### PR TITLE
Actually use full screen on iOS devices

### DIFF
--- a/src/ui/components/VPNFlickable.qml
+++ b/src/ui/components/VPNFlickable.qml
@@ -11,7 +11,7 @@ Flickable {
     id: vpnFlickable
 
     property var flickContentHeight
-    property var windowHeightExceedsContentHeight: (window.height > flickContentHeight)
+    property var windowHeightExceedsContentHeight: (window.safeContentHeight > flickContentHeight)
 
     function ensureVisible(item) {
         if (windowHeightExceedsContentHeight) {
@@ -27,7 +27,7 @@ Flickable {
         }
     }
 
-    contentHeight: Math.max(window.height, flickContentHeight)
+    contentHeight: Math.max(window.safeContentHeight, flickContentHeight)
     boundsBehavior: Flickable.StopAtBounds
     opacity: 0
     Component.onCompleted: {

--- a/src/ui/components/VPNFooterLink.qml
+++ b/src/ui/components/VPNFooterLink.qml
@@ -8,5 +8,5 @@ import "../themes/themes.js" as Theme
 VPNLinkButton {
     anchors.horizontalCenter: parent.horizontalCenter
     anchors.bottom: parent.bottom
-    anchors.bottomMargin: Math.min(window.height * .08, 60)
+    anchors.bottomMargin: Math.min(window.safeContentHeight * .08, 60)
 }

--- a/src/ui/main.qml
+++ b/src/ui/main.qml
@@ -11,7 +11,7 @@ import "./components"
 Window {
     id: window
 
-    property var safeContentHeight: Qt.platform.os === "ios" ? window.height - iosSafeArea.height : window.height
+    property var safeContentHeight: Qt.platform.os === "ios" ? window.height - iosSafeAreaTopMargin.height : window.height
 
     function fullscreenRequired() {
         return Qt.platform.os === "android" ||

--- a/src/ui/main.qml
+++ b/src/ui/main.qml
@@ -11,13 +11,15 @@ import "./components"
 Window {
     id: window
 
+    property var safeContentHeight: Qt.platform.os === "ios" ? window.height - iosSafeArea.height : window.height
+
     function fullscreenRequired() {
         return Qt.platform.os === "android" ||
                 Qt.platform.os === "ios" ||
                 Qt.platform.os === "tvos";
     }
 
-    flags: if (Qt.platform.os === "ios") Qt.MaximizeUsingFullscreenGeometryHint
+    flags: Qt.platform.os === "ios" ? Qt.MaximizeUsingFullscreenGeometryHint : Qt.Window
 
     visible: true
     width: fullscreenRequired() ? maximumWidth : 360
@@ -52,7 +54,7 @@ Window {
 
     }
     Rectangle {
-        id: iosSafeArea
+        id: iosSafeAreaTopMargin
 
         color: "transparent"
         height: 40
@@ -65,8 +67,8 @@ Window {
 
         initialItem: mainView
         width: parent.width
-        anchors.top: Qt.platform.os === "ios" ? iosSafeArea.bottom : parent.top
-        height: Qt.platform.os === "ios" ? window.height - iosSafeArea.height : window.height
+        anchors.top: Qt.platform.os === "ios" ? iosSafeAreaTopMargin.bottom : parent.top
+        height: safeContentHeight
     }
 
     Component {

--- a/src/ui/main.qml
+++ b/src/ui/main.qml
@@ -17,6 +17,8 @@ Window {
                 Qt.platform.os === "tvos";
     }
 
+    flags: if (Qt.platform.os === "ios") Qt.MaximizeUsingFullscreenGeometryHint
+
     visible: true
     width: fullscreenRequired() ? maximumWidth : 360
     height: fullscreenRequired() ? maximumHeight : 454
@@ -49,12 +51,22 @@ Window {
             this.showMinimized();
 
     }
+    Rectangle {
+        id: iosSafeArea
+
+        color: "transparent"
+        height: 40
+        width: window.width
+        visible: Qt.platform.os === "ios"
+    }
 
     VPNStackView {
         id: mainStackView
 
         initialItem: mainView
-        anchors.fill: parent
+        width: parent.width
+        anchors.top: Qt.platform.os === "ios" ? iosSafeArea.bottom : parent.top
+        height: Qt.platform.os === "ios" ? window.height - iosSafeArea.height : window.height
     }
 
     Component {

--- a/src/ui/settings/ViewSettingsMenu.qml
+++ b/src/ui/settings/ViewSettingsMenu.qml
@@ -95,7 +95,7 @@ VPNFlickable {
         readonly property var textVpnUser: qsTrId("vpn.settings.user")
         logoTitle: VPNUser.displayName ? VPNUser.displayName : textVpnUser
         logoSubtitle: VPNUser.email
-        y: (Math.max(window.height * .08, Theme.windowMargin * 2))
+        y: (Math.max(window.safeContentHeight * .08, Theme.windowMargin * 2))
         maskImage: true
         imageIsVector: false
     }

--- a/src/ui/views/ViewDevices.qml
+++ b/src/ui/views/ViewDevices.qml
@@ -15,7 +15,7 @@ Item {
 
     property var isModalDialogOpened: removePopup.visible
 
-    height: window.height
+    height: window.safeContentHeight
     width: window.width
 
     VPNMenu {

--- a/src/ui/views/ViewLogs.qml
+++ b/src/ui/views/ViewLogs.qml
@@ -16,7 +16,7 @@ Item {
     id: logs
 
     width: window.width
-    height: window.height
+    height: window.safeContentHeight
     Component.onCompleted: VPNCloseEventHandler.addView(logs)
 
     VPNMenu {

--- a/src/ui/views/ViewSubscriptionNeeded.qml
+++ b/src/ui/views/ViewSubscriptionNeeded.qml
@@ -36,7 +36,7 @@ VPNFlickable {
         id: spacer1
 
         width: parent.width
-        height: (Math.max(window.height * .08, Theme.windowMargin * 2))
+        height: (Math.max(window.safeContentHeight * .08, Theme.windowMargin * 2))
     }
 
     VPNPanel {
@@ -117,7 +117,7 @@ VPNFlickable {
     Item {
         id: spacer2
         anchors.top: featureListBackground.bottom
-        height: Math.max(Theme.windowMargin * 2, (window.height - flickContentHeight))
+        height: Math.max(Theme.windowMargin * 2, (window.safeContentHeight - flickContentHeight))
         width: vpnFlickable.width
     }
 

--- a/src/ui/views/ViewUpdate.qml
+++ b/src/ui/views/ViewUpdate.qml
@@ -75,7 +75,7 @@ VPNFlickable {
     Item {
         id: spacer1
 
-        height: Math.max(Theme.windowMargin * 2, ( window.height - flickContentHeight ) / 2)
+        height: Math.max(Theme.windowMargin * 2, ( window.safeContentHeight - flickContentHeight ) / 2)
         width: vpnFlickable.width
     }
 
@@ -93,7 +93,7 @@ VPNFlickable {
         id: spacer2
 
         anchors.top: vpnPanel.bottom
-        height: Math.max(Theme.windowMargin * 2, (window.height -flickContentHeight ) / 2)
+        height: Math.max(Theme.windowMargin * 2, (window.safeContentHeight -flickContentHeight ) / 2)
         width: vpnFlickable.width
     }
 


### PR DESCRIPTION
Had to do a bit of repositioning to prevent some of the VPN content from getting stuck beneath the default device info.
<img width="300" alt="Screen Shot 2020-11-24 at 9 30 13 PM" src="https://user-images.githubusercontent.com/22355127/100179964-be744980-2e9c-11eb-98ab-b9345fd1f01e.png">
<img width="300" alt="Screen Shot 2020-11-24 at 9 28 55 PM" src="https://user-images.githubusercontent.com/22355127/100179972-c7651b00-2e9c-11eb-8dfb-5f136d41d56d.png">
