### PR TITLE
Execute resolvconf as a shell script

### DIFF
--- a/linux/daemon/helper.sh
+++ b/linux/daemon/helper.sh
@@ -109,12 +109,12 @@ set_dns() {
 	# Iterate through values of DNS array and pipe "nameserver" string to 
 	# resolvconf command which adds nameserver rows for each dns entry to /etc/resolv.conf
 	# (maybe amongst other things)
-	printf 'nameserver %s\n' "${DNS[@]}" | resolvconf -a "$(resolvconf_iface_prefix)$INTERFACE" -m 0 -x
+	printf 'nameserver %s\n' "${DNS[@]}" | /bin/bash resolvconf -a "$(resolvconf_iface_prefix)$INTERFACE" -m 0 -x
 	HAVE_SET_DNS=1
 }
 
 unset_dns() {
-	resolvconf -d "$(resolvconf_iface_prefix)$INTERFACE" -f
+	/bin/bash resolvconf -d "$(resolvconf_iface_prefix)$INTERFACE" -f
 }
 
 add_route() {


### PR DESCRIPTION
OS - Fedora 34. 
/usr/sbin/resolvconf stems to /usr/sbin/resolvconf.openresolv which does not have +x. 
Closes #987