### PR TITLE
Fix high-DPI scaling on Android

### DIFF
--- a/src/command.cpp
+++ b/src/command.cpp
@@ -164,6 +164,11 @@ int Command::runQmlApp(std::function<int()>&& a_callback) {
   QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
 #endif
 
+#ifdef MVPN_ANDROID
+  QGuiApplication::setHighDpiScaleFactorRoundingPolicy(
+      Qt::HighDpiScaleFactorRoundingPolicy::Round);
+#endif
+
   QApplication app(CommandLineParser::argc(), CommandLineParser::argv());
 
   QCoreApplication::setApplicationName("Mozilla VPN");

--- a/src/ui/main.qml
+++ b/src/ui/main.qml
@@ -60,7 +60,7 @@ Window {
     }
 
     screen: Qt.platform.os === "wasm" && Qt.application.screens.length > 1 ? Qt.application.screens[1] : Qt.application.screens[0]
-    flags: Qt.platform.os === "ios" || Qt.platform.os === "android" ? Qt.MaximizeUsingFullscreenGeometryHint : Qt.Window
+    flags: Qt.platform.os === "ios" ? Qt.MaximizeUsingFullscreenGeometryHint : Qt.Window
     visible: true
 
     width: fullscreenRequired() ? Screen.width : VPNTheme.theme.desktopAppWidth;

--- a/src/ui/main.qml
+++ b/src/ui/main.qml
@@ -60,7 +60,7 @@ Window {
     }
 
     screen: Qt.platform.os === "wasm" && Qt.application.screens.length > 1 ? Qt.application.screens[1] : Qt.application.screens[0]
-    flags: Qt.platform.os === "ios" ? Qt.MaximizeUsingFullscreenGeometryHint : Qt.Window
+    flags: Qt.platform.os === "ios" || Qt.platform.os === "android" ? Qt.MaximizeUsingFullscreenGeometryHint : Qt.Window
     visible: true
 
     width: fullscreenRequired() ? Screen.width : VPNTheme.theme.desktopAppWidth;


### PR DESCRIPTION
⚠️ This PR possibly has wide-ranging consequences for scaling on Android devices. If we decide to make this change we should test the change on as many Android devices as possible.

On some Android devices the dimensions of the application window are not filling the screen entirely. The issue seems to be rooted in how the app is scaled for high-DPI screens. The default policy for rounding the DPI scale factor for Android is different from other devices. This behaviour can be adjusted by using [QGuiApplication::setHighDpiScaleFactorRoundingPolicy](https://doc.qt.io/qt-5/qguiapplication.html#setHighDpiScaleFactorRoundingPolicy). From the documentation: 

> The default value is Qt::HighDpiScaleFactorRoundingPolicy::Round. On Qt for Android the default is Qt::HighDpiScaleFactorRoundingPolicy::PassThrough, which preserves historical behavior from earlier Qt versions.

Setting `Qt::HighDpiScaleFactorRoundingPolicy::Round` for Android seems to resolve the issue and the window is scaled correctly.

**Notes**
- This change has possibly an effect on scaling for all Android devices. To keep track of the devices that the change was tested on I created the following sheet: [Checklist for high-DPI scaling on Android](https://docs.google.com/spreadsheets/d/1J6m-g0ARY4p3uWehuk0WjCoP5Be2jqOjubYP7hF2QHY/edit#gid=0)
- For a list of devices on which this issue is currently reproducible see: #2770

**Screenshots**
Device: Nexus 5X
Version: Android 11.0
Arch: arm64

|Before|After|
|---|---|
|<img width="261" alt="image" src="https://user-images.githubusercontent.com/13835474/160602660-0b691199-1df6-4763-a9d8-9efdf8c9a11d.png">|<img width="261" alt="image" src="https://user-images.githubusercontent.com/13835474/160601133-e73ea070-1b5a-4a01-a7a5-3b1272756157.png">|

Resolves #2770