### PR TITLE
Android: Fix Log Share

### DIFF
--- a/android/src/org/mozilla/firefox/vpn/qt/VPNUtils.kt
+++ b/android/src/org/mozilla/firefox/vpn/qt/VPNUtils.kt
@@ -53,10 +53,13 @@ object VPNUtils {
             return false
         }
         try {
-            tx.writer(Charsets.UTF_8)?.write(text)
+            val writer = tx.writer(Charsets.UTF_8)
+            writer?.write(text)
+            writer?.flush()
         } catch (e: IOException) {
             return false
         }
+        tx.flush()
         tx.close()
         // Now update the Files meta data that the file exists
         fileMetaData.clear()
@@ -65,7 +68,7 @@ object VPNUtils {
 
         val sendIntent = Intent(Intent.ACTION_SEND)
         sendIntent.putExtra(Intent.EXTRA_STREAM, fileURI)
-        sendIntent.setType("text/plain")
+        sendIntent.setType("*/*")
 
         val chooseIntent = Intent.createChooser(sendIntent, "Share Logs")
         ctx.startActivity(chooseIntent)


### PR DESCRIPTION
Fixes 2 Issues:
-> Writer & Outstream were not flushed, not all text might be written to the file.
-> Change mime-type from text/plain to "any" - some applications (i.e slack) are handling text/plain intents "wrong" as in they try to read "EXTRA_TEXT" (which is empty) and ignore the attachment file. Applications that can handle "any" have a higher probability to check the attached file :)   


#closes https://github.com/mozilla-mobile/mozilla-vpn-client/issues/2226