### PR TITLE
Add option to tunnel VPN traffic on port 53/DNS

### DIFF
--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -239,6 +239,11 @@ void Controller::activateInternal() {
   if (!FeatureMultiHop::instance()->isSupported() || !vpn->multihop()) {
     exitHop.m_excludedAddresses.append(exitHop.m_server.ipv4AddrIn());
     exitHop.m_excludedAddresses.append(exitHop.m_server.ipv6AddrIn());
+
+    // If requested, force the use of port 53/DNS.
+    if (settingsHolder->tunnelPort53()) {
+      exitHop.m_server.forcePort(53);
+    }
   }
   // For controllers that support multiple hops, create a queue of connections.
   // The entry server should start first, followed by the exit server.
@@ -249,6 +254,10 @@ void Controller::activateInternal() {
       logger.error() << "Empty entry server list in state" << m_state;
       serverUnavailable();
       return;
+    }
+    // If requested, force the use of port 53/DNS.
+    if (settingsHolder->tunnelPort53()) {
+      hop.m_server.forcePort(53);
     }
 
     hop.m_hopindex = 1;
@@ -267,6 +276,9 @@ void Controller::activateInternal() {
       serverUnavailable();
       return;
     }
+    // NOTE: For platforms without multihop support, we cannot emulate multihop
+    // and use port 53 at the same time. If the user has selected both options
+    // then let's choose multihop.
     exitHop.m_server.fromMultihop(exitHop.m_server, entryServer);
     exitHop.m_excludedAddresses.append(entryServer.ipv4AddrIn());
     exitHop.m_excludedAddresses.append(entryServer.ipv6AddrIn());

--- a/src/models/server.h
+++ b/src/models/server.h
@@ -48,6 +48,8 @@ class Server final {
 
   uint32_t multihopPort() const { return m_multihopPort; }
 
+  bool forcePort(uint32_t port);
+
   bool operator==(const Server& other) const {
     return m_publicKey == other.m_publicKey;
   }

--- a/src/settingslist.h
+++ b/src/settingslist.h
@@ -336,6 +336,14 @@ SETTING_STRING(token,     // getter
                true       // remove when reset
 )
 
+SETTING_BOOL(tunnelPort53,     // getter
+             setTunnelPort53,  // setter
+             hasTunnelPort53,  // has
+             "tunnelPort53",   // key
+             false,            // default value
+             true              // remove when reset
+)
+
 SETTING_BOOL(unsecuredNetworkAlert,     // getter
              setUnsecuredNetworkAlert,  // setter
              hasUnsecuredNetworkAlert,  // has

--- a/src/ui/settings/ViewNetworkSettings.qml
+++ b/src/ui/settings/ViewNetworkSettings.qml
@@ -75,6 +75,23 @@ Item {
                 }
             }
 
+            VPNCheckBoxRow {
+                id: tunnelPort53
+                objectName: "settingTunnelPort53"
+                width: parent.width - VPNTheme.theme.windowMargin
+                showDivider: true
+
+                labelText: VPNl18n.SettingsTunnelPort53
+                subLabelText: VPNl18n.SettingsTunnelPort53Description
+                isChecked: (VPNSettings.tunnelPort53)
+                isEnabled: vpnFlickable.vpnIsOff
+                onClicked: {
+                    if (vpnFlickable.vpnIsOff) {
+                        VPNSettings.tunnelPort53 = !VPNSettings.tunnelPort53
+                    }
+                }
+            }
+
             Column {
                 width: parent.width
                 spacing: VPNTheme.theme.windowMargin  /2

--- a/translations/strings.yaml
+++ b/translations/strings.yaml
@@ -310,7 +310,9 @@ settings:
     value: Connect VPN on startup
     comment: Startup refers to a device's startup, not the VPN client's.
   startAtBootSubtitle: Mozilla VPN will launch and connect when you start up your device
-  tunnelPort53: Tunnel VPN using port 53/DNS
+  tunnelPort53:
+    value: Tunnel VPN through port 53/DNS
+    comment: Tunnel is used as a verb, as in to direct traffic through
   tunnelPort53Description: Use port 53/DNS for Wireguard traffic, which may help evade firewalls
 
 

--- a/translations/strings.yaml
+++ b/translations/strings.yaml
@@ -310,6 +310,8 @@ settings:
     value: Connect VPN on startup
     comment: Startup refers to a device's startup, not the VPN client's.
   startAtBootSubtitle: Mozilla VPN will launch and connect when you start up your device
+  tunnelPort53: Tunnel VPN using port 53/DNS
+  tunnelPort53Description: Use port 53/DNS for Wireguard traffic, which may help evade firewalls
 
 
 aboutUs:


### PR DESCRIPTION
This option allows the user to force their VPN traffic to use UDP port 53/DNS, which may do a better job of evading aggressive network firewalls. This option can be supported generically in all cases except mobile platforms when combined with multihop.

![tunnel-port53](https://user-images.githubusercontent.com/7256630/150883213-52b552ba-ce26-4ed1-ab18-795170e42e35.png)

Some room for improvement: 
- [x] Wordsmithing around how this option is displayed in the settings menu.
- [ ] Display a warning that this option has no effect when combined with mutlihop on mobile devices.

See: #2621