### PR TITLE
Fix 'flicker' on App permissions view

### DIFF
--- a/src/ui/components/VPNExpandableAppList.qml
+++ b/src/ui/components/VPNExpandableAppList.qml
@@ -24,6 +24,12 @@ ColumnLayout {
     anchors.rightMargin: Theme.vSpacing
     spacing: Theme.vSpacing
 
+    // Ensure the inital presentation of the component is consistent with the
+    // "hidden" state. This prevents the transition from firing on the
+    // component load which appears as a "flicker".
+    opacity: 0
+    visible: false
+
     states: [
         State {
             name: "visibleAndEnabled"


### PR DESCRIPTION
Closes #1410.

The issue was caused by a QML component that had the expandable app list sub-view set as the default state for the view. When the view was rendered, the app would see that `VPNSettings.protectSelectedApps` is `false` and fire the transition to the hidden state, which caused the screen to flicker. This solution sets the default state of the view to match the "hidden" state. (This means that the app list fades in if the view is selected and `protectSelectedApps` is true, but it's barely noticeable imo.)