### PR TITLE
Add data review URL for Mozilla VPN metrics

### DIFF
--- a/glean/pings.yaml
+++ b/glean/pings.yaml
@@ -17,6 +17,6 @@ main:
   bugs:
     - https://bugzilla.mozilla.org/show_bug.cgi?id=1708637
   data_reviews:
-    - TBD
+    - https://bugzilla.mozilla.org/show_bug.cgi?id=1711123
   notification_emails:
     - amarchesini@mozilla.com


### PR DESCRIPTION
It seems to be missing per https://dictionary.telemetry.mozilla.org/apps/mozilla_vpn/pings/main?showExpired=1