### PR TITLE
Proposal: Handle Timeouts in InAppAuth Sign-In Step

### DIFF
--- a/docs/authentication-in-app.md
+++ b/docs/authentication-in-app.md
@@ -107,6 +107,7 @@ The client asks for the password. Then, it goes to the **Signing-in** state.
 * Errors:
     * Incorrect password
     * Too many requests
+    * Request Timeout 
     * Sign in with this email type is not currently supported -This is a
       strange FxA code. We have to investigate how to reproduce it.
     * Failed to send email - the unblock code is needed but the email sending
@@ -283,6 +284,7 @@ The authentication continues in the browser as we used to do in v2.7.
 - Invalid TOTP code
 - Too many requests
 - Server unavailable
+- Request Timeout
 - Unknown account
 
 ### The whole flow

--- a/nebula/ui/components/VPNPopup.qml
+++ b/nebula/ui/components/VPNPopup.qml
@@ -110,7 +110,7 @@ Popup {
     Overlay.modal: Rectangle {
         id: overlayBackground
 
-        color: "#4D000000"
+        color: VPNTheme.theme.overlayBackground
 
         Behavior on opacity {
             NumberAnimation {

--- a/nebula/ui/components/VPNRemoveDevicePopup.qml
+++ b/nebula/ui/components/VPNRemoveDevicePopup.qml
@@ -209,7 +209,7 @@ Popup {
 
         Overlay.modal: Rectangle {
             id: overlayBackground
-            color: "#4D000000"
+            color: VPNTheme.theme.overlayBackground
 
             Behavior on opacity {
                 NumberAnimation {

--- a/nebula/ui/components/inAppAuth/VPNInAppAuthenticationErrorPopup.qml
+++ b/nebula/ui/components/inAppAuth/VPNInAppAuthenticationErrorPopup.qml
@@ -78,7 +78,10 @@ VPNPopup {
                 authErrorMessage.text = VPNl18n.InAppAuthInvalidEmailFormatErrorMessage
                 openErrorModalAndForceFocus();
                 break;
-
+            case VPNAuthInApp.ErrorConnectionTimeout:
+                authErrorMessage.text = qsTrId("vpn.alert.noInternet")
+                openErrorModalAndForceFocus();
+                break;
             case VPNAuthInApp.ErrorFailedToSendEmail:
                 authErrorMessage.text = "Error - failed to send email"
                 openErrorModalAndForceFocus();

--- a/nebula/ui/components/inAppAuth/VPNInAppAuthenticationInputs.qml
+++ b/nebula/ui/components/inAppAuth/VPNInAppAuthenticationInputs.qml
@@ -208,6 +208,10 @@ ColumnLayout {
                 base._inputErrorMessage = VPNl18n.InAppAuthInvalidCodeErrorMessage;
                 activeInput().forceActiveFocus();
                 break;
+            case VPNAuthInApp.ErrorConnectionTimeout:
+                // In case of a timeout we want to exit here 
+                // to skip setting hasError - so the user can retry instantly
+                return;
             }
 
             if (!authError.visible)

--- a/nebula/ui/themes/themes.js
+++ b/nebula/ui/themes/themes.js
@@ -36,6 +36,8 @@ theme.redPressed = '#C50042';
 theme.redfocusOutline = '#66C50042';
 theme.white = '#FFFFFF'
 
+theme.overlayBackground = '#4D000000';
+
 theme.checkBoxWarning = '#C45A27';
 
 theme.errorFocusOutline = '#FFBDC5';

--- a/src/authenticationinapp/authenticationinapp.h
+++ b/src/authenticationinapp/authenticationinapp.h
@@ -73,6 +73,7 @@ class AuthenticationInApp final : public QObject {
     ErrorInvalidTotpCode,
     ErrorTooManyRequests,
     ErrorServerUnavailable,
+    ErrorConnectionTimeout,
     ErrorUnknownAccount,
   };
   Q_ENUM(ErrorType);

--- a/src/authenticationinapp/authenticationinapplistener.cpp
+++ b/src/authenticationinapp/authenticationinapplistener.cpp
@@ -266,6 +266,14 @@ void AuthenticationInAppListener::signInInternal(const QString& unblockCode) {
   connect(request, &NetworkRequest::requestFailed, this,
           [this, unblockCode](QNetworkReply::NetworkError error,
                               const QByteArray& data) {
+            if (error == QNetworkReply::TimeoutError) {
+              AuthenticationInApp* aia = AuthenticationInApp::instance();
+              aia->requestState(AuthenticationInApp::StateSignIn, this);
+              aia->requestErrorPropagation(
+                  this, AuthenticationInApp::ErrorConnectionTimeout);
+              return;
+            }
+
             QJsonDocument json = QJsonDocument::fromJson(data);
             if (json.isObject()) {
               QJsonObject obj = json.object();

--- a/src/commands/commandlogin.cpp
+++ b/src/commands/commandlogin.cpp
@@ -189,6 +189,9 @@ int CommandLogin::run(QStringList& tokens) {
               case AuthenticationInApp::ErrorInvalidTotpCode:
                 stream << "Invalid TOTP code" << Qt::endl;
                 break;
+              case AuthenticationInApp::ErrorConnectionTimeout:
+                stream << "Request Timed Out" << Qt::endl;
+                break;
             }
           });
     }


### PR DESCRIPTION
## Description
During the weekend, I tried logging in on a VERY flaky internet connection. It was not fun. 
Currently, on a timeout in the sign-in step, we will error out, have show the "auth failed notification" and close the dialogue, forcing me to go through all the steps again, which is quite painful on an already flaky/bad connection. 

How about we use the error modal and let the user retry instead of exiting auth?

## Reference

https://user-images.githubusercontent.com/9611612/161549325-381be9e0-9beb-4d90-8439-b44192b8a1bc.mp4

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
