### PR TITLE
Only run Taskcluster on main + releases/* branches (#2449)

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -100,7 +100,7 @@ tasks:
               $if: >
                 tasks_for in ["action", "cron"]
                 || (tasks_for == "github-pull-request" && pullRequestAction in ["opened", "reopened", "synchronize"])
-                || (tasks_for == "github-push" && head_branch[:10] != "refs/tags/")
+                || (tasks_for == "github-push" && (head_branch == "refs/heads/main" || head_branch[:19] == "refs/heads/releases"))
                 || (tasks_for == "github-release" && releaseAction == "published")
               then:
                   $let:
@@ -307,7 +307,7 @@ tasks:
                                               else:
                                                   $if: 'tasks_for == "github-release"'
                                                   then:
-                                                      symbol: 'ship_mozilavpn'
+                                                      symbol: 'ship_mozillavpn'
                                                   else:
                                                       $if: 'tasks_for == "action"'
                                                       then:


### PR DESCRIPTION
Dupe of #2449 - CI was failing since secrets are not filled in on forks 

This will stop running Decision tasks on feature branches. To run tasks
a pull request can still be opened for them.