### PR TITLE
Fix QML warnings in ViewSettingsMenu.qml #4118

### DIFF
--- a/nebula/ui/components/VPNUserProfile.qml
+++ b/nebula/ui/components/VPNUserProfile.qml
@@ -18,16 +18,25 @@ VPNClickableRow {
     property bool _loaderVisible: false
     property var _buttonOnClicked
 
+
     Layout.preferredHeight: row.implicitHeight + VPNTheme.theme.windowMargin * 2
     Layout.fillWidth: true
+    Layout.leftMargin: VPNTheme.theme.windowMargin / 2
+    Layout.rightMargin: VPNTheme.theme.windowMargin / 2
     accessibleName: qsTrId("vpn.main.manageAccount")
     objectName: _objNameBase + "-manageAccountButton"
     onClicked: _buttonOnClicked()
-
     height: undefined
     anchors {
         left: undefined
         right: undefined
+    }
+
+    anchors {
+        left: undefined
+        right: undefined
+        leftMargin: undefined
+        rightMargin: undefined
     }
 
     RowLayout {

--- a/src/ui/screens/settings/ViewSettingsMenu.qml
+++ b/src/ui/screens/settings/ViewSettingsMenu.qml
@@ -22,8 +22,6 @@ VPNViewBase {
         ColumnLayout {
             spacing: 0
             Layout.fillWidth: true
-            Layout.leftMargin: VPNTheme.theme.windowMargin  / 2
-            Layout.rightMargin: VPNTheme.theme.windowMargin / 2
 
             VPNUserProfile {
                 property bool subscriptionManagementEnabled: VPNFeatureList.get("subscriptionManagement").isSupported
@@ -52,8 +50,8 @@ VPNViewBase {
 
                 Layout.preferredHeight: 1
                 Layout.fillWidth: true
-                Layout.leftMargin: VPNTheme.theme.windowMargin / 2
-                Layout.rightMargin: VPNTheme.theme.windowMargin / 2
+                Layout.leftMargin: VPNTheme.theme.windowMargin
+                Layout.rightMargin: VPNTheme.theme.windowMargin
                 color: VPNTheme.colors.grey10
             }
         }


### PR DESCRIPTION
## Description
Fixes `ReferenceError: _iconButtonImageSource is not defined (VPNUserProfile.qml:91)` and `Warning: qrc:/ui/settings/ViewSettingsMenu.qml:48:13: QML VPNUserProfile: Detected anchors on an item that is managed by a layout. This is undefined behavior; use Layout.alignment instead. (ViewSettingsMenu.qml:48)` warnings/errors in ViewSettingsMenu.qml.

## Reference
Fixes #4118

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
