### PR TITLE
Windows: Replace connectivity hint with GetIpInterfaceTable()

### DIFF
--- a/scripts/windows/compile.bat
+++ b/scripts/windows/compile.bat
@@ -81,7 +81,7 @@ python3 scripts\utils\import_languages.py
 ECHO Generating glean samples...
 python3 scripts\utils\generate_glean.py
 
-ECHO BUILD_BUILD = %DEBUG_BUILD%
+ECHO DEBUG_BUILD = %DEBUG_BUILD%
 
 ECHO Creating the project with flags: %FLAGS%
 
@@ -144,13 +144,11 @@ ECHO Moving mozillavpn.exe
 if %DEBUG_BUILD% == T (
   REM We need to move the exes in debug so the installer can find them
   xcopy /y debug\*.exe .\
-  xcopy /y extension\bridge\target\debug\mozillavpnnp.exe .\
 )
 
-IF %DEBUG_BUILD%==F (
-  REM We need to move the exes in release so the installer can find them
-  xcopy /y extension\bridge\target\release\mozillavpnnp.exe .
-)
+REM We need to move the web extension bridge so the installer can find it
+REM Note that the web extension is always built in release mode
+xcopy /y extension\bridge\target\release\mozillavpnnp.exe .\
 
 ECHO Creating the installer...
 CALL windows\installer\build.cmd

--- a/src/platforms/windows/daemon/dnsutilswindows.cpp
+++ b/src/platforms/windows/daemon/dnsutilswindows.cpp
@@ -7,7 +7,6 @@
 #include "logger.h"
 
 #include <QProcess>
-#include <QScopeGuard>
 #include <QTextStream>
 
 #include <windows.h>

--- a/src/platforms/windows/daemon/windowsdaemon.cpp
+++ b/src/platforms/windows/daemon/windowsdaemon.cpp
@@ -17,7 +17,6 @@
 #include <QJsonValue>
 #include <QLocalSocket>
 #include <QNetworkInterface>
-#include <QScopeGuard>
 #include <QTextStream>
 #include <QtGlobal>
 

--- a/src/platforms/windows/daemon/windowsroutemonitor.cpp
+++ b/src/platforms/windows/daemon/windowsroutemonitor.cpp
@@ -6,6 +6,8 @@
 #include "leakdetector.h"
 #include "logger.h"
 
+#include <QScopeGuard>
+
 namespace {
 Logger logger(LOG_WINDOWS, "WindowsRouteMonitor");
 };  // namespace
@@ -75,6 +77,7 @@ void WindowsRouteMonitor::updateValidInterfaces(int family) {
     logger.warning() << "Failed to retrive interface table." << result;
     return;
   }
+  auto guard = qScopeGuard([&] { FreeMibTable(table); });
 
   // Flush the list of interfaces that are valid for routing.
   if ((family == AF_INET) || (family == AF_UNSPEC)) {
@@ -103,8 +106,6 @@ void WindowsRouteMonitor::updateValidInterfaces(int family) {
       m_validInterfacesIpv6.append(row->InterfaceLuid.Value);
     }
   }
-
-  FreeMibTable(table);
 }
 
 void WindowsRouteMonitor::updateExclusionRoute(MIB_IPFORWARD_ROW2* data,

--- a/src/platforms/windows/daemon/windowsroutemonitor.cpp
+++ b/src/platforms/windows/daemon/windowsroutemonitor.cpp
@@ -68,6 +68,45 @@ WindowsRouteMonitor::~WindowsRouteMonitor() {
   logger.debug() << "WindowsRouteMonitor destroyed.";
 }
 
+void WindowsRouteMonitor::updateValidInterfaces(int family) {
+  PMIB_IPINTERFACE_TABLE table;
+  DWORD result = GetIpInterfaceTable(family, &table);
+  if (result != NO_ERROR) {
+    logger.warning() << "Failed to retrive interface table." << result;
+    return;
+  }
+
+  // Flush the list of interfaces that are valid for routing.
+  if ((family == AF_INET) || (family == AF_UNSPEC)) {
+    m_validInterfacesIpv4.clear();
+  }
+  if ((family == AF_INET6) || (family == AF_UNSPEC)) {
+    m_validInterfacesIpv6.clear();
+  }
+
+  // Rebuild the list of interfaces that are valid for routing.
+  for (ULONG i = 0; i < table->NumEntries; i++) {
+    MIB_IPINTERFACE_ROW* row = &table->Table[i];
+    if (row->InterfaceLuid.Value == m_luid) {
+      continue;
+    }
+    if (!row->Connected) {
+      continue;
+    }
+
+    if (row->Family == AF_INET) {
+      logger.debug() << "Interface" << row->InterfaceIndex << "is valid for IPv4 routing";
+      m_validInterfacesIpv4.append(row->InterfaceLuid.Value);
+    }
+    if (row->Family == AF_INET6) {
+      logger.debug() << "Interface" << row->InterfaceIndex << "is valid for IPv6 routing";
+      m_validInterfacesIpv6.append(row->InterfaceLuid.Value);
+    }
+  }
+
+  FreeMibTable(table);
+}
+
 void WindowsRouteMonitor::updateExclusionRoute(MIB_IPFORWARD_ROW2* data,
                                                void* ptable) {
   PMIB_IPFORWARD_TABLE2 table = reinterpret_cast<PMIB_IPFORWARD_TABLE2>(ptable);
@@ -97,6 +136,9 @@ void WindowsRouteMonitor::updateExclusionRoute(MIB_IPFORWARD_ROW2* data,
       if (row->DestinationPrefix.Prefix.Ipv6.sin6_family != AF_INET6) {
         continue;
       }
+      if (!m_validInterfacesIpv6.contains(row->InterfaceLuid.Value)) {
+        continue;
+      }
       if (prefixcmp(&data->DestinationPrefix.Prefix.Ipv6.sin6_addr,
                     &row->DestinationPrefix.Prefix.Ipv6.sin6_addr,
                     row->DestinationPrefix.PrefixLength) != 0) {
@@ -106,6 +148,9 @@ void WindowsRouteMonitor::updateExclusionRoute(MIB_IPFORWARD_ROW2* data,
       if (row->DestinationPrefix.Prefix.Ipv4.sin_family != AF_INET) {
         continue;
       }
+      if (!m_validInterfacesIpv4.contains(row->InterfaceLuid.Value)) {
+        continue;
+      }
       if (prefixcmp(&data->DestinationPrefix.Prefix.Ipv4.sin_addr,
                     &row->DestinationPrefix.Prefix.Ipv4.sin_addr,
                     row->DestinationPrefix.PrefixLength) != 0) {
@@ -113,16 +158,6 @@ void WindowsRouteMonitor::updateExclusionRoute(MIB_IPFORWARD_ROW2* data,
       }
     } else {
       // Unsupported destination address family.
-      continue;
-    }
-
-    // Ensure that the outgoing network interface is actually online and usable.
-    DWORD result;
-    NL_NETWORK_CONNECTIVITY_HINT hint;
-    result = GetNetworkConnectivityHintForInterface(row->InterfaceIndex, &hint);
-    if ((result != NO_ERROR) ||
-        (hint.ConnectivityLevel == NetworkConnectivityLevelHintHidden)) {
-      logger.debug() << "Ignoring hidden ifindex:" << row->InterfaceIndex;
       continue;
     }
 
@@ -215,6 +250,7 @@ bool WindowsRouteMonitor::addExclusionRoute(const QHostAddress& address) {
     delete data;
     return false;
   }
+  updateValidInterfaces(family);
   updateExclusionRoute(data, table);
   FreeMibTable(table);
 
@@ -268,6 +304,7 @@ void WindowsRouteMonitor::routeChanged() {
     return;
   }
 
+  updateValidInterfaces(AF_UNSPEC);
   for (MIB_IPFORWARD_ROW2* data : m_exclusionRoutes) {
     updateExclusionRoute(data, table);
   }

--- a/src/platforms/windows/daemon/windowsroutemonitor.cpp
+++ b/src/platforms/windows/daemon/windowsroutemonitor.cpp
@@ -98,11 +98,13 @@ void WindowsRouteMonitor::updateValidInterfaces(int family) {
     }
 
     if (row->Family == AF_INET) {
-      logger.debug() << "Interface" << row->InterfaceIndex << "is valid for IPv4 routing";
+      logger.debug() << "Interface" << row->InterfaceIndex
+                     << "is valid for IPv4 routing";
       m_validInterfacesIpv4.append(row->InterfaceLuid.Value);
     }
     if (row->Family == AF_INET6) {
-      logger.debug() << "Interface" << row->InterfaceIndex << "is valid for IPv6 routing";
+      logger.debug() << "Interface" << row->InterfaceIndex
+                     << "is valid for IPv6 routing";
       m_validInterfacesIpv6.append(row->InterfaceLuid.Value);
     }
   }

--- a/src/platforms/windows/daemon/windowsroutemonitor.h
+++ b/src/platforms/windows/daemon/windowsroutemonitor.h
@@ -33,8 +33,11 @@ class WindowsRouteMonitor final : public QObject {
 
  private:
   void updateExclusionRoute(MIB_IPFORWARD_ROW2* data, void* table);
+  void updateValidInterfaces(int family);
 
   QHash<QHostAddress, MIB_IPFORWARD_ROW2*> m_exclusionRoutes;
+  QList<quint64> m_validInterfacesIpv4;
+  QList<quint64> m_validInterfacesIpv6;
 
   quint64 m_luid = 0;
   HANDLE m_routeHandle = INVALID_HANDLE_VALUE;

--- a/src/platforms/windows/daemon/wireguardutilswindows.cpp
+++ b/src/platforms/windows/daemon/wireguardutilswindows.cpp
@@ -10,7 +10,6 @@
 #include "windowsfirewall.h"
 #include "wgquickprocess.h"
 
-#include <QScopeGuard>
 #include <QFileInfo>
 
 #include <winsock2.h>


### PR DESCRIPTION
## Description
In the 2.8.0 release train, we encountered an issue where the VPN client would fail to launch on Windows 10 versions 1909.00 and older due to a new dependency introduced on the `GetNetworkConnectivityHint` system call. Unfortunately this would mean dropping support for some LTSC versions of windows that may still be out in the wild.

This patch attempts to work around this system call by inspecting the IP interface table, using the `GetIpInterfaceTable` system call, which is supported from Windows Vista and onwards. This is also slightly more correct, and we now respect the routing policy if users opt to disable IPv6 on one or more interfaces.

## Reference

JIRA ticket [VPN-2135](https://mozilla-hub.atlassian.net/browse/VPN-2135)
Github issue #3394
Related issue #2693

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
