### PR TITLE
✨Experiment✨ Extend custom DNS with AD & Tracking Protection

### DIFF
--- a/src/platforms/windows/windowsnetworkwatcher.cpp
+++ b/src/platforms/windows/windowsnetworkwatcher.cpp
@@ -40,7 +40,8 @@ void WindowsNetworkWatcher::initialize() {
 
   DWORD prefNotifSource;
   if (WlanRegisterNotification(m_wlanHandle, WLAN_NOTIFICATION_SOURCE_MSM,
-                               true /* ignore duplicates */, wlanCallback, this,
+                               true /* ignore duplicates */,
+                               (WLAN_NOTIFICATION_CALLBACK)wlanCallback, this,
                                nullptr, &prefNotifSource) != ERROR_SUCCESS) {
     WindowsCommons::windowsLog("Failed to register a wlan callback");
     return;

--- a/src/qml.qrc
+++ b/src/qml.qrc
@@ -462,5 +462,6 @@
         <file>ui/components/VPNTabNavigation.qml</file>
         <file>ui/resources/encodedPassword.txt</file>
         <file>ui/developerMenu/ViewFeatureList.qml</file>
+        <file>ui/components/VPNViewDNSSettings.qml</file>
     </qresource>
 </RCC>

--- a/src/rfc/rfc4193.cpp
+++ b/src/rfc/rfc4193.cpp
@@ -12,3 +12,13 @@ QList<IPAddress> RFC4193::ipv6() {
 
   return list;
 }
+
+bool RFC4193::contains(const QHostAddress& ip) {
+  QList<IPAddress> list = ipv6();
+  foreach (const IPAddress& addr, list) {
+    if (addr.contains(ip)) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/src/rfc/rfc4193.h
+++ b/src/rfc/rfc4193.h
@@ -12,6 +12,7 @@
 class RFC4193 final {
  public:
   static QList<IPAddress> ipv6();
+  static bool contains(const QHostAddress& ip);
 };
 
 #endif  // RFC4193_H

--- a/src/settingsholder.cpp
+++ b/src/settingsholder.cpp
@@ -14,6 +14,7 @@
 #include "rfc/rfc5735.h"
 
 #include "features/featurecaptiveportal.h"
+#include "features/featurecustomdns.h"
 #include "features/featurelocalareaaccess.h"
 #include "features/featuresplittunnel.h"
 #include "features/featurestartonboot.h"
@@ -30,11 +31,10 @@ constexpr bool SETTINGS_STARTATBOOT_DEFAULT = false;
 constexpr bool SETTINGS_PROTECTSELECTEDAPPS_DEFAULT = false;
 constexpr bool SETTINGS_SERVERSWITCHNOTIFICATION_DEFAULT = true;
 constexpr bool SETTINGS_CONNECTIONSWITCHNOTIFICATION_DEFAULT = true;
-constexpr bool SETTINGS_USEGATEWAYDNS_DEFAULT = true;
 const QStringList SETTINGS_DEFAULT_EMPTY_LIST = QStringList();
 constexpr const char* SETTINGS_USER_DNS_DEFAULT = "";
 constexpr bool SETTINGS_MULTIHOP_TUNNEL_DEFAULT = false;
-
+const int SETTINGS_DNS_PROVIDER_DEFAULT = SettingsHolder::DnsProvider::Gateway;
 constexpr const char* SETTINGS_IPV6ENABLED = "ipv6Enabled";
 constexpr const char* SETTINGS_LOCALNETWORKACCESS = "localNetworkAccess";
 constexpr const char* SETTINGS_UNSECUREDNETWORKALERT = "unsecuredNetworkAlert";
@@ -53,9 +53,9 @@ constexpr const char* SETTINGS_TOKEN = "token";
 constexpr const char* SETTINGS_SERVERS = "servers";
 constexpr const char* SETTINGS_PRIVATEKEY = "privateKey";
 constexpr const char* SETTINGS_PUBLICKEY = "publicKey";
-constexpr const char* SETTINGS_USEGATEWAYDNS = "useGatewayDNS";
+constexpr const char* SETTINGS_USER_DNS = "userDNS";
+constexpr const char* SETTINGS_DNS_PROVIDER = "dnsProvider";
 constexpr const char* SETTINGS_USER_AVATAR = "user/avatar";
-constexpr const char* SETTINGS_USER_DNS = "user/dns";
 constexpr const char* SETTINGS_USER_DISPLAYNAME = "user/displayName";
 constexpr const char* SETTINGS_USER_EMAIL = "user/email";
 constexpr const char* SETTINGS_USER_MAXDEVICES = "user/maxDevices";
@@ -219,9 +219,6 @@ GETSETDEFAULT(FeatureLocalAreaAccess::instance()->isSupported() &&
               bool, toBool, SETTINGS_LOCALNETWORKACCESS, hasLocalNetworkAccess,
               localNetworkAccess, setLocalNetworkAccess,
               localNetworkAccessChanged)
-GETSETDEFAULT(SETTINGS_USEGATEWAYDNS_DEFAULT, bool, toBool,
-              SETTINGS_USEGATEWAYDNS, hasUsegatewayDNS, useGatewayDNS,
-              setUseGatewayDNS, useGatewayDNSChanged)
 GETSETDEFAULT(SETTINGS_USER_DNS_DEFAULT, QString, toString, SETTINGS_USER_DNS,
               hasUserDNS, userDNS, setUserDNS, userDNSChanged)
 GETSETDEFAULT(SETTINGS_MULTIHOP_TUNNEL_DEFAULT, bool, toBool,
@@ -267,6 +264,8 @@ GETSETDEFAULT(SETTINGS_DEVELOPERUNLOCK_DEFAULT, bool, toBool,
 GETSETDEFAULT(SETTINGS_STAGINGSERVER_DEFAULT, bool, toBool,
               SETTINGS_STAGINGSERVER, hasStagingServer, stagingServer,
               setStagingServer, stagingServerChanged)
+GETSETDEFAULT(SETTINGS_DNS_PROVIDER_DEFAULT, int, toInt, SETTINGS_DNS_PROVIDER,
+              hasDNSProvider, dnsProvider, setDNSProvider, dnsProviderChanged)
 GETSETDEFAULT(SETTINGS_DEFAULT_EMPTY_LIST, QStringList, toStringList,
               SETTINGS_DEVMODE_FEATURE_FLAGS, hasDevModeFeatureFlags,
               devModeFeatureFlags, setDevModeFeatureFlags,
@@ -434,9 +433,9 @@ void SettingsHolder::addConsumedSurvey(const QString& surveyId) {
 }
 
 bool SettingsHolder::validateUserDNS(const QString& dns) const {
-  logger.debug() << "checking -> " << dns;
   QHostAddress address = QHostAddress(dns);
-  return address.isNull();
+  logger.debug() << "checking -> " << dns << "==" << !address.isNull();
+  return !address.isNull();
 }
 
 QString SettingsHolder::placeholderUserDNS() const {
@@ -458,6 +457,7 @@ void SettingsHolder::enableDevModeFeatureFlag(const QString& featureID) {
   features.append(featureID);
   setDevModeFeatureFlags(features);
 }
+
 void SettingsHolder::removeDevModeFeatureFlag(const QString& featureID) {
   QStringList features;
   if (hasDevModeFeatureFlags()) {
@@ -465,4 +465,43 @@ void SettingsHolder::removeDevModeFeatureFlag(const QString& featureID) {
   }
   features.removeAll(featureID);
   setDevModeFeatureFlags(features);
+}
+
+// Returns the DNS Server the user asked for in the Settings;
+constexpr const char* MULLVAD_BLOCK_ADS_DNS = "100.64.0.1";
+constexpr const char* MULLVAD_BLOCK_TRACKING_DNS = "100.64.0.2";
+constexpr const char* MULLVAD_BLOCK_ALL_DNS = "100.64.0.3";
+
+QString SettingsHolder::getDNS(const QString& serverGateWay) {
+  if (!FeatureCustomDNS::instance()->isSupported()) {
+    return serverGateWay;
+  }
+
+  switch (dnsProvider()) {
+    case Gateway:
+      return serverGateWay;
+    case BlockAll:
+      return MULLVAD_BLOCK_ALL_DNS;
+    case BlockAds:
+      return MULLVAD_BLOCK_ADS_DNS;
+    case BlockTracking:
+      return MULLVAD_BLOCK_TRACKING_DNS;
+    case Custom:
+    default:
+      break;
+  }
+  Q_ASSERT(dnsProvider() == Custom);
+  QString dns = userDNS();
+  // User wants to use a Custom DNS, let's check that this is valid.
+  if (dns == SETTINGS_USER_DNS_DEFAULT) {
+    // User selected Custom but did not enter a dns,
+    // lets fallback
+    return serverGateWay;
+  }
+  if (!validateUserDNS(dns)) {
+    logger.debug()
+        << "Saved Custom DNS seems invalid, defaulting to gateway dns";
+    return serverGateWay;
+  }
+  return dns;
 }

--- a/src/settingsholder.cpp
+++ b/src/settingsholder.cpp
@@ -6,6 +6,7 @@
 #include "constants.h"
 #include "cryptosettings.h"
 #include "featurelist.h"
+#include "ipaddress.h"
 #include "leakdetector.h"
 #include "logger.h"
 #include "rfc/rfc1918.h"
@@ -504,4 +505,9 @@ QString SettingsHolder::getDNS(const QString& serverGateWay) {
     return serverGateWay;
   }
   return dns;
+}
+
+bool SettingsHolder::isMullvadDNS(const QString& address) {
+  IPAddress mullvadAddresses = IPAddress::create("100.64.0.0/24");
+  return mullvadAddresses.contains(QHostAddress(address));
 }

--- a/src/settingsholder.h
+++ b/src/settingsholder.h
@@ -34,25 +34,32 @@ class SettingsHolder final : public QObject {
   Q_PROPERTY(bool connectionChangeNotification READ connectionChangeNotification
                  WRITE setConnectionChangeNotification NOTIFY
                      connectionChangeNotificationChanged)
-
-  Q_PROPERTY(bool useGatewayDNS READ useGatewayDNS WRITE setUseGatewayDNS NOTIFY
-                 useGatewayDNSChanged)
-  Q_PROPERTY(
-      QString userDNS READ userDNS WRITE setUserDNS NOTIFY userDNSChanged)
   Q_PROPERTY(QString placeholderUserDNS READ placeholderUserDNS CONSTANT)
-
   Q_PROPERTY(bool developerUnlock READ developerUnlock WRITE setDeveloperUnlock
                  NOTIFY developerUnlockChanged)
   Q_PROPERTY(bool stagingServer READ stagingServer WRITE setStagingServer NOTIFY
                  stagingServerChanged)
   Q_PROPERTY(bool multihopTunnel READ multihopTunnel WRITE setMultihopTunnel
                  NOTIFY multihopTunnelChanged)
+  Q_PROPERTY(int dnsProvider READ dnsProvider WRITE setDNSProvider NOTIFY
+                 dnsProviderChanged)
+  Q_PROPERTY(
+      QString userDNS READ userDNS WRITE setUserDNS NOTIFY userDNSChanged)
 
  public:
   SettingsHolder();
   ~SettingsHolder();
 
   static SettingsHolder* instance();
+
+  enum DnsProvider {
+    Gateway = 0,
+    BlockAll = 1,
+    BlockAds = 2,
+    BlockTracking = 3,
+    Custom = 4,
+  };
+  Q_ENUM(DnsProvider)
 
   QString getReport();
 
@@ -104,8 +111,8 @@ class SettingsHolder final : public QObject {
   GETSET(bool, hasProtectSelectedApps, protectSelectedApps,
          setProtectSelectedApps)
   GETSET(QStringList, hasVpnDisabledApps, vpnDisabledApps, setVpnDisabledApps)
-  GETSET(bool, hasUsegatewayDNS, useGatewayDNS, setUseGatewayDNS)
   GETSET(QString, hasUserDNS, userDNS, setUserDNS)
+  GETSET(int, hasDNSProvider, dnsProvider, setDNSProvider)
   GETSET(bool, hasGleanEnabled, gleanEnabled, setGleanEnabled)
   GETSET(bool, hasDeveloperUnlock, developerUnlock, setDeveloperUnlock)
   GETSET(bool, hasStagingServer, stagingServer, setStagingServer)
@@ -134,6 +141,7 @@ class SettingsHolder final : public QObject {
 
   Q_INVOKABLE
   bool validateUserDNS(const QString& dns) const;
+  QString getDNS(const QString& serverGateway);
 
 #ifdef MVPN_IOS
   GETSET(bool, hasNativeIOSDataMigrated, nativeIOSDataMigrated,
@@ -168,8 +176,8 @@ class SettingsHolder final : public QObject {
   void startAtBootChanged(bool value);
   void protectSelectedAppsChanged(bool value);
   void vpnDisabledAppsChanged(const QStringList& apps);
-  void useGatewayDNSChanged(bool value);
   void userDNSChanged(QString value);
+  void dnsProviderChanged(int value);
   void gleanEnabledChanged(bool value);
   void serverSwitchNotificationChanged(bool value);
   void connectionChangeNotificationChanged(bool value);

--- a/src/settingsholder.h
+++ b/src/settingsholder.h
@@ -141,7 +141,9 @@ class SettingsHolder final : public QObject {
 
   Q_INVOKABLE
   bool validateUserDNS(const QString& dns) const;
+
   QString getDNS(const QString& serverGateway);
+  bool isMullvadDNS(const QString& address);
 
 #ifdef MVPN_IOS
   GETSET(bool, hasNativeIOSDataMigrated, nativeIOSDataMigrated,

--- a/src/ui/components/VPNViewDNSSettings.qml
+++ b/src/ui/components/VPNViewDNSSettings.qml
@@ -22,43 +22,6 @@ VPNFlickable {
     property alias settingsListModel: repeater.model
 
 
-    function isChecked(settingId) {
-        switch(String(settingId)) {
-          case settingId_default.toString():
-            return VPNSettings.dnsProvider === VPNSettings.Gateway;
-          case settingId_adblock.toString():
-            return VPNSettings.dnsProvider === VPNSettings.BlockAds;
-          case settingId_antiTracking.toString():
-            return VPNSettings.dnsProvider === VPNSettings.BlockTracking;
-          case settingId_adblockAndAntiTracking.toString():
-            return VPNSettings.dnsProvider === VPNSettings.BlockAll;
-          case settingId_local.toString():
-            return VPNSettings.dnsProvider === VPNSettings.Custom;
-          default:
-            console.log("TODO")
-        }
-        return false;
-    }
-
-    function handleClick(settingId) {
-        if (!vpnFlickable.vpnIsOff) {
-            return;
-        }
-        switch(String(settingId)) {
-          case settingId_default.toString():
-            return VPNSettings.dnsProvider = VPNSettings.Gateway;
-          case settingId_adblock.toString():
-            return VPNSettings.dnsProvider = VPNSettings.BlockAds;
-          case settingId_antiTracking.toString():
-            return VPNSettings.dnsProvider = VPNSettings.BlockTracking;
-          case settingId_adblockAndAntiTracking.toString():
-            return VPNSettings.dnsProvider = VPNSettings.BlockAll;
-          case settingId_local.toString():
-            return VPNSettings.dnsProvider = VPNSettings.Custom;
-          default:
-            console.log("TODO")
-        }
-    }
     flickContentHeight: col.height + 56*2
     interactive: flickContentHeight > height
 
@@ -85,10 +48,10 @@ VPNFlickable {
                     Layout.preferredWidth: Theme.vSpacing
                     Layout.preferredHeight: Theme.rowHeight
                     Layout.alignment: Qt.AlignTop
-                    checked: isChecked(settingId)
+                    checked: VPNSettings.dnsProvider == settingValue
                     ButtonGroup.group: radioButtonGroup
                     accessibleName: settingTitle
-                    onClicked: handleClick(settingId)
+                    onClicked: VPNSettings.dnsProvider = settingValue
                 }
 
                 Column {

--- a/src/ui/components/VPNViewDNSSettings.qml
+++ b/src/ui/components/VPNViewDNSSettings.qml
@@ -1,0 +1,223 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import QtQuick 2.5
+import QtQuick.Controls 2.14
+import QtGraphicalEffects 1.14
+import QtQuick.Layouts 1.14
+import Mozilla.VPN 1.0
+import "../components"
+import "../components/forms"
+import "../themes/themes.js" as Theme
+
+import org.mozilla.Glean 0.15
+import telemetry 0.15
+
+
+VPNFlickable {
+
+    id: vpnFlickable
+    property bool vpnIsOff: (VPNController.state === VPNController.StateOff)
+    property alias settingsListModel: repeater.model
+
+
+    function isChecked(settingId) {
+        switch(String(settingId)) {
+          case settingId_default.toString():
+            return VPNSettings.dnsProvider === VPNSettings.Gateway;
+          case settingId_adblock.toString():
+            return VPNSettings.dnsProvider === VPNSettings.BlockAds;
+          case settingId_antiTracking.toString():
+            return VPNSettings.dnsProvider === VPNSettings.BlockTracking;
+          case settingId_adblockAndAntiTracking.toString():
+            return VPNSettings.dnsProvider === VPNSettings.BlockAll;
+          case settingId_local.toString():
+            return VPNSettings.dnsProvider === VPNSettings.Custom;
+          default:
+            console.log("TODO")
+        }
+        return false;
+    }
+
+    function handleClick(settingId) {
+        if (!vpnFlickable.vpnIsOff) {
+            return;
+        }
+        switch(String(settingId)) {
+          case settingId_default.toString():
+            return VPNSettings.dnsProvider = VPNSettings.Gateway;
+          case settingId_adblock.toString():
+            return VPNSettings.dnsProvider = VPNSettings.BlockAds;
+          case settingId_antiTracking.toString():
+            return VPNSettings.dnsProvider = VPNSettings.BlockTracking;
+          case settingId_adblockAndAntiTracking.toString():
+            return VPNSettings.dnsProvider = VPNSettings.BlockAll;
+          case settingId_local.toString():
+            return VPNSettings.dnsProvider = VPNSettings.Custom;
+          default:
+            console.log("TODO")
+        }
+    }
+    flickContentHeight: col.height + 56*2
+    interactive: flickContentHeight > height
+
+    ColumnLayout {
+        id: col
+        width: parent.width
+        anchors.top: parent.top
+        anchors.topMargin: 18
+        anchors.left: parent.left
+        anchors.leftMargin: 18
+        anchors.right: parent.right
+        anchors.rightMargin: Theme.windowMargin
+        spacing: Theme.vSpacing
+
+        Repeater {
+            id: repeater
+
+            delegate: RowLayout {
+                Layout.fillWidth: true
+                spacing: Theme.windowMargin
+                Layout.rightMargin: Theme.windowMargin
+
+                VPNRadioButton {
+                    Layout.preferredWidth: Theme.vSpacing
+                    Layout.preferredHeight: Theme.rowHeight
+                    Layout.alignment: Qt.AlignTop
+                    checked: isChecked(settingId)
+                    ButtonGroup.group: radioButtonGroup
+                    accessibleName: settingTitle
+                    onClicked: handleClick(settingId)
+                }
+
+                Column {
+                    spacing: 4
+                    Layout.fillWidth: true
+
+                    VPNInterLabel {
+                        text: settingTitle
+                        wrapMode: Text.WordWrap
+                        width: parent.width
+                        horizontalAlignment: Text.AlignLeft
+                    }
+
+                    VPNTextBlock {
+                       text: settingDescription
+                       width: parent.width
+                    }
+
+                    VPNVerticalSpacer {
+                        visible: ipInput.visible
+                        height: Theme.windowMargin
+                    }
+
+                    VPNTextField {
+                        property bool valueInvalid: false
+                        property string error: "This is an error string"
+                        hasError: valueInvalid
+                        visible: showDNSInput
+                        id: ipInput
+
+                        enabled: VPNSettings.dnsProvider === VPNSettings.Custom
+                        placeholderText: VPNSettings.placeholderUserDNS
+                        text: VPNSettings.userDNS
+                        width: parent.width
+                        height: 40
+
+                        PropertyAnimation on opacity {
+                            duration: 200
+                        }
+
+                        onTextChanged: text => {
+                            if (ipInput.text === "") {
+                                // If nothing is entered, thats valid too. We will ignore the value later.
+                                ipInput.valueInvalid = false;
+                                VPNSettings.userDNS = ipInput.text
+                                return;
+                            }
+                            if(VPNSettings.validateUserDNS(ipInput.text)){
+                                ipInput.valueInvalid = false;
+                                VPNSettings.userDNS = ipInput.text
+                            }else{
+                                ipInput.error = VPNl18n.tr(VPNl18n.CustomDNSSettingsInlineCustomDNSError)
+                                ipInput.valueInvalid = true;
+                            }
+                        }
+                    }
+
+                    VPNCheckBoxAlert {
+                            id: errorAlert
+                            errorMessage: ipInput.error
+                            anchors.left: undefined
+                            anchors.right: undefined
+                            anchors.leftMargin: undefined
+                            anchors.rightMargin: undefined
+                            anchors.top: undefined
+                            anchors.topMargin: undefined
+                            Layout.leftMargin: ipInput.Layout.leftMargin
+                            alertColor: Theme.red
+
+                            states: [
+                                State {
+                                    name: "visible"
+                                    when: ipInput.valueInvalid
+                                    PropertyChanges {
+                                        target: errorAlert
+                                        visible: true
+                                        opacity: 1
+                                    }
+                                },
+                                State {
+                                    name: "hidden"
+                                    when: !ipInput.valueInvalid
+                                    PropertyChanges {
+                                        target: errorAlert
+                                        visible: false
+                                        opacity: 0
+                                    }
+                                }
+                            ]
+
+                            transitions: [
+                                Transition {
+                                    to: "hidden"
+                                    SequentialAnimation {
+                                        PropertyAnimation {
+                                            target: errorAlert
+                                            property: "opacity"
+                                            to: 0
+                                            duration: 100
+                                        }
+                                        PropertyAction {
+                                            target: errorAlert
+                                            property: "visible"
+                                            value: false
+                                        }
+                                    }
+                                },
+                                Transition {
+                                    to: "visible"
+                                    SequentialAnimation {
+                                        PropertyAction {
+                                            target: errorAlert
+                                            property: "visible"
+                                            value: true
+                                        }
+                                        PropertyAnimation {
+                                            target: errorAlert
+                                            property: "opacity"
+                                            from: 0
+                                            to: 1
+                                            duration: 100
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                }
+            }
+        }
+    }
+
+}

--- a/src/ui/settings/ViewAdvancedDNSSettings.qml
+++ b/src/ui/settings/ViewAdvancedDNSSettings.qml
@@ -16,12 +16,6 @@ import telemetry 0.15
 
 
 Item {
-    property string settingId_default: "default"
-    property string settingId_local: "local"
-    property string settingId_adblock: "adblock"
-    property string settingId_antiTracking: "antiTracking"
-    property string settingId_adblockAndAntiTracking: "adblockAndAntiTracking"
-
     id: root
 
     StackView.onDeactivating: root.opacity = 0
@@ -44,7 +38,7 @@ Item {
         id: menu
         objectName: "settingsAdvancedDNSSettingsBackButton"
 
-        title: "DNS Settings"
+        title: VPNl18n.tr(VPNl18n.CustomDNSSettingsDnsDnsNavItem)
         isSettingsView: true
     }
 
@@ -74,10 +68,10 @@ Item {
                 }
                 Component.onCompleted: {
                     defaultTabListModel.append({
-                                                "settingId": "default",
-                                                "settingTitle": VPNl18n.tr(VPNl18n.CustomDNSSettingsDnsDefaultRadioHeader),
-                                                "settingDescription": VPNl18n.tr(VPNl18n.CustomDNSSettingsDnsDefaultRadioBody),
-                                                "showDNSInput": false,
+                                                settingValue: VPNSettings.Gateway,
+                                                settingTitle: VPNl18n.tr(VPNl18n.CustomDNSSettingsDnsDefaultRadioHeader),
+                                                settingDescription: VPNl18n.tr(VPNl18n.CustomDNSSettingsDnsDefaultRadioBody),
+                                                showDNSInput: false,
                     })
                 }
             },
@@ -87,19 +81,19 @@ Item {
                 }
                 Component.onCompleted: {
                     advancedListModel.append({
-                                                 settingId: "adblock",
+                                                 settingValue: VPNSettings.BlockAds,
                                                  settingTitle: VPNl18n.tr(VPNl18n.CustomDNSSettingsDnsAdblockRadioHeader),
                                                  settingDescription: VPNl18n.tr(VPNl18n.CustomDNSSettingsDnsAdblockRadioBody),
                                                  showDNSInput: false})
-                    advancedListModel.append({   settingId: "antiTracking",
+                    advancedListModel.append({   settingValue: VPNSettings.BlockTracking,
                                                  settingTitle: VPNl18n.tr(VPNl18n.CustomDNSSettingsDnsAntitrackRadioHeader),
                                                  settingDescription: VPNl18n.tr(VPNl18n.CustomDNSSettingsDnsAntitrackRadioBody),
                                                  showDNSInput: false})
-                    advancedListModel.append({   settingId: "adblockAndAntiTracking",
+                    advancedListModel.append({   settingValue: VPNSettings.BlockAll,
                                                  settingTitle: VPNl18n.tr(VPNl18n.CustomDNSSettingsDnsAdblockAntiTrackRadioHeader),
                                                  settingDescription: VPNl18n.tr(VPNl18n.CustomDNSSettingsDnsAdblockAntiTrackRadioBody),
                                                  showDNSInput: false})
-                    advancedListModel.append({   settingId: "local",
+                    advancedListModel.append({   settingValue: VPNSettings.Custom,
                                                  settingTitle: VPNl18n.tr(VPNl18n.CustomDNSSettingsDnsCustomDNSRadioHeader),
                                                  settingDescription:  VPNl18n.tr(VPNl18n.CustomDNSSettingsDnsCustomDNSRadioBody),
                                                  showDNSInput: true})

--- a/src/ui/settings/ViewAdvancedDNSSettings.qml
+++ b/src/ui/settings/ViewAdvancedDNSSettings.qml
@@ -16,229 +16,97 @@ import telemetry 0.15
 
 
 Item {
+    property string settingId_default: "default"
+    property string settingId_local: "local"
+    property string settingId_adblock: "adblock"
+    property string settingId_antiTracking: "antiTracking"
+    property string settingId_adblockAndAntiTracking: "adblockAndAntiTracking"
+
     id: root
+
+    StackView.onDeactivating: root.opacity = 0
+
+    Behavior on opacity {
+        PropertyAnimation {
+            duration: 100
+        }
+    }
+
+    Component.onCompleted: {
+        tabButtonList.append({"buttonLabel":VPNl18n.tr(VPNl18n.CustomDNSSettingsDnsDefaultToggle)})
+        tabButtonList.append({"buttonLabel":VPNl18n.tr(VPNl18n.CustomDNSSettingsDnsAdvancedToggle)})
+
+
+
+    }
 
     VPNMenu {
         id: menu
         objectName: "settingsAdvancedDNSSettingsBackButton"
 
-        //% "Advanced DNS settings"
-        title: qsTrId("vpn.settings.advancedDNSSettings.title2")
+        title: "DNS Settings"
         isSettingsView: true
     }
 
-    VPNFlickable {
-        id: vpnFlickable
-        property bool vpnIsOff: (VPNController.state === VPNController.StateOff)
+    VPNTabNavigation {
+        // hacks to circumvent the fact that we can't send
+        // "scripts" as property values through ListModel/ListElement
 
+        id: tabs
+        width: root.width
         anchors.top: menu.bottom
-        anchors.right: parent.right
         anchors.left: parent.left
+        anchors.right: parent.right
         height: root.height - menu.height
-        flickContentHeight: col.childrenRect.height
-        interactive: flickContentHeight > height
 
-        Component.onCompleted: {
-            Glean.sample.dnsSettingsViewOpened.record();
+        tabList: ListModel {
+              id: tabButtonList
         }
 
         ButtonGroup {
             id: radioButtonGroup
         }
 
-        ColumnLayout {
-            id: col
-            width: parent.width
-            anchors.top: parent.top
-            anchors.topMargin: 18
-            anchors.left: parent.left
-            anchors.leftMargin: 18
-            anchors.right: parent.right
-            anchors.rightMargin: Theme.windowMargin
-            spacing: Theme.vSpacing
-
-            RowLayout {
-                Layout.fillWidth: true
-                spacing: Theme.windowMargin
-                Layout.rightMargin: Theme.windowMargin
-
-                VPNRadioButton {
-                    Layout.preferredWidth: Theme.vSpacing
-                    Layout.preferredHeight: Theme.rowHeight
-                    Layout.alignment: Qt.AlignTop
-                    checked: VPNSettings.useGatewayDNS
-                    accessibleName: useDefaultLabel.text
-
-                    onClicked: {
-                        if (vpnFlickable.vpnIsOff) {
-                            VPNSettings.useGatewayDNS = true
-                        }
-                    }
+        stackContent: [
+            VPNViewDNSSettings {
+                settingsListModel: ListModel {
+                    id:defaultTabListModel
                 }
-
-                Column {
-                    spacing: 4
-                    Layout.fillWidth: true
-                    VPNInterLabel {
-                        id: useDefaultLabel
-                        //% "Use default DNS"
-                        text: qsTrId("vpn.advancedDNSSettings.gateway")
-                        Layout.alignment: Qt.AlignTop
-                    }
-
-                    VPNTextBlock {
-
-                       //% "Automatically use Mozilla VPN-protected DNS"
-                       text: qsTrId("vpn.advancedDNSSettings.gateway.description")
-                       width: parent.width
-                    }
+                Component.onCompleted: {
+                    defaultTabListModel.append({
+                                                "settingId": "default",
+                                                "settingTitle": VPNl18n.tr(VPNl18n.CustomDNSSettingsDnsDefaultRadioHeader),
+                                                "settingDescription": VPNl18n.tr(VPNl18n.CustomDNSSettingsDnsDefaultRadioBody),
+                                                "showDNSInput": false,
+                    })
+                }
+            },
+            VPNViewDNSSettings {
+                settingsListModel: ListModel{
+                    id:advancedListModel
+                }
+                Component.onCompleted: {
+                    advancedListModel.append({
+                                                 settingId: "adblock",
+                                                 settingTitle: VPNl18n.tr(VPNl18n.CustomDNSSettingsDnsAdblockRadioHeader),
+                                                 settingDescription: VPNl18n.tr(VPNl18n.CustomDNSSettingsDnsAdblockRadioBody),
+                                                 showDNSInput: false})
+                    advancedListModel.append({   settingId: "antiTracking",
+                                                 settingTitle: VPNl18n.tr(VPNl18n.CustomDNSSettingsDnsAntitrackRadioHeader),
+                                                 settingDescription: VPNl18n.tr(VPNl18n.CustomDNSSettingsDnsAntitrackRadioBody),
+                                                 showDNSInput: false})
+                    advancedListModel.append({   settingId: "adblockAndAntiTracking",
+                                                 settingTitle: VPNl18n.tr(VPNl18n.CustomDNSSettingsDnsAdblockAntiTrackRadioHeader),
+                                                 settingDescription: VPNl18n.tr(VPNl18n.CustomDNSSettingsDnsAdblockAntiTrackRadioBody),
+                                                 showDNSInput: false})
+                    advancedListModel.append({   settingId: "local",
+                                                 settingTitle: VPNl18n.tr(VPNl18n.CustomDNSSettingsDnsCustomDNSRadioHeader),
+                                                 settingDescription:  VPNl18n.tr(VPNl18n.CustomDNSSettingsDnsCustomDNSRadioBody),
+                                                 showDNSInput: true})
                 }
             }
 
-            ColumnLayout {
-                spacing: Theme.windowMargin
-
-                RowLayout {
-                    Layout.fillWidth: true
-                    spacing: Theme.windowMargin
-                    Layout.rightMargin: Theme.windowMargin
-
-                    VPNRadioButton {
-                        Layout.preferredWidth: Theme.vSpacing
-                        Layout.preferredHeight: Theme.rowHeight
-                        Layout.alignment: Qt.AlignTop
-                        checked: !VPNSettings.useGatewayDNS
-                        onClicked: VPNSettings.useGatewayDNS = false
-                        accessibleName:  useLocalDNSLabel.text
-                    }
-
-                    Column {
-                        spacing: 4
-                        Layout.fillWidth: true
-                        VPNInterLabel {
-                            id: useLocalDNSLabel
-                            //% "Use local DNS"
-                            text: qsTrId("vpn.advancedDNSSettings.localDNS")
-                            Layout.alignment: Qt.AlignTop
-                        }
-
-                        VPNTextBlock {
-                           //% "Resolve website domain names using a DNS in your local network"
-                           text: qsTrId("vpn.advancedDNSSettings.localDNS.resolveWebsiteDomainNames")
-                           width: parent.width
-                        }
-                    }
-                }
-
-                VPNTextField {
-                    property bool valueInvalid: false
-                    property string error: "This is an error string"
-                    hasError: valueInvalid
-
-                    id: ipInput
-
-                    enabled: !VPNSettings.useGatewayDNS
-                    placeholderText: VPNSettings.placeholderUserDNS
-                    text: VPNSettings.userDNS
-                    Layout.fillWidth: true
-                    Layout.leftMargin: 40
-
-                    PropertyAnimation on opacity {
-                        duration: 200
-                    }
-
-                    onTextChanged: text => {
-                        if (ipInput.text === "") {
-                            // If nothing is entered, thats valid too. We will ignore the value later.
-                            ipInput.valueInvalid = false;
-                            VPNSettings.userDNS = ipInput.text
-                            return;
-                        }
-                        if(VPNSettings.validateUserDNS(ipInput.text)){
-                            ipInput.valueInvalid = false;
-                            if (text !== VPNSettings.userDNS) {
-                                VPNSettings.userDNS = ipInput.text
-                            }
-                        }else{
-                            // Now bother user if the ip is invalid :)
-                            //% "Invalid IP address"
-                            ipInput.error = qsTrId("vpn.settings.userDNS.invalid")
-                            ipInput.valueInvalid = true;
-                        }
-                    }
-                }
-
-                VPNCheckBoxAlert {
-                    id: errorAlert
-                    errorMessage: ipInput.error
-                    anchors.left: undefined
-                    anchors.right: undefined
-                    anchors.leftMargin: undefined
-                    anchors.rightMargin: undefined
-                    anchors.top: undefined
-                    anchors.topMargin: undefined
-                    Layout.leftMargin: ipInput.Layout.leftMargin
-                    alertColor: Theme.red
-
-                    states: [
-                        State {
-                            name: "visible"
-                            when: ipInput.valueInvalid
-                            PropertyChanges {
-                                target: errorAlert
-                                visible: true
-                                opacity: 1
-                            }
-                        },
-                        State {
-                            name: "hidden"
-                            when: !ipInput.valueInvalid
-                            PropertyChanges {
-                                target: errorAlert
-                                visible: false
-                                opacity: 0
-                            }
-                        }
-                    ]
-
-                    transitions: [
-                        Transition {
-                            to: "hidden"
-                            SequentialAnimation {
-                                PropertyAnimation {
-                                    target: errorAlert
-                                    property: "opacity"
-                                    to: 0
-                                    duration: 100
-                                }
-                                PropertyAction {
-                                    target: errorAlert
-                                    property: "visible"
-                                    value: false
-                                }
-                            }
-                        },
-                        Transition {
-                            to: "visible"
-                            SequentialAnimation {
-                                PropertyAction {
-                                    target: errorAlert
-                                    property: "visible"
-                                    value: true
-                                }
-                                PropertyAnimation {
-                                    target: errorAlert
-                                    property: "opacity"
-                                    from: 0
-                                    to: 1
-                                    duration: 100
-                                }
-                            }
-                        }
-                    ]
-                }
-            }
-        }
+        ]
     }
 }
 

--- a/src/ui/settings/ViewNetworkSettings.qml
+++ b/src/ui/settings/ViewNetworkSettings.qml
@@ -122,8 +122,6 @@ Item {
                 objectName: "advancedDNSSettings"
                 anchors.left: parent.left
                 anchors.right: parent.right
-                Layout.fillWidth: undefined
-                Layout.preferredHeight: undefined
                 width: parent.width - Theme.windowMargin
 
                 //% "Advanced DNS Settings"

--- a/translations/strings.yaml
+++ b/translations/strings.yaml
@@ -223,13 +223,13 @@ customDNSSettings:
   dnsDefaultToggle: Default
   dnsDefaultRadioHeader: Use default DNS
   dnsDefaultRadioBody: Automatically use Mozilla VPN-protected DNS
-#  dnsAdvancedToggle: Advanced
-#  dnsAdblockRadioHeader: Use adblock DNS
-#  dnsAdblockRadioBody: Block internet ads with VPN
-#  dnsAntitrackRadioHeader: Use anti-tracking DNS
-#  dnsAntitrackRadioBody: Block harmful domains with VPN
-#  dnsAdblockAntiTrackRadioHeader: Use adblock and anti-tracking DNS
-#  dnsAdblockAntiTrackRadioBody: Block internet ads and harmful domains with VPN
+  dnsAdvancedToggle: Advanced
+  dnsAdblockRadioHeader: Use adblock DNS
+  dnsAdblockRadioBody: Block internet ads with VPN
+  dnsAntitrackRadioHeader: Use anti-tracking DNS
+  dnsAntitrackRadioBody: Block harmful domains with VPN
+  dnsAdblockAntiTrackRadioHeader: Use adblock and anti-tracking DNS
+  dnsAdblockAntiTrackRadioBody: Block internet ads and harmful domains with VPN
   dnsCustomDNSRadioHeader: Use custom DNS
   dnsCustomDNSRadioBody: Resolve websites using a custom DNS
   dnsFieldPlaceHolder: Enter custom DNS

--- a/translations/strings.yaml
+++ b/translations/strings.yaml
@@ -219,7 +219,7 @@ whatsNewReleaseNotes:
 # Adding functionality for users selecting custom DNS settings, associated settings nav items, headers, and selectable options. Some is not included in 2.5.
 customDNSSettings:
   dnsInfoAlert: VPN must be off to change these settings
-  dnsNavItem: DNS setting
+  dnsNavItem: DNS settings
   dnsDefaultToggle: Default
   dnsDefaultRadioHeader: Use default DNS
   dnsDefaultRadioBody: Automatically use Mozilla VPN-protected DNS


### PR DESCRIPTION
This is based on #902 

With our Code for custom dns in place, we can extend the feature to offer ad-blocking and/or tracking blocking dns servers. 
Which i think would be nice :) 

![Unbenannt](https://user-images.githubusercontent.com/9611612/122404545-9c98fc00-cf7f-11eb-8543-06e24b2361fa.PNG)

┆Issue is synchronized with this [Jira Bug](https://mozilla-hub.atlassian.net/browse/VPN-796)
