### PR TITLE
Wrap subtitle in main view

### DIFF
--- a/src/ui/components/VPNConnectionStability.qml
+++ b/src/ui/components/VPNConnectionStability.qml
@@ -9,6 +9,7 @@ import "../themes/themes.js" as Theme
 
 RowLayout {
     id: stability
+    Layout.preferredHeight: Theme.controllerInterLineHeight
 
     spacing: 0
     opacity: 0
@@ -101,16 +102,16 @@ RowLayout {
         Layout.minimumWidth: 60
 
         Rectangle {
-            height: 22
-            width: 15
+            height: 16
+            width: 14
             color: "transparent"
-            Layout.rightMargin: 8
+            Layout.rightMargin: 6
 
             Image {
                 id: warningIcon
 
-                sourceSize.height: 15
-                sourceSize.width: 15
+                sourceSize.height: 14
+                sourceSize.width: sourceSize.height
                 fillMode: Image.PreserveAspectFit
             }
 
@@ -118,19 +119,19 @@ RowLayout {
 
         VPNInterLabel {
             id: stabilityLabel
+            lineHeight: Theme.controllerInterLineHeight
         }
 
     }
 
     Rectangle {
-        Layout.preferredHeight: 5
-        Layout.preferredWidth: 5
+        Layout.preferredHeight: 4
+        Layout.preferredWidth: 4
         color: "#FFFFFF"
         opacity: 0.8
         radius: 3
-        Layout.leftMargin: 12
-        Layout.rightMargin: 12
-        Layout.bottomMargin: 4
+        Layout.leftMargin: Theme.windowMargin / 2
+        Layout.rightMargin: Layout.leftMargin
     }
 
     VPNInterLabel {
@@ -138,6 +139,7 @@ RowLayout {
         text: qsTrId("vpn.connectionStability.checkConnection")
         color: "#FFFFFF"
         opacity: 0.8
+        lineHeight: Theme.controllerInterLineHeight
     }
 
 }

--- a/src/ui/components/VPNControllerView.qml
+++ b/src/ui/components/VPNControllerView.qml
@@ -485,7 +485,6 @@ Rectangle {
     VPNMainImage {
         id: logo
 
-        anchors.horizontalCenterOffset: 0
         anchors.horizontalCenter: parent.horizontalCenter
         y: 50
         height: 80
@@ -570,38 +569,37 @@ Rectangle {
     VPNHeadline {
         id: logoTitle
 
-        anchors.top: logo.bottom
-        anchors.topMargin: 22
-        anchors.horizontalCenterOffset: 0
-        anchors.horizontalCenter: parent.horizontalCenter
-        font.family: Theme.fontFamily
         horizontalAlignment: Text.AlignHCenter
-        y: logo.y + logo.height + 26
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.top: logo.bottom
+        anchors.topMargin: 24
         font.pixelSize: 22
-        height: 32
     }
 
     VPNInterLabel {
         id: logoSubtitle
 
-        anchors.horizontalCenterOffset: 0
         anchors.horizontalCenter: parent.horizontalCenter
-        y: logoTitle.y + logoTitle.height + 8
+        anchors.top: logoTitle.bottom
+        anchors.topMargin: Theme.windowMargin / 2
+        lineHeight: Theme.controllerInterLineHeight
+        width: box.width - Theme.windowMargin * 3
     }
 
     VPNConnectionStability {
         id: connectionStability
 
-        anchors.horizontalCenterOffset: 0
         anchors.horizontalCenter: parent.horizontalCenter
-        y: logoTitle.y + logoTitle.height + 8
+        anchors.top: logoTitle.bottom
+        anchors.topMargin: Theme.windowMargin / 2
         visible: false
     }
 
     VPNToggle {
         id: toggle
 
-        y: logoSubtitle.y + logoSubtitle.height + 24
+        anchors.bottom: box.bottom
+        anchors.bottomMargin: 48
         anchors.horizontalCenterOffset: 0
         anchors.horizontalCenter: parent.horizontalCenter
     }

--- a/src/ui/themes/themes.js
+++ b/src/ui/themes/themes.js
@@ -47,6 +47,7 @@ const fontWeightBold = 600;
 
 const iconSize = 16;
 const labelLineHeight = 22;
+const controllerInterLineHeight = 18;
 
 const hSpacing = 20;
 const vSpacing = 24;


### PR DESCRIPTION
Fixes #159 

This enables subtitle text in the controller view to wrap and unwrap without throwing off the layout- but only once! We'll still need to think about what should happen when/if the headline and subtitle text need to wrap, or one or the other needs to wrap more than once. 

<img width="200" alt="Screen Shot 2020-11-06 at 1 55 09 PM" src="https://user-images.githubusercontent.com/22355127/98412507-a9469080-203d-11eb-8a75-ce987e8993ed.png">
<img width="200" alt="Screen Shot 2020-11-06 at 2 39 05 PM" src="https://user-images.githubusercontent.com/22355127/98412611-deeb7980-203d-11eb-9cc2-4dde8d9f7d21.png">
<img width="200" alt="Screen Shot 2020-11-06 at 2 39 41 PM" src="https://user-images.githubusercontent.com/22355127/98412632-e874e180-203d-11eb-9c28-10d12026bd8c.png">
