### PR TITLE
HackFix for 2.9 tutorial UI issues (#4002)

### DIFF
--- a/nebula/ui/components/VPNFlickable.qml
+++ b/nebula/ui/components/VPNFlickable.qml
@@ -34,6 +34,9 @@ Flickable {
     clip: true
 
     function ensureVisible(item) {
+        if (VPNTutorial.playing) {
+            return;
+        }
         let yPosition = item.mapToItem(contentItem, 0, 0).y;
         if (!contentExceedsHeight || item.skipEnsureVisible || yPosition < 0) {
             return;

--- a/nebula/ui/components/VPNServerCountry.qml
+++ b/nebula/ui/components/VPNServerCountry.qml
@@ -20,6 +20,13 @@ VPNClickableRow {
     property var currentCityIndex
     property alias serverCountryName: countryName.text
 
+    function ensureVisibleDuringTutorial() {
+        const serverListYCenter = vpnFlickable.height / 2 - listOffset
+        const emitterYPosition = serverCountry.y + - serverListYCenter;
+        const destinationY = (emitterYPosition + vpnFlickable.height > vpnFlickable.contentHeight) ? vpnFlickable.contentHeight - vpnFlickable.height : emitterYPosition;
+        vpnFlickable.contentY = destinationY;
+    }
+
     function openCityList() {
         cityListVisible = !cityListVisible;
         const itemDistanceFromWindowTop = serverCountry.mapToItem(null, 0, 0).y - multiHopMenuHeight;

--- a/nebula/ui/components/VPNTutorialPopups.qml
+++ b/nebula/ui/components/VPNTutorialPopups.qml
@@ -56,11 +56,15 @@ Item {
         verticalPadding: VPNTheme.theme.windowMargin
         horizontalPadding: VPNTheme.theme.windowMargin
         focus: true
-
         y: {
             if (targetElement) {
                const windowHeight = window.height;
-               const targetElementDistanceFromTop = targetElement.mapToItem(window.contentItem, 0, 0).y
+               let targetElementDistanceFromTop = getTargetElementYPosition();
+
+                if (windowHeight < targetElementDistanceFromTop && targetElement.ensureVisibleDuringTutorial) {
+                    targetElement.ensureVisibleDuringTutorial();
+                    targetElementDistanceFromTop = getTargetElementYPosition();
+                }
 
                if (targetElementDistanceFromTop + targetElement.height + tutorialTooltip.implicitHeight > windowHeight) {
                    tooltipPositionedAboveTargetElement = true;
@@ -174,6 +178,9 @@ Item {
                     sourceSize.width: VPNTheme.theme.windowMargin
                 }
             }
+        }
+        function getTargetElementYPosition() {
+            return targetElement.mapToItem(window.contentItem, 0, 0).y;
         }
     }
 


### PR DESCRIPTION
## Description

Bandaid fix for tutorial UI issues in the 'Get started' tutorial when Australia is not the first country in the server list. We will do something more future-proof for 2.10. 
<table>
<tr>
<td>
<img width="468" alt="Screen Shot 2022-07-14 at 4 41 34 PM" src="https://user-images.githubusercontent.com/22355127/179091358-acc92eef-4cd8-4549-a616-63e03563258a.png">
</td>
<td>
<img width="476" alt="Screen Shot 2022-07-14 at 4 41 39 PM" src="https://user-images.githubusercontent.com/22355127/179091377-787ea039-1f16-48ae-a5ca-4e72dce78304.png">
</td>
<td>
<img width="467" alt="Screen Shot 2022-07-14 at 4 42 21 PM" src="https://user-images.githubusercontent.com/22355127/179091405-3d19f1c2-3eeb-4607-a5dc-367426de9105.png">

</td>
<td>
<img width="471" alt="Screen Shot 2022-07-14 at 4 42 28 PM" src="https://user-images.githubusercontent.com/22355127/179091427-74a24684-5ac8-4fd7-b54b-7567b7ad251a.png">
</td>
<td>
<img width="472" alt="Screen Shot 2022-07-14 at 4 43 21 PM" src="https://user-images.githubusercontent.com/22355127/179091459-e6c5c62e-bf4a-4057-be20-0f38e2da9817.png">

</td>
<td>
<img width="470" alt="Screen Shot 2022-07-14 at 4 43 28 PM" src="https://user-images.githubusercontent.com/22355127/179091486-c3b7e55f-cd97-47f3-ab42-cc7b4d26c239.png">

</td>
</tr>
</table>

## Reference

#4002 

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
