### PR TITLE
Fix way to enable debug features for Glean

### DIFF
--- a/src/ui/main.qml
+++ b/src/ui/main.qml
@@ -309,13 +309,10 @@ Window {
         }
 
         function onInitializeGlean() {
-            var debug = {};
             if (VPN.debugMode) {
                 console.debug("Initializing glean with debug mode");
-                debug = {
-                    logPings: true,
-                    debugViewTag: "MozillaVPN"
-                };
+                Glean.setLogPings(true);
+                Glean.setDebugViewTag("MozillaVPN");
             }
             var channel = VPN.stagingMode ? "staging" : "production";
             console.debug("Initializing glean with channel set to:", channel);
@@ -323,7 +320,6 @@ Window {
                 appBuild: "MozillaVPN/" + VPN.versionString,
                 appDisplayVersion: VPN.versionString,
                 channel: channel,
-                debug: debug,
                 osVersion: VPN.osVersion,
                 architecture: VPN.architecture,
             });

--- a/tests/qml/tst_mainWindowGleanMocks.qml
+++ b/tests/qml/tst_mainWindowGleanMocks.qml
@@ -18,6 +18,8 @@ Item {
         property var spyUploadEnabledInitialize
         property var spyConfig
         property var spyTags
+        property var spyLogPings
+        property var spySetDebugViewTag
         property var spyShutdownCalled: false
         property var spyUploadEnabled
 
@@ -34,6 +36,14 @@ Item {
                 spyTags = tags
             }
             Glean.setSourceTags = mockGleanSetSourceTags;
+            function mockGleanSetLogPings(flag) {
+                spyLogPings = flag
+            }
+            Glean.setLogPings = mockGleanSetLogPings;
+            function mockGleanSetDebugViewTag(tag) {
+                spySetDebugViewTag = tag
+            }
+            Glean.setDebugViewTag = mockGleanSetDebugViewTag;
             function mockGleanShutdown() {
                 // Should be false before setting it to true in this function.
                 // Helps protect us from bad testing state.
@@ -101,13 +111,13 @@ Item {
         function test_onInitializeGleanByDebugMode() {
             TestHelper.debugMode = false
             TestHelper.triggerInitializeGlean()
-            compare(spyConfig.debug.logPings, undefined)
-            compare(spyConfig.debug.debugViewTag, undefined)
+            compare(spyLogPings, undefined)
+            compare(spySetDebugViewTag, undefined)
 
             TestHelper.debugMode = true
             TestHelper.triggerInitializeGlean()
-            compare(spyConfig.debug.logPings, true)
-            compare(spyConfig.debug.debugViewTag, "MozillaVPN")
+            compare(spyLogPings, true)
+            compare(spySetDebugViewTag, "MozillaVPN")
         }
 
         /*


### PR DESCRIPTION
Hey folks, I noticed this issue while going through the code. 

This was our bad for not communicating the change better to our users, but in [v0.27.0](https://github.com/mozilla/glean.js/releases/tag/v0.27.0) Glean.js removed the `debug` option for the configration object. So the way that was set up right now would just be ignored by Glean.

This PR addresses that issue.