### PR TITLE
Simplify balrog implementation

### DIFF
--- a/balrog/Makefile
+++ b/balrog/Makefile
@@ -1,4 +1,8 @@
 all:
+	make clean install build
+build:
 	go build -buildmode c-archive -v
-
 install:
+	go install
+clean:
+	git clean -x -f

--- a/balrog/api.go
+++ b/balrog/api.go
@@ -39,30 +39,20 @@ func (l *CLogger) Write(p []byte) (int, error) {
 //export balrogSetLogger
 func balrogSetLogger(loggerFn uintptr) {
 	loggerFunc = unsafe.Pointer(loggerFn)
-  }
-  
+}
+
 //export balrogValidate
 func balrogValidate(x5u string, input string, signature string, rootHash string, leafCertSubject string) bool {
-	//
-	// NEW METHOD SIGNATURE - balrogValidate(x5uDataGo, updateDataGo, signatureGo, certSubjectGo);
-	// - parse x5uData
-	// - validate chain
-	// - validate root (with root cert fingerprint?)
-	// - validate leaf (with certSubject)
-	// - get publickey from leaf
-	// - validate updateData (aka input) with publickey and signature
-	//
-	//
 	logger := log.New(&CLogger{level: 0}, "", 0)
 	err := contentsignature.Verify([]byte(input), []byte(x5u), signature, rootHash)
 	if err != nil {
 		logger.Println("Verification failed with error:", err.Error())
 		return false
 	}
-	// Verify method does not verify the leaf
+	// Verify method does not verify the leaf cert subject, so we do it here.
 	certs, _ := contentsignature.ParseChain([]byte(x5u))
 	leaf := certs[0]
-	if string(leaf.RawSubject) != leafCertSubject {
+	if string(leaf.Subject.CommonName) != leafCertSubject {
 		logger.Println("Leaf subject didn't match. Expected: ", leafCertSubject, " Got: ", leaf.Subject)
 		return false
 	}

--- a/balrog/api.go
+++ b/balrog/api.go
@@ -13,70 +13,70 @@ package main
 import "C"
 
 import (
-  "crypto/ecdsa"
-  "crypto/sha256"
-  "crypto/sha512"
-  "crypto/x509"
-  "encoding/base64"
-  "errors"
-  "encoding/pem"
-  "math/big"
-  "log"
-  "hash"
-  "unsafe"
+	"crypto/ecdsa"
+	"crypto/sha256"
+	"crypto/sha512"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"errors"
+	"hash"
+	"log"
+	"math/big"
+	"unsafe"
 )
 
 var loggerFunc unsafe.Pointer
 
 type CLogger struct {
-  level C.int
+	level C.int
 }
 
 func (l *CLogger) Write(p []byte) (int, error) {
-  if uintptr(loggerFunc) == 0 {
-    return 0, errors.New("No logger initialized")
-  }
-  message := C.CString(string(p))
-  C.callLogger(loggerFunc, l.level, message)
-  C.free(unsafe.Pointer(message))
-  return len(p), nil
+	if uintptr(loggerFunc) == 0 {
+		return 0, errors.New("No logger initialized")
+	}
+	message := C.CString(string(p))
+	C.callLogger(loggerFunc, l.level, message)
+	C.free(unsafe.Pointer(message))
+	return len(p), nil
 }
 
 // ContentSignature contains the parsed representation of a signature
 type ContentSignature struct {
-  R, S     *big.Int // fields must be exported for ASN.1 marshalling
-  HashName string
-  Mode     string
-  X5U      string
-  ID       string
-  Len      int
-  Finished bool
+	R, S     *big.Int // fields must be exported for ASN.1 marshalling
+	HashName string
+	Mode     string
+	X5U      string
+	ID       string
+	Len      int
+	Finished bool
 }
 
 const (
-  // Type of this signer is 'contentsignature'
-  Type = "contentsignature"
+	// Type of this signer is 'contentsignature'
+	Type = "contentsignature"
 
-  // P256ECDSA defines an ecdsa content signature on the P-256 curve
-  P256ECDSA = "p256ecdsa"
+	// P256ECDSA defines an ecdsa content signature on the P-256 curve
+	P256ECDSA = "p256ecdsa"
 
-  // P256ECDSABYTESIZE defines the bytes length of a P256ECDSA signature
-  P256ECDSABYTESIZE = 64
+	// P256ECDSABYTESIZE defines the bytes length of a P256ECDSA signature
+	P256ECDSABYTESIZE = 64
 
-  // P384ECDSA defines an ecdsa content signature on the P-384 curve
-  P384ECDSA = "p384ecdsa"
+	// P384ECDSA defines an ecdsa content signature on the P-384 curve
+	P384ECDSA = "p384ecdsa"
 
-  // P384ECDSABYTESIZE defines the bytes length of a P384ECDSA signature
-  P384ECDSABYTESIZE = 96
+	// P384ECDSABYTESIZE defines the bytes length of a P384ECDSA signature
+	P384ECDSABYTESIZE = 96
 
-  // P521ECDSA defines an ecdsa content signature on the P-521 curve
-  P521ECDSA = "p521ecdsa"
+	// P521ECDSA defines an ecdsa content signature on the P-521 curve
+	P521ECDSA = "p521ecdsa"
 
-  // P521ECDSABYTESIZE defines the bytes length of a P521ECDSA signature
-  P521ECDSABYTESIZE = 132
+	// P521ECDSABYTESIZE defines the bytes length of a P521ECDSA signature
+	P521ECDSABYTESIZE = 132
 
-  // SignaturePrefix is a string preprended to data prior to signing
-  SignaturePrefix = "Content-Signature:\x00"
+	// SignaturePrefix is a string preprended to data prior to signing
+	SignaturePrefix = "Content-Signature:\x00"
 )
 
 // getSignatureLen returns the size of an ECDSA signature issued by the signer,
@@ -86,42 +86,41 @@ const (
 // (each R and S value is equal to the size of the curve field).
 // If the curve field it not a multiple of 8, round to the upper multiple of 8.
 func getSignatureLen(mode string) int {
-  switch mode {
-  case P256ECDSA:
-    return P256ECDSABYTESIZE
-  case P384ECDSA:
-    return P384ECDSABYTESIZE
-  case P521ECDSA:
-    return P521ECDSABYTESIZE
-  }
-  return -1
+	switch mode {
+	case P256ECDSA:
+		return P256ECDSABYTESIZE
+	case P384ECDSA:
+		return P384ECDSABYTESIZE
+	case P521ECDSA:
+		return P521ECDSABYTESIZE
+	}
+	return -1
 }
 
 // getSignatureHash returns the name of the hash function used by a given mode,
 // or an empty string if the mode is unknown
 func getSignatureHash(mode string) string {
-  switch mode {
-  case P256ECDSA:
-    return "sha256"
-  case P384ECDSA:
-    return "sha384"
-  case P521ECDSA:
-    return "sha512"
-  }
-  return ""
+	switch mode {
+	case P256ECDSA:
+		return "sha256"
+	case P384ECDSA:
+		return "sha384"
+	case P521ECDSA:
+		return "sha512"
+	}
+	return ""
 }
 
 // VerifyData verifies a signatures on its raw, untemplated, input using a public key
 func (sig *ContentSignature) VerifyData(input []byte, pubKey *ecdsa.PublicKey) bool {
-  _, hash := makeTemplatedHash(input, sig.Mode)
-  return sig.VerifyHash(hash, pubKey)
+	_, hash := makeTemplatedHash(input, sig.Mode)
+	return sig.VerifyHash(hash, pubKey)
 }
 
 // VerifyHash verifies a signature on its templated hash using a public key
 func (sig *ContentSignature) VerifyHash(hash []byte, pubKey *ecdsa.PublicKey) bool {
-  return ecdsa.Verify(pubKey, hash, sig.R, sig.S)
+	return ecdsa.Verify(pubKey, hash, sig.R, sig.S)
 }
-
 
 // hash returns the templated sha384 of the input data. The template adds
 // the string "Content-Signature:\x00" before the input data prior to
@@ -129,23 +128,23 @@ func (sig *ContentSignature) VerifyHash(hash []byte, pubKey *ecdsa.PublicKey) bo
 //
 // The name of the hash function is returned, followed by the hash bytes
 func makeTemplatedHash(data []byte, curvename string) (alg string, out []byte) {
-  templated := make([]byte, len(SignaturePrefix)+len(data))
-  copy(templated[:len(SignaturePrefix)], []byte(SignaturePrefix))
-  copy(templated[len(SignaturePrefix):], data)
-  var md hash.Hash
-  switch curvename {
-  case P384ECDSA:
-    md = sha512.New384()
-    alg = "sha384"
-  case P521ECDSA:
-    md = sha512.New()
-    alg = "sha512"
-  default:
-    md = sha256.New()
-    alg = "sha256"
-  }
-  md.Write(templated)
-  return alg, md.Sum(nil)
+	templated := make([]byte, len(SignaturePrefix)+len(data))
+	copy(templated[:len(SignaturePrefix)], []byte(SignaturePrefix))
+	copy(templated[len(SignaturePrefix):], data)
+	var md hash.Hash
+	switch curvename {
+	case P384ECDSA:
+		md = sha512.New384()
+		alg = "sha384"
+	case P521ECDSA:
+		md = sha512.New()
+		alg = "sha512"
+	default:
+		md = sha256.New()
+		alg = "sha256"
+	}
+	md.Write(templated)
+	return alg, md.Sum(nil)
 }
 
 // Unmarshal parses a base64 url encoded content signature
@@ -153,80 +152,91 @@ func makeTemplatedHash(data []byte, curvename string) (alg string, out []byte) {
 //
 // Note this function does not set the X5U value of a signature.
 func Unmarshal(signature string) (sig *ContentSignature) {
-  logger := log.New(&CLogger{level: 0}, "", 0)
+	logger := log.New(&CLogger{level: 0}, "", 0)
 
-  if len(signature) < 30 {
-    logger.Println("contentsignature: signature cannot be shorter than 30 characters, got %d", len(signature))
-    return nil
-  }
+	if len(signature) < 30 {
+		logger.Println("contentsignature: signature cannot be shorter than 30 characters, got %d", len(signature))
+		return nil
+	}
 
-  // decode the actual signature into its R and S values
-  data, err := base64.RawURLEncoding.DecodeString(signature)
-  if err != nil {
-    logger.Println("decode string failed")
-    return nil
-  }
+	// decode the actual signature into its R and S values
+	data, err := base64.RawURLEncoding.DecodeString(signature)
+	if err != nil {
+		logger.Println("decode string failed")
+		return nil
+	}
 
-  // Use the length to determine the mode
-  sig = new(ContentSignature)
-  sig.Len = len(data)
-  switch sig.Len {
-  case P256ECDSABYTESIZE:
-    sig.Mode = P256ECDSA
-  case P384ECDSABYTESIZE:
-    sig.Mode = P384ECDSA
-  case P521ECDSABYTESIZE:
-    sig.Mode = P521ECDSA
-  default:
-    logger.Println("contentsignature: unknown signature length %d", len(data))
-    return nil
-  }
+	// Use the length to determine the mode
+	sig = new(ContentSignature)
+	sig.Len = len(data)
+	switch sig.Len {
+	case P256ECDSABYTESIZE:
+		sig.Mode = P256ECDSA
+	case P384ECDSABYTESIZE:
+		sig.Mode = P384ECDSA
+	case P521ECDSABYTESIZE:
+		sig.Mode = P521ECDSA
+	default:
+		logger.Println("contentsignature: unknown signature length %d", len(data))
+		return nil
+	}
 
-  sig.HashName = getSignatureHash(sig.Mode)
-  // parse the signature into R and S value by splitting it in the middle
-  sig.R, sig.S = new(big.Int), new(big.Int)
-  sig.R.SetBytes(data[:len(data)/2])
-  sig.S.SetBytes(data[len(data)/2:])
-  sig.Finished = true
-  return sig
+	sig.HashName = getSignatureHash(sig.Mode)
+	// parse the signature into R and S value by splitting it in the middle
+	sig.R, sig.S = new(big.Int), new(big.Int)
+	sig.R.SetBytes(data[:len(data)/2])
+	sig.S.SetBytes(data[len(data)/2:])
+	sig.Finished = true
+	return sig
 }
 
 //export balrogSetLogger
 func balrogSetLogger(loggerFn uintptr) {
-  loggerFunc = unsafe.Pointer(loggerFn)
+	loggerFunc = unsafe.Pointer(loggerFn)
 }
+
+//
+// NEW METHOD SIGNATURE - balrogValidate(x5uDataGo, updateDataGo, signatureGo, certSubjectGo);
+// - parse x5uData
+// - validate chain
+// - validate root (with root cert fingerprint?)
+// - validate leaf (with certSubject)
+// - get publickey from leaf
+// - validate updateData (aka input) with publickey and signature
+//
+//
 
 //export balrogValidateSignature
 func balrogValidateSignature(publicKey string, signature string, input string) bool {
-  logger := log.New(&CLogger{level: 0}, "", 0)
+	logger := log.New(&CLogger{level: 0}, "", 0)
 
-  cs := Unmarshal(signature)
-  if cs == nil {
-    logger.Println("Unmarshal failed")
-    return false
-  }
+	cs := Unmarshal(signature)
+	if cs == nil {
+		logger.Println("Unmarshal failed")
+		return false
+	}
 
-  block, _ := pem.Decode([]byte(publicKey))
-  if block == nil {
-    logger.Println("Invalid PEM public key format")
-    return false
-  }
+	block, _ := pem.Decode([]byte(publicKey))
+	if block == nil {
+		logger.Println("Invalid PEM public key format")
+		return false
+	}
 
-  keyInterface, err := x509.ParsePKIXPublicKey(block.Bytes)
-  if err != nil {
-    logger.Println("Failed to parse public key DIR:", err)
-    return false
-  }
-  pubkey := keyInterface.(*ecdsa.PublicKey)
+	keyInterface, err := x509.ParsePKIXPublicKey(block.Bytes)
+	if err != nil {
+		logger.Println("Failed to parse public key DIR:", err)
+		return false
+	}
+	pubkey := keyInterface.(*ecdsa.PublicKey)
 
-  // verify signature on input data
-  if !cs.VerifyData([]byte(input), pubkey) {
-    logger.Println("Failed to verify content signature")
-    return false
-  }
+	// verify signature on input data
+	if !cs.VerifyData([]byte(input), pubkey) {
+		logger.Println("Failed to verify content signature")
+		return false
+	}
 
-  logger.Println("Verified")
-  return true
+	logger.Println("Verified")
+	return true
 }
 
 func main() {}

--- a/balrog/api.go
+++ b/balrog/api.go
@@ -13,17 +13,11 @@ package main
 import "C"
 
 import (
-	"crypto/ecdsa"
-	"crypto/sha256"
-	"crypto/sha512"
-	"crypto/x509"
-	"encoding/base64"
-	"encoding/pem"
 	"errors"
-	"hash"
 	"log"
-	"math/big"
 	"unsafe"
+
+	"github.com/mozilla-services/autograph/verifier/contentsignature"
 )
 
 var loggerFunc unsafe.Pointer
@@ -34,165 +28,12 @@ type CLogger struct {
 
 func (l *CLogger) Write(p []byte) (int, error) {
 	if uintptr(loggerFunc) == 0 {
-		return 0, errors.New("No logger initialized")
+		return 0, errors.New("no logger initialized")
 	}
 	message := C.CString(string(p))
 	C.callLogger(loggerFunc, l.level, message)
 	C.free(unsafe.Pointer(message))
 	return len(p), nil
-}
-
-// ContentSignature contains the parsed representation of a signature
-type ContentSignature struct {
-	R, S     *big.Int // fields must be exported for ASN.1 marshalling
-	HashName string
-	Mode     string
-	X5U      string
-	ID       string
-	Len      int
-	Finished bool
-}
-
-const (
-	// Type of this signer is 'contentsignature'
-	Type = "contentsignature"
-
-	// P256ECDSA defines an ecdsa content signature on the P-256 curve
-	P256ECDSA = "p256ecdsa"
-
-	// P256ECDSABYTESIZE defines the bytes length of a P256ECDSA signature
-	P256ECDSABYTESIZE = 64
-
-	// P384ECDSA defines an ecdsa content signature on the P-384 curve
-	P384ECDSA = "p384ecdsa"
-
-	// P384ECDSABYTESIZE defines the bytes length of a P384ECDSA signature
-	P384ECDSABYTESIZE = 96
-
-	// P521ECDSA defines an ecdsa content signature on the P-521 curve
-	P521ECDSA = "p521ecdsa"
-
-	// P521ECDSABYTESIZE defines the bytes length of a P521ECDSA signature
-	P521ECDSABYTESIZE = 132
-
-	// SignaturePrefix is a string preprended to data prior to signing
-	SignaturePrefix = "Content-Signature:\x00"
-)
-
-// getSignatureLen returns the size of an ECDSA signature issued by the signer,
-// or -1 if the mode is unknown
-//
-// The signature length is double the size size of the curve field, in bytes
-// (each R and S value is equal to the size of the curve field).
-// If the curve field it not a multiple of 8, round to the upper multiple of 8.
-func getSignatureLen(mode string) int {
-	switch mode {
-	case P256ECDSA:
-		return P256ECDSABYTESIZE
-	case P384ECDSA:
-		return P384ECDSABYTESIZE
-	case P521ECDSA:
-		return P521ECDSABYTESIZE
-	}
-	return -1
-}
-
-// getSignatureHash returns the name of the hash function used by a given mode,
-// or an empty string if the mode is unknown
-func getSignatureHash(mode string) string {
-	switch mode {
-	case P256ECDSA:
-		return "sha256"
-	case P384ECDSA:
-		return "sha384"
-	case P521ECDSA:
-		return "sha512"
-	}
-	return ""
-}
-
-// VerifyData verifies a signatures on its raw, untemplated, input using a public key
-func (sig *ContentSignature) VerifyData(input []byte, pubKey *ecdsa.PublicKey) bool {
-	_, hash := makeTemplatedHash(input, sig.Mode)
-	return sig.VerifyHash(hash, pubKey)
-}
-
-// VerifyHash verifies a signature on its templated hash using a public key
-func (sig *ContentSignature) VerifyHash(hash []byte, pubKey *ecdsa.PublicKey) bool {
-	return ecdsa.Verify(pubKey, hash, sig.R, sig.S)
-}
-
-// hash returns the templated sha384 of the input data. The template adds
-// the string "Content-Signature:\x00" before the input data prior to
-// calculating the sha384.
-//
-// The name of the hash function is returned, followed by the hash bytes
-func makeTemplatedHash(data []byte, curvename string) (alg string, out []byte) {
-	templated := make([]byte, len(SignaturePrefix)+len(data))
-	copy(templated[:len(SignaturePrefix)], []byte(SignaturePrefix))
-	copy(templated[len(SignaturePrefix):], data)
-	var md hash.Hash
-	switch curvename {
-	case P384ECDSA:
-		md = sha512.New384()
-		alg = "sha384"
-	case P521ECDSA:
-		md = sha512.New()
-		alg = "sha512"
-	default:
-		md = sha256.New()
-		alg = "sha256"
-	}
-	md.Write(templated)
-	return alg, md.Sum(nil)
-}
-
-// Unmarshal parses a base64 url encoded content signature
-// and returns it into a ContentSignature structure that can be verified.
-//
-// Note this function does not set the X5U value of a signature.
-func Unmarshal(signature string) (sig *ContentSignature) {
-	logger := log.New(&CLogger{level: 0}, "", 0)
-
-	if len(signature) < 30 {
-		logger.Println("contentsignature: signature cannot be shorter than 30 characters, got %d", len(signature))
-		return nil
-	}
-
-	// decode the actual signature into its R and S values
-	data, err := base64.RawURLEncoding.DecodeString(signature)
-	if err != nil {
-		logger.Println("decode string failed")
-		return nil
-	}
-
-	// Use the length to determine the mode
-	sig = new(ContentSignature)
-	sig.Len = len(data)
-	switch sig.Len {
-	case P256ECDSABYTESIZE:
-		sig.Mode = P256ECDSA
-	case P384ECDSABYTESIZE:
-		sig.Mode = P384ECDSA
-	case P521ECDSABYTESIZE:
-		sig.Mode = P521ECDSA
-	default:
-		logger.Println("contentsignature: unknown signature length %d", len(data))
-		return nil
-	}
-
-	sig.HashName = getSignatureHash(sig.Mode)
-	// parse the signature into R and S value by splitting it in the middle
-	sig.R, sig.S = new(big.Int), new(big.Int)
-	sig.R.SetBytes(data[:len(data)/2])
-	sig.S.SetBytes(data[len(data)/2:])
-	sig.Finished = true
-	return sig
-}
-
-//export balrogSetLogger
-func balrogSetLogger(loggerFn uintptr) {
-	loggerFunc = unsafe.Pointer(loggerFn)
 }
 
 //
@@ -205,37 +46,15 @@ func balrogSetLogger(loggerFn uintptr) {
 // - validate updateData (aka input) with publickey and signature
 //
 //
-
-//export balrogValidateSignature
-func balrogValidateSignature(publicKey string, signature string, input string) bool {
-	logger := log.New(&CLogger{level: 0}, "", 0)
-
-	cs := Unmarshal(signature)
-	if cs == nil {
-		logger.Println("Unmarshal failed")
-		return false
-	}
-
-	block, _ := pem.Decode([]byte(publicKey))
-	if block == nil {
-		logger.Println("Invalid PEM public key format")
-		return false
-	}
-
-	keyInterface, err := x509.ParsePKIXPublicKey(block.Bytes)
+func balrogValidate(x5u string, input string, signature string, certSubject string) bool {
+	rootHash := "rootHash"
+	certChain := "certChain"
+	err := contentsignature.Verify([]byte(input), []byte(certChain), signature, rootHash)
 	if err != nil {
-		logger.Println("Failed to parse public key DIR:", err)
+		logger := log.New(&CLogger{level: 0}, "", 0)
+		logger.Println("Verification failed with error:", err.Error())
 		return false
 	}
-	pubkey := keyInterface.(*ecdsa.PublicKey)
-
-	// verify signature on input data
-	if !cs.VerifyData([]byte(input), pubkey) {
-		logger.Println("Failed to verify content signature")
-		return false
-	}
-
-	logger.Println("Verified")
 	return true
 }
 

--- a/balrog/go.mod
+++ b/balrog/go.mod
@@ -1,3 +1,5 @@
 module balrog
 
 go 1.16
+
+require github.com/mozilla-services/autograph/verifier/contentsignature v0.0.0-20210505200649-cb56f0dcbdd1 // indirect

--- a/balrog/go.mod
+++ b/balrog/go.mod
@@ -1,0 +1,3 @@
+module balrog
+
+go 1.16

--- a/balrog/go.mod
+++ b/balrog/go.mod
@@ -2,4 +2,4 @@ module balrog
 
 go 1.16
 
-require github.com/mozilla-services/autograph/verifier/contentsignature v0.0.0-20210505200649-cb56f0dcbdd1 // indirect
+require github.com/mozilla-services/autograph/verifier/contentsignature v0.0.0-20210505200649-cb56f0dcbdd1

--- a/balrog/go.sum
+++ b/balrog/go.sum
@@ -1,0 +1,3 @@
+github.com/mozilla-services/autograph v0.0.0-20210505200649-cb56f0dcbdd1 h1:ptnkDFsc8xf5bLDu3BPCYw1mfmcLJz/Sw6m00IeIVWI=
+github.com/mozilla-services/autograph/verifier/contentsignature v0.0.0-20210505200649-cb56f0dcbdd1 h1:POnrn8x0qEBOx0R0nqr5WYdhQW8GejkE/H56HTRsVZ8=
+github.com/mozilla-services/autograph/verifier/contentsignature v0.0.0-20210505200649-cb56f0dcbdd1/go.mod h1:Za7D7eunll59848s0oJ43o0wE/J38/8q7mTl4A9J73I=

--- a/src/update/balrog.cpp
+++ b/src/update/balrog.cpp
@@ -252,6 +252,7 @@ bool Balrog::validateSignature(const QByteArray& x5uData,
                           (size_t)updateDataCopy.length()};
 
   QByteArray rootHashCopy = Constants::BALROG_ROOT_CERT_FINGERPRINT;
+  rootHashCopy = rootHashCopy.toUpper();
   gostring_t rootHashGo{rootHashCopy.constData(),
                         (size_t)rootHashCopy.length()};
 

--- a/src/update/balrog.cpp
+++ b/src/update/balrog.cpp
@@ -122,7 +122,7 @@ void Balrog::start() {
 }
 
 bool Balrog::fetchSignature(NetworkRequest* initialRequest,
-                            const QByteArray& dataUpdate) {
+                            const QByteArray& updateData) {
   Q_ASSERT(initialRequest);
 
   QByteArray header = initialRequest->rawHeader("Content-Signature");
@@ -133,7 +133,6 @@ bool Balrog::fetchSignature(NetworkRequest* initialRequest,
 
   QByteArray x5u;
   QByteArray signatureBlob;
-  QCryptographicHash::Algorithm algorithm = QCryptographicHash::Sha256;
 
   for (const QByteArray& item : header.split(';')) {
     QByteArray entry = item.trimmed();
@@ -146,24 +145,17 @@ bool Balrog::fetchSignature(NetworkRequest* initialRequest,
     QByteArray key = entry.left(pos);
     if (key == "x5u") {
       x5u = entry.remove(0, pos + 1);
-    } else if (key == "p384ecdsa") {
-      algorithm = QCryptographicHash::Sha384;
-      signatureBlob = entry.remove(0, pos + 1);
-    } else if (key == "p256ecdsa") {
-      algorithm = QCryptographicHash::Sha256;
-      signatureBlob = entry.remove(0, pos + 1);
-    } else if (key == "p521ecdsa") {
-      algorithm = QCryptographicHash::Sha512;
+    } else {
       signatureBlob = entry.remove(0, pos + 1);
     }
   }
 
   if (x5u.isEmpty() || signatureBlob.isEmpty()) {
-    logger.log() << "No p256ecdsa/p384ecdsa or x5u found";
+    logger.log() << "No signatureBlob or x5u found";
     return false;
   }
 
-  logger.log() << "Fetching URL:" << x5u;
+  logger.log() << "Fetching x5u URL:" << x5u;
 
   NetworkRequest* x5uRequest = NetworkRequest::createForGetUrl(this, x5u, 200);
 
@@ -174,9 +166,9 @@ bool Balrog::fetchSignature(NetworkRequest* initialRequest,
           });
 
   connect(x5uRequest, &NetworkRequest::requestCompleted,
-          [this, signatureBlob, algorithm, dataUpdate](const QByteArray& data) {
+          [this, signatureBlob, updateData](const QByteArray& x5uData) {
             logger.log() << "Request completed";
-            if (!checkSignature(data, signatureBlob, algorithm, dataUpdate)) {
+            if (!checkSignature(x5uData, updateData, signatureBlob)) {
               deleteLater();
             }
           });
@@ -184,77 +176,12 @@ bool Balrog::fetchSignature(NetworkRequest* initialRequest,
   return true;
 }
 
-bool Balrog::checkSignature(const QByteArray& signature,
-                            const QByteArray& signatureBlob,
-                            QCryptographicHash::Algorithm algorithm,
-                            const QByteArray& data) {
+bool Balrog::checkSignature(const QByteArray& x5uData,
+                            const QByteArray& updateData,
+                            const QByteArray& signatureBlob) {
   logger.log() << "Checking the signature";
-  QList<QSslCertificate> list;
-  QByteArray cert;
-  for (const QByteArray& line : signature.split('\n')) {
-    cert.append(line);
-    cert.append('\n');
 
-    if (line != "-----END CERTIFICATE-----") {
-      continue;
-    }
-
-    QSslCertificate ssl(cert, QSsl::Pem);
-    if (ssl.isNull()) {
-      logger.log() << "Invalid certificate" << cert;
-      return false;
-    }
-
-    list.append(ssl);
-    cert.clear();
-  }
-
-  if (list.isEmpty()) {
-    logger.log() << "No certificates found";
-    return false;
-  }
-
-  logger.log() << "Found certificates:" << list.length();
-
-  // TODO: do we care about OID extensions?
-
-  // Qt5.15 doesn't implement the certificate validation (yet?)
-#ifndef MVPN_MACOS
-  QList<QSslError> errors = QSslCertificate::verify(list);
-  for (const QSslError& error : errors) {
-    if (error.error() != QSslError::SelfSignedCertificateInChain) {
-      logger.log() << "Chain validation failed:" << error.errorString();
-      return false;
-    }
-  }
-#endif
-
-  logger.log() << "Validating root certificate";
-  const QSslCertificate& rootCert = list.constLast();
-  QByteArray rootCertHash = rootCert.digest(QCryptographicHash::Sha256).toHex();
-  if (rootCertHash != Constants::BALROG_ROOT_CERT_FINGERPRINT) {
-    logger.log() << "Invalid root certificate fingerprint" << rootCertHash;
-    return false;
-  }
-
-  const QSslCertificate& leaf = list.constFirst();
-  logger.log() << "Validating cert subject";
-  QStringList cnList = leaf.subjectInfo("CN");
-  if (cnList.isEmpty() || cnList[0] != BALROG_CERT_SUBJECT_CN) {
-    logger.log() << "Invalid CN:" << cnList;
-    return false;
-  }
-
-  logger.log() << "Validate public key";
-  QSslKey leafPublicKey = leaf.publicKey();
-  if (leafPublicKey.isNull()) {
-    logger.log() << "Empty public key";
-    return false;
-  }
-
-  logger.log() << "Validate the signature";
-  if (!validateSignature(leafPublicKey.toPem(), data, algorithm,
-                         signatureBlob)) {
+  if (!validateX5u(x5uData, updateData, signatureBlob)) {
     logger.log() << "Invalid signature";
     return false;
   }
@@ -268,13 +195,9 @@ bool Balrog::checkSignature(const QByteArray& signature,
   return true;
 }
 
-bool Balrog::validateSignature(const QByteArray& publicKey,
-                               const QByteArray& data,
-                               QCryptographicHash::Algorithm algorithm,
-                               const QByteArray& signature) {
-  // The algortihm is detected by the length of the signature
-  Q_UNUSED(algorithm);
-
+bool Balrog::validateSignature(const QByteArray& x5uData,
+                               const QByteArray& updateData,
+                               const QByteArray& signatureBlob) {
 #if defined(MVPN_WINDOWS)
   static HMODULE balrogDll = nullptr;
   static BalrogSetLogger* balrogSetLogger = nullptr;
@@ -312,19 +235,23 @@ bool Balrog::validateSignature(const QByteArray& publicKey,
 
   balrogSetLogger(balrogLogger);
 
-  QByteArray publicKeyCopy = publicKey;
-  gostring_t publicKeyGo{publicKeyCopy.constData(),
-                         (size_t)publicKeyCopy.length()};
+  QByteArray x5uDataCopy = x5uData;
+  gostring_t x5uDataGo{x5uDataCopy.constData(), (size_t)x5uDataCopy.length()};
 
-  QByteArray signatureCopy = signature;
+  QByteArray signatureCopy = signatureBlob;
   gostring_t signatureGo{signatureCopy.constData(),
                          (size_t)signatureCopy.length()};
 
-  QByteArray dataCopy = data;
-  gostring_t dataGo{dataCopy.constData(), (size_t)dataCopy.length()};
+  QByteArray updateDataCopy = updateData;
+  gostring_t updateDataGo{updateDataCopy.constData(),
+                          (size_t)updateDataCopy.length()};
+
+  QByteArray certSubjectCopy = BALROG_CERT_SUBJECT_CN;
+  gostring_t certSubjectGo{certSubjectCopy.constData(),
+                           (size_t)certSubjectCopy.length()};
 
   unsigned char verify =
-      balrogValidateSignature(publicKeyGo, signatureGo, dataGo);
+      balrogValidate(x5uDataGo, updateDataGo, signatureGo, certSubjectGo);
   if (!verify) {
     logger.log() << "Verification failed";
     return false;

--- a/src/update/balrog.cpp
+++ b/src/update/balrog.cpp
@@ -34,22 +34,17 @@ typedef void (*logFunc)(int level, const char* msg);
 constexpr const char* BALROG_WINDOWS_UA = "WINNT_x86_64";
 
 typedef void BalrogSetLogger(logFunc func);
-typedef unsigned char BalrogValidate(gostring_t x5uData,
-                                     gostring_t updateData,
-                                     gostring_t signature,
-                                     gostring_t rootHash,
+typedef unsigned char BalrogValidate(gostring_t x5uData, gostring_t updateData,
+                                     gostring_t signature, gostring_t rootHash,
                                      gostring_t leafCertSubject);
-
 
 #elif defined(MVPN_MACOS)
 #  define EXPORT __attribute__((visibility("default")))
 
 extern "C" {
 EXPORT void balrogSetLogger(logFunc func);
-EXPORT unsigned char balrogValidate(gostring_t x5uData,
-                                    gostring_t updateData,
-                                    gostring_t signature,
-                                    gostring_t rootHash,
+EXPORT unsigned char balrogValidate(gostring_t x5uData, gostring_t updateData,
+                                    gostring_t signature, gostring_t rootHash,
                                     gostring_t leafCertSubject);
 }
 
@@ -228,11 +223,10 @@ bool Balrog::validateSignature(const QByteArray& x5uData,
   }
 
   if (!balrogValidate) {
-    balrogValidate = (BalrogValidate*)GetProcAddress(
-        balrogDll, "balrogValidate");
+    balrogValidate =
+        (BalrogValidate*)GetProcAddress(balrogDll, "balrogValidate");
     if (!balrogValidate) {
-      WindowsCommons::windowsLog(
-          "Failed to get balrogValidate function");
+      WindowsCommons::windowsLog("Failed to get balrogValidate function");
       return false;
     }
   }

--- a/src/update/balrog.h
+++ b/src/update/balrog.h
@@ -27,13 +27,11 @@ class Balrog final : public Updater {
 
   bool processData(const QByteArray& data);
   bool fetchSignature(NetworkRequest* request, const QByteArray& data);
-  bool checkSignature(const QByteArray& signature,
-                      const QByteArray& signatureBlob,
-                      QCryptographicHash::Algorithm algorithm,
-                      const QByteArray& data);
-  bool validateSignature(const QByteArray& publicKey, const QByteArray& data,
-                         QCryptographicHash::Algorithm algorithm,
-                         const QByteArray& signature);
+  bool checkSignature(const QByteArray& x5uData, const QByteArray& updateData,
+                      const QByteArray& signatureBlob);
+  bool validateSignature(const QByteArray& x5uData,
+                         const QByteArray& updateData,
+                         const QByteArray& signatureBlob);
   bool computeHash(const QString& url, const QByteArray& data,
                    const QString& hashValue, const QString& hashFunction);
   bool saveFileAndInstall(const QString& url, const QByteArray& data);


### PR DESCRIPTION
Fixes #797, #798

Instead of rolling our own, we use the new verify module of the mozilla go package autograph (https://github.com/mozilla-services/autograph/).

This allows for simplification of both the api.go code and the update/balrog.cpp. 

In addition, we also resolve the FVP-02-002 and FVP-02-003.

Note, we have verified that balrog algorithm is p384ecdsa which is supported by autograph module.

Thanks to @g-k for splitting out the verify module.