### PR TITLE
Linux: Add prerm hook to terminate the UI if uninstalled

### DIFF
--- a/linux/debian/mozillavpn.prerm
+++ b/linux/debian/mozillavpn.prerm
@@ -1,0 +1,8 @@
+#!/bin/sh
+# Ensure the UI is terminated when uninstalling the daemon, otherwise
+# it might linger in a broken state.
+sockname="/tmp/mozillavpn.ui.sock"
+if [ -e "$sockname" ]; then
+  username=$(stat -c '%U' $sockname)
+  killall -u $username -TERM mozillavpn
+fi


### PR DESCRIPTION
## Description
When uninstalling the VPN client, the backend daemon is terminated, but there is nothing to shut down the UI. For most application, this is fine since the UI can continue running even if it's binary has been removed, but for the VPN this will quickly lead to breakage due to the missing daemon. It is best if we terminate the UI during the `prerm` step.

## Reference
Closes: #3293

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
