### PR TITLE
Disable Lottie Support for Windows

### DIFF
--- a/.github/workflows/windows-build.yaml
+++ b/.github/workflows/windows-build.yaml
@@ -82,9 +82,10 @@ jobs:
         with:
             name: build
             path: windows/installer/x64/MozillaVPN.msi
-
+            if-no-files-found: error 
       - name: Upload unsigned app
         uses: actions/upload-artifact@v2
         with:
             name: unsigned
             path: unsigned
+            if-no-files-found: error 

--- a/src/commands/commandui.cpp
+++ b/src/commands/commandui.cpp
@@ -27,7 +27,6 @@
 #include "theme.h"
 
 #include <glean.h>
-#include <lottie.h>
 #include <nebula.h>
 
 #ifdef MVPN_LINUX
@@ -50,6 +49,7 @@
 
 #ifndef Q_OS_WIN
 #  include "signalhandler.h"
+#  include <lottie.h>
 #endif
 
 #ifdef MVPN_WINDOWS
@@ -131,7 +131,11 @@ int CommandUI::run(QStringList& tokens) {
     QQmlApplicationEngine* engine = QmlEngineHolder::instance()->engine();
 
     Glean::Initialize(engine);
+
+#ifndef MVPN_WINDOWS
     Lottie::initialize(engine, QString(NetworkManager::userAgent()));
+#endif
+
     Nebula::Initialize(engine);
 
     MozillaVPN vpn;

--- a/src/src.pro
+++ b/src/src.pro
@@ -44,8 +44,18 @@ INCLUDEPATH += \
             ../nebula
 
 include($$PWD/../glean/glean.pri)
-include($$PWD/../lottie/lottie.pri)
+
 include($$PWD/../nebula/nebula.pri)
+
+!win32{
+    message("Adding Lottie")
+    # https://github.com/mozilla-mobile/mozilla-vpn-client/issues/2509
+    # Something in the Lottie project causes qmake to generate a 
+    # broken vcxproj, making windows fail the build
+    include($$PWD/../lottie/lottie.pri)
+    INCLUDEPATH += ../lottie/lib 
+}
+
 
 DEPENDPATH  += $${INCLUDEPATH}
 


### PR DESCRIPTION
Apparently the Lottie.pri is breaking windows builds and the CI did not catch it. 
Something about those 2 lines is making qmake generate a broken vcxproj but i dont know enough currently about how a qml import name would create broken vcxproj include-groups🤷 - See: https://github.com/mozilla-mobile/mozilla-vpn-client/issues/2509
```
QML_IMPORT_NAME = vpn.mozilla.lottie
QML_IMPORT_MAJOR_VERSION = 1

```
Since the code path is not relevant for 2.7, let's disable lottie on win so QA can get testable builds for now. 
Also let's have the CI error when there is no final msi. 