### PR TITLE
Fix the wasm client - fixes VPN-2589

### DIFF
--- a/src/addonmanager.cpp
+++ b/src/addonmanager.cpp
@@ -384,6 +384,13 @@ bool AddonManager::validateAndLoad(const QString& addonId,
                                    const QByteArray& sha256, bool checkSha256) {
   logger.debug() << "Load addon" << addonId;
 
+#ifdef MVPN_WASM
+  if (addonId.startsWith("message_")) {
+    logger.debug() << "Skipping the message addon";
+    return true;
+  }
+#endif
+
   if (m_addons.contains(addonId)) {
     logger.warning() << "Addon" << addonId << "already loaded";
     return false;

--- a/tests/functional/guardian.js
+++ b/tests/functional/guardian.js
@@ -26,8 +26,9 @@ const GuardianEndpoints = {
     '/api/v1/vpn/featurelist': {status: 200, body: {features: {}}},
     '/api/v1/vpn/versions': {status: 200, body: {}},
     '/__heartbeat__': {status: 200, body: {mullvadOK: true, dbOK: true}},
-    '/api/v2/vpn/login/ios': {
+    '/api/v2/vpn/login/': {
       status: 200,
+      match: 'startWith',
       body: {
         fxa_oauth: {
           url: 'https://accounts.stage.mozaws.net/authorization',


### PR DESCRIPTION
This is a temporary fix because it seems that WASM is unable to message addon RCC Files (yet).