### PR TITLE
Fix wrong name for controller step event

### DIFF
--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -607,7 +607,8 @@ void Controller::setState(State state) {
   }
   logger.debug() << "Setting state:" << state;
   emit MozillaVPN::instance()->recordGleanEventWithExtraKeys(
-      GleanSample::appStep, {{"state", QVariant::fromValue(state).toString()}});
+      GleanSample::controllerStep,
+      {{"state", QVariant::fromValue(state).toString()}});
   m_state = state;
   emit stateChanged();
 }


### PR DESCRIPTION
Fixing bug in #3470 - glean event name was wrong.