### PR TITLE
Fix Taskcluster win cleanup

### DIFF
--- a/taskcluster/scripts/build/windows.ps1
+++ b/taskcluster/scripts/build/windows.ps1
@@ -59,5 +59,7 @@ Stop-Process -Name "mspdbsrv" -Force -ErrorAction SilentlyContinue
 Stop-Process -Name "vctip.exe" -Force -ErrorAction SilentlyContinue
 
 Write-Output "Open Processes:"
-
 wmic process get description,executablepath 
+
+#Final Cleanup - So next tasks will fail on the pre-installed go-files
+git clean -xdff

--- a/taskcluster/scripts/build/windows.ps1
+++ b/taskcluster/scripts/build/windows.ps1
@@ -13,6 +13,10 @@ $QTPATH =resolve-path "$FETCHES_PATH/QT_OUT/bin/"
 . "$FETCHES_PATH/QT_OUT/configure_qt.ps1"
 . "$REPO_ROOT_PATH/taskcluster/scripts/fetch/enable_win_rust.ps1"
 
+# Remove vctip - it's a build-telemetry thing from ms,
+# that will try to send metrics after the build, so it blocks taskcluster cleanup. 
+Remove-Item $FETCHES_PATH/VisualStudio/VC/Tools/MSVC/14.30.30705/bin/HostX64/x64/vctip.exe  
+
 # Fetch 3rdparty stuff.
 python3 -m pip install -r requirements.txt --user
 git submodule update --init --force --recursive --depth=1

--- a/taskcluster/scripts/build/windows.ps1
+++ b/taskcluster/scripts/build/windows.ps1
@@ -61,5 +61,6 @@ Stop-Process -Name "vctip.exe" -Force -ErrorAction SilentlyContinue
 Write-Output "Open Processes:"
 wmic process get description,executablepath 
 
-#Final Cleanup - So next tasks will fail on the pre-installed go-files
-git clean -xdff
+# Final Cleanup - So next tasks will not fail on pre-cleanup
+Remove-Item -Recurse -Force -ErrorAction SilentlyContinue windows/tunnel/.deps
+Remove-Item -Recurse -Force -ErrorAction SilentlyContinue balrog/.deps


### PR DESCRIPTION
## Description

This pr solves 2 things: 

Failures to cleanup a finished task with the error 
```PermissionError: [WinError 5] Access is denied: 'Z:\\task_165109248829054\\fetches\\VisualStudio\\VC\\Tools\\MSVC\\14.30.30705\\bin\\Hostx64\\x64\\Microsoft.Diagnostics.Tracing.EventSource.dll' ```

Failures to start a task with the error: 

```
executing ['git', 'clean', '-xdff']
[vcs 2022-04-27T21:29:24.735Z] warning: failed to remove balrog/.deps/gopath/pkg/mod/github.com/mozilla-services/autograph/verifier/contentsignature@v0.0.0-20210505200649-cb56f0dcbdd1: Permission denied
```   

## Reference

    i.e Jira or Github issue URL

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
