### PR TITLE
Ignore: Taskcluster cache experiment

### DIFF
--- a/taskcluster/ci/build-openssl/kind.yml
+++ b/taskcluster/ci/build-openssl/kind.yml
@@ -8,6 +8,7 @@ kind-dependencies:
     - fetch
 
 transforms:
+    - mozillavpn_taskgraph.transforms.hashIndex:transforms
     - taskgraph.transforms.job:transforms
     - taskgraph.transforms.task:transforms
 

--- a/taskcluster/ci/build-openssl/windows.yml
+++ b/taskcluster/ci/build-openssl/windows.yml
@@ -18,10 +18,8 @@ windows:
         product: openssl
         job-name: openssl-windows
     optimization: 
-        index-search: 
-        # TODO: Question: should this maybe be a pushdate? 
-        # Otherwise we might build once and never again?
-            - mozillavpn.v2.mozilla-vpn-client.latest.openssl.openssl-windows
+        hashIndex: 
+            - taskcluster/scripts/build_openssl/compile_openssl.ps1
     run:
         using: run-task
         cwd: '{checkout}'

--- a/taskcluster/ci/build/android.yml
+++ b/taskcluster/ci/build/android.yml
@@ -24,6 +24,9 @@ android-arm64/debug:
             platform: android/arm64-v8a
         worker:
             docker-image: {in-tree: android-build-arm64}
+            caches:
+                - name: "android-build-arm64"
+                  mount-point: "/builds/worker/.cache"
         run:
             command: ./taskcluster/scripts/build/android_build_debug.sh arm64-v8a
         release-artifacts:


### PR DESCRIPTION
- Use hashIndex for Openssl
- Can we cache the ccache folder on taskgraph?

## Description

    Describe your changes

## Reference

    i.e Jira or Github issue URL

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
