### PR TITLE
Prevent mouse clicks around server city names from toggling list visibility

### DIFF
--- a/src/ui/components/VPNButtonBase.qml
+++ b/src/ui/components/VPNButtonBase.qml
@@ -13,6 +13,7 @@ RoundButton {
     property var visualStateItem: root
     property var uiState: Theme.uiState
     property var loaderVisible: false
+    property var handleKeyClick: function() { clicked() }
 
     focusPolicy: Qt.StrongFocus
     Keys.onPressed: {
@@ -32,11 +33,11 @@ RoundButton {
             visualStateItem.state = uiState.stateDefault;
         }
         if (event.key === Qt.Key_Return)
-            clicked();
+            handleKeyClick();
     }
 
     Accessible.role: Accessible.Button
-    Accessible.onPressAction: clicked()
+    Accessible.onPressAction: handleKeyClick()
     Accessible.focusable: true
 
     onActiveFocusChanged: {

--- a/src/ui/components/VPNClickableRow.qml
+++ b/src/ui/components/VPNClickableRow.qml
@@ -17,6 +17,7 @@ VPNButtonBase {
     property var accessibleName
     property var backgroundColor: Theme.iconButtonLightBackground
 
+    property var handleMouseClick: function() { mainRow.clicked(); }
     visualStateItem: rowVisualStates
 
     height: Theme.rowHeight
@@ -59,8 +60,10 @@ VPNButtonBase {
     }
 
     VPNMouseArea {
+        anchors.fill: rowVisualStates
         hoverEnabled: !rowShouldBeDisabled
         targetEl: rowVisualStates
+        onMouseAreaClicked: handleMouseClick
     }
 
 }

--- a/src/ui/components/VPNMouseArea.qml
+++ b/src/ui/components/VPNMouseArea.qml
@@ -10,6 +10,7 @@ MouseArea {
 
     property var targetEl: parent
     property var uiState: Theme.uiState
+    property var onMouseAreaClicked: function() { parent.clicked() }
 
     function changeState(stateName) {
         if (mouseArea.hoverEnabled)
@@ -26,7 +27,7 @@ MouseArea {
     onReleased: {
         if (hoverEnabled) {
             changeState(uiState.stateDefault);
-            parent.clicked();
+            onMouseAreaClicked();
         }
     }
 }

--- a/src/ui/components/VPNServerCountry.qml
+++ b/src/ui/components/VPNServerCountry.qml
@@ -25,7 +25,10 @@ VPNClickableRow {
     anchors.right: parent ? parent.right : undefined
     state: cityListVisible ? "list-visible" : "list-hidden"
     width: ListView.view.width
-    onClicked: cityListVisible = !cityListVisible
+
+    Keys.onReleased: if (event.key === Qt.Key_Space) handleKeyClick()
+    handleMouseClick: function() { cityListVisible = !cityListVisible; }
+    handleKeyClick: function() { cityListVisible = !cityListVisible; }
 
     accessibleName: name
 


### PR DESCRIPTION
Prevents clicks to the left of server city names, and clicks to the spacing between server city names, from collapsing the entire city list. 