### PR TITLE
ci(signing): switch Android builds back to an AWS pool

### DIFF
--- a/taskcluster/ci/config.yml
+++ b/taskcluster/ci/config.yml
@@ -41,7 +41,7 @@ workers:
             provisioner: 'mozillavpn-{level}'
             implementation: docker-worker
             os: linux
-            worker-type: b-linux-large-gcp
+            worker-type: b-linux-large
         b-win2012:
             provisioner: 'mozillavpn-{level}'
             implementation: generic-worker


### PR DESCRIPTION
## Description

The GCP build images we were using have an outdated Chain of Trust key
baked in and will need to be re-built with the new ones.

This means we can't use these images for any release builds as they'll
fail the CoT verification when the signing tasks run.

For now let's just switch back to an AWS pool.

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
