### PR TITLE
Nit: "Hide" settings list scrollbar during stack transitions

### DIFF
--- a/src/ui/components/VPNFlickable.qml
+++ b/src/ui/components/VPNFlickable.qml
@@ -12,6 +12,7 @@ Flickable {
 
     property var flickContentHeight
     property var windowHeightExceedsContentHeight: (window.safeContentHeight > flickContentHeight)
+    property bool hideScollBarOnStackTransition: false
 
     function ensureVisible(item) {
         if (windowHeightExceedsContentHeight) {
@@ -49,6 +50,12 @@ Flickable {
     ScrollBar.vertical: ScrollBar {
         policy: windowHeightExceedsContentHeight ? ScrollBar.AlwaysOff : ScrollBar.AlwaysOn
         Accessible.ignored: true
+        opacity: hideScollBarOnStackTransition && (vpnFlickable.StackView.status !== StackView.Active) ? 0 : 1
+        Behavior on opacity {
+            PropertyAnimation {
+                duration: 100
+            }
+        }
     }
 
 }

--- a/src/ui/settings/ViewSettingsMenu.qml
+++ b/src/ui/settings/ViewSettingsMenu.qml
@@ -14,6 +14,8 @@ VPNFlickable {
 
     width: window.width
     flickContentHeight: settingsList.y + (settingsList.count * 56) + signOutLink.height + signOutLink.anchors.bottomMargin
+    hideScollBarOnStackTransition: true
+
     ListModel {
         id: settingsMenuListModel
 


### PR DESCRIPTION
This reduces the opacity of the scrollbar only when the the settings list StackView is transitioning between views. 