### PR TITLE
Fix ping loss calculation if latency is zero

### DIFF
--- a/src/pinghelper.cpp
+++ b/src/pinghelper.cpp
@@ -179,7 +179,7 @@ double PingHelper::loss() const {
       QDateTime::currentMSecsSinceEpoch() - (PING_TIMOUT_SEC * 1000);
 
   for (const PingSendData& data : m_pingData) {
-    if (data.latency > 0) {
+    if (data.latency >= 0) {
       recvCount++;
       sendCount++;
     } else if ((data.timestamp > 0) && (data.timestamp < sendBefore)) {


### PR DESCRIPTION
The server test has been unstable for a while, and examining the logs it seems that we have a bug with the ping statistics that treats a latency of zero as a lost ping. This is unlikely in real life, but for the dummy client this results in connection instability and server switches.

The test instability occurs, because pings that are less than 1 second old are ignored from loss calculation, resulting in a few seconds of delay before the instability manifests and opens a timing window for a race with the test driver.

The fix is to consider a ping latency of zero as valid.

Closes: #1640 