### PR TITLE
Also check for x64 arch on non-prod .msi

### DIFF
--- a/windows/installer/MozillaVPN.wxs
+++ b/windows/installer/MozillaVPN.wxs
@@ -18,6 +18,10 @@
     Version="!(bind.FileVersion.MozillaVPNExecutable)"
     Manufacturer="Mozilla Corporation"
     UpgradeCode="$(var.UpgradeCode)">
+    <Condition Message="This application is only supported on 64 bit x86 platforms."> %PROCESSOR_ARCHITECTURE="AMD64" </Condition>
+    <Condition Message="This application is only supported on Windows 10 or higher.">
+      <![CDATA[Installed OR (VersionNT >= 603)]]>
+    </Condition>
     <Package
       InstallerVersion="400"
       Compressed="yes"

--- a/windows/installer/MozillaVPN.wxs
+++ b/windows/installer/MozillaVPN.wxs
@@ -18,16 +18,16 @@
     Version="!(bind.FileVersion.MozillaVPNExecutable)"
     Manufacturer="Mozilla Corporation"
     UpgradeCode="$(var.UpgradeCode)">
-    <Condition Message="This application is only supported on 64 bit x86 platforms."> %PROCESSOR_ARCHITECTURE="AMD64" </Condition>
-    <Condition Message="This application is only supported on Windows 10 or higher.">
-      <![CDATA[Installed OR (VersionNT >= 603)]]>
-    </Condition>
     <Package
       InstallerVersion="400"
       Compressed="yes"
       InstallScope="perMachine"
       Description="Mozilla VPN"
       ReadOnly="yes" />
+    <Condition Message="This application is only supported on Windows 10 or higher.">
+      <![CDATA[Installed OR (VersionNT >= 603)]]>
+    </Condition>
+    <Condition Message="This application is only supported on 64 bit x86 platforms."> %PROCESSOR_ARCHITECTURE="AMD64" </Condition>
 
     <Upgrade Id="$(var.UpgradeCode)">
       <UpgradeVersion OnlyDetect='no' Property='PREVIOUSFOUND'


### PR DESCRIPTION
## Description

In - https://github.com/mozilla-mobile/mozilla-vpn-client/pull/3236 We changed that the prod installer can only run on x64, we should do that on non prod (like taskcluster) installers aswell.

## Reference

    i.e Jira or Github issue URL

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
