### PR TITLE
Use ccache if installed for speedups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ android/*/.cxx/
 !android/*/*/Makefile 
 xcode.xconfig
 .gradle/
+.gradle_cache/
 
 *.ts
 tests/unit/tests

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -26,3 +26,4 @@ androidBuildToolsVersion=30.0.2
 androidCompileSdkVersion=30
 buildDir=build
 org.gradle.caching=true
+org.gradle.parallel=true

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,0 +1,7 @@
+buildCache {
+    local {
+        // mozilla-vpn-client/.gradle_cache
+        directory = new File(rootDir.getParentFile().getParentFile().getParentFile(),'.gradle_cache')
+        removeUnusedEntriesAfterDays = 30
+    }
+}

--- a/android/tunnel/CMakeLists.txt
+++ b/android/tunnel/CMakeLists.txt
@@ -8,6 +8,12 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}")
 set( CMAKE_WG_TOOLS_DIR ../../../../3rdparty/wireguard-tools )
 
 
+find_program(CCACHE_FOUND ccache)
+if(CCACHE_FOUND)
+        set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
+        set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
+endif(CCACHE_FOUND)
+
 # Work around https://github.com/android-ndk/ndk/issues/602
 set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fuse-ld=gold")
 

--- a/src/src.pro
+++ b/src/src.pro
@@ -10,6 +10,15 @@ DEFINES += BUILD_ID=\\\"$$BUILD_ID\\\"
     DEFINES += MVPN_EXTRA_USERAGENT=\\\"$$MVPN_EXTRA_USERAGENT\\\"
 }
 
+CCACHE_BIN = $$system(which ccache)
+!isEmpty(CCACHE_BIN) {
+    message(Using ccache)
+    load(ccache)
+    QMAKE_CXXFLAGS +=-g -fdebug-prefix-map=$(shell pwd)=.
+
+
+}
+
 QT += network
 QT += quick
 QT += widgets


### PR DESCRIPTION
Currently as we can only do full compiles for android ... it's a bit slow. 
Let's use ccache, if that is installed on a machine to speed things up. 
Also let's move the .gradle cache to a folder outside of .tmp so it is actually usefull :)

On my old mbp which i'm able to get up to 2x speedup, which is nice :)

┆Issue is synchronized with this [Jiraserver Bug](https://mozilla-hub.atlassian.net/browse/VPN-816)
