### PR TITLE
fix: Captive portal layout

### DIFF
--- a/src/ui/views/ViewCaptivePortalInfo.qml
+++ b/src/ui/views/ViewCaptivePortalInfo.qml
@@ -14,7 +14,7 @@ VPNFlickable {
 
     flickContentHeight: content.height
 
-    state: (VPNController.state == VPNController.StateOff)? "pre-activation" : "post-activation"
+    state: (VPNController.state == VPNController.StateOff) ? "pre-activation" : "post-activation"
     states: [
         State {
             name: "pre-activation"

--- a/src/ui/views/ViewCaptivePortalInfo.qml
+++ b/src/ui/views/ViewCaptivePortalInfo.qml
@@ -12,8 +12,9 @@ import components 0.1
 VPNFlickable {
     id: vpnFlickable
 
-    state: (VPNController.state == VPNController.StateOff)? "pre-activation" : "post-activation"
+    flickContentHeight: content.height
 
+    state: (VPNController.state == VPNController.StateOff)? "pre-activation" : "post-activation"
     states: [
         State {
             name: "pre-activation"
@@ -39,63 +40,49 @@ VPNFlickable {
         }
     ]
 
-    Item {
-        id: spacer1
-        height: Math.max(Theme.windowMargin * 2, ( window.safeContentHeight - flickContentHeight ) / 2)
-        width: vpnFlickable.width
-    }
-
-    VPNPanel {
-        id: vpnPanel
-        property var childRectHeight: vpnPanel.childrenRect.height
-
-        anchors.top: spacer1.bottom
-        anchors.topMargin: 80
-        width: Math.min(vpnFlickable.width - VPNTheme.theme.windowMargin * 2, VPNTheme.theme.maxHorizontalContentWidth)
-        logoSize: 80
-        logoTitle: VPNl18n.CaptivePortalAlertTitle
-        logoSubtitle: VPNl18n.CaptivePortalAlertHeader
-        logo: "qrc:/ui/resources/globe-warning.svg"
-    }
-
-    Item {
-        id: spacer2
-        anchors.top: vpnPanel.bottom
-        height: Math.max(VPNTheme.theme.windowMargin * 2, (window.safeContentHeight - flickContentHeight ) / 2)
-        width: vpnFlickable.width
-    }
-
-    VPNSubtitle {
-        id: subTextBlock
-        anchors.top:  vpnPanel.bottom
-        anchors.topMargin: VPNTheme.theme.windowMargin
-        anchors.horizontalCenter: parent.horizontalCenter
-        width: Math.min(vpnFlickable.width - (VPNTheme.theme.windowMargin * 4), VPNTheme.theme.maxHorizontalContentWidth)
-        font.family: VPNTheme.theme.fontBoldFamily
-        font.pixelSize: VPNTheme.theme.fontSizeSmall
-        color: VPNTheme.theme.fontColor
-        Layout.fillWidth: true
-        Layout.alignment: Qt.AlignHCenter
-        text: VPNl18n.CaptivePortalAlertPreActivation
-    }
-
-
 
     ColumnLayout {
-        id: footerContent
+        id: content
 
-        anchors.top: subTextBlock.bottom
         anchors.horizontalCenter: parent.horizontalCenter
-        width: Math.min(parent.width, VPNTheme.theme.maxHorizontalContentWidth)
-        spacing: VPNTheme.theme.windowMargin * 1.25
+        anchors.verticalCenter: parent.verticalCenter
+        width: Math.min(vpnFlickable.width, VPNTheme.theme.maxHorizontalContentWidth)
 
-        Item {
+        VPNPanel {
+            id: vpnPanel
+            property var childRectHeight: vpnPanel.childrenRect.height
+
+            logo: "qrc:/ui/resources/globe-warning.svg"
+            logoSize: 80
+            logoSubtitle: VPNl18n.CaptivePortalAlertHeader
+            logoTitle: VPNl18n.CaptivePortalAlertTitle
+            width: parent.width
+
+            anchors.horizontalCenter: undefined
+            Layout.alignment: Qt.AlignHCenter
             Layout.fillWidth: true
-            Layout.preferredHeight: VPNTheme.theme.windowMargin / 2
+        }
+
+        VPNSubtitle {
+            id: subTextBlock
+
+            color: VPNTheme.theme.fontColor
+            font.pixelSize: VPNTheme.theme.fontSizeSmall
+            font.family: VPNTheme.theme.fontBoldFamily
+            text: VPNl18n.CaptivePortalAlertPreActivation
+            width: openPortalButton.width
+
+            Layout.alignment: Qt.AlignHCenter
+            Layout.fillWidth: true
+            Layout.bottomMargin: VPNTheme.theme.vSpacingSmall
+            Layout.topMargin: VPNTheme.theme.vSpacingSmall
+            Layout.leftMargin: VPNTheme.theme.windowMargin * 2
+            Layout.rightMargin: VPNTheme.theme.windowMargin * 2
         }
 
         VPNButton {
             id: openPortalButton
+
             objectName: "captivePortalAlertActionButton"
             text: VPNl18n.CaptivePortalAlertPreActivation
             radius: 4
@@ -108,11 +95,11 @@ VPNFlickable {
                 }
                 stackview.pop();
             }
+
+            Layout.fillWidth: true
+            Layout.leftMargin: VPNTheme.theme.windowMargin * 2
+            Layout.rightMargin: VPNTheme.theme.windowMargin * 2
         }
 
-        Item {
-            Layout.fillWidth: true
-            Layout.preferredHeight: VPNTheme.theme.windowMargin * 2
-        }
     }
 }

--- a/src/ui/views/ViewMain.qml
+++ b/src/ui/views/ViewMain.qml
@@ -42,10 +42,10 @@ VPNFlickable {
     ]
 
     Connections{
-     target: VPNController
-     onActivationBlockedForCaptivePortal:{
-        stackview.push("qrc:/ui/views/ViewCaptivePortalInfo.qml");
-       }
+        target: VPNController
+        onActivationBlockedForCaptivePortal:{
+            stackview.push("qrc:/ui/views/ViewCaptivePortalInfo.qml");
+        }
     }
     Connections{
         target: VPNCaptivePortal


### PR DESCRIPTION
Fixes the layout issues for longer locales on the `captive portal` view.

**Design**
[Figma spec](https://www.figma.com/file/OQpyNjmowo3BIE23WGnOCM/Captive-Portal---Additional-Messaging?node-id=14%3A1494)

**Before**
| EN | NL |
| --- | --- |
| <img width="472" alt="captive-portal-layout-before-en" src="https://user-images.githubusercontent.com/13835474/149787923-e3f3ced4-f97d-44fd-b027-ffe383a1eb51.png"> | <img width="472" alt="captive-portal-layout-before-nl" src="https://user-images.githubusercontent.com/13835474/149787942-aedc4009-d3ba-4a23-8fc9-a3bdc9b27970.png"> |

**After**
| EN | NL |
| --- | --- |
| <img width="472" alt="captive-portal-layout-after-en" src="https://user-images.githubusercontent.com/13835474/149788186-0b02f9cf-8e42-4454-ad07-92b7108e8f47.png"> | <img width="472" alt="captive-portal-layout-after-nl" src="https://user-images.githubusercontent.com/13835474/149788038-29165bb4-d2d6-4857-9622-ed6cc426e499.png"> |

Resolves #2579