### PR TITLE
Fix auto-generated BUILD_ID to include major version.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,7 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 if(NOT DEFINED BUILD_ID)
-    string(TIMESTAMP BUILD_ID "${mozillavpn_VERSION_MAJOR}.%Y%m%d%H%M")
+    string(TIMESTAMP BUILD_ID "${CMAKE_PROJECT_VERSION_MAJOR}.%Y%m%d%H%M")
     message("Generated BUILD_ID: ${BUILD_ID}")
 endif()
 


### PR DESCRIPTION
## Description
In a recent PR #3567 to get the Windows installer working again, we renamed the top-level project, and neglected to update the use of the `${mozillavpn_VERSION_MAJOR}` CMake variable accordingly.

## Reference
GitHub #3593 [(VPN-2272)](https://mozilla-hub.atlassian.net/browse/VPN-2272)

## Checklist

- [X] My code follows the style guidelines for this project
- [X] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [X] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
