### PR TITLE
Fixes app background color and divider color on Android

### DIFF
--- a/nebula/ui/components/VPNCheckBoxRow.qml
+++ b/nebula/ui/components/VPNCheckBoxRow.qml
@@ -103,7 +103,7 @@ RowLayout {
             Layout.topMargin: VPNTheme.theme.windowMargin
             Layout.preferredHeight: 1
             Layout.fillWidth: true
-            color: "#E7E7E7"
+            color: VPNTheme.colors.grey10
             visible: showDivider
         }
 

--- a/src/crashreporter/crashui/main.qml
+++ b/src/crashreporter/crashui/main.qml
@@ -32,7 +32,7 @@ Window {
     maximumHeight: fullscreenRequired() ? Screen.height : VPNTheme.theme.desktopAppHeight;
 
     title: VPNl18n.CrashreporterMainTitle
-    color: "#F9F9FA"
+    color: VPNTheme.theme.bgColor
 
     Rectangle {
         id: iosSafeAreaTopMargin

--- a/src/ui/main.qml
+++ b/src/ui/main.qml
@@ -63,7 +63,7 @@ Window {
 
     //% "Mozilla VPN"
     title: qsTrId("vpn.main.productName")
-    color: "#F9F9FA"
+    color: VPNTheme.theme.bgColor
     onClosing: close => {
         console.log("Closing request handling");
 


### PR DESCRIPTION
## Description

   This fixes a few color issues I noticed while debugging something else on Android
<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>
<img width="502" alt="Screen Shot 2022-06-22 at 4 43 11 PM" src="https://user-images.githubusercontent.com/22355127/175160115-0c29e2e6-71ed-485f-aa6b-708ea8d661ef.png">
</td>
<td>
<img width="505" alt="Screen Shot 2022-06-22 at 4 49 15 PM" src="https://user-images.githubusercontent.com/22355127/175160130-f3d401ac-066f-4456-b83c-27932e403b27.png"

</td>
</tr>


<tr>
<td>
<img width="505" alt="Screen Shot 2022-06-22 at 4 19 08 PM" src="https://user-images.githubusercontent.com/22355127/175160195-e0f29b07-3e8d-4c48-b9ee-befe30a8faa4.png">
</td>
<td>
<img width="501" alt="Screen Shot 2022-06-22 at 4 49 52 PM" src="https://user-images.githubusercontent.com/22355127/175160264-684fd267-b741-4ee3-a6cb-cfa4da6b1474.png">

</td>
</tr>

<tr>
<td>
<img width="504" alt="Screen Shot 2022-06-22 at 4 41 58 PM" src="https://user-images.githubusercontent.com/22355127/175159303-f1ce18ad-201c-4755-a20a-fc15b3c7c3c5.png">
</td>
<td>
<img width="506" alt="Screen Shot 2022-06-22 at 4 48 14 PM" src="https://user-images.githubusercontent.com/22355127/175159867-9fa92359-185f-4a46-910c-27e56bb2d165.png">
</td>
</tr>

</table>

## Reference

    i.e Jira or Github issue URL

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
