### PR TITLE
Fix broken SignalHandler slot connection on Qt<5.15

### DIFF
--- a/src/platforms/linux/daemon/pidtracker.cpp
+++ b/src/platforms/linux/daemon/pidtracker.cpp
@@ -75,8 +75,7 @@ PidTracker::PidTracker(QObject* parent) : QObject(parent) {
   }
 
   m_socket = new QSocketNotifier(m_nlsock, QSocketNotifier::Read, this);
-  connect(m_socket, SIGNAL(activated(QSocketDescriptor, QSocketNotifier::Type)),
-          SLOT(readData()));
+  connect(m_socket, &QSocketNotifier::activated, this, &PidTracker::readData);
 }
 
 PidTracker::~PidTracker() {

--- a/src/platforms/linux/daemon/pidtracker.h
+++ b/src/platforms/linux/daemon/pidtracker.h
@@ -64,7 +64,7 @@ class PidTracker final : public QObject {
  private:
   int m_nlsock;
   char m_readBuf[2048];
-  QSocketNotifier* m_socket;
+  QSocketNotifier* m_socket = nullptr;
   QHash<int, ProcessGroup*> m_processTree;
   QList<ProcessGroup*> m_processGroups;
 };

--- a/src/platforms/linux/daemon/wireguardutilslinux.cpp
+++ b/src/platforms/linux/daemon/wireguardutilslinux.cpp
@@ -81,9 +81,8 @@ WireguardUtilsLinux::WireguardUtilsLinux(QObject* parent)
   }
 
   m_notifier = new QSocketNotifier(m_nlsock, QSocketNotifier::Read, this);
-  connect(m_notifier,
-          SIGNAL(activated(QSocketDescriptor, QSocketNotifier::Type)),
-          SLOT(nlsockReady()));
+  connect(m_notifier, &QSocketNotifier::activated, this,
+          &WireguardUtilsLinux::nlsockReady);
 
   /* Create control groups for split tunnelling */
   m_cgroups = LinuxDependencies::findCgroupPath("net_cls");

--- a/src/signalhandler.cpp
+++ b/src/signalhandler.cpp
@@ -6,6 +6,7 @@
 #include "logger.h"
 #include "signal.h"
 
+#include <fcntl.h>
 #include <unistd.h>
 
 namespace {
@@ -31,11 +32,11 @@ SignalHandler::SignalHandler() {
     logger.log() << "Unable to create signal wakeup pipe";
     return;
   }
+  fcntl(m_pipefds[0], F_SETFL, fcntl(m_pipefds[0], F_GETFL) | O_NONBLOCK);
   s_signalpipe = m_pipefds[1];
   m_notifier = new QSocketNotifier(m_pipefds[0], QSocketNotifier::Read, this);
-  connect(m_notifier,
-          SIGNAL(activated(QSocketDescriptor, QSocketNotifier::Type)),
-          SLOT(pipeReadReady()));
+  connect(m_notifier, &QSocketNotifier::activated, this,
+          &SignalHandler::pipeReadReady);
 
   struct sigaction sa;
   sa.sa_handler = SignalHandler::saHandler;
@@ -59,7 +60,7 @@ SignalHandler::~SignalHandler() {
 
 void SignalHandler::pipeReadReady() {
   int signal;
-  if (read(m_pipefds[0], &signal, sizeof(signal)) == sizeof(signal)) {
+  while (read(m_pipefds[0], &signal, sizeof(signal)) == sizeof(signal)) {
     logger.log() << "Signal" << signal;
     emit quitRequested();
   }

--- a/src/signalhandler.cpp
+++ b/src/signalhandler.cpp
@@ -60,7 +60,7 @@ SignalHandler::~SignalHandler() {
 
 void SignalHandler::pipeReadReady() {
   int signal;
-  while (read(m_pipefds[0], &signal, sizeof(signal)) == sizeof(signal)) {
+  if (read(m_pipefds[0], &signal, sizeof(signal)) == sizeof(signal)) {
     logger.log() << "Signal" << signal;
     emit quitRequested();
   }


### PR DESCRIPTION
The API to the `QSocketNotifier` changed between Qt 5.14 and 5.15, which caused the `SignalHandler` class to stop receiving signals. We can work around the problem by using functions pointer instead of trying to marshal the signal with the `SIGNAL()` macro.

Closes: #1275