### PR TITLE
Fix server list spacing

### DIFF
--- a/nebula/ui/components/VPNServerCountry.qml
+++ b/nebula/ui/components/VPNServerCountry.qml
@@ -169,6 +169,7 @@ VPNClickableRow {
                 property string _activeServerCount: modelData[2]
                 property string _countryCode: code
                 property bool isAvailable: _activeServerCount > 0
+                property int itemHeight: 54
 
                 id: del
                 objectName: "serverCity-" + del._cityName.replace(/ /g, '_')
@@ -193,7 +194,7 @@ VPNClickableRow {
                     serversTabs[currentServer.whichHop] = [del._countryCode,  del._cityName, del._localizedCityName]; // [countryCode, cityName, localizedCityName]
                     multiHopStackView.pop();
                 }
-                height: 54
+                height: itemHeight
                 checked: del._countryCode === focusScope.currentServer.countryCode && del._cityName === focusScope.currentServer.cityName
                 isHoverable: cityListVisible && del.isAvailable
                 enabled: cityListVisible && del.isAvailable


### PR DESCRIPTION
Fixes the height of items in the server list when compiling with Qt 6 so that inputs are spaced correctly and are not being cut off anymore.

**Screenshots**
|Server list (before)|Server list (after)|
|---|---|
|<img width="428" alt="server-list-before" src="https://user-images.githubusercontent.com/13835474/153628391-337c5705-c3a1-4579-9179-8ae285920780.png">|<img width="472" alt="server-list-after" src="https://user-images.githubusercontent.com/13835474/153628397-bba3202f-8791-43bb-9db6-cc766bd374d3.png">|

Fixes #2649