### PR TITLE
Fix connection graph layout breakage

### DIFF
--- a/src/ui/components/VPNConnectionInfo.qml
+++ b/src/ui/components/VPNConnectionInfo.qml
@@ -14,6 +14,9 @@ Popup {
 
     height: box.height
     width: box.width
+    padding: 0
+    leftInset: 0
+    rightInset: 0
     modal: true
     focus: true
     closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutsideParent
@@ -40,7 +43,6 @@ Popup {
         property var rBytes: VPNConnectionData.rxBytes
         property var tBytes: VPNConnectionData.txBytes
 
-
         width: box.width
         height: box.height
         antialiasing: true
@@ -50,12 +52,13 @@ Popup {
 
             antialiasing: true
             backgroundColor: "#321C64"
-            width: parent.width + 16
-            height: (parent.height / 2) - 32
+            width: chartWrapper.width
+            height: (chartWrapper.height / 2) - 32
             legend.visible: false
-            anchors.horizontalCenter: parent.horizontalCenter
-            anchors.top: parent.top
+            anchors.horizontalCenter: chartWrapper.horizontalCenter
+            anchors.top: chartWrapper.top
             anchors.topMargin: 48
+            anchors.left: chartWrapper.left
             margins.top: 0
             margins.bottom: 0
             margins.left: 0
@@ -109,7 +112,7 @@ Popup {
 
         VPNBoldLabel {
             anchors.top: parent.top
-            anchors.topMargin: Theme.windowMargin
+            anchors.topMargin: Theme.windowMargin * 1.5
             anchors.left: parent.left
             anchors.right: parent.right
             anchors.horizontalCenter: parent.center
@@ -154,6 +157,8 @@ Popup {
             buttonColorScheme: Theme.iconButtonDarkBackground
             anchors.top: parent.top
             anchors.left: parent.left
+            anchors.topMargin: Theme.windowMargin / 2
+            anchors.leftMargin: Theme.windowMargin / 2
             //% "Close"
             accessibleName: qsTrId("vpn.connectionInfo.close")
 


### PR DESCRIPTION
Fixes #365 - 

I was able to reproduce #365 by removing the `maximumWidth` / `minimumWidth` properties set to the window in main.qml and adjusting the overall window width. After these changes, I can no longer reproduce. 
<img width="654" alt="Screen Shot 2020-12-08 at 4 05 03 PM" src="https://user-images.githubusercontent.com/22355127/101546932-23d13b80-396f-11eb-811e-fbe8a1cc9de2.png">

<img width="303" alt="Screen Shot 2020-12-08 at 3 58 27 PM" src="https://user-images.githubusercontent.com/22355127/101546507-7fe79000-396e-11eb-8d39-726cc338ef93.png">
