### PR TITLE
Add debug->debug android app migration path

### DIFF
--- a/src/platforms/android/androiddatamigration.cpp
+++ b/src/platforms/android/androiddatamigration.cpp
@@ -22,8 +22,11 @@
 
 namespace {
 Logger logger(LOG_ANDROID, "AndroidDataMigration");
+#ifdef QT_DEBUG
+const QString MIGRATION_FILE = "org.mozilla.firefox.vpn.debug_preferences.xml";
+#else
 const QString MIGRATION_FILE = "org.mozilla.firefox.vpn.preferences.xml";
-
+#endif
 void importDeviceInfo() {
   QVariant prefValue =
       AndroidSharedPrefs::GetValue(MIGRATION_FILE, "pref_current_device");

--- a/src/platforms/android/androidsharedprefs.cpp
+++ b/src/platforms/android/androidsharedprefs.cpp
@@ -14,8 +14,13 @@
 namespace {
 Logger logger(LOG_ANDROID, "AndroidSharedPrefs");
 
+#ifdef QT_DEBUG
+const QString SHARED_PREF_FOLDER =
+    "/data/data/org.mozilla.firefox.vpn.debug/shared_prefs";
+#else
 const QString SHARED_PREF_FOLDER =
     "/data/data/org.mozilla.firefox.vpn/shared_prefs";
+#endif
 }  // namespace
 
 AndroidSharedPrefs::AndroidSharedPrefs() {


### PR DESCRIPTION
We're currently only looking at the release shared-pref. This makes testing the migration require a release->release upgrade.
Lets use the debug shared-pref on debug, so QA can test migration from a debug 1.3 version to 2.0 debug apk