### PR TITLE
Detect the Request of the OS to close the vpn connection

### DIFF
--- a/android/src/org/mozilla/firefox/vpn/VPNServiceBinder.kt
+++ b/android/src/org/mozilla/firefox/vpn/VPNServiceBinder.kt
@@ -132,6 +132,11 @@ class VPNServiceBinder(service: VPNService) : Binder() {
                 NotificationUtil.saveFallBackMessage(data, mService)
                 return true
             }
+            IBinder.LAST_CALL_TRANSACTION -> {
+                Log.e(tag, "The OS Requested to shut down the VPN")
+                this.mService.turnOff()
+                return true
+            }
 
             else -> {
                 Log.e(tag, "Received invalid bind request \t Code -> $code")


### PR DESCRIPTION
This is not really well documented but this is the signal Android sends us if the User does an action in the Settings.app that would require the vpn tunnel to be closed. E.g: 
- Disable Always On VPN
- Revoke VPN permission
- Disconnect vpn from the Quicksettings


Closes #1194
