### PR TITLE
Show tooltips only on hover during a tutorial

### DIFF
--- a/nebula/ui/components/VPNToolTip.qml
+++ b/nebula/ui/components/VPNToolTip.qml
@@ -11,7 +11,7 @@ import compat 0.1
 ToolTip {
     id: toolTip
 
-    visible: mouseArea.containsMouse || parent.activeFocus
+    visible: mouseArea.containsMouse || (parent.activeFocus && !tutorialUI.visible)
     onVisibleChanged: if (visible) fadeDown.start()
     leftMargin: VPNTheme.theme.windowMargin * 1.5
     rightMargin: VPNTheme.theme.windowMargin * 1.5


### PR DESCRIPTION
## Description

This prevents tooltips from opening when an element has focus during a tutorial. Tooltips will still open if the user hovers over an accepted element.

## Reference

#3795 #3794 

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
