### PR TITLE
Consolidate code for scrolling items into view

### DIFF
--- a/src/ui/components/VPNButtonBase.qml
+++ b/src/ui/components/VPNButtonBase.qml
@@ -27,7 +27,7 @@ RoundButton {
     }
     Keys.onReleased: {
         if (loaderVisible) {
-            return
+            return;
         }
         if (event.key === Qt.Key_Return || event.key === Qt.Key_Space) {
             visualStateItem.state = uiState.stateDefault;
@@ -44,8 +44,8 @@ RoundButton {
         if (!activeFocus)
             return visualStateItem.state = uiState.stateDefault;
 
-        if (typeof (ensureVisible) !== "undefined")
-            return ensureVisible(visualStateItem);
+        if (vpnFlickable && typeof (vpnFlickable.ensureVisible) !== "undefined")
+            return vpnFlickable.ensureVisible(visualStateItem);
     }
 
     background: Rectangle {

--- a/src/ui/components/VPNFlickable.qml
+++ b/src/ui/components/VPNFlickable.qml
@@ -15,17 +15,33 @@ Flickable {
     property bool hideScollBarOnStackTransition: false
 
     function ensureVisible(item) {
-        if (windowHeightExceedsContentHeight) {
+        let yPosition = item.mapToItem(contentItem, 0, 0).y;
+        if (windowHeightExceedsContentHeight || item.skipEnsureVisible || yPosition < 0) {
             return;
         }
 
-        let yPosition = item.mapToItem(contentItem, 0, 0).y;
+        const buffer = 20;
+        const itemHeight = Math.min(item.height, Theme.rowHeight) + buffer
         let ext = item.height + yPosition;
-        if (yPosition < contentY || yPosition > contentY + height || ext < contentY || ext > contentY + height) {
-            let destinationY = Math.max(0, Math.min(yPosition - height + item.height, contentHeight - height));
-            ensureVisAnimation.to = destinationY;
-            ensureVisAnimation.start();
+        let destinationY;
+
+
+        if (yPosition < vpnFlickable.contentY || yPosition > vpnFlickable.contentY + vpnFlickable.height || ext < vpnFlickable.contentY || ext > vpnFlickable.contentY + vpnFlickable.height) {
+            destinationY = Math.min(yPosition - vpnFlickable.height + itemHeight, vpnFlickable.contentHeight - vpnFlickable.height);
         }
+
+        if (yPosition < vpnFlickable.contentY) {
+            const diff = vpnFlickable.contentY - yPosition;
+            if (diff < itemHeight) {
+                destinationY = vpnFlickable.contentY - (vpnFlickable.contentY - yPosition);
+                destinationY = (destinationY - buffer) > 0 ? (destinationY - buffer) : destinationY;
+            }
+
+        }
+        if (typeof(destinationY) === "undefined") return;
+
+        ensureVisAnimation.to = destinationY > 0 ? destinationY : 0;
+        ensureVisAnimation.start();
     }
 
     contentHeight: Math.max(window.safeContentHeight, flickContentHeight)

--- a/src/ui/components/VPNIconButton.qml
+++ b/src/ui/components/VPNIconButton.qml
@@ -10,7 +10,7 @@ import "../themes/themes.js" as Theme
 
 VPNButtonBase {
     id: iconButton
-
+    property bool skipEnsureVisible: false
     property var accessibleName
     property var buttonColorScheme: Theme.iconButtonLightBackground
 

--- a/src/ui/components/VPNLinkButton.qml
+++ b/src/ui/components/VPNLinkButton.qml
@@ -20,8 +20,6 @@ VPNButtonBase {
 
 
     radius: 4
-
-    onFocusChanged: if (focus && typeof(ensureVisible) !== "undefined") ensureVisible(root)
     horizontalPadding: buttonPadding
 
     Keys.onReleased: {

--- a/src/ui/components/VPNMenu.qml
+++ b/src/ui/components/VPNMenu.qml
@@ -42,6 +42,8 @@ Item {
     VPNIconButton {
         id: iconButton
 
+        skipEnsureVisible: true // prevents scrolling of lists when this is focused
+
         onClicked: isMainView ? mainStackView.pop() : (isSettingsView ? settingsStackView.pop() : stackview.pop())
         anchors.top: parent.top
         anchors.left: parent.left

--- a/src/ui/components/VPNServerCountry.qml
+++ b/src/ui/components/VPNServerCountry.qml
@@ -25,8 +25,8 @@ VPNClickableRow {
         if (itemDistanceFromWindowTop + cityList.height < vpnFlickable.height || !cityListVisible) {
             return;
         }
-        scrollAnimation.to = (cityList.height > vpnFlickable.height) ? listScrollPosition + itemDistanceFromWindowTop - Theme.rowHeight * 1.5 : listScrollPosition + cityList.height + Theme.rowHeight;
-        scrollAnimation.start();
+        vpnFlickable.ensureVisAnimation.to = (cityList.height > vpnFlickable.height) ? listScrollPosition + itemDistanceFromWindowTop - Theme.rowHeight * 1.5 : listScrollPosition + cityList.height + Theme.rowHeight;
+        vpnFlickable.ensureVisAnimation.start();
     }
 
     Keys.onReleased: if (event.key === Qt.Key_Space) handleKeyClick()
@@ -35,7 +35,6 @@ VPNClickableRow {
     clip: true
 
     activeFocusOnTab: true
-    onActiveFocusChanged: parent.scrollDelegateIntoView(serverCountry)
 
     accessibleName: VPNLocalizer.translateServerCountry(code, name)
     Keys.onDownPressed: repeater.itemAt(index + 1) ? repeater.itemAt(index + 1).forceActiveFocus() : repeater.itemAt(0).forceActiveFocus()
@@ -148,10 +147,11 @@ VPNClickableRow {
                 objectName: "serverCity-" + modelData.replace(/ /g, '_')
 
                 activeFocusOnTab: cityListVisible
-                onActiveFocusChanged: if (focus) serverList.scrollDelegateIntoView(del)
 
                 Keys.onDownPressed: if (citiesRepeater.itemAt(index + 1)) citiesRepeater.itemAt(index + 1).forceActiveFocus()
                 Keys.onUpPressed: if (citiesRepeater.itemAt(index - 1)) citiesRepeater.itemAt(index - 1).forceActiveFocus()
+
+                onActiveFocusChanged: if (focus) vpnFlickable.ensureVisible(del)
 
                 radioButtonLabelText: VPNLocalizer.translateServerCity(code, modelData)
                 accessibleName: VPNLocalizer.translateServerCity(code, modelData)

--- a/src/ui/settings/ViewLanguage.qml
+++ b/src/ui/settings/ViewLanguage.qml
@@ -55,14 +55,6 @@ Item {
             flickContentHeight: row.y + row.implicitHeight + col.y + col.implicitHeight + (Theme.rowHeight * 2)
             anchors.fill: parent
 
-            NumberAnimation on contentY {
-                id: scrollAnimation
-
-                duration: 200
-                easing.type: Easing.OutQuad
-            }
-
-
             RowLayout {
                 id: row
                 width: parent.width - (defaultMargin * 2)
@@ -135,7 +127,7 @@ Item {
                         if (focus) {
                             forceFocus = true;
                             focusScope.lastFocusedItemIdx = -1;
-                            col.scrollDelegateIntoView(useSystemLanguageToggle);
+                            vpnFlickable.ensureVisible(useSystemLanguageToggle);
                       }
                     }
                     Layout.preferredHeight: 24
@@ -165,7 +157,6 @@ Item {
                 color: "#E7E7E7"
                 opacity: 1
             }
-
 
             Column {
                 id: col
@@ -207,22 +198,6 @@ Item {
                     }
                 }
 
-                function scrollDelegateIntoView(item) {
-
-                    if (window.height > vpnFlickable.contentHeight) {
-                        return;
-                    }
-                    const yPosition = item.mapToItem(vpnFlickable.contentItem, 0, 0).y;
-                    const approximateDelegateHeight = 50;
-                    const ext = approximateDelegateHeight + yPosition;
-
-                    if (yPosition < vpnFlickable.contentY || yPosition > vpnFlickable.contentY + vpnFlickable.height || ext < vpnFlickable.contentY || ext > vpnFlickable.contentY + vpnFlickable.height) {
-                        const destinationY = Math.max(0, Math.min(yPosition - vpnFlickable.height + approximateDelegateHeight, vpnFlickable.contentHeight - vpnFlickable.height));
-                        scrollAnimation.to = destinationY;
-                        scrollAnimation.start();
-                    }
-                }
-
                 Repeater {
                     id: repeater
 
@@ -253,7 +228,7 @@ Item {
                         activeFocusOnTab: !useSystemLanguageEnabled
                         onActiveFocusChanged: {
                             if (focus) {
-                                col.scrollDelegateIntoView(del);
+                                vpnFlickable.ensureVisible(del);
                                 focusScope.lastFocusedItemIdx = index;
                             }
                         }

--- a/src/ui/views/ViewServers.qml
+++ b/src/ui/views/ViewServers.qml
@@ -44,13 +44,6 @@ Item {
             flickContentHeight: serverList.y + serverList.implicitHeight + (Theme.rowHeight * 2)
             anchors.fill: parent
 
-            NumberAnimation on contentY {
-                id: scrollAnimation
-
-                duration: 200
-                easing.type: Easing.OutQuad
-            }
-
             Rectangle {
                 id: verticalSpacer
 
@@ -85,21 +78,6 @@ Item {
 
                         vpnFlickable.contentY = destinationY;
                         return;
-                    }
-                }
-
-                function scrollDelegateIntoView(item) {
-                    if (window.height > vpnFlickable.contentHeight) {
-                        return;
-                    }
-                    const yPosition = item.mapToItem(vpnFlickable.contentItem, 0, 0).y;
-                    const approximateDelegateHeight = 60;
-                    const ext = approximateDelegateHeight + yPosition;
-
-                    if (yPosition < vpnFlickable.contentY || yPosition > vpnFlickable.contentY + vpnFlickable.height || ext < vpnFlickable.contentY || ext > vpnFlickable.contentY + vpnFlickable.height) {
-                        const destinationY = Math.max(0, Math.min(yPosition - vpnFlickable.height + approximateDelegateHeight, vpnFlickable.contentHeight - vpnFlickable.height));
-                        scrollAnimation.to = destinationY;
-                        scrollAnimation.start();
                     }
                 }
 


### PR DESCRIPTION
This PR consolidates and improves the code for scrolling items into view and resolves some personal nits I've been wanting to triage.

- Fixes jumpiness in server list when tabbing through list items
- Better support for upward tabbing
- Uses 'vpnFlickable.ensureVisible' to handle scrolling into view on tab everywhere so that the behavior is consistent across views.