### PR TITLE
Add fallback to raw sockets in LinuxPingSender

### DIFF
--- a/src/pingsender.cpp
+++ b/src/pingsender.cpp
@@ -8,8 +8,8 @@ quint16 PingSender::inetChecksum(const void* data, size_t len) {
   int nleft, sum;
   quint16* w;
   union {
-    u_short us;
-    u_char uc[2];
+    quint16 us;
+    quint8 uc[2];
   } last;
   quint16 answer;
 
@@ -29,7 +29,7 @@ quint16 PingSender::inetChecksum(const void* data, size_t len) {
 
   /* mop up an odd byte, if necessary */
   if (nleft == 1) {
-    last.uc[0] = *(u_char*)w;
+    last.uc[0] = *(quint8*)w;
     last.uc[1] = 0;
     sum += last.us;
   }

--- a/src/pingsender.cpp
+++ b/src/pingsender.cpp
@@ -1,0 +1,42 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "pingsender.h"
+
+quint16 PingSender::inetChecksum(const void* data, size_t len) {
+  int nleft, sum;
+  quint16* w;
+  union {
+    u_short us;
+    u_char uc[2];
+  } last;
+  quint16 answer;
+
+  nleft = len;
+  sum = 0;
+  w = (quint16*)data;
+
+  /*
+   * Our algorithm is simple, using a 32 bit accumulator (sum), we add
+   * sequential 16 bit words to it, and at the end, fold back all the
+   * carry bits from the top 16 bits into the lower 16 bits.
+   */
+  while (nleft > 1) {
+    sum += *w++;
+    nleft -= 2;
+  }
+
+  /* mop up an odd byte, if necessary */
+  if (nleft == 1) {
+    last.uc[0] = *(u_char*)w;
+    last.uc[1] = 0;
+    sum += last.us;
+  }
+
+  /* add back carry outs from top 16 bits to low 16 bits */
+  sum = (sum >> 16) + (sum & 0xffff); /* add hi 16 to low 16 */
+  sum += (sum >> 16);                 /* add carry */
+  answer = ~sum;                      /* truncate to 16 bits */
+  return (answer);
+}

--- a/src/pingsender.h
+++ b/src/pingsender.h
@@ -17,6 +17,8 @@ class PingSender : public QObject {
 
   virtual void sendPing(const QString& destination, quint16 sequence) = 0;
 
+  static quint16 inetChecksum(const void* data, size_t length);
+
  signals:
   void recvPing(quint16 sequence);
 };

--- a/src/platforms/linux/linuxpingsender.h
+++ b/src/platforms/linux/linuxpingsender.h
@@ -21,12 +21,17 @@ class LinuxPingSender final : public PingSender {
 
   void sendPing(const QString& dest, quint16 sequence) override;
 
+ private:
+  int createSocket();
+
  private slots:
-  void socketReady();
+  void rawSocketReady();
+  void icmpSocketReady();
 
  private:
   QSocketNotifier* m_notifier = nullptr;
   int m_socket = 0;
+  quint16 m_ident = 0;
 };
 
 #endif  // LINUXPINGSENDER_H

--- a/src/platforms/macos/macospingsender.cpp
+++ b/src/platforms/macos/macospingsender.cpp
@@ -22,44 +22,6 @@ Logger logger({LOG_MACOS, LOG_NETWORKING}, "MacOSPingSender");
 
 int identifier() { return (getpid() & 0xFFFF); }
 
-// From ping.c implementation:
-u_short in_cksum(u_short* addr, int len) {
-  int nleft, sum;
-  u_short* w;
-  union {
-    u_short us;
-    u_char uc[2];
-  } last;
-  u_short answer;
-
-  nleft = len;
-  sum = 0;
-  w = addr;
-
-  /*
-   * Our algorithm is simple, using a 32 bit accumulator (sum), we add
-   * sequential 16 bit words to it, and at the end, fold back all the
-   * carry bits from the top 16 bits into the lower 16 bits.
-   */
-  while (nleft > 1) {
-    sum += *w++;
-    nleft -= 2;
-  }
-
-  /* mop up an odd byte, if necessary */
-  if (nleft == 1) {
-    last.uc[0] = *(u_char*)w;
-    last.uc[1] = 0;
-    sum += last.us;
-  }
-
-  /* add back carry outs from top 16 bits to low 16 bits */
-  sum = (sum >> 16) + (sum & 0xffff); /* add hi 16 to low 16 */
-  sum += (sum >> 16);                 /* add carry */
-  answer = ~sum;                      /* truncate to 16 bits */
-  return (answer);
-}
-
 };  // namespace
 
 MacOSPingSender::MacOSPingSender(const QString& source, QObject* parent)
@@ -119,7 +81,7 @@ void MacOSPingSender::sendPing(const QString& dest, quint16 sequence) {
   packet.icmp_type = ICMP_ECHO;
   packet.icmp_id = identifier();
   packet.icmp_seq = htons(sequence);
-  packet.icmp_cksum = in_cksum((u_short*)&packet, sizeof(packet));
+  packet.icmp_cksum = inetChecksum(&packet, sizeof(packet));
 
   if (sendto(m_socket, (char*)&packet, sizeof(packet), 0,
              (struct sockaddr*)&addr, sizeof(addr)) != sizeof(packet)) {

--- a/src/src.pro
+++ b/src/src.pro
@@ -96,6 +96,7 @@ SOURCES += \
         networkwatcher.cpp \
         notificationhandler.cpp \
         pinghelper.cpp \
+        pingsender.cpp \
         platforms/dummy/dummyapplistprovider.cpp \
         platforms/dummy/dummynetworkwatcher.cpp \
         qmlengineholder.cpp \


### PR DESCRIPTION
Some Linux distros, such as Debian 11, are starting to disable ICMP ping sockets, in which case the least-intrusive way install the VPN and still be able to send pings is to use a raw socket and then acquire `CAP_NET_RAW` either by starting as root or using `setcap cap_net_raw+ep /usr/bin/mozillavpn` after installation.
