### PR TITLE
Reverted DNS setting string to old version

### DIFF
--- a/translations/strings.yaml
+++ b/translations/strings.yaml
@@ -178,7 +178,7 @@ whatsNewReleaseNotes:
   supportModalHeader: In-app support form
   supportModalBodyText: The in-app support form will allow you to contact support from within the VPN app. You can find it in the “Get help” section.
   dnsModalHeader: Custom DNS
-  dnsModalBodyText: Custom DNS servers allow for faster speed using local networks, features like ad-blocking and anti-tracking. You can find this feature in the “Network settings” section.
+  dnsModalBodyTextNew: Custom DNS servers allow for faster speed using local networks, features like ad-blocking and anti-tracking. You can find this feature in the “Network settings” section.
   dnsModalButtonText: Done
   tourPageHeader: What’s new
   tourSubHeader: Take the tour


### PR DESCRIPTION
New tour string includes adblock and anti-tracking reference. This is the only change.