### PR TITLE
Add reuseable full screen error view

### DIFF
--- a/src/qml.qrc
+++ b/src/qml.qrc
@@ -408,5 +408,6 @@
         <file>ui/components/VPNWasmMenu.qml</file>
         <file>ui/components/VPNWasmMenuButton.qml</file>
         <file>ui/components/VPNWasmHeader.qml</file>
+        <file>ui/views/ViewErrorFullScreen.qml</file>
     </qresource>
 </RCC>

--- a/src/ui/states/StateBackendFailure.qml
+++ b/src/ui/states/StateBackendFailure.qml
@@ -5,16 +5,32 @@
 import QtQuick 2.5
 import QtQuick.Controls 2.14
 import Mozilla.VPN 1.0
-
 import "../components"
 
-Item {
-    VPNButton {
-        // This is needed for testing.
-        objectName: "heartbeatTryButton";
 
-        text: "click me"
-        anchors.fill: parent
-        onClicked: VPN.triggerHeartbeat();
+VPNStackView {
+    id: stackview
+
+    function handleButtonClick() {
+        VPN.triggerHeartbeat();
     }
+
+    Component.onCompleted:stackview.push(
+        "../views/ViewErrorFullScreen.qml",
+        {
+            //% "Something went wrong…"
+            headlineText: qsTrId("vpn.errors.somethingWentWrong"),
+
+            //% "Unable to establish a connection at this time. We're working hard to resolve the issue. Please try again shortly."
+            errorMessage: qsTrId("vpn.errors.unableToEstablishConnection"),
+
+            //% "Try Again"
+            buttonText: qsTrId("vpn.errors.tryAgain"),
+
+            buttonObjectName: "heartbeatTryButton",
+            buttonOnClick: stackview.handleButtonClick,
+            signOffLinkVisible: false,
+            getHelpLinkVisible: true
+        }
+    )
 }

--- a/src/ui/states/StateSubscriptionBlocked.qml
+++ b/src/ui/states/StateSubscriptionBlocked.qml
@@ -8,130 +8,31 @@ import Mozilla.VPN 1.0
 import "../components"
 import "../themes/themes.js" as Theme
 
-VPNFlickable {
-    id: vpnFlickable
+VPNStackView {
+    id: stackview
 
-    Component.onCompleted: {
-        flickContentHeight = vpnFlickable.childrenRect.height;
+    function handleButtonClick() {
+        VPN.openLink(VPN.LinkSubscriptionsBlocked)
     }
 
-    ColumnLayout {
-        width: vpnFlickable.width
-        anchors.fill: parent
-        anchors.topMargin: vpnFlickable.height * 0.08
-
-        VPNHeadline {
-            id: headline
-
+    Component.onCompleted:stackview.push(
+        "../views/ViewErrorFullScreen.qml",
+        {
             //% "Error confirming subscription…"
-            text: qsTrId("vpn.subscriptionBlocked.title")
-            Layout.preferredHeight: paintedHeight
-            Layout.preferredWidth: Math.max(Theme.maxTextWidth, vpnFlickable.width * 0.85)
+            headlineText: qsTrId("vpn.subscriptionBlocked.title"),
+
+            //% "Another Firefox Account has already subscribed using this Apple ID."
+            errorMessage:qsTrId("vpn.subscriptionBlocked.anotherFxaSubscribed"),
+
+            //% "Visit our help center to learn more about managing your subscriptions."
+            errorMessage2: qsTrId("vpn.subscriptionBlocked.visitHelpCenter"),
+
+            //% "Get Help"
+            buttonText: qsTrId("vpn.subscriptionBlocked.getHelp"),
+            buttonObjectName: "errorGetHelpButton",
+            buttonOnClick: stackview.handleButtonClick,
+            signOffLinkVisible: true,
+            getHelpLinkVisible: false
         }
-
-
-        Item {
-            id: wrapper
-
-            Layout.preferredHeight: parent.height - headline.paintedHeight - footerItems.childrenRect.height
-            Layout.fillWidth: true
-            Item {
-                id: floatingContentWrapper
-
-                anchors.verticalCenter: parent.verticalCenter
-                anchors.right: parent.right
-                anchors.left: parent.left
-                height: childrenRect.height
-
-                Rectangle {
-                    id: warningIconWrapper
-
-                    height: 48
-                    width: 48
-                    color: Theme.red
-                    radius: height / 2
-                    anchors.top: parent.top
-                    anchors.horizontalCenter: parent.horizontalCenter
-
-                    Image {
-                        source: "../resources/warning-white.svg"
-                        antialiasing: true
-                        sourceSize.height: 20
-                        sourceSize.width: 20
-                        anchors.centerIn: parent
-                    }
-
-                }
-
-                VPNTextBlock {
-                    id: copyBlock1
-
-                    anchors.top: warningIconWrapper.bottom
-                    anchors.topMargin: Theme.windowMargin * 2
-                    anchors.horizontalCenter: parent.horizontalCenter
-                    horizontalAlignment: Text.AlignHCenter
-                    width: Theme.maxTextWidth
-                    font.pixelSize: Theme.fontSize
-                    lineHeight: 22
-                    //% "Another Firefox Account has already subscribed using this Apple ID."
-                    text:qsTrId("vpn.subscriptionBlocked.anotherFxaSubscribed")
-                }
-
-                VPNTextBlock {
-                    id: copyBlock2
-
-                    anchors.top: copyBlock1.bottom
-                    anchors.topMargin: Theme.windowMargin * 1.5
-                    anchors.horizontalCenter: parent.horizontalCenter
-                    horizontalAlignment: Text.AlignHCenter
-                    width: Theme.maxTextWidth
-                    font.pixelSize: Theme.fontSize
-                    lineHeight: 22
-                    //% "Visit our help center to learn more about managing your subscriptions."
-                    text: qsTrId("vpn.subscriptionBlocked.visitHelpCenter")
-                }
-
-                Rectangle {
-                    height: Theme.rowHeight * 2
-                    width: parent.width
-                    color: "transparent"
-                    anchors.top: copyBlock2.bottom
-                }
-
-            }
-
-        }
-
-        Item {
-            id: footerItems
-            Layout.preferredHeight: childrenRect.height
-            Layout.fillWidth: true
-            Layout.alignment: Qt.AlignBottom
-
-            VPNButton {
-                //% "Get Help"
-                text: qsTrId("vpn.subscriptionBlocked.getHelp")
-                anchors.bottom: spacer.top
-                anchors.horizontalCenter: parent.horizontalCenter
-                loaderVisible: false
-                onClicked: VPN.openLink(VPN.LinkSubscriptionBlocked)
-            }
-
-            Rectangle {
-                id: spacer
-                anchors.bottom: signOff.top
-                height: Theme.windowMargin
-            }
-
-            VPNSignOut {
-                id: signOff
-
-                height: Theme.rowHeight
-                onClicked: {
-                    VPNController.logout();
-                }
-            }
-
-        }
-    }
+    )
 }

--- a/src/ui/views/ViewErrorFullScreen.qml
+++ b/src/ui/views/ViewErrorFullScreen.qml
@@ -1,0 +1,157 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import QtQuick 2.5
+import QtQuick.Layouts 1.14
+import Mozilla.VPN 1.0
+import "../components"
+import "../themes/themes.js" as Theme
+
+VPNFlickable {
+    property var headlineText
+    property var errorMessage: ""
+    property var errorMessage2: ""
+    property var buttonText
+    property var buttonObjectName
+    property var buttonOnClick
+    property var signOffLinkVisible: false
+    property var getHelpLinkVisible: false
+    id: vpnFlickable
+
+    Component.onCompleted: {
+        flickContentHeight = col.childrenRect.height + col.anchors.topMargin
+    }
+
+    ColumnLayout {
+        id: col
+        width: vpnFlickable.width
+        anchors.top: parent.top
+        anchors.topMargin: vpnFlickable.height * 0.08
+        anchors.horizontalCenter: parent.horizontalCenter
+        spacing: 32
+
+        Component.onCompleted: {
+            height = Math.max(window.height, childrenRect.height)
+        }
+
+        VPNHeadline {
+            id: headline
+
+            text: headlineText
+            Layout.preferredHeight: paintedHeight
+            Layout.preferredWidth: col.width - (Theme.windowMargin * 2)
+            Layout.maximumWidth: 500
+        }
+
+        ColumnLayout {
+            spacing: 24
+            Layout.alignment: Qt.AlignHCenter
+
+            Rectangle {
+                id: warningIconWrapper
+
+                Layout.preferredHeight: 48
+                Layout.preferredWidth: 48
+                Layout.alignment: Qt.AlignHCenter;
+                color: Theme.red
+                radius: height / 2
+
+                Image {
+                    source: "../resources/warning-white.svg"
+                    antialiasing: true
+                    sourceSize.height: 20
+                    sourceSize.width: 20
+                    anchors.centerIn: parent
+                }
+            }
+
+            ColumnLayout {
+                spacing: Theme.windowMargin
+                Layout.alignment: Qt.AlignHCenter
+                VPNTextBlock {
+                    id: copyBlock1
+                    Layout.preferredWidth: Theme.maxTextWidth
+                    Layout.preferredHeight: paintedHeight
+                    Layout.alignment: Qt.AlignHCenter
+                    horizontalAlignment: Text.AlignHCenter
+                    font.pixelSize: Theme.fontSize
+                    lineHeight: 22
+                    text: errorMessage
+                }
+
+                VPNTextBlock {
+                    id: copyBlock2
+
+                    Layout.preferredWidth: Theme.maxTextWidth
+                    horizontalAlignment: Text.AlignHCenter
+                    Layout.preferredHeight: paintedHeight
+                    Layout.alignment: Qt.AlignHCenter
+                    font.pixelSize: Theme.fontSize
+                    lineHeight: 22
+                    text: errorMessage2
+                }
+            }
+        }
+
+        ColumnLayout {
+            spacing: Theme.windowMargin
+            Layout.fillWidth: true
+            Layout.preferredWidth: parent.width
+            Layout.alignment: Qt.AlignHCenter
+
+
+            VPNButton {
+                id: btn
+
+                objectName: buttonObjectName
+                text: buttonText
+                Layout.preferredHeight: Theme.rowHeight
+                loaderVisible: false
+                onClicked: buttonOnClick()
+            }
+
+            VPNFooterLink {
+                id: getHelpLink
+
+                visible: getHelpLinkVisible
+                Layout.preferredHeight: Theme.rowHeight
+                Layout.alignment: Qt.AlignHCenter
+                labelText: qsTrId("vpn.main.getHelp")
+                fontName: Theme.fontBoldFamily
+                linkColor: Theme.redButton
+                anchors.horizontalCenter: undefined
+                anchors.bottom: undefined
+                anchors.bottomMargin: undefined
+                onClicked: stackview.push(getHelpComponent)
+            }
+
+            VPNSignOut {
+                id: signOff
+
+                visible: signOffLinkVisible
+                Layout.preferredHeight: Theme.rowHeight
+                Layout.alignment: Qt.AlignHCenter
+                anchors.horizontalCenter: undefined
+                anchors.bottom: undefined
+                anchors.bottomMargin: undefined
+                height: undefined
+                onClicked: {
+                    VPNController.logout();
+                }
+            }
+        }
+
+        Component {
+            id: getHelpComponent
+
+            VPNGetHelp {
+                isSettingsView: false
+            }
+        }
+
+        VPNVerticalSpacer {
+            Layout.preferredHeight: Theme.windowMargin * 2
+        }
+    }
+}


### PR DESCRIPTION
Adds ViewErrorFullScreen.qml and updates StateSubscriptionBlocked and StateBackendFailure to use it. 

<img width="363" alt="Screen Shot 2021-03-03 at 4 34 47 PM" src="https://user-images.githubusercontent.com/22355127/109882071-e8c56800-7c3e-11eb-9771-57bdd5db700a.png">
