### PR TITLE
Make city list visible when a country list item is expanded

### DIFF
--- a/src/ui/components/VPNServerCountry.qml
+++ b/src/ui/components/VPNServerCountry.qml
@@ -26,9 +26,20 @@ VPNClickableRow {
     state: cityListVisible ? "list-visible" : "list-hidden"
     width: ListView.view.width
 
+    function openCityList() {
+        cityListVisible = !cityListVisible;
+        const itemDistanceFromWindowTop = serverCountry.mapToItem(null, 0, 0).y;
+        const listScrollPosition = serverList.contentY
+        if (itemDistanceFromWindowTop + cityList.height < serverList.height || !cityListVisible) {
+            return;
+        }
+        scrollList.to = (cityList.height > serverList.height) ? listScrollPosition + itemDistanceFromWindowTop - Theme.rowHeight * 1.5 : listScrollPosition + cityList.height + (Theme.windowMargin / 2);
+        scrollList.start();
+    }
+
     Keys.onReleased: if (event.key === Qt.Key_Space) handleKeyClick()
-    handleMouseClick: function() { cityListVisible = !cityListVisible; }
-    handleKeyClick: function() { cityListVisible = !cityListVisible; }
+    handleMouseClick: openCityList
+    handleKeyClick: openCityList
     clip: true
 
     Behavior on y {

--- a/src/ui/views/ViewServers.qml
+++ b/src/ui/views/ViewServers.qml
@@ -54,6 +54,14 @@ Item {
             width: serverList.width
         }
 
+        NumberAnimation {
+            id: scrollList
+            target: serverList
+            property: "contentY"
+            to: 0 //Dummy value - will be set up when this animation is called.
+            duration: 300
+        }
+
         Component.onCompleted: {
             for (let idx = 0; idx < serverList.count; idx++) {
                 if (delegateModel.items.get(idx).model.code === VPNCurrentServer.countryCode) {


### PR DESCRIPTION
This scrolls a city list into view when it's parent country item is expanded but the city list isn't totally visible. 
