### PR TITLE
Experiment: Automating PPA release candidate builds

### DIFF
--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -16,7 +16,26 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
-      
+
+      - name: Generate build version
+        shell: bash
+        env:
+          GITREF: ${{github.ref}}
+        run: |
+          VERSION=$(grep ':VERSION' version.pri | cut -d= -f2 | tr -d '[:space:]')
+          if [[ "$GITREF" =~ ^refs/pull/([0-9]+)/merge ]]; then
+            BUILDREV="~pr${BASH_REMATCH[1]}"
+          elif [[ "$GITREF" =~ ^refs/heads/releases/([0-9][^/]*) ]]; then
+            git fetch --unshallow
+            BUILDREV="~rc$(git rev-list --count --first-parent origin/main..HEAD)"
+            VERSION=${BASH_REMATCH[1]}
+          else
+            BUILDREV="~github${{github.run_number}}"
+          fi
+
+          # Force the upstream package version
+          sed -i "s/:VERSION.*/:VERSION = ${VERSION}${BUILDREV}/" version.pri
+
       - name: Install source dependencies
         shell: bash
         run: |
@@ -34,7 +53,7 @@ jobs:
         with:
             name: Sources
             path: .tmp
-
+  
   focal-staging:
     name: Focal Staging
     needs: source-bundle

--- a/.github/workflows/ppa_automation.yml
+++ b/.github/workflows/ppa_automation.yml
@@ -1,0 +1,68 @@
+name: PPA Automated Releases
+on:
+  push:
+    branches:
+      - 'releases/**'
+
+jobs:
+  ppa-release-candidate:
+    name: PPA Releases
+    runs-on: ubuntu-latest
+    environment: PPA Automation
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Generate release version
+        shell: bash
+        env:
+          GITREF: ${{github.ref}}
+        run: |
+          BUILDREV="~rc$(git rev-list --count --first-parent origin/main..HEAD)"
+          VERSION=$(echo $GITREF | cut -d'/' -f4)
+          sed -i "s/:VERSION.*/:VERSION = ${VERSION}${BUILDREV}/" version.pri
+
+      - name: Install dependencies
+        shell: bash
+        run: |
+          sudo apt-get install golang debhelper devscripts dput-ng -y
+          pip3 install "glean_parser==3.5"
+          pip3 install pyhumps
+          pip3 install pyyaml
+
+      - name: Build source bundle
+        shell: bash
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
+          GNUPGHOME: ${{ runner.temp }}/gnupg-data
+        run: |
+          mkdir -m700 $GNUPGHOME
+          echo "allow-preset-passphrase" > $GNUPGHOME/gpg-agent.conf
+          gpgconf --kill gpg-agent
+
+          echo "$GPG_PRIVATE_KEY" | gpg --import --pinentry-mode loopback --passphrase "$GPG_PASSWORD"
+          KEYID=$(gpg --with-colons --list-keys | grep -m1 '^fpr:' | tr -d [fpr:])
+          KEYGRIP=$(gpg --with-colons --with-keygrip --list-keys | grep -m1 '^grp:' | tr -d [grp:])
+
+          echo "$GPG_PASSWORD" | /lib/gnupg2/gpg-preset-passphrase --preset $KEYGRIP
+          ./scripts/linux_script.sh --sign-key $KEYID --source
+
+      - name: Uploading sources
+        uses: actions/upload-artifact@v2
+        with:
+            name: Sources
+            path: .tmp
+
+      - name: Push to Launchpad PPA
+        shell: bash
+        env:
+          PPA_URL: ppa:okirby/mozilla-vpn-test
+          GNUPGHOME: ${{ runner.temp }}/gnupg-data
+        run: |
+          for dist in $(find .tmp -type d -name '*-prod'); do
+            (cd $dist && ln -s ../mozillavpn_*.orig.tar.gz)
+            dput $PPA_URL $dist/mozillavpn_*_source.changes
+          done

--- a/linux/debian/rules.prod.bionic
+++ b/linux/debian/rules.prod.bionic
@@ -6,13 +6,14 @@ export PATH := $(QTDIR)/bin:$(PATH)
 export LD_LIBRARY_PATH := $(QTDIR)/lib:$(LD_LIBRARY_PATH)
 
 DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
+DEB_VERSION ?= $(shell dpkg-parsechangelog -SVersion)
 
 %:
 	dh $@ --with systemd --warn-missing
 
 override_dh_auto_configure:
 	python3 scripts/importLanguages.py -p
-	qmake CONFIG+=production CONFIG-=debug CONFIG+=release CONFIG-=debug_and_release QT+=svg BUILD_ID=FULLVERSION
+	qmake CONFIG+=production CONFIG-=debug CONFIG+=release CONFIG-=debug_and_release QT+=svg BUILD_ID=$(DEB_VERSION)
 
 override_dh_installdocs:
 

--- a/linux/debian/rules.prod.focal
+++ b/linux/debian/rules.prod.focal
@@ -6,13 +6,14 @@ export PATH := $(QTDIR)/bin:$(PATH)
 export LD_LIBRARY_PATH := $(QTDIR)/lib:$(LD_LIBRARY_PATH)
 
 DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
+DEB_VERSION ?= $(shell dpkg-parsechangelog -SVersion)
 
 %:
 	dh $@ --with systemd --warn-missing
 
 override_dh_auto_configure:
 	python3 scripts/importLanguages.py -p
-	qmake CONFIG+=production CONFIG-=debug CONFIG+=release CONFIG-=debug_and_release QT+=svg BUILD_ID=FULLVERSION
+	qmake CONFIG+=production CONFIG-=debug CONFIG+=release CONFIG-=debug_and_release QT+=svg BUILD_ID=$(DEB_VERSION)
 
 override_dh_installdocs:
 

--- a/linux/debian/rules.prod.groovy
+++ b/linux/debian/rules.prod.groovy
@@ -3,13 +3,14 @@
 export DH_VERBOSE=1
 
 DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
+DEB_VERSION ?= $(shell dpkg-parsechangelog -SVersion)
 
 %:
 	dh $@ --with systemd --warn-missing
 
 override_dh_auto_configure:
 	python3 scripts/importLanguages.py -p
-	qmake CONFIG+=production CONFIG-=debug CONFIG+=release CONFIG-=debug_and_release BUILD_ID=FULLVERSION
+	qmake CONFIG+=production CONFIG-=debug CONFIG+=release CONFIG-=debug_and_release BUILD_ID=$(DEB_VERSION)
 
 override_dh_installdocs:
 

--- a/linux/debian/rules.prod.hirsute
+++ b/linux/debian/rules.prod.hirsute
@@ -3,13 +3,14 @@
 export DH_VERBOSE=1
 
 DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
+DEB_VERSION ?= $(shell dpkg-parsechangelog -SVersion)
 
 %:
 	dh $@ --with systemd --warn-missing
 
 override_dh_auto_configure:
 	python3 scripts/importLanguages.py -p 
-	qmake CONFIG+=production CONFIG-=debug CONFIG+=release CONFIG-=debug_and_release BUILD_ID=FULLVERSION
+	qmake CONFIG+=production CONFIG-=debug CONFIG+=release CONFIG-=debug_and_release BUILD_ID=$(DEB_VERSION)
 
 override_dh_installdocs:
 

--- a/linux/debian/rules.stage.bionic
+++ b/linux/debian/rules.stage.bionic
@@ -6,13 +6,14 @@ export PATH := $(QTDIR)/bin:$(PATH)
 export LD_LIBRARY_PATH := $(QTDIR)/lib:$(LD_LIBRARY_PATH)
 
 DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
+DEB_VERSION ?= $(shell dpkg-parsechangelog -SVersion)
 
 %:
 	dh $@ --with systemd --warn-missing
 
 override_dh_auto_configure:
 	python3 scripts/importLanguages.py
-	qmake CONFIG-=debug CONFIG+=release CONFIG-=debug_and_release QT+=svg CONFIG+=inspector BUILD_ID=FULLVERSION
+	qmake CONFIG-=debug CONFIG+=release CONFIG-=debug_and_release QT+=svg CONFIG+=inspector BUILD_ID=$(DEB_VERSION)
 
 override_dh_installdocs:
 

--- a/linux/debian/rules.stage.focal
+++ b/linux/debian/rules.stage.focal
@@ -6,13 +6,14 @@ export PATH := $(QTDIR)/bin:$(PATH)
 export LD_LIBRARY_PATH := $(QTDIR)/lib:$(LD_LIBRARY_PATH)
 
 DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
+DEB_VERSION ?= $(shell dpkg-parsechangelog -SVersion)
 
 %:
 	dh $@ --with systemd --warn-missing
 
 override_dh_auto_configure:
 	python3 scripts/importLanguages.py
-	qmake CONFIG-=debug CONFIG+=release CONFIG-=debug_and_release QT+=svg CONFIG+=inspector BUILD_ID=FULLVERSION
+	qmake CONFIG-=debug CONFIG+=release CONFIG-=debug_and_release QT+=svg CONFIG+=inspector BUILD_ID=$(DEB_VERSION)
 
 override_dh_installdocs:
 

--- a/linux/debian/rules.stage.groovy
+++ b/linux/debian/rules.stage.groovy
@@ -3,13 +3,14 @@
 export DH_VERBOSE=1
 
 DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
+DEB_VERSION ?= $(shell dpkg-parsechangelog -SVersion)
 
 %:
 	dh $@ --with systemd --warn-missing
 
 override_dh_auto_configure:
 	python3 scripts/importLanguages.py
-	qmake CONFIG-=debug CONFIG+=release CONFIG-=debug_and_release CONFIG+=inspector BUILD_ID=FULLVERSION
+	qmake CONFIG-=debug CONFIG+=release CONFIG-=debug_and_release CONFIG+=inspector BUILD_ID=$(DEB_VERSION)
 
 override_dh_installdocs:
 

--- a/linux/debian/rules.stage.hirsute
+++ b/linux/debian/rules.stage.hirsute
@@ -3,13 +3,14 @@
 export DH_VERBOSE=1
 
 DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
+DEB_VERSION ?= $(shell dpkg-parsechangelog -SVersion)
 
 %:
 	dh $@ --with systemd --warn-missing
 
 override_dh_auto_configure:
 	python3 scripts/importLanguages.py
-	qmake CONFIG-=debug CONFIG+=release CONFIG-=debug_and_release CONFIG+=inspector BUILD_ID=FULLVERSION
+	qmake CONFIG-=debug CONFIG+=release CONFIG-=debug_and_release CONFIG+=inspector BUILD_ID=$(DEB_VERSION)
 
 override_dh_installdocs:
 

--- a/scripts/linux_script.sh
+++ b/scripts/linux_script.sh
@@ -92,9 +92,8 @@ done
 
 printn Y "Computing the version... "
 SHORTVERSION=$(cat version.pri | grep VERSION | grep defined | cut -d= -f2 | tr -d \ )
-FULLVERSION=$(echo $SHORTVERSION | cut -d. -f1).$(date +"%Y%m%d%H%M")
 WORKDIR=mozillavpn-$SHORTVERSION
-print G "$SHORTVERSION - $FULLVERSION"
+print G "$SHORTVERSION"
 
 rm -rf .tmp || die "Failed to remove the temporary directory"
 mkdir .tmp || die "Failed to create the temporary directory"
@@ -160,7 +159,6 @@ build_deb_source() {
   sed -i -e "s/VERSION/$buildrev/g" $WORKDIR/debian/changelog || die "Failed"
   sed -i -e "s/RELEASE/$distro/g" $WORKDIR/debian/changelog || die "Failed"
   sed -i -e "s/DATE/$(date -R)/g" $WORKDIR/debian/changelog || die "Failed"
-  sed -i -e "s/FULLVERSION/$FULLVERSION/g" $WORKDIR/debian/rules || die "Failed"
 
   (cd $WORKDIR && dpkg-buildpackage --build=source $DPKG_SIGN --no-check-builddeps) || die "Failed"
 }


### PR DESCRIPTION
This is an experiment to try generating automating releases to a Launchpad PPA on every push to a release branch.

While we're at it, we also add suffixes to the package version for CI-generated packages as follows to ensure that the uploaded artifacts are easier to distinguish once installed:
- Pull requests are suffixed with `~pr<pull request #>` 
- Pushes to a release branch is suffixed with `~rc<# of commits since main>`
- Everything else is suffixed with `~github<workflow run #>`

For this to work, we need to decide on a PPA to which these packages should be uploaded and/or published, and github needs access to a GPG signing key. For the purpose of testing this, I have been using my personal PPA at `ppa:okirby/mozilla-vpn-test` and the signing key on my personal github account, but these will need to be changed to something a little more official if we decide to accept this PR.

