### PR TITLE
Workaround broken Azure packages in CI

### DIFF
--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -142,6 +142,7 @@ jobs:
       - name: Create base ${{ matrix.config.dist }} image
         run: |
           pip3 install pyyaml
+          sudo apt-get update
           sudo apt-get install pbuilder debootstrap debhelper devscripts -y
           sudo pbuilder create --distribution ${{ matrix.config.dist }} --basetgz $BASETGZ --debootstrapopts --variant=buildd
 


### PR DESCRIPTION
Github CI seems to be broken due to a recent update to the `debootstrap` package that bumped its version number on the Azure package mirrors, but that change hasn't made its way down to the github base images, which still point to the old package version. To resolve this issue, we need to manually do an `apt-get update` before attempting to install packages.