### PR TITLE
Restore copy/paste functionality for inputs on iOS

### DIFF
--- a/nebula/ui/components/VPNFlickable.qml
+++ b/nebula/ui/components/VPNFlickable.qml
@@ -25,7 +25,6 @@ Flickable {
             if (window.activeFocusItem &&
                 window.activeFocusItem.forceBlurOnOutsidePress &&
                 (Qt.platform.os === "android" || Qt.platform.os === "ios")) {
-                Qt.inputMethod.hide();
                 vpnFlickable.focus = true;
             }
             mouse.accepted = false;

--- a/nebula/ui/components/VPNFlickable.qml
+++ b/nebula/ui/components/VPNFlickable.qml
@@ -16,6 +16,22 @@ Flickable {
     property bool hideScollBarOnStackTransition: false
     interactive: !VPNTutorial.playing
 
+    MouseArea {
+
+        anchors.fill: parent
+        propagateComposedEvents: true
+
+        onPressed: mouse => {
+            if (window.activeFocusItem &&
+                window.activeFocusItem.forceBlurOnOutsidePress &&
+                (Qt.platform.os === "android" || Qt.platform.os === "ios")) {
+                Qt.inputMethod.hide();
+                vpnFlickable.focus = true;
+            }
+            mouse.accepted = false;
+        }
+    }
+
     clip: true
 
     function ensureVisible(item) {

--- a/nebula/ui/components/forms/VPNTextField.qml
+++ b/nebula/ui/components/forms/VPNTextField.qml
@@ -37,7 +37,7 @@ TextField {
     rightPadding: VPNTheme.theme.windowMargin
     topPadding: VPNTheme.theme.windowMargin / 2
     bottomPadding: VPNTheme.theme.windowMargin / 2
-
+    focus: true
     cursorDelegate: VPNCursorDelegate {}
 
     Text {
@@ -55,5 +55,12 @@ TextField {
     VPNInputStates {
         id: textFieldState
         itemToTarget: textField
+    }
+
+    MouseArea {
+        anchors.fill: textField
+        onPressed: {
+            textField.forceActiveFocus();
+        }
     }
 }

--- a/src/ui/authenticationInApp/ViewAuthenticationStart.qml
+++ b/src/ui/authenticationInApp/ViewAuthenticationStart.qml
@@ -24,7 +24,7 @@ VPNInAppAuthenticationBase {
         _buttonEnabled: VPNAuthInApp.state === VPNAuthInApp.StateStart && activeInput().text.length !== 0 && !activeInput().hasError
         _buttonOnClicked: (inputText) => { VPNAuthInApp.checkAccount(inputText); }
         _buttonText: qsTrId("vpn.postAuthentication.continue")
-        _inputMethodHints: Qt.ImhEmailCharactersOnly | Qt.ImhNoAutoUppercase | Qt.ImhNoPredictiveText | Qt.ImhSensitiveData
+        _inputMethodHints: Qt.ImhEmailCharactersOnly | Qt.ImhNoAutoUppercase | Qt.ImhSensitiveData
         _inputPlaceholderText: VPNl18n.InAppSupportWorkflowSupportEmailFieldPlaceholder
     }
 

--- a/src/ui/main.qml
+++ b/src/ui/main.qml
@@ -94,18 +94,6 @@ Window {
         VPN.mainWindowLoaded()
     }
 
-    MouseArea {
-        anchors.fill: parent
-        propagateComposedEvents: true
-        z: 10
-        onPressed: mouse => {
-            if (window.activeFocusItem && window.activeFocusItem.forceBlurOnOutsidePress) {
-                window.activeFocusItem.focus = false;
-            }
-            mouse.accepted = false;
-        }
-    }
-
     VPNMobileStatusBarModifier {
         id: statusBarModifier
     }


### PR DESCRIPTION
## Description

This restores native input edit menus (select/select all/cut/copy depending on platform) on Android and iOS and restores the ability to paste into inputs on iOS.

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>


https://user-images.githubusercontent.com/22355127/176479126-1bec4acf-8104-486a-a8b5-095048dbb18e.mov


</td>
<td>

https://user-images.githubusercontent.com/22355127/176478974-b129e04f-7d4c-484b-8b4f-fafdfd40881c.mov


</td>
</tr>
</table>

## Reference

    TBD

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
