### PR TITLE
Vary iOS top margin height based on device

### DIFF
--- a/src/ui/main.qml
+++ b/src/ui/main.qml
@@ -11,7 +11,7 @@ import "./components"
 Window {
     id: window
 
-    property var safeContentHeight: Qt.platform.os === "ios" ? window.height - iosSafeAreaTopMargin.height : window.height
+    property var safeContentHeight: window.height - iosSafeAreaTopMargin.height
 
     function fullscreenRequired() {
         return Qt.platform.os === "android" ||
@@ -57,9 +57,29 @@ Window {
         id: iosSafeAreaTopMargin
 
         color: "transparent"
-        height: 40
+        height: marginHeightByDevice()
         width: window.width
-        visible: Qt.platform.os === "ios"
+
+        function marginHeightByDevice() {
+            if (Qt.platform.os !== "ios") {
+                return 0;
+            }
+            switch(window.height * Screen.devicePixelRatio) {
+            case 1624: // iPhone_XR (Qt Provided Physical Resolution)
+            case 1792: // iPhone_XR
+
+            case 2436: // iPhone_X_XS
+            case 2688: // iPhone_XS_MAX
+
+            case 2532: // iPhone_12_Pro
+            case 2778: // iPhone_12_Pro_Max
+            case 2340: // iPhone_12_mini
+                return 30;
+            default:
+                return 20;
+            }
+
+        }
     }
 
     VPNStackView {
@@ -67,7 +87,7 @@ Window {
 
         initialItem: mainView
         width: parent.width
-        anchors.top: Qt.platform.os === "ios" ? iosSafeAreaTopMargin.bottom : parent.top
+        anchors.top: iosSafeAreaTopMargin.bottom
         height: safeContentHeight
     }
 


### PR DESCRIPTION
Older iOS devices require less clearance. This varies the height of `iosSafeAreaTopMargin` by device to maintain the layout (prevent it from getting pushed awkwardly downward) on older iOS devices.

**Before  /     After** - Screen caps from iPhone 8 simulator. Note the "Get Help" link in the upper right corner. 
<div>
<img style="display: inline-block" width="200" alt="Screen Shot 2020-12-01 at 4 34 37 PM" src="https://user-images.githubusercontent.com/22355127/100912644-5cb47080-3496-11eb-963e-e761506c6c40.png">
<img style="display: inline-block" width="200" src="https://user-images.githubusercontent.com/22355127/100913115-f845e100-3496-11eb-8b19-b35388fd4bf2.png">
</div>



