### PR TITLE
Properly handle QML that failed to load

### DIFF
--- a/src/commands/commandui.cpp
+++ b/src/commands/commandui.cpp
@@ -553,16 +553,11 @@ int CommandUI::run(QStringList& tokens) {
 
     // Here is the main QML file.
     const QUrl url(QStringLiteral("qrc:/ui/main.qml"));
-    QObject::connect(
-        engine, &QQmlApplicationEngine::objectCreated, qApp,
-        [url](QObject* obj, const QUrl& objUrl) {
-          if (!obj && url == objUrl) {
-            logger.error() << "Failed to load " << objUrl.toString();
-            QGuiApplication::exit(-1);
-          }
-        },
-        Qt::QueuedConnection);
     engine->load(url);
+    if (!engineHolder->hasWindow()) {
+      logger.error() << "Failed to load " << url.toString();
+      return -1;
+    }
 
     NotificationHandler* notificationHandler =
         NotificationHandler::create(engineHolder);

--- a/src/qmlengineholder.cpp
+++ b/src/qmlengineholder.cpp
@@ -54,6 +54,10 @@ QWindow* QmlEngineHolder::window() const {
   return qobject_cast<QWindow*>(rootObject);
 }
 
+bool QmlEngineHolder::hasWindow() const {
+  return !m_engine.rootObjects().isEmpty();
+}
+
 void QmlEngineHolder::showWindow() {
   QWindow* w = window();
   Q_ASSERT(w);

--- a/src/qmlengineholder.h
+++ b/src/qmlengineholder.h
@@ -29,6 +29,7 @@ class QmlEngineHolder final : public NetworkManager {
   QWindow* window() const;
   void showWindow();
   void hideWindow();
+  bool hasWindow() const;
 
  protected:
   void clearCacheInternal() override;


### PR DESCRIPTION
## Description

Added early bail-out when qml fails to load in UI command, since the current callback and proper exit only get called too late (in `qApp.exec()`), i.e. after the error caused a segfault.

An alternate fix would be to delay all `connect()` calls that require the window (like the one below) until after the execution has started and the window has been confirmed to exist.

https://github.com/mozilla-mobile/mozilla-vpn-client/blob/3ae9aea3c262c0aa7a8d313976f80f38dcc957e5/src/systemtraynotificationhandler.cpp#L79-L80

## Reference

See #3749

## Checklist
    
- [ ] My code follows the style guidelines for this project
   I was unable to find style guidelines in the README, in the wiki, in other top-level md files in the repo, on the support website…
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
      A test that the code does not segfault on failed QML loading would be nice I suppose, but I don’t know much about where or how to add it.
