### PR TITLE
An optimization related to saved addons

### DIFF
--- a/src/addonmanager.h
+++ b/src/addonmanager.h
@@ -36,8 +36,7 @@ class AddonManager final : public QAbstractListModel {
   void storeAndLoadAddon(const QByteArray& addonData, const QString& addonId,
                          const QByteArray& sha256);
 
-  bool loadManifest(const QString& addonManifestFileName,
-                    const QByteArray& sha256);
+  bool loadManifest(const QString& addonManifestFileName);
 
   void unload(const QString& addonId);
 
@@ -75,6 +74,8 @@ class AddonManager final : public QAbstractListModel {
   void loadCompletedChanged();
 
  private:
+  // This struct can be partially empty in case the sha does not match, or the
+  // addon does not need to be loaded for unmatched conditions.
   struct AddonData {
     QByteArray m_sha256;
     QString m_addonId;

--- a/src/inspector/inspectorhandler.cpp
+++ b/src/inspector/inspectorhandler.cpp
@@ -928,8 +928,8 @@ static QList<InspectorCommand> s_commands{
                        // This is a debugging method. We don't need to compute
                        // the hash of the addon because we will not be able to
                        // find it in the addon index.
-                       obj["value"] = AddonManager::instance()->loadManifest(
-                           arguments[1], "INVALID SHA256");
+                       obj["value"] =
+                           AddonManager::instance()->loadManifest(arguments[1]);
                        return obj;
                      }},
 


### PR DESCRIPTION
As we know, we don't load all the addons. But because of this, without this PR, at any refresh, we try to download the non-loaded ones. With this PR, we keep track of them, storing them on disk without loading them.