### PR TITLE
Wrap “WhatsNew” overview title

### DIFF
--- a/src/ui/components/VPNFeatureTourPopup.qml
+++ b/src/ui/components/VPNFeatureTourPopup.qml
@@ -5,8 +5,8 @@ import "../themes/themes.js" as Theme
 VPNPopup {
     id: root
 
+    anchors.centerIn: parent
     maxWidth: Theme.desktopAppWidth
-    topMargin: Theme.windowMargin * 2
     contentItem: VPNFeatureTour {
         id: featureTour
 

--- a/src/ui/components/VPNIconAndLabel.qml
+++ b/src/ui/components/VPNIconAndLabel.qml
@@ -38,7 +38,10 @@ Item {
         Accessible.ignored: true
         wrapMode: Text.WordWrap
         leftPadding: icon.width + 14
+        lineHeightMode: Text.FixedHeight
+        lineHeight: Theme.labelLineHeight
         rightPadding: icon.width + 14
+        topPadding: Theme.labelLineHeight - font.pixelSize
         width: title.implicitWidth < parent.width ? undefined : parent.width
 
         Rectangle {

--- a/src/ui/settings/ViewWhatsNew.qml
+++ b/src/ui/settings/ViewWhatsNew.qml
@@ -82,6 +82,7 @@ Item {
 
                         title: feature.displayName
                         icon: feature.iconPath
+                        Layout.fillWidth: true
                     }
 
                     VPNTextBlock {


### PR DESCRIPTION
Fixes longer titles not wrapping in the “WhatsNew” overview list.

| Before | After |
| --- | --- |
| <img width="472" alt="text-not-wrapping" src="https://user-images.githubusercontent.com/13835474/132316128-75bb4d55-8138-4886-b6d4-b76de49f8f87.png"> | <img width="472" alt="text-wrapping" src="https://user-images.githubusercontent.com/13835474/132316154-89d701ca-f86d-4d68-a930-d0e54daba7bf.png"> |

