### PR TITLE
Add systemd service file and kill old versions on upgrade

### DIFF
--- a/linux/debian/control.prod.bionic
+++ b/linux/debian/control.prod.bionic
@@ -2,7 +2,7 @@ Source: mozillavpn
 Section: net
 Priority: optional
 Maintainer: mozilla <vpn@mozilla.com>
-Build-Depends: debhelper (>= 8.1.3),
+Build-Depends: debhelper (>= 9.20160709),
                cdbs,
                quilt,
                flex,

--- a/linux/debian/control.prod.focal
+++ b/linux/debian/control.prod.focal
@@ -2,7 +2,7 @@ Source: mozillavpn
 Section: net
 Priority: optional
 Maintainer: mozilla <vpn@mozilla.com>
-Build-Depends: debhelper (>= 8.1.3),
+Build-Depends: debhelper (>= 9.20160709),
                cdbs,
                quilt,
                flex,

--- a/linux/debian/control.prod.groovy
+++ b/linux/debian/control.prod.groovy
@@ -2,7 +2,7 @@ Source: mozillavpn
 Section: net
 Priority: optional
 Maintainer: mozilla <vpn@mozilla.com>
-Build-Depends: debhelper (>= 8.1.3),
+Build-Depends: debhelper (>= 9.20160709),
                cdbs,
                quilt,
                flex,

--- a/linux/debian/control.stage.bionic
+++ b/linux/debian/control.stage.bionic
@@ -2,7 +2,7 @@ Source: mozillavpn
 Section: net
 Priority: optional
 Maintainer: mozilla <vpn@mozilla.com>
-Build-Depends: debhelper (>= 8.1.3),
+Build-Depends: debhelper (>= 9.20160709),
                cdbs,
                quilt,
                flex,

--- a/linux/debian/control.stage.focal
+++ b/linux/debian/control.stage.focal
@@ -2,7 +2,7 @@ Source: mozillavpn
 Section: net
 Priority: optional
 Maintainer: mozilla <vpn@mozilla.com>
-Build-Depends: debhelper (>= 8.1.3),
+Build-Depends: debhelper (>= 9.20160709),
                cdbs,
                quilt,
                flex,

--- a/linux/debian/control.stage.groovy
+++ b/linux/debian/control.stage.groovy
@@ -2,7 +2,7 @@ Source: mozillavpn
 Section: net
 Priority: optional
 Maintainer: mozilla <vpn@mozilla.com>
-Build-Depends: debhelper (>= 8.1.3),
+Build-Depends: debhelper (>= 9.20160709),
                cdbs,
                quilt,
                flex,

--- a/linux/debian/mozillavpn.preinst
+++ b/linux/debian/mozillavpn.preinst
@@ -1,0 +1,7 @@
+#!/bin/sh
+action="$1"
+if [ "$action" = "upgrade" ]; then
+  if dpkg --compare-versions "$2" lt 2.3.0; then
+    killall mozillavpn 2>/dev/null
+  fi
+fi

--- a/linux/debian/mozillavpn.service
+++ b/linux/debian/mozillavpn.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=MozillaVPN D-Bus service
+
+[Service]
+Type=dbus
+BusName=org.mozilla.vpn.dbus
+ExecStart=/usr/bin/mozillavpn linuxdaemon

--- a/linux/debian/rules.prod.bionic
+++ b/linux/debian/rules.prod.bionic
@@ -8,7 +8,7 @@ export LD_LIBRARY_PATH := $(QTDIR)/lib:$(LD_LIBRARY_PATH)
 DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
 
 %:
-	dh $@ --warn-missing
+	dh $@ --with systemd --warn-missing
 
 override_dh_auto_configure:
 	qmake CONFIG+=production CONFIG-=debug CONFIG+=release CONFIG-=debug_and_release QT+=svg BUILD_ID=FULLVERSION

--- a/linux/debian/rules.prod.focal
+++ b/linux/debian/rules.prod.focal
@@ -8,7 +8,7 @@ export LD_LIBRARY_PATH := $(QTDIR)/lib:$(LD_LIBRARY_PATH)
 DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
 
 %:
-	dh $@ --warn-missing
+	dh $@ --with systemd --warn-missing
 
 override_dh_auto_configure:
 	qmake CONFIG+=production CONFIG-=debug CONFIG+=release CONFIG-=debug_and_release QT+=svg BUILD_ID=FULLVERSION

--- a/linux/debian/rules.prod.groovy
+++ b/linux/debian/rules.prod.groovy
@@ -5,7 +5,7 @@ export DH_VERBOSE=1
 DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
 
 %:
-	dh $@ --warn-missing
+	dh $@ --with systemd --warn-missing
 
 override_dh_auto_configure:
 	qmake CONFIG+=production CONFIG-=debug CONFIG+=release CONFIG-=debug_and_release BUILD_ID=FULLVERSION

--- a/linux/debian/rules.stage.bionic
+++ b/linux/debian/rules.stage.bionic
@@ -8,7 +8,7 @@ export LD_LIBRARY_PATH := $(QTDIR)/lib:$(LD_LIBRARY_PATH)
 DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
 
 %:
-	dh $@ --warn-missing
+	dh $@ --with systemd --warn-missing
 
 override_dh_auto_configure:
 	qmake CONFIG-=debug CONFIG+=release CONFIG-=debug_and_release QT+=svg CONFIG+=inspector BUILD_ID=FULLVERSION

--- a/linux/debian/rules.stage.focal
+++ b/linux/debian/rules.stage.focal
@@ -8,7 +8,7 @@ export LD_LIBRARY_PATH := $(QTDIR)/lib:$(LD_LIBRARY_PATH)
 DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
 
 %:
-	dh $@ --warn-missing
+	dh $@ --with systemd --warn-missing
 
 override_dh_auto_configure:
 	qmake CONFIG-=debug CONFIG+=release CONFIG-=debug_and_release QT+=svg CONFIG+=inspector BUILD_ID=FULLVERSION

--- a/linux/debian/rules.stage.groovy
+++ b/linux/debian/rules.stage.groovy
@@ -5,7 +5,7 @@ export DH_VERBOSE=1
 DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
 
 %:
-	dh $@ --warn-missing
+	dh $@ --with systemd --warn-missing
 
 override_dh_auto_configure:
 	qmake CONFIG-=debug CONFIG+=release CONFIG-=debug_and_release CONFIG+=inspector BUILD_ID=FULLVERSION

--- a/src/platforms/linux/daemon/org.mozilla.vpn.dbus.service
+++ b/src/platforms/linux/daemon/org.mozilla.vpn.dbus.service
@@ -2,3 +2,4 @@
 User=root
 Name=org.mozilla.vpn.dbus
 Exec=/usr/bin/mozillavpn linuxdaemon
+SystemdService=mozillavpn.service


### PR DESCRIPTION
When launching the D-Bus service as a bus-activatable service we can start the daemon but we don't have a good way to stop it
during a software update. Adding a systemd service file allows the OS to manage that service when interacting with the package
manager.

However, when upgrading from 2.2.0 and earlier the systemd service file doesn't exist. For these cases we need a preinst hook to kill off any old versions that might be running.

Together, these two changes should ensure that the user can't be left running a version of the daemon that's older than the UI after performing an upgrade via the package manager.

See: mozilla-mobile/mozilla-vpn-client#977