### PR TITLE
Fix tab navigation errors on Kubuntu

### DIFF
--- a/src/ui/components/VPNTabNavigation.qml
+++ b/src/ui/components/VPNTabNavigation.qml
@@ -47,7 +47,8 @@ Item {
             delegate: TabButton {
                 id: btn
                 objectName: tabButtonId
-                height: bar.height
+                height: bar.contentHeight
+                width: stack.children.length > 0 ? (bar.width / stack.children.length) : bar.width
                 onClicked: handleTabClick(btn)
 
                 background: Rectangle {


### PR DESCRIPTION
The geometry of the `TabButton` in the `VPNTabNavigation` component is getting computed incorrectly on Kubuntu 21.04, which seems to lead to heights and widths of zero. This results in multiple UI elements overlapping with one another and making the tab navigation unusable.

Setting the `height` property to `bar.contentHeight` seems to fix the overlapping elements problem, and explicitly setting the `width` property also results in properly centred menus again.

Closes: #1937