### PR TITLE
Maybe fix appstore connect?

### DIFF
--- a/ci_scripts/ci_post_clone.sh
+++ b/ci_scripts/ci_post_clone.sh
@@ -18,6 +18,7 @@ git submodule update
 export PATH=/Users/local/.gem/ruby/2.6.0/bin:/Users/local/Library/Python/3.8/bin:$PATH
 
 python3 -m pip install --upgrade pip
+python3 -m pip install --upgrade setuptools
 
 if [ $CI_PRODUCT_PLATFORM == 'macOS' ]
 then


### PR DESCRIPTION
## Description
 Oh no its failing .__.
The error we see is 

```
`ModuleNotFoundError: No module named 'setuptools.command.build'
```



## Reference

    i.e Jira or Github issue URL

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
