### PR TITLE
Move windows ring logger into its own thread

### DIFF
--- a/src/platforms/windows/daemon/windowstunnellogger.cpp
+++ b/src/platforms/windows/daemon/windowstunnellogger.cpp
@@ -50,8 +50,6 @@ WindowsTunnelLogger::WindowsTunnelLogger(const QString& filename,
 
 WindowsTunnelLogger::~WindowsTunnelLogger() {
   MVPN_COUNT_DTOR(WindowsTunnelLogger);
-  m_timer.stop();
-
   if (m_logdata) {
     timeout();
 

--- a/src/platforms/windows/daemon/windowstunnellogger.cpp
+++ b/src/platforms/windows/daemon/windowstunnellogger.cpp
@@ -1,0 +1,119 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "windowstunnellogger.h"
+#include "leakdetector.h"
+#include "logger.h"
+
+#include <QDateTime>
+
+constexpr uint32_t WINDOWS_TUNNEL_MONITOR_TIMEOUT_MSEC = 2000;
+
+/* The ring logger format used by the Wireguard DLL is as follows, assuming
+ * no padding:
+ *
+ * struct {
+ *   uint32_t magic;
+ *   uint32_t index;
+ *   struct {
+ *     uint64_t timestamp;
+ *     char message[512];
+ *   } ring[2048];
+ * };
+ */
+
+constexpr uint32_t RINGLOG_POLL_MSEC = 250;
+constexpr uint32_t RINGLOG_MAGIC_HEADER = 0xbadbabe;
+constexpr uint32_t RINGLOG_INDEX_OFFSET = 4;
+constexpr uint32_t RINGLOG_HEADER_SIZE = 8;
+constexpr uint32_t RINGLOG_MAX_ENTRIES = 2048;
+constexpr uint32_t RINGLOG_MESSAGE_SIZE = 512;
+constexpr uint32_t RINGLOG_TIMESTAMP_SIZE = 8;
+constexpr uint32_t RINGLOG_FILE_SIZE =
+    RINGLOG_HEADER_SIZE +
+    ((RINGLOG_MESSAGE_SIZE + RINGLOG_TIMESTAMP_SIZE) * RINGLOG_MAX_ENTRIES);
+
+namespace {
+Logger logger(LOG_WINDOWS, "tunnel.dll");
+}  // namespace
+
+WindowsTunnelLogger::WindowsTunnelLogger(const QString& filename,
+                                         QObject* parent)
+    : QObject(parent), m_logfile(filename, this), m_timer(this) {
+  MVPN_COUNT_CTOR(WindowsTunnelLogger);
+  m_startTime = QDateTime::currentMSecsSinceEpoch() * 1000000;
+
+  // Open the tunnel log file.
+  m_logfile.open(QIODevice::ReadOnly);
+  m_logindex = -1;
+  m_logdata = m_logfile.map(0, RINGLOG_FILE_SIZE);
+  if (!m_logdata) {
+    return;
+  }
+
+  // Check for a valid magic header
+  uint32_t magic;
+  memcpy(&magic, m_logdata, 4);
+  logger.debug() << "Opening tunnel log file" << filename;
+  if (magic != RINGLOG_MAGIC_HEADER) {
+    logger.error() << "Unexpected magic header:" << QString::number(magic, 16);
+    return;
+  }
+
+  connect(&m_timer, SIGNAL(timeout()), this, SLOT(timeout()));
+  m_timer.start(RINGLOG_POLL_MSEC);
+}
+
+WindowsTunnelLogger::~WindowsTunnelLogger() {
+  MVPN_COUNT_DTOR(WindowsTunnelLogger);
+  m_timer.stop();
+
+  if (m_logdata) {
+    timeout();
+
+    m_logfile.unmap(m_logdata);
+    m_logdata = nullptr;
+  }
+}
+
+int WindowsTunnelLogger::nextIndex() {
+  if (!m_logdata) {
+    return 0;
+  }
+  qint32 value;
+  memcpy(&value, m_logdata + RINGLOG_INDEX_OFFSET, 4);
+  return value % RINGLOG_MAX_ENTRIES;
+}
+
+void WindowsTunnelLogger::process(int index) {
+  Q_ASSERT(index >= 0);
+  Q_ASSERT(index < RINGLOG_MAX_ENTRIES);
+  size_t offset = index * (RINGLOG_TIMESTAMP_SIZE + RINGLOG_MESSAGE_SIZE);
+  uchar* data = m_logdata + RINGLOG_HEADER_SIZE + offset;
+
+  quint64 timestamp;
+  memcpy(&timestamp, data, 8);
+  if (timestamp <= m_startTime) {
+    return;
+  }
+
+  QByteArray message((const char*)data + RINGLOG_TIMESTAMP_SIZE,
+                     RINGLOG_MESSAGE_SIZE);
+  logger.info() << QString::fromUtf8(message);
+}
+
+void WindowsTunnelLogger::timeout() {
+  /* On the first pass, scan all log messages. */
+  if (m_logindex < 0) {
+    m_logindex = nextIndex();
+    process(m_logindex);
+    m_logindex = (m_logindex + 1) % RINGLOG_MAX_ENTRIES;
+  }
+
+  /* Report new messages. */
+  while (m_logindex != nextIndex()) {
+    process(m_logindex);
+    m_logindex = (m_logindex + 1) % RINGLOG_MAX_ENTRIES;
+  }
+}

--- a/src/platforms/windows/daemon/windowstunnellogger.h
+++ b/src/platforms/windows/daemon/windowstunnellogger.h
@@ -1,0 +1,35 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef WINDOWSTUNNELLOGGER_H
+#define WINDOWSTUNNELLOGGER_H
+
+#include <QFile>
+#include <QObject>
+#include <QTimer>
+
+class WindowsTunnelLogger final : public QObject {
+  Q_OBJECT
+  Q_DISABLE_COPY_MOVE(WindowsTunnelLogger)
+
+ public:
+  WindowsTunnelLogger(const QString& filename, QObject* parent = nullptr);
+  ~WindowsTunnelLogger();
+
+ private slots:
+  void timeout();
+
+ private:
+  void process(int index);
+  int nextIndex();
+
+ private:
+  QTimer m_timer;
+  QFile m_logfile;
+  uchar* m_logdata = nullptr;
+  int m_logindex = -1;
+  quint64 m_startTime = 0;
+};
+
+#endif  // WINDOWSTUNNELLOGGER_H

--- a/src/platforms/windows/daemon/windowstunnellogger.h
+++ b/src/platforms/windows/daemon/windowstunnellogger.h
@@ -21,6 +21,7 @@ class WindowsTunnelLogger final : public QObject {
   void timeout();
 
  private:
+  bool openLogData();
   void process(int index);
   int nextIndex();
 

--- a/src/platforms/windows/daemon/windowstunnelservice.cpp
+++ b/src/platforms/windows/daemon/windowstunnelservice.cpp
@@ -19,33 +19,8 @@
 
 constexpr uint32_t WINDOWS_TUNNEL_MONITOR_TIMEOUT_MSEC = 2000;
 
-/* The ring logger format used by the Wireguard DLL is as follows, assuming
- * no padding:
- *
- * struct {
- *   uint32_t magic;
- *   uint32_t index;
- *   struct {
- *     uint64_t timestamp;
- *     char message[512];
- *   } ring[2048];
- * };
- */
-
-constexpr uint32_t RINGLOG_POLL_MSEC = 250;
-constexpr uint32_t RINGLOG_MAGIC_HEADER = 0xbadbabe;
-constexpr uint32_t RINGLOG_INDEX_OFFSET = 4;
-constexpr uint32_t RINGLOG_HEADER_SIZE = 8;
-constexpr uint32_t RINGLOG_MAX_ENTRIES = 2048;
-constexpr uint32_t RINGLOG_MESSAGE_SIZE = 512;
-constexpr uint32_t RINGLOG_TIMESTAMP_SIZE = 8;
-constexpr uint32_t RINGLOG_FILE_SIZE =
-    RINGLOG_HEADER_SIZE +
-    ((RINGLOG_MESSAGE_SIZE + RINGLOG_TIMESTAMP_SIZE) * RINGLOG_MAX_ENTRIES);
-
 namespace {
 Logger logger(LOG_WINDOWS, "WindowsTunnelService");
-Logger logdll(LOG_WINDOWS, "tunnel.dll");
 }  // namespace
 
 static bool stopAndDeleteTunnelService(SC_HANDLE service);
@@ -59,52 +34,13 @@ WindowsTunnelService::WindowsTunnelService(QObject* parent) : QObject(parent) {
     WindowsCommons::windowsLog("Failed to open SCManager");
   }
 
-  m_logEpochNsec = QDateTime::currentMSecsSinceEpoch() * 1000000;
-
   connect(&m_timer, &QTimer::timeout, this, &WindowsTunnelService::timeout);
-  connect(&m_logtimer, &QTimer::timeout, this,
-          &WindowsTunnelService::processLogs);
 }
 
 WindowsTunnelService::~WindowsTunnelService() {
   MVPN_COUNT_CTOR(WindowsTunnelService);
   stop();
   CloseServiceHandle((SC_HANDLE)m_scm);
-}
-
-bool WindowsTunnelService::start(const QString& configFile) {
-  logger.debug() << "Starting the tunnel service";
-  m_logEpochNsec = QDateTime::currentMSecsSinceEpoch() * 1000000;
-
-  if (!registerTunnelService(configFile)) {
-    return false;
-  }
-  m_timer.start(WINDOWS_TUNNEL_MONITOR_TIMEOUT_MSEC);
-
-  /* Open and map the tunnel log file. */
-  QString logFileName = WindowsCommons::tunnelLogFile();
-  if (logFileName.isNull()) {
-    return true;
-  }
-  m_logfile = new QFile(logFileName, this);
-  m_logfile->open(QIODevice::ReadOnly);
-  m_logindex = -1;
-  m_logdata = m_logfile->map(0, RINGLOG_FILE_SIZE);
-  if (!m_logdata) {
-    return true;
-  }
-
-  /* Check for a valid magic header */
-  uint32_t magic;
-  memcpy(&magic, m_logdata, 4);
-  logger.debug() << "Opening tunnel log file" << logFileName;
-  if (magic != RINGLOG_MAGIC_HEADER) {
-    logger.error() << "Unexpected magic header:" << QString::number(magic, 16);
-    return true;
-  }
-
-  m_logtimer.start(RINGLOG_POLL_MSEC);
-  return true;
 }
 
 void WindowsTunnelService::stop() {
@@ -116,13 +52,12 @@ void WindowsTunnelService::stop() {
   }
 
   m_timer.stop();
-  m_logtimer.stop();
 
-  if (m_logfile) {
-    m_logfile->unmap(m_logdata);
-    delete m_logfile;
-    m_logfile = nullptr;
-    m_logdata = nullptr;
+  if (m_logworker) {
+    m_logthread.quit();
+    m_logthread.wait();
+    delete m_logworker;
+    m_logworker = nullptr;
   }
 }
 
@@ -162,55 +97,26 @@ void WindowsTunnelService::timeout() {
   emit backendFailure();
 }
 
-int WindowsTunnelService::nextLogIndex() {
-  if (!m_logdata) {
-    return 0;
+bool WindowsTunnelService::start(const QString& configFile) {
+  logger.debug() << "Starting the tunnel service";
+
+  m_logworker = new WindowsTunnelLogger(WindowsCommons::tunnelLogFile());
+  if (m_logworker) {
+    m_logworker->moveToThread(&m_logthread);
+    m_logthread.start();
   }
-  qint32 value;
-  memcpy(&value, m_logdata + RINGLOG_INDEX_OFFSET, 4);
-  return value % RINGLOG_MAX_ENTRIES;
-}
-
-void WindowsTunnelService::processMessage(int index) {
-  Q_ASSERT(index >= 0);
-  Q_ASSERT(index < RINGLOG_MAX_ENTRIES);
-  size_t offset = index * (RINGLOG_TIMESTAMP_SIZE + RINGLOG_MESSAGE_SIZE);
-  uchar* data = m_logdata + RINGLOG_HEADER_SIZE + offset;
-
-  quint64 timestamp;
-  memcpy(&timestamp, data, 8);
-  if (timestamp <= m_logEpochNsec) {
-    return;
-  }
-
-  QByteArray message((const char*)data + RINGLOG_TIMESTAMP_SIZE,
-                     RINGLOG_MESSAGE_SIZE);
-  logdll.info() << QString::fromUtf8(message);
-}
-
-void WindowsTunnelService::processLogs() {
-  /* On the first pass, scan all log messages. */
-  if (m_logindex < 0) {
-    m_logindex = nextLogIndex();
-    processMessage(m_logindex);
-    m_logindex = (m_logindex + 1) % RINGLOG_MAX_ENTRIES;
-  }
-
-  /* Report new messages. */
-  while (m_logindex != nextLogIndex()) {
-    processMessage(m_logindex);
-    m_logindex = (m_logindex + 1) % RINGLOG_MAX_ENTRIES;
-  }
-}
-
-bool WindowsTunnelService::registerTunnelService(const QString& configFile) {
-  logger.debug() << "Register tunnel service";
 
   SC_HANDLE scm = (SC_HANDLE)m_scm;
   SC_HANDLE service = nullptr;
   auto guard = qScopeGuard([&] {
     if (service) {
       CloseServiceHandle(service);
+    }
+    if (m_logworker) {
+      m_logthread.quit();
+      m_logthread.wait();
+      delete m_logworker;
+      m_logworker = nullptr;
     }
   });
 
@@ -269,6 +175,7 @@ bool WindowsTunnelService::registerTunnelService(const QString& configFile) {
     logger.debug() << "The tunnel service is up and running";
     guard.dismiss();
     m_service = service;
+    m_timer.start(WINDOWS_TUNNEL_MONITOR_TIMEOUT_MSEC);
     return true;
   }
 

--- a/src/platforms/windows/daemon/windowstunnelservice.cpp
+++ b/src/platforms/windows/daemon/windowstunnelservice.cpp
@@ -101,10 +101,8 @@ bool WindowsTunnelService::start(const QString& configFile) {
   logger.debug() << "Starting the tunnel service";
 
   m_logworker = new WindowsTunnelLogger(WindowsCommons::tunnelLogFile());
-  if (m_logworker) {
-    m_logworker->moveToThread(&m_logthread);
-    m_logthread.start();
-  }
+  m_logworker->moveToThread(&m_logthread);
+  m_logthread.start();
 
   SC_HANDLE scm = (SC_HANDLE)m_scm;
   SC_HANDLE service = nullptr;
@@ -112,12 +110,10 @@ bool WindowsTunnelService::start(const QString& configFile) {
     if (service) {
       CloseServiceHandle(service);
     }
-    if (m_logworker) {
-      m_logthread.quit();
-      m_logthread.wait();
-      delete m_logworker;
-      m_logworker = nullptr;
-    }
+    m_logthread.quit();
+    m_logthread.wait();
+    delete m_logworker;
+    m_logworker = nullptr;
   });
 
   // Let's see if we have to delete a previous instance.

--- a/src/platforms/windows/daemon/windowstunnelservice.h
+++ b/src/platforms/windows/daemon/windowstunnelservice.h
@@ -5,9 +5,12 @@
 #ifndef WINDOWSTUNNELSERVICE_H
 #define WINDOWSTUNNELSERVICE_H
 
+#include "windowstunnellogger.h"
+
 #include <QFile>
 #include <QObject>
 #include <QTimer>
+#include <QThread>
 
 class WindowsTunnelService final : public QObject {
   Q_OBJECT
@@ -36,11 +39,8 @@ class WindowsTunnelService final : public QObject {
 
  private:
   QTimer m_timer;
-  QTimer m_logtimer;
-  QFile* m_logfile = nullptr;
-  uchar* m_logdata = nullptr;
-  int m_logindex = -1;
-  quint64 m_logEpochNsec = 0;
+  QThread m_logthread;
+  WindowsTunnelLogger* m_logworker = nullptr;
 
   // These are really SC_HANDLEs in disguise.
   void* m_scm = nullptr;

--- a/src/platforms/windows/daemon/windowstunnelservice.h
+++ b/src/platforms/windows/daemon/windowstunnelservice.h
@@ -30,11 +30,6 @@ class WindowsTunnelService final : public QObject {
 
  private:
   void timeout();
-  void processLogs();
-  void processMessage(int index);
-  int nextLogIndex();
-
-  bool registerTunnelService(const QString& configFile);
   static QString exitCodeToFailure(unsigned int code);
 
  private:

--- a/src/src.pro
+++ b/src/src.pro
@@ -760,6 +760,7 @@ else:win* {
         platforms/windows/daemon/windowsdaemon.cpp \
         platforms/windows/daemon/windowsdaemonserver.cpp \
         platforms/windows/daemon/windowsdaemontunnel.cpp \
+        platforms/windows/daemon/windowstunnellogger.cpp \
         platforms/windows/daemon/windowstunnelservice.cpp \
         platforms/windows/daemon/wireguardutilswindows.cpp \
         platforms/windows/daemon/windowsfirewall.cpp \
@@ -791,6 +792,7 @@ else:win* {
         platforms/windows/daemon/windowsdaemon.h \
         platforms/windows/daemon/windowsdaemonserver.h \
         platforms/windows/daemon/windowsdaemontunnel.h \
+        platforms/windows/daemon/windowstunnellogger.h \
         platforms/windows/daemon/windowstunnelservice.h \
         platforms/windows/daemon/wireguardutilswindows.h \
         platforms/windows/daemon/windowsfirewall.h \


### PR DESCRIPTION
If the tunnel daemon fails to start, then we can be left in the condition where we never actually started the ring logger, meaning that we might not get any logs as to the cause of the failure. To make debug easier when this occurs, we move the ring logger into its own thread so that it can run asynchronously from whatever the service startup is doing.

Closes: #1548