### PR TITLE
Enable Advanced DNS for all

### DIFF
--- a/src/features/featurecustomdns.h
+++ b/src/features/featurecustomdns.h
@@ -24,14 +24,7 @@ class FeatureCustomDNS final : public Feature {
             true  // Can be enabled in devmode
         ) {}
 
-  bool checkSupportCallback() const override {
-#if defined(MVPN_ANDROID) || defined(MVPN_WASM) || defined(MVPN_DUMMY) || \
-    defined(MVPN_WINDOWS) || defined(MVPN_LINUX) || defined(MVPN_MACOS)
-    return true;
-#else
-    return false;
-#endif
-  }
+  bool checkSupportCallback() const override { return true; }
 
   static const FeatureCustomDNS* instance() {
     return static_cast<const FeatureCustomDNS*>(get(FEATURE_CUSTOM_DNS));


### PR DESCRIPTION
Regressed by: https://github.com/mozilla-mobile/mozilla-vpn-client/commit/e27252cf59ea28bb16fbfcca78b6ba53abac5fd9#

My initial pr actually did not flip the feature flag for IOS when it should have, as @mbirghan wrote the required supporting code. 

Closes https://github.com/mozilla-mobile/mozilla-vpn-client/issues/1852