### PR TITLE
Fix #1653 - Open DNS view to correct tab

### DIFF
--- a/src/ui/settings/ViewAdvancedDNSSettings.qml
+++ b/src/ui/settings/ViewAdvancedDNSSettings.qml
@@ -101,6 +101,11 @@ Item {
             }
 
         ]
+        Component.onCompleted: {
+            if (VPNSettings.dnsProvider !== VPNSettings.Gateway) {
+                return tabs.setCurrentTabIndex(1)
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Open DNS view to correct tab based on the user's DNS setting.
Fixes #1653 