### PR TITLE
Fix the unit-test script

### DIFF
--- a/.github/workflows/test_coverage.yaml
+++ b/.github/workflows/test_coverage.yaml
@@ -58,4 +58,4 @@ jobs:
         run: |
           # Manually add QT executables to path
           export PATH=/opt/qt515/bin:$PATH
-          ./scripts/test_coverage.sh -j8
+          ./scripts/test_coverage.sh -j 8

--- a/scripts/test_coverage.sh
+++ b/scripts/test_coverage.sh
@@ -32,6 +32,8 @@ while [[ $# -gt 0 ]]; do
     helpFunction
     ;;
   *)
+    helpFunction
+    ;;
   esac
 done
 


### PR DESCRIPTION
There was a missing space when running the test_coverage script. 