### PR TITLE
Fix small UX issues in AppPermission

### DIFF
--- a/src/ui/components/VPNCheckBoxRow.qml
+++ b/src/ui/components/VPNCheckBoxRow.qml
@@ -19,6 +19,7 @@ RowLayout {
     property bool showDivider: true
     property var iconURL: ""
     property var leftMargin: 18
+    property var subLabelWrapMode: Text.WrapAnywhere
 
     signal clicked()
     spacing: 0
@@ -65,6 +66,7 @@ RowLayout {
             Layout.fillWidth: true
             text: subLabelText
             visible: !!subLabelText.length
+            wrapMode: subLabelWrapMode
         }
 
         Rectangle {

--- a/src/ui/components/VPNExpandableAppList.qml
+++ b/src/ui/components/VPNExpandableAppList.qml
@@ -22,7 +22,6 @@ ColumnLayout{
     property var isListVisible : true && applist.count > 0
     opacity: isEnabled ? 1 : 0.5
     property var isActionEnabled: isEnabled && applist.count > 0
-    height: appRowHeader.height + (isListVisible  ? applist.height + defaultMargin : 0)
 
     VPNClickableRow {
         id: appRow
@@ -32,14 +31,15 @@ ColumnLayout{
         clip: true
         canGrowVertical: true
         accessibleName: name
-        width: parent.width
+        Layout.preferredWidth: parent.width - Theme.windowMargin
         height: appRowHeader.height
-        Layout.preferredHeight: appRowHeader.height
+        Layout.preferredHeight: Theme.rowHeight * 1.5
 
 
         RowLayout {
             id: appRowHeader
-            width: appListContainer.width
+            width: parent.width
+            anchors.centerIn: parent
             spacing: 0
 
             VPNIcon {
@@ -98,12 +98,11 @@ ColumnLayout{
     VPNList {
         id: applist
         model: listModel
-        width: appListContainer.width
-        height: contentItem.childrenRect.height
+        Layout.fillWidth: true
         spacing: 26
         listName: header
 
-        Layout.preferredHeight: height
+        Layout.preferredHeight: contentItem.childrenRect.height
         Layout.topMargin: defaultMargin
 
         visible: isListVisible
@@ -116,7 +115,7 @@ ColumnLayout{
             showDivider:false
             onClicked: VPNAppPermissions.flip(appID)
             visible: true
-            width: applist.width - leftMargin
+            width: parent.width
             anchors.left: parent.left
             anchors.topMargin: defaultMargin
             leftMargin:defaultMargin


### PR DESCRIPTION
Hello! I've changed a few small things in the AppPermission that came up:

- The List is no longer child of VPNClickableRow
-> Otherwise if you fat finger in the list anything other than the checkbox, the list will close (which is probably not good)



- The Action Button (unprotect all etc) is hidden if the list is empty
-> Since it doesn't do anything if the list is empty we might also just hide it

- Disable Word Wrapping for the App PackageID
-> Some apps have very long package names, with wrapping the list element would grow and look janky :(, I've disabled word wrapping - its i guess not that important for the user, unlike the App Name. 

let me know what you think :) 


New Screen attached : 
![Screenshot (06 01](https://user-images.githubusercontent.com/9611612/103796424-74f44e00-5047-11eb-8180-f7f4f9da5d22.png)
