### PR TITLE
Fix: No-Signal shown after disconnecting VPN

### DIFF
--- a/src/connectionhealth.cpp
+++ b/src/connectionhealth.cpp
@@ -45,6 +45,7 @@ void ConnectionHealth::stop() {
 
   m_pingHelper.stop();
   m_noSignalTimer.stop();
+  m_healthCheckTimer.stop();
 
   setStability(Stable);
 }


### PR DESCRIPTION
The recent PR #1231  introduced a bug where the health check timer would be left running after stopping the connection health check. This would trigger a No-Signal warning even though the VPN is disconnected.