### PR TITLE
Fix server reconnection issues

### DIFF
--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -184,12 +184,6 @@ bool Controller::activate() {
       m_portalDetected = false;
       return true;
     }
-
-    if (hasCooldownForAllServers()) {
-      emit readyToServerUnavailable();
-      return true;
-    }
-
     setState(StateConnecting);
   }
 
@@ -480,26 +474,6 @@ void Controller::setCooldownForAllServersInACity(const QString& countryCode,
   Q_ASSERT(vpn);
 
   vpn->setCooldownForAllServersInACity(countryCode, cityCode);
-}
-
-bool Controller::hasCooldownForAllServers() {
-  logger.debug() << "Has cooldown for all servers in a city";
-
-  MozillaVPN* vpn = MozillaVPN::instance();
-  Q_ASSERT(vpn);
-
-  bool hasCooldownForAllExitServers = vpn->hasCooldownForAllServersInACity(
-      vpn->currentServer()->exitCountryCode(),
-      vpn->currentServer()->exitCityName());
-
-  if (FeatureMultiHop::instance()->isSupported() && vpn->multihop()) {
-    bool hasCooldownForAllEntryServers = vpn->hasCooldownForAllServersInACity(
-        vpn->currentServer()->entryCountryCode(),
-        vpn->currentServer()->entryCityName());
-    return hasCooldownForAllEntryServers || hasCooldownForAllExitServers;
-  }
-
-  return hasCooldownForAllExitServers;
 }
 
 bool Controller::isUnsettled() { return !m_settled; }

--- a/src/controller.h
+++ b/src/controller.h
@@ -159,6 +159,7 @@ class Controller final : public QObject {
 
   void heartbeatCompleted();
 
+  void clearConnectedTime();
   void resetConnectedTime();
 
   void startUnsettledPeriod();

--- a/src/controller.h
+++ b/src/controller.h
@@ -104,7 +104,6 @@ class Controller final : public QObject {
   void serverUnavailable();
   void setCooldownForAllServersInACity(const QString& countryCode,
                                        const QString& cityCode);
-  bool hasCooldownForAllServers();
 
   void captivePortalPresent();
   void captivePortalGone();

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -307,9 +307,10 @@ bool Daemon::deactivate(bool emitSignals) {
     if (!run(Down, state.m_config)) {
       return false;
     }
-    if (emitSignals) {
-      emit disconnected();
-    }
+  }
+
+  if (emitSignals) {
+    emit disconnected();
   }
 
   // Cleanup DNS

--- a/src/daemon/daemonlocalserverconnection.cpp
+++ b/src/daemon/daemonlocalserverconnection.cpp
@@ -75,7 +75,6 @@ void DaemonLocalServerConnection::readData() {
 }
 
 void DaemonLocalServerConnection::parseCommand(const QByteArray& data) {
-  logger.debug() << "Command received:" << data.left(20);
 
   QJsonDocument json = QJsonDocument::fromJson(data);
   if (!json.isObject()) {
@@ -91,6 +90,8 @@ void DaemonLocalServerConnection::parseCommand(const QByteArray& data) {
   }
 
   QString type = typeValue.toString();
+  logger.debug() << type << "received:" << data.left(20);
+
   if (type == "activate") {
     InterfaceConfig config;
     if (!Daemon::parseConfig(obj, config)) {

--- a/src/daemon/daemonlocalserverconnection.cpp
+++ b/src/daemon/daemonlocalserverconnection.cpp
@@ -75,7 +75,6 @@ void DaemonLocalServerConnection::readData() {
 }
 
 void DaemonLocalServerConnection::parseCommand(const QByteArray& data) {
-
   QJsonDocument json = QJsonDocument::fromJson(data);
   if (!json.isObject()) {
     logger.error() << "Invalid input";

--- a/src/models/servercountrymodel.cpp
+++ b/src/models/servercountrymodel.cpp
@@ -326,19 +326,6 @@ void ServerCountryModel::setServerCooldown(const QString& publicKey,
   }
 }
 
-bool ServerCountryModel::hasServerCooldown(const QString& publicKey) const {
-  if (m_servers.contains(publicKey)) {
-    qint64 now = QDateTime::currentSecsSinceEpoch();
-    if (m_servers.value(publicKey).cooldownTimeout() <= now) {
-      return false;
-    }
-
-    return true;
-  }
-
-  return false;
-}
-
 void ServerCountryModel::setCooldownForAllServersInACity(
     const QString& countryCode, const QString& cityCode,
     unsigned int duration) {
@@ -358,28 +345,6 @@ void ServerCountryModel::setCooldownForAllServersInACity(
       break;
     }
   }
-}
-
-bool ServerCountryModel::hasCooldownForAllServersInACity(
-    const QString& countryCode, const QString& cityName) const {
-  logger.debug()
-      << "Checking if all servers in a city have a cooldown period set";
-
-  for (const ServerCountry& country : m_countries) {
-    if (country.code() == countryCode) {
-      for (const ServerCity& city : country.cities()) {
-        if (city.name() == cityName) {
-          for (const QString& pubkey : city.servers()) {
-            return hasServerCooldown(pubkey);
-          }
-          break;
-        }
-      }
-      break;
-    }
-  }
-
-  return false;
 }
 
 namespace {

--- a/src/models/servercountrymodel.h
+++ b/src/models/servercountrymodel.h
@@ -60,12 +60,9 @@ class ServerCountryModel final : public QAbstractListModel {
 
   void retranslate();
   void setServerCooldown(const QString& publicKey, unsigned int duration);
-  bool hasServerCooldown(const QString& publicKey) const;
   void setCooldownForAllServersInACity(const QString& countryCode,
                                        const QString& cityCode,
                                        unsigned int duration);
-  bool hasCooldownForAllServersInACity(const QString& countryCode,
-                                       const QString& cityName) const;
 
   // QAbstractListModel methods
 

--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -1025,7 +1025,6 @@ void MozillaVPN::setCooldownForAllServersInACity(const QString& countryCode,
                                                  const QString& cityCode) {
   m_private->m_serverCountryModel.setCooldownForAllServersInACity(
       countryCode, cityCode, Constants::SERVER_UNRESPONSIVE_COOLDOWN_SEC);
-  MozillaVPN::instance()->controller()->serverUnavailable();
 }
 
 QList<Server> MozillaVPN::filterServerList(const QList<Server>& servers) const {

--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -1028,12 +1028,6 @@ void MozillaVPN::setCooldownForAllServersInACity(const QString& countryCode,
   MozillaVPN::instance()->controller()->serverUnavailable();
 }
 
-bool MozillaVPN::hasCooldownForAllServersInACity(const QString& countryCode,
-                                                 const QString& cityName) {
-  return m_private->m_serverCountryModel.hasCooldownForAllServersInACity(
-      countryCode, cityName);
-}
-
 QList<Server> MozillaVPN::filterServerList(const QList<Server>& servers) const {
   QList<Server> results;
   qint64 now = QDateTime::currentSecsSinceEpoch();

--- a/src/mozillavpn.h
+++ b/src/mozillavpn.h
@@ -306,8 +306,6 @@ class MozillaVPN final : public QObject {
   void setServerCooldown(const QString& publicKey);
   void setCooldownForAllServersInACity(const QString& countryCode,
                                        const QString& cityCode);
-  bool hasCooldownForAllServersInACity(const QString& countryCode,
-                                       const QString& cityName);
 
   void addCurrentDeviceAndRefreshData();
 


### PR DESCRIPTION
This commit reverts the previous workaround in #2610 and fixes the underlying problem by ensuring that the daemon always emits a `disconnected()` signal, even if no attempt was made to  start a connection in the first place.

We also transition to the `Controller::StateConfirming` state as soon as a request has been made to the platform to start the connections. This should allow the user to abort the connection instead of waiting for the server unavailable popup, should the handshake take too long to complete.

We also remove the direct call to `Controller::serverUnavailable()` when setting cooldowns via the inspector, since we should leave it up to the controller to generate this naturally when instructed to activate the connection.

Closes: #2615
Closes: #2775