### PR TITLE
Suspend the timer execution if the Lottie object is not visible - Fixes VPN-1704

### DIFF
--- a/lottie/lib/lottie/LottieAnimation.qml
+++ b/lottie/lib/lottie/LottieAnimation.qml
@@ -82,7 +82,7 @@ Item {
 
         property bool componentCompleted: false
 
-        readyToPlay: canvas.available && componentCompleted && source
+        readyToPlay: canvas.available && componentCompleted && source && lottieItem.visible
     }
 
     onParentChanged: Qt.callLater(lottiePrivate.destroyAndRecreate);

--- a/lottie/lib/lottieprivate.cpp
+++ b/lottie/lib/lottieprivate.cpp
@@ -54,6 +54,15 @@ void LottiePrivate::setSource(const QString& source) {
 void LottiePrivate::setReadyToPlay(bool readyToPlay) {
   m_readyToPlay = readyToPlay;
   emit readyToPlayChanged();
+
+  if (m_window) {
+    if (m_readyToPlay) {
+      m_window->resume();
+    } else {
+      m_window->suspend();
+    }
+  }
+
   createAnimation();
 }
 
@@ -199,7 +208,11 @@ void LottiePrivate::setFillMode(const QString& fillMode) {
 }
 
 QJSValue LottiePrivate::createWindowObject() {
-  return engine()->toScriptValue(new LottiePrivateWindow(this));
+  if (!m_window) {
+    m_window = new LottiePrivateWindow(this);
+  }
+
+  return engine()->toScriptValue(m_window);
 }
 
 QJSValue LottiePrivate::createNavigatorObject() {

--- a/lottie/lib/lottieprivate.h
+++ b/lottie/lib/lottieprivate.h
@@ -11,6 +11,7 @@
 #include <QtQuick/QQuickItem>
 
 class QJSEngine;
+class LottiePrivateWindow;
 
 class LottiePrivate : public QQuickItem {
   Q_OBJECT
@@ -122,6 +123,8 @@ class LottiePrivate : public QQuickItem {
   QJSValue m_lottieModule;
   QJSValue m_lottieInstance;
   QJSValue m_animation;
+
+  LottiePrivateWindow* m_window = nullptr;
 };
 
 #endif  // LOTTIEPRIVATE_H

--- a/lottie/lib/lottieprivatewindow.h
+++ b/lottie/lib/lottieprivatewindow.h
@@ -38,6 +38,9 @@ class LottiePrivateWindow final : public QObject {
   QJSValue lottie() const;
   void setLottie(QJSValue lottie);
 
+  void suspend();
+  void resume();
+
  signals:
   void lottieChanged();
 
@@ -50,15 +53,19 @@ class LottiePrivateWindow final : public QObject {
   struct TimerData {
     TimerData() = default;
 
-    TimerData(QTimer* timer, QJSValue callback, int timerId, bool singleShot)
+    TimerData(QTimer* timer, QJSValue callback, int timerId, int interval,
+              bool singleShot)
         : m_timer(timer),
           m_callback(callback),
           m_timerId(timerId),
+          m_interval(interval),
           m_singleShot(singleShot) {}
 
     QTimer* m_timer = nullptr;
     QJSValue m_callback;
     int m_timerId = 0;
+    int m_interval = 0;
+    int m_remainingInterval = -1;
     bool m_singleShot = true;
   };
 

--- a/lottie/tests/unit/testwindow.h
+++ b/lottie/tests/unit/testwindow.h
@@ -10,4 +10,5 @@ class TestWindow : public TestHelper {
  private slots:
   void setInterval();
   void setTimeout();
+  void suspendAndResume();
 };


### PR DESCRIPTION
There are 2 problems:
- we create the lottie JS component even when the LottieAnimation QML object is not visible
- we do not suspend timers when the object becomes invisible.