### PR TITLE
ci(taskcluster): make sure Android build failures turn the task red (…

### DIFF
--- a/taskcluster/scripts/build/android_build_debug.sh
+++ b/taskcluster/scripts/build/android_build_debug.sh
@@ -2,6 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+set -e
 
 # This script is used in the Android Debug (universal) build task
 git submodule init

--- a/taskcluster/scripts/build/android_build_release.sh
+++ b/taskcluster/scripts/build/android_build_release.sh
@@ -2,6 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+set -e
 
 # This script is used in the Android Build Release (universal) build task
 git submodule init

--- a/taskcluster/scripts/build/linux.sh
+++ b/taskcluster/scripts/build/linux.sh
@@ -4,6 +4,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+set -e
 bash scripts/linux/script.sh --source
 
 cd .tmp

--- a/taskcluster/scripts/build/macos_build.sh
+++ b/taskcluster/scripts/build/macos_build.sh
@@ -4,6 +4,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+set -e
+
 . $(dirname $0)/../../../scripts/utils/commons.sh
 
 print N "Taskcluster macOS compilation script"

--- a/taskcluster/scripts/build/wasm.sh
+++ b/taskcluster/scripts/build/wasm.sh
@@ -13,7 +13,7 @@ ls /opt/emsdk/emsdk
 ls /opt/6.2.3/wasm_32/bin
 ls /opt/6.2.3/gcc_64/bin
 
-where qmake 
+which qmake 
 qmake --version
 
 # This script is used in the Android Debug (universal) build task

--- a/taskcluster/scripts/build/wasm.sh
+++ b/taskcluster/scripts/build/wasm.sh
@@ -2,6 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+set -e
 
 source /opt/emsdk/emsdk_env.sh
 


### PR DESCRIPTION
…#3413)

We noticed that sometimes the Android builds fail but the task is still
green. Partly this is taskcluster/taskcluster#4590 as the task should
fail if one of its declared artifacts doesn't exist.

But partly the build script itself should fail the task if one of its
commands returns non-zero. This PR fixes that by enabling `set -e` in
all the build scripts.