### PR TITLE
Windows Firewall Implementation

### DIFF
--- a/src/platforms/windows/daemon/windowsdaemon.cpp
+++ b/src/platforms/windows/daemon/windowsdaemon.cpp
@@ -7,9 +7,11 @@
 #include "logger.h"
 #include "platforms/windows/windowscommons.h"
 #include "platforms/windows/windowsservicemanager.h"
+#include "windowsfirewall.h"
 #include "wgquickprocess.h"
 
 #include <QCoreApplication>
+#include <QNetworkInterface>
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QJsonValue>

--- a/src/platforms/windows/daemon/windowsdaemon.cpp
+++ b/src/platforms/windows/daemon/windowsdaemon.cpp
@@ -7,15 +7,15 @@
 #include "logger.h"
 #include "platforms/windows/windowscommons.h"
 #include "platforms/windows/windowsservicemanager.h"
-#include "windowsfirewall.h"
 #include "wgquickprocess.h"
+#include "windowsfirewall.h"
 
 #include <QCoreApplication>
-#include <QNetworkInterface>
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QJsonValue>
 #include <QLocalSocket>
+#include <QNetworkInterface>
 #include <QScopeGuard>
 #include <QTextStream>
 #include <QtGlobal>

--- a/src/platforms/windows/daemon/windowsfirewall.cpp
+++ b/src/platforms/windows/daemon/windowsfirewall.cpp
@@ -1,0 +1,867 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "windowsfirewall.h"
+#include "logger.h"
+#include "leakdetector.h"
+#include "../windowscommons.h"
+#include "../../daemon/interfaceconfig.h"
+
+#include <QApplication>
+#include <QObject>
+#include <QFileInfo>
+#include <QNetworkInterface>
+#include <QScopeGuard>
+#include <QHostAddress>
+#include <QtEndian>
+#include <windows.h>
+#include <fwpmu.h>
+#include <stdio.h>
+#include <comdef.h>
+#include <netfw.h>
+#include "winsock.h"
+
+#include <initguid.h>
+#include <guiddef.h>
+#include <qaccessible.h>
+
+// ID for the Firewall Sublayer
+DEFINE_GUID(ST_FW_WINFW_BASELINE_SUBLAYER_KEY, 0xc78056ff, 0x2bc1, 0x4211, 0xaa,
+            0xdd, 0x7f, 0x35, 0x8d, 0xef, 0x20, 0x2d);
+// ID for the Mullvad Split-Tunnel Sublayer Provider
+DEFINE_GUID(ST_FW_PROVIDER_KEY, 0xe2c114ee, 0xf32a, 0x4264, 0xa6, 0xcb, 0x3f,
+            0xa7, 0x99, 0x63, 0x56, 0xd9);
+
+namespace {
+Logger logger(LOG_WINDOWS, "WindowsFirewall");
+WindowsFirewall* s_instance = nullptr;
+
+// Note Filter Weight may be between 0-15!
+constexpr uint8_t LOW_WEIGHT = 0;
+constexpr uint8_t MED_WEIGHT = 7;
+constexpr uint8_t HIGH_WEIGHT = 13;
+constexpr uint8_t MAX_WEIGHT = 15;
+}  // namespace
+
+WindowsFirewall* WindowsFirewall::instance() {
+  if (s_instance == nullptr) {
+    s_instance = new WindowsFirewall(qApp);
+  }
+  return s_instance;
+}
+
+WindowsFirewall::WindowsFirewall(QObject* parent) : QObject(parent) {
+  MVPN_COUNT_CTOR(WindowsFirewall);
+  Q_ASSERT(s_instance == nullptr);
+
+  HANDLE engineHandle = NULL;
+  DWORD result = ERROR_SUCCESS;
+  // Use dynamic sessions for efficiency and safety:
+  //  -> Filtering policy objects are deleted even when the application crashes/
+  //  deamon goes down
+  FWPM_SESSION0 session;
+  memset(&session, 0, sizeof(session));
+  session.flags = FWPM_SESSION_FLAG_DYNAMIC;
+
+  logger.log() << ("Opening the filter engine.");
+
+  result =
+      FwpmEngineOpen0(NULL, RPC_C_AUTHN_WINNT, NULL, &session, &engineHandle);
+
+  if (result != ERROR_SUCCESS) {
+    WindowsCommons::windowsLog("FwpmEngineOpen0 failed");
+    return;
+  }
+  logger.log() << ("Filter engine opened successfully.");
+  m_sessionHandle = engineHandle;
+}
+
+WindowsFirewall::~WindowsFirewall() {
+  MVPN_COUNT_DTOR(WindowsFirewall);
+  CloseHandle(m_sessionHandle);
+}
+
+bool WindowsFirewall::init() {
+  if (m_init) {
+    logger.log() << "Alread initialised FW_WFP layer";
+    return true;
+  }
+  if (m_sessionHandle == INVALID_HANDLE_VALUE) {
+    logger.log() << "Cant Init Sublayer with invalid wfp handle";
+    return false;
+  }
+  // If we were not able to aquire a handle, this will fail anyway.
+  // We need to open up another handle because of wfp rules:
+  // If a wfp resource was created with SESSION_DYNAMIC,
+  // the session exlusively owns the resource, meaning the driver can't add
+  // filters to the sublayer. So let's have non dynamic session only for the
+  // sublayer creation. This means the Layer exists until the next Reboot.
+  DWORD result = ERROR_SUCCESS;
+  HANDLE wfp = INVALID_HANDLE_VALUE;
+  FWPM_SESSION0 session;
+  memset(&session, 0, sizeof(session));
+
+  logger.log() << "Opening the filter engine";
+  result = FwpmEngineOpen0(NULL, RPC_C_AUTHN_WINNT, NULL, &session, &wfp);
+  if (result != ERROR_SUCCESS) {
+    logger.log() << "FwpmEngineOpen0 failed. Return value:.\n" << result;
+    return false;
+  }
+  auto cleanup = qScopeGuard([&] { FwpmEngineClose0(wfp); });
+
+  // Check if the Layer Already Exists
+  FWPM_SUBLAYER0* maybeLayer;
+  result = FwpmSubLayerGetByKey0(wfp, &ST_FW_WINFW_BASELINE_SUBLAYER_KEY,
+                                 &maybeLayer);
+  if (result == ERROR_SUCCESS) {
+    logger.log() << "The Sublayer Already Exists!";
+    FwpmFreeMemory0((void**)&maybeLayer);
+    return true;
+  }
+
+  // Step 1: Start Transaction
+  result = FwpmTransactionBegin(wfp, NULL);
+  if (result != ERROR_SUCCESS) {
+    logger.log() << "FwpmTransactionBegin0 failed. Return value:.\n" << result;
+    return false;
+  }
+
+  // Step 3: Add Sublayer
+  FWPM_SUBLAYER0 subLayer;
+  memset(&subLayer, 0, sizeof(subLayer));
+  subLayer.subLayerKey = ST_FW_WINFW_BASELINE_SUBLAYER_KEY;
+  subLayer.displayData.name = (PWSTR)L"MozillaVPN-SplitTunnel-Sublayer";
+  subLayer.displayData.description =
+      (PWSTR)L"Filters that enforce a good baseline";
+  // subLayer.providerKey= const_cast<GUID*>(&ST_FW_PROVIDER_KEY);
+  subLayer.weight = 0xFFFF;
+
+  result = FwpmSubLayerAdd0(wfp, &subLayer, NULL);
+  if (result != ERROR_SUCCESS) {
+    logger.log() << "FwpmSubLayerAdd0 failed. Return value:.\n" << result;
+    return false;
+  }
+  // Step 4: Commit!
+  result = FwpmTransactionCommit0(wfp);
+  if (result != ERROR_SUCCESS) {
+    logger.log() << "FwpmTransactionCommit0 failed. Return value:.\n" << result;
+    return false;
+  }
+  logger.log() << "Initialised Sublayer";
+  m_init = true;
+  return true;
+}
+
+bool WindowsFirewall::allowTrafficForAppOnAdapter(const QString& exePath,
+                                                  int network) {
+  logger.log() << "Adding hard Permit for " << exePath
+               << " Accessing Device: " << network;
+  DWORD result = ERROR_SUCCESS;
+
+  // Get the AppID for the Executable;
+  QString appName = QFileInfo(exePath).baseName();
+  std::wstring wstr = exePath.toStdWString();
+  PCWSTR appPath = wstr.c_str();
+  FWP_BYTE_BLOB* appID = NULL;
+  uint64_t filterID = 0;
+
+  result = FwpmGetAppIdFromFileName0(appPath, &appID);
+  if (result != ERROR_SUCCESS) {
+    WindowsCommons::windowsLog("FwpmGetAppIdFromFileName0 failure");
+    return false;
+  }
+  // Condition 1: Request must come from the .exe
+  FWPM_FILTER_CONDITION0 conds[2];
+  conds[0].fieldKey = FWPM_CONDITION_ALE_APP_ID;
+  conds[0].matchType = FWP_MATCH_EQUAL;
+  conds[0].conditionValue.type = FWP_BYTE_BLOB_TYPE;
+  conds[0].conditionValue.byteBlob = appID;
+
+  // Condition 2: Request may NOT be targeting the TUN interface
+  conds[1].fieldKey = FWPM_CONDITION_INTERFACE_INDEX;
+  conds[1].matchType = FWP_MATCH_EQUAL;
+  conds[1].conditionValue.type = FWP_UINT32;
+  conds[1].conditionValue.uint32 = network;
+
+  // Assemble the Filter base
+  FWPM_FILTER0 filter;
+  memset(&filter, 0, sizeof(filter));
+  filter.filterCondition = conds;
+  filter.numFilterConditions = 2;
+  filter.action.type = FWP_ACTION_PERMIT;
+  filter.weight.type = FWP_UINT8;
+  filter.weight.uint8 = 15;
+  filter.subLayerKey = ST_FW_WINFW_BASELINE_SUBLAYER_KEY;
+  filter.flags = FWPM_FILTER_FLAG_CLEAR_ACTION_RIGHT;  // Make this decision
+                                                       // only blockable by veto
+
+  // Build and add the Filters
+  // #1 Permit outbound IPv4 traffic.
+  {
+    QString name = QString("Permit (out) IPv4 Traffic of: " + appName);
+    std::wstring wname = name.toStdWString();
+    PCWSTR filterName = wname.c_str();
+    filter.displayData.name = (PWSTR)filterName;
+    filter.layerKey = FWPM_LAYER_ALE_AUTH_CONNECT_V4;
+
+    result = FwpmFilterAdd0(m_sessionHandle, &filter, NULL, &filterID);
+
+    if (result != ERROR_SUCCESS) {
+      logger.log() << "Failed to set rule " << name << "\n" << result;
+      return false;
+    }
+  }
+  // #2 Permit inbound IPv4 traffic.
+  {
+    QString name = QString("Permit (in)  IPv4 Traffic of: " + appName);
+    std::wstring wname = name.toStdWString();
+    PCWSTR filterName = wname.c_str();
+    filter.displayData.name = (PWSTR)filterName;
+    filter.layerKey = FWPM_LAYER_ALE_AUTH_RECV_ACCEPT_V4;
+    result = FwpmFilterAdd0(m_sessionHandle, &filter, NULL, &filterID);
+
+    if (result != ERROR_SUCCESS) {
+      logger.log() << "Failed to set rule " << name << "\n" << result;
+      return false;
+    }
+  }
+  // #3 Permit outbound IPv6 traffic.
+  {
+    QString name = QString("Permit (out) IPv6 Traffic of: " + appName);
+    std::wstring wname = name.toStdWString();
+    PCWSTR filterName = wname.c_str();
+    filter.displayData.name = (PWSTR)filterName;
+    filter.layerKey = FWPM_LAYER_ALE_AUTH_CONNECT_V6;
+    result = FwpmFilterAdd0(m_sessionHandle, &filter, NULL, &filterID);
+
+    if (result != ERROR_SUCCESS) {
+      logger.log() << "Failed to set rule " << name << "\n" << result;
+      return false;
+    }
+  }
+  // #4 Permit inbound IPv6 traffic.
+  {
+    QString name = QString("Permit (in)  IPv6 Traffic of: " + appName);
+    std::wstring wname = name.toStdWString();
+    PCWSTR filterName = wname.c_str();
+    filter.displayData.name = (PWSTR)filterName;
+    filter.layerKey = FWPM_LAYER_ALE_AUTH_RECV_ACCEPT_V6;
+    result = FwpmFilterAdd0(m_sessionHandle, &filter, NULL, &filterID);
+
+    if (result != ERROR_SUCCESS) {
+      logger.log() << "Failed to set rule " << name << "\n" << result;
+      return false;
+    }
+  }
+
+  logger.log() << "Ruleset applied for: " << exePath;
+  return true;
+}
+
+bool WindowsFirewall::enableKillSwitch(int vpnAdapterIndex,
+                                       const InterfaceConfig& config) {
+  logger.log() << "Enableling Killswitch Using Adapter:" << vpnAdapterIndex;
+  if (!blockAll(LOW_WEIGHT)) {
+    logger.log() << "Ruleset failed: blockAll";
+    disableKillSwitch();
+    return false;
+  };
+  logger.log() << "Ruleset applied: blockAll";
+
+  if (!allowTrafficOfAdapter(vpnAdapterIndex, MED_WEIGHT)) {
+    logger.log() << "Ruleset failed: allowTrafficOfAdapter";
+    disableKillSwitch();
+    return false;
+  }
+  logger.log() << "Ruleset applied: allowTrafficOfAdapter";
+
+  if (!allowDHCPTraffic(MED_WEIGHT)) {
+    logger.log() << "Ruleset failed: allowDHCPTraffic";
+    disableKillSwitch();
+    return false;
+  }
+  logger.log() << "Ruleset applied: allowDHCPTraffic";
+
+  if (!allowHyperVTraffic(MED_WEIGHT)) {
+    logger.log() << "Ruleset failed: allowHyperVTraffic";
+    disableKillSwitch();
+    return false;
+  }
+  logger.log() << "Ruleset applied: allowHyperVTraffic";
+
+  if (!allowTrafficForAppOnAll(getCurrentPath(), MAX_WEIGHT)) {
+    logger.log() << "Ruleset failed: allowTrafficForAppOnAll";
+    disableKillSwitch();
+    return false;
+  }
+  logger.log() << "Ruleset applied: allowTrafficForAppOnAll: MozillaVPN";
+
+  if (!allowTrafficTo(QHostAddress(config.m_dnsServer), 53, HIGH_WEIGHT)) {
+    logger.log() << "Ruleset failed: allowTrafficTo DNS Server";
+    disableKillSwitch();
+    return false;
+  }
+  logger.log() << "Ruleset applied: allowTrafficTo: DNS-Server";
+
+  logger.log() << "Killswitch on! Rules:" << m_activeRules.length();
+  return true;
+}
+
+bool WindowsFirewall::disableKillSwitch() {
+  auto result = FwpmTransactionBegin(m_sessionHandle, NULL);
+  auto cleanup = qScopeGuard([&] {
+    if (result != ERROR_SUCCESS) {
+      FwpmTransactionAbort0(m_sessionHandle);
+    }
+  });
+  if (result != ERROR_SUCCESS) {
+    logger.log() << "FwpmTransactionBegin0 failed. Return value:.\n" << result;
+    return false;
+  }
+
+  for (const auto& filterID : qAsConst(m_activeRules)) {
+    FwpmFilterDeleteById0(m_sessionHandle, filterID);
+  }
+
+  // Commit!
+  result = FwpmTransactionCommit0(m_sessionHandle);
+  if (result != ERROR_SUCCESS) {
+    logger.log() << "FwpmTransactionCommit0 failed. Return value:.\n" << result;
+    return false;
+  }
+  m_activeRules.clear();
+  logger.log() << "Firewall Disabled!";
+  return true;
+}
+
+bool WindowsFirewall::allowTrafficForAppOnAll(const QString& exePath,
+                                              int weight) {
+  logger.log() << "Adding hard Permit for " << exePath
+               << " Accessing All Devices: ";
+  DWORD result = ERROR_SUCCESS;
+  Q_ASSERT(weight <= 15);
+
+  // Get the AppID for the Executable;
+  QString appName = QFileInfo(exePath).baseName();
+  std::wstring wstr = exePath.toStdWString();
+  PCWSTR appPath = wstr.c_str();
+  FWP_BYTE_BLOB* appID = NULL;
+  uint64_t filterID = 0;
+  result = FwpmGetAppIdFromFileName0(appPath, &appID);
+  if (result != ERROR_SUCCESS) {
+    WindowsCommons::windowsLog("FwpmGetAppIdFromFileName0 failure");
+    return false;
+  }
+
+  // Start Transaction
+  result = FwpmTransactionBegin(m_sessionHandle, NULL);
+  auto cleanup = qScopeGuard([&] {
+    if (result != ERROR_SUCCESS) {
+      FwpmTransactionAbort0(m_sessionHandle);
+    }
+  });
+  if (result != ERROR_SUCCESS) {
+    logger.log() << "FwpmTransactionBegin0 failed. Return value:.\n" << result;
+    return false;
+  }
+
+  // Condition: Request must come from the .exe
+  FWPM_FILTER_CONDITION0 conds;
+  conds.fieldKey = FWPM_CONDITION_ALE_APP_ID;
+  conds.matchType = FWP_MATCH_EQUAL;
+  conds.conditionValue.type = FWP_BYTE_BLOB_TYPE;
+  conds.conditionValue.byteBlob = appID;
+
+  // Assemble the Filter base
+  FWPM_FILTER0 filter;
+  memset(&filter, 0, sizeof(filter));
+  filter.filterCondition = &conds;
+  filter.numFilterConditions = 1;
+  filter.action.type = FWP_ACTION_PERMIT;
+  filter.weight.type = FWP_UINT8;
+  filter.weight.uint8 = weight;
+  filter.subLayerKey = ST_FW_WINFW_BASELINE_SUBLAYER_KEY;
+  filter.flags = FWPM_FILTER_FLAG_CLEAR_ACTION_RIGHT;  // Make this decision
+                                                       // only blockable by veto
+
+  // Build and add the Filters
+  // #1 Permit outbound IPv4 traffic.
+  {
+    QString name = QString("Permit (out) IPv4 Traffic of: " + appName);
+    std::wstring wname = name.toStdWString();
+    PCWSTR filterName = wname.c_str();
+    filter.displayData.name = (PWSTR)filterName;
+    filter.layerKey = FWPM_LAYER_ALE_AUTH_CONNECT_V4;
+
+    result = FwpmFilterAdd0(m_sessionHandle, &filter, NULL, &filterID);
+
+    if (result != ERROR_SUCCESS) {
+      logger.log() << "Failed to set rule " << name << "\n" << result;
+      return false;
+    }
+  }
+  // #2 Permit inbound IPv4 traffic.
+  {
+    QString name = QString("Permit (in)  IPv4 Traffic of: " + appName);
+    std::wstring wname = name.toStdWString();
+    PCWSTR filterName = wname.c_str();
+    filter.displayData.name = (PWSTR)filterName;
+    filter.layerKey = FWPM_LAYER_ALE_AUTH_RECV_ACCEPT_V4;
+    result = FwpmFilterAdd0(m_sessionHandle, &filter, NULL, &filterID);
+
+    if (result != ERROR_SUCCESS) {
+      logger.log() << "Failed to set rule " << name << "\n" << result;
+      return false;
+    }
+  }
+
+  // Commit!
+  result = FwpmTransactionCommit0(m_sessionHandle);
+  if (result != ERROR_SUCCESS) {
+    logger.log() << "FwpmTransactionCommit0 failed. Return value:.\n" << result;
+    return false;
+  }
+  return true;
+}
+
+bool WindowsFirewall::allowTrafficOfAdapter(int networkAdapter,
+                                            uint8_t weight) {
+  // Start Transaction
+  auto result = FwpmTransactionBegin(m_sessionHandle, NULL);
+  auto cleanup = qScopeGuard([&] {
+    if (result != ERROR_SUCCESS) {
+      FwpmTransactionAbort0(m_sessionHandle);
+    }
+  });
+  if (result != ERROR_SUCCESS) {
+    logger.log() << "FwpmTransactionBegin0 failed. Return value:.\n" << result;
+    return false;
+  }
+
+  FWPM_FILTER_CONDITION0 conds;
+  // Condition: Request must be targeting the TUN interface
+  conds.fieldKey = FWPM_CONDITION_INTERFACE_INDEX;
+  conds.matchType = FWP_MATCH_EQUAL;
+  conds.conditionValue.type = FWP_UINT32;
+  conds.conditionValue.uint32 = networkAdapter;
+
+  // Assemble the Filter base
+  FWPM_FILTER0 filter;
+  memset(&filter, 0, sizeof(filter));
+  filter.filterCondition = &conds;
+  filter.numFilterConditions = 1;
+  filter.action.type = FWP_ACTION_PERMIT;
+  filter.weight.type = FWP_UINT8;
+  filter.weight.uint8 = weight;
+  filter.subLayerKey = ST_FW_WINFW_BASELINE_SUBLAYER_KEY;
+
+  uint64_t filterID = 0;
+  // #1 Permit outbound IPv4 traffic.
+  std::wstring name(L"Permit outbound IPv4 traffic on TUN adapter");
+  filter.displayData.name = (PWSTR)name.c_str();
+  filter.layerKey = FWPM_LAYER_ALE_AUTH_CONNECT_V4;
+
+  result = FwpmFilterAdd0(m_sessionHandle, &filter, NULL, &filterID);
+  if (result != ERROR_SUCCESS) {
+    WindowsCommons::windowsLog(
+        "Failed: Permit outbound IPv4 traffic on adapter");
+    logger.log() << "Result code " << result;
+    return false;
+  }
+  m_activeRules.append(filterID);
+
+  // #2 Permit inbound IPv4 traffic.
+  name = std::wstring(L"Permit inbound IPv4 traffic on TUN adapter");
+  filter.displayData.name = (PWSTR)name.c_str();
+  filter.layerKey = FWPM_LAYER_ALE_AUTH_RECV_ACCEPT_V4;
+
+  result = FwpmFilterAdd0(m_sessionHandle, &filter, NULL, &filterID);
+  if (result != ERROR_SUCCESS) {
+    WindowsCommons::windowsLog(
+        "Failed: Permit inbound IPv4 traffic on adapter");
+    logger.log() << "Result code " << result;
+    return false;
+  }
+  m_activeRules.append(filterID);
+
+  // #3 Permit outbound IPv6 traffic.
+  name = std::wstring(L"Permit outbound IPv6 traffic on TUN adapter");
+  filter.displayData.name = (PWSTR)name.c_str();
+  filter.layerKey = FWPM_LAYER_ALE_AUTH_CONNECT_V6;
+
+  result = FwpmFilterAdd0(m_sessionHandle, &filter, NULL, &filterID);
+  if (result != ERROR_SUCCESS) {
+    WindowsCommons::windowsLog(
+        "Failed: Permit outbound IPv6 traffic on adapter");
+    logger.log() << "Result code " << result;
+    return false;
+  }
+  m_activeRules.append(filterID);
+
+  // #4 Permit inbound IPv6 traffic.
+  name = std::wstring(L"Permit inbound IPv4 traffic on TUN adapter");
+  filter.displayData.name = (PWSTR)name.c_str();
+  filter.layerKey = FWPM_LAYER_ALE_AUTH_RECV_ACCEPT_V6;
+
+  result = FwpmFilterAdd0(m_sessionHandle, &filter, NULL, &filterID);
+  if (result != ERROR_SUCCESS) {
+    WindowsCommons::windowsLog(
+        "Failed: Permit inbound IPv6 traffic on adapter");
+    return false;
+  }
+  m_activeRules.append(filterID);
+
+  // Commit!
+  result = FwpmTransactionCommit0(m_sessionHandle);
+  if (result != ERROR_SUCCESS) {
+    logger.log() << "FwpmTransactionCommit0 failed. Return value:.\n" << result;
+    return false;
+  }
+  return true;
+}
+
+bool WindowsFirewall::allowTrafficTo(const QHostAddress& targetIP, uint port,
+                                     int weight) {
+  logger.log() << "Requesting to allow Traffic to: " << targetIP.toString()
+               << ":" << port;
+  if (targetIP.protocol() == QAbstractSocket::IPv6Protocol) {
+    // TODO: Implement it :)
+    logger.log() << "Allow Traffic to not implemented for v6 adresses yet";
+    return false;
+  }
+
+  quint32_be ipBigEndian;
+  quint32 ip = targetIP.toIPv4Address();
+  qToBigEndian(ip, &ipBigEndian);
+
+  // Start Transaction
+  auto result = FwpmTransactionBegin(m_sessionHandle, NULL);
+  auto cleanup = qScopeGuard([&] {
+    if (result != ERROR_SUCCESS) {
+      FwpmTransactionAbort0(m_sessionHandle);
+    }
+  });
+  if (result != ERROR_SUCCESS) {
+    logger.log() << "FwpmTransactionBegin0 failed. Return value:.\n" << result;
+    return false;
+  }
+  // Allow Traffic to IP with PORT using any protocol
+  FWPM_FILTER_CONDITION0 conds[4];
+  conds[0].fieldKey = FWPM_CONDITION_IP_PROTOCOL;
+  conds[0].matchType = FWP_MATCH_EQUAL;
+  conds[0].conditionValue.type = FWP_UINT8;
+  conds[0].conditionValue.uint8 = (IPPROTO_UDP);
+
+  conds[1].fieldKey = FWPM_CONDITION_IP_PROTOCOL;
+  conds[1].matchType = FWP_MATCH_EQUAL;
+  conds[1].conditionValue.type = FWP_UINT8;
+  conds[1].conditionValue.uint16 = (IPPROTO_TCP);
+
+  conds[2].fieldKey = FWPM_CONDITION_IP_REMOTE_PORT;
+  conds[2].matchType = FWP_MATCH_EQUAL;
+  conds[2].conditionValue.type = FWP_UINT16;
+  conds[2].conditionValue.uint16 = port;
+
+  conds[3].fieldKey = FWPM_CONDITION_IP_REMOTE_ADDRESS;
+  conds[3].matchType = FWP_MATCH_EQUAL;
+  conds[3].conditionValue.type = FWP_UINT32;
+  conds[3].conditionValue.uint32 = ipBigEndian;
+
+  // Assemble the Filter base
+  FWPM_FILTER0 filter;
+  memset(&filter, 0, sizeof(filter));
+  filter.filterCondition = conds;
+  filter.numFilterConditions = 4;
+  filter.action.type = FWP_ACTION_PERMIT;
+  filter.weight.type = FWP_UINT8;
+  filter.weight.uint8 = weight;
+  filter.subLayerKey = ST_FW_WINFW_BASELINE_SUBLAYER_KEY;
+
+  uint64_t filterID = 0;
+  auto name = std::wstring(L"Permit outbound Traffic to Fixed IPv4");
+  filter.displayData.name = (PWSTR)name.c_str();
+  filter.layerKey = FWPM_LAYER_ALE_AUTH_CONNECT_V4;
+  result = FwpmFilterAdd0(m_sessionHandle, &filter, NULL, &filterID);
+  if (result != ERROR_SUCCESS) {
+    return false;
+  }
+  m_activeRules.append(filterID);
+
+  name = std::wstring(L"Permit inbound Traffic from Fixed IPv4");
+  filter.displayData.name = (PWSTR)name.c_str();
+  filter.layerKey = FWPM_LAYER_ALE_AUTH_RECV_ACCEPT_V4;
+
+  result = FwpmFilterAdd0(m_sessionHandle, &filter, NULL, &filterID);
+  if (result != ERROR_SUCCESS) {
+    return false;
+  }
+  m_activeRules.append(filterID);
+
+  result = FwpmTransactionCommit0(m_sessionHandle);
+  if (result != ERROR_SUCCESS) {
+    logger.log() << "FwpmTransactionCommit0 failed. Return value:.\n" << result;
+    return false;
+  }
+  return true;
+}
+
+bool WindowsFirewall::allowDHCPTraffic(uint8_t weight) {
+  // Start Transaction
+  auto result = FwpmTransactionBegin(m_sessionHandle, NULL);
+  auto cleanup = qScopeGuard([&] {
+    if (result != ERROR_SUCCESS) {
+      FwpmTransactionAbort0(m_sessionHandle);
+    }
+  });
+  if (result != ERROR_SUCCESS) {
+    logger.log() << "FwpmTransactionBegin0 failed. Return value:.\n" << result;
+    return false;
+  }
+  // Allow outbound DHCPv4
+  {
+    FWPM_FILTER_CONDITION0 conds[4];
+    // Condition: Request must be targeting the TUN interface
+    conds[0].fieldKey = FWPM_CONDITION_IP_PROTOCOL;
+    conds[0].matchType = FWP_MATCH_EQUAL;
+    conds[0].conditionValue.type = FWP_UINT8;
+    conds[0].conditionValue.uint8 = (IPPROTO_UDP);
+
+    conds[1].fieldKey = FWPM_CONDITION_IP_LOCAL_PORT;
+    conds[1].matchType = FWP_MATCH_EQUAL;
+    conds[1].conditionValue.type = FWP_UINT16;
+    conds[1].conditionValue.uint16 = (68);
+
+    conds[2].fieldKey = FWPM_CONDITION_IP_REMOTE_PORT;
+    conds[2].matchType = FWP_MATCH_EQUAL;
+    conds[2].conditionValue.type = FWP_UINT16;
+    conds[2].conditionValue.uint16 = 67;
+
+    conds[3].fieldKey = FWPM_CONDITION_IP_REMOTE_ADDRESS;
+    conds[3].matchType = FWP_MATCH_EQUAL;
+    conds[3].conditionValue.type = FWP_UINT32;
+    conds[3].conditionValue.uint32 = (0xffffffff);
+
+    // Assemble the Filter base
+    FWPM_FILTER0 filter;
+    memset(&filter, 0, sizeof(filter));
+    filter.filterCondition = conds;
+    filter.numFilterConditions = 4;
+    filter.action.type = FWP_ACTION_PERMIT;
+    filter.weight.type = FWP_UINT8;
+    filter.weight.uint8 = weight;
+    filter.subLayerKey = ST_FW_WINFW_BASELINE_SUBLAYER_KEY;
+
+    uint64_t filterID = 0;
+    auto name = std::wstring(L"Permit outbound DHCPv4");
+    filter.displayData.name = (PWSTR)name.c_str();
+    filter.layerKey = FWPM_LAYER_ALE_AUTH_CONNECT_V4;
+
+    result = FwpmFilterAdd0(m_sessionHandle, &filter, NULL, &filterID);
+    if (result != ERROR_SUCCESS) {
+      return false;
+    }
+    m_activeRules.append(filterID);
+  }
+  // Allow inbound DHCPv4
+  {
+    FWPM_FILTER_CONDITION0 conds[3];
+    // Condition: Request must be targeting the TUN interface
+    conds[0].fieldKey = FWPM_CONDITION_IP_PROTOCOL;
+    conds[0].matchType = FWP_MATCH_EQUAL;
+    conds[0].conditionValue.type = FWP_UINT8;
+    conds[0].conditionValue.uint8 = (IPPROTO_UDP);
+
+    conds[1].fieldKey = FWPM_CONDITION_IP_LOCAL_PORT;
+    conds[1].matchType = FWP_MATCH_EQUAL;
+    conds[1].conditionValue.type = FWP_UINT16;
+    conds[1].conditionValue.uint16 = (68);
+
+    conds[2].fieldKey = FWPM_CONDITION_IP_REMOTE_PORT;
+    conds[2].matchType = FWP_MATCH_EQUAL;
+    conds[2].conditionValue.type = FWP_UINT16;
+    conds[2].conditionValue.uint16 = 67;
+
+    // Assemble the Filter base
+    FWPM_FILTER0 filter;
+    memset(&filter, 0, sizeof(filter));
+    filter.filterCondition = conds;
+    filter.numFilterConditions = 3;
+    filter.action.type = FWP_ACTION_PERMIT;
+    filter.weight.type = FWP_UINT8;
+    filter.weight.uint8 = weight;
+    filter.subLayerKey = ST_FW_WINFW_BASELINE_SUBLAYER_KEY;
+
+    uint64_t filterID = 0;
+    auto name = std::wstring(L"Permit inbound DHCPv4");
+    filter.displayData.name = (PWSTR)name.c_str();
+    filter.layerKey = FWPM_LAYER_ALE_AUTH_RECV_ACCEPT_V4;
+
+    result = FwpmFilterAdd0(m_sessionHandle, &filter, NULL, &filterID);
+    if (result != ERROR_SUCCESS) {
+      return false;
+    }
+    m_activeRules.append(filterID);
+  }
+  // TODO: Allow v6 DHCP
+
+  // Commit!
+  result = FwpmTransactionCommit0(m_sessionHandle);
+  if (result != ERROR_SUCCESS) {
+    logger.log() << "FwpmTransactionCommit0 failed. Return value:.\n" << result;
+    return false;
+  }
+  return true;
+}
+// Allows the internal Hyper-V Switches to work.
+bool WindowsFirewall::allowHyperVTraffic(uint8_t weight) {
+  // Start Transaction
+  auto result = FwpmTransactionBegin(m_sessionHandle, NULL);
+  auto cleanup = qScopeGuard([&] {
+    if (result != ERROR_SUCCESS) {
+      FwpmTransactionAbort0(m_sessionHandle);
+    }
+  });
+  if (result != ERROR_SUCCESS) {
+    logger.log() << "FwpmTransactionBegin0 failed. Return value:.\n" << result;
+    return false;
+  }
+
+  FWPM_FILTER_CONDITION0 cond;
+  // Condition: Request must be targeting the TUN interface
+  cond.fieldKey = FWPM_CONDITION_L2_FLAGS;
+  cond.matchType = FWP_MATCH_EQUAL;
+  cond.conditionValue.type = FWP_UINT32;
+  cond.conditionValue.uint32 = FWP_CONDITION_L2_IS_VM2VM;
+
+  // Assemble the Filter base
+  FWPM_FILTER0 filter;
+  memset(&filter, 0, sizeof(filter));
+  filter.filterCondition = &cond;
+  filter.numFilterConditions = 1;
+  filter.action.type = FWP_ACTION_PERMIT;
+  filter.weight.type = FWP_UINT8;
+  filter.weight.uint8 = weight;
+  filter.subLayerKey = ST_FW_WINFW_BASELINE_SUBLAYER_KEY;
+
+  uint64_t filterID = 0;
+  // #1 Permit Hyper-V => Hyper-V outbound.
+  std::wstring name(L"Permit Hyper-V => Hyper-V outbound");
+  filter.displayData.name = (PWSTR)name.c_str();
+  filter.layerKey = FWPM_LAYER_OUTBOUND_MAC_FRAME_NATIVE;
+
+  result = FwpmFilterAdd0(m_sessionHandle, &filter, NULL, &filterID);
+  if (result != ERROR_SUCCESS) {
+    logger.log() << "Permit Hyper-V => Hyper-V outbound failed " << result;
+    return false;
+  }
+  m_activeRules.append(filterID);
+  // #2 Permit Hyper-V => Hyper-V inbound.
+  name = std::wstring(L"Permit Hyper-V => Hyper-V inbound");
+  filter.displayData.name = (PWSTR)name.c_str();
+  filter.layerKey = FWPM_LAYER_INBOUND_MAC_FRAME_NATIVE;
+
+  result = FwpmFilterAdd0(m_sessionHandle, &filter, NULL, &filterID);
+  if (result != ERROR_SUCCESS) {
+    logger.log() << "Permit Hyper-V => Hyper-V inbound failed " << result;
+    return false;
+  }
+  m_activeRules.append(filterID);
+
+  // Commit!
+  result = FwpmTransactionCommit0(m_sessionHandle);
+  if (result != ERROR_SUCCESS) {
+    logger.log() << "FwpmTransactionCommit0 failed. Return value:.\n" << result;
+    return false;
+  }
+  return true;
+}
+
+// Blocks All Traffic!
+bool WindowsFirewall::blockAll(uint8_t weight) {
+  // Start Transaction
+  auto result = FwpmTransactionBegin(m_sessionHandle, NULL);
+  auto cleanup = qScopeGuard([&] {
+    if (result != ERROR_SUCCESS) {
+      FwpmTransactionAbort0(m_sessionHandle);
+    }
+  });
+  if (result != ERROR_SUCCESS) {
+    logger.log() << "FwpmTransactionBegin0 failed. Return value:.\n" << result;
+    return false;
+  }
+
+  // Assemble the Filter base
+  FWPM_FILTER0 filter;
+  memset(&filter, 0, sizeof(filter));
+  filter.action.type = FWP_ACTION_BLOCK;
+  filter.weight.type = FWP_UINT8;
+  filter.weight.uint8 = weight;
+  filter.subLayerKey = ST_FW_WINFW_BASELINE_SUBLAYER_KEY;
+
+  uint64_t filterID = 0;
+  // #1 Block Outbound traffic on IPv4
+  std::wstring name(L"Block all outbound (IPv4)");
+  filter.displayData.name = (PWSTR)name.c_str();
+  filter.layerKey = FWPM_LAYER_ALE_AUTH_CONNECT_V4;
+  result = FwpmFilterAdd0(m_sessionHandle, &filter, NULL, &filterID);
+  if (result != ERROR_SUCCESS) {
+    return false;
+  }
+  m_activeRules.append(filterID);
+  // #2 Block Inbound traffic on IPv4
+  name = std::wstring(L"Block all inbound (IPv4)");
+  filter.displayData.name = (PWSTR)name.c_str();
+  filter.layerKey = FWPM_LAYER_ALE_AUTH_RECV_ACCEPT_V4;
+
+  result = FwpmFilterAdd0(m_sessionHandle, &filter, NULL, &filterID);
+  if (result != ERROR_SUCCESS) {
+    return false;
+  }
+  m_activeRules.append(filterID);
+
+  // #3 Block Outbound traffic on IPv6
+  name = std::wstring(L"Block all outbound (IPv6)");
+  filter.displayData.name = (PWSTR)name.c_str();
+  filter.layerKey = FWPM_LAYER_ALE_AUTH_CONNECT_V6;
+  result = FwpmFilterAdd0(m_sessionHandle, &filter, NULL, &filterID);
+  if (result != ERROR_SUCCESS) {
+    return false;
+  }
+  m_activeRules.append(filterID);
+  // #4 Block Inbound traffic on IPv6
+  name = std::wstring(L"Block all inbound (IPv6)");
+  filter.displayData.name = (PWSTR)name.c_str();
+  filter.layerKey = FWPM_LAYER_ALE_AUTH_RECV_ACCEPT_V6;
+
+  result = FwpmFilterAdd0(m_sessionHandle, &filter, NULL, &filterID);
+  if (result != ERROR_SUCCESS) {
+    return false;
+  }
+  m_activeRules.append(filterID);
+
+  // Commit!
+  result = FwpmTransactionCommit0(m_sessionHandle);
+  if (result != ERROR_SUCCESS) {
+    logger.log() << "FwpmTransactionCommit0 failed. Return value:.\n" << result;
+    return false;
+  }
+  return true;
+}
+
+// Returns the Path of the Current Executable this runs in
+QString WindowsFirewall::getCurrentPath() {
+  QByteArray buffer(2048, 0xFF);
+  auto ok = GetModuleFileNameA(NULL, buffer.data(), buffer.size());
+
+  if (ok == ERROR_INSUFFICIENT_BUFFER) {
+    buffer.resize(buffer.size() * 2);
+    ok = GetModuleFileNameA(NULL, buffer.data(), buffer.size());
+  }
+  if (ok == 0) {
+    WindowsCommons::windowsLog("Err fetching dos path");
+    return "";
+  }
+  QString::fromWCharArray((wchar_t*)buffer.data());
+  return QString::fromLocal8Bit(buffer);
+}

--- a/src/platforms/windows/daemon/windowsfirewall.h
+++ b/src/platforms/windows/daemon/windowsfirewall.h
@@ -1,0 +1,41 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef WindowsFirewall_H
+#define WindowsFirewall_H
+
+#include "../../daemon/interfaceconfig.h"
+
+#include <windows.h>
+#include <QString>
+#include <QObject>
+#include <QHostAddress>
+
+class WindowsFirewall final : public QObject {
+ public:
+  ~WindowsFirewall();
+
+  static WindowsFirewall* instance();
+  bool init();
+
+  bool enableKillSwitch(int vpnAdapterIndex, const InterfaceConfig& config);
+  bool disableKillSwitch();
+
+ private:
+  WindowsFirewall(QObject* parent);
+  HANDLE m_sessionHandle;
+  bool m_init = false;
+  QList<uint64_t> m_activeRules;
+
+  QString getCurrentPath();
+  bool allowTrafficForAppOnAdapter(const QString& exePath, int networkIndex);
+  bool allowTrafficForAppOnAll(const QString& exePath, int weight);
+  bool allowTrafficTo(const QHostAddress& targetIP, uint port, int weight);
+  bool allowTrafficOfAdapter(int networkAdapter, uint8_t weight);
+  bool allowDHCPTraffic(uint8_t weight);
+  bool allowHyperVTraffic(uint8_t weight);
+  bool blockAll(uint8_t weight);
+};
+
+#endif  // WindowsFirewall_H

--- a/src/platforms/windows/daemon/windowsfirewall.h
+++ b/src/platforms/windows/daemon/windowsfirewall.h
@@ -2,15 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#ifndef WindowsFirewall_H
-#define WindowsFirewall_H
+#ifndef WINDOWSFIREWALL_H
+#define WINDOWSFIREWALL_H
 
 #include "../../daemon/interfaceconfig.h"
 
 #include <windows.h>
 #include <QString>
 #include <QObject>
-#include <QHostAddress>
+class QHostAddress;
 
 class WindowsFirewall final : public QObject {
  public:
@@ -38,4 +38,4 @@ class WindowsFirewall final : public QObject {
   bool blockAll(uint8_t weight);
 };
 
-#endif  // WindowsFirewall_H
+#endif  // WINDOWSFIREWALL_H

--- a/src/platforms/windows/daemon/windowssplittunnel.cpp
+++ b/src/platforms/windows/daemon/windowssplittunnel.cpp
@@ -21,6 +21,7 @@
 
 namespace {
 Logger logger(LOG_WINDOWS, "WindowsSplitTunnel");
+}
 
 WindowsSplitTunnel::WindowsSplitTunnel(QObject* parent) : QObject(parent) {
   if (!isInstalled()) {
@@ -73,10 +74,10 @@ void WindowsSplitTunnel::initDriver() {
 
   auto state = getState();
   if (state == STATE_UNKNOWN) {
-    logger.log() << "Cannot check if driver is initialised";
+    logger.log() << "Cannot check if driver is initialized";
   }
   if (state >= STATE_INITIALIZED) {
-    logger.log() << "Driver already initialised: " << state;
+    logger.log() << "Driver already initialized: " << state;
     return;
   }
   DWORD bytesReturned;

--- a/src/src.pro
+++ b/src/src.pro
@@ -757,6 +757,8 @@ else:win* {
         platforms/windows/daemon/windowsdaemontunnel.cpp \
         platforms/windows/daemon/windowstunnelservice.cpp \
         platforms/windows/daemon/wireguardutilswindows.cpp \
+        platforms/windows/daemon/windowsfirewall.cpp \
+        platforms/windows/daemon/windowssplittunnel.cpp \
         platforms/windows/windowsservicemanager.cpp \
         platforms/windows/daemon/windowssplittunnel.cpp \
         platforms/windows/windowscommons.cpp \
@@ -786,6 +788,7 @@ else:win* {
         platforms/windows/daemon/windowsdaemontunnel.h \
         platforms/windows/daemon/windowstunnelservice.h \
         platforms/windows/daemon/wireguardutilswindows.h \
+        platforms/windows/daemon/windowsfirewall.h \
         platforms/windows/daemon/windowssplittunnel.h \
         platforms/windows/windowsservicemanager.h \
         platforms/windows/windowscommons.h \


### PR DESCRIPTION
**Do not merge, this is currently based on the split tunnel PR**

This creates a set of rules in the WFP, to get a good killswitch. Not quite complete, i.e dnsv6/ dhcpv6 is missing.
Sets the following rules: 

- blockAllTrafffic(LOW_WEIGHT)
- allowTrafficOfAdapter(vpnAdapterIndex, MED_WEIGHT)
- allowDHCPTraffic(MED_WEIGHT))
- allowHyperVTraffic(MED_WEIGHT)
- allowTrafficForAppOnAll(MozillaVPN,MAX_WEIGHT)
- allowTrafficTo(DNS, HIGH_WEIGHT))

The split tunnel driver sets its own rules in this sublayer so they interact with eachother:
-> blockSplittedAppFromTUN(HIGH_WEIGHT)
-> allowSpplittetAppNonTUN(MAX_WEIGHT)

Marking this as wip, since i need to do a bit more testing if the rules currently work as they should. 
... maybe i should write a script that can test that 🤔 
