### PR TITLE
Suspend Connection Health when the app is inactive

### DIFF
--- a/src/connectionhealth.cpp
+++ b/src/connectionhealth.cpp
@@ -7,6 +7,7 @@
 #include "logger.h"
 #include "models/server.h"
 #include "mozillavpn.h"
+#include <QApplication>
 
 // In seconds, the timeout for unstable pings.
 constexpr uint32_t PING_TIME_UNSTABLE_SEC = 1;
@@ -27,6 +28,9 @@ ConnectionHealth::ConnectionHealth() {
 
   connect(&m_pingHelper, &PingHelper::pingSentAndReceived, this,
           &ConnectionHealth::pingSentAndReceived);
+
+  connect(qApp, &QApplication::applicationStateChanged, this,
+          &ConnectionHealth::applicationStateChanged);
 }
 
 ConnectionHealth::~ConnectionHealth() { MVPN_COUNT_DTOR(ConnectionHealth); }
@@ -38,6 +42,17 @@ void ConnectionHealth::stop() {
   m_noSignalTimer.stop();
 
   setStability(Stable);
+}
+
+void ConnectionHealth::start(const QString& serverIpv4Gateway) {
+  logger.log() << "ConnectionHealth activated";
+  if (!serverIpv4Gateway.isEmpty() ||
+      MozillaVPN::instance()->controller()->state() != Controller::StateOn) {
+    return;
+  }
+  m_currentGateway = serverIpv4Gateway;
+  m_pingHelper.start(serverIpv4Gateway);
+  m_noSignalTimer.start(PING_TIME_NOSIGNAL_SEC * 1000);
 }
 
 void ConnectionHealth::setStability(ConnectionStability stability) {
@@ -66,13 +81,7 @@ void ConnectionHealth::connectionStateChanged() {
         Q_UNUSED(rxBytes);
 
         stop();
-
-        if (!serverIpv4Gateway.isEmpty() &&
-            MozillaVPN::instance()->controller()->state() ==
-                Controller::StateOn) {
-          m_pingHelper.start(serverIpv4Gateway);
-          m_noSignalTimer.start(PING_TIME_NOSIGNAL_SEC * 1000);
-        }
+        start(serverIpv4Gateway);
       });
 }
 
@@ -92,4 +101,23 @@ void ConnectionHealth::pingSentAndReceived(qint64 msec) {
 void ConnectionHealth::noSignalDetected() {
   logger.log() << "No signal detected";
   setStability(NoSignal);
+}
+
+void ConnectionHealth::applicationStateChanged(Qt::ApplicationState state) {
+  switch (state) {
+    case Qt::ApplicationState::ApplicationActive:
+      if (m_suspended) {
+        Q_ASSERT(!m_noSignalTimer.isActive());
+        logger.log() << "Resuming connection check from Suspension";
+        start(m_currentGateway);
+      }
+      break;
+    case Qt::ApplicationState::ApplicationSuspended:
+    case Qt::ApplicationState::ApplicationInactive:
+    case Qt::ApplicationState::ApplicationHidden:
+      logger.log() << "Pausing connection for Suspension";
+      m_suspended = true;
+      stop();
+      break;
+  }
 }

--- a/src/connectionhealth.h
+++ b/src/connectionhealth.h
@@ -31,12 +31,14 @@ class ConnectionHealth final : public QObject {
 
  public slots:
   void connectionStateChanged();
+  void applicationStateChanged(Qt::ApplicationState state);
 
  signals:
   void stabilityChanged();
 
  private:
   void stop();
+  void start(const QString& serverIpv4Gateway);
 
   void pingSentAndReceived(qint64 msec);
 
@@ -50,6 +52,9 @@ class ConnectionHealth final : public QObject {
   QTimer m_noSignalTimer;
 
   PingHelper m_pingHelper;
+
+  bool m_suspended = false;
+  QString m_currentGateway;
 };
 
 #endif  // CONNECTIONHEALTH_H


### PR DESCRIPTION
Stop ConnectionHealth when the app goes into an inactive state and resume once the app is back up - so we're not getting a "no connection" after every resume :)  