### PR TITLE
Remove Unresolved CaptivePortal Todo code 

### DIFF
--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -550,15 +550,6 @@ QList<IPAddressRange> Controller::getAllowedIPAddressRanges(
       logger.log() << "Filtering out the captive portal address" << address;
       excludeIPv4s.append(IPAddress::create(address));
     }
-
-    if (ipv6Enabled) {
-      const QStringList& captivePortalIpv6Addresses =
-          captivePortal->ipv6Addresses();
-      for (const QString& address : captivePortalIpv6Addresses) {
-        // TODO IPv6 is not supported by IPAddress yet.
-        allowedIPv6s.append(IPAddressRange(address, 0, IPAddressRange::IPv6));
-      }
-    }
   }
 
   // filtering out the RFC1918 local area network


### PR DESCRIPTION
Since we have #593 still open, we have no code to filter a certain v6 adress out. 
So currently instead we add "[cp-address-v6]/0" to the allowed ipv6 adress ranges, which is not correct.
So i think we should remove this todo for now :) 
