### PR TITLE
Wrap the user's display name in the Settings view - Fix #124

### DIFF
--- a/src/ui/settings/ViewSettingsMenu.qml
+++ b/src/ui/settings/ViewSettingsMenu.qml
@@ -125,7 +125,6 @@ ScrollView {
         text: VPNUser.displayName ? VPNUser.displayName : textVpnUser
         anchors.top: logo.bottom
         anchors.topMargin: Theme.vSpacing
-        height: 32
     }
 
     VPNSubtitle {


### PR DESCRIPTION
Fixes #124 

<img width="369" alt="Screen Shot 2020-10-30 at 9 14 14 PM" src="https://user-images.githubusercontent.com/22355127/97768997-43b24b80-1af5-11eb-85d8-b987fbc8e5ea.png">
