### PR TITLE
Clear QT_STYLE_OVERRIDE if the style was not found.

### DIFF
--- a/src/command.cpp
+++ b/src/command.cpp
@@ -26,6 +26,7 @@
 
 #include <QApplication>
 #include <QIcon>
+#include <QStyleFactory>
 #include <QTextStream>
 
 namespace {
@@ -147,6 +148,9 @@ int Command::runQmlApp(std::function<int()>&& a_callback) {
   }
 
   qInstallMessageHandler(LogHandler::messageQTHandler);
+
+  // Ensure that external styling hints are disabled.
+  qunsetenv("QT_STYLE_OVERRIDE");
 
   logger.info() << "MozillaVPN" << Constants::versionString();
   logger.info() << "User-Agent:" << NetworkManager::userAgent();

--- a/src/command.cpp
+++ b/src/command.cpp
@@ -26,7 +26,6 @@
 
 #include <QApplication>
 #include <QIcon>
-#include <QStyleFactory>
 #include <QTextStream>
 
 namespace {


### PR DESCRIPTION
## Description
Some distros may set `QT_STYLE_OVERRIDE` by default when attempting to apply a uniform style their Qt5 applications. However, this style may not necessarily exist for Qt6, which will result in a failure to load QML content. To work around this issue, check that the style exists before creating the `QApplication`, and unset the environment variable if no such style was found.

The QML fails to load `QtQuick.Controls` when this situation occurs.

## Reference
Github: #3367
JIRA: [VPN-2113](https://mozilla-hub.atlassian.net/browse/VPN-2113)

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
