### PR TITLE
Fix crash in generic ping sender on Ubuntu/Bionic

### DIFF
--- a/src/pingsender.cpp
+++ b/src/pingsender.cpp
@@ -50,10 +50,11 @@ void PingSender::genericSendPing(const QStringList& args, qint16 sequence) {
   process->start("ping", args, QIODevice::ReadOnly);
 
   connect(process, qOverload<int, QProcess::ExitStatus>(&QProcess::finished),
-          this, [this, process, sequence](int exitCode, QProcess::ExitStatus) {
+          this, [this, sequence](int exitCode, QProcess::ExitStatus) {
             if (exitCode == 0) emit recvPing(sequence);
-            process->deleteLater();
           });
+  connect(process, qOverload<int, QProcess::ExitStatus>(&QProcess::finished),
+          process, &QObject::deleteLater);
 
   // Ensure any lingering pings are cleaned up when the PingSender is destroyed
   connect(this, &QObject::destroyed, process, [process] {


### PR DESCRIPTION
I don't have a good explanation for why the generic ping sender was crashing on Bionic builds, but it seems to have something to do with the parameter capture in the lambda expression. Making a separate connection just for the garbage collection of the ping process seems to make the crash go away.

┆Issue is synchronized with this [Jiraserver Bug](https://mozilla-hub.atlassian.net/browse/VPN-814)
