### PR TITLE
Fix handling of aborted download benchmark

### DIFF
--- a/nebula/ui/components/VPNConnectionInfoScreen.qml
+++ b/nebula/ui/components/VPNConnectionInfoScreen.qml
@@ -156,7 +156,9 @@ Rectangle {
         z: 1
 
         onClicked: {
-            VPNConnectionBenchmark.start();
+            if (VPNConnectionBenchmark.state !== VPNConnectionBenchmark.StateRunning) {
+                VPNConnectionBenchmark.start();
+            }
         }
 
         Image {

--- a/src/connectionbenchmark/benchmarktaskdownload.cpp
+++ b/src/connectionbenchmark/benchmarktaskdownload.cpp
@@ -118,7 +118,7 @@ void BenchmarkTaskDownload::downloadReady(QNetworkReply::NetworkError error,
   Q_UNUSED(data);
 
   NetworkRequest* request = qobject_cast<NetworkRequest*>(QObject::sender());
-  m_requests.removeAll(request);
+  m_requests.removeOne(request);
 
   quint64 bitsPerSec = 0;
   double msecs = static_cast<double>(m_elapsedTimer.elapsed());

--- a/src/ui/views/ViewMain.qml
+++ b/src/ui/views/ViewMain.qml
@@ -56,12 +56,6 @@ VPNFlickable {
         }
     }
 
-    MouseArea {
-        anchors.fill: parent
-        enabled: box.connectionInfoScreenVisible
-        onClicked: box.closeConnectionInfo()
-    }
-
     GridLayout {
         id: col
 


### PR DESCRIPTION
## Description

When aborting the download benchmark for the _Connection Info Screen_ while it was running not all network requests were stopped. There was always one request left in `m_requests` that did not reliably call `downloadReady` on the `requestFailed` signal so that the `BenchmarkTaskDownload` only finished after this request completed.

## Reference

- Issue: #3314

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
