### PR TITLE
 Fix #2682

### DIFF
--- a/nebula/ui/components/VPNExpandableAppList.qml
+++ b/nebula/ui/components/VPNExpandableAppList.qml
@@ -16,11 +16,7 @@ ColumnLayout {
     property var header: ""
     property string searchBarPlaceholder: ""
 
-    anchors.left: parent.left
-    anchors.right:parent.right
-    anchors.leftMargin: VPNTheme.theme.vSpacing
-    anchors.rightMargin: VPNTheme.theme.vSpacing
-    spacing: VPNTheme.theme.vSpacing
+    spacing: VPNTheme.theme.windowMargin
 
     // Ensure the inital presentation of the component is consistent with the
     // "hidden" state. This prevents the transition from firing on the
@@ -101,7 +97,6 @@ ColumnLayout {
         color: VPNTheme.theme.fontColorDark
         horizontalAlignment: Text.AlignLeft
         Layout.alignment: Qt.AlignLeft
-        Layout.topMargin: 4
         verticalAlignment: Text.AlignVCenter
         lineHeight: VPNTheme.theme.vSpacing
         lineHeightMode: Text.FixedHeight
@@ -111,7 +106,7 @@ ColumnLayout {
 
     VPNSearchBar {
         id: filterInput
-        Layout.fillWidth: true
+        Layout.preferredWidth: parent.width
         Layout.preferredHeight: VPNTheme.theme.rowHeight
         onTextChanged: text => {
             model.invalidate();
@@ -131,13 +126,10 @@ ColumnLayout {
         }
     }
 
-    ColumnLayout {
-        spacing: VPNTheme.theme.windowMargin / 2
-
-        VPNVerticalSpacer {
-            Layout.preferredHeight: 1
-        }
-
+    Column {
+        spacing: VPNTheme.theme.windowMargin
+        Layout.fillHeight: false
+        Layout.topMargin: VPNTheme.theme.windowMargin / 2
         Repeater {
             id: applist
             model: model
@@ -152,31 +144,30 @@ ColumnLayout {
                 Layout.minimumHeight: VPNTheme.theme.rowHeight * 1.5
             }
         }
-        VPNButton {
-            text: ""
-            Layout.fillWidth: true
-            onClicked: VPNAppPermissions.openFilePicker()
-            visible: Qt.platform.os === "windows"
-            contentItem: Text {
-                // for accessibility
-                text: addApplication
-                color: "transparent"
-            }
+    }
 
-            RowLayout {
-                anchors.centerIn: parent
-                VPNIcon {
-                    source: "qrc:/nebula/resources/plus.svg"
-                    sourceSize.height: VPNTheme.theme.windowMargin
-                    sourceSize.width: VPNTheme.theme.windowMargin
-                }
-                VPNBoldLabel {
-                    text: addApplication
-                    color: "white"
-                }
+    VPNButton {
+        text: ""
+        Layout.fillWidth: true
+        onClicked: VPNAppPermissions.openFilePicker()
+        visible: Qt.platform.os === "windows"
+        contentItem: Text {
+            // for accessibility
+            text: addApplication
+            color: "transparent"
+        }
+
+        RowLayout {
+            anchors.centerIn: parent
+            VPNIcon {
+                source: "qrc:/nebula/resources/plus.svg"
+                sourceSize.height: VPNTheme.theme.windowMargin
+                sourceSize.width: VPNTheme.theme.windowMargin
+            }
+            VPNBoldLabel {
+                text: addApplication
+                color: "white"
             }
         }
     }
-
-
 }

--- a/nebula/ui/components/forms/VPNContextualAlert.qml
+++ b/nebula/ui/components/forms/VPNContextualAlert.qml
@@ -14,6 +14,8 @@ RowLayout {
     property string iconSrc
     property string fontColor
 
+    Layout.preferredWidth: parent.width
+    Layout.fillWidth: true
     spacing: 0
     visible: modelData.visible
     states: [
@@ -51,7 +53,6 @@ RowLayout {
             }
         }
     ]
-    Layout.fillWidth: true
 
     VPNIcon {
         id: warningIcon
@@ -75,7 +76,7 @@ RowLayout {
         color: fontColor
         text: modelData.message
         wrapMode: Text.WordWrap
-
+        width: undefined
         Layout.fillWidth: true
         Layout.topMargin: VPNTheme.theme.listSpacing / 2
     }

--- a/src/ui/settings/ViewAppPermissions.qml
+++ b/src/ui/settings/ViewAppPermissions.qml
@@ -30,7 +30,7 @@ Item {
     VPNFlickable {
         id: vpnFlickable
         property bool vpnIsOff: (VPNController.state === VPNController.StateOff)
-        flickContentHeight:  (VPNSettings.protectSelectedApps ? enabledList.y + enabledList.implicitHeight + 100 : vpnFlickable.y + toggleCard.height )+ helpInfoText.height + helpLink.height
+        flickContentHeight: col.height + VPNTheme.theme.menuHeight
         anchors.top: parent.top
         anchors.topMargin: VPNTheme.theme.menuHeight
         height: root.height - menu.height
@@ -46,124 +46,127 @@ Item {
             }
         }
 
-        ColumnLayout{
-            id: messageBox
-            visible: true
+        ColumnLayout {
+            id: col
+            spacing: 0
+            width: root.width
             anchors.top: parent.top
-            anchors.topMargin: VPNTheme.theme.windowMargin
-            anchors.left: parent.left
-            anchors.leftMargin: 8
-            width: toggleCard.width-16
 
-            height: (vpnOnAlert.visible ? vpnOnAlert.height : 0) + (toast.visible ? toast.height : 0)
+            ColumnLayout{
+                id: messageBox
+                visible: true
+                Layout.leftMargin: VPNTheme.theme.windowMargin
+                Layout.rightMargin: VPNTheme.theme.windowMargin * 2
+                Layout.fillHeight: false
+                spacing: 0
 
-            VPNContextualAlerts {
-                id: vpnOnAlert
+                VPNContextualAlerts {
+                    id: vpnOnAlert
+                    Layout.preferredWidth: parent.width
+                    Layout.fillHeight: false
+                    Layout.topMargin: vpnFlickable.vpnIsOff ? 0 : VPNTheme.theme.windowMargin
 
-                anchors {
-                    left: parent.left
-                    leftMargin: VPNTheme.theme.windowMargin / 2
-                    right: parent.right
-                    topMargin: VPNTheme.theme.listSpacing
-                }
-
-                messages: [
-                    {
-                        type: "error",
-                        //% "VPN must be off to edit App Permissions"
-                        //: Associated to a group of settings that require the VPN to be disconnected to change
-                        message: qsTrId("vpn.settings.protectSelectedApps.vpnMustBeOff"),
-                        visible: !vpnFlickable.vpnIsOff
-                    }
-                ]
-            }
-
-            Connections {
-                target: VPNAppPermissions
-                function onNotification(type,message,action) {
-                    console.log("Got notification: "+type + "  message:"+message);
-                    var component = Qt.createComponent("qrc:/nebula/components/VPNAlert.qml", { updateURL: "qrc:/ui/views/ViewUpdate.qml" });
-                    if(component.status !== Component.Ready)
+                    messages: [
                         {
-                            if( component.status == Component.Error )
-                                console.debug("Error:"+ component.errorString() );
-                            
+                            type: "warning",
+                            //% "VPN must be off to edit App Permissions"
+                            //: Associated to a group of settings that require the VPN to be disconnected to change
+                            message: qsTrId("vpn.settings.protectSelectedApps.vpnMustBeOff"),
+                            visible: !vpnFlickable.vpnIsOff
                         }
-                    var alert = component.createObject(root, {
-                                               isLayout:false,
-                                               visible:true,
-                                               alertText: message,
-                                               alertType: type,
-                                               alertActionText: action,
-                                               duration:type === "warning"? 0: 2000,
-                                               destructive:true,
-                                               // Pin y hight to be below the alert bar as we can't render above it
-                                               setY: vpnFlickable.y+VPNTheme.theme.windowMargin, 
-                                               onActionPressed: ()=>{VPNAppPermissions.openFilePicker();},
-                                           });
+                    ]
+                }
 
-                    alert.show();
+                Connections {
+                    target: VPNAppPermissions
+                    function onNotification(type,message,action) {
+                        console.log("Got notification: "+type + "  message:"+message);
+                        var component = Qt.createComponent("qrc:/nebula/components/VPNAlert.qml", { updateURL: "qrc:/ui/views/ViewUpdate.qml" });
+                        if(component.status !== Component.Ready)
+                            {
+                                if( component.status == Component.Error )
+                                    console.debug("Error:"+ component.errorString() );
+
+                            }
+                        var alert = component.createObject(root, {
+                                                   isLayout:false,
+                                                   visible:true,
+                                                   alertText: message,
+                                                   alertType: type,
+                                                   alertActionText: action,
+                                                   duration:type === "warning"? 0: 2000,
+                                                   destructive:true,
+                                                   // Pin y hight to be below the alert bar as we can't render above it
+                                                   setY: vpnFlickable.y+VPNTheme.theme.windowMargin,
+                                                   onActionPressed: ()=>{VPNAppPermissions.openFilePicker();},
+                                               });
+
+                        alert.show();
+
+                    }
                 }
             }
 
-        }
+            VPNToggleCard {
+                id: toggleCard
 
+                toggleObjectName: "settingsAppPermissionsToggle"
+                toggleEnabled: vpnFlickable.vpnIsOff
+                Layout.preferredWidth: parent.width
+                Layout.preferredHeight: childrenRect.height + VPNTheme.theme.windowMargin
 
-        VPNToggleCard {
-            id: toggleCard
+                //% "Protect all apps with VPN"
+                labelText: qsTrId("vpn.settings.protectAllApps")
 
-            toggleObjectName: "settingsAppPermissionsToggle"
-            toggleEnabled: vpnFlickable.vpnIsOff
-            anchors.left: parent.left
-            anchors.right: parent.right
-            height: childrenRect.height
-            anchors.top: messageBox.visible ? messageBox.bottom : parent.top
+                //% "VPN protects all apps by default. Turn off to choose which apps Mozilla VPN should not protect."
+                sublabelText: qsTrId("vpn.settings.protectAllApps.description")
 
-            //% "Protect all apps with VPN"
-            labelText: qsTrId("vpn.settings.protectAllApps")
+                //% "VPN protects all apps by default. Turn off to choose which apps Mozilla VPN should not protect."
+                toolTipTitleText: qsTrId("vpn.settings.protectAllApps.description")
 
-            //% "VPN protects all apps by default. Turn off to choose which apps Mozilla VPN should not protect."
-            sublabelText: qsTrId("vpn.settings.protectAllApps.description")
+                toggleChecked: (!VPNSettings.protectSelectedApps)
 
-            //% "VPN protects all apps by default. Turn off to choose which apps Mozilla VPN should not protect."
-            toolTipTitleText: qsTrId("vpn.settings.protectAllApps.description")
-
-            toggleChecked: (!VPNSettings.protectSelectedApps)
-
-            function handleClick() {
-                if (vpnFlickable.vpnIsOff) {
-                    VPNSettings.protectSelectedApps = !VPNSettings.protectSelectedApps
+                function handleClick() {
+                    if (vpnFlickable.vpnIsOff) {
+                        VPNSettings.protectSelectedApps = !VPNSettings.protectSelectedApps
+                    }
                 }
             }
-        }
 
-        VPNExpandableAppList {
-            id: enabledList
-            anchors.topMargin: 30
-            anchors.top: toggleCard.bottom
-            searchBarPlaceholder: searchApps
+            VPNExpandableAppList {
+                id: enabledList
+                Layout.fillWidth: true
+                Layout.leftMargin: VPNTheme.theme.vSpacing
+                Layout.rightMargin: VPNTheme.theme.vSpacing
+                Layout.preferredWidth: parent.width
+                Layout.maximumWidth: parent.width - VPNTheme.theme.vSpacing * 2
+                Layout.topMargin: VPNTheme.theme.vSpacing
+                searchBarPlaceholder: searchApps
 
-            //% "Exclude apps from VPN protection"
-            //: Header for the list of apps protected by VPN
-            header: qsTrId("vpn.settings.excludeTitle")
-        }
+                //% "Exclude apps from VPN protection"
+                //: Header for the list of apps protected by VPN
+                header: qsTrId("vpn.settings.excludeTitle")
+            }
 
-        VPNTextBlock {
-            id: helpInfoText
-            width: vpnFlickable.width - VPNTheme.theme.windowMargin*3
-            anchors.topMargin: 30
-            anchors.top: enabledList.visible? enabledList.bottom : toggleCard.bottom
-            anchors.horizontalCenter:  enabledList.visible? enabledList.horizontalCenter : toggleCard.horizontalCenter
-            text: VPNl18n.SplittunnelInfoText
-        }
+            VPNTextBlock {
+                id: helpInfoText
+                width: undefined
+                Layout.preferredWidth: parent.width - VPNTheme.theme.vSpacing * 2
+                Layout.leftMargin: VPNTheme.theme.vSpacing
+                Layout.rightMargin: VPNTheme.theme.vSpacing
+                Layout.topMargin: VPNTheme.theme.vSpacing
+                text: VPNl18n.SplittunnelInfoText
+            }
 
-        VPNHeaderLink{
-            id: helpLink
-            anchors.top:  helpInfoText.bottom
-            anchors.horizontalCenter: helpInfoText.horizontalCenter
-            labelText: VPNl18n.SplittunnelInfoLinkText
-            onClicked: {
-               VPN.openLink(VPN.LinkSplitTunnelHelp)
+            VPNLinkButton {
+                id: helpLink
+                labelText: VPNl18n.SplittunnelInfoLinkText
+                Layout.preferredWidth: col.width
+                Layout.alignment: Qt.AlignHCenter
+                Layout.topMargin: VPNTheme.theme.windowMargin / 2
+                onClicked: {
+                   VPN.openLink(VPN.LinkSplitTunnelHelp)
+                }
             }
         }
     }

--- a/src/ui/settings/ViewNetworkSettings.qml
+++ b/src/ui/settings/ViewNetworkSettings.qml
@@ -46,7 +46,6 @@ Item {
 
             anchors {
                 left: parent.left
-                leftMargin: VPNTheme.theme.windowMargin / 2
                 right: parent.right
                 top: parent.top
                 topMargin: VPNTheme.theme.windowMargin
@@ -54,7 +53,13 @@ Item {
             spacing: VPNTheme.theme.windowMargin
 
             VPNContextualAlerts {
-                anchors.leftMargin: VPNTheme.theme.windowMargin
+                anchors {
+                    left: parent.left
+                    right: parent.right
+                    leftMargin: VPNTheme.theme.windowMargin
+                    rightMargin: VPNTheme.theme.windowMargin
+                }
+
                 messages: [
                     {
                         type: "warning",


### PR DESCRIPTION
I thought this would be a fast fix but it turned into something else. This fixes #2682, then fixes a binding loop and some anchor warnings in the app permissions view. It also refactors for better handling of text wrapping/responsiveness to app width changes (which only _really_ matters to us in a landscape-mode-enabled future when app width can change). 

<table>

<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>
<img width="362" alt="Screen Shot 2022-02-23 at 8 16 58 PM" src="https://user-images.githubusercontent.com/22355127/155445599-b5237928-f1d9-403b-b724-2f2868e7268b.png">
</td>
<td>
<img width="360" alt="Screen Shot 2022-02-17 at 10 03 57 PM" src="https://user-images.githubusercontent.com/22355127/155445633-3d2c1af6-7b1b-4901-aae9-2f6579bf3921.png">
</td>
</tr>

<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>
<img width="363" alt="Screen Shot 2022-02-23 at 8 18 23 PM" src="https://user-images.githubusercontent.com/22355127/155445762-587d815e-ec22-49e9-b985-291b8b3cd4c3.png">

</td>
<td>
<img width="362" alt="Screen Shot 2022-02-23 at 8 24 28 PM" src="https://user-images.githubusercontent.com/22355127/155445785-3314850f-5e3f-4e28-9c33-0b9ce6564587.png">
</td>
</tr>
</table>
<table>

<tr>
<th colspan="3">Also verified on Android and Windows</th>
</tr>
<tr>
<td>
<img width="362" alt="" src="https://user-images.githubusercontent.com/22355127/155446092-4b8c94a3-b1e3-4200-967a-ee256b4c4bc9.png">

</td>
<td>

<img width="362" alt="" src="https://user-images.githubusercontent.com/22355127/155446261-f3d5d523-1cb4-4586-a5a6-0aab924a8195.png">
</td>
<td>
<img width="362" alt="Screen Shot 2022-02-23 at 8 24 28 PM" src="https://user-images.githubusercontent.com/22355127/155446615-e0b53b29-b478-4e40-9285-c7abd0c5857c.png">


</td>

</table>