### PR TITLE
Add the Adjust SDK to Android

### DIFF
--- a/.github/workflows/android.yaml
+++ b/.github/workflows/android.yaml
@@ -57,6 +57,8 @@ jobs:
           pip3 install pyyaml
 
       - name: Compilation
+        env:
+          ADJUST_SDK_TOKEN: ${{ secrets.ADJUST_SDK_TOKEN }}
         run: |
           export ANDROID_NDK_ROOT=${{ steps.setup-ndk.outputs.ndk-path }}
           bash ./scripts/android_package.sh /home/runner/work/mozilla-vpn-client/Qt/5.15.2 ${{ matrix.config.args }}

--- a/README.md
+++ b/README.md
@@ -274,6 +274,8 @@ You may be interested in flags like -i for the inspector (see ./scripts/apple_co
   $ adb install .tmp/src/android-build//build/outputs/apk/debug/android-build-debug.apk
 ```
 
+9. To build the apk for release the environment variable ADJUST_SDK_TOKEN is required. It must be set to the app token of the Adjust SDK dashboard. 
+
 ### Windows
 
 We use a statically-compiled QT5.15 version to deploy the app. There are many

--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -21,7 +21,7 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
     <application
         android:hardwareAccelerated="true"
         android:allowBackup="false"
-        android:name="org.qtproject.qt5.android.bindings.QtApplication"
+        android:name="org.mozilla.firefox.vpn.qt.VPNApplication"
         android:label="Mozilla VPN"
         android:extractNativeLibs="true"
         android:theme="@style/AppTheme"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -49,10 +49,12 @@ apply plugin: 'kotlin-android-extensions'
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar', '*.aar'])
     implementation 'androidx.core:core-ktx:1.1.0'
-    implementation 'com.android.installreferrer:installreferrer:1.1'
+    implementation 'com.android.installreferrer:installreferrer:2.2'
     implementation 'com.android.billingclient:billing-ktx:4.0.0'
     implementation "androidx.security:security-crypto:1.1.0-alpha03"
     implementation "androidx.security:security-identity-credential:1.0.0-alpha02"
+    implementation 'com.adjust.sdk:adjust-android:4.28.2'
+    implementation 'com.google.android.gms:play-services-ads-identifier:17.0.1'
     coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:1.0.10"
 }
 
@@ -144,6 +146,7 @@ android {
         targetSdkVersion 30
         versionCode  System.getenv("VERSIONCODE").toInteger()
         versionName  System.getenv("SHORTVERSION")
+        buildConfigField "String", "ADJUST_SDK_TOKEN", '"' + System.getenv("ADJUST_SDK_TOKEN") + '"'
     }
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/android/src/org/mozilla/firefox/vpn/qt/VPNAdjustHelper.java
+++ b/android/src/org/mozilla/firefox/vpn/qt/VPNAdjustHelper.java
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.firefox.vpn.qt;
+
+import com.adjust.sdk.Adjust;
+import com.adjust.sdk.AdjustEvent;
+
+import org.mozilla.firefox.vpn.BuildConfig;
+
+public class VPNAdjustHelper
+{
+    public VPNAdjustHelper() {}
+
+    public static void trackEvent(String event) {
+      if(BuildConfig.ADJUST_SDK_TOKEN != null && !BuildConfig.ADJUST_SDK_TOKEN.isEmpty()) {
+        AdjustEvent adjustEvent = new AdjustEvent(event);
+        Adjust.trackEvent(adjustEvent);
+      }
+    }
+}
+

--- a/android/src/org/mozilla/firefox/vpn/qt/VPNAdjustHelper.java
+++ b/android/src/org/mozilla/firefox/vpn/qt/VPNAdjustHelper.java
@@ -9,15 +9,14 @@ import com.adjust.sdk.AdjustEvent;
 
 import org.mozilla.firefox.vpn.BuildConfig;
 
-public class VPNAdjustHelper
-{
-    public VPNAdjustHelper() {}
+public class VPNAdjustHelper {
+  
+  private VPNAdjustHelper() {}
 
-    public static void trackEvent(String event) {
-      if(BuildConfig.ADJUST_SDK_TOKEN != null && !BuildConfig.ADJUST_SDK_TOKEN.isEmpty()) {
-        AdjustEvent adjustEvent = new AdjustEvent(event);
-        Adjust.trackEvent(adjustEvent);
-      }
+  public static void trackEvent(String event) {
+    if (BuildConfig.ADJUST_SDK_TOKEN != null && !BuildConfig.ADJUST_SDK_TOKEN.isEmpty()) {
+      AdjustEvent adjustEvent = new AdjustEvent(event);
+      Adjust.trackEvent(adjustEvent);
     }
+  }
 }
-

--- a/android/src/org/mozilla/firefox/vpn/qt/VPNApplication.java
+++ b/android/src/org/mozilla/firefox/vpn/qt/VPNApplication.java
@@ -20,7 +20,7 @@ public class VPNApplication extends org.qtproject.qt5.android.bindings.QtApplica
         String appToken = BuildConfig.ADJUST_SDK_TOKEN;
         String environment = BuildConfig.DEBUG ? AdjustConfig.ENVIRONMENT_SANDBOX : AdjustConfig.ENVIRONMENT_PRODUCTION;
         AdjustConfig config = new AdjustConfig(this, appToken, environment);
-        config.setLogLevel(LogLevel.VERBOSE);
+        config.setLogLevel(LogLevel.DEBUG);
         Adjust.onCreate(config);
       }
   }

--- a/android/src/org/mozilla/firefox/vpn/qt/VPNApplication.java
+++ b/android/src/org/mozilla/firefox/vpn/qt/VPNApplication.java
@@ -1,0 +1,27 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.firefox.vpn.qt;
+
+import com.adjust.sdk.Adjust;
+import com.adjust.sdk.AdjustConfig;
+import com.adjust.sdk.LogLevel;
+
+import org.mozilla.firefox.vpn.BuildConfig;
+
+public class VPNApplication extends org.qtproject.qt5.android.bindings.QtApplication {
+
+  @Override
+  public void onCreate() {
+      super.onCreate();
+
+      if(BuildConfig.ADJUST_SDK_TOKEN != null && !BuildConfig.ADJUST_SDK_TOKEN.isEmpty()) {
+        String appToken = BuildConfig.ADJUST_SDK_TOKEN;
+        String environment = BuildConfig.DEBUG ? AdjustConfig.ENVIRONMENT_SANDBOX : AdjustConfig.ENVIRONMENT_PRODUCTION;
+        AdjustConfig config = new AdjustConfig(this, appToken, environment);
+        config.setLogLevel(LogLevel.VERBOSE);
+        Adjust.onCreate(config);
+      }
+  }
+}

--- a/scripts/android_package.sh
+++ b/scripts/android_package.sh
@@ -103,6 +103,9 @@ fi
 if [ -z "${ANDROID_SDK_ROOT}" ]; then
   die "Could not find 'ANDROID_SDK_ROOT' in env"
 fi
+if [[ "$RELEASE" ]] && [ -z "${ADJUST_SDK_TOKEN}" ]; then
+  die "Could not find 'ADJUST_SDK_TOKEN' in env which is required for a release build"
+fi
 
 $QTPATH/android/bin/qmake -v &>/dev/null || die "qmake doesn't exist or it fails"
 

--- a/src/platforms/android/androidadjusthelper.cpp
+++ b/src/platforms/android/androidadjusthelper.cpp
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "androidadjusthelper.h"
+
+#include <QAndroidJniObject>
+#include <QString>
+
+void AndroidAdjustHelper::trackEvent(const QString& event) {
+  QAndroidJniObject javaMessage = QAndroidJniObject::fromString(event);
+  QAndroidJniObject::callStaticMethod<void>("org/mozilla/firefox/vpn/qt/VPNAdjustHelper",
+                                            "trackEvent",
+                                            "(Ljava/lang/String;)V",
+                                            javaMessage.object<jstring>());
+}

--- a/src/platforms/android/androidadjusthelper.cpp
+++ b/src/platforms/android/androidadjusthelper.cpp
@@ -9,8 +9,7 @@
 
 void AndroidAdjustHelper::trackEvent(const QString& event) {
   QAndroidJniObject javaMessage = QAndroidJniObject::fromString(event);
-  QAndroidJniObject::callStaticMethod<void>("org/mozilla/firefox/vpn/qt/VPNAdjustHelper",
-                                            "trackEvent",
-                                            "(Ljava/lang/String;)V",
-                                            javaMessage.object<jstring>());
+  QAndroidJniObject::callStaticMethod<void>(
+      "org/mozilla/firefox/vpn/qt/VPNAdjustHelper", "trackEvent",
+      "(Ljava/lang/String;)V", javaMessage.object<jstring>());
 }

--- a/src/platforms/android/androidadjusthelper.h
+++ b/src/platforms/android/androidadjusthelper.h
@@ -8,12 +8,10 @@
 #include <QString>
 
 class AndroidAdjustHelper {
+ public:
+  AndroidAdjustHelper() = default;
 
-  public:
-    AndroidAdjustHelper() = default;
-
-    static void trackEvent(const QString& event);
-
+  static void trackEvent(const QString& event);
 };
 
-#endif // ANDROIDADJUSTHELPER_H
+#endif  // ANDROIDADJUSTHELPER_H

--- a/src/platforms/android/androidadjusthelper.h
+++ b/src/platforms/android/androidadjusthelper.h
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef ANDROIDADJUSTHELPER_H
+#define ANDROIDADJUSTHELPER_H
+
+#include <QString>
+
+class AndroidAdjustHelper {
+
+  public:
+    AndroidAdjustHelper() = default;
+
+    static void trackEvent(const QString& event);
+
+};
+
+#endif // ANDROIDADJUSTHELPER_H

--- a/src/src.pro
+++ b/src/src.pro
@@ -520,7 +520,8 @@ else:android {
 
     INCLUDEPATH += platforms/android
 
-    SOURCES +=  platforms/android/androidauthenticationlistener.cpp \
+    SOURCES +=  platforms/android/androidadjusthelper.cpp \
+                platforms/android/androidauthenticationlistener.cpp \
                 platforms/android/androidcontroller.cpp \
                 platforms/android/androidnotificationhandler.cpp \
                 platforms/android/androidutils.cpp \
@@ -532,7 +533,8 @@ else:android {
                 platforms/android/androidsharedprefs.cpp \
                 tasks/authenticate/desktopauthenticationlistener.cpp
 
-    HEADERS +=  platforms/android/androidauthenticationlistener.h \
+    HEADERS +=  platforms/android/androidadjusthelper.h \
+                platforms/android/androidauthenticationlistener.h \
                 platforms/android/androidcontroller.h \
                 platforms/android/androidnotificationhandler.h \
                 platforms/android/androidutils.h \


### PR DESCRIPTION
I this PR I added the Adjust SDK to Android. 
Thanks to @strseb for helping :)

Parts of this PR:
- Added a `VPNApplication` to initialize adjust
- Add the Adjust SDK token as a build variable
- Add a way to call adjust functions from C++

The Adjust SDK will only be initialized and track events if the environment variable `ADJUST_SDK_TOKEN` is defined at build time. Also adjust will use the sandbox environment if the application is build for `debug` and will use the production environment when build for `release`.