### PR TITLE
Patch QT header to fix inclusion error when compiling QT from scratch…

### DIFF
--- a/macos/qt-for-mac.patch
+++ b/macos/qt-for-mac.patch
@@ -1,0 +1,10 @@
+--- qiosurfacegraphicsbuffer_original.h	2020-09-02 12:15:07.000000000 +0200
++++ qiosurfacegraphicsbuffer.h	2022-01-04 11:04:55.000000000 +0100
+@@ -40,6 +40,7 @@
+ #ifndef QIOSURFACEGRAPHICSBUFFER_H
+ #define QIOSURFACEGRAPHICSBUFFER_H
+ 
++#include <CoreGraphics/CGColorSpace.h>
+ #include <qpa/qplatformgraphicsbuffer.h>
+ #include <private/qcore_mac_p.h>
+ 

--- a/scripts/qt5_compile.sh
+++ b/scripts/qt5_compile.sh
@@ -8,6 +8,7 @@
 
 POSITIONAL=()
 JOBS=8
+BASE_DIRECTORY="$(pwd)"
 
 helpFunction() {
   print G "Usage:"
@@ -79,6 +80,12 @@ if [[ "$OSTYPE" == "linux-gnu"* ]]; then
 elif [[ "$OSTYPE" == "darwin"* ]]; then
   print N "Configure for darwin"
   PLATFORM=$MACOS
+
+  # remove or review this if we upgrade to a more recent QT version
+  print Y "Patching QT header to compile on recent MacOS systems..."
+  patch -u -b "qtbase/src/plugins/platforms/cocoa/qiosurfacegraphicsbuffer.h" \
+        -i "$BASE_DIRECTORY/macos/qt-for-mac.patch"
+  print G "Done"
 else
   die "Unsupported platform (yet?)"
 fi


### PR DESCRIPTION
… on MacOS 11.6 and above.

See this issue for context: https://github.com/mozilla-mobile/mozilla-vpn-client/issues/2513