### PR TITLE
Gracefully support QSessionManager termination

### DIFF
--- a/src/commands/commandui.cpp
+++ b/src/commands/commandui.cpp
@@ -409,7 +409,9 @@ int CommandUI::run(QStringList& tokens) {
     QObject::connect(
         qApp, &QGuiApplication::commitDataRequest, &vpn,
         []() {
+#if QT_VERSION < 0x060000
           qApp->setFallbackSessionManagementEnabled(false);
+#endif
           MozillaVPN::instance()->deactivate();
         },
         Qt::DirectConnection);

--- a/src/commands/commandui.cpp
+++ b/src/commands/commandui.cpp
@@ -407,10 +407,10 @@ int CommandUI::run(QStringList& tokens) {
                      &MozillaVPN::aboutToQuit);
 
     QObject::connect(
-        qApp, &QGuiApplication::commitDataRequest, &engineHolder,
-        [&]() {
+        qApp, &QGuiApplication::commitDataRequest, &vpn,
+        []() {
           qApp->setFallbackSessionManagementEnabled(false);
-          vpn.deactivate();
+          MozillaVPN::instance()->deactivate();
         },
         Qt::DirectConnection);
 

--- a/src/commands/commandui.cpp
+++ b/src/commands/commandui.cpp
@@ -406,6 +406,14 @@ int CommandUI::run(QStringList& tokens) {
     QObject::connect(qApp, &QCoreApplication::aboutToQuit, &vpn,
                      &MozillaVPN::aboutToQuit);
 
+    QObject::connect(
+        qApp, &QGuiApplication::commitDataRequest, &engineHolder,
+        [&]() {
+          qApp->setFallbackSessionManagementEnabled(false);
+          vpn.deactivate();
+        },
+        Qt::DirectConnection);
+
     QObject::connect(vpn.controller(), &Controller::readyToQuit, &vpn,
                      &MozillaVPN::quit, Qt::QueuedConnection);
 


### PR DESCRIPTION
When terminating the desktop session, the default termination provided by Qt often results in a hung logout session due to the minimize-on-quit behavior of the main window.

Furthermore, logging out of the desktop session with the VPN connected may leave the tunnel active even though the GUI has exited. This can lead to confusing connection behavior when logging back in. To remedy this, it is safer to disconnect the VPN when handling session termination.

Closes: #2370