### PR TITLE
Ensure `taskgraph` can be generated locally

### DIFF
--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -111,3 +111,6 @@ jobs:
       - name: Test release-push
         run: |
           taskgraph full --p taskcluster/test/params/release-push.yml           
+      - name: Test default parameters
+        run: |
+          taskgraph full

--- a/taskcluster/mozillavpn_taskgraph/parameters.py
+++ b/taskcluster/mozillavpn_taskgraph/parameters.py
@@ -7,11 +7,20 @@ import os
 from taskgraph.parameters import extend_parameters_schema
 from voluptuous import All, Any, Range, Required
 
+
+def get_defaults(repo_root):
+    return {
+        "pull_request_number": None,
+        "version": "",
+    }
+
+
 extend_parameters_schema(
     {
         Required("pull_request_number"): Any(All(int, Range(min=1)), None),
         Required("version"): str,
-    }
+    },
+    defaults_fn=get_defaults
 )
 
 

--- a/taskcluster/requirements.in
+++ b/taskcluster/requirements.in
@@ -1,4 +1,4 @@
 # For instructions on managing dependencies, see:
 # https://taskcluster-taskgraph.readthedocs.io/en/latest/howto/bootstrap-taskgraph.html
 
-taskcluster-taskgraph
+taskcluster-taskgraph >= 1.4.0

--- a/taskcluster/requirements.txt
+++ b/taskcluster/requirements.txt
@@ -79,9 +79,9 @@ slugid==2.0.0 \
     --hash=sha256:a950d98b72691178bdd4d6c52743c4a2aa039207cf7a97d71060a111ff9ba297 \
     --hash=sha256:aec8b0e01c4ad32e38e12d609eab3ec912fd129aaf6b2ded0199b56a5f8fd67c
     # via taskcluster-taskgraph
-taskcluster-taskgraph==1.3.1 \
-    --hash=sha256:b9b13d131c7fa3396ef635c676684a34acf7594c40a94b6ee528ce469dbb9098 \
-    --hash=sha256:ebfb635d4ffaf75b15bbe3219763996c0ae9b0800fbfee75617925e542b7787d
+taskcluster-taskgraph==1.4.0 \
+    --hash=sha256:237ed0399ef55e9eef537e6163b456c04d58a7b72bc1b55e8c61a05331170b1e \
+    --hash=sha256:2be5ac94745180029dfad260486aafeb14f564f5a95d1d3269e0d17834273f11
     # via -r requirements.in
 taskcluster-urls==13.0.1 \
     --hash=sha256:5e25e7e6818e8877178b175ff43d2e6548afad72694aa125f404a7329ece0973 \


### PR DESCRIPTION
When working on Taskcluster CI changes it's useful to be able to debug locally by running the `taskgraph` command. However, a couple of exceptions have crept into this process lately necessitating workarounds. This ensure we can run `taskgraph <subcommand>` without errors.

Ideally we should set up some tests to cover this, but I haven't had a chance to work on those yet.