### PR TITLE
Only allow ring animation if the app is visible

### DIFF
--- a/src/ui/components/VPNControllerView.qml
+++ b/src/ui/components/VPNControllerView.qml
@@ -445,7 +445,12 @@ Rectangle {
 
     VPNAnimatedRings {
         id: animatedRingsWrapper
-        isCurrentyVisible: stackview.depth === 1
+        // Make sure we only do the render animation when
+        // The element is visible &&
+        // the application is not minimized
+        isCurrentyVisible: stackview.depth === 1 &&
+                           (Qt.application.state === Qt.ApplicationActive ||
+                            Qt.application.state === Qt.ApplicationInactive)
     }
 
     VPNMainImage {


### PR DESCRIPTION
Touching  #846 - Whilst we need to get this more performant, we can definitely limit the cpu usage when the window is minimized. 
We could also remove Qt.ApplicationInactive condition, so we stop when the window gets out of focus. 
... But's might also look wierdish having the frozen animation in a - non focused window when it's visible.