### PR TITLE
Re-enable native multihop support via LocalSocketController

### DIFF
--- a/src/localsocketcontroller.h
+++ b/src/localsocketcontroller.h
@@ -34,6 +34,8 @@ class LocalSocketController final : public ControllerImpl {
 
   void cleanupBackendLogs() override;
 
+  bool multihopSupported() override { return true; }
+
  private:
   void initializeInternal();
   void disconnectInternal();


### PR DESCRIPTION
While refactoring the `ControllerImpl` class to support the new "Port 53/DNS" option, we added a new API to check if the platform supports multihop. Unfortunately, this was left unimplemented for the `LocalSocketController` which meant that Mac and Windows were falling back to the Mullvad multihop port, which conflicts with the "Port 53/DNS" option.

Closes: #3123 