### PR TITLE
Fix a dumb typo causing the nightly PPA to fail.

### DIFF
--- a/scripts/linux/script.sh
+++ b/scripts/linux/script.sh
@@ -136,7 +136,7 @@ elif [[ "$GITREF" =~ ^refs/heads/releases/([0-9][^/]*) ]]; then
   RCVERSION="~rc$(git rev-list --count --first-parent origin/main..HEAD)"
   SHORTVERSION="${BASH_REMATCH[1]}${RCVERSION}"
 elif [[ "$GITREF" == "refs/heads/main" ]]; then
-  SHOFTVERSION="${SHORTVERSION}~nightly$(date +%Y%m%d)"
+  SHORTVERSION="${SHORTVERSION}~nightly$(date +%Y%m%d)"
 fi
 WORKDIR=mozillavpn-${SHORTVERSION}
 print G "${SHORTVERSION}"


### PR DESCRIPTION
## Description
In the omnibus CMake PR #3350 I moved some things around and introduced a typo in the linux packaging script that set the Debianization version suffix incorrectly when the gitref is `refs/heads/main` This means that we have not been including the suffix in the nightly builds, resulting in rejected packages because the version number is duplicated.

## Reference
None

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
