### PR TITLE
Open server list to selected server

### DIFF
--- a/src/ui/components/VPNControllerServer.qml
+++ b/src/ui/components/VPNControllerServer.qml
@@ -18,7 +18,6 @@ VPNClickableRow {
     property var descriptionText: qsTrId("vpn.servers.currentLocation").arg(VPNCurrentServer.city)
 
     accessibleName: titleText + ": " + descriptionText
-    rowShouldBeDisabled: VPN.state === VPN.StateDeviceLimit
     Accessible.ignored: rowShouldBeDisabled
     activeFocusOnTab: true
 

--- a/src/ui/components/VPNServerCountry.qml
+++ b/src/ui/components/VPNServerCountry.qml
@@ -13,7 +13,7 @@ import "../themes/themes.js" as Theme
 VPNClickableRow {
     id: serverCountry
 
-    property var cityListVisible: false
+    property var cityListVisible: (code === VPNCurrentServer.countryCode)
     readonly property bool isActive: cityList.activeFocus
 
     // During transition, when expanding the row or scrolling,

--- a/src/ui/components/VPNServerCountry.qml
+++ b/src/ui/components/VPNServerCountry.qml
@@ -69,37 +69,38 @@ VPNClickableRow {
         }
     }
     Keys.onDownPressed: {
-        if (!cityListVisible) {
-            event.accepted = false;
-            return;
-        }
+        if (!cityListVisible)
+            return event.accepted = false;
 
-        if (cityList.activeFocus) {
-            event.accepted = false;
-        } else {
-            cityList.forceActiveFocus();
-        }
+        if (cityList.activeFocus)
+            return event.accepted = false;
+
+        cityList.forceActiveFocus();
     }
     Keys.onUpPressed: {
-        if (!serverCountry.activeFocus) {
-            serverCountry.forceActiveFocus();
-        } else if (serverList.currentIndex > 0) {
+        if (!serverCountry.activeFocus)
+            return serverCountry.forceActiveFocus();
+
+        if (serverList.currentIndex > 0) {
             serverList.decrementCurrentIndex();
-            if (serverList.currentItem.cityListVisible && !serverList.currentItem.isActive) {
+
+            if (serverList.currentItem.cityListVisible && !serverList.currentItem.isActive)
                 serverList.currentItem.activate();
-            }
         }
     }
-    Keys.onRightPressed: {
-        if (!cityListVisible) {
-            serverCountry.clicked();
-        }
+
+    Keys.onTabPressed: {
+        if (index < serverList.count - 1)
+            return serverList.incrementCurrentIndex();
+        return root.forceActiveFocus();
     }
-    Keys.onLeftPressed: {
-        if (cityListVisible) {
-            serverCountry.clicked();
-        }
+    Keys.onBacktabPressed: {
+        if (index > 0)
+            return serverList.decrementCurrentIndex();
+        return root.forceActiveFocus();
     }
+    Keys.onRightPressed: if (!cityListVisible) serverCountry.clicked()
+    Keys.onLeftPressed: if (cityListVisible) serverCountry.clicked()
 
     function activate() {
         cityList.forceActiveFocus();
@@ -166,20 +167,15 @@ VPNClickableRow {
         activeFocusOnTab: serverCountry.ListView.isCurrentItem
         highlightFollowsCurrentItem: true
         Keys.onDownPressed: {
-            if (cityList.currentIndex === cityList.count - 1) {
-                event.accepted = false;
-                return;
-            }
+            if (cityList.currentIndex === cityList.count - 1)
+                return event.accepted = false;
 
-            cityList.incrementCurrentIndex()
+            return cityList.incrementCurrentIndex();
         }
         Keys.onUpPressed: {
-            if (cityList.currentIndex === 0) {
-                event.accepted = false;
-                return;
-            }
-
-            cityList.decrementCurrentIndex()
+            if (cityList.currentIndex === 0)
+                return event.accepted = false;
+            return cityList.decrementCurrentIndex();
         }
 
         delegate: VPNRadioDelegate {

--- a/src/ui/views/ViewMain.qml
+++ b/src/ui/views/ViewMain.qml
@@ -166,7 +166,7 @@ VPNFlickable {
 
             onClicked: stackview.push("ViewServers.qml")
             y: box.y + box.height + Theme.iconSize
-            rowShouldBeDisabled: box.connectionInfoVisible
+            rowShouldBeDisabled: VPN.state === VPN.StateDeviceLimit || VPNController.state === VPNController.StateSwitching || box.connectionInfoVisible
         }
 
         VPNControllerDevice {

--- a/src/ui/views/ViewServers.qml
+++ b/src/ui/views/ViewServers.qml
@@ -5,6 +5,7 @@
 import QtQuick 2.5
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
+import QtQml.Models 2.2
 import Mozilla.VPN 1.0
 import "../components"
 import "../themes/themes.js" as Theme
@@ -20,6 +21,13 @@ Item {
         id: radioButtonGroup
     }
 
+    DelegateModel {
+        id: delegateModel
+
+        model: VPNServerCountryModel
+        delegate: VPNServerCountry {}
+    }
+
     VPNList {
         id: serverList
 
@@ -28,7 +36,6 @@ Item {
         anchors.top: menu.bottom
         spacing: Theme.listSpacing
         clip: true
-        model: VPNServerCountryModel
         listName: menu.title
         interactive: true
         onActiveFocusChanged: {
@@ -43,8 +50,22 @@ Item {
             width: serverList.width
             color: "transparent"
         }
+        model: delegateModel
 
-        delegate: VPNServerCountry {}
+        Component.onCompleted: {
+            const getCurrentServerIndex = () => {
+                for (var x = 0; x < serverList.count; x++) {
+                    if (delegateModel.items.get(x).model.code === VPNCurrentServer.countryCode) {
+                        return x;
+                    }
+                }
+            };
+            serverList.currentIndex = getCurrentServerIndex();
+            serverList.currentItem.cityListVisible = true;
+            serverList.currentItem.forceActiveFocus();
+            serverList.positionViewAtIndex(serverList.currentIndex, ListView.Center);
+
+        }
 
         ScrollBar.vertical: ScrollBar {
             Accessible.ignored: true

--- a/src/ui/views/ViewServers.qml
+++ b/src/ui/views/ViewServers.qml
@@ -53,16 +53,17 @@ Item {
         model: delegateModel
 
         Component.onCompleted: {
-            const getCurrentServerIndex = () => {
-                for (var x = 0; x < serverList.count; x++) {
-                    if (delegateModel.items.get(x).model.code === VPNCurrentServer.countryCode) {
-                        return x;
-                    }
-                }
-            };
-            serverList.currentIndex = getCurrentServerIndex();
-            serverList.currentItem.cityListVisible = true;
-            serverList.currentItem.forceActiveFocus();
+            if (VPNController.state === VPNController.StateSwitching) {
+                return;
+            }
+
+            serverList.currentIndex = (() => {
+               for (let idx = 0; idx < serverList.count; idx++) {
+                   if (delegateModel.items.get(idx).model.code === VPNCurrentServer.countryCode) {
+                       return idx;
+                   }
+               }
+            })();
             serverList.positionViewAtIndex(serverList.currentIndex, ListView.Center);
 
         }

--- a/src/ui/views/ViewServers.qml
+++ b/src/ui/views/ViewServers.qml
@@ -11,6 +11,7 @@ import "../components"
 import "../themes/themes.js" as Theme
 
 Item {
+    id: root
     VPNMenu {
         id: menu
 
@@ -38,13 +39,8 @@ Item {
         clip: true
         listName: menu.title
         interactive: true
-        onActiveFocusChanged: {
-            if (activeFocus) {
-                currentItem.forceActiveFocus();
-            }
-        }
-        onCurrentIndexChanged: currentItem.forceActiveFocus()
 
+        onCurrentIndexChanged: currentItem.forceActiveFocus()
         header: Rectangle {
             height: 16
             width: serverList.width


### PR DESCRIPTION
Marking this as WIP because there are a few things to decide: 

1.) What should happen when the server list is opened and `VPNController.state === VPNController.StateSwitching` ? Right now, we just return instead of scrolling to the previously selected server country. Maybe there is something better to do here.

2.) Do we want to disable clicks to the server list when `VPNController.state === VPNController.StateSwitching` ? We disable the toggle, so this doesn't feel like a stretch. 

Fixes #116 