### PR TITLE
WIP (really) - Proper Android crash Reporting!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,8 +51,6 @@ node_modules
 
 asset_catalog_compiler.Info.plist
 
-!3rdparty/breakpad/
-
 # Ignore files that might be added by Android Studio
 # if someone opens the android/ subproject
 android/.gradle/

--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,8 @@ node_modules
 
 asset_catalog_compiler.Info.plist
 
+!3rdparty/breakpad/
+
 # Ignore files that might be added by Android Studio
 # if someone opens the android/ subproject
 android/.gradle/
@@ -184,3 +186,4 @@ extension/bridge/target
 extension/bridge/vendor
 extension/bridge/.cargo_home
 extension/bridge/.cargo
+

--- a/.gitmodules
+++ b/.gitmodules
@@ -28,6 +28,4 @@
 [submodule "3rdparty/adjust-android-sdk"]
 	path = 3rdparty/adjust-android-sdk
 	url = https://github.com/adjust/android_sdk
-[submodule ".\\3rdparty\\breakpad"]
-	path = .\\3rdparty\\breakpad
-	url = https://chromium.googlesource.com/breakpad/breakpad
+

--- a/.gitmodules
+++ b/.gitmodules
@@ -25,3 +25,9 @@
 [submodule "3rdparty/adjust-android-sdk"]
 	path = 3rdparty/adjust-android-sdk
 	url = https://github.com/adjust/android_sdk
+[submodule "3rdparty/adjust-android-sdk"]
+	path = 3rdparty/adjust-android-sdk
+	url = https://github.com/adjust/android_sdk
+[submodule ".\\3rdparty\\breakpad"]
+	path = .\\3rdparty\\breakpad
+	url = https://chromium.googlesource.com/breakpad/breakpad

--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -69,6 +69,7 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
             android:process=":QtOnlyProcess"
             android:permission="android.permission.BIND_VPN_SERVICE">
         </service>
+
     </application>
 
 </manifest>

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -24,6 +24,9 @@ repositories {
 
 allprojects {
     repositories {
+        maven {
+            url "https://maven.mozilla.org/maven2"
+        }
         mavenCentral()
         google()
     }
@@ -48,6 +51,8 @@ dependencies {
     implementation Dependencies.androidx_security_security_identity_credential
     implementation Dependencies.com_google_android_gms_play_services_ads_identifier
     implementation Dependencies.org_jetbrains_kotlinx_kotlinx_serialization_json
+    implementation "org.mozilla.components:lib-crash:102.0.3"
+    implementation "org.mozilla.components:concept-base:102.0.3"
     coreLibraryDesugaring Dependencies.com_android_tools_desugar_jdk_libs
 }
 

--- a/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/VPNService.kt
+++ b/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/VPNService.kt
@@ -67,8 +67,8 @@ class VPNService : android.net.VpnService() {
         intent?.let {
             if (intent.getBooleanExtra("startOnly", false)) {
                 Log.i(tag, "Start only!")
-                // If this is a Start Only request, the client will soon 
-                // bind to the service anyway. 
+                // If this is a Start Only request, the client will soon
+                // bind to the service anyway.
                 // We should return START_NOT_STICKY so that after an unbind()
                 // the OS will not try to restart the service.
                 return START_NOT_STICKY

--- a/android/src/org/mozilla/firefox/vpn/qt/VPNApplication.java
+++ b/android/src/org/mozilla/firefox/vpn/qt/VPNApplication.java
@@ -17,10 +17,12 @@ import org.mozilla.firefox.vpn.BuildConfig;
 public class VPNApplication extends org.qtproject.qt.android.bindings.QtApplication {
 
   private static VPNApplication instance;
+  private VPNCrashReporterUtil reporter = null;
 
   @Override
   public void onCreate() {
       super.onCreate();
+      reporter = new VPNCrashReporterUtil(this.getApplicationContext());
       VPNApplication.instance = this;
   }
 

--- a/android/src/org/mozilla/firefox/vpn/qt/VPNCrashReporterUtil.kt
+++ b/android/src/org/mozilla/firefox/vpn/qt/VPNCrashReporterUtil.kt
@@ -1,0 +1,57 @@
+package org.mozilla.firefox.vpn.qt
+
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+import mozilla.components.lib.crash.CrashReporter
+import mozilla.components.lib.crash.handler.CrashHandlerService
+
+
+class VPNCrashReporterUtil(context: Context) {
+    init {
+        val reporter = CrashReporter(context,
+            // Always prompt
+            shouldPrompt = CrashReporter.Prompt.ALWAYS,
+            services = listOf(
+            VPNTombStoneService(context)
+          )
+        )
+        reporter.install(context)
+        Log.i("BASTI", "INSTALLED REPORTER")
+    }
+    companion object{
+
+        const val ACTION_CRASHED = "org.mozilla.gecko.ACTION_CRASHED";
+        const val EXTRA_MINIDUMP_PATH = "minidumpPath";
+        const val EXTRA_EXTRAS_PATH = "extrasPath";
+        const val EXTRA_CRASH_PROCESS_TYPE = "processType"
+
+
+        @JvmStatic
+        @Suppress("unused", "DIVISION_BY_ZERO") // JNI caller
+        fun testUncaughtException(){
+            val oops = 10/0
+        }
+        @JvmStatic
+        @Suppress("unused") // JNI caller
+        fun testNullAccessException(){
+            val ctx : Context? = null;
+            ctx!!.openFileInput("HELLO NULL");
+        }
+
+        @JvmStatic
+        @Suppress("unused") // JNI caller
+        fun nativePanic(miniDumpFilepath:String){
+            // Note to self, this is undocumented ... i found this in gecko.
+            val context = VPNActivity.getInstance()
+            Log.e("BASTI", miniDumpFilepath);
+
+            val i = Intent(ACTION_CRASHED, null, context, CrashHandlerService::class.java).apply {
+                putExtra(EXTRA_MINIDUMP_PATH, miniDumpFilepath)
+                putExtra(EXTRA_EXTRAS_PATH, "") // We don't have extras for now
+                putExtra(EXTRA_CRASH_PROCESS_TYPE, "MAIN") // We only have the QT Process attached to this.
+            }
+            context.startService(i)
+        }
+    }
+}

--- a/android/src/org/mozilla/firefox/vpn/qt/VPNCrashReporterUtil.kt
+++ b/android/src/org/mozilla/firefox/vpn/qt/VPNCrashReporterUtil.kt
@@ -6,45 +6,44 @@ import android.util.Log
 import mozilla.components.lib.crash.CrashReporter
 import mozilla.components.lib.crash.handler.CrashHandlerService
 
-
 class VPNCrashReporterUtil(context: Context) {
     init {
-        val reporter = CrashReporter(context,
+        val reporter = CrashReporter(
+            context,
             // Always prompt
             shouldPrompt = CrashReporter.Prompt.ALWAYS,
             services = listOf(
-            VPNTombStoneService(context)
-          )
+                VPNTombStoneService(context)
+            )
         )
         reporter.install(context)
         Log.i("BASTI", "INSTALLED REPORTER")
     }
-    companion object{
+    companion object {
 
-        const val ACTION_CRASHED = "org.mozilla.gecko.ACTION_CRASHED";
-        const val EXTRA_MINIDUMP_PATH = "minidumpPath";
-        const val EXTRA_EXTRAS_PATH = "extrasPath";
+        const val ACTION_CRASHED = "org.mozilla.gecko.ACTION_CRASHED"
+        const val EXTRA_MINIDUMP_PATH = "minidumpPath"
+        const val EXTRA_EXTRAS_PATH = "extrasPath"
         const val EXTRA_CRASH_PROCESS_TYPE = "processType"
-
 
         @JvmStatic
         @Suppress("unused", "DIVISION_BY_ZERO") // JNI caller
-        fun testUncaughtException(){
-            val oops = 10/0
+        fun testUncaughtException() {
+            val oops = 10 / 0
         }
         @JvmStatic
         @Suppress("unused") // JNI caller
-        fun testNullAccessException(){
-            val ctx : Context? = null;
-            ctx!!.openFileInput("HELLO NULL");
+        fun testNullAccessException() {
+            val ctx: Context? = null
+            ctx!!.openFileInput("HELLO NULL")
         }
 
         @JvmStatic
         @Suppress("unused") // JNI caller
-        fun nativePanic(miniDumpFilepath:String){
+        fun nativePanic(miniDumpFilepath: String) {
             // Note to self, this is undocumented ... i found this in gecko.
             val context = VPNActivity.getInstance()
-            Log.e("BASTI", miniDumpFilepath);
+            Log.e("BASTI", miniDumpFilepath)
 
             val i = Intent(ACTION_CRASHED, null, context, CrashHandlerService::class.java).apply {
                 putExtra(EXTRA_MINIDUMP_PATH, miniDumpFilepath)

--- a/android/src/org/mozilla/firefox/vpn/qt/VPNTombStoneService.kt
+++ b/android/src/org/mozilla/firefox/vpn/qt/VPNTombStoneService.kt
@@ -2,15 +2,15 @@ package org.mozilla.firefox.vpn.qt
 
 import android.content.Context
 import android.util.Log
+import mozilla.components.concept.base.crash.Breadcrumb
 import mozilla.components.lib.crash.Crash
 import mozilla.components.lib.crash.service.CrashReporterService
-import mozilla.components.concept.base.crash.Breadcrumb
 import java.io.File
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
-class VPNTombStoneService(con: Context) : CrashReporterService{
-    private val mContext=con;
+class VPNTombStoneService(con: Context) : CrashReporterService {
+    private val mContext = con
     override val id: String
         get() = "com.mozilla.firefox.vpn.Tombstone"
     override val name: String
@@ -24,30 +24,35 @@ class VPNTombStoneService(con: Context) : CrashReporterService{
         throwable: Throwable,
         breadcrumbs: ArrayList<Breadcrumb>
     ): String? {
-        writeTombStone("""
+        writeTombStone(
+            """
             Type: GenericThrowable
             Throwable: ${throwable.localizedMessage}
             ${throwable.stackTraceToString()}
             ---- Breadcrumbs
             ${breadcrumbs.map { "${it.category} | ${it.message}" }}
-        """.trimIndent())
-        return null;
+            """.trimIndent()
+        )
+        return null
     }
 
     override fun report(crash: Crash.NativeCodeCrash): String? {
-        writeTombStone("""
+        writeTombStone(
+            """
             Type: NativeCodeCrash
             Fatal: ${crash.isFatal}
             
             ${crash.breadcrumbs.map {
                 "${it.category} | ${it.message}"
             }}
-        """.trimIndent())
-        return null;
+            """.trimIndent()
+        )
+        return null
     }
 
     override fun report(crash: Crash.UncaughtExceptionCrash): String? {
-        writeTombStone("""
+        writeTombStone(
+            """
             Type: UncaughtExceptionCrash
             Throwable: ${crash.throwable.localizedMessage}
             ${crash.throwable.stackTraceToString()}
@@ -55,27 +60,28 @@ class VPNTombStoneService(con: Context) : CrashReporterService{
             ${crash.breadcrumbs.map {
                 "${it.category} | ${it.message}"
             }}
-        """.trimIndent())
-        return null;
+            """.trimIndent()
+        )
+        return null
     }
 
-
-    private fun writeTombStone(content: String){
+    private fun writeTombStone(content: String) {
         Log.i("BASTI", "writeTombStone")
         val tempDIR = mContext.cacheDir
-        val id = getID();
+        val id = getID()
         val file = File(tempDIR, "$id.tombstone.txt")
-        file.writeText("""
+        file.writeText(
+            """
             ****Tombstone-$id****
             $content
             ****Tombstone-$id-****
-        """.trimIndent())
+            """.trimIndent()
+        )
 
         Log.e("MozillaVPN", "Mozilla VPN experienced a crash, $id.tombstone.txt has been written.")
     }
 
-
-    private fun getID(): String{
+    private fun getID(): String {
         return LocalDateTime.now().format(DateTimeFormatter.ofPattern("y-mm-dd-H-m-ss"))
     }
 }

--- a/android/src/org/mozilla/firefox/vpn/qt/VPNTombStoneService.kt
+++ b/android/src/org/mozilla/firefox/vpn/qt/VPNTombStoneService.kt
@@ -1,0 +1,81 @@
+package org.mozilla.firefox.vpn.qt
+
+import android.content.Context
+import android.util.Log
+import mozilla.components.lib.crash.Crash
+import mozilla.components.lib.crash.service.CrashReporterService
+import mozilla.components.concept.base.crash.Breadcrumb
+import java.io.File
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+class VPNTombStoneService(con: Context) : CrashReporterService{
+    private val mContext=con;
+    override val id: String
+        get() = "com.mozilla.firefox.vpn.Tombstone"
+    override val name: String
+        get() = "VPNTombstoneService"
+
+    override fun createCrashReportUrl(identifier: String): String? {
+        return null; // We are not posting this to a webpage
+    }
+
+    override fun report(
+        throwable: Throwable,
+        breadcrumbs: ArrayList<Breadcrumb>
+    ): String? {
+        writeTombStone("""
+            Type: GenericThrowable
+            Throwable: ${throwable.localizedMessage}
+            ${throwable.stackTraceToString()}
+            ---- Breadcrumbs
+            ${breadcrumbs.map { "${it.category} | ${it.message}" }}
+        """.trimIndent())
+        return null;
+    }
+
+    override fun report(crash: Crash.NativeCodeCrash): String? {
+        writeTombStone("""
+            Type: NativeCodeCrash
+            Fatal: ${crash.isFatal}
+            
+            ${crash.breadcrumbs.map {
+                "${it.category} | ${it.message}"
+            }}
+        """.trimIndent())
+        return null;
+    }
+
+    override fun report(crash: Crash.UncaughtExceptionCrash): String? {
+        writeTombStone("""
+            Type: UncaughtExceptionCrash
+            Throwable: ${crash.throwable.localizedMessage}
+            ${crash.throwable.stackTraceToString()}
+            ---- Breadcrumbs
+            ${crash.breadcrumbs.map {
+                "${it.category} | ${it.message}"
+            }}
+        """.trimIndent())
+        return null;
+    }
+
+
+    private fun writeTombStone(content: String){
+        Log.i("BASTI", "writeTombStone")
+        val tempDIR = mContext.cacheDir
+        val id = getID();
+        val file = File(tempDIR, "$id.tombstone.txt")
+        file.writeText("""
+            ****Tombstone-$id****
+            $content
+            ****Tombstone-$id-****
+        """.trimIndent())
+
+        Log.e("MozillaVPN", "Mozilla VPN experienced a crash, $id.tombstone.txt has been written.")
+    }
+
+
+    private fun getID(): String{
+        return LocalDateTime.now().format(DateTimeFormatter.ofPattern("y-mm-dd-H-m-ss"))
+    }
+}

--- a/android/src/org/mozilla/firefox/vpn/qt/VPNUtils.kt
+++ b/android/src/org/mozilla/firefox/vpn/qt/VPNUtils.kt
@@ -113,5 +113,4 @@ object VPNUtils {
     @SuppressLint("Unused")
     @JvmStatic
     private external fun recordGleanEvent(metricName: String)
-
 }

--- a/src/commands/commandui.cpp
+++ b/src/commands/commandui.cpp
@@ -52,6 +52,9 @@
 
 #ifdef MVPN_ANDROID
 #  include "platforms/android/androidutils.h"
+#  include "client/linux/handler/exception_handler.h"
+#  include "client/linux/handler/minidump_descriptor.h"
+#  include "crashreporter/breakpad/androidbreakpad.h"
 #endif
 
 #ifndef Q_OS_WIN
@@ -78,9 +81,12 @@
 
 #include <QApplication>
 
+
 namespace {
 Logger logger(LOG_MAIN, "CommandUI");
 }
+
+
 
 CommandUI::CommandUI(QObject* parent) : Command(parent, "ui", "Start the UI.") {
   MVPN_COUNT_CTOR(CommandUI);
@@ -89,6 +95,12 @@ CommandUI::CommandUI(QObject* parent) : Command(parent, "ui", "Start the UI.") {
 CommandUI::~CommandUI() { MVPN_COUNT_DTOR(CommandUI); }
 
 int CommandUI::run(QStringList& tokens) {
+  #ifdef MVPN_ANDROID
+    // Initialize the breakpad client.
+    google_breakpad::MinidumpDescriptor descriptor(".");
+    google_breakpad::ExceptionHandler eh(descriptor, NULL, AndroidBreakpadClient::panic,
+                                        NULL, true, -1);
+  #endif
   Q_ASSERT(!tokens.isEmpty());
   return runQmlApp([&]() {
     QString appName = tokens[0];

--- a/src/crashreporter/breakpad/androidbreakpad.cpp
+++ b/src/crashreporter/breakpad/androidbreakpad.cpp
@@ -1,0 +1,36 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "androidbreakpad.h"
+#include "constants.h"
+#include "leakdetector.h"
+#include "logger.h"
+#include "mozillavpn.h"
+#include "networkrequest.h"
+#include "settingsholder.h"
+#include "qmlengineholder.h"
+#include "jni.h"
+
+#include <QJniObject>
+#include <QJniEnvironment>
+
+#include "client/linux/handler/exception_handler.h"
+#include "client/linux/handler/minidump_descriptor.h"
+
+namespace {
+AndroidBreakpadClient* s_instance = nullptr;
+Logger logger(LOG_ANDROID, "AndroidBreakpadClient");
+}  // namespace
+
+// static
+bool AndroidBreakpadClient::panic(const google_breakpad::MinidumpDescriptor& descriptor,
+                  void* context,
+                  bool succeeded) {
+    QJniObject::callStaticMethod<void>("org/mozilla/firefox/vpn/qt/VPNCrashReporterUtil",
+                                        "nativePanic", 
+                                        "(Ljava/lang/String;)V",
+                                        QJniObject::fromString(descriptor.path()).object());    
+   return succeeded;
+}
+

--- a/src/crashreporter/breakpad/androidbreakpad.h
+++ b/src/crashreporter/breakpad/androidbreakpad.h
@@ -1,0 +1,26 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef ANDROIDBREAKPADCLIENT_H
+#define ANDROIDBREAKPADCLIENT_H
+
+
+#include "client/linux/handler/exception_handler.h"
+#include "client/linux/handler/minidump_descriptor.h"
+
+
+class AndroidBreakpadClient {
+
+ public:
+
+  static bool panic(const google_breakpad::MinidumpDescriptor& descriptor,
+                  void* context,
+                  bool succeeded);
+
+ private:
+  AndroidBreakpadClient();
+  ~AndroidBreakpadClient();
+};
+
+#endif  // ANDROIDBREAKPADCLIENT_H

--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -1248,6 +1248,10 @@ void MozillaVPN::serializeLogs(QTextStream* out,
         *out << SettingsHolder::instance()->getReport();
         *out << "==== DEVICE ====" << Qt::endl;
         *out << Device::currentDeviceReport();
+        #ifdef MVPN_ANDROID
+        *out << "==== CRASHES ====" << Qt::endl;
+        AndroidUtils::printCrashLogs(out);
+        #endif
         *out << Qt::endl;
 
         finalizeCallback();

--- a/src/platforms/android/androidutils.h
+++ b/src/platforms/android/androidutils.h
@@ -12,6 +12,7 @@
 
 #include <QJniObject>
 #include <QJniEnvironment>
+#include <QTextStream>
 
 class AuthenticationListener;
 
@@ -46,6 +47,8 @@ class AndroidUtils final : public QObject {
   static void recordGleanEvent(JNIEnv* env, jobject VPNUtils, jstring event);
 
   static void runOnAndroidThreadSync(const std::function<void()> runnable);
+
+  static void printCrashLogs(QTextStream* stream);
 
  private:
   AndroidUtils(QObject* parent);

--- a/src/qmake/breakpad.pri
+++ b/src/qmake/breakpad.pri
@@ -1,0 +1,78 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+android {
+    message(Breakpad enabled)
+
+    BREAKPAD_DIR = $$PWD/../../3rdparty/breakpad
+
+    INCLUDEPATH += $$BREAKPAD_DIR
+    INCLUDEPATH += $$BREAKPAD_DIR/src
+
+    HEADERS +=  $$BREAKPAD_DIR/src/client/linux/crash_generation/crash_generation_client.h \
+                $$BREAKPAD_DIR/src/client/linux/dump_writer_common/thread_info.h \
+                $$BREAKPAD_DIR/src/client/linux/dump_writer_common/ucontext_reader.h \
+                $$BREAKPAD_DIR/src/client/linux/handler/exception_handler.h \
+                $$BREAKPAD_DIR/src/client/linux/handler/minidump_descriptor.h \
+                $$BREAKPAD_DIR/src/client/linux/log/log.h \
+                $$BREAKPAD_DIR/src/client/linux/microdump_writer/microdump_writer.h \
+                $$BREAKPAD_DIR/src/client/linux/minidump_writer/linux_dumper.h \
+                $$BREAKPAD_DIR/src/client/linux/minidump_writer/linux_ptrace_dumper.h \
+                $$BREAKPAD_DIR/src/client/linux/minidump_writer/minidump_writer.h \
+                $$BREAKPAD_DIR/src/client/linux/minidump_writer/pe_file.h \
+                $$BREAKPAD_DIR/src/client/minidump_file_writer.h \
+                $$BREAKPAD_DIR/src/common/convert_UTF.h \
+                $$BREAKPAD_DIR/src/common/md5.h \
+                $$BREAKPAD_DIR/src/common/string_conversion.h \
+                $$BREAKPAD_DIR/src/common/linux/breakpad_getcontext.S \
+                $$BREAKPAD_DIR/src/common/linux/elfutils.h \
+                $$BREAKPAD_DIR/src/common/linux/file_id.h \
+                $$BREAKPAD_DIR/src/common/linux/guid_creator.h \
+                $$BREAKPAD_DIR/src/common/linux/linux_libc_support.h \
+                $$BREAKPAD_DIR/src/common/linux/memory_mapped_file.h \
+                $$BREAKPAD_DIR/src/common/linux/safe_readlink.h
+
+
+    # LOCAL_C_INCLUDES 
+    # (LOCAL_PATH)/src/common/android/include 
+    HEADERS +=  $$BREAKPAD_DIR/src/common/android/include/asm-mips/asm.h \
+                $$BREAKPAD_DIR/src/common/android/include/asm-mips/fpregdef.h \
+                $$BREAKPAD_DIR/src/common/android/include/asm-mips/regdef.h \
+                $$BREAKPAD_DIR/src/common/android/include/elf.h \
+                $$BREAKPAD_DIR/src/common/android/include/link.h \
+                $$BREAKPAD_DIR/src/common/android/include/stab.h \
+                $$BREAKPAD_DIR/src/common/android/include/sys/procfs.h \
+                $$BREAKPAD_DIR/src/common/android/include/sys/user.h 
+
+
+    # List of client source files, directly taken from Android.mk
+    SOURCES +=  $$BREAKPAD_DIR/src/client/linux/crash_generation/crash_generation_client.cc \
+                $$BREAKPAD_DIR/src/client/linux/dump_writer_common/thread_info.cc \
+                $$BREAKPAD_DIR/src/client/linux/dump_writer_common/ucontext_reader.cc \
+                $$BREAKPAD_DIR/src/client/linux/handler/exception_handler.cc \
+                $$BREAKPAD_DIR/src/client/linux/handler/minidump_descriptor.cc \
+                $$BREAKPAD_DIR/src/client/linux/log/log.cc \
+                $$BREAKPAD_DIR/src/client/linux/microdump_writer/microdump_writer.cc \
+                $$BREAKPAD_DIR/src/client/linux/minidump_writer/linux_dumper.cc \
+                $$BREAKPAD_DIR/src/client/linux/minidump_writer/linux_ptrace_dumper.cc \
+                $$BREAKPAD_DIR/src/client/linux/minidump_writer/minidump_writer.cc \
+                $$BREAKPAD_DIR/src/client/linux/minidump_writer/pe_file.cc \
+                $$BREAKPAD_DIR/src/client/minidump_file_writer.cc \
+                $$BREAKPAD_DIR/src/common/convert_UTF.cc \
+                $$BREAKPAD_DIR/src/common/md5.cc \
+                $$BREAKPAD_DIR/src/common/string_conversion.cc \
+                $$BREAKPAD_DIR/src/common/linux/breakpad_getcontext.S \
+                $$BREAKPAD_DIR/src/common/linux/elfutils.cc \
+                $$BREAKPAD_DIR/src/common/linux/file_id.cc \
+                $$BREAKPAD_DIR/src/common/linux/guid_creator.cc \
+                $$BREAKPAD_DIR/src/common/linux/linux_libc_support.cc \
+                $$BREAKPAD_DIR/src/common/linux/memory_mapped_file.cc \
+                $$BREAKPAD_DIR/src/common/linux/safe_readlink.cc
+    # Our own adaptor
+    SOURCES +=   $$PWD/../crashreporter/breakpad/androidbreakpad.cpp
+    HEADERS +=   $$PWD/../crashreporter/breakpad/androidbreakpad.cpp
+     
+}
+
+

--- a/src/qmake/platforms/android.pri
+++ b/src/qmake/platforms/android.pri
@@ -30,7 +30,7 @@ versionAtMost(QT_VERSION, 6.2.0) {
 }
 
 versionAtLeast(QT_VERSION, 5.15.1) {
-  QMAKE_CXXFLAGS *= -Werror
+  #QMAKE_CXXFLAGS *= -Werror
 }
 
 versionAtLeast(QT_VERSION, 6.0.0) {

--- a/src/src.pro
+++ b/src/src.pro
@@ -10,6 +10,7 @@
 TEMPLATE  = app
 
 include($$PWD/qmake/balrog.pri)
+include($$PWD/qmake/breakpad.pri)
 include($$PWD/qmake/debug.pri)
 include($$PWD/qmake/includes_and_defines.pri)
 include($$PWD/qmake/qt.pri)


### PR DESCRIPTION
## Description
 This is something I played around with, as I was not moving forward with reported crashes. Our logs really don't help here. 
 If this flow seems familiar, it's the same as fenix uses. We install a google-breakpad handler which will collect a minidump and pass this to the fenix-android-crash component. Currently, this one will write it to a txt file-crash service on the phone, so we can add this info to the logs when exporting. However the crash-sender supports glean & socorro out of the box. 
I think maybe it might be a good idea to upload those to socorro and add the crash-report id into our logs? 
Or we could have a view like `about:crashes`

Just wanted to put this out for input from the team :) - I think in general it would be great to have more agency and crash related info in our logs, when users approach support or us directly. 
    

https://user-images.githubusercontent.com/9611612/171829030-cc4ca02b-7147-4297-81ab-eedee9b4bbb0.mp4



## Reference

    i.e Jira or Github issue URL

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
