### PR TITLE
Disable switch notifications when exit server is unchanged

### DIFF
--- a/src/notificationhandler.cpp
+++ b/src/notificationhandler.cpp
@@ -70,6 +70,12 @@ void NotificationHandler::showNotification() {
           // Dont show notification if it's turned off.
           return;
         }
+        if ((m_switchingLocalizedServerCountry == localizedCountryName) &&
+            (m_switchingLocalizedServerCity == localizedCityName)) {
+          // Don't show notifications unless the exit server changed, see:
+          // https://github.com/mozilla-mobile/mozilla-vpn-client/issues/1719
+          return;
+        }
 
         //% "VPN Switched Servers"
         title = qtTrId("vpn.systray.statusSwitch.title");


### PR DESCRIPTION
When changing only the entry server for a multihop connection (or switching from single to multihop), the VPN client can generate a confusing server switch notification (eg: "Switched from Mos Eisley, Tatooine to Mos Eisley, Tatooine"). Since a proper fix for this likely requires a string change, we can work around the issue by simply supressing the notification when the exit server is unchanged.

See: #1719 