### PR TITLE
Android: Cleanup the Namespace

### DIFF
--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -108,7 +108,7 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
                 <action android:name="android.net.VpnService"/>
             </intent-filter>
         </service>
-        <service android:name=".VPNPermissionHelper"
+        <service android:name="org.mozilla.firefox.vpn.qt.VPNPermissionHelper"
             android:process=":QtOnlyProcess"
             android:permission="android.permission.BIND_VPN_SERVICE">
         </service>

--- a/android/src/org/mozilla/firefox/vpn/BootReceiver.kt
+++ b/android/src/org/mozilla/firefox/vpn/BootReceiver.kt
@@ -8,7 +8,6 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.os.Build
-import com.mozilla.vpn.Log
 import com.wireguard.android.backend.GoBackend
 
 class BootReceiver : BroadcastReceiver() {
@@ -19,7 +18,7 @@ class BootReceiver : BroadcastReceiver() {
             Log.i(TAG, "This device does not support start on boot - exit")
             return
         }
-        val prefs = context.getSharedPreferences("com.mozilla.vpn.prefrences", Context.MODE_PRIVATE)
+        val prefs = context.getSharedPreferences("org.mozilla.firefox.vpn.prefrences", Context.MODE_PRIVATE)
         val startOnBoot = prefs.getBoolean("startOnBoot", false)
         if (!startOnBoot) {
             Log.i(TAG, "This device did not enable start on boot - exit")

--- a/android/src/org/mozilla/firefox/vpn/NotificationUtil.kt
+++ b/android/src/org/mozilla/firefox/vpn/NotificationUtil.kt
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package com.mozilla.vpn
+package org.mozilla.firefox.vpn
 
 import android.app.NotificationChannel
 import android.app.NotificationManager
@@ -13,7 +13,6 @@ import android.os.Build
 import android.os.Parcel
 import androidx.core.app.NotificationCompat
 import org.json.JSONObject
-import org.mozilla.firefox.vpn.VPNService
 
 object NotificationUtil {
     var sCurrentContext: Context? = null
@@ -62,7 +61,7 @@ object NotificationUtil {
         val content = JSONObject(json)
 
         val prefs =
-            context.getSharedPreferences("com.mozilla.vpn.prefrences", Context.MODE_PRIVATE)
+            context.getSharedPreferences("org.mozilla.firefox.vpn.prefrences", Context.MODE_PRIVATE)
         prefs.edit()
             .putString("fallbackNotificationHeader", content.getString("title"))
             .putString("fallbackNotificationMessage", content.getString("message"))
@@ -93,7 +92,7 @@ object NotificationUtil {
         // In case we do not have gotten a message to show from the Frontend
         // try to populate the notification with a translated Fallback message
         val prefs =
-            service.getSharedPreferences("com.mozilla.vpn.prefrences", Context.MODE_PRIVATE)
+            service.getSharedPreferences("org.mozilla.firefox.vpn.prefrences", Context.MODE_PRIVATE)
         val message =
             "" + prefs.getString("fallbackNotificationMessage", "Running in the Background")
         val header = "" + prefs.getString("fallbackNotificationHeader", "Mozilla VPN")

--- a/android/src/org/mozilla/firefox/vpn/VPNLogger.kt
+++ b/android/src/org/mozilla/firefox/vpn/VPNLogger.kt
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package com.mozilla.vpn
+package org.mozilla.firefox.vpn
 
 import android.content.Context
 import java.io.File

--- a/android/src/org/mozilla/firefox/vpn/VPNService.kt
+++ b/android/src/org/mozilla/firefox/vpn/VPNService.kt
@@ -7,9 +7,6 @@ package org.mozilla.firefox.vpn
 import android.content.Context
 import android.content.Intent
 import android.os.IBinder
-import com.mozilla.vpn.Log
-import com.mozilla.vpn.NotificationUtil
-import com.mozilla.vpn.VPNTunnel
 import com.wireguard.android.backend.*
 import com.wireguard.android.backend.GoBackend
 import com.wireguard.config.Config
@@ -66,7 +63,7 @@ class VPNService : android.net.VpnService() {
 
         if (this.mConfig == null) {
             // We don't have tunnel to turn on - Try to create one with last config the service got
-            val prefs = getSharedPreferences("com.mozilla.vpn.prefrences", Context.MODE_PRIVATE)
+            val prefs = getSharedPreferences("org.mozilla.firefox.vpn.prefrences", Context.MODE_PRIVATE)
             val lastConfString = prefs.getString("lastConf", "")
             if (lastConfString.isNullOrEmpty()) {
                 // We have nothing to connect to -> Exit

--- a/android/src/org/mozilla/firefox/vpn/VPNServiceBinder.kt
+++ b/android/src/org/mozilla/firefox/vpn/VPNServiceBinder.kt
@@ -8,8 +8,6 @@ import android.os.Binder
 import android.os.DeadObjectException
 import android.os.IBinder
 import android.os.Parcel
-import com.mozilla.vpn.Log
-import com.mozilla.vpn.NotificationUtil
 import com.wireguard.android.backend.Tunnel
 import com.wireguard.config.*
 import com.wireguard.crypto.Key
@@ -60,7 +58,7 @@ class VPNServiceBinder(service: VPNService) : Binder() {
                     // Store the config in case the service gets
                     // asked boot vpn from the OS
                     val prefs = mService.getSharedPreferences(
-                        "com.mozilla.vpn.prefrences", Context.MODE_PRIVATE
+                        "org.mozilla.firefox.vpn.prefrences", Context.MODE_PRIVATE
                     )
                     prefs.edit()
                         .putString("lastConf", json)
@@ -132,7 +130,7 @@ class VPNServiceBinder(service: VPNService) : Binder() {
                 if (buffer == null) { return true; }
                 val startOnBootEnabled = buffer.get(0) != 0.toByte()
                 val prefs = mService.getSharedPreferences(
-                    "com.mozilla.vpn.prefrences", Context.MODE_PRIVATE
+                    "org.mozilla.firefox.vpn.prefrences", Context.MODE_PRIVATE
                 )
                 prefs.edit()
                     .putBoolean("startOnBoot", startOnBootEnabled)

--- a/android/src/org/mozilla/firefox/vpn/VPNTunnel.kt
+++ b/android/src/org/mozilla/firefox/vpn/VPNTunnel.kt
@@ -2,10 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package com.mozilla.vpn
+package org.mozilla.firefox.vpn
 
 import com.wireguard.android.backend.Tunnel
-import org.mozilla.firefox.vpn.VPNServiceBinder
+
 
 class VPNTunnel : Tunnel {
     val mName: String

--- a/android/src/org/mozilla/firefox/vpn/qt/PackageManagerHelper.java
+++ b/android/src/org/mozilla/firefox/vpn/qt/PackageManagerHelper.java
@@ -2,37 +2,27 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package com.mozilla.vpn;
+package org.mozilla.firefox.vpn.qt;
 
-import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
-import android.graphics.Canvas;
 import android.graphics.Color;
-import android.graphics.ColorFilter;
 import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.os.Build;
-import android.os.UserHandle;
-import android.os.UserManager;
 import android.util.Log;
 import android.webkit.WebView;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-
-import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.regex.Pattern;
 

--- a/android/src/org/mozilla/firefox/vpn/qt/VPNPermissionHelper.kt
+++ b/android/src/org/mozilla/firefox/vpn/qt/VPNPermissionHelper.kt
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package org.mozilla.firefox.vpn
+package org.mozilla.firefox.vpn.qt
 
 import android.content.Context
 import android.content.Intent

--- a/android/src/org/mozilla/firefox/vpn/qt/VPNWebView.java
+++ b/android/src/org/mozilla/firefox/vpn/qt/VPNWebView.java
@@ -2,17 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package org.mozilla.firefox.vpn;
+package org.mozilla.firefox.vpn.qt;
 
 import android.app.Activity;
-import android.content.Intent;
-import android.content.pm.PackageInfo;
-import android.content.pm.PackageManager;
 import android.graphics.Bitmap;
-import android.net.Uri;
-import android.os.Build;
 import android.os.RemoteException;
-import android.webkit.URLUtil;
 import android.webkit.WebSettings;
 import android.webkit.WebSettings.PluginState;
 import android.webkit.WebView;
@@ -25,7 +19,6 @@ import com.android.installreferrer.api.ReferrerDetails;
 
 import java.lang.Runnable;
 import java.lang.String;
-import java.util.Date;
 import java.util.concurrent.Semaphore;
 
 public class VPNWebView

--- a/src/platforms/android/androidapplistprovider.cpp
+++ b/src/platforms/android/androidapplistprovider.cpp
@@ -31,7 +31,7 @@ void AndroidAppListProvider::getApplicationList() {
   Q_ASSERT(activity.isValid());
 
   QAndroidJniObject str = QAndroidJniObject::callStaticObjectMethod(
-      "com/mozilla/vpn/PackageManagerHelper", "getAllAppNames",
+      "org/mozilla/firefox/vpn/qt/PackageManagerHelper", "getAllAppNames",
       "(Landroid/content/Context;)Ljava/lang/String;", activity.object());
   QJsonDocument appList = QJsonDocument::fromJson(str.toString().toLocal8Bit());
   QJsonObject listObj = appList.object();

--- a/src/platforms/android/androidauthenticationlistener.cpp
+++ b/src/platforms/android/androidauthenticationlistener.cpp
@@ -37,7 +37,7 @@ void AndroidAuthenticationListener::start(MozillaVPN* vpn, QUrl& url,
 
   QAndroidJniObject activity = QtAndroid::androidActivity();
   jboolean supported = QAndroidJniObject::callStaticMethod<jboolean>(
-      "com/mozilla/vpn/PackageManagerHelper", "isWebViewSupported",
+      "org/mozilla/firefox/vpn/qt/PackageManagerHelper", "isWebViewSupported",
       "(Landroid/content/Context;)Z", activity.object());
   if (supported) {
     AndroidUtils::instance()->startAuthentication(this, url);

--- a/src/platforms/android/androidcontroller.cpp
+++ b/src/platforms/android/androidcontroller.cpp
@@ -49,6 +49,9 @@ namespace {
 Logger logger(LOG_ANDROID, "AndroidController");
 AndroidController* s_instance = nullptr;
 
+constexpr auto PERMISSIONHELPER_CLASS =
+    "org/mozilla/firefox/vpn/qt/VPNPermissionHelper";
+
 }  // namespace
 
 AndroidController::AndroidController() : m_binder(this) {
@@ -76,7 +79,7 @@ void AndroidController::initialize(const Device* device, const Keys* keys) {
   JNINativeMethod methods[]{{"startActivityForResult",
                              "(Landroid/content/Intent;)V",
                              reinterpret_cast<void*>(startActivityForResult)}};
-  QAndroidJniObject javaClass("org/mozilla/firefox/vpn/VPNPermissionHelper");
+  QAndroidJniObject javaClass(PERMISSIONHELPER_CLASS);
   QAndroidJniEnvironment env;
   jclass objectClass = env->GetObjectClass(javaClass.object<jobject>());
   env->RegisterNatives(objectClass, methods,
@@ -145,8 +148,8 @@ void AndroidController::activate(
   auto appContext = QtAndroid::androidActivity().callObjectMethod(
       "getApplicationContext", "()Landroid/content/Context;");
   QAndroidJniObject::callStaticMethod<void>(
-      "org/mozilla/firefox/vpn/VPNPermissionHelper", "startService",
-      "(Landroid/content/Context;)V", appContext.object());
+      PERMISSIONHELPER_CLASS, "startService", "(Landroid/content/Context;)V",
+      appContext.object());
 
   m_server = server;
 

--- a/src/platforms/android/androidwebview.cpp
+++ b/src/platforms/android/androidwebview.cpp
@@ -21,6 +21,7 @@ namespace {
 Logger logger(LOG_ANDROID, "AndroidWebView");
 bool s_methodsInitialized = false;
 AndroidWebView* s_instance = nullptr;
+constexpr auto WEBVIEW_CLASS = "org/mozilla/firefox/vpn/qt/VPNWebView";
 }  // namespace
 
 // static
@@ -82,7 +83,7 @@ AndroidWebView::AndroidWebView(QQuickItem* parent) : QQuickItem(parent) {
     s_methodsInitialized = true;
 
     QAndroidJniEnvironment env;
-    jclass javaClass = env.findClass("org/mozilla/firefox/vpn/VPNWebView");
+    jclass javaClass = env.findClass(WEBVIEW_CLASS);
     if (!javaClass) {
       propagateError(ErrorHandler::RemoteServiceError);
       return;
@@ -107,10 +108,9 @@ AndroidWebView::AndroidWebView(QQuickItem* parent) : QQuickItem(parent) {
   QAndroidJniObject activity = QtAndroid::androidActivity();
   Q_ASSERT(activity.isValid());
 
-  m_object = QAndroidJniObject("org/mozilla/firefox/vpn/VPNWebView",
-                               "(Landroid/app/Activity;Ljava/lang/String;)V",
-                               activity.object<jobject>(),
-                               userAgent.object<jstring>());
+  m_object = QAndroidJniObject(
+      WEBVIEW_CLASS, "(Landroid/app/Activity;Ljava/lang/String;)V",
+      activity.object<jobject>(), userAgent.object<jstring>());
 
   if (!m_object.isValid()) {
     propagateError(ErrorHandler::UnrecoverableError);


### PR DESCRIPTION
Small refactor, as our current namespace does not make any sense :) 
A: Our global package is org.mozilla.firefox.. for legacy reasons. 
Most but not all of the classes have been under com.mozilla.* - so i changed those so they are consistent across the project.

B: We're currently having two independent processes (QT and the Deamon/Service) and you can't see where each file lives.
So i created the subpackage ./QT for stuff jni'd into the qt process since they can't really access the service stuff under ./vpn :)  

Also i removed quite a few unused headers while i'm at it :) 
﻿
