### PR TITLE
Fix assert in server unavailable notification on Linux

### DIFF
--- a/src/platforms/linux/linuxsystemtraynotificationhandler.cpp
+++ b/src/platforms/linux/linuxsystemtraynotificationhandler.cpp
@@ -56,6 +56,7 @@ void LinuxSystemTrayNotificationHandler::notify(Message type,
   QString actionMessage;
   switch (type) {
     case None:
+    case ServerUnavailable:
       return SystemTrayNotificationHandler::notify(type, title, message,
                                                    timerMsec);
 


### PR DESCRIPTION
When a server unavailable notification occurs on Linux platforms, this can cause an assert in the system tray handler because the notification type is missing from the switch statement.