### PR TITLE
Fix parsing of subscription payment data

### DIFF
--- a/src/subscriptiondata.cpp
+++ b/src/subscriptiondata.cpp
@@ -118,7 +118,8 @@ bool SubscriptionData::fromJson(const QByteArray& json) {
         }
         m_creditCardLast4 = creditCardLast4.toString();
 
-        m_creditCardExpMonth = paymentData.value("credit_card_exp_month").toInt();
+        m_creditCardExpMonth =
+            paymentData.value("credit_card_exp_month").toInt();
         if (!m_creditCardExpMonth) {
           return false;
         }

--- a/src/subscriptiondata.cpp
+++ b/src/subscriptiondata.cpp
@@ -87,34 +87,47 @@ bool SubscriptionData::fromJson(const QByteArray& json) {
   // Payment
   QJsonObject paymentData = obj.value("payment").toObject();
 
-  QJsonValue paymentType = paymentData.value("type");
-  if (!paymentType.isString()) {
-    return false;
-  }
-
-  m_paymentType = paymentType.toString();
-
-  if (m_paymentType == "credit") {
-    QJsonValue creditCardBrand = paymentData.value("credit_card_brand");
-    if (!creditCardBrand.isString()) {
+  // If we do not receive payment data from FxA we don’t show it instead of
+  // throwing an error. There is a known bug with FxA which causes FxA to not
+  // show payment info: https://mozilla-hub.atlassian.net/browse/FXA-3856.
+  if (!paymentData.isEmpty()) {
+    // Payment provider
+    QJsonValue paymentProvider = paymentData.value("provider");
+    // We should always get a payment provider if there is payment data
+    if (!paymentProvider.isString()) {
       return false;
     }
-    m_creditCardBrand = creditCardBrand.toString();
+    m_paymentProvider = paymentProvider.toString();
 
-    QJsonValue creditCardLast4 = paymentData.value("credit_card_last4");
-    if (!creditCardBrand.isString()) {
-      return false;
-    }
-    m_creditCardLast4 = creditCardLast4.toString();
+    // Payment type
+    QJsonValue paymentType = paymentData.value("type");
+    if (paymentType.isString()) {
+      m_paymentType = paymentType.toString();
 
-    m_creditCardExpMonth = paymentData.value("credit_card_exp_month").toInt();
-    if (!m_creditCardExpMonth) {
-      return false;
-    }
+      // For credit cards we also show card details
+      if (m_paymentType == "credit") {
+        QJsonValue creditCardBrand = paymentData.value("credit_card_brand");
+        if (!creditCardBrand.isString()) {
+          return false;
+        }
+        m_creditCardBrand = creditCardBrand.toString();
 
-    m_creditCardExpYear = paymentData.value("credit_card_exp_year").toInt();
-    if (!m_creditCardExpYear) {
-      return false;
+        QJsonValue creditCardLast4 = paymentData.value("credit_card_last4");
+        if (!creditCardBrand.isString()) {
+          return false;
+        }
+        m_creditCardLast4 = creditCardLast4.toString();
+
+        m_creditCardExpMonth = paymentData.value("credit_card_exp_month").toInt();
+        if (!m_creditCardExpMonth) {
+          return false;
+        }
+
+        m_creditCardExpYear = paymentData.value("credit_card_exp_year").toInt();
+        if (!m_creditCardExpYear) {
+          return false;
+        }
+      }
     }
   }
 

--- a/src/subscriptiondata.h
+++ b/src/subscriptiondata.h
@@ -26,6 +26,7 @@ class SubscriptionData final : public QObject {
   Q_PROPERTY(int planIntervalCount MEMBER m_planIntervalCount CONSTANT)
 
   // Payment
+  Q_PROPERTY(QString paymentProvider MEMBER m_paymentProvider CONSTANT)
   Q_PROPERTY(QString paymentType MEMBER m_paymentType CONSTANT)
   Q_PROPERTY(QString creditCardBrand MEMBER m_creditCardBrand CONSTANT)
   Q_PROPERTY(QString creditCardLast4 MEMBER m_creditCardLast4 CONSTANT)
@@ -56,6 +57,7 @@ class SubscriptionData final : public QObject {
   QString m_planCurrency;
   int m_planIntervalCount = 0;
 
+  QString m_paymentProvider;
   QString m_paymentType;
   QString m_creditCardBrand;
   QString m_creditCardLast4;

--- a/src/ui/settings/ViewSubscriptionManagement/ViewSubscriptionManagement.qml
+++ b/src/ui/settings/ViewSubscriptionManagement/ViewSubscriptionManagement.qml
@@ -165,24 +165,26 @@ VPNFlickable {
         });
 
         // Subscription payment model
-        if (VPNSubscriptionData.paymentType === "credit") {
-            subscriptionPaymentModel.append({
-                labelText: VPNSubscriptionData.creditCardBrand,
-                valueText: VPNl18n.SubscriptionManagementCardLast4.arg(VPNSubscriptionData.creditCardLast4),
-                type: "payment",
-            });
+        if (VPNSubscriptionData.paymentProvider) {
+            if (VPNSubscriptionData.paymentType === "credit") {
+                subscriptionPaymentModel.append({
+                    labelText: VPNSubscriptionData.creditCardBrand,
+                    valueText: VPNl18n.SubscriptionManagementCardLast4.arg(VPNSubscriptionData.creditCardLast4),
+                    type: "payment",
+                });
 
-            subscriptionPaymentModel.append({
-                labelText: VPNl18n.SubscriptionManagementCardExpiresLabel,
-                valueText: getPaymentExpiration(),
-                type: "text",
-            });
-        } else {
-            subscriptionPaymentModel.append({
-                labelText: VPNSubscriptionData.paymentType,
-                valueText: "",
-                type: "payment",
-            });
+                subscriptionPaymentModel.append({
+                    labelText: VPNl18n.SubscriptionManagementCardExpiresLabel,
+                    valueText: getPaymentExpiration(),
+                    type: "text",
+                });
+            } else {
+                subscriptionPaymentModel.append({
+                    labelText: VPNSubscriptionData.paymentType || VPNSubscriptionData.paymentProvider,
+                    valueText: "",
+                    type: "payment",
+                });
+            }
         }
     }
 


### PR DESCRIPTION
## Description

The parsing of the received subscription `payment` data from FxA did not handle missing data well and was also missing the payment `provider`. There are instances where we would expect payment information for a subscription, but due to an issue ([FXA-3856](https://mozilla-hub.atlassian.net/browse/FXA-3856)) we could end up not receiving it. In that case let’s just not show it instead of throwing an error and blocking the user from accessing the `profile` view.

## Reference

- Resolves #3789

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
