### PR TITLE
Let's force openGL QT rendering on windows

### DIFF
--- a/src/command.cpp
+++ b/src/command.cpp
@@ -15,6 +15,7 @@
 #include "simplenetworkmanager.h"
 
 #ifdef MVPN_WINDOWS
+#  include <QQuickWindow>
 #  include <Windows.h>
 #endif
 
@@ -119,6 +120,10 @@ int Command::runGuiApp(std::function<int()>&& a_callback) {
 
   logger.info() << "MozillaVPN" << APP_VERSION;
   logger.info() << "User-Agent:" << NetworkManager::userAgent();
+
+#ifdef MVPN_WINDOWS
+  QQuickWindow::setGraphicsApi(QSGRendererInterface::OpenGL);
+#endif
 
   QApplication app(CommandLineParser::argc(), CommandLineParser::argv());
 


### PR DESCRIPTION
This PR works on my computer(tm), but I would like to chat with other engineers to see if this approach is OK for real.
Reading https://doc.qt.io/qt-6/windows-graphics.html it seems that we do not need to include openGL dll files.