### PR TITLE
Increase client version to 2.7.0

### DIFF
--- a/version.pri
+++ b/version.pri
@@ -2,6 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-!defined(VERSION, var):VERSION = 2.6.0
+!defined(VERSION, var):VERSION = 2.7.0
 
 DBUS_PROTOCOL_VERSION = 1


### PR DESCRIPTION
Now that Client version 2.6.0 has reached code freeze, we can bump the version of the `main` branch to 2.7.0 to keep the release and development branches separate.