### PR TITLE
Lower C++ language version to C++14

### DIFF
--- a/src/src.pro
+++ b/src/src.pro
@@ -11,7 +11,7 @@ QT += quick
 QT += widgets
 QT += charts
 
-CONFIG += c++1z
+CONFIG += c++14
 
 TEMPLATE  = app
 

--- a/tests/unit/unit.pro
+++ b/tests/unit/unit.pro
@@ -17,6 +17,11 @@ DEFINES += UNIT_TEST
 TEMPLATE = app
 TARGET = tests
 
+wasm {
+    CONFIG += c++1z
+    QMAKE_CXXFLAGS *= -Werror
+}
+
 INCLUDEPATH += \
             . \
             ../../src \


### PR DESCRIPTION
In order to be able to build on platforms that don't have fully support for C++17, C++14 should be considered the minimum required.