### PR TITLE
Update Ubuntu package maintainer e-mail

### DIFF
--- a/linux/debian/changelog.template
+++ b/linux/debian/changelog.template
@@ -2,4 +2,4 @@ mozillavpn (SHORTVERSION-VERSION) RELEASE; urgency=medium
 
   * First ubuntu package
 
- -- Andrea Marchesini <baku@mozilla.com>  DATE
+ -- Mozilla VPN Team <vpn@mozilla.com>  DATE


### PR DESCRIPTION
For the Ubuntu PPA packages, we should use a more generic e-mail as the contact point so that we don't spam any particular developer.

Closes: #1557 