### PR TITLE
Disable features

### DIFF
--- a/src/featurelist.cpp
+++ b/src/featurelist.cpp
@@ -80,11 +80,28 @@ void FeatureList::initialize() {
   m_featurelist = Feature::getAll();
 }
 
-void FeatureList::devModeFlipFeatureFlag(const QString& feature) {
-  logger.debug() << "Flipping " << feature;
+void FeatureList::toggleForcedEnable(const QString& feature) {
+  logger.debug() << "Flipping on" << feature;
+
+  const Feature* f = Feature::get(feature);
+  if (!f) {
+    logger.debug() << "Feature" << feature << "does not exist";
+    return;
+  }
+
+  if (!f->isFlippableOn()) {
+    logger.debug() << "Feature" << feature << "cannot be flipped on";
+    return;
+  }
+
+  if (f->isSupportedIgnoringFlip()) {
+    logger.debug() << "This is an internal bug. Why flipping on a pref that is "
+                      "already supported?";
+    return;
+  }
 
   auto const settings = SettingsHolder::instance();
-  QStringList flags = settings->devModeFeatureFlags();
+  QStringList flags = settings->featuresFlippedOn();
 
   logger.debug() << "Got List - size:" << flags.size();
 
@@ -96,7 +113,46 @@ void FeatureList::devModeFlipFeatureFlag(const QString& feature) {
     flags.append(feature);
   }
 
-  settings->setDevModeFeatureFlags(flags);
+  settings->setFeaturesFlippedOn(flags);
+
+  logger.debug() << "Feature Flipped! new size:" << flags.size();
+  emit dataChanged(createIndex(0, 0), createIndex(m_featurelist.size(), 0));
+}
+
+void FeatureList::toggleForcedDisable(const QString& feature) {
+  logger.debug() << "Flipping off" << feature;
+
+  const Feature* f = Feature::get(feature);
+  if (!f) {
+    logger.debug() << "Feature" << feature << "does not exist";
+    return;
+  }
+
+  if (!f->isFlippableOff()) {
+    logger.debug() << "Feature" << feature << "cannot be flipped off";
+    return;
+  }
+
+  if (!f->isSupportedIgnoringFlip()) {
+    logger.debug() << "This is an internal bug. Why flipping off a pref that "
+                      "is already supported?";
+    return;
+  }
+
+  auto const settings = SettingsHolder::instance();
+  QStringList flags = settings->featuresFlippedOff();
+
+  logger.debug() << "Got List - size:" << flags.size();
+
+  if (flags.contains(feature)) {
+    logger.debug() << "Contains yes -> remove" << flags.size();
+    flags.removeAll(feature);
+  } else {
+    logger.debug() << "Contains no -> add" << flags.size();
+    flags.append(feature);
+  }
+
+  settings->setFeaturesFlippedOff(flags);
 
   logger.debug() << "Feature Flipped! new size:" << flags.size();
   emit dataChanged(createIndex(0, 0), createIndex(m_featurelist.size(), 0));
@@ -132,43 +188,50 @@ void FeatureList::updateFeatureList(const QByteArray& data) {
   SettingsHolder* settingsHolder = SettingsHolder::instance();
   Q_ASSERT(settingsHolder);
 
-  bool changed = false;
-  QStringList devModeFeatureFlags = settingsHolder->devModeFeatureFlags();
-
   QJsonObject json = QJsonDocument::fromJson(data).object();
-  QJsonValue featuresValue = json["features"];
-  if (!featuresValue.isObject()) {
-    logger.error() << "Error in the json format";
-    return;
-  }
-
-  QJsonObject featuresObj = featuresValue.toObject();
-  for (const QString& key : featuresObj.keys()) {
-    QJsonValue value = featuresObj.value(key);
-    if (!value.isBool()) {
-      logger.error() << "Error in parsing feature enabling:" << key;
-      continue;
+  if (json.contains("featuresOverwrite")) {
+    QJsonValue featuresValue = json["featuresOverwrite"];
+    if (!featuresValue.isObject()) {
+      logger.error() << "Error in the json format";
+      return;
     }
 
-    const Feature* feature = Feature::getOrNull(key);
-    if (!feature) {
-      logger.error() << "No feature named" << key;
-      continue;
-    }
+    QStringList featuresFlippedOn;
+    QStringList featuresFlippedOff;
 
-    if (value.toBool() == false) {
-      if (devModeFeatureFlags.contains(key)) {
-        devModeFeatureFlags.removeAll(key);
-        changed = true;
+    QJsonObject featuresObj = featuresValue.toObject();
+    for (const QString& key : featuresObj.keys()) {
+      QJsonValue value = featuresObj.value(key);
+      if (!value.isBool()) {
+        logger.error() << "Error in parsing feature enabling:" << key;
+        continue;
       }
-    } else if (!devModeFeatureFlags.contains(key)) {
-      devModeFeatureFlags.append(key);
-      changed = true;
-    }
-  }
 
-  if (changed) {
-    settingsHolder->setDevModeFeatureFlags(devModeFeatureFlags);
+      const Feature* feature = Feature::getOrNull(key);
+      if (!feature) {
+        logger.error() << "No feature named" << key;
+        continue;
+      }
+
+      if (value.toBool()) {
+        if (!feature->isFlippableOn()) {
+          logger.error() << "Feature" << key << "cannot be flipped on";
+          continue;
+        }
+
+        featuresFlippedOn.append(key);
+      } else {
+        if (!feature->isFlippableOff()) {
+          logger.error() << "Feature" << key << "cannot be flipped off";
+          continue;
+        }
+
+        featuresFlippedOff.append(key);
+      }
+    }
+
+    settingsHolder->setFeaturesFlippedOn(featuresFlippedOn);
+    settingsHolder->setFeaturesFlippedOff(featuresFlippedOff);
   }
 
 #ifdef MVPN_ADJUST

--- a/src/featurelist.h
+++ b/src/featurelist.h
@@ -33,7 +33,8 @@ class FeatureList final : public QAbstractListModel {
   int rowCount(const QModelIndex&) const override;
   QVariant data(const QModelIndex& index, int role) const override;
 
-  Q_INVOKABLE void devModeFlipFeatureFlag(const QString& feature);
+  Q_INVOKABLE void toggleForcedEnable(const QString& feature);
+  Q_INVOKABLE void toggleForcedDisable(const QString& feature);
   Q_INVOKABLE QObject* get(const QString& feature);
 
  private:

--- a/src/features/featureaccountdeletion.h
+++ b/src/features/featureaccountdeletion.h
@@ -21,7 +21,8 @@ class FeatureAccountDeletion final : public Feature {
                 "",                  // IconPath
                 "",                  // link URL
                 "2.9",               // released
-                true,                // Can be enabled in devmode
+                true,                // Can be flipped on
+                false,               // Can be flipped off
                 QStringList()        // feature dependencies
         ) {}
 

--- a/src/features/featureappreview.h
+++ b/src/features/featureappreview.h
@@ -21,7 +21,8 @@ class FeatureAppReview : public Feature {
                 "",                  // IconPath
                 "",                  // link URL
                 "2.5",               // released
-                false,               // Can be enabled in devmode
+                false,               // Can be flipped on
+                false,               // Can be flipped off
                 QStringList()        // feature dependencies
         ) {}
 

--- a/src/features/featurecaptiveportal.h
+++ b/src/features/featurecaptiveportal.h
@@ -21,7 +21,8 @@ class FeatureCaptivePortal final : public Feature {
                 "",                  // IconPath
                 "",                  // link URL
                 "2.1",               // released
-                true,                // Can be enabled in devmode
+                true,                // Can be flipped on
+                false,               // Can be flipped off
                 QStringList()        // feature dependencies
         ) {}
 

--- a/src/features/featureconnectioninfo.h
+++ b/src/features/featureconnectioninfo.h
@@ -26,7 +26,8 @@ class FeatureConnectionInfo final : public Feature {
             "qrc:/ui/resources/features/connection-info-icon.svg",  // IconPath
             "",                                                     // link URL
             "2.8",                                                  // released
-            true,          // Can be enabled in devmode
+            true,          // Can be flipped on
+            false,         // Can be flipped off
             QStringList()  // feature dependencies
         ) {}
 

--- a/src/features/featurecustomdns.h
+++ b/src/features/featurecustomdns.h
@@ -22,7 +22,8 @@ class FeatureCustomDNS final : public Feature {
             "qrc:/ui/resources/settings/networkSettings.svg",      // IconPath
             "",                                                    // link URL
             "2.5",                                                 // released
-            true,          // Can be enabled in devmode
+            true,          // Can be flipped on
+            false,         // Can be flipped off
             QStringList()  // feature dependencies
         ) {}
 

--- a/src/features/featurefreetrial.h
+++ b/src/features/featurefreetrial.h
@@ -21,7 +21,8 @@ class FeatureFreeTrial : public Feature {
                 "",                  // IconPath
                 "",                  // link URL
                 "2.8.1",             // released
-                true,                // Can be enabled in devmode
+                true,                // Can be flipped on
+                true,                // Can be flipped off
                 QStringList()        // feature dependencies
         ) {}
 

--- a/src/features/featureinappaccountcreate.h
+++ b/src/features/featureinappaccountcreate.h
@@ -21,7 +21,8 @@ class FeatureInAppAccountCreate final : public Feature {
                 "",                                 // IconPath
                 "",                                 // link URL
                 "2.6",                              // released
-                true,                               // Can be enabled in devmode
+                true,                               // Can be flipped on
+                false,                              // Can be flipped off
                 QStringList{"inAppAuthentication"}  // feature dependencies
         ) {}
 

--- a/src/features/featureinappauth.h
+++ b/src/features/featureinappauth.h
@@ -21,7 +21,8 @@ class FeatureInAppAuth final : public Feature {
                 "",                  // IconPath
                 "",                  // link URL
                 "2.4",               // released
-                true,                // Can be enabled in devmode
+                true,                // Can be flipped on
+                false,               // Can be flipped off
                 QStringList()        // feature dependencies
         ) {}
 

--- a/src/features/featureinapppurchase.h
+++ b/src/features/featureinapppurchase.h
@@ -21,7 +21,8 @@ class FeatureInAppPurchase final : public Feature {
                 "",                  // IconPath
                 "",                  // link URL
                 "2.4",               // released
-                false,               // Can be enabled in devmode
+                false,               // Can be flipped on
+                false,               // Can be flipped off
                 QStringList()        // feature dependencies
         ){};
 

--- a/src/features/featureioskillswitch.h
+++ b/src/features/featureioskillswitch.h
@@ -25,7 +25,8 @@ class FeatureIosKillswitch : public Feature {
                 "",                  // IconPath
                 "",                  // link URL
                 "2.8",               // released
-                true,                // Can be enabled in devmode
+                true,                // Can be flipped on
+                false,               // Can be flipped off
                 QStringList()        // feature dependencies
         ) {}
 

--- a/src/features/featurelocalareaaccess.h
+++ b/src/features/featurelocalareaaccess.h
@@ -21,7 +21,8 @@ class FeatureLocalAreaAccess final : public Feature {
                 "",                  // IconPath
                 "",                  // link URL
                 "2.2",               // released
-                true,                // Can be enabled in devmode
+                true,                // Can be flipped on
+                false,               // Can be flipped off
                 QStringList()        // feature dependencies
         ){};
 

--- a/src/features/featuremobileonboarding.h
+++ b/src/features/featuremobileonboarding.h
@@ -21,7 +21,8 @@ class FeatureMobileOnboarding final : public Feature {
                 "",                  // IconPath
                 "",                  // link URL
                 "2.8",               // released
-                true,                // Can be enabled in devmode
+                true,                // Can be flipped on
+                false,               // Can be flipped off
                 QStringList()        // feature dependencies
         ) {}
 

--- a/src/features/featuremultiaccountcontainers.h
+++ b/src/features/featuremultiaccountcontainers.h
@@ -31,7 +31,8 @@ class FeatureMultiAccountContainers final : public Feature {
             "client&utm_medium=in-app-link&utm_content=whats-new-panel&utm_"
             "campaign=vpn-better-together",  // link URL
             "2.7",
-            false,         // Can be enabled in devmode
+            false,         // Can be flipped on
+            false,         // Can be flipped off
             QStringList()  // feature dependencies
         ) {}
 

--- a/src/features/featuremultihop.h
+++ b/src/features/featuremultihop.h
@@ -26,7 +26,8 @@ class FeatureMultiHop : public Feature {
 #else
             "2.5",  // released for desktop
 #endif
-            true,          // Can be enabled in devmode
+            true,          // Can be flipped on
+            false,         // Can be flipped off
             QStringList()  // feature dependencies
         ) {
   }

--- a/src/features/featurenotificationcontrol.h
+++ b/src/features/featurenotificationcontrol.h
@@ -21,7 +21,8 @@ class FeatureNotificationControl final : public Feature {
                 "",                  // IconPath
                 "",                  // link URL
                 "2.3",               // released
-                true,                // Can be enabled in devmode
+                true,                // Can be flipped on
+                false,               // Can be flipped off
                 QStringList()        // feature dependencies
         ){};
 

--- a/src/features/featureserverunavailablenotification.h
+++ b/src/features/featureserverunavailablenotification.h
@@ -23,7 +23,8 @@ class FeatureServerUnavailableNotification final : public Feature {
                 "",                  // IconPath
                 "",                  // link URL
                 "2.7",               // released
-                true,                // Can be enabled in devmode
+                true,                // Can be flipped on
+                false,               // Can be flipped off
                 QStringList()        // feature dependencies
         ){};
 

--- a/src/features/featuresharelogs.h
+++ b/src/features/featuresharelogs.h
@@ -31,7 +31,8 @@ class FeatureShareLogs : public Feature {
                 "",                  // IconPath
                 "",                  // link URL
                 "2.6",               // released
-                false,               // Can be enabled in devmode
+                false,               // Can be flipped on
+                false,               // Can be flipped off
                 QStringList()        // feature dependencies
         ) {}
 

--- a/src/features/featuresplittunnel.h
+++ b/src/features/featuresplittunnel.h
@@ -26,7 +26,8 @@ class FeatureSplitTunnel final : public Feature {
                 "",                  // IconPath
                 "",                  // link URL
                 "2.4",               // released
-                true,                // Can be enabled in devmode
+                true,                // Can be flipped on
+                false,               // Can be flipped off
                 QStringList()        // feature dependencies
         ){};
 

--- a/src/features/featurestartonboot.h
+++ b/src/features/featurestartonboot.h
@@ -21,7 +21,8 @@ class FeatureStartOnBoot final : public Feature {
                 "",                  // IconPath
                 "",                  // link URL
                 "2.0",               // released
-                true,                // Can be enabled in devmode
+                true,                // Can be flipped on
+                false,               // Can be flipped off
                 QStringList()        // feature dependencies
         ){};
 

--- a/src/features/featureunsecurednetworknotification.h
+++ b/src/features/featureunsecurednetworknotification.h
@@ -23,7 +23,8 @@ class FeatureUnsecuredNetworkNotification final : public Feature {
                 "",                  // IconPath
                 "",                  // link URL
                 "2.2",               // released
-                true,                // Can be enabled in devmode
+                true,                // Can be flipped on
+                false,               // Can be flipped off
                 QStringList()        // feature dependencies
         ){};
 

--- a/src/inspector/inspectorhandler.cpp
+++ b/src/inspector/inspectorhandler.cpp
@@ -807,53 +807,35 @@ static QList<InspectorCommand> s_commands{
                        MozillaVPN::instance()->requestContactUs();
                        return QJsonObject();
                      }},
-    InspectorCommand{
-        "enable_feature", "Enable a feature", 1,
-        [](InspectorHandler*, const QList<QByteArray>& arguments) {
-          QString featureName = arguments[1];
-          const Feature* feature = Feature::getOrNull(featureName);
-          if (!feature) {
-            QJsonObject obj;
-            obj["error"] = "Feature does not exist";
-            return obj;
-          }
+    InspectorCommand{"flip_on_feature", "Flip On a feature", 1,
+                     [](InspectorHandler*, const QList<QByteArray>& arguments) {
+                       QString featureName = arguments[1];
+                       const Feature* feature = Feature::getOrNull(featureName);
+                       if (!feature) {
+                         QJsonObject obj;
+                         obj["error"] = "Feature does not exist";
+                         return obj;
+                       }
 
-          SettingsHolder* settingsHolder = SettingsHolder::instance();
-          Q_ASSERT(settingsHolder);
+                       FeatureList::instance()->toggleForcedEnable(
+                           arguments[1]);
+                       return QJsonObject();
+                     }},
 
-          QStringList devModeFeatureFlags =
-              settingsHolder->devModeFeatureFlags();
-          if (!devModeFeatureFlags.contains(featureName)) {
-            devModeFeatureFlags.append(featureName);
-            settingsHolder->setDevModeFeatureFlags(devModeFeatureFlags);
-          }
+    InspectorCommand{"flip_off_feature", "Flip Off a feature", 1,
+                     [](InspectorHandler*, const QList<QByteArray>& arguments) {
+                       QString featureName = arguments[1];
+                       const Feature* feature = Feature::getOrNull(featureName);
+                       if (!feature) {
+                         QJsonObject obj;
+                         obj["error"] = "Feature does not exist";
+                         return obj;
+                       }
 
-          return QJsonObject();
-        }},
-
-    InspectorCommand{
-        "disable_feature", "Disable a feature", 1,
-        [](InspectorHandler*, const QList<QByteArray>& arguments) {
-          QString featureName = arguments[1];
-          const Feature* feature = Feature::getOrNull(featureName);
-          if (!feature) {
-            QJsonObject obj;
-            obj["error"] = "Feature does not exist";
-            return obj;
-          }
-
-          SettingsHolder* settingsHolder = SettingsHolder::instance();
-          Q_ASSERT(settingsHolder);
-
-          QStringList devModeFeatureFlags =
-              settingsHolder->devModeFeatureFlags();
-          if (devModeFeatureFlags.contains(featureName)) {
-            devModeFeatureFlags.removeAll(featureName);
-            settingsHolder->setDevModeFeatureFlags(devModeFeatureFlags);
-          }
-
-          return QJsonObject();
-        }},
+                       FeatureList::instance()->toggleForcedDisable(
+                           arguments[1]);
+                       return QJsonObject();
+                     }},
 };
 
 // static

--- a/src/models/feature.cpp
+++ b/src/models/feature.cpp
@@ -22,7 +22,8 @@ Feature::Feature(const QString& id, const QString& name, bool isMajor,
                  L18nStrings::String shortDesc_id, L18nStrings::String desc_id,
                  const QString& imgPath, const QString& iconPath,
                  const QString& linkUrl, const QString& aReleaseVersion,
-                 bool devModeWriteable, const QStringList& featureDependencies)
+                 bool flippableOn, bool flippableOff,
+                 const QStringList& featureDependencies)
     : QObject(qApp),
       m_id(id),
       m_name(name),
@@ -33,7 +34,8 @@ Feature::Feature(const QString& id, const QString& name, bool isMajor,
       m_imagePath(imgPath),
       m_iconPath(iconPath),
       m_linkUrl(linkUrl),
-      m_devModeWriteable(devModeWriteable),
+      m_flippableOn(flippableOn),
+      m_flippableOff(flippableOff),
       m_featureDependencies(featureDependencies) {
   logger.debug() << "Initializing feature" << id;
 
@@ -61,16 +63,26 @@ Feature::Feature(const QString& id, const QString& name, bool isMajor,
     m_new = false;
   }
 
-  if (m_devModeWriteable) {
-    m_devModeEnabled =
-        SettingsHolder::instance()->devModeFeatureFlags().contains(m_id);
+  SettingsHolder* settingsHolder = SettingsHolder::instance();
+  Q_ASSERT(settingsHolder);
 
-    connect(
-        SettingsHolder::instance(), &SettingsHolder::devModeFeatureFlagsChanged,
-        this, [this]() {
-          maybeChangeDevMode(
-              SettingsHolder::instance()->devModeFeatureFlags().contains(m_id));
-        });
+  if (m_flippableOn) {
+    if (settingsHolder->featuresFlippedOn().contains(m_id)) {
+      m_state = FlippedOn;
+    }
+
+    connect(settingsHolder, &SettingsHolder::featuresFlippedOnChanged, this,
+            &Feature::maybeFlipOnOrOff);
+  }
+
+  if (m_flippableOff) {
+    if (m_state == DefaultValue &&
+        settingsHolder->featuresFlippedOff().contains(m_id)) {
+      m_state = FlippedOff;
+    }
+
+    connect(settingsHolder, &SettingsHolder::featuresFlippedOffChanged, this,
+            &Feature::maybeFlipOnOrOff);
   }
 }
 
@@ -94,24 +106,45 @@ const Feature* Feature::get(const QString& featureID) {
   return feature;
 }
 
-bool Feature::isDevModeEnabled(bool ignoreCache) const {
-  if (!m_devModeWriteable) {
+bool Feature::isFlippedOn(bool ignoreCache) const {
+  if (!m_flippableOn) {
     return false;
   }
 
   if (ignoreCache) {
-    return SettingsHolder::instance()->devModeFeatureFlags().contains(m_id);
+    return SettingsHolder::instance()->featuresFlippedOn().contains(m_id);
   }
 
-  return m_devModeEnabled;
+  return m_state == FlippedOn;
+}
+
+bool Feature::isFlippedOff(bool ignoreCache) const {
+  if (!m_flippableOff) {
+    return false;
+  }
+
+  if (ignoreCache) {
+    return SettingsHolder::instance()->featuresFlippedOff().contains(m_id);
+  }
+
+  return m_state == FlippedOff;
 }
 
 bool Feature::isSupported(bool ignoreCache) const {
-  if (isDevModeEnabled(ignoreCache)) {
-    logger.debug() << "Devmode Enabled " << m_id;
+  if (isFlippedOn(ignoreCache)) {
+    logger.debug() << "Flipped On" << m_id;
     return true;
   }
 
+  if (isFlippedOff(ignoreCache)) {
+    logger.debug() << "Flipped Off" << m_id;
+    return false;
+  }
+
+  return isSupportedIgnoringFlip();
+}
+
+bool Feature::isSupportedIgnoringFlip() const {
   if (!m_released) {
     return false;
   }
@@ -140,68 +173,89 @@ QString Feature::shortDescription() const {
   return L18nStrings::instance()->t(m_shortDescription_id);
 }
 
-void Feature::maybeChangeDevMode(bool newDevModeEnabled) {
-  if (newDevModeEnabled == m_devModeEnabled) {
+void Feature::maybeFlipOnOrOff() {
+  SettingsHolder* settingsHolder = SettingsHolder::instance();
+  Q_ASSERT(settingsHolder);
+
+  State newState = DefaultValue;
+  if (settingsHolder->featuresFlippedOn().contains(m_id)) {
+    newState = FlippedOn;
+  } else if (settingsHolder->featuresFlippedOff().contains(m_id)) {
+    newState = FlippedOff;
+  }
+
+  if (newState == m_state) {
     // Something else has changed. Let's see if we have to disable this feature
     // because one of the dependencies has changed.
-    if (newDevModeEnabled) {
+    if (newState == FlippedOn) {
       for (const QString& featureID : m_featureDependencies) {
         Feature* feature = s_features->value(featureID, nullptr);
         Q_ASSERT(feature);
 
-        // Let's check the support ignoring the cache (m_devModeEnabled)
+        // Let's check the support ignoring the cache (m_state)
         // because maybe this feature doesn't know yet that it has been
         // disabled.
         if (feature->isSupported(true)) continue;
 
-        QStringList devModeFeatureFlags =
-            SettingsHolder::instance()->devModeFeatureFlags();
-        devModeFeatureFlags.removeAll(m_id);
-        SettingsHolder::instance()->setDevModeFeatureFlags(devModeFeatureFlags);
+        QStringList featuresFlippedOn =
+            SettingsHolder::instance()->featuresFlippedOn();
+        featuresFlippedOn.removeAll(m_id);
+        SettingsHolder::instance()->setFeaturesFlippedOn(featuresFlippedOn);
         break;
       }
     }
     return;
   }
 
-  if (!newDevModeEnabled) {
-    m_devModeEnabled = newDevModeEnabled;
+  if (newState != FlippedOn) {
+    m_state = newState;
     emit supportedChanged();
     return;
   }
 
   // Let's set it before checking other features to break cycles.
-  m_devModeEnabled = newDevModeEnabled;
+  m_state = newState;
 
-  QStringList devModeFeatureFlags =
-      SettingsHolder::instance()->devModeFeatureFlags();
-
+  QList<Feature*> featuresToFlipOnAndCheck;
   for (const QString& featureID : m_featureDependencies) {
     Feature* feature = s_features->value(featureID, nullptr);
     Q_ASSERT(feature);
 
-    if (feature->isSupported()) continue;
+    if (feature->isSupported(true)) continue;
 
-    if (!feature->m_devModeWriteable) {
+    if (!feature->m_flippableOn) {
       logger.debug() << "Unable to activate feature" << id()
                      << "because feature" << feature->id()
                      << "cannot be enabled in dev mode";
-      m_devModeEnabled = false;
+      m_state = DefaultValue;
       return;
     }
 
-    feature->maybeChangeDevMode(true);
-    if (!feature->isSupported()) {
-      logger.debug() << "Unable to activate feature" << id()
-                     << "because feature" << feature->id()
-                     << "cannot be enabled";
-      m_devModeEnabled = false;
-      return;
+    featuresToFlipOnAndCheck.append(feature);
+  }
+
+  if (!featuresToFlipOnAndCheck.isEmpty()) {
+    QStringList featuresFlippedOn =
+        SettingsHolder::instance()->featuresFlippedOn();
+
+    for (Feature* feature : featuresToFlipOnAndCheck) {
+      if (!featuresFlippedOn.contains(feature->m_id)) {
+        featuresFlippedOn.append(feature->m_id);
+      }
     }
 
-    devModeFeatureFlags.append(featureID);
+    SettingsHolder::instance()->setFeaturesFlippedOn(featuresFlippedOn);
+
+    for (Feature* feature : featuresToFlipOnAndCheck) {
+      if (!feature->isSupported()) {
+        logger.debug() << "Unable to activate feature" << id()
+                       << "because feature" << feature->id()
+                       << "cannot be enabled";
+        m_state = DefaultValue;
+        return;
+      }
+    }
   }
 
   emit supportedChanged();
-  SettingsHolder::instance()->setDevModeFeatureFlags(devModeFeatureFlags);
 }

--- a/src/models/feature.h
+++ b/src/models/feature.h
@@ -25,8 +25,11 @@ class Feature : public QObject {
   Q_PROPERTY(QString linkUrl READ linkUrl CONSTANT)
   Q_PROPERTY(bool isReleased MEMBER m_released CONSTANT)
   Q_PROPERTY(bool isNew READ isNew CONSTANT)
-  Q_PROPERTY(bool devModeWriteable MEMBER m_devModeWriteable CONSTANT)
+  Q_PROPERTY(bool flippableOn READ isFlippableOn CONSTANT)
+  Q_PROPERTY(bool flippableOff READ isFlippableOff CONSTANT)
   Q_PROPERTY(bool isSupported READ isSupported NOTIFY supportedChanged)
+  Q_PROPERTY(bool isSupportedIgnoringFlip READ isSupportedIgnoringFlip NOTIFY
+                 supportedChanged)
 
   // protected:
  public:
@@ -34,7 +37,7 @@ class Feature : public QObject {
           L18nStrings::String displayName_id, L18nStrings::String shortDesc_id,
           L18nStrings::String desc_id, const QString& imgPath,
           const QString& iconPath, const QString& linkUrl,
-          const QString& releaseVersion, bool devModeWriteable,
+          const QString& releaseVersion, bool flippableOn, bool flippableOff,
           const QStringList& otherFeatureDependencies);
 
  public:
@@ -51,12 +54,21 @@ class Feature : public QObject {
   static const Feature* getOrNull(const QString& featureID);
 
   // Checks if the feature is released
-  // or force enabled by the DevMode
+  // or force enabled/disable via flip flags
   // returns the features checkSupportCallback otherwise.
   bool isSupported(bool ignoreCache = false) const;
 
-  // Returns true if it was enabled via DevMode
-  Q_INVOKABLE bool isDevModeEnabled(bool ignoreCache = false) const;
+  // Checks if the feature is released ignoring the flip on/off
+  bool isSupportedIgnoringFlip() const;
+
+  bool isFlippableOn() const { return m_flippableOn; }
+  bool isFlippableOff() const { return m_flippableOff; }
+
+  // Returns true if this feature is flipped on via settings
+  Q_INVOKABLE bool isFlippedOn(bool ignoreCache = false) const;
+
+  // Returns true if this feature is flipped off via settings
+  Q_INVOKABLE bool isFlippedOff(bool ignoreCache = false) const;
 
   // Returns true if this is a newly introduced feature
   bool isNew() const { return m_new; }
@@ -73,9 +85,9 @@ class Feature : public QObject {
   QString linkUrl() const { return m_linkUrl; }
 
  signals:
-  // Is send if the underlying factors for support changed
-  // e.g Controller support level for features depending on this
-  // or if the devmode enabled a feature
+  // This signal is emitted if the underlying factors for support changed e.g
+  // Controller support level for features depending on this or if the feature
+  // has been flipped on/off somehow.
   void supportedChanged();
 
  protected:
@@ -83,10 +95,11 @@ class Feature : public QObject {
   // Should check if the feature could be used, if released
   virtual bool checkSupportCallback() const = 0;
 
-  void maybeChangeDevMode(bool newDevModeEnabled);
+  void maybeFlipOnOrOff();
 
   // Unique Identifier of the Feature, used to Check
-  // Capapbilities of the Daemon/Server or if is Force-Enabled in the Dev Menu
+  // Capapbilities of the Daemon/Server or if is Force-Enabled/Disabled in the
+  // Dev Menu
   const QString m_id;
 
   // Human Readable Name of the Feature
@@ -108,15 +121,24 @@ class Feature : public QObject {
   // Link URL to external information on the feature
   const QString m_linkUrl;
 
-  // If true, the feature can be enabled in the Dev-Settings
-  const bool m_devModeWriteable;
+  // If true, the feature can be enabled.
+  const bool m_flippableOn;
+  // If true, the feature can be disabled.
+  const bool m_flippableOff;
 
   // List of other features to be supported in order to support this one.
   const QStringList m_featureDependencies;
 
-  // If true, the feature is enabled in the Dev-Settings. If
-  // `m_devModeWriteable` is false, this will always be false.
-  bool m_devModeEnabled = false;
+  // How to compute the feature support value.
+  enum State {
+    // Just use what the `checkSupportCallback` method returns
+    DefaultValue,
+    // This pref is forced to be true
+    FlippedOn,
+    // This pref is forced to be false
+    FlippedOff,
+  };
+  State m_state = DefaultValue;
 
   // Determines if the feature should be available if possible
   // Otherwise it can only be reached via a dev-override

--- a/src/settingslist.h
+++ b/src/settingslist.h
@@ -108,12 +108,20 @@ SETTING_BYTEARRAY(devices,     // getter
                   true         // remove when reset
 )
 
-SETTING_STRINGLIST(devModeFeatureFlags,     // getter
-                   setDevModeFeatureFlags,  // setter
-                   hasDevModeFeatureFlags,  // has
-                   "devmodeFeatureFlags",   // key
-                   QStringList(),           // default value
-                   false                    // remove when reset
+SETTING_STRINGLIST(featuresFlippedOn,     // getter
+                   setFeaturesFlippedOn,  // setter
+                   hasFeaturesFlippedOn,  // has
+                   "featuresFlippedOn",   // key
+                   QStringList(),         // default value
+                   false                  // remove when reset
+)
+
+SETTING_STRINGLIST(featuresFlippedOff,     // getter
+                   setFeaturesFlippedOff,  // setter
+                   hasFeaturesFlippedOff,  // has
+                   "featuresFlippedOff",   // key
+                   QStringList(),          // default value
+                   false                   // remove when reset
 )
 
 SETTING_INT(dnsProvider,                           // getter

--- a/src/ui/developerMenu/ViewFeatureList.qml
+++ b/src/ui/developerMenu/ViewFeatureList.qml
@@ -23,9 +23,15 @@ Item {
     }
 
     VPNFilterProxyModel {
-        id: editableFeatureModel
+        id: flippableOnFeatureModel
         source: VPNFeatureList
-        filterCallback: entry => entry.feature.devModeWriteable
+        filterCallback: entry => entry.feature.flippableOn && !entry.feature.isSupportedIgnoringFlip
+    }
+
+    VPNFilterProxyModel {
+        id: flippableOffFeatureModel
+        source: VPNFeatureList
+        filterCallback: entry => entry.feature.flippableOff && entry.feature.isSupportedIgnoringFlip
     }
 
     VPNFlickable {
@@ -46,20 +52,38 @@ Item {
 
             VPNBoldLabel{
                 // Do not translate this string!
-                text: "Features that can be toggled"
+                text: "Features that can be flipped on"
             }
 
             Repeater {
-                model: editableFeatureModel
+                model: flippableOnFeatureModel
                 delegate: VPNCheckBoxRow {
                     showDivider: false
                     labelText: feature.name
                     subLabelText: feature.id
                     showAppImage: false
-                    onClicked: VPNFeatureList.devModeFlipFeatureFlag(feature.id)
-                    // Only enable the list on features where devModeEnable has any impact
+                    onClicked: VPNFeatureList.toggleForcedEnable(feature.id)
                     enabled: true
-                    isChecked: feature.isDevModeEnabled()
+                    isChecked: feature.isFlippedOn()
+                    Layout.minimumHeight: VPNTheme.theme.rowHeight * 1.5
+                }
+            }
+
+            VPNBoldLabel{
+                // Do not translate this string!
+                text: "Features that can be flipped off"
+            }
+
+            Repeater {
+                model: flippableOffFeatureModel
+                delegate: VPNCheckBoxRow {
+                    showDivider: false
+                    labelText: feature.name
+                    subLabelText: feature.id
+                    showAppImage: false
+                    onClicked: VPNFeatureList.toggleForcedDisable(feature.id)
+                    enabled: true
+                    isChecked: feature.isFlippedOff()
                     Layout.minimumHeight: VPNTheme.theme.rowHeight * 1.5
                 }
             }

--- a/tests/auth/main.cpp
+++ b/tests/auth/main.cpp
@@ -31,7 +31,7 @@ int main(int argc, char* argv[]) {
   SimpleNetworkManager snm;
   FeatureList::instance()->initialize();
 
-  settingsHolder.setDevModeFeatureFlags(QStringList{
+  settingsHolder.setFeaturesFlippedOn(QStringList{
       "inAppAccountCreate", "inAppAuthentication", "accountDeletion"});
 
   LogHandler::enableDebug();

--- a/tests/unit/testfeature.cpp
+++ b/tests/unit/testfeature.cpp
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "testfeature.h"
+#include "testfeaturelist.h"
 #include "../../src/featurelist.h"
 #include "../../src/features/featurecustomdns.h"
 #include "../../src/models/feature.h"
@@ -10,28 +11,143 @@
 #include "../../src/adjust/adjustfiltering.h"
 #include "helper.h"
 
+void TestFeature::flipOnOff() {
+  SettingsHolder settingsHolder;
+
+  // Fresh settings!
+  QVERIFY(!settingsHolder.featuresFlippedOn().contains("testFeatureA"));
+  QVERIFY(!settingsHolder.featuresFlippedOn().contains("testFeatureB"));
+  QVERIFY(!settingsHolder.featuresFlippedOn().contains("testFeatureC"));
+  QVERIFY(!settingsHolder.featuresFlippedOff().contains("testFeatureA"));
+  QVERIFY(!settingsHolder.featuresFlippedOff().contains("testFeatureB"));
+  QVERIFY(!settingsHolder.featuresFlippedOff().contains("testFeatureC"));
+
+  // Let's create a few features
+  FeatureTestA fA;
+  QVERIFY(!!Feature::get("testFeatureA"));
+  QVERIFY(Feature::get("testFeatureA")->isSupported());
+
+  FeatureTestB fB;
+  QVERIFY(!!Feature::get("testFeatureB"));
+  QVERIFY(!Feature::get("testFeatureB")->isSupported());
+
+  FeatureTestC fC;
+  QVERIFY(!!Feature::get("testFeatureC"));
+  QVERIFY(!Feature::get("testFeatureC")->isSupported());
+
+  // FeatureList initialization
+  FeatureList* fl = FeatureList::instance();
+  fl->initialize();
+
+  // Flipping on an already-supported feature doesn't produce changes.
+  fl->toggleForcedEnable("testFeatureA");
+  QVERIFY(!settingsHolder.featuresFlippedOn().contains("testFeatureA"));
+  QVERIFY(!settingsHolder.featuresFlippedOff().contains("testFeatureA"));
+  QVERIFY(Feature::get("testFeatureA")->isSupported());
+
+  // Flipping off a feature which was on -> it becomes off
+  fl->toggleForcedDisable("testFeatureA");
+  QVERIFY(!settingsHolder.featuresFlippedOn().contains("testFeatureA"));
+  QVERIFY(settingsHolder.featuresFlippedOff().contains("testFeatureA"));
+  QVERIFY(!Feature::get("testFeatureA")->isSupported());
+
+  // Flipping off a feature which was on but disabled -> it becomes on
+  fl->toggleForcedDisable("testFeatureA");
+  QVERIFY(!settingsHolder.featuresFlippedOn().contains("testFeatureA"));
+  QVERIFY(!settingsHolder.featuresFlippedOff().contains("testFeatureA"));
+  QVERIFY(Feature::get("testFeatureA")->isSupported());
+
+  // Flipping off an non-supported feature doesn't produce changes.
+  fl->toggleForcedDisable("testFeatureB");
+  QVERIFY(!settingsHolder.featuresFlippedOn().contains("testFeatureB"));
+  QVERIFY(!settingsHolder.featuresFlippedOff().contains("testFeatureB"));
+  QVERIFY(!Feature::get("testFeatureB")->isSupported());
+
+  // Flipping on a feature which was off -> it becomes on
+  fl->toggleForcedEnable("testFeatureB");
+  QVERIFY(settingsHolder.featuresFlippedOn().contains("testFeatureB"));
+  QVERIFY(!settingsHolder.featuresFlippedOff().contains("testFeatureB"));
+  QVERIFY(Feature::get("testFeatureB")->isSupported());
+
+  // Flipping on a feature which was off but enabled -> it becomes off
+  fl->toggleForcedEnable("testFeatureB");
+  QVERIFY(!settingsHolder.featuresFlippedOn().contains("testFeatureB"));
+  QVERIFY(!settingsHolder.featuresFlippedOff().contains("testFeatureB"));
+  QVERIFY(!Feature::get("testFeatureB")->isSupported());
+
+  // Flipping on an unflippable feature doesn't produce changes.
+  fl->toggleForcedEnable("testFeatureC");
+  QVERIFY(!settingsHolder.featuresFlippedOn().contains("testFeatureC"));
+  QVERIFY(!settingsHolder.featuresFlippedOff().contains("testFeatureC"));
+  QVERIFY(!Feature::get("testFeatureC")->isSupported());
+
+  // Flipping on an unflippable feature doesn't produce changes.
+  fl->toggleForcedDisable("testFeatureC");
+  QVERIFY(!settingsHolder.featuresFlippedOn().contains("testFeatureC"));
+  QVERIFY(!settingsHolder.featuresFlippedOff().contains("testFeatureC"));
+  QVERIFY(!Feature::get("testFeatureC")->isSupported());
+}
+
 void TestFeature::enableByAPI() {
   SettingsHolder settingsHolder;
+  // Fresh settings!
+  QVERIFY(!settingsHolder.featuresFlippedOn().contains("testFeatureA"));
+  QVERIFY(!settingsHolder.featuresFlippedOn().contains("testFeatureB"));
+  QVERIFY(!settingsHolder.featuresFlippedOn().contains("testFeatureC"));
+  QVERIFY(!settingsHolder.featuresFlippedOff().contains("testFeatureA"));
+  QVERIFY(!settingsHolder.featuresFlippedOff().contains("testFeatureB"));
+  QVERIFY(!settingsHolder.featuresFlippedOff().contains("testFeatureC"));
+
+  // Let's create a few features
+  // Let's create a few features
+  FeatureTestA fA;
+  QVERIFY(!!Feature::get("testFeatureA"));
+  QVERIFY(Feature::get("testFeatureA")->isSupported());
+
+  FeatureTestB fB;
+  QVERIFY(!!Feature::get("testFeatureB"));
+  QVERIFY(!Feature::get("testFeatureB")->isSupported());
+
+  FeatureTestC fC;
+  QVERIFY(!!Feature::get("testFeatureC"));
+  QVERIFY(!Feature::get("testFeatureC")->isSupported());
 
   FeatureList::instance()->initialize();
 
-  const Feature* feature = Feature::get(FEATURE_CUSTOM_DNS);
-  QVERIFY(feature->isSupported());
-
   QJsonObject obj;
-  obj["customDNS"] = false;
+  obj["testFeatureA"] = true;
+  obj["testFeatureB"] = true;
+  obj["testFeatureC"] = true;
 
   QJsonObject json;
-  json["features"] = obj;
+  json["featuresOverwrite"] = obj;
 
   FeatureList::instance()->updateFeatureList(QJsonDocument(json).toJson());
-  QVERIFY(feature->isSupported());
+  QVERIFY(settingsHolder.featuresFlippedOn().contains("testFeatureA"));
+  QVERIFY(settingsHolder.featuresFlippedOn().contains("testFeatureB"));
+  QVERIFY(!settingsHolder.featuresFlippedOn().contains("testFeatureC"));
+  QVERIFY(!settingsHolder.featuresFlippedOff().contains("testFeatureA"));
+  QVERIFY(!settingsHolder.featuresFlippedOff().contains("testFeatureB"));
+  QVERIFY(!settingsHolder.featuresFlippedOff().contains("testFeatureC"));
+  QVERIFY(Feature::get("testFeatureA")->isSupported());
+  QVERIFY(Feature::get("testFeatureB")->isSupported());
+  QVERIFY(!Feature::get("testFeatureC")->isSupported());
 
-  obj["customDNS"] = true;
-  json["features"] = obj;
+  obj["testFeatureA"] = false;
+  obj["testFeatureB"] = false;
+  obj["testFeatureC"] = false;
+  json["featuresOverwrite"] = obj;
 
   FeatureList::instance()->updateFeatureList(QJsonDocument(json).toJson());
-  QVERIFY(feature->isSupported());
+  QVERIFY(!settingsHolder.featuresFlippedOn().contains("testFeatureA"));
+  QVERIFY(!settingsHolder.featuresFlippedOn().contains("testFeatureB"));
+  QVERIFY(!settingsHolder.featuresFlippedOn().contains("testFeatureC"));
+  QVERIFY(settingsHolder.featuresFlippedOff().contains("testFeatureA"));
+  QVERIFY(settingsHolder.featuresFlippedOff().contains("testFeatureB"));
+  QVERIFY(!settingsHolder.featuresFlippedOff().contains("testFeatureC"));
+  QVERIFY(!Feature::get("testFeatureA")->isSupported());
+  QVERIFY(!Feature::get("testFeatureB")->isSupported());
+  QVERIFY(!Feature::get("testFeatureC")->isSupported());
 
   obj["allowParameters"] = QJsonArray{"allowTest"};
 

--- a/tests/unit/testfeature.h
+++ b/tests/unit/testfeature.h
@@ -8,5 +8,6 @@ class TestFeature final : public TestHelper {
   Q_OBJECT
 
  private slots:
+  void flipOnOff();
   void enableByAPI();
 };

--- a/tests/unit/testfeaturelist.h
+++ b/tests/unit/testfeaturelist.h
@@ -1,0 +1,85 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef TESTFEATURELIST_H
+#define TESTFEATURELIST_H
+
+#include "../../src/models/feature.h"
+
+// Feature A can be turned on/off but it's always on by default
+class FeatureTestA final : public Feature {
+ public:
+  FeatureTestA()
+      : Feature("testFeatureA", "Feature A",
+                false,               // Is Major Feature
+                L18nStrings::Empty,  // Display name
+                L18nStrings::Empty,  // Description
+                L18nStrings::Empty,  // LongDescr
+                "",                  // ImagePath
+                "",                  // IconPath
+                "",                  // link URL
+                "1.0",               // released
+                true,                // Can be flipped on
+                true,                // Can be flipped off
+                QStringList()        // feature dependencies
+        ) {}
+
+  bool checkSupportCallback() const override { return true; }
+
+  static const FeatureTestA* instance() {
+    return static_cast<const FeatureTestA*>(get("testFeatureA"));
+  }
+};
+
+// Feature B can be turned on/off but it's always on by default
+class FeatureTestB final : public Feature {
+ public:
+  FeatureTestB()
+      : Feature("testFeatureB", "Feature B",
+                false,               // Is Major Feature
+                L18nStrings::Empty,  // Display name
+                L18nStrings::Empty,  // Description
+                L18nStrings::Empty,  // LongDescr
+                "",                  // ImagePath
+                "",                  // IconPath
+                "",                  // link URL
+                "1.0",               // released
+                true,                // Can be flipped on
+                true,                // Can be flipped off
+                QStringList()        // feature dependencies
+        ) {}
+
+  bool checkSupportCallback() const override { return false; }
+
+  static const FeatureTestB* instance() {
+    return static_cast<const FeatureTestB*>(get("testFeatureB"));
+  }
+};
+
+// Feature C can be turned on/off but it's always on by default
+class FeatureTestC final : public Feature {
+ public:
+  FeatureTestC()
+      : Feature("testFeatureC", "Feature C",
+                false,               // Is Major Feature
+                L18nStrings::Empty,  // Display name
+                L18nStrings::Empty,  // Description
+                L18nStrings::Empty,  // LongDescr
+                "",                  // ImagePath
+                "",                  // IconPath
+                "",                  // link URL
+                "1.0",               // released
+                false,               // Can be flipped on
+                false,               // Can be flipped off
+                QStringList()        // feature dependencies
+        ) {}
+
+  bool checkSupportCallback() const override { return false; }
+
+  static const FeatureTestC* instance() {
+    return static_cast<const FeatureTestC*>(get("testFeatureC"));
+  }
+};
+
+#endif  // TESTFEATURELIST_H


### PR DESCRIPTION
## Description

For 2.8.2 we want to have a way to disable the free-trial feature in case something goes wrong. With this PR, each `Feature` can be defined as flippable on and flippable off, independently. If they are flipped on/off this setting overwrites the default Feature state.

As Lesley said, this PR transforms a boolean into a quantum boolean. Because now a feature can be:
- on or off
- forced on
- forced off

To make it happen, this PR does:

1. It allows the flip on/off of features from the dev-menu.
2. Now the dev menu makes toggleable only the features that can be enabled for real
3. Similar toggles/checkboxes are for features that can be disabled
4. rename the SettingsList devModeFeatureFlags to featuresFlippedOn
5. introduce SettingsList featuresFlippedOff
6. tests


## Reference
https://mozilla-hub.atlassian.net/browse/VPN-2228
