### PR TITLE
Add missing entitlements

### DIFF
--- a/taskcluster/scripts/signing/entitlements.xml
+++ b/taskcluster/scripts/signing/entitlements.xml
@@ -8,6 +8,9 @@
       <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
-
+	<key>com.apple.security.network.client</key>
+	<true/>
+	<key>com.apple.security.network.server</key>
+	<true/>
       </dict>
 </plist>0


### PR DESCRIPTION
## Description
To build unsigned builds we're using these entitlements:
https://github.com/mozilla-mobile/mozilla-vpn-client/blob/basti/addEntitlements/macos/app/app.entitlements


However the taskcluster macos-sign seems to be using those:
https://github.com/mozilla-mobile/mozilla-vpn-client/blob/main/taskcluster/scripts/signing/entitlements.xml

Looking at codesign, this seems to match:
```
$basti codesign -d --entitlements :- /Applications/Mozilla\ VPN.app/
   <?xml version="1.0" encoding="UTF-8"?>
   <plist version="1.0">
 <dict>
 <key>
  com.apple.security.app-sandbox
 </key>
 <true/>
 </dict>
</plist>

```

Which means we're certainly missing network.client/server.
