### PR TITLE
Fix Linux PingSend Worker on Android

### DIFF
--- a/src/platforms/android/androidcontroller.cpp
+++ b/src/platforms/android/androidcontroller.cpp
@@ -147,6 +147,7 @@ void AndroidController::activate(
       appContext.object());
 
   m_server = server;
+  m_device = *device;
 
   // Serialise arguments for the VPNService
   QJsonObject jDevice;
@@ -304,7 +305,7 @@ bool AndroidController::VPNBinder::onTransact(int code,
       // Data is here a JSON String
       doc = QJsonDocument::fromJson(data.readData());
       emit m_controller->statusUpdated(m_controller->m_server.ipv4Gateway(),
-                                       m_controller->m_server.ipv4AddrIn(),
+                                       m_controller->m_device.ipv4Address(),
                                        doc.object()["totalTX"].toInt(),
                                        doc.object()["totalRX"].toInt());
       break;

--- a/src/platforms/android/androidcontroller.h
+++ b/src/platforms/android/androidcontroller.h
@@ -6,6 +6,7 @@
 #define ANDROIDCONTROLLER_H
 
 #include "controllerimpl.h"
+#include "models/device.h"
 
 #include <QAndroidBinder>
 #include <QAndroidServiceConnection>
@@ -47,6 +48,7 @@ class AndroidController final : public ControllerImpl,
 
  private:
   Server m_server;
+  Device m_device;
   bool m_serviceConnected = false;
   std::function<void(const QString&)> m_logCallback;
 


### PR DESCRIPTION
Since the signal is:
```   
void statusUpdated(const QString& serverIpv4Gateway,
                     const QString& deviceIpv4Address, uint64_t txBytes,
                     uint64_t rxBytes); 
```

I think this should not be `m_server.ipv4AddrIn()`right? Otherwise the ping send worker tries to bind to that and fails.