### PR TITLE
Fix the logo dock path after Nebula refactor

### DIFF
--- a/src/constants.h
+++ b/src/constants.h
@@ -75,7 +75,7 @@ constexpr const char* API_PRODUCTION_URL = "https://vpn.mozilla.org";
 constexpr const char* API_STAGING_URL =
     "https://stage-vpn.guardian.nonprod.cloudops.mozgcp.net";
 
-constexpr const char* LOGO_URL = ":/ui/resources/logo-dock.png";
+constexpr const char* LOGO_URL = ":/nebula/resources/logo-dock.png";
 
 PRODBETAEXPR(const char*, fxaUrl, "https://api.accounts.firefox.com",
              "https://api-accounts.stage.mozaws.net")


### PR DESCRIPTION
The recent refactoring for Nebula moved the `logo-dock.png` into the Nebula directory, which caused the VPN client to show an empty dock icon.

Closes: #2436
Closes: #2424