### PR TITLE
Fix #895 - Resolution/scaling issues on Windows

### DIFF
--- a/src/command.cpp
+++ b/src/command.cpp
@@ -13,6 +13,10 @@
 #include "settingsholder.h"
 #include "simplenetworkmanager.h"
 
+#ifdef MVPN_WINDOWS
+# include <Windows.h>
+#endif
+
 #include <QApplication>
 #include <QIcon>
 #include <QTextStream>
@@ -114,6 +118,10 @@ int Command::runQmlApp(std::function<int()>&& a_callback) {
   // Our logging system.
   qInstallMessageHandler(LogHandler::messageQTHandler);
   logger.log() << "MozillaVPN" << APP_VERSION;
+
+#ifdef MVPN_WINDOWS
+  SetProcessDPIAware();
+#endif
 
   QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
 

--- a/src/command.cpp
+++ b/src/command.cpp
@@ -14,7 +14,7 @@
 #include "simplenetworkmanager.h"
 
 #ifdef MVPN_WINDOWS
-# include <Windows.h>
+#  include <Windows.h>
 #endif
 
 #include <QApplication>

--- a/src/ui/main.qml
+++ b/src/ui/main.qml
@@ -20,26 +20,14 @@ Window {
                 Qt.platform.os === "ios" ||
                 Qt.platform.os === "tvos";
     }
-
     screen: Qt.platform.os === "wasm" && Qt.application.screens.length > 1 ? Qt.application.screens[1] : Qt.application.screens[0]
 
     flags: Qt.platform.os === "ios" ? Qt.MaximizeUsingFullscreenGeometryHint : Qt.Window
 
     visible: true
 
-    function getWidth() {
-        return fullscreenRequired() ? Screen.width : Theme.desktopAppWidth;
-    }
-    function getHeight() {
-        return fullscreenRequired() ? Screen.height : Theme.desktopAppHeight;
-    }
-
-    width: getWidth()
-    height: getHeight()
-    maximumHeight: getHeight()
-    maximumWidth: getWidth()
-    minimumHeight: getHeight()
-    minimumWidth: getWidth()
+    width: fullscreenRequired() ? Screen.width : Theme.desktopAppWidth;
+    height: fullscreenRequired() ? Screen.height : Theme.desktopAppHeight;
 
     //% "Mozilla VPN"
     title: qsTrId("vpn.main.productName")
@@ -62,9 +50,15 @@ Window {
         console.log("closing.");
     }
     Component.onCompleted: {
-        if (VPN.startMinimized)
+        if (VPN.startMinimized) {
             this.showMinimized();
-
+        }
+        if (!fullscreenRequired()) {
+            maximumHeight = Theme.desktopAppHeight
+            minimumHeight = Theme.desktopAppHeight
+            maximumWidth = Theme.desktopAppWidth
+            minimumWidth = Theme.desktopAppWidth
+        }
     }
     Rectangle {
         id: iosSafeAreaTopMargin


### PR DESCRIPTION
This fixes a few Windows UI issues when using multiple displays noticed by @bfyee and referenced in #895.

- Fixes UI distortion triggered by "monitor hopping" the app across multiple displays using Window key + arrow left or Windows key + arrow right.
- Prevents the app from being incorrectly resized on Display #1 when changing the scale of Display #2. 

Before:
![outputbeforewindows](https://user-images.githubusercontent.com/22355127/116960272-8fd97680-ac65-11eb-89de-8ddad6771535.gif)

After:
![output400](https://user-images.githubusercontent.com/22355127/116960326-ab448180-ac65-11eb-9505-ecfb026f3218.gif)



