### PR TITLE
Pass iap free trial duration to qml

### DIFF
--- a/android/src/org/mozilla/firefox/vpn/InAppPurchase.kt
+++ b/android/src/org/mozilla/firefox/vpn/InAppPurchase.kt
@@ -348,14 +348,7 @@ class InAppPurchase private constructor(ctx: Context) :
         val monthlyPriceString = formatter.format(monthlyPrice)
 
         // freeTrialPeriod is a ISO 8601 duration i.e P7D == 7 days
-        val trialDays = if (monthCount == 12 && VPNUtils.isDevMode) {
-            // TODO: This is just some debugging stuff
-            // We need to be on prod so, for testing let's
-            // mock the PlayStore response for 12month if we're in isDevMode
-            // so QA can test when we go live
-            val duration = Duration.parse("P7D")
-            duration.toDays().toInt()
-        } else if (details.freeTrialPeriod.isEmpty()) {
+        val trialDays = if (details.freeTrialPeriod.isEmpty()) {
             0
         } else {
             val duration = Duration.parse(details.freeTrialPeriod)

--- a/android/src/org/mozilla/firefox/vpn/qt/VPNUtils.kt
+++ b/android/src/org/mozilla/firefox/vpn/qt/VPNUtils.kt
@@ -113,4 +113,14 @@ object VPNUtils {
     @SuppressLint("Unused")
     @JvmStatic
     private external fun recordGleanEvent(metricName: String)
+
+    @SuppressLint("Unused")
+    @JvmStatic
+    private external fun getIsDevMode(): Boolean
+
+    val isDevMode by lazy {
+        // "by lazy" means, we evaluate this on first
+        // get() and never again.
+        getIsDevMode()
+    }
 }

--- a/android/src/org/mozilla/firefox/vpn/qt/VPNUtils.kt
+++ b/android/src/org/mozilla/firefox/vpn/qt/VPNUtils.kt
@@ -114,13 +114,4 @@ object VPNUtils {
     @JvmStatic
     private external fun recordGleanEvent(metricName: String)
 
-    @SuppressLint("Unused")
-    @JvmStatic
-    private external fun getIsDevMode(): Boolean
-
-    val isDevMode by lazy {
-        // "by lazy" means, we evaluate this on first
-        // get() and never again.
-        getIsDevMode()
-    }
 }

--- a/nebula/ui/components/VPNSubscriptionOption.qml
+++ b/nebula/ui/components/VPNSubscriptionOption.qml
@@ -132,6 +132,8 @@ RadioDelegate {
             //% "%1/month"
             property string monthlyPrice: qsTrId("vpn.subscription.price").arg(productMonthlyPrice)
 
+            property int trialDays: productTrialDays
+
             spacing: VPNTheme.theme.listSpacing * 0.5
 
             VPNBoldLabel {
@@ -148,6 +150,13 @@ RadioDelegate {
             VPNLightLabel {
                 font.pixelSize: VPNTheme.theme.fontSize
                 text: col.subscriptionDuration !== -1 ? (col.subscriptionDuration > 1 ? col.monthlyPrice : col.productSingleMonth) : ""
+                wrapMode: Text.WordWrap
+
+                Layout.fillWidth: true
+            }
+            VPNLightLabel {
+                font.pixelSize: VPNTheme.theme.fontSize
+                text: col.trialDays
                 wrapMode: Text.WordWrap
 
                 Layout.fillWidth: true

--- a/src/iaphandler.cpp
+++ b/src/iaphandler.cpp
@@ -229,6 +229,7 @@ QHash<int, QByteArray> IAPHandler::roleNames() const {
   roles[ProductIdentifierRole] = "productIdentifier";
   roles[ProductPriceRole] = "productPrice";
   roles[ProductMonthlyPriceRole] = "productMonthlyPrice";
+  roles[ProductTrialDaysRole] = "productTrialDays";
   roles[ProductTypeRole] = "productType";
   roles[ProductFeaturedRole] = "productFeatured";
   roles[ProductSavingsRole] = "productSavings";
@@ -266,6 +267,9 @@ QVariant IAPHandler::data(const QModelIndex& index, int role) const {
 
     case ProductSavingsRole:
       return QVariant(m_products.at(index.row()).m_savings);
+
+    case ProductTrialDaysRole:
+      return QVariant(m_products.at(index.row()).m_trialDays);
 
     default:
       return QVariant();

--- a/src/iaphandler.cpp
+++ b/src/iaphandler.cpp
@@ -4,6 +4,7 @@
 
 #include "iaphandler.h"
 #include "constants.h"
+#include "inspector/inspectorhandler.h"
 #include "leakdetector.h"
 #include "logger.h"
 
@@ -269,6 +270,10 @@ QVariant IAPHandler::data(const QModelIndex& index, int role) const {
       return QVariant(m_products.at(index.row()).m_savings);
 
     case ProductTrialDaysRole:
+      if ((m_products.at(index.row()).m_type == ProductYearly) &&
+          InspectorHandler::mockFreeTrial()) {
+        return QVariant(7);
+      }
       return QVariant(m_products.at(index.row()).m_trialDays);
 
     default:

--- a/src/iaphandler.h
+++ b/src/iaphandler.h
@@ -29,6 +29,7 @@ class IAPHandler : public QAbstractListModel {
     ProductTypeRole,
     ProductFeaturedRole,
     ProductSavingsRole,
+    ProductTrialDaysRole,
   };
 
   static IAPHandler* createInstance();
@@ -76,6 +77,7 @@ class IAPHandler : public QAbstractListModel {
     QString m_name;
     QString m_price;
     QString m_monthlyPrice;
+    int m_trialDays = 0;
     // This is not exposed and it's not localized. It's used to compute the
     // saving %.
     double m_nonLocalizedMonthlyPrice = 0;

--- a/src/inspector/inspectorhandler.cpp
+++ b/src/inspector/inspectorhandler.cpp
@@ -48,6 +48,7 @@ Logger logger(LOG_INSPECTOR, "InspectorHandler");
 
 bool s_stealUrls = false;
 bool s_forwardNetwork = false;
+bool s_mockFreeTrial = false;
 
 QString s_updateVersion;
 QStringList s_pickedItems;
@@ -448,6 +449,12 @@ static QList<InspectorCommand> s_commands{
           s_stealUrls = true;
           return QJsonObject();
         }},
+    InspectorCommand{"mockFreeTrial",
+                     "Force the UI to show 7 day trial on 1 year plan", 0,
+                     [](InspectorHandler*, const QList<QByteArray>&) {
+                       s_mockFreeTrial = true;
+                       return QJsonObject();
+                     }},
 
     InspectorCommand{"lasturl", "Retrieve the last opened URL", 0,
                      [](InspectorHandler*, const QList<QByteArray>&) {
@@ -962,6 +969,9 @@ QString InspectorHandler::getObjectClass(const QObject* target) {
 
 // static
 bool InspectorHandler::stealUrls() { return s_stealUrls; }
+
+// static
+bool InspectorHandler::mockFreeTrial() { return s_mockFreeTrial; }
 
 // static
 QString InspectorHandler::appVersionForUpdate() {

--- a/src/inspector/inspectorhandler.h
+++ b/src/inspector/inspectorhandler.h
@@ -20,6 +20,7 @@ class InspectorHandler : public QObject {
   static void initialize();
 
   static bool stealUrls();
+  static bool mockFreeTrial();
   static QString appVersionForUpdate();
   static QString getObjectClass(const QObject* target);
   static QJsonObject getViewTree();

--- a/src/platforms/android/androidiaphandler.cpp
+++ b/src/platforms/android/androidiaphandler.cpp
@@ -267,7 +267,7 @@ void AndroidIAPHandler::updateProductsInfo(const QJsonArray& returnedProducts) {
     QString productIdentifier = product[QString("sku")].toString();
     Product* productData = findProduct(productIdentifier);
     Q_ASSERT(productData);
-
+    productData->m_trialDays = product[QString("trialDays")].toInt();
     productData->m_price = product[QString("totalPriceString")].toString();
     productData->m_monthlyPrice =
         product[QString("monthlyPriceString")].toString();

--- a/src/platforms/android/androidutils.cpp
+++ b/src/platforms/android/androidutils.cpp
@@ -9,6 +9,7 @@
 #include "logger.h"
 #include "mozillavpn.h"
 #include "networkrequest.h"
+#include "settingsholder.h"
 #include "qmlengineholder.h"
 #include "jni.h"
 
@@ -67,6 +68,7 @@ AndroidUtils::AndroidUtils(QObject* parent) : QObject(parent) {
   JNINativeMethod methods[]{
       {"recordGleanEvent", "(Ljava/lang/String;)V",
        reinterpret_cast<void*>(recordGleanEvent)},
+      {"getIsDevMode", "()Z", reinterpret_cast<bool*>(getIsDevMode)},
   };
 
   env->RegisterNatives(javaClass, methods,
@@ -261,4 +263,10 @@ void AndroidUtils::recordGleanEvent(JNIEnv* env, jobject VPNUtils,
   logger.info() << "Glean Event via JNI:" << eventString;
   emit MozillaVPN::instance()->recordGleanEvent(eventString);
   env->ReleaseStringUTFChars(event, buffer);
+}
+
+bool AndroidUtils::getIsDevMode(JNIEnv* env, jobject VPNUtils) {
+  Q_UNUSED(VPNUtils);
+  Q_UNUSED(env);
+  return SettingsHolder::instance()->developerUnlock();
 }

--- a/src/platforms/android/androidutils.cpp
+++ b/src/platforms/android/androidutils.cpp
@@ -68,7 +68,6 @@ AndroidUtils::AndroidUtils(QObject* parent) : QObject(parent) {
   JNINativeMethod methods[]{
       {"recordGleanEvent", "(Ljava/lang/String;)V",
        reinterpret_cast<void*>(recordGleanEvent)},
-      {"getIsDevMode", "()Z", reinterpret_cast<bool*>(getIsDevMode)},
   };
 
   env->RegisterNatives(javaClass, methods,
@@ -263,10 +262,4 @@ void AndroidUtils::recordGleanEvent(JNIEnv* env, jobject VPNUtils,
   logger.info() << "Glean Event via JNI:" << eventString;
   emit MozillaVPN::instance()->recordGleanEvent(eventString);
   env->ReleaseStringUTFChars(event, buffer);
-}
-
-bool AndroidUtils::getIsDevMode(JNIEnv* env, jobject VPNUtils) {
-  Q_UNUSED(VPNUtils);
-  Q_UNUSED(env);
-  return SettingsHolder::instance()->developerUnlock();
 }

--- a/src/platforms/android/androidutils.h
+++ b/src/platforms/android/androidutils.h
@@ -66,6 +66,8 @@ class AndroidUtils final : public QObject {
 
   void resetListener() { m_listener = nullptr; }
 
+  static bool getIsDevMode(JNIEnv* env, jobject VPNUtils);
+
  private:
   QUrl m_url;
   AuthenticationListener* m_listener = nullptr;

--- a/src/platforms/android/androidutils.h
+++ b/src/platforms/android/androidutils.h
@@ -66,7 +66,6 @@ class AndroidUtils final : public QObject {
 
   void resetListener() { m_listener = nullptr; }
 
-  static bool getIsDevMode(JNIEnv* env, jobject VPNUtils);
 
  private:
   QUrl m_url;

--- a/src/platforms/android/androidutils.h
+++ b/src/platforms/android/androidutils.h
@@ -66,7 +66,6 @@ class AndroidUtils final : public QObject {
 
   void resetListener() { m_listener = nullptr; }
 
-
  private:
   QUrl m_url;
   AuthenticationListener* m_listener = nullptr;

--- a/src/platforms/ios/iosiaphandler.h
+++ b/src/platforms/ios/iosiaphandler.h
@@ -7,6 +7,8 @@
 
 #include "iaphandler.h"
 
+#import <StoreKit/StoreKit.h>
+
 class IOSIAPHandler final : public IAPHandler {
   Q_OBJECT
   Q_DISABLE_COPY_MOVE(IOSIAPHandler)
@@ -27,6 +29,8 @@ class IOSIAPHandler final : public IAPHandler {
 
  private:
   void* m_delegate = nullptr;
+
+  int discountToDays(SKProductDiscount* discount);
 };
 
 #endif  // IOSIAPHANDLER_H

--- a/src/platforms/ios/iosiaphandler.h
+++ b/src/platforms/ios/iosiaphandler.h
@@ -7,9 +7,6 @@
 
 #include "iaphandler.h"
 
-#import <Foundation/Foundation.h>
-#import <StoreKit/StoreKit.h>
-
 
 class IOSIAPHandler final : public IAPHandler {
   Q_OBJECT
@@ -31,8 +28,7 @@ class IOSIAPHandler final : public IAPHandler {
 
  private:
   void* m_delegate = nullptr;
-
-  int discountToDays(SKProductDiscount* discount);
+  int discountToDays(void* discount);
 };
 
 #endif  // IOSIAPHANDLER_H

--- a/src/platforms/ios/iosiaphandler.h
+++ b/src/platforms/ios/iosiaphandler.h
@@ -7,7 +7,9 @@
 
 #include "iaphandler.h"
 
+#import <Foundation/Foundation.h>
 #import <StoreKit/StoreKit.h>
+
 
 class IOSIAPHandler final : public IAPHandler {
   Q_OBJECT

--- a/src/platforms/ios/iosiaphandler.h
+++ b/src/platforms/ios/iosiaphandler.h
@@ -7,7 +7,6 @@
 
 #include "iaphandler.h"
 
-
 class IOSIAPHandler final : public IAPHandler {
   Q_OBJECT
   Q_DISABLE_COPY_MOVE(IOSIAPHandler)

--- a/src/platforms/ios/iosiaphandler.mm
+++ b/src/platforms/ios/iosiaphandler.mm
@@ -20,6 +20,9 @@
 #include <QJsonValue>
 #include <QScopeGuard>
 
+#import <Foundation/Foundation.h>
+#import <StoreKit/StoreKit.h>
+
 constexpr const uint32_t GUARDIAN_ERROR_RECEIPT_NOT_VALID = 142;
 constexpr const uint32_t GUARDIAN_ERROR_RECEIPT_IN_USE = 145;
 
@@ -390,7 +393,8 @@ void IOSIAPHandler::noSubscriptionFoundError() {
   ErrorHandler::instance()->noSubscriptionFoundError();
 }
 
-int IOSIAPHandler::discountToDays(SKProductDiscount* discount) {
+int IOSIAPHandler::discountToDays(void* aDiscount) {
+  SKProductDiscount* discount = static_cast<SKProductDiscount*>(aDiscount);
   if (discount == nullptr) {
     return 0;
   }

--- a/src/platforms/ios/iosiaphandler.mm
+++ b/src/platforms/ios/iosiaphandler.mm
@@ -20,9 +20,6 @@
 #include <QJsonValue>
 #include <QScopeGuard>
 
-#import <Foundation/Foundation.h>
-#import <StoreKit/StoreKit.h>
-
 constexpr const uint32_t GUARDIAN_ERROR_RECEIPT_NOT_VALID = 142;
 constexpr const uint32_t GUARDIAN_ERROR_RECEIPT_IN_USE = 145;
 


### PR DESCRIPTION
## Description

This PR fetches the in-app subscription free trial info from playstore and passes it to qml. 
Given this is a bit hard to test, you need to use a signed build on prod. - When the dev menu is enabled, it will mock the 12-month plan with 7 days, otherwise it will return the values from google play (all 0 currently)  - so qa can test the ui flow for now, we might need a better way to test this. 



![Screenshot_20220419-182839](https://user-images.githubusercontent.com/9611612/164051466-2076dd94-50b1-4b0a-afb8-bddb8ada5ce0.png)


## Reference

    i.e Jira or Github issue URL

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
