### PR TITLE
Remove the 'fake' disconecting timeout - closes VPN-1985

### DIFF
--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -46,8 +46,6 @@ constexpr const int CONNECTION_MAX_RETRY = 9;
 constexpr const uint32_t CONFIRMING_TIMOUT_SEC = 10;
 constexpr const uint32_t HANDSHAKE_TIMEOUT_SEC = 15;
 
-constexpr const uint32_t TIME_DEACTIVATION = 1500;
-
 // The Mullvad proxy services are located at internal IPv4 addresses in the
 // 10.124.0.0/20 address range, which is a subset of the 10.0.0.0/8 Class-A
 // private address range.
@@ -425,18 +423,6 @@ void Controller::disconnected() {
 
   clearConnectedTime();
   clearRetryCounter();
-
-  // This is an unexpected disconnection. Let's use the Disconnecting state to
-  // animate the UI.
-  if (m_state != StateDisconnecting && m_state != StateSwitching) {
-    setState(StateDisconnecting);
-    TimerSingleShot::create(this, TIME_DEACTIVATION, [this]() {
-      if (m_state == StateDisconnecting) {
-        disconnected();
-      }
-    });
-    return;
-  }
 
   NextStep nextStep = m_nextStep;
 


### PR DESCRIPTION
## Description

We don't need to have this timeout to simulate the disconnecting phase, because:
- we have removed it elsewhere
- it introduces funny non-sense animations when already disconnected

## Reference

VPN-1985