### PR TITLE
Fix crash on swipe kill

### DIFF
--- a/src/commands/commandui.cpp
+++ b/src/commands/commandui.cpp
@@ -202,7 +202,7 @@ int CommandUI::run(QStringList& tokens) {
     }
 #endif
     // This object _must_ live longer than MozillaVPN to avoid shutdown crashes.
-    QmlEngineHolder engineHolder;
+    QmlEngineHolder* engineHolder = new QmlEngineHolder();
     QQmlApplicationEngine* engine = QmlEngineHolder::instance()->engine();
 
     // TODO pending #3398
@@ -567,7 +567,7 @@ int CommandUI::run(QStringList& tokens) {
     engine->load(url);
 
     NotificationHandler* notificationHandler =
-        NotificationHandler::create(&engineHolder);
+        NotificationHandler::create(engineHolder);
 
     QObject::connect(vpn.controller(), &Controller::stateChanged,
                      notificationHandler,


### PR DESCRIPTION
## Description

On iOS devices the VPN crashed when swipe killed from multiple views.

## Reference

[VPN-2548](https://mozilla-hub.atlassian.net/browse/VPN-2548): [iOS] Crash after swipe kill while on Profile screen

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
