### PR TITLE
Fix #801: Potential race condition in ping sender

### DIFF
--- a/src/connectioncheck.cpp
+++ b/src/connectioncheck.cpp
@@ -29,8 +29,8 @@ void ConnectionCheck::start() {
   logger.log() << "Starting a connection check";
 
   MozillaVPN::instance()->controller()->getStatus(
-      [this](const QString& serverIpv4Gateway, uint64_t txBytes,
-             uint64_t rxBytes) {
+      [this](const QString& serverIpv4Gateway, const QString& deviceIpv4Address,
+             uint64_t txBytes, uint64_t rxBytes) {
         Q_UNUSED(txBytes);
         Q_UNUSED(rxBytes);
 
@@ -38,7 +38,7 @@ void ConnectionCheck::start() {
 
         if (!serverIpv4Gateway.isEmpty()) {
           m_timer.start(CONNECTION_CHECK_TIMEOUT_MSEC);
-          m_pingHelper.start(serverIpv4Gateway);
+          m_pingHelper.start(serverIpv4Gateway, deviceIpv4Address);
         }
       });
 }

--- a/src/connectiondataholder.cpp
+++ b/src/connectiondataholder.cpp
@@ -29,8 +29,10 @@ ConnectionDataHolder::ConnectionDataHolder()
   connect(&m_ipAddressTimer, &QTimer::timeout, [this]() { updateIpAddress(); });
   connect(&m_checkStatusTimer, &QTimer::timeout, [this]() {
     MozillaVPN::instance()->controller()->getStatus(
-        [this](const QString& serverIpv4Gateway, uint64_t txBytes,
+        [this](const QString& serverIpv4Gateway,
+               const QString& deviceIpv4Address, uint64_t txBytes,
                uint64_t rxBytes) {
+          Q_UNUSED(deviceIpv4Address);
           if (!serverIpv4Gateway.isEmpty()) {
             add(txBytes, rxBytes);
           }

--- a/src/connectionhealth.h
+++ b/src/connectionhealth.h
@@ -38,7 +38,8 @@ class ConnectionHealth final : public QObject {
 
  private:
   void stop();
-  void start(const QString& serverIpv4Gateway);
+  void start(const QString& serverIpv4Gateway,
+             const QString& deviceIpv4Address);
 
   void pingSentAndReceived(qint64 msec);
 
@@ -55,6 +56,7 @@ class ConnectionHealth final : public QObject {
 
   bool m_suspended = false;
   QString m_currentGateway;
+  QString m_deviceAddress;
 };
 
 #endif  // CONNECTIONHEALTH_H

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -488,16 +488,18 @@ void Controller::cleanupBackendLogs() {
 }
 
 void Controller::getStatus(
-    std::function<void(const QString& serverIpv4Gateway, uint64_t txByte,
+    std::function<void(const QString& serverIpv4Gateway,
+                       const QString& deviceIpv4Address, uint64_t txByte,
                        uint64_t rxBytes)>&& a_callback) {
   logger.log() << "check status";
 
-  std::function<void(const QString& serverIpv4Gateway, uint64_t txBytes,
+  std::function<void(const QString& serverIpv4Gateway,
+                     const QString& deviceIpv4Address, uint64_t txBytes,
                      uint64_t rxBytes)>
       callback = std::move(a_callback);
 
   if (m_state != StateOn && m_state != StateConfirming) {
-    callback(QString(), 0, 0);
+    callback(QString(), QString(), 0, 0);
     return;
   }
 
@@ -511,17 +513,19 @@ void Controller::getStatus(
 }
 
 void Controller::statusUpdated(const QString& serverIpv4Gateway,
+                               const QString& deviceIpv4Address,
                                uint64_t txBytes, uint64_t rxBytes) {
   logger.log() << "Status updated";
-  QList<std::function<void(const QString& serverIpv4Gateway, uint64_t txBytes,
+  QList<std::function<void(const QString& serverIpv4Gateway,
+                           const QString& deviceIpv4Address, uint64_t txBytes,
                            uint64_t rxBytes)>>
       list;
 
   list.swap(m_getStatusCallbacks);
-  for (const std::function<void(const QString&serverIpv4Gateway,
-                                uint64_t txBytes, uint64_t rxBytes)>&func :
-       list) {
-    func(serverIpv4Gateway, txBytes, rxBytes);
+  for (const std::function<void(
+           const QString&serverIpv4Gateway, const QString&deviceIpv4Address,
+           uint64_t txBytes, uint64_t rxBytes)>&func : list) {
+    func(serverIpv4Gateway, deviceIpv4Address, txBytes, rxBytes);
   }
 }
 

--- a/src/controller.h
+++ b/src/controller.h
@@ -71,7 +71,8 @@ class Controller final : public QObject {
   void cleanupBackendLogs();
 
   void getStatus(
-      std::function<void(const QString& serverIpv4Gateway, uint64_t txBytes,
+      std::function<void(const QString& serverIpv4Gateway,
+                         const QString& deviceIpv4Address, uint64_t txBytes,
                          uint64_t rxBytes)>&& callback);
 
   int connectionRetry() const { return m_connectionRetry; }
@@ -92,7 +93,8 @@ class Controller final : public QObject {
   void timerTimeout();
   void implInitialized(bool status, bool connected,
                        const QDateTime& connectionDate);
-  void statusUpdated(const QString& serverIpv4Gateway, uint64_t txBytes,
+  void statusUpdated(const QString& serverIpv4Gateway,
+                     const QString& deviceIpv4Address, uint64_t txBytes,
                      uint64_t rxBytes);
 
   void connectionConfirmed();
@@ -162,7 +164,8 @@ class Controller final : public QObject {
 
   ReconnectionStep m_reconnectionStep = NoReconnection;
 
-  QList<std::function<void(const QString& serverIpv4Gateway, uint64_t txBytes,
+  QList<std::function<void(const QString& serverIpv4Gateway,
+                           const QString& deviceIpv4Address, uint64_t txBytes,
                            uint64_t rxBytes)>>
       m_getStatusCallbacks;
 };

--- a/src/controllerimpl.h
+++ b/src/controllerimpl.h
@@ -82,10 +82,12 @@ class ControllerImpl : public QObject {
   void disconnected();
 
   // This method should be emitted after a checkStatus() call.
-  // "serverIpv4Gateway" is the current VPN tunnel gateway. "txBytes" and
-  // "rxBytes" contain the number of transmitted and received bytes since the
-  // last statusUpdated signal.
-  void statusUpdated(const QString& serverIpv4Gateway, uint64_t txBytes,
+  // "serverIpv4Gateway" is the current VPN tunnel gateway.
+  // "deviceIpv4Address" is the address of the VPN client.
+  // "txBytes" and "rxBytes" contain the number of transmitted and received
+  // bytes since the last statusUpdated signal.
+  void statusUpdated(const QString& serverIpv4Gateway,
+                     const QString& deviceIpv4Address, uint64_t txBytes,
                      uint64_t rxBytes);
 };
 

--- a/src/localsocketcontroller.cpp
+++ b/src/localsocketcontroller.cpp
@@ -278,6 +278,12 @@ void LocalSocketController::parseCommand(const QByteArray& command) {
       return;
     }
 
+    QJsonValue deviceIpv4Address = obj.value("deviceIpv4Address");
+    if (!deviceIpv4Address.isString()) {
+      logger.log() << "Unexpected deviceIpv4Address value";
+      return;
+    }
+
     QJsonValue txBytes = obj.value("txBytes");
     if (!txBytes.isDouble()) {
       logger.log() << "Unexpected txBytes value";
@@ -290,7 +296,8 @@ void LocalSocketController::parseCommand(const QByteArray& command) {
       return;
     }
 
-    emit statusUpdated(serverIpv4Gateway.toString(), txBytes.toDouble(),
+    emit statusUpdated(serverIpv4Gateway.toString(),
+                       deviceIpv4Address.toString(), txBytes.toDouble(),
                        rxBytes.toDouble());
     return;
   }

--- a/src/pinghelper.cpp
+++ b/src/pinghelper.cpp
@@ -32,10 +32,12 @@ PingHelper::~PingHelper() {
   m_pingThread.wait();
 }
 
-void PingHelper::start(const QString& serverIpv4Gateway) {
+void PingHelper::start(const QString& serverIpv4Gateway,
+                       const QString& deviceIpv4Address) {
   logger.log() << "PingHelper activated for server:" << serverIpv4Gateway;
 
   m_gateway = serverIpv4Gateway;
+  m_source = deviceIpv4Address.section('/', 0, 0);
   m_pingTimer.start(PING_TIMOUT_SEC * 1000);
 }
 
@@ -56,7 +58,7 @@ void PingHelper::nextPing() {
   PingSender* pingSender = new PingSender(this, &m_pingThread);
   connect(pingSender, &PingSender::completed, this, &PingHelper::pingReceived);
   m_pings.append(pingSender);
-  pingSender->send(m_gateway);
+  pingSender->send(m_gateway, m_source);
 
   while (m_pings.length() > PINGS_MAX) {
     m_pings.at(0)->deleteLater();

--- a/src/pinghelper.h
+++ b/src/pinghelper.h
@@ -21,7 +21,8 @@ class PingHelper final : public QObject {
   PingHelper();
   ~PingHelper();
 
-  void start(const QString& serverIpv4Gateway);
+  void start(const QString& serverIpv4Gateway,
+             const QString& deviceIpv4Address);
 
   void stop();
 
@@ -35,6 +36,7 @@ class PingHelper final : public QObject {
 
  private:
   QString m_gateway;
+  QString m_source;
 
   QTimer m_pingTimer;
 

--- a/src/pingsender.cpp
+++ b/src/pingsender.cpp
@@ -56,9 +56,9 @@ PingSender::PingSender(QObject* parent, QThread* thread) : QObject(parent) {
 
 PingSender::~PingSender() { MVPN_COUNT_DTOR(PingSender); }
 
-void PingSender::send(const QString& destination) {
+void PingSender::send(const QString& destination, const QString& source) {
   logger.log() << "PingSender send to" << destination;
-  emit sendPing(destination);
+  emit sendPing(destination, source);
 }
 
 void PingSender::pingFailed() {

--- a/src/pingsender.h
+++ b/src/pingsender.h
@@ -18,13 +18,13 @@ class PingSender final : public QObject {
   PingSender(QObject* parent, QThread* thread);
   ~PingSender();
 
-  void send(const QString& destination);
+  void send(const QString& destination, const QString& source);
 
  signals:
   void completed(PingSender* pingSender, qint64 msec);
 
   // internal only
-  void sendPing(const QString& destination);
+  void sendPing(const QString& destination, const QString& source);
 
  private slots:
   void pingFailed();

--- a/src/pingsendworker.h
+++ b/src/pingsendworker.h
@@ -11,7 +11,7 @@ class PingSendWorker : public QObject {
   Q_OBJECT
 
  public slots:
-  virtual void sendPing(const QString& destination) = 0;
+  virtual void sendPing(const QString& destination, const QString& source) = 0;
 
  signals:
   void pingSucceeded();

--- a/src/platforms/android/androidcontroller.cpp
+++ b/src/platforms/android/androidcontroller.cpp
@@ -301,6 +301,7 @@ bool AndroidController::VPNBinder::onTransact(int code,
       // Data is here a JSON String
       doc = QJsonDocument::fromJson(data.readData());
       emit m_controller->statusUpdated(m_controller->m_server.ipv4Gateway(),
+                                       m_controller->m_server.ipv4AddrIn(),
                                        doc.object()["totalTX"].toInt(),
                                        doc.object()["totalRX"].toInt());
       break;

--- a/src/platforms/dummy/dummycontroller.cpp
+++ b/src/platforms/dummy/dummycontroller.cpp
@@ -44,7 +44,7 @@ void DummyController::checkStatus() {
   m_txBytes += QRandomGenerator::global()->generate() % 100000;
   m_rxBytes += QRandomGenerator::global()->generate() % 100000;
 
-  emit statusUpdated("127.0.0.1", m_txBytes, m_rxBytes);
+  emit statusUpdated("127.0.0.1", "127.0.0.1", m_txBytes, m_rxBytes);
 }
 
 void DummyController::getBackendLogs(

--- a/src/platforms/dummy/dummypingsendworker.cpp
+++ b/src/platforms/dummy/dummypingsendworker.cpp
@@ -18,7 +18,8 @@ DummyPingSendWorker::~DummyPingSendWorker() {
   MVPN_COUNT_DTOR(DummyPingSendWorker);
 }
 
-void DummyPingSendWorker::sendPing(const QString& destination) {
-  logger.log() << "Dummy ping to:" << destination;
+void DummyPingSendWorker::sendPing(const QString& destination,
+                                   const QString& source) {
+  logger.log() << "Dummy ping to:" << destination << "from:" << source;
   emit pingSucceeded();
 }

--- a/src/platforms/dummy/dummypingsendworker.h
+++ b/src/platforms/dummy/dummypingsendworker.h
@@ -16,7 +16,7 @@ class DummyPingSendWorker final : public PingSendWorker {
   ~DummyPingSendWorker();
 
  public slots:
-  void sendPing(const QString& destination) override;
+  void sendPing(const QString& destination, const QString& source) override;
 };
 
 #endif  // DUMMYPINGSENDWORKER_H

--- a/src/platforms/ios/ioscontroller.mm
+++ b/src/platforms/ios/ioscontroller.mm
@@ -170,7 +170,8 @@ void IOSController::checkStatus() {
 
   m_checkingStatus = true;
 
-  [impl checkStatusWithCallback:^(NSString* serverIpv4Gateway, NSString* configString) {
+  [impl checkStatusWithCallback:^(NSString* serverIpv4Gateway, NSString* deviceIpv4Address,
+                                  NSString* configString) {
     QString config = QString::fromNSString(configString);
 
     m_checkingStatus = false;
@@ -196,8 +197,10 @@ void IOSController::checkStatus() {
     }
 
     logger.log() << "ServerIpv4Gateway:" << QString::fromNSString(serverIpv4Gateway)
+                 << "DeviceIpv4Address:" << QString::fromNSString(deviceIpv4Address)
                  << "RxBytes:" << rxBytes << "TxBytes:" << txBytes;
-    emit statusUpdated(QString::fromNSString(serverIpv4Gateway), txBytes, rxBytes);
+    emit statusUpdated(QString::fromNSString(serverIpv4Gateway),
+                       QString::fromNSString(deviceIpv4Address), txBytes, rxBytes);
   }];
 }
 

--- a/src/platforms/ios/ioscontroller.swift
+++ b/src/platforms/ios/ioscontroller.swift
@@ -235,31 +235,37 @@ public class IOSControllerImpl : NSObject {
         (tunnel!.connection as? NETunnelProviderSession)?.stopTunnel()
     }
 
-    @objc func checkStatus(callback: @escaping (String, String) -> Void) {
+    @objc func checkStatus(callback: @escaping (String, String, String) -> Void) {
         Logger.global?.log(message: "Check status")
         assert(tunnel != nil)
 
         let proto = tunnel!.protocolConfiguration as? NETunnelProviderProtocol
         if proto == nil {
-            callback("", "")
+            callback("", "", "")
             return
         }
 
         let tunnelConfiguration = proto?.asTunnelConfiguration()
         if tunnelConfiguration == nil {
-            callback("", "")
+            callback("", "", "")
             return
         }
 
         let serverIpv4Gateway = tunnelConfiguration?.interface.dns[0].address
         if serverIpv4Gateway == nil {
-            callback("", "")
+            callback("", "", "")
+            return
+        }
+
+        let deviceIpv4Address = tunnelConfiguration.interface.addresses[0].address
+        if deviceIpv4Address == nil {
+            callback("", "", "")
             return
         }
 
         guard let session = tunnel?.connection as? NETunnelProviderSession
         else {
-            callback("", "")
+            callback("", "", "")
             return
         }
 
@@ -269,11 +275,11 @@ public class IOSControllerImpl : NSObject {
                       let configString = String(data: data, encoding: .utf8)
                 else {
                     Logger.global?.log(message: "Failed to convert data to string")
-                    callback("", "")
+                    callback("", "", "")
                     return
                 }
 
-                callback("\(serverIpv4Gateway!)", configString)
+                callback("\(serverIpv4Gateway!)", "\(deviceIpv4Address!)", configString)
             }
         } catch {
             Logger.global?.log(message: "Failed to retrieve data from session")

--- a/src/platforms/linux/daemon/dbusservice.cpp
+++ b/src/platforms/linux/daemon/dbusservice.cpp
@@ -133,6 +133,8 @@ QByteArray DBusService::getStatus() {
   json.insert("status", QJsonValue(true));
   json.insert("serverIpv4Gateway",
               QJsonValue(m_lastConfig.m_serverIpv4Gateway));
+  json.insert("deviceIpv4Address",
+              QJsonValue(m_lastConfig.m_deviceIpv4Address));
   json.insert("txBytes", QJsonValue(double(txBytes)));
   json.insert("rxBytes", QJsonValue(double(rxBytes)));
 

--- a/src/platforms/linux/linuxcontroller.cpp
+++ b/src/platforms/linux/linuxcontroller.cpp
@@ -148,6 +148,10 @@ void LinuxController::checkStatusCompleted(QDBusPendingCallWatcher* call) {
   QJsonValue serverIpv4Gateway = obj.value("serverIpv4Gateway");
   Q_ASSERT(serverIpv4Gateway.isString());
 
+  Q_ASSERT(obj.contains("deviceIpv4Address"));
+  QJsonValue deviceIpv4Address = obj.value("deviceIpv4Address");
+  Q_ASSERT(deviceIpv4Address.isString());
+
   Q_ASSERT(obj.contains("txBytes"));
   QJsonValue txBytes = obj.value("txBytes");
   Q_ASSERT(txBytes.isDouble());
@@ -156,8 +160,8 @@ void LinuxController::checkStatusCompleted(QDBusPendingCallWatcher* call) {
   QJsonValue rxBytes = obj.value("rxBytes");
   Q_ASSERT(rxBytes.isDouble());
 
-  emit statusUpdated(serverIpv4Gateway.toString(), txBytes.toDouble(),
-                     rxBytes.toDouble());
+  emit statusUpdated(serverIpv4Gateway.toString(), deviceIpv4Address.toString(),
+                     txBytes.toDouble(), rxBytes.toDouble());
 }
 
 void LinuxController::getBackendLogs(

--- a/src/platforms/linux/linuxpingsendworker.h
+++ b/src/platforms/linux/linuxpingsendworker.h
@@ -20,7 +20,7 @@ class LinuxPingSendWorker final : public PingSendWorker {
   ~LinuxPingSendWorker();
 
  public slots:
-  void sendPing(const QString& destination) override;
+  void sendPing(const QString& destination, const QString& source) override;
 
  private:
   void releaseObjects();

--- a/src/platforms/macos/daemon/macosdaemon.cpp
+++ b/src/platforms/macos/daemon/macosdaemon.cpp
@@ -98,6 +98,7 @@ QByteArray MacOSDaemon::getStatus() {
 
     obj.insert("status", true);
     obj.insert("serverIpv4Gateway", m_lastConfig.m_serverIpv4Gateway);
+    obj.insert("deviceIpv4Address", m_lastConfig.m_deviceIpv4Address);
     obj.insert("date", m_connectionDate.toString());
 
     obj.insert("txBytes", QJsonValue(double(txBytes)));

--- a/src/platforms/macos/macospingsendworker.h
+++ b/src/platforms/macos/macospingsendworker.h
@@ -18,7 +18,7 @@ class MacOSPingSendWorker final : public PingSendWorker {
   ~MacOSPingSendWorker();
 
  public slots:
-  void sendPing(const QString& destination) override;
+  void sendPing(const QString& destination, const QString& source) override;
 
  private:
   void releaseObjects();

--- a/src/platforms/windows/daemon/windowsdaemon.cpp
+++ b/src/platforms/windows/daemon/windowsdaemon.cpp
@@ -279,6 +279,7 @@ QByteArray WindowsDaemon::getStatus() {
 
   obj.insert("status", true);
   obj.insert("serverIpv4Gateway", m_lastConfig.m_serverIpv4Gateway);
+  obj.insert("deviceIpv4Address", m_lastConfig.m_deviceIpv4Address);
   obj.insert("date", m_connectionDate.toString());
   obj.insert("txBytes", QJsonValue(double(txBytes)));
   obj.insert("rxBytes", QJsonValue(double(rxBytes)));

--- a/src/platforms/windows/windowspingsendworker.h
+++ b/src/platforms/windows/windowspingsendworker.h
@@ -16,7 +16,7 @@ class WindowsPingSendWorker final : public PingSendWorker {
   ~WindowsPingSendWorker();
 
  public slots:
-  void sendPing(const QString& destination) override;
+  void sendPing(const QString& destination, const QString& source) override;
 };
 
 #endif  // WINDOWSPINGSENDWORKER_H

--- a/tests/unit/moccontroller.cpp
+++ b/tests/unit/moccontroller.cpp
@@ -39,7 +39,8 @@ int Controller::time() const { return 42; }
 
 void Controller::getBackendLogs(std::function<void(const QString&)>&&) {}
 
-void Controller::statusUpdated(const QString&, uint64_t, uint64_t) {}
+void Controller::statusUpdated(const QString&, const QString&, uint64_t,
+                               uint64_t) {}
 
 QList<IPAddressRange> Controller::getAllowedIPAddressRanges(
     const Server& server) {
@@ -54,12 +55,14 @@ Controller::State Controller::state() const {
 void Controller::updateRequired() {}
 
 void Controller::getStatus(
-    std::function<void(const QString& serverIpv4Gateway, uint64_t txBytes,
+    std::function<void(const QString& serverIpv4Gateway,
+                       const QString& deviceIpv4Address, uint64_t txBytes,
                        uint64_t rxBytes)>&& a_callback) {
-  std::function<void(const QString& serverIpv4Gateway, uint64_t txBytes,
+  std::function<void(const QString& serverIpv4Gateway,
+                     const QString& deviceIpv4Address, uint64_t txBytes,
                      uint64_t rxBytes)>
       callback = std::move(a_callback);
-  callback("127.0.0.1", 0, 0);
+  callback("127.0.0.1", "127.0.0.1", 0, 0);
 }
 
 void Controller::quit() {}


### PR DESCRIPTION
There is a potential race condition when sending ICMP pings for connection health monitoring where closing the tunnel could result
in exposure of the gateway IP address (see issue #801). By binding to the source address when sending a ping, we should prevent this from occurring.

So far I have tested this on Linux and Windows. I've updated the platform code for Android, iOS and Mac while I was at it, but I haven't been able to test any of them yet.