### PR TITLE
AdjustSDK activable just at the first execution

### DIFF
--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -1388,9 +1388,16 @@ void MozillaVPN::subscriptionCompleted() {
   }
 
   logger.debug() << "Subscription completed";
+
 #ifdef MVPN_ADJUST
   AdjustHandler::trackEvent(Constants::ADJUST_SUBSCRIPTION_COMPLETED);
+
+  // When the subscription is completed, we do not need adjustSDK anymore. We
+  // cannot disable it at runtime, but we can disable it for the next
+  // execution.
+  SettingsHolder::instance()->setAdjustActivatable(false);
 #endif
+
   completeActivation();
 }
 
@@ -1565,4 +1572,13 @@ void MozillaVPN::maybeRegenerateDeviceKey() {
   // We do not need to remove the current device! guardian-website "overwrites"
   // the current device key when we submit a new one.
   addCurrentDeviceAndRefreshData();
+}
+
+void MozillaVPN::hardResetAndQuit() {
+  logger.debug() << "Hard reset and quit";
+
+  SettingsHolder* settingsHolder = SettingsHolder::instance();
+  Q_ASSERT(settingsHolder);
+  settingsHolder->hardReset();
+  quit();
 }

--- a/src/mozillavpn.h
+++ b/src/mozillavpn.h
@@ -154,6 +154,7 @@ class MozillaVPN final : public QObject {
                                        const QString& issueText,
                                        const QString& category);
   Q_INVOKABLE bool validateUserDNS(const QString& dns) const;
+  Q_INVOKABLE void hardResetAndQuit();
 #ifdef MVPN_ANDROID
   Q_INVOKABLE void launchPlayStore();
 #endif

--- a/src/settingsholder.cpp
+++ b/src/settingsholder.cpp
@@ -59,6 +59,7 @@ SettingsHolder::SettingsHolder()
   s_instance = this;
 
   if (!hasInstallationTime()) {
+    m_firstExecution = true;
     setInstallationTime(QDateTime::currentDateTime());
   }
 }
@@ -85,8 +86,11 @@ void SettingsHolder::clear() {
 
 #include "settingslist.h"
 #undef SETTING
+}
 
-  // We do not remove language, ipv6 and localnetwork settings.
+void SettingsHolder::hardReset() {
+  logger.debug() << "Hard reset";
+  m_settings.clear();
 }
 
 // Returns a Report which settings are set

--- a/src/settingsholder.h
+++ b/src/settingsholder.h
@@ -29,6 +29,8 @@ class SettingsHolder final : public QObject {
 
   static SettingsHolder* instance();
 
+  bool firstExecution() const { return m_firstExecution; }
+
   enum DnsProvider {
     Gateway = 0,
     BlockAll = 1,
@@ -54,6 +56,10 @@ class SettingsHolder final : public QObject {
 
   QString envOrDefault(const QString& name, const QString& defaultValue) const;
 
+  // Delete _ALL_ the settings. Probably this method is not what you want to
+  // use.
+  void hardReset();
+
  private:
   explicit SettingsHolder(QObject* parent);
 
@@ -61,6 +67,7 @@ class SettingsHolder final : public QObject {
 
  private:
   QSettings m_settings;
+  bool m_firstExecution = false;
 };
 
 #endif  // SETTINGSHOLDER_H

--- a/src/settingslist.h
+++ b/src/settingslist.h
@@ -406,6 +406,16 @@ SETTING_STRINGLIST(vpnDisabledApps,     // getter
                    false                // remove when reset
 )
 
+#if defined(MVPN_ADJUST)
+SETTING_BOOL(adjustActivatable,     // getter
+             setAdjustActivatable,  // setter
+             hasAdjustActivatable,  // has
+             "adjustActivatable",   // key
+             false,                 // default value
+             false                  // remove when reset
+)
+#endif
+
 #if defined(MVPN_ANDROID)
 SETTING_BOOL(nativeAndroidDataMigrated,     // getter
              setNativeAndroidDataMigrated,  // setter

--- a/src/ui/developerMenu/ViewDeveloperMenu.qml
+++ b/src/ui/developerMenu/ViewDeveloperMenu.qml
@@ -119,6 +119,7 @@ VPNFlickable {
             }
         }
     }
+
     VPNSettingsItem {
         id: featureListLink
         objectName: "settingsFeatureList"
@@ -135,6 +136,7 @@ VPNFlickable {
         imageRightSrc: "qrc:/ui/resources/chevron.svg"
         onClicked: stackview.push("qrc:/ui/developerMenu/ViewFeatureList.qml")
     }
+
     VPNExternalLinkListItem {
         id:inspectorLink
         visible: stagingServerCheckBox.checked && !restartRequired.visible
@@ -154,9 +156,30 @@ VPNFlickable {
         }
     }
 
+    VPNButton {
+        id:resetAndQuit
+        property int clickNeeded: 5
+
+        anchors.top: stagingServerCheckBox.checked && !restartRequired.visible ? inspectorLink.bottom : featureListLink.bottom
+        anchors.topMargin: Theme.windowMargin
+        anchors.horizontalCenterOffset: 0
+        anchors.horizontalCenter: parent.horizontalCenter
+
+        text: "Reset and Quit"
+        onClicked: {
+            if (clickNeeded) {
+             text = "Reset and Quit (" + clickNeeded + ")";
+              --clickNeeded;
+             return;
+            }
+
+            VPN.hardResetAndQuit()
+        }
+    }
+
     VPNCheckBoxAlert {
         id: restartRequired
-        anchors.top: inspectorLink.bottom
+        anchors.top: resetAndQuit.bottom
         visible: false
         Connections {
             target: VPNSettings

--- a/tests/auth/mocmozillavpn.cpp
+++ b/tests/auth/mocmozillavpn.cpp
@@ -156,3 +156,5 @@ bool MozillaVPN::validateUserDNS(const QString&) const { return false; }
 void MozillaVPN::reset(bool) {}
 
 void MozillaVPN::maybeRegenerateDeviceKey() {}
+
+void MozillaVPN::hardResetAndQuit() {}

--- a/tests/unit/mocmozillavpn.cpp
+++ b/tests/unit/mocmozillavpn.cpp
@@ -156,3 +156,5 @@ bool MozillaVPN::validateUserDNS(const QString&) const { return false; }
 void MozillaVPN::reset(bool) {}
 
 void MozillaVPN::maybeRegenerateDeviceKey() {}
+
+void MozillaVPN::hardResetAndQuit() {}


### PR DESCRIPTION
This PR introduces a few new concepts:
- `reset and quit` in the dev menu. This is needed to test the adjustSDK activation, Without this, the QA team will not be able to run the tests. The button needs to be clicked 6 times before removing the data and quit the app.
- first-execution: if the app does not have the "installationTime", it can be older than 2.3 or a new installation. Let's assume it's a new installation.
- adjust activable: this is a new boolean setting. By default it's false. It's set to true if this is the first execution. It's set to false after the sending of the subscription event.