### PR TITLE
2621/4090 - Fix menu UI breakages with lengthier menu titles

### DIFF
--- a/nebula/ui/components/VPNMenu.qml
+++ b/nebula/ui/components/VPNMenu.qml
@@ -16,7 +16,7 @@ Item {
     property bool accessibleIgnored: false
     property bool btnDisabled: false
     property alias forceFocus: iconButton.focus
-    property string _menIconButtonSource: "qrc:/nebula/resources/back.svg"
+    property string _menuIconButtonSource: "qrc:/nebula/resources/back.svg"
     property alias _iconButtonAccessibleName: iconButton.accessibleName
     property var _menuOnBackClicked: () => {}
 
@@ -34,6 +34,8 @@ Item {
 
     RowLayout {
         id: row
+
+        objectName: "menuBar"
         anchors {
             fill: parent
             margins: VPNTheme.theme.windowMargin / 2

--- a/nebula/ui/components/VPNMenu.qml
+++ b/nebula/ui/components/VPNMenu.qml
@@ -16,7 +16,7 @@ Item {
     property bool accessibleIgnored: false
     property bool btnDisabled: false
     property alias forceFocus: iconButton.focus
-    property string _iconButtonSource: "qrc:/nebula/resources/back.svg"
+    property string _menIconButtonSource: "qrc:/nebula/resources/back.svg"
     property alias _iconButtonAccessibleName: iconButton.accessibleName
     property var _menuOnBackClicked: () => {}
 
@@ -58,7 +58,7 @@ Item {
 
             Image {
                 objectName: "menuIcon"
-                source: _iconButtonSource
+                source: _menuIconButtonSource
                 sourceSize.width: VPNTheme.theme.iconSize
                 fillMode: Image.PreserveAspectFit
                 anchors.centerIn: iconButton

--- a/nebula/ui/components/VPNMenu.qml
+++ b/nebula/ui/components/VPNMenu.qml
@@ -4,7 +4,7 @@
 
 import QtQuick 2.5
 import QtQuick.Controls 2.15
-
+import QtQuick.Layouts 1.14
 import Mozilla.VPN 1.0
 
 Item {
@@ -16,7 +16,7 @@ Item {
     property bool accessibleIgnored: false
     property bool btnDisabled: false
     property alias forceFocus: iconButton.focus
-    property string _menuIconButtonSource: "qrc:/nebula/resources/back.svg"
+    property string _iconButtonSource: "qrc:/nebula/resources/back.svg"
     property alias _iconButtonAccessibleName: iconButton.accessibleName
     property var _menuOnBackClicked: () => {}
 
@@ -29,57 +29,76 @@ Item {
     Rectangle {
         id: menuBackground
         color: VPNTheme.theme.bgColor
-        y: 0
-        width: parent.width
-        height: 55
+        anchors.fill: parent
     }
 
-    VPNIconButton {
-        id: iconButton
-
-        skipEnsureVisible: true // prevents scrolling of lists when this is focused
-
-        onClicked: _menuOnBackClicked()
-        anchors.top: parent.top
-        anchors.left: parent.left
-        anchors.topMargin: VPNTheme.theme.windowMargin / 2
-        anchors.leftMargin: VPNTheme.theme.windowMargin / 2
-        //% "Back"
-        //: Go back
-        accessibleName: qsTrId("vpn.main.back")
-        Accessible.ignored: accessibleIgnored
-
-        enabled: !btnDisabled
-        opacity: enabled ? 1 : .4
-        Image {
-            objectName: "menuIcon"
-            source: _menuIconButtonSource
-            sourceSize.width: VPNTheme.theme.iconSize
-            fillMode: Image.PreserveAspectFit
-            anchors.centerIn: iconButton
+    RowLayout {
+        id: row
+        anchors {
+            fill: parent
+            margins: VPNTheme.theme.windowMargin / 2
         }
-    }
+        spacing: VPNTheme.theme.windowMargin / 4
 
-    VPNBoldLabel {
-        id: title
+        VPNIconButton {
+            id: iconButton
 
-        anchors.top: menuBar.top
-        anchors.centerIn: menuBar
-        Accessible.ignored: accessibleIgnored
-    }
+            skipEnsureVisible: true // prevents scrolling of lists when this is focused
 
-    VPNLightLabel {
-        id: rightTitle
+            onClicked: _menuOnBackClicked()
+            Layout.alignment: Qt.AlignLeft
+            //% "Back"
+            //: Go back
+            accessibleName: qsTrId("vpn.main.back")
+            Accessible.ignored: accessibleIgnored
+            Layout.preferredHeight: VPNTheme.theme.rowHeight
+            Layout.preferredWidth: VPNTheme.theme.rowHeight
+            enabled: !btnDisabled
+            opacity: enabled ? 1 : .4
 
-        anchors.verticalCenter: menuBar.verticalCenter
-        anchors.right: menuBar.right
-        anchors.rightMargin: VPNTheme.theme.windowMargin
-        Accessible.ignored: accessibleIgnored
+            Image {
+                objectName: "menuIcon"
+                source: _iconButtonSource
+                sourceSize.width: VPNTheme.theme.iconSize
+                fillMode: Image.PreserveAspectFit
+                anchors.centerIn: iconButton
+            }
+        }
+
+        // This is a hack to preven the menu title from being thrown off horizontal center by varying 'rightTitle' widths.
+        Rectangle {
+           Layout.preferredWidth: rightTitle.width > VPNTheme.theme.rowHeight ? Math.max(rightTitle.width - VPNTheme.theme.rowHeight - row.spacing, 0) : 0
+           Layout.preferredHeight: parent.height
+           color: VPNTheme.theme.transparent
+        }
+
+        VPNBoldLabel {
+            id: title
+
+            Layout.alignment: Qt.AlignHCenter
+            Layout.fillWidth: true
+            elide: Text.ElideRight
+            Accessible.ignored: accessibleIgnored
+            horizontalAlignment: Text.AlignHCenter
+            verticalAlignment: Text.AlignVCenter
+        }
+
+        VPNLightLabel {
+            id: rightTitle
+
+            Layout.alignment: Qt.AlignVCenter | Qt.AlignRight
+            Layout.minimumWidth: VPNTheme.theme.rowHeight
+            Layout.maximumWidth: row.width / 3
+            elide: Text.ElideRight
+            Accessible.ignored: accessibleIgnored
+            rightPadding: VPNTheme.theme.windowMargin / 2
+            horizontalAlignment: Text.AlignRight
+        }
     }
 
     Rectangle {
         color: VPNTheme.colors.grey10
-        y: 55
+        anchors.bottom: parent.bottom
         width: parent.width
         height: 1
     }


### PR DESCRIPTION
## Description

This refactors VPNMenu.qml to handle longer menu titles in some locales.
![Screen Shot 2022-08-01 at 11 53 23 AM](https://user-images.githubusercontent.com/22355127/182210123-9ffb182f-8232-469a-870f-f0aee72d628a.png)
<img width="364" alt="Screen Shot 2022-08-01 at 12 45 45 PM" src="https://user-images.githubusercontent.com/22355127/182210259-c67bf597-5f34-4844-bfcb-c4fe9ce5c02e.png">


## Reference
VPN-2621
#4090
## Checklist
    
- [x] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
