### PR TITLE
Fix bug preventing update notification from showing

### DIFF
--- a/src/ui/components/VPNAlerts.qml
+++ b/src/ui/components/VPNAlerts.qml
@@ -14,15 +14,14 @@ ColumnLayout {
     Layout.maximumWidth: col.width - Theme.windowMargin
     Layout.alignment: Qt.AlignHCenter
     Layout.fillHeight: false
-    visible: VPNSurveyModel.hasSurvey || updateAlert.visible
+    visible: VPNSurveyModel.hasSurvey || VPN.updateRecommended
 
     VPNAlert {
         id: updateAlert
 
-        state: VPN.updateRecommended ? "recommended" : ""
         alertType: "update"
         alertColor: Theme.blueButton
-        visible: state === "recommended"
+        visible: VPN.updateRecommended
         //% "New version is available."
         alertText: qsTrId("vpn.updates.newVersionAvailable")
         //% "Update now"


### PR DESCRIPTION
While testing some stuff in the windows update code, I think there actually is a bug in the update alert. It seems that when forcing an update using the inspector, most of the time the notification fails to show unless something else triggers the `VPNAlerts` to become visible (such as a survey).

What I think is going wrong is that the `updateAlert` is hidden, causing the parent `VPNAlerts` to be hidden and because the parent is hidden updates to the children's properties are not processed. The fix is to make `VPNAlerts` visible depending on whether an update is recommended and thereby untangle the visibility dependency graph.

Closes: #1254