### PR TITLE
Disable VPNToggle when Connection Info Screen is open

### DIFF
--- a/nebula/ui/components/VPNControllerView.qml
+++ b/nebula/ui/components/VPNControllerView.qml
@@ -597,7 +597,9 @@ Item {
         z: 1
 
         onClicked: {
-            Sample.connectionInfoOpened.record();
+            if (!box.connectionInfoScreenVisible) {
+                Sample.connectionInfoOpened.record();
+            }
             box.connectionInfoScreenVisible = !box.connectionInfoScreenVisible;
         }
 
@@ -826,7 +828,7 @@ Item {
 
         VPNConnectionStability {
             id: connectionStability
-            Accessible.ignored: connectionInfoVisible || !visible
+            Accessible.ignored: connectionInfoScreenVisible || !visible
             width: parent.width
             implicitHeight: childrenRect.height
         }
@@ -841,8 +843,8 @@ Item {
         anchors.bottomMargin: 48
         anchors.horizontalCenterOffset: 0
         anchors.horizontalCenter: parent.horizontalCenter
-        Accessible.ignored: connectionInfoVisible
-        enabled: !connectionInfoVisible
+        Accessible.ignored: connectionInfoScreenVisible
+        enabled: !connectionInfoScreenVisible
     }
 
     VPNConnectionInfo {


### PR DESCRIPTION
This PR disables the VPNToggle while the Connection Info Screen is open. Additionally `Sample.connectionInfoOpened.record()` is now only called when opening the view and not when closing as well.