### PR TITLE
Force use of mullvad dns on android 

### DIFF
--- a/android/src/com/mozilla/vpn/VPNServiceBinder.kt
+++ b/android/src/com/mozilla/vpn/VPNServiceBinder.kt
@@ -246,7 +246,7 @@ class VPNServiceBinder(service: VPNService) : Binder() {
         ifaceBuilder.parsePrivateKey(privateKey)
         ifaceBuilder.addAddress(InetNetwork.parse(jDevice.getString("ipv4Address")))
         ifaceBuilder.addAddress(InetNetwork.parse(jDevice.getString("ipv6Address")))
-        
+        ifaceBuilder.addDnsServer(InetNetwork.parse(jServer.getString("ipv4Gateway")).address)
         val jExcludedApplication = obj.getJSONArray("excludedApps");
         (0 until jExcludedApplication.length()).toList().forEach {
             val appName = jExcludedApplication.get(it).toString();


### PR DESCRIPTION
Just noticed mullvad/check said we're not using the mullvad dns on android.