### PR TITLE
Delay multihop peer startup based on handshake completion

### DIFF
--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -374,7 +374,7 @@ bool Daemon::switchServer(const InterfaceConfig& config) {
 
   // Remove the old peer if it is no longer necessary.
   if (config.m_serverPublicKey != lastConfig.m_serverPublicKey) {
-    if (!wgutils()->deletePeer(lastConfig.m_serverPublicKey)) {
+    if (!wgutils()->deletePeer(lastConfig)) {
       return false;
     }
   }

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -299,13 +299,14 @@ bool Daemon::deactivate(bool emitSignals) {
     return false;
   }
 
-  // Cleanup routing
+  // Cleanup peers and routing
   for (const ConnectionState& state : m_connections.values()) {
     const InterfaceConfig& config = state.m_config;
     logger.debug() << "Deleting routes for hop" << config.m_hopindex;
     for (const IPAddressRange& ip : config.m_allowedIPAddressRanges) {
       wgutils()->deleteRoutePrefix(ip, config.m_hopindex);
     }
+    wgutils()->deletePeer(config);
   }
 
   // Delete the interface

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -31,9 +31,7 @@ class Daemon : public QObject {
 
   virtual bool activate(const InterfaceConfig& config);
   virtual bool deactivate(bool emitSignals = true);
-
-  // Explose a JSON object with the daemon status.
-  virtual QByteArray getStatus() = 0;
+  virtual QJsonObject getStatus();
 
   // Callback before any Activating measure is done
   virtual void prepareActivation(const InterfaceConfig& config){

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -41,8 +41,8 @@ class Daemon : public QObject {
   void cleanLogs();
 
  signals:
-  void connected(int hopindex);
-  void disconnected(int hopindex);
+  void connected(const QString& pubkey);
+  void disconnected();
   void backendFailure();
 
  protected:

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -11,6 +11,7 @@
 #include "wireguardutils.h"
 
 #include <QDateTime>
+#include <QTimer>
 
 class Daemon : public QObject {
   Q_OBJECT
@@ -60,17 +61,17 @@ class Daemon : public QObject {
   virtual bool supportDnsUtils() const { return false; }
   virtual DnsUtils* dnsutils() { return nullptr; }
 
+  void checkHandshake();
+
   class ConnectionState {
    public:
     ConnectionState(){};
-    ConnectionState(const InterfaceConfig& config) {
-      m_config = config;
-      m_date = QDateTime::currentDateTime();
-    }
+    ConnectionState(const InterfaceConfig& config) { m_config = config; }
     QDateTime m_date;
     InterfaceConfig m_config;
   };
   QMap<int, ConnectionState> m_connections;
+  QTimer m_handshakeTimer;
 };
 
 #endif  // DAEMON_H

--- a/src/daemon/daemonlocalserverconnection.cpp
+++ b/src/daemon/daemonlocalserverconnection.cpp
@@ -136,10 +136,10 @@ void DaemonLocalServerConnection::parseCommand(const QByteArray& data) {
   logger.warning() << "Invalid command:" << type;
 }
 
-void DaemonLocalServerConnection::connected(int hopindex) {
+void DaemonLocalServerConnection::connected(const QString& pubkey) {
   QJsonObject obj;
   obj.insert("type", "connected");
-  obj.insert("hopindex", QJsonValue(hopindex));
+  obj.insert("pubkey", QJsonValue(pubkey));
   write(obj);
 }
 

--- a/src/daemon/daemonlocalserverconnection.cpp
+++ b/src/daemon/daemonlocalserverconnection.cpp
@@ -112,7 +112,9 @@ void DaemonLocalServerConnection::parseCommand(const QByteArray& data) {
   }
 
   if (type == "status") {
-    m_socket->write(Daemon::instance()->getStatus());
+    QJsonObject obj = Daemon::instance()->getStatus();
+    obj.insert("type", "status");
+    m_socket->write(QJsonDocument(obj).toJson(QJsonDocument::Compact));
     m_socket->write("\n");
     return;
   }

--- a/src/daemon/daemonlocalserverconnection.h
+++ b/src/daemon/daemonlocalserverconnection.h
@@ -21,7 +21,7 @@ class DaemonLocalServerConnection final : public QObject {
 
   void parseCommand(const QByteArray& json);
 
-  void connected(int hopindex);
+  void connected(const QString& pubkey);
   void disconnected();
   void backendFailure();
 

--- a/src/daemon/wireguardutils.h
+++ b/src/daemon/wireguardutils.h
@@ -18,6 +18,8 @@ class WireguardUtils : public QObject {
 
  public:
   struct peerStatus {
+    QString pubkey;
+    qint64 handshake;
     qint64 rxBytes;
     qint64 txBytes;
   };
@@ -32,7 +34,7 @@ class WireguardUtils : public QObject {
 
   virtual bool updatePeer(const InterfaceConfig& config) = 0;
   virtual bool deletePeer(const QString& pubkey) = 0;
-  virtual peerStatus getPeerStatus(const QString& pubkey) = 0;
+  virtual QList<peerStatus> getPeerStatus() = 0;
 
   virtual bool updateRoutePrefix(const IPAddressRange& prefix,
                                  int hopindex) = 0;

--- a/src/daemon/wireguardutils.h
+++ b/src/daemon/wireguardutils.h
@@ -42,6 +42,15 @@ class WireguardUtils : public QObject {
                                  int hopindex) = 0;
   virtual bool deleteRoutePrefix(const IPAddressRange& prefix,
                                  int hopindex) = 0;
+
+  // static
+  static QString printableKey(const QString& pubkey) {
+    if (pubkey.length() < 12) {
+      return pubkey;
+    } else {
+      return pubkey.left(6) + "..." + pubkey.right(6);
+    }
+  }
 };
 
 #endif  // WIREGUARDUTILS_H

--- a/src/daemon/wireguardutils.h
+++ b/src/daemon/wireguardutils.h
@@ -13,6 +13,8 @@
 
 constexpr const char* WG_INTERFACE = "moz0";
 
+constexpr uint16_t WG_KEEPALIVE_PERIOD = 60;
+
 class WireguardUtils : public QObject {
   Q_OBJECT
 

--- a/src/daemon/wireguardutils.h
+++ b/src/daemon/wireguardutils.h
@@ -17,11 +17,13 @@ class WireguardUtils : public QObject {
   Q_OBJECT
 
  public:
-  struct peerStatus {
-    QString pubkey;
-    qint64 handshake;
-    qint64 rxBytes;
-    qint64 txBytes;
+  class PeerStatus {
+   public:
+    PeerStatus(const QString& pubkey = QString()) { m_pubkey = pubkey; }
+    QString m_pubkey;
+    qint64 m_handshake = 0;
+    qint64 m_rxBytes = 0;
+    qint64 m_txBytes = 0;
   };
 
   explicit WireguardUtils(QObject* parent) : QObject(parent){};
@@ -34,7 +36,7 @@ class WireguardUtils : public QObject {
 
   virtual bool updatePeer(const InterfaceConfig& config) = 0;
   virtual bool deletePeer(const QString& pubkey) = 0;
-  virtual QList<peerStatus> getPeerStatus() = 0;
+  virtual QList<PeerStatus> getPeerStatus() = 0;
 
   virtual bool updateRoutePrefix(const IPAddressRange& prefix,
                                  int hopindex) = 0;

--- a/src/daemon/wireguardutils.h
+++ b/src/daemon/wireguardutils.h
@@ -37,7 +37,7 @@ class WireguardUtils : public QObject {
   virtual bool deleteInterface() = 0;
 
   virtual bool updatePeer(const InterfaceConfig& config) = 0;
-  virtual bool deletePeer(const QString& pubkey) = 0;
+  virtual bool deletePeer(const InterfaceConfig& config) = 0;
   virtual QList<PeerStatus> getPeerStatus() = 0;
 
   virtual bool updateRoutePrefix(const IPAddressRange& prefix,

--- a/src/localsocketcontroller.cpp
+++ b/src/localsocketcontroller.cpp
@@ -353,7 +353,7 @@ void LocalSocketController::parseCommand(const QByteArray& command) {
   if (type == "connected") {
     QString pubkey = obj.value("pubkey").toString();
     logger.debug() << "Handshake completed with:" << pubkey;
-  
+
     if (m_activationQueue.isEmpty()) {
       return;
     }
@@ -367,8 +367,7 @@ void LocalSocketController::parseCommand(const QByteArray& command) {
     m_activationQueue.removeFirst();
     if (m_activationQueue.isEmpty()) {
       emit connected();
-    }
-    else {
+    } else {
       activateNext();
     }
     return;

--- a/src/localsocketcontroller.cpp
+++ b/src/localsocketcontroller.cpp
@@ -90,56 +90,63 @@ void LocalSocketController::activate(
     const QList<IPAddressRange>& allowedIPAddressRanges,
     const QList<QString>& vpnDisabledApps, const QHostAddress& dnsServer,
     Reason reason) {
-  Q_UNUSED(vpnDisabledApps);
   Q_UNUSED(reason);
+  Q_ASSERT(!serverList.isEmpty());
+
+  // Clear out any connections that might have been lingering.
+  m_activationQueue.clear();
+  m_device = device;
+  m_keys = keys;
 
   if (m_state != eReady) {
     emit disconnected();
     return;
   }
-  const Server& server = serverList.first();
 
   // Activate connections starting from the outermost tunnel
   for (int hopindex = serverList.count() - 1; hopindex > 0; hopindex--) {
-    const Server& hop = serverList[hopindex];
     const Server& next = serverList[hopindex - 1];
-    QJsonObject hopJson;
-    hopJson.insert("type", "activate");
-    hopJson.insert("hopindex", QJsonValue((double)hopindex));
-    hopJson.insert("privateKey", QJsonValue(keys->privateKey()));
-    hopJson.insert("deviceIpv4Address", QJsonValue(device->ipv4Address()));
-    hopJson.insert("deviceIpv6Address", QJsonValue(device->ipv6Address()));
-    hopJson.insert("serverPublicKey", QJsonValue(hop.publicKey()));
-    hopJson.insert("serverIpv4AddrIn", QJsonValue(hop.ipv4AddrIn()));
-    hopJson.insert("serverIpv6AddrIn", QJsonValue(hop.ipv6AddrIn()));
-    hopJson.insert("serverPort", QJsonValue((double)hop.choosePort()));
-
-    QJsonArray hopAddressRanges;
-    hopAddressRanges.append(QJsonObject(
-        {{"address", next.ipv4AddrIn()}, {"range", 32}, {"isIpv6", false}}));
-    hopAddressRanges.append(QJsonObject(
-        {{"address", next.ipv6AddrIn()}, {"range", 128}, {"isIpv6", true}}));
-    hopJson.insert("allowedIPAddressRanges", hopAddressRanges);
-
-    write(hopJson);
+    HopConnection hop;
+    hop.m_server = serverList[hopindex];
+    hop.m_hopindex = hopindex;
+    hop.m_allowedIPAddressRanges.append(IPAddressRange(next.ipv4AddrIn()));
+    hop.m_allowedIPAddressRanges.append(IPAddressRange(next.ipv6AddrIn()));
+    m_activationQueue.append(hop);
   }
 
+  // The final hop should be activated last.
+  HopConnection lastHop;
+  lastHop.m_server = serverList.first();
+  lastHop.m_hopindex = 0;
+  lastHop.m_allowedIPAddressRanges = allowedIPAddressRanges;
+  lastHop.m_vpnDisabledApps = vpnDisabledApps;
+  lastHop.m_dnsServer = dnsServer;
+  m_activationQueue.append(lastHop);
+
+  logger.debug() << "Activating";
+  activateNext();
+}
+
+void LocalSocketController::activateNext() {
+  const HopConnection& hop = m_activationQueue.first();
   QJsonObject json;
   json.insert("type", "activate");
-  json.insert("hopindex", QJsonValue((double)0));
-  json.insert("privateKey", QJsonValue(keys->privateKey()));
-  json.insert("deviceIpv4Address", QJsonValue(device->ipv4Address()));
-  json.insert("deviceIpv6Address", QJsonValue(device->ipv6Address()));
-  json.insert("serverIpv4Gateway", QJsonValue(server.ipv4Gateway()));
-  json.insert("serverIpv6Gateway", QJsonValue(server.ipv6Gateway()));
-  json.insert("serverPublicKey", QJsonValue(server.publicKey()));
-  json.insert("serverIpv4AddrIn", QJsonValue(server.ipv4AddrIn()));
-  json.insert("serverIpv6AddrIn", QJsonValue(server.ipv6AddrIn()));
-  json.insert("serverPort", QJsonValue((double)server.choosePort()));
-  json.insert("dnsServer", QJsonValue(dnsServer.toString()));
+  json.insert("hopindex", QJsonValue((double)hop.m_hopindex));
+  json.insert("privateKey", QJsonValue(m_keys->privateKey()));
+  json.insert("deviceIpv4Address", QJsonValue(m_device->ipv4Address()));
+  json.insert("deviceIpv6Address", QJsonValue(m_device->ipv6Address()));
+  json.insert("serverPublicKey", QJsonValue(hop.m_server.publicKey()));
+  json.insert("serverIpv4AddrIn", QJsonValue(hop.m_server.ipv4AddrIn()));
+  json.insert("serverIpv6AddrIn", QJsonValue(hop.m_server.ipv6AddrIn()));
+  json.insert("serverPort", QJsonValue((double)hop.m_server.choosePort()));
+  if (hop.m_hopindex == 0) {
+    json.insert("serverIpv4Gateway", QJsonValue(hop.m_server.ipv4Gateway()));
+    json.insert("serverIpv6Gateway", QJsonValue(hop.m_server.ipv6Gateway()));
+    json.insert("dnsServer", QJsonValue(hop.m_dnsServer.toString()));
+  }
 
   QJsonArray allowedIPAddesses;
-  for (const IPAddressRange& i : allowedIPAddressRanges) {
+  for (const IPAddressRange& i : hop.m_allowedIPAddressRanges) {
     QJsonObject range;
     range.insert("address", QJsonValue(i.ipAddress()));
     range.insert("range", QJsonValue((double)i.range()));
@@ -148,7 +155,7 @@ void LocalSocketController::activate(
   };
   json.insert("allowedIPAddressRanges", allowedIPAddesses);
   QJsonArray splitTunnelApps;
-  for (const auto& uri : vpnDisabledApps) {
+  for (const auto& uri : hop.m_vpnDisabledApps) {
     splitTunnelApps.append(QJsonValue(uri));
   }
   json.insert("vpnDisabledApps", splitTunnelApps);
@@ -158,6 +165,8 @@ void LocalSocketController::activate(
 
 void LocalSocketController::deactivate(Reason reason) {
   logger.debug() << "Deactivating";
+
+  m_activationQueue.clear();
 
   if (m_state != eReady) {
     emit disconnected();
@@ -342,12 +351,25 @@ void LocalSocketController::parseCommand(const QByteArray& command) {
   }
 
   if (type == "connected") {
-    int hopindex = obj.value("hopindex").toInt(0);
-    if (hopindex != 0) {
-      logger.debug() << "hopindex" << hopindex << "connected";
+    QString pubkey = obj.value("pubkey").toString();
+    logger.debug() << "Handshake completed with:" << pubkey;
+  
+    if (m_activationQueue.isEmpty()) {
       return;
-    } else {
+    }
+    const HopConnection& hop = m_activationQueue.first();
+    if (hop.m_server.publicKey() != pubkey) {
+      return;
+    }
+
+    // After a connection is completed, start the next handshake or signal
+    // success if all connections came up successfully.
+    m_activationQueue.removeFirst();
+    if (m_activationQueue.isEmpty()) {
       emit connected();
+    }
+    else {
+      activateNext();
     }
     return;
   }

--- a/src/localsocketcontroller.h
+++ b/src/localsocketcontroller.h
@@ -9,6 +9,7 @@
 
 #include <functional>
 #include <QLocalSocket>
+#include <QHostAddress>
 
 class QJsonObject;
 
@@ -36,6 +37,7 @@ class LocalSocketController final : public ControllerImpl {
   void cleanupBackendLogs() override;
 
  private:
+  void activateNext();
   void daemonConnected();
   void errorOccurred(QLocalSocket::LocalSocketError socketError);
   void readData();
@@ -50,6 +52,19 @@ class LocalSocketController final : public ControllerImpl {
     eReady,
     eDisconnected,
   } m_state = eUnknown;
+
+  class HopConnection {
+   public:
+    HopConnection() {}
+    Server m_server;
+    int m_hopindex = 0;
+    QList<IPAddressRange> m_allowedIPAddressRanges;
+    QList<QString> m_vpnDisabledApps;
+    QHostAddress m_dnsServer;
+  };
+  QList<HopConnection> m_activationQueue;
+  const Device* m_device = nullptr;
+  const Keys* m_keys = nullptr;
 
   QLocalSocket* m_socket = nullptr;
 

--- a/src/platforms/linux/daemon/dbusservice.cpp
+++ b/src/platforms/linux/daemon/dbusservice.cpp
@@ -115,42 +115,8 @@ bool DBusService::deactivate(bool emitSignals) {
   return Daemon::deactivate(emitSignals);
 }
 
-QString DBusService::status() { return QString(getStatus()); }
-
-QByteArray DBusService::getStatus() {
-  logger.debug() << "Status request";
-  QJsonObject json;
-
-  if (!m_connections.contains(0)) {
-    json.insert("status", QJsonValue(false));
-    return QJsonDocument(json).toJson(QJsonDocument::Compact);
-  }
-
-  const ConnectionState& connection = m_connections.value(0);
-  if (!m_wgutils->interfaceExists()) {
-    logger.error() << "Unable to get device";
-    json.insert("status", QJsonValue(false));
-    return QJsonDocument(json).toJson(QJsonDocument::Compact);
-  }
-
-  QList<WireguardUtils::peerStatus> peers = m_wgutils->getPeerStatus();
-  for (WireguardUtils::peerStatus status : peers) {
-    if (status.pubkey != connection.m_config.m_serverPublicKey) {
-      continue;
-    }
-    json.insert("status", QJsonValue(true));
-    json.insert("serverIpv4Gateway",
-                QJsonValue(connection.m_config.m_serverIpv4Gateway));
-    json.insert("deviceIpv4Address",
-                QJsonValue(connection.m_config.m_deviceIpv4Address));
-    json.insert("date", connection.m_date.toString());
-    json.insert("txBytes", QJsonValue(status.txBytes));
-    json.insert("rxBytes", QJsonValue(status.rxBytes));
-    return QJsonDocument(json).toJson(QJsonDocument::Compact);
-  }
-
-  json.insert("status", QJsonValue(false));
-  return QJsonDocument(json).toJson(QJsonDocument::Compact);
+QString DBusService::status() {
+  return QString(QJsonDocument(getStatus()).toJson(QJsonDocument::Compact));
 }
 
 QString DBusService::getLogs() {

--- a/src/platforms/linux/daemon/dbusservice.cpp
+++ b/src/platforms/linux/daemon/dbusservice.cpp
@@ -126,21 +126,30 @@ QByteArray DBusService::getStatus() {
     return QJsonDocument(json).toJson(QJsonDocument::Compact);
   }
 
-  const InterfaceConfig& config = m_connections.value(0).m_config;
+  const ConnectionState& connection = m_connections.value(0);
   if (!m_wgutils->interfaceExists()) {
     logger.error() << "Unable to get device";
     json.insert("status", QJsonValue(false));
     return QJsonDocument(json).toJson(QJsonDocument::Compact);
   }
 
-  json.insert("status", QJsonValue(true));
-  json.insert("serverIpv4Gateway", QJsonValue(config.m_serverIpv4Gateway));
-  json.insert("deviceIpv4Address", QJsonValue(config.m_deviceIpv4Address));
-  WireguardUtilsLinux::peerStatus status =
-      m_wgutils->getPeerStatus(config.m_serverPublicKey);
-  json.insert("txBytes", QJsonValue(status.txBytes));
-  json.insert("rxBytes", QJsonValue(status.rxBytes));
+  QList<WireguardUtils::peerStatus> peers = m_wgutils->getPeerStatus();
+  for (WireguardUtils::peerStatus status : peers) {
+    if (status.pubkey != connection.m_config.m_serverPublicKey) {
+      continue;
+    }
+    json.insert("status", QJsonValue(true));
+    json.insert("serverIpv4Gateway",
+                QJsonValue(connection.m_config.m_serverIpv4Gateway));
+    json.insert("deviceIpv4Address",
+                QJsonValue(connection.m_config.m_deviceIpv4Address));
+    json.insert("date", connection.m_date.toString());
+    json.insert("txBytes", QJsonValue(status.txBytes));
+    json.insert("rxBytes", QJsonValue(status.rxBytes));
+    return QJsonDocument(json).toJson(QJsonDocument::Compact);
+  }
 
+  json.insert("status", QJsonValue(false));
   return QJsonDocument(json).toJson(QJsonDocument::Compact);
 }
 

--- a/src/platforms/linux/daemon/dbusservice.h
+++ b/src/platforms/linux/daemon/dbusservice.h
@@ -48,8 +48,6 @@ class DBusService final : public Daemon {
   bool supportDnsUtils() const override { return true; }
   DnsUtils* dnsutils() override;
 
-  QByteArray getStatus() override;
-
  private:
   bool removeInterfaceIfExists();
   QString getAppStateCgroup(const QString& state);

--- a/src/platforms/linux/daemon/org.mozilla.vpn.dbus.xml
+++ b/src/platforms/linux/daemon/org.mozilla.vpn.dbus.xml
@@ -36,10 +36,9 @@
     <method name="cleanupLogs">
     </method>
     <signal name="connected">
-      <arg name="hopindex" type="i" direction="out"/>
+      <arg name="pubkey" type="s" direction="out"/>
     </signal>
     <signal name="disconnected">
-      <arg name="hopindex" type="i" direction="out"/>
     </signal>
   </interface>
 </node>

--- a/src/platforms/linux/daemon/wireguardutilslinux.cpp
+++ b/src/platforms/linux/daemon/wireguardutilslinux.cpp
@@ -34,8 +34,6 @@ extern "C" {
 #endif
 // End import wireguard
 
-constexpr uint16_t WG_KEEPALIVE_PERIOD = 60;
-
 /* Packets sent outside the VPN need to be marked for the routing policy
  * to direct them appropriately. The value of the mark and the table ID
  * aren't important, so long as they are unique.

--- a/src/platforms/linux/daemon/wireguardutilslinux.cpp
+++ b/src/platforms/linux/daemon/wireguardutilslinux.cpp
@@ -294,29 +294,29 @@ bool WireguardUtilsLinux::deleteInterface() {
   return true;
 }
 
-QList<WireguardUtils::peerStatus> WireguardUtilsLinux::getPeerStatus() {
+QList<WireguardUtils::PeerStatus> WireguardUtilsLinux::getPeerStatus() {
   wg_device* device = nullptr;
   wg_peer* peer = nullptr;
-  QList<WireguardUtils::peerStatus> result;
+  QList<WireguardUtils::PeerStatus> peerList;
 
   if (wg_get_device(&device, WG_INTERFACE) != 0) {
     logger.warning() << "Unable to get stats for" << WG_INTERFACE;
-    return result;
+    return peerList;
   }
 
   wg_for_each_peer(device, peer) {
-    peerStatus status;
+    PeerStatus status;
     wg_key_b64_string keystring;
     wg_key_to_base64(keystring, peer->public_key);
-    status.pubkey = QString(keystring);
-    status.handshake = peer->last_handshake_time.tv_sec * 1000;
-    status.handshake += peer->last_handshake_time.tv_nsec / 1000000;
-    status.txBytes = peer->tx_bytes;
-    status.rxBytes = peer->rx_bytes;
-    result.append(status);
+    status.m_pubkey = QString(keystring);
+    status.m_handshake = peer->last_handshake_time.tv_sec * 1000;
+    status.m_handshake += peer->last_handshake_time.tv_nsec / 1000000;
+    status.m_txBytes = peer->tx_bytes;
+    status.m_rxBytes = peer->rx_bytes;
+    peerList.append(status);
   }
   wg_free_device(device);
-  return result;
+  return peerList;
 }
 
 bool WireguardUtilsLinux::updateRoutePrefix(const IPAddressRange& prefix,

--- a/src/platforms/linux/daemon/wireguardutilslinux.cpp
+++ b/src/platforms/linux/daemon/wireguardutilslinux.cpp
@@ -242,7 +242,7 @@ bool WireguardUtilsLinux::updatePeer(const InterfaceConfig& config) {
   return true;
 }
 
-bool WireguardUtilsLinux::deletePeer(const QString& pubkey) {
+bool WireguardUtilsLinux::deletePeer(const InterfaceConfig& config) {
   wg_device* device = static_cast<wg_device*>(calloc(1, sizeof(*device)));
   if (!device) {
     logger.error() << "Allocation failure";
@@ -257,11 +257,11 @@ bool WireguardUtilsLinux::deletePeer(const QString& pubkey) {
   }
   device->first_peer = device->last_peer = peer;
 
-  logger.debug() << "Removing peer" << printableKey(pubkey);
+  logger.debug() << "Removing peer" << printableKey(config.m_serverPublicKey);
 
   // Public Key
   peer->flags = (wg_peer_flags)(WGPEER_HAS_PUBLIC_KEY | WGPEER_REMOVE_ME);
-  wg_key_from_base64(peer->public_key, qPrintable(pubkey));
+  wg_key_from_base64(peer->public_key, qPrintable(config.m_serverPublicKey));
 
   // Set/update device
   strncpy(device->name, WG_INTERFACE, IFNAMSIZ);

--- a/src/platforms/linux/daemon/wireguardutilslinux.h
+++ b/src/platforms/linux/daemon/wireguardutilslinux.h
@@ -42,8 +42,6 @@ class WireguardUtilsLinux final : public WireguardUtils {
   static bool buildAllowedIp(struct wg_allowedip*,
                              const IPAddressRange& prefix);
 
-  static QString printablePubkey(const QString& pubkey);
-
   int m_nlsock = -1;
   int m_nlseq = 0;
   QSocketNotifier* m_notifier = nullptr;

--- a/src/platforms/linux/daemon/wireguardutilslinux.h
+++ b/src/platforms/linux/daemon/wireguardutilslinux.h
@@ -22,7 +22,7 @@ class WireguardUtilsLinux final : public WireguardUtils {
 
   bool updatePeer(const InterfaceConfig& config) override;
   bool deletePeer(const QString& pubkey) override;
-  QList<peerStatus> getPeerStatus() override;
+  QList<PeerStatus> getPeerStatus() override;
 
   bool updateRoutePrefix(const IPAddressRange& prefix, int hopindex) override;
   bool deleteRoutePrefix(const IPAddressRange& prefix, int hopindex) override;

--- a/src/platforms/linux/daemon/wireguardutilslinux.h
+++ b/src/platforms/linux/daemon/wireguardutilslinux.h
@@ -6,6 +6,7 @@
 #define WIREGUARDUTILSLINUX_H
 
 #include "daemon/wireguardutils.h"
+#include <QHostAddress>
 #include <QObject>
 #include <QSocketNotifier>
 #include <QStringList>
@@ -38,6 +39,7 @@ class WireguardUtilsLinux final : public WireguardUtils {
   bool rtmSendRule(int action, int flags, int addrfamily);
   bool rtmSendRoute(int action, int flags, const IPAddressRange& prefix,
                     int hopindex);
+  bool rtmSendExclude(int action, int flags, const QHostAddress& address);
   static bool setupCgroupClass(const QString& path, unsigned long classid);
   static bool buildAllowedIp(struct wg_allowedip*,
                              const IPAddressRange& prefix);

--- a/src/platforms/linux/daemon/wireguardutilslinux.h
+++ b/src/platforms/linux/daemon/wireguardutilslinux.h
@@ -22,7 +22,7 @@ class WireguardUtilsLinux final : public WireguardUtils {
 
   bool updatePeer(const InterfaceConfig& config) override;
   bool deletePeer(const QString& pubkey) override;
-  peerStatus getPeerStatus(const QString& pubkey) override;
+  QList<peerStatus> getPeerStatus() override;
 
   bool updateRoutePrefix(const IPAddressRange& prefix, int hopindex) override;
   bool deleteRoutePrefix(const IPAddressRange& prefix, int hopindex) override;

--- a/src/platforms/linux/daemon/wireguardutilslinux.h
+++ b/src/platforms/linux/daemon/wireguardutilslinux.h
@@ -21,7 +21,7 @@ class WireguardUtilsLinux final : public WireguardUtils {
   bool deleteInterface() override;
 
   bool updatePeer(const InterfaceConfig& config) override;
-  bool deletePeer(const QString& pubkey) override;
+  bool deletePeer(const InterfaceConfig& config) override;
   QList<PeerStatus> getPeerStatus() override;
 
   bool updateRoutePrefix(const IPAddressRange& prefix, int hopindex) override;

--- a/src/platforms/linux/dbusclient.h
+++ b/src/platforms/linux/dbusclient.h
@@ -41,8 +41,8 @@ class DBusClient final : public QObject {
   QDBusPendingCallWatcher* cleanupLogs();
 
  signals:
-  void connected(int hopindex);
-  void disconnected(int hopindex);
+  void connected(const QString& pubkey);
+  void disconnected();
 
  private:
   OrgMozillaVpnDbusInterface* m_dbus;

--- a/src/platforms/linux/linuxcontroller.cpp
+++ b/src/platforms/linux/linuxcontroller.cpp
@@ -29,9 +29,10 @@ LinuxController::LinuxController() {
   MVPN_COUNT_CTOR(LinuxController);
 
   m_dbus = new DBusClient(this);
-  connect(m_dbus, &DBusClient::connected, this, &LinuxController::hopConnected);
+  connect(m_dbus, &DBusClient::connected, this,
+          &LinuxController::peerConnected);
   connect(m_dbus, &DBusClient::disconnected, this,
-          &LinuxController::hopDisconnected);
+          &LinuxController::disconnected);
 }
 
 LinuxController::~LinuxController() { MVPN_COUNT_DTOR(LinuxController); }
@@ -73,32 +74,51 @@ void LinuxController::activate(
     const QList<QString>& vpnDisabledApps, const QHostAddress& dnsServer,
     Reason reason) {
   Q_UNUSED(reason);
-  Q_UNUSED(vpnDisabledApps);
+  Q_ASSERT(!serverList.isEmpty());
+
+  // Clear out any connections that might have been lingering.
+  m_activationQueue.clear();
+  m_device = device;
+  m_keys = keys;
 
   // Activate connections starting from the outermost tunnel
   for (int hopindex = serverList.count() - 1; hopindex > 0; hopindex--) {
-    const Server& hop = serverList[hopindex];
     const Server& next = serverList[hopindex - 1];
-    QList<IPAddressRange> hopAddressRanges = {
-        IPAddressRange(next.ipv4AddrIn()), IPAddressRange(next.ipv6AddrIn())};
-    logger.debug() << "LinuxController hopindex" << hopindex << "activated";
-    connect(m_dbus->activate(hop, device, keys, hopindex, hopAddressRanges,
-                             QStringList(), QHostAddress(hop.ipv4Gateway())),
-            &QDBusPendingCallWatcher::finished, this,
-            &LinuxController::operationCompleted);
+    HopConnection hop;
+
+    hop.m_server = serverList[hopindex];
+    hop.m_hopindex = hopindex;
+    hop.m_allowedIPAddressRanges.append(IPAddressRange(next.ipv4AddrIn()));
+    hop.m_allowedIPAddressRanges.append(IPAddressRange(next.ipv6AddrIn()));
+    m_activationQueue.append(hop);
   }
 
-  // Activate the final hop last
+  // The final hop should be activated last
+  HopConnection lastHop;
+  lastHop.m_server = serverList.first();
+  lastHop.m_hopindex = 0;
+  lastHop.m_allowedIPAddressRanges = allowedIPAddressRanges;
+  lastHop.m_vpnDisabledApps = vpnDisabledApps;
+  lastHop.m_dnsServer = dnsServer;
+  m_activationQueue.append(lastHop);
+
   logger.debug() << "LinuxController activated";
-  const Server& server = serverList[0];
-  connect(m_dbus->activate(server, device, keys, 0, allowedIPAddressRanges,
-                           vpnDisabledApps, dnsServer),
+  activateNext();
+}
+
+void LinuxController::activateNext() {
+  const HopConnection& hop = m_activationQueue.first();
+  connect(m_dbus->activate(hop.m_server, m_device, m_keys, hop.m_hopindex,
+                           hop.m_allowedIPAddressRanges, hop.m_vpnDisabledApps,
+                           hop.m_dnsServer),
           &QDBusPendingCallWatcher::finished, this,
           &LinuxController::operationCompleted);
 }
 
 void LinuxController::deactivate(Reason reason) {
   logger.debug() << "LinuxController deactivated";
+
+  m_activationQueue.clear();
 
   if (reason == ReasonSwitching) {
     logger.debug() << "No disconnect for quick server switching";
@@ -131,21 +151,24 @@ void LinuxController::operationCompleted(QDBusPendingCallWatcher* call) {
   emit disconnected();
 }
 
-void LinuxController::hopConnected(int hopindex) {
-  if (hopindex == 0) {
-    logger.debug() << "LinuxController connected";
+// When the daemon reports that a peer connected, activate the next
+// connection in the queue, or emit a connected() signal when we are done.
+void LinuxController::peerConnected(const QString& pubkey) {
+  logger.debug() << "handshake completed with:" << pubkey;
+  if (m_activationQueue.isEmpty()) {
+    return;
+  }
+
+  const HopConnection& hop = m_activationQueue.first();
+  if (hop.m_server.publicKey() != pubkey) {
+    return;
+  }
+
+  m_activationQueue.removeFirst();
+  if (m_activationQueue.isEmpty()) {
     emit connected();
   } else {
-    logger.debug() << "LinuxController hopindex" << hopindex << "connected";
-  }
-}
-
-void LinuxController::hopDisconnected(int hopindex) {
-  if (hopindex == 0) {
-    logger.debug() << "LinuxController disconnected";
-    emit disconnected();
-  } else {
-    logger.debug() << "LinuxController hopindex" << hopindex << "disconnected";
+    activateNext();
   }
 }
 

--- a/src/platforms/linux/linuxcontroller.cpp
+++ b/src/platforms/linux/linuxcontroller.cpp
@@ -60,8 +60,8 @@ void LinuxController::initializeCompleted(QDBusPendingCallWatcher* call) {
   Q_ASSERT(json.isObject());
 
   QJsonObject obj = json.object();
-  Q_ASSERT(obj.contains("status"));
-  QJsonValue statusValue = obj.value("status");
+  Q_ASSERT(obj.contains("connected"));
+  QJsonValue statusValue = obj.value("connected");
   Q_ASSERT(statusValue.isBool());
 
   emit initialized(true, statusValue.toBool(), QDateTime::currentDateTime());
@@ -171,8 +171,8 @@ void LinuxController::checkStatusCompleted(QDBusPendingCallWatcher* call) {
   Q_ASSERT(json.isObject());
 
   QJsonObject obj = json.object();
-  Q_ASSERT(obj.contains("status"));
-  QJsonValue statusValue = obj.value("status");
+  Q_ASSERT(obj.contains("connected"));
+  QJsonValue statusValue = obj.value("connected");
   Q_ASSERT(statusValue.isBool());
 
   if (!statusValue.toBool()) {

--- a/src/platforms/linux/linuxcontroller.h
+++ b/src/platforms/linux/linuxcontroller.h
@@ -8,6 +8,7 @@
 #include "controllerimpl.h"
 
 #include <QObject>
+#include <QHostAddress>
 
 class DBusClient;
 class QDBusPendingCallWatcher;
@@ -39,10 +40,25 @@ class LinuxController final : public ControllerImpl {
   void checkStatusCompleted(QDBusPendingCallWatcher* call);
   void initializeCompleted(QDBusPendingCallWatcher* call);
   void operationCompleted(QDBusPendingCallWatcher* call);
-  void hopConnected(int hopindex);
-  void hopDisconnected(int hopindex);
+  void peerConnected(const QString& pubkey);
 
  private:
+  void activateNext();
+
+ private:
+  class HopConnection {
+   public:
+    HopConnection() {}
+    Server m_server;
+    int m_hopindex = 0;
+    QList<IPAddressRange> m_allowedIPAddressRanges;
+    QList<QString> m_vpnDisabledApps;
+    QHostAddress m_dnsServer;
+  };
+  QList<HopConnection> m_activationQueue;
+  const Device* m_device = nullptr;
+  const Keys* m_keys = nullptr;
+
   DBusClient* m_dbus = nullptr;
 };
 

--- a/src/platforms/macos/daemon/macosdaemon.cpp
+++ b/src/platforms/macos/daemon/macosdaemon.cpp
@@ -50,25 +50,3 @@ MacOSDaemon* MacOSDaemon::instance() {
   Q_ASSERT(s_daemon);
   return s_daemon;
 }
-
-QByteArray MacOSDaemon::getStatus() {
-  logger.debug() << "Status request";
-
-  bool connected = m_connections.contains(0);
-  QJsonObject obj;
-  obj.insert("type", "status");
-  obj.insert("connected", connected);
-
-  if (connected) {
-    const ConnectionState& state = m_connections.value(0).m_config;
-    WireguardUtils::peerStatus status =
-        m_wgutils->getPeerStatus(state.m_config.m_serverPublicKey);
-    obj.insert("serverIpv4Gateway", state.m_config.m_serverIpv4Gateway);
-    obj.insert("deviceIpv4Address", state.m_config.m_deviceIpv4Address);
-    obj.insert("date", state.m_date.toString());
-    obj.insert("txBytes", QJsonValue(status.txBytes));
-    obj.insert("rxBytes", QJsonValue(status.rxBytes));
-  }
-
-  return QJsonDocument(obj).toJson(QJsonDocument::Compact);
-}

--- a/src/platforms/macos/daemon/macosdaemon.h
+++ b/src/platforms/macos/daemon/macosdaemon.h
@@ -19,8 +19,6 @@ class MacOSDaemon final : public Daemon {
 
   static MacOSDaemon* instance();
 
-  QByteArray getStatus() override;
-
  protected:
   WireguardUtils* wgutils() const override { return m_wgutils; }
   bool supportDnsUtils() const override { return true; }

--- a/src/platforms/macos/daemon/macosroutemonitor.cpp
+++ b/src/platforms/macos/daemon/macosroutemonitor.cpp
@@ -54,7 +54,7 @@ MacosRouteMonitor::MacosRouteMonitor(const QString& ifname, QObject* parent)
   m_notifier = new QSocketNotifier(m_rtsock, QSocketNotifier::Read, this);
   connect(m_notifier, &QSocketNotifier::activated, this,
           &MacosRouteMonitor::rtsockReady);
-  
+
   // Grab the default routes at startup.
   rtmFetchRoutes(AF_INET);
   rtmFetchRoutes(AF_INET6);
@@ -85,13 +85,13 @@ void MacosRouteMonitor::handleRtmDelete(const struct rt_msghdr* rtm,
   char ifname[IF_NAMESIZE];
   if_indextoname(rtm->rtm_index, ifname);
   logger.debug() << "Route deleted via" << ifname
-                 << QString("addrs(%1):").arg(rtm->rtm_addrs, 0, 16) 
+                 << QString("addrs(%1):").arg(rtm->rtm_addrs, 0, 16)
                  << list.join(" ");
 }
 
 // Compare memory against zero.
-static int memcmpzero(const void *data, size_t len) {
-  const quint8 *ptr = (const quint8*)data;
+static int memcmpzero(const void* data, size_t len) {
+  const quint8* ptr = (const quint8*)data;
   while (len--) {
     if (*ptr++) return 1;
   }
@@ -123,8 +123,8 @@ void MacosRouteMonitor::handleRtmUpdate(const struct rt_msghdr* rtm,
   }
   if_indextoname(rtm->rtm_index, ifname);
   logger.debug() << "Route update via" << ifname
-                << QString("addrs(%1):").arg(rtm->rtm_addrs, 0, 16)
-                << list.join(" ");
+                 << QString("addrs(%1):").arg(rtm->rtm_addrs, 0, 16)
+                 << list.join(" ");
 
   // Check for a default route, which should have a netmask of zero.
   const struct sockaddr* sa = (const struct sockaddr*)addrlist[2].constData();
@@ -306,7 +306,7 @@ bool MacosRouteMonitor::rtmSendRoute(int action, const QHostAddress& prefix,
     sin.sin_addr.s_addr = htonl(dst);
     rtmAppendAddr(rtm, rtm_max_size, RTA_DST, &sin);
   }
-  
+
   // Append RTA_GATEWAY
   if (gateway != nullptr) {
     if (gateway->sa_family == AF_INET) {
@@ -357,8 +357,8 @@ bool MacosRouteMonitor::rtmSendRoute(int action, const QHostAddress& prefix,
 }
 
 bool MacosRouteMonitor::rtmFetchRoutes(int family) {
-  constexpr size_t rtm_max_size = sizeof(struct rt_msghdr) +
-                                  sizeof(struct sockaddr_storage) * 2;
+  constexpr size_t rtm_max_size =
+      sizeof(struct rt_msghdr) + sizeof(struct sockaddr_storage) * 2;
   char buf[rtm_max_size];
   struct rt_msghdr* rtm = (struct rt_msghdr*)buf;
 

--- a/src/platforms/macos/daemon/macosroutemonitor.cpp
+++ b/src/platforms/macos/daemon/macosroutemonitor.cpp
@@ -8,7 +8,6 @@
 
 #include <QCoreApplication>
 
-#include <QHostAddress>
 #include <QScopeGuard>
 #include <QTimer>
 #include <QProcess>
@@ -50,78 +49,132 @@ MacosRouteMonitor::MacosRouteMonitor(const QString& ifname, QObject* parent)
     return;
   }
 
-  // Disable replies to our own messages.
-  int off = 0;
-  setsockopt(m_rtsock, SOL_SOCKET, SO_USELOOPBACK, &off, sizeof(off));
+  m_ifindex = if_nametoindex(qPrintable(ifname));
 
   m_notifier = new QSocketNotifier(m_rtsock, QSocketNotifier::Read, this);
   connect(m_notifier, &QSocketNotifier::activated, this,
           &MacosRouteMonitor::rtsockReady);
+  
+  // Grab the default routes at startup.
+  rtmFetchRoutes(AF_INET);
+  rtmFetchRoutes(AF_INET6);
 }
 
 MacosRouteMonitor::~MacosRouteMonitor() {
   MVPN_COUNT_DTOR(MacosRouteMonitor);
+  flushExclusionRoutes();
   if (m_rtsock >= 0) {
     close(m_rtsock);
   }
   logger.debug() << "MacosRouteMonitor destroyed.";
 }
 
-void MacosRouteMonitor::handleRtmAdd(const struct rt_msghdr* rtm,
-                                     const QByteArray& payload) {
-  QList<QByteArray> addrlist = parseAddrList(payload);
-
-  // Ignore routing changes on the tunnel interfaces
-  if ((rtm->rtm_addrs & RTA_DST) && (rtm->rtm_addrs & RTA_GATEWAY)) {
-    if (m_ifname == addrToString(addrlist[1])) {
-      return;
-    }
-  }
-
-  QStringList list;
-  for (auto addr : addrlist) {
-    list.append(addrToString(addr));
-  }
-  logger.debug() << "Route added by" << rtm->rtm_pid
-                 << QString("addrs(%1):").arg(rtm->rtm_addrs) << list.join(" ");
-}
-
 void MacosRouteMonitor::handleRtmDelete(const struct rt_msghdr* rtm,
                                         const QByteArray& payload) {
   QList<QByteArray> addrlist = parseAddrList(payload);
 
-  // Ignore routing changes on the tunnel interfaces
-  if ((rtm->rtm_addrs & RTA_DST) && (rtm->rtm_addrs & RTA_GATEWAY)) {
-    if (m_ifname == addrToString(addrlist[1])) {
-      return;
-    }
+  // Ignore routing changes on the tunnel interface.
+  if (rtm->rtm_index == m_ifindex) {
+    return;
   }
 
   QStringList list;
   for (auto addr : addrlist) {
     list.append(addrToString(addr));
   }
-  logger.debug() << "Route deleted by" << rtm->rtm_pid
-                 << QString("addrs(%1):").arg(rtm->rtm_addrs) << list.join(" ");
+  char ifname[IF_NAMESIZE];
+  if_indextoname(rtm->rtm_index, ifname);
+  logger.debug() << "Route deleted via" << ifname
+                 << QString("addrs(%1):").arg(rtm->rtm_addrs, 0, 16) 
+                 << list.join(" ");
 }
 
-void MacosRouteMonitor::handleRtmChange(const struct rt_msghdr* rtm,
+// Compare memory against zero.
+static int memcmpzero(const void *data, size_t len) {
+  const quint8 *ptr = (const quint8*)data;
+  while (len--) {
+    if (*ptr++) return 1;
+  }
+  return 0;
+}
+
+void MacosRouteMonitor::handleRtmUpdate(const struct rt_msghdr* rtm,
                                         const QByteArray& payload) {
   QList<QByteArray> addrlist = parseAddrList(payload);
+  char ifname[IF_NAMESIZE];
 
-  // Ignore routing changes on the tunnel interfaces
-  if ((rtm->rtm_addrs & RTA_DST) && (rtm->rtm_addrs & RTA_GATEWAY)) {
-    if (m_ifname == addrToString(addrlist[1])) {
-      return;
-    }
+  // We expect all useful routes to contain a destination, netmask and gateway.
+  if (!(rtm->rtm_addrs & RTA_DST) || !(rtm->rtm_addrs & RTA_GATEWAY) ||
+      !(rtm->rtm_addrs & RTA_NETMASK)) {
+    return;
+  }
+  // Ignore route changes that we caused, or routes on the tunnel interface.
+  if (rtm->rtm_index == m_ifindex) {
+    return;
+  }
+  if ((rtm->rtm_pid == getpid()) && (rtm->rtm_type != RTM_GET)) {
+    return;
   }
 
+  // Log relevant updates to the routing table.
   QStringList list;
   for (auto addr : addrlist) {
     list.append(addrToString(addr));
   }
-  logger.debug() << "Route chagned by" << rtm->rtm_pid
-                 << QString("addrs(%1):").arg(rtm->rtm_addrs) << list.join(" ");
+  if_indextoname(rtm->rtm_index, ifname);
+  logger.debug() << "Route update via" << ifname
+                << QString("addrs(%1):").arg(rtm->rtm_addrs, 0, 16)
+                << list.join(" ");
+
+  // Check for a default route, which should have a netmask of zero.
+  const struct sockaddr* sa = (const struct sockaddr*)addrlist[2].constData();
+  if (sa->sa_family == AF_INET) {
+    struct sockaddr_in sin;
+    Q_ASSERT(sa->sa_len <= sizeof(sin));
+    memset(&sin, 0, sizeof(sin));
+    memcpy(&sin, sa, sa->sa_len);
+    if (memcmpzero(&sin.sin_addr, sizeof(sin.sin_addr)) != 0) {
+      return;
+    }
+  } else if (sa->sa_family == AF_INET6) {
+    struct sockaddr_in6 sin6;
+    Q_ASSERT(sa->sa_len <= sizeof(sin6));
+    memset(&sin6, 0, sizeof(sin6));
+    memcpy(&sin6, sa, sa->sa_len);
+    if (memcmpzero(&sin6.sin6_addr, sizeof(sin6.sin6_addr)) != 0) {
+      return;
+    }
+  } else if (sa->sa_family != AF_UNSPEC) {
+    // We have sometimes seen the default route reported with AF_UNSPEC.
+    return;
+  }
+
+  // Determine if this is the IPv4 or IPv6 default route.
+  const struct sockaddr* dst = (const struct sockaddr*)addrlist[0].constData();
+  QAbstractSocket::NetworkLayerProtocol protocol;
+  unsigned int plen;
+  if (dst->sa_family == AF_INET) {
+    m_defaultGatewayIpv4 = addrlist[1];
+    m_defaultIfindexIpv4 = rtm->rtm_index;
+    protocol = QAbstractSocket::IPv4Protocol;
+    plen = 32;
+  } else if (dst->sa_family == AF_INET6) {
+    m_defaultGatewayIpv6 = addrlist[1];
+    m_defaultIfindexIpv6 = rtm->rtm_index;
+    protocol = QAbstractSocket::IPv6Protocol;
+    plen = 128;
+  } else {
+    return;
+  }
+
+  // Update the exclusion routes with the new default route.
+  logger.debug() << "Updating default route via" << ifname;
+  const struct sockaddr* gw = (const struct sockaddr*)addrlist[1].constData();
+  for (const QHostAddress& addr : m_exclusionRoutes) {
+    if (addr.protocol() == protocol) {
+      rtmSendRoute(RTM_ADD, addr, plen, rtm->rtm_index, gw);
+    }
+  }
 }
 
 void MacosRouteMonitor::handleIfaceInfo(const struct if_msghdr* ifm,
@@ -137,9 +190,10 @@ void MacosRouteMonitor::handleIfaceInfo(const struct if_msghdr* ifm,
   for (auto addr : addrlist) {
     list.append(addrToString(addr));
   }
-  logger.debug() << "Interface " << ifm->ifm_index
+  logger.debug() << "Interface" << ifm->ifm_index
                  << "chagned flags:" << ifm->ifm_flags
-                 << QString("addrs(%1):").arg(ifm->ifm_addrs) << list.join(" ");
+                 << QString("addrs(%1):").arg(ifm->ifm_addrs, 0, 16)
+                 << list.join(" ");
 }
 
 void MacosRouteMonitor::rtsockReady() {
@@ -159,6 +213,8 @@ void MacosRouteMonitor::rtsockReady() {
   while (rtm < end) {
     // Ensure the message fits within the buffer
     if (RTMSG_NEXT(rtm) > end) {
+      logger.debug() << "Routing message overflowed with length"
+                     << rtm->rtm_msglen;
       break;
     }
 
@@ -167,7 +223,7 @@ void MacosRouteMonitor::rtsockReady() {
     switch (rtm->rtm_type) {
       case RTM_ADD:
         message.remove(0, sizeof(struct rt_msghdr));
-        handleRtmAdd(rtm, message);
+        handleRtmUpdate(rtm, message);
         break;
       case RTM_DELETE:
         message.remove(0, sizeof(struct rt_msghdr));
@@ -175,7 +231,11 @@ void MacosRouteMonitor::rtsockReady() {
         break;
       case RTM_CHANGE:
         message.remove(0, sizeof(struct rt_msghdr));
-        handleRtmChange(rtm, message);
+        handleRtmUpdate(rtm, message);
+        break;
+      case RTM_GET:
+        message.remove(0, sizeof(struct rt_msghdr));
+        handleRtmUpdate(rtm, message);
         break;
       case RTM_IFINFO:
         message.remove(0, sizeof(struct if_msghdr));
@@ -206,10 +266,12 @@ void MacosRouteMonitor::rtmAppendAddr(struct rt_msghdr* rtm, size_t maxlen,
   }
 }
 
-bool MacosRouteMonitor::rtmSendRoute(int action, const IPAddressRange& prefix) {
+bool MacosRouteMonitor::rtmSendRoute(int action, const QHostAddress& prefix,
+                                     unsigned int plen, unsigned int ifindex,
+                                     const struct sockaddr* gateway) {
   constexpr size_t rtm_max_size = sizeof(struct rt_msghdr) +
                                   sizeof(struct sockaddr_in6) * 2 +
-                                  sizeof(struct sockaddr_dl);
+                                  sizeof(struct sockaddr_storage);
   char buf[rtm_max_size];
   struct rt_msghdr* rtm = (struct rt_msghdr*)buf;
 
@@ -217,7 +279,7 @@ bool MacosRouteMonitor::rtmSendRoute(int action, const IPAddressRange& prefix) {
   rtm->rtm_msglen = sizeof(struct rt_msghdr);
   rtm->rtm_version = RTM_VERSION;
   rtm->rtm_type = action;
-  rtm->rtm_index = if_nametoindex(qPrintable(m_ifname));
+  rtm->rtm_index = ifindex;
   rtm->rtm_flags = RTF_STATIC | RTF_UP;
   rtm->rtm_addrs = 0;
   rtm->rtm_pid = 0;
@@ -227,9 +289,9 @@ bool MacosRouteMonitor::rtmSendRoute(int action, const IPAddressRange& prefix) {
   memset(&rtm->rtm_rmx, 0, sizeof(rtm->rtm_rmx));
 
   // Append RTA_DST
-  if (prefix.type() == IPAddressRange::IPv6) {
+  if (prefix.protocol() == QAbstractSocket::IPv6Protocol) {
     struct sockaddr_in6 sin6;
-    Q_IPV6ADDR dst = QHostAddress(prefix.ipAddress()).toIPv6Address();
+    Q_IPV6ADDR dst = prefix.toIPv6Address();
     memset(&sin6, 0, sizeof(sin6));
     sin6.sin6_family = AF_INET6;
     sin6.sin6_len = sizeof(sin6);
@@ -237,32 +299,27 @@ bool MacosRouteMonitor::rtmSendRoute(int action, const IPAddressRange& prefix) {
     rtmAppendAddr(rtm, rtm_max_size, RTA_DST, &sin6);
   } else {
     struct sockaddr_in sin;
-    quint32 dst = QHostAddress(prefix.ipAddress()).toIPv4Address();
+    quint32 dst = prefix.toIPv4Address();
     memset(&sin, 0, sizeof(sin));
     sin.sin_family = AF_INET;
     sin.sin_len = sizeof(sin);
     sin.sin_addr.s_addr = htonl(dst);
     rtmAppendAddr(rtm, rtm_max_size, RTA_DST, &sin);
   }
-
+  
   // Append RTA_GATEWAY
-  if (action != RTM_DELETE) {
-    struct sockaddr_dl sdl;
-    memset(&sdl, 0, sizeof(sdl));
-    sdl.sdl_family = AF_LINK;
-    sdl.sdl_len = offsetof(struct sockaddr_dl, sdl_data) + m_ifname.length();
-    sdl.sdl_index = rtm->rtm_index;
-    sdl.sdl_type = IFT_OTHER;
-    sdl.sdl_nlen = m_ifname.length();
-    sdl.sdl_alen = 0;
-    sdl.sdl_slen = 0;
-    memcpy(&sdl.sdl_data, qPrintable(m_ifname), sdl.sdl_nlen);
-    rtmAppendAddr(rtm, rtm_max_size, RTA_GATEWAY, &sdl);
+  if (gateway != nullptr) {
+    if (gateway->sa_family == AF_INET) {
+      rtm->rtm_flags |= RTF_GATEWAY;
+    }
+    if (gateway->sa_family == AF_INET6) {
+      rtm->rtm_flags |= RTF_GATEWAY;
+    }
+    rtmAppendAddr(rtm, rtm_max_size, RTA_GATEWAY, gateway);
   }
 
   // Append RTA_NETMASK
-  int plen = prefix.range();
-  if (prefix.type() == IPAddressRange::IPv6) {
+  if (prefix.protocol() == QAbstractSocket::IPv6Protocol) {
     struct sockaddr_in6 sin6;
     memset(&sin6, 0, sizeof(sin6));
     sin6.sin6_family = AF_INET6;
@@ -272,7 +329,7 @@ bool MacosRouteMonitor::rtmSendRoute(int action, const IPAddressRange& prefix) {
       sin6.sin6_addr.s6_addr[plen / 8] = 0xFF ^ (0xFF >> (plen % 8));
     }
     rtmAppendAddr(rtm, rtm_max_size, RTA_NETMASK, &sin6);
-  } else if (prefix.type() == IPAddressRange::IPv4) {
+  } else if (prefix.protocol() == QAbstractSocket::IPv4Protocol) {
     struct sockaddr_in sin;
     memset(&sin, 0, sizeof(sin));
     sin.sin_family = AF_INET;
@@ -299,12 +356,121 @@ bool MacosRouteMonitor::rtmSendRoute(int action, const IPAddressRange& prefix) {
   return false;
 }
 
+bool MacosRouteMonitor::rtmFetchRoutes(int family) {
+  constexpr size_t rtm_max_size = sizeof(struct rt_msghdr) +
+                                  sizeof(struct sockaddr_storage) * 2;
+  char buf[rtm_max_size];
+  struct rt_msghdr* rtm = (struct rt_msghdr*)buf;
+
+  memset(rtm, 0, rtm_max_size);
+  rtm->rtm_msglen = sizeof(struct rt_msghdr);
+  rtm->rtm_version = RTM_VERSION;
+  rtm->rtm_type = RTM_GET;
+  rtm->rtm_flags = RTF_UP | RTF_GATEWAY;
+  rtm->rtm_addrs = 0;
+  rtm->rtm_pid = 0;
+  rtm->rtm_seq = m_rtseq++;
+  rtm->rtm_errno = 0;
+  rtm->rtm_inits = 0;
+  memset(&rtm->rtm_rmx, 0, sizeof(rtm->rtm_rmx));
+
+  if (family == AF_INET) {
+    struct sockaddr_in sin;
+    memset(&sin, 0, sizeof(struct sockaddr_in));
+    sin.sin_family = AF_INET;
+    sin.sin_len = sizeof(struct sockaddr_in);
+    rtmAppendAddr(rtm, rtm_max_size, RTA_DST, &sin);
+    rtmAppendAddr(rtm, rtm_max_size, RTA_NETMASK, &sin);
+  } else if (family == AF_INET6) {
+    struct sockaddr_in6 sin6;
+    memset(&sin6, 0, sizeof(struct sockaddr_in6));
+    sin6.sin6_family = AF_INET6;
+    sin6.sin6_len = sizeof(struct sockaddr_in6);
+    rtmAppendAddr(rtm, rtm_max_size, RTA_DST, &sin6);
+    rtmAppendAddr(rtm, rtm_max_size, RTA_NETMASK, &sin6);
+  } else {
+    logger.warning() << "Unsupported address family";
+    return false;
+  }
+
+  // Send the routing message into the kernel.
+  int len = write(m_rtsock, rtm, rtm->rtm_msglen);
+  if (len == rtm->rtm_msglen) {
+    return true;
+  }
+  logger.warning() << "Failed to request routing table:" << strerror(errno);
+  return false;
+}
+
 bool MacosRouteMonitor::insertRoute(const IPAddressRange& prefix) {
-  return rtmSendRoute(RTM_ADD, prefix);
+  struct sockaddr_dl datalink;
+  memset(&datalink, 0, sizeof(datalink));
+  datalink.sdl_family = AF_LINK;
+  datalink.sdl_len = offsetof(struct sockaddr_dl, sdl_data) + m_ifname.length();
+  datalink.sdl_index = m_ifindex;
+  datalink.sdl_type = IFT_OTHER;
+  datalink.sdl_nlen = m_ifname.length();
+  datalink.sdl_alen = 0;
+  datalink.sdl_slen = 0;
+  memcpy(&datalink.sdl_data, qPrintable(m_ifname), datalink.sdl_nlen);
+
+  QHostAddress addr(prefix.ipAddress());
+  return rtmSendRoute(RTM_ADD, addr, prefix.range(), m_ifindex,
+                      (const struct sockaddr*)&datalink);
 }
 
 bool MacosRouteMonitor::deleteRoute(const IPAddressRange& prefix) {
-  return rtmSendRoute(RTM_DELETE, prefix);
+  QHostAddress addr(prefix.ipAddress());
+  return rtmSendRoute(RTM_DELETE, addr, prefix.range(), m_ifindex, nullptr);
+}
+
+bool MacosRouteMonitor::addExclusionRoute(const QHostAddress& address) {
+  logger.debug() << "Adding exclusion route for" << address.toString();
+
+  if (m_exclusionRoutes.contains(address)) {
+    logger.warning() << "Exclusion route already exists";
+    return false;
+  }
+  m_exclusionRoutes.append(address);
+
+  // If the default route is known, then updte the routing table immediately.
+  if ((address.protocol() == QAbstractSocket::IPv4Protocol) &&
+      (m_defaultIfindexIpv4 != 0) && !m_defaultGatewayIpv4.isEmpty()) {
+    const struct sockaddr* gw =
+        (const struct sockaddr*)m_defaultGatewayIpv4.constData();
+    return rtmSendRoute(RTM_ADD, address, 32, m_defaultIfindexIpv4, gw);
+  }
+  if ((address.protocol() == QAbstractSocket::IPv6Protocol) &&
+      (m_defaultIfindexIpv6 != 0) && !m_defaultGatewayIpv6.isEmpty()) {
+    const struct sockaddr* gw =
+        (const struct sockaddr*)m_defaultGatewayIpv6.constData();
+    return rtmSendRoute(RTM_ADD, address, 128, m_defaultIfindexIpv6, gw);
+  }
+
+  // Otherwise, the default route isn't known yet. Do nothing.
+  return true;
+}
+
+void MacosRouteMonitor::deleteExclusionRoute(const QHostAddress& address) {
+  logger.debug() << "Deleting exclusion route for" << address.toString();
+
+  m_exclusionRoutes.removeAll(address);
+  if (address.protocol() == QAbstractSocket::IPv4Protocol) {
+    rtmSendRoute(RTM_DELETE, address, 32, m_defaultIfindexIpv4, nullptr);
+  } else if (address.protocol() == QAbstractSocket::IPv6Protocol) {
+    rtmSendRoute(RTM_DELETE, address, 128, m_defaultIfindexIpv6, nullptr);
+  }
+}
+
+void MacosRouteMonitor::flushExclusionRoutes() {
+  while (!m_exclusionRoutes.isEmpty()) {
+    QHostAddress address = m_exclusionRoutes.takeFirst();
+    if (address.protocol() == QAbstractSocket::IPv4Protocol) {
+      rtmSendRoute(RTM_DELETE, address, 32, m_defaultIfindexIpv4, nullptr);
+    } else if (address.protocol() == QAbstractSocket::IPv6Protocol) {
+      rtmSendRoute(RTM_DELETE, address, 128, m_defaultIfindexIpv6, nullptr);
+    }
+  }
 }
 
 // static
@@ -342,6 +508,9 @@ QString MacosRouteMonitor::addrToString(const struct sockaddr* sa) {
   if (sa->sa_family == AF_LINK) {
     const struct sockaddr_dl* sdl = (const struct sockaddr_dl*)sa;
     return QString(link_ntoa(sdl));
+  }
+  if (sa->sa_family == AF_UNSPEC) {
+    return QString("unspec");
   }
   return QString("unknown(af=%1)").arg(sa->sa_family);
 }

--- a/src/platforms/macos/daemon/wireguardutilsmacos.cpp
+++ b/src/platforms/macos/daemon/wireguardutilsmacos.cpp
@@ -153,6 +153,7 @@ bool WireguardUtilsMacos::updatePeer(const InterfaceConfig& config) {
   out << config.m_serverPort << "\n";
 
   out << "replace_allowed_ips=true\n";
+  out << "persistent_keepalive_interval=" << WG_KEEPALIVE_PERIOD << "\n";
   for (const IPAddressRange& ip : config.m_allowedIPAddressRanges) {
     out << "allowed_ip=" << ip.toString() << "\n";
   }

--- a/src/platforms/macos/daemon/wireguardutilsmacos.cpp
+++ b/src/platforms/macos/daemon/wireguardutilsmacos.cpp
@@ -137,7 +137,7 @@ bool WireguardUtilsMacos::updatePeer(const InterfaceConfig& config) {
   QByteArray publicKey =
       QByteArray::fromBase64(qPrintable(config.m_serverPublicKey));
 
-  // HACK: This is an sloppy way to detect entry vs. exit server.
+  // HACK: This is a sloppy way to detect entry vs. exit server.
   if (config.m_hopindex != 0) {
     m_rtmonitor->addExclusionRoute(config.m_serverIpv4AddrIn);
   }
@@ -174,7 +174,7 @@ bool WireguardUtilsMacos::deletePeer(const InterfaceConfig& config) {
   QByteArray publicKey =
       QByteArray::fromBase64(qPrintable(config.m_serverPublicKey));
 
-  // HACK: This is an sloppy way to detect entry vs. exit server.
+  // HACK: This is a sloppy way to detect entry vs. exit server.
   if (config.m_hopindex != 0) {
     m_rtmonitor->deleteExclusionRoute(config.m_serverIpv4AddrIn);
   }

--- a/src/platforms/macos/daemon/wireguardutilsmacos.cpp
+++ b/src/platforms/macos/daemon/wireguardutilsmacos.cpp
@@ -137,6 +137,11 @@ bool WireguardUtilsMacos::updatePeer(const InterfaceConfig& config) {
   QByteArray publicKey =
       QByteArray::fromBase64(qPrintable(config.m_serverPublicKey));
 
+  // HACK: This is an sloppy way to detect entry vs. exit server.
+  if (config.m_hopindex != 0) {
+    m_rtmonitor->addExclusionRoute(config.m_serverIpv4AddrIn);
+  }
+
   // Update/create the peer config
   QString message;
   QTextStream out(&message);
@@ -168,6 +173,11 @@ bool WireguardUtilsMacos::updatePeer(const InterfaceConfig& config) {
 bool WireguardUtilsMacos::deletePeer(const InterfaceConfig& config) {
   QByteArray publicKey =
       QByteArray::fromBase64(qPrintable(config.m_serverPublicKey));
+
+  // HACK: This is an sloppy way to detect entry vs. exit server.
+  if (config.m_hopindex != 0) {
+    m_rtmonitor->deleteExclusionRoute(config.m_serverIpv4AddrIn);
+  }
 
   QString message;
   QTextStream out(&message);

--- a/src/platforms/macos/daemon/wireguardutilsmacos.cpp
+++ b/src/platforms/macos/daemon/wireguardutilsmacos.cpp
@@ -165,8 +165,9 @@ bool WireguardUtilsMacos::updatePeer(const InterfaceConfig& config) {
   return (err == 0);
 }
 
-bool WireguardUtilsMacos::deletePeer(const QString& pubkey) {
-  QByteArray publicKey = QByteArray::fromBase64(qPrintable(pubkey));
+bool WireguardUtilsMacos::deletePeer(const InterfaceConfig& config) {
+  QByteArray publicKey =
+      QByteArray::fromBase64(qPrintable(config.m_serverPublicKey));
 
   QString message;
   QTextStream out(&message);

--- a/src/platforms/macos/daemon/wireguardutilsmacos.h
+++ b/src/platforms/macos/daemon/wireguardutilsmacos.h
@@ -27,7 +27,7 @@ class WireguardUtilsMacos final : public WireguardUtils {
 
   bool updatePeer(const InterfaceConfig& config) override;
   bool deletePeer(const QString& pubkey) override;
-  peerStatus getPeerStatus(const QString& pubkey) override;
+  QList<PeerStatus> getPeerStatus() override;
 
   bool updateRoutePrefix(const IPAddressRange& prefix, int hopindex) override;
   bool deleteRoutePrefix(const IPAddressRange& prefix, int hopindex) override;

--- a/src/platforms/macos/daemon/wireguardutilsmacos.h
+++ b/src/platforms/macos/daemon/wireguardutilsmacos.h
@@ -26,7 +26,7 @@ class WireguardUtilsMacos final : public WireguardUtils {
   bool deleteInterface() override;
 
   bool updatePeer(const InterfaceConfig& config) override;
-  bool deletePeer(const QString& pubkey) override;
+  bool deletePeer(const InterfaceConfig& config) override;
   QList<PeerStatus> getPeerStatus() override;
 
   bool updateRoutePrefix(const IPAddressRange& prefix, int hopindex) override;

--- a/src/platforms/windows/daemon/windowsdaemon.cpp
+++ b/src/platforms/windows/daemon/windowsdaemon.cpp
@@ -70,28 +70,6 @@ bool WindowsDaemon::run(Op op, const InterfaceConfig& config) {
   return true;
 }
 
-QByteArray WindowsDaemon::getStatus() {
-  logger.debug() << "Status request";
-
-  bool connected = m_connections.contains(0);
-  QJsonObject obj;
-  obj.insert("type", "status");
-  obj.insert("connected", connected);
-
-  if (connected) {
-    const ConnectionState& state = m_connections.value(0).m_config;
-    WireguardUtilsWindows::peerStatus status =
-        m_wgutils->getPeerStatus(state.m_config.m_serverPublicKey);
-    obj.insert("serverIpv4Gateway", state.m_config.m_serverIpv4Gateway);
-    obj.insert("deviceIpv4Address", state.m_config.m_deviceIpv4Address);
-    obj.insert("date", state.m_date.toString());
-    obj.insert("txBytes", QJsonValue(status.txBytes));
-    obj.insert("rxBytes", QJsonValue(status.rxBytes));
-  }
-
-  return QJsonDocument(obj).toJson(QJsonDocument::Compact);
-}
-
 void WindowsDaemon::monitorBackendFailure() {
   logger.warning() << "Tunnel service is down";
 

--- a/src/platforms/windows/daemon/windowsdaemon.h
+++ b/src/platforms/windows/daemon/windowsdaemon.h
@@ -20,7 +20,6 @@ class WindowsDaemon final : public Daemon {
   WindowsDaemon();
   ~WindowsDaemon();
 
-  QByteArray getStatus() override;
   void prepareActivation(const InterfaceConfig& config) override;
 
  protected:

--- a/src/platforms/windows/daemon/windowsroutemonitor.cpp
+++ b/src/platforms/windows/daemon/windowsroutemonitor.cpp
@@ -36,7 +36,7 @@ static void routeChangeCallback(PVOID context, PMIB_IPFORWARD_ROW2 row,
 }
 
 // Perform prefix matching comparison on IP addresses in host order.
-static int prefixcmp(const void *a, const void *b, size_t bits) {
+static int prefixcmp(const void* a, const void* b, size_t bits) {
   size_t bytes = bits / 8;
   if (bytes > 0) {
     int diff = memcmp(a, b, bytes);
@@ -69,20 +69,21 @@ WindowsRouteMonitor::~WindowsRouteMonitor() {
 }
 
 void WindowsRouteMonitor::updateExclusionRoute(MIB_IPFORWARD_ROW2* data,
-                                               void *ptable) {
+                                               void* ptable) {
   PMIB_IPFORWARD_TABLE2 table = (PMIB_IPFORWARD_TABLE2)ptable;
   SOCKADDR_INET nexthop;
   quint64 bestLuid = 0;
   int bestMatch = -1;
 
   for (ULONG i = 0; i < table->NumEntries; i++) {
-    MIB_IPFORWARD_ROW2 *row = &table->Table[i];
+    MIB_IPFORWARD_ROW2* row = &table->Table[i];
     // Ignore routes into the VPN interface.
     if (row->InterfaceLuid.Value == m_luid) {
       continue;
     }
     // Ignore host routes, and shorter potential matches.
-    if (row->DestinationPrefix.PrefixLength >= data->DestinationPrefix.PrefixLength) {
+    if (row->DestinationPrefix.PrefixLength >=
+        data->DestinationPrefix.PrefixLength) {
       continue;
     }
     if (row->DestinationPrefix.PrefixLength < bestMatch) {
@@ -139,7 +140,7 @@ void WindowsRouteMonitor::updateExclusionRoute(MIB_IPFORWARD_ROW2* data,
 
 bool WindowsRouteMonitor::addExclusionRoute(const QHostAddress& address) {
   logger.debug() << "Adding exclusion route for" << address.toString();
-  
+
   if (m_exclusionRoutes.contains(address)) {
     logger.warning() << "Exclusion route already exists";
     return false;

--- a/src/platforms/windows/daemon/windowsroutemonitor.cpp
+++ b/src/platforms/windows/daemon/windowsroutemonitor.cpp
@@ -1,0 +1,244 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "windowsroutemonitor.h"
+#include "leakdetector.h"
+#include "logger.h"
+
+namespace {
+Logger logger(LOG_WINDOWS, "WindowsRouteMonitor");
+};  // namespace
+
+// Called by the kernel on route changes - perform some basic filtering and
+// invoke the routeChanged slot to do the real work.
+static void routeChangeCallback(PVOID context, PMIB_IPFORWARD_ROW2 row,
+                                MIB_NOTIFICATION_TYPE type) {
+  WindowsRouteMonitor* monitor = (WindowsRouteMonitor*)context;
+  Q_UNUSED(type);
+
+  // Ignore host route changes, and unsupported protocols.
+  if (row->DestinationPrefix.Prefix.si_family == AF_INET6) {
+    if (row->DestinationPrefix.PrefixLength >= 128) {
+      return;
+    }
+  } else if (row->DestinationPrefix.Prefix.si_family == AF_INET) {
+    if (row->DestinationPrefix.PrefixLength >= 32) {
+      return;
+    }
+  } else {
+    return;
+  }
+
+  if (monitor->getLuid() != row->InterfaceLuid.Value) {
+    QMetaObject::invokeMethod(monitor, "routeChanged", Qt::QueuedConnection);
+  }
+}
+
+// Perform prefix matching comparison on IP addresses in host order.
+static int prefixcmp(const void *a, const void *b, size_t bits) {
+  size_t bytes = bits / 8;
+  if (bytes > 0) {
+    int diff = memcmp(a, b, bytes);
+    if (diff != 0) {
+      return diff;
+    }
+  }
+
+  if (bits % 8) {
+    quint8 avalue = *((const quint8*)a + bytes) >> (8 - bits % 8);
+    quint8 bvalue = *((const quint8*)b + bytes) >> (8 - bits % 8);
+    return avalue - bvalue;
+  }
+
+  return 0;
+}
+
+WindowsRouteMonitor::WindowsRouteMonitor(QObject* parent) : QObject(parent) {
+  MVPN_COUNT_CTOR(WindowsRouteMonitor);
+  logger.debug() << "WindowsRouteMonitor created.";
+
+  NotifyRouteChange2(AF_INET, routeChangeCallback, this, FALSE, &m_routeHandle);
+}
+
+WindowsRouteMonitor::~WindowsRouteMonitor() {
+  MVPN_COUNT_DTOR(WindowsRouteMonitor);
+  CancelMibChangeNotify2(m_routeHandle);
+  flushExclusionRoutes();
+  logger.debug() << "WindowsRouteMonitor destroyed.";
+}
+
+void WindowsRouteMonitor::updateExclusionRoute(MIB_IPFORWARD_ROW2* data,
+                                               void *ptable) {
+  PMIB_IPFORWARD_TABLE2 table = (PMIB_IPFORWARD_TABLE2)ptable;
+  SOCKADDR_INET nexthop;
+  quint64 bestLuid = 0;
+  int bestMatch = -1;
+
+  for (ULONG i = 0; i < table->NumEntries; i++) {
+    MIB_IPFORWARD_ROW2 *row = &table->Table[i];
+    // Ignore routes into the VPN interface.
+    if (row->InterfaceLuid.Value == m_luid) {
+      continue;
+    }
+    // Ignore host routes, and shorter potential matches.
+    if (row->DestinationPrefix.PrefixLength >= data->DestinationPrefix.PrefixLength) {
+      continue;
+    }
+    if (row->DestinationPrefix.PrefixLength < bestMatch) {
+      continue;
+    }
+
+    // Check if the routing table entry matches the destination.
+    if (data->DestinationPrefix.Prefix.si_family == AF_INET6) {
+      if (row->DestinationPrefix.Prefix.Ipv6.sin6_family != AF_INET6) {
+        continue;
+      }
+      if (prefixcmp(&data->DestinationPrefix.Prefix.Ipv6.sin6_addr,
+                    &row->DestinationPrefix.Prefix.Ipv6.sin6_addr,
+                    row->DestinationPrefix.PrefixLength) != 0) {
+        continue;
+      }
+    } else if (data->DestinationPrefix.Prefix.si_family == AF_INET) {
+      if (row->DestinationPrefix.Prefix.Ipv4.sin_family != AF_INET) {
+        continue;
+      }
+      if (prefixcmp(&data->DestinationPrefix.Prefix.Ipv4.sin_addr,
+                    &row->DestinationPrefix.Prefix.Ipv4.sin_addr,
+                    row->DestinationPrefix.PrefixLength) != 0) {
+        continue;
+      }
+    } else {
+      // Unsupported destination address family.
+      continue;
+    }
+
+    // If we got here, then this is the longest prefix match so far.
+    memcpy(&nexthop, &row->NextHop, sizeof(SOCKADDR_INET));
+    bestLuid = row->InterfaceLuid.Value;
+    bestMatch = row->DestinationPrefix.PrefixLength;
+  }
+
+  // If neither the interface nor next-hop have changed, then do nothing.
+  if ((data->InterfaceLuid.Value) == bestLuid &&
+      memcmp(&nexthop, &data->NextHop, sizeof(SOCKADDR_INET)) == 0) {
+    return;
+  }
+
+  // Update the routing table entry.
+  if (data->InterfaceLuid.Value != 0) {
+    DWORD result = DeleteIpForwardEntry2(data);
+    if ((result != NO_ERROR) && (result != ERROR_NOT_FOUND)) {
+      logger.error() << "Failed to delete route:" << result;
+    }
+  }
+  data->InterfaceLuid.Value = bestLuid;
+  memcpy(&data->NextHop, &nexthop, sizeof(SOCKADDR_INET));
+  CreateIpForwardEntry2(data);
+}
+
+bool WindowsRouteMonitor::addExclusionRoute(const QHostAddress& address) {
+  logger.debug() << "Adding exclusion route for" << address.toString();
+  
+  if (m_exclusionRoutes.contains(address)) {
+    logger.warning() << "Exclusion route already exists";
+    return false;
+  }
+
+  // Allocate and initialize the MIB routing table row.
+  MIB_IPFORWARD_ROW2* data = new MIB_IPFORWARD_ROW2;
+  InitializeIpForwardEntry(data);
+  if (address.protocol() == QAbstractSocket::IPv6Protocol) {
+    Q_IPV6ADDR buf = address.toIPv6Address();
+
+    memcpy(&data->DestinationPrefix.Prefix.Ipv6.sin6_addr, &buf, sizeof(buf));
+    data->DestinationPrefix.Prefix.Ipv6.sin6_family = AF_INET6;
+    data->DestinationPrefix.PrefixLength = 128;
+  } else {
+    quint32 buf = address.toIPv4Address();
+
+    data->DestinationPrefix.Prefix.Ipv4.sin_addr.s_addr = htonl(buf);
+    data->DestinationPrefix.Prefix.Ipv4.sin_family = AF_INET;
+    data->DestinationPrefix.PrefixLength = 32;
+  }
+  data->NextHop.si_family = data->DestinationPrefix.Prefix.si_family;
+
+  // Set the rest of the flags for a static route.
+  data->ValidLifetime = 0xffffffff;
+  data->PreferredLifetime = 0xffffffff;
+  data->Metric = 0;
+  data->Protocol = MIB_IPPROTO_NETMGMT;
+  data->Loopback = false;
+  data->AutoconfigureAddress = false;
+  data->Publish = false;
+  data->Immortal = false;
+  data->Age = 0;
+
+  PMIB_IPFORWARD_TABLE2 table;
+  int family;
+  if (address.protocol() == QAbstractSocket::IPv6Protocol) {
+    family = AF_INET6;
+  } else {
+    family = AF_INET;
+  }
+
+  DWORD result = GetIpForwardTable2(family, &table);
+  if (result != NO_ERROR) {
+    logger.error() << "Failed to fetch routing table:" << result;
+    delete data;
+    return false;
+  }
+  updateExclusionRoute(data, table);
+  FreeMibTable(table);
+
+  m_exclusionRoutes[address] = data;
+  return true;
+}
+
+void WindowsRouteMonitor::deleteExclusionRoute(const QHostAddress& address) {
+  logger.debug() << "Deleting exclusion route for" << address.toString();
+
+  for (;;) {
+    MIB_IPFORWARD_ROW2* data = m_exclusionRoutes.take(address);
+    if (data == nullptr) {
+      break;
+    }
+
+    DWORD result = DeleteIpForwardEntry2(data);
+    if ((result != ERROR_NOT_FOUND) && (result != NO_ERROR)) {
+      logger.error() << "Failed to delete route to" << address.toString()
+                     << "result:" << result;
+    }
+    delete data;
+  }
+}
+
+void WindowsRouteMonitor::flushExclusionRoutes() {
+  for (auto i = m_exclusionRoutes.begin(); i != m_exclusionRoutes.end(); i++) {
+    MIB_IPFORWARD_ROW2* data = i.value();
+    DWORD result = DeleteIpForwardEntry2(data);
+    if ((result != ERROR_NOT_FOUND) && (result != NO_ERROR)) {
+      logger.error() << "Failed to delete route to" << i.key().toString()
+                     << "result:" << result;
+    }
+    delete data;
+  }
+  m_exclusionRoutes.clear();
+}
+
+void WindowsRouteMonitor::routeChanged() {
+  logger.debug() << "Routes changed";
+
+  PMIB_IPFORWARD_TABLE2 table;
+  DWORD result = GetIpForwardTable2(AF_UNSPEC, &table);
+  if (result != NO_ERROR) {
+    logger.error() << "Failed to fetch routing table:" << result;
+    return;
+  }
+
+  for (MIB_IPFORWARD_ROW2* data : m_exclusionRoutes) {
+    updateExclusionRoute(data, table);
+  }
+
+  FreeMibTable(table);
+}

--- a/src/platforms/windows/daemon/windowsroutemonitor.h
+++ b/src/platforms/windows/daemon/windowsroutemonitor.h
@@ -1,0 +1,51 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef WINDOWSROUTEMONITOR_H
+#define WINDOWSROUTEMONITOR_H
+
+#include <QHostAddress>
+#include <QObject>
+
+#include <winsock2.h>
+#include <WS2tcpip.h>
+#include <windows.h>
+#include <ws2ipdef.h>
+#include <iphlpapi.h>
+
+class WindowsRouteMonitor final : public QObject {
+  Q_OBJECT
+
+ public:
+  WindowsRouteMonitor(QObject* parent);
+  ~WindowsRouteMonitor();
+
+  bool addExclusionRoute(const QHostAddress& address);
+  bool addExclusionRoute(const QString& address) { 
+    return addExclusionRoute(QHostAddress(address));
+  }
+
+  void deleteExclusionRoute(const QHostAddress& address);
+  void deleteExclusionRoute(const QString& address) {
+    deleteExclusionRoute(QHostAddress(address));
+  }
+
+  void flushExclusionRoutes();
+
+  void setLuid(quint64 luid) { m_luid = luid; }
+  quint64 getLuid() { return m_luid; }
+
+ public slots:
+  void routeChanged();
+
+ private:
+  void updateExclusionRoute(MIB_IPFORWARD_ROW2* data, void* table);
+
+  QHash<QHostAddress, MIB_IPFORWARD_ROW2*> m_exclusionRoutes;
+
+  quint64 m_luid = 0;
+  HANDLE m_routeHandle = INVALID_HANDLE_VALUE;
+};
+
+#endif /* WINDOWSROUTEMONITOR_H */

--- a/src/platforms/windows/daemon/windowsroutemonitor.h
+++ b/src/platforms/windows/daemon/windowsroutemonitor.h
@@ -22,7 +22,7 @@ class WindowsRouteMonitor final : public QObject {
   ~WindowsRouteMonitor();
 
   bool addExclusionRoute(const QHostAddress& address);
-  bool addExclusionRoute(const QString& address) { 
+  bool addExclusionRoute(const QString& address) {
     return addExclusionRoute(QHostAddress(address));
   }
 

--- a/src/platforms/windows/daemon/wireguardutilswindows.cpp
+++ b/src/platforms/windows/daemon/wireguardutilswindows.cpp
@@ -26,7 +26,7 @@ Logger logger(LOG_WINDOWS, "WireguardUtilsWindows");
 };  // namespace
 
 WireguardUtilsWindows::WireguardUtilsWindows(QObject* parent)
-    : WireguardUtils(parent), m_tunnel(this) {
+    : WireguardUtils(parent), m_tunnel(this), m_routeMonitor(this) {
   MVPN_COUNT_CTOR(WireguardUtilsWindows);
   logger.debug() << "WireguardUtilsWindows created.";
 
@@ -112,6 +112,7 @@ bool WireguardUtilsWindows::addInterface(const InterfaceConfig& config) {
     return false;
   }
   m_luid = luid.Value;
+  m_routeMonitor.setLuid(luid.Value);
 
   // Enable the windows firewall
   NET_IFINDEX ifindex;
@@ -132,8 +133,15 @@ bool WireguardUtilsWindows::updatePeer(const InterfaceConfig& config) {
   QByteArray publicKey =
       QByteArray::fromBase64(qPrintable(config.m_serverPublicKey));
 
-  // Enable the windows firewall for this peer.
+  // Enable the windows firewall and routes for this peer.
   WindowsFirewall::instance()->enablePeerTraffic(config);
+  if (config.m_hopindex != 0) {
+    // HACK: This is an sloppy way to detect entry vs. exit server.
+    m_routeMonitor.addExclusionRoute(config.m_serverIpv4AddrIn);
+  }
+
+  logger.debug() << "Updating peer" << printableKey(config.m_serverPublicKey)
+                 << "via" <<  config.m_serverIpv4AddrIn;
 
   // Update/create the peer config
   QString message;
@@ -161,11 +169,16 @@ bool WireguardUtilsWindows::updatePeer(const InterfaceConfig& config) {
   return true;
 }
 
-bool WireguardUtilsWindows::deletePeer(const QString& pubkey) {
-  QByteArray publicKey = QByteArray::fromBase64(qPrintable(pubkey));
+bool WireguardUtilsWindows::deletePeer(const InterfaceConfig& config) {
+  QByteArray publicKey =
+      QByteArray::fromBase64(qPrintable(config.m_serverPublicKey));
 
-  // Disable the windows firewall for this peer.
-  WindowsFirewall::instance()->disablePeerTraffic(pubkey);
+  // Disable the windows firewall and routes for this peer.
+  WindowsFirewall::instance()->disablePeerTraffic(config.m_serverPublicKey);
+  if (config.m_hopindex != 0) {
+    // HACK: This is an sloppy way to detect entry vs. exit server.
+    m_routeMonitor.deleteExclusionRoute(config.m_serverIpv4AddrIn);
+  }
 
   QString message;
   QTextStream out(&message);

--- a/src/platforms/windows/daemon/wireguardutilswindows.cpp
+++ b/src/platforms/windows/daemon/wireguardutilswindows.cpp
@@ -141,7 +141,7 @@ bool WireguardUtilsWindows::updatePeer(const InterfaceConfig& config) {
   }
 
   logger.debug() << "Updating peer" << printableKey(config.m_serverPublicKey)
-                 << "via" <<  config.m_serverIpv4AddrIn;
+                 << "via" << config.m_serverIpv4AddrIn;
 
   // Update/create the peer config
   QString message;

--- a/src/platforms/windows/daemon/wireguardutilswindows.cpp
+++ b/src/platforms/windows/daemon/wireguardutilswindows.cpp
@@ -151,6 +151,7 @@ bool WireguardUtilsWindows::updatePeer(const InterfaceConfig& config) {
   out << config.m_serverPort << "\n";
 
   out << "replace_allowed_ips=true\n";
+  out << "persistent_keepalive_interval=" << WG_KEEPALIVE_PERIOD << "\n";
   for (const IPAddressRange& ip : config.m_allowedIPAddressRanges) {
     out << "allowed_ip=" << ip.toString() << "\n";
   }

--- a/src/platforms/windows/daemon/wireguardutilswindows.cpp
+++ b/src/platforms/windows/daemon/wireguardutilswindows.cpp
@@ -136,7 +136,7 @@ bool WireguardUtilsWindows::updatePeer(const InterfaceConfig& config) {
   // Enable the windows firewall and routes for this peer.
   WindowsFirewall::instance()->enablePeerTraffic(config);
   if (config.m_hopindex != 0) {
-    // HACK: This is an sloppy way to detect entry vs. exit server.
+    // HACK: This is a sloppy way to detect entry vs. exit server.
     m_routeMonitor.addExclusionRoute(config.m_serverIpv4AddrIn);
   }
 
@@ -176,7 +176,7 @@ bool WireguardUtilsWindows::deletePeer(const InterfaceConfig& config) {
   // Disable the windows firewall and routes for this peer.
   WindowsFirewall::instance()->disablePeerTraffic(config.m_serverPublicKey);
   if (config.m_hopindex != 0) {
-    // HACK: This is an sloppy way to detect entry vs. exit server.
+    // HACK: This is a sloppy way to detect entry vs. exit server.
     m_routeMonitor.deleteExclusionRoute(config.m_serverIpv4AddrIn);
   }
 

--- a/src/platforms/windows/daemon/wireguardutilswindows.h
+++ b/src/platforms/windows/daemon/wireguardutilswindows.h
@@ -24,7 +24,7 @@ class WireguardUtilsWindows final : public WireguardUtils {
 
   bool updatePeer(const InterfaceConfig& config) override;
   bool deletePeer(const QString& pubkey) override;
-  peerStatus getPeerStatus(const QString& pubkey) override;
+  QList<PeerStatus> getPeerStatus() override;
 
   bool updateRoutePrefix(const IPAddressRange& prefix, int hopindex) override;
   bool deleteRoutePrefix(const IPAddressRange& prefix, int hopindex) override;

--- a/src/platforms/windows/daemon/wireguardutilswindows.h
+++ b/src/platforms/windows/daemon/wireguardutilswindows.h
@@ -6,8 +6,11 @@
 #define WIREGUARDUTILSWINDOWS_H
 
 #include "daemon/wireguardutils.h"
+#include "windowsroutemonitor.h"
 #include "windowstunnelservice.h"
 
+#include <windows.h>
+#include <QHostAddress>
 #include <QObject>
 
 class WireguardUtilsWindows final : public WireguardUtils {
@@ -23,7 +26,7 @@ class WireguardUtilsWindows final : public WireguardUtils {
   bool deleteInterface() override;
 
   bool updatePeer(const InterfaceConfig& config) override;
-  bool deletePeer(const QString& pubkey) override;
+  bool deletePeer(const InterfaceConfig& config) override;
   QList<PeerStatus> getPeerStatus() override;
 
   bool updateRoutePrefix(const IPAddressRange& prefix, int hopindex) override;
@@ -37,6 +40,7 @@ class WireguardUtilsWindows final : public WireguardUtils {
 
   quint64 m_luid = 0;
   WindowsTunnelService m_tunnel;
+  WindowsRouteMonitor m_routeMonitor;
 };
 
 #endif  // WIREGUARDUTILSWINDOWS_H

--- a/src/src.pro
+++ b/src/src.pro
@@ -852,6 +852,7 @@ else:win* {
         platforms/windows/daemon/windowsdaemon.cpp \
         platforms/windows/daemon/windowsdaemonserver.cpp \
         platforms/windows/daemon/windowsdaemontunnel.cpp \
+        platforms/windows/daemon/windowsroutemonitor.cpp \
         platforms/windows/daemon/windowstunnellogger.cpp \
         platforms/windows/daemon/windowstunnelservice.cpp \
         platforms/windows/daemon/wireguardutilswindows.cpp \
@@ -885,6 +886,7 @@ else:win* {
         platforms/windows/daemon/windowsdaemon.h \
         platforms/windows/daemon/windowsdaemonserver.h \
         platforms/windows/daemon/windowsdaemontunnel.h \
+        platforms/windows/daemon/windowsroutemonitor.h \
         platforms/windows/daemon/windowstunnellogger.h \
         platforms/windows/daemon/windowstunnelservice.h \
         platforms/windows/daemon/wireguardutilswindows.h \


### PR DESCRIPTION
This attempts to make the activation and server switch of a multihop connection a bit more reliable by waiting for each peer to come up before starting the next one. This also enables us to get feedback on the individual servers being used and makes the procedure a bit more reliable.

In the process of testing this, it was discovered that we have a race condition when switching entry servers. This occurs because the routes to the entry server are set up by carefully excluding them from the allowed IPs of the exit server, but during a server switch we find ourselves in the situation where we are switching the entry server while still using the old exit server's allowed IPs. As a resolution to this problem, we introduce route monitoring to the desktop platforms, and use it to bind the entry server's IP address to the best non-VPN interface for reaching the internet.

This route monitoring is extremely close to what was envisioned for #1527 but I would like to address that issue in a follow up PR that also cleans up the hacks used to detect entry vs. exit servers in the daemon.

Closes: #1585