### PR TITLE
RELENG-790: Linux build debian package signing

### DIFF
--- a/taskcluster/ci/build/linux.yml
+++ b/taskcluster/ci/build/linux.yml
@@ -13,10 +13,10 @@ linux/opt:
     worker:
         docker-image: {in-tree: build}
         max-run-time: 3600
-        artifacts:
-            - type: directory
-              name: public/build
-              path: /builds/worker/artifacts
+        chain-of-trust: true
+        release-artifacts:
+            # release-artifacts expects file to be in /builds/worker/artifacts/
+            - target.tar.gz
     run:
         using: run-task
         use-caches: true

--- a/taskcluster/ci/signing/kind.yml
+++ b/taskcluster/ci/signing/kind.yml
@@ -18,6 +18,7 @@ group-by: build-type
 
 only-for-build-types:
     # - macos/opt
+    - linux/opt
     - android-x64/release
     - android-x86/release
     - android-arm64/release
@@ -30,6 +31,7 @@ job-template:
     signing-format:
         by-build-type:
             # macos.*: macapp
+            linux.*: autograph_debsign
             android.*: autograph_apk
             default: ""
 
@@ -44,3 +46,4 @@ job-template:
                 android-arm64/release: android/arm64-v8a
                 android-armv7/release: android/armv7
                 # macos/opt: macos/all
+                linux/opt: linux/all

--- a/taskcluster/mozillavpn_taskgraph/transforms/signing.py
+++ b/taskcluster/mozillavpn_taskgraph/transforms/signing.py
@@ -18,6 +18,7 @@ PRODUCTION_SIGNING_BUILD_TYPES = [
     "android-arm64/release",
     "android-armv7/release",
     # "macos/opt",
+    "linux/opt",
 ]
 
 SIGNING_BUILD_TYPES = PRODUCTION_SIGNING_BUILD_TYPES + [

--- a/taskcluster/scripts/build/linux.sh
+++ b/taskcluster/scripts/build/linux.sh
@@ -6,6 +6,5 @@
 
 bash scripts/linux/script.sh --source
 
-mkdir -p /builds/worker/artifacts/public/build
 cd .tmp
-tar -zvcf /builds/worker/artifacts/public/build/target.tar.gz .
+tar -zvcf /builds/worker/artifacts/target.tar.gz .


### PR DESCRIPTION
## Description

Now that we have debsign support in signingscript ([scriptworker-scripts #496](https://github.com/mozilla-releng/scriptworker-scripts/pull/496)) we can add build signing tasks to sign the debian package generated by the Linux build task.

## Reference

[RELENG-790: Stand-up Linux build signing tasks](https://mozilla-hub.atlassian.net/browse/RELENG-790)

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
