### PR TITLE
Pass glean version when invoking glean_parser.

### DIFF
--- a/scripts/generate_glean.py
+++ b/scripts/generate_glean.py
@@ -41,7 +41,7 @@ def run_glean_parser(yaml):
   try:
     subprocess.call(["glean_parser", "translate", yaml, "-f", "javascript",
                      "-o", "glean/generated", "--option", "platform=qt",
-                     "--option", "namespace=RealGlean"])
+                     "--option", "namespace=RealGlean", "--option", "version=0.11"])
     return True
   except:
     print("glean_parser failed. Is it installed? Try with:\n\tpip3 install glean_parser");


### PR DESCRIPTION
The latest update to glean v3.5 now requires the `glean.js` version passed when invoking `glean_parser`