### PR TITLE
Fix deadlock due to unsafe signal handling

### DIFF
--- a/src/signalhandler.h
+++ b/src/signalhandler.h
@@ -6,15 +6,23 @@
 #define SIGNALHANDLER_H
 
 #include <QObject>
+#include <QSocketNotifier>
 
 class SignalHandler final : public QObject {
   Q_OBJECT
 
  public:
   SignalHandler();
+  ~SignalHandler();
+
+ private slots:
+  void pipeReadReady();
 
  private:
   static void saHandler(int signal);
+
+  int m_pipefds[2] = {-1, -1};
+  QSocketNotifier* m_notifier = nullptr;
 
  signals:
   void quitRequested();


### PR DESCRIPTION
While testing #1187 I found that somewhere around 2% of the time while handling a POSIX signal, the VPN client will deadlock on the logger mutex. To prevent the problem we can write the signal to a pipe, and use the read end of the pipe to emit the necessary Qt signals to terminate the application gracefully.

Unfortunately, signal safety didn't seem to be the culprit for #1187