### PR TITLE
Fix Crash in androidController::Binder::init

### DIFF
--- a/src/platforms/android/androidcontroller.cpp
+++ b/src/platforms/android/androidcontroller.cpp
@@ -101,6 +101,9 @@ void AndroidController::initialize(const Device* device, const Keys* keys) {
   QtAndroid::bindService(
       QAndroidIntent(appContext.object(), "org.mozilla.firefox.vpn.VPNService"),
       *this, QtAndroid::BindFlag::AutoCreate);
+
+  connect(this, &AndroidController::initialized, this,
+          &AndroidController::applyStrings, Qt::QueuedConnection);
 }
 
 /*
@@ -305,9 +308,6 @@ bool AndroidController::VPNBinder::onTransact(int code,
           true, doc.object()["connected"].toBool(),
           QDateTime::fromMSecsSinceEpoch(
               doc.object()["time"].toVariant().toLongLong()));
-      // Pass a localised version of the Fallback string for the Notification
-      m_controller->applyStrings();
-
       break;
     case EVENT_CONNECTED:
       logger.debug() << "Transact: connected";


### PR DESCRIPTION
VPNBinder is not guaranteed to be in the qapp thread, so instead of letting it call a func in androidcontroller it should only use emits :) 

Otherwise we might access the l18n via some subthread and fail here:
```
11-16 14:28:37.951 24769 24769 D mozillavpn: (Parent is QApplication(0x7530611df0), parent's thread is QThread(0xb4000075ccd7b790), current thread is QThread(0xb4000075ccdb7b10)
11-16 14:28:38.050 24769 24799 D mozillavpn: [16.11.2021 14:28:38.050] Error: QQmlEngine: Illegal attempt to connect to QQmlPropertyMap(0xb4000075ccdb7ef0) that is in a different thread than the QML engine QQmlApplicationEngine(0x7530611a68.

```
