### PR TITLE
Android: Also Support x86 64 abi

### DIFF
--- a/src/src.pro
+++ b/src/src.pro
@@ -351,7 +351,7 @@ else:android {
 
     DEFINES += MVPN_ANDROID
 
-    ANDROID_ABIS = x86 armeabi-v7a arm64-v8a
+    ANDROID_ABIS = x86 x86_64 armeabi-v7a arm64-v8a
 
     INCLUDEPATH += platforms/android
 


### PR DESCRIPTION
While not really relevant on android, x86_64 is  very relevant on Chrome OS. 
Users that have an x86_64 abi currently just experience a crash. "A fatal error... and the app cannot continue etc" 

