### PR TITLE
CI: add a kotlin linter

### DIFF
--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -35,3 +35,18 @@ jobs:
           source: '.'
           clangFormatVersion: 11
           style: file
+  ktlint:
+    name: Run ktLint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Clone repo
+        uses: actions/checkout@master
+        with:
+          fetch-depth: 1
+      - name: ktlint
+        uses: ScaCap/action-ktlint@master
+        with:
+          github_token: ${{ secrets.github_token }}
+          reporter: github-pr-review # Change reporter
+          android: true


### PR DESCRIPTION
Our hooks don't seem to catch kotlin, so i thought about adding a ci step for that :) 
 