### PR TITLE
Restyle textarea placeholder text and adjust visibility conditional

### DIFF
--- a/src/ui/components/forms/VPNTextArea.qml
+++ b/src/ui/components/forms/VPNTextArea.qml
@@ -5,6 +5,7 @@
 import QtQuick 2.0
 import QtQuick.Controls 2.14
 import QtQuick.Layouts 1.14
+import "../"
 import "../../themes/themes.js" as Theme
 
 Item {
@@ -40,25 +41,31 @@ Item {
             property bool loseFocusOnOutsidePress: true
 
             id: textArea
-
             textFormat: Text.PlainText
             font.pixelSize: Theme.fontSizeSmall
             font.family: Theme.fontInterFamily
             color: Theme.fontColor
             wrapMode: Text.WrapAtWordBoundaryOrAnywhere
-            textMargin: Theme.windowMargin
+            textMargin: Theme.windowMargin * .75
             padding: 0
             Keys.onTabPressed: nextItemInFocusChain().forceActiveFocus(Qt.TabFocusReason)
             onTextChanged: if (length > maxCharacterCount) remove(maxCharacterCount, length)
             selectByMouse: true
             selectionColor: Theme.input.highlight
 
-            Text {
+            VPNTextBlock {
                 id: formattedPlaceholderText
-                anchors.fill:parent
-                anchors.margins: Theme.windowMargin
+                anchors.fill: textArea
+                anchors.leftMargin: Theme.windowMargin
+                anchors.rightMargin: Theme.windowMargin
+                anchors.topMargin: Theme.windowMargin * .75
                 color:  Theme.fontColor
-                visible: !textArea.text && !textArea.focus
+                visible: textArea.text.length < 1
+                opacity: textArea.focus ? .7 : 1
+
+                PropertyAnimation on opacity {
+                    duration: 100
+                }
             }
         }
     }


### PR DESCRIPTION
VPNTextArea updates to address a few UX asks: 
- Restyles VPNTextArea placeholder text to match other text throughout the app
- Hides placeholder text only after the user starts typing, instead of immediately disappearing when the input receives focus. 

| Before | After |
:-------------------------:|:-------------------------:
<img width="200" src="https://user-images.githubusercontent.com/22355127/126008602-b76b1601-4286-47cc-b3a5-b7fa8392ebf9.png"> |  <img width="200" src="https://user-images.githubusercontent.com/22355127/126008499-0593c079-d75d-44a9-a190-c8a069b61803.png">
<img width="200" src="https://user-images.githubusercontent.com/22355127/126008598-3b29912b-5638-4d74-9ad8-4253ffe4977f.png"> | <img width="200" src="https://user-images.githubusercontent.com/22355127/126008511-d3d6692f-1c27-4768-8848-4e774c7c87fc.png">
