### PR TITLE
Try enforcing concurrency limits to abort stale CI runs

### DIFF
--- a/.github/workflows/android_qt6.yaml
+++ b/.github/workflows/android_qt6.yaml
@@ -9,6 +9,9 @@ on:
       - main
       - 'releases/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   compile-android-qt6:

--- a/.github/workflows/functional_tests.yaml
+++ b/.github/workflows/functional_tests.yaml
@@ -9,6 +9,11 @@ on:
       - main
       - 'releases/**'
 
+# Restrict tests to the most recent commit.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build_test_app:
     name: Build Test Client

--- a/.github/workflows/ios-build.yaml
+++ b/.github/workflows/ios-build.yaml
@@ -14,6 +14,10 @@ on:
       - main
       - 'releases/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   macos:
     name: iOS build

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -6,6 +6,7 @@ on:
       - main
       - 'releases/**'
     types: [ opened, synchronize, reopened ]
+
 jobs:
   linter:
     runs-on: ubuntu-20.04

--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -9,6 +9,10 @@ on:
       - main
       - 'releases/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   source-bundle:
     name: Source Bundle

--- a/.github/workflows/macos-build.yaml
+++ b/.github/workflows/macos-build.yaml
@@ -10,6 +10,10 @@ on:
       - main
       - 'releases/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   macos:
     name: MacOS packages

--- a/.github/workflows/screencapture.yaml
+++ b/.github/workflows/screencapture.yaml
@@ -9,6 +9,10 @@ on:
       - main
       - 'releases/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   screencapture:
     name: Screencapture

--- a/.github/workflows/test_lottie.yaml
+++ b/.github/workflows/test_lottie.yaml
@@ -9,6 +9,10 @@ on:
       - main
       - 'releases/**'
 
+# Restrict tests to the most recent commit.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   linux-lottie-tests:

--- a/.github/workflows/test_qml.yaml
+++ b/.github/workflows/test_qml.yaml
@@ -9,6 +9,11 @@ on:
       - main
       - 'releases/**'
 
+# Restrict tests to the most recent commit.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   linux-qml-tests:
     runs-on: ubuntu-20.04

--- a/.github/workflows/test_unit.yaml
+++ b/.github/workflows/test_unit.yaml
@@ -9,6 +9,10 @@ on:
       - main
       - 'releases/**'
 
+# Restrict tests to the most recent commit.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   linux-unit-tests:

--- a/.github/workflows/wasm.yaml
+++ b/.github/workflows/wasm.yaml
@@ -10,6 +10,10 @@ on:
       - main
       - 'releases/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   wasmQt6:
     name: Wasm Qt6

--- a/.github/workflows/windows-build.yaml
+++ b/.github/workflows/windows-build.yaml
@@ -10,6 +10,10 @@ on:
       - main
       - 'releases/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   windows:
     name: Windows build

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ security, we will always put your privacy first._
 
 See: https://vpn.mozilla.org
 
+This is a test to trigger github concurrency!
+
 ## Getting Involved
 
 We encourage you to participate in this open source project. We love Pull

--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@ security, we will always put your privacy first._
 
 See: https://vpn.mozilla.org
 
-This is a test to trigger github concurrency!
-
 ## Getting Involved
 
 We encourage you to participate in this open source project. We love Pull


### PR DESCRIPTION
## Description
I have noticed that I have often created dumb bugs that cause a CI run to fail, and therefore require an extra commit to fix. However, doing so causes us to waste a bunch of compute time running the extra workflows for the old and stale commit. Fortunately, github has a [concurrency](https://docs.github.com/en/actions/using-jobs/using-concurrency) directive that can abort these stale jobs for us.

I am particularly worried that my sloppy code may be causing us to run afoul of an execution cap, and leading to a lot of queued jobs blocking important work.

## Reference
None!

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
