### PR TITLE
Fix German Free Trial layout

### DIFF
--- a/nebula/ui/components/VPNSubscriptionOption.qml
+++ b/nebula/ui/components/VPNSubscriptionOption.qml
@@ -21,7 +21,7 @@ RadioDelegate {
     ButtonGroup.group: subscriptionOptions
 
     Layout.fillWidth: true
-    Layout.preferredHeight: chipFreeTrial.visible ? 96+headLineLabel.overflow : 96
+    Layout.preferredHeight: Math.max(96, row.implicitHeight + row.anchors.topMargin + row.anchors.bottomMargin)
 
     background: Rectangle {
         id: bg
@@ -141,7 +141,6 @@ RadioDelegate {
 
             VPNBoldLabel {
                 id: headLineLabel
-                property var overflow: headLineLabel.height - headLineLabel.lineHeight
                 font.pixelSize: 16
                 lineHeight: VPNTheme.theme.labelLineHeight + 2
                 lineHeightMode: Text.FixedHeight

--- a/nebula/ui/components/VPNSubscriptionOption.qml
+++ b/nebula/ui/components/VPNSubscriptionOption.qml
@@ -23,7 +23,6 @@ RadioDelegate {
     Layout.fillWidth: true
     Layout.preferredHeight: Math.max(96, row.implicitHeight + row.anchors.topMargin + row.anchors.bottomMargin)
 
-
     background: Rectangle {
         id: bg
         color: VPNTheme.theme.white

--- a/nebula/ui/components/VPNSubscriptionOption.qml
+++ b/nebula/ui/components/VPNSubscriptionOption.qml
@@ -21,7 +21,7 @@ RadioDelegate {
     ButtonGroup.group: subscriptionOptions
 
     Layout.fillWidth: true
-    Layout.preferredHeight: 96
+    Layout.preferredHeight: chipFreeTrial.visible ? 96+headLineLabel.overflow : 96
 
     background: Rectangle {
         id: bg
@@ -140,6 +140,8 @@ RadioDelegate {
             Layout.fillHeight: true
 
             VPNBoldLabel {
+                id: headLineLabel
+                property var overflow: headLineLabel.height - headLineLabel.lineHeight
                 font.pixelSize: 16
                 lineHeight: VPNTheme.theme.labelLineHeight + 2
                 lineHeightMode: Text.FixedHeight

--- a/nebula/ui/components/VPNSubscriptionOption.qml
+++ b/nebula/ui/components/VPNSubscriptionOption.qml
@@ -23,6 +23,7 @@ RadioDelegate {
     Layout.fillWidth: true
     Layout.preferredHeight: Math.max(96, row.implicitHeight + row.anchors.topMargin + row.anchors.bottomMargin)
 
+
     background: Rectangle {
         id: bg
         color: VPNTheme.theme.white


### PR DESCRIPTION
## Description

Currently, the free trial chip is cut off in German, so let's take the Headline-Overflow into account when calculating the box size
Before German:

| Live(German) | Fixed (German) | Fix applied  (English) |
| ------------- | ------------- | -----|
| ![Screenshot_20220505-151213(1)](https://user-images.githubusercontent.com/9611612/166940000-68de56df-37ac-4990-bbf0-d38a165178d7.png) | ![Screenshot_20220505-155911](https://user-images.githubusercontent.com/9611612/166940451-637f5bb7-cbb6-41d7-9681-48159dafaa2e.png) | ![Screenshot_20220505-155943](https://user-images.githubusercontent.com/9611612/166940512-6631c7ba-d644-48c6-a2ed-096c8fec1e5f.png) |

Don't mind the sorting, that is from my other pr.
