### PR TITLE
Fix missing units in connection info screen

### DIFF
--- a/nebula/ui/components/VPNGraphLegendMarker.qml
+++ b/nebula/ui/components/VPNGraphLegendMarker.qml
@@ -4,6 +4,7 @@
 
 import QtQuick 2.5
 
+import Mozilla.VPN 1.0
 import themes 0.1
 
 Row {


### PR DESCRIPTION
This was due to a missing QML import, leading to error messages in the `VPNGraphLegendMarker.qml` file as follows:
```
qrc:/nebula/components/VPNGraphLegendMarker.qml:19: ReferenceError: VPNl18n is not defined (VPNGraphLegendMarker.qml:19)
```

Closes: #2422 