### PR TITLE
basti/fixAndroidQt6StackView

### DIFF
--- a/nebula/ui/components/VPNStackView.qml
+++ b/nebula/ui/components/VPNStackView.qml
@@ -10,11 +10,19 @@ import Mozilla.VPN 1.0
 
 StackView {
     id: stackView
-    Component.onCompleted: VPNCloseEventHandler.addStackView(stackView)
 
     onCurrentItemChanged: {
         var objString = currentItem.toString().split("(")[0];
         VPN.currentView = objString.split("_QML")[0];
+    }
+
+    Component.onCompleted: function(){
+        VPNCloseEventHandler.addStackView(stackView)
+
+        if(!currentItem && typeof initialItem === "number" ){
+            console.error("Failed to parse initialItem, try Component.OnComplete:push(someURI)");
+        }
+
     }
 
     anchors.fill: parent

--- a/src/commands/commandui.cpp
+++ b/src/commands/commandui.cpp
@@ -137,9 +137,8 @@ int CommandUI::run(QStringList& tokens) {
     }
 
 #ifdef MVPN_DEBUG
-    // To enable the qml debugger:
-    // drop CONFIG+=qml_debug into src.pro or your qmake call
-    // Then go to QtCreator: Debug->Start Debugging-> Attach to QML port
+    // This enables the qt-creator qml debugger on debug builds.:
+    // Go to QtCreator: Debug->Start Debugging-> Attach to QML port
     // Port is 1234.
     // Note: Qt creator only will use localhost:port so tunnel any external
     // device to there i.e on android $adb forward tcp:1234 tcp:1234

--- a/src/commands/commandui.cpp
+++ b/src/commands/commandui.cpp
@@ -30,6 +30,10 @@
 #include <glean.h>
 #include <nebula.h>
 
+#ifdef MVPN_DEBUG
+#  include <QQmlDebuggingEnabler>
+#endif
+
 #ifdef MVPN_LINUX
 #  include "eventlistener.h"
 #  include "platforms/linux/linuxdependencies.h"
@@ -132,6 +136,24 @@ int CommandUI::run(QStringList& tokens) {
       }
     }
 
+#ifdef MVPN_DEBUG
+    // To enable the qml debugger:
+    // drop CONFIG+=qml_debug into src.pro or your qmake call
+    // Then go to QtCreator: Debug->Start Debugging-> Attach to QML port
+    // Port is 1234.
+    // Note: Qt creator only will use localhost:port so tunnel any external
+    // device to there i.e on android $adb forward tcp:1234 tcp:1234
+
+    // We need to create the qmldebug server before the engine is created.
+    QQmlDebuggingEnabler enabler;
+    bool ok = enabler.startTcpDebugServer(
+        1234, QQmlDebuggingEnabler::StartMode::DoNotWaitForClient, "0.0.0.0");
+    if (ok) {
+      logger.debug() << "Started QML Debugging server on 0.0.0.0:1234";
+    } else {
+      logger.error() << "Failed to start QML Debugging";
+    }
+#endif
     // This object _must_ live longer than MozillaVPN to avoid shutdown crashes.
     QmlEngineHolder engineHolder;
     QQmlApplicationEngine* engine = QmlEngineHolder::instance()->engine();

--- a/src/src.pro
+++ b/src/src.pro
@@ -1014,4 +1014,8 @@ debug {
 mvpn_debug {
     message(MVPN Debug enabled)
     DEFINES += MVPN_DEBUG
+
+    # This Flag will enable a qmljsdebugger on 0.0.0.0:1234
+    CONFIG+=qml_debug
+
 }

--- a/src/ui/states/StateAuthenticationInApp.qml
+++ b/src/ui/states/StateAuthenticationInApp.qml
@@ -10,5 +10,7 @@ import components 0.1
 VPNStackView {
     id: stackview
 
-    initialItem: "qrc:/ui/authenticationInApp/ViewAuthenticationInApp.qml"
+    Component.onCompleted: function(){
+        stackview.push("qrc:/ui/authenticationInApp/ViewAuthenticationInApp.qml")
+    }
 }

--- a/src/ui/states/StateDeviceLimit.qml
+++ b/src/ui/states/StateDeviceLimit.qml
@@ -10,5 +10,7 @@ import components 0.1
 VPNStackView {
     id: stackview
 
-    initialItem: "qrc:/ui/views/ViewDevices.qml"
+    Component.onCompleted: function(){
+        stackview.push("qrc:/ui/views/ViewDevices.qml")
+    }
 }

--- a/src/ui/states/StateMain.qml
+++ b/src/ui/states/StateMain.qml
@@ -11,5 +11,7 @@ VPNStackView {
     id: stackview
     objectName: "ViewMainStackView"
 
-    initialItem: "qrc:/ui/views/ViewMain.qml"
+    Component.onCompleted: function(){
+        stackview.push("qrc:/ui/views/ViewMain.qml")
+    }
 }

--- a/src/ui/states/StateModules.qml
+++ b/src/ui/states/StateModules.qml
@@ -10,5 +10,7 @@ import components 0.1
 VPNStackView {
     id: moduleStackview
 
-    initialItem: "qrc:/ui/modules/ModuleMain.qml"
+    Component.onCompleted: function(){
+        stackview.push("qrc:/ui/modules/ModuleMain.qml")
+    }
 }

--- a/src/ui/states/StateSubscriptionNeeded.qml
+++ b/src/ui/states/StateSubscriptionNeeded.qml
@@ -8,5 +8,7 @@ import QtQuick.Controls 2.14
 StackView {
     id: stackview
 
-    initialItem: "qrc:/ui/views/ViewSubscriptionNeeded.qml"
+    Component.onCompleted: function(){
+        stackview.push("qrc:/ui/views/ViewSubscriptionNeeded.qml")
+    }
 }

--- a/src/ui/states/StateUpdateRequired.qml
+++ b/src/ui/states/StateUpdateRequired.qml
@@ -7,5 +7,7 @@ import QtQuick 2.5
 Loader {
     id: loader
 
-    source: "qrc:/ui/views/ViewUpdate.qml"
+    Component.onCompleted: function(){
+        loader.source="qrc:/ui/views/ViewUpdate.qml"
+    }
 }

--- a/src/ui/views/ViewSettings.qml
+++ b/src/ui/views/ViewSettings.qml
@@ -38,7 +38,10 @@ Item {
         anchors.left: parent.left
         anchors.right: parent.right
         anchors.bottom: parent.bottom
-        initialItem: "qrc:/ui/settings/ViewSettingsMenu.qml"
+
+        Component.onCompleted: {
+            settingsStackView.push("qrc:/ui/settings/ViewSettingsMenu.qml")
+        }
 
         onCurrentItemChanged: {
             menu.title = Qt.binding(() => currentItem._menuTitle || "");


### PR DESCRIPTION
This is a wierd one, sorry. 

On Qt6/Android, when moving to either StateMainView/StateDeviceLimit, the page would be blank. No qml error given. 
I've digged into it using the debugger. It seems when `initialItem` was _supposed_ to be handled as a qrc-URL it will be parsed into ... a float (?). So ie. doing `stackview.onCompleted:push(initialItem)` will correctly point out that there is a type mismatch. 
Thus the view will be blank. 

From the [qml docs](https://doc.qt.io/qt-5/qml-qtquick-controls2-stackview.html#initialItem-prop): 
> Specifying an initial item is equivalent to:
> Component.onCompleted: stackView.push(myInitialItem)

This however this still works with qrc-urls! So I changed all usages of this to use this style. Also i've added an error message if that case is popping up in our code again 🙈 

 
Sidenote: that qmljsdebugger stuff is totally optional (i can remove it np)  but that piece helped me so much in debugging this, maybe we should keep it :D 