### PR TITLE
Add strings for “Server unavailable” modal

### DIFF
--- a/translations/strings.yaml
+++ b/translations/strings.yaml
@@ -329,3 +329,8 @@ crashreporter:
   dontSendButton:
     value: No thanks
     comment: User does not agree to send a crash report.
+
+serverUnavailableModal:
+  headerText: Server unavailable
+  bodyText: This server location is temporarily unavailable. Choose a new location.
+  buttonLabel: Choose a new location


### PR DESCRIPTION
Strings that will be needed for the [“Server unavailable” modal](https://github.com/mozilla-mobile/mozilla-vpn-client/pull/2419#issue-796124399).