### PR TITLE
First stab at captive portal on Linux

### DIFF
--- a/linux/daemon/dbus.cpp
+++ b/linux/daemon/dbus.cpp
@@ -104,12 +104,14 @@ bool DBus::activate(const QString &jsonConfig)
     GETVALUESTR("serverPublicKey", m_lastServerPublicKey);
     GETVALUESTR("serverIpv4AddrIn", m_lastServerIpv4AddrIn);
     GETVALUESTR("serverIpv6AddrIn", m_lastServerIpv6AddrIn);
+    GETVALUESTR("captivePortalIpv4Addresses", m_lastCaptivePortalIpv4Addresses);
+    GETVALUESTR("captivePortalIpv6Addresses", m_lastCaptivePortalIpv6Addresses);
 
 #undef GETVALUESTR
 
 #define GETVALUEINT(name, where) \
     if (!obj.contains(name)) { \
-        logger.log() << name << " missing in the jsoConfig input"; \
+        logger.log() << name << " missing in the jsonConfig input"; \
         return false; \
     } \
     { \
@@ -127,7 +129,7 @@ bool DBus::activate(const QString &jsonConfig)
 
 #define GETVALUEBOOL(name, where) \
     if (!obj.contains(name)) { \
-        logger.log() << name << " missing in the jsoConfig input"; \
+        logger.log() << name << " missing in the jsonConfig input"; \
         return false; \
     } \
     { \
@@ -153,6 +155,8 @@ bool DBus::activate(const QString &jsonConfig)
                              m_lastServerPublicKey,
                              m_lastServerIpv4AddrIn,
                              m_lastServerIpv6AddrIn,
+                             m_lastCaptivePortalIpv4Addresses,
+                             m_lastCaptivePortalIpv6Addresses,
                              m_lastServerPort,
                              m_lastIpv6Enabled,
                              m_lastLocalNetworkAccess);
@@ -191,6 +195,8 @@ bool DBus::deactivate()
                              m_lastServerPublicKey,
                              m_lastServerIpv4AddrIn,
                              m_lastServerIpv6AddrIn,
+                             m_lastCaptivePortalIpv4Addresses,
+                             m_lastCaptivePortalIpv6Addresses,
                              m_lastServerPort,
                              m_lastIpv6Enabled,
                              m_lastLocalNetworkAccess);
@@ -262,6 +268,8 @@ bool DBus::runWgQuick(WgQuickProcess::Op op,
                       const QString &serverPublicKey,
                       const QString &serverIpv4AddrIn,
                       const QString &serverIpv6AddrIn,
+                      const QString &captivePortalIpv4Addresses,
+                      const QString &captivePortalIpv6Addresses,
                       int serverPort,
                       bool ipv6Enabled,
                       bool localNetworkAccess)
@@ -276,6 +284,8 @@ bool DBus::runWgQuick(WgQuickProcess::Op op,
                  serverPublicKey,
                  serverIpv4AddrIn,
                  serverIpv6AddrIn,
+                 captivePortalIpv4Addresses,
+                 captivePortalIpv6Addresses,
                  serverPort,
                  ipv6Enabled,
                  localNetworkAccess);

--- a/linux/daemon/dbus.h
+++ b/linux/daemon/dbus.h
@@ -44,6 +44,8 @@ private:
                     const QString &serverPublicKey,
                     const QString &serverIpv4AddrIn,
                     const QString &serverIpv6AddrIn,
+                    const QString &captivePortalIpv4Addresses,
+                    const QString &captivePortalIpv6Addresses,
                     int serverPort,
                     bool ipv6Enabled,
                     bool localNetworkAccess);
@@ -60,6 +62,8 @@ private:
     QString m_lastServerPublicKey;
     QString m_lastServerIpv4AddrIn;
     QString m_lastServerIpv6AddrIn;
+    QString m_lastCaptivePortalIpv4Addresses;
+    QString m_lastCaptivePortalIpv6Addresses;
     int m_lastServerPort = 0;
     bool m_lastIpv6Enabled = false;
     bool m_lastLocalNetworkAccess = false;

--- a/linux/daemon/wgquickprocess.cpp
+++ b/linux/daemon/wgquickprocess.cpp
@@ -24,6 +24,8 @@ void WgQuickProcess::run(const QString &privateKey,
                          const QString &serverPublicKey,
                          const QString &serverIpv4AddrIn,
                          const QString &serverIpv6AddrIn,
+                         const QString &captivePortalIpv4Addresses,
+                         const QString &captivePortalIpv6Addresses,
                          int serverPort,
                          bool ipv6Enabled,
                          bool localNetworkAccess)
@@ -65,6 +67,16 @@ void WgQuickProcess::run(const QString &privateKey,
     */
 
     content.append("\nAllowedIPs = 0.0.0.0/0");
+
+    if (captivePortalIpv4Addresses.length() > 0) {
+        content.append(", ");
+        content.append(captivePortalIpv4Addresses.toUtf8());
+    }
+    if (captivePortalIpv6Addresses.length() > 0) {
+        content.append(", ");
+        content.append(captivePortalIpv6Addresses.toUtf8());
+    }
+
 
     if (ipv6Enabled) {
         content.append(",::0");

--- a/linux/daemon/wgquickprocess.h
+++ b/linux/daemon/wgquickprocess.h
@@ -29,6 +29,8 @@ public:
              const QString &serverPublicKey,
              const QString &serverIpv4AddrIn,
              const QString &serverIpv6AddrIn,
+             const QString &captivePortalIpv4Addresses,
+             const QString &captivePortalIpv6Addresses,
              int serverPort,
              bool ipv6Enabled,
              bool localNetworkAccess);

--- a/src/platforms/linux/dbus.cpp
+++ b/src/platforms/linux/dbus.cpp
@@ -8,6 +8,7 @@
 #include "logger.h"
 #include "mozillavpn.h"
 #include "server.h"
+#include "../captiveportal/captiveportal.h"
 
 #include <QDBusPendingCall>
 #include <QDBusPendingCallWatcher>
@@ -43,7 +44,7 @@ QDBusPendingCallWatcher *DBus::version()
     return watcher;
 }
 
-QDBusPendingCallWatcher *DBus::activate(const Server &server, const Device *device, const Keys *keys)
+QDBusPendingCallWatcher *DBus::activate(const Server &server, const Device *device, const Keys *keys, const CaptivePortal &captivePortal)
 {
     QJsonObject json;
     json.insert("privateKey", QJsonValue(keys->privateKey()));
@@ -54,6 +55,8 @@ QDBusPendingCallWatcher *DBus::activate(const Server &server, const Device *devi
     json.insert("serverPublicKey", QJsonValue(server.publicKey()));
     json.insert("serverIpv4AddrIn", QJsonValue(server.ipv4AddrIn()));
     json.insert("serverIpv6AddrIn", QJsonValue(server.ipv6AddrIn()));
+    json.insert("captivePortalIpv4Addresses", QJsonValue(captivePortal.ipv4Addresses().join(", ")));
+    json.insert("captivePortalIpv6Addresses", QJsonValue(captivePortal.ipv6Addresses().join(", ")));
     json.insert("serverPort", QJsonValue((double) server.choosePort()));
     json.insert("ipv6Enabled", QJsonValue(MozillaVPN::instance()->settingsHolder()->ipv6Enabled()));
     json.insert("localNetworkAccess",

--- a/src/platforms/linux/dbus.h
+++ b/src/platforms/linux/dbus.h
@@ -6,6 +6,7 @@
 #define DBUS_H
 
 #include "dbus_interface.h"
+#include "../captiveportal/captiveportal.h"
 
 #include <QObject>
 
@@ -22,7 +23,7 @@ public:
     DBus(QObject *parent);
 
     QDBusPendingCallWatcher *version();
-    QDBusPendingCallWatcher *activate(const Server &server, const Device *device, const Keys *keys);
+    QDBusPendingCallWatcher *activate(const Server &server, const Device *device, const Keys *keys, const CaptivePortal &captivePortal);
     QDBusPendingCallWatcher *deactivate();
     QDBusPendingCallWatcher *status();
     QDBusPendingCallWatcher *logs();

--- a/src/platforms/linux/linuxcontroller.cpp
+++ b/src/platforms/linux/linuxcontroller.cpp
@@ -73,7 +73,7 @@ void LinuxController::activate(const Server &server,
     Q_UNUSED(forSwitching);
 
     logger.log() << "LinuxController activated";
-    monitorWatcher(m_dbus->activate(server, device, keys));
+    monitorWatcher(m_dbus->activate(server, device, keys, captivePortal));
 }
 
 void LinuxController::deactivate(bool forSwitching)

--- a/src/platforms/linux/linuxcontroller.cpp
+++ b/src/platforms/linux/linuxcontroller.cpp
@@ -69,7 +69,6 @@ void LinuxController::activate(const Server &server,
                                const CaptivePortal &captivePortal,
                                bool forSwitching)
 {
-    Q_UNUSED(captivePortal);
     Q_UNUSED(forSwitching);
 
     logger.log() << "LinuxController activated";

--- a/src/systemtrayhandler.cpp
+++ b/src/systemtrayhandler.cpp
@@ -52,6 +52,6 @@ void SystemTrayHandler::controllerStateChanged()
 
 void SystemTrayHandler::captivePortalNotificationRequested()
 {
-    logger.log() << "Capitve portal notification shown";
+    logger.log() << "Captive portal notification shown";
     showMessage(tr("Captive portal detected!"), tr("TODO"), NoIcon, 2000);
 }


### PR DESCRIPTION
I'm currently stuck because dnsLookup is failing so even if it is trying to do the right thing I'm not sure how to test it.

The captive portal software I'm using locally just does a 307 redirect from detectportal.firefox.com, but while the VPN is on that's not allowed to go through because the dnsLookup is failing.

I'm sure I'm missing a bunch of things. Thanks in advance for your guidance.

(this is branched off #89 so base is that for ease of comparison)