### PR TITLE
Prevent VPN from reconnecting to a location that is currently “unavailable”

### DIFF
--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -179,11 +179,19 @@ bool Controller::activate() {
   }
 
   if (m_state == StateOff) {
+    logger.debug() << "Test - try to turn on" << m_state;
+
     if (m_portalDetected) {
       emit activationBlockedForCaptivePortal();
       m_portalDetected = false;
       return true;
     }
+
+    if (hasCooldownForAllServersInACity()) {
+      logger.debug() << "Test - hasCooldownForAllServersInACity" << m_state;
+      return true;
+    }
+
     setState(StateConnecting);
   }
 
@@ -455,6 +463,12 @@ void Controller::setCooldownForAllServersInACity(const QString& countryCode,
   Q_ASSERT(vpn);
 
   vpn->setCooldownForAllServersInACity(countryCode, cityCode);
+}
+
+bool Controller::hasCooldownForAllServersInACity() {
+  logger.debug() << "Has cooldown for all servers in a city";
+
+  return true;
 }
 
 bool Controller::isUnsettled() { return !m_settled; }

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -469,9 +469,18 @@ bool Controller::hasCooldownForAllServers() {
   MozillaVPN* vpn = MozillaVPN::instance();
   Q_ASSERT(vpn);
 
-  return vpn->hasCooldownForAllServersInACity(
+  bool hasCooldownForAllExitServers = vpn->hasCooldownForAllServersInACity(
       vpn->currentServer()->exitCountryCode(),
       vpn->currentServer()->exitCityName());
+
+  if (FeatureMultiHop::instance()->isSupported() && vpn->multihop()) {
+    bool hasCooldownForAllEntryServers = vpn->hasCooldownForAllServersInACity(
+        vpn->currentServer()->entryCountryCode(),
+        vpn->currentServer()->entryCityName());
+    return hasCooldownForAllEntryServers || hasCooldownForAllExitServers;
+  }
+
+  return hasCooldownForAllExitServers;
 }
 
 bool Controller::isUnsettled() { return !m_settled; }

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -179,16 +179,14 @@ bool Controller::activate() {
   }
 
   if (m_state == StateOff) {
-    logger.debug() << "Test - try to turn on" << m_state;
-
     if (m_portalDetected) {
       emit activationBlockedForCaptivePortal();
       m_portalDetected = false;
       return true;
     }
 
-    if (hasCooldownForAllServersInACity()) {
-      logger.debug() << "Test - hasCooldownForAllServersInACity" << m_state;
+    if (hasCooldownForAllServers()) {
+      emit readyToServerUnavailable();
       return true;
     }
 
@@ -465,10 +463,15 @@ void Controller::setCooldownForAllServersInACity(const QString& countryCode,
   vpn->setCooldownForAllServersInACity(countryCode, cityCode);
 }
 
-bool Controller::hasCooldownForAllServersInACity() {
+bool Controller::hasCooldownForAllServers() {
   logger.debug() << "Has cooldown for all servers in a city";
 
-  return true;
+  MozillaVPN* vpn = MozillaVPN::instance();
+  Q_ASSERT(vpn);
+
+  return vpn->hasCooldownForAllServersInACity(
+      vpn->currentServer()->exitCountryCode(),
+      vpn->currentServer()->exitCityName());
 }
 
 bool Controller::isUnsettled() { return !m_settled; }

--- a/src/controller.h
+++ b/src/controller.h
@@ -104,7 +104,7 @@ class Controller final : public QObject {
   void serverUnavailable();
   void setCooldownForAllServersInACity(const QString& countryCode,
                                        const QString& cityCode);
-  bool hasCooldownForAllServersInACity();
+  bool hasCooldownForAllServers();
 
   void captivePortalPresent();
   void captivePortalGone();

--- a/src/controller.h
+++ b/src/controller.h
@@ -104,6 +104,7 @@ class Controller final : public QObject {
   void serverUnavailable();
   void setCooldownForAllServersInACity(const QString& countryCode,
                                        const QString& cityCode);
+  bool hasCooldownForAllServersInACity();
 
   void captivePortalPresent();
   void captivePortalGone();

--- a/src/models/servercountrymodel.cpp
+++ b/src/models/servercountrymodel.cpp
@@ -321,6 +321,12 @@ void ServerCountryModel::setServerCooldown(const QString& publicKey,
   }
 }
 
+// bool ServerCountryModel::hasServerCooldown(const QString& publicKey) {
+//   if (m_servers.contains(publicKey)) {
+//     return true;
+//   }
+// }
+
 void ServerCountryModel::setCooldownForAllServersInACity(
     const QString& countryCode, const QString& cityCode,
     unsigned int duration) {
@@ -340,6 +346,26 @@ void ServerCountryModel::setCooldownForAllServersInACity(
       break;
     }
   }
+}
+
+bool ServerCountryModel::hasCooldownForAllServersInACity(
+    const QString& countryCode, const QString& cityCode) const {
+  logger.debug()
+      << "Checking if all servers in a city have a cooldown period set"
+      << countryCode << cityCode;
+
+  for (const ServerCountry& country : m_countries) {
+    if (country.code() == countryCode) {
+      for (const ServerCity& city : country.cities()) {
+        if (city.code() == cityCode) {
+          return true;
+        }
+      }
+      break;
+    }
+  }
+
+  return false;
 }
 
 namespace {

--- a/src/models/servercountrymodel.cpp
+++ b/src/models/servercountrymodel.cpp
@@ -321,11 +321,18 @@ void ServerCountryModel::setServerCooldown(const QString& publicKey,
   }
 }
 
-// bool ServerCountryModel::hasServerCooldown(const QString& publicKey) {
-//   if (m_servers.contains(publicKey)) {
-//     return true;
-//   }
-// }
+bool ServerCountryModel::hasServerCooldown(const QString& publicKey) const {
+  if (m_servers.contains(publicKey)) {
+    qint64 now = QDateTime::currentSecsSinceEpoch();
+    if (m_servers.value(publicKey).cooldownTimeout() <= now) {
+      return false;
+    }
+
+    return true;
+  }
+
+  return false;
+}
 
 void ServerCountryModel::setCooldownForAllServersInACity(
     const QString& countryCode, const QString& cityCode,
@@ -349,16 +356,18 @@ void ServerCountryModel::setCooldownForAllServersInACity(
 }
 
 bool ServerCountryModel::hasCooldownForAllServersInACity(
-    const QString& countryCode, const QString& cityCode) const {
+    const QString& countryCode, const QString& cityName) const {
   logger.debug()
-      << "Checking if all servers in a city have a cooldown period set"
-      << countryCode << cityCode;
+      << "Checking if all servers in a city have a cooldown period set";
 
   for (const ServerCountry& country : m_countries) {
     if (country.code() == countryCode) {
       for (const ServerCity& city : country.cities()) {
-        if (city.code() == cityCode) {
-          return true;
+        if (city.name() == cityName) {
+          for (const QString& pubkey : city.servers()) {
+            return hasServerCooldown(pubkey);
+          }
+          break;
         }
       }
       break;

--- a/src/models/servercountrymodel.h
+++ b/src/models/servercountrymodel.h
@@ -58,12 +58,12 @@ class ServerCountryModel final : public QAbstractListModel {
 
   void retranslate();
   void setServerCooldown(const QString& publicKey, unsigned int duration);
-  // bool hasServerCooldown(const QString& publicKey);
+  bool hasServerCooldown(const QString& publicKey) const;
   void setCooldownForAllServersInACity(const QString& countryCode,
                                        const QString& cityCode,
                                        unsigned int duration);
   bool hasCooldownForAllServersInACity(const QString& countryCode,
-                                       const QString& cityCode) const;
+                                       const QString& cityName) const;
 
   // QAbstractListModel methods
 

--- a/src/models/servercountrymodel.h
+++ b/src/models/servercountrymodel.h
@@ -58,9 +58,12 @@ class ServerCountryModel final : public QAbstractListModel {
 
   void retranslate();
   void setServerCooldown(const QString& publicKey, unsigned int duration);
+  // bool hasServerCooldown(const QString& publicKey);
   void setCooldownForAllServersInACity(const QString& countryCode,
                                        const QString& cityCode,
                                        unsigned int duration);
+  bool hasCooldownForAllServersInACity(const QString& countryCode,
+                                       const QString& cityCode) const;
 
   // QAbstractListModel methods
 

--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -1022,6 +1022,12 @@ void MozillaVPN::setCooldownForAllServersInACity(const QString& countryCode,
   MozillaVPN::instance()->controller()->serverUnavailable();
 }
 
+bool MozillaVPN::hasCooldownForAllServersInACity(const QString& countryCode,
+                                                 const QString& cityName) {
+  return m_private->m_serverCountryModel.hasCooldownForAllServersInACity(
+      countryCode, cityName);
+}
+
 QList<Server> MozillaVPN::filterServerList(const QList<Server>& servers) const {
   QList<Server> results;
   qint64 now = QDateTime::currentSecsSinceEpoch();

--- a/src/mozillavpn.h
+++ b/src/mozillavpn.h
@@ -305,6 +305,8 @@ class MozillaVPN final : public QObject {
   void setServerCooldown(const QString& publicKey);
   void setCooldownForAllServersInACity(const QString& countryCode,
                                        const QString& cityCode);
+  bool hasCooldownForAllServersInACity(const QString& countryCode,
+                                       const QString& cityName);
 
   void addCurrentDeviceAndRefreshData();
 


### PR DESCRIPTION
When a user tries to connect to an unavailable server the VPN is stuck in `StateDisconnecting`. This PR prevents the VPN from attempting to connect to a city which has all of their servers set to a cooldown period.

Resolves #2583