### PR TITLE
Fix assert in BigInt() copy constructor

### DIFF
--- a/src/bigint.h
+++ b/src/bigint.h
@@ -18,7 +18,7 @@ class BigInt final {
     memset(m_value.data(), 0, bytes);
   }
 
-  BigInt(const BigInt& other) { *this = other; }
+  BigInt(const BigInt& other) { m_value = other.m_value; }
 
   const uint8_t* value() const { return m_value.data(); }
 
@@ -27,23 +27,14 @@ class BigInt final {
   // Assign operator.
 
   BigInt& operator=(const BigInt& other) {
-    Q_ASSERT(other.size() == size());
-    memcpy(m_value.data(), other.m_value.data(), size());
+    m_value = other.m_value;
     return *this;
   }
 
   // Comparison operators.
 
   bool operator==(const BigInt& other) const {
-    Q_ASSERT(size() == other.size());
-
-    for (int i = 0; i < size(); ++i) {
-      if (m_value[i] != other.m_value[i]) {
-        return false;
-      }
-    }
-
-    return true;
+    return m_value == other.m_value;
   }
 
   bool operator!=(const BigInt& other) const { return !(*this == other); }


### PR DESCRIPTION
When building the VPN client on MS Visual Studio with debug, we encounter an assert in the `BigInt` copy constructor, which is invoking `operator=()` and then fails because `*this` was default-constructed with a length of zero. This would also suggest a memory corruption bug in release builds if the length is actually zero and the assert gets skipped.