### PR TITLE
Remove cleanup-flaky-script-output reference from the github action - fixes VPN-2601

### DIFF
--- a/.github/workflows/functional_tests.yaml
+++ b/.github/workflows/functional_tests.yaml
@@ -124,7 +124,6 @@ jobs:
             export HEADLESS=yes
             mkdir -p $ARTIFACT_DIR
             xvfb-run -a npm run functionalTest -- ${{matrix.test.path}}
-          on_retry_command: npm run cleanup-flaky-script-output
         env:
           ARTIFACT_DIR: ${{ runner.temp }}/artifacts
           MVPN_BIN: ./build/cmake/src/mozillavpn


### PR DESCRIPTION
I cannot find that script in package.json. I guess it never existed. 