### PR TITLE
WIP: Detect too old WebViews

### DIFF
--- a/android/src/com/mozilla/vpn/BootReceiver.kt
+++ b/android/src/com/mozilla/vpn/BootReceiver.kt
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package com.mozilla.vpn
+package org.mozilla.firefox.vpn
 
 import android.content.BroadcastReceiver
 import android.content.Context

--- a/android/src/com/mozilla/vpn/VPNWebView.java
+++ b/android/src/com/mozilla/vpn/VPNWebView.java
@@ -6,8 +6,11 @@ package org.mozilla.firefox.vpn;
 
 import android.app.Activity;
 import android.content.Intent;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
 import android.graphics.Bitmap;
 import android.net.Uri;
+import android.os.Build;
 import android.os.RemoteException;
 import android.webkit.URLUtil;
 import android.webkit.WebSettings;
@@ -22,6 +25,7 @@ import com.android.installreferrer.api.ReferrerDetails;
 
 import java.lang.Runnable;
 import java.lang.String;
+import java.util.Date;
 import java.util.concurrent.Semaphore;
 
 public class VPNWebView
@@ -78,6 +82,8 @@ public class VPNWebView
             public void run() {
                 m_webView = new WebView(m_activity);
                 WebSettings webSettings = m_webView.getSettings();
+
+                Log.e(TAG, "UA" + webSettings.getUserAgentString());
 
                 webSettings.setAllowFileAccess(false);
                 webSettings.setDatabaseEnabled(true);

--- a/src/platforms/android/androidauthenticationlistener.h
+++ b/src/platforms/android/androidauthenticationlistener.h
@@ -6,8 +6,6 @@
 #define ANDROIDAUTHENTICATIONLISTENER_H
 
 #include "authenticationlistener.h"
-#include "tasks/authenticate/desktopauthenticationlistener.h"
-
 #include <QObject>
 
 class AndroidAuthenticationListener final : public AuthenticationListener {
@@ -19,8 +17,6 @@ class AndroidAuthenticationListener final : public AuthenticationListener {
 
   void start(MozillaVPN* vpn, QUrl& url, QUrlQuery& query) override;
 
- private:
-  DesktopAuthenticationListener* m_legacyAuth;
 };
 
 #endif  // ANDROIDAUTHENTICATIONLISTENER_H

--- a/src/platforms/android/androidauthenticationlistener.h
+++ b/src/platforms/android/androidauthenticationlistener.h
@@ -6,6 +6,7 @@
 #define ANDROIDAUTHENTICATIONLISTENER_H
 
 #include "authenticationlistener.h"
+#include "tasks/authenticate/desktopauthenticationlistener.h"
 
 #include <QObject>
 
@@ -17,6 +18,9 @@ class AndroidAuthenticationListener final : public AuthenticationListener {
   ~AndroidAuthenticationListener();
 
   void start(MozillaVPN* vpn, QUrl& url, QUrlQuery& query) override;
+
+ private:
+  DesktopAuthenticationListener* m_legacyAuth;
 };
 
 #endif  // ANDROIDAUTHENTICATIONLISTENER_H

--- a/src/platforms/android/androidauthenticationlistener.h
+++ b/src/platforms/android/androidauthenticationlistener.h
@@ -16,7 +16,6 @@ class AndroidAuthenticationListener final : public AuthenticationListener {
   ~AndroidAuthenticationListener();
 
   void start(MozillaVPN* vpn, QUrl& url, QUrlQuery& query) override;
-
 };
 
 #endif  // ANDROIDAUTHENTICATIONLISTENER_H

--- a/src/src.pro
+++ b/src/src.pro
@@ -323,7 +323,9 @@ else:android {
                 platforms/android/androiddatamigration.cpp \
                 platforms/android/androidappimageprovider.cpp \
                 platforms/android/androidapplistprovider.cpp \
-                platforms/android/androidsharedprefs.cpp
+                platforms/android/androidsharedprefs.cpp \
+                tasks/authenticate/desktopauthenticationlistener.cpp
+
     HEADERS +=  platforms/android/androidauthenticationlistener.h \
                 platforms/android/androidcontroller.h \
                 platforms/android/androidnotificationhandler.h \
@@ -333,7 +335,8 @@ else:android {
                 platforms/android/androiddatamigration.h\
                 platforms/android/androidappimageprovider.h \
                 platforms/android/androidapplistprovider.h \
-                platforms/android/androidsharedprefs.h
+                platforms/android/androidsharedprefs.h \
+                tasks/authenticate/desktopauthenticationlistener.h
 
     # Usable Linux Imports
     SOURCES += platforms/linux/linuxpingsendworker.cpp \


### PR DESCRIPTION
This is an idea i came up to handle #344. 
Even though i think it's unlikely that a user on a real device that has the play store will encounter this, a fallback is always good.
So what i try to do here is to detect old webviews and then use the DesktopAuth. 
In that case we would open the users default browser instead of a webview, which hopefully is way newer. 
Currently the user would need to navigate back to the app by hand, but still this is way better then not beeing able to login in at all.
