### PR TITLE
ci: temporarily disable production mac signing tasks

### DIFF
--- a/taskcluster/mozillavpn_taskgraph/transforms/signing.py
+++ b/taskcluster/mozillavpn_taskgraph/transforms/signing.py
@@ -18,14 +18,15 @@ PRODUCTION_SIGNING_BUILD_TYPES = [
     "android-arm64/release",
     "android-armv7/release",
     "linux/opt",
-    "macos/opt",
 ]
 
 SIGNING_BUILD_TYPES = PRODUCTION_SIGNING_BUILD_TYPES + [
-    # Note: it appears we don't have infra for debug sign
-    # contact releng if you need it :)
-    #    "android-debug",
-    #
+    # TODO Move this to PRODUCTION_SIGNING_BUILD_TYPES once MacOS pool has
+    # updated CoT key.
+    "macos/opt",
+    # TODO We don't have infra for debug signing on Android. Contact releng if
+    # you need it :)
+    # "android-debug",
 ]
 
 


### PR DESCRIPTION
The level 3 pools these tasks are running on are using an outdated Chain
of Trust private key. We'll need to provision the workers with the new
key before we these will be useful.

Instead of turning Mac signing off completely, just turning them into
dep signing tasks to help avoid regressions.