### PR TITLE
VPN2524 - Update xcodebuild script to only build for x86_64 arch

### DIFF
--- a/scripts/macos/utils/commons.sh
+++ b/scripts/macos/utils/commons.sh
@@ -39,6 +39,8 @@ _compile() {
   xcodebuild build \
     CODE_SIGN_IDENTITY="" \
     CODE_SIGNING_REQUIRED=NO \
+    ONLY_ACTIVE_ARCH=NO \
+    -arch x86_64 \
     -derivedDataPath=/build \
     -resultBundlePath=/tmp \
     -enableCodeCoverage=YES \


### PR DESCRIPTION
## Description

With the change from Apple to switch to arm64 on new macbooks
the default value of the ARCHS_STANDARD configuration is 'arm64 x86_64'.

Since the VPN app does not support arm64 architectures yet,
this is an issue (see: https://mozilla-hub.atlassian.net/browse/VPN-82).
It became an apparent issue, though, after the addition of the
signature Rust library to the codebase.

Rust will only build for the active architecture (x86_64), while xcode
will attempt to build for both. That was causing a linker error.

## Reference

https://mozilla-hub.atlassian.net/browse/VPN-2524
