### PR TITLE
Remove Broken Apk's in release tasks

### DIFF
--- a/.github/workflows/android_qt6.yaml
+++ b/.github/workflows/android_qt6.yaml
@@ -61,7 +61,7 @@ jobs:
             path: ${{ matrix.config.apk }}/android-build-${{ matrix.arch.qmake }}-release-signed.apk
       - name: Upload Unsigned APK${{ matrix.config.args }}
         uses: actions/upload-artifact@v1
-        if: ${{ matrix.config.sign }} == false
+        if: matrix.config.sign == false
         with:
             name: ${{matrix.arch.name}}_${{ matrix.config.name }}
             path: ${{ matrix.config.apk }}

--- a/.github/workflows/android_qt6.yaml
+++ b/.github/workflows/android_qt6.yaml
@@ -52,7 +52,11 @@ jobs:
           AUTOGRAPH_TOKEN: ${{ secrets.AUTOGRAPH_KEY }}
         run: |
           bash ./scripts/android/sign.sh ${{ matrix.config.apk }}
+          # Delete all unsigned
           rm ${{ matrix.config.apk }}/*unsigned.apk
+          # Delete all other apks except the selected arch
+          cd ${{ matrix.config.apk }}
+          ls | grep "${{ matrix.arch.qmake }}" | xargs rm
       - name: Upload APK${{ matrix.config.args }}
         uses: actions/upload-artifact@v1
         with:

--- a/.github/workflows/android_qt6.yaml
+++ b/.github/workflows/android_qt6.yaml
@@ -52,13 +52,16 @@ jobs:
           AUTOGRAPH_TOKEN: ${{ secrets.AUTOGRAPH_KEY }}
         run: |
           bash ./scripts/android/sign.sh ${{ matrix.config.apk }}
-          # Delete all unsigned
-          rm ${{ matrix.config.apk }}/*unsigned.apk
-          # Delete all other apks except the selected arch
-          cd ${{ matrix.config.apk }}
-          ls | grep -v "${{ matrix.arch.qmake }}" | xargs rm
-      - name: Upload APK${{ matrix.config.args }}
+
+      - name: Upload Signed APK${{ matrix.config.args }}
         uses: actions/upload-artifact@v1
+        if: ${{ matrix.config.sign }}
+        with:
+            name: ${{matrix.arch.name}}_${{ matrix.config.name }}
+            path: ${{ matrix.config.apk }}/android-build-${{ matrix.arch.qmake }}-release-signed.apk
+      - name: Upload Unsigned APK${{ matrix.config.args }}
+        uses: actions/upload-artifact@v1
+        if: ${{ matrix.config.sign }} == false
         with:
             name: ${{matrix.arch.name}}_${{ matrix.config.name }}
             path: ${{ matrix.config.apk }}

--- a/.github/workflows/android_qt6.yaml
+++ b/.github/workflows/android_qt6.yaml
@@ -56,7 +56,7 @@ jobs:
           rm ${{ matrix.config.apk }}/*unsigned.apk
           # Delete all other apks except the selected arch
           cd ${{ matrix.config.apk }}
-          ls | grep "${{ matrix.arch.qmake }}" | xargs rm
+          ls | grep -v "${{ matrix.arch.qmake }}" | xargs rm
       - name: Upload APK${{ matrix.config.args }}
         uses: actions/upload-artifact@v1
         with:


### PR DESCRIPTION
Currently the release task generates 5 apks (each arch, + universal) - 
However, as qt only builds one arch now - only the matching apk for the job actually contains everything. 
Therefore, we should delete the broken any other APKs - so noone is wondering why "universal" won't work for them :) 

Closes https://github.com/mozilla-mobile/mozilla-vpn-client/issues/3126