### PR TITLE
ci: Add missing 'index' prefix to Taskcluster branch routes

### DIFF
--- a/taskcluster/mozillavpn_taskgraph/transforms/release_index.py
+++ b/taskcluster/mozillavpn_taskgraph/transforms/release_index.py
@@ -8,16 +8,17 @@ transforms = TransformSequence()
 
 _GIT_REFS_HEADS_PREFIX = "refs/heads/"
 
+
 @transforms.add
 def add_branch_index(config, tasks):
-   for task in tasks:
+    for task in tasks:
         if "add-branch-index" in task:
             release_index = task.pop("add-branch-index")
             if release_index and int(config.params["level"]) == 3:
                 name = task['name'].split("/")[0]
                 git_branch = config.params["head_ref"]
                 if git_branch.startswith(_GIT_REFS_HEADS_PREFIX):
-                    git_branch = git_branch[len(_GIT_REFS_HEADS_PREFIX) :]
-                route = f"mozillavpn.v2.mozilla-vpn-client.branch.{git_branch}.{name}"
+                    git_branch = git_branch[len(_GIT_REFS_HEADS_PREFIX):]
+                route = f"index.mozillavpn.v2.mozilla-vpn-client.branch.{git_branch}.latest.{name}"
                 task.setdefault("routes", []).append(route)
         yield task


### PR DESCRIPTION
I also added a 'latest' to the route for two reasons:

A) Consistency with the decision task
B) This will leave the door open to other branch based routes so we can
e.g find tasks by revision, date or version number in the future.

Jira: RELENG-938