### PR TITLE
Nit: Update scrollbar visibility

### DIFF
--- a/nebula/ui/components/VPNFlickable.qml
+++ b/nebula/ui/components/VPNFlickable.qml
@@ -19,7 +19,7 @@ Flickable {
 
     function ensureVisible(item) {
         let yPosition = item.mapToItem(contentItem, 0, 0).y;
-        if (!   contentExceedsHeight || item.skipEnsureVisible || yPosition < 0) {
+        if (!contentExceedsHeight || item.skipEnsureVisible || yPosition < 0) {
             return;
         }
 

--- a/nebula/ui/components/VPNFlickable.qml
+++ b/nebula/ui/components/VPNFlickable.qml
@@ -12,14 +12,14 @@ Flickable {
     id: vpnFlickable
 
     property var flickContentHeight
-    property var windowHeightExceedsContentHeight: (window.safeContentHeight > flickContentHeight)
+    property bool contentExceedsHeight: height < flickContentHeight
     property bool hideScollBarOnStackTransition: false
 
     clip: true
 
     function ensureVisible(item) {
         let yPosition = item.mapToItem(contentItem, 0, 0).y;
-        if (windowHeightExceedsContentHeight || item.skipEnsureVisible || yPosition < 0) {
+        if (!   contentExceedsHeight || item.skipEnsureVisible || yPosition < 0) {
             return;
         }
 
@@ -106,7 +106,7 @@ Flickable {
         minimumSize: 0
 
         opacity: hideScollBarOnStackTransition && (vpnFlickable.StackView.status !== StackView.Active) ? 0 : 1
-        visible: vpnFlickable.interactive
+        visible: contentExceedsHeight
 
         Behavior on opacity {
             PropertyAnimation {

--- a/src/ui/views/ViewMultiHop.qml
+++ b/src/ui/views/ViewMultiHop.qml
@@ -17,7 +17,6 @@ StackView {
         id: vpnFlickable
 
         flickContentHeight: col.implicitHeight + col.y + VPNTheme.theme.windowMargin
-        windowHeightExceedsContentHeight: parent.height > flickContentHeight
         contentHeight: flickContentHeight
 
         ColumnLayout {


### PR DESCRIPTION
## Description

Tweaks to VPNFlickable so that scrollbar is not visible when scrolling is unnecessary
<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>


<tr>
<td>
<img width="300" alt="Screen Shot 2022-06-02 at 12 19 55 PM" src="https://user-images.githubusercontent.com/22355127/171699919-8aee9bd8-5d7e-412b-bbd8-a623ae300b48.png">
</td>
<td>
<img width="300" alt="Screen Shot 2022-06-02 at 1 23 39 PM" src="https://user-images.githubusercontent.com/22355127/171699989-3448483b-d481-42fa-866a-e5edd62c0943.png">

</td>
</tr>

<tr>
<td>
<img width="300" alt="Screen Shot 2022-06-02 at 1 22 45 PM" src="https://user-images.githubusercontent.com/22355127/171699843-b1c7ba71-94a4-4108-8171-48b1b7f836c9.png">
</td>
<td>
<img width="300" alt="Screen Shot 2022-06-02 at 1 19 03 PM" src="https://user-images.githubusercontent.com/22355127/171699741-b622c548-b901-4696-9db7-05c6e4cb634a.png">
</td>
</tr>

<tr>
<td>
<img width="300" alt="Screen Shot 2022-06-02 at 12 20 37 PM" src="https://user-images.githubusercontent.com/22355127/171700067-1a0141a7-ee0b-4048-aeff-4b9aade75848.png">
</td>
<td>
<img width="300" alt="Screen Shot 2022-06-02 at 1 24 21 PM" src="https://user-images.githubusercontent.com/22355127/171700139-4fc8e1ab-e258-4fa8-9d3e-87bf6397f2eb.png">
</td>
</tr>

<tr></tr>
</table>


## Reference

   #3610 

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
