### PR TITLE
Audit log messages to hide potentially sensitive information.

### DIFF
--- a/src/authenticationinapp/authenticationinapplistener.cpp
+++ b/src/authenticationinapp/authenticationinapplistener.cpp
@@ -149,7 +149,7 @@ void AuthenticationInAppListener::checkAccount(const QString& emailAddress) {
 
   connect(request, &NetworkRequest::requestCompleted, this,
           [this](const QByteArray& data) {
-            logger.debug() << "Account status checked" << data;
+            logger.debug() << "Account status checked";
 
             QJsonDocument json = QJsonDocument::fromJson(data);
             QJsonObject obj = json.object();
@@ -267,7 +267,7 @@ void AuthenticationInAppListener::signInInternal(const QString& unblockCode) {
 
   connect(request, &NetworkRequest::requestCompleted, this,
           [this](const QByteArray& data) {
-            logger.debug() << "Sign in completed" << data;
+            logger.debug() << "Sign in completed";
 
             QJsonDocument json = QJsonDocument::fromJson(data);
             QJsonObject obj = json.object();
@@ -295,7 +295,7 @@ void AuthenticationInAppListener::signUp() {
 
   connect(request, &NetworkRequest::requestCompleted, this,
           [this](const QByteArray& data) {
-            logger.debug() << "Sign up completed" << data;
+            logger.debug() << "Sign up completed";
 
             QJsonDocument json = QJsonDocument::fromJson(data);
             QJsonObject obj = json.object();
@@ -337,9 +337,8 @@ void AuthenticationInAppListener::sendUnblockCodeEmail() {
             processRequestFailure(error, data);
           });
 
-  connect(
-      request, &NetworkRequest::requestCompleted,
-      [](const QByteArray& data) { logger.debug() << "Code resent" << data; });
+  connect(request, &NetworkRequest::requestCompleted,
+          []() { logger.debug() << "Code resent"; });
 }
 
 void AuthenticationInAppListener::verifySessionEmailCode(const QString& code) {
@@ -359,11 +358,10 @@ void AuthenticationInAppListener::verifySessionEmailCode(const QString& code) {
             processRequestFailure(error, data);
           });
 
-  connect(request, &NetworkRequest::requestCompleted, this,
-          [this](const QByteArray& data) {
-            logger.debug() << "Verification completed" << data;
-            finalizeSignInOrUp();
-          });
+  connect(request, &NetworkRequest::requestCompleted, this, [this]() {
+    logger.debug() << "Verification completed";
+    finalizeSignInOrUp();
+  });
 }
 
 void AuthenticationInAppListener::resendVerificationSessionCodeEmail() {
@@ -379,9 +377,8 @@ void AuthenticationInAppListener::resendVerificationSessionCodeEmail() {
             processRequestFailure(error, data);
           });
 
-  connect(
-      request, &NetworkRequest::requestCompleted,
-      [](const QByteArray& data) { logger.debug() << "Code resent" << data; });
+  connect(request, &NetworkRequest::requestCompleted,
+          []() { logger.debug() << "Code resent"; });
 }
 
 void AuthenticationInAppListener::verifySessionTotpCode(const QString& code) {
@@ -402,7 +399,7 @@ void AuthenticationInAppListener::verifySessionTotpCode(const QString& code) {
 
   connect(request, &NetworkRequest::requestCompleted, this,
           [this](const QByteArray& data) {
-            logger.debug() << "Verification completed" << data;
+            logger.debug() << "Verification completed";
 
             QJsonDocument json = QJsonDocument::fromJson(data);
             if (json.isNull()) {
@@ -470,7 +467,7 @@ void AuthenticationInAppListener::createTotpCodes() {
 
   connect(request, &NetworkRequest::requestCompleted, this,
           [this](const QByteArray& data) {
-            logger.debug() << "Totp code creation completed" << data;
+            logger.debug() << "Totp code creation completed";
 
             AuthenticationInApp* aip = AuthenticationInApp::instance();
             aip->requestState(
@@ -529,7 +526,7 @@ void AuthenticationInAppListener::finalizeSignInOrUp() {
   connect(
       request, &NetworkRequest::requestCompleted, this,
       [this](const QByteArray& data) {
-        logger.debug() << "Oauth code creation completed" << data;
+        logger.debug() << "Oauth code creation completed";
 
         QJsonDocument json = QJsonDocument::fromJson(data);
         if (json.isNull()) {

--- a/src/authenticationinapp/authenticationinapplistener.cpp
+++ b/src/authenticationinapp/authenticationinapplistener.cpp
@@ -149,7 +149,8 @@ void AuthenticationInAppListener::checkAccount(const QString& emailAddress) {
 
   connect(request, &NetworkRequest::requestCompleted, this,
           [this](const QByteArray& data) {
-            logger.debug() << "Account status checked";
+            logger.debug() << "Account status checked:"
+                           << logger.sensitive(data);
 
             QJsonDocument json = QJsonDocument::fromJson(data);
             QJsonObject obj = json.object();
@@ -267,7 +268,7 @@ void AuthenticationInAppListener::signInInternal(const QString& unblockCode) {
 
   connect(request, &NetworkRequest::requestCompleted, this,
           [this](const QByteArray& data) {
-            logger.debug() << "Sign in completed";
+            logger.debug() << "Sign in completed:" << logger.sensitive(data);
 
             QJsonDocument json = QJsonDocument::fromJson(data);
             QJsonObject obj = json.object();
@@ -295,7 +296,7 @@ void AuthenticationInAppListener::signUp() {
 
   connect(request, &NetworkRequest::requestCompleted, this,
           [this](const QByteArray& data) {
-            logger.debug() << "Sign up completed";
+            logger.debug() << "Sign up completed:" << logger.sensitive(data);
 
             QJsonDocument json = QJsonDocument::fromJson(data);
             QJsonObject obj = json.object();
@@ -338,7 +339,9 @@ void AuthenticationInAppListener::sendUnblockCodeEmail() {
           });
 
   connect(request, &NetworkRequest::requestCompleted,
-          []() { logger.debug() << "Code resent"; });
+          [](const QByteArray& data) {
+            logger.debug() << "Code resent:" << logger.sensitive(data);
+          });
 }
 
 void AuthenticationInAppListener::verifySessionEmailCode(const QString& code) {
@@ -358,10 +361,12 @@ void AuthenticationInAppListener::verifySessionEmailCode(const QString& code) {
             processRequestFailure(error, data);
           });
 
-  connect(request, &NetworkRequest::requestCompleted, this, [this]() {
-    logger.debug() << "Verification completed";
-    finalizeSignInOrUp();
-  });
+  connect(request, &NetworkRequest::requestCompleted, this,
+          [this](const QByteArray& data) {
+            logger.debug() << "Verification completed:"
+                           << logger.sensitive(data);
+            finalizeSignInOrUp();
+          });
 }
 
 void AuthenticationInAppListener::resendVerificationSessionCodeEmail() {
@@ -378,7 +383,9 @@ void AuthenticationInAppListener::resendVerificationSessionCodeEmail() {
           });
 
   connect(request, &NetworkRequest::requestCompleted,
-          []() { logger.debug() << "Code resent"; });
+          [](const QByteArray& data) {
+            logger.debug() << "Code resent:" << logger.sensitive(data);
+          });
 }
 
 void AuthenticationInAppListener::verifySessionTotpCode(const QString& code) {
@@ -399,7 +406,8 @@ void AuthenticationInAppListener::verifySessionTotpCode(const QString& code) {
 
   connect(request, &NetworkRequest::requestCompleted, this,
           [this](const QByteArray& data) {
-            logger.debug() << "Verification completed";
+            logger.debug() << "Verification completed:"
+                           << logger.sensitive(data);
 
             QJsonDocument json = QJsonDocument::fromJson(data);
             if (json.isNull()) {
@@ -467,7 +475,8 @@ void AuthenticationInAppListener::createTotpCodes() {
 
   connect(request, &NetworkRequest::requestCompleted, this,
           [this](const QByteArray& data) {
-            logger.debug() << "Totp code creation completed";
+            logger.debug() << "Totp code creation completed:"
+                           << logger.sensitive(data);
 
             AuthenticationInApp* aip = AuthenticationInApp::instance();
             aip->requestState(
@@ -489,7 +498,7 @@ void AuthenticationInAppListener::deleteAccount() {
 
   connect(request, &NetworkRequest::requestCompleted, this,
           [this](const QByteArray& data) {
-            logger.debug() << "Account deleted" << data;
+            logger.debug() << "Account deleted" << logger.sensitive(data);
 
             AuthenticationInApp* aip = AuthenticationInApp::instance();
             aip->requestState(AuthenticationInApp::StateStart, this);
@@ -526,7 +535,8 @@ void AuthenticationInAppListener::finalizeSignInOrUp() {
   connect(
       request, &NetworkRequest::requestCompleted, this,
       [this](const QByteArray& data) {
-        logger.debug() << "Oauth code creation completed";
+        logger.debug() << "Oauth code creation completed:"
+                       << logger.sensitive(data);
 
         QJsonDocument json = QJsonDocument::fromJson(data);
         if (json.isNull()) {

--- a/src/authenticationinapp/authenticationinapplistener.cpp
+++ b/src/authenticationinapp/authenticationinapplistener.cpp
@@ -404,32 +404,31 @@ void AuthenticationInAppListener::verifySessionTotpCode(const QString& code) {
             processRequestFailure(error, data);
           });
 
-  connect(request, &NetworkRequest::requestCompleted, this,
-          [this](const QByteArray& data) {
-            logger.debug() << "Verification completed:"
-                           << logger.sensitive(data);
+  connect(
+      request, &NetworkRequest::requestCompleted, this,
+      [this](const QByteArray& data) {
+        logger.debug() << "Verification completed:" << logger.sensitive(data);
 
-            QJsonDocument json = QJsonDocument::fromJson(data);
-            if (json.isNull()) {
-              MozillaVPN::instance()->errorHandle(
-                  ErrorHandler::AuthenticationError);
-              return;
-            }
+        QJsonDocument json = QJsonDocument::fromJson(data);
+        if (json.isNull()) {
+          MozillaVPN::instance()->errorHandle(
+              ErrorHandler::AuthenticationError);
+          return;
+        }
 
-            QJsonObject obj = json.object();
-            bool success = obj.value("success").toBool();
-            if (success) {
-              finalizeSignInOrUp();
-              return;
-            }
+        QJsonObject obj = json.object();
+        bool success = obj.value("success").toBool();
+        if (success) {
+          finalizeSignInOrUp();
+          return;
+        }
 
-            AuthenticationInApp* aip = AuthenticationInApp::instance();
-            aip->requestState(
-                AuthenticationInApp::StateVerificationSessionByTotpNeeded,
-                this);
-            aip->requestErrorPropagation(
-                this, AuthenticationInApp::ErrorInvalidTotpCode);
-          });
+        AuthenticationInApp* aip = AuthenticationInApp::instance();
+        aip->requestState(
+            AuthenticationInApp::StateVerificationSessionByTotpNeeded, this);
+        aip->requestErrorPropagation(this,
+                                     AuthenticationInApp::ErrorInvalidTotpCode);
+      });
 }
 
 void AuthenticationInAppListener::signInOrUpCompleted(

--- a/src/captiveportal/captiveportalrequest.cpp
+++ b/src/captiveportal/captiveportalrequest.cpp
@@ -63,7 +63,7 @@ void CaptivePortalRequest::createRequest(const QUrl& url) {
           [this](NetworkRequest* request, const QUrl& url) {
             // In Case the Captive Portal request Redirects, we 100% have one.
             logger.info() << "Portal Detected -> Redirect to "
-                          << url.toString();
+                          << logger.sensitive(url.toString());
             request->abort();
             onResult(PortalDetected);
           });

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -285,7 +285,7 @@ void Controller::activateNext() {
   }
   const HopConnection& hop = m_activationQueue.first();
 
-  logger.debug() << "Activating peer" << hop.m_server.publicKey();
+  logger.debug() << "Activating peer" << logger.keys(hop.m_server.publicKey());
   m_handshakeTimer.start(HANDSHAKE_TIMEOUT_SEC * 1000);
   m_impl->activate(hop, device, vpn->keys(), stateToReason(m_state));
 
@@ -345,7 +345,7 @@ bool Controller::deactivate() {
 }
 
 void Controller::connected(const QString& pubkey) {
-  logger.debug() << "handshake completed with:" << pubkey;
+  logger.debug() << "handshake completed with:" << logger.keys(pubkey);
   if (m_activationQueue.isEmpty()) {
     logger.warning() << "Unexpected handshake: no pending connections.";
     return;

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -141,7 +141,8 @@ bool Daemon::activate(const InterfaceConfig& config) {
   // set routing
   for (const IPAddress& ip : config.m_allowedIPAddressRanges) {
     if (!wgutils()->updateRoutePrefix(ip, config.m_hopindex)) {
-      logger.debug() << "Routing configuration failed for" << ip.toString();
+      logger.debug() << "Routing configuration failed for"
+                     << logger.sensitive(ip.toString());
       return false;
     }
   }
@@ -478,8 +479,7 @@ void Daemon::checkHandshake() {
     if (connection.m_date.isValid()) {
       continue;
     }
-    logger.debug() << "awaiting"
-                   << WireguardUtils::printableKey(config.m_serverPublicKey);
+    logger.debug() << "awaiting" << logger.keys(config.m_serverPublicKey);
 
     // Check if the handshake has completed.
     for (const WireguardUtils::PeerStatus& status : peers) {

--- a/src/daemon/daemonlocalserverconnection.cpp
+++ b/src/daemon/daemonlocalserverconnection.cpp
@@ -87,9 +87,9 @@ void DaemonLocalServerConnection::parseCommand(const QByteArray& data) {
     logger.warning() << "No type command. Ignoring request.";
     return;
   }
-
   QString type = typeValue.toString();
-  logger.debug() << type << "received:" << data.left(20);
+
+  logger.debug() << "Command received:" << type;
 
   if (type == "activate") {
     InterfaceConfig config;

--- a/src/daemon/wireguardutils.h
+++ b/src/daemon/wireguardutils.h
@@ -46,15 +46,6 @@ class WireguardUtils : public QObject {
 
   virtual bool addExclusionRoute(const QHostAddress& address) = 0;
   virtual bool deleteExclusionRoute(const QHostAddress& address) = 0;
-
-  // static
-  static QString printableKey(const QString& pubkey) {
-    if (pubkey.length() < 12) {
-      return pubkey;
-    } else {
-      return pubkey.left(6) + "..." + pubkey.right(6);
-    }
-  }
 };
 
 #endif  // WIREGUARDUTILS_H

--- a/src/localsocketcontroller.cpp
+++ b/src/localsocketcontroller.cpp
@@ -261,8 +261,6 @@ void LocalSocketController::readData() {
 }
 
 void LocalSocketController::parseCommand(const QByteArray& command) {
-  logger.debug() << "Parse command:" << command.left(20);
-
   QJsonDocument json = QJsonDocument::fromJson(command);
   if (!json.isObject()) {
     logger.error() << "Invalid JSON - object expected";
@@ -275,8 +273,9 @@ void LocalSocketController::parseCommand(const QByteArray& command) {
     logger.error() << "Invalid JSON - no type";
     return;
   }
-
   QString type = typeValue.toString();
+
+  logger.debug() << "Parse command:" << type;
 
   if (m_daemonState == eInitializing && type == "status") {
     m_daemonState = eReady;
@@ -354,7 +353,8 @@ void LocalSocketController::parseCommand(const QByteArray& command) {
       return;
     }
 
-    logger.debug() << "Handshake completed with:" << pubkey.toString();
+    logger.debug() << "Handshake completed with:"
+                   << logger.keys(pubkey.toString());
     emit connected(pubkey.toString());
     return;
   }

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -51,12 +51,25 @@ Logger::Log& Logger::Log::operator<<(QTextStreamFunction t) {
   return *this;
 }
 
-// static
 QString Logger::sensitive(const QString& input) {
 #ifdef MVPN_DEBUG
   return input;
 #else
-  return QString(input.length(), 'X');
+  Q_UNUSED(input);
+  return QString(8, 'X');
+#endif
+}
+
+QString Logger::keys(const QString& pubkey) {
+#ifdef MVPN_DEBUG
+  if (input.length() < 12) {
+    return input;
+  } else {
+    return input.left(5) + "..." + input.right(5);
+  }
+#else
+  Q_UNUSED(input);
+  return QString(8, 'X');
 #endif
 }
 

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -60,7 +60,7 @@ QString Logger::sensitive(const QString& input) {
 #endif
 }
 
-QString Logger::keys(const QString& pubkey) {
+QString Logger::keys(const QString& input) {
 #ifdef MVPN_DEBUG
   if (input.length() < 12) {
     return input;

--- a/src/logger.h
+++ b/src/logger.h
@@ -92,9 +92,13 @@ class Logger {
   Log info();
   Log debug();
 
-  // Use this to log sensitive data such as IP address, session tokens, and so
-  // on.
+  // Use this to log sensitive data such as IP address, session tokens, and etc.
+  // When compiled with debug, this allows the sensitive data to be logged.
   QString sensitive(const QString& input);
+
+  // Use this to log keys, which should always be obscured.
+  // When compiled with debug, this truncates the keys instead for readability.
+  QString keys(const QString& input);
 
  private:
   QStringList m_modules;

--- a/src/models/servercountrymodel.cpp
+++ b/src/models/servercountrymodel.cpp
@@ -186,7 +186,8 @@ QVariant ServerCountryModel::data(const QModelIndex& index, int role) const {
 bool ServerCountryModel::pickIfExists(const QString& countryCode,
                                       const QString& cityCode,
                                       ServerData& data) const {
-  logger.debug() << "Checking if the server exists" << countryCode << cityCode;
+  logger.debug() << "Checking if a server exists"
+                 << logger.sensitive(countryCode) << logger.sensitive(cityCode);
 
   for (const ServerCountry& country : m_countries) {
     if (country.code() == countryCode) {
@@ -239,7 +240,8 @@ void ServerCountryModel::pickRandom(ServerData& data) const {
 
 bool ServerCountryModel::pickByIPv4Address(const QString& ipv4Address,
                                            ServerData& data) const {
-  logger.debug() << "Choosing a server with addres:" << ipv4Address;
+  logger.debug() << "Choosing a server with addres:"
+                 << logger.sensitive(ipv4Address);
 
   for (const ServerCountry& country : m_countries) {
     for (const ServerCity& city : country.cities()) {
@@ -329,8 +331,8 @@ void ServerCountryModel::setServerCooldown(const QString& publicKey,
 void ServerCountryModel::setCooldownForAllServersInACity(
     const QString& countryCode, const QString& cityCode,
     unsigned int duration) {
-  logger.debug() << "Set cooldown for all servers for: " << countryCode << " - "
-                 << cityCode;
+  logger.debug() << "Set cooldown for all servers for: "
+                 << logger.sensitive(countryCode) << logger.sensitive(cityCode);
 
   for (const ServerCountry& country : m_countries) {
     if (country.code() == countryCode) {

--- a/src/models/serverdata.cpp
+++ b/src/models/serverdata.cpp
@@ -82,7 +82,6 @@ void ServerData::writeSettings() {
 void ServerData::update(const QString& countryCode, const QString& cityName,
                         const QString& entryCountryCode,
                         const QString& entryCityName) {
-  logger.debug() << "Country:" << countryCode << "City:" << cityName;
   initializeInternal(countryCode, cityName, entryCountryCode, entryCityName);
   emit changed();
 }

--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -401,7 +401,7 @@ void MozillaVPN::maybeStateMain() {
 }
 
 void MozillaVPN::setServerPublicKey(const QString& publicKey) {
-  logger.debug() << "Set server public key:" << publicKey;
+  logger.debug() << "Set server public key:" << logger.keys(publicKey);
   m_serverPublicKey = publicKey;
 }
 

--- a/src/networkwatcher.cpp
+++ b/src/networkwatcher.cpp
@@ -98,7 +98,8 @@ void NetworkWatcher::settingsChanged(const bool& active) {
 
 void NetworkWatcher::unsecuredNetwork(const QString& networkName,
                                       const QString& networkId) {
-  logger.debug() << "Unsecured network:" << networkName << "id:" << networkId;
+  logger.debug() << "Unsecured network:" << logger.sensitive(networkName)
+                 << "id:" << logger.sensitive(networkId);
 
 #ifndef UNIT_TEST
   if (!m_reportUnsecuredNetwork) {

--- a/src/pinghelper.cpp
+++ b/src/pinghelper.cpp
@@ -37,7 +37,8 @@ PingHelper::~PingHelper() { MVPN_COUNT_DTOR(PingHelper); }
 
 void PingHelper::start(const QString& serverIpv4Gateway,
                        const QString& deviceIpv4Address) {
-  logger.debug() << "PingHelper activated for server:" << serverIpv4Gateway;
+  logger.debug() << "PingHelper activated for server:"
+                 << logger.sensitive(serverIpv4Gateway);
 
   m_gateway = QHostAddress(serverIpv4Gateway);
   m_source = QHostAddress(deviceIpv4Address.section('/', 0, 0));

--- a/src/platforms/android/androidcontroller.cpp
+++ b/src/platforms/android/androidcontroller.cpp
@@ -154,7 +154,7 @@ void AndroidController::activate(const HopConnection& hop, const Device* device,
   jKeys["privateKey"] = keys->privateKey();
 
   QJsonObject jServer;
-  logger.info() << "Server" << hop.m_server.hostname();
+  logger.info() << "Server" << logger.sensitive(hop.m_server.hostname());
   jServer["ipv4AddrIn"] = hop.m_server.ipv4AddrIn();
   jServer["ipv4Gateway"] = hop.m_server.ipv4Gateway();
   jServer["ipv6AddrIn"] = hop.m_server.ipv6AddrIn();

--- a/src/platforms/android/androidutils.cpp
+++ b/src/platforms/android/androidutils.cpp
@@ -100,11 +100,9 @@ void AndroidUtils::startAuthentication(AuthenticationListener* listener,
 }
 
 bool AndroidUtils::maybeCompleteAuthentication(const QString& url) {
-  logger.debug() << "Maybe complete authentication - url:" << url;
+  logger.debug() << "Maybe complete authentication";
 
   Q_ASSERT(m_listener);
-
-  logger.debug() << "AndroidWebView is about to load" << url;
 
   QString apiUrl = NetworkRequest::apiBaseUrl();
   if (!url.startsWith(apiUrl)) {

--- a/src/platforms/android/androidwebview.cpp
+++ b/src/platforms/android/androidwebview.cpp
@@ -148,7 +148,8 @@ QUrl AndroidWebView::url() const {
 }
 
 void AndroidWebView::setUrl(const QUrl& url) {
-  logger.debug() << "Set URL:" << url.toString();
+  QUrl::FormattingOptions options = QUrl::RemoveQuery | QUrl::RemoveUserInfo;
+  logger.debug() << "Set URL:" << url.toString(options);
 
   if (!m_object.isValid()) {
     logger.error() << "Invalid object. Failed the loading.";

--- a/src/platforms/linux/daemon/dnsutilslinux.cpp
+++ b/src/platforms/linux/daemon/dnsutilslinux.cpp
@@ -122,8 +122,10 @@ void DnsUtilsLinux::setLinkDomains(int ifindex,
   const char* ifname = if_indextoname(ifindex, ifnamebuf);
   if (ifname) {
     for (auto d : domains) {
-      logger.debug() << "Setting DNS domain:" << d.domain << "via" << ifname
-                     << (d.search ? "search" : "");
+      // The DNS search domains often winds up revealing user's ISP which
+      // can correlate back to their location.
+      logger.debug() << "Setting DNS domain:" << logger.sensitive(d.domain)
+                     << "via" << ifname << (d.search ? "search" : "");
     }
   }
 

--- a/src/platforms/linux/daemon/iputilslinux.cpp
+++ b/src/platforms/linux/daemon/iputilslinux.cpp
@@ -100,7 +100,7 @@ bool IPUtilsLinux::addIP4AddressToDevice(const InterfaceConfig& config) {
   // Set ifr to interface
   int ret = ioctl(sockfd, SIOCSIFADDR, &ifr);
   if (ret) {
-    logger.error() << "Failed to set IPv4: " << deviceAddr
+    logger.error() << "Failed to set IPv4: " << logger.sensitive(deviceAddr)
                    << "error:" << strerror(errno);
     return false;
   }
@@ -141,7 +141,7 @@ bool IPUtilsLinux::addIP6AddressToDevice(const InterfaceConfig& config) {
   // Set ifr6 to the interface
   ret = ioctl(sockfd, SIOCSIFADDR, &ifr6);
   if (ret && (errno != EEXIST)) {
-    logger.error() << "Failed to set IPv6: " << deviceAddr
+    logger.error() << "Failed to set IPv6: " << logger.sensitive(deviceAddr)
                    << "error:" << strerror(errno);
     return false;
   }

--- a/src/platforms/linux/daemon/wireguardutilslinux.cpp
+++ b/src/platforms/linux/daemon/wireguardutilslinux.cpp
@@ -194,7 +194,7 @@ bool WireguardUtilsLinux::updatePeer(const InterfaceConfig& config) {
   }
   device->first_peer = device->last_peer = peer;
 
-  logger.debug() << "Adding peer" << printableKey(config.m_serverPublicKey);
+  logger.debug() << "Adding peer" << logger.keys(config.m_serverPublicKey);
 
   // Public Key
   wg_key_from_base64(peer->public_key, qPrintable(config.m_serverPublicKey));
@@ -258,7 +258,7 @@ bool WireguardUtilsLinux::deletePeer(const InterfaceConfig& config) {
   }
   device->first_peer = device->last_peer = peer;
 
-  logger.debug() << "Removing peer" << printableKey(config.m_serverPublicKey);
+  logger.debug() << "Removing peer" << logger.keys(config.m_serverPublicKey);
 
   // Public Key
   peer->flags = (wg_peer_flags)(WGPEER_HAS_PUBLIC_KEY | WGPEER_REMOVE_ME);
@@ -316,7 +316,7 @@ QList<WireguardUtils::PeerStatus> WireguardUtilsLinux::getPeerStatus() {
     status.m_handshake += peer->last_handshake_time.tv_nsec / 1000000;
     status.m_txBytes = peer->tx_bytes;
     status.m_rxBytes = peer->rx_bytes;
-    logger.debug() << "found" << printableKey(status.m_pubkey) << "handshake"
+    logger.debug() << "found" << logger.keys(status.m_pubkey) << "handshake"
                    << peer->last_handshake_time.tv_sec;
     peerList.append(status);
   }
@@ -333,19 +333,21 @@ bool WireguardUtilsLinux::updateRoutePrefix(const IPAddress& prefix,
 
 bool WireguardUtilsLinux::deleteRoutePrefix(const IPAddress& prefix,
                                             int hopindex) {
-  logger.debug() << "Removing route to" << prefix.toString();
+  logger.debug() << "Removing route to" << logger.sensitive(prefix.toString());
   const int flags = NLM_F_REQUEST | NLM_F_ACK;
   return rtmSendRoute(RTM_DELROUTE, flags, prefix, hopindex);
 }
 
 bool WireguardUtilsLinux::addExclusionRoute(const QHostAddress& address) {
-  logger.debug() << "Adding exclusion route for" << address.toString();
+  logger.debug() << "Adding exclusion route for"
+                 << logger.sensitive(address.toString());
   const int flags = NLM_F_REQUEST | NLM_F_CREATE | NLM_F_REPLACE | NLM_F_ACK;
   return rtmSendExclude(RTM_NEWRULE, flags, address);
 }
 
 bool WireguardUtilsLinux::deleteExclusionRoute(const QHostAddress& address) {
-  logger.debug() << "Removing exclusion route for" << address.toString();
+  logger.debug() << "Removing exclusion route for"
+                 << logger.sensitive(address.toString());
   return rtmSendExclude(RTM_DELRULE, NLM_F_REQUEST | NLM_F_ACK, address);
 }
 

--- a/src/platforms/linux/linuxnetworkwatcherworker.cpp
+++ b/src/platforms/linux/linuxnetworkwatcherworker.cpp
@@ -167,7 +167,8 @@ void LinuxNetworkWatcherWorker::checkDevices() {
       // network devices.
       logger.warning() << "Unsecured AP detected!"
                        << "rsnFlags:" << rsnFlags.toInt()
-                       << "wpaFlags:" << wpaFlags.toInt() << "ssid:" << ssid;
+                       << "wpaFlags:" << wpaFlags.toInt()
+                       << "ssid:" << logger.sensitive(ssid);
       emit unsecuredNetwork(ssid, bssid);
       break;
     }

--- a/src/platforms/linux/linuxpingsender.cpp
+++ b/src/platforms/linux/linuxpingsender.cpp
@@ -65,7 +65,9 @@ int LinuxPingSender::createSocket() {
 LinuxPingSender::LinuxPingSender(const QHostAddress& source, QObject* parent)
     : PingSender(parent) {
   MVPN_COUNT_CTOR(LinuxPingSender);
-  logger.debug() << "LinuxPingSender(" + source.toString() + ") created";
+
+  logger.debug() << "LinuxPingSender(" + logger.sensitive(source.toString()) +
+                        ") created";
 
   m_socket = createSocket();
   if (m_socket < 0) {

--- a/src/platforms/macos/daemon/iputilsmacos.cpp
+++ b/src/platforms/macos/daemon/iputilsmacos.cpp
@@ -124,7 +124,7 @@ bool IPUtilsMacos::addIP4AddressToDevice(const InterfaceConfig& config) {
   // Set ifr to interface
   int ret = ioctl(sockfd, SIOCAIFADDR, &ifr);
   if (ret) {
-    logger.error() << "Failed to set IPv4: " << deviceAddr
+    logger.error() << "Failed to set IPv4: " << logger.sensitive(deviceAddr)
                    << "error:" << strerror(errno);
     return false;
   }
@@ -164,7 +164,7 @@ bool IPUtilsMacos::addIP6AddressToDevice(const InterfaceConfig& config) {
   // Set ifr to interface
   int ret = ioctl(sockfd, SIOCAIFADDR_IN6, &ifr6);
   if (ret) {
-    logger.error() << "Failed to set IPv6: " << deviceAddr
+    logger.error() << "Failed to set IPv6: " << logger.sensitive(deviceAddr)
                    << "error:" << strerror(errno);
     return false;
   }

--- a/src/platforms/macos/daemon/wireguardutilsmacos.cpp
+++ b/src/platforms/macos/daemon/wireguardutilsmacos.cpp
@@ -137,7 +137,7 @@ bool WireguardUtilsMacos::updatePeer(const InterfaceConfig& config) {
   QByteArray publicKey =
       QByteArray::fromBase64(qPrintable(config.m_serverPublicKey));
 
-  logger.debug() << "Configuring peer" << printableKey(config.m_serverPublicKey)
+  logger.debug() << "Configuring peer" << logger.keys(config.m_serverPublicKey)
                  << "via" << config.m_serverIpv4AddrIn;
 
   // Update/create the peer config

--- a/src/platforms/windows/daemon/windowsfirewall.cpp
+++ b/src/platforms/windows/daemon/windowsfirewall.cpp
@@ -211,7 +211,8 @@ bool WindowsFirewall::enablePeerTraffic(const InterfaceConfig& config) {
   });
 
   // Build the firewall rules for this peer.
-  logger.info() << "Enabling traffic for peer" << config.m_serverPublicKey;
+  logger.info() << "Enabling traffic for peer"
+                << logger.keys(config.m_serverPublicKey);
   if (!blockTrafficTo(config.m_allowedIPAddressRanges, LOW_WEIGHT,
                       "Block Internet", config.m_serverPublicKey)) {
     return false;
@@ -256,7 +257,7 @@ bool WindowsFirewall::disablePeerTraffic(const QString& pubkey) {
     return false;
   }
 
-  logger.info() << "Disabling traffic for peer" << pubkey;
+  logger.info() << "Disabling traffic for peer" << logger.keys(pubkey);
   for (const auto& filterID : m_peerRules.values(pubkey)) {
     FwpmFilterDeleteById0(m_sessionHandle, filterID);
     m_peerRules.remove(pubkey, filterID);

--- a/src/platforms/windows/daemon/windowsroutemonitor.cpp
+++ b/src/platforms/windows/daemon/windowsroutemonitor.cpp
@@ -139,7 +139,8 @@ void WindowsRouteMonitor::updateExclusionRoute(MIB_IPFORWARD_ROW2* data,
 }
 
 bool WindowsRouteMonitor::addExclusionRoute(const QHostAddress& address) {
-  logger.debug() << "Adding exclusion route for" << address.toString();
+  logger.debug() << "Adding exclusion route for"
+                 << logger.sensitive(address.toString());
 
   if (m_exclusionRoutes.contains(address)) {
     logger.warning() << "Exclusion route already exists";
@@ -197,7 +198,8 @@ bool WindowsRouteMonitor::addExclusionRoute(const QHostAddress& address) {
 }
 
 bool WindowsRouteMonitor::deleteExclusionRoute(const QHostAddress& address) {
-  logger.debug() << "Deleting exclusion route for" << address.toString();
+  logger.debug() << "Deleting exclusion route for"
+                 << logger.sensitive(address.toString());
 
   for (;;) {
     MIB_IPFORWARD_ROW2* data = m_exclusionRoutes.take(address);
@@ -207,7 +209,8 @@ bool WindowsRouteMonitor::deleteExclusionRoute(const QHostAddress& address) {
 
     DWORD result = DeleteIpForwardEntry2(data);
     if ((result != ERROR_NOT_FOUND) && (result != NO_ERROR)) {
-      logger.error() << "Failed to delete route to" << address.toString()
+      logger.error() << "Failed to delete route to"
+                     << logger.sensitive(address.toString())
                      << "result:" << result;
     }
     delete data;
@@ -221,7 +224,8 @@ void WindowsRouteMonitor::flushExclusionRoutes() {
     MIB_IPFORWARD_ROW2* data = i.value();
     DWORD result = DeleteIpForwardEntry2(data);
     if ((result != ERROR_NOT_FOUND) && (result != NO_ERROR)) {
-      logger.error() << "Failed to delete route to" << i.key().toString()
+      logger.error() << "Failed to delete route to"
+                     << logger.sensitive(i.key().toString())
                      << "result:" << result;
     }
     delete data;

--- a/src/platforms/windows/daemon/windowssplittunnel.cpp
+++ b/src/platforms/windows/daemon/windowssplittunnel.cpp
@@ -275,7 +275,7 @@ void WindowsSplitTunnel::getAddress(int adapterIndex, IN_ADDR* out_ipv4,
     if (address.ip().protocol() == QAbstractSocket::IPv4Protocol) {
       auto adrr = address.ip().toString();
       std::wstring wstr = adrr.toStdWString();
-      logger.debug() << "IpV4" << adrr;
+      logger.debug() << "IpV4" << logger.sensitive(adrr);
       PCWSTR w_str_ip = wstr.c_str();
       auto ok = InetPtonW(AF_INET, w_str_ip, out_ipv4);
       if (ok != 1) {
@@ -288,7 +288,7 @@ void WindowsSplitTunnel::getAddress(int adapterIndex, IN_ADDR* out_ipv4,
     if (address.ip().protocol() == QAbstractSocket::IPv6Protocol) {
       auto adrr = address.ip().toString();
       std::wstring wstr = adrr.toStdWString();
-      logger.debug() << "IpV6" << adrr;
+      logger.debug() << "IpV6" << logger.sensitive(adrr);
       PCWSTR w_str_ip = wstr.c_str();
       auto ok = InetPtonW(AF_INET6, w_str_ip, out_ipv6);
       if (ok != 1) {

--- a/src/platforms/windows/daemon/wireguardutilswindows.cpp
+++ b/src/platforms/windows/daemon/wireguardutilswindows.cpp
@@ -136,7 +136,7 @@ bool WireguardUtilsWindows::updatePeer(const InterfaceConfig& config) {
   // Enable the windows firewall for this peer.
   WindowsFirewall::instance()->enablePeerTraffic(config);
 
-  logger.debug() << "Configuring peer" << printableKey(config.m_serverPublicKey)
+  logger.debug() << "Configuring peer" << logger.keys(config.m_serverPublicKey)
                  << "via" << config.m_serverIpv4AddrIn;
 
   // Update/create the peer config
@@ -227,7 +227,8 @@ bool WireguardUtilsWindows::updateRoutePrefix(const IPAddress& prefix,
     return true;
   }
   if (result != NO_ERROR) {
-    logger.error() << "Failed to create route to" << prefix.toString()
+    logger.error() << "Failed to create route to"
+                   << logger.sensitive(prefix.toString())
                    << "result:" << result;
   }
   return result == NO_ERROR;
@@ -245,7 +246,8 @@ bool WireguardUtilsWindows::deleteRoutePrefix(const IPAddress& prefix,
     return true;
   }
   if (result != NO_ERROR) {
-    logger.error() << "Failed to delete route to" << prefix.toString()
+    logger.error() << "Failed to delete route to"
+                   << logger.sensitive(prefix.toString())
                    << "result:" << result;
   }
   return result == NO_ERROR;

--- a/src/platforms/windows/windowscommons.cpp
+++ b/src/platforms/windows/windowscommons.cpp
@@ -111,7 +111,7 @@ QString WindowsCommons::tunnelLogFile() {
 // static
 int WindowsCommons::AdapterIndexTo(const QHostAddress& dst) {
   logger.debug() << "Getting Current Internet Adapter that routes to"
-                 << dst.toString();
+                 << logger.sensitive(dst.toString());
   quint32_be ipBigEndian;
   quint32 ip = dst.toIPv4Address();
   qToBigEndian(ip, &ipBigEndian);

--- a/src/platforms/windows/windowsnetworkwatcher.cpp
+++ b/src/platforms/windows/windowsnetworkwatcher.cpp
@@ -130,6 +130,7 @@ void WindowsNetworkWatcher::processWlan(PWLAN_NOTIFICATION_DATA data) {
         (char)connectionInfo->wlanAssociationAttributes.dot11Ssid.ucSSID[i]));
   }
 
-  logger.debug() << "Unsecure network:" << ssid << "id:" << bssid;
+  logger.debug() << "Unsecure network:" << logger.sensitive(ssid)
+                 << "id:" << logger.sensitive(bssid);
   emit unsecuredNetwork(ssid, bssid);
 }

--- a/src/platforms/windows/windowspingsender.cpp
+++ b/src/platforms/windows/windowspingsender.cpp
@@ -60,7 +60,8 @@ void WindowsPingSender::sendPing(const QHostAddress& dest, quint16 sequence) {
   if (status != ERROR_IO_PENDING) {
     QString errmsg = WindowsCommons::getErrorMessage();
     logger.error() << "failed to start Code: " << status
-                   << " Message: " << errmsg << " dest:" << dest.toString();
+                   << " Message: " << errmsg
+                   << " dest:" << logger.sensitive(dest.toString());
   }
 }
 

--- a/src/tasks/ipfinder/taskipfinder.cpp
+++ b/src/tasks/ipfinder/taskipfinder.cpp
@@ -68,12 +68,12 @@ void TaskIPFinder::dnsLookupCompleted(const QHostInfo& hostInfo) {
     if (address.isNull() || address.isBroadcast()) continue;
 
     if (address.protocol() == QAbstractSocket::IPv4Protocol) {
-      logger.debug() << "Ipv4:" << address.toString();
+      logger.debug() << "Ipv4:" << logger.sensitive(address.toString());
       createRequest(address, false);
     }
 
     if (address.protocol() == QAbstractSocket::IPv6Protocol) {
-      logger.debug() << "Ipv6:" << address.toString();
+      logger.debug() << "Ipv6:" << logger.sensitive(address.toString());
       createRequest(address, true);
     }
   }

--- a/src/tasks/removedevice/taskremovedevice.cpp
+++ b/src/tasks/removedevice/taskremovedevice.cpp
@@ -32,7 +32,8 @@ TaskRemoveDevice::~TaskRemoveDevice() {
 }
 
 void TaskRemoveDevice::run() {
-  logger.debug() << "Removing the device with public key" << m_publicKey;
+  logger.debug() << "Removing the device with public key"
+                 << logger.keys(m_publicKey);
 
   NetworkRequest* request =
       NetworkRequest::createForDeviceRemoval(this, m_publicKey);


### PR DESCRIPTION
This should remove the following information from the logs:
 - User's public keys, e-mail address and account details.
 - Any identifying details of the chosen server.
 - Wi-Fi SSID/BSSID.
 - Captive portal redirection URL.