### PR TITLE
Fix red cursor in VPNTextArea on Android

### DIFF
--- a/nebula/ui/components.qrc
+++ b/nebula/ui/components.qrc
@@ -111,5 +111,6 @@
         <file>components/inAppAuth/VPNInAppAuthenticationPasswordCondition.qml</file>
         <file>components/inAppAuth/VPNInAppAuthenticationLegalDisclaimer.qml</file>
         <file>components/inAppAuth/VPNInAppAuthenticationCancel.qml</file>
+        <file>components/forms/VPNCursorDelegate.qml</file>
     </qresource>
 </RCC>

--- a/nebula/ui/components/forms/VPNCursorDelegate.qml
+++ b/nebula/ui/components/forms/VPNCursorDelegate.qml
@@ -1,0 +1,29 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import QtQuick 2.6
+import Qt.labs.qmlmodels 1.0
+
+import components.forms 0.1
+
+
+Rectangle {
+        // force cursor color and blink
+        id: cursor
+        visible: parent.activeFocus && !parent.readOnly && parent.selectionStart === parent.selectionEnd
+        color: parent.placeholderTextColor
+        width: 1
+
+        Timer {
+            // This is duped from CursorDelegate.qml to preserve cursor blinking which is overwritten
+            // when explicity setting cursor.color.
+            id: timer
+            running: cursor.parent.activeFocus && !cursor.parent.readOnly && interval != 0
+            repeat: true
+            interval: Qt.styleHints.cursorFlashTime / 2
+            onTriggered: cursor.opacity = !cursor.opacity ? 1 : 0
+            // force the cursor visible when gaining focus
+            onRunningChanged: cursor.opacity = 1
+        }
+    }

--- a/nebula/ui/components/forms/VPNTextArea.qml
+++ b/nebula/ui/components/forms/VPNTextArea.qml
@@ -48,8 +48,10 @@ Item {
             font.family: VPNTheme.theme.fontInterFamily
             color: VPNTheme.colors.input.default.text
             wrapMode: Text.WrapAtWordBoundaryOrAnywhere
-            textMargin: VPNTheme.theme.windowMargin * .75
-            padding: 0
+            leftPadding: VPNTheme.theme.windowMargin
+            rightPadding: VPNTheme.theme.windowMargin
+            bottomPadding: VPNTheme.theme.windowMargin
+            topPadding: VPNTheme.theme.windowMargin
             Keys.onTabPressed: nextItemInFocusChain().forceActiveFocus(Qt.TabFocusReason)
             onTextChanged: handleOnTextChanged(text)
             selectByMouse: true
@@ -61,12 +63,14 @@ Item {
                 z: -1
             }
 
+            cursorDelegate: VPNCursorDelegate {}
+
             VPNTextBlock {
                 id: formattedPlaceholderText
                 anchors.fill: textArea
                 anchors.leftMargin: VPNTheme.theme.windowMargin
                 anchors.rightMargin: VPNTheme.theme.windowMargin
-                anchors.topMargin: VPNTheme.theme.windowMargin * .75
+                anchors.topMargin: VPNTheme.theme.windowMargin
                 color: textAreaStates.state === "emptyHovered" ? VPNTheme.colors.input.hover.placeholder : VPNTheme.colors.input.default.placeholder
                 visible: textArea.text.length < 1
 

--- a/nebula/ui/components/forms/VPNTextField.qml
+++ b/nebula/ui/components/forms/VPNTextField.qml
@@ -38,25 +38,7 @@ TextField {
     topPadding: VPNTheme.theme.windowMargin / 2
     bottomPadding: VPNTheme.theme.windowMargin / 2
 
-    cursorDelegate: Rectangle {
-        // force cursor color and blink
-        id: cursor
-        visible: parent.activeFocus && !parent.readOnly && parent.selectionStart === parent.selectionEnd
-        color: textField.placeholderTextColor
-        width: 1
-
-        Timer {
-            // This is duped from CursorDelegate.qml to preserve cursor blinking which is overwritten
-            // when explicity setting cursor.color.
-            id: timer
-            running: cursor.parent.activeFocus && !cursor.parent.readOnly && interval != 0
-            repeat: true
-            interval: Qt.styleHints.cursorFlashTime / 2
-            onTriggered: cursor.opacity = !cursor.opacity ? 1 : 0
-            // force the cursor visible when gaining focus
-            onRunningChanged: cursor.opacity = 1
-        }
-    }
+    cursorDelegate: VPNCursorDelegate {}
 
     Text {
         id: centeredPlaceholderText

--- a/nebula/ui/components/forms/qmldir
+++ b/nebula/ui/components/forms/qmldir
@@ -1,9 +1,10 @@
 VPNComboBox 0.1 VPNComboBox.qml
-VPNInputBackground 0.1 VPNInputBackground.qml
 VPNContextualAlert 0.1 VPNContextualAlert.qml
 VPNContextualAlerts 0.1 VPNContextualAlerts.qml
-VPNPasswordInput 0.1 VPNPasswordInput.qml
+VPNCursorDelegate 0.1 VPNCursorDelegate.qml
+VPNInputBackground 0.1 VPNInputBackground.qml
 VPNInputStates 0.1 VPNInputStates.qml
+VPNPasswordInput 0.1 VPNPasswordInput.qml
 VPNRadioButton 0.1 VPNRadioButton.qml
 VPNSearchBar 0.1 VPNSearchBar.qml
 VPNTextArea 0.1 VPNTextArea.qml


### PR DESCRIPTION
This PR adds `VPNCursorDelegate {}` and uses it in `VPNTextField {}`and `VPNTextArea {}` to correct the red cursor issue on Android and fix the rest of #2901. This also fixes a misalignment issue between the placeholder text and cursor position in `VPNTextArea {}`.
<table>
<tr>
<th>Before</th>
<th colspan="2">After</th>
</tr>
<tr>
<td>
<img width="200" alt="Screen Shot 2022-03-30 at 6 04 48 PM" src="https://user-images.githubusercontent.com/22355127/160947652-362f3c3d-9981-4452-9d84-ea97765e3f62.png">

</td>
<td>
<img width="200" alt="Screen Shot 2022-03-30 at 6 33 20 PM" src="https://user-images.githubusercontent.com/22355127/160948013-a6e98d78-cd9d-40ce-b179-7a43fb629ac7.png">
</td>
<td>
<img width="200" alt="Screen Shot 2022-03-30 at 5 07 16 PM" src="https://user-images.githubusercontent.com/22355127/160939093-e37d7265-5fc3-4a66-85f4-5ed9c7fbf127.png"></td>
</tr>
</table>