### PR TITLE
Fix unsecured Wi-Fi detection when disconnected

### DIFF
--- a/src/platforms/linux/linuxnetworkwatcherworker.cpp
+++ b/src/platforms/linux/linuxnetworkwatcherworker.cpp
@@ -152,17 +152,22 @@ void LinuxNetworkWatcherWorker::checkDevices() {
                       "org.freedesktop.NetworkManager.AccessPoint",
                       QDBusConnection::systemBus());
 
-    int rsnFlags = ap.property("RsnFlags").toInt();
-    int wpaFlags = ap.property("WpaFlags").toInt();
-    if (!checkUnsecureFlags(rsnFlags, wpaFlags)) {
+    QVariant rsnFlags = ap.property("RsnFlags");
+    QVariant wpaFlags = ap.property("WpaFlags");
+    if (!rsnFlags.isValid() || !wpaFlags.isValid()) {
+      // We are probably not connected.
+      continue;
+    }
+
+    if (!checkUnsecureFlags(rsnFlags.toInt(), wpaFlags.toInt())) {
       QString ssid = ap.property("Ssid").toString();
       QString bssid = ap.property("HwAddress").toString();
 
       // We have found 1 unsecured network. We don't need to check other wifi
       // network devices.
-      logger.warning() << "Unsecured AP detected flags:"
-                       << QString("%1:%2").arg(rsnFlags).arg(wpaFlags)
-                       << "ssid:" << ssid;
+      logger.warning() << "Unsecured AP detected!"
+                       << "rsnFlags:" << rsnFlags.toInt()
+                       << "wpaFlags:" << wpaFlags.toInt() << "ssid:" << ssid;
       emit unsecuredNetwork(ssid, bssid);
       break;
     }


### PR DESCRIPTION
On Linux, the network interface watcher checks the active access points over D-Bus to determine if they are connected to an unsecure Wi-Fi network. However, when the Wi-Fi is disconnected, we get a non-empty string, but invalid D-Bus path of `/`. Trying to retrieve the WiFi flags for this bogus path returns invalid `QVariant`, which confuses the unsecured Wi-Fi check.

To fix this, we must ensure that the properties we got back from the Wi-Fi access point are actually valid before continuing with the check.

Closes: #1454