### PR TITLE
App permissions UI update

### DIFF
--- a/src/qml.qrc
+++ b/src/qml.qrc
@@ -407,5 +407,6 @@
         <file>ui/components/VPNWasmHeader.qml</file>
         <file>ui/views/ViewErrorFullScreen.qml</file>
         <file>ui/components/VPNControllerNav.qml</file>
+        <file>ui/components/VPNSettingsToggle.qml</file>
     </qresource>
 </RCC>

--- a/src/ui/components/VPNCheckBoxRow.qml
+++ b/src/ui/components/VPNCheckBoxRow.qml
@@ -17,9 +17,7 @@ RowLayout {
     property bool isChecked
     property bool isEnabled: true
     property bool showDivider: true
-    property var iconURL: ""
     property var leftMargin: 18
-    property var subLabelWrapMode: Text.WordWrap
 
     signal clicked()
     spacing: 0
@@ -32,17 +30,6 @@ RowLayout {
         checked: isChecked
         enabled: isEnabled
         opacity: isEnabled ? 1 : 0.5
-    }
-    Image {
-        source: iconURL
-        visible: iconURL != ""
-        sourceSize.width: labelWrapper.height
-        sourceSize.height: labelWrapper.height
-        Layout.leftMargin: 5
-        Layout.rightMargin: 18
-
-        asynchronous: true
-        fillMode:  Image.PreserveAspectFit
     }
 
     ColumnLayout {
@@ -66,7 +53,7 @@ RowLayout {
             Layout.fillWidth: true
             text: subLabelText
             visible: !!subLabelText.length
-            wrapMode: subLabelWrapMode
+            wrapMode: Text.WordWrap
         }
 
         Rectangle {

--- a/src/ui/components/VPNExpandableAppList.qml
+++ b/src/ui/components/VPNExpandableAppList.qml
@@ -52,7 +52,7 @@ ColumnLayout {
 
         ColumnLayout {
             id: appRowHeader
-            width: appRow.width
+            width: appRow.Layout.preferredWidth
             anchors.verticalCenter: parent.verticalCenter
             spacing: 0
             RowLayout {
@@ -66,8 +66,8 @@ ColumnLayout {
                 }
                 VPNIcon {
                     id: toggleArrow
-                    Layout.leftMargin: defaultMargin / 3
-                    Layout.rightMargin: defaultMargin - 4
+                    Layout.leftMargin: 6
+                    Layout.rightMargin: 14
                     Layout.alignment: Qt.AlignVCenter
 
                     source: "../resources/arrow-toggle.svg"

--- a/src/ui/components/VPNExpandableAppList.qml
+++ b/src/ui/components/VPNExpandableAppList.qml
@@ -44,7 +44,7 @@ ColumnLayout {
         Layout.preferredWidth: parent.width - Theme.windowMargin
         Layout.alignment: Qt.AlignHCenter
         Layout.minimumHeight: Theme.rowHeight * 1.5
-        enabled: vpnIsOff && applist.count > 0
+        enabled: vpnFlickable.vpnIsOff && applist.count > 0
         anchors.left: undefined
         anchors.right: undefined
         anchors.rightMargin: undefined
@@ -69,11 +69,9 @@ ColumnLayout {
                     Layout.leftMargin: 6
                     Layout.rightMargin: 14
                     Layout.alignment: Qt.AlignVCenter
-
                     source: "../resources/arrow-toggle.svg"
                     transformOrigin: Image.Center
                     smooth: true
-                    opacity: applist.count > 0 ?1:0;
                     rotation: isListVisible ? 0 :-90
                 }
 
@@ -155,7 +153,6 @@ ColumnLayout {
                   properties: "x,y"
                   duration: 200
               }
-
           }
           remove: Transition {
               PropertyAnimation {

--- a/src/ui/components/VPNExpandableAppList.qml
+++ b/src/ui/components/VPNExpandableAppList.qml
@@ -20,79 +20,111 @@ ColumnLayout{
     property var onAction: ()=>{}
     property var isEnabled: true
     property var isListVisible : true && applist.count > 0
-    opacity: isEnabled ? 1 : 0.5
     property var isActionEnabled: isEnabled && applist.count > 0
+    property var dividerVisible: false
+
+
+    opacity: isEnabled && applist.count > 0 ? 1 : 0.5
+    anchors.horizontalCenter: parent.horizontalCenter
+    width: parent.width
+    spacing: 0
 
     VPNClickableRow {
         id: appRow
         Keys.onReleased: if (event.key === Qt.Key_Space) handleKeyClick()
         handleMouseClick: function() { isListVisible = !isListVisible && applist.count > 0; }
         handleKeyClick: function() { isListVisible = !isListVisible && applist.count > 0; }
-        clip: true
         canGrowVertical: true
-        accessibleName: name
-        Layout.preferredWidth: parent.width - Theme.windowMargin
-        height: appRowHeader.height
-        Layout.preferredHeight: Theme.rowHeight * 1.5
-
-
-        RowLayout {
+//        accessibleName: name
+        Layout.fillWidth: true
+        Layout.minimumHeight: Theme.rowHeight * 1.5
+        enabled: vpnIsOff && applist.count > 0
+        ColumnLayout {
             id: appRowHeader
-            width: parent.width
-            anchors.centerIn: parent
+            width: appRow.width
+            anchors.verticalCenter: parent.verticalCenter
             spacing: 0
-
-            VPNIcon {
-                id: toggleArrow
-                Layout.leftMargin: defaultMargin / 2
-                Layout.rightMargin: defaultMargin - 5
-                source: "../resources/arrow-toggle.svg"
-                transformOrigin: Image.Center
-                smooth: true
-                opacity: applist.count > 0 ?1:0;
-                rotation: isListVisible ? 0 :-90
-            }
-            ColumnLayout {
-                Layout.alignment: Qt.AlignLeft
-                Layout.fillWidth: true
+            RowLayout {
                 spacing: 0
+                Layout.alignment: Qt.AlignLeft | Qt.AlignVCenter
+
+                Behavior on y {
+                    PropertyAnimation {
+                        duration: 100
+                    }
+                }
+
+                VPNIcon {
+                    id: toggleArrow
+                    Layout.leftMargin: defaultMargin / 3
+                    Layout.rightMargin: defaultMargin - 4
+                    Layout.alignment: Qt.AlignVCenter
+
+                    source: "../resources/arrow-toggle.svg"
+                    transformOrigin: Image.Center
+                    smooth: true
+                    opacity: applist.count > 0 ?1:0;
+                    rotation: isListVisible ? 0 :-90
+                }
 
                 RowLayout {
                     Layout.alignment: Qt.AlignLeft
-                    Layout.fillWidth: true
+                    spacing: 0
 
-                    VPNInterLabel {
+                    VPNBoldLabel {
                         id: label
                         text: header
                         Accessible.role: Accessible.Heading
                         color: Theme.fontColorDark
                         horizontalAlignment: Text.AlignLeft
+                        Layout.alignment: Qt.AlignLeft | Qt.AlignVCenter
                     }
 
                     VPNTextBlock{
-                        visible: !isListVisible || !isEnabled
+//                        visible: !isListVisible || !isEnabled
                         text: " (%0)".arg(applist.count)
+                        verticalAlignment: Text.AlignVCenter
+                        horizontalAlignment: Text.AlignLeft
+                        Layout.alignment: Qt.AlignLeft
+                        Layout.fillWidth: true
                     }
                 }
 
-                VPNTextBlock {
-                    id: enabledAppSubtext
-                    text: description // "These apps will (not) use vpn.."
-                    Layout.fillWidth: true
-                }
             }
-            VPNLinkButton{
-                Layout.alignment: Qt.AlignRight
-                // (Un)protect-All Button
-                labelText: actionText
-                onClicked: {
-                    onAction();
-                    isListVisible=false
-                }
-                enabled: isActionEnabled
-                opacity: isActionEnabled ? 1 : 0
+
+            VPNVerticalSpacer {
+                Layout.preferredHeight: 2
+                visible: isListVisible
             }
+
+            VPNTextBlock {
+                id: enabledAppSubtext
+                text: description // "These apps will (not) use vpn.."
+                Layout.fillWidth: true
+                Layout.maximumWidth: parent.width
+                width: undefined
+                visible: isListVisible
+                Layout.leftMargin: 44
+                wrapMode: Text.Wrap
+            }
+
         }
+    }
+
+    VPNLinkButton{
+        Layout.alignment: Qt.AlignRight
+        fontSize: Theme.fontSizeSmall
+
+//        buttonPadding: 0
+        // (Un)protect-All Button
+        labelText: actionText
+        onClicked: {
+            onAction();
+            isListVisible=false
+        }
+        enabled: isActionEnabled
+        opacity: isActionEnabled ? 1 : 0
+        visible: isListVisible
     }
 
     VPNList {
@@ -103,24 +135,74 @@ ColumnLayout{
         listName: header
 
         Layout.preferredHeight: contentItem.childrenRect.height
-        Layout.topMargin: defaultMargin
+        Layout.topMargin: 4
 
-        visible: isListVisible
+        visible: isListVisible && count  > 0
 
-        delegate: VPNCheckBoxRow {
-            labelText: appName
-            subLabelText: appID
-            isChecked: appIsEnabled
-            isEnabled: appListContainer.isEnabled
-            showDivider:false
-            onClicked: VPNAppPermissions.flip(appID)
-            visible: true
-            width: parent.width
-            anchors.left: parent.left
-            anchors.topMargin: defaultMargin
-            leftMargin:defaultMargin
-            iconURL: "image://app/"+appID
-            subLabelWrapMode: Text.NoWrap
+        delegate: RowLayout {
+            width: parent.width - Theme.windowMargin
+            anchors.rightMargin: 0
+            anchors.right: parent.right
+            spacing: Theme.windowMargin
+
+            Image {
+                //iconURL: "image://app/"+appID
+                source: "../resources/update-lock.svg"
+                visible: iconURL != ""
+                sourceSize.width:16
+                sourceSize.height: 6
+                Layout.alignment: Qt.AlignTop
+                Layout.leftMargin: 36
+                Layout.topMargin: 6
+                asynchronous: true
+                fillMode:  Image.PreserveAspectFit
+            }
+
+            ColumnLayout {
+                id: labelWrapper
+                Layout.alignment: Qt.AlignTop
+
+                spacing: 4
+
+                VPNInterLabel {
+                    Layout.alignment: Qt.AlignLeft | Qt.AlignTop
+                    Layout.fillWidth: true
+                    text: appName
+                    color: Theme.fontColorDark
+                    horizontalAlignment: Text.AlignLeft
+                }
+
+                VPNTextBlock {
+                    id: subLabel
+
+                    Layout.fillWidth: true
+                    text: appID
+                    visible: !!text.length
+                    wrapMode: subLabelWrapMode
+                }
+
+            }
+
+            VPNCheckBox {
+               Layout.alignment: Qt.AlignTop
+               Layout.topMargin: 6
+               onClicked: VPNAppPermissions.flip(appID)
+               checked: appIsEnabled
+               Layout.rightMargin: 4
+            }
         }
     }
+    VPNVerticalSpacer {
+        Layout.preferredHeight: Theme.windowMargin * 3
+        Layout.fillWidth: true
+        visible: dividerVisible && isListVisible && applist.count > 0
+        Rectangle {
+            height: 1
+            width: parent.width - Theme.windowMargin * 2
+            color: "#e7e7e7"
+            visible: isListVisible && applist.count > 0
+            anchors.centerIn: parent
+        }
+    }
+
 }

--- a/src/ui/components/VPNExpandableAppList.qml
+++ b/src/ui/components/VPNExpandableAppList.qml
@@ -10,7 +10,7 @@ import QtGraphicalEffects 1.14
 import Mozilla.VPN 1.0
 import "../themes/themes.js" as Theme
 
-ColumnLayout{
+ColumnLayout {
     id: appListContainer
 
     property var listModel: undefined
@@ -23,11 +23,16 @@ ColumnLayout{
     property var isActionEnabled: isEnabled && applist.count > 0
     property var dividerVisible: false
 
-
     opacity: isEnabled && applist.count > 0 ? 1 : 0.5
     anchors.horizontalCenter: parent.horizontalCenter
     width: parent.width
     spacing: 0
+
+    Behavior on y {
+        PropertyAnimation {
+            duration: 200
+        }
+    }
 
     VPNClickableRow {
         id: appRow
@@ -35,10 +40,16 @@ ColumnLayout{
         handleMouseClick: function() { isListVisible = !isListVisible && applist.count > 0; }
         handleKeyClick: function() { isListVisible = !isListVisible && applist.count > 0; }
         canGrowVertical: true
-//        accessibleName: name
-        Layout.fillWidth: true
+        accessibleName: description
+        Layout.preferredWidth: parent.width - Theme.windowMargin
+        Layout.alignment: Qt.AlignHCenter
         Layout.minimumHeight: Theme.rowHeight * 1.5
         enabled: vpnIsOff && applist.count > 0
+        anchors.left: undefined
+        anchors.right: undefined
+        anchors.rightMargin: undefined
+        anchors.leftMargin: undefined
+
         ColumnLayout {
             id: appRowHeader
             width: appRow.width
@@ -53,7 +64,6 @@ ColumnLayout{
                         duration: 100
                     }
                 }
-
                 VPNIcon {
                     id: toggleArrow
                     Layout.leftMargin: defaultMargin / 3
@@ -81,7 +91,6 @@ ColumnLayout{
                     }
 
                     VPNTextBlock{
-//                        visible: !isListVisible || !isEnabled
                         text: " (%0)".arg(applist.count)
                         verticalAlignment: Text.AlignVCenter
                         horizontalAlignment: Text.AlignLeft
@@ -89,7 +98,6 @@ ColumnLayout{
                         Layout.fillWidth: true
                     }
                 }
-
             }
 
             VPNVerticalSpacer {
@@ -115,7 +123,6 @@ ColumnLayout{
         Layout.alignment: Qt.AlignRight
         fontSize: Theme.fontSizeSmall
 
-//        buttonPadding: 0
         // (Un)protect-All Button
         labelText: actionText
         onClicked: {
@@ -139,6 +146,39 @@ ColumnLayout{
 
         visible: isListVisible && count  > 0
 
+        PropertyAnimation on opacity {
+            duration: 200
+        }
+
+        removeDisplaced: Transition {
+              NumberAnimation {
+                  properties: "x,y"
+                  duration: 200
+              }
+
+          }
+          remove: Transition {
+              PropertyAnimation {
+                  property: "opacity"
+                  from: 1
+                  to: 0
+                  duration: 200
+              }
+          }
+        addDisplaced: Transition {
+            NumberAnimation {
+                properties: "x,y"
+                duration: 200
+            }
+        }
+        add: Transition {
+            PropertyAnimation {
+                property: "opacity"
+                from: 0
+                to: 1
+                duration: 200
+            }
+        }
         delegate: RowLayout {
             width: parent.width - Theme.windowMargin
             anchors.rightMargin: 0
@@ -146,14 +186,13 @@ ColumnLayout{
             spacing: Theme.windowMargin
 
             Image {
-                //iconURL: "image://app/"+appID
-                source: "../resources/update-lock.svg"
-                visible: iconURL != ""
-                sourceSize.width:16
+                source: "image://app/"+appID
+                visible: appID !== ""
+                sourceSize.width: Theme.windowMargin
                 sourceSize.height: 6
                 Layout.alignment: Qt.AlignTop
                 Layout.leftMargin: 36
-                Layout.topMargin: 6
+                Layout.topMargin: 4
                 asynchronous: true
                 fillMode:  Image.PreserveAspectFit
             }
@@ -161,7 +200,6 @@ ColumnLayout{
             ColumnLayout {
                 id: labelWrapper
                 Layout.alignment: Qt.AlignTop
-
                 spacing: 4
 
                 VPNInterLabel {
@@ -173,12 +211,9 @@ ColumnLayout{
                 }
 
                 VPNTextBlock {
-                    id: subLabel
-
                     Layout.fillWidth: true
                     text: appID
                     visible: !!text.length
-                    wrapMode: subLabelWrapMode
                 }
 
             }

--- a/src/ui/components/VPNSettingsToggle.qml
+++ b/src/ui/components/VPNSettingsToggle.qml
@@ -15,6 +15,8 @@ CheckBox {
     property alias forceFocus: vpnSettingsToggle.focus
     property var toolTipTitle
 
+    onClicked: toolTip.hide()
+
     height: 24
     width: 45
     states: [
@@ -50,6 +52,7 @@ CheckBox {
     ]
 
     VPNToolTip {
+        id: toolTip
         text: toolTipTitle
     }
 

--- a/src/ui/components/VPNSettingsToggle.qml
+++ b/src/ui/components/VPNSettingsToggle.qml
@@ -1,0 +1,168 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import QtQuick 2.0
+import QtQuick.Controls 2.5
+import Mozilla.VPN 1.0
+import "../themes/themes.js" as Theme
+
+CheckBox {
+    id: vpnSettingsToggle
+
+    property var toggleColor: Theme.vpnToggleConnected
+    property var uiState: Theme.uiState
+    property alias forceFocus: vpnSettingsToggle.focus
+    property var toolTipTitle
+
+    height: 24
+    width: 45
+    states: [
+        State {
+            when: checked
+
+            PropertyChanges {
+                target: vpnSettingsToggle
+                toggleColor: Theme.vpnToggleConnected
+            }
+
+            PropertyChanges {
+                target: cursor
+                x: 24
+            }
+
+        },
+
+        State {
+            when: !checked
+
+            PropertyChanges {
+                target: vpnSettingsToggle
+                toggleColor: Theme.vpnToggleDisconnected
+
+            }
+
+            PropertyChanges {
+                target: cursor
+                x: 3
+            }
+        }
+    ]
+
+    VPNToolTip {
+        text: toolTipTitle
+    }
+
+
+    transitions: [
+        Transition {
+            NumberAnimation {
+                target: cursor
+                property: "x"
+                duration: 200
+            }
+        }
+    ]
+
+    VPNFocusBorder {
+        id: focusHandler
+
+        anchors.fill: hoverPressHandler
+        border.color: toggleColor.focusBorder
+        color: "transparent"
+        anchors.margins: -1
+        radius: 50
+        opacity: vpnSettingsToggle.activeFocus ? 1: 0
+    }
+
+    Rectangle {
+        id: cursor
+
+        height: 18
+        width: 18
+        radius: 9
+        color: Theme.white
+        z: 1
+        anchors.verticalCenter: vpnSettingsToggle.verticalCenter
+    }
+
+    VPNMouseArea {
+        id: mouseArea
+
+        anchors.fill: hoverPressHandler
+        targetEl: uiPlaceholder
+    }
+
+    Rectangle {
+        id: hoverPressHandler
+
+        color: "#C2C2C2"
+        opacity: 0
+        z: -1
+        anchors.fill: uiPlaceholder
+        radius: height / 2
+        anchors.margins: -4
+        state: uiPlaceholder.state
+        states: [
+            State {
+                name: uiState.stateHovered
+                PropertyChanges {
+                    target: hoverPressHandler
+                    opacity: 0.2;
+
+                }
+            },
+            State {
+                name: uiState.statePressed
+                PropertyChanges {
+                    target: hoverPressHandler
+                    opacity: .3
+                }
+            }
+        ]
+
+        transitions: [
+            Transition {
+                PropertyAnimation {
+                    target: hoverPressHandler
+                    property: "opacity"
+                    duration: 200
+                }
+            }
+
+        ]
+    }
+
+    focusPolicy: Qt.StrongFocus
+
+    function handleKeyClick() {
+        vpnSettingsToggle.clicked()
+    }
+
+    Keys.onReleased: {
+        if (event.key === Qt.Key_Return)
+            handleKeyClick();
+            uiPlaceholder.state = uiState.stateDefault;
+    }
+
+    Keys.onPressed: {
+        if (event.key === Qt.Key_Return || event.key === Qt.Key_Space)
+            uiPlaceholder.state = uiState.statePressed;
+    }
+
+    Rectangle {
+        id: uiPlaceholder /* Binding loop hack-around */
+        height: 24
+        width: 45
+        color: "transparent"
+    }
+
+    indicator:  VPNUIStates {
+        id: toggleBackground
+        itemToFocus: vpnSettingsToggle
+        itemToAnchor: uiPlaceholder
+        colorScheme: toggleColor
+        radius: height / 2
+        showFocusRings: false
+    }
+}

--- a/src/ui/settings/ViewAppPermissions.qml
+++ b/src/ui/settings/ViewAppPermissions.qml
@@ -10,164 +10,172 @@ import Mozilla.VPN 1.0
 import "../components"
 import "../themes/themes.js" as Theme
 
-VPNFlickable {
-    id: vpnFlickable
-    readonly property int defaultMargin: 18
-    property bool vpnIsOff: (VPNController.state === VPNController.StateOff)
-    flickContentHeight: menu.height + enableAppList.height + enableAppList.anchors.topMargin + (vpnOnAlert.visible ? vpnOnAlert.height : 0) + (disabledList.visible? (disabledList.height+disabledList.anchors.topMargin):0)+(enabledList.visible? (enabledList.height + enabledList.anchors.topMargin):0)+20
-
-    Component.onCompleted: {
-       VPNAppPermissions.requestApplist();
-    }
-
+Item {
+    id: root
+    anchors.fill: parent
     VPNMenu {
         id: menu
         title: qsTrId("vpn.settings.appPermissions")
         isSettingsView: true
     }
 
-    VPNDropShadow {
-        anchors.fill: rect
-        source: rect
-        z: -2
-    }
-
-    Rectangle {
-        id: rect
-        anchors.fill: enableAppList
-        anchors.topMargin: -12
-        anchors.bottomMargin: anchors.topMargin
-        anchors.leftMargin: -Theme.windowMargin
-        anchors.rightMargin: anchors.leftMargin
-        color: Theme.white
-        radius: 4
-    }
-
-    RowLayout {
-        id: enableAppList
+    VPNFlickable {
+        id: vpnFlickable
+        readonly property int defaultMargin: 18
+        property bool vpnIsOff: (VPNController.state === VPNController.StateOff)
+        flickContentHeight: enableAppList.height + enableAppList.anchors.topMargin + (vpnOnAlert.visible ? vpnOnAlert.height : 0) + (disabledList.visible ? disabledList.height : 0) + (enabledList.visible ? enabledList.height : 0) + 60
         anchors.top: menu.bottom
-        anchors.topMargin: Theme.windowMargin * 1.5
-        anchors.horizontalCenter: parent.horizontalCenter
-        width: vpnFlickable.width - Theme.windowMargin * 3.5
-        spacing: Theme.windowMargin
-
-        ColumnLayout {
-            Layout.fillWidth: true
-            VPNInterLabel {
-                Layout.alignment: Qt.AlignLeft
-                Layout.fillWidth: true
-                //% "Protect specific apps"
-                text: qsTrId("vpn.settings.protectSelectedApps")
-                color: Theme.fontColorDark
-                horizontalAlignment: Text.AlignLeft
-            }
-
-            VPNTextBlock {
-                Layout.fillWidth: true
-                //% "Choose which apps should use the VPN"
-                text: qsTrId("vpn.settings.protectSelectedApps.description")
-                visible: !!text.length
-            }
+        height: root.height - menu.height
+        width: root.width
+        Component.onCompleted: {
+           VPNAppPermissions.requestApplist();
         }
 
-        VPNSettingsToggle {
-            Layout.preferredHeight: 24
-            Layout.preferredWidth: 45
-            checked: (VPNSettings.protectSelectedApps)
-            enabled: vpnFlickable.vpnIsOff
-            toolTipTitle: qsTrId("vpn.settings.protectSelectedApps")
-            onClicked: {
-                if (vpnFlickable.vpnIsOff) {
-                    VPNSettings.protectSelectedApps = !VPNSettings.protectSelectedApps
+        VPNDropShadow {
+            anchors.fill: rect
+            source: rect
+            z: -2
+        }
+
+        Rectangle {
+            id: rect
+            anchors.fill: enableAppList
+            anchors.topMargin: -12
+            anchors.bottomMargin: anchors.topMargin
+            anchors.leftMargin: -Theme.windowMargin
+            anchors.rightMargin: anchors.leftMargin
+            color: Theme.white
+            radius: 4
+        }
+
+        RowLayout {
+            id: enableAppList
+            anchors.top: parent.top
+            anchors.topMargin: Theme.windowMargin * 1.5
+            anchors.horizontalCenter: parent.horizontalCenter
+            width: vpnFlickable.width - Theme.windowMargin * 3.5
+            spacing: Theme.windowMargin
+
+            ColumnLayout {
+                Layout.fillWidth: true
+                VPNInterLabel {
+                    Layout.alignment: Qt.AlignLeft
+                    Layout.fillWidth: true
+                    //% "Protect specific apps"
+                    text: qsTrId("vpn.settings.protectSelectedApps")
+                    color: Theme.fontColorDark
+                    horizontalAlignment: Text.AlignLeft
+                }
+
+                VPNTextBlock {
+                    Layout.fillWidth: true
+                    //% "Choose which apps should use the VPN"
+                    text: qsTrId("vpn.settings.protectSelectedApps.description")
+                    visible: !!text.length
+                }
+            }
+
+            VPNSettingsToggle {
+                Layout.preferredHeight: 24
+                Layout.preferredWidth: 45
+                checked: (VPNSettings.protectSelectedApps)
+                enabled: vpnFlickable.vpnIsOff
+                toolTipTitle: qsTrId("vpn.settings.protectSelectedApps")
+                onClicked: {
+                    if (vpnFlickable.vpnIsOff) {
+                        VPNSettings.protectSelectedApps = !VPNSettings.protectSelectedApps
+                    }
                 }
             }
         }
-    }
 
-    VPNCheckBoxAlert {
-        id: vpnOnAlert
+        VPNCheckBoxAlert {
+            id: vpnOnAlert
 
-        anchors.top: enableAppList.bottom
-        anchors.topMargin: Theme.windowMargin * 2
-        visible: !vpnFlickable.vpnIsOff
-        anchors.leftMargin: Theme.windowMargin
-        width: enableAppList.width
-        //% "VPN must be off to edit App Permissions"
-        //: Associated to a group of settings that require the VPN to be disconnected to change
-        errorMessage: qsTrId("vpn.settings.protectSelectedApps.vpnMustBeOff")
-    }
+            anchors.top: enableAppList.bottom
+            anchors.topMargin: Theme.windowMargin * 2
+            visible: !vpnFlickable.vpnIsOff
+            anchors.leftMargin: Theme.windowMargin
+            width: enableAppList.width
+            //% "VPN must be off to edit App Permissions"
+            //: Associated to a group of settings that require the VPN to be disconnected to change
+            errorMessage: qsTrId("vpn.settings.protectSelectedApps.vpnMustBeOff")
+        }
 
-    RowLayout {
-        id: allAppsProtectedHint
+        RowLayout {
+            id: allAppsProtectedHint
 
-        anchors.top: enableAppList.bottom
-        anchors.topMargin: Theme.windowMargin * 2
-        anchors.horizontalCenter: parent.horizontalCenter
-        visible: !VPNSettings.protectSelectedApps && vpnFlickable.vpnIsOff
+            anchors.top: enableAppList.bottom
+            anchors.topMargin: Theme.windowMargin * 2
+            anchors.horizontalCenter: parent.horizontalCenter
+            visible: !VPNSettings.protectSelectedApps && vpnFlickable.vpnIsOff
 
-        Rectangle {
-            color: "transparent"
-            Layout.maximumHeight: infoMessage.lineHeight
-            Layout.preferredWidth: 14
-            Layout.rightMargin: 8
-            Layout.alignment: Qt.AlignTop
-            VPNIcon {
-                id: warningIcon
+            Rectangle {
+                color: "transparent"
+                Layout.maximumHeight: infoMessage.lineHeight
+                Layout.preferredWidth: 14
+                Layout.rightMargin: 8
+                Layout.alignment: Qt.AlignTop
+                VPNIcon {
+                    id: warningIcon
 
-                source: "../resources/connection-info.svg"
-                sourceSize.height: 14
-                sourceSize.width: 14
+                    source: "../resources/connection-info.svg"
+                    sourceSize.height: 14
+                    sourceSize.width: 14
+                    Layout.alignment: Qt.AlignVCenter
+                }
+            }
+
+            VPNTextBlock {
+                id: infoMessage
+                //% "VPN protects all apps by default"
+                text: qsTrId("vpn.settings.protectSelectedApps.allAppsProtected")
+                Layout.fillWidth: true
                 Layout.alignment: Qt.AlignVCenter
+                verticalAlignment: Text.AlignTop
             }
         }
 
-        VPNTextBlock {
-            id: infoMessage
-            //% "VPN protects all apps by default"
-            text: qsTrId("vpn.settings.protectSelectedApps.allAppsProtected")
-            Layout.fillWidth: true
-            Layout.alignment: Qt.AlignVCenter
-            verticalAlignment: Text.AlignTop
+        VPNExpandableAppList{
+            id: enabledList
+            visible: VPNSettings.protectSelectedApps
+            anchors.topMargin: 28
+            anchors.top: vpnOnAlert.visible ? vpnOnAlert.bottom : enableAppList.bottom
+
+            //% "Protected"
+            //: Header for the list of apps protected by VPN
+            header: qsTrId("vpn.settings.protected")
+            //% "These apps will use the VPN"
+            //: Description for the list of apps protected by VPN
+            description: qsTrId("vpn.settings.protected.description")
+            listModel: VPNAppPermissions.enabledApps
+            onAction: ()=>{VPNAppPermissions.unprotectAll()}
+            //% "Unprotect All"
+            //: Label for the button to remove protection from all apps
+            //: currently protected.
+            actionText: qsTrId("vpn.settings.unprotectall")
+            dividerVisible: true
+        }
+
+        VPNExpandableAppList{
+            id: disabledList
+
+            anchors.top: enabledList.bottom
+            visible: VPNSettings.protectSelectedApps
+            //% "Unprotected"
+            //: Header for the list of apps not protected by VPN
+            header: qsTrId("vpn.settings.unprotected")
+            //% "These apps will not use the VPN"
+            //: Description for the list of apps not protected by VPN
+            description: qsTrId("vpn.settings.unprotected.description")
+            listModel: VPNAppPermissions.disabledApps
+            onAction: ()=>{VPNAppPermissions.protectAll()}
+            //% "Protect All"
+            //: Label for the button to add protection to all apps
+            //: currently unprotected.
+            actionText: qsTrId("vpn.settings.protectall")
         }
     }
 
-    VPNExpandableAppList{
-        id: enabledList
-        visible: VPNSettings.protectSelectedApps
-        anchors.topMargin: 28
-        anchors.top: vpnOnAlert.visible ? vpnOnAlert.bottom : enableAppList.bottom
-
-        //% "Protected"
-        //: Header for the list of apps protected by VPN
-        header: qsTrId("vpn.settings.protected")
-        //% "These apps will use the VPN"
-        //: Description for the list of apps protected by VPN
-        description: qsTrId("vpn.settings.protected.description")
-        listModel: VPNAppPermissions.enabledApps
-        onAction: ()=>{VPNAppPermissions.unprotectAll()}
-        //% "Unprotect All"
-        //: Label for the button to remove protection from all apps
-        //: currently protected.
-        actionText: qsTrId("vpn.settings.unprotectall")
-        dividerVisible: true
-    }
-
-    VPNExpandableAppList{
-        id: disabledList
-
-        anchors.top: enabledList.bottom
-        visible: VPNSettings.protectSelectedApps
-        //% "Unprotected"
-        //: Header for the list of apps not protected by VPN
-        header: qsTrId("vpn.settings.unprotected")
-        //% "These apps will not use the VPN"
-        //: Description for the list of apps not protected by VPN
-        description: qsTrId("vpn.settings.unprotected.description")
-        listModel: VPNAppPermissions.disabledApps
-        onAction: ()=>{VPNAppPermissions.protectAll()}
-        //% "Protect All"
-        //: Label for the button to add protection to all apps
-        //: currently unprotected.
-        actionText: qsTrId("vpn.settings.protectall")
-    }
 }
+

--- a/src/ui/settings/ViewAppPermissions.qml
+++ b/src/ui/settings/ViewAppPermissions.qml
@@ -12,7 +12,7 @@ import "../themes/themes.js" as Theme
 
 Item {
     id: root
-    anchors.fill: parent
+
     VPNMenu {
         id: menu
         title: qsTrId("vpn.settings.appPermissions")
@@ -23,12 +23,25 @@ Item {
         id: vpnFlickable
         readonly property int defaultMargin: 18
         property bool vpnIsOff: (VPNController.state === VPNController.StateOff)
-        flickContentHeight: enableAppList.height + enableAppList.anchors.topMargin + (vpnOnAlert.visible ? vpnOnAlert.height : 0) + (disabledList.visible ? disabledList.height : 0) + (enabledList.visible ? enabledList.height : 0) + 60
+        flickContentHeight: enableAppList.height + enableAppList.anchors.topMargin + (vpnOnAlert.visible ? vpnOnAlert.height : 0) + (disabledList.visible ? disabledList.height : 0) + (enabledList.visible ? enabledList.height : 0) + 100
         anchors.top: menu.bottom
         height: root.height - menu.height
         width: root.width
         Component.onCompleted: {
            VPNAppPermissions.requestApplist();
+        }
+
+        VPNCheckBoxAlert {
+            id: vpnOnAlert
+
+            anchors.top: parent.top
+            anchors.topMargin: Theme.windowMargin * 1
+            visible: !vpnFlickable.vpnIsOff
+            anchors.leftMargin: Theme.windowMargin
+            width: enableAppList.width
+            //% "VPN must be off to edit App Permissions"
+            //: Associated to a group of settings that require the VPN to be disconnected to change
+            errorMessage: qsTrId("vpn.settings.protectSelectedApps.vpnMustBeOff")
         }
 
         VPNDropShadow {
@@ -50,7 +63,7 @@ Item {
 
         RowLayout {
             id: enableAppList
-            anchors.top: parent.top
+            anchors.top: vpnOnAlert.visible ? vpnOnAlert.bottom : parent.top
             anchors.topMargin: Theme.windowMargin * 1.5
             anchors.horizontalCenter: parent.horizontalCenter
             width: vpnFlickable.width - Theme.windowMargin * 3.5
@@ -87,19 +100,6 @@ Item {
                     }
                 }
             }
-        }
-
-        VPNCheckBoxAlert {
-            id: vpnOnAlert
-
-            anchors.top: enableAppList.bottom
-            anchors.topMargin: Theme.windowMargin * 2
-            visible: !vpnFlickable.vpnIsOff
-            anchors.leftMargin: Theme.windowMargin
-            width: enableAppList.width
-            //% "VPN must be off to edit App Permissions"
-            //: Associated to a group of settings that require the VPN to be disconnected to change
-            errorMessage: qsTrId("vpn.settings.protectSelectedApps.vpnMustBeOff")
         }
 
         RowLayout {

--- a/src/ui/settings/ViewAppPermissions.qml
+++ b/src/ui/settings/ViewAppPermissions.qml
@@ -36,10 +36,10 @@ VPNFlickable {
         id: rect
         anchors.fill: enableAppList
         anchors.topMargin: -12
-        anchors.bottomMargin: -12
-        anchors.leftMargin: -16
-        anchors.rightMargin: -16
-        color: "#FFFFFF"
+        anchors.bottomMargin: anchors.topMargin
+        anchors.leftMargin: -Theme.windowMargin
+        anchors.rightMargin: anchors.leftMargin
+        color: Theme.white
         radius: 4
     }
 
@@ -49,11 +49,11 @@ VPNFlickable {
         anchors.topMargin: Theme.windowMargin * 1.5
         anchors.horizontalCenter: parent.horizontalCenter
         width: vpnFlickable.width - Theme.windowMargin * 3.5
+        spacing: Theme.windowMargin
 
         ColumnLayout {
             Layout.fillWidth: true
             VPNInterLabel {
-                id: label
                 Layout.alignment: Qt.AlignLeft
                 Layout.fillWidth: true
                 //% "Protect specific apps"
@@ -63,12 +63,10 @@ VPNFlickable {
             }
 
             VPNTextBlock {
-                id: subLabel
-
                 Layout.fillWidth: true
                 //% "Choose which apps should use the VPN"
                 text: qsTrId("vpn.settings.protectSelectedApps.description")
-                visible: !!subLabel.text.length
+                visible: !!text.length
             }
         }
 
@@ -77,7 +75,7 @@ VPNFlickable {
             Layout.preferredWidth: 45
             checked: (VPNSettings.protectSelectedApps)
             enabled: vpnFlickable.vpnIsOff
-            toolTipTitle: ""
+            toolTipTitle: qsTrId("vpn.settings.protectSelectedApps")
             onClicked: {
                 if (vpnFlickable.vpnIsOff) {
                     VPNSettings.protectSelectedApps = !VPNSettings.protectSelectedApps
@@ -88,26 +86,27 @@ VPNFlickable {
 
     VPNCheckBoxAlert {
         id: vpnOnAlert
-        anchors.top: enableAppList.bottom
-        visible: !vpnFlickable.vpnIsOff
 
+        anchors.top: enableAppList.bottom
+        anchors.topMargin: Theme.windowMargin * 2
+        visible: !vpnFlickable.vpnIsOff
+        anchors.leftMargin: Theme.windowMargin
+        width: enableAppList.width
         //% "VPN must be off to edit App Permissions"
         //: Associated to a group of settings that require the VPN to be disconnected to change
         errorMessage: qsTrId("vpn.settings.protectSelectedApps.vpnMustBeOff")
     }
 
-
     RowLayout {
         id: allAppsProtectedHint
-        anchors.top: enableAppList.bottom
-        anchors.topMargin: Theme.windowMargin *3
-        anchors.horizontalCenter: parent.horizontalCenter
 
+        anchors.top: enableAppList.bottom
+        anchors.topMargin: Theme.windowMargin * 2
+        anchors.horizontalCenter: parent.horizontalCenter
         visible: !VPNSettings.protectSelectedApps && vpnFlickable.vpnIsOff
 
         Rectangle {
             color: "transparent"
-            Layout.preferredHeight: infoMessage.lineHeight
             Layout.maximumHeight: infoMessage.lineHeight
             Layout.preferredWidth: 14
             Layout.rightMargin: 8
@@ -130,13 +129,12 @@ VPNFlickable {
             Layout.alignment: Qt.AlignVCenter
             verticalAlignment: Text.AlignTop
         }
-
     }
 
     VPNExpandableAppList{
         id: enabledList
         visible: VPNSettings.protectSelectedApps
-        anchors.topMargin: 36
+        anchors.topMargin: 28
         anchors.top: vpnOnAlert.visible ? vpnOnAlert.bottom : enableAppList.bottom
 
         //% "Protected"
@@ -159,7 +157,6 @@ VPNFlickable {
 
         anchors.top: enabledList.bottom
         visible: VPNSettings.protectSelectedApps
-
         //% "Unprotected"
         //: Header for the list of apps not protected by VPN
         header: qsTrId("vpn.settings.unprotected")

--- a/src/ui/settings/ViewAppPermissions.qml
+++ b/src/ui/settings/ViewAppPermissions.qml
@@ -107,7 +107,9 @@ Item {
 
             anchors.top: enableAppList.bottom
             anchors.topMargin: Theme.windowMargin * 2
-            anchors.horizontalCenter: parent.horizontalCenter
+
+            anchors.left: parent.left
+            anchors.leftMargin: 18
             visible: !VPNSettings.protectSelectedApps && vpnFlickable.vpnIsOff
 
             Rectangle {

--- a/src/ui/settings/ViewAppPermissions.qml
+++ b/src/ui/settings/ViewAppPermissions.qml
@@ -14,7 +14,6 @@ VPNFlickable {
     id: vpnFlickable
     readonly property int defaultMargin: 18
     property bool vpnIsOff: (VPNController.state === VPNController.StateOff)
-
     flickContentHeight: menu.height + enableAppList.height + enableAppList.anchors.topMargin + (vpnOnAlert.visible ? vpnOnAlert.height : 0) + (disabledList.visible? (disabledList.height+disabledList.anchors.topMargin):0)+(enabledList.visible? (enabledList.height + enabledList.anchors.topMargin):0)+20
 
     Component.onCompleted: {
@@ -27,23 +26,62 @@ VPNFlickable {
         isSettingsView: true
     }
 
-    VPNCheckBoxRow {
+    VPNDropShadow {
+        anchors.fill: rect
+        source: rect
+        z: -2
+    }
+
+    Rectangle {
+        id: rect
+        anchors.fill: enableAppList
+        anchors.topMargin: -12
+        anchors.bottomMargin: -12
+        anchors.leftMargin: -16
+        anchors.rightMargin: -16
+        color: "#FFFFFF"
+        radius: 4
+    }
+
+    RowLayout {
         id: enableAppList
-
         anchors.top: menu.bottom
-        anchors.topMargin: Theme.windowMargin
-        width: parent.width - Theme.windowMargin
+        anchors.topMargin: Theme.windowMargin * 1.5
+        anchors.horizontalCenter: parent.horizontalCenter
+        width: vpnFlickable.width - Theme.windowMargin * 3.5
 
-        //% "Protect specific apps"
-        labelText: qsTrId("vpn.settings.protectSelectedApps")
-        //% "Choose which apps should use the VPN"
-        subLabelText: qsTrId("vpn.settings.protectSelectedApps.description")
-        isChecked: (VPNSettings.protectSelectedApps)
-        isEnabled: vpnFlickable.vpnIsOff
-        showDivider: true
-        onClicked: {
-            if (vpnFlickable.vpnIsOff) {
-                VPNSettings.protectSelectedApps = !VPNSettings.protectSelectedApps
+        ColumnLayout {
+            Layout.fillWidth: true
+            VPNInterLabel {
+                id: label
+                Layout.alignment: Qt.AlignLeft
+                Layout.fillWidth: true
+                //% "Protect specific apps"
+                text: qsTrId("vpn.settings.protectSelectedApps")
+                color: Theme.fontColorDark
+                horizontalAlignment: Text.AlignLeft
+            }
+
+            VPNTextBlock {
+                id: subLabel
+
+                Layout.fillWidth: true
+                //% "Choose which apps should use the VPN"
+                text: qsTrId("vpn.settings.protectSelectedApps.description")
+                visible: !!subLabel.text.length
+            }
+        }
+
+        VPNSettingsToggle {
+            Layout.preferredHeight: 24
+            Layout.preferredWidth: 45
+            checked: (VPNSettings.protectSelectedApps)
+            enabled: vpnFlickable.vpnIsOff
+            toolTipTitle: ""
+            onClicked: {
+                if (vpnFlickable.vpnIsOff) {
+                    VPNSettings.protectSelectedApps = !VPNSettings.protectSelectedApps
+                }
             }
         }
     }
@@ -62,18 +100,17 @@ VPNFlickable {
     RowLayout {
         id: allAppsProtectedHint
         anchors.top: enableAppList.bottom
-        anchors.left: enableAppList.left
-        anchors.leftMargin: 15
-        anchors.topMargin: 15
-        width: parent.width - anchors.leftMargin - anchors.rightMargin
+        anchors.topMargin: Theme.windowMargin *3
+        anchors.horizontalCenter: parent.horizontalCenter
+
         visible: !VPNSettings.protectSelectedApps && vpnFlickable.vpnIsOff
+
         Rectangle {
             color: "transparent"
             Layout.preferredHeight: infoMessage.lineHeight
             Layout.maximumHeight: infoMessage.lineHeight
             Layout.preferredWidth: 14
-            Layout.rightMargin: 18
-            Layout.leftMargin: 4
+            Layout.rightMargin: 8
             Layout.alignment: Qt.AlignTop
             VPNIcon {
                 id: warningIcon
@@ -90,44 +127,17 @@ VPNFlickable {
             //% "VPN protects all apps by default"
             text: qsTrId("vpn.settings.protectSelectedApps.allAppsProtected")
             Layout.fillWidth: true
+            Layout.alignment: Qt.AlignVCenter
+            verticalAlignment: Text.AlignTop
         }
 
     }
 
     VPNExpandableAppList{
-        id: disabledList
-        anchors.topMargin: 20
-        anchors.top: vpnOnAlert.visible ? vpnOnAlert.bottom : enableAppList.bottom
-        anchors.leftMargin: 5
-        anchors.rightMargin: 5
-        width: vpnFlickable.width - 5 *2
-        visible: VPNSettings.protectSelectedApps
-        isEnabled: vpnIsOff
-
-        //% "Unprotected"
-        //: Header for the list of apps not protected by VPN
-        header: qsTrId("vpn.settings.unprotected")
-        //% "These apps will not use the VPN"
-        //: Description for the list of apps not protected by VPN
-        description: qsTrId("vpn.settings.unprotected.description")
-        listModel: VPNAppPermissions.disabledApps
-        onAction: ()=>{VPNAppPermissions.protectAll()}
-        //% "Protect All"
-        //: Label for the button to add protection to all apps
-        //: currently unprotected.
-        actionText: qsTrId("vpn.settings.protectall")
-    }
-
-
-    VPNExpandableAppList{
         id: enabledList
-        anchors.topMargin: 20
-        anchors.top: disabledList.bottom
-        anchors.leftMargin: 5
-        anchors.rightMargin: 5
-        width: vpnFlickable.width - 5 *2
         visible: VPNSettings.protectSelectedApps
-        isEnabled: vpnIsOff
+        anchors.topMargin: 36
+        anchors.top: vpnOnAlert.visible ? vpnOnAlert.bottom : enableAppList.bottom
 
         //% "Protected"
         //: Header for the list of apps protected by VPN
@@ -141,5 +151,26 @@ VPNFlickable {
         //: Label for the button to remove protection from all apps
         //: currently protected.
         actionText: qsTrId("vpn.settings.unprotectall")
+        dividerVisible: true
+    }
+
+    VPNExpandableAppList{
+        id: disabledList
+
+        anchors.top: enabledList.bottom
+        visible: VPNSettings.protectSelectedApps
+
+        //% "Unprotected"
+        //: Header for the list of apps not protected by VPN
+        header: qsTrId("vpn.settings.unprotected")
+        //% "These apps will not use the VPN"
+        //: Description for the list of apps not protected by VPN
+        description: qsTrId("vpn.settings.unprotected.description")
+        listModel: VPNAppPermissions.disabledApps
+        onAction: ()=>{VPNAppPermissions.protectAll()}
+        //% "Protect All"
+        //: Label for the button to add protection to all apps
+        //: currently unprotected.
+        actionText: qsTrId("vpn.settings.protectall")
     }
 }


### PR DESCRIPTION
- Adds and uses VPNSettingToggle instead of checkbox for "Protect selected apps" setting
- Fixes menu header to top of view to match other settings sub-pages
- Disables clicking/toggling of zero length lists
- Closes #682
- Moves 'VPN Must be off..." to top of view
- Adds list item transitions when items are removed or added to each list

<img width="361" alt="Screen Shot 2021-03-25 at 3 44 40 PM" src="https://user-images.githubusercontent.com/22355127/112542383-80236400-8d82-11eb-8d07-88111d15ff4a.png">
<img width="363" alt="Screen Shot 2021-03-25 at 3 44 23 PM" src="https://user-images.githubusercontent.com/22355127/112542400-831e5480-8d82-11eb-8f53-fd1bcf899e68.png">
<img width="362" alt="Screen Shot 2021-03-25 at 3 44 12 PM" src="https://user-images.githubusercontent.com/22355127/112542421-874a7200-8d82-11eb-872d-7d82534997fc.png">

<img width="365" alt="Screen Shot 2021-03-24 at 3 40 25 PM" src="https://user-images.githubusercontent.com/22355127/112383631-610dcf00-8cbb-11eb-9c94-2249dc90118c.png">

