### PR TITLE
In-App Auth button loaders and disabled style

### DIFF
--- a/nebula/ui/components/VPNButton.qml
+++ b/nebula/ui/components/VPNButton.qml
@@ -12,12 +12,21 @@ VPNButtonBase {
     id: button
 
     height: VPNTheme.theme.rowHeight
-    Layout.preferredHeight: Layout ? VPNTheme.theme.rowHeight : undefined
     width: Math.min(parent.width * 0.83, VPNTheme.theme.maxHorizontalContentWidth)
-    Layout.preferredWidth: Layout ? Math.min(parent.width * 0.83, VPNTheme.theme.maxHorizontalContentWidth) : undefined
+
     Layout.alignment: Layout ? Qt.AlignHCenter : undefined
+    Layout.preferredHeight: Layout ? VPNTheme.theme.rowHeight : undefined
+    Layout.preferredWidth: Layout
+        ? Math.min(parent.width * 0.83, VPNTheme.theme.maxHorizontalContentWidth)
+        : undefined
+
     Component.onCompleted: {
-        state = uiState.stateDefault;
+        state = Qt.binding(() => (
+            enabled ? uiState.stateDefault : uiState.stateDisabled
+        ));
+        buttonMouseArea.hoverEnabled = Qt.binding(() => (
+            enabled && loaderVisible === false
+        ));
     }
 
     VPNUIStates {
@@ -31,7 +40,7 @@ VPNButtonBase {
     }
 
     VPNMouseArea {
-        hoverEnabled: loaderVisible === false
+        id: buttonMouseArea
     }
 
     contentItem: Label {

--- a/nebula/ui/components/VPNMouseArea.qml
+++ b/nebula/ui/components/VPNMouseArea.qml
@@ -14,8 +14,7 @@ MouseArea {
     property var onMouseAreaClicked: function() { parent.clicked() }
 
     function changeState(stateName) {
-        if (mouseArea.hoverEnabled)
-           targetEl.state = stateName;
+        targetEl.state = stateName;
     }
 
     anchors.fill: parent
@@ -30,5 +29,8 @@ MouseArea {
             changeState(uiState.stateDefault);
             onMouseAreaClicked();
         }
+    }
+    onHoverEnabledChanged: {
+        changeState(hoverEnabled ? uiState.stateDefault : uiState.stateDisabled);
     }
 }

--- a/nebula/ui/components/VPNUIStates.qml
+++ b/nebula/ui/components/VPNUIStates.qml
@@ -53,6 +53,16 @@ Rectangle {
                 opacity: 1
             }
 
+        },
+        State {
+            when: itemToAnchor.state === uiState.stateDisabled
+
+            PropertyChanges {
+                target: buttonBackground
+                color: colorScheme.buttonDisabled
+                opacity: 1
+            }
+
         }
     ]
     transitions: [

--- a/src/ui/authenticationInApp/ViewAuthenticationSignIn.qml
+++ b/src/ui/authenticationInApp/ViewAuthenticationSignIn.qml
@@ -74,12 +74,13 @@ VPNInAppAuthenticationBase {
         VPNButton {
             id: signInBtn
             text: VPNl18n.InAppAuthSignInButton
-            Layout.fillWidth: true
             enabled: VPNAuthInApp.state === VPNAuthInApp.StateSignIn
+            loaderVisible: VPNAuthInApp.state === VPNAuthInApp.StateSigningIn
             onClicked: {
                 VPNAuthInApp.setPassword(passwordInput.text);
                 VPNAuthInApp.signIn();
             }
+            Layout.fillWidth: true
         }
 
         Connections {

--- a/src/ui/authenticationInApp/ViewAuthenticationSignUp.qml
+++ b/src/ui/authenticationInApp/ViewAuthenticationSignUp.qml
@@ -89,6 +89,7 @@ VPNInAppAuthenticationBase {
             id: createAccountButton
             enabled: authSignUp.signUpEnabled && VPNAuthInApp.state === VPNAuthInApp.StateSignUp
             text: "Create account"
+            loaderVisible: VPNAuthInApp.state === VPNAuthInApp.StateSigningUp
             Layout.fillWidth: true
 
             onClicked: {

--- a/src/ui/authenticationInApp/ViewAuthenticationStart.qml
+++ b/src/ui/authenticationInApp/ViewAuthenticationStart.qml
@@ -41,9 +41,10 @@ VPNInAppAuthenticationBase {
         }
         VPNButton {
             text: "Continue"
-            Layout.fillWidth: true
             enabled: VPNAuthInApp.state === VPNAuthInApp.StateStart && emailInput.text.length !== 0 && !emailInput.hasError
+            loaderVisible: VPNAuthInApp.state === VPNAuthInApp.StateCheckingAccount
             onClicked: VPNAuthInApp.checkAccount(emailInput.text);
+            Layout.fillWidth: true
         }
     }
 

--- a/src/ui/authenticationInApp/ViewAuthenticationVerificationSessionByEmailNeeded.qml
+++ b/src/ui/authenticationInApp/ViewAuthenticationVerificationSessionByEmailNeeded.qml
@@ -73,6 +73,7 @@ VPNInAppAuthenticationBase {
         VPNButton {
             id: createAccountButton
             enabled: VPNAuthInApp.state === VPNAuthInApp.StateVerificationSessionByEmailNeeded && codeInput.text && codeInput.text.length === VPNAuthInApp.verificationCodeLength
+            loaderVisible: VPNAuthInApp.state === VPNAuthInApp.StateVerifyingSessionEmailCode
             text: "Verify"
             Layout.fillWidth: true
 

--- a/src/ui/authenticationInApp/ViewAuthenticationVerificationSessionByTotpNeeded.qml
+++ b/src/ui/authenticationInApp/ViewAuthenticationVerificationSessionByTotpNeeded.qml
@@ -44,11 +44,12 @@ VPNInAppAuthenticationBase {
 
         VPNButton {
             text: "Verify"
-            Layout.fillWidth: true
             enabled: VPNAuthInApp.state === VPNAuthInApp.StateVerificationSessionByTotpNeeded
+            loaderVisible: VPNAuthInApp.state === VPNAuthInApp.StateVerifyingSessionTotpCode
             onClicked: {
               VPNAuthInApp.verifySessionTotpCode(codeInput.text);
             }
+            Layout.fillWidth: true
         }
     }
 


### PR DESCRIPTION
This PR does two things:
1. Uses the new VPNAuthInApp states that were introduced by PR #2793 to support transitions in the In-App Auth flow through showing button loaders.
2. Fixes `VPNButton`’s disabled state and style