### PR TITLE
Stop the animated-circles when not visible or navigating

### DIFF
--- a/src/ui/components/VPNAnimatedRings.qml
+++ b/src/ui/components/VPNAnimatedRings.qml
@@ -15,6 +15,29 @@ Rectangle {
 
     property var yCenter: logo.y + 40 - 1
     property bool startAnimation: false
+    property bool isCurrentyVisible: true
+    property bool canRender:true
+
+    property var animationPuffer: 0
+    onIsCurrentyVisibleChanged: {
+        // In case we got Visible, start a delay-timer
+        // so that we switch canRender to true after 300ms.
+        // - Otherwise this animation will require Draw-Cycles
+        // that might be needed for the pan-navigation-animation.
+        if(isCurrentyVisible){
+            canRenderTimer.start();
+            return;
+        }
+        canRender=false;
+    }
+
+    Timer {
+        interval: 300
+        id: canRenderTimer
+        running: false
+        repeat: false
+        onTriggered: { canRender = true;}
+    }
 
     onStartAnimationChanged: animatedRings.requestPaint()
     anchors.fill: box
@@ -84,6 +107,9 @@ Rectangle {
         }
 
         function animateRings() {
+            if(!canRender){
+                return;
+            }
             updateRing1();
             if (drawingRing2)
                 updateRing2();
@@ -127,6 +153,10 @@ Rectangle {
         renderStrategy: Canvas.Threaded
         contextType: "2d"
         onPaint: {
+            // Dont paint if not needed
+            if(!canRender){
+                return
+            }
             let ctx = getContext("2d");
             ctx.reset();
             if (!animatedRingsWrapper.startAnimation) {

--- a/src/ui/components/VPNControllerView.qml
+++ b/src/ui/components/VPNControllerView.qml
@@ -499,6 +499,7 @@ Rectangle {
 
     VPNAnimatedRings {
         id: animatedRingsWrapper
+        isCurrentyVisible: stackview.depth === 1
     }
 
     VPNMainImage {


### PR DESCRIPTION
Hello! About #445 - I've had the idea that we might freeze the ring-animation when we navigate to another page and wait a bit when navigating back.
So devices that are already struggling with the ring animation (Like my pixel) have GPU time for the navigation animations. That makes it way smother to navigate to languages/devices while connected
Let me know what you think :)