### PR TITLE
CI: Generate Signed Android apks

### DIFF
--- a/.github/workflows/android.yaml
+++ b/.github/workflows/android.yaml
@@ -14,8 +14,8 @@ jobs:
     strategy:
       matrix:
         config:
-            - { name: Release, args: --prod, apk: .tmp/src/android-build/build/outputs/apk/release/, sym: true  }
-            - { name: Debug, args: --debug, apk: .tmp/src/android-build/mozillavpn.apk, sym: false}
+            - { name: Release, args: --prod, apk: .tmp/src/android-build/build/outputs/apk/release/, sym: true, sign: true  }
+            - { name: Debug, args: --debug, apk: .tmp/src/android-build/mozillavpn.apk, sym: false, sign: false}
 
     runs-on: ubuntu-20.04
       
@@ -60,6 +60,13 @@ jobs:
         run: |
           export ANDROID_NDK_ROOT=${{ steps.setup-ndk.outputs.ndk-path }}
           bash ./scripts/android_package.sh /home/runner/work/mozilla-vpn-client/Qt/5.15.2 ${{ matrix.config.args }}
+      - name: Sign Android
+        if: ${{ matrix.config.sign }} 
+        env:
+          AUTOGRAPH_TOKEN: ${{ secrets.AUTOGRAPH_KEY }}
+        run: |
+          bash ./scripts/android_sign.sh ${{ matrix.config.apk }}
+          rm ${{ matrix.config.apk }}/*unsigned.apk
 
       - name: Upload APK${{ matrix.config.args }}
         uses: actions/upload-artifact@v1

--- a/scripts/android_sign.sh
+++ b/scripts/android_sign.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+. $(dirname $0)/commons.sh
+
+if [ -f .env ]; then
+  . .env
+fi
+
+export AUTOGRAPH_URL=https://edge.prod.autograph.services.mozaws.net/sign
+
+helpFunction() {
+  print G "Usage:"
+  print N "\t$0 <path to *.apk>"
+  print N ""
+  print N ""
+  exit 0
+}
+
+if [ -z "$1" ]
+then
+      helpFunction
+      die "No File Path Provided :c"
+fi
+
+
+
+if [ -z "$AUTOGRAPH_TOKEN" ]
+then
+      print N "Could not find 'AUTOGRAPH_TOKEN'"
+      die "Export it or put it into .env"
+fi
+
+cd $1
+
+for i in *.apk; do
+  UNSIGNED_BUILD=$i
+  SIGNED_BUILD=$(echo $i | sed -e 's/unsigned/signed/')
+  print N "Signing $i"
+  curl -H "Authorization: $AUTOGRAPH_TOKEN" -F "input=@$UNSIGNED_BUILD" -o $SIGNED_BUILD $AUTOGRAPH_URL
+done
+
+print G "All Done ! :)"


### PR DESCRIPTION
This expects a GH Secret set:
AUTOGRAPH_KEY


Test Result: 
https://github.com/strseb/mozilla-vpn-client/actions/runs/1071509877

┆Issue is synchronized with this [Jiraserver Bug](https://mozilla-hub.atlassian.net/browse/VPN-813)
