### PR TITLE
Tutorial engine

### DIFF
--- a/src/commands/commandui.cpp
+++ b/src/commands/commandui.cpp
@@ -13,9 +13,10 @@
 #include "features/featureinapppurchase.h"
 #include "filterproxymodel.h"
 #include "fontloader.h"
-#include "l18nstrings.h"
 #include "iaphandler.h"
+#include "imageproviderfactory.h"
 #include "inspector/inspectorwebsocketserver.h"
+#include "l18nstrings.h"
 #include "leakdetector.h"
 #include "localizer.h"
 #include "logger.h"
@@ -24,8 +25,8 @@
 #include "notificationhandler.h"
 #include "qmlengineholder.h"
 #include "settingsholder.h"
-#include "imageproviderfactory.h"
 #include "theme.h"
+#include "tutorial.h"
 
 #include <glean.h>
 #include <lottie.h>
@@ -433,6 +434,14 @@ int CommandUI::run(QStringList& tokens) {
         "Mozilla.VPN", 1, 0, "VPNErrorHandler",
         [](QQmlEngine*, QJSEngine*) -> QObject* {
           QObject* obj = ErrorHandler::instance();
+          QQmlEngine::setObjectOwnership(obj, QQmlEngine::CppOwnership);
+          return obj;
+        });
+
+    qmlRegisterSingletonType<MozillaVPN>(
+        "Mozilla.VPN", 1, 0, "VPNTutorial",
+        [](QQmlEngine*, QJSEngine*) -> QObject* {
+          QObject* obj = Tutorial::instance();
           QQmlEngine::setObjectOwnership(obj, QQmlEngine::CppOwnership);
           return obj;
         });

--- a/src/inspector/inspectoritempicker.cpp
+++ b/src/inspector/inspectoritempicker.cpp
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "inspectoritempicker.h"
+#include "inspectorwebsocketconnection.h"
+
+InspectorItemPicker::InspectorItemPicker(QObject* parent)
+    : ItemPicker(parent) {}
+
+bool InspectorItemPicker::itemPicked(const QStringList& list) {
+  InspectorWebSocketConnection::itemsPicked(list);
+  return true;
+}

--- a/src/inspector/inspectoritempicker.h
+++ b/src/inspector/inspectoritempicker.h
@@ -1,0 +1,18 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef INSPECTORITEMPICKER_H
+#define INSPECTORITEMPICKER_H
+
+#include "itempicker.h"
+
+class InspectorItemPicker final : public ItemPicker {
+ public:
+  explicit InspectorItemPicker(QObject* parent);
+
+ private:
+  bool itemPicked(const QStringList& list) override;
+};
+
+#endif  // INSPECTORITEMPICKER_H

--- a/src/inspector/inspectorutils.cpp
+++ b/src/inspector/inspectorutils.cpp
@@ -1,0 +1,72 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "inspectorutils.h"
+#include "qmlengineholder.h"
+
+#include <QQuickItem>
+
+// static
+QObject* InspectorUtils::findObject(const QString& name) {
+  QStringList parts = name.split("/");
+  Q_ASSERT(!parts.isEmpty());
+
+  QQuickItem* parent = nullptr;
+  QQmlApplicationEngine* engine = QmlEngineHolder::instance()->engine();
+  for (QObject* rootObject : engine->rootObjects()) {
+    if (!rootObject) {
+      continue;
+    }
+
+    parent = rootObject->findChild<QQuickItem*>(parts[0]);
+    if (parent) {
+      break;
+    }
+  }
+
+  if (!parent) {
+    if (parts.length() == 1) {
+      int id = qmlTypeId("Mozilla.VPN", 1, 0, qPrintable(parts[0]));
+      return engine->singletonInstance<QObject*>(id);
+    }
+    return parent;
+  }
+
+  for (int i = 1; i < parts.length(); ++i) {
+    QList<QQuickItem*> children = parent->childItems();
+
+    bool found = false;
+    for (QQuickItem* item : children) {
+      if (item->objectName() == parts[i]) {
+        parent = item;
+        found = true;
+        break;
+      }
+    }
+
+    if (!found) {
+      QQuickItem* contentItem =
+          parent->property("contentItem").value<QQuickItem*>();
+      if (!contentItem) {
+        return nullptr;
+      }
+
+      QList<QQuickItem*> contentItemChildren = contentItem->childItems();
+
+      for (QQuickItem* item : contentItemChildren) {
+        if (item->objectName() == parts[i]) {
+          parent = item;
+          found = true;
+          break;
+        }
+      }
+    }
+
+    if (!found) {
+      return nullptr;
+    }
+  }
+
+  return parent;
+}

--- a/src/inspector/inspectorutils.h
+++ b/src/inspector/inspectorutils.h
@@ -1,0 +1,15 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef INSPECTORUTILS_H
+#define INSPECTORUTILS_H
+
+#include <QObject>
+
+class InspectorUtils final {
+ public:
+  static QObject* findObject(const QString& name);
+};
+
+#endif  // INSPECTORUTILS_H

--- a/src/inspector/inspectorwebsocketconnection.h
+++ b/src/inspector/inspectorwebsocketconnection.h
@@ -27,6 +27,7 @@ class InspectorWebSocketConnection final : public QObject {
   static QString getObjectClass(const QObject* target);
   static QJsonObject getViewTree();
   static QJsonObject serialize(QQuickItem* item);
+  static void itemsPicked(const QStringList& objectNames);
 
  private:
   void textMessageReceived(const QString& message);
@@ -35,6 +36,8 @@ class InspectorWebSocketConnection final : public QObject {
   void parseCommand(const QByteArray& command);
 
   void logEntryAdded(const QByteArray& log);
+
+  void tutorialChanged();
 
   void notificationShown(const QString& title, const QString& message);
 

--- a/src/itempicker.cpp
+++ b/src/itempicker.cpp
@@ -1,0 +1,87 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "itempicker.h"
+
+#include <QCoreApplication>
+#include <QEvent>
+#include <QMouseEvent>
+#include <QQuickItem>
+#include <QQuickWindow>
+
+ItemPicker::ItemPicker(QObject* parent) : QObject(parent) {}
+
+bool ItemPicker::eventFilter(QObject* obj, QEvent* event) {
+  if (m_lastEvent == event) {
+    return QObject::eventFilter(obj, event);
+  }
+
+  m_lastEvent = event;
+
+  if (event->type() != QEvent::MouseButtonPress) {
+    return QObject::eventFilter(obj, event);
+  }
+
+  QQuickItem* item = qobject_cast<QQuickItem*>(obj);
+  if (!item) {
+    QQuickWindow* window = qobject_cast<QQuickWindow*>(obj);
+    if (window) {
+      item = window->contentItem();
+    }
+  }
+
+  if (!item) {
+    return QObject::eventFilter(obj, event);
+  }
+
+  QStringList list = pickItem(static_cast<QMouseEvent*>(event), item);
+  if (itemPicked(list)) {
+    event->setAccepted(true);
+    return true;
+  }
+
+  return QObject::eventFilter(obj, event);
+}
+
+QStringList ItemPicker::pickItem(QMouseEvent* event, QQuickItem* item) {
+  QStringList list;
+  if (!item->objectName().isEmpty()) {
+    list.append(item->objectName());
+  }
+
+  for (QQuickItem* child : item->childItems()) {
+    if (!child->isVisible() || !child->isEnabled()) {
+      continue;
+    }
+
+    QPointF gpos = child->mapFromGlobal(event->globalPos());
+    if (!child->contains(gpos)) {
+      continue;
+    }
+
+    list.append(pickItem(event, child));
+  }
+
+  QQuickItem* contentItem = item->property("contentItem").value<QQuickItem*>();
+  if (contentItem) {
+    for (QQuickItem* child : contentItem->childItems()) {
+      if (!child->isVisible() || !child->isEnabled()) {
+        continue;
+      }
+
+      QPointF gpos = child->mapFromGlobal(event->globalPos());
+      if (!child->contains(gpos)) {
+        continue;
+      }
+
+      if (!child->contains(gpos)) {
+        continue;
+      }
+
+      list.append(pickItem(event, child));
+    }
+  }
+
+  return list;
+}

--- a/src/itempicker.h
+++ b/src/itempicker.h
@@ -1,0 +1,32 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef ITEMPICKER_H
+#define ITEMPICKER_H
+
+#include <QObject>
+
+class QMouseEvent;
+class QQuickItem;
+
+class ItemPicker : public QObject {
+  Q_OBJECT
+
+ public:
+  explicit ItemPicker(QObject* parent);
+
+ protected:
+  // Return true if the event should be accepted and not propagated.
+  virtual bool itemPicked(const QStringList& list) = 0;
+
+ private:
+  bool eventFilter(QObject* obj, QEvent* event) override;
+
+  QStringList pickItem(QMouseEvent* event, QQuickItem* item);
+
+ private:
+  QEvent* m_lastEvent = nullptr;
+};
+
+#endif  // ITEMPICKER_H

--- a/src/src.pro
+++ b/src/src.pro
@@ -108,9 +108,12 @@ SOURCES += \
         hkdf.cpp \
         iaphandler.cpp \
         imageproviderfactory.cpp \
+        inspector/inspectoritempicker.cpp \
+        inspector/inspectorutils.cpp \
         inspector/inspectorwebsocketconnection.cpp \
         inspector/inspectorwebsocketserver.cpp \
         ipaddress.cpp \
+        itempicker.cpp \
         l18nstringsimpl.cpp \
         leakdetector.cpp \
         localizer.cpp \
@@ -177,6 +180,7 @@ SOURCES += \
         taskscheduler.cpp \
         theme.cpp \
         timersingleshot.cpp \
+        tutorial.cpp \
         update/updater.cpp \
         update/versionapi.cpp \
         urlopener.cpp
@@ -242,9 +246,12 @@ HEADERS += \
         hkdf.h \
         iaphandler.h \
         imageproviderfactory.h \
+        inspector/inspectoritempicker.h \
+        inspector/inspectorutils.h \
         inspector/inspectorwebsocketconnection.h \
         inspector/inspectorwebsocketserver.h \
         ipaddress.h \
+        itempicker.h \
         leakdetector.h \
         localizer.h \
         logger.h \
@@ -311,6 +318,7 @@ HEADERS += \
         taskscheduler.h \
         theme.h \
         timersingleshot.h \
+        tutorial.h \
         update/updater.h \
         update/versionapi.h \
         urlopener.h

--- a/src/tutorial.cpp
+++ b/src/tutorial.cpp
@@ -1,0 +1,164 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "tutorial.h"
+#include "inspector/inspectorutils.h"
+#include "l18nstrings.h"
+#include "leakdetector.h"
+#include "logger.h"
+#include "qmlengineholder.h"
+
+#include <QCoreApplication>
+#include <QFile>
+#include <QQuickItem>
+
+constexpr int TIMEOUT_ITEM_TIMER_MSEC = 300;
+
+namespace {
+Tutorial* s_instance = nullptr;
+Logger logger(LOG_MAIN, "Tutorial");
+}  // namespace
+
+// static
+Tutorial* Tutorial::instance() {
+  if (!s_instance) {
+    s_instance = new Tutorial(qApp);
+  }
+  return s_instance;
+}
+
+Tutorial::Tutorial(QObject* parent) : ItemPicker(parent) {
+  MVPN_COUNT_CTOR(Tutorial);
+
+  m_timer.setSingleShot(true);
+  connect(&m_timer, &QTimer::timeout, this, [this]() { processNextOp(); });
+}
+
+Tutorial::~Tutorial() { MVPN_COUNT_DTOR(Tutorial); }
+
+void Tutorial::play(const QString& fileName) {
+  if (!m_steps.isEmpty()) {
+    m_steps.clear();
+    emit playingChanged();
+  }
+
+  QFile file(fileName);
+  if (!file.open(QIODevice::ReadOnly)) {
+    emit playingChanged();
+    return;
+  }
+
+  QByteArray content = file.readAll();
+  QList<QByteArray> entries = content.split('\n');
+  for (QByteArray& entry : entries) {
+    QByteArray line = entry.trimmed();
+
+    if (line.isEmpty()) continue;
+
+    if (line[0] == '#') continue;
+
+    if (line.startsWith("TOOLTIP ")) {
+      QList<QByteArray> parts(line.remove(0, 8).split(' '));
+      if (parts.length() != 2) {
+        logger.error()
+            << "Invalid tutorial file. TOOLTIP wants 2 elements only";
+        return;
+      }
+
+      if (!L18nStrings::instance()->contains(parts[0])) {
+        logger.error() << "Invalid tooltip string" << parts[0];
+        return;
+      }
+
+      m_steps.append(Op{parts[1], parts[0]});
+      continue;
+    }
+
+    logger.error() << "Invalid instruction" << line;
+    m_steps.clear();
+    return;
+  }
+
+  if (m_steps.isEmpty()) {
+    logger.error() << "Empty tutorial";
+    return;
+  }
+
+  emit playingChanged();
+
+  qApp->installEventFilter(this);
+
+  processNextOp();
+}
+
+void Tutorial::stop() {
+  if (!isPlaying()) {
+    return;
+  }
+
+  m_timer.stop();
+  m_steps.clear();
+  maybeStop();
+}
+
+bool Tutorial::maybeStop() {
+  if (m_steps.isEmpty()) {
+    qApp->removeEventFilter(this);
+    setTooltipShown(false);
+    emit playingChanged();
+    return true;
+  }
+
+  return false;
+}
+
+void Tutorial::processNextOp() {
+  if (maybeStop()) {
+    return;
+  }
+
+  const Op& op = m_steps[0];
+  QObject* element = InspectorUtils::findObject(op.m_element);
+  if (!element) {
+    m_timer.start(TIMEOUT_ITEM_TIMER_MSEC);
+    return;
+  }
+
+  QQuickItem* item = qobject_cast<QQuickItem*>(element);
+  Q_ASSERT(item);
+
+  QRectF rect = item->mapRectToScene(
+      QRectF(item->x(), item->y(), item->width(), item->height()));
+
+  setTooltipShown(true);
+  emit tooltipNeeded(L18nStrings::instance()->value(op.m_stringId).toString(),
+                     rect);
+}
+
+bool Tutorial::itemPicked(const QStringList& list) {
+  Q_ASSERT(!m_steps.isEmpty());
+
+  if (list.contains(m_steps[0].m_element)) {
+    m_steps.removeFirst();
+    processNextOp();
+    return false;
+  }
+
+  for (const QString& objectName : m_allowedItems) {
+    if (list.contains(objectName)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+void Tutorial::allowItem(const QString& objectName) {
+  m_allowedItems.append(objectName);
+}
+
+void Tutorial::setTooltipShown(bool shown) {
+  m_tooltipShown = shown;
+  emit tooltipShownChanged();
+}

--- a/src/tutorial.h
+++ b/src/tutorial.h
@@ -1,0 +1,57 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef TUTORIAL_H
+#define TUTORIAL_H
+
+#include "itempicker.h"
+
+#include <QTimer>
+
+class Tutorial final : public ItemPicker {
+  Q_OBJECT
+  Q_PROPERTY(bool playing READ isPlaying NOTIFY playingChanged)
+  Q_PROPERTY(bool tooltipShown MEMBER m_tooltipShown NOTIFY tooltipShownChanged)
+
+ public:
+  static Tutorial* instance();
+
+  ~Tutorial();
+
+  Q_INVOKABLE void play(const QString& fileName);
+  Q_INVOKABLE void stop();
+  Q_INVOKABLE void allowItem(const QString& objectName);
+
+  bool isPlaying() const { return !m_steps.isEmpty(); }
+
+ private:
+  explicit Tutorial(QObject* parent);
+
+  bool itemPicked(const QStringList& list) override;
+
+  void processNextOp();
+
+  // Return true if there are no operations left.
+  bool maybeStop();
+
+  void setTooltipShown(bool shown);
+
+ signals:
+  void playingChanged();
+  void tooltipNeeded(const QString& tooltipText, const QRectF& itemRect);
+  void tooltipShownChanged();
+
+ private:
+  struct Op {
+    QString m_element;
+    QString m_stringId;
+  };
+
+  QList<Op> m_steps;
+  QStringList m_allowedItems;
+  QTimer m_timer;
+  bool m_tooltipShown = false;
+};
+
+#endif  // TUTORIAL_H

--- a/src/ui/main.qml
+++ b/src/ui/main.qml
@@ -4,6 +4,7 @@
 
 import QtQuick 2.5
 import QtQuick.Controls 2.14
+import QtQuick.Layouts 1.14
 import QtQuick.Window 2.12
 
 import Mozilla.VPN 1.0
@@ -461,6 +462,47 @@ Window {
         }
 
     }
+
+    // This part needs UI - TODO
+    Popup {
+        id: tooltip
+        property alias text: text.text
+        visible: false
+        x: VPNTheme.theme.windowMargin
+        width: parent.width - VPNTheme.theme.windowMargin * 2
+
+        ColumnLayout {
+            Text {
+                id: text
+                text: ""
+            }
+
+            Button {
+                objectName: "tutorialExit"
+                text: "Exit"
+                Component.onCompleted: VPNTutorial.allowItem("tutorialExit")
+                onClicked: VPNTutorial.stop()
+            }
+        }
+    }
+
+    Connections {
+        target: VPNTutorial
+        function onTooltipNeeded(text, rect) {
+            if (tooltip.height + rect.y + rect.height <= window.height - VPNTheme.theme.windowMargin) {
+              tooltip.y = rect.y + rect.height;
+            } else {
+              tooltip.y = rect.y - tooltip.height;
+            }
+            tooltip.text = text
+            tooltip.open();
+        }
+
+        function onPlayingChanged() {
+            tooltip.visible = VPNTutorial.tooltipShown
+        }
+    }
+
 
     VPNSystemAlert {
     }

--- a/tests/unit/testtutorial.cpp
+++ b/tests/unit/testtutorial.cpp
@@ -1,0 +1,59 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "testtutorial.h"
+#include "../../src/tutorial.h"
+#include "../../src/qmlengineholder.h"
+
+void TestTutorial::parser_data() {
+  QTest::addColumn<QByteArray>("input");
+  QTest::addColumn<bool>("result");
+
+  QTest::addRow("empty") << QByteArray("") << false;
+  QTest::addRow("empty lines") << QByteArray("\n\n\n") << false;
+  QTest::addRow("empty lines with spaces")
+      << QByteArray(" \n   \n\t \n ") << false;
+  QTest::addRow("comments")
+      << QByteArray("# this is a comment\n # Here another one") << false;
+  QTest::addRow("invalid command") << QByteArray("T") << false;
+  QTest::addRow("tooltip invalid") << QByteArray("TOOLTIP") << false;
+  QTest::addRow("tooltip invalid2") << QByteArray("TOOLTIP ") << false;
+  QTest::addRow("tooltip invalid3") << QByteArray("TOOLTIP a") << false;
+  QTest::addRow("tooltip invalid3") << QByteArray("TOOLTIP a ") << false;
+  QTest::addRow("tooltip invalid stringID")
+      << QByteArray("TOOLTIP a b") << false;
+  QTest::addRow("tooltip valid")
+      << QByteArray("TOOLTIP ServersViewSearchPlaceholder aaa") << true;
+}
+
+void TestTutorial::parser() {
+  QmlEngineHolder qml;
+
+  Tutorial* t = Tutorial::instance();
+  QVERIFY(!!t);
+  QVERIFY(!t->isPlaying());
+
+  QSignalSpy signalSpy(t, &Tutorial::playingChanged);
+
+  t->stop();
+  QCOMPARE(signalSpy.count(), 0);
+
+  QFETCH(QByteArray, input);
+  QTemporaryFile file;
+  QVERIFY(file.open());
+  QCOMPARE(file.write(input.data(), input.length()), input.length());
+  file.close();
+
+  QFETCH(bool, result);
+
+  t->play(file.fileName());
+  QCOMPARE(signalSpy.count(), result ? 1 : 0);
+
+  if (result) {
+    t->stop();
+    QCOMPARE(signalSpy.count(), 2);
+  }
+}
+
+static TestTutorial s_testTutorial;

--- a/tests/unit/testtutorial.h
+++ b/tests/unit/testtutorial.h
@@ -1,0 +1,13 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "helper.h"
+
+class TestTutorial : public TestHelper {
+  Q_OBJECT
+
+ private slots:
+  void parser_data();
+  void parser();
+};

--- a/tests/unit/unit.pro
+++ b/tests/unit/unit.pro
@@ -6,6 +6,7 @@ QT += testlib
 QT += charts
 QT += network
 QT += qml
+QT += quick
 QT += xml
 
 DEFINES += APP_VERSION=\\\"1234\\\"
@@ -52,6 +53,8 @@ HEADERS += \
     ../../src/featurelist.h \
     ../../src/inspector/inspectorwebsocketconnection.h \
     ../../src/ipaddress.h \
+    ../../src/itempicker.h \
+    ../../src/inspector/inspectorutils.h \
     ../../src/leakdetector.h \
     ../../src/localizer.h \
     ../../src/logger.h \
@@ -104,6 +107,7 @@ HEADERS += \
     ../../src/taskscheduler.h \
     ../../src/theme.h \
     ../../src/timersingleshot.h \
+    ../../src/tutorial.h \
     ../../src/update/updater.h \
     ../../src/update/versionapi.h \
     ../../src/urlopener.h \
@@ -125,7 +129,8 @@ HEADERS += \
     teststatusicon.h \
     testtasks.h \
     testthemes.h \
-    testtimersingleshot.h
+    testtimersingleshot.h \
+    testtutorial.h
 
 SOURCES += \
     ../../src/adjust/adjustfiltering.cpp \
@@ -145,6 +150,8 @@ SOURCES += \
     ../../src/hacl-star/Hacl_Curve25519_51.c \
     ../../src/hacl-star/Hacl_Poly1305_32.c \
     ../../src/ipaddress.cpp \
+    ../../src/itempicker.cpp \
+    ../../src/inspector/inspectorutils.cpp \
     ../../src/l18nstringsimpl.cpp \
     ../../src/leakdetector.cpp \
     ../../src/localizer.cpp \
@@ -193,6 +200,7 @@ SOURCES += \
     ../../src/taskscheduler.cpp \
     ../../src/theme.cpp \
     ../../src/timersingleshot.cpp \
+    ../../src/tutorial.cpp \
     ../../src/update/updater.cpp \
     ../../src/update/versionapi.cpp \
     ../../src/urlopener.cpp \
@@ -218,7 +226,8 @@ SOURCES += \
     teststatusicon.cpp \
     testtasks.cpp \
     testthemes.cpp \
-    testtimersingleshot.cpp
+    testtimersingleshot.cpp \
+    testtutorial.cpp
 
 exists($$PWD/../../translations/generated/l18nstrings.h) {
     SOURCES += $$PWD/../../translations/generated/l18nstrings_p.cpp

--- a/tools/tutorialgen/package.json
+++ b/tools/tutorialgen/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "tutorialgen",
+  "version": "1.0.0",
+  "description": "A simple tutorial generator",
+  "main": "tutorialgen.js",
+  "type": "module",
+  "license": "Mozilla Public License 2.0",
+  "dependencies": {
+    "chalk": "^4.1.2",
+    "commander": "^8.2.0",
+    "fuzzy": "^0.1.3",
+    "inquirer": "^8.2.0",
+    "inquirer-autocomplete-prompt": "^1.4.0",
+    "pascalize": "^1.0.1",
+    "websocket": "^1.0.34",
+    "yaml": "^1.10.2"
+  }
+}

--- a/tools/tutorialgen/tutorialgen.js
+++ b/tools/tutorialgen/tutorialgen.js
@@ -1,0 +1,344 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import chalk from 'chalk';
+import child_process from 'child_process';
+import fs from 'fs';
+import fuzzy from 'fuzzy';
+import program from 'commander';
+import inquirer from 'inquirer';
+import inquirerAutocompletePrompt from 'inquirer-autocomplete-prompt';
+import websocket from 'websocket';
+import YAML from 'yaml'
+import pascalize from 'pascalize';
+
+const DEFAULT_MOZILLAVPN = '../../src/mozillavpn';
+
+const steps = [];
+
+class Command {
+  get cmd() {
+    return '';
+  }
+  get desc() {
+    return '';
+  }
+  get params() {
+    return []
+  }
+  run(config) {}
+}
+
+class Quit extends Command {
+  get cmd() {
+    return 'quit';
+  }
+
+  get desc() {
+    return 'Quit the app';
+  }
+
+  run(config) {
+    TutorialGen.quit();
+  }
+}
+
+class Help extends Command {
+  get cmd() {
+    return 'help';
+  }
+
+  get desc() {
+    return 'This help menu';
+  }
+
+  run(config) {
+    Commands.forEach(c => {
+      process.stdout.write(`${chalk.blue(c.cmd)}\t${c.desc}\n`);
+
+      c.params.forEach(param => {
+        process.stdout.write(
+            `\t${param.params.map(a => chalk.green(a)).join(' | ')}\t${
+                param.desc}\n`);
+      });
+    });
+  }
+}
+
+class Tooltip extends Command {
+  get cmd() {
+    return 'tooltip';
+  }
+
+  get desc() {
+    return 'Show a tooltip next to an element';
+  }
+
+  async run(config) {
+    const answer = await inquirer.prompt([{
+      type: 'autocomplete',
+      name: 'value',
+      message: 'String ID:',
+      source: (answers, input) =>
+          fuzzy.filter(input || '', config.stringIds, {})
+              .map(el => el.original),
+    }]);
+    const stringId = answer.value;
+    if (!stringId) {
+      console.log(chalk.red('A string ID is needed.'));
+      return;
+    }
+
+    await TutorialGen.sendMessageToClient('pick');
+
+    console.log('Pick an element, please.');
+    let elements = await new Promise(async r => {
+      while (true) {
+        const answer = await TutorialGen.sendMessageToClient('picked');
+        if (answer.clicked) {
+          r(answer.value);
+          break;
+        }
+
+        await new Promise(r => setTimeout(r, 200));
+      }
+    });
+
+    elements = [...new Set(elements)];
+
+    if (elements.length === 0) {
+      console.log(chalk.red(
+          'You have not selected an object with a name. Please, add names in the QML world.'));
+      return;
+    }
+
+    if (elements.length > 1) {
+      console.log(`You have selected more than 1 elements: ${
+          elements.join(', ')}. Pick one.`);
+
+      const elementAnswer = await inquirer.prompt([{
+        type: 'autocomplete',
+        name: 'value',
+        message: '>',
+        source: (elementAnswers, input) =>
+            fuzzy.filter(input || '', elements, {}).map(el => el.original),
+      }]);
+      elements = [elementAnswer.value];
+    }
+
+    console.log(chalk.green('Added a tooltip.'));
+
+    const step = {
+      type: 'tooltip',
+      name: elements[0],
+      id: stringId,
+    };
+
+    steps.push(step);
+  }
+}
+
+class Finalize extends Command {
+  get cmd() {
+    return 'done';
+  }
+
+  get desc() {
+    return 'Finalize the tutorial file';
+  }
+
+  async run(config) {
+    console.log(
+        `Your tutorial file is composed by ${chalk.bold(steps.length)} steps`);
+
+    const content = await this.serializeSteps(TutorialGen.rl);
+    fs.writeFileSync(config.tutorialFile, content);
+
+    console.log(chalk.bold.green('All done!'));
+
+    TutorialGen.quit();
+  }
+
+  async serializeSteps(rl) {
+    let content = [
+      '# This Source Code Form is subject to the terms of the Mozilla Public',
+      '# License, v. 2.0. If a copy of the MPL was not distributed with this',
+      '# file, You can obtain one at http://mozilla.org/MPL/2.0/. */',
+      '',
+    ];
+
+    steps.forEach((step, pos) => {
+      switch (step.type) {
+        case 'tooltip':
+          content = content.concat(this.serializeStepTooltip(step));
+          break;
+        default:
+          console.log('Unsupported step!');
+          break;
+      }
+    });
+
+    return content.join('\n') + '\n';
+    ;
+  }
+
+  serializeStepTooltip(step) {
+    return [`TOOLTIP ${step.id} ${step.name}`];
+  }
+}
+
+const Commands = [
+  new Quit(),
+  new Help(),
+  new Tooltip(),
+  new Finalize(),
+];
+
+const TutorialGen = {
+  get vpn() {
+    return this._vpn;
+  },
+  get client() {
+    return this._client;
+  },
+  get rl() {
+    return this._rl;
+  },
+
+  quit() {
+    if (this.vpn) {
+      this.vpn.kill();
+    }
+
+    process.exit();
+  },
+
+  async sendMessageToClient(cmd, params = '', reportError = false) {
+    let answer = await new Promise(resolve => {
+      this._waitReadCallback = resolve;
+      this.client.send(`${cmd} ${params}`.trim());
+    });
+
+    if (answer.type !== cmd) {
+      console.log('Something wrong is happening.');
+      this.quit();
+    }
+
+    if (!reportError) {
+      if (answer.error) {
+        console.log(`Something wrong is happening: ${answer.error}`);
+        this.quit();
+      }
+    }
+
+    return answer;
+  },
+
+  execClient(path) {
+    const vpn = child_process.spawn(path, ['ui', '--testing']);
+
+    console.log('Running the client...');
+    vpn.stderr.on('data', data => {});
+    vpn.stdout.on('data', data => {});
+    vpn.on('close', code => {
+      console.log(
+          'The client has been closed. I hope this is what you wanted.');
+      this.quit();
+    });
+
+    this._vpn = vpn;
+  },
+
+  async connectToClient() {
+    // Let's wait 1 sec for the activation of the websocket.
+    await new Promise(r => setTimeout(r, 1000));
+
+    const client = await new Promise(resolve => {
+      const client = new websocket.w3cwebsocket('ws://localhost:8765/', '');
+
+      client.onopen = async () => resolve(client);
+
+      client.onclose = () => {
+        console.log('The client has closed the websocket connection.');
+        this.quit();
+      };
+
+      client.onerror = () => resolve(null);
+
+      client.onmessage = data => {
+        const json = JSON.parse(data.data);
+
+        // Ignoring logs.
+        if (json.type === 'log') return;
+
+        // Ignore notifications.
+        if (json.type === 'notification') return;
+
+        if (!this._waitReadCallback) {
+          console.log('Internal error?!?');
+          return;
+        }
+
+        const wr = this._waitReadCallback;
+        this._waitReadCallback = null;
+        wr(json);
+      };
+    });
+
+    if (!client) {
+      console.log('Failed to connect.');
+      process.exit();
+    }
+
+    this._client = client;
+  },
+
+  async init() {
+    program.version('0.0.1')
+
+    program.option(
+        '-p, --path <mozillavpn>',
+        `config file. Default: ${DEFAULT_MOZILLAVPN}`, DEFAULT_MOZILLAVPN);
+    program.argument('<tutorialFile>', 'The tutorial file');
+    program.action(
+        async tutorialFile => await this.run(program.opts(), tutorialFile));
+
+    program.parseAsync(process.argv);
+  },
+
+  async run(options, tutorialFile) {
+    this.execClient(options.path);
+    await this.connectToClient();
+
+    const yaml = YAML.parse(
+        fs.readFileSync('../../translations/strings.yaml').toString());
+    const stringIds = [];
+    Object.keys(yaml).forEach(categories => {
+      Object.keys(yaml[categories]).forEach(key => {
+        stringIds.push(pascalize(categories + '_' + key));
+      });
+    });
+
+    inquirer.registerPrompt('autocomplete', inquirerAutocompletePrompt);
+
+    while (true) {
+      const answer = await inquirer.prompt([{
+        type: 'autocomplete',
+        name: 'value',
+        message: '>',
+        source: (answers, input) =>
+            fuzzy
+                .filter(
+                    input || '', Commands.map(c => ({name: c.cmd, value: c})),
+                    {extract: el => el.name})
+                .map(el => el.original),
+      }]);
+
+      const config = {tutorialFile, stringIds};
+      await answer.value.run(config);
+    };
+  },
+};
+
+TutorialGen.init();

--- a/tools/tutorialplayer/package.json
+++ b/tools/tutorialplayer/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "tutorialplayer",
+  "version": "1.0.0",
+  "description": "A simple tutorial player",
+  "main": "tutorialplayer.js",
+  "type": "module",
+  "license": "Mozilla Public License 2.0",
+  "dependencies": {
+    "chalk": "^4.1.2",
+    "commander": "^8.2.0",
+    "websocket": "^1.0.34"
+  }
+}

--- a/tools/tutorialplayer/tutorialplayer.js
+++ b/tools/tutorialplayer/tutorialplayer.js
@@ -1,0 +1,162 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import chalk from 'chalk';
+import child_process from 'child_process';
+import fs from 'fs';
+import program from 'commander';
+import websocket from 'websocket';
+
+const DEFAULT_MOZILLAVPN = '../../src/mozillavpn';
+
+const TutorialPlayer = {
+  get vpn() {
+    return this._vpn;
+  },
+  get client() {
+    return this._client;
+  },
+  get rl() {
+    return this._rl;
+  },
+
+  quit() {
+    if (this.vpn) {
+      this.vpn.kill();
+    }
+
+    process.exit();
+  },
+
+  async sendMessageToClient(cmd, params = '', reportError = false) {
+    let answer = await new Promise(resolve => {
+      this._waitReadCallback = resolve;
+      this.client.send(`${cmd} ${params}`.trim());
+    });
+
+    if (answer.type !== cmd) {
+      console.log('Something wrong is happening.');
+      this.quit();
+    }
+
+    if (!reportError) {
+      if (answer.error) {
+        console.log(`Something wrong is happening: ${answer.error}`);
+        this.quit();
+      }
+    }
+
+    return answer;
+  },
+
+  execClient(path) {
+    const vpn = child_process.spawn(path, ['ui', '--testing']);
+
+    console.log('Running the client...');
+    vpn.stderr.on('data', data => {});
+    vpn.stdout.on('data', data => {});
+    vpn.on('close', code => {
+      console.log(
+          'The client has been closed. I hope this is what you wanted.');
+      this.quit();
+    });
+
+    this._vpn = vpn;
+  },
+
+  async connectToClient() {
+    // Let's wait 1 sec for the activation of the websocket.
+    await new Promise(r => setTimeout(r, 1000));
+
+    const client = await new Promise(resolve => {
+      const client = new websocket.w3cwebsocket('ws://localhost:8765/', '');
+
+      client.onopen = async () => resolve(client);
+
+      client.onclose = () => {
+        console.log('The client has closed the websocket connection.');
+        this.quit();
+      };
+
+      client.onerror = () => resolve(null);
+
+      client.onmessage = data => {
+        const json = JSON.parse(data.data);
+
+        if (json.type === 'tutorialCompleted') {
+          console.log('Tutorial completed!');
+          return;
+        }
+
+        if (json.type === 'tutorialStarted') {
+          console.log('Tutorial started!');
+          return;
+        }
+
+        // Ignoring logs.
+        if (json.type === 'log') return;
+
+        // Ignore notifications.
+        if (json.type === 'notification') return;
+
+        if (!this._waitReadCallback) {
+          console.log('Internal error?!?');
+          return;
+        }
+
+        const wr = this._waitReadCallback;
+        this._waitReadCallback = null;
+        wr(json);
+      };
+    });
+
+    if (!client) {
+      console.log('Failed to connect.');
+      process.exit();
+    }
+
+    this._client = client;
+  },
+
+  async init() {
+    program.version('0.0.1')
+
+    program.option(
+        '-p, --path <mozillavpn>',
+        `config file. Default: ${DEFAULT_MOZILLAVPN}`, DEFAULT_MOZILLAVPN);
+    program.argument('<tutorialFile>', 'The tutorial file');
+    program.action(
+        async tutorialFile => await this.run(program.opts(), tutorialFile));
+
+    program.parseAsync(process.argv);
+  },
+
+  async waitForElement(id) {},
+
+  async run(options, tutorialFile) {
+    this.execClient(options.path);
+    await this.connectToClient();
+
+    console.log('Wait for the main view to be shown...');
+
+    while (true) {
+      const answer = await this.sendMessageToClient('has', 'deviceListButton');
+      if (answer.value) break;
+      await new Promise(resolve => setTimeout(resolve, 200));
+    }
+
+    while (true) {
+      const answer = await this.sendMessageToClient(
+          'property', 'deviceListButton visible');
+      if (answer.value) break;
+      await new Promise(resolve => setTimeout(resolve, 200));
+    }
+
+    console.log('Ready!');
+
+    await this.sendMessageToClient('tutorial', tutorialFile);
+  }
+};
+
+TutorialPlayer.init();


### PR DESCRIPTION
# Introduction
This is the engine of the tutorial system for the VPN client. The code works, but we need to add the final UI (not in this PR).

# What this PR contains
- unit-tests for the tutorial parser
- a tool to generate tutorial files (tools/tutorialgen)
- a tool to test tutorial files (tools/tutorialplayer)
- the parser of the tutorial files (src/tutorial.cpp)
- the QML object to start/stop tutorials (src/tutorial.cpp)
- the inspector hooks
- an example about how to show tooltip QML elements

# What this PR does not contain
- the final UI of the tooltips
- the guide view
- the tutorial

# How to use it
A few steps for the use of this code.

## Step 1: record a tutorial
The easiest solution is to use the `tutorialgen.js` app. Enter in `tools/tutorialgen` folder and run `npm install` to install the dependencies. Then, start the recording of a tutorial running the command: `node ./tutorialgen.js <filename>`.
The tutorial system works only if it starts from the main VPN view (after the authentication).

Use `help` to see the available commands. The main command is `tooltip` which wants 1 argument: a string id. Pick one from the l18nstring.yaml file. For instance, run the following steps:

1. `tooltip SettingsTunnelPort53`, and pick an item (the settings menu button).
2. Open the system view.
3. Run `tooltip ServerUnavailableModalBodyText` and pick the system preference menu item.
4. Open the system preferences
5. Continue like this until you have complete your tutorial.
6. Run `done`.

Your file is now ready to be used.

## Step 2: check the file
Your tutorial file should be a sequence of `TOOLTIP` commands. The first parameter is the string ID, the second one is the name of the QML object.

## Step 3: test the tutorial
The easiest way to test a tutorial is to use `tools/tutorialplayer`. Enter in this folder, run `npm install` for the dependencies. Then, run: `node tutorialplayer.js <filename>`. You should see the client running, step by step your tutorial.

## Step 4: the integration
This part is not done in this PR. It requires UI/UX work, but all the technical pieces should be available from this piece of code. See how the tutorials as triggered in `main.qml`.