### PR TITLE
Fix the condition and introduce a reduce() method

### DIFF
--- a/src/addonmanager.h
+++ b/src/addonmanager.h
@@ -23,6 +23,8 @@ class AddonManager final : public QAbstractListModel {
  public:
   Q_INVOKABLE Addon* pick(QJSValue filterCallback) const;
 
+  Q_INVOKABLE QJSValue reduce(QJSValue callback, QJSValue initialValue) const;
+
   enum ModelRoles {
     AddonRole = Qt::UserRole + 1,
   };

--- a/src/ui/developerMenu/ViewMessages.qml
+++ b/src/ui/developerMenu/ViewMessages.qml
@@ -42,6 +42,10 @@ Item {
                 filterCallback: obj => obj.addon.type === "message"
             }
 
+            Text {
+               text: "Unread messages: " + VPNAddonManager.reduce((addon, initialValue) => initialValue + (addon.type === "message" ? 1 : 0), 0);
+            }
+
             Repeater {
                 model: messagesModel
                 delegate: VPNCheckBoxRow {


### PR DESCRIPTION
For the in-app messaging we need to show the number of unread messages. I don't want to expose a method in VPNAddonManager because that break the addon isolation. Instead, I want to have a `reduce` method to compute the number of unread message in the front-end code.

In the meantime, I have optimized the dynamic condition handling.