### PR TITLE
Fix Functional Tests

### DIFF
--- a/src/captiveportal/captiveportalrequest.cpp
+++ b/src/captiveportal/captiveportalrequest.cpp
@@ -37,9 +37,11 @@ void CaptivePortalRequest::run() {
 
   // We do not have IPs to check.
   if (ipv4Addresses.isEmpty() && ipv6Addresses.isEmpty()) {
-    onResult(NoPortal);
+    emit completed(NoPortal);
     return;
   }
+  m_running = 0;
+  m_success = 0;
 
   // We do not care which request succeeds.
   // Let's make 1 request for any available IP addresses. The first one will
@@ -88,13 +90,28 @@ void CaptivePortalRequest::createRequest(const QUrl& url) {
             logger.log() << "Captive portal detected. Content does not match.";
             onResult(PortalDetected);
           });
+
+  m_running++;
 }
 
 void CaptivePortalRequest::onResult(CaptivePortalResult portalDetected) {
-  if (m_completed) {
+  Q_ASSERT(m_running > 0);
+  m_running--;
+  if (portalDetected == NoPortal) {
+    m_success++;
+  }
+
+  // If any request detects a portal, we can terminate immediately.
+  if (portalDetected == PortalDetected) {
+    deleteLater();
+    emit completed(portalDetected);
     return;
   }
-  m_completed = true;
-  deleteLater();
-  emit completed(portalDetected);
+
+  // Otherwise, we are complete after all the workers have terminated.
+  if (m_running == 0) {
+    deleteLater();
+    emit completed((m_success > 0) ? NoPortal : Failure);
+    return;
+  }
 }

--- a/src/captiveportal/captiveportalrequest.h
+++ b/src/captiveportal/captiveportalrequest.h
@@ -29,7 +29,8 @@ class CaptivePortalRequest final : public QObject {
   void onResult(CaptivePortalResult portalDetected);
 
  private:
-  bool m_completed = false;
+  int m_running = 0;
+  int m_success = 0;
 };
 
 #endif  // CAPTIVEPORTALREQUEST_H

--- a/src/ipaddressrange.cpp
+++ b/src/ipaddressrange.cpp
@@ -13,6 +13,7 @@ IPAddressRange::IPAddressRange(const QString& ipAddress, uint32_t range,
 }
 
 IPAddressRange::IPAddressRange(const QString& prefix) {
+  MVPN_COUNT_CTOR(IPAddressRange);
   QStringList split = prefix.split('/');
   m_ipAddress = split[0];
   if (m_ipAddress.contains(':')) {
@@ -51,8 +52,7 @@ QList<IPAddressRange> IPAddressRange::fromIPAddressList(
     const QList<IPAddress>& list) {
   QList<IPAddressRange> result;
   for (const IPAddress& ip : list) {
-    result.append(
-        IPAddressRange(ip.address().toString(), ip.prefixLength(), IPv4));
+    result.append(IPAddressRange(ip.toString()));
   }
   return result;
 }

--- a/src/platforms/linux/daemon/wireguardutilslinux.cpp
+++ b/src/platforms/linux/daemon/wireguardutilslinux.cpp
@@ -420,21 +420,21 @@ bool WireguardUtilsLinux::setAllowedIpsOnPeer(
     peer->last_allowedip = allowedip;
     allowedip->cidr = ip.range();
 
-    bool ok = false;
+    QString ipstring = ip.ipAddress();
     if (ip.type() == IPAddressRange::IPv4) {
       allowedip->family = AF_INET;
-      ok = inet_pton(AF_INET, ip.ipAddress().toLocal8Bit(), &allowedip->ip4) ==
-           1;
+      if (inet_pton(AF_INET, qPrintable(ipstring), &allowedip->ip4) != 1) {
+        logger.log() << "Invalid IPv4 address:" << ip.ipAddress();
+        return false;
+      }
     } else if (ip.type() == IPAddressRange::IPv6) {
       allowedip->family = AF_INET6;
-      ok = inet_pton(AF_INET6, ip.ipAddress().toLocal8Bit(), &allowedip->ip6) ==
-           1;
+      if (inet_pton(AF_INET6, qPrintable(ipstring), &allowedip->ip6) != 1) {
+        logger.log() << "Invalid IPv6 address:" << ip.ipAddress();
+        return false;
+      }
     } else {
       logger.log() << "Invalid IPAddressRange type";
-      return false;
-    }
-    if (!ok) {
-      logger.log() << "Invalid IP address:" << ip.ipAddress();
       return false;
     }
   }

--- a/src/ui/main.qml
+++ b/src/ui/main.qml
@@ -64,11 +64,18 @@ Window {
             minimumWidth = Theme.desktopAppWidth
         }
 
-        Glean.initialize('MozillaVPN', VPNSettings.gleanEnabled && VPN.productionMode, {
+        Glean.initialize('MozillaVPN', VPNSettings.gleanEnabled, {
           appBuild: `MozillaVPN/${VPN.versionString}`,
           appDisplayVersion: VPN.versionString,
           httpClient: {
                   post(url, body, headers) {
+                      if (typeof(VPNGleanTest) !== "undefined") {
+                          VPNGleanTest.requestDone(url, body);
+                      }
+                      if (!VPN.productionMode) {
+                          return Promise.reject('Glean disabled');
+                      }
+
                       return new Promise((resolve, reject) => {
                           const xhr = new XMLHttpRequest();
                           xhr.open("POST", url);
@@ -81,9 +88,6 @@ Window {
                           }
                           xhr.send(body);
 
-                          if (typeof(VPNGleanTest) !== "undefined") {
-                              VPNGleanTest.requestDone(url, body);
-                          }
                       });
                   }
           }
@@ -293,7 +297,7 @@ Window {
         }
 
         function onSendGleanPings() {
-            if (VPNSettings.gleanEnabled && VPN.productionMode) {
+            if (VPNSettings.gleanEnabled) {
                 Pings.main.submit();
             }
         }
@@ -305,7 +309,7 @@ Window {
         function onAboutToQuit() {
             // We are about to quit. Let's see if we are fast enough to send
             // the last chunck of data to the glean servers.
-            if (VPNSettings.gleanEnabled && VPN.productionMode) {
+            if (VPNSettings.gleanEnabled) {
               Pings.main.submit();
             }
         }


### PR DESCRIPTION
There were a collection of bugs that were breaking the functional tests, including:
- Glean tests broken due to change in ping submission (tests only).
- IPv6 captive portal detection breaks when IPv6 is unreachable.
- IPv6 excluded addresses were incorrectly parsed as IPv4 in `fromIPAddressList()`