### PR TITLE
Reset profile flow on account deletion

### DIFF
--- a/src/profileflow.cpp
+++ b/src/profileflow.cpp
@@ -50,7 +50,9 @@ void ProfileFlow::start() {
 
   setState(StateLoading);
 
-  User* user = MozillaVPN::instance()->user();
+  MozillaVPN* vpn = MozillaVPN::instance();
+  Q_ASSERT(vpn);
+  User* user = vpn->user();
   Q_ASSERT(user);
 
   TaskGetSubscriptionDetails* task =
@@ -80,6 +82,7 @@ void ProfileFlow::start() {
       setState(StateError);
     }
   });
+  connect(vpn, &MozillaVPN::accountDeleted, this, [&] { reset(); });
 
   TaskScheduler::scheduleTask(task);
   m_currentTask = task;

--- a/src/profileflow.cpp
+++ b/src/profileflow.cpp
@@ -82,7 +82,11 @@ void ProfileFlow::start() {
       setState(StateError);
     }
   });
-  connect(vpn, &MozillaVPN::accountDeleted, this, [&] { reset(); });
+  connect(vpn, &MozillaVPN::stateChanged, this, [&] {
+    if (vpn->state() != MozillaVPN::StateMain) {
+      reset();
+    }
+  });
 
   TaskScheduler::scheduleTask(task);
   m_currentTask = task;

--- a/src/profileflow.cpp
+++ b/src/profileflow.cpp
@@ -82,7 +82,9 @@ void ProfileFlow::start() {
       setState(StateError);
     }
   });
-  connect(vpn, &MozillaVPN::stateChanged, this, [&] {
+  connect(vpn, &MozillaVPN::stateChanged, this, [this]() {
+    MozillaVPN* vpn = MozillaVPN::instance();
+    Q_ASSERT(vpn);
     if (vpn->state() != MozillaVPN::StateMain) {
       reset();
     }


### PR DESCRIPTION
## Description

Reset the profile flow on account deletion.

## Reference

[VPN-2554: Profile screen cannot be accessed after a delete-account action](https://mozilla-hub.atlassian.net/browse/VPN-2554)

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
