### PR TITLE
Speed up tests by mocking the devices API

### DIFF
--- a/.github/workflows/functional_tests.yaml
+++ b/.github/workflows/functional_tests.yaml
@@ -147,17 +147,11 @@ jobs:
           ACCOUNT_EMAIL: ${{ secrets.ACCOUNT_EMAIL }}
           ACCOUNT_PASSWORD: ${{ secrets.ACCOUNT_PASSWORD }}
 
-      - name: Uploading logs
+      - name: Uploading artifacts
         uses: actions/upload-artifact@v1
         if: ${{ always() && steps.runTests.outcome != 'success' }}
         with:
           name: ${{matrix.test.name}} Logs
-          path: /tmp/VPN_LOG.txt
-
-      - name: Uploading screenshots
-        uses: actions/upload-artifact@v1
-        # Not every Job has screenshots, skip if none are present
-        if: hashFiles('/tmp/screencapture') != ''
-        with:
-            name: Screen capture
-            path: /tmp/screencapture
+          path: |
+            /tmp/VPN_LOG.txt
+            /tmp/screencapture

--- a/.github/workflows/functional_tests.yaml
+++ b/.github/workflows/functional_tests.yaml
@@ -41,12 +41,6 @@ jobs:
     name: Build Test Client
     runs-on: ubuntu-20.04
     steps:
-      - name: Install Linux packages
-        run: |
-          # Add external PPA, latest version of QT is 5.12.x for Ubuntu 20.04
-          sudo add-apt-repository ppa:beineri/opt-qt-5.15.2-focal -y
-          sudo apt update
-          sudo apt install git qt515base qt515tools qt515svg qt515networkauth-no-lgpl qt515charts-no-lgpl libgl-dev libpolkit-gobject-1-dev qt515quickcontrols2 qt515imageformats qt515graphicaleffects  qt515websockets qt515declarative -y
       - name: Clone repository
         uses: actions/checkout@v2
 
@@ -57,38 +51,47 @@ jobs:
           git submodule sync --recursive
           git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
 
-      - name: Generating glean samples
-        shell: bash
+      - name: Cache build
+        id: cache-build
+        uses: actions/cache@v2
+        with:
+          path: build/
+          key: ${{ github.sha }}
+
+      - name: Install Linux packages
+        if: steps.cache-build.outputs.cache-hit != 'true'
         run: |
+          mkdir -p build/archive
+
+          # Add external PPA, latest version of QT is 5.12.x for Ubuntu 20.04
+          sudo add-apt-repository ppa:beineri/opt-qt-5.15.2-focal -y
+          sudo apt-get -o "Dir::Cache::archives=$(pwd)/build/archive" install -y \
+               git qt515base qt515tools qt515svg qt515networkauth-no-lgpl qt515charts-no-lgpl \
+               libgl-dev libpolkit-gobject-1-dev qt515quickcontrols2 qt515imageformats \
+               qt515graphicaleffects qt515websockets qt515declarative -y
+          sudo chown -R $USER:$USER build/archive
+
+      - name: Compile test client
+        shell: bash
+        if: steps.cache-build.outputs.cache-hit != 'true'
+        run: |
+          export PATH=/opt/qt515/bin:$PATH
+
           pip3 install glean_parser
           pip3 install pyhumps
           pip3 install pyyaml
-          python3 scripts/generate_glean.py
 
-      - name: Importing translation files
-        shell: bash
-        run: |
-          # Manually add QT executables to path
-          export PATH=/opt/qt515/bin:$PATH
           git submodule update --remote --depth 1 i18n
           python3 scripts/importLanguages.py
+          python3 scripts/generate_glean.py
 
-      - name: Compile
-        shell: bash
-        run: |
-          # Manually add QT executables to path
-          export PATH=/opt/qt515/bin:$PATH
           qmake CONFIG+=DUMMY QMAKE_CXX=clang++ QMAKE_LINK=clang++ CONFIG+=debug CONFIG+=inspector QT+=svg
           make -j8
-      - name: Check Content
-        run: |
-          ls -ial ./src/
-      - name: Save Build
-        uses: actions/cache@v2
-        with:
-          path: ./src/mozillavpn
-          key: ${{ github.sha }}
+          cp ./src/mozillavpn build/
 
+      - name: Check build
+        run: |
+          ls -ial build/
 
   functionaltests:
     name: Functional tests
@@ -102,63 +105,46 @@ jobs:
       matrix:
         test: ${{ fromJson(needs.test_list.outputs.matrix) }}
     steps:
-      - name: Install Linux packages
-        run: |
-          # Add external PPA, latest version of QT is 5.12.x for Ubuntu 20.04
-          sudo add-apt-repository ppa:beineri/opt-qt-5.15.2-focal -y
-          sudo apt update
-          sudo apt install git qt515base qt515tools qt515svg qt515networkauth-no-lgpl qt515charts-no-lgpl libgl-dev libpolkit-gobject-1-dev qt515quickcontrols2 qt515imageformats qt515graphicaleffects  qt515websockets qt515declarative jp2a -y
       - name: Clone repository
         uses: actions/checkout@v2
-      - name: Save Build
+      
+      - name: Cache build
+        id: cache-build
         uses: actions/cache@v2
-        id: cache
         with:
-          path: ./src/mozillavpn
+          path: build/
           key: ${{ github.sha }}
-      - name: Check Content
-        run: |
-          ls -ial ./src/
-      - name: Check Cache
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: |
-          echo "Build was not cached, exiting!"
-          exit -1
-      - name: Install xvfb
-        run: |
-          sudo apt install xvfb -y
-
-      - name: Install firefox
-        run: |
-          sudo apt install firefox -y
-
-      - name: Install geckodriver
-        run: |
-          sudo apt install wget -y
-          wget https://github.com/mozilla/geckodriver/releases/download/v0.26.0/geckodriver-v0.26.0-linux64.tar.gz -O geckodriver.tar.gz
-          tar xvf geckodriver.tar.gz
 
       - name: Install dependecies
         run: |
+          sudo dpkg -i build/archive/*.deb
+          sudo apt install --no-upgrade firefox xvfb -y
           pip3 install flask
           npm install dotenv
           npm install selenium-webdriver
           npm install mocha
           npm install websocket
+      
+      - name: Check build
+        shell: bash
+        run: ./build/mozillavpn -v
 
-      - name: Running ${{matrix.test.name}} tests
+      - name: Launching API proxy
+        shell: bash
+        run: ./tests/proxy/wsgi.py --mock-devices > /dev/null &
+
+      - name: Running ${{matrix.test.name}} Tests
         id: runTests
         run: |
-          export PATH=.:$(npm bin):$PATH
+          export PATH=$GECKOWEBDRIVER:$(npm bin):$PATH
           export HEADLESS=yes
-          export MVPN_API_BASE_URL=http://localhost:5000
-          ./tests/proxy/wsgi.py --mock-devices > /dev/null &
 
-          xvfb-run -a ./scripts/test_function.sh ./src/mozillavpn ${{matrix.test.path}}
+          xvfb-run -a ./scripts/test_function.sh ./build/mozillavpn ${{matrix.test.path}}
         env:
+          MVPN_API_BASE_URL: http://localhost:5000
           ACCOUNT_EMAIL: ${{ secrets.ACCOUNT_EMAIL }}
           ACCOUNT_PASSWORD: ${{ secrets.ACCOUNT_PASSWORD }}
-      
+
       - name: Uploading logs
         uses: actions/upload-artifact@v1
         if: ${{ always() && steps.runTests.outcome != 'success' }}
@@ -173,4 +159,3 @@ jobs:
         with:
             name: Screen capture
             path: /tmp/screencapture
-

--- a/.github/workflows/functional_tests.yaml
+++ b/.github/workflows/functional_tests.yaml
@@ -141,9 +141,11 @@ jobs:
           export PATH=$GECKOWEBDRIVER:$(npm bin):$PATH
           export HEADLESS=yes
 
+          mkdir -p $ARTIFACT_DIR
           xvfb-run -a ./scripts/test_function.sh ./build/mozillavpn ${{matrix.test.path}}
         env:
           MVPN_API_BASE_URL: http://localhost:5000
+          ARTIFACT_DIR: ${{ runner.temp }}/artifacts
           ACCOUNT_EMAIL: ${{ secrets.ACCOUNT_EMAIL }}
           ACCOUNT_PASSWORD: ${{ secrets.ACCOUNT_PASSWORD }}
 
@@ -152,6 +154,4 @@ jobs:
         if: ${{ always() && steps.runTests.outcome != 'success' }}
         with:
           name: ${{matrix.test.name}} Logs
-          path: |
-            /tmp/VPN_LOG.txt
-            /tmp/screencapture
+          path: ${{ runner.temp }}/artifacts

--- a/.github/workflows/functional_tests.yaml
+++ b/.github/workflows/functional_tests.yaml
@@ -85,8 +85,10 @@ jobs:
           python3 scripts/importLanguages.py
           python3 scripts/generate_glean.py
 
+          # Delete unit tests, so we can get to testing faster
+          sed -i '/tests\/unit/d' mozillavpn.pro
           qmake CONFIG+=DUMMY QMAKE_CXX=clang++ QMAKE_LINK=clang++ CONFIG+=debug CONFIG+=inspector QT+=svg
-          make -j8
+          make -j$(nproc)
           cp ./src/mozillavpn build/
 
       - name: Check build

--- a/.github/workflows/functional_tests.yaml
+++ b/.github/workflows/functional_tests.yaml
@@ -99,7 +99,6 @@ jobs:
     timeout-minutes: 60
     strategy:
       fail-fast: false # Don't cancel other jobs if a test fails
-      max-parallel: 1 #  To avoid max-device limit
       matrix:
         test: ${{ fromJson(needs.test_list.outputs.matrix) }}
     steps:
@@ -139,8 +138,9 @@ jobs:
           wget https://github.com/mozilla/geckodriver/releases/download/v0.26.0/geckodriver-v0.26.0-linux64.tar.gz -O geckodriver.tar.gz
           tar xvf geckodriver.tar.gz
 
-      - name: Install node dependecies
+      - name: Install dependecies
         run: |
+          pip3 install flask
           npm install dotenv
           npm install selenium-webdriver
           npm install mocha
@@ -151,6 +151,9 @@ jobs:
         run: |
           export PATH=.:$(npm bin):$PATH
           export HEADLESS=yes
+          export MVPN_API_BASE_URL=http://localhost:5000
+          ./tests/proxy/wsgi.py --mock-devices > /dev/null &
+
           xvfb-run -a ./scripts/test_function.sh ./src/mozillavpn ${{matrix.test.path}}
         env:
           ACCOUNT_EMAIL: ${{ secrets.ACCOUNT_EMAIL }}

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ xcode.xconfig
 *.ts
 tests/unit/tests
 tests/nativemessaging/tests
+tests/proxy/__pycache__/
 build
 Debug/
 !android/src/debug/

--- a/ios/utils/screenCaptureIOS.js
+++ b/ios/utils/screenCaptureIOS.js
@@ -8,8 +8,6 @@ const util = require('util');
 const vpn = require('./helper.js');
 const FirefoxHelper = require('./firefox.js');
 
-const dir = '/tmp/screencapture';
-
 describe('Take screenshots for each view', function() {
   let languages = [];
   let driver;
@@ -29,6 +27,10 @@ describe('Take screenshots for each view', function() {
 
       const data = await vpn.screenCapture();
       const buffer = Buffer.from(data, 'base64');
+      const dir = process.env.ARTIFACT_DIR + '/screencapture'
+      if (!fs.existsSync(dir)) {
+        fs.mkdirSync(dir);
+      }
       fs.writeFileSync(`${dir}/${name}_${language}.png`, buffer);
     }
   }

--- a/ios/utils/screenCaptureIOS.js
+++ b/ios/utils/screenCaptureIOS.js
@@ -8,6 +8,8 @@ const util = require('util');
 const vpn = require('./helper.js');
 const FirefoxHelper = require('./firefox.js');
 
+const dir = process.env.ARTIFACT_DIR + '/screencapture';
+
 describe('Take screenshots for each view', function() {
   let languages = [];
   let driver;
@@ -27,10 +29,6 @@ describe('Take screenshots for each view', function() {
 
       const data = await vpn.screenCapture();
       const buffer = Buffer.from(data, 'base64');
-      const dir = process.env.ARTIFACT_DIR + '/screencapture'
-      if (!fs.existsSync(dir)) {
-        fs.mkdirSync(dir);
-      }
       fs.writeFileSync(`${dir}/${name}_${language}.png`, buffer);
     }
   }

--- a/scripts/test_function.sh
+++ b/scripts/test_function.sh
@@ -28,8 +28,9 @@ runTest() {
   print G "done."
 
   print Y "Running the test: $2"
-  mocha -b $2 || ERROR=yes
+  mocha --bail $2 || ERROR=yes
 
+  kill $PID 2>/dev/null || true
   wait $PID
 
   if [ "$ERROR" = yes ]; then

--- a/scripts/test_function.sh
+++ b/scripts/test_function.sh
@@ -28,7 +28,7 @@ runTest() {
   print G "done."
 
   print Y "Running the test: $2"
-  mocha $2 || ERROR=yes
+  mocha -b $2 || ERROR=yes
 
   wait $PID
 

--- a/scripts/test_function.sh
+++ b/scripts/test_function.sh
@@ -14,12 +14,16 @@ print N ""
 
 ID=0
 
+if [ -z "$ARTIFACT_DIR" ]; then
+  export ARTIFACT_DIR=/tmp
+fi
+
 runTest() {
   ID=$((ID+1))
   export LLVM_PROFILE_FILE=/tmp/mozillavpn.llvm-$ID
 
   print Y "Running the app..."
-  "$1" &>/tmp/VPN_LOG.txt &
+  "$1" &> "$ARTIFACT_DIR/VPN_LOG.txt" &
   PID=$!
   print G "done."
 
@@ -30,7 +34,7 @@ runTest() {
 
   if [ "$ERROR" = yes ]; then
     echo "::group::Error Logs"
-    cat /tmp/VPN_LOG.txt
+    cat "$ARTIFACT_DIR/VPN_LOG.txt"
     echo "::endgroup::"
     print R "Nooo"
     exit 1

--- a/src/captiveportal/captiveportalrequest.cpp
+++ b/src/captiveportal/captiveportalrequest.cpp
@@ -37,9 +37,11 @@ void CaptivePortalRequest::run() {
 
   // We do not have IPs to check.
   if (ipv4Addresses.isEmpty() && ipv6Addresses.isEmpty()) {
-    onResult(NoPortal);
+    emit completed(NoPortal);
     return;
   }
+  m_running = 0;
+  m_success = 0;
 
   // We do not care which request succeeds.
   // Let's make 1 request for any available IP addresses. The first one will
@@ -88,13 +90,28 @@ void CaptivePortalRequest::createRequest(const QUrl& url) {
             logger.log() << "Captive portal detected. Content does not match.";
             onResult(PortalDetected);
           });
+
+  m_running++;
 }
 
 void CaptivePortalRequest::onResult(CaptivePortalResult portalDetected) {
-  if (m_completed) {
+  Q_ASSERT(m_running > 0);
+  m_running--;
+  if (portalDetected == NoPortal) {
+    m_success++;
+  }
+
+  // If any request detects a portal, we can terminate immediately.
+  if (portalDetected == PortalDetected) {
+    deleteLater();
+    emit completed(portalDetected);
     return;
   }
-  m_completed = true;
-  deleteLater();
-  emit completed(portalDetected);
+
+  // Otherwise, we are complete after all the workers have terminated.
+  if (m_running == 0) {
+    deleteLater();
+    emit completed((m_success > 0) ? NoPortal : Failure);
+    return;
+  }
 }

--- a/src/captiveportal/captiveportalrequest.h
+++ b/src/captiveportal/captiveportalrequest.h
@@ -29,7 +29,8 @@ class CaptivePortalRequest final : public QObject {
   void onResult(CaptivePortalResult portalDetected);
 
  private:
-  bool m_completed = false;
+  int m_running = 0;
+  int m_success = 0;
 };
 
 #endif  // CAPTIVEPORTALREQUEST_H

--- a/src/ipaddressrange.cpp
+++ b/src/ipaddressrange.cpp
@@ -13,6 +13,7 @@ IPAddressRange::IPAddressRange(const QString& ipAddress, uint32_t range,
 }
 
 IPAddressRange::IPAddressRange(const QString& prefix) {
+  MVPN_COUNT_CTOR(IPAddressRange);
   QStringList split = prefix.split('/');
   m_ipAddress = split[0];
   if (m_ipAddress.contains(':')) {
@@ -51,8 +52,7 @@ QList<IPAddressRange> IPAddressRange::fromIPAddressList(
     const QList<IPAddress>& list) {
   QList<IPAddressRange> result;
   for (const IPAddress& ip : list) {
-    result.append(
-        IPAddressRange(ip.address().toString(), ip.prefixLength(), IPv4));
+    result.append(IPAddressRange(ip.toString()));
   }
   return result;
 }

--- a/src/ipfinder.cpp
+++ b/src/ipfinder.cpp
@@ -36,7 +36,7 @@ IPFinder::~IPFinder() {
 void IPFinder::start() {
   logger.log() << "Starting the ip-lookup";
 
-  QUrl url(Constants::API_URL);
+  QUrl url(NetworkRequest::apiBaseUrl());
   m_lookupId = QHostInfo::lookupHost(url.host(), this,
                                      SLOT(dnsLookupCompleted(QHostInfo)));
 }

--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -12,6 +12,7 @@
 #include "models/device.h"
 #include "models/servercountrymodel.h"
 #include "models/user.h"
+#include "networkrequest.h"
 #include "qmlengineholder.h"
 #include "settingsholder.h"
 #include "tasks/accountandservers/taskaccountandservers.h"
@@ -388,23 +389,23 @@ void MozillaVPN::openLink(LinkType linkType) {
 
   switch (linkType) {
     case LinkAccount:
-      url = Constants::API_URL;
+      url = NetworkRequest::apiBaseUrl();
       url.append("/r/vpn/account");
       addEmailAddress = true;
       break;
 
     case LinkContact:
-      url = Constants::API_URL;
+      url = NetworkRequest::apiBaseUrl();
       url.append("/r/vpn/contact");
       break;
 
     case LinkFeedback:
-      url = Constants::API_URL;
+      url = NetworkRequest::apiBaseUrl();
       url.append("/r/vpn/client/feedback");
       break;
 
     case LinkHelpSupport:
-      url = Constants::API_URL;
+      url = NetworkRequest::apiBaseUrl();
       url.append("/r/vpn/support");
       break;
 
@@ -415,23 +416,23 @@ void MozillaVPN::openLink(LinkType linkType) {
       break;
 
     case LinkTermsOfService:
-      url = Constants::API_URL;
+      url = NetworkRequest::apiBaseUrl();
       url.append("/r/vpn/terms");
       break;
 
     case LinkPrivacyNotice:
-      url = Constants::API_URL;
+      url = NetworkRequest::apiBaseUrl();
       url.append("/r/vpn/privacy");
       break;
 
     case LinkUpdate:
-      url = Constants::API_URL;
+      url = NetworkRequest::apiBaseUrl();
       url.append("/r/vpn/update/");
       url.append(Constants::PLATFORM_NAME);
       break;
 
     case LinkSubscriptionBlocked:
-      url = Constants::API_URL;
+      url = NetworkRequest::apiBaseUrl();
       url.append("/r/vpn/subscriptionBlocked");
       break;
 

--- a/src/networkrequest.cpp
+++ b/src/networkrequest.cpp
@@ -17,6 +17,7 @@
 #include <QNetworkAccessManager>
 #include <QNetworkReply>
 #include <QNetworkRequest>
+#include <QProcessEnvironment>
 #include <QUrl>
 
 // Timeout for the network requests.
@@ -75,6 +76,17 @@ NetworkRequest::~NetworkRequest() {
 }
 
 // static
+QString NetworkRequest::apiBaseUrl() {
+#ifndef MVPN_PRODUCTION_MODE
+  QProcessEnvironment pe = QProcessEnvironment::systemEnvironment();
+  if (pe.contains("MVPN_API_BASE_URL")) {
+    return pe.value("MVPN_API_BASE_URL");
+  }
+#endif
+  return Constants::API_URL;
+}
+
+// static
 NetworkRequest* NetworkRequest::createForGetUrl(QObject* parent,
                                                 const QString& url,
                                                 int status) {
@@ -100,7 +112,7 @@ NetworkRequest* NetworkRequest::createForAuthenticationVerification(
   r->m_request.setHeader(QNetworkRequest::ContentTypeHeader,
                          "application/json");
 
-  QUrl url(Constants::API_URL);
+  QUrl url(apiBaseUrl());
   url.setPath("/api/v2/vpn/login/verify");
   r->m_request.setUrl(url);
 
@@ -125,7 +137,7 @@ NetworkRequest* NetworkRequest::createForDeviceCreation(
   r->m_request.setHeader(QNetworkRequest::ContentTypeHeader,
                          "application/json");
 
-  QUrl url(Constants::API_URL);
+  QUrl url(apiBaseUrl());
   url.setPath("/api/v1/vpn/device");
   r->m_request.setUrl(url);
 
@@ -147,7 +159,7 @@ NetworkRequest* NetworkRequest::createForDeviceRemoval(QObject* parent,
 
   NetworkRequest* r = new NetworkRequest(parent, 204, true);
 
-  QString url(Constants::API_URL);
+  QString url(apiBaseUrl());
   url.append("/api/v1/vpn/device/");
   url.append(QUrl::toPercentEncoding(pubKey));
 
@@ -167,7 +179,7 @@ NetworkRequest* NetworkRequest::createForServers(QObject* parent) {
 
   NetworkRequest* r = new NetworkRequest(parent, 200, true);
 
-  QUrl url(Constants::API_URL);
+  QUrl url(apiBaseUrl());
   url.setPath("/api/v1/vpn/servers");
   r->m_request.setUrl(url);
 
@@ -180,7 +192,7 @@ NetworkRequest* NetworkRequest::createForSurveyData(QObject* parent) {
 
   NetworkRequest* r = new NetworkRequest(parent, 200, true);
 
-  QUrl url(Constants::API_URL);
+  QUrl url(apiBaseUrl());
   url.setPath("/api/v1/vpn/surveys");
   r->m_request.setUrl(url);
 
@@ -193,7 +205,7 @@ NetworkRequest* NetworkRequest::createForVersions(QObject* parent) {
 
   NetworkRequest* r = new NetworkRequest(parent, 200, false);
 
-  QUrl url(Constants::API_URL);
+  QUrl url(apiBaseUrl());
   url.setPath("/api/v1/vpn/versions");
   r->m_request.setUrl(url);
 
@@ -206,7 +218,7 @@ NetworkRequest* NetworkRequest::createForAccount(QObject* parent) {
 
   NetworkRequest* r = new NetworkRequest(parent, 200, true);
 
-  QUrl url(Constants::API_URL);
+  QUrl url(apiBaseUrl());
   url.setPath("/api/v1/vpn/account");
   r->m_request.setUrl(url);
 
@@ -227,7 +239,7 @@ NetworkRequest* NetworkRequest::createForIpInfo(QObject* parent,
     r->m_request.setUrl(QUrl(QString(IPINFO_URL_IPV4).arg(address.toString())));
   }
 
-  QUrl url(Constants::API_URL);
+  QUrl url(apiBaseUrl());
   r->m_request.setRawHeader("Host", url.host().toLocal8Bit());
 
   r->getRequest();
@@ -257,7 +269,7 @@ NetworkRequest* NetworkRequest::createForCaptivePortalDetection(
 NetworkRequest* NetworkRequest::createForCaptivePortalLookup(QObject* parent) {
   NetworkRequest* r = new NetworkRequest(parent, 200, true);
 
-  QUrl url(Constants::API_URL);
+  QUrl url(apiBaseUrl());
   url.setPath("/api/v1/vpn/dns/detectportal");
   r->m_request.setUrl(url);
 
@@ -268,7 +280,7 @@ NetworkRequest* NetworkRequest::createForCaptivePortalLookup(QObject* parent) {
 NetworkRequest* NetworkRequest::createForHeartbeat(QObject* parent) {
   NetworkRequest* r = new NetworkRequest(parent, 200, false);
 
-  QUrl url(Constants::API_URL);
+  QUrl url(apiBaseUrl());
   url.setPath("/__heartbeat__");
   r->m_request.setUrl(url);
 
@@ -283,7 +295,7 @@ NetworkRequest* NetworkRequest::createForFeedback(QObject* parent,
                                                   const QString& category) {
   NetworkRequest* r = new NetworkRequest(parent, 201, true);
 
-  QUrl url(Constants::API_URL);
+  QUrl url(apiBaseUrl());
   url.setPath("/api/v1/vpn/feedback");
   r->m_request.setUrl(url);
 
@@ -311,7 +323,7 @@ NetworkRequest* NetworkRequest::createForIOSProducts(QObject* parent) {
 
   NetworkRequest* r = new NetworkRequest(parent, 200, true);
 
-  QUrl url(Constants::API_URL);
+  QUrl url(apiBaseUrl());
   url.setPath("/api/v2/vpn/products/ios");
   r->m_request.setUrl(url);
 
@@ -327,7 +339,7 @@ NetworkRequest* NetworkRequest::createForIOSPurchase(QObject* parent,
   r->m_request.setHeader(QNetworkRequest::ContentTypeHeader,
                          "application/json");
 
-  QUrl url(Constants::API_URL);
+  QUrl url(apiBaseUrl());
   url.setPath("/api/v1/vpn/purchases/ios");
   r->m_request.setUrl(url);
 

--- a/src/networkrequest.h
+++ b/src/networkrequest.h
@@ -75,6 +75,8 @@ class NetworkRequest final : public QObject {
 
   void abort();
 
+  static QString apiBaseUrl();
+
  private:
   NetworkRequest(QObject* parent, int status, bool setAuthorizationHeader);
 

--- a/src/platforms/android/androidutils.cpp
+++ b/src/platforms/android/androidutils.cpp
@@ -7,6 +7,7 @@
 #include "leakdetector.h"
 #include "logger.h"
 #include "mozillavpn.h"
+#include "networkrequest.h"
 #include "platforms/android/androidauthenticationlistener.h"
 #include "qmlengineholder.h"
 

--- a/src/platforms/android/androidutils.cpp
+++ b/src/platforms/android/androidutils.cpp
@@ -87,7 +87,7 @@ bool AndroidUtils::maybeCompleteAuthentication(const QString& url) {
 
   logger.log() << "AndroidWebView is about to load" << url;
 
-  QString apiUrl = Constants::API_URL;
+  QString apiUrl = NetworkRequest::apiBaseUrl();
   if (!url.startsWith(apiUrl)) {
     return false;
   }

--- a/src/platforms/dummy/dummycontroller.h
+++ b/src/platforms/dummy/dummycontroller.h
@@ -40,6 +40,8 @@ class DummyController final : public ControllerImpl {
  private:
   int64_t m_txBytes = 0;
   int64_t m_rxBytes = 0;
+  bool m_connected = false;
+  QTimer m_delayTimer;
 };
 
 #endif  // DUMMYCONTROLLER_H

--- a/src/platforms/linux/daemon/wireguardutilslinux.cpp
+++ b/src/platforms/linux/daemon/wireguardutilslinux.cpp
@@ -420,21 +420,21 @@ bool WireguardUtilsLinux::setAllowedIpsOnPeer(
     peer->last_allowedip = allowedip;
     allowedip->cidr = ip.range();
 
-    bool ok = false;
+    QString ipstring = ip.ipAddress();
     if (ip.type() == IPAddressRange::IPv4) {
       allowedip->family = AF_INET;
-      ok = inet_pton(AF_INET, ip.ipAddress().toLocal8Bit(), &allowedip->ip4) ==
-           1;
+      if (inet_pton(AF_INET, qPrintable(ipstring), &allowedip->ip4) != 1) {
+        logger.log() << "Invalid IPv4 address:" << ip.ipAddress();
+        return false;
+      }
     } else if (ip.type() == IPAddressRange::IPv6) {
       allowedip->family = AF_INET6;
-      ok = inet_pton(AF_INET6, ip.ipAddress().toLocal8Bit(), &allowedip->ip6) ==
-           1;
+      if (inet_pton(AF_INET6, qPrintable(ipstring), &allowedip->ip6) != 1) {
+        logger.log() << "Invalid IPv6 address:" << ip.ipAddress();
+        return false;
+      }
     } else {
       logger.log() << "Invalid IPAddressRange type";
-      return false;
-    }
-    if (!ok) {
-      logger.log() << "Invalid IP address:" << ip.ipAddress();
       return false;
     }
   }

--- a/src/platforms/wasm/wasmnetworkrequest.cpp
+++ b/src/platforms/wasm/wasmnetworkrequest.cpp
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "networkrequest.h"
+#include "constants.h"
 #include "leakdetector.h"
 #include "logger.h"
 #include "mozillavpn.h"
@@ -50,6 +51,9 @@ NetworkRequest::NetworkRequest(QObject* parent, int status,
 }
 
 NetworkRequest::~NetworkRequest() { MVPN_COUNT_DTOR(NetworkRequest); }
+
+// static
+QString NetworkRequest::apiBaseUrl() { return QString(Constants::API_URL); }
 
 // static
 NetworkRequest* NetworkRequest::createForAuthenticationVerification(

--- a/src/tasks/authenticate/taskauthenticate.cpp
+++ b/src/tasks/authenticate/taskauthenticate.cpp
@@ -105,7 +105,7 @@ void TaskAuthenticate::run(MozillaVPN* vpn) {
   path.append("linux");
 #endif
 
-  QUrl url(Constants::API_URL);
+  QUrl url(NetworkRequest::apiBaseUrl());
   url.setPath(path);
 
   QUrlQuery query;

--- a/src/ui/main.qml
+++ b/src/ui/main.qml
@@ -64,11 +64,18 @@ Window {
             minimumWidth = Theme.desktopAppWidth
         }
 
-        Glean.initialize('MozillaVPN', VPNSettings.gleanEnabled && VPN.productionMode, {
+        Glean.initialize('MozillaVPN', VPNSettings.gleanEnabled, {
           appBuild: `MozillaVPN/${VPN.versionString}`,
           appDisplayVersion: VPN.versionString,
           httpClient: {
                   post(url, body, headers) {
+                      if (typeof(VPNGleanTest) !== "undefined") {
+                          VPNGleanTest.requestDone(url, body);
+                      }
+                      if (!VPN.productionMode) {
+                          return Promise.reject('Glean disabled');
+                      }
+
                       return new Promise((resolve, reject) => {
                           const xhr = new XMLHttpRequest();
                           xhr.open("POST", url);
@@ -81,9 +88,6 @@ Window {
                           }
                           xhr.send(body);
 
-                          if (typeof(VPNGleanTest) !== "undefined") {
-                              VPNGleanTest.requestDone(url, body);
-                          }
                       });
                   }
           }
@@ -293,7 +297,7 @@ Window {
         }
 
         function onSendGleanPings() {
-            if (VPNSettings.gleanEnabled && VPN.productionMode) {
+            if (VPNSettings.gleanEnabled) {
                 Pings.main.submit();
             }
         }
@@ -305,7 +309,7 @@ Window {
         function onAboutToQuit() {
             // We are about to quit. Let's see if we are fast enough to send
             // the last chunck of data to the glean servers.
-            if (VPNSettings.gleanEnabled && VPN.productionMode) {
+            if (VPNSettings.gleanEnabled) {
               Pings.main.submit();
             }
         }

--- a/tests/functional/helper.js
+++ b/tests/functional/helper.js
@@ -330,11 +330,13 @@ module.exports = {
     if (this.currentTest.state === 'failed') {
       const data = await module.exports.screenCapture();
       const buffer = Buffer.from(data, 'base64');
-      const dir = process.env.ARTIFACT_DIR + '/screencapture'
+      const dir = process.env.ARTIFACT_DIR + '/screencapture';
+      const title = this.currentTest.title.toLowerCase();
+      const filename = title.replace(/[^a-z0-9]/g, '_');
       if (!fs.existsSync(dir)) {
         fs.mkdirSync(dir);
       }
-      fs.writeFileSync(`${dir}/failure.png`, buffer);
+      fs.writeFileSync(`${dir}/${filename}.png`, buffer);
     }
   },
 

--- a/tests/functional/helper.js
+++ b/tests/functional/helper.js
@@ -330,7 +330,7 @@ module.exports = {
     if (this.currentTest.state === 'failed') {
       const data = await module.exports.screenCapture();
       const buffer = Buffer.from(data, 'base64');
-      const dir = '/tmp/screencapture';
+      const dir = process.env.ARTIFACT_DIR + '/screencapture'
       if (!fs.existsSync(dir)) {
         fs.mkdirSync(dir);
       }

--- a/tests/functional/helper.js
+++ b/tests/functional/helper.js
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 const assert = require('assert');
+const fs = require('fs');
 const websocket = require('websocket').w3cwebsocket;
 const FirefoxHelper = require('./firefox.js');
 
@@ -329,13 +330,11 @@ module.exports = {
     if (this.currentTest.state === 'failed') {
       const data = await module.exports.screenCapture();
       const buffer = Buffer.from(data, 'base64');
-      require('fs').writeFileSync('/tmp/img.png', buffer);
-      const {exec} = require('child_process');
-      exec('TERM=xterm-256color jp2a /tmp/img.png', (error, stdout, stderr) => {
-        if (error) console.log(error);
-        console.log(stderr);
-        console.log(stdout);
-      });
+      const dir = '/tmp/screencapture';
+      if (!fs.existsSync(dir)) {
+        fs.mkdirSync(dir);
+      }
+      fs.writeFileSync(`${dir}/failure.png`, buffer);
     }
   },
 

--- a/tests/functional/screenCapture.js
+++ b/tests/functional/screenCapture.js
@@ -7,6 +7,8 @@ const fs = require('fs');
 const util = require('util');
 const vpn = require('./helper.js');
 
+const dir = process.env.ARTIFACT_DIR + '/screencapture';
+
 describe('Take screenshots for each view', function() {
   let languages = [];
   let servers;
@@ -16,10 +18,6 @@ describe('Take screenshots for each view', function() {
   async function singleScreenCapture(name, language) {
     const data = await vpn.screenCapture();
     const buffer = Buffer.from(data, 'base64');
-    const dir = process.env.ARTIFACT_DIR + '/screencapture'
-    if (!fs.existsSync(dir)) {
-      fs.mkdirSync(dir);
-    }
     fs.writeFileSync(`${dir}/${name}_${language}.png`, buffer);
   }
 

--- a/tests/functional/screenCapture.js
+++ b/tests/functional/screenCapture.js
@@ -7,8 +7,6 @@ const fs = require('fs');
 const util = require('util');
 const vpn = require('./helper.js');
 
-const dir = '/tmp/screencapture';
-
 describe('Take screenshots for each view', function() {
   let languages = [];
   let servers;
@@ -18,6 +16,10 @@ describe('Take screenshots for each view', function() {
   async function singleScreenCapture(name, language) {
     const data = await vpn.screenCapture();
     const buffer = Buffer.from(data, 'base64');
+    const dir = process.env.ARTIFACT_DIR + '/screencapture'
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir);
+    }
     fs.writeFileSync(`${dir}/${name}_${language}.png`, buffer);
   }
 

--- a/tests/functional/testAuthentication.js
+++ b/tests/functional/testAuthentication.js
@@ -9,7 +9,7 @@ const vpn = require('./helper.js');
 const exec = util.promisify(require('child_process').exec);
 
 describe('User authentication', function() {
-  this.timeout(500000);
+  this.timeout(60000);
 
   before(async () => {
     await vpn.connect();

--- a/tests/functional/testCaptivePortal.js
+++ b/tests/functional/testCaptivePortal.js
@@ -7,7 +7,7 @@ const util = require('util');
 const vpn = require('./helper.js');
 
 describe('Captive portal', function() {
-  this.timeout(500000);
+  this.timeout(300000);
 
   before(async () => {
     await vpn.connect();

--- a/tests/functional/testConnection.js
+++ b/tests/functional/testConnection.js
@@ -9,7 +9,7 @@ const vpn = require('./helper.js');
 const exec = util.promisify(require('child_process').exec);
 
 describe('Connectivity', function() {
-  this.timeout(500000);
+  this.timeout(300000);
 
   before(async () => {
     await vpn.connect();

--- a/tests/functional/testDevices.js
+++ b/tests/functional/testDevices.js
@@ -9,7 +9,7 @@ const vpn = require('./helper.js');
 const exec = util.promisify(require('child_process').exec);
 
 describe('Devices', function() {
-  this.timeout(500000);
+  this.timeout(300000);
 
   before(async () => {
     await vpn.connect();

--- a/tests/functional/testGlean.js
+++ b/tests/functional/testGlean.js
@@ -8,7 +8,7 @@ const util = require('util');
 const vpn = require('./helper.js');
 
 describe('Glean event logging', function() {
-  this.timeout(500000);
+  this.timeout(60000);
 
   before(async () => {
     await vpn.connect();

--- a/tests/functional/testHeartbeat.js
+++ b/tests/functional/testHeartbeat.js
@@ -19,7 +19,7 @@ describe('Backend failure', function() {
     await vpn.wait();
   }
 
-  this.timeout(1000000);
+  this.timeout(300000);
 
   before(async () => {
     await vpn.connect();

--- a/tests/functional/testOnboarding.js
+++ b/tests/functional/testOnboarding.js
@@ -7,7 +7,7 @@ const util = require('util');
 const vpn = require('./helper.js');
 
 describe('Initial view and onboarding', function() {
-  this.timeout(500000);
+  this.timeout(300000);
 
   before(async () => {
     await vpn.connect();

--- a/tests/functional/testServers.js
+++ b/tests/functional/testServers.js
@@ -9,8 +9,6 @@ const vpn = require('./helper.js');
 const webdriver = require('selenium-webdriver'), By = webdriver.By,
       Keys = webdriver.Key, until = webdriver.until;
 
-const exec = util.promisify(require('child_process').exec);
-
 describe('Server list', function() {
   let servers;
   let currentCountryCode;
@@ -199,9 +197,9 @@ describe('Server list', function() {
 
     assert(currentCountry != '');
 
-    assert(vpn.lastNotification().title === 'VPN Connected');
-    assert(
-        vpn.lastNotification().message ===
+    assert.strictEqual(vpn.lastNotification().title, 'VPN Connected');
+    assert.strictEqual(
+        vpn.lastNotification().message,
         `Connected to ${currentCountry}, ${currentCity}`);
 
     await vpn.clickOnElement('serverListButton');
@@ -251,8 +249,8 @@ describe('Server list', function() {
       return connectingMsg === 'Switching…';
     });
 
-    assert(
-        await vpn.getElementProperty('controllerSubTitle', 'text') ===
+    assert.strictEqual(
+        await vpn.getElementProperty('controllerSubTitle', 'text'),
         `From ${previousCity} to ${currentCity}`);
 
     await vpn.waitForCondition(async () => {
@@ -260,9 +258,9 @@ describe('Server list', function() {
           'VPN is on';
     });
 
-    assert(vpn.lastNotification().title === 'VPN Switched Servers');
-    assert(
-        vpn.lastNotification().message ===
+    assert.strictEqual(vpn.lastNotification().title, 'VPN Switched Servers');
+    assert.strictEqual(
+        vpn.lastNotification().message,
         `Switched from ${previousCountry}, ${previousCity} to ${
             currentCountry}, ${currentCity}`);
   });

--- a/tests/functional/testSettings.js
+++ b/tests/functional/testSettings.js
@@ -9,7 +9,7 @@ const vpn = require('./helper.js');
 const exec = util.promisify(require('child_process').exec);
 
 describe('Settings', function() {
-  this.timeout(2000000);
+  this.timeout(600000);
 
   before(async () => {
     await vpn.connect();

--- a/tests/functional/testTelemetryView.js
+++ b/tests/functional/testTelemetryView.js
@@ -7,7 +7,7 @@ const util = require('util');
 const vpn = require('./helper.js');
 
 describe('Telemetry view', function() {
-  this.timeout(500000);
+  this.timeout(60000);
 
   before(async () => {
     await vpn.connect();

--- a/tests/functional/testUnsecuredNetworkAlert.js
+++ b/tests/functional/testUnsecuredNetworkAlert.js
@@ -7,7 +7,7 @@ const util = require('util');
 const vpn = require('./helper.js');
 
 describe('Unsecured network alert', function() {
-  this.timeout(500000);
+  this.timeout(300000);
 
   before(async () => {
     await vpn.connect();

--- a/tests/proxy/wsgi.py
+++ b/tests/proxy/wsgi.py
@@ -8,12 +8,20 @@ import re
 import urllib.parse
 import json
 
+import logging
+log = logging.getLogger('werkzeug')
+log.disabled = True
+
 app = Flask(__name__)
+app.logger.disabled = True
 
 ## Proxy configuration
 upstream = 'https://stage-vpn.guardian.nonprod.cloudops.mozgcp.net'
+
+#----------------------------------------------------------
+# Request handling and forwarding
+#----------------------------------------------------------
 log_patterns = []
-mock_devices = False
 
 def log_headers(headers):
     for (key, value) in headers:

--- a/tests/proxy/wsgi.py
+++ b/tests/proxy/wsgi.py
@@ -1,12 +1,16 @@
 #!/usr/bin/env python3
 from flask import Flask
 from flask import request, redirect, Response
+import argparse
 import requests
+import re
+import urllib.parse
 import json
 
 app = Flask(__name__)
 
 upstream = 'https://stage-vpn.guardian.nonprod.cloudops.mozgcp.net'
+log_patterns = []
 
 def log_headers(headers):
     for (key, value) in headers:
@@ -18,10 +22,24 @@ def log_headers(headers):
         else:
             print(f"\t{key}: {value}")
 
-def forward_upstream(req, verbose=False):
+def log_match(path):
+    for prog in log_patterns:
+        if prog.match(path):
+            return True
+    return False
+
+def forward_upstream(req, desturl=None, verbose=None):
+    # Determine if we should make this verbose
+    if verbose is None:
+        verbose = log_match(req.path)
+
+    # Log the request
     print(f"REQUEST {req.method} -> {req.path}")
     if verbose:
         log_headers(req.headers)
+    if verbose and request.json:
+        print(f"REQUEST BODY -> {req.path}")
+        print('\t' + json.dumps(request.json, indent=3).replace('\n', '\n\t'))
 
     # Parse the request headers  
     exclude_upstream = [
@@ -34,16 +52,22 @@ def forward_upstream(req, verbose=False):
         else:
             upstream_headers[key] = value
 
+    # Determine the destination URL
+    if desturl is None:
+        desturl = upstream + req.path
+    else:
+        print(f"REQUEST TARGET -> {desturl}")
+
     # Forward the request to the staging service
     upstream_request = requests.request(
         method=req.method,
-        url=upstream + req.path,
+        url=desturl,
         headers={k: v for (k, v) in req.headers if k.lower() not in exclude_upstream},
         data=req.get_data(),
         cookies=req.cookies
     )
     print(f"RESPONSE {req.method} -> {req.path} -> {upstream_request.status_code}")
-    if verbose:
+    if log_match(req.path):
         log_headers(upstream_request.raw.headers.items())
 
     # Filter out certain response headers
@@ -60,28 +84,47 @@ def forward_upstream(req, verbose=False):
     return Response(upstream_request.content, upstream_request.status_code, downstream_headers)
 
 #----------------------------------------------------------
-# Proxy anything we aren't handling to the staging server
-#----------------------------------------------------------
-@app.errorhandler(404)
-def default_url_handler(e):
-    return forward_upstream(request)
-
-#----------------------------------------------------------
 # Redirect authentication to the staging server
 #----------------------------------------------------------
 @app.route('/api/v2/vpn/login/verify', methods=['POST'])
 def intercept_login():
-    return forward_upstream(request, verbose=True)
+    return forward_upstream(request)
 
 @app.route('/api/v2/vpn/login/<path:text>')
 def redirect_login(text):
     print(f"REDIRECT {request.method} -> {request.path}")
-    log_headers(request.headers)
+    if (log_match(request.path)):
+        log_headers(request.headers)
 
     url = f"{upstream}{request.path}"
     if request.query_string:
         url += f"?{request.query_string.decode('utf-8')}"
     return redirect(url)
 
+#----------------------------------------------------------
+# Workaround for /api/v1/device and URL escaping
+#----------------------------------------------------------
+@app.route('/api/v1/vpn/device/<path:pubkey>', methods=['DELETE'])
+def delete_device(pubkey):
+    # Flask insists on URL-decoding, so we must re-encode the public key.
+    destination=f"{upstream}/api/v1/vpn/device/{urllib.parse.quote(pubkey, safe='')}"
+    return forward_upstream(request, desturl=destination)
+
+#----------------------------------------------------------
+# Proxy anything we aren't handling to the staging server
+#----------------------------------------------------------
+default_methods=['GET', 'HEAD', 'POST', 'PUT', 'DELETE', 'OPTIONS']
+@app.route('/<path:path>', methods=default_methods)
+def default_handler(path):
+    return forward_upstream(request)
+
 if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Intercept and proxy VPN API requests')
+    parser.add_argument('--verbose', metavar='PATTERN', action='append', default=[],
+                        help='Enable verbose logging for paths matching PATTERN')
+
+    args = parser.parse_args()
+    for pattern in args.verbose:
+        log_patterns.append(re.compile(pattern))
+
     app.run()

--- a/tests/proxy/wsgi.py
+++ b/tests/proxy/wsgi.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+from flask import Flask
+from flask import request, redirect, Response
+import requests
+import json
+
+app = Flask(__name__)
+
+upstream = 'https://stage-vpn.guardian.nonprod.cloudops.mozgcp.net'
+
+def log_headers(headers):
+    for (key, value) in headers:
+        # If the value contains semicolons, split to multiple lines for readability
+        if value.find(";") >= 0:
+            print(f"\t{key}:")
+            for token in value.split(';'):
+                print(f"\t\t{token.strip()}")
+        else:
+            print(f"\t{key}: {value}")
+
+def forward_upstream(req, verbose=False):
+    print(f"REQUEST {req.method} -> {req.path}")
+    if verbose:
+        log_headers(req.headers)
+
+    # Parse the request headers  
+    exclude_upstream = [
+        'host'
+    ]
+    upstream_headers = {}
+    for (key, value) in req.headers:
+        if key == 'Host':
+            continue
+        else:
+            upstream_headers[key] = value
+
+    # Forward the request to the staging service
+    upstream_request = requests.request(
+        method=req.method,
+        url=upstream + req.path,
+        headers={k: v for (k, v) in req.headers if k.lower() not in exclude_upstream},
+        data=req.get_data(),
+        cookies=req.cookies
+    )
+    print(f"RESPONSE {req.method} -> {req.path} -> {upstream_request.status_code}")
+    if verbose:
+        log_headers(upstream_request.raw.headers.items())
+
+    # Filter out certain response headers
+    exclude_downstream = [
+        'content-encoding',
+        'content-length',
+        'transfer-encoding',
+        'connection'
+    ]
+    downstream_headers = [
+        (k,v) for (k,v) in upstream_request.raw.headers.items() if k.lower() not in exclude_downstream
+    ]
+
+    return Response(upstream_request.content, upstream_request.status_code, downstream_headers)
+
+#----------------------------------------------------------
+# Proxy anything we aren't handling to the staging server
+#----------------------------------------------------------
+@app.errorhandler(404)
+def default_url_handler(e):
+    return forward_upstream(request)
+
+#----------------------------------------------------------
+# Redirect authentication to the staging server
+#----------------------------------------------------------
+@app.route('/api/v2/vpn/login/verify', methods=['POST'])
+def intercept_login():
+    return forward_upstream(request, verbose=True)
+
+@app.route('/api/v2/vpn/login/<path:text>')
+def redirect_login(text):
+    print(f"REDIRECT {request.method} -> {request.path}")
+    log_headers(request.headers)
+
+    url = f"{upstream}{request.path}"
+    if request.query_string:
+        url += f"?{request.query_string.decode('utf-8')}"
+    return redirect(url)
+
+if __name__ == '__main__':
+    app.run()

--- a/tests/unit/mocnetworkrequest.cpp
+++ b/tests/unit/mocnetworkrequest.cpp
@@ -6,6 +6,7 @@
 #include "../../src/timersingleshot.h"
 #include "helper.h"
 #include "networkrequest.h"
+#include "constants.h"
 
 namespace {};
 
@@ -33,6 +34,9 @@ NetworkRequest::NetworkRequest(QObject* parent, int status,
 }
 
 NetworkRequest::~NetworkRequest() { MVPN_COUNT_DTOR(NetworkRequest); }
+
+// static
+QString NetworkRequest::apiBaseUrl() { return QString(Constants::API_URL); }
 
 // static
 NetworkRequest* NetworkRequest::createForGetUrl(QObject* parent, const QString&,


### PR DESCRIPTION
It would be nice if the tests would fail faster, so that we can get a better picture of when our code has broken things. To that end, I've written a Python/Flask API proxy that allows us to mock out the device list, and allows us to run all tests in parallel so long as they don't need to connect to a real VPN tunnel.

Plus a bunch of other speedups and improvements
- Skip building unit tests so that we can get to the functional tests quicker.
-  Cache .deb files downloaded by the build task so that we can skip the PPA.
- Trim dependencies used by the test runner jobs.
- Fail earlier by using `--bail` when starting `mocha`
- Bundle logs and screencaps together on failure.
- Simulate a connection delay in `DummyController` to avoid some races in tests that depend in hitting an intermediate `connecting` or `disconnecting` state

This also includes the bugs fixed by PR #1347 