### PR TITLE
Fix missing QML import of Qt.labs.qmlmodels

### DIFF
--- a/linux/debian/control.impish
+++ b/linux/debian/control.impish
@@ -52,7 +52,8 @@ Depends: libpolkit-gobject-1-0 (>=0.105),
          qml-module-qtquick-window2 (>=5.15.2),
          qml-module-qtquick2 (>=5.15.2),
          qml-module-qtqml-models2 (>=5.15.2),
-         qml-module-qtqml (>=5.15.2)
+         qml-module-qtqml (>=5.15.2),
+         qml-module-qt-labs-qmlmodels (>=5.15.2)
 Description: A fast, secure and easy to use VPN. Built by the makers of Firefox.
  Read more on https://vpn.mozilla.org
 

--- a/linux/debian/control.jammy
+++ b/linux/debian/control.jammy
@@ -52,7 +52,8 @@ Depends: libpolkit-gobject-1-0 (>=0.105),
          qml-module-qtquick-window2 (>=5.15.2),
          qml-module-qtquick2 (>=5.15.2),
          qml-module-qtqml-models2 (>=5.15.2),
-         qml-module-qtqml (>=5.15.2)
+         qml-module-qtqml (>=5.15.2),
+         qml-module-qt-labs-qmlmodels (>=5.15.2)
 Description: A fast, secure and easy to use VPN. Built by the makers of Firefox.
  Read more on https://vpn.mozilla.org
 


### PR DESCRIPTION
A dependency on `Qt.labs.qmlmodels` has recently been introduced, and needs to be added as a Debian package dependency on distributions that supply their own version of Qt5.

Without this package installed, we are unable to open the network settings menu, and receive the following error instead:
```
[16.02.2022 09:50:00.092] Warning: qrc:/ui/views/ViewSettings.qml:35:5: QML VPNStackView: push: qrc:/ui/settings/ViewNetworkSettings.qml:52 Type VPNContextualAlerts unavailable
qrc:/nebula/components/forms/VPNContextualAlerts.qml:7 module "Qt.labs.qmlmodels" is not installed (ViewSettings.qml:35)
```