### PR TITLE
Fix spacing in Notifications

### DIFF
--- a/src/ui/components/VPNCheckBoxRow.qml
+++ b/src/ui/components/VPNCheckBoxRow.qml
@@ -49,7 +49,7 @@ RowLayout {
         id: labelWrapper
 
         Layout.fillWidth: true
-        spacing: 0
+        spacing: 4
 
         VPNInterLabel {
             id: label


### PR DESCRIPTION
Tiniest of nits noticed while working on #661 

After:
<img width="363" alt="Screen Shot 2021-03-15 at 10 54 45 PM" src="https://user-images.githubusercontent.com/22355127/111253766-b96d0e80-85e1-11eb-8896-bc92dea1cd74.png">

Before: 
<img width="360" alt="Screen Shot 2021-03-15 at 10 55 58 PM" src="https://user-images.githubusercontent.com/22355127/111253727-ac501f80-85e1-11eb-959f-7b588a0fa2c2.png">