### PR TITLE
Support more subscription intervals for testing

### DIFF
--- a/src/models/subscriptiondata.cpp
+++ b/src/models/subscriptiondata.cpp
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "subscriptiondata.h"
+#include "constants.h"
 #include "leakdetector.h"
 #include "logger.h"
 #include "mozillavpn.h"
@@ -54,10 +55,15 @@ bool SubscriptionData::fromJson(const QByteArray& json) {
 
   // Convert `interval` to number of months
   int planIntervalMonths;
-  if (planInterval == "month") {
-    planIntervalMonths = 1;
-  } else if (planInterval == "year") {
+  if (planInterval == "year") {
     planIntervalMonths = 12;
+  } else if (planInterval == "month") {
+    planIntervalMonths = 1;
+  } else if ((planInterval == "week" || planInterval == "day") &&
+             !Constants::inProduction()) {
+    // For testing purposes we support additional intervals
+    // and use a monthly plan as fallback
+    planIntervalMonths = 1;
   } else {
     logger.error() << "Unexpected interval type:" << planInterval;
     emit MozillaVPN::instance()->recordGleanEventWithExtraKeys(


### PR DESCRIPTION
## Description

QA can create subscriptions for testing that have `day` as subscription interval. Let’s support them and show them as monthly plans for testing purposes.

## Reference

[VPN-2428](https://mozilla-hub.atlassian.net/jira/software/c/projects/VPN/boards/344?modal=detail&selectedIssue=VPN-2428)

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
