### PR TITLE
Do not add Catch All IP range if LAN access is enabled

### DIFF
--- a/src/controller.h
+++ b/src/controller.h
@@ -101,7 +101,7 @@ class Controller final : public QObject {
 
   bool processNextStep();
 
-  QList<IPAddressRange> getAllowedIPAddressRanges();
+  QList<IPAddressRange> getAllowedIPAddressRanges(const Server& server);
 
  private:
   State m_state = StateInitializing;

--- a/tests/unit/moccontroller.cpp
+++ b/tests/unit/moccontroller.cpp
@@ -41,7 +41,8 @@ void Controller::statusUpdated(const QString&, uint64_t, uint64_t) {}
 
 void Controller::captivePortalDetected() {}
 
-QList<IPAddressRange> Controller::getAllowedIPAddressRanges() {
+QList<IPAddressRange> Controller::getAllowedIPAddressRanges(const Server& server) {
+  Q_UNUSED(server);
   return QList<IPAddressRange>();
 }
 


### PR DESCRIPTION
- Fix for #299 

We always add 0.0.0.0/0 to the allowed ip - so local traffic is always routed through the vpn on android. 


