### PR TITLE
Fix string export for main branch

### DIFF
--- a/scripts/utils/generate_strings.py
+++ b/scripts/utils/generate_strings.py
@@ -154,9 +154,9 @@ class L18nStrings final : public QQmlPropertyMap {
   ~L18nStrings() = default;
 
   void retranslate();
-  
+
   const char* id(L18nStrings::String) const;
-  
+
   QString t(String) const;
 
  private:
@@ -218,7 +218,7 @@ const char* const L18nStrings::_ids[] = {
 if __name__ == "__main__":
     # Parse arguments to locate the input and output files.
     parser = argparse.ArgumentParser(
-        description="Generate internationaliation strings database from a YAML source"
+        description="Generate internationalization strings database from a YAML source"
     )
     parser.add_argument(
         "source",

--- a/scripts/utils/generate_ts.sh
+++ b/scripts/utils/generate_ts.sh
@@ -22,7 +22,7 @@ cp scripts/utils/generate_strings.py cache || die
 print G "done."
 
 printn Y "Generating strings... "
-python cache/generate_strings.py -o translations/generated
+python cache/generate_strings.py translations/strings.yaml -o translations/generated
 print G "done."
 
 printn Y "Generating a dummy PRO file... "


### PR DESCRIPTION
## Description

https://github.com/mozilla-mobile/mozilla-vpn-client/runs/6838383168?check_suite_focus=true

> Unable to find /home/runner/work/mozilla-vpn-client/translations/strings.yaml

We're running a copy of the script in a different folder, the default defined in the Python script won't exist.

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
