### PR TITLE
Add QEvent::TouchEnd to ItemPicker::eventFilterInternal

### DIFF
--- a/src/itempicker.cpp
+++ b/src/itempicker.cpp
@@ -24,6 +24,7 @@ bool ItemPicker::eventFilter(QObject* obj, QEvent* event) {
 }
 
 bool ItemPicker::eventFilterInternal(QObject* obj, QEvent* event) {
+  qDebug() << event->type();
   if (event->type() == QEvent::Wheel) {
     return true;
   }
@@ -32,7 +33,8 @@ bool ItemPicker::eventFilterInternal(QObject* obj, QEvent* event) {
                       event->type() == QEvent::MouseButtonDblClick ||
                       event->type() == QEvent::MouseButtonRelease;
   bool isTouchEvent =
-      event->type() == QEvent::TouchBegin &&
+      (event->type() == QEvent::TouchEnd ||
+       event->type() == QEvent::TouchBegin) &&
       !!qobject_cast<QQuickWindow*>(static_cast<QTouchEvent*>(event)->target());
 
   if (

--- a/src/itempicker.cpp
+++ b/src/itempicker.cpp
@@ -24,7 +24,6 @@ bool ItemPicker::eventFilter(QObject* obj, QEvent* event) {
 }
 
 bool ItemPicker::eventFilterInternal(QObject* obj, QEvent* event) {
-  qDebug() << event->type();
   if (event->type() == QEvent::Wheel) {
     return true;
   }


### PR DESCRIPTION
## Description

This adds `QEvent::TouchEnd` to `ItemPicker::eventFilterInternal` to fix #3814. 

## Reference

#3814

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
