### PR TITLE
Update settings menu per in-app subscription management updates

### DIFF
--- a/nebula/ui/components.qrc
+++ b/nebula/ui/components.qrc
@@ -113,5 +113,6 @@
         <file>components/forms/VPNCursorDelegate.qml</file>
         <file>components/VPNSegmentedToggle.qml</file>
         <file>components/VPNSegmentedNavigation.qml</file>
+        <file>components/VPNUserProfile.qml</file>
     </qresource>
 </RCC>

--- a/nebula/ui/components/VPNAvatar.qml
+++ b/nebula/ui/components/VPNAvatar.qml
@@ -20,6 +20,7 @@ Item {
         fillMode: Image.PreserveAspectFit
         smooth: true
         source: isDefaultAvatar() ? "" : avatarUrl
+        visible: false
     }
 
     Image {
@@ -39,17 +40,13 @@ Item {
     Rectangle {
         id: avatarMask
 
-        anchors.centerIn: avatar
-        height: avatar.height
+        anchors.fill: avatar
         radius: height / 2
         visible: false
-        width: height
     }
 
     VPNOpacityMask {
-        anchors.centerIn: avatar
-        height: avatar.height
-        width: height
+        anchors.fill: avatar
         source: avatar
         maskSource: avatarMask
     }

--- a/nebula/ui/components/VPNMenu.qml
+++ b/nebula/ui/components/VPNMenu.qml
@@ -19,6 +19,8 @@ Item {
     property bool accessibleIgnored: false
     property bool btnDisabled: false
     property alias forceFocus: iconButton.focus
+    property var _menuOnBackClicked: () => handleMenuGoBack();
+    property string _iconButtonSource: "qrc:/nebula/resources/back.svg"
 
     width: parent.width
     height: VPNTheme.theme.menuHeight
@@ -39,7 +41,7 @@ Item {
 
         skipEnsureVisible: true // prevents scrolling of lists when this is focused
 
-        onClicked: handleMenuGoBack()
+        onClicked: _menuOnBackClicked()
         anchors.top: parent.top
         anchors.left: parent.left
         anchors.topMargin: VPNTheme.theme.windowMargin / 2
@@ -52,14 +54,12 @@ Item {
         enabled: !btnDisabled
         opacity: enabled ? 1 : .4
         Image {
-            id: backImage
-
-            source: "qrc:/nebula/resources/back.svg"
+            objectName: "menuIcon"
+            source: _iconButtonSource
             sourceSize.width: VPNTheme.theme.iconSize
             fillMode: Image.PreserveAspectFit
             anchors.centerIn: iconButton
         }
-
     }
 
     VPNBoldLabel {

--- a/nebula/ui/components/VPNUserProfile.qml
+++ b/nebula/ui/components/VPNUserProfile.qml
@@ -1,0 +1,73 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import QtQuick 2.5
+import QtQuick.Layouts 1.14
+
+import Mozilla.VPN 1.0
+import components 0.1
+
+
+RowLayout {
+    property string _iconButtonImageSource: ""
+    property var _iconButtonOnClicked
+
+    id: userInfo
+    spacing: VPNTheme.theme.windowMargin
+
+    Rectangle {
+      Layout.preferredWidth: VPNTheme.theme.rowHeight
+      Layout.preferredHeight: VPNTheme.theme.rowHeight
+      Layout.alignment: Qt.AlignVCenter
+      color: VPNTheme.theme.transparent
+
+        VPNAvatar {
+          id: avatar
+          avatarUrl: VPNUser.avatar
+          anchors.fill: parent
+        }
+    }
+
+    ColumnLayout {
+      Layout.alignment: Qt.AlignVCenter
+
+      VPNBoldLabel {
+          readonly property var textVpnUser: VPNl18n.GlobalVpnUser
+          text: VPNUser.displayName ? VPNUser.displayName : textVpnUser
+          wrapMode: Text.WrapAtWordBoundaryOrAnywhere
+          Layout.fillWidth: true
+      }
+
+      VPNTextBlock {
+          id: serverLocation
+          text: VPNUser.email
+          Accessible.ignored: true
+          Layout.alignment: Qt.AlignLeft
+          width: undefined
+          Layout.fillWidth: true
+          wrapMode: Text.NoWrap
+          elide: Text.ElideRight
+          lineHeight: 1
+          lineHeightMode: Text.FixedHeight
+      }
+    }
+
+    VPNIconButton {
+      id: iconButton
+      objectName: "manageAccountButton"
+      Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
+      Layout.preferredHeight: VPNTheme.theme.rowHeight
+      Layout.preferredWidth: VPNTheme.theme.rowHeight
+      accessibleName: qsTrId("vpn.main.manageAccount")
+      onClicked: _iconButtonOnClicked()
+      visible: _iconButtonImageSource !== ""
+
+        VPNIcon {
+          id: icon
+          source: _iconButtonImageSource
+          fillMode: Image.PreserveAspectFit
+          anchors.centerIn: iconButton
+        }
+    }
+}

--- a/nebula/ui/components/qmldir
+++ b/nebula/ui/components/qmldir
@@ -86,6 +86,7 @@ VPNToggle 0.1 VPNToggle.qml
 VPNToggleCard 0.1 VPNToggleCard.qml
 VPNToolTip 0.1 VPNToolTip.qml
 VPNUIStates 0.1 VPNUIStates.qml
+VPNUserProfile 0.1 VPNUserProfile.qml
 VPNVerticalSpacer 0.1 VPNVerticalSpacer.qml
 VPNViewDNSSettings 0.1 VPNViewDNSSettings.qml
 VPNWasmAlerts 0.1 VPNWasmAlerts.qml

--- a/src/ui/settings/ViewSettingsMenu.qml
+++ b/src/ui/settings/ViewSettingsMenu.qml
@@ -73,7 +73,7 @@ VPNFlickable {
                 Layout.fillWidth: true
                 Layout.leftMargin: VPNTheme.theme.windowMargin / 2
                 Layout.rightMargin: VPNTheme.theme.windowMargin / 2
-                color: "#E7E7E7"
+                color: VPNTheme.colors.grey10
             }
         }
 

--- a/src/ui/settings/ViewSettingsMenu.qml
+++ b/src/ui/settings/ViewSettingsMenu.qml
@@ -13,56 +13,16 @@ import org.mozilla.Glean 0.30
 import telemetry 0.30
 
 VPNFlickable {
+    property string _menuTitle: qsTrId("vpn.main.settings")
+
     id: vpnFlickable
     objectName: "settingsView"
-    flickContentHeight: settingsList.y + settingsList.height + signOutLink.height + signOutLink.anchors.bottomMargin
-    hideScollBarOnStackTransition: true
 
-    VPNIconButton {
-        id: iconButton
-        objectName: "settingsCloseButton"
-        onClicked: stackview.pop(StackView.Immediate)
-        anchors.top: parent.top
-        anchors.left: parent.left
-        anchors.topMargin: VPNTheme.theme.windowMargin / 2
-        anchors.leftMargin: VPNTheme.theme.windowMargin / 2
-        accessibleName: qsTrId("vpn.connectionInfo.close")
+    flickContentHeight: settingsList.implicitHeight + VPNTheme.theme.menuHeight
+    windowHeightExceedsContentHeight: !(flickContentHeight > height)
 
-        Image {
-            id: backImage
-
-            source: "qrc:/nebula/resources/close-dark.svg"
-            sourceSize.width: VPNTheme.theme.iconSize
-            fillMode: Image.PreserveAspectFit
-            anchors.centerIn: iconButton
-        }
-    }
-
-    VPNPanel {
-        id: vpnPanel
-        logoSize: 80
-        logo: VPNUser.avatar
-        //% "VPN User"
-        readonly property var textVpnUser: qsTrId("vpn.settings.user")
-        logoTitle: VPNUser.displayName ? VPNUser.displayName : textVpnUser
-        logoSubtitle: VPNUser.email
-        anchors.top: parent.top
-        anchors.topMargin: (Math.max(window.safeContentHeight * .08, VPNTheme.theme.windowMargin * 2))
-        isSettingsView: true
-    }
-
-    VPNButton {
-        id: manageAccountButton
-        objectName: "manageAccountButton"
-        text: qsTrId("vpn.main.manageAccount")
-        anchors.top: vpnPanel.bottom
-        anchors.topMargin: VPNTheme.theme.vSpacing
-        anchors.horizontalCenter: parent.horizontalCenter
-        onClicked: {
-            Sample.manageAccountClicked.record();
-            VPN.openLink(VPN.LinkAccount)
-        }
-    }
+    anchors.top:  parent.top
+    anchors.topMargin: VPNTheme.theme.menuHeight
 
     Component {
         id: aboutUsComponent
@@ -77,91 +37,143 @@ VPNFlickable {
     ColumnLayout {
         id: settingsList
 
-        spacing: VPNTheme.theme.listSpacing
-        y: VPNTheme.theme.vSpacing + manageAccountButton.y + manageAccountButton.height
+        spacing: VPNTheme.theme.windowMargin
         width: parent.width - VPNTheme.theme.windowMargin
-        anchors.horizontalCenter: parent.horizontalCenter
+        height: Math.max(vpnFlickable.height - VPNTheme.theme.menuHeight, settingsList.implicitHeight)
 
-        VPNSettingsItem {
-            objectName: "settingsWhatsNew"
-            settingTitle: VPNl18n.WhatsNewReleaseNotesTourPageHeader
-            imageLeftSrc: "qrc:/nebula/resources/gift-dark.svg"
-            imageRightSrc: "qrc:/nebula/resources/chevron.svg"
-            onClicked: settingsStackView.push("qrc:/ui/settings/ViewWhatsNew.qml")
-            showIndicator: VPNWhatsNewModel.hasUnseenFeature
-            visible: VPNWhatsNewModel.rowCount() > 0
+        anchors {
+            top: parent.top
+            horizontalCenter: parent.horizontalCenter
         }
 
-        VPNSettingsItem {
-            objectName: "settingsNetworking"
-            settingTitle: qsTrId("vpn.settings.networking")
-            imageLeftSrc: "qrc:/ui/resources/settings/networkSettings.svg"
-            imageRightSrc: "qrc:/nebula/resources/chevron.svg"
-            onClicked: settingsStackView.push("qrc:/ui/settings/ViewNetworkSettings.qml", {
-                                                  //% "App permissions"
-                                                  _appPermissionsTitle: Qt.binding(() => qsTrId("vpn.settings.appPermissions2"))
-                                              })
-        }
+        ColumnLayout {
+            spacing: 0
 
-        VPNSettingsItem {
-            id: preferencesSetting
-            objectName: "settingsPreferences"
-            settingTitle: VPNl18n.SettingsSystemPreferences
-            imageLeftSrc: "qrc:/ui/resources/settings/preferences.svg"
-            imageRightSrc: "qrc:/nebula/resources/chevron.svg"
-            onClicked: settingsStackView.push("qrc:/ui/settings/ViewPrivacySecurity.qml", {
-                                                _startAtBootTitle: Qt.binding(() => VPNl18n.SettingsStartAtBootTitle),
-                                                _languageTitle:  Qt.binding(() => qsTrId("vpn.settings.language")),
-                                                _notificationsTitle:  Qt.binding(() => qsTrId("vpn.settings.notifications")),
-                                                _menuTitle: Qt.binding(() => preferencesSetting.settingTitle)
-                                              })
-        }
+            VPNVerticalSpacer {
+                Layout.preferredHeight: VPNTheme.theme.windowMargin * 2
+            }
 
-        VPNSettingsItem {
-            //% "Give feedback"
-            property string giveFeedbackTitle: qsTrId("vpn.settings.giveFeedback")
-            objectName: "settingsGetHelp"
-            settingTitle: qsTrId("vpn.main.getHelp2")
-            imageLeftSrc: "qrc:/ui/resources/settings/questionMark.svg"
-            imageRightSrc: "qrc:/nebula/resources/chevron.svg"
-            onClicked: {
-                Sample.getHelpClickedViewSettings.record();
-                settingsStackView.push("qrc:/ui/views/ViewGetHelp.qml", {isSettingsView: true})
+            VPNUserProfile {
+                _iconButtonImageSource: "qrc:/nebula/resources/chevron.svg"
+                _iconButtonOnClicked: () => {
+                    Sample.manageAccountClicked.record();
+                    VPN.openLink(VPN.LinkAccount)
+                }
+                Layout.leftMargin: VPNTheme.theme.windowMargin / 2
+            }
+
+            VPNVerticalSpacer {
+                Layout.preferredHeight: VPNTheme.theme.windowMargin * 2
+            }
+
+            Rectangle {
+                id: divider
+
+                Layout.preferredHeight: 1
+                Layout.fillWidth: true
+                Layout.leftMargin: VPNTheme.theme.windowMargin / 2
+                Layout.rightMargin: VPNTheme.theme.windowMargin / 2
+                color: "#E7E7E7"
             }
         }
 
-        VPNSettingsItem {
-            objectName: "settingsAboutUs"
-            settingTitle: qsTrId("vpn.settings.aboutUs")
-            imageLeftSrc: "qrc:/ui/resources/settings/aboutUs.svg"
-            imageRightSrc: "qrc:/nebula/resources/chevron.svg"
-            onClicked: settingsStackView.push(aboutUsComponent)
-        }
 
         // TODO: Move to subscription management
-        VPNLinkButton {
-            Layout.alignment: Qt.AlignHCenter
-            Layout.topMargin: VPNTheme.theme.vSpacing
+        ColumnLayout {
+            Layout.fillWidth: true
+            Layout.minimumWidth: parent.width
 
-            fontName: VPNTheme.theme.fontBoldFamily
-            labelText: VPNl18n.DeleteAccountButtonLabel + " (WIP)" 
-            linkColor: VPNTheme.theme.redButton
-            visible: VPNFeatureList.get("accountDeletion").isSupported
-            onClicked: {
-                settingsStackView.push("qrc:/ui/deleteAccount/ViewDeleteAccount.qml");
+            VPNSettingsItem {
+                objectName: "settingsWhatsNew"
+                settingTitle: VPNl18n.WhatsNewReleaseNotesTourPageHeader
+                imageLeftSrc: "qrc:/nebula/resources/gift-dark.svg"
+                imageRightSrc: "qrc:/nebula/resources/chevron.svg"
+                onClicked: settingsStackView.push("qrc:/ui/settings/ViewWhatsNew.qml")
+                showIndicator: VPNWhatsNewModel.hasUnseenFeature
+                visible: VPNWhatsNewModel.rowCount() > 0
+            }
+
+            VPNSettingsItem {
+                objectName: "settingsNetworking"
+                settingTitle: qsTrId("vpn.settings.networking")
+                imageLeftSrc: "qrc:/ui/resources/settings/networkSettings.svg"
+                imageRightSrc: "qrc:/nebula/resources/chevron.svg"
+                onClicked: settingsStackView.push("qrc:/ui/settings/ViewNetworkSettings.qml", {
+                                                      //% "App permissions"
+                                                      _appPermissionsTitle: Qt.binding(() => qsTrId("vpn.settings.appPermissions2"))
+                                                  })
+            }
+
+            VPNSettingsItem {
+                id: preferencesSetting
+                objectName: "settingsPreferences"
+                settingTitle: VPNl18n.SettingsSystemPreferences
+                imageLeftSrc: "qrc:/ui/resources/settings/preferences.svg"
+                imageRightSrc: "qrc:/nebula/resources/chevron.svg"
+                onClicked: settingsStackView.push("qrc:/ui/settings/ViewPrivacySecurity.qml", {
+                                                    _startAtBootTitle: Qt.binding(() => VPNl18n.SettingsStartAtBootTitle),
+                                                    _languageTitle:  Qt.binding(() => qsTrId("vpn.settings.language")),
+                                                    _notificationsTitle:  Qt.binding(() => qsTrId("vpn.settings.notifications")),
+                                                    _menuTitle: Qt.binding(() => preferencesSetting.settingTitle)
+                                                  })
+            }
+
+            VPNSettingsItem {
+                //% "Give feedback"
+                property string giveFeedbackTitle: qsTrId("vpn.settings.giveFeedback")
+                objectName: "settingsGetHelp"
+                settingTitle: qsTrId("vpn.main.getHelp2")
+                imageLeftSrc: "qrc:/ui/resources/settings/questionMark.svg"
+                imageRightSrc: "qrc:/nebula/resources/chevron.svg"
+                onClicked: {
+                    Sample.getHelpClickedViewSettings.record();
+                    settingsStackView.push("qrc:/ui/views/ViewGetHelp.qml", {isSettingsView: true})
+                }
+            }
+
+            VPNSettingsItem {
+                objectName: "settingsAboutUs"
+                settingTitle: qsTrId("vpn.settings.aboutUs")
+                imageLeftSrc: "qrc:/ui/resources/settings/aboutUs.svg"
+                imageRightSrc: "qrc:/nebula/resources/chevron.svg"
+                onClicked: settingsStackView.push(aboutUsComponent)
+            }
+
+            VPNLinkButton {
+                Layout.alignment: Qt.AlignHCenter
+                Layout.topMargin: VPNTheme.theme.vSpacing
+
+                fontName: VPNTheme.theme.fontBoldFamily
+                labelText: VPNl18n.DeleteAccountButtonLabel + " (WIP)"
+                linkColor: VPNTheme.theme.redButton
+                visible: VPNFeatureList.get("accountDeletion").isSupported
+                onClicked: {
+                    settingsStackView.push("qrc:/ui/deleteAccount/ViewDeleteAccount.qml");
+                }
+            }
+
+            VPNVerticalSpacer {
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+            }
+
+            VPNSignOut {
+                id: signOutLink
+
+                objectName: "settingsLogout"
+                anchors {
+                    horizontalCenter: undefined
+                    bottom: undefined
+                    bottomMargin: undefined
+                }
+                Layout.alignment: Qt.AlignHCenter | Qt.AlignBottom
+            }
+
+            VPNVerticalSpacer {
+                Layout.fillWidth: true
+                Layout.minimumHeight: VPNTheme.theme.rowHeight
             }
         }
-
-        Rectangle {
-            Layout.preferredHeight: fullscreenRequired? VPNTheme.theme.rowHeight * 1.5 : VPNTheme.theme.rowHeight
-            Layout.fillWidth: true
-            color: VPNTheme.theme.transparent
-        }
-    }
-
-    VPNSignOut {
-        id: signOutLink
-
-        objectName: "settingsLogout"
     }
 }
+

--- a/src/ui/views/ViewContactUs.qml
+++ b/src/ui/views/ViewContactUs.qml
@@ -160,49 +160,12 @@ Item {
                     ColumnLayout {
                         Layout.fillWidth: true
                         Layout.preferredWidth: parent.width
-                        RowLayout {
-                            visible: VPN.userState === VPN.UserAuthenticated
-                            spacing: 15
-                            Layout.fillWidth: true
-                            Layout.bottomMargin: 15
+                        spacing: 10
 
-                            Rectangle {
-                                Layout.preferredWidth: 40
-                                Layout.preferredHeight: 40
-                                color: VPNTheme.theme.transparent
-
-                                VPNAvatar {
-                                    id: avatar
-
-                                    avatarUrl: VPNUser.avatar
-                                    anchors.fill: parent
-                                }
-                            }
-
-                            ColumnLayout {
-
-                                VPNBoldLabel {
-                                    //% "VPN User"
-                                    readonly property var textVpnUser: qsTrId("vpn.settings.user")
-                                    text: VPNUser.displayName ? VPNUser.displayName : textVpnUser
-                                    wrapMode: Text.WrapAtWordBoundaryOrAnywhere
-                                    Layout.fillWidth: true
-
-                                }
-
-
-                                VPNLightLabel {
-                                    id: serverLocation
-                                    text: VPNUser.email
-                                    Accessible.ignored: true
-                                    Layout.alignment: Qt.AlignLeft
-                                    elide: Text.ElideRight
-                                    Layout.fillWidth: true
-                                }
-                            }
+                        VPNUserProfile {
+                            Layout.bottomMargin: VPNTheme.theme.windowMargin / 2
                         }
 
-                        spacing: 10
 
                         VPNBoldLabel {
                             property string enterEmailAddress: VPNl18n.InAppSupportWorkflowSupportFieldHeader

--- a/src/ui/views/ViewSettings.qml
+++ b/src/ui/views/ViewSettings.qml
@@ -19,8 +19,14 @@ Item {
 
         title: ""
         isSettingsView: true
-        visible: settingsStackView.depth !== 1
         opacity: visible ? 1 : 0
+        _iconButtonSource: settingsStackView.depth === 1 ? "qrc:/nebula/resources/close-dark.svg" : "qrc:/nebula/resources/back.svg"
+        _menuOnBackClicked: () => {
+            if (settingsStackView.depth !== 1) {
+                return settingsStackView.pop();
+            }
+            stackview.pop(StackView.Immediate)
+        }
 
 
         Behavior on opacity {
@@ -29,7 +35,6 @@ Item {
             }
         }
     }
-
 
     VPNStackView {
         id: settingsStackView

--- a/src/ui/views/ViewSettings.qml
+++ b/src/ui/views/ViewSettings.qml
@@ -49,9 +49,7 @@ Item {
 
         onCurrentItemChanged: {
             menu.title = Qt.binding(() => currentItem._menuTitle || "");
-            menu.visible = Qt.binding(() => currentItem._menuVisible !== undefined
-                ? currentItem._menuVisible
-                : settingsStackView.depth !== 1);
+            menu.visible = Qt.binding(() => currentItem._menuTitle);
         }
     }
 }

--- a/tests/functional/testScreenCapture.js
+++ b/tests/functional/testScreenCapture.js
@@ -419,8 +419,6 @@ describe.skip('Take screenshots for each view', function() {
 
     await vpn.waitForElement('manageAccountButton');
     await vpn.waitForElementProperty('manageAccountButton', 'visible', 'true');
-    await vpn.waitForElementProperty(
-        'manageAccountButton', 'text', 'Manage account');
   });
 
   // TODO: app-permission
@@ -505,7 +503,7 @@ describe.skip('Take screenshots for each view', function() {
     await vpn.setElementProperty('settingsView', 'contentY', 'i', 0);
     await vpn.wait();
 
-    await vpn.clickOnElement('settingsCloseButton');
+    await vpn.clickOnElement('settingsBackButton');
     await vpn.wait();
 
     await vpn.waitForElement('controllerTitle');

--- a/tests/functional/testSettings.js
+++ b/tests/functional/testSettings.js
@@ -33,9 +33,18 @@ describe('Settings', function() {
   }
 
   it('Opening and closing the settings view', async () => {
-    await vpn.waitForElement('settingsCloseButton');
-    await vpn.waitForElementProperty('settingsCloseButton', 'visible', 'true');
-    await vpn.clickOnElement('settingsCloseButton');
+    await vpn.waitForElement('settingsBackButton');
+    await vpn.waitForElementProperty('settingsBackButton', 'visible', 'true');
+
+    await vpn.waitForElement('menuIcon');
+    await vpn.waitForElementProperty(
+        'menuIcon', 'source', 'qrc:/nebula/resources/close-dark.svg');
+
+    await vpn.waitForElement('manageAccountButton');
+    await vpn.waitForElementProperty('manageAccountButton', 'visible', 'true');
+
+
+    await vpn.clickOnElement('settingsBackButton');
     await vpn.wait();
 
     await vpn.waitForElement('controllerTitle');
@@ -111,6 +120,9 @@ describe('Settings', function() {
     await vpn.clickOnElement('languageList/language-it');
     await vpn.wait();
 
+
+    await vpn.waitForElement('settingsBackButton');
+    await vpn.waitForElementProperty('settingsBackButton', 'visible', 'true');
     await vpn.clickOnElement('settingsBackButton');
     await vpn.wait();
 
@@ -156,8 +168,6 @@ describe('Settings', function() {
 
     await vpn.waitForElement('manageAccountButton');
     await vpn.waitForElementProperty('manageAccountButton', 'visible', 'true');
-    await vpn.waitForElementProperty(
-        'manageAccountButton', 'text', 'Manage account');
 
     await vpn.waitForElement('settingsPreferences');
     await vpn.waitForElementProperty('settingsPreferences', 'visible', 'true');
@@ -192,8 +202,6 @@ describe('Settings', function() {
 
     await vpn.waitForElement('manageAccountButton');
     await vpn.waitForElementProperty('manageAccountButton', 'visible', 'true');
-    await vpn.waitForElementProperty(
-        'manageAccountButton', 'text', 'Manage account');
   });
 
   // TODO: app-permission

--- a/translations/strings.yaml
+++ b/translations/strings.yaml
@@ -592,3 +592,6 @@ global:
   collapse:
     value: Collapse
     comment: Action used in the context of an expandable/collapsible card component
+  vpnUser: 
+    value: VPN User
+    comment: Fallback string for users who have not specified a Display Name.


### PR DESCRIPTION
## Description

  This updates the Settings menu view to latest Figma spec ahead of upcoming In-App Subscription Management work. 
- Adds and uses VPNUserInfo.qml in ViewSettingsMenu.qml and ViewContactUs.qml. 
- Adds menu bar to settings view
- Removes blue 'Manage account' button.
- Fixes #3366

This will need a rebase and some small refactors once #3376 and #3365 are merged. Also, once the new in-app subscription management view is available, we'll need to update the VPNUserInfo button to open that view, instead of opening a browser window.

<img width="260" alt="Screen Shot 2022-04-26 at 9 06 12 PM" src="https://user-images.githubusercontent.com/22355127/165433824-e360f06e-0a63-4620-9678-d623a2ccd7b6.png">

<img width="260" alt="Screen Shot 2022-04-26 at 9 07 02 PM" src="https://user-images.githubusercontent.com/22355127/165433831-304481a5-c843-47b1-9e1f-b9e883d72c4d.png">

## Reference

Fixes #3366 & VPN-2068

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [] I have commented my code PARTICULARLY in hard to understand areas
- [] I have added thorough tests where needed
