### PR TITLE
Do not add ServerExtras to Logs

### DIFF
--- a/src/settingsholder.cpp
+++ b/src/settingsholder.cpp
@@ -23,9 +23,11 @@ namespace {
 Logger logger(LOG_MAIN, "SettingsHolder");
 // Setting Keys That won't show up in a report;
 QVector<QString> SENSITIVE_SETTINGS({
-    "token", "privateKey",
-    "servers",  // Those 2 are not sensitive but
-    "devices",  // are more noise then info
+    "token",
+    "privateKey",
+    "servers",       // Those 3 are not sensitive but
+    "serverExtras",  // are more noise then info
+    "devices",
 });
 
 SettingsHolder* s_instance = nullptr;


### PR DESCRIPTION
serverExtras is quite some noise, how about we hide it in the settings report :) 