### PR TITLE
Fix segfault if LinuxNetworkWatcher loads before qApp->exec()

### DIFF
--- a/src/platforms/linux/linuxnetworkwatcher.h
+++ b/src/platforms/linux/linuxnetworkwatcher.h
@@ -23,7 +23,6 @@ class LinuxNetworkWatcher final : public NetworkWatcherImpl {
   void start() override;
 
  signals:
-  void initializeInThread();
   void checkDevicesInThread();
 
  private:


### PR DESCRIPTION
Because the `LinuxNetworkWatcherWorker` runs in its own thread, even the delaying call to `checkDevices()` can occur before the main `QEventLoop` starts, leading to potential race conditions. To prevent such races, the `initialize()` call should be invoked from a timer owned by the main `QEventLoop`.