### PR TITLE
Init IAP handler lazy to handle onCreateRace

### DIFF
--- a/src/platforms/android/androidiaphandler.cpp
+++ b/src/platforms/android/androidiaphandler.cpp
@@ -24,10 +24,29 @@ constexpr auto CLASSNAME = "org.mozilla.firefox.vpn.InAppPurchase";
 
 AndroidIAPHandler::AndroidIAPHandler(QObject* parent) : IAPHandler(parent) {
   MVPN_COUNT_CTOR(AndroidIAPHandler);
+  maybeInit();
+}
 
+AndroidIAPHandler::~AndroidIAPHandler() {
+  MVPN_COUNT_DTOR(AndroidIAPHandler);
+  QAndroidJniObject::callStaticMethod<void>(
+      "org/mozilla/firefox/vpn/InAppPurchase", "deinit", "()V");
+}
+
+void AndroidIAPHandler::maybeInit() {
+  if (m_init) {
+    return;
+  }
   // Init the billing client
   auto appContext = QtAndroid::androidActivity().callObjectMethod(
       "getApplicationContext", "()Landroid/content/Context;");
+  if (!appContext.isValid()) {
+    // This is a race condition, we could be here while android has not finished
+    // activity::onCreate on the Ui thread. In this case the context is null.
+      logger.debug() << "Android IAP handler init skipped";
+    return;
+  }
+  logger.debug() << "Android IAP handler init";
   QAndroidJniObject::callStaticMethod<void>(
       "org/mozilla/firefox/vpn/InAppPurchase", "init",
       "(Landroid/content/Context;)V", appContext.object());
@@ -59,15 +78,12 @@ AndroidIAPHandler::AndroidIAPHandler(QObject* parent) : IAPHandler(parent) {
                          sizeof(methods) / sizeof(methods[0]));
     env->DeleteLocalRef(objectClass);
   });
-}
-
-AndroidIAPHandler::~AndroidIAPHandler() {
-  MVPN_COUNT_DTOR(AndroidIAPHandler);
-  QAndroidJniObject::callStaticMethod<void>(
-      "org/mozilla/firefox/vpn/InAppPurchase", "deinit", "()V");
+  m_init = true;
 }
 
 void AndroidIAPHandler::nativeRegisterProducts() {
+  maybeInit();
+  Q_ASSERT(m_init);
   // Convert products to JSON
   QJsonArray jsonProducts;
   for (auto p : m_products) {
@@ -89,6 +105,8 @@ void AndroidIAPHandler::nativeRegisterProducts() {
 }
 
 void AndroidIAPHandler::nativeStartSubscription(Product* product) {
+  maybeInit();
+  Q_ASSERT(m_init);
   auto jniString = QAndroidJniObject::fromString(product->m_name);
   auto appActivity = QtAndroid::androidActivity();
   QAndroidJniObject::callStaticMethod<void>(
@@ -98,6 +116,8 @@ void AndroidIAPHandler::nativeStartSubscription(Product* product) {
 }
 
 void AndroidIAPHandler::launchPlayStore() {
+  maybeInit();
+  Q_ASSERT(m_init);
   auto appActivity = QtAndroid::androidActivity();
   QAndroidJniObject::callStaticMethod<void>(
       "org/mozilla/firefox/vpn/InAppPurchase", "launchPlayStore",

--- a/src/platforms/android/androidiaphandler.h
+++ b/src/platforms/android/androidiaphandler.h
@@ -22,6 +22,7 @@ class AndroidIAPHandler final : public IAPHandler {
   void nativeStartSubscription(Product* product) override;
 
  private:
+  void maybeInit();
   void updateProductsInfo(const QJsonArray& products);
   void processPurchase(QJsonObject purchase);
   void validatePurchase(QJsonObject purchase);
@@ -37,6 +38,9 @@ class AndroidIAPHandler final : public IAPHandler {
                                           jstring data);
   static void onSkuDetailsFailed(JNIEnv* env, jobject thiz, jstring data);
   static void onSubscriptionFailed(JNIEnv* env, jobject thiz, jstring data);
+
+ private:
+  bool m_init = false;
 };
 
 #endif  // ANDROIDIAPHANDLER_H


### PR DESCRIPTION
Should close https://github.com/mozilla-mobile/mozilla-vpn-client/issues/1686 - we kinda have a race condition here :) 

From QA logs 
```
09-02 10:05:46.080  6703  6723 I System  : Loaded time zone names for "c_DEFAULT_Default" in 12ms (12ms in ICU)

09-02 10:05:46.086  6703  6703 W System.err: java.lang.NoSuchMethodError: no non-static method "Lorg/mozilla/firefox/vpn/InAppPurchase;.<init>()V"
{....}

09-02 10:05:46.103  6703  6703 F zygote64: java_vm_ext.cc:504] JNI DETECTED ERROR IN APPLICATION: java_object == null

```