### PR TITLE
Proposal: Scheudle Periodic Tasks using a persistent Timer

### DIFF
--- a/src/mozillavpn.h
+++ b/src/mozillavpn.h
@@ -23,6 +23,7 @@
 #include "models/user.h"
 #include "models/whatsnewmodel.h"
 #include "networkwatcher.h"
+#include "persistenttimer.h"
 #include "releasemonitor.h"
 #include "statusicon.h"
 
@@ -287,8 +288,6 @@ class MozillaVPN final : public QObject {
 
   void startSchedulingPeriodicOperations();
 
-  void stopSchedulingPeriodicOperations();
-
   void setAlert(AlertType alert);
 
   bool writeAndShowLogs(QStandardPaths::StandardLocation location);
@@ -398,7 +397,7 @@ class MozillaVPN final : public QObject {
   QString m_serverPublicKey;
 
   QTimer m_alertTimer;
-  QTimer m_periodicOperationsTimer;
+  PersistentTimer m_periodicOperationsTimer;
   QTimer m_gleanTimer;
 
   bool m_updateRecommended = false;

--- a/src/persistenttimer.cpp
+++ b/src/persistenttimer.cpp
@@ -1,0 +1,64 @@
+#include "persistenttimer.h"
+#include "settingsholder.h"
+#include "logger.h"
+
+#include <QTimer>
+#include <QMap>
+
+namespace {
+Logger logger(LOG_MAIN, "PersistentTimer");
+}  // namespace
+
+PersistentTimer::PersistentTimer(QObject* parent, const QString& timerName,
+                                 int interval_msec)
+    : QObject(parent), m_name(timerName), m_interval(interval_msec) {
+  m_timer.setInterval(interval_msec);
+  connect(&m_timer, &QTimer::timeout, this, &PersistentTimer::timeoutInternal);
+}
+
+void PersistentTimer::timeoutInternal() {
+  logger.info() << "Timer(" << m_name << ") - Fired!";
+
+  QMap<QString, QVariant> state =
+      SettingsHolder::instance()->persistentTimerState();
+  QDateTime now = QDateTime::currentDateTime();
+  state.insert(m_name, now);
+  SettingsHolder::instance()->setPersistentTimerState(state);
+  emit timeout();
+  m_timer.setInterval(m_interval);
+  m_timer.start();
+}
+
+void PersistentTimer::start() {
+  logger.info() << "Creating Long Timer: " << m_name
+                << " every: " << (m_interval / 1000) << "s";
+  QMap<QString, QVariant> state =
+      SettingsHolder::instance()->persistentTimerState();
+  QVariant timerState = state.value(m_name);
+
+  if (!timerState.isValid() || timerState.isNull()) {
+    // This Timer has never ever started or completed.
+    // So fire it now and then at the next Interval.
+    logger.info() << "Timer(" << m_name << ") - No state yet - fire";
+
+    return timeoutInternal();
+  }
+  if (!timerState.canConvert(QVariant::DateTime)) {
+    // Wierd.
+    logger.error() << "Timer(" << m_name << ") -  Malformed state - fire";
+    return timeoutInternal();
+  }
+  QDateTime lastRun = timerState.toDateTime();
+  QDateTime now = QDateTime::currentDateTime();
+  auto time_since_last_run = (lastRun.secsTo(now));
+  auto required_secs = (m_interval / 1000) - time_since_last_run;
+  if (time_since_last_run >= (m_interval / 1000)) {
+    // We're Overdue!
+    logger.info() << "Timer(" << m_name << ") -  s overdue" << required_secs;
+    return timeoutInternal();
+  }
+  // Not overdue, scheudle remaining time.
+  logger.info() << "Timer(" << m_name
+                << ") -  not overdue will fire in: " << required_secs;
+  m_timer.start(required_secs * 1000);
+}

--- a/src/persistenttimer.h
+++ b/src/persistenttimer.h
@@ -1,0 +1,32 @@
+#ifndef PERSISTENTTIMER_H
+#define PERSISTENTTIMER_H
+
+#include <QObject>
+#include <QTimer>
+
+/* PersistentTimer is an Alternative for long QTimer tasks.
+ * PersistentTimer notes the last Time it fired in SettingsHolder
+ * and restores it old state on init.
+ * so use it to do stuff like "once every 24h do: xyz"
+ */
+class PersistentTimer : public QObject {
+  Q_OBJECT
+ public:
+  PersistentTimer(QObject* parent, const QString& timerName, int interval_msec);
+
+  bool isActive() const;
+  int remainingTime() const;
+  void start();
+  void stop();
+
+ signals:
+  void timeout();
+
+ private:
+  void timeoutInternal();
+  QTimer m_timer;
+  const QString m_name;
+  const int m_interval;
+};
+
+#endif  // PERSISTENTTIMER_H

--- a/src/settingslist.h
+++ b/src/settingslist.h
@@ -26,6 +26,9 @@
 #define SETTING_STRINGLIST(getter, ...) \
   SETTING(QStringList, toStringList, getter, __VA_ARGS__)
 
+#define SETTING_MAP(getter, ...) \
+  SETTING(QVariantMap, toMap, getter, __VA_ARGS__)
+
 // Please! Keep the alphabetic order!
 
 SETTING_BOOL(captivePortalAlert,                               // getter
@@ -202,6 +205,14 @@ SETTING_STRINGLIST(missingApps,     // getter
                    "MissingApps",   // key
                    QStringList(),   // default value
                    false            // remove when reset
+)
+
+SETTING_MAP(persistentTimerState,     // getter
+            setPersistentTimerState,  // setter
+            hasPersistentTimerState,  // has
+            "persistentTimerState",   // key
+            QVariantMap(),            // default value
+            true                      // remove when reset
 )
 
 SETTING_BOOL(postAuthenticationShown,     // getter

--- a/src/src.pro
+++ b/src/src.pro
@@ -127,6 +127,7 @@ SOURCES += \
         networkrequest.cpp \
         networkwatcher.cpp \
         notificationhandler.cpp \
+        persistenttimer.cpp \
         pinghelper.cpp \
         pingsender.cpp \
         platforms/dummy/dummyapplistprovider.cpp \
@@ -258,6 +259,7 @@ HEADERS += \
         networkwatcher.h \
         networkwatcherimpl.h \
         notificationhandler.h \
+        persistenttimer.h \
         pinghelper.h \
         pingsender.h \
         platforms/dummy/dummyapplistprovider.h \


### PR DESCRIPTION
This is just a random idea - 

Currently we have m_periodicOperationsTimer to handle stuff that needs to be fetched regularly. I think on release it's once every hour but only after the app has started. 
-> This does not work for mobile, as it's unlikely the client will be alive that long. 
So to still have all the data we need, we currently put a lot of those Tasks also into init(), which we fire quite a few requests irrelevant on how old our current data is. 
For example re-loading the surveys which did not change since their release on every init is a bit of waste of network data (on mobile). 
So how about adding a persistent timer that stores the last `timeout()` timestamp.
-> On every start it compares last timeout with now and the interval
-> if overdue, fire, note, scheudle qtimer for interval.
-> if not overdue, scheudle qtimer for remaining time.

