### PR TITLE
Fix rpmbuild when run from git checkout

### DIFF
--- a/linux/mozillavpn.spec
+++ b/linux/mozillavpn.spec
@@ -3,7 +3,7 @@
 
 Name:      mozillavpn
 Version:   %{_version}
-Release:   1
+Release:   1~git%(git log -1 --format=%h)%{?dist}
 Summary:   Mozilla VPN
 License:   MPLv2.0
 URL:       https://vpn.mozilla.org
@@ -32,18 +32,17 @@ A fast, secure and easy to use VPN. Built by the makers of Firefox.
 Read more on https://vpn.mozilla.org
 
 %prep
-%setup -q
 %undefine _lto_cflags
 
 %build
-python3 scripts/importLanguages.py
-%{qmake_qt5} CONFIG+=production QT+=svg
-make -j$(nproc)
+%{_srcdir}/scripts/importLanguages.py
+%{qmake_qt5} %{_srcdir}/mozillavpn.pro QT+=svg
+make %{?_smp_mflags}
 
 %install
 make install INSTALL_ROOT=%{buildroot}
 install -d %{buildroot}/%{_licensedir}/%{name}
-install LICENSE.md %{buildroot}/%{_licensedir}/%{name}/
+install %{_srcdir}/LICENSE.md %{buildroot}/%{_licensedir}/%{name}/
 
 %files
 %license %{_licensedir}/%{name}/LICENSE.md

--- a/scripts/importLanguages.py
+++ b/scripts/importLanguages.py
@@ -11,6 +11,13 @@ import os
 import sys
 import shutil
 import generate_strings
+import atexit
+
+# Use the project root as the working directory
+prevdir = os.getcwd()
+workdir = os.path.join(os.path.dirname(__file__), '..')
+os.chdir(workdir)
+atexit.register(os.chdir, prevdir)
 
 # Include only locales above this threshold (e.g. 70%) in production
 l10n_threshold = 0.70

--- a/scripts/linux_script.sh
+++ b/scripts/linux_script.sh
@@ -127,10 +127,11 @@ print G "done."
 ## Generate the spec file for building RPMs
 build_rpm_spec() {
 cat << EOF > mozillavpn.spec
+%define _srcdir .
 Version: $SHORTVERSION
 Release: $REVISION
 Source0: mozillavpn_$SHORTVERSION.orig.tar.gz
-$(grep -v -e "^Version:" -e "^Release" -e "^%define" ../linux/mozillavpn.spec)
+$(sed -e '/^%prep/ a %autosetup' ../linux/mozillavpn.spec | grep -v -e "^Version:" -e "^Release" -e "^%define")
 EOF
 }
 
@@ -161,7 +162,7 @@ build_deb_source() {
 ## For source-only, build all the source bundles we can.
 if [ "$SOURCEONLY" == "Y" ]; then
   print Y "Configuring the DEB sources..."
-  for control in ../linux/debian/control.*; do
+  (which dpkg-buildpackage > /dev/null) && for control in ../linux/debian/control.*; do
     filename=$(basename $control)
     distro=$(echo $filename | cut -d'.' -f2)
 


### PR DESCRIPTION
This tries to get a little closer to supporting RPM builds when run from a git checkout, and without needing `linux_script.sh` to do any fixups for us. To build an RPM package this way, you would need to do the following:
- `git clone` to fetch the mozilla-vpn-client project.
- `git submodule init && git submodule update` to fetch the relevant submodules.
- `pip3 install glean_parser==3.5 && ./scripts/generate_glean.py` to generate the telemetry code.
- `sudo dnf builddep linux/mozillavpn.spec` to install the build-dependencies.
- `rpmbuild -ba linux/mozillavpn.spec` to build the package.

This is not yet a complete solution to go from git checkout -> usable RPM, since we still need `glean_parser` and it has no RPM equivalent that I can find.