### PR TITLE
Mobile onboarding image transitions

### DIFF
--- a/src/ui/views/ViewMobileOnboarding.qml
+++ b/src/ui/views/ViewMobileOnboarding.qml
@@ -63,14 +63,24 @@ VPNFlickable {
 
                     Image {
                         id: panelImg
+
+                        property real imageScaleValue: 0.95
+                        property real imageOpacityValue: 0.0
+
                         anchors.horizontalCenter: parent.horizontalCenter
                         anchors.top: parent.top
                         anchors.topMargin: onboardingPanel.panelHeight / 2 - currentPanelValues._finalImageHeight
                         antialiasing: true
                         fillMode: Image.PreserveAspectFit
-                        opacity: 0
+                        opacity: panelImg.imageOpacityValue
                         source: imageSrc
                         sourceSize.height: currentPanelValues._startingImageHeight
+                        transform: Scale {
+                            origin.x: panelImg.width / 2
+                            origin.y: panelImg.height / 2
+                            xScale: panelImg.imageScaleValue
+                            yScale: panelImg.imageScaleValue
+                        }
 
                         SequentialAnimation {
                             id: updatePanel
@@ -83,30 +93,30 @@ VPNFlickable {
                                 targets: [panelTitle, panelDescription]
                                 property: "opacity"
                                 from: 1
-                                to: 0
+                                to: panelImg.imageOpacityValue
                                 duration: 100
                             }
                             PauseAnimation {
-                                duration: 300
+                                duration: 100
                             }
                             ScriptAction {
                                 script: updatePanel.updateStrings()
                             }
                             ParallelAnimation {
-                                PropertyAnimation {
+                                NumberAnimation {
                                     target: panelImg
-                                    property: "sourceSize.height"
-                                    from: currentPanelValues._startingImageHeight
-                                    to: currentPanelValues._finalImageHeight
-                                    duration: 200
+                                    property: "imageScaleValue"
+                                    from: panelImg.imageScaleValue
+                                    to: 1
+                                    duration: 250
                                     easing.type: Easing.OutQuad
                                 }
                                 PropertyAnimation {
                                     targets: [panelTitle, panelDescription, panelImg]
                                     property: "opacity"
-                                    from: 0
+                                    from: panelImg.imageOpacityValue
                                     to: 1
-                                    duration: 400
+                                    duration: 250
                                     easing.type: Easing.OutQuad
                                 }
                             }

--- a/src/ui/views/ViewMobileOnboarding.qml
+++ b/src/ui/views/ViewMobileOnboarding.qml
@@ -122,6 +122,13 @@ VPNFlickable {
                             }
                         }
                     }
+                    onClicked: {
+                        if (swipeView.currentIndex < onboardingModel.count - 1) {
+                            swipeView.currentIndex += 1;
+                        } else {
+                            swipeView.currentIndex = 0;
+                        }
+                    }
                     Component.onCompleted: {
                         currentPanelValues._panelTitleText = headline;
                         currentPanelValues._panelDescriptionText = subtitle;

--- a/src/ui/views/ViewMobileOnboarding.qml
+++ b/src/ui/views/ViewMobileOnboarding.qml
@@ -64,17 +64,17 @@ VPNFlickable {
                     Image {
                         id: panelImg
 
-                        property real imageScaleValue: 0.95
+                        property real imageScaleValue: 0.9
                         property real imageOpacityValue: 0.0
 
                         anchors.horizontalCenter: parent.horizontalCenter
                         anchors.top: parent.top
-                        anchors.topMargin: onboardingPanel.panelHeight / 2 - currentPanelValues._finalImageHeight
+                        anchors.topMargin: onboardingPanel.panelHeight / 2 - currentPanelValues._imageHeight
                         antialiasing: true
                         fillMode: Image.PreserveAspectFit
                         opacity: panelImg.imageOpacityValue
                         source: imageSrc
-                        sourceSize.height: currentPanelValues._startingImageHeight
+                        sourceSize.height: currentPanelValues._imageHeight
                         transform: Scale {
                             origin.x: panelImg.width / 2
                             origin.y: panelImg.height / 2
@@ -97,7 +97,7 @@ VPNFlickable {
                                 duration: 100
                             }
                             PauseAnimation {
-                                duration: 100
+                                duration: 150
                             }
                             ScriptAction {
                                 script: updatePanel.updateStrings()
@@ -151,8 +151,7 @@ VPNFlickable {
         id: currentPanelValues
         property string _panelTitleText: ""
         property string _panelDescriptionText: ""
-        property real _finalImageHeight: Math.min(240, panelHeight * .35)
-        property real _startingImageHeight: _finalImageHeight * .9
+        property real _imageHeight: Math.min(240, panelHeight * .35)
     }
 
     ColumnLayout {


### PR DESCRIPTION
Transforming the `height` of the images for the entering transition seems to cause some slight visual _jitter_ for me. Using `Scale` seems to resolve this issue. I also tweaked the transition durations a bit, but I’m not really sure if it’s _better_ and happy to reset to the initial values.

**Before**: Using `height`

https://user-images.githubusercontent.com/13835474/147763905-70cd26fa-22af-4727-adc1-ac6e4ee607f5.mp4

**After**: Using `Scale`

https://user-images.githubusercontent.com/13835474/147763910-80c1217f-043e-45f9-abc7-45a4f68ce221.mp4


