### PR TITLE
Experiment: Support split tunneling with cgroups v2

### DIFF
--- a/linux/mozillavpn.service.in
+++ b/linux/mozillavpn.service.in
@@ -1,7 +1,7 @@
 [Unit]
 Description=MozillaVPN D-Bus service
+Wants=modprobe@xt_cgroup.service
 After=modprobe@xt_cgroup.service
-Requires=modprobe@xt_cgroup.service
 
 [Service]
 Type=dbus

--- a/linux/mozillavpn.service.in
+++ b/linux/mozillavpn.service.in
@@ -1,5 +1,7 @@
 [Unit]
 Description=MozillaVPN D-Bus service
+After=modprobe@xt_cgroup.service
+Requires=modprobe@xt_cgroup.service
 
 [Service]
 Type=dbus

--- a/src/featureslistcallback.h
+++ b/src/featureslistcallback.h
@@ -11,6 +11,7 @@
 
 #ifdef MVPN_LINUX
 #  include <QProcessEnvironment>
+#  include "update/versionapi.h"
 #  include "platforms/linux/linuxdependencies.h"
 #endif
 
@@ -118,8 +119,18 @@ bool FeatureCallback_splitTunnel() {
     return false;
   }
   QStringList desktop = pe.value("XDG_CURRENT_DESKTOP").split(":");
-  if (!desktop.contains("GNOME") && !desktop.contains("MATE") &&
-      !desktop.contains("Unity") && !desktop.contains("X-Cinnamon")) {
+  if (desktop.contains("GNOME")) {
+    QString shellVersion = LinuxDependencies::gnomeShellVersion();
+    if (shellVersion.isNull()) {
+      return false;
+    }
+    if (VersionApi::compareVersions(shellVersion, "3.34") < 0) {
+      return false;
+    }
+  }
+  // TODO: These shells need more testing.
+  else if (!desktop.contains("MATE") && !desktop.contains("Unity") &&
+           !desktop.contains("X-Cinnamon")) {
     return false;
   }
   splitTunnelSupported = true;

--- a/src/featureslistcallback.h
+++ b/src/featureslistcallback.h
@@ -105,9 +105,9 @@ bool FeatureCallback_splitTunnel() {
   }
   initDone = true;
 
-  /* Control groups v1 must be mounted for traffic classification
+  /* Control groups v2 must be mounted for app/traffic classification
    */
-  if (LinuxDependencies::findCgroupPath("net_cls").isNull()) {
+  if (LinuxDependencies::findCgroup2Path().isNull()) {
     return false;
   }
 

--- a/src/platforms/linux/daemon/apptracker.cpp
+++ b/src/platforms/linux/daemon/apptracker.cpp
@@ -25,7 +25,7 @@ constexpr const char* DBUS_SYSTEMD_MANAGER = "org.freedesktop.systemd1.Manager";
 namespace {
 Logger logger(LOG_LINUX, "AppTracker");
 QString s_cgroupMount;
-}
+}  // namespace
 
 AppTracker::AppTracker(QObject* parent) : QObject(parent) {
   MVPN_COUNT_CTOR(AppTracker);
@@ -64,8 +64,8 @@ void AppTracker::userCreated(uint userid, const QDBusObjectPath& path) {
   /* For correctness we should ask systemd for the user's runtime directory. */
   QString busPath = "unix:path=/run/user/" + QString::number(userid) + "/bus";
   logger.debug() << "Connection to" << busPath;
-  QDBusConnection connection = QDBusConnection::connectToBus(
-      busPath, "user-" + QString::number(userid));
+  QDBusConnection connection =
+      QDBusConnection::connectToBus(busPath, "user-" + QString::number(userid));
 
   /* Connect to the user's GTK launch event. */
   bool gtkConnected = connection.connect(
@@ -160,7 +160,7 @@ void AppTracker::cgroupsChanged(const QString& directory) {
 
       m_runningApps[path] = data;
       appHeuristicMatch(data);
-    
+
       emit appLaunched(data->cgroup, data->appId, data->rootpid);
     }
   }

--- a/src/platforms/linux/daemon/apptracker.cpp
+++ b/src/platforms/linux/daemon/apptracker.cpp
@@ -157,9 +157,10 @@ void AppTracker::cgroupsChanged(const QString& directory) {
       // This is a new scope, let's add it.
       logger.debug() << "Control group created:" << path;
       AppData* data = new AppData(path);
-      m_runningApps[path] = new AppData(path);
 
+      m_runningApps[path] = data;
       appHeuristicMatch(data);
+    
       emit appLaunched(data->cgroup, data->appId, data->rootpid);
     }
   }

--- a/src/platforms/linux/daemon/apptracker.h
+++ b/src/platforms/linux/daemon/apptracker.h
@@ -9,6 +9,8 @@
 #include <QFileSystemWatcher>
 #include <QString>
 
+class QDBusInterface;
+
 class AppTracker final : public QObject {
   Q_OBJECT
   Q_DISABLE_COPY_MOVE(AppTracker)
@@ -31,9 +33,12 @@ class AppTracker final : public QObject {
  private:
   const uint m_userid;
   const QDBusObjectPath m_objectPath;
+  QDBusInterface* m_interface;
 
   QString m_cgroupPath;
   QFileSystemWatcher m_cgroupWatcher;
+
+  QStringList m_cgroupScopes;
 };
 
 #endif  // APPTRACKER_H

--- a/src/platforms/linux/daemon/apptracker.h
+++ b/src/platforms/linux/daemon/apptracker.h
@@ -5,27 +5,35 @@
 #ifndef APPTRACKER_H
 #define APPTRACKER_H
 
-#include <QDBusPendingCallWatcher>
 #include <QDBusObjectPath>
+#include <QFileSystemWatcher>
+#include <QString>
 
 class AppTracker final : public QObject {
   Q_OBJECT
   Q_DISABLE_COPY_MOVE(AppTracker)
 
  public:
-  explicit AppTracker(QObject* parent);
+  explicit AppTracker(uint userid, const QDBusObjectPath& path,
+                      QObject* parent = nullptr);
   ~AppTracker();
 
  signals:
   void appLaunched(const QString& name, int rootpid);
 
  private slots:
-  void userListCompleted(QDBusPendingCallWatcher* call);
-  void userCreated(uint uid, const QDBusObjectPath& path);
-  void userRemoved(uint uid, const QDBusObjectPath& path);
   void gtkLaunchEvent(const QByteArray& appid, const QString& display,
                       qlonglong pid, const QStringList& uris,
                       const QVariantMap& extra);
+
+  void cgroupsChanged(const QString& directory);
+
+ private:
+  const uint m_userid;
+  const QDBusObjectPath m_objectPath;
+
+  QString m_cgroupPath;
+  QFileSystemWatcher m_cgroupWatcher;
 };
 
 #endif  // APPTRACKER_H

--- a/src/platforms/linux/daemon/apptracker.h
+++ b/src/platforms/linux/daemon/apptracker.h
@@ -15,9 +15,7 @@ class QDBusInterface;
 
 class AppData {
  public:
-  AppData(const QString& path) : cgroup(path) {
-    MVPN_COUNT_CTOR(AppData);
-  }
+  AppData(const QString& path) : cgroup(path) { MVPN_COUNT_CTOR(AppData); }
   ~AppData() { MVPN_COUNT_DTOR(AppData); }
 
   QList<int> pids() const;

--- a/src/platforms/linux/daemon/dbusservice.cpp
+++ b/src/platforms/linux/daemon/dbusservice.cpp
@@ -42,9 +42,8 @@ DBusService::DBusService(QObject* parent) : Daemon(parent) {
   connect(m_appTracker,
           SIGNAL(appLaunched(const QString&, const QString&, int)), this,
           SLOT(appLaunched(const QString&, const QString&, int)));
-  connect(m_appTracker,
-          SIGNAL(appTerminated(const QString&, const QString&)), this,
-          SLOT(appTerminated(const QString&, const QString&)));
+  connect(m_appTracker, SIGNAL(appTerminated(const QString&, const QString&)),
+          this, SLOT(appTerminated(const QString&, const QString&)));
 
   // Setup to track user login sessions.
   QDBusConnection bus = QDBusConnection::systemBus();
@@ -170,7 +169,7 @@ void DBusService::appLaunched(const QString& cgroup, const QString& appId,
                               int rootpid) {
   logger.debug() << "tracking:" << cgroup << "appId:" << appId
                  << "PID:" << rootpid;
-  
+
   // HACK: Quick and dirty split tunnelling.
   // TODO: Apply filtering to currently-running apps too.
   if (m_excludedApps.contains(appId)) {
@@ -223,8 +222,7 @@ bool DBusService::firewallApp(const QString& appName, const QString& state) {
     }
     if (state == APP_STATE_EXCLUDED) {
       m_wgutils->excludeCgroup(data->cgroup);
-    }
-    else {
+    } else {
       m_wgutils->resetCgroup(data->cgroup);
     }
   }

--- a/src/platforms/linux/daemon/dbusservice.h
+++ b/src/platforms/linux/daemon/dbusservice.h
@@ -51,11 +51,10 @@ class DBusService final : public Daemon {
 
  private:
   bool removeInterfaceIfExists();
-  QString getAppStateCgroup(const QString& state);
 
  private slots:
-  void appLaunched(const QString& name, int rootpid);
-  void appTerminated(const QString& name, int rootpid);
+  void appLaunched(const QString& cgroup, const QString& appId, int rootpid);
+  void appTerminated(const QString& cgroup, const QString& appId);
 
   void userListCompleted(QDBusPendingCallWatcher* call);
   void userCreated(uint uid, const QDBusObjectPath& path);
@@ -67,9 +66,8 @@ class DBusService final : public Daemon {
   IPUtilsLinux* m_iputils = nullptr;
   DnsUtilsLinux* m_dnsutils = nullptr;
 
-  PidTracker* m_pidtracker = nullptr;
-  QMap<uint, AppTracker*> m_appTrackers;
-  QMap<QString, QString> m_firewallApps;
+  AppTracker* m_appTracker = nullptr;
+  QList<QString> m_excludedApps;
 };
 
 #endif  // DBUSSERVICE_H

--- a/src/platforms/linux/daemon/dbusservice.h
+++ b/src/platforms/linux/daemon/dbusservice.h
@@ -57,14 +57,18 @@ class DBusService final : public Daemon {
   void appLaunched(const QString& name, int rootpid);
   void appTerminated(const QString& name, int rootpid);
 
+  void userListCompleted(QDBusPendingCallWatcher* call);
+  void userCreated(uint uid, const QDBusObjectPath& path);
+  void userRemoved(uint uid, const QDBusObjectPath& path);
+
  private:
   DbusAdaptor* m_adaptor = nullptr;
   WireguardUtilsLinux* m_wgutils = nullptr;
   IPUtilsLinux* m_iputils = nullptr;
   DnsUtilsLinux* m_dnsutils = nullptr;
 
-  AppTracker* m_apptracker = nullptr;
   PidTracker* m_pidtracker = nullptr;
+  QMap<uint, AppTracker*> m_appTrackers;
   QMap<QString, QString> m_firewallApps;
 };
 

--- a/src/platforms/linux/daemon/wireguardutilslinux.cpp
+++ b/src/platforms/linux/daemon/wireguardutilslinux.cpp
@@ -8,6 +8,7 @@
 #include "platforms/linux/linuxdependencies.h"
 
 #include <QHostAddress>
+#include <QFile>
 #include <QScopeGuard>
 
 #include <arpa/inet.h>
@@ -88,16 +89,28 @@ WireguardUtilsLinux::WireguardUtilsLinux(QObject* parent)
   connect(m_notifier, &QSocketNotifier::activated, this,
           &WireguardUtilsLinux::nlsockReady);
 
-  /* Create control groups for split tunnelling */
-  m_cgroups = LinuxDependencies::findCgroupPath("net_cls");
-  if (!m_cgroups.isNull()) {
-    if (!setupCgroupClass(m_cgroups + VPN_EXCLUDE_CGROUP,
+  // Most kernels cannot simultaneously support traffic classification with
+  // both the net_cls (v1) and unified (v2) cgroups simultaneously. If both
+  // are present, the net_cls traffic classifiers take priority.
+  //
+  // In this situation, you will likely see this kernel log warning:
+  //   cgroup: disabling cgroup2 socket matching due to net_prio or net_cls activation
+  m_cgroupNetClass = LinuxDependencies::findCgroupPath("net_cls");
+  m_cgroupUnified = LinuxDependencies::findCgroup2Path();
+  if (!m_cgroupNetClass.isNull()) {
+    if (setupCgroupClass(m_cgroupNetClass + VPN_EXCLUDE_CGROUP,
                           VPN_EXCLUDE_CLASS_ID)) {
-      m_cgroups.clear();
-    } else if (!setupCgroupClass(m_cgroups + VPN_BLOCK_CGROUP,
-                                 VPN_BLOCK_CLASS_ID)) {
-      m_cgroups.clear();
+      logger.info() << "Setup split tunneling with net_cls cgroups (v1)";
+      m_cgroupVersion = 1;
     }
+  }
+  // Otherwise, try to use unified cgroups (v2)
+  else if ((m_cgroupVersion == 0) && !m_cgroupUnified.isNull()) {
+    logger.info() << "Setup split tunneling with unified cgroups (v2)";
+    m_cgroupVersion = 2;
+  }
+  else {
+    logger.warning() << "Unable to setup split tunneling: no supported cgroups";
   }
 
   logger.debug() << "WireguardUtilsLinux created.";
@@ -163,9 +176,8 @@ bool WireguardUtilsLinux::addInterface(const InterfaceConfig& config) {
   if (NetfilterIfup(goIfname, device->fwmark) != 0) {
     return false;
   }
-  if (!m_cgroups.isNull()) {
-    NetfilterMarkCgroup(VPN_EXCLUDE_CLASS_ID, device->fwmark);
-    NetfilterBlockCgroup(VPN_BLOCK_CLASS_ID);
+  if (m_cgroupVersion == 1) {
+    NetfilterMarkCgroupV1(VPN_EXCLUDE_CLASS_ID, device->fwmark);
   }
 
   int slashPos = config.m_deviceIpv6Address.indexOf('/');
@@ -677,18 +689,66 @@ bool WireguardUtilsLinux::setupCgroupClass(const QString& path,
   return true;
 }
 
-QString WireguardUtilsLinux::getExcludeCgroup() const {
-  if (m_cgroups.isNull()) {
-    return QString();
+// static
+bool WireguardUtilsLinux::moveCgroupProcs(const QString& src, const QString& dest) {
+  QFile srcProcs(src + "/cgroup.procs");
+  FILE* fp = fopen(qPrintable(dest + "/cgroup.procs"), "w");
+  if (!fp) {
+    return false;
   }
-  return m_cgroups + VPN_EXCLUDE_CGROUP;
+  auto guard = qScopeGuard([&] { fclose(fp); });
+
+  if (!srcProcs.open(QIODevice::ReadOnly | QIODevice::Text)) {
+    return false;
+  }
+  while (true) {
+    QString line = QString::fromLocal8Bit(srcProcs.readLine());
+    if (line.isEmpty()) {
+      break;
+    }
+    fputs(qPrintable(line), fp);
+    fflush(fp);
+  }
+  srcProcs.close();
+  return true;
 }
 
-QString WireguardUtilsLinux::getBlockCgroup() const {
-  if (m_cgroups.isNull()) {
-    return QString();
+void WireguardUtilsLinux::excludeCgroup(const QString& cgroup) {
+  logger.error() << "Excluding traffic from" << cgroup;
+  if (m_cgroupVersion == 1) {
+    // Add all PIDs from the unified cgroup to the net_cls exclusion cgroup.
+    moveCgroupProcs(m_cgroupUnified + cgroup,
+                    m_cgroupNetClass + VPN_EXCLUDE_CGROUP);
   }
-  return m_cgroups + VPN_BLOCK_CGROUP;
+  else if (m_cgroupVersion == 2) {
+    QByteArray cgpath = cgroup.toLocal8Bit();
+    GoString goCgroup = {.p = cgpath.constData(), .n = (ptrdiff_t)cgpath.length()};
+    NetfilterMarkCgroupV2(goCgroup);
+  }
+}
+
+void WireguardUtilsLinux::resetCgroup(const QString& cgroup) {
+  logger.error() << "Permitting traffic from" << cgroup;
+  if (m_cgroupVersion == 1) {
+    // Add all PIDs from the unified cgroup to the net_cls default cgroup.
+    moveCgroupProcs(m_cgroupUnified + cgroup, m_cgroupNetClass);
+  }
+  else if (m_cgroupVersion == 2) {
+    QByteArray cgpath = cgroup.toLocal8Bit();
+    GoString goCgroup = {.p = cgpath.constData(), .n = (ptrdiff_t)cgpath.length()};
+    NetfilterResetCgroupV2(goCgroup);
+  }
+}
+
+void WireguardUtilsLinux::resetAllCgroups() {
+  logger.error() << "Permitting traffic from all cgroups";
+  if (m_cgroupVersion == 1) {
+    // Add all PIDs from the net_cls exclusion cgroup to the default cgroup.
+    moveCgroupProcs(m_cgroupNetClass + VPN_EXCLUDE_CGROUP, m_cgroupNetClass);
+  }
+  else if (m_cgroupVersion == 2) {
+    NetfilterResetAllCgroupsV2();
+  }
 }
 
 // static

--- a/src/platforms/linux/daemon/wireguardutilslinux.cpp
+++ b/src/platforms/linux/daemon/wireguardutilslinux.cpp
@@ -715,7 +715,7 @@ bool WireguardUtilsLinux::moveCgroupProcs(const QString& src,
 }
 
 void WireguardUtilsLinux::excludeCgroup(const QString& cgroup) {
-  logger.error() << "Excluding traffic from" << cgroup;
+  logger.info() << "Excluding traffic from" << cgroup;
   if (m_cgroupVersion == 1) {
     // Add all PIDs from the unified cgroup to the net_cls exclusion cgroup.
     moveCgroupProcs(m_cgroupUnified + cgroup,
@@ -725,11 +725,13 @@ void WireguardUtilsLinux::excludeCgroup(const QString& cgroup) {
     GoString goCgroup = {.p = cgpath.constData(),
                          .n = (ptrdiff_t)cgpath.length()};
     NetfilterMarkCgroupV2(goCgroup);
+  } else {
+    Q_ASSERT(m_cgroupVersion == 0);
   }
 }
 
 void WireguardUtilsLinux::resetCgroup(const QString& cgroup) {
-  logger.error() << "Permitting traffic from" << cgroup;
+  logger.info() << "Permitting traffic from" << cgroup;
   if (m_cgroupVersion == 1) {
     // Add all PIDs from the unified cgroup to the net_cls default cgroup.
     moveCgroupProcs(m_cgroupUnified + cgroup, m_cgroupNetClass);
@@ -738,16 +740,20 @@ void WireguardUtilsLinux::resetCgroup(const QString& cgroup) {
     GoString goCgroup = {.p = cgpath.constData(),
                          .n = (ptrdiff_t)cgpath.length()};
     NetfilterResetCgroupV2(goCgroup);
+  } else {
+    Q_ASSERT(m_cgroupVersion == 0);
   }
 }
 
 void WireguardUtilsLinux::resetAllCgroups() {
-  logger.error() << "Permitting traffic from all cgroups";
+  logger.info() << "Permitting traffic from all cgroups";
   if (m_cgroupVersion == 1) {
     // Add all PIDs from the net_cls exclusion cgroup to the default cgroup.
     moveCgroupProcs(m_cgroupNetClass + VPN_EXCLUDE_CGROUP, m_cgroupNetClass);
   } else if (m_cgroupVersion == 2) {
     NetfilterResetAllCgroupsV2();
+  } else {
+    Q_ASSERT(m_cgroupVersion == 0);
   }
 }
 

--- a/src/platforms/linux/daemon/wireguardutilslinux.cpp
+++ b/src/platforms/linux/daemon/wireguardutilslinux.cpp
@@ -746,8 +746,7 @@ void WireguardUtilsLinux::resetAllCgroups() {
   if (m_cgroupVersion == 1) {
     // Add all PIDs from the net_cls exclusion cgroup to the default cgroup.
     moveCgroupProcs(m_cgroupNetClass + VPN_EXCLUDE_CGROUP, m_cgroupNetClass);
-  }
-  else if (m_cgroupVersion == 2) {
+  } else if (m_cgroupVersion == 2) {
     NetfilterResetAllCgroupsV2();
   }
 }

--- a/src/platforms/linux/daemon/wireguardutilslinux.cpp
+++ b/src/platforms/linux/daemon/wireguardutilslinux.cpp
@@ -94,12 +94,13 @@ WireguardUtilsLinux::WireguardUtilsLinux(QObject* parent)
   // are present, the net_cls traffic classifiers take priority.
   //
   // In this situation, you will likely see this kernel log warning:
-  //   cgroup: disabling cgroup2 socket matching due to net_prio or net_cls activation
+  //   cgroup: disabling cgroup2 socket matching due to net_prio or net_cls
+  //   activation
   m_cgroupNetClass = LinuxDependencies::findCgroupPath("net_cls");
   m_cgroupUnified = LinuxDependencies::findCgroup2Path();
   if (!m_cgroupNetClass.isNull()) {
     if (setupCgroupClass(m_cgroupNetClass + VPN_EXCLUDE_CGROUP,
-                          VPN_EXCLUDE_CLASS_ID)) {
+                         VPN_EXCLUDE_CLASS_ID)) {
       logger.info() << "Setup split tunneling with net_cls cgroups (v1)";
       m_cgroupVersion = 1;
     }
@@ -108,8 +109,7 @@ WireguardUtilsLinux::WireguardUtilsLinux(QObject* parent)
   else if ((m_cgroupVersion == 0) && !m_cgroupUnified.isNull()) {
     logger.info() << "Setup split tunneling with unified cgroups (v2)";
     m_cgroupVersion = 2;
-  }
-  else {
+  } else {
     logger.warning() << "Unable to setup split tunneling: no supported cgroups";
   }
 
@@ -690,7 +690,8 @@ bool WireguardUtilsLinux::setupCgroupClass(const QString& path,
 }
 
 // static
-bool WireguardUtilsLinux::moveCgroupProcs(const QString& src, const QString& dest) {
+bool WireguardUtilsLinux::moveCgroupProcs(const QString& src,
+                                          const QString& dest) {
   QFile srcProcs(src + "/cgroup.procs");
   FILE* fp = fopen(qPrintable(dest + "/cgroup.procs"), "w");
   if (!fp) {
@@ -719,10 +720,10 @@ void WireguardUtilsLinux::excludeCgroup(const QString& cgroup) {
     // Add all PIDs from the unified cgroup to the net_cls exclusion cgroup.
     moveCgroupProcs(m_cgroupUnified + cgroup,
                     m_cgroupNetClass + VPN_EXCLUDE_CGROUP);
-  }
-  else if (m_cgroupVersion == 2) {
+  } else if (m_cgroupVersion == 2) {
     QByteArray cgpath = cgroup.toLocal8Bit();
-    GoString goCgroup = {.p = cgpath.constData(), .n = (ptrdiff_t)cgpath.length()};
+    GoString goCgroup = {.p = cgpath.constData(),
+                         .n = (ptrdiff_t)cgpath.length()};
     NetfilterMarkCgroupV2(goCgroup);
   }
 }
@@ -732,10 +733,10 @@ void WireguardUtilsLinux::resetCgroup(const QString& cgroup) {
   if (m_cgroupVersion == 1) {
     // Add all PIDs from the unified cgroup to the net_cls default cgroup.
     moveCgroupProcs(m_cgroupUnified + cgroup, m_cgroupNetClass);
-  }
-  else if (m_cgroupVersion == 2) {
+  } else if (m_cgroupVersion == 2) {
     QByteArray cgpath = cgroup.toLocal8Bit();
-    GoString goCgroup = {.p = cgpath.constData(), .n = (ptrdiff_t)cgpath.length()};
+    GoString goCgroup = {.p = cgpath.constData(),
+                         .n = (ptrdiff_t)cgpath.length()};
     NetfilterResetCgroupV2(goCgroup);
   }
 }

--- a/src/platforms/linux/daemon/wireguardutilslinux.cpp
+++ b/src/platforms/linux/daemon/wireguardutilslinux.cpp
@@ -177,7 +177,7 @@ bool WireguardUtilsLinux::addInterface(const InterfaceConfig& config) {
     return false;
   }
   if (m_cgroupVersion == 1) {
-    NetfilterMarkCgroupV1(VPN_EXCLUDE_CLASS_ID, device->fwmark);
+    NetfilterMarkCgroupV1(VPN_EXCLUDE_CLASS_ID);
   }
 
   int slashPos = config.m_deviceIpv6Address.indexOf('/');

--- a/src/platforms/linux/daemon/wireguardutilslinux.h
+++ b/src/platforms/linux/daemon/wireguardutilslinux.h
@@ -31,9 +31,9 @@ class WireguardUtilsLinux final : public WireguardUtils {
   bool addExclusionRoute(const QHostAddress& address) override;
   bool deleteExclusionRoute(const QHostAddress& address) override;
 
-  QString getDefaultCgroup() const { return m_cgroups; }
-  QString getExcludeCgroup() const;
-  QString getBlockCgroup() const;
+  void excludeCgroup(const QString& cgroup);
+  void resetCgroup(const QString& cgroup);
+  void resetAllCgroups();
 
  private:
   QStringList currentInterfaces();
@@ -44,12 +44,16 @@ class WireguardUtilsLinux final : public WireguardUtils {
                     int hopindex);
   bool rtmSendExclude(int action, int flags, const QHostAddress& address);
   static bool setupCgroupClass(const QString& path, unsigned long classid);
+  static bool moveCgroupProcs(const QString& src, const QString& dest);
   static bool buildAllowedIp(struct wg_allowedip*, const IPAddress& prefix);
 
   int m_nlsock = -1;
   int m_nlseq = 0;
   QSocketNotifier* m_notifier = nullptr;
-  QString m_cgroups;
+
+  int m_cgroupVersion = 0;
+  QString m_cgroupNetClass;
+  QString m_cgroupUnified;
 
  private slots:
   void nlsockReady();

--- a/src/platforms/linux/linuxdependencies.cpp
+++ b/src/platforms/linux/linuxdependencies.cpp
@@ -101,3 +101,24 @@ QString LinuxDependencies::findCgroupPath(const QString& type) {
 
   return QString();
 }
+
+// static
+QString LinuxDependencies::findCgroup2Path() {
+  struct mntent entry;
+  char buf[PATH_MAX];
+
+  FILE* fp = fopen("/etc/mtab", "r");
+  if (fp == NULL) {
+    return QString();
+  }
+
+  while (getmntent_r(fp, &entry, buf, sizeof(buf)) != NULL) {
+    if (strcmp(entry.mnt_type, "cgroup2") != 0) {
+      continue;
+    }
+    return QString(entry.mnt_dir);
+  }
+  fclose(fp);
+
+  return QString();
+}

--- a/src/platforms/linux/linuxdependencies.cpp
+++ b/src/platforms/linux/linuxdependencies.cpp
@@ -122,3 +122,17 @@ QString LinuxDependencies::findCgroup2Path() {
 
   return QString();
 }
+
+// static
+QString LinuxDependencies::gnomeShellVersion() {
+  QDBusInterface iface("org.gnome.Shell", "/org/gnome/Shell", "org.gnome.Shell");
+  if (!iface.isValid()) {
+    return QString();
+  }
+
+  QVariant shellVersion = iface.property("ShellVersion");
+  if (!shellVersion.isValid()) {
+    return QString();
+  }
+  return shellVersion.toString();
+}

--- a/src/platforms/linux/linuxdependencies.cpp
+++ b/src/platforms/linux/linuxdependencies.cpp
@@ -125,7 +125,8 @@ QString LinuxDependencies::findCgroup2Path() {
 
 // static
 QString LinuxDependencies::gnomeShellVersion() {
-  QDBusInterface iface("org.gnome.Shell", "/org/gnome/Shell", "org.gnome.Shell");
+  QDBusInterface iface("org.gnome.Shell", "/org/gnome/Shell",
+                       "org.gnome.Shell");
   if (!iface.isValid()) {
     return QString();
   }

--- a/src/platforms/linux/linuxdependencies.h
+++ b/src/platforms/linux/linuxdependencies.h
@@ -11,6 +11,7 @@ class LinuxDependencies final {
  public:
   static bool checkDependencies();
   static QString findCgroupPath(const QString& type);
+  static QString findCgroup2Path();
 
  private:
   LinuxDependencies() = default;

--- a/src/platforms/linux/linuxdependencies.h
+++ b/src/platforms/linux/linuxdependencies.h
@@ -12,6 +12,7 @@ class LinuxDependencies final {
   static bool checkDependencies();
   static QString findCgroupPath(const QString& type);
   static QString findCgroup2Path();
+  static QString gnomeShellVersion();
 
  private:
   LinuxDependencies() = default;


### PR DESCRIPTION
## Description
This is an experiment to investigate how to pursue split tunnelling with Linux Control Groups v2. This presents some unique challenges because the support for network traffic classification was dropped in the transitions from Cgroups v1 to v2. And there doesn't appear to be a reliable mechanism to map between control group and application ID.

Roughly speaking, to resolve this issue, we need to accomplish the following tasks:
- [x] Track the creation and destruction of control groups, as they relate to user applications.
- [x] Associate control groups with their corresponding desktop application identifier.
- [x] Update netfilter.go to match traffic originating from cgroups v2 (xt_cgroup)
- [x] Tweak nftable rules to ensure that marked traffic is routed outside of the VPN when this feature is enabled.
- [x] Select v1 or v2 split tunnelling implementation depending on which cgroupfs exists.
- [x] Update packaging and test installation.

## Reference

See: #3283

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
