### PR TITLE
Fix Privacy & Security view title

### DIFF
--- a/src/ui/settings/ViewPrivacySecurity.qml
+++ b/src/ui/settings/ViewPrivacySecurity.qml
@@ -17,8 +17,8 @@ VPNFlickable {
         id: menu
         objectName: "settingsPrivacySecurtyBackButton"
 
-        //% "Privacy & Security settings"
-        title: qsTrId("vpn.settings.privacySecurity")
+        //% "Privacy & Security"
+        title: qsTrId("vpn.settings.privacySecurityTitle")
         isSettingsView: true
     }
 


### PR DESCRIPTION
Removes "settings" from Privacy & Security settings sub-page.
If the new German string is the same as the one on the settings menu view, it will fix #1037 and look like this: 
<img width="200" alt="Screen Shot 2021-05-19 at 10 24 20 AM" src="https://user-images.githubusercontent.com/22355127/118839797-6e46d480-b88c-11eb-8d8b-918c342ec10f.png">