### PR TITLE
Allow update while connected for Windows builds

### DIFF
--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -1238,6 +1238,8 @@ void MozillaVPN::update() {
 
   setUpdating(true);
 
+  // The windows installer will stop the client and daemon before installation
+  // so it's not necessary to disable the VPN to perform an upgrade.
 #ifndef MVPN_WINDOWS
   if (m_private->m_controller.state() != Controller::StateOff &&
       m_private->m_controller.state() != Controller::StateInitializing) {

--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -1238,11 +1238,13 @@ void MozillaVPN::update() {
 
   setUpdating(true);
 
+#ifndef MVPN_WINDOWS
   if (m_private->m_controller.state() != Controller::StateOff &&
       m_private->m_controller.state() != Controller::StateInitializing) {
     deactivate();
     return;
   }
+#endif
 
   m_private->m_releaseMonitor.update();
 }


### PR DESCRIPTION
The windows installer stops and restarts the client and the daemon, so there is no need to disconnect while downloading the updates.