### PR TITLE
Add periodic check (3 hours / 1 minute) for controller state

### DIFF
--- a/glean/metrics.yaml
+++ b/glean/metrics.yaml
@@ -879,6 +879,40 @@ sample:
           "switching", etc. The list can be found in `controller.h`.
         type: string
 
+  controller_state_on:
+    type: event
+    lifetime: ping
+    send_in_pings:
+      - main
+    description: |
+      Controller state is on.
+    bugs:
+      - https://github.com/mozilla-mobile/mozilla-vpn-client/issues/2643
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=TBD
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - amarchesini@mozilla.com
+    expires: never
+
+  controller_state_off:
+    type: event
+    lifetime: ping
+    send_in_pings:
+      - main
+    description: |
+      Controller state is off.
+    bugs:
+      - https://github.com/mozilla-mobile/mozilla-vpn-client/issues/2643
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=TBD
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - amarchesini@mozilla.com
+    expires: never
+
   update_step:
     type: event
     lifetime: ping

--- a/glean/metrics.yaml
+++ b/glean/metrics.yaml
@@ -889,7 +889,7 @@ sample:
     bugs:
       - https://github.com/mozilla-mobile/mozilla-vpn-client/issues/2643
     data_reviews:
-      - https://bugzilla.mozilla.org/show_bug.cgi?id=TBD
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1773423
     data_sensitivity:
       - interaction
     notification_emails:
@@ -906,7 +906,7 @@ sample:
     bugs:
       - https://github.com/mozilla-mobile/mozilla-vpn-client/issues/2643
     data_reviews:
-      - https://bugzilla.mozilla.org/show_bug.cgi?id=TBD
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1773423
     data_sensitivity:
       - interaction
     notification_emails:

--- a/glean/metrics.yaml
+++ b/glean/metrics.yaml
@@ -902,9 +902,9 @@ sample:
     send_in_pings:
       - main
     description: |
-      Controller state is off. It is important to note that mobile reports of this event
-      are likely to be unreliable because they come from an non-active background process
-      which is not guaranteed to be alive.
+      Controller state is off. It is important to note that mobile reports of
+      this event are likely to be unreliable because they come from an
+      non-active background process which is not guaranteed to be alive.
     bugs:
       - https://github.com/mozilla-mobile/mozilla-vpn-client/issues/2643
     data_reviews:

--- a/glean/metrics.yaml
+++ b/glean/metrics.yaml
@@ -902,7 +902,9 @@ sample:
     send_in_pings:
       - main
     description: |
-      Controller state is off.
+      Controller state is off. It is important to note that mobile reports of this event
+      are likely to be unreliable because they come from an non-active background process
+      which is not guaranteed to be alive.
     bugs:
       - https://github.com/mozilla-mobile/mozilla-vpn-client/issues/2643
     data_reviews:

--- a/src/constants.h
+++ b/src/constants.h
@@ -71,6 +71,9 @@ CONSTEXPR(uint32_t, statusIconAnimationMsec, 200, 200, 0)
 // How often glean pings are sent
 CONSTEXPR(uint32_t, gleanTimeoutMsec, 1200000, 4000, 0)
 
+// How often to check in on the controller state
+CONSTEXPR(uint32_t, controllerPeriodicStateRecorderMsec, 10800000, 600000, 0)
+
 // How often we check the surveys to be executed (no network requests are done
 // for this check)
 CONSTEXPR(uint32_t, surveyTimerMsec, 300000, 4000, 0)

--- a/src/constants.h
+++ b/src/constants.h
@@ -72,7 +72,7 @@ CONSTEXPR(uint32_t, statusIconAnimationMsec, 200, 200, 0)
 CONSTEXPR(uint32_t, gleanTimeoutMsec, 1200000, 4000, 0)
 
 // How often to check in on the controller state
-CONSTEXPR(uint32_t, controllerPeriodicStateRecorderMsec, 10800000, 600000, 0)
+CONSTEXPR(uint32_t, controllerPeriodicStateRecorderMsec, 10800000, 60000, 0)
 
 // How often we check the surveys to be executed (no network requests are done
 // for this check)

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -606,20 +606,6 @@ void Controller::setState(State state) {
     return;
   }
   logger.debug() << "Setting state:" << state;
-  emit MozillaVPN::instance()->recordGleanEventWithExtraKeys(
-      GleanSample::controllerStep,
-      {{"state", QVariant::fromValue(state).toString()}});
-
-  // Specific events for on and off state to aid with analysis
-  if (state == StateOn) {
-    emit MozillaVPN::instance()->recordGleanEvent(
-        GleanSample::controllerStateOn);
-  }
-  if (state == StateOff) {
-    emit MozillaVPN::instance()->recordGleanEvent(
-        GleanSample::controllerStateOff);
-  }
-
   m_state = state;
   emit stateChanged();
 }

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -611,11 +611,11 @@ void Controller::setState(State state) {
       {{"state", QVariant::fromValue(state).toString()}});
 
   // Specific events for on and off state to aid with analysis
-  if (m_state == StateOn) {
+  if (state == StateOn) {
     emit MozillaVPN::instance()->recordGleanEvent(
         GleanSample::controllerStateOn);
   }
-  if (m_state == StateOff) {
+  if (state == StateOff) {
     emit MozillaVPN::instance()->recordGleanEvent(
         GleanSample::controllerStateOff);
   }

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -80,13 +80,6 @@ Controller::Controller() {
 
   connect(&m_handshakeTimer, &QTimer::timeout, this,
           &Controller::handshakeTimeout);
-
-  // Setup regular check for controller up state
-  connect(&m_gleanControllerUpTimer, &QTimer::timeout, this,
-          &Controller::periodicStateRecorder);
-  m_gleanControllerUpTimer.start(
-      Constants::controllerPeriodicStateRecorderMsec());
-  m_gleanControllerUpTimer.setSingleShot(false);
 }
 
 Controller::~Controller() { MVPN_COUNT_DTOR(Controller); }
@@ -629,21 +622,6 @@ void Controller::setState(State state) {
 
   m_state = state;
   emit stateChanged();
-}
-
-void Controller::periodicStateRecorder() {
-// On mobile this is handled in the background process that talks to the
-// controller
-#if defined(MVPN_WINDOWS) || defined(MVPN_LINUX) || defined(MVPN_MACOS)
-  if (m_state == StateOn) {
-    emit MozillaVPN::instance()->recordGleanEvent(
-        GleanSample::controllerStateOn);
-  }
-  if (m_state == StateOff) {
-    emit MozillaVPN::instance()->recordGleanEvent(
-        GleanSample::controllerStateOff);
-  }
-#endif
 }
 
 qint64 Controller::time() const {

--- a/src/controller.h
+++ b/src/controller.h
@@ -141,7 +141,7 @@ class Controller final : public QObject {
 
  private:
   void setState(State state);
-
+  void periodicStateRecorder();
   void maybeEnableDisconnectInConfirming();
 
   bool processNextStep();
@@ -176,6 +176,7 @@ class Controller final : public QObject {
 
   QTimer m_connectingTimer;
   QTimer m_handshakeTimer;
+  QTimer m_gleanControllerUpTimer;
   bool m_enableDisconnectInConfirming = false;
 
   enum NextStep {

--- a/src/controller.h
+++ b/src/controller.h
@@ -141,6 +141,7 @@ class Controller final : public QObject {
 
  private:
   void setState(State state);
+
   void maybeEnableDisconnectInConfirming();
 
   bool processNextStep();

--- a/src/controller.h
+++ b/src/controller.h
@@ -141,7 +141,6 @@ class Controller final : public QObject {
 
  private:
   void setState(State state);
-  void periodicStateRecorder();
   void maybeEnableDisconnectInConfirming();
 
   bool processNextStep();
@@ -176,7 +175,6 @@ class Controller final : public QObject {
 
   QTimer m_connectingTimer;
   QTimer m_handshakeTimer;
-  QTimer m_gleanControllerUpTimer;
   bool m_enableDisconnectInConfirming = false;
 
   enum NextStep {

--- a/src/telemetry.cpp
+++ b/src/telemetry.cpp
@@ -22,11 +22,13 @@ Telemetry::Telemetry() {
   connect(&m_connectionStabilityTimer, &QTimer::timeout, this,
           &Telemetry::connectionStabilityEvent);
 
+#if defined(MVPN_WINDOWS) || defined(MVPN_LINUX) || defined(MVPN_MACOS)
   connect(&m_gleanControllerUpTimer, &QTimer::timeout, this,
           &Telemetry::periodicStateRecorder);
   m_gleanControllerUpTimer.start(
       Constants::controllerPeriodicStateRecorderMsec());
   m_gleanControllerUpTimer.setSingleShot(false);
+#endif
 }
 
 Telemetry::~Telemetry() { MVPN_COUNT_DTOR(Telemetry); }

--- a/src/telemetry.h
+++ b/src/telemetry.h
@@ -17,11 +17,15 @@ class Telemetry final : public QObject {
 
  private:
   void connectionStabilityEvent();
+#if defined(MVPN_WINDOWS) || defined(MVPN_LINUX) || defined(MVPN_MACOS)
   void periodicStateRecorder();
+#endif
 
  private:
   QTimer m_connectionStabilityTimer;
+#if defined(MVPN_WINDOWS) || defined(MVPN_LINUX) || defined(MVPN_MACOS)
   QTimer m_gleanControllerUpTimer;
+#endif
 };
 
 #endif  // TELEMETRY_H

--- a/src/telemetry.h
+++ b/src/telemetry.h
@@ -17,9 +17,11 @@ class Telemetry final : public QObject {
 
  private:
   void connectionStabilityEvent();
+  void periodicStateRecorder();
 
  private:
   QTimer m_connectionStabilityTimer;
+  QTimer m_gleanControllerUpTimer;
 };
 
 #endif  // TELEMETRY_H


### PR DESCRIPTION
## Description

Adds two new events for particular controller states (to ease analysis as opposed to using the controller_step data) and sets a long timer (3 hours / 10 minutes) to report the controller state for desktop. Follow-up work will be done to incorporate the controllerStateOn event for mobile in separate PRs.

## Reference

* [Jira](https://mozilla-hub.atlassian.net/browse/VPN-1619)
* [Github](https://github.com/mozilla-mobile/mozilla-vpn-client/issues/2643)

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
