### PR TITLE
Fix script name typo in initialization section

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Finally, **add `$(pwd)/qt/qt/bin` to `PATH`.**
 git submodule init
 git submodule update
 # glean
-./scripts/generate_clean.py
+./scripts/generate_glean.py
 # translations
 python scripts/importLanguages.py
 ```


### PR DESCRIPTION
When compiling `mozilla-vpn-client` from source I noticed there is a small typo in the README.md or `scripts/generate_glean.py` was renamed recently.