### PR TITLE
[2.9.0] Properly disable qmljsdebugger in release mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,17 +6,17 @@ cmake_minimum_required(VERSION 3.16)
 
 option(BUILD_DUMMY "Build for the dummy platform" OFF)
 
-project("Mozilla VPN" VERSION 2.9.0 LANGUAGES C CXX
-        DESCRIPTION "A fast, secure and easy to use VPN. Built by the makers of Firefox."
-        HOMEPAGE_URL "https://vpn.mozilla.org"
-)
-
 message("Configuring for ${CMAKE_GENERATOR}")
-if(NOT (DEFINED CMAKE_CONFIGURATION_TYPES OR "${CMAKE_BUILD_TYPE}"))
+if(NOT (DEFINED CMAKE_CONFIGURATION_TYPES OR DEFINED CMAKE_BUILD_TYPE))
     ## Ensure the build type is set for single-config generators.
     set(CMAKE_BUILD_TYPE "Debug" CACHE PATH "default build type" FORCE)
     message("Setting build type ${CMAKE_BUILD_TYPE}")
 endif()
+
+project("Mozilla VPN" VERSION 2.9.0 LANGUAGES C CXX
+        DESCRIPTION "A fast, secure and easy to use VPN. Built by the makers of Firefox."
+        HOMEPAGE_URL "https://vpn.mozilla.org"
+)
 
 ## Toolchain Setup
 set(CMAKE_CXX_STANDARD 17)

--- a/src/qmake/debug.pri
+++ b/src/qmake/debug.pri
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-debug {
+CONFIG(debug, debug|release) {
     # If in debug mode, set mvpn_debug flag too.
     CONFIG += mvpn_debug
 }


### PR DESCRIPTION
## Description

This is a 2.9.0 backport of the security fix for both qmake and CMake in #3539.

> * In qmake, the `debug` variable and the `release` variable are both present by default.  We need to check which one is active, by virtue of having been set later.
>
>   https://doc.qt.io/qt-6/qmake-test-function-reference.html#config-config
>
> * In CMake, the `"${CMAKE_BUILD_TYPE}"` test did not do what it looks like it does.  CMake evaluates `if("${CMAKE_BUILD_TYPE}")` to `if(Release)`, which tests whether the *variable named `Release`* is defined; it isn’t, so we were unconditionally setting `CMAKE_BUILD_TYPE` to `Debug`.
>
>   https://cmake.org/cmake/help/latest/command/if.html#variable-expansion
>
>   We need to check whether `CMAKE_BUILD_TYPE` variable itself is defined, and we need to do so before `project()` defines it by default.

(There was a trivial merge conflict on the line with the version number, and I wanted to make sure this isn’t forgotten for the 2.9.0 release that appears to be imminent.)

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
