### PR TITLE
Heartbeat

### DIFF
--- a/scripts/test_function.sh
+++ b/scripts/test_function.sh
@@ -6,10 +6,18 @@
 
 . $(dirname $0)/commons.sh
 
+export LLVM_PROFILE_FILE=/tmp/mozillavpn.llvm-0
+REPORT_FILE=/tmp/report.html
+
 print N "This script runs the functional tests"
 print N ""
 
+ID=0
+
 runTest() {
+  ID=$((ID+1))
+  export LLVM_PROFILE_FILE=/tmp/mozillavpn.llvm-$ID
+
   print Y "Running the app..."
   "$1" &>/tmp/VPN_LOG.txt &
   PID=$!
@@ -49,3 +57,30 @@ else
     runTest "$1" "$i"
   done
 fi
+
+FILES=()
+for ((I=0; $I <= $ID; I=$I+1)); do
+  LLVM_PROFILE_FILE=/tmp/mozillavpn.llvm-$I
+  if ! [ -f $LLVM_PROFILE_FILE ]; then
+    print Y "$LLVM_PROFILE_FILE: No report generated!"
+    continue
+  fi
+
+  FILES[$I]="$LLVM_PROFILE_FILE"
+done
+
+if [ ${#FILES[*]} == 0 ]; then
+  print Y "No reports generated"
+  exit 0
+fi
+
+printn Y "Merge the profile data... "
+llvm-profdata-10 merge ${FILES[@]} -o /tmp/mozillavpn.llvm-final || die "Failed to merge the coverage report"
+print G "done."
+
+print Y "Report:"
+llvm-cov-10 report "$1" -instr-profile=/tmp/mozillavpn.llvm-final src
+
+printn Y "Generating the HTML report... "
+llvm-cov-10 show "$1" -instr-profile=/tmp/mozillavpn.llvm-final src -format=html > $REPORT_FILE || die "Failed to generate the HTML report"
+print G $REPORT_FILE

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -124,6 +124,7 @@ void Controller::implInitialized(bool status, bool a_connected,
   Q_UNUSED(status);
 
   if (processNextStep()) {
+    setState(StateOff);
     return;
   }
 
@@ -319,6 +320,7 @@ void Controller::disconnected() {
   NextStep nextStep = m_nextStep;
 
   if (processNextStep()) {
+    setState(StateOff);
     return;
   }
 

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -385,6 +385,22 @@ void Controller::quit() {
   }
 }
 
+void Controller::backendFailure() {
+  logger.log() << "backend failure";
+
+  if (m_state == StateOff) {
+    emit readyToBackendFailure();
+    return;
+  }
+
+  m_nextStep = BackendFailure;
+
+  if (m_state == StateOn) {
+    deactivate();
+    return;
+  }
+}
+
 void Controller::updateRequired() {
   logger.log() << "Update required";
 
@@ -429,6 +445,11 @@ bool Controller::processNextStep() {
 
   if (nextStep == Update) {
     emit readyToUpdate();
+    return true;
+  }
+
+  if (nextStep == BackendFailure) {
+    emit readyToBackendFailure();
     return true;
   }
 

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -390,7 +390,7 @@ void Controller::quit() {
 void Controller::backendFailure() {
   logger.log() << "backend failure";
 
-  if (m_state == StateOff) {
+  if (m_state == StateInitializing || m_state == StateOff) {
     emit readyToBackendFailure();
     return;
   }

--- a/src/controller.h
+++ b/src/controller.h
@@ -76,6 +76,8 @@ class Controller final : public QObject {
 
   int connectionRetry() const { return m_connectionRetry; }
 
+  void backendFailure();
+
  public slots:
   void activate();
 
@@ -100,6 +102,7 @@ class Controller final : public QObject {
   void timeChanged();
   void readyToQuit();
   void readyToUpdate();
+  void readyToBackendFailure();
   void connectionRetryChanged();
 
  private:
@@ -134,6 +137,7 @@ class Controller final : public QObject {
     Quit,
     Update,
     Disconnect,
+    BackendFailure,
   };
 
   NextStep m_nextStep = None;

--- a/src/controller.h
+++ b/src/controller.h
@@ -113,6 +113,8 @@ class Controller final : public QObject {
 
   void resetConnectionCheck();
 
+  void heartbeatCompleted();
+
  private:
   State m_state = StateInitializing;
 
@@ -138,7 +140,14 @@ class Controller final : public QObject {
 
   ConnectionCheck m_connectionCheck;
   int m_connectionRetry = 0;
-  bool m_expectDisconnection = false;
+
+  enum ReconnectionStep {
+    NoReconnection,
+    ExpectDisconnection,
+    ExpectHeartbeat,
+  };
+
+  ReconnectionStep m_reconnectionStep = NoReconnection;
 
   QList<std::function<void(const QString& serverIpv4Gateway, uint64_t txBytes,
                            uint64_t rxBytes)>>

--- a/src/inspector/inspectorwebsocketconnection.cpp
+++ b/src/inspector/inspectorwebsocketconnection.cpp
@@ -162,6 +162,11 @@ static bool cmdForceUnsecuredNetwork(QWebSocket*, const QList<QByteArray>&) {
   return true;
 }
 
+static bool cmdForceHeartbeatFailure(QWebSocket*, const QList<QByteArray>&) {
+  MozillaVPN::instance()->heartbeatFailure();
+  return true;
+}
+
 struct WebSocketCommand {
   QString m_commandName;
   int32_t m_arguments;
@@ -184,6 +189,7 @@ static QList<WebSocketCommand> s_commands{
     WebSocketCommand{"force_unsecured_network", 0, cmdForceUnsecuredNetwork},
     WebSocketCommand{"activate", 0, cmdActivate},
     WebSocketCommand{"deactivate", 0, cmdDeactivate},
+    WebSocketCommand{"force_heartbeat_failure", 0, cmdForceHeartbeatFailure},
     WebSocketCommand{"logout", 0, cmdLogout},
 };
 

--- a/src/inspector/inspectorwebsocketconnection.cpp
+++ b/src/inspector/inspectorwebsocketconnection.cpp
@@ -163,7 +163,7 @@ static bool cmdForceUnsecuredNetwork(QWebSocket*, const QList<QByteArray>&) {
 }
 
 static bool cmdForceHeartbeatFailure(QWebSocket*, const QList<QByteArray>&) {
-  MozillaVPN::instance()->heartbeatFailure();
+  MozillaVPN::instance()->heartbeatCompleted(false /* success */);
   return true;
 }
 

--- a/src/inspector/webserver/index.html
+++ b/src/inspector/webserver/index.html
@@ -103,6 +103,7 @@
     commands.set("detectCaptivePortal", { func: () => ws.send("force_captive_portal_check"), desc: "Starts the captive portal detection" });
     commands.set("triggerCaptivePortal", { func: () => ws.send("force_captive_portal_detection"), desc: "Triggers the captive portal detection" });
     commands.set("triggerUnsecuredNetwork", { func: () => ws.send("force_unsecured_network"), desc: "Triggers the unsecured network detection" });
+    commands.set("triggerHeartbeatFailure", { func: () => ws.send("force_heartbeat_failure"), desc: "Triggers the heartbeat server-side failure" });
 
     function parseCommand(input) {
       input = input.trim();

--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -96,6 +96,12 @@ MozillaVPN::MozillaVPN() : m_private(new Private()) {
   connect(&m_private->m_controller, &Controller::readyToUpdate,
           [this]() { setState(StateUpdateRequired); });
 
+  connect(&m_private->m_controller, &Controller::readyToBackendFailure,
+          [this]() {
+            deleteTasks();
+            setState(StateBackendFailure);
+          });
+
   connect(&m_private->m_controller, &Controller::stateChanged, this,
           &MozillaVPN::controllerStateChanged);
 
@@ -1165,8 +1171,7 @@ void MozillaVPN::heartbeatCompleted(bool success) {
   logger.log() << "Server-side check done:" << success;
 
   if (!success) {
-    deleteTasks();
-    setState(StateBackendFailure);
+    m_private->m_controller.backendFailure();
     return;
   }
 

--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -1175,6 +1175,10 @@ void MozillaVPN::heartbeatCompleted(bool success) {
     return;
   }
 
+  if (m_state != StateBackendFailure) {
+    return;
+  }
+
   if (!modelsInitialized() || !m_userAuthenticated) {
     setState(StateInitialize);
     return;

--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -19,6 +19,7 @@
 #include "tasks/captiveportallookup/taskcaptiveportallookup.h"
 #include "tasks/controlleraction/taskcontrolleraction.h"
 #include "tasks/function/taskfunction.h"
+#include "tasks/heartbeat/taskheartbeat.h"
 #include "tasks/removedevice/taskremovedevice.h"
 #include "urlopener.h"
 
@@ -80,8 +81,8 @@ MozillaVPN::MozillaVPN() : m_private(new Private()) {
 
   connect(&m_periodicOperationsTimer, &QTimer::timeout, [this]() {
     scheduleTask(new TaskAccountAndServers());
-
     scheduleTask(new TaskCaptivePortalLookup());
+    scheduleTask(new TaskHeartbeat());
   });
 
   connect(this, &MozillaVPN::stateChanged, [this]() {
@@ -317,6 +318,7 @@ void MozillaVPN::authenticate() {
     return;
   }
 
+  scheduleTask(new TaskHeartbeat());
   scheduleTask(new TaskAuthenticate());
 }
 
@@ -1156,5 +1158,10 @@ void MozillaVPN::controllerStateChanged() {
 
 void MozillaVPN::backendServiceRestore() {
   logger.log() << "Background service restore request";
+  // TODO
+}
+
+void MozillaVPN::heartbeatFailure() {
+  logger.log() << "Server-side failure detected";
   // TODO
 }

--- a/src/mozillavpn.h
+++ b/src/mozillavpn.h
@@ -50,6 +50,7 @@ class MozillaVPN final : public QObject {
     StateSubscriptionValidation,
     StateSubscriptionBlocked,
     StateDeviceLimit,
+    StateBackendFailure,
   };
   Q_ENUM(State);
 
@@ -119,6 +120,7 @@ class MozillaVPN final : public QObject {
   Q_INVOKABLE void refreshDevices();
   Q_INVOKABLE void update();
   Q_INVOKABLE void backendServiceRestore();
+  Q_INVOKABLE void triggerHeartbeat();
 
   // Internal object getters:
   CaptivePortal* captivePortal() { return &m_private->m_captivePortal; }
@@ -199,7 +201,7 @@ class MozillaVPN final : public QObject {
   bool updating() const { return m_updating; }
   void setUpdating(bool updating);
 
-  void heartbeatFailure();
+  void heartbeatCompleted(bool success);
 
  private:
   void setState(State state);

--- a/src/mozillavpn.h
+++ b/src/mozillavpn.h
@@ -199,6 +199,8 @@ class MozillaVPN final : public QObject {
   bool updating() const { return m_updating; }
   void setUpdating(bool updating);
 
+  void heartbeatFailure();
+
  private:
   void setState(State state);
 

--- a/src/networkrequest.cpp
+++ b/src/networkrequest.cpp
@@ -229,6 +229,17 @@ NetworkRequest* NetworkRequest::createForCaptivePortalLookup(QObject* parent) {
   return r;
 }
 
+NetworkRequest* NetworkRequest::createForHeartbeat(QObject* parent) {
+  NetworkRequest* r = new NetworkRequest(parent, 200);
+
+  QUrl url(Constants::API_URL);
+  url.setPath("/__heartbeat__");
+  r->m_request.setUrl(url);
+
+  r->getRequest();
+  return r;
+}
+
 #ifdef MVPN_IOS
 NetworkRequest* NetworkRequest::createForIOSProducts(QObject* parent) {
   Q_ASSERT(parent);

--- a/src/networkrequest.h
+++ b/src/networkrequest.h
@@ -48,6 +48,8 @@ class NetworkRequest final : public QObject {
 
   static NetworkRequest* createForCaptivePortalLookup(QObject* parent);
 
+  static NetworkRequest* createForHeartbeat(QObject* parent);
+
 #ifdef MVPN_IOS
   static NetworkRequest* createForIOSProducts(QObject* parent);
 

--- a/src/platforms/wasm/wasmnetworkrequest.cpp
+++ b/src/platforms/wasm/wasmnetworkrequest.cpp
@@ -127,6 +127,14 @@ NetworkRequest* NetworkRequest::createForCaptivePortalLookup(QObject* parent) {
   return r;
 }
 
+NetworkRequest* NetworkRequest::createForHeartbeat(QObject* parent) {
+  Q_ASSERT(parent);
+
+  NetworkRequest* r = new NetworkRequest(parent, 200);
+  createDummyRequest(r);
+  return r;
+}
+
 void NetworkRequest::replyFinished() {}
 
 void NetworkRequest::timeout() {}

--- a/src/qml.qrc
+++ b/src/qml.qrc
@@ -63,6 +63,7 @@
         <file>ui/states/StatePostAuthentication.qml</file>
         <file>ui/states/StateUpdateRequired.qml</file>
         <file>ui/states/StateDeviceLimit.qml</file>
+        <file>ui/states/StateBackendFailure.qml</file>
         <file>ui/views/ViewMain.qml</file>
         <file>ui/views/ViewDevices.qml</file>
         <file>ui/views/ViewServers.qml</file>

--- a/src/src.pro
+++ b/src/src.pro
@@ -103,6 +103,7 @@ SOURCES += \
         tasks/captiveportallookup/taskcaptiveportallookup.cpp \
         tasks/controlleraction/taskcontrolleraction.cpp \
         tasks/function/taskfunction.cpp \
+        tasks/heartbeat/taskheartbeat.cpp \
         tasks/removedevice/taskremovedevice.cpp \
         timercontroller.cpp \
         timersingleshot.cpp \
@@ -185,6 +186,7 @@ HEADERS += \
         tasks/captiveportallookup/taskcaptiveportallookup.h \
         tasks/controlleraction/taskcontrolleraction.h \
         tasks/function/taskfunction.h \
+        tasks/heartbeat/taskheartbeat.h \
         tasks/removedevice/taskremovedevice.h \
         timercontroller.h \
         timersingleshot.h \

--- a/src/src.pro
+++ b/src/src.pro
@@ -750,3 +750,9 @@ else{
 QMAKE_LRELEASE_FLAGS += -idbased
 CONFIG += lrelease
 CONFIG += embed_translations
+
+equals(QMAKE_CXX, clang++):debug {
+    message(Coverage enabled)
+    QMAKE_CXXFLAGS += -fprofile-instr-generate -fcoverage-mapping
+    QMAKE_LFLAGS += -fprofile-instr-generate -fcoverage-mapping
+}

--- a/src/tasks/heartbeat/taskheartbeat.cpp
+++ b/src/tasks/heartbeat/taskheartbeat.cpp
@@ -1,0 +1,50 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "taskheartbeat.h"
+#include "leakdetector.h"
+#include "logger.h"
+#include "mozillavpn.h"
+#include "networkrequest.h"
+
+#include <QJsonDocument>
+#include <QJsonObject>
+
+namespace {
+Logger logger(LOG_MAIN, "TaskHeartbeat");
+}
+
+TaskHeartbeat::TaskHeartbeat() : Task("TaskHeartbeat") {
+  MVPN_COUNT_CTOR(TaskHeartbeat);
+}
+
+TaskHeartbeat::~TaskHeartbeat() { MVPN_COUNT_DTOR(TaskHeartbeat); }
+
+void TaskHeartbeat::run(MozillaVPN* vpn) {
+  NetworkRequest* request = NetworkRequest::createForHeartbeat(this);
+
+  connect(request, &NetworkRequest::requestFailed,
+          [this](QNetworkReply::NetworkError, const QByteArray&) {
+            logger.log() << "Failed to talk with the server";
+            // We don't know if this happeneded because of a global network
+            // failure or a local network issue. In general, let's ignore this
+            // error.
+            emit completed();
+          });
+
+  connect(request, &NetworkRequest::requestCompleted,
+          [this, vpn](const QByteArray& data) {
+            logger.log() << "Heartbeat content received:" << data;
+
+            QJsonObject json = QJsonDocument::fromJson(data).object();
+            QJsonValue mullvad = json.value("mullvadOK");
+            QJsonValue db = json.value("dbOK");
+            if ((mullvad.isBool() && db.isBool()) &&
+                (!mullvad.toBool() || !db.toBool())) {
+              vpn->heartbeatFailure();
+            }
+
+            emit completed();
+          });
+}

--- a/src/tasks/heartbeat/taskheartbeat.h
+++ b/src/tasks/heartbeat/taskheartbeat.h
@@ -1,0 +1,22 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef TASKHEARTBEAT_H
+#define TASKHEARTBEAT_H
+
+#include "task.h"
+
+#include <QObject>
+
+class TaskHeartbeat final : public Task {
+  Q_DISABLE_COPY_MOVE(TaskHeartbeat)
+
+ public:
+  TaskHeartbeat();
+  ~TaskHeartbeat();
+
+  void run(MozillaVPN* vpn) override;
+};
+
+#endif  // TASKHEARTBEAT_H

--- a/src/ui/main.qml
+++ b/src/ui/main.qml
@@ -192,6 +192,15 @@ Window {
                         source: "states/StateDeviceLimit.qml"
                     }
 
+                },
+                State {
+                    name: VPN.StateBackendFailure
+
+                    PropertyChanges {
+                        target: loader
+                        source: "states/StateBackendFailure.qml"
+                    }
+
                 }
             ]
 

--- a/src/ui/states/StateBackendFailure.qml
+++ b/src/ui/states/StateBackendFailure.qml
@@ -10,6 +10,9 @@ import "../components"
 
 Item {
     VPNButton {
+        // This is needed for testing.
+        objectName: "heartbeatTryButton";
+
         text: "click me"
         anchors.fill: parent
         onClicked: VPN.triggerHeartbeat();

--- a/src/ui/states/StateBackendFailure.qml
+++ b/src/ui/states/StateBackendFailure.qml
@@ -1,0 +1,17 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import QtQuick 2.5
+import QtQuick.Controls 2.14
+import Mozilla.VPN 1.0
+
+import "../components"
+
+Item {
+    VPNButton {
+        text: "click me"
+        anchors.fill: parent
+        onClicked: VPN.triggerHeartbeat();
+    }
+}

--- a/tests/functional/helper.js
+++ b/tests/functional/helper.js
@@ -66,6 +66,11 @@ module.exports = {
     assert(buffer.length === 1 && buffer[0] === 'ok', 'Invalid answer');
   },
 
+  async forceHeartbeatFailure() {
+    const buffer = await this._writeCommand('force_heartbeat_failure');
+    assert(buffer.length === 1 && buffer[0] === 'ok', 'Invalid answer');
+  },
+
   async quit() {
     const buffer = await this._writeCommand('quit');
     assert(

--- a/tests/functional/testConnection.js
+++ b/tests/functional/testConnection.js
@@ -63,8 +63,7 @@ describe('User authentication', function() {
     await vpn.waitForCondition(async () => {
       let connectingMsg =
           await vpn.getElementProperty('controllerTitle', 'text');
-      return connectingMsg == 'Connecting…' ||
-          connectingMsg == 'vpn.controller.connectingState';
+      return connectingMsg == 'Connecting…';
     });
 
     assert(

--- a/tests/functional/testHeartbeat.js
+++ b/tests/functional/testHeartbeat.js
@@ -162,8 +162,7 @@ describe('Backend failure', function() {
     await vpn.waitForCondition(async () => {
       let connectingMsg =
           await vpn.getElementProperty('controllerTitle', 'text');
-      return connectingMsg == 'Connecting…' ||
-          connectingMsg == 'vpn.controller.connectingState';
+      return connectingMsg == 'Connecting…';
     });
 
     assert(
@@ -185,8 +184,7 @@ describe('Backend failure', function() {
     await vpn.waitForCondition(async () => {
       let connectingMsg =
           await vpn.getElementProperty('controllerTitle', 'text');
-      return connectingMsg == 'Connecting…' ||
-          connectingMsg == 'vpn.controller.connectingState';
+      return connectingMsg == 'Connecting…';
     });
   });
 
@@ -211,8 +209,7 @@ describe('Backend failure', function() {
     await vpn.waitForCondition(async () => {
       let connectingMsg =
           await vpn.getElementProperty('controllerTitle', 'text');
-      return connectingMsg == 'Connecting…' ||
-          connectingMsg == 'vpn.controller.connectingState';
+      return connectingMsg == 'Connecting…';
     });
   });
 

--- a/tests/functional/testHeartbeat.js
+++ b/tests/functional/testHeartbeat.js
@@ -1,0 +1,251 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const assert = require('assert');
+const util = require('util');
+const vpn = require('./helper.js');
+const FirefoxHelper = require('./firefox.js');
+
+describe('Backend failure', function() {
+  let driver;
+
+  async function backendFailureAndRestore() {
+    await vpn.forceHeartbeatFailure();
+
+    await vpn.waitForElement('heartbeatTryButton');
+    await vpn.waitForElementProperty('heartbeatTryButton', 'visible', 'true');
+
+    await vpn.wait();
+
+    await vpn.clickOnElement('heartbeatTryButton');
+    await vpn.wait();
+  }
+
+  this.timeout(100000);
+
+  before(async () => {
+    await vpn.connect();
+    driver = await FirefoxHelper.createDriver();
+  });
+
+  beforeEach(() => {});
+
+  afterEach(() => {});
+
+  after(async () => {
+    await driver.quit();
+    vpn.disconnect();
+  });
+
+  it('reset the app', async () => await vpn.reset());
+
+  it('Backend failure during the main view', async () => {
+    assert(await vpn.getLastUrl() == '');
+
+    await vpn.waitForElement('getHelpLink');
+    await vpn.waitForElementProperty('getHelpLink', 'visible', 'true');
+
+    await backendFailureAndRestore();
+
+    await vpn.waitForElement('getHelpLink');
+    await vpn.waitForElementProperty('getHelpLink', 'visible', 'true');
+  });
+
+  it('Backend failure in the help menu', async () => {
+    await vpn.clickOnElement('getHelpLink');
+    await vpn.waitForElementProperty('getHelpLink', 'visible', 'false');
+
+    await vpn.waitForElement('getHelpBack');
+    await vpn.waitForElementProperty('getHelpBack', 'visible', 'true');
+
+    await backendFailureAndRestore();
+
+    await vpn.waitForElement('getHelpLink');
+    await vpn.waitForElementProperty('getHelpLink', 'visible', 'true');
+  });
+
+  it('Backend failure in the onboarding (aborting in each phase)', async () => {
+    let onboardingView = 0;
+    let onboarding = true;
+    while (onboarding) {
+      assert(
+          await vpn.getElementProperty('learnMoreLink', 'visible') == 'true');
+      await vpn.clickOnElement('learnMoreLink');
+
+      await vpn.waitForElement('skipOnboarding');
+      await vpn.waitForElementProperty('skipOnboarding', 'visible', 'true');
+
+      await vpn.wait();
+
+      for (let i = 0; i < onboardingView; ++i) {
+        assert(await vpn.hasElement('onboardingNext'));
+        assert(
+            await vpn.getElementProperty('onboardingNext', 'visible') ==
+            'true');
+        await vpn.clickOnElement('onboardingNext');
+
+        await vpn.wait();
+      }
+
+      assert(
+          await vpn.getElementProperty('onboardingNext', 'visible') == 'true');
+
+      onboarding =
+          await vpn.getElementProperty('onboardingNext', 'text') == 'Next';
+
+      await backendFailureAndRestore();
+
+      await vpn.waitForElement('getHelpLink');
+      await vpn.waitForElementProperty('getHelpLink', 'visible', 'true');
+
+      await vpn.wait();
+
+      ++onboardingView;
+    }
+  });
+
+  it('BackendFailure during the authentication', async () => {
+    await vpn.waitForElement('getHelpLink');
+    await vpn.waitForElementProperty('getHelpLink', 'visible', 'true');
+
+    await vpn.clickOnElement('getStarted');
+
+    await vpn.waitForCondition(async () => {
+      const url = await vpn.getLastUrl();
+      return url.includes('/api/v2/vpn/login');
+    });
+
+    await vpn.wait();
+
+    await vpn.waitForElement('authenticatingView');
+    await vpn.waitForElementProperty('authenticatingView', 'visible', 'true');
+
+    await backendFailureAndRestore();
+
+    await vpn.waitForElement('getHelpLink');
+    await vpn.waitForElementProperty('getHelpLink', 'visible', 'true');
+
+    await vpn.wait();
+  });
+
+  it('authenticate', async () => await vpn.authenticate(driver, false));
+
+  it('BackendFailure in the Post authentication view', async () => {
+    await vpn.waitForElement('postAuthenticationButton');
+
+    await backendFailureAndRestore();
+
+    await vpn.waitForElement('controllerTitle');
+    await vpn.waitForElementProperty('controllerTitle', 'visible', 'true');
+  });
+
+  it('BackendFailure in the Controller view', async () => {
+    await vpn.waitForElement('controllerTitle');
+    await vpn.waitForElementProperty('controllerTitle', 'visible', 'true');
+    assert(
+        await vpn.getElementProperty('controllerTitle', 'text') ==
+        'VPN is off');
+
+    await backendFailureAndRestore();
+
+    await vpn.waitForElement('controllerTitle');
+    await vpn.waitForElementProperty('controllerTitle', 'visible', 'true');
+    assert(
+        await vpn.getElementProperty('controllerTitle', 'text') ==
+        'VPN is off');
+  });
+
+  it('BackendFailure when connecting', async () => {
+    await vpn.activate();
+
+    await vpn.waitForCondition(async () => {
+      let connectingMsg =
+          await vpn.getElementProperty('controllerTitle', 'text');
+      return connectingMsg == 'Connecting…' ||
+          connectingMsg == 'vpn.controller.connectingState';
+    });
+
+    assert(
+        await vpn.getElementProperty('controllerSubTitle', 'text') ==
+        'Masking connection and location');
+
+    await backendFailureAndRestore();
+
+    await vpn.waitForElement('controllerTitle');
+    await vpn.waitForElementProperty('controllerTitle', 'visible', 'true');
+    assert(
+        await vpn.getElementProperty('controllerTitle', 'text') ==
+        'VPN is off');
+  });
+
+  it('connecting', async () => {
+    await vpn.activate();
+
+    await vpn.waitForCondition(async () => {
+      let connectingMsg =
+          await vpn.getElementProperty('controllerTitle', 'text');
+      return connectingMsg == 'Connecting…' ||
+          connectingMsg == 'vpn.controller.connectingState';
+    });
+  });
+
+  it('BackendFailure when connected', async () => {
+    await vpn.waitForCondition(async () => {
+      return await vpn.getElementProperty('controllerTitle', 'text') ==
+          'VPN is on';
+    });
+
+    await backendFailureAndRestore();
+
+    await vpn.waitForElement('controllerTitle');
+    await vpn.waitForElementProperty('controllerTitle', 'visible', 'true');
+    assert(
+        await vpn.getElementProperty('controllerTitle', 'text') ==
+        'VPN is off');
+  });
+
+  it('connecting', async () => {
+    await vpn.activate();
+
+    await vpn.waitForCondition(async () => {
+      let connectingMsg =
+          await vpn.getElementProperty('controllerTitle', 'text');
+      return connectingMsg == 'Connecting…' ||
+          connectingMsg == 'vpn.controller.connectingState';
+    });
+  });
+
+  it('connected', async () => {
+    await vpn.waitForCondition(async () => {
+      return await vpn.getElementProperty('controllerTitle', 'text') ==
+          'VPN is on';
+    });
+
+    vpn.wait();
+  });
+
+  it('disconnecting', async () => {
+    await vpn.deactivate();
+
+    await vpn.waitForCondition(async () => {
+      return await vpn.getElementProperty('controllerTitle', 'text') ==
+          'Disconnecting…';
+    });
+
+    await backendFailureAndRestore();
+
+    await vpn.waitForElement('controllerTitle');
+    await vpn.waitForElementProperty('controllerTitle', 'visible', 'true');
+    assert(
+        await vpn.getElementProperty('controllerTitle', 'text') ==
+        'VPN is off');
+  });
+
+  it('Logout', async () => {
+    await vpn.logout();
+    await vpn.wait();
+  });
+
+  it('quit the app', async () => await vpn.quit());
+});

--- a/tests/unit/moccontroller.cpp
+++ b/tests/unit/moccontroller.cpp
@@ -67,3 +67,5 @@ void Controller::quit() {}
 void Controller::connectionConfirmed() {}
 
 void Controller::connectionFailed() {}
+
+void Controller::heartbeatCompleted() {}

--- a/tests/unit/moccontroller.cpp
+++ b/tests/unit/moccontroller.cpp
@@ -69,3 +69,5 @@ void Controller::connectionConfirmed() {}
 void Controller::connectionFailed() {}
 
 void Controller::heartbeatCompleted() {}
+
+void Controller::backendFailure() {}

--- a/tests/unit/mocmozillavpn.cpp
+++ b/tests/unit/mocmozillavpn.cpp
@@ -127,3 +127,5 @@ MozillaVPN::RemovalDeviceOption MozillaVPN::maybeRemoveCurrentDevice() {
 void MozillaVPN::controllerStateChanged() {}
 
 void MozillaVPN::backendServiceRestore() {}
+
+void MozillaVPN::heartbeatFailure() {}

--- a/tests/unit/mocmozillavpn.cpp
+++ b/tests/unit/mocmozillavpn.cpp
@@ -128,4 +128,6 @@ void MozillaVPN::controllerStateChanged() {}
 
 void MozillaVPN::backendServiceRestore() {}
 
-void MozillaVPN::heartbeatFailure() {}
+void MozillaVPN::heartbeatCompleted(bool) {}
+
+void MozillaVPN::triggerHeartbeat() {}


### PR DESCRIPTION
This PR implements the following:
- backend failure view (just a button for now)
- the view is shown when the app detects a backend failure
- the backend failure happens before the authentication, at VPN activation failure, any hour (in debug builds, 4 seconds).
- the WebSocket command: triggerHeatbeatFailure
- a test to check the view during any known phase (onboarding, initial view, authenticating, authenticated, main view, connecting, connected, disconnecting, disconnected)