### PR TITLE
Log request URL on network error

### DIFF
--- a/src/networkrequest.cpp
+++ b/src/networkrequest.cpp
@@ -784,8 +784,10 @@ void NetworkRequest::replyFinished() {
   QByteArray data = m_reply->readAll();
 
   if (m_reply->error() != QNetworkReply::NoError) {
+    QUrl::FormattingOptions options = QUrl::RemoveQuery | QUrl::RemoveUserInfo;
     logger.error() << "Network error:" << m_reply->errorString()
                    << "status code:" << status << "- body:" << data;
+    logger.error() << "Failed to access:" << m_request.url().toString(options);
     emit requestFailed(m_reply->error(), data);
     return;
   }


### PR DESCRIPTION
This adds an extra logging message to show the URL that failed when handling a network error.

Closes: #1959