### PR TITLE
Fix the cmake-generated windows installer

### DIFF
--- a/.github/workflows/windows-build.yaml
+++ b/.github/workflows/windows-build.yaml
@@ -37,16 +37,9 @@ jobs:
         run: |
           auth_header="$(git config --local --get http.https://github.com/.extraheader)"
           git clone https://github.com/mozilla-mobile/qt_static_windows --depth 1
-          cd qt_static_windows
-          cat qt6* > qt_static.tar.bz2
-          tar xf qt_static.tar.bz2
-          tar xf msm.tar.gz
           mkdir /c/MozillaVPNBuild
-          cp -r * /c/MozillaVPNBuild
-          cd ..
-          cp /c/MozillaVPNBuild/SSL/bin/libssl-1_1-x64.dll .
-          cp /c/MozillaVPNBuild/SSL/bin/libcrypto-1_1-x64.dll .
-          cp /c/MozillaVPNBuild/*.msm .
+          cat qt_static_windows/qt6* > qt6_static.tar.bz2
+          tar xf qt6_static.tar.bz2 -C /c/MozillaVPNBuild
 
       - name: Install glean depedencies
         shell: bash

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ cmake_minimum_required(VERSION 3.16)
 
 option(BUILD_DUMMY "Build for the dummy platform" OFF)
 
-project(mozillavpn VERSION 2.9.0 LANGUAGES C CXX
+project("Mozilla VPN" VERSION 2.9.0 LANGUAGES C CXX
         DESCRIPTION "A fast, secure and easy to use VPN. Built by the makers of Firefox."
         HOMEPAGE_URL "https://vpn.mozilla.org"
 )

--- a/src/cmake/windows.cmake
+++ b/src/cmake/windows.cmake
@@ -71,6 +71,14 @@ target_sources(mozillavpn PRIVATE
     wgquickprocess.h
 )
 
+# Windows sources for the GPU check workaround
+# See: https://bugreports.qt.io/browse/QTBUG-100689
+target_sources(mozillavpn PRIVATE
+    commands/commandgpucheck.cpp
+    commands/commandgpucheck.h
+    ui/gpucheck.qrc
+)
+
 # Windows Qt6 UI workaround resources
 if(${QT_VERSION} VERSION_GREATER_EQUAL 6.3.0)
     message(WARNING "Remove the Qt6 windows hack!")

--- a/src/platforms/windows/daemon/windowsfirewall.cpp
+++ b/src/platforms/windows/daemon/windowsfirewall.cpp
@@ -188,7 +188,7 @@ bool WindowsFirewall::enableKillSwitch(int vpnAdapterIndex) {
   FW_OK(allowDHCPTraffic(MED_WEIGHT, "Allow DHCP Traffic"));
   FW_OK(allowHyperVTraffic(MED_WEIGHT, "Allow Hyper-V Traffic"));
   FW_OK(allowTrafficForAppOnAll(getCurrentPath(), MAX_WEIGHT,
-                                "Allow all for MozillaVPN.exe"));
+                                "Allow all for Mozilla VPN.exe"));
   FW_OK(blockTrafficOnPort(53, MED_WEIGHT, "Block all DNS"));
   FW_OK(
       allowLoopbackTraffic(MED_WEIGHT, "Allow Loopback traffic on device %1"));

--- a/windows/installer/MozillaVPN_cmake.wxs
+++ b/windows/installer/MozillaVPN_cmake.wxs
@@ -156,7 +156,7 @@
     <!--
       Force application closed
     -->
-    <Property Id="QtExecCmdLine" Value='"[#SystemFolder]taskkill.exe" /F /IM "Mozilla VPN.exe"'/>
+    <Property Id="QtExecCmdLine" Value='"[#SystemFolder]taskkill.exe" /F /IM "Mozilla VPN.exe" /IM "MozillaVPN.exe"'/>
     <CustomAction Id="CloseApplication" BinaryKey="WixCA" DllEntry="CAQuietExec" Execute="immediate" Return="ignore"/>
     <InstallExecuteSequence>
       <Custom Action="CloseApplication" After="StopServices" />

--- a/windows/installer/MozillaVPN_cmake.wxs
+++ b/windows/installer/MozillaVPN_cmake.wxs
@@ -156,7 +156,7 @@
     <!--
       Force application closed
     -->
-    <Property Id="QtExecCmdLine" Value='"[#SystemFolder]taskkill.exe" /F /IM Mozilla VPN.exe'/>
+    <Property Id="QtExecCmdLine" Value='"[#SystemFolder]taskkill.exe" /F /IM "Mozilla VPN.exe"'/>
     <CustomAction Id="CloseApplication" BinaryKey="WixCA" DllEntry="CAQuietExec" Execute="immediate" Return="ignore"/>
     <InstallExecuteSequence>
       <Custom Action="CloseApplication" After="StopServices" />

--- a/windows/installer/MozillaVPN_cmake.wxs
+++ b/windows/installer/MozillaVPN_cmake.wxs
@@ -122,7 +122,7 @@
         <RegistryKey Root="HKLM" Key="Software\Google\Chrome\NativeMessagingHosts\mozillavpn">
           <RegistryValue Type="string" Value="[MozillaVPNFolder]\mozillavpn.json"/>
         </RegistryKey>
-        <RegistryKey Root="HKLM" Key="SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps\MozillaVPN.exe">
+        <RegistryKey Root="HKLM" Key="SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps\Mozilla VPN.exe">
           <RegistryValue Type="string" Name="DumpFolder" Value="[LocalAppDataFolder]MozillaVPN\dumps" />
           <RegistryValue Type="integer" Name="DumpCount" Value="3" />
           <RegistryValue Type="integer" Name="DumpType" Value="1" />
@@ -156,7 +156,7 @@
     <!--
       Force application closed
     -->
-    <Property Id="QtExecCmdLine" Value='"[#SystemFolder]taskkill.exe" /F /IM MozillaVPN.exe'/>
+    <Property Id="QtExecCmdLine" Value='"[#SystemFolder]taskkill.exe" /F /IM Mozilla VPN.exe'/>
     <CustomAction Id="CloseApplication" BinaryKey="WixCA" DllEntry="CAQuietExec" Execute="immediate" Return="ignore"/>
     <InstallExecuteSequence>
       <Custom Action="CloseApplication" After="StopServices" />

--- a/windows/version.rc.in
+++ b/windows/version.rc.in
@@ -12,8 +12,8 @@
 // See https://docs.microsoft.com/en-us/windows/win32/menurc/versioninfo-resource
 // for a list of all the neat metadata we can set in this file.
 VS_VERSION_INFO VERSIONINFO
-FILEVERSION     @CMAKE_PROJECT_VERSION@
-PRODUCTVERSION  @CMAKE_PROJECT_VERSION@
+FILEVERSION     @CMAKE_PROJECT_VERSION_MAJOR@, @CMAKE_PROJECT_VERSION_MINOR@, @CMAKE_PROJECT_VERSION_PATCH@
+PRODUCTVERSION  @CMAKE_PROJECT_VERSION_MAJOR@, @CMAKE_PROJECT_VERSION_MINOR@, @CMAKE_PROJECT_VERSION_PATCH@
 FILEFLAGSMASK   VS_FFI_FILEFLAGSMASK
 FILEFLAGS       (VER_DEBUG)
 FILEOS          VOS__WINDOWS32
@@ -32,7 +32,7 @@ BEGIN
             //VALUE "LegalTrademarks1", VER_LEGALTRADEMARKS1_STR
             //VALUE "LegalTrademarks2", VER_LEGALTRADEMARKS2_STR
             //VALUE "OriginalFilename", VER_ORIGINALFILENAME_STR
-            //VALUE "ProductName",      VER_PRODUCTNAME_STR
+            VALUE "ProductName",      "@CMAKE_PROJECT_NAME@"
             VALUE "ProductVersion",   "@CMAKE_PROJECT_VERSION@"
         END
     END


### PR DESCRIPTION
## Description
Some cleanup of the executable paths in the Wix installer after renaming the client from `MozillaVPN.exe` to `Mozilla VPN.exe` and the sources for the GPU check command got lost in the rebase when merging PR #3350 

## Reference
GitHub: #3528 ([VPN-2224](https://mozilla-hub.atlassian.net/browse/VPN-2224))
GitHub: #3515 ([VPN-2211](https://mozilla-hub.atlassian.net/browse/VPN-2211))

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
