### PR TITLE
Fix Wix schema error due to out-of-order Conditions.

### DIFF
--- a/windows/installer/MozillaVPN_prod.wxs
+++ b/windows/installer/MozillaVPN_prod.wxs
@@ -18,16 +18,17 @@
 		Version="!(bind.FileVersion.MozillaVPNExecutable)"
 		Manufacturer="Mozilla Corporation"
 		UpgradeCode="$(var.UpgradeCode)">
-    <Condition Message="This application is only supported on Windows 10 or higher.">
-      <![CDATA[Installed OR (VersionNT >= 603)]]>
-    </Condition>
-    <Condition Message="This application is only supported on 64 bit x86 platforms."> %PROCESSOR_ARCHITECTURE="AMD64" </Condition>
     <Package
 			InstallerVersion="400"
 			Compressed="yes"
 			InstallScope="perMachine"
 			Description="Mozilla VPN"
 			ReadOnly="yes" />
+
+    <Condition Message="This application is only supported on Windows 10 or higher.">
+      <![CDATA[Installed OR (VersionNT >= 603)]]>
+    </Condition>
+    <Condition Message="This application is only supported on 64 bit x86 platforms."> %PROCESSOR_ARCHITECTURE="AMD64" </Condition>
 
     <Upgrade Id="$(var.UpgradeCode)">
       <UpgradeVersion OnlyDetect='no' Property='PREVIOUSFOUND'


### PR DESCRIPTION
## Description
During production code signing, we have encountered an XML schema error when trying to generate the installer package. This seems to be due to the `Condition` element being present in the wrong order. To fix this, we simply move it after the `Product` element, which is required to go first.

## Reference
See: #3236

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
