### PR TITLE
Add index routes to find builds from a `github-release` graph

### DIFF
--- a/taskcluster/ci/build/windows.yml
+++ b/taskcluster/ci/build/windows.yml
@@ -3,7 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 ---
 windows/opt:
-    add-branch-index: build
+    add-index-routes: build
     description: "Windows Build"
     treeherder:
         symbol: B

--- a/taskcluster/ci/build/windows.yml
+++ b/taskcluster/ci/build/windows.yml
@@ -3,7 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 ---
 windows/opt:
-    add-branch-index: true
+    add-branch-index: build
     description: "Windows Build"
     treeherder:
         symbol: B

--- a/taskcluster/ci/signing/kind.yml
+++ b/taskcluster/ci/signing/kind.yml
@@ -29,7 +29,7 @@ job-template:
     description: Sign MozillaVPN
     worker: {} # Will be configured by signing:transforms
     run-on-tasks-for: []
-    add-branch-index: build
+    add-index-routes: build
     signing-format:
         by-build-type:
             android.*: autograph_apk

--- a/taskcluster/ci/signing/kind.yml
+++ b/taskcluster/ci/signing/kind.yml
@@ -29,7 +29,7 @@ job-template:
     description: Sign MozillaVPN
     worker: {} # Will be configured by signing:transforms
     run-on-tasks-for: []
-    add-branch-index: true
+    add-branch-index: build
     signing-format:
         by-build-type:
             android.*: autograph_apk

--- a/taskcluster/mozillavpn_taskgraph/transforms/release_index.py
+++ b/taskcluster/mozillavpn_taskgraph/transforms/release_index.py
@@ -12,23 +12,36 @@ _GIT_REFS_HEADS_PREFIX = "refs/heads/"
 BRANCH_INDEX_ROUTES = (
     "index.mozillavpn.v2.mozilla-vpn-client.branch.{branch}.latest.{task_type}.{name}",
 )
+RELEASE_INDEX_ROUTES = (
+    "index.mozillavpn.v2.mozilla-vpn-client.release.{version}.latest.{task_type}.{name}",
+)
 
 
 @transforms.add
-def add_branch_index(config, tasks):
+def add_index_routes(config, tasks):
     for task in tasks:
-        task_type = task.pop("add-branch-index", None)
-        if task_type and int(config.params["level"]) == 3:
-            name = task["name"].split("/")[0]
+        task_type = task.pop("add-index-routes", None)
+        if not task_type or int(config.params["level"]) != 3:
+            yield task
+            continue
+
+        routes = []
+        context = {
+            "name": task["name"].split("/")[0],
+            "task_type": task_type,
+        }
+        if config.params["tasks_for"] == "github-push":
+            routes = BRANCH_INDEX_ROUTES
             branch = config.params["head_ref"]
             if branch.startswith(_GIT_REFS_HEADS_PREFIX):
                 branch = branch[len(_GIT_REFS_HEADS_PREFIX):]
+            context["branch"] = branch
 
-            task.setdefault("routes", [])
-            for route in BRANCH_INDEX_ROUTES:
-                task["routes"].append(route.format(
-                    branch=branch,
-                    task_type=task_type,
-                    name=name,
-                ))
+        elif config.params["tasks_for"] == "github-release":
+            routes = RELEASE_INDEX_ROUTES
+            context["version"] = config.params["head_tag"]
+
+        task.setdefault("routes", []).extend(
+            [route.format(**context) for route in routes]
+        )
         yield task

--- a/taskcluster/mozillavpn_taskgraph/transforms/release_index.py
+++ b/taskcluster/mozillavpn_taskgraph/transforms/release_index.py
@@ -4,21 +4,31 @@
 
 
 from taskgraph.transforms.base import TransformSequence
+
 transforms = TransformSequence()
 
 _GIT_REFS_HEADS_PREFIX = "refs/heads/"
+
+BRANCH_INDEX_ROUTES = (
+    "index.mozillavpn.v2.mozilla-vpn-client.branch.{branch}.latest.{task_type}.{name}",
+)
 
 
 @transforms.add
 def add_branch_index(config, tasks):
     for task in tasks:
-        if "add-branch-index" in task:
-            release_index = task.pop("add-branch-index")
-            if release_index and int(config.params["level"]) == 3:
-                name = task['name'].split("/")[0]
-                git_branch = config.params["head_ref"]
-                if git_branch.startswith(_GIT_REFS_HEADS_PREFIX):
-                    git_branch = git_branch[len(_GIT_REFS_HEADS_PREFIX):]
-                route = f"index.mozillavpn.v2.mozilla-vpn-client.branch.{git_branch}.latest.{name}"
-                task.setdefault("routes", []).append(route)
+        task_type = task.pop("add-branch-index", None)
+        if task_type and int(config.params["level"]) == 3:
+            name = task["name"].split("/")[0]
+            branch = config.params["head_ref"]
+            if branch.startswith(_GIT_REFS_HEADS_PREFIX):
+                branch = branch[len(_GIT_REFS_HEADS_PREFIX):]
+
+            task.setdefault("routes", [])
+            for route in BRANCH_INDEX_ROUTES:
+                task["routes"].append(route.format(
+                    branch=branch,
+                    task_type=task_type,
+                    name=name,
+                ))
         yield task

--- a/taskcluster/test/params/github-release.yml
+++ b/taskcluster/test/params/github-release.yml
@@ -1,0 +1,22 @@
+base_repository: https://github.com/mozilla-mobile/mozilla-vpn-client
+build_date: 1656077029
+do_not_optimize: []
+existing_tasks: {}
+filters:
+- target_tasks_method
+head_ref: main
+head_repository: https://github.com/mozilla-mobile/mozilla-vpn-client
+head_rev: e11bd1ecc4c486242738811667f6523d7d9a07ed
+head_tag: v2.10
+level: '3'
+moz_build_date: '20220624132349'
+optimize_target_tasks: true
+owner: user@example.com
+project: mozilla-vpn-client
+pull_request_number: null
+pushdate: 0
+pushlog_id: '0'
+repository_type: git
+target_tasks_method: default
+tasks_for: github-release
+version: '2.10'


### PR DESCRIPTION
This change will make it easier for QA and others to find release builds after creating a new "Github Release".
