### PR TITLE
Android: Add a white booting theme

### DIFF
--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -26,6 +26,7 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
             android:name="org.qtproject.qt5.android.bindings.QtActivity"
             android:label="Mozilla VPN"
             android:screenOrientation="unspecified"
+            android:theme="@style/splashScreenTheme"
             android:launchMode="singleTop">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/android/res/drawable-anydpi-v26/vpnsplash.xml
+++ b/android/res/drawable-anydpi-v26/vpnsplash.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- The android:opacity=”opaque” android:opacity="opaque" line — this is critical in preventing a flash of black as your theme transitions. -->
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android" android:opacity="opaque">
+    <item>
+        <shape android:shape="rectangle">
+             <solid android:color="@android:color/white" />
+        </shape>
+     </item>
+    <item>
+        <bitmap
+            android:src="@mipmap/vpnicon"
+            android:gravity="center"/>
+    </item>
+</layer-list>

--- a/android/res/values/style.xml
+++ b/android/res/values/style.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style xmlns:android="http://schemas.android.com/apk/res/android" name="splashScreenTheme" parent="@android:style/Theme.DeviceDefault.Light.NoActionBar" >
+        <item name="android:windowBackground">@drawable/vpnsplash</item>
+        <item name="android:windowNoTitle">true</item>
+        <item name="android:windowFullscreen">true</item>
+    </style>
+</resources>


### PR DESCRIPTION
This removes the ugly default white screen + black bar on boot. 
Not really a "splashscreen" tho.