### PR TITLE
Build also ABI-Splitted apk's for release

### DIFF
--- a/.github/workflows/android.yaml
+++ b/.github/workflows/android.yaml
@@ -105,7 +105,7 @@ jobs:
         uses: actions/upload-artifact@v1
         with:
             name: production-release
-            path: .tmp/src/android-build/build/outputs/apk/release/android-build-release-unsigned.apk
+            path: .tmp/src/android-build/build/outputs/apk/release/android-build-universal-release-unsigned.apk
 
   android-staging-debug:
     runs-on: ubuntu-20.04

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -45,6 +45,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 
+
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar', '*.aar'])
     implementation 'androidx.core:core-ktx:1.1.0'
@@ -70,6 +71,10 @@ android {
     compileSdkVersion androidCompileSdkVersion.toInteger()
 
     buildToolsVersion '28.0.3'
+
+    dexOptions {
+       javaMaxHeapSize "3g"
+    }
 
     sourceSets {
         main {
@@ -108,12 +113,45 @@ android {
         resConfig "en"
         minSdkVersion 21
         targetSdkVersion 30
-        versionCode System.getenv("VERSIONCODE").toInteger()
-        versionName System.getenv("SHORTVERSION")
+        versionCode  System.getenv("VERSIONCODE").toInteger()
+        versionName  System.getenv("SHORTVERSION")
     }
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
         coreLibraryDesugaringEnabled = true
     }
+    splits {
+                // Configures multiple APKs based on ABI.
+                abi {
+                    if(System.getenv("SPLITAPK")== "1" ){
+                        enable true
+                        // Resets the list of ABIs that Gradle should create APKs for to none.
+                        reset()
+
+                        // Specifies a list of ABIs that Gradle should create APKs for.
+                        include "x86", "armeabi-v7a", "arm64-v8a", "x86_64"
+                        // Also generate one universal apk that contains all abi's
+                        universalApk true
+                    }else{
+                        enable false
+                    }
+                }
+            }
+
 }
+
+import com.android.build.OutputFile
+// Map for the version code that gives each ABI a value.
+ext.abiCodes = ['armeabi-v7a':1,"arm64-v8a":2, x86:3, x86_64:4]
+android.applicationVariants.all { variant ->
+  // Assigns a different version code for each output APK
+  // other than the universal APK.
+  variant.outputs.each { output ->
+    def baseAbiVersionCode = project.ext.abiCodes.get(output.getFilter(OutputFile.ABI))
+    if (baseAbiVersionCode != null) {
+      output.versionCodeOverride =
+              baseAbiVersionCode + variant.versionCode
+    }
+  }
+} 

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -6,7 +6,7 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-#org.gradle.jvmargs=-Xmx1536m
+org.gradle.jvmargs=-Xmx3g
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects

--- a/scripts/android_package.sh
+++ b/scripts/android_package.sh
@@ -13,6 +13,7 @@ JOBS=8
 QTPATH=
 RELEASE=1
 PROD=
+export SPLITAPK=0
 
 helpFunction() {
   print G "Usage:"
@@ -180,12 +181,11 @@ print N "Your debug .APK is Located in .tmp/src/android-build/mozillavpn.apk"
 # also compile the java/kotlin code in release mode
 if [[ "$RELEASE" ]]; then
   print Y "Generating Release APK..."
+  export SPLITAPK=1
   cd android-build
   ./gradlew compileReleaseSources
   ./gradlew assemble
-  ./gradlew bundleRelease
 
   print G "Done 🎉"
-  print G "Your Release APK is under .tmp/src/android-build/build/outputs/apk/release/android-build-release-unsigned.apk"
-  print G "Your Release AAB is under .tmp/src/android-build/build/outputs/bundle/release/android-build-release.aab"
+  print G "Your Release APK is under .tmp/src/android-build/build/outputs/apk/release/android-build-universal-release-unsigned.apk"
 fi


### PR DESCRIPTION
Closes #459 - Whilst nothing we should try in 2.0.x, i think this is a neat thing for the next release.
This adds abi- splitted apk's in addition to our (current) universal apk. They are way smaller, 20mb vs 80mb (universal).
I followed https://developer.android.com/google/play/publishing/multiple-apks
