### PR TITLE
Set LinuxNetworkWatcherWorker::initialize as a public slot

### DIFF
--- a/src/platforms/linux/linuxnetworkwatcherworker.h
+++ b/src/platforms/linux/linuxnetworkwatcherworker.h
@@ -19,12 +19,13 @@ class LinuxNetworkWatcherWorker final : public QObject {
   explicit LinuxNetworkWatcherWorker(QThread* thread);
   ~LinuxNetworkWatcherWorker();
 
-  void initialize();
-
   void checkDevices();
 
  signals:
   void unsecuredNetwork(const QString& networkName, const QString& networkId);
+
+ public slots:
+  void initialize();
 
  private slots:
   void propertyChanged(QString interface, QVariantMap properties,


### PR DESCRIPTION
Debugging #1187 I found that initialize() needs to be defined as a public slot.