### PR TITLE
Use `font.pixelSize` instead of `font.pointSize`

### DIFF
--- a/src/components/VPNRadioButtonLabel.qml
+++ b/src/components/VPNRadioButtonLabel.qml
@@ -13,7 +13,7 @@ Label {
     anchors.leftMargin: Theme.hSpacing - 2
 
     font.family: Theme.fontInterFamily
-    font.pointSize: Theme.fontSize
+    font.pixelSize: Theme.fontSize
     color: Theme.fontColorDark
 
     states: State {


### PR DESCRIPTION
Use `font.pixelSize` for consistency across platforms. This should fix the font size of `VPNRadioButtonLabel {}` on Linux.