### PR TITLE
Android isolate qt

### DIFF
--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -28,6 +28,7 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
         <activity
             android:configChanges="orientation|uiMode|screenLayout|screenSize|smallestScreenSize|layoutDirection|locale|fontScale|keyboard|keyboardHidden|navigation|mcc|mnc|density"
             android:name="org.qtproject.qt5.android.bindings.QtActivity"
+            android:process=":QtOnlyProcess"
             android:label="Mozilla VPN"
             android:screenOrientation="unspecified"
             android:theme="@style/AppTheme.Splash"
@@ -100,13 +101,16 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
             <meta-data android:name="android.app.extract_android_style" android:value="default" />
             <!-- extract android style -->
         </activity>
-        <!-- For adding service(s) please check: https://wiki.qt.io/AndroidServices -->
+        <!-- For adding service(s) please check: https://wiki.qt.io/AndroidServices-->
         <service android:name=".VPNService"
-            android:process=":ServiceProcess"
             android:permission="android.permission.BIND_VPN_SERVICE">
             <intent-filter>
                 <action android:name="android.net.VpnService"/>
             </intent-filter>
+        </service>
+        <service android:name=".VPNPermissionHelper"
+            android:process=":QtOnlyProcess"
+            android:permission="android.permission.BIND_VPN_SERVICE">
         </service>
         <receiver android:name=".BootReceiver">
             <intent-filter>

--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -102,6 +102,7 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
         </activity>
         <!-- For adding service(s) please check: https://wiki.qt.io/AndroidServices -->
         <service android:name=".VPNService"
+            android:process=":ServiceProcess"
             android:permission="android.permission.BIND_VPN_SERVICE">
             <intent-filter>
                 <action android:name="android.net.VpnService"/>

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -50,6 +50,7 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar', '*.aar'])
     implementation 'androidx.core:core-ktx:1.1.0'
     implementation 'com.android.installreferrer:installreferrer:1.1'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.2'
     implementation 'com.wireguard.android:tunnel:1.0.20200927'
     coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:1.0.10"
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -50,7 +50,6 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar', '*.aar'])
     implementation 'androidx.core:core-ktx:1.1.0'
     implementation 'com.android.installreferrer:installreferrer:1.1'
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.2'
     implementation 'com.wireguard.android:tunnel:1.0.20200927'
     coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:1.0.10"
 }

--- a/android/src/com/mozilla/vpn/VPNPermissionHelper.kt
+++ b/android/src/com/mozilla/vpn/VPNPermissionHelper.kt
@@ -1,0 +1,39 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+
+package org.mozilla.firefox.vpn
+
+import android.content.Context
+import android.content.Intent
+
+class VPNPermissionHelper : android.net.VpnService() {
+    /**
+     * This small service does nothing else then checking if the vpn permission
+     * is present and prompting if not.
+     */
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        val intent = prepare(this.applicationContext);
+        if(intent != null){
+            startActivityForResult(intent)
+        }
+        return START_NOT_STICKY;
+    }
+
+    companion object{
+        @JvmStatic
+        fun startService(c : Context) {
+            val appC = c.applicationContext;
+            appC.startService(Intent(appC,VPNPermissionHelper::class.java))
+        }
+    }
+
+
+    /**
+     * Fetches the Global QTAndroidActivity and calls startActivityForResult with the given intent
+     * Is used to request the VPN-Permission, if not given.
+     * Actually Implemented in src/platforms/android/AndroidController.cpp
+     */
+    external fun startActivityForResult(i: Intent)
+}

--- a/android/src/com/mozilla/vpn/VPNServiceBinder.kt
+++ b/android/src/com/mozilla/vpn/VPNServiceBinder.kt
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.firefox.vpn
-import kotlinx.coroutines.*
 import android.content.Context
 import android.os.Binder
 import android.os.IBinder
@@ -78,7 +77,6 @@ class VPNServiceBinder(service: VPNService) : Binder() {
                     }
                     this.mService.turnOn(config)
                 } catch (e: Exception) {
-
                     Log.e(tag, "An Error occurred while enabling the VPN: ${e.localizedMessage}")
                 }
                 return true
@@ -87,9 +85,6 @@ class VPNServiceBinder(service: VPNService) : Binder() {
             ACTIONS.resumeActivate -> {
                 // [data] is empty
                 // Activate the current tunnel
-                if(!mService.checkPermissions()){
-                    return true;
-                }
                 try{
                     this.mService.turnOn(mResumeConfig)
                 }
@@ -109,11 +104,10 @@ class VPNServiceBinder(service: VPNService) : Binder() {
                 // [data] contains the Binder that we need to dispatch the Events
                 val binder = data.readStrongBinder()
                 mListener = binder
-                if(mService.state == Tunnel.State.UP){
-                    dispatchEvent(EVENTS.init, "connected")
-                }else{
-                    dispatchEvent(EVENTS.init, "disconnected")
-                }
+                val obj = JSONObject()
+                obj.put("connected",  mService.state == Tunnel.State.UP)
+                obj.put("time",  mService.connectionTime)
+                dispatchEvent(EVENTS.init, obj.toString())
                 return true
             }
 

--- a/android/src/com/mozilla/vpn/VPNServiceBinder.kt
+++ b/android/src/com/mozilla/vpn/VPNServiceBinder.kt
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.firefox.vpn
-
+import kotlinx.coroutines.*
 import android.content.Context
 import android.os.Binder
 import android.os.IBinder
@@ -22,7 +22,7 @@ class VPNServiceBinder(service: VPNService) : Binder() {
 
     private val mService = service
     private val tag = "VPNServiceBinder"
-    private val mListeners = mutableListOf<IBinder>()
+    private var mListener: IBinder?= null
     private var mResumeConfig: Config? = null
 
     /**
@@ -78,6 +78,7 @@ class VPNServiceBinder(service: VPNService) : Binder() {
                     }
                     this.mService.turnOn(config)
                 } catch (e: Exception) {
+
                     Log.e(tag, "An Error occurred while enabling the VPN: ${e.localizedMessage}")
                 }
                 return true
@@ -107,8 +108,7 @@ class VPNServiceBinder(service: VPNService) : Binder() {
             ACTIONS.registerEventListener -> {
                 // [data] contains the Binder that we need to dispatch the Events
                 val binder = data.readStrongBinder()
-                mListeners.add(binder)
-                Log.d(tag, "Registered ${mListeners.size} EventListeners")
+                mListener = binder
                 if(mService.state == Tunnel.State.UP){
                     dispatchEvent(EVENTS.init, "connected")
                 }else{
@@ -177,12 +177,12 @@ class VPNServiceBinder(service: VPNService) : Binder() {
      * [ACTIONS.registerEventListener]
      */
     fun dispatchEvent(code: Int, payload: String) {
-        mListeners.forEach {
-           if (it.isBinderAlive) {
-               val data = Parcel.obtain()
-               data.writeByteArray(payload.toByteArray(charset("UTF-8")))
-               it.transact(code, data, Parcel.obtain(), 0)
-           }
+        mListener?.let{
+            if (it.isBinderAlive) {
+                val data = Parcel.obtain()
+                data.writeByteArray(payload.toByteArray(charset("UTF-8")))
+                it.transact(code, data, Parcel.obtain(), 0)
+            }
         }
     }
 

--- a/android/src/com/mozilla/vpn/VPNTunnel.kt
+++ b/android/src/com/mozilla/vpn/VPNTunnel.kt
@@ -5,13 +5,13 @@
 package com.mozilla.vpn
 
 import com.wireguard.android.backend.Tunnel
-import org.mozilla.firefox.vpn.VPNService
 import org.mozilla.firefox.vpn.VPNServiceBinder
 
 class VPNTunnel : Tunnel {
     val mName: String;
     val mBinder: VPNServiceBinder;
     var mState = Tunnel.State.DOWN;
+    var mConnectionTime = 0L;
 
     constructor(name: String, m: VPNServiceBinder) {
         this.mName = name;
@@ -26,10 +26,17 @@ class VPNTunnel : Tunnel {
         if (mState != newState) {
             mState = newState;
             if (mState == Tunnel.State.UP) {
+                mConnectionTime = System.currentTimeMillis();
                 mBinder.dispatchEvent(VPNServiceBinder.EVENTS.connected, "")
             } else {
+                mConnectionTime=0
                 mBinder.dispatchEvent(VPNServiceBinder.EVENTS.disconnected, "")
             }
         }
+    }
+    // Tells QT that the connection attempt failed.
+    fun abort(){
+        mState = Tunnel.State.DOWN
+        mBinder.dispatchEvent(VPNServiceBinder.EVENTS.disconnected, "")
     }
 }

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -114,7 +114,7 @@ void Controller::implInitialized(bool status, bool a_connected,
                << "connected:" << a_connected
                << "connectionDate:" << connectionDate.toString();
 
-  Q_ASSERT(m_state == StateInitializing);
+  // Q_ASSERT(m_state == StateInitializing);
 
   if (!status) {
     MozillaVPN::instance()->errorHandle(ErrorHandler::BackendServiceError);

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -114,7 +114,7 @@ void Controller::implInitialized(bool status, bool a_connected,
                << "connected:" << a_connected
                << "connectionDate:" << connectionDate.toString();
 
-  // Q_ASSERT(m_state == StateInitializing);
+  Q_ASSERT(m_state == StateInitializing);
 
   if (!status) {
     MozillaVPN::instance()->errorHandle(ErrorHandler::BackendServiceError);
@@ -131,8 +131,9 @@ void Controller::implInitialized(bool status, bool a_connected,
   // If we are connected already at startup time, we can trigger the connection
   // sequence of tasks.
   if (a_connected) {
-    connected();
     m_connectionDate = connectionDate;
+    emit timeChanged();
+    m_timer.start(TIMER_MSEC);
     return;
   }
 

--- a/src/platforms/android/androidcontroller.cpp
+++ b/src/platforms/android/androidcontroller.cpp
@@ -83,10 +83,17 @@ void AndroidController::initialize(const Device* device, const Keys* keys) {
                        sizeof(methods) / sizeof(methods[0]));
   env->DeleteLocalRef(objectClass);
 
+  auto appContext = QtAndroid::androidActivity().callObjectMethod(
+      "getApplicationContext", "()Landroid/content/Context;");
+
+  QAndroidJniObject::callStaticMethod<void>(
+      "org/mozilla/firefox/vpn/VPNService", "startService",
+      "(Landroid/content/Context;)V", appContext.object());
+
   // Start the VPN Service (if not yet) and Bind to it
-  QtAndroid::bindService(QAndroidIntent(QtAndroid::androidActivity(),
-                                        "org.mozilla.firefox.vpn.VPNService"),
-                         *this, QtAndroid::BindFlag::AutoCreate);
+  QtAndroid::bindService(
+      QAndroidIntent(appContext.object(), "org.mozilla.firefox.vpn.VPNService"),
+      *this, QtAndroid::BindFlag::AutoCreate);
 }
 
 void AndroidController::enableStartAtBoot(bool enabled) {

--- a/src/platforms/android/androidcontroller.cpp
+++ b/src/platforms/android/androidcontroller.cpp
@@ -76,7 +76,7 @@ void AndroidController::initialize(const Device* device, const Keys* keys) {
   JNINativeMethod methods[]{{"startActivityForResult",
                              "(Landroid/content/Intent;)V",
                              reinterpret_cast<void*>(startActivityForResult)}};
-  QAndroidJniObject javaClass("org/mozilla/firefox/vpn/VPNService");
+  QAndroidJniObject javaClass("org/mozilla/firefox/vpn/VPNPermissionHelper");
   QAndroidJniEnvironment env;
   jclass objectClass = env->GetObjectClass(javaClass.object<jobject>());
   env->RegisterNatives(objectClass, methods,
@@ -140,6 +140,13 @@ void AndroidController::activate(
     const QList<IPAddressRange>& allowedIPAddressRanges,
     const QList<QString>& vpnDisabledApps, Reason reason) {
   logger.log() << "Activation";
+
+  logger.log() << "Prompting for VPN permission";
+  auto appContext = QtAndroid::androidActivity().callObjectMethod(
+      "getApplicationContext", "()Landroid/content/Context;");
+  QAndroidJniObject::callStaticMethod<void>(
+      "org/mozilla/firefox/vpn/VPNPermissionHelper", "startService",
+      "(Landroid/content/Context;)V", appContext.object());
 
   m_server = server;
 
@@ -279,12 +286,11 @@ bool AndroidController::VPNBinder::onTransact(int code,
   switch (code) {
     case EVENT_INIT:
       logger.log() << "Transact: init";
-      buffer = readUTF8Parcel(data);
-      if (buffer == "connected") {
-        emit m_controller->initialized(true, true, QDateTime());
-      } else {
-        emit m_controller->initialized(true, false, QDateTime());
-      }
+      doc = QJsonDocument::fromJson(data.readData());
+      emit m_controller->initialized(
+          true, doc.object()["connected"].toBool(),
+          QDateTime::fromMSecsSinceEpoch(
+              doc.object()["time"].toVariant().toLongLong()));
       // Pass a localised version of the Fallback string for the Notification
       m_controller->setFallbackConnectedNotification();
 


### PR DESCRIPTION
There were 3 things that caused us to close down unexpectedly:
We were starting the service as a bind-first service ( so it got closed once all binders are disconnected)
We were starting the service with context of qt -> so once the qt context got closed the service aswell
Qt just kills the whole process when closing -> so the service was killed aswell. 

So in android controller we're now starting the service intent-first with the app context. ( so unbinding does not affect lifecycle)
And we're putting QT in it's own process called QtOnlyProcess. This means i had to create a small dummy-vpn service that is able to prompt the vpn permission for us, since can't use jni cross process. 