### PR TITLE
Document that right now we rely on CMAKE_INSTALL_PREFIX=/usr

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ PATH the build process is effectively the same on each of the supported platform
 1. Start by creating a build directory and using `cmake` to generate the Makefiles.
 
 ```bash
-mkdir build && cmake -S . -B build
+mkdir build && cmake -S . -B -DCMAKE_INSTALL_PREFIX=/usr build
 ```
 
 This generation step can be augmented by providing variable definitions on the


### PR DESCRIPTION
We hard-code /usr/bin/mozillavpn in a couple places on Linux.

The right fix would be to make the relevant files:

 * `linux/extra/mozillavpn-startup.desktop`
 * `linux/extra/mozillavpn.desktop`
 * `linux/mozillavpn.service`
 * `src/platforms/linux/daemon/org.mozilla.vpn.dbus.service`

Generated at build-time, using the specified `CMAKE_INSTALL_PREFIX`
instead. But I'm not a CMake expert and I'm not sure what's the best way
to do that.

Instead, document that this flag is needed, since a lot of distros
default to /usr/local otherwise.