### PR TITLE
Hide slide indicator for single tour features

### DIFF
--- a/nebula/ui/components/VPNFeatureTour.qml
+++ b/nebula/ui/components/VPNFeatureTour.qml
@@ -230,7 +230,7 @@ ColumnLayout {
             currentIndex: swipeView.currentIndex - 1
             interactive: false
             spacing: VPNTheme.theme.windowMargin / 2
-            visible: swipeView.currentIndex >= 1
+            visible: swipeView.currentIndex >= 1 && count > 1
             delegate: Rectangle {
                 id: circle
 


### PR DESCRIPTION
In case we only show one feature in the _What’s new_ panel there is a single page indicator that might be confusing. Let’s only show it if there is more than one feature to discover.

| Before | After |
| --- | --- |
| <img width="472" alt="single-feature-slide-indicator-before" src="https://user-images.githubusercontent.com/13835474/149816428-ad6f53a7-ddad-4c8b-bb1d-539b8190a79e.png"> | <img width="472" alt="single-feature-slide-indicator-after" src="https://user-images.githubusercontent.com/13835474/149816434-336f740c-d495-4626-bd82-cf0be126a11c.png"> |

