### PR TITLE
Use hashIndex for Openssl

### DIFF
--- a/taskcluster/ci/build-openssl/kind.yml
+++ b/taskcluster/ci/build-openssl/kind.yml
@@ -8,6 +8,7 @@ kind-dependencies:
     - fetch
 
 transforms:
+    - mozillavpn_taskgraph.transforms.hashIndex:transforms
     - taskgraph.transforms.job:transforms
     - taskgraph.transforms.task:transforms
 

--- a/taskcluster/ci/build-openssl/windows.yml
+++ b/taskcluster/ci/build-openssl/windows.yml
@@ -18,10 +18,8 @@ windows:
         product: openssl
         job-name: openssl-windows
     optimization: 
-        index-search: 
-        # TODO: Question: should this maybe be a pushdate? 
-        # Otherwise we might build once and never again?
-            - mozillavpn.v2.mozilla-vpn-client.latest.openssl.openssl-windows
+        hashIndex: 
+            - taskcluster/scripts/build_openssl/compile_openssl.ps1
     run:
         using: run-task
         cwd: '{checkout}'


### PR DESCRIPTION
## Description
I kinda introduced a chicken and egg situation into our ci. 
Creating tasks with index-routes require level-3. Pr's are level-1 
When we now have a pr that invalidates our index-search (i.e a taskgraph update like #3421) - it thus creates a level-1 task that now has a route, which is rejected. 

The hashIndex transform solves this. It auto-removes routes on level-1 tasks. Also it will make sure we will re-compile openssl when the build script changes. We're using this for qt already.

## Reference

    i.e Jira or Github issue URL

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
