### PR TITLE
VPN-2260 - Create resilient connection with Guardian Websocket

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,8 +277,8 @@ scripts/wasm/compile.sh
 ## Testing
 
 * Run the unit tests with `./scripts/tests/unit_tests.sh`
-* Run the qml tests with `./tests/tests/qml_tests.sh`
-* Run the lottie tests with `./tests/tests/lottie_tests.sh`
+* Run the qml tests with `./scripts/tests/qml_tests.sh`
+* Run the lottie tests with `./scripts/tests/lottie_tests.sh`
 * Run the funcional tests (See below)
 
 ### Running the functional tests

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,7 +13,7 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR}/hacl-star/kremlin)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/hacl-star/kremlin/minimal)
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
-find_package(Qt6 REQUIRED COMPONENTS Widgets Gui Test)
+find_package(Qt6 REQUIRED COMPONENTS Widgets Gui Test WebSockets)
 find_package(Qt6 REQUIRED COMPONENTS Qml Quick)
 find_package(Qt6 REQUIRED COMPONENTS NetworkAuth)
 find_package(Qt6 REQUIRED COMPONENTS WebSockets)

--- a/src/cmake/sources.cmake
+++ b/src/cmake/sources.cmake
@@ -298,6 +298,8 @@ target_sources(mozillavpn PRIVATE
     update/versionapi.h
     urlopener.cpp
     urlopener.h
+    websockethandler.cpp
+    websockethandler.h
 )
 
 # VPN Client UI resources

--- a/src/crashreporter/CMakeLists.txt
+++ b/src/crashreporter/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 add_library(crashreporter STATIC)
 
-find_package(Qt6 REQUIRED COMPONENTS Core Gui Widgets)
+find_package(Qt6 REQUIRED COMPONENTS Core Gui Widgets WebSockets)
 find_package(Qt6 REQUIRED COMPONENTS Qml Quick)
 target_include_directories(crashreporter PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 

--- a/src/crashreporter/CMakeLists.txt
+++ b/src/crashreporter/CMakeLists.txt
@@ -11,6 +11,7 @@ target_include_directories(crashreporter PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(crashreporter PRIVATE
     Qt6::Core
     Qt6::Gui
+    Qt6::WebSockets
     Qt6::Widgets
     Qt6::Qml
     Qt6::Quick

--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -42,6 +42,7 @@
 #include "taskscheduler.h"
 #include "update/versionapi.h"
 #include "urlopener.h"
+#include "websockethandler.h"
 
 #ifdef MVPN_IOS
 #  include "platforms/ios/iosdatamigration.h"
@@ -192,6 +193,8 @@ MozillaVPN::~MozillaVPN() {
 
 MozillaVPN::State MozillaVPN::state() const { return m_state; }
 
+MozillaVPN::UserState MozillaVPN::userState() const { return m_userState; }
+
 bool MozillaVPN::stagingMode() const { return !Constants::inProduction(); }
 
 bool MozillaVPN::debugMode() const {
@@ -218,6 +221,8 @@ void MozillaVPN::initialize() {
   m_private->m_connectionBenchmark.initialize();
 
   m_private->m_ipAddressLookup.initialize();
+
+  m_private->m_webSocketHandler.initialize();
 
   TaskScheduler::scheduleTask(new TaskGetFeatureList());
 

--- a/src/mozillavpn.h
+++ b/src/mozillavpn.h
@@ -30,6 +30,7 @@
 #include "statusicon.h"
 #include "telemetry.h"
 #include "theme.h"
+#include "websockethandler.h"
 
 #include <QList>
 #include <QNetworkReply>
@@ -291,7 +292,7 @@ class MozillaVPN final : public QObject {
 
   void setUpdateRecommended(bool value);
 
-  UserState userState() const { return m_userState; }
+  UserState userState() const;
 
   bool startMinimized() const { return m_startMinimized; }
 
@@ -447,6 +448,7 @@ class MozillaVPN final : public QObject {
     SurveyModel m_surveyModel;
     Telemetry m_telemetry;
     Theme m_theme;
+    WebSocketHandler m_webSocketHandler;
     WhatsNewModel m_whatsNewModel;
     User m_user;
   };

--- a/src/qmake/sources.pri
+++ b/src/qmake/sources.pri
@@ -138,7 +138,8 @@ SOURCES += \
         timersingleshot.cpp \
         update/updater.cpp \
         update/versionapi.cpp \
-        urlopener.cpp
+        urlopener.cpp \
+        websockethandler.cpp
 
 HEADERS += \
         appimageprovider.h \
@@ -294,7 +295,8 @@ HEADERS += \
         timersingleshot.h \
         update/updater.h \
         update/versionapi.h \
-        urlopener.h
+        urlopener.h \
+        websockethandler.h
 
 # Signal handling for unix platforms
 unix {

--- a/src/websockethandler.cpp
+++ b/src/websockethandler.cpp
@@ -38,7 +38,7 @@ QString WebSocketHandler::s_customWebSocketServerUrl = "";
 
 // static
 QString WebSocketHandler::webSocketServerUrl() {
-  if (s_customWebSocketServerUrl.isEmpty()) {
+  if (!s_customWebSocketServerUrl.isEmpty()) {
     return s_customWebSocketServerUrl;
   }
 

--- a/src/websockethandler.cpp
+++ b/src/websockethandler.cpp
@@ -1,0 +1,222 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "websockethandler.h"
+#include "constants.h"
+#include "leakdetector.h"
+#include "logger.h"
+#include "mozillavpn.h"
+#include "networkrequest.h"
+#include "settingsholder.h"
+#include "urlopener.h"
+
+namespace {
+Logger logger(LOG_MAIN, "WebSocketHandler");
+}  // namespace
+
+WebSocketHandler::WebSocketHandler() {
+  MVPN_COUNT_CTOR(WebSocketHandler)
+
+  connect(&m_webSocket, &QWebSocket::connected, this,
+          &WebSocketHandler::onConnected);
+  connect(&m_webSocket, &QWebSocket::disconnected, this,
+          &WebSocketHandler::onClose);
+  connect(&m_webSocket,
+          QOverload<QAbstractSocket::SocketError>::of(&QWebSocket::error), this,
+          &WebSocketHandler::onError);
+  connect(&m_webSocket, &QWebSocket::pong, this, &WebSocketHandler::onPong);
+
+  connect(&m_pingTimer, &QTimer::timeout, this,
+          &WebSocketHandler::onPingTimeout);
+}
+
+// static
+QString WebSocketHandler::webSocketServerUrl() {
+  QString httpServerUrl;
+  if (Constants::inProduction()) {
+    httpServerUrl = Constants::API_PRODUCTION_URL;
+  } else {
+    httpServerUrl = Constants::getStagingServerAddress();
+  }
+
+  return httpServerUrl.toLower().replace("http", "ws");
+}
+
+// static
+bool WebSocketHandler::isUserAuthenticated() {
+  MozillaVPN* vpn = MozillaVPN::instance();
+  Q_ASSERT(vpn);
+
+  return vpn->userState() == MozillaVPN::UserAuthenticated;
+}
+
+void WebSocketHandler::initialize() {
+  logger.debug() << "Initialize";
+
+  MozillaVPN* vpn = MozillaVPN::instance();
+  Q_ASSERT(vpn);
+
+  connect(vpn, &MozillaVPN::userStateChanged, this,
+          &WebSocketHandler::onUserStateChanged);
+}
+
+/**
+ * @brief Acknowledges the user state has changed.
+ *
+ * When the user has authenticated, a WebSocket connection is openened.
+ * Otherwise it's closed.
+ *
+ * The Guardian WebSocket does not accept unauthenticated users. Attempting to
+ * connect while unauthenticated would result is an infinite retry loop.
+ */
+void WebSocketHandler::onUserStateChanged() {
+  logger.debug() << "User state change detected:"
+                 << MozillaVPN::instance()->userState();
+
+  if (WebSocketHandler::isUserAuthenticated()) {
+    open();
+  } else {
+    close();
+  }
+}
+
+/**
+ * @brief Opens the websocket connection.
+ *
+ * No-op in case the connection is already open.
+ */
+void WebSocketHandler::open() {
+  if (m_webSocket.state() != QAbstractSocket::UnconnectedState &&
+      m_webSocket.state() != QAbstractSocket::ClosingState) {
+    logger.debug()
+        << "Attempted to open a WebSocket connection, but it's already open.";
+    return;
+  }
+
+  logger.debug() << "Attempting to open WebSocket connection."
+                 << WebSocketHandler::webSocketServerUrl();
+
+  QNetworkRequest request;
+  request.setRawHeader("Authorization",
+                       SettingsHolder::instance()->token().toLocal8Bit());
+  request.setUrl(QUrl(WebSocketHandler::webSocketServerUrl()));
+  m_webSocket.open(request);
+}
+
+/**
+ * @brief Ackowledges the WebSocket has been succesfully connected.
+ */
+void WebSocketHandler::onConnected() {
+  logger.debug() << "WebSocket connected";
+
+  connect(&m_webSocket, &QWebSocket::textMessageReceived, this,
+          &WebSocketHandler::onMessageReceived);
+
+  sendPing();
+}
+
+/**
+ * @brief Closes the websocket connection.
+ *
+ * No-op in case the connection is already closed.
+ */
+void WebSocketHandler::close() {
+  if (m_webSocket.state() == QAbstractSocket::UnconnectedState ||
+      m_webSocket.state() == QAbstractSocket::ClosingState) {
+    logger.debug()
+        << "Attempted to close a WebSocket, but it's already closed.";
+    return;
+  }
+
+  logger.debug() << "Closing WebSocket";
+  m_webSocket.close();
+}
+
+/**
+ * @brief Ackowledges the WebSocket has been closed.
+ *
+ * May trigger a reconnection attempt depending on whether the user is
+ * authenticated.
+ */
+void WebSocketHandler::onClose() {
+  logger.debug() << "WebSocket closed";
+
+  if (WebSocketHandler::isUserAuthenticated()) {
+    logger.debug()
+        << "User is authenticated. Attempting to reopen WebSocket in:"
+        << WEBSOCKET_RETRY_INTERVAL;
+
+    QTimer::singleShot(WEBSOCKET_RETRY_INTERVAL, this, &WebSocketHandler::open);
+  } else {
+    logger.debug()
+        << "User is not authenticated. Will not attempt to reopen WebSocket.";
+  }
+}
+
+/**
+ * @brief Sends a ping to the WebSocket server.
+ *
+ * WebSocket connections may silently be broken. Periodically pinging the server
+ * keeps track of the connection. Everytime a new ping is sent, a timer is
+ * started. If a response is received before the timer is up, the connection is
+ * alive and a new ping is scheduled. Otherwise the WebSocket is closed a a
+ * reconnection attempt is scheduled.
+ */
+void WebSocketHandler::sendPing() {
+  m_webSocket.ping();
+
+  m_pingTimer.setSingleShot(true);
+  m_pingTimer.start(WEBSOCKET_PING_INTERVAL);
+}
+
+/**
+ * @brief Acknowledges a pong response from the WebSocket server. Schedules the
+ * next ping.
+ *
+ * @param elapsedTime How long it took to get the response since a ping was sent
+ * out.
+ */
+void WebSocketHandler::onPong(quint64 elapsedTime) {
+  qDebug() << "PONG PONG PONG";
+
+  logger.debug() << "WebSocket pong" << elapsedTime;
+
+  m_pingTimer.stop();
+  QTimer::singleShot(WEBSOCKET_PING_INTERVAL, this,
+                     &WebSocketHandler::sendPing);
+}
+
+/**
+ * @brief Handles the timeout of the ping timer.
+ *
+ * Reaching this timeout means connection with the server was silently broken
+ * e.g. due to the network being disconnected. The connection will be explicitly
+ * closed and a reconnection attempt scheduled.
+ */
+void WebSocketHandler::onPingTimeout() {
+  logger.debug() << "Timed out waiting for ping response";
+  close();
+}
+
+/**
+ * @brief Ackowledges there was a WebSocket error.
+ *
+ * Closes the websocket, is the user is authenticated a new connection attempt
+ * will be triggered after WEBSOCKET_RETRY_INTERVAL.
+ */
+void WebSocketHandler::onError(QAbstractSocket::SocketError error) {
+  logger.debug() << "WebSocket error:" << error;
+  close();
+}
+
+/**
+ * @brief Acknowledges a message was received from the WebSocket server.
+ *
+ * Each message will trigger a different task on the VPN client.
+ */
+void WebSocketHandler::onMessageReceived(const QString& message) {
+  logger.debug() << "Message received:" << message;
+
+  // TODO: DO SOMETHING WITH THE MESSAGE.
+}

--- a/src/websockethandler.cpp
+++ b/src/websockethandler.cpp
@@ -16,7 +16,7 @@ Logger logger(LOG_MAIN, "WebSocketHandler");
 }  // namespace
 
 WebSocketHandler::WebSocketHandler() {
-  MVPN_COUNT_CTOR(WebSocketHandler)
+  MVPN_COUNT_CTOR(WebSocketHandler);
 
   connect(&m_webSocket, &QWebSocket::connected, this,
           &WebSocketHandler::onConnected);

--- a/src/websockethandler.h
+++ b/src/websockethandler.h
@@ -17,6 +17,11 @@ class WebSocketHandler final : public QObject {
   WebSocketHandler();
   void initialize();
 
+  // These functions are here for testing purposes.
+  static void testOverrideWebSocketServerUrl(QString url);
+  void testOverridePingInterval(int newInterval);
+  void testOverrideRetryInterval(int newInterval);
+
  signals:
   void closed();
 
@@ -39,6 +44,9 @@ class WebSocketHandler final : public QObject {
   QWebSocket m_webSocket;
   QUrl m_url;
   QTimer m_pingTimer;
+
+  int m_pingInterval = WEBSOCKET_PING_INTERVAL;
+  int m_retryInterval = WEBSOCKET_RETRY_INTERVAL;
 
   static QString m_customWebSocketServerUrl;
 };

--- a/src/websockethandler.h
+++ b/src/websockethandler.h
@@ -1,0 +1,46 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef WEBSOCKETHANDLER_H
+#define WEBSOCKETHANDLER_H
+
+#include <QWebSocket>
+#include <QTimer>
+
+constexpr const int WEBSOCKET_PING_INTERVAL = 30 * 1000;   // 30s
+constexpr const int WEBSOCKET_RETRY_INTERVAL = 30 * 1000;  // 30s
+
+class WebSocketHandler final : public QObject {
+  Q_OBJECT
+ public:
+  WebSocketHandler();
+  void initialize();
+
+ signals:
+  void closed();
+
+ private:
+  void open();
+  void close();
+  void sendPing();
+  static QString webSocketServerUrl();
+  static bool isUserAuthenticated();
+
+  void onUserStateChanged();
+  void onConnected();
+  void onClose();
+  void onMessageReceived(const QString& message);
+  void onError(QAbstractSocket::SocketError error);
+  void onPong(quint64 elapsedTime);
+  void onPingTimeout();
+
+ private:
+  QWebSocket m_webSocket;
+  QUrl m_url;
+  QTimer m_pingTimer;
+
+  static QString m_customWebSocketServerUrl;
+};
+
+#endif  // WEBSOCKETHANDLER_H

--- a/src/websockethandler.h
+++ b/src/websockethandler.h
@@ -17,10 +17,11 @@ class WebSocketHandler final : public QObject {
   WebSocketHandler();
   void initialize();
 
-  // These functions are here for testing purposes.
-  static void testOverrideWebSocketServerUrl(QString url);
+#ifdef UNIT_TEST
+  static void testOverrideWebSocketServerUrl(const QString& url);
   void testOverridePingInterval(int newInterval);
   void testOverrideRetryInterval(int newInterval);
+#endif
 
  signals:
   void closed();
@@ -48,7 +49,7 @@ class WebSocketHandler final : public QObject {
   int m_pingInterval = WEBSOCKET_PING_INTERVAL;
   int m_retryInterval = WEBSOCKET_RETRY_INTERVAL;
 
-  static QString m_customWebSocketServerUrl;
+  static QString s_customWebSocketServerUrl;
 };
 
 #endif  // WEBSOCKETHANDLER_H

--- a/tests/auth/CMakeLists.txt
+++ b/tests/auth/CMakeLists.txt
@@ -28,6 +28,7 @@ target_link_libraries(auth_tests PRIVATE
     Qt6::Network
     Qt6::NetworkAuth
     Qt6::Gui
+    Qt6::WebSockets
     Qt6::Widgets
     Qt6::Qml
     Qt6::Quick

--- a/tests/auth/CMakeLists.txt
+++ b/tests/auth/CMakeLists.txt
@@ -6,7 +6,7 @@ add_definitions(-DUNIT_TEST)
 add_definitions(-DMVPN_DEBUG)
 add_definitions(-DMVPN_DUMMY)
 
-find_package(Qt6 REQUIRED COMPONENTS Core Test)
+find_package(Qt6 REQUIRED COMPONENTS Core Test WebSockets)
 find_package(Qt6 REQUIRED COMPONENTS Network NetworkAuth)
 find_package(Qt6 REQUIRED COMPONENTS Gui Widgets)
 find_package(Qt6 REQUIRED COMPONENTS Qml Quick)

--- a/tests/auth/auth.pro
+++ b/tests/auth/auth.pro
@@ -7,6 +7,7 @@ QT += network
 QT += networkauth
 QT += qml
 QT += widgets
+QT += websockets
 
 CONFIG += c++1z
 

--- a/tests/auth/mocmozillavpn.cpp
+++ b/tests/auth/mocmozillavpn.cpp
@@ -24,6 +24,10 @@ MozillaVPN::MozillaVPN() {}
 MozillaVPN::~MozillaVPN() {}
 
 MozillaVPN::State MozillaVPN::state() const { return StateInitialize; }
+MozillaVPN::UserState MozillaVPN::userState() const {
+  return UserNotAuthenticated;
+}
+
 bool MozillaVPN::stagingMode() const { return true; }
 bool MozillaVPN::debugMode() const { return true; }
 

--- a/tests/qml/CMakeLists.txt
+++ b/tests/qml/CMakeLists.txt
@@ -20,6 +20,7 @@ add_dependencies(build_tests qml_tests)
 
 target_link_libraries(qml_tests PRIVATE
     Qt6::Gui
+    Qt6::WebSockets
     Qt6::Widgets
     Qt6::Qml
     Qt6::Quick

--- a/tests/qml/CMakeLists.txt
+++ b/tests/qml/CMakeLists.txt
@@ -6,7 +6,7 @@ add_definitions(-DQUICK_TEST_SOURCE_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}\")
 add_definitions(-DUNIT_TEST)
 add_definitions(-DMVPN_DUMMY)
 
-find_package(Qt6 REQUIRED COMPONENTS Gui Widgets)
+find_package(Qt6 REQUIRED COMPONENTS Gui Widgets WebSockets)
 find_package(Qt6 REQUIRED COMPONENTS Qml Quick)
 find_package(Qt6 REQUIRED COMPONENTS QuickTest)
 

--- a/tests/qml/mocmozillavpn.cpp
+++ b/tests/qml/mocmozillavpn.cpp
@@ -25,6 +25,10 @@ MozillaVPN::MozillaVPN() {}
 MozillaVPN::~MozillaVPN() {}
 
 MozillaVPN::State MozillaVPN::state() const { return StateInitialize; }
+MozillaVPN::UserState MozillaVPN::userState() const {
+  return UserNotAuthenticated;
+}
+
 bool MozillaVPN::stagingMode() const {
   return TestHelper::instance()->stagingMode();
 }

--- a/tests/qml/qml.pro
+++ b/tests/qml/qml.pro
@@ -7,6 +7,7 @@ TARGET = qml_tests
 
 QT += quick
 QT += widgets
+QT += websockets
 
 CONFIG += warn_on qmltestcase
 CONFIG += c++1z

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -25,6 +25,7 @@ target_link_libraries(unit_tests PRIVATE
     Qt6::Xml
     Qt6::Network
     Qt6::Test
+    Qt6::WebSockets
     Qt6::Widgets
     Qt6::Gui
     Qt6::Qml

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -5,7 +5,7 @@
 add_definitions(-DUNIT_TEST)
 add_definitions(-DMVPN_ADJUST)
 
-find_package(Qt6 REQUIRED COMPONENTS Core Network Xml Test)
+find_package(Qt6 REQUIRED COMPONENTS Core Network Xml Test WebSockets)
 find_package(Qt6 REQUIRED COMPONENTS Widgets Gui)
 find_package(Qt6 REQUIRED COMPONENTS Qml Quick)
 

--- a/tests/unit/helper.h
+++ b/tests/unit/helper.h
@@ -35,6 +35,8 @@ class TestHelper : public QObject {
 
   static MozillaVPN::State vpnState;
 
+  static MozillaVPN::UserState userState;
+
   static Controller::State controllerState;
 
   static QVector<QObject*> testList;

--- a/tests/unit/main.cpp
+++ b/tests/unit/main.cpp
@@ -12,6 +12,7 @@
 QVector<TestHelper::NetworkConfig> TestHelper::networkConfig;
 MozillaVPN::State TestHelper::vpnState = MozillaVPN::StateInitialize;
 Controller::State TestHelper::controllerState = Controller::StateInitializing;
+MozillaVPN::UserState TestHelper::userState = MozillaVPN::UserNotAuthenticated;
 QVector<QObject*> TestHelper::testList;
 
 QObject* TestHelper::findTest(const QString& name) {

--- a/tests/unit/mocmozillavpn.cpp
+++ b/tests/unit/mocmozillavpn.cpp
@@ -26,6 +26,10 @@ MozillaVPN::~MozillaVPN() {}
 
 MozillaVPN::State MozillaVPN::state() const { return TestHelper::vpnState; }
 
+MozillaVPN::UserState MozillaVPN::userState() const {
+  return TestHelper::userState;
+}
+
 bool MozillaVPN::stagingMode() const { return true; }
 bool MozillaVPN::debugMode() const { return true; }
 

--- a/tests/unit/testwebsockethandler.cpp
+++ b/tests/unit/testwebsockethandler.cpp
@@ -35,12 +35,12 @@ MockServer::~MockServer() {
 void MockServer::onNewConnection() {
   QWebSocket* pSocket = m_pWebSocketServer->nextPendingConnection();
 
+  m_clients << pSocket;
+
   emit newConnection(pSocket->request());
 
   connect(pSocket, &QWebSocket::disconnected, this,
           &MockServer::onSocketDisconnected);
-
-  m_clients << pSocket;
 }
 
 /**
@@ -153,7 +153,7 @@ void TestWebSocketHandler::tst_reconnectionAttemptsAfterUnexpectedClose() {
 
   // No need to do anything here.
   //
-  // The handler should be polling for reconnection every 10ms,
+  // The handler should be polling for reconnection every 100ms,
   // we just wait for the reconnection to actually take place.
 
   QVERIFY(newConnectionSpy.wait());
@@ -194,8 +194,9 @@ void TestWebSocketHandler::tst_reconnectionAttemptsOnPingTimeout() {
 
   // No need to do anything here.
   //
-  // The handler should be polling for reconnection every 10ms,
+  // The handler should be polling for reconnection every 100ms,
   // we just wait for the reconnection to actually take place.
+
   QVERIFY(newConnectionSpy.wait());
   QCOMPARE(newConnectionSpy.count(), 2);
 

--- a/tests/unit/testwebsockethandler.cpp
+++ b/tests/unit/testwebsockethandler.cpp
@@ -1,0 +1,207 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.orgß/MPL/2.0/. */
+
+#include "testwebsockethandler.h"
+#include "../../src/settingsholder.h"
+#include "../../src/constants.h"
+#include "../../src/mozillavpn.h"
+#include "helper.h"
+
+#include <QtWebSockets/QWebSocketServer>
+
+/**
+ * @brief Construct a new Mock Server:: Mock Server object
+ *
+ * Simple web socket server that exposes signals which tests can spy on.
+ */
+MockServer::MockServer() {
+  m_pWebSocketServer = new QWebSocketServer(
+      QStringLiteral("Mock Server"), QWebSocketServer::NonSecureMode, this);
+  if (m_pWebSocketServer->listen(QHostAddress::Any, 5000)) {
+    connect(m_pWebSocketServer, &QWebSocketServer::newConnection, this,
+            &MockServer::onNewConnection);
+  }
+}
+
+MockServer::~MockServer() {
+  m_pWebSocketServer->close();
+  qDeleteAll(m_clients.begin(), m_clients.end());
+}
+
+/**
+ * @brief Ackowledges a new client has connected to the server.
+ */
+void MockServer::onNewConnection() {
+  QWebSocket* pSocket = m_pWebSocketServer->nextPendingConnection();
+
+  emit newConnection(pSocket->request());
+
+  connect(pSocket, &QWebSocket::disconnected, this,
+          &MockServer::onSocketDisconnected);
+
+  m_clients << pSocket;
+}
+
+/**
+ * @brief Ackowledges a new client has disconnected from the server.
+ */
+void MockServer::onSocketDisconnected() {
+  QWebSocket* pClient = qobject_cast<QWebSocket*>(QObject::sender());
+  if (pClient) {
+    m_clients.removeAll(pClient);
+    pClient->deleteLater();
+
+    emit socketDisconnected();
+  }
+}
+
+/**
+ * @brief Closes each of the open client connection and leaves the server open.
+ */
+void MockServer::closeEach() {
+  QListIterator<QWebSocket*> i(m_clients);
+  while (i.hasNext()) {
+    QWebSocket* client = i.next();
+    client->abort();
+  }
+}
+
+void TestWebSocketHandler::tst_connectionIsTiedToUserState() {
+  SettingsHolder settingsHolder;
+  WebSocketHandler::testOverrideWebSocketServerUrl(MOCK_SERVER_ADDRESS);
+
+  MockServer server;
+  QSignalSpy newConnectionSpy(&server, SIGNAL(newConnection(QNetworkRequest)));
+  QSignalSpy socketDisconnectedSpy(&server, SIGNAL(socketDisconnected()));
+
+  WebSocketHandler handler;
+  handler.initialize();
+
+  // Mock a user log in, this should prompt a new websocket connection.
+  TestHelper::userState = MozillaVPN::UserAuthenticated;
+  emit MozillaVPN::instance()->userStateChanged();
+
+  QVERIFY(newConnectionSpy.wait());
+  QCOMPARE(newConnectionSpy.count(), 1);
+
+  // Mock start a user log out, this should prompt the connected websocket to
+  // disconnect.
+  TestHelper::userState = MozillaVPN::UserLoggingOut;
+  emit MozillaVPN::instance()->userStateChanged();
+
+  QVERIFY(socketDisconnectedSpy.wait());
+  QCOMPARE(socketDisconnectedSpy.count(), 1);
+
+  // Reset the spies.
+  newConnectionSpy.clear();
+  socketDisconnectedSpy.clear();
+
+  // Mock finish the user log out.
+  TestHelper::userState = MozillaVPN::UserNotAuthenticated;
+  emit MozillaVPN::instance()->userStateChanged();
+
+  // Check that the last userStateChange signal did not trigger any connections
+  // or disconnections.
+  QCOMPARE(newConnectionSpy.count(), 0);
+  QCOMPARE(socketDisconnectedSpy.count(), 0);
+}
+
+void TestWebSocketHandler::tst_connectionRequestContainsRequiredHeaders() {
+  SettingsHolder settingsHolder;
+  WebSocketHandler::testOverrideWebSocketServerUrl(MOCK_SERVER_ADDRESS);
+
+  MockServer server;
+  QSignalSpy newConnectionSpy(&server, SIGNAL(newConnection(QNetworkRequest)));
+  QSignalSpy socketDisconnectedSpy(&server, SIGNAL(socketDisconnected()));
+
+  WebSocketHandler handler;
+  handler.initialize();
+
+  // Mock a user log in, this should prompt a new websocket connection.
+  TestHelper::userState = MozillaVPN::UserAuthenticated;
+  emit MozillaVPN::instance()->userStateChanged();
+
+  QVERIFY(newConnectionSpy.wait());
+  QCOMPARE(newConnectionSpy.count(), 1);
+
+  QList<QVariant> arguments = newConnectionSpy.takeFirst();
+  QNetworkRequest requestConnected = arguments.at(0).value<QNetworkRequest>();
+  QVERIFY(requestConnected.hasRawHeader("Authorization"));
+}
+
+void TestWebSocketHandler::tst_reconnectionAttemptsAfterUnexpectedClose() {
+  SettingsHolder settingsHolder;
+  WebSocketHandler::testOverrideWebSocketServerUrl(MOCK_SERVER_ADDRESS);
+
+  MockServer server;
+  QSignalSpy newConnectionSpy(&server, SIGNAL(newConnection(QNetworkRequest)));
+
+  WebSocketHandler handler;
+  handler.testOverrideRetryInterval(100);
+  handler.initialize();
+
+  // Mock a user log in, this should prompt a new websocket connection.
+  TestHelper::userState = MozillaVPN::UserAuthenticated;
+  emit MozillaVPN::instance()->userStateChanged();
+
+  QVERIFY(newConnectionSpy.wait());
+  QCOMPARE(newConnectionSpy.count(), 1);
+
+  // Disconnect client from the server.
+  server.closeEach();
+
+  // No need to do anything here.
+  //
+  // The handler should be polling for reconnection every 10ms,
+  // we just wait for the reconnection to actually take place.
+
+  QVERIFY(newConnectionSpy.wait());
+  QCOMPARE(newConnectionSpy.count(), 2);
+}
+
+void TestWebSocketHandler::tst_reconnectionAttemptsOnPingTimeout() {
+  SettingsHolder settingsHolder;
+  WebSocketHandler::testOverrideWebSocketServerUrl(MOCK_SERVER_ADDRESS);
+
+  MockServer server;
+  QSignalSpy newConnectionSpy(&server, SIGNAL(newConnection(QNetworkRequest)));
+  QSignalSpy socketDisconnectedSpy(&server, SIGNAL(socketDisconnected()));
+
+  WebSocketHandler handler;
+  handler.testOverrideRetryInterval(100);
+  // By setting an extremely low ping interval,
+  // we are guaranteed to have the ping timer timeout before we get a ping
+  // response.
+  //
+  // That should trigger the server to close the connection and schedule a
+  // retry.
+  handler.testOverridePingInterval(0);
+  handler.initialize();
+
+  // Mock a user log in, this should prompt a new websocket connection.
+  TestHelper::userState = MozillaVPN::UserAuthenticated;
+  emit MozillaVPN::instance()->userStateChanged();
+
+  // Wait for connection.
+  QVERIFY(newConnectionSpy.wait());
+  QCOMPARE(newConnectionSpy.count(), 1);
+
+  // Once connected we should almost immediatelly disconnect because the ping
+  // timer is timed out.
+  QVERIFY(socketDisconnectedSpy.wait());
+  QCOMPARE(socketDisconnectedSpy.count(), 1);
+
+  // No need to do anything here.
+  //
+  // The handler should be polling for reconnection every 10ms,
+  // we just wait for the reconnection to actually take place.
+  QVERIFY(newConnectionSpy.wait());
+  QCOMPARE(newConnectionSpy.count(), 2);
+
+  // Mock a user log out, so that we stop sending so many pings ASAP.
+  TestHelper::userState = MozillaVPN::UserLoggingOut;
+  emit MozillaVPN::instance()->userStateChanged();
+}
+
+static TestWebSocketHandler s_testWebSocketHandler;

--- a/tests/unit/testwebsockethandler.h
+++ b/tests/unit/testwebsockethandler.h
@@ -1,0 +1,43 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "helper.h"
+
+class QWebSocketServer;
+
+constexpr const char* MOCK_SERVER_ADDRESS = "ws://localhost:5000";
+
+// Adapted from:
+// https://code.woboq.org/qt5/qtwebsockets/tests/auto/websockets/qwebsocket/tst_qwebsocket.cpp.html#EchoServer
+class MockServer : public QObject {
+  Q_OBJECT
+
+ public:
+  explicit MockServer();
+  ~MockServer();
+
+  void closeEach();
+
+ signals:
+  void newConnection(QNetworkRequest request);
+  void socketDisconnected();
+
+ private slots:
+  void onNewConnection();
+  void onSocketDisconnected();
+
+ private:
+  QWebSocketServer* m_pWebSocketServer;
+  QList<QWebSocket*> m_clients;
+};
+
+class TestWebSocketHandler : public TestHelper {
+  Q_OBJECT
+
+ private slots:
+  void tst_connectionIsTiedToUserState();
+  void tst_connectionRequestContainsRequiredHeaders();
+  void tst_reconnectionAttemptsAfterUnexpectedClose();
+  void tst_reconnectionAttemptsOnPingTimeout();
+};

--- a/tests/unit/unit.pro
+++ b/tests/unit/unit.pro
@@ -8,6 +8,7 @@ QT += qml
 QT += quick
 QT += xml
 QT += widgets
+QT += websockets
 
 DEFINES += BUILD_QMAKE
 
@@ -122,6 +123,7 @@ HEADERS += \
     ../../src/update/updater.h \
     ../../src/update/versionapi.h \
     ../../src/urlopener.h \
+    ../../src/websockethandler.h \
     helper.h \
     testadjust.h \
     testandroidmigration.h \
@@ -143,7 +145,8 @@ HEADERS += \
     testtasks.h \
     testthemes.h \
     testtimersingleshot.h \
-    testtutorial.h
+    testtutorial.h \
+    testwebsockethandler.h
 
 SOURCES += \
     ../../src/adjust/adjustfiltering.cpp \
@@ -224,6 +227,7 @@ SOURCES += \
     ../../src/update/updater.cpp \
     ../../src/update/versionapi.cpp \
     ../../src/urlopener.cpp \
+    ../../src/websockethandler.cpp \
     main.cpp \
     moccontroller.cpp \
     mocinspectorhandler.cpp \
@@ -249,7 +253,8 @@ SOURCES += \
     testtasks.cpp \
     testthemes.cpp \
     testtimersingleshot.cpp \
-    testtutorial.cpp
+    testtutorial.cpp \
+    testwebsockethandler.cpp
 
 # Platform-specific: Linux
 linux {


### PR DESCRIPTION
## Description

This sets up the client to connect to the Guardian websocket implemented on https://github.com/mozilla-services/guardian-website/pull/1504.

Right now it's not sending any messages so over here we are also not doing anything to process messages. Those will come as follow up work.

## Reference

https://mozilla-hub.atlassian.net/browse/VPN-2260

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
