### PR TITLE
Fix devices view

### DIFF
--- a/src/components/VPNIconButton.qml
+++ b/src/components/VPNIconButton.qml
@@ -14,7 +14,7 @@ RoundButton {
     id: iconButton
     property var backgroundColor: Theme.greyButton
     property var defaultColor: Theme.bgColor
-    required property var accessibleName
+    property var accessibleName
     signal clicked
 
     background: Rectangle {


### PR DESCRIPTION
This (temporarily?) removes `required` from `required property var accessibleName` to fix the devices view. It [looks possible](https://doc.qt.io/qt-5/qtquick-modelviewsdata-modelview.html) to have required properties inside ListView delegate children, but will require some exploration/refactoring. 