### PR TITLE
Windows: Ignore hidden interfaces for exclusion routes.

### DIFF
--- a/src/platforms/windows/daemon/windowsroutemonitor.cpp
+++ b/src/platforms/windows/daemon/windowsroutemonitor.cpp
@@ -69,8 +69,8 @@ WindowsRouteMonitor::~WindowsRouteMonitor() {
 }
 
 void WindowsRouteMonitor::updateExclusionRoute(MIB_IPFORWARD_ROW2* data,
-                                               const void* ptable) {
-  PMIB_IPFORWARD_TABLE2 table = (PMIB_IPFORWARD_TABLE2)ptable;
+                                               void* ptable) {
+  PMIB_IPFORWARD_TABLE2 table = reinterpret_cast<PMIB_IPFORWARD_TABLE2>(ptable);
   SOCKADDR_INET nexthop = {0};
   quint64 bestLuid = 0;
   int bestMatch = -1;
@@ -117,12 +117,11 @@ void WindowsRouteMonitor::updateExclusionRoute(MIB_IPFORWARD_ROW2* data,
     }
 
     // Ensure that the outgoing network interface is actually online and usable.
-    DWORD hintResult;
+    DWORD result;
     NL_NETWORK_CONNECTIVITY_HINT hint;
-    hintResult = GetNetworkConnectivityHintForInterface(row->InterfaceIndex,
-                                                        &hint);
-    if ((hint.ConnectivityLevel == NetworkConnectivityLevelHintHidden) ||
-        (hintResult != NO_ERROR)) {
+    result = GetNetworkConnectivityHintForInterface(row->InterfaceIndex, &hint);
+    if ((result != NO_ERROR) ||
+        (hint.ConnectivityLevel == NetworkConnectivityLevelHintHidden)) {
       logger.debug() << "Ignoring hidden ifindex:" << row->InterfaceIndex;
       continue;
     }

--- a/src/platforms/windows/daemon/windowsroutemonitor.h
+++ b/src/platforms/windows/daemon/windowsroutemonitor.h
@@ -32,7 +32,7 @@ class WindowsRouteMonitor final : public QObject {
   void routeChanged();
 
  private:
-  void updateExclusionRoute(MIB_IPFORWARD_ROW2* data, const void* table);
+  void updateExclusionRoute(MIB_IPFORWARD_ROW2* data, void* table);
 
   QHash<QHostAddress, MIB_IPFORWARD_ROW2*> m_exclusionRoutes;
 

--- a/src/platforms/windows/daemon/windowsroutemonitor.h
+++ b/src/platforms/windows/daemon/windowsroutemonitor.h
@@ -32,7 +32,7 @@ class WindowsRouteMonitor final : public QObject {
   void routeChanged();
 
  private:
-  void updateExclusionRoute(MIB_IPFORWARD_ROW2* data, void* table);
+  void updateExclusionRoute(MIB_IPFORWARD_ROW2* data, const void* table);
 
   QHash<QHostAddress, MIB_IPFORWARD_ROW2*> m_exclusionRoutes;
 


### PR DESCRIPTION
## Description

When handling the exclusion routes, Windows will sometimes report multiple default routes, including interfaces that may be inactive or hidden. If one of these interfaces is selected for the exclusion route, then this often results in a broken routing table and a failure to remain connected.

To resolve this properly, we must do two things:
- Rank duplicate routing table entries using their routing metric.
- Ignore routes on inactive interfaces. We utilize the `GetNetworkConnectivityHintForInterface` API call for this.

## Reference

Closes: #2693
JIRA Issue: [VPN-1698](https://mozilla-hub.atlassian.net/browse/VPN-1698)

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
