### PR TITLE
Clear WebviewStorage on Auth abort

### DIFF
--- a/android/src/org/mozilla/firefox/vpn/qt/VPNWebView.java
+++ b/android/src/org/mozilla/firefox/vpn/qt/VPNWebView.java
@@ -11,8 +11,10 @@ import android.view.Window;
 import android.view.WindowManager;
 import android.webkit.WebSettings;
 import android.webkit.WebSettings.PluginState;
+import android.webkit.WebStorage;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
+import android.webkit.CookieManager;
 
 import android.util.Log;
 
@@ -154,5 +156,11 @@ public class VPNWebView
             m_activity.getWindow().clearFlags(WindowManager.LayoutParams.FLAG_SECURE);
           }
         });
+    }
+    public void clearStorage(){
+        m_webView.clearCache(true);
+        CookieManager.getInstance().removeAllCookies(null);
+        CookieManager.getInstance().flush();
+        WebStorage.getInstance().deleteAllData();
     }
 }

--- a/src/platforms/android/androidauthenticationview.qml
+++ b/src/platforms/android/androidauthenticationview.qml
@@ -33,6 +33,7 @@ Item {
 
             onClicked: {
                 VPNAndroidUtils.abortAuthentication();
+                authWebview.clearStorage();
                 mainStackView.pop(StackView.Immediate);
             }
 
@@ -72,6 +73,7 @@ Item {
     }
 
     VPNAndroidWebView {
+        id: authWebview
         url: VPNAndroidUtils.url
 
         height: parent.height - menuBar.height

--- a/src/platforms/android/androidwebview.cpp
+++ b/src/platforms/android/androidwebview.cpp
@@ -245,8 +245,7 @@ void AndroidWebView::invalidateSceneGraph() {
   }
 }
 
-void AndroidWebView::clearStorage(){
-  QtAndroid::runOnAndroidThreadSync([this]() {
-    m_object.callMethod<void>("clearStorage", "()V");
-  });
+void AndroidWebView::clearStorage() {
+  QtAndroid::runOnAndroidThreadSync(
+      [this]() { m_object.callMethod<void>("clearStorage", "()V"); });
 }

--- a/src/platforms/android/androidwebview.cpp
+++ b/src/platforms/android/androidwebview.cpp
@@ -244,3 +244,9 @@ void AndroidWebView::invalidateSceneGraph() {
     m_window->setVisible(false);
   }
 }
+
+void AndroidWebView::clearStorage(){
+  QtAndroid::runOnAndroidThreadSync([this]() {
+    m_object.callMethod<void>("clearStorage", "()V");
+  });
+}

--- a/src/platforms/android/androidwebview.h
+++ b/src/platforms/android/androidwebview.h
@@ -26,6 +26,7 @@ class AndroidWebView : public QQuickItem {
 
   QUrl url() const;
   void setUrl(const QUrl& url);
+  Q_INVOKABLE void clearStorage();
 
  protected:
   void componentComplete() override;


### PR DESCRIPTION
We should clear that on close, so people can't get stuck like #1657

closes #1657