### PR TITLE
Move the condition block in the addon world

### DIFF
--- a/addons/tutorial_02_connect_on_startup/manifest.json
+++ b/addons/tutorial_02_connect_on_startup/manifest.json
@@ -2,6 +2,9 @@
   "api_version": "0.1",
   "id": "tutorial_02_connect_on_startup",
   "name": "Tutorial: Connect on startup",
+  "conditions": {
+    "enabledFeatures": ["startOnBoot"]
+  },
   "type": "tutorial",
   "tutorial": {
     "id": "02_connect_on_startup",
@@ -9,9 +12,6 @@
     "title": "Connect VPN on startup",
     "subtitle": "Follow this walkthrough to learn how to activate your VPN when you start your device.",
     "completion_message": "You’ve successfully learned how to set “Connect VPN on startup”. Would you like to learn more tips and tricks?",
-    "conditions": {
-      "enabledFeatures": ["startOnBoot"]
-    },
     "steps": [
       {
         "id": "s1",

--- a/docs/add-on.md
+++ b/docs/add-on.md
@@ -1,0 +1,25 @@
+# Addons
+
+TBD
+
+### Condition object
+
+The condition object contains the following properties:
+
+| Property | Description | Type | Required |
+| --- | --- | --- | --- |
+| enabledFeatures | An array of features to be enabled | Array of string | No |
+| platforms | An array of platforms to be checked | Array of string | No |
+| settings | An array of Condition Setting object. See below | Array of Condition Setting object | No |
+
+### Condition Setting object
+
+When a setting must be checked as a condition, the JSON object must contain the following properties:
+
+| Property | Description | Type | Required |
+| --- | --- | --- | --- |
+| setting | The name of the setting key | String | Yes |
+| value | The value of the setting key | String | Yes |
+| op | The compare operator: eq or neq | String | Yes |
+
+The list of setting keys can be found here: https://github.com/mozilla-mobile/mozilla-vpn-client/blob/main/src/settingslist.h

--- a/docs/guides.md
+++ b/docs/guides.md
@@ -3,8 +3,7 @@
 Guides are part of the "Tips & Tricks" page and they are a way to inform the
 users about features, HowTo, and functionalities of the Mozilla VPN app.
 
-Technically, they are implemented as JSON files, stored in the `qrc://guides`
-folder.
+Technically, they are implemented as add-ons (see the add-on documentation).
 
 The JSON files are validated via [JSON Schema](https://json-schema.org/) files:
 https://github.com/mozilla-mobile/mozilla-vpn-client/tree/main/scripts/ci/jsonSchemas
@@ -13,13 +12,13 @@ On this page, we want to describe how to write new guides.
 
 ## JSON format
 
-The Guide JSON files are JSON objects. The required properties are:
+The Guide JSON files are add-on JSON objects, with type "guide" and a "guide"
+property object with the following properties:
 
 
 | Property | Description | Type | Required |
 | --- | --- | --- | --- |
 | id | Each guide must have an id. This is used for the localization | String | Yes |
-| conditions | A list of conditions to be checked before exposing the guide. See below | Condition object | No |
 | title | The title of the Guide | String | Yes |
 | title_comment | An optional comment to describe the meaning of the title | String | No |
 | subtitle | The subtitle of the Guide | String | Yes |
@@ -49,25 +48,3 @@ If the content is an object, it must contains the following properties:
 | id | Each content must have an id. This is used for the localization | String | Yes |
 | content | The text content of the sub block | String | Yes |
 | comment | An optional comment to describe the meaning of the content | String | No | 
-
-### Condition object
-
-The condition object contains the following properties:
-
-| Property | Description | Type | Required |
-| --- | --- | --- | --- |
-| enabledFeatures | An array of features to be enabled | Array of string | No |
-| platforms | An array of platforms to be checked | Array of string | No |
-| settings | An array of Condition Setting object. See below | Array of Condition Setting object | No |
-
-### Condition Setting object
-
-When a setting must be checked as a condition, the JSON object must contain the following properties:
-
-| Property | Description | Type | Required |
-| --- | --- | --- | --- |
-| setting | The name of the setting key | String | Yes |
-| value | The value of the setting key | String | Yes |
-| op | The compare operator: eq or neq | String | Yes |
-
-The list of setting keys can be found here: https://github.com/mozilla-mobile/mozilla-vpn-client/blob/main/src/settingslist.h

--- a/docs/tutorials.md
+++ b/docs/tutorials.md
@@ -3,8 +3,7 @@
 Tutorials are part of the "Tips & Tricks" page and they are a way to teach how
 to use the Mozilla VPN features with an interactive system.
 
-Technically, they are implemented as JSON files, stored in the `qrc://tutorials`
-folder.
+Technically, they are implemented as add-ons (see the add-on documentation).
 
 The JSON files are validated via [JSON Schema](https://json-schema.org/) files:
 https://github.com/mozilla-mobile/mozilla-vpn-client/tree/main/scripts/ci/jsonSchemas
@@ -13,12 +12,12 @@ On this page, we want to describe how to write new tutorials.
 
 ## JSON format
 
-The Tutorial JSON files are JSON objects. The required properties are:
+The Tutorial JSON files are add-on JSON objects, with type "tutorial" and a "tutorial"
+property object with the following properties:
 
 | Property | Description | Type | Required |
 | --- | --- | --- | --- |
 | id | Each tutorial must have an id. This is used for the localization | String | Yes |
-| conditions | A list of conditions to be checked before exposing the tutorial. See below | Condition object | No |
 | highlighted | Is this tutorial highlighted? | Boolean | No |
 | title | The title of the Tutorial | String | Yes |
 | title_comment | An optional comment to describe the meaning of the title | String | No |
@@ -47,7 +46,7 @@ A step is a JSON object composed of the following properties:
 
 ### Condition object
 
-The condition object is similar to the Guide one. See the Guide documentation.
+The condition object is similar to the add-on one. See the Add-on documentation.
 
 ### Before object
 

--- a/scripts/ci/jsonSchemas/addon.json
+++ b/scripts/ci/jsonSchemas/addon.json
@@ -19,6 +19,9 @@
       "type": "string",
       "description": "The type of the addon: tutorial, guide, i18n"
     },
+    "conditions": {
+      "$ref": "conditions.json"
+    },
     "tutorial": {
       "$ref": "tutorial.json#"
     },

--- a/scripts/ci/jsonSchemas/guide.json
+++ b/scripts/ci/jsonSchemas/guide.json
@@ -8,9 +8,6 @@
       "description": "The ID of the guide",
       "pattern": "^[A-Za-z0-9_]+"
     },
-    "conditions": {
-      "$ref": "conditions.json"
-    },
     "title": {
       "type": "string",
       "description": "The title of the guide"

--- a/scripts/ci/jsonSchemas/tutorial.json
+++ b/scripts/ci/jsonSchemas/tutorial.json
@@ -8,9 +8,6 @@
       "description": "The ID of the tutorial",
       "pattern": "^[A-Za-z0-9_]+"
     },
-    "conditions": {
-      "$ref": "conditions.json#"
-    },
     "highlighted": {
       "type": "boolean",
       "description": "Is this tutorial highlighted?"

--- a/src/addons/addon.cpp
+++ b/src/addons/addon.cpp
@@ -9,18 +9,115 @@
 #include "addontutorial.h"
 #include "leakdetector.h"
 #include "logger.h"
-#include "models/guidemodel.h"
+#include "models/feature.h"
+#include "mozillavpn.h"
 #include "settingsholder.h"
 
 #include <QCoreApplication>
 #include <QDir>
 #include <QFileInfo>
+#include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
 
 namespace {
 Logger logger(LOG_MAIN, "Addon");
+
+bool evaluateConditionsEnabledFeatures(const QJsonArray& enabledFeatures) {
+  for (QJsonValue enabledFeature : enabledFeatures) {
+    QString featureName = enabledFeature.toString();
+
+    // If the feature doesn't exist, we crash.
+    const Feature* feature = Feature::get(featureName);
+    if (!feature) {
+      logger.info() << "Feature not found" << featureName;
+      return false;
+    }
+
+    if (!feature->isSupported()) {
+      logger.info() << "Feature not supported" << featureName;
+      return false;
+    }
+  }
+
+  return true;
 }
+
+bool evaluateConditionsPlatforms(const QJsonArray& platformArray) {
+  QStringList platforms;
+  for (QJsonValue platform : platformArray) {
+    platforms.append(platform.toString());
+  }
+
+  if (!platforms.isEmpty() &&
+      !platforms.contains(MozillaVPN::instance()->platform())) {
+    logger.info() << "Not supported platform";
+    return false;
+  }
+
+  return true;
+}
+
+bool evaluateConditionsSettingsOp(const QString& op, bool result) {
+  if (op == "eq") return result;
+
+  if (op == "neq") return !result;
+
+  logger.warning() << "Invalid settings operator" << op;
+  return false;
+}
+
+bool evaluateConditionsSettings(const QJsonArray& settings) {
+  for (QJsonValue setting : settings) {
+    QJsonObject obj = setting.toObject();
+
+    QString op = obj["op"].toString();
+    QString key = obj["setting"].toString();
+    QVariant valueA = SettingsHolder::instance()->rawSetting(key);
+    if (!valueA.isValid()) {
+      logger.info() << "Unable to retrieve setting key" << key;
+      return false;
+    }
+
+    QJsonValue valueB = obj["value"];
+    switch (valueB.type()) {
+      case QJsonValue::Bool:
+        if (!evaluateConditionsSettingsOp(op,
+                                          valueA.toBool() == valueB.toBool())) {
+          logger.info() << "Setting value doesn't match for key" << key;
+          return false;
+        }
+
+        break;
+
+      case QJsonValue::Double:
+        if (!evaluateConditionsSettingsOp(
+                op, valueA.toDouble() == valueB.toDouble())) {
+          logger.info() << "Setting value doesn't match for key" << key;
+          return false;
+        }
+
+        break;
+        break;
+
+      case QJsonValue::String:
+        if (!evaluateConditionsSettingsOp(
+                op, valueA.toString() == valueB.toString())) {
+          logger.info() << "Setting value doesn't match for key" << key;
+          return false;
+        }
+
+        break;
+
+      default:
+        logger.warning() << "Unsupported setting value type for key" << key;
+        return false;
+    }
+  }
+
+  return true;
+}
+}  // namespace
 
 // static
 Addon* Addon::create(QObject* parent, const QString& manifestFileName) {
@@ -49,6 +146,13 @@ Addon* Addon::create(QObject* parent, const QString& manifestFileName) {
   if (version != "0.1") {
     logger.warning() << "Unsupported API version" << version
                      << manifestFileName;
+    return nullptr;
+  }
+
+  QJsonObject conditions = obj["conditions"].toObject();
+  if (!evaluateConditions(conditions)) {
+    logger.info() << "Exclude the addon because conditions do not match"
+                  << manifestFileName;
     return nullptr;
   }
 
@@ -123,4 +227,22 @@ void Addon::retranslate() {
           QFileInfo(m_manifestFileName).dir().filePath("i18n"))) {
     logger.error() << "Loading the locale failed. - code:" << code;
   }
+}
+
+// static
+bool Addon::evaluateConditions(const QJsonObject& conditions) {
+  if (!evaluateConditionsEnabledFeatures(
+          conditions["enabledFeatures"].toArray())) {
+    return false;
+  }
+
+  if (!evaluateConditionsPlatforms(conditions["platforms"].toArray())) {
+    return false;
+  }
+
+  if (!evaluateConditionsSettings(conditions["settings"].toArray())) {
+    return false;
+  }
+
+  return true;
 }

--- a/src/addons/addon.h
+++ b/src/addons/addon.h
@@ -8,6 +8,8 @@
 #include <QObject>
 #include <QTranslator>
 
+class QJsonObject;
+
 class Addon : public QObject {
   Q_OBJECT
   Q_DISABLE_COPY_MOVE(Addon)
@@ -17,6 +19,8 @@ class Addon : public QObject {
 
  public:
   static Addon* create(QObject* parent, const QString& manifestFileName);
+
+  static bool evaluateConditions(const QJsonObject& conditions);
 
   ~Addon();
 

--- a/src/models/guide.h
+++ b/src/models/guide.h
@@ -22,8 +22,6 @@ class Guide final : public QObject {
   static Guide* create(QObject* parent, const QString& fileName);
   static Guide* create(QObject* parent, const QJsonObject& obj);
 
-  static bool evaluateConditions(const QJsonObject& conditions);
-
   const QString& titleId() const { return m_titleId; }
 
   ~Guide();

--- a/src/models/tutorial.cpp
+++ b/src/models/tutorial.cpp
@@ -49,12 +49,6 @@ Tutorial* Tutorial::create(QObject* parent, const QString& fileName) {
 
 // static
 Tutorial* Tutorial::create(QObject* parent, const QJsonObject& obj) {
-  QJsonObject conditions = obj["conditions"].toObject();
-  if (!Guide::evaluateConditions(conditions)) {
-    logger.info() << "Exclude the tutorial because conditions do not match";
-    return nullptr;
-  }
-
   QString tutorialId = obj["id"].toString();
   if (tutorialId.isEmpty()) {
     logger.warning() << "Empty ID for tutorial";

--- a/src/models/tutorialstep.cpp
+++ b/src/models/tutorialstep.cpp
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "tutorialstep.h"
-#include "guide.h"
+#include "addons/addon.h"
 #include "inspector/inspectorutils.h"
 #include "leakdetector.h"
 #include "logger.h"
@@ -106,7 +106,7 @@ void TutorialStep::start() {
 void TutorialStep::startInternal() {
   Q_ASSERT(m_started);
 
-  if (!Guide::evaluateConditions(m_conditions)) {
+  if (!Addon::evaluateConditions(m_conditions)) {
     logger.info()
         << "Exclude the tutorial step because conditions do not match";
     emit completed();

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -226,6 +226,8 @@ target_sources(unit_tests PRIVATE
     mocmozillavpn.cpp
     mocnetworkrequest.cpp
     helper.h
+    testaddon.cpp
+    testaddon.h
     testadjust.cpp
     testadjust.h
     testandroidmigration.cpp

--- a/tests/unit/testaddon.cpp
+++ b/tests/unit/testaddon.cpp
@@ -1,0 +1,122 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "testaddon.h"
+#include "../../src/addons/addon.h"
+#include "../../src/settingsholder.h"
+#include "helper.h"
+
+void TestAddon::conditions_data() {
+  QTest::addColumn<QJsonObject>("conditions");
+  QTest::addColumn<bool>("result");
+  QTest::addColumn<QString>("settingKey");
+  QTest::addColumn<QVariant>("settingValue");
+
+  QTest::addRow("empty") << QJsonObject() << true << "" << QVariant();
+
+  {
+    QJsonObject obj;
+    obj["platforms"] = QJsonArray{"foo"};
+    QTest::addRow("platforms") << obj << false << "" << QVariant();
+  }
+
+  {
+    QJsonObject obj;
+    obj["enabledFeatures"] = QJsonArray{"appReview"};
+    QTest::addRow("enabledFeatures") << obj << false << "" << QVariant();
+  }
+
+  {
+    QJsonObject obj;
+    QJsonObject settings;
+    obj["settings"] = QJsonArray{settings};
+    QTest::addRow("empty settings") << obj << false << "" << QVariant();
+
+    settings["op"] = "eq";
+    settings["setting"] = "foo";
+    settings["value"] = true;
+    obj["settings"] = QJsonArray{settings};
+    QTest::addRow("invalid settings") << obj << false << "" << QVariant();
+
+    QTest::addRow("string to boolean type settings - boolean")
+        << obj << true << "foo" << QVariant("wow");
+
+    QTest::addRow("op=eq settings - boolean")
+        << obj << true << "foo" << QVariant(true);
+
+    QTest::addRow("op=eq settings - boolean 2")
+        << obj << false << "foo" << QVariant(false);
+
+    settings["op"] = "WOW";
+    obj["settings"] = QJsonArray{settings};
+    QTest::addRow("invalid op settings - boolean")
+        << obj << false << "foo" << QVariant(false);
+
+    settings["op"] = "neq";
+    obj["settings"] = QJsonArray{settings};
+    QTest::addRow("op=neq settings - boolean")
+        << obj << true << "foo" << QVariant(false);
+
+    settings["op"] = "eq";
+    settings["value"] = 42;
+    obj["settings"] = QJsonArray{settings};
+    QTest::addRow("invalid type settings - double")
+        << obj << false << "foo" << QVariant("wow");
+
+    QTest::addRow("op=eq settings - double")
+        << obj << true << "foo" << QVariant(42);
+
+    QTest::addRow("op=eq settings - double 2")
+        << obj << false << "foo" << QVariant(43);
+
+    settings["op"] = "WOW";
+    obj["settings"] = QJsonArray{settings};
+    QTest::addRow("invalid op settings - double")
+        << obj << false << "foo" << QVariant(43);
+
+    settings["op"] = "neq";
+    obj["settings"] = QJsonArray{settings};
+    QTest::addRow("op=neq settings - double")
+        << obj << true << "foo" << QVariant(43);
+
+    settings["op"] = "eq";
+    settings["value"] = "wow";
+    obj["settings"] = QJsonArray{settings};
+    QTest::addRow("invalid type settings - string")
+        << obj << false << "foo" << QVariant(false);
+
+    QTest::addRow("op=eq settings - string")
+        << obj << true << "foo" << QVariant("wow");
+
+    QTest::addRow("op=eq settings - string 2")
+        << obj << false << "foo" << QVariant("wooow");
+
+    settings["op"] = "WOW";
+    obj["settings"] = QJsonArray{settings};
+    QTest::addRow("invalid op settings - string")
+        << obj << false << "foo" << QVariant("woow");
+
+    settings["op"] = "neq";
+    obj["settings"] = QJsonArray{settings};
+    QTest::addRow("op=neq settings - string")
+        << obj << true << "foo" << QVariant("woow");
+  }
+}
+
+void TestAddon::conditions() {
+  SettingsHolder settingsHolder;
+
+  QFETCH(QJsonObject, conditions);
+  QFETCH(bool, result);
+  QFETCH(QString, settingKey);
+  QFETCH(QVariant, settingValue);
+
+  if (!settingKey.isEmpty()) {
+    settingsHolder.setRawSetting(settingKey, settingValue);
+  }
+
+  QCOMPARE(Addon::evaluateConditions(conditions), result);
+}
+
+static TestAddon s_testAddon;

--- a/tests/unit/testaddon.h
+++ b/tests/unit/testaddon.h
@@ -4,13 +4,10 @@
 
 #include "helper.h"
 
-class TestGuide final : public TestHelper {
+class TestAddon final : public TestHelper {
   Q_OBJECT
 
  private slots:
-  void create_data();
-  void create();
-  void createNotExisting();
-
-  void model();
+  void conditions_data();
+  void conditions();
 };

--- a/tests/unit/testguide.cpp
+++ b/tests/unit/testguide.cpp
@@ -104,16 +104,6 @@ void TestGuide::create_data() {
   obj["blocks"] = blocks;
   QTest::addRow("with-block-type-olist-with-subblock")
       << "foo" << QJsonDocument(obj).toJson() << true;
-
-  obj["conditions"] = QJsonObject();
-  QTest::addRow("with-block-type-olist-with-subblock and conditions")
-      << "foo" << QJsonDocument(obj).toJson() << true;
-
-  block["type"] = "ulist";
-  blocks.replace(0, block);
-  obj["conditions"] = QJsonObject();
-  QTest::addRow("with-block-type-ulist-with-subblock and conditions")
-      << "foo" << QJsonDocument(obj).toJson() << true;
 }
 
 void TestGuide::create() {
@@ -173,118 +163,6 @@ void TestGuide::model() {
   Guide* guide =
       mg->data(mg->index(0, 0), GuideModel::GuideRole).value<Guide*>();
   QVERIFY(!!guide);
-}
-
-void TestGuide::conditions_data() {
-  QTest::addColumn<QJsonObject>("conditions");
-  QTest::addColumn<bool>("result");
-  QTest::addColumn<QString>("settingKey");
-  QTest::addColumn<QVariant>("settingValue");
-
-  QTest::addRow("empty") << QJsonObject() << true << "" << QVariant();
-
-  {
-    QJsonObject obj;
-    obj["platforms"] = QJsonArray{"foo"};
-    QTest::addRow("platforms") << obj << false << "" << QVariant();
-  }
-
-  {
-    QJsonObject obj;
-    obj["enabledFeatures"] = QJsonArray{"appReview"};
-    QTest::addRow("enabledFeatures") << obj << false << "" << QVariant();
-  }
-
-  {
-    QJsonObject obj;
-    QJsonObject settings;
-    obj["settings"] = QJsonArray{settings};
-    QTest::addRow("empty settings") << obj << false << "" << QVariant();
-
-    settings["op"] = "eq";
-    settings["setting"] = "foo";
-    settings["value"] = true;
-    obj["settings"] = QJsonArray{settings};
-    QTest::addRow("invalid settings") << obj << false << "" << QVariant();
-
-    QTest::addRow("string to boolean type settings - boolean")
-        << obj << true << "foo" << QVariant("wow");
-
-    QTest::addRow("op=eq settings - boolean")
-        << obj << true << "foo" << QVariant(true);
-
-    QTest::addRow("op=eq settings - boolean 2")
-        << obj << false << "foo" << QVariant(false);
-
-    settings["op"] = "WOW";
-    obj["settings"] = QJsonArray{settings};
-    QTest::addRow("invalid op settings - boolean")
-        << obj << false << "foo" << QVariant(false);
-
-    settings["op"] = "neq";
-    obj["settings"] = QJsonArray{settings};
-    QTest::addRow("op=neq settings - boolean")
-        << obj << true << "foo" << QVariant(false);
-
-    settings["op"] = "eq";
-    settings["value"] = 42;
-    obj["settings"] = QJsonArray{settings};
-    QTest::addRow("invalid type settings - double")
-        << obj << false << "foo" << QVariant("wow");
-
-    QTest::addRow("op=eq settings - double")
-        << obj << true << "foo" << QVariant(42);
-
-    QTest::addRow("op=eq settings - double 2")
-        << obj << false << "foo" << QVariant(43);
-
-    settings["op"] = "WOW";
-    obj["settings"] = QJsonArray{settings};
-    QTest::addRow("invalid op settings - double")
-        << obj << false << "foo" << QVariant(43);
-
-    settings["op"] = "neq";
-    obj["settings"] = QJsonArray{settings};
-    QTest::addRow("op=neq settings - double")
-        << obj << true << "foo" << QVariant(43);
-
-    settings["op"] = "eq";
-    settings["value"] = "wow";
-    obj["settings"] = QJsonArray{settings};
-    QTest::addRow("invalid type settings - string")
-        << obj << false << "foo" << QVariant(false);
-
-    QTest::addRow("op=eq settings - string")
-        << obj << true << "foo" << QVariant("wow");
-
-    QTest::addRow("op=eq settings - string 2")
-        << obj << false << "foo" << QVariant("wooow");
-
-    settings["op"] = "WOW";
-    obj["settings"] = QJsonArray{settings};
-    QTest::addRow("invalid op settings - string")
-        << obj << false << "foo" << QVariant("woow");
-
-    settings["op"] = "neq";
-    obj["settings"] = QJsonArray{settings};
-    QTest::addRow("op=neq settings - string")
-        << obj << true << "foo" << QVariant("woow");
-  }
-}
-
-void TestGuide::conditions() {
-  SettingsHolder settingsHolder;
-
-  QFETCH(QJsonObject, conditions);
-  QFETCH(bool, result);
-  QFETCH(QString, settingKey);
-  QFETCH(QVariant, settingValue);
-
-  if (!settingKey.isEmpty()) {
-    settingsHolder.setRawSetting(settingKey, settingValue);
-  }
-
-  QCOMPARE(Guide::evaluateConditions(conditions), result);
 }
 
 static TestGuide s_testGuide;

--- a/tests/unit/unit.pro
+++ b/tests/unit/unit.pro
@@ -133,6 +133,7 @@ HEADERS += \
     ../../src/urlopener.h \
     ../../src/websockethandler.h \
     helper.h \
+    testaddon.h \
     testadjust.h \
     testandroidmigration.h \
     testcommandlineparser.h \
@@ -249,6 +250,7 @@ SOURCES += \
     mocinspectorhandler.cpp \
     mocmozillavpn.cpp \
     mocnetworkrequest.cpp \
+    testaddon.cpp \
     testadjust.cpp \
     testandroidmigration.cpp \
     testcommandlineparser.cpp \


### PR DESCRIPTION
To clean up the code more, let's unify the "conditions" property in the addon manifest instead as a sub-property of tutorial/guide objects.