### PR TITLE
Fix qml warnings

### DIFF
--- a/nebula/ui/components/VPNTabNavigation.qml
+++ b/nebula/ui/components/VPNTabNavigation.qml
@@ -86,11 +86,11 @@ Item {
 
     Rectangle {
         objectName: "activeTabIndicator"
-        width: bar.currentItem.width
+        width: bar.visible ? bar.currentItem.width : 0
         height: 2
         color: VPNTheme.colors.purple70
         anchors.bottom: bar.bottom
-        x: bar.currentItem.x
+        x: bar.visible ? bar.currentItem.x : 0
         visible: stack.children.length > 1
         Behavior on x {
             PropertyAnimation {

--- a/src/ui/views/ViewMain.qml
+++ b/src/ui/views/ViewMain.qml
@@ -50,7 +50,7 @@ VPNFlickable {
     Connections{
         target: VPNCaptivePortal
         function onCaptivePortalPresent() {
-            if(VPNController.state != VPNController.StateOff){
+            if (VPNController.state != VPNController.StateOff){
                 stackview.push("qrc:/ui/views/ViewCaptivePortalInfo.qml");
             }
         }

--- a/src/ui/views/ViewMain.qml
+++ b/src/ui/views/ViewMain.qml
@@ -41,15 +41,15 @@ VPNFlickable {
         }
     ]
 
-    Connections{
+    Connections {
         target: VPNController
-        onActivationBlockedForCaptivePortal:{
+        function onActivationBlockedForCaptivePortal() {
             stackview.push("qrc:/ui/views/ViewCaptivePortalInfo.qml");
         }
     }
     Connections{
         target: VPNCaptivePortal
-        onCaptivePortalPresent:{
+        function onCaptivePortalPresent() {
             if(VPNController.state != VPNController.StateOff){
                 stackview.push("qrc:/ui/views/ViewCaptivePortalInfo.qml");
             }


### PR DESCRIPTION
Fixes some QML warnings related to `Connections` properties syntax and `undefined` properties in `VPNTabNavigation`.