### PR TITLE
Allow Disconnect Notification On Init Screen

### DIFF
--- a/src/notificationhandler.cpp
+++ b/src/notificationhandler.cpp
@@ -42,7 +42,9 @@ void NotificationHandler::showNotification() {
   logger.log() << "Show notification";
 
   MozillaVPN* vpn = MozillaVPN::instance();
-  if (vpn->state() != MozillaVPN::StateMain) {
+  if (vpn->state() != MozillaVPN::StateMain &&
+      !(vpn->state() == MozillaVPN::StateInitialize &&
+        vpn->controller()->state() == Controller::StateOff)) {
     return;
   }
 

--- a/src/notificationhandler.cpp
+++ b/src/notificationhandler.cpp
@@ -43,6 +43,9 @@ void NotificationHandler::showNotification() {
 
   MozillaVPN* vpn = MozillaVPN::instance();
   if (vpn->state() != MozillaVPN::StateMain &&
+      // The Disconnected notification should be triggerable
+      // on StateInitialize, in case the user was connected during a log-out
+      // Otherwise existing notifications showing "connected" would update
       !(vpn->state() == MozillaVPN::StateInitialize &&
         vpn->controller()->state() == Controller::StateOff)) {
     return;


### PR DESCRIPTION
Currently we only allow updating the notification if we're on the main screen. 

To close #683, we probably should also allow the disconnected notification on the init screen, as it might have been triggered by a logout.