### PR TITLE
Refactor VPNPopup

### DIFF
--- a/nebula/ui/components.qrc
+++ b/nebula/ui/components.qrc
@@ -90,6 +90,7 @@
         <file>components/VPNSettingsItem.qml</file>
         <file>components/VPNSettingsToggle.qml</file>
         <file>components/VPNSignOut.qml</file>
+        <file>components/VPNSimplePopup.qml</file>
         <file>components/VPNStackView.qml</file>
         <file>components/VPNSubscriptionOption.qml</file>
         <file>components/VPNSubtitle.qml</file>

--- a/nebula/ui/components/VPNAboutUs.qml
+++ b/nebula/ui/components/VPNAboutUs.qml
@@ -213,146 +213,41 @@ Item {
             listenForUpdateEvents=false;
         }
     }
-    VPNPopup {
+
+    VPNSimplePopup {
         id: updateAvailablePopup
-        anchors.centerIn: parent
-        maxWidth: VPNTheme.theme.desktopAppWidth
-        _popupContent: ColumnLayout {
 
-            Item {
-                // Main Image
-                Layout.alignment: Qt.AlignHCenter
-                Layout.preferredHeight: 90
-                Layout.preferredWidth: 90
-                Layout.bottomMargin: VPNTheme.theme.listSpacing
-
-                Image {
-                    anchors.fill: parent
-                    source:  "qrc:/nebula/resources/updateStatusUpdateAvailable.svg"
-                    sourceSize.height: parent.height * Screen.devicePixelRatio
-                    sourceSize.width: parent.width * Screen.devicePixelRatio
-                    fillMode: Image.PreserveAspectFit
-
-                    anchors.horizontalCenter: parent.horizontalCenter
-                    anchors.bottom: parent.bottom
-                    anchors.bottomMargin: VPNTheme.theme.listSpacing * 0.5
-                }
-            }
-
-            VPNMetropolisLabel {
-                color: VPNTheme.theme.fontColorDark
-                horizontalAlignment: Text.AlignHCenter
-                font.pixelSize: VPNTheme.theme.fontSizeLarge
-                text: VPNl18n.UpdateButtonTitleOnUpdate
-                Layout.bottomMargin: VPNTheme.theme.listSpacing
-                Layout.fillWidth: true
-            }
-
-            VPNTextBlock {
-                horizontalAlignment: Text.AlignHCenter
-                text: VPNl18n.UpdateButtonDescriptionOnUpdate
-                Layout.fillWidth: true
-                Layout.preferredWidth: parent.width
-            }
-
+        anchors.centerIn: Overlay.overlay
+        imageSrc: "qrc:/nebula/resources/updateStatusUpdateAvailable.svg"
+        imageSize: Qt.size(80, 80)
+        title: VPNl18n.UpdateButtonTitleOnUpdate
+        description: VPNl18n.UpdateButtonDescriptionOnUpdate
+        buttons: [
             VPNButton {
-                radius: VPNTheme.theme.cornerRadius
-                Layout.fillWidth: true
-                Layout.alignment: Qt.AlignBottom
-                Layout.topMargin: VPNTheme.theme.vSpacing
                 text: VPNl18n.UpdateButtonActionOnUpdate
                 onClicked: {
                     updateAvailablePopup.close()
                     mainStackView.push("qrc:/ui/views/ViewUpdate.qml");
                 }
-
-                Image {
-                    anchors {
-                        right: parent.contentItem.right
-                        rightMargin: VPNTheme.theme.windowMargin
-                        verticalCenter: parent.verticalCenter
-                    }
-                    fillMode: Image.PreserveAspectFit
-                    source: "qrc:/nebula/resources/arrow-forward-white.svg"
-                    sourceSize.height: VPNTheme.theme.iconSize * 1.5
-                    sourceSize.width: VPNTheme.theme.iconSize * 1.5
-                    visible: false
-                }
             }
-
-        }
+        ]
     }
 
-
-    VPNPopup {
+    VPNSimplePopup {
         id: noUpdateAvailablePopup
-        anchors.centerIn: parent
-        maxWidth: VPNTheme.theme.desktopAppWidth
-        _popupContent: ColumnLayout {
 
-            Item {
-                // Main Image
-                Layout.alignment: Qt.AlignHCenter
-                Layout.preferredHeight: 90
-                Layout.preferredWidth: 90
-                Layout.bottomMargin: VPNTheme.theme.listSpacing
-
-                Image {
-                    anchors.fill: parent
-                    source: "qrc:/nebula/resources/updateStatusUpToDate.svg"
-                    sourceSize.height: parent.height * Screen.devicePixelRatio
-                    sourceSize.width: parent.width * Screen.devicePixelRatio
-                    fillMode: Image.PreserveAspectFit
-
-                    anchors.horizontalCenter: parent.horizontalCenter
-                    anchors.bottom: parent.bottom
-                    anchors.bottomMargin: VPNTheme.theme.listSpacing * 0.5
-                }
-            }
-
-            VPNMetropolisLabel {
-                color: VPNTheme.theme.fontColorDark
-                horizontalAlignment: Text.AlignHCenter
-                font.pixelSize: VPNTheme.theme.fontSizeLarge
-                text: VPNl18n.UpdateButtonTitleNoUpdate
-
-                Layout.bottomMargin: VPNTheme.theme.listSpacing
-                Layout.fillWidth: true
-            }
-
-            VPNTextBlock {
-                horizontalAlignment: Text.AlignHCenter
-                text: VPNl18n.UpdateButtonDescriptionNoUpdate2
-                Layout.fillWidth: true
-                Layout.preferredWidth: parent.width
-            }
-
+        anchors.centerIn: Overlay.overlay
+        imageSrc: "qrc:/nebula/resources/updateStatusUpToDate.svg"
+        imageSize: Qt.size(80, 80)
+        title: VPNl18n.UpdateButtonTitleNoUpdate
+        description: VPNl18n.UpdateButtonDescriptionNoUpdate2
+        buttons: [
             VPNButton {
-                radius: VPNTheme.theme.cornerRadius
-                Layout.fillWidth: true
-                Layout.alignment: Qt.AlignBottom
-                Layout.topMargin: VPNTheme.theme.vSpacing
                 text: VPNl18n.UpdateButtonActionNoUpdate
                 onClicked: {
                     noUpdateAvailablePopup.close();
                 }
-
-                Image {
-                    anchors {
-                        right: parent.contentItem.right
-                        rightMargin: VPNTheme.theme.windowMargin
-                        verticalCenter: parent.verticalCenter
-                    }
-                    fillMode: Image.PreserveAspectFit
-                    source: "qrc:/nebula/resources/arrow-forward-white.svg"
-                    sourceSize.height: VPNTheme.theme.iconSize * 1.5
-                    sourceSize.width: VPNTheme.theme.iconSize * 1.5
-                    visible: false
-                }
             }
-
-        }
+        ]
     }
-
-
 }

--- a/nebula/ui/components/VPNFeatureTourPopup.qml
+++ b/nebula/ui/components/VPNFeatureTourPopup.qml
@@ -10,7 +10,6 @@ VPNPopup {
     id: root
 
     anchors.centerIn: parent
-    maxWidth: VPNTheme.theme.desktopAppWidth
     _popupContent: VPNFeatureTour {
         id: featureTour
 

--- a/nebula/ui/components/VPNPopup.qml
+++ b/nebula/ui/components/VPNPopup.qml
@@ -12,55 +12,61 @@ import compat 0.1
 Popup {
     id: popup
 
-    property int maxWidth: ({})
-    property alias _popupContent: popupContent.data
+    default property alias _popupContent: popupContent.data
+    property alias popupContentItem: popupContent //this is exposed so popupContent implicitHeight can (and should) be set externally
+    property bool showCloseButton: true
+    property bool startContentBeneathCloseButton: showCloseButton //popup content will appear under the close button
 
     closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
-    enabled: true
     focus: true
     modal: true
-    width: Math.min(window.width - VPNTheme.theme.vSpacing, maxWidth)
-    horizontalPadding: VPNTheme.theme.popupMargin
+    width: Math.min(window.width - (VPNTheme.theme.windowMargin * 2), 500)
+    contentHeight: startContentBeneathCloseButton ? closeButton.height + closeButton.anchors.topMargin + popupContent.implicitHeight + popupContent.anchors.topMargin: popupContent.implicitHeight
+    horizontalPadding: 0
+    verticalPadding: 0
 
-    contentItem: ColumnLayout {
-        spacing: 0
-        // Close button
-        VPNIconButton {
-            id: closeButton
+    // Close button
+    VPNIconButton {
+        id: closeButton
 
-            accessibleName: qsTrId("menubar.file.close")
-            onClicked: {
-                popup.close();
-            }
+        anchors.top: parent.top
+        anchors.right: parent.right
+        anchors.topMargin: VPNTheme.theme.windowMargin / 2
+        anchors.rightMargin: VPNTheme.theme.windowMargin / 2
 
-            Layout.preferredHeight: VPNTheme.theme.rowHeight
-            Layout.preferredWidth: VPNTheme.theme.rowHeight
-            Layout.margins: VPNTheme.theme.windowMargin / 2
-            Layout.alignment: Qt.AlignRight
+        height: VPNTheme.theme.rowHeight
+        width: VPNTheme.theme.rowHeight
+        visible: showCloseButton
 
-            Image {
-                id: closeImage
-                anchors.centerIn: closeButton
-                fillMode: Image.PreserveAspectFit
-                source: "qrc:/nebula/resources/close-darker.svg"
-                sourceSize.height: VPNTheme.theme.iconSize
-                sourceSize.width: VPNTheme.theme.iconSize
-            }
+        accessibleName: qsTrId("menubar.file.close")
+
+        onClicked: {
+            popup.close();
         }
 
-        ColumnLayout {
-            id: popupContent
-            Layout.leftMargin: VPNTheme.theme.vSpacing
-            Layout.rightMargin: VPNTheme.theme.vSpacing
-            Layout.bottomMargin: VPNTheme.theme.vSpacing
-            Layout.alignment: Qt.AlignHCenter
+        Image {
+            anchors.centerIn: closeButton
+
+            fillMode: Image.PreserveAspectFit
+            source: "qrc:/nebula/resources/close-darker.svg"
+            sourceSize.height: VPNTheme.theme.iconSize
+            sourceSize.width: VPNTheme.theme.iconSize
         }
+    }
+
+    Item {
+        id: popupContent
+
+        anchors.top: startContentBeneathCloseButton ? closeButton.bottom : undefined
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.topMargin: startContentBeneathCloseButton ? VPNTheme.theme.windowMargin / 2 : 0
     }
 
     background: Rectangle {
         id: popupBackground
 
-        anchors.fill: contentItem
+        anchors.fill: parent
         color: VPNTheme.theme.bgColor
         radius: 8
 

--- a/nebula/ui/components/VPNRemoveDevicePopup.qml
+++ b/nebula/ui/components/VPNRemoveDevicePopup.qml
@@ -9,48 +9,49 @@ import QtQuick.Layouts 1.14
 import Mozilla.VPN 1.0
 import compat 0.1
 
-Popup {
+VPNSimplePopup {
     id: popup
 
     property var deviceName
     property var devicePublicKey
     property var wasmView
 
-    anchors.centerIn: parent
-    closePolicy: Popup.CloseOnEscape
-    focus: true
-    leftInset: VPNTheme.theme.windowMargin
-    rightInset: VPNTheme.theme.windowMargin
-    modal: true
-    verticalPadding: VPNTheme.theme.popupMargin
+    anchors.centerIn: Overlay.overlay
+    topPadding: 24
+    showCloseButton: false
+    imageSrc: "qrc:/nebula/resources/devicesRemove.svg"
+    imageSize: Qt.size(116, 80)
+    //% "Remove device?"
+    title: qsTrId("vpn.devices.removeDeviceQuestion")
+    //: %1 is the name of the device being removed. The name is displayed on purpose on a new line.
+    //% "Please confirm you would like to remove\n%1."
+    description: qsTrId("vpn.devices.deviceRemovalConfirm").replace("\n", " ").arg(popup.deviceName)
+    buttons: [
+        VPNPopupButton {
+            //: This is the “remove” device button.
+            //% "Remove"
+            buttonText: qsTrId("vpn.devices.removeDeviceButton")
+            buttonTextColor: VPNTheme.theme.white
+            colorScheme: VPNTheme.theme.redButton
+            onClicked: {
+                VPN.removeDeviceFromPublicKey(popup.devicePublicKey);
+                if (vpnFlickable.state === "deviceLimit") {
+                    // there is no further action the user can take on the deviceList
+                    // so leave the modal open until the user is redirected back to the main view
+                    col.opacity = .5
+                    return;
+                }
 
-    // TODO: We can not use Accessible type on Popup because it does not inherit
-    // from an Item. The code below generates the following warning:
-    // "...Accessible must be attached to an Item..."
-    // See https://github.com/mozilla-mobile/mozilla-vpn-client/issues/322 for
-    // more details.
-    // Accessible.role: Accessible.Dialog
-    // Accessible.name: popupTitle.text
-
-    enter: Transition {
-        NumberAnimation {
-            property: "opacity"
-            duration: 120
-            from: 0.0
-            to: 1.0
-            easing.type: Easing.InOutQuad
+                popup.close();
+            }
+            isCancelBtn: false
+        },
+        VPNCancelButton {
+            onClicked: {
+                popup.close();
+            }
         }
-    }
-
-    exit: Transition {
-        NumberAnimation {
-            property: "opacity"
-            duration: 120
-            from: 1.0
-            to: 0.0
-            easing.type: Easing.InOutQuad
-        }
-    }
+    ]
 
     onClosed: {
         // When closing the dialog, put the focus back on the
@@ -62,152 +63,5 @@ Popup {
         if (deviceList.focusedIconButton) {
             deviceList.focusedIconButton.forceActiveFocus();
         }
-    }
-
-    background: Rectangle {
-        id: popupBackground
-
-        anchors.margins: 0
-        color: VPNTheme.theme.bgColor
-        radius: 8
-
-        VPNDropShadow {
-            id: popupShadow
-
-            anchors.fill: popupBackground
-            cached: true
-            color: "black"
-            opacity: 0.2
-            radius: 16
-            source: popupBackground
-            spread: 0.1
-            transparentBorder: true
-            verticalOffset: 4
-            z: -1
-        }
-    }
-
-    contentItem: Item {
-        id: contentRoot
-
-        ColumnLayout {
-            id: col
-
-            anchors.centerIn: contentRoot
-            spacing: 0
-            width: contentRoot.width - VPNTheme.theme.windowMargin / 2
-
-            Image {
-                fillMode: Image.PreserveAspectFit
-                source: "qrc:/nebula/resources/devicesRemove.svg"
-                sourceSize: Qt.size(116, 80)
-
-                Layout.alignment: Qt.AlignHCenter
-                Layout.preferredHeight: 80
-            }
-
-            VPNMetropolisLabel {
-                id: popupTitle
-
-                color: VPNTheme.theme.fontColorDark
-                font.pixelSize: VPNTheme.theme.fontSizeLarge
-                horizontalAlignment: Text.AlignHCenter
-
-                Layout.alignment: Qt.AlignHCenter
-                Layout.bottomMargin: VPNTheme.theme.vSpacingSmall
-                Layout.fillWidth: true
-                Layout.leftMargin: VPNTheme.theme.popupMargin
-                Layout.minimumHeight: 36
-                Layout.rightMargin: VPNTheme.theme.popupMargin
-                Layout.topMargin: 4
-
-                //% "Remove device?"
-                text: qsTrId("vpn.devices.removeDeviceQuestion")
-                verticalAlignment: Text.AlignBottom
-            }
-
-            VPNTextBlock {
-                id: popupText
-
-                property string textString
-
-                color: VPNTheme.theme.fontColor
-                font.pixelSize: 15
-                horizontalAlignment: Text.AlignHCenter
-                Layout.alignment: Qt.AlignHCenter
-                Layout.bottomMargin: VPNTheme.theme.vSpacing
-                Layout.leftMargin: VPNTheme.theme.popupMargin
-                Layout.rightMargin: VPNTheme.theme.popupMargin
-                Layout.fillWidth: true
-                lineHeight: 22;
-                text: textString.arg(popup.deviceName)
-                wrapMode: Text.WrapAtWordBoundaryOrAnywhere
-
-                Component.onCompleted: {
-                    //: %1 is the name of the device being removed. The name is displayed on purpose on a new line.
-                    //% "Please confirm you would like to remove\n%1."
-                    textString = qsTrId("vpn.devices.deviceRemovalConfirm").replace("\n", " ")
-                }
-            }
-
-            GridLayout {
-                id: buttonsContainer
-
-                property int gridSpacing: 16
-
-                columnSpacing: gridSpacing
-                rowSpacing: gridSpacing
-                columns: 1
-
-                Layout.fillWidth: true
-                Layout.minimumHeight: 40
-                Layout.leftMargin: VPNTheme.theme.popupMargin
-                Layout.rightMargin: VPNTheme.theme.popupMargin
-                Layout.topMargin: gridSpacing / 2
-
-                VPNPopupButton {
-                    id: removeBtn
-
-                    //: This is the “remove” device button.
-                    //% "Remove"
-                    buttonText: qsTrId("vpn.devices.removeDeviceButton")
-                    buttonTextColor: VPNTheme.theme.white
-                    colorScheme: VPNTheme.theme.redButton
-                    onClicked: {
-                        VPN.removeDeviceFromPublicKey(popup.devicePublicKey);
-                        if (vpnFlickable.state === "deviceLimit") {
-                            // there is no further action the user can take on the deviceList
-                            // so leave the modal open until the user is redirected back to the main view
-                            col.opacity = .5
-                            return;
-                        }
-
-                        popup.close();
-                    }
-                    isCancelBtn: false
-                }
-
-                VPNCancelButton {
-                    Layout.fillWidth: true
-                    Layout.alignment: Qt.AlignCenter
-
-                    onClicked: {
-                        popup.close();
-                    }
-                }
-            }
-        }
-
-        Overlay.modal: Rectangle {
-            id: overlayBackground
-            color: VPNTheme.theme.overlayBackground
-
-            Behavior on opacity {
-                NumberAnimation {
-                    duration: 175
-                }
-            }
-        }
-
     }
 }

--- a/nebula/ui/components/VPNServerUnavailablePopup.qml
+++ b/nebula/ui/components/VPNServerUnavailablePopup.qml
@@ -24,9 +24,4 @@ VPNSimplePopup {
                 window.goToServersView();
             }
         }]
-
-    onHeightChanged: {
-        console.log(height)
-    }
-
 }

--- a/nebula/ui/components/VPNServerUnavailablePopup.qml
+++ b/nebula/ui/components/VPNServerUnavailablePopup.qml
@@ -4,62 +4,29 @@
 
 import QtQuick 2.0
 import QtQuick.Layouts 1.14
+import QtQuick.Controls 2.14
 
 import Mozilla.VPN 1.0
 
-VPNPopup {
+VPNSimplePopup {
     id: root
 
     anchors.centerIn: parent
-    maxWidth: VPNTheme.theme.desktopAppWidth
-    _popupContent: ColumnLayout {
-        id: popupContentItem
-
-        Item {
-            Layout.alignment: Qt.AlignHCenter
-            Layout.bottomMargin: VPNTheme.theme.listSpacing * 1.5
-            Layout.preferredHeight: 80
-            Layout.preferredWidth: 80
-
-            Image {
-                anchors.fill: parent
-                source: "qrc:/nebula/resources/server-unavailable.svg"
-                sourceSize.height: parent.height
-                sourceSize.width: parent.width
-                fillMode: Image.PreserveAspectFit
-            }
-        }
-
-        VPNMetropolisLabel {
-            color: VPNTheme.theme.fontColorDark
-            horizontalAlignment: Text.AlignHCenter
-            font.pixelSize: VPNTheme.theme.fontSizeLarge
-            text: VPNl18n.ServerUnavailableModalHeaderText
-
-            Layout.bottomMargin: VPNTheme.theme.listSpacing
-            Layout.fillWidth: true
-        }
-
-        VPNTextBlock {
-            horizontalAlignment: Text.AlignHCenter
-            text: VPNl18n.ServerUnavailableModalBodyText
-
-            Layout.fillWidth: true
-            Layout.preferredWidth: parent.width
-        }
-
+    imageSrc: "qrc:/nebula/resources/server-unavailable.svg"
+    imageSize: Qt.size(80, 80)
+    title: VPNl18n.ServerUnavailableModalHeaderText
+    description: VPNl18n.ServerUnavailableModalBodyText
+    buttons: [
         VPNButton {
-            radius: VPNTheme.theme.cornerRadius
             text: VPNl18n.ServerUnavailableModalButtonLabel
-
-            Layout.fillWidth: true
-            Layout.alignment: Qt.AlignBottom
-            Layout.topMargin: VPNTheme.theme.vSpacing
-
-            onClicked: () => {
+            onClicked: {
                 root.close();
                 window.goToServersView();
             }
-        }
+        }]
+
+    onHeightChanged: {
+        console.log(height)
     }
+
 }

--- a/nebula/ui/components/VPNSimplePopup.qml
+++ b/nebula/ui/components/VPNSimplePopup.qml
@@ -1,0 +1,74 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import QtQuick 2.15
+import QtQuick.Layouts 1.15
+
+import Mozilla.VPN 1.0
+
+VPNPopup {
+    property alias imageSrc: image.source
+    property alias imageSize: image.sourceSize
+    property alias title: titleText.text
+    property alias description: descriptionText.text
+    property list<VPNButtonBase> buttons
+
+    popupContentItem.implicitHeight: popupLayout.implicitHeight
+
+    ColumnLayout {
+        id: popupLayout
+
+        anchors.fill: parent
+        anchors.leftMargin: VPNTheme.theme.popupMargin
+        anchors.rightMargin: VPNTheme.theme.popupMargin
+
+        spacing: 0
+
+        Image {
+            id: image
+            Layout.alignment: Qt.AlignHCenter
+            asynchronous: true
+        }
+
+        VPNMetropolisLabel {
+            id: titleText
+
+            Layout.topMargin: VPNTheme.theme.vSpacingSmall
+            Layout.fillWidth: true
+
+            color: VPNTheme.theme.fontColorDark
+            font.pixelSize: VPNTheme.theme.fontSizeLarge
+            lineHeight: VPNTheme.theme.vSpacingSmall * 2
+
+        }
+
+        VPNInterLabel {
+            id: descriptionText
+
+            Layout.topMargin: VPNTheme.theme.vSpacingSmall / 2
+            Layout.fillWidth: true
+
+            color: VPNTheme.theme.fontColor
+        }
+
+        ColumnLayout {
+            Layout.topMargin: VPNTheme.theme.vSpacingSmall * 2
+
+            spacing: 0
+            data: buttons
+            visible: buttons.length > 0
+
+            Component.onCompleted: {
+                for(var i = 0 ; i < buttons.length; i++) {
+                    buttons[i].Layout.fillWidth = true
+                    if(i > 0) buttons[i].Layout.topMargin = VPNTheme.theme.vSpacingSmall
+                }
+            }
+        }
+
+        Item {
+            Layout.preferredHeight: VPNTheme.theme.vSpacing
+        }
+    }
+}

--- a/nebula/ui/components/inAppAuth/VPNInAppAuthenticationErrorPopup.qml
+++ b/nebula/ui/components/inAppAuth/VPNInAppAuthenticationErrorPopup.qml
@@ -4,57 +4,30 @@
 
 import QtQuick 2.5
 import QtQuick.Layouts 1.14
+import QtQuick.Controls 2.15
 
 import Mozilla.VPN 1.0
 import components 0.1
 
-VPNPopup {
+VPNSimplePopup {
     id: authError
-    anchors.centerIn: parent
-    width: Math.min(parent.width - VPNTheme.theme.windowMargin * 2, VPNTheme.theme.maxHorizontalContentWidth)
-    height: Math.min(parent.height - VPNTheme.theme.windowMargin * 2, implicitHeight + VPNTheme.theme.windowMargin * 2)
-    maxWidth: Math.min(parent.width * 0.83, VPNTheme.theme.maxHorizontalContentWidth)
 
-    _popupContent:
-        ColumnLayout {
-            id: authErrorContent
-            spacing: VPNTheme.theme.vSpacing
-
-            Image {
-                source: "qrc:/ui/resources/updateRequired.svg"
-                antialiasing: true
-                sourceSize.height: 80
-                sourceSize.width: 80
-                Layout.alignment: Qt.AlignHCenter
-            }
-
-            VPNHeadline {
-                text: VPNl18n.InAppAuthSignInFailedPopupTitle
-                width: undefined
-                Layout.fillWidth: true
-            }
-
-            VPNTextBlock {
-                id: authErrorMessage
-                text: ""
-                horizontalAlignment: Text.AlignHCenter
-                Layout.preferredWidth: parent.width
-                Layout.fillWidth: true
-            }
-
-            VPNButton {
-                text: VPNl18n.CaptivePortalAlertButtonTextPreActivation
-                onClicked: authError.close()
+    anchors.centerIn: Overlay.overlay
+    imageSrc: "qrc:/ui/resources/updateRequired.svg"
+    imageSize: Qt.size(80, 80)
+    title: VPNl18n.InAppAuthSignInFailedPopupTitle
+    description: ""
+    buttons: [
+        VPNButton {
+            text: VPNl18n.CaptivePortalAlertButtonTextPreActivation
+            onClicked: {
+                authError.close()
             }
         }
+    ]
 
     Connections {
         target: VPNAuthInApp
-
-        function openErrorModalAndForceFocus() {
-            authError.open();
-            authErrorContent.forceActiveFocus();
-        }
 
         function retryAfterSecToMin(retryAfterSec) {
             if (retryAfterSec <= 0) {
@@ -67,8 +40,8 @@ VPNPopup {
         }
 
         function showGenericAuthError() {
-            authErrorMessage.text = VPNl18n.InAppSupportWorkflowSupportErrorText
-            openErrorModalAndForceFocus();
+            authError.description = VPNl18n.InAppSupportWorkflowSupportErrorText
+            authError.open()
         }
 
         function onErrorOccurred(e, retryAfterSec) {
@@ -86,16 +59,16 @@ VPNPopup {
                 break;
 
             case VPNAuthInApp.ErrorEmailTypeNotSupported:
-                authErrorMessage.text = VPNl18n.InAppAuthProblemEmailTypeNotSupported
-                openErrorModalAndForceFocus();
+                authError.description = VPNl18n.InAppAuthProblemEmailTypeNotSupported
+                authError.open()
                 break;
             case VPNAuthInApp.ErrorConnectionTimeout:
-                authErrorMessage.text = qsTrId("vpn.alert.noInternet")
-                openErrorModalAndForceFocus();
+                authError.description = qsTrId("vpn.alert.noInternet")
+                authError.open()
                 break;
             case VPNAuthInApp.ErrorFailedToSendEmail:
-                authErrorMessage.text =VPNl18n.InAppAuthProblemSendingEmailErrorMessage
-                openErrorModalAndForceFocus();
+                authError.description = VPNl18n.InAppAuthProblemSendingEmailErrorMessage
+                authError.open()
                 break;
 
             case VPNAuthInApp.ErrorServerUnavailable:
@@ -105,11 +78,11 @@ VPNPopup {
             case VPNAuthInApp.ErrorTooManyRequests:
                 const retryAfterMin = retryAfterSecToMin(retryAfterSec);
                 if (retryAfterMin === 1) {
-                    authErrorMessage.text = VPNl18n.InAppAuthSignInBlockedForOneMinute;
+                    authError.description = VPNl18n.InAppAuthSignInBlockedForOneMinute;
                 } else {
-                    authErrorMessage.text = VPNl18n.InAppAuthSignInFailedPopupDescription
+                    authError.description = VPNl18n.InAppAuthSignInFailedPopupDescription
                 }
-                openErrorModalAndForceFocus();
+                authError.open()
                 break;
             }
         }

--- a/nebula/ui/components/qmldir
+++ b/nebula/ui/components/qmldir
@@ -78,6 +78,7 @@ VPNServerUnavailablePopup 0.1 VPNServerUnavailablePopup.qml
 VPNSettingsItem 0.1 VPNSettingsItem.qml
 VPNSettingsToggle 0.1 VPNSettingsToggle.qml
 VPNSignOut 0.1 VPNSignOut.qml
+VPNSimplePopup 0.1 VPNSimplePopup.qml
 VPNStackView 0.1 VPNStackView.qml
 VPNSubscriptionOption 0.1 VPNSubscriptionOption.qml
 VPNSubtitle 0.1 VPNSubtitle.qml


### PR DESCRIPTION
## Description

- Refactor VPNPopup to:
	- Parent the background to the popup instead of the content
	- Be the correct width
	- Have a more dynamic layout with toggle-able "showCloseButton" property and allow the contents of the popup to start beneath the close button OR at the top of the popup
- Add VPNSimplePopup to be used for *most* of our popups that neatly displays just an image + title + description + action button(s)
- Refactor current VPNPopup based modals (Check for updates, server unavailable, in-app authentication errors) to work with  VPNSimplePopup
- Refactor current Popup based modals (Remove device) to work with VPNSimplePopup

Note: This patch will break the "What's new" modal - but that will quickly be resolved in #3625 since that feature is being modified

## Reference

[VPN-2283: [Tech Debt] - Refactor VPNPopup Component](https://mozilla-hub.atlassian.net/browse/VPN-2283)

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
