### PR TITLE
Nit fix #3384 - Prevent button "clicks" if pressed mouse leaves button

### DIFF
--- a/nebula/ui/components/VPNMouseArea.qml
+++ b/nebula/ui/components/VPNMouseArea.qml
@@ -26,7 +26,7 @@ MouseArea {
     onPressed: changeState(uiState.statePressed)
     onCanceled: changeState(uiState.stateDefault)
     onReleased: {
-        if (hoverEnabled) {
+        if (hoverEnabled && mouseArea.containsMouse) {
             changeState(uiState.stateDefault);
             onMouseAreaClicked();
         }

--- a/nebula/ui/components/VPNMouseArea.qml
+++ b/nebula/ui/components/VPNMouseArea.qml
@@ -14,6 +14,9 @@ MouseArea {
     property bool propagateClickToParent: true
     property var onMouseAreaClicked: () => { if(propagateClickToParent) parent.clicked() }
 
+    // Set to true in tst_VPNMouseArea.qml to prevent failing
+    // at L32 `mouseArea.containsMouse`.
+    property bool qmlUnitTestWorkaround: false
     function changeState(stateName) {
         targetEl.state = stateName;
     }
@@ -26,7 +29,7 @@ MouseArea {
     onPressed: changeState(uiState.statePressed)
     onCanceled: changeState(uiState.stateDefault)
     onReleased: {
-        if (hoverEnabled && mouseArea.containsMouse) {
+        if (hoverEnabled && (mouseArea.containsMouse || mouseArea.qmlUnitTestWorkaround)) {
             changeState(uiState.stateDefault);
             onMouseAreaClicked();
         }

--- a/tests/qml/tst_VPNMouseArea.qml
+++ b/tests/qml/tst_VPNMouseArea.qml
@@ -61,7 +61,7 @@ TestCase {
         verify(expected === actual, `propagateClickToParent was ${actual} not ${expected}.`);
 
         //Ensures parent does not get `clicked' events on VPNMouseArea 'release' signal
-        testCase.testComponent.mouseArea.released(TestEvent)
+        testCase.testComponent.mouseArea.clicked(TestEvent)
         compare(testCase.testComponent.spyTestButtonClicked.count, 0)
     }
 

--- a/tests/qml/tst_VPNMouseArea.qml
+++ b/tests/qml/tst_VPNMouseArea.qml
@@ -49,7 +49,7 @@ TestCase {
         verify(expected === actual, `propagateClickToParent was ${actual} not ${expected}.`);
 
         //Ensures parent gets 'clicked' event on VPNMouseArea 'release' signal
-        testCase.testComponent.mouseArea.released(TestEvent)
+        testCase.testComponent.mouseArea.clicked(TestEvent)
         compare(testCase.testComponent.spyTestButtonClicked.count, 1)
     }
 

--- a/tests/qml/tst_VPNMouseArea.qml
+++ b/tests/qml/tst_VPNMouseArea.qml
@@ -31,6 +31,7 @@ TestCase {
 
             VPNMouseArea {
                 id: mouseArea
+                qmlUnitTestWorkaround: true
             }
 
             SignalSpy {
@@ -49,7 +50,7 @@ TestCase {
         verify(expected === actual, `propagateClickToParent was ${actual} not ${expected}.`);
 
         //Ensures parent gets 'clicked' event on VPNMouseArea 'release' signal
-        testCase.testComponent.mouseArea.clicked(TestEvent)
+        testCase.testComponent.mouseArea.released(TestEvent)
         compare(testCase.testComponent.spyTestButtonClicked.count, 1)
     }
 
@@ -61,7 +62,7 @@ TestCase {
         verify(expected === actual, `propagateClickToParent was ${actual} not ${expected}.`);
 
         //Ensures parent does not get `clicked' events on VPNMouseArea 'release' signal
-        testCase.testComponent.mouseArea.clicked(TestEvent)
+        testCase.testComponent.mouseArea.released(TestEvent)
         compare(testCase.testComponent.spyTestButtonClicked.count, 0)
     }
 


### PR DESCRIPTION
## Description

This prevent button "clicks" after 1.) clicking and holding a button then 2.) moving the mouse away from the button and 3.) releasing the mouse outside of the button.

## Reference

Fixes #3384

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
