### PR TITLE
Repair mismerge of #3539

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,13 @@
 
 cmake_minimum_required(VERSION 3.16)
 
+message("Configuring for ${CMAKE_GENERATOR}")
+if(NOT (DEFINED CMAKE_CONFIGURATION_TYPES OR DEFINED CMAKE_BUILD_TYPE))
+    ## Ensure the build type is set for single-config generators.
+    set(CMAKE_BUILD_TYPE "Debug" CACHE STRING "default build type" FORCE)
+    message("Setting build type ${CMAKE_BUILD_TYPE}")
+endif()
+
 project("Mozilla VPN" VERSION 2.10.0 LANGUAGES C CXX
         DESCRIPTION "A fast, secure and easy to use VPN. Built by the makers of Firefox."
         HOMEPAGE_URL "https://vpn.mozilla.org"
@@ -43,13 +50,6 @@ if(APPLE)
 endif()
 
 option(BUILD_DUMMY "Build for the dummy platform" OFF)
-
-message("Configuring for ${CMAKE_GENERATOR}")
-if(NOT (DEFINED CMAKE_CONFIGURATION_TYPES OR DEFINED CMAKE_BUILD_TYPE))
-    ## Ensure the build type is set for single-config generators.
-    set(CMAKE_BUILD_TYPE "Debug" CACHE STRING "default build type" FORCE)
-    message("Setting build type ${CMAKE_BUILD_TYPE}")
-endif()
 
 if(NOT DEFINED BUILD_ID)
     string(TIMESTAMP BUILD_ID "${PROJECT_VERSION_MAJOR}.%Y%m%d%H%M")


### PR DESCRIPTION
## Description

While #3539 was waiting to be merged, it accumulated an undetected merge conflict with commit 7369bb3dc5792059389295504b56d2e7917fb615 (#3935), which moved the `project()` directive to the top of the file. GitHub incorrectly resolved this by duplicating the `project()` directive.  Then commit 28cc02cdd9de5f1c00e258a3fe32f132d875bb31 (#4023) deleted one of the duplicates, but left the original fix ineffective, because the `set(CMAKE_BUILD_TYPE …)` directive is still incorrectly after the remaining `project()` directive.

Fix it.

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
