### PR TITLE
Add a link to split-tunnel help page

### DIFF
--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -449,6 +449,12 @@ void MozillaVPN::openLink(LinkType linkType) {
       url = NetworkRequest::apiBaseUrl();
       url.append("/r/vpn/subscriptionBlocked");
       break;
+    case LinkSplitTunnelHelp:
+      // TODO: This should link to a more helpful article
+      url =
+          "https://support.mozilla.org/kb/"
+          "split-tunneling-use-mozilla-vpn-specific-apps-wind";
+      break;
 
     default:
       qFatal("Unsupported link type!");

--- a/src/mozillavpn.h
+++ b/src/mozillavpn.h
@@ -81,6 +81,7 @@ class MozillaVPN final : public QObject {
     LinkPrivacyNotice,
     LinkUpdate,
     LinkSubscriptionBlocked,
+    LinkSplitTunnelHelp
   };
   Q_ENUM(LinkType)
 

--- a/src/ui/settings/ViewAppPermissions.qml
+++ b/src/ui/settings/ViewAppPermissions.qml
@@ -35,7 +35,7 @@ Item {
     VPNFlickable {
         id: vpnFlickable
         property bool vpnIsOff: (VPNController.state === VPNController.StateOff)
-        flickContentHeight:  VPNSettings.protectSelectedApps ? enabledList.y + enabledList.implicitHeight + 100 : vpnFlickable.y + toggleCard.height
+        flickContentHeight:  (VPNSettings.protectSelectedApps ? enabledList.y + enabledList.implicitHeight + 100 : vpnFlickable.y + toggleCard.height )+ helpInfoText.height + helpLink.height
         anchors.top: menu.bottom
         height: root.height - menu.height
         anchors.left: parent.left
@@ -130,5 +130,24 @@ Item {
             //: Header for the list of apps protected by VPN
             header: qsTrId("vpn.settings.excludeTitle")
         }
+
+        VPNTextBlock {
+            id: helpInfoText
+            width: vpnFlickable.width - Theme.windowMargin*3
+            anchors.topMargin: 30
+            anchors.top: enabledList.visible? enabledList.bottom : toggleCard.bottom
+            anchors.horizontalCenter:  enabledList.visible? enabledList.horizontalCenter : toggleCard.horizontalCenter
+            text: VPNl18n.tr(VPNl18n.SplittunnelInfoText)
+        }
+
+        VPNHeaderLink{
+            id: helpLink
+            anchors.top:  helpInfoText.bottom
+            anchors.horizontalCenter: helpInfoText.horizontalCenter
+            labelText: VPNl18n.tr(VPNl18n.SplittunnelInfoLinkText)
+            onClicked: {
+               VPN.openLink(VPN.LinkSplitTunnelHelp)
+            }
+        }     
     }
 }


### PR DESCRIPTION
Note: This should not be merged until we have the right sumo article and changed the url.

Also wierd, our font seems to be failing on `we’ve`

![grafik](https://user-images.githubusercontent.com/9611612/130246620-96023edf-5bf7-4b81-9bcd-2cfdcea48b95.png)
