### PR TITLE
Support back-button on android in the guide view - fixes VPN-2435

### DIFF
--- a/src/ui/settings/ViewGuide.qml
+++ b/src/ui/settings/ViewGuide.qml
@@ -239,4 +239,16 @@ Item {
             }
         }
     }
+
+    Connections {
+        function onGoBack(item) {
+            if (item === root)
+                mainStackView.pop();
+
+        }
+
+        target: VPNCloseEventHandler
+    }
+
+    Component.onCompleted: VPNCloseEventHandler.addView(root)
 }


### PR DESCRIPTION
The issue is in how we load ViewGuide.qml: always on the mainview stack. We do
it also when we are in settings.  When we go back, the app removes a layer on
top stack view (settings) and the tips&tricks view goes away, instead of the
guide.