### PR TITLE
Fix QRC resource loading after Nebula refactor

### DIFF
--- a/src/fontloader.cpp
+++ b/src/fontloader.cpp
@@ -14,11 +14,12 @@ Logger logger(LOG_MAIN, "FontLoader");
 
 // static
 void FontLoader::loadFonts() {
-  QDir dir(":/ui/resources/fonts");
+  QDir dir(":/nebula/resources/fonts");
   QStringList files = dir.entryList();
   for (const QString& file : files) {
     logger.debug() << "Loading font:" << file;
-    int id = QFontDatabase::addApplicationFont(":/ui/resources/fonts/" + file);
+    int id =
+        QFontDatabase::addApplicationFont(":/nebula/resources/fonts/" + file);
     logger.debug() << "Result:" << id;
   }
 }

--- a/src/systemtraynotificationhandler.cpp
+++ b/src/systemtraynotificationhandler.cpp
@@ -198,7 +198,7 @@ void SystemTrayNotificationHandler::updateContextMenu() {
 
   m_lastLocationLabel->setVisible(true);
 
-  QIcon flagIcon(QString(":/ui/resources/flags/%1.png")
+  QIcon flagIcon(QString(":/nebula/resources/flags/%1.png")
                      .arg(vpn->currentServer()->exitCountryCode().toUpper()));
 
   QString countryCode = vpn->currentServer()->exitCountryCode();


### PR DESCRIPTION
On Linux, it seems that we fail to load fonts and assets from the Nebula QRC archive, which leads to warnings warnings in the `QFontDatabase` about missing system fonts, and breakage in the system tray due to misising country flags.