### PR TITLE
Support unique survey alert for 2.9 UR #3402 / VPN-2139 - WIP 

### DIFF
--- a/nebula/ui/components/VPNAlerts.qml
+++ b/nebula/ui/components/VPNAlerts.qml
@@ -47,7 +47,7 @@ ColumnLayout {
         alertText: qsTrId("vpn.systray.survey.wouldLoveYourFeedback")
         //% "Take Survey"
         alertActionText: qsTrId("vpn.systray.survey.takeSurvey")
-        visible: VPNSurveyModel.hasSurvey || isWasmViewer
+        visible: VPNSurveyModel.hasSurvey && !interceptSurveyAlert.visible /* TODO: && VPNSurveyModel.currentSurveyId === ""someUniqueInterceptSurveyId" */ || isWasmViewer
 
         onActionPressed: ()=>{
             VPNSurveyModel.openCurrentSurvey();
@@ -57,4 +57,20 @@ ColumnLayout {
         }
     }
 
+    VPNAlert {
+        // This survey will be shown in English only for X number of days in
+        // the 2.9 release cycle.
+
+        // TODO: Remove in 2.10
+
+        id: interceptSurveyAlert
+
+        isLayout: true
+        alertType: alertTypes.success
+        visible: /* TODO: && VPNSurveyModel.id === "someUniqueInterceptSurveyId" */ VPNSurveyModel.hasSurvey
+        alertText: "Share your VPN experience with us. Research participants receive $100."
+        alertActionText: "Learn more"
+        onActionPressed: ()=>VPNSurveyModel.openCurrentSurvey()
+        onClosePressed: ()=>VPNSurveyModel.dismissCurrentSurvey()
+    }
 }

--- a/nebula/ui/components/VPNAlerts.qml
+++ b/nebula/ui/components/VPNAlerts.qml
@@ -47,7 +47,7 @@ ColumnLayout {
         alertText: qsTrId("vpn.systray.survey.wouldLoveYourFeedback")
         //% "Take Survey"
         alertActionText: qsTrId("vpn.systray.survey.takeSurvey")
-        visible: VPNSurveyModel.hasSurvey && !interceptSurveyAlert.visible /* TODO: && VPNSurveyModel.currentSurveyId === ""someUniqueInterceptSurveyId" */ || isWasmViewer
+        visible: (VPNSurveyModel.hasSurvey && VPNSurveyModel.id !== "mozilla-vpn-survey-2022-05") /* TODO: Remove after 2.9 */ || isWasmViewer
 
         onActionPressed: ()=>{
             VPNSurveyModel.openCurrentSurvey();
@@ -67,7 +67,7 @@ ColumnLayout {
 
         isLayout: true
         alertType: alertTypes.success
-        visible: /* TODO: && VPNSurveyModel.id === "someUniqueInterceptSurveyId" */ VPNSurveyModel.hasSurvey
+        visible: VPNSurveyModel.id === "mozilla-vpn-survey-2022-05" &&  VPNSurveyModel.hasSurvey
         alertText: "Share your VPN experience with us. Research participants receive $100."
         alertActionText: "Learn more"
         onActionPressed: ()=>VPNSurveyModel.openCurrentSurvey()

--- a/src/models/surveymodel.cpp
+++ b/src/models/surveymodel.cpp
@@ -129,6 +129,13 @@ void SurveyModel::openCurrentSurvey() {
   }
 }
 
+QString SurveyModel::getCurrentSurveyId() {
+  if (m_currentSurveyId.isEmpty()) {
+    return "";
+  }
+  return m_currentSurveyId;
+}
+
 void SurveyModel::dismissCurrentSurvey() {
   SettingsHolder* settingsHolder = SettingsHolder::instance();
   Q_ASSERT(settingsHolder);

--- a/src/models/surveymodel.cpp
+++ b/src/models/surveymodel.cpp
@@ -129,13 +129,6 @@ void SurveyModel::openCurrentSurvey() {
   }
 }
 
-QString SurveyModel::getCurrentSurveyId() {
-  if (m_currentSurveyId.isEmpty()) {
-    return "";
-  }
-  return m_currentSurveyId;
-}
-
 void SurveyModel::dismissCurrentSurvey() {
   SettingsHolder* settingsHolder = SettingsHolder::instance();
   Q_ASSERT(settingsHolder);

--- a/src/models/surveymodel.h
+++ b/src/models/surveymodel.h
@@ -16,6 +16,8 @@ class SurveyModel final : public QObject {
   Q_DISABLE_COPY_MOVE(SurveyModel)
 
   Q_PROPERTY(bool hasSurvey READ hasSurvey NOTIFY hasSurveyChanged)
+  Q_PROPERTY(
+      QString currentSurveyId MEMBER m_currentSurveyId NOTIFY hasSurveyChanged)
 
  public:
   SurveyModel();
@@ -33,7 +35,6 @@ class SurveyModel final : public QObject {
 
   Q_INVOKABLE void openCurrentSurvey();
   Q_INVOKABLE void dismissCurrentSurvey();
-  Q_INVOKABLE QString getCurrentSurveyId();
 
  signals:
   void hasSurveyChanged();

--- a/src/models/surveymodel.h
+++ b/src/models/surveymodel.h
@@ -33,6 +33,7 @@ class SurveyModel final : public QObject {
 
   Q_INVOKABLE void openCurrentSurvey();
   Q_INVOKABLE void dismissCurrentSurvey();
+  Q_INVOKABLE QString getCurrentSurveyId();
 
  signals:
   void hasSurveyChanged();


### PR DESCRIPTION
## Description

<img width="300" alt="Screen Shot 2022-06-14 at 5 22 59 PM" src="https://user-images.githubusercontent.com/22355127/173699256-d9cf7f76-2d54-40a7-b751-695f3faa7db5.png">

   This adds client support for the survey alert described in https://github.com/mozilla-mobile/mozilla-vpn-client/issues/3402. This survey alert will be removed after 2.9.


## Reference

    #3402 

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
