### PR TITLE
Fix assert when switching to recent connections

### DIFF
--- a/src/inspector/inspectorwebsocketconnection.cpp
+++ b/src/inspector/inspectorwebsocketconnection.cpp
@@ -335,15 +335,20 @@ static QList<WebSocketCommand> s_commands{
                          QMetaProperty mp = meta->property(i);
                          int padding = longest - strlen(mp.name());
                          QVariant value = mp.read(item);
-                         if (!result.isEmpty()) {
-                           result += "\n";
+                         QString name = mp.name() + QString(padding, ' ');
+
+                         if (value.type() == QVariant::StringList) {
+                           for (const QString& x : value.value<QStringList>()) {
+                             result += name + " = " + x + "\n";
+                             name.fill(' ', longest);
+                           }
+                           continue;
                          }
-                         result += QString(mp.name());
-                         result += QString(padding, ' ') + " = ";
-                         result += value.toString();
+
+                         result += name + " = " + value.toString() + "\n";
                        }
 
-                       obj["value"] = result;
+                       obj["value"] = result.trimmed();
                        return obj;
                      }},
 

--- a/src/localizer.cpp
+++ b/src/localizer.cpp
@@ -258,6 +258,10 @@ QString Localizer::previousCode() const {
   return SettingsHolder::instance()->previousLanguageCode();
 }
 
+QString Localizer::localizedCityName(const QString& code, const QString& city) {
+  return ServerI18N::translateCityName(code, city);
+}
+
 // static
 void Localizer::macOSInstallerStrings() {
   //% "Mozilla VPN for macOS"

--- a/src/localizer.h
+++ b/src/localizer.h
@@ -58,6 +58,9 @@ class Localizer final : public QAbstractListModel {
 
   QVariant data(const QModelIndex& index, int role) const override;
 
+  Q_INVOKABLE QString localizedCityName(const QString& code,
+                                        const QString& city);
+
  signals:
   void codeChanged();
   void previousCodeChanged();

--- a/src/models/server.cpp
+++ b/src/models/server.cpp
@@ -115,7 +115,11 @@ bool Server::fromJson(const QJsonObject& obj) {
 
 // static
 const Server& Server::weightChooser(const QList<Server>& servers) {
-  Q_ASSERT(!servers.isEmpty());
+  static const Server emptyServer;
+  Q_ASSERT(!emptyServer.initialized());
+  if (servers.isEmpty()) {
+    return emptyServer;
+  }
 
   uint32_t weightSum = 0;
 
@@ -135,7 +139,7 @@ const Server& Server::weightChooser(const QList<Server>& servers) {
 
   // This should not happen.
   Q_ASSERT(false);
-  return servers[0];
+  return emptyServer;
 }
 
 uint32_t Server::choosePort() const {

--- a/src/ui/components/VPNRecentConnections.qml
+++ b/src/ui/components/VPNRecentConnections.qml
@@ -75,26 +75,18 @@ ColumnLayout {
                     const connection = [];
 
                     for(let x = 0; x < servers.length; x++) {
-                        const server = servers[x].split(",");
-                        let serverCityName = server.slice(0, server.length -1)
-
-                        // catch us cities with state abbreviations
-                        // restyle the state string so that it can be sent in VPNController.changeServer
-                        // TODO - make this less chancy - is there a way to grab the localized city name?
-                        if (serverCityName.length > 1) {
-                            let abbreviatedStateName = serverCityName[serverCityName.length - 1].replace(" ", "");
-                            abbreviatedStateName = abbreviatedStateName.charAt(0).toUpperCase() + abbreviatedStateName.slice(1).toLowerCase();
-                            serverCityName[serverCityName.length - 1] = abbreviatedStateName;
-                            serverCityName = serverCityName.join(", ");
-                        } else {
-                            serverCityName = serverCityName.join("");
+                        let index = servers[x].lastIndexOf(",");
+                        if (index <= 0) {
+                            console.log("Unable to parse server from " + servers[x]);
+                            continue;
                         }
-
-                        const countryCode = server[server.length - 1].split(" ").join("");
+                        let countryCode = servers[x].slice(index+1).trim();
+                        let serverCityName = servers[x].slice(0, index).trim();
 
                         connection.push({
                              countryCode: countryCode,
-                             localizedCityName: serverCityName
+                             serverCityName: serverCityName,
+                             localizedCityName: VPNLocalizer.localizedCityName(countryCode, serverCityName)
                          });
                     }
 
@@ -129,10 +121,10 @@ ColumnLayout {
                     popStack();
 
                     if (isMultiHop) {
-                        return VPNController.changeServer(connection.get(1).countryCode, connection.get(1).localizedCityName, connection.get(0).countryCode, connection.get(0).localizedCityName)
+                        return VPNController.changeServer(connection.get(1).countryCode, connection.get(1).serverCityName, connection.get(0).countryCode, connection.get(0).serverCityName)
                     }
 
-                    return VPNController.changeServer(connection.get(0).countryCode, connection.get(0).localizedCityName)
+                    return VPNController.changeServer(connection.get(0).countryCode, connection.get(0).serverCityName)
 
                 }
 


### PR DESCRIPTION
To address the assert when switching to a server in the US from the recent connections list, we need to remove the case mangling when QML is attempting to parse the recent connections. However, since this feature has already shipped, we may need to handle users for whom the recent connections list may contain malformed city names.

To handle this, and other possible server list edge cases (such as a server being removed), we replace the asserts in the connection activation procedure with a backend failure. This leads to a clunky user experience if such an edge case can occur, but it is presumably much better than crashing the client.

While we're at it, we also make an attempt to resolve the localization problems in the recent connections list.

Closes: #1878 