### PR TITLE
Windows Symbol Generation

### DIFF
--- a/.github/workflows/windows-build.yaml
+++ b/.github/workflows/windows-build.yaml
@@ -82,6 +82,12 @@ jobs:
         with:
             name: build
             path: windows/installer/x64/MozillaVPN.msi
+            if-no-files-found: error
+      - name: Upload Symbols
+        uses: actions/upload-artifact@v2
+        with:
+            name: win_symbols
+            path: MozillaVPN.pdb
             if-no-files-found: error 
       - name: Upload unsigned app
         uses: actions/upload-artifact@v2

--- a/scripts/windows_compile.bat
+++ b/scripts/windows_compile.bat
@@ -128,7 +128,7 @@ IF %DEBUG_BUILD%==T (
 
 IF %DEBUG_BUILD%==F (
   ECHO Generating Release Build for the extension bridge
-  qmake -tp vc extension\app\app.pro CONFIG-=debug CONFIG+=release CONFIG-=debug_and_release
+  qmake -tp vc extension\app\app.pro CONFIG-=debug CONFIG+=release CONFIG-=debug_and_release CONFIG+=force_debug_info
 )
 
 IF %ERRORLEVEL% NEQ 0 (


### PR DESCRIPTION
Generate Windows symbol files for builds and uploads them as an artifact.  This will not handle upload yet, as we don't have an account.  We can upload them manually for releases until we do.