### PR TITLE
Reposition error alerts

### DIFF
--- a/src/ui/components/VPNAlert.qml
+++ b/src/ui/components/VPNAlert.qml
@@ -18,7 +18,7 @@ Rectangle {
     color: "transparent"
     height: Math.max(40, (labelWrapper.height + Theme.windowMargin))
     width: parent.width - Theme.windowMargin
-    y: window.fullscreenRequired() ? parent.height - 80 : parent.height - 48
+    y: fullscreenRequired()? iosSafeAreaTopMargin.height + Theme.windowMargin : Theme.windowMargin
     anchors.horizontalCenter: parent.horizontalCenter
     anchors.margins: Theme.windowMargin / 2
     radius: Theme.cornerRadius


### PR DESCRIPTION
Fixes part 1 of #347 

This moves error message from the bottom of the window to the top. There will be additional work to eventually nest these in the layout like the update alerts but not before V2.

<img width="377" alt="Screen Shot 2020-12-07 at 12 51 27 PM" src="https://user-images.githubusercontent.com/22355127/101547383-c2f63300-396f-11eb-9344-a1d9d2b0d3e0.png">
