### PR TITLE
Add comment for vpn.connectionInfo.accessibleName

### DIFF
--- a/src/ui/components/VPNGraphLegendMarker.qml
+++ b/src/ui/components/VPNGraphLegendMarker.qml
@@ -44,6 +44,9 @@ Row {
     Accessible.focusable: true
     Accessible.role: Accessible.StaticText
     //% "%1: %2 %3"
+    //: Used as accessibility description for the connection info:
+    //: %1 is the localized label for “Upload” or “Download”, %2 is the speed
+    //: value, %3 is the localized unit. Example: “Upload: 10 Mbps”.
     Accessible.name: qsTrId("vpn.connectionInfo.accessibleName")
         .arg(label.text)
         .arg(value.text)


### PR DESCRIPTION
Hopefully I figured out the right comment looking at the code. The export looks correct, the multiline comment is rendered as one line.

```
    <message id="vpn.connectionInfo.accessibleName">
        <location filename="../src/ui/components/VPNGraphLegendMarker.qml" line="50"/>
        <source>%1: %2 %3</source>
        <extracomment>Used as accessibility description for the connection info: %1 is the localized label for “Upload” or “Download”, %2 is the speed value, %3 is the localized unit. Example: “Upload: 10 Mbps”.</extracomment>
        <translation type="unfinished"></translation>
    </message>
```

