### PR TITLE
Make Desktop Auth the default auth type

### DIFF
--- a/src/authenticationlistener.cpp
+++ b/src/authenticationlistener.cpp
@@ -28,7 +28,10 @@ Logger logger(LOG_MAIN, "AuthenticationListener");
 AuthenticationListener* AuthenticationListener::create(
     QObject* parent, MozillaVPN::AuthenticationType authenticationType) {
   switch (authenticationType) {
+    case MozillaVPN::AuthenticationInApp:
+      return new AuthenticationInAppListener(parent);
     case MozillaVPN::AuthenticationInBrowser:
+    default:
 #if defined(MVPN_ANDROID)
       return new AndroidAuthenticationListener(parent);
 #elif defined(MVPN_IOS)
@@ -38,12 +41,6 @@ AuthenticationListener* AuthenticationListener::create(
 #else
       return new DesktopAuthenticationListener(parent);
 #endif
-    case MozillaVPN::AuthenticationInApp:
-      return new AuthenticationInAppListener(parent);
-
-    default:
-      Q_ASSERT(false);
-      return nullptr;
   }
 }
 


### PR DESCRIPTION
Re https://github.com/mozilla-mobile/mozilla-vpn-client/issues/1772
To be honest, I don't quite understand this crash. 

In `MozillaVPN::authenticate()` we correctly call `MozillaVPN::authenticateWithType(1 || 0) ` depending on the auth type. 
In the same function however in line 441 `new TaskAuthenticate(authenticationType)` something has changed that value, in some cases. Neither me nor qa can pinpoint when it happens, seems random. On my android device this tends to be then `0x65`(101) 🤷 

So then we return in AuthenticationListener::create a nullptr and then qt exits on the connection setup for it. 
We could just make desktopAuth the default case for any other value then "AuthenticationInApp" as ... well we're gonna replace it with that anyway :) 