### PR TITLE
Consume signed stuff from the 'signed-internals' folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,6 +94,7 @@ ios/gobridge/wireguard-go-version.h
 # Taskcluster/ Taskgraph
 !taskcluster/ci/build
 !taskcluster/scripts/build
+signed-internals/
 *.pyc
 
 # Editors
@@ -119,6 +120,7 @@ tunnel.h
 *.dll
 .vs/
 *.msi
+addon.wxs
 MozillaVPN.exe
 MozillaVPN.exp
 MozillaVPN.lib

--- a/windows/installer/MozillaVPN_prod.wxs
+++ b/windows/installer/MozillaVPN_prod.wxs
@@ -76,20 +76,20 @@
     -->
     <ComponentGroup Id="MozillaVPNComponents">
       <Component Directory="MozillaVPNFolder" Id="MozillaVPNExecutable" Guid="EF353A73-A10B-4A2D-87AC-4389BBD9313B">
-        <File Id="MozillaVPNExecutable" Source="../../MozillaVPN.exe" KeyPath="yes">
+        <File Id="MozillaVPNExecutable" Source="../../signed-internals/MozillaVPN.exe" KeyPath="yes">
           <Shortcut Id="MozillaVPNShortcut" Directory="ProgramMenuFolder" Name="Mozilla VPN" Description="A fast, secure and easy to use VPN. Built by the makers of Firefox." WorkingDirectory="MozillaVPNFolder" Advertise="yes" />
         </File>
-        <File Source="../../tunnel.dll" />
-        <File Source="../../wintun.dll" />
-        <File Source="../../balrog.dll" />
-        <File Source="../../libcrypto-1_1-x64.dll" />
-        <File Source="../../libssl-1_1-x64.dll" />
-        <File Source="../../mullvad-split-tunnel.cat" />
-        <File Source="../../mullvad-split-tunnel.inf" />
-        <File Source="../../mullvad-split-tunnel.sys" />
-        <File Source="../../WdfCoinstaller01011.dll" />
-        <File Source="../../mozillavpn.json" />
-        <File Source="../../mozillavpnnp.exe" />
+        <File Source="../../signed-internals/tunnel.dll" />
+        <File Source="../../signed-internals/wintun.dll" />
+        <File Source="../../signed-internals/balrog.dll" />
+        <File Source="../../signed-internals/libcrypto-1_1-x64.dll" />
+        <File Source="../../signed-internals/libssl-1_1-x64.dll" />
+        <File Source="../../signed-internals/mullvad-split-tunnel.cat" />
+        <File Source="../../signed-internals/mullvad-split-tunnel.inf" />
+        <File Source="../../signed-internals/mullvad-split-tunnel.sys" />
+        <File Source="../../signed-internals/WdfCoinstaller01011.dll" />
+        <File Source="../../signed-internals/mozillavpn.json" />
+        <File Source="../../signed-internals/mozillavpnnp.exe" />
 
         <!-- Broker Service -->
         <ServiceInstall
@@ -121,7 +121,7 @@
       Merge modules
     -->
     <DirectoryRef Id="MozillaVPNFolder">
-      <Merge Id="VCRedistModule" SourceFile="../../Microsoft_VC142_CRT_$(var.Platform).msm" DiskId="1" Language="0"/>
+      <Merge Id="VCRedistModule" SourceFile="../../signed-internals/Microsoft_VC142_CRT_$(var.Platform).msm" DiskId="1" Language="0"/>
     </DirectoryRef>
 
     <DirectoryRef Id="MozillaVPNFolder">

--- a/windows/installer/build_prod.cmd
+++ b/windows/installer/build_prod.cmd
@@ -43,10 +43,10 @@ if exist .deps\prepared goto :build
 :msi
 	if not exist "%~1" mkdir "%~1"
 	echo [+] Compiling %1
-	"%WIX%bin\heat" dir ..\..\addons -o addon.wxs -scon -sfrag -srd -sreg -gg -cg addons -dr MozillaVPNAddonFolder || exit /b %errorlevel%
+	"%WIX%bin\heat" dir ..\..\signed-internals\addons -o addon.wxs -scon -sfrag -srd -sreg -gg -cg addons -dr MozillaVPNAddonFolder || exit /b %errorlevel%
 	"%WIX%bin\candle" %WIX_CANDLE_FLAGS% -dPlatform=%1 -arch %1 MozillaVPN_prod.wxs addon.wxs || exit /b %errorlevel%
 	echo [+] Linking %1
-	"%WIX%bin\light" %WIX_LIGHT_FLAGS% -out "%~1/MozillaVPN.msi" -b ..\..\addons MozillaVPN_prod.wixobj addon.wixobj || exit /b %errorlevel%
+	"%WIX%bin\light" %WIX_LIGHT_FLAGS% -out "%~1/MozillaVPN.msi" -b ..\..\signed-internals\addons MozillaVPN_prod.wixobj addon.wixobj || exit /b %errorlevel%
 	goto :eof
 
 :error


### PR DESCRIPTION
This should generate a valid .msi with addons working. 
We would need the "msi-windows-tunnel"  task to change the MOZ_FETCHES from 
```
 "MOZ_FETCHES": "[{\"artifact\": \"public/build/signed-internals.zip\", \"dest\": \"../build/src/\", \"extract\": true, ....
```
to: 
```
 "MOZ_FETCHES": "[{\"artifact\": \"public/build/signed-internals.zip\", \"dest\": \"../build/src/signed-internals\", \"extract\": true, ....
```
