### PR TITLE
Fix string naming in captive_portal unblock

### DIFF
--- a/src/notificationhandler.cpp
+++ b/src/notificationhandler.cpp
@@ -193,7 +193,7 @@ void NotificationHandler::captivePortalUnblockNotificationRequired() {
   QString title =
       l18nStrings->t(L18nStrings::NotificationsCaptivePortalUnblockTitle);
   QString message =
-      l18nStrings->t(L18nStrings::NotificationsCaptivePortalUnblockMessage);
+      l18nStrings->t(L18nStrings::NotificationsCaptivePortalUnblockMessage2);
 
   notifyInternal(CaptivePortalUnblock, title, message,
                  Constants::CAPTIVE_PORTAL_ALERT_MSEC);

--- a/translations/strings.yaml
+++ b/translations/strings.yaml
@@ -265,7 +265,7 @@ notifications:
   captivePortalBlockTitle: Guest Wi-Fi portal blocked
   captivePortalBlockMessage2: The guest Wi-Fi network you’re connected to requires action. Click to turn off VPN to see the portal.
   captivePortalUnblockTitle: Guest Wi-Fi portal detected
-  captivePortalUnblockMessage: The guest Wi-Fi network you’re connected to may not be secure. Click here to turn on VPN to secure your device.
+  captivePortalUnblockMessage2: The guest Wi-Fi network you’re connected to may not be secure. Click to turn on VPN to secure your device.
   unsecuredNetworkTitle: Unsecured Wi-Fi network detected
   unsecuredNetworkMessage:
     value: "%1 is not secure. Click here to turn on VPN and secure your device."


### PR DESCRIPTION
From the new [spec ](https://www.figma.com/file/OQpyNjmowo3BIE23WGnOCM/Captive-Portal---Additional-Messaging?node-id=14%3A1434) - we did update the new "captivePortalBlockMessage2" - but I missed adjusting the "unblock" message to the new wording. 

closes https://github.com/mozilla-mobile/mozilla-vpn-client/issues/729