### PR TITLE
Fix text field focus and navigation

### DIFF
--- a/nebula/ui/components/forms/VPNTextField.qml
+++ b/nebula/ui/components/forms/VPNTextField.qml
@@ -59,6 +59,7 @@ TextField {
 
     MouseArea {
         anchors.fill: textField
+        visible: !textField.activeFocus
         onPressed: {
             textField.forceActiveFocus();
         }


### PR DESCRIPTION
## Description

This fixes the cursor navigation inside text field. Furthermore this change fixes an issue where the visibility of password inputs can’t be toggled. I’m not entirely sure if this will break the ability to paste into inputs on iOS and Android that was introduced with PR #3875 again.

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>

https://user-images.githubusercontent.com/13835474/177840824-429daa4c-8210-43b2-836a-bbb879777fce.mov

</td>
<td>

https://user-images.githubusercontent.com/13835474/177840845-4fd1cd0e-e89a-4a4d-9bf2-b41aa962a209.mov

</td>
</tr>
</table>

## Reference

- [VPN-2498: Cursor cannot be moved in text fields](https://mozilla-hub.atlassian.net/browse/VPN-2498)
- [VPN-2503: [mobile] “Eye” icon is not working if the cursor is in the field](https://mozilla-hub.atlassian.net/browse/VPN-2503)

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
