### PR TITLE
Choose a random entry server when loading multihop tab

### DIFF
--- a/src/models/servercountrymodel.cpp
+++ b/src/models/servercountrymodel.cpp
@@ -170,6 +170,26 @@ bool ServerCountryModel::pickIfExists(const QString& countryCode,
   return false;
 }
 
+QStringList ServerCountryModel::pickRandom() {
+  logger.debug() << "Choosing a random server";
+
+  QStringList serverTuple;
+
+  quint32 countryId =
+      QRandomGenerator::global()->generate() % m_countries.length();
+  const ServerCountry& country = m_countries[countryId];
+
+  quint32 cityId =
+      QRandomGenerator::global()->generate() % country.cities().length();
+  const ServerCity& city = country.cities().at(cityId);
+
+  serverTuple.append(country.code());
+  serverTuple.append(city.name());
+  serverTuple.append(
+      ServerI18N::translateCityName(country.code(), city.name()));
+  return serverTuple;
+}
+
 void ServerCountryModel::pickRandom(ServerData& data) const {
   logger.debug() << "Choosing a random server";
 

--- a/src/models/servercountrymodel.h
+++ b/src/models/servercountrymodel.h
@@ -15,6 +15,7 @@
 class ServerData;
 
 class ServerCountryModel final : public QAbstractListModel {
+  Q_OBJECT
   Q_DISABLE_COPY_MOVE(ServerCountryModel)
 
  public:
@@ -33,6 +34,8 @@ class ServerCountryModel final : public QAbstractListModel {
   [[nodiscard]] bool fromJson(const QByteArray& data);
 
   bool initialized() const { return !m_rawJson.isEmpty(); }
+
+  Q_INVOKABLE QStringList pickRandom();
 
   void pickRandom(ServerData& data) const;
 

--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -980,12 +980,6 @@ void MozillaVPN::changeServer(const QString& countryCode, const QString& city,
   SettingsHolder::instance()->setRecentConnections(recent);
 }
 
-const Server& MozillaVPN::randomHop(ServerData& data) const {
-  m_private->m_serverCountryModel.pickRandom(data);
-  const QList<Server> servers = m_private->m_serverCountryModel.servers(data);
-  return Server::weightChooser(servers);
-}
-
 void MozillaVPN::postAuthenticationCompleted() {
   logger.debug() << "Post authentication completed";
 

--- a/src/mozillavpn.h
+++ b/src/mozillavpn.h
@@ -223,8 +223,6 @@ class MozillaVPN final : public QObject {
 
   void silentSwitch();
 
-  const Server& randomHop(ServerData& data) const;
-
   const QString versionString() const { return QString(APP_VERSION); }
 
   const QString buildNumber() const { return QString(BUILD_ID); }

--- a/src/ui/views/ViewServers.qml
+++ b/src/ui/views/ViewServers.qml
@@ -92,10 +92,10 @@ Item {
         }
         handleTabClick: (tab) => {
             if (multiHopStackView && multiHopStackView.depth > 1) {
-                    // Return to the Multi-hop main view when the Multi-hop tab
-                    // is clicked from a Multi-hop entry or exit server list
-                    multiHopStackView.pop();
-                }
+                // Return to the Multi-hop main view when the Multi-hop tab
+                // is clicked from a Multi-hop entry or exit server list
+                multiHopStackView.pop();
+            }
 
             if (tab.objectName === "tabSingleHop") {
                 // Do single hop things
@@ -103,9 +103,12 @@ Item {
                 singleHopServerList.centerActiveServer();
                 return;
             }
+            else if (multiHopEntryServer[0] === "") {
+                // Choose a random entry server when switching to multihop
+                multiHopEntryServer = VPNServerCountryModel.pickRandom();
+            }
         }
     }
-
 
     Component.onCompleted: {
         if (!VPNFeatureList.get("multiHop").isSupported) {
@@ -113,10 +116,10 @@ Item {
         }
 
         serversTabs.stackContent.push(multiHopStackView);
-      if (VPNCurrentServer.entryCountryCode && VPNCurrentServer.entryCountryCode !== "") {
-          // Set default tab to multi-hop
-          return serversTabs.setCurrentTabIndex(1);
-      }
+        if (VPNCurrentServer.entryCountryCode && VPNCurrentServer.entryCountryCode !== "") {
+            // Set default tab to multi-hop
+            return serversTabs.setCurrentTabIndex(1);
+        }
     }
 }
 

--- a/tests/unit/testmodels.cpp
+++ b/tests/unit/testmodels.cpp
@@ -1023,6 +1023,15 @@ void TestModels::serverCountryModelPick() {
   }
 
   {
+    SettingsHolder settingsHolder;
+    QStringList tuple = m.pickRandom();
+    QCOMPARE(tuple.length(), 3);
+    QCOMPARE(tuple.at(0), "serverCountryCode");
+    QCOMPARE(tuple.at(1), "serverCityName");
+    QCOMPARE(tuple.at(2), "serverCityName");  // Localized?
+  }
+
+  {
     ServerData sd;
     QCOMPARE(m.pickByIPv4Address("ipv4AddrIn", sd), true);
     QCOMPARE(sd.exitCountryCode(), "serverCountryCode");


### PR DESCRIPTION
On the server selection view, when switching from single-hop to multihop, the entry server is left uninitialized, which looks weird and inconsistent. To fix this, we make `ServerCountryModel::pickRandom()` invokable by QML and use it to pick an entry server at random.