### PR TITLE
Fix MacOS local socket hang on queued JSON commands

### DIFF
--- a/src/daemon/daemonlocalserverconnection.cpp
+++ b/src/daemon/daemonlocalserverconnection.cpp
@@ -48,13 +48,16 @@ void DaemonLocalServerConnection::readData() {
   logger.debug() << "Read Data";
 
   Q_ASSERT(m_socket);
-  QByteArray input = m_socket->readAll();
-  m_buffer.append(input);
 
   while (true) {
     int pos = m_buffer.indexOf("\n");
     if (pos == -1) {
-      break;
+      QByteArray input = m_socket->readAll();
+      if (input.isEmpty()) {
+        break;
+      }
+      m_buffer.append(input);
+      continue;
     }
 
     QByteArray line = m_buffer.left(pos);


### PR DESCRIPTION
When the client is able to send JSON commands to the daemon faster than the Qt event loop is able to process them, this can lead to data getting queued up on the socket, but without generating a `readyRead()` signal. This manifests as instability in the daemon where some commands get delayed for ridiculously long periods of time.

To resolve the issue, keep calling `readAll()` until it returns an empty `QByteArray`, indicating that the socket was empty or an error occured.

Closes: #1706