### PR TITLE
Crash reporter as a `Command` and fix the exit steps if nothing needs to be sent

### DIFF
--- a/src/commands/commandcrashreporter.cpp
+++ b/src/commands/commandcrashreporter.cpp
@@ -1,0 +1,25 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "commandcrashreporter.h"
+#include "commandlineparser.h"
+#include "leakdetector.h"
+
+#include <crashreporter/crashreporterapp.h>
+
+CommandCrashReporter::CommandCrashReporter(QObject* parent)
+    : Command(parent, "crashreporter", "Starts the crash reporter.") {
+  MVPN_COUNT_CTOR(CommandCrashReporter);
+}
+
+CommandCrashReporter::~CommandCrashReporter() {
+  MVPN_COUNT_DTOR(CommandCrashReporter);
+}
+
+int CommandCrashReporter::run(QStringList& tokens) {
+  return CrashReporterApp::main(CommandLineParser::argc(),
+                                CommandLineParser::argv());
+}
+
+static Command::RegistrationProxy<CommandCrashReporter> s_commandCrashReporter;

--- a/src/commands/commandcrashreporter.h
+++ b/src/commands/commandcrashreporter.h
@@ -1,0 +1,18 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef COMMANDCRASHREPORTER_H
+#define COMMANDCRASHREPORTER_H
+
+#include "command.h"
+
+class CommandCrashReporter final : public Command {
+ public:
+  explicit CommandCrashReporter(QObject* parent);
+  ~CommandCrashReporter();
+
+  int run(QStringList& tokens) override;
+};
+
+#endif  // COMMANDCRASHREPORTER_H

--- a/src/commands/commandui.cpp
+++ b/src/commands/commandui.cpp
@@ -57,9 +57,13 @@
 #endif
 
 #ifdef MVPN_WINDOWS
+#  include "crashreporter/crashclient.h"
 #  include "eventlistener.h"
 #  include "platforms/windows/windowsstartatbootwatcher.h"
 #  include "platforms/windows/windowsappimageprovider.h"
+
+#  include <iostream>
+#  include <windows.h>
 #endif
 
 #ifdef MVPN_WASM
@@ -138,6 +142,21 @@ int CommandUI::run(QStringList& tokens) {
 
     // This class receives communications from other instances.
     EventListener eventListener;
+#endif
+
+#ifdef MVPN_WINDOWS
+    // Allocate a console to view log output in debug mode on windows
+    if (AllocConsole()) {
+      FILE* unusedFile;
+      freopen_s(&unusedFile, "CONOUT$", "w", stdout);
+      freopen_s(&unusedFile, "CONOUT$", "w", stderr);
+      std::cout.clear();
+      std::clog.clear();
+      std::cerr.clear();
+    }
+
+    CrashClient::instance().start(CommandLineParser::argc(),
+                                  CommandLineParser::argv());
 #endif
 
 #ifdef MVPN_DEBUG

--- a/src/crashreporter/crashreporterapp.cpp
+++ b/src/crashreporter/crashreporterapp.cpp
@@ -19,7 +19,9 @@ int CrashReporterApp::main(int argc, char* argv[]) {
   auto crashreporter = CrashReporterFactory::createCrashReporter();
   qInstallMessageHandler(LogHandler::messageQTHandler);
   QTimer::singleShot(0, &a, [crashreporter, argc, argv]() {
-    crashreporter->start(argc, argv);
+    if (!crashreporter->start(argc, argv)) {
+      qApp->quit();
+    }
   });
   return a.exec();
 }

--- a/src/crashreporter/crashui/main.qml
+++ b/src/crashreporter/crashui/main.qml
@@ -31,8 +31,7 @@ Window {
     maximumWidth: fullscreenRequired() ? Screen.width : VPNTheme.theme.desktopAppWidth;
     maximumHeight: fullscreenRequired() ? Screen.height : VPNTheme.theme.desktopAppHeight;
 
-    //% "Mozilla Crash Reporter"
-    title: qsTrId("vpn.crashreporter.mainTitle")
+    title: VPNl18n.CrashreporterMainTitle
     color: "#F9F9FA"
 
     Rectangle {

--- a/src/crashreporter/platforms/windows/wincrashreporter.cpp
+++ b/src/crashreporter/platforms/windows/wincrashreporter.cpp
@@ -46,17 +46,20 @@ bool WinCrashReporter::start(int argc, char* argv[]) {
   for (auto file : dumpFiles) {
     absDumpPaths << dumpRoot.absoluteFilePath(file);
   }
-  if (!absDumpPaths.empty()) {
-    connect(this, &CrashReporter::startUpload, this,
-            [this, absDumpPaths]() { m_uploader->startUploads(absDumpPaths); });
-    connect(this, &CrashReporter::cleanup, this,
-            [this, absDumpPaths]() { cleanupDumps(absDumpPaths); });
-    connect(m_uploader.get(), &CrashUploader::uploadsComplete, this,
-            [this, absDumpPaths]() { cleanupDumps(absDumpPaths); });
-    if (shouldPromptUser()) {
-      if (!promptUser()) {
-        return false;
-      }
+  if (absDumpPaths.empty()) {
+    logger.info() << "No dump files found.";
+    return false;
+  }
+
+  connect(this, &CrashReporter::startUpload, this,
+          [this, absDumpPaths]() { m_uploader->startUploads(absDumpPaths); });
+  connect(this, &CrashReporter::cleanup, this,
+          [this, absDumpPaths]() { cleanupDumps(absDumpPaths); });
+  connect(m_uploader.get(), &CrashUploader::uploadsComplete, this,
+          [this, absDumpPaths]() { cleanupDumps(absDumpPaths); });
+  if (shouldPromptUser()) {
+    if (!promptUser()) {
+      return false;
     }
   }
   return true;

--- a/src/crashreporter/platforms/windows/windowscrashclient.cpp
+++ b/src/crashreporter/platforms/windows/windowscrashclient.cpp
@@ -18,7 +18,7 @@ namespace {
 Logger logger("CrashClient", "WindowsCrashServerClient");
 }
 
-constexpr auto ARG = L"--crashreporter";
+constexpr auto ARG = L"crashreporter";
 
 DWORD RecoveryCallback(PVOID contextParam) {
   BOOL cancelled;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,41 +4,13 @@
 
 #include "commandlineparser.h"
 #include "leakdetector.h"
-#include <iostream>
-#include <crashreporter/crashreporterapp.h>
-#include <crashreporter/crashclient.h>
-
-#if defined MVPN_WINDOWS
-#  include <windows.h>
-#endif
 
 int main(int argc, char* argv[]) {
 #ifdef MVPN_DEBUG
   LeakDetector leakDetector;
   Q_UNUSED(leakDetector);
-#  ifdef MVPN_WINDOWS
-  // Allocate a console to view log output in debug mode on windows
-  if (AllocConsole()) {
-    FILE* unusedFile;
-    freopen_s(&unusedFile, "CONOUT$", "w", stdout);
-    freopen_s(&unusedFile, "CONOUT$", "w", stderr);
-    std::cout.clear();
-    std::clog.clear();
-    std::cerr.clear();
-  }
-#  endif
+#endif
 
-#endif
-#ifdef MVPN_WINDOWS
-  if (argc > 1) {
-    for (int i = 1; i < argc; i++) {
-      if (!strcmp("--crashreporter", argv[i])) {
-        return CrashReporterApp::main(argc, argv);
-      }
-    }
-  }
-  CrashClient::instance().start(argc, argv);
-#endif
   CommandLineParser clp;
   return clp.parse(argc, argv);
 }

--- a/src/src.pro
+++ b/src/src.pro
@@ -897,6 +897,7 @@ else:win* {
     RC_ICONS = ui/resources/logo.ico
 
     SOURCES += \
+        commands/commandcrashreporter.cpp \
         daemon/daemon.cpp \
         daemon/daemonlocalserver.cpp \
         daemon/daemonlocalserverconnection.cpp \
@@ -926,6 +927,7 @@ else:win* {
         wgquickprocess.cpp
 
     HEADERS += \
+        commands/commandcrashreporter.h \
         daemon/interfaceconfig.h \
         daemon/daemon.h \
         daemon/daemonlocalserver.h \


### PR DESCRIPTION
This patch contains 3 things:
- fixes a string conflict between mainTitle via VPNl18n and qsTrId
- move the crashreporter command as a `Command` - to be consistent with the rest of the code.
- if there is nothing to send, quick exit.