### PR TITLE
Add settings to hold multihop entry server

### DIFF
--- a/src/commands/commandselect.cpp
+++ b/src/commands/commandselect.cpp
@@ -21,7 +21,7 @@ CommandSelect::~CommandSelect() { MVPN_COUNT_DTOR(CommandSelect); }
 int CommandSelect::run(QStringList& tokens) {
   Q_ASSERT(!tokens.isEmpty());
   return runCommandLineApp([&]() {
-    if (tokens.length() < 2) {
+    if ((tokens.length() < 2) || (tokens.length() > 3)) {
       QTextStream stream(stdout);
       stream << "usage: " << tokens[0] << " <server_hostname> [entry_hostname]"
              << Qt::endl;

--- a/src/commands/commandselect.cpp
+++ b/src/commands/commandselect.cpp
@@ -58,7 +58,7 @@ bool CommandSelect::pickServer(const QString& hostname,
     for (const ServerCity& city : country.cities()) {
       for (const Server& server : city.servers()) {
         if (server.hostname() == hostname) {
-          serverData.update(country.code(), country.name(), city.name());
+          serverData.update(country.code(), city.name());
           return true;
         }
       }

--- a/src/commands/commandselect.h
+++ b/src/commands/commandselect.h
@@ -17,7 +17,8 @@ class CommandSelect final : public Command {
   int run(QStringList& tokens) override;
 
  private:
-  bool pickServer(const QString& hostname, ServerData& serverData);
+  bool pickServer(const QString& hostname, QString& countryCode,
+                  QString& cityName);
 };
 
 #endif  // COMMANDSELECT_H

--- a/src/commands/commandstatus.cpp
+++ b/src/commands/commandstatus.cpp
@@ -100,10 +100,12 @@ int CommandStatus::run(QStringList& tokens) {
       stream << " - ipv6 address: " << device.ipv6Address() << Qt::endl;
     }
 
+    ServerCountryModel* model = vpn.serverCountryModel();
     ServerData* sd = vpn.currentServer();
     if (sd) {
       stream << "Server country code: " << sd->countryCode() << Qt::endl;
-      stream << "Server country: " << sd->countryName() << Qt::endl;
+      stream << "Server country: " << model->countryName(sd->countryCode())
+             << Qt::endl;
       stream << "Server city: " << sd->cityName() << Qt::endl;
     }
 

--- a/src/commands/commandstatus.cpp
+++ b/src/commands/commandstatus.cpp
@@ -103,10 +103,10 @@ int CommandStatus::run(QStringList& tokens) {
     ServerCountryModel* model = vpn.serverCountryModel();
     ServerData* sd = vpn.currentServer();
     if (sd) {
-      stream << "Server country code: " << sd->countryCode() << Qt::endl;
-      stream << "Server country: " << model->countryName(sd->countryCode())
+      stream << "Server country code: " << sd->exitCountryCode() << Qt::endl;
+      stream << "Server country: " << model->countryName(sd->exitCountryCode())
              << Qt::endl;
-      stream << "Server city: " << sd->cityName() << Qt::endl;
+      stream << "Server city: " << sd->exitCityName() << Qt::endl;
     }
 
     return 0;

--- a/src/connectiondataholder.cpp
+++ b/src/connectiondataholder.cpp
@@ -231,9 +231,10 @@ void ConnectionDataHolder::updateIpAddress() {
           return;
         }
 
+        MozillaVPN* vpn = MozillaVPN::instance();
         logger.debug() << "IP address request completed";
         if (m_checkStatusTimer.isActive() &&
-            country != MozillaVPN::instance()->currentServer()->countryCode()) {
+            country != vpn->currentServer()->exitCountryCode()) {
           // In case the country-we're reported in does not match the
           // connected server we may retry only once.
           logger.warning() << "Reported ip not in the right country, retry!";

--- a/src/constants.h
+++ b/src/constants.h
@@ -19,6 +19,9 @@ constexpr uint32_t CAPTIVE_PORTAL_ALERT_MSEC = 4000;
 // Number of msecs for the unsecured network alert.
 constexpr uint32_t UNSECURED_NETWORK_ALERT_MSEC = 4000;
 
+// Number of recent connections to retain.
+constexpr int RECENT_CONNECTIONS_MAX_COUNT = 5;
+
 #if defined(UNIT_TEST)
 #  define CONSTEXPR(type, functionName, releaseValue, debugValue, \
                     testingValue)                                 \

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -173,7 +173,7 @@ void Controller::activateInternal() {
   MozillaVPN* vpn = MozillaVPN::instance();
   Q_ASSERT(vpn);
 
-  QList<Server> servers = vpn->servers();
+  QList<Server> servers = vpn->exitServers();
   Q_ASSERT(!servers.isEmpty());
 
   Server server = Server::weightChooser(servers);
@@ -194,13 +194,9 @@ void Controller::activateInternal() {
   // Multihop connections provide a list of servers, starting with the exit
   // node as the first element, and the entry node as the final entry.
   QList<Server> serverList = {server};
-  if (FeatureMultiHop::instance()->isSupported() &&
-      settingsHolder->multihopTunnel()) {
-    ServerData data;
-    Server hop = vpn->randomHop(data);
-    while (serverList.contains(hop)) {
-      hop = vpn->randomHop(data);
-    }
+  if (FeatureMultiHop::instance()->isSupported() && vpn->multihop()) {
+    Server hop = Server::weightChooser(vpn->entryServers());
+    Q_ASSERT(hop.initialized());
     serverList.append(hop);
   }
 
@@ -226,7 +222,7 @@ bool Controller::silentSwitchServers() {
   MozillaVPN* vpn = MozillaVPN::instance();
   Q_ASSERT(vpn);
 
-  QList<Server> servers = vpn->servers();
+  QList<Server> servers = vpn->exitServers();
   Q_ASSERT(!servers.isEmpty());
 
   if (servers.length() <= 1) {
@@ -266,13 +262,9 @@ bool Controller::silentSwitchServers() {
   }
 
   QList<Server> serverList = {server};
-  if (FeatureMultiHop::instance()->isSupported() &&
-      settingsHolder->multihopTunnel()) {
-    ServerData data;
-    Server hop = vpn->randomHop(data);
-    while (serverList.contains(hop)) {
-      hop = vpn->randomHop(data);
-    }
+  if (FeatureMultiHop::instance()->isSupported() && vpn->multihop()) {
+    Server hop = Server::weightChooser(vpn->entryServers());
+    Q_ASSERT(hop.initialized());
     serverList.append(hop);
   }
 
@@ -445,21 +437,25 @@ void Controller::timerTimeout() {
   emit timeChanged();
 }
 
-void Controller::changeServer(const QString& countryCode, const QString& city) {
+void Controller::changeServer(const QString& countryCode, const QString& city,
+                              const QString& entryCountryCode,
+                              const QString& entryCity) {
   Q_ASSERT(m_state == StateOn || m_state == StateOff);
 
   MozillaVPN* vpn = MozillaVPN::instance();
   Q_ASSERT(vpn);
 
   if (vpn->currentServer()->countryCode() == countryCode &&
-      vpn->currentServer()->cityName() == city) {
+      vpn->currentServer()->cityName() == city &&
+      vpn->currentServer()->entryCountryCode() == entryCountryCode &&
+      vpn->currentServer()->entryCityName() == entryCity) {
     logger.debug() << "No server change needed";
     return;
   }
 
   if (m_state == StateOff) {
     logger.debug() << "Change server";
-    vpn->changeServer(countryCode, city);
+    vpn->changeServer(countryCode, city, entryCountryCode, entryCity);
     return;
   }
 

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -445,8 +445,8 @@ void Controller::changeServer(const QString& countryCode, const QString& city,
   MozillaVPN* vpn = MozillaVPN::instance();
   Q_ASSERT(vpn);
 
-  if (vpn->currentServer()->countryCode() == countryCode &&
-      vpn->currentServer()->cityName() == city &&
+  if (vpn->currentServer()->exitCountryCode() == countryCode &&
+      vpn->currentServer()->exitCityName() == city &&
       vpn->currentServer()->entryCountryCode() == entryCountryCode &&
       vpn->currentServer()->entryCityName() == entryCity) {
     logger.debug() << "No server change needed";
@@ -464,8 +464,8 @@ void Controller::changeServer(const QString& countryCode, const QString& city,
 
   logger.debug() << "Switching to a different server";
 
-  m_currentCity = vpn->currentServer()->cityName();
-  m_currentCountryCode = vpn->currentServer()->countryCode();
+  m_currentCity = vpn->currentServer()->exitCityName();
+  m_currentCountryCode = vpn->currentServer()->exitCountryCode();
   m_switchingCountryCode = countryCode;
   m_switchingCity = city;
 

--- a/src/controller.h
+++ b/src/controller.h
@@ -54,8 +54,9 @@ class Controller final : public QObject {
 
   State state() const;
 
-  Q_INVOKABLE void changeServer(const QString& countryCode,
-                                const QString& city);
+  Q_INVOKABLE void changeServer(const QString& countryCode, const QString& city,
+                                const QString& entryCountryCode = QString(),
+                                const QString& entryCity = QString());
 
   Q_INVOKABLE void logout();
 

--- a/src/inspector/inspectorwebsocketconnection.cpp
+++ b/src/inspector/inspectorwebsocketconnection.cpp
@@ -209,13 +209,15 @@ static QList<WebSocketSettingCommand> s_settingCommands{
     WebSocketSettingCommand{
         "current-server-country-code", WebSocketSettingCommand::String, nullptr,
         []() {
-          return MozillaVPN::instance()->currentServer()->countryCode();
+          return MozillaVPN::instance()->currentServer()->exitCountryCode();
         }},
 
     // server city
     WebSocketSettingCommand{
         "current-server-city", WebSocketSettingCommand::String, nullptr,
-        []() { return MozillaVPN::instance()->currentServer()->cityName(); }},
+        []() {
+          return MozillaVPN::instance()->currentServer()->exitCityName();
+        }},
 
     // glean-enabled
     WebSocketSettingCommand{

--- a/src/inspector/inspectorwebsocketconnection.cpp
+++ b/src/inspector/inspectorwebsocketconnection.cpp
@@ -309,6 +309,44 @@ static QList<WebSocketCommand> s_commands{
                        return obj;
                      }},
 
+    WebSocketCommand{"list", "List all properties for an object", 1,
+                     [](const QList<QByteArray>& arguments) {
+                       QJsonObject obj;
+                       QString result;
+
+                       QObject* item = findObject(arguments[1]);
+                       if (!item) {
+                         obj["error"] = "Object not found";
+                         return obj;
+                       }
+                       const QMetaObject* meta = item->metaObject();
+                       int start = meta->propertyOffset();
+                       int longest = 0;
+
+                       for (int i = start; i < meta->propertyCount(); i++) {
+                         QMetaProperty mp = meta->property(i);
+                         int namelen = strlen(mp.name());
+                         if (namelen > longest) {
+                           longest = namelen;
+                         }
+                       }
+
+                       for (int i = start; i < meta->propertyCount(); i++) {
+                         QMetaProperty mp = meta->property(i);
+                         int padding = longest - strlen(mp.name());
+                         QVariant value = mp.read(item);
+                         if (!result.isEmpty()) {
+                           result += "\n";
+                         }
+                         result += QString(mp.name());
+                         result += QString(padding, ' ') + " = ";
+                         result += value.toString();
+                       }
+
+                       obj["value"] = result;
+                       return obj;
+                     }},
+
     WebSocketCommand{"property", "Retrieve a property value from an object", 2,
                      [](const QList<QByteArray>& arguments) {
                        QJsonObject obj;

--- a/src/models/servercountry.cpp
+++ b/src/models/servercountry.cpp
@@ -76,7 +76,7 @@ bool ServerCountry::fromJson(const QJsonObject& countryObj) {
 
 const QList<Server> ServerCountry::servers(const ServerData& data) const {
   for (const ServerCity& city : m_cities) {
-    if (city.name() == data.cityName()) {
+    if (city.name() == data.exitCityName()) {
       return city.servers();
     }
   }

--- a/src/models/servercountrymodel.cpp
+++ b/src/models/servercountrymodel.cpp
@@ -159,7 +159,7 @@ bool ServerCountryModel::pickIfExists(const QString& countryCode,
     if (country.code() == countryCode) {
       for (const ServerCity& city : country.cities()) {
         if (city.code() == cityCode) {
-          data.initialize(country, city);
+          data.update(country.code(), city.name());
           return true;
         }
       }
@@ -181,7 +181,7 @@ void ServerCountryModel::pickRandom(ServerData& data) const {
       QRandomGenerator::global()->generate() % country.cities().length();
   const ServerCity& city = country.cities().at(cityId);
 
-  data.initialize(country, city);
+  data.update(country.code(), city.name());
 }
 
 bool ServerCountryModel::pickByIPv4Address(const QString& ipv4Address,
@@ -192,7 +192,7 @@ bool ServerCountryModel::pickByIPv4Address(const QString& ipv4Address,
     for (const ServerCity& city : country.cities()) {
       for (const Server& server : city.servers()) {
         if (server.ipv4AddrIn() == ipv4Address) {
-          data.initialize(country, city);
+          data.update(country.code(), city.name());
           return true;
         }
       }
@@ -240,6 +240,12 @@ const QString ServerCountryModel::countryName(
   }
 
   return QString();
+}
+
+const QString ServerCountryModel::localizedCountryName(
+    const QString& countryCode) const {
+  const QString name = countryName(countryCode);
+  return ServerI18N::translateCountryName(countryCode, name);
 }
 
 void ServerCountryModel::retranslate() {

--- a/src/models/servercountrymodel.cpp
+++ b/src/models/servercountrymodel.cpp
@@ -207,9 +207,9 @@ bool ServerCountryModel::exists(ServerData& data) const {
   Q_ASSERT(data.initialized());
 
   for (const ServerCountry& country : m_countries) {
-    if (country.code() == data.countryCode()) {
+    if (country.code() == data.exitCountryCode()) {
       for (const ServerCity& city : country.cities()) {
-        if (data.cityName() == city.name()) {
+        if (data.exitCityName() == city.name()) {
           return true;
         }
       }
@@ -223,7 +223,7 @@ bool ServerCountryModel::exists(ServerData& data) const {
 
 const QList<Server> ServerCountryModel::servers(const ServerData& data) const {
   for (const ServerCountry& country : m_countries) {
-    if (country.code() == data.countryCode()) {
+    if (country.code() == data.exitCountryCode()) {
       return country.servers(data);
     }
   }

--- a/src/models/servercountrymodel.h
+++ b/src/models/servercountrymodel.h
@@ -48,6 +48,8 @@ class ServerCountryModel final : public QAbstractListModel {
 
   const QString countryName(const QString& countryCode) const;
 
+  const QString localizedCountryName(const QString& countryCode) const;
+
   const QList<ServerCountry>& countries() const { return m_countries; }
 
   void retranslate();

--- a/src/models/serverdata.cpp
+++ b/src/models/serverdata.cpp
@@ -61,8 +61,8 @@ void ServerData::writeSettings() {
   SettingsHolder* settingsHolder = SettingsHolder::instance();
   Q_ASSERT(settingsHolder);
 
-  settingsHolder->setCurrentServerCountryCode(m_countryCode);
-  settingsHolder->setCurrentServerCity(m_cityName);
+  settingsHolder->setCurrentServerCountryCode(m_exitCountryCode);
+  settingsHolder->setCurrentServerCity(m_exitCityName);
 
   if (multihop()) {
     settingsHolder->setEntryServerCountryCode(m_entryCountryCode);
@@ -80,19 +80,19 @@ void ServerData::update(const QString& countryCode, const QString& cityName,
   emit changed();
 }
 
-void ServerData::initializeInternal(const QString& countryCode,
-                                    const QString& cityName,
+void ServerData::initializeInternal(const QString& exitCountryCode,
+                                    const QString& exitCityName,
                                     const QString& entryCountryCode,
                                     const QString& entryCityName) {
   m_initialized = true;
-  m_countryCode = countryCode;
-  m_cityName = cityName;
+  m_exitCountryCode = exitCountryCode;
+  m_exitCityName = exitCityName;
   m_entryCountryCode = entryCountryCode;
   m_entryCityName = entryCityName;
 }
 
 QString ServerData::localizedCityName() const {
-  return ServerI18N::translateCityName(m_countryCode, m_cityName);
+  return ServerI18N::translateCityName(m_exitCountryCode, m_exitCityName);
 }
 
 QString ServerData::localizedEntryCity() const {
@@ -105,6 +105,6 @@ QString ServerData::toString() const {
     result += m_entryCityName + ", " + m_entryCountryCode + " -> ";
   }
 
-  result += m_cityName + ", " + m_countryCode;
+  result += m_exitCityName + ", " + m_exitCountryCode;
   return result;
 }

--- a/src/models/serverdata.cpp
+++ b/src/models/serverdata.cpp
@@ -38,20 +38,27 @@ bool ServerData::fromSettings() {
 bool ServerData::fromString(const QString& data) {
   QStringList serverList = data.split("->");
 
-  QStringList current = serverList.last().split(",");
-  if (current.count() != 2) {
+  QString exit = serverList.last();
+  int index = exit.lastIndexOf(',');
+  if (index < 0) {
     return false;
   }
-  QStringList entry;
+  QString exitCountryCode = exit.mid(index + 1).trimmed();
+  QString exitCityName = exit.left(index).trimmed();
+  QString entryCountryCode;
+  QString entryCityName;
+
   if (serverList.count() > 1) {
-    entry = serverList.first().split(",");
-  } else {
-    entry.append(QString());
-    entry.append(QString());
+    QString entry = serverList.first();
+    index = entry.lastIndexOf(',');
+    if (index > 0) {
+      entryCityName = entry.left(index).trimmed();
+      entryCountryCode = entry.mid(index + 1).trimmed();
+    }
   }
 
-  initializeInternal(current[1].trimmed(), current[0].trimmed(),
-                     entry[1].trimmed(), entry[0].trimmed());
+  initializeInternal(exitCountryCode, exitCityName, entryCountryCode,
+                     entryCityName);
 
   logger.debug() << toString();
   return true;
@@ -100,6 +107,10 @@ QString ServerData::localizedEntryCity() const {
 }
 
 QString ServerData::toString() const {
+  if (!m_initialized) {
+    return QString();
+  }
+
   QString result = "";
   if (multihop()) {
     result += m_entryCityName + ", " + m_entryCountryCode + " -> ";

--- a/src/models/serverdata.h
+++ b/src/models/serverdata.h
@@ -34,8 +34,6 @@ class ServerData final : public QObject {
 
   void writeSettings();
 
-  void initialize(const ServerCountry& country, const ServerCity& city);
-
   bool initialized() const { return m_initialized; }
 
   const QString& countryCode() const { return m_countryCode; }
@@ -44,7 +42,9 @@ class ServerData final : public QObject {
 
   QString localizedCityName() const;
 
-  bool multihop() const { return m_multihop; }
+  bool multihop() const {
+    return !m_entryCountryCode.isEmpty() && !m_entryCityName.isEmpty();
+  }
 
   const QString& entryCountryCode() const { return m_entryCountryCode; }
 
@@ -54,7 +54,6 @@ class ServerData final : public QObject {
 
   void forget() {
     m_initialized = false;
-    m_multihop = false;
   }
 
   void update(const QString& countryCode, const QString& cityName,
@@ -67,9 +66,9 @@ class ServerData final : public QObject {
   void changed();
 
  private:
-  void initializeInternal(const QString& countryCode, const QString& cityName);
-  void initializeEntryServer(const QString& countryCode,
-                             const QString& cityName);
+  void initializeInternal(const QString& countryCode, const QString& cityName,
+                          const QString& entryCountryCode,
+                          const QString& entryCityName);
 
  private:
   bool m_initialized = false;
@@ -77,7 +76,6 @@ class ServerData final : public QObject {
   QString m_countryCode;
   QString m_cityName;
 
-  bool m_multihop = false;
   QString m_entryCountryCode;
   QString m_entryCityName;
 };

--- a/src/models/serverdata.h
+++ b/src/models/serverdata.h
@@ -52,9 +52,7 @@ class ServerData final : public QObject {
 
   QString localizedEntryCity() const;
 
-  void forget() {
-    m_initialized = false;
-  }
+  void forget() { m_initialized = false; }
 
   void update(const QString& exitCountryCode, const QString& exitCityName,
               const QString& entryCountryCode = QString(),

--- a/src/models/serverdata.h
+++ b/src/models/serverdata.h
@@ -20,11 +20,17 @@ class ServerData final : public QObject {
   Q_PROPERTY(QString cityName READ cityName NOTIFY changed)
   Q_PROPERTY(QString localizedCityName READ localizedCityName NOTIFY changed)
 
+  Q_PROPERTY(bool multihop READ multihop NOTIFY changed)
+  Q_PROPERTY(QString entryCountryCode READ entryCountryCode NOTIFY changed)
+  Q_PROPERTY(QString entryCityName READ entryCityName NOTIFY changed)
+  Q_PROPERTY(QString localizedEntryCity READ localizedEntryCity NOTIFY changed)
+
  public:
   ServerData();
   ~ServerData();
 
   [[nodiscard]] bool fromSettings();
+  [[nodiscard]] bool fromString(const QString& data);
 
   void writeSettings();
 
@@ -34,32 +40,46 @@ class ServerData final : public QObject {
 
   const QString& countryCode() const { return m_countryCode; }
 
-  const QString& countryName() const { return m_countryName; }
-
-  QString localizedCountryName() const;
-
   const QString& cityName() const { return m_cityName; }
 
   QString localizedCityName() const;
 
-  void forget() { m_initialized = false; }
+  bool multihop() const { return m_multihop; }
 
-  void update(const QString& countryCode, const QString& countryName,
-              const QString& cityName);
+  const QString& entryCountryCode() const { return m_entryCountryCode; }
+
+  const QString& entryCityName() const { return m_entryCityName; }
+
+  QString localizedEntryCity() const;
+
+  void forget() {
+    m_initialized = false;
+    m_multihop = false;
+  }
+
+  void update(const QString& countryCode, const QString& cityName,
+              const QString& entryCountryCode = QString(),
+              const QString& entryCityName = QString());
+
+  QString toString() const;
 
  signals:
   void changed();
 
  private:
-  void initializeInternal(const QString& countryCode,
-                          const QString& countryName, const QString& cityName);
+  void initializeInternal(const QString& countryCode, const QString& cityName);
+  void initializeEntryServer(const QString& countryCode,
+                             const QString& cityName);
 
  private:
   bool m_initialized = false;
 
   QString m_countryCode;
-  QString m_countryName;
   QString m_cityName;
+
+  bool m_multihop = false;
+  QString m_entryCountryCode;
+  QString m_entryCityName;
 };
 
 #endif  // SERVERDATA_H

--- a/src/models/serverdata.h
+++ b/src/models/serverdata.h
@@ -16,8 +16,8 @@ class ServerData final : public QObject {
   Q_OBJECT
   Q_DISABLE_COPY_MOVE(ServerData);
 
-  Q_PROPERTY(QString countryCode READ countryCode NOTIFY changed)
-  Q_PROPERTY(QString cityName READ cityName NOTIFY changed)
+  Q_PROPERTY(QString exitCountryCode READ exitCountryCode NOTIFY changed)
+  Q_PROPERTY(QString exitCityName READ exitCityName NOTIFY changed)
   Q_PROPERTY(QString localizedCityName READ localizedCityName NOTIFY changed)
 
   Q_PROPERTY(bool multihop READ multihop NOTIFY changed)
@@ -36,9 +36,9 @@ class ServerData final : public QObject {
 
   bool initialized() const { return m_initialized; }
 
-  const QString& countryCode() const { return m_countryCode; }
+  const QString& exitCountryCode() const { return m_exitCountryCode; }
 
-  const QString& cityName() const { return m_cityName; }
+  const QString& exitCityName() const { return m_exitCityName; }
 
   QString localizedCityName() const;
 
@@ -56,7 +56,7 @@ class ServerData final : public QObject {
     m_initialized = false;
   }
 
-  void update(const QString& countryCode, const QString& cityName,
+  void update(const QString& exitCountryCode, const QString& exitCityName,
               const QString& entryCountryCode = QString(),
               const QString& entryCityName = QString());
 
@@ -66,15 +66,16 @@ class ServerData final : public QObject {
   void changed();
 
  private:
-  void initializeInternal(const QString& countryCode, const QString& cityName,
+  void initializeInternal(const QString& exitCountryCode,
+                          const QString& exitCityName,
                           const QString& entryCountryCode,
                           const QString& entryCityName);
 
  private:
   bool m_initialized = false;
 
-  QString m_countryCode;
-  QString m_cityName;
+  QString m_exitCountryCode;
+  QString m_exitCityName;
 
   QString m_entryCountryCode;
   QString m_entryCityName;

--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -910,10 +910,7 @@ const QList<Server> MozillaVPN::servers() const {
 }
 
 void MozillaVPN::changeServer(const QString& countryCode, const QString& city) {
-  QString countryName =
-      m_private->m_serverCountryModel.countryName(countryCode);
-
-  m_private->m_serverData.update(countryCode, countryName, city);
+  m_private->m_serverData.update(countryCode, city);
   m_private->m_serverData.writeSettings();
 }
 

--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -905,12 +905,25 @@ void MozillaVPN::errorHandle(ErrorHandler::ErrorType error) {
   }
 }
 
-const QList<Server> MozillaVPN::servers() const {
+const QList<Server> MozillaVPN::exitServers() const {
   return m_private->m_serverCountryModel.servers(m_private->m_serverData);
 }
 
-void MozillaVPN::changeServer(const QString& countryCode, const QString& city) {
-  m_private->m_serverData.update(countryCode, city);
+const QList<Server> MozillaVPN::entryServers() const {
+  if (!m_private->m_serverData.multihop()) {
+    return QList<Server>();
+  }
+  ServerData sd;
+  sd.update(m_private->m_serverData.entryCountryCode(),
+            m_private->m_serverData.entryCityName());
+  return m_private->m_serverCountryModel.servers(sd);
+}
+
+void MozillaVPN::changeServer(const QString& countryCode, const QString& city,
+                              const QString& entryCountryCode,
+                              const QString& entryCity) {
+  m_private->m_serverData.update(countryCode, city, entryCountryCode,
+                                 entryCity);
   m_private->m_serverData.writeSettings();
 }
 

--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -925,6 +925,25 @@ void MozillaVPN::changeServer(const QString& countryCode, const QString& city,
   m_private->m_serverData.update(countryCode, city, entryCountryCode,
                                  entryCity);
   m_private->m_serverData.writeSettings();
+
+  // Update the list of recent connections.
+  QString description = m_private->m_serverData.toString();
+  QStringList recent = SettingsHolder::instance()->recentConnections();
+  int index = recent.indexOf(description);
+  if (index == 0) {
+    // This is already the most-recent connection.
+    return;
+  }
+
+  if (index > 0) {
+    recent.removeAt(index);
+  } else {
+    while (recent.count() >= Constants::RECENT_CONNECTIONS_MAX_COUNT) {
+      recent.removeLast();
+    }
+  }
+  recent.prepend(description);
+  SettingsHolder::instance()->setRecentConnections(recent);
 }
 
 const Server& MozillaVPN::randomHop(ServerData& data) const {

--- a/src/mozillavpn.h
+++ b/src/mozillavpn.h
@@ -201,13 +201,17 @@ class MozillaVPN final : public QObject {
 
   void surveyChecked(const QByteArray& json);
 
-  const QList<Server> servers() const;
+  const QList<Server> exitServers() const;
+  const QList<Server> entryServers() const;
+  bool multihop() const { return m_private->m_serverData.multihop(); }
 
   void errorHandle(ErrorHandler::ErrorType error);
 
   void abortAuthentication();
 
-  void changeServer(const QString& countryCode, const QString& city);
+  void changeServer(const QString& countryCode, const QString& city,
+                    const QString& entryCountryCode = QString(),
+                    const QString& entryCity = QString());
 
   void silentSwitch();
 

--- a/src/notificationhandler.cpp
+++ b/src/notificationhandler.cpp
@@ -54,6 +54,10 @@ void NotificationHandler::showNotification() {
 
   QString title;
   QString message;
+  QString countryCode = vpn->currentServer()->countryCode();
+  QString localizedCityName = vpn->currentServer()->localizedCityName();
+  QString localizedCountryName =
+      vpn->serverCountryModel()->localizedCountryName(countryCode);
 
   switch (vpn->controller()->state()) {
     case Controller::StateOn:
@@ -75,8 +79,8 @@ void NotificationHandler::showNotification() {
         message = qtTrId("vpn.systray.statusSwtich.message")
                       .arg(m_switchingLocalizedServerCountry)
                       .arg(m_switchingLocalizedServerCity)
-                      .arg(vpn->currentServer()->localizedCountryName())
-                      .arg(vpn->currentServer()->localizedCityName());
+                      .arg(localizedCountryName)
+                      .arg(localizedCityName);
       } else {
         if (!SettingsHolder::instance()->connectionChangeNotification()) {
           // Notifications for ConnectionChange are disabled
@@ -88,8 +92,8 @@ void NotificationHandler::showNotification() {
         //: Shown as message body in a notification. %1 is the country, %2 is
         //: the city.
         message = qtTrId("vpn.systray.statusConnected.message")
-                      .arg(vpn->currentServer()->localizedCountryName())
-                      .arg(vpn->currentServer()->localizedCityName());
+                      .arg(localizedCountryName)
+                      .arg(localizedCityName);
       }
       break;
 
@@ -107,8 +111,8 @@ void NotificationHandler::showNotification() {
         //: Shown as message body in a notification. %1 is the country, %2 is
         //: the city.
         message = qtTrId("vpn.systray.statusDisconnected.message")
-                      .arg(vpn->currentServer()->localizedCountryName())
-                      .arg(vpn->currentServer()->localizedCityName());
+                      .arg(localizedCountryName)
+                      .arg(localizedCityName);
       }
       break;
 
@@ -116,10 +120,8 @@ void NotificationHandler::showNotification() {
       m_connected = true;
 
       m_switching = true;
-      m_switchingLocalizedServerCountry =
-          vpn->currentServer()->localizedCountryName();
-      m_switchingLocalizedServerCity =
-          vpn->currentServer()->localizedCityName();
+      m_switchingLocalizedServerCountry = localizedCountryName;
+      m_switchingLocalizedServerCity = localizedCityName;
       break;
 
     default:

--- a/src/notificationhandler.cpp
+++ b/src/notificationhandler.cpp
@@ -54,7 +54,7 @@ void NotificationHandler::showNotification() {
 
   QString title;
   QString message;
-  QString countryCode = vpn->currentServer()->countryCode();
+  QString countryCode = vpn->currentServer()->exitCountryCode();
   QString localizedCityName = vpn->currentServer()->localizedCityName();
   QString localizedCountryName =
       vpn->serverCountryModel()->localizedCountryName(countryCode);

--- a/src/settingsholder.cpp
+++ b/src/settingsholder.cpp
@@ -78,7 +78,6 @@ constexpr const char* SETTINGS_POSTAUTHENTICATIONSHOWN =
 constexpr const char* SETTINGS_TELEMETRYPOLICYSHOWN = "telemetryPolicyShown";
 constexpr const char* SETTINGS_PROTECTSELECTEDAPPS = "protectSelectedApps";
 constexpr const char* SETTINGS_VPNDISABLEDAPPS = "vpnDisabledApps";
-constexpr const char* SETTINGS_MULTIHOP_TUNNEL = "multihopTunnel";
 constexpr const char* SETTINGS_DEVMODE_FEATURE_FLAGS = "devmodeFeatureFlags";
 
 #ifdef MVPN_IOS
@@ -223,9 +222,6 @@ GETSETDEFAULT(FeatureLocalAreaAccess::instance()->isSupported() &&
               localNetworkAccessChanged)
 GETSETDEFAULT(SETTINGS_USER_DNS_DEFAULT, QString, toString, SETTINGS_USER_DNS,
               hasUserDNS, userDNS, setUserDNS, userDNSChanged)
-GETSETDEFAULT(SETTINGS_MULTIHOP_TUNNEL_DEFAULT, bool, toBool,
-              SETTINGS_MULTIHOP_TUNNEL, hasMultihopTunnel, multihopTunnel,
-              setMultihopTunnel, multihopTunnelChanged)
 GETSETDEFAULT(FeatureUnsecuredNetworkNotification::instance()->isSupported() &&
                   SETTINGS_UNSECUREDNETWORKALERT_DEFAULT,
               bool, toBool, SETTINGS_UNSECUREDNETWORKALERT,

--- a/src/settingsholder.cpp
+++ b/src/settingsholder.cpp
@@ -29,6 +29,9 @@ const QStringList SETTINGS_DEFAULT_EMPTY_LIST = QStringList();
 constexpr const char* SETTINGS_USER_DNS_DEFAULT = "";
 constexpr bool SETTINGS_MULTIHOP_TUNNEL_DEFAULT = false;
 const int SETTINGS_DNS_PROVIDER_DEFAULT = SettingsHolder::DnsProvider::Gateway;
+constexpr const char* SETTINGS_ENTRYSERVER_COUNTRYCODE_DEFAULT = nullptr;
+constexpr const char* SETTINGS_ENTRYSERVER_CITY_DEFAULT = nullptr;
+
 constexpr const char* SETTINGS_IPV6ENABLED = "ipv6Enabled";
 constexpr const char* SETTINGS_LOCALNETWORKACCESS = "localNetworkAccess";
 constexpr const char* SETTINGS_UNSECUREDNETWORKALERT = "unsecuredNetworkAlert";
@@ -61,7 +64,6 @@ constexpr const char* SETTINGS_CURRENTSERVER_COUNTRY = "currentServer/country";
 constexpr const char* SETTINGS_CURRENTSERVER_CITY = "currentServer/city";
 constexpr const char* SETTINGS_ENTRYSERVER_COUNTRYCODE =
     "entryServer/countryCode";
-constexpr const char* SETTINGS_ENTRYSERVER_COUNTRY = "entryServer/country";
 constexpr const char* SETTINGS_ENTRYSERVER_CITY = "entryServer/city";
 constexpr const char* SETTINGS_DEVICES = "devices";
 constexpr const char* SETTINGS_SURVEYS = "surveys";
@@ -172,7 +174,6 @@ void SettingsHolder::clear() {
   m_settings.remove(SETTINGS_CURRENTSERVER_COUNTRY);
   m_settings.remove(SETTINGS_CURRENTSERVER_CITY);
   m_settings.remove(SETTINGS_ENTRYSERVER_COUNTRYCODE);
-  m_settings.remove(SETTINGS_ENTRYSERVER_COUNTRY);
   m_settings.remove(SETTINGS_ENTRYSERVER_CITY);
   m_settings.remove(SETTINGS_DEVICES);
   m_settings.remove(SETTINGS_SURVEYS);
@@ -271,6 +272,14 @@ GETSETDEFAULT(SETTINGS_DEFAULT_EMPTY_LIST, QStringList, toStringList,
               SETTINGS_DEVMODE_FEATURE_FLAGS, hasDevModeFeatureFlags,
               devModeFeatureFlags, setDevModeFeatureFlags,
               devModeFeatureFlagsChanged);
+GETSETDEFAULT(SETTINGS_ENTRYSERVER_COUNTRYCODE_DEFAULT, QString, toString,
+              SETTINGS_ENTRYSERVER_COUNTRYCODE, hasEntryServerCountryCode,
+              entryServerCountryCode, setEntryServerCountryCode,
+              entryServerCountryCodeChanged)
+GETSETDEFAULT(SETTINGS_ENTRYSERVER_CITY_DEFAULT, QString, toString,
+              SETTINGS_ENTRYSERVER_CITY, hasEntryServerCity, entryServerCity,
+              setEntryServerCity, entryServerCityChanged)
+
 #undef GETSETDEFAULT
 
 #define GETSET(type, toType, key, has, get, set)                        \
@@ -309,13 +318,6 @@ GETSET(QString, toString, SETTINGS_CURRENTSERVER_COUNTRY,
        hasCurrentServerCountry, currentServerCountry, setCurrentServerCountry)
 GETSET(QString, toString, SETTINGS_CURRENTSERVER_CITY, hasCurrentServerCity,
        currentServerCity, setCurrentServerCity)
-GETSET(QString, toString, SETTINGS_ENTRYSERVER_COUNTRYCODE,
-       hasEntryServerCountryCode, entryServerCountryCode,
-       setEntryServerCountryCode)
-GETSET(QString, toString, SETTINGS_ENTRYSERVER_COUNTRY, hasEntryServerCountry,
-       entryServerCountry, setEntryServerCountry)
-GETSET(QString, toString, SETTINGS_ENTRYSERVER_CITY, hasEntryServerCity,
-       entryServerCity, setEntryServerCity)
 GETSET(QByteArray, toByteArray, SETTINGS_DEVICES, hasDevices, devices,
        setDevices)
 GETSET(QByteArray, toByteArray, SETTINGS_SURVEYS, hasSurveys, surveys,
@@ -470,6 +472,5 @@ void SettingsHolder::removeDevModeFeatureFlag(const QString& featureID) {
 
 void SettingsHolder::removeEntryServer() {
   m_settings.remove(SETTINGS_ENTRYSERVER_COUNTRYCODE);
-  m_settings.remove(SETTINGS_ENTRYSERVER_COUNTRY);
   m_settings.remove(SETTINGS_ENTRYSERVER_CITY);
 }

--- a/src/settingsholder.cpp
+++ b/src/settingsholder.cpp
@@ -78,6 +78,7 @@ constexpr const char* SETTINGS_TELEMETRYPOLICYSHOWN = "telemetryPolicyShown";
 constexpr const char* SETTINGS_PROTECTSELECTEDAPPS = "protectSelectedApps";
 constexpr const char* SETTINGS_VPNDISABLEDAPPS = "vpnDisabledApps";
 constexpr const char* SETTINGS_DEVMODE_FEATURE_FLAGS = "devmodeFeatureFlags";
+constexpr const char* SETTINGS_RECENT_CONNECTIONS = "recentConnections";
 
 #ifdef MVPN_IOS
 constexpr const char* SETTINGS_NATIVEIOSDATAMIGRATED = "nativeIOSDataMigrated";
@@ -177,6 +178,7 @@ void SettingsHolder::clear() {
   m_settings.remove(SETTINGS_SURVEYS);
   m_settings.remove(SETTINGS_IAPPRODUCTS);
   m_settings.remove(SETTINGS_POSTAUTHENTICATIONSHOWN);
+  m_settings.remove(SETTINGS_RECENT_CONNECTIONS);
 
   // We do not remove language, ipv6 and localnetwork settings.
 }
@@ -274,6 +276,10 @@ GETSETDEFAULT(SETTINGS_ENTRYSERVER_COUNTRYCODE_DEFAULT, QString, toString,
 GETSETDEFAULT(SETTINGS_ENTRYSERVER_CITY_DEFAULT, QString, toString,
               SETTINGS_ENTRYSERVER_CITY, hasEntryServerCity, entryServerCity,
               setEntryServerCity, entryServerCityChanged)
+GETSETDEFAULT(SETTINGS_DEFAULT_EMPTY_LIST, QStringList, toStringList,
+              SETTINGS_RECENT_CONNECTIONS, hasRecentConnections,
+              recentConnections, setRecentConnections,
+              recentConnectionsChanged);
 
 #undef GETSETDEFAULT
 

--- a/src/settingsholder.cpp
+++ b/src/settingsholder.cpp
@@ -27,7 +27,6 @@ constexpr bool SETTINGS_SERVERSWITCHNOTIFICATION_DEFAULT = true;
 constexpr bool SETTINGS_CONNECTIONSWITCHNOTIFICATION_DEFAULT = true;
 const QStringList SETTINGS_DEFAULT_EMPTY_LIST = QStringList();
 constexpr const char* SETTINGS_USER_DNS_DEFAULT = "";
-constexpr bool SETTINGS_MULTIHOP_TUNNEL_DEFAULT = false;
 const int SETTINGS_DNS_PROVIDER_DEFAULT = SettingsHolder::DnsProvider::Gateway;
 constexpr const char* SETTINGS_ENTRYSERVER_COUNTRYCODE_DEFAULT = nullptr;
 constexpr const char* SETTINGS_ENTRYSERVER_CITY_DEFAULT = nullptr;
@@ -465,6 +464,7 @@ void SettingsHolder::removeDevModeFeatureFlag(const QString& featureID) {
   }
   features.removeAll(featureID);
   setDevModeFeatureFlags(features);
+}
 
 void SettingsHolder::removeEntryServer() {
   m_settings.remove(SETTINGS_ENTRYSERVER_COUNTRYCODE);

--- a/src/settingsholder.cpp
+++ b/src/settingsholder.cpp
@@ -59,6 +59,10 @@ constexpr const char* SETTINGS_CURRENTSERVER_COUNTRYCODE =
     "currentServer/countryCode";
 constexpr const char* SETTINGS_CURRENTSERVER_COUNTRY = "currentServer/country";
 constexpr const char* SETTINGS_CURRENTSERVER_CITY = "currentServer/city";
+constexpr const char* SETTINGS_ENTRYSERVER_COUNTRYCODE =
+    "entryServer/countryCode";
+constexpr const char* SETTINGS_ENTRYSERVER_COUNTRY = "entryServer/country";
+constexpr const char* SETTINGS_ENTRYSERVER_CITY = "entryServer/city";
 constexpr const char* SETTINGS_DEVICES = "devices";
 constexpr const char* SETTINGS_SURVEYS = "surveys";
 constexpr const char* SETTINGS_CONSUMEDSURVEYS = "consumedSurveys";
@@ -167,6 +171,9 @@ void SettingsHolder::clear() {
   m_settings.remove(SETTINGS_CURRENTSERVER_COUNTRYCODE);
   m_settings.remove(SETTINGS_CURRENTSERVER_COUNTRY);
   m_settings.remove(SETTINGS_CURRENTSERVER_CITY);
+  m_settings.remove(SETTINGS_ENTRYSERVER_COUNTRYCODE);
+  m_settings.remove(SETTINGS_ENTRYSERVER_COUNTRY);
+  m_settings.remove(SETTINGS_ENTRYSERVER_CITY);
   m_settings.remove(SETTINGS_DEVICES);
   m_settings.remove(SETTINGS_SURVEYS);
   m_settings.remove(SETTINGS_IAPPRODUCTS);
@@ -302,6 +309,13 @@ GETSET(QString, toString, SETTINGS_CURRENTSERVER_COUNTRY,
        hasCurrentServerCountry, currentServerCountry, setCurrentServerCountry)
 GETSET(QString, toString, SETTINGS_CURRENTSERVER_CITY, hasCurrentServerCity,
        currentServerCity, setCurrentServerCity)
+GETSET(QString, toString, SETTINGS_ENTRYSERVER_COUNTRYCODE,
+       hasEntryServerCountryCode, entryServerCountryCode,
+       setEntryServerCountryCode)
+GETSET(QString, toString, SETTINGS_ENTRYSERVER_COUNTRY, hasEntryServerCountry,
+       entryServerCountry, setEntryServerCountry)
+GETSET(QString, toString, SETTINGS_ENTRYSERVER_CITY, hasEntryServerCity,
+       entryServerCity, setEntryServerCity)
 GETSET(QByteArray, toByteArray, SETTINGS_DEVICES, hasDevices, devices,
        setDevices)
 GETSET(QByteArray, toByteArray, SETTINGS_SURVEYS, hasSurveys, surveys,
@@ -453,4 +467,9 @@ void SettingsHolder::removeDevModeFeatureFlag(const QString& featureID) {
   }
   features.removeAll(featureID);
   setDevModeFeatureFlags(features);
+
+void SettingsHolder::removeEntryServer() {
+  m_settings.remove(SETTINGS_ENTRYSERVER_COUNTRYCODE);
+  m_settings.remove(SETTINGS_ENTRYSERVER_COUNTRY);
+  m_settings.remove(SETTINGS_ENTRYSERVER_CITY);
 }

--- a/src/settingsholder.h
+++ b/src/settingsholder.h
@@ -96,6 +96,11 @@ class SettingsHolder final : public QObject {
   GETSET(QString, hasCurrentServerCountry, currentServerCountry,
          setCurrentServerCountry)
   GETSET(QString, hasCurrentServerCity, currentServerCity, setCurrentServerCity)
+  GETSET(QString, hasEntryServerCountryCode, entryServerCountryCode,
+         setEntryServerCountryCode)
+  GETSET(QString, hasEntryServerCountry, entryServerCountry,
+         setEntryServerCountry)
+  GETSET(QString, hasEntryServerCity, entryServerCity, setEntryServerCity)
   GETSET(QByteArray, hasDevices, devices, setDevices)
   GETSET(QByteArray, hasSurveys, surveys, setSurveys)
   GETSET(QStringList, hasConsumedSurveys, consumedSurveys, setConsumedSurveys)
@@ -138,6 +143,7 @@ class SettingsHolder final : public QObject {
   void removeDevModeFeatureFlag(const QString& featureID);
 
   void addConsumedSurvey(const QString& surveyId);
+  void removeEntryServer();
 
 #ifdef MVPN_IOS
   GETSET(bool, hasNativeIOSDataMigrated, nativeIOSDataMigrated,

--- a/src/settingsholder.h
+++ b/src/settingsholder.h
@@ -43,6 +43,8 @@ class SettingsHolder final : public QObject {
                  dnsProviderChanged)
   Q_PROPERTY(
       QString userDNS READ userDNS WRITE setUserDNS NOTIFY userDNSChanged)
+  Q_PROPERTY(QStringList recentConnections READ recentConnections WRITE
+                 setRecentConnections NOTIFY recentConnectionsChanged)
 
  public:
   SettingsHolder();
@@ -128,6 +130,8 @@ class SettingsHolder final : public QObject {
   GETSET(QStringList, hasMissingApps, missingApps, setMissingApps)
   GETSET(QStringList, hasDevModeFeatureFlags, devModeFeatureFlags,
          setDevModeFeatureFlags);
+  GETSET(QStringList, hasRecentConnections, recentConnections,
+         setRecentConnections);
 
   void removeMissingApp(const QString& appID);
   void addMissingApp(const QString& appID);
@@ -186,6 +190,7 @@ class SettingsHolder final : public QObject {
   void devModeFeatureFlagsChanged(const QStringList& featureIDs);
   void entryServerCountryCodeChanged(const QString& value);
   void entryServerCityChanged(const QString& value);
+  void recentConnectionsChanged(const QStringList& value);
 
  private:
   explicit SettingsHolder(QObject* parent);

--- a/src/settingsholder.h
+++ b/src/settingsholder.h
@@ -39,8 +39,6 @@ class SettingsHolder final : public QObject {
                  NOTIFY developerUnlockChanged)
   Q_PROPERTY(bool stagingServer READ stagingServer WRITE setStagingServer NOTIFY
                  stagingServerChanged)
-  Q_PROPERTY(bool multihopTunnel READ multihopTunnel WRITE setMultihopTunnel
-                 NOTIFY multihopTunnelChanged)
   Q_PROPERTY(int dnsProvider READ dnsProvider WRITE setDNSProvider NOTIFY
                  dnsProviderChanged)
   Q_PROPERTY(
@@ -126,7 +124,7 @@ class SettingsHolder final : public QObject {
          setServerSwitchNotification);
   GETSET(bool, hasConnectionChangeNotification, connectionChangeNotification,
          setConnectionChangeNotification);
-  GETSET(bool, hasMultihopTunnel, multihopTunnel, setMultihopTunnel)
+
   GETSET(QStringList, hasMissingApps, missingApps, setMissingApps)
   GETSET(QStringList, hasDevModeFeatureFlags, devModeFeatureFlags,
          setDevModeFeatureFlags);
@@ -185,7 +183,6 @@ class SettingsHolder final : public QObject {
   void connectionChangeNotificationChanged(bool value);
   void developerUnlockChanged(bool value);
   void stagingServerChanged(bool value);
-  void multihopTunnelChanged(bool value);
   void devModeFeatureFlagsChanged(const QStringList& featureIDs);
   void entryServerCountryCodeChanged(const QString& value);
   void entryServerCityChanged(const QString& value);

--- a/src/settingsholder.h
+++ b/src/settingsholder.h
@@ -187,6 +187,8 @@ class SettingsHolder final : public QObject {
   void stagingServerChanged(bool value);
   void multihopTunnelChanged(bool value);
   void devModeFeatureFlagsChanged(const QStringList& featureIDs);
+  void entryServerCountryCodeChanged(const QString& value);
+  void entryServerCityChanged(const QString& value);
 
  private:
   explicit SettingsHolder(QObject* parent);

--- a/src/systemtrayhandler.cpp
+++ b/src/systemtrayhandler.cpp
@@ -188,9 +188,9 @@ void SystemTrayHandler::updateContextMenu() {
   m_lastLocationLabel->setVisible(true);
 
   QIcon flagIcon(QString(":/ui/resources/flags/%1.png")
-                     .arg(vpn->currentServer()->countryCode().toUpper()));
+                     .arg(vpn->currentServer()->exitCountryCode().toUpper()));
 
-  QString countryCode = vpn->currentServer()->countryCode();
+  QString countryCode = vpn->currentServer()->exitCountryCode();
   QString localizedCityName = vpn->currentServer()->localizedCityName();
   QString localizedCountryName =
       vpn->serverCountryModel()->localizedCountryName(countryCode);

--- a/src/systemtrayhandler.cpp
+++ b/src/systemtrayhandler.cpp
@@ -190,13 +190,18 @@ void SystemTrayHandler::updateContextMenu() {
   QIcon flagIcon(QString(":/ui/resources/flags/%1.png")
                      .arg(vpn->currentServer()->countryCode().toUpper()));
 
+  QString countryCode = vpn->currentServer()->countryCode();
+  QString localizedCityName = vpn->currentServer()->localizedCityName();
+  QString localizedCountryName =
+      vpn->serverCountryModel()->localizedCountryName(countryCode);
+
   m_lastLocationLabel->setIcon(flagIcon);
   m_lastLocationLabel->setText(
       //% "%1, %2"
       //: Location in the systray. %1 is the country, %2 is the city.
       qtTrId("vpn.systray.location")
-          .arg(vpn->currentServer()->countryName())
-          .arg(vpn->currentServer()->cityName()));
+          .arg(localizedCountryName)
+          .arg(localizedCityName));
   m_lastLocationLabel->setEnabled(vpn->controller()->state() ==
                                   Controller::StateOff);
 }

--- a/src/ui/components/VPNServerCountry.qml
+++ b/src/ui/components/VPNServerCountry.qml
@@ -13,7 +13,7 @@ VPNClickableRow {
     id: serverCountry
     objectName: "serverCountry-" + code
 
-    property bool cityListVisible: (code === VPNCurrentServer.countryCode)
+    property bool cityListVisible: (code === VPNCurrentServer.exitCountryCode)
     property real animationDuration: 200 + (citiesRepeater.count * 25)
     property var currentCityIndex
     property alias serverCountryName: countryName.text
@@ -177,7 +177,7 @@ VPNClickableRow {
                     stackview.pop();
                 }
                 height: 54
-                checked: code === VPNCurrentServer.countryCode && modelData[0] === VPNCurrentServer.cityName
+                checked: code === VPNCurrentServer.exitCountryCode && modelData[0] === VPNCurrentServer.exitCityName
                 isHoverable: cityListVisible
                 enabled: cityListVisible
                 Component.onCompleted: {

--- a/src/ui/components/VPNServerLabel.qml
+++ b/src/ui/components/VPNServerLabel.qml
@@ -34,7 +34,7 @@ RowLayout {
             Image {
                 id: flag
                 fillMode: Image.PreserveAspectFit
-                source: "../resources/flags/" + modelData.countryCode.toUpperCase() + ".png"
+                source: "../resources/flags/" + modelData.exitCountryCode.toUpperCase() + ".png"
 
                 Layout.preferredWidth: imgSize
                 Layout.preferredHeight: imgSize

--- a/src/ui/settings/ViewNetworkSettings.qml
+++ b/src/ui/settings/ViewNetworkSettings.qml
@@ -98,25 +98,6 @@ Item {
                 }
             }
 
-            VPNCheckBoxRow {
-                id: multihopTunnel
-                objectName: "settingMultihopTunnel"
-                visible: VPNFeatureList.get("multiHop").isSupported
-                Layout.rightMargin: Theme.windowMargin
-
-                labelText: VPNl18n.tr(VPNl18n.NetworkSettingsMultihopTitle)
-                //% "Protect your traffic by routing it through multiple servers"
-                subLabelText: qsTrId("vpn.settings.multihop.description")
-                isChecked: (VPNSettings.multihopTunnel)
-                isEnabled: vpnFlickable.vpnIsOff
-                showDivider: vpnFlickable.vpnIsOff
-                onClicked: {
-                    if (vpnFlickable.vpnIsOff) {
-                        VPNSettings.multihopTunnel = !VPNSettings.multihopTunnel
-                    }
-                }
-            }
-
             VPNSettingsItem {
                 objectName: "advancedDNSSettings"
                 anchors.left: parent.left

--- a/src/ui/views/ViewMain.qml
+++ b/src/ui/views/ViewMain.qml
@@ -102,7 +102,7 @@ VPNFlickable {
             descriptionText: qsTrId("vpn.servers.currentLocation").arg(VPNCurrentServer.localizedCityName)
 
             subtitleText: VPNCurrentServer.localizedCityName
-            imgSource:  "../resources/flags/" + VPNCurrentServer.countryCode.toUpperCase() + ".png"
+            imgSource:  "../resources/flags/" + VPNCurrentServer.exitCountryCode.toUpperCase() + ".png"
             disableRowWhen: (VPNController.state !== VPNController.StateOn && VPNController.state !== VPNController.StateOff) || box.connectionInfoVisible
         }
 

--- a/tests/auth/mocmozillavpn.cpp
+++ b/tests/auth/mocmozillavpn.cpp
@@ -67,9 +67,14 @@ void MozillaVPN::setAlert(AlertType) {}
 
 void MozillaVPN::errorHandle(ErrorHandler::ErrorType) {}
 
-const QList<Server> MozillaVPN::servers() const { return QList<Server>(); }
+const QList<Server> MozillaVPN::exitServers() const { return QList<Server>(); }
 
-void MozillaVPN::changeServer(const QString&, const QString&) {}
+const QList<Server> MozillaVPN::entryServers() const { return QList<Server>(); }
+
+bool MozillaVPN::multihop() const { return false; }
+
+void MozillaVPN::changeServer(const QString&, const QString&, const QString&,
+                              const QString&) {}
 
 void MozillaVPN::postAuthenticationCompleted() {}
 

--- a/tests/auth/mocmozillavpn.cpp
+++ b/tests/auth/mocmozillavpn.cpp
@@ -71,8 +71,6 @@ const QList<Server> MozillaVPN::exitServers() const { return QList<Server>(); }
 
 const QList<Server> MozillaVPN::entryServers() const { return QList<Server>(); }
 
-bool MozillaVPN::multihop() const { return false; }
-
 void MozillaVPN::changeServer(const QString&, const QString&, const QString&,
                               const QString&) {}
 

--- a/tests/unit/moccontroller.cpp
+++ b/tests/unit/moccontroller.cpp
@@ -27,7 +27,8 @@ void Controller::disconnected() {}
 
 void Controller::timerTimeout() {}
 
-void Controller::changeServer(const QString&, const QString&) {}
+void Controller::changeServer(const QString&, const QString&, const QString&,
+                              const QString&) {}
 
 void Controller::logout() {}
 

--- a/tests/unit/mocmozillavpn.cpp
+++ b/tests/unit/mocmozillavpn.cpp
@@ -69,9 +69,12 @@ void MozillaVPN::setAlert(AlertType) {}
 
 void MozillaVPN::errorHandle(ErrorHandler::ErrorType) {}
 
-const QList<Server> MozillaVPN::servers() const { return QList<Server>(); }
+const QList<Server> MozillaVPN::exitServers() const { return QList<Server>(); }
 
-void MozillaVPN::changeServer(const QString&, const QString&) {}
+const QList<Server> MozillaVPN::entryServers() const { return QList<Server>(); }
+
+void MozillaVPN::changeServer(const QString&, const QString&, const QString&,
+                              const QString&) {}
 
 void MozillaVPN::postAuthenticationCompleted() {}
 

--- a/tests/unit/testmodels.cpp
+++ b/tests/unit/testmodels.cpp
@@ -1072,6 +1072,7 @@ void TestModels::serverDataBasic() {
     QVERIFY(!sd.multihop());
     QCOMPARE(sd.entryCountryCode(), "");
     QCOMPARE(sd.entryCityName(), "");
+    QCOMPARE(sd.toString(), "serverCityName, serverCountryCode");
 
     {
       SettingsHolder settingsHolder;
@@ -1086,6 +1087,7 @@ void TestModels::serverDataBasic() {
       QVERIFY(!sd2.multihop());
       QCOMPARE(sd2.entryCountryCode(), "");
       QCOMPARE(sd2.entryCityName(), "");
+      QCOMPARE(sd2.toString(), "serverCityName, serverCountryCode");
 
       QCOMPARE(spy.count(), 1);
     }
@@ -1100,6 +1102,7 @@ void TestModels::serverDataBasic() {
   QVERIFY(!sd.multihop());
   QCOMPARE(sd.entryCountryCode(), "");
   QCOMPARE(sd.entryCityName(), "");
+  QCOMPARE(sd.toString(), "new City, new Country Code");
 
   sd.forget();
   QCOMPARE(spy.count(), 2);
@@ -1110,6 +1113,7 @@ void TestModels::serverDataBasic() {
   QVERIFY(!sd.multihop());
   QCOMPARE(sd.entryCountryCode(), "");
   QCOMPARE(sd.entryCityName(), "");
+  QCOMPARE(sd.toString(), "");
 
   {
     SettingsHolder settingsHolder;
@@ -1124,6 +1128,8 @@ void TestModels::serverDataBasic() {
   QVERIFY(sd.multihop());
   QCOMPARE(sd.entryCountryCode(), "entry Country Code");
   QCOMPARE(sd.entryCityName(), "entry City");
+  QCOMPARE(sd.toString(),
+           "entry City, entry Country Code -> new City, new Country Code");
 
   sd.forget();
   QCOMPARE(spy.count(), 3);
@@ -1134,6 +1140,16 @@ void TestModels::serverDataBasic() {
   QVERIFY(sd.multihop());
   QCOMPARE(sd.entryCountryCode(), "entry Country Code");
   QCOMPARE(sd.entryCityName(), "entry City");
+
+  sd.forget();
+  QVERIFY(sd.fromString("Eureka, CA, us -> McMurdo Station, aq"));
+  QVERIFY(sd.initialized());
+  QCOMPARE(sd.exitCountryCode(), "aq");
+  QCOMPARE(sd.exitCityName(), "McMurdo Station");
+  QVERIFY(sd.multihop());
+  QCOMPARE(sd.entryCountryCode(), "us");
+  QCOMPARE(sd.entryCityName(), "Eureka, CA");
+  QCOMPARE(sd.toString(), "Eureka, CA, us -> McMurdo Station, aq");
 }
 
 // User

--- a/tests/unit/testmodels.cpp
+++ b/tests/unit/testmodels.cpp
@@ -1006,8 +1006,8 @@ void TestModels::serverCountryModelPick() {
   {
     ServerData sd;
     QCOMPARE(m.pickIfExists("serverCountryCode", "serverCityCode", sd), true);
-    QCOMPARE(sd.countryCode(), "serverCountryCode");
-    QCOMPARE(sd.cityName(), "serverCityName");
+    QCOMPARE(sd.exitCountryCode(), "serverCountryCode");
+    QCOMPARE(sd.exitCityName(), "serverCityName");
     QCOMPARE(m.exists(sd), true);
 
     QCOMPARE(m.pickIfExists("serverCountryCode2", "serverCityCode", sd), false);
@@ -1017,16 +1017,16 @@ void TestModels::serverCountryModelPick() {
   {
     ServerData sd;
     m.pickRandom(sd);
-    QCOMPARE(sd.countryCode(), "serverCountryCode");
-    QCOMPARE(sd.cityName(), "serverCityName");
+    QCOMPARE(sd.exitCountryCode(), "serverCountryCode");
+    QCOMPARE(sd.exitCityName(), "serverCityName");
     QCOMPARE(m.exists(sd), true);
   }
 
   {
     ServerData sd;
     QCOMPARE(m.pickByIPv4Address("ipv4AddrIn", sd), true);
-    QCOMPARE(sd.countryCode(), "serverCountryCode");
-    QCOMPARE(sd.cityName(), "serverCityName");
+    QCOMPARE(sd.exitCountryCode(), "serverCountryCode");
+    QCOMPARE(sd.exitCityName(), "serverCityName");
     QCOMPARE(m.exists(sd), true);
 
     QCOMPARE(m.pickByIPv4Address("ipv4AddrIn2", sd), false);
@@ -1041,8 +1041,8 @@ void TestModels::serverDataBasic() {
   QSignalSpy spy(&sd, &ServerData::changed);
 
   QVERIFY(!sd.initialized());
-  QCOMPARE(sd.countryCode(), "");
-  QCOMPARE(sd.cityName(), "");
+  QCOMPARE(sd.exitCountryCode(), "");
+  QCOMPARE(sd.exitCityName(), "");
   QVERIFY(!sd.multihop());
   QCOMPARE(sd.entryCountryCode(), "");
   QCOMPARE(sd.entryCityName(), "");
@@ -1067,8 +1067,8 @@ void TestModels::serverDataBasic() {
     QCOMPARE(spy.count(), 1);
 
     QVERIFY(sd.initialized());
-    QCOMPARE(sd.countryCode(), "serverCountryCode");
-    QCOMPARE(sd.cityName(), "serverCityName");
+    QCOMPARE(sd.exitCountryCode(), "serverCountryCode");
+    QCOMPARE(sd.exitCityName(), "serverCityName");
     QVERIFY(!sd.multihop());
     QCOMPARE(sd.entryCountryCode(), "");
     QCOMPARE(sd.entryCityName(), "");
@@ -1081,8 +1081,8 @@ void TestModels::serverDataBasic() {
       ServerData sd2;
       QVERIFY(sd2.fromSettings());
       QVERIFY(sd2.initialized());
-      QCOMPARE(sd2.countryCode(), "serverCountryCode");
-      QCOMPARE(sd2.cityName(), "serverCityName");
+      QCOMPARE(sd2.exitCountryCode(), "serverCountryCode");
+      QCOMPARE(sd2.exitCityName(), "serverCityName");
       QVERIFY(!sd2.multihop());
       QCOMPARE(sd2.entryCountryCode(), "");
       QCOMPARE(sd2.entryCityName(), "");
@@ -1095,8 +1095,8 @@ void TestModels::serverDataBasic() {
   QCOMPARE(spy.count(), 2);
 
   QVERIFY(sd.initialized());
-  QCOMPARE(sd.countryCode(), "new Country Code");
-  QCOMPARE(sd.cityName(), "new City");
+  QCOMPARE(sd.exitCountryCode(), "new Country Code");
+  QCOMPARE(sd.exitCityName(), "new City");
   QVERIFY(!sd.multihop());
   QCOMPARE(sd.entryCountryCode(), "");
   QCOMPARE(sd.entryCityName(), "");
@@ -1105,8 +1105,8 @@ void TestModels::serverDataBasic() {
   QCOMPARE(spy.count(), 2);
 
   QVERIFY(!sd.initialized());
-  QCOMPARE(sd.countryCode(), "new Country Code");
-  QCOMPARE(sd.cityName(), "new City");
+  QCOMPARE(sd.exitCountryCode(), "new Country Code");
+  QCOMPARE(sd.exitCityName(), "new City");
   QVERIFY(!sd.multihop());
   QCOMPARE(sd.entryCountryCode(), "");
   QCOMPARE(sd.entryCityName(), "");
@@ -1119,8 +1119,8 @@ void TestModels::serverDataBasic() {
 
   sd.update("new Country Code", "new City", "entry Country Code", "entry City");
   QVERIFY(sd.initialized());
-  QCOMPARE(sd.countryCode(), "new Country Code");
-  QCOMPARE(sd.cityName(), "new City");
+  QCOMPARE(sd.exitCountryCode(), "new Country Code");
+  QCOMPARE(sd.exitCityName(), "new City");
   QVERIFY(sd.multihop());
   QCOMPARE(sd.entryCountryCode(), "entry Country Code");
   QCOMPARE(sd.entryCityName(), "entry City");
@@ -1129,8 +1129,8 @@ void TestModels::serverDataBasic() {
   QCOMPARE(spy.count(), 3);
 
   QVERIFY(!sd.initialized());
-  QCOMPARE(sd.countryCode(), "new Country Code");
-  QCOMPARE(sd.cityName(), "new City");
+  QCOMPARE(sd.exitCountryCode(), "new Country Code");
+  QCOMPARE(sd.exitCityName(), "new City");
   QVERIFY(sd.multihop());
   QCOMPARE(sd.entryCountryCode(), "entry Country Code");
   QCOMPARE(sd.entryCityName(), "entry City");

--- a/tests/unit/testmodels.cpp
+++ b/tests/unit/testmodels.cpp
@@ -1131,7 +1131,7 @@ void TestModels::serverDataBasic() {
   QVERIFY(!sd.initialized());
   QCOMPARE(sd.countryCode(), "new Country Code");
   QCOMPARE(sd.cityName(), "new City");
-  QVERIFY(!sd.multihop());
+  QVERIFY(sd.multihop());
   QCOMPARE(sd.entryCountryCode(), "entry Country Code");
   QCOMPARE(sd.entryCityName(), "entry City");
 }


### PR DESCRIPTION
This extends the `ServerData` class to hold an exit server and optional entry server, which permits the configuration of multihop tunnelling. From QML, this can be achieved by providing optional parameters to the `VPNCurrentServer.update()` or `VPNController.changeServer()` methods. When those options are omitted, only a single hop is used.

For example: `VPNController.changeServer("aq", "McMurdo Station", "ca", "North Pole")`

While we were at it, we also added a recent connections list to the `SettingsHolder` class which contains a list of up to 5 recent connections.