### PR TITLE
Fix subscription management for Apple subscriptions

### DIFF
--- a/src/models/subscriptiondata.cpp
+++ b/src/models/subscriptiondata.cpp
@@ -37,6 +37,42 @@ bool SubscriptionData::fromJson(const QByteArray& json) {
 
   QJsonObject obj = doc.object();
 
+  // Subscription
+  QJsonObject subscriptionData = obj["subscription"].toObject();
+
+  QString type = subscriptionData["_subscription_type"].toString();
+  if (type.isEmpty()) {
+    return false;
+  }
+
+  // Parse subscription data depending on subscription platform
+  if (type == "web") {
+    m_type = SubscriptionWeb;
+    if (!parseSubscriptionDataWeb(subscriptionData)) {
+      return false;
+    }
+  } else if (type == "iap_apple") {
+    // TODO: Parse subscription data as soon as FxA includes Apple subscriptions
+    // in their API response.
+    // For Apple subscriptions that is all the information we currently have.
+    m_type = SubscriptionApple;
+    m_status = Active;
+
+    m_rawJson = json;
+    emit changed();
+    logger.debug() << "Subscription data from JSON ready";
+
+    return true;
+  } else if (type == "iap_google") {
+    m_type = SubscriptionGoogle;
+    if (!parseSubscriptionDataIap(subscriptionData)) {
+      return false;
+    }
+  } else {
+    logger.error() << "No matching subscription type" << type;
+    return false;
+  }
+
   // Plan
   logger.debug() << "Parse plan start";
   QJsonObject planData = obj["plan"].toObject();
@@ -98,35 +134,6 @@ bool SubscriptionData::fromJson(const QByteArray& json) {
   // transformation from Stripe.
   m_planCurrency = planData["currency"].toString().toUpper();
   if (m_planCurrency.isEmpty()) {
-    return false;
-  }
-
-  // Subscription
-  QJsonObject subscriptionData = obj["subscription"].toObject();
-
-  QString type = subscriptionData["_subscription_type"].toString();
-  if (type.isEmpty()) {
-    return false;
-  }
-
-  // Parse subscription data depending on subscription platform
-  if (type == "web") {
-    m_type = SubscriptionWeb;
-    if (!parseSubscriptionDataWeb(subscriptionData)) {
-      return false;
-    }
-  } else if (type == "iap_apple") {
-    m_type = SubscriptionApple;
-    if (!parseSubscriptionDataIap(subscriptionData)) {
-      return false;
-    }
-  } else if (type == "iap_google") {
-    m_type = SubscriptionGoogle;
-    if (!parseSubscriptionDataIap(subscriptionData)) {
-      return false;
-    }
-  } else {
-    logger.error() << "No matching subscription type" << type;
     return false;
   }
 

--- a/src/ui/settings/ViewSubscriptionManagement/ViewSubscriptionManagement.qml
+++ b/src/ui/settings/ViewSubscriptionManagement/ViewSubscriptionManagement.qml
@@ -152,15 +152,18 @@ VPNFlickable {
     function populateListModels() {
         // Subscription info model
         // Subscription plan
-        subscriptionInfoModel.append({
-            _objectName: "subscriptionItem-plan",
-            labelText: VPNl18n.SubscriptionManagementPlanLabel,
-            valueText: getPlanText(
-                VPNSubscriptionData.planCurrency,
-                VPNSubscriptionData.planAmount,
-            ),
-            type: "text",
-        });
+
+        if (VPNSubscriptionData.type !== VPNSubscriptionData.SubscriptionApple) {
+            subscriptionInfoModel.append({
+                _objectName: "subscriptionItem-plan",
+                labelText: VPNl18n.SubscriptionManagementPlanLabel,
+                valueText: getPlanText(
+                    VPNSubscriptionData.planCurrency,
+                    VPNSubscriptionData.planAmount,
+                ),
+                type: "text",
+            });
+        }
 
         // Status
         subscriptionInfoModel.append({
@@ -173,7 +176,10 @@ VPNFlickable {
         });
 
         // Created at
-        if (VPNSubscriptionData.createdAt) {
+        if (
+            VPNSubscriptionData.createdAt
+            && VPNSubscriptionData.type !== VPNSubscriptionData.SubscriptionApple
+        ) {
             subscriptionInfoModel.append({
                 _objectName: "subscriptionItem-activated",
                 labelText: VPNl18n.SubscriptionManagementActivatedLabel,
@@ -183,14 +189,16 @@ VPNFlickable {
         }
 
         // Expires or next billed
-        subscriptionInfoModel.append({
-            _objectName: "subscriptionItem-cancelled",
-            labelText: VPNSubscriptionData.isCancelled
-                ? VPNl18n.SubscriptionManagementExpiresLabel
-                : VPNl18n.SubscriptionManagementNextLabel,
-            valueText: epochTimeToDate(VPNSubscriptionData.expiresOn),
-            type: "text",
-        });
+        if (VPNSubscriptionData.type !== VPNSubscriptionData.SubscriptionApple) {
+            subscriptionInfoModel.append({
+                _objectName: "subscriptionItem-cancelled",
+                labelText: VPNSubscriptionData.isCancelled
+                    ? VPNl18n.SubscriptionManagementExpiresLabel
+                    : VPNl18n.SubscriptionManagementNextLabel,
+                valueText: epochTimeToDate(VPNSubscriptionData.expiresOn),
+                type: "text",
+            });
+        }
 
         // Subscription payment model
         if (

--- a/tests/functional/testSubscription.js
+++ b/tests/functional/testSubscription.js
@@ -232,31 +232,6 @@ describe('Subscription view', function() {
             'https://accounts.stage.mozaws.net/subscriptions',
       },
       {
-        name: 'apple subscription: auto renew',
-        subscription: {
-          value: {
-            _subscription_type: 'iap_apple',
-            expiry_time_millis: 2147483647,
-            auto_renewing: true,
-          },
-          expected:
-              {cancelled: '1/25/70', label: 'Next billed', status: 'Inactive'}
-        },
-        manageSubscriptionLink: 'https://apps.apple.com/account/subscriptions',
-      },
-      {
-        name: 'apple subscription: no auto renew',
-        subscription: {
-          value: {
-            _subscription_type: 'iap_apple',
-            expiry_time_millis: 2147483647,
-            auto_renewing: false,
-          },
-          expected: {cancelled: '1/25/70', label: 'Expires', status: 'Inactive'}
-        },
-        manageSubscriptionLink: 'https://apps.apple.com/account/subscriptions',
-      },
-      {
         name: 'google subscription: auto renew',
         subscription: {
           value: {
@@ -284,22 +259,6 @@ describe('Subscription view', function() {
             'https://play.google.com/store/account/subscriptions',
       },
       {
-        name: 'apple subscription: no payment data',
-        subscription: {
-          value: {
-            _subscription_type: 'iap_apple',
-            expiry_time_millis: 2147483647,
-            auto_renewing: true,
-          },
-          expected:
-              {cancelled: '1/25/70', label: 'Next billed', status: 'Inactive'}
-        },
-        payment: {
-          value: {},
-          expected: {payment: 'Apple subscription'}
-        },
-      },
-      {
         name: 'google subscription: no payment data',
         subscription: {
           value: {
@@ -314,6 +273,25 @@ describe('Subscription view', function() {
           value: {},
           expected: {payment: 'Google subscription'}
         },
+      },
+      {
+        name: 'apple subscription: Active',
+        subscription: {
+          value: {
+            _subscription_type: 'iap_apple',
+          },
+          expected: { status: 'Active'}
+        }
+      },
+      {
+        name: 'apple subscription: Manage subscriptions link',
+        subscription: {
+          value: {
+            _subscription_type: 'iap_apple',
+          },
+          expected: { status: 'Active'}
+        },
+        manageSubscriptionLink: 'https://apps.apple.com/account/subscriptions',
       },
     ];
 
@@ -405,20 +383,33 @@ describe('Subscription view', function() {
           'subscriptionManagmentView', 'visible', 'true');
       await vpn.wait();
 
-      await vpn.waitForElement(
-          'subscriptionItem/subscriptionItem-plan/subscriptionItem-plan-parent/subscriptionItem-plan-container/subscriptionItem-plan-valueText');
-      await vpn.waitForElementProperty(
-          'subscriptionItem/subscriptionItem-plan/subscriptionItem-plan-parent/subscriptionItem-plan-container/subscriptionItem-plan-valueText',
-          'visible', 'true');
+      if (data.subscription.value._subscription_type !== "iap_apple") {
+        await vpn.waitForElement(
+            'subscriptionItem/subscriptionItem-plan/subscriptionItem-plan-parent/subscriptionItem-plan-container/subscriptionItem-plan-valueText');
+        await vpn.waitForElementProperty(
+            'subscriptionItem/subscriptionItem-plan/subscriptionItem-plan-parent/subscriptionItem-plan-container/subscriptionItem-plan-valueText',
+            'visible', 'true');
 
-      assert(
-          await vpn.getElementProperty(
-              'subscriptionItem/subscriptionItem-plan/subscriptionItem-plan-parent/subscriptionItem-plan-container/subscriptionItem-plan-valueText',
-              'text') === data.plan.expected);
-      assert(
-          await vpn.getElementProperty(
-              'subscriptionItem/subscriptionItem-status/subscriptionItem-status-parent/subscriptionItem-status-container/subscriptionItem-status-pillWrapper/subscriptionItem-status-pill',
-              'text') === data.subscription.expected.status);
+        assert(
+            await vpn.getElementProperty(
+                'subscriptionItem/subscriptionItem-plan/subscriptionItem-plan-parent/subscriptionItem-plan-container/subscriptionItem-plan-valueText',
+                'text') === data.plan.expected);
+        assert(
+            await vpn.getElementProperty(
+                'subscriptionItem/subscriptionItem-status/subscriptionItem-status-parent/subscriptionItem-status-container/subscriptionItem-status-pillWrapper/subscriptionItem-status-pill',
+                'text') === data.subscription.expected.status);
+
+        await vpn.waitForElement(
+            'subscriptionItem/subscriptionItem-cancelled/subscriptionItem-cancelled-parent/subscriptionItem-cancelled-container/subscriptionItem-cancelled-valueText');
+        assert(
+            await vpn.getElementProperty(
+                'subscriptionItem/subscriptionItem-cancelled/subscriptionItem-cancelled-parent/subscriptionItem-cancelled-container/subscriptionItem-cancelled-valueText',
+                'text') === data.subscription.expected.cancelled);
+        assert(
+            await vpn.getElementProperty(
+                'subscriptionItem/subscriptionItem-cancelled/subscriptionItem-cancelled-parent/subscriptionItem-cancelled-container/subscriptionItem-cancelled-labelText',
+                'text') === data.subscription.expected.label);
+      }
 
       if (data.subscription.expected.activated) {
         await vpn.waitForElement(
@@ -429,16 +420,6 @@ describe('Subscription view', function() {
                 'text') === data.subscription.expected.activated);
       }
 
-      await vpn.waitForElement(
-          'subscriptionItem/subscriptionItem-cancelled/subscriptionItem-cancelled-parent/subscriptionItem-cancelled-container/subscriptionItem-cancelled-valueText');
-      assert(
-          await vpn.getElementProperty(
-              'subscriptionItem/subscriptionItem-cancelled/subscriptionItem-cancelled-parent/subscriptionItem-cancelled-container/subscriptionItem-cancelled-valueText',
-              'text') === data.subscription.expected.cancelled);
-      assert(
-          await vpn.getElementProperty(
-              'subscriptionItem/subscriptionItem-cancelled/subscriptionItem-cancelled-parent/subscriptionItem-cancelled-container/subscriptionItem-cancelled-labelText',
-              'text') === data.subscription.expected.label);
       if (data.subscription.value._subscription_type == "web") {
         if (data.payment.expected.card) {
           await vpn.waitForElement(


### PR DESCRIPTION
## Description

For Apple subscriptions we can only show the status and subscription type for now. We can extend the subscription information to match the amount of information we can also show for Google subscriptions when these are available via FxA for the VPN.

## Reference

[VPN-2428](https://mozilla-hub.atlassian.net/jira/software/c/projects/VPN/boards/344?modal=detail&selectedIssue=VPN-2428)

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
