### PR TITLE
Build functional tests using GCC-10

### DIFF
--- a/.github/workflows/functional_tests.yaml
+++ b/.github/workflows/functional_tests.yaml
@@ -65,8 +65,8 @@ jobs:
 
           # Add external PPA, latest version of QT is 5.12.x for Ubuntu 20.04
           sudo add-apt-repository ppa:beineri/opt-qt-5.15.2-focal -y
-          sudo apt-get -o "Dir::Cache::archives=$(pwd)/build/archive" install -y \
-               git qt515base qt515tools qt515svg qt515networkauth-no-lgpl qt515charts-no-lgpl \
+          sudo apt-get -o "Dir::Cache::archives=$(pwd)/build/archive" install -y git gcc-10 g++-10 \
+               qt515base qt515tools qt515svg qt515networkauth-no-lgpl qt515charts-no-lgpl \
                libgl-dev libpolkit-gobject-1-dev qt515quickcontrols2 qt515imageformats \
                qt515graphicaleffects qt515websockets qt515declarative -y
           sudo chown -R $USER:$USER build/archive
@@ -85,7 +85,8 @@ jobs:
 
           # Delete unit tests, so we can get to testing faster
           sed -i '/tests\/unit/d' mozillavpn.pro
-          qmake CONFIG+=DUMMY QMAKE_CXXFLAGS+=--coverage QMAKE_LFLAGS+=--coverage CONFIG+=debug CONFIG+=inspector QT+=svg
+          qmake QMAKE_CXX=g++-10 QMAKE_LINK=g++-10 QMAKE_CXXFLAGS+=--coverage QMAKE_LFLAGS+=--coverage \
+              CONFIG+=DUMMY CONFIG+=debug CONFIG+=inspector QT+=svg
           make -j$(nproc)
           cp ./src/mozillavpn build/
           cp -r ./src/.obj build/


### PR DESCRIPTION
The functional tests are often failing due to a `grcov` parsing error which appears to be getting a float/integer conversion wrong. Hopefully we can work around the error by switching to a newer compiler.

See: https://github.com/mozilla/grcov/issues/570