### PR TITLE
Use DNT/GPC to inform the server when the user doesn't want to be tracked - closes #1089

### DIFF
--- a/src/networkrequest.cpp
+++ b/src/networkrequest.cpp
@@ -34,6 +34,15 @@ NetworkRequest::NetworkRequest(QObject* parent, int status)
   m_request.setRawHeader("User-Agent", NetworkManager::userAgent());
 #endif
 
+  // Let's use "glean-enabled" as an indicator for DNT/GPC too.
+  if (!SettingsHolder::instance()->gleanEnabled()) {
+    // Do-Not-Track:
+    // https://datatracker.ietf.org/doc/html/draft-mayer-do-not-track-00
+    m_request.setRawHeader("DNT", "1");
+    // Global Privacy Control: https://globalprivacycontrol.github.io/gpc-spec/
+    m_request.setRawHeader("Sec-GPC", "1");
+  }
+
   m_timer.setSingleShot(true);
 
   connect(&m_timer, &QTimer::timeout, this, &NetworkRequest::timeout);


### PR DESCRIPTION
Of course, this is just the client-side. Then we need extra work to parse the header and follow what the user asks.