### PR TITLE
Filtering out the captive portal endpoint

### DIFF
--- a/src/captiveportal/captiveportalrequest.cpp
+++ b/src/captiveportal/captiveportalrequest.cpp
@@ -30,9 +30,14 @@ void CaptivePortalRequest::run() {
   }
 
   QStringList ipv6Addresses;
+#if 0
+  // TODO https://github.com/mozilla-mobile/mozilla-vpn-client/issues/593
+  // The captive portal detection doesn't work in ipv6 because we do not
+  // support (yet) the IPAddress ipv6 filtering.
   if (settings->ipv6Enabled() && settings->hasCaptivePortalIpv6Addresses()) {
     ipv6Addresses = settings->captivePortalIpv6Addresses();
   }
+#endif
 
   // We do not have IPs to check.
   if (ipv4Addresses.isEmpty() && ipv6Addresses.isEmpty()) {

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -577,7 +577,7 @@ QList<IPAddressRange> Controller::getAllowedIPAddressRanges(
     logger.log() << "Exclude the server:" << server.ipv4AddrIn();
     excludeIPv4s.append(IPAddress::create(server.ipv4AddrIn()));
 
-    allowedIPv4s = IPAddress::excludes(allowedIPv4s, excludeIPv4s);
+    allowedIPv4s = IPAddress::excludeAddresses(allowedIPv4s, excludeIPv4s);
     list.append(IPAddressRange::fromIPAddressList(allowedIPv4s));
 
     logger.log() << "Allow the server:" << server.ipv4Gateway();

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -524,50 +524,72 @@ void Controller::captivePortalDetected() {
 
 QList<IPAddressRange> Controller::getAllowedIPAddressRanges(
     const Server& server) {
+  logger.log() << "Computing the allowed ip addresses";
+
   bool ipv6Enabled = SettingsHolder::instance()->ipv6Enabled();
 
-  // catch all-range.
-  QList<IPAddress> allowedIPv4s{IPAddress::create("0.0.0.0/0")};
+  QList<IPAddress> excludeIPv4s;
+  QList<IPAddressRange> allowedIPv6s;
 
   // filtering out the captive portal endpoint
   if (SettingsHolder::instance()->captivePortalAlert()) {
     CaptivePortal* captivePortal = MozillaVPN::instance()->captivePortal();
+
     const QStringList& captivePortalIpv4Addresses =
         captivePortal->ipv4Addresses();
 
-    QList<IPAddress> excludeList;
     for (const QString& address : captivePortalIpv4Addresses) {
-      excludeList.append(IPAddress::create(address));
+      logger.log() << "Filtering out the captive portal address" << address;
+      excludeIPv4s.append(IPAddress::create(address));
     }
 
-    // IPv6 is not supported by IPAddress yet.
-
-    allowedIPv4s = IPAddress::excludes(allowedIPv4s, excludeList);
+    if (ipv6Enabled) {
+      const QStringList& captivePortalIpv6Addresses =
+          captivePortal->ipv6Addresses();
+      for (const QString& address : captivePortalIpv6Addresses) {
+        // TODO IPv6 is not supported by IPAddress yet.
+        allowedIPv6s.append(IPAddressRange(address, 0, IPAddressRange::IPv6));
+      }
+    }
   }
-
-  QList<IPAddressRange> list;
 
   // filtering out the RFC1918 local area network
   if (MozillaVPN::instance()->localNetworkAccessSupported() &&
       SettingsHolder::instance()->localNetworkAccess()) {
-    // In case of lan enabled, whitelist all non LAN ip's
-    allowedIPv4s = IPAddress::excludes(allowedIPv4s, RFC1918::ipv4());
-
-    list = IPAddressRange::fromIPAddressList(allowedIPv4s);
+    logger.log() << "Filtering out the local area networks (rfc 1918)";
+    excludeIPv4s.append(RFC1918::ipv4());
 
     if (ipv6Enabled) {
-      list.append(RFC4193::ipv6());
+      // TODO IPv6 is not supported by IPAddress yet.
+      logger.log() << "Filtering out the local area networks (rfc 4193)";
+      allowedIPv6s.append(RFC4193::ipv6());
     }
+  }
 
-    // Allow the servers gateway -
-    // otherwise we can't ping it for connectionhealth
-    list.append(IPAddressRange(server.ipv4Gateway(), 32, IPAddressRange::IPv4));
+  QList<IPAddressRange> list;
 
+  if (excludeIPv4s.isEmpty()) {
+    logger.log() << "Catch all IPv4";
+    list.append(IPAddressRange("0.0.0.0", 0, IPAddressRange::IPv4));
   } else {
-    // Add catchall-range in case LAN is disabled
-    list = IPAddressRange::fromIPAddressList(allowedIPv4s);
-    if (ipv6Enabled) {
+    QList<IPAddress> allowedIPv4s{IPAddress::create("0.0.0.0/0")};
+
+    logger.log() << "Exclude the server:" << server.ipv4AddrIn();
+    excludeIPv4s.append(IPAddress::create(server.ipv4AddrIn()));
+
+    allowedIPv4s = IPAddress::excludes(allowedIPv4s, excludeIPv4s);
+    list.append(IPAddressRange::fromIPAddressList(allowedIPv4s));
+
+    logger.log() << "Allow the server:" << server.ipv4Gateway();
+    list.append(IPAddressRange(server.ipv4Gateway(), 32, IPAddressRange::IPv4));
+  }
+
+  if (ipv6Enabled) {
+    if (allowedIPv6s.isEmpty()) {
+      logger.log() << "Catch all IPv6";
       list.append(IPAddressRange("::0", 0, IPAddressRange::IPv6));
+    } else {
+      list.append(allowedIPv6s);
     }
   }
 

--- a/src/ipaddress.cpp
+++ b/src/ipaddress.cpp
@@ -120,8 +120,8 @@ QList<IPAddress> IPAddress::subnets() const {
 }
 
 // static
-QList<IPAddress> IPAddress::excludes(const QList<IPAddress>& sourceList,
-                                     const QList<IPAddress>& excludeList) {
+QList<IPAddress> IPAddress::excludeAddresses(
+    const QList<IPAddress>& sourceList, const QList<IPAddress>& excludeList) {
   QList<IPAddress> results = sourceList;
 
   for (const IPAddress& exclude : excludeList) {
@@ -129,7 +129,7 @@ QList<IPAddress> IPAddress::excludes(const QList<IPAddress>& sourceList,
 
     for (const IPAddress& ip : results) {
       if (ip.overlaps(exclude)) {
-        QList<IPAddress> range = ip.excludes(exclude);
+        QList<IPAddress> range = ip.excludeAddresses(exclude);
         newResults.append(range);
       } else {
         newResults.append(ip);
@@ -142,7 +142,7 @@ QList<IPAddress> IPAddress::excludes(const QList<IPAddress>& sourceList,
   return results;
 }
 
-QList<IPAddress> IPAddress::excludes(const IPAddress& ip) const {
+QList<IPAddress> IPAddress::excludeAddresses(const IPAddress& ip) const {
   QList<IPAddress> sn = subnets();
   Q_ASSERT(sn.length() >= 2);
 

--- a/src/ipaddress.cpp
+++ b/src/ipaddress.cpp
@@ -1,0 +1,147 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "ipaddress.h"
+#include "leakdetector.h"
+#include "logger.h"
+
+#include <QtMath>
+
+namespace {
+Logger logger(LOG_NETWORKING, "IPAddress");
+}
+
+static quint32 s_allOnes = static_cast<quint32>(qPow(2, 32) - 1);
+
+static QHostAddress prefixLengthToAddress(int prefixLength) {
+  Q_ASSERT(prefixLength >= 0 && prefixLength <= 32);
+  return QHostAddress(s_allOnes ^ (s_allOnes >> prefixLength));
+}
+
+// static
+IPAddress IPAddress::create(const QString& ip) {
+  if (ip.contains("/")) {
+    QPair<QHostAddress, int> p = QHostAddress::parseSubnet(ip);
+    if (p.second < 32) {
+      return IPAddress(p.first, p.second);
+    }
+
+    return IPAddress(p.first);
+  }
+
+  return IPAddress(QHostAddress(ip));
+}
+
+IPAddress::IPAddress() { MVPN_COUNT_CTOR(IPAddress); }
+
+IPAddress::IPAddress(const IPAddress& other) {
+  MVPN_COUNT_CTOR(IPAddress);
+  *this = other;
+}
+
+IPAddress& IPAddress::operator=(const IPAddress& other) {
+  if (this == &other) return *this;
+
+  m_address = other.m_address;
+  m_prefixLength = other.m_prefixLength;
+  m_netmask = other.m_netmask;
+  m_hostmask = other.m_hostmask;
+  m_broadcastAddress = other.m_broadcastAddress;
+
+  return *this;
+}
+
+IPAddress::IPAddress(const QHostAddress& address)
+    : m_address(address),
+      m_prefixLength(32),
+      m_netmask(QHostAddress(s_allOnes)),
+      m_hostmask(QHostAddress((quint32)(0))),
+      m_broadcastAddress(address) {
+  MVPN_COUNT_CTOR(IPAddress);
+}
+
+IPAddress::IPAddress(const QHostAddress& address, int prefixLength)
+    : m_address(address), m_prefixLength(prefixLength) {
+  MVPN_COUNT_CTOR(IPAddress);
+
+  m_netmask = prefixLengthToAddress(prefixLength);
+  m_hostmask = QHostAddress(m_netmask.toIPv4Address() ^ s_allOnes);
+  m_broadcastAddress =
+      QHostAddress(address.toIPv4Address() | m_hostmask.toIPv4Address());
+}
+
+IPAddress::~IPAddress() { MVPN_COUNT_DTOR(IPAddress); }
+
+bool IPAddress::overlaps(const IPAddress& other) const {
+  return other.contains(m_address) || other.contains(m_broadcastAddress) ||
+         contains(other.m_address) || contains(other.m_broadcastAddress);
+}
+
+bool IPAddress::contains(const QHostAddress& address) const {
+  return (m_address.toIPv4Address() <= address.toIPv4Address()) &&
+         (address.toIPv4Address() <= m_broadcastAddress.toIPv4Address());
+}
+
+bool IPAddress::operator==(const IPAddress& other) const {
+  return m_address == other.m_address && m_netmask == other.m_netmask;
+}
+
+bool IPAddress::subnetOf(const IPAddress& other) const {
+  return other.m_address.toIPv4Address() <= m_address.toIPv4Address() &&
+         other.m_broadcastAddress.toIPv4Address() >=
+             m_broadcastAddress.toIPv4Address();
+}
+
+QList<IPAddress> IPAddress::subnets() const {
+  quint64 start = m_address.toIPv4Address();
+  quint64 end = quint64(m_broadcastAddress.toIPv4Address()) + 1;
+  quint64 step = ((quint64)m_hostmask.toIPv4Address() + 1) >> 1;
+
+  QList<IPAddress> list;
+
+  if (m_prefixLength == 32) {
+    list.append(*this);
+    return list;
+  }
+
+  while (start < end) {
+    int newPrefixLength = m_prefixLength + 1;
+    if (newPrefixLength == 32) {
+      list.append(IPAddress(QHostAddress(start)));
+    } else {
+      list.append(IPAddress(QHostAddress(start), m_prefixLength + 1));
+    }
+    start += step;
+  }
+
+  return list;
+}
+
+QList<IPAddress> IPAddress::excludes(const IPAddress& ip) const {
+  QList<IPAddress> sn = subnets();
+  Q_ASSERT(sn.length() >= 2);
+
+  QList<IPAddress> result;
+  while (sn[0] != ip && sn[1] != ip) {
+    if (ip.subnetOf(sn[0])) {
+      result.append(sn[1]);
+      sn = sn[0].subnets();
+    } else if (ip.subnetOf(sn[1])) {
+      result.append(sn[0]);
+      sn = sn[1].subnets();
+    } else {
+      Q_ASSERT(false);
+    }
+  }
+
+  if (sn[0] == ip) {
+    result.append(sn[1]);
+  } else if (sn[1] == ip) {
+    result.append(sn[0]);
+  } else {
+    Q_ASSERT(false);
+  }
+
+  return result;
+}

--- a/src/ipaddress.h
+++ b/src/ipaddress.h
@@ -10,6 +10,8 @@
 class IPAddress final {
  public:
   static IPAddress create(const QString& ip);
+  static QList<IPAddress> excludes(const QList<IPAddress>& sourceList,
+                                   const QList<IPAddress>& excludeList);
 
   IPAddress();
   IPAddress(const IPAddress& other);

--- a/src/ipaddress.h
+++ b/src/ipaddress.h
@@ -1,0 +1,55 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef IPADDRESS_H
+#define IPADDRESS_H
+
+#include <QHostAddress>
+
+class IPAddress final {
+ public:
+  static IPAddress create(const QString& ip);
+
+  IPAddress();
+  IPAddress(const IPAddress& other);
+  IPAddress& operator=(const IPAddress& other);
+  ~IPAddress();
+
+  QString toString() const {
+    return QString("%1/%2").arg(m_address.toString()).arg(m_prefixLength);
+  }
+
+  const QHostAddress& address() const { return m_address; }
+  int prefixLength() const { return m_prefixLength; }
+  const QHostAddress& netmask() const { return m_netmask; }
+  const QHostAddress& hostmask() const { return m_hostmask; }
+  const QHostAddress& broadcastAddress() const { return m_broadcastAddress; }
+
+  bool overlaps(const IPAddress& other) const;
+
+  bool contains(const QHostAddress& address) const;
+
+  bool operator==(const IPAddress& other) const;
+  bool operator!=(const IPAddress& other) const { return !operator==(other); }
+
+  bool subnetOf(const IPAddress& other) const;
+
+  QList<IPAddress> subnets() const;
+
+  QList<IPAddress> excludes(const IPAddress& ip) const;
+
+ private:
+  IPAddress(const QHostAddress& address);
+  IPAddress(const QHostAddress& address, int prefixLength);
+
+ private:
+  QHostAddress m_address;
+  int m_prefixLength;
+
+  QHostAddress m_netmask;
+  QHostAddress m_hostmask;
+  QHostAddress m_broadcastAddress;
+};
+
+#endif  // IPADDRESS_H

--- a/src/ipaddress.h
+++ b/src/ipaddress.h
@@ -10,8 +10,8 @@
 class IPAddress final {
  public:
   static IPAddress create(const QString& ip);
-  static QList<IPAddress> excludes(const QList<IPAddress>& sourceList,
-                                   const QList<IPAddress>& excludeList);
+  static QList<IPAddress> excludeAddresses(const QList<IPAddress>& sourceList,
+                                           const QList<IPAddress>& excludeList);
 
   IPAddress();
   IPAddress(const IPAddress& other);
@@ -39,7 +39,7 @@ class IPAddress final {
 
   QList<IPAddress> subnets() const;
 
-  QList<IPAddress> excludes(const IPAddress& ip) const;
+  QList<IPAddress> excludeAddresses(const IPAddress& ip) const;
 
  private:
   IPAddress(const QHostAddress& address);

--- a/src/ipaddressrange.cpp
+++ b/src/ipaddressrange.cpp
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "ipaddressrange.h"
+#include "ipaddress.h"
 #include "leakdetector.h"
 
 IPAddressRange::IPAddressRange(const QString& ipAddress, uint32_t range,
@@ -27,3 +28,14 @@ IPAddressRange& IPAddressRange::operator=(const IPAddressRange& other) {
 }
 
 IPAddressRange::~IPAddressRange() { MVPN_COUNT_DTOR(IPAddressRange); }
+
+// static
+QList<IPAddressRange> IPAddressRange::fromIPAddressList(
+    const QList<IPAddress>& list) {
+  QList<IPAddressRange> result;
+  for (const IPAddress& ip : list) {
+    result.append(
+        IPAddressRange(ip.address().toString(), ip.prefixLength(), IPv4));
+  }
+  return result;
+}

--- a/src/ipaddressrange.h
+++ b/src/ipaddressrange.h
@@ -8,12 +8,16 @@
 #include <QObject>
 #include <QString>
 
+class IPAddress;
+
 class IPAddressRange final {
  public:
   enum IPAddressType {
     IPv4,
     IPv6,
   };
+
+  static QList<IPAddressRange> fromIPAddressList(const QList<IPAddress>& list);
 
   IPAddressRange(const QString& ipAddress, uint32_t range, IPAddressType type);
   IPAddressRange(const IPAddressRange& other);

--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -1071,12 +1071,7 @@ void MozillaVPN::quit() {
 }
 
 bool MozillaVPN::localNetworkAccessSupported() const {
-#if defined(MVPN_LINUX)
-  // TODO: https://github.com/mozilla-mobile/mozilla-vpn-client/issues/295
-  return false;
-#endif
-
-#if defined(MVPN_MACOS) || defined(MVPN_IOS)
+#if defined(MVPN_IOS)
   // managed by the OS automatically. No need to expose this feature.
   return false;
 #endif

--- a/src/rfc1918.cpp
+++ b/src/rfc1918.cpp
@@ -5,43 +5,13 @@
 #include "rfc1918.h"
 
 // static
-QList<IPAddressRange> RFC1918::ipv4() {
-  QList<IPAddressRange> list;
+QList<IPAddress> RFC1918::ipv4() {
+  QList<IPAddress> list;
 
   // From RFC1918: https://tools.ietf.org/html/rfc1918
-  list.append(IPAddressRange("0.0.0.0", 5, IPAddressRange::IPv4));
-  list.append(IPAddressRange("8.0.0.0", 7, IPAddressRange::IPv4));
-  list.append(IPAddressRange("11.0.0.0", 8, IPAddressRange::IPv4));
-  list.append(IPAddressRange("12.0.0.0", 6, IPAddressRange::IPv4));
-  list.append(IPAddressRange("16.0.0.0", 4, IPAddressRange::IPv4));
-  list.append(IPAddressRange("32.0.0.0", 3, IPAddressRange::IPv4));
-  list.append(IPAddressRange("64.0.0.0", 2, IPAddressRange::IPv4));
-  list.append(IPAddressRange("128.0.0.0", 3, IPAddressRange::IPv4));
-  list.append(IPAddressRange("160.0.0.0", 5, IPAddressRange::IPv4));
-  list.append(IPAddressRange("168.0.0.0", 6, IPAddressRange::IPv4));
-  list.append(IPAddressRange("172.0.0.0", 12, IPAddressRange::IPv4));
-  list.append(IPAddressRange("172.32.0.0", 11, IPAddressRange::IPv4));
-  list.append(IPAddressRange("172.64.0.0", 10, IPAddressRange::IPv4));
-  list.append(IPAddressRange("172.128.0.0", 9, IPAddressRange::IPv4));
-  list.append(IPAddressRange("173.0.0.0", 8, IPAddressRange::IPv4));
-  list.append(IPAddressRange("174.0.0.0", 7, IPAddressRange::IPv4));
-  list.append(IPAddressRange("176.0.0.0", 4, IPAddressRange::IPv4));
-  list.append(IPAddressRange("192.0.0.0", 9, IPAddressRange::IPv4));
-  list.append(IPAddressRange("192.128.0.0", 11, IPAddressRange::IPv4));
-  list.append(IPAddressRange("192.160.0.0", 13, IPAddressRange::IPv4));
-  list.append(IPAddressRange("192.169.0.0", 16, IPAddressRange::IPv4));
-  list.append(IPAddressRange("192.170.0.0", 15, IPAddressRange::IPv4));
-  list.append(IPAddressRange("192.172.0.0", 14, IPAddressRange::IPv4));
-  list.append(IPAddressRange("192.176.0.0", 12, IPAddressRange::IPv4));
-  list.append(IPAddressRange("192.192.0.0", 10, IPAddressRange::IPv4));
-  list.append(IPAddressRange("193.0.0.0", 8, IPAddressRange::IPv4));
-  list.append(IPAddressRange("194.0.0.0", 7, IPAddressRange::IPv4));
-  list.append(IPAddressRange("196.0.0.0", 6, IPAddressRange::IPv4));
-  list.append(IPAddressRange("200.0.0.0", 5, IPAddressRange::IPv4));
-  list.append(IPAddressRange("208.0.0.0", 4, IPAddressRange::IPv4));
+  list.append(IPAddress::create("10.0.0.0/8"));
+  list.append(IPAddress::create("172.16.0.0/12"));
+  list.append(IPAddress::create("192.168.0.0/16"));
 
   return list;
 }
-
-// static
-QList<IPAddressRange> RFC1918::ipv6() { return QList<IPAddressRange>(); }

--- a/src/rfc1918.h
+++ b/src/rfc1918.h
@@ -5,14 +5,13 @@
 #ifndef RFC1918_H
 #define RFC1918_H
 
-#include "ipaddressrange.h"
+#include "ipaddress.h"
 
 #include <QList>
 
 class RFC1918 final {
  public:
-  static QList<IPAddressRange> ipv4();
-  static QList<IPAddressRange> ipv6();
+  static QList<IPAddress> ipv4();
 };
 
 #endif  // RFC1918_H

--- a/src/rfc4193.h
+++ b/src/rfc4193.h
@@ -11,6 +11,8 @@
 
 class RFC4193 final {
  public:
+  // Note: this returns the "opposite" of the RFC4193: what does not be treated
+  // as local network.
   static QList<IPAddressRange> ipv6();
 };
 

--- a/src/src.pro
+++ b/src/src.pro
@@ -59,6 +59,7 @@ SOURCES += \
         hacl-star/Hacl_Chacha20Poly1305_32.c \
         hacl-star/Hacl_Curve25519_51.c \
         hacl-star/Hacl_Poly1305_32.c \
+        ipaddress.cpp \
         ipaddressrange.cpp \
         leakdetector.cpp \
         localizer.cpp \
@@ -133,6 +134,7 @@ HEADERS += \
         curve25519.h \
         errorhandler.h \
         fontloader.h \
+        ipaddress.h \
         ipaddressrange.h \
         leakdetector.h \
         localizer.h \

--- a/src/wgquickprocess.cpp
+++ b/src/wgquickprocess.cpp
@@ -97,6 +97,10 @@ bool WgQuickProcess::createConfigFile(
   content.append(
       QString("\nAllowedIPs = %1\n").arg(allowedIPAddressRanges).toUtf8());
 
+#ifdef QT_DEBUG
+  logger.log() << content;
+#endif
+
   QFile file(configFile);
   if (!file.open(QIODevice::WriteOnly)) {
     qWarning("Unable to create a file in the temporary folder");

--- a/tests/unit/testipaddress.cpp
+++ b/tests/unit/testipaddress.cpp
@@ -1,0 +1,189 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "testipaddress.h"
+#include "../../src/ipaddress.h"
+#include "helper.h"
+
+void TestIpAddress::basic_data() {
+  QTest::addColumn<QString>("input");
+  QTest::addColumn<QString>("address");
+  QTest::addColumn<int>("prefixLength");
+  QTest::addColumn<QString>("netmask");
+  QTest::addColumn<QString>("hostmask");
+  QTest::addColumn<QString>("broadcastAddress");
+
+  QTest::addRow("localhost") << "127.0.0.1"
+                             << "127.0.0.1" << 32 << "255.255.255.255"
+                             << "0.0.0.0"
+                             << "127.0.0.1";
+  QTest::addRow("localhost/32") << "127.0.0.1/32"
+                                << "127.0.0.1" << 32 << "255.255.255.255"
+                                << "0.0.0.0"
+                                << "127.0.0.1";
+
+  QTest::addRow("random") << "1.1.1.1"
+                          << "1.1.1.1" << 32 << "255.255.255.255"
+                          << "0.0.0.0"
+                          << "1.1.1.1";
+
+  QTest::addRow("world") << "0.0.0.0/0"
+                         << "0.0.0.0" << 0 << "0.0.0.0"
+                         << "255.255.255.255"
+                         << "255.255.255.255";
+
+  QTest::addRow("netmask C") << "192.168.1.0/24"
+                             << "192.168.1.0" << 24 << "255.255.255.0"
+                             << "0.0.0.255"
+                             << "192.168.1.255";
+
+  QTest::addRow("netmask/8") << "192.0.0.0/8"
+                             << "192.0.0.0" << 8 << "255.0.0.0"
+                             << "0.255.255.255"
+                             << "192.255.255.255";
+  QTest::addRow("netmask/30") << "192.0.0.0/30"
+                              << "192.0.0.0" << 30 << "255.255.255.252"
+                              << "0.0.0.3"
+                              << "192.0.0.3";
+}
+
+void TestIpAddress::basic() {
+  QFETCH(QString, input);
+
+  IPAddress ipAddress = IPAddress::create(input);
+
+  QFETCH(QString, address);
+  QCOMPARE(ipAddress.address().toString(), address);
+  QFETCH(int, prefixLength);
+  QCOMPARE(ipAddress.prefixLength(), prefixLength);
+  QFETCH(QString, netmask);
+  QCOMPARE(ipAddress.netmask().toString(), netmask);
+  QFETCH(QString, hostmask);
+  QCOMPARE(ipAddress.hostmask().toString(), hostmask);
+  QFETCH(QString, broadcastAddress);
+  QCOMPARE(ipAddress.broadcastAddress().toString(), broadcastAddress);
+}
+
+void TestIpAddress::overlaps_data() {
+  QTest::addColumn<QString>("a");
+  QTest::addColumn<QString>("b");
+  QTest::addColumn<bool>("result");
+
+  QTest::addRow("self localhost") << "127.0.0.1"
+                                  << "127.0.0.1" << true;
+  QTest::addRow("world") << "0.0.0.0/0"
+                         << "127.0.0.1" << true;
+  QTest::addRow("A") << "1.2.3.0/24"
+                     << "127.0.0.1" << false;
+  QTest::addRow("B") << "1.2.3.0/24"
+                     << "1.2.2.0/24" << false;
+  QTest::addRow("C") << "1.2.3.0/24"
+                     << "1.2.4.3" << false;
+}
+
+void TestIpAddress::overlaps() {
+  QFETCH(QString, a);
+  IPAddress ipAddressA = IPAddress::create(a);
+
+  QFETCH(QString, b);
+  IPAddress ipAddressB = IPAddress::create(b);
+
+  QFETCH(bool, result);
+  QCOMPARE(ipAddressA.overlaps(ipAddressB), result);
+}
+
+void TestIpAddress::contains_data() {
+  QTest::addColumn<QString>("a");
+  QTest::addColumn<QString>("b");
+  QTest::addColumn<bool>("result");
+
+  QTest::addRow("self localhost") << "127.0.0.1"
+                                  << "127.0.0.1" << true;
+  QTest::addRow("world") << "0.0.0.0/0"
+                         << "127.0.0.1" << true;
+  QTest::addRow("A") << "1.2.3.0/24"
+                     << "127.0.0.1" << false;
+  QTest::addRow("B") << "1.2.3.0/24"
+                     << "1.2.2.0/24" << false;
+  QTest::addRow("C") << "1.2.3.0/24"
+                     << "1.2.4.3" << false;
+}
+
+void TestIpAddress::contains() {
+  QFETCH(QString, a);
+  IPAddress ipAddressA = IPAddress::create(a);
+
+  QFETCH(QString, b);
+  QHostAddress ipAddressB(b);
+
+  QFETCH(bool, result);
+  QCOMPARE(ipAddressA.contains(ipAddressB), result);
+}
+
+void TestIpAddress::equal_data() {
+  QTest::addColumn<QString>("a");
+  QTest::addColumn<QString>("b");
+  QTest::addColumn<bool>("result");
+
+  QTest::addRow("self localhost") << "127.0.0.1"
+                                  << "127.0.0.1" << true;
+  QTest::addRow("world vs localhost") << "0.0.0.0/0"
+                                      << "127.0.0.1" << false;
+  QTest::addRow("world vs world") << "0.0.0.0/0"
+                                  << "0.0.0.0/0" << true;
+}
+
+void TestIpAddress::equal() {
+  QFETCH(QString, a);
+  IPAddress ipAddressA = IPAddress::create(a);
+
+  QFETCH(QString, b);
+  IPAddress ipAddressB = IPAddress::create(b);
+
+  QFETCH(bool, result);
+  QCOMPARE(ipAddressA == ipAddressB, result);
+}
+
+void TestIpAddress::excludes_data() {
+  QTest::addColumn<QString>("input");
+  QTest::addColumn<QString>("excludes");
+  QTest::addColumn<QString>("result");
+
+  QTest::addRow("world vs localhost")
+      << "0.0.0.0/0"
+      << "127.0.0.1"
+      << "0.0.0.0/2,112.0.0.0/5,120.0.0.0/6,124.0.0.0/7,126.0.0.0/8,127.0.0.0/"
+         "32,127.0.0.128/25,127.0.0.16/28,127.0.0.2/31,127.0.0.32/27,127.0.0.4/"
+         "30,127.0.0.64/26,127.0.0.8/29,127.0.1.0/24,127.0.128.0/17,127.0.16.0/"
+         "20,127.0.2.0/23,127.0.32.0/19,127.0.4.0/22,127.0.64.0/18,127.0.8.0/"
+         "21,127.1.0.0/16,127.128.0.0/9,127.16.0.0/12,127.2.0.0/15,127.32.0.0/"
+         "11,127.4.0.0/14,127.64.0.0/10,127.8.0.0/13,128.0.0.0/1,64.0.0.0/"
+         "3,96.0.0.0/4";
+
+  QTest::addRow("world vs rfc1918 (part)")
+      << "0.0.0.0/0"
+      << "10.0.0.0/8"
+      << "0.0.0.0/5,11.0.0.0/8,12.0.0.0/6,128.0.0.0/1,16.0.0.0/4,32.0.0.0/"
+         "3,64.0.0.0/2,8.0.0.0/7";
+}
+
+void TestIpAddress::excludes() {
+  QFETCH(QString, input);
+  IPAddress a = IPAddress::create(input);
+
+  QFETCH(QString, excludes);
+  IPAddress b = IPAddress::create(excludes);
+
+  QStringList list;
+  for (const IPAddress& r : a.excludes(b)) {
+    list.append(r.toString());
+  }
+
+  std::sort(list.begin(), list.end());
+
+  QFETCH(QString, result);
+  QVERIFY(list.join(",") == result);
+}
+
+static TestIpAddress s_testIpAddress;

--- a/tests/unit/testipaddress.cpp
+++ b/tests/unit/testipaddress.cpp
@@ -145,9 +145,9 @@ void TestIpAddress::equal() {
   QCOMPARE(ipAddressA == ipAddressB, result);
 }
 
-void TestIpAddress::excludes_data() {
+void TestIpAddress::excludeAddresses_data() {
   QTest::addColumn<QString>("input");
-  QTest::addColumn<QString>("excludes");
+  QTest::addColumn<QString>("excludeAddresses");
   QTest::addColumn<QString>("result");
 
   QTest::addRow("world vs localhost")
@@ -168,15 +168,15 @@ void TestIpAddress::excludes_data() {
          "3,64.0.0.0/2,8.0.0.0/7";
 }
 
-void TestIpAddress::excludes() {
+void TestIpAddress::excludeAddresses() {
   QFETCH(QString, input);
   IPAddress a = IPAddress::create(input);
 
-  QFETCH(QString, excludes);
-  IPAddress b = IPAddress::create(excludes);
+  QFETCH(QString, excludeAddresses);
+  IPAddress b = IPAddress::create(excludeAddresses);
 
   QStringList list;
-  for (const IPAddress& r : a.excludes(b)) {
+  for (const IPAddress& r : a.excludeAddresses(b)) {
     list.append(r.toString());
   }
 

--- a/tests/unit/testipaddress.h
+++ b/tests/unit/testipaddress.h
@@ -1,0 +1,25 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "helper.h"
+
+class TestIpAddress final : public TestHelper {
+  Q_OBJECT
+
+ private slots:
+  void basic_data();
+  void basic();
+
+  void overlaps_data();
+  void overlaps();
+
+  void contains_data();
+  void contains();
+
+  void equal_data();
+  void equal();
+
+  void excludes_data();
+  void excludes();
+};

--- a/tests/unit/testipaddress.h
+++ b/tests/unit/testipaddress.h
@@ -20,6 +20,6 @@ class TestIpAddress final : public TestHelper {
   void equal_data();
   void equal();
 
-  void excludes_data();
-  void excludes();
+  void excludeAddresses_data();
+  void excludeAddresses();
 };

--- a/tests/unit/unit.pro
+++ b/tests/unit/unit.pro
@@ -31,6 +31,7 @@ HEADERS += \
     ../../src/controller.h \
     ../../src/curve25519.h \
     ../../src/errorhandler.h \
+    ../../src/ipaddress.h \
     ../../src/ipaddressrange.h \
     ../../src/leakdetector.h \
     ../../src/localizer.h \
@@ -72,6 +73,7 @@ HEADERS += \
     testconnectiondataholder.h \
     testlocalizer.h \
     testlogger.h \
+    testipaddress.h \
     testmodels.h \
     testnetworkmanager.h \
     testreleasemonitor.h \
@@ -91,6 +93,7 @@ SOURCES += \
     ../../src/hacl-star/Hacl_Chacha20Poly1305_32.c \
     ../../src/hacl-star/Hacl_Curve25519_51.c \
     ../../src/hacl-star/Hacl_Poly1305_32.c \
+    ../../src/ipaddress.cpp \
     ../../src/ipaddressrange.cpp \
     ../../src/leakdetector.cpp \
     ../../src/localizer.cpp \
@@ -131,6 +134,7 @@ SOURCES += \
     testconnectiondataholder.cpp \
     testlocalizer.cpp \
     testlogger.cpp \
+    testipaddress.cpp \
     testmodels.cpp \
     testnetworkmanager.cpp \
     testreleasemonitor.cpp \


### PR DESCRIPTION
On top of the IP filtering for the captive portal, this PR closes #295 and #521, implementing the local access network for all the platforms (Linux, windows, macos, ios, for sure. Android to be checked)