### PR TITLE
Elide server city names when necessary

### DIFF
--- a/src/ui/components/VPNControllerServer.qml
+++ b/src/ui/components/VPNControllerServer.qml
@@ -29,6 +29,8 @@ VPNClickableRow {
         spacing: 0
 
         VPNIconAndLabel {
+            id: selectLocation
+
             icon: "../resources/connection.svg"
             title: titleText
             Accessible.ignored: true
@@ -39,6 +41,8 @@ VPNClickableRow {
         }
 
         Image {
+            id: flag
+
             Layout.preferredWidth: 16
             Layout.preferredHeight: 16
             Layout.rightMargin: 8
@@ -47,9 +51,13 @@ VPNClickableRow {
         }
 
         VPNLightLabel {
+            id: serverLocation
+
             text: VPNCurrentServer.city
             Layout.rightMargin: 8
             Accessible.ignored: true
+            Layout.maximumWidth: parent.width - selectLocation.width - flag.width - flag.Layout.rightMargin - (Theme.windowMargin * 2.5)
+            elide: Text.ElideRight
         }
 
         VPNChevron {


### PR DESCRIPTION
Elide server city names in the main view when there is not enough space to show the entire name.
Closes #120 
<img width="363" alt="Screen Shot 2020-11-30 at 4 37 13 PM" src="https://user-images.githubusercontent.com/22355127/100674939-9e74d800-332b-11eb-807f-46ac55efabf9.png">

<img width="363" alt="Screen Shot 2020-11-30 at 4 46 29 PM" src="https://user-images.githubusercontent.com/22355127/100674928-99178d80-332b-11eb-8b97-1c2a78a01860.png">