### PR TITLE
Run Connection info animation only once

### DIFF
--- a/nebula/ui/components/VPNConnectionInfoContent.qml
+++ b/nebula/ui/components/VPNConnectionInfoContent.qml
@@ -75,6 +75,7 @@ Flickable {
 
             VPNLottieAnimation {
                 id: speedometerAnimation
+                loop: false
                 source: ":/nebula/resources/animations/speedometer_animation.json"
             }
         }


### PR DESCRIPTION
Only run the speedometer animation on the Connection info view once.