### PR TITLE
Add billing to dependencies

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -50,6 +50,7 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar', '*.aar'])
     implementation 'androidx.core:core-ktx:1.1.0'
     implementation 'com.android.installreferrer:installreferrer:1.1'
+    implementation 'com.android.billingclient:billing:4.0.0'
     implementation "androidx.security:security-crypto:1.1.0-alpha03"
     implementation "androidx.security:security-identity-credential:1.0.0-alpha02"
     coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:1.0.10"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -50,7 +50,7 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar', '*.aar'])
     implementation 'androidx.core:core-ktx:1.1.0'
     implementation 'com.android.installreferrer:installreferrer:1.1'
-    implementation 'com.android.billingclient:billing:4.0.0'
+    implementation 'com.android.billingclient:billing-ktx:4.0.0'
     implementation "androidx.security:security-crypto:1.1.0-alpha03"
     implementation "androidx.security:security-identity-credential:1.0.0-alpha02"
     coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:1.0.10"


### PR DESCRIPTION
Getting set up on for google play is an interesting iterative process. According to the docs, per my reading, we need to upload a copy of the app to the google play store that contains the billing library before certain features are unlocked.

> To integrate Google Play's billing system, first add a dependency to the Google Play Billing Library in your app. This library provides access to Android APIs that connect you to Google Play. From there, you can access purchase information, query for updates about purchases, prompt a user to make new purchases, and more.
> Once you've added the library to your app, build and publish your app. For this step, create your app and then publish to any track, including the internal test track.
> After enabling Google Play Billing features for your app, you need to configure products to sell.

Source: https://developer.android.com/google/play/billing/getting-ready

Hopefully once this is setup we can setup a test subscription product that I can work with.
