### PR TITLE
Deactivate Background Monitor on Network Changes

### DIFF
--- a/src/captiveportal/captiveportaldetection.cpp
+++ b/src/captiveportal/captiveportaldetection.cpp
@@ -37,6 +37,13 @@ void CaptivePortalDetection::networkChanged() {
   MozillaVPN* vpn = MozillaVPN::instance();
   Q_ASSERT(vpn);
 
+  // The captive portal background monitor is looking
+  // wheter a portal on the current network is gone.
+  // So it should be deactivated when the network changes.
+  // Otherwise we might show the "unblock" notification
+  // on networks that never had a portal.
+  captivePortalBackgroundMonitor()->stop();
+
   if (vpn->controller()->state() != Controller::StateOn &&
       vpn->controller()->state() != Controller::StateConfirming) {
     // Network Changed but we're not connected, no need to test for captive


### PR DESCRIPTION
The issue here is: 
-> We detect captive portal.
-> Press deactivate.
-> Doing this, we activate the background-monitor - this will look for a captive portal, to check if it is gone after auth. 
-> Instead we connect to another "secure" network.
-> The still active monitor will now detect "no portal" and send the "captive portal gone" notification but this network never had one in the first place.

So we should deactivate the Monitor once the network changes. 

Closes https://github.com/mozilla-mobile/mozilla-vpn-client/issues/2544