### PR TITLE
Remove transition from stackview.pop

### DIFF
--- a/src/ui/settings/ViewGiveFeedback.qml
+++ b/src/ui/settings/ViewGiveFeedback.qml
@@ -371,7 +371,7 @@ Item {
                 anchors.top: col.bottom
                 anchors.topMargin: VPNTheme.theme.vSpacing
                 anchors.horizontalCenter: parent.horizontalCenter
-                onClicked: stackview.pop(StackView.Immediate)
+                onClicked: stackview.pop()
                 Component.onCompleted: {
                    if (window.fullscreenRequired()) {
                        anchors.top = undefined;


### PR DESCRIPTION
Closes #2302 

For some reason the transition caused the blank page. Removing it fixed it.