### PR TITLE
Fixed Go link errors on Linux build.

### DIFF
--- a/src/src.pro
+++ b/src/src.pro
@@ -359,6 +359,10 @@ else:linux:!android {
     QT += networkauth
     QT += dbus
 
+    system(c++ -lgo 2>&1 | grep "__go_init_main" > /dev/null) {
+        LIBS += -lgo
+    }
+
     CONFIG += c++14
 
     DEFINES += MVPN_LINUX


### PR DESCRIPTION
Some Linux distros choose to configure Go differently to how it's assumed to be in the build scripts. When linking against netfilter  on the latest version of Fedora the linker would emit errors because it can't find Go's runtime object code. Linking with `-lgo` resolves these errors.