### PR TITLE
Ubuntu notification - a few changes

### DIFF
--- a/src/captiveportal/captiveportalnotifier.cpp
+++ b/src/captiveportal/captiveportalnotifier.cpp
@@ -8,10 +8,6 @@
 #include "logger.h"
 #include "systemtrayhandler.h"
 
-#ifdef MVPN_LINUX
-#  include "platforms/linux/linuxsystemtrayhandler.h"
-#endif
-
 namespace {
 Logger logger(LOG_NETWORKING, "CaptivePortalNotifier");
 }
@@ -31,22 +27,12 @@ CaptivePortalNotifier::~CaptivePortalNotifier() {
 
 void CaptivePortalNotifier::notifyCaptivePortalBlock() {
   logger.log() << "Captive portal block notify";
-
-#if defined(MVPN_LINUX)
-  LinuxSystemTrayHandler::instance()->captivePortalBlockNotificationRequired();
-#else
   SystemTrayHandler::instance()->captivePortalBlockNotificationRequired();
-#endif
 }
 
 void CaptivePortalNotifier::notifyCaptivePortalUnblock() {
   logger.log() << "Captive portal unblock notify";
-#if defined(MVPN_LINUX)
-  LinuxSystemTrayHandler::instance()
-      ->captivePortalUnblockNotificationRequired();
-#else
   SystemTrayHandler::instance()->captivePortalUnblockNotificationRequired();
-#endif
 }
 
 void CaptivePortalNotifier::notificationClicked(

--- a/src/commands/commandui.cpp
+++ b/src/commands/commandui.cpp
@@ -341,7 +341,8 @@ int CommandUI::run(QStringList& tokens) {
         Qt::QueuedConnection);
     engine->load(url);
 
-    SystemTrayHandler* systemTrayHandler = SystemTrayHandler::create(qApp);
+    SystemTrayHandler* systemTrayHandler =
+        SystemTrayHandler::create(&engineHolder);
     Q_ASSERT(systemTrayHandler);
 
     systemTrayHandler->show();

--- a/src/networkwatcher.cpp
+++ b/src/networkwatcher.cpp
@@ -17,7 +17,6 @@
 #endif
 
 #ifdef MVPN_LINUX
-#  include "platforms/linux/linuxsystemtrayhandler.h"
 #  include "platforms/linux/linuxnetworkwatcher.h"
 #endif
 
@@ -132,12 +131,7 @@ void NetworkWatcher::unsecuredNetwork(const QString& networkName,
     m_firstNotification = false;
   }
 
-#  if defined(MVPN_LINUX)
-  LinuxSystemTrayHandler::instance()->unsecuredNetworkNotification(networkName);
-#  else
   SystemTrayHandler::instance()->unsecuredNetworkNotification(networkName);
-#  endif
-
 #endif
 }
 

--- a/src/platforms/linux/linuxsystemtrayhandler.cpp
+++ b/src/platforms/linux/linuxsystemtrayhandler.cpp
@@ -15,99 +15,53 @@ constexpr const char* DBUS_INTERFACE = "org.freedesktop.Notifications";
 
 namespace {
 Logger logger(LOG_LINUX, "LinuxSystemTrayHandler");
-LinuxSystemTrayHandler* s_instance = nullptr;
 }  // namespace
 
 // static
-LinuxSystemTrayHandler* LinuxSystemTrayHandler::instance() {
-  Q_ASSERT(s_instance);
-  return s_instance;
+bool LinuxSystemTrayHandler::requiredCustomImpl() {
+  // This custom systemTrayHandler implementation is required only on Unity.
+  QStringList registeredServices = QDBusConnection::sessionBus()
+                                       .interface()
+                                       ->registeredServiceNames()
+                                       .value();
+  return registeredServices.contains("com.canonical.Unity");
 }
 
 LinuxSystemTrayHandler::LinuxSystemTrayHandler(QObject* parent)
     : SystemTrayHandler(parent) {
   MVPN_COUNT_CTOR(LinuxSystemTrayHandler);
-  s_instance = this;
-  // Are we on Unity?
-  QStringList registeredServices = QDBusConnection::sessionBus()
-                                       .interface()
-                                       ->registeredServiceNames()
-                                       .value();
-  m_isUnity = registeredServices.contains("com.canonical.Unity");
 }
 
 LinuxSystemTrayHandler::~LinuxSystemTrayHandler() {
   MVPN_COUNT_DTOR(LinuxSystemTrayHandler);
 }
 
-void LinuxSystemTrayHandler::unsecuredNetworkNotification(
-    const QString& networkName) {
-  logger.log() << "Unsecured network notification shown";
+void LinuxSystemTrayHandler::showNotificationInternal(Message type,
+                                                      const QString& title,
+                                                      const QString& message,
+                                                      int timerMsec) {
+  QString actionMessage;
+  switch (type) {
+    case None:
+      return SystemTrayHandler::showNotificationInternal(type, title, message,
+                                                         timerMsec);
 
-  //% "Unsecured Wi-Fi network detected"
-  QString title = qtTrId("vpn.systray.unsecuredNetwork.title");
+    case UnsecuredNetwork:
+      actionMessage = qtTrId("vpn.toggle.on");
+      break;
 
-  //% "%1 is not secure. Click here to turn on VPN and secure your device."
-  //: %1 is the Wi-Fi network name
-  QString message =
-      qtTrId("vpn.systray.unsecuredNetwork2.message").arg(networkName);
-  QString actionMessage = qtTrId("vpn.toggle.on");
+    case CaptivePortalBlock:
+      actionMessage = qtTrId("vpn.toggle.off");
+      break;
 
-  if (m_isUnity) {
-    showUnityActionNotification(UnsecuredNetwork, title, actionMessage, message,
-                                Constants::UNSECURED_NETWORK_ALERT_MSEC);
-  } else {
-    SystemTrayHandler::instance()->showNotificationInternal(
-        UnsecuredNetwork, title, message,
-        Constants::UNSECURED_NETWORK_ALERT_MSEC);
+    case CaptivePortalUnblock:
+      actionMessage = qtTrId("vpn.toggle.on");
+      break;
+
+    default:
+      Q_ASSERT(false);
   }
-}
 
-void LinuxSystemTrayHandler::captivePortalBlockNotificationRequired() {
-  logger.log() << "Captive portal block notification shown";
-
-  //% "Guest Wi-Fi portal blocked"
-  QString title = qtTrId("vpn.systray.captivePortalBlock.title");
-
-  //% "The guest Wi-Fi network you’re connected to requires action. Click here"
-  //% " to turn off VPN to see the portal."
-  QString message = qtTrId("vpn.systray.captivePortalBlock2.message");
-  QString actionMessage = qtTrId("vpn.toggle.off");
-
-  if (m_isUnity) {
-    showUnityActionNotification(CaptivePortalBlock, title, actionMessage,
-                                message, Constants::CAPTIVE_PORTAL_ALERT_MSEC);
-  } else {
-    SystemTrayHandler::instance()->showNotificationInternal(
-        CaptivePortalBlock, title, message,
-        Constants::CAPTIVE_PORTAL_ALERT_MSEC);
-  }
-}
-
-void LinuxSystemTrayHandler::captivePortalUnblockNotificationRequired() {
-  logger.log() << "Captive portal unblock notification shown";
-
-  //% "Guest Wi-Fi portal detected"
-  QString title = qtTrId("vpn.systray.captivePortalUnblock.title");
-
-  //% "The guest Wi-Fi network you’re connected to may not be secure. Click"
-  //% " here to turn on VPN to secure your device."
-  QString message = qtTrId("vpn.systray.captivePortalUnblock2.message");
-  QString actionMessage = qtTrId("vpn.toggle.on");
-
-  if (m_isUnity) {
-    showUnityActionNotification(CaptivePortalUnblock, title, actionMessage,
-                                message, Constants::CAPTIVE_PORTAL_ALERT_MSEC);
-  } else {
-    SystemTrayHandler::instance()->showNotificationInternal(
-        CaptivePortalUnblock, title, message,
-        Constants::CAPTIVE_PORTAL_ALERT_MSEC);
-  }
-}
-
-void LinuxSystemTrayHandler::showUnityActionNotification(
-    SystemTrayHandler::Message type, const QString& title,
-    const QString& actionMessage, const QString& message, int timerMsec) {
   m_lastMessage = type;
   emit notificationShown(title, message);
 

--- a/src/platforms/linux/linuxsystemtrayhandler.h
+++ b/src/platforms/linux/linuxsystemtrayhandler.h
@@ -13,20 +13,14 @@ class LinuxSystemTrayHandler final : public SystemTrayHandler {
   Q_DISABLE_COPY_MOVE(LinuxSystemTrayHandler)
 
  public:
-  static LinuxSystemTrayHandler* instance();
+  static bool requiredCustomImpl();
 
   LinuxSystemTrayHandler(QObject* parent);
   ~LinuxSystemTrayHandler();
-  void captivePortalBlockNotificationRequired();
-  void captivePortalUnblockNotificationRequired();
-  void unsecuredNetworkNotification(const QString& networkName);
 
  private:
-  void showUnityActionNotification(SystemTrayHandler::Message type,
-                                   const QString& title,
-                                   const QString& actionMessage,
-                                   const QString& message, int timerMsec);
-  bool m_isUnity = true;
+  void showNotificationInternal(Message type, const QString& title,
+                                const QString& message, int timerMsec) override;
 };
 
 #endif  // LINUXNOTIFICATIONHANDLER_H

--- a/src/platforms/linux/linuxsystemtrayhandler.h
+++ b/src/platforms/linux/linuxsystemtrayhandler.h
@@ -10,6 +10,7 @@
 #include <QObject>
 
 class LinuxSystemTrayHandler final : public SystemTrayHandler {
+  Q_OBJECT
   Q_DISABLE_COPY_MOVE(LinuxSystemTrayHandler)
 
  public:
@@ -21,6 +22,12 @@ class LinuxSystemTrayHandler final : public SystemTrayHandler {
  private:
   void showNotificationInternal(Message type, const QString& title,
                                 const QString& message, int timerMsec) override;
+
+ private slots:
+  void actionInvoked(uint actionId, QString action);
+
+ private:
+  uint m_lastNotificationId = 0;
 };
 
 #endif  // LINUXNOTIFICATIONHANDLER_H

--- a/src/qmlengineholder.cpp
+++ b/src/qmlengineholder.cpp
@@ -33,6 +33,9 @@ QmlEngineHolder* QmlEngineHolder::instance() {
   return s_instance;
 }
 
+// static
+bool QmlEngineHolder::exists() { return !!s_instance; }
+
 QNetworkAccessManager* QmlEngineHolder::networkAccessManager() {
   return m_engine.networkAccessManager();
 }

--- a/src/qmlengineholder.h
+++ b/src/qmlengineholder.h
@@ -20,6 +20,8 @@ class QmlEngineHolder final : public NetworkManager {
 
   static QmlEngineHolder* instance();
 
+  static bool exists();
+
   QQmlApplicationEngine* engine() { return &m_engine; }
 
   QNetworkAccessManager* networkAccessManager() override;

--- a/src/systemtrayhandler.h
+++ b/src/systemtrayhandler.h
@@ -24,10 +24,11 @@ class SystemTrayHandler : public QSystemTrayIcon {
     CaptivePortalUnblock,
   };
 
+  static SystemTrayHandler* create(QObject* parent);
+
   static SystemTrayHandler* instance();
 
-  explicit SystemTrayHandler(QObject* parent);
-  ~SystemTrayHandler();
+  virtual ~SystemTrayHandler();
 
   void captivePortalBlockNotificationRequired();
   void captivePortalUnblockNotificationRequired();
@@ -36,9 +37,6 @@ class SystemTrayHandler : public QSystemTrayIcon {
 
   void showNotification(const QString& title, const QString& message,
                         int timerMsec);
-
-  void showNotificationInternal(Message type, const QString& title,
-                                const QString& message, int timerMsec);
 
   void retranslate();
 
@@ -53,6 +51,12 @@ class SystemTrayHandler : public QSystemTrayIcon {
   void updateContextMenu();
 
   void messageClickHandle();
+
+ protected:
+  explicit SystemTrayHandler(QObject* parent);
+
+  virtual void showNotificationInternal(Message type, const QString& title,
+                                        const QString& message, int timerMsec);
 
  protected:
   Message m_lastMessage = None;


### PR DESCRIPTION
This PR contains 2 commits:

1. the first one contains a less-intrusive systemTrayHandler code. Let's move the "Linux vs Default" in the CTOR of SystemTrayHandler and let's overwrite just the `showNotificationInternal` method.
2. The clicking is not received for me. I had to add a slot for that.