### PR TITLE
Enable calling abortAuthentication multiple times

### DIFF
--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -374,7 +374,10 @@ void MozillaVPN::authenticate() {
 }
 
 void MozillaVPN::abortAuthentication() {
-  logger.log() << "Abort authentication";
+  if(m_state == StateInitialize){
+    return;
+  }
+  logger.log() << "Abort authentication from:" << m_state;
   Q_ASSERT(m_state == StateAuthenticating);
   setState(StateInitialize);
 
@@ -844,7 +847,7 @@ void MozillaVPN::errorHandle(ErrorHandler::ErrorType error) {
     } else {
       emit triggerGleanSample(GleanSample::authenticationFailure);
     }
-    setState(StateInitialize);
+    abortAuthentication();
     return;
   }
 


### PR DESCRIPTION
Currently move away from the authenticating state when we abort but also when we encounter an error
so we might abort Authentication when already back into StateInitialize because also an error occured

Fixes #938 

﻿
