### PR TITLE
Do not create an IAP Handler Obj

### DIFF
--- a/src/platforms/android/androidiaphandler.cpp
+++ b/src/platforms/android/androidiaphandler.cpp
@@ -71,12 +71,14 @@ void AndroidIAPHandler::maybeInit() {
         {"onSkuDetailsReceived", "(Ljava/lang/String;)V",
          reinterpret_cast<void*>(onSkuDetailsReceived)},
     };
-    QAndroidJniObject javaClass(CLASSNAME);
     QAndroidJniEnvironment env;
-    jclass objectClass = env->GetObjectClass(javaClass.object<jobject>());
+    jclass objectClass = env.findClass(CLASSNAME);
+    if (objectClass == nullptr) {
+      logger.error() << "Android-IAP Class is Null?!";
+      return;
+    }
     env->RegisterNatives(objectClass, methods,
                          sizeof(methods) / sizeof(methods[0]));
-    env->DeleteLocalRef(objectClass);
   });
   m_init = true;
 }


### PR DESCRIPTION
Crash reason for https://github.com/mozilla-mobile/mozilla-vpn-client/issues/1686
```
QAndroidJniObject javaClass(CLASSNAME);
```
This line creates an instance of CLASSNAME. But as this does not have a default constructor it is null; jni causes a crash on ```env->GetObjectClass(javaClass.object<jobject>()); ```

