### PR TITLE
Disable v6 custom DNS for now

### DIFF
--- a/src/dnshelper.cpp
+++ b/src/dnshelper.cpp
@@ -71,7 +71,15 @@ bool DNSHelper::isMullvadDNS(const QString& address) {
 bool DNSHelper::validateUserDNS(const QString& dns) {
   QHostAddress address = QHostAddress(dns);
   logger.debug() << "checking -> " << dns << "==" << !address.isNull();
-  return !address.isNull();
+  if (address.isNull()) {
+    return false;
+  }
+  if (address.protocol() == QAbstractSocket::IPv6Protocol) {
+    // We have an issue on Windows with v6 dns, lets disable v6 dns for now.
+    // See: https://github.com/mozilla-mobile/mozilla-vpn-client/issues/1714
+    return false;
+  }
+  return true;
 }
 
 // static


### PR DESCRIPTION
Since a custom v6 DNS is rare, we should disable those while i figure out why the v6 dns fwp_condition_values is corrupting the memory but other v6 fwp_values work fine🙈 

Closes https://github.com/mozilla-mobile/mozilla-vpn-client/issues/1633