### PR TITLE
Restrict screen orientation to portrait on Android

### DIFF
--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -31,7 +31,7 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
             android:name="org.mozilla.firefox.vpn.qt.VPNActivity"
             android:process=":QtOnlyProcess"
             android:label="Mozilla VPN"
-            android:screenOrientation="unspecified"
+            android:screenOrientation="portrait"
             android:theme="@style/AppTheme.Splash"
             android:windowSoftInputMode="adjustResize"
             android:launchMode="singleTop">


### PR DESCRIPTION
Bandaid fix for #1067 

This restricts the screen orientation on Android devices to portrait which is consistent with existing behavior on iPhone.