### PR TITLE
Build fixes and RPM packaging for Fedora 33+

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ curl -L https://download.qt.io/archive/qt/5.15/5.15.1/single/qt-everywhere-src-5
 tar xvf qt-everywhere-src-5.15.1.tar.xz
 mv qt-everywhere-src-5.15.1 qt
 sudo apt build-dep qt5-default
-sudo apt install libxcb-xinerama0-dev
+sudo apt install clang llvm golang
+sudo apt install libxcb-xinerama0-dev libxcb-util-dev
 bash scripts/qt5_compile.sh qt qt
 ```
 
@@ -60,7 +61,7 @@ git submodule update
 # glean
 ./scripts/generate_glean.py
 # translations
-python scripts/importLanguages.py
+./scripts/importLanguages.py
 ```
 
 #### Build

--- a/linux/mozillavpn.spec
+++ b/linux/mozillavpn.spec
@@ -1,0 +1,58 @@
+%define _srcdir %(git rev-parse --show-toplevel)
+%define _version %(cat %{_srcdir}/version.pri | grep :VERSION | awk '{print $NF}')
+
+Name:      mozillavpn
+Version:   %{_version}
+Release:   1
+Summary:   Mozilla VPN
+License:   MPLv2.0
+URL:       https://vpn.mozilla.org
+Packager:  Owen Kirby
+Requires:  qt5-qtbase
+Requires:  qt5-qtcharts
+Requires:  qt5-qtnetworkauth
+Requires:  qt5-qtquickcontrols2
+Requires:  qt5-qtsvg
+Requires:  wireguard-tools
+
+BuildRequires: golang
+BuildRequires: polkit-devel
+BuildRequires: qt5-qtbase-devel
+BuildRequires: qt5-qtcharts-devel
+BuildRequires: qt5-qtnetworkauth-devel
+BuildRequires: qt5-qtquickcontrols2-devel
+BuildRequires: qt5-qtsvg-devel
+BuildRequires: qt5-qttools-devel
+BuildRequires: qt5-qtwebsockets-devel
+BuildRequires: systemd-rpm-macros
+
+%description
+A fast, secure and easy to use VPN. Built by the makers of Firefox.
+Read more on https://vpn.mozilla.org
+
+%prep
+qmake-qt5 %{_srcdir}/mozillavpn.pro CONFIG+=production QT+=svg
+
+%build
+make -j$(nproc)
+
+%install
+make install INSTALL_ROOT=%{buildroot}
+install -d %{buildroot}/%{_licensedir}/%{name}
+install %{_srcdir}/LICENSE.md %{buildroot}/%{_licensedir}/%{name}/
+
+%files
+%license %{_licensedir}/%{name}/LICENSE.md
+%{_sysconfdir}/xdg/autostart/MozillaVPN-startup.desktop
+%{_unitdir}/mozillavpn.service
+%{_bindir}/mozillavpn
+%{_datadir}/applications/MozillaVPN.desktop
+%{_datadir}/dbus-1/system-services/org.mozilla.vpn.dbus.service
+%{_datadir}/dbus-1/system.d/org.mozilla.vpn.conf
+%{_datadir}/icons/hicolor/128x128/apps/mozillavpn.png
+%{_datadir}/icons/hicolor/16x16/apps/mozillavpn.png
+%{_datadir}/icons/hicolor/32x32/apps/mozillavpn.png
+%{_datadir}/icons/hicolor/48x48/apps/mozillavpn.png
+%{_datadir}/icons/hicolor/64x64/apps/mozillavpn.png
+%{_datadir}/polkit-1/actions/org.mozilla.vpn.policy
+

--- a/scripts/importLanguages.py
+++ b/scripts/importLanguages.py
@@ -9,6 +9,7 @@ import argparse
 import xml.etree.ElementTree as ET
 import os
 import sys
+import shutil
 
 # Include only locales above this threshold (e.g. 70%) in production
 l10n_threshold = 0.70
@@ -18,6 +19,22 @@ parser.add_argument(
     '-p', '--prod', default=False, action="store_true", dest="isprod",
     help='Build only for production locales.')
 args = parser.parse_args()
+
+# Step 0
+# Locate the lupdate and lconvert tools
+lupdate = shutil.which('lupdate')
+if lupdate is None:
+    lupdate = shutil.which('lupdate-qt5')
+if lupdate is None:
+    print('Unable to locate lupdate tool.')
+    sys.exit(1)
+
+lconvert = shutil.which('lconvert')
+if lconvert is None:
+    lconvert = shutil.which('lconvert-qt5')
+if lconvert is None:
+    print('Unable to locate lconvert tool.')
+    sys.exit(1)
 
 # Step 1
 # Go through the i18n repo, check each XLIFF file and take
@@ -83,11 +100,11 @@ print('Updated translations.pri')
 
 # Step 3
 # Generate new ts files
-os.system('lupdate src/src.pro')
+os.system(f"{lupdate} src/src.pro")
 
 # Step 4
 # Now import translations into the files
 for l10n_file in l10n_files:
-    os.system(f"lconvert -if xlf -i {l10n_file['xliff']} -o {l10n_file['ts']}")
+    os.system(f"{lconvert} -if xlf -i {l10n_file['xliff']} -o {l10n_file['ts']}")
 
 print(f'Imported {len(l10n_files)} locales')

--- a/scripts/qt5_compile.sh
+++ b/scripts/qt5_compile.sh
@@ -89,7 +89,7 @@ print Y "Wait..."
   --recheck-all \
   -opensource \
   -confirm-license \
-  -release \
+  -debug-and-release \
   -static \
   -strip \
   -silent \

--- a/src/src.pro
+++ b/src/src.pro
@@ -440,7 +440,7 @@ else:linux:!android {
     INSTALLS += dbus_service
 
     systemd_service.files = ../linux/debian/mozillavpn.service
-    systemd_service.path = /lib/systemd/system
+    systemd_service.path = /usr/lib/systemd/system
     INSTALLS += systemd_service
 
     CONFIG += link_pkgconfig


### PR DESCRIPTION
After a bit of experimenting, I've been able to build and run the VPN client on Fedora 33 and 34, and I've written a spec file that should enable us to build binary RPM packages out of a git checkout by doing:

```
sudo dnf builddep linux/mozillavpn.spec
rpmbuild -bb linux/mozillavpn.spec
```

Some users have noted problems with SELinux, but I wasn't able to reproduce them in my virtual machine, it just seemed to work for me, even with `getenforce` reporting that SELinux is enabled.