### PR TITLE
Android: Fix Contoller::Status callback when activated by always-on

### DIFF
--- a/android/src/org/mozilla/firefox/vpn/VPNService.kt
+++ b/android/src/org/mozilla/firefox/vpn/VPNService.kt
@@ -10,12 +10,14 @@ import android.os.Build
 import android.os.IBinder
 import android.system.OsConstants
 import com.wireguard.android.util.SharedLibraryLoader
-import com.wireguard.config.Config
+import com.wireguard.config.*
+import com.wireguard.crypto.Key
+import org.json.JSONObject
 
 class VPNService : android.net.VpnService() {
     private val tag = "VPNService"
     private var mBinder: VPNServiceBinder = VPNServiceBinder(this)
-    private var mConfig: Config? = null
+    private var mConfig: JSONObject? = null
     private var mConnectionTime: Long = 0
     private var mAlreadyInitialised = false
 
@@ -65,7 +67,6 @@ class VPNService : android.net.VpnService() {
             }
         }
         // This start is from always-on
-
         if (this.mConfig == null) {
             // We don't have tunnel to turn on - Try to create one with last config the service got
             val prefs = Prefs.get(this)
@@ -78,7 +79,7 @@ class VPNService : android.net.VpnService() {
                 )
                 return super.onStartCommand(intent, flags, startId)
             }
-            this.mConfig = mBinder.buildConfigFromJSON(lastConfString)
+            this.mConfig = JSONObject(lastConfString)
         }
         turnOn(this.mConfig!!)
         return super.onStartCommand(intent, flags, startId)
@@ -109,22 +110,21 @@ class VPNService : android.net.VpnService() {
             mBinder.dispatchEvent(VPNServiceBinder.EVENTS.disconnected, "")
             mConnectionTime = 0
         }
-    val totalRx: Int
+    val status: JSONObject
         get() {
-            val value = getConfigValue("rx_bytes") ?: return 0
-            return value.toInt()
+            val deviceIpv4: String = ""
+            return JSONObject().apply {
+                putOpt("rx_bytes", getConfigValue("rx_bytes"))
+                putOpt("tx_bytes", getConfigValue("tx_bytes"))
+                putOpt("endpoint", mConfig?.getJSONObject("server")?.getString("ipv4Gateway"))
+                putOpt("deviceIpv4", mConfig?.getJSONObject("device")?.getString("ipv4Address"))
+            }
         }
-    val totalTx: Int
-        get() {
-            val value = getConfigValue("tx_bytes") ?: return 0
-            return value.toInt()
-        }
-
-     /*
-     * Checks if the VPN Permission is given. 
-     * If the permission is given, returns true
-     * Requests permission and returns false if not.
-     */
+      /*
+      * Checks if the VPN Permission is given. 
+      * If the permission is given, returns true
+      * Requests permission and returns false if not.
+      */
     fun checkPermissions(): Boolean {
         // See https://developer.android.com/guide/topics/connectivity/vpn#connect_a_service
         // Call Prepare, if we get an Intent back, we dont have the VPN Permission
@@ -138,27 +138,24 @@ class VPNService : android.net.VpnService() {
         return false
     }
 
-    fun turnOn(newConf: Config?) {
-        if (newConf == null) {
-            return
-        }
+    fun turnOn(json: JSONObject) {
+        Log.sensitive(tag, json.toString())
+        val wireguard_conf = buildWireugardConfig(json)
+
         if (!checkPermissions()) {
             Log.e(tag, "turn on was called without no permissions present!")
             isUp = false
             return
         }
         Log.i(tag, "Permission okay")
-        mConfig = newConf
         if (currentTunnelHandle != -1) {
             Log.e(tag, "Tunnel already up")
             // Turn the tunnel down because this might be a switch
             wgTurnOff(currentTunnelHandle)
         }
-
-        val wgConfig: String = newConf!!.toWgUserspaceString()
-
+        val wgConfig: String = wireguard_conf!!.toWgUserspaceString()
         val builder = Builder()
-        setupBuilder(newConf, builder)
+        setupBuilder(wireguard_conf, builder)
         builder.setSession("mvpn0")
         builder.establish().use { tun ->
             if (tun == null)return
@@ -172,7 +169,16 @@ class VPNService : android.net.VpnService() {
         }
         protect(wgGetSocketV4(currentTunnelHandle))
         protect(wgGetSocketV6(currentTunnelHandle))
+        mConfig = json
         isUp = true
+
+        // Store the config in case the service gets
+        // asked boot vpn from the OS
+        val prefs = Prefs.get(this)
+        prefs.edit()
+            .putString("lastConf", json.toString())
+            .apply()
+
         NotificationUtil.show(this) // Go foreground
     }
 
@@ -232,6 +238,49 @@ class VPNService : android.net.VpnService() {
             }
         }
         return null
+    }
+
+    /**
+     * Create a Wireguard [Config]  from a [json] string -
+     * The [json] will be created in AndroidController.cpp
+     */
+    private fun buildWireugardConfig(obj: JSONObject): Config {
+        val confBuilder = Config.Builder()
+        val jServer = obj.getJSONObject("server")
+        val peerBuilder = Peer.Builder()
+        val ep =
+            InetEndpoint.parse(jServer.getString("ipv4AddrIn") + ":" + jServer.getString("port"))
+        peerBuilder.setEndpoint(ep)
+        peerBuilder.setPublicKey(Key.fromBase64(jServer.getString("publicKey")))
+
+        val jAllowedIPList = obj.getJSONArray("allowedIPs")
+        if (jAllowedIPList.length() == 0) {
+            val internet = InetNetwork.parse("0.0.0.0/0") // aka The whole internet.
+            peerBuilder.addAllowedIp(internet)
+        } else {
+            (0 until jAllowedIPList.length()).toList().forEach {
+                val network = InetNetwork.parse(jAllowedIPList.getString(it))
+                peerBuilder.addAllowedIp(network)
+            }
+        }
+
+        confBuilder.addPeer(peerBuilder.build())
+
+        val privateKey = obj.getJSONObject("keys").getString("privateKey")
+        val jDevice = obj.getJSONObject("device")
+
+        val ifaceBuilder = Interface.Builder()
+        ifaceBuilder.parsePrivateKey(privateKey)
+        ifaceBuilder.addAddress(InetNetwork.parse(jDevice.getString("ipv4Address")))
+        ifaceBuilder.addAddress(InetNetwork.parse(jDevice.getString("ipv6Address")))
+        ifaceBuilder.addDnsServer(InetNetwork.parse(obj.getString("dns")).address)
+        val jExcludedApplication = obj.getJSONArray("excludedApps")
+        (0 until jExcludedApplication.length()).toList().forEach {
+            val appName = jExcludedApplication.get(it).toString()
+            ifaceBuilder.excludeApplication(appName)
+        }
+        confBuilder.setInterface(ifaceBuilder.build())
+        return confBuilder.build()
     }
 
     companion object {

--- a/src/connectioncheck.cpp
+++ b/src/connectioncheck.cpp
@@ -27,7 +27,6 @@ ConnectionCheck::~ConnectionCheck() { MVPN_COUNT_DTOR(ConnectionCheck); }
 
 void ConnectionCheck::start() {
   logger.debug() << "Starting a connection check";
-
   MozillaVPN::instance()->controller()->getStatus(
       [this](const QString& serverIpv4Gateway, const QString& deviceIpv4Address,
              uint64_t txBytes, uint64_t rxBytes) {
@@ -36,10 +35,12 @@ void ConnectionCheck::start() {
 
         stop();
 
-        if (!serverIpv4Gateway.isEmpty()) {
-          m_timer.start(CONNECTION_CHECK_TIMEOUT_MSEC);
-          m_pingHelper.start(serverIpv4Gateway, deviceIpv4Address);
+        if (serverIpv4Gateway.isEmpty()) {
+          emit failure();
+          return;
         }
+        m_timer.start(CONNECTION_CHECK_TIMEOUT_MSEC);
+        m_pingHelper.start(serverIpv4Gateway, deviceIpv4Address);
       });
 }
 

--- a/src/platforms/android/androidcontroller.cpp
+++ b/src/platforms/android/androidcontroller.cpp
@@ -148,7 +148,7 @@ void AndroidController::activate(
       PERMISSIONHELPER_CLASS, "startService", "(Landroid/content/Context;)V",
       appContext.object());
 
-  m_server = serverList[0];
+  Server server = serverList[0];
   m_device = *device;
 
   // Serialise arguments for the VPNService
@@ -163,12 +163,12 @@ void AndroidController::activate(
   jKeys["privateKey"] = keys->privateKey();
 
   QJsonObject jServer;
-  jServer["ipv4AddrIn"] = m_server.ipv4AddrIn();
-  jServer["ipv4Gateway"] = m_server.ipv4Gateway();
-  jServer["ipv6AddrIn"] = m_server.ipv6AddrIn();
-  jServer["ipv6Gateway"] = m_server.ipv6Gateway();
-  jServer["publicKey"] = m_server.publicKey();
-  jServer["port"] = (int)m_server.choosePort();
+  jServer["ipv4AddrIn"] = server.ipv4AddrIn();
+  jServer["ipv4Gateway"] = server.ipv4Gateway();
+  jServer["ipv6AddrIn"] = server.ipv6AddrIn();
+  jServer["ipv6Gateway"] = server.ipv6Gateway();
+  jServer["publicKey"] = server.publicKey();
+  jServer["port"] = (int)server.choosePort();
 
   QJsonArray allowedIPs;
   foreach (auto item, allowedIPAddressRanges) {
@@ -306,8 +306,8 @@ bool AndroidController::VPNBinder::onTransact(int code,
 
       // Data is here a JSON String
       doc = QJsonDocument::fromJson(data.readData());
-      emit m_controller->statusUpdated(m_controller->m_server.ipv4Gateway(),
-                                       m_controller->m_device.ipv4Address(),
+      emit m_controller->statusUpdated(doc.object()["endpoint"].toString(),
+                                       doc.object()["deviceIpv4"].toString(),
                                        doc.object()["totalTX"].toInt(),
                                        doc.object()["totalRX"].toInt());
       break;


### PR DESCRIPTION
The connection gets stuck because,  in ConnectionCheck::start() we fetch the ping destination via the Controller::Status event. 
On android, we did get the current server gateway on the android-controller - so when the system started the vpn via always-on this would still be null. So ConnectionCheck fails silently. 
Since the server's gateway is not part of the wg-conf obj, let's pass the whole "connect" args json, so the VPNService can respond with the appropriate server gateway in Controller::Status. :)

closes https://github.com/mozilla-mobile/mozilla-vpn-client/issues/1179