### PR TITLE
Check if we are in an active subscription process before showing error

### DIFF
--- a/src/platforms/ios/iosiaphandler.mm
+++ b/src/platforms/ios/iosiaphandler.mm
@@ -329,6 +329,13 @@ void IOSIAPHandler::processCompletedTransactions(const QStringList& ids) {
           [this](QNetworkReply::NetworkError error, const QByteArray& data) {
             logger.error() << "Purchase request failed" << error;
 
+            if (m_subscriptionState != eActive) {
+              logger.warning()
+                  << "Transaction failed out of subscription process! Don't need to show error.";
+              emit subscriptionFailed();
+              return;
+            }
+
             stopSubscription();
 
             QJsonDocument json = QJsonDocument::fromJson(data);

--- a/src/platforms/ios/iosiaphandler.mm
+++ b/src/platforms/ios/iosiaphandler.mm
@@ -329,13 +329,6 @@ void IOSIAPHandler::processCompletedTransactions(const QStringList& ids) {
           [this](QNetworkReply::NetworkError error, const QByteArray& data) {
             logger.error() << "Purchase request failed" << error;
 
-            if (m_subscriptionState != eActive) {
-              logger.warning()
-                  << "Transaction failed out of subscription process! Don't need to show error.";
-              emit subscriptionFailed();
-              return;
-            }
-
             stopSubscription();
 
             QJsonDocument json = QJsonDocument::fromJson(data);

--- a/src/ui/main.qml
+++ b/src/ui/main.qml
@@ -361,7 +361,13 @@ Window {
     Connections {
         target: VPNErrorHandler
         function onSubscriptionGeneric() {
+            if(VPN.state !== VPN.StateSubscriptionNeeded && VPN.state !== VPN.StateSubscriptionInProgress) {
+                return;
+            }
+
             mainStackView.push("qrc:/ui/views/ViewErrorFullScreen.qml", {
+                isMainView: true,
+
                 // Problem confirming subscription...
                 headlineText: VPNl18n.GenericPurchaseErrorGenericPurchaseErrorHeader,
 
@@ -370,16 +376,22 @@ Window {
                 errorMessage: VPNl18n.RestorePurchaseGenericPurchaseErrorRestorePurchaseGenericPurchaseErrorText,
 
                 // Try again
-                buttonText: VPNl18n.GenericPurchaseErrorGenericPurchaseErrorButton,
-                buttonObjectName: "errorTryAgainButton",
-                buttonOnClick: mainStackView.pop,
-                signOffLinkVisible: false,
+                primaryButtonText: VPNl18n.GenericPurchaseErrorGenericPurchaseErrorButton,
+                primaryButtonObjectName: "errorTryAgainButton",
+                primaryButtonOnClick: mainStackView.pop,
+                secondaryButtonIsSignOff: false,
                 getHelpLinkVisible: true
             });
         }
 
         function onNoSubscriptionFound() {
+            if(VPN.state !== VPN.StateSubscriptionNeeded && VPN.state !== VPN.StateSubscriptionInProgress) {
+                return;
+            }
+
             mainStackView.push("qrc:/ui/views/ViewErrorFullScreen.qml", {
+                isMainView: true,
+
                 // Problem confirming subscription...
                 headlineText: VPNl18n.GenericPurchaseErrorGenericPurchaseErrorHeader,
 
@@ -388,16 +400,22 @@ Window {
                 errorMessage: VPNl18n.RestorePurchaseGenericPurchaseErrorRestorePurchaseGenericPurchaseErrorText,
 
                 // Try again
-                buttonText: VPNl18n.GenericPurchaseErrorGenericPurchaseErrorButton,
-                buttonObjectName: "errorTryAgainButton",
-                buttonOnClick: mainStackView.pop,
-                signOffLinkVisible: true,
+                primaryButtonText: VPNl18n.GenericPurchaseErrorGenericPurchaseErrorButton,
+                primaryButtonObjectName: "errorTryAgainButton",
+                primaryButtonOnClick: mainStackView.pop,
+                secondaryButtonIsSignOff: true,
                 getHelpLinkVisible: true
             });
         }
 
         function onSubscriptionExpired() {
+            if(VPN.state !== VPN.StateSubscriptionNeeded && VPN.state !== VPN.StateSubscriptionInProgress) {
+                return;
+            }
+
             mainStackView.push("qrc:/ui/views/ViewErrorFullScreen.qml", {
+                isMainView: true,
+                
                 // Problem confirming subscription...
                 headlineText: VPNl18n.GenericPurchaseErrorGenericPurchaseErrorHeader,
 
@@ -406,16 +424,22 @@ Window {
                 errorMessage: VPNl18n.RestorePurchaseExpiredErrorRestorePurchaseExpiredErrorText,
 
                 // Try again
-                buttonText: VPNl18n.GenericPurchaseErrorGenericPurchaseErrorButton,
-                buttonObjectName: "errorTryAgainButton",
-                buttonOnClick: mainStackView.pop,
-                signOffLinkVisible: false,
+                primaryButtonText: VPNl18n.GenericPurchaseErrorGenericPurchaseErrorButton,
+                primaryButtonObjectName: "errorTryAgainButton",
+                primaryButtonOnClick: mainStackView.pop,
+                secondaryButtonIsSignOff: false,
                 getHelpLinkVisible: true
             });
         }
 
         function onSubscriptionInUse() {
+            if(VPN.state !== VPN.StateSubscriptionNeeded && VPN.state !== VPN.StateSubscriptionInProgress) {
+                return;
+            }
+
             mainStackView.push("qrc:/ui/views/ViewErrorFullScreen.qml", {
+                isMainView: true,
+                
                 // Problem confirming subscription...
                 headlineText: VPNl18n.GenericPurchaseErrorGenericPurchaseErrorHeader,
 
@@ -424,10 +448,10 @@ Window {
                 errorMessage: VPNl18n.RestorePurchaseInUseErrorRestorePurchaseInUseErrorText,
 
                 // Sign out
-                buttonText: qsTrId("vpn.main.signOut2"),
-                buttonObjectName: "errorSignOutButton",
-                buttonOnClick: mainStackView.pop,
-                signOffLinkVisible: false,
+                primaryButtonText: qsTrId("vpn.main.signOut2"),
+                primaryButtonObjectName: "errorSignOutButton",
+                primaryButtonOnClick: mainStackView.pop,
+                secondaryButtonIsSignOff: false,
                 getHelpLinkVisible: true
             });
         }

--- a/src/ui/views/ViewErrorFullScreen.qml
+++ b/src/ui/views/ViewErrorFullScreen.qml
@@ -12,6 +12,8 @@ import org.mozilla.Glean 0.30
 import telemetry 0.30
 
 VPNFlickable {
+    property var isMainView: false
+
     property var headlineText
     property var errorMessage: ""
     property var errorMessage2: ""
@@ -39,7 +41,7 @@ VPNFlickable {
         visible: getHelpLinkVisible
 
         labelText: qsTrId("vpn.main.getHelp2")
-        onClicked: stackview.push("qrc:/ui/views/ViewGetHelp.qml", {isSettingsView: false})
+        onClicked: isMainView ? mainStackView.push("qrc:/ui/views/ViewGetHelp.qml", {isSettingsView: false, isMainView: true}) : stackview.push("qrc:/ui/views/ViewGetHelp.qml", {isSettingsView: false})
     }
 
     ColumnLayout {


### PR DESCRIPTION
Fixes #2598 and #2570 

The problem is a random subscription failed event. This causes an error to be shown. 
We should not show an error if we are not in an active subscription process.

The second error happened due to a change in variable names in `ViewErrorFullScreen.qml`