### PR TITLE
Remove TextField/TextArea focus on outside click

### DIFF
--- a/src/ui/components/forms/VPNSearchBar.qml
+++ b/src/ui/components/forms/VPNSearchBar.qml
@@ -9,7 +9,7 @@ import Mozilla.VPN 1.0
 import "../../themes/themes.js" as Theme
 import "./../../components"
 
-TextField {
+VPNTextField {
     // TODO Add strings for Accessible.description, Accessible.name
 
     property bool stateError: false

--- a/src/ui/components/forms/VPNTextArea.qml
+++ b/src/ui/components/forms/VPNTextArea.qml
@@ -37,6 +37,7 @@ Item {
 
         TextArea.flickable: TextArea {
             property var maxCharacterCount: 1000
+            property bool loseFocusOnOutsidePress: true
 
             id: textArea
 

--- a/src/ui/components/forms/VPNTextField.qml
+++ b/src/ui/components/forms/VPNTextField.qml
@@ -12,6 +12,8 @@ import "./../../components"
 TextField {
     // TODO Add strings for Accessible.description, Accessible.name
     property bool stateError: false
+    property bool loseFocusOnOutsidePress: true
+
     id: textField
 
     Layout.preferredHeight: Theme.rowHeight

--- a/src/ui/main.qml
+++ b/src/ui/main.qml
@@ -89,6 +89,19 @@ Window {
           }
         });
     }
+
+    MouseArea {
+        anchors.fill: parent
+        propagateComposedEvents: true
+        z: 10
+        onPressed: {
+            if (window.activeFocusItem.loseFocusOnOutsidePress) {
+                window.activeFocusItem.focus = false;
+            }
+            mouse.accepted = false;
+        }
+    }
+
     Rectangle {
         id: iosSafeAreaTopMargin
 


### PR DESCRIPTION
On iOS it is currently quite difficult, in some cases impossible without clicking on another button, to drop focus and close the native keyboard once you've clicked into any of the text inputs.  This lets users bail out of text editing and close the native keyboard by tapping or clicking anywhere outside of the input. 