### PR TITLE
Add All release APK's to the Artifact

### DIFF
--- a/.github/workflows/android.yaml
+++ b/.github/workflows/android.yaml
@@ -105,7 +105,7 @@ jobs:
         uses: actions/upload-artifact@v1
         with:
             name: production-release
-            path: .tmp/src/android-build/build/outputs/apk/release/android-build-universal-release-unsigned.apk
+            path: .tmp/src/android-build/build/outputs/apk/release/
 
   android-staging-debug:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
This should add all the diffrent arches, let's see what the ci gets :) 
- Works, prod-release artifact has them all now :)