### PR TITLE
Use Timestamp to calculate the android version code

### DIFF
--- a/scripts/android_package.sh
+++ b/scripts/android_package.sh
@@ -119,7 +119,7 @@ python3 scripts/importLanguages.py $([[ "$PROD" ]] && echo "-p" || echo "") || d
 
 printn Y "Computing the version... "
 export SHORTVERSION=$(cat version.pri | grep VERSION | grep defined | cut -d= -f2 | tr -d \ ) # Export so gradle can pick it up
-export VERSIONCODE=$(echo $SHORTVERSION| tr -d .)"0"
+export VERSIONCODE=$(date +%s | sed 's/.\{3\}$//' )"0" #Remove the last 3 digits of the timestamp, so we only get every ~16m a new versioncode
 FULLVERSION=$SHORTVERSION.$(date +"%Y%m%d%H%M")
 print G "$SHORTVERSION - $FULLVERSION - $VERSIONCODE"
 print Y "Configuring the android build"


### PR DESCRIPTION
Lets change the android version code to use something time based instead of our real version, so we dont have to bump it every time we we want to test on google play. 
the $Fullversion is sadly too big. We have a max versioncode of 2 100 000 000. With just a UNIX timestamp we would burn all codes out in ~15 years. So my idea is to cut of the last ~16 minutes of the timestamp, which adds more then enough time before the codes burn out. 