### PR TITLE
Fix QML typo which breaks multihop entry selection

### DIFF
--- a/src/ui/views/ViewMultiHop.qml
+++ b/src/ui/views/ViewMultiHop.qml
@@ -52,7 +52,7 @@ StackView {
             VPNControllerNav {
                 function handleClick() {
                     multiHopStackView.push(
-                        "qrc://components/components/VPNServerList.qml",
+                        "qrc:/components/components/VPNServerList.qml",
                         {
                             currentServer: entryLabel.serversList[0],
                             showRecentConnections: false


### PR DESCRIPTION
Closes: #2139 