### PR TITLE
Auth flow updates

### DIFF
--- a/nebula/ui/components.qrc
+++ b/nebula/ui/components.qrc
@@ -105,5 +105,7 @@
         <file>components/VPNWasmMenu.qml</file>
         <file>components/inAppAuth/qmldir</file>
         <file>components/inAppAuth/VPNInAppAuthenticationBase.qml</file>
+        <file>components/inAppAuth/VPNInAppAuthenticationErrorPopup.qml</file>
+        <file>components/inAppAuth/VPNInAppAuthenticationInputs.qml</file>
     </qresource>
 </RCC>

--- a/nebula/ui/components/VPNIconButton.qml
+++ b/nebula/ui/components/VPNIconButton.qml
@@ -11,7 +11,6 @@ import components 0.1
 
 VPNButtonBase {
     id: iconButton
-
     property bool skipEnsureVisible: false
     property var accessibleName
     property var buttonColorScheme: VPNTheme.theme.iconButtonLightBackground
@@ -34,7 +33,6 @@ VPNButtonBase {
 
     VPNMouseArea {
         id: mouseArea
-        anchors.fill: parent
         onExited: toolTip.close()
     }
 

--- a/nebula/ui/components/VPNIconButton.qml
+++ b/nebula/ui/components/VPNIconButton.qml
@@ -11,6 +11,7 @@ import components 0.1
 
 VPNButtonBase {
     id: iconButton
+
     property bool skipEnsureVisible: false
     property var accessibleName
     property var buttonColorScheme: VPNTheme.theme.iconButtonLightBackground
@@ -33,6 +34,7 @@ VPNButtonBase {
 
     VPNMouseArea {
         id: mouseArea
+        anchors.fill: parent
         onExited: toolTip.close()
     }
 

--- a/nebula/ui/components/VPNPopup.qml
+++ b/nebula/ui/components/VPNPopup.qml
@@ -53,6 +53,7 @@ Popup {
             Layout.leftMargin: VPNTheme.theme.vSpacing
             Layout.rightMargin: VPNTheme.theme.vSpacing
             Layout.bottomMargin: VPNTheme.theme.vSpacing
+            Layout.alignment: Qt.AlignHCenter
         }
     }
 

--- a/nebula/ui/components/forms/VPNContextualAlert.qml
+++ b/nebula/ui/components/forms/VPNContextualAlert.qml
@@ -68,6 +68,7 @@ RowLayout {
         Layout.preferredWidth: VPNTheme.theme.iconSize - VPNTheme.theme.focusBorderWidth
         Layout.rightMargin: VPNTheme.theme.listSpacing
         Layout.topMargin: 1
+        visible: messageText.text && messageText.text.length !== 0;
     }
 
     VPNTextBlock {

--- a/nebula/ui/components/inAppAuth/VPNInAppAuthenticationBase.qml
+++ b/nebula/ui/components/inAppAuth/VPNInAppAuthenticationBase.qml
@@ -32,8 +32,9 @@ VPNFlickable {
     ColumnLayout {
         id: col
         anchors.top: parent.top
-        height: Math.max(authBase.height, col.implicitHeight)
-        width: authBase.width
+        height: Math.max(parent.height, col.implicitHeight)
+        anchors.left: parent.left
+        anchors.right: parent.right
 
         PropertyAnimation on opacity {
             from: 0

--- a/nebula/ui/components/inAppAuth/VPNInAppAuthenticationBase.qml
+++ b/nebula/ui/components/inAppAuth/VPNInAppAuthenticationBase.qml
@@ -159,11 +159,4 @@ VPNFlickable {
         }
     }
 
-    Connections {
-        target: VPNAuthInApp
-        function onErrorOccurred(error) {
-            console.log("VPNAuthInApp error", error);
-        }
-    }
-
 }

--- a/nebula/ui/components/inAppAuth/VPNInAppAuthenticationErrorPopup.qml
+++ b/nebula/ui/components/inAppAuth/VPNInAppAuthenticationErrorPopup.qml
@@ -67,11 +67,6 @@ VPNPopup {
                 openErrorModalAndForceFocus();
                 break;
 
-            case VPNAuthInApp.ErrorInvalidOrExpiredVerificationCode:
-                authErrorMessage.text = "Invalid or expired verification code"
-                openErrorModalAndForceFocus();
-                break;
-
             case VPNAuthInApp.ErrorTooManyRequests:
                 authErrorMessage.text = "Too many login attempts, hold off for 15 minutes"
                 openErrorModalAndForceFocus();

--- a/nebula/ui/components/inAppAuth/VPNInAppAuthenticationErrorPopup.qml
+++ b/nebula/ui/components/inAppAuth/VPNInAppAuthenticationErrorPopup.qml
@@ -1,0 +1,82 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import QtQuick 2.5
+import QtQuick.Layouts 1.14
+
+import Mozilla.VPN 1.0
+import components 0.1
+import components.forms 0.1
+
+VPNPopup {
+    id: authError
+    anchors.centerIn: parent
+    width: Math.min(parent.width * 0.73, VPNTheme.theme.maxHorizontalContentWidth)
+    maxWidth: Math.min(parent.width * 0.83, VPNTheme.theme.maxHorizontalContentWidth)
+    _popupContent:
+        ColumnLayout {
+            id: authErrorContent
+            spacing: VPNTheme.theme.vSpacing
+
+                Image {
+                    source: "qrc:/ui/resources/updateRequired.svg"
+                    antialiasing: true
+                    sourceSize.height: 80
+                    sourceSize.width: 80
+                    Layout.alignment: Qt.AlignHCenter
+                }
+            VPNTextBlock {
+                id: authErrorMessage
+                text: ""
+                horizontalAlignment: Text.AlignHCenter
+                Layout.preferredWidth: parent.width
+                Layout.fillWidth: true
+                width: undefined
+            }
+
+            VPNButton {
+                text: "Okay"
+                onClicked: authError.close()
+            }
+        }
+
+
+    Connections {
+        target: VPNAuthInApp
+
+        function openErrorModalAndForceFocus() {
+            authError.open();
+            authErrorContent.forceActiveFocus();
+        }
+
+        function onErrorOccurred(e) {
+            switch(e) {
+            case VPNAuthInApp.ErrorEmailCanNotBeUsedToLogin:
+                authErrorMessage.text = "email can not be used to log in";
+                openErrorModalAndForceFocus();
+                break;
+
+            case VPNAuthInApp.ErrorEmailTypeNotSupported:
+                authErrorMessage.text = "email type not supported";
+                openErrorModalAndForceFocus();
+                break;
+
+            case VPNAuthInApp.ErrorFailedToSendEmail:
+                authErrorMessage.text = "Error - failed to send email"
+                openErrorModalAndForceFocus();
+                break;
+
+            case VPNAuthInApp.ErrorInvalidOrExpiredVerificationCode:
+                authErrorMessage.text = "Invalid or expired verification code"
+                openErrorModalAndForceFocus();
+                break;
+
+            case VPNAuthInApp.ErrorTooManyRequests:
+                authErrorMessage.text = "Too many login attempts, hold off for 15 minutes"
+                openErrorModalAndForceFocus();
+                break;
+            }
+        }
+    }
+}

--- a/nebula/ui/components/inAppAuth/VPNInAppAuthenticationErrorPopup.qml
+++ b/nebula/ui/components/inAppAuth/VPNInAppAuthenticationErrorPopup.qml
@@ -7,7 +7,6 @@ import QtQuick.Layouts 1.14
 
 import Mozilla.VPN 1.0
 import components 0.1
-import components.forms 0.1
 
 VPNPopup {
     id: authError

--- a/nebula/ui/components/inAppAuth/VPNInAppAuthenticationInputs.qml
+++ b/nebula/ui/components/inAppAuth/VPNInAppAuthenticationInputs.qml
@@ -113,10 +113,17 @@ ColumnLayout {
                 base._inputErrorMessage =  VPNl18n.InAppAuthInvalidPasswordErrorMessage;
                 activeInput().forceActiveFocus();
                 break;
+
             case VPNAuthInApp.ErrorInvalidEmailCode:
                 base._inputErrorMessage = "Invalid email code";
                 activeInput().forceActiveFocus();
                 break;
+
+            case VPNAuthInApp.ErrorInvalidOrExpiredVerificationCode:
+                base._inputErrorMessage = "Invalid or expired verification code"
+                activeInput().forceActiveFocus();
+                break;
+
             case VPNAuthInApp.ErrorInvalidTotpCode:
                 base._inputErrorMessage = "invalid 2fa unblock code";
                 activeInput().forceActiveFocus();

--- a/nebula/ui/components/inAppAuth/VPNInAppAuthenticationInputs.qml
+++ b/nebula/ui/components/inAppAuth/VPNInAppAuthenticationInputs.qml
@@ -113,7 +113,10 @@ ColumnLayout {
                 base._inputErrorMessage =  VPNl18n.InAppAuthInvalidPasswordErrorMessage;
                 activeInput().forceActiveFocus();
                 break;
-
+            case VPNAuthInApp.ErrorInvalidEmailAddress:
+                base._inputErrorMessage = "Invalid email address";
+                activeInput().forceActiveFocus();
+                break;
             case VPNAuthInApp.ErrorInvalidEmailCode:
                 base._inputErrorMessage = "Invalid email code";
                 activeInput().forceActiveFocus();

--- a/nebula/ui/components/inAppAuth/VPNInAppAuthenticationInputs.qml
+++ b/nebula/ui/components/inAppAuth/VPNInAppAuthenticationInputs.qml
@@ -1,0 +1,136 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import QtQuick 2.5
+import QtQuick.Layouts 1.14
+
+import Mozilla.VPN 1.0
+import components 0.1
+import components.forms 0.1
+
+ColumnLayout {
+    id: base
+    property string _inputPlaceholderText: ""
+    property string _inputErrorMessage: ""
+    property alias _inputMethodHints: textInput.inputMethodHints
+    property var _buttonOnClicked
+    property alias _buttonEnabled: btn.enabled
+    property alias _buttonText: btn.text
+    property bool _isSignInView: (VPNAuthInApp.state === VPNAuthInApp.StateSignIn || VPNAuthInApp.state === VPNAuthInApp.StateSigningIn)
+
+    function activeInput() {
+        return _isSignInView ? passwordInput : textInput
+    }
+
+    Component.onCompleted: if (typeof(authError) === "undefined" || !authError.visible) activeInput().forceActiveFocus();
+
+    spacing: VPNTheme.theme.vSpacing - VPNTheme.theme.listSpacing
+
+    ColumnLayout {
+        id: col
+        Layout.fillWidth: true
+        spacing: VPNTheme.theme.listSpacing
+
+        function submitInfo(input) {
+            if (!input.hasError && input.text.length > 0) btn.clicked();
+        }
+
+        VPNTextField {
+            id: textInput
+            Layout.fillWidth: true
+            _placeholderText: _inputPlaceholderText
+            Keys.onReturnPressed: col.submitInfo(textInput)
+            onTextChanged: if (hasError) hasError = false
+        }
+
+        VPNPasswordInput {
+            id: passwordInput
+            _placeholderText: _inputPlaceholderText
+            Layout.fillWidth: true
+            Keys.onReturnPressed: col.submitInfo(passwordInput)
+            onTextChanged: if (hasError) hasError = false
+        }
+
+        VPNContextualAlerts {
+            anchors.left: undefined
+            anchors.right: undefined
+            anchors.topMargin: undefined
+            Layout.minimumHeight: VPNTheme.theme.vSpacing
+            Layout.fillHeight: false
+            messages: [
+                {
+                    type: "error",
+                    message: base._inputErrorMessage,
+                    visible: activeInput().hasError
+                }
+            ]
+        }
+    }
+
+    states: [
+        State {
+            when: _isSignInView
+            PropertyChanges {
+                target: textInput
+                visible: false
+            }
+            PropertyChanges {
+                target: passwordInput
+                visible: true
+            }
+        },
+        State {
+            when: !_isSignInView
+            PropertyChanges {
+                target: textInput
+                visible: true
+            }
+            PropertyChanges {
+                target: passwordInput
+                visible: false
+            }
+        }
+    ]
+
+    VPNButton {
+        id: btn
+        Layout.fillWidth: true
+        loaderVisible:  VPNAuthInApp.state === VPNAuthInApp.StateCheckingAccount ||
+                        VPNAuthInApp.state === VPNAuthInApp.StateSigningIn ||
+                        VPNAuthInApp.state === VPNAuthInApp.StateSigningUp ||
+                        VPNAuthInApp.state === VPNAuthInApp.StateVerifyingSessionEmailCode ||
+                        VPNAuthInApp.state === VPNAuthInApp.StateVerifyingSessionTotpCode
+        onClicked: _buttonOnClicked(activeInput().text)
+
+    }
+
+    Connections {
+        target: VPNAuthInApp
+        function onErrorOccurred(e) {
+            switch(e) {
+            case VPNAuthInApp.ErrorIncorrectPassword:
+                base._inputErrorMessage =  VPNl18n.InAppAuthInvalidPasswordErrorMessage;
+                activeInput().forceActiveFocus();
+                break;
+            case VPNAuthInApp.ErrorInvalidEmailCode:
+                base._inputErrorMessage = "Invalid email code";
+                activeInput().forceActiveFocus();
+                break;
+            case VPNAuthInApp.ErrorInvalidTotpCode:
+                base._inputErrorMessage = "invalid 2fa unblock code";
+                activeInput().forceActiveFocus();
+                break;
+
+            case VPNAuthInApp.ErrorInvalidUnblockCode:
+                base._inputErrorMessage = "Invalid unblock code";
+                activeInput().forceActiveFocus();
+                break;
+            }
+
+            if (!authError.visible)
+                activeInput().forceActiveFocus();
+            activeInput().hasError = true;
+        }
+    }
+}

--- a/nebula/ui/components/inAppAuth/qmldir
+++ b/nebula/ui/components/inAppAuth/qmldir
@@ -1,1 +1,3 @@
 VPNInAppAuthenticationBase 0.1 VPNInAppAuthenticationBase.qml
+VPNInAppAuthenticationErrorPopup 0.1 VPNInAppAuthenticationErrorPopup.qml
+VPNInAppAuthenticationInputs 0.1 VPNInAppAuthenticationInputs.qml

--- a/src/authenticationinapp/authenticationinapplistener.cpp
+++ b/src/authenticationinapp/authenticationinapplistener.cpp
@@ -664,7 +664,8 @@ void AuthenticationInAppListener::processErrorCode(
       break;
 
     case 127:  // Invalid unblock code
-      aip->requestState(AuthenticationInApp::StateVerificationSessionByEmailNeeded, this);
+      aip->requestState(
+          AuthenticationInApp::StateVerificationSessionByEmailNeeded, this);
       aip->requestErrorPropagation(AuthenticationInApp::ErrorInvalidEmailCode,
                                    this);
       break;

--- a/src/authenticationinapp/authenticationinapplistener.cpp
+++ b/src/authenticationinapp/authenticationinapplistener.cpp
@@ -664,7 +664,6 @@ void AuthenticationInAppListener::processErrorCode(
       break;
 
     case 127:  // Invalid unblock code
-      aip->requestState(AuthenticationInApp::StateStart, this);
       aip->requestErrorPropagation(AuthenticationInApp::ErrorInvalidEmailCode,
                                    this);
       break;

--- a/src/authenticationinapp/authenticationinapplistener.cpp
+++ b/src/authenticationinapp/authenticationinapplistener.cpp
@@ -664,6 +664,7 @@ void AuthenticationInAppListener::processErrorCode(
       break;
 
     case 127:  // Invalid unblock code
+      aip->requestState(AuthenticationInApp::StateVerificationSessionByEmailNeeded, this);
       aip->requestErrorPropagation(AuthenticationInApp::ErrorInvalidEmailCode,
                                    this);
       break;

--- a/src/ui/authenticationInApp/ViewAuthenticationInApp.qml
+++ b/src/ui/authenticationInApp/ViewAuthenticationInApp.qml
@@ -3,10 +3,12 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import QtQuick 2.5
+import QtQuick.Layouts 1.14
 
 import Mozilla.VPN 1.0
 import components 0.1
 import components.forms 0.1
+import components.inAppAuth 0.1
 
 Item {
     id: viewAuthenticationInApp
@@ -16,6 +18,10 @@ Item {
 
         asynchronous: true
         anchors.fill: parent
+    }
+
+    VPNInAppAuthenticationErrorPopup {
+        id: authError
     }
 
     states: [

--- a/src/ui/authenticationInApp/ViewAuthenticationSignIn.qml
+++ b/src/ui/authenticationInApp/ViewAuthenticationSignIn.qml
@@ -7,7 +7,6 @@ import QtQuick.Layouts 1.14
 
 import Mozilla.VPN 1.0
 import components 0.1
-import components.forms 0.1
 import components.inAppAuth 0.1
 
 VPNInAppAuthenticationBase {

--- a/src/ui/authenticationInApp/ViewAuthenticationSignIn.qml
+++ b/src/ui/authenticationInApp/ViewAuthenticationSignIn.qml
@@ -39,59 +39,14 @@ VPNInAppAuthenticationBase {
     _imgSource: "qrc:/nebula/resources/avatar.svg"
     _inputLabel: VPNl18n.InAppAuthPasswordInputLabel
 
-    _inputs: ColumnLayout {
-        spacing: VPNTheme.theme.vSpacing - VPNTheme.theme.listSpacing
-
-        ColumnLayout {
-            Layout.fillWidth: true
-            spacing: VPNTheme.theme.listSpacing
-
-            VPNPasswordInput {
-                id: passwordInput
-                Layout.fillWidth: true
-                _placeholderText: VPNl18n.InAppAuthPasswordInputPlaceholder
-                Keys.onReturnPressed: if (!hasError && text.length > 0) signInBtn.clicked();
-                onTextChanged: if (passwordInput.hasError) hasError = false
-            }
-
-            VPNContextualAlerts {
-                id: searchWarning
-                anchors.left: undefined
-                anchors.right: undefined
-                anchors.topMargin: undefined
-                Layout.minimumHeight: VPNTheme.theme.vSpacing
-                Layout.fillHeight: false
-                messages: [
-                    {
-                        type: "error",
-                        message: VPNl18n.InAppAuthInvalidPasswordErrorMessage,
-                        visible: passwordInput.hasError
-                    }
-                ]
-            }
-        }
-
-        VPNButton {
-            id: signInBtn
-            text: VPNl18n.InAppAuthSignInButton
-            enabled: VPNAuthInApp.state === VPNAuthInApp.StateSignIn
-            loaderVisible: VPNAuthInApp.state === VPNAuthInApp.StateSigningIn
-            onClicked: {
-                VPNAuthInApp.setPassword(passwordInput.text);
-                VPNAuthInApp.signIn();
-            }
-            Layout.fillWidth: true
-        }
-
-        Connections {
-            target: VPNAuthInApp
-            function onErrorOccurred(e) {
-                if (e === 2) {
-                    passwordInput.hasError = true;
-                    passwordInput.forceActiveFocus();
-                }
-            }
-        }
+    _inputs: VPNInAppAuthenticationInputs {
+        _buttonEnabled: VPNAuthInApp.state === VPNAuthInApp.StateSignIn && !activeInput().hasError
+        _buttonOnClicked: (inputText) => {
+             VPNAuthInApp.setPassword(inputText);
+             VPNAuthInApp.signIn();
+         }
+        _buttonText: VPNl18n.InAppAuthSignInButton
+        _inputPlaceholderText: VPNl18n.InAppAuthPasswordInputPlaceholder
     }
 
     _disclaimers: ColumnLayout {

--- a/src/ui/authenticationInApp/ViewAuthenticationStart.qml
+++ b/src/ui/authenticationInApp/ViewAuthenticationStart.qml
@@ -7,7 +7,6 @@ import QtQuick.Layouts 1.14
 
 import Mozilla.VPN 1.0
 import components 0.1
-import components.forms 0.1
 import components.inAppAuth 0.1
 
 VPNInAppAuthenticationBase {

--- a/src/ui/authenticationInApp/ViewAuthenticationStart.qml
+++ b/src/ui/authenticationInApp/ViewAuthenticationStart.qml
@@ -31,21 +31,19 @@ VPNInAppAuthenticationBase {
     _imgSource: "qrc:/ui/resources/logo.svg"
     _inputLabel: "Email address"
 
-    _inputs: ColumnLayout {
-        spacing: VPNTheme.theme.vSpacing * 2
-        VPNTextField {
-            id: emailInput
-            hasError: !VPNAuthInApp.validateEmailAddress(emailInput.text)
-            _placeholderText: "Enter email"
-            Layout.fillWidth: true
-        }
-        VPNButton {
-            text: "Continue"
-            enabled: VPNAuthInApp.state === VPNAuthInApp.StateStart && emailInput.text.length !== 0 && !emailInput.hasError
-            loaderVisible: VPNAuthInApp.state === VPNAuthInApp.StateCheckingAccount
-            onClicked: VPNAuthInApp.checkAccount(emailInput.text);
-            Layout.fillWidth: true
-        }
+    _inputs: VPNInAppAuthenticationInputs {
+        _buttonEnabled: VPNAuthInApp.state === VPNAuthInApp.StateStart && activeInput().text.length !== 0 && !activeInput().hasError
+        _buttonOnClicked: (inputText) => {
+                              if (!VPNAuthInApp.validateEmailAddress(inputText)) {
+                                  activeInput().hasError = true;
+                                  _inputErrorMessage = "invalid email address, try again"
+                                  return activeInput().forceActiveFocus();
+                              }
+                              VPNAuthInApp.checkAccount(inputText);
+                          }
+        _buttonText: "Continue"
+        _inputMethodHints: Qt.ImhEmailCharactersOnly | Qt.ImhNoAutoUppercase
+        _inputPlaceholderText: "Enter email"
     }
 
     _disclaimers: RowLayout {

--- a/src/ui/authenticationInApp/ViewAuthenticationVerificationSessionByEmailNeeded.qml
+++ b/src/ui/authenticationInApp/ViewAuthenticationVerificationSessionByEmailNeeded.qml
@@ -32,57 +32,18 @@ VPNInAppAuthenticationBase {
 
     id: authSignUp
 
-    _changeEmailLinkVisible: true
     _menuButtonImageSource: "qrc:/nebula/resources/back.svg"
-    _menuButtonOnClick: () => {
-        VPNAuthInApp.reset();
-    }
+    _menuButtonOnClick: () => { VPNAuthInApp.reset() }
     _menuButtonAccessibleName: "Back"
     _headlineText: "Enter verification code"
     _subtitleText: "Open your email and enter the verification code it that was sent."
     _imgSource: "qrc:/nebula/resources/verification-code.svg"
 
-    _inputs: ColumnLayout {
-        spacing: VPNTheme.theme.vSpacingSmall
-
-        VPNBoldLabel {
-            id: codeLabel
-            text: "Verification code"
-        }
-
-        VPNTextField {
-            id: codeInput
-            hasError: false
-            _placeholderText: "Enter 6-digit code"
-            Layout.fillWidth: true
-        }
-
-        VPNContextualAlerts {
-            id: passwordInputCreateWarnings
-            Layout.fillWidth: true
-
-            messages: [
-                {
-                    type: "error",
-                    message: "Invalid code entry",
-                    visible: !createAccountButton.enabled
-                }
-            ]
-        }
-
-        VPNButton {
-            id: createAccountButton
-            enabled: VPNAuthInApp.state === VPNAuthInApp.StateVerificationSessionByEmailNeeded && codeInput.text && codeInput.text.length === VPNAuthInApp.verificationCodeLength
-            loaderVisible: VPNAuthInApp.state === VPNAuthInApp.StateVerifyingSessionEmailCode
-            text: "Verify"
-            Layout.fillWidth: true
-
-            onClicked: {
-                if (enabled) {
-                    VPNAuthInApp.verifySessionEmailCode(codeInput.text);
-                }
-            }
-        }
+    _inputs: VPNInAppAuthenticationInputs {
+        _buttonEnabled: VPNAuthInApp.state === VPNAuthInApp.StateVerificationSessionByEmailNeeded && activeInput().text && activeInput().text.length === VPNAuthInApp.verificationCodeLength && !activeInput().hasError
+        _buttonOnClicked: (inputText) => { VPNAuthInApp.verifySessionEmailCode(inputText) }
+        _buttonText: "Verify"
+        _inputPlaceholderText: "Enter 6 digit code"
     }
 
     _footerContent: Column {
@@ -92,9 +53,7 @@ VPNInAppAuthenticationBase {
         VPNLinkButton {
             labelText: "Resend code"
             anchors.horizontalCenter: parent.horizontalCenter
-            onClicked: {
-                VPNAuthInApp.resendVerificationSessionCodeEmail();
-            }
+            onClicked: VPNAuthInApp.resendVerificationSessionCodeEmail();
         }
 
         VPNLinkButton {

--- a/src/ui/authenticationInApp/ViewAuthenticationVerificationSessionByEmailNeeded.qml
+++ b/src/ui/authenticationInApp/ViewAuthenticationVerificationSessionByEmailNeeded.qml
@@ -7,7 +7,6 @@ import QtQuick.Layouts 1.14
 
 import Mozilla.VPN 1.0
 import components 0.1
-import components.forms 0.1
 import components.inAppAuth 0.1
 
 

--- a/src/ui/authenticationInApp/ViewAuthenticationVerificationSessionByEmailNeeded.qml
+++ b/src/ui/authenticationInApp/ViewAuthenticationVerificationSessionByEmailNeeded.qml
@@ -42,6 +42,7 @@ VPNInAppAuthenticationBase {
         _buttonEnabled: VPNAuthInApp.state === VPNAuthInApp.StateVerificationSessionByEmailNeeded && activeInput().text && activeInput().text.length === VPNAuthInApp.verificationCodeLength && !activeInput().hasError
         _buttonOnClicked: (inputText) => { VPNAuthInApp.verifySessionEmailCode(inputText) }
         _buttonText: "Verify"
+        _inputMethodHints: Qt.ImhDigitsOnly
         _inputPlaceholderText: "Enter 6 digit code"
     }
 

--- a/src/ui/authenticationInApp/ViewAuthenticationVerificationSessionByTotpNeeded.qml
+++ b/src/ui/authenticationInApp/ViewAuthenticationVerificationSessionByTotpNeeded.qml
@@ -7,7 +7,6 @@ import QtQuick.Layouts 1.14
 
 import Mozilla.VPN 1.0
 import components 0.1
-import components.forms 0.1
 import components.inAppAuth 0.1
 
 VPNInAppAuthenticationBase {

--- a/src/ui/authenticationInApp/ViewAuthenticationVerificationSessionByTotpNeeded.qml
+++ b/src/ui/authenticationInApp/ViewAuthenticationVerificationSessionByTotpNeeded.qml
@@ -38,6 +38,7 @@ VPNInAppAuthenticationBase {
         _buttonEnabled: VPNAuthInApp.state === VPNAuthInApp.StateVerificationSessionByTotpNeeded && !activeInput().hasError
         _buttonOnClicked: (inputText) => { VPNAuthInApp.verifySessionTotpCode(inputText) }
         _buttonText: "Continue"
+        _inputMethodHints: Qt.ImhDigitsOnly
         _inputPlaceholderText: "Enter 2-factor auth code"
     }
 

--- a/src/ui/authenticationInApp/ViewAuthenticationVerificationSessionByTotpNeeded.qml
+++ b/src/ui/authenticationInApp/ViewAuthenticationVerificationSessionByTotpNeeded.qml
@@ -28,29 +28,18 @@ VPNInAppAuthenticationBase {
     Component.onCompleted: console.log("SESSION VERIFICATION BY TOTP")
 
     _menuButtonImageSource: "qrc:/nebula/resources/close-dark.svg"
-    _menuButtonOnClick: () => { VPNAuthInApp.reset() }
+    _menuButtonOnClick: () => { VPN.cancelAuthentication() }
     _menuButtonAccessibleName: "TODO: Lorum Ipsum - Back"
     _headlineText: "Enter 2-factor auth code"
     _subtitleText: "Enter your 2-factor auth code"
     _imgSource: "qrc:/ui/resources/logo.svg"
     _inputLabel: "Enter code"
 
-    _inputs: ColumnLayout {
-        spacing: VPNTheme.theme.vSpacing * 2
-        VPNTextField {
-            id: codeInput
-            Layout.fillWidth: true
-        }
-
-        VPNButton {
-            text: "Verify"
-            enabled: VPNAuthInApp.state === VPNAuthInApp.StateVerificationSessionByTotpNeeded
-            loaderVisible: VPNAuthInApp.state === VPNAuthInApp.StateVerifyingSessionTotpCode
-            onClicked: {
-              VPNAuthInApp.verifySessionTotpCode(codeInput.text);
-            }
-            Layout.fillWidth: true
-        }
+    _inputs: VPNInAppAuthenticationInputs {
+        _buttonEnabled: VPNAuthInApp.state === VPNAuthInApp.StateVerificationSessionByTotpNeeded && !activeInput().hasError
+        _buttonOnClicked: (inputText) => { VPNAuthInApp.verifySessionTotpCode(inputText) }
+        _buttonText: "Continue"
+        _inputPlaceholderText: "Enter 2-factor auth code"
     }
 
     _footerContent: Column {
@@ -60,7 +49,7 @@ VPNInAppAuthenticationBase {
             fontName: VPNTheme.theme.fontBoldFamily
             anchors.horizontalCenter: parent.horizontalCenter
             linkColor: VPNTheme.theme.redButton
-            onClicked: VPNAuthInApp.reset()
+            onClicked: VPN.cancelAuthentication()
         }
     }
 }

--- a/src/ui/authenticationInApp/ViewAuthenticationVerificationSessionByTotpNeeded.qml
+++ b/src/ui/authenticationInApp/ViewAuthenticationVerificationSessionByTotpNeeded.qml
@@ -31,8 +31,8 @@ VPNInAppAuthenticationBase {
     _menuButtonOnClick: () => { VPN.cancelAuthentication() }
     _menuButtonAccessibleName: "TODO: Lorum Ipsum - Back"
     _headlineText: "Enter 2-factor auth code"
-    _subtitleText: "Enter your 2-factor auth code"
-    _imgSource: "qrc:/ui/resources/logo.svg"
+    _subtitleText: "Enter 6-digit code"
+    _imgSource: "qrc:/nebula/resources/verification-code.svg"
     _inputLabel: "Enter code"
 
     _inputs: VPNInAppAuthenticationInputs {


### PR DESCRIPTION
This PR:
- Adds VPNInAppAuthenticationInputs.qml to consolidate duped code across all auth templates (except password creation)
- Adds VPNInAppAuthenticationErrorPopup.qml to surface authentication errors not relevant to a specific input. 

Also:
  - Valid forms can be submitted by hitting 'Enter'
  - Adds `inputMethodHints` to email entry text field to cue mobile devices and improve native keyboard options on Apple
  - Email validation occurs after hitting "submit"
  - Handles all auth errors currently exposed to the QML
  
To follow: 
- final content
- final TOS content/UI
- tests
- password creation fixes
- more error handling, form polish, etc.

Fixes #2870 , #2823 , #2818, #2817, VPN-1771, VPN-1610, VPN-1611

<table>
<tr>
<td>
<img width="260" alt="Screen Shot 2022-03-03 at 10 46 25 AM" src="https://user-images.githubusercontent.com/22355127/156615298-01c85264-9eab-4aef-a5cb-153d914c8b5e.png">
</td>
<td>
<img width="260" alt="Screen Shot 2022-03-03 at 10 46 32 AM" src="https://user-images.githubusercontent.com/22355127/156618631-6c2a21f2-74c9-4a42-9726-369c05c4e39c.png">

</td>
</tr>
<tr>
<td>
<img width="260" alt="Screen Shot 2022-03-03 at 11 30 03 AM" src="https://user-images.githubusercontent.com/22355127/156619989-d710e771-f2b4-438d-ae12-4184ee0038b9.png">

</td>
<td>
<img width="260" alt="Screen Shot 2022-03-03 at 10 46 13 AM" src="https://user-images.githubusercontent.com/22355127/156616279-977af34b-351c-40d5-a3a2-1251e3141702.png">
</td>
</tr>
<tr>
<td>
<img width="260" alt="Screen Shot 2022-03-03 at 11 30 19 AM" src="https://user-images.githubusercontent.com/22355127/156620112-d888d84d-b72c-4c8c-9a57-b7e3ad2fe298.png">
</td>
<td>
<img width="260" alt="Screen Shot 2022-03-03 at 11 31 51 AM" src="https://user-images.githubusercontent.com/22355127/156620160-b817c3d0-da74-437b-9982-830dd838a224.png">

</td>
</tr>

<tr>
<td>
<img width="260" alt="Screen Shot 2022-03-03 at 10 50 38 AM" src="https://user-images.githubusercontent.com/22355127/156618418-1d99818e-337b-4257-a707-510f0023f635.png">
</td>
<td>
<img width="260" alt="Screen Shot 2022-03-03 at 10 54 51 AM" src="https://user-images.githubusercontent.com/22355127/156621798-4bd3f911-33fa-4a4e-9d56-df9815d7dc8c.png">

</td>
</tr>
<tr>
<td>
<img width="260" alt="Screen Shot 2022-03-03 at 10 47 59 AM" src="https://user-images.githubusercontent.com/22355127/156618505-813971b7-4b7c-4219-9cbd-bb58bef94501.png">
</td>

</tr>

</table>