### PR TITLE
Fix hang on multihop server switch if one hop is unchanged

### DIFF
--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -368,14 +368,18 @@ bool Daemon::switchServer(const InterfaceConfig& config) {
     }
   }
 
-  // Deactivate the old peer and remove its routes.
+  // Remove routing entries for the old peer.
   for (const IPAddressRange& ip : lastConfig.m_allowedIPAddressRanges) {
     if (!config.m_allowedIPAddressRanges.contains(ip)) {
       wgutils()->deleteRoutePrefix(ip, config.m_hopindex);
     }
   }
-  if (!wgutils()->deletePeer(lastConfig.m_serverPublicKey)) {
-    return false;
+
+  // Remove the old peer if it is no longer necessary.
+  if (config.m_serverPublicKey != lastConfig.m_serverPublicKey) {
+    if (!wgutils()->deletePeer(lastConfig.m_serverPublicKey)) {
+      return false;
+    }
   }
 
   m_connections[config.m_hopindex] = ConnectionState(config);

--- a/src/platforms/linux/daemon/wireguardutilslinux.cpp
+++ b/src/platforms/linux/daemon/wireguardutilslinux.cpp
@@ -193,7 +193,7 @@ bool WireguardUtilsLinux::updatePeer(const InterfaceConfig& config) {
   }
   device->first_peer = device->last_peer = peer;
 
-  logger.debug() << "Adding peer" << config.m_serverIpv4AddrIn;
+  logger.debug() << "Adding peer" << printablePubkey(config.m_serverPublicKey);
 
   // Public Key
   wg_key_from_base64(peer->public_key, qPrintable(config.m_serverPublicKey));
@@ -254,6 +254,8 @@ bool WireguardUtilsLinux::deletePeer(const QString& pubkey) {
     return false;
   }
   device->first_peer = device->last_peer = peer;
+
+  logger.debug() << "Removing peer" << printablePubkey(pubkey);
 
   // Public Key
   peer->flags = (wg_peer_flags)(WGPEER_HAS_PUBLIC_KEY | WGPEER_REMOVE_ME);
@@ -634,4 +636,13 @@ bool WireguardUtilsLinux::buildAllowedIp(wg_allowedip* ip,
     return inet_pton(AF_INET6, qPrintable(prefix.ipAddress()), &ip->ip6) == 1;
   }
   return false;
+}
+
+// static
+QString WireguardUtilsLinux::printablePubkey(const QString& pubkey) {
+  if (pubkey.length() < 12) {
+    return pubkey;
+  } else {
+    return pubkey.left(6) + "..." + pubkey.right(6);
+  }
 }

--- a/src/platforms/linux/daemon/wireguardutilslinux.h
+++ b/src/platforms/linux/daemon/wireguardutilslinux.h
@@ -42,6 +42,8 @@ class WireguardUtilsLinux final : public WireguardUtils {
   static bool buildAllowedIp(struct wg_allowedip*,
                              const IPAddressRange& prefix);
 
+  static QString printablePubkey(const QString& pubkey);
+
   int m_nlsock = -1;
   int m_nlseq = 0;
   QSocketNotifier* m_notifier = nullptr;


### PR DESCRIPTION
When switching servers with multihop enabled, this can sometimes result in changing a peer's configuration but without choosing a new peer. This results in a sequence of calls where we `updatePeer()` to set its config, and then immediately `deletePeer()` to remove it.

The fix is that we should only call `deletePeer()` on the old public key, if that key has changed.

Closes: #1875 