### PR TITLE
Nit Fix #626 - Use correct accessible name for Settings close button

### DIFF
--- a/nebula/ui/components/VPNMenu.qml
+++ b/nebula/ui/components/VPNMenu.qml
@@ -17,6 +17,7 @@ Item {
     property bool btnDisabled: false
     property alias forceFocus: iconButton.focus
     property string _iconButtonSource: "qrc:/nebula/resources/back.svg"
+    property alias _iconButtonAccessibleName: iconButton.accessibleName
     property var _menuOnBackClicked: () => { goBack(); }
 
     width: parent.width

--- a/src/ui/views/ViewSettings.qml
+++ b/src/ui/views/ViewSettings.qml
@@ -25,7 +25,7 @@ Item {
             mainStackView.pop();
         }
         _iconButtonSource: settingsStackView.depth === 1 ? "qrc:/nebula/resources/close-dark.svg" : "qrc:/nebula/resources/back.svg"
-
+        _iconButtonAccessibleName: settingsStackView.depth === 1 ? qsTrId("vpn.connectionInfo.close") : qsTrId("vpn.main.back")
         anchors.top: parent.top
         anchors.left: parent.left
         anchors.right: parent.right


### PR DESCRIPTION
## Description

This changes the tooltip label of the "X" button on the Settings menu page from "Back" to "Close". 
![Screen Shot 2022-07-25 at 10 59 17 AM](https://user-images.githubusercontent.com/22355127/180823435-a794c2be-b8a2-42de-ad8d-bebf2d25f83d.png)


## Reference

Fixes #626 
## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
