### PR TITLE
Fix 626 - Use "Close" instead of "Back" for close button tooltip in Settings Menu

### DIFF
--- a/src/ui/settings/ViewSettingsMenu.qml
+++ b/src/ui/settings/ViewSettingsMenu.qml
@@ -24,7 +24,7 @@ VPNFlickable {
         anchors.left: parent.left
         anchors.topMargin: Theme.windowMargin / 2
         anchors.leftMargin: Theme.windowMargin / 2
-        accessibleName: qsTrId("vpn.main.back")
+        accessibleName: qsTrId("vpn.connectionInfo.close")
 
         Image {
             id: backImage


### PR DESCRIPTION
<img width="358" alt="Screen Shot 2021-03-04 at 2 16 45 PM" src="https://user-images.githubusercontent.com/22355127/110025397-e9203a80-7cf4-11eb-834e-e69affda54f4.png">

Closes #626 
