### PR TITLE
Mitigate scrollbar/content overlaps

### DIFF
--- a/nebula/ui/components/VPNFlickable.qml
+++ b/nebula/ui/components/VPNFlickable.qml
@@ -67,8 +67,20 @@ Flickable {
         duration: 200
     }
 
-    ScrollBar.vertical: ScrollBar {
-        policy: windowHeightExceedsContentHeight ? ScrollBar.AlwaysOff : ScrollBar.AlwaysOn
+    ScrollIndicator.vertical: ScrollIndicator {
+        background: Rectangle {
+            color: "transparent"
+            implicitWidth: VPNTheme.theme.windowMargin / 2
+        }
+
+        contentItem: Rectangle {
+            radius: VPNTheme.theme.windowMargin / 2
+            implicitWidth: VPNTheme.theme.windowMargin / 2 * .75
+            color: VPNTheme.colors.grey40
+            opacity: .3
+        }
+
+        visible: !windowHeightExceedsContentHeight
         Accessible.ignored: true
         opacity: hideScollBarOnStackTransition && (vpnFlickable.StackView.status !== StackView.Active) ? 0 : 1
         Behavior on opacity {


### PR DESCRIPTION
Fix #2879 

<table>
<tr>
<th>
Before
</th>

<th>
After
</th>
</tr>
<td>
<img width="300" alt="Screen Shot 2022-02-28 at 4 37 15 PM" src="https://user-images.githubusercontent.com/22355127/156070299-b8090233-309a-489f-8be4-7290465383d5.png">
</td>

<td>
<img width="300" alt="Screen Shot 2022-02-28 at 4 24 29 PM" src="https://user-images.githubusercontent.com/22355127/156070485-95ed8ae0-adbf-45e1-ac1c-8fff1089815f.png">

</td>

</tr>
</table>
<table>
<tr>
<th>
Before
</th>

<th>
After
</th>
</tr>
<tr>
<td>
<img width="300" alt="Screen Shot 2022-02-28 at 4 37 26 PM" src="https://user-images.githubusercontent.com/22355127/156070322-2f9416b9-cd05-47e7-852f-328ab8ae49e3.png">
</td>

<td>
<img width="300" alt="Screen Shot 2022-02-28 at 4 33 39 PM" src="https://user-images.githubusercontent.com/22355127/156070436-3550bac9-b15e-4bf6-9039-5352e5005d58.png">

</td>

</tr>
</table>