### PR TITLE
Remove line that sets the build system to legacy

### DIFF
--- a/ci_scripts/ci_post_clone.sh
+++ b/ci_scripts/ci_post_clone.sh
@@ -54,18 +54,6 @@ EOF
 
 ./scripts/apple_compile.sh ios
 
-# use New Build System instead of legacy build system
-cat > ./MozillaVPN.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings << EOF
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-  <dict>
-    <key>IDEWorkspaceSharedSettings_AutocreateContextsIfNeeded</key>
-    <false/>
-  </dict>
-</plist>
-EOF
-
 # build Qt resources
 # XCode Cloud has some problem with dependencies and timing therefore we have to
 # build Qt before we call xcodebuild

--- a/scripts/apple_compile.sh
+++ b/scripts/apple_compile.sh
@@ -223,6 +223,12 @@ print Y "Patching the xcode project..."
 ruby scripts/xcode_patcher.rb "MozillaVPN.xcodeproj" "$SHORTVERSION" "$FULLVERSION" "$OSRUBY" "$NETWORKEXTENSION" "$ADJUST_SDK_TOKEN" || die "Failed to merge xcode with wireguard"
 print G "done."
 
+
+if command -v "sed" &>/dev/null; then
+  sed -i '' '/<key>BuildSystemType<\/key>/d' MozillaVPN.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+  sed -i '' '/<string>Original<\/string>/d' MozillaVPN.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+fi
+
 print Y "Opening in XCode..."
 open MozillaVPN.xcodeproj
 print G "All done!"


### PR DESCRIPTION
This PR removes the lines that set the build system to legacy from the `xcsettings` file. 
We have to do it this way since `Xcodeproj` does not allow us to change those files. 

Due to this change we can remove the part of the ci_scripts for iOS that were doing this. 