### PR TITLE
Properly disable qmljsdebugger in release mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,17 +39,17 @@ endif()
 
 option(BUILD_DUMMY "Build for the dummy platform" OFF)
 
-project("Mozilla VPN" VERSION 2.10.0 LANGUAGES C CXX
-        DESCRIPTION "A fast, secure and easy to use VPN. Built by the makers of Firefox."
-        HOMEPAGE_URL "https://vpn.mozilla.org"
-)
-
 message("Configuring for ${CMAKE_GENERATOR}")
-if(NOT (DEFINED CMAKE_CONFIGURATION_TYPES OR "${CMAKE_BUILD_TYPE}"))
+if(NOT (DEFINED CMAKE_CONFIGURATION_TYPES OR DEFINED CMAKE_BUILD_TYPE))
     ## Ensure the build type is set for single-config generators.
     set(CMAKE_BUILD_TYPE "Debug" CACHE STRING "default build type" FORCE)
     message("Setting build type ${CMAKE_BUILD_TYPE}")
 endif()
+
+project("Mozilla VPN" VERSION 2.10.0 LANGUAGES C CXX
+        DESCRIPTION "A fast, secure and easy to use VPN. Built by the makers of Firefox."
+        HOMEPAGE_URL "https://vpn.mozilla.org"
+)
 
 if(NOT DEFINED BUILD_ID)
     string(TIMESTAMP BUILD_ID "${PROJECT_VERSION_MAJOR}.%Y%m%d%H%M")

--- a/src/qmake/debug.pri
+++ b/src/qmake/debug.pri
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-debug {
+CONFIG(debug, debug|release) {
     # If in debug mode, set mvpn_debug flag too.
     CONFIG += mvpn_debug
 }


### PR DESCRIPTION
## Description

* In qmake, the `debug` variable and the `release` variable are both present by default.  We need to check which one is active, by virtue of having been set later.

  https://doc.qt.io/qt-6/qmake-test-function-reference.html#config-config

* In CMake, the `"${CMAKE_BUILD_TYPE}"` test did not do what it looks like it does.  CMake evaluates `if("${CMAKE_BUILD_TYPE}")` to `if(Release)`, which tests whether the *variable named `Release`* is defined; it isn’t, so we were unconditionally setting `CMAKE_BUILD_TYPE` to `Debug`.

  https://cmake.org/cmake/help/latest/command/if.html#variable-expansion

  We need to check whether `CMAKE_BUILD_TYPE` variable itself is defined, and we need to do so before `project()` defines it by default.

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
