### PR TITLE
Suppress false-positive SSL errors with raw Host headers

### DIFF
--- a/src/networkrequest.cpp
+++ b/src/networkrequest.cpp
@@ -22,7 +22,7 @@
 #include <QNetworkAccessManager>
 #include <QNetworkReply>
 #include <QNetworkRequest>
-#include <QRegExp>
+#include <QRegularExpression>
 #include <QUrl>
 #include <QUrlQuery>
 
@@ -928,9 +928,10 @@ bool NetworkRequest::checkSubjectName(const QSslCertificate& cert) {
 
   // Check there is a match amongst the subject alternative names.
   QStringList altNames = cert.subjectAlternativeNames().values(QSsl::DnsEntry);
-  for (const QString& name : altNames) {
-    QRegExp re(name, Qt::CaseSensitive, QRegExp::Wildcard);
-    if (re.exactMatch(hostname)) {
+  for (const QString& pattern : altNames) {
+    QRegularExpression re(
+        QRegularExpression::wildcardToRegularExpression(pattern));
+    if (re.match(hostname).hasMatch()) {
       logger.debug() << "Found subjectAltName match for" << hostname;
       return true;
     }

--- a/src/networkrequest.h
+++ b/src/networkrequest.h
@@ -147,6 +147,7 @@ class NetworkRequest final : public QObject {
   void handleReply(QNetworkReply* reply);
   void handleHeaderReceived();
   void handleRedirect(const QUrl& url);
+  bool checkSubjectName(const QSslCertificate& cert);
 
  private slots:
   void replyFinished();

--- a/src/networkrequest.h
+++ b/src/networkrequest.h
@@ -12,6 +12,7 @@
 
 class QHostAddress;
 class QNetworkAccessManager;
+class QSslCertificate;
 class QurlQuery;
 class Task;
 


### PR DESCRIPTION
The network request to lookup the user's IP address makes use of the raw `Host` header so that we can dispatch the request separately for both IPv4 and IPv6. However, this triggers an SSL error due to the certificate not matching the explicit IP addresses used for the network request. While we are able to ignore the error by calling `QNetworkReply::ignoreSslErrors()` this still generates a lot of noise in the logs, and we are leaving ourselves open to ignoring other certificate errors.

This patch should improve upon this solution by manually checking the certificate's subject names against the raw host header, and suppresses the SSL warning if, and only if, a match is found.