### PR TITLE
Fix contact and developer menu when visited from iOS onboarding

### DIFF
--- a/src/ui/developerMenu/ViewDeveloperMenu.qml
+++ b/src/ui/developerMenu/ViewDeveloperMenu.qml
@@ -13,6 +13,7 @@ import components.forms 0.1
 Item {
     property string _menuTitle: VPNl18n.SettingsDevTitle
     property alias isSettingsView: menu.isSettingsView
+    property bool addSafeAreaMargin: false
     property bool vpnIsOff: (VPNController.state === VPNController.StateOff) ||
         (VPNController.state === VPNController.StateInitializing)
 
@@ -22,6 +23,7 @@ Item {
         id: menu
         title: VPNl18n.SettingsDevTitle
         isSettingsView: false
+        y: addSafeAreaMargin ? safeAreaHeightByDevice() : 0
     }
 
     VPNFlickable {

--- a/src/ui/main.qml
+++ b/src/ui/main.qml
@@ -300,7 +300,10 @@ Window {
                 mainStackView.pop(null, StackView.Immediate);
             }
 
-            mainStackView.push("qrc:/ui/views/ViewContactUs.qml", { isMainView: true });
+            mainStackView.push("qrc:/ui/views/ViewContactUs.qml", {
+                isMainView: true,
+                addSafeAreaMargin: true
+            });
         }
 
         function onLoadAndroidAuthenticationView() {

--- a/src/ui/views/ViewContactUs.qml
+++ b/src/ui/views/ViewContactUs.qml
@@ -13,6 +13,7 @@ import components.forms 0.1
 Item {
     property string _menuTitle: VPNl18n.InAppSupportWorkflowSupportNavLinkText
     property alias isMainView: menu.isMainView
+    property bool addSafeAreaMargin: false
 
     // This property is used to cache the emailAddress between the sub-views.
     property string emailAddress: ""
@@ -45,6 +46,7 @@ Item {
         id: menu
         objectName: "supportTicketScreen"
         title: VPNl18n.InAppSupportWorkflowSupportNavLinkText
+        y: addSafeAreaMargin ? safeAreaHeightByDevice() : 0
 
         // this view gets pushed to stackView from backend always
         // and so should be removed from stackView (even in settings flow) on back clicks

--- a/src/ui/views/ViewGetHelp.qml
+++ b/src/ui/views/ViewGetHelp.qml
@@ -109,9 +109,15 @@ Item {
             visible: VPNSettings.developerUnlock
             onClicked: {
                 if (isSettingsView) {
-                    settingsStackView.push("qrc:/ui/developerMenu/ViewDeveloperMenu.qml", {isSettingsView: true})
+                    settingsStackView.push("qrc:/ui/developerMenu/ViewDeveloperMenu.qml", {
+                        isSettingsView: true,
+                        addSafeAreaMargin: getHelp.addSafeAreaMargin
+                    })
                 } else {
-                    stackview.push("qrc:/ui/developerMenu/ViewDeveloperMenu.qml", {isSettingsView: false})
+                    stackview.push("qrc:/ui/developerMenu/ViewDeveloperMenu.qml", {
+                        isSettingsView: false,
+                        addSafeAreaMargin: getHelp.addSafeAreaMargin
+                    })
                 }
             }
         }


### PR DESCRIPTION
## Description

Fixes the safe area for the settings contact and developer views when visited from the mobile onboarding on iOS.

## Reference

Fixes #3215

## Checklist

- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
