### PR TITLE
Consolidate and use final content

### DIFF
--- a/nebula/ui/components.qrc
+++ b/nebula/ui/components.qrc
@@ -109,5 +109,7 @@
         <file>components/inAppAuth/VPNInAppAuthenticationErrorPopup.qml</file>
         <file>components/inAppAuth/VPNInAppAuthenticationInputs.qml</file>
         <file>components/inAppAuth/VPNInAppAuthenticationPasswordCondition.qml</file>
+        <file>components/inAppAuth/VPNInAppAuthenticationLegalDisclaimer.qml</file>
+        <file>components/inAppAuth/VPNInAppAuthenticationCancel.qml</file>
     </qresource>
 </RCC>

--- a/nebula/ui/components/inAppAuth/VPNInAppAuthenticationBase.qml
+++ b/nebula/ui/components/inAppAuth/VPNInAppAuthenticationBase.qml
@@ -29,14 +29,12 @@ VPNFlickable {
     id: authBase
     flickContentHeight: col.implicitHeight
 
-
     ColumnLayout {
         id: col
         anchors.top: parent.top
         height: Math.max(parent.height, col.implicitHeight)
         anchors.left: parent.left
         anchors.right: parent.right
-        width: Math.min(authBase.width, 200)
 
         PropertyAnimation on opacity {
             from: 0

--- a/nebula/ui/components/inAppAuth/VPNInAppAuthenticationCancel.qml
+++ b/nebula/ui/components/inAppAuth/VPNInAppAuthenticationCancel.qml
@@ -1,0 +1,17 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import QtQuick 2.5
+import QtQuick.Layouts 1.14
+
+import Mozilla.VPN 1.0
+import components 0.1
+
+VPNLinkButton {
+    labelText: VPNl18n.InAppSupportWorkflowSupportSecondaryActionText // "Cancel"
+    fontName: VPNTheme.theme.fontBoldFamily
+    anchors.horizontalCenter: parent.horizontalCenter
+    linkColor: VPNTheme.theme.redButton
+    onClicked: VPN.cancelAuthentication()
+}

--- a/nebula/ui/components/inAppAuth/VPNInAppAuthenticationErrorPopup.qml
+++ b/nebula/ui/components/inAppAuth/VPNInAppAuthenticationErrorPopup.qml
@@ -11,35 +11,43 @@ import components 0.1
 VPNPopup {
     id: authError
     anchors.centerIn: parent
-    width: Math.min(parent.width * 0.73, VPNTheme.theme.maxHorizontalContentWidth)
+    width: Math.min(parent.width - VPNTheme.theme.windowMargin * 2, VPNTheme.theme.maxHorizontalContentWidth)
+    height: Math.min(parent.height - VPNTheme.theme.windowMargin * 2, implicitHeight + VPNTheme.theme.windowMargin * 2)
     maxWidth: Math.min(parent.width * 0.83, VPNTheme.theme.maxHorizontalContentWidth)
+
     _popupContent:
         ColumnLayout {
             id: authErrorContent
             spacing: VPNTheme.theme.vSpacing
 
-                Image {
-                    source: "qrc:/ui/resources/updateRequired.svg"
-                    antialiasing: true
-                    sourceSize.height: 80
-                    sourceSize.width: 80
-                    Layout.alignment: Qt.AlignHCenter
-                }
+
+            Image {
+                source: "qrc:/ui/resources/updateRequired.svg"
+                antialiasing: true
+                sourceSize.height: 80
+                sourceSize.width: 80
+                Layout.alignment: Qt.AlignHCenter
+            }
+            VPNHeadline {
+                text: VPNl18n.InAppAuthSignInFailedPopupTitle
+                width: undefined
+                Layout.fillWidth: true
+
+            }
+
             VPNTextBlock {
                 id: authErrorMessage
                 text: ""
                 horizontalAlignment: Text.AlignHCenter
                 Layout.preferredWidth: parent.width
                 Layout.fillWidth: true
-                width: undefined
             }
 
             VPNButton {
-                text: "Okay"
+                text: VPNl18n.CaptivePortalAlertButtonTextPreActivation
                 onClicked: authError.close()
             }
         }
-
 
     Connections {
         target: VPNAuthInApp
@@ -62,12 +70,12 @@ VPNPopup {
         function onErrorOccurred(e, retryAfterSec) {
             switch(e) {
             case VPNAuthInApp.ErrorEmailCanNotBeUsedToLogin:
-                authErrorMessage.text = "email can not be used to log in";
+                authErrorMessage.text = VPNl18n.InAppAuthProblemSigningInErrorMessage;
                 openErrorModalAndForceFocus();
                 break;
 
             case VPNAuthInApp.ErrorEmailTypeNotSupported:
-                authErrorMessage.text = "email type not supported";
+                authErrorMessage.text = VPNl18n.InAppAuthInvalidEmailFormatErrorMessage
                 openErrorModalAndForceFocus();
                 break;
 

--- a/nebula/ui/components/inAppAuth/VPNInAppAuthenticationInputs.qml
+++ b/nebula/ui/components/inAppAuth/VPNInAppAuthenticationInputs.qml
@@ -100,15 +100,15 @@ ColumnLayout {
 
                     VPNInAppAuthenticationPasswordCondition {
                         _passwordConditionIsSatisfied: toolTip._isSignUp && VPNAuthInApp.validatePasswordLength(passwordInput.text)
-                        _passwordConditionDescription:  "Must be a minumum of 8 characters and lots of wrapping text"
+                        _passwordConditionDescription:  VPNl18n.InAppAuthPasswordHintCharacterLength
                     }
                     VPNInAppAuthenticationPasswordCondition {
                         _passwordConditionIsSatisfied: toolTip._isSignUp && VPNAuthInApp.validatePasswordEmail(passwordInput.text)
-                        _passwordConditionDescription:  "Must not be email"
+                        _passwordConditionDescription:  VPNl18n.InAppAuthPasswordHintEmailAddressAsPassword
                     }
                     VPNInAppAuthenticationPasswordCondition {
                         _passwordConditionIsSatisfied: toolTip._isSignUp && passwordInput.text.length > 0 && VPNAuthInApp.validatePasswordCommons(passwordInput.text)
-                        _passwordConditionDescription:  "Must not be a common password"
+                        _passwordConditionDescription:  VPNl18n.InAppAuthPasswordHintCommonPassword
                     }
                 }
             }
@@ -180,26 +180,26 @@ ColumnLayout {
                 activeInput().forceActiveFocus();
                 break;
             case VPNAuthInApp.ErrorInvalidEmailAddress:
-                base._inputErrorMessage = "Invalid email address";
+                base._inputErrorMessage =  VPNl18n.InAppAuthInvalidEmailErrorMessage;
                 activeInput().forceActiveFocus();
                 break;
             case VPNAuthInApp.ErrorInvalidEmailCode:
-                base._inputErrorMessage = "Invalid email code";
+                base._inputErrorMessage = VPNl18n.InAppAuthInvalidCodeErrorMessage;
                 activeInput().forceActiveFocus();
                 break;
 
             case VPNAuthInApp.ErrorInvalidOrExpiredVerificationCode:
-                base._inputErrorMessage = "Invalid or expired verification code"
+                base._inputErrorMessage = VPNl18n.InAppAuthInvalidCodeErrorMessage
                 activeInput().forceActiveFocus();
                 break;
 
             case VPNAuthInApp.ErrorInvalidTotpCode:
-                base._inputErrorMessage = "invalid 2fa unblock code";
+                base._inputErrorMessage = VPNl18n.InAppAuthInvalidCodeErrorMessage;
                 activeInput().forceActiveFocus();
                 break;
 
             case VPNAuthInApp.ErrorInvalidUnblockCode:
-                base._inputErrorMessage = "Invalid unblock code";
+                base._inputErrorMessage = VPNl18n.InAppAuthInvalidCodeErrorMessage;
                 activeInput().forceActiveFocus();
                 break;
             }

--- a/nebula/ui/components/inAppAuth/VPNInAppAuthenticationLegalDisclaimer.qml
+++ b/nebula/ui/components/inAppAuth/VPNInAppAuthenticationLegalDisclaimer.qml
@@ -1,0 +1,30 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import QtQuick 2.5
+import QtQuick.Layouts 1.14
+
+import Mozilla.VPN 1.0
+
+ColumnLayout {
+    Layout.alignment: Qt.AlignHCenter
+
+    Text {
+        text: VPNl18n.InAppAuthTermsOfServiceAndPrivacyDisclaimer
+        font.family: VPNTheme.theme.fontInterFamily
+        font.pixelSize: VPNTheme.theme.fontSizeSmall
+        color: VPNTheme.theme.fontColor
+        Layout.fillWidth: true
+        wrapMode: Text.WrapAtWordBoundaryOrAnywhere
+        horizontalAlignment: Text.AlignHCenter
+        linkColor: VPNTheme.theme.fontColorDark
+        lineHeightMode: Text.FixedHeight
+        lineHeight: VPNTheme.theme.labelLineHeight
+        onLinkActivated: {
+            if (link === "terms-of-service")
+                return VPN.openLink(VPN.LinkTermsOfService);
+            VPN.openLink(VPN.LinkPrivacyNotice);
+        }
+    }
+}

--- a/nebula/ui/components/inAppAuth/qmldir
+++ b/nebula/ui/components/inAppAuth/qmldir
@@ -1,4 +1,6 @@
 VPNInAppAuthenticationBase 0.1 VPNInAppAuthenticationBase.qml
+VPNInAppAuthenticationCancel 0.1 VPNInAppAuthenticationCancel.qml
 VPNInAppAuthenticationErrorPopup 0.1 VPNInAppAuthenticationErrorPopup.qml
 VPNInAppAuthenticationInputs 0.1 VPNInAppAuthenticationInputs.qml
+VPNInAppAuthenticationLegalDisclaimer 0.1 VPNInAppAuthenticationLegalDisclaimer.qml
 VPNInAppAuthenticationPasswordCondition 0.1 VPNInAppAuthenticationPasswordCondition.qml

--- a/src/ui/authenticationInApp/ViewAuthenticationSignIn.qml
+++ b/src/ui/authenticationInApp/ViewAuthenticationSignIn.qml
@@ -48,27 +48,7 @@ VPNInAppAuthenticationBase {
         _inputPlaceholderText: VPNl18n.InAppAuthPasswordInputPlaceholder
     }
 
-    _disclaimers: ColumnLayout {
-        Layout.alignment: Qt.AlignHCenter
-
-        Text {
-            text: VPNl18n.InAppAuthTermsOfServiceAndPrivacyDisclaimer
-            font.family: VPNTheme.theme.fontInterFamily
-            font.pixelSize: VPNTheme.theme.fontSizeSmall
-            color: VPNTheme.theme.fontColor
-            Layout.fillWidth: true
-            wrapMode: Text.WrapAtWordBoundaryOrAnywhere
-            horizontalAlignment: Text.AlignHCenter
-            linkColor: VPNTheme.theme.fontColorDark
-            lineHeightMode: Text.FixedHeight
-            lineHeight: VPNTheme.theme.labelLineHeight
-            onLinkActivated: {
-                if (link === "terms-of-service")
-                    return VPN.openLink(VPN.LinkTermsOfService);
-                VPN.openLink(VPN.LinkPrivacyNotice);
-            }
-        }
-    }
+    _disclaimers: VPNInAppAuthenticationLegalDisclaimer {}
 
     _footerContent: Column {
         Layout.alignment: Qt.AlignHCenter
@@ -80,14 +60,6 @@ VPNInAppAuthenticationBase {
             onClicked: VPN.openLink(VPN.LinkForgotPassword)
         }
 
-        VPNLinkButton {
-            // TODO create cancel component and use everywhere
-            labelText: VPNl18n.InAppSupportWorkflowSupportSecondaryActionText // "Cancel"
-            fontName: VPNTheme.theme.fontBoldFamily
-            anchors.horizontalCenter: parent.horizontalCenter
-            linkColor: VPNTheme.theme.redButton
-            onClicked: VPN.cancelAuthentication()
-        }
-
+        VPNInAppAuthenticationCancel {}
     }
 }

--- a/src/ui/authenticationInApp/ViewAuthenticationSignIn.qml
+++ b/src/ui/authenticationInApp/ViewAuthenticationSignIn.qml
@@ -32,7 +32,7 @@ VPNInAppAuthenticationBase {
     _changeEmailLinkVisible: true
     _menuButtonImageSource: "qrc:/nebula/resources/back.svg"
     _menuButtonOnClick: () => { VPNAuthInApp.reset() }
-    _menuButtonAccessibleName: "Back"
+    _menuButtonAccessibleName: qsTrId("vpn.main.back")
     _headlineText: VPNAuthInApp.emailAddress
     _subtitleText: VPNl18n.InAppAuthSignInSubtitle
     _imgSource: "qrc:/nebula/resources/avatar.svg"

--- a/src/ui/authenticationInApp/ViewAuthenticationSignUp.qml
+++ b/src/ui/authenticationInApp/ViewAuthenticationSignUp.qml
@@ -25,11 +25,11 @@ VPNInAppAuthenticationBase {
     _menuButtonOnClick: () => {
         VPNAuthInApp.reset();
     }
-    _menuButtonAccessibleName: "Back"
+    _menuButtonAccessibleName: qsTrId("vpn.main.back")
     _headlineText: VPNAuthInApp.emailAddress
-    _subtitleText: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor"
+    _subtitleText: VPNl18n.InAppAuthFinishAccountCreationDescription
     _imgSource: "qrc:/nebula/resources/avatar.svg"
-    _inputLabel: "Create password"
+    _inputLabel: VPNl18n.InAppAuthCreatePasswordLabel
 
     _inputs: VPNInAppAuthenticationInputs {
         function validatePassword(passwordString) {
@@ -42,30 +42,15 @@ VPNInAppAuthenticationBase {
                               VPNAuthInApp.setPassword(inputText);
                               VPNAuthInApp.signUp();
                           }
-        _buttonText: "Create account"
+        _buttonText: VPNl18n.InAppAuthCreateAccountButton
         _inputPlaceholderText: "Secure password"
     }
 
-    _disclaimers: RowLayout {
-        Layout.alignment: Qt.AlignHCenter
-        VPNTextBlock {
-            Layout.fillWidth: true
-            horizontalAlignment: Text.AlignHCenter
-            text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
-        }
-    }
+    _disclaimers: VPNInAppAuthenticationLegalDisclaimer {}
 
     _footerContent: Column {
         Layout.alignment: Qt.AlignHCenter
-        spacing: VPNTheme.theme.windowMargin
 
-        VPNLinkButton {
-            labelText: VPNl18n.InAppSupportWorkflowSupportSecondaryActionText // "Cancel"
-            fontName: VPNTheme.theme.fontBoldFamily
-            anchors.horizontalCenter: parent.horizontalCenter
-            linkColor: VPNTheme.theme.redButton
-            onClicked: VPN.cancelAuthentication()
-        }
-
+        VPNInAppAuthenticationCancel {}
     }
 }

--- a/src/ui/authenticationInApp/ViewAuthenticationStart.qml
+++ b/src/ui/authenticationInApp/ViewAuthenticationStart.qml
@@ -24,25 +24,18 @@ VPNInAppAuthenticationBase {
 
     _menuButtonOnClick: () => {VPN.cancelAuthentication() }
     _menuButtonImageSource: "qrc:/nebula/resources/back.svg"
-    _menuButtonAccessibleName: "Back"
+    _menuButtonAccessibleName:  qsTrId("vpn.main.back")
     _headlineText: "Mozilla VPN"
-    _subtitleText: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut"
+    _subtitleText: VPNl18n.InAppAuthEnterEmailAddressDescription
     _imgSource: "qrc:/ui/resources/logo.svg"
-    _inputLabel: "Email address"
+    _inputLabel: VPNl18n.InAppAuthEmailInputPlaceholder
 
     _inputs: VPNInAppAuthenticationInputs {
         _buttonEnabled: VPNAuthInApp.state === VPNAuthInApp.StateStart && activeInput().text.length !== 0 && !activeInput().hasError
-        _buttonOnClicked: (inputText) => {
-                              if (!VPNAuthInApp.validateEmailAddress(inputText)) {
-                                  activeInput().hasError = true;
-                                  _inputErrorMessage = "invalid email address, try again"
-                                  return activeInput().forceActiveFocus();
-                              }
-                              VPNAuthInApp.checkAccount(inputText);
-                          }
-        _buttonText: "Continue"
+        _buttonOnClicked: (inputText) => { VPNAuthInApp.checkAccount(inputText); }
+        _buttonText: qsTrId("vpn.postAuthentication.continue")
         _inputMethodHints: Qt.ImhEmailCharactersOnly | Qt.ImhNoAutoUppercase
-        _inputPlaceholderText: "Enter email"
+        _inputPlaceholderText: VPNl18n.InAppSupportWorkflowSupportEmailFieldPlaceholder
     }
 
     _disclaimers: RowLayout {
@@ -62,7 +55,7 @@ VPNInAppAuthenticationBase {
 
         VPNTextBlock {
             id: txt
-            text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
+            text: VPNl18n.InAppAuthInformationUsageDisclaimer
             Layout.fillWidth: true
         }
     }

--- a/src/ui/authenticationInApp/ViewAuthenticationVerificationSessionByEmailNeeded.qml
+++ b/src/ui/authenticationInApp/ViewAuthenticationVerificationSessionByEmailNeeded.qml
@@ -33,17 +33,17 @@ VPNInAppAuthenticationBase {
 
     _menuButtonImageSource: "qrc:/nebula/resources/back.svg"
     _menuButtonOnClick: () => { VPNAuthInApp.reset() }
-    _menuButtonAccessibleName: "Back"
-    _headlineText: "Enter verification code"
-    _subtitleText: "Open your email and enter the verification code it that was sent."
+    _menuButtonAccessibleName: qsTrId("vpn.connectionInfo.close")
+    _headlineText: VPNl18n.InAppAuthVerificationCodeTitle
+    _subtitleText: VPNl18n.InAppAuthEmailVerificationDescription
     _imgSource: "qrc:/nebula/resources/verification-code.svg"
 
     _inputs: VPNInAppAuthenticationInputs {
         _buttonEnabled: VPNAuthInApp.state === VPNAuthInApp.StateVerificationSessionByEmailNeeded && activeInput().text && activeInput().text.length === VPNAuthInApp.verificationCodeLength && !activeInput().hasError
         _buttonOnClicked: (inputText) => { VPNAuthInApp.verifySessionEmailCode(inputText) }
-        _buttonText: "Verify"
+        _buttonText: VPNl18n.InAppAuthVerifySecurityCodeButton
         _inputMethodHints: Qt.ImhDigitsOnly
-        _inputPlaceholderText: "Enter 6 digit code"
+        _inputPlaceholderText: VPNl18n.InAppAuthVerificationCodeInputPlaceholder
     }
 
     _footerContent: Column {
@@ -51,18 +51,12 @@ VPNInAppAuthenticationBase {
         spacing: VPNTheme.theme.windowMargin
 
         VPNLinkButton {
-            labelText: "Resend code"
+            labelText: VPNl18n.InAppAuthResendCodeLink
             anchors.horizontalCenter: parent.horizontalCenter
             onClicked: VPNAuthInApp.resendVerificationSessionCodeEmail();
         }
 
-        VPNLinkButton {
-            labelText: "Cancel"
-            fontName: VPNTheme.theme.fontBoldFamily
-            anchors.horizontalCenter: parent.horizontalCenter
-            linkColor: VPNTheme.theme.redButton
-            onClicked: VPNAuthInApp.reset()
-        }
+        VPNInAppAuthenticationCancel{}
 
     }
 

--- a/src/ui/authenticationInApp/ViewAuthenticationVerificationSessionByTotpNeeded.qml
+++ b/src/ui/authenticationInApp/ViewAuthenticationVerificationSessionByTotpNeeded.qml
@@ -28,28 +28,23 @@ VPNInAppAuthenticationBase {
 
     _menuButtonImageSource: "qrc:/nebula/resources/close-dark.svg"
     _menuButtonOnClick: () => { VPN.cancelAuthentication() }
-    _menuButtonAccessibleName: "TODO: Lorum Ipsum - Back"
-    _headlineText: "Enter 2-factor auth code"
-    _subtitleText: "Enter 6-digit code"
+    _menuButtonAccessibleName: qsTrId("vpn.connectionInfo.close")
+    _headlineText: VPNl18n.InAppAuthSecurityCodeTitle
+    _subtitleText: VPNl18n.InAppAuthSecurityCodeSubtitle
     _imgSource: "qrc:/nebula/resources/verification-code.svg"
-    _inputLabel: "Enter code"
+    _inputLabel: VPNl18n.InAppAuthSecurityCodeLabel
 
     _inputs: VPNInAppAuthenticationInputs {
         _buttonEnabled: VPNAuthInApp.state === VPNAuthInApp.StateVerificationSessionByTotpNeeded && !activeInput().hasError
         _buttonOnClicked: (inputText) => { VPNAuthInApp.verifySessionTotpCode(inputText) }
-        _buttonText: "Continue"
+        _buttonText: VPNl18n.InAppAuthVerifySecurityCodeButton
         _inputMethodHints: Qt.ImhDigitsOnly
-        _inputPlaceholderText: "Enter 2-factor auth code"
+        _inputPlaceholderText: VPNl18n.InAppAuthVerificationCodeInputPlaceholder
     }
 
     _footerContent: Column {
         Layout.alignment: Qt.AlignHCenter
-        VPNLinkButton {
-            labelText: "Cancel"
-            fontName: VPNTheme.theme.fontBoldFamily
-            anchors.horizontalCenter: parent.horizontalCenter
-            linkColor: VPNTheme.theme.redButton
-            onClicked: VPN.cancelAuthentication()
-        }
+
+        VPNInAppAuthenticationCancel {}
     }
 }


### PR DESCRIPTION
This PR adds two components to consolidate content/copypasta 
- Adds VPNInAppAuthenticationLegalDisclaimer.qml to consolidate legal disclaimer content & reduce copyDuping
- Adds VPNInAppAuthenticationCancel.qml to consolidate cancel button content & reduce copyDuping
- Replaces _most_ (two errors will be addressed in a follow-up) hard-coded content with string IDs.
- Adds missing headline el to VPNInAppAuthenticationPopup.qml

