### PR TITLE
Status indicator states for unstable and lost connection

### DIFF
--- a/src/ui/components/VPNMainImage.qml
+++ b/src/ui/components/VPNMainImage.qml
@@ -27,13 +27,14 @@ Rectangle {
             }
             PropertyChanges {
                 target: insetCircle
-                color: Color.green
+                color: Color.success.default
             }
             PropertyChanges {
                 target: insetIcon
                 source: "qrc:/ui/resources/shield-on.svg"
                 opacity: 1
             }
+
         },
         State {
             name: VPNController.StateConfirming
@@ -45,7 +46,7 @@ Rectangle {
             }
             PropertyChanges {
                 target: insetCircle
-                color: Color.green
+                color: Color.success.default
             }
             PropertyChanges {
                 target: insetIcon
@@ -64,7 +65,7 @@ Rectangle {
             }
             PropertyChanges {
                 target: insetCircle
-                color: Color.red
+                color: Color.error.default
             }
             PropertyChanges {
                 target: insetIcon
@@ -82,6 +83,10 @@ Rectangle {
                 showVPNOnIcon: true
             }
             PropertyChanges {
+                target: insetCircle
+                color: Color.success.default
+            }
+            PropertyChanges {
                 target: switchingIcon
                 opacity: 1
             }
@@ -94,6 +99,10 @@ Rectangle {
         State {
             name: VPNController.StateOff
 
+            PropertyChanges {
+                target: insetCircle
+                color: Color.error.default
+            }
             PropertyChanges {
                 target: insetIcon
                 source: "qrc:/ui/resources/shield-off.svg"
@@ -110,7 +119,7 @@ Rectangle {
             }
             PropertyChanges {
                 target: insetCircle
-                color: Color.green
+                color: Color.success.default
             }
             PropertyChanges {
                 target: insetIcon
@@ -129,7 +138,7 @@ Rectangle {
             }
             PropertyChanges {
                 target: insetCircle
-                color: Color.red
+                color: Color.success.default
             }
             PropertyChanges {
                 target: insetIcon
@@ -157,6 +166,7 @@ Rectangle {
                 source: "qrc:/ui/resources/shield-on.svg"
                 opacity: 1
             }
+
         },
         State {
             name: "noSignalOn"
@@ -177,6 +187,7 @@ Rectangle {
                 source: "qrc:/ui/resources/shield-off.svg"
                 opacity: 1
             }
+
         }
     ]
     transitions: [

--- a/src/ui/components/VPNMainImage.qml
+++ b/src/ui/components/VPNMainImage.qml
@@ -26,11 +26,14 @@ Rectangle {
                 showVPNOnIcon: true
             }
             PropertyChanges {
+                target: insetCircle
+                color: Color.green
+            }
+            PropertyChanges {
                 target: insetIcon
                 source: "qrc:/ui/resources/shield-on.svg"
                 opacity: 1
             }
-
         },
         State {
             name: VPNController.StateConfirming
@@ -39,6 +42,10 @@ Rectangle {
                 target: logo
                 opacity: 0.6
                 showVPNOnIcon: true
+            }
+            PropertyChanges {
+                target: insetCircle
+                color: Color.green
             }
             PropertyChanges {
                 target: insetIcon
@@ -54,6 +61,10 @@ Rectangle {
                 target: logo
                 opacity: 0.55
                 showVPNOnIcon: false
+            }
+            PropertyChanges {
+                target: insetCircle
+                color: Color.red
             }
             PropertyChanges {
                 target: insetIcon
@@ -97,7 +108,10 @@ Rectangle {
                 target: logo
                 showVPNOnIcon: true
             }
-
+            PropertyChanges {
+                target: insetCircle
+                color: Color.green
+            }
             PropertyChanges {
                 target: insetIcon
                 source: "qrc:/ui/resources/shield-on.svg"
@@ -113,13 +127,56 @@ Rectangle {
                 showVPNOnIcon: false
                 opacity: 0.55
             }
-
+            PropertyChanges {
+                target: insetCircle
+                color: Color.red
+            }
             PropertyChanges {
                 target: insetIcon
                 source: "qrc:/ui/resources/shield-off.svg"
                 opacity: 1
             }
 
+        },
+        State {
+            name: "unstableOn"
+            when: VPNController.state === VPNController.StateOn &&
+                VPNConnectionHealth.stability === VPNConnectionHealth.Unstable
+
+            PropertyChanges {
+                target: logo
+                showVPNOnIcon: true
+                opacity: 1
+            }
+            PropertyChanges {
+                target: insetCircle
+                color: Color.warning.default
+            }
+            PropertyChanges {
+                target: insetIcon
+                source: "qrc:/ui/resources/shield-on.svg"
+                opacity: 1
+            }
+        },
+        State {
+            name: "noSignalOn"
+            when: VPNController.state === VPNController.StateOn &&
+                VPNConnectionHealth.stability === VPNConnectionHealth.NoSignal
+
+            PropertyChanges {
+                target: logo
+                showVPNOnIcon: true
+                opacity: 1
+            }
+            PropertyChanges {
+                target: insetCircle
+                color: Color.error.default
+            }
+            PropertyChanges {
+                target: insetIcon
+                source: "qrc:/ui/resources/shield-off.svg"
+                opacity: 1
+            }
         }
     ]
     transitions: [
@@ -216,7 +273,7 @@ Rectangle {
             }
         },
         Transition {
-            to: VPNController.StateOn
+            to: "*"
             ParallelAnimation {
                 PropertyAnimation {
                     target: insetIcon
@@ -257,7 +314,6 @@ Rectangle {
         y: 5
         antialiasing: true
         smooth: true
-        color: showVPNOnIcon ? "#3FE1B0" : "#FF4F5E"
 
         Image {
             id: insetIcon


### PR DESCRIPTION
Adds additional states to the status indicator for when the VPN is on but the connection is unstable or lost.

**Design**
[Figma spec](https://www.figma.com/file/ziJ5tGCqhfst4svjtKJlbr/2.7--Feature-Enhancements?node-id=1%3A1631)

**Screenshots**
| VPN on & unstable | VPN on & no signal |
|---|---|
|<img width="100" alt="unstableOn" src="https://user-images.githubusercontent.com/13835474/142024087-e5cd39f5-04ae-4c89-bf44-264e1033afce.png">|<img width="95" alt="noSignalOn" src="https://user-images.githubusercontent.com/13835474/142024122-a03721b3-fa74-44b1-8a3d-465cc0974a2c.png">|