### PR TITLE
Fix #236 - Components remain selected on scroll

### DIFF
--- a/src/ui/components/VPNMouseArea.qml
+++ b/src/ui/components/VPNMouseArea.qml
@@ -22,6 +22,7 @@ MouseArea {
     onEntered: changeState(uiState.stateHovered)
     onExited: changeState(uiState.stateDefault)
     onPressed: changeState(uiState.statePressed)
+    onCanceled: if (targetEl.state === uiState.stateHovered || targetEl.state === uiState.statePressed) changeState(uiState.stateDefault)
     onReleased: {
         if (hoverEnabled) {
             changeState(uiState.stateDefault);

--- a/src/ui/components/VPNMouseArea.qml
+++ b/src/ui/components/VPNMouseArea.qml
@@ -22,7 +22,7 @@ MouseArea {
     onEntered: changeState(uiState.stateHovered)
     onExited: changeState(uiState.stateDefault)
     onPressed: changeState(uiState.statePressed)
-    onCanceled: if (targetEl.state === uiState.stateHovered || targetEl.state === uiState.statePressed) changeState(uiState.stateDefault)
+    onCanceled: changeState(uiState.stateDefault)
     onReleased: {
         if (hoverEnabled) {
             changeState(uiState.stateDefault);


### PR DESCRIPTION
Revert to "uiState.stateDefault" when a mouse event is canceled because scrolling is detected or another component has usurped the mouse event. This fixes the issue on iOS and Android emulators. 