### PR TITLE
Wait for the Correct IP to be fetched

### DIFF
--- a/src/connectiondataholder.cpp
+++ b/src/connectiondataholder.cpp
@@ -244,7 +244,6 @@ void ConnectionDataHolder::updateIpAddress() {
                 // connected server we may retry only once.
                 logger.log() << "Reported ip not in the right country, retry!";
                 TimerSingleShot::create(this, 3000, [this]() {
-                  m_updatingIpAddress = false;
                   updateIpAddress();
                 });
               }

--- a/src/connectiondataholder.cpp
+++ b/src/connectiondataholder.cpp
@@ -8,6 +8,7 @@
 #include "logger.h"
 #include "mozillavpn.h"
 #include "networkrequest.h"
+#include "timersingleshot.h"
 
 #include <QJsonDocument>
 #include <QJsonObject>
@@ -19,10 +20,10 @@ namespace {
 Logger logger(LOG_NETWORKING, "ConnectionDataHolder");
 }
 
-//% "Unknown"
-//: This refers to the current IP address, i.e. "IP: Unknown".
+//% "Loading"
+//: This refers to the current IP address, i.e. "IP: Loading".
 ConnectionDataHolder::ConnectionDataHolder()
-    : m_ipAddress(qtTrId("vpn.connectionInfo.unknown")) {
+    : m_ipAddress(qtTrId("vpn.connectionInfo.loading")) {
   MVPN_COUNT_CTOR(ConnectionDataHolder);
 
   connect(&m_ipAddressTimer, &QTimer::timeout, [this]() { updateIpAddress(); });
@@ -104,6 +105,7 @@ void ConnectionDataHolder::activate(const QVariant& a_txSeries,
                                     const QVariant& a_axisX,
                                     const QVariant& a_axisY) {
   logger.log() << "Activated";
+  updateIpAddress();
 
   QtCharts::QSplineSeries* txSeries =
       qobject_cast<QtCharts::QSplineSeries*>(a_txSeries.value<QObject*>());
@@ -200,6 +202,12 @@ void ConnectionDataHolder::reset() {
 
 void ConnectionDataHolder::updateIpAddress() {
   logger.log() << "Updating IP address";
+  auto state = MozillaVPN::instance()->controller()->state();
+  // Only start the check if we're actually connected/connecting
+  if (state != Controller::StateOn && state != Controller::StateConfirming) {
+    logger.log() << "Skip Updating IP address, not connected";
+    return;
+  }
 
   if (m_updatingIpAddress) {
     return;
@@ -224,14 +232,27 @@ void ConnectionDataHolder::updateIpAddress() {
   connect(request, &NetworkRequest::requestCompleted,
           [this](QNetworkReply*, const QByteArray& data) {
             logger.log() << "IP address request completed";
-
             QJsonDocument json = QJsonDocument::fromJson(data);
             if (json.isObject()) {
               QJsonObject obj = json.object();
 
+              QJsonValue country = obj.take("country");
+              if (m_checkStatusTimer.isActive() &&
+                  country.toString().toLower() !=
+                      MozillaVPN::instance()->currentServer()->countryCode()) {
+                // In case the country-we're reported in does not match the
+                // connected server we may retry only once.
+                logger.log() << "Reported ip not in the right country, retry!";
+                TimerSingleShot::create(this, 3000, [this]() {
+                  m_updatingIpAddress = false;
+                  updateIpAddress();
+                });
+              }
               QJsonValue value = obj.value("ip");
               if (value.isString()) {
                 m_ipAddress = value.toString();
+                logger.log() << "Set own Address: " << m_ipAddress << " in "
+                             << country.toString();
                 emit ipAddressChanged();
               }
             }

--- a/src/connectiondataholder.cpp
+++ b/src/connectiondataholder.cpp
@@ -243,9 +243,8 @@ void ConnectionDataHolder::updateIpAddress() {
                 // In case the country-we're reported in does not match the
                 // connected server we may retry only once.
                 logger.log() << "Reported ip not in the right country, retry!";
-                TimerSingleShot::create(this, 3000, [this]() {
-                  updateIpAddress();
-                });
+                TimerSingleShot::create(this, 3000,
+                                        [this]() { updateIpAddress(); });
               }
               QJsonValue value = obj.value("ip");
               if (value.isString()) {

--- a/tests/unit/testconnectiondataholder.cpp
+++ b/tests/unit/testconnectiondataholder.cpp
@@ -31,16 +31,16 @@ void TestConnectionDataHolder::checkIpAddressSucceess_data() {
   QTest::addColumn<QString>("ipAddress");
   QTest::addColumn<bool>("signal");
 
-  QTest::addRow("invalid") << QByteArray("") << "vpn.connectionInfo.unknown"
+  QTest::addRow("invalid") << QByteArray("") << "vpn.connectionInfo.loading"
                            << false;
 
   QJsonObject json;
   QTest::addRow("empty") << QJsonDocument(json).toJson()
-                         << "vpn.connectionInfo.unknown" << false;
+                         << "vpn.connectionInfo.loading" << false;
 
   json.insert("ip", 42);
   QTest::addRow("invalid ip")
-      << QJsonDocument(json).toJson() << "vpn.connectionInfo.unknown" << false;
+      << QJsonDocument(json).toJson() << "vpn.connectionInfo.loading" << false;
 
   json.insert("ip", "42");
   QTest::addRow("valid ip") << QJsonDocument(json).toJson() << "42" << true;
@@ -63,7 +63,6 @@ void TestConnectionDataHolder::checkIpAddressSucceess() {
 
     QFETCH(bool, signal);
     QCOMPARE(spy.count(), signal ? 1 : 0);
-
     loop.exit();
   });
 
@@ -74,6 +73,9 @@ void TestConnectionDataHolder::checkIpAddressSucceess() {
 void TestConnectionDataHolder::chart() {
   ConnectionDataHolder cdh;
   QSignalSpy spy(&cdh, &ConnectionDataHolder::bytesChanged);
+
+  TestHelper::networkConfig.append(TestHelper::NetworkConfig(
+      TestHelper::NetworkConfig::Success, QString("{'ip':'42'}").toUtf8()));
 
   cdh.add(123, 123);
   QCOMPARE(spy.count(), 0);

--- a/tests/unit/testconnectiondataholder.h
+++ b/tests/unit/testconnectiondataholder.h
@@ -8,9 +8,14 @@ class TestConnectionDataHolder final : public TestHelper {
   Q_OBJECT
 
  private slots:
+  void initTestCase() { TestHelper::controllerState = Controller::StateOn; }
   void checkIpAddressFailure();
   void checkIpAddressSucceess_data();
   void checkIpAddressSucceess();
 
   void chart();
+
+  void cleanupTestCase() {
+    TestHelper::controllerState = Controller::StateInitializing;
+  }
 };


### PR DESCRIPTION
Prevent to fetch the ip if we're not connected so the real ip is not shown while we try to get the vpn-ed ip. 
Assert that the fetched ip has to be reported in the same country as we are connected to, otherwise retry. 
Oh and change the "unknown" string to "loading".. as we're probably loading when the user sees this. :) 

Closes #549 