### PR TITLE
Remove qt5 from xcode cloud

### DIFF
--- a/ci_scripts/ci_post_clone.sh
+++ b/ci_scripts/ci_post_clone.sh
@@ -25,18 +25,20 @@ then
   export PATH=`pwd`/qt_static_macos/qt6/bin:$PATH
 else
   # generate qt_ios
-  git clone https://github.com/mozilla-mobile/qt_ios
-  cd qt_ios
-  cat qt6* > qt_static.tar.gz
-  tar xf qt_static.tar.gz
-  sudo mkdir /opt/6.2.3
-  sudo mv ios /opt/6.2.3
-  sudo mv macos /opt/6.2.3
-  echo `ls -la /opt`
-  echo `ls -la /opt/6.2.3`
-  cd ..
-  export QT_IOS_BIN=/opt/6.2.3/ios/bin
-  export PATH=/opt/6.2.3/ios/bin:/opt/6.2.3/macos/bin:$PATH
+  #git clone https://github.com/mozilla-mobile/qt_ios
+  #cd qt_ios
+  #cat qt6* > qt_static.tar.gz
+  #tar xf qt_static.tar.gz
+  #sudo mkdir /opt/6.2.3
+  #sudo mv ios /opt/6.2.3
+  #sudo mv macos /opt/6.2.3
+  #echo `ls -la /opt`
+  #echo `ls -la /opt/6.2.3`
+  #cd ..
+  pip3 install aqtinstall
+  aqt install-qt -O ./qt_ios mac ios 6.2.3 -m qtcharts qtwebsockets qt5compat
+  export QT_IOS_BIN=`pwd`/qt_ios/6.2.3/ios/bin
+  export PATH=`pwd`/qt_ios/6.2.3/ios/bin:`pwd`/qt_ios/6.2.3/macos/bin:$PATH
 fi
 
 

--- a/ci_scripts/ci_post_clone.sh
+++ b/ci_scripts/ci_post_clone.sh
@@ -12,6 +12,9 @@ cd /Volumes/workspace/repository
 git submodule init
 git submodule update
 
+# add necessary directories to path
+export PATH=/Users/local/.gem/ruby/2.6.0/bin:/Users/local/Library/Python/3.8/bin:$PATH
+
 if [ $CI_PRODUCT_PLATFORM == 'macOS' ]
 then
   # generate qt_static_macos
@@ -40,10 +43,6 @@ else
   export QT_IOS_BIN=`pwd`/qt_ios/6.2.3/ios/bin
   export PATH=`pwd`/qt_ios/6.2.3/ios/bin:`pwd`/qt_ios/6.2.3/macos/bin:$PATH
 fi
-
-
-# add necessary directories to path
-export PATH=/Users/local/.gem/ruby/2.6.0/bin:/Users/local/Library/Python/3.8/bin:$PATH
 
 # install xcodeproj which is needed by xcode_patcher.rb
 # use --user-install for permissions

--- a/ci_scripts/ci_post_clone.sh
+++ b/ci_scripts/ci_post_clone.sh
@@ -41,7 +41,7 @@ else
   pip3 install aqtinstall
   aqt install-qt -O /Volumes/workspace/repository/qt_ios mac desktop 6.2.3 -m qtcharts qtwebsockets qt5compat
   aqt install-qt -O /Volumes/workspace/repository/qt_ios mac ios 6.2.3 -m qtcharts qtwebsockets qt5compat
-  mv /Volumes/workspace/qt_ios/6.2.3/macos /Volumes/workspace/qt_ios/6.2.3/clang_64
+  mv /Volumes/workspace/repository/qt_ios/6.2.3/macos /Volumes/workspace/repository/qt_ios/6.2.3/clang_64
   export QT_IOS_BIN=`pwd`/qt_ios/6.2.3/ios/bin
   export PATH=`pwd`/qt_ios/6.2.3/ios/bin:`pwd`/qt_ios/6.2.3/macos/bin:`pwd`/qt_ios/6.2.3/clang_64/bin:$PATH
 fi

--- a/ci_scripts/ci_post_clone.sh
+++ b/ci_scripts/ci_post_clone.sh
@@ -71,6 +71,9 @@ GROUP_ID_IOS = group.org.mozilla.ios.Guardian
 APP_ID_IOS = org.mozilla.ios.FirefoxVPN
 NETEXT_ID_IOS = org.mozilla.ios.FirefoxVPN.network-extension
 EOF
+which qmake
+qmake -v
+$QT_IOS_BIN/qmake -v
 
 if [ $CI_PRODUCT_PLATFORM == 'macOS' ]
 then

--- a/ci_scripts/ci_post_clone.sh
+++ b/ci_scripts/ci_post_clone.sh
@@ -18,20 +18,20 @@ then
   auth_header="$(git config --local --get http.https://github.com/.extraheader)"
   git clone https://github.com/mozilla-mobile/qt_static_macos
   cd qt_static_macos
-  cat x* > qt_static.tar.gz
+  cat qt6* > qt_static.tar.gz
   tar xf qt_static.tar.gz
   cd ..
-  export QT_MACOS_BIN=`pwd`/qt_static_macos/qt/bin
-  export PATH=`pwd`/qt_static_macos/qt/bin:$PATH
+  export QT_MACOS_BIN=`pwd`/qt_static_macos/qt6/bin
+  export PATH=`pwd`/qt_static_macos/qt6/bin:$PATH
 else
   # generate qt_ios
   git clone https://github.com/mozilla-mobile/qt_ios
   cd qt_ios
-  cat qt5* > qt_static.tar.gz
+  cat qt6* > qt_static.tar.gz
   tar xf qt_static.tar.gz
   cd ..
-  export QT_IOS_BIN=`pwd`/qt_ios/ios/bin
-  export PATH=`pwd`/qt_ios/ios/bin:$PATH
+  export QT_IOS_BIN=`pwd`/qt_ios/6.2.3/ios/bin
+  export PATH=`pwd`/qt_ios/6.2.3/ios/bin:`pwd`/qt_ios/6.2.3/macos/bin:$PATH
 fi
 
 

--- a/ci_scripts/ci_post_clone.sh
+++ b/ci_scripts/ci_post_clone.sh
@@ -29,9 +29,12 @@ else
   cd qt_ios
   cat qt6* > qt_static.tar.gz
   tar xf qt_static.tar.gz
+  sudo mkdir /opt/6.2.3
+  sudo mv ios /opt/6.2.3
+  sudo mv macos /opt/6.2.3
   cd ..
-  export QT_IOS_BIN=`pwd`/qt_ios/6.2.3/ios/bin
-  export PATH=`pwd`/qt_ios/6.2.3/ios/bin:`pwd`/qt_ios/6.2.3/macos/bin:$PATH
+  export QT_IOS_BIN=/opt/6.2.3/ios/bin
+  export PATH=/opt/6.2.3/ios/bin:/opt/6.2.3/macos/bin:$PATH
 fi
 
 

--- a/ci_scripts/ci_post_clone.sh
+++ b/ci_scripts/ci_post_clone.sh
@@ -39,9 +39,9 @@ else
   #echo `ls -la /opt/6.2.3`
   #cd ..
   pip3 install aqtinstall
-  aqt install-qt -O ./qt_ios mac ios 6.2.3 -m qtcharts qtwebsockets qt5compat
+  aqt install-qt -O /Volumes/workspace/repository/qt_ios mac ios 6.2.3 -m qtcharts qtwebsockets qt5compat
   export QT_IOS_BIN=`pwd`/qt_ios/6.2.3/ios/bin
-  export PATH=`pwd`/qt_ios/6.2.3/ios/bin:`pwd`/qt_ios/6.2.3/macos/bin:$PATH
+  export PATH=`pwd`/qt_ios/6.2.3/ios/bin:`pwd`/qt_ios/6.2.3/macos/bin:`pwd`/qt_ios/6.2.3/clang_64/bin:$PATH
 fi
 
 # install xcodeproj which is needed by xcode_patcher.rb

--- a/ci_scripts/ci_post_clone.sh
+++ b/ci_scripts/ci_post_clone.sh
@@ -39,7 +39,9 @@ else
   #echo `ls -la /opt/6.2.3`
   #cd ..
   pip3 install aqtinstall
-  aqt install-qt -O /Volumes/workspace/repository/qt_ios mac ios clang_64 6.2.3 -m qtcharts qtwebsockets qt5compat
+  aqt install-qt -O /Volumes/workspace/repository/qt_ios mac desktop 6.2.3 -m qtcharts qtwebsockets qt5compat
+  aqt install-qt -O /Volumes/workspace/repository/qt_ios mac ios 6.2.3 -m qtcharts qtwebsockets qt5compat
+  mv /Volumes/workspace/qt_ios/6.2.3/macos /Volumes/workspace/qt_ios/6.2.3/clang_64
   export QT_IOS_BIN=`pwd`/qt_ios/6.2.3/ios/bin
   export PATH=`pwd`/qt_ios/6.2.3/ios/bin:`pwd`/qt_ios/6.2.3/macos/bin:`pwd`/qt_ios/6.2.3/clang_64/bin:$PATH
 fi

--- a/ci_scripts/ci_post_clone.sh
+++ b/ci_scripts/ci_post_clone.sh
@@ -39,7 +39,7 @@ else
   #echo `ls -la /opt/6.2.3`
   #cd ..
   pip3 install aqtinstall
-  aqt install-qt -O /Volumes/workspace/repository/qt_ios mac ios 6.2.3 -m qtcharts qtwebsockets qt5compat
+  aqt install-qt -O /Volumes/workspace/repository/qt_ios mac ios clang_64 6.2.3 -m qtcharts qtwebsockets qt5compat
   export QT_IOS_BIN=`pwd`/qt_ios/6.2.3/ios/bin
   export PATH=`pwd`/qt_ios/6.2.3/ios/bin:`pwd`/qt_ios/6.2.3/macos/bin:`pwd`/qt_ios/6.2.3/clang_64/bin:$PATH
 fi

--- a/ci_scripts/ci_post_clone.sh
+++ b/ci_scripts/ci_post_clone.sh
@@ -27,17 +27,6 @@ then
   export QT_MACOS_BIN=`pwd`/qt_static_macos/qt6/bin
   export PATH=`pwd`/qt_static_macos/qt6/bin:$PATH
 else
-  # generate qt_ios
-  #git clone https://github.com/mozilla-mobile/qt_ios
-  #cd qt_ios
-  #cat qt6* > qt_static.tar.gz
-  #tar xf qt_static.tar.gz
-  #sudo mkdir /opt/6.2.3
-  #sudo mv ios /opt/6.2.3
-  #sudo mv macos /opt/6.2.3
-  #echo `ls -la /opt`
-  #echo `ls -la /opt/6.2.3`
-  #cd ..
   pip3 install aqtinstall
   aqt install-qt -O /Volumes/workspace/repository/qt_ios mac desktop 6.2.3 -m qtcharts qtwebsockets qt5compat
   aqt install-qt -O /Volumes/workspace/repository/qt_ios mac ios 6.2.3 -m qtcharts qtwebsockets qt5compat

--- a/ci_scripts/ci_post_clone.sh
+++ b/ci_scripts/ci_post_clone.sh
@@ -32,6 +32,8 @@ else
   sudo mkdir /opt/6.2.3
   sudo mv ios /opt/6.2.3
   sudo mv macos /opt/6.2.3
+  echo `ls -la /opt`
+  echo `ls -la /opt/6.2.3`
   cd ..
   export QT_IOS_BIN=/opt/6.2.3/ios/bin
   export PATH=/opt/6.2.3/ios/bin:/opt/6.2.3/macos/bin:$PATH


### PR DESCRIPTION
This PR changes the Xcode Cloud workflow to use Qt6 for both iOS and MacOS.

For iOS we switch from using `qt_static_ios` to using `aqt` to install qt6. 
Note that since qt6 for iOS references the macos packages witch we have to install first. 
Also, since the installation on iOS using `aqt` references `clang_64` instead of `macos` we rename the macos installation.