### PR TITLE
Run apt-get update in PPA automation workflow

### DIFF
--- a/.github/workflows/ppa-automation.yaml
+++ b/.github/workflows/ppa-automation.yaml
@@ -23,6 +23,7 @@ jobs:
       - name: Install dependencies
         shell: bash
         run: |
+          sudo apt-get update
           sudo apt-get install golang debhelper devscripts dput-ng -y
           pip3 install -r requirements.txt
 


### PR DESCRIPTION
## Description
It appears that an Ubuntu package has been updated, to which the github runners are now out of date and are now pointing to a stale URL. To resolve the problem, we should run an `apt-get update` first to ensure we have the updated package manifest.

## Checklist
    
- [X] My code follows the style guidelines for this project
- [X] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [X] I have performed a self review of my own code
- [X] I have commented my code PARTICULARLY in hard to understand areas
- [X] I have added thorough tests where needed
