### PR TITLE
Update ViewMain.qml when "VPNController.StateDeviceLimit"

### DIFF
--- a/src/components/VPNControllerDevice.qml
+++ b/src/components/VPNControllerDevice.qml
@@ -49,7 +49,11 @@ VPNClickableRow {
                 PropertyChanges {
                     target: icon
                     // TODO: this should be an alert icon
-                    source: "../resources/chevron.svg"
+                    source: "../resources/warning.svg"
+                    sourceSize.height: 14
+                    sourceSize.width: 14
+                    Layout.rightMargin: 6
+                    Layout.leftMargin: 6
                 }
             }
         ]

--- a/src/components/VPNControllerView.qml
+++ b/src/components/VPNControllerView.qml
@@ -211,16 +211,19 @@ Rectangle {
             PropertyChanges {
                 target: logo
                 source: "../resources/state-off.svg"
+                opacity: .55
             }
             PropertyChanges {
                 target: logoTitle
                 text: qsTr("VPN is off")
                 color: Theme.fontColorDark
+                opacity: .55
             }
             PropertyChanges {
                 target: logoSubtitle
                 text: qsTr("Turn on to protect your privacy")
                 color: Theme.fontColor
+                opacity: .55
             }
             PropertyChanges {
                 target: settingsImage

--- a/src/components/VPNToggle.qml
+++ b/src/components/VPNToggle.qml
@@ -79,7 +79,7 @@ Rectangle {
             }
             PropertyChanges {
                 target: toggle
-                color: "#9E9E9E"
+                color: "#E7E7E7"
             }
         }
     ]


### PR DESCRIPTION
On ViewMain.qml, this replaces the chevron beside the device total with a warning icon when the device total has been exceeded. It also lowers the opacity or changes the color of content that is disabled when the device limit has been exceeded.

<img width="363" alt="Screen Shot 2020-09-17 at 4 20 52 PM" src="https://user-images.githubusercontent.com/22355127/93530601-76b4cd00-f903-11ea-8ed9-2ea708943db3.png">
