### PR TITLE
Fix package upgrade from 2.2.0 when daemon is not running

### DIFF
--- a/linux/debian/mozillavpn.preinst
+++ b/linux/debian/mozillavpn.preinst
@@ -2,6 +2,6 @@
 action="$1"
 if [ "$action" = "upgrade" ]; then
   if dpkg --compare-versions "$2" lt 2.3.0; then
-    killall mozillavpn 2>/dev/null
+    killall -q mozillavpn || true
   fi
 fi


### PR DESCRIPTION
For versions 2.2.0 and earlier, there is no systemd service file, so we must manually kill the daemon when performing an upgrade. However, if the daemon is not running at the time of an upgrade then `killall` will return an error which Debian will interpret as a package installation failure. In this particular case we should ignore the error and continue installation.

Closes: #1158 