### PR TITLE
Update `VPNSettings.startAtBoot` setting strings

### DIFF
--- a/src/ui/settings/ViewPrivacySecurity.qml
+++ b/src/ui/settings/ViewPrivacySecurity.qml
@@ -46,7 +46,7 @@ Item {
                 objectName: "settingStartAtBoot"
 
                 labelText: _startAtBootTitle
-                subLabelText: VPNl18n.SettingsStartAtBootDescription
+                subLabelText: VPNl18n.SettingsStartAtBootSubtitle
                 isChecked: VPNSettings.startAtBoot
                 isEnabled: true
                 showDivider: false

--- a/src/ui/settings/ViewSettingsMenu.qml
+++ b/src/ui/settings/ViewSettingsMenu.qml
@@ -104,8 +104,6 @@ VPNFlickable {
                                               })
         }
         VPNSettingsItem {
-            //% "Launch VPN app on startup"
-            property string startAtBootTitle: qsTrId("vpn.settings.runOnBoot2")
 
             id: preferencesSetting
             objectName: "settingsPreferences"
@@ -113,7 +111,7 @@ VPNFlickable {
             imageLeftSrc: "qrc:/ui/resources/settings/preferences.svg"
             imageRightSrc: "qrc:/ui/resources/chevron.svg"
             onClicked: settingsStackView.push("qrc:/ui/settings/ViewPrivacySecurity.qml", {
-                                                _startAtBootTitle: Qt.binding(() => startAtBootTitle),
+                                                _startAtBootTitle: Qt.binding(() => VPNl18n.SettingsStartAtBootTitle),
                                                 _languageTitle:  Qt.binding(() => qsTrId("vpn.settings.language")),
                                                 _notificationsTitle:  Qt.binding(() => qsTrId("vpn.settings.notifications")),
                                                 _menuTitle: Qt.binding(() => preferencesSetting.settingTitle)

--- a/translations/strings.yaml
+++ b/translations/strings.yaml
@@ -267,7 +267,8 @@ systray:
 
 settings:
   systemPreferences: System preferences
-  startAtBootDescription: Mozilla VPN will launch when you open the app
+  startAtBootTitle: Connect VPN on startup
+  startAtBootSubtitle: Mozilla VPN will launch and connect when you start up your device
 
 aboutUs:
   licenses: Licenses


### PR DESCRIPTION
New strings in response to feedback that the current strings for the `VPNSettings.startAtBoot` setting are confusing. 

<img width="362" alt="Screen Shot 2021-11-15 at 9 17 44 PM" src="https://user-images.githubusercontent.com/22355127/141890133-2e20e1f4-5608-4a87-a9aa-a9f50f5984d9.png">

[Figma spec](https://www.figma.com/file/iBkvpAPTSMQHeRxIrCynQi/Settings-Redesign?node-id=99%3A1749)