### PR TITLE
MacOS DNS recovering after crash

### DIFF
--- a/macos/daemon/helper.sh
+++ b/macos/daemon/helper.sh
@@ -216,7 +216,7 @@ collect_new_service_dns() {
 		[[ $service == "*"* ]] && service="${service:1}"
 		found_services="$found_services;$service"
 		array_contains "$SERVICE_DNS" "$service" && continue
-		get_response="$(cmd networksetup -getdnsservers "$service")"
+		get_response="$(cmd networksetup -getdnsservers "$service" |tr '\n' '-')"
 		[[ $get_response == *" "* ]] && get_response="Empty"
 		[[ -n $get_response ]] && SERVICE_DNS="$SERVICE_DNS;$service=$get_response"
 		get_response="$(cmd networksetup -getsearchdomains "$service")"
@@ -335,13 +335,15 @@ del_dns() {
 	for service_value in $SERVICE_DNS; do
                 [[ -n "$service_value" ]] || continue
                 service=$(echo $service_value | cut -d= -f1)
-                value=$(echo $service_value | cut -d= -f2)
+                value=$(echo $service_value | cut -d= -f2 | sed "s/-/ /g")
+                IFS=' '
 		while read -r response; do
 			[[ $response == *Error* ]] && echo "$response" >&2
 		done < <(
-			cmd networksetup -setdnsservers "$service" "$value" || true
+			cmd networksetup -setdnsservers "$service" $value || true
 			cmd networksetup -setsearchdomains "$service" "$(array_value "$SERVICE_DNS_SEARCH" "$service")" || true
 		)
+                IFS=';'
 	done
         IFS=$oifs
 }
@@ -399,6 +401,7 @@ set_config() {
 cmd_usage() {
 	cat >&2 <<-_EOF
 	Usage: $PROGRAM [ up | down ] [ CONFIG_FILE ]
+	Usage: $PROGRAM [ cleanup ] [ DNS, DNS... ]
 	_EOF
 }
 
@@ -429,6 +432,32 @@ cmd_down() {
 	del_if
 }
 
+cmd_cleanup() {
+  INTERFACE="$1"
+
+  { read -r _ && while read -r service; do
+    [[ $service == "*"* ]] && service="${service:1}"
+    get_response="$(cmd networksetup -getdnsservers "$service" |tr '\n' '-')"
+    [[ $get_response == *" "* ]] && continue
+
+    get_response="$(echo $get_response | tr '-' '\n')"
+    echo "$get_response" | grep "$2" &>/dev/null || continue
+    get_response="$(echo "$get_response" | grep -v "$2")"
+
+    if [[ "$3" ]]; then
+      get_response="$(echo "$get_response" | grep -v "$3" || echo "")"
+    fi
+
+    if [[ $get_response ]]; then
+      cmd networksetup -setdnsservers "$service" $get_response
+    else
+      cmd networksetup -setdnsservers "$service" "Empty"
+    fi
+  done; } < <(networksetup -listallnetworkservices)
+
+  del_if
+}
+
 # ~~ function override insertion point ~~
 
 if [[ $# -eq 1 && ( $1 == --help || $1 == -h || $1 == help ) ]]; then
@@ -441,6 +470,9 @@ elif [[ $# -eq 2 && $1 == down ]]; then
 	admin_check
 	parse_options "$2"
 	cmd_down
+elif [[ $1 == cleanup ]]; then
+	admin_check
+	cmd_cleanup "$2" "$3" "$4"
 else
 	cmd_usage
 	exit 1

--- a/src/platforms/macos/daemon/macosdaemon.cpp
+++ b/src/platforms/macos/daemon/macosdaemon.cpp
@@ -14,8 +14,13 @@
 #include <QJsonValue>
 #include <QLocalSocket>
 #include <QProcess>
+#include <QSettings>
 #include <QTextStream>
 #include <QtGlobal>
+
+constexpr const char* LATEST_IPV4GATEWAY = "latestServerIpv4Gateway";
+constexpr const char* LATEST_IPV6GATEWAY = "latestServerIpv6Gateway";
+constexpr const char* LATEST_IPV6ENABLED = "latestIpv6Enabled";
 
 namespace {
 Logger logger(LOG_MACOS, "MacOSDaemon");
@@ -108,10 +113,65 @@ bool MacOSDaemon::run(Daemon::Op op, const InterfaceConfig& config) {
     addresses.append(ip.toString());
   }
 
+  QSettings settings;
+
+  if (op == Daemon::Up) {
+    settings.setValue(LATEST_IPV4GATEWAY, config.m_serverIpv4Gateway);
+    settings.setValue(LATEST_IPV6GATEWAY, config.m_serverIpv6Gateway);
+    settings.setValue(LATEST_IPV6ENABLED, config.m_ipv6Enabled);
+  } else {
+    settings.remove(LATEST_IPV4GATEWAY);
+    settings.remove(LATEST_IPV6GATEWAY);
+    settings.remove(LATEST_IPV6ENABLED);
+  }
+
   return WgQuickProcess::run(
       op, config.m_privateKey, config.m_deviceIpv4Address,
       config.m_deviceIpv6Address, config.m_serverIpv4Gateway,
       config.m_serverIpv6Gateway, config.m_serverPublicKey,
       config.m_serverIpv4AddrIn, config.m_serverIpv6AddrIn,
       addresses.join(", "), config.m_serverPort, config.m_ipv6Enabled);
+}
+
+void MacOSDaemon::maybeCleanup() {
+  logger.log() << "Cleanup";
+
+  QString app = WgQuickProcess::scriptPath();
+
+  QSettings settings;
+  if (!settings.contains(LATEST_IPV4GATEWAY)) {
+    return;
+  }
+
+  QString serverIpv4Gateway = settings.value(LATEST_IPV4GATEWAY).toString();
+  QString serverIpv6Gateway = settings.value(LATEST_IPV6GATEWAY).toString();
+  bool ipv6Enabled = settings.value(LATEST_IPV6ENABLED).toBool();
+
+  QStringList arguments;
+  arguments.append("cleanup");
+  arguments.append(WG_INTERFACE);
+  arguments.append(serverIpv4Gateway.toUtf8());
+
+  if (ipv6Enabled) {
+    arguments.append(serverIpv6Gateway.toUtf8());
+  }
+
+  logger.log() << "Start:" << app << " - arguments:" << arguments;
+
+  QProcess wgQuickProcess;
+  wgQuickProcess.start(app, arguments);
+
+  if (!wgQuickProcess.waitForFinished(-1)) {
+    logger.log() << "Error occurred:" << wgQuickProcess.errorString();
+    return;
+  }
+
+  logger.log() << "Execution finished" << wgQuickProcess.exitCode();
+
+  logger.log() << "wg-quick stdout:" << Qt::endl
+               << qUtf8Printable(wgQuickProcess.readAllStandardOutput())
+               << Qt::endl;
+  logger.log() << "wg-quick stderr:" << Qt::endl
+               << qUtf8Printable(wgQuickProcess.readAllStandardError())
+               << Qt::endl;
 }

--- a/src/platforms/macos/daemon/macosdaemon.h
+++ b/src/platforms/macos/daemon/macosdaemon.h
@@ -16,6 +16,8 @@ class MacOSDaemon final : public Daemon {
 
   QByteArray getStatus() override;
 
+  void maybeCleanup();
+
  protected:
   bool run(Op op, const InterfaceConfig& config) override;
 };

--- a/src/platforms/macos/daemon/macosdaemonserver.cpp
+++ b/src/platforms/macos/daemon/macosdaemonserver.cpp
@@ -41,6 +41,8 @@ int MacOSDaemonServer::run(QStringList& tokens) {
 
   MacOSDaemon daemon;
 
+  daemon.maybeCleanup();
+
   DaemonLocalServer server(qApp);
   if (!server.initialize()) {
     logger.log() << "Failed to initialize the server";

--- a/src/wgquickprocess.cpp
+++ b/src/wgquickprocess.cpp
@@ -20,21 +20,6 @@ Logger logger(
 #endif
     ,
     "WgQuickProcess");
-
-QString scriptPath() {
-#if defined(MVPN_LINUX)
-  QDir appPath(MVPN_DATA_PATH);
-  return appPath.filePath("helper.sh");
-#elif defined(MVPN_MACOS_DAEMON)
-  QDir appPath(QCoreApplication::applicationDirPath());
-  appPath.cdUp();
-  appPath.cd("Resources");
-  appPath.cd("utils");
-  return appPath.filePath("helper.sh");
-#endif
-  return QString();
-}
-
 }  // namespace
 
 // static
@@ -167,4 +152,19 @@ bool WgQuickProcess::run(
                << Qt::endl;
 
   return wgQuickProcess.exitCode() == 0;
+}
+
+// static
+QString WgQuickProcess::scriptPath() {
+#if defined(MVPN_LINUX)
+  QDir appPath(MVPN_DATA_PATH);
+  return appPath.filePath("helper.sh");
+#elif defined(MVPN_MACOS_DAEMON)
+  QDir appPath(QCoreApplication::applicationDirPath());
+  appPath.cdUp();
+  appPath.cd("Resources");
+  appPath.cd("utils");
+  return appPath.filePath("helper.sh");
+#endif
+  return QString();
 }

--- a/src/wgquickprocess.h
+++ b/src/wgquickprocess.h
@@ -28,6 +28,8 @@ class WgQuickProcess final {
       const QString& serverPublicKey, const QString& serverIpv4AddrIn,
       const QString& serverIpv6AddrIn, const QString& allowedIPAddressRanges,
       int serverPort, bool ipv6Enabled);
+
+  static QString scriptPath();
 };
 
 #endif  // WGQUICKPROCESS_H


### PR DESCRIPTION
This is a temporary fix for the next release until we have a better daemon implementation. It turned out that macOS leaks VPN DNSs randomly. I suspect there is a crash or a restart of the daemon. When this happens, the user is unable to navigate because the DNSs are wrongly set.
This is a temporary fix that stores the DNSs in a Settings and remove them at startup if found.

If somebody has time to work on a better fix, I'm happier :)