### PR TITLE
TC-Windows: Add debug symbols to artifact bundle

### DIFF
--- a/taskcluster/scripts/build/windows.ps1
+++ b/taskcluster/scripts/build/windows.ps1
@@ -41,6 +41,7 @@ Write-Output "Writing Artifacts"
 
 New-Item -Path $REPO_ROOT_PATH/artifacts -ItemType "directory"
 Copy-Item -Path windows/installer/x64/MozillaVPN.msi -Destination ./artifacts/MozillaVPN.msi
+Copy-Item -Path MozillaVPN.pdb -Destination ./artifacts/MozillaVPN.pdb
 
 Compress-Archive -Path unsigned/* -Destination $REPO_ROOT_PATH/artifacts/unsigned.zip
 
@@ -52,3 +53,7 @@ Get-ChildItem -Path $REPO_ROOT_PATH/artifacts
 Stop-Process -Name "mspdbsrv.exe" -Force -ErrorAction SilentlyContinue
 Stop-Process -Name "mspdbsrv" -Force -ErrorAction SilentlyContinue
 Stop-Process -Name "vctip.exe" -Force -ErrorAction SilentlyContinue
+
+Write-Output "Open Processes:"
+
+wmic process get description,executablepath 


### PR DESCRIPTION
## Description
We should be generating the pdb already, so let's put into the artifacts. 

Also log open processes. Currently, the task builds fine but is marked as "fail" due to failing the post-task cleanup. 
Something is having an open handle to some vs-studio .dll and i want to know which :)
