### PR TITLE
Network requests improvements

### DIFF
--- a/src/captiveportal/captiveportalrequest.cpp
+++ b/src/captiveportal/captiveportalrequest.cpp
@@ -69,15 +69,14 @@ void CaptivePortalRequest::createRequest(const QUrl& url) {
       this, url, CAPTIVEPORTAL_HOST);
 
   connect(request, &NetworkRequest::requestFailed,
-          [this](QNetworkReply*, QNetworkReply::NetworkError error,
-                 const QByteArray&) {
+          [this](QNetworkReply::NetworkError error, const QByteArray&) {
             logger.log() << "Captive portal request failed:" << error;
             --m_pendingRequests;
             maybeComplete();
           });
 
   connect(request, &NetworkRequest::requestCompleted,
-          [this](QNetworkReply*, const QByteArray& data) {
+          [this](const QByteArray& data) {
             logger.log() << "Captive portal request completed:" << data;
 
             --m_pendingRequests;

--- a/src/connectiondataholder.cpp
+++ b/src/connectiondataholder.cpp
@@ -216,8 +216,7 @@ void ConnectionDataHolder::updateIpAddress() {
 
   NetworkRequest* request = NetworkRequest::createForIpInfo(this);
   connect(request, &NetworkRequest::requestFailed,
-          [this](QNetworkReply*, QNetworkReply::NetworkError error,
-                 const QByteArray&) {
+          [this](QNetworkReply::NetworkError error, const QByteArray&) {
             logger.log() << "IP address request failed" << error;
 
             ErrorHandler::ErrorType errorType =
@@ -231,7 +230,7 @@ void ConnectionDataHolder::updateIpAddress() {
           });
 
   connect(request, &NetworkRequest::requestCompleted,
-          [this](QNetworkReply*, const QByteArray& data) {
+          [this](const QByteArray& data) {
             logger.log() << "IP address request completed";
             QJsonDocument json = QJsonDocument::fromJson(data);
             if (json.isObject()) {

--- a/src/logger.h
+++ b/src/logger.h
@@ -36,8 +36,6 @@ constexpr const char* LOG_IOS = "ios";
 constexpr const char* LOG_ANDROID = "android";
 #endif
 
-class QNetworkReply;
-
 class Logger {
  public:
   Logger(const QString& module, const QString& className);

--- a/src/networkrequest.cpp
+++ b/src/networkrequest.cpp
@@ -297,7 +297,7 @@ void NetworkRequest::replyFinished() {
   if (m_reply->error() != QNetworkReply::NoError) {
     logger.log() << "Network error:" << m_reply->error()
                  << "status code:" << status << "- body:" << data;
-    emit requestFailed(m_reply, m_reply->error(), data);
+    emit requestFailed(m_reply->error(), data);
     return;
   }
 
@@ -306,11 +306,11 @@ void NetworkRequest::replyFinished() {
   if (m_status && status != m_status) {
     logger.log() << "Status code unexpected - status code:" << status
                  << "- expected:" << m_status;
-    emit requestFailed(m_reply, QNetworkReply::ConnectionRefusedError, data);
+    emit requestFailed(QNetworkReply::ConnectionRefusedError, data);
     return;
   }
 
-  emit requestCompleted(m_reply, data);
+  emit requestCompleted(data);
 }
 
 void NetworkRequest::handleHeaderReceived() {
@@ -327,7 +327,7 @@ void NetworkRequest::timeout() {
   m_reply->abort();
 
   logger.log() << "Network request timeout";
-  emit requestFailed(m_reply, QNetworkReply::TimeoutError, QByteArray());
+  emit requestFailed(QNetworkReply::TimeoutError, QByteArray());
 }
 
 void NetworkRequest::getRequest() {

--- a/src/networkrequest.h
+++ b/src/networkrequest.h
@@ -57,6 +57,8 @@ class NetworkRequest final : public QObject {
 
   void disableTimeout();
 
+  int statusCode() const;
+
  private:
   NetworkRequest(QObject* parent, int status);
 
@@ -67,14 +69,12 @@ class NetworkRequest final : public QObject {
   void handleReply(QNetworkReply* reply);
   void handleHeaderReceived();
 
-  int statusCode() const;
-
  private slots:
   void replyFinished();
   void timeout();
 
  signals:
-  void requestHeaderReceived(QNetworkReply* reply);
+  void requestHeaderReceived(NetworkRequest* request);
   void requestFailed(QNetworkReply* reply, QNetworkReply::NetworkError error,
                      const QByteArray& data);
   void requestCompleted(QNetworkReply*, const QByteArray& data);

--- a/src/networkrequest.h
+++ b/src/networkrequest.h
@@ -75,9 +75,8 @@ class NetworkRequest final : public QObject {
 
  signals:
   void requestHeaderReceived(NetworkRequest* request);
-  void requestFailed(QNetworkReply* reply, QNetworkReply::NetworkError error,
-                     const QByteArray& data);
-  void requestCompleted(QNetworkReply*, const QByteArray& data);
+  void requestFailed(QNetworkReply::NetworkError error, const QByteArray& data);
+  void requestCompleted(const QByteArray& data);
 
  private:
   QNetworkRequest m_request;

--- a/src/platforms/ios/iaphandler.mm
+++ b/src/platforms/ios/iaphandler.mm
@@ -344,7 +344,7 @@ void IAPHandler::processCompletedTransactions(const QStringList& ids) {
   NetworkRequest* request = NetworkRequest::createForIOSPurchase(this, receipt);
 
   connect(request, &NetworkRequest::requestFailed,
-          [this](QNetworkReply*, QNetworkReply::NetworkError error, const QByteArray& data) {
+          [this](QNetworkReply::NetworkError error, const QByteArray& data) {
             logger.log() << "Purchase request failed" << error;
 
             if (m_subscriptionState != eActive) {
@@ -379,8 +379,7 @@ void IAPHandler::processCompletedTransactions(const QStringList& ids) {
             emit alreadySubscribed();
           });
 
-  connect(request, &NetworkRequest::requestCompleted,
-          [this, ids](QNetworkReply*, const QByteArray&) {
+  connect(request, &NetworkRequest::requestCompleted, [this, ids](const QByteArray&) {
     logger.log() << "Purchase request completed";
     SettingsHolder::instance()->addSubscriptionTransactions(ids);
 

--- a/src/platforms/ios/taskiosproducts.cpp
+++ b/src/platforms/ios/taskiosproducts.cpp
@@ -36,7 +36,7 @@ void TaskIOSProducts::run(MozillaVPN* vpn) {
           });
 
   connect(request, &NetworkRequest::requestCompleted,
-          [this](QNetworkReply*, const QByteArray& data) {
+          [this](const QByteArray& data) {
             logger.log() << "IOS product request completed" << data;
 
             QJsonDocument json = QJsonDocument::fromJson(data);

--- a/src/platforms/wasm/wasmnetworkrequest.cpp
+++ b/src/platforms/wasm/wasmnetworkrequest.cpp
@@ -14,15 +14,6 @@
 namespace {
 Logger logger(LOG_NETWORKING, "WASM NetworkRequest");
 
-// A simple class to make QNetworkReply CTOR public
-class NetworkReply : public QNetworkReply {
- public:
-  NetworkReply() : QNetworkReply(nullptr) {}
-
-  qint64 readData(char*, qint64) override { return -1; }
-  void abort() override {}
-};
-
 void createDummyRequest(NetworkRequest* r, const QString& resource) {
   TimerSingleShot::create(r, 200, [r, resource] {
     QByteArray data;
@@ -38,11 +29,9 @@ void createDummyRequest(NetworkRequest* r, const QString& resource) {
       file.close();
     }
 
-    NetworkReply nr;
-    emit r->requestCompleted(
-        &nr, data.replace(
-                 "%%PUBLICKEY%%",
-                 MozillaVPN::instance()->keys()->publicKey().toLocal8Bit()));
+    emit r->requestCompleted(data.replace(
+        "%%PUBLICKEY%%",
+        MozillaVPN::instance()->keys()->publicKey().toLocal8Bit()));
   });
 }
 

--- a/src/tasks/accountandservers/taskaccountandservers.cpp
+++ b/src/tasks/accountandservers/taskaccountandservers.cpp
@@ -30,8 +30,7 @@ void TaskAccountAndServers::run(MozillaVPN* vpn) {
     NetworkRequest* request = NetworkRequest::createForAccount(this);
 
     connect(request, &NetworkRequest::requestFailed,
-            [this, vpn](QNetworkReply*, QNetworkReply::NetworkError error,
-                        const QByteArray&) {
+            [this, vpn](QNetworkReply::NetworkError error, const QByteArray&) {
               logger.log() << "Account request failed" << error;
               vpn->errorHandle(ErrorHandler::toErrorType(error));
               m_accountCompleted = true;
@@ -39,7 +38,7 @@ void TaskAccountAndServers::run(MozillaVPN* vpn) {
             });
 
     connect(request, &NetworkRequest::requestCompleted,
-            [this, vpn](QNetworkReply*, const QByteArray& data) {
+            [this, vpn](const QByteArray& data) {
               logger.log() << "Account request completed";
               vpn->accountChecked(data);
               m_accountCompleted = true;
@@ -52,8 +51,7 @@ void TaskAccountAndServers::run(MozillaVPN* vpn) {
     NetworkRequest* request = NetworkRequest::createForServers(this);
 
     connect(request, &NetworkRequest::requestFailed,
-            [this, vpn](QNetworkReply*, QNetworkReply::NetworkError error,
-                        const QByteArray&) {
+            [this, vpn](QNetworkReply::NetworkError error, const QByteArray&) {
               logger.log() << "Failed to retrieve servers";
               vpn->errorHandle(ErrorHandler::toErrorType(error));
               m_serversCompleted = true;
@@ -61,7 +59,7 @@ void TaskAccountAndServers::run(MozillaVPN* vpn) {
             });
 
     connect(request, &NetworkRequest::requestCompleted,
-            [this, vpn](QNetworkReply*, const QByteArray& data) {
+            [this, vpn](const QByteArray& data) {
               logger.log() << "Servers obtained";
               vpn->serversFetched(data);
               m_serversCompleted = true;

--- a/src/tasks/adddevice/taskadddevice.cpp
+++ b/src/tasks/adddevice/taskadddevice.cpp
@@ -54,18 +54,16 @@ void TaskAddDevice::run(MozillaVPN* vpn) {
       NetworkRequest::createForDeviceCreation(this, m_deviceName, publicKey);
 
   connect(request, &NetworkRequest::requestFailed,
-          [this, vpn](QNetworkReply*, QNetworkReply::NetworkError error,
-                      const QByteArray&) {
+          [this, vpn](QNetworkReply::NetworkError error, const QByteArray&) {
             logger.log() << "Failed to add the device" << error;
             vpn->errorHandle(ErrorHandler::toErrorType(error));
             emit completed();
           });
 
-  connect(
-      request, &NetworkRequest::requestCompleted,
-      [this, vpn, publicKey, privateKey](QNetworkReply*, const QByteArray&) {
-        logger.log() << "Device added";
-        vpn->deviceAdded(m_deviceName, publicKey, privateKey);
-        emit completed();
-      });
+  connect(request, &NetworkRequest::requestCompleted,
+          [this, vpn, publicKey, privateKey](const QByteArray&) {
+            logger.log() << "Device added";
+            vpn->deviceAdded(m_deviceName, publicKey, privateKey);
+            emit completed();
+          });
 }

--- a/src/tasks/authenticate/taskauthenticate.cpp
+++ b/src/tasks/authenticate/taskauthenticate.cpp
@@ -69,17 +69,16 @@ void TaskAuthenticate::run(MozillaVPN* vpn) {
             NetworkRequest::createForAuthenticationVerification(
                 this, pkceCodeSucces, pkceCodeVerifier);
 
-        connect(request, &NetworkRequest::requestFailed,
-                [this, vpn](QNetworkReply*, QNetworkReply::NetworkError error,
-                            const QByteArray&) {
-                  logger.log()
-                      << "Failed to complete the authentication" << error;
-                  vpn->errorHandle(ErrorHandler::toErrorType(error));
-                  emit completed();
-                });
+        connect(
+            request, &NetworkRequest::requestFailed,
+            [this, vpn](QNetworkReply::NetworkError error, const QByteArray&) {
+              logger.log() << "Failed to complete the authentication" << error;
+              vpn->errorHandle(ErrorHandler::toErrorType(error));
+              emit completed();
+            });
 
         connect(request, &NetworkRequest::requestCompleted,
-                [this, vpn](QNetworkReply*, const QByteArray& data) {
+                [this, vpn](const QByteArray& data) {
                   logger.log() << "Authentication completed";
                   authenticationCompleted(vpn, data);
                 });

--- a/src/tasks/captiveportallookup/taskcaptiveportallookup.cpp
+++ b/src/tasks/captiveportallookup/taskcaptiveportallookup.cpp
@@ -27,15 +27,14 @@ void TaskCaptivePortalLookup::run(MozillaVPN* vpn) {
 
   NetworkRequest* request = NetworkRequest::createForCaptivePortalLookup(this);
   connect(request, &NetworkRequest::requestFailed,
-          [this, vpn](QNetworkReply*, QNetworkReply::NetworkError error,
-                      const QByteArray&) {
+          [this, vpn](QNetworkReply::NetworkError error, const QByteArray&) {
             logger.log() << "Failed to obtain captive poral IPs" << error;
             vpn->errorHandle(ErrorHandler::toErrorType(error));
             emit completed();
           });
 
   connect(request, &NetworkRequest::requestCompleted,
-          [this, vpn](QNetworkReply*, const QByteArray& data) {
+          [this, vpn](const QByteArray& data) {
             logger.log() << "Lookup completed";
             if (vpn->captivePortal()->fromJson(data)) {
               vpn->captivePortal()->writeSettings();

--- a/src/tasks/removedevice/taskremovedevice.cpp
+++ b/src/tasks/removedevice/taskremovedevice.cpp
@@ -28,15 +28,14 @@ void TaskRemoveDevice::run(MozillaVPN* vpn) {
       NetworkRequest::createForDeviceRemoval(this, m_publicKey);
 
   connect(request, &NetworkRequest::requestFailed,
-          [this, vpn](QNetworkReply*, QNetworkReply::NetworkError error,
-                      const QByteArray&) {
+          [this, vpn](QNetworkReply::NetworkError error, const QByteArray&) {
             logger.log() << "Failed to remove the device" << error;
             vpn->errorHandle(ErrorHandler::toErrorType(error));
             emit completed();
           });
 
   connect(request, &NetworkRequest::requestCompleted,
-          [this, vpn](QNetworkReply*, const QByteArray&) {
+          [this, vpn](const QByteArray&) {
             logger.log() << "Device removed";
             vpn->deviceRemoved(m_publicKey);
             emit completed();

--- a/src/update/balrog.cpp
+++ b/src/update/balrog.cpp
@@ -381,15 +381,13 @@ bool Balrog::processData(const QByteArray& data) {
             });
 
     connect(request, &NetworkRequest::requestHeaderReceived,
-            [this](QNetworkReply* reply) {
+            [this](NetworkRequest* request) {
               Q_ASSERT(reply);
               logger.log() << "Request header received";
 
               // We want to proceed only if the status code is 200. The request
               // will be aborted, but the signal emitted.
-              QVariant statusCode =
-                  reply->attribute(QNetworkRequest::HttpStatusCodeAttribute);
-              if (statusCode.isValid() && statusCode.toInt() == 200) {
+              if (request->statusCode() == 200) {
                 emit updateRecommended();
               }
 

--- a/src/update/balrog.cpp
+++ b/src/update/balrog.cpp
@@ -14,7 +14,6 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QJsonValue>
-#include <QNetworkReply>
 #include <QProcess>
 #include <QScopeGuard>
 #include <QSslCertificate>
@@ -112,28 +111,27 @@ void Balrog::start() {
   NetworkRequest* request = NetworkRequest::createForGetUrl(this, url, 200);
 
   connect(request, &NetworkRequest::requestFailed,
-          [this](QNetworkReply*, QNetworkReply::NetworkError error,
-                 const QByteArray&) {
+          [this](QNetworkReply::NetworkError error, const QByteArray&) {
             logger.log() << "Request failed" << error;
             deleteLater();
           });
 
   connect(request, &NetworkRequest::requestCompleted,
-          [this](QNetworkReply* reply, const QByteArray& data) {
+          [this, request](const QByteArray& data) {
             logger.log() << "Request completed";
 
-            if (!fetchSignature(reply, data)) {
+            if (!fetchSignature(request, data)) {
               logger.log() << "Ignore failure.";
               deleteLater();
             }
           });
 }
 
-bool Balrog::fetchSignature(QNetworkReply* reply,
+bool Balrog::fetchSignature(NetworkRequest* request,
                             const QByteArray& dataUpdate) {
-  Q_ASSERT(reply);
+  Q_ASSERT(request);
 
-  QByteArray header = reply->rawHeader("Content-Signature");
+  QByteArray header = request->rawHeader("Content-Signature");
   if (header.isEmpty()) {
     logger.log() << "Content-Signature missing";
     return false;
@@ -176,15 +174,13 @@ bool Balrog::fetchSignature(QNetworkReply* reply,
   NetworkRequest* request = NetworkRequest::createForGetUrl(this, x5u, 200);
 
   connect(request, &NetworkRequest::requestFailed,
-          [this](QNetworkReply*, QNetworkReply::NetworkError error,
-                 const QByteArray&) {
+          [this](QNetworkReply::NetworkError error, const QByteArray&) {
             logger.log() << "Request failed" << error;
             deleteLater();
           });
 
   connect(request, &NetworkRequest::requestCompleted,
-          [this, signatureBlob, algorithm, dataUpdate](QNetworkReply*,
-                                                       const QByteArray& data) {
+          [this, signatureBlob, algorithm, dataUpdate](const QByteArray& data) {
             logger.log() << "Request completed";
             if (!checkSignature(data, signatureBlob, algorithm, dataUpdate)) {
               deleteLater();
@@ -374,15 +370,14 @@ bool Balrog::processData(const QByteArray& data) {
     NetworkRequest* request = NetworkRequest::createForGetUrl(this, url);
 
     connect(request, &NetworkRequest::requestFailed,
-            [this](QNetworkReply*, QNetworkReply::NetworkError error,
-                   const QByteArray&) {
+            [this](QNetworkReply::NetworkError error, const QByteArray&) {
               logger.log() << "Request failed" << error;
               deleteLater();
             });
 
     connect(request, &NetworkRequest::requestHeaderReceived,
             [this](NetworkRequest* request) {
-              Q_ASSERT(reply);
+              Q_ASSERT(request);
               logger.log() << "Request header received";
 
               // We want to proceed only if the status code is 200. The request
@@ -393,11 +388,11 @@ bool Balrog::processData(const QByteArray& data) {
 
               logger.log() << "Abort request for status code"
                            << statusCode.toInt();
-              reply->abort();
+              request->abort();
             });
 
     connect(request, &NetworkRequest::requestCompleted,
-            [this](QNetworkReply*, const QByteArray&) {
+            [this](const QByteArray&) {
               logger.log() << "Request completed";
               deleteLater();
             });
@@ -428,17 +423,16 @@ bool Balrog::processData(const QByteArray& data) {
   // No timeout for this request.
   request->disableTimeout();
 
-  connect(request, &NetworkRequest::requestFailed,
-          [this](QNetworkReply* reply, QNetworkReply::NetworkError error,
-                 const QByteArray&) {
-            logger.log() << "Request failed" << error;
-            propagateError(reply, error);
-            deleteLater();
-          });
+  connect(
+      request, &NetworkRequest::requestFailed,
+      [this, request](QNetworkReply::NetworkError error, const QByteArray&) {
+        logger.log() << "Request failed" << error;
+        propagateError(request, error);
+        deleteLater();
+      });
 
   connect(request, &NetworkRequest::requestCompleted,
-          [this, hashValue, hashFunction, url](QNetworkReply*,
-                                               const QByteArray& data) {
+          [this, hashValue, hashFunction, url](const QByteArray& data) {
             logger.log() << "Request completed";
 
             if (!computeHash(url, data, hashValue, hashFunction)) {
@@ -586,17 +580,15 @@ bool Balrog::install(const QString& filePath) {
   return true;
 }
 
-void Balrog::propagateError(QNetworkReply* reply,
+void Balrog::propagateError(NetworkRequest* request,
                             QNetworkReply::NetworkError error) {
-  Q_ASSERT(reply);
+  Q_ASSERT(request);
 
   MozillaVPN* vpn = MozillaVPN::instance();
   Q_ASSERT(vpn);
 
-  QVariant statusCode =
-      reply->attribute(QNetworkRequest::HttpStatusCodeAttribute);
   // 451 Unavailable For Legal Reasons
-  if (statusCode.isValid() && statusCode.toInt() == 451) {
+  if (request->statusCode() == 451) {
     logger.log() << "Geo IP restriction detected";
     vpn->errorHandle(ErrorHandler::GeoIpRestrictionError);
     return;

--- a/src/update/balrog.h
+++ b/src/update/balrog.h
@@ -11,6 +11,8 @@
 #include <QNetworkReply>
 #include <QTemporaryDir>
 
+class NetworkRequest;
+
 class Balrog final : public Updater {
   Q_DISABLE_COPY_MOVE(Balrog)
 
@@ -24,7 +26,7 @@ class Balrog final : public Updater {
   static QString userAgent();
 
   bool processData(const QByteArray& data);
-  bool fetchSignature(QNetworkReply* reply, const QByteArray& data);
+  bool fetchSignature(NetworkRequest* request, const QByteArray& data);
   bool checkSignature(const QByteArray& signature,
                       const QByteArray& signatureBlob,
                       QCryptographicHash::Algorithm algorithm,
@@ -36,7 +38,8 @@ class Balrog final : public Updater {
                    const QString& hashValue, const QString& hashFunction);
   bool saveFileAndInstall(const QString& url, const QByteArray& data);
   bool install(const QString& filePath);
-  void propagateError(QNetworkReply* reply, QNetworkReply::NetworkError error);
+  void propagateError(NetworkRequest* request,
+                      QNetworkReply::NetworkError error);
 
  private:
   QTemporaryDir m_tmpDir;

--- a/src/update/versionapi.cpp
+++ b/src/update/versionapi.cpp
@@ -29,11 +29,12 @@ void VersionApi::start() {
   NetworkRequest* request = NetworkRequest::createForVersions(this);
 
   connect(request, &NetworkRequest::requestFailed,
-          [](QNetworkReply*, QNetworkReply::NetworkError error,
-             const QByteArray&) { logger.log() << "Request failed" << error; });
+          [](QNetworkReply::NetworkError error, const QByteArray&) {
+            logger.log() << "Request failed" << error;
+          });
 
   connect(request, &NetworkRequest::requestCompleted,
-          [this](QNetworkReply*, const QByteArray& data) {
+          [this](const QByteArray& data) {
             logger.log() << "Request completed";
 
             if (!processData(data)) {

--- a/tests/unit/mocnetworkrequest.cpp
+++ b/tests/unit/mocnetworkrequest.cpp
@@ -9,15 +9,6 @@
 
 namespace {};
 
-// A simple class to make QNetworkReply CTOR public
-class NetworkReply : public QNetworkReply {
- public:
-  NetworkReply() : QNetworkReply(nullptr) {}
-
-  qint64 readData(char*, qint64) override { return -1; }
-  void abort() override {}
-};
-
 NetworkRequest::NetworkRequest(QObject* parent, int status)
     : QObject(parent), m_status(status) {
   MVPN_COUNT_CTOR(NetworkRequest);
@@ -28,15 +19,12 @@ NetworkRequest::NetworkRequest(QObject* parent, int status)
   TimerSingleShot::create(this, 0, [this, nc]() {
     deleteLater();
 
-    NetworkReply nr;
-
     if (nc.m_status == TestHelper::NetworkConfig::Failure) {
-      emit requestFailed(&nr, QNetworkReply::NetworkError::HostNotFoundError,
-                         "");
+      emit requestFailed(QNetworkReply::NetworkError::HostNotFoundError, "");
     } else {
       Q_ASSERT(nc.m_status == TestHelper::NetworkConfig::Success);
 
-      emit requestCompleted(&nr, nc.m_body);
+      emit requestCompleted(nc.m_body);
     }
   });
 }


### PR DESCRIPTION
This PR does 2 things:
1. it fixes the authentication failure, letting the `NetworkRequest::replyFinished()` to propagate the error
2. it removes the sharing of `QNetworkReply` to the rest of the codebase. It was done for balrog and used for 2 methods: `rawHeader` and `statusCode`. Now these 2 methods are part of the `NetworkRequest` class