### PR TITLE
Update LICENSE.md for Adjust framework

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -32,9 +32,14 @@ the terms of the MIT Public License (*MIT*), a copy of which is [availble
 here](https://opensource.org/licenses/MIT) and a copy is provided below.
 
 For Desktop releases (Linux, MacOS and Windows), the project relies on [JSON
-for Modern C++](https://github.com/nlohmann/json) under the term of the MIT
+for Modern C++](https://github.com/nlohmann/json) under the terms of the MIT
 Public License (*MIT*), a copy of which is [available
 here](https://opensource.org/licenses/MIT) and a copy is provided below.
+
+For Mobile releases (Android and iOS), the project relies on the [Adjust
+Framework](https://www.adjust.com) under the terms of the MIT Public License
+(*MIT*), a copy of which is available [available
+here](https://opensource.org/license/MIT) and a copy is provided below.
 
 Finally, this project uses EC25519 and CHACHA-POLY implementations from HACL\*,
 available under the terms of the MIT Public License (*MIT*) and copyright (c)
@@ -450,6 +455,31 @@ HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
 WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
+
+The MIT License (MIT) - Adjust
+==============================
+
+Copyright (c) 2012-2017 adjust GmbH,
+http://www.adjust.com
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 GNU Lesser General Public License
 =================================


### PR DESCRIPTION
Since mobile releases now include the Adjust framework, we need to update the VPN software license to reflect the portions of the code which fall under Adjust's software license (MIT).