### PR TITLE
Condition watcher for addons

### DIFF
--- a/addons/message_survey_28d_desktop/manifest.json
+++ b/addons/message_survey_28d_desktop/manifest.json
@@ -1,0 +1,16 @@
+{
+  "api_version": "0.1",
+  "id": "message_survey_28d_desktop",
+  "name": "Survey 28d Desktop",
+  "type": "message",
+  "conditions": {
+    "trigger_time": 2419200,
+    "platforms": ["windows", "macos", "linux"],
+    "locales": ["en"]
+  },
+  "message": {
+    "id": "survey_28d_mobile",
+    "title": "TODO",
+    "blocks": []
+  }
+}

--- a/addons/message_survey_28d_mobile/manifest.json
+++ b/addons/message_survey_28d_mobile/manifest.json
@@ -1,0 +1,16 @@
+{
+  "api_version": "0.1",
+  "id": "message_survey_28d_mobile",
+  "name": "Survey 28d Mobile",
+  "type": "message",
+  "conditions": {
+    "trigger_time": 2419200,
+    "platforms": ["ios", "android"],
+    "locales": ["en"]
+  },
+  "message": {
+    "id": "survey_28d_mobile",
+    "title": "TODO",
+    "blocks": []
+  }
+}

--- a/addons/message_survey_staging_10s/manifest.json
+++ b/addons/message_survey_staging_10s/manifest.json
@@ -1,0 +1,15 @@
+{
+  "api_version": "0.1",
+  "id": "message_survey_staging_10s",
+  "name": "Staging Survey 10 secs",
+  "type": "message",
+  "conditions": {
+    "env": "staging",
+    "trigger_time": 10
+  },
+  "message": {
+    "id": "message_survey_staging_10s",
+    "title": "TODO",
+    "blocks": []
+  }
+}

--- a/addons/message_survey_staging_4s/manifest.json
+++ b/addons/message_survey_staging_4s/manifest.json
@@ -1,0 +1,15 @@
+{
+  "api_version": "0.1",
+  "id": "message_survey_staging_4s",
+  "name": "Staging Survey 4 secs",
+  "type": "message",
+  "conditions": {
+    "env": "staging",
+    "trigger_time": 4
+  },
+  "message": {
+    "id": "message_survey_staging_4s",
+    "title": "TODO",
+    "blocks": []
+  }
+}

--- a/scripts/addon/build.py
+++ b/scripts/addon/build.py
@@ -169,11 +169,6 @@ def retrieve_strings_message(manifest, filename):
         "value": message_json["title"],
         "comments": message_json.get("title_comment", "Title for a message view"),
     }
-    subtitle_id = f"message.{message_id}.subtitle"
-    message_strings[subtitle_id] = {
-        "value": message_json["subtitle"],
-        "comments": message_json.get("subtitle_comment", "Subtitle for a message view"),
-    }
 
     return retrieve_strings_blocks(message_json["blocks"], filename, message_strings, f"message.{message_id}")
 

--- a/scripts/ci/jsonSchemas/conditions.json
+++ b/scripts/ci/jsonSchemas/conditions.json
@@ -11,6 +11,17 @@
         "type": "string"
       }
     },
+    "env": {
+      "type": "string",
+      "description": "Force a particular environment: staging, production"
+    },
+    "locales": {
+      "type": "array",
+      "description": "List of supported locales",
+      "items": {
+        "type": "string"
+      }
+    },
     "platforms": {
       "type": "array",
       "description": "List of supported platforms",
@@ -40,6 +51,10 @@
         },
         "required": [ "setting", "value", "op" ]
       }
+    },
+    "trigger_time": {
+      "type": "number",
+      "description": "How many seconds from the first installation"
     }
   }
 }

--- a/scripts/ci/jsonSchemas/conditions.json
+++ b/scripts/ci/jsonSchemas/conditions.json
@@ -13,7 +13,7 @@
     },
     "env": {
       "type": "string",
-      "description": "Force a particular environment: staging, production"
+      "description": "Enable the addon only in a particular environment: staging, production"
     },
     "locales": {
       "type": "array",
@@ -54,7 +54,7 @@
     },
     "trigger_time": {
       "type": "number",
-      "description": "How many seconds from the first installation"
+      "description": "How many seconds from the first execution of the mozilla vpn client"
     }
   }
 }

--- a/src/addons/addon.cpp
+++ b/src/addons/addon.cpp
@@ -8,6 +8,9 @@
 #include "addoni18n.h"
 #include "addonmessage.h"
 #include "addontutorial.h"
+#include "conditionwatchers/addonconditionwatchergroup.h"
+#include "conditionwatchers/addonconditionwatcherlocales.h"
+#include "conditionwatchers/addonconditionwatchertriggertimesecs.h"
 #include "leakdetector.h"
 #include "logger.h"
 #include "models/feature.h"
@@ -57,6 +60,23 @@ bool evaluateConditionsPlatforms(const QJsonArray& platformArray) {
   }
 
   return true;
+}
+
+bool evaluateConditionsEnv(const QString& env) {
+  if (env.isEmpty()) {
+    return true;
+  }
+
+  if (env == "staging") {
+    return !Constants::inProduction();
+  }
+
+  if (env == "production") {
+    return Constants::inProduction();
+  }
+
+  logger.info() << "Unknown env value:" << env;
+  return false;
 }
 
 bool evaluateConditionsSettingsOp(const QString& op, bool result) {
@@ -118,6 +138,7 @@ bool evaluateConditionsSettings(const QJsonArray& settings) {
 
   return true;
 }
+
 }  // namespace
 
 // static
@@ -175,28 +196,44 @@ Addon* Addon::create(QObject* parent, const QString& manifestFileName) {
     return nullptr;
   }
 
+  Addon* addon = nullptr;
+
   if (!Constants::inProduction() && type == "demo") {
-    return AddonDemo::create(parent, manifestFileName, id, name, obj);
+    addon = AddonDemo::create(parent, manifestFileName, id, name, obj);
   }
 
-  if (type == "i18n") {
-    return new AddonI18n(parent, manifestFileName, id, name);
+  else if (type == "i18n") {
+    addon = new AddonI18n(parent, manifestFileName, id, name);
   }
 
-  if (type == "tutorial") {
-    return AddonTutorial::create(parent, manifestFileName, id, name, obj);
+  else if (type == "tutorial") {
+    addon = AddonTutorial::create(parent, manifestFileName, id, name, obj);
   }
 
-  if (type == "guide") {
-    return AddonGuide::create(parent, manifestFileName, id, name, obj);
+  else if (type == "guide") {
+    addon = AddonGuide::create(parent, manifestFileName, id, name, obj);
   }
 
-  if (type == "message") {
-    return AddonMessage::create(parent, manifestFileName, id, name, obj);
+  else if (type == "message") {
+    addon = AddonMessage::create(parent, manifestFileName, id, name, obj);
   }
 
-  logger.warning() << "Unsupported type" << type << manifestFileName;
-  return nullptr;
+  else {
+    logger.warning() << "Unsupported type" << type << manifestFileName;
+    return nullptr;
+  }
+
+  if (!addon) {
+    return nullptr;
+  }
+
+  addon->maybeCreateConditionWatchers(conditions);
+
+  if (addon->enabled()) {
+    addon->enable();
+  }
+
+  return addon;
 }
 
 Addon::Addon(QObject* parent, const QString& manifestFileName,
@@ -207,14 +244,11 @@ Addon::Addon(QObject* parent, const QString& manifestFileName,
       m_name(name),
       m_type(type) {
   MVPN_COUNT_CTOR(Addon);
-
-  QCoreApplication::installTranslator(&m_translator);
-  retranslate();
 }
 
 Addon::~Addon() {
   MVPN_COUNT_DTOR(Addon);
-  QCoreApplication::removeTranslator(&m_translator);
+  disable();
 }
 
 void Addon::retranslate() {
@@ -235,6 +269,59 @@ void Addon::retranslate() {
   }
 }
 
+void Addon::maybeCreateConditionWatchers(const QJsonObject& conditions) {
+  QList<AddonConditionWatcher*> watcherList;
+
+  {
+    QStringList locales;
+    for (const QJsonValue& value : conditions["locales"].toArray()) {
+      locales.append(value.toString().toLower());
+    }
+
+    AddonConditionWatcher* tmpWatcher =
+        AddonConditionWatcherLocales::maybeCreate(this, locales);
+    if (tmpWatcher) {
+      watcherList.append(tmpWatcher);
+    }
+  }
+
+  {
+    AddonConditionWatcher* tmpWatcher =
+        AddonConditionWatcherTriggerTimeSecs::maybeCreate(
+            this, conditions["trigger_time"].toInteger());
+    if (tmpWatcher) {
+      watcherList.append(tmpWatcher);
+    }
+  }
+
+  switch (watcherList.length()) {
+    case 0:
+      return;
+
+    case 1:
+      m_conditionWatcher = watcherList.at(0);
+      break;
+
+    default:
+      m_conditionWatcher = new AddonConditionWatcherGroup(this, watcherList);
+      break;
+  }
+
+  Q_ASSERT(m_conditionWatcher);
+
+  connect(m_conditionWatcher, &AddonConditionWatcher::conditionChanged, this,
+          &Addon::conditionChanged);
+
+  connect(m_conditionWatcher, &AddonConditionWatcher::conditionChanged, this,
+          [this](bool enabled) {
+            if (enabled) {
+              enable();
+            } else {
+              disable();
+            }
+          });
+}
+
 // static
 bool Addon::evaluateConditions(const QJsonObject& conditions) {
   if (!evaluateConditionsEnabledFeatures(
@@ -246,9 +333,29 @@ bool Addon::evaluateConditions(const QJsonObject& conditions) {
     return false;
   }
 
+  // TODO: this could be a watcher too but we are not using it yet.
   if (!evaluateConditionsSettings(conditions["settings"].toArray())) {
+    return false;
+  }
+
+  if (!evaluateConditionsEnv(conditions["env"].toString())) {
     return false;
   }
 
   return true;
 }
+
+bool Addon::enabled() const {
+  if (!m_conditionWatcher) {
+    return true;
+  }
+
+  return m_conditionWatcher->conditionApplied();
+}
+
+void Addon::enable() {
+  QCoreApplication::installTranslator(&m_translator);
+  retranslate();
+}
+
+void Addon::disable() { QCoreApplication::removeTranslator(&m_translator); }

--- a/src/addons/addon.h
+++ b/src/addons/addon.h
@@ -8,6 +8,7 @@
 #include <QObject>
 #include <QTranslator>
 
+class AddonConditionWatcher;
 class QJsonObject;
 
 class Addon : public QObject {
@@ -23,16 +24,27 @@ class Addon : public QObject {
 
   static bool evaluateConditions(const QJsonObject& conditions);
 
-  ~Addon();
+  virtual ~Addon();
 
   const QString& id() const { return m_id; }
   const QString& type() const { return m_type; }
 
   void retranslate();
 
+  bool enabled() const;
+
+ signals:
+  void conditionChanged(bool enabled);
+
  protected:
   Addon(QObject* parent, const QString& manifestFileName, const QString& id,
         const QString& name, const QString& type);
+
+  virtual void enable();
+  virtual void disable();
+
+ private:
+  void maybeCreateConditionWatchers(const QJsonObject& conditions);
 
  private:
   const QString m_manifestFileName;
@@ -41,6 +53,8 @@ class Addon : public QObject {
   const QString m_type;
 
   QTranslator m_translator;
+
+  AddonConditionWatcher* m_conditionWatcher = nullptr;
 };
 
 #endif  // ADDON_H

--- a/src/addons/addondemo.cpp
+++ b/src/addons/addondemo.cpp
@@ -34,10 +34,7 @@ Addon* AddonDemo::create(QObject* parent, const QString& manifestFileName,
     return nullptr;
   }
 
-  Addon* addon = new AddonDemo(parent, manifestFileName, id, name, qmlFileName);
-  emit AddonManager::instance()->runAddon(addon);
-
-  return addon;
+  return new AddonDemo(parent, manifestFileName, id, name, qmlFileName);
 }
 
 AddonDemo::AddonDemo(QObject* parent, const QString& manifestFileName,
@@ -56,4 +53,9 @@ QString AddonDemo::qml() const {
   }
 
   return QString("file:%1").arg(m_qmlFileName);
+}
+
+void AddonDemo::enable() {
+  Addon::enable();
+  emit AddonManager::instance()->runAddon(this);
 }

--- a/src/addons/addondemo.h
+++ b/src/addons/addondemo.h
@@ -28,6 +28,8 @@ class AddonDemo final : public Addon {
   AddonDemo(QObject* parent, const QString& manifestFileName, const QString& id,
             const QString& name, const QString& qmlFileName);
 
+  void enable() override;
+
  private:
   QString m_qmlFileName;
 };

--- a/src/addons/addoni18n.cpp
+++ b/src/addons/addoni18n.cpp
@@ -10,8 +10,16 @@ AddonI18n::AddonI18n(QObject* parent, const QString& manifestFileName,
                      const QString& id, const QString& name)
     : Addon(parent, manifestFileName, id, name, "i18n") {
   MVPN_COUNT_CTOR(AddonI18n);
-
-  emit Localizer::instance()->codeChanged();
 }
 
 AddonI18n::~AddonI18n() { MVPN_COUNT_DTOR(AddonI18n); }
+
+void AddonI18n::enable() {
+  Addon::enable();
+  emit Localizer::instance()->codeChanged();
+}
+
+void AddonI18n::disable() {
+  Addon::disable();
+  emit Localizer::instance()->codeChanged();
+}

--- a/src/addons/addoni18n.h
+++ b/src/addons/addoni18n.h
@@ -16,6 +16,10 @@ class AddonI18n final : public Addon {
             const QString& name);
 
   ~AddonI18n();
+
+ private:
+  void enable() override;
+  void disable() override;
 };
 
 #endif  // ADDONI18N_H

--- a/src/addons/conditionwatchers/addonconditionwatcher.cpp
+++ b/src/addons/conditionwatchers/addonconditionwatcher.cpp
@@ -1,0 +1,15 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "addonconditionwatcher.h"
+#include "leakdetector.h"
+
+AddonConditionWatcher::AddonConditionWatcher(QObject* parent)
+    : QObject(parent) {
+  MVPN_COUNT_CTOR(AddonConditionWatcher);
+}
+
+AddonConditionWatcher::~AddonConditionWatcher() {
+  MVPN_COUNT_DTOR(AddonConditionWatcher);
+}

--- a/src/addons/conditionwatchers/addonconditionwatcher.h
+++ b/src/addons/conditionwatchers/addonconditionwatcher.h
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef ADDONCONDITIONWATCHER_H
+#define ADDONCONDITIONWATCHER_H
+
+#include <QObject>
+
+class AddonConditionWatcher : public QObject {
+  Q_OBJECT
+  Q_DISABLE_COPY_MOVE(AddonConditionWatcher)
+
+ public:
+  AddonConditionWatcher(QObject* parent);
+  virtual ~AddonConditionWatcher();
+
+  virtual bool conditionApplied() const = 0;
+
+ signals:
+  void conditionChanged(bool enabled);
+};
+
+#endif  // ADDONCONDITIONWATCHER_H

--- a/src/addons/conditionwatchers/addonconditionwatchergroup.cpp
+++ b/src/addons/conditionwatchers/addonconditionwatchergroup.cpp
@@ -1,0 +1,38 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "addonconditionwatchergroup.h"
+#include "leakdetector.h"
+
+AddonConditionWatcherGroup::AddonConditionWatcherGroup(
+    QObject* parent, const QList<AddonConditionWatcher*>& group)
+    : AddonConditionWatcher(parent), m_group(group) {
+  MVPN_COUNT_CTOR(AddonConditionWatcherGroup);
+
+  m_currentStatus = conditionApplied();
+
+  for (AddonConditionWatcher* watcher : m_group) {
+    connect(watcher, &AddonConditionWatcher::conditionChanged, this,
+            [this](bool) {
+              bool newStatus = conditionApplied();
+              if (newStatus != m_currentStatus) {
+                m_currentStatus = newStatus;
+                emit conditionChanged(m_currentStatus);
+              }
+            });
+  }
+}
+
+AddonConditionWatcherGroup::~AddonConditionWatcherGroup() {
+  MVPN_COUNT_DTOR(AddonConditionWatcherGroup);
+}
+
+bool AddonConditionWatcherGroup::conditionApplied() const {
+  for (AddonConditionWatcher* watcher : m_group) {
+    if (!watcher->conditionApplied()) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/src/addons/conditionwatchers/addonconditionwatchergroup.h
+++ b/src/addons/conditionwatchers/addonconditionwatchergroup.h
@@ -1,0 +1,26 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef ADDONCONDITIONWATCHERGROUP_H
+#define ADDONCONDITIONWATCHERGROUP_H
+
+#include "addonconditionwatcher.h"
+
+class AddonConditionWatcherGroup final : public AddonConditionWatcher {
+  Q_OBJECT
+  Q_DISABLE_COPY_MOVE(AddonConditionWatcherGroup)
+
+ public:
+  AddonConditionWatcherGroup(QObject* parent,
+                             const QList<AddonConditionWatcher*>& group);
+  ~AddonConditionWatcherGroup();
+
+  bool conditionApplied() const override;
+
+ private:
+  const QList<AddonConditionWatcher*> m_group;
+  bool m_currentStatus = false;
+};
+
+#endif  // ADDONCONDITIONWATCHERGROUP_H

--- a/src/addons/conditionwatchers/addonconditionwatcherlocales.cpp
+++ b/src/addons/conditionwatchers/addonconditionwatcherlocales.cpp
@@ -1,0 +1,50 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "addonconditionwatcherlocales.h"
+#include "leakdetector.h"
+#include "localizer.h"
+#include "settingsholder.h"
+
+// static
+AddonConditionWatcher* AddonConditionWatcherLocales::maybeCreate(
+    QObject* parent, const QStringList& locales) {
+  if (locales.isEmpty()) {
+    return nullptr;
+  }
+
+  return new AddonConditionWatcherLocales(parent, locales);
+}
+
+AddonConditionWatcherLocales::AddonConditionWatcherLocales(
+    QObject* parent, const QStringList& locales)
+    : AddonConditionWatcher(parent), m_locales(locales) {
+  MVPN_COUNT_CTOR(AddonConditionWatcherLocales);
+
+  connect(SettingsHolder::instance(), &SettingsHolder::languageCodeChanged,
+          this, [this]() {
+            bool newStatus = conditionApplied();
+            if (m_currentStatus != newStatus) {
+              m_currentStatus = newStatus;
+              emit conditionChanged(m_currentStatus);
+            }
+          });
+}
+
+AddonConditionWatcherLocales::~AddonConditionWatcherLocales() {
+  MVPN_COUNT_DTOR(AddonConditionWatcherLocales);
+}
+
+bool AddonConditionWatcherLocales::conditionApplied() const {
+  QString code = SettingsHolder::instance()->languageCode();
+  if (code.isEmpty()) {
+    code = QLocale::system().bcp47Name();
+    if (code.isEmpty()) {
+      code = "en";
+    }
+  }
+
+  code = Localizer::majorLanguageCode(code);
+  return m_locales.contains(code.toLower());
+}

--- a/src/addons/conditionwatchers/addonconditionwatcherlocales.h
+++ b/src/addons/conditionwatchers/addonconditionwatcherlocales.h
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef ADDONCONDITIONWATCHERLOCALES_H
+#define ADDONCONDITIONWATCHERLOCALES_H
+
+#include "addonconditionwatcher.h"
+
+class AddonConditionWatcherLocales final : public AddonConditionWatcher {
+  Q_OBJECT
+  Q_DISABLE_COPY_MOVE(AddonConditionWatcherLocales)
+
+ public:
+  ~AddonConditionWatcherLocales();
+
+  static AddonConditionWatcher* maybeCreate(QObject* parent,
+                                            const QStringList& locales);
+
+  bool conditionApplied() const override;
+
+ private:
+  AddonConditionWatcherLocales(QObject* parent, const QStringList& locales);
+
+ private:
+  const QStringList m_locales;
+
+  bool m_currentStatus = false;
+};
+
+#endif  // ADDONCONDITIONWATCHERLOCALES_H

--- a/src/addons/conditionwatchers/addonconditionwatchertriggertimesecs.cpp
+++ b/src/addons/conditionwatchers/addonconditionwatchertriggertimesecs.cpp
@@ -1,0 +1,46 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "addonconditionwatchertriggertimesecs.h"
+#include "leakdetector.h"
+#include "settingsholder.h"
+
+#include <QDateTime>
+
+// static
+AddonConditionWatcher* AddonConditionWatcherTriggerTimeSecs::maybeCreate(
+    QObject* parent, qint64 triggerTimeSecs) {
+  if (triggerTimeSecs == 0) {
+    return nullptr;
+  }
+
+  return new AddonConditionWatcherTriggerTimeSecs(parent, triggerTimeSecs);
+}
+
+AddonConditionWatcherTriggerTimeSecs::AddonConditionWatcherTriggerTimeSecs(
+    QObject* parent, qint64 triggerTimeSecs)
+    : AddonConditionWatcher(parent) {
+  MVPN_COUNT_CTOR(AddonConditionWatcherTriggerTimeSecs);
+
+  QDateTime now = QDateTime::currentDateTime();
+  QDateTime installation = SettingsHolder::instance()->installationTime();
+
+  // Note: triggerTimeSecs is seconds!
+  qint64 secs = triggerTimeSecs - installation.secsTo(now);
+  if (secs > 0) {
+    m_timer.setSingleShot(true);
+    m_timer.start(secs * 1000);
+
+    connect(&m_timer, &QTimer::timeout, this,
+            [this]() { emit conditionChanged(true); });
+  }
+}
+
+AddonConditionWatcherTriggerTimeSecs::~AddonConditionWatcherTriggerTimeSecs() {
+  MVPN_COUNT_DTOR(AddonConditionWatcherTriggerTimeSecs);
+}
+
+bool AddonConditionWatcherTriggerTimeSecs::conditionApplied() const {
+  return !m_timer.isActive();
+}

--- a/src/addons/conditionwatchers/addonconditionwatchertriggertimesecs.h
+++ b/src/addons/conditionwatchers/addonconditionwatchertriggertimesecs.h
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef ADDONCONDITIONWATCHERTRIGGERTIMESECS_H
+#define ADDONCONDITIONWATCHERTRIGGERTIMESECS_H
+
+#include "addonconditionwatcher.h"
+
+#include <QTimer>
+
+class AddonConditionWatcherTriggerTimeSecs final
+    : public AddonConditionWatcher {
+  Q_OBJECT
+  Q_DISABLE_COPY_MOVE(AddonConditionWatcherTriggerTimeSecs)
+
+ public:
+  ~AddonConditionWatcherTriggerTimeSecs();
+
+  static AddonConditionWatcher* maybeCreate(QObject* parent, qint64 time);
+
+  bool conditionApplied() const override;
+
+ private:
+  AddonConditionWatcherTriggerTimeSecs(QObject* parent, qint64 time);
+
+ private:
+  QTimer m_timer;
+};
+
+#endif  // ADDONCONDITIONWATCHERTRIGGERTIMESECS_H

--- a/src/cmake/sources.cmake
+++ b/src/cmake/sources.cmake
@@ -22,6 +22,14 @@ target_sources(mozillavpn PRIVATE
     addons/addonmessage.h
     addons/addontutorial.cpp
     addons/addontutorial.h
+    addons/conditionwatchers/addonconditionwatcher.cpp
+    addons/conditionwatchers/addonconditionwatcher.h
+    addons/conditionwatchers/addonconditionwatchergroup.cpp
+    addons/conditionwatchers/addonconditionwatchergroup.h
+    addons/conditionwatchers/addonconditionwatcherlocales.cpp
+    addons/conditionwatchers/addonconditionwatcherlocales.h
+    addons/conditionwatchers/addonconditionwatchertriggertimesecs.cpp
+    addons/conditionwatchers/addonconditionwatchertriggertimesecs.h
     appimageprovider.h
     applistprovider.h
     apppermission.cpp

--- a/src/qmake/sources.pri
+++ b/src/qmake/sources.pri
@@ -10,6 +10,10 @@ SOURCES += \
         addons/addoni18n.cpp \
         addons/addonmessage.cpp \
         addons/addontutorial.cpp \
+        addons/conditionwatchers/addonconditionwatcher.cpp \
+        addons/conditionwatchers/addonconditionwatchergroup.cpp \
+        addons/conditionwatchers/addonconditionwatcherlocales.cpp \
+        addons/conditionwatchers/addonconditionwatchertriggertimesecs.cpp \
         apppermission.cpp \
         authenticationlistener.cpp \
         authenticationinapp/authenticationinapp.cpp \
@@ -162,6 +166,10 @@ HEADERS += \
         addons/addoni18n.h \
         addons/addonmessage.h \
         addons/addontutorial.h \
+        addons/conditionwatchers/addonconditionwatcher.h \
+        addons/conditionwatchers/addonconditionwatcherlocales.h \
+        addons/conditionwatchers/addonconditionwatchertriggertimesecs.h \
+        addons/conditionwatchers/addonconditionwatchergroup.h \
         appimageprovider.h \
         apppermission.h \
         applistprovider.h \

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -47,6 +47,14 @@ target_sources(unit_tests PRIVATE
     ${MVPN_SOURCE_DIR}/addons/addonmessage.h
     ${MVPN_SOURCE_DIR}/addons/addontutorial.cpp
     ${MVPN_SOURCE_DIR}/addons/addontutorial.h
+    ${MVPN_SOURCE_DIR}/addons/conditionwatchers/addonconditionwatcher.cpp
+    ${MVPN_SOURCE_DIR}/addons/conditionwatchers/addonconditionwatcher.h
+    ${MVPN_SOURCE_DIR}/addons/conditionwatchers/addonconditionwatchergroup.cpp
+    ${MVPN_SOURCE_DIR}/addons/conditionwatchers/addonconditionwatchergroup.h
+    ${MVPN_SOURCE_DIR}/addons/conditionwatchers/addonconditionwatcherlocales.cpp
+    ${MVPN_SOURCE_DIR}/addons/conditionwatchers/addonconditionwatcherlocales.h
+    ${MVPN_SOURCE_DIR}/addons/conditionwatchers/addonconditionwatchertriggertimesecs.cpp
+    ${MVPN_SOURCE_DIR}/addons/conditionwatchers/addonconditionwatchertriggertimesecs.h
     ${MVPN_SOURCE_DIR}/adjust/adjustfiltering.cpp
     ${MVPN_SOURCE_DIR}/adjust/adjustfiltering.h
     ${MVPN_SOURCE_DIR}/adjust/adjustproxypackagehandler.cpp

--- a/tests/unit/testaddon.h
+++ b/tests/unit/testaddon.h
@@ -11,6 +11,10 @@ class TestAddon final : public TestHelper {
   void conditions_data();
   void conditions();
 
+  void conditionWatcher_locale();
+  void conditionWatcher_group();
+  void conditionWatcher_triggerTime();
+
   void guide_create_data();
   void guide_create();
 

--- a/tests/unit/unit.pro
+++ b/tests/unit/unit.pro
@@ -50,6 +50,10 @@ HEADERS += \
     ../../src/addons/addoni18n.h \
     ../../src/addons/addonmessage.h \
     ../../src/addons/addontutorial.h \
+    ../../src/addons/conditionwatchers/addonconditionwatcher.h \
+    ../../src/addons/conditionwatchers/addonconditionwatchergroup.h \
+    ../../src/addons/conditionwatchers/addonconditionwatcherlocales.h \
+    ../../src/addons/conditionwatchers/addonconditionwatchertriggertimesecs.h \
     ../../src/adjust/adjustfiltering.h \
     ../../src/adjust/adjustproxypackagehandler.h \
     ../../src/captiveportal/captiveportal.h \
@@ -166,6 +170,10 @@ SOURCES += \
     ../../src/addons/addoni18n.cpp \
     ../../src/addons/addonmessage.cpp \
     ../../src/addons/addontutorial.cpp \
+    ../../src/addons/conditionwatchers/addonconditionwatcher.cpp \
+    ../../src/addons/conditionwatchers/addonconditionwatchergroup.cpp \
+    ../../src/addons/conditionwatchers/addonconditionwatcherlocales.cpp \
+    ../../src/addons/conditionwatchers/addonconditionwatchertriggertimesecs.cpp \
     ../../src/adjust/adjustfiltering.cpp \
     ../../src/adjust/adjustproxypackagehandler.cpp \
     ../../src/captiveportal/captiveportal.cpp \


### PR DESCRIPTION
This patch introduces a big change in addons. They now can be:
- not loaded - in case the "static" conditions do not match (platform, env, ...)
- loaded but disabled - in case dynamic conditions do not match (locales, triggering time, ...)
- loaded and enabled - in case conditions match.

When the conditions change the addon can be enabled or disabled. The model is updated and the frontend will be updated too.

I also wrote 4 temporary addons to test the surveys as addon messages with triggering time. 2 for testing only.

This PR has also unit-tests.