### PR TITLE
Fix SSL certificate list for Linux

### DIFF
--- a/src/networkrequest.cpp
+++ b/src/networkrequest.cpp
@@ -927,6 +927,7 @@ void NetworkRequest::sslErrors(const QList<QSslError>& errors) {
 
 void NetworkRequest::enableSSLIntervention() {
   if (s_intervention_certs.isEmpty()) {
+    s_intervention_certs = QSslConfiguration::systemCaCertificates();
     QDirIterator certFolder(":/certs");
     while (certFolder.hasNext()) {
       QFile f(certFolder.next());


### PR DESCRIPTION
On Linux, it seems that `QSslConfiguration` is initialized with an empty CA list, and defaults back to the system CA store only when the CA list is empty. Therefore, in order to extend the CA list, we must merge it with the system CA list first. 

Closes: #2121