### PR TITLE
Create PPA release bundle from linux_script.sh

### DIFF
--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -103,39 +103,30 @@ jobs:
 
   bionic-staging:
     name: Bionic Staging
+    needs: source-bundle
     runs-on: ubuntu-18.04
     steps:
-      - name: Install Linux packages
+      - name: Download Source Package
+        uses: actions/download-artifact@v2
+        with:
+            name: Sources
+
+      - name: Install Dependencies
         run: |
           # Add external PPA, latest version of QT is 5.12.x for Ubuntu 18.04
           sudo add-apt-repository ppa:beineri/opt-qt-5.15.2-bionic -y
-          sudo apt update
-          sudo apt install git golang-1.13 qt515tools qt515svg qt515networkauth-no-lgpl qt515charts-no-lgpl \
-                           libgl-dev libpolkit-gobject-1-dev devscripts debhelper cdbs quilt qt515graphicaleffects \
-                           qt515imageformats qt515quickcontrols2 libxcb-image0-dev libxcb-shape0-dev libxcb-sync0-dev \
-                           libxcb-render-util0-dev libxcb-xfixes0-dev libxcb-icccm4-dev libx11-xcb-dev \
-                           libxcb-keysyms1-dev libasound2-dev libaudio-dev libcups2-dev libdbus-1-dev \
-                           libglu1-mesa-dev  libmng-dev libtiff5-dev libxcursor-dev libxi-dev libxinerama-dev \
-                           libxmu-dev libxrandr-dev libxv-dev libedit-dev libvulkan-dev qt515websockets \
-                           python3-setuptools -y
+          sudo apt-get install debhelper devscripts equivs -y
 
-      - name: Clone repository
-        uses: actions/checkout@v2
-
-      - name: Install glean depedencies
-        shell: bash
-        run: |
-          pip3 install "glean_parser==3.5"
-          pip3 install pyhumps
-          pip3 install pyyaml
+          for file in $(find bionic-stage -type f); do ln -s $file; done
+          dpkg-source -x mozillavpn_*.dsc
+          sudo mk-build-deps -ir mozillavpn-*/debian/control
 
       - name: Create package structure
         shell: bash
         run: |
-          export PATH=/opt/qt515/bin:$PATH
-          ./scripts/linux_script.sh -s -r bionic
+          (cd mozillavpn-* && dpkg-buildpackage --build=binary --no-sign)
           mkdir packages
-          cp .tmp/*.deb packages
+          cp *.deb packages
 
       - name: Uploading
         uses: actions/upload-artifact@v1
@@ -145,38 +136,30 @@ jobs:
 
   bionic-production:
     name: Bionic Production
+    needs: source-bundle
     runs-on: ubuntu-18.04
     steps:
-      - name: Install Linux packages
+      - name: Download Source Package
+        uses: actions/download-artifact@v2
+        with:
+            name: Sources
+
+      - name: Install Dependencies
         run: |
           # Add external PPA, latest version of QT is 5.12.x for Ubuntu 18.04
           sudo add-apt-repository ppa:beineri/opt-qt-5.15.2-bionic -y
-          sudo apt update
-          sudo apt install git golang-1.13 qt515tools qt515svg qt515networkauth-no-lgpl qt515charts-no-lgpl libgl-dev \
-                           libpolkit-gobject-1-dev devscripts debhelper cdbs quilt qt515graphicaleffects \
-                           qt515imageformats qt515quickcontrols2 libxcb-image0-dev libxcb-shape0-dev libxcb-sync0-dev \
-                           libxcb-render-util0-dev libxcb-xfixes0-dev libxcb-icccm4-dev libx11-xcb-dev \
-                           libxcb-keysyms1-dev libasound2-dev libaudio-dev libcups2-dev libdbus-1-dev libglu1-mesa-dev \
-                           libmng-dev libtiff5-dev libxcursor-dev libxi-dev libxinerama-dev libxmu-dev libxrandr-dev \
-                           libxv-dev libedit-dev libvulkan-dev qt515websockets python3-setuptools -y
+          sudo apt-get install debhelper devscripts equivs -y
 
-      - name: Clone repository
-        uses: actions/checkout@v2
-
-      - name: Install glean depedencies
-        shell: bash
-        run: |
-          pip3 install "glean_parser==3.5"
-          pip3 install pyhumps
-          pip3 install pyyaml
+          for file in $(find bionic-prod -type f); do ln -s $file; done
+          dpkg-source -x mozillavpn_*.dsc
+          sudo mk-build-deps -ir mozillavpn-*/debian/control
 
       - name: Create package structure
         shell: bash
         run: |
-          export PATH=/opt/qt515/bin:$PATH
-          ./scripts/linux_script.sh -r bionic
+          (cd mozillavpn-* && dpkg-buildpackage --build=binary --no-sign)
           mkdir packages
-          cp .tmp/*.deb packages
+          cp *.deb packages
 
       - name: Uploading
         uses: actions/upload-artifact@v1

--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Install source dependencies
         shell: bash
         run: |
-          sudo apt-get install qt5-default qttools5-dev-tools golang -y
+          sudo apt-get install qt5-default qttools5-dev-tools golang debhelper -y
           pip3 install "glean_parser==3.5"
           pip3 install pyhumps
           pip3 install pyyaml
@@ -34,7 +34,7 @@ jobs:
         with:
             name: Sources
             path: .tmp
-      
+
   focal-staging:
     name: Focal Staging
     runs-on: ubuntu-20.04
@@ -44,7 +44,13 @@ jobs:
           # Add external PPA, latest version of QT is 5.12.x for Ubuntu 20.04
           sudo add-apt-repository ppa:beineri/opt-qt-5.15.2-focal -y
           sudo apt update
-          sudo apt install git qt515tools qt515svg qt515networkauth-no-lgpl qt515charts-no-lgpl libgl-dev libpolkit-gobject-1-dev devscripts debhelper cdbs quilt qt515graphicaleffects qt515imageformats  qt515quickcontrols2   libxcb-image0-dev libxcb-shape0-dev libxcb-sync0-dev libxcb-render-util0-dev libxcb-xfixes0-dev libxcb-icccm4-dev libx11-xcb-dev libxcb-keysyms1-dev libasound2-dev libaudio-dev libcups2-dev libdbus-1-dev libglu1-mesa-dev  libmng-dev libtiff5-dev libxcursor-dev libxi-dev libxinerama-dev libxmu-dev libxrandr-dev libxv-dev libedit-dev libvulkan-dev qt515websockets -y
+          sudo apt install git golang qt515tools qt515svg qt515networkauth-no-lgpl qt515charts-no-lgpl libgl-dev \
+                           libpolkit-gobject-1-dev devscripts debhelper cdbs quilt qt515graphicaleffects \
+                           qt515imageformats qt515quickcontrols2 libxcb-image0-dev libxcb-shape0-dev libxcb-sync0-dev \
+                           libxcb-render-util0-dev libxcb-xfixes0-dev libxcb-icccm4-dev libx11-xcb-dev \
+                           libxcb-keysyms1-dev libasound2-dev libaudio-dev libcups2-dev libdbus-1-dev libglu1-mesa-dev \
+                           libmng-dev libtiff5-dev libxcursor-dev libxi-dev libxinerama-dev libxmu-dev libxrandr-dev \
+                           libxv-dev libedit-dev libvulkan-dev qt515websockets -y
 
       - name: Clone repository
         uses: actions/checkout@v2
@@ -79,7 +85,13 @@ jobs:
           # Add external PPA, latest version of QT is 5.12.x for Ubuntu 20.04
           sudo add-apt-repository ppa:beineri/opt-qt-5.15.2-focal -y
           sudo apt update
-          sudo apt install git qt515tools qt515svg qt515networkauth-no-lgpl qt515charts-no-lgpl libgl-dev libpolkit-gobject-1-dev devscripts debhelper cdbs quilt qt515graphicaleffects qt515imageformats  qt515quickcontrols2   libxcb-image0-dev libxcb-shape0-dev libxcb-sync0-dev libxcb-render-util0-dev libxcb-xfixes0-dev libxcb-icccm4-dev libx11-xcb-dev libxcb-keysyms1-dev libasound2-dev libaudio-dev libcups2-dev libdbus-1-dev libglu1-mesa-dev  libmng-dev libtiff5-dev libxcursor-dev libxi-dev libxinerama-dev libxmu-dev libxrandr-dev libxv-dev libedit-dev libvulkan-dev qt515websockets -y
+          sudo apt install git golang qt515tools qt515svg qt515networkauth-no-lgpl qt515charts-no-lgpl libgl-dev \
+                           libpolkit-gobject-1-dev devscripts debhelper cdbs quilt qt515graphicaleffects \
+                           qt515imageformats qt515quickcontrols2 libxcb-image0-dev libxcb-shape0-dev libxcb-sync0-dev \
+                           libxcb-render-util0-dev libxcb-xfixes0-dev libxcb-icccm4-dev libx11-xcb-dev \
+                           libxcb-keysyms1-dev libasound2-dev libaudio-dev libcups2-dev libdbus-1-dev \
+                           libglu1-mesa-dev libmng-dev libtiff5-dev libxcursor-dev libxi-dev libxinerama-dev \
+                           libxmu-dev libxrandr-dev libxv-dev libedit-dev libvulkan-dev qt515websockets -y
 
       - name: Clone repository
         uses: actions/checkout@v2
@@ -114,7 +126,14 @@ jobs:
           # Add external PPA, latest version of QT is 5.12.x for Ubuntu 18.04
           sudo add-apt-repository ppa:beineri/opt-qt-5.15.2-bionic -y
           sudo apt update
-          sudo apt install git qt515tools qt515svg qt515networkauth-no-lgpl qt515charts-no-lgpl libgl-dev libpolkit-gobject-1-dev devscripts debhelper cdbs quilt qt515graphicaleffects qt515imageformats  qt515quickcontrols2   libxcb-image0-dev libxcb-shape0-dev libxcb-sync0-dev libxcb-render-util0-dev libxcb-xfixes0-dev libxcb-icccm4-dev libx11-xcb-dev libxcb-keysyms1-dev libasound2-dev libaudio-dev libcups2-dev libdbus-1-dev libglu1-mesa-dev  libmng-dev libtiff5-dev libxcursor-dev libxi-dev libxinerama-dev libxmu-dev libxrandr-dev libxv-dev libedit-dev libvulkan-dev qt515websockets python3-setuptools -y
+          sudo apt install git golang-1.13 qt515tools qt515svg qt515networkauth-no-lgpl qt515charts-no-lgpl \
+                           libgl-dev libpolkit-gobject-1-dev devscripts debhelper cdbs quilt qt515graphicaleffects \
+                           qt515imageformats qt515quickcontrols2 libxcb-image0-dev libxcb-shape0-dev libxcb-sync0-dev \
+                           libxcb-render-util0-dev libxcb-xfixes0-dev libxcb-icccm4-dev libx11-xcb-dev \
+                           libxcb-keysyms1-dev libasound2-dev libaudio-dev libcups2-dev libdbus-1-dev \
+                           libglu1-mesa-dev  libmng-dev libtiff5-dev libxcursor-dev libxi-dev libxinerama-dev \
+                           libxmu-dev libxrandr-dev libxv-dev libedit-dev libvulkan-dev qt515websockets \
+                           python3-setuptools -y
 
       - name: Clone repository
         uses: actions/checkout@v2
@@ -149,7 +168,13 @@ jobs:
           # Add external PPA, latest version of QT is 5.12.x for Ubuntu 18.04
           sudo add-apt-repository ppa:beineri/opt-qt-5.15.2-bionic -y
           sudo apt update
-          sudo apt install git qt515tools qt515svg qt515networkauth-no-lgpl qt515charts-no-lgpl libgl-dev libpolkit-gobject-1-dev devscripts debhelper cdbs quilt qt515graphicaleffects qt515imageformats  qt515quickcontrols2   libxcb-image0-dev libxcb-shape0-dev libxcb-sync0-dev libxcb-render-util0-dev libxcb-xfixes0-dev libxcb-icccm4-dev libx11-xcb-dev libxcb-keysyms1-dev libasound2-dev libaudio-dev libcups2-dev libdbus-1-dev libglu1-mesa-dev  libmng-dev libtiff5-dev libxcursor-dev libxi-dev libxinerama-dev libxmu-dev libxrandr-dev libxv-dev libedit-dev libvulkan-dev qt515websockets python3-setuptools -y
+          sudo apt install git golang-1.13 qt515tools qt515svg qt515networkauth-no-lgpl qt515charts-no-lgpl libgl-dev \
+                           libpolkit-gobject-1-dev devscripts debhelper cdbs quilt qt515graphicaleffects \
+                           qt515imageformats qt515quickcontrols2 libxcb-image0-dev libxcb-shape0-dev libxcb-sync0-dev \
+                           libxcb-render-util0-dev libxcb-xfixes0-dev libxcb-icccm4-dev libx11-xcb-dev \
+                           libxcb-keysyms1-dev libasound2-dev libaudio-dev libcups2-dev libdbus-1-dev libglu1-mesa-dev \
+                           libmng-dev libtiff5-dev libxcursor-dev libxi-dev libxinerama-dev libxmu-dev libxrandr-dev \
+                           libxv-dev libedit-dev libvulkan-dev qt515websockets python3-setuptools -y
 
       - name: Clone repository
         uses: actions/checkout@v2
@@ -185,6 +210,8 @@ jobs:
             - { name: "Hirsute Production", dist: hirsute, buildtype: "prod" }
 
     runs-on: ubuntu-latest
+    env:
+      BASETGZ: /var/cache/pbuilder/ubuntu-buildd-${{ matrix.config.dist }}.tgz
     steps:
       - name: Download Source Package
         uses: actions/download-artifact@v2
@@ -194,14 +221,14 @@ jobs:
       - name: Create base ${{ matrix.config.dist }} image
         run: |
           sudo apt-get install pbuilder debootstrap debhelper devscripts -y
-          sudo pbuilder create --distribution ${{ matrix.config.dist }} --basetgz /var/cache/pbuilder/ubuntu-buildd-${{ matrix.config.dist }}.tgz --debootstrapopts --variant=buildd
+          sudo pbuilder create --distribution ${{ matrix.config.dist }} --basetgz $BASETGZ --debootstrapopts --variant=buildd
 
       - name: Building package
         shell: bash
         run: |
           cd ${{matrix.config.dist}}-${{matrix.config.buildtype}}
           ln -s ../mozillavpn_*.orig.tar.gz
-          sudo pbuilder build --basetgz /var/cache/pbuilder/ubuntu-buildd-${{ matrix.config.dist }}.tgz --buildresult $(pwd) mozillavpn_*.dsc
+          sudo pbuilder build --basetgz $BASETGZ --buildresult $(pwd) mozillavpn_*.dsc
 
       - name: Uploading
         uses: actions/upload-artifact@v1

--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -37,38 +37,30 @@ jobs:
 
   focal-staging:
     name: Focal Staging
+    needs: source-bundle
     runs-on: ubuntu-20.04
     steps:
-      - name: Install Linux packages
+      - name: Download Source Package
+        uses: actions/download-artifact@v2
+        with:
+            name: Sources
+
+      - name: Install Dependencies
         run: |
           # Add external PPA, latest version of QT is 5.12.x for Ubuntu 20.04
           sudo add-apt-repository ppa:beineri/opt-qt-5.15.2-focal -y
-          sudo apt update
-          sudo apt install git golang qt515tools qt515svg qt515networkauth-no-lgpl qt515charts-no-lgpl libgl-dev \
-                           libpolkit-gobject-1-dev devscripts debhelper cdbs quilt qt515graphicaleffects \
-                           qt515imageformats qt515quickcontrols2 libxcb-image0-dev libxcb-shape0-dev libxcb-sync0-dev \
-                           libxcb-render-util0-dev libxcb-xfixes0-dev libxcb-icccm4-dev libx11-xcb-dev \
-                           libxcb-keysyms1-dev libasound2-dev libaudio-dev libcups2-dev libdbus-1-dev libglu1-mesa-dev \
-                           libmng-dev libtiff5-dev libxcursor-dev libxi-dev libxinerama-dev libxmu-dev libxrandr-dev \
-                           libxv-dev libedit-dev libvulkan-dev qt515websockets -y
+          sudo apt-get install debhelper devscripts equivs -y
 
-      - name: Clone repository
-        uses: actions/checkout@v2
-
-      - name: Install glean depedencies
-        shell: bash
-        run: |
-          pip3 install "glean_parser==3.5"
-          pip3 install pyhumps
-          pip3 install pyyaml
+          for file in $(find focal-stage -type f); do ln -s $file; done
+          dpkg-source -x mozillavpn_*.dsc
+          sudo mk-build-deps -ir mozillavpn-*/debian/control
 
       - name: Create package structure
         shell: bash
         run: |
-          export PATH=/opt/qt515/bin:$PATH
-          ./scripts/linux_script.sh -s -r focal
+          (cd mozillavpn-* && dpkg-buildpackage --build=binary --no-sign)
           mkdir packages
-          cp .tmp/*.deb packages
+          cp *.deb packages
 
       - name: Uploading
         uses: actions/upload-artifact@v1
@@ -78,38 +70,30 @@ jobs:
 
   focal-production:
     name: Focal Production
+    needs: source-bundle
     runs-on: ubuntu-20.04
     steps:
-      - name: Install Linux packages
+      - name: Download Source Package
+        uses: actions/download-artifact@v2
+        with:
+            name: Sources
+
+      - name: Install Dependencies
         run: |
           # Add external PPA, latest version of QT is 5.12.x for Ubuntu 20.04
           sudo add-apt-repository ppa:beineri/opt-qt-5.15.2-focal -y
-          sudo apt update
-          sudo apt install git golang qt515tools qt515svg qt515networkauth-no-lgpl qt515charts-no-lgpl libgl-dev \
-                           libpolkit-gobject-1-dev devscripts debhelper cdbs quilt qt515graphicaleffects \
-                           qt515imageformats qt515quickcontrols2 libxcb-image0-dev libxcb-shape0-dev libxcb-sync0-dev \
-                           libxcb-render-util0-dev libxcb-xfixes0-dev libxcb-icccm4-dev libx11-xcb-dev \
-                           libxcb-keysyms1-dev libasound2-dev libaudio-dev libcups2-dev libdbus-1-dev \
-                           libglu1-mesa-dev libmng-dev libtiff5-dev libxcursor-dev libxi-dev libxinerama-dev \
-                           libxmu-dev libxrandr-dev libxv-dev libedit-dev libvulkan-dev qt515websockets -y
+          sudo apt-get install debhelper devscripts equivs -y
 
-      - name: Clone repository
-        uses: actions/checkout@v2
-
-      - name: Install glean depedencies
-        shell: bash
-        run: |
-          pip3 install "glean_parser==3.5"
-          pip3 install pyhumps
-          pip3 install pyyaml
+          for file in $(find focal-prod -type f); do ln -s $file; done
+          dpkg-source -x mozillavpn_*.dsc
+          sudo mk-build-deps -ir mozillavpn-*/debian/control
 
       - name: Create package structure
         shell: bash
         run: |
-          export PATH=/opt/qt515/bin:$PATH
-          ./scripts/linux_script.sh -r focal
+          (cd mozillavpn-* && dpkg-buildpackage --build=binary --no-sign)
           mkdir packages
-          cp .tmp/*.deb packages
+          cp *.deb packages
 
       - name: Uploading
         uses: actions/upload-artifact@v1

--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -20,15 +20,15 @@ jobs:
       - name: Install source dependencies
         shell: bash
         run: |
-          sudo apt-get install qt5-default qttools5-dev-tools golang debhelper -y
+          sudo apt-get install golang debhelper -y
           pip3 install "glean_parser==3.5"
           pip3 install pyhumps
           pip3 install pyyaml
-      
+
       - name: Build source bundle
         shell: bash
         run: ./scripts/linux_script.sh --source
-      
+
       - name: Uploading
         uses: actions/upload-artifact@v2
         with:
@@ -265,4 +265,3 @@ jobs:
             path: |
               RPMS/
               SRPMS/
-

--- a/linux/debian/rules.prod.bionic
+++ b/linux/debian/rules.prod.bionic
@@ -11,6 +11,7 @@ DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
 	dh $@ --with systemd --warn-missing
 
 override_dh_auto_configure:
+	python3 scripts/importLanguages.py -p
 	qmake CONFIG+=production CONFIG-=debug CONFIG+=release CONFIG-=debug_and_release QT+=svg BUILD_ID=FULLVERSION
 
 override_dh_installdocs:

--- a/linux/debian/rules.prod.focal
+++ b/linux/debian/rules.prod.focal
@@ -11,6 +11,7 @@ DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
 	dh $@ --with systemd --warn-missing
 
 override_dh_auto_configure:
+	python3 scripts/importLanguages.py -p
 	qmake CONFIG+=production CONFIG-=debug CONFIG+=release CONFIG-=debug_and_release QT+=svg BUILD_ID=FULLVERSION
 
 override_dh_installdocs:

--- a/linux/debian/rules.prod.groovy
+++ b/linux/debian/rules.prod.groovy
@@ -8,6 +8,7 @@ DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
 	dh $@ --with systemd --warn-missing
 
 override_dh_auto_configure:
+	python3 scripts/importLanguages.py -p
 	qmake CONFIG+=production CONFIG-=debug CONFIG+=release CONFIG-=debug_and_release BUILD_ID=FULLVERSION
 
 override_dh_installdocs:

--- a/linux/debian/rules.prod.hirsute
+++ b/linux/debian/rules.prod.hirsute
@@ -8,6 +8,7 @@ DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
 	dh $@ --with systemd --warn-missing
 
 override_dh_auto_configure:
+	python3 scripts/importLanguages.py -p 
 	qmake CONFIG+=production CONFIG-=debug CONFIG+=release CONFIG-=debug_and_release BUILD_ID=FULLVERSION
 
 override_dh_installdocs:

--- a/linux/debian/rules.stage.bionic
+++ b/linux/debian/rules.stage.bionic
@@ -11,6 +11,7 @@ DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
 	dh $@ --with systemd --warn-missing
 
 override_dh_auto_configure:
+	python3 scripts/importLanguages.py
 	qmake CONFIG-=debug CONFIG+=release CONFIG-=debug_and_release QT+=svg CONFIG+=inspector BUILD_ID=FULLVERSION
 
 override_dh_installdocs:

--- a/linux/debian/rules.stage.focal
+++ b/linux/debian/rules.stage.focal
@@ -11,6 +11,7 @@ DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
 	dh $@ --with systemd --warn-missing
 
 override_dh_auto_configure:
+	python3 scripts/importLanguages.py
 	qmake CONFIG-=debug CONFIG+=release CONFIG-=debug_and_release QT+=svg CONFIG+=inspector BUILD_ID=FULLVERSION
 
 override_dh_installdocs:

--- a/linux/debian/rules.stage.groovy
+++ b/linux/debian/rules.stage.groovy
@@ -8,6 +8,7 @@ DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
 	dh $@ --with systemd --warn-missing
 
 override_dh_auto_configure:
+	python3 scripts/importLanguages.py
 	qmake CONFIG-=debug CONFIG+=release CONFIG-=debug_and_release CONFIG+=inspector BUILD_ID=FULLVERSION
 
 override_dh_installdocs:

--- a/linux/debian/rules.stage.hirsute
+++ b/linux/debian/rules.stage.hirsute
@@ -8,6 +8,7 @@ DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
 	dh $@ --with systemd --warn-missing
 
 override_dh_auto_configure:
+	python3 scripts/importLanguages.py
 	qmake CONFIG-=debug CONFIG+=release CONFIG-=debug_and_release CONFIG+=inspector BUILD_ID=FULLVERSION
 
 override_dh_installdocs:

--- a/linux/mozillavpn.spec
+++ b/linux/mozillavpn.spec
@@ -35,6 +35,7 @@ Read more on https://vpn.mozilla.org
 %undefine _lto_cflags
 
 %build
+python3 scripts/importLanguages.py -p
 %{qmake_qt5} CONFIG+=production QT+=svg
 make -j$(nproc)
 

--- a/scripts/linux_script.sh
+++ b/scripts/linux_script.sh
@@ -110,7 +110,7 @@ print G "Creating the orig tarball"
 printn N "Creating the working directory... "
 cd .tmp
 mkdir $WORKDIR || die "Failed"
-rsync -av --exclude='.*' .. $WORKDIR || die "Failed"
+rsync -a --exclude='.*' .. $WORKDIR || die "Failed"
 print G "done."
 
 print Y "Generating glean samples..."
@@ -144,7 +144,7 @@ EOF
 build_deb_source() {
   local distro=$1
   local buildtype=$2
-  local buildrev=$(distro)${REVISION}
+  local buildrev=${distro}${REVISION}
 
   print Y "Building sources for $distro ($buildtype)..."
   rm -rf $WORKDIR/debian || die "Failed"

--- a/scripts/linux_script.sh
+++ b/scripts/linux_script.sh
@@ -108,9 +108,9 @@ print G "done."
 print G "Creating the orig tarball"
 
 printn N "Creating the working directory... "
-mkdir -p .tmp/$WORKDIR || die "Failed"
-cp -R * .tmp/$WORKDIR 2>/dev/null || die "Failed"
 cd .tmp
+mkdir $WORKDIR || die "Failed"
+rsync -av --exclude='.*' .. $WORKDIR || die "Failed"
 print G "done."
 
 print Y "Importing translation files..."
@@ -130,7 +130,8 @@ rm -rf $WORKDIR/linux/debian || die "Failed"
 print G "done."
 
 printn Y "Archiving the source code... "
-tar cfz mozillavpn_$SHORTVERSION.orig.tar.gz $WORKDIR || die "Failed"
+TAR_OPTIONS="--mtime=$(git log -1 --format=%cI) --owner=root:0 --group=root:0 --sort=name"
+LC_ALL=C tar cfz mozillavpn_$SHORTVERSION.orig.tar.gz $TAR_OPTIONS $WORKDIR || die "Failed"
 print G "done."
 
 ## Generate the spec file for building RPMs
@@ -217,7 +218,7 @@ rm -rf $WORKDIR || die "Failed"
 if [ ! -z "$PPA_URL" ]; then
   print Y "Uploading sources to $PPA_URL"
   for dist in $(find . -type d -name '*-prod'); do
-    ln -s ../$TARBALL $dist/$TARBALL
+    ln -s ../mozillavpn_${SHORTVERSION}.orig.tar.gz $dist/mozillavpn_${SHORTVERSION}.orig.tar.gz
     dput "$PPA_URL" $dist/mozillavpn_${SHORTVERSION}-*_source.changes
   done
 fi

--- a/scripts/linux_script.sh
+++ b/scripts/linux_script.sh
@@ -6,10 +6,12 @@
 
 . $(dirname $0)/commons.sh
 
-VERSION=1
+REVISION=1
 RELEASE=focal
 BUILDTYPE=prod
 SOURCEONLY=N
+PPA_URL=
+DPKG_SIGN="--no-sign"
 RPM=N
 DEB=N
 
@@ -18,8 +20,19 @@ if [ -f .env ]; then
 fi
 
 helpFunction() {
-  print G "Usage:"
-  print N "\t$0 [-r|--release <release>] [-v|--version <id>] [-s|--stage] [--source]"
+  print G "Usage: $0 [OPTIONS]"
+  print N ""
+  print N "Build options:"
+  print N "  -r, --release DIST     Build packages for distribution DIST"
+  print N "  -v, --version REV      Set package revision to REV"
+  print N "  -s, --stage            Build packages to use staging services"
+  print N "      --source           Build source packages only (no binary)"
+  print N "      --ppa URL          Upload source packages to PPA at URL (implies: --source)"
+  print N ""
+  print N "Signing options:"
+  print N "      --sign             Enable package signing (default: disabled)"
+  print N "  -k, --sign-key KEYID   Enable package using using GPG key of KEYID"
+  print N "      --no-sign          Disable package signing" 
   print N ""
   print N "By default, the release is 'focal'"
   print N "The default version is 1, but you can recreate packages using the same code version changing the version id."
@@ -44,12 +57,31 @@ while [[ $# -gt 0 ]]; do
     shift
     ;;
   -v | --version)
-    VERSION="$2"
+    REVISION="$2"
     shift
     shift
     ;;
   --source)
     SOURCEONLY=Y
+    shift
+    ;;
+  --ppa)
+    SOURCEONLY=Y
+    PPA_URL="$2"
+    shift
+    shift
+    ;;
+  --sign)
+    DPKG_SIGN=""
+    shift
+    ;;
+  -k | --sign-key)
+    DPKG_SIGN="--sign-key=$2"
+    shift
+    shift
+    ;;
+  --no-sign)
+    DPKG_SIGN="--no-sign"
     shift
     ;;
   *)
@@ -105,34 +137,35 @@ print G "done."
 build_rpm_spec() {
 cat << EOF > mozillavpn.spec
 Version: $SHORTVERSION
-Release: $VERSION
+Release: $REVISION
 Source0: mozillavpn_$SHORTVERSION.orig.tar.gz
 $(grep -v -e "^Version:" -e "^Release" -e "^%define" ../linux/mozillavpn.spec)
 EOF
 }
 
-## For a given release, build the DSC and debian tarball.
+## For a given distro, build the DSC and debian tarball.
 build_deb_source() {
-  local release=$1
+  local distro=$1
   local buildtype=$2
+  local buildrev=$(distro)${REVISION}
 
-  print Y "Building sources for $release ($buildtype)..."
+  print Y "Building sources for $distro ($buildtype)..."
   rm -rf $WORKDIR/debian || die "Failed"
   cp -r ../linux/debian $WORKDIR || die "Failed"
 
-  mv $WORKDIR/debian/rules.$buildtype.$release $WORKDIR/debian/rules
-  mv $WORKDIR/debian/control.$buildtype.$release $WORKDIR/debian/control
+  mv $WORKDIR/debian/rules.$buildtype.$distro $WORKDIR/debian/rules
+  mv $WORKDIR/debian/control.$buildtype.$distro $WORKDIR/debian/control
   rm $WORKDIR/debian/control.*
   rm $WORKDIR/debian/rules.*
 
   mv $WORKDIR/debian/changelog.template $WORKDIR/debian/changelog || die "Failed"
   sed -i -e "s/SHORTVERSION/$SHORTVERSION/g" $WORKDIR/debian/changelog || die "Failed"
-  sed -i -e "s/VERSION/$VERSION/g" $WORKDIR/debian/changelog || die "Failed"
-  sed -i -e "s/RELEASE/$release/g" $WORKDIR/debian/changelog || die "Failed"
+  sed -i -e "s/VERSION/$buildrev/g" $WORKDIR/debian/changelog || die "Failed"
+  sed -i -e "s/RELEASE/$distro/g" $WORKDIR/debian/changelog || die "Failed"
   sed -i -e "s/DATE/$(date -R)/g" $WORKDIR/debian/changelog || die "Failed"
   sed -i -e "s/FULLVERSION/$FULLVERSION/g" $WORKDIR/debian/rules || die "Failed"
 
-  dpkg-source --build $WORKDIR || die "Failed"
+  (cd $WORKDIR && dpkg-buildpackage --build=source $DPKG_SIGN --no-check-builddeps) || die "Failed"
 }
 
 ## For source-only, build all the source bundles we can.
@@ -141,13 +174,15 @@ if [ "$SOURCEONLY" == "Y" ]; then
   for control in ../linux/debian/control.*; do
     filename=$(basename $control)
     buildtype=$(echo $filename | cut -d'.' -f2)
-    release=$(echo $filename | cut -d'.' -f3)
+    distro=$(echo $filename | cut -d'.' -f3)
 
-    build_deb_source $release $buildtype
+    build_deb_source $distro $buildtype
 
-    mkdir $release-$buildtype/
-    mv mozillavpn_$SHORTVERSION-$VERSION.debian.tar.* $release-$buildtype/ || die "Failed"
-    mv mozillavpn_$SHORTVERSION-$VERSION.dsc $release-$buildtype/ || die "Failed"
+    mkdir $distro-$buildtype/
+    mv mozillavpn_${SHORTVERSION}-*_source.buildinfo $distro-$buildtype/ || die "Failed"
+    mv mozillavpn_${SHORTVERSION}-*_source.changes $distro-$buildtype/ || die "Failed"
+    mv mozillavpn_${SHORTVERSION}-*.debian.tar.* $distro-$buildtype/ || die "Failed"
+    mv mozillavpn_${SHORTVERSION}-*.dsc $distro-$buildtype/ || die "Failed"
   done
 
   print Y "Configuring the RPM spec..."
@@ -159,7 +194,7 @@ else
       build_deb_source $RELEASE $BUILDTYPE
 
       print Y "Building Debian packages for $RELEASE ($BUILDTYPE)"
-      (cd $WORKDIR && dpkg-buildpackage --build=binary --no-sign) || die "Failed"
+      (cd $WORKDIR && dpkg-buildpackage --build=binary $DPKG_SIGN) || die "Failed"
       ;;
     
     fedora)
@@ -178,5 +213,13 @@ fi
 
 print Y "Cleaning up working directory..."
 rm -rf $WORKDIR || die "Failed"
+
+if [ ! -z "$PPA_URL" ]; then
+  print Y "Uploading sources to $PPA_URL"
+  for dist in $(find . -type d -name '*-prod'); do
+    ln -s ../$TARBALL $dist/$TARBALL
+    dput "$PPA_URL" $dist/mozillavpn_${SHORTVERSION}-*_source.changes
+  done
+fi
 
 print G "All done."

--- a/scripts/linux_script.sh
+++ b/scripts/linux_script.sh
@@ -113,10 +113,6 @@ mkdir $WORKDIR || die "Failed"
 rsync -av --exclude='.*' .. $WORKDIR || die "Failed"
 print G "done."
 
-print Y "Importing translation files..."
-LANG_ARGS=$([ "$BUILDTYPE" == "stage" ] || echo "-p")
-(cd $WORKDIR && python3 scripts/importLanguages.py $LANG_ARGS) || die "Failed to import languages"
-
 print Y "Generating glean samples..."
 (cd $WORKDIR && python3 scripts/generate_glean.py) || die "Failed to generate glean samples"
 


### PR DESCRIPTION
This attempts to update the source bundled generated from `linux_script.sh` to produce output that's suitable for upload to a PPA. This is the simple half of PR #1282 that just ensures we have the necessary files in place without trying to rework the version numbering scheme.

Changes include:
- The `.orig.tar.gz` should be reproduceable when generated from the same commit. This means we need determinstic timestamps, UID/GID and generated content.
- Add package signing support to `linux_script.sh` using GPG keys (debian only, RPMs are still mysterious to me).
- Use `dpkg-buildpackage` to produce the necessary `_souce.buildinfo` and `_source.changes` for PPA upload.
- Fix missing golang Build-Depends for Focal and Bionic