### PR TITLE
Sort countries and cities by localized names

### DIFF
--- a/src/commands/commandselect.cpp
+++ b/src/commands/commandselect.cpp
@@ -46,7 +46,7 @@ int CommandSelect::run(QStringList& tokens) {
       return 1;
     }
 
-    vpn.changeServer(sd.countryCode(), sd.city());
+    vpn.changeServer(sd.countryCode(), sd.cityName());
     return 0;
   });
 }

--- a/src/commands/commandstatus.cpp
+++ b/src/commands/commandstatus.cpp
@@ -103,8 +103,8 @@ int CommandStatus::run(QStringList& tokens) {
     ServerData* sd = vpn.currentServer();
     if (sd) {
       stream << "Server country code: " << sd->countryCode() << Qt::endl;
-      stream << "Server country: " << sd->country() << Qt::endl;
-      stream << "Server city: " << sd->city() << Qt::endl;
+      stream << "Server country: " << sd->countryName() << Qt::endl;
+      stream << "Server city: " << sd->cityName() << Qt::endl;
     }
 
     return 0;

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -344,7 +344,7 @@ void Controller::changeServer(const QString& countryCode, const QString& city) {
   Q_ASSERT(vpn);
 
   if (vpn->currentServer()->countryCode() == countryCode &&
-      vpn->currentServer()->city() == city) {
+      vpn->currentServer()->cityName() == city) {
     logger.log() << "No server change needed";
     return;
   }
@@ -360,7 +360,7 @@ void Controller::changeServer(const QString& countryCode, const QString& city) {
 
   logger.log() << "Switching to a different server";
 
-  m_currentCity = vpn->currentServer()->city();
+  m_currentCity = vpn->currentServer()->cityName();
   m_switchingCountryCode = countryCode;
   m_switchingCity = city;
 

--- a/src/inspector/inspectorwebsocketconnection.cpp
+++ b/src/inspector/inspectorwebsocketconnection.cpp
@@ -181,7 +181,7 @@ static QList<WebSocketSettingCommand> s_settingCommands{
     // server city
     WebSocketSettingCommand{
         "current-server-city", WebSocketSettingCommand::String, nullptr,
-        []() { return MozillaVPN::instance()->currentServer()->city(); }},
+        []() { return MozillaVPN::instance()->currentServer()->cityName(); }},
 };
 
 struct WebSocketCommand {

--- a/src/localizer.cpp
+++ b/src/localizer.cpp
@@ -255,13 +255,3 @@ bool Localizer::languageSort(const Localizer::Language& a,
 QString Localizer::previousCode() const {
   return SettingsHolder::instance()->previousLanguageCode();
 }
-
-QString Localizer::translateServerCountry(const QString& countryCode,
-                                          const QString& countryName) {
-  return ServerI18N::translateCountryName(countryCode, countryName);
-}
-
-QString Localizer::translateServerCity(const QString& countryCode,
-                                       const QString& cityName) {
-  return ServerI18N::translateCityName(countryCode, cityName);
-}

--- a/src/localizer.cpp
+++ b/src/localizer.cpp
@@ -9,6 +9,7 @@
 #include "serveri18n.h"
 #include "settingsholder.h"
 
+#include <QCollator>
 #include <QCoreApplication>
 #include <QDir>
 #include <QFileInfo>
@@ -107,7 +108,10 @@ void Localizer::initialize() {
   }
 
   // Sorting languages.
-  std::sort(m_languages.begin(), m_languages.end(), languageSort);
+  QCollator collator;
+  std::sort(m_languages.begin(), m_languages.end(),
+            std::bind(languageSort, std::placeholders::_1,
+                      std::placeholders::_2, &collator));
 }
 
 void Localizer::loadLanguage(const QString& code) {
@@ -248,8 +252,10 @@ QStringList Localizer::languages() const {
 }
 
 bool Localizer::languageSort(const Localizer::Language& a,
-                             const Localizer::Language& b) {
-  return a.m_localizedName < b.m_localizedName;
+                             const Localizer::Language& b,
+                             QCollator* collator) {
+  Q_ASSERT(collator);
+  return collator->compare(a.m_localizedName, b.m_localizedName) < 0;
 }
 
 QString Localizer::previousCode() const {

--- a/src/localizer.h
+++ b/src/localizer.h
@@ -8,6 +8,7 @@
 #include <QAbstractListModel>
 #include <QTranslator>
 
+class QCollator;
 class SettingsHolder;
 
 class Localizer final : public QAbstractListModel {
@@ -64,7 +65,8 @@ class Localizer final : public QAbstractListModel {
  private:
   static QString languageName(const QString& code);
   static QString localizedLanguageName(const QString& code);
-  static bool languageSort(const Language& a, const Language& b);
+  static bool languageSort(const Language& a, const Language& b,
+                           QCollator* collator);
 
   bool loadLanguageInternal(const QString& code);
 

--- a/src/localizer.h
+++ b/src/localizer.h
@@ -57,14 +57,6 @@ class Localizer final : public QAbstractListModel {
 
   QVariant data(const QModelIndex& index, int role) const override;
 
-  // For QML
-
-  Q_INVOKABLE QString translateServerCountry(const QString& countryCode,
-                                             const QString& countryName);
-
-  Q_INVOKABLE QString translateServerCity(const QString& countryCode,
-                                          const QString& cityName);
-
  signals:
   void codeChanged();
   void previousCodeChanged();

--- a/src/models/servercountry.cpp
+++ b/src/models/servercountry.cpp
@@ -7,20 +7,11 @@
 #include "serverdata.h"
 #include "serveri18n.h"
 
+#include <QCollator>
 #include <QJsonArray>
 #include <QJsonObject>
 #include <QJsonValue>
 #include <QStringList>
-
-namespace {
-
-bool sortCityCallback(const ServerCity& a, const ServerCity& b,
-                      const QString& countryCode) {
-  return ServerI18N::translateCityName(countryCode, a.name()) <
-         ServerI18N::translateCityName(countryCode, b.name());
-}
-
-}  // anonymous namespace
 
 ServerCountry::ServerCountry() { MVPN_COUNT_CTOR(ServerCountry); }
 
@@ -93,8 +84,22 @@ const QList<Server> ServerCountry::servers(const ServerData& data) const {
   return QList<Server>();
 }
 
+namespace {
+
+bool sortCityCallback(const ServerCity& a, const ServerCity& b,
+                      const QString& countryCode, QCollator* collator) {
+  Q_ASSERT(collator);
+  return collator->compare(
+             ServerI18N::translateCityName(countryCode, a.name()),
+             ServerI18N::translateCityName(countryCode, b.name())) < 0;
+}
+
+}  // anonymous namespace
+
 void ServerCountry::sortCities() {
+  QCollator collator;
+
   std::sort(m_cities.begin(), m_cities.end(),
             std::bind(sortCityCallback, std::placeholders::_1,
-                      std::placeholders::_2, m_code));
+                      std::placeholders::_2, m_code, &collator));
 }

--- a/src/models/servercountry.h
+++ b/src/models/servercountry.h
@@ -31,6 +31,8 @@ class ServerCountry final {
 
   const QList<Server> servers(const ServerData& data) const;
 
+  void sortCities();
+
  private:
   QString m_name;
   QString m_code;

--- a/src/models/servercountrymodel.cpp
+++ b/src/models/servercountrymodel.cpp
@@ -7,6 +7,7 @@
 #include "logger.h"
 #include "servercountry.h"
 #include "serverdata.h"
+#include "serveri18n.h"
 #include "settingsholder.h"
 
 #include <QJsonArray>
@@ -64,7 +65,8 @@ bool ServerCountryModel::fromJson(const QByteArray& s) {
 namespace {
 
 bool sortCountryCallback(const ServerCountry& a, const ServerCountry& b) {
-  return a.name() < b.name();
+  return ServerI18N::translateCountryName(a.code(), a.name()) <
+         ServerI18N::translateCountryName(b.code(), b.name());
 }
 
 }  // anonymous namespace
@@ -103,7 +105,7 @@ bool ServerCountryModel::fromJsonInternal(const QByteArray& s) {
     m_countries.append(country);
   }
 
-  std::sort(m_countries.begin(), m_countries.end(), sortCountryCallback);
+  sortCountries();
 
   endResetModel();
 
@@ -113,6 +115,7 @@ bool ServerCountryModel::fromJsonInternal(const QByteArray& s) {
 QHash<int, QByteArray> ServerCountryModel::roleNames() const {
   QHash<int, QByteArray> roles;
   roles[NameRole] = "name";
+  roles[LocalizedNameRole] = "localizedName";
   roles[CodeRole] = "code";
   roles[CitiesRole] = "cities";
   return roles;
@@ -127,15 +130,24 @@ QVariant ServerCountryModel::data(const QModelIndex& index, int role) const {
     case NameRole:
       return QVariant(m_countries.at(index.row()).name());
 
+    case LocalizedNameRole: {
+      const ServerCountry& country = m_countries.at(index.row());
+      return QVariant(
+          ServerI18N::translateCountryName(country.code(), country.name()));
+    }
+
     case CodeRole:
       return QVariant(m_countries.at(index.row()).code());
 
     case CitiesRole: {
-      QStringList list;
-      const QList<ServerCity>& cities = m_countries.at(index.row()).cities();
+      const ServerCountry& country = m_countries.at(index.row());
 
+      QList<QVariant> list;
+      const QList<ServerCity>& cities = country.cities();
       for (const ServerCity& city : cities) {
-        list.append(city.name());
+        QStringList names{city.name(), ServerI18N::translateCityName(
+                                           country.code(), city.name())};
+        list.append(QVariant(names));
       }
 
       return QVariant(list);
@@ -205,7 +217,7 @@ bool ServerCountryModel::exists(ServerData& data) const {
   for (const ServerCountry& country : m_countries) {
     if (country.code() == data.countryCode()) {
       for (const ServerCity& city : country.cities()) {
-        if (data.city() == city.name()) {
+        if (data.cityName() == city.name()) {
           return true;
         }
       }
@@ -240,5 +252,13 @@ const QString ServerCountryModel::countryName(
 
 void ServerCountryModel::retranslate() {
   beginResetModel();
+  sortCountries();
   endResetModel();
+}
+
+void ServerCountryModel::sortCountries() {
+  std::sort(m_countries.begin(), m_countries.end(), sortCountryCallback);
+  for (ServerCountry& country : m_countries) {
+    country.sortCities();
+  }
 }

--- a/src/models/servercountrymodel.h
+++ b/src/models/servercountrymodel.h
@@ -20,6 +20,7 @@ class ServerCountryModel final : public QAbstractListModel {
  public:
   enum ServerCountryRoles {
     NameRole = Qt::UserRole + 1,
+    LocalizedNameRole,
     CodeRole,
     CitiesRole,
   };
@@ -66,6 +67,8 @@ class ServerCountryModel final : public QAbstractListModel {
 
  private:
   [[nodiscard]] bool fromJsonInternal(const QByteArray& data);
+
+  void sortCountries();
 
  private:
   QByteArray m_rawJson;

--- a/src/models/serverdata.cpp
+++ b/src/models/serverdata.cpp
@@ -6,6 +6,7 @@
 #include "leakdetector.h"
 #include "logger.h"
 #include "servercountrymodel.h"
+#include "serveri18n.h"
 #include "settingsholder.h"
 
 namespace {
@@ -30,7 +31,7 @@ bool ServerData::fromSettings() {
                      settingsHolder->currentServerCountry(),
                      settingsHolder->currentServerCity());
 
-  logger.log() << m_countryCode << m_country << m_city;
+  logger.log() << m_countryCode << m_countryName << m_cityName;
   return true;
 }
 
@@ -39,8 +40,8 @@ void ServerData::writeSettings() {
   Q_ASSERT(settingsHolder);
 
   settingsHolder->setCurrentServerCountryCode(m_countryCode);
-  settingsHolder->setCurrentServerCountry(m_country);
-  settingsHolder->setCurrentServerCity(m_city);
+  settingsHolder->setCurrentServerCountry(m_countryName);
+  settingsHolder->setCurrentServerCity(m_cityName);
 }
 
 void ServerData::initialize(const ServerCountry& country,
@@ -51,17 +52,21 @@ void ServerData::initialize(const ServerCountry& country,
   emit changed();
 }
 
-void ServerData::update(const QString& countryCode, const QString& country,
-                        const QString& city) {
-  initializeInternal(countryCode, country, city);
+void ServerData::update(const QString& countryCode, const QString& countryName,
+                        const QString& cityName) {
+  initializeInternal(countryCode, countryName, cityName);
   emit changed();
 }
 
 void ServerData::initializeInternal(const QString& countryCode,
-                                    const QString& country,
-                                    const QString& city) {
+                                    const QString& countryName,
+                                    const QString& cityName) {
   m_initialized = true;
   m_countryCode = countryCode;
-  m_country = country;
-  m_city = city;
+  m_countryName = countryName;
+  m_cityName = cityName;
+}
+
+QString ServerData::localizedCityName() const {
+  return ServerI18N::translateCityName(m_countryCode, m_cityName);
 }

--- a/src/models/serverdata.h
+++ b/src/models/serverdata.h
@@ -17,7 +17,8 @@ class ServerData final : public QObject {
   Q_DISABLE_COPY_MOVE(ServerData);
 
   Q_PROPERTY(QString countryCode READ countryCode NOTIFY changed)
-  Q_PROPERTY(QString city READ city NOTIFY changed)
+  Q_PROPERTY(QString cityName READ cityName NOTIFY changed)
+  Q_PROPERTY(QString localizedCityName READ localizedCityName NOTIFY changed)
 
  public:
   ServerData();
@@ -33,28 +34,30 @@ class ServerData final : public QObject {
 
   const QString& countryCode() const { return m_countryCode; }
 
-  const QString& country() const { return m_country; }
+  const QString& countryName() const { return m_countryName; }
 
-  const QString& city() const { return m_city; }
+  const QString& cityName() const { return m_cityName; }
+
+  QString localizedCityName() const;
 
   void forget() { m_initialized = false; }
 
-  void update(const QString& countryCode, const QString& country,
-              const QString& city);
+  void update(const QString& countryCode, const QString& countryName,
+              const QString& cityName);
 
  signals:
   void changed();
 
  private:
-  void initializeInternal(const QString& countryCode, const QString& country,
-                          const QString& city);
+  void initializeInternal(const QString& countryCode,
+                          const QString& countryName, const QString& cityName);
 
  private:
   bool m_initialized = false;
 
   QString m_countryCode;
-  QString m_country;
-  QString m_city;
+  QString m_countryName;
+  QString m_cityName;
 };
 
 #endif  // SERVERDATA_H

--- a/src/notificationhandler.cpp
+++ b/src/notificationhandler.cpp
@@ -69,8 +69,8 @@ void NotificationHandler::showNotification() {
         message = qtTrId("vpn.systray.statusSwtich.message")
                       .arg(m_switchingServerCountry)
                       .arg(m_switchingServerCity)
-                      .arg(vpn->currentServer()->country())
-                      .arg(vpn->currentServer()->city());
+                      .arg(vpn->currentServer()->countryName())
+                      .arg(vpn->currentServer()->cityName());
       } else {
         //% "VPN Connected"
         title = qtTrId("vpn.systray.statusConnected.title");
@@ -78,8 +78,8 @@ void NotificationHandler::showNotification() {
         //: Shown as message body in a notification. %1 is the country, %2 is
         //: the city.
         message = qtTrId("vpn.systray.statusConnected.message")
-                      .arg(vpn->currentServer()->country())
-                      .arg(vpn->currentServer()->city());
+                      .arg(vpn->currentServer()->countryName())
+                      .arg(vpn->currentServer()->cityName());
       }
       break;
 
@@ -93,8 +93,8 @@ void NotificationHandler::showNotification() {
         //: Shown as message body in a notification. %1 is the country, %2 is
         //: the city.
         message = qtTrId("vpn.systray.statusDisconnected.message")
-                      .arg(vpn->currentServer()->country())
-                      .arg(vpn->currentServer()->city());
+                      .arg(vpn->currentServer()->countryName())
+                      .arg(vpn->currentServer()->cityName());
       }
       break;
 
@@ -102,8 +102,8 @@ void NotificationHandler::showNotification() {
       m_connected = true;
 
       m_switching = true;
-      m_switchingServerCountry = vpn->currentServer()->country();
-      m_switchingServerCity = vpn->currentServer()->city();
+      m_switchingServerCountry = vpn->currentServer()->countryName();
+      m_switchingServerCity = vpn->currentServer()->cityName();
       break;
 
     default:

--- a/src/serveri18n.cpp
+++ b/src/serveri18n.cpp
@@ -114,6 +114,10 @@ void maybeInitialize() {
 
 QString translateItem(const QString& countryCode, const QString& cityName,
                       const QString& fallback) {
+  if (!SettingsHolder::instance()->hasLanguageCode()) {
+    return fallback;
+  }
+
   maybeInitialize();
   return s_items.value(itemKey(SettingsHolder::instance()->languageCode(),
                                countryCode, cityName),

--- a/src/systemtrayhandler.cpp
+++ b/src/systemtrayhandler.cpp
@@ -187,8 +187,8 @@ void SystemTrayHandler::updateContextMenu() {
       //% "%1, %2"
       //: Location in the systray. %1 is the country, %2 is the city.
       qtTrId("vpn.systray.location")
-          .arg(vpn->currentServer()->country())
-          .arg(vpn->currentServer()->city()));
+          .arg(vpn->currentServer()->countryName())
+          .arg(vpn->currentServer()->cityName()));
   m_lastLocationLabel->setEnabled(vpn->controller()->state() ==
                                   Controller::StateOff);
 }

--- a/src/ui/components/VPNServerCountry.qml
+++ b/src/ui/components/VPNServerCountry.qml
@@ -36,7 +36,7 @@ VPNClickableRow {
 
     activeFocusOnTab: true
 
-    accessibleName: VPNLocalizer.translateServerCountry(code, name)
+    accessibleName: localizedName
     Keys.onDownPressed: repeater.itemAt(index + 1) ? repeater.itemAt(index + 1).forceActiveFocus() : repeater.itemAt(0).forceActiveFocus()
     Keys.onUpPressed: repeater.itemAt(index - 1) ? repeater.itemAt(index - 1).forceActiveFocus() : menu.forceActiveFocus()
     Keys.onBacktabPressed: {
@@ -111,7 +111,7 @@ VPNClickableRow {
         VPNBoldLabel {
             id: countryName
 
-            text: VPNLocalizer.translateServerCountry(code, name)
+            text: localizedName
             Layout.leftMargin: Theme.hSpacing
             Layout.fillWidth: true
         }
@@ -144,7 +144,7 @@ VPNClickableRow {
             model: cities
             delegate: VPNRadioDelegate {
                 id: del
-                objectName: "serverCity-" + modelData.replace(/ /g, '_')
+                objectName: "serverCity-" + modelData[0].replace(/ /g, '_')
 
                 activeFocusOnTab: cityListVisible
 
@@ -153,14 +153,14 @@ VPNClickableRow {
 
                 onActiveFocusChanged: if (focus) vpnFlickable.ensureVisible(del)
 
-                radioButtonLabelText: VPNLocalizer.translateServerCity(code, modelData)
-                accessibleName: VPNLocalizer.translateServerCity(code, modelData)
+                radioButtonLabelText: modelData[1]
+                accessibleName: modelData[1]
                 onClicked: {
-                    VPNController.changeServer(code, modelData);
+                    VPNController.changeServer(code, modelData[0]);
                     stackview.pop();
                 }
                 height: 54
-                checked: code === VPNCurrentServer.countryCode && modelData === VPNCurrentServer.city
+                checked: code === VPNCurrentServer.countryCode && modelData[0] === VPNCurrentServer.cityName
                 isHoverable: cityListVisible
                 enabled: cityListVisible
                 Component.onCompleted: {

--- a/src/ui/views/ViewMain.qml
+++ b/src/ui/views/ViewMain.qml
@@ -186,9 +186,9 @@ VPNFlickable {
             titleText: qsTrId("vpn.servers.selectLocation")
             //% "current location - %1"
             //: Accessibility description for current location of the VPN server
-            descriptionText: qsTrId("vpn.servers.currentLocation").arg(VPNLocalizer.translateServerCity(VPNCurrentServer.countryCode, VPNCurrentServer.city))
+            descriptionText: qsTrId("vpn.servers.currentLocation").arg(VPNCurrentServer.localizedCityName)
 
-            subtitleText: VPNLocalizer.translateServerCity(VPNCurrentServer.countryCode, VPNCurrentServer.city)
+            subtitleText: VPNCurrentServer.localizedCityName
             imgSource:  "../resources/flags/" + VPNCurrentServer.countryCode.toUpperCase() + ".png"
             anchors.top: box.bottom
             anchors.topMargin: 30

--- a/tests/unit/testmodels.cpp
+++ b/tests/unit/testmodels.cpp
@@ -768,8 +768,9 @@ void TestModels::serverCountryModelBasic() {
   QVERIFY(!dm.fromSettings());
 
   QHash<int, QByteArray> rn = dm.roleNames();
-  QCOMPARE(rn.count(), 3);
+  QCOMPARE(rn.count(), 4);
   QCOMPARE(rn[ServerCountryModel::NameRole], "name");
+  QCOMPARE(rn[ServerCountryModel::LocalizedNameRole], "localizedName");
   QCOMPARE(rn[ServerCountryModel::CodeRole], "code");
   QCOMPARE(rn[ServerCountryModel::CitiesRole], "cities");
 
@@ -836,7 +837,8 @@ void TestModels::serverCountryModelFromJson_data() {
   QTest::addRow("good but empty cities")
       << QJsonDocument(obj).toJson() << true << 1
       << QVariant("serverCountryName") << QVariant("serverCountryCode")
-      << QVariant(QStringList{"serverCityName"});
+      << QVariant(
+             QList<QVariant>{QStringList{"serverCityName", "serverCityName"}});
 
   cities.append(city);
   d.insert("cities", cities);
@@ -845,7 +847,8 @@ void TestModels::serverCountryModelFromJson_data() {
   QTest::addRow("good") << QJsonDocument(obj).toJson() << true << 2
                         << QVariant("serverCountryName")
                         << QVariant("serverCountryCode")
-                        << QVariant(QStringList{"serverCityName"});
+                        << QVariant(QList<QVariant>{QStringList{
+                               "serverCityName", "serverCityName"}});
 }
 
 void TestModels::serverCountryModelFromJson() {
@@ -854,6 +857,8 @@ void TestModels::serverCountryModelFromJson() {
 
   // from json
   {
+    SettingsHolder settingsHolder;
+
     ServerCountryModel m;
     QCOMPARE(m.fromJson(json), result);
 
@@ -973,8 +978,8 @@ void TestModels::serverCountryModelPick() {
     ServerData sd;
     QCOMPARE(m.pickIfExists("serverCountryCode", "serverCityCode", sd), true);
     QCOMPARE(sd.countryCode(), "serverCountryCode");
-    QCOMPARE(sd.country(), "serverCountryName");
-    QCOMPARE(sd.city(), "serverCityName");
+    QCOMPARE(sd.countryName(), "serverCountryName");
+    QCOMPARE(sd.cityName(), "serverCityName");
     QCOMPARE(m.exists(sd), true);
 
     QCOMPARE(m.pickIfExists("serverCountryCode2", "serverCityCode", sd), false);
@@ -985,8 +990,8 @@ void TestModels::serverCountryModelPick() {
     ServerData sd;
     m.pickRandom(sd);
     QCOMPARE(sd.countryCode(), "serverCountryCode");
-    QCOMPARE(sd.country(), "serverCountryName");
-    QCOMPARE(sd.city(), "serverCityName");
+    QCOMPARE(sd.countryName(), "serverCountryName");
+    QCOMPARE(sd.cityName(), "serverCityName");
     QCOMPARE(m.exists(sd), true);
   }
 
@@ -994,8 +999,8 @@ void TestModels::serverCountryModelPick() {
     ServerData sd;
     QCOMPARE(m.pickByIPv4Address("ipv4AddrIn", sd), true);
     QCOMPARE(sd.countryCode(), "serverCountryCode");
-    QCOMPARE(sd.country(), "serverCountryName");
-    QCOMPARE(sd.city(), "serverCityName");
+    QCOMPARE(sd.countryName(), "serverCountryName");
+    QCOMPARE(sd.cityName(), "serverCityName");
     QCOMPARE(m.exists(sd), true);
 
     QCOMPARE(m.pickByIPv4Address("ipv4AddrIn2", sd), false);
@@ -1011,8 +1016,8 @@ void TestModels::serverDataBasic() {
 
   QVERIFY(!sd.initialized());
   QCOMPARE(sd.countryCode(), "");
-  QCOMPARE(sd.country(), "");
-  QCOMPARE(sd.city(), "");
+  QCOMPARE(sd.countryName(), "");
+  QCOMPARE(sd.cityName(), "");
 
   {
     QJsonObject countryObj;
@@ -1035,8 +1040,8 @@ void TestModels::serverDataBasic() {
 
     QVERIFY(sd.initialized());
     QCOMPARE(sd.countryCode(), "serverCountryCode");
-    QCOMPARE(sd.country(), "serverCountryName");
-    QCOMPARE(sd.city(), "serverCityName");
+    QCOMPARE(sd.countryName(), "serverCountryName");
+    QCOMPARE(sd.cityName(), "serverCityName");
 
     {
       SettingsHolder settingsHolder;
@@ -1047,8 +1052,8 @@ void TestModels::serverDataBasic() {
       QVERIFY(sd2.fromSettings());
       QVERIFY(sd2.initialized());
       QCOMPARE(sd2.countryCode(), "serverCountryCode");
-      QCOMPARE(sd2.country(), "serverCountryName");
-      QCOMPARE(sd2.city(), "serverCityName");
+      QCOMPARE(sd2.countryName(), "serverCountryName");
+      QCOMPARE(sd2.cityName(), "serverCityName");
 
       QCOMPARE(spy.count(), 1);
     }
@@ -1059,16 +1064,16 @@ void TestModels::serverDataBasic() {
 
   QVERIFY(sd.initialized());
   QCOMPARE(sd.countryCode(), "new Country Code");
-  QCOMPARE(sd.country(), "new Country");
-  QCOMPARE(sd.city(), "new City");
+  QCOMPARE(sd.countryName(), "new Country");
+  QCOMPARE(sd.cityName(), "new City");
 
   sd.forget();
   QCOMPARE(spy.count(), 2);
 
   QVERIFY(!sd.initialized());
   QCOMPARE(sd.countryCode(), "new Country Code");
-  QCOMPARE(sd.country(), "new Country");
-  QCOMPARE(sd.city(), "new City");
+  QCOMPARE(sd.countryName(), "new Country");
+  QCOMPARE(sd.cityName(), "new City");
 
   {
     SettingsHolder settingsHolder;


### PR DESCRIPTION
This PR contains the following commits (squashed):
1. rename ServerData::country() to ServerData::countryName()
2. rename ServerData::city() to ServerData::cityName()
3. sort countries/cities when the language changes
4. expose `localizedName` in the ServerCountryModel
5. expose `cities` as an array of QVariant<QStringList> composed by name and localizedName
6. update the tests