### PR TITLE
Fix unit tests after window focus changes

### DIFF
--- a/src/ui/main.qml
+++ b/src/ui/main.qml
@@ -95,7 +95,7 @@ Window {
         propagateComposedEvents: true
         z: 10
         onPressed: {
-            if (window.activeFocusItem.loseFocusOnOutsidePress) {
+            if (window.activeFocusItem && window.activeFocusItem.loseFocusOnOutsidePress) {
                 window.activeFocusItem.focus = false;
             }
             mouse.accepted = false;


### PR DESCRIPTION
We're getting a QML exception the unit tests due to the `window.activeFocusItem` potentially being null if the app looses focus. This was causing the functional tests to fail when the browser steals focus for the authentication flow.

This bug was introduced in b61249dcd256b6a4c676bd2ec2393efb142bd77e