### PR TITLE
Show masked images when using Qt6

### DIFF
--- a/nebula/ui/components/VPNAvatar.qml
+++ b/nebula/ui/components/VPNAvatar.qml
@@ -18,10 +18,6 @@ Item {
         asynchronous: true
         height: logoRoot.height
         fillMode: Image.PreserveAspectFit
-        layer.enabled: true
-        layer.effect: VPNOpacityMask {
-            maskSource: avatarMask
-        }
         smooth: true
         source: isDefaultAvatar() ? "" : avatarUrl
     }
@@ -43,10 +39,19 @@ Item {
     Rectangle {
         id: avatarMask
 
+        anchors.centerIn: avatar
         height: avatar.height
-        radius: avatar.width / 2
+        radius: height / 2
         visible: false
-        width: avatar.height
+        width: height
+    }
+
+    VPNOpacityMask {
+        anchors.centerIn: avatar
+        height: avatar.height
+        width: height
+        source: avatar
+        maskSource: avatarMask
     }
 
     /**

--- a/nebula/ui/components/VPNPanel.qml
+++ b/nebula/ui/components/VPNPanel.qml
@@ -13,7 +13,6 @@ Item {
     property alias logoTitle: logoTitle.text
     property alias logoSubtitle: logoSubtitle.text
     property var logoSize: 76
-    property var maskImage: false
     property var isSettingsView: false
 
     anchors.horizontalCenter: parent.horizontalCenter
@@ -47,19 +46,6 @@ Item {
                 sourceSize.height: logoSize
                 sourceSize.width: logoSize
                 fillMode: Image.PreserveAspectFit
-                layer.enabled: true
-
-                Rectangle {
-                    id: mask
-
-                    anchors.fill: parent
-                    radius: logoSize / 2
-                    visible: false
-                }
-
-                layer.effect: VPNOpacityMask {
-                    maskSource: maskImage ? mask : undefined
-                }
             }
 
             VPNAvatar {

--- a/src/ui/settings/ViewSettingsMenu.qml
+++ b/src/ui/settings/ViewSettingsMenu.qml
@@ -48,7 +48,6 @@ VPNFlickable {
         logoSubtitle: VPNUser.email
         anchors.top: parent.top
         anchors.topMargin: (Math.max(window.safeContentHeight * .08, VPNTheme.theme.windowMargin * 2))
-        maskImage: true
         isSettingsView: true
     }
 


### PR DESCRIPTION
`OpacityMask` as `layer.effect` is not working as expected so that images do not show when compiling with Qt6.