### PR TITLE
Fix Missing Text in segmented button

### DIFF
--- a/nebula/ui/components/VPNSegmentedToggle.qml
+++ b/nebula/ui/components/VPNSegmentedToggle.qml
@@ -106,7 +106,9 @@ Rectangle {
                     text: VPNl18n[segmentLabelStringId]
                     horizontalAlignment: Text.AlignHCenter
                     verticalAlignment: Text.AlignVCenter
-                    elide: Text.ElideRight
+                    // Bug VPN-2158 - Apparently QText is not rendered on android
+                    // When we select any other elide then none
+                    elide: Qt.platform.os === "android" ? Text.ElideNone : Text.ElideRight
                     font.family: VPNTheme.theme.fontBoldFamily
                     font.pixelSize: VPNTheme.theme.fontSize
                     color: {


### PR DESCRIPTION
## Description

ElideRight seems to cause android to simply not render any text, so lets make it conditional 

![Screenshot 2022-06-22 142416](https://user-images.githubusercontent.com/9611612/175028759-2fcf92d2-2c99-4606-ad70-6405ba4ef9a9.png)



## Reference

Fixes https://mozilla-hub.atlassian.net/browse/VPN-2158
Closes #3437

