### PR TITLE
Fix version bug when a pre/post release suffix exists.

### DIFF
--- a/src/update/versionapi.cpp
+++ b/src/update/versionapi.cpp
@@ -11,6 +11,7 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QJsonValue>
+#include <QRegularExpression>
 
 namespace {
 Logger logger(LOG_NETWORKING, "VersionApi");
@@ -133,20 +134,26 @@ int VersionApi::compareVersions(const QString& a, const QString& b) {
     return -1;
   }
 
-  QList<uint32_t> aParts;
-  for (const QString& part : a.split(".")) aParts.append(part.toInt());
+  QRegularExpression re("[^0-9a-z.]");
 
-  while (aParts.length() < 3) aParts.append(0);
+  QStringList aParts;
+  int aMatchLength = a.indexOf(re);
+  aParts = (aMatchLength < 0) ? a.split(".") : a.left(aMatchLength).split(".");
 
-  QList<uint32_t> bParts;
-  for (const QString& part : b.split(".")) bParts.append(part.toInt());
+  QStringList bParts;
+  int bMatchLength = b.indexOf(re);
+  bParts = (bMatchLength < 0) ? b.split(".") : b.left(bMatchLength).split(".");
 
-  while (bParts.length() < 3) bParts.append(0);
+  // Normalize by appending zeros as necessary.
+  while (aParts.length() < 3) aParts.append("0");
+  while (bParts.length() < 3) bParts.append("0");
 
   // Major version number.
   for (uint32_t i = 0; i < 3; ++i) {
-    if (aParts[i] != bParts[i]) {
-      return aParts[i] < bParts[i] ? -1 : 1;
+    int aDigit = aParts[i].toInt();
+    int bDigit = bParts[i].toInt();
+    if (aDigit != bDigit) {
+      return aDigit < bDigit ? -1 : 1;
     }
   }
 
@@ -158,7 +165,9 @@ QString VersionApi::stripMinor(const QString& a) {
   QStringList aParts;
 
   if (!a.isEmpty()) {
-    for (const QString& part : a.split(".")) aParts.append(part);
+    QRegularExpression re("[^0-9a-z.]");
+    int matchLength = a.indexOf(re);
+    aParts = (matchLength < 0) ? a.split(".") : a.left(matchLength).split(".");
   }
 
   while (aParts.length() < 3) aParts.append("0");

--- a/tests/unit/testreleasemonitor.cpp
+++ b/tests/unit/testreleasemonitor.cpp
@@ -202,6 +202,11 @@ void TestReleaseMonitor::compareVersions_data() {
                             << "0.1.2" << 1;
   QTest::addRow("b wins 10") << "0.1.3"
                              << "0.1.2" << 1;
+
+  QTest::addRow("a extra") << "1.2.3~4.5.6"
+                           << "1.2.3" << 0;
+  QTest::addRow("b extra") << "1.2.3"
+                           << "1.2.3~4.5.6" << 0;
 }
 
 void TestReleaseMonitor::compareVersions() {
@@ -226,6 +231,8 @@ void TestReleaseMonitor::stripMinor_data() {
                           << "1.2.0";
   QTest::addRow("big") << "1.2.3.4"
                        << "1.2.0";
+  QTest::addRow("extra") << "1.2.3~alpha"
+                         << "1.2.0";
 }
 
 void TestReleaseMonitor::stripMinor() {


### PR DESCRIPTION
The use of pre-release version suffixes causes `VersionApi::compareVersions()` to generate bad comparison results by dropping the trailing digit of the release. This in effect, leads to several of the feature API checks to report that features are unavailable when they ought to be. This can be fixed by extracting only the leading substring which contains digits and decimal separators.

Closes: #2584 #2581 #2572