### PR TITLE
Fix #751 - Disable settings button when device limit is reached

### DIFF
--- a/src/ui/components/VPNControllerView.qml
+++ b/src/ui/components/VPNControllerView.qml
@@ -494,6 +494,8 @@ Rectangle {
     VPNIconButton {
         id: settingsButton
         objectName: "settingsButton"
+        enabled: VPN.state !== VPN.StateDeviceLimit
+        opacity: VPN.state === VPN.StateDeviceLimit ? .5 : 1
 
         onClicked: stackview.push("../views/ViewSettings.qml", StackView.Immediate)
         anchors.top: parent.top


### PR DESCRIPTION
This disables the settings button and reduces its opacity when `VPN.state === VPN.StateDeviceLimit`.