### PR TITLE
WIP: Start a server verification task on handshake failure.

### DIFF
--- a/src/constants.h
+++ b/src/constants.h
@@ -56,7 +56,7 @@ CONSTEXPR(uint32_t, releaseMonitorMsec, 21600000, 4000, 0)
 
 // in milliseconds, how often we should fetch the server list, the account and
 // so on.
-CONSTEXPR(uint32_t, schedulePeriodicTaskTimerMsec, 3600000, 4000, 0)
+CONSTEXPR(uint32_t, schedulePeriodicTaskTimerMsec, 3600000, 60000, 0)
 
 // how often we check the captive portal when the VPN is on.
 CONSTEXPR(uint32_t, captivePortalRequestTimeoutMsec, 10000, 4000, 0)

--- a/src/controller.h
+++ b/src/controller.h
@@ -137,7 +137,7 @@ class Controller final : public QObject {
   void enableDisconnectInConfirmingChanged();
   void silentSwitchDone();
   void activationBlockedForCaptivePortal();
-  void handshakeFailed(const QString& serverHostname);
+  void handshakeFailed(const QString& serverPublicKey);
 
  private:
   void setState(State state);

--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -32,6 +32,7 @@
 #include "tasks/products/taskproducts.h"
 #include "tasks/removedevice/taskremovedevice.h"
 #include "tasks/servers/taskservers.h"
+#include "tasks/serververify/taskserververify.h"
 #include "tasks/surveydata/tasksurveydata.h"
 #include "tasks/sendfeedback/tasksendfeedback.h"
 #include "tasks/createsupportticket/taskcreatesupportticket.h"
@@ -123,10 +124,12 @@ MozillaVPN::MozillaVPN() : m_private(new Private()) {
             setState(StateBackendFailure);
           });
 
-  connect(&m_private->m_controller, &Controller::readyToServerUnavailable, this,
-          []() {
-            NotificationHandler::instance()->serverUnavailableNotification();
-          });
+  connect(
+      &m_private->m_controller, &Controller::readyToServerUnavailable, this,
+      [this]() {
+        TaskScheduler::scheduleTask(new TaskServerVerify(m_serverPublicKey));
+        NotificationHandler::instance()->serverUnavailableNotification();
+      });
 
   connect(&m_private->m_controller, &Controller::stateChanged, this,
           &MozillaVPN::controllerStateChanged);

--- a/src/platforms/linux/linuxpingsender.cpp
+++ b/src/platforms/linux/linuxpingsender.cpp
@@ -75,17 +75,19 @@ LinuxPingSender::LinuxPingSender(const QHostAddress& source, QObject* parent)
     return;
   }
 
-  quint32 ipv4addr = source.toIPv4Address();
-  struct sockaddr_in addr;
-  memset(&addr, 0, sizeof addr);
-  addr.sin_family = AF_INET;
-  addr.sin_addr.s_addr = qToBigEndian<quint32>(ipv4addr);
+  if (!source.isNull()) {
+    quint32 ipv4addr = source.toIPv4Address();
+    struct sockaddr_in addr;
+    memset(&addr, 0, sizeof addr);
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = qToBigEndian<quint32>(ipv4addr);
 
-  if (bind(m_socket, (struct sockaddr*)&addr, sizeof(addr)) != 0) {
-    close(m_socket);
-    m_socket = -1;
-    logger.error() << "bind error:" << strerror(errno);
-    return;
+    if (bind(m_socket, (struct sockaddr*)&addr, sizeof(addr)) != 0) {
+      close(m_socket);
+      m_socket = -1;
+      logger.error() << "bind error:" << strerror(errno);
+      return;
+    }
   }
 
   m_notifier = new QSocketNotifier(m_socket, QSocketNotifier::Read, this);

--- a/src/platforms/macos/macospingsender.cpp
+++ b/src/platforms/macos/macospingsender.cpp
@@ -40,16 +40,18 @@ MacOSPingSender::MacOSPingSender(const QHostAddress& source, QObject* parent)
     return;
   }
 
-  quint32 ipv4addr = source.toIPv4Address();
-  struct sockaddr_in addr;
-  bzero(&addr, sizeof(addr));
-  addr.sin_family = AF_INET;
-  addr.sin_len = sizeof(addr);
-  addr.sin_addr.s_addr = qToBigEndian<quint32>(ipv4addr);
+  if (!source.isNull()) {
+    quint32 ipv4addr = source.toIPv4Address();
+    struct sockaddr_in addr;
+    bzero(&addr, sizeof(addr));
+    addr.sin_family = AF_INET;
+    addr.sin_len = sizeof(addr);
+    addr.sin_addr.s_addr = qToBigEndian<quint32>(ipv4addr);
 
-  if (bind(m_socket, (struct sockaddr*)&addr, sizeof(addr)) != 0) {
-    logger.error() << "bind error:" << strerror(errno);
-    return;
+    if (bind(m_socket, (struct sockaddr*)&addr, sizeof(addr)) != 0) {
+      logger.error() << "bind error:" << strerror(errno);
+      return;
+    }
   }
 
   m_notifier = new QSocketNotifier(m_socket, QSocketNotifier::Read, this);

--- a/src/qmake/sources.pri
+++ b/src/qmake/sources.pri
@@ -122,6 +122,7 @@ SOURCES += \
         tasks/removedevice/taskremovedevice.cpp \
         tasks/sendfeedback/tasksendfeedback.cpp \
         tasks/servers/taskservers.cpp \
+        tasks/serververify/taskserververify.cpp \
         tasks/surveydata/tasksurveydata.cpp \
         taskscheduler.cpp \
         telemetry.cpp \
@@ -268,6 +269,7 @@ HEADERS += \
         tasks/removedevice/taskremovedevice.h \
         tasks/sendfeedback/tasksendfeedback.h \
         tasks/servers/taskservers.h \
+        tasks/serververify/taskserververify.h \
         tasks/surveydata/tasksurveydata.h \
         taskscheduler.h \
         telemetry.h \

--- a/src/tasks/serververify/taskserververify.cpp
+++ b/src/tasks/serververify/taskserververify.cpp
@@ -1,0 +1,65 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "taskserververify.h"
+#include "errorhandler.h"
+#include "leakdetector.h"
+#include "logger.h"
+#include "mozillavpn.h"
+#include "pingsenderfactory.h"
+
+constexpr const int SERVER_VERIFY_MAX_ATTEMPTS = 4;
+constexpr const int SERVER_VERIFY_INTERVAL_MSEC = 1000;
+
+namespace {
+Logger logger(LOG_MAIN, "TaskServerVerify");
+}
+
+TaskServerVerify::TaskServerVerify(const QString& serverPublicKey)
+    : Task("TaskServerVerify") {
+  MVPN_COUNT_CTOR(TaskServerVerify);
+
+  logger.error() << "Attempting to verify" << logger.keys(serverPublicKey);
+  ServerCountryModel* scm = MozillaVPN::instance()->serverCountryModel();
+  m_server = scm->server(serverPublicKey);
+}
+
+TaskServerVerify::~TaskServerVerify() { MVPN_COUNT_DTOR(TaskServerVerify); }
+
+void TaskServerVerify::run() {
+  if (!m_server.initialized()) {
+    logger.error() << "Attempting to verify an invalid server";
+    emit completed();
+  }
+
+  m_pingReceived = 0;
+  m_pingAttempts = SERVER_VERIFY_MAX_ATTEMPTS;
+  m_pingSender = PingSenderFactory::create(QHostAddress(), this);
+  if (!m_pingSender->isValid()) {
+    logger.error() << "Failed to create PingSender for server verification";
+    emit completed();
+  }
+
+  connect(&m_pingTimer, &QTimer::timeout, this, [&]() {
+    if (m_pingAttempts) {
+      m_pingAttempts--;
+      m_pingSender->sendPing(QHostAddress(m_server.ipv4AddrIn()),
+                             1000 + m_pingAttempts);
+    } else {
+      logger.info() << "Received" << m_pingReceived << "out of"
+                    << SERVER_VERIFY_MAX_ATTEMPTS << "ping attempts";
+      emit completed();
+    }
+  });
+
+  connect(m_pingSender, &PingSender::recvPing, this, [&](quint16 sequence) {
+    Q_UNUSED(sequence);
+    m_pingReceived++;
+    logger.info() << "Received ping from"
+                  << logger.sensitive(m_server.hostname());
+  });
+
+  logger.info() << "Starting ping to" << logger.sensitive(m_server.hostname());
+  m_pingTimer.start(SERVER_VERIFY_INTERVAL_MSEC);
+}

--- a/src/tasks/serververify/taskserververify.h
+++ b/src/tasks/serververify/taskserververify.h
@@ -1,0 +1,34 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef TASKSERVERVERIFY_H
+#define TASKSERVERVERIFY_H
+
+#include "task.h"
+#include "models/server.h"
+
+#include <QObject>
+#include <QTimer>
+
+class PingSender;
+
+class TaskServerVerify final : public Task {
+  Q_DISABLE_COPY_MOVE(TaskServerVerify)
+
+ public:
+  TaskServerVerify(const QString& serverPublicKey);
+  ~TaskServerVerify();
+
+  void run() override;
+
+ private:
+  Server m_server;
+
+  int m_pingAttempts = 0;
+  int m_pingReceived = 0;
+  PingSender* m_pingSender = nullptr;
+  QTimer m_pingTimer;
+};
+
+#endif  // TASKSERVERVERIFY_H

--- a/tests/unit/testtasks.cpp
+++ b/tests/unit/testtasks.cpp
@@ -8,6 +8,7 @@
 #include "../../src/tasks/adddevice/taskadddevice.h"
 #include "../../src/tasks/function/taskfunction.h"
 #include "../../src/tasks/servers/taskservers.h"
+#include "../../src/tasks/serververify/taskserververify.h"
 #include "../../src/taskscheduler.h"
 
 void TestTasks::account() {

--- a/tests/unit/unit.pro
+++ b/tests/unit/unit.pro
@@ -107,6 +107,7 @@ HEADERS += \
     ../../src/tasks/function/taskfunction.h \
     ../../src/tasks/release/taskrelease.h \
     ../../src/tasks/servers/taskservers.h \
+    ../../src/tasks/serververify/taskserververify.h \
     ../../src/taskscheduler.h \
     ../../src/theme.h \
     ../../src/timersingleshot.h \
@@ -202,6 +203,7 @@ SOURCES += \
     ../../src/tasks/function/taskfunction.cpp \
     ../../src/tasks/release/taskrelease.cpp \
     ../../src/tasks/servers/taskservers.cpp \
+    ../../src/tasks/serververify/taskserververify.cpp \
     ../../src/taskscheduler.cpp \
     ../../src/theme.cpp \
     ../../src/timersingleshot.cpp \


### PR DESCRIPTION
## Description

When the user encounters a server unavailable notification error, this often results in a support ticket. In order to provide better logs in this case, we can attempt to ping the failed server and log what we get back. Hopefully, this can help us identify if there is a genuine reachability issue, or if this is some kind of UDP/firewall block.


## Reference

Github issue #2693

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
