### PR TITLE
Fixing the parenting of QObjects

### DIFF
--- a/src/adjust/adjustproxyconnection.cpp
+++ b/src/adjust/adjustproxyconnection.cpp
@@ -89,7 +89,7 @@ void AdjustProxyConnection::forwardRequest() {
                                bodyParameters, unknownParameters);
 
   connect(
-      task, &AdjustTaskSubmission::operationCompleted,
+      task, &AdjustTaskSubmission::operationCompleted, this,
       [this](const QByteArray& data, int statusCode) {
         m_connection->write(
             HTTP_RESPONSE.arg(QByteArray::number(statusCode), data).toUtf8());

--- a/src/adjust/adjusttasksubmission.cpp
+++ b/src/adjust/adjusttasksubmission.cpp
@@ -35,7 +35,7 @@ void AdjustTaskSubmission::run() {
       this, m_method, m_path, m_headers, m_queryParameters, m_bodyParameters,
       m_unknownParameters);
 
-  connect(request, &NetworkRequest::requestFailed,
+  connect(request, &NetworkRequest::requestFailed, this,
           [this, request](QNetworkReply::NetworkError, const QByteArray& data) {
             logger.debug() << "Adjust Proxy request completed with: "
                            << request->statusCode() << ", " << data;
@@ -43,7 +43,7 @@ void AdjustTaskSubmission::run() {
             emit completed();
           });
 
-  connect(request, &NetworkRequest::requestCompleted,
+  connect(request, &NetworkRequest::requestCompleted, this,
           [this, request](const QByteArray& data) {
             logger.debug() << "Adjust Proxy request completed with: "
                            << request->statusCode() << ", " << data;

--- a/src/authenticationinapp/authenticationinapp.cpp
+++ b/src/authenticationinapp/authenticationinapp.cpp
@@ -51,7 +51,7 @@ void AuthenticationInApp::registerListener(
   Q_ASSERT(!m_listener);
 
   m_listener = listener;
-  connect(listener, &QObject::destroyed, [this]() {
+  connect(listener, &QObject::destroyed, this, [this]() {
     m_listener = nullptr;
     setState(StateInitializing);
   });

--- a/src/authenticationinapp/authenticationinapplistener.cpp
+++ b/src/authenticationinapp/authenticationinapplistener.cpp
@@ -41,13 +41,13 @@ void AuthenticationInAppListener::aboutToFinish() {
       NetworkRequest::createForFxaSessionDestroy(m_task, m_sessionToken);
   Q_ASSERT(request);
 
-  connect(request, &NetworkRequest::requestFailed,
+  connect(request, &NetworkRequest::requestFailed, this,
           [this](QNetworkReply::NetworkError error, const QByteArray&) {
             logger.error() << "Failed to destroy the FxA session" << error;
             emit readyToFinish();
           });
 
-  connect(request, &NetworkRequest::requestCompleted,
+  connect(request, &NetworkRequest::requestCompleted, this,
           [this](const QByteArray&) {
             logger.error() << "FxA session destroyed";
             emit readyToFinish();
@@ -76,7 +76,7 @@ void AuthenticationInAppListener::start(Task* task,
   NetworkRequest* request =
       NetworkRequest::createForGetUrl(task, url.toString());
 
-  connect(request, &NetworkRequest::requestRedirected,
+  connect(request, &NetworkRequest::requestRedirected, this,
           [this](NetworkRequest* request, const QUrl& url) {
             logger.debug() << "Redirect received";
             m_urlQuery = QUrlQuery(url.query());
@@ -98,7 +98,7 @@ void AuthenticationInAppListener::start(Task* task,
             request->abort();
           });
 
-  connect(request, &NetworkRequest::requestFailed,
+  connect(request, &NetworkRequest::requestFailed, this,
           [this](QNetworkReply::NetworkError error, const QByteArray& data) {
             logger.error() << "Failed to fetch the initial request" << error;
             if (error != QNetworkReply::OperationCanceledError) {
@@ -116,13 +116,13 @@ void AuthenticationInAppListener::checkAccount(const QString& emailAddress) {
   NetworkRequest* request =
       NetworkRequest::createForFxaAccountStatus(m_task, m_emailAddress);
 
-  connect(request, &NetworkRequest::requestFailed,
+  connect(request, &NetworkRequest::requestFailed, this,
           [this](QNetworkReply::NetworkError error, const QByteArray& data) {
             logger.error() << "Failed to check the account status" << error;
             processRequestFailure(error, data);
           });
 
-  connect(request, &NetworkRequest::requestCompleted,
+  connect(request, &NetworkRequest::requestCompleted, this,
           [this](const QByteArray& data) {
             logger.debug() << "Account status checked" << data;
 
@@ -195,13 +195,13 @@ void AuthenticationInAppListener::signIn(const QString& unblockCode) {
   NetworkRequest* request = NetworkRequest::createForFxaLogin(
       m_task, m_emailAddress, m_authPw, unblockCode, m_urlQuery);
 
-  connect(request, &NetworkRequest::requestFailed,
+  connect(request, &NetworkRequest::requestFailed, this,
           [this](QNetworkReply::NetworkError error, const QByteArray& data) {
             logger.error() << "Failed to sign in" << error;
             processRequestFailure(error, data);
           });
 
-  connect(request, &NetworkRequest::requestCompleted,
+  connect(request, &NetworkRequest::requestCompleted, this,
           [this](const QByteArray& data) {
             logger.debug() << "Sign in completed" << data;
 
@@ -220,13 +220,13 @@ void AuthenticationInAppListener::signUp() {
   NetworkRequest* request = NetworkRequest::createForFxaAccountCreation(
       m_task, m_emailAddress, m_authPw, m_urlQuery);
 
-  connect(request, &NetworkRequest::requestFailed,
+  connect(request, &NetworkRequest::requestFailed, this,
           [this](QNetworkReply::NetworkError error, const QByteArray& data) {
             logger.error() << "Failed to sign up" << error;
             processRequestFailure(error, data);
           });
 
-  connect(request, &NetworkRequest::requestCompleted,
+  connect(request, &NetworkRequest::requestCompleted, this,
           [this](const QByteArray& data) {
             logger.debug() << "Sign up completed" << data;
 
@@ -260,7 +260,7 @@ void AuthenticationInAppListener::sendUnblockCodeEmail() {
   NetworkRequest* request =
       NetworkRequest::createForFxaSendUnblockCode(m_task, m_emailAddress);
 
-  connect(request, &NetworkRequest::requestFailed,
+  connect(request, &NetworkRequest::requestFailed, this,
           [this](QNetworkReply::NetworkError error, const QByteArray& data) {
             logger.error() << "Failed to resend the unblock code" << error;
             processRequestFailure(error, data);
@@ -279,13 +279,13 @@ void AuthenticationInAppListener::verifySessionEmailCode(const QString& code) {
       NetworkRequest::createForFxaSessionVerifyByEmailCode(
           m_task, m_sessionToken, code, m_urlQuery);
 
-  connect(request, &NetworkRequest::requestFailed,
+  connect(request, &NetworkRequest::requestFailed, this,
           [this](QNetworkReply::NetworkError error, const QByteArray& data) {
             logger.error() << "Failed to verify the session code" << error;
             processRequestFailure(error, data);
           });
 
-  connect(request, &NetworkRequest::requestCompleted,
+  connect(request, &NetworkRequest::requestCompleted, this,
           [this](const QByteArray& data) {
             logger.debug() << "Verification completed" << data;
             finalizeSignInOrUp();
@@ -299,7 +299,7 @@ void AuthenticationInAppListener::resendVerificationSessionCodeEmail() {
   NetworkRequest* request =
       NetworkRequest::createForFxaSessionResendCode(m_task, m_sessionToken);
 
-  connect(request, &NetworkRequest::requestFailed,
+  connect(request, &NetworkRequest::requestFailed, this,
           [this](QNetworkReply::NetworkError error, const QByteArray& data) {
             logger.error() << "Failed to resend the session code" << error;
             processRequestFailure(error, data);
@@ -317,13 +317,13 @@ void AuthenticationInAppListener::verifySessionTotpCode(const QString& code) {
   NetworkRequest* request = NetworkRequest::createForFxaSessionVerifyByTotpCode(
       m_task, m_sessionToken, code, m_urlQuery);
 
-  connect(request, &NetworkRequest::requestFailed,
+  connect(request, &NetworkRequest::requestFailed, this,
           [this](QNetworkReply::NetworkError error, const QByteArray& data) {
             logger.error() << "Failed to verify the session code" << error;
             processRequestFailure(error, data);
           });
 
-  connect(request, &NetworkRequest::requestCompleted,
+  connect(request, &NetworkRequest::requestCompleted, this,
           [this](const QByteArray& data) {
             logger.debug() << "Verification completed" << data;
 
@@ -382,13 +382,13 @@ void AuthenticationInAppListener::createTotpCodes() {
   NetworkRequest* request =
       NetworkRequest::createForFxaTotpCreation(m_task, m_sessionToken);
 
-  connect(request, &NetworkRequest::requestFailed,
+  connect(request, &NetworkRequest::requestFailed, this,
           [this](QNetworkReply::NetworkError error, const QByteArray& data) {
             logger.error() << "Failed to create totp codes" << error;
             processRequestFailure(error, data);
           });
 
-  connect(request, &NetworkRequest::requestCompleted,
+  connect(request, &NetworkRequest::requestCompleted, this,
           [this](const QByteArray& data) {
             logger.debug() << "Totp code creation completed" << data;
 
@@ -418,14 +418,14 @@ void AuthenticationInAppListener::finalizeSignInOrUp() {
   NetworkRequest* request =
       NetworkRequest::createForFxaAuthz(m_task, m_sessionToken, m_urlQuery);
 
-  connect(request, &NetworkRequest::requestFailed,
+  connect(request, &NetworkRequest::requestFailed, this,
           [this](QNetworkReply::NetworkError error, const QByteArray& data) {
             logger.error() << "Failed to create oauth code" << error;
             processRequestFailure(error, data);
           });
 
   connect(
-      request, &NetworkRequest::requestCompleted,
+      request, &NetworkRequest::requestCompleted, this,
       [this](const QByteArray& data) {
         logger.debug() << "Oauth code creation completed" << data;
 
@@ -463,14 +463,14 @@ void AuthenticationInAppListener::finalizeSignInOrUp() {
             NetworkRequest::createForGetUrl(m_task, redirect.toString(), 200);
 
         connect(
-            request, &NetworkRequest::requestFailed,
+            request, &NetworkRequest::requestFailed, this,
             [this](QNetworkReply::NetworkError error, const QByteArray& data) {
               logger.error()
                   << "Failed to fetch the final redirect data" << error;
               processRequestFailure(error, data);
             });
 
-        connect(request, &NetworkRequest::requestHeaderReceived,
+        connect(request, &NetworkRequest::requestHeaderReceived, this,
                 [this](NetworkRequest* request) {
 #ifdef UNIT_TEST
                   AuthenticationInApp* aip = AuthenticationInApp::instance();

--- a/src/captiveportal/captiveportaldetectionimpl.cpp
+++ b/src/captiveportal/captiveportaldetectionimpl.cpp
@@ -25,7 +25,7 @@ void CaptivePortalDetectionImpl::start() {
   logger.debug() << "Captive portal detection started";
 
   CaptivePortalRequestTask* task = new CaptivePortalRequestTask();
-  connect(task, &CaptivePortalRequestTask::operationCompleted,
+  connect(task, &CaptivePortalRequestTask::operationCompleted, this,
           [this](CaptivePortalRequest::CaptivePortalResult detected) {
             logger.debug() << "Captive portal detection:" << detected;
             emit detectionCompleted(detected);

--- a/src/captiveportal/captiveportalmonitor.cpp
+++ b/src/captiveportal/captiveportalmonitor.cpp
@@ -38,7 +38,7 @@ void CaptivePortalMonitor::check() {
   logger.debug() << "Checking the internet connectivity";
 
   CaptivePortalRequestTask* task = new CaptivePortalRequestTask(false);
-  connect(task, &CaptivePortalRequestTask::operationCompleted,
+  connect(task, &CaptivePortalRequestTask::operationCompleted, this,
           [this](CaptivePortalRequest::CaptivePortalResult result) {
             logger.debug() << "Captive portal detection:" << result;
 

--- a/src/captiveportal/captiveportalrequest.cpp
+++ b/src/captiveportal/captiveportalrequest.cpp
@@ -58,7 +58,7 @@ void CaptivePortalRequest::createRequest(const QUrl& url) {
   NetworkRequest* request = NetworkRequest::createForCaptivePortalDetection(
       static_cast<Task*>(parent()), url, CAPTIVEPORTAL_HOST);
 
-  connect(request, &NetworkRequest::requestRedirected,
+  connect(request, &NetworkRequest::requestRedirected, this,
           [this](NetworkRequest* request, const QUrl& url) {
             // In Case the Captive Portal request Redirects, we 100% have one.
             logger.info() << "Portal Detected -> Redirect to "
@@ -66,14 +66,14 @@ void CaptivePortalRequest::createRequest(const QUrl& url) {
             request->abort();
             onResult(PortalDetected);
           });
-  connect(request, &NetworkRequest::requestFailed,
+  connect(request, &NetworkRequest::requestFailed, this,
           [this](QNetworkReply::NetworkError error, const QByteArray&) {
             logger.warning() << "Captive portal request failed:" << error;
             onResult(Failure);
           });
 
   connect(
-      request, &NetworkRequest::requestCompleted,
+      request, &NetworkRequest::requestCompleted, this,
       [this, request](const QByteArray& data) {
         logger.debug() << "Captive portal request completed:" << data;
         // Usually, captive-portal pages do a redirect to an internal page.

--- a/src/captiveportal/captiveportalrequesttask.cpp
+++ b/src/captiveportal/captiveportalrequesttask.cpp
@@ -39,7 +39,7 @@ void CaptivePortalRequestTask::run() {
 void CaptivePortalRequestTask::createRequest() {
   NetworkManager::instance()->clearCache();
   CaptivePortalRequest* request = new CaptivePortalRequest(this);
-  connect(request, &CaptivePortalRequest::completed,
+  connect(request, &CaptivePortalRequest::completed, this,
           [this](CaptivePortalRequest::CaptivePortalResult detected) {
             logger.debug() << "Captive portal detection:" << detected;
             onResult(detected);

--- a/src/connectiondataholder.cpp
+++ b/src/connectiondataholder.cpp
@@ -28,8 +28,9 @@ ConnectionDataHolder::ConnectionDataHolder()
       m_ipv6Address(qtTrId("vpn.connectionInfo.loading")) {
   MVPN_COUNT_CTOR(ConnectionDataHolder);
 
-  connect(&m_ipAddressTimer, &QTimer::timeout, [this]() { updateIpAddress(); });
-  connect(&m_checkStatusTimer, &QTimer::timeout, [this]() {
+  connect(&m_ipAddressTimer, &QTimer::timeout, this,
+          [this]() { updateIpAddress(); });
+  connect(&m_checkStatusTimer, &QTimer::timeout, this, [this]() {
     MozillaVPN::instance()->controller()->getStatus(
         [this](const QString& serverIpv4Gateway,
                const QString& deviceIpv4Address, uint64_t txBytes,
@@ -221,7 +222,7 @@ void ConnectionDataHolder::updateIpAddress() {
 
   TaskIPFinder* ipfinder = new TaskIPFinder();
   connect(
-      ipfinder, &TaskIPFinder::operationCompleted,
+      ipfinder, &TaskIPFinder::operationCompleted, this,
       [this](const QString& ipv4, const QString& ipv6, const QString& country) {
         if (ipv4.isEmpty() && ipv6.isEmpty()) {
           logger.error() << "IP address request failed";

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -82,7 +82,7 @@ Controller::Controller() {
           &Controller::connectionConfirmed);
   connect(&m_connectionCheck, &ConnectionCheck::failure, this,
           &Controller::connectionFailed);
-  connect(&m_connectingTimer, &QTimer::timeout, [this]() {
+  connect(&m_connectingTimer, &QTimer::timeout, this, [this]() {
     m_enableDisconnectInConfirming = true;
     emit enableDisconnectInConfirmingChanged();
   });

--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -102,7 +102,8 @@ MozillaVPN::MozillaVPN() : m_private(new Private()) {
   AdjustHandler::initialize();
 #endif
 
-  connect(&m_alertTimer, &QTimer::timeout, [this]() { setAlert(NoAlert); });
+  connect(&m_alertTimer, &QTimer::timeout, this,
+          [this]() { setAlert(NoAlert); });
 
   connect(&m_periodicOperationsTimer, &QTimer::timeout, []() {
     TaskScheduler::scheduleTask(new TaskAccountAndServers());
@@ -121,10 +122,10 @@ MozillaVPN::MozillaVPN() : m_private(new Private()) {
     }
   });
 
-  connect(&m_private->m_controller, &Controller::readyToUpdate,
+  connect(&m_private->m_controller, &Controller::readyToUpdate, this,
           [this]() { setState(StateUpdateRequired); });
 
-  connect(&m_private->m_controller, &Controller::readyToBackendFailure,
+  connect(&m_private->m_controller, &Controller::readyToBackendFailure, this,
           [this]() {
             TaskScheduler::deleteTasks();
             setState(StateBackendFailure);

--- a/src/platforms/android/androidiaphandler.cpp
+++ b/src/platforms/android/androidiaphandler.cpp
@@ -315,7 +315,7 @@ void AndroidIAPHandler::validatePurchase(QJsonObject purchase) {
   Q_ASSERT(purchaseTask);
 
   connect(
-      purchaseTask, &TaskPurchase::failed,
+      purchaseTask, &TaskPurchase::failed, this,
       [this](QNetworkReply::NetworkError error, const QByteArray&) {
         logger.error() << "Purchase validation request to guardian failed";
         MozillaVPN::instance()->errorHandle(ErrorHandler::toErrorType(error));
@@ -323,7 +323,7 @@ void AndroidIAPHandler::validatePurchase(QJsonObject purchase) {
         emit subscriptionNotValidated();
       });
 
-  connect(purchaseTask, &TaskPurchase::succeeded,
+  connect(purchaseTask, &TaskPurchase::succeeded, this,
           [this, token](const QByteArray& data) {
             logger.debug() << "Products request to guardian completed" << data;
 

--- a/src/platforms/ios/iosiaphandler.mm
+++ b/src/platforms/ios/iosiaphandler.mm
@@ -304,7 +304,7 @@ void IOSIAPHandler::processCompletedTransactions(const QStringList& ids) {
   TaskPurchase* purchase = TaskPurchase::createForIOS(receipt);
   Q_ASSERT(purchase);
 
-  connect(purchase, &TaskPurchase::failed,
+  connect(purchase, &TaskPurchase::failed, this,
           [this](QNetworkReply::NetworkError error, const QByteArray& data) {
             logger.error() << "Purchase request failed" << error;
 
@@ -335,7 +335,7 @@ void IOSIAPHandler::processCompletedTransactions(const QStringList& ids) {
             emit alreadySubscribed();
           });
 
-  connect(purchase, &TaskPurchase::succeeded, [this, ids](const QByteArray&) {
+  connect(purchase, &TaskPurchase::succeeded, this, [this, ids](const QByteArray&) {
     logger.debug() << "Purchase request completed";
     SettingsHolder* settingsHolder = SettingsHolder::instance();
     Q_ASSERT(settingsHolder);

--- a/src/platforms/wasm/wasmauthenticationlistener.cpp
+++ b/src/platforms/wasm/wasmauthenticationlistener.cpp
@@ -34,6 +34,6 @@ void WasmAuthenticationListener::start(Task* task, const QString& codeChallenge,
   Q_UNUSED(emailAddress);
 
   QTimer* timer = new QTimer(this);
-  connect(timer, &QTimer::timeout, [this]() { emit completed("WASM"); });
+  connect(timer, &QTimer::timeout, this, [this]() { emit completed("WASM"); });
   timer->start(2000);
 }

--- a/src/tasks/accountandservers/taskaccountandservers.cpp
+++ b/src/tasks/accountandservers/taskaccountandservers.cpp
@@ -30,7 +30,7 @@ void TaskAccountAndServers::run() {
     NetworkRequest* request = NetworkRequest::createForAccount(this);
 
     connect(
-        request, &NetworkRequest::requestFailed,
+        request, &NetworkRequest::requestFailed, this,
         [this](QNetworkReply::NetworkError error, const QByteArray&) {
           logger.error() << "Account request failed" << error;
           MozillaVPN::instance()->errorHandle(ErrorHandler::toErrorType(error));
@@ -38,7 +38,7 @@ void TaskAccountAndServers::run() {
           maybeCompleted();
         });
 
-    connect(request, &NetworkRequest::requestCompleted,
+    connect(request, &NetworkRequest::requestCompleted, this,
             [this](const QByteArray& data) {
               logger.debug() << "Account request completed";
               MozillaVPN::instance()->accountChecked(data);
@@ -52,7 +52,7 @@ void TaskAccountAndServers::run() {
     NetworkRequest* request = NetworkRequest::createForServers(this);
 
     connect(
-        request, &NetworkRequest::requestFailed,
+        request, &NetworkRequest::requestFailed, this,
         [this](QNetworkReply::NetworkError error, const QByteArray&) {
           logger.error() << "Failed to retrieve servers";
           MozillaVPN::instance()->errorHandle(ErrorHandler::toErrorType(error));
@@ -60,7 +60,7 @@ void TaskAccountAndServers::run() {
           maybeCompleted();
         });
 
-    connect(request, &NetworkRequest::requestCompleted,
+    connect(request, &NetworkRequest::requestCompleted, this,
             [this](const QByteArray& data) {
               logger.debug() << "Servers obtained";
               MozillaVPN::instance()->serversFetched(data);

--- a/src/tasks/adddevice/taskadddevice.cpp
+++ b/src/tasks/adddevice/taskadddevice.cpp
@@ -52,14 +52,14 @@ void TaskAddDevice::run() {
       this, m_deviceName, publicKey, m_deviceID);
 
   connect(
-      request, &NetworkRequest::requestFailed,
+      request, &NetworkRequest::requestFailed, this,
       [this](QNetworkReply::NetworkError error, const QByteArray&) {
         logger.error() << "Failed to add the device" << error;
         MozillaVPN::instance()->errorHandle(ErrorHandler::toErrorType(error));
         emit completed();
       });
 
-  connect(request, &NetworkRequest::requestCompleted,
+  connect(request, &NetworkRequest::requestCompleted, this,
           [this, publicKey, privateKey](const QByteArray&) {
             logger.debug() << "Device added";
             MozillaVPN::instance()->deviceAdded(m_deviceName, publicKey,

--- a/src/tasks/authenticate/desktopauthenticationlistener.cpp
+++ b/src/tasks/authenticate/desktopauthenticationlistener.cpp
@@ -21,7 +21,7 @@ DesktopAuthenticationListener::DesktopAuthenticationListener(QObject* parent)
   MVPN_COUNT_CTOR(DesktopAuthenticationListener);
 
   m_server = new QOAuthHttpServerReplyHandler(QHostAddress::LocalHost, this);
-  connect(m_server, &QAbstractOAuthReplyHandler::callbackReceived,
+  connect(m_server, &QAbstractOAuthReplyHandler::callbackReceived, this,
           [this](const QVariantMap& values) {
             logger.debug() << "DesktopAuthenticationListener data received";
 

--- a/src/tasks/authenticate/taskauthenticate.cpp
+++ b/src/tasks/authenticate/taskauthenticate.cpp
@@ -66,7 +66,7 @@ void TaskAuthenticate::run() {
   connect(m_authenticationListener, &AuthenticationListener::readyToFinish,
           this, &Task::completed);
 
-  connect(m_authenticationListener, &AuthenticationListener::completed,
+  connect(m_authenticationListener, &AuthenticationListener::completed, this,
           [this, pkceCodeVerifier](const QString& pkceCodeSucces) {
             logger.debug() << "Authentication completed with code:"
                            << pkceCodeSucces;
@@ -75,7 +75,7 @@ void TaskAuthenticate::run() {
                 NetworkRequest::createForAuthenticationVerification(
                     this, pkceCodeSucces, pkceCodeVerifier);
 
-            connect(request, &NetworkRequest::requestFailed,
+            connect(request, &NetworkRequest::requestFailed, this,
                     [](QNetworkReply::NetworkError error, const QByteArray&) {
                       logger.error()
                           << "Failed to complete the authentication" << error;
@@ -83,21 +83,21 @@ void TaskAuthenticate::run() {
                           ErrorHandler::toErrorType(error));
                     });
 
-            connect(request, &NetworkRequest::requestCompleted,
+            connect(request, &NetworkRequest::requestCompleted, this,
                     [this](const QByteArray& data) {
                       logger.debug() << "Authentication completed";
                       authenticationCompleted(data);
                     });
           });
 
-  connect(m_authenticationListener, &AuthenticationListener::failed,
+  connect(m_authenticationListener, &AuthenticationListener::failed, this,
           [this](const ErrorHandler::ErrorType error) {
             MozillaVPN::instance()->errorHandle(error);
             m_authenticationListener->aboutToFinish();
           });
 
   connect(m_authenticationListener, &AuthenticationListener::abortedByUser,
-          [this]() {
+          this, [this]() {
             MozillaVPN::instance()->abortAuthentication();
             m_authenticationListener->aboutToFinish();
           });

--- a/src/tasks/captiveportallookup/taskcaptiveportallookup.cpp
+++ b/src/tasks/captiveportallookup/taskcaptiveportallookup.cpp
@@ -27,7 +27,7 @@ void TaskCaptivePortalLookup::run() {
 
   NetworkRequest* request = NetworkRequest::createForCaptivePortalLookup(this);
   connect(
-      request, &NetworkRequest::requestFailed,
+      request, &NetworkRequest::requestFailed, this,
       [this](QNetworkReply::NetworkError error, const QByteArray&) {
         if (m_cancelled) {
           return;
@@ -37,7 +37,7 @@ void TaskCaptivePortalLookup::run() {
         emit completed();
       });
 
-  connect(request, &NetworkRequest::requestCompleted,
+  connect(request, &NetworkRequest::requestCompleted, this,
           [this](const QByteArray& data) {
             logger.debug() << "Lookup completed";
 

--- a/src/tasks/createsupportticket/taskcreatesupportticket.cpp
+++ b/src/tasks/createsupportticket/taskcreatesupportticket.cpp
@@ -44,14 +44,14 @@ void TaskCreateSupportTicket::run() {
   NetworkRequest* request = NetworkRequest::createForSupportTicket(
       this, m_email, m_subject, m_issueText, m_logs, m_category);
 
-  connect(request, &NetworkRequest::requestFailed,
+  connect(request, &NetworkRequest::requestFailed, this,
           [this](QNetworkReply::NetworkError error, const QByteArray&) {
             logger.error() << "Failed to create support ticket" << error;
             MozillaVPN::instance()->createTicketAnswerRecieved(false);
             emit completed();
           });
 
-  connect(request, &NetworkRequest::requestCompleted,
+  connect(request, &NetworkRequest::requestCompleted, this,
           [this](const QByteArray&) {
             logger.debug() << "Support ticket created";
             MozillaVPN::instance()->createTicketAnswerRecieved(true);

--- a/src/tasks/getfeaturelist/taskgetfeaturelist.cpp
+++ b/src/tasks/getfeaturelist/taskgetfeaturelist.cpp
@@ -27,13 +27,13 @@ TaskGetFeatureList::~TaskGetFeatureList() {
 void TaskGetFeatureList::run() {
   NetworkRequest* request = NetworkRequest::createForGetFeatureList(this);
 
-  connect(request, &NetworkRequest::requestFailed,
+  connect(request, &NetworkRequest::requestFailed, this,
           [this](QNetworkReply::NetworkError error, const QByteArray&) {
             logger.error() << "Get feature list is failed" << error;
             emit completed();
           });
 
-  connect(request, &NetworkRequest::requestCompleted,
+  connect(request, &NetworkRequest::requestCompleted, this,
           [this](const QByteArray& data) {
             logger.debug() << "Get feature list is completed" << data;
             FeatureList::instance()->updateFeatureList(data);

--- a/src/tasks/heartbeat/taskheartbeat.cpp
+++ b/src/tasks/heartbeat/taskheartbeat.cpp
@@ -24,7 +24,7 @@ TaskHeartbeat::~TaskHeartbeat() { MVPN_COUNT_DTOR(TaskHeartbeat); }
 void TaskHeartbeat::run() {
   NetworkRequest* request = NetworkRequest::createForHeartbeat(this);
 
-  connect(request, &NetworkRequest::requestFailed,
+  connect(request, &NetworkRequest::requestFailed, this,
           [this, request](QNetworkReply::NetworkError, const QByteArray&) {
             logger.error() << "Failed to talk with the server";
 
@@ -52,7 +52,7 @@ void TaskHeartbeat::run() {
             emit completed();
           });
 
-  connect(request, &NetworkRequest::requestCompleted,
+  connect(request, &NetworkRequest::requestCompleted, this,
           [this](const QByteArray& data) {
             logger.debug() << "Heartbeat content received:" << data;
 

--- a/src/tasks/ipfinder/taskipfinder.cpp
+++ b/src/tasks/ipfinder/taskipfinder.cpp
@@ -90,7 +90,7 @@ void TaskIPFinder::createRequest(const QHostAddress& address, bool ipv6) {
 
   ++m_requestCount;
 
-  connect(request, &NetworkRequest::requestFailed,
+  connect(request, &NetworkRequest::requestFailed, this,
           [this](QNetworkReply::NetworkError error, const QByteArray&) {
             logger.error() << "IP address request failed" << error;
 
@@ -109,7 +109,7 @@ void TaskIPFinder::createRequest(const QHostAddress& address, bool ipv6) {
             emit operationCompleted(QString(), QString(), QString());
           });
 
-  connect(request, &NetworkRequest::requestCompleted,
+  connect(request, &NetworkRequest::requestCompleted, this,
           [this, ipv6](const QByteArray& data) {
             logger.debug() << "IP address request completed";
 

--- a/src/tasks/products/taskproducts.cpp
+++ b/src/tasks/products/taskproducts.cpp
@@ -23,14 +23,14 @@ void TaskProducts::run() {
   NetworkRequest* request = NetworkRequest::createForProducts(this);
 
   connect(
-      request, &NetworkRequest::requestFailed,
+      request, &NetworkRequest::requestFailed, this,
       [this](QNetworkReply::NetworkError error, const QByteArray&) {
         logger.error() << "Products request to guardian failed" << error;
         MozillaVPN::instance()->errorHandle(ErrorHandler::toErrorType(error));
         emit completed();
       });
 
-  connect(request, &NetworkRequest::requestCompleted,
+  connect(request, &NetworkRequest::requestCompleted, this,
           [this](const QByteArray& data) {
             logger.debug() << "Products request to guardian completed" << data;
 

--- a/src/tasks/removedevice/taskremovedevice.cpp
+++ b/src/tasks/removedevice/taskremovedevice.cpp
@@ -38,14 +38,14 @@ void TaskRemoveDevice::run() {
       NetworkRequest::createForDeviceRemoval(this, m_publicKey);
 
   connect(
-      request, &NetworkRequest::requestFailed,
+      request, &NetworkRequest::requestFailed, this,
       [this](QNetworkReply::NetworkError error, const QByteArray&) {
         logger.error() << "Failed to remove the device" << error;
         MozillaVPN::instance()->errorHandle(ErrorHandler::toErrorType(error));
         emit completed();
       });
 
-  connect(request, &NetworkRequest::requestCompleted,
+  connect(request, &NetworkRequest::requestCompleted, this,
           [this](const QByteArray&) {
             logger.debug() << "Device removed";
             MozillaVPN::instance()->deviceRemoved(m_publicKey);

--- a/src/tasks/sendfeedback/tasksendfeedback.cpp
+++ b/src/tasks/sendfeedback/tasksendfeedback.cpp
@@ -36,13 +36,13 @@ void TaskSendFeedback::run() {
   NetworkRequest* request = NetworkRequest::createForFeedback(
       this, m_feedbackText, m_logs, m_rating, m_category);
 
-  connect(request, &NetworkRequest::requestFailed,
+  connect(request, &NetworkRequest::requestFailed, this,
           [this](QNetworkReply::NetworkError error, const QByteArray&) {
             logger.error() << "Failed to send feedback" << error;
             emit completed();
           });
 
-  connect(request, &NetworkRequest::requestCompleted,
+  connect(request, &NetworkRequest::requestCompleted, this,
           [this](const QByteArray&) {
             logger.debug() << "Feedback sent";
             emit completed();

--- a/src/tasks/surveydata/tasksurveydata.cpp
+++ b/src/tasks/surveydata/tasksurveydata.cpp
@@ -24,13 +24,13 @@ void TaskSurveyData::run() {
 
   NetworkRequest* request = NetworkRequest::createForSurveyData(this);
 
-  connect(request, &NetworkRequest::requestFailed,
+  connect(request, &NetworkRequest::requestFailed, this,
           [this](QNetworkReply::NetworkError error, const QByteArray&) {
             logger.error() << "Failed to fetch survey data" << error;
             emit completed();
           });
 
-  connect(request, &NetworkRequest::requestCompleted,
+  connect(request, &NetworkRequest::requestCompleted, this,
           [this](const QByteArray& data) {
             logger.debug() << "Survey data fetched";
             MozillaVPN::instance()->surveyChecked(data);

--- a/src/timercontroller.cpp
+++ b/src/timercontroller.cpp
@@ -18,9 +18,9 @@ TimerController::TimerController(ControllerImpl* impl) : m_impl(impl) {
 
   connect(m_impl, &ControllerImpl::initialized, this,
           &ControllerImpl::initialized);
-  connect(m_impl, &ControllerImpl::connected,
+  connect(m_impl, &ControllerImpl::connected, this,
           [this] { TimerController::maybeDone(true); });
-  connect(m_impl, &ControllerImpl::disconnected,
+  connect(m_impl, &ControllerImpl::disconnected, this,
           [this] { TimerController::maybeDone(false); });
   connect(m_impl, &ControllerImpl::statusUpdated, this,
           &ControllerImpl::statusUpdated);

--- a/src/update/balrog.cpp
+++ b/src/update/balrog.cpp
@@ -95,13 +95,13 @@ void Balrog::start(Task* task) {
 
   NetworkRequest* request = NetworkRequest::createForGetUrl(task, url, 200);
 
-  connect(request, &NetworkRequest::requestFailed,
+  connect(request, &NetworkRequest::requestFailed, this,
           [this](QNetworkReply::NetworkError error, const QByteArray&) {
             logger.error() << "Request failed" << error;
             deleteLater();
           });
 
-  connect(request, &NetworkRequest::requestCompleted,
+  connect(request, &NetworkRequest::requestCompleted, this,
           [this, task, request](const QByteArray& data) {
             logger.debug() << "Request completed";
 
@@ -150,13 +150,13 @@ bool Balrog::fetchSignature(Task* task, NetworkRequest* initialRequest,
 
   NetworkRequest* x5uRequest = NetworkRequest::createForGetUrl(task, x5u, 200);
 
-  connect(x5uRequest, &NetworkRequest::requestFailed,
+  connect(x5uRequest, &NetworkRequest::requestFailed, this,
           [this](QNetworkReply::NetworkError error, const QByteArray&) {
             logger.warning() << "Request failed" << error;
             deleteLater();
           });
 
-  connect(x5uRequest, &NetworkRequest::requestCompleted,
+  connect(x5uRequest, &NetworkRequest::requestCompleted, this,
           [this, task, signatureBlob, updateData](const QByteArray& x5uData) {
             logger.debug() << "Request completed";
             if (!checkSignature(task, x5uData, updateData, signatureBlob)) {
@@ -285,13 +285,13 @@ bool Balrog::processData(Task* task, const QByteArray& data) {
 
     NetworkRequest* request = NetworkRequest::createForGetUrl(task, url);
 
-    connect(request, &NetworkRequest::requestFailed,
+    connect(request, &NetworkRequest::requestFailed, this,
             [this](QNetworkReply::NetworkError error, const QByteArray&) {
               logger.error() << "Request failed" << error;
               deleteLater();
             });
 
-    connect(request, &NetworkRequest::requestHeaderReceived,
+    connect(request, &NetworkRequest::requestHeaderReceived, this,
             [this](NetworkRequest* request) {
               Q_ASSERT(request);
               logger.debug() << "Request header received";
@@ -307,7 +307,7 @@ bool Balrog::processData(Task* task, const QByteArray& data) {
               request->abort();
             });
 
-    connect(request, &NetworkRequest::requestCompleted,
+    connect(request, &NetworkRequest::requestCompleted, this,
             [this](const QByteArray&) {
               logger.debug() << "Request completed";
               deleteLater();
@@ -340,14 +340,14 @@ bool Balrog::processData(Task* task, const QByteArray& data) {
   request->disableTimeout();
 
   connect(
-      request, &NetworkRequest::requestFailed,
+      request, &NetworkRequest::requestFailed, this,
       [this, request](QNetworkReply::NetworkError error, const QByteArray&) {
         logger.error() << "Request failed" << error;
         propagateError(request, error);
         deleteLater();
       });
 
-  connect(request, &NetworkRequest::requestCompleted,
+  connect(request, &NetworkRequest::requestCompleted, this,
           [this, hashValue, hashFunction, url](const QByteArray& data) {
             logger.debug() << "Request completed";
 
@@ -447,14 +447,14 @@ bool Balrog::install(const QString& filePath) {
                   << Qt::endl;
   });
 
-  connect(process, &QProcess::errorOccurred,
+  connect(process, &QProcess::errorOccurred, this,
           [this](QProcess::ProcessError error) {
             logger.error() << "Installation failed:" << error;
             deleteLater();
           });
 
   connect(process,
-          QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished),
+          QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished), this,
           [this, process, logFile](int exitCode, QProcess::ExitStatus) {
             logger.debug() << "Installation completed - exitCode:" << exitCode;
 
@@ -494,7 +494,7 @@ bool Balrog::install(const QString& filePath) {
   QProcess* process = new QProcess(this);
   process->start("open", arguments);
   connect(process,
-          QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished),
+          QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished), this,
           [this, process](int exitCode, QProcess::ExitStatus) {
             logger.debug() << "Installation completed - exitCode:" << exitCode;
 

--- a/src/update/versionapi.cpp
+++ b/src/update/versionapi.cpp
@@ -34,7 +34,7 @@ void VersionApi::start(Task* task) {
             logger.error() << "Request failed" << error;
           });
 
-  connect(request, &NetworkRequest::requestCompleted,
+  connect(request, &NetworkRequest::requestCompleted, this,
           [this](const QByteArray& data) {
             logger.debug() << "Request completed";
 


### PR DESCRIPTION
Often we do not pass a 'context' param when connecting signals/slots via
functor. We should because in this way objects are automatically disconnected
when destroyed.