### PR TITLE
Fix bug in multihop server switch that reverts to single-hop

### DIFF
--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -423,8 +423,9 @@ void Controller::disconnected() {
   }
 
   if (nextStep == None && m_state == StateSwitching) {
-    MozillaVPN::instance()->changeServer(m_switchingCountryCode,
-                                         m_switchingCity);
+    MozillaVPN* vpn = MozillaVPN::instance();
+    vpn->changeServer(m_switchingExitCountry, m_switchingExitCity,
+                      m_switchingEntryCountry, m_switchingEntryCity);
     activate();
     return;
   }
@@ -466,8 +467,10 @@ void Controller::changeServer(const QString& countryCode, const QString& city,
 
   m_currentCity = vpn->currentServer()->exitCityName();
   m_currentCountryCode = vpn->currentServer()->exitCountryCode();
-  m_switchingCountryCode = countryCode;
-  m_switchingCity = city;
+  m_switchingExitCountry = countryCode;
+  m_switchingExitCity = city;
+  m_switchingEntryCountry = entryCountryCode;
+  m_switchingEntryCity = entryCity;
 
   setState(StateSwitching);
 
@@ -750,5 +753,6 @@ QString Controller::currentLocalizedCityName() const {
 }
 
 QString Controller::switchingLocalizedCityName() const {
-  return ServerI18N::translateCityName(m_switchingCountryCode, m_switchingCity);
+  return ServerI18N::translateCityName(m_switchingExitCountry,
+                                       m_switchingExitCity);
 }

--- a/src/controller.h
+++ b/src/controller.h
@@ -64,8 +64,6 @@ class Controller final : public QObject {
 
   QString currentLocalizedCityName() const;
 
-  const QString& switchingCountryCode() const { return m_switchingCountryCode; }
-
   QString switchingLocalizedCityName() const;
 
   bool silentSwitchServers();
@@ -141,8 +139,10 @@ class Controller final : public QObject {
   QString m_currentCountryCode;
   QString m_currentCity;
 
-  QString m_switchingCountryCode;
-  QString m_switchingCity;
+  QString m_switchingExitCountry;
+  QString m_switchingExitCity;
+  QString m_switchingEntryCountry;
+  QString m_switchingEntryCity;
 
   enum NextStep {
     None,


### PR DESCRIPTION
When performing a server switch, we store the server country and city codes in the `Controller` class, and change the server on receipt of the `disconnected()` signal. However, for this to work for multihop we need to store both the entry and exit server.