### PR TITLE
Fix Not Loadable Lottie Animations on Android 12

### DIFF
--- a/lottie/lib/lottieprivate.cpp
+++ b/lottie/lib/lottieprivate.cpp
@@ -122,7 +122,7 @@ void LottiePrivate::createAnimation() {
   }
 
   QJSValue jsonData =
-      jsonParser.call(QList<QJSValue>{QJSValue(QString(file.readAll()))});
+      jsonParser.call(QList<QJSValue>{engine()->toScriptValue(file.readAll())});
   if (jsonData.isError()) {
     QString errorMessage("Failed to parse the source as JSON: ");
     errorMessage.append(jsonData.toString());
@@ -134,11 +134,12 @@ void LottiePrivate::createAnimation() {
 
   QJSValue rendererSettings = engine()->newObject();
   rendererSettings.setProperty("clearCanvas", true);
-  rendererSettings.setProperty("preserveAspectRatio", fillModeToAspectRatio());
+  rendererSettings.setProperty(
+      "preserveAspectRatio", engine()->toScriptValue(fillModeToAspectRatio()));
 
   QJSValue obj = engine()->newObject();
   obj.setProperty("container", engine()->toScriptValue(m_container));
-  obj.setProperty("renderer", "canvas");
+  obj.setProperty("renderer", engine()->toScriptValue(m_renderer));
   obj.setProperty("rendererSettings", rendererSettings);
   obj.setProperty("loop", m_loops);
   obj.setProperty("autoplay", m_autoPlay);
@@ -273,8 +274,8 @@ void LottiePrivate::clearCanvas() {
 
   QJSValue getContext = canvasValue.property("getContext");
   Q_ASSERT(getContext.isCallable());
-  QJSValue ctx =
-      getContext.callWithInstance(canvasValue, QList<QJSValue>{"2d"});
+  QJSValue ctx = getContext.callWithInstance(
+      canvasValue, QList<QJSValue>{engine()->toScriptValue(m_context_type)});
   if (ctx.isObject() && ctx.hasProperty("reset")) {
     QJSValue ctxReset = ctx.property("reset");
     Q_ASSERT(ctxReset.isCallable());

--- a/lottie/lib/lottieprivate.h
+++ b/lottie/lib/lottieprivate.h
@@ -116,6 +116,8 @@ class LottiePrivate : public QQuickItem {
   LottieStatus m_status;
   bool m_autoPlay = false;
   QString m_fillMode = "stretch";
+  const QString m_context_type = "2d";
+  const QString m_renderer = "canvas";
 
   QQuickItem* m_canvas = nullptr;
   QQuickItem* m_container = nullptr;


### PR DESCRIPTION

The QJSValue constructor for qstring actually constructs a js-number (a float actually) on android-11+ on arm64. (...Don't ask me why...)
Therefore getContext and loadanimation are not working there. 

Luckly engine->toScriptValue creates the right value here.
![image](https://user-images.githubusercontent.com/9611612/160410206-2daa7003-7aed-454c-a7af-7f3de40352df.png)

