### PR TITLE
VPN-1839: Dinamically change status bar text color on mobile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ Release/
 Release-iphone*
 !android/resources/release/
 macos/gobridge/wireguard-go-version.h
+ios/gobridge/wireguard-go-version.h
 
 # Taskcluster/ Taskgraph
 !taskcluster/ci/build
@@ -81,11 +82,11 @@ macos/gobridge/wireguard-go-version.h
 .idea/
 .vscode/
 vscode-cpptools/*
-MozillaVPN.xcodeproj/
+*.xcodeproj/
 MozillaVPN.vcxproj*
 *.autosave
 
-#Windows 
+#Windows
 .deps
 lib*.dll
 balrog.dll

--- a/ios/app/Info.plist
+++ b/ios/app/Info.plist
@@ -54,5 +54,7 @@
 	<string>group.org.mozilla.ios.Guardian</string>
 	<key>ADJUST_SDK_TOKEN</key>
 	<string>$(ADJUST_SDK_TOKEN)</string>
+	<key>UIViewControllerBasedStatusBarAppearance</key>
+	<false/>
 </dict>
 </plist>

--- a/ios/app/Info.plist
+++ b/ios/app/Info.plist
@@ -55,6 +55,6 @@
 	<key>ADJUST_SDK_TOKEN</key>
 	<string>$(ADJUST_SDK_TOKEN)</string>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
-	<false/>
+	<true/>
 </dict>
 </plist>

--- a/nebula/ui/components.qrc
+++ b/nebula/ui/components.qrc
@@ -68,6 +68,7 @@
         <file>components/VPNMainImage.qml</file>
         <file>components/VPNMenu.qml</file>
         <file>components/VPNMetropolisLabel.qml</file>
+        <file>components/VPNMobileStatusBarModifier.qml</file>
         <file>components/VPNMouseArea.qml</file>
         <file>components/VPNPanel.qml</file>
         <file>components/VPNPopupButton.qml</file>

--- a/nebula/ui/components/VPNMobileStatusBarModifier.qml
+++ b/nebula/ui/components/VPNMobileStatusBarModifier.qml
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import QtQuick 2.5
+
+import Mozilla.VPN 1.0
+
+QtObject {
+    id: statusBarModifier
+
+    enum StatusBarTextColor {
+        Light,
+        Dark
+    }
+    property int statusBarTextColor: VPNMobileStatusBarModifier.StatusBarTextColor.Dark
+
+    function applyChanges() {
+        VPN.setStatusBarTextColor(statusBarModifier.statusBarTextColor);
+    }
+
+    function resetDefaults() {
+        VPN.setStatusBarTextColor(VPNMobileStatusBarModifier.StatusBarTextColor.Dark);
+    }
+
+    Component.onCompleted: applyChanges()
+    Component.onDestruction: resetDefaults()
+}

--- a/nebula/ui/components/VPNMobileStatusBarModifier.qml
+++ b/nebula/ui/components/VPNMobileStatusBarModifier.qml
@@ -5,22 +5,19 @@
 import QtQuick 2.5
 
 import Mozilla.VPN 1.0
+import components 0.1
 
 QtObject {
     id: statusBarModifier
 
-    enum StatusBarTextColor {
-        Light,
-        Dark
-    }
-    property int statusBarTextColor: VPNMobileStatusBarModifier.StatusBarTextColor.Dark
+    property int statusBarTextColor: VPNTheme.StatusBarTextColorDark
 
     function applyChanges() {
-        VPN.setStatusBarTextColor(statusBarModifier.statusBarTextColor);
+        VPNTheme.setStatusBarTextColor(statusBarModifier.statusBarTextColor);
     }
 
     function resetDefaults() {
-        VPN.setStatusBarTextColor(VPNMobileStatusBarModifier.StatusBarTextColor.Dark);
+        VPNTheme.setStatusBarTextColor(VPNTheme.StatusBarTextColorDark);
     }
 
     Component.onCompleted: applyChanges()

--- a/nebula/ui/components/qmldir
+++ b/nebula/ui/components/qmldir
@@ -54,6 +54,7 @@ VPNLottieAnimation 0.1 VPNLottieAnimation.qml
 VPNMainImage 0.1 VPNMainImage.qml
 VPNMenu 0.1 VPNMenu.qml
 VPNMetropolisLabel 0.1 VPNMetropolisLabel.qml
+VPNMobileStatusBarModifier 0.1 VPNMobileStatusBarModifier.qml
 VPNMouseArea 0.1 VPNMouseArea.qml
 VPNPanel 0.1 VPNPanel.qml
 VPNPopup 0.1 VPNPopup.qml

--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -1741,3 +1741,9 @@ void MozillaVPN::cancelAccountDeletion() {
   logger.warning() << "Canceling account deletion";
   AuthenticationInApp::instance()->terminateSession();
 }
+
+void MozillaVPN::setStatusBarTextColor(const quint8 color) {
+  #ifdef MVPN_IOS
+    IOSUtils::setStatusBarTextColor(color);
+  #endif
+}

--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -1741,9 +1741,3 @@ void MozillaVPN::cancelAccountDeletion() {
   logger.warning() << "Canceling account deletion";
   AuthenticationInApp::instance()->terminateSession();
 }
-
-void MozillaVPN::setStatusBarTextColor(const quint8 color) {
-  #ifdef MVPN_IOS
-    IOSUtils::setStatusBarTextColor(color);
-  #endif
-}

--- a/src/mozillavpn.h
+++ b/src/mozillavpn.h
@@ -195,6 +195,7 @@ class MozillaVPN final : public QObject {
   Q_INVOKABLE void crashTest();
   Q_INVOKABLE void deleteAccount();
   Q_INVOKABLE void cancelAccountDeletion();
+  Q_INVOKABLE void setStatusBarTextColor(const quint8 color);
 #ifdef MVPN_ANDROID
   Q_INVOKABLE void launchPlayStore();
 #endif

--- a/src/mozillavpn.h
+++ b/src/mozillavpn.h
@@ -195,7 +195,6 @@ class MozillaVPN final : public QObject {
   Q_INVOKABLE void crashTest();
   Q_INVOKABLE void deleteAccount();
   Q_INVOKABLE void cancelAccountDeletion();
-  Q_INVOKABLE void setStatusBarTextColor(const quint8 color);
 #ifdef MVPN_ANDROID
   Q_INVOKABLE void launchPlayStore();
 #endif

--- a/src/platforms/ios/iosutils.h
+++ b/src/platforms/ios/iosutils.h
@@ -18,6 +18,8 @@ class IOSUtils final {
   static void shareLogs(const QString& logs);
 
   static int compareStrings(const QString& a, const QString& b);
+
+  static void setStatusBarTextColor(const quint8 color);
 };
 
 #endif  // IOSUTILS_H

--- a/src/platforms/ios/iosutils.h
+++ b/src/platforms/ios/iosutils.h
@@ -21,7 +21,7 @@ class IOSUtils final {
 
   static int compareStrings(const QString& a, const QString& b);
 
-  static void setStatusBarTextColor(const Theme::StatusBarTextColor color);
+  static void setStatusBarTextColor(Theme::StatusBarTextColor color);
 };
 
 #endif  // IOSUTILS_H

--- a/src/platforms/ios/iosutils.h
+++ b/src/platforms/ios/iosutils.h
@@ -5,6 +5,8 @@
 #ifndef IOSUTILS_H
 #define IOSUTILS_H
 
+#include "theme.h"
+
 #include <QString>
 
 class IOSUtils final {
@@ -19,7 +21,7 @@ class IOSUtils final {
 
   static int compareStrings(const QString& a, const QString& b);
 
-  static void setStatusBarTextColor(const quint8 color);
+  static void setStatusBarTextColor(const Theme::StatusBarTextColor color);
 };
 
 #endif  // IOSUTILS_H

--- a/src/platforms/ios/iosutils.mm
+++ b/src/platforms/ios/iosutils.mm
@@ -113,3 +113,12 @@ int IOSUtils::compareStrings(const QString& a, const QString& b) {
       return -1;
   }
 }
+
+// static
+void IOSUtils::setStatusBarTextColor(quint8 color) {
+  if (color == 0) {
+    [UIApplication sharedApplication].statusBarStyle = UIStatusBarStyleLightContent;
+  } else {
+    [UIApplication sharedApplication].statusBarStyle = UIStatusBarStyleDarkContent;
+  }
+}

--- a/src/platforms/ios/iosutils.mm
+++ b/src/platforms/ios/iosutils.mm
@@ -4,6 +4,7 @@
 
 #include "iosutils.h"
 #include "logger.h"
+#include "theme.h"
 #include "qmlengineholder.h"
 
 #include <QDateTime>
@@ -115,8 +116,8 @@ int IOSUtils::compareStrings(const QString& a, const QString& b) {
 }
 
 // static
-void IOSUtils::setStatusBarTextColor(quint8 color) {
-  if (color == 0) {
+void IOSUtils::setStatusBarTextColor(const Theme::StatusBarTextColor color) {
+  if (color == Theme::StatusBarTextColorLight) {
     [UIApplication sharedApplication].statusBarStyle = UIStatusBarStyleLightContent;
   } else {
     [UIApplication sharedApplication].statusBarStyle = UIStatusBarStyleDarkContent;

--- a/src/platforms/ios/iosutils.mm
+++ b/src/platforms/ios/iosutils.mm
@@ -12,6 +12,7 @@
 #include <QtGui>
 #include <QtGui/qpa/qplatformnativeinterface.h>
 #include <QtQuick>
+#include <iostream>
 
 #import <UIKit/UIKit.h>
 
@@ -115,11 +116,16 @@ int IOSUtils::compareStrings(const QString& a, const QString& b) {
   }
 }
 
-// static
+@interface StatusBarModifierViewController : UIViewController
+@property (nonatomic, assign) UIStatusBarStyle preferredStatusBarStyle;
+@end
+
 void IOSUtils::setStatusBarTextColor(const Theme::StatusBarTextColor color) {
-  if (color == Theme::StatusBarTextColorLight) {
-    [UIApplication sharedApplication].statusBarStyle = UIStatusBarStyleLightContent;
-  } else {
-    [UIApplication sharedApplication].statusBarStyle = UIStatusBarStyleDarkContent;
-  }
+    StatusBarModifierViewController* rootViewController = static_cast<StatusBarModifierViewController *>([[UIApplication sharedApplication].windows[0] rootViewController]);
+    if (color == Theme::StatusBarTextColorLight) {
+        rootViewController.preferredStatusBarStyle = UIStatusBarStyleLightContent;
+    } else {
+        rootViewController.preferredStatusBarStyle = UIStatusBarStyleDarkContent;
+    }
+    [rootViewController setNeedsStatusBarAppearanceUpdate];
 }

--- a/src/platforms/ios/iosutils.mm
+++ b/src/platforms/ios/iosutils.mm
@@ -4,15 +4,14 @@
 
 #include "iosutils.h"
 #include "logger.h"
-#include "theme.h"
 #include "qmlengineholder.h"
+#include "theme.h"
 
 #include <QDateTime>
 #include <QString>
 #include <QtGui>
 #include <QtGui/qpa/qplatformnativeinterface.h>
 #include <QtQuick>
-#include <iostream>
 
 #import <UIKit/UIKit.h>
 
@@ -120,7 +119,7 @@ int IOSUtils::compareStrings(const QString& a, const QString& b) {
 @property (nonatomic, assign) UIStatusBarStyle preferredStatusBarStyle;
 @end
 
-void IOSUtils::setStatusBarTextColor(const Theme::StatusBarTextColor color) {
+void IOSUtils::setStatusBarTextColor(Theme::StatusBarTextColor color) {
     StatusBarModifierViewController* rootViewController = static_cast<StatusBarModifierViewController *>([[UIApplication sharedApplication].windows[0] rootViewController]);
     if (color == Theme::StatusBarTextColorLight) {
         rootViewController.preferredStatusBarStyle = UIStatusBarStyleLightContent;

--- a/src/platforms/macos/macosutils.h
+++ b/src/platforms/macos/macosutils.h
@@ -17,6 +17,7 @@ class MacOSUtils final {
   static void enableLoginItem(bool startAtBoot);
 
   static void setDockClickHandler();
+  static void setStatusBarTextColor();
 
   static void hideDockIcon();
   static void showDockIcon();

--- a/src/theme.cpp
+++ b/src/theme.cpp
@@ -10,6 +10,10 @@
 #include <QDir>
 #include <QJSEngine>
 
+#ifdef MVPN_IOS
+#  include "platforms/ios/iosutils.h"
+#endif
+
 namespace {
 Logger logger(LOG_MAIN, "Theme");
 }
@@ -143,4 +147,10 @@ QVariant Theme::data(const QModelIndex& index, int role) const {
     default:
       return QVariant();
   }
+}
+
+void Theme::setStatusBarTextColor([[maybe_unused]] const StatusBarTextColor color) {
+  #ifdef MVPN_IOS
+    IOSUtils::setStatusBarTextColor(color);
+  #endif
 }

--- a/src/theme.cpp
+++ b/src/theme.cpp
@@ -149,8 +149,7 @@ QVariant Theme::data(const QModelIndex& index, int role) const {
   }
 }
 
-void Theme::setStatusBarTextColor(
-    [[maybe_unused]] const StatusBarTextColor color) {
+void Theme::setStatusBarTextColor([[maybe_unused]] StatusBarTextColor color) {
 #ifdef MVPN_IOS
   IOSUtils::setStatusBarTextColor(color);
 #endif

--- a/src/theme.cpp
+++ b/src/theme.cpp
@@ -149,8 +149,9 @@ QVariant Theme::data(const QModelIndex& index, int role) const {
   }
 }
 
-void Theme::setStatusBarTextColor([[maybe_unused]] const StatusBarTextColor color) {
-  #ifdef MVPN_IOS
-    IOSUtils::setStatusBarTextColor(color);
-  #endif
+void Theme::setStatusBarTextColor(
+    [[maybe_unused]] const StatusBarTextColor color) {
+#ifdef MVPN_IOS
+  IOSUtils::setStatusBarTextColor(color);
+#endif
 }

--- a/src/theme.h
+++ b/src/theme.h
@@ -44,6 +44,13 @@ class Theme final : public QAbstractListModel {
 
   QVariant data(const QModelIndex& index, int role) const override;
 
+  enum StatusBarTextColor {
+    StatusBarTextColorLight,
+    StatusBarTextColorDark,
+  };
+  Q_ENUM(StatusBarTextColor)
+  Q_INVOKABLE void setStatusBarTextColor(const StatusBarTextColor color);
+
  private:
   void parseTheme(QJSEngine* engine, const QString& themeName);
   bool loadTheme(const QString& themeName);

--- a/src/theme.h
+++ b/src/theme.h
@@ -49,7 +49,7 @@ class Theme final : public QAbstractListModel {
     StatusBarTextColorDark,
   };
   Q_ENUM(StatusBarTextColor)
-  Q_INVOKABLE void setStatusBarTextColor(const StatusBarTextColor color);
+  Q_INVOKABLE void setStatusBarTextColor(StatusBarTextColor color);
 
  private:
   void parseTheme(QJSEngine* engine, const QString& themeName);

--- a/src/ui/views/ViewMobileOnboarding.qml
+++ b/src/ui/views/ViewMobileOnboarding.qml
@@ -23,6 +23,10 @@ VPNFlickable {
     height: parent.height
     interactive: flickContentHeight > height
 
+    VPNMobileStatusBarModifier {
+        statusBarTextColor: VPNMobileStatusBarModifier.StatusBarTextColor.Light
+    }
+
     ListModel {
         id: onboardingModel
 

--- a/src/ui/views/ViewMobileOnboarding.qml
+++ b/src/ui/views/ViewMobileOnboarding.qml
@@ -24,7 +24,7 @@ VPNFlickable {
     interactive: flickContentHeight > height
 
     VPNMobileStatusBarModifier {
-        statusBarTextColor: VPNMobileStatusBarModifier.StatusBarTextColor.Light
+        statusBarTextColor: VPNTheme.StatusBarTextColorLight
     }
 
     ListModel {


### PR DESCRIPTION
## Description

The default text color is black for this text. Contrary to what I
thought, iOS does not automatically verify background color and
change the text accordingly. Status bar text color needs to explicitly be
changed when necessary.

This is a draft because I still need to:

- [x] Stop using deprecated APIs on the iOS implementation
- [ ] ~Write tests~
   - Skipped for this functionality due to the lack of structue for adding platform specific tests at the moment.

I would like to get some early feedback on the approach I took here,
especially on how I handled this on the QML side, since this is my first PR on the project.
I thought it would be best to double check.

https://user-images.githubusercontent.com/25176023/164515154-2f296ad5-95b3-4228-b4b5-c0902815f451.mov

## Reference

https://mozilla-hub.atlassian.net/browse/VPN-1839

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
