### PR TITLE
implement in app support client side with additions to featurelist

### DIFF
--- a/src/commands/commandui.cpp
+++ b/src/commands/commandui.cpp
@@ -252,6 +252,14 @@ int CommandUI::run(QStringList& tokens) {
         });
 
     qmlRegisterSingletonType<MozillaVPN>(
+        "Mozilla.VPN", 1, 0, "VPNSupportCategoryModel",
+        [](QQmlEngine*, QJSEngine*) -> QObject* {
+          QObject* obj = MozillaVPN::instance()->supportCategoryModel();
+          QQmlEngine::setObjectOwnership(obj, QQmlEngine::CppOwnership);
+          return obj;
+        });
+
+    qmlRegisterSingletonType<MozillaVPN>(
         "Mozilla.VPN", 1, 0, "VPNHelpModel",
         [](QQmlEngine*, QJSEngine*) -> QObject* {
           QObject* obj = MozillaVPN::instance()->helpModel();

--- a/src/featurelist.cpp
+++ b/src/featurelist.cpp
@@ -20,7 +20,7 @@
 namespace {
 Logger logger(LOG_MAIN, "FeatureList");
 FeatureList s_featureList;
-} // namespace
+}  // namespace
 
 // static
 FeatureList* FeatureList::instance() { return &s_featureList; }

--- a/src/featurelist.cpp
+++ b/src/featurelist.cpp
@@ -20,7 +20,7 @@
 namespace {
 Logger logger(LOG_MAIN, "FeatureList");
 FeatureList s_featureList;
-}
+} // namespace
 
 // static
 FeatureList* FeatureList::instance() { return &s_featureList; }

--- a/src/featurelist.cpp
+++ b/src/featurelist.cpp
@@ -3,8 +3,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "featurelist.h"
+#include "logger.h"
 
 #include <QProcessEnvironment>
+#include <QJsonDocument>
+#include <QJsonObject>
 
 #ifdef MVPN_ANDROID
 #  include "platforms/android/androidutils.h"
@@ -15,11 +18,24 @@
 #endif
 
 namespace {
+Logger logger(LOG_MAIN, "FeatureList");
 FeatureList s_featureList;
 }
 
 // static
 FeatureList* FeatureList::instance() { return &s_featureList; }
+
+void FeatureList::updateFeatureList(const QByteArray& data) {
+  QJsonObject json = QJsonDocument::fromJson(data).object();
+  QJsonValue unauthSupportEnabled = json["unauthSupportEnabled"];
+  if (unauthSupportEnabled.isBool()) {
+    logger.debug() << "Setting unauth support enablet to: "
+                   << unauthSupportEnabled.toBool();
+    m_unauthSupportSupported = unauthSupportEnabled.toBool();
+  } else {
+    logger.error() << "Error in parsing unauth support response";
+  }
+}
 
 bool FeatureList::startOnBootSupported() const {
 #if defined(MVPN_LINUX) || defined(MVPN_MACOS) || defined(MVPN_WINDOWS) || \
@@ -160,4 +176,8 @@ bool FeatureList::appReviewSupported() const {
 #else
   return false;
 #endif
+}
+
+bool FeatureList::unauthSupportSupported() const {
+  return m_unauthSupportSupported;
 }

--- a/src/featurelist.h
+++ b/src/featurelist.h
@@ -70,7 +70,7 @@ class FeatureList final : public QObject {
 
  private:
   Q_PROPERTY(bool unauthSupport READ unauthSupportSupported)
-  
+
   bool m_unauthSupportSupported = false;
 };
 

--- a/src/featurelist.h
+++ b/src/featurelist.h
@@ -28,11 +28,17 @@ class FeatureList final : public QObject {
   Q_PROPERTY(bool multihopSupported READ multihopSupported CONSTANT)
   Q_PROPERTY(bool appReviewSupported READ appReviewSupported CONSTANT)
 
+  Q_PROPERTY(bool unauthSupport READ unauthSupportSupported)
+
+  bool m_unauthSupportSupported = false;
+
  public:
   FeatureList() = default;
   ~FeatureList() = default;
 
   static FeatureList* instance();
+
+  void updateFeatureList(const QByteArray& data);
 
   bool startOnBootSupported() const;
 
@@ -59,6 +65,8 @@ class FeatureList final : public QObject {
   bool multihopSupported() const;
 
   bool appReviewSupported() const;
+  
+  bool unauthSupportSupported() const;
 };
 
 #endif  // FEATURELIST_H

--- a/src/featurelist.h
+++ b/src/featurelist.h
@@ -40,6 +40,10 @@ class FeatureList final : public QObject {
 
   void updateFeatureList(const QByteArray& data);
 
+  void setUnauthSupportSupported(bool enabled) {
+    m_unauthSupportSupported = enabled;
+  }
+
   bool startOnBootSupported() const;
 
   bool protectSelectedAppsSupported() const;

--- a/src/featurelist.h
+++ b/src/featurelist.h
@@ -28,10 +28,6 @@ class FeatureList final : public QObject {
   Q_PROPERTY(bool multihopSupported READ multihopSupported CONSTANT)
   Q_PROPERTY(bool appReviewSupported READ appReviewSupported CONSTANT)
 
-  Q_PROPERTY(bool unauthSupport READ unauthSupportSupported)
-
-  bool m_unauthSupportSupported = false;
-
  public:
   FeatureList() = default;
   ~FeatureList() = default;
@@ -71,6 +67,11 @@ class FeatureList final : public QObject {
   bool appReviewSupported() const;
 
   bool unauthSupportSupported() const;
+
+ private:
+  Q_PROPERTY(bool unauthSupport READ unauthSupportSupported)
+  
+  bool m_unauthSupportSupported = false;
 };
 
 #endif  // FEATURELIST_H

--- a/src/featurelist.h
+++ b/src/featurelist.h
@@ -69,7 +69,7 @@ class FeatureList final : public QObject {
   bool multihopSupported() const;
 
   bool appReviewSupported() const;
-  
+
   bool unauthSupportSupported() const;
 };
 

--- a/src/inspector/inspectorwebsocketconnection.cpp
+++ b/src/inspector/inspectorwebsocketconnection.cpp
@@ -232,7 +232,7 @@ static QList<WebSocketSettingCommand> s_settingCommands{
 struct WebSocketFeatureCommand {
   QString m_featureName;
 
-  std::function<void(const QByteArray&)> m_set;
+  std::function<void(bool)> m_set;
   std::function<QJsonValue()> m_get;
 };
 
@@ -241,8 +241,8 @@ static QList<WebSocketFeatureCommand> s_featureCommands{
     // Unauth Support
     WebSocketFeatureCommand{
         "unauth-support",
-        [](const QByteArray& value) {
-          FeatureList::instance()->setUnauthSupportSupported(value == "true");
+        [](bool enabled) {
+          FeatureList::instance()->setUnauthSupportSupported(enabled);
         },
         []() {
           return FeatureList::instance()->unauthSupportSupported() ? "true"
@@ -547,7 +547,7 @@ static QList<WebSocketCommand> s_commands{
                 return obj;
               }
 
-              feature.m_set(arguments[2]);
+              feature.m_set(arguments[2] == "true");
               return obj;
             }
           }

--- a/src/models/helpmodel.cpp
+++ b/src/models/helpmodel.cpp
@@ -30,13 +30,18 @@ struct HelpEntry {
 static QList<HelpEntry> s_helpEntries;
 
 void maybeInitialize() {
-  if (s_initialized && s_contactUsExternalLink == (!MozillaVPN::instance()->userAuthenticated() && !FeatureList::instance()->unauthSupportSupported())) {
+  if (s_initialized &&
+      s_contactUsExternalLink ==
+          (!MozillaVPN::instance()->userAuthenticated() &&
+           !FeatureList::instance()->unauthSupportSupported())) {
     return;
   }
   s_helpEntries.clear();
 
   s_initialized = true;
-  s_contactUsExternalLink = (!MozillaVPN::instance()->userAuthenticated() && !FeatureList::instance()->unauthSupportSupported());
+  s_contactUsExternalLink =
+      (!MozillaVPN::instance()->userAuthenticated() &&
+       !FeatureList::instance()->unauthSupportSupported());
   // Here we use the logger to force lrelease to add the help menu Ids.
 
   //% "View log"
@@ -56,10 +61,8 @@ void maybeInitialize() {
 
   //% "Contact us"
   logger.debug() << "Adding:" << qtTrId("help.contactUs");
-  s_helpEntries.append(
-      HelpEntry("help.contactUs",
-                s_contactUsExternalLink,
-                false, MozillaVPN::LinkContact));
+  s_helpEntries.append(HelpEntry("help.contactUs", s_contactUsExternalLink,
+                                 false, MozillaVPN::LinkContact));
 }
 
 }  // namespace

--- a/src/models/helpmodel.cpp
+++ b/src/models/helpmodel.cpp
@@ -10,7 +10,7 @@
 
 namespace {
 bool s_initialized = false;
-bool s_contactUsExternalLink;
+bool s_contactUsExternalLink = false;
 Logger logger(LOG_MAIN, "HelpModel");
 
 struct HelpEntry {

--- a/src/models/helpmodel.cpp
+++ b/src/models/helpmodel.cpp
@@ -10,6 +10,7 @@
 
 namespace {
 bool s_initialized = false;
+bool s_contactUsExternalLink;
 Logger logger(LOG_MAIN, "HelpModel");
 
 struct HelpEntry {
@@ -29,12 +30,13 @@ struct HelpEntry {
 static QList<HelpEntry> s_helpEntries;
 
 void maybeInitialize() {
-  if (s_initialized) {
-    s_helpEntries.clear();
+  if (s_initialized && s_contactUsExternalLink == (!MozillaVPN::instance()->userAuthenticated() && !FeatureList::instance()->unauthSupportSupported())) {
+    return;
   }
+  s_helpEntries.clear();
 
   s_initialized = true;
-
+  s_contactUsExternalLink = (!MozillaVPN::instance()->userAuthenticated() && !FeatureList::instance()->unauthSupportSupported());
   // Here we use the logger to force lrelease to add the help menu Ids.
 
   //% "View log"
@@ -56,8 +58,7 @@ void maybeInitialize() {
   logger.debug() << "Adding:" << qtTrId("help.contactUs");
   s_helpEntries.append(
       HelpEntry("help.contactUs",
-                (!MozillaVPN::instance()->userAuthenticated() &&
-                 !FeatureList::instance()->unauthSupportSupported()),
+                s_contactUsExternalLink,
                 false, MozillaVPN::LinkContact));
 }
 

--- a/src/models/supportcategorymodel.cpp
+++ b/src/models/supportcategorymodel.cpp
@@ -1,0 +1,81 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "supportcategorymodel.h"
+#include "leakdetector.h"
+#include "logger.h"
+
+namespace {
+Logger logger(LOG_MODEL, "SupportCategoryModel");
+
+struct SupportCategory {
+  const char* m_categoryName;
+  const char* m_nameId;
+};
+
+static QList<SupportCategory> s_supportCategories;
+}  // namespace
+
+SupportCategoryModel::SupportCategoryModel() {
+  MVPN_COUNT_CTOR(SupportCategoryModel);
+
+  // Here we use the logger to force lrelease to add the category ids.
+
+  //% "Payment and billing"
+  logger.debug() << "Adding:" << qtTrId("support.category.paymentDropdownListItem");
+  s_supportCategories.append(
+      SupportCategory{"payment", "support.category.paymentDropdownListItem"});
+
+  //% "Account issues"
+  logger.debug() << "Adding:" << qtTrId("support.category.accountDropdownListItem");
+  s_supportCategories.append(
+      SupportCategory{"account", "support.category.accountDropdownListItem"});
+
+  //% "Technical issues"
+  logger.debug() << "Adding:" << qtTrId("support.category.technicaDropdownListItem");
+  s_supportCategories.append(
+      SupportCategory{"technical", "support.category.technicaDropdownListItem"});
+
+  //% "Request features"
+  logger.debug() << "Adding:" << qtTrId("support.category.featureRequestDropdownListItem");
+  s_supportCategories.append(
+      SupportCategory{"feature", "support.category.featureRequestDropdownListItem"});
+
+  //% "Other"
+  logger.debug() << "Adding:" << qtTrId("support.category.otherDropdownListItem");
+  s_supportCategories.append(
+      SupportCategory{"other", "support.category.otherDropdownListItem"});
+}
+
+SupportCategoryModel::~SupportCategoryModel() {
+  MVPN_COUNT_DTOR(SupportCategoryModel);
+}
+
+QHash<int, QByteArray> SupportCategoryModel::roleNames() const {
+  QHash<int, QByteArray> roles;
+  roles[CategoryNameRole] = "value";
+  roles[LocalizedNameRole] = "name";
+  return roles;
+}
+
+int SupportCategoryModel::rowCount(const QModelIndex&) const {
+  return s_supportCategories.count();
+}
+
+QVariant SupportCategoryModel::data(const QModelIndex& index, int role) const {
+  if (!index.isValid()) {
+    return QVariant();
+  }
+
+  switch (role) {
+    case CategoryNameRole:
+      return QVariant(s_supportCategories.at(index.row()).m_categoryName);
+
+    case LocalizedNameRole:
+      return QVariant(qtTrId(s_supportCategories.at(index.row()).m_nameId));
+
+    default:
+      return QVariant();
+  }
+}

--- a/src/models/supportcategorymodel.cpp
+++ b/src/models/supportcategorymodel.cpp
@@ -5,6 +5,7 @@
 #include "supportcategorymodel.h"
 #include "leakdetector.h"
 #include "logger.h"
+#include "l18nstrings.h"
 
 namespace {
 Logger logger(LOG_MODEL, "SupportCategoryModel");
@@ -23,27 +24,41 @@ SupportCategoryModel::SupportCategoryModel() {
   // Here we use the logger to force lrelease to add the category ids.
 
   //% "Payment and billing"
-  logger.debug() << "Adding:" << qtTrId("support.category.paymentDropdownListItem");
+  logger.debug()
+      << "Adding:"
+      << L18nStrings::instance()->tr(
+             L18nStrings::InAppSupportWorkflowPaymentDropdownListItem);
   s_supportCategories.append(
       SupportCategory{"payment", "support.category.paymentDropdownListItem"});
 
   //% "Account issues"
-  logger.debug() << "Adding:" << qtTrId("support.category.accountDropdownListItem");
+  logger.debug()
+      << "Adding:"
+      << L18nStrings::instance()->tr(
+             L18nStrings::InAppSupportWorkflowAccountDropdownListItem);
   s_supportCategories.append(
       SupportCategory{"account", "support.category.accountDropdownListItem"});
 
   //% "Technical issues"
-  logger.debug() << "Adding:" << qtTrId("support.category.technicaDropdownListItem");
+  logger.debug()
+      << "Adding:"
+      << L18nStrings::instance()->tr(
+             L18nStrings::InAppSupportWorkflowTechnicaDropdownListItem);
   s_supportCategories.append(
       SupportCategory{"technical", "support.category.technicaDropdownListItem"});
 
   //% "Request features"
-  logger.debug() << "Adding:" << qtTrId("support.category.featureRequestDropdownListItem");
+  logger.debug()
+      << "Adding:"
+      << L18nStrings::instance()->tr(
+             L18nStrings::InAppSupportWorkflowFeatureRequestDropdownListItem);
   s_supportCategories.append(
       SupportCategory{"feature", "support.category.featureRequestDropdownListItem"});
 
   //% "Other"
-  logger.debug() << "Adding:" << qtTrId("support.category.otherDropdownListItem");
+  logger.debug() << "Adding:"
+                 << L18nStrings::instance()->tr(
+                        L18nStrings::InAppSupportWorkflowOtherDropdownListItem);
   s_supportCategories.append(
       SupportCategory{"other", "support.category.otherDropdownListItem"});
 }

--- a/src/models/supportcategorymodel.cpp
+++ b/src/models/supportcategorymodel.cpp
@@ -20,47 +20,6 @@ static QList<SupportCategory> s_supportCategories;
 
 SupportCategoryModel::SupportCategoryModel() {
   MVPN_COUNT_CTOR(SupportCategoryModel);
-
-  // Here we use the logger to force lrelease to add the category ids.
-
-  //% "Payment and billing"
-  logger.debug()
-      << "Adding:"
-      << L18nStrings::instance()->tr(
-             L18nStrings::InAppSupportWorkflowPaymentDropdownListItem);
-  s_supportCategories.append(
-      SupportCategory{"payment", "support.category.paymentDropdownListItem"});
-
-  //% "Account issues"
-  logger.debug()
-      << "Adding:"
-      << L18nStrings::instance()->tr(
-             L18nStrings::InAppSupportWorkflowAccountDropdownListItem);
-  s_supportCategories.append(
-      SupportCategory{"account", "support.category.accountDropdownListItem"});
-
-  //% "Technical issues"
-  logger.debug()
-      << "Adding:"
-      << L18nStrings::instance()->tr(
-             L18nStrings::InAppSupportWorkflowTechnicaDropdownListItem);
-  s_supportCategories.append(SupportCategory{
-      "technical", "support.category.technicaDropdownListItem"});
-
-  //% "Request features"
-  logger.debug()
-      << "Adding:"
-      << L18nStrings::instance()->tr(
-             L18nStrings::InAppSupportWorkflowFeatureRequestDropdownListItem);
-  s_supportCategories.append(SupportCategory{
-      "feature", "support.category.featureRequestDropdownListItem"});
-
-  //% "Other"
-  logger.debug() << "Adding:"
-                 << L18nStrings::instance()->tr(
-                        L18nStrings::InAppSupportWorkflowOtherDropdownListItem);
-  s_supportCategories.append(
-      SupportCategory{"other", "support.category.otherDropdownListItem"});
 }
 
 SupportCategoryModel::~SupportCategoryModel() {

--- a/src/models/supportcategorymodel.cpp
+++ b/src/models/supportcategorymodel.cpp
@@ -44,16 +44,16 @@ SupportCategoryModel::SupportCategoryModel() {
       << "Adding:"
       << L18nStrings::instance()->tr(
              L18nStrings::InAppSupportWorkflowTechnicaDropdownListItem);
-  s_supportCategories.append(
-      SupportCategory{"technical", "support.category.technicaDropdownListItem"});
+  s_supportCategories.append(SupportCategory{
+      "technical", "support.category.technicaDropdownListItem"});
 
   //% "Request features"
   logger.debug()
       << "Adding:"
       << L18nStrings::instance()->tr(
              L18nStrings::InAppSupportWorkflowFeatureRequestDropdownListItem);
-  s_supportCategories.append(
-      SupportCategory{"feature", "support.category.featureRequestDropdownListItem"});
+  s_supportCategories.append(SupportCategory{
+      "feature", "support.category.featureRequestDropdownListItem"});
 
   //% "Other"
   logger.debug() << "Adding:"

--- a/src/models/supportcategorymodel.h
+++ b/src/models/supportcategorymodel.h
@@ -1,0 +1,32 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef FEEDBACKCATEGORYMODEL_H
+#define FEEDBACKCATEGORYMODEL_H
+
+#include <QAbstractListModel>
+
+class SupportCategoryModel final : public QAbstractListModel {
+  Q_OBJECT
+  Q_DISABLE_COPY_MOVE(SupportCategoryModel)
+
+ public:
+  SupportCategoryModel();
+  ~SupportCategoryModel();
+
+  enum SupportCategoryRoles {
+    CategoryNameRole = Qt::UserRole + 1,
+    LocalizedNameRole,
+  };
+
+  // QAbstractListModel methods
+
+  QHash<int, QByteArray> roleNames() const override;
+
+  int rowCount(const QModelIndex&) const override;
+
+  QVariant data(const QModelIndex& index, int role) const override;
+};
+
+#endif  // FEEDBACKCATEGORYMODEL_H

--- a/src/models/supportcategorymodel.h
+++ b/src/models/supportcategorymodel.h
@@ -2,8 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#ifndef FEEDBACKCATEGORYMODEL_H
-#define FEEDBACKCATEGORYMODEL_H
+#ifndef SUPPORTCATEGORYMODEL_H
+#define SUPPORTCATEGORYMODEL_H
 
 #include <QAbstractListModel>
 
@@ -29,4 +29,4 @@ class SupportCategoryModel final : public QAbstractListModel {
   QVariant data(const QModelIndex& index, int role) const override;
 };
 
-#endif  // FEEDBACKCATEGORYMODEL_H
+#endif  // SUPPORTCATEGORYMODEL_H

--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -191,6 +191,8 @@ void MozillaVPN::initialize() {
   Q_ASSERT(m_state == StateInitialize);
 
   m_private->m_releaseMonitor.runSoon();
+    
+  scheduleTask(new TaskGetFeatureList());
 
   SettingsHolder* settingsHolder = SettingsHolder::instance();
   Q_ASSERT(settingsHolder);
@@ -279,8 +281,6 @@ void MozillaVPN::initialize() {
   scheduleTask(new TaskAccountAndServers());
 
   scheduleTask(new TaskCaptivePortalLookup());
-
-  scheduleTask(new TaskGetFeatureList());
 
   if (FeatureList::instance()->inAppPurchaseSupported()) {
     scheduleTask(new TaskProducts());

--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -191,7 +191,7 @@ void MozillaVPN::initialize() {
   Q_ASSERT(m_state == StateInitialize);
 
   m_private->m_releaseMonitor.runSoon();
-    
+
   scheduleTask(new TaskGetFeatureList());
 
   SettingsHolder* settingsHolder = SettingsHolder::instance();

--- a/src/mozillavpn.h
+++ b/src/mozillavpn.h
@@ -144,6 +144,10 @@ class MozillaVPN final : public QObject {
   Q_INVOKABLE void submitFeedback(const QString& feedbackText,
                                   const qint8 rating, const QString& category);
   Q_INVOKABLE void appReviewRequested();
+  Q_INVOKABLE void createSupportTicket(const QString& email,
+                                       const QString& subject,
+                                       const QString& issueText,
+                                       const QString& category);
 
   // Internal object getters:
   CaptivePortal* captivePortal() { return &m_private->m_captivePortal; }
@@ -246,6 +250,10 @@ class MozillaVPN final : public QObject {
     emit currentViewChanged();
   }
 
+  void createTicketAnswerRecieved(bool successful) {
+    emit ticketCreationAnswer(successful);
+  }
+
  private:
   void setState(State state);
 
@@ -286,6 +294,7 @@ class MozillaVPN final : public QObject {
   void requestSettings();
   void requestAbout();
   void requestViewLogs();
+  void requestContactUs();
 
  private slots:
   void taskCompleted();
@@ -299,6 +308,7 @@ class MozillaVPN final : public QObject {
   void settingsNeeded();
   void aboutNeeded();
   void viewLogsNeeded();
+  void contactUsNeeded();
   void updatingChanged();
 
   // For Glean
@@ -314,6 +324,8 @@ class MozillaVPN final : public QObject {
   void logsReady(const QString& logs);
 
   void currentViewChanged();
+
+  void ticketCreationAnswer(bool successful);
 
  private:
   bool m_initialized = false;

--- a/src/mozillavpn.h
+++ b/src/mozillavpn.h
@@ -18,6 +18,7 @@
 #include "models/keys.h"
 #include "models/servercountrymodel.h"
 #include "models/serverdata.h"
+#include "models/supportcategorymodel.h"
 #include "models/surveymodel.h"
 #include "models/user.h"
 #include "networkwatcher.h"
@@ -168,6 +169,9 @@ class MozillaVPN final : public QObject {
   DeviceModel* deviceModel() { return &m_private->m_deviceModel; }
   FeedbackCategoryModel* feedbackCategoryModel() {
     return &m_private->m_feedbackCategoryModel;
+  }
+  SupportCategoryModel* supportCategoryModel() {
+    return &m_private->m_supportCategoryModel;
   }
   Keys* keys() { return &m_private->m_keys; }
   HelpModel* helpModel() { return &m_private->m_helpModel; }
@@ -340,6 +344,7 @@ class MozillaVPN final : public QObject {
     Controller m_controller;
     DeviceModel m_deviceModel;
     FeedbackCategoryModel m_feedbackCategoryModel;
+    SupportCategoryModel m_supportCategoryModel;
     Keys m_keys;
     HelpModel m_helpModel;
     NetworkWatcher m_networkWatcher;

--- a/src/networkrequest.cpp
+++ b/src/networkrequest.cpp
@@ -328,6 +328,46 @@ NetworkRequest* NetworkRequest::createForFeedback(QObject* parent,
   return r;
 }
 
+NetworkRequest* NetworkRequest::createForSupportTicket(
+    QObject* parent, const QString& email, const QString& subject,
+    const QString& issueText, const QString& logs, const QString& category) {
+  NetworkRequest* r = new NetworkRequest(parent, 201, true);
+
+  QUrl url(apiBaseUrl());
+  url.setPath("/api/v1/vpn/createSupportTicket");
+  r->m_request.setUrl(url);
+
+  r->m_request.setHeader(QNetworkRequest::ContentTypeHeader,
+                         "application/json");
+
+  QJsonObject obj;
+  obj.insert("email", email);
+  obj.insert("logs", logs);
+  obj.insert("versionString", MozillaVPN::instance()->versionString());
+  obj.insert("platformVersion", QString(NetworkManager::osVersion()));
+  obj.insert("subject", subject);
+  obj.insert("issueText", issueText);
+  obj.insert("category", category);
+
+  QJsonDocument json;
+  json.setObject(obj);
+
+  r->postRequest(json.toJson(QJsonDocument::Compact));
+  return r;
+}
+
+// static
+NetworkRequest* NetworkRequest::createForGetFeatureList(QObject* parent) {
+  NetworkRequest* r = new NetworkRequest(parent, 200, false);
+
+  QUrl url(apiBaseUrl());
+  url.setPath("/api/v1/featureList");
+  r->m_request.setUrl(url);
+
+  r->getRequest();
+  return r;
+}
+
 // static
 NetworkRequest* NetworkRequest::createForFxaAccountStatus(
     QObject* parent, const QString& emailAddress) {

--- a/src/networkrequest.cpp
+++ b/src/networkrequest.cpp
@@ -361,7 +361,7 @@ NetworkRequest* NetworkRequest::createForGetFeatureList(QObject* parent) {
   NetworkRequest* r = new NetworkRequest(parent, 200, false);
 
   QUrl url(apiBaseUrl());
-  url.setPath("/api/v1/featureList");
+  url.setPath("/api/v1/featurelist");
   r->m_request.setUrl(url);
 
   r->getRequest();

--- a/src/networkrequest.h
+++ b/src/networkrequest.h
@@ -61,6 +61,12 @@ class NetworkRequest final : public QObject {
                                            const qint8 rating,
                                            const QString& category);
 
+  static NetworkRequest* createForSupportTicket(
+      QObject* parent, const QString& email, const QString& subject,
+      const QString& issueText, const QString& logs, const QString& category);
+
+  static NetworkRequest* createForGetFeatureList(QObject* parent);
+
   static NetworkRequest* createForFxaAccountStatus(QObject* parent,
                                                    const QString& emailAddress);
 

--- a/src/platforms/wasm/wasmnetworkrequest.cpp
+++ b/src/platforms/wasm/wasmnetworkrequest.cpp
@@ -192,6 +192,22 @@ NetworkRequest* NetworkRequest::createForFeedback(QObject* parent,
 }
 
 // static
+NetworkRequest* NetworkRequest::createForSupportTicket(
+    QObject* parent, const QString& email, const QString& subject,
+    const QString& issueText, const QString& logs, const QString& category) {
+  Q_UNUSED(parent);
+  Q_UNUSED(email);
+  Q_UNUSED(subject);
+  Q_UNUSED(issueText);
+  Q_UNUSED(logs);
+  Q_UNUSED(category);
+
+  NetworkRequest* r = new NetworkRequest(parent, 200, false);
+  createDummyRequest(r);
+  return r;
+}
+
+// static
 NetworkRequest* NetworkRequest::createForFxaAccountStatus(
     QObject* parent, const QString& emailAddress) {
   Q_ASSERT(parent);

--- a/src/platforms/wasm/wasmnetworkrequest.cpp
+++ b/src/platforms/wasm/wasmnetworkrequest.cpp
@@ -208,6 +208,13 @@ NetworkRequest* NetworkRequest::createForSupportTicket(
 }
 
 // static
+NetworkRequest* NetworkRequest::createForGetFeatureList(QObject* parent) {
+  NetworkRequest* r = new NetworkRequest(parent, 200, false);
+  createDummyRequest(r);
+  return r;
+}
+
+// static
 NetworkRequest* NetworkRequest::createForFxaAccountStatus(
     QObject* parent, const QString& emailAddress) {
   Q_ASSERT(parent);

--- a/src/qml.qrc
+++ b/src/qml.qrc
@@ -392,6 +392,7 @@
         <file>ui/components/VPNAboutUs.qml</file>
         <file>ui/components/VPNRemoveDevicePopup.qml</file>
         <file>ui/views/ViewLogs.qml</file>
+        <file>ui/views/ViewContactUs.qml</file>
         <file>ui/components/VPNStackView.qml</file>
         <file>ui/components/VPNFocusOutline.qml</file>
         <file>ui/components/VPNMouseArea.qml</file>

--- a/src/src.pro
+++ b/src/src.pro
@@ -115,6 +115,7 @@ SOURCES += \
         models/servercountry.cpp \
         models/servercountrymodel.cpp \
         models/serverdata.cpp \
+        models/supportcategorymodel.cpp \
         models/survey.cpp \
         models/surveymodel.cpp \
         models/user.cpp \
@@ -223,6 +224,7 @@ HEADERS += \
         models/servercountry.h \
         models/servercountrymodel.h \
         models/serverdata.h \
+        models/supportcategorymodel.h \
         models/survey.h \
         models/surveymodel.h \
         models/user.h \

--- a/src/src.pro
+++ b/src/src.pro
@@ -143,13 +143,15 @@ SOURCES += \
         tasks/adddevice/taskadddevice.cpp \
         tasks/authenticate/taskauthenticate.cpp \
         tasks/captiveportallookup/taskcaptiveportallookup.cpp \
+        tasks/getfeaturelist/taskgetfeaturelist.cpp \
         tasks/controlleraction/taskcontrolleraction.cpp \
+        tasks/createsupportticket/taskcreatesupportticket.cpp \
         tasks/function/taskfunction.cpp \
         tasks/heartbeat/taskheartbeat.cpp \
         tasks/products/taskproducts.cpp \
         tasks/removedevice/taskremovedevice.cpp \
-        tasks/surveydata/tasksurveydata.cpp \
         tasks/sendfeedback/tasksendfeedback.cpp \
+        tasks/surveydata/tasksurveydata.cpp \
         timercontroller.cpp \
         timersingleshot.cpp \
         update/updater.cpp \
@@ -251,11 +253,14 @@ HEADERS += \
         tasks/adddevice/taskadddevice.h \
         tasks/authenticate/taskauthenticate.h \
         tasks/captiveportallookup/taskcaptiveportallookup.h \
+        tasks/getfeaturelist/taskgetfeaturelist.h \
         tasks/controlleraction/taskcontrolleraction.h \
+        tasks/createsupportticket/taskcreatesupportticket.h \
         tasks/function/taskfunction.h \
         tasks/heartbeat/taskheartbeat.h \
         tasks/products/taskproducts.h \
         tasks/removedevice/taskremovedevice.h \
+        tasks/sendfeedback/tasksendfeedback.h \
         tasks/surveydata/tasksurveydata.h \
         timercontroller.h \
         timersingleshot.h \

--- a/src/tasks/createsupportticket/taskcreatesupportticket.cpp
+++ b/src/tasks/createsupportticket/taskcreatesupportticket.cpp
@@ -1,0 +1,59 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "taskcreatesupportticket.h"
+#include "errorhandler.h"
+#include "leakdetector.h"
+#include "logger.h"
+#include "models/user.h"
+#include "networkrequest.h"
+
+constexpr uint32_t SUPPORT_TICKET_SUBJECT_MAX_LENGTH = 300;
+
+constexpr uint32_t SUPPORT_TICKET_MESSAGE_MAX_LENGTH = 1000;
+
+constexpr uint32_t SUPPORT_TICKET_LOG_MAX_LENGTH = 100000;
+
+namespace {
+Logger logger(LOG_MAIN, "TaskCreateSupportTicket");
+}
+
+TaskCreateSupportTicket::TaskCreateSupportTicket(const QString& email,
+                                                 const QString& subject,
+                                                 const QString& issueText,
+                                                 const QString& logs,
+                                                 const QString& category)
+    : Task("TaskCreateSupportTicket"),
+      m_email(email),
+      m_subject(subject.left(SUPPORT_TICKET_SUBJECT_MAX_LENGTH)),
+      m_issueText(issueText.left(SUPPORT_TICKET_MESSAGE_MAX_LENGTH)),
+      m_logs(logs.right(SUPPORT_TICKET_LOG_MAX_LENGTH)),
+      m_category(category) {
+  MVPN_COUNT_CTOR(TaskCreateSupportTicket);
+}
+
+TaskCreateSupportTicket::~TaskCreateSupportTicket() {
+  MVPN_COUNT_DTOR(TaskCreateSupportTicket);
+}
+
+void TaskCreateSupportTicket::run(MozillaVPN* vpn) {
+  logger.debug() << "Sending the support ticket";
+
+  NetworkRequest* request = NetworkRequest::createForSupportTicket(
+      this, m_email, m_subject, m_issueText, m_logs, m_category);
+
+  connect(request, &NetworkRequest::requestFailed,
+          [this, vpn](QNetworkReply::NetworkError error, const QByteArray&) {
+            logger.error() << "Failed to create support ticket" << error;
+            vpn->createTicketAnswerRecieved(false);
+            emit completed();
+          });
+
+  connect(request, &NetworkRequest::requestCompleted,
+          [this, vpn](const QByteArray&) {
+            logger.debug() << "Support ticket created";
+            vpn->createTicketAnswerRecieved(true);
+            emit completed();
+          });
+}

--- a/src/tasks/createsupportticket/taskcreatesupportticket.h
+++ b/src/tasks/createsupportticket/taskcreatesupportticket.h
@@ -14,10 +14,10 @@ class TaskCreateSupportTicket final : public Task {
   Q_DISABLE_COPY_MOVE(TaskCreateSupportTicket)
 
  public:
-  explicit TaskCreateSupportTicket(const QString& email, const QString& subject,
-                                   const QString& issueText,
-                                   const QString& logs,
-                                   const QString& category);
+  TaskCreateSupportTicket(const QString& email, const QString& subject,
+                          const QString& issueText,
+                          const QString& logs,
+                          const QString& category);
   ~TaskCreateSupportTicket();
 
   void run(MozillaVPN* vpn) override;

--- a/src/tasks/createsupportticket/taskcreatesupportticket.h
+++ b/src/tasks/createsupportticket/taskcreatesupportticket.h
@@ -15,8 +15,7 @@ class TaskCreateSupportTicket final : public Task {
 
  public:
   TaskCreateSupportTicket(const QString& email, const QString& subject,
-                          const QString& issueText,
-                          const QString& logs,
+                          const QString& issueText, const QString& logs,
                           const QString& category);
   ~TaskCreateSupportTicket();
 

--- a/src/tasks/createsupportticket/taskcreatesupportticket.h
+++ b/src/tasks/createsupportticket/taskcreatesupportticket.h
@@ -1,0 +1,33 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef TASKCREATESUPPORTTICKET_H
+#define TASKCREATESUPPORTTICKET_H
+
+#include "task.h"
+#include "mozillavpn.h"
+
+#include <QObject>
+
+class TaskCreateSupportTicket final : public Task {
+  Q_DISABLE_COPY_MOVE(TaskCreateSupportTicket)
+
+ public:
+  explicit TaskCreateSupportTicket(const QString& email, const QString& subject,
+                                   const QString& issueText,
+                                   const QString& logs,
+                                   const QString& category);
+  ~TaskCreateSupportTicket();
+
+  void run(MozillaVPN* vpn) override;
+
+ private:
+  QString m_email;
+  QString m_subject;
+  QString m_issueText;
+  QString m_logs;
+  QString m_category;
+};
+
+#endif  // TASKCREATESUPPORTTICKET_H

--- a/src/tasks/getfeaturelist/taskgetfeaturelist.cpp
+++ b/src/tasks/getfeaturelist/taskgetfeaturelist.cpp
@@ -36,9 +36,9 @@ void TaskGetFeatureList::run(MozillaVPN* vpn) {
           });
 
   connect(request, &NetworkRequest::requestCompleted,
-      [this](const QByteArray& data) {
-        logger.debug() << "Get feature list is completed" << data;
-        FeatureList::instance()->updateFeatureList(data);
-        emit completed();
-      });
+    [this](const QByteArray& data) {
+      logger.debug() << "Get feature list is completed" << data;
+      FeatureList::instance()->updateFeatureList(data);
+      emit completed();
+    });
 }

--- a/src/tasks/getfeaturelist/taskgetfeaturelist.cpp
+++ b/src/tasks/getfeaturelist/taskgetfeaturelist.cpp
@@ -1,0 +1,48 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "taskgetfeaturelist.h"
+#include "leakdetector.h"
+#include "errorhandler.h"
+#include "logger.h"
+#include "featurelist.h"
+#include "networkrequest.h"
+
+#include <QJsonDocument>
+#include <QJsonObject>
+
+namespace {
+Logger logger(LOG_MAIN, "TaskGetFeatureList");
+}
+
+TaskGetFeatureList::TaskGetFeatureList()
+    : Task("TaskGetFeatureList") {
+  MVPN_COUNT_CTOR(TaskGetFeatureList);
+}
+
+TaskGetFeatureList::~TaskGetFeatureList() {
+  MVPN_COUNT_DTOR(TaskGetFeatureList);
+}
+
+void TaskGetFeatureList::run(MozillaVPN* vpn) {
+  Q_UNUSED(vpn);
+
+  NetworkRequest* request = NetworkRequest::createForGetFeatureList(this);
+
+  connect(request, &NetworkRequest::requestFailed,
+          [this](QNetworkReply::NetworkError error, const QByteArray&) {
+            logger.error() << "Get feature list is failed"
+                           << error;
+            emit completed();
+          });
+
+  connect(
+      request, &NetworkRequest::requestCompleted,
+      [this](const QByteArray& data) {
+        logger.debug() << "Get feature list is completed"
+                       << data;
+        FeatureList::instance()->updateFeatureList(data);
+        emit completed();
+      });
+}

--- a/src/tasks/getfeaturelist/taskgetfeaturelist.cpp
+++ b/src/tasks/getfeaturelist/taskgetfeaturelist.cpp
@@ -16,8 +16,7 @@ namespace {
 Logger logger(LOG_MAIN, "TaskGetFeatureList");
 }
 
-TaskGetFeatureList::TaskGetFeatureList()
-    : Task("TaskGetFeatureList") {
+TaskGetFeatureList::TaskGetFeatureList() : Task("TaskGetFeatureList") {
   MVPN_COUNT_CTOR(TaskGetFeatureList);
 }
 
@@ -32,16 +31,13 @@ void TaskGetFeatureList::run(MozillaVPN* vpn) {
 
   connect(request, &NetworkRequest::requestFailed,
           [this](QNetworkReply::NetworkError error, const QByteArray&) {
-            logger.error() << "Get feature list is failed"
-                           << error;
+            logger.error() << "Get feature list is failed" << error;
             emit completed();
           });
 
-  connect(
-      request, &NetworkRequest::requestCompleted,
+  connect(request, &NetworkRequest::requestCompleted,
       [this](const QByteArray& data) {
-        logger.debug() << "Get feature list is completed"
-                       << data;
+        logger.debug() << "Get feature list is completed" << data;
         FeatureList::instance()->updateFeatureList(data);
         emit completed();
       });

--- a/src/tasks/getfeaturelist/taskgetfeaturelist.cpp
+++ b/src/tasks/getfeaturelist/taskgetfeaturelist.cpp
@@ -36,9 +36,9 @@ void TaskGetFeatureList::run(MozillaVPN* vpn) {
           });
 
   connect(request, &NetworkRequest::requestCompleted,
-    [this](const QByteArray& data) {
-      logger.debug() << "Get feature list is completed" << data;
-      FeatureList::instance()->updateFeatureList(data);
-      emit completed();
-    });
+          [this](const QByteArray& data) {
+            logger.debug() << "Get feature list is completed" << data;
+            FeatureList::instance()->updateFeatureList(data);
+            emit completed();
+          });
 }

--- a/src/tasks/getfeaturelist/taskgetfeaturelist.h
+++ b/src/tasks/getfeaturelist/taskgetfeaturelist.h
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef TASKCHECKUNAUTHSUPPORTENABLED_H
+#define TASKCHECKUNAUTHSUPPORTENABLED_H
+
+#include "task.h"
+#include "mozillavpn.h"
+
+#include <QObject>
+
+class TaskGetFeatureList final : public Task {
+  Q_DISABLE_COPY_MOVE(TaskGetFeatureList)
+
+ public:
+  explicit TaskGetFeatureList();
+  ~TaskGetFeatureList();
+
+  void run(MozillaVPN* vpn) override;
+};
+
+#endif  // TASKCHECKUNAUTHSUPPORTENABLED_H

--- a/src/tasks/getfeaturelist/taskgetfeaturelist.h
+++ b/src/tasks/getfeaturelist/taskgetfeaturelist.h
@@ -2,8 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#ifndef TASKCHECKUNAUTHSUPPORTENABLED_H
-#define TASKCHECKUNAUTHSUPPORTENABLED_H
+#ifndef TASKGETFEATURELIST_H
+#define TASKGETFEATURELIST_H
 
 #include "task.h"
 #include "mozillavpn.h"
@@ -14,10 +14,10 @@ class TaskGetFeatureList final : public Task {
   Q_DISABLE_COPY_MOVE(TaskGetFeatureList)
 
  public:
-  explicit TaskGetFeatureList();
+  TaskGetFeatureList();
   ~TaskGetFeatureList();
 
   void run(MozillaVPN* vpn) override;
 };
 
-#endif  // TASKCHECKUNAUTHSUPPORTENABLED_H
+#endif  // TASKGETFEATURELIST_H

--- a/src/ui/main.qml
+++ b/src/ui/main.qml
@@ -289,6 +289,10 @@ Window {
             }
         }
 
+        function onContactUsNeeded() {
+            mainStackView.push("views/ViewContactUs.qml");
+        }
+
         function onLoadAndroidAuthenticationView() {
             if (Qt.platform.os !== "android") {
                 console.log("Unexpected android authentication view request!");

--- a/src/ui/views/ViewContactUs.qml
+++ b/src/ui/views/ViewContactUs.qml
@@ -1,0 +1,339 @@
+
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import QtQuick 2.5
+
+import QtQuick.Controls 2.14
+import QtQuick.Layouts 1.14
+import Mozilla.VPN 1.0
+
+import "../components"
+import "../components/forms"
+import "../themes/themes.js" as Theme
+
+Item {
+    id: contactUsRoot
+
+    function tryAgain() {
+        contactUsStackView.pop();
+        contactUsStackView.pop();
+    }
+
+
+    function createSupportTicket(email, subject, issueText, category) {
+        contactUsStackView.push("../components/VPNLoader.qml", {
+            footerLinkIsVisible: false
+        });
+        VPN.createSupportTicket(email, subject, issueText, category);
+    }
+
+    VPNMenu {
+        id: menu
+        title: qsTrId("help.contactUs")
+        isMainView: true
+    }
+
+    StackView {
+        initialItem: contactUsView
+        id: contactUsStackView
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.bottom: parent.bottom
+        anchors.top: menu.bottom
+
+        Connections {
+            target: VPN
+            function onTicketCreationAnswer(successful) {
+                if(successful) {
+                    contactUsStackView.push(thankYouView);
+                } else {
+                    contactUsStackView.push("../views/ViewErrorFullScreen.qml", {
+                        //% "Error submitting your support request..."
+                        headlineText: qsTrId("vpn.contactUs.errorTitle"),
+
+                        //% "An unexpected error has occured, please try again."
+                        errorMessage:qsTrId("vpn.contactUs.unexpectedError"),
+
+                        //% "Try again"
+                        buttonText: qsTrId("vpn.contactUs.tryagain"),
+                        buttonOnClick: contactUsRoot.tryAgain,
+                        buttonObjectName: "errorTryAgainButton"
+                        }
+                    );
+                }
+            }
+        }
+    }
+
+    Component {
+        id: contactUsView
+        VPNFlickable {
+            id: vpnFlickable
+            property var appRating
+            property var feedbackCategory
+            flickContentHeight: col.childrenRect.height
+            interactive: flickContentHeight > height
+
+            Rectangle {
+                anchors.fill: parent
+                color: Theme.bgColor
+            }
+
+            ColumnLayout {
+                id: col
+
+                anchors.left: parent.left
+                anchors.right: parent.right
+                anchors.top: parent.top
+                spacing: Theme.windowMargin
+                anchors.margins: Theme.windowMargin * 2
+                anchors.topMargin: window.fullscreenRequired() ? Theme.contentTopMarginMobile : Theme.contentTopMarginDesktop
+
+
+                ColumnLayout {
+                    Layout.alignment: Qt.AlignTop
+                    Layout.preferredWidth: parent.width
+
+                    spacing: 24
+
+                    ColumnLayout {
+                        Layout.fillHeight: true
+                        spacing: 24
+                        visible: !VPN.userAuthenticated
+
+                        ColumnLayout {
+                            spacing: 10
+                            VPNBoldLabel {
+                                //% "Enter your email"
+                                property string enterEmailAddress: qsTrId("vpn.contactUs.enterEmailAddress")
+
+                                text: enterEmailAddress
+                                lineHeight: 10
+                                lineHeightMode: Text.FixedHeight
+                                wrapMode: Text.WordWrap
+                                verticalAlignment: Text.AlignVCenter
+                                Layout.fillWidth: true
+                            }
+
+                            VPNTextField {
+                                id: emailInput
+
+                                width: parent.width
+                                verticalAlignment: Text.AlignVCenter
+                                Layout.fillWidth: true
+                                hasError: !VPNAuthInApp.validateEmailAddress(emailInput.text)
+                                //% "Email address"
+                                placeholderText: qsTrId("vpn.contactUs.emailAddress")
+                            }
+                        }
+
+                        VPNTextField {
+                            id: confirmEmailInput
+
+                            width: parent.width
+                            verticalAlignment: Text.AlignVCenter
+                            Layout.fillWidth: true
+                            hasError: emailInput.text != confirmEmailInput.text
+                            //% "Confirm email address"
+                            placeholderText: qsTrId("vpn.contactUs.confirmEmailAddress")
+                        }
+                    }
+
+                    ColumnLayout {
+                        RowLayout {
+                        spacing: 15
+                        Layout.fillWidth: true
+                        Layout.bottomMargin: 15
+
+                        Rectangle {
+                            Layout.preferredWidth: 40
+                            Layout.preferredHeight: 40
+                            color: "transparent"
+
+                            VPNAvatar {
+                                id: avatar
+
+                                avatarUrl: VPNUser.avatar
+                                anchors.fill: parent
+                            }
+                        }
+
+                        ColumnLayout {
+
+                            VPNBoldLabel {
+                                //% "VPN User"
+                                readonly property var textVpnUser: qsTrId("vpn.settings.user")
+                                text: VPNUser.displayName ? VPNUser.displayName : textVpnUser
+
+                            }
+
+
+                            VPNLightLabel {
+                                id: serverLocation
+                                text: VPNUser.email
+                                Accessible.ignored: true
+                                Layout.alignment: Qt.AlignLeft
+                                elide: Text.ElideRight
+                            }
+                        }
+                    }
+
+                        spacing: 10
+
+                        VPNBoldLabel {
+                            //% "How can we help you with Mozilla VPN?"
+                            property string enterEmailAddress: qsTrId("vpn.contactUs.howCanWeHelp")
+
+                            text: enterEmailAddress
+                            lineHeight: 10
+                            lineHeightMode: Text.FixedHeight
+                            wrapMode: Text.WordWrap
+                            verticalAlignment: Text.AlignVCenter
+                            Layout.fillWidth: true
+                        }
+
+                        VPNComboBox {
+                            id: dropDown
+                            placeholderText: VPNl18n.tr(VPNl18n.ContactUsFormChooseCategory)
+                            model: VPNFeedbackCategoryModel
+                        }
+                    }
+
+                    VPNTextField {
+                        id: subjectInput
+
+                        width: parent.width
+                        verticalAlignment: Text.AlignVCenter
+                        Layout.fillWidth: true
+                        //% "Subject (optional)"
+                        placeholderText: qsTrId("vpn.contactUs.subject")
+                    }
+
+                    VPNTextArea {
+                        id: textArea
+                        //% "Describe issue..."
+                        placeholderText: qsTrId("vpn.contactUs.textAreaPlaceholder")
+                    }
+                }
+
+                ColumnLayout {
+                    Layout.fillHeight: true
+                    spacing: 24
+
+                    VPNVerticalSpacer {
+                        Layout.fillWidth: true
+                        Layout.minimumHeight: 16
+                        Layout.fillHeight: !window.fullscreenRequired()
+                    }
+
+                    Column {
+                        spacing: 0
+                        Layout.fillWidth: true
+
+
+                        VPNTextBlock {
+                            font.pixelSize: Theme.fontSize
+                            horizontalAlignment: Text.AlignHCenter
+                            //% "When you submit, Mozilla VPN will collect technical and interaction data with your email to help our support team understand your issue."
+                            text: qsTrId("vpn.contactUs.privacyDisclaimer")
+                            width:parent.width
+                        }
+
+                        VPNLinkButton {
+                            //% "Mozilla VPN Privacy Notice"
+                            labelText: qsTrId("vpn.contactUs.privacyNoticeLink")
+                            Layout.alignment: Qt.AlignHCenter
+                            onClicked: VPN.openLink(VPN.LinkPrivacyNotice)
+                            width: parent.width
+                        }
+                    }
+
+                    ColumnLayout {
+                        spacing: Theme.windowMargin
+
+                        VPNButton {
+                             //% "Submit"
+                            text: qsTrId("vpn.contactUs.submit")
+                            onClicked: contactUsRoot.createSupportTicket(emailInput.text, subjectInput.text, textArea.userEntry, dropDown.currentValue);
+                            enabled: dropDown.currentValue != null && textArea.userEntry != "" &&
+                                     (VPN.userAuthenticated ? true :
+                                        (VPNAuthInApp.validateEmailAddress(emailInput.text) && emailInput.text == confirmEmailInput.text)
+                                     )
+                            opacity: enabled ? 1 : .5
+                            Layout.preferredHeight: Theme.rowHeight
+                            Layout.fillWidth: true
+                            width: undefined
+                            height: undefined
+                            Behavior on opacity {
+                                PropertyAnimation {
+                                    duration: 100
+                                }
+                            }
+                        }
+                        VPNLinkButton {
+                            //% "Cancel"
+                            labelText: qsTrId("vpn.contactUs.cancel")
+                            Layout.preferredHeight: Theme.rowHeight
+                            Layout.alignment: Qt.AlignHCenter
+                            onClicked: mainStackView.pop()
+                            implicitHeight: Theme.rowHeight
+
+                        }
+                    }
+                    VPNVerticalSpacer {
+                        Layout.fillWidth: true
+                        Layout.fillHeight: true
+                        Layout.minimumHeight: Theme.rowHeight * 2
+                        Layout.maximumHeight: Layout.minimumHeight
+                    }
+                }
+            }
+        }
+    }
+
+    Item {
+        id: spinnerRoot
+        anchors.fill: parent
+    }
+
+    Component {
+        id: thankYouView
+        Item {
+            ColumnLayout {
+                id: col
+                anchors.top: parent.top
+                anchors.topMargin: window.height * .10
+                anchors.horizontalCenter: parent.horizontalCenter
+                width: Math.min(Theme.maxHorizontalContentWidth, parent.width - Theme.windowMargin * 4)
+                VPNPanel {
+                    id: panel
+                    logo: "../resources/heart-check.svg"
+                    //% "Thank you!"
+                    logoTitle: qsTrId("vpn.contactUs.thankyou")
+                    //% "We appreciate your feedback. You’re helping us improve Mozilla VPN."
+                    logoSubtitle: qsTrId("vpn.contactUs.thankyouSubtitle")
+                    anchors.horizontalCenter: undefined
+                    Layout.fillWidth: true
+                }
+            }
+            VPNButton {
+                //% "Done"
+               text: qsTrId("vpn.contactUs.done")
+               anchors.top: col.bottom
+               anchors.topMargin: Theme.vSpacing
+               anchors.horizontalCenter: parent.horizontalCenter
+               onClicked: mainStackView.pop()
+               Component.onCompleted: {
+                 if (window.fullscreenRequired()) {
+                     anchors.top = undefined;
+                     anchors.topMargin = undefined;
+                     anchors.bottom= parent.bottom
+                     anchors.bottomMargin = Theme.windowMargin * 4
+                 }
+               }
+            }
+        }
+    }
+}

--- a/src/ui/views/ViewContactUs.qml
+++ b/src/ui/views/ViewContactUs.qml
@@ -1,5 +1,3 @@
-
-
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
@@ -135,7 +133,7 @@ Item {
                             width: parent.width
                             verticalAlignment: Text.AlignVCenter
                             Layout.fillWidth: true
-                            hasError: emailInput.text != confirmEmailInput.text
+                            hasError: !VPNAuthInApp.validateEmailAddress(confirmEmailInput.text) && emailInput.text != confirmEmailInput.text
                             //% "Confirm email address"
                             placeholderText: qsTrId("vpn.contactUs.confirmEmailAddress")
                         }

--- a/src/ui/views/ViewContactUs.qml
+++ b/src/ui/views/ViewContactUs.qml
@@ -143,42 +143,43 @@ Item {
 
                     ColumnLayout {
                         RowLayout {
-                        spacing: 15
-                        Layout.fillWidth: true
-                        Layout.bottomMargin: 15
+                            visible: VPN.userAuthenticated
+                            spacing: 15
+                            Layout.fillWidth: true
+                            Layout.bottomMargin: 15
 
-                        Rectangle {
-                            Layout.preferredWidth: 40
-                            Layout.preferredHeight: 40
-                            color: "transparent"
+                            Rectangle {
+                                Layout.preferredWidth: 40
+                                Layout.preferredHeight: 40
+                                color: "transparent"
 
-                            VPNAvatar {
-                                id: avatar
+                                VPNAvatar {
+                                    id: avatar
 
-                                avatarUrl: VPNUser.avatar
-                                anchors.fill: parent
+                                    avatarUrl: VPNUser.avatar
+                                    anchors.fill: parent
+                                }
+                            }
+
+                            ColumnLayout {
+
+                                VPNBoldLabel {
+                                    //% "VPN User"
+                                    readonly property var textVpnUser: qsTrId("vpn.settings.user")
+                                    text: VPNUser.displayName ? VPNUser.displayName : textVpnUser
+
+                                }
+
+
+                                VPNLightLabel {
+                                    id: serverLocation
+                                    text: VPNUser.email
+                                    Accessible.ignored: true
+                                    Layout.alignment: Qt.AlignLeft
+                                    elide: Text.ElideRight
+                                }
                             }
                         }
-
-                        ColumnLayout {
-
-                            VPNBoldLabel {
-                                //% "VPN User"
-                                readonly property var textVpnUser: qsTrId("vpn.settings.user")
-                                text: VPNUser.displayName ? VPNUser.displayName : textVpnUser
-
-                            }
-
-
-                            VPNLightLabel {
-                                id: serverLocation
-                                text: VPNUser.email
-                                Accessible.ignored: true
-                                Layout.alignment: Qt.AlignLeft
-                                elide: Text.ElideRight
-                            }
-                        }
-                    }
 
                         spacing: 10
 

--- a/src/ui/views/ViewContactUs.qml
+++ b/src/ui/views/ViewContactUs.qml
@@ -29,7 +29,8 @@ Item {
 
     VPNMenu {
         id: menu
-        title: qsTrId("help.contactUs")
+        //% "Contact support"
+        title: VPNl18n.tr(VPNl18n.InAppSupportWorkflowSupportNavLinkText)
         isMainView: true
     }
 
@@ -49,13 +50,13 @@ Item {
                 } else {
                     contactUsStackView.push("../views/ViewErrorFullScreen.qml", {
                         //% "Error submitting your support request..."
-                        headlineText: qsTrId("vpn.contactUs.errorTitle"),
+                        headlineText: VPNl18n.tr(VPNl18n.InAppSupportWorkflowSupportErrorHeader),
 
                         //% "An unexpected error has occured, please try again."
-                        errorMessage:qsTrId("vpn.contactUs.unexpectedError"),
+                        errorMessage: VPNl18n.tr(VPNl18n.InAppSupportWorkflowSupportErrorText),
 
                         //% "Try again"
-                        buttonText: qsTrId("vpn.contactUs.tryagain"),
+                        buttonText: VPNl18n.tr(VPNl18n.InAppSupportWorkflowSupportErrorButton),
                         buttonOnClick: contactUsRoot.tryAgain,
                         buttonObjectName: "errorTryAgainButton"
                         }
@@ -105,7 +106,7 @@ Item {
                             spacing: 10
                             VPNBoldLabel {
                                 //% "Enter your email"
-                                property string enterEmailAddress: qsTrId("vpn.contactUs.enterEmailAddress")
+                                property string enterEmailAddress: VPNl18n.tr(VPNl18n.InAppSupportWorkflowSupportEmailFieldLabel)
 
                                 text: enterEmailAddress
                                 lineHeight: 10
@@ -123,7 +124,7 @@ Item {
                                 Layout.fillWidth: true
                                 hasError: !VPNAuthInApp.validateEmailAddress(emailInput.text)
                                 //% "Email address"
-                                placeholderText: qsTrId("vpn.contactUs.emailAddress")
+                                placeholderText: VPNl18n.tr(VPNl18n.InAppSupportWorkflowSupportFieldPlaceholder)
                             }
                         }
 
@@ -135,7 +136,7 @@ Item {
                             Layout.fillWidth: true
                             hasError: !VPNAuthInApp.validateEmailAddress(confirmEmailInput.text) && emailInput.text != confirmEmailInput.text
                             //% "Confirm email address"
-                            placeholderText: qsTrId("vpn.contactUs.confirmEmailAddress")
+                            placeholderText: VPNl18n.tr(VPNl18n.InAppSupportWorkflowSupportConfirmEmailPlaceholder)
                         }
                     }
 
@@ -183,7 +184,7 @@ Item {
 
                         VPNBoldLabel {
                             //% "How can we help you with Mozilla VPN?"
-                            property string enterEmailAddress: qsTrId("vpn.contactUs.howCanWeHelp")
+                            property string enterEmailAddress: VPNl18n.tr(VPNl18n.InAppSupportWorkflowSupportFieldHeader)
 
                             text: enterEmailAddress
                             lineHeight: 10
@@ -195,8 +196,8 @@ Item {
 
                         VPNComboBox {
                             id: dropDown
-                            placeholderText: VPNl18n.tr(VPNl18n.ContactUsFormChooseCategory)
-                            model: VPNFeedbackCategoryModel
+                            placeholderText: VPNl18n.tr(VPNl18n.InAppSupportWorkflowDropdownLabel)
+                            model: VPNSupportCategoryModel
                         }
                     }
 
@@ -207,13 +208,13 @@ Item {
                         verticalAlignment: Text.AlignVCenter
                         Layout.fillWidth: true
                         //% "Subject (optional)"
-                        placeholderText: qsTrId("vpn.contactUs.subject")
+                        placeholderText: VPNl18n.tr(VPNl18n.InAppSupportWorkflowSubjectFieldPlaceholder)
                     }
 
                     VPNTextArea {
                         id: textArea
                         //% "Describe issue..."
-                        placeholderText: qsTrId("vpn.contactUs.textAreaPlaceholder")
+                        placeholderText: VPNl18n.tr(VPNl18n.InAppSupportWorkflowIssueFieldPlaceholder)
                     }
                 }
 
@@ -236,13 +237,13 @@ Item {
                             font.pixelSize: Theme.fontSize
                             horizontalAlignment: Text.AlignHCenter
                             //% "When you submit, Mozilla VPN will collect technical and interaction data with your email to help our support team understand your issue."
-                            text: qsTrId("vpn.contactUs.privacyDisclaimer")
+                            text: VPNl18n.tr(VPNl18n.InAppSupportWorkflowDisclaimerText)
                             width:parent.width
                         }
 
                         VPNLinkButton {
                             //% "Mozilla VPN Privacy Notice"
-                            labelText: qsTrId("vpn.contactUs.privacyNoticeLink")
+                            labelText: VPNl18n.tr(VPNl18n.InAppSupportWorkflowPrivacyNoticeLinkText)
                             Layout.alignment: Qt.AlignHCenter
                             onClicked: VPN.openLink(VPN.LinkPrivacyNotice)
                             width: parent.width
@@ -254,7 +255,7 @@ Item {
 
                         VPNButton {
                              //% "Submit"
-                            text: qsTrId("vpn.contactUs.submit")
+                            text: VPNl18n.tr(VPNl18n.InAppSupportWorkflowSupportPrimaryButtonText)
                             onClicked: contactUsRoot.createSupportTicket(emailInput.text, subjectInput.text, textArea.userEntry, dropDown.currentValue);
                             enabled: dropDown.currentValue != null && textArea.userEntry != "" &&
                                      (VPN.userAuthenticated ? true :
@@ -273,7 +274,7 @@ Item {
                         }
                         VPNLinkButton {
                             //% "Cancel"
-                            labelText: qsTrId("vpn.contactUs.cancel")
+                            labelText: VPNl18n.tr(VPNl18n.InAppSupportWorkflowSupportSecondaryActionText)
                             Layout.preferredHeight: Theme.rowHeight
                             Layout.alignment: Qt.AlignHCenter
                             onClicked: mainStackView.pop()
@@ -292,11 +293,6 @@ Item {
         }
     }
 
-    Item {
-        id: spinnerRoot
-        anchors.fill: parent
-    }
-
     Component {
         id: thankYouView
         Item {
@@ -310,16 +306,16 @@ Item {
                     id: panel
                     logo: "../resources/heart-check.svg"
                     //% "Thank you!"
-                    logoTitle: qsTrId("vpn.contactUs.thankyou")
+                    logoTitle: VPNl18n.tr(VPNl18n.InAppSupportWorkflowSupportResponseHeader)
                     //% "We appreciate your feedback. You’re helping us improve Mozilla VPN."
-                    logoSubtitle: qsTrId("vpn.contactUs.thankyouSubtitle")
+                    logoSubtitle: VPNl18n.tr(VPNl18n.InAppSupportWorkflowSupportResponseBody)
                     anchors.horizontalCenter: undefined
                     Layout.fillWidth: true
                 }
             }
             VPNButton {
                 //% "Done"
-               text: qsTrId("vpn.contactUs.done")
+               text: VPNl18n.tr(VPNl18n.InAppSupportWorkflowSupportResponseButton)
                anchors.top: col.bottom
                anchors.topMargin: Theme.vSpacing
                anchors.horizontalCenter: parent.horizontalCenter

--- a/src/ui/views/ViewErrorFullScreen.qml
+++ b/src/ui/views/ViewErrorFullScreen.qml
@@ -30,6 +30,7 @@ VPNFlickable {
     VPNHeaderLink {
         id: headerLink
         objectName: "getHelpLink"
+        visible: getHelpLinkVisible
 
         labelText: qsTrId("vpn.main.getHelp2")
         onClicked: stackview.push("../views/ViewGetHelp.qml", {isSettingsView: false})

--- a/tests/auth/auth.pro
+++ b/tests/auth/auth.pro
@@ -30,6 +30,7 @@ INCLUDEPATH += \
             ../../src/hacl-star \
             ../../src/hacl-star/kremlin \
             ../../src/hacl-star/kremlin/minimal
+            ../../translations/generated
 
 HEADERS += \
     ../../src/authenticationinapp/authenticationinapp.h \

--- a/tests/auth/auth.pro
+++ b/tests/auth/auth.pro
@@ -61,6 +61,7 @@ HEADERS += \
     ../../src/tasks/authenticate/desktopauthenticationlistener.h \
     ../../src/tasks/authenticate/taskauthenticate.h \
     ../../src/urlopener.h \
+    ../../translations/generated/l18nstrings.h \
     testemailvalidation.h \
     testpasswordvalidation.h \
     testsignupandin.h
@@ -93,6 +94,7 @@ SOURCES += \
     ../../src/tasks/authenticate/desktopauthenticationlistener.cpp \
     ../../src/tasks/authenticate/taskauthenticate.cpp \
     ../../src/urlopener.cpp \
+    ../../translations/generated/l18nstrings_p.cpp
     main.cpp \
     testemailvalidation.cpp \
     testpasswordvalidation.cpp \

--- a/tests/auth/auth.pro
+++ b/tests/auth/auth.pro
@@ -30,7 +30,6 @@ INCLUDEPATH += \
             ../../src/hacl-star \
             ../../src/hacl-star/kremlin \
             ../../src/hacl-star/kremlin/minimal
-            ../../translations/generated
 
 HEADERS += \
     ../../src/authenticationinapp/authenticationinapp.h \
@@ -61,6 +60,7 @@ HEADERS += \
     ../../src/tasks/authenticate/desktopauthenticationlistener.h \
     ../../src/tasks/authenticate/taskauthenticate.h \
     ../../src/urlopener.h \
+    ../../translations/generated/l18nstrings.h \
     testemailvalidation.h \
     testpasswordvalidation.h \
     testsignupandin.h

--- a/tests/auth/auth.pro
+++ b/tests/auth/auth.pro
@@ -29,7 +29,8 @@ INCLUDEPATH += \
             ../../src \
             ../../src/hacl-star \
             ../../src/hacl-star/kremlin \
-            ../../src/hacl-star/kremlin/minimal
+            ../../src/hacl-star/kremlin/minimal \
+            ../../translations/generated
 
 HEADERS += \
     ../../src/authenticationinapp/authenticationinapp.h \
@@ -60,7 +61,6 @@ HEADERS += \
     ../../src/tasks/authenticate/desktopauthenticationlistener.h \
     ../../src/tasks/authenticate/taskauthenticate.h \
     ../../src/urlopener.h \
-    ../../translations/generated/l18nstrings.h \
     testemailvalidation.h \
     testpasswordvalidation.h \
     testsignupandin.h

--- a/tests/auth/mocmozillavpn.cpp
+++ b/tests/auth/mocmozillavpn.cpp
@@ -104,6 +104,8 @@ void MozillaVPN::requestAbout() {}
 
 void MozillaVPN::requestViewLogs() {}
 
+void MozillaVPN::requestContactUs() {}
+
 void MozillaVPN::retrieveLogs() {}
 
 void MozillaVPN::storeInClipboard(const QString&) {}

--- a/tests/auth/mocmozillavpn.cpp
+++ b/tests/auth/mocmozillavpn.cpp
@@ -134,6 +134,9 @@ void MozillaVPN::triggerHeartbeat() {}
 
 void MozillaVPN::submitFeedback(const QString&, const qint8, const QString&) {}
 
+void MozillaVPN::createSupportTicket(const QString&, const QString&,
+                                     const QString&, const QString&) {}
+
 void MozillaVPN::addCurrentDeviceAndRefreshData() {}
 
 void MozillaVPN::abortAuthentication() {}

--- a/tests/unit/mocmozillavpn.cpp
+++ b/tests/unit/mocmozillavpn.cpp
@@ -136,6 +136,9 @@ void MozillaVPN::triggerHeartbeat() {}
 
 void MozillaVPN::submitFeedback(const QString&, const qint8, const QString&) {}
 
+void MozillaVPN::createSupportTicket(const QString&, const QString&,
+                                     const QString&, const QString&) {}
+
 void MozillaVPN::addCurrentDeviceAndRefreshData() {}
 
 void MozillaVPN::appReviewRequested() {}

--- a/tests/unit/mocmozillavpn.cpp
+++ b/tests/unit/mocmozillavpn.cpp
@@ -106,6 +106,8 @@ void MozillaVPN::requestAbout() {}
 
 void MozillaVPN::requestViewLogs() {}
 
+void MozillaVPN::requestContactUs() {}
+
 void MozillaVPN::retrieveLogs() {}
 
 void MozillaVPN::storeInClipboard(const QString&) {}

--- a/tests/unit/mocnetworkrequest.cpp
+++ b/tests/unit/mocnetworkrequest.cpp
@@ -132,6 +132,11 @@ NetworkRequest* NetworkRequest::createForSupportTicket(
   return new NetworkRequest(parent, 1234, false);
 }
 
+// static
+NetworkRequest* NetworkRequest::createForGetFeatureList(QObject* parent) {
+  return new NetworkRequest(parent, 1234, false);
+}
+
 void NetworkRequest::replyFinished() { QFAIL("Not called!"); }
 
 void NetworkRequest::timeout() {}

--- a/tests/unit/mocnetworkrequest.cpp
+++ b/tests/unit/mocnetworkrequest.cpp
@@ -119,6 +119,19 @@ NetworkRequest* NetworkRequest::createForFeedback(QObject* parent,
   return new NetworkRequest(parent, 1234, false);
 }
 
+NetworkRequest* NetworkRequest::createForSupportTicket(
+    QObject* parent, const QString& email, const QString& subject,
+    const QString& issueText, const QString& logs, const QString& category) {
+  Q_UNUSED(parent);
+  Q_UNUSED(email);
+  Q_UNUSED(subject);
+  Q_UNUSED(issueText);
+  Q_UNUSED(logs);
+  Q_UNUSED(category);
+
+  return new NetworkRequest(parent, 1234, false);
+}
+
 void NetworkRequest::replyFinished() { QFAIL("Not called!"); }
 
 void NetworkRequest::timeout() {}

--- a/tests/unit/unit.pro
+++ b/tests/unit/unit.pro
@@ -23,6 +23,7 @@ INCLUDEPATH += \
             ../../src/hacl-star \
             ../../src/hacl-star/kremlin \
             ../../src/hacl-star/kremlin/minimal
+            ../../translations/generated
 
 HEADERS += \
     ../../src/bigint.h \

--- a/tests/unit/unit.pro
+++ b/tests/unit/unit.pro
@@ -23,7 +23,6 @@ INCLUDEPATH += \
             ../../src/hacl-star \
             ../../src/hacl-star/kremlin \
             ../../src/hacl-star/kremlin/minimal
-            ../../translations/generated
 
 HEADERS += \
     ../../src/bigint.h \
@@ -90,6 +89,7 @@ HEADERS += \
     ../../src/update/updater.h \
     ../../src/update/versionapi.h \
     ../../src/urlopener.h \
+    ../../translations/generated/l18nstrings.h \
     helper.h \
     testandroidmigration.h \
     testbigint.h \

--- a/tests/unit/unit.pro
+++ b/tests/unit/unit.pro
@@ -55,6 +55,7 @@ HEADERS += \
     ../../src/models/servercountry.h \
     ../../src/models/servercountrymodel.h \
     ../../src/models/serverdata.h \
+    ../../src/models/supportcategorymodel.h \
     ../../src/models/survey.h \
     ../../src/models/surveymodel.h \
     ../../src/models/user.h \
@@ -136,6 +137,7 @@ SOURCES += \
     ../../src/models/servercountry.cpp \
     ../../src/models/servercountrymodel.cpp \
     ../../src/models/serverdata.cpp \
+    ../../src/models/supportcategorymodel.cpp \
     ../../src/models/survey.cpp \
     ../../src/models/surveymodel.cpp \
     ../../src/models/user.cpp \

--- a/tests/unit/unit.pro
+++ b/tests/unit/unit.pro
@@ -22,7 +22,8 @@ INCLUDEPATH += \
             ../../src \
             ../../src/hacl-star \
             ../../src/hacl-star/kremlin \
-            ../../src/hacl-star/kremlin/minimal
+            ../../src/hacl-star/kremlin/minimal \
+            ../../translations/generated
 
 HEADERS += \
     ../../src/bigint.h \
@@ -89,7 +90,6 @@ HEADERS += \
     ../../src/update/updater.h \
     ../../src/update/versionapi.h \
     ../../src/urlopener.h \
-    ../../translations/generated/l18nstrings.h \
     helper.h \
     testandroidmigration.h \
     testbigint.h \

--- a/tests/unit/unit.pro
+++ b/tests/unit/unit.pro
@@ -90,6 +90,7 @@ HEADERS += \
     ../../src/update/updater.h \
     ../../src/update/versionapi.h \
     ../../src/urlopener.h \
+    ../../translations/generated/l18nstrings.h \
     helper.h \
     testandroidmigration.h \
     testbigint.h \
@@ -167,6 +168,7 @@ SOURCES += \
     ../../src/update/updater.cpp \
     ../../src/update/versionapi.cpp \
     ../../src/urlopener.cpp \
+    ../../translations/generated/l18nstrings_p.cpp \
     main.cpp \
     moccontroller.cpp \
     mocinspectorwebsocketconnection.cpp \


### PR DESCRIPTION
This PR implements:
- the frontend of the in app support flow
- creating a support ticket on guardian
- an addition to `FeatureList` to load a feature list (unauthSupportEnabled in this case) from guardian
- enable the unauthenticated in app support form if enabled