### PR TITLE
Add linked OpenSSL

### DIFF
--- a/scripts/qt5_compile.bat
+++ b/scripts/qt5_compile.bat
@@ -69,7 +69,7 @@ IF NOT EXIST configure.bat (
   EXIT /B 1
 )
 
-configure -static -opensource -release -no-dbus -no-feature-qdbus -confirm-license -strip -silent -no-compile-examples -nomake tests -make libs -no-sql-psql -no-sql-sqlite -skip qt3d -skip webengine -skip qtmultimedia -skip qtserialport -skip qtsensors -skip qtwebsockets -skip qtgamepad -skip qtwebchannel -skip qtandroidextras -feature-imageformat_png -qt-libpng -qt-zlib -recheck-all -openssl -I c:\MozillaVPNBuild\include -L c:\MozillaVPNBuild\lib -prefix c:\MozillaVPNBuild
+configure -static -opensource -release -no-dbus -no-feature-qdbus -confirm-license -strip -silent -no-compile-examples -nomake tests -make libs -no-sql-psql -no-sql-sqlite -skip qt3d -skip webengine -skip qtmultimedia -skip qtserialport -skip qtsensors -skip qtwebsockets -skip qtgamepad -skip qtwebchannel -skip qtandroidextras -feature-imageformat_png -qt-libpng -qt-zlib -recheck-all -openssl -openssl-linked -I c:\MozillaVPNBuild\include -L c:\MozillaVPNBuild\lib -prefix c:\MozillaVPNBuild
 IF %ERRORLEVEL% NEQ 0 (
   ECHO Failed to configure QT5.
   EXIT /B 1


### PR DESCRIPTION
We also need to specify that we want openssl linked. `By default, an SSL-enabled Qt library dynamically loads any installed OpenSSL library at run-time.`
This is probably why ssl only works in your git shell. With this flag, explorer and cmd also run fine :) 