### PR TITLE
Drop support for Ubuntu/Impish which is EOL.

### DIFF
--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -47,7 +47,6 @@ jobs:
         config:
             - { name: "Bionic", dist: bionic, ppa: "ppa:okirby/qt6-backports" }
             - { name: "Focal", dist: focal, ppa: "ppa:okirby/qt6-backports" }
-            - { name: "Impish", dist: impish, ppa: "ppa:okirby/qt6-backports" }
             - { name: "Jammy", dist: jammy, ppa: "" }
 
     runs-on: ubuntu-latest

--- a/scripts/linux/ppa_script.sh
+++ b/scripts/linux/ppa_script.sh
@@ -76,7 +76,7 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-[ "$RELEASE" != "focal" ] && [ "$RELEASE" != "bionic" ] && [ "$RELEASE" != "impish" ] && die "We support RELEASE focal, impish and bionic only"
+[ "$RELEASE" != "focal" ] && [ "$RELEASE" != "bionic" ] && [ "$RELEASE" != "jammy" ] && die "We support RELEASE focal, jammy and bionic only"
 
 printn Y "Computing the version... "
 SHORTVERSION=$(cat version.pri | grep VERSION | grep defined | cut -d= -f2 | tr -d \ )

--- a/scripts/linux/script.sh
+++ b/scripts/linux/script.sh
@@ -79,7 +79,7 @@ while [[ $# -gt 0 ]]; do
     shift
     ;;
   --source)
-    RELEASE="bionic focal impish jammy fedora"
+    RELEASE="bionic focal jammy fedora"
     SOURCEONLY=Y
     shift
     ;;


### PR DESCRIPTION
## Description
Ubuntu 21.10/Impish reached EOL status on July 14th (announcement [here](https://lists.ubuntu.com/archives/ubuntu-announce/2022-July/000281.html)) and is no longer accepting new packages. This means that we can no longer build packages for Impish on any of our PPA tasks.

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
