### PR TITLE
Stay in eReady when VPN disconnects

### DIFF
--- a/src/localsocketcontroller.cpp
+++ b/src/localsocketcontroller.cpp
@@ -72,7 +72,7 @@ void LocalSocketController::errorOccurred(
 }
 
 void LocalSocketController::disconnectInternal() {
-  // We're still eReady as the Deamon is alive 
+  // We're still eReady as the Deamon is alive
   // and can make a new connection.
   m_state = eReady;
   m_initializingRetry = 0;

--- a/src/localsocketcontroller.cpp
+++ b/src/localsocketcontroller.cpp
@@ -23,7 +23,7 @@
 #include <QHostAddress>
 
 // How many times do we try to reconnect.
-constexpr int MAX_CONNECTION_RETRY = 3;
+constexpr int MAX_CONNECTION_RETRY = 10;
 
 // How long do we wait between one try and the next one.
 constexpr int CONNECTION_RETRY_TIMER_MSEC = 500;
@@ -72,7 +72,9 @@ void LocalSocketController::errorOccurred(
 }
 
 void LocalSocketController::disconnectInternal() {
-  m_state = eDisconnected;
+  // We're still eReady as the Deamon is alive 
+  // and can make a new connection.
+  m_state = eReady;
   m_initializingRetry = 0;
   m_initializingTimer.stop();
   emit disconnected();


### PR DESCRIPTION
Sorry apparently did this on the release branch, i will do a follow-up cherrypick for main later :) 

Marking m_state = eDisconnected; means the deamon socket closed, so pressing the "disconnect" button means we're marking deamon as closed, thus after a new activation we won't listen to handshake response oder "activation completed" signals. :) 
