### PR TITLE
Fix systemd packaging for Debian

### DIFF
--- a/linux/debian/mozillavpn.service
+++ b/linux/debian/mozillavpn.service
@@ -1,1 +1,0 @@
-../mozillavpn.service

--- a/linux/debian/rules.bionic
+++ b/linux/debian/rules.bionic
@@ -9,7 +9,7 @@ export LD_LIBRARY_PATH := $(QTDIR)/lib:$(LD_LIBRARY_PATH)
 DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
 
 %:
-	dh $@ --with systemd --warn-missing
+	dh $@ --with=systemd --warn-missing
 
 override_dh_auto_configure:
 	python3 scripts/importLanguages.py
@@ -18,3 +18,13 @@ override_dh_auto_configure:
 override_dh_installdocs:
 
 override_dh_installinfo:
+
+override_dh_installsystemd:
+	dh_installsystemd linux/mozillavpn.service
+
+override_dh_systemd_start:
+	dh_systemd_start linux/mozillavpn.service
+
+override_dh_systemd_enable:
+	dh_systemd_enable linux/mozillavpn.service
+

--- a/linux/debian/rules.focal
+++ b/linux/debian/rules.focal
@@ -8,7 +8,7 @@ export LD_LIBRARY_PATH := $(QTDIR)/lib:$(LD_LIBRARY_PATH)
 DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
 
 %:
-	dh $@ --with systemd --warn-missing
+	dh $@ --with=systemd --warn-missing
 
 override_dh_auto_configure:
 	python3 scripts/importLanguages.py
@@ -17,3 +17,13 @@ override_dh_auto_configure:
 override_dh_installdocs:
 
 override_dh_installinfo:
+
+override_dh_installsystemd:
+	dh_installsystemd linux/mozillavpn.service
+
+override_dh_systemd_start:
+	dh_systemd_start linux/mozillavpn.service
+
+override_dh_systemd_enable:
+	dh_systemd_enable linux/mozillavpn.service
+

--- a/linux/debian/rules.groovy
+++ b/linux/debian/rules.groovy
@@ -5,7 +5,7 @@ export DH_VERBOSE=1
 DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
 
 %:
-	dh $@ --with systemd --warn-missing
+	dh $@ --with=systemd --warn-missing
 
 override_dh_auto_configure:
 	python3 scripts/importLanguages.py
@@ -14,3 +14,13 @@ override_dh_auto_configure:
 override_dh_installdocs:
 
 override_dh_installinfo:
+
+override_dh_installsystemd:
+	dh_installsystemd linux/mozillavpn.service
+
+override_dh_systemd_start:
+	dh_systemd_start linux/mozillavpn.service
+
+override_dh_systemd_enable:
+	dh_systemd_enable linux/mozillavpn.service
+

--- a/linux/debian/rules.hirsute
+++ b/linux/debian/rules.hirsute
@@ -5,7 +5,7 @@ export DH_VERBOSE=1
 DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
 
 %:
-	dh $@ --with systemd --warn-missing
+	dh $@ --with=systemd --warn-missing
 
 override_dh_auto_configure:
 	python3 scripts/importLanguages.py
@@ -14,3 +14,13 @@ override_dh_auto_configure:
 override_dh_installdocs:
 
 override_dh_installinfo:
+
+override_dh_installsystemd:
+	dh_installsystemd linux/mozillavpn.service
+
+override_dh_systemd_start:
+	dh_systemd_start linux/mozillavpn.service
+
+override_dh_systemd_enable:
+	dh_systemd_enable linux/mozillavpn.service
+


### PR DESCRIPTION
After moving `mozillavpn.service` and replacing it with a symlink in commit 92beeb927c79ae90b282ce83a8d2c63518dcea00, we broke the systemd helpers in the Debian packages. To fix it, we remove the symlink and override the systemd debhelpers with the path to the real `mozillavpn.service` file.