### PR TITLE
Fix warnings in VPNAboutUs.qml and 'Check for update' button

### DIFF
--- a/nebula/ui/components/VPNAboutUs.qml
+++ b/nebula/ui/components/VPNAboutUs.qml
@@ -5,6 +5,7 @@
 import QtQuick 2.5
 import QtQuick.Controls 2.14
 import QtQuick.Layouts 1.14
+import QtQuick.Window 2.1
 
 import Mozilla.VPN 1.0
 import components 0.1
@@ -176,7 +177,7 @@ Item {
         onClicked: {
             listenForUpdateEvents=true;
             updateButtonImageAnimation.start();
-            VPN.releaseMonitor.runSoon();
+            VPNReleaseMonitor.runSoon();
         }
         text: VPNl18n.UpdateButtonCheckForUpdateButtonText
         Image {
@@ -243,8 +244,8 @@ Item {
                 Image {
                     anchors.fill: parent
                     source:  "qrc:/nebula/resources/updateStatusUpdateAvailable.svg"
-                    sourceSize.height: parent.height * QtQuick_Window.Screen.devicePixelRatio
-                    sourceSize.width: parent.width * QtQuick_Window.Screen.devicePixelRatio
+                    sourceSize.height: parent.height * Screen.devicePixelRatio
+                    sourceSize.width: parent.width * Screen.devicePixelRatio
                     fillMode: Image.PreserveAspectFit
 
                     anchors.horizontalCenter: parent.horizontalCenter
@@ -315,8 +316,8 @@ Item {
                 Image {
                     anchors.fill: parent
                     source: "qrc:/nebula/resources/updateStatusUpToDate.svg"
-                    sourceSize.height: parent.height * QtQuick_Window.Screen.devicePixelRatio
-                    sourceSize.width: parent.width * QtQuick_Window.Screen.devicePixelRatio
+                    sourceSize.height: parent.height * Screen.devicePixelRatio
+                    sourceSize.width: parent.width * Screen.devicePixelRatio
                     fillMode: Image.PreserveAspectFit
 
                     anchors.horizontalCenter: parent.horizontalCenter


### PR DESCRIPTION
```
[28.12.2021 10:12:05.224] Warning: qrc:/nebula/components/VPNAboutUs.qml:318: ReferenceError: QtQuick_Window is not defined (VPNAboutUs.qml:318)

[28.12.2021 10:12:05.929] Warning: qrc:/nebula/components/VPNAboutUs.qml:179: TypeError: Cannot call method 'runSoon' of undefined (VPNAboutUs.qml:179)
```

This fixes some console complaints in VPNAboutUs.qml about `runSoon()` and `QtQuick_Window` being undefined. 

Also fixes #2386. Clicking the 'Check for updates' button once again triggers the 'no update' modal to open again.