### PR TITLE
Bump Qt version / Maybe fix iOS crash?

### DIFF
--- a/taskcluster/ci/toolchain/qt.yml
+++ b/taskcluster/ci/toolchain/qt.yml
@@ -5,7 +5,7 @@
 job-defaults:
     worker:
         env:
-            QT_VERSION: "6.2.3"
+            QT_VERSION: "6.2.4"
             QT_MAJOR: "6.2"
         max-run-time: 14400
 


### PR DESCRIPTION
## Description
https://github.com/mozilla-mobile/mozilla-vpn-client/issues/3960
Sounds very much like a bug we had in android that we had resolved by upgrading to 6.2.4. - Let's do that for ios too, we can always roll back if it breaks things

Note: Merging this into main will bump the next ios build but not windows/macos. - :) 
