### PR TITLE
Fix margins in ViewPrivacySecurity.qml/"System preferences"

### DIFF
--- a/src/ui/settings/ViewPrivacySecurity.qml
+++ b/src/ui/settings/ViewPrivacySecurity.qml
@@ -52,7 +52,7 @@ Item {
                 width: parent.width - VPNTheme.theme.windowMargin
                 onClicked: VPNSettings.startAtBoot = !VPNSettings.startAtBoot
                 visible: VPNFeatureList.get("startOnBoot").isSupported
-
+                anchors.rightMargin: VPNTheme.theme.windowMargin
             }
 
             VPNVerticalSpacer {
@@ -66,6 +66,7 @@ Item {
                 width: parent.width - VPNTheme.theme.windowMargin
                 anchors.left: parent.left
                 anchors.right: parent.right
+                anchors.rightMargin: VPNTheme.theme.windowMargin
 
                 //% "Data collection and use"
                 labelText: qsTrId("vpn.settings.dataCollection")


### PR DESCRIPTION
Fix margin issue in **System preferences**
<table>
<tr>
<td>
<img width="373" alt="Screen Shot 2021-12-17 at 12 38 52 PM" src="https://user-images.githubusercontent.com/22355127/147308189-720ddf84-1ccc-4798-b88b-764edf4517f7.png">


</td>
<td>
<img width="374" alt="Screen Shot 2021-12-17 at 12 43 18 PM" src="https://user-images.githubusercontent.com/22355127/147308113-5e0b62e1-3499-42d4-bbb9-26e44b7d1c99.png">


</td>
</tr>
</table>