### PR TITLE
Sort application list by name

### DIFF
--- a/src/apppermission.cpp
+++ b/src/apppermission.cpp
@@ -95,7 +95,7 @@ Q_INVOKABLE void AppPermission::flip(const QString& appID) {
     settingsHolder->addVpnDisabledApp(appID);
   }
 
-  int index = m_applist.indexOf(AppDescription(appID, "Test"));
+  int index = m_applist.indexOf(AppDescription(appID));
   dataChanged(createIndex(index, 0), createIndex(index, 0));
 }
 

--- a/src/apppermission.h
+++ b/src/apppermission.h
@@ -6,6 +6,7 @@
 #define APPPERMISSION_H
 
 #include <QObject>
+#include <QPair>
 #include <QSortFilterProxyModel>
 #include <QAbstractListModel>
 #include "applistprovider.h"
@@ -24,6 +25,27 @@ class AppPermission final : public QAbstractListModel {
     AppNameRole,
     AppIdRole,
     AppEnabledRole,
+  };
+
+  class AppDescription {
+   public:
+    AppDescription(const QString& appId, const QString& appName) {
+      name = appName;
+      id = appId;
+    };
+    QString name;
+    QString id;
+
+    bool operator<(const AppDescription& other) const {
+      return name.compare(other.name, Qt::CaseInsensitive) < 0;
+    }
+    bool operator>(const AppDescription& other) const {
+      return name.compare(other.name, Qt::CaseInsensitive) > 0;
+    }
+    bool operator==(const AppDescription& other) const {
+      return id == other.id;
+    }
+    bool operator==(const QString& appId) const { return id == appId; }
   };
 
   static AppPermission* instance();
@@ -52,7 +74,7 @@ class AppPermission final : public QAbstractListModel {
  private:
   AppPermission(QObject* parent);
   AppListProvider* m_listprovider = nullptr;
-  QMap<QString, QString> m_applist;
+  QList<AppDescription> m_applist;
 
   // Sublist of AppPermission, can either include all Enabled or Disabled apps
   class FilteredAppList : public QSortFilterProxyModel {

--- a/src/apppermission.h
+++ b/src/apppermission.h
@@ -29,7 +29,7 @@ class AppPermission final : public QAbstractListModel {
 
   class AppDescription {
    public:
-    AppDescription(const QString& appId, const QString& appName) {
+    AppDescription(const QString& appId, const QString& appName = "") {
       name = appName;
       id = appId;
     };


### PR DESCRIPTION
In the App Permissions window, it's a little easier to find applications if they are sorted by name instead of application ID.

This would be a fix for #939 