### PR TITLE
Fix pyyaml exception on Windows when parsing strings.yaml

### DIFF
--- a/scripts/generate_strings.py
+++ b/scripts/generate_strings.py
@@ -28,7 +28,7 @@ def generateStrings():
     if not os.path.isfile(yaml_path):
         exit("Unable to find translations/strings.yaml")
 
-    with open(yaml_path, "r") as yaml_file:
+    with open(yaml_path, "r", encoding="utf-8") as yaml_file:
         yaml_content = yaml.safe_load(yaml_file)
 
         stringIds = []

--- a/scripts/importLanguages.py
+++ b/scripts/importLanguages.py
@@ -3,8 +3,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-# This script must be executed at the root of the repository.
-
 import argparse
 import xml.etree.ElementTree as ET
 import os


### PR DESCRIPTION
When parsing a yaml file, and no byte-order-mark is present, then the file will be assumed to use the system encoding, on Windows this tends to misfire and we try to parse the file as CP-1251 instead of UTF-8. We workaround the issue by explicitly opening the `strings.yaml` as UTF-8.

We also fixed a comment that is out of date after merging #1571