### PR TITLE
Fix VPN Activation on Windows

### DIFF
--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -654,8 +654,11 @@ QList<IPAddressRange> Controller::getAllowedIPAddressRanges(
     excludeIPv4s.append(RFC1918::ipv4());
 
     if (ipv6Enabled) {
+      #ifndef MVPN_WINDOWS
+      // TODO: Does not seem to work on windows so far :(
       logger.log() << "Filtering out the local area networks (rfc 4193)";
       excludeIPv6s.append(RFC4193::ipv6());
+      #endif 
     }
   } else if (FeatureList::instance()->userDNSSupported() &&
              !SettingsHolder::instance()->useGatewayDNS() &&

--- a/src/platforms/windows/daemon/wireguardutilswindows.cpp
+++ b/src/platforms/windows/daemon/wireguardutilswindows.cpp
@@ -159,11 +159,12 @@ bool WireguardUtilsWindows::addRoutePrefix(const IPAddressRange& prefix) {
 
   // Install the route
   result = CreateIpForwardEntry2(&entry);
-  if (result != NO_ERROR) {
+  bool ok = result == NO_ERROR || result == ERROR_OBJECT_ALREADY_EXISTS;
+  if (!ok) {
     logger.log() << "Failed to create route to" << prefix.toString()
                  << "result:" << result;
   }
-  return result == NO_ERROR;
+  return ok;
 }
 
 void WireguardUtilsWindows::flushRoutes() {


### PR DESCRIPTION
Small fix for #1350
-> Also a bit better error handling, if the activation fails we need to disable the TunnelService. 
->Adding to RFC4193::ipv6() exclude list makes WireguardUtilsWindows::addRoutePrefix fail with "invalid parameter" :( 
No idea why so far, but that might be not essential to have in 2.4 i guess? 