### PR TITLE
Stop using 8.8.8.8 in the connection check

### DIFF
--- a/src/connectionhealth.cpp
+++ b/src/connectionhealth.cpp
@@ -26,8 +26,8 @@ constexpr uint32_t PING_TIME_NOSIGNAL_SEC = 4;
 constexpr double PING_LOSS_UNSTABLE_THRESHOLD = 0.10;
 
 // Destination address for latency measurements when the VPN is
-// deactivated. This is the Google anycast DNS server.
-constexpr const char* PING_WELL_KNOWN_ANYCAST_DNS = "8.8.8.8";
+// deactivated. This is the doh.mullvad.net DNS server.
+constexpr const char* PING_WELL_KNOWN_ANYCAST_DNS = "194.242.2.2";
 
 // The baseline latency measurement averaged using an Exponentially Weighted
 // Moving Average (EWMA), this defines the decay rate.


### PR DESCRIPTION
## Description
Replaces the server using a public mullvad controlled one :) 

## Reference
Closes https://github.com/mozilla-mobile/mozilla-vpn-client/issues/3171

https://mullvad.net/en/help/dns-over-https-and-dns-over-tls/
