### PR TITLE
Set Windows app icon when building with CMake.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,11 @@
 
 cmake_minimum_required(VERSION 3.16)
 
+project("Mozilla VPN" VERSION 2.10.0 LANGUAGES C CXX
+        DESCRIPTION "A fast, secure and easy to use VPN. Built by the makers of Firefox."
+        HOMEPAGE_URL "https://vpn.mozilla.org"
+)
+
 ## Some workarounds for platform build quirks
 if(WIN32)
     ## CMake v3.20 has problems with race conditions in dependency generation.
@@ -38,11 +43,6 @@ if(APPLE)
 endif()
 
 option(BUILD_DUMMY "Build for the dummy platform" OFF)
-
-project("Mozilla VPN" VERSION 2.10.0 LANGUAGES C CXX
-        DESCRIPTION "A fast, secure and easy to use VPN. Built by the makers of Firefox."
-        HOMEPAGE_URL "https://vpn.mozilla.org"
-)
 
 message("Configuring for ${CMAKE_GENERATOR}")
 if(NOT (DEFINED CMAKE_CONFIGURATION_TYPES OR "${CMAKE_BUILD_TYPE}"))

--- a/lottie/CMakeLists.txt
+++ b/lottie/CMakeLists.txt
@@ -14,6 +14,9 @@ set(CMAKE_AUTOUIC ON)
 if(NOT CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
     set(CMAKE_FOLDER "Lottie")
 endif()
+if(${CMAKE_VERSION} VERSION_GREATER_EQUAL 3.17)
+    cmake_policy(SET CMP0099 OLD)
+endif()
 
 add_library(lottie STATIC)
 

--- a/windows/version.rc.in
+++ b/windows/version.rc.in
@@ -2,12 +2,15 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #include <winresrc.h>
+#include "winver.h"
 
 #ifndef DEBUG
 #define VER_DEBUG                   0
 #else
 #define VER_DEBUG                   VS_FF_DEBUG
 #endif
+
+IDI_ICON1       ICON "@CMAKE_SOURCE_DIR@/src/ui/resources/logo.ico"
 
 // See https://docs.microsoft.com/en-us/windows/win32/menurc/versioninfo-resource
 // for a list of all the neat metadata we can set in this file.


### PR DESCRIPTION
## Description
With `qmake` we can set the application icon using the `RC_ICON` macro, but unfortunately this doesn't exist in CMake and we need to implement this by adding a the `IDI_ICON1` directive when generating the application resource file.

## Reference
Closes: #3641
JIRA: [VPN-2301](https://mozilla-hub.atlassian.net/browse/VPN-2301)

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
