### PR TITLE
Fix MacOS session logout bugs

### DIFF
--- a/src/localsocketcontroller.cpp
+++ b/src/localsocketcontroller.cpp
@@ -136,6 +136,7 @@ void LocalSocketController::deactivate(Reason reason) {
   logger.debug() << "Deactivating";
 
   if (m_state != eReady) {
+    logger.debug() << "No disconnect, controller is not ready";
     emit disconnected();
     return;
   }
@@ -354,4 +355,5 @@ void LocalSocketController::write(const QJsonObject& json) {
   Q_ASSERT(m_socket);
   m_socket->write(QJsonDocument(json).toJson(QJsonDocument::Compact));
   m_socket->write("\n");
+  m_socket->flush();
 }


### PR DESCRIPTION
When logging out of a MacOS desktop session, while the VPN is connected, we first need to shut down the VPN connection before the client can be safely terminated. Unfortunately, due to the asynchronous nature of socket IO, it often occurs that a `disconnect` command gets written to the socket, but it is never received by the daemon. We can work around this situation by calling `QAbstractSocket::flush()` after writing any command in the `LocalSocketController`

Closes: #2370 