### PR TITLE
modified layout to support long country names

### DIFF
--- a/nebula/ui/components/VPNConnectionInfoItem.qml
+++ b/nebula/ui/components/VPNConnectionInfoItem.qml
@@ -45,9 +45,10 @@ RowLayout {
         id: itemLabel
         color: VPNTheme.theme.white
         text: infoStatusItem.title
+        wrapMode: Text.WordWrap
 
         Layout.alignment: Qt.AlignVCenter
-        Layout.fillWidth: true
+        Layout.preferredWidth: 120
     }
 
     VPNInterLabel {
@@ -55,7 +56,9 @@ RowLayout {
 
         color: VPNTheme.colors.white
         text: infoStatusItem.subtitle
-
+        horizontalAlignment: Text.AlignRight
+        
+        Layout.fillWidth: true
         Layout.alignment: Qt.AlignVCenter | Qt.AlignRight
     }
 }

--- a/nebula/ui/components/VPNConnectionInfoItem.qml
+++ b/nebula/ui/components/VPNConnectionInfoItem.qml
@@ -45,10 +45,10 @@ RowLayout {
         id: itemLabel
         color: VPNTheme.theme.white
         text: infoStatusItem.title
-        wrapMode: Text.WordWrap
-
+        
         Layout.alignment: Qt.AlignVCenter
-        Layout.preferredWidth: 120
+        Layout.fillWidth: true
+        elide: Text.ElideRight
     }
 
     VPNInterLabel {
@@ -58,7 +58,6 @@ RowLayout {
         text: infoStatusItem.subtitle
         horizontalAlignment: Text.AlignRight
         
-        Layout.fillWidth: true
-        Layout.alignment: Qt.AlignVCenter | Qt.AlignRight
+        Layout.alignment: Qt.AlignRight | Qt. AlignVCenter
     }
 }


### PR DESCRIPTION
## Description

This PR addresses issues with long country names and city names after running a speed test. 

The fix makes long bolded labels wrap - by whole words, making sure we don't break words. Example: United States of America wraps at end of `of` instead of United States of Am-erica. See image below: 

<img width="271" alt="image" src="https://user-images.githubusercontent.com/3924990/161893591-ce64d1e0-7815-42ba-a2cf-6fbda303d612.png">

Bug addressed can be seen in image below: 

<img width="638" alt="image" src="https://user-images.githubusercontent.com/3924990/161893865-4cd3fc1b-f3d5-42fc-a029-03482c054878.png">


## Reference

Jira Issue: https://mozilla-hub.atlassian.net/browse/VPN-2023 
 