### PR TITLE
fix: Multi-hop feature icon path

### DIFF
--- a/src/features/featuremultihop.h
+++ b/src/features/featuremultihop.h
@@ -19,7 +19,7 @@ class FeatureMultiHop : public Feature {
             L18nStrings::WhatsNewReleaseNotesMultiListItemBody,  // Description
             L18nStrings::WhatsNewReleaseNotesMultiModalBodyText,  // LongDescr
             "qrc:/ui/resources/features/multi-hop-preview.png",   // ImagePath
-            "qrc:/ui/resources/location-dark.svg",                // IconPath
+            "qrc:/nebula/resources/location-dark.svg",            // IconPath
             "",                                                   // link URL
 #if defined(MVPN_ANDROID) || defined(MVPN_IOS)
             "2.7",  // released for android


### PR DESCRIPTION
Updates the icon path of the “Multi-hop” feature to point to the new nebula resources.

Fixes #2413