### PR TITLE
Remove Bind handle deadlock

### DIFF
--- a/src/platforms/linux/linuxpingsender.cpp
+++ b/src/platforms/linux/linuxpingsender.cpp
@@ -80,6 +80,8 @@ LinuxPingSender::LinuxPingSender(const QString& source, QObject* parent)
     return;
   }
   if (bind(m_socket, (struct sockaddr*)&addr, sizeof(addr)) != 0) {
+    close(m_socket);
+    m_socket = -1;
     logger.error() << "bind error:" << strerror(errno);
     return;
   }


### PR DESCRIPTION
Closes https://github.com/mozilla-mobile/mozilla-vpn-client/issues/1495

In regards to #1495, the logs i got show we get this error: 
```
[04.08.2021 18:47:30.665] (linux|networking - LinuxPingSender) LinuxPingSender(10.65.123.53) created
[04.08.2021 18:47:30.666] (linux|networking - LinuxPingSender) bind error: Permission denied
```

Problem here is, in case we error on bind, we just exit the constructor of the LinuxPingSender. The socket handle is still open and valid (so we wont use the qprocess ping)- but we did not yet setup the qsocketnotifer. 
So any send ping will result in a timeout.  
