### PR TITLE
HTTP2-redirect hack can be removed after qt6.4.0 - Fixes VPN-1723

### DIFF
--- a/src/networkrequest.cpp
+++ b/src/networkrequest.cpp
@@ -777,7 +777,7 @@ void NetworkRequest::replyFinished() {
     return;
   }
 
-#if QT_VERSION >= 0x060000
+#if QT_VERSION >= 0x060000 && QT_VERSION < 0x060400
   if (m_reply->error() == QNetworkReply::HostNotFoundError && isRedirect()) {
     QUrl brokenUrl = m_reply->url();
 
@@ -858,7 +858,7 @@ void NetworkRequest::handleHeaderReceived() {
 }
 
 void NetworkRequest::handleRedirect(const QUrl& redirectUrl) {
-#if QT_VERSION >= 0x060000
+#if QT_VERSION >= 0x060000 && QT_VERSION < 0x060400
   if (redirectUrl.host().isEmpty()) {
 #  ifdef MVPN_DEBUG
     // See https://bugreports.qt.io/browse/QTBUG-100651


### PR DESCRIPTION
See the release version of [QTBUG-100651](https://bugreports.qt.io/browse/QTBUG-100651).