### PR TITLE
Fix LogViewer

### DIFF
--- a/src/ui/views/ViewLogs.qml
+++ b/src/ui/views/ViewLogs.qml
@@ -26,21 +26,16 @@ Item {
         title: qsTrId("vpn.viewlogs.title")
     }
 
-    ScrollView {
+    VPNFlickable {
         id: logScrollView
 
         height: logs.height - menu.height - copyClearWrapper.height
-        width: logs.width
+        flickContentHeight: logText.height + VPNTheme.theme.windowMargin
+        width: logs.width - VPNTheme.theme.windowMargin
         anchors.top: menu.bottom
+        anchors.leftMargin: VPNTheme.theme.windowMargin
         anchors.horizontalCenter: logs.horizontalCenter
         contentWidth: width - (VPNTheme.theme.windowMargin * 2)
-        clip: true
-        topInset: VPNTheme.theme.rowHeight
-        bottomInset: VPNTheme.theme.rowHeight * 2
-        leftPadding: VPNTheme.theme.windowMargin
-        rightPadding: VPNTheme.theme.windowMargin
-        ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
-        ScrollBar.vertical.policy: ScrollBar.AlwaysOn
 
         VPNTextBlock {
             id: logText


### PR DESCRIPTION
## Description

   On Qt6 ScrollView behaves wierd with upward scrolling, not limiting the upper limit. Also "flicking" is broken. So let's replace it with VPNFlickable which works great and has none of those issues. 


## Reference

   closes https://github.com/mozilla-mobile/mozilla-vpn-client/issues/2710

https://user-images.githubusercontent.com/9611612/161100048-c40ffe8a-62ac-4e74-8738-5cbfd7e87e16.mp4




## Checklist


    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
