### PR TITLE
Set wasm menu height to 0 when not visible

### DIFF
--- a/src/ui/main.qml
+++ b/src/ui/main.qml
@@ -123,7 +123,7 @@ Window {
     VPNWasmHeader {
         id: wasmMenuHeader
         visible: isWasmApp
-        height: VPNTheme.theme.menuHeight
+        height: visible ? VPNTheme.theme.menuHeight : 0
         anchors.top: parent.top
         anchors.topMargin: iosSafeAreaTopMargin.height
     }
@@ -133,7 +133,7 @@ Window {
         initialItem: mainView
         width: parent.width
         anchors.top: parent.top
-        anchors.topMargin: iosSafeAreaTopMargin.height + isWasmApp ? wasmMenuHeader.height : 0
+        anchors.topMargin: iosSafeAreaTopMargin.height + wasmMenuHeader.height
         height: safeContentHeight
         clip: true
     }


### PR DESCRIPTION
This zeroes out the height of the wasm menu when `!isWasmApp` and prevents app content from getting awkwardly pushed down on mobile (strangely, desktop is unaffected). 


<table>
<tr>
<td>Before</td>
<td>After</td>
</tr>
<td>
<img width="200" alt="Screen Shot 2021-12-21 at 12 34 45 PM" src="https://user-images.githubusercontent.com/22355127/147306461-1e1d4204-7bfe-4f85-a16d-d2953bf866bb.png">

</td>
<td>
<img width="200" alt="Screen Shot 2021-12-23 at 7 57 01 PM" src="https://user-images.githubusercontent.com/22355127/147306393-7b6a5d5a-6ff2-4c81-81da-53e69a1b42a2.png">

</td>
</tr>
</table>

<table>
<tr>
<td>Before</td>
<td>After</td>
</tr>
<td>
<img width="200" alt="Screen Shot 2021-12-23 at 7 27 54 PM" src="https://user-images.githubusercontent.com/22355127/147306657-c336ce9b-75dd-45c6-8fdb-6b46217dad4e.png">


</td>
<td>

<img width="200" alt="Screen Shot 2021-12-23 at 7 34 24 PM" src="https://user-images.githubusercontent.com/22355127/147306678-7a07a514-1e28-4dd2-bdd1-4e5e0b3a79a3.png">


</td>
</tr>
</table>

<table>
<tr>
<td colspan="2">
With visible wasm menu...
</td>
</tr>
<tr>
<td>
<img width="200" alt="Screen Shot 2021-12-23 at 7 50 04 PM" src="https://user-images.githubusercontent.com/22355127/147306774-a99533db-8653-41af-8fb4-17e33c33e1bc.png">
</td>

<td>
<img width="200" alt="Screen Shot 2021-12-23 at 7 35 44 PM" src="https://user-images.githubusercontent.com/22355127/147306798-fb1854e3-9dc9-46f3-8c13-5b2daa99c6f5.png">

</td>
</tr>
</table>


