### PR TITLE
Linux daemon should output logs to /var/log

### DIFF
--- a/src/loghandler.cpp
+++ b/src/loghandler.cpp
@@ -221,28 +221,33 @@ void LogHandler::writeLogs(QTextStream& out) {
 // static
 void LogHandler::cleanupLogs() {
   QMutexLocker lock(&s_mutex);
+  cleanupLogFile(lock);
+}
 
+// static
+void LogHandler::cleanupLogFile(const QMutexLocker& proofOfLock) {
   if (!s_instance || !s_instance->m_logFile) {
     return;
   }
 
   QString logFileName = s_instance->m_logFile->fileName();
-  s_instance->closeLogFile(lock);
+  s_instance->closeLogFile(proofOfLock);
 
   {
     QFile file(logFileName);
     file.remove();
   }
 
-  s_instance->openLogFile(lock);
+  s_instance->openLogFile(proofOfLock);
 }
 
 // static
 void LogHandler::setLocation(const QString& path) {
+  QMutexLocker lock(&s_mutex);
   s_location = path;
 
   if (s_instance && s_instance->m_logFile) {
-    cleanupLogs();
+    cleanupLogFile(lock);
   }
 }
 

--- a/src/loghandler.h
+++ b/src/loghandler.h
@@ -82,6 +82,8 @@ class LogHandler final : public QObject {
 
   void closeLogFile(const QMutexLocker& proofOfLock);
 
+  static void cleanupLogFile(const QMutexLocker& proofOfLock);
+
   const QStringList m_modules;
 
   QFile* m_logFile = nullptr;

--- a/src/loghandler.h
+++ b/src/loghandler.h
@@ -64,6 +64,8 @@ class LogHandler final : public QObject {
 
   static void cleanupLogs();
 
+  static void setLocation(const QString& path);
+
  signals:
   void logEntryAdded(const QByteArray& log);
 
@@ -82,7 +84,6 @@ class LogHandler final : public QObject {
 
   const QStringList m_modules;
 
-  QString m_logFileName;
   QFile* m_logFile = nullptr;
   QTextStream* m_output = nullptr;
 };

--- a/src/platforms/linux/daemon/linuxdaemon.cpp
+++ b/src/platforms/linux/daemon/linuxdaemon.cpp
@@ -25,6 +25,7 @@ class CommandLinuxDaemon final : public Command {
 
   int run(QStringList& tokens) override {
     Q_ASSERT(!tokens.isEmpty());
+    LogHandler::setLocation("/var/log");
 
     return runCommandLineApp([&]() {
       DBusService* dbus = new DBusService(qApp);


### PR DESCRIPTION
The linux daemon is started as a D-Bus service by systemd, in which case it will not have a valid $HOME directory and it would be more appropriate to send out logs to /var/log.

Closes: mozilla-mobile/mozilla-vpn-client/issues/1057