### PR TITLE
Fix the test failures

### DIFF
--- a/nebula/ui/components/VPNTutorialPopups.qml
+++ b/nebula/ui/components/VPNTutorialPopups.qml
@@ -232,6 +232,7 @@ Item {
             VPN.recordGleanEventWithExtraKeys("tutorialAborted", {"id": VPNTutorial.currentTutorial.id});
             tutorialPopup._onClosed = () => {
                 if (op !== null) VPNTutorial.interruptAccepted(op);
+                else VPNTutorial.stop();
             }
             tutorialPopup.close();
         }

--- a/src/externalophandler.cpp
+++ b/src/externalophandler.cpp
@@ -58,6 +58,9 @@ void ExternalOpHandler::request(Op op) {
   }
 
   switch (op) {
+    case OpAbout:
+      vpn->requestAbout();
+      break;
     case OpContactUs:
       vpn->requestContactUs();
       break;

--- a/src/externalophandler.h
+++ b/src/externalophandler.h
@@ -13,6 +13,7 @@ class ExternalOpHandler final : public QObject {
 
  public:
   enum Op {
+    OpAbout,
     OpActivate,
     OpCloseEvent,
     OpContactUs,

--- a/src/inspector/inspectorhandler.cpp
+++ b/src/inspector/inspectorhandler.cpp
@@ -6,6 +6,7 @@
 #include "addonmanager.h"
 #include "constants.h"
 #include "controller.h"
+#include "externalophandler.h"
 #include "inspectoritempicker.h"
 #include "inspectorutils.h"
 #include "leakdetector.h"
@@ -857,12 +858,14 @@ static QList<InspectorCommand> s_commands{
 
     InspectorCommand{"open_settings", "Open settings menu", 0,
                      [](InspectorHandler*, const QList<QByteArray>&) {
-                       MozillaVPN::instance()->settingsNeeded();
+                       ExternalOpHandler::instance()->request(
+                           ExternalOpHandler::OpSettings);
                        return QJsonObject();
                      }},
     InspectorCommand{"open_contact_us", "Open in-app support form", 0,
                      [](InspectorHandler*, const QList<QByteArray>&) {
-                       MozillaVPN::instance()->requestContactUs();
+                       ExternalOpHandler::instance()->request(
+                           ExternalOpHandler::OpContactUs);
                        return QJsonObject();
                      }},
     InspectorCommand{"is_feature_flipped_on",

--- a/src/platforms/macos/macosmenubar.cpp
+++ b/src/platforms/macos/macosmenubar.cpp
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "macosmenubar.h"
+#include "externalophandler.h"
 #include "leakdetector.h"
 #include "logger.h"
 #include "mozillavpn.h"
@@ -56,14 +57,16 @@ void MacOSMenuBar::initialize() {
   quit->setMenuRole(QAction::QuitRole);
 
   // Do not use qtTrId here!
-  m_aboutAction =
-      fileMenu->addAction("about.vpn", vpn, &MozillaVPN::requestAbout);
+  m_aboutAction = fileMenu->addAction("about.vpn", []() {
+    ExternalOpHandler::instance()->request(ExternalOpHandler::OpAbout);
+  });
   m_aboutAction->setMenuRole(QAction::AboutRole);
   m_aboutAction->setVisible(vpn->state() == MozillaVPN::StateMain);
 
   // Do not use qtTrId here!
-  m_preferencesAction =
-      fileMenu->addAction("preferences", vpn, &MozillaVPN::requestSettings);
+  m_preferencesAction = fileMenu->addAction("preferences", []() {
+    ExternalOpHandler::instance()->request(ExternalOpHandler::OpSettings);
+  });
   m_preferencesAction->setMenuRole(QAction::PreferencesRole);
   m_preferencesAction->setVisible(vpn->state() == MozillaVPN::StateMain);
 

--- a/src/ui/views/ViewMain.qml
+++ b/src/ui/views/ViewMain.qml
@@ -253,13 +253,18 @@ VPNFlickable {
         }
     }
 
+    function maybeActivateTipsAndTricksIntro() {
+        if (!VPNSettings.tipsAndTricksIntroShown &&
+            VPNAddonManager.loadCompleted &&
+            !!VPNAddonManager.pick(addon => addon.type === "tutorial" || addon.type === "guide")) {
+            tipsAndTricksIntroPopupLoader.active = true
+        }
+    }
+
+    Component.onCompleted: () => maybeActivateTipsAndTricksIntro();
+
     Connections {
         target: VPNAddonManager
-        function onLoadCompletedChanged() {
-            if (!VPNSettings.tipsAndTricksIntroShown &&
-                !!VPNAddonManager.pick(addon => addon.type === "tutorial" || addon.type === "guide")) {
-                tipsAndTricksIntroPopupLoader.active = true
-            }
-        }
+        function onLoadCompletedChanged() { maybeActivateTipsAndTricksIntro(); }
     }
 }


### PR DESCRIPTION
There are 2 issues here:
- maybe the VPNAddonManager is faster than nebula and when the tips&tricks modal is loaded the addons have been already processed. If this happens, the `loadCompleted` signal was already emitted and the `Connection` block will not be executed.
- the inspector does not call the `ExternalOpHandler` when loading settings and contact-us views. Now it does.
- Same thing for the macosbar handler.