### PR TITLE
Don't use Unicode character in alert strings on Windows

### DIFF
--- a/src/ui/components/VPNAlert.qml
+++ b/src/ui/components/VPNAlert.qml
@@ -186,15 +186,16 @@ Rectangle {
             anchors.verticalCenter: parent.verticalCenter
 
             Label {
+                property var whiteSpaceCharacter: Qt.platform.os === "windows" ? " " : "\u0001" 
                 id: label
-                 anchors.centerIn: parent
-                 text: alertBox.alertText + "\u0001" + "<b><u>"  + alertBox.alertActionText + "</b></u>"
-                 horizontalAlignment: Text.AlignHCenter
-                 font.pixelSize: Theme.fontSizeSmall
-                 color: style.fontColor
-                 width: labelWrapper.width - Theme.windowMargin
-                 wrapMode: Label.WordWrap
-             }
+                anchors.centerIn: parent
+                text: alertBox.alertText + whiteSpaceCharacter + "<b><u>"  + alertBox.alertActionText + "</b></u>"
+                horizontalAlignment: Text.AlignHCenter
+                font.pixelSize: Theme.fontSizeSmall
+                color: style.fontColor
+                width: labelWrapper.width - Theme.windowMargin
+                wrapMode: Label.WordWrap
+            }
         }
 
         VPNMouseArea {


### PR DESCRIPTION
The Unicode character added in #1728 to create space between `alertText` and `alertActionText` and fix #1455 is rendering as a smiley face on Windows (though not on macos, ios, or android emulators- need someone with a Linux machine to check on Linux). Injecting a blank space `" "` is correctly interpreted by the Windows build however. This adds a `whiteSpaceCharacter` property variable that checks if the platform is Windows and sets itself to `" "` or `\u0001` accordingly.

The smiley face: 
<img width="260" src="https://user-images.githubusercontent.com/22355127/132605107-a55ad159-208e-4c1a-96da-609a12d1b849.jpeg" />
