### PR TITLE
Pin Device Key regeneration To <2.5

### DIFF
--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -291,12 +291,6 @@ void Controller::activateInternal() {
 void Controller::activateNext() {
   MozillaVPN* vpn = MozillaVPN::instance();
   const Device* device = vpn->deviceModel()->currentDevice(vpn->keys());
-  if (device == nullptr) {
-    logger.error()
-        << "Current device is no longer in DeviceModel - cannot continue ";
-    vpn->errorHandle(ErrorHandler::UnrecoverableError);
-    return;
-  }
   const HopConnection& hop = m_activationQueue.first();
 
   logger.debug() << "Activating peer" << hop.m_server.publicKey();

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -291,6 +291,12 @@ void Controller::activateInternal() {
 void Controller::activateNext() {
   MozillaVPN* vpn = MozillaVPN::instance();
   const Device* device = vpn->deviceModel()->currentDevice(vpn->keys());
+  if (device == nullptr) {
+    logger.error()
+        << "Current device is no longer in DeviceModel - cannot continue ";
+    vpn->errorHandle(ErrorHandler::UnrecoverableError);
+    return;
+  }
   const HopConnection& hop = m_activationQueue.first();
 
   logger.debug() << "Activating peer" << hop.m_server.publicKey();

--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -1661,7 +1661,7 @@ void MozillaVPN::maybeRegenerateDeviceKey() {
 
   if (settingsHolder->hasDeviceKeyVersion() &&
       VersionApi::compareVersions(settingsHolder->deviceKeyVersion(),
-                                  APP_VERSION) >= 0) {
+                                  "2.5.0") >= 0) {
     return;
   }
 


### PR DESCRIPTION
So 2 Things go wrong here: 

We're refreshing the device key on any update, even though we only need to to it when a key has been used before the 2.5 update. 

Also looking at the video at: 0:51-0:57.  https://mozilla-hub.atlassian.net/browse/VPN-1747
- After refresh  we also scheudle a full account refresh, pulling in the new devices
- We can see on the video the device count now dropped from 5 to 4
- I think the update of the device failed, and thus guardian has removed it. (idk why tho)
- It's likely that the devicemodel no longer includes the current keys. 
- So we should check the nullptr case on activation this is the case. Otherwise we will crash once we deref the device :)

Maybe we should force a full reset() of the app here, so the user can-re login and reauth the device. 