### PR TITLE
Add generic authentication error message

### DIFF
--- a/nebula/ui/components/inAppAuth/VPNInAppAuthenticationErrorPopup.qml
+++ b/nebula/ui/components/inAppAuth/VPNInAppAuthenticationErrorPopup.qml
@@ -27,9 +27,9 @@ VPNPopup {
                 sourceSize.width: 80
                 Layout.alignment: Qt.AlignHCenter
             }
+
             VPNHeadline {
-                id: authErrorTitle
-                text: ""
+                text: VPNl18n.InAppAuthSignInFailedPopupTitle
                 width: undefined
                 Layout.fillWidth: true
             }
@@ -67,7 +67,6 @@ VPNPopup {
         }
 
         function showGenericAuthError() {
-            authErrorTitle.text = VPNl18n.InAppAuthProblemSigningInTitle
             authErrorMessage.text = VPNl18n.InAppSupportWorkflowSupportErrorText
             openErrorModalAndForceFocus();
         }
@@ -83,19 +82,16 @@ VPNPopup {
                 break;
 
             case VPNAuthInApp.ErrorEmailCanNotBeUsedToLogin:
-                authErrorTitle.text = VPNl18n.InAppAuthProblemSigningInTitle
                 authErrorMessage.text = VPNl18n.InAppAuthProblemSigningInErrorMessage;
                 openErrorModalAndForceFocus();
                 break;
 
             case VPNAuthInApp.ErrorEmailTypeNotSupported:
-                authErrorTitle.text = VPNl18n.InAppAuthProblemSigningInTitle
-                authErrorMessage.text = VPNl18n.InAppAuthInvalidEmailFormatErrorMessage
+                authErrorMessage.text = VPNl18n.InAppAuthProblemEmailTypeNotSupported
                 openErrorModalAndForceFocus();
                 break;
 
             case VPNAuthInApp.ErrorFailedToSendEmail:
-                authErrorTitle.text = VPNl18n.InAppAuthProblemSigningInTitle
                 authErrorMessage.text =VPNl18n.InAppAuthProblemSendingEmailErrorMessage
                 openErrorModalAndForceFocus();
                 break;
@@ -105,7 +101,6 @@ VPNPopup {
                 break;
 
             case VPNAuthInApp.ErrorTooManyRequests:
-                authErrorTitle.text = VPNl18n.InAppAuthSignInFailedPopupTitle
                 const retryAfterMin = retryAfterSecToMin(retryAfterSec);
                 if (retryAfterMin === 1) {
                     authErrorMessage.text = VPNl18n.InAppAuthSignInBlockedForOneMinute;

--- a/nebula/ui/components/inAppAuth/VPNInAppAuthenticationErrorPopup.qml
+++ b/nebula/ui/components/inAppAuth/VPNInAppAuthenticationErrorPopup.qml
@@ -82,8 +82,7 @@ VPNPopup {
                 break;
 
             case VPNAuthInApp.ErrorEmailCanNotBeUsedToLogin:
-                authErrorMessage.text = VPNl18n.InAppAuthProblemSigningInErrorMessage;
-                openErrorModalAndForceFocus();
+                showGenericAuthError();
                 break;
 
             case VPNAuthInApp.ErrorEmailTypeNotSupported:

--- a/nebula/ui/components/inAppAuth/VPNInAppAuthenticationErrorPopup.qml
+++ b/nebula/ui/components/inAppAuth/VPNInAppAuthenticationErrorPopup.qml
@@ -20,7 +20,6 @@ VPNPopup {
             id: authErrorContent
             spacing: VPNTheme.theme.vSpacing
 
-
             Image {
                 source: "qrc:/ui/resources/updateRequired.svg"
                 antialiasing: true
@@ -29,10 +28,10 @@ VPNPopup {
                 Layout.alignment: Qt.AlignHCenter
             }
             VPNHeadline {
-                text: VPNl18n.InAppAuthSignInFailedPopupTitle
+                id: authErrorTitle
+                text: ""
                 width: undefined
                 Layout.fillWidth: true
-
             }
 
             VPNTextBlock {
@@ -67,24 +66,46 @@ VPNPopup {
             return Math.ceil(retryAfterSec / 60);
         }
 
+        function showGenericAuthError() {
+            authErrorTitle.text = VPNl18n.InAppAuthProblemSigningInTitle
+            authErrorMessage.text = VPNl18n.InAppSupportWorkflowSupportErrorText
+            openErrorModalAndForceFocus();
+        }
+
         function onErrorOccurred(e, retryAfterSec) {
             switch(e) {
+            case VPNAuthInApp.ErrorAccountAlreadyExists:
+                showGenericAuthError();
+                break;
+
+            case VPNAuthInApp.ErrorAccountUnknown:
+                showGenericAuthError();
+                break;
+
             case VPNAuthInApp.ErrorEmailCanNotBeUsedToLogin:
+                authErrorTitle.text = VPNl18n.InAppAuthProblemSigningInTitle
                 authErrorMessage.text = VPNl18n.InAppAuthProblemSigningInErrorMessage;
                 openErrorModalAndForceFocus();
                 break;
 
             case VPNAuthInApp.ErrorEmailTypeNotSupported:
+                authErrorTitle.text = VPNl18n.InAppAuthProblemSigningInTitle
                 authErrorMessage.text = VPNl18n.InAppAuthInvalidEmailFormatErrorMessage
                 openErrorModalAndForceFocus();
                 break;
 
             case VPNAuthInApp.ErrorFailedToSendEmail:
-                authErrorMessage.text = "Error - failed to send email"
+                authErrorTitle.text = VPNl18n.InAppAuthProblemSigningInTitle
+                authErrorMessage.text =VPNl18n.InAppAuthProblemSendingEmailErrorMessage
                 openErrorModalAndForceFocus();
                 break;
 
+            case VPNAuthInApp.ErrorServerUnavailable:
+                showGenericAuthError();
+                break;
+
             case VPNAuthInApp.ErrorTooManyRequests:
+                authErrorTitle.text = VPNl18n.InAppAuthSignInFailedPopupTitle
                 const retryAfterMin = retryAfterSecToMin(retryAfterSec);
                 if (retryAfterMin === 1) {
                     authErrorMessage.text = VPNl18n.InAppAuthSignInBlockedForOneMinute;


### PR DESCRIPTION
## Description

This PR adds updates VPNInAppAuthenticationErrorPopup.qml to show a generic error message for the following edge-case errors `ErrorAccountAlreadyExists`, `ErrorAccountUnknown`, and `ErrorServerUnavailable`.

<img width="200" alt="Screen Shot 2022-04-01 at 11 27 40 AM" src="https://user-images.githubusercontent.com/22355127/161327516-f7e3bcb6-d859-4803-a26d-938240972b79.png">

## Reference

#3243 #3068 

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
