### PR TITLE
Improved UX / UI when device limit is exceeded

### DIFF
--- a/src/qml.qrc
+++ b/src/qml.qrc
@@ -408,5 +408,6 @@
         <file>ui/views/ViewErrorFullScreen.qml</file>
         <file>ui/components/VPNControllerNav.qml</file>
         <file>ui/components/VPNSettingsToggle.qml</file>
+        <file>ui/components/VPNDeviceListItem.qml</file>
     </qresource>
 </RCC>

--- a/src/ui/components/VPNControllerNav.qml
+++ b/src/ui/components/VPNControllerNav.qml
@@ -20,20 +20,6 @@ ColumnLayout {
     spacing: 4
     width: parent.width - Theme.windowMargin
     anchors.horizontalCenter: parent.horizontalCenter
-    state: ""
-    states: [
-        State {
-            name: "deviceLimit"
-            PropertyChanges {
-                target: icon
-                source: "../resources/warning.svg"
-                sourceSize.height: 14
-                sourceSize.width: 14
-                Layout.rightMargin: 6
-                Layout.leftMargin: 6
-            }
-        }
-    ]
 
     VPNBoldLabel {
         text: titleText

--- a/src/ui/components/VPNControllerView.qml
+++ b/src/ui/components/VPNControllerView.qml
@@ -494,8 +494,7 @@ Rectangle {
     VPNIconButton {
         id: settingsButton
         objectName: "settingsButton"
-        enabled: VPN.state !== VPN.StateDeviceLimit
-        opacity: VPN.state === VPN.StateDeviceLimit ? .5 : 1
+        opacity: 1
 
         onClicked: stackview.push("../views/ViewSettings.qml", StackView.Immediate)
         anchors.top: parent.top

--- a/src/ui/components/VPNDeviceListItem.qml
+++ b/src/ui/components/VPNDeviceListItem.qml
@@ -16,10 +16,10 @@ Item {
     Layout.preferredHeight: deviceRow.height
 
     Rectangle {
-        color: Theme.grey
-        opacity: device.focus || iconButton.focus ? .1 : 0
+        color: Theme.greyHovered
+        opacity: device.focus || iconButton.focus ? 1 : 0
         anchors.fill: device
-        anchors.topMargin: -Theme.windowMargin / 2
+        anchors.topMargin: -Theme.windowMargin / 1.5
         anchors.bottomMargin: anchors.topMargin
     }
 
@@ -179,7 +179,7 @@ Item {
             buttonColorScheme: Theme.removeDeviceBtn
             visible: !currentOne
             Layout.alignment: Qt.AlignTop | Qt.AlignRight
-            Layout.rightMargin: Theme.windowMargin
+            Layout.rightMargin: Theme.windowMargin / 2
             Layout.preferredHeight: Theme.rowHeight
             Layout.preferredWidth: Theme.rowHeight
             onClicked: removePopup.initializeAndOpen(name, index)

--- a/src/ui/components/VPNDeviceListItem.qml
+++ b/src/ui/components/VPNDeviceListItem.qml
@@ -1,0 +1,214 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import QtQuick 2.5
+import QtQuick.Controls 2.14
+import QtQuick.Layouts 1.14
+import Mozilla.VPN 1.0
+
+import "../themes/themes.js" as Theme
+
+
+Item {
+    id: device
+    Layout.preferredWidth: content.width
+    Layout.preferredHeight: deviceRow.height
+
+    Rectangle {
+        color: Theme.grey
+        opacity: device.focus || iconButton.focus ? .1 : 0
+        anchors.fill: device
+        anchors.topMargin: -Theme.windowMargin / 2
+        anchors.bottomMargin: anchors.topMargin
+    }
+
+    activeFocusOnTab: true
+    onFocusChanged: if (focus && typeof(vpnFlickable.ensureVisible) !== "undefined") vpnFlickable.ensureVisible(device)
+
+
+    RowLayout {
+        id: deviceRow
+
+        property var deviceName: name
+        spacing: 0
+        //% "%1 %2"
+        //: Example: "deviceName deviceDescription"
+        Accessible.name: qsTrId("vpn.devices.deviceAccessibleName").arg(name).arg(deviceDesc.text)
+        Accessible.role: Accessible.ListItem
+        Accessible.ignored: root.isModalDialogOpened
+        focus: true
+        width: device.width
+        Layout.alignment: Qt.AlignHCenter
+
+        SequentialAnimation {
+            id: deviceRemovalTransition
+
+            ParallelAnimation {
+                PropertyAnimation {
+                    target: iconButton
+                    property: "opacity"
+                    from: 1
+                    to: 0
+                    duration: 100
+                }
+
+                PropertyAnimation {
+                    targets: [deviceName, deviceDesc, deviceIcon]
+                    property: "opacity"
+                    from: 1
+                    to: 0.6
+                    duration: 100
+                }
+
+            }
+
+            PropertyAction {
+                target: iconButton
+                property: "iconHeightWidth"
+                value: 20
+            }
+
+            PropertyAction {
+                target: iconButton
+                property: "iconSource"
+                value: "../resources/spinner.svg"
+            }
+
+            ParallelAnimation {
+                PropertyAnimation {
+                    target: iconButton
+                    property: "opacity"
+                    from: 0
+                    to: 1
+                    duration: 300
+                }
+
+                PropertyAction {
+                    target: iconButton
+                    property: "startRotation"
+                    value: true
+                }
+
+            }
+        }
+
+
+        Connections {
+            function onDeviceRemoving(devName) {
+                if (name === devName)
+                    deviceRemovalTransition.start();
+            }
+
+            target: VPN
+        }
+
+        VPNIcon {
+            id: deviceIcon
+
+            source: "../resources/devices.svg"
+            fillMode: Image.PreserveAspectFit
+            Layout.leftMargin: Theme.windowMargin
+            Layout.rightMargin: Theme.windowMargin
+            Layout.alignment: Qt.AlignTop | Qt.AlignLeft
+            Layout.topMargin: Theme.windowMargin / 2
+        }
+
+        ColumnLayout {
+            id: deviceInfo
+
+            Layout.alignment: Qt.AlignLeft
+            Layout.topMargin: Theme.windowMargin / 2
+            Layout.preferredWidth: deviceRow.Layout.preferredWidth - deviceIcon.Layout.rightMargin - deviceIcon.sourceSize.width - iconButton.width - Theme.windowMargin
+            spacing: 0
+
+            VPNInterLabel {
+                id: deviceName
+
+                text: name
+                color: Theme.fontColorDark
+                elide: Text.ElideRight
+                Layout.alignment: Qt.AlignLeft
+                horizontalAlignment: Text.AlignLeft
+                Layout.preferredWidth: deviceInfo.Layout.preferredWidth - Theme.windowMargin / 2
+                Layout.fillWidth: true
+                Accessible.ignored: root.isModalDialogOpened
+            }
+
+            VPNTextBlock {
+                id: deviceDesc
+
+                function deviceSubtitle() {
+                    if (currentOne) {
+                        //% "Current Device"
+                        return qsTrId("vpn.devices.currentDevice");
+                    }
+
+                    const diff = (Date.now() - createdAt.valueOf()) / 1000;
+                    if (diff < 3600) {
+                        //% "Added less than an hour ago"
+                        return qsTrId("vpn.devices.addedltHour");
+                    }
+
+                    if (diff < 86400) {
+                        //: %1 is the number of hours.
+                        //% "Added a few hours ago (%1)"
+                        return qsTrId("vpn.devices.addedXhoursAgo").arg(Math.floor(diff / 3600));
+                    }
+
+                    //% "Added %1 days ago"
+                    //: %1 is the number of days.
+                    //: Note: there is currently no support for proper plurals
+                    return qsTrId("vpn.devices.addedXdaysAgo").arg(Math.floor(diff / 86400));
+                }
+
+                text: deviceSubtitle()
+                color: currentOne ? Theme.blue : Theme.fontColor
+                Accessible.ignored: root.isModalDialogOpened
+            }
+
+        }
+
+        VPNIconButton {
+            id: iconButton
+
+            property var iconSource: "../resources/delete.svg"
+            property real iconHeightWidth: 22
+            property bool startRotation: false
+
+            buttonColorScheme: Theme.removeDeviceBtn
+            visible: !currentOne
+            Layout.alignment: Qt.AlignTop | Qt.AlignRight
+            Layout.rightMargin: Theme.windowMargin
+            Layout.preferredHeight: Theme.rowHeight
+            Layout.preferredWidth: Theme.rowHeight
+            onClicked: removePopup.initializeAndOpen(name, index)
+            //: Label used for accessibility on the button to remove a device. %1 is the name of the device.
+            //% "Remove %1"
+            accessibleName: qsTrId("vpn.devices.removeA11Y").arg(deviceRow.deviceName)
+            // Only allow focus within the current item in the list.
+
+            Accessible.ignored: root.isModalDialogOpened
+
+            VPNIcon {
+                source: iconButton.iconSource
+                anchors.centerIn: iconButton
+                sourceSize.height: iconButton.iconHeightWidth
+                sourceSize.width: iconButton.iconHeightWidth
+                rotation: iconButton.startRotation ? 360 : 0
+
+                Behavior on rotation {
+                    PropertyAnimation {
+                        duration: 5000
+                        loops: Animation.Infinite
+                    }
+
+                }
+
+            }
+
+        }
+    }
+
+}
+

--- a/src/ui/components/VPNDevicesListHeader.qml
+++ b/src/ui/components/VPNDevicesListHeader.qml
@@ -12,10 +12,8 @@ Item {
     property var pendingDeviceRemoval: false
 
     width: deviceList.width
-    state: "deviceLimitNotReached"
     states: [
         State {
-            name: "deviceLimitReached"
             when: vpnFlickable.state === "deviceLimit" || vpnFlickable.wasmShowMaxDeviceWarning === true
 
             PropertyChanges {
@@ -26,7 +24,6 @@ Item {
 
         },
         State {
-            name: "deviceLimitNotReached"
             when: vpnFlickable.state === "active"
 
             PropertyChanges {

--- a/src/ui/components/VPNMenu.qml
+++ b/src/ui/components/VPNMenu.qml
@@ -14,6 +14,7 @@ Item {
     property bool isSettingsView: false
     property bool isMainView: false
     property bool accessibleIgnored: false
+    property bool btnDisabled: false
     property alias forceFocus: iconButton.focus
 
     width: parent.width
@@ -52,6 +53,8 @@ Item {
         accessibleName: qsTrId("vpn.main.back")
         Accessible.ignored: accessibleIgnored
 
+        enabled: !btnDisabled
+        opacity: enabled ? 1 : .4
         Image {
             id: backImage
 

--- a/src/ui/components/VPNRemoveDevicePopup.qml
+++ b/src/ui/components/VPNRemoveDevicePopup.qml
@@ -80,6 +80,13 @@ Popup {
             spacing: 0
             anchors.centerIn: contentRoot
             width: contentRoot.width - Theme.windowMargin * 2
+            opacity: 1
+
+            Behavior on opacity {
+                PropertyAnimation {
+                    duration: 200
+                }
+            }
 
 
             Image {
@@ -156,6 +163,13 @@ Popup {
                     colorScheme: Theme.redButton
                     onClicked: {
                         VPN.removeDevice(popup.deviceName);
+                        if (vpnFlickable.state === "deviceLimit") {
+                            // there is no further action the user can take on the deviceList
+                            // so leave the modal open until the user is redirected back to the main view
+                            col.opacity = .5
+                            return;
+                        }
+
                         popup.close();
                     }
                 }

--- a/src/ui/states/StateDeviceLimit.qml
+++ b/src/ui/states/StateDeviceLimit.qml
@@ -10,5 +10,5 @@ import "../components"
 VPNStackView {
     id: stackview
 
-    initialItem: "../views/ViewMain.qml"
+    initialItem: "../views/ViewDevices.qml"
 }

--- a/src/ui/views/ViewDevices.qml
+++ b/src/ui/views/ViewDevices.qml
@@ -34,8 +34,8 @@ Item {
         height: root.height - menu.height
         width: root.width
         interactive: true
-        flickContentHeight: maxDevicesReached.height + deviceList.height
-        contentHeight: maxDevicesReached.height + deviceList.height
+        flickContentHeight: maxDevicesReached.height + content.height + col.height
+        contentHeight: maxDevicesReached.height + content.height + col.height
         contentWidth: window.width
         state: VPN.state !== VPN.StateDeviceLimit ? "active" : "deviceLimit"
         Component.onCompleted: {
@@ -70,270 +70,61 @@ Item {
             width: root.width
         }
 
-        VPNList {
-            id: deviceList
-
-            property VPNIconButton focusedIconButton: null
-
-            height: count * 80
-            width: parent.width
+        ColumnLayout {
+            id: content
+            width: vpnFlickable.width
             anchors.top: maxDevicesReached.bottom
-            anchors.horizontalCenter: parent.horizontalCenter
-            interactive: false
-            model: VPNDeviceModel
-            spacing: 20
-            Keys.onDownPressed: {
-                vpnFlickable.ensureVisible(currentItem);
-            }
-            Keys.onUpPressed: {
-                vpnFlickable.ensureVisible(currentItem);
-            }
-            onFocusChanged: {
-                // Clear focus from the last focused remove button.
-                if (deviceList.focusedIconButton) {
-                    deviceList.focusedIconButton.focus = false;
-                    deviceList.focusedIconButton = null;
-                }
-            }
-            listName: menu.title
-            Accessible.ignored: root.isModalDialogOpened
+            spacing: Theme.windowMargin
 
-            highlightFollowsCurrentItem: false
-            highlight: Rectangle {
-                color: Theme.greyHovered
-                width: deviceList.width
-                height: deviceList.currentItem ? deviceList.currentItem.height + 20 : 0
-                y: deviceList.currentItem ? deviceList.currentItem.y - 10 : 0
-                opacity: deviceList.currentItem && deviceList.currentItem.activeFocus ? 1 : 0
+            Repeater {
+                id: deviceList
+                model: VPNDeviceModel
+                Layout.alignment: Qt.AlignHCenter
+                Layout.fillWidth: true
 
-                Behavior on y {
-                    PropertyAnimation {
-                        duration: 10
-                    }
-                }
+                delegate: VPNDeviceListItem{}
             }
 
-            removeDisplaced: Transition {
-                NumberAnimation {
-                    properties: "x,y"
-                    duration: Theme.removeDeviceAnimation
-                }
-
+            VPNVerticalSpacer {
+                Layout.preferredHeight: Theme.rowHeight / 2
             }
 
-            remove: Transition {
-                ParallelAnimation {
-                    NumberAnimation {
-                        property: "opacity"
-                        to: 0
-                        duration: Theme.removeDeviceAnimation
-                    }
-
-                }
-
+            Rectangle {
+                Layout.preferredHeight: 1
+                Layout.preferredWidth: parent.width - Theme.windowMargin * 2
+                Layout.alignment: Qt.AlignHCenter
+                color: "#e7e7e7"
+                visible: VPN.state === VPN.StateDeviceLimit
             }
 
-            delegate: RowLayout {
-                id: deviceRow
-
-                property var deviceName: name
-
+            ColumnLayout {
+                id: col
                 spacing: 0
-                //% "%1 %2"
-                //: Example: "deviceName deviceDescription"
-                Accessible.name: qsTrId("vpn.devices.deviceAccessibleName").arg(name).arg(deviceDesc.text)
-                Accessible.role: Accessible.ListItem
-                Accessible.ignored: root.isModalDialogOpened
-                width: deviceList.width - Theme.windowMargin
-                anchors.horizontalCenter: parent.horizontalCenter
+                visible: VPN.state === VPN.StateDeviceLimit
+                Layout.alignment: Qt.AlignHCenter
 
-                Connections {
-                    function onDeviceRemoving(devName) {
-                        if (name === devName)
-                            deviceRemovalTransition.start();
+                VPNLinkButton {
+                    id: getHelpLink
 
-                    }
-
-                    target: VPN
-                }
-
-                VPNIcon {
-                    id: deviceIcon
-
-                    source: "../resources/devices.svg"
-                    fillMode: Image.PreserveAspectFit
-                    Layout.leftMargin: Theme.windowMargin / 2
-                    Layout.rightMargin: Theme.windowMargin
-                    Layout.alignment: Qt.AlignTop | Qt.AlignLeft
-                    Layout.topMargin: Theme.windowMargin / 2
-                }
-
-                ColumnLayout {
-                    id: deviceInfo
-
-                    Layout.alignment: Qt.AlignLeft
-                    Layout.topMargin: Theme.windowMargin / 2
-                    Layout.preferredWidth: deviceRow.Layout.preferredWidth - deviceIcon.Layout.rightMargin - deviceIcon.sourceSize.width - iconButton.width - Theme.windowMargin
-                    spacing: 0
-
-                    VPNInterLabel {
-                        id: deviceName
-
-                        text: name
-                        color: Theme.fontColorDark
-                        elide: Text.ElideRight
-                        Layout.alignment: Qt.AlignLeft
-                        horizontalAlignment: Text.AlignLeft
-                        Layout.preferredWidth: deviceInfo.Layout.preferredWidth - Theme.windowMargin / 2
-                        Layout.fillWidth: true
-                        Accessible.ignored: root.isModalDialogOpened
-                    }
-
-                    VPNTextBlock {
-                        id: deviceDesc
-
-                        function deviceSubtitle() {
-                            if (currentOne) {
-                                //% "Current Device"
-                                return qsTrId("vpn.devices.currentDevice");
-                            }
-
-                            const diff = (Date.now() - createdAt.valueOf()) / 1000;
-                            if (diff < 3600) {
-                                //% "Added less than an hour ago"
-                                return qsTrId("vpn.devices.addedltHour");
-                            }
-
-                            if (diff < 86400) {
-                                //: %1 is the number of hours.
-                                //% "Added a few hours ago (%1)"
-                                return qsTrId("vpn.devices.addedXhoursAgo").arg(Math.floor(diff / 3600));
-                            }
-
-                            //% "Added %1 days ago"
-                            //: %1 is the number of days.
-                            //: Note: there is currently no support for proper plurals
-                            return qsTrId("vpn.devices.addedXdaysAgo").arg(Math.floor(diff / 86400));
-                        }
-
-                        text: deviceSubtitle()
-                        width: parent.width
-                        color: currentOne ? Theme.blue : Theme.fontColor
-                        Accessible.ignored: root.isModalDialogOpened
-                    }
-
-                }
-
-                VPNIconButton {
-                    id: iconButton
-
-                    property var iconSource: "../resources/delete.svg"
-                    property real iconHeightWidth: 22
-                    property bool startRotation: false
-
-                    buttonColorScheme: Theme.removeDeviceBtn
-                    visible: !currentOne
-                    Layout.alignment: Qt.AlignTop | Qt.AlignRight
+                    labelText: qsTrId("vpn.main.getHelp")
+                    Layout.alignment: Qt.AlignHCenter
+                    onClicked: stackview.push(getHelpComponent)
                     Layout.preferredHeight: Theme.rowHeight
-                    Layout.preferredWidth: Theme.rowHeight
-                    onClicked: removePopup.initializeAndOpen(name, index)
-                    //: Label used for accessibility on the button to remove a device. %1 is the name of the device.
-                    //% "Remove %1"
-                    accessibleName: qsTrId("vpn.devices.removeA11Y").arg(deviceRow.deviceName)
-                    // Only allow focus within the current item in the list.
-                    focusPolicy: deviceList.currentItem === deviceRow ? Qt.StrongFocus : Qt.NoFocus
-                    onFocusChanged: {
-                        // If the remove button gets a focus, remember it.
-                        if (focus)
-                            deviceList.focusedIconButton = this;
-
-                    }
-                    Accessible.ignored: root.isModalDialogOpened
-
-                    VPNIcon {
-                        source: iconButton.iconSource
-                        anchors.centerIn: iconButton
-                        sourceSize.height: iconButton.iconHeightWidth
-                        sourceSize.width: iconButton.iconHeightWidth
-                        rotation: iconButton.startRotation ? 360 : 0
-
-                        Behavior on rotation {
-                            PropertyAnimation {
-                                duration: 5000
-                                loops: Animation.Infinite
-                            }
-
-                        }
-
-                    }
-
                 }
 
-                SequentialAnimation {
-                    id: deviceRemovalTransition
-
-                    ParallelAnimation {
-                        PropertyAnimation {
-                            target: iconButton
-                            property: "opacity"
-                            from: 1
-                            to: 0
-                            duration: 100
-                        }
-
-                        PropertyAnimation {
-                            targets: [deviceName, deviceDesc, deviceIcon]
-                            property: "opacity"
-                            from: 1
-                            to: 0.6
-                            duration: 100
-                        }
-
+                VPNSignOut {
+                    id: signOff
+                    anchors.bottom: undefined
+                    anchors.horizontalCenter: undefined
+                    anchors.bottomMargin: undefined
+                    Layout.alignment: Qt.AlignHCenter
+                    Layout.preferredHeight: Theme.rowHeight
+                    onClicked: {
+                        VPNController.logout();
                     }
-
-                    PropertyAction {
-                        target: iconButton
-                        property: "iconHeightWidth"
-                        value: 20
-                    }
-
-                    PropertyAction {
-                        target: iconButton
-                        property: "iconSource"
-                        value: "../resources/spinner.svg"
-                    }
-
-                    ParallelAnimation {
-                        PropertyAnimation {
-                            target: iconButton
-                            property: "opacity"
-                            from: 0
-                            to: 1
-                            duration: 300
-                        }
-
-                        PropertyAction {
-                            target: iconButton
-                            property: "startRotation"
-                            value: true
-                        }
-
-                    }
-
                 }
-
             }
-
-            footer: Rectangle {
-                id: listfooter
-
-                color: "transparent"
-                height: 40
-                width: parent.width
-            }
-
         }
-
     }
 
     VPNRemoveDevicePopup {

--- a/src/ui/views/ViewDevices.qml
+++ b/src/ui/views/ViewDevices.qml
@@ -138,4 +138,13 @@ Item {
     }
 
     Component.onCompleted: VPN.refreshDevices()
+
+    Component {
+        id: getHelpComponent
+
+        VPNGetHelp {
+            isSettingsView: false
+        }
+
+    }
 }

--- a/src/ui/views/ViewDevices.qml
+++ b/src/ui/views/ViewDevices.qml
@@ -51,7 +51,14 @@ Item {
                     target: menu
                     rightTitle: qsTrId("vpn.devices.activeVsMaxDeviceCount").arg(VPNDeviceModel.activeDevices).arg(VPNUser.maxDevices)
                 }
-
+                PropertyChanges {
+                    target: col
+                    visible: false
+                }
+                PropertyChanges {
+                    target: menu
+                    btnDisabled: false
+                }
             },
             State {
                 name: "deviceLimit"
@@ -60,7 +67,14 @@ Item {
                     target: menu
                     rightTitle: qsTrId("vpn.devices.activeVsMaxDeviceCount").arg(VPNDeviceModel.activeDevices + 1).arg(VPNUser.maxDevices)
                 }
-
+                PropertyChanges {
+                    target: col
+                    visible: true
+                }
+                PropertyChanges {
+                    target: menu
+                    btnDisabled: true
+                }
             }
         ]
 
@@ -74,7 +88,8 @@ Item {
             id: content
             width: vpnFlickable.width
             anchors.top: maxDevicesReached.bottom
-            spacing: Theme.windowMargin
+            anchors.topMargin: Theme.windowMargin / 2
+            spacing: Theme.windowMargin / 2
 
             Repeater {
                 id: deviceList
@@ -86,22 +101,28 @@ Item {
             }
 
             VPNVerticalSpacer {
-                Layout.preferredHeight: Theme.rowHeight / 2
-            }
-
-            Rectangle {
                 Layout.preferredHeight: 1
-                Layout.preferredWidth: parent.width - Theme.windowMargin * 2
-                Layout.alignment: Qt.AlignHCenter
-                color: "#e7e7e7"
-                visible: VPN.state === VPN.StateDeviceLimit
             }
 
             ColumnLayout {
                 id: col
                 spacing: 0
-                visible: VPN.state === VPN.StateDeviceLimit
+
+                Layout.preferredWidth: vpnFlickable.width
                 Layout.alignment: Qt.AlignHCenter
+
+                VPNVerticalSpacer {
+                    Layout.preferredHeight: Theme.windowMargin * 2
+                    Layout.preferredWidth: vpnFlickable.width - Theme.windowMargin * 2
+                    Layout.alignment: Qt.AlignHCenter
+                    Rectangle {
+                        id: divider
+                        height: 1
+                        width:  parent.width
+                        anchors.centerIn: parent
+                        color: "#e7e7e7"
+                    }
+                }
 
                 VPNLinkButton {
                     id: getHelpLink

--- a/src/ui/views/ViewMain.qml
+++ b/src/ui/views/ViewMain.qml
@@ -193,9 +193,7 @@ VPNFlickable {
             anchors.top: box.bottom
             anchors.topMargin: 30
 
-            disableRowWhen: VPN.state === VPN.StateDeviceLimit ||
-                                 (VPNController.state !== VPNController.StateOn && VPNController.state !== VPNController.StateOff) ||
-                                 box.connectionInfoVisible
+            disableRowWhen: (VPNController.state !== VPNController.StateOn && VPNController.state !== VPNController.StateOff) || box.connectionInfoVisible
         }
 
         VPNControllerNav {
@@ -215,7 +213,6 @@ VPNFlickable {
             //% "My devices"
             titleText: qsTrId("vpn.devices.myDevices")
             disableRowWhen: box.connectionInfoVisible
-            state: VPN.state !== VPN.StateDeviceLimit ? "" : "deviceLimit"
         }
 
         Behavior on y {


### PR DESCRIPTION
Fixes #752 

User flow changes when the device limit is exceeded:
- When the device limit has been exceeded, the user is taken directly to the devices view instead of the main view
- Adds 'Sign Out' and 'Get Help' links to the devices view, and disables the 'back' button when the device limit warning is visible.
- Removes code to show UI/disable certain bits of functionality in the main view when `VPN.StateDeviceLimit`
- Refactors as needed
<img width="362" alt="Screen Shot 2021-04-09 at 2 58 06 PM" src="https://user-images.githubusercontent.com/22355127/114234227-18554780-9944-11eb-9397-5c744f03eedb.png">
<img width="362" alt="Screen Shot 2021-04-09 at 2 58 15 PM" src="https://user-images.githubusercontent.com/22355127/114234234-19867480-9944-11eb-8062-1870c8654f0c.png">

