### PR TITLE
Use Constants::API_PROD as default value for Stage_server if none is given

### DIFF
--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -6,6 +6,7 @@
 #include "settingsholder.h"
 
 #include <QString>
+#include <QtGlobal>
 
 namespace {
 bool s_inProduction = true;
@@ -21,4 +22,5 @@ const QString& Constants::getStagingServerAddress() {
 void Constants::setStaging() {
   s_inProduction = false;
   s_stagingServerAddress = SettingsHolder::instance()->stagingServerAddress();
+  Q_ASSERT(!s_stagingServerAddress.isEmpty());
 }

--- a/src/constants.h
+++ b/src/constants.h
@@ -71,8 +71,6 @@ CONSTEXPR(uint32_t, surveyTimerMsec, 300000, 4000, 0)
   inline type functionName() { return inProduction() ? prod : beta; }
 
 constexpr const char* API_PRODUCTION_URL = "https://vpn.mozilla.org";
-constexpr const char* API_STAGING_URL =
-    "https://stage-vpn.guardian.nonprod.cloudops.mozgcp.net";
 
 constexpr const char* LOGO_URL = ":/ui/resources/logo-dock.png";
 

--- a/src/platforms/wasm/wasmnetworkrequest.cpp
+++ b/src/platforms/wasm/wasmnetworkrequest.cpp
@@ -56,7 +56,11 @@ void NetworkRequest::abort() {}
 
 // static
 QString NetworkRequest::apiBaseUrl() {
-  return QString(Constants::API_STAGING_URL);
+  if (Constants::inProduction()) {
+    return Constants::API_PRODUCTION_URL;
+  }
+
+  return Constants::getStagingServerAddress();
 }
 
 // static

--- a/src/settingsholder.cpp
+++ b/src/settingsholder.cpp
@@ -274,10 +274,10 @@ GETSETDEFAULT(SETTINGS_DEVELOPERUNLOCK_DEFAULT, bool, toBool,
 GETSETDEFAULT(SETTINGS_STAGINGSERVER_DEFAULT, bool, toBool,
               SETTINGS_STAGINGSERVER, hasStagingServer, stagingServer,
               setStagingServer, stagingServerChanged)
-GETSETDEFAULT(getEnvVariable("MVPN_API_BASE_URL"), QString, toString,
-              SETTINGS_STAGINGSERVERADDRESS, hasStagingServerAddress,
-              stagingServerAddress, setStagingServerAddress,
-              stagingServerAddressChanged)
+GETSETDEFAULT(envOrDefault("MVPN_API_BASE_URL", Constants::API_STAGING_URL),
+              QString, toString, SETTINGS_STAGINGSERVERADDRESS,
+              hasStagingServerAddress, stagingServerAddress,
+              setStagingServerAddress, stagingServerAddressChanged)
 GETSETDEFAULT(SETTINGS_SEENFEATURES_DEFAULT, QStringList, toStringList,
               SETTINGS_SEENFEATURES, hasSeenFeatures, seenFeatures,
               setSeenFeatures, seenFeaturesChanged);
@@ -505,4 +505,13 @@ QString SettingsHolder::getEnvVariable(const QString& name) const {
   QProcessEnvironment pe = QProcessEnvironment::systemEnvironment();
   if (pe.contains(name)) return pe.value(name);
   return QString();
+}
+
+QString SettingsHolder::envOrDefault(const QString& name,
+                                     const QString& defaultValue) const {
+  const QString env = getEnvVariable(name);
+  if (!env.isEmpty()) {
+    return env;
+  }
+  return defaultValue;
 }

--- a/src/settingsholder.cpp
+++ b/src/settingsholder.cpp
@@ -510,8 +510,11 @@ QString SettingsHolder::getEnvVariable(const QString& name) const {
 QString SettingsHolder::envOrDefault(const QString& name,
                                      const QString& defaultValue) const {
   const QString env = getEnvVariable(name);
-  if (!env.isEmpty()) {
-    return env;
+  if (env.isEmpty()) {
+    return defaultValue;
   }
-  return defaultValue;
+  if (!QUrl(env).isValid()) {
+    return defaultValue;
+  }
+  return env;
 }

--- a/src/settingsholder.cpp
+++ b/src/settingsholder.cpp
@@ -274,7 +274,7 @@ GETSETDEFAULT(SETTINGS_DEVELOPERUNLOCK_DEFAULT, bool, toBool,
 GETSETDEFAULT(SETTINGS_STAGINGSERVER_DEFAULT, bool, toBool,
               SETTINGS_STAGINGSERVER, hasStagingServer, stagingServer,
               setStagingServer, stagingServerChanged)
-GETSETDEFAULT(envOrDefault("MVPN_API_BASE_URL", Constants::API_STAGING_URL),
+GETSETDEFAULT(envOrDefault("MVPN_API_BASE_URL", Constants::API_PRODUCTION_URL),
               QString, toString, SETTINGS_STAGINGSERVERADDRESS,
               hasStagingServerAddress, stagingServerAddress,
               setStagingServerAddress, stagingServerAddressChanged)

--- a/src/settingsholder.h
+++ b/src/settingsholder.h
@@ -159,6 +159,7 @@ class SettingsHolder final : public QObject {
   void removeEntryServer();
 
   QString getEnvVariable(const QString& name) const;
+  QString envOrDefault(const QString& name, const QString& defaultValue) const;
 
 #ifdef MVPN_IOS
   GETSET(bool, hasNativeIOSDataMigrated, nativeIOSDataMigrated,

--- a/tests/unit/mocnetworkrequest.cpp
+++ b/tests/unit/mocnetworkrequest.cpp
@@ -7,6 +7,7 @@
 #include "helper.h"
 #include "networkrequest.h"
 #include "constants.h"
+#include "settingsholder.h"
 
 namespace {};
 
@@ -37,7 +38,8 @@ NetworkRequest::~NetworkRequest() { MVPN_COUNT_DTOR(NetworkRequest); }
 
 // static
 QString NetworkRequest::apiBaseUrl() {
-  return QString(Constants::API_STAGING_URL);
+  return SettingsHolder::instance()->envOrDefault(
+      "MVPN_API_BASE_URL", Constants::API_PRODUCTION_URL);
 }
 
 // static


### PR DESCRIPTION
We should use Constants::API_STAGING_URL as Default setting value if MVPN_API_BASE_URL is not present - Otherwise auth uri might be empty when unset;  thus we get stuck on windows (we crash on android) ... also I don't want to copy our guardian uri every time I install a debug build on my phone :) 🙈 