### PR TITLE
Fix version.h regeneration with qmake

### DIFF
--- a/src/addons/addonguide.cpp
+++ b/src/addons/addonguide.cpp
@@ -7,6 +7,7 @@
 #include "logger.h"
 
 #include <QJsonObject>
+#include <QScopeGuard>
 
 namespace {
 Logger logger(LOG_MAIN, "AddonGuide");

--- a/version.pri
+++ b/version.pri
@@ -17,13 +17,7 @@ VERSION_MAJOR = $$section(VERSION, ., 0, 0)
 DBUS_PROTOCOL_VERSION = 1
 
 # Generate the version header file.
-VERSION_TEMPLATE = $$PWD/src/version.h.in
-genversion.input = VERSION_TEMPLATE
-genversion.output = $$PWD/src/version.h
-genversion.commands = @echo Building ${QMAKE_FILE_OUT} && \
-    python3 $$PWD/scripts/utils/make_template.py ${QMAKE_FILE_IN} \
-        -o ${QMAKE_FILE_OUT} -k @CMAKE_PROJECT_VERSION@=$${VERSION} -k @BUILD_ID@=$${BUILD_ID}
-genversion.depends = FORCE
-genversion.CONFIG = target_predeps no_link
-genversion.variable_out = HEADERS
-QMAKE_EXTRA_COMPILERS += genversion
+message("Generating version.h")
+system(python3 $PWD/scripts/utils/make_template.py \
+         $PWD/src/version.h.in -o $PWD/src/version.h \
+         -k @CMAKE_PROJECT_VERSION@="$${VERSION}" -k @BUILD_ID@="$${BUILD_ID}")

--- a/version.pri
+++ b/version.pri
@@ -23,7 +23,7 @@ genversion.output = $$PWD/src/version.h
 genversion.commands = @echo Building ${QMAKE_FILE_OUT} && \
     python3 $$PWD/scripts/utils/make_template.py ${QMAKE_FILE_IN} \
         -o ${QMAKE_FILE_OUT} -k @CMAKE_PROJECT_VERSION@=$${VERSION} -k @BUILD_ID@=$${BUILD_ID}
+genversion.depends = FORCE
 genversion.CONFIG = target_predeps no_link
 genversion.variable_out = HEADERS
 QMAKE_EXTRA_COMPILERS += genversion
-

--- a/version.pri
+++ b/version.pri
@@ -18,6 +18,6 @@ DBUS_PROTOCOL_VERSION = 1
 
 # Generate the version header file.
 message("Generating version.h")
-system(python3 $PWD/scripts/utils/make_template.py \
-         $PWD/src/version.h.in -o $PWD/src/version.h \
+system(python3 $$PWD/scripts/utils/make_template.py \
+         $$PWD/src/version.h.in -o $$PWD/src/version.h \
          -k @CMAKE_PROJECT_VERSION@="$${VERSION}" -k @BUILD_ID@="$${BUILD_ID}")


### PR DESCRIPTION
## Description
With the introduction of CMake, we now use a generated header file to set the `APP_VERSION` and `BUILD_ID` macros, so that we don't have to re-build everything whenever the makefiles get touched.

Unfortunately, this has the downside that when `src/version.h` already exists we don't update the version numbers, which can often lead to stale build identifiers even when the code is updated. To resolve this issue, we can make the version generation depend on the `FORCE` target.

## Reference

Github: #3853
JIRA: [VPN-2460](https://mozilla-hub.atlassian.net/browse/VPN-2460)

## Checklist

- [X] My code follows the style guidelines for this project
- [X] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [X] I have performed a self review of my own code
- [X] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
