### PR TITLE
Fix OpenGL framebuffer crash on Linux again

### DIFF
--- a/src/ui/components/VPNAnimatedRings.qml
+++ b/src/ui/components/VPNAnimatedRings.qml
@@ -163,7 +163,7 @@ Rectangle {
         width: animatedRingsWrapper.width
         anchors.fill: animatedRingsWrapper
         onRing1RadiusChanged: makeDirty()
-        renderTarget: (Qt.platform.os !== "ios") ? Canvas.FramebufferObject : Canvas.Image
+        renderTarget: Canvas.FramebufferObject
 
         contextType: "2d"
         onPaint: {
@@ -194,7 +194,12 @@ Rectangle {
                 drawRing(ctx, ring3Radius, ring3BorderWidth);
         }
 
-        Component.onCompleted: resetRingValues()
+        Component.onCompleted: {
+            if (Qt.platform.os === "ios") {
+                renderTarget = Canvas.Image
+            }
+            resetRingValues()
+        }
     }
 
     RadialGradient {


### PR DESCRIPTION
This is starting to get into cargo cult programming, but it seems that the issue is still related to changing the renderTarget
programmatically in QML, regardless of whether it occurs in the onComplete handler or elsewhere.

Since it seems that the dynamic selection of the renderTarget was added for an iOS bug it seems a bit more sensible to change the target only for iOS.

Closes: mozilla-mobile/mozilla-vpn-client/issues/1150