### PR TITLE
Fix assert when activating multihop on Mac and Windows

### DIFF
--- a/src/daemon/daemonlocalserverconnection.cpp
+++ b/src/daemon/daemonlocalserverconnection.cpp
@@ -131,9 +131,10 @@ void DaemonLocalServerConnection::parseCommand(const QByteArray& data) {
   logger.warning() << "Invalid command:" << type;
 }
 
-void DaemonLocalServerConnection::connected() {
+void DaemonLocalServerConnection::connected(int hopindex) {
   QJsonObject obj;
   obj.insert("type", "connected");
+  obj.insert("hopindex", QJsonValue(hopindex));
   write(obj);
 }
 

--- a/src/daemon/daemonlocalserverconnection.h
+++ b/src/daemon/daemonlocalserverconnection.h
@@ -21,7 +21,7 @@ class DaemonLocalServerConnection final : public QObject {
 
   void parseCommand(const QByteArray& json);
 
-  void connected();
+  void connected(int hopindex);
   void disconnected();
   void backendFailure();
 

--- a/src/localsocketcontroller.cpp
+++ b/src/localsocketcontroller.cpp
@@ -346,7 +346,13 @@ void LocalSocketController::parseCommand(const QByteArray& command) {
   }
 
   if (type == "connected") {
-    emit connected();
+    int hopindex = obj.value("hopindex").toInt(0);
+    if (hopindex != 0) {
+      logger.debug() << "hopindex" << hopindex << "connected";
+      return;
+    } else {
+      emit connected();
+    }
     return;
   }
 


### PR DESCRIPTION
We have encountered a sporadic assert when activating multihop connections on MacOS and Windows. This seems to be caused by generating a `connected()` signal for each peer in a multihop connection while the `Controller` class only expected a single signal for the exit server.

```
[31.08.2021 15:44:59.796] Debug: (controller - LocalSocketController) Reading
[31.08.2021 15:44:59.796] Debug: (controller - LocalSocketController) Parse command: {"type":"connected"}
[31.08.2021 15:44:59.796] Debug: (controller - TimerController) TimerController - Operation completed: 2 1
[31.08.2021 15:44:59.797] Error: ASSERT: "m_state == None" in file /Users/okirby/Work/mozilla-vpn-client/src/timercontroller.cpp, line 139 (timercontroller.cpp:139)
```

To fix this, we should pass the hopindex from daemon to client, and let the client decide how to handle non-zero hop indices.