### PR TITLE
Fix #1289 - Use correct string in rating view

### DIFF
--- a/src/ui/settings/ViewGiveFeedback.qml
+++ b/src/ui/settings/ViewGiveFeedback.qml
@@ -129,7 +129,7 @@ Item {
                         VPNInterLabel {
                             Layout.alignment: Qt.AlignLeft
                             horizontalAlignment: Qt.AlignLeft
-                            text: qsTrId("vpn.feedbackForm.poor")
+                            text: qsTrId("vpn.feedbackForm.veryPoor")
                             Layout.fillWidth: true
                             color: Theme.fontColor
                         }


### PR DESCRIPTION
Fixes #1289  - This changes the "Poor" string to "Very Poor" in the app rating view. Regarding the "Excellent" string... we actually do not have an "Excellent" string (I think the strings in the spec may have changed since this was implemented) and so will have to add an "Excellent" string in later releases since we're now in string freeze. 