### PR TITLE
Android: Do not block UI thread for ipc

### DIFF
--- a/src/platforms/android/androidcontroller.cpp
+++ b/src/platforms/android/androidcontroller.cpp
@@ -268,9 +268,7 @@ void AndroidController::startActivityForResult(JNIEnv* env, jobject /*thiz*/,
 
     if (resultCode == ACTIVITY_RESULT_OK) {
       logger.debug() << "VPN PROMPT RESULT - Accepted";
-      AndroidUtils::dispatchToMainThread(
-          [&] { s_instance->resume_activate(); });
-
+      s_instance->resume_activate();
       return;
     }
     // If the request got rejected abort the current

--- a/src/platforms/android/androidvpnactivity.cpp
+++ b/src/platforms/android/androidvpnactivity.cpp
@@ -74,13 +74,11 @@ void AndroidVPNActivity::sendToService(ServiceAction type,
   if (!Constants::inProduction()) {
     logger.debug() << "sendToService: " << messageType << " " << data;
   }
-  AndroidUtils::runOnAndroidThreadSync([messageType, &data]() {
-    QJniEnvironment env;
-    QJniObject::callStaticMethod<void>(
-        CLASSNAME, "sendToService", "(ILjava/lang/String;)V",
-        static_cast<int>(messageType),
-        QJniObject::fromString(data).object<jstring>());
-  });
+  QJniEnvironment env;
+  QJniObject::callStaticMethod<void>(
+      CLASSNAME, "sendToService", "(ILjava/lang/String;)V",
+      static_cast<int>(messageType),
+      QJniObject::fromString(data).object<jstring>());
 }
 
 // static


### PR DESCRIPTION
We're deadlocking the UI and Qt thread, after you press "yes" on the permission prompt it seems. (on signed, release builds only )
Thinking about it, there is no reason to 
A: move `s_instance->resume_activate()`to the QT-Main thread anymore, as now IPC is no longer handled by QTIBinder.
B: Force "AndroidActivity::sendToService" to be on the Android-UI thread; it does not have side effects and the transaction later is happening on the ipc thread anyway. 

Should close https://github.com/mozilla-mobile/mozilla-vpn-client/issues/2774

Update: Got confirmation of QA that this fixes the issue. 