### PR TITLE
Update windowspingsender.cpp

### DIFF
--- a/src/platforms/macos/macospingsender.cpp
+++ b/src/platforms/macos/macospingsender.cpp
@@ -86,6 +86,7 @@ void MacOSPingSender::sendPing(const QString& dest, quint16 sequence) {
   if (sendto(m_socket, (char*)&packet, sizeof(packet), 0,
              (struct sockaddr*)&addr, sizeof(addr)) != sizeof(packet)) {
     logger.error() << "ping sending failed:" << strerror(errno);
+    emit criticalPingError();
     return;
   }
 }

--- a/src/platforms/windows/windowspingsender.cpp
+++ b/src/platforms/windows/windowspingsender.cpp
@@ -61,7 +61,9 @@ void WindowsPingSender::sendPing(const QString& dest, quint16 sequence) {
   DWORD status = GetLastError();
   if (status != ERROR_IO_PENDING) {
     QString errmsg = WindowsCommons::getErrorMessage();
-    logger.error() << "failed to start:" << errmsg;
+    logger.error() << "failed to start Code: " << status
+                   << " Message: " << errmsg << " dest:" << dest;
+    emit criticalPingError();
   }
 }
 


### PR DESCRIPTION
I was never able to reproduce this.  I think that is because the fixes I put in that have TaskControllerAction using a smarter watchdog vs. simple timer are mitigating it.  That said I think these errors should have resulted in the criticalPingError signal to be raised.  That will cause the connection to reset in the real world event that the connection is bad somehow.  I've also added extra logging if the problem persists to make sure the address actually isn't invalid as the error states.