### PR TITLE
Fix #3811 - Leave tutorial modal issues when opened from top bar

### DIFF
--- a/nebula/ui/components/VPNTutorialPopups.qml
+++ b/nebula/ui/components/VPNTutorialPopups.qml
@@ -228,7 +228,12 @@ Item {
 
     function openLeaveTutorialPopup(callback = () => {}) {
         tutorialPopup.imageSrc = "qrc:/ui/resources/logo-error.svg";
-        tutorialPopup.primaryButtonOnClicked = () => tutorialPopup.close();
+
+        tutorialPopup.primaryButtonOnClicked = () => {
+            tutorialPopup._onClosed = () => {};
+            tutorialPopup.close();
+        }
+
         tutorialPopup.secondaryButtonOnClicked = () => {
             tutorialPopup._onClosed = () => callback()
             leaveTutorial();


### PR DESCRIPTION
## Description

    Fixes wonky behavior described in #3811 when the "Leave tutorial?" modal is triggered twice by attempting to open Preferences or Contact support from the macos top menu bar whilst taking a tutorial. 

## Reference

    #3811

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
