### PR TITLE
Fix connection info graph pixelation

### DIFF
--- a/src/ui/components/VPNClickableRow.qml
+++ b/src/ui/components/VPNClickableRow.qml
@@ -34,8 +34,10 @@ VPNButtonBase {
     Accessible.ignored: rowShouldBeDisabled
     Accessible.name: accessibleName
 
-    PropertyAnimation on opacity {
-        duration: 200
+    Behavior on opacity {
+        PropertyAnimation {
+            duration: 100
+        }
     }
 
     // visual state changes are applied to this

--- a/src/ui/components/VPNConnectionInfo.qml
+++ b/src/ui/components/VPNConnectionInfo.qml
@@ -9,192 +9,174 @@ import Mozilla.VPN 1.0
 import "../themes/themes.js" as Theme
 
 
-Popup {
-    id: popup
+Item {
+    property var rBytes: VPNConnectionData.rxBytes
+    property var tBytes: VPNConnectionData.txBytes
 
-    height: box.height
-    width: box.width
-    padding: 0
-    leftInset: 0
-    rightInset: 0
-    modal: true
-    focus: true
-    closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutsideParent
-    onClosed: VPNConnectionData.deactivate()
-    onOpened: {
+    id: connectionInfo
+
+    anchors.fill: box
+
+    function open() {
         VPNConnectionData.activate(txSeries, rxSeries, axisX, axisY);
-        VPNCloseEventHandler.addView(chartWrapper);
-        popup.forceActiveFocus()
+        VPNCloseEventHandler.addView(connectionInfo);
+        connectionInfo.forceActiveFocus()
+        connectionInfo.visible = true;
     }
 
-    // TODO: We can not use Accessible type on Popup because it does not inherit
-    // from an Item. The code below generates the following warning:
-    // "...Accessible must be attached to an Item..."
-    // See https://github.com/mozilla-mobile/mozilla-vpn-client/issues/322 for
-    // more details.
-    // Accessible.focusable: true
-    // Accessible.role: Accessible.Dialog
-    // Accessible.name: connectionInfoButton.accessibleName
-
-
-    contentItem: Item {
-        id: chartWrapper
-
-        property var rBytes: VPNConnectionData.rxBytes
-        property var tBytes: VPNConnectionData.txBytes
-
-        width: box.width
-        height: box.height
-        antialiasing: true
-
-        ChartView {
-            id: chart
-
-            antialiasing: true
-            backgroundColor: "#321C64"
-            width: chartWrapper.width
-            height: (chartWrapper.height / 2) - 32
-            legend.visible: false
-            anchors.horizontalCenter: chartWrapper.horizontalCenter
-            anchors.top: chartWrapper.top
-            anchors.topMargin: 48
-            anchors.left: chartWrapper.left
-            margins.top: 0
-            margins.bottom: 0
-            margins.left: 0
-            margins.right: 0
-            animationOptions: ChartView.NoAnimation
-
-
-            ValueAxis {
-                id: axisX
-
-                tickCount: 1
-                min: 0
-                max: 29
-                lineVisible: false
-                labelsVisible: false
-                gridVisible: false
-                visible: false
-            }
-
-            ValueAxis {
-                id: axisY
-
-                tickCount: 1
-                min: 10
-                max: 80
-                lineVisible: false
-                labelsVisible: false
-                gridVisible: false
-                visible: false
-            }
-
-            SplineSeries {
-                id: txSeries
-
-                axisX: axisX
-                axisY: axisY
-                color: "#F68953"
-                width: 2
-            }
-
-            SplineSeries {
-                id: rxSeries
-
-                axisX: axisX
-                axisY: axisY
-                color: "#EE3389"
-                width: 2
-            }
-
-        }
-
-        VPNBoldLabel {
-            anchors.top: parent.top
-            anchors.topMargin: Theme.windowMargin * 1.5
-            anchors.left: parent.left
-            anchors.right: parent.right
-            anchors.horizontalCenter: parent.center
-            anchors.horizontalCenterOffset: 0
-            horizontalAlignment: Text.AlignHCenter
-            color: Theme.white
-            //% "IP: %1"
-            //: The current IP address
-            text: qsTrId("vpn.connectionInfo.ip").arg(VPNConnectionData.ipAddress)
-            Accessible.name: text
-            Accessible.role: Accessible.StaticText
-        }
-
-        Row {
-            spacing: 48
-            anchors.bottom: parent.bottom
-            anchors.bottomMargin: 32
-            anchors.horizontalCenter: parent.horizontalCenter
-
-            VPNGraphLegendMarker {
-                //% "Download"
-                //: The current download speed. The speed is shown on the next line.
-                markerLabel: qsTrId("vpn.connectionInfo.download")
-                rectColor: "#EE3389"
-                markerData: chartWrapper.rBytes
-            }
-
-            VPNGraphLegendMarker {
-                //% "Upload"
-                //: The current upload speed. The speed is shown on the next line.
-                markerLabel: qsTrId("vpn.connectionInfo.upload")
-                rectColor: "#F68953"
-                markerData: chartWrapper.tBytes
-            }
-
-        }
-
-        VPNIconButton {
-            id: backButton
-            objectName: "connectionInfoBackButton"
-
-            onClicked: popup.close()
-            buttonColorScheme: Theme.iconButtonDarkBackground
-            anchors.top: parent.top
-            anchors.left: parent.left
-            anchors.topMargin: Theme.windowMargin / 2
-            anchors.leftMargin: Theme.windowMargin / 2
-            //% "Close"
-            accessibleName: qsTrId("vpn.connectionInfo.close")
-
-            Image {
-                anchors.centerIn: backButton
-                source: "../resources/close-white.svg"
-                sourceSize.height: 16
-                sourceSize.width: 16
-            }
-
-        }
-
-        Connections {
-            function onGoBack(item) {
-                if (item === chartWrapper)
-                    backButton.clicked();
-
-            }
-
-            target: VPNCloseEventHandler
-        }
-
+    function close() {
+        VPNConnectionData.deactivate();
+        connectionInfo.visible = false;
     }
 
-    background: Rectangle {
-        color: box.color
-        height: box.height
-        width: box.width
+    Rectangle {
+        id: rect
+
+        anchors.fill: parent
+        color:"#321C64"
         radius: box.radius
+
+    }
+    ChartView {
+        id: chart
+
         antialiasing: true
+        backgroundColor: "#321C64"
+        width: connectionInfo.width
+        height: (connectionInfo.height / 2) - 32
+        legend.visible: false
+        anchors.horizontalCenter: connectionInfo.horizontalCenter
+        anchors.top: connectionInfo.top
+        anchors.topMargin: 48
+        anchors.left: connectionInfo.left
+        margins.top: 0
+        margins.bottom: 0
+        margins.left: 0
+        margins.right: 0
+        animationOptions: ChartView.NoAnimation
+
+         Accessible.focusable: true
+         Accessible.role: Accessible.Dialog
+         Accessible.name: connectionInfoButton.accessibleName
+
+
+        ValueAxis {
+            id: axisX
+
+            tickCount: 1
+            min: 0
+            max: 29
+            lineVisible: false
+            labelsVisible: false
+            gridVisible: false
+            visible: false
+        }
+
+        ValueAxis {
+            id: axisY
+
+            tickCount: 1
+            min: 10
+            max: 80
+            lineVisible: false
+            labelsVisible: false
+            gridVisible: false
+            visible: false
+        }
+
+        SplineSeries {
+            id: txSeries
+
+            axisX: axisX
+            axisY: axisY
+            color: "#F68953"
+            width: 2
+        }
+
+        SplineSeries {
+            id: rxSeries
+
+            axisX: axisX
+            axisY: axisY
+            color: "#EE3389"
+            width: 2
+        }
+
     }
 
-    Overlay.modal: Rectangle {
-        color: Theme.bgColor30
-        opacity: 0.5
+    VPNBoldLabel {
+        anchors.top: parent.top
+        anchors.topMargin: Theme.windowMargin * 1.5
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.horizontalCenter: parent.center
+        anchors.horizontalCenterOffset: 0
+        horizontalAlignment: Text.AlignHCenter
+        color: Theme.white
+        //% "IP: %1"
+        //: The current IP address
+        text: qsTrId("vpn.connectionInfo.ip").arg(VPNConnectionData.ipAddress)
+        Accessible.name: text
+        Accessible.role: Accessible.StaticText
     }
 
+    Row {
+        spacing: 48
+        anchors.bottom: parent.bottom
+        anchors.bottomMargin: 32
+        anchors.horizontalCenter: parent.horizontalCenter
+
+        VPNGraphLegendMarker {
+            //% "Download"
+            //: The current download speed. The speed is shown on the next line.
+            markerLabel: qsTrId("vpn.connectionInfo.download")
+            rectColor: "#EE3389"
+            markerData: connectionInfo.rBytes
+        }
+
+        VPNGraphLegendMarker {
+            //% "Upload"
+            //: The current upload speed. The speed is shown on the next line.
+            markerLabel: qsTrId("vpn.connectionInfo.upload")
+            rectColor: "#F68953"
+            markerData: connectionInfo.tBytes
+        }
+
+    }
+
+    VPNIconButton {
+        id: backButton
+        objectName: "connectionInfoBackButton"
+
+        onClicked: {
+            connectionInfo.close();
+        }
+
+        buttonColorScheme: Theme.iconButtonDarkBackground
+        anchors.top: parent.top
+        anchors.left: parent.left
+        anchors.topMargin: Theme.windowMargin / 2
+        anchors.leftMargin: Theme.windowMargin / 2
+        //% "Close"
+        accessibleName: qsTrId("vpn.connectionInfo.close")
+        enabled: connectionInfo.visible
+
+        Image {
+            anchors.centerIn: backButton
+            source: "../resources/close-white.svg"
+            sourceSize.height: 16
+            sourceSize.width: 16
+        }
+
+    }
+
+    Connections {
+        function onGoBack(item) {
+            if (item === connectionInfo)
+                backButton.clicked();
+
+        }
+
+        target: VPNCloseEventHandler
+    }
 }

--- a/src/ui/components/VPNControllerNav.qml
+++ b/src/ui/components/VPNControllerNav.qml
@@ -24,6 +24,13 @@ ColumnLayout {
     VPNBoldLabel {
         text: titleText
         Layout.leftMargin: Theme.windowMargin
+        opacity: disableRowWhen ?  .7 : 1
+
+        Behavior on opacity {
+            PropertyAnimation {
+                duration: 100
+            }
+        }
     }
 
     VPNClickableRow {

--- a/src/ui/components/VPNControllerView.qml
+++ b/src/ui/components/VPNControllerView.qml
@@ -30,6 +30,10 @@ Rectangle {
         return formatSingle(time) + ":" + formatSingle(mins) + ":" + formatSingle(secs);
     }
 
+    function closeConnectionInfo() {
+        connectionInfo.close();
+    }
+
     state: VPNController.state
     anchors.top: parent.top
     anchors.left: parent.left
@@ -481,6 +485,7 @@ Rectangle {
         //% "Connection Information"
         accessibleName: qsTrId("vpn.controller.info")
         Accessible.ignored: connectionInfoVisible
+        enabled: !connectionInfoVisible
 
         VPNIcon {
             id: connectionInfoImage
@@ -518,6 +523,7 @@ Rectangle {
         //% "Settings"
         accessibleName: qsTrId("vpn.main.settings")
         Accessible.ignored: connectionInfoVisible
+        enabled: !connectionInfoVisible
 
         VPNIcon {
             id: settingsImage
@@ -642,10 +648,12 @@ Rectangle {
         anchors.horizontalCenterOffset: 0
         anchors.horizontalCenter: parent.horizontalCenter
         Accessible.ignored: connectionInfoVisible
+        enabled: !connectionInfoVisible
     }
 
     VPNConnectionInfo {
         id: connectionInfo
+        visible: false
 
         Behavior on opacity {
             NumberAnimation {

--- a/src/ui/views/ViewMain.qml
+++ b/src/ui/views/ViewMain.qml
@@ -65,6 +65,12 @@ VPNFlickable {
         }
     ]
 
+    MouseArea {
+        anchors.fill: parent
+        enabled: box.connectionInfoVisible
+        onClicked: box.closeConnectionInfo()
+    }
+
     Item {
         id: mobileHeader
 


### PR DESCRIPTION
Resolves some weird aliasing grief brought about by using Popup{} to show/hide the connection info.

Before:
<img width="362" alt="Screen Shot 2021-05-06 at 10 38 10 AM" src="https://user-images.githubusercontent.com/22355127/117337229-bfa19d80-ae62-11eb-91b7-3dda7c504b99.png">


After:
<img width="362" alt="Screen Shot 2021-05-06 at 11 57 58 AM" src="https://user-images.githubusercontent.com/22355127/117337177-abf63700-ae62-11eb-85a4-c9fece69f601.png">
