### PR TITLE
Delay initial handleStabilityChange call

### DIFF
--- a/src/connectionbenchmark/connectionbenchmark.cpp
+++ b/src/connectionbenchmark/connectionbenchmark.cpp
@@ -12,6 +12,7 @@
 #include "logger.h"
 #include "mozillavpn.h"
 #include "taskscheduler.h"
+#include "timersingleshot.h"
 
 namespace {
 Logger logger(LOG_MODEL, "ConnectionBenchmark");
@@ -75,7 +76,7 @@ void ConnectionBenchmark::start() {
   setState(StateRunning);
 
   if (vpn->connectionHealth()->stability() == ConnectionHealth::NoSignal) {
-    handleStabilityChange();
+    TimerSingleShot::create(this, 3000, [this]() { handleStabilityChange(); });
   }
 
   // Create ping benchmark


### PR DESCRIPTION
## Description

If the speed test is restarted from the error screen it seems like we do not run it again. That’s the case because if we have no signal at the time the test is retaken we are setting `StateError` again. Let’s delay `handleStabilityChange` so we do not abort the speed test immediately.

## Reference

Refresh button from the connection information unexpected error screen is not working ([VPN-1944](https://mozilla-hub.atlassian.net/jira/software/c/projects/VPN/boards/344?modal=detail&selectedIssue=VPN-1944))

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
