### PR TITLE
Disable loopback as valid dns on android

### DIFF
--- a/android/src/org/mozilla/firefox/vpn/VPNServiceBinder.kt
+++ b/android/src/org/mozilla/firefox/vpn/VPNServiceBinder.kt
@@ -75,6 +75,7 @@ class VPNServiceBinder(service: VPNService) : Binder() {
                     this.mService.turnOn(config)
                 } catch (e: Exception) {
                     Log.e(tag, "An Error occurred while enabling the VPN: ${e.localizedMessage}")
+                    dispatchEvent(EVENTS.activationError, e.localizedMessage)
                 }
                 return true
             }
@@ -177,6 +178,7 @@ class VPNServiceBinder(service: VPNService) : Binder() {
         const val disconnected = 2
         const val statisticUpdate = 3
         const val backendLogs = 4
+        const val activationError = 5
     }
 
     /**

--- a/src/dnshelper.cpp
+++ b/src/dnshelper.cpp
@@ -79,6 +79,12 @@ bool DNSHelper::validateUserDNS(const QString& dns) {
     // See: https://github.com/mozilla-mobile/mozilla-vpn-client/issues/1714
     return false;
   }
+  #ifdef MVPN_ANDROID
+  // Android rejects loopback as dns
+  if(address.isLoopback()){
+    return false;
+  }
+  #endif
   return true;
 }
 

--- a/src/platforms/android/androidcontroller.cpp
+++ b/src/platforms/android/androidcontroller.cpp
@@ -9,6 +9,7 @@
 #include "models/device.h"
 #include "models/keys.h"
 #include "models/server.h"
+#include "mozillavpn.h"
 #include "settingsholder.h"
 
 #include <QAndroidBinder>
@@ -44,6 +45,7 @@ const int EVENT_CONNECTED = 1;
 const int EVENT_DISCONNECTED = 2;
 const int EVENT_STATISTIC_UPDATE = 3;
 const int EVENT_BACKEND_LOGS = 4;
+const int EVENT_ACTIVATION_ERROR =5;
 
 namespace {
 Logger logger(LOG_ANDROID, "AndroidController");
@@ -317,6 +319,9 @@ bool AndroidController::VPNBinder::onTransact(int code,
         m_controller->m_logCallback(buffer);
       }
       break;
+    case EVENT_ACTIVATION_ERROR:
+      MozillaVPN::instance()->errorHandle(ErrorHandler::ConnectionFailureError);
+      emit m_controller->disconnected();
     default:
       logger.warning() << "Transact: Invalid!";
       break;


### PR DESCRIPTION
Android Builder.addDNS rejects a loopback address, so we should disable this. 
Also added some error handling so an invalid config won't deadlock the client. :) 

closes #1785 