### PR TITLE
Move address exclusion support into the daemon

### DIFF
--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -765,18 +765,6 @@ QStringList Controller::getExcludedAddresses(const QList<Server>& serverList) {
     list.append(dns);
   }
 
-  // It's not clear if this is really needed for the Android platform, but
-  // the Controller on the desktop platforms sorts this out using the server
-  // hop list, and iOS doesn't need to explicitly exclude the entry servers.
-#ifdef MVPN_ANDROID
-  const Server& entryServer = serverList.last();
-  // filtering out the ingress server's public IPv4 and IPv6 addresses.
-  logger.debug() << "Exclude the entry server:" << entryServer.ipv4AddrIn();
-  list.append(entryServer.ipv4AddrIn());
-  logger.debug() << "Exclude the entry server:" << entryServer.ipv6AddrIn();
-  list.append(entryServer.ipv6AddrIn());
-#endif
-
   return list;
 }
 

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -231,7 +231,8 @@ void Controller::activateInternal() {
 
   Q_ASSERT(m_impl);
   m_impl->activate(serverList, device, vpn->keys(),
-                   getAllowedIPAddressRanges(serverList), vpnDisabledApps, dns,
+                   getAllowedIPAddressRanges(serverList),
+                   getExcludedAddresses(serverList), vpnDisabledApps, dns,
                    stateToReason(m_state));
 }
 
@@ -295,7 +296,8 @@ bool Controller::silentSwitchServers() {
 
   Q_ASSERT(m_impl);
   m_impl->activate(serverList, device, vpn->keys(),
-                   getAllowedIPAddressRanges(serverList), vpnDisabledApps, dns,
+                   getAllowedIPAddressRanges(serverList),
+                   getExcludedAddresses(serverList), vpnDisabledApps, dns,
                    stateToReason(StateSwitching));
   return true;
 }
@@ -681,7 +683,7 @@ void Controller::statusUpdated(const QString& serverIpv4Gateway,
 
 QList<IPAddressRange> Controller::getAllowedIPAddressRanges(
     const QList<Server>& serverList) {
-  logger.debug() << "Computing the allowed ip addresses";
+  logger.debug() << "Computing the allowed IP addresses";
 
   QList<IPAddress> excludeIPv4s;
   QList<IPAddress> excludeIPv6s;
@@ -689,20 +691,6 @@ QList<IPAddressRange> Controller::getAllowedIPAddressRanges(
   // ingress node to the network of wireguard servers, and must not be
   // routed through the VPN.
   const Server& server = serverList.last();
-
-  // filtering out the captive portal endpoint
-  if (FeatureCaptivePortal::instance()->isSupported() &&
-      SettingsHolder::instance()->captivePortalAlert()) {
-    CaptivePortal* captivePortal = MozillaVPN::instance()->captivePortal();
-
-    const QStringList& captivePortalIpv4Addresses =
-        captivePortal->ipv4Addresses();
-
-    for (const QString& address : captivePortalIpv4Addresses) {
-      logger.debug() << "Filtering out the captive portal address" << address;
-      excludeIPv4s.append(IPAddress::create(address));
-    }
-  }
 
   // filtering out the RFC1918 local area network
   if (FeatureLocalAreaAccess::instance()->isSupported() &&
@@ -717,12 +705,6 @@ QList<IPAddressRange> Controller::getAllowedIPAddressRanges(
     excludeIPv4s.append(RFC1112::ipv4MulticastAddressBlock());
     excludeIPv6s.append(RFC4291::ipv6MulticastAddressBlock());
   }
-  if (DNSHelper::shouldExcludeDNS()) {
-    auto dns = DNSHelper::getDNS(server.ipv4Gateway());
-    // Filter out the Custom DNS Server, if the user has set one.
-    logger.debug() << "Filtering out the DNS address" << dns;
-    excludeIPv4s.append(IPAddress::create(dns));
-  }
 
   QList<IPAddressRange> list;
 
@@ -733,14 +715,9 @@ QList<IPAddressRange> Controller::getAllowedIPAddressRanges(
   logger.debug() << "Catch all IPv6";
   list.append(IPAddressRange("::0", 0, IPAddressRange::IPv6));
 #else
-  // filtering out the ingress server's public IPv4 and IPv6 addresses.
-  logger.debug() << "Exclude the ingress server:" << server.ipv4AddrIn();
-  excludeIPv4s.append(IPAddress::create(server.ipv4AddrIn()));
+  // Allow access to the internal gateway addresses.
   logger.debug() << "Allow the ingress server:" << server.ipv4Gateway();
   list.append(IPAddressRange(server.ipv4Gateway(), 32, IPAddressRange::IPv4));
-
-  logger.debug() << "Exclude the ingress server:" << server.ipv6AddrIn();
-  excludeIPv6s.append(IPAddress::create(server.ipv6AddrIn()));
   logger.debug() << "Allow the ingress server:" << server.ipv6Gateway();
   list.append(IPAddressRange(server.ipv6Gateway(), 128, IPAddressRange::IPv6));
 
@@ -756,6 +733,48 @@ QList<IPAddressRange> Controller::getAllowedIPAddressRanges(
   QList<IPAddress> allowedIPv6s{IPAddress::create("::/0")};
   allowedIPv6s = IPAddress::excludeAddresses(allowedIPv6s, excludeIPv6s);
   list.append(IPAddressRange::fromIPAddressList(allowedIPv6s));
+#endif
+
+  return list;
+}
+
+QStringList Controller::getExcludedAddresses(const QList<Server>& serverList) {
+  logger.debug() << "Computing the excluded IP addresses";
+
+  QStringList list;
+
+  // filtering out the captive portal endpoint
+  if (FeatureCaptivePortal::instance()->isSupported() &&
+      SettingsHolder::instance()->captivePortalAlert()) {
+    CaptivePortal* captivePortal = MozillaVPN::instance()->captivePortal();
+
+    for (const QString& address : captivePortal->ipv4Addresses()) {
+      logger.debug() << "Filtering out the captive portal address:" << address;
+      list.append(address);
+    }
+    for (const QString& address : captivePortal->ipv6Addresses()) {
+      logger.debug() << "Filtering out the captive portal address:" << address;
+      list.append(address);
+    }
+  }
+
+  // Filter out the Custom DNS Server, if the user has set one.
+  if (DNSHelper::shouldExcludeDNS()) {
+    auto dns = DNSHelper::getDNS(serverList.last().ipv4Gateway());
+    logger.debug() << "Filtering out the DNS address:" << dns;
+    list.append(dns);
+  }
+
+  // It's not clear if this is really needed for the Android platform, but
+  // the Controller on the desktop platforms sorts this out using the server
+  // hop list, and iOS doesn't need to explicitly exclude the entry servers.
+#ifdef MVPN_ANDROID
+  const Server& entryServer = serverList.last();
+  // filtering out the ingress server's public IPv4 and IPv6 addresses.
+  logger.debug() << "Exclude the entry server:" << entryServer.ipv4AddrIn();
+  list.append(entryServer.ipv4AddrIn());
+  logger.debug() << "Exclude the entry server:" << entryServer.ipv6AddrIn();
+  list.append(entryServer.ipv6AddrIn());
 #endif
 
   return list;

--- a/src/controller.h
+++ b/src/controller.h
@@ -129,6 +129,7 @@ class Controller final : public QObject {
 
   bool processNextStep();
   QList<IPAddressRange> getAllowedIPAddressRanges(const QList<Server>& servers);
+  QStringList getExcludedAddresses(const QList<Server>& serverList);
 
   void activateInternal();
 

--- a/src/controllerimpl.h
+++ b/src/controllerimpl.h
@@ -49,7 +49,8 @@ class ControllerImpl : public QObject {
   virtual void activate(const QList<Server>& serverList, const Device* device,
                         const Keys* keys,
                         const QList<IPAddressRange>& allowedIPAddressRanges,
-                        const QList<QString>& vpnDisabledApps,
+                        const QStringList& excludedAddresses,
+                        const QStringList& vpnDisabledApps,
                         const QHostAddress& dnsServer, Reason Reason) = 0;
 
   // This method terminates the VPN tunnel. The VPN client is in

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -59,6 +59,9 @@ class Daemon : public QObject {
   virtual bool supportDnsUtils() const { return false; }
   virtual DnsUtils* dnsutils() { return nullptr; }
 
+  static bool parseStringList(const QJsonObject& obj, const QString& name,
+                              QStringList& list);
+
   void checkHandshake();
 
   class ConnectionState {

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -72,6 +72,7 @@ class Daemon : public QObject {
     InterfaceConfig m_config;
   };
   QMap<int, ConnectionState> m_connections;
+  QHash<QHostAddress, int> m_excludedAddrSet;
   QTimer m_handshakeTimer;
 };
 

--- a/src/daemon/interfaceconfig.h
+++ b/src/daemon/interfaceconfig.h
@@ -23,7 +23,8 @@ struct InterfaceConfig {
   QString m_dnsServer;
   int m_serverPort = 0;
   QList<IPAddressRange> m_allowedIPAddressRanges;
-  QList<QString> m_vpnDisabledApps;
+  QStringList m_excludedAddresses;
+  QStringList m_vpnDisabledApps;
 };
 
 #endif  // INTERFACECONFIG_H

--- a/src/daemon/wireguardutils.h
+++ b/src/daemon/wireguardutils.h
@@ -7,6 +7,7 @@
 
 #include "interfaceconfig.h"
 
+#include <QHostAddress>
 #include <QObject>
 #include <QStringList>
 #include <QCoreApplication>
@@ -44,6 +45,9 @@ class WireguardUtils : public QObject {
                                  int hopindex) = 0;
   virtual bool deleteRoutePrefix(const IPAddressRange& prefix,
                                  int hopindex) = 0;
+
+  virtual bool addExclusionRoute(const QHostAddress& address) = 0;
+  virtual bool deleteExclusionRoute(const QHostAddress& address) = 0;
 
   // static
   static QString printableKey(const QString& pubkey) {

--- a/src/localsocketcontroller.cpp
+++ b/src/localsocketcontroller.cpp
@@ -88,10 +88,14 @@ void LocalSocketController::daemonConnected() {
 void LocalSocketController::activate(
     const QList<Server>& serverList, const Device* device, const Keys* keys,
     const QList<IPAddressRange>& allowedIPAddressRanges,
-    const QList<QString>& vpnDisabledApps, const QHostAddress& dnsServer,
-    Reason reason) {
+    const QStringList& excludedAddresses, const QStringList& vpnDisabledApps,
+    const QHostAddress& dnsServer, Reason reason) {
   Q_UNUSED(reason);
   Q_ASSERT(!serverList.isEmpty());
+
+  // The first hop should exclude the entry server.
+  const Server& entry = serverList.last();
+  bool first = true;
 
   // Clear out any connections that might have been lingering.
   m_activationQueue.clear();
@@ -111,6 +115,11 @@ void LocalSocketController::activate(
     hop.m_hopindex = hopindex;
     hop.m_allowedIPAddressRanges.append(IPAddressRange(next.ipv4AddrIn()));
     hop.m_allowedIPAddressRanges.append(IPAddressRange(next.ipv6AddrIn()));
+    if (first) {
+      hop.m_excludedAddresses.append(entry.ipv4AddrIn());
+      hop.m_excludedAddresses.append(entry.ipv6AddrIn());
+      first = false;
+    }
     m_activationQueue.append(hop);
   }
 
@@ -119,6 +128,12 @@ void LocalSocketController::activate(
   lastHop.m_server = serverList.first();
   lastHop.m_hopindex = 0;
   lastHop.m_allowedIPAddressRanges = allowedIPAddressRanges;
+  lastHop.m_excludedAddresses = excludedAddresses;
+  if (first) {
+    lastHop.m_excludedAddresses.append(entry.ipv4AddrIn());
+    lastHop.m_excludedAddresses.append(entry.ipv6AddrIn());
+    first = false;
+  }
   lastHop.m_vpnDisabledApps = vpnDisabledApps;
   lastHop.m_dnsServer = dnsServer;
   m_activationQueue.append(lastHop);
@@ -154,6 +169,13 @@ void LocalSocketController::activateNext() {
     allowedIPAddesses.append(range);
   };
   json.insert("allowedIPAddressRanges", allowedIPAddesses);
+
+  QJsonArray excludedAddresses;
+  for (const auto& address : hop.m_excludedAddresses) {
+    excludedAddresses.append(QJsonValue(address));
+  }
+  json.insert("excludedAddresses", excludedAddresses);
+
   QJsonArray splitTunnelApps;
   for (const auto& uri : hop.m_vpnDisabledApps) {
     splitTunnelApps.append(QJsonValue(uri));

--- a/src/localsocketcontroller.h
+++ b/src/localsocketcontroller.h
@@ -25,7 +25,8 @@ class LocalSocketController final : public ControllerImpl {
   void activate(const QList<Server>& serverList, const Device* device,
                 const Keys* keys,
                 const QList<IPAddressRange>& allowedIPAddressRanges,
-                const QList<QString>& vpnDisabledApps,
+                const QStringList& excludedAddresses,
+                const QStringList& vpnDisabledApps,
                 const QHostAddress& dnsServer, Reason reason) override;
 
   void deactivate(Reason reason) override;
@@ -59,7 +60,8 @@ class LocalSocketController final : public ControllerImpl {
     Server m_server;
     int m_hopindex = 0;
     QList<IPAddressRange> m_allowedIPAddressRanges;
-    QList<QString> m_vpnDisabledApps;
+    QStringList m_excludedAddresses;
+    QStringList m_vpnDisabledApps;
     QHostAddress m_dnsServer;
   };
   QList<HopConnection> m_activationQueue;

--- a/src/platforms/android/androidcontroller.h
+++ b/src/platforms/android/androidcontroller.h
@@ -26,7 +26,8 @@ class AndroidController final : public ControllerImpl,
   void activate(const QList<Server>& data, const Device* device,
                 const Keys* keys,
                 const QList<IPAddressRange>& allowedIPAddressRanges,
-                const QList<QString>& vpnDisabledApps, const QHostAddress& dns,
+                const QStringList& excludedAddresses,
+                const QStringList& vpnDisabledApps, const QHostAddress& dns,
                 Reason reason) override;
   void resume_activate();
 

--- a/src/platforms/dummy/dummycontroller.cpp
+++ b/src/platforms/dummy/dummycontroller.cpp
@@ -34,11 +34,12 @@ DummyController::~DummyController() { MVPN_COUNT_DTOR(DummyController); }
 void DummyController::activate(
     const QList<Server>& serverList, const Device* device, const Keys* keys,
     const QList<IPAddressRange>& allowedIPAddressRanges,
-    const QList<QString>& vpnDisabledApps, const QHostAddress& dnsServer,
-    Reason reason) {
+    const QStringList& excludedAddresses, const QStringList& vpnDisabledApps,
+    const QHostAddress& dnsServer, Reason reason) {
   Q_UNUSED(device);
   Q_UNUSED(keys);
   Q_UNUSED(allowedIPAddressRanges);
+  Q_UNUSED(excludedAddresses);
   Q_UNUSED(reason);
   Q_UNUSED(vpnDisabledApps);
 

--- a/src/platforms/dummy/dummycontroller.h
+++ b/src/platforms/dummy/dummycontroller.h
@@ -27,7 +27,8 @@ class DummyController final : public ControllerImpl {
   void activate(const QList<Server>& serverList, const Device* device,
                 const Keys* keys,
                 const QList<IPAddressRange>& allowedIPAddressRanges,
-                const QList<QString>& vpnDisabledApps,
+                const QStringList& excludedAddresses,
+                const QStringList& vpnDisabledApps,
                 const QHostAddress& dnsServer, Reason reason) override;
 
   void deactivate(Reason reason) override;

--- a/src/platforms/ios/ioscontroller.h
+++ b/src/platforms/ios/ioscontroller.h
@@ -21,7 +21,8 @@ class IOSController final : public ControllerImpl {
   void activate(const QList<Server>& serverList, const Device* device,
                 const Keys* keys,
                 const QList<IPAddressRange>& allowedIPAddressRanges,
-                const QList<QString>& vpnDisabledApps,
+                const QStringList& excludedAddresses,
+                const QStringList& vpnDisabledApps,
                 const QHostAddress& dnsServer, Reason reason) override;
 
   void deactivate(Reason reason) override;

--- a/src/platforms/ios/ioscontroller.mm
+++ b/src/platforms/ios/ioscontroller.mm
@@ -99,10 +99,12 @@ void IOSController::initialize(const Device* device, const Keys* keys) {
 
 void IOSController::activate(const QList<Server>& serverList, const Device* device,
                              const Keys* keys, const QList<IPAddressRange>& allowedIPAddressRanges,
-                             const QList<QString>& vpnDisabledApps, const QHostAddress& dnsServer,
+                             const QStringList& excludedAddresses,
+                             const QStringList& vpnDisabledApps, const QHostAddress& dnsServer,
                              Reason reason) {
   Q_UNUSED(device);
   Q_UNUSED(keys);
+  Q_UNUSED(excludedAddresses);
 
   bool isMultihop = serverList.length() > 1;
   Server exitServer = serverList.first();

--- a/src/platforms/linux/daemon/wireguardutilslinux.cpp
+++ b/src/platforms/linux/daemon/wireguardutilslinux.cpp
@@ -196,12 +196,11 @@ bool WireguardUtilsLinux::updatePeer(const InterfaceConfig& config) {
 
   logger.debug() << "Adding peer" << printableKey(config.m_serverPublicKey);
 
-  // HACK: This is a sloppy way to detect entry vs. exit server.
-  if (config.m_hopindex != 0) {
-    logger.debug() << "Adding exclusion route for" << config.m_serverIpv4AddrIn;
+  for (const QString& address : config.m_excludedAddresses) {
+    logger.debug() << "Adding exclusion route for" << address;
     rtmSendExclude(RTM_NEWRULE,
                    NLM_F_REQUEST | NLM_F_CREATE | NLM_F_REPLACE | NLM_F_ACK,
-                   QHostAddress(config.m_serverIpv4AddrIn));
+                   QHostAddress(address));
   }
 
   // Public Key
@@ -259,12 +258,10 @@ bool WireguardUtilsLinux::deletePeer(const InterfaceConfig& config) {
   }
   auto guard = qScopeGuard([&] { wg_free_device(device); });
 
-  // HACK: This is a sloppy way to detect entry vs. exit server.
-  if (config.m_hopindex != 0) {
-    logger.debug() << "Removing exclusion route for"
-                   << config.m_serverIpv4AddrIn;
+  for (const QString& address : config.m_excludedAddresses) {
+    logger.debug() << "Removing exclusion route for" << address;
     rtmSendExclude(RTM_DELRULE, NLM_F_REQUEST | NLM_F_ACK,
-                   QHostAddress(config.m_serverIpv4AddrIn));
+                   QHostAddress(address));
   }
 
   wg_peer* peer = static_cast<wg_peer*>(calloc(1, sizeof(*peer)));

--- a/src/platforms/linux/daemon/wireguardutilslinux.h
+++ b/src/platforms/linux/daemon/wireguardutilslinux.h
@@ -28,6 +28,9 @@ class WireguardUtilsLinux final : public WireguardUtils {
   bool updateRoutePrefix(const IPAddressRange& prefix, int hopindex) override;
   bool deleteRoutePrefix(const IPAddressRange& prefix, int hopindex) override;
 
+  bool addExclusionRoute(const QHostAddress& address) override;
+  bool deleteExclusionRoute(const QHostAddress& address) override;
+
   QString getDefaultCgroup() const { return m_cgroups; }
   QString getExcludeCgroup() const;
   QString getBlockCgroup() const;

--- a/src/platforms/linux/dbusclient.cpp
+++ b/src/platforms/linux/dbusclient.cpp
@@ -49,7 +49,8 @@ QDBusPendingCallWatcher* DBusClient::version() {
 QDBusPendingCallWatcher* DBusClient::activate(
     const Server& server, const Device* device, const Keys* keys, int hopindex,
     const QList<IPAddressRange>& allowedIPAddressRanges,
-    const QStringList& vpnDisabledApps, const QHostAddress& dnsServer) {
+    const QStringList& excludedAddresses, const QStringList& vpnDisabledApps,
+    const QHostAddress& dnsServer) {
   QJsonObject json;
   json.insert("privateKey", QJsonValue(keys->privateKey()));
   json.insert("deviceIpv4Address", QJsonValue(device->ipv4Address()));
@@ -72,6 +73,12 @@ QDBusPendingCallWatcher* DBusClient::activate(
     allowedIPAddesses.append(range);
   };
   json.insert("allowedIPAddressRanges", allowedIPAddesses);
+
+  QJsonArray jsExcludedAddresses;
+  for (const QString& i : excludedAddresses) {
+    jsExcludedAddresses.append(QJsonValue(i));
+  }
+  json.insert("excludedAddresses", jsExcludedAddresses);
 
   QJsonArray disabledApps;
   for (const QString& i : vpnDisabledApps) {

--- a/src/platforms/linux/dbusclient.h
+++ b/src/platforms/linux/dbusclient.h
@@ -30,7 +30,8 @@ class DBusClient final : public QObject {
   QDBusPendingCallWatcher* activate(
       const Server& server, const Device* device, const Keys* keys,
       int hopindex, const QList<IPAddressRange>& allowedIPAddressRanges,
-      const QStringList& vpnDisabledApps, const QHostAddress& dnsServer);
+      const QStringList& excludedAddresses, const QStringList& vpnDisabledApps,
+      const QHostAddress& dnsServer);
 
   QDBusPendingCallWatcher* deactivate();
 

--- a/src/platforms/linux/linuxcontroller.cpp
+++ b/src/platforms/linux/linuxcontroller.cpp
@@ -71,10 +71,14 @@ void LinuxController::initializeCompleted(QDBusPendingCallWatcher* call) {
 void LinuxController::activate(
     const QList<Server>& serverList, const Device* device, const Keys* keys,
     const QList<IPAddressRange>& allowedIPAddressRanges,
-    const QList<QString>& vpnDisabledApps, const QHostAddress& dnsServer,
-    Reason reason) {
+    const QStringList& excludedAddresses, const QStringList& vpnDisabledApps,
+    const QHostAddress& dnsServer, Reason reason) {
   Q_UNUSED(reason);
   Q_ASSERT(!serverList.isEmpty());
+
+  // The first hop should exclude the entry server.
+  const Server& entry = serverList.last();
+  bool first = true;
 
   // Clear out any connections that might have been lingering.
   m_activationQueue.clear();
@@ -90,6 +94,11 @@ void LinuxController::activate(
     hop.m_hopindex = hopindex;
     hop.m_allowedIPAddressRanges.append(IPAddressRange(next.ipv4AddrIn()));
     hop.m_allowedIPAddressRanges.append(IPAddressRange(next.ipv6AddrIn()));
+    if (first) {
+      hop.m_excludedAddresses.append(entry.ipv4AddrIn());
+      hop.m_excludedAddresses.append(entry.ipv6AddrIn());
+      first = false;
+    }
     m_activationQueue.append(hop);
   }
 
@@ -98,6 +107,12 @@ void LinuxController::activate(
   lastHop.m_server = serverList.first();
   lastHop.m_hopindex = 0;
   lastHop.m_allowedIPAddressRanges = allowedIPAddressRanges;
+  lastHop.m_excludedAddresses = excludedAddresses;
+  if (first) {
+    lastHop.m_excludedAddresses.append(entry.ipv4AddrIn());
+    lastHop.m_excludedAddresses.append(entry.ipv6AddrIn());
+    first = false;
+  }
   lastHop.m_vpnDisabledApps = vpnDisabledApps;
   lastHop.m_dnsServer = dnsServer;
   m_activationQueue.append(lastHop);
@@ -108,11 +123,12 @@ void LinuxController::activate(
 
 void LinuxController::activateNext() {
   const HopConnection& hop = m_activationQueue.first();
-  connect(m_dbus->activate(hop.m_server, m_device, m_keys, hop.m_hopindex,
-                           hop.m_allowedIPAddressRanges, hop.m_vpnDisabledApps,
-                           hop.m_dnsServer),
-          &QDBusPendingCallWatcher::finished, this,
-          &LinuxController::operationCompleted);
+  connect(
+      m_dbus->activate(hop.m_server, m_device, m_keys, hop.m_hopindex,
+                       hop.m_allowedIPAddressRanges, hop.m_excludedAddresses,
+                       hop.m_vpnDisabledApps, hop.m_dnsServer),
+      &QDBusPendingCallWatcher::finished, this,
+      &LinuxController::operationCompleted);
 }
 
 void LinuxController::deactivate(Reason reason) {

--- a/src/platforms/linux/linuxcontroller.h
+++ b/src/platforms/linux/linuxcontroller.h
@@ -25,7 +25,8 @@ class LinuxController final : public ControllerImpl {
   void activate(const QList<Server>& serverList, const Device* device,
                 const Keys* keys,
                 const QList<IPAddressRange>& allowedIPAddressRanges,
-                const QList<QString>& vpnDisabledApps,
+                const QStringList& excludedAddresses,
+                const QStringList& vpnDisabledApps,
                 const QHostAddress& dnsServer, Reason reason) override;
 
   void deactivate(Reason reason) override;
@@ -52,7 +53,8 @@ class LinuxController final : public ControllerImpl {
     Server m_server;
     int m_hopindex = 0;
     QList<IPAddressRange> m_allowedIPAddressRanges;
-    QList<QString> m_vpnDisabledApps;
+    QStringList m_excludedAddresses;
+    QStringList m_vpnDisabledApps;
     QHostAddress m_dnsServer;
   };
   QList<HopConnection> m_activationQueue;

--- a/src/platforms/macos/daemon/macosroutemonitor.cpp
+++ b/src/platforms/macos/daemon/macosroutemonitor.cpp
@@ -105,7 +105,7 @@ void MacosRouteMonitor::handleRtmUpdate(const struct rt_msghdr* rtm,
 
   // We expect all useful routes to contain a destination, netmask and gateway.
   if (!(rtm->rtm_addrs & RTA_DST) || !(rtm->rtm_addrs & RTA_GATEWAY) ||
-      !(rtm->rtm_addrs & RTA_NETMASK)) {
+      !(rtm->rtm_addrs & RTA_NETMASK) || (addrlist.count() < 3)) {
     return;
   }
   // Ignore route changes that we caused, or routes on the tunnel interface.

--- a/src/platforms/macos/daemon/macosroutemonitor.cpp
+++ b/src/platforms/macos/daemon/macosroutemonitor.cpp
@@ -435,14 +435,17 @@ bool MacosRouteMonitor::addExclusionRoute(const QHostAddress& address) {
   return true;
 }
 
-void MacosRouteMonitor::deleteExclusionRoute(const QHostAddress& address) {
+bool MacosRouteMonitor::deleteExclusionRoute(const QHostAddress& address) {
   logger.debug() << "Deleting exclusion route for" << address.toString();
 
   m_exclusionRoutes.removeAll(address);
   if (address.protocol() == QAbstractSocket::IPv4Protocol) {
-    rtmSendRoute(RTM_DELETE, address, 32, m_defaultIfindexIpv4, nullptr);
+    return rtmSendRoute(RTM_DELETE, address, 32, m_defaultIfindexIpv4, nullptr);
   } else if (address.protocol() == QAbstractSocket::IPv6Protocol) {
-    rtmSendRoute(RTM_DELETE, address, 128, m_defaultIfindexIpv6, nullptr);
+    return rtmSendRoute(RTM_DELETE, address, 128, m_defaultIfindexIpv6,
+                        nullptr);
+  } else {
+    return false;
   }
 }
 

--- a/src/platforms/macos/daemon/macosroutemonitor.h
+++ b/src/platforms/macos/daemon/macosroutemonitor.h
@@ -29,15 +29,7 @@ class MacosRouteMonitor final : public QObject {
   int interfaceFlags() { return m_ifflags; }
 
   bool addExclusionRoute(const QHostAddress& address);
-  bool addExclusionRoute(const QString& address) {
-    return addExclusionRoute(QHostAddress(address));
-  }
-
   void deleteExclusionRoute(const QHostAddress& address);
-  void deleteExclusionRoute(const QString& address) {
-    deleteExclusionRoute(QHostAddress(address));
-  }
-
   void flushExclusionRoutes();
 
  private:

--- a/src/platforms/macos/daemon/macosroutemonitor.h
+++ b/src/platforms/macos/daemon/macosroutemonitor.h
@@ -29,7 +29,7 @@ class MacosRouteMonitor final : public QObject {
   int interfaceFlags() { return m_ifflags; }
 
   bool addExclusionRoute(const QHostAddress& address);
-  void deleteExclusionRoute(const QHostAddress& address);
+  bool deleteExclusionRoute(const QHostAddress& address);
   void flushExclusionRoutes();
 
  private:

--- a/src/platforms/macos/daemon/macosroutemonitor.h
+++ b/src/platforms/macos/daemon/macosroutemonitor.h
@@ -37,7 +37,7 @@ class MacosRouteMonitor final : public QObject {
   void handleRtmUpdate(const struct rt_msghdr* msg, const QByteArray& payload);
   void handleIfaceInfo(const struct if_msghdr* msg, const QByteArray& payload);
   bool rtmSendRoute(int action, const QHostAddress& prefix, unsigned int plen,
-                    unsigned int ifindex, const struct sockaddr* gateway);
+                    unsigned int ifindex, const void* gateway);
   bool rtmFetchRoutes(int family);
   static void rtmAppendAddr(struct rt_msghdr* rtm, size_t maxlen, int rtaddr,
                             const void* sa);

--- a/src/platforms/macos/daemon/wireguardutilsmacos.cpp
+++ b/src/platforms/macos/daemon/wireguardutilsmacos.cpp
@@ -139,9 +139,6 @@ bool WireguardUtilsMacos::updatePeer(const InterfaceConfig& config) {
 
   logger.debug() << "Configuring peer" << printableKey(config.m_serverPublicKey)
                  << "via" << config.m_serverIpv4AddrIn;
-  for (const QString& address : config.m_excludedAddresses) {
-    m_rtmonitor->addExclusionRoute(QHostAddress(address));
-  }
 
   // Update/create the peer config
   QString message;
@@ -174,10 +171,6 @@ bool WireguardUtilsMacos::updatePeer(const InterfaceConfig& config) {
 bool WireguardUtilsMacos::deletePeer(const InterfaceConfig& config) {
   QByteArray publicKey =
       QByteArray::fromBase64(qPrintable(config.m_serverPublicKey));
-
-  for (const QString& address : config.m_excludedAddresses) {
-    m_rtmonitor->deleteExclusionRoute(QHostAddress(address));
-  }
 
   QString message;
   QTextStream out(&message);
@@ -266,6 +259,20 @@ bool WireguardUtilsMacos::deleteRoutePrefix(const IPAddressRange& prefix,
            m_rtmonitor->deleteRoute(IPAddressRange("8000::/1"));
   }
   return m_rtmonitor->deleteRoute(prefix);
+}
+
+bool WireguardUtilsMacos::addExclusionRoute(const QHostAddress& address) {
+  if (!m_rtmonitor) {
+    return false;
+  }
+  return m_rtmonitor->addExclusionRoute(address);
+}
+
+bool WireguardUtilsMacos::deleteExclusionRoute(const QHostAddress& address) {
+  if (!m_rtmonitor) {
+    return false;
+  }
+  return m_rtmonitor->deleteExclusionRoute(address);
 }
 
 QString WireguardUtilsMacos::uapiCommand(const QString& command) {

--- a/src/platforms/macos/daemon/wireguardutilsmacos.h
+++ b/src/platforms/macos/daemon/wireguardutilsmacos.h
@@ -32,6 +32,9 @@ class WireguardUtilsMacos final : public WireguardUtils {
   bool updateRoutePrefix(const IPAddressRange& prefix, int hopindex) override;
   bool deleteRoutePrefix(const IPAddressRange& prefix, int hopindex) override;
 
+  bool addExclusionRoute(const QHostAddress& address) override;
+  bool deleteExclusionRoute(const QHostAddress& address) override;
+
  signals:
   void backendFailure();
 

--- a/src/platforms/windows/daemon/windowsroutemonitor.cpp
+++ b/src/platforms/windows/daemon/windowsroutemonitor.cpp
@@ -196,7 +196,7 @@ bool WindowsRouteMonitor::addExclusionRoute(const QHostAddress& address) {
   return true;
 }
 
-void WindowsRouteMonitor::deleteExclusionRoute(const QHostAddress& address) {
+bool WindowsRouteMonitor::deleteExclusionRoute(const QHostAddress& address) {
   logger.debug() << "Deleting exclusion route for" << address.toString();
 
   for (;;) {
@@ -212,6 +212,8 @@ void WindowsRouteMonitor::deleteExclusionRoute(const QHostAddress& address) {
     }
     delete data;
   }
+
+  return true;
 }
 
 void WindowsRouteMonitor::flushExclusionRoutes() {

--- a/src/platforms/windows/daemon/windowsroutemonitor.h
+++ b/src/platforms/windows/daemon/windowsroutemonitor.h
@@ -22,7 +22,7 @@ class WindowsRouteMonitor final : public QObject {
   ~WindowsRouteMonitor();
 
   bool addExclusionRoute(const QHostAddress& address);
-  void deleteExclusionRoute(const QHostAddress& address);
+  bool deleteExclusionRoute(const QHostAddress& address);
   void flushExclusionRoutes();
 
   void setLuid(quint64 luid) { m_luid = luid; }

--- a/src/platforms/windows/daemon/windowsroutemonitor.h
+++ b/src/platforms/windows/daemon/windowsroutemonitor.h
@@ -22,15 +22,7 @@ class WindowsRouteMonitor final : public QObject {
   ~WindowsRouteMonitor();
 
   bool addExclusionRoute(const QHostAddress& address);
-  bool addExclusionRoute(const QString& address) {
-    return addExclusionRoute(QHostAddress(address));
-  }
-
   void deleteExclusionRoute(const QHostAddress& address);
-  void deleteExclusionRoute(const QString& address) {
-    deleteExclusionRoute(QHostAddress(address));
-  }
-
   void flushExclusionRoutes();
 
   void setLuid(quint64 luid) { m_luid = luid; }

--- a/src/platforms/windows/daemon/wireguardutilswindows.cpp
+++ b/src/platforms/windows/daemon/wireguardutilswindows.cpp
@@ -135,12 +135,11 @@ bool WireguardUtilsWindows::updatePeer(const InterfaceConfig& config) {
 
   // Enable the windows firewall and routes for this peer.
   WindowsFirewall::instance()->enablePeerTraffic(config);
-  if (config.m_hopindex != 0) {
-    // HACK: This is a sloppy way to detect entry vs. exit server.
-    m_routeMonitor.addExclusionRoute(config.m_serverIpv4AddrIn);
+  for (const QString& address : config.m_excludedAddresses) {
+    m_routeMonitor.addExclusionRoute(QHostAddress(address));
   }
 
-  logger.debug() << "Updating peer" << printableKey(config.m_serverPublicKey)
+  logger.debug() << "Configuring peer" << printableKey(config.m_serverPublicKey)
                  << "via" << config.m_serverIpv4AddrIn;
 
   // Update/create the peer config
@@ -175,9 +174,8 @@ bool WireguardUtilsWindows::deletePeer(const InterfaceConfig& config) {
 
   // Disable the windows firewall and routes for this peer.
   WindowsFirewall::instance()->disablePeerTraffic(config.m_serverPublicKey);
-  if (config.m_hopindex != 0) {
-    // HACK: This is a sloppy way to detect entry vs. exit server.
-    m_routeMonitor.deleteExclusionRoute(config.m_serverIpv4AddrIn);
+  for (const QString& address : config.m_excludedAddresses) {
+    m_routeMonitor.deleteExclusionRoute(QHostAddress(address));
   }
 
   QString message;

--- a/src/platforms/windows/daemon/wireguardutilswindows.cpp
+++ b/src/platforms/windows/daemon/wireguardutilswindows.cpp
@@ -133,11 +133,8 @@ bool WireguardUtilsWindows::updatePeer(const InterfaceConfig& config) {
   QByteArray publicKey =
       QByteArray::fromBase64(qPrintable(config.m_serverPublicKey));
 
-  // Enable the windows firewall and routes for this peer.
+  // Enable the windows firewall for this peer.
   WindowsFirewall::instance()->enablePeerTraffic(config);
-  for (const QString& address : config.m_excludedAddresses) {
-    m_routeMonitor.addExclusionRoute(QHostAddress(address));
-  }
 
   logger.debug() << "Configuring peer" << printableKey(config.m_serverPublicKey)
                  << "via" << config.m_serverIpv4AddrIn;
@@ -172,11 +169,8 @@ bool WireguardUtilsWindows::deletePeer(const InterfaceConfig& config) {
   QByteArray publicKey =
       QByteArray::fromBase64(qPrintable(config.m_serverPublicKey));
 
-  // Disable the windows firewall and routes for this peer.
+  // Disable the windows firewall for this peer.
   WindowsFirewall::instance()->disablePeerTraffic(config.m_serverPublicKey);
-  for (const QString& address : config.m_excludedAddresses) {
-    m_routeMonitor.deleteExclusionRoute(QHostAddress(address));
-  }
 
   QString message;
   QTextStream out(&message);
@@ -255,4 +249,12 @@ bool WireguardUtilsWindows::deleteRoutePrefix(const IPAddressRange& prefix,
                    << "result:" << result;
   }
   return result == NO_ERROR;
+}
+
+bool WireguardUtilsWindows::addExclusionRoute(const QHostAddress& address) {
+  return m_routeMonitor.addExclusionRoute(address);
+}
+
+bool WireguardUtilsWindows::deleteExclusionRoute(const QHostAddress& address) {
+  return m_routeMonitor.deleteExclusionRoute(address);
 }

--- a/src/platforms/windows/daemon/wireguardutilswindows.h
+++ b/src/platforms/windows/daemon/wireguardutilswindows.h
@@ -32,6 +32,9 @@ class WireguardUtilsWindows final : public WireguardUtils {
   bool updateRoutePrefix(const IPAddressRange& prefix, int hopindex) override;
   bool deleteRoutePrefix(const IPAddressRange& prefix, int hopindex) override;
 
+  bool addExclusionRoute(const QHostAddress& address) override;
+  bool deleteExclusionRoute(const QHostAddress& address) override;
+
  signals:
   void backendFailure();
 

--- a/src/timercontroller.cpp
+++ b/src/timercontroller.cpp
@@ -38,8 +38,8 @@ void TimerController::initialize(const Device* device, const Keys* keys) {
 void TimerController::activate(
     const QList<Server>& serverList, const Device* device, const Keys* keys,
     const QList<IPAddressRange>& allowedIPAddressRanges,
-    const QList<QString>& vpnDisabledApps, const QHostAddress& dns,
-    Reason reason) {
+    const QStringList& excludedAddresses, const QStringList& vpnDisabledApps,
+    const QHostAddress& dns, Reason reason) {
   if (m_state != None) {
     return;
   }
@@ -52,7 +52,7 @@ void TimerController::activate(
   }
 
   m_impl->activate(serverList, device, keys, allowedIPAddressRanges,
-                   vpnDisabledApps, dns, reason);
+                   excludedAddresses, vpnDisabledApps, dns, reason);
 }
 
 void TimerController::deactivate(Reason reason) {

--- a/src/timercontroller.h
+++ b/src/timercontroller.h
@@ -29,7 +29,8 @@ class TimerController final : public ControllerImpl {
   void activate(const QList<Server>& serverList, const Device* device,
                 const Keys* keys,
                 const QList<IPAddressRange>& allowedIPAddressRanges,
-                const QList<QString>& vpnDisabledApps, const QHostAddress& dns,
+                const QStringList& excludedAddresses,
+                const QStringList& vpnDisabledApps, const QHostAddress& dns,
                 Reason reason) override;
 
   void deactivate(Reason reason) override;


### PR DESCRIPTION
This cleans up some of the lingering hacks in the multihop peer startup pull request (#2291), while at the same time allowing the daemon to manage the list of excluded addresses, which it may be better able to do using platform-specific techniques (eg: routing policy rules or by listening for routing table updates).

Platform implementation status:
- [x] Windows address exclusion support
- [x] MacOS address exclusion support
- [X] Linux address exclusion support
- [x] Verify that iOS is not broken
- [x] Verify that Android is not broken
- [x] Repair unit tests

Closes: #1527 