### PR TITLE
Wasm builds on taskcluster

### DIFF
--- a/taskcluster/ci/build/kind.yml
+++ b/taskcluster/ci/build/kind.yml
@@ -14,5 +14,6 @@ jobs-from:
 #    - windows.yml
     - android.yml
 #    - mac.yml
+    - wasm.yml
 
 

--- a/taskcluster/ci/build/wasm.yml
+++ b/taskcluster/ci/build/wasm.yml
@@ -1,0 +1,26 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+---
+
+
+wasm/opt:
+        description: "Wasm Build"
+        treeherder:
+            symbol: B
+            kind: build
+            tier: 1
+            platform: web/opt
+        worker-type: b-linux
+        worker:
+            docker-image: {in-tree: wasm}
+            max-run-time: 3600
+            artifacts:
+                - type: directory
+                  name: public/build
+                  path: /builds/worker/artifacts
+        run:
+            using: run-task
+            use-caches: true
+            cwd: '{checkout}'
+            command: ./taskcluster/scripts/build/wasm.sh

--- a/taskcluster/ci/docker-image/kind.yml
+++ b/taskcluster/ci/docker-image/kind.yml
@@ -28,6 +28,9 @@ jobs:
     lint:
         parent: base
         symbol: I(lint)
+    wasm:
+        parent: base
+        symbol: I(wasm)
     android-build:
         parent: base
         symbol: I(android)

--- a/taskcluster/docker/wasm/Dockerfile
+++ b/taskcluster/docker/wasm/Dockerfile
@@ -1,0 +1,35 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+FROM $DOCKER_IMAGE_PARENT
+
+MAINTAINER Sebastian Streich <sstreich@mozilla.com>
+
+VOLUME /builds/worker/checkouts
+VOLUME /builds/worker/ccache
+
+RUN mkdir -p /builds/worker/.cache/go-build &&\
+    chown -R worker:worker /builds/worker/.cache/ &&\
+    chown -R worker:worker /builds/worker/ccache &&\
+    chmod -R 777 /builds/worker/ 
+
+RUN apt-get -q update && apt-get install -y git ccache python3 &&\
+     python3 -m pip install aqtinstall &&\
+     # qt6.2.3 for wasm needs the desktop linux installation
+     python3 -m aqt install-qt -O /opt linux desktop 6.2.3 &&\
+     python3 -m aqt install-qt -O /opt linux desktop 6.2.3 wasm_32 -m qtcharts qtwebsockets qt5compat &&\
+     # see: https://wiki.qt.io/Qt_6.2_Known_Issues#WebAssembly
+     sed '/sse/,+5 d' /opt/6.2.3/wasm_32/mkspecs/features/wasm/wasm.prf > /tmp/wasm.prf &&\
+     mv /tmp/wasm.prf /opt/6.2.3/wasm_32/mkspecs/features/wasm/wasm.prf &&\
+     cd /opt/ &&\
+     git clone https://github.com/emscripten-core/emsdk.git &&\
+     cd emsdk &&\
+     ./emsdk install latest &&\
+     ./emsdk activate latest 
+
+ENV QTPATH=/opt/6.2.3/
+ENV EMSDKPATH=/opt/emsdk/
+ENV CCACHE_DIR=/builds/worker/ccache
+
+ENV PATH="/opt/6.2.3/wasm_32/bin:/opt/6.2.3/gcc_64/bin:${PATH}"

--- a/taskcluster/docker/wasm/Dockerfile
+++ b/taskcluster/docker/wasm/Dockerfile
@@ -7,14 +7,12 @@ FROM $DOCKER_IMAGE_PARENT
 MAINTAINER Sebastian Streich <sstreich@mozilla.com>
 
 VOLUME /builds/worker/checkouts
-VOLUME /builds/worker/ccache
 
 RUN mkdir -p /builds/worker/.cache/go-build &&\
     chown -R worker:worker /builds/worker/.cache/ &&\
-    chown -R worker:worker /builds/worker/ccache &&\
     chmod -R 777 /builds/worker/ 
 
-RUN apt-get -q update && apt-get install -y git ccache python3 &&\
+RUN apt-get -q update && apt-get install -y git ccache python3 libglib2.0-0 &&\
      python3 -m pip install aqtinstall &&\
      # qt6.2.3 for wasm needs the desktop linux installation
      python3 -m aqt install-qt -O /opt linux desktop 6.2.3 &&\
@@ -25,11 +23,10 @@ RUN apt-get -q update && apt-get install -y git ccache python3 &&\
      cd /opt/ &&\
      git clone https://github.com/emscripten-core/emsdk.git &&\
      cd emsdk &&\
-     ./emsdk install latest &&\
-     ./emsdk activate latest 
+     ./emsdk install 2.0.14 &&\
+     ./emsdk activate 2.0.14 
 
 ENV QTPATH=/opt/6.2.3/
 ENV EMSDKPATH=/opt/emsdk/
-ENV CCACHE_DIR=/builds/worker/ccache
 
 ENV PATH="/opt/6.2.3/wasm_32/bin:/opt/6.2.3/gcc_64/bin:${PATH}"

--- a/taskcluster/mozillavpn_taskgraph/transforms/build.py
+++ b/taskcluster/mozillavpn_taskgraph/transforms/build.py
@@ -58,3 +58,17 @@ def add_artifacts(config, tasks):
         yield task
 
 
+# Adds an index route to the build task. 
+@transforms.add
+def index_build_tasks(config, tasks):
+    for task in tasks:
+        head_ref = config.params["head_ref"]
+        short_head_branch = head_ref.replace("refs/heads/", "")
+        task_name = task["name"]
+
+        route = f"mozillavpn.v2.mozilla-vpn-client.latest.client.{short_head_branch}.{task_name}"
+        if task.__contains__("routes"):
+            task["routes"].append(route)
+        else:
+            task["routes"] = [route]
+        yield task

--- a/taskcluster/mozillavpn_taskgraph/transforms/build.py
+++ b/taskcluster/mozillavpn_taskgraph/transforms/build.py
@@ -58,17 +58,3 @@ def add_artifacts(config, tasks):
         yield task
 
 
-# Adds an index route to the build task. 
-@transforms.add
-def index_build_tasks(config, tasks):
-    for task in tasks:
-        head_ref = config.params["head_ref"]
-        short_head_branch = head_ref.replace("refs/heads/", "")
-        task_name = task["name"]
-
-        route = f"mozillavpn.v2.mozilla-vpn-client.latest.client.{short_head_branch}.{task_name}"
-        if task.__contains__("routes"):
-            task["routes"].append(route)
-        else:
-            task["routes"] = [route]
-        yield task

--- a/taskcluster/scripts/build/wasm.sh
+++ b/taskcluster/scripts/build/wasm.sh
@@ -1,0 +1,26 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+/opt/emsdk/emsdk activate latest
+source /opt/emsdk/emsdk/emsdk_env.sh
+
+# This script is used in the Android Debug (universal) build task
+git submodule init
+git submodule update
+
+
+pip3 install -r requirements.txt
+# glean
+python3 ./scripts/utils/generate_glean.py
+# translations
+python3 ./scripts/utils/import_languages.py
+
+./scripts/wasm/compile.sh
+# Artifacts should be placed here!
+mkdir -p /builds/worker/artifacts/
+
+cp wasm/* /builds/worker/artifacts/
+
+ccache -s

--- a/taskcluster/scripts/build/wasm.sh
+++ b/taskcluster/scripts/build/wasm.sh
@@ -3,8 +3,17 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 
-/opt/emsdk/emsdk activate latest
-source /opt/emsdk/emsdk/emsdk_env.sh
+source /opt/emsdk/emsdk_env.sh
+
+
+echo "TEST"
+ls /opt/emsdk
+ls /opt/emsdk/emsdk
+ls /opt/6.2.3/wasm_32/bin
+ls /opt/6.2.3/gcc_64/bin
+
+where qmake 
+qmake --version
 
 # This script is used in the Android Debug (universal) build task
 git submodule init
@@ -21,6 +30,6 @@ python3 ./scripts/utils/import_languages.py
 # Artifacts should be placed here!
 mkdir -p /builds/worker/artifacts/
 
-cp wasm/* /builds/worker/artifacts/
+cp -r wasm/* /builds/worker/artifacts/
 
 ccache -s


### PR DESCRIPTION
This adds taskcluster jobs to build wasm(qt6)

-> Small nit change:
- Every /build/ task now will be indexed. 
- (Currently only decision tasks are indexed) 
- This gives us static routes for each build-job,branch combo  (i.e main.android.opt.x86.apk) ... or the mozillavpn.wasm, similar to what we have for the static_qt builds :) 