### PR TITLE
Inspector command to force subscription management re-authentication

### DIFF
--- a/src/inspector/inspectorhandler.cpp
+++ b/src/inspector/inspectorhandler.cpp
@@ -541,6 +541,13 @@ static QList<InspectorCommand> s_commands{
           return QJsonObject();
         }},
 
+    InspectorCommand{
+        "force_subscription_management_reauthentication",
+        "Force re-authentication for the subscription management view", 0,
+        [](InspectorHandler*, const QList<QByteArray>&) {
+          return QJsonObject();
+        }},
+
     InspectorCommand{"activate", "Activate the VPN", 0,
                      [](InspectorHandler*, const QList<QByteArray>&) {
                        MozillaVPN::instance()->activate();

--- a/src/inspector/inspectorhandler.cpp
+++ b/src/inspector/inspectorhandler.cpp
@@ -17,6 +17,7 @@
 #include "mozillavpn.h"
 #include "networkmanager.h"
 #include "notificationhandler.h"
+#include "profileflow.h"
 #include "qmlengineholder.h"
 #include "serveri18n.h"
 #include "settingsholder.h"
@@ -545,6 +546,7 @@ static QList<InspectorCommand> s_commands{
         "force_subscription_management_reauthentication",
         "Force re-authentication for the subscription management view", 0,
         [](InspectorHandler*, const QList<QByteArray>&) {
+          MozillaVPN::instance()->profileFlow()->setForceReauthFlow(true);
           return QJsonObject();
         }},
 

--- a/src/profileflow.cpp
+++ b/src/profileflow.cpp
@@ -53,9 +53,8 @@ void ProfileFlow::start() {
   TaskGetSubscriptionDetails* task =
       new TaskGetSubscriptionDetails(user->email(), m_forceReauthFlow);
 
-  if (m_forceReauthFlow) {
-    setForceReauthFlow(false);
-  }
+  // Reset forcing the re-auth flow
+  setForceReauthFlow(false);
 
   connect(task, &TaskGetSubscriptionDetails::receivedData, this,
           &ProfileFlow::subscriptionDetailsFetched);

--- a/src/profileflow.cpp
+++ b/src/profileflow.cpp
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#include "constants.h"
 #include "leakdetector.h"
 #include "logger.h"
 #include "mozillavpn.h"

--- a/src/profileflow.h
+++ b/src/profileflow.h
@@ -33,16 +33,19 @@ class ProfileFlow final : public QObject {
 
   State state() const { return m_state; }
 
+  void setForceReauthFlow(const bool forceReauthFlow);
+
  signals:
   void stateChanged(State state);
 
  private:
-  void populateFakeData();
   void setState(State state);
   void subscriptionDetailsFetched(const QByteArray& subscriptionData);
 
  private:
   State m_state = StateInitial;
+
+  bool m_forceReauthFlow = false;
 };
 
 #endif  // PROFILEFLOW_H

--- a/src/tasks/getsubscriptiondetails/taskgetsubscriptiondetails.cpp
+++ b/src/tasks/getsubscriptiondetails/taskgetsubscriptiondetails.cpp
@@ -17,8 +17,9 @@ Logger logger(LOG_MAIN, "TaskGetSubscriptionDetails");
 
 TaskGetSubscriptionDetails::TaskGetSubscriptionDetails(
     const QString& emailAddress, const bool forceReauth)
-    : Task("TaskGetSubscriptionDetails"), m_emailAddress(emailAddress),
-        m_forceReauth(forceReauth) {
+    : Task("TaskGetSubscriptionDetails"),
+      m_emailAddress(emailAddress),
+      m_forceReauth(forceReauth) {
   MVPN_COUNT_CTOR(TaskGetSubscriptionDetails);
 }
 

--- a/src/tasks/getsubscriptiondetails/taskgetsubscriptiondetails.cpp
+++ b/src/tasks/getsubscriptiondetails/taskgetsubscriptiondetails.cpp
@@ -30,9 +30,12 @@ TaskGetSubscriptionDetails::~TaskGetSubscriptionDetails() {
 void TaskGetSubscriptionDetails::run() {
   logger.debug() << "run";
 
+  // If this Task is created with `forceReauth = true`,
+  // we are forcing the user to authenticate.
   if (m_forceReauth) {
     logger.error() << "Force authentication";
     initAuthentication();
+    // Reset the flag so we can run the Task after successful authentication.
     m_forceReauth = false;
     return;
   }

--- a/src/tasks/getsubscriptiondetails/taskgetsubscriptiondetails.h
+++ b/src/tasks/getsubscriptiondetails/taskgetsubscriptiondetails.h
@@ -14,7 +14,8 @@ class TaskGetSubscriptionDetails final : public Task {
   Q_DISABLE_COPY_MOVE(TaskGetSubscriptionDetails)
 
  public:
-  explicit TaskGetSubscriptionDetails(const QString& emailAddress);
+  explicit TaskGetSubscriptionDetails(const QString& emailAddress,
+                                      const bool forceReauth);
   ~TaskGetSubscriptionDetails();
 
   void run() override;
@@ -30,6 +31,7 @@ class TaskGetSubscriptionDetails final : public Task {
  private:
   AuthenticationInAppSession* m_authenticationInAppSession = nullptr;
   const QString m_emailAddress;
+  bool m_forceReauth;
 };
 
 #endif  // TASKGETSUBSCRIPTIONDETAILS_H

--- a/tests/functional/helper.js
+++ b/tests/functional/helper.js
@@ -123,7 +123,7 @@ module.exports = {
     const json = await this._writeCommand(
         'force_subscription_management_reauthentication');
     assert(
-        json.type === 'force_server_unavailable' && !('error' in json),
+        json.type === 'force_subscription_management_reauthentication' && !('error' in json),
         `Command failed: ${json.error}`);
   },
 

--- a/tests/functional/helper.js
+++ b/tests/functional/helper.js
@@ -119,6 +119,14 @@ module.exports = {
         `Command failed: ${json.error}`);
   },
 
+  async forceSubscriptionManagementReauth() {
+    const json = await this._writeCommand(
+        'force_subscription_management_reauthentication');
+    assert(
+        json.type === 'force_server_unavailable' && !('error' in json),
+        `Command failed: ${json.error}`);
+  },
+
   async forceCaptivePortalDetection() {
     const json = await this._writeCommand('force_captive_portal_detection');
     assert(


### PR DESCRIPTION
## Description

This PR adds the inspector command `force_subscription_managment_reauthentication` for testing the re-authentication flow for the subscription management view.

## Reference

[VPN-2320](https://mozilla-hub.atlassian.net/jira/software/c/projects/VPN/boards/344?modal=detail&selectedIssue=)

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
