### PR TITLE
Misc improvements from linux build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,6 @@ mozillavpnnp.vcxproj*
 # glean
 /glean/telemetry/*
 !/glean/telemetry/.keepme
+
+# For users compiling QT per the README
+/qt/

--- a/.gitignore
+++ b/.gitignore
@@ -89,4 +89,5 @@ mozillavpnnp.exe
 mozillavpnnp.vcxproj*
 
 # glean
-glean/generated/*
+/glean/telemetry/*
+!/glean/telemetry/.keepme

--- a/scripts/qt5_compile.sh
+++ b/scripts/qt5_compile.sh
@@ -67,6 +67,7 @@ LINUX="
 "
 
 MACOS="
+  -debug-and-release \
   -appstore-compliant \
   -no-feature-qdbus \
   -no-speechd
@@ -89,7 +90,6 @@ print Y "Wait..."
   --recheck-all \
   -opensource \
   -confirm-license \
-  -debug-and-release \
   -static \
   -strip \
   -silent \

--- a/src/platforms/linux/linuxpingsender.cpp
+++ b/src/platforms/linux/linuxpingsender.cpp
@@ -26,7 +26,7 @@ LinuxPingSender::LinuxPingSender(const QString& source, QObject* parent)
 
   m_socket = socket(AF_INET, SOCK_DGRAM, IPPROTO_ICMP);
   if (m_socket < 0) {
-    logger.log() << "Socket creation error";
+    logger.log() << "Socket creation error: " << strerror(errno);
     return;
   }
 


### PR DESCRIPTION
Some miscellaneous improvements for the build process based on my experience building on Debian which I hope other's might find helpful: 

- Log strerror linuxpingsender socket create failure

    This helped me diagnose #1252 so others might find it useful.

- Update .gitignore rules for `glean`

    With a96253e44482f11745f1d2ddd1ee35d1e90c5d63 scripts/generate_glean.py
    was updated to write under 'glean/telemetry' rather than
    'glean/generated' `.gitignore` was updated then to reflect this, but
    then was updated again with e27252cf59ea28bb16fbfcca78b6ba53abac5fd9.
    Since it appears `glean` is indeed writing under `telemetry`, restore
    this previous ignore behaviour

- Add .gitignore rule for QT compilation

    One of the suggested methods for installing QT5 in the README is to
    compile it under `qt/`, so ignore this as a convenience for anyone
    choosing to compile like this.

- Remove unspported QT config flag for Linux builds

    '-debug-and-release' is not supported on Linux (see issue #1250), so
    move it to be for MacOS builds only
