### PR TITLE
Update Get help menus

### DIFF
--- a/scripts/utils/generate_strings.py
+++ b/scripts/utils/generate_strings.py
@@ -323,7 +323,9 @@ class L18nStrings final : public QQmlPropertyMap {
   ~L18nStrings() = default;
 
   void retranslate();
-
+  
+  const char* id(L18nStrings::String) const;
+  
   QString t(String) const;
 
  private:

--- a/src/models/helpmodel.cpp
+++ b/src/models/helpmodel.cpp
@@ -49,7 +49,7 @@ void maybeInitialize() {
   s_helpEntries.append(
       HelpEntry(L18nStrings::instance()->id(
                     L18nStrings::InAppSupportWorkflowSupportNavLinkText),
-                true, false, MozillaVPN::LinkContact));
+                false, false, MozillaVPN::LinkContact));
 
   //% "View log"
   logger.debug() << "Adding:" << qtTrId("help.viewLog");

--- a/src/models/helpmodel.cpp
+++ b/src/models/helpmodel.cpp
@@ -43,10 +43,10 @@ void maybeInitialize() {
   s_helpEntries.append(
       HelpEntry("help.helpCenter2", true, false, MozillaVPN::LinkHelpSupport));
 
-  //% "Contact us"
-  logger.debug() << "Adding:" << qtTrId("help.contactUs");
-  s_helpEntries.append(
-      HelpEntry("help.contactUs", false, false, MozillaVPN::LinkContact));
+  logger.debug() << "Adding:"
+                 << qtTrId("vpn.inAppSupportWorkflow.supportNavLinkText");
+  s_helpEntries.append(HelpEntry("vpn.inAppSupportWorkflow.supportNavLinkText",
+                                 false, false, MozillaVPN::LinkContact));
 
   //% "View log"
   logger.debug() << "Adding:" << qtTrId("help.viewLog");

--- a/src/models/helpmodel.cpp
+++ b/src/models/helpmodel.cpp
@@ -44,9 +44,12 @@ void maybeInitialize() {
       HelpEntry("help.helpCenter2", true, false, MozillaVPN::LinkHelpSupport));
 
   logger.debug() << "Adding:"
-                 << qtTrId("vpn.inAppSupportWorkflow.supportNavLinkText");
-  s_helpEntries.append(HelpEntry("vpn.inAppSupportWorkflow.supportNavLinkText",
-                                 false, false, MozillaVPN::LinkContact));
+                 << qtTrId(L18nStrings::instance()->id(
+                        L18nStrings::InAppSupportWorkflowSupportNavLinkText));
+  s_helpEntries.append(
+      HelpEntry(L18nStrings::instance()->id(
+                    L18nStrings::InAppSupportWorkflowSupportNavLinkText),
+                true, false, MozillaVPN::LinkContact));
 
   //% "View log"
   logger.debug() << "Adding:" << qtTrId("help.viewLog");

--- a/src/ui/views/ViewGetHelp.qml
+++ b/src/ui/views/ViewGetHelp.qml
@@ -62,18 +62,6 @@ Item {
         anchors.topMargin: VPNTheme.theme.windowMargin
         anchors.top: menu.bottom
 
-        VPNExternalLinkListItem {
-            objectName: "settingsGiveFeedback"
-
-            accessibleName: title
-            title: qsTrId("vpn.settings.giveFeedback")
-            onClicked: mainStackView.push("qrc:/ui/settings/ViewGiveFeedback.qml")
-            iconSource: "qrc:/nebula/resources/chevron.svg"
-            backgroundColor: VPNTheme.theme.iconButtonLightBackground
-            width: parent.width - VPNTheme.theme.windowMargin
-            visible: VPN.userState === VPN.UserAuthenticated
-        }
-
         Repeater {
             id: getHelpList
             objectName: "getHelpBackList"
@@ -91,6 +79,19 @@ Item {
                     VPNHelpModel.open(id)
                 }
             }
+        }
+
+        VPNExternalLinkListItem {
+            id: gf
+            objectName: "settingsGiveFeedback"
+
+            accessibleName: title
+            title: qsTrId("vpn.settings.giveFeedback")
+            onClicked: mainStackView.push("qrc:/ui/settings/ViewGiveFeedback.qml")
+            iconSource: "qrc:/nebula/resources/chevron.svg"
+            backgroundColor: VPNTheme.theme.iconButtonLightBackground
+            width: parent.width - VPNTheme.theme.windowMargin
+            visible: VPN.userState === VPN.UserAuthenticated
         }
 
         VPNSettingsItem {

--- a/translations/l18nstrings.cpp
+++ b/translations/l18nstrings.cpp
@@ -31,6 +31,11 @@ L18nStrings::L18nStrings(QObject* parent) : QQmlPropertyMap(parent) {
   retranslate();
 }
 
+const char* L18nStrings::id(L18nStrings::String string) const {
+  Q_ASSERT(string < __Last);
+  return _ids[string];
+}
+
 QString L18nStrings::t(L18nStrings::String string) const {
   Q_ASSERT(string < __Last);
   QString id = _ids[string];


### PR DESCRIPTION
## Description

This changes the 'Contact us' string to 'Contact support' in the macOS top bar menu and moves 'Give feedback' to the bottom of the list in ViewGetHelp.qml. 

## Reference

   VPN-2198

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
