### PR TITLE
Allow the lib path to be set during build config

### DIFF
--- a/src/qmake/platforms/linux.pri
+++ b/src/qmake/platforms/linux.pri
@@ -141,7 +141,7 @@ INSTALLS += systemd_service
 
 ORIG_MOZILLAVPN_JSON = $$PWD/../../../extension/manifests/linux/mozillavpn.json
 manifestFile.input = ORIG_MOZILLAVPN_JSON
-manifestFile.output = $$PWD/../../../linux/mozillavpn.json
+manifestFile.output = $${OBJECTS_DIR}/mozillavpn.json
 manifestFile.commands = @python3 -c \'with open(\"$$ORIG_MOZILLAVPN_JSON\") as fin, open(\"$$manifestFile.output\", \"w\") as fout: [print(l.replace(\"/usr/lib/\", \"$${LIBPATH}/\"), end=\"\", file=fout) for l in fin]\'
 manifestFile.CONFIG = target_predeps no_link
 QMAKE_EXTRA_COMPILERS += manifestFile

--- a/src/qmake/platforms/linux.pri
+++ b/src/qmake/platforms/linux.pri
@@ -79,6 +79,9 @@ HEADERS += \
 isEmpty(USRPATH) {
     USRPATH=/usr
 }
+isEmpty(LIBPATH) {
+    LIBPATH=$${USRPATH}/lib
+}
 isEmpty(ETCPATH) {
     ETCPATH=/etc
 }
@@ -136,20 +139,33 @@ systemd_service.files = $$PWD/../../../linux/mozillavpn.service
 systemd_service.path = $${USRPATH}/lib/systemd/system
 INSTALLS += systemd_service
 
-manifestFirefox.files = $$PWD/../../../extension/manifests/linux/mozillavpn.json
-manifestFirefox.path = $${USRPATH}/lib/mozilla/native-messaging-hosts
+ORIG_MOZILLAVPN_JSON = $$PWD/../../../extension/manifests/linux/mozillavpn.json
+manifestFile.input = ORIG_MOZILLAVPN_JSON
+manifestFile.output = $$PWD/../../../linux/mozillavpn.json
+manifestFile.commands = @$(SED) \'/\"path\":/c\ \ \"path\":\ \"$${LIBPATH}/mozillavpn/mozillavpnnp\",\' $$ORIG_MOZILLAVPN_JSON >  $$manifestFile.output
+manifestFile.CONFIG = target_predeps no_link
+QMAKE_EXTRA_COMPILERS += manifestFile
+
+manifestFirefox.files = $$manifestFile.output
+manifestFirefox.path = $${LIBPATH}/mozilla/native-messaging-hosts
+manifestFirefox.depends = $$manifestFile.output
+manifestFirefox.CONFIG = no_check_exist
 INSTALLS += manifestFirefox
 
-manifestChrome.files = $$PWD/../../../extension/manifests/linux/mozillavpn.json
+manifestChrome.files = $$manifestFile.output
 manifestChrome.path = $${ETCPATH}/opt/chrome/native-messaging-hosts
+manifestChrome.depends = $$manifestFile.output
+manifestChrome.CONFIG = no_check_exist
 INSTALLS += manifestChrome
 
-manifestChromium.files = $$PWD/../../../extension/manifests/linux/mozillavpn.json
+manifestChromium.files = $$manifestFile.output
 manifestChromium.path = $${ETCPATH}/chromium/native-messaging-hosts
+manifestChromium.depends = $$manifestFile.output
+manifestChromium.CONFIG = no_check_exist
 INSTALLS += manifestChromium
 
 browserBridge.files = $$PWD/../../../extension/bridge/target/release/mozillavpnnp
-browserBridge.path = $${USRPATH}/lib/mozillavpn
+browserBridge.path = $${LIBPATH}/mozillavpn
 browserBridge.CONFIG = no_check_exist executable
 INSTALLS += browserBridge
 

--- a/src/qmake/platforms/linux.pri
+++ b/src/qmake/platforms/linux.pri
@@ -142,7 +142,7 @@ INSTALLS += systemd_service
 ORIG_MOZILLAVPN_JSON = $$PWD/../../../extension/manifests/linux/mozillavpn.json
 manifestFile.input = ORIG_MOZILLAVPN_JSON
 manifestFile.output = $${OBJECTS_DIR}/mozillavpn.json
-manifestFile.commands = @python3 -c \'with open(\"$$ORIG_MOZILLAVPN_JSON\") as fin, open(\"$$manifestFile.output\", \"w\") as fout: [print(l.replace(\"/usr/lib/\", \"$${LIBPATH}/\"), end=\"\", file=fout) for l in fin]\'
+manifestFile.commands = @python3 -c \'with open(\"$$ORIG_MOZILLAVPN_JSON\") as fin, open(\"$$manifestFile.output\", \"w\") as fout: print(\"\".join(fin).replace(\"/usr/lib/\", \"$${LIBPATH}/\"), end=\"\", file=fout)\'
 manifestFile.CONFIG = target_predeps no_link
 QMAKE_EXTRA_COMPILERS += manifestFile
 

--- a/src/qmake/platforms/linux.pri
+++ b/src/qmake/platforms/linux.pri
@@ -142,7 +142,7 @@ INSTALLS += systemd_service
 ORIG_MOZILLAVPN_JSON = $$PWD/../../../extension/manifests/linux/mozillavpn.json
 manifestFile.input = ORIG_MOZILLAVPN_JSON
 manifestFile.output = $$PWD/../../../linux/mozillavpn.json
-manifestFile.commands = @$(SED) \'/\"path\":/c\ \ \"path\":\ \"$${LIBPATH}/mozillavpn/mozillavpnnp\",\' $$ORIG_MOZILLAVPN_JSON >  $$manifestFile.output
+manifestFile.commands = @python3 -c \'with open(\"$$ORIG_MOZILLAVPN_JSON\") as fin, open(\"$$manifestFile.output\", \"w\") as fout: [print(l.replace(\"/usr/lib/\", \"$${LIBPATH}/\"), end=\"\", file=fout) for l in fin]\'
 manifestFile.CONFIG = target_predeps no_link
 QMAKE_EXTRA_COMPILERS += manifestFile
 


### PR DESCRIPTION
Some firefox builds (all 64-bit builds? just some?) look for the `native-messaging-hosts` under `/usr/lib64/native-messaging-hosts`. These changes allow to build for those systems with `qmake ... LIBPATH=/usr/lib64`.

The manifest file is now also updated to contain the install-configured path to the `mozillavpnnp` binary, rather than the hardcoded default path as previously.  Changes to `USRPATH` (or the new `LIBPATH`) previously caused the installed json file to point to a wrong location.

The sed command does not depend on the current path in the file and just replaces the line that contains ”path” with the appropriate path. Not sure this is optimal, but it works. An alternate way that depends on the current path (not sure it’s more readable) could be something like:
```
manifestFile.commands = @$(SED) \'s,\"path\":\ *"/usr/lib/,\"path\":\ \"$${LIBPATH}/,\' $$ORIG_MOZILLAVPN_JSON >  $$manifestFile.output
```

Finally the `mozillavpnnp` binary is now also installed to the directory of appropriate bitness as selected by the `LIBPATH` variable.

Allows fixing mozilla/multi-account-containers#2315 at build time instead of manually doing `sudo mv /usr/lib/… /usr/lib64/…`