### PR TITLE
DO NOT LAND: Switch to a Gecko Windows pool

### DIFF
--- a/taskcluster/ci/config.yml
+++ b/taskcluster/ci/config.yml
@@ -38,7 +38,7 @@ workers:
             os: linux
             worker-type: b-linux
         b-win2012:
-            provisioner: 'mozillavpn-{level}'
+            provisioner: 'gecko-1'
             implementation: generic-worker
             os: windows
             worker-type: b-win2012


### PR DESCRIPTION
This is testing out an issue where level 1 workers are failing to claim
Windows build tasks.