### PR TITLE
Maybe fix appstore connect build in 2.8.2?

### DIFF
--- a/ci_scripts/ci_post_clone.sh
+++ b/ci_scripts/ci_post_clone.sh
@@ -32,9 +32,9 @@ else
   pip3 install aqtinstall
   aqt install-qt -O /Volumes/workspace/repository/qt_ios mac desktop 6.2.3 -m qtcharts qtwebsockets qt5compat
   aqt install-qt -O /Volumes/workspace/repository/qt_ios mac ios 6.2.3 -m qtcharts qtwebsockets qt5compat
-  mv /Volumes/workspace/repository/qt_ios/6.2.3/macos /Volumes/workspace/repository/qt_ios/6.2.3/clang_64
+ # mv /Volumes/workspace/repository/qt_ios/6.2.3/macos /Volumes/workspace/repository/qt_ios/6.2.3/clang_64
   export QT_IOS_BIN=/Volumes/workspace/repository/qt_ios/6.2.3/ios/bin
-  export PATH=/Volumes/workspace/repository/qt_ios/6.2.3/ios/bin:/Volumes/workspace/repository/qt_ios/6.2.3/clang_64/bin:$PATH
+  export PATH=/Volumes/workspace/repository/qt_ios/6.2.3/ios/bin:/Volumes/workspace/repository/qt_ios/6.2.3/macos/bin:$PATH
 fi
 
 # install xcodeproj which is needed by xcode_patcher.rb
@@ -67,5 +67,5 @@ if [ $CI_PRODUCT_PLATFORM == 'macOS' ]
 then
   ./scripts/macos/apple_compile.sh macos
 else
-  ./scripts/macos/apple_compile.sh ios -q /Volumes/workspace/repository/qt_ios/6.2.3/clang_64/bin
+  ./scripts/macos/apple_compile.sh ios -q /Volumes/workspace/repository/qt_ios/6.2.3/macos/bin
 fi


### PR DESCRIPTION
@mbirghan , @bakulf - It seems on the release branch we are not currently building ios in appstore connect...

Looking at the logs
```
==> Running `brew cleanup go`...

Disable this behaviour by setting HOMEBREW_NO_INSTALL_CLEANUP.

Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).

/Volumes/workspace/repository/qt_ios/6.2.3/ios/bin/qmake

/Volumes/workspace/repository/qt_ios/6.2.3/ios/bin/qmake: line 7: /Volumes/workspace/repository/qt_ios/6.2.3/macos/bin/qmake: No such file or directory

/Volumes/workspace/repository/qt_ios/6.2.3/ios/bin/qmake: line 7: /Volumes/workspace/repository/qt_ios/6.2.3/macos/bin/qmake: No such file or directory

This script compiles MozillaVPN for MacOS/iOS

Using the MVPN_IOS_ADJUST_TOKEN value for the adjust token

qmake path: /Volumes/workspace/repository/qt_ios/6.2.3/ios/bin/qmake

qmake doesn't exist or it fails
```

It seems like ios/bin/qmake does expect the destop qmake not under `clang_64` but to be in the macos folder. Not sure if this will fix it? But i do not understand how this would have worked for 2.8.0 then 😅 
