### PR TITLE
Fix SVGs not showing on macOS

### DIFF
--- a/src/src.pro
+++ b/src/src.pro
@@ -619,6 +619,7 @@ else:macos {
     TARGET = MozillaVPN
     QMAKE_TARGET_BUNDLE_PREFIX = org.mozilla.macos
     QT += networkauth
+    QT += svg
 
     CONFIG += c++1z
 


### PR DESCRIPTION
On macOS SVGs didn’t show anymore when building the app with QT Creator and the application output logged the warning `svg: Unsupported image format` for multiple SVGs — this fixed the issue.

| before | after |
| --- | --- |
| <img width="472" alt="macos-svg-error" src="https://user-images.githubusercontent.com/13835474/133254023-86287780-d63d-465f-ae2b-cfcd9a9a33cc.png"> | <img width="472" alt="macos-svg-fixed" src="https://user-images.githubusercontent.com/13835474/133253996-bae633cc-efaf-4234-a324-461a65f741d1.png"> |
 