### PR TITLE
Android: Only go Foreground-Service if the vpn is Connected

### DIFF
--- a/android/src/org/mozilla/firefox/vpn/VPNService.kt
+++ b/android/src/org/mozilla/firefox/vpn/VPNService.kt
@@ -26,7 +26,6 @@ class VPNService : android.net.VpnService() {
             return
         }
         Log.init(this)
-        NotificationUtil.show(this)
         SharedLibraryLoader.loadSharedLibrary(this, "wg-go")
         Log.i(tag, "loaded lib")
         Log.e(tag, "Wireguard Version ${wgVersion()}")


### PR DESCRIPTION
Currently, we're moving the vpn service to a foreground service asap. This means we might encounter a notification that did not get a string from the qt-notification handler, so we show the English fallback message.
Going foreground is not needed until we actually connect the VPN and need the service to be alive.



Closes #548