### PR TITLE
Nit: Add link for inspector in dev menu

### DIFF
--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -454,6 +454,10 @@ void MozillaVPN::openLink(LinkType linkType) {
       url = NetworkRequest::apiBaseUrl();
       url.append("/r/vpn/subscriptionBlocked");
       break;
+    case LinkInspector:
+      Q_ASSERT(!Constants::inProduction());
+      url = "http://localhost:8766/";
+      break;
 
     default:
       qFatal("Unsupported link type!");

--- a/src/mozillavpn.h
+++ b/src/mozillavpn.h
@@ -81,6 +81,7 @@ class MozillaVPN final : public QObject {
     LinkTermsOfService,
     LinkPrivacyNotice,
     LinkUpdate,
+    LinkInspector,
     LinkSubscriptionBlocked,
   };
   Q_ENUM(LinkType)

--- a/src/ui/views/ViewDeveloper.qml
+++ b/src/ui/views/ViewDeveloper.qml
@@ -55,6 +55,23 @@ VPNFlickable {
             }
         }
     }
+    VPNExternalLinkListItem {
+        visible: stagingServer.isChecked && !restartRequired.visible
+        anchors.top: stagingServer.bottom
+        anchors.topMargin: Theme.windowMargin
+        anchors.left: stagingServer.left
+        anchors.leftMargin: Theme.windowMargin/2
+        width: parent.width - Theme.windowMargin
+
+        objectName: "openInspector"
+        title: "Open Inspector"
+        accessibleName: "Open Inspector"
+        iconSource:  "../resources/externalLink.svg"
+        backgroundColor: Theme.clickableRowBlue
+        onClicked: {
+            VPN.openLink(VPN.LinkInspector)
+        }
+    }
 
     VPNCheckBoxAlert {
         id: restartRequired


### PR DESCRIPTION
I never can't seem to remember the port for the inspector, how about we link to it in the dev-menu if its active :) 