### PR TITLE
DNS ping fallback when ICMP sockets are unavailable

### DIFF
--- a/src/connectionhealth.cpp
+++ b/src/connectionhealth.cpp
@@ -41,7 +41,7 @@ namespace {
 Logger logger(LOG_NETWORKING, "ConnectionHealth");
 }
 
-ConnectionHealth::ConnectionHealth() : m_dnsPingSender(QString()) {
+ConnectionHealth::ConnectionHealth() : m_dnsPingSender(QHostAddress()) {
   MVPN_COUNT_CTOR(ConnectionHealth);
 
   m_noSignalTimer.setSingleShot(true);
@@ -65,7 +65,8 @@ ConnectionHealth::ConnectionHealth() : m_dnsPingSender(QString()) {
   connect(&m_dnsPingTimer, &QTimer::timeout, this, [this]() {
     m_dnsPingSequence++;
     m_dnsPingTimestamp = QDateTime::currentMSecsSinceEpoch();
-    m_dnsPingSender.sendPing(PING_WELL_KNOWN_ANYCAST_DNS, m_dnsPingSequence);
+    m_dnsPingSender.sendPing(QHostAddress(PING_WELL_KNOWN_ANYCAST_DNS),
+                             m_dnsPingSequence);
   });
 
   m_dnsPingInitialized = false;
@@ -117,7 +118,8 @@ void ConnectionHealth::startIdle() {
 
   // Send an initial ping right away.
   m_dnsPingTimestamp = QDateTime::currentMSecsSinceEpoch();
-  m_dnsPingSender.sendPing(PING_WELL_KNOWN_ANYCAST_DNS, m_dnsPingSequence);
+  m_dnsPingSender.sendPing(QHostAddress(PING_WELL_KNOWN_ANYCAST_DNS),
+                           m_dnsPingSequence);
 }
 
 void ConnectionHealth::setStability(ConnectionStability stability) {

--- a/src/dnspingsender.cpp
+++ b/src/dnspingsender.cpp
@@ -47,14 +47,14 @@ namespace {
 Logger logger(LOG_NETWORKING, "DnsPingSender");
 }
 
-DnsPingSender::DnsPingSender(const QString& source, QObject* parent)
+DnsPingSender::DnsPingSender(const QHostAddress& source, QObject* parent)
     : PingSender(parent) {
   MVPN_COUNT_CTOR(DnsPingSender);
 
-  if (source.isEmpty()) {
+  if (source.isNull()) {
     m_socket.bind();
   } else {
-    m_socket.bind(QHostAddress(source));
+    m_socket.bind(source);
   }
 
   connect(&m_socket, &QUdpSocket::readyRead, this, &DnsPingSender::readData);
@@ -62,7 +62,7 @@ DnsPingSender::DnsPingSender(const QString& source, QObject* parent)
 
 DnsPingSender::~DnsPingSender() { MVPN_COUNT_DTOR(DnsPingSender); }
 
-void DnsPingSender::sendPing(const QString& dest, quint16 sequence) {
+void DnsPingSender::sendPing(const QHostAddress& dest, quint16 sequence) {
   QByteArray packet;
 
   // Assemble a DNS query header.
@@ -81,7 +81,7 @@ void DnsPingSender::sendPing(const QString& dest, quint16 sequence) {
   packet.append(query, sizeof(query));
 
   // Send the datagram.
-  m_socket.writeDatagram(packet, QHostAddress(dest), DNS_PORT);
+  m_socket.writeDatagram(packet, dest, DNS_PORT);
 }
 
 void DnsPingSender::readData() {

--- a/src/dnspingsender.h
+++ b/src/dnspingsender.h
@@ -14,10 +14,10 @@ class DnsPingSender final : public PingSender {
   Q_DISABLE_COPY_MOVE(DnsPingSender)
 
  public:
-  DnsPingSender(const QString& source, QObject* parent = nullptr);
+  DnsPingSender(const QHostAddress& source, QObject* parent = nullptr);
   ~DnsPingSender();
 
-  void sendPing(const QString& dest, quint16 sequence) override;
+  void sendPing(const QHostAddress& dest, quint16 sequence) override;
 
  private:
   void readData();

--- a/src/pinghelper.cpp
+++ b/src/pinghelper.cpp
@@ -3,10 +3,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "pinghelper.h"
+#include "dnspingsender.h"
 #include "leakdetector.h"
 #include "logger.h"
 #include "pingsender.h"
-#include "platforms/dummy/dummypingsender.h"
 #include "timersingleshot.h"
 
 #if defined(MVPN_LINUX) || defined(MVPN_ANDROID)
@@ -16,6 +16,7 @@
 #elif defined(MVPN_WINDOWS)
 #  include "platforms/windows/windowspingsender.h"
 #elif defined(MVPN_DUMMY) || defined(UNIT_TEST)
+#  include "platforms/dummy/dummypingsender.h"
 #else
 #  error "Unsupported platform"
 #endif
@@ -32,8 +33,7 @@ constexpr int PING_STATS_WINDOW = 32;
 
 namespace {
 Logger logger(LOG_NETWORKING, "PingHelper");
-bool s_has_critical_ping_error = false;
-}  // namespace
+}
 
 PingHelper::PingHelper() {
   MVPN_COUNT_CTOR(PingHelper);
@@ -53,23 +53,28 @@ void PingHelper::start(const QString& serverIpv4Gateway,
   m_gateway = serverIpv4Gateway;
   m_source = deviceIpv4Address.section('/', 0, 0);
 
-  if (s_has_critical_ping_error) {
-    m_pingSender = new DummyPingSender(m_source, this);
-  } else {
-    m_pingSender =
+  m_pingSender =
 #if defined(MVPN_LINUX) || defined(MVPN_ANDROID)
-        new LinuxPingSender(m_source, this);
+      new LinuxPingSender(m_source, this);
 #elif defined(MVPN_MACOS) || defined(MVPN_IOS)
-        new MacOSPingSender(m_source, this);
+      new MacOSPingSender(m_source, this);
 #elif defined(MVPN_WINDOWS)
-        new WindowsPingSender(m_source, this);
+      new WindowsPingSender(m_source, this);
 #else
-        new DummyPingSender(m_source, this);
+      new DummyPingSender(m_source, this);
 #endif
+
+  // Some platforms require root access to send and receive ICMP pings. If
+  // we happen to be on one of these unlucky devices, create a DnsPingSender
+  // instead.
+  if (!m_pingSender->isValid()) {
+    delete m_pingSender;
+    m_pingSender = new DnsPingSender(m_source, this);
   }
+
   connect(m_pingSender, &PingSender::recvPing, this, &PingHelper::pingReceived);
   connect(m_pingSender, &PingSender::criticalPingError, this,
-          &PingHelper::handlePingError);
+          []() { logger.info() << "Encountered Unrecoverable ping error"; });
 
   // Reset the ping statistics
   m_sequence = 0;
@@ -200,28 +205,4 @@ double PingHelper::loss() const {
     return 0.0;
   }
   return (double)(sendCount - recvCount) / sendCount;
-}
-
-void PingHelper::handlePingError() {
-  if (s_has_critical_ping_error) {
-    return;
-  }
-  logger.info() << "Encountered Unrecoverable ping error, switching to DUMMY "
-                   "Ping for next 10 Minutes";
-  // When the ping helper is unable to work, set the error flag
-  // and restart the pinghelper, to replace the impl with a dummy impl
-  // which we will use for the rest of the session
-  emit pingSentAndReceived(1);  // Fake a ping response with 1ms;
-  s_has_critical_ping_error = true;
-  stop();
-  start(m_gateway, m_source);
-
-  TimerSingleShot::create(this, 600000, [&] {  // 10 Minutes
-    logger.debug() << "Removing ping error state";
-    s_has_critical_ping_error = false;
-    if (m_pingSender) {
-      stop();
-      start(m_gateway, m_source);
-    }
-  });
 }

--- a/src/pinghelper.h
+++ b/src/pinghelper.h
@@ -5,6 +5,7 @@
 #ifndef PINGHELPER_H
 #define PINGHELPER_H
 
+#include <QHostAddress>
 #include <QList>
 #include <QObject>
 #include <QTimer>
@@ -39,8 +40,8 @@ class PingHelper final : public QObject {
   void pingReceived(quint16 sequence);
 
  private:
-  QString m_gateway;
-  QString m_source;
+  QHostAddress m_gateway;
+  QHostAddress m_source;
   quint16 m_sequence = 0;
 
   class PingSendData {

--- a/src/pinghelper.h
+++ b/src/pinghelper.h
@@ -37,7 +37,6 @@ class PingHelper final : public QObject {
   void nextPing();
 
   void pingReceived(quint16 sequence);
-  void handlePingError();
 
  private:
   QString m_gateway;

--- a/src/pingsender.cpp
+++ b/src/pingsender.cpp
@@ -5,11 +5,6 @@
 #include "pingsender.h"
 #include "logger.h"
 
-// QProcess is not supported on iOS and Wasm
-#if !defined(MVPN_IOS) && !defined(MVPN_WASM)
-#  include <QProcess>
-#endif
-
 namespace {
 Logger logger(LOG_NETWORKING, "PingSender");
 }
@@ -50,68 +45,3 @@ quint16 PingSender::inetChecksum(const void* data, size_t len) {
   answer = ~sum;                      /* truncate to 16 bits */
   return (answer);
 }
-
-// QProcess is not supported on iOS
-#if !defined(MVPN_IOS) && !defined(MVPN_WASM)
-// Send a ping by launching the "ping" command.
-void PingSender::genericSendPing(const QStringList& args, qint16 sequence) {
-  QProcess* process = new QProcess(this);
-  process->setProcessChannelMode(QProcess::MergedChannels);
-  process->start("ping", args, QIODevice::ReadOnly);
-
-  connect(process, qOverload<int, QProcess::ExitStatus>(&QProcess::finished),
-          this, [this, sequence](int exitCode, QProcess::ExitStatus) {
-            if (exitCode == 0) {
-              emit recvPing(sequence);
-              return;
-            }
-            // exitCode == 1 -> ok but no ping response
-            if (exitCode == 2) {
-              logger.info() << "QProcess-Ping encountered an error!";
-              emit criticalPingError();
-            }
-          });
-  connect(process, qOverload<int, QProcess::ExitStatus>(&QProcess::finished),
-          process, &QObject::deleteLater);
-  connect(
-      process, &QProcess::errorOccurred, this,
-      [this](QProcess::ProcessError error) {
-        switch (error) {
-          case QProcess::ProcessError::Crashed:
-            logger.error() << "Failed to use native Ping: Crashed";
-            break;
-          case QProcess::ProcessError::FailedToStart:
-            logger.error() << "Failed to use native Ping: FailedToStart";
-            break;
-          case QProcess::ProcessError::ReadError:
-            logger.error() << "Failed to use native Ping: ReadError";
-            break;
-          case QProcess::ProcessError::Timedout:
-            logger.error() << "Failed to use native Ping: Timedout";
-            break;
-          case QProcess::ProcessError::UnknownError:
-            logger.error() << "Failed to use native Ping: UnknownError";
-            break;
-          case QProcess::ProcessError::WriteError:
-            logger.error() << "Failed to use native Ping: WriteError";
-            break;
-        };
-        // Using generic ping is a fallback anyway, if we fail here
-        // we won't be able to infer any info about connection health -
-        // so lets just return a fake ping, so the user can use the app
-        // but without the "no connection" / "no confirm"
-        logger.info() << "Pushing fake ping response";
-        emit criticalPingError();
-      },
-      Qt::ConnectionType::QueuedConnection);
-  connect(process, &QProcess::errorOccurred, process, &QObject::deleteLater);
-
-  // Ensure any lingering pings are cleaned up when the PingSender is destroyed
-  connect(this, &QObject::destroyed, process, [process] {
-    process->terminate();
-    if (!process->waitForFinished(100)) {
-      process->kill();
-    }
-  });
-}
-#endif

--- a/src/pingsender.h
+++ b/src/pingsender.h
@@ -21,13 +21,6 @@ class PingSender : public QObject {
 
   static quint16 inetChecksum(const void* data, size_t length);
 
- protected:
-  // QProcess is not supported on iOS. Because of this we cannot use the `ping`
-  // app as fallback on this platform.
-#ifndef MVPN_IOS
-  void genericSendPing(const QStringList& args, qint16 sequence);
-#endif
-
  signals:
   void recvPing(quint16 sequence);
   void criticalPingError();

--- a/src/pingsender.h
+++ b/src/pingsender.h
@@ -15,6 +15,8 @@ class PingSender : public QObject {
  public:
   PingSender(QObject* parent = nullptr) : QObject(parent) {}
 
+  virtual bool isValid() { return true; };
+
   virtual void sendPing(const QString& destination, quint16 sequence) = 0;
 
   static quint16 inetChecksum(const void* data, size_t length);

--- a/src/pingsender.h
+++ b/src/pingsender.h
@@ -6,6 +6,7 @@
 #define PINGSENDER_H
 
 #include <QElapsedTimer>
+#include <QHostAddress>
 #include <QObject>
 
 class PingSender : public QObject {
@@ -17,7 +18,7 @@ class PingSender : public QObject {
 
   virtual bool isValid() { return true; };
 
-  virtual void sendPing(const QString& destination, quint16 sequence) = 0;
+  virtual void sendPing(const QHostAddress& destination, quint16 sequence) = 0;
 
   static quint16 inetChecksum(const void* data, size_t length);
 

--- a/src/pingsenderfactory.cpp
+++ b/src/pingsenderfactory.cpp
@@ -1,0 +1,30 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "pingsenderfactory.h"
+
+#if defined(MVPN_LINUX) || defined(MVPN_ANDROID)
+#  include "platforms/linux/linuxpingsender.h"
+#elif defined(MVPN_MACOS) || defined(MVPN_IOS)
+#  include "platforms/macos/macospingsender.h"
+#elif defined(MVPN_WINDOWS)
+#  include "platforms/windows/windowspingsender.h"
+#elif defined(MVPN_DUMMY) || defined(UNIT_TEST)
+#  include "platforms/dummy/dummypingsender.h"
+#else
+#  error "Unsupported platform"
+#endif
+
+PingSender* PingSenderFactory::create(const QHostAddress& source,
+                                      QObject* parent) {
+#if defined(MVPN_LINUX) || defined(MVPN_ANDROID)
+  return new LinuxPingSender(source, parent);
+#elif defined(MVPN_MACOS) || defined(MVPN_IOS)
+  return new MacOSPingSender(source, parent);
+#elif defined(MVPN_WINDOWS)
+  return new WindowsPingSender(source, parent);
+#else
+  return new DummyPingSender(source, parent);
+#endif
+}

--- a/src/pingsenderfactory.h
+++ b/src/pingsenderfactory.h
@@ -1,0 +1,18 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef PINGSENDERFACTORY_H
+#define PINGSENDERFACTORY_H
+
+class PingSender;
+class QHostAddress;
+class QObject;
+
+class PingSenderFactory final {
+ public:
+  PingSenderFactory() = delete;
+  static PingSender* create(const QHostAddress& source, QObject* parent);
+};
+
+#endif  // PINGSENDERFACTORY_H

--- a/src/platforms/dummy/dummypingsender.cpp
+++ b/src/platforms/dummy/dummypingsender.cpp
@@ -10,7 +10,7 @@ namespace {
 Logger logger(LOG_NETWORKING, "DummyPingSender");
 }
 
-DummyPingSender::DummyPingSender(const QString& source, QObject* parent)
+DummyPingSender::DummyPingSender(const QHostAddress& source, QObject* parent)
     : PingSender(parent) {
   MVPN_COUNT_CTOR(DummyPingSender);
   Q_UNUSED(source);
@@ -18,7 +18,7 @@ DummyPingSender::DummyPingSender(const QString& source, QObject* parent)
 
 DummyPingSender::~DummyPingSender() { MVPN_COUNT_DTOR(DummyPingSender); }
 
-void DummyPingSender::sendPing(const QString& dest, quint16 sequence) {
-  logger.debug() << "Dummy ping to:" << dest;
+void DummyPingSender::sendPing(const QHostAddress& dest, quint16 sequence) {
+  logger.debug() << "Dummy ping to:" << dest.toString();
   emit recvPing(sequence);
 }

--- a/src/platforms/dummy/dummypingsender.h
+++ b/src/platforms/dummy/dummypingsender.h
@@ -12,10 +12,10 @@ class DummyPingSender final : public PingSender {
   Q_DISABLE_COPY_MOVE(DummyPingSender)
 
  public:
-  DummyPingSender(const QString& source, QObject* parent = nullptr);
+  DummyPingSender(const QHostAddress& source, QObject* parent = nullptr);
   ~DummyPingSender();
 
-  void sendPing(const QString& dest, quint16 sequence) override;
+  void sendPing(const QHostAddress& dest, quint16 sequence) override;
 };
 
 #endif  // DUMMYPINGSENDER_H

--- a/src/platforms/linux/linuxpingsender.cpp
+++ b/src/platforms/linux/linuxpingsender.cpp
@@ -7,6 +7,7 @@
 #include "logger.h"
 
 #include <QSocketNotifier>
+#include <QtEndian>
 
 #include <arpa/inet.h>
 #include <errno.h>
@@ -61,10 +62,10 @@ int LinuxPingSender::createSocket() {
   return m_socket;
 }
 
-LinuxPingSender::LinuxPingSender(const QString& source, QObject* parent)
-    : PingSender(parent), m_source(source) {
+LinuxPingSender::LinuxPingSender(const QHostAddress& source, QObject* parent)
+    : PingSender(parent) {
   MVPN_COUNT_CTOR(LinuxPingSender);
-  logger.debug() << "LinuxPingSender(" + source + ") created";
+  logger.debug() << "LinuxPingSender(" + source.toString() + ") created";
 
   m_socket = createSocket();
   if (m_socket < 0) {
@@ -72,13 +73,12 @@ LinuxPingSender::LinuxPingSender(const QString& source, QObject* parent)
     return;
   }
 
+  quint32 ipv4addr = source.toIPv4Address();
   struct sockaddr_in addr;
   memset(&addr, 0, sizeof addr);
   addr.sin_family = AF_INET;
-  if (inet_aton(source.toLocal8Bit().constData(), &addr.sin_addr) == 0) {
-    logger.error() << "source" << source << "error:" << strerror(errno);
-    return;
-  }
+  addr.sin_addr.s_addr = qToBigEndian<quint32>(ipv4addr);
+
   if (bind(m_socket, (struct sockaddr*)&addr, sizeof(addr)) != 0) {
     close(m_socket);
     m_socket = -1;
@@ -103,13 +103,12 @@ LinuxPingSender::~LinuxPingSender() {
   }
 }
 
-void LinuxPingSender::sendPing(const QString& dest, quint16 sequence) {
+void LinuxPingSender::sendPing(const QHostAddress& dest, quint16 sequence) {
+  quint32 ipv4dest = dest.toIPv4Address();
   struct sockaddr_in addr;
   memset(&addr, 0, sizeof(addr));
   addr.sin_family = AF_INET;
-  if (inet_aton(dest.toLocal8Bit().constData(), &addr.sin_addr) == 0) {
-    return;
-  }
+  addr.sin_addr.s_addr = qToBigEndian<quint32>(ipv4dest);
 
   struct icmphdr packet;
   memset(&packet, 0, sizeof(packet));

--- a/src/platforms/linux/linuxpingsender.cpp
+++ b/src/platforms/linux/linuxpingsender.cpp
@@ -104,21 +104,6 @@ LinuxPingSender::~LinuxPingSender() {
 }
 
 void LinuxPingSender::sendPing(const QString& dest, quint16 sequence) {
-  // QProcess is not supported on iOS. Because of this we cannot use the `ping`
-  // app as fallback on this platform.
-#ifndef MVPN_IOS
-  // Use the generic ping sender if we failed to open an ICMP socket.
-  if (m_socket < 0) {
-    QStringList args;
-    args << "-c"
-         << "1";
-    args << "-I" << m_source;
-    args << dest;
-    genericSendPing(args, sequence);
-    return;
-  }
-#endif
-
   struct sockaddr_in addr;
   memset(&addr, 0, sizeof(addr));
   addr.sin_family = AF_INET;

--- a/src/platforms/linux/linuxpingsender.h
+++ b/src/platforms/linux/linuxpingsender.h
@@ -19,6 +19,8 @@ class LinuxPingSender final : public PingSender {
   LinuxPingSender(const QString& source, QObject* parent = nullptr);
   ~LinuxPingSender();
 
+  bool isValid() override { return (m_socket >= 0); };
+
   void sendPing(const QString& dest, quint16 sequence) override;
 
  private:
@@ -31,7 +33,7 @@ class LinuxPingSender final : public PingSender {
  private:
   QSocketNotifier* m_notifier = nullptr;
   QString m_source;
-  int m_socket = 0;
+  int m_socket = -1;
   quint16 m_ident = 0;
 };
 

--- a/src/platforms/linux/linuxpingsender.h
+++ b/src/platforms/linux/linuxpingsender.h
@@ -16,12 +16,12 @@ class LinuxPingSender final : public PingSender {
   Q_DISABLE_COPY_MOVE(LinuxPingSender)
 
  public:
-  LinuxPingSender(const QString& source, QObject* parent = nullptr);
+  LinuxPingSender(const QHostAddress& source, QObject* parent = nullptr);
   ~LinuxPingSender();
 
   bool isValid() override { return (m_socket >= 0); };
 
-  void sendPing(const QString& dest, quint16 sequence) override;
+  void sendPing(const QHostAddress& dest, quint16 sequence) override;
 
  private:
   int createSocket();
@@ -32,7 +32,6 @@ class LinuxPingSender final : public PingSender {
 
  private:
   QSocketNotifier* m_notifier = nullptr;
-  QString m_source;
   int m_socket = -1;
   quint16 m_ident = 0;
 };

--- a/src/platforms/macos/macospingsender.cpp
+++ b/src/platforms/macos/macospingsender.cpp
@@ -70,7 +70,7 @@ void MacOSPingSender::sendPing(const QHostAddress& dest, quint16 sequence) {
   bzero(&addr, sizeof(addr));
   addr.sin_family = AF_INET;
   addr.sin_len = sizeof(addr);
-  addr.sin_addr.s_addr = qToBigEndian<quint32>(dest);
+  addr.sin_addr.s_addr = qToBigEndian<quint32>(ipv4dest);
 
   struct icmp packet;
   bzero(&packet, sizeof packet);

--- a/src/platforms/macos/macospingsender.h
+++ b/src/platforms/macos/macospingsender.h
@@ -14,10 +14,10 @@ class MacOSPingSender final : public PingSender {
   Q_DISABLE_COPY_MOVE(MacOSPingSender)
 
  public:
-  MacOSPingSender(const QString& source, QObject* parent = nullptr);
+  MacOSPingSender(const QHostAddress& source, QObject* parent = nullptr);
   ~MacOSPingSender();
 
-  void sendPing(const QString& dest, quint16 sequence) override;
+  void sendPing(const QHostAddress& dest, quint16 sequence) override;
 
  private slots:
   void socketReady();

--- a/src/platforms/windows/windowspingsender.cpp
+++ b/src/platforms/windows/windowspingsender.cpp
@@ -11,7 +11,8 @@ namespace {
 Logger logger({LOG_WINDOWS, LOG_NETWORKING}, "WindowsPingSender");
 }
 
-WindowsPingSender::WindowsPingSender(const QString& source, QObject* parent)
+WindowsPingSender::WindowsPingSender(const QHostAddress& source,
+                                     QObject* parent)
     : PingSender(parent) {
   MVPN_COUNT_CTOR(WindowsPingSender);
   m_source = source;
@@ -38,15 +39,7 @@ WindowsPingSender::~WindowsPingSender() {
   }
 }
 
-void WindowsPingSender::sendPing(const QString& dest, quint16 sequence) {
-  IN_ADDR dst{};
-  IN_ADDR src{};
-  if (InetPtonA(AF_INET, dest.toLocal8Bit(), &dst) != 1) {
-    return;
-  }
-  if (InetPtonA(AF_INET, m_source.toLocal8Bit(), &src) != 1) {
-    return;
-  }
+void WindowsPingSender::sendPing(const QHostAddress& dest, quint16 sequence) {
   if (m_handle == INVALID_HANDLE_VALUE) {
     return;
   }
@@ -54,15 +47,18 @@ void WindowsPingSender::sendPing(const QString& dest, quint16 sequence) {
     return;
   }
 
-  IcmpSendEcho2Ex(m_handle, m_event, nullptr, nullptr, src.S_un.S_addr,
-                  dst.S_un.S_addr, &sequence, sizeof(sequence), nullptr,
-                  m_buffer, sizeof(m_buffer), 10000);
+  quint32 v4src = m_source.toIPv4Address();
+  quint32 v4dst = dest.toIPv4Address();
+  IcmpSendEcho2Ex(m_handle, m_event, nullptr, nullptr,
+                  qToBigEndian<quint32>(v4src), qToBigEndian<quint32>(v4dst),
+                  &sequence, sizeof(sequence), nullptr, m_buffer,
+                  sizeof(m_buffer), 10000);
 
   DWORD status = GetLastError();
   if (status != ERROR_IO_PENDING) {
     QString errmsg = WindowsCommons::getErrorMessage();
     logger.error() << "failed to start Code: " << status
-                   << " Message: " << errmsg << " dest:" << dest;
+                   << " Message: " << errmsg << " dest:" << dest.toString();
   }
 }
 

--- a/src/platforms/windows/windowspingsender.cpp
+++ b/src/platforms/windows/windowspingsender.cpp
@@ -7,6 +7,8 @@
 #include "leakdetector.h"
 #include "windowscommons.h"
 
+#include <QtEndian>
+
 namespace {
 Logger logger({LOG_WINDOWS, LOG_NETWORKING}, "WindowsPingSender");
 }

--- a/src/platforms/windows/windowspingsender.h
+++ b/src/platforms/windows/windowspingsender.h
@@ -38,7 +38,7 @@ class WindowsPingSender final : public PingSender {
   void pingEventReady();
 
  private:
-  QString m_source;
+  QHostAddress m_source;
   HANDLE m_handle = INVALID_HANDLE_VALUE;
   HANDLE m_event = INVALID_HANDLE_VALUE;
   QWinEventNotifier* m_notifier = nullptr;

--- a/src/platforms/windows/windowspingsender.h
+++ b/src/platforms/windows/windowspingsender.h
@@ -29,10 +29,10 @@ class WindowsPingSender final : public PingSender {
   Q_DISABLE_COPY_MOVE(WindowsPingSender)
 
  public:
-  WindowsPingSender(const QString& source, QObject* parent = nullptr);
+  WindowsPingSender(const QHostAddress& source, QObject* parent = nullptr);
   ~WindowsPingSender();
 
-  void sendPing(const QString& destination, quint16 sequence) override;
+  void sendPing(const QHostAddress& destination, quint16 sequence) override;
 
  private slots:
   void pingEventReady();

--- a/src/src.pro
+++ b/src/src.pro
@@ -151,6 +151,7 @@ SOURCES += \
         notificationhandler.cpp \
         pinghelper.cpp \
         pingsender.cpp \
+        pingsenderfactory.cpp \
         platforms/dummy/dummyapplistprovider.cpp \
         platforms/dummy/dummyiaphandler.cpp \
         platforms/dummy/dummynetworkwatcher.cpp \
@@ -289,6 +290,7 @@ HEADERS += \
         notificationhandler.h \
         pinghelper.h \
         pingsender.h \
+        pingsenderfactory.h \
         platforms/dummy/dummyapplistprovider.h \
         platforms/dummy/dummyiaphandler.h \
         platforms/dummy/dummynetworkwatcher.h \

--- a/tests/unit/unit.pro
+++ b/tests/unit/unit.pro
@@ -180,6 +180,7 @@ SOURCES += \
     ../../src/networkmanager.cpp \
     ../../src/networkwatcher.cpp \
     ../../src/pinghelper.cpp \
+    ../../src/pingsenderfactory.cpp \
     ../../src/platforms/android/androiddatamigration.cpp \
     ../../src/platforms/android/androidsharedprefs.cpp \
     ../../src/platforms/dummy/dummynetworkwatcher.cpp \

--- a/tests/unit/unit.pro
+++ b/tests/unit/unit.pro
@@ -50,6 +50,7 @@ HEADERS += \
     ../../src/constants.h \
     ../../src/controller.h \
     ../../src/curve25519.h \
+    ../../src/dnspingsender.h \
     ../../src/errorhandler.h \
     ../../src/featurelist.h \
     ../../src/inspector/inspectorhandler.h \
@@ -143,6 +144,7 @@ SOURCES += \
     ../../src/connectiondataholder.cpp \
     ../../src/constants.cpp \
     ../../src/curve25519.cpp \
+    ../../src/dnspingsender.cpp \
     ../../src/errorhandler.cpp \
     ../../src/featurelist.cpp \
     ../../src/hacl-star/Hacl_Chacha20.c \

--- a/tests/unit/unit.pro
+++ b/tests/unit/unit.pro
@@ -85,6 +85,7 @@ HEADERS += \
     ../../src/networkwatcherimpl.h \
     ../../src/pinghelper.h \
     ../../src/pingsender.h \
+    ../../src/pingsenderfactory.h \
     ../../src/platforms/android/androiddatamigration.h \
     ../../src/platforms/android/androidsharedprefs.h \
     ../../src/platforms/dummy/dummynetworkwatcher.h \


### PR DESCRIPTION
For some Linux and Android platforms, we have encountered cases where ICMP sockets are not available without root permissions, and this can lead to a scenario when we fall back to the dummy ping sender and lose the ability to test the network connectivity. We now have a better workaround in in the form of the `DnsPingSender` which uses DNS queries, and shouldn't require any elevated permissions.

To test this on Linux, we can deny ICMP socket creation with: `echo 0 0 > /proc/sys/net/ipv4/ping_group_range`
After this change, we can observe in the logs that the client still produces realistic ping measurements.