### PR TITLE
Reduce the number of writing operations - fixes VPN-VPN-1996

### DIFF
--- a/src/settingsholder.cpp
+++ b/src/settingsholder.cpp
@@ -129,8 +129,10 @@ QString SettingsHolder::getReport() {
     return m_settings.value(key).toType();                              \
   }                                                                     \
   void SettingsHolder::setter(const type& value) {                      \
-    m_settings.setValue(key, value);                                    \
-    emit getter##Changed(value);                                        \
+    if (!has() || getter() != value) {                                  \
+      m_settings.setValue(key, value);                                  \
+      emit getter##Changed(value);                                      \
+    }                                                                   \
   }
 
 #include "settingslist.h"


### PR DESCRIPTION
We end up writing the setting file too many times. This PR reduces the number of writes to ~0. But it could introduce regressions. So, please, extra care when reviewing. Thanks!