### PR TITLE
Fix #4067 - Wrap or elide long labels in Settings menu

### DIFF
--- a/nebula/ui/components/VPNSettingsItem.qml
+++ b/nebula/ui/components/VPNSettingsItem.qml
@@ -14,7 +14,6 @@ VPNClickableRow {
     property var settingTitle
     property var imageLeftSrc
     property var imageRightSrc
-    property bool showIndicator: false
     property string fontColor: VPNTheme.theme.fontColorDark
 
     accessibleName: settingTitle
@@ -25,22 +24,42 @@ VPNClickableRow {
     Layout.alignment: Qt.AlignHCenter
     Layout.minimumHeight: VPNTheme.theme.rowHeight
     Layout.preferredWidth: parent.width
+    Layout.maximumWidth: parent.width
+    canGrowVertical: true
+    Layout.preferredHeight: title.lineCount > 1 ? title.implicitHeight + VPNTheme.theme.windowMargin : VPNTheme.theme.rowHeight
 
     RowLayout {
         id: row
-        spacing: 0
-        anchors.left: parent.left
-        anchors.right: parent.right
-        anchors.leftMargin: VPNTheme.theme.windowMargin / 2
-        anchors.rightMargin: VPNTheme.theme.windowMargin / 2
+        spacing: VPNTheme.theme.windowMargin
         anchors.verticalCenter: parent.verticalCenter
+        anchors.horizontalCenter: parent.horizontalCenter
+        width: root.width - VPNTheme.theme.windowMargin
 
-        VPNIconAndLabel {
-            id: iconAndLabel
-            icon: imageLeftSrc
-            title: settingTitle
-            fontColor: root.fontColor
-            showIndicator: root.showIndicator
+        Rectangle {
+            Layout.preferredHeight: VPNTheme.theme.rowHeight
+            Layout.preferredWidth: icon.width
+            Layout.alignment: Qt.AlignTop
+            color: VPNTheme.theme.transparent
+
+            VPNIcon {
+                id: icon
+                anchors.centerIn: parent
+                source: imageLeftSrc
+            }
+        }
+
+        VPNBoldLabel {
+            id: title
+            text: settingTitle
+            Layout.alignment: Qt.AlignLeft | Qt.AlignVCenter
+            verticalAlignment: Text.AlignVCenter
+            horizontalAlignment: Text.AlignLeft
+            Layout.fillWidth: true
+            lineHeightMode: Text.FixedHeight
+            lineHeight: VPNTheme.theme.labelLineHeight
+            wrapMode: Text.WordWrap
+            topPadding: 1
+            elide: Text.ElideRight
         }
 
         VPNIcon {


### PR DESCRIPTION
## Description

This PR adds handling for very long Settings menu labels and fixes #4067.

<table>
<tr>
<th>Do nothing when there is enough horizontal space...</th>
<th colspan="2">Wrap text when there is not enough horizontal space...</th>
</tr>
<tr>
<td>
<img src="https://user-images.githubusercontent.com/22355127/181635926-5594d2fd-867f-4bb9-b133-faa621774a71.png">

</td>
<td>

<img src="https://user-images.githubusercontent.com/22355127/181635822-199d20b9-3506-4092-a91f-4795185b53cc.png">
</td>
<td>
<img src="https://user-images.githubusercontent.com/22355127/181635856-f38ff91b-7cd6-4d24-af51-ad3de91a5d66.png">
</td>
</tr>
</table>

<table>
<tr><th>Elide words exceeding the available <br>horizontal space instead of breaking and wrapping<br>(see Kerfisstilli...)</th></tr>
<tr>
<td>
<img src="https://user-images.githubusercontent.com/22355127/181636342-583d41cf-7cc1-4742-93b6-ca1ca3fd1f07.png">

</td>

</tr>
</table>

## Reference

    i.e Jira or Github issue URL

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
