### PR TITLE
Debounce Captive Portal Notification

### DIFF
--- a/src/captiveportal/captiveportaldetection.cpp
+++ b/src/captiveportal/captiveportaldetection.cpp
@@ -13,7 +13,6 @@
 #include "mozillavpn.h"
 #include "settingsholder.h"
 
-
 namespace {
 Logger logger(LOG_CAPTIVEPORTAL, "CaptivePortalDetection");
 }
@@ -45,6 +44,14 @@ void CaptivePortalDetection::stateChanged() {
       vpn->controller()->state() != Controller::StateConfirming) {
     logger.log() << "No captive portal detection required";
     m_impl.reset();
+    // Since we now reached a stable state, on the next time we have an
+    // instablity check for portal again.
+    m_shouldRun = true;
+    return;
+  }
+  if (!m_shouldRun) {
+    logger.log() << "Captive Portal detection was already done for this "
+                    "instability, skipping.";
     return;
   }
 
@@ -103,6 +110,7 @@ void CaptivePortalDetection::detectionCompleted(CaptivePortalResult detected) {
   logger.log() << "Detection completed:" << detected;
 
   m_impl.reset();
+  m_shouldRun = false;
   switch (detected) {
     case CaptivePortalResult::NoPortal:
     case CaptivePortalResult::Failure:

--- a/src/captiveportal/captiveportaldetection.h
+++ b/src/captiveportal/captiveportaldetection.h
@@ -41,6 +41,7 @@ class CaptivePortalDetection final : public QObject {
 
  private:
   bool m_active = false;
+  bool m_shouldRun = true;
 
   // Don't use it directly. Use captivePortalMonitor().
   CaptivePortalMonitor* m_captivePortalMonitor = nullptr;

--- a/src/connectionhealth.cpp
+++ b/src/connectionhealth.cpp
@@ -108,6 +108,10 @@ void ConnectionHealth::noSignalDetected() {
 }
 
 void ConnectionHealth::applicationStateChanged(Qt::ApplicationState state) {
+#if defined(MVPN_WINDOWS) || defined(MVPN_LINUX) || defined(MVPN_MACOS)
+  // Do not suspend PingsendHelper on Desktop.
+  return;
+#else
   switch (state) {
     case Qt::ApplicationState::ApplicationActive:
       if (m_suspended) {
@@ -127,4 +131,5 @@ void ConnectionHealth::applicationStateChanged(Qt::ApplicationState state) {
       stop();
       break;
   }
+#endif 
 }


### PR DESCRIPTION
2 Bugs here to solve. 

On desktop when the window loses focus, we suspend ping-send worker. This thus we set stability to "stable".
This means when the user connects to a cp-wifi while the app is in the background, we would not start detection. 

Also i limit the amound of Captive Portal requests to only one after we're no longer stable. 
Reason here beeing, connection health might move from stable->instable->noSignal causing 2 cp detections and  2 notifications.
We would need to go to "stable" once again to trigger a new one. 