### PR TITLE
Restore the login after a logout - closes #1254

### DIFF
--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -882,8 +882,6 @@ void MozillaVPN::logout() {
 
   setAlert(LogoutAlert);
 
-  setUserAuthenticated(false);
-
   deleteTasks();
 
   if (FeatureInAppPurchase::instance()->isSupported()) {


### PR DESCRIPTION
Adding that line there, we broke the logoutObserver. The LogoutObserver monitors the authentication state and that _must_ run after a reset. Note that reset() calls `setUserAuthenticated(false)` too.