### PR TITLE
Fix #3026 - Submit auth forms on 'Enter' clicks only when submit buttons are enabled

### DIFF
--- a/nebula/ui/components/inAppAuth/VPNInAppAuthenticationInputs.qml
+++ b/nebula/ui/components/inAppAuth/VPNInAppAuthenticationInputs.qml
@@ -31,7 +31,7 @@ ColumnLayout {
 
     ColumnLayout {
         function submitInfo(input) {
-            if (!input.hasError && input.text.length > 0) btn.clicked();
+            if (!input.hasError && input.text.length > 0 && btn.enabled) btn.clicked();
         }
 
         id: col


### PR DESCRIPTION
Fixes #3026 
This prevents auth forms from being submitted when the user clicks 'Enter' or taps 'Done' on mobile native keyboards if the form's submit button is disabled.