### PR TITLE
Remove the 'aia' params in the client user-agent - PSP-393

### DIFF
--- a/src/networkmanager.cpp
+++ b/src/networkmanager.cpp
@@ -73,10 +73,6 @@ QByteArray NetworkManager::userAgent() {
       flags.append("iap:true");
     }
 
-    if (FeatureInAppAuth::instance()->isSupported()) {
-      flags.append("aia:true");
-    }
-
 #ifdef MVPN_EXTRA_USERAGENT
     flags.append(MVPN_EXTRA_USERAGENT);
 #endif


### PR DESCRIPTION
## Description

Remove the 'aia' params in the client user-agent

## Reference

PSP-393