### PR TITLE
Fix OpenGL framebuffer crash on Linux

### DIFF
--- a/src/ui/components/VPNAnimatedRings.qml
+++ b/src/ui/components/VPNAnimatedRings.qml
@@ -163,6 +163,7 @@ Rectangle {
         width: animatedRingsWrapper.width
         anchors.fill: animatedRingsWrapper
         onRing1RadiusChanged: makeDirty()
+        renderTarget: (Qt.platform.os !== "ios") ? Canvas.FramebufferObject : Canvas.Image
 
         contextType: "2d"
         onPaint: {
@@ -193,13 +194,7 @@ Rectangle {
                 drawRing(ctx, ring3Radius, ring3BorderWidth);
         }
 
-        Component.onCompleted: {
-            if (Qt.platform.os !== "ios") {
-                renderTarget = Canvas.FramebufferObject
-            }
-
-            resetRingValues();
-        }
+        Component.onCompleted: resetRingValues()
     }
 
     RadialGradient {


### PR DESCRIPTION
In recent builds of the VPN client, I have been experiencing intermittent crashes when loading the main view. Backtraces show that a null `this` pointer is making its way into the OpenGL context during the Qt canvas creation and things go badly from there. I first encountered this on my Fedora/RPM pull request (mozilla-mobile/mozilla-vpn-client/pull/1122) but I think users have been experiencing this in the 2.3.0 release (mozilla-mobile/mozilla-vpn-client/issues/1150)