### PR TITLE
nit: Fix vertical alignment of settings menu button text

### DIFF
--- a/nebula/ui/components/VPNIconAndLabel.qml
+++ b/nebula/ui/components/VPNIconAndLabel.qml
@@ -29,8 +29,7 @@ Item {
         id: title
 
         anchors.left: parent.left
-        anchors.verticalCenter: parent.verticalCenter
-        anchors.verticalCenterOffset: -1
+        anchors.verticalCenter: icon.verticalCenter
         color: fontColor
         // VPNIconAndLabel is only used inside a VPNClickableRow
         // which acts as atomic interactive control thus we want
@@ -40,10 +39,10 @@ Item {
         wrapMode: Text.WordWrap
         leftPadding: icon.width + 14
         lineHeightMode: Text.FixedHeight
-        lineHeight: VPNTheme.theme.labelLineHeight
+        lineHeight: 1
+        anchors.verticalCenterOffset: 1
         rightPadding: icon.width + 14
-        topPadding: VPNTheme.theme.labelLineHeight - font.pixelSize
-        width: title.implicitWidth < parent.width ? undefined : parent.width
+        width: implicitWidth
 
         Rectangle {
             id: indicator

--- a/src/ui/settings/ViewWhatsNew.qml
+++ b/src/ui/settings/ViewWhatsNew.qml
@@ -82,6 +82,7 @@ Item {
                         text: feature.shortDescription
                         Layout.fillWidth: true
                         Layout.leftMargin: VPNTheme.theme.vSpacing + 14
+                        Layout.topMargin: VPNTheme.theme.windowMargin / 4
                     }
                 }
             }


### PR DESCRIPTION

<table>
<tr>
<th>
Before
</th>
<th>
After
</th>
</tr>
<tr>
<td>
<img width="384" alt="Screen Shot 2022-02-17 at 9 46 16 PM" src="https://user-images.githubusercontent.com/22355127/156074307-3a907245-eebe-42f7-8a95-2c02be8206db.png">

<img width="392" alt="Screen Shot 2022-02-28 at 4 47 03 PM" src="https://user-images.githubusercontent.com/22355127/156074336-e029f9e3-c06d-4065-8199-f81166b041ca.png">
<img width="388" alt="Screen Shot 2022-02-28 at 4 46 57 PM" src="https://user-images.githubusercontent.com/22355127/156074345-f56be5c7-7e36-45b5-a5a2-b4db29fc347d.png">
<img width="384" alt="Screen Shot 2022-02-28 at 4 46 51 PM" src="https://user-images.githubusercontent.com/22355127/156074350-4585bdff-2887-4322-8854-12cf846d3ef3.png">

</td>
<td>
<img width="379" alt="Screen Shot 2022-02-28 at 5 04 53 PM" src="https://user-images.githubusercontent.com/22355127/156074406-36834a8a-7f5c-443b-9c9c-0d58423308a3.png">

<img width="383" alt="Screen Shot 2022-02-28 at 5 05 05 PM" src="https://user-images.githubusercontent.com/22355127/156074389-8353a5a1-22dd-4f9a-9fc0-fe47ca493d39.png">
<img width="381" alt="Screen Shot 2022-02-28 at 5 04 59 PM" src="https://user-images.githubusercontent.com/22355127/156074400-8575496b-838a-4a36-ba06-6b0fadafa6f7.png">

</td>
</tr>
</table>