### PR TITLE
Fix glean warnings when telemetry disabled

### DIFF
--- a/src/ui/main.qml
+++ b/src/ui/main.qml
@@ -280,7 +280,9 @@ Window {
         }
 
         function onSendGleanPings() {
-            Pings.main.submit();
+            if (VPNSettings.gleanEnabled && VPN.productionMode) {
+                Pings.main.submit();
+            }
         }
 
         function onTriggerGleanSample(sample) {
@@ -290,7 +292,9 @@ Window {
         function onAboutToQuit() {
             // We are about to quit. Let's see if we are fast enough to send
             // the last chunck of data to the glean servers.
-            Pings.main.submit();
+            if (VPNSettings.gleanEnabled && VPN.productionMode) {
+              Pings.main.submit();
+            }
         }
     }
 


### PR DESCRIPTION
When telemetry is disabled, or when not on a production build, we get lots of warnings about glean pings being disabled:
```
[14.07.2021 10:10:13.053] Info: Glean disabled: not submitting pings. Glean may still submit the deletion-request ping. (glean.lib.js:1)
```

We can fix this just by not submitting pings only when enabled.