### PR TITLE
Word wrap by default for VPNCheckBoxRow

### DIFF
--- a/src/ui/components/VPNCheckBoxRow.qml
+++ b/src/ui/components/VPNCheckBoxRow.qml
@@ -19,7 +19,7 @@ RowLayout {
     property bool showDivider: true
     property var iconURL: ""
     property var leftMargin: 18
-    property var subLabelWrapMode: Text.WrapAnywhere
+    property var subLabelWrapMode: Text.WordWrap
 
     signal clicked()
     spacing: 0


### PR DESCRIPTION
On windows, without this change, the network settings will be wrapped in this way:

![image](https://user-images.githubusercontent.com/515957/105999037-857b6f80-60ad-11eb-92ba-add1c87804b1.png)


I could change the wrapping for the settings only, but why wrapAnywhere? @lesleyjanenorton let me know what you think.