### PR TITLE
Fix random timout banner

### DIFF
--- a/src/errorhandler.cpp
+++ b/src/errorhandler.cpp
@@ -38,7 +38,7 @@ ErrorHandler::ErrorType ErrorHandler::toErrorType(
     case QNetworkReply::HostNotFoundError:
       [[fallthrough]];
     case QNetworkReply::TimeoutError:
-      [[fallthrough]];
+      return VPNDependentConnectionError;
     case QNetworkReply::UnknownNetworkError:
       // On mac, this means: no internet
       // On Android check if

--- a/src/errorhandler.cpp
+++ b/src/errorhandler.cpp
@@ -36,7 +36,7 @@ ErrorHandler::ErrorType ErrorHandler::toErrorType(
       return ConnectionFailureError;
 
     case QNetworkReply::HostNotFoundError:
-      [[fallthrough]];
+      return NoConnectionError;
     case QNetworkReply::TimeoutError:
       return VPNDependentConnectionError;
     case QNetworkReply::UnknownNetworkError:

--- a/src/errorhandler.h
+++ b/src/errorhandler.h
@@ -13,6 +13,7 @@ class ErrorHandler final {
     NoError,
     ConnectionFailureError,
     NoConnectionError,
+    VPNDependentConnectionError,
     AuthenticationError,
     ControllerError,
     RemoteServiceError,

--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -737,6 +737,16 @@ void MozillaVPN::errorHandle(ErrorHandler::ErrorType error) {
   AlertType alert = NoAlert;
 
   switch (error) {
+    case ErrorHandler::VPNDependentConnectionError:
+      // This type of error might be caused by switchting the VPN
+      // on, in which case it's okay to be ignored.
+      // In Case the vpn is not connected - handle this like a
+      // ConnectionFailureError
+      if (controller()->state() == Controller::StateOn) {
+        logger.log() << "Ignore network error probably caused by enabled VPN";
+        break;
+      }
+      [[fallthrough]];
     case ErrorHandler::ConnectionFailureError:
       alert = ConnectionFailedAlert;
       break;


### PR DESCRIPTION
Closes #495 

Issue here is: 
We have a task that starts an http-request.  (e.g. account&Servers)
We connect vpn.
The Request times out, as expected.  
We show the no connection banner.

My idea: Add a new connection-error for things that might be caused by vpn and are okay to ignore if the vpn is connected. 