### PR TITLE
Add a console to windows to see debug

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,7 +6,7 @@
 #include "leakdetector.h"
 #include <iostream>
 
-#ifdef MVPN_WINDOWS&& MVPN_DEBUG
+#if defined MVPN_WINDOWS && defined MVPN_DEBUG 
 #  include <windows.h>
 #endif
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,7 +6,7 @@
 #include "leakdetector.h"
 #include <iostream>
 
-#if defined MVPN_WINDOWS && defined MVPN_DEBUG 
+#if defined MVPN_WINDOWS && defined MVPN_DEBUG
 #  include <windows.h>
 #endif
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,11 +4,28 @@
 
 #include "commandlineparser.h"
 #include "leakdetector.h"
+#include <iostream>
+
+#ifdef MVPN_WINDOWS&& MVPN_DEBUG
+#  include <windows.h>
+#endif
 
 int main(int argc, char* argv[]) {
 #ifdef MVPN_DEBUG
   LeakDetector leakDetector;
   Q_UNUSED(leakDetector);
+#  ifdef MVPN_WINDOWS
+  // Allocate a console to view log output in debug mode on windows
+  if (AllocConsole()) {
+    FILE* unusedFile;
+    freopen_s(&unusedFile, "CONOUT$", "w", stdout);
+    freopen_s(&unusedFile, "CONOUT$", "w", stderr);
+    std::cout.clear();
+    std::clog.clear();
+    std::cerr.clear();
+  }
+#  endif
+
 #endif
 
   CommandLineParser clp;


### PR DESCRIPTION
This code allocates a console for windows debug builds.  Since you can't see std::out, we need to do this to see the logs.