### PR TITLE
Fallback attempt to use language code as region for City translation

### DIFF
--- a/src/serveri18n.cpp
+++ b/src/serveri18n.cpp
@@ -150,8 +150,15 @@ QString translateItem(const QString& countryCode, const QString& cityName,
     if (!result.isEmpty()) {
       return result;
     }
+  } else {
+    // If the language code is not trimmed e.g "es" and we did not have a match
+    // so far, lets try itself as region e.g es -> es_ES, de -> de_DE
+    QString concat_code = languageCode + "_" + languageCode.toUpper();
+    result = s_items.value(itemKey(concat_code, countryCode, cityName));
+    if (!result.isEmpty()) {
+      return result;
+    }
   }
-
   return fallback;
 }
 


### PR DESCRIPTION
If we have Spanish as sys language, we might get "es" (which we don't have in our json ) instead of "es_ES" (which we have), so we should just attempt as a last attempt to try "language_LANGUAGE" as a possible present translation :) 