### PR TITLE
Do not rely on the metrics table to choose right adapters for split-tunnel

### DIFF
--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -82,6 +82,8 @@ bool Daemon::activate(const InterfaceConfig& config) {
     return activate(config);
   }
 
+  prepareActivation(config);
+
   if (supportWGUtils()) {
     if (wgutils()->interfaceExists()) {
       qWarning("Wireguard interface `%s` already exists.", WG_INTERFACE);

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -34,6 +34,10 @@ class Daemon : public QObject {
   // Explose a JSON object with the daemon status.
   virtual QByteArray getStatus() = 0;
 
+  // Callback before any Activating measure is done
+  virtual void prepareActivation(const InterfaceConfig& config){
+      Q_UNUSED(config)};
+
   QString logs();
   void cleanLogs();
 

--- a/src/platforms/windows/daemon/windowsdaemon.cpp
+++ b/src/platforms/windows/daemon/windowsdaemon.cpp
@@ -39,6 +39,12 @@ WindowsDaemon::~WindowsDaemon() {
   MVPN_COUNT_DTOR(WindowsDaemon);
   logger.log() << "Daemon released";
 }
+void WindowsDaemon::prepareActivation(const InterfaceConfig& config) {
+  // Before Creating the interface we need to check which adapter
+  // routes to the Server endpoint
+  auto serveraddr = QHostAddress(config.m_serverIpv4AddrIn);
+  m_inetAdapterIndex = WindowsCommons::AdapterIndexTo(serveraddr);
+}
 
 bool WindowsDaemon::run(Op op, const InterfaceConfig& config) {
   bool splitTunnelEnabled = config.m_vpnDisabledApps.length() > 0;
@@ -56,7 +62,7 @@ bool WindowsDaemon::run(Op op, const InterfaceConfig& config) {
       logger.log() << "Split Tunnel Driver not Installed yet, fixing this.";
       WindowsSplitTunnel::installDriver();
     }
-    m_splitTunnelManager.start();
+    m_splitTunnelManager.start(m_inetAdapterIndex);
     m_splitTunnelManager.setRules(config.m_vpnDisabledApps);
   }
   WindowsFirewall::instance()->enableKillSwitch(

--- a/src/platforms/windows/daemon/windowsdaemon.cpp
+++ b/src/platforms/windows/daemon/windowsdaemon.cpp
@@ -59,8 +59,8 @@ bool WindowsDaemon::run(Op op, const InterfaceConfig& config) {
     m_splitTunnelManager.start();
     m_splitTunnelManager.setRules(config.m_vpnDisabledApps);
   }
-  auto vpnIndex = QNetworkInterface::allInterfaces().at(0).index();
-  WindowsFirewall::instance()->enableKillSwitch(vpnIndex, config);
+  WindowsFirewall::instance()->enableKillSwitch(
+      WindowsCommons::VPNAdapterIndex(), config);
   return true;
 }
 

--- a/src/platforms/windows/daemon/windowsdaemon.cpp
+++ b/src/platforms/windows/daemon/windowsdaemon.cpp
@@ -40,8 +40,8 @@ WindowsDaemon::~WindowsDaemon() {
   logger.log() << "Daemon released";
 }
 void WindowsDaemon::prepareActivation(const InterfaceConfig& config) {
-  // Before Creating the interface we need to check which adapter
-  // routes to the Server endpoint
+  // Before creating the interface we need to check which adapter
+  // routes to the server endpoint
   auto serveraddr = QHostAddress(config.m_serverIpv4AddrIn);
   m_inetAdapterIndex = WindowsCommons::AdapterIndexTo(serveraddr);
 }

--- a/src/platforms/windows/daemon/windowsdaemon.h
+++ b/src/platforms/windows/daemon/windowsdaemon.h
@@ -20,6 +20,7 @@ class WindowsDaemon final : public Daemon {
   ~WindowsDaemon();
 
   QByteArray getStatus() override;
+  void prepareActivation(const InterfaceConfig& config) override;
 
  protected:
   bool supportWGUtils() const override { return true; }
@@ -40,6 +41,7 @@ class WindowsDaemon final : public Daemon {
   };
 
   State m_state = Inactive;
+  int m_inetAdapterIndex = -1;
 
   WireguardUtilsWindows* m_wgutils = nullptr;
   WindowsSplitTunnel m_splitTunnelManager;

--- a/src/platforms/windows/daemon/windowssplittunnel.h
+++ b/src/platforms/windows/daemon/windowssplittunnel.h
@@ -132,7 +132,7 @@ class WindowsSplitTunnel final : public QObject {
   void setRules(const QStringList& appPaths);
 
   // Fetches and Pushed needed info to move to engaged mode
-  void start();
+  void start(int inetAdapterIndex);
   // Deletes Rules and puts the driver into passive mode
   void stop();
   // Resets the Whole Driver
@@ -150,7 +150,6 @@ class WindowsSplitTunnel final : public QObject {
   void initDriver();
 
  private:
-  int m_InternetAdapterIndex = -1;
   HANDLE m_driver = INVALID_HANDLE_VALUE;
   constexpr static const auto DRIVER_SYMLINK = L"\\\\.\\MULLVADSPLITTUNNEL";
   constexpr static const auto DRIVER_FILENAME = "mullvad-split-tunnel.sys";
@@ -163,7 +162,7 @@ class WindowsSplitTunnel final : public QObject {
   // Generates a Configuration for Each APP
   std::vector<uint8_t> generateAppConfiguration(const QStringList& appPaths);
   // Generates a Configuration which IP's are VPN and which network
-  std::vector<uint8_t> generateIPConfiguration();
+  std::vector<uint8_t> generateIPConfiguration(int inetAdapterIndex);
   std::vector<uint8_t> generateProcessBlob();
 
   void getAddress(int adapterIndex, IN_ADDR* out_ipv4, IN6_ADDR* out_ipv6);

--- a/src/platforms/windows/daemon/windowssplittunnel.h
+++ b/src/platforms/windows/daemon/windowssplittunnel.h
@@ -150,6 +150,7 @@ class WindowsSplitTunnel final : public QObject {
   void initDriver();
 
  private:
+  int m_InternetAdapterIndex = -1;
   HANDLE m_driver = INVALID_HANDLE_VALUE;
   constexpr static const auto DRIVER_SYMLINK = L"\\\\.\\MULLVADSPLITTUNNEL";
   constexpr static const auto DRIVER_FILENAME = "mullvad-split-tunnel.sys";

--- a/src/platforms/windows/windowscommons.cpp
+++ b/src/platforms/windows/windowscommons.cpp
@@ -105,8 +105,9 @@ QString WindowsCommons::tunnelLogFile() {
 }
 
 // static
-int WindowsCommons::CurrentGatewayIndex() {
-  QHostAddress dst("1.1.1.1");
+int WindowsCommons::AdapterIndexTo(const QHostAddress& dst) {
+  logger.log() << "Getting Current Internet Adapter that routes to"
+               << dst.toString();
   quint32_be ipBigEndian;
   quint32 ip = dst.toIPv4Address();
   qToBigEndian(ip, &ipBigEndian);
@@ -115,7 +116,6 @@ int WindowsCommons::CurrentGatewayIndex() {
   if (result != NO_ERROR) {
     return -1;
   }
-  logger.log() << "Getting Current Internet Adapter";
   auto adapter =
       QNetworkInterface::interfaceFromIndex(routeInfo.dwForwardIfIndex);
   logger.log() << "Internet Adapter:" << adapter.name();

--- a/src/platforms/windows/windowscommons.cpp
+++ b/src/platforms/windows/windowscommons.cpp
@@ -6,9 +6,13 @@
 #include "logger.h"
 
 #include <QDir>
+#include <QtEndian>
+#include <QHostAddress>
 #include <QStandardPaths>
+#include <QNetworkInterface>
 
 #include <Windows.h>
+#include <iphlpapi.h>
 
 #define TUNNEL_SERVICE_NAME L"WireGuardTunnel$mozvpn"
 
@@ -98,4 +102,34 @@ QString WindowsCommons::tunnelLogFile() {
   }
 
   return QString();
+}
+
+// static
+int WindowsCommons::CurrentGatewayIndex() {
+  QHostAddress dst("1.1.1.1");
+  quint32_be ipBigEndian;
+  quint32 ip = dst.toIPv4Address();
+  qToBigEndian(ip, &ipBigEndian);
+  _MIB_IPFORWARDROW routeInfo;
+  auto result = GetBestRoute(ipBigEndian, 0, &routeInfo);
+  if (result != NO_ERROR) {
+    return -1;
+  }
+  logger.log() << "Getting Current Internet Adapter";
+  auto adapter =
+      QNetworkInterface::interfaceFromIndex(routeInfo.dwForwardIfIndex);
+  logger.log() << "Internet Adapter:" << adapter.name();
+  return routeInfo.dwForwardIfIndex;
+}
+
+// static
+int WindowsCommons::VPNAdapterIndex() {
+  // For someReason QNetworkInterface::fromName(MozillaVPN) does not work >:(
+  auto adapterList = QNetworkInterface::allInterfaces();
+  for (const auto& adapter : adapterList) {
+    if (adapter.humanReadableName().contains("MozillaVPN")) {
+      return adapter.index();
+    }
+  }
+  return -1;
 }

--- a/src/platforms/windows/windowscommons.h
+++ b/src/platforms/windows/windowscommons.h
@@ -7,6 +7,7 @@
 
 #include <QString>
 #include <Windows.h>
+class QHostAddress;
 
 class WindowsCommons final {
  public:
@@ -19,8 +20,8 @@ class WindowsCommons final {
 
   // Returns the Interface Index of the VPN Adapter
   static int VPNAdapterIndex();
-  // Returns the Interface Index that could Route to 1.1.1.1
-  static int CurrentGatewayIndex();
+  // Returns the Interface Index that could Route to dst
+  static int AdapterIndexTo(const QHostAddress& dst);
 };
 
 #endif  // WINDOWSCOMMONS_H

--- a/src/platforms/windows/windowscommons.h
+++ b/src/platforms/windows/windowscommons.h
@@ -16,6 +16,11 @@ class WindowsCommons final {
 
   static QString tunnelConfigFile();
   static QString tunnelLogFile();
+
+  // Returns the Interface Index of the VPN Adapter
+  static int VPNAdapterIndex();
+  // Returns the Interface Index that could Route to 1.1.1.1
+  static int CurrentGatewayIndex();
 };
 
 #endif  // WINDOWSCOMMONS_H


### PR DESCRIPTION
As afraid, checking the metrics table does not really work except for clean vm's >:c 

I.e NordVPN put's itself into the first spot even when disabled. 

So he's what i want to do instead: 
When the deamon starts before the vpn starts, check what adapter can route to 1.1.1.1, and use that as the "Internet" Adapter.  
For the vpn adapter check the name :) 