### PR TITLE
feature tour and guide view layout fixes

### DIFF
--- a/nebula/ui/components/VPNFeatureTour.qml
+++ b/nebula/ui/components/VPNFeatureTour.qml
@@ -53,7 +53,6 @@ ColumnLayout {
 
                     asynchronous: true
                     visible: status == Loader.Ready
-                    active: index === swipeView.currentIndex
                     opacity: index === swipeView.currentIndex ? 1 : 0
 
                     Behavior on opacity {
@@ -199,9 +198,15 @@ ColumnLayout {
 
         tour.started();
 
-        //Calculate which slide is the tallest so we can set that height to the swipe view, this way the modal does not change size
+        calculateTallestSlideHeight()
+    }
+
+    //Calculate which slide is the tallest so we can set that height to the swipe view, this way the modal does not change size
+    function calculateTallestSlideHeight() {
         var tallestSlideHeight = 0
         for(var i = 0; i < slidesRepeater.count; i++) {
+            slidesRepeater.itemAt(i).active = false
+            slidesRepeater.itemAt(i).active = true
             const slideHeight = slidesRepeater.itemAt(i).implicitHeight
             if (slideHeight > tallestSlideHeight) tallestSlideHeight = slideHeight
         }
@@ -212,4 +217,20 @@ ColumnLayout {
         swipeView.contentItem.highlightMoveDuration = 250;
         swipeView.decrementCurrentIndex();
     }
+
+    //Hacky workaround to recalculate tallest slide height after a language change
+    Timer {
+        id: calculateTallestSlideTimer
+        interval: 50
+        repeat: false
+        onTriggered: {
+            for(var i = 0; i < slidesRepeater.count; i++) {
+                slidesRepeater.itemAt(i).active = false
+                slidesRepeater.itemAt(i).active = true
+            }
+            calculateTallestSlideHeight()
+        }
+    }
+
+    onVisibleChanged: if(visible) calculateTallestSlideTimer.start()
 }

--- a/src/ui/settings/ViewGuide.qml
+++ b/src/ui/settings/ViewGuide.qml
@@ -166,6 +166,7 @@ Item {
                                 font.pixelSize: VPNTheme.theme.fontSize
                                 lineHeight: VPNTheme.theme.labelLineHeight
                                 verticalAlignment: Text.AlignVCenter
+                                wrapMode: Text.Wrap
                             }
                         }
 


### PR DESCRIPTION
## Description

- Fix layout issues in the feature tour card when switching between languages
- Fix title blocks in guide view from going off the edge of the screen

## Reference

[VPN-2446: When accessing the “Tour the VPN” option for the first time, after changing the language from English, the text is cut off](https://mozilla-hub.atlassian.net/browse/VPN-2446)

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
