### PR TITLE
Fix The Whitebox issues on android 11+

### DIFF
--- a/nebula/ui/components/VPNAboutUs.qml
+++ b/nebula/ui/components/VPNAboutUs.qml
@@ -67,7 +67,7 @@ Item {
         anchors.rightMargin: VPNTheme.theme.windowMargin
         height: childrenRect.height
         width: viewAboutUs.width - (VPNTheme.theme.windowMargin * 2)
-        color: "transparent"
+        color: VPNTheme.theme.transparent
 
         VPNBoldLabel {
             id: mozillaLabel

--- a/nebula/ui/components/VPNAlert.qml
+++ b/nebula/ui/components/VPNAlert.qml
@@ -183,7 +183,7 @@ Rectangle {
         Rectangle {
             id: labelWrapper
             height: label.paintedHeight + VPNTheme.theme.windowMargin
-            color: "transparent"
+            color: VPNTheme.theme.transparent
             anchors.left: alertAction.left
             width: alertAction.width - VPNTheme.theme.rowHeight
             anchors.verticalCenter: parent.verticalCenter
@@ -306,16 +306,16 @@ Rectangle {
         id: focusIndicators
         anchors.fill: closeButton.activeFocus ? closeButton : alertAction
         anchors.margins: -3
-        border.color: colorScheme ? colorScheme.focusOutline : "transparent"
+        border.color: colorScheme ? colorScheme.focusOutline : VPNTheme.theme.transparent
         border.width: 3
         visible: closeButton.activeFocus || alertAction.activeFocus
-        color: "transparent"
+        color: VPNTheme.theme.transparent
         radius: VPNTheme.theme.cornerRadius + (anchors.margins * -1)
 
         Rectangle {
-            color: "transparent"
+            color: VPNTheme.theme.transparent
             border.width: 2
-            border.color: parent.colorScheme ? parent.colorScheme.focusBorder : "transparent"
+            border.color: parent.colorScheme ? parent.colorScheme.focusBorder : VPNTheme.theme.transparent
             radius: VPNTheme.theme.cornerRadius
             anchors.fill: parent
             anchors.margins: 3

--- a/nebula/ui/components/VPNButtonBase.qml
+++ b/nebula/ui/components/VPNButtonBase.qml
@@ -59,7 +59,7 @@ RoundButton {
     }
 
     background: Rectangle {
-        color: "transparent"
+        color: VPNTheme.theme.transparent
     }
 
 }

--- a/nebula/ui/components/VPNCallout.qml
+++ b/nebula/ui/components/VPNCallout.qml
@@ -20,7 +20,7 @@ RowLayout {
     Rectangle {
         Layout.preferredHeight: 24
         Layout.preferredWidth: 24
-        color: "transparent"
+        color: VPNTheme.theme.transparent
 
         VPNIcon {
             id: img

--- a/nebula/ui/components/VPNCheckBoxAlert.qml
+++ b/nebula/ui/components/VPNCheckBoxAlert.qml
@@ -22,7 +22,7 @@ RowLayout {
     anchors.leftMargin: VPNTheme.theme.windowMargin
 
     Rectangle {
-        color: "transparent"
+        color: VPNTheme.theme.transparent
         Layout.preferredHeight: message.lineHeight
         Layout.maximumHeight: message.lineHeight
         Layout.preferredWidth: VPNTheme.theme.iconSizeSmall

--- a/nebula/ui/components/VPNCheckBoxRow.qml
+++ b/nebula/ui/components/VPNCheckBoxRow.qml
@@ -40,7 +40,7 @@ RowLayout {
         visible: showAppImage
         Layout.preferredWidth: VPNTheme.theme.windowMargin * 2
         Layout.preferredHeight: VPNTheme.theme.windowMargin * 2
-        color: "transparent"
+        color: VPNTheme.theme.transparent
         radius: 4
         Layout.alignment: Qt.AlignTop
 

--- a/nebula/ui/components/VPNCheckmark.qml
+++ b/nebula/ui/components/VPNCheckmark.qml
@@ -25,7 +25,7 @@ Item {
         antialiasing: true
         smooth: true
         visible: false
-        color: "transparent"
+        color: VPNTheme.theme.transparent
 
         Behavior on color {
             PropertyAnimation {

--- a/nebula/ui/components/VPNClickableRow.qml
+++ b/nebula/ui/components/VPNClickableRow.qml
@@ -50,8 +50,8 @@ VPNButtonBase {
         anchors.top: mainRow.top
         radius: VPNTheme.theme.cornerRadius
         border.width: VPNTheme.theme.focusBorderWidth
-        border.color: "transparent"
-        color: "transparent"
+        border.color: VPNTheme.theme.transparent
+        color: VPNTheme.theme.transparent
         opacity: rowVisualStates.state === VPNTheme.theme.uiState.stateFocused
             ? 1
             : 0

--- a/nebula/ui/components/VPNConnectionStability.qml
+++ b/nebula/ui/components/VPNConnectionStability.qml
@@ -94,7 +94,7 @@ Item {
             Rectangle {
                 height: 16
                 width: VPNTheme.theme.iconSizeSmall
-                color: "transparent"
+                color: VPNTheme.theme.transparent
 
                 Image {
                     id: warningIcon

--- a/nebula/ui/components/VPNDevicesListHeader.qml
+++ b/nebula/ui/components/VPNDevicesListHeader.qml
@@ -62,7 +62,7 @@ Item {
         anchors.top: listHeader.top
         height: VPNTheme.theme.windowMargin * 2
         width: listHeader.width
-        color: "transparent"
+        color: VPNTheme.theme.transparent
     }
 
     VPNPanel {
@@ -84,7 +84,7 @@ Item {
         anchors.top: vpnPanel.bottom
         height: VPNTheme.theme.windowMargin * 2
         width: listHeader.width
-        color: "transparent"
+        color: VPNTheme.theme.transparent
     }
 
 }

--- a/nebula/ui/components/VPNExpandableAppList.qml
+++ b/nebula/ui/components/VPNExpandableAppList.qml
@@ -159,7 +159,7 @@ ColumnLayout {
         contentItem: Text {
             // for accessibility
             text: addApplication
-            color: "transparent"
+            color: VPNTheme.theme.transparent
         }
 
         RowLayout {

--- a/nebula/ui/components/VPNFeedbackRadioDelegate.qml
+++ b/nebula/ui/components/VPNFeedbackRadioDelegate.qml
@@ -58,7 +58,7 @@ RadioDelegate {
 
     background: VPNFocusOutline {
             opacity: radio.checked || radio.activeFocus ? 1 : 0
-            color: "transparent"
+            color: VPNTheme.theme.transparent
             border.width: 4
             border.color: VPNTheme.theme.blueFocusOutline
             anchors.margins: 2

--- a/nebula/ui/components/VPNFlickable.qml
+++ b/nebula/ui/components/VPNFlickable.qml
@@ -81,7 +81,7 @@ Flickable {
         anchors.rightMargin: Qt.platform.os === "osx" ? 2 : 0
 
         background: Rectangle {
-            color: "transparent"
+            color: VPNTheme.theme.transparent
             anchors.fill: parent
         }
 

--- a/nebula/ui/components/VPNFocusBorder.qml
+++ b/nebula/ui/components/VPNFocusBorder.qml
@@ -10,7 +10,7 @@ Rectangle {
 
     id: focusInnerBorder
 
-    color: "transparent"
+    color: VPNTheme.theme.transparent
     anchors.fill: parent
     radius: parent.radius
     border.width: VPNTheme.theme.focusBorderWidth

--- a/nebula/ui/components/VPNLinkButton.qml
+++ b/nebula/ui/components/VPNLinkButton.qml
@@ -88,7 +88,7 @@ VPNButtonBase {
 
     background: Rectangle {
         id: backgroundRect
-        color: "transparent"
+        color: VPNTheme.theme.transparent
     }
 
     contentItem: Label {

--- a/nebula/ui/components/VPNMainImage.qml
+++ b/nebula/ui/components/VPNMainImage.qml
@@ -12,7 +12,7 @@ Rectangle {
 
     property var showVPNOnIcon: false
 
-    color: "transparent"
+    color: VPNTheme.theme.transparent
     opacity: 1
     states: [
         State {

--- a/nebula/ui/components/VPNRadioDelegate.qml
+++ b/nebula/ui/components/VPNRadioDelegate.qml
@@ -119,7 +119,7 @@ RadioDelegate {
     }
 
     background: Rectangle {
-        color: "transparent"
+        color: VPNTheme.theme.transparent
     }
 
     VPNMouseArea {

--- a/nebula/ui/components/VPNServerList.qml
+++ b/nebula/ui/components/VPNServerList.qml
@@ -74,7 +74,7 @@ FocusScope {
 
             height: VPNTheme.theme.vSpacing
             width: parent.width
-            color: "transparent"
+            color: VPNTheme.theme.transparent
         }
 
         NumberAnimation on contentY {

--- a/nebula/ui/components/VPNSettingsToggle.qml
+++ b/nebula/ui/components/VPNSettingsToggle.qml
@@ -73,7 +73,7 @@ CheckBox {
 
         anchors.fill: hoverPressHandler
         border.color: toggleColor.focusBorder
-        color: "transparent"
+        color: VPNTheme.theme.transparent
         anchors.margins: -1
         radius: 50
         opacity: vpnSettingsToggle.activeFocus ? 1: 0
@@ -158,7 +158,7 @@ CheckBox {
         id: uiPlaceholder /* Binding loop hack-around */
         height: 24
         width: 45
-        color: "transparent"
+        color: VPNTheme.theme.transparent
     }
 
     indicator:  VPNUIStates {

--- a/nebula/ui/components/VPNSubscriptionOption.qml
+++ b/nebula/ui/components/VPNSubscriptionOption.qml
@@ -83,7 +83,7 @@ RadioDelegate {
         Rectangle {
             anchors.fill: parent
             border.color: (radioDelegate.checked || radioDelegate.focus) ? VPNTheme.theme.purple60 : VPNTheme.theme.white
-            color: "transparent"
+            color: VPNTheme.theme.transparent
             radius: VPNTheme.theme.cornerRadius
 
             Behavior on border.color {

--- a/nebula/ui/components/VPNTabNavigation.qml
+++ b/nebula/ui/components/VPNTabNavigation.qml
@@ -37,7 +37,7 @@ Item {
         visible: stack.children.length > 1
         contentHeight: stack.children.length === 1 ? 0 : VPNTheme.theme.menuHeight
         background: Rectangle {
-            color: "transparent"
+            color: VPNTheme.theme.transparent
         }
 
         Repeater {
@@ -51,7 +51,7 @@ Item {
                 onClicked: handleTabClick(btn)
 
                 background: Rectangle {
-                    color: "transparent"
+                    color: VPNTheme.theme.transparent
 
                     Rectangle {
                         height: 2

--- a/nebula/ui/components/VPNToggle.qml
+++ b/nebula/ui/components/VPNToggle.qml
@@ -221,7 +221,7 @@ VPNButtonBase {
         anchors.margins: -4
         radius: height / 2
         border.color: toggleColor.focusBorder
-        color: "transparent"
+        color: VPNTheme.theme.transparent
         opacity: toggleButton.activeFocus && (VPNController.state === VPNController.StateOn || VPNController.state === VPNController.StateOff) ? 1 : 0
 
         VPNFocusOutline {
@@ -232,7 +232,7 @@ VPNButtonBase {
             setMargins: -6
             radius: height / 2
             border.width: 7
-            color: "transparent"
+            color: VPNTheme.theme.transparent
             border.color: toggleColor.focusOutline
             opacity: 0.25
         }

--- a/nebula/ui/components/VPNUIStates.qml
+++ b/nebula/ui/components/VPNUIStates.qml
@@ -21,7 +21,7 @@ Rectangle {
 
     anchors.fill: itemToAnchor
     antialiasing: true
-    color: "transparent"
+    color: VPNTheme.theme.transparent
     radius: VPNTheme.theme.cornerRadius
     z: -1
     states: [

--- a/nebula/ui/components/VPNVerticalSpacer.qml
+++ b/nebula/ui/components/VPNVerticalSpacer.qml
@@ -4,7 +4,9 @@
 
 import QtQuick 2.0
 
+import Mozilla.VPN 1.0
+
 Rectangle {
-    color: "transparent"
+    color: VPNTheme.theme.transparent
     width: parent.width
 }

--- a/nebula/ui/components/forms/VPNComboBox.qml
+++ b/nebula/ui/components/forms/VPNComboBox.qml
@@ -123,7 +123,7 @@ ComboBox {
                 anchors.fill: parent
                 anchors.bottomMargin: -4
                 anchors.topMargin: anchors.bottomMargin
-                border.color: "transparent"
+                border.color: VPNTheme.theme.transparent
             }
         }
 

--- a/nebula/ui/components/forms/VPNInputBackground.qml
+++ b/nebula/ui/components/forms/VPNInputBackground.qml
@@ -31,7 +31,7 @@ Rectangle {
         antialiasing: true
         border.color: itemToFocus && itemToFocus.hasError ? VPNTheme.colors.input.error.highlight : VPNTheme.colors.input.focus.highlight
         border.width: 4
-        color: "transparent"
+        color: VPNTheme.theme.transparent
         opacity: itemToFocus && itemToFocus.activeFocus && itemToFocus.showInteractionStates ? 1 : 0
         radius: parent.radius + anchors.margins * -1
         z: -1

--- a/nebula/ui/components/forms/VPNRadioButton.qml
+++ b/nebula/ui/components/forms/VPNRadioButton.qml
@@ -94,7 +94,7 @@ RadioDelegate {
     ]
 
     background: Rectangle {
-        color: "transparent"
+        color: VPNTheme.theme.transparent
     }
 
     VPNMouseArea {

--- a/nebula/ui/components/inAppAuth/VPNInAppAuthenticationBase.qml
+++ b/nebula/ui/components/inAppAuth/VPNInAppAuthenticationBase.qml
@@ -91,7 +91,7 @@ VPNFlickable {
             Layout.preferredWidth: col.width - VPNTheme.theme.vSpacing * 2
 
             Rectangle {
-                color: "transparent"
+                color: VPNTheme.theme.transparent
                 height: VPNTheme.theme.rowHeight * 2
                 Layout.preferredWidth: 100
                 Layout.alignment: Qt.AlignHCenter

--- a/nebula/ui/themes/themes.js
+++ b/nebula/ui/themes/themes.js
@@ -4,6 +4,8 @@
 
 const theme = {};
 
+theme.transparent = '#00000000';
+
 theme.bgColor = '#F9F9FA';
 theme.bgColor30 = '#4DF9F9FA';
 theme.bgColor80 = '#CCF9F9FA';

--- a/src/crashreporter/crashui/main.qml
+++ b/src/crashreporter/crashui/main.qml
@@ -37,7 +37,7 @@ Window {
     Rectangle {
         id: iosSafeAreaTopMargin
 
-        color: "transparent"
+        color: VPNTheme.theme.transparent
         height: marginHeightByDevice()
         width: window.width
         anchors.top: parent.top

--- a/src/ui/main.qml
+++ b/src/ui/main.qml
@@ -94,7 +94,7 @@ Window {
     Rectangle {
         id: iosSafeAreaTopMargin
 
-        color: "transparent"
+        color: VPNTheme.theme.transparent
         height: marginHeightByDevice()
         width: window.width
         anchors.top: parent.top

--- a/src/ui/settings/ViewSettingsMenu.qml
+++ b/src/ui/settings/ViewSettingsMenu.qml
@@ -141,7 +141,7 @@ VPNFlickable {
         Rectangle {
             Layout.preferredHeight: fullscreenRequired? VPNTheme.theme.rowHeight * 1.5 : VPNTheme.theme.rowHeight
             Layout.fillWidth: true
-            color: "transparent"
+            color: VPNTheme.theme.transparent
         }
     }
 

--- a/src/ui/views/ViewContactUs.qml
+++ b/src/ui/views/ViewContactUs.qml
@@ -167,7 +167,7 @@ Item {
                             Rectangle {
                                 Layout.preferredWidth: 40
                                 Layout.preferredHeight: 40
-                                color: "transparent"
+                                color: VPNTheme.theme.transparent
 
                                 VPNAvatar {
                                     id: avatar

--- a/src/ui/views/ViewMultiHop.qml
+++ b/src/ui/views/ViewMultiHop.qml
@@ -119,7 +119,7 @@ StackView {
                     Layout.preferredHeight: VPNTheme.theme.rowHeight
 
                     Rectangle {
-                        color: "transparent"
+                        color: VPNTheme.theme.transparent
                         Layout.preferredHeight: VPNTheme.theme.vSpacing
                         Layout.preferredWidth: VPNTheme.theme.vSpacing
                         Layout.leftMargin: 12

--- a/src/ui/views/ViewUpdate.qml
+++ b/src/ui/views/ViewUpdate.qml
@@ -162,7 +162,7 @@ VPNFlickable {
         Rectangle {
             Layout.fillWidth: true
             Layout.preferredHeight: VPNTheme.theme.windowMargin / 2
-            color: "transparent"
+            color: VPNTheme.theme.transparent
         }
 
         VPNButton {
@@ -198,7 +198,7 @@ VPNFlickable {
         Rectangle {
             Layout.fillWidth: true
             Layout.preferredHeight: VPNTheme.theme.windowMargin * 2
-            color: "transparent"
+            color: VPNTheme.theme.transparent
         }
 
     }


### PR DESCRIPTION
Note: Okay lottie's still not working on android 11+


So for some reason(tm) on android 11+ qt fails to parse:
``` 
color: "transparent"
``` 
therefore all rectangles default to ```color:white```

Before:
![image](https://user-images.githubusercontent.com/9611612/159934405-36740d3c-8aa6-4886-9e69-766af4524329.png)

After:
![image](https://user-images.githubusercontent.com/9611612/159931918-c64c3426-6049-43b1-8164-208f4e0f80e6.png)
