### PR TITLE
Don’t show error screen behind “Server unavailable” modal

### DIFF
--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -128,9 +128,8 @@ MozillaVPN::MozillaVPN() : m_private(new Private()) {
           });
 
   connect(&m_private->m_controller, &Controller::readyToServerUnavailable, this,
-          [this]() {
+          []() {
             NotificationHandler::instance()->serverUnavailableNotification();
-            setState(StateBackendFailure);
           });
 
   connect(&m_private->m_controller, &Controller::stateChanged, this,


### PR DESCRIPTION
In addition to showing the “Server unavailable” modal and launching a system notification we set `StateBackendFailure` which results in showing the error view on `readyToServerUnavailable`. If there isn’t a reason that we need it for something else at this point — let’s remove it.

Resolves #2582