### PR TITLE
Better text wrapping in settings menu and settings views

### DIFF
--- a/src/ui/components/VPNAboutUs.qml
+++ b/src/ui/components/VPNAboutUs.qml
@@ -63,6 +63,7 @@ Item {
             text: qsTrId("vpn.main.productDescription")
             anchors.top: mozillaLabel.bottom
             anchors.topMargin: 8
+            width: aboutUsCopy.width
         }
 
         VPNBoldLabel {

--- a/src/ui/components/VPNCheckBoxAlert.qml
+++ b/src/ui/components/VPNCheckBoxAlert.qml
@@ -16,17 +16,26 @@ RowLayout {
     Layout.rightMargin: Theme.windowMargin
     spacing: 0
 
-    VPNIcon {
-        id: warningIcon
-
-        source: "../resources/warning.svg"
-        sourceSize.height: 14
-        sourceSize.width: 14
+    Rectangle {
+        color: "transparent"
+        Layout.preferredHeight: message.lineHeight
+        Layout.maximumHeight: message.lineHeight
+        Layout.preferredWidth: 14
         Layout.rightMargin: 8
         Layout.leftMargin: 4
+        Layout.alignment: Qt.AlignTop
+        VPNIcon {
+            id: warningIcon
+
+            source: "../resources/warning.svg"
+            sourceSize.height: 14
+            sourceSize.width: 14
+            Layout.alignment: Qt.AlignVCenter
+        }
     }
 
     VPNTextBlock {
+        id: message
         //% "VPN must be off before enabling"
         //: Associated to a setting that requires the VPN to be disconnected to change state
         readonly property var textAlertEnabled: qsTrId("vpn.turnOffAlert.enabling")
@@ -36,8 +45,7 @@ RowLayout {
 
         text: VPNSettings.localNetwork ? textAlertEnabled : textAlertDisabled
         color: Theme.red
-        width: parent.width - warningIcon.sourceSize.width - warningIcon.leftMargin - warningIcon.rightMargin
-        Layout.topMargin: 6
+        Layout.fillWidth: true
     }
 
 }

--- a/src/ui/components/VPNCheckBoxRow.qml
+++ b/src/ui/components/VPNCheckBoxRow.qml
@@ -20,6 +20,7 @@ RowLayout {
 
     signal clicked()
 
+    Layout.fillWidth: true
     Layout.topMargin: 18
     spacing: 0
 
@@ -41,16 +42,17 @@ RowLayout {
 
         VPNInterLabel {
             id: label
-
+            Layout.alignment: Qt.AlignLeft
+            Layout.fillWidth: true
             text: labelText
             color: Theme.fontColorDark
+            horizontalAlignment: Text.AlignLeft
         }
 
         VPNTextBlock {
             id: subLabel
 
-            width: Theme.maxTextWidth - Theme.windowMargin / 2
-            Layout.preferredWidth: subLabel.width
+            Layout.fillWidth: true
             text: subLabelText
             visible: !!subLabelText.length
         }

--- a/src/ui/settings/ViewNetworkSettings.qml
+++ b/src/ui/settings/ViewNetworkSettings.qml
@@ -13,7 +13,8 @@ import "../themes/themes.js" as Theme
 VPNFlickable {
     id: vpnFlickable
 
-    flickContentHeight: vpnFlickable.childrenRect.height
+    flickContentHeight: columnLayout.height + menu.height
+    width: window.width
 
     VPNMenu {
         id: menu
@@ -24,8 +25,9 @@ VPNFlickable {
     }
 
     ColumnLayout {
+        id: columnLayout
         anchors.top: menu.bottom
-        Layout.preferredWidth: parent.width
+        width: vpnFlickable.width - Theme.windowMargin
         spacing: 0
 
         VPNCheckBoxRow {

--- a/src/ui/settings/ViewNotifications.qml
+++ b/src/ui/settings/ViewNotifications.qml
@@ -7,11 +7,14 @@ import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
 import Mozilla.VPN 1.0
 import "../components"
+import "../themes/themes.js" as Theme
 
 VPNFlickable {
     id: vpnFlickable
 
-    flickContentHeight: vpnFlickable.childrenRect.height
+    flickContentHeight: columnLayout.height + menu.height
+    width: window.width
+
     VPNMenu {
         id: menu
 
@@ -21,8 +24,9 @@ VPNFlickable {
     }
 
     ColumnLayout {
+        id: columnLayout
         anchors.top: menu.bottom
-        Layout.preferredWidth: parent.width
+        width: vpnFlickable.width - Theme.windowMargin
         spacing: 0
 
         /* TODO

--- a/src/ui/settings/ViewSettingsMenu.qml
+++ b/src/ui/settings/ViewSettingsMenu.qml
@@ -12,6 +12,7 @@ import "../themes/themes.js" as Theme
 VPNFlickable {
     id: vpnFlickable
 
+    width: window.width
     flickContentHeight: settingsList.y + (settingsList.count * 56) + signOutLink.height + signOutLink.anchors.bottomMargin
     ListModel {
         id: settingsMenuListModel
@@ -119,7 +120,7 @@ VPNFlickable {
         anchors.top: manageAccountButton.bottom
         anchors.topMargin: Theme.hSpacing * 1.5
         anchors.rightMargin: Theme.hSpacing
-        width: parent.width - Theme.hSpacing
+        width: vpnFlickable.width - Theme.hSpacing
         onClicked: VPNSettings.startAtBoot = !VPNSettings.startAtBoot
 
         visible: VPN.startOnBootSupported


### PR DESCRIPTION

<img width="200" alt="Screen Shot 2020-11-17 at 1 02 04 PM" src="https://user-images.githubusercontent.com/22355127/99455841-0835c080-28ee-11eb-9687-4e83e624cffd.png">

Noticed this layout issue while running the app in a few of the Android simulators.
This PR 
- Allows text in the settings views to wrap, unwrap as necessary according to the window width
- Prevents checkbox alert "VPN must be disabled.." from being cut off on narrower devices. 
<br>
<br>


Text will now wrap based on window width
<img width="200" alt="Screen Shot 2020-11-17 at 3 42 19 PM" src="https://user-images.githubusercontent.com/22355127/99455640-b8ef9000-28ed-11eb-914c-2e74fc21445c.png">

<img width="300" alt="Screen Shot 2020-11-17 at 2 42 20 PM" src="https://user-images.githubusercontent.com/22355127/99455675-c9a00600-28ed-11eb-8c92-7ca8d263a067.png">

<img width="200" alt="Screen Shot 2020-11-17 at 2 49 03 PM" src="https://user-images.githubusercontent.com/22355127/99455647-bb51ea00-28ed-11eb-8dcb-dfd0d51eb810.png">
