### PR TITLE
Improve "device limit" removal visual cues

### DIFF
--- a/nebula/ui/components/VPNDeviceListItem.qml
+++ b/nebula/ui/components/VPNDeviceListItem.qml
@@ -82,6 +82,8 @@ Item {
                 value: "qrc:/nebula/resources/spinner.svg"
             }
 
+            ScriptAction { script: icon.rotating = true; }
+
             ParallelAnimation {
                 PropertyAnimation {
                     target: iconButton
@@ -90,13 +92,6 @@ Item {
                     to: 1
                     duration: 300
                 }
-
-                PropertyAction {
-                    target: iconButton
-                    property: "startRotation"
-                    value: true
-                }
-
             }
         }
 
@@ -118,6 +113,7 @@ Item {
             Layout.leftMargin: VPNTheme.theme.windowMargin
             Layout.rightMargin: VPNTheme.theme.windowMargin
             Layout.alignment: Qt.AlignTop | Qt.AlignLeft
+            opacity: enabled ? 1 : 0.6
         }
 
         Column {
@@ -135,6 +131,7 @@ Item {
                 anchors.left: parent.left
                 horizontalAlignment: Text.AlignLeft
                 anchors.right: parent.right
+                opacity: enabled ? 1 : 0.6
                 Accessible.ignored: root.isModalDialogOpened
             }
 
@@ -169,6 +166,7 @@ Item {
                 width: parent.width
                 wrapMode: Text.WrapAtWordBoundaryOrAnywhere
                 verticalAlignment: Text.AlignVCenter
+                opacity: enabled ? 1 : 0.6
 
             }
         }
@@ -178,10 +176,10 @@ Item {
 
             property var iconSource: "qrc:/nebula/resources/delete.svg"
             property real iconHeightWidth: 22
-            property bool startRotation: false
 
             buttonColorScheme: VPNTheme.theme.removeDeviceBtn
             visible: !currentOne
+            opacity: enabled || (!enabled && iconSource === "qrc:/nebula/resources/spinner.svg") ? 1 : 0.6
             Layout.topMargin: -8
             Layout.alignment: Qt.AlignTop | Qt.AlignRight
             Layout.preferredHeight: VPNTheme.theme.rowHeight
@@ -195,18 +193,23 @@ Item {
             Accessible.ignored: root.isModalDialogOpened
 
             VPNIcon {
+                id: icon
+
+                property bool rotating: false
+
                 source: iconButton.iconSource
                 anchors.centerIn: iconButton
                 sourceSize.height: iconButton.iconHeightWidth
                 sourceSize.width: iconButton.iconHeightWidth
-                rotation: iconButton.startRotation ? 360 : 0
 
-                Behavior on rotation {
-                    PropertyAnimation {
-                        duration: 5000
-                        loops: Animation.Infinite
-                    }
-
+                PropertyAnimation {
+                    target: icon
+                    running: icon.rotating
+                    property: "rotation"
+                    from: 0
+                    to: 360
+                    duration: 5000
+                    loops: Animation.Infinite
                 }
 
             }

--- a/nebula/ui/components/VPNRemoveDevicePopup.qml
+++ b/nebula/ui/components/VPNRemoveDevicePopup.qml
@@ -35,13 +35,6 @@ VPNSimplePopup {
             colorScheme: VPNTheme.theme.redButton
             onClicked: {
                 VPN.removeDeviceFromPublicKey(popup.devicePublicKey);
-                if (vpnFlickable.state === "deviceLimit") {
-                    // there is no further action the user can take on the deviceList
-                    // so leave the modal open until the user is redirected back to the main view
-                    col.opacity = .5
-                    return;
-                }
-
                 popup.close();
             }
             isCancelBtn: false

--- a/nebula/ui/themes/themes.js
+++ b/nebula/ui/themes/themes.js
@@ -184,6 +184,7 @@ theme.removeDeviceBtn = {
   'defaultColor': theme.bgColorTransparent,
   'buttonHovered': '#FFDFE7',
   'buttonPressed': '#FFBDC5',
+  'buttonDisabled': theme.bgColorTransparent,
   'focusOutline': theme.bgColorTransparent,
   'focusBorder': theme.red,
 };

--- a/src/ui/views/ViewDevices.qml
+++ b/src/ui/views/ViewDevices.qml
@@ -149,6 +149,17 @@ Item {
     VPNRemoveDevicePopup {
         id: removePopup
 
+        Connections {
+            target: VPN
+            function onDeviceRemoving(devPublicKey) {
+                if(VPN.state === VPN.StateDeviceLimit) {
+                    for(var i = 0; i < deviceList.count; i++) {
+                        deviceList.itemAt(i).enabled = false
+                    }
+                }
+            }
+        }
+
         function initializeAndOpen(name, publicKey) {
             removePopup.deviceName = name;
             removePopup.devicePublicKey = publicKey;


### PR DESCRIPTION
## Description

- When clicking "Remove" on the "Remove device" popup from the device limit reached page:
    - Close the "Remove device" popup
    - Disables all of the items in the list
    - Indefinitely shows a spinner next to the device being removed

https://user-images.githubusercontent.com/15353801/173144876-d4802772-66eb-40fd-9bcb-9231a81a1b9a.mov

## Reference

[VPN-2002: Improve "loading" visual cues when removing a device during authentication](https://mozilla-hub.atlassian.net/browse/VPN-2002)

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
