### PR TITLE
Install systemd service file via make install

### DIFF
--- a/src/src.pro
+++ b/src/src.pro
@@ -428,6 +428,10 @@ else:linux:!android {
     dbus_service.path = $${USRPATH}/share/dbus-1/system-services
     INSTALLS += dbus_service
 
+    systemd_service.files = ../linux/debian/mozillavpn.service
+    systemd_service.path = /lib/systemd/system
+    INSTALLS += systemd_service
+
     DEFINES += MVPN_DATA_PATH=\\\"$${USRPATH}/share/mozillavpn\\\"
     helper.path = $${USRPATH}/share/mozillavpn
     helper.files = ../linux/daemon/helper.sh


### PR DESCRIPTION
In a recent commit, 7f44dc826f6c8d6f2bb9533a5d7b5383771360f6, which added a systemd service file, we only added it to the Debian package. This means that a user trying to install from sources can miss the installation of this file via `make install`. Leaving them with an incomplete installation.

See also: https://github.com/mozilla-mobile/mozilla-vpn-client/issues/1028