### PR TITLE
Fix #780 - Confusing sign out language

### DIFF
--- a/src/ui/components/VPNSystemAlert.qml
+++ b/src/ui/components/VPNSystemAlert.qml
@@ -5,11 +5,13 @@
 import QtQuick 2.0
 import QtQuick.Controls 2.5
 import Mozilla.VPN 1.0
+import "../themes/themes.js" as Theme
 
 VPNAlert {
     id: alertBox
 
     state: VPN.alert
+
     states: [
         State {
             name: VPN.NoAlert
@@ -141,9 +143,11 @@ VPNAlert {
 
             PropertyChanges {
                 target: alertBox
-                //% "Signed out and device removed"
-                alertText: qsTrId("vpn.alert.deviceRemovedAndLogout")
+                //% "Signed out and device disconnected"
+                alertText: qsTrId("vpn.alert.deviceDisconnectedAndLogout")
                 visible: true
+                alertColor: Theme.greenAlert
+                textColor: Theme.fontColorDark
             }
 
         }


### PR DESCRIPTION
- Changes the sign out alert to green
- Tweaks the sign out message

@flodolo Do you think this requires adding a new string? It is a one word change and, without knowing how this has been handled in other locales, I'm wondering if it makes sense to keep the existing string ID and update the English string only.

<img width="368" alt="Screen Shot 2021-05-13 at 4 30 08 PM" src="https://user-images.githubusercontent.com/22355127/118190467-c43cf780-b408-11eb-87f0-8d4509a0d75f.png">
