### PR TITLE
Revise password hint behavior in create password view

### DIFF
--- a/nebula/ui/components/inAppAuth/VPNInAppAuthenticationInputs.qml
+++ b/nebula/ui/components/inAppAuth/VPNInAppAuthenticationInputs.qml
@@ -99,16 +99,22 @@ ColumnLayout {
                     spacing: VPNTheme.theme.windowMargin / 2
 
                     VPNInAppAuthenticationPasswordCondition {
+                        id: passwordLength
+                        _iconVisible: true
                         _passwordConditionIsSatisfied: toolTip._isSignUp && VPNAuthInApp.validatePasswordLength(passwordInput.text)
-                        _passwordConditionDescription:  VPNl18n.InAppAuthPasswordHintCharacterLength
+                        _passwordConditionDescription: VPNl18n.InAppAuthPasswordHintCharacterLength
                     }
                     VPNInAppAuthenticationPasswordCondition {
-                        _passwordConditionIsSatisfied: toolTip._isSignUp && VPNAuthInApp.validatePasswordEmail(passwordInput.text)
-                        _passwordConditionDescription:  VPNl18n.InAppAuthPasswordHintEmailAddressAsPassword
+                        _iconVisible: passwordLength._passwordConditionIsSatisfied
+                        _passwordConditionIsSatisfied: toolTip._isSignUp && passwordLength._passwordConditionIsSatisfied && VPNAuthInApp.validatePasswordEmail(passwordInput.text)
+                        _passwordConditionDescription: VPNl18n.InAppAuthPasswordHintEmailAddressAsPassword
+                        opacity: passwordLength._passwordConditionIsSatisfied ? 1 : .5
                     }
                     VPNInAppAuthenticationPasswordCondition {
-                        _passwordConditionIsSatisfied: toolTip._isSignUp && passwordInput.text.length > 0 && VPNAuthInApp.validatePasswordCommons(passwordInput.text)
-                        _passwordConditionDescription:  VPNl18n.InAppAuthPasswordHintCommonPassword
+                        _iconVisible:  passwordLength._passwordConditionIsSatisfied
+                        _passwordConditionIsSatisfied: toolTip._isSignUp && passwordLength._passwordConditionIsSatisfied && VPNAuthInApp.validatePasswordCommons(passwordInput.text)
+                        _passwordConditionDescription: VPNl18n.InAppAuthPasswordHintCommonPassword
+                        opacity: _iconVisible ? 1 : .5
                     }
                 }
             }

--- a/nebula/ui/components/inAppAuth/VPNInAppAuthenticationPasswordCondition.qml
+++ b/nebula/ui/components/inAppAuth/VPNInAppAuthenticationPasswordCondition.qml
@@ -10,15 +10,20 @@ import components 0.1
 import components.forms 0.1
 
 RowLayout {
-
+    id: root
+    property alias _iconVisible: icon.visible
     property bool _passwordConditionIsSatisfied: false
     property alias _passwordConditionDescription: passwordConditionDescription.text
 
-    VPNIcon {
-        source: parent._passwordConditionIsSatisfied ? "qrc:/nebula/resources/check-green70.svg" : "qrc:/nebula/resources/x-red50.svg"
-        sourceSize.width: VPNTheme.theme.iconSize * 1.25
-        sourceSize.height: VPNTheme.theme.iconSize * 1.25
+    Rectangle {
+        Layout.preferredHeight: VPNTheme.theme.iconSize * 1.25
+        Layout.preferredWidth: VPNTheme.theme.iconSize * 1.25
         Layout.alignment: Qt.AlignTop
+        VPNIcon {
+            id: icon
+            source: root._passwordConditionIsSatisfied ? "qrc:/nebula/resources/check-green70.svg" : "qrc:/nebula/resources/x-red50.svg"
+            anchors.fill: parent
+        }
     }
 
     Text {


### PR DESCRIPTION
This PR tweaks the way we show password rules in the password creation screen.
We now:
- Dim the opacity of 'Must not be common password" and "Must not be email" rules until "Must be at least 8 characters" is satisfied. 
- Hide the red "X" images beside 'Must not be common password" and "Must not be email" rules until "Must be at least 8 characters" is satisfied. 
<img width="362" alt="Screen Shot 2022-03-15 at 6 18 46 PM" src="https://user-images.githubusercontent.com/22355127/158489868-95358b24-bb98-45b6-b7a2-2b3216de572c.png">
<img width="362" alt="Screen Shot 2022-03-15 at 6 18 29 PM" src="https://user-images.githubusercontent.com/22355127/158489895-7226258b-23fa-4508-aa55-433faa1e0855.png">
<img width="364" alt="Screen Shot 2022-03-15 at 6 18 13 PM" src="https://user-images.githubusercontent.com/22355127/158489908-f93a81a3-a915-4645-92bc-3f92ef5ed572.png">

