### PR TITLE
Fix subscription management re-auth inspector command

### DIFF
--- a/src/profileflow.cpp
+++ b/src/profileflow.cpp
@@ -56,9 +56,6 @@ void ProfileFlow::start() {
   TaskGetSubscriptionDetails* task =
       new TaskGetSubscriptionDetails(user->email(), m_forceReauthFlow);
 
-  // Reset forcing the re-auth flow
-  setForceReauthFlow(false);
-
   connect(task, &TaskGetSubscriptionDetails::receivedData, this,
           [this, task](const QByteArray& data) {
             if (task == m_currentTask) {
@@ -68,9 +65,12 @@ void ProfileFlow::start() {
           });
   connect(task, &TaskGetSubscriptionDetails::needsAuthentication, this,
           [this, task] {
-            if (task == m_currentTask) {
+            if (task == m_currentTask || m_forceReauthFlow) {
               logger.debug() << "Needs authentication";
               setState(StateAuthenticationNeeded);
+
+              // Reset forcing the re-auth flow
+              setForceReauthFlow(false);
             }
           });
   connect(task, &TaskGetSubscriptionDetails::failed, this, [this, task]() {


### PR DESCRIPTION
## Description

Fixes the inspector command `force_subscription_mananagement_reauthentication` for testing the re-authentication flow for the profile view

## Reference

[VPN-2320: Add a way to test the re-authentication flow](https://mozilla-hub.atlassian.net/jira/software/c/projects/VPN/boards/344?modal=detail&selectedIssue=VPN-2320)

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
