### PR TITLE
Fixed go link errors.

### DIFF
--- a/src/src.pro
+++ b/src/src.pro
@@ -359,6 +359,8 @@ else:linux:!android {
     QT += networkauth
     QT += dbus
 
+    LIBS += -lgo
+
     CONFIG += c++14
 
     DEFINES += MVPN_LINUX


### PR DESCRIPTION
When linking against netfilter.a the linker would emit errors because it can't find Go's runtime object code. Linking with `-lgo` fixes theses errors.