### PR TITLE
Keep en-lang file in tree and remove generator comments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ xcode.xconfig
 .gradle/
 
 *.ts
+!translations/mozillavpn_en.ts
 tests/unit/tests
 build
 Debug/

--- a/scripts/importLanguages.py
+++ b/scripts/importLanguages.py
@@ -85,10 +85,6 @@ with open('translations/translations.pri', 'w') as pri_file:
 print('Updated translations.pri')
 
 # Step 3
-# Generate new ts files
-os.system('lupdate src/src.pro')
-
-# Step 4
 # Now import translations into the files
 for l10n_file in l10n_files:
     os.system(f"lconvert -if xlf -i {l10n_file['xliff']} -o {l10n_file['ts']}")

--- a/src/connectiondataholder.cpp
+++ b/src/connectiondataholder.cpp
@@ -20,8 +20,7 @@ namespace {
 Logger logger(LOG_NETWORKING, "ConnectionDataHolder");
 }
 
-//% "Loading"
-//: This refers to the current IP address, i.e. "IP: Loading".
+
 ConnectionDataHolder::ConnectionDataHolder()
     : m_ipAddress(qtTrId("vpn.connectionInfo.loading")) {
   MVPN_COUNT_CTOR(ConnectionDataHolder);

--- a/src/models/helpmodel.cpp
+++ b/src/models/helpmodel.cpp
@@ -36,7 +36,6 @@ void maybeInitialize() {
 
   // Here we use the logger to force lrelease to add the help menu Ids.
 
-  //% "View log"
   logger.log() << "Adding:" << qtTrId("help.viewLog");
   s_helpEntries.append(HelpEntry("help.viewLog",
 #if defined(MVPN_ANDROID) || defined(MVPN_IOS)
@@ -46,12 +45,11 @@ void maybeInitialize() {
 #endif
                                  true, MozillaVPN::LinkContact));
 
-  //% "Help Center"
   logger.log() << "Adding:" << qtTrId("help.helpCenter");
   s_helpEntries.append(
       HelpEntry("help.helpCenter", true, false, MozillaVPN::LinkHelpSupport));
 
-  //% "Contact us"
+
   logger.log() << "Adding:" << qtTrId("help.contactUs");
   s_helpEntries.append(
       HelpEntry("help.contactUs", true, false, MozillaVPN::LinkContact));

--- a/src/notificationhandler.cpp
+++ b/src/notificationhandler.cpp
@@ -56,22 +56,15 @@ void NotificationHandler::showNotification() {
       if (m_switching) {
         m_switching = false;
 
-        //% "VPN Switched Servers"
-        title = qtTrId("vpn.systray.statusSwitch.title");
-        //% "Switched from %1, %2 to %3, %4"
-        //: Shown as message body in a notification. %1 and %3 are countries, %2
-        //: and %4 are cities.
+        title = qtTrId("vpn.systray.statusSwitch.title")
         message = qtTrId("vpn.systray.statusSwtich.message")
                       .arg(m_switchingServerCountry)
                       .arg(m_switchingServerCity)
                       .arg(vpn->currentServer()->country())
                       .arg(vpn->currentServer()->city());
       } else {
-        //% "VPN Connected"
+
         title = qtTrId("vpn.systray.statusConnected.title");
-        //% "Connected to %1, %2"
-        //: Shown as message body in a notification. %1 is the country, %2 is
-        //: the city.
         message = qtTrId("vpn.systray.statusConnected.message")
                       .arg(vpn->currentServer()->country())
                       .arg(vpn->currentServer()->city());
@@ -82,11 +75,8 @@ void NotificationHandler::showNotification() {
       if (m_connected) {
         m_connected = false;
 
-        //% "VPN Disconnected"
+
         title = qtTrId("vpn.systray.statusDisconnected.title");
-        //% "Disconnected from %1, %2"
-        //: Shown as message body in a notification. %1 is the country, %2 is
-        //: the city.
         message = qtTrId("vpn.systray.statusDisconnected.message")
                       .arg(vpn->currentServer()->country())
                       .arg(vpn->currentServer()->city());

--- a/src/notificationhandler.cpp
+++ b/src/notificationhandler.cpp
@@ -56,7 +56,7 @@ void NotificationHandler::showNotification() {
       if (m_switching) {
         m_switching = false;
 
-        title = qtTrId("vpn.systray.statusSwitch.title")
+        title = qtTrId("vpn.systray.statusSwitch.title");
         message = qtTrId("vpn.systray.statusSwtich.message")
                       .arg(m_switchingServerCountry)
                       .arg(m_switchingServerCity)

--- a/src/platforms/android/androidauthenticationview.qml
+++ b/src/platforms/android/androidauthenticationview.qml
@@ -59,7 +59,6 @@ Item {
             anchors.top: menuBar.top
             anchors.centerIn: menuBar
 
-            //% "Authentication"
             text: qsTrId("vpn.android.authentication")
         }
 

--- a/src/platforms/android/androidcontroller.cpp
+++ b/src/platforms/android/androidcontroller.cpp
@@ -126,8 +126,6 @@ void AndroidController::setNotificationText(const QString& title,
 void AndroidController::setFallbackConnectedNotification() {
   QJsonObject args;
   args["title"] = qtTrId("vpn.main.productName");
-  //% "Ready for you to connect"
-  //: Refers to the app - which is currently running the background and waiting
   args["message"] = qtTrId("vpn.android.notification.isIDLE");
   QJsonDocument doc(args);
   QAndroidParcel data;

--- a/src/platforms/macos/macosmenubar.cpp
+++ b/src/platforms/macos/macosmenubar.cpp
@@ -43,7 +43,6 @@ void MacOSMenuBar::initialize() {
 
   m_menuBar = new QMenuBar(nullptr);
 
-  //% "File"
   QMenu* fileMenu = m_menuBar->addMenu(qtTrId("menubar.file.title"));
 
   // Do not use qtTrId here!
@@ -80,10 +79,8 @@ void MacOSMenuBar::controllerStateChanged() {
 void MacOSMenuBar::retranslate() {
   logger.log() << "Retranslate";
 
-  //% "Close"
   m_closeAction->setText(qtTrId("menubar.file.close"));
 
-  //% "Help"
   m_helpMenu->setTitle(qtTrId("menubar.help.title"));
   for (QAction* action : m_helpMenu->actions()) {
     m_helpMenu->removeAction(action);

--- a/src/src.pro
+++ b/src/src.pro
@@ -738,13 +738,6 @@ else{
     message(Languages were not imported - using fallback english)
     TRANSLATIONS += \
         ../translations/mozillavpn_en.ts
-
-    ts.commands += lupdate $$PWD -no-obsolete -ts $$PWD/../translations/mozillavpn_en.ts
-    ts.CONFIG += no_check_exist
-    ts.output = $$PWD/../translations/mozillavpn_en.ts
-    ts.input = .
-    QMAKE_EXTRA_TARGETS += ts
-    PRE_TARGETDEPS += ts
 }
 
 QMAKE_LRELEASE_FLAGS += -idbased

--- a/src/systemtrayhandler.cpp
+++ b/src/systemtrayhandler.cpp
@@ -103,10 +103,8 @@ void SystemTrayHandler::updateContextMenu() {
   m_separator->setVisible(isStateMain);
 
   if (QmlEngineHolder::instance()->window()->isVisible()) {
-    //% "Hide Mozilla VPN"
     m_showHideLabel->setText(qtTrId("systray.hide"));
   } else {
-    //% "Show Mozilla VPN"
     m_showHideLabel->setText(qtTrId("systray.show"));
   }
 
@@ -119,12 +117,10 @@ void SystemTrayHandler::updateContextMenu() {
 
   switch (vpn->controller()->state()) {
     case Controller::StateOn:
-      //% "Connected to:"
       statusLabel = qtTrId("vpn.systray.status.connectedTo");
       break;
 
     case Controller::StateOff:
-      //% "Connect to the last location:"
       statusLabel = qtTrId("vpn.systray.status.connectTo");
       break;
 
@@ -133,12 +129,10 @@ void SystemTrayHandler::updateContextMenu() {
     case Controller::StateConnecting:
       [[fallthrough]];
     case Controller::StateConfirming:
-      //% "Connecting to:"
       statusLabel = qtTrId("vpn.systray.status.connectingTo");
       break;
 
     case Controller::StateDisconnecting:
-      //% "Disconnecting from:"
       statusLabel = qtTrId("vpn.systray.status.disconnectingFrom");
       break;
 
@@ -160,8 +154,6 @@ void SystemTrayHandler::updateContextMenu() {
 
   m_lastLocationLabel->setIcon(flagIcon);
   m_lastLocationLabel->setText(
-      //% "%1, %2"
-      //: Location in the systray. %1 is the country, %2 is the city.
       qtTrId("vpn.systray.location")
           .arg(vpn->currentServer()->country())
           .arg(vpn->currentServer()->city()));
@@ -173,11 +165,8 @@ void SystemTrayHandler::unsecuredNetworkNotification(
     const QString& networkName) {
   logger.log() << "Unsecured network notification shown";
 
-  //% "Unsecured Wi-Fi network detected"
   QString title = qtTrId("vpn.systray.unsecuredNetwork.title");
 
-  //% "%1 is not secure. Turn on VPN to secure your device."
-  //: %1 is the Wi-Fi network name
   QString message =
       qtTrId("vpn.systray.unsecuredNetwork.message").arg(networkName);
 
@@ -190,11 +179,8 @@ void SystemTrayHandler::unsecuredNetworkNotification(
 void SystemTrayHandler::captivePortalBlockNotificationRequired() {
   logger.log() << "Captive portal block notification shown";
 
-  //% "Guest Wi-Fi portal blocked"
   QString title = qtTrId("vpn.systray.captivePortalBlock.title");
 
-  //% "The guest Wi-Fi network you’re connected to requires action. Click to"
-  //% " turn off VPN to see the portal."
   QString message = qtTrId("vpn.systray.captivePortalBlock.message");
 
   m_lastMessage = CaptivePortalBlock;
@@ -206,11 +192,8 @@ void SystemTrayHandler::captivePortalBlockNotificationRequired() {
 void SystemTrayHandler::captivePortalUnblockNotificationRequired() {
   logger.log() << "Captive portal unblock notification shown";
 
-  //% "Guest Wi-Fi portal detected"
   QString title = qtTrId("vpn.systray.captivePortalUnblock.title");
 
-  //% "The guest Wi-Fi network you’re connected to may not be secure. Click to"
-  //% " turn on VPN to secure your device."
   QString message = qtTrId("vpn.systray.captivePortalUnblock.message");
 
   m_lastMessage = CaptivePortalUnblock;
@@ -237,10 +220,8 @@ void SystemTrayHandler::showHideWindow() {
 void SystemTrayHandler::retranslate() {
   logger.log() << "Retranslate";
 
-  //% "Disconnect"
   m_disconnectAction->setText(qtTrId("systray.disconnect"));
 
-  //% "Help"
   m_helpMenu->setTitle(qtTrId("systray.help"));
   for (QAction* action : m_helpMenu->actions()) {
     m_helpMenu->removeAction(action);
@@ -252,10 +233,7 @@ void SystemTrayHandler::retranslate() {
                           [help = vpn->helpModel(), id]() { help->open(id); });
   });
 
-  //% "Preferences…"
   m_preferencesAction->setText(qtTrId("systray.preferences"));
-
-  //% "Quit Mozilla VPN"
   m_quitAction->setText(qtTrId("systray.quit"));
 
   updateContextMenu();

--- a/src/ui/components/VPNAboutUs.qml
+++ b/src/ui/components/VPNAboutUs.qml
@@ -17,18 +17,15 @@ Item {
         id: aboutUsListModel
 
         ListElement {
-            //% "Terms of Service"
             linkTitle: qsTrId("vpn.aboutUs.tos")
             openUrl: VPN.LinkTermsOfService
         }
 
         ListElement {
-            //% "Privacy Notice"
             linkTitle: qsTrId("vpn.aboutUs.privacyNotice")
             openUrl: VPN.LinkPrivacyNotice
         }
         ListElement {
-            //% "License"
             linkTitle: qsTrId("vpn.aboutUs.license")
             openUrl: VPN.LinkLicense
         }
@@ -38,7 +35,6 @@ Item {
     VPNMenu {
         id: menu
 
-        //% "About us"
         title: qsTrId("vpn.settings.aboutUs")
         isSettingsView: true
     }
@@ -74,8 +70,6 @@ Item {
         VPNBoldLabel {
             id: releaseLabel
 
-            //% "Release Version"
-            //: Refers to the installed version. For example: "Release Version: 1.23"
             text: qsTrId("vpn.aboutUs.releaseVersion")
             anchors.top: mozillaText.bottom
             anchors.topMargin: 16

--- a/src/ui/components/VPNConnectionInfo.qml
+++ b/src/ui/components/VPNConnectionInfo.qml
@@ -119,8 +119,6 @@ Popup {
             anchors.horizontalCenterOffset: 0
             horizontalAlignment: Text.AlignHCenter
             color: Theme.white
-            //% "IP: %1"
-            //: The current IP address
             text: qsTrId("vpn.connectionInfo.ip").arg(VPNConnectionData.ipAddress)
             Accessible.name: text
             Accessible.role: Accessible.StaticText
@@ -133,16 +131,12 @@ Popup {
             anchors.horizontalCenter: parent.horizontalCenter
 
             VPNGraphLegendMarker {
-                //% "Download"
-                //: The current download speed. The speed is shown on the next line.
                 markerLabel: qsTrId("vpn.connectionInfo.download")
                 rectColor: "#EE3389"
                 markerData: chartWrapper.rBytes
             }
 
             VPNGraphLegendMarker {
-                //% "Upload"
-                //: The current upload speed. The speed is shown on the next line.
                 markerLabel: qsTrId("vpn.connectionInfo.upload")
                 rectColor: "#F68953"
                 markerData: chartWrapper.tBytes
@@ -159,7 +153,6 @@ Popup {
             anchors.left: parent.left
             anchors.topMargin: Theme.windowMargin / 2
             anchors.leftMargin: Theme.windowMargin / 2
-            //% "Close"
             accessibleName: qsTrId("vpn.connectionInfo.close")
 
             Image {

--- a/src/ui/components/VPNConnectionStability.qml
+++ b/src/ui/components/VPNConnectionStability.qml
@@ -150,9 +150,6 @@ RowLayout {
     }
 
     VPNInterLabel {
-        //% "Check Connection"
-        //: Message displayed to the user when the connection is unstable or
-        //: missing, asking them to check their connection.
         text: qsTrId("vpn.connectionStability.checkConnection")
         color: "#FFFFFF"
         opacity: 0.8

--- a/src/ui/components/VPNControllerDevice.qml
+++ b/src/ui/components/VPNControllerDevice.qml
@@ -12,7 +12,6 @@ VPNClickableRow {
 
         Accessible.role: Accessible.Button
 
-    //% "My devices"
     property var titleText: qsTrId("vpn.devices.myDevices")
 
     accessibleName: titleText + " - " + label.text
@@ -31,8 +30,6 @@ VPNClickableRow {
 
                 PropertyChanges {
                     target: label
-                    //% "%1 of %2"
-                    //: Example: You have "x of y" devices in your account, where y is the limit of allowed devices.
                     text: qsTrId("vpn.devices.activeVsMaxDeviceCount").arg(VPNDeviceModel.activeDevices).arg(VPNUser.maxDevices)
                 }
 

--- a/src/ui/components/VPNControllerServer.qml
+++ b/src/ui/components/VPNControllerServer.qml
@@ -10,11 +10,7 @@ import "../themes/themes.js" as Theme
 VPNClickableRow {
     id: servers
 
-    //% "Select location"
-    //: Select the Location of the VPN server
     property var titleText: qsTrId("vpn.servers.selectLocation")
-    //% "current location - %1"
-    //: Accessibility description for current location of the VPN server
     property var descriptionText: qsTrId("vpn.servers.currentLocation").arg(VPNCurrentServer.city)
 
     accessibleName: titleText + ": " + descriptionText

--- a/src/ui/components/VPNControllerView.qml
+++ b/src/ui/components/VPNControllerView.qml
@@ -48,14 +48,12 @@ Rectangle {
 
             PropertyChanges {
                 target: logoTitle
-                //% "VPN is off"
                 text: qsTrId("vpn.controller.deactivated")
                 color: Theme.fontColorDark
             }
 
             PropertyChanges {
                 target: logoSubtitle
-                //% "Turn on to protect your privacy"
                 text: qsTrId("vpn.controller.activationSloagan")
                 color: Theme.fontColor
             }
@@ -143,14 +141,12 @@ Rectangle {
 
             PropertyChanges {
                 target: logoTitle
-                //% "Connecting…"
                 text: qsTrId("vpn.controller.connectingState")
                 color: "#FFFFFF"
             }
 
             PropertyChanges {
                 target: logoSubtitle
-                //% "Masking connection and location"
                 text: qsTrId("vpn.controller.activating")
                 color: "#FFFFFF"
                 opacity: 0.8
@@ -204,7 +200,6 @@ Rectangle {
             PropertyChanges {
                 target: logoSubtitle
                 text: VPNController.connectionRetry > 1 ?
-                          //% "Attempting to confirm connection"
                           qsTrId("vpn.controller.attemptingToConfirm") :
                           qsTrId("vpn.controller.activating")
                 color: "#FFFFFF"
@@ -252,15 +247,12 @@ Rectangle {
 
             PropertyChanges {
                 target: logoTitle
-                //% "VPN is on"
                 text: qsTrId("vpn.controller.activated")
                 color: "#FFFFFF"
             }
 
             PropertyChanges {
                 target: logoSubtitle
-                //% "Secure and private"
-                //: This refers to the user’s internet connection.
                 text: qsTrId("vpn.controller.active") + "  •  " + formatTime(VPNController.time)
                 color: "#FFFFFF"
                 opacity: 0.8
@@ -299,14 +291,12 @@ Rectangle {
 
             PropertyChanges {
                 target: logoTitle
-                //% "Disconnecting…"
                 text: qsTrId("vpn.controller.disconnecting")
                 color: Theme.fontColorDark
             }
 
             PropertyChanges {
                 target: logoSubtitle
-                //% "Unmasking connection and location"
                 text: qsTrId("vpn.controller.deactivating")
                 color: Theme.fontColor
                 opacity: 1
@@ -353,15 +343,12 @@ Rectangle {
 
             PropertyChanges {
                 target: logoTitle
-                //% "Switching…"
                 text: qsTrId("vpn.controller.switching")
                 color: "#FFFFFF"
             }
 
             PropertyChanges {
                 target: logoSubtitle
-                //% "From %1 to %2"
-                //: Switches from location 1 to location 2
                 text: qsTrId("vpn.controller.switchingDetail").arg(VPNController.currentCity).arg(VPNController.switchingCity)
                 color: "#FFFFFF"
                 opacity: 0.8
@@ -467,7 +454,6 @@ Rectangle {
         anchors.left: parent.left
         anchors.topMargin: Theme.windowMargin / 2
         anchors.leftMargin: Theme.windowMargin / 2
-        //% "Connection Information"
         accessibleName: qsTrId("vpn.controller.info")
         Accessible.ignored: connectionInfoVisible
 
@@ -498,7 +484,6 @@ Rectangle {
         anchors.right: parent.right
         anchors.topMargin: Theme.windowMargin / 2
         anchors.rightMargin: Theme.windowMargin / 2
-        //% "Settings"
         accessibleName: qsTrId("vpn.main.settings")
         Accessible.ignored: connectionInfoVisible
 

--- a/src/ui/components/VPNDevicesListHeader.qml
+++ b/src/ui/components/VPNDevicesListHeader.qml
@@ -74,9 +74,7 @@ Item {
         anchors.top: spacer.bottom
         logoSize: 80
         logo: "../resources/devicesLimit.svg"
-        //% "Remove a device"
         logoTitle: qsTrId("vpn.devices.doDeviceRemoval")
-        //% "You’ve reached your limit. To install the VPN on this device, you’ll need to remove one."
         logoSubtitle: qsTrId("vpn.devices.maxDevicesReached")
     }
 

--- a/src/ui/components/VPNGetHelp.qml
+++ b/src/ui/components/VPNGetHelp.qml
@@ -15,8 +15,6 @@ Item {
     VPNMenu {
         id: menu
         objectName: "getHelpBack"
-
-        //% "Get Help"
         title: qsTrId("vpn.main.getHelp")
         isSettingsView: true
     }

--- a/src/ui/components/VPNGraphLegendMarker.qml
+++ b/src/ui/components/VPNGraphLegendMarker.qml
@@ -12,31 +12,21 @@ Row {
 
     function computeRange() {
         if (markerData < 1024) {
-            //% "B/s"
-            //: Bytes per second
             return qsTrId("vpn.connectionInfo.Bps");
         }
 
         if (markerData < 1048576 /* 1024^2 */) {
-            //% "kB/s"
-            //: Kilobytes per second
             return qsTrId("vpn.connectionInfo.kBps");
         }
 
         if (markerData < 1073741824 /* 1024^3 */) {
-            //% "MB/s"
-            //: Megabytes per second
             return qsTrId("vpn.connectioInfo.mBps");
         }
 
         if (markerData < 1099511627776 /* 1024^4 */) {
-            //% "GB/s"
-            //: Gigabytes per second
             return qsTrId("vpn.connectioInfo.gBps");
         }
 
-        //% "TB/s"
-        //: Terabytes per second
         return qsTrId("vpn.connectionInfo.tBps");
     }
 
@@ -61,10 +51,6 @@ Row {
     }
     Accessible.focusable: true
     Accessible.role: Accessible.StaticText
-    //% "%1: %2 %3"
-    //: Used as accessibility description for the connection info:
-    //: %1 is the localized label for “Upload” or “Download”, %2 is the speed
-    //: value, %3 is the localized unit. Example: “Upload: 10 Mbps”.
     Accessible.name: qsTrId("vpn.connectionInfo.accessibleName")
         .arg(label.text)
         .arg(value.text)

--- a/src/ui/components/VPNLoader.qml
+++ b/src/ui/components/VPNLoader.qml
@@ -78,7 +78,6 @@ Item {
         objectName: "cancelFooterLink"
 
         visible: footerLinkIsVisible
-        //% "Cancel"
         labelText: qsTrId("vpn.authenticating.cancel")
         onClicked: VPN.cancelAuthentication()
     }

--- a/src/ui/components/VPNMenu.qml
+++ b/src/ui/components/VPNMenu.qml
@@ -38,8 +38,6 @@ Item {
         anchors.left: parent.left
         anchors.topMargin: Theme.windowMargin / 2
         anchors.leftMargin: Theme.windowMargin / 2
-        //% "Back"
-        //: Go back
         accessibleName: qsTrId("vpn.main.back")
         Accessible.ignored: accessibleIgnored
 

--- a/src/ui/components/VPNRemoveDevicePopup.qml
+++ b/src/ui/components/VPNRemoveDevicePopup.qml
@@ -101,7 +101,6 @@ Popup {
                 Layout.rightMargin: Theme.windowMargin
                 Layout.minimumHeight: 36
                 verticalAlignment: Text.AlignBottom
-                //% "Remove device?"
                 text: qsTrId("vpn.devices.removeDeviceQuestion")
             }
 
@@ -113,8 +112,6 @@ Popup {
                 Layout.topMargin: 10
                 horizontalAlignment: Text.AlignHCenter
                 color: Theme.fontColorDark
-                //: %1 is the name of the device being removed. The name is displayed on purpose on a new line.
-                //% "Please confirm you would like to remove\n%1."
                 text: qsTrId("vpn.devices.deviceRemovalConfirm").arg(popup.deviceName)
             }
 
@@ -135,7 +132,6 @@ Popup {
                 VPNPopupButton {
                     id: cancelBtn
 
-                    //% "Cancel"
                     buttonText: qsTrId("vpn.devices.cancelDeviceRemoval")
                     buttonTextColor: "#262626"
                     colorScheme: Theme.popupButtonCancel
@@ -149,8 +145,6 @@ Popup {
                 VPNPopupButton {
                     id: removeBtn
 
-                    //: This is the “remove” device button.
-                    //% "Remove"
                     buttonText: qsTrId("vpn.devices.removeDeviceButton")
                     buttonTextColor: Theme.white
                     colorScheme: Theme.redButton

--- a/src/ui/components/VPNServerCountry.qml
+++ b/src/ui/components/VPNServerCountry.qml
@@ -127,8 +127,6 @@ VPNClickableRow {
         width: serverCountry.width - anchors.leftMargin
 
         Accessible.role: Accessible.List
-        //% "Cities"
-        //: The title for the list of cities.
         Accessible.name: qsTrId("cities")
 
         Behavior on opacity {

--- a/src/ui/components/VPNSignOut.qml
+++ b/src/ui/components/VPNSignOut.qml
@@ -6,7 +6,6 @@ import QtQuick 2.0
 import "../themes/themes.js" as Theme
 
 VPNFooterLink {
-    //% "Sign Out"
     labelText: qsTrId("vpn.main.signOut")
     fontName: Theme.fontBoldFamily
     linkColor: Theme.redButton

--- a/src/ui/components/VPNStabilityLabelActions.qml
+++ b/src/ui/components/VPNStabilityLabelActions.qml
@@ -10,10 +10,7 @@ import "../themes/themes.js" as Theme
 ParallelAnimation {
     property var connectionStatus: VPNConnectionHealth.stability
     property bool isConnectionUnstable: connectionStatus === VPNConnectionHealth.Unstable
-    //% "Unstable"
-    //: This refers to the user’s internet connection.
     readonly property var textUnable: qsTrId("vpn.connectionStability.unstable")
-    //% "No Signal"
     readonly property var textNoSignal: qsTrId("vpn.connectionStability.noSignal")
 
     PropertyAction {

--- a/src/ui/components/VPNSystemAlert.qml
+++ b/src/ui/components/VPNSystemAlert.qml
@@ -38,9 +38,7 @@ VPNAlert {
             PropertyChanges {
                 target: alertBox
                 alertType: "authentication-failed"
-                //% "Authentication error"
                 alertText: qsTrId("vpn.alert.authenticationError")
-                //% "Try again"
                 alertLinkText: qsTrId("vpn.alert.tryAgain")
                 opacity: 1
                 visible: true
@@ -53,7 +51,6 @@ VPNAlert {
             PropertyChanges {
                 target: alertBox
                 alertType: "connection-failed"
-                //% "Unable to connect"
                 alertText: qsTrId("vpn.alert.unableToConnect")
                 alertLinkText: qsTrId("vpn.alert.tryAgain")
                 opacity: 1
@@ -67,7 +64,6 @@ VPNAlert {
             PropertyChanges {
                 target: alertBox
                 alertType: "no-connection"
-                //% "No internet connection"
                 alertText: qsTrId("vpn.alert.noInternet")
                 alertLinkText: qsTrId("vpn.alert.tryAgain")
                 opacity: 1
@@ -81,10 +77,7 @@ VPNAlert {
             PropertyChanges {
                 target: alertBox
                 alertType: "backend-service"
-                //% "Background service error"
                 alertText: qsTrId("vpn.alert.backendServiceError")
-                //% "Restore"
-                //: Restore a service in case of error.
                 alertLinkText: qsTrId("vpn.alert.restore")
                 opacity: 1
                 visible: true
@@ -97,7 +90,6 @@ VPNAlert {
             PropertyChanges {
                 target: alertBox
                 alertType: "backend-service"
-                //% "Remote service error"
                 alertText: qsTrId("vpn.alert.remoteServiceError")
                 alertLinkText: ""
                 opacity: 1
@@ -111,7 +103,6 @@ VPNAlert {
             PropertyChanges {
                 target: alertBox
                 alertType: "subscription-failed"
-                //% "Subscription failed"
                 alertText: qsTrId("vpn.alert.subscriptionFailureError")
                 alertLinkText: qsTrId("vpn.alert.tryAgain")
                 opacity: 1
@@ -125,7 +116,6 @@ VPNAlert {
             PropertyChanges {
                 target: alertBox
                 alertType: "geoip-restriction"
-                //% "Operation not allowed from current location"
                 alertText: qsTrId("vpn.alert.getIPRestrictionError")
                 alertLinkText: ""
                 opacity: 1
@@ -138,7 +128,6 @@ VPNAlert {
 
             PropertyChanges {
                 target: alertBox
-                //% "Signed out and device removed"
                 alertText: qsTrId("vpn.alert.deviceRemovedAndLogout")
                 opacity: 1
                 visible: true

--- a/src/ui/components/VPNToggle.qml
+++ b/src/ui/components/VPNToggle.qml
@@ -71,7 +71,6 @@ VPNButtonBase {
 
             PropertyChanges {
                 target: toggleButton
-                //% "Turn VPN on"
                 toolTipTitle: qsTrId("vpn.toggle.on")
             }
 
@@ -93,7 +92,6 @@ VPNButtonBase {
 
             PropertyChanges {
                 target: toggleButton
-                //% "Turn VPN off"
                 toolTipTitle: qsTrId("vpn.toggle.off")
                 toggleColor: Theme.vpnToggleConnected
             }
@@ -116,7 +114,6 @@ VPNButtonBase {
 
             PropertyChanges {
                 target: toggleButton
-                //% "Turn VPN off"
                 toolTipTitle: qsTrId("vpn.toggle.off")
                 toggleColor: Theme.vpnToggleConnected
             }

--- a/src/ui/main.qml
+++ b/src/ui/main.qml
@@ -31,7 +31,6 @@ Window {
     maximumWidth: width
     minimumHeight: height
     minimumWidth: width
-    //% "Mozilla VPN"
     title: qsTrId("vpn.main.productName")
     color: "#F9F9FA"
     onClosing: {

--- a/src/ui/settings/ViewAppPermissions.qml
+++ b/src/ui/settings/ViewAppPermissions.qml
@@ -52,9 +52,6 @@ VPNFlickable {
         id: vpnOnAlert
         anchors.top: enableAppList.bottom
         visible: !vpnFlickable.vpnIsOff
-
-        //% "VPN must be off to edit App Permissions"
-        //: Associated to a group of settings that require the VPN to be disconnected to change
         errorMessage: qsTrId("vpn.settings.protectSelectedApps.vpnMustBeOff")
     }
 
@@ -105,16 +102,12 @@ VPNFlickable {
         isEnabled: vpnIsOff
 
         //% "Unprotected"
-        //: Header for the list of apps not protected by VPN
         header: qsTrId("vpn.settings.unprotected")
         //% "These apps will not use the VPN"
-        //: Description for the list of apps not protected by VPN
         description: qsTrId("vpn.settings.unprotected.description")
         listModel: VPNAppPermissions.disabledApps
         onAction: ()=>{VPNAppPermissions.protectAll()}
         //% "Protect All"
-        //: Label for the button to add protection to all apps
-        //: currently unprotected.
         actionText: qsTrId("vpn.settings.protectall")
     }
 
@@ -130,16 +123,12 @@ VPNFlickable {
         isEnabled: vpnIsOff
 
         //% "Protected"
-        //: Header for the list of apps protected by VPN
         header: qsTrId("vpn.settings.protected")
         //% "These apps will use the VPN"
-        //: Description for the list of apps protected by VPN
         description: qsTrId("vpn.settings.protected.description")
         listModel: VPNAppPermissions.enabledApps
         onAction: ()=>{VPNAppPermissions.unprotectAll()}
         //% "Unprotect All"
-        //: Label for the button to remove protection from all apps
-        //: currently protected.
         actionText: qsTrId("vpn.settings.unprotectall")
     }
 }

--- a/src/ui/settings/ViewLanguage.qml
+++ b/src/ui/settings/ViewLanguage.qml
@@ -15,8 +15,6 @@ Item {
 
     VPNMenu {
         id: menu
-
-        //% "Language"
         title: qsTrId("vpn.settings.language")
         isSettingsView: true
         onActiveFocusChanged: if (focus) forceFocus = true
@@ -115,9 +113,6 @@ Item {
                         anchors.left: parent.left
                         anchors.leftMargin: defaultMargin
                         width: parent.width - defaultMargin * 2
-                        //% "%1 %2"
-                        //: This string is read by accessibility tools.
-                        //: %1 is the language name, %2 is the localized language name.
                         accessibleName: qsTrId("vpn.settings.languageAccessibleName")
                             .arg(language)
                             .arg(localizedLanguage)

--- a/src/ui/settings/ViewNetworkSettings.qml
+++ b/src/ui/settings/ViewNetworkSettings.qml
@@ -17,7 +17,6 @@ VPNFlickable {
     VPNMenu {
         id: menu
 
-        //% "Network settings"
         title: qsTrId("vpn.settings.networking")
         isSettingsView: true
     }
@@ -29,9 +28,7 @@ VPNFlickable {
         anchors.topMargin: Theme.windowMargin
         width: parent.width - Theme.windowMargin
 
-        //% "IPv6"
         labelText: qsTrId("vpn.settings.ipv6")
-        //% "Push the internet forward with the latest version of the Internet Protocol"
         subLabelText: qsTrId("vpn.settings.ipv6.description")
         isChecked: (VPNSettings.ipv6Enabled)
         isEnabled: vpnFlickable.vpnIsOff
@@ -51,9 +48,7 @@ VPNFlickable {
         width: parent.width - Theme.windowMargin
         visible: VPNFeatureList.localNetworkAccessSupported
 
-        //% "Local network access"
         labelText: qsTrId("vpn.settings.lanAccess")
-        //% "Access printers, streaming sticks and all other devices on your local network"
         subLabelText: qsTrId("vpn.settings.lanAccess.description")
         isChecked: (VPNSettings.localNetworkAccess)
         isEnabled: vpnFlickable.vpnIsOff
@@ -69,8 +64,6 @@ VPNFlickable {
         anchors.top: localNetwork.visible ? localNetwork.bottom : ipv6.bottom
         visible: !vpnFlickable.vpnIsOff
 
-        //% "VPN must be off to edit these settings"
-        //: Associated to a group of settings that require the VPN to be disconnected to change
         errorMessage: qsTrId("vpn.settings.vpnMustBeOff")
     }
 

--- a/src/ui/settings/ViewNotifications.qml
+++ b/src/ui/settings/ViewNotifications.qml
@@ -16,7 +16,6 @@ VPNFlickable {
     VPNMenu {
         id: menu
 
-        //% "Notifications"
         title: qsTrId("vpn.settings.notifications")
         isSettingsView: true
     }
@@ -29,9 +28,7 @@ VPNFlickable {
         width: parent.width - Theme.windowMargin
         visible: VPNFeatureList.captivePortalNotificationSupported
 
-        //% "Guest Wi-Fi portal alert"
         labelText: qsTrId("vpn.settings.guestWifiAlert")
-        //% "Get notified if a guest Wi-Fi portal is blocked due to VPN connection"
         subLabelText: qsTrId("vpn.settings.guestWifiAlert.description")
 
         isChecked: (VPNSettings.captivePortalAlert)
@@ -52,9 +49,7 @@ VPNFlickable {
         width: parent.width - Theme.windowMargin
         visible: VPNFeatureList.unsecuredNetworkNotificationSupported
 
-        //% "Unsecured network alert"
         labelText: qsTrId("vpn.settings.unsecuredNetworkAlert")
-        //% "Get notified if you connect to an unsecured Wi-Fi network"
         subLabelText: qsTrId("vpn.settings.unsecuredNetworkAlert.description")
 
         isChecked: (VPNSettings.unsecuredNetworkAlert)
@@ -71,8 +66,6 @@ VPNFlickable {
         anchors.top: VPNFeatureList.unsecuredNetworkNotificationSupported ? unsecuredNetworkAlert.bottom : captivePortalAlert.bottom
         visible: !vpnFlickable.vpnIsOff
 
-        //% "VPN must be off to edit these settings"
-        //: Associated to a group of settings that require the VPN to be disconnected to change
         errorMessage: qsTrId("vpn.settings.vpnMustBeOff")
     }
 }

--- a/src/ui/settings/ViewSettingsMenu.qml
+++ b/src/ui/settings/ViewSettingsMenu.qml
@@ -41,7 +41,6 @@ VPNFlickable {
         id: vpnPanel
         logoSize: 80
         logo:  VPNUser.avatar
-        //% "VPN User"
         readonly property var textVpnUser: qsTrId("vpn.settings.user")
         logoTitle: VPNUser.displayName ? VPNUser.displayName : textVpnUser
         logoSubtitle: VPNUser.email
@@ -63,7 +62,6 @@ VPNFlickable {
     VPNCheckBoxRow {
         id: startAtBootCheckBox
 
-        //% "Launch VPN app on Startup"
         labelText: qsTrId("vpn.settings.runOnBoot")
         subLabelText: ""
         isChecked: VPNSettings.startAtBoot
@@ -125,7 +123,6 @@ VPNFlickable {
             visible: VPNLocalizer.hasLanguages
         }
         VPNSettingsItem {
-            //% "App Permissions"
             settingTitle: qsTrId("vpn.settings.appPermissions")
             imageLeftSrc: "../resources/settings/apps.svg"
             imageRightSrc: "../resources/chevron.svg"
@@ -139,7 +136,6 @@ VPNFlickable {
             onClicked: settingsStackView.push(aboutUsComponent)
         }
         VPNSettingsItem {
-            //% "Give feedback"
             settingTitle: qsTrId("vpn.settings.giveFeedback")
             imageLeftSrc: "../resources/settings/feedback.svg"
             imageRightSrc: "../resources/externalLink.svg"

--- a/src/ui/states/StateAuthenticating.qml
+++ b/src/ui/states/StateAuthenticating.qml
@@ -7,7 +7,5 @@ import "../components"
 
 VPNLoader {
     objectName: "authenticatingView"
-
-    //% "Waiting for sign in and subscription confirmation…"
     headlineText: qsTrId("vpn.authenticating.waitForSignIn")
 }

--- a/src/ui/states/StatePostAuthentication.qml
+++ b/src/ui/states/StatePostAuthentication.qml
@@ -18,14 +18,12 @@ Item {
         anchors.top: parent.top
         anchors.topMargin: parent.height * 0.08
         anchors.horizontalCenter: parent.horizontalCenter
-        //% "Quick access"
         text: qsTrId("vpn.postAuthentication..quickAccess")
     }
 
     VPNSubtitle {
         id: logoSubtitle
 
-        //% "You can quickly access Mozilla VPN from your status bar."
         text: qsTrId("vpn.postAuthentication.statusBarIntro")
         anchors.top: headline.bottom
         anchors.topMargin: 12
@@ -44,7 +42,6 @@ Item {
         id: button
         objectName: "postAuthenticationButton"
 
-        //% "Continue"
         text: qsTrId("vpn.postAuthentication.continue")
         anchors.horizontalCenterOffset: 0
         anchors.horizontalCenter: parent.horizontalCenter

--- a/src/ui/states/StateSubscriptionBlocked.qml
+++ b/src/ui/states/StateSubscriptionBlocked.qml
@@ -23,7 +23,6 @@ VPNFlickable {
         VPNHeadline {
             id: headline
 
-            //% "Error confirming subscription…"
             text: qsTrId("vpn.subscriptionBlocked.title")
             Layout.preferredHeight: paintedHeight
             Layout.preferredWidth: Math.max(Theme.maxTextWidth, vpnFlickable.width * 0.85)
@@ -73,7 +72,6 @@ VPNFlickable {
                     width: Theme.maxTextWidth
                     font.pixelSize: Theme.fontSize
                     lineHeight: 22
-                    //% "Another Firefox Account has already subscribed using this Apple ID."
                     text:qsTrId("vpn.subscriptionBlocked.anotherFxaSubscribed")
                 }
 
@@ -87,7 +85,6 @@ VPNFlickable {
                     width: Theme.maxTextWidth
                     font.pixelSize: Theme.fontSize
                     lineHeight: 22
-                    //% "Visit our help center to learn more about managing your subscriptions."
                     text: qsTrId("vpn.subscriptionBlocked.visitHelpCenter")
                 }
 
@@ -109,7 +106,6 @@ VPNFlickable {
             Layout.alignment: Qt.AlignBottom
 
             VPNButton {
-                //% "Get Help"
                 text: qsTrId("vpn.subscriptionBlocked.getHelp")
                 anchors.bottom: spacer.top
                 anchors.horizontalCenter: parent.horizontalCenter

--- a/src/ui/states/StateSubscriptionValidation.qml
+++ b/src/ui/states/StateSubscriptionValidation.qml
@@ -5,7 +5,6 @@
 import "../components"
 
 VPNLoader {
-    //% "Please wait…"
     headlineText: qsTrId("vpn.subscription.pleaseWait")
     footerLinkIsVisible: false
 }

--- a/src/ui/views/ViewDevices.qml
+++ b/src/ui/views/ViewDevices.qml
@@ -21,7 +21,6 @@ Item {
     VPNMenu {
         id: menu
 
-        //% "My devices"
         title: qsTrId("vpn.devices.myDevices")
         accessibleIgnored: isModalDialogOpened
     }
@@ -138,8 +137,6 @@ Item {
                 property var deviceName: name
 
                 spacing: 0
-                //% "%1 %2"
-                //: Example: "deviceName deviceDescription"
                 Accessible.name: qsTrId("vpn.devices.deviceAccessibleName").arg(name).arg(deviceDesc.text)
                 Accessible.role: Accessible.ListItem
                 Accessible.ignored: root.isModalDialogOpened
@@ -193,25 +190,18 @@ Item {
 
                         function deviceSubtitle() {
                             if (currentOne) {
-                                //% "Current Device"
                                 return qsTrId("vpn.devices.currentDevice");
                             }
 
                             const diff = (Date.now() - createdAt.valueOf()) / 1000;
                             if (diff < 3600) {
-                                //% "Added less than an hour ago"
                                 return qsTrId("vpn.devices.addedltHour");
                             }
 
                             if (diff < 86400) {
-                                //: %1 is the number of hours.
-                                //% "Added a few hours ago (%1)"
                                 return qsTrId("vpn.devices.addedXhoursAgo").arg(Math.floor(diff / 3600));
                             }
 
-                            //% "Added %1 days ago"
-                            //: %1 is the number of days.
-                            //: Note: there is currently no support for proper plurals
                             return qsTrId("vpn.devices.addedXdaysAgo").arg(Math.floor(diff / 86400));
                         }
 
@@ -236,8 +226,6 @@ Item {
                     Layout.preferredHeight: Theme.rowHeight
                     Layout.preferredWidth: Theme.rowHeight
                     onClicked: removePopup.initializeAndOpen(name, index)
-                    //: Label used for accessibility on the button to remove a device. %1 is the name of the device.
-                    //% "Remove %1"
                     accessibleName: qsTrId("vpn.devices.removeA11Y").arg(deviceRow.deviceName)
                     // Only allow focus within the current item in the list.
                     focusPolicy: deviceList.currentItem === deviceRow ? Qt.StrongFocus : Qt.NoFocus

--- a/src/ui/views/ViewInitialize.qml
+++ b/src/ui/views/ViewInitialize.qml
@@ -30,7 +30,6 @@ Item {
     VPNPanel {
         logo: "../resources/logo.svg"
         logoTitle: qsTrId("vpn.main.productName")
-        //% "A fast, secure and easy to use VPN. Built by the makers of Firefox."
         logoSubtitle: qsTrId("vpn.main.productDescription")
         logoSize: 80
         height: parent.height - (getStarted.height + getStarted.anchors.bottomMargin + learnMore.height + learnMore.anchors.bottomMargin)
@@ -42,7 +41,6 @@ Item {
 
         anchors.bottom: learnMore.top
         anchors.bottomMargin: 24
-        //% "Get started"
         text: qsTrId("vpn.main.getStarted")
         anchors.horizontalCenterOffset: 0
         anchors.horizontalCenter: parent.horizontalCenter
@@ -55,7 +53,6 @@ Item {
         id: learnMore
         objectName: "learnMoreLink"
 
-        //% "Learn more"
         labelText: qsTrId("vpn.main.learnMore")
         onClicked: stackview.push("ViewOnboarding.qml")
     }

--- a/src/ui/views/ViewLogs.qml
+++ b/src/ui/views/ViewLogs.qml
@@ -23,7 +23,6 @@ Item {
         id: menu
 
         isMainView: true
-        //% "View Logs"
         title: qsTrId("vpn.viewlogs.title")
     }
 
@@ -87,12 +86,10 @@ Item {
             width: copyClearWrapper.width
 
             VPNLogsButton {
-                //% "Copy"
                 buttonText: qsTrId("vpn.logs.copy")
                 iconSource: "../resources/copy.svg"
                 onClicked: {
                     VPN.storeInClipboard(logText.text);
-                    //% "Copied!"
                     buttonText = qsTrId("vpn.logs.copied");
                 }
             }
@@ -105,7 +102,6 @@ Item {
             }
 
             VPNLogsButton {
-                //% "Clear"
                 buttonText: qsTrId("vpn.logs.clear")
                 iconSource: "../resources/delete.svg"
                 onClicked: {

--- a/src/ui/views/ViewMain.qml
+++ b/src/ui/views/ViewMain.qml
@@ -87,7 +87,6 @@ VPNFlickable {
             }
 
             VPNBoldLabel {
-                //% "Mozilla VPN"
                 text: qsTrId("MozillaVPN")
                 color: "#000000"
                 anchors.verticalCenter: parent.verticalCenter
@@ -105,9 +104,7 @@ VPNFlickable {
         alertColor: Theme.blueButton
         visible: state === "recommended"
         onVisibleChanged: if (visible) showAlert.start();
-        //% "New version is available."
         alertText: qsTrId("vpn.updates.newVersionAvailable")
-        //% "Update now"
         alertLinkText: qsTrId("vpn.updates.updateNow")
         width: parent.width - (Theme.windowMargin * 2)
 

--- a/src/ui/views/ViewOnboarding.qml
+++ b/src/ui/views/ViewOnboarding.qml
@@ -31,34 +31,25 @@ Item {
 
             ListElement {
                 image: "../resources/onboarding/onboarding1.svg"
-                //% "Device-level encryption"
                 headline: qsTrId("vpn.onboarding.headline.1")
-                //% "Encrypt your traffic so that it can’t be read by your ISP or eavesdroppers."
                 subtitle: qsTrId("vpn.onboarding.subtitle.1")
             }
 
             ListElement {
                 image: "../resources/onboarding/onboarding2.svg"
-                //: The + after the number stands for “more than”. If you change the number of countries here, please update ViewSubscriptionNeeded.qml too.
-                //% "Servers in 30+ countries"
                 headline: qsTrId("vpn.onboarding.headline.2")
-                //% "Pick a server in any country you want and hide your location to throw off trackers."
                 subtitle: qsTrId("vpn.onboarding.subtitle.2")
             }
 
             ListElement {
                 image: "../resources/onboarding/onboarding3.svg"
-                //% "No bandwidth restrictions"
                 headline: qsTrId("vpn.onboarding.headline.3")
-                //% "Stream, download, and game without limits, monthly caps or ISP throttling."
                 subtitle: qsTrId("vpn.onboarding.subtitle.3")
             }
 
             ListElement {
                 image: "../resources/onboarding/onboarding4.svg"
-                //% "No online activity logs"
                 headline: qsTrId("vpn.onboarding.headline.4")
-                //% "We are committed to not monitoring or logging your browsing or network history."
                 subtitle: qsTrId("vpn.onboarding.subtitle.4")
             }
         }
@@ -98,7 +89,6 @@ Item {
     VPNHeaderLink {
         objectName: "skipOnboarding"
 
-        //% "Skip"
         labelText: qsTrId("vpn.onboarding.skip")
         onClicked: stackview.pop()
         visible: swipeView.currentIndex !== swipeView.count - 1
@@ -108,7 +98,6 @@ Item {
         id: nextPanel
         objectName: "onboardingNext"
 
-        //% "Next"
         readonly property var textNext: qsTrId("vpn.onboarding.next")
 
         text: swipeView.currentIndex === swipeView.count - 1 ? qsTrId("vpn.main.getStarted") : textNext

--- a/src/ui/views/ViewSubscriptionNeeded.qml
+++ b/src/ui/views/ViewSubscriptionNeeded.qml
@@ -50,10 +50,7 @@ VPNFlickable {
     VPNPanel {
         id: vpnPanel
 
-        //: “/mo” stands for “per month”. %1 is replaced by the cost (including currency).
-        //% "Subscribe for %1/mo"
         logoTitle: qsTrId("vpn.subscription.title").arg(VPNIAP.priceValue)
-        //% "30-day money-back guarantee"
         logoSubtitle: qsTrId("vpn.subscription.moneyBackGuarantee")
         anchors.top: spacer1.bottom
         logo: "../resources/logo.svg"
@@ -89,7 +86,6 @@ VPNFlickable {
         VPNCallout {
             // "Device level encryption" - String defined in ViewOnboarding.qml
             calloutTitle: qsTrId("vpn.onboarding.headline.1")
-            //% "We encrypt your entire device."
             calloutSubtitle: qsTrId("vpn.subscription.featureSubtitle2")
             calloutImage: "../resources/onboarding/onboarding1.svg"
         }
@@ -97,25 +93,18 @@ VPNFlickable {
         VPNCallout {
             // Servers in 30+ countries - String defined in ViewOnboarding.qml
             calloutTitle: qsTrId("vpn.onboarding.headline.2")
-            //% "Protect your access to the web."
             calloutSubtitle: qsTrId("vpn.subscription.featureSubtitle3")
             calloutImage: "../resources/onboarding/onboarding2.svg"
         }
 
         VPNCallout {
-            //% "Connect up to %1 devices"
-            //: %1 is the number of devices.
-            //: Note: there is currently no support for proper plurals
             calloutTitle: qsTrId("vpn.subscription.featureTitle4").arg(VPNUser.maxDevices)
-            //% "We won’t restrict your bandwidth."
             calloutSubtitle: qsTrId("vpn.subscription.featureSubtitle4")
             calloutImage: "../resources/onboarding/onboarding3.svg"
         }
 
         VPNCallout {
-            //% "No activity logs"
             calloutTitle: qsTrId("vpn.subscription.featureTitle1")
-            //% "We’re Mozilla. We’re on your side."
             calloutSubtitle: qsTrId("vpn.subscription.featureSubtitle1")
             calloutImage: "../resources/onboarding/onboarding4.svg"
         }
@@ -141,7 +130,6 @@ VPNFlickable {
         VPNButton {
             id: subscribeNow
 
-            //% "Subscribe now"
             text: qsTrId("vpn.updates.subscribeNow")
             Layout.alignment: Qt.AlignHCenter
             loaderVisible: false
@@ -201,7 +189,6 @@ VPNFlickable {
         }
 
         VPNLinkButton {
-            //% "Restore purchases"
             labelText: qsTrId("vpn.main.restorePurchases")
             Layout.alignment: Qt.AlignHCenter
             Layout.preferredHeight: Theme.rowHeight

--- a/src/ui/views/ViewUpdate.qml
+++ b/src/ui/views/ViewUpdate.qml
@@ -20,9 +20,7 @@ VPNFlickable {
 
             PropertyChanges {
                 target: vpnPanel
-                //% "Update recommended"
                 logoTitle: qsTrId("vpn.updates.updateRecomended")
-                //% "Please update the app before you continue to use the VPN"
                 logoSubtitle: qsTrId("vpn.updates.updateRecomended.description")
                 logo: "../resources/updateRecommended.svg"
             }
@@ -48,9 +46,7 @@ VPNFlickable {
 
             PropertyChanges {
                 target: vpnPanel
-                //% "Update required"
                 logoTitle: qsTrId("vpn.updates.updateRequired")
-                //% "We detected and fixed a serious bug. You must update your app."
                 logoSubtitle: qsTrId("vpn.updates.updateRequire.reason")
                 logo: "../resources/updateRequired.svg"
             }
@@ -143,7 +139,6 @@ VPNFlickable {
                 color: Theme.fontColorDark
                 Layout.fillWidth: true
                 Layout.alignment: Qt.AlignVCenter
-                //% "Your connection will not be secure while you update."
                 text: qsTrId("vpn.updates.updateConnectionInsecureWarning")
             }
 
@@ -177,9 +172,7 @@ VPNFlickable {
         VPNLinkButton {
             id: footerLink
 
-            //% "Not now"
             readonly property var textNotNow: qsTrId("vpn.updates.notNow")
-            //% "Manage account"
             readonly property var textManageAccount: qsTrId("vpn.main.manageAccount")
 
             Layout.alignment: Qt.AlignHCenter

--- a/translations/mozillavpn_en.ts
+++ b/translations/mozillavpn_en.ts
@@ -1,0 +1,733 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="en_US">
+<context>
+    <name></name>
+    <message id="vpn.main.back">
+        <source>Back</source>
+        <extracomment>Go back</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.android.authentication">
+        <source>Authentication</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.aboutUs.tos">
+        <source>Terms of Service</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.aboutUs.privacyNotice">
+        <source>Privacy Notice</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.aboutUs.license">
+        <source>License</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.settings.aboutUs">
+        <source>About us</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.main.productName">
+        <source>Mozilla VPN</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.main.productDescription">
+        <source>A fast, secure and easy to use VPN. Built by the makers of Firefox.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.aboutUs.releaseVersion">
+        <source>Release Version</source>
+        <extracomment>Refers to the installed version. For example: &quot;Release Version: 1.23&quot;</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.connectionInfo.ip">
+        <source>IP: %1</source>
+        <extracomment>The current IP address</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.connectionInfo.download">
+        <source>Download</source>
+        <extracomment>The current download speed. The speed is shown on the next line.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.connectionInfo.upload">
+        <source>Upload</source>
+        <extracomment>The current upload speed. The speed is shown on the next line.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.connectionInfo.close">
+        <source>Close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.connectionStability.checkConnection">
+        <source>Check Connection</source>
+        <extracomment>Message displayed to the user when the connection is unstable or missing, asking them to check their connection.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.devices.myDevices">
+        <source>My devices</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.devices.activeVsMaxDeviceCount">
+        <source>%1 of %2</source>
+        <extracomment>Example: You have &quot;x of y&quot; devices in your account, where y is the limit of allowed devices.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.servers.selectLocation">
+        <source>Select location</source>
+        <extracomment>Select the Location of the VPN server</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.servers.currentLocation">
+        <source>current location - %1</source>
+        <extracomment>Accessibility description for current location of the VPN server</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.controller.deactivated">
+        <source>VPN is off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.controller.activationSloagan">
+        <source>Turn on to protect your privacy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.controller.connectingState">
+        <source>Connecting…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.controller.activating">
+        <source>Masking connection and location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.controller.attemptingToConfirm">
+        <source>Attempting to confirm connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.controller.activated">
+        <source>VPN is on</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.controller.active">
+        <source>Secure and private</source>
+        <extracomment>This refers to the user’s internet connection.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.controller.disconnecting">
+        <source>Disconnecting…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.controller.deactivating">
+        <source>Unmasking connection and location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.controller.switching">
+        <source>Switching…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.controller.switchingDetail">
+        <source>From %1 to %2</source>
+        <extracomment>Switches from location 1 to location 2</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.controller.info">
+        <source>Connection Information</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.main.settings">
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.devices.doDeviceRemoval">
+        <source>Remove a device</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.devices.maxDevicesReached">
+        <source>You’ve reached your limit. To install the VPN on this device, you’ll need to remove one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.main.getHelp">
+        <source>Get Help</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.connectionInfo.Bps">
+        <source>B/s</source>
+        <extracomment>Bytes per second</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.connectionInfo.kBps">
+        <source>kB/s</source>
+        <extracomment>Kilobytes per second</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.connectioInfo.mBps">
+        <source>MB/s</source>
+        <extracomment>Megabytes per second</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.connectioInfo.gBps">
+        <source>GB/s</source>
+        <extracomment>Gigabytes per second</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.connectionInfo.tBps">
+        <source>TB/s</source>
+        <extracomment>Terabytes per second</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.connectionInfo.accessibleName">
+        <source>%1: %2 %3</source>
+        <extracomment>Used as accessibility description for the connection info: %1 is the localized label for “Upload” or “Download”, %2 is the speed value, %3 is the localized unit. Example: “Upload: 10 Mbps”.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.authenticating.cancel">
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.devices.removeDeviceQuestion">
+        <source>Remove device?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.devices.deviceRemovalConfirm">
+        <source>Please confirm you would like to remove
+%1.</source>
+        <extracomment>%1 is the name of the device being removed. The name is displayed on purpose on a new line.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.devices.cancelDeviceRemoval">
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.devices.removeDeviceButton">
+        <source>Remove</source>
+        <extracomment>This is the “remove” device button.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="cities">
+        <source>Cities</source>
+        <extracomment>The title for the list of cities.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.main.signOut">
+        <source>Sign Out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.connectionStability.unstable">
+        <source>Unstable</source>
+        <extracomment>This refers to the user’s internet connection.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.connectionStability.noSignal">
+        <source>No Signal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.alert.authenticationError">
+        <source>Authentication error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.alert.tryAgain">
+        <source>Try again</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.alert.unableToConnect">
+        <source>Unable to connect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.alert.noInternet">
+        <source>No internet connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.alert.backendServiceError">
+        <source>Background service error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.alert.restore">
+        <source>Restore</source>
+        <extracomment>Restore a service in case of error.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.alert.remoteServiceError">
+        <source>Remote service error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.alert.subscriptionFailureError">
+        <source>Subscription failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.alert.getIPRestrictionError">
+        <source>Operation not allowed from current location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.alert.deviceRemovedAndLogout">
+        <source>Signed out and device removed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.toggle.on">
+        <source>Turn VPN on</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.toggle.off">
+        <source>Turn VPN off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.updates.updateNow">
+        <source>Update now</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.updates.newVersionAvailable">
+        <source>New version is available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.settings.appPermissions">
+        <source>App Permissions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.settings.protectSelectedApps">
+        <source>Protect specific apps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.settings.protectSelectedApps.description">
+        <source>Choose which apps should use the VPN</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.settings.protectSelectedApps.vpnMustBeOff">
+        <source>VPN must be off to edit App Permissions</source>
+        <extracomment>Associated to a group of settings that require the VPN to be disconnected to change</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.settings.protectSelectedApps.allAppsProtected">
+        <source>VPN protects all apps by default</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.settings.unprotected">
+        <source>Unprotected</source>
+        <extracomment>Header for the list of apps not protected by VPN</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.settings.unprotected.description">
+        <source>These apps will not use the VPN</source>
+        <extracomment>Description for the list of apps not protected by VPN</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.settings.protectall">
+        <source>Protect All</source>
+        <extracomment>Label for the button to add protection to all apps currently unprotected.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.settings.protected">
+        <source>Protected</source>
+        <extracomment>Header for the list of apps protected by VPN</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.settings.protected.description">
+        <source>These apps will use the VPN</source>
+        <extracomment>Description for the list of apps protected by VPN</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.settings.unprotectall">
+        <source>Unprotect All</source>
+        <extracomment>Label for the button to remove protection from all apps currently protected.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.settings.language">
+        <source>Language</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.settings.languageAccessibleName">
+        <source>%1 %2</source>
+        <extracomment>This string is read by accessibility tools. %1 is the language name, %2 is the localized language name.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.settings.networking">
+        <source>Network settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.settings.ipv6">
+        <source>IPv6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.settings.ipv6.description">
+        <source>Push the internet forward with the latest version of the Internet Protocol</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.settings.lanAccess">
+        <source>Local network access</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.settings.lanAccess.description">
+        <source>Access printers, streaming sticks and all other devices on your local network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.settings.vpnMustBeOff">
+        <source>VPN must be off to edit these settings</source>
+        <extracomment>Associated to a group of settings that require the VPN to be disconnected to change</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.settings.notifications">
+        <source>Notifications</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.settings.guestWifiAlert">
+        <source>Guest Wi-Fi portal alert</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.settings.guestWifiAlert.description">
+        <source>Get notified if a guest Wi-Fi portal is blocked due to VPN connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.settings.unsecuredNetworkAlert">
+        <source>Unsecured network alert</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.settings.unsecuredNetworkAlert.description">
+        <source>Get notified if you connect to an unsecured Wi-Fi network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.settings.user">
+        <source>VPN User</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.main.manageAccount">
+        <source>Manage account</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.settings.runOnBoot">
+        <source>Launch VPN app on Startup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.settings.giveFeedback">
+        <source>Give feedback</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.authenticating.waitForSignIn">
+        <source>Waiting for sign in and subscription confirmation…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.postAuthentication..quickAccess">
+        <source>Quick access</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.postAuthentication.statusBarIntro">
+        <source>You can quickly access Mozilla VPN from your status bar.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.postAuthentication.continue">
+        <source>Continue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.subscriptionBlocked.title">
+        <source>Error confirming subscription…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.subscriptionBlocked.anotherFxaSubscribed">
+        <source>Another Firefox Account has already subscribed using this Apple ID.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.subscriptionBlocked.visitHelpCenter">
+        <source>Visit our help center to learn more about managing your subscriptions.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.subscriptionBlocked.getHelp">
+        <source>Get Help</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.subscription.pleaseWait">
+        <source>Please wait…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.devices.deviceAccessibleName">
+        <source>%1 %2</source>
+        <extracomment>Example: &quot;deviceName deviceDescription&quot;</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.devices.currentDevice">
+        <source>Current Device</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.devices.addedltHour">
+        <source>Added less than an hour ago</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.devices.addedXhoursAgo">
+        <source>Added a few hours ago (%1)</source>
+        <extracomment>%1 is the number of hours.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.devices.addedXdaysAgo">
+        <source>Added %1 days ago</source>
+        <extracomment>%1 is the number of days. Note: there is currently no support for proper plurals</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.devices.removeA11Y">
+        <source>Remove %1</source>
+        <extracomment>Label used for accessibility on the button to remove a device. %1 is the name of the device.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.main.getStarted">
+        <source>Get started</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.main.learnMore">
+        <source>Learn more</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.viewlogs.title">
+        <source>View Logs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.logs.copy">
+        <source>Copy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.logs.copied">
+        <source>Copied!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.logs.clear">
+        <source>Clear</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="MozillaVPN">
+        <source>Mozilla VPN</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.onboarding.headline.1">
+        <source>Device-level encryption</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.onboarding.subtitle.1">
+        <source>Encrypt your traffic so that it can’t be read by your ISP or eavesdroppers.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.onboarding.headline.2">
+        <source>Servers in 30+ countries</source>
+        <extracomment>The + after the number stands for “more than”. If you change the number of countries here, please update ViewSubscriptionNeeded.qml too.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.onboarding.subtitle.2">
+        <source>Pick a server in any country you want and hide your location to throw off trackers.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.onboarding.headline.3">
+        <source>No bandwidth restrictions</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.onboarding.subtitle.3">
+        <source>Stream, download, and game without limits, monthly caps or ISP throttling.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.onboarding.headline.4">
+        <source>No online activity logs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.onboarding.subtitle.4">
+        <source>We are committed to not monitoring or logging your browsing or network history.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.onboarding.skip">
+        <source>Skip</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.onboarding.next">
+        <source>Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.subscription.title">
+        <source>Subscribe for %1/mo</source>
+        <extracomment>“/mo” stands for “per month”. %1 is replaced by the cost (including currency).</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.subscription.moneyBackGuarantee">
+        <source>30-day money-back guarantee</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.subscription.featureSubtitle2">
+        <source>We encrypt your entire device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.subscription.featureSubtitle3">
+        <source>Protect your access to the web.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.subscription.featureTitle4">
+        <source>Connect up to %1 devices</source>
+        <extracomment>%1 is the number of devices. Note: there is currently no support for proper plurals</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.subscription.featureSubtitle4">
+        <source>We won’t restrict your bandwidth.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.subscription.featureTitle1">
+        <source>No activity logs</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.subscription.featureSubtitle1">
+        <source>We’re Mozilla. We’re on your side.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.updates.subscribeNow">
+        <source>Subscribe now</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.main.restorePurchases">
+        <source>Restore purchases</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.updates.updateRecomended">
+        <source>Update recommended</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.updates.updateRecomended.description">
+        <source>Please update the app before you continue to use the VPN</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.updates.updateRequired">
+        <source>Update required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.updates.updateRequire.reason">
+        <source>We detected and fixed a serious bug. You must update your app.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.updates.updateConnectionInsecureWarning">
+        <source>Your connection will not be secure while you update.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.updates.notNow">
+        <source>Not now</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.connectionInfo.loading">
+        <source>Loading</source>
+        <extracomment>This refers to the current IP address, i.e. &quot;IP: Loading&quot;.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="help.viewLog">
+        <source>View log</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="help.helpCenter">
+        <source>Help Center</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="help.contactUs">
+        <source>Contact us</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.systray.statusSwitch.title">
+        <source>VPN Switched Servers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.systray.statusSwtich.message">
+        <source>Switched from %1, %2 to %3, %4</source>
+        <extracomment>Shown as message body in a notification. %1 and %3 are countries, %2 and %4 are cities.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.systray.statusConnected.title">
+        <source>VPN Connected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.systray.statusConnected.message">
+        <source>Connected to %1, %2</source>
+        <extracomment>Shown as message body in a notification. %1 is the country, %2 is the city.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.systray.statusDisconnected.title">
+        <source>VPN Disconnected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.systray.statusDisconnected.message">
+        <source>Disconnected from %1, %2</source>
+        <extracomment>Shown as message body in a notification. %1 is the country, %2 is the city.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.android.notification.isIDLE">
+        <source>Ready for you to connect</source>
+        <extracomment>Refers to the app - which is currently running the background and waiting</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="menubar.file.title">
+        <source>File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="menubar.file.close">
+        <source>Close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="menubar.help.title">
+        <source>Help</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="systray.hide">
+        <source>Hide Mozilla VPN</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="systray.show">
+        <source>Show Mozilla VPN</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.systray.status.connectedTo">
+        <source>Connected to:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.systray.status.connectTo">
+        <source>Connect to the last location:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.systray.status.connectingTo">
+        <source>Connecting to:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.systray.status.disconnectingFrom">
+        <source>Disconnecting from:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.systray.location">
+        <source>%1, %2</source>
+        <extracomment>Location in the systray. %1 is the country, %2 is the city.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.systray.unsecuredNetwork.title">
+        <source>Unsecured Wi-Fi network detected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.systray.unsecuredNetwork.message">
+        <source>%1 is not secure. Turn on VPN to secure your device.</source>
+        <extracomment>%1 is the Wi-Fi network name</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.systray.captivePortalBlock.title">
+        <source>Guest Wi-Fi portal blocked</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.systray.captivePortalBlock.message">
+        <source>The guest Wi-Fi network you’re connected to requires action. Click to turn off VPN to see the portal.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.systray.captivePortalUnblock.title">
+        <source>Guest Wi-Fi portal detected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="vpn.systray.captivePortalUnblock.message">
+        <source>The guest Wi-Fi network you’re connected to may not be secure. Click to turn on VPN to secure your device.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="systray.disconnect">
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="systray.help">
+        <source>Help</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="systray.preferences">
+        <source>Preferences…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message id="systray.quit">
+        <source>Quit Mozilla VPN</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>


### PR DESCRIPTION
Helloo! We've been talking about how it's hard to keep track of what strings already exists in the project and where they are defined. So my idea was, instead of having one qml/c++ file that has all the strings to generate the en.ts once and keep it in tree. Also i've removed all the obsolete comments now. 
