### PR TITLE
Android: Fix Random Service starts in the client

### DIFF
--- a/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/VPNService.kt
+++ b/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/VPNService.kt
@@ -67,7 +67,11 @@ class VPNService : android.net.VpnService() {
         intent?.let {
             if (intent.getBooleanExtra("startOnly", false)) {
                 Log.i(tag, "Start only!")
-                return super.onStartCommand(intent, flags, startId)
+                // If this is a Start Only request, the client will soon 
+                // bind to the service anyway. 
+                // We should return START_NOT_STICKY so that after an unbind()
+                // the OS will not try to restart the service.
+                return START_NOT_STICKY
             }
         }
         // This start is from always-on


### PR DESCRIPTION
## Description

The Default value here is "START_STICKY" - So if the OS stops the service not because of the unbind, Android will re-deliver the intent but without the extra "start-only". 
We handle a start without extras as if the os requests-always on, thus enabling the vpn. 

Start_NOT_STICKY means here that once the service is stopped by the os, we won't get a new intent to restart. 

## Reference
closes https://github.com/mozilla-mobile/mozilla-vpn-client/issues/3179
