### PR TITLE
Openssl script update

### DIFF
--- a/scripts/openssl_compile.bat
+++ b/scripts/openssl_compile.bat
@@ -65,7 +65,7 @@ IF %ERRORLEVEL% NEQ 0 (
 )
 
 mkdir %BUILDDIR%
-xcopy /E /I "C:\Program Files\Common\SSL\" C:\MozillaVPNBuild\
+xcopy /E /I "C:\Program Files\Common\SSL\" %BUILDDIR%
 
 popd
 

--- a/scripts/openssl_compile.bat
+++ b/scripts/openssl_compile.bat
@@ -16,6 +16,7 @@ IF "%selfWrapped%" == "" (
   %ComSpec% /s /c ""%~0" %*"
   GOTO :EOF
 )
+ECHO Administrator privileges are required to run this script.
 
 IF "%~1"=="" (
   CALL :Usage
@@ -29,9 +30,8 @@ IF "%~2"=="clean" (
 
 CALL :CheckRequirements
 
-
 IF "%BUILDDIR%" == "" (
-  SET BUILDDIR=C:\MozillaVPNBuild
+  SET BUILDDIR=C:\MozillaVPNBuild\
 )
 
 ECHO Using Build Directory %BUILDDIR%
@@ -40,7 +40,7 @@ ECHO Compiling openssl...
 
 pushd %1
 
-perl Configure VC-WIN64A --release --prefix=%BUILDDIR% --openssldir=%BUILDDIR% no-tests -DOPENSSL_NO_ENGINE
+perl Configure VC-WIN64A --release --prefix="C:\\Program Files\\Common\openssl\\" --openssldir="C:\\Program Files\\Common\openssl\\" no-tests no-engine -DOPENSSL_NO_ENGINE
 IF %ERRORLEVEL% NEQ 0 (
   ECHO Failed to configure OpenSSL.
   EXIT /B 1
@@ -59,6 +59,9 @@ IF %ERRORLEVEL% NEQ 0 (
   ECHO Failed to install OpenSSL.
   EXIT /B 1
 )
+
+mkdir %BUILDDIR%
+xcopy "C:\Program Files\Common\openssl\" %BUILDDIR% /E /I
 
 popd
 

--- a/scripts/openssl_compile.bat
+++ b/scripts/openssl_compile.bat
@@ -17,12 +17,6 @@ IF "%selfWrapped%" == "" (
   GOTO :EOF
 )
 
-net file 1>NUL 2>NUL
-if not '%errorlevel%' == '0' (
-  ECHO This script requires administrator privileges.
-  exit /b
-)
-
 IF "%~1"=="" (
   CALL :Usage
   EXIT /B 1
@@ -32,7 +26,9 @@ IF "%~2"=="clean" (
   CALL :Clean %1
   EXIT /B 1
 )
+
 CALL :CheckRequirements
+
 
 IF "%BUILDDIR%" == "" (
   SET BUILDDIR=C:\MozillaVPNBuild
@@ -44,7 +40,7 @@ ECHO Compiling openssl...
 
 pushd %1
 
-perl Configure VC-WIN64A --release --prefix="C:\Program Files\Common\SSL" --openssldir="C:\Program Files\Common\SSL" no-tests
+perl Configure VC-WIN64A --release --prefix=%BUILDDIR% --openssldir=%BUILDDIR% no-tests -DOPENSSL_NO_ENGINE
 IF %ERRORLEVEL% NEQ 0 (
   ECHO Failed to configure OpenSSL.
   EXIT /B 1
@@ -63,9 +59,6 @@ IF %ERRORLEVEL% NEQ 0 (
   ECHO Failed to install OpenSSL.
   EXIT /B 1
 )
-
-mkdir %BUILDDIR%
-xcopy /E /I "C:\Program Files\Common\SSL\" %BUILDDIR%
 
 popd
 

--- a/scripts/openssl_compile.bat
+++ b/scripts/openssl_compile.bat
@@ -17,6 +17,12 @@ IF "%selfWrapped%" == "" (
   GOTO :EOF
 )
 
+net file 1>NUL 2>NUL
+if not '%errorlevel%' == '0' (
+    ECHO This script requires administrator privileges.
+    exit /b
+)
+
 IF "%~1"=="" (
   CALL :Usage
   EXIT /B 1
@@ -38,7 +44,7 @@ ECHO Compiling openssl...
 
 pushd %1
 
-perl Configure VC-WIN64A --release --prefix=%BUILDDIR% --openssldir=%BUILDDIR%\SSL no-tests
+perl Configure VC-WIN64A --release --prefix="C:\Program Files\Common\SSL" --openssldir="C:\Program Files\Common\SSL" no-tests
 IF %ERRORLEVEL% NEQ 0 (
   ECHO Failed to configure OpenSSL.
   EXIT /B 1
@@ -57,6 +63,9 @@ IF %ERRORLEVEL% NEQ 0 (
   ECHO Failed to install OpenSSL.
   EXIT /B 1
 )
+
+mkdir %BUILDDIR%
+xcopy /E /I "C:\Program Files\Common\SSL\" C:\MozillaVPNBuild\
 
 popd
 

--- a/scripts/openssl_compile.bat
+++ b/scripts/openssl_compile.bat
@@ -19,8 +19,8 @@ IF "%selfWrapped%" == "" (
 
 net file 1>NUL 2>NUL
 if not '%errorlevel%' == '0' (
-    ECHO This script requires administrator privileges.
-    exit /b
+  ECHO This script requires administrator privileges.
+  exit /b
 )
 
 IF "%~1"=="" (


### PR DESCRIPTION
Disable engines in openssl so that we do not load them at runtime.
The -DOPENSSL_NO_ENGINES switch disables all use of engines in openssl.  It will still load an openssl.cnf file, but not load any engines from it.