### PR TITLE
Added a settling period to VPN connect/disconnect

### DIFF
--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -39,6 +39,8 @@
 #  include "platforms/dummy/dummycontroller.h"
 #endif
 
+constexpr auto SETTLE_TIMEOUT = 3000;
+
 constexpr const uint32_t TIMER_MSEC = 1000;
 
 // X connection retries.
@@ -367,6 +369,9 @@ void Controller::connectionConfirmed() {
   }
 
   setState(StateOn);
+
+  startUnsettledPeriod();
+
   emit timeChanged();
 
   if (m_nextStep != None) {
@@ -403,6 +408,8 @@ void Controller::connectionFailed() {
   m_impl->deactivate(ControllerImpl::ReasonConfirming);
 }
 
+bool Controller::isUnsettled() { return !m_settled; }
+
 void Controller::disconnected() {
   logger.debug() << "Disconnected from state:" << m_state;
 
@@ -420,6 +427,8 @@ void Controller::disconnected() {
     task->run();
     return;
   }
+
+  startUnsettledPeriod();
 
   m_timer.stop();
   resetConnectionCheck();
@@ -768,6 +777,16 @@ void Controller::heartbeatCompleted() {
 
 void Controller::resetConnectedTime() {
   m_connectedTimeInUTC = QDateTime::currentDateTimeUtc();
+}
+
+void Controller::startUnsettledPeriod() {
+  logger.debug() << "Starting unsettled period.";
+  m_settled = false;
+  m_settleTimer.stop();
+  m_settleTimer.singleShot(SETTLE_TIMEOUT, [this]() {
+    m_settled = true;
+    logger.debug() << "Unsettled period over.";
+  });
 }
 
 QString Controller::currentLocalizedCityName() const {

--- a/src/controller.h
+++ b/src/controller.h
@@ -89,6 +89,8 @@ class Controller final : public QObject {
 
   void backendFailure();
 
+  bool isUnsettled();
+
  public slots:
   // These 2 methods activate/deactivate the VPN. Return true if a signal will
   // be emitted at the end of the operation.
@@ -136,10 +138,15 @@ class Controller final : public QObject {
 
   void resetConnectedTime();
 
+  void startUnsettledPeriod();
+
  private:
   State m_state = StateInitializing;
 
   QTimer m_timer;
+  QTimer m_settleTimer;
+
+  bool m_settled = true;
 
   QDateTime m_connectedTimeInUTC;
 

--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -935,6 +935,9 @@ void MozillaVPN::errorHandle(ErrorHandler::ErrorType error) {
       break;
 
     case ErrorHandler::NoConnectionError:
+      if (controller()->isUnsettled()) {
+        return;
+      }
       alert = NoConnectionAlert;
       break;
 


### PR DESCRIPTION
I would have made this a state, but since the controller is tied to the UI, it made things difficult.  This works as well and is probably simpler.  Basic flag and timer when we connect and disconnect to ignore errors while the routes and interface become stable.
