### PR TITLE
Do not run CaptivePortalRequest::onResult() after an abort

### DIFF
--- a/src/networkrequest.cpp
+++ b/src/networkrequest.cpp
@@ -957,6 +957,8 @@ QByteArray NetworkRequest::rawHeader(const QByteArray& headerName) const {
 }
 
 void NetworkRequest::abort() {
+  m_aborted = true;
+
   if (!m_reply) {
     logger.error() << "INTERNAL ERROR! NetworkRequest::abort called before "
                       "starting the request";

--- a/src/networkrequest.h
+++ b/src/networkrequest.h
@@ -135,6 +135,7 @@ class NetworkRequest final : public QObject {
   QUrl url() const { return m_reply ? m_reply->url() : m_request.url(); }
 
   void abort();
+  bool isAborted() const { return m_aborted; }
 
   static QString apiBaseUrl();
 
@@ -174,6 +175,7 @@ class NetworkRequest final : public QObject {
   QNetworkReply* m_reply = nullptr;
   int m_status = 0;
   bool m_completed = false;
+  bool m_aborted = false;
 
   QUrl m_redirectedUrl;
 };


### PR DESCRIPTION
I managed to reproduce a crash:
It seems that we call ::onResult() multiple times. This can happen because an abort() triggers a finished() signal.

```
[11.02.2022 12:48:43.737] Debug: (captiveportal - CaptivePortalRequest) request: http://34.107.221.82/success.txt
[11.02.2022 12:48:43.737] Debug: (networking - NetworkRequest) Network request created by CaptivePortalRequestTask
[11.02.2022 12:48:43.737] Debug: (captiveportal - CaptivePortalRequest) request: http://[2600:1901:0:38d7::]/success.txt
[11.02.2022 12:48:43.737] Debug: (networking - NetworkRequest) Network request created by CaptivePortalRequestTask
[11.02.2022 12:48:43.737] Debug: (networking - NetworkRequest) Network reply received - status: 0 - expected: any
[11.02.2022 12:48:43.737] Error: (networking - NetworkRequest) Network error: Network unreachable status code: 0 - body:
[11.02.2022 12:48:43.737] Error: (networking - NetworkRequest) Failed to access: http://[2600:1901:0:38d7::]/success.txt
[11.02.2022 12:48:43.737] Warning: (captiveportal - CaptivePortalRequest) Captive portal request failed: QNetworkReply::UnknownNetworkError
[11.02.2022 12:48:43.749] Warning: Texture 0x7effc4bac300 () used with different accesses within the same pass, this is not allowed.
[11.02.2022 12:48:43.803] Warning: Texture 0x7effc4bac300 () used with different accesses within the same pass, this is not allowed.
[11.02.2022 12:48:46.235] Debug: (main - SurveyModel) Checking surveys
[11.02.2022 12:48:46.235] Debug: (main - TaskScheduler) Scheduling task: TaskGroup
[11.02.2022 12:48:46.235] Debug: (main - TaskScheduler) Tasks:  9
[11.02.2022 12:48:46.235] Debug: sending Glean pings (main.qml:337, onSendGleanPings)
[11.02.2022 12:48:46.236] Info: (Glean.core.Pings.Maker) Storage for main empty. Bailing out. (glean.lib.js:1, s)
[11.02.2022 12:48:46.821] Info: (captiveportal - CaptivePortalRequest) Portal Detected -> Redirect to  https://controller.access.network?dst=http%3A%2F%2Fdetectportal.firefox.com%2Fsuccess.txt
[11.02.2022 12:48:46.821] Debug: (networking - NetworkRequest) Network reply received - status: 302 - expected: any
[11.02.2022 12:48:46.822] Warning: QIODevice::read (QNetworkReplyHttpImpl): device not open
[11.02.2022 12:48:46.822] Error: (networking - NetworkRequest) Network error: Operation canceled status code: 302 - body:
[11.02.2022 12:48:46.822] Error: (networking - NetworkRequest) Failed to access: http://34.107.221.82/success.txt
[11.02.2022 12:48:46.822] Warning: (captiveportal - CaptivePortalRequest) Captive portal request failed: QNetworkReply::OperationCanceledError
[11.02.2022 12:48:46.822] Debug: (captiveportal - CaptivePortalRequestTask) Captive portal detection: CaptivePortalRequest::Failure
[11.02.2022 12:48:46.822] Debug: (networking - CaptivePortalMonitor) Captive portal detection: CaptivePortalRequest::Failure
[11.02.2022 12:48:46.822] Debug: (main - TaskScheduler) Task completed: CaptivePortalRequestTask
[11.02.2022 12:48:46.822] Debug: (main - TaskScheduler) Tasks:  9
[11.02.2022 12:48:46.822] Debug: (main - TaskGroup) Running subtask: TaskAccount
[11.02.2022 12:48:46.822] Debug: (networking - NetworkRequest) Network request created by TaskAccount
[11.02.2022 12:48:46.822] Debug: (main - TaskGroup) Running subtask: TaskServers
[11.02.2022 12:48:46.822] Debug: (networking - NetworkRequest) Network request created by TaskServers
[11.02.2022 12:48:46.822] Debug: (main - TaskGroup) Running subtask: TaskCaptivePortalLookup
[11.02.2022 12:48:46.822] Debug: (networking - TaskCaptivePortalLookup) Resolving the captive portal detector URL
[11.02.2022 12:48:46.822] Debug: (networking - NetworkRequest) Network request created by TaskCaptivePortalLookup
[11.02.2022 12:48:46.823] Debug: (main - TaskGroup) Running subtask: TaskHeartbeat
[11.02.2022 12:48:46.823] Debug: (networking - NetworkRequest) Network request created by TaskHeartbeat
[11.02.2022 12:48:46.823] Debug: (main - TaskGroup) Running subtask: TaskSurveyData
[11.02.2022 12:48:46.823] Debug: (main - TaskSurveyData) Fetch survey data
[11.02.2022 12:48:46.823] Debug: (networking - NetworkRequest) Network request created by TaskSurveyData
[11.02.2022 12:48:46.823] Debug: (main - TaskGroup) Running subtask: TaskGetFeatureList
[11.02.2022 12:48:46.823] Debug: (networking - NetworkRequest) Network request created by TaskGetFeatureList
[11.02.2022 12:48:46.823] Error: ASSERT: "m_running > 0" in file captiveportal/captiveportalrequest.cpp, line 102 (captiveportalrequest.cpp:102)
```