### PR TITLE
Expose the app-state via glean events

### DIFF
--- a/glean/metrics.yaml
+++ b/glean/metrics.yaml
@@ -831,3 +831,27 @@ sample:
       stddev:
         description: Standard deviation of the ping responses
         type: string
+
+  app_step:
+    type: event
+    lifetime: ping
+    send_in_pings:
+      - main
+    description: |
+      The application state flow (authenticating, subscribing, main, etc).
+    bugs:
+      - https://github.com/mozilla-mobile/mozilla-vpn-client/issues/3411
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1767028
+    data_sensitivity:
+      - technical
+    notification_emails:
+      - amarchesini@mozilla.com
+    expires: never
+    extra_keys:
+      state:
+        description: |
+          The name of the app state, e.g. "authenticating", "device-limit",
+          "main", "subscription-needed", etc. The list can be found in
+          `mozillavpn.h`.
+        type: string

--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -336,6 +336,9 @@ void MozillaVPN::setState(State state) {
   m_state = state;
   emit stateChanged();
 
+  emit MozillaVPN::instance()->recordGleanEventWithExtraKeys(
+      GleanSample::appStep, {{"state", QVariant::fromValue(state).toString()}});
+
   // If we are activating the app, let's initialize the controller.
   if (m_state == StateMain) {
     m_private->m_controller.initialize();


### PR DESCRIPTION
## Description

Expose the app state via glean events.

## Reference

https://github.com/mozilla-mobile/mozilla-vpn-client/issues/3411