### PR TITLE
Show ScrollBar in Settings view

### DIFF
--- a/src/ui/settings/ViewSettingsMenu.qml
+++ b/src/ui/settings/ViewSettingsMenu.qml
@@ -10,13 +10,13 @@ import Mozilla.VPN 1.0
 import "../components"
 import "../themes/themes.js" as Theme
 
-Flickable {
+ScrollView {
     id: scrollingFrame
 
-    contentHeight: 720
     height: parent.height
-    boundsBehavior: Flickable.StopAtBounds
+    contentHeight: (height > 740) ? parent.height : 740
     opacity: 0
+    ScrollBar.vertical.policy: (height > 740) ? ScrollBar.AlwaysOff : ScrollBar.AlwaysOn
     Component.onCompleted: {
         opacity = 1;
     }
@@ -215,10 +215,6 @@ Flickable {
             duration: 200
         }
 
-    }
-
-    ScrollBar.vertical: ScrollBar {
-        Accessible.ignored: true
     }
 
 }


### PR DESCRIPTION
- Makes the Settings view scrollbar visible by default except when the height of the window is greater than the height of the Settings view content. 
<img width="363" alt="Screen Shot 2020-10-19 at 1 03 17 PM" src="https://user-images.githubusercontent.com/22355127/96495544-9fcfc280-120d-11eb-98d2-f5e3f040f6bf.png">
<img width="362" alt="Screen Shot 2020-10-19 at 1 03 05 PM" src="https://user-images.githubusercontent.com/22355127/96495543-9e05ff00-120d-11eb-9c42-bfad98157e6b.png">
