### PR TITLE
Version Bump to 2.0.4

### DIFF
--- a/version.pri
+++ b/version.pri
@@ -2,9 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-# Please make sure to only use single digets for the sub-versions The numbers
-# are concatenated for the android version code so e.g 2.0.2 becomes version
-# Code 2020
-!defined(VERSION, var):VERSION = 2.0.3
+!defined(VERSION, var):VERSION = 2.0.4
 
 DBUS_PROTOCOL_VERSION = 1


### PR DESCRIPTION
I guess for the next fixed Android release, we might want to bump the to version 2.0.4 ? 