### PR TITLE
Reduce clickable area for checkboxrow labels

### DIFF
--- a/nebula/ui/components/VPNCheckBoxRow.qml
+++ b/nebula/ui/components/VPNCheckBoxRow.qml
@@ -77,6 +77,9 @@ RowLayout {
             visible: !!labelText.length
 
             VPNMouseArea {
+                anchors.fill: undefined
+                width: parent.implicitWidth
+                height: parent.implicitHeight
                 propagateClickToParent: false
                 onClicked: checkBox.clicked()
             }

--- a/tests/qml/tst_VPNCheckBoxRow.qml
+++ b/tests/qml/tst_VPNCheckBoxRow.qml
@@ -59,6 +59,12 @@ Item {
             expected = false
             actual = checkboxrow.isChecked
             verify(expected === actual, `isChecked was ${actual} not ${expected}.`);
+
+            //Simulate clicking to the right of the label of the checkbox. The last parameter (2) represents the topMargin for the VPNInterLabel in VPNCheckBoxRow
+            mouseClick(checkboxrow, checkboxrow.width + 1, 2)
+            expected = false
+            actual = checkboxrow.isChecked
+            verify(expected === actual, `isChecked was ${actual} not ${expected}.`);
         }
 
         function init() {


### PR DESCRIPTION
## Description

- Reduce the clickable area of a checkboxrow label to just the width (and height) of the text

## Reference

[VPN-889: Clicking on a radiobox/checkbox label should enable/disable the input field.](https://mozilla-hub.atlassian.net/browse/VPN-889)

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
