### PR TITLE
Fix a crash in the CI - VPN-1989

### DIFF
--- a/src/connectionbenchmark/benchmarktask.h
+++ b/src/connectionbenchmark/benchmarktask.h
@@ -6,6 +6,7 @@
 #define BENCHMARKTASK_H
 
 #include "task.h"
+#include "benchmarktasksentinel.h"
 
 #include <QElapsedTimer>
 
@@ -25,6 +26,8 @@ class BenchmarkTask : public Task {
   State state() const { return m_state; }
   qint64 executionTime() const { return m_elapsedTimer.elapsed(); }
 
+  const BenchmarkTaskSentinel* sentinel() const { return &m_sentinel; }
+
  signals:
   void stateChanged(State state);
 
@@ -36,6 +39,8 @@ class BenchmarkTask : public Task {
 
   const uint32_t m_maxExecutionTime;
   QElapsedTimer m_elapsedTimer;
+
+  BenchmarkTaskSentinel m_sentinel;
 };
 
 #endif  // BENCHMARKTASK_H

--- a/src/connectionbenchmark/benchmarktasksentinel.h
+++ b/src/connectionbenchmark/benchmarktasksentinel.h
@@ -1,0 +1,22 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef BENCHMARKTASKSENTINEL_H
+#define BENCHMARKTASKSENTINEL_H
+
+#include <QObject>
+
+class BenchmarkTaskSentinel final : public QObject {
+  Q_OBJECT
+  Q_DISABLE_COPY_MOVE(BenchmarkTaskSentinel)
+
+ public:
+  BenchmarkTaskSentinel() = default;
+  ~BenchmarkTaskSentinel() { emit destroyed(); }
+
+ signals:
+  void destroyed();
+};
+
+#endif  // BENCHMARKTASKSENTINEL_H

--- a/src/connectionbenchmark/connectionbenchmark.h
+++ b/src/connectionbenchmark/connectionbenchmark.h
@@ -25,6 +25,8 @@ class ConnectionBenchmark final : public QObject {
   ConnectionBenchmark();
   ~ConnectionBenchmark();
 
+  void initialize();
+
   Q_INVOKABLE void start();
   Q_INVOKABLE void reset();
 

--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -218,6 +218,8 @@ void MozillaVPN::initialize() {
 
   m_private->m_telemetry.initialize();
 
+  m_private->m_connectionBenchmark.initialize();
+
   TaskScheduler::scheduleTask(new TaskGetFeatureList());
 
 #ifdef MVPN_ADJUST

--- a/src/qmake/sources.pri
+++ b/src/qmake/sources.pri
@@ -163,6 +163,7 @@ HEADERS += \
         connectionbenchmark/benchmarktask.h \
         connectionbenchmark/benchmarktaskdownload.h \
         connectionbenchmark/benchmarktaskping.h \
+        connectionbenchmark/benchmarktasksentinel.h \
         connectionbenchmark/connectionbenchmark.h \
         connectiondataholder.h \
         connectionhealth.h \


### PR DESCRIPTION
The tasks are fully disconnected when they complete their job or when they are
deleted. Because of this, the ConnectionBenchmark object does not receie the
QObject::destroyed signal, it does not cleanup the list of tasks, and
eventually, it crashes.

This PR fixes this using a 3rd QObject (a sentinel). It also remove the
multiple connections using a `initialize` method.