### PR TITLE
VPN-2384 - Do not rely on QElapsedTimer for websocket handler tests

### DIFF
--- a/src/websockethandler.cpp
+++ b/src/websockethandler.cpp
@@ -190,8 +190,8 @@ void WebSocketHandler::onConnected() {
   logger.debug() << "WebSocket connected";
 
   m_backoffStrategy.reset();
-#ifdef UNIT_TEST:
-  currentBackoffInterval = 0;
+#ifdef UNIT_TEST
+  m_currentBackoffInterval = 0;
 #endif
 
   connect(&m_webSocket, &QWebSocket::textMessageReceived, this,
@@ -225,8 +225,8 @@ void WebSocketHandler::onClose() {
         << "User is authenticated. Will attempt to reopen websocket in:"
         << nextAttemptIn;
 
-#ifdef UNIT_TEST:
-    currentBackoffInterval = nextAttemptIn;
+#ifdef UNIT_TEST
+    m_currentBackoffInterval = nextAttemptIn;
 #endif
   } else {
     logger.debug()

--- a/src/websockethandler.cpp
+++ b/src/websockethandler.cpp
@@ -190,6 +190,9 @@ void WebSocketHandler::onConnected() {
   logger.debug() << "WebSocket connected";
 
   m_backoffStrategy.reset();
+#ifdef UNIT_TEST:
+  currentBackoffInterval = 0;
+#endif
 
   connect(&m_webSocket, &QWebSocket::textMessageReceived, this,
           &WebSocketHandler::onMessageReceived);
@@ -221,6 +224,10 @@ void WebSocketHandler::onClose() {
     logger.debug()
         << "User is authenticated. Will attempt to reopen websocket in:"
         << nextAttemptIn;
+
+#ifdef UNIT_TEST:
+    currentBackoffInterval = nextAttemptIn;
+#endif
   } else {
     logger.debug()
         << "User is not authenticated. Will not attempt to reopen WebSocket.";

--- a/src/websockethandler.h
+++ b/src/websockethandler.h
@@ -44,6 +44,12 @@ class WebSocketHandler final : public QObject {
   static void testOverrideWebSocketServerUrl(const QString& url);
   void testOverridePingInterval(int newInterval);
   void testOverrideBaseRetryInterval(int newInterval);
+
+  // If currently waiting for until attempting reconnection,
+  // this variable will contain the backoff interval.
+  //
+  // When not waiting, this will be 0.
+  int currentBackoffInterval = 0;
 #endif
 
  signals:

--- a/src/websockethandler.h
+++ b/src/websockethandler.h
@@ -49,7 +49,7 @@ class WebSocketHandler final : public QObject {
   // this variable will contain the backoff interval.
   //
   // When not waiting, this will be 0.
-  int currentBackoffInterval = 0;
+  int m_currentBackoffInterval = 0;
 #endif
 
  signals:

--- a/tests/unit/testwebsockethandler.cpp
+++ b/tests/unit/testwebsockethandler.cpp
@@ -302,7 +302,7 @@ void TestWebSocketHandler::
   // We know there were at least three retries,
   // so the current backoff interval should be at least longer than the 3rd
   // interval.
-  QVERIFY(handler.currentBackoffInterval > qPow(testBaseRetryInterval, 3));
+  QVERIFY(handler.m_currentBackoffInterval > qPow(testBaseRetryInterval, 3));
 
   // Reopen the server so reconnections can take place.
   server.open();
@@ -322,8 +322,8 @@ void TestWebSocketHandler::
 
   // The reconnection interval should have been reset.
   // Reconnection might be so fast that when we get to this line
-  // currentBackoffInterval has already been reset to 0.
-  QVERIFY(handler.currentBackoffInterval <= testBaseRetryInterval);
+  // m_currentBackoffInterval has already been reset to 0.
+  QVERIFY(handler.m_currentBackoffInterval <= testBaseRetryInterval);
 
   // Wait for reconnection.
   QVERIFY(newConnectionSpy.wait());
@@ -331,7 +331,7 @@ void TestWebSocketHandler::
 
   // The backoff interval is reset to 0 when not waiting for reconnection
   // attempt.
-  QCOMPARE(handler.currentBackoffInterval, testBaseRetryInterval);
+  QCOMPARE(handler.m_currentBackoffInterval, testBaseRetryInterval);
 }
 
 void TestWebSocketHandler::tst_reconnectionAttemptsOnPingTimeout() {

--- a/tests/unit/testwebsockethandler.cpp
+++ b/tests/unit/testwebsockethandler.cpp
@@ -300,7 +300,8 @@ void TestWebSocketHandler::
   // We have to be a bit loose here with the checks.
   //
   // We know there were at least three retries,
-  // so the current backoff interval should be at least longer than the 3rd interval.
+  // so the current backoff interval should be at least longer than the 3rd
+  // interval.
   QVERIFY(handler.currentBackoffInterval > qPow(testBaseRetryInterval, 3));
 
   // Reopen the server so reconnections can take place.
@@ -328,7 +329,8 @@ void TestWebSocketHandler::
   QVERIFY(newConnectionSpy.wait());
   QCOMPARE(newConnectionSpy.count(), 3);
 
-  // The backoff interval is reset to 0 when not waiting for reconnection attempt.
+  // The backoff interval is reset to 0 when not waiting for reconnection
+  // attempt.
   QCOMPARE(handler.currentBackoffInterval, testBaseRetryInterval);
 }
 


### PR DESCRIPTION
## Description

--

## Reference

https://mozilla-hub.atlassian.net/browse/VPN-2384

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
