### PR TITLE
Add fallback path when pkg-config is unable to find systemd

### DIFF
--- a/src/cmake/linux.cmake
+++ b/src/cmake/linux.cmake
@@ -114,10 +114,10 @@ install(FILES platforms/linux/daemon/org.mozilla.vpn.conf
 install(FILES platforms/linux/daemon/org.mozilla.vpn.dbus.service
     DESTINATION ${CMAKE_INSTALL_DATADIR}/dbus-1/system-services)
 
-## This is only really needed when building from source. Otherwise, we
-## expect the Distro's packaging magic to sort this out.
 pkg_check_modules(SYSTEMD systemd)
 if("${SYSTEMD_FOUND}" EQUAL 1)
     pkg_get_variable(SYSTEMD_UNIT_DIR systemd systemdsystemunitdir)
     install(FILES ../linux/mozillavpn.service DESTINATION ${SYSTEMD_UNIT_DIR})
+else()
+    install(FILES ../linux/mozillavpn.service DESTINATION /lib/systemd/system)
 endif()


### PR DESCRIPTION
## Description
When pkg-config is unable to locate the systemd package configuration, we skip the installation of the systemd service file on the assumption that the packaging tools will install it for us. Unfortunately, it seems that this assumption isn't true on Ubuntu/18.04 Bionic, which leaves the MozillaVPN service incorrectly installed.

When this occurs, let's choose a sensible default of `/lib/systemd/system` instead.

## Reference
Github: #3670
JIRA: [VPN-2322](https://mozilla-hub.atlassian.net/browse/VPN-2322)

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
