### PR TITLE
Do not send unique ID to the prod server

### DIFF
--- a/src/featurelist.cpp
+++ b/src/featurelist.cpp
@@ -18,6 +18,7 @@
 #include "features/featurenotificationcontrol.h"
 #include "features/featuresplittunnel.h"
 #include "features/featuresharelogs.h"
+#include "features/featureuniqueid.h"
 #include "features/featurestartonboot.h"
 #include "features/featureunsecurednetworknotification.h"
 
@@ -51,6 +52,7 @@ void FeatureList::initialize() {
   new FeatureShareLogs();
   new FeatureSplitTunnel();
   new FeatureStartOnBoot();
+  new FeatureUniqueID();
   new FeatureUnsecuredNetworkNotification();
 
   m_featurelist = Feature::getAll();

--- a/src/features/featureuniqueid.h
+++ b/src/features/featureuniqueid.h
@@ -8,7 +8,7 @@
 #include "constants.h"
 #include "models/feature.h"
 
-constexpr const char* FEATURE_UNIQUE_ID = "shareLogs";
+constexpr const char* FEATURE_UNIQUE_ID = "uniqueID";
 /*
  * This Featureflag describes if the Client
  * creates a guardian Device using it's unique ID
@@ -24,14 +24,14 @@ class FeatureUniqueID : public Feature {
                 "",                  // ImagePath
                 "",                  // IconPath
                 "2.6",               // released
-                false                // Can be enabled in devmode
+                true                 // Can be enabled in devmode
         ) {}
 
   bool checkSupportCallback() const override {
-        // This feature can't be enabled in production: 
-        // We need to solve the underlying guardian issue,
-        // See: https://mozilla-hub.atlassian.net/browse/VPN-1177
-      return !Constants::inProduction();
+    // This feature can't be enabled in production:
+    // We need to solve the underlying guardian issue,
+    // See: https://mozilla-hub.atlassian.net/browse/VPN-1177
+    return !Constants::inProduction();
   }
 
   static const FeatureUniqueID* instance() {

--- a/src/features/featureuniqueid.h
+++ b/src/features/featureuniqueid.h
@@ -1,0 +1,42 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef FEATURE_UNIQUE_ID_H
+#define FEATURE_UNIQUE_ID_H
+
+#include "constants.h"
+#include "models/feature.h"
+
+constexpr const char* FEATURE_UNIQUE_ID = "shareLogs";
+/*
+ * This Featureflag describes if the Client
+ * creates a guardian Device using it's unique ID
+ */
+class FeatureUniqueID : public Feature {
+ public:
+  FeatureUniqueID()
+      : Feature(FEATURE_UNIQUE_ID, "uniqueID",
+                false,               // Is Major Feature
+                L18nStrings::Empty,  // Display name
+                L18nStrings::Empty,  // Description
+                L18nStrings::Empty,  // LongDescr
+                "",                  // ImagePath
+                "",                  // IconPath
+                "2.6",               // released
+                false                // Can be enabled in devmode
+        ) {}
+
+  bool checkSupportCallback() const override {
+        // This feature can't be enabled in production: 
+        // We need to solve the underlying guardian issue,
+        // See: https://mozilla-hub.atlassian.net/browse/VPN-1177
+      return !Constants::inProduction();
+  }
+
+  static const FeatureUniqueID* instance() {
+    return static_cast<const FeatureUniqueID*>(get(FEATURE_UNIQUE_ID));
+  }
+};
+
+#endif  // FEATURE_UNIQUE_ID_H

--- a/src/networkrequest.cpp
+++ b/src/networkrequest.cpp
@@ -5,6 +5,7 @@
 #include "networkrequest.h"
 #include "captiveportal/captiveportal.h"
 #include "constants.h"
+#include "features/featureuniqueid.h"
 #include "hawkauth.h"
 #include "leakdetector.h"
 #include "logger.h"
@@ -194,11 +195,7 @@ NetworkRequest* NetworkRequest::createForDeviceCreation(
   QJsonObject obj;
   obj.insert("name", deviceName);
 
-  if (!Constants::inProduction()) {
-    // TODO: Remove this.
-    // We need to solve the underlying guardian issue,
-    // before we can send this info to guardian-prod
-    // See: https://mozilla-hub.atlassian.net/browse/VPN-1177
+  if (!FeatureUniqueID::instance()->isSupported()) {
     obj.insert("unique_id", deviceId);
   }
   obj.insert("pubkey", pubKey);

--- a/src/networkrequest.cpp
+++ b/src/networkrequest.cpp
@@ -193,7 +193,14 @@ NetworkRequest* NetworkRequest::createForDeviceCreation(
 
   QJsonObject obj;
   obj.insert("name", deviceName);
-  obj.insert("unique_id", deviceId);
+
+  if (!Constants::inProduction()) {
+    // TODO: Remove this.
+    // We need to solve the underlying guardian issue,
+    // before we can send this info to guardian-prod
+    // See: https://mozilla-hub.atlassian.net/browse/VPN-1177
+    obj.insert("unique_id", deviceId);
+  }
   obj.insert("pubkey", pubKey);
 
   QJsonDocument json;

--- a/src/src.pro
+++ b/src/src.pro
@@ -219,6 +219,7 @@ HEADERS += \
         features/featuresharelogs.h \
         features/featuresplittunnel.h \
         features/featurestartonboot.h \
+        features/featureuniqueid.h \
         features/featureunsecurednetworknotification.h \
         filterproxymodel.h \
         fontloader.h \


### PR DESCRIPTION
Given that we are close to fix-freeze we might consider not sending the device id to guardian. - This would Mean 2.7 would still have the device-duplicate issue but we gain a whole cycle to debug this. 