### PR TITLE
Update i18n repo in ci runs

### DIFF
--- a/.github/workflows/android_qt6.yaml
+++ b/.github/workflows/android_qt6.yaml
@@ -45,6 +45,7 @@ jobs:
         continue-on-error: true
         id: compile
         run: |
+          git submodule update --remote --depth 1 i18n 
           bash ./scripts/android/package.sh $QTPATH -A ${{matrix.arch.qmake}} -a ${{ secrets.ADJUST_SDK_TOKEN }} ${{ matrix.config.args }}
       - name: Sign Android
         if: ${{ matrix.config.sign }}

--- a/scripts/utils/import_languages.py
+++ b/scripts/utils/import_languages.py
@@ -172,3 +172,7 @@ for l10n_file in l10n_files:
     os.system(f"{lconvert} -i {l10n_file['ts']} -if xlf -i {l10n_file['xliff']} -o {l10n_file['ts']}")
 
 print(f'Imported {len(l10n_files)} locales')
+
+git = os.popen(f'git submodule status i18n')
+git_commit_hash = git.read().strip().replace("+","").split(' ')[0]
+print(f'Current commit:  https://github.com/mozilla-l10n/mozilla-vpn-client-l10n/commit/{git_commit_hash}')

--- a/taskcluster/scripts/build/android_build_debug.sh
+++ b/taskcluster/scripts/build/android_build_debug.sh
@@ -9,6 +9,7 @@ git submodule update
 # glean
 ./scripts/utils/generate_glean.py
 # translations
+git submodule update --remote --depth 1 i18n 
 ./scripts/utils/import_languages.py
 
 # $1 should be the qmake arch. 

--- a/taskcluster/scripts/build/android_build_release.sh
+++ b/taskcluster/scripts/build/android_build_release.sh
@@ -10,6 +10,7 @@ git submodule update
 ./scripts/utils/generate_glean.py
 # translations
 echo "Importing translations"
+git submodule update --remote --depth 1 i18n      
 ./scripts/utils/import_languages.py
 
 # Get Secrets for building


### PR DESCRIPTION
We had this line `git submodule update --remote --depth 1 i18n` in the package.sh prior. 
So therefore when adding the old gh-ci script back, that was not caught i guess :) 

Also let's print the current used translation commit in the script so we can easily check what commit was used in each build 