### PR TITLE
Set AdServices.framework to optional

### DIFF
--- a/scripts/xcode_patcher.rb
+++ b/scripts/xcode_patcher.rb
@@ -152,7 +152,8 @@ class XCodeprojPatcher
       frameworks_build_phase = @target_main.build_phases.find { |build_phase| build_phase.to_s == 'FrameworksBuildPhase' }
 
       framework_ref = frameworks_group.new_file('AdServices.framework')
-      frameworks_build_phase.add_file_reference(framework_ref)
+      build_file = frameworks_build_phase.add_file_reference(framework_ref)
+      build_file.settings = { 'ATTRIBUTES' => ['Weak'] }
 
       framework_ref = frameworks_group.new_file('iAd.framework')
       frameworks_build_phase.add_file_reference(framework_ref)


### PR DESCRIPTION
Closes #2129 

This issue only happens on older iOS versions (before 14.3) since these versions do not have `AdServices.framework` installed. This PR sets the `AdServices.framework` to optional which prevents the app from crashing if it cannot be found. 

References:
https://githubmemory.com/repo/BranchMetrics/ios-branch-deep-linking-attribution/issues/1116
https://developer.apple.com/forums/thread/12110
https://gist.github.com/onevcat/033cc4eb4f0cc29cce56#file-xcodeproj_build-rb-L48