### PR TITLE
Fix QML VPNPanel: Binding loop detected for property "height"

### DIFF
--- a/src/ui/components/VPNPanel.qml
+++ b/src/ui/components/VPNPanel.qml
@@ -17,7 +17,7 @@ Item {
 
     anchors.horizontalCenter: parent.horizontalCenter
     width: Math.min(parent.width, Theme.maxHorizontalContentWidth)
-    height: panel.height
+    height: panel.implicitHeight
 
     ColumnLayout {
         id: panel


### PR DESCRIPTION
Noticed while reviewing #1586 