### PR TITLE
Adding permissions needed for Android 12

### DIFF
--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -12,6 +12,7 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES"/>
+    <uses-permission android:name="com.google.android.gms.permission.AD_ID"/>
     <!-- The following comment will be replaced upon deployment with default features based on the dependencies of the application.
          Remove the comment if you do not require these default features. -->
     <!-- %%INSERT_FEATURES -->


### PR DESCRIPTION
Starting early next year Google will require new permissions to read Google Advertiser ID which is required by the Adjust SDK. 

Documentation:
https://help.adjust.com/en/article/get-started-android-sdk#add-permissions
https://developers.google.com/android/reference/com/google/android/gms/ads/identifier/AdvertisingIdClient.Info#public-string-getid 