### PR TITLE
Tunnel log entries were not decoded correctly

### DIFF
--- a/src/platforms/windows/daemon/windowstunnellogger.cpp
+++ b/src/platforms/windows/daemon/windowstunnellogger.cpp
@@ -101,15 +101,14 @@ void WindowsTunnelLogger::process(int index) {
   uchar* data = m_logdata + RINGLOG_HEADER_SIZE + offset;
 
   quint64 timestamp;
-  memcpy(&timestamp, data, 8);
+  memcpy(&timestamp, data, RINGLOG_TIMESTAMP_SIZE);
   if (timestamp <= m_startTime) {
     return;
   }
-
   QByteArray message((const char*)data + RINGLOG_TIMESTAMP_SIZE,
                      RINGLOG_MESSAGE_SIZE);
   int nullIndex = message.indexOf(0x0);
-  if (nullIndex > 0) {
+  if (nullIndex >= 0) {
     message.truncate(nullIndex);
   }
   logger.info() << QString::fromUtf8(message);

--- a/src/platforms/windows/daemon/windowstunnellogger.cpp
+++ b/src/platforms/windows/daemon/windowstunnellogger.cpp
@@ -96,7 +96,8 @@ int WindowsTunnelLogger::nextIndex() {
 void WindowsTunnelLogger::process(int index) {
   Q_ASSERT(index >= 0);
   Q_ASSERT(index < RINGLOG_MAX_ENTRIES);
-  size_t offset = index * (RINGLOG_TIMESTAMP_SIZE + RINGLOG_MESSAGE_SIZE);
+  size_t offset = static_cast<size_t>(index) *
+                  (RINGLOG_TIMESTAMP_SIZE + RINGLOG_MESSAGE_SIZE);
   uchar* data = m_logdata + RINGLOG_HEADER_SIZE + offset;
 
   quint64 timestamp;
@@ -107,6 +108,10 @@ void WindowsTunnelLogger::process(int index) {
 
   QByteArray message((const char*)data + RINGLOG_TIMESTAMP_SIZE,
                      RINGLOG_MESSAGE_SIZE);
+  int nullIndex = message.indexOf(0x0);
+  if (nullIndex > 0) {
+    message.truncate(nullIndex);
+  }
   logger.info() << QString::fromUtf8(message);
 }
 


### PR DESCRIPTION
On windows, the conversion from the fixed length buffer read from the tunnel's ringbuffer resulted in a 512b fixed length string being written to the log.  When encoded and sent to guardian for a support request that turned in to 512 /u0000s which caused it to be rejected by FxA for length.
I now truncate the buffer before conversion.  Also fixed a casting issue that was causing a warning.