### PR TITLE
Add status page message.

### DIFF
--- a/src/ui/states/StateBackendFailure.qml
+++ b/src/ui/states/StateBackendFailure.qml
@@ -24,6 +24,9 @@ VPNStackView {
             //% "Unable to establish a connection at this time. We’re working hard to resolve the issue. Please try again shortly."
             errorMessage: qsTrId("vpn.errors.unableToEstablishConnection"),
 
+            //% "Check for outage updates on our <a href='https://vpn.status.mozilla.org'>status page</a>."
+            errorMessage2: qsTrId("vpn.errors.seeStatusPage"),
+
             //% "Try Again"
             buttonText: qsTrId("vpn.errors.tryAgain"),
 

--- a/src/ui/states/StateBackendFailure.qml
+++ b/src/ui/states/StateBackendFailure.qml
@@ -24,16 +24,14 @@ VPNStackView {
             //% "Unable to establish a connection at this time. We’re working hard to resolve the issue. Please try again shortly."
             errorMessage: qsTrId("vpn.errors.unableToEstablishConnection"),
 
-            //% "Check for outage updates on our <a href='https://vpn.status.mozilla.org'>status page</a>."
-            errorMessage2: qsTrId("vpn.errors.seeStatusPage"),
-
             //% "Try Again"
             buttonText: qsTrId("vpn.errors.tryAgain"),
 
             buttonObjectName: "heartbeatTryButton",
             buttonOnClick: stackview.handleButtonClick,
             signOffLinkVisible: false,
-            getHelpLinkVisible: true
+            getHelpLinkVisible: true,
+            statusLinkVisible: true
         }
     )
 }

--- a/src/ui/views/ViewErrorFullScreen.qml
+++ b/src/ui/views/ViewErrorFullScreen.qml
@@ -17,17 +17,36 @@ VPNFlickable {
     property var buttonOnClick
     property var signOffLinkVisible: false
     property var getHelpLinkVisible: false
+    property var statusLinkVisible: false
     id: vpnFlickable
 
     Component.onCompleted: {
-        flickContentHeight = col.childrenRect.height + col.anchors.topMargin
+        flickContentHeight = col.childrenRect.height
+    }
+
+    VPNHeaderLink {
+        id: headerLink
+        objectName: "getHelpLink"
+
+        labelText: qsTrId("vpn.main.getHelp")
+        onClicked: stackview.push(getHelpComponent)
+    }
+
+    Component {
+        id: getHelpComponent
+
+        VPNGetHelp {
+            isSettingsView: false
+        }
+
     }
 
     ColumnLayout {
         id: col
-        width: vpnFlickable.width
+        width: Math.min(Theme.maxHorizontalContentWidth, vpnFlickable.width)
         anchors.top: parent.top
-        anchors.topMargin: vpnFlickable.height * 0.08
+        anchors.topMargin: headerLink.height + vpnFlickable.height * 0.08
+        anchors.bottom: parent.bottom
         anchors.horizontalCenter: parent.horizontalCenter
         spacing: 32
 
@@ -71,7 +90,7 @@ VPNFlickable {
                 Layout.alignment: Qt.AlignHCenter
                 VPNTextBlock {
                     id: copyBlock1
-                    Layout.preferredWidth: Theme.maxTextWidth
+                    Layout.preferredWidth: col.width - (Theme.windowMargin * 3)
                     Layout.preferredHeight: paintedHeight
                     Layout.alignment: Qt.AlignHCenter
                     horizontalAlignment: Text.AlignHCenter
@@ -83,13 +102,22 @@ VPNFlickable {
                 VPNTextBlock {
                     id: copyBlock2
 
-                    Layout.preferredWidth: Theme.maxTextWidth
+                    Layout.preferredWidth: col.width - (Theme.windowMargin * 3)
                     horizontalAlignment: Text.AlignHCenter
                     Layout.preferredHeight: paintedHeight
                     Layout.alignment: Qt.AlignHCenter
                     font.pixelSize: Theme.fontSize
                     lineHeight: 22
                     text: errorMessage2
+                }
+
+                VPNLinkButton {
+                    //% "Check outage updates"
+                    labelText: qsTrId("vpn.errors.checkOutageUpdates")
+                    Layout.preferredWidth: col.width - (Theme.windowMargin * 3)
+                    onClicked: VPN.openLink("https://status.vpn.mozilla.org")
+                    Layout.alignment: Qt.AlignHCenter
+                    visible: statusLinkVisible
                 }
             }
         }
@@ -111,18 +139,6 @@ VPNFlickable {
                 onClicked: buttonOnClick()
             }
 
-            VPNFooterLink {
-                id: getHelpLink
-
-                visible: getHelpLinkVisible
-                Layout.preferredHeight: Theme.rowHeight
-                Layout.alignment: Qt.AlignHCenter
-                labelText: qsTrId("vpn.main.getHelp")
-                anchors.horizontalCenter: undefined
-                anchors.bottom: undefined
-                anchors.bottomMargin: undefined
-                onClicked: stackview.push(getHelpComponent)
-            }
 
             VPNSignOut {
                 id: signOff
@@ -140,16 +156,9 @@ VPNFlickable {
             }
         }
 
-        Component {
-            id: getHelpComponent
-
-            VPNGetHelp {
-                isSettingsView: false
-            }
-        }
 
         VPNVerticalSpacer {
-            Layout.preferredHeight: Theme.windowMargin * 2
+            Layout.preferredHeight: fullscreenRequired() ? Theme.windowMargin : 1
         }
     }
 }


### PR DESCRIPTION
Fixes #834

ToDos:
- add string to ftl file
- get @lesleyjanenorton input on how to make this clickable to open a web page
- @chrisrooneys this is the string i need a copy review on "Check for outage updates on our <a href='https://vpn.status.mozilla.org'>status page</a>." Clicking on the link will take you to a page that looks like https://status.mozilla.org/ but tailored for VPN.

Before:
<img width=200 src="https://user-images.githubusercontent.com/1796208/118163650-d65a6e00-b3e7-11eb-8b4f-541b9494168a.png">


After:
<img width=200 src="https://user-images.githubusercontent.com/1796208/118163523-b1fe9180-b3e7-11eb-8996-5deea8a4993a.png">

