### PR TITLE
Invoke glean_parser as a module.

### DIFF
--- a/scripts/utils/generate_glean.py
+++ b/scripts/utils/generate_glean.py
@@ -3,6 +3,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import sys
 import os.path
 import yaml
 import subprocess
@@ -85,7 +86,7 @@ output.close();
 
 print("Generating the JS modules...")
 try:
-  subprocess.call(["glean_parser", "translate", "glean/metrics.yaml", "glean/pings.yaml",
+  subprocess.call([sys.executable, "-m", "glean_parser", "translate", "glean/metrics.yaml", "glean/pings.yaml",
                    "-f", "javascript", "-o", "glean/telemetry", "--option", "platform=qt",
                    "--option", "version=0.30"])
 except:


### PR DESCRIPTION
In the upgrade from Windows 10 --> 11. Microsoft has decided to install yet another copy of python at some incomprehensible path, and this led to a conflicts between the location of `python.exe`, `pip.exe`, `glean_parser.exe` and the module location all of which being slightly incompatible with one another. I have attached a diagram of my situation...

![python environment](https://imgs.xkcd.com/comics/python_environment.png)

To resolve the build situation I have found myself in, let's ensure that we invoke the `glean_parser` using the current python interpreter. This is effectively the same as replacing `glean_parser --foo=bar` with `python -m glean_parser --foo=bar` 