### PR TITLE
Disable editing of custom DNS while connected

### DIFF
--- a/src/ui/components/VPNViewDNSSettings.qml
+++ b/src/ui/components/VPNViewDNSSettings.qml
@@ -94,7 +94,7 @@ VPNFlickable {
                         visible: showDNSInput
                         id: ipInput
 
-                        enabled: VPNSettings.dnsProvider === VPNSettings.Custom
+                        enabled: (VPNSettings.dnsProvider === VPNSettings.Custom) && vpnIsOff
                         placeholderText: VPNSettings.placeholderUserDNS
                         text: ""
                         width: parent.width


### PR DESCRIPTION
Now that the advanced DNS menu is visible while connected, we need to make sure that the fields are not editable while connected, and unfortunately, I missed the custom DNS field.

Closes: #2162 