### PR TITLE
Delete local storage on hard reset.

### DIFF
--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -1699,6 +1699,10 @@ void MozillaVPN::hardReset() {
   SettingsHolder* settingsHolder = SettingsHolder::instance();
   Q_ASSERT(settingsHolder);
   settingsHolder->hardReset();
+
+  QmlEngineHolder* engineHolder = QmlEngineHolder::instance();
+  Q_ASSERT(engineHolder);
+  engineHolder->clearLocalStorage();
 }
 
 void MozillaVPN::hardResetAndQuit() {

--- a/src/qmlengineholder.cpp
+++ b/src/qmlengineholder.cpp
@@ -69,3 +69,10 @@ void QmlEngineHolder::hideWindow() {
 
   w->hide();
 }
+
+void QmlEngineHolder::clearLocalStorage() {
+  QDir offlineStorageDir(m_engine.offlineStoragePath());
+  if (!offlineStorageDir.removeRecursively()) {
+    logger.debug() << "Failed to clear storage at" << offlineStorageDir.path();
+  }
+}

--- a/src/qmlengineholder.h
+++ b/src/qmlengineholder.h
@@ -7,6 +7,7 @@
 
 #include "networkmanager.h"
 
+#include <QDir>
 #include <QQmlApplicationEngine>
 
 class QWindow;
@@ -29,6 +30,8 @@ class QmlEngineHolder final : public NetworkManager {
   QWindow* window() const;
   void showWindow();
   void hideWindow();
+
+  void clearLocalStorage();
 
  protected:
   void clearCacheInternal() override;


### PR DESCRIPTION
## Description

When issuing a hard reset through the developer menu, we should ensure that any data saved by the Glean local storage database should be purged. 

## Reference

Closes: #2231

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
