### PR TITLE
Using hard-reset for reinitialize functional tests is wrong

### DIFF
--- a/tests/functional/helper.js
+++ b/tests/functional/helper.js
@@ -88,6 +88,13 @@ module.exports = {
         `Command failed: ${json.error}`);
   },
 
+  async reset() {
+    const json = await this._writeCommand('reset');
+    assert(
+        json.type === 'reset' && !('error' in json),
+        `Command failed: ${json.error}`);
+  },
+
   async waitForMainView() {
     await this.waitForElement('getHelpLink');
     await this.waitForElementProperty('getHelpLink', 'visible', 'true');

--- a/tests/functional/setupVpn.js
+++ b/tests/functional/setupVpn.js
@@ -71,7 +71,7 @@ exports.mochaHooks = {
       fxa.overrideEndpoints = null;
 
       await startAndConnect();
-      await vpn.hardReset();
+      await vpn.reset();
       await vpn.setSetting('tips-and-tricks-intro-shown', 'true')
       await vpn.authenticateInApp(true, true);
 
@@ -101,7 +101,7 @@ exports.mochaHooks = {
       }
 
       await startAndConnect();
-      await vpn.hardReset();
+      await vpn.reset();
       await vpn.setSetting('tips-and-tricks-intro-shown', 'true')
     }
 


### PR DESCRIPTION
Because hard-reset requires a restart. Instead, what we want is to go go back
to the initial screen.

VPN-2466