### PR TITLE
Replace logcat reading with a log-file

### DIFF
--- a/android/src/com/mozilla/vpn/BootReceiver.kt
+++ b/android/src/com/mozilla/vpn/BootReceiver.kt
@@ -8,12 +8,13 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.os.Build
-import android.util.Log
+import com.mozilla.vpn.Log
 import com.wireguard.android.backend.GoBackend
 
 class BootReceiver : BroadcastReceiver() {
     private val TAG = "BootReceiver"
     override fun onReceive(context: Context, arg1: Intent) {
+        Log.init(context)
         if (!canEnableVPNOnBoot()) {
             Log.i(TAG, "This device does not support start on boot - exit")
             return

--- a/android/src/com/mozilla/vpn/NotificationUtil.kt
+++ b/android/src/com/mozilla/vpn/NotificationUtil.kt
@@ -11,7 +11,6 @@ import android.content.Context
 import android.content.Intent
 import android.os.Build
 import android.os.Parcel
-import android.util.Log
 import androidx.core.app.NotificationCompat
 import org.json.JSONObject
 import org.mozilla.firefox.vpn.VPNService

--- a/android/src/com/mozilla/vpn/VPNLogger.kt
+++ b/android/src/com/mozilla/vpn/VPNLogger.kt
@@ -1,0 +1,59 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package com.mozilla.vpn
+
+import android.content.Context
+import java.io.File
+import java.time.LocalDateTime
+import android.util.Log as nativeLog
+
+/*
+ * Drop in replacement for android.util.Log 
+ * Also stores a copy of all logs in tmp/mozilla_deamon_logs.txt
+*/
+class Log {
+    private var file: File
+    private constructor(context: Context) {
+        val tempDIR = context.cacheDir
+        file = File(tempDIR, "mozilla_deamon_logs.txt")
+    }
+
+    companion object {
+        var instance: Log? = null
+        fun init(ctx: Context) {
+            if (instance == null) {
+                instance = Log(ctx)
+            }
+        }
+        fun i(tag: String, message: String) {
+            instance?.write("[info] - ($tag) - $message")
+            nativeLog.i(tag, message)
+        }
+        fun v(tag: String, message: String) {
+            instance?.write("($tag) - $message")
+            nativeLog.v(tag, message)
+        }
+        fun e(tag: String, message: String) {
+            instance?.write("[error] - ($tag) - $message")
+            nativeLog.e(tag, message)
+        }
+
+        fun getContent(): String? {
+            return try {
+                instance?.file?.readText()
+            } catch (e: Exception) {
+                "=== Failed to read Daemon Logs === \n ${e.localizedMessage} "
+            }
+        }
+
+        fun clearFile() {
+            instance?.file?.writeText("")
+        }
+    }
+    private fun write(message: String) {
+        LocalDateTime.now()
+        file.appendText("[${LocalDateTime.now()}] $message  \n")
+    }
+}

--- a/android/src/com/mozilla/vpn/VPNService.kt
+++ b/android/src/com/mozilla/vpn/VPNService.kt
@@ -7,7 +7,7 @@ package org.mozilla.firefox.vpn
 import android.content.Context
 import android.content.Intent
 import android.os.IBinder
-import android.util.Log
+import com.mozilla.vpn.Log
 import com.mozilla.vpn.NotificationUtil
 import com.mozilla.vpn.VPNTunnel
 import com.wireguard.android.backend.*
@@ -36,6 +36,7 @@ class VPNService : android.net.VpnService() {
      * calles bindService. Returns the [VPNServiceBinder] so QT can send Requests to it.
      */
     override fun onBind(intent: Intent?): IBinder? {
+        Log.init(this)
         NotificationUtil.show(this)
         Log.v(tag, "Got Bind request")
         return mBinder
@@ -47,6 +48,7 @@ class VPNService : android.net.VpnService() {
      * or from Booting the device and having "connect on boot" enabled.
      */
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        Log.init(this)
         this.startService(Intent(this, GoBackend.VpnService::class.java))
         intent?.let {
             if (intent.getBooleanExtra("startOnly", false)) {

--- a/android/src/com/mozilla/vpn/VPNServiceBinder.kt
+++ b/android/src/com/mozilla/vpn/VPNServiceBinder.kt
@@ -8,14 +8,12 @@ import android.os.Binder
 import android.os.DeadObjectException
 import android.os.IBinder
 import android.os.Parcel
-import android.util.Log
+import com.mozilla.vpn.Log
 import com.mozilla.vpn.NotificationUtil
 import com.wireguard.android.backend.Tunnel
 import com.wireguard.config.*
 import com.wireguard.crypto.Key
 import org.json.JSONObject
-import java.io.BufferedReader
-import java.io.InputStreamReader
 import java.lang.Exception
 
 class VPNServiceBinder(service: VPNService) : Binder() {
@@ -124,12 +122,7 @@ class VPNServiceBinder(service: VPNService) : Binder() {
 
             ACTIONS.requestGetLog -> {
                 // Grabs all the Logs and dispatch new Log Event
-                val process = Runtime.getRuntime().exec("logcat -d")
-                val bufferedReader = BufferedReader(
-                    InputStreamReader(process.inputStream)
-                )
-                val allText = bufferedReader.use(BufferedReader::readText)
-                dispatchEvent(EVENTS.backendLogs, allText)
+                dispatchEvent(EVENTS.backendLogs, Log.getContent())
                 return true
             }
             ACTIONS.enableStartOnBoot -> {
@@ -147,7 +140,7 @@ class VPNServiceBinder(service: VPNService) : Binder() {
             }
 
             ACTIONS.requestCleanupLog -> {
-                Runtime.getRuntime().exec("logcat -c")
+                Log.clearFile()
                 return true
             }
             ACTIONS.setNotificationText -> {
@@ -174,12 +167,12 @@ class VPNServiceBinder(service: VPNService) : Binder() {
      * To register an Eventhandler use [onTransact] with
      * [ACTIONS.registerEventListener]
      */
-    fun dispatchEvent(code: Int, payload: String) {
+    fun dispatchEvent(code: Int, payload: String?) {
         try {
             mListener?.let {
                 if (it.isBinderAlive) {
                     val data = Parcel.obtain()
-                    data.writeByteArray(payload.toByteArray(charset("UTF-8")))
+                    data.writeByteArray(payload?.toByteArray(charset("UTF-8")))
                     it.transact(code, data, Parcel.obtain(), 0)
                 }
             }


### PR DESCRIPTION
Closes #685

Logcat has a few issues. If the call fails and the callback is never done we'll just show a white page. 
Also logcat does not keep logs as long as we want to, so i want to replace it with a drop-in replacement that also stores everything to disk aswell as printing to logcat. - Just like the qt version. 
This should be more robust as we can just catch i/o errors :) 