### PR TITLE
Fix SIGABRT on linux during the shutdown - closes #1187

### DIFF
--- a/src/commands/commandui.cpp
+++ b/src/commands/commandui.cpp
@@ -123,6 +123,11 @@ int CommandUI::run(QStringList& tokens) {
       }
     }
 
+    // This object _must_ live longer than MozillaVPN to avoid shutdown crashes.
+    QmlEngineHolder engineHolder;
+    QQmlApplicationEngine* engine = QmlEngineHolder::instance()->engine();
+    engine->addImportPath("qrc:///glean");
+
     MozillaVPN vpn;
     vpn.setStartMinimized(minimizedOption.m_set);
 
@@ -151,10 +156,6 @@ int CommandUI::run(QStringList& tokens) {
     // Font loader
     FontLoader::loadFonts();
 
-    // Create the QML engine and expose a few internal objects.
-    QmlEngineHolder engineHolder;
-    QQmlApplicationEngine* engine = QmlEngineHolder::instance()->engine();
-    engine->addImportPath("qrc:///glean");
     vpn.initialize();
 
 #ifdef MVPN_MACOS

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -31,6 +31,7 @@ CREATE_LOG_OP_REF(uint64_t);
 CREATE_LOG_OP_REF(const char*);
 CREATE_LOG_OP_REF(const QString&);
 CREATE_LOG_OP_REF(const QByteArray&);
+CREATE_LOG_OP_REF(void*);
 
 #undef CREATE_LOG_OP_REF
 

--- a/src/logger.h
+++ b/src/logger.h
@@ -56,6 +56,7 @@ class Logger {
     Log& operator<<(const QStringList& t);
     Log& operator<<(const QByteArray& t);
     Log& operator<<(QTextStreamFunction t);
+    Log& operator<<(void* t);
 
    private:
     Logger* m_logger;


### PR DESCRIPTION
There are two issues here:
- SignalHandler receives signal notifications on random threads. This is fixed
  using QMetaObject::invokeMethod to emit signals.
- QmlEngineHolder must be created before MozillaVPN to avoid memory corruption