### PR TITLE
Change MigrationFile Name for prod

### DIFF
--- a/src/platforms/android/androiddatamigration.cpp
+++ b/src/platforms/android/androiddatamigration.cpp
@@ -25,7 +25,7 @@ Logger logger(LOG_ANDROID, "AndroidDataMigration");
 #ifdef QT_DEBUG
 const QString MIGRATION_FILE = "org.mozilla.firefox.vpn.debug_preferences.xml";
 #else
-const QString MIGRATION_FILE = "org.mozilla.firefox.vpn.preferences.xml";
+const QString MIGRATION_FILE = "org.mozilla.firefox.vpn_preferences.xml";
 #endif
 void importDeviceInfo() {
   QVariant prefValue =


### PR DESCRIPTION
From my Android Logs - it seems the prod-migration fail was caused by the name beeing wrong
```
[12.01.2021 14:31:04.903] (android - AndroidDataMigration) Android Data Migration -- Start
[12.01.2021 14:31:04.904] (android - AndroidDataMigration) Migration org.mozilla.firefox.vpn.preferences.xml was not file found - skip
[12.01.2021 14:31:04.904] (android - AndroidDataMigration) Migration files:  [.,..,org.mozilla.firefox.vpn_preferences.xml]
[12.01.2021 14:31:04.904] (main - SettingsHolder) Setting nativeAndroidDataMigrated
```