### PR TITLE
Convert installer logs from UTF-16 before writing.

### DIFF
--- a/src/update/balrog.cpp
+++ b/src/update/balrog.cpp
@@ -458,7 +458,9 @@ bool Balrog::install(const QString& filePath) {
             if (!log.open(QIODevice::ReadOnly | QIODevice::Text)) {
               logger.log() << "Unable to read the msiexec log file";
             } else {
-              logger.log() << "Log file:" << Qt::endl << log.readAll();
+              QTextStream logStream(&log);
+              logStream.setCodec("utf-16");
+              logger.log() << "Log file:" << Qt::endl << logStream.readAll();
             }
 
             if (exitCode != 0) {


### PR DESCRIPTION
When launching an MSI installer from within the VPN client, the installer generates its logs in UTF-16, which causes them to be printed incorrectly to the client logs, which I think are in UTF-8. To make them a little more readable, we should use a `QTextStream` to convert the character encodings before committing them to the client logs.