### PR TITLE
Fix app permissions for Flatpak applications

### DIFF
--- a/src/platforms/linux/linuxapplistprovider.cpp
+++ b/src/platforms/linux/linuxapplistprovider.cpp
@@ -48,7 +48,7 @@ void LinuxAppListProvider::fetchEntries(const QString& dataDir,
       continue;
     }
 
-    map[fileinfo.canonicalFilePath()] = entry.value("Name").toString();
+    map[fileinfo.absoluteFilePath()] = entry.value("Name").toString();
   }
 }
 


### PR DESCRIPTION
There is a bug in how applications are found vs. how they are tracked by the daemon that manifests when the `.desktop` file is a symlink to somewhere else on the system. The VPN client uses `QFileInfo::canonicalFilePath()` which collapses and `..` path elements and resolves symlinks, but the daemon gets launch notifications with the absolute file path (eg: symlinks are not resolved). Because we use the filename to match PIDs to an application group, this causes the split tunnelling to fail.

To resolve it, we use the absolute file path instead of the canonical file path when building the application list.