### PR TITLE
Captive portal queue

### DIFF
--- a/src/captiveportal/captiveportaldetection.cpp
+++ b/src/captiveportal/captiveportaldetection.cpp
@@ -97,16 +97,22 @@ void CaptivePortalDetection::settingsChanged() {
   }
 }
 
-void CaptivePortalDetection::detectionCompleted(bool detected) {
+void CaptivePortalDetection::detectionCompleted(
+    CaptivePortalRequest::CaptivePortalResult detected) {
   logger.log() << "Detection completed:" << detected;
 
   m_impl.reset();
 
-  if (!detected) {
-    return;
+  switch (detected) {
+    case CaptivePortalRequest::CaptivePortalResult::NoPortal:
+      return;
+    case CaptivePortalRequest::CaptivePortalResult::PortalPossible:
+      captivePortalPossible();
+      return;
+    case CaptivePortalRequest::CaptivePortalResult::PortalDetected:
+      captivePortalDetected();
+      return;
   }
-
-  captivePortalDetected();
 }
 
 void CaptivePortalDetection::captivePortalDetected() {
@@ -120,6 +126,19 @@ void CaptivePortalDetection::captivePortalDetected() {
 
   if (MozillaVPN::instance()->controller()->state() == Controller::StateOn) {
     captivePortalNotifier()->notifyCaptivePortalBlock();
+  }
+}
+void CaptivePortalDetection::captivePortalPossible() {
+  logger.log() << "Captive portal possible!";
+
+  // Quick return in case this method is called by the inspector even when the
+  // feature is disabled.
+  if (!m_active) {
+    return;
+  }
+
+  if (MozillaVPN::instance()->controller()->state() == Controller::StateOn) {
+    captivePortalNotifier()->notifyCaptivePortalPossible();
   }
 }
 

--- a/src/captiveportal/captiveportaldetection.h
+++ b/src/captiveportal/captiveportaldetection.h
@@ -6,6 +6,7 @@
 #define CAPTIVEPORTALDETECTION_H
 
 #include <QObject>
+#include "captiveportalrequest.h"
 
 class CaptivePortalDetectionImpl;
 class CaptivePortalMonitor;
@@ -24,11 +25,12 @@ class CaptivePortalDetection final : public QObject {
   // Methods exposed for the inspector.
   void detectCaptivePortal();
   void captivePortalDetected();
+  void captivePortalPossible();
 
  public slots:
   void stateChanged();
   void settingsChanged();
-  void detectionCompleted(bool detected);
+  void detectionCompleted(CaptivePortalRequest::CaptivePortalResult detected);
   void captivePortalGone();
 
   void activationRequired();

--- a/src/captiveportal/captiveportaldetectionimpl.cpp
+++ b/src/captiveportal/captiveportaldetectionimpl.cpp
@@ -23,10 +23,11 @@ void CaptivePortalDetectionImpl::start() {
   logger.log() << "Captive portal detection started";
 
   CaptivePortalRequest* request = new CaptivePortalRequest(this);
-  connect(request, &CaptivePortalRequest::completed, [this](bool detected) {
-    logger.log() << "Captive portal detection:" << detected;
-    emit detectionCompleted(detected);
-  });
+  connect(request, &CaptivePortalRequest::completed,
+          [this](CaptivePortalRequest::CaptivePortalResult detected) {
+            logger.log() << "Captive portal detection:" << detected;
+            emit detectionCompleted(detected);
+          });
 
   request->run();
 }

--- a/src/captiveportal/captiveportaldetectionimpl.h
+++ b/src/captiveportal/captiveportaldetectionimpl.h
@@ -6,6 +6,7 @@
 #define CAPTIVEPORTALDETECTIONIMPL_H
 
 #include <QObject>
+#include "captiveportalrequest.h"
 
 class CaptivePortalDetectionImpl : public QObject {
   Q_OBJECT
@@ -17,7 +18,8 @@ class CaptivePortalDetectionImpl : public QObject {
   virtual void start();
 
  signals:
-  void detectionCompleted(bool captivePortalDetected);
+  void detectionCompleted(
+      CaptivePortalRequest::CaptivePortalResult captivePortalDetected);
 };
 
 #endif  // CAPTIVEPORTALDETECTIONIMPL_H

--- a/src/captiveportal/captiveportalnotifier.cpp
+++ b/src/captiveportal/captiveportalnotifier.cpp
@@ -29,6 +29,10 @@ void CaptivePortalNotifier::notifyCaptivePortalBlock() {
   logger.log() << "Captive portal block notify";
   SystemTrayHandler::instance()->captivePortalBlockNotificationRequired();
 }
+void CaptivePortalNotifier::notifyCaptivePortalPossible() {
+  logger.log() << "Captive portal possible notify";
+  SystemTrayHandler::instance()->captivePortalPossibleNotificationRequired();
+}
 
 void CaptivePortalNotifier::notifyCaptivePortalUnblock() {
   logger.log() << "Captive portal unblock notify";

--- a/src/captiveportal/captiveportalnotifier.h
+++ b/src/captiveportal/captiveportalnotifier.h
@@ -17,6 +17,7 @@ class CaptivePortalNotifier final : public QObject {
   ~CaptivePortalNotifier();
 
   void notifyCaptivePortalBlock();
+  void notifyCaptivePortalPossible();
   void notifyCaptivePortalUnblock();
 
  signals:

--- a/src/captiveportal/captiveportalrequest.h
+++ b/src/captiveportal/captiveportalrequest.h
@@ -7,6 +7,7 @@
 
 #include <QObject>
 #include <QUrl>
+#include <QQueue>
 
 class CaptivePortalRequest final : public QObject {
   Q_OBJECT
@@ -18,16 +19,19 @@ class CaptivePortalRequest final : public QObject {
 
   void run();
 
+  enum CaptivePortalResult { NoPortal, PortalPossible, PortalDetected };
+
  signals:
-  void completed(bool detected);
+  void completed(CaptivePortalResult detected);
 
  private:
   void createRequest(const QUrl& url);
-  void maybeComplete();
+  void nextStep();
+  void onResult(CaptivePortalResult portalDetected);
 
  private:
-  uint32_t m_pendingRequests = 0;
   bool m_completed = false;
+  QQueue<QUrl> m_requestQueue = QQueue<QUrl>();
 };
 
 #endif  // CAPTIVEPORTALREQUEST_H

--- a/src/networkrequest.cpp
+++ b/src/networkrequest.cpp
@@ -205,7 +205,7 @@ NetworkRequest* NetworkRequest::createForCaptivePortalDetection(
     QObject* parent, const QUrl& url, const QByteArray& host) {
   Q_ASSERT(parent);
 
-  NetworkRequest* r = new NetworkRequest(parent, 200);
+  NetworkRequest* r = new NetworkRequest(parent, 0);
 
   r->m_request.setUrl(url);
   r->m_request.setRawHeader("Host", host);

--- a/src/systemtrayhandler.cpp
+++ b/src/systemtrayhandler.cpp
@@ -219,6 +219,20 @@ void SystemTrayHandler::captivePortalBlockNotificationRequired() {
                            Constants::CAPTIVE_PORTAL_ALERT_MSEC);
 }
 
+void SystemTrayHandler::captivePortalPossibleNotificationRequired() {
+  logger.log() << "Captive portal possible notification shown";
+
+  //% "Guest Wi-Fi portal possible"
+  QString title = qtTrId("vpn.systray.captivePortalPossible.title");
+
+  //% "The guest Wi-Fi network you’re connected to might require action. Click
+  //here" % " to turn off VPN to see the portal."
+  QString message = qtTrId("vpn.systray.captivePortalPossible.message");
+
+  showNotificationInternal(CaptivePortalBlock, title, message,
+                           Constants::CAPTIVE_PORTAL_ALERT_MSEC);
+}
+
 void SystemTrayHandler::captivePortalUnblockNotificationRequired() {
   logger.log() << "Captive portal unblock notification shown";
 

--- a/src/systemtrayhandler.h
+++ b/src/systemtrayhandler.h
@@ -31,6 +31,7 @@ class SystemTrayHandler : public QSystemTrayIcon {
   virtual ~SystemTrayHandler();
 
   void captivePortalBlockNotificationRequired();
+  void captivePortalPossibleNotificationRequired();
   void captivePortalUnblockNotificationRequired();
 
   void unsecuredNetworkNotification(const QString& networkName);


### PR DESCRIPTION
Here is my idea for the retry: 
1: Put all captive portal requests in a queue. 
2: After a small delay, fire the first request in the queue
 2.2: If we get a result, we pass that on and exit. 
 2.3: On error, put it back in the queue and go to 2.

If we can't confirm that there is *no* portal in 30s e.g like my telecom hotspot that just blocks detectportal.firefox.com, show a notification that a portal might affect connectivity. 
