### PR TITLE
Upgrade Taskgraph to 1.5.0

### DIFF
--- a/taskcluster/requirements.txt
+++ b/taskcluster/requirements.txt
@@ -79,9 +79,9 @@ slugid==2.0.0 \
     --hash=sha256:a950d98b72691178bdd4d6c52743c4a2aa039207cf7a97d71060a111ff9ba297 \
     --hash=sha256:aec8b0e01c4ad32e38e12d609eab3ec912fd129aaf6b2ded0199b56a5f8fd67c
     # via taskcluster-taskgraph
-taskcluster-taskgraph==1.4.0 \
-    --hash=sha256:237ed0399ef55e9eef537e6163b456c04d58a7b72bc1b55e8c61a05331170b1e \
-    --hash=sha256:2be5ac94745180029dfad260486aafeb14f564f5a95d1d3269e0d17834273f11
+taskcluster-taskgraph==1.5.0 \
+    --hash=sha256:6fc66e13a8665006e6ad28057368dd837afd126c489355c00e21ec486b44ea94 \
+    --hash=sha256:e1d147d4581da3fc12907f9aa2e0f6b0feb24040e50434b1b4486ba6c7990a8b
     # via -r requirements.in
 taskcluster-urls==13.0.1 \
     --hash=sha256:5e25e7e6818e8877178b175ff43d2e6548afad72694aa125f404a7329ece0973 \


### PR DESCRIPTION
This includes a fix which should help fix the cleanup error in Windows
builds.
