### PR TITLE
Android: Fix Notification Intent

### DIFF
--- a/android/src/org/mozilla/firefox/vpn/NotificationUtil.kt
+++ b/android/src/org/mozilla/firefox/vpn/NotificationUtil.kt
@@ -96,7 +96,7 @@ object NotificationUtil {
         val header = "" + prefs.getString("fallbackNotificationHeader", "Mozilla VPN")
 
         // Create the Intent that Should be Fired if the User Clicks the notification
-        val mainActivityName = "org.qtproject.qt5.android.bindings.QtActivity"
+        val mainActivityName = "org.mozilla.firefox.vpn.qt.VPNActivity"
         val activity = Class.forName(mainActivityName)
         val intent = Intent(service, activity)
         val pendingIntent = PendingIntent.getActivity(service, 0, intent, 0)


### PR DESCRIPTION
In: https://github.com/mozilla-mobile/mozilla-vpn-client/pull/862/files android/AndroidManifest.xml
we changed the main activity, but i forgot to update the Notification code, so currently on notification tap nothing happens :(
