### PR TITLE
Enable MVPN_WEBEXTENSION when building for desktop

### DIFF
--- a/src/cmake/sources.cmake
+++ b/src/cmake/sources.cmake
@@ -335,7 +335,13 @@ if(NOT CMAKE_CROSSCOMPILING)
         systemtraynotificationhandler.h
         tasks/authenticate/desktopauthenticationlistener.cpp
         tasks/authenticate/desktopauthenticationlistener.h
+        server/serverconnection.cpp
+        server/serverconnection.h
+        server/serverhandler.cpp
+        server/serverhandler.h
     )
+
+    add_compile_definitions(MVPN_WEBEXTENSION)
 endif()
 
 qt6_add_qml_module(mozillavpn


### PR DESCRIPTION
## Description
It seems that we forgot to enable the ServerHandler class when converting CMake, which prevents the MAC addon and webextension from being able to communicate with the VPN.

## Reference

Closes: #3919 ([VPN-2507](https://mozilla-hub.atlassian.net/browse/VPN-2507))

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
