### PR TITLE
Fix developer menu unlock from settings view

### DIFF
--- a/nebula/ui/components/VPNMenu.qml
+++ b/nebula/ui/components/VPNMenu.qml
@@ -19,23 +19,12 @@ Item {
     property bool accessibleIgnored: false
     property bool btnDisabled: false
     property alias forceFocus: iconButton.focus
-    signal clicked(QtObject mouse)
 
     width: parent.width
     height: VPNTheme.theme.menuHeight
     // Ensure that menu is on top of possible scrollable
     // content.
     z: 2
-
-    MouseArea {
-        // Prevent mouse events from passing through to
-        // underlying elements
-        anchors.fill: menuBar
-        preventStealing: true
-        propagateComposedEvents: false
-        hoverEnabled: true
-        onClicked: mouse => menuBar.clicked(mouse)
-    }
 
     Rectangle {
         id: menuBackground

--- a/src/ui/developerMenu/ViewDeveloperMenu.qml
+++ b/src/ui/developerMenu/ViewDeveloperMenu.qml
@@ -28,8 +28,10 @@ Item {
         id: flickableContent
 
         anchors.top: menu.bottom
+        anchors.topMargin: VPNTheme.theme.windowMargin
+        anchors.left: parent.left
+        anchors.right: parent.right
         height: parent.height - menu.height
-        width: parent.width
 
         VPNCheckBoxRow {
             id: developerUnlock

--- a/src/ui/views/ViewGetHelp.qml
+++ b/src/ui/views/ViewGetHelp.qml
@@ -34,8 +34,12 @@ Item {
         //% "Get help"
         title: qsTrId("vpn.main.getHelp2")
         visible: !isSettingsView
+    }
 
-        onClicked: {
+    VPNMouseArea {
+        anchors.fill: menu
+        hoverEnabled: true
+        onMouseAreaClicked: function() {
             if (unlockCounter >= 5) {
                 unlockCounter = 0
                 VPNSettings.developerUnlock = true
@@ -46,7 +50,6 @@ Item {
             }
         }
     }
-
 
     Column {
         objectName: "getHelpLinks"


### PR DESCRIPTION
When opening the Get Help menu from the settings view, clicking on the "Get Help" text at the top of the window doesn't trigger the developer unlock, but it still appears to work fine when the menu is accessed from any other view. This appears to be caused by toggling the `visible` property, eventually leading to either missing or mis-routed `onClicked` signals.

It seems that this has already been worked around by using the `VPNMouseArea` component, so let's just use that for unlocking the developer menu in place of a standard QML `MouseArea`