### PR TITLE
Settings refactoring

### DIFF
--- a/src/apppermission.cpp
+++ b/src/apppermission.cpp
@@ -84,7 +84,7 @@ QVariant AppPermission::data(const QModelIndex& index, int role) const {
     case AppIdRole:
       return QVariant(app.id);
     case AppEnabledRole:
-      if (!SettingsHolder::instance()->hasVpnDisabledApps()) {
+      if (SettingsHolder::instance()->vpnDisabledApps().isEmpty()) {
         // All are enabled then
         return true;
       }
@@ -96,14 +96,15 @@ QVariant AppPermission::data(const QModelIndex& index, int role) const {
 
 void AppPermission::flip(const QString& appID) {
   SettingsHolder* settingsHolder = SettingsHolder::instance();
-  if (settingsHolder->hasVpnDisabledApp(appID)) {
+  QStringList applist = settingsHolder->vpnDisabledApps();
+  if (settingsHolder->vpnDisabledApps().contains(appID)) {
     logger.debug() << "Enabled --" << appID << " for VPN";
-    settingsHolder->removeVpnDisabledApp(appID);
-
+    applist.removeAll(appID);
   } else {
     logger.debug() << "Disabled --" << appID << " for VPN";
-    settingsHolder->addVpnDisabledApp(appID);
+    applist.append(appID);
   }
+  settingsHolder->setVpnDisabledApps(applist);
 
   int index = m_applist.indexOf(AppDescription(appID));
   dataChanged(createIndex(index, 0), createIndex(index, 0));
@@ -115,42 +116,60 @@ void AppPermission::requestApplist() {
 }
 
 void AppPermission::receiveAppList(const QMap<QString, QString>& applist) {
+  SettingsHolder* settingsHolder = SettingsHolder::instance();
+  Q_ASSERT(settingsHolder);
+
   QMap<QString, QString> applistCopy = applist;
-  QList<QString> removedMissingApps;
+  QStringList removedMissingApps;
+
   // Add Missing apps, cleanup ones that we can't find anymore.
   // If that happens
-  if (SettingsHolder::instance()->hasMissingApps()) {
-    auto missingAppList = SettingsHolder::instance()->missingApps();
-    for (const auto& appPath : missingAppList) {
-      // Check if the App Still exists, otherwise clean up.
-      if (!m_listprovider->isValidAppId(appPath)) {
-        SettingsHolder::instance()->removeMissingApp(appPath);
-        removedMissingApps.append(m_listprovider->getAppName(appPath));
-      } else {
-        applistCopy.insert(appPath, m_listprovider->getAppName(appPath));
-      }
+
+  QStringList missingAppList = settingsHolder->missingApps();
+  QMutableStringListIterator iter(missingAppList);
+  while (iter.hasNext()) {
+    const QString& appPath = iter.next();
+    // Check if the App Still exists, otherwise clean up.
+    if (!m_listprovider->isValidAppId(appPath)) {
+      removedMissingApps.append(m_listprovider->getAppName(appPath));
+      iter.remove();
+      continue;
     }
+    applistCopy.insert(appPath, m_listprovider->getAppName(appPath));
+  }
+
+  if (!removedMissingApps.isEmpty()) {
+    settingsHolder->setMissingApps(missingAppList);
   }
 
   auto keys = applistCopy.keys();
   if (!m_applist.isEmpty()) {
+    QStringList disabledApps = settingsHolder->vpnDisabledApps();
     // Check the Disabled-List
-    SettingsHolder* settingsHolder = SettingsHolder::instance();
-    foreach (QString blockedAppId, settingsHolder->vpnDisabledApps()) {
+    QMutableStringListIterator iter(disabledApps);
+    while (iter.hasNext()) {
+      const QString& blockedAppId = iter.next();
+
       if (!m_listprovider->isValidAppId(blockedAppId)) {
         // In case the AppID is no longer valid we don't need to keep it
         logger.debug() << "Removed obsolete appid" << blockedAppId;
-        settingsHolder->removeVpnDisabledApp(blockedAppId);
         removedMissingApps.append(m_listprovider->getAppName(blockedAppId));
-      } else if (!keys.contains(blockedAppId)) {
-        // In case the AppID is valid but not in our applist, we need to create
-        // an entry
+        iter.remove();
+        continue;
+      }
+
+      if (!keys.contains(blockedAppId)) {
+        // In case the AppID is valid but not in our applist, we need to
+        // create an entry
         logger.debug() << "Added missing appid" << blockedAppId;
         m_applist.append(
             AppDescription(blockedAppId, applistCopy[blockedAppId]));
       }
     }
+
+    settingsHolder->setVpnDisabledApps(disabledApps);
   }
+
   beginResetModel();
   logger.debug() << "Recived new Applist -- Entrys: " << applistCopy.size();
   m_applist.clear();

--- a/src/captiveportal/captiveportal.cpp
+++ b/src/captiveportal/captiveportal.cpp
@@ -74,12 +74,8 @@ bool CaptivePortal::fromSettings() {
   SettingsHolder* settingsHolder = SettingsHolder::instance();
   Q_ASSERT(settingsHolder);
 
-  if (settingsHolder->hasCaptivePortalIpv4Addresses()) {
-    m_ipv4Addresses = settingsHolder->captivePortalIpv4Addresses();
-  }
-  if (settingsHolder->hasCaptivePortalIpv6Addresses()) {
-    m_ipv6Addresses = settingsHolder->captivePortalIpv6Addresses();
-  }
+  m_ipv4Addresses = settingsHolder->captivePortalIpv4Addresses();
+  m_ipv6Addresses = settingsHolder->captivePortalIpv6Addresses();
 
   return true;
 }

--- a/src/captiveportal/captiveportalrequest.cpp
+++ b/src/captiveportal/captiveportalrequest.cpp
@@ -25,13 +25,10 @@ CaptivePortalRequest::~CaptivePortalRequest() {
 void CaptivePortalRequest::run() {
   SettingsHolder* settings = SettingsHolder::instance();
 
-  QStringList ipv4Addresses;
-  if (settings->hasCaptivePortalIpv4Addresses()) {
-    ipv4Addresses = settings->captivePortalIpv4Addresses();
-  }
+  QStringList ipv4Addresses = settings->captivePortalIpv4Addresses();
 
   QStringList ipv6Addresses;
-  if (settings->ipv6Enabled() && settings->hasCaptivePortalIpv6Addresses()) {
+  if (settings->ipv6Enabled()) {
     ipv6Addresses = settings->captivePortalIpv6Addresses();
   }
 

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -186,8 +186,7 @@ void Controller::activateInternal() {
   QList<QString> vpnDisabledApps;
 
   SettingsHolder* settingsHolder = SettingsHolder::instance();
-  if (settingsHolder->protectSelectedApps() &&
-      settingsHolder->hasVpnDisabledApps()) {
+  if (settingsHolder->protectSelectedApps()) {
     vpnDisabledApps = settingsHolder->vpnDisabledApps();
   }
 
@@ -256,8 +255,7 @@ bool Controller::silentSwitchServers() {
   QList<QString> vpnDisabledApps;
 
   SettingsHolder* settingsHolder = SettingsHolder::instance();
-  if (settingsHolder->protectSelectedApps() &&
-      settingsHolder->hasVpnDisabledApps()) {
+  if (settingsHolder->protectSelectedApps()) {
     vpnDisabledApps = settingsHolder->vpnDisabledApps();
   }
 

--- a/src/featurelist.cpp
+++ b/src/featurelist.cpp
@@ -61,11 +61,8 @@ void FeatureList::initialize() {
 void FeatureList::devModeFlipFeatureFlag(const QString& feature) {
   logger.debug() << "Flipping " << feature;
 
-  QStringList flags;
   auto const settings = SettingsHolder::instance();
-  if (settings->hasDevModeFeatureFlags()) {
-    flags = settings->devModeFeatureFlags();
-  }
+  QStringList flags = settings->devModeFeatureFlags();
 
   logger.debug() << "Got List - size:" << flags.size();
 

--- a/src/localizer.cpp
+++ b/src/localizer.cpp
@@ -51,9 +51,7 @@ Localizer::Localizer() {
   s_instance = this;
 
   SettingsHolder* settingsHolder = SettingsHolder::instance();
-  if (settingsHolder->hasLanguageCode()) {
-    m_code = settingsHolder->languageCode();
-  }
+  m_code = settingsHolder->languageCode();
 
   initialize();
 }
@@ -72,20 +70,17 @@ void Localizer::initialize() {
   // If this is the first time we are here, we need to check if the current
   // language matches with the system one.
   SettingsHolder* settingsHolder = SettingsHolder::instance();
-  if (!settingsHolder->hasSystemLanguageCodeMigrated() ||
-      !settingsHolder->systemLanguageCodeMigrated()) {
+  if (!settingsHolder->systemLanguageCodeMigrated()) {
     settingsHolder->setSystemLanguageCodeMigrated(true);
 
-    if (settingsHolder->hasLanguageCode() &&
-        settingsHolder->languageCode() == systemCode) {
+    if (settingsHolder->languageCode() == systemCode) {
       settingsHolder->setPreviousLanguageCode(settingsHolder->languageCode());
       settingsHolder->setLanguageCode("");
     }
   }
 
   // We always need a previous code.
-  if (!settingsHolder->hasPreviousLanguageCode() ||
-      settingsHolder->previousLanguageCode().isEmpty()) {
+  if (settingsHolder->previousLanguageCode().isEmpty()) {
     settingsHolder->setPreviousLanguageCode(systemCode);
   }
 

--- a/src/models/devicemodel.cpp
+++ b/src/models/devicemodel.cpp
@@ -43,12 +43,8 @@ bool DeviceModel::fromSettings(const Keys* keys) {
 
   logger.debug() << "Reading the device list from settings";
 
-  if (!settingsHolder->hasDevices()) {
-    return false;
-  }
-
   const QByteArray& json = settingsHolder->devices();
-  if (!fromJsonInternal(keys, json)) {
+  if (json.isEmpty() || !fromJsonInternal(keys, json)) {
     return false;
   }
 

--- a/src/models/feature.cpp
+++ b/src/models/feature.cpp
@@ -82,8 +82,8 @@ bool Feature::isDevModeEnabled() const {
   if (!m_devModeWriteable) {
     return false;
   }
-  const auto settings = SettingsHolder::instance();
-  return settings->hasDevModeFeatureFlag(m_id);
+
+  return SettingsHolder::instance()->devModeFeatureFlags().contains(m_id);
 }
 
 bool Feature::isSupported() const {

--- a/src/models/keys.cpp
+++ b/src/models/keys.cpp
@@ -20,17 +20,17 @@ bool Keys::fromSettings() {
   SettingsHolder* settingsHolder = SettingsHolder::instance();
   Q_ASSERT(settingsHolder);
 
-  if (!settingsHolder->hasPrivateKey()) {
+  if (settingsHolder->privateKey().isEmpty()) {
     return false;
   }
 
   // Quick migration to retrieve the public key from the current device.
-  if (!settingsHolder->hasPublicKey()) {
-    if (!settingsHolder->hasDevices()) {
+  if (settingsHolder->publicKey().isEmpty()) {
+    const QByteArray& json = settingsHolder->devices();
+    if (json.isEmpty()) {
       return false;
     }
 
-    const QByteArray& json = settingsHolder->devices();
     QJsonDocument doc = QJsonDocument::fromJson(json);
     if (!doc.isObject()) {
       return false;

--- a/src/models/servercountrymodel.cpp
+++ b/src/models/servercountrymodel.cpp
@@ -34,12 +34,8 @@ bool ServerCountryModel::fromSettings() {
 
   logger.debug() << "Reading the server list from settings";
 
-  if (!settingsHolder->hasServers()) {
-    return false;
-  }
-
   const QByteArray json = settingsHolder->servers();
-  if (!fromJsonInternal(json)) {
+  if (json.isEmpty() || !fromJsonInternal(json)) {
     return false;
   }
 

--- a/src/models/survey.cpp
+++ b/src/models/survey.cpp
@@ -86,8 +86,7 @@ bool Survey::isTriggerable() const {
   SettingsHolder* settingsHolder = SettingsHolder::instance();
   Q_ASSERT(settingsHolder);
 
-  if (settingsHolder->hasConsumedSurveys() &&
-      settingsHolder->consumedSurveys().contains(m_id)) {
+  if (settingsHolder->consumedSurveys().contains(m_id)) {
     return false;
   }
 

--- a/src/models/surveymodel.cpp
+++ b/src/models/surveymodel.cpp
@@ -56,12 +56,8 @@ bool SurveyModel::fromSettings() {
 
   logger.debug() << "Reading the survey list from settings";
 
-  if (!settingsHolder->hasSurveys()) {
-    return false;
-  }
-
   const QByteArray& json = settingsHolder->surveys();
-  if (!fromJsonInternal(json)) {
+  if (json.isEmpty() || !fromJsonInternal(json)) {
     return false;
   }
 
@@ -137,7 +133,9 @@ void SurveyModel::dismissCurrentSurvey() {
   SettingsHolder* settingsHolder = SettingsHolder::instance();
   Q_ASSERT(settingsHolder);
 
-  settingsHolder->addConsumedSurvey(m_currentSurveyId);
+  QStringList list = settingsHolder->consumedSurveys();
+  list.append(m_currentSurveyId);
+  settingsHolder->setConsumedSurveys(list);
 
   m_currentSurveyId.clear();
   emit hasSurveyChanged();

--- a/src/models/whatsnewmodel.cpp
+++ b/src/models/whatsnewmodel.cpp
@@ -69,11 +69,11 @@ bool WhatsNewModel::hasUnseenFeature() {
   Q_ASSERT(settingsHolder);
 
   logger.debug() << "Reading seen features from settings";
-  if (!settingsHolder->hasSeenFeatures()) {
+  const QStringList& seenFeatureList = settingsHolder->seenFeatures();
+  if (seenFeatureList.isEmpty()) {
     return false;
   }
 
-  const QStringList& seenFeatureList = settingsHolder->seenFeatures();
   for (Feature* feature : m_featurelist) {
     if (!seenFeatureList.contains(feature->id())) {
       return true;
@@ -89,11 +89,7 @@ void WhatsNewModel::markFeaturesAsSeen() {
 
   logger.debug() << "Add seen features to settings";
 
-  QStringList seenfeatureslist;
-  if (settingsHolder->hasSeenFeatures()) {
-    seenfeatureslist = settingsHolder->seenFeatures();
-  }
-
+  QStringList seenfeatureslist = settingsHolder->seenFeatures();
   for (Feature* feature : m_featurelist) {
     const QString& featureID = feature->id();
 

--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -211,21 +211,21 @@ void MozillaVPN::initialize() {
   Q_ASSERT(settingsHolder);
 
 #ifdef MVPN_IOS
-  if (!settingsHolder->hasNativeIOSDataMigrated()) {
+  if (!settingsHolder->nativeIOSDataMigrated()) {
     IOSDataMigration::migrate();
     settingsHolder->setNativeIOSDataMigrated(true);
   }
 #endif
 
 #ifdef MVPN_WINDOWS
-  if (!settingsHolder->hasNativeWindowsDataMigrated()) {
+  if (!settingsHolder->nativeWindowsDataMigrated()) {
     WindowsDataMigration::migrate();
     settingsHolder->setNativeWindowsDataMigrated(true);
   }
 #endif
 
 #ifdef MVPN_ANDROID
-  if (!settingsHolder->hasNativeAndroidDataMigrated()) {
+  if (!settingsHolder->nativeAndroidDataMigrated()) {
     AndroidDataMigration::migrate();
     settingsHolder->setNativeAndroidDataMigrated(true);
   }
@@ -336,15 +336,13 @@ void MozillaVPN::maybeStateMain() {
   SettingsHolder* settingsHolder = SettingsHolder::instance();
 
 #if !defined(MVPN_ANDROID) && !defined(MVPN_IOS)
-  if (!settingsHolder->hasPostAuthenticationShown() ||
-      !settingsHolder->postAuthenticationShown()) {
+  if (!settingsHolder->postAuthenticationShown()) {
     setState(StatePostAuthentication);
     return;
   }
 #endif
 
-  if (!settingsHolder->hasTelemetryPolicyShown() ||
-      !settingsHolder->telemetryPolicyShown()) {
+  if (!settingsHolder->telemetryPolicyShown()) {
     setState(StateTelemetryPolicy);
     return;
   }
@@ -376,8 +374,7 @@ void MozillaVPN::getStarted() {
 
   SettingsHolder* settingsHolder = SettingsHolder::instance();
 
-  if (!settingsHolder->hasTelemetryPolicyShown() ||
-      !settingsHolder->telemetryPolicyShown()) {
+  if (!settingsHolder->telemetryPolicyShown()) {
     setState(StateTelemetryPolicy);
     return;
   }

--- a/src/networkwatcher.cpp
+++ b/src/networkwatcher.cpp
@@ -73,7 +73,7 @@ void NetworkWatcher::initialize() {
           &NetworkWatcher::settingsChanged);
 }
 
-void NetworkWatcher::settingsChanged(bool active) {
+void NetworkWatcher::settingsChanged(const bool& active) {
   logger.debug() << "Settings changed:" << active;
   if (m_active == active) {
     return;

--- a/src/networkwatcher.h
+++ b/src/networkwatcher.h
@@ -27,7 +27,7 @@ class NetworkWatcher final : public QObject {
   void unsecuredNetwork(const QString& networkName, const QString& networkId);
 
  private:
-  void settingsChanged(bool active);
+  void settingsChanged(const bool& value);
 
   void notificationClicked(SystemTrayHandler::Message message);
 

--- a/src/platforms/ios/iosiaphandler.mm
+++ b/src/platforms/ios/iosiaphandler.mm
@@ -114,8 +114,7 @@ Logger logger(LOG_IAP, "IOSIAPHandler");
 
         completedTransactions = true;
 
-        SettingsHolder* settingsHolder = SettingsHolder::instance();
-        if (settingsHolder->hasSubscriptionTransaction(identifier)) {
+        if (SettingsHolder::instance()->subscriptionTransactions().contains(identifier)) {
           logger.warning() << "This transaction has already been processed. Let's ignore it.";
         } else {
           completedTransactionIds.append(identifier);
@@ -356,7 +355,12 @@ void IOSIAPHandler::processCompletedTransactions(const QStringList& ids) {
 
   connect(request, &NetworkRequest::requestCompleted, [this, ids](const QByteArray&) {
     logger.debug() << "Purchase request completed";
-    SettingsHolder::instance()->addSubscriptionTransactions(ids);
+    SettingsHolder* settingsHolder = SettingsHolder::instance();
+    Q_ASSERT(settingsHolder);
+
+    QStringList transactions = settingsHolder->subscriptionTransactions();
+    transactions.append(ids);
+    settingsHolder->setSubscriptionTransactions(transactions);
 
     if (m_subscriptionState != eActive) {
       logger.warning() << "We have been canceled in the meantime";

--- a/src/platforms/macos/macosstartatbootwatcher.cpp
+++ b/src/platforms/macos/macosstartatbootwatcher.cpp
@@ -22,7 +22,7 @@ MacOSStartAtBootWatcher::~MacOSStartAtBootWatcher() {
   MVPN_COUNT_DTOR(MacOSStartAtBootWatcher);
 }
 
-void MacOSStartAtBootWatcher::startAtBootChanged(bool startAtBoot) {
+void MacOSStartAtBootWatcher::startAtBootChanged(const bool& startAtBoot) {
   logger.debug() << "StartAtBoot changed:" << startAtBoot;
   MacOSUtils::enableLoginItem(startAtBoot);
 }

--- a/src/platforms/macos/macosstartatbootwatcher.h
+++ b/src/platforms/macos/macosstartatbootwatcher.h
@@ -15,8 +15,7 @@ class MacOSStartAtBootWatcher final : public QObject {
   explicit MacOSStartAtBootWatcher(bool startAtBoot);
   ~MacOSStartAtBootWatcher();
 
- public slots:
-  void startAtBootChanged(bool value);
+  void startAtBootChanged(const bool& startAtBoot);
 };
 
 #endif  // MACOSSTARTATBOOTWATCHER_H

--- a/src/platforms/windows/windowsapplistprovider.cpp
+++ b/src/platforms/windows/windowsapplistprovider.cpp
@@ -53,7 +53,15 @@ void WindowsAppListProvider::getApplicationList() {
 }
 
 void WindowsAppListProvider::addApplication(const QString& appPath) {
-  SettingsHolder::instance()->addMissingApp(appPath);
+  SettingsHolder* settingsHolder = SettingsHolder::instance();
+  Q_ASSERT(settingsHolder);
+
+  QStringList applist = settingsHolder->missingApps();
+  if (!applist.contains(appPath)) {
+    appList.append(appPath);
+    settingsHolder->setMissingApps(applist);
+  }
+
   getApplicationList();
 }
 

--- a/src/platforms/windows/windowsstartatbootwatcher.cpp
+++ b/src/platforms/windows/windowsstartatbootwatcher.cpp
@@ -5,6 +5,8 @@
 #include "windowsstartatbootwatcher.h"
 #include "leakdetector.h"
 #include "logger.h"
+#include "settingsholder.h"
+
 #include <QCoreApplication>
 #include <QSettings>
 #include <QDir>
@@ -23,7 +25,7 @@ WindowsStartAtBootWatcher::~WindowsStartAtBootWatcher() {
   MVPN_COUNT_DTOR(WindowsStartAtBootWatcher);
 }
 
-void WindowsStartAtBootWatcher::startAtBootChanged(bool startAtBoot) {
+void WindowsStartAtBootWatcher::startAtBootChanged(const bool& startAtBoot) {
   logger.debug() << "StartAtBoot changed:" << startAtBoot;
   QSettings settings(
       "HKEY_CURRENT_USER\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Run",

--- a/src/platforms/windows/windowsstartatbootwatcher.h
+++ b/src/platforms/windows/windowsstartatbootwatcher.h
@@ -15,8 +15,7 @@ class WindowsStartAtBootWatcher final : public QObject {
   explicit WindowsStartAtBootWatcher(bool startAtBoot);
   ~WindowsStartAtBootWatcher();
 
- public slots:
-  void startAtBootChanged(bool value);
+  void startAtBootChanged(const bool& startAtBoot);
 };
 
 #endif  // WINDOWSSTARTATBOOTWATCHER_H

--- a/src/settingsholder.cpp
+++ b/src/settingsholder.cpp
@@ -18,115 +18,18 @@
 #include <QSettings>
 #include <QProcessEnvironment>
 
-constexpr bool SETTINGS_IPV6ENABLED_DEFAULT = true;
-constexpr bool SETTINGS_LOCALNETWORKACCESS_DEFAULT = false;
-constexpr bool SETTINGS_UNSECUREDNETWORKALERT_DEFAULT = true;
-constexpr bool SETTINGS_CAPTIVEPORTALALERT_DEFAULT = true;
-constexpr bool SETTINGS_STARTATBOOT_DEFAULT = false;
-constexpr bool SETTINGS_PROTECTSELECTEDAPPS_DEFAULT = false;
-constexpr bool SETTINGS_SERVERSWITCHNOTIFICATION_DEFAULT = true;
-constexpr bool SETTINGS_CONNECTIONSWITCHNOTIFICATION_DEFAULT = true;
-const QStringList SETTINGS_DEFAULT_EMPTY_LIST = QStringList();
-constexpr const char* SETTINGS_USER_DNS_DEFAULT = "";
-const int SETTINGS_DNS_PROVIDER_DEFAULT = SettingsHolder::DnsProvider::Gateway;
-constexpr const char* SETTINGS_ENTRYSERVER_COUNTRYCODE_DEFAULT = nullptr;
-constexpr const char* SETTINGS_ENTRYSERVER_CITY_DEFAULT = nullptr;
-
-constexpr const char* SETTINGS_IPV6ENABLED = "ipv6Enabled";
-constexpr const char* SETTINGS_LOCALNETWORKACCESS = "localNetworkAccess";
-constexpr const char* SETTINGS_UNSECUREDNETWORKALERT = "unsecuredNetworkAlert";
-constexpr const char* SETTINGS_SERVERSWITCHNOTIFICATION =
-    "serverSwitchNotification";
-constexpr const char* SETTINGS_CONNECTIONSWITCHNOTIFICATION =
-    "connectionChangeNotification";
-constexpr const char* SETTINGS_CAPTIVEPORTALALERT = "captivePortalAlert";
-constexpr const char* SETTINGS_STARTATBOOT = "startAtBoot";
-constexpr const char* SETTINGS_LANGUAGECODE = "languageCode";
-constexpr const char* SETTINGS_PREVIOUSLANGUAGECODE = "previousLanguageCode";
-constexpr const char* SETTINGS_SYSTEMLANGUAGECODEMIGRATED =
-    "systemLanguageCodeMigrated";
-constexpr const char* SETTINGS_INSTALLATIONTIME = "installationTime";
-constexpr const char* SETTINGS_TOKEN = "token";
-constexpr const char* SETTINGS_SERVERS = "servers";
-constexpr const char* SETTINGS_PRIVATEKEY = "privateKey";
-constexpr const char* SETTINGS_PUBLICKEY = "publicKey";
-constexpr const char* SETTINGS_USER_DNS = "userDNS";
-constexpr const char* SETTINGS_DNS_PROVIDER = "dnsProvider";
-constexpr const char* SETTINGS_USER_AVATAR = "user/avatar";
-constexpr const char* SETTINGS_USER_DISPLAYNAME = "user/displayName";
-constexpr const char* SETTINGS_USER_EMAIL = "user/email";
-constexpr const char* SETTINGS_USER_MAXDEVICES = "user/maxDevices";
-constexpr const char* SETTINGS_USER_SUBSCRIPTIONNEEDED =
-    "user/subscriptionNeeded";
-constexpr const char* SETTINGS_CURRENTSERVER_COUNTRYCODE =
-    "currentServer/countryCode";
-constexpr const char* SETTINGS_CURRENTSERVER_COUNTRY = "currentServer/country";
-constexpr const char* SETTINGS_CURRENTSERVER_CITY = "currentServer/city";
-constexpr const char* SETTINGS_ENTRYSERVER_COUNTRYCODE =
-    "entryServer/countryCode";
-constexpr const char* SETTINGS_ENTRYSERVER_CITY = "entryServer/city";
-constexpr const char* SETTINGS_DEVICES = "devices";
-constexpr const char* SETTINGS_SURVEYS = "surveys";
-constexpr const char* SETTINGS_CONSUMEDSURVEYS = "consumedSurveys";
-constexpr const char* SETTINGS_IAPPRODUCTS = "iapProducts";
-constexpr const char* SETTINGS_CAPTIVEPORTALIPV4ADDRESSES =
-    "captivePortal/ipv4Addresses";
-constexpr const char* SETTINGS_CAPTIVEPORTALIPV6ADDRESSES =
-    "captivePortal/ipv6Addresses";
-constexpr const char* SETTINGS_POSTAUTHENTICATIONSHOWN =
-    "postAuthenticationShown";
-constexpr const char* SETTINGS_TELEMETRYPOLICYSHOWN = "telemetryPolicyShown";
-constexpr const char* SETTINGS_PROTECTSELECTEDAPPS = "protectSelectedApps";
-constexpr const char* SETTINGS_VPNDISABLEDAPPS = "vpnDisabledApps";
-constexpr const char* SETTINGS_DEVMODE_FEATURE_FLAGS = "devmodeFeatureFlags";
-constexpr const char* SETTINGS_RECENT_CONNECTIONS = "recentConnections";
-
-#ifdef MVPN_IOS
-constexpr const char* SETTINGS_NATIVEIOSDATAMIGRATED = "nativeIOSDataMigrated";
-constexpr const char* SETTINGS_SUBSCRIPTIONTRANSACTIONS =
-    "subscriptionTransactions";
-#endif
-
-#ifdef MVPN_ANDROID
-constexpr const char* SETTINGS_NATIVEANDROIDSDATAMIGRATED =
-    "nativeAndroidDataMigrated";
-#endif
-
-#ifdef MVPN_WINDOWS
-constexpr const char* SETTINGS_NATIVEWINDOWSDATAMIGRATED =
-    "nativeWindowsDataMigrated";
-#endif
-constexpr const char* SETTINGS_MISSING_SPLITTUNNEL_APPS = "MissingApps";
-
-constexpr bool SETTINGS_GLEANENABLED_DEFAULT = true;
-constexpr const char* SETTINGS_GLEANENABLED = "gleanEnabled";
-
-constexpr bool SETTINGS_DEVELOPERUNLOCK_DEFAULT = false;
-constexpr const char* SETTINGS_DEVELOPERUNLOCK = "developerUnlock";
-
-constexpr bool SETTINGS_STAGINGSERVER_DEFAULT = false;
-constexpr const char* SETTINGS_STAGINGSERVER = "stagingServer";
-
-constexpr const char* SETTINGS_STAGINGSERVERADDRESS = "stagingServerAddress";
-
-const QStringList SETTINGS_SEENFEATURES_DEFAULT = QStringList();
-constexpr const char* SETTINGS_SEENFEATURES = "seenFeatures";
-
-constexpr bool SETTINGS_FEATURESTOURSHOWN_DEFAULT = false;
-constexpr const char* SETTINGS_FEATURESTOURSHOWN = "featuresTourShown";
-
-constexpr const char* SETTINGS_DEVICEKEYVERSION = "deviceKeyVersion";
-
 namespace {
+
 Logger logger(LOG_MAIN, "SettingsHolder");
 // Setting Keys That won't show up in a report;
 QVector<QString> SENSITIVE_SETTINGS({
-    SETTINGS_TOKEN, SETTINGS_PRIVATEKEY,
-    SETTINGS_SERVERS,  // Those 2 Are not sensitive but
-    SETTINGS_DEVICES   // are more noise then info
+    "token", "privateKey",
+    "servers",  // Those 2 are not sensitive but
+    "devices",  // are more noise then info
 });
 
 SettingsHolder* s_instance = nullptr;
+
 }  // namespace
 
 // static
@@ -172,24 +75,14 @@ SettingsHolder::~SettingsHolder() {
 void SettingsHolder::clear() {
   logger.debug() << "Clean up the settings";
 
-  m_settings.remove(SETTINGS_TOKEN);
-  m_settings.remove(SETTINGS_SERVERS);
-  m_settings.remove(SETTINGS_PRIVATEKEY);
-  m_settings.remove(SETTINGS_USER_AVATAR);
-  m_settings.remove(SETTINGS_USER_DISPLAYNAME);
-  m_settings.remove(SETTINGS_USER_EMAIL);
-  m_settings.remove(SETTINGS_USER_MAXDEVICES);
-  m_settings.remove(SETTINGS_USER_SUBSCRIPTIONNEEDED);
-  m_settings.remove(SETTINGS_CURRENTSERVER_COUNTRYCODE);
-  m_settings.remove(SETTINGS_CURRENTSERVER_COUNTRY);
-  m_settings.remove(SETTINGS_CURRENTSERVER_CITY);
-  m_settings.remove(SETTINGS_ENTRYSERVER_COUNTRYCODE);
-  m_settings.remove(SETTINGS_ENTRYSERVER_CITY);
-  m_settings.remove(SETTINGS_DEVICES);
-  m_settings.remove(SETTINGS_SURVEYS);
-  m_settings.remove(SETTINGS_IAPPRODUCTS);
-  m_settings.remove(SETTINGS_POSTAUTHENTICATIONSHOWN);
-  m_settings.remove(SETTINGS_RECENT_CONNECTIONS);
+#define SETTING(type, toType, getter, setter, has, key, defvalue, \
+                removeWhenReset)                                  \
+  if (removeWhenReset) {                                          \
+    m_settings.remove(key);                                       \
+  }
+
+#include "settingslist.h"
+#undef SETTING
 
   // We do not remove language, ipv6 and localnetwork settings.
 }
@@ -211,310 +104,47 @@ QString SettingsHolder::getReport() {
   return buff;
 }
 
-#define GETSETDEFAULT(def, type, toType, key, has, get, set, signal)    \
-  bool SettingsHolder::has() const { return m_settings.contains(key); } \
-  type SettingsHolder::get() const {                                    \
-    if (!has()) {                                                       \
-      return def;                                                       \
-    }                                                                   \
-    return m_settings.value(key).toType();                              \
-  }                                                                     \
-  void SettingsHolder::set(const type& value) {                         \
-    logger.debug() << "Setting" << key << "to" << value;                \
-    m_settings.setValue(key, value);                                    \
-    emit signal(value);                                                 \
+#define SETTING(type, toType, getter, setter, has, key, defvalue, __VA_ARGS__) \
+  bool SettingsHolder::has() const { return m_settings.contains(key); }        \
+  type SettingsHolder::getter() const {                                        \
+    if (!has()) {                                                              \
+      return defvalue;                                                         \
+    }                                                                          \
+    return m_settings.value(key).toType();                                     \
+  }                                                                            \
+  void SettingsHolder::setter(const type& value) {                             \
+    m_settings.setValue(key, value);                                           \
+    emit getter##Changed(value);                                               \
   }
 
-GETSETDEFAULT(SETTINGS_IPV6ENABLED_DEFAULT, bool, toBool, SETTINGS_IPV6ENABLED,
-              hasIpv6Enabled, ipv6Enabled, setIpv6Enabled, ipv6EnabledChanged)
-GETSETDEFAULT(FeatureLocalAreaAccess::instance()->isSupported() &&
-                  SETTINGS_LOCALNETWORKACCESS_DEFAULT,
-              bool, toBool, SETTINGS_LOCALNETWORKACCESS, hasLocalNetworkAccess,
-              localNetworkAccess, setLocalNetworkAccess,
-              localNetworkAccessChanged)
-GETSETDEFAULT(SETTINGS_USER_DNS_DEFAULT, QString, toString, SETTINGS_USER_DNS,
-              hasUserDNS, userDNS, setUserDNS, userDNSChanged)
-GETSETDEFAULT(FeatureUnsecuredNetworkNotification::instance()->isSupported() &&
-                  SETTINGS_UNSECUREDNETWORKALERT_DEFAULT,
-              bool, toBool, SETTINGS_UNSECUREDNETWORKALERT,
-              hasUnsecuredNetworkAlert, unsecuredNetworkAlert,
-              setUnsecuredNetworkAlert, unsecuredNetworkAlertChanged)
-GETSETDEFAULT(FeatureCaptivePortal::instance()->isSupported() &&
-                  SETTINGS_CAPTIVEPORTALALERT_DEFAULT,
-              bool, toBool, SETTINGS_CAPTIVEPORTALALERT, hasCaptivePortalAlert,
-              captivePortalAlert, setCaptivePortalAlert,
-              captivePortalAlertChanged)
-GETSETDEFAULT(FeatureStartOnBoot::instance()->isSupported() &&
-                  SETTINGS_STARTATBOOT_DEFAULT,
-              bool, toBool, SETTINGS_STARTATBOOT, hasStartAtBoot, startAtBoot,
-              setStartAtBoot, startAtBootChanged)
-GETSETDEFAULT(FeatureSplitTunnel::instance()->isSupported() &&
-                  SETTINGS_PROTECTSELECTEDAPPS_DEFAULT,
-              bool, toBool, SETTINGS_PROTECTSELECTEDAPPS,
-              hasProtectSelectedApps, protectSelectedApps,
-              setProtectSelectedApps, protectSelectedAppsChanged)
-GETSETDEFAULT(SETTINGS_DEFAULT_EMPTY_LIST, QStringList, toStringList,
-              SETTINGS_VPNDISABLEDAPPS, hasVpnDisabledApps, vpnDisabledApps,
-              setVpnDisabledApps, vpnDisabledAppsChanged)
-GETSETDEFAULT(SETTINGS_GLEANENABLED_DEFAULT, bool, toBool,
-              SETTINGS_GLEANENABLED, hasGleanEnabled, gleanEnabled,
-              setGleanEnabled, gleanEnabledChanged)
-GETSETDEFAULT(SETTINGS_SERVERSWITCHNOTIFICATION_DEFAULT, bool, toBool,
-              SETTINGS_SERVERSWITCHNOTIFICATION, hasServerSwitchNotification,
-              serverSwitchNotification, setServerSwitchNotification,
-              serverSwitchNotificationChanged);
-GETSETDEFAULT(SETTINGS_CONNECTIONSWITCHNOTIFICATION_DEFAULT, bool, toBool,
-              SETTINGS_CONNECTIONSWITCHNOTIFICATION,
-              hasConnectionChangeNotification, connectionChangeNotification,
-              setConnectionChangeNotification,
-              connectionChangeNotificationChanged);
-GETSETDEFAULT(SETTINGS_DEVELOPERUNLOCK_DEFAULT, bool, toBool,
-              SETTINGS_DEVELOPERUNLOCK, hasDeveloperUnlock, developerUnlock,
-              setDeveloperUnlock, developerUnlockChanged)
-GETSETDEFAULT(SETTINGS_STAGINGSERVER_DEFAULT, bool, toBool,
-              SETTINGS_STAGINGSERVER, hasStagingServer, stagingServer,
-              setStagingServer, stagingServerChanged)
-GETSETDEFAULT(envOrDefault("MVPN_API_BASE_URL", Constants::API_PRODUCTION_URL),
-              QString, toString, SETTINGS_STAGINGSERVERADDRESS,
-              hasStagingServerAddress, stagingServerAddress,
-              setStagingServerAddress, stagingServerAddressChanged)
-GETSETDEFAULT(SETTINGS_SEENFEATURES_DEFAULT, QStringList, toStringList,
-              SETTINGS_SEENFEATURES, hasSeenFeatures, seenFeatures,
-              setSeenFeatures, seenFeaturesChanged);
-GETSETDEFAULT(SETTINGS_FEATURESTOURSHOWN_DEFAULT, bool, toBool,
-              SETTINGS_FEATURESTOURSHOWN, hasFeaturesTourShown,
-              featuresTourShown, setFeaturesTourShown,
-              featuresTourShownChanged);
-GETSETDEFAULT(SETTINGS_DNS_PROVIDER_DEFAULT, int, toInt, SETTINGS_DNS_PROVIDER,
-              hasDNSProvider, dnsProvider, setDNSProvider, dnsProviderChanged)
-GETSETDEFAULT(SETTINGS_DEFAULT_EMPTY_LIST, QStringList, toStringList,
-              SETTINGS_DEVMODE_FEATURE_FLAGS, hasDevModeFeatureFlags,
-              devModeFeatureFlags, setDevModeFeatureFlags,
-              devModeFeatureFlagsChanged);
-GETSETDEFAULT(SETTINGS_ENTRYSERVER_COUNTRYCODE_DEFAULT, QString, toString,
-              SETTINGS_ENTRYSERVER_COUNTRYCODE, hasEntryServerCountryCode,
-              entryServerCountryCode, setEntryServerCountryCode,
-              entryServerCountryCodeChanged)
-GETSETDEFAULT(SETTINGS_ENTRYSERVER_CITY_DEFAULT, QString, toString,
-              SETTINGS_ENTRYSERVER_CITY, hasEntryServerCity, entryServerCity,
-              setEntryServerCity, entryServerCityChanged)
-GETSETDEFAULT(SETTINGS_DEFAULT_EMPTY_LIST, QStringList, toStringList,
-              SETTINGS_RECENT_CONNECTIONS, hasRecentConnections,
-              recentConnections, setRecentConnections,
-              recentConnectionsChanged);
-
-#undef GETSETDEFAULT
-
-#define GETSET(type, toType, key, has, get, set)                        \
-  bool SettingsHolder::has() const { return m_settings.contains(key); } \
-  type SettingsHolder::get() const {                                    \
-    Q_ASSERT(has());                                                    \
-    return m_settings.value(key).toType();                              \
-  }                                                                     \
-  void SettingsHolder::set(const type& value) {                         \
-    logger.debug() << "Setting" << key;                                 \
-    m_settings.setValue(key, value);                                    \
-  }
-
-GETSET(QString, toString, SETTINGS_TOKEN, hasToken, token, setToken)
-GETSET(QString, toString, SETTINGS_PRIVATEKEY, hasPrivateKey, privateKey,
-       setPrivateKey)
-GETSET(QString, toString, SETTINGS_PUBLICKEY, hasPublicKey, publicKey,
-       setPublicKey)
-GETSET(QByteArray, toByteArray, SETTINGS_SERVERS, hasServers, servers,
-       setServers)
-GETSET(QString, toString, SETTINGS_USER_AVATAR, hasUserAvatar, userAvatar,
-       setUserAvatar)
-GETSET(QString, toString, SETTINGS_USER_DISPLAYNAME, hasUserDisplayName,
-       userDisplayName, setUserDisplayName)
-GETSET(QString, toString, SETTINGS_USER_EMAIL, hasUserEmail, userEmail,
-       setUserEmail)
-GETSET(int, toInt, SETTINGS_USER_MAXDEVICES, hasUserMaxDevices, userMaxDevices,
-       setUserMaxDevices)
-GETSET(bool, toBool, SETTINGS_USER_SUBSCRIPTIONNEEDED,
-       hasUserSubscriptionNeeded, userSubscriptionNeeded,
-       setUserSubscriptionNeeded)
-GETSET(QString, toString, SETTINGS_CURRENTSERVER_COUNTRYCODE,
-       hasCurrentServerCountryCode, currentServerCountryCode,
-       setCurrentServerCountryCode)
-GETSET(QString, toString, SETTINGS_CURRENTSERVER_COUNTRY,
-       hasCurrentServerCountry, currentServerCountry, setCurrentServerCountry)
-GETSET(QString, toString, SETTINGS_CURRENTSERVER_CITY, hasCurrentServerCity,
-       currentServerCity, setCurrentServerCity)
-GETSET(QByteArray, toByteArray, SETTINGS_DEVICES, hasDevices, devices,
-       setDevices)
-GETSET(QByteArray, toByteArray, SETTINGS_SURVEYS, hasSurveys, surveys,
-       setSurveys)
-GETSET(QStringList, toStringList, SETTINGS_CONSUMEDSURVEYS, hasConsumedSurveys,
-       consumedSurveys, setConsumedSurveys)
-GETSET(QStringList, toStringList, SETTINGS_IAPPRODUCTS, hasIapProducts,
-       iapProducts, setIapProducts)
-GETSET(QStringList, toStringList, SETTINGS_CAPTIVEPORTALIPV4ADDRESSES,
-       hasCaptivePortalIpv4Addresses, captivePortalIpv4Addresses,
-       setCaptivePortalIpv4Addresses)
-GETSET(QStringList, toStringList, SETTINGS_CAPTIVEPORTALIPV6ADDRESSES,
-       hasCaptivePortalIpv6Addresses, captivePortalIpv6Addresses,
-       setCaptivePortalIpv6Addresses)
-GETSET(bool, toBool, SETTINGS_POSTAUTHENTICATIONSHOWN,
-       hasPostAuthenticationShown, postAuthenticationShown,
-       setPostAuthenticationShown);
-GETSET(bool, toBool, SETTINGS_TELEMETRYPOLICYSHOWN, hasTelemetryPolicyShown,
-       telemetryPolicyShown, setTelemetryPolicyShown);
-GETSET(QString, toString, SETTINGS_LANGUAGECODE, hasLanguageCode, languageCode,
-       setLanguageCode);
-GETSET(QString, toString, SETTINGS_PREVIOUSLANGUAGECODE,
-       hasPreviousLanguageCode, previousLanguageCode, setPreviousLanguageCode);
-GETSET(bool, toBool, SETTINGS_SYSTEMLANGUAGECODEMIGRATED,
-       hasSystemLanguageCodeMigrated, systemLanguageCodeMigrated,
-       setSystemLanguageCodeMigrated);
-GETSET(QDateTime, toDateTime, SETTINGS_INSTALLATIONTIME, hasInstallationTime,
-       installationTime, setInstallationTime);
-GETSET(QString, toString, SETTINGS_DEVICEKEYVERSION, hasDeviceKeyVersion,
-       deviceKeyVersion, setDeviceKeyVersion);
-
-#ifdef MVPN_ANDROID
-GETSET(bool, toBool, SETTINGS_NATIVEANDROIDSDATAMIGRATED,
-       hasNativeAndroidDataMigrated, nativeAndroidDataMigrated,
-       setNativeAndroidDataMigrated);
-#endif
-
-#ifdef MVPN_IOS
-GETSET(bool, toBool, SETTINGS_NATIVEIOSDATAMIGRATED, hasNativeIOSDataMigrated,
-       nativeIOSDataMigrated, setNativeIOSDataMigrated)
-GETSET(QStringList, toStringList, SETTINGS_SUBSCRIPTIONTRANSACTIONS,
-       hasSubscriptionTransactions, subscriptionTransactions,
-       setSubscriptionTransactions)
-
-bool SettingsHolder::hasSubscriptionTransaction(
-    const QString& transactionId) const {
-  return hasSubscriptionTransactions() &&
-         subscriptionTransactions().contains(transactionId);
-}
-
-void SettingsHolder::addSubscriptionTransactions(
-    const QStringList& transactionIds) {
-  QStringList transactions;
-  if (hasSubscriptionTransactions()) {
-    transactions = subscriptionTransactions();
-  }
-
-  transactions.append(transactionIds);
-  setSubscriptionTransactions(transactions);
-}
-#endif
-
-#ifdef MVPN_WINDOWS
-GETSET(bool, toBool, SETTINGS_NATIVEWINDOWSDATAMIGRATED,
-       hasNativeWindowsDataMigrated, nativeWindowsDataMigrated,
-       setNativeWindowsDataMigrated)
-
-#endif
-
-GETSET(QStringList, toStringList, SETTINGS_MISSING_SPLITTUNNEL_APPS,
-       hasMissingApps, missingApps, setMissingApps)
-
-void SettingsHolder::removeMissingApp(const QString& appID) {
-  QStringList applist;
-  if (hasMissingApps()) {
-    applist = missingApps();
-  }
-  applist.removeAll(appID);
-  setMissingApps(applist);
-}
-void SettingsHolder::addMissingApp(const QString& appID) {
-  QStringList applist;
-  if (hasMissingApps()) {
-    applist = missingApps();
-  }
-  if (applist.contains(appID)) {
-    return;
-  }
-  applist.append(appID);
-  setMissingApps(applist);
-}
-#undef GETSET
-
-bool SettingsHolder::hasVpnDisabledApp(const QString& appID) {
-  QStringList applist;
-  if (hasVpnDisabledApps()) {
-    applist = vpnDisabledApps();
-  }
-  return applist.contains(appID);
-}
-void SettingsHolder::removeVpnDisabledApp(const QString& appID) {
-  QStringList applist;
-  if (hasVpnDisabledApps()) {
-    applist = vpnDisabledApps();
-  }
-  applist.removeAll(appID);
-  setVpnDisabledApps(applist);
-}
-void SettingsHolder::addVpnDisabledApp(const QString& appID) {
-  QStringList applist;
-  if (hasVpnDisabledApps()) {
-    applist = vpnDisabledApps();
-  }
-  applist.append(appID);
-  setVpnDisabledApps(applist);
-}
-
-void SettingsHolder::addConsumedSurvey(const QString& surveyId) {
-  QStringList list;
-  if (hasConsumedSurveys()) {
-    list = consumedSurveys();
-  }
-  list.append(surveyId);
-  setConsumedSurveys(list);
-}
+#include "settingslist.h"
+#undef SETTING
 
 QString SettingsHolder::placeholderUserDNS() const {
   return Constants::PLACEHOLDER_USER_DNS;
 }
 
-bool SettingsHolder::hasDevModeFeatureFlag(const QString& featureID) {
-  QStringList features;
-  if (hasDevModeFeatureFlags()) {
-    features = devModeFeatureFlags();
-  }
-  return features.contains(featureID);
-}
-void SettingsHolder::enableDevModeFeatureFlag(const QString& featureID) {
-  QStringList features;
-  if (hasDevModeFeatureFlags()) {
-    features = devModeFeatureFlags();
-  }
-  features.append(featureID);
-  setDevModeFeatureFlags(features);
-}
-
-void SettingsHolder::removeDevModeFeatureFlag(const QString& featureID) {
-  QStringList features;
-  if (hasDevModeFeatureFlags()) {
-    features = devModeFeatureFlags();
-  }
-  features.removeAll(featureID);
-  setDevModeFeatureFlags(features);
-}
-
 void SettingsHolder::removeEntryServer() {
-  m_settings.remove(SETTINGS_ENTRYSERVER_COUNTRYCODE);
-  m_settings.remove(SETTINGS_ENTRYSERVER_CITY);
-}
-
-QString SettingsHolder::getEnvVariable(const QString& name) const {
-  QProcessEnvironment pe = QProcessEnvironment::systemEnvironment();
-  if (pe.contains(name)) return pe.value(name);
-  return QString();
+  m_settings.remove("entryServer/countryCode");
+  m_settings.remove("entryServer/city");
 }
 
 QString SettingsHolder::envOrDefault(const QString& name,
                                      const QString& defaultValue) const {
-  const QString env = getEnvVariable(name);
+  QString env;
+
+  QProcessEnvironment pe = QProcessEnvironment::systemEnvironment();
+  if (pe.contains(name)) {
+    env = pe.value(name);
+  }
+
   if (env.isEmpty()) {
     return defaultValue;
   }
+
   if (!QUrl(env).isValid()) {
     return defaultValue;
   }
+
   return env;
 }

--- a/src/settingsholder.h
+++ b/src/settingsholder.h
@@ -14,45 +14,16 @@ class SettingsHolder final : public QObject {
   Q_OBJECT
   Q_DISABLE_COPY_MOVE(SettingsHolder)
 
-  Q_PROPERTY(bool ipv6Enabled READ ipv6Enabled WRITE setIpv6Enabled NOTIFY
-                 ipv6EnabledChanged)
-  Q_PROPERTY(bool localNetworkAccess READ localNetworkAccess WRITE
-                 setLocalNetworkAccess NOTIFY localNetworkAccessChanged)
-  Q_PROPERTY(bool unsecuredNetworkAlert READ unsecuredNetworkAlert WRITE
-                 setUnsecuredNetworkAlert NOTIFY unsecuredNetworkAlertChanged)
-  Q_PROPERTY(bool captivePortalAlert READ captivePortalAlert WRITE
-                 setCaptivePortalAlert NOTIFY captivePortalAlertChanged)
-  Q_PROPERTY(bool startAtBoot READ startAtBoot WRITE setStartAtBoot NOTIFY
-                 startAtBootChanged)
-  Q_PROPERTY(bool protectSelectedApps READ protectSelectedApps WRITE
-                 setProtectSelectedApps NOTIFY protectSelectedAppsChanged)
-  Q_PROPERTY(bool gleanEnabled READ gleanEnabled WRITE setGleanEnabled NOTIFY
-                 gleanEnabledChanged)
-  Q_PROPERTY(
-      bool serverSwitchNotification READ serverSwitchNotification WRITE
-          setServerSwitchNotification NOTIFY serverSwitchNotificationChanged)
-  Q_PROPERTY(bool connectionChangeNotification READ connectionChangeNotification
-                 WRITE setConnectionChangeNotification NOTIFY
-                     connectionChangeNotificationChanged)
-  Q_PROPERTY(QString placeholderUserDNS READ placeholderUserDNS CONSTANT)
-  Q_PROPERTY(bool developerUnlock READ developerUnlock WRITE setDeveloperUnlock
-                 NOTIFY developerUnlockChanged)
-  Q_PROPERTY(bool stagingServer READ stagingServer WRITE setStagingServer NOTIFY
-                 stagingServerChanged)
-  Q_PROPERTY(QString stagingServerAddress READ stagingServerAddress WRITE
-                 setStagingServerAddress NOTIFY stagingServerAddressChanged)
-  Q_PROPERTY(QStringList seenFeatures READ seenFeatures WRITE setSeenFeatures
-                 NOTIFY seenFeaturesChanged)
-  Q_PROPERTY(bool featuresTourShown READ featuresTourShown WRITE
-                 setFeaturesTourShown NOTIFY featuresTourShownChanged)
-  Q_PROPERTY(int dnsProvider READ dnsProvider WRITE setDNSProvider NOTIFY
-                 dnsProviderChanged)
-  Q_PROPERTY(
-      QString userDNS READ userDNS WRITE setUserDNS NOTIFY userDNSChanged)
-  Q_PROPERTY(QStringList recentConnections READ recentConnections WRITE
-                 setRecentConnections NOTIFY recentConnectionsChanged)
-
  public:
+#define SETTING(type, toType, getter, setter, ...)                        \
+  Q_PROPERTY(type getter READ getter WRITE setter NOTIFY getter##Changed) \
+  Q_SIGNAL void getter##Changed(const type& value);
+
+#include "settingslist.h"
+#undef SETTING
+
+  Q_PROPERTY(QString placeholderUserDNS READ placeholderUserDNS CONSTANT)
+
   SettingsHolder();
   ~SettingsHolder();
 
@@ -71,146 +42,24 @@ class SettingsHolder final : public QObject {
 
   void clear();
 
-#define GETSET(type, has, get, set) \
-  bool has() const;                 \
-  type get() const;                 \
-  void set(const type& value);
+#define SETTING(type, toType, getter, setter, has, ...) \
+  bool has() const;                                     \
+  type getter() const;                                  \
+  void setter(const type& value);
 
-  GETSET(bool, hasIpv6Enabled, ipv6Enabled, setIpv6Enabled)
-  GETSET(bool, hasLocalNetworkAccess, localNetworkAccess, setLocalNetworkAccess)
-  GETSET(bool, hasUnsecuredNetworkAlert, unsecuredNetworkAlert,
-         setUnsecuredNetworkAlert)
-  GETSET(bool, hasCaptivePortalAlert, captivePortalAlert, setCaptivePortalAlert)
-  GETSET(bool, hasStartAtBoot, startAtBoot, setStartAtBoot)
-  GETSET(QString, hasLanguageCode, languageCode, setLanguageCode)
-  GETSET(QString, hasPreviousLanguageCode, previousLanguageCode,
-         setPreviousLanguageCode)
-  GETSET(bool, hasSystemLanguageCodeMigrated, systemLanguageCodeMigrated,
-         setSystemLanguageCodeMigrated)
-  GETSET(QString, hasToken, token, setToken)
-  GETSET(QString, hasPrivateKey, privateKey, setPrivateKey)
-  GETSET(QString, hasPublicKey, publicKey, setPublicKey)
-  GETSET(QByteArray, hasServers, servers, setServers)
-  GETSET(QString, hasUserAvatar, userAvatar, setUserAvatar)
-  GETSET(QString, hasUserDisplayName, userDisplayName, setUserDisplayName)
-  GETSET(QString, hasUserEmail, userEmail, setUserEmail)
-  GETSET(int, hasUserMaxDevices, userMaxDevices, setUserMaxDevices)
-  GETSET(bool, hasUserSubscriptionNeeded, userSubscriptionNeeded,
-         setUserSubscriptionNeeded)
-  GETSET(QString, hasCurrentServerCountryCode, currentServerCountryCode,
-         setCurrentServerCountryCode)
-  GETSET(QString, hasCurrentServerCountry, currentServerCountry,
-         setCurrentServerCountry)
-  GETSET(QString, hasCurrentServerCity, currentServerCity, setCurrentServerCity)
-  GETSET(QString, hasEntryServerCountryCode, entryServerCountryCode,
-         setEntryServerCountryCode)
-  GETSET(QString, hasEntryServerCountry, entryServerCountry,
-         setEntryServerCountry)
-  GETSET(QString, hasEntryServerCity, entryServerCity, setEntryServerCity)
-  GETSET(QByteArray, hasDevices, devices, setDevices)
-  GETSET(QByteArray, hasSurveys, surveys, setSurveys)
-  GETSET(QStringList, hasConsumedSurveys, consumedSurveys, setConsumedSurveys)
-  GETSET(QStringList, hasIapProducts, iapProducts, setIapProducts)
-  GETSET(QStringList, hasCaptivePortalIpv4Addresses, captivePortalIpv4Addresses,
-         setCaptivePortalIpv4Addresses)
-  GETSET(QStringList, hasCaptivePortalIpv6Addresses, captivePortalIpv6Addresses,
-         setCaptivePortalIpv6Addresses)
-  GETSET(bool, hasPostAuthenticationShown, postAuthenticationShown,
-         setPostAuthenticationShown);
-  GETSET(bool, hasTelemetryPolicyShown, telemetryPolicyShown,
-         setTelemetryPolicyShown);
-  GETSET(bool, hasProtectSelectedApps, protectSelectedApps,
-         setProtectSelectedApps)
-  GETSET(QStringList, hasVpnDisabledApps, vpnDisabledApps, setVpnDisabledApps)
-  GETSET(QString, hasUserDNS, userDNS, setUserDNS)
-  GETSET(int, hasDNSProvider, dnsProvider, setDNSProvider)
-  GETSET(bool, hasGleanEnabled, gleanEnabled, setGleanEnabled)
-  GETSET(bool, hasDeveloperUnlock, developerUnlock, setDeveloperUnlock)
-  GETSET(bool, hasStagingServer, stagingServer, setStagingServer)
-  GETSET(QString, hasStagingServerAddress, stagingServerAddress,
-         setStagingServerAddress)
-  GETSET(QDateTime, hasInstallationTime, installationTime, setInstallationTime)
-  GETSET(bool, hasServerSwitchNotification, serverSwitchNotification,
-         setServerSwitchNotification);
-  GETSET(bool, hasConnectionChangeNotification, connectionChangeNotification,
-         setConnectionChangeNotification);
-  GETSET(bool, hasFeaturesTourShown, featuresTourShown, setFeaturesTourShown);
-  GETSET(QStringList, hasMissingApps, missingApps, setMissingApps)
-  GETSET(QStringList, hasSeenFeatures, seenFeatures, setSeenFeatures)
-  GETSET(QStringList, hasDevModeFeatureFlags, devModeFeatureFlags,
-         setDevModeFeatureFlags);
-  GETSET(QStringList, hasRecentConnections, recentConnections,
-         setRecentConnections);
-  GETSET(QString, hasDeviceKeyVersion, deviceKeyVersion, setDeviceKeyVersion)
-
-  void removeMissingApp(const QString& appID);
-  void addMissingApp(const QString& appID);
-
-  bool hasVpnDisabledApp(const QString& appID);
-  void removeVpnDisabledApp(const QString& appID);
-  void addVpnDisabledApp(const QString& appID);
-
-  bool hasDevModeFeatureFlag(const QString& featureID);
-  void enableDevModeFeatureFlag(const QString& featureID);
-  void removeDevModeFeatureFlag(const QString& featureID);
-
-  void addConsumedSurvey(const QString& surveyId);
+#include "settingslist.h"
+#undef SETTING
 
   void removeEntryServer();
 
-  QString getEnvVariable(const QString& name) const;
   QString envOrDefault(const QString& name, const QString& defaultValue) const;
 
-#ifdef MVPN_IOS
-  GETSET(bool, hasNativeIOSDataMigrated, nativeIOSDataMigrated,
-         setNativeIOSDataMigrated)
-  GETSET(QStringList, hasSubscriptionTransactions, subscriptionTransactions,
-         setSubscriptionTransactions);
-
-  bool hasSubscriptionTransaction(const QString& transactionId) const;
-  void addSubscriptionTransactions(const QStringList& transactionIds);
-#endif
-
-#ifdef MVPN_WINDOWS
-  GETSET(bool, hasNativeWindowsDataMigrated, nativeWindowsDataMigrated,
-         setNativeWindowsDataMigrated)
-
-#endif
-
-#ifdef MVPN_ANDROID
-  GETSET(bool, hasNativeAndroidDataMigrated, nativeAndroidDataMigrated,
-         setNativeAndroidDataMigrated)
-#endif
-
-#undef GETSET
-
-  QString placeholderUserDNS() const;
-
  signals:
-  void ipv6EnabledChanged(bool value);
-  void localNetworkAccessChanged(bool value);
-  void unsecuredNetworkAlertChanged(bool value);
-  void captivePortalAlertChanged(bool value);
-  void startAtBootChanged(bool value);
-  void protectSelectedAppsChanged(bool value);
-  void vpnDisabledAppsChanged(const QStringList& apps);
-  void userDNSChanged(QString value);
-  void dnsProviderChanged(int value);
-  void gleanEnabledChanged(bool value);
-  void serverSwitchNotificationChanged(bool value);
-  void connectionChangeNotificationChanged(bool value);
-  void developerUnlockChanged(bool value);
-  void stagingServerChanged(bool value);
-  void stagingServerAddressChanged(const QString& value);
-  void seenFeaturesChanged(const QStringList& featureIDs);
-  void featuresTourShownChanged(bool value);
-  void devModeFeatureFlagsChanged(const QStringList& featureIDs);
-  void entryServerCountryCodeChanged(const QString& value);
-  void entryServerCityChanged(const QString& value);
-  void recentConnectionsChanged(const QStringList& value);
 
  private:
   explicit SettingsHolder(QObject* parent);
+
+  QString placeholderUserDNS() const;
 
  private:
   QSettings m_settings;

--- a/src/settingslist.h
+++ b/src/settingslist.h
@@ -1,0 +1,441 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// 1. Define the SETTING macro
+// 2. include this file
+// 3. undefine the SETTING macro
+
+#define SETTING_BOOL(getter, ...) SETTING(bool, toBool, getter, __VA_ARGS__)
+
+#define SETTING_BYTEARRAY(getter, ...) \
+  SETTING(QByteArray, toByteArray, getter, __VA_ARGS__)
+
+#define SETTING_DATETIME(getter, ...) \
+  SETTING(QDateTime, toDateTime, getter, __VA_ARGS__)
+
+#define SETTING_INT(getter, ...) SETTING(int, toInt, getter, __VA_ARGS__)
+
+#define SETTING_STRING(getter, ...) \
+  SETTING(QString, toString, getter, __VA_ARGS__)
+
+#define SETTING_STRINGLIST(getter, ...) \
+  SETTING(QStringList, toStringList, getter, __VA_ARGS__)
+
+// Please! Keep the alphabetic order!
+
+SETTING_BOOL(captivePortalAlert,                               // getter
+             setCaptivePortalAlert,                            // setter
+             hasCaptivePortalAlert,                            // has
+             "captivePortalAlert",                             // key
+             FeatureCaptivePortal::instance()->isSupported(),  // default value
+             false  // remove when reset
+)
+
+SETTING_STRINGLIST(captivePortalIpv4Addresses,     // getter
+                   setCaptivePortalIpv4Addresses,  // setter
+                   hasCaptivePortalIpv4Addresses,  // has
+                   "captivePortal/ipv4Addresses",  // key
+                   QStringList(),                  // default value
+                   false                           // remove when reset
+)
+
+SETTING_STRINGLIST(captivePortalIpv6Addresses,     // getter
+                   setCaptivePortalIpv6Addresses,  // setter
+                   hasCaptivePortalIpv6Addresses,  // has
+                   "captivePortal/ipv6Addresses",  // key
+                   QStringList(),                  // default value
+                   false                           // remove when reset
+)
+
+SETTING_BOOL(connectionChangeNotification,     // getter
+             setConnectionChangeNotification,  // setter
+             hasConnectionChangeNotification,  // has
+             "connectionChangeNotification",   // key
+             true,                             // default value
+             false                             // remove when reset
+)
+
+SETTING_STRINGLIST(consumedSurveys,     // getter
+                   setConsumedSurveys,  // setter
+                   hasConsumedSurveys,  // has
+                   "consumedSurveys",   // key
+                   QStringList(),       // default value
+                   false                // remove when reset
+)
+
+SETTING_STRING(currentServerCity,     // getter
+               setCurrentServerCity,  // setter
+               hasCurrentServerCity,  // has
+               "currentServer/city",  // key
+               "",                    // default value
+               true                   // remove when reset
+)
+
+SETTING_STRING(currentServerCountry,     // getter
+               setCurrentServerCountry,  // setter
+               hasCurrentServerCountry,  // has
+               "currentServer/country",  // key
+               "",                       // default value
+               true                      // remove when reset
+)
+
+SETTING_STRING(currentServerCountryCode,     // getter
+               setCurrentServerCountryCode,  // setter
+               hasCurrentServerCountryCode,  // has
+               "currentServer/countryCode",  // key
+               "",                           // default value
+               true                          // remove when reset
+)
+
+SETTING_BOOL(developerUnlock,     // getter
+             setDeveloperUnlock,  // setter
+             hasDeveloperUnlock,  // has
+             "developerUnlock",   // key
+             false,               // default value
+             false                // remove when reset
+)
+
+SETTING_STRING(deviceKeyVersion,     // getter
+               setDeviceKeyVersion,  // setter
+               hasDeviceKeyVersion,  // has
+               "deviceKeyVersion",   // key
+               "",                   // default value
+               true                  // remove when reset
+)
+
+SETTING_BYTEARRAY(devices,     // getter
+                  setDevices,  // setter
+                  hasDevices,  // has
+                  "devices",   // key
+                  "",          // default value
+                  true         // remove when reset
+)
+
+SETTING_STRINGLIST(devModeFeatureFlags,     // getter
+                   setDevModeFeatureFlags,  // setter
+                   hasDevModeFeatureFlags,  // has
+                   "devmodeFeatureFlags",   // key
+                   QStringList(),           // default value
+                   false                    // remove when reset
+)
+
+SETTING_INT(dnsProvider,                           // getter
+            setDNSProvider,                        // setter
+            hasDNSProvider,                        // has
+            "dnsProvider",                         // key
+            SettingsHolder::DnsProvider::Gateway,  // default value
+            false                                  // remove when reset
+)
+
+SETTING_STRING(entryServerCity,     // getter
+               setEntryServerCity,  // setter
+               hasEntryServerCity,  // has
+               "entryServer/city",  // key
+               nullptr,             // default value
+               true                 // remove when reset
+)
+
+SETTING_STRING(entryServerCountryCode,     // getter
+               setEntryServerCountryCode,  // setter
+               hasEntryServerCountryCode,  // has
+               "entryServer/countryCode",  // key
+               nullptr,                    // default value
+               true                        // remove when reset
+)
+
+SETTING_BOOL(featuresTourShown,     // getter
+             setFeaturesTourShown,  // setter
+             hasFeaturesTourShown,  // has
+             "featuresTourShown",   // key
+             false,                 // default value
+             false                  // remove when reset
+)
+
+SETTING_BOOL(gleanEnabled,     // getter
+             setGleanEnabled,  // setter
+             hasGleanEnabled,  // has
+             "gleanEnabled",   // key
+             true,             // default value
+             false             // remove when reset
+)
+
+SETTING_STRINGLIST(iapProducts,     // getter
+                   setIapProducts,  // setter
+                   hasIapProducts,  // has
+                   "iapProducts",   // key
+                   QStringList(),   // default value
+                   true             // remove when reset
+)
+
+SETTING_DATETIME(installationTime,     // getter
+                 setInstallationTime,  // setter
+                 hasInstallationTime,  // has
+                 "installationTime",   // key
+                 QDateTime(),          // default value
+                 false                 // remove when reset
+)
+
+SETTING_BOOL(ipv6Enabled,     // getter
+             setIpv6Enabled,  // setter
+             hasIpv6Enabled,  // has
+             "ipv6Enabled",   // key
+             true,            // default value
+             false            // remove when reset
+)
+
+SETTING_STRING(languageCode,     // getter
+               setLanguageCode,  // setter
+               hasLanguageCode,  // has
+               "languageCode",   // key
+               "",               // default value
+               false             // remove when reset
+)
+
+SETTING_BOOL(localNetworkAccess,     // getter
+             setLocalNetworkAccess,  // setter
+             hasLocalNetworkAccess,  // has
+             "localNetworkAccess",   // key
+             false,                  // default value
+             false                   // remove when reset
+)
+
+SETTING_STRINGLIST(missingApps,     // getter
+                   setMissingApps,  // setter
+                   hasMissingApps,  // has
+                   "MissingApps",   // key
+                   QStringList(),   // default value
+                   false            // remove when reset
+)
+
+SETTING_BOOL(postAuthenticationShown,     // getter
+             setPostAuthenticationShown,  // setter
+             hasPostAuthenticationShown,  // has
+             "postAuthenticationShown",   // key
+             false,                       // default value
+             true                         // remove when reset
+)
+
+SETTING_STRING(previousLanguageCode,     // getter
+               setPreviousLanguageCode,  // setter
+               hasPreviousLanguageCode,  // has
+               "previousLanguageCode",   // key
+               "",                       // default value
+               false                     // remove when reset
+)
+
+SETTING_STRING(privateKey,     // getter
+               setPrivateKey,  // setter
+               hasPrivateKey,  // has
+               "privateKey",   // key
+               "",             // default value
+               true            // remove when reset
+)
+
+SETTING_BOOL(protectSelectedApps,     // getter
+             setProtectSelectedApps,  // setter
+             hasProtectSelectedApps,  // has
+             "protectSelectedApps",   // key
+             false,                   // default value
+             false                    // remove when reset
+)
+
+SETTING_STRING(publicKey,     // getter
+               setPublicKey,  // setter
+               hasPublicKey,  // has
+               "publicKey",   // key
+               "",            // default value
+               true           // remove when reset
+)
+
+SETTING_STRINGLIST(recentConnections,     // getter
+                   setRecentConnections,  // setter
+                   hasRecentConnections,  // has
+                   "recentConnections",   // key
+                   QStringList(),         // default value
+                   true                   // remove when reset
+)
+
+SETTING_STRINGLIST(seenFeatures,     // getter
+                   setSeenFeatures,  // setter
+                   hasSeenFeatures,  // has
+                   "seenFeatures",   // key
+                   QStringList(),    // default value
+                   false             // remove when reset
+)
+
+SETTING_BYTEARRAY(servers,     // getter
+                  setServers,  // setter
+                  hasServers,  // has
+                  "servers",   // key
+                  "",          // default value
+                  true         // remove when reset
+)
+
+SETTING_BOOL(serverSwitchNotification,     // getter
+             setServerSwitchNotification,  // setter
+             hasServerSwitchNotification,  // has
+             "serverSwitchNotification",   // key
+             true,                         // default value
+             false                         // remove when reset
+)
+
+SETTING_STRING(stagingServerAddress,     // getter
+               setStagingServerAddress,  // setter
+               hasStagingServerAddress,  // has
+               "stagingServerAddress",   // key
+               envOrDefault("MVPN_API_BASE_URL",
+                            Constants::API_PRODUCTION_URL),  // default value
+               false  // remove when reset
+)
+
+SETTING_BOOL(stagingServer,     // getter
+             setStagingServer,  // setter
+             hasStagingServer,  // has
+             "stagingServer",   // key
+             false,             // default value
+             false              // remove when reset
+)
+
+SETTING_BOOL(startAtBoot,     // getter
+             setStartAtBoot,  // setter
+             hasStartAtBoot,  // has
+             "startAtBoot",   // key
+             false,           // default value
+             false            // remove when reset
+)
+
+SETTING_BYTEARRAY(surveys,     // getter
+                  setSurveys,  // setter
+                  hasSurveys,  // has
+                  "surveys",   // key
+                  "",          // default value
+                  true         // remove when reset
+)
+
+SETTING_BOOL(systemLanguageCodeMigrated,     // getter
+             setSystemLanguageCodeMigrated,  // setter
+             hasSystemLanguageCodeMigrated,  // has
+             "systemLanguageCodeMigrated",   // key
+             false,                          // default value
+             true                            // remove when reset
+)
+
+SETTING_BOOL(telemetryPolicyShown,     // getter
+             setTelemetryPolicyShown,  // setter
+             hasTelemetryPolicyShown,  // has
+             "telemetryPolicyShown",   // key
+             false,                    // default value
+             false                     // remove when reset
+)
+
+SETTING_STRING(token,     // getter
+               setToken,  // setter
+               hasToken,  // has
+               "token",   // key
+               "",        // default value
+               true       // remove when reset
+)
+
+SETTING_BOOL(unsecuredNetworkAlert,     // getter
+             setUnsecuredNetworkAlert,  // setter
+             hasUnsecuredNetworkAlert,  // has
+             "unsecuredNetworkAlert",   // key
+             FeatureUnsecuredNetworkNotification::instance()
+                 ->isSupported(),  // default value
+             false                 // remove when reset
+)
+
+SETTING_STRING(userAvatar,     // getter
+               setUserAvatar,  // setter
+               hasUserAvatar,  // has
+               "user/avatar",  // key
+               "",             // default value
+               true            // remove when reset
+)
+
+SETTING_STRING(userDisplayName,     // getter
+               setUserDisplayName,  // setter
+               hasUserDisplayName,  // has
+               "user/displayName",  // key
+               "",                  // default value
+               true                 // remove when reset
+)
+
+SETTING_STRING(userDNS,     // getter
+               setUserDNS,  // setter
+               hasUserDNS,  // has
+               "userDNS",   // key
+               "",          // default value
+               false        // remove when reset
+)
+
+SETTING_STRING(userEmail,     // getter
+               setUserEmail,  // setter
+               hasUserEmail,  // has
+               "user/email",  // key
+               "",            // default value
+               true           // remove when reset
+)
+
+SETTING_INT(userMaxDevices,     // getter
+            setUserMaxDevices,  // setter
+            hasUserMaxDevices,  // has
+            "user/maxDevices",  // key
+            0,                  // default value
+            true                // remove when reset
+)
+
+SETTING_BOOL(userSubscriptionNeeded,     // getter
+             setUserSubscriptionNeeded,  // setter
+             hasUserSubscriptionNeeded,  // has
+             "user/subscriptionNeeded",  // key
+             false,                      // default value
+             true                        // remove when reset
+)
+
+SETTING_STRINGLIST(vpnDisabledApps,     // getter
+                   setVpnDisabledApps,  // setter
+                   hasVpnDisabledApps,  // has
+                   "vpnDisabledApps",   // key
+                   QStringList(),       // default value
+                   false                // remove when reset
+)
+
+#ifdef MVPN_ANDROID
+SETTING_BOOL(nativeAndroidDataMigrated,     // getter
+             setNativeAndroidDataMigrated,  // setter
+             hasNativeAndroidDataMigrated,  // has
+             "nativeAndroidDataMigrated",   // key
+             false,                         // default value
+             false                          // remove when reset
+)
+#endif
+
+#ifdef MVPN_WINDOWS
+SETTING_BOOL(nativeWindowsDataMigrated,     // getter
+             setNativeWindowsDataMigrated,  // setter
+             hasNativeWindowsDataMigrated,  // has
+             "nativeWindowsDataMigrated",   // key
+             false,                         // default value
+             false                          // remove when reset
+)
+#endif
+
+#ifdef MVN_IOS
+SETTING_BOOL(nativeIOSDataMigrated,     // getter
+             setNativeIOSDataMigrated,  // setter
+             hasNativeIOSDataMigrated,  // has
+             "nativeIOSDataMigrated",   // key
+             false                      // default value
+             false                      // remove when reset
+)
+
+SETTING_STRINGLIST(subscriptionTransactions,     // getter
+                   setSubscriptionTransactions,  // setter
+                   hasSubscriptionTransactions,  // has
+                   "subscriptionTransactions",   // key
+                   QStringList(),                // efault value
+                   false                         // remove when reset
+)
+#endif

--- a/tests/unit/testmodels.cpp
+++ b/tests/unit/testmodels.cpp
@@ -1529,7 +1529,10 @@ void TestModels::surveyModelFromJson() {
         QCOMPARE(sm.surveys()[0].isTriggerable(), surveyTriggerable);
 
         if (surveyTriggerable) {
-          settingsHolder.addConsumedSurvey(surveyId);
+          QStringList list = settingsHolder.consumedSurveys();
+          list.append(surveyId);
+          settingsHolder.setConsumedSurveys(list);
+
           QVERIFY(!sm.surveys()[0].isTriggerable());
         }
       }


### PR DESCRIPTION
This is a big refactoring of how we expose setting "properties". There is a new file (`settinglist.h`) containing a map of the properties. And this map is included in multiple ways to give different meetings to the `SETTING` macro.