### PR TITLE
Make ping workers async and remove threading

### DIFF
--- a/src/networkrequest.cpp
+++ b/src/networkrequest.cpp
@@ -360,7 +360,7 @@ void NetworkRequest::replyFinished() {
   QByteArray data = m_reply->readAll();
 
   if (m_reply->error() != QNetworkReply::NoError) {
-    logger.log() << "Network error:" << m_reply->error()
+    logger.log() << "Network error:" << m_reply->errorString()
                  << "status code:" << status << "- body:" << data;
     emit requestFailed(m_reply->error(), data);
     return;

--- a/src/pinghelper.cpp
+++ b/src/pinghelper.cpp
@@ -21,15 +21,10 @@ PingHelper::PingHelper() {
   MVPN_COUNT_CTOR(PingHelper);
 
   connect(&m_pingTimer, &QTimer::timeout, this, &PingHelper::nextPing);
-
-  m_pingThread.start();
 }
 
 PingHelper::~PingHelper() {
   MVPN_COUNT_DTOR(PingHelper);
-
-  m_pingThread.quit();
-  m_pingThread.wait();
 }
 
 void PingHelper::start(const QString& serverIpv4Gateway,
@@ -55,7 +50,7 @@ void PingHelper::stop() {
 void PingHelper::nextPing() {
   logger.log() << "Sending a new ping. Total:" << m_pings.length();
 
-  PingSender* pingSender = new PingSender(this, &m_pingThread);
+  PingSender* pingSender = new PingSender(this);
   connect(pingSender, &PingSender::completed, this, &PingHelper::pingReceived);
   m_pings.append(pingSender);
   pingSender->send(m_gateway, m_source);

--- a/src/pinghelper.cpp
+++ b/src/pinghelper.cpp
@@ -23,9 +23,7 @@ PingHelper::PingHelper() {
   connect(&m_pingTimer, &QTimer::timeout, this, &PingHelper::nextPing);
 }
 
-PingHelper::~PingHelper() {
-  MVPN_COUNT_DTOR(PingHelper);
-}
+PingHelper::~PingHelper() { MVPN_COUNT_DTOR(PingHelper); }
 
 void PingHelper::start(const QString& serverIpv4Gateway,
                        const QString& deviceIpv4Address) {

--- a/src/pinghelper.h
+++ b/src/pinghelper.h
@@ -7,7 +7,6 @@
 
 #include <QList>
 #include <QObject>
-#include <QThread>
 #include <QTimer>
 
 class PingSender;
@@ -41,8 +40,6 @@ class PingHelper final : public QObject {
   QTimer m_pingTimer;
 
   QList<PingSender*> m_pings;
-
-  QThread m_pingThread;
 };
 
 #endif  // PINGHELPER_H

--- a/src/pingsender.h
+++ b/src/pingsender.h
@@ -8,14 +8,12 @@
 #include <QElapsedTimer>
 #include <QObject>
 
-class QThread;
-
 class PingSender final : public QObject {
   Q_OBJECT
   Q_DISABLE_COPY_MOVE(PingSender)
 
  public:
-  PingSender(QObject* parent, QThread* thread);
+  PingSender(QObject* parent);
   ~PingSender();
 
   void send(const QString& destination, const QString& source);

--- a/src/pingsendworker.h
+++ b/src/pingsendworker.h
@@ -10,6 +10,9 @@
 class PingSendWorker : public QObject {
   Q_OBJECT
 
+ public:
+  PingSendWorker(QObject* parent = nullptr) : QObject(parent) {}
+
  public slots:
   virtual void sendPing(const QString& destination, const QString& source) = 0;
 

--- a/src/platforms/dummy/dummypingsendworker.cpp
+++ b/src/platforms/dummy/dummypingsendworker.cpp
@@ -10,7 +10,8 @@ namespace {
 Logger logger(LOG_NETWORKING, "DummyPingSendWorker");
 }
 
-DummyPingSendWorker::DummyPingSendWorker() {
+DummyPingSendWorker::DummyPingSendWorker(QObject* parent)
+    : PingSendWorker(parent) {
   MVPN_COUNT_CTOR(DummyPingSendWorker);
 }
 

--- a/src/platforms/dummy/dummypingsendworker.h
+++ b/src/platforms/dummy/dummypingsendworker.h
@@ -12,7 +12,7 @@ class DummyPingSendWorker final : public PingSendWorker {
   Q_DISABLE_COPY_MOVE(DummyPingSendWorker)
 
  public:
-  DummyPingSendWorker();
+  DummyPingSendWorker(QObject* parent = nullptr);
   ~DummyPingSendWorker();
 
  public slots:

--- a/src/platforms/linux/linuxpingsendworker.cpp
+++ b/src/platforms/linux/linuxpingsendworker.cpp
@@ -19,7 +19,8 @@ namespace {
 Logger logger({LOG_LINUX, LOG_NETWORKING}, "LinuxPingSendWorker");
 }
 
-LinuxPingSendWorker::LinuxPingSendWorker() {
+LinuxPingSendWorker::LinuxPingSendWorker(QObject* parent)
+    : PingSendWorker(parent) {
   MVPN_COUNT_CTOR(LinuxPingSendWorker);
 }
 

--- a/src/platforms/linux/linuxpingsendworker.h
+++ b/src/platforms/linux/linuxpingsendworker.h
@@ -16,7 +16,7 @@ class LinuxPingSendWorker final : public PingSendWorker {
   Q_DISABLE_COPY_MOVE(LinuxPingSendWorker)
 
  public:
-  LinuxPingSendWorker();
+  LinuxPingSendWorker(QObject* parent = nullptr);
   ~LinuxPingSendWorker();
 
  public slots:

--- a/src/platforms/macos/macospingsendworker.cpp
+++ b/src/platforms/macos/macospingsendworker.cpp
@@ -62,7 +62,8 @@ u_short in_cksum(u_short* addr, int len) {
 
 };  // namespace
 
-MacOSPingSendWorker::MacOSPingSendWorker() {
+MacOSPingSendWorker::MacOSPingSendWorker(QObject* parent)
+    : PingSendWorker(parent) {
   MVPN_COUNT_CTOR(MacOSPingSendWorker);
 }
 

--- a/src/platforms/macos/macospingsendworker.h
+++ b/src/platforms/macos/macospingsendworker.h
@@ -14,7 +14,7 @@ class MacOSPingSendWorker final : public PingSendWorker {
   Q_DISABLE_COPY_MOVE(MacOSPingSendWorker)
 
  public:
-  MacOSPingSendWorker();
+  MacOSPingSendWorker(QObject* parent = nullptr);
   ~MacOSPingSendWorker();
 
  public slots:

--- a/src/platforms/windows/windowscommons.cpp
+++ b/src/platforms/windows/windowscommons.cpp
@@ -18,10 +18,8 @@ namespace {
 Logger logger(LOG_MAIN, "WindowsCommons");
 }
 
-// A simple function to log windows error messages.
-void WindowsCommons::windowsLog(const QString& msg) {
+QString WindowsCommons::getErrorMessage() {
   DWORD errorId = GetLastError();
-
   LPSTR messageBuffer = nullptr;
   size_t size = FormatMessageA(
       FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM |
@@ -30,9 +28,15 @@ void WindowsCommons::windowsLog(const QString& msg) {
       (LPSTR)&messageBuffer, 0, nullptr);
 
   std::string message(messageBuffer, size);
-
-  logger.log() << msg << "-" << QString(message.c_str());
+  QString result(message.c_str());
   LocalFree(messageBuffer);
+  return result;
+}
+
+// A simple function to log windows error messages.
+void WindowsCommons::windowsLog(const QString& msg) {
+  QString errmsg = getErrorMessage();
+  logger.log() << msg << "-" << errmsg;
 }
 
 QString WindowsCommons::tunnelConfigFile() {

--- a/src/platforms/windows/windowscommons.h
+++ b/src/platforms/windows/windowscommons.h
@@ -9,6 +9,7 @@
 
 class WindowsCommons final {
  public:
+  static QString getErrorMessage();
   static void windowsLog(const QString& msg);
 
   static QString tunnelConfigFile();

--- a/src/platforms/windows/windowspingsendworker.cpp
+++ b/src/platforms/windows/windowspingsendworker.cpp
@@ -5,31 +5,36 @@
 #include "windowspingsendworker.h"
 #include "logger.h"
 #include "leakdetector.h"
-
-#include <WS2tcpip.h>
-#include <Windows.h>
-#include <iphlpapi.h>
-#include <IcmpAPI.h>
-
-#pragma comment(lib, "Iphlpapi.lib")
-#pragma comment(lib, "Ws2_32.lib")
+#include "windowscommons.h"
 
 namespace {
 Logger logger({LOG_WINDOWS, LOG_NETWORKING}, "WindowsPingSendWorker");
 }
 
-WindowsPingSendWorker::WindowsPingSendWorker() {
+WindowsPingSendWorker::WindowsPingSendWorker(QObject* parent)
+    : PingSendWorker(parent) {
   MVPN_COUNT_CTOR(WindowsPingSendWorker);
+  m_handle = IcmpCreateFile();
+  m_event = CreateEventA(NULL, FALSE, FALSE, NULL);
+  memset(m_buffer, 0, sizeof(m_buffer));
 }
 
 WindowsPingSendWorker::~WindowsPingSendWorker() {
   MVPN_COUNT_DTOR(WindowsPingSendWorker);
+  if (m_notifier) {
+    delete m_notifier;
+  }
+  if (m_event != INVALID_HANDLE_VALUE) {
+    CloseHandle(m_event);
+  }
+  if (m_handle != INVALID_HANDLE_VALUE) {
+    IcmpCloseHandle(m_handle);
+  }
 }
 
 void WindowsPingSendWorker::sendPing(const QString& destination,
                                      const QString& source) {
-  logger.log() << "WindowsPingSendWorker - start" << destination << "from"
-               << source;
+  logger.log() << "start" << destination << "from" << source;
 
   IN_ADDR dst{};
   IN_ADDR src{};
@@ -41,9 +46,11 @@ void WindowsPingSendWorker::sendPing(const QString& destination,
     emit pingFailed();
     return;
   }
-
-  HANDLE icmpHandle = IcmpCreateFile();
-  if (icmpHandle == INVALID_HANDLE_VALUE) {
+  if (m_handle == INVALID_HANDLE_VALUE) {
+    emit pingFailed();
+    return;
+  }
+  if (m_event == INVALID_HANDLE_VALUE) {
     emit pingFailed();
     return;
   }
@@ -51,16 +58,28 @@ void WindowsPingSendWorker::sendPing(const QString& destination,
   constexpr WORD payloadSize = 1;
   unsigned char payload[payloadSize]{42};
 
-  constexpr DWORD replyBufferSize = sizeof(ICMP_ECHO_REPLY) + payloadSize + 8;
-  unsigned char replyBuffer[replyBufferSize]{};
+  IcmpSendEcho2Ex(m_handle, m_event, nullptr, nullptr, src.S_un.S_addr,
+                  dst.S_un.S_addr, payload, payloadSize, nullptr, m_buffer,
+                  sizeof(m_buffer), 10000);
 
-  DWORD replyCount =
-      IcmpSendEcho2Ex(icmpHandle, INVALID_HANDLE_VALUE, nullptr, nullptr,
-                      src.S_un.S_addr, dst.S_un.S_addr, payload, payloadSize,
-                      nullptr, replyBuffer, replyBufferSize, 10000);
-  IcmpCloseHandle(icmpHandle);
+  DWORD status = GetLastError();
+  if (status != ERROR_IO_PENDING) {
+    QString errmsg = WindowsCommons::getErrorMessage();
+    logger.log() << "failed to start:" << errmsg;
+    emit pingFailed();
+    return;
+  }
 
+  m_notifier = new QWinEventNotifier(m_event, this);
+  QObject::connect(m_notifier, &QWinEventNotifier::activated, this,
+                   &WindowsPingSendWorker::recvPing);
+}
+
+void WindowsPingSendWorker::recvPing() {
+  DWORD replyCount = IcmpParseReplies(m_buffer, sizeof(m_buffer));
   if (replyCount == 0) {
+    QString errmsg = WindowsCommons::getErrorMessage();
+    logger.log() << "failed with error:" << errmsg;
     emit pingFailed();
     return;
   }

--- a/src/platforms/windows/windowspingsendworker.h
+++ b/src/platforms/windows/windowspingsendworker.h
@@ -7,16 +7,34 @@
 
 #include "pingsendworker.h"
 
+#include <QWinEventNotifier>
+
+#include <WS2tcpip.h>
+#include <Windows.h>
+#include <iphlpapi.h>
+#include <IcmpAPI.h>
+
+constexpr WORD WindowsPingPayloadSize = sizeof(WORD);
+
 class WindowsPingSendWorker final : public PingSendWorker {
   Q_OBJECT
   Q_DISABLE_COPY_MOVE(WindowsPingSendWorker)
 
  public:
-  WindowsPingSendWorker();
+  WindowsPingSendWorker(QObject* parent = nullptr);
   ~WindowsPingSendWorker();
 
  public slots:
   void sendPing(const QString& destination, const QString& source) override;
+
+ private slots:
+  void recvPing();
+
+ private:
+  HANDLE m_handle = INVALID_HANDLE_VALUE;
+  HANDLE m_event = INVALID_HANDLE_VALUE;
+  QWinEventNotifier* m_notifier = nullptr;
+  unsigned char m_buffer[sizeof(ICMP_ECHO_REPLY) + WindowsPingPayloadSize + 8];
 };
 
 #endif  // WINDOWSPINGSENDWORKER_H


### PR DESCRIPTION
To try and make the connection health checker a bit more resilient to packet loss, we should convert the Windows ping sender to use asynchronous calls when sending pings. This allows the ping worker thread to continue sending more pings during the timeout on the lost ping. This prevents `sendPing()` calls from backing up and triggering unnecessary server switching when they all arrive late.

Since the windows implementation was the only one that blocked anyways, it's no longer necessary to have a worker thread at all after converting them to use asynchronous operations.