### PR TITLE
Fix developer unlock timer due to typo

### DIFF
--- a/src/ui/views/ViewGetHelp.qml
+++ b/src/ui/views/ViewGetHelp.qml
@@ -41,7 +41,7 @@ Item {
                 VPNSettings.developerUnlock = true
             }
             else if (!VPNSettings.developerUnlock) {
-                unlockTimeout.restaabrt()
+                unlockTimeout.restart()
                 unlockCounter = unlockCounter + 1
             }
         }


### PR DESCRIPTION
Unlocking the developer menu produces a QML error due to a typo of the `restart()` method, which also means that the unlock counter doesn't get reset after 10s of inactivity anymore.

```
[07.09.2021 11:14:37.965] Warning: qrc:/ui/views/ViewGetHelp.qml:44: TypeError: Property 'restaabrt' of object QQmlTimer(0x3fe2470) is not a function (ViewGetHelp.qml:44)
```
