### PR TITLE
Clear subscription data before populating

### DIFF
--- a/src/models/subscriptiondata.cpp
+++ b/src/models/subscriptiondata.cpp
@@ -31,6 +31,8 @@ bool SubscriptionData::fromJson(const QByteArray& json) {
     return true;
   }
 
+  resetData();
+
   QJsonDocument doc = QJsonDocument::fromJson(json);
   if (!doc.isObject()) {
     return false;
@@ -225,4 +227,25 @@ bool SubscriptionData::parseSubscriptionDataWeb(
   }
 
   return true;
+}
+
+void SubscriptionData::resetData() {
+  logger.debug() << "Reset data";
+  m_rawJson.clear();
+
+  m_type = SubscriptionUnknown;
+  m_status = Inactive;
+  m_createdAt = 0;
+  m_expiresOn = 0;
+  m_isCancelled = false;
+
+  m_planBillingInterval = BillingIntervalUnknown;
+  m_planAmount = 0;
+  m_planCurrency.clear();
+
+  m_paymentProvider.clear();
+  m_creditCardBrand.clear();
+  m_creditCardLast4.clear();
+  m_creditCardExpMonth = 0;
+  m_creditCardExpYear = 0;
 }

--- a/src/models/subscriptiondata.h
+++ b/src/models/subscriptiondata.h
@@ -41,6 +41,7 @@ class SubscriptionData final : public QObject {
     SubscriptionApple,
     SubscriptionGoogle,
     SubscriptionWeb,
+    SubscriptionUnknown,
   };
   Q_ENUM(TypeSubscription)
 
@@ -54,6 +55,7 @@ class SubscriptionData final : public QObject {
     BillingIntervalMonthly,
     BillingIntervalHalfYearly,
     BillingIntervalYearly,
+    BillingIntervalUnknown,
   };
   Q_ENUM(TypeBillingInterval)
 
@@ -67,17 +69,18 @@ class SubscriptionData final : public QObject {
  private:
   bool parseSubscriptionDataIap(const QJsonObject& subscriptionData);
   bool parseSubscriptionDataWeb(const QJsonObject& subscriptionData);
+  void resetData();
 
  private:
   QByteArray m_rawJson;
 
-  TypeSubscription m_type;
-  TypeStatus m_status;
+  TypeSubscription m_type = SubscriptionUnknown;
+  TypeStatus m_status = Inactive;
   quint64 m_createdAt = 0;
   quint64 m_expiresOn = 0;
   bool m_isCancelled = false;
 
-  TypeBillingInterval m_planBillingInterval;
+  TypeBillingInterval m_planBillingInterval = BillingIntervalUnknown;
   int m_planAmount = 0;
   QString m_planCurrency;
 


### PR DESCRIPTION
## Description

We need to reset the subscription data entirely and not expect it to be overwritten. If the subscription type a user has for the VPN changes (for example “web” to “Apple IAP”) and we were able to show more data for a previous subscription than for the current one, it could be that we partly show infos from the old subscription.

## Reference

TBD

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
