### PR TITLE
 FVP-02 WP5: Harden android

### DIFF
--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -20,6 +20,7 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
     <supports-screens android:largeScreens="true" android:normalScreens="true" android:anyDensity="true" android:smallScreens="true" />
     <application
         android:hardwareAccelerated="true"
+        android:allowBackup="false"
         android:name="org.qtproject.qt5.android.bindings.QtApplication"
         android:label="Mozilla VPN"
         android:extractNativeLibs="true"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -50,6 +50,8 @@ dependencies {
     implementation 'androidx.core:core-ktx:1.1.0'
     implementation 'com.android.installreferrer:installreferrer:1.1'
     implementation 'com.wireguard.android:tunnel:1.0.20200927'
+    implementation "androidx.security:security-crypto:1.1.0-alpha03"
+    implementation "androidx.security:security-identity-credential:1.0.0-alpha02"
     coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:1.0.10"
 }
 
@@ -122,7 +124,7 @@ android {
 
     defaultConfig {
         resConfig "en"
-        minSdkVersion 21
+        minSdkVersion 24
         targetSdkVersion 30
         versionCode  System.getenv("VERSIONCODE").toInteger()
         versionName  System.getenv("SHORTVERSION")

--- a/android/src/org/mozilla/firefox/vpn/BootReceiver.kt
+++ b/android/src/org/mozilla/firefox/vpn/BootReceiver.kt
@@ -18,7 +18,7 @@ class BootReceiver : BroadcastReceiver() {
             Log.i(TAG, "This device does not support start on boot - exit")
             return
         }
-        val prefs = context.getSharedPreferences("org.mozilla.firefox.vpn.prefrences", Context.MODE_PRIVATE)
+        val prefs = Prefs.get(context)
         val startOnBoot = prefs.getBoolean("startOnBoot", false)
         if (!startOnBoot) {
             Log.i(TAG, "This device did not enable start on boot - exit")

--- a/android/src/org/mozilla/firefox/vpn/NotificationUtil.kt
+++ b/android/src/org/mozilla/firefox/vpn/NotificationUtil.kt
@@ -60,8 +60,7 @@ object NotificationUtil {
         val json = buffer?.let { String(it) }
         val content = JSONObject(json)
 
-        val prefs =
-            context.getSharedPreferences("org.mozilla.firefox.vpn.prefrences", Context.MODE_PRIVATE)
+        val prefs = Prefs.get(context)
         prefs.edit()
             .putString("fallbackNotificationHeader", content.getString("title"))
             .putString("fallbackNotificationMessage", content.getString("message"))
@@ -91,8 +90,7 @@ object NotificationUtil {
         }
         // In case we do not have gotten a message to show from the Frontend
         // try to populate the notification with a translated Fallback message
-        val prefs =
-            service.getSharedPreferences("org.mozilla.firefox.vpn.prefrences", Context.MODE_PRIVATE)
+        val prefs = Prefs.get(service)
         val message =
             "" + prefs.getString("fallbackNotificationMessage", "Running in the Background")
         val header = "" + prefs.getString("fallbackNotificationHeader", "Mozilla VPN")

--- a/android/src/org/mozilla/firefox/vpn/Prefs.kt
+++ b/android/src/org/mozilla/firefox/vpn/Prefs.kt
@@ -1,0 +1,35 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.firefox.vpn
+
+import android.content.Context
+import android.content.SharedPreferences
+import android.util.Log
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
+
+object Prefs {
+    // Opens and returns an instance of EncryptedSharedPreferences
+    fun get(context: Context): SharedPreferences {
+        try {
+            val mainKey = MasterKey.Builder(context.applicationContext)
+                .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+                .build()
+
+            val sharedPrefsFile = "com.mozilla.vpn.secure.prefs"
+            val sharedPreferences: SharedPreferences = EncryptedSharedPreferences.create(
+                context.applicationContext,
+                sharedPrefsFile,
+                mainKey,
+                EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+                EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+            )
+            return sharedPreferences
+        } catch (e: Exception) {
+            Log.e("Android-Prefs", "Getting Encryption Storage failed, plaintext fallback")
+            return context.getSharedPreferences("com.mozilla.vpn.prefrences", Context.MODE_PRIVATE)
+        }
+    }
+}

--- a/android/src/org/mozilla/firefox/vpn/VPNLogger.kt
+++ b/android/src/org/mozilla/firefox/vpn/VPNLogger.kt
@@ -5,6 +5,7 @@
 package org.mozilla.firefox.vpn
 
 import android.content.Context
+import org.mozilla.firefox.vpn.BuildConfig
 import java.io.File
 import java.time.LocalDateTime
 import android.util.Log as nativeLog
@@ -33,14 +34,17 @@ class Log {
         }
         fun i(tag: String, message: String) {
             instance?.write("[info] - ($tag) - $message")
+            if (!BuildConfig.DEBUG) { return; }
             nativeLog.i(tag, message)
         }
         fun v(tag: String, message: String) {
             instance?.write("($tag) - $message")
+            if (!BuildConfig.DEBUG) { return; }
             nativeLog.v(tag, message)
         }
         fun e(tag: String, message: String) {
             instance?.write("[error] - ($tag) - $message")
+            if (!BuildConfig.DEBUG) { return; }
             nativeLog.e(tag, message)
         }
 

--- a/android/src/org/mozilla/firefox/vpn/VPNService.kt
+++ b/android/src/org/mozilla/firefox/vpn/VPNService.kt
@@ -63,7 +63,7 @@ class VPNService : android.net.VpnService() {
 
         if (this.mConfig == null) {
             // We don't have tunnel to turn on - Try to create one with last config the service got
-            val prefs = getSharedPreferences("org.mozilla.firefox.vpn.prefrences", Context.MODE_PRIVATE)
+            val prefs = Prefs.get(this)
             val lastConfString = prefs.getString("lastConf", "")
             if (lastConfString.isNullOrEmpty()) {
                 // We have nothing to connect to -> Exit

--- a/android/src/org/mozilla/firefox/vpn/VPNServiceBinder.kt
+++ b/android/src/org/mozilla/firefox/vpn/VPNServiceBinder.kt
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.firefox.vpn
-import android.content.Context
 import android.os.Binder
 import android.os.DeadObjectException
 import android.os.IBinder
@@ -57,9 +56,7 @@ class VPNServiceBinder(service: VPNService) : Binder() {
                     val json = buffer?.let { String(it) }
                     // Store the config in case the service gets
                     // asked boot vpn from the OS
-                    val prefs = mService.getSharedPreferences(
-                        "org.mozilla.firefox.vpn.prefrences", Context.MODE_PRIVATE
-                    )
+                    val prefs = Prefs.get(mService)
                     prefs.edit()
                         .putString("lastConf", json)
                         .apply()
@@ -129,9 +126,7 @@ class VPNServiceBinder(service: VPNService) : Binder() {
                 val buffer = data.createByteArray()
                 if (buffer == null) { return true; }
                 val startOnBootEnabled = buffer.get(0) != 0.toByte()
-                val prefs = mService.getSharedPreferences(
-                    "org.mozilla.firefox.vpn.prefrences", Context.MODE_PRIVATE
-                )
+                val prefs = Prefs.get(mService)
                 prefs.edit()
                     .putBoolean("startOnBoot", startOnBootEnabled)
                     .apply()

--- a/android/src/org/mozilla/firefox/vpn/qt/VPNWebView.java
+++ b/android/src/org/mozilla/firefox/vpn/qt/VPNWebView.java
@@ -7,10 +7,13 @@ package org.mozilla.firefox.vpn.qt;
 import android.app.Activity;
 import android.graphics.Bitmap;
 import android.os.RemoteException;
+import android.view.Window;
+import android.view.WindowManager;
 import android.webkit.WebSettings;
 import android.webkit.WebSettings.PluginState;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
+
 import android.util.Log;
 
 import com.android.installreferrer.api.InstallReferrerClient;
@@ -43,12 +46,12 @@ public class VPNWebView
         }
 
         @Override
-        public void onPageStarted(WebView view, String url, Bitmap favicon)
-        {
-            Log.v(TAG, "Url changed: " + url);
+        public void onPageStarted(WebView view, String url, Bitmap favicon) {
+          // While the login view is open, disable the ability to do screenshots.
+          m_activity.getWindow().addFlags(WindowManager.LayoutParams.FLAG_SECURE);
 
-            super.onPageStarted(view, url, favicon);
-            nativeOnPageStarted(url, favicon);
+          super.onPageStarted(view, url, favicon);
+          nativeOnPageStarted(url, favicon);
         }
 
         @Override
@@ -145,10 +148,11 @@ public class VPNWebView
     {
         Log.v(TAG, "bye!");
         m_activity.runOnUiThread(new Runnable() {
-            @Override
-            public void run() {
-                m_webView.destroy();
-            }
+          @Override
+          public void run() {
+            m_webView.destroy();
+            m_activity.getWindow().clearFlags(WindowManager.LayoutParams.FLAG_SECURE);
+          }
         });
     }
 }

--- a/src/loghandler.cpp
+++ b/src/loghandler.cpp
@@ -173,7 +173,7 @@ void LogHandler::addLog(const Log& log, const QMutexLocker& proofOfLock) {
 
 #endif  // defined(MVPN_ANDROID) || defined(MVPN_INSPECTOR)
 
-#if defined(MVPN_ANDROID)
+#if defined(MVPN_ANDROID) && defined(QT_DEBUG)
   const char* str = buffer.constData();
   if (str) {
     __android_log_write(ANDROID_LOG_DEBUG, "mozillavpn", str);


### PR DESCRIPTION
** Dont Merge yet. - As this would include dropping support of android <7.  **
-->This is required for the Encrypted Shared prefs and #805 - to force using the v2 APK signature. 

This should address all WP5 related issues.

Disallow Backups of Data (2ca5182)
Closes #803

Encypt Shared Prefs (830231c)
Closes #808

Make the Web-View a secured View (10c90ae)
Closes #804

Stop Posting all Log messages to Logcat on Release Builds (e3b3eba)
Closes #809

Closes #805 - As we require android 7 now. 

