### PR TITLE
Only add apps that are Valid to the Missing Apps List

### DIFF
--- a/src/apppermission.cpp
+++ b/src/apppermission.cpp
@@ -220,6 +220,10 @@ void AppPermission::openFilePicker() {
   Q_ASSERT(fileNames.length() == 1);
 
   Q_ASSERT(m_listprovider);
+  if (!m_listprovider->isValidAppId(fileNames[0])) {
+    logger.debug() << "App not valid:" << fileNames[0];
+    return;
+  }
   m_listprovider->addApplication(fileNames[0]);
 
   QString message = L18nStrings::instance()


### PR DESCRIPTION
well if you add a non valid file, we should not show the success banner and not add it to the list. (this will be cleared from there, and you will see the missing apps notification then ) 
-> Maybe we should have also an alert for that :) 
#closes https://github.com/mozilla-mobile/mozilla-vpn-client/issues/1402#