### PR TITLE
Linux: Update Qt6 PPA URL for Github CI builds

### DIFF
--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -58,9 +58,9 @@ jobs:
     strategy:
       matrix:
         config:
-            - { name: "Bionic", dist: bionic, ppa: "ppa:okirby/qt6-testing" }
-            - { name: "Focal", dist: focal, ppa: "ppa:okirby/qt6-testing" }
-            - { name: "Impish", dist: impish, ppa: "ppa:okirby/qt6-testing" }
+            - { name: "Bionic", dist: bionic, ppa: "ppa:okirby/qt6-backports" }
+            - { name: "Focal", dist: focal, ppa: "ppa:okirby/qt6-backports" }
+            - { name: "Impish", dist: impish, ppa: "ppa:okirby/qt6-backports" }
             - { name: "Jammy", dist: jammy, ppa: "" }
 
     runs-on: ubuntu-latest


### PR DESCRIPTION
I've re-built the Qt6 packages in a PPA that's a bit more suitable for backporting and less of a mess. Let's switch the Github CI to use this new PPA at [ppa:okirby/qt6-backports](https://launchpad.net/~okirby/+archive/ubuntu/qt6-backports)