### PR TITLE
Add MacosAuthenticationListener to support deep linking

### DIFF
--- a/macos/app/Info.plist
+++ b/macos/app/Info.plist
@@ -20,6 +20,16 @@
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLSchemes</key>
+			<array><string>mozilla-vpn</string></array>
+
+			<key>CFBundleURLName</key>
+			<string>$(PROJECT_BUNDLE_IDENTIFIER)</string>
+		</dict>
+	</array>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationCategoryType</key>

--- a/src/authenticationlistener.cpp
+++ b/src/authenticationlistener.cpp
@@ -14,6 +14,8 @@
 #  include "platforms/android/androidauthenticationlistener.h"
 #elif defined(MVPN_IOS)
 #  include "platforms/ios/iosauthenticationlistener.h"
+#elif defined(MVPN_MACOS)
+#  include "platforms/macos/macosauthenticationlistener.h"
 #elif defined(MVPN_WASM)
 #  include "platforms/wasm/wasmauthenticationlistener.h"
 #else
@@ -35,6 +37,8 @@ AuthenticationListener* AuthenticationListener::create(
       return new AndroidAuthenticationListener(parent);
 #elif defined(MVPN_IOS)
       return new IOSAuthenticationListener(parent);
+#elif defined(MVPN_MACOS)
+      return new MacosAuthenticationListener(parent);
 #elif defined(MVPN_WASM)
       return new WasmAuthenticationListener(parent);
 #else

--- a/src/platforms/macos/macosauthenticationlistener.cpp
+++ b/src/platforms/macos/macosauthenticationlistener.cpp
@@ -30,9 +30,10 @@ MacosAuthenticationListener::~MacosAuthenticationListener() {
   qApp->removeEventFilter(this);
 }
 
-void MacosAuthenticationListener::start(Task* task, const QString& codeChallenge,
-                                       const QString& codeChallengeMethod,
-                                       const QString& emailAddress) {
+void MacosAuthenticationListener::start(Task* task,
+                                        const QString& codeChallenge,
+                                        const QString& codeChallengeMethod,
+                                        const QString& emailAddress) {
   logger.debug() << "MacosAuthenticationListener started";
 
   Q_UNUSED(task);
@@ -44,13 +45,12 @@ void MacosAuthenticationListener::start(Task* task, const QString& codeChallenge
   UrlOpener::open(url.toString());
 }
 
-bool MacosAuthenticationListener::eventFilter(QObject* obj, QEvent* event)
-{
+bool MacosAuthenticationListener::eventFilter(QObject* obj, QEvent* event) {
   if (event->type() != QEvent::FileOpen) {
     return QObject::eventFilter(obj, event);
   }
 
-  QFileOpenEvent *ev = static_cast<QFileOpenEvent *>(event);
+  QFileOpenEvent* ev = static_cast<QFileOpenEvent*>(event);
   QUrl url = ev->url();
   if ((url.scheme() != "mozilla-vpn") || (url.authority() != "login")) {
     logger.warning() << "Received unknown URL:" << url.toString();

--- a/src/platforms/macos/macosauthenticationlistener.cpp
+++ b/src/platforms/macos/macosauthenticationlistener.cpp
@@ -1,0 +1,72 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "macosauthenticationlistener.h"
+#include "leakdetector.h"
+#include "logger.h"
+#include "urlopener.h"
+
+#include <QCoreApplication>
+#include <QFileOpenEvent>
+#include <QUrlQuery>
+
+namespace {
+
+Logger logger(LOG_MAIN, "MacosAuthenticationListener");
+
+}  // anonymous namespace
+
+MacosAuthenticationListener::MacosAuthenticationListener(QObject* parent)
+    : AuthenticationListener(parent) {
+  MVPN_COUNT_CTOR(MacosAuthenticationListener);
+
+  qApp->installEventFilter(this);
+}
+
+MacosAuthenticationListener::~MacosAuthenticationListener() {
+  MVPN_COUNT_DTOR(MacosAuthenticationListener);
+
+  qApp->removeEventFilter(this);
+}
+
+void MacosAuthenticationListener::start(Task* task, const QString& codeChallenge,
+                                       const QString& codeChallengeMethod,
+                                       const QString& emailAddress) {
+  logger.debug() << "MacosAuthenticationListener started";
+
+  Q_UNUSED(task);
+
+  QUrl url(createAuthenticationUrl(MozillaVPN::AuthenticationInBrowser,
+                                   codeChallenge, codeChallengeMethod,
+                                   emailAddress));
+
+  UrlOpener::open(url.toString());
+}
+
+bool MacosAuthenticationListener::eventFilter(QObject* obj, QEvent* event)
+{
+  if (event->type() != QEvent::FileOpen) {
+    return QObject::eventFilter(obj, event);
+  }
+
+  QFileOpenEvent *ev = static_cast<QFileOpenEvent *>(event);
+  QUrl url = ev->url();
+  if ((url.scheme() != "mozilla-vpn") || (url.authority() != "login")) {
+    logger.warning() << "Received unknown URL:" << url.toString();
+    return false;
+  }
+  if (url.path() != "/success") {
+    logger.warning() << "Received unexpected auth endpoint:" << url.path();
+    return false;
+  }
+
+  QUrlQuery query(url.query());
+  if (!query.hasQueryItem("code")) {
+    logger.warning() << "Received OAuth success, but no code was found.";
+    return false;
+  }
+
+  emit completed(query.queryItemValue("code"));
+  return false;
+}

--- a/src/platforms/macos/macosauthenticationlistener.cpp
+++ b/src/platforms/macos/macosauthenticationlistener.cpp
@@ -18,7 +18,7 @@ Logger logger(LOG_MAIN, "MacosAuthenticationListener");
 }  // anonymous namespace
 
 MacosAuthenticationListener::MacosAuthenticationListener(QObject* parent)
-    : AuthenticationListener(parent) {
+    : DesktopAuthenticationListener(parent) {
   MVPN_COUNT_CTOR(MacosAuthenticationListener);
 
   qApp->installEventFilter(this);
@@ -28,21 +28,6 @@ MacosAuthenticationListener::~MacosAuthenticationListener() {
   MVPN_COUNT_DTOR(MacosAuthenticationListener);
 
   qApp->removeEventFilter(this);
-}
-
-void MacosAuthenticationListener::start(Task* task,
-                                        const QString& codeChallenge,
-                                        const QString& codeChallengeMethod,
-                                        const QString& emailAddress) {
-  logger.debug() << "MacosAuthenticationListener started";
-
-  Q_UNUSED(task);
-
-  QUrl url(createAuthenticationUrl(MozillaVPN::AuthenticationInBrowser,
-                                   codeChallenge, codeChallengeMethod,
-                                   emailAddress));
-
-  UrlOpener::open(url.toString());
 }
 
 bool MacosAuthenticationListener::eventFilter(QObject* obj, QEvent* event) {

--- a/src/platforms/macos/macosauthenticationlistener.h
+++ b/src/platforms/macos/macosauthenticationlistener.h
@@ -5,21 +5,17 @@
 #ifndef MACOSAUTHENTICATIONLISTENER_H
 #define MACOSAUTHENTICATIONLISTENER_H
 
-#include "authenticationlistener.h"
+#include "desktopauthenticationlistener.h"
 
 #include <QEvent>
 
-class MacosAuthenticationListener final : public AuthenticationListener {
+class MacosAuthenticationListener final : public DesktopAuthenticationListener {
   Q_OBJECT
   Q_DISABLE_COPY_MOVE(MacosAuthenticationListener)
 
  public:
   explicit MacosAuthenticationListener(QObject* parent);
   ~MacosAuthenticationListener();
-
-  void start(Task* task, const QString& codeChallenge,
-             const QString& codeChallengeMethod,
-             const QString& emailAddress) override;
 
  private:
   bool eventFilter(QObject* obj, QEvent* event) override;

--- a/src/platforms/macos/macosauthenticationlistener.h
+++ b/src/platforms/macos/macosauthenticationlistener.h
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef MACOSAUTHENTICATIONLISTENER_H
+#define MACOSAUTHENTICATIONLISTENER_H
+
+#include "authenticationlistener.h"
+
+#include <QEvent>
+
+class MacosAuthenticationListener final : public AuthenticationListener {
+  Q_OBJECT
+  Q_DISABLE_COPY_MOVE(MacosAuthenticationListener)
+
+ public:
+  explicit MacosAuthenticationListener(QObject* parent);
+  ~MacosAuthenticationListener();
+
+  void start(Task* task, const QString& codeChallenge,
+             const QString& codeChallengeMethod,
+             const QString& emailAddress) override;
+
+ private:
+  bool eventFilter(QObject* obj, QEvent* event) override;
+};
+
+#endif  // MACOSAUTHENTICATIONLISTENER_H

--- a/src/qmake/platforms/macos.pri
+++ b/src/qmake/platforms/macos.pri
@@ -45,6 +45,7 @@ SOURCES += \
     platforms/macos/daemon/macosdaemonserver.cpp \
     platforms/macos/daemon/macosroutemonitor.cpp \
     platforms/macos/daemon/wireguardutilsmacos.cpp \
+    platforms/macos/macosauthenticationlistener.cpp \
     platforms/macos/macosmenubar.cpp \
     platforms/macos/macospingsender.cpp \
     platforms/macos/macosstartatbootwatcher.cpp \
@@ -72,6 +73,7 @@ HEADERS += \
     platforms/macos/daemon/macosdaemonserver.h \
     platforms/macos/daemon/macosroutemonitor.h \
     platforms/macos/daemon/wireguardutilsmacos.h \
+    platforms/macos/macosauthenticationlistener.h \
     platforms/macos/macosmenubar.h \
     platforms/macos/macospingsender.h \
     platforms/macos/macosstartatbootwatcher.h \

--- a/src/tasks/authenticate/desktopauthenticationlistener.h
+++ b/src/tasks/authenticate/desktopauthenticationlistener.h
@@ -9,7 +9,7 @@
 
 class QOAuthHttpServerReplyHandler;
 
-class DesktopAuthenticationListener final : public AuthenticationListener {
+class DesktopAuthenticationListener : public AuthenticationListener {
   Q_OBJECT
   Q_DISABLE_COPY_MOVE(DesktopAuthenticationListener)
 


### PR DESCRIPTION
Recently MacOS users with Safari as their default browser have been unable to authenticate due to Safari's HSTS policy forcing the use of HTTPS when accessing localhost. As a workaround to this, we may need to implement our own custom URL handler in order to pass the OAuth auth code from Safari back to the VPN client.

This PR extends the `DesktopAuthenticationListener` class for MacOS to include support for receiving the OAuth code via a deep link of the form `mozilla-vpn://login/success?code=XXXXX` which should provide an alternate path for Safari users to complete authentication. For this to resolve the issue completely, we will need a corresponding update to the guardian website to utilize such a deep link.

See: #2846 