### PR TITLE
Add completion handler to the switching call

### DIFF
--- a/src/platforms/ios/ioscontroller.swift
+++ b/src/platforms/ios/ioscontroller.swift
@@ -202,7 +202,7 @@ public class IOSControllerImpl : NSObject {
                         let settings = config.asWgQuickConfig()
                         let settingsData = settings.data(using: .utf8)!
                         try (self.tunnel!.connection as? NETunnelProviderSession)?
-                                .sendProviderMessage(settingsData)
+                                .sendProviderMessage(settingsData) {_ in return}
                     } else {
                         try (self.tunnel!.connection as? NETunnelProviderSession)?.startTunnel()
                     }


### PR DESCRIPTION
A few months ago we removed the `completionHandler` for the sendProviderMessage call in the switching function. 

However, the handleAppMessage function, which receives the provider messages, returns if the `completionHandler` is nil. This might be a bug in the wireguard code. 

By simply adding a `completionHandler` that just returns the message gets handled and the switch works.