### PR TITLE
Hide WhatsNew in settings when there are no new features

### DIFF
--- a/src/ui/settings/ViewSettingsMenu.qml
+++ b/src/ui/settings/ViewSettingsMenu.qml
@@ -88,6 +88,7 @@ VPNFlickable {
             imageRightSrc: "../resources/chevron.svg"
             onClicked: settingsStackView.push("../settings/ViewWhatsNew.qml")
             showIndicator: VPNWhatsNewModel.hasUnseenFeature
+            visible: VPNWhatsNewModel.rowCount() > 0
         }
 
         VPNSettingsItem {


### PR DESCRIPTION
In case we do not have any new features that we would like to show this hides the WhatsNew menu item in the settings view.