### PR TITLE
Fix PPA automation workflow after Qt6 changes

### DIFF
--- a/.github/workflows/ppa-automation.yaml
+++ b/.github/workflows/ppa-automation.yaml
@@ -11,6 +11,7 @@ on:
 jobs:
   ppa-release-candidate:
     name: PPA Releases
+    if: github.repository == 'mozilla-mobile/mozilla-vpn-client'
     runs-on: ubuntu-latest
     environment: PPA Automation
     steps:

--- a/.github/workflows/ppa-automation.yaml
+++ b/.github/workflows/ppa-automation.yaml
@@ -77,9 +77,8 @@ jobs:
           PPA_URL: ppa:okirby/mozilla-vpn-testing
           GNUPGHOME: ${{ runner.temp }}/gnupg-data
         run: |
-          for dist in $(find .tmp -mindepth 1 -type d); do
-            (cd $dist && ln -s ../mozillavpn_*.orig.tar.gz)
-            dput $PPA_URL $dist/mozillavpn_*_source.changes
+          for changeset in $(find .tmp -name '*_source.changes'); do
+            dput $PPA_URL $changeset
           done
 
       - name: Push to Launchpad Nightly PPA
@@ -89,7 +88,6 @@ jobs:
           PPA_URL: ppa:okirby/mozilla-vpn-nightly
           GNUPGHOME: ${{ runner.temp }}/gnupg-data
         run: |
-          for dist in $(find .tmp -mindepth 1 -type d); do
-            (cd $dist && ln -s ../mozillavpn_*.orig.tar.gz)
-            dput $PPA_URL $dist/mozillavpn_*_source.changes
+          for changeset in $(find .tmp -name '*_source.changes'); do
+            dput $PPA_URL $changeset
           done

--- a/scripts/linux/script.sh
+++ b/scripts/linux/script.sh
@@ -190,7 +190,7 @@ for distro in $RELEASE; do
     fedora|rpm)
       print Y "Building RPM packages for $distro"
       build_rpm_spec
-      rpmbuild --define "_topdir $(pwd)" --define "_sourcedir $(pwd)" -bs mozillavpn.spec
+      rpmbuild --define "_srcrpmdir $(pwd)" --define "_sourcedir $(pwd)" -bs mozillavpn.spec
       ;;
 
     *)


### PR DESCRIPTION
## Description
In PR #3063 we reorganized the structure of the source bundle, but this was never reflected in the PPA automation workflow, which now fails to find the changeset for upload. This should fix the workflow and get it uploading packages again.

## Reference
See: #3063 

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
