### PR TITLE
Update suscription needed view

### DIFF
--- a/src/ui/states/StateSubscriptionNeeded.qml
+++ b/src/ui/states/StateSubscriptionNeeded.qml
@@ -3,8 +3,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import QtQuick 2.5
+import QtQuick.Controls 2.15
 
-Loader {
-    id: loader
-    source: "../views/ViewSubscriptionNeeded.qml"
+StackView {
+    id: stackview
+
+    initialItem: "../views/ViewSubscriptionNeeded.qml"
 }

--- a/src/ui/views/ViewSubscriptionNeeded.qml
+++ b/src/ui/views/ViewSubscriptionNeeded.qml
@@ -35,23 +35,18 @@ VPNFlickable {
     width: window.width
     flickContentHeight: footerContent.height + spacer1.height + vpnPanel.height + featureListBackground.height + (Theme.windowMargin * 4)
 
-    VPNIconButton {
-        id: iconButton
+    VPNHeaderLink {
+        id: headerLink
 
-        onClicked: stackview.pop(StackView.Immediate)
-        anchors.top: parent.top
-        anchors.left: parent.left
-        anchors.topMargin: Theme.windowMargin / 2
-        anchors.leftMargin: Theme.windowMargin / 2
-        accessibleName: qsTrId("vpn.main.back")
+        labelText: qsTrId("vpn.main.getHelp")
+        onClicked: stackview.push(getHelpComponent)
+    }
 
-        Image {
-            id: backImage
+    Component {
+        id: getHelpComponent
 
-            source: "../resources/close-dark.svg"
-            sourceSize.width: Theme.iconSize
-            fillMode: Image.PreserveAspectFit
-            anchors.centerIn: iconButton
+        VPNGetHelp {
+            isSettingsView: false
         }
 
     }


### PR DESCRIPTION
- Remove "X" in upper left corner
- Add "Get help" to upper right corner and use stackview so that navigating back to the subscription view is possible.
- Will add the button loader to the "Subscribe Now" once #211 is merged and the button loader is available.

Closes #192, #203 
<img width="362" alt="Screen Shot 2020-11-15 at 8 20 46 PM" src="https://user-images.githubusercontent.com/22355127/99206077-1960bf00-2780-11eb-877b-fba236ed8bc6.png">
