### PR TITLE
Fix #4009 - UI overlap in App Permissions

### DIFF
--- a/nebula/ui/components/VPNExpandableAppList.qml
+++ b/nebula/ui/components/VPNExpandableAppList.qml
@@ -106,27 +106,18 @@ ColumnLayout {
     }
 
     VPNSearchBar {
-        id: filterInput
-        Layout.preferredWidth: parent.width
-        Layout.preferredHeight: VPNTheme.theme.rowHeight
-        onTextChanged: text => {
-            model.invalidate();
-        }
-        _placeholderText: searchBarPlaceholder
-        hasError: applist.count === 0
+        id: searchBar
+        _filterProxySource: VPNAppPermissions
+        _filterProxyCallback: obj => {
+             const filterValue = getSearchBarText();
+             return obj.appName.toLowerCase().includes(filterValue);
+         }
+        _searchBarHasError: () => { return applist.count === 0 }
+        _searchBarPlaceholderText: searchBarPlaceholder
+
         enabled: vpnFlickable.vpnIsOff && VPNSettings.protectSelectedApps
+        Layout.fillWidth: true
     }
-
-    VPNFilterProxyModel {
-        id: model
-        source: VPNAppPermissions
-        // No filter
-        filterCallback: obj => {
-           const filterValue = filterInput.text.toLowerCase();
-           return obj.appName.toLowerCase().includes(filterValue);
-        }
-    }
-
 
 
     ColumnLayout {
@@ -138,7 +129,9 @@ ColumnLayout {
 
         Repeater {
             id: applist
-            model: model
+            model: searchBar.getProxyModel()
+            Layout.fillHeight: false
+            visible: count > 0
             delegate: VPNCheckBoxRow {
                 showDivider: false
                 labelText: appName

--- a/src/ui/settings/ViewAppPermissions.qml
+++ b/src/ui/settings/ViewAppPermissions.qml
@@ -130,6 +130,7 @@ Item {
             VPNExpandableAppList {
                 id: enabledList
                 Layout.fillWidth: true
+                Layout.fillHeight: false
                 Layout.leftMargin: VPNTheme.theme.vSpacing
                 Layout.rightMargin: VPNTheme.theme.vSpacing
                 Layout.preferredWidth: parent.width - VPNTheme.theme.vSpacing * 2

--- a/src/ui/settings/ViewLanguage.qml
+++ b/src/ui/settings/ViewLanguage.qml
@@ -7,7 +7,6 @@ import QtQuick.Controls 2.14
 import QtQuick.Layouts 1.14
 
 import Mozilla.VPN 1.0
-import Mozilla.VPN.qmlcomponents 1.0
 import components 0.1
 import components.forms 0.1
 
@@ -94,7 +93,7 @@ Item {
                     // Scroll vpnFlickable so that the current language is
                     // vertically centered in the view
 
-                    const yCenter = (vpnFlickable.height - menu.height - filterInput.height) / 2
+                    const yCenter = (vpnFlickable.height - menu.height - searchBar.height) / 2
 
                     for (let idx = 0; idx < repeater.count; idx++) {
                         const repeaterItem = repeater.itemAt(idx);
@@ -117,33 +116,25 @@ Item {
                 }
 
                 VPNSearchBar {
-                    id: filterInput
-                    height: VPNTheme.theme.rowHeight
+                    id: searchBar
+                    _filterProxySource: VPNLocalizer
+                    _filterProxyCallback: obj => {
+                         const filterValue = getSearchBarText();
+                         return obj.localizedLanguage.toLowerCase().includes(filterValue) ||
+                                 obj.language.toLowerCase().includes(filterValue);
+                     }
+                    _searchBarHasError: () => { return repeater.count === 0 }
+                    _searchBarPlaceholderText: VPNl18n.LanguageViewSearchPlaceholder
+
+                    enabled: !useSystemLanguageEnabled
                     anchors.left: parent.left
                     anchors.right: parent.right
-                    onTextChanged: text => {
-                        model.invalidate();
-                    }
-                    hasError: repeater.count === 0
-                    enabled: !useSystemLanguageEnabled
-                    _placeholderText: VPNl18n.LanguageViewSearchPlaceholder
-                }
-
-                VPNFilterProxyModel {
-                    id: model
-                    source: VPNLocalizer
-                    // No filter
-                    filterCallback: obj => {
-                       const filterValue = filterInput.text.toLowerCase();
-                       return obj.localizedLanguage.toLowerCase().includes(filterValue) ||
-                              obj.language.toLowerCase().includes(filterValue);
-                    }
                 }
 
                 Repeater {
                     id: repeater
 
-                    model: model
+                    model: searchBar.getProxyModel()
                     delegate: ColumnLayout {
 
                         spacing: 0
@@ -171,8 +162,8 @@ Item {
                             activeFocusOnTab: !useSystemLanguageEnabled
                             onActiveFocusChanged: if (focus) vpnFlickable.ensureVisible(del)
                             Keys.onDownPressed: repeater.itemAt(index + 1) ? repeater.itemAt(index + 1).forceActiveFocus() : repeater.itemAt(0).forceActiveFocus()
-                            Keys.onUpPressed: repeater.itemAt(index - 1) ? repeater.itemAt(index - 1).forceActiveFocus() : filterInput.forceActiveFocus()
-                            Keys.onBacktabPressed: filterInput.forceActiveFocus()
+                            Keys.onUpPressed: repeater.itemAt(index - 1) ? repeater.itemAt(index - 1).forceActiveFocus() : searchBar.forceActiveFocus()
+                            Keys.onBacktabPressed: searchBar.forceActiveFocus()
                         }
 
                         VPNTextBlock {


### PR DESCRIPTION
## Description

This PR consolidates instances of `VPNFilterProxyModel{}` into `VPNSearchBar.qml` and refactors to fix UI bug in App Permissions. 

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>
<img width="887" alt="Screen Shot 2022-07-22 at 11 45 26 AM" src="https://user-images.githubusercontent.com/22355127/180486132-1ea1d2d5-dd1a-4264-845e-77aaa7fe343d.png">


</td>
<td>

<img width="363" alt="Screen Shot 2022-07-22 at 11 44 36 AM" src="https://user-images.githubusercontent.com/22355127/180485934-09cc3a6a-c133-49df-836b-2f123c054d78.png">

</td>
</tr>
</table>


## Reference

Fixes #4009 

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
