### PR TITLE
Wrap exceedingly long words (or display names) anywhere.

### DIFF
--- a/src/ui/components/VPNHeadline.qml
+++ b/src/ui/components/VPNHeadline.qml
@@ -11,7 +11,7 @@ import "../themes/themes.js" as Theme
 Text {
     horizontalAlignment: Text.AlignHCenter
     verticalAlignment: Text.AlignVCenter
-    wrapMode: Text.WordWrap
+    wrapMode: Text.WrapAtWordBoundaryOrAnywhere
     width: Theme.maxTextWidth
     color: Theme.fontColorDark
     font.family: Theme.fontFamily

--- a/src/ui/components/VPNPanel.qml
+++ b/src/ui/components/VPNPanel.qml
@@ -85,6 +85,12 @@ ColumnLayout {
             Layout.topMargin: 12
             Layout.fillWidth: true
             wrapMode: Text.WordWrap
+            onLineLaidOut: {
+                if (text.indexOf(" ") > 0)
+                    return;
+                if (line.implicitWidth > panel.width)
+                    wrapMode = Text.WrapAnywhere
+            }
         }
 
     }

--- a/src/ui/components/VPNPanel.qml
+++ b/src/ui/components/VPNPanel.qml
@@ -75,7 +75,6 @@ ColumnLayout {
             Layout.alignment: Qt.AlignHCenter
             Layout.topMargin: 24
             Layout.fillWidth: true
-            wrapMode: Text.WordWrap
         }
 
         VPNSubtitle {
@@ -84,13 +83,6 @@ ColumnLayout {
             Layout.alignment: Qt.AlignHCenter
             Layout.topMargin: 12
             Layout.fillWidth: true
-            wrapMode: Text.WordWrap
-            onLineLaidOut: {
-                if (text.indexOf(" ") > 0)
-                    return;
-                if (line.implicitWidth > panel.width)
-                    wrapMode = Text.WrapAnywhere
-            }
         }
 
     }


### PR DESCRIPTION
<img width="367" alt="Screen Shot 2021-01-19 at 10 40 46 AM" src="https://user-images.githubusercontent.com/22355127/105197696-7e2ef180-5b02-11eb-8cf8-0a3f2f77693a.png">
Fixes #480 