### PR TITLE
Rescan for dumps

### DIFF
--- a/src/crashreporter/crashreporterapp.cpp
+++ b/src/crashreporter/crashreporterapp.cpp
@@ -11,10 +11,6 @@
 #include "crashreporterfactory.h"
 
 int CrashReporterApp::main(int argc, char* argv[]) {
-#if QT_VERSION < 0x060000
-  // This flag is set by default in qt6.
-  QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
-#endif
   QApplication a(argc, argv);
   auto crashreporter = CrashReporterFactory::createCrashReporter();
   qInstallMessageHandler(LogHandler::messageQTHandler);


### PR DESCRIPTION
This is a working theory that the dump files might not be written at the time the crash reporter is launched.  There is a 5x retry of the directory listing with an increasing interval (+ 1s each time).