### PR TITLE
Support per-app VPN on Linux

### DIFF
--- a/linux/debian/mozillavpn.service
+++ b/linux/debian/mozillavpn.service
@@ -5,3 +5,6 @@ Description=MozillaVPN D-Bus service
 Type=dbus
 BusName=org.mozilla.vpn.dbus
 ExecStart=/usr/bin/mozillavpn linuxdaemon
+
+[Install]
+WantedBy=multi-user.target

--- a/src/apppermission.cpp
+++ b/src/apppermission.cpp
@@ -11,8 +11,10 @@
 #include <QVector>
 #include "settingsholder.h"
 
-#ifdef MVPN_ANDROID
+#if defined(MVPN_ANDROID)
 #  include "platforms/android/androidapplistprovider.h"
+#elif defined(MVPN_LINUX)
+#  include "platforms/linux/linuxapplistprovider.h"
 #else
 #  include "platforms/dummy/dummyapplistprovider.h"
 #endif
@@ -30,8 +32,10 @@ AppPermission::AppPermission(QObject* parent) : QAbstractListModel(parent) {
   m_disabledlist = new FilteredAppList(this, false);
 
   m_listprovider =
-#ifdef MVPN_ANDROID
+#if defined(MVPN_ANDROID)
       new AndroidAppListProvider(this);
+#elif defined(MVPN_LINUX)
+      new LinuxAppListProvider(this);
 #else
       new DummyAppListProvider(this);
 #endif

--- a/src/commands/commandui.cpp
+++ b/src/commands/commandui.cpp
@@ -23,6 +23,7 @@
 #ifdef MVPN_LINUX
 #  include "eventlistener.h"
 #  include "platforms/linux/linuxdependencies.h"
+#  include "platforms/linux/linuxappimageprovider.h"
 #endif
 
 #ifdef MVPN_MACOS
@@ -179,6 +180,10 @@ int CommandUI::run(QStringList& tokens) {
     if (!LinuxDependencies::checkDependencies()) {
       return 1;
     }
+
+    // Register an Image Provider that will resolve "image://app/{id}" for qml
+    QQuickImageProvider* provider = new LinuxAppImageProvider(qApp);
+    engine->addImageProvider(QString("app"), provider);
 #endif
 
 #ifdef MVPN_ANDROID

--- a/src/featurelist.cpp
+++ b/src/featurelist.cpp
@@ -35,7 +35,7 @@ bool FeatureList::localNetworkAccessSupported() const {
 }
 
 bool FeatureList::protectSelectedAppsSupported() const {
-#if defined(MVPN_ANDROID)
+#if defined(MVPN_ANDROID) || defined(MVPN_LINUX)
   return true;
 #else
   return false;

--- a/src/featurelist.cpp
+++ b/src/featurelist.cpp
@@ -4,8 +4,14 @@
 
 #include "featurelist.h"
 
+#include <QProcessEnvironment>
+
 #ifdef MVPN_ANDROID
 #  include "platforms/android/androidutils.h"
+#endif
+
+#ifdef MVPN_LINUX
+#  include "platforms/linux/linuxdependencies.h"
 #endif
 
 namespace {
@@ -35,8 +41,33 @@ bool FeatureList::localNetworkAccessSupported() const {
 }
 
 bool FeatureList::protectSelectedAppsSupported() const {
-#if defined(MVPN_ANDROID) || defined(MVPN_LINUX)
+#if defined(MVPN_ANDROID)
   return true;
+#elif defined(MVPN_LINUX)
+  static bool initDone = false;
+  static bool splitTunnelSupported = false;
+  if (initDone) {
+    return splitTunnelSupported;
+  }
+  initDone = true;
+
+  /* Control groups v1 must be mounted for traffic classification */
+  if (LinuxDependencies::findCgroupPath("net_cls").isNull()) {
+    return false;
+  }
+
+  /* Application tracking is only supported on GTK-based desktops */
+  QProcessEnvironment pe = QProcessEnvironment::systemEnvironment();
+  if (!pe.contains("XDG_CURRENT_DESKTOP")) {
+    return false;
+  }
+  QStringList desktop = pe.value("XDG_CURRENT_DESKTOP").split(":");
+  if (!desktop.contains("GNOME") && !desktop.contains("MATE") &&
+      !desktop.contains("Unity") && !desktop.contains("X-Cinnamon")) {
+    return false;
+  }
+  splitTunnelSupported = true;
+  return splitTunnelSupported;
 #else
   return false;
 #endif

--- a/src/platforms/linux/daemon/apptracker.cpp
+++ b/src/platforms/linux/daemon/apptracker.cpp
@@ -50,13 +50,11 @@ AppTracker::~AppTracker() {
 
 void AppTracker::userListCompleted(QDBusPendingCallWatcher* watcher) {
   QDBusPendingReply<UserDataList> reply = *watcher;
-  if (!reply.isValid()) {
-    return;
-  }
-
-  UserDataList list = reply.value();
-  for (auto user : list) {
-    userCreated(user.userid, user.path);
+  if (reply.isValid()) {
+    UserDataList list = reply.value();
+    for (auto user : list) {
+      userCreated(user.userid, user.path);
+    }
   }
 
   delete watcher;

--- a/src/platforms/linux/daemon/apptracker.cpp
+++ b/src/platforms/linux/daemon/apptracker.cpp
@@ -1,0 +1,111 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "apptracker.h"
+#include "dbustypeslinux.h"
+#include "leakdetector.h"
+#include "logger.h"
+
+#include <QtDBus/QtDBus>
+#include <QDBusConnection>
+#include <QDBusInterface>
+#include <QScopeGuard>
+
+#include <unistd.h>
+
+constexpr const char* GTK_DESKTOP_APP_SERVICE = "org.gtk.gio.DesktopAppInfo";
+constexpr const char* GTK_DESKTOP_APP_PATH = "/org/gtk/gio/DesktopAppInfo";
+
+constexpr const char* DBUS_LOGIN_SERVICE = "org.freedesktop.login1";
+constexpr const char* DBUS_LOGIN_PATH = "/org/freedesktop/login1";
+constexpr const char* DBUS_LOGIN_MANAGER = "org.freedesktop.login1.Manager";
+
+namespace {
+Logger logger(LOG_LINUX, "AppTracker");
+}
+
+AppTracker::AppTracker(QObject* parent) : QObject(parent) {
+  MVPN_COUNT_CTOR(AppTracker);
+  logger.log() << "AppTracker created.";
+
+  QDBusConnection m_conn = QDBusConnection::systemBus();
+  m_conn.connect("", DBUS_LOGIN_PATH, DBUS_LOGIN_MANAGER, "UserNew", this,
+                 SLOT(userCreated(uint, const QDBusObjectPath&)));
+  m_conn.connect("", DBUS_LOGIN_PATH, DBUS_LOGIN_MANAGER, "UserRemoved", this,
+                 SLOT(userRemoved(uint, const QDBusObjectPath&)));
+
+  QDBusInterface n(DBUS_LOGIN_SERVICE, DBUS_LOGIN_PATH, DBUS_LOGIN_MANAGER,
+                   m_conn);
+  QDBusPendingReply<UserDataList> reply = n.asyncCall("ListUsers");
+  QDBusPendingCallWatcher* watcher = new QDBusPendingCallWatcher(reply, this);
+  QObject::connect(watcher, SIGNAL(finished(QDBusPendingCallWatcher*)), this,
+                   SLOT(userListCompleted(QDBusPendingCallWatcher*)));
+}
+
+AppTracker::~AppTracker() {
+  MVPN_COUNT_DTOR(AppTracker);
+  logger.log() << "AppTracker destroyed.";
+}
+
+void AppTracker::userListCompleted(QDBusPendingCallWatcher* watcher) {
+  QDBusPendingReply<UserDataList> reply = *watcher;
+  if (!reply.isValid()) {
+    return;
+  }
+
+  UserDataList list = reply.value();
+  for (auto user : list) {
+    userCreated(user.userid, user.path);
+  }
+
+  delete watcher;
+}
+
+void AppTracker::userCreated(uint userid, const QDBusObjectPath& path) {
+  logger.log() << "User created uid:" << userid << "at:" << path.path();
+
+  /* Acquire the effective UID of the user to connect to their session bus. */
+  uid_t realuid = getuid();
+  if (seteuid(userid) < 0) {
+    logger.log() << "Failed to set effective UID";
+  }
+  auto guard = qScopeGuard([&] {
+    if (seteuid(realuid) < 0) {
+      logger.log() << "Failed to restore effective UID";
+    }
+  });
+
+  /* For correctness we should ask systemd for the user's runtime directory. */
+  QString busPath = "unix:path=/run/user/" + QString::number(userid) + "/bus";
+  logger.log() << "Connection to" << busPath;
+  QDBusConnection connection =
+      QDBusConnection::connectToBus(busPath, "user-" + QString::number(userid));
+
+  /* Connect to the user's GTK launch event. */
+  bool isConnected = connection.connect(
+      "", GTK_DESKTOP_APP_PATH, GTK_DESKTOP_APP_SERVICE, "Launched", this,
+      SLOT(gtkLaunchEvent(const QByteArray&, const QString&, qlonglong,
+                          const QStringList&, const QVariantMap&)));
+  if (!isConnected) {
+    logger.log() << "Failed to connect to GTK Launched signal";
+  }
+}
+
+void AppTracker::userRemoved(uint uid, const QDBusObjectPath& path) {
+  logger.log() << "User removed uid:" << uid << "at:" << path.path();
+  QDBusConnection::disconnectFromBus("user-" + QString::number(uid));
+}
+
+void AppTracker::gtkLaunchEvent(const QByteArray& appid, const QString& display,
+                                qlonglong pid, const QStringList& uris,
+                                const QVariantMap& extra) {
+  Q_UNUSED(display);
+  Q_UNUSED(uris);
+  Q_UNUSED(extra);
+
+  QString appIdName = QString(appid);
+  if (!appIdName.isEmpty()) {
+    emit appLaunched(appIdName, pid);
+  }
+}

--- a/src/platforms/linux/daemon/apptracker.h
+++ b/src/platforms/linux/daemon/apptracker.h
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef APPTRACKER_H
+#define APPTRACKER_H
+
+#include <QDBusPendingCallWatcher>
+#include <QDBusObjectPath>
+
+class AppTracker final : public QObject {
+  Q_OBJECT
+  Q_DISABLE_COPY_MOVE(AppTracker)
+
+ public:
+  explicit AppTracker(QObject* parent);
+  ~AppTracker();
+
+ signals:
+  void appLaunched(const QString& name, int rootpid);
+
+ private slots:
+  void userListCompleted(QDBusPendingCallWatcher* call);
+  void userCreated(uint uid, const QDBusObjectPath& path);
+  void userRemoved(uint uid, const QDBusObjectPath& path);
+  void gtkLaunchEvent(const QByteArray& appid, const QString& display,
+                      qlonglong pid, const QStringList& uris,
+                      const QVariantMap& extra);
+};
+
+#endif  // APPTRACKER_H

--- a/src/platforms/linux/daemon/dbusservice.cpp
+++ b/src/platforms/linux/daemon/dbusservice.cpp
@@ -41,9 +41,7 @@ DBusService::DBusService(QObject* parent) : Daemon(parent) {
 
 DBusService::~DBusService() { MVPN_COUNT_DTOR(DBusService); }
 
-WireguardUtils* DBusService::wgutils() {
-  return m_wgutils;
-}
+WireguardUtils* DBusService::wgutils() { return m_wgutils; }
 
 IPUtils* DBusService::iputils() {
   if (!m_iputils) {

--- a/src/platforms/linux/daemon/dbusservice.cpp
+++ b/src/platforms/linux/daemon/dbusservice.cpp
@@ -24,7 +24,13 @@ DBusService::DBusService(QObject* parent) : Daemon(parent) {
            WG_INTERFACE);
   }
 
+  m_apptracker = new AppTracker(this);
   m_pidtracker = new PidTracker(this);
+
+  connect(m_apptracker, SIGNAL(appLaunched(const QString&, int)), this,
+          SLOT(appLaunched(const QString&, int)));
+  connect(m_pidtracker, SIGNAL(terminated(const QString&, int)), this,
+          SLOT(appTerminated(const QString&, int)));
 }
 
 DBusService::~DBusService() { MVPN_COUNT_DTOR(DBusService); }
@@ -140,4 +146,13 @@ bool DBusService::supportServerSwitching(const InterfaceConfig& config) const {
          m_lastConfig.m_deviceIpv6Address == config.m_deviceIpv6Address &&
          m_lastConfig.m_serverIpv4Gateway == config.m_serverIpv4Gateway &&
          m_lastConfig.m_serverIpv6Gateway == config.m_serverIpv6Gateway;
+}
+
+void DBusService::appLaunched(const QString& name, int rootpid) {
+  logger.log() << "tracking:" << name << "PID:" << rootpid;
+  m_pidtracker->track(name, rootpid);
+}
+
+void DBusService::appTerminated(const QString& name, int rootpid) {
+  logger.log() << "terminate:" << name << "PID:" << rootpid;
 }

--- a/src/platforms/linux/daemon/dbusservice.cpp
+++ b/src/platforms/linux/daemon/dbusservice.cpp
@@ -23,6 +23,8 @@ DBusService::DBusService(QObject* parent) : Daemon(parent) {
     qFatal("Interface `%s` exists and cannot be removed. Cannot proceed!",
            WG_INTERFACE);
   }
+
+  m_pidtracker = new PidTracker(this);
 }
 
 DBusService::~DBusService() { MVPN_COUNT_DTOR(DBusService); }

--- a/src/platforms/linux/daemon/dbusservice.h
+++ b/src/platforms/linux/daemon/dbusservice.h
@@ -8,6 +8,7 @@
 #include "daemon/daemon.h"
 #include "iputilslinux.h"
 #include "dnsutilslinux.h"
+#include "pidtracker.h"
 #include "wireguardutilslinux.h"
 
 class DbusAdaptor;
@@ -55,6 +56,8 @@ class DBusService final : public Daemon {
   WireguardUtilsLinux* m_wgutils = nullptr;
   IPUtilsLinux* m_iputils = nullptr;
   DnsUtilsLinux* m_dnsutils = nullptr;
+
+  PidTracker* m_pidtracker = nullptr;
 };
 
 #endif  // DBUSSERVICE_H

--- a/src/platforms/linux/daemon/dbusservice.h
+++ b/src/platforms/linux/daemon/dbusservice.h
@@ -36,6 +36,11 @@ class DBusService final : public Daemon {
   QString version();
   QString getLogs();
 
+  QString runningApps();
+  bool firewallApp(const QStringList& names, const QString& state);
+  bool firewallPid(int rootpid, const QString& state);
+  bool firewallClear();
+
  protected:
   bool supportServerSwitching(const InterfaceConfig& config) const override;
   bool switchServer(const InterfaceConfig& config) override;
@@ -60,6 +65,7 @@ class DBusService final : public Daemon {
 
   AppTracker* m_apptracker = nullptr;
   PidTracker* m_pidtracker = nullptr;
+  QMap<QString, QString> m_firewallApps;
 
  private slots:
   void appLaunched(const QString& name, int rootpid);

--- a/src/platforms/linux/daemon/dbusservice.h
+++ b/src/platforms/linux/daemon/dbusservice.h
@@ -6,6 +6,7 @@
 #define DBUSSERVICE_H
 
 #include "daemon/daemon.h"
+#include "apptracker.h"
 #include "iputilslinux.h"
 #include "dnsutilslinux.h"
 #include "pidtracker.h"
@@ -57,7 +58,12 @@ class DBusService final : public Daemon {
   IPUtilsLinux* m_iputils = nullptr;
   DnsUtilsLinux* m_dnsutils = nullptr;
 
+  AppTracker* m_apptracker = nullptr;
   PidTracker* m_pidtracker = nullptr;
+
+ private slots:
+  void appLaunched(const QString& name, int rootpid);
+  void appTerminated(const QString& name, int rootpid);
 };
 
 #endif  // DBUSSERVICE_H

--- a/src/platforms/linux/daemon/dbusservice.h
+++ b/src/platforms/linux/daemon/dbusservice.h
@@ -37,7 +37,7 @@ class DBusService final : public Daemon {
   QString getLogs();
 
   QString runningApps();
-  bool firewallApp(const QStringList& names, const QString& state);
+  bool firewallApp(const QString& appName, const QString& state);
   bool firewallPid(int rootpid, const QString& state);
   bool firewallClear();
 
@@ -56,6 +56,11 @@ class DBusService final : public Daemon {
 
  private:
   bool removeInterfaceIfExists();
+  QString getAppStateCgroup(const QString& state);
+
+ private slots:
+  void appLaunched(const QString& name, int rootpid);
+  void appTerminated(const QString& name, int rootpid);
 
  private:
   DbusAdaptor* m_adaptor = nullptr;
@@ -66,10 +71,6 @@ class DBusService final : public Daemon {
   AppTracker* m_apptracker = nullptr;
   PidTracker* m_pidtracker = nullptr;
   QMap<QString, QString> m_firewallApps;
-
- private slots:
-  void appLaunched(const QString& name, int rootpid);
-  void appTerminated(const QString& name, int rootpid);
 };
 
 #endif  // DBUSSERVICE_H

--- a/src/platforms/linux/daemon/dbustypeslinux.h
+++ b/src/platforms/linux/daemon/dbustypeslinux.h
@@ -8,6 +8,7 @@
 #include <QtDBus/QtDBus>
 #include <QDBusArgument>
 #include <QByteArray>
+#include <QHostAddress>
 
 #include <sys/socket.h>
 
@@ -119,6 +120,31 @@ typedef QList<DnsDomain> DnsDomainList;
 Q_DECLARE_METATYPE(DnsDomain);
 Q_DECLARE_METATYPE(DnsDomainList);
 
+/* D-Bus metatype for marshalling the freedesktop login manager data. */
+class UserData {
+ public:
+  QString name;
+  uint userid;
+  QDBusObjectPath path;
+
+  friend QDBusArgument& operator<<(QDBusArgument& args, const UserData& data) {
+    args.beginStructure();
+    args << data.userid << data.name << data.path;
+    args.endStructure();
+    return args;
+  }
+  friend const QDBusArgument& operator>>(const QDBusArgument& args,
+                                         UserData& data) {
+    args.beginStructure();
+    args >> data.userid >> data.name >> data.path;
+    args.endStructure();
+    return args;
+  }
+};
+typedef QList<UserData> UserDataList;
+Q_DECLARE_METATYPE(UserData);
+Q_DECLARE_METATYPE(UserDataList);
+
 class DnsMetatypeRegistrationProxy {
  public:
   DnsMetatypeRegistrationProxy() {
@@ -134,6 +160,10 @@ class DnsMetatypeRegistrationProxy {
     qDBusRegisterMetaType<DnsDomain>();
     qRegisterMetaType<DnsDomainList>();
     qDBusRegisterMetaType<DnsDomainList>();
+    qRegisterMetaType<UserData>();
+    qDBusRegisterMetaType<UserData>();
+    qRegisterMetaType<UserDataList>();
+    qDBusRegisterMetaType<UserDataList>();
   }
 };
 

--- a/src/platforms/linux/daemon/org.mozilla.vpn.dbus.xml
+++ b/src/platforms/linux/daemon/org.mozilla.vpn.dbus.xml
@@ -19,7 +19,7 @@
     </method>
     <method name="firewallApp">
       <arg type="b" direction="out"/>
-      <arg name="names" type="as" direction="in"/>
+      <arg name="appName" type="s" direction="in"/>
       <arg name="state" type="s" direction="in"/>
     </method>
     <method name="firewallPid">

--- a/src/platforms/linux/daemon/org.mozilla.vpn.dbus.xml
+++ b/src/platforms/linux/daemon/org.mozilla.vpn.dbus.xml
@@ -14,6 +14,22 @@
     <method name="status">
       <arg name="jsonStatus" type="s" direction="out"/>
     </method>
+    <method name="runningApps">
+      <arg type="s" direction="out"/>
+    </method>
+    <method name="firewallApp">
+      <arg type="b" direction="out"/>
+      <arg name="names" type="as" direction="in"/>
+      <arg name="state" type="s" direction="in"/>
+    </method>
+    <method name="firewallPid">
+      <arg type="b" direction="out"/>
+      <arg name="rootpid" type="i" direction="in"/>
+      <arg name="state" type="s" direction="in"/>
+    </method>
+    <method name="firewallClear">
+      <arg type="b" direction="out"/>
+    </method>
     <method name="getLogs">
       <arg name="logs" type="s" direction="out"/>
     </method>

--- a/src/platforms/linux/daemon/pidtracker.cpp
+++ b/src/platforms/linux/daemon/pidtracker.cpp
@@ -203,3 +203,17 @@ void PidTracker::readData() {
     }
   }
 }
+
+bool ProcessGroup::moveToCgroup(const QString& name) {
+  QString cgProcsFile = name + "/cgroup.procs";
+  FILE* fp = fopen(qPrintable(cgProcsFile), "w");
+  if (!fp) {
+    return false;
+  }
+  for (auto pid : kthreads.keys()) {
+    fprintf(fp, "%d\n", pid);
+    fflush(fp);
+  }
+  fclose(fp);
+  return true;
+}

--- a/src/platforms/linux/daemon/pidtracker.cpp
+++ b/src/platforms/linux/daemon/pidtracker.cpp
@@ -1,0 +1,205 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "pidtracker.h"
+#include "leakdetector.h"
+#include "logger.h"
+
+#include <stdio.h>
+#include <string.h>
+#include <errno.h>
+#include <unistd.h>
+#include <limits.h>
+#include <sys/select.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+
+#include <linux/netlink.h>
+#include <linux/connector.h>
+#include <linux/cn_proc.h>
+
+constexpr size_t CN_MCAST_MSG_SIZE =
+    sizeof(struct cn_msg) + sizeof(enum proc_cn_mcast_op);
+
+namespace {
+Logger logger(LOG_LINUX, "PidTracker");
+}
+
+PidTracker::PidTracker(QObject* parent) : QObject(parent) {
+  MVPN_COUNT_CTOR(PidTracker);
+  logger.log() << "PidTracker created.";
+
+  m_nlsock = socket(PF_NETLINK, SOCK_DGRAM, NETLINK_CONNECTOR);
+  if (m_nlsock < 0) {
+    logger.log() << "Failed to create netlink socket:" << strerror(errno);
+    return;
+  }
+
+  struct sockaddr_nl nladdr;
+  nladdr.nl_family = AF_NETLINK;
+  nladdr.nl_groups = CN_IDX_PROC;
+  nladdr.nl_pid = getpid();
+  nladdr.nl_pad = 0;
+  if (bind(m_nlsock, (struct sockaddr*)&nladdr, sizeof(nladdr)) < 0) {
+    logger.log() << "Failed to bind netlink socket:" << strerror(errno);
+    close(m_nlsock);
+    m_nlsock = -1;
+    return;
+  }
+
+  char buf[NLMSG_SPACE(CN_MCAST_MSG_SIZE)];
+  struct nlmsghdr* nlmsg = (struct nlmsghdr*)buf;
+  struct cn_msg* cnmsg = (struct cn_msg*)NLMSG_DATA(nlmsg);
+  enum proc_cn_mcast_op mcast_op = PROC_CN_MCAST_LISTEN;
+
+  memset(buf, 0, sizeof(buf));
+  nlmsg->nlmsg_len = NLMSG_LENGTH(CN_MCAST_MSG_SIZE);
+  nlmsg->nlmsg_type = NLMSG_DONE;
+  nlmsg->nlmsg_flags = 0;
+  nlmsg->nlmsg_seq = 0;
+  nlmsg->nlmsg_pid = getpid();
+
+  cnmsg->id.idx = CN_IDX_PROC;
+  cnmsg->id.val = CN_VAL_PROC;
+  cnmsg->seq = 0;
+  cnmsg->ack = 0;
+  cnmsg->len = sizeof(mcast_op);
+  memcpy(cnmsg->data, &mcast_op, sizeof(mcast_op));
+
+  if (send(m_nlsock, nlmsg, sizeof(buf), 0) != sizeof(buf)) {
+    logger.log() << "Failed to send netlink message:" << strerror(errno);
+    close(m_nlsock);
+    m_nlsock = -1;
+    return;
+  }
+
+  m_socket = new QSocketNotifier(m_nlsock, QSocketNotifier::Read, this);
+  connect(m_socket, SIGNAL(activated(QSocketDescriptor, QSocketNotifier::Type)),
+          SLOT(readData()));
+}
+
+PidTracker::~PidTracker() {
+  MVPN_COUNT_DTOR(PidTracker);
+  logger.log() << "PidTracker destroyed.";
+
+  m_processTree.clear();
+  while (!m_processGroups.isEmpty()) {
+    ProcessGroup* group = m_processGroups.takeFirst();
+    delete group;
+  }
+
+  if (m_nlsock > 0) {
+    close(m_nlsock);
+  }
+}
+
+void PidTracker::track(const QString& name, int rootpid) {
+  if (m_processTree.contains(rootpid)) {
+    logger.log() << "Ignoring attempt to track duplicate PID";
+    return;
+  }
+  ProcessGroup* group = new ProcessGroup(name, rootpid);
+  group->kthreads[rootpid] = 1;
+  group->refcount = 1;
+
+  m_processGroups.append(group);
+  m_processTree[rootpid] = group;
+}
+
+void PidTracker::handleProcEvent(struct cn_msg* cnmsg) {
+  struct proc_event* ev = (struct proc_event*)cnmsg->data;
+
+  if (ev->what == proc_event::PROC_EVENT_FORK) {
+    auto forkdata = &ev->event_data.fork;
+    /* If the child process already exists, track a new kernel thread. */
+    ProcessGroup* group = m_processTree.value(forkdata->child_tgid, nullptr);
+    if (group) {
+      group->kthreads[forkdata->child_tgid]++;
+      return;
+    }
+
+    /* Track a new userspace process if was forked from a known parent. */
+    group = m_processTree.value(forkdata->parent_tgid, nullptr);
+    if (!group) {
+      return;
+    }
+    m_processTree[forkdata->child_tgid] = group;
+    group->kthreads[forkdata->child_tgid] = 1;
+    group->refcount++;
+    emit pidForked(group->name, forkdata->parent_tgid, forkdata->child_tgid);
+  }
+
+  if (ev->what == proc_event::PROC_EVENT_EXIT) {
+    auto exitdata = &ev->event_data.exit;
+    ProcessGroup* group = m_processTree.value(exitdata->process_tgid, nullptr);
+    if (!group) {
+      return;
+    }
+
+    /* Decrement the number of kernel threads in this userspace process. */
+    uint threadcount = group->kthreads.value(exitdata->process_tgid, 0);
+    if (threadcount == 0) {
+      return;
+    }
+    if (threadcount > 1) {
+      group->kthreads[exitdata->process_tgid] = threadcount - 1;
+      return;
+    }
+    group->kthreads.remove(exitdata->process_tgid);
+
+    /* A userspace process exits when all of its kernel threads exit. */
+    Q_ASSERT(group->refcount > 0);
+    group->refcount--;
+    if (group->refcount == 0) {
+      emit terminated(group->name, group->rootpid);
+      m_processGroups.removeAll(group);
+      delete group;
+    }
+  }
+}
+
+void PidTracker::readData() {
+  struct sockaddr_nl src;
+  socklen_t srclen = sizeof(src);
+  ssize_t recvlen;
+
+  recvlen = recvfrom(m_nlsock, m_readBuf, sizeof(m_readBuf), MSG_DONTWAIT,
+                     (struct sockaddr*)&src, &srclen);
+  if (recvlen == ENOBUFS) {
+    logger.log()
+        << "Failed to read netlink socket: buffer full, message dropped";
+    return;
+  }
+  if (recvlen < 0) {
+    logger.log() << "Failed to read netlink socket:" << strerror(errno);
+    return;
+  }
+  if (srclen != sizeof(src)) {
+    logger.log() << "Failed to read netlink socket: invalid address length";
+    return;
+  }
+
+  /* We are only interested in process-control messages from the kernel */
+  if ((src.nl_groups != CN_IDX_PROC) || (src.nl_pid != 0)) {
+    return;
+  }
+
+  /* Handle the process-control messages. */
+  struct nlmsghdr* msg;
+  for (msg = (struct nlmsghdr*)m_readBuf; NLMSG_OK(msg, recvlen);
+       msg = NLMSG_NEXT(msg, recvlen)) {
+    struct cn_msg* cnmsg = (struct cn_msg*)NLMSG_DATA(msg);
+    if (msg->nlmsg_type == NLMSG_NOOP) {
+      continue;
+    }
+    if ((msg->nlmsg_type == NLMSG_ERROR) ||
+        (msg->nlmsg_type == NLMSG_OVERRUN)) {
+      break;
+    }
+    handleProcEvent(cnmsg);
+    if (msg->nlmsg_type == NLMSG_DONE) {
+      break;
+    }
+  }
+}

--- a/src/platforms/linux/daemon/pidtracker.h
+++ b/src/platforms/linux/daemon/pidtracker.h
@@ -26,6 +26,8 @@ class ProcessGroup {
   }
   ~ProcessGroup() { MVPN_COUNT_DTOR(ProcessGroup); }
 
+  bool moveToCgroup(const QString& name);
+
   QHash<int, uint> kthreads;
   QString name;
   QString state;

--- a/src/platforms/linux/daemon/pidtracker.h
+++ b/src/platforms/linux/daemon/pidtracker.h
@@ -1,0 +1,65 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef PIDTRACKER_H
+#define PIDTRACKER_H
+
+#include <QHash>
+#include <QList>
+#include <QSocketNotifier>
+#include <QString>
+
+#include "leakdetector.h"
+
+struct cn_msg;
+
+class ProcessGroup {
+ public:
+  ProcessGroup(const QString& groupName, int groupRootPid) {
+    MVPN_COUNT_CTOR(ProcessGroup);
+    name = groupName;
+    rootpid = groupRootPid;
+    refcount = 0;
+  }
+  ~ProcessGroup() { MVPN_COUNT_DTOR(ProcessGroup); }
+  QHash<int, uint> kthreads;
+  QString name;
+  int rootpid;
+  int refcount;
+};
+
+class PidTracker final : public QObject {
+  Q_OBJECT
+  Q_DISABLE_COPY_MOVE(PidTracker)
+
+ public:
+  explicit PidTracker(QObject* parent);
+  ~PidTracker();
+
+  void track(const QString& name, int rootpid);
+
+  QList<int> pids() { return m_processTree.keys(); }
+  QList<ProcessGroup*>::iterator begin() { return m_processGroups.begin(); }
+  QList<ProcessGroup*>::iterator end() { return m_processGroups.end(); }
+  const ProcessGroup* group(int pid) { return m_processTree.value(pid); }
+
+ signals:
+  void pidForked(const QString& name, int parent, int child);
+  void pidExited(const QString& name, int pid);
+  void terminated(const QString& name, int rootpid);
+
+ private:
+  int m_nlsock;
+  char m_readBuf[2048];
+  QSocketNotifier* m_socket;
+  QHash<int, ProcessGroup*> m_processTree;
+  QList<ProcessGroup*> m_processGroups;
+
+  void handleProcEvent(struct cn_msg*);
+
+ private slots:
+  void readData();
+};
+
+#endif  // PIDTRACKER_H

--- a/src/platforms/linux/daemon/pidtracker.h
+++ b/src/platforms/linux/daemon/pidtracker.h
@@ -16,15 +16,19 @@ struct cn_msg;
 
 class ProcessGroup {
  public:
-  ProcessGroup(const QString& groupName, int groupRootPid) {
+  ProcessGroup(const QString& groupName, int groupRootPid,
+               const QString& groupState = "active") {
     MVPN_COUNT_CTOR(ProcessGroup);
     name = groupName;
     rootpid = groupRootPid;
+    state = groupState;
     refcount = 0;
   }
   ~ProcessGroup() { MVPN_COUNT_DTOR(ProcessGroup); }
+
   QHash<int, uint> kthreads;
   QString name;
+  QString state;
   int rootpid;
   int refcount;
 };
@@ -42,7 +46,7 @@ class PidTracker final : public QObject {
   QList<int> pids() { return m_processTree.keys(); }
   QList<ProcessGroup*>::iterator begin() { return m_processGroups.begin(); }
   QList<ProcessGroup*>::iterator end() { return m_processGroups.end(); }
-  const ProcessGroup* group(int pid) { return m_processTree.value(pid); }
+  ProcessGroup* group(int pid) { return m_processTree.value(pid); }
 
  signals:
   void pidForked(const QString& name, int parent, int child);

--- a/src/platforms/linux/daemon/pidtracker.h
+++ b/src/platforms/linux/daemon/pidtracker.h
@@ -43,7 +43,7 @@ class PidTracker final : public QObject {
   explicit PidTracker(QObject* parent);
   ~PidTracker();
 
-  void track(const QString& name, int rootpid);
+  ProcessGroup* track(const QString& name, int rootpid);
 
   QList<int> pids() { return m_processTree.keys(); }
   QList<ProcessGroup*>::iterator begin() { return m_processGroups.begin(); }
@@ -56,16 +56,17 @@ class PidTracker final : public QObject {
   void terminated(const QString& name, int rootpid);
 
  private:
+  void handleProcEvent(struct cn_msg*);
+
+ private slots:
+  void readData();
+
+ private:
   int m_nlsock;
   char m_readBuf[2048];
   QSocketNotifier* m_socket;
   QHash<int, ProcessGroup*> m_processTree;
   QList<ProcessGroup*> m_processGroups;
-
-  void handleProcEvent(struct cn_msg*);
-
- private slots:
-  void readData();
 };
 
 #endif  // PIDTRACKER_H

--- a/src/platforms/linux/daemon/wireguardutilslinux.h
+++ b/src/platforms/linux/daemon/wireguardutilslinux.h
@@ -23,6 +23,10 @@ class WireguardUtilsLinux final : public WireguardUtils {
   bool addRoutePrefix(const IPAddressRange& prefix) override;
   peerBytes getThroughputForInterface() override;
 
+  QString getDefaultCgroup() const { return m_cgroups; }
+  QString getExcludeCgroup() const;
+  QString getBlockCgroup() const;
+
  private:
   QStringList currentInterfaces();
   bool setPeerEndpoint(struct sockaddr* peerEndpoint, const QString& address,
@@ -33,7 +37,7 @@ class WireguardUtilsLinux final : public WireguardUtils {
                           const InterfaceConfig& conf);
   bool setRouteRules(int action, int flags, int addrfamily);
   bool setRoutePrefix(int action, int flags, const IPAddressRange& prefix);
-  unsigned long getCgroupClass(const QString& path);
+  static bool setupCgroupClass(const QString& path, unsigned long classid);
 
   int m_nlsock = -1;
   int m_nlseq = 0;

--- a/src/platforms/linux/dbusclient.cpp
+++ b/src/platforms/linux/dbusclient.cpp
@@ -48,7 +48,8 @@ QDBusPendingCallWatcher* DBusClient::version() {
 
 QDBusPendingCallWatcher* DBusClient::activate(
     const Server& server, const Device* device, const Keys* keys,
-    const QList<IPAddressRange>& allowedIPAddressRanges) {
+    const QList<IPAddressRange>& allowedIPAddressRanges,
+    const QStringList& vpnDisabledApps) {
   QJsonObject json;
   json.insert("privateKey", QJsonValue(keys->privateKey()));
   json.insert("deviceIpv4Address", QJsonValue(device->ipv4Address()));
@@ -71,6 +72,13 @@ QDBusPendingCallWatcher* DBusClient::activate(
     allowedIPAddesses.append(range);
   };
   json.insert("allowedIPAddressRanges", allowedIPAddesses);
+
+  QJsonArray disabledApps;
+  for (const QString& i : vpnDisabledApps) {
+    disabledApps.append(QJsonValue(i));
+    logger.log() << "Disabling:" << i;
+  }
+  json.insert("vpnDisabledApps", disabledApps);
 
   logger.log() << "Activate via DBus";
   QDBusPendingReply<bool> reply =

--- a/src/platforms/linux/dbusclient.h
+++ b/src/platforms/linux/dbusclient.h
@@ -28,7 +28,8 @@ class DBusClient final : public QObject {
 
   QDBusPendingCallWatcher* activate(
       const Server& server, const Device* device, const Keys* keys,
-      const QList<IPAddressRange>& allowedIPAddressRanges);
+      const QList<IPAddressRange>& allowedIPAddressRanges,
+      const QStringList& vpnDisabledApps);
 
   QDBusPendingCallWatcher* deactivate();
 

--- a/src/platforms/linux/linuxappimageprovider.cpp
+++ b/src/platforms/linux/linuxappimageprovider.cpp
@@ -6,11 +6,15 @@
 #include "logger.h"
 #include "leakdetector.h"
 
+#include <QDir>
+#include <QDirIterator>
+#include <QProcessEnvironment>
+#include <QString>
 #include <QSettings>
 #include <QIcon>
 
-constexpr const char* DESKTOP_ENTRY_LOCATION = "/usr/share/applications/";
 constexpr const char* PIXMAP_FALLBACK_PATH = "/usr/share/pixmaps/";
+constexpr const char* DESKTOP_ICON_LOCATION = "/usr/share/icons/";
 
 namespace {
 Logger logger(LOG_CONTROLLER, "LinuxAppImageProvider");
@@ -21,18 +25,47 @@ LinuxAppImageProvider::LinuxAppImageProvider(QObject* parent)
                           QQmlImageProviderBase::ForceAsynchronousImageLoading),
       QObject(parent) {
   MVPN_COUNT_CTOR(LinuxAppImageProvider);
-  QIcon::setFallbackSearchPaths(QIcon::fallbackSearchPaths() << PIXMAP_FALLBACK_PATH);
+
+  QStringList searchPaths = QIcon::fallbackSearchPaths();
+
+  QProcessEnvironment pe = QProcessEnvironment::systemEnvironment();
+  if (pe.contains("XDG_DATA_DIRS")) {
+    QStringList parts = pe.value("XDG_DATA_DIRS").split(":");
+    for (const QString& part : parts) {
+      addFallbackPaths(part + "/icons", searchPaths);
+    }
+  } else {
+    addFallbackPaths(DESKTOP_ICON_LOCATION, searchPaths);
+  }
+
+  if (pe.contains("HOME")) {
+    addFallbackPaths(pe.value("HOME") + "/.local/share/icons", searchPaths);
+  }
+
+  searchPaths << PIXMAP_FALLBACK_PATH;
+  QIcon::setFallbackSearchPaths(searchPaths);
 }
 
 LinuxAppImageProvider::~LinuxAppImageProvider() {
   MVPN_COUNT_DTOR(LinuxAppImageProvider);
 }
 
+void LinuxAppImageProvider::addFallbackPaths(const QString& iconDir,
+                                             QStringList& searchPaths) {
+  searchPaths << iconDir;
+
+  QDirIterator iter(iconDir, QDir::Dirs | QDir::NoDotAndDotDot);
+  while (iter.hasNext()) {
+    QFileInfo fileinfo(iter.next());
+    logger.log() << "Adding QIcon fallback:" << fileinfo.absoluteFilePath();
+    searchPaths << fileinfo.absoluteFilePath();
+  }
+}
+
 // from QQuickImageProvider
 QImage LinuxAppImageProvider::requestImage(const QString& id, QSize* size,
-                                             const QSize& requestedSize) {
-
-  QSettings entry(QString(DESKTOP_ENTRY_LOCATION) + "/" + id, QSettings::IniFormat);
+                                           const QSize& requestedSize) {
+  QSettings entry(id, QSettings::IniFormat);
   entry.beginGroup("Desktop Entry");
   QString name = entry.value("Icon").toString();
 
@@ -40,7 +73,8 @@ QImage LinuxAppImageProvider::requestImage(const QString& id, QSize* size,
   QPixmap pixmap = icon.pixmap(requestedSize);
   size->setHeight(pixmap.height());
   size->setWidth(pixmap.width());
-  logger.log() << "Loaded icon" << icon.name() << "size:" << pixmap.width() << "x" << pixmap.height();
+  logger.log() << "Loaded icon" << icon.name() << "size:" << pixmap.width()
+               << "x" << pixmap.height();
 
   return pixmap.toImage();
 }

--- a/src/platforms/linux/linuxappimageprovider.cpp
+++ b/src/platforms/linux/linuxappimageprovider.cpp
@@ -1,0 +1,46 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "linuxappimageprovider.h"
+#include "logger.h"
+#include "leakdetector.h"
+
+#include <QSettings>
+#include <QIcon>
+
+constexpr const char* DESKTOP_ENTRY_LOCATION = "/usr/share/applications/";
+constexpr const char* PIXMAP_FALLBACK_PATH = "/usr/share/pixmaps/";
+
+namespace {
+Logger logger(LOG_CONTROLLER, "LinuxAppImageProvider");
+}
+
+LinuxAppImageProvider::LinuxAppImageProvider(QObject* parent)
+    : QQuickImageProvider(QQuickImageProvider::Image,
+                          QQmlImageProviderBase::ForceAsynchronousImageLoading),
+      QObject(parent) {
+  MVPN_COUNT_CTOR(LinuxAppImageProvider);
+  QIcon::setFallbackSearchPaths(QIcon::fallbackSearchPaths() << PIXMAP_FALLBACK_PATH);
+}
+
+LinuxAppImageProvider::~LinuxAppImageProvider() {
+  MVPN_COUNT_DTOR(LinuxAppImageProvider);
+}
+
+// from QQuickImageProvider
+QImage LinuxAppImageProvider::requestImage(const QString& id, QSize* size,
+                                             const QSize& requestedSize) {
+
+  QSettings entry(QString(DESKTOP_ENTRY_LOCATION) + "/" + id, QSettings::IniFormat);
+  entry.beginGroup("Desktop Entry");
+  QString name = entry.value("Icon").toString();
+
+  QIcon icon = QIcon::fromTheme(name);
+  QPixmap pixmap = icon.pixmap(requestedSize);
+  size->setHeight(pixmap.height());
+  size->setWidth(pixmap.width());
+  logger.log() << "Loaded icon" << icon.name() << "size:" << pixmap.width() << "x" << pixmap.height();
+
+  return pixmap.toImage();
+}

--- a/src/platforms/linux/linuxappimageprovider.h
+++ b/src/platforms/linux/linuxappimageprovider.h
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef LINUXAPPIMAGEPROVIDER_H
+#define LINUXAPPIMAGEPROVIDER_H
+
+#include <QObject>
+#include <QQuickImageProvider>
+
+class LinuxAppImageProvider final : public QQuickImageProvider,
+                                      public QObject {
+ public:
+  LinuxAppImageProvider(QObject* parent);
+  ~LinuxAppImageProvider();
+  QImage requestImage(const QString& id, QSize* size,
+                      const QSize& requestedSize) override;
+};
+
+#endif  // LINUXAPPIMAGEPROVIDER_H

--- a/src/platforms/linux/linuxappimageprovider.h
+++ b/src/platforms/linux/linuxappimageprovider.h
@@ -8,13 +8,16 @@
 #include <QObject>
 #include <QQuickImageProvider>
 
-class LinuxAppImageProvider final : public QQuickImageProvider,
-                                      public QObject {
+class LinuxAppImageProvider final : public QQuickImageProvider, public QObject {
  public:
   LinuxAppImageProvider(QObject* parent);
   ~LinuxAppImageProvider();
   QImage requestImage(const QString& id, QSize* size,
                       const QSize& requestedSize) override;
+
+ private:
+  static void addFallbackPaths(const QString& dataDir,
+                               QStringList& fallbackPaths);
 };
 
 #endif  // LINUXAPPIMAGEPROVIDER_H

--- a/src/platforms/linux/linuxapplistprovider.cpp
+++ b/src/platforms/linux/linuxapplistprovider.cpp
@@ -1,0 +1,50 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "linuxapplistprovider.h"
+#include "leakdetector.h"
+
+#include <QProcess>
+#include <QString>
+#include <QDir>
+#include <QDirIterator>
+#include <QSettings>
+
+#include "logger.h"
+#include "leakdetector.h"
+
+constexpr const char* DESKTOP_ENTRY_LOCATION = "/usr/share/applications/";
+
+namespace {
+Logger logger(LOG_CONTROLLER, "LinuxAppListProvider");
+}
+
+LinuxAppListProvider::LinuxAppListProvider(QObject* parent)
+    : AppListProvider(parent) {
+  MVPN_COUNT_CTOR(LinuxAppListProvider);
+}
+
+void LinuxAppListProvider::getApplicationList() {
+  logger.log() << "Fetch Application list from Linux desktop";
+
+  QMap<QString, QString> out;
+  QDirIterator iter(DESKTOP_ENTRY_LOCATION, QStringList() << "*.desktop", QDir::Files);
+  while (iter.hasNext()) {
+    QFileInfo fileinfo(iter.next());
+    QSettings entry(fileinfo.filePath(), QSettings::IniFormat);
+    entry.beginGroup("Desktop Entry");
+
+    /* Filter out everything except visible applications. */
+    if (entry.value("Type").toString() != "Application") {
+      continue;
+    }
+    if (entry.value("NoDisplay", QVariant(false)).toBool()) {
+      continue;
+    }
+
+    out[fileinfo.fileName()] = entry.value("Name").toString();
+  }
+
+  emit newAppList(out);
+}

--- a/src/platforms/linux/linuxapplistprovider.h
+++ b/src/platforms/linux/linuxapplistprovider.h
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef LINUXAPPLISTPROVIDER_H
+#define LINUXAPPLISTPROVIDER_H
+
+#include <applistprovider.h>
+#include <QObject>
+#include <QProcess>
+
+class LinuxAppListProvider : public AppListProvider {
+  Q_OBJECT
+ public:
+  LinuxAppListProvider(QObject* parent);
+  void getApplicationList() override;
+};
+
+#endif  // LINUXAPPLISTPROVIDER_H

--- a/src/platforms/linux/linuxapplistprovider.h
+++ b/src/platforms/linux/linuxapplistprovider.h
@@ -9,10 +9,10 @@
 #include <QObject>
 #include <QProcess>
 
-class LinuxAppListProvider : public AppListProvider {
+class LinuxAppListProvider final : public AppListProvider {
   Q_OBJECT
  public:
-  LinuxAppListProvider(QObject* parent);
+  explicit LinuxAppListProvider(QObject* parent);
   ~LinuxAppListProvider();
   void getApplicationList() override;
 

--- a/src/platforms/linux/linuxapplistprovider.h
+++ b/src/platforms/linux/linuxapplistprovider.h
@@ -13,7 +13,11 @@ class LinuxAppListProvider : public AppListProvider {
   Q_OBJECT
  public:
   LinuxAppListProvider(QObject* parent);
+  ~LinuxAppListProvider();
   void getApplicationList() override;
+
+ private:
+  void fetchEntries(const QString& dataDir, QMap<QString, QString>& map);
 };
 
 #endif  // LINUXAPPLISTPROVIDER_H

--- a/src/platforms/linux/linuxcontroller.cpp
+++ b/src/platforms/linux/linuxcontroller.cpp
@@ -74,7 +74,8 @@ void LinuxController::activate(
   Q_UNUSED(vpnDisabledApps);
 
   logger.log() << "LinuxController activated";
-  connect(m_dbus->activate(server, device, keys, allowedIPAddressRanges),
+  connect(m_dbus->activate(server, device, keys, allowedIPAddressRanges,
+                           vpnDisabledApps),
           &QDBusPendingCallWatcher::finished, this,
           &LinuxController::operationCompleted);
 }

--- a/src/src.pro
+++ b/src/src.pro
@@ -335,6 +335,8 @@ else:linux:!android {
             eventlistener.cpp \
             platforms/linux/backendlogsobserver.cpp \
             platforms/linux/dbusclient.cpp \
+            platforms/linux/linuxappimageprovider.cpp \
+            platforms/linux/linuxapplistprovider.cpp \
             platforms/linux/linuxcontroller.cpp \
             platforms/linux/linuxcryptosettings.cpp \
             platforms/linux/linuxdependencies.cpp \
@@ -349,6 +351,8 @@ else:linux:!android {
             eventlistener.h \
             platforms/linux/backendlogsobserver.h \
             platforms/linux/dbusclient.h \
+            platforms/linux/linuxappimageprovider.h \
+            platforms/linux/linuxapplistprovider.h \
             platforms/linux/linuxcontroller.h \
             platforms/linux/linuxdependencies.h \
             platforms/linux/linuxnetworkwatcher.h \

--- a/src/src.pro
+++ b/src/src.pro
@@ -370,6 +370,7 @@ else:linux:!android {
             platforms/linux/daemon/dnsutilslinux.cpp \
             platforms/linux/daemon/iputilslinux.cpp \
             platforms/linux/daemon/linuxdaemon.cpp \
+            platforms/linux/daemon/pidtracker.cpp \
             platforms/linux/daemon/polkithelper.cpp \
             platforms/linux/daemon/wireguardutilslinux.cpp
 
@@ -384,6 +385,7 @@ else:linux:!android {
             platforms/linux/daemon/dbustypeslinux.h \
             platforms/linux/daemon/dnsutilslinux.h \
             platforms/linux/daemon/iputilslinux.h \
+            platforms/linux/daemon/pidtracker.h \
             platforms/linux/daemon/polkithelper.h \
             platforms/linux/daemon/wireguardutilslinux.h
 

--- a/src/src.pro
+++ b/src/src.pro
@@ -366,6 +366,7 @@ else:linux:!android {
     SOURCES += \
             ../3rdparty/wireguard-tools/contrib/embeddable-wg-library/wireguard.c \
             daemon/daemon.cpp \
+            platforms/linux/daemon/apptracker.cpp \
             platforms/linux/daemon/dbusservice.cpp \
             platforms/linux/daemon/dnsutilslinux.cpp \
             platforms/linux/daemon/iputilslinux.cpp \
@@ -381,6 +382,7 @@ else:linux:!android {
             daemon/dnsutils.h \
             daemon/iputils.h \
             daemon/wireguardutils.h \
+            platforms/linux/daemon/apptracker.h \
             platforms/linux/daemon/dbusservice.h \
             platforms/linux/daemon/dbustypeslinux.h \
             platforms/linux/daemon/dnsutilslinux.h \


### PR DESCRIPTION
This is a rebase of PR  #996 to merge the firewall and daemon together into the same D-Bus servce and to incorporate the changes resulting from the removal of the Linux helper script in commit 2f291e35db90ada46fbbe95c3c0d891364ed3a23

This change still lacks a solution to the shared DNS cache/resolvers provided by systemd, so there still exists a potential for the VPN to be detected by an application excluded from the VPN, but I think that should be addressed as a separate issue.
