### PR TITLE
Make connection info accessible

### DIFF
--- a/src/ui/components/VPNConnectionInfo.qml
+++ b/src/ui/components/VPNConnectionInfo.qml
@@ -32,6 +32,10 @@ Popup {
     contentItem: Item {
         id: chartWrapper
 
+        property var rBytes: VPNConnectionData.rxBytes
+        property var tBytes: VPNConnectionData.txBytes
+
+
         width: box.width
         height: box.height
         antialiasing: true
@@ -53,12 +57,13 @@ Popup {
             margins.right: 0
             animationOptions: ChartView.SeriesAnimations
 
+
             ValueAxis {
                 id: axisX
 
+                tickCount: 1
                 min: 0
                 max: 29
-                tickCount: 5
                 lineVisible: false
                 labelsVisible: false
                 gridVisible: false
@@ -68,6 +73,7 @@ Popup {
             ValueAxis {
                 id: axisY
 
+                tickCount: 1
                 min: 10
                 max: 80
                 lineVisible: false
@@ -125,7 +131,7 @@ Popup {
                 //: The current download speed. The speed is shown on the next line.
                 markerLabel: qsTrId("vpn.connectionInfo.download")
                 rectColor: "#EE3389"
-                markerData: VPNConnectionData.rxBytes
+                markerData: chartWrapper.rBytes
             }
 
             VPNGraphLegendMarker {
@@ -133,7 +139,7 @@ Popup {
                 //: The current upload speed. The speed is shown on the next line.
                 markerLabel: qsTrId("vpn.connectionInfo.upload")
                 rectColor: "#F68953"
-                markerData: VPNConnectionData.txBytes
+                markerData: chartWrapper.tBytes
             }
 
         }

--- a/src/ui/components/VPNConnectionInfo.qml
+++ b/src/ui/components/VPNConnectionInfo.qml
@@ -4,176 +4,193 @@
 
 import QtQuick 2.5
 import QtCharts 2.0
+import QtQuick.Controls 2.15
 import Mozilla.VPN 1.0
 import "../themes/themes.js" as Theme
 
-Item {
-    id: chartWrapper
 
-    anchors.fill: box
-    states: [
-        State {
-            name: "visible"
-            when: chartWrapper.visible
+Popup {
+    id: popup
 
-            StateChangeScript {
-                script: VPNConnectionData.activate(txSeries, rxSeries, axisX, axisY)
-            }
+    height: box.height
+    width: box.width
+    modal: true
+    focus: true
+    leftInset: 0
+    rightInset: 0
+    padding: 0
+    closePolicy: Popup.CloseOnEscape
+    Component.onCompleted: VPNCloseEventHandler.addView(chartWrapper)
+    onOpened: VPNConnectionData.activate(txSeries, rxSeries, axisX, axisY)
+    onClosed: VPNConnectionData.deactivate()
 
-        },
-        State {
-            name: "invisible"
-            when: !chartWrapper.visible
+    VPNIconButton {
+        id: backButton
 
-            StateChangeScript {
-                script: VPNConnectionData.deactivate()
-            }
+        onClicked: popup.close()
+        buttonColorScheme: Theme.iconButtonDarkBackground
+        anchors.top: parent.top
+        anchors.left: parent.left
+        anchors.topMargin: 8
+        anchors.leftMargin: 8
+        //% "Close"
+        accessibleName: qsTrId("vpn.connectionInfo.close")
+
+        Image {
+            anchors.centerIn: backButton
+            source: "../resources/close-white.svg"
+            sourceSize.height: 16
+            sourceSize.width: 16
+        }
+
+    }
+
+    Connections {
+        function onGoBack(item) {
+            if (item === chartWrapper)
+                backButton.clicked();
 
         }
-    ]
 
-    Rectangle {
-        anchors.fill: parent
-        height: parent.height
-        width: parent.width
-        color: "#321C64"
-        radius: 8
+        target: VPNCloseEventHandler
+    }
+
+    Item {
+        id: chartWrapper
+
+        width: box.width
+        height: box.height
         antialiasing: true
+        smooth: true
+        Component.onCompleted: VPNCloseEventHandler.addView(chartWrapper)
 
-        ChartView {
-            id: chart
-
+        Rectangle {
+            color: "transparent"
+            anchors.fill: chartWrapper
             antialiasing: true
-            backgroundColor: "#321C64"
-            width: parent.width
-            height: (parent.height / 2) - 32
-            legend.visible: false
-            anchors.horizontalCenter: parent.horizontalCenter
-            anchors.top: parent.top
-            anchors.topMargin: 60
-            margins.top: 0
-            margins.bottom: 0
-            margins.left: 0
-            margins.right: 0
-            animationOptions: ChartView.SeriesAnimations
+            smooth: true
 
-            ValueAxis {
-                id: axisX
+            ChartView {
+                id: chart
 
-                min: 0
-                max: 29
-                tickCount: 5
-                lineVisible: false
-                labelsVisible: false
-                gridVisible: false
-                visible: false
+                antialiasing: true
+                smooth: true
+                width: parent.width
+                height: (parent.height / 2) - 32
+                legend.visible: false
+                anchors.horizontalCenter: parent.horizontalCenter
+                backgroundColor: box.color
+                anchors.top: parent.top
+                anchors.topMargin: 60
+                margins.top: 0
+                margins.bottom: 0
+                margins.left: 0
+                margins.right: 0
+                animationOptions: ChartView.SeriesAnimations
+
+                ValueAxis {
+                    id: axisX
+
+                    min: 0
+                    max: 29
+                    tickCount: 5
+                    lineVisible: false
+                    labelsVisible: false
+                    gridVisible: false
+                    visible: false
+                }
+
+                ValueAxis {
+                    id: axisY
+
+                    min: 10
+                    max: 80
+                    lineVisible: false
+                    labelsVisible: false
+                    gridVisible: false
+                    visible: false
+                }
+
+                SplineSeries {
+                    id: txSeries
+
+                    axisX: axisX
+                    axisY: axisY
+                    useOpenGL: true
+
+                    color: "#F68953"
+                    width: 2
+                }
+
+                SplineSeries {
+                    id: rxSeries
+
+                    axisX: axisX
+                    axisY: axisY
+                    useOpenGL: true
+                    color: "#EE3389"
+
+                    width: 2
+                }
+
             }
 
-            ValueAxis {
-                id: axisY
-
-                min: 10
-                max: 80
-                lineVisible: false
-                labelsVisible: false
-                gridVisible: false
-                visible: false
+            VPNBoldLabel {
+                anchors.top: parent.top
+                anchors.topMargin: 24
+                anchors.left: parent.left
+                anchors.right: parent.right
+                anchors.horizontalCenter: parent.center
+                anchors.horizontalCenterOffset: 0
+                horizontalAlignment: Text.AlignHCenter
+                color: Theme.white
+                //% "IP: %1"
+                //: The current IP address
+                text: qsTrId("vpn.connectionInfo.ip").arg(VPNConnectionData.ipAddress)
+                Accessible.name: text
+                Accessible.role: Accessible.StaticText
+                focus: true
+                activeFocusOnTab: true
             }
 
-            SplineSeries {
-                id: txSeries
+            Row {
+                spacing: 48
+                anchors.bottom: parent.bottom
+                anchors.bottomMargin: 48
+                anchors.horizontalCenter: parent.horizontalCenter
 
-                axisX: axisX
-                axisY: axisY
-                useOpenGL: false
-                capStyle: Qt.RoundCap
-                color: "#F68953"
-                width: 2
-            }
+                VPNGraphLegendMarker {
+                    //% "Download"
+                    //: The current download speed. The speed is shown on the next line.
+                    markerLabel: qsTrId("vpn.connectionInfo.download")
+                    rectColor: "#EE3389"
+                    markerData: VPNConnectionData.rxBytes
+                }
 
-            SplineSeries {
-                id: rxSeries
+                VPNGraphLegendMarker {
+                    //% "Upload"
+                    //: The current upload speed. The speed is shown on the next line.
+                    markerLabel: qsTrId("vpn.connectionInfo.upload")
+                    rectColor: "#F68953"
+                    markerData: VPNConnectionData.txBytes
+                }
 
-                axisX: axisX
-                axisY: axisY
-                useOpenGL: true
-                capStyle: Qt.RoundCap
-                color: "#EE3389"
-                width: 2
-            }
-
-        }
-
-        VPNBoldLabel {
-            anchors.top: parent.top
-            anchors.topMargin: 24
-            anchors.left: parent.left
-            anchors.right: parent.right
-            anchors.horizontalCenter: parent.center
-            anchors.horizontalCenterOffset: 0
-            horizontalAlignment: Text.AlignHCenter
-            color: Theme.white
-            //% "IP: %1"
-            //: The current IP address
-            text: qsTrId("vpn.connectionInfo.ip").arg(VPNConnectionData.ipAddress)
-        }
-
-        Row {
-            spacing: 48
-            anchors.bottom: parent.bottom
-            anchors.bottomMargin: 48
-            anchors.horizontalCenter: parent.horizontalCenter
-
-            VPNGraphLegendMarker {
-                //% "Download"
-                //: The current download speed. The speed is shown on the next line.
-                markerLabel: qsTrId("vpn.connectionInfo.download")
-                rectColor: "#EE3389"
-                markerData: VPNConnectionData.rxBytes
-            }
-
-            VPNGraphLegendMarker {
-                //% "Upload"
-                //: The current upload speed. The speed is shown on the next line.
-                markerLabel: qsTrId("vpn.connectionInfo.upload")
-                rectColor: "#F68953"
-                markerData: VPNConnectionData.txBytes
-            }
-
-        }
-
-        VPNIconButton {
-            id: backButton
-
-            onClicked: chartWrapper.visible = false
-            buttonColorScheme: Theme.iconButtonDarkBackground
-            anchors.top: parent.top
-            anchors.left: parent.left
-            anchors.topMargin: 8
-            anchors.leftMargin: 8
-            //% "Close"
-            accessibleName: qsTrId("vpn.connectionInfo.close")
-
-            Image {
-                anchors.centerIn: backButton
-                source: "../resources/close-white.svg"
-                sourceSize.height: 16
-                sourceSize.width: 16
             }
 
         }
 
     }
 
-    Component.onCompleted: VPNCloseEventHandler.addView(chartWrapper)
+    background: Rectangle {
+        color: box.color
+        anchors.fill: parent
+        radius: box.radius
+        antialiasing: true
+        smooth: true
+    }
 
-    Connections {
-        target: VPNCloseEventHandler
-        function onGoBack(item) {
-            if (item === chartWrapper) {
-                backButton.clicked();
-            }
-        }
+    Overlay.modal: Rectangle {
+        color: Theme.bgColor80
     }
 
 }

--- a/src/ui/components/VPNControllerView.qml
+++ b/src/ui/components/VPNControllerView.qml
@@ -456,7 +456,7 @@ Rectangle {
     VPNIconButton {
         id: connectionInfoButton
 
-        onClicked: connectionInfo.visible = true
+        onClicked: connectionInfo.open()
         buttonColorScheme: Theme.iconButtonDarkBackground
         opacity: connectionInfoButton.visible ? 1 : 0
         anchors.top: parent.top
@@ -567,12 +567,6 @@ Rectangle {
 
     VPNConnectionInfo {
         id: connectionInfo
-
-        anchors.fill: parent
-        height: box.height
-        width: box.width
-        visible: false
-        opacity: connectionInfo.visible ? 1 : 0
 
         Behavior on opacity {
             NumberAnimation {

--- a/src/ui/components/VPNGraphLegendMarker.qml
+++ b/src/ui/components/VPNGraphLegendMarker.qml
@@ -41,6 +41,12 @@ Row {
 
         return roundValue(markeData / 8.192e+09);
     }
+    Accessible.focusable: true
+    Accessible.role: Accessible.StaticText
+    Accessible.name: markerLabel
+    Accessible.description: markerData
+    focus: true
+    activeFocusOnTab: true
 
     spacing: 12
 


### PR DESCRIPTION
Fixes #134 and most of #136 

- Restricts focus to connection info when connection info graph is visible
- Makes graph legend information accessible screen readers (do we want to create some new strings for this?)
- Makes IP address accessible to screen readers
- Connection info can be closed by clicking escape, clicking outside the graph, or clicking the close button

A few remaining issues:
- the semantics of the connection info Popup {} are not exposed to screen readers.