### PR TITLE
Remove "Debug" link

### DIFF
--- a/src/components/VPNGetHelp.qml
+++ b/src/components/VPNGetHelp.qml
@@ -33,15 +33,9 @@ Item {
                 linkTitle: qsTr("Contact us")
                 clickId: "contact_us"
             }
-
             ListElement {
                 linkTitle: qsTr("Help & Support")
                 clickId: "help_support"
-            }
-
-            ListElement {
-                linkTitle: qsTr("Debug")
-                clickId: "debug"
             }
             ListElement {
                 linkTitle: qsTr("View log")


### PR DESCRIPTION
This link will only be visible on the mobile clients and is out of scope for 1.5