### PR TITLE
Android 5&6 : Fix Start On Boot

### DIFF
--- a/android/src/com/mozilla/vpn/VPNService.kt
+++ b/android/src/com/mozilla/vpn/VPNService.kt
@@ -74,7 +74,15 @@ class VPNService : android.net.VpnService() {
             }
             this.mConfig = mBinder?.buildConfigFromJSON(lastConfString)
         }
-        turnOn(this.mConfig)
+        val connected = turnOn(this.mConfig)
+        // Try to send a status update to QT
+        mBinder?.let { 
+            if(connected){
+                it.dispatchEvent(VPNServiceBinder.EVENTS.connected, "")
+            }else{
+                it.dispatchEvent(VPNServiceBinder.EVENTS.disconnected, "")
+            }
+        }
         return Service.START_NOT_STICKY
     }
 

--- a/android/src/com/mozilla/vpn/VPNServiceBinder.kt
+++ b/android/src/com/mozilla/vpn/VPNServiceBinder.kt
@@ -153,8 +153,9 @@ class VPNServiceBinder(service: VPNService) : Binder() {
 
             }
             ACTIONS.enableStartOnBoot ->{
-                // Sets the Start on boot pref data is here a QVariant Byte
-                val buffer = data.createByteArray() // there is no byte.toBool?
+                // Sets the Start on boot pref data is here a Byte Array with length 1
+                // and the byte is a boolean
+                val buffer = data.createByteArray()
                 if(buffer == null){return true;}
                 val startOnBootEnabled = buffer.get(0) != 0.toByte();
                 val prefs = mService.getSharedPreferences("com.mozilla.vpn.prefrences", Context.MODE_PRIVATE);

--- a/android/src/com/mozilla/vpn/VPNServiceBinder.kt
+++ b/android/src/com/mozilla/vpn/VPNServiceBinder.kt
@@ -154,11 +154,12 @@ class VPNServiceBinder(service: VPNService) : Binder() {
             }
             ACTIONS.enableStartOnBoot ->{
                 // Sets the Start on boot pref data is here a QVariant Byte
-                val startOnBootEnabled = data.readByte().equals(true) // there is no byte.toBool?
-                Log.v(tag,"Set ServicePref Start on boot to -> $startOnBootEnabled")
+                val buffer = data.createByteArray() // there is no byte.toBool?
+                if(buffer == null){return true;}
+                val startOnBootEnabled = buffer.get(0) != 0.toByte();
                 val prefs = mService.getSharedPreferences("com.mozilla.vpn.prefrences", Context.MODE_PRIVATE);
                 prefs.edit()
-                    .putBoolean("startOnBoot",startOnBootEnabled)
+                    .putBoolean("startOnBoot", startOnBootEnabled )
                     .apply()
             }
 
@@ -190,7 +191,7 @@ class VPNServiceBinder(service: VPNService) : Binder() {
      * To register an Eventhandler use [onTransact] with
      * [ACTIONS.registerEventListener]
      */
-    private fun dispatchEvent(code: Int, payload: String) {
+    fun dispatchEvent(code: Int, payload: String) {
         mListeners.forEach {
            if (it.isBinderAlive) {
                val data = Parcel.obtain()

--- a/src/platforms/android/androidcontroller.cpp
+++ b/src/platforms/android/androidcontroller.cpp
@@ -90,11 +90,8 @@ void AndroidController::initialize(const Device* device, const Keys* keys) {
 }
 
 void AndroidController::enableStartAtBoot(bool enabled) {
-  if (!m_serviceConnected) {
-    return;
-  }
   QAndroidParcel data;
-  data.writeVariant(enabled);
+  data.writeData(QByteArray(1, enabled));
   m_serviceBinder.transact(ACTION_ENABLE_START_ON_BOOT, data, nullptr);
 }
 


### PR DESCRIPTION
- The the pref would never transfer to VPNService since reading the QVariant did not properly work in Kotlin
- Without Preloading the Backend, the Android Scheudler might drop loading the Service as a whole because of cpu pressure 
- Also we're now propagating a vpn state change to the frontend (if loaded) - in case the system starts the vpn :) 
- Also more logs