### PR TITLE
Fix disclaimer alignment in auth template

### DIFF
--- a/src/ui/authenticationInApp/ViewAuthenticationSignIn.qml
+++ b/src/ui/authenticationInApp/ViewAuthenticationSignIn.qml
@@ -67,6 +67,7 @@ VPNInAppAuthenticationBase {
     _disclaimers: Loader {
         id: disclaimersLoader
 
+        Layout.alignment: Qt.AlignHCenter
         source: "qrc:/nebula/components/inAppAuth/VPNInAppAuthenticationLegalDisclaimer.qml"
     }
 


### PR DESCRIPTION
## Description

Center disclaimer text on in-app auth sign in page.

## Screenshots

|Before|After|
|---|---|
|<img width="373" alt="disclaimer-before" src="https://user-images.githubusercontent.com/13835474/165858517-104e9b5d-389f-4a37-b9fa-0c0d6be619ef.png">|<img width="371" alt="disclaimer-after" src="https://user-images.githubusercontent.com/13835474/165858525-e0929892-128a-483d-9fb1-d396a23225b3.png">|

## Reference

Fixes #3393

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
