### PR TITLE
Allow CP-Deactivation in any State that is not State::OFF

### DIFF
--- a/src/captiveportal/captiveportaldetection.cpp
+++ b/src/captiveportal/captiveportaldetection.cpp
@@ -155,7 +155,7 @@ void CaptivePortalDetection::deactivationRequired() {
 
   MozillaVPN* vpn = MozillaVPN::instance();
 
-  if (vpn->controller()->state() == Controller::StateOn) {
+  if (vpn->controller()->state() != Controller::StateOff) {
     vpn->deactivate();
     captivePortalMonitor()->start();
   }


### PR DESCRIPTION
From @ValentinaPC  #1066
> VPN ON - Captive Portal checked - connected to a network with CP -> CP notification is displayed -> click on the notification -> nothing happens at click; (this might happen because the VPN does not finalize connection until the user clicks on the notification)

We should allow any state here for the notification to disconnect the connection