### PR TITLE
Parallelize the connection download benchmark

### DIFF
--- a/nebula/ui/components/VPNConnectionInfoError.qml
+++ b/nebula/ui/components/VPNConnectionInfoError.qml
@@ -50,6 +50,7 @@ ColumnLayout {
     }
 
     VPNButton {
+        objectName: "connectionInfoErrorRetryButton"
         Layout.fillWidth: true
 
         // Try again

--- a/nebula/ui/components/VPNConnectionInfoScreen.qml
+++ b/nebula/ui/components/VPNConnectionInfoScreen.qml
@@ -132,6 +132,7 @@ Rectangle {
 
     VPNConnectionInfoError {
         id: connectionInfoError
+        objectName: "connectionInfoError"
 
         opacity: visible && root.state !== "closing" ? 1 : 0
         visible: root.state === "open-error" || root.state === "closing"

--- a/nebula/ui/components/VPNControllerView.qml
+++ b/nebula/ui/components/VPNControllerView.qml
@@ -525,6 +525,7 @@ Item {
 
     VPNIconButton {
         id: connectionInfoToggleButton
+        objectName: "connectionInfoToggleButton"
 
         //% "Close"
         property var connectionInfoCloseText: qsTrId("vpn.connectionInfo.close")

--- a/src/connectionbenchmark/benchmarktask.cpp
+++ b/src/connectionbenchmark/benchmarktask.cpp
@@ -34,7 +34,6 @@ void BenchmarkTask::run() {
   }
 
   setState(StateActive);
-  m_elapsedTimer.start();
 
   TimerSingleShot::create(this, m_maxExecutionTime, [this]() { stop(); });
 }

--- a/src/connectionbenchmark/benchmarktask.h
+++ b/src/connectionbenchmark/benchmarktask.h
@@ -8,8 +8,6 @@
 #include "task.h"
 #include "benchmarktasksentinel.h"
 
-#include <QElapsedTimer>
-
 class BenchmarkTask : public Task {
   Q_OBJECT
   Q_DISABLE_COPY_MOVE(BenchmarkTask)
@@ -24,7 +22,6 @@ class BenchmarkTask : public Task {
   enum State { StateActive, StateInactive, StateCancelled };
 
   State state() const { return m_state; }
-  qint64 executionTime() const { return m_elapsedTimer.elapsed(); }
 
   const BenchmarkTaskSentinel* sentinel() const { return &m_sentinel; }
 
@@ -38,7 +35,6 @@ class BenchmarkTask : public Task {
   State m_state = StateInactive;
 
   const uint32_t m_maxExecutionTime;
-  QElapsedTimer m_elapsedTimer;
 
   BenchmarkTaskSentinel m_sentinel;
 };

--- a/src/connectionbenchmark/benchmarktaskdownload.cpp
+++ b/src/connectionbenchmark/benchmarktaskdownload.cpp
@@ -10,6 +10,7 @@
 
 #include <QByteArray>
 #include <QDnsLookup>
+#include <QHostAddress>
 
 constexpr const char* MULLVAD_DEFAULT_DNS = "10.64.0.1";
 

--- a/src/connectionbenchmark/benchmarktaskdownload.cpp
+++ b/src/connectionbenchmark/benchmarktaskdownload.cpp
@@ -12,7 +12,9 @@
 #include <QDnsLookup>
 #include <QHostAddress>
 
+#if !defined(MVPN_DUMMY)
 constexpr const char* MULLVAD_DEFAULT_DNS = "10.64.0.1";
+#endif
 
 namespace {
 Logger logger(LOG_MAIN, "BenchmarkTaskDownload");
@@ -39,7 +41,9 @@ void BenchmarkTaskDownload::handleState(BenchmarkTask::State state) {
 
   if (state == BenchmarkTask::StateActive) {
     // Start DNS resolution
+#if !defined(MVPN_DUMMY)
     m_dnsLookup.setNameserver(QHostAddress(MULLVAD_DEFAULT_DNS));
+#endif
     m_dnsLookup.lookup();
   } else if (state == BenchmarkTask::StateInactive) {
     for (NetworkRequest* request : m_requests) {

--- a/src/connectionbenchmark/benchmarktaskdownload.cpp
+++ b/src/connectionbenchmark/benchmarktaskdownload.cpp
@@ -50,10 +50,15 @@ void BenchmarkTaskDownload::handleState(BenchmarkTask::State state) {
       request->abort();
     }
     m_requests.clear();
+    m_dnsLookup.abort();
   }
 }
 
 void BenchmarkTaskDownload::dnsLookupFinished() {
+  if (state() != BenchmarkTask::StateActive) {
+    logger.warning() << "DNS Lookup finished after task aborted";
+    return;
+  }
   if (m_dnsLookup.error() != QDnsLookup::NoError) {
     logger.error() << "DNS Lookup Failed:" << m_dnsLookup.errorString();
     emit finished(0, true);

--- a/src/connectionbenchmark/benchmarktaskdownload.cpp
+++ b/src/connectionbenchmark/benchmarktaskdownload.cpp
@@ -92,6 +92,8 @@ void BenchmarkTaskDownload::downloadProgressed(qint64 bytesReceived,
 #ifdef MVPN_DEBUG
   logger.debug() << "Handle progressed:" << bytesReceived << "(received)"
                  << bytesTotal << "(total)";
+#else
+  Q_UNUSED(bytesReceived);
 #endif
 
   // Count and discard downloaded data

--- a/src/connectionbenchmark/benchmarktaskdownload.h
+++ b/src/connectionbenchmark/benchmarktaskdownload.h
@@ -7,7 +7,10 @@
 
 #include "benchmarktask.h"
 
+#include <QDnsLookup>
+#include <QElapsedTimer>
 #include <QNetworkReply>
+#include <QUrl>
 
 class NetworkRequest;
 
@@ -16,22 +19,26 @@ class BenchmarkTaskDownload final : public BenchmarkTask {
   Q_DISABLE_COPY_MOVE(BenchmarkTaskDownload)
 
  public:
-  explicit BenchmarkTaskDownload(const QString& fileUrl);
+  explicit BenchmarkTaskDownload(const QUrl& url);
   ~BenchmarkTaskDownload();
 
  signals:
   void finished(quint64 bytesPerSecond, bool hasUnexpectedError);
 
  private:
+  void dnsLookupFinished();
   void downloadProgressed(qint64 bytesReceived, qint64 bytesTotal,
                           QNetworkReply* reply);
   void downloadReady(QNetworkReply::NetworkError error, const QByteArray& data);
   void handleState(BenchmarkTask::State state);
 
  private:
-  NetworkRequest* m_request = nullptr;
-  const QString m_fileUrl;
+  QDnsLookup m_dnsLookup;
+  QList<NetworkRequest*> m_requests;
+  const QUrl m_fileUrl;
+
   qint64 m_bytesReceived = 0;
+  QElapsedTimer m_elapsedTimer;
 };
 
 #endif  // BENCHMARKTASKDOWNLOAD_H

--- a/src/connectionbenchmark/connectionbenchmark.cpp
+++ b/src/connectionbenchmark/connectionbenchmark.cpp
@@ -17,7 +17,8 @@ namespace {
 Logger logger(LOG_MODEL, "ConnectionBenchmark");
 }
 
-ConnectionBenchmark::ConnectionBenchmark() {
+ConnectionBenchmark::ConnectionBenchmark()
+    : m_downloadUrl(Constants::BENCHMARK_DOWNLOAD_URL) {
   MVPN_COUNT_CTOR(ConnectionBenchmark);
 }
 
@@ -89,7 +90,7 @@ void ConnectionBenchmark::start() {
 
   // Create download benchmark
   BenchmarkTaskDownload* downloadTask =
-      new BenchmarkTaskDownload(QUrl(Constants::BENCHMARK_DOWNLOAD_URL));
+      new BenchmarkTaskDownload(m_downloadUrl);
   connect(downloadTask, &BenchmarkTaskDownload::finished, this,
           &ConnectionBenchmark::downloadBenchmarked);
   connect(downloadTask->sentinel(), &BenchmarkTask::destroyed, this,

--- a/src/connectionbenchmark/connectionbenchmark.cpp
+++ b/src/connectionbenchmark/connectionbenchmark.cpp
@@ -89,7 +89,7 @@ void ConnectionBenchmark::start() {
 
   // Create download benchmark
   BenchmarkTaskDownload* downloadTask =
-      new BenchmarkTaskDownload(Constants::BENCHMARK_DOWNLOAD_URL);
+      new BenchmarkTaskDownload(QUrl(Constants::BENCHMARK_DOWNLOAD_URL));
   connect(downloadTask, &BenchmarkTaskDownload::finished, this,
           &ConnectionBenchmark::downloadBenchmarked);
   connect(downloadTask->sentinel(), &BenchmarkTask::destroyed, this,

--- a/src/connectionbenchmark/connectionbenchmark.h
+++ b/src/connectionbenchmark/connectionbenchmark.h
@@ -9,6 +9,7 @@
 
 #include <QList>
 #include <QObject>
+#include <QUrl>
 
 class ConnectionHealth;
 
@@ -16,6 +17,8 @@ class ConnectionBenchmark final : public QObject {
   Q_OBJECT;
   Q_DISABLE_COPY_MOVE(ConnectionBenchmark);
 
+  Q_PROPERTY(QString downloadUrl READ downloadUrl WRITE setDownloadUrl NOTIFY
+                 downloadUrlChanged)
   Q_PROPERTY(State state READ state NOTIFY stateChanged);
   Q_PROPERTY(Speed speed READ speed NOTIFY speedChanged);
   Q_PROPERTY(quint64 bitsPerSec READ bitsPerSec NOTIFY bitsPerSecChanged);
@@ -50,11 +53,18 @@ class ConnectionBenchmark final : public QObject {
   quint16 pingLatency() const { return m_pingLatency; }
   quint64 bitsPerSec() const { return m_bitsPerSec; }
 
+  QString downloadUrl() const { return m_downloadUrl.toString(); }
+  void setDownloadUrl(QString url) {
+    m_downloadUrl.setUrl(url);
+    emit downloadUrlChanged();
+  }
+
  signals:
   void bitsPerSecChanged();
   void pingLatencyChanged();
   void speedChanged();
   void stateChanged();
+  void downloadUrlChanged();
 
  private:
   void downloadBenchmarked(quint64 bitsPerSec, bool hasUnexpectedError);
@@ -67,6 +77,8 @@ class ConnectionBenchmark final : public QObject {
   void stop();
 
  private:
+  QUrl m_downloadUrl;
+
   QList<BenchmarkTask*> m_benchmarkTasks;
 
   State m_state = StateInitial;

--- a/src/connectionhealth.cpp
+++ b/src/connectionhealth.cpp
@@ -47,8 +47,10 @@ ConnectionHealth::ConnectionHealth() : m_dnsPingSender(QHostAddress()) {
   m_noSignalTimer.setSingleShot(true);
 
   m_settlingTimer.setSingleShot(true);
-  connect(&m_settlingTimer, &QTimer::timeout, this,
-          []() { logger.debug() << "Unsettled period over."; });
+  connect(&m_settlingTimer, &QTimer::timeout, this, [this]() {
+    logger.debug() << "Unsettled period over.";
+    emit unsettledChanged();
+  });
 
   connect(&m_healthCheckTimer, &QTimer::timeout, this,
           &ConnectionHealth::healthCheckup);
@@ -228,6 +230,7 @@ void ConnectionHealth::healthCheckup() {
 
 void ConnectionHealth::startUnsettledPeriod() {
   logger.debug() << "Starting unsettled period.";
+  emit unsettledChanged();
   m_settlingTimer.start(SETTLING_TIMEOUT_SEC * 1000);
 }
 

--- a/src/connectionhealth.h
+++ b/src/connectionhealth.h
@@ -25,6 +25,7 @@ class ConnectionHealth final : public QObject {
                  NOTIFY stabilityChanged)
   Q_PROPERTY(uint latency READ latency NOTIFY pingReceived)
   Q_PROPERTY(double loss READ loss NOTIFY pingReceived)
+  Q_PROPERTY(bool unsettled READ isUnsettled NOTIFY unsettledChanged)
 
  public:
   ConnectionHealth();
@@ -43,6 +44,7 @@ class ConnectionHealth final : public QObject {
 
  signals:
   void stabilityChanged();
+  void unsettledChanged();
   void pingReceived();
 
  private:

--- a/src/networkrequest.cpp
+++ b/src/networkrequest.cpp
@@ -112,6 +112,32 @@ NetworkRequest* NetworkRequest::createForGetUrl(Task* parent,
   return r;
 }
 
+NetworkRequest* NetworkRequest::createForGetHostAddress(
+    Task* parent, const QString& url, const QHostAddress& address) {
+  Q_ASSERT(parent);
+  QUrl requestUrl(url);
+  QString hostname = requestUrl.host();
+
+  NetworkRequest* r = new NetworkRequest(parent, 200, false);
+  r->m_request.setHeader(QNetworkRequest::ContentTypeHeader,
+                         "application/json");
+  r->m_request.setAttribute(QNetworkRequest::RedirectPolicyAttribute,
+                            QNetworkRequest::NoLessSafeRedirectPolicy);
+
+  // Rewrite the request URL to use an explicit host address.
+  if (address.protocol() == QAbstractSocket::IPv6Protocol) {
+    requestUrl.setHost("[" + address.toString() + "]");
+  } else {
+    requestUrl.setHost(address.toString());
+  }
+  r->m_request.setUrl(requestUrl);
+  r->m_request.setRawHeader("Host", hostname.toLocal8Bit());
+  r->m_request.setPeerVerifyName(hostname);
+
+  r->getRequest();
+  return r;
+}
+
 // static
 NetworkRequest* NetworkRequest::createForAuthenticationVerification(
     Task* parent, const QString& pkceCodeSuccess,

--- a/src/networkrequest.h
+++ b/src/networkrequest.h
@@ -26,6 +26,9 @@ class NetworkRequest final : public QObject {
 
   static NetworkRequest* createForGetUrl(Task* parent, const QString& url,
                                          int status = 0);
+  static NetworkRequest* createForGetHostAddress(Task* parent,
+                                                 const QString& url,
+                                                 const QHostAddress& address);
 
   static NetworkRequest* createForAuthenticationVerification(
       Task* parent, const QString& pkceCodeSuccess,

--- a/src/platforms/wasm/wasmnetworkrequest.cpp
+++ b/src/platforms/wasm/wasmnetworkrequest.cpp
@@ -77,6 +77,18 @@ NetworkRequest* NetworkRequest::createForGetUrl(Task* parent,
 }
 
 // static
+NetworkRequest* NetworkRequest::createForGetHostAddress(
+    Task* parent, const QString& url, const QHostAddress& address) {
+  Q_ASSERT(parent);
+  Q_UNUSED(url);
+  Q_UNUSED(address);
+
+  NetworkRequest* r = new NetworkRequest(parent, 200, false);
+  createDummyRequest(r);
+  return r;
+}
+
+// static
 NetworkRequest* NetworkRequest::createForAuthenticationVerification(
     Task* parent, const QString&, const QString&) {
   Q_ASSERT(parent);

--- a/tests/functional/helper.js
+++ b/tests/functional/helper.js
@@ -59,11 +59,20 @@ module.exports = {
     client.close();
   },
 
-  async activate() {
+  async activate(awaitConnectionOkay = false) {
     const json = await this._writeCommand('activate');
     assert(
         json.type === 'activate' && !('error' in json),
         `Command failed: ${json.error}`);
+
+    if (awaitConnectionOkay) {
+      await this.waitForCondition(async () => {
+        let title = await this.getElementProperty('controllerTitle', 'text');
+        let unsettled =
+            await this.getElementProperty('VPNConnectionHealth', 'unsettled');
+        return (title == 'VPN is on') && (unsettled == 'false');
+      });
+    }
   },
 
   async deactivate() {

--- a/tests/functional/testBenchmark.js
+++ b/tests/functional/testBenchmark.js
@@ -1,0 +1,182 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+const vpn = require('./helper.js');
+const assert = require('assert');
+
+describe('Benchmark', function() {
+  this.timeout(120000);
+
+  it('Successful benchmark', async () => {
+    await vpn.authenticate(true, true);
+    await vpn.waitForElement('controllerTitle');
+    await vpn.activate(true);
+
+    // Start the connection benchmark.
+    await vpn.waitForElement('connectionInfoToggleButton');
+    await vpn.clickOnElement('connectionInfoToggleButton');
+    await vpn.waitForCondition(async () => {
+      let state =
+          await vpn.getElementProperty('VPNConnectionBenchmark', 'state');
+      return state == 'StateRunning';
+    });
+    await vpn.waitForCondition(async () => {
+      let state =
+          await vpn.getElementProperty('VPNConnectionBenchmark', 'state');
+      return state != 'StateRunning';
+    });
+
+    // We expect the benchmark to succeed.
+    await vpn.wait(3000);
+    let state = await vpn.getElementProperty('VPNConnectionBenchmark', 'state');
+    let speed = await vpn.getElementProperty('VPNConnectionBenchmark', 'speed');
+    let bps = parseInt(
+        await vpn.getElementProperty('VPNConnectionBenchmark', 'bitsPerSec'));
+    assert.strictEqual(state, 'StateReady');
+    assert.strictEqual(speed, (bps >= 25000000) ? 'SpeedFast' : 'SpeedSlow');
+
+    // Exit the benchmark
+    await vpn.waitForElement('connectionInfoToggleButton');
+    await vpn.clickOnElement('connectionInfoToggleButton');
+  });
+
+  it('Failed benchmark on HTTP error', async () => {
+    await vpn.authenticate(true, true);
+    await vpn.waitForElement('controllerTitle');
+    await vpn.activate(true);
+
+    // Re-Configure the benchmark to use a URL that generates an HTTP error.
+    await vpn.setElementProperty(
+        'VPNConnectionBenchmark', 'downloadUrl', 's',
+        'http://httpstat.us/500?sleep=2000');
+
+    // Start the connection benchmark and wait for it to finish.
+    await vpn.waitForElement('connectionInfoToggleButton');
+    await vpn.clickOnElement('connectionInfoToggleButton');
+    await vpn.waitForCondition(async () => {
+      let state =
+          await vpn.getElementProperty('VPNConnectionBenchmark', 'state');
+      return state == 'StateRunning';
+    });
+    await vpn.waitForCondition(async () => {
+      let state =
+          await vpn.getElementProperty('VPNConnectionBenchmark', 'state');
+      return state != 'StateRunning';
+    });
+
+    // We expect the benchmark to fail.
+    await vpn.wait(3000);
+    assert.strictEqual(
+        await vpn.getElementProperty('VPNConnectionBenchmark', 'state'),
+        'StateError');
+    assert.strictEqual(
+        await vpn.getElementProperty('connectionInfoError', 'visible'), 'true');
+
+    // Exit the benchmark
+    await vpn.waitForElement('connectionInfoToggleButton');
+    await vpn.clickOnElement('connectionInfoToggleButton');
+  });
+
+  it('Retry failed benchmark', async () => {
+    await vpn.authenticate(true, true);
+    await vpn.waitForElement('controllerTitle');
+    await vpn.activate(true);
+
+    let downloadUrl =
+        await vpn.getElementProperty('VPNConnectionBenchmark', 'downloadUrl');
+
+    // Re-Configure the benchmark to use a URL that generates an HTTP error.
+    await vpn.setElementProperty(
+        'VPNConnectionBenchmark', 'downloadUrl', 's',
+        'http://httpstat.us/404?sleep=2000');
+
+    // Start the connection benchmark and wait for it to finish.
+    await vpn.waitForElement('connectionInfoToggleButton');
+    await vpn.clickOnElement('connectionInfoToggleButton');
+    await vpn.waitForCondition(async () => {
+      let state =
+          await vpn.getElementProperty('VPNConnectionBenchmark', 'state');
+      return state == 'StateRunning';
+    });
+    await vpn.waitForCondition(async () => {
+      let state =
+          await vpn.getElementProperty('VPNConnectionBenchmark', 'state');
+      return state != 'StateRunning';
+    });
+
+    // We expect the benchmark to fail.
+    await vpn.wait(3000);
+    assert.strictEqual(
+        await vpn.getElementProperty('VPNConnectionBenchmark', 'state'),
+        'StateError');
+    assert.strictEqual(
+        await vpn.getElementProperty('connectionInfoError', 'visible'), 'true');
+
+    // Restore the original download URL and retry the benchmark.
+    await vpn.setElementProperty(
+        'VPNConnectionBenchmark', 'downloadUrl', 's', downloadUrl);
+    await vpn.clickOnElement('connectionInfoErrorRetryButton');
+    await vpn.waitForCondition(async () => {
+      let state =
+          await vpn.getElementProperty('VPNConnectionBenchmark', 'state');
+      return state == 'StateRunning';
+    });
+    await vpn.waitForCondition(async () => {
+      let state =
+          await vpn.getElementProperty('VPNConnectionBenchmark', 'state');
+      return state != 'StateRunning';
+    });
+
+    // This time we expect the benchmark to succeed.
+    await vpn.wait();
+    let speed = await vpn.getElementProperty('VPNConnectionBenchmark', 'speed');
+    let bps = parseInt(
+        await vpn.getElementProperty('VPNConnectionBenchmark', 'bitsPerSec'));
+    assert.strictEqual(speed, (bps >= 25000000) ? 'SpeedFast' : 'SpeedSlow');
+
+    // Exit the benchmark
+    await vpn.waitForElement('connectionInfoToggleButton');
+    await vpn.clickOnElement('connectionInfoToggleButton');
+  });
+
+  it('Error on unexpected disconnect', async () => {
+    await vpn.authenticate(true, true);
+    await vpn.waitForElement('controllerTitle');
+    await vpn.activate(true);
+
+    // Re-Configure the benchmark to use a URL that will hang for a while.
+    await vpn.setElementProperty(
+        'VPNConnectionBenchmark', 'downloadUrl', 's',
+        'http://httpstat.us/204?sleep=10000');
+
+    // Start the connection benchmark.
+    await vpn.waitForElement('connectionInfoToggleButton');
+    await vpn.clickOnElement('connectionInfoToggleButton');
+    await vpn.waitForCondition(async () => {
+      let state =
+          await vpn.getElementProperty('VPNConnectionBenchmark', 'state');
+      return state == 'StateRunning';
+    });
+
+    // Disconnect the VPN, this should trigger an error.
+    await vpn.wait(1000);
+    await vpn.deactivate();
+    await vpn.waitForCondition(async () => {
+      let state =
+          await vpn.getElementProperty('VPNConnectionBenchmark', 'state');
+      return state != 'StateRunning';
+    });
+
+    // We expect the benchmark to fail.
+    await vpn.wait(5000);
+    assert.strictEqual(
+        await vpn.getElementProperty('VPNConnectionBenchmark', 'state'),
+        'StateError');
+    assert.strictEqual(
+        await vpn.getElementProperty('connectionInfoError', 'visible'), 'true');
+
+    // Exit the benchmark
+    await vpn.waitForElement('connectionInfoToggleButton');
+    await vpn.clickOnElement('connectionInfoToggleButton');
+  });
+});


### PR DESCRIPTION
## Description

In an attempt to get benchmark results closer to what's reported by speedtest.net, we can open multiple connections to try and do a better job of saturating the VPN network connection. This patch does so by exploiting DNS load balancing to open connections to multiple servers that ought to be hosting the download file.

## Reference

Closes: #3002
Closes: #3000

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
