### PR TITLE
Support Start On Boot && AlwaysOn

### DIFF
--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -9,6 +9,7 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
          Remove the comment if you do not require these default permissions. -->
     <!-- %%INSERT_PERMISSIONS -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <!-- The following comment will be replaced upon deployment with default features based on the dependencies of the application.
          Remove the comment if you do not require these default features. -->
     <!-- %%INSERT_FEATURES -->
@@ -103,6 +104,11 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
                 <action android:name="android.net.VpnService"/>
             </intent-filter>
         </service>
+        <receiver android:name=".BootReceiver">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+            </intent-filter>
+        </receiver>
     </application>
 
 </manifest>

--- a/android/src/com/mozilla/vpn/BootReceiver.kt
+++ b/android/src/com/mozilla/vpn/BootReceiver.kt
@@ -1,0 +1,42 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package com.mozilla.vpn
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.util.Log
+
+class BootReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, arg1: Intent) {
+        if(!canEnableVPNOnBoot()){
+            return;
+        }
+        val prefs = context.getSharedPreferences("com.mozilla.vpn.prefrences", Context.MODE_PRIVATE);
+        val startOnBoot =  prefs.getBoolean("startOnBoot",false)
+        if(!startOnBoot){
+            return;
+        }
+        val intent = Intent(context, VPNService::class.java)
+        intent.putExtra("startOnBoot",true)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            context.startForegroundService(intent)
+        } else {
+            context.startService(intent)
+        }
+        Log.i("BootReceiver", "Started Service")
+    }
+
+    companion object{
+        /**
+         * Only devices below N allow us to enable the VPN after the OnBootIntent
+         * Devices higher then that should refer to the Always On VPN option in settings
+         */
+        fun canEnableVPNOnBoot(): Boolean {
+            return (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N)
+        }
+    }
+}

--- a/android/src/com/mozilla/vpn/VPNService.kt
+++ b/android/src/com/mozilla/vpn/VPNService.kt
@@ -4,18 +4,16 @@
 
 package com.mozilla.vpn
 
-import android.R
-import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.PendingIntent
+import android.app.Service
 import android.content.Context
 import android.content.Intent
 import android.os.Build
 import android.os.IBinder
 import android.util.Log
 import androidx.core.app.NotificationCompat
-import androidx.core.content.ContextCompat
 import com.wireguard.android.backend.Statistics
 import com.wireguard.android.backend.Tunnel
 import com.wireguard.android.backend.VpnServiceBackend
@@ -23,12 +21,18 @@ import com.wireguard.android.backend.applyConfig
 import com.wireguard.config.Config
 import com.wireguard.crypto.Key
 import com.wireguard.crypto.KeyFormatException
+import java.lang.reflect.Array.newInstance
+import java.lang.reflect.Field
+import java.lang.reflect.Method
+
 
 class VPNService : android.net.VpnService() {
     private val tag = "VPNService"
     var tunnel: Tunnel? = null
     private var mBinder: VPNServiceBinder? = null
-
+    val NOTIFICATION_CHANNEL_ID = "com.mozilla.vpnNotification"
+    val CONNECTED_NOTIFICATION_ID = 1337
+    private val mNotificationBuilder = NotificationCompat.Builder(this, NOTIFICATION_CHANNEL_ID);
     /**
      * EntryPoint for the Service, gets Called when AndroidController.cpp
      * calles bindService. Returns the [VPNServiceBinder] so QT can send Requests to it.
@@ -51,13 +55,47 @@ class VPNService : android.net.VpnService() {
 
     /**
      * Might be the entryPoint if the Service gets Started via an
-     * Service Intent (Settings or vice versa)
+     * Service Intent: Might be from Always-On-Vpn from Settings
+     * or from Booting the device and having "connect on boot" enabled.
      */
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         if (mBinder == null) {
             mBinder = VPNServiceBinder(this)
         }
-        return super.onStartCommand(intent, flags, startId)
+
+        intent?.let {
+            if(intent.getBooleanExtra("startOnBoot", false)){
+                Log.v(tag, "Starting VPN because 'start on boot is enabled'")
+            }else{
+                Log.v(tag, "Starting VPN because 'always on vpn' is enabled")
+            }
+        }
+
+        if(this.tunnel == null){
+            // We don't have tunnel to turn on - Try to create one with last config the service got
+            val prefs = getSharedPreferences("com.mozilla.vpn.prefrences", Context.MODE_PRIVATE);
+            val lastConfString = prefs.getString("lastConf", "")
+            if(lastConfString.isNullOrEmpty()){
+                // We have nothing to connect to -> Exit
+                Log.e(tag, "VPN service was triggered without defining a Server or having a tunnel")
+                return Service.START_NOT_STICKY
+            }
+            val tunnelConfig = mBinder?.buildConfigFromJSON(lastConfString)
+            createTunnel(tunnelConfig);
+        }
+        this.tunnel?.let {
+            // If we now managed to get a tunnel, turn on!
+            startSticky()
+            turnOn()
+        }
+        return Service.START_NOT_STICKY
+    }
+
+    // Invoked when the application is revoked.
+    // At this moment, the VPN interface is already deactivated by the system.
+    override fun onRevoke() {
+        this.turnOff();
+        super.onRevoke()
     }
 
     fun getStatistic(): Statistics? {
@@ -98,7 +136,10 @@ class VPNService : android.net.VpnService() {
         return stats
     }
 
-    fun createTunnel(conf: Config) {
+    fun createTunnel(conf: Config?) {
+        if(conf == null){
+            return;
+        }
         this.tunnel = Tunnel("myCoolTunnel", conf)
     }
 
@@ -123,6 +164,7 @@ class VPNService : android.net.VpnService() {
 
     fun turnOn(): Boolean {
         val tunnel = this.tunnel ?: return false
+        this.startSticky()
 
         tunnel.tunnelHandle?.let {
             this.protect(it)
@@ -133,7 +175,10 @@ class VPNService : android.net.VpnService() {
         if (fileDescriptor != null) {
             Log.v(tag, "Got file Descriptor for VPN - Try to up")
             backend.tunnelUp(tunnel, fileDescriptor, config.toWgUserspaceString())
-            this.startSticky()
+            mNotificationBuilder
+                .setContentTitle("Todo: Connected")
+                .setContentText("Todo: Safe and Secure")
+            startForeground(CONNECTED_NOTIFICATION_ID, mNotificationBuilder.build())
             return true
         }
         Log.e(tag, "Failed to get a File Descriptor for VPN")
@@ -144,16 +189,15 @@ class VPNService : android.net.VpnService() {
         Log.v(tag, "Try to disable tunnel")
         this.tunnel?.let { backend.tunnelDown(it) }
         stopForeground(true)
+        this.tunnel= null;
     }
 
-    val NOTIFICATION_CHANNEL_ID = "com.mozilla.vpnNotification"
-    val CONNECTED_NOTIFICATION_ID = 1337
 
     /*
     * Creates a Sticky Notification for this
     * Service and Calls startForeground to 
     * make sure we cant get closed as long
-    * as we're connected
+    * as we're connecting
      */
     fun startSticky() {
         // For Android 8+ We need to Register a Notification Channel
@@ -176,13 +220,14 @@ class VPNService : android.net.VpnService() {
         val intent = Intent(this, activity)
         val pendingIntent = PendingIntent.getActivity(this, 0, intent, 0)
 
-        val builder = NotificationCompat.Builder(this, NOTIFICATION_CHANNEL_ID)
+        mNotificationBuilder
             .setSmallIcon(com.mozilla.vpn.R.drawable.ic_logo_on)
-            .setContentTitle("Todo: Connected Title")
-            .setContentText("Todo: you're connected")
+            .setContentTitle("Todo: Connecting")
+            .setContentText("Todo: ...")
+            .setOnlyAlertOnce(true)
             .setPriority(NotificationCompat.PRIORITY_DEFAULT)
             .setContentIntent(pendingIntent)
-        startForeground(CONNECTED_NOTIFICATION_ID, builder.build())
+        startForeground(CONNECTED_NOTIFICATION_ID, mNotificationBuilder.build())
     }
 
     /**

--- a/android/src/com/mozilla/vpn/VPNService.kt
+++ b/android/src/com/mozilla/vpn/VPNService.kt
@@ -230,10 +230,18 @@ class VPNService : android.net.VpnService() {
         startForeground(CONNECTED_NOTIFICATION_ID, mNotificationBuilder.build())
     }
 
+    fun isUp(): Boolean{
+        return tunnel?.isUp() ?: return false
+    }
+
     /**
      * Fetches the Global QTAndroidActivity and calls startActivityForResult with the given intent
      * Is used to request the VPN-Permission, if not given.
      * Actually Implemented in src/platforms/android/AndroidJNIUtils.cpp
      */
     external fun startActivityForResult(i: Intent)
+
+}
+fun Tunnel.isUp(): Boolean {
+    return this.state == Tunnel.State.Up
 }

--- a/android/src/com/mozilla/vpn/VPNServiceBinder.kt
+++ b/android/src/com/mozilla/vpn/VPNServiceBinder.kt
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 package com.mozilla.vpn
 
+import android.content.Context
 import android.os.Binder
 import android.os.IBinder
 import android.os.Parcel
@@ -13,6 +14,8 @@ import java.lang.Exception
 import org.json.JSONObject
 import java.io.BufferedReader
 import java.io.InputStreamReader
+import java.lang.reflect.Field
+import java.lang.reflect.Method
 
 class VPNServiceBinder(service: VPNService) : Binder() {
 
@@ -30,6 +33,7 @@ class VPNServiceBinder(service: VPNService) : Binder() {
         const val requestStatistic = 4
         const val requestLog = 5
         const val resumeActivate = 6;
+        const val enableStartOnBoot =7;
     }
 
     /**
@@ -50,6 +54,14 @@ class VPNServiceBinder(service: VPNService) : Binder() {
                     // [data] is here a json containing the wireguard conf
                     val buffer = data.createByteArray()
                     val json = buffer?.let { String(it) }
+                    // Store the config in case the service gets
+                    // asked boot vpn from the OS
+                    val prefs = mService.getSharedPreferences("com.mozilla.vpn.prefrences", Context.MODE_PRIVATE);
+                    prefs.edit()
+                        .putString("lastConf",json)
+                        .apply()
+
+                    Log.v(tag,"Stored new Tunnel config in Service")
                     val config = buildConfigFromJSON(json)
 
                     var forSwitching = false;
@@ -123,6 +135,15 @@ class VPNServiceBinder(service: VPNService) : Binder() {
                 dispatchEvent(EVENTS.backendLogs, allText)
 
             }
+            ACTIONS.enableStartOnBoot ->{
+                // Sets the Start on boot pref data is here a QVariant Byte
+                val startOnBootEnabled = data.readByte().equals(true) // there is no byte.toBool?
+                Log.v(tag,"Set ServicePref Start on boot to -> $startOnBootEnabled")
+                val prefs = mService.getSharedPreferences("com.mozilla.vpn.prefrences", Context.MODE_PRIVATE);
+                prefs.edit()
+                    .putBoolean("startOnBoot",startOnBootEnabled)
+                    .apply()
+            }
 
             else -> {
                 Log.e(tag, "Received invalid bind request \t Code -> $code")
@@ -164,7 +185,7 @@ class VPNServiceBinder(service: VPNService) : Binder() {
      * Create a Wireguard [Config]  from a [json] string -
      * The [json] will be created in AndroidController.cpp
      */
-    private fun buildConfigFromJSON(json: String?): Config {
+    fun buildConfigFromJSON(json: String?): Config {
         val confBuilder = Config.Builder()
         if (json == null) {
             return confBuilder.build()

--- a/android/src/com/mozilla/vpn/VPNServiceBinder.kt
+++ b/android/src/com/mozilla/vpn/VPNServiceBinder.kt
@@ -117,7 +117,11 @@ class VPNServiceBinder(service: VPNService) : Binder() {
                 val binder = data.readStrongBinder()
                 mListeners.add(binder)
                 Log.d(tag, "Registered ${mListeners.size} EventListeners")
-                dispatchEvent(EVENTS.init, "")
+                if(mService.isUp()){
+                    dispatchEvent(EVENTS.init, "connected")
+                }else{
+                    dispatchEvent(EVENTS.init, "disconnected")
+                }
             }
             ACTIONS.requestStatistic -> {
                 val statistics = this.mService.getStatistic()

--- a/src/commands/commandui.cpp
+++ b/src/commands/commandui.cpp
@@ -39,6 +39,9 @@
 #ifdef MVPN_ANDROID
 #include "platforms/android/androidutils.h"
 #include "platforms/android/androidwebview.h"
+
+#include "platforms/android/androidstartatbootwatcher.h"
+#include "platforms/android/androidutils.h"
 #endif
 
 #include <QApplication>
@@ -134,6 +137,16 @@ int CommandUI::run(QStringList &tokens)
 
         MacOSUtils::setDockClickHandler();
 #endif
+
+
+#ifdef MVPN_ANDROID
+        AndroidStartAtBootWatcher startAtBootWatcher(SettingsHolder::instance()->startAtBoot());
+        QObject::connect(SettingsHolder::instance(),
+                         &SettingsHolder::startAtBootChanged,
+                         &startAtBootWatcher,
+                         &AndroidStartAtBootWatcher::startAtBootChanged);
+#endif
+
 
 #ifdef MVPN_LINUX
         // Dependencies - so far, only for linux.

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -60,7 +60,7 @@ void Controller::initialize()
 #elif defined(MVPN_IOS)
         new MacOSController()
 #elif defined(MVPN_ANDROID)
-        new AndroidController()
+        AndroidController::instance()
 #else
         new DummyController()
 #endif

--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -26,6 +26,10 @@
 #include "platforms/ios/taskiosproducts.h"
 #endif
 
+#ifdef MVPN_ANDROID
+#include "platforms/android/androidutils.h"
+#endif
+
 #include <QApplication>
 #include <QClipboard>
 #include <QDesktopServices>
@@ -980,6 +984,8 @@ bool MozillaVPN::startOnBootSupported() const
 {
 #if defined(MVPN_LINUX) || defined(MVPN_MACOS)
     return true;
+#elif defined (MVPN_ANDROID)
+    return AndroidUtils::CanEnableStartOnBoot();
 #else
     return false;
 #endif

--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -985,7 +985,7 @@ bool MozillaVPN::startOnBootSupported() const
 #if defined(MVPN_LINUX) || defined(MVPN_MACOS)
     return true;
 #elif defined (MVPN_ANDROID)
-    return AndroidUtils::CanEnableStartOnBoot();
+    return AndroidUtils::canEnableStartOnBoot();
 #else
     return false;
 #endif

--- a/src/platforms/android/androidcontroller.cpp
+++ b/src/platforms/android/androidcontroller.cpp
@@ -46,11 +46,7 @@ AndroidController *s_instance = nullptr;
 
 } // namespace
 
-AndroidController::AndroidController() : m_binder(this)
-{
-    Q_ASSERT(!s_instance);
-    s_instance = this;
-}
+AndroidController::AndroidController() : m_binder(this){}
 AndroidController::~AndroidController()
 {
     Q_ASSERT(s_instance == this);
@@ -59,6 +55,10 @@ AndroidController::~AndroidController()
 
 AndroidController *AndroidController::instance()
 {
+    if(s_instance == nullptr){
+        logger.log() << "Create Android Controller";
+        s_instance = new AndroidController();
+    }
     return s_instance;
 }
 

--- a/src/platforms/android/androidcontroller.cpp
+++ b/src/platforms/android/androidcontroller.cpp
@@ -31,6 +31,7 @@ const int ACTION_REGISTERLISTENER = 3;
 const int ACTION_REQUEST_STATISTIC = 4;
 const int ACTION_REQUEST_LOG = 5;
 const int ACTION_RESUME_ACTIVATE = 6;
+const int ACTION_ENABLE_START_ON_BOOT=7;
 
 // Event Types that will be Dispatched after registration
 const int EVENT_INIT = 0;
@@ -83,6 +84,12 @@ void AndroidController::initialize(const Device *device, const Keys *keys)
                                           "com.mozilla.vpn.VPNService"),
                            *this,
                            QtAndroid::BindFlag::AutoCreate);
+}
+
+void AndroidController::enableStartAtBoot(bool enabled){
+    QAndroidParcel data;
+    data.writeVariant(enabled);
+    m_serviceBinder.transact(ACTION_ENABLE_START_ON_BOOT, data, nullptr);
 }
 
 void AndroidController::activate(const Server &server,

--- a/src/platforms/android/androidcontroller.h
+++ b/src/platforms/android/androidcontroller.h
@@ -41,6 +41,9 @@ public:
 
 private:
     Server m_server;
+    bool m_enabledStartAtBoot = false;
+    bool m_startAtBootWasSet = false;
+    bool m_serviceConnected = false;
     std::function<void(const QString &)> m_logCallback;
 
     QAndroidBinder m_serviceBinder;

--- a/src/platforms/android/androidcontroller.h
+++ b/src/platforms/android/androidcontroller.h
@@ -31,6 +31,8 @@ public:
 
     void checkStatus() override;
 
+    void enableStartAtBoot(bool enabled);
+
     void getBackendLogs(std::function<void(const QString &)> &&callback) override;
 
     // from QAndroidServiceConnection

--- a/src/platforms/android/androidcontroller.h
+++ b/src/platforms/android/androidcontroller.h
@@ -13,7 +13,6 @@
 class AndroidController : public ControllerImpl, public QAndroidServiceConnection
 {
 public:
-    AndroidController();
     static AndroidController *instance();
     ~AndroidController();
 
@@ -40,6 +39,7 @@ public:
     void onServiceDisconnected(const QString &name) override;
 
 private:
+    AndroidController();
     Server m_server;
     bool m_enabledStartAtBoot = false;
     bool m_startAtBootWasSet = false;

--- a/src/platforms/android/androidstartatbootwatcher.cpp
+++ b/src/platforms/android/androidstartatbootwatcher.cpp
@@ -24,5 +24,5 @@ AndroidStartAtBootWatcher::AndroidStartAtBootWatcher(bool startAtBoot)
 void AndroidStartAtBootWatcher::startAtBootChanged(bool startAtBoot)
 {
     logger.log() << "StartAtBoot changed:" << startAtBoot;
-    AndroidController::Instance()->enableStartAtBoot(startAtBoot);
+    AndroidController::instance()->enableStartAtBoot(startAtBoot);
 }

--- a/src/platforms/android/androidstartatbootwatcher.cpp
+++ b/src/platforms/android/androidstartatbootwatcher.cpp
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "androidstartatbootwatcher.h"
+#include "logger.h"
+#include "androidcontroller.h"
+#include "platforms/android/androidutils.h"
+
+#include <jni.h>
+#include <QAndroidJniEnvironment>
+#include <QAndroidJniObject>
+#include <QtAndroid>
+
+namespace {
+Logger logger(LOG_ANDROID, "AndroidStartAtBootWatcher");
+}
+
+AndroidStartAtBootWatcher::AndroidStartAtBootWatcher(bool startAtBoot)
+{
+    startAtBootChanged(startAtBoot);
+}
+
+void AndroidStartAtBootWatcher::startAtBootChanged(bool startAtBoot)
+{
+    logger.log() << "StartAtBoot changed:" << startAtBoot;
+    AndroidController::Instance()->enableStartAtBoot(startAtBoot);
+}

--- a/src/platforms/android/androidstartatbootwatcher.h
+++ b/src/platforms/android/androidstartatbootwatcher.h
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef ANDROIDSTARTATBOOTWATCHER_H
+#define ANDROIDSTARTATBOOTWATCHER_H
+
+
+#include <QObject>
+
+class AndroidStartAtBootWatcher final : public QObject
+{
+public:
+    AndroidStartAtBootWatcher(bool startAtBoot);
+
+public slots:
+    void startAtBootChanged(bool value);
+};
+
+#endif // ANDROIDSTARTATBOOTWATCHER_H

--- a/src/platforms/android/androidutils.cpp
+++ b/src/platforms/android/androidutils.cpp
@@ -41,7 +41,7 @@ QString AndroidUtils::GetDeviceName()
 };
 
 // Static
-bool AndroidUtils::CanEnableStartOnBoot()
+bool AndroidUtils::canEnableStartOnBoot()
 {
     jboolean res = QAndroidJniObject::callStaticMethod<jboolean>("com/mozilla/vpn/BootReceiver", "canEnableVPNOnBoot");
     return bool(res);

--- a/src/platforms/android/androidutils.cpp
+++ b/src/platforms/android/androidutils.cpp
@@ -40,6 +40,13 @@ QString AndroidUtils::GetDeviceName()
     return res;
 };
 
+// Static
+bool AndroidUtils::CanEnableStartOnBoot()
+{
+    jboolean res = QAndroidJniObject::callStaticMethod<jboolean>("com/mozilla/vpn/BootReceiver", "canEnableVPNOnBoot");
+    return bool(res);
+};
+
 // static
 AndroidUtils *AndroidUtils::instance()
 {

--- a/src/platforms/android/androidutils.h
+++ b/src/platforms/android/androidutils.h
@@ -20,7 +20,7 @@ class AndroidUtils final : public QObject
 public:
     static QString GetDeviceName();
 
-    static bool CanEnableStartOnBoot();
+    static bool canEnableStartOnBoot();
 
     static AndroidUtils *instance();
 

--- a/src/platforms/android/androidutils.h
+++ b/src/platforms/android/androidutils.h
@@ -2,6 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#ifndef ANDROIDUTILS_H
+#define ANDROIDUTILS_H
+
 #include <QObject>
 #include <QString>
 #include <QUrl>
@@ -16,6 +19,8 @@ class AndroidUtils final : public QObject
 
 public:
     static QString GetDeviceName();
+
+    static bool CanEnableStartOnBoot();
 
     static AndroidUtils *instance();
 
@@ -38,3 +43,5 @@ private:
     QUrl m_url;
     AuthenticationListener *m_listener = nullptr;
 };
+
+#endif // ANDROIDUTILS_H

--- a/src/src.pro
+++ b/src/src.pro
@@ -231,13 +231,14 @@ else:android {
                 platforms/android/androidcontroller.cpp \
                 platforms/android/androidnotificationhandler.cpp \
                 platforms/android/androidutils.cpp \
-                platforms/android/androidwebview.cpp
-
+                platforms/android/androidwebview.cpp \
+                platforms/android/androidstartatbootwatcher.cpp
     HEADERS +=  platforms/android/androidauthenticationlistener.h \
                 platforms/android/androidcontroller.h \
                 platforms/android/androidnotificationhandler.h \
                 platforms/android/androidutils.h \
-                platforms/android/androidwebview.h
+                platforms/android/androidwebview.h \
+                platforms/android/androidstartatbootwatcher.h
 
     # Usable Linux Imports
     SOURCES += platforms/linux/linuxpingsendworker.cpp \


### PR DESCRIPTION
Would Fix #180 -
-> Adds the Ability for Supported API levels to Start the API on boot 
-> Adds Support for the Always ON Vpn android setting


Marking on wip as I neeed to test lower api levels, just tested on my pixel so far.