### PR TITLE
Create the dump folder

### DIFF
--- a/src/crashreporter/platforms/windows/windowscrashclient.cpp
+++ b/src/crashreporter/platforms/windows/windowscrashclient.cpp
@@ -10,8 +10,9 @@
 #include <Windows.h>
 #include <sstream>
 #include <codecvt>
-
-#include <crashreporter/crashreporterapp.h>
+#include <QStandardPaths>
+#include <QDir>
+#include "crashreporter/crashreporterapp.h"
 using namespace std;
 
 namespace {
@@ -35,6 +36,11 @@ WindowsCrashClient::WindowsCrashClient() {}
 WindowsCrashClient::~WindowsCrashClient() {}
 
 bool WindowsCrashClient::start(int argc, char* argv[]) {
+  auto appDatas =
+      QStandardPaths::standardLocations(QStandardPaths::AppLocalDataLocation);
+  auto appLocal = appDatas.first() + "\\dumps";
+  QDir().mkpath(appLocal);
+
   m_launchPath = argv[0];
   if (!SUCCEEDED(RegisterApplicationRecoveryCallback(RecoveryCallback, this,
                                                      30000, 0))) {


### PR DESCRIPTION
It seem WER will not create the dump folder on it's own.  We need to make sure it is there to get the dumps written out.