### PR TITLE
Fix xcode patcher for iOS and MacOS builds, update Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,11 @@ The built up will show up in `Release/Mozilla VPN.app` (relative to the root of 
 
 ### IOS
 
-The IOS procedure is similar to the macOS one:
+For IOS, we recommend installing Qt using the [Qt Online Installer](https://www.qt.io/download-qt-installer). We recommend installing
+the latest available release of Qt5 for IOS. You may also need to enable support for Qt Charts and Qt Network Qt Network Authorization
+during the installation.
+
+Once Qt has been installed, the IOS procedure is similar to the macOS one:
 
 1. Install XCodeProj:
 ```

--- a/scripts/xcode_patcher.rb
+++ b/scripts/xcode_patcher.rb
@@ -92,8 +92,10 @@ class XCodeprojPatcher
       groupId = "";
       if (platform == 'macos')
         groupId = configHash['DEVELOPMENT_TEAM'] + "." + configHash['GROUP_ID_MACOS']
+        config.build_settings['APP_ID_MACOS'] ||= configHash['APP_ID_MACOS']
       else
         groupId = configHash['GROUP_ID_IOS']
+        config.build_settings['GROUP_ID_IOS'] ||= configHash['GROUP_ID_IOS']
       end
 
       config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= [


### PR DESCRIPTION
To build for iOS, we lack a script to build Qt from sources so it's only really practical to use the Qt online installer for iOS development.

We also have a problem that the `APP_ID_MACOS` and `GROUP_ID_IOS` variables don't get expanded when used by Xcode, so for code-signing to work we must set them in the `config.build_settings` dictionary for that to succeed.