### PR TITLE
Functional testing: Qt6 and cleanup

### DIFF
--- a/.github/workflows/functional_tests.yaml
+++ b/.github/workflows/functional_tests.yaml
@@ -107,7 +107,7 @@ jobs:
 
       - name: Install dependecies
         run: |
-          sudo dpkg -i build/archive/*.deb
+          sudo apt install ./build/archive/*.deb
           sudo apt install --no-upgrade firefox xvfb -y
           pip3 install -r requirements.txt
           npm install

--- a/.github/workflows/functional_tests.yaml
+++ b/.github/workflows/functional_tests.yaml
@@ -41,17 +41,15 @@ jobs:
           # Install grcov into the build directory, to reduce downstream compilation times.
           cargo install --root $(pwd)/build grcov 
 
-          # Add external PPA, latest version of QT is 5.12.x for Ubuntu 20.04
-          sudo add-apt-repository ppa:beineri/opt-qt-5.15.2-focal -y
-          sudo apt-get -o "Dir::Cache::archives=$(pwd)/build/archive" install -y \
-               git qt515base qt515tools qt515svg qt515networkauth-no-lgpl qt515charts-no-lgpl \
-               libgl-dev libpolkit-gobject-1-dev qt515quickcontrols2 qt515imageformats \
-               qt515graphicaleffects qt515websockets qt515declarative -y
-          sudo chown -R $USER:$USER build/archive
+          # Add external PPA for Qt6 support on Ubuntu 20.04
+          sudo add-apt-repository ppa:okirby/qt6-backports
 
-          # Some debug
-          echo "Listing $(pwd)/build/bin"
-          ls -al $(pwd)/build/bin
+          # Download the Qt6 package dependencies.
+          sudo apt-get install devscripts equivs -y
+          sudo mk-build-deps linux/debian/control.qt6
+          sudo apt-get -o "Dir::Cache::archives=$(pwd)/build/archive" install -y \
+               ./mozillavpn-build-deps_1.0_all.deb $(./scripts/linux/getdeps.py)
+          sudo chown -R $USER:$USER build/archive
 
       - name: Compile test client
         shell: bash
@@ -87,12 +85,6 @@ jobs:
           TEST_LIST: ${{ steps.testGen.outputs.tests }}
         run: |
           echo $TEST_LIST | jq
-
-      - name: Uploading artifacts
-        uses: actions/upload-artifact@v1
-        with:
-          name: Test Bundle
-          path: build/
 
   functionaltests:
     name: Functional tests
@@ -152,10 +144,13 @@ jobs:
       - name: Generating grcov reports
         id: generateGrcov
         continue-on-error: true # Ignore GRCOV parsing errors, see github.com/mozilla/grcov/issues/570
+        timeout-minutes: 1 # Give GRCOV a short timeout in case it hangs due to panics
         run: |
           cp build/.obj/*.gcno src/.obj
+          echo foo
           ./build/bin/grcov src/.obj -s src -t lcov --branch --ignore-not-existing \
-              -o ${{runner.temp}}/artifacts/functional_lcov.info
+              -o ${{runner.temp}}/artifacts/functional_lcov.info || exit 1
+          echo bar
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2

--- a/.github/workflows/functional_tests.yaml
+++ b/.github/workflows/functional_tests.yaml
@@ -33,7 +33,7 @@ jobs:
           path: build/
           key: ${{ github.sha }}
 
-      - name: Install Linux packages
+      - name: Install dependecies
         if: steps.cache-build.outputs.cache-hit != 'true'
         run: |
           mkdir -p build/archive
@@ -48,6 +48,10 @@ jobs:
                libgl-dev libpolkit-gobject-1-dev qt515quickcontrols2 qt515imageformats \
                qt515graphicaleffects qt515websockets qt515declarative -y
           sudo chown -R $USER:$USER build/archive
+
+          # Some debug
+          echo "Listing $(pwd)/build/bin"
+          ls -al $(pwd)/build/bin
 
       - name: Compile test client
         shell: bash

--- a/.github/workflows/functional_tests.yaml
+++ b/.github/workflows/functional_tests.yaml
@@ -65,7 +65,7 @@ jobs:
 
           # Delete unit tests, so we can get to testing faster
           sed -i '/tests\/unit/d' mozillavpn.pro
-          qmake CONFIG+=DUMMY QMAKE_CXXFLAGS+=--coverage QMAKE_LFLAGS+=--coverage CONFIG+=debug CONFIG+=inspector QT+=svg
+          qmake6 CONFIG+=DUMMY QMAKE_CXXFLAGS+=--coverage QMAKE_LFLAGS+=--coverage CONFIG+=debug CONFIG+=inspector QT+=svg
           make -j$(nproc)
           cp ./src/mozillavpn build/
           cp -r ./src/.obj build/

--- a/.github/workflows/functional_tests.yaml
+++ b/.github/workflows/functional_tests.yaml
@@ -44,7 +44,7 @@ jobs:
           # Add external PPA for Qt6 support on Ubuntu 20.04
           sudo add-apt-repository ppa:okirby/qt6-backports
 
-          # Download the Qt6 package dependencies.
+          # Download the build and runtime package dependencies.
           sudo apt-get -o "Dir::Cache::archives=$(pwd)/build/archive" install -y \
                $(./scripts/linux/getdeps.py -a linux/debian/control.qt6)
           sudo chown -R $USER:$USER build/archive
@@ -142,13 +142,11 @@ jobs:
       - name: Generating grcov reports
         id: generateGrcov
         continue-on-error: true # Ignore GRCOV parsing errors, see github.com/mozilla/grcov/issues/570
-        timeout-minutes: 1 # Give GRCOV a short timeout in case it hangs due to panics
+        timeout-minutes: 1 # Give GRCOV a short timeout in case it hangs after a panic
         run: |
           cp build/.obj/*.gcno src/.obj
-          echo foo
           ./build/bin/grcov src/.obj -s src -t lcov --branch --ignore-not-existing \
-              -o ${{runner.temp}}/artifacts/functional_lcov.info || exit 1
-          echo bar
+              -o ${{runner.temp}}/artifacts/functional_lcov.info
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2

--- a/.github/workflows/functional_tests.yaml
+++ b/.github/workflows/functional_tests.yaml
@@ -10,36 +10,11 @@ on:
       - 'releases/**'
 
 jobs:
-  test_list:
-    name: Generate Tasklist
-    runs-on: ubuntu-20.04
-    outputs:
-      matrix: ${{ steps.testGen.outputs.tests }}
-    steps:
-      - name: Install Packages
-        run: |
-          sudo apt update
-          sudo apt install jq -y
-      
-      - name: Clone repository
-        uses: actions/checkout@v2
-      - id: testGen
-        shell: bash
-        run: |
-          echo -n "::set-output name=tests::"
-          for test in $(find tests/functional -name 'test*.js' | sort); do
-            printf '{"name": "%s", "path": "%s"}' $(basename ${test%.js} | sed -n 's/test//p') $test
-          done | jq -s -c
-      - name: Check Tests
-        shell: bash
-        env:
-          TEST_LIST: ${{ steps.testGen.outputs.tests }}
-        run: |
-          echo $TEST_LIST | jq
-
   build_test_app:
     name: Build Test Client
     runs-on: ubuntu-20.04
+    outputs:
+      matrix: ${{ steps.testGen.outputs.tests }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -90,21 +65,32 @@ jobs:
           cp ./src/mozillavpn build/
           cp -r ./src/.obj build/
 
-      - name: Check build
+      - name: Generate Tasklist
+        id: testGen
+        shell: bash
         run: |
-          ls -ial build/
+          echo -n "::set-output name=tests::"
+          for test in $(find tests/functional -name 'test*.js' | sort); do
+            printf '{"name": "%s", "path": "%s"}' $(basename ${test%.js} | sed -n 's/test//p') $test
+          done | jq -s -c
+
+      - name: Check Tests
+        shell: bash
+        env:
+          TEST_LIST: ${{ steps.testGen.outputs.tests }}
+        run: |
+          echo $TEST_LIST | jq
 
   functionaltests:
     name: Functional tests
     needs: 
       - build_test_app
-      - test_list
     runs-on: ubuntu-20.04
     timeout-minutes: 45
     strategy:
       fail-fast: false # Don't cancel other jobs if a test fails
       matrix:
-        test: ${{ fromJson(needs.test_list.outputs.matrix) }}
+        test: ${{ fromJson(needs.build_test_app.outputs.matrix) }}
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -156,22 +142,17 @@ jobs:
           MVPN_BIN: ./build/mozillavpn
 
       - name: Generating grcov reports
+        id: generateGrcov
+        continue-on-error: true
         shell: bash
         run: |
           cp build/.obj/*.gcno src/.obj
           cd src
-          find .
-          grcov .obj -s . -t lcov --branch --ignore-not-existing > ../functional_lcov.info || rm -f ../functional_lcov.info
-
-      - name: Check grcov file existence
-        id: grcov_check_files
-        uses: andstor/file-existence-action@v1
-        with:
-          files: functional_lcov.info
+          grcov .obj -s . -t lcov --branch --ignore-not-existing > ../functional_lcov.info
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2
-        if: steps.grcov_check_files.outputs.files_exists == 'true'
+        if: steps.generateGrcov.outcome == 'success'
         with:
           directory: .
           flags: functional_tests

--- a/.github/workflows/functional_tests.yaml
+++ b/.github/workflows/functional_tests.yaml
@@ -154,7 +154,7 @@ jobs:
         continue-on-error: true # Ignore GRCOV parsing errors, see github.com/mozilla/grcov/issues/570
         run: |
           cp build/.obj/*.gcno src/.obj
-          ${{runner.temp}}/build/bin/grcov src/.obj -s src -t lcov --branch --ignore-not-existing \
+          ./build/bin/grcov src/.obj -s src -t lcov --branch --ignore-not-existing \
               -o ${{runner.temp}}/artifacts/functional_lcov.info
 
       - name: Upload coverage to Codecov

--- a/.github/workflows/functional_tests.yaml
+++ b/.github/workflows/functional_tests.yaml
@@ -45,10 +45,8 @@ jobs:
           sudo add-apt-repository ppa:okirby/qt6-backports
 
           # Download the Qt6 package dependencies.
-          sudo apt-get install devscripts equivs -y
-          sudo mk-build-deps linux/debian/control.qt6
           sudo apt-get -o "Dir::Cache::archives=$(pwd)/build/archive" install -y \
-               ./mozillavpn-build-deps_1.0_all.deb $(./scripts/linux/getdeps.py)
+               $(./scripts/linux/getdeps.py -a linux/debian/control.qt6)
           sudo chown -R $USER:$USER build/archive
 
       - name: Compile test client

--- a/.github/workflows/functional_tests.yaml
+++ b/.github/workflows/functional_tests.yaml
@@ -38,6 +38,9 @@ jobs:
         run: |
           mkdir -p build/archive
 
+          # Install grcov into the build directory, to reduce downstream compilation times.
+          cargo install --root $(pwd)/build grcov 
+
           # Add external PPA, latest version of QT is 5.12.x for Ubuntu 20.04
           sudo add-apt-repository ppa:beineri/opt-qt-5.15.2-focal -y
           sudo apt-get -o "Dir::Cache::archives=$(pwd)/build/archive" install -y \
@@ -65,7 +68,7 @@ jobs:
           cp ./src/mozillavpn build/
           cp -r ./src/.obj build/
 
-      - name: Generate Tasklist
+      - name: Generate tasklist
         id: testGen
         shell: bash
         run: |
@@ -74,7 +77,7 @@ jobs:
             printf '{"name": "%s", "path": "%s"}' $(basename ${test%.js} | sed -n 's/test//p') $test
           done | jq -s -c
 
-      - name: Check Tests
+      - name: Check tests
         shell: bash
         env:
           TEST_LIST: ${{ steps.testGen.outputs.tests }}
@@ -117,11 +120,6 @@ jobs:
         shell: bash
         run: ./tests/proxy/wsgi.py --mock-devices > /dev/null &
 
-      - name: Install Grcov
-        shell: bash
-        run: |
-          cargo install grcov
-
       - name: Running ${{matrix.test.name}} Tests
         id: runTests
         uses: nick-invision/retry@v2
@@ -143,12 +141,11 @@ jobs:
 
       - name: Generating grcov reports
         id: generateGrcov
-        continue-on-error: true
-        shell: bash
+        continue-on-error: true # Ignore GRCOV parsing errors, see github.com/mozilla/grcov/issues/570
         run: |
           cp build/.obj/*.gcno src/.obj
-          cd src
-          grcov .obj -s . -t lcov --branch --ignore-not-existing > ../functional_lcov.info
+          ${{runner.temp}}/build/bin/grcov src/.obj -s src -t lcov --branch --ignore-not-existing \
+              -o ${{runner.temp}}/artifacts/functional_lcov.info
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2
@@ -157,7 +154,7 @@ jobs:
           directory: .
           flags: functional_tests
           name: codecov-poc
-          files: functional_lcov.info
+          files: ${{runner.temp}}/artifacts/functional_lcov.info
           verbose: true
 
       - name: Uploading artifacts

--- a/.github/workflows/functional_tests.yaml
+++ b/.github/workflows/functional_tests.yaml
@@ -88,6 +88,12 @@ jobs:
         run: |
           echo $TEST_LIST | jq
 
+      - name: Uploading artifacts
+        uses: actions/upload-artifact@v1
+        with:
+          name: Test Bundle
+          path: build/
+
   functionaltests:
     name: Functional tests
     needs: 

--- a/scripts/linux/getdeps.py
+++ b/scripts/linux/getdeps.py
@@ -7,6 +7,12 @@ import os
 parser = argparse.ArgumentParser(description='List package dependencies')
 parser.add_argument('control', type=str, nargs='?',
                     help='Debian control file to parse')
+parser.add_argument('-b', '--build', action='store_true',
+                    help='List packages from the Build-Depends paragraph')
+parser.add_argument('-r', '--runtime', action='store_true',
+                    help='List packages from the Depends paragraph')
+parser.add_argument('-a', '--all', action='store_true',
+                    help='List all packages dependencies')
 args = parser.parse_args()
 
 ## If no control file was provided, assume control.qt6 from the source checkout.
@@ -14,10 +20,25 @@ if args.control is None:
     linuxdir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "../../linux/debian")
     args.control = os.path.normpath(os.path.join(linuxdir, "control.qt6"))
 
+## Figure out which paragraphs to dump.
+if args.all:
+    args.build = True
+    args.runtime = True
+
+## Default to the runtime dependencies if nothing else is set.
+if not (args.build or args.runtime):
+    args.runtime = True
+
+
 # Parse the control file to dump the runtime dependencies.
+def dump(depends):
+    for dep in depends.split(','):
+        print(dep.split()[0])
+
 for p in Deb822.iter_paragraphs(open(args.control)):
     for item in p.items():
-        if item[0] != 'Depends':
-            continue
-        for dep in item[1].split(','):
-            print(dep.split()[0])
+        if args.runtime and item[0] == 'Depends':
+            dump(item[1])
+        if args.build and item[0] == 'Build-Depends':
+            dump(item[1])
+

--- a/scripts/linux/getdeps.py
+++ b/scripts/linux/getdeps.py
@@ -3,7 +3,7 @@ from debian.deb822 import Deb822
 import argparse
 import os
 
-## Parse arguments for the control file
+## Parse arguments for the control file and desired dependency section.
 parser = argparse.ArgumentParser(description='List package dependencies')
 parser.add_argument('control', type=str, nargs='?',
                     help='Debian control file to parse')
@@ -29,8 +29,7 @@ if args.all:
 if not (args.build or args.runtime):
     args.runtime = True
 
-
-# Parse the control file to dump the runtime dependencies.
+# Parse the control file to dump the package dependencies.
 def dump(depends):
     for dep in depends.split(','):
         print(dep.split()[0])

--- a/scripts/linux/getdeps.py
+++ b/scripts/linux/getdeps.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+from debian.deb822 import Deb822
+import argparse
+import os
+
+## Parse arguments for the control file
+parser = argparse.ArgumentParser(description='List package dependencies')
+parser.add_argument('control', type=str, nargs='?',
+                    help='Debian control file to parse')
+args = parser.parse_args()
+
+## If no control file was provided, assume control.qt6 from the source checkout.
+if args.control is None:
+    linuxdir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "../../linux/debian")
+    args.control = os.path.normpath(os.path.join(linuxdir, "control.qt6"))
+
+# Parse the control file to dump the runtime dependencies.
+for p in Deb822.iter_paragraphs(open(args.control)):
+    for item in p.items():
+        if item[0] != 'Depends':
+            continue
+        for dep in item[1].split(','):
+            print(dep.split()[0])

--- a/src/inspector/inspectorhandler.cpp
+++ b/src/inspector/inspectorhandler.cpp
@@ -49,7 +49,6 @@ Logger logger(LOG_INSPECTOR, "InspectorHandler");
 bool s_stealUrls = false;
 bool s_forwardNetwork = false;
 
-QUrl s_lastUrl;
 QString s_updateVersion;
 QStringList s_pickedItems;
 bool s_pickedItemsSet = false;
@@ -452,7 +451,7 @@ static QList<InspectorCommand> s_commands{
     InspectorCommand{"lasturl", "Retrieve the last opened URL", 0,
                      [](const QList<QByteArray>&) {
                        QJsonObject obj;
-                       obj["value"] = s_lastUrl.toString();
+                       obj["value"] = MozillaVPN::instance()->lastUrl();
                        return obj;
                      }},
 
@@ -947,9 +946,6 @@ QString InspectorHandler::getObjectClass(const QObject* target) {
   auto metaObject = target->metaObject();
   return metaObject->className();
 }
-
-// static
-void InspectorHandler::setLastUrl(const QUrl& url) { s_lastUrl = url; }
 
 // static
 bool InspectorHandler::stealUrls() { return s_stealUrls; }

--- a/src/inspector/inspectorhandler.h
+++ b/src/inspector/inspectorhandler.h
@@ -19,7 +19,6 @@ class InspectorHandler : public QObject {
  public:
   static void initialize();
 
-  static void setLastUrl(const QUrl& url);
   static bool stealUrls();
   static QString appVersionForUpdate();
   static QString getObjectClass(const QObject* target);

--- a/src/mozillavpn.h
+++ b/src/mozillavpn.h
@@ -133,6 +133,8 @@ class MozillaVPN final : public QObject {
   Q_PROPERTY(bool debugMode READ debugMode CONSTANT)
   Q_PROPERTY(QString currentView READ currentView WRITE setCurrentView NOTIFY
                  currentViewChanged)
+  Q_PROPERTY(
+      QString lastUrl READ lastUrl WRITE setLastUrl NOTIFY lastUrlChanged)
 
  public:
   MozillaVPN();
@@ -323,6 +325,12 @@ class MozillaVPN final : public QObject {
     emit currentViewChanged();
   }
 
+  const QString& lastUrl() const { return m_lastUrl; }
+  void setLastUrl(const QString& url) {
+    m_lastUrl = url;
+    emit lastUrlChanged();
+  }
+
   void createTicketAnswerRecieved(bool successful) {
     emit ticketCreationAnswer(successful);
   }
@@ -411,6 +419,7 @@ class MozillaVPN final : public QObject {
   void logsReady(const QString& logs);
 
   void currentViewChanged();
+  void lastUrlChanged();
 
   void ticketCreationAnswer(bool successful);
 
@@ -449,6 +458,7 @@ class MozillaVPN final : public QObject {
   State m_state = StateInitialize;
   AlertType m_alert = NoAlert;
   QString m_currentView;
+  QString m_lastUrl;
 
   UserState m_userState = UserNotAuthenticated;
 

--- a/src/urlopener.cpp
+++ b/src/urlopener.cpp
@@ -5,6 +5,7 @@
 #include "urlopener.h"
 #include "constants.h"
 #include "logger.h"
+#include "mozillavpn.h"
 #include "inspector/inspectorhandler.h"
 #include "settingsholder.h"
 
@@ -28,7 +29,8 @@ void UrlOpener::open(QUrl url, bool addEmailAddress) {
   }
 
   if (!Constants::inProduction()) {
-    InspectorHandler::setLastUrl(url.toString());
+    MozillaVPN* vpn = MozillaVPN::instance();
+    vpn->setLastUrl(url.toString());
 
     if (InspectorHandler::stealUrls()) {
       return;

--- a/tests/functional/helper.js
+++ b/tests/functional/helper.js
@@ -153,6 +153,24 @@ module.exports = {
         `Command failed: ${json.error}`);
   },
 
+  async scrollToElement(view, id) {
+    assert(await this.hasElement(view), 'Scrolling on an non-existing view?!?');
+    assert(await this.hasElement(id), 'Requesting an non-existing element?!?');
+
+    const contentHeight =
+        parseInt(await this.getElementProperty(view, 'contentHeight'));
+    const height = parseInt(await this.getElementProperty(view, 'height'));
+    let maxScroll = (contentHeight > height) ? contentHeight - height : 0;
+    let elementY = parseInt(await this.getElementProperty(id, 'y'));
+
+    let contentY = elementY - (height / 2);
+    if (contentY < 0) contentY = 0;
+    if (contentY > maxScroll) contentY = maxScroll;
+
+    await this.setElementProperty(view, 'contentY', 'i', contentY);
+    await this.wait();
+  },
+
   async getElementProperty(id, property) {
     assert(
         await this.hasElement(id),
@@ -200,11 +218,7 @@ module.exports = {
   },
 
   async getLastUrl() {
-    const json = await this._writeCommand('lasturl');
-    assert(
-        json.type === 'lasturl' && !('error' in json),
-        `Command failed: ${json.error}`);
-    return json.value || '';
+    return await this.getElementProperty('VPN', 'lastUrl');
   },
 
   async waitForCondition(condition) {
@@ -223,6 +237,7 @@ module.exports = {
   async authenticate(clickOnPostAuthenticate = false, acceptTelemetry = false) {
     // This method must be called when the client is on the "Get Started" view.
     await this.waitForMainView();
+    await this.setElementProperty('VPN', 'lastUrl', 's', '');
 
     // Click on get started and wait for authenticating view
     await this.clickOnElement('getStarted');
@@ -266,6 +281,7 @@ module.exports = {
         'https://stage-vpn.guardian.nonprod.cloudops.mozgcp.net/vpn/client/login/success');
 
     // Wait for VPN client screen to move from spinning wheel to next screen
+    await this.waitForElementProperty('VPN', 'userState', 'UserAuthenticated');
     await this.waitForElement('postAuthenticationButton');
     await driver.quit();
 

--- a/tests/functional/setupVpn.js
+++ b/tests/functional/setupVpn.js
@@ -83,6 +83,7 @@ exports.mochaHooks = {
     // then this can fail and cause the tests to hang.
     // Logging the error lets us clean-up and move on.
     try {
+      await vpn.hardReset();
       await vpn.quit();
     } catch (error) {
       console.error(error);

--- a/tests/functional/testAuthentication.js
+++ b/tests/functional/testAuthentication.js
@@ -71,11 +71,9 @@ describe('User authentication', function() {
     await vpn.waitForElementProperty('authenticatingView', 'visible', 'true');
   });
 
-  it('Completes authentication', async () => {
+  it('Completes authentication and logout', async () => {
     await vpn.authenticate(true, true);
-  });
 
-  it('Logout again', async () => {
     await vpn.waitForElement('settingsButton');
     await vpn.clickOnElement('settingsButton');
 

--- a/tests/functional/testAuthentication.js
+++ b/tests/functional/testAuthentication.js
@@ -71,19 +71,17 @@ describe('User authentication', function() {
     await vpn.waitForElementProperty('authenticatingView', 'visible', 'true');
   });
 
-  it('Completes authentication and logout', async () => {
+  it('Completes authentication after logout', async () => {
     await vpn.authenticate(true, true);
 
     await vpn.waitForElement('settingsButton');
     await vpn.clickOnElement('settingsButton');
 
     await vpn.waitForElement('settingsLogout');
+    await vpn.scrollToElement('settingsView', 'settingsLogout');
     await vpn.clickOnElement('settingsLogout');
     await vpn.waitForMainView();
-  });
 
-  it('Login again', async () => {
     await vpn.authenticate();
   });
-
 });

--- a/tests/functional/testSettings.js
+++ b/tests/functional/testSettings.js
@@ -411,9 +411,9 @@ describe('Settings', function() {
   it('Checking the logout', async () => {
     await vpn.waitForElement('settingsLogout');
     await vpn.waitForElementProperty('settingsLogout', 'visible', 'true');
-    // TODO - Should be able to click on SignOut and observe
-    // the signout, but the next line doesn't work
-    // await vpn.clickOnElement('settingsLogout');
-    // await vpn.waitForMainView();
+    await vpn.scrollToElement('settingsView', 'settingsLogout');
+
+    await vpn.clickOnElement('settingsLogout');
+    await vpn.waitForMainView();
   });
 });

--- a/tests/unit/mocinspectorhandler.cpp
+++ b/tests/unit/mocinspectorhandler.cpp
@@ -8,8 +8,6 @@ InspectorHandler::InspectorHandler(QObject*) {}
 
 InspectorHandler::~InspectorHandler() = default;
 
-void InspectorHandler::setLastUrl(const QUrl&) {}
-
 bool InspectorHandler::stealUrls() { return false; }
 
 QString InspectorHandler::appVersionForUpdate() { return "42"; }


### PR DESCRIPTION
Another round of refactoring and cleanup for our functional tests. The big feature is switching to use Qt6 in our functional tests, however, some other changes include:
 - Eliminate the `Generate Tasklist` job, it's silly to get Github to spin up a container just to list a directory.
 - Reduce CPU usage by compiling `grcov` only once.
 - Gracefully ignore coverage if `grcov` decides to panic on us.
 - Fix test flakiness due to state carried between tests:
   - Clear state with a `hard_reset` after each test.
   - Add `scrollToElement()` to ensure an element is clickable during tests.
   - Convert `lasturl` to a property, so that it can be cleared.