### PR TITLE
Fix captive portal functional tests.

### DIFF
--- a/src/captiveportal/captiveportaldetection.cpp
+++ b/src/captiveportal/captiveportaldetection.cpp
@@ -44,8 +44,9 @@ void CaptivePortalDetection::networkChanged() {
   // on networks that never had a portal.
   captivePortalMonitor()->stop();
 
-  if (vpn->controller()->state() != Controller::StateOn &&
-      vpn->controller()->state() != Controller::StateConfirming) {
+  Controller::State state = vpn->controller()->state();
+  if (state != Controller::StateOn && state != Controller::StateConnecting &&
+      state != Controller::StateConfirming) {
     // Network Changed but we're not connected, no need to test for captive
     // portal
     return;
@@ -77,6 +78,7 @@ void CaptivePortalDetection::stateChanged() {
 
   if ((state != Controller::StateOn ||
        vpn->connectionHealth()->stability() == ConnectionHealth::Stable) &&
+      state != Controller::StateConnecting &&
       state != Controller::StateConfirming) {
     logger.warning() << "No captive portal detection required";
     m_impl.reset();
@@ -112,8 +114,9 @@ void CaptivePortalDetection::detectCaptivePortal() {
 
   // This method is called by the inspector too. Let's check the status of the
   // VPN.
-  if (vpn->controller()->state() != Controller::StateOn &&
-      vpn->controller()->state() != Controller::StateConfirming) {
+  Controller::State state = vpn->controller()->state();
+  if (state != Controller::StateOn && state != Controller::StateConnecting &&
+      state != Controller::StateConfirming) {
     logger.warning() << "The VPN is not online. Ignore request.";
     return;
   }
@@ -175,8 +178,7 @@ void CaptivePortalDetection::captivePortalDetected() {
   MozillaVPN* vpn = MozillaVPN::instance();
   Q_ASSERT(vpn);
 
-  if (vpn->controller()->state() == Controller::StateOn ||
-      vpn->controller()->state() == Controller::StateConfirming) {
+  if (vpn->controller()->state() == Controller::StateOn) {
     captivePortalNotifier()->notifyCaptivePortalBlock();
   }
 }

--- a/tests/functional/testCaptivePortal.js
+++ b/tests/functional/testCaptivePortal.js
@@ -106,7 +106,7 @@ describe('Captive portal', function() {
     await vpn.waitForCondition(() => {
       return vpn.lastNotification().title === null;
     });
-    assert(vpn.lastNotification().title === null);
+    assert.strictEqual(vpn.lastNotification().title, null);
 
     // Something about this test upsets the next tests,
     // adding these waits gives everything a change to resolve.


### PR DESCRIPTION
After the last refactoring of the connection states, `Controller::StateConnecting` and `Controller::StateConfirming` have kind of become the same thing, and exist as transient states during which the Wireguard connection(s) are being negotiated. We should treat these two states the same when responding to a captive portal check.