### PR TITLE
Implement DNS utils for Windows

### DIFF
--- a/src/platforms/windows/daemon/dnsutilswindows.cpp
+++ b/src/platforms/windows/daemon/dnsutilswindows.cpp
@@ -1,0 +1,95 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "dnsutilswindows.h"
+#include "leakdetector.h"
+#include "logger.h"
+
+#include <QScopeGuard>
+
+#include <windows.h>
+#include <iphlpapi.h>
+
+namespace {
+Logger logger(LOG_WINDOWS, "DnsUtilsWindows");
+}
+
+DnsUtilsWindows::DnsUtilsWindows(QObject* parent) : DnsUtils(parent) {
+  MVPN_COUNT_CTOR(DnsUtilsWindows);
+
+  logger.debug() << "DnsUtilsWindows created.";
+}
+
+DnsUtilsWindows::~DnsUtilsWindows() {
+  MVPN_COUNT_DTOR(DnsUtilsWindows);
+  restoreResolvers();
+  logger.debug() << "DnsUtilsWindows destroyed.";
+}
+
+bool DnsUtilsWindows::updateResolvers(const QString& ifname,
+                                      const QList<QHostAddress>& resolvers) {
+
+  // Lookup the interface GUID
+  NET_LUID luid;
+  GUID guid;
+  if (ConvertInterfaceAliasToLuid((wchar_t*)ifname.utf16(), &luid) != 0) {
+    logger.error() << "Failed to resolved LUID for" << ifname;
+    return false;
+  }
+  if (ConvertInterfaceLuidToGuid(&luid, &guid) != 0) {
+    logger.error() << "Failed to resolved GUID for" << ifname;
+    return false;
+  }
+  m_ifname = ifname;
+
+  QStringList v4resolvers;
+  QStringList v6resolvers;
+  for (const QHostAddress& addr : resolvers) {
+    if (addr.protocol() == QAbstractSocket::IPv4Protocol) {
+      v4resolvers.append(addr.toString());
+    }
+    if (addr.protocol() == QAbstractSocket::IPv6Protocol) {
+      v6resolvers.append(addr.toString());
+    }
+  }
+
+  DNS_INTERFACE_SETTINGS settings;
+  settings.Version = DNS_INTERFACE_SETTINGS_VERSION1;
+  settings.Flags = DNS_SETTING_NAMESERVER | DNS_SETTING_SEARCHLIST;
+  settings.Domain = nullptr;
+  settings.NameServer = nullptr;
+  settings.SearchList = (wchar_t*)L".";
+  settings.RegistrationEnabled = false;
+  settings.RegisterAdapterName = false;
+  settings.EnableLLMNR = false;
+  settings.QueryAdapterName = false;
+  settings.ProfileNameServer = nullptr;
+
+  // Configure nameservers for IPv4
+  QString v4resolverstring = v4resolvers.join(",");
+  settings.NameServer = (wchar_t*)v4resolverstring.utf16();
+  DWORD v4result = SetInterfaceDnsSettings(guid, &settings);
+  if (v4result != NO_ERROR) {
+    logger.error() << "Failed to configure IPv4 resolvers:" << v4result;
+  }
+
+  // Configure nameservers for IPv6
+  QString v6resolverstring = v6resolvers.join(",");
+  settings.Flags |= DNS_SETTING_IPV6;
+  settings.NameServer = (wchar_t*)v6resolverstring.utf16();
+  DWORD v6result = SetInterfaceDnsSettings(guid, &settings);
+  if (v6result != NO_ERROR) {
+    logger.error() << "Failed to configure IPv6 resolvers" << v6result;
+  }
+
+  return ((v4result == NO_ERROR) || (v6result == NO_ERROR));
+}
+
+bool DnsUtilsWindows::restoreResolvers() {
+  if (!m_ifname.isEmpty()) {
+    QList<QHostAddress> empty;
+    updateResolvers(m_ifname, empty);
+  }
+  return true;
+}

--- a/src/platforms/windows/daemon/dnsutilswindows.cpp
+++ b/src/platforms/windows/daemon/dnsutilswindows.cpp
@@ -23,7 +23,7 @@ DnsUtilsWindows::DnsUtilsWindows(QObject* parent) : DnsUtils(parent) {
   MVPN_COUNT_CTOR(DnsUtilsWindows);
   logger.debug() << "DnsUtilsWindows created.";
 
-  typedef DWORD WindowsSetDnsCallType(GUID, const void *);
+  typedef DWORD WindowsSetDnsCallType(GUID, const void*);
   HMODULE library = LoadLibrary(TEXT("iphlpapi.dll"));
   if (library) {
     m_setInterfaceDnsSettingsProcAddr = (WindowsSetDnsCallType*)GetProcAddress(
@@ -108,7 +108,8 @@ bool DnsUtilsWindows::updateResolversWin32(
 }
 
 constexpr const char* netshFlushTemplate =
-    "interface %1 set dnsservers name=%2 address=none valdiate=no register=both\r\n";
+    "interface %1 set dnsservers name=%2 address=none valdiate=no "
+    "register=both\r\n";
 constexpr const char* netshAddTemplate =
     "interface %1 add dnsservers name=%2 address=%3 validate=no\r\n";
 
@@ -146,10 +147,11 @@ bool DnsUtilsWindows::updateResolversNetsh(
     if (addr.protocol() == QAbstractSocket::IPv6Protocol) {
       family = "ipv6";
     }
-    QString nsaddr = addr.toString();
-    QString nscmd = QString(netshAddTemplate).arg(family).arg(ifindex).arg(nsaddr);
-    logger.debug() << "netsh write:" << nscmd.trimmed();
-    cmdstream << nscmd;
+    QString nsAddr = addr.toString();
+    QString nsCommand =
+        QString(netshAddTemplate).arg(family).arg(ifindex).arg(nsAddr);
+    logger.debug() << "netsh write:" << nsCommand.trimmed();
+    cmdstream << nsCommand;
   }
 
   // Exit and cleanup netsh

--- a/src/platforms/windows/daemon/dnsutilswindows.cpp
+++ b/src/platforms/windows/daemon/dnsutilswindows.cpp
@@ -104,7 +104,7 @@ bool DnsUtilsWindows::updateResolversWin32(
     logger.error() << "Failed to configure IPv6 resolvers" << v6result;
   }
 
-  return ((v4result == NO_ERROR) || (v6result == NO_ERROR));
+  return ((v4result == NO_ERROR) && (v6result == NO_ERROR));
 }
 
 constexpr const char* netshFlushTemplate =

--- a/src/platforms/windows/daemon/dnsutilswindows.cpp
+++ b/src/platforms/windows/daemon/dnsutilswindows.cpp
@@ -29,7 +29,6 @@ DnsUtilsWindows::~DnsUtilsWindows() {
 
 bool DnsUtilsWindows::updateResolvers(const QString& ifname,
                                       const QList<QHostAddress>& resolvers) {
-
   // Lookup the interface GUID
   NET_LUID luid;
   GUID guid;

--- a/src/platforms/windows/daemon/dnsutilswindows.cpp
+++ b/src/platforms/windows/daemon/dnsutilswindows.cpp
@@ -49,9 +49,8 @@ bool DnsUtilsWindows::updateResolvers(const QString& ifname,
   logger.debug() << "Configuring DNS for" << ifname;
   if (m_setInterfaceDnsSettingsProcAddr == nullptr) {
     return updateResolversNetsh(resolvers);
-  } else {
-    return updateResolversWin32(resolvers);
   }
+  return updateResolversWin32(resolvers);
 }
 
 bool DnsUtilsWindows::updateResolversWin32(
@@ -171,9 +170,8 @@ bool DnsUtilsWindows::restoreResolvers() {
   }
 
   QList<QHostAddress> empty;
-  if (m_setInterfaceDnsSettingsProcAddr != nullptr) {
-    return updateResolversWin32(empty);
-  } else {
+  if (m_setInterfaceDnsSettingsProcAddr == nullptr) {
     return updateResolversNetsh(empty);
   }
+  return updateResolversWin32(empty);
 }

--- a/src/platforms/windows/daemon/dnsutilswindows.h
+++ b/src/platforms/windows/daemon/dnsutilswindows.h
@@ -26,7 +26,7 @@ class DnsUtilsWindows final : public DnsUtils {
 
  private:
   quint64 m_luid = 0;
-  DWORD (*m_setInterfaceDnsSettingsProcAddr)(GUID, const void *) = nullptr;
+  DWORD (*m_setInterfaceDnsSettingsProcAddr)(GUID, const void*) = nullptr;
 
   bool updateResolversWin32(const QList<QHostAddress>& resolvers);
   bool updateResolversNetsh(const QList<QHostAddress>& resolvers);

--- a/src/platforms/windows/daemon/dnsutilswindows.h
+++ b/src/platforms/windows/daemon/dnsutilswindows.h
@@ -8,7 +8,6 @@
 #include "daemon/dnsutils.h"
 
 #include <QHostAddress>
-#include <QMap>
 #include <QString>
 
 #include <windows.h>

--- a/src/platforms/windows/daemon/dnsutilswindows.h
+++ b/src/platforms/windows/daemon/dnsutilswindows.h
@@ -11,6 +11,8 @@
 #include <QMap>
 #include <QString>
 
+#include <windows.h>
+
 class DnsUtilsWindows final : public DnsUtils {
   Q_OBJECT
   Q_DISABLE_COPY_MOVE(DnsUtilsWindows)
@@ -23,7 +25,11 @@ class DnsUtilsWindows final : public DnsUtils {
   bool restoreResolvers() override;
 
  private:
-  QString m_ifname;
+  quint64 m_luid = 0;
+  DWORD (*m_setInterfaceDnsSettingsProcAddr)(GUID, const void *) = nullptr;
+
+  bool updateResolversWin32(const QList<QHostAddress>& resolvers);
+  bool updateResolversNetsh(const QList<QHostAddress>& resolvers);
 };
 
 #endif  // DNSUTILSWINDOWS_H

--- a/src/platforms/windows/daemon/dnsutilswindows.h
+++ b/src/platforms/windows/daemon/dnsutilswindows.h
@@ -1,0 +1,29 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef DNSUTILSWINDOWS_H
+#define DNSUTILSWINDOWS_H
+
+#include "daemon/dnsutils.h"
+
+#include <QHostAddress>
+#include <QMap>
+#include <QString>
+
+class DnsUtilsWindows final : public DnsUtils {
+  Q_OBJECT
+  Q_DISABLE_COPY_MOVE(DnsUtilsWindows)
+
+ public:
+  explicit DnsUtilsWindows(QObject* parent);
+  virtual ~DnsUtilsWindows();
+  bool updateResolvers(const QString& ifname,
+                       const QList<QHostAddress>& resolvers) override;
+  bool restoreResolvers() override;
+
+ private:
+  QString m_ifname;
+};
+
+#endif  // DNSUTILSWINDOWS_H

--- a/src/platforms/windows/daemon/windowsdaemon.h
+++ b/src/platforms/windows/daemon/windowsdaemon.h
@@ -6,6 +6,7 @@
 #define WINDOWSDAEMON_H
 
 #include "daemon/daemon.h"
+#include "dnsutilswindows.h"
 #include "windowstunnelservice.h"
 #include "wireguardutilswindows.h"
 #include "windowssplittunnel.h"
@@ -25,6 +26,8 @@ class WindowsDaemon final : public Daemon {
  protected:
   bool run(Op op, const InterfaceConfig& config) override;
   WireguardUtils* wgutils() const override { return m_wgutils; }
+  bool supportDnsUtils() const override { return true; }
+  DnsUtils* dnsutils() override { return m_dnsutils; }
 
  private:
   void monitorBackendFailure();
@@ -39,6 +42,7 @@ class WindowsDaemon final : public Daemon {
   int m_inetAdapterIndex = -1;
 
   WireguardUtilsWindows* m_wgutils = nullptr;
+  DnsUtilsWindows* m_dnsutils = nullptr;
   WindowsSplitTunnel m_splitTunnelManager;
 };
 

--- a/src/platforms/windows/daemon/windowsfirewall.cpp
+++ b/src/platforms/windows/daemon/windowsfirewall.cpp
@@ -226,8 +226,7 @@ bool WindowsFirewall::enablePeerTraffic(const InterfaceConfig& config) {
     if (config.m_ipv6Enabled &&
         config.m_dnsServer == config.m_serverIpv4Gateway) {
       if (!allowTrafficTo(QHostAddress(config.m_serverIpv6Gateway), 53,
-                          HIGH_WEIGHT,
-                          "Allow extra IPv6 DNS-Server",
+                          HIGH_WEIGHT, "Allow extra IPv6 DNS-Server",
                           config.m_serverPublicKey)) {
         return false;
       }
@@ -464,9 +463,9 @@ bool WindowsFirewall::allowTrafficTo(const QHostAddress& targetIP, uint port,
     return false;
   }
   filter.layerKey = layerIn;
-  if (!enableFilter(
-          &filter, title,
-          description.arg("from").arg(targetIP.toString()).arg(port), peer)) {
+  if (!enableFilter(&filter, title,
+                    description.arg("from").arg(targetIP.toString()).arg(port),
+                    peer)) {
     return false;
   }
   return true;
@@ -689,8 +688,8 @@ bool WindowsFirewall::blockTrafficTo(const IPAddressRange& range,
   filter.filterCondition = cond;
 
   filter.layerKey = layerKeyOut;
-  if (!enableFilter(&filter, title,
-                    description.arg("to").arg(range.toString()), peer)) {
+  if (!enableFilter(&filter, title, description.arg("to").arg(range.toString()),
+                    peer)) {
     return false;
   }
   filter.layerKey = layerKeyIn;
@@ -827,8 +826,7 @@ bool WindowsFirewall::enableFilter(FWPM_FILTER0* filter, const QString& title,
   logger.info() << "Filter added: " << title << ":" << description;
   if (peer.isEmpty()) {
     m_activeRules.append(filterID);
-  }
-  else {
+  } else {
     m_peerRules.insert(peer, filterID);
   }
   return true;

--- a/src/platforms/windows/daemon/windowsfirewall.cpp
+++ b/src/platforms/windows/daemon/windowsfirewall.cpp
@@ -160,8 +160,7 @@ bool WindowsFirewall::init() {
   return true;
 }
 
-bool WindowsFirewall::enableKillSwitch(int vpnAdapterIndex,
-                                       const InterfaceConfig& config) {
+bool WindowsFirewall::enableKillSwitch(int vpnAdapterIndex) {
 // Checks if the FW_Rule was enabled succesfully,
 // disables the whole killswitch and returns false if not.
 #define FW_OK(rule)                                                       \
@@ -185,8 +184,6 @@ bool WindowsFirewall::enableKillSwitch(int vpnAdapterIndex,
   }
 
   logger.info() << "Enabling Killswitch Using Adapter:" << vpnAdapterIndex;
-  FW_OK(blockTrafficTo(config.m_allowedIPAddressRanges, LOW_WEIGHT,
-                       "Block Internet"));
   FW_OK(allowTrafficOfAdapter(vpnAdapterIndex, MED_WEIGHT,
                               "Allow usage of VPN Adapter"));
   FW_OK(allowDHCPTraffic(MED_WEIGHT, "Allow DHCP Traffic"));
@@ -194,12 +191,86 @@ bool WindowsFirewall::enableKillSwitch(int vpnAdapterIndex,
   FW_OK(allowTrafficForAppOnAll(getCurrentPath(), MAX_WEIGHT,
                                 "Allow all for MozillaVPN.exe"));
   FW_OK(blockTrafficOnPort(53, MED_WEIGHT, "Block all DNS"));
-  FW_OK(allowTrafficTo(QHostAddress(config.m_dnsServer), 53, HIGH_WEIGHT,
-                       "Allow DNS-Server"));
 
   logger.debug() << "Killswitch on! Rules:" << m_activeRules.length();
   return true;
 #undef FW_OK
+}
+
+bool WindowsFirewall::enablePeerTraffic(const InterfaceConfig& config) {
+  // Start the firewall transaction
+  auto result = FwpmTransactionBegin(m_sessionHandle, NULL);
+  if (result != ERROR_SUCCESS) {
+    disableKillSwitch();
+    return false;
+  }
+  auto cleanup = qScopeGuard([&] {
+    FwpmTransactionAbort0(m_sessionHandle);
+    disableKillSwitch();
+  });
+
+  // Build the firewall rules for this peer.
+  logger.info() << "Enabling traffic for peer" << config.m_serverPublicKey;
+  if (!blockTrafficTo(config.m_allowedIPAddressRanges, LOW_WEIGHT,
+                      "Block Internet", config.m_serverPublicKey)) {
+    return false;
+  }
+  if (!config.m_dnsServer.isEmpty()) {
+    if (!allowTrafficTo(QHostAddress(config.m_dnsServer), 53, HIGH_WEIGHT,
+                        "Allow DNS-Server", config.m_serverPublicKey)) {
+      return false;
+    }
+    // In some cases, we might configure a 2nd DNS server for IPv6, however
+    // this should probably be cleaned up by converting m_dnsServer into
+    // a QStringList instead.
+    if (config.m_ipv6Enabled &&
+        config.m_dnsServer == config.m_serverIpv4Gateway) {
+      if (!allowTrafficTo(QHostAddress(config.m_serverIpv6Gateway), 53,
+                          HIGH_WEIGHT,
+                          "Allow extra IPv6 DNS-Server",
+                          config.m_serverPublicKey)) {
+        return false;
+      }
+    }
+  }
+
+  result = FwpmTransactionCommit0(m_sessionHandle);
+  if (result != ERROR_SUCCESS) {
+    logger.error() << "FwpmTransactionCommit0 failed with error:" << result;
+    return false;
+  }
+
+  cleanup.dismiss();
+  return true;
+}
+
+bool WindowsFirewall::disablePeerTraffic(const QString& pubkey) {
+  auto result = FwpmTransactionBegin(m_sessionHandle, NULL);
+  auto cleanup = qScopeGuard([&] {
+    if (result != ERROR_SUCCESS) {
+      FwpmTransactionAbort0(m_sessionHandle);
+    }
+  });
+  if (result != ERROR_SUCCESS) {
+    logger.error() << "FwpmTransactionBegin0 failed. Return value:.\n"
+                   << result;
+    return false;
+  }
+
+  logger.info() << "Disabling traffic for peer" << pubkey;
+  for (const auto& filterID : m_peerRules.values(pubkey)) {
+    FwpmFilterDeleteById0(m_sessionHandle, filterID);
+    m_peerRules.remove(pubkey, filterID);
+  }
+
+  // Commit!
+  result = FwpmTransactionCommit0(m_sessionHandle);
+  if (result != ERROR_SUCCESS) {
+    logger.error() << "FwpmTransactionCommit0 failed. Return value:.\n"
+                   << result;
+    return false;
+  }
+  return true;
 }
 
 bool WindowsFirewall::disableKillSwitch() {
@@ -215,6 +286,10 @@ bool WindowsFirewall::disableKillSwitch() {
     return false;
   }
 
+  for (const auto& filterID : m_peerRules.values()) {
+    FwpmFilterDeleteById0(m_sessionHandle, filterID);
+  }
+
   for (const auto& filterID : qAsConst(m_activeRules)) {
     FwpmFilterDeleteById0(m_sessionHandle, filterID);
   }
@@ -226,6 +301,7 @@ bool WindowsFirewall::disableKillSwitch() {
                    << result;
     return false;
   }
+  m_peerRules.clear();
   m_activeRules.clear();
   logger.debug() << "Firewall Disabled!";
   return true;
@@ -334,7 +410,8 @@ bool WindowsFirewall::allowTrafficOfAdapter(int networkAdapter, uint8_t weight,
 }
 
 bool WindowsFirewall::allowTrafficTo(const QHostAddress& targetIP, uint port,
-                                     int weight, const QString& title) {
+                                     int weight, const QString& title,
+                                     const QString& peer) {
   bool isIPv4 = targetIP.protocol() == QAbstractSocket::IPv4Protocol;
   GUID layerOut =
       isIPv4 ? FWPM_LAYER_ALE_AUTH_CONNECT_V4 : FWPM_LAYER_ALE_AUTH_CONNECT_V6;
@@ -379,16 +456,17 @@ bool WindowsFirewall::allowTrafficTo(const QHostAddress& targetIP, uint port,
   filter.subLayerKey = ST_FW_WINFW_BASELINE_SUBLAYER_KEY;
   filter.flags = FWPM_FILTER_FLAG_CLEAR_ACTION_RIGHT;  // Hard Permit!
 
-  QString description("Permit traffic %1 %2 on port");
+  QString description("Permit traffic %1 %2 on port %3");
   filter.layerKey = layerOut;
   if (!enableFilter(&filter, title,
-                    description.arg("to").arg(targetIP.toString()).arg(port))) {
+                    description.arg("to").arg(targetIP.toString()).arg(port),
+                    peer)) {
     return false;
   }
   filter.layerKey = layerIn;
   if (!enableFilter(
           &filter, title,
-          description.arg("from").arg(targetIP.toString()).arg(port))) {
+          description.arg("from").arg(targetIP.toString()).arg(port), peer)) {
     return false;
   }
   return true;
@@ -538,6 +616,7 @@ bool WindowsFirewall::allowDHCPTraffic(uint8_t weight, const QString& title) {
   }
   return true;
 }
+
 // Allows the internal Hyper-V Switches to work.
 bool WindowsFirewall::allowHyperVTraffic(uint8_t weight, const QString& title) {
   FWPM_FILTER_CONDITION0 cond;
@@ -571,7 +650,8 @@ bool WindowsFirewall::allowHyperVTraffic(uint8_t weight, const QString& title) {
 }
 
 bool WindowsFirewall::blockTrafficTo(const IPAddressRange& range,
-                                     uint8_t weight, const QString& title) {
+                                     uint8_t weight, const QString& title,
+                                     const QString& peer) {
   QString description("Block traffic %1 %2 ");
   IPAddress addr = IPAddress::create(range.toString());
 
@@ -610,21 +690,22 @@ bool WindowsFirewall::blockTrafficTo(const IPAddressRange& range,
 
   filter.layerKey = layerKeyOut;
   if (!enableFilter(&filter, title,
-                    description.arg("to").arg(range.toString()))) {
+                    description.arg("to").arg(range.toString()), peer)) {
     return false;
   }
   filter.layerKey = layerKeyIn;
   if (!enableFilter(&filter, title,
-                    description.arg("from").arg(range.toString()))) {
+                    description.arg("from").arg(range.toString()), peer)) {
     return false;
   }
   return true;
 }
 
 bool WindowsFirewall::blockTrafficTo(const QList<IPAddressRange>& rangeList,
-                                     uint8_t weight, const QString& title) {
+                                     uint8_t weight, const QString& title,
+                                     const QString& peer) {
   for (auto range : rangeList) {
-    if (!blockTrafficTo(range, weight, title)) {
+    if (!blockTrafficTo(range, weight, title, peer)) {
       logger.info() << "Setting Range of" << range.toString() << "failed";
       return false;
     }
@@ -730,7 +811,8 @@ bool WindowsFirewall::blockTrafficOnPort(uint port, uint8_t weight,
 }
 
 bool WindowsFirewall::enableFilter(FWPM_FILTER0* filter, const QString& title,
-                                   const QString& description) {
+                                   const QString& description,
+                                   const QString& peer) {
   uint64_t filterID = 0;
   auto name = title.toStdWString();
   auto desc = description.toStdWString();
@@ -743,6 +825,11 @@ bool WindowsFirewall::enableFilter(FWPM_FILTER0* filter, const QString& title,
     return false;
   }
   logger.info() << "Filter added: " << title << ":" << description;
-  m_activeRules.append(filterID);
+  if (peer.isEmpty()) {
+    m_activeRules.append(filterID);
+  }
+  else {
+    m_peerRules.insert(peer, filterID);
+  }
   return true;
 }

--- a/src/platforms/windows/daemon/windowsfirewall.h
+++ b/src/platforms/windows/daemon/windowsfirewall.h
@@ -34,7 +34,7 @@ class WindowsFirewall final : public QObject {
   HANDLE m_sessionHandle;
   bool m_init = false;
   QList<uint64_t> m_activeRules;
-  QMultiMap<QString,uint64_t> m_peerRules;
+  QMultiMap<QString, uint64_t> m_peerRules;
 
   bool allowTrafficForAppOnAll(const QString& exePath, int weight,
                                const QString& title);
@@ -57,7 +57,8 @@ class WindowsFirewall final : public QObject {
   void importAddress(const QHostAddress& addr, OUT FWP_CONDITION_VALUE0_& value,
                      OUT QByteArray* v6DataBuffer);
   bool enableFilter(FWPM_FILTER0* filter, const QString& title,
-                    const QString& description, const QString& peer = QString());
+                    const QString& description,
+                    const QString& peer = QString());
 };
 
 #endif  // WINDOWSFIREWALL_H

--- a/src/platforms/windows/daemon/windowsfirewall.h
+++ b/src/platforms/windows/daemon/windowsfirewall.h
@@ -24,7 +24,9 @@ class WindowsFirewall final : public QObject {
   static WindowsFirewall* instance();
   bool init();
 
-  bool enableKillSwitch(int vpnAdapterIndex, const InterfaceConfig& config);
+  bool enableKillSwitch(int vpnAdapterIndex);
+  bool enablePeerTraffic(const InterfaceConfig& config);
+  bool disablePeerTraffic(const QString& pubkey);
   bool disableKillSwitch();
 
  private:
@@ -32,16 +34,17 @@ class WindowsFirewall final : public QObject {
   HANDLE m_sessionHandle;
   bool m_init = false;
   QList<uint64_t> m_activeRules;
+  QMultiMap<QString,uint64_t> m_peerRules;
 
   bool allowTrafficForAppOnAll(const QString& exePath, int weight,
                                const QString& title);
   bool blockTrafficTo(const QList<IPAddressRange>& range, uint8_t weight,
-                      const QString& title);
+                      const QString& title, const QString& peer = QString());
   bool blockTrafficTo(const IPAddressRange& range, uint8_t weight,
-                      const QString& title);
+                      const QString& title, const QString& peer = QString());
   bool blockTrafficOnPort(uint port, uint8_t weight, const QString& title);
   bool allowTrafficTo(const QHostAddress& targetIP, uint port, int weight,
-                      const QString& title);
+                      const QString& title, const QString& peer = QString());
   bool allowTrafficOfAdapter(int networkAdapter, uint8_t weight,
                              const QString& title);
   bool allowDHCPTraffic(uint8_t weight, const QString& title);
@@ -54,7 +57,7 @@ class WindowsFirewall final : public QObject {
   void importAddress(const QHostAddress& addr, OUT FWP_CONDITION_VALUE0_& value,
                      OUT QByteArray* v6DataBuffer);
   bool enableFilter(FWPM_FILTER0* filter, const QString& title,
-                    const QString& description);
+                    const QString& description, const QString& peer = QString());
 };
 
 #endif  // WINDOWSFIREWALL_H

--- a/src/src.pro
+++ b/src/src.pro
@@ -813,6 +813,7 @@ else:win* {
         localsocketcontroller.cpp \
         platforms/windows/windowsapplistprovider.cpp  \
         platforms/windows/windowsappimageprovider.cpp \
+        platforms/windows/daemon/dnsutilswindows.cpp \
         platforms/windows/daemon/windowsdaemon.cpp \
         platforms/windows/daemon/windowsdaemonserver.cpp \
         platforms/windows/daemon/windowsdaemontunnel.cpp \
@@ -845,6 +846,7 @@ else:win* {
         localsocketcontroller.h \
         platforms/windows/windowsapplistprovider.h \
         platforms/windows/windowsappimageprovider.h \ 
+        platforms/windows/daemon/dnsutilswindows.h \
         platforms/windows/daemon/windowsdaemon.h \
         platforms/windows/daemon/windowsdaemonserver.h \
         platforms/windows/daemon/windowsdaemontunnel.h \

--- a/windows/tunnel/addressconfig.go
+++ b/windows/tunnel/addressconfig.go
@@ -166,12 +166,7 @@ func configureInterface(family winipcfg.AddressFamily, conf *conf.Config, tun *t
 		ipif.DadTransmits = 0
 		ipif.RouterDiscoveryBehavior = winipcfg.RouterDiscoveryDisabled
 	}
-	err = ipif.Set()
-	if err != nil {
-		return err
-	}
-
-	return luid.SetDNS(family, conf.Interface.DNS, conf.Interface.DNSSearch)
+	return ipif.Set()
 }
 
 func enableFirewall(conf *conf.Config, tun *tun.NativeTun) error {


### PR DESCRIPTION
When relying on the Wireguard Go module to configure DNS, we find ourselves with a chicken-and-egg bug in Windows when multihop is enabled. The DNS server lists need to be provided when creating the interface, but that is typically done for the entry server, however, we aren't given the DNS configuration until we configure the exit server, which is configured last.

To resolve the issue, we implement the `DnsUtils` class for Windows and remove the DNS setup from the Go module, which conveniently takes us one step closer to completing #1526

Closes: #1673