### PR TITLE
Add optional filter for surveys by platform

### DIFF
--- a/src/constants.h
+++ b/src/constants.h
@@ -79,4 +79,22 @@ PRODBETAEXPR(
 
 #undef PRODBETAEXPR
 
+constexpr const char* PLATFORM_NAME =
+#if defined(MVPN_IOS)
+    "ios"
+#elif defined(MVPN_MACOS)
+    "macos"
+#elif defined(MVPN_LINUX)
+    "linux"
+#elif defined(MVPN_ANDROID)
+    "android"
+#elif defined(MVPN_WINDOWS)
+    "windows"
+#elif defined(UNIT_TEST) || defined(MVPN_DUMMY)
+    "dummy"
+#else
+#  error "Unsupported platform"
+#endif
+    ;
+
 };  // namespace Constants

--- a/src/models/survey.cpp
+++ b/src/models/survey.cpp
@@ -91,7 +91,7 @@ bool Survey::isTriggerable() const {
     return false;
   }
 
-  if ((m_platforms.count() > 0) &&
+  if (!m_platforms.isEmpty() &&
       !m_platforms.contains(Constants::PLATFORM_NAME)) {
     return false;
   }

--- a/src/models/survey.h
+++ b/src/models/survey.h
@@ -6,6 +6,7 @@
 #define SURVEY_H
 
 #include <QString>
+#include <QStringList>
 
 class QJsonValue;
 
@@ -28,6 +29,7 @@ class Survey final {
   QString m_id;
   QString m_url;
   uint32_t m_triggerTime;
+  QStringList m_platforms;
 };
 
 #endif  // SURVEY_H

--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -421,17 +421,7 @@ void MozillaVPN::openLink(LinkType linkType) {
     case LinkUpdate:
       url = Constants::API_URL;
       url.append("/r/vpn/update/");
-#if defined(MVPN_LINUX)
-      url.append("linux");
-#elif defined(MVPN_MACOS)
-      url.append("macos");
-#elif defined(MVPN_IOS)
-      url.append("ios");
-#elif defined(MVPN_ANDROID)
-      url.append("android");
-#else
-      url.append("dummy");
-#endif
+      url.append(Constants::PLATFORM_NAME);
       break;
 
     case LinkSubscriptionBlocked:

--- a/src/tasks/authenticate/taskauthenticate.cpp
+++ b/src/tasks/authenticate/taskauthenticate.cpp
@@ -97,21 +97,11 @@ void TaskAuthenticate::run(MozillaVPN* vpn) {
 
   QString path("/api/v2/vpn/login/");
 
-#if defined(MVPN_IOS)
-  path.append("ios");
-#elif defined(MVPN_LINUX)
-  path.append("linux");
-#elif defined(MVPN_ANDROID)
-  path.append("android");
-#elif defined(MVPN_MACOS)
-  path.append("macos");
-#elif defined(MVPN_WINDOWS)
-  path.append("windows");
-#elif defined(MVPN_DUMMY)
+#if !defined(MVPN_DUMMY)
+  path.append(Constants::PLATFORM_NAME);
+#else
   // Let's use linux here.
   path.append("linux");
-#else
-#  error Not supported
 #endif
 
   QUrl url(Constants::API_URL);

--- a/src/update/versionapi.cpp
+++ b/src/update/versionapi.cpp
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "versionapi.h"
+#include "constants.h"
 #include "leakdetector.h"
 #include "logger.h"
 #include "networkrequest.h"
@@ -54,23 +55,7 @@ bool VersionApi::processData(const QByteArray& data) {
 
   QJsonObject obj = json.object();
 
-  QString platformKey =
-#if defined(MVPN_IOS)
-      "ios"
-#elif defined(MVPN_MACOS)
-      "macos"
-#elif defined(MVPN_LINUX)
-      "linux"
-#elif defined(MVPN_ANDROID)
-      "android"
-#elif defined(MVPN_WINDOWS)
-      "windows"
-#elif defined(UNIT_TEST) || defined(MVPN_DUMMY)
-      "dummy"
-#else
-#  error "Unsupported platform"
-#endif
-      ;
+  QString platformKey = Constants::PLATFORM_NAME;
 
   if (!obj.contains(platformKey)) {
     logger.log() << "No key" << platformKey;


### PR DESCRIPTION
This allows surveys to include a `platforms` array, which lists the platforms on which a survey should be trigger-able, if the array is absent, or empty, then the survey should apply to all platforms.

Closes: https://github.com/mozilla-mobile/mozilla-vpn-client/issues/988