### PR TITLE
Add MacOS beetmover tasks on the mozilla-vpn-client github-release taskgraph

### DIFF
--- a/taskcluster/ci/beetmover/kind.yml
+++ b/taskcluster/ci/beetmover/kind.yml
@@ -21,11 +21,7 @@ primary-dependency: signing
 
 job-template:
     worker-type: beetmover
-    run-on-tasks-for: [action, github-release]
-    bucket:
-        by-level:
-            "3": "release"
-            default: "dep"
+    run-on-tasks-for: [action:release-promotion, github-release]
     treeherder:
         job-symbol: BM
         kind: build

--- a/taskcluster/ci/beetmover/kind.yml
+++ b/taskcluster/ci/beetmover/kind.yml
@@ -1,0 +1,35 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+---
+loader: mozillavpn_taskgraph.loader.multi_dep:loader
+
+transforms:
+    - mozillavpn_taskgraph.transforms.multi_dep:transforms
+    - mozillavpn_taskgraph.transforms.beetmover:transforms
+    - taskgraph.transforms.task:transforms
+
+group-by: build-type
+
+only-for-build-types:
+    - macos/opt
+
+kind-dependencies:
+    - signing
+
+primary-dependency: signing
+
+job-template:
+    worker-type: beetmover
+    run-on-tasks-for: [action, github-release]
+    bucket:
+        by-level:
+            "3": "release"
+            default: "dep"
+    treeherder:
+        job-symbol: BM
+        kind: build
+        tier: 1
+        platform:
+            by-build-type:
+                macos/opt: macos/all

--- a/taskcluster/ci/config.yml
+++ b/taskcluster/ci/config.yml
@@ -91,3 +91,8 @@ workers:
             implementation: scriptworker-pushapk
             os: scriptworker
             worker-type: 'mozillavpn-{level}-pushapk'
+        beetmover:
+            provisioner: scriptworker-k8s
+            implementation: scriptworker-beetmover
+            os: scriptworker
+            worker-type: 'mozillavpn-{level}-beetmover'

--- a/taskcluster/mozillavpn_taskgraph/transforms/beetmover.py
+++ b/taskcluster/mozillavpn_taskgraph/transforms/beetmover.py
@@ -39,7 +39,7 @@ def add_beetmover_worker_config(config, tasks):
         )
         destination_paths = [candidates_path]
         archive_url = "https://ftp.stage.mozaws.net/" if config.params["level"] != 3 else "https://ftp.mozilla.org/"
-        task_description = f"This {worker_type} task will upload a release candidate for v{app_version} of the {app_name} on {build_os} to {archive_url}{candidates_path}"
+        task_description = f"This {worker_type} task will upload a {build_os} release candidate for {app_name} v{app_version} to {archive_url}{candidates_path}/"
         branch = config.params["head_ref"]
 
         def get_artifact_path(path):

--- a/taskcluster/mozillavpn_taskgraph/transforms/beetmover.py
+++ b/taskcluster/mozillavpn_taskgraph/transforms/beetmover.py
@@ -1,0 +1,104 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+import os.path
+
+from taskgraph.transforms.base import TransformSequence
+from taskgraph.util.schema import resolve_keyed_by
+
+transforms = TransformSequence()
+
+
+@transforms.add
+def add_beetmover_worker_config(config, tasks):
+    for task in tasks:
+        worker_type = task["worker-type"]
+        task_name = task["name"]
+        task_label = f"{worker_type}-{task_name}"
+        resolve_keyed_by(
+            task,
+            "bucket",
+            item_name=task_label,
+            **{"level": config.params["level"]},
+        )
+        bucket = task["bucket"]
+        # When we add balrog releases we will need to add an action to beetmoverscript
+        action = "push-to-nightly"
+        app_name = "vpn"
+        attributes = task["attributes"]
+        run_on_tasks_for = task["run-on-tasks-for"]
+        build_id = config.params["moz_build_date"]
+        build_type = attributes["build-type"]
+        build_os = os.path.dirname(build_type)
+        dependencies = task["dependencies"]
+        app_version = config.params["version"]
+        candidates_path = os.path.join(
+            "pub", app_name, "candidates", app_version, build_id, build_os
+        )
+        destination_paths = [candidates_path]
+        archive_url = "https://ftp.stage.mozaws.net/" if config.params["level"] != 3 else "https://ftp.mozilla.org/"
+        task_description = f"This {worker_type} task will upload a release candidate for v{app_version} of the {app_name} on {build_os} to {archive_url}{candidates_path}"
+        branch = config.params["head_ref"]
+
+        def get_artifact_path(path):
+            # iscript turns .tar.gz files into signed .pkg files
+            if build_os == "macos":
+                return path.replace(".tar.gz", ".pkg")
+            return path
+
+        upstream_artifacts = [
+            {
+                **upstream_artifact,
+                "paths": [
+                    get_artifact_path(path) for path in upstream_artifact["paths"]
+                ],
+            }
+            for upstream_artifact in task["worker"]["upstream-artifacts"]
+        ]
+
+        artifact_map = []
+        for artifact in upstream_artifacts:
+            artifact_map.append(
+                {
+                    "taskId": artifact["taskId"],
+                    "paths": {
+                        path: {
+                            "destinations": [
+                                os.path.join(
+                                    destination_path,
+                                    os.path.basename(path),
+                                )
+                                for destination_path in destination_paths
+                            ]
+                        }
+                        for path in artifact["paths"]
+                    },
+                }
+            )
+
+        worker = {
+            "upstream-artifacts": upstream_artifacts,
+            "bucket": bucket,
+            "action": action,
+            "release-properties": {
+                "app-name": app_name,
+                "app-version": app_version,
+                "branch": branch,
+                "build-id": build_id,
+                "platform": build_type,
+            },
+            "artifact-map": artifact_map,
+        }
+        task_def = {
+            "label": task_label,
+            "name": task_label,
+            "description": task_description,
+            "dependencies": dependencies,
+            "worker-type": worker_type,
+            "worker": worker,
+            "attributes": attributes,
+            "run-on-tasks-for": run_on_tasks_for,
+        }
+        yield task_def

--- a/taskcluster/mozillavpn_taskgraph/transforms/beetmover.py
+++ b/taskcluster/mozillavpn_taskgraph/transforms/beetmover.py
@@ -32,17 +32,9 @@ def add_beetmover_worker_config(config, tasks):
         )
         destination_paths = [candidates_path]
         archive_url = (
-<<<<<<< HEAD
             "https://ftp.mozilla.org/" if l3_relpro else "https://ftp.stage.mozaws.net/"
         )
         task_description = f"This {worker_type} task will upload a {build_os} release candidate for v{app_version} to {archive_url}{candidates_path}/"
-=======
-            "https://ftp.stage.mozaws.net/"
-            if config.params["level"] != 3
-            else "https://ftp.mozilla.org/"
-        )
-        task_description = f"This {worker_type} task will upload a {build_os} release candidate for {app_name} v{app_version} to {archive_url}{candidates_path}/"
->>>>>>> f02b663680342802248071a2edd69d6a73cc71d4
         branch = config.params["head_ref"]
 
         def get_artifact_path(path):

--- a/taskcluster/mozillavpn_taskgraph/worker_types.py
+++ b/taskcluster/mozillavpn_taskgraph/worker_types.py
@@ -2,10 +2,11 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from voluptuous import Any, Required, Optional
-from taskgraph.util.schema import taskref_or_string
-from taskgraph.transforms.task import payload_builder
 from datetime import datetime
+
+from taskgraph.transforms.task import payload_builder
+from taskgraph.util.schema import taskref_or_string
+from voluptuous import Any, Optional, Required
 
 
 @payload_builder(

--- a/taskcluster/mozillavpn_taskgraph/worker_types.py
+++ b/taskcluster/mozillavpn_taskgraph/worker_types.py
@@ -5,6 +5,7 @@
 from voluptuous import Any, Required, Optional
 from taskgraph.util.schema import taskref_or_string
 from taskgraph.transforms.task import payload_builder
+from datetime import datetime
 
 
 @payload_builder(
@@ -92,3 +93,71 @@ def build_push_apk_payload(config, task, task_def):
     task_def["scopes"].append(
         "project:mozillavpn:releng:googleplay:product:{}".format(worker["product"])
     )
+
+
+@payload_builder(
+    "scriptworker-beetmover",
+    schema={
+        Required("bucket"): str,
+        Required("action"): str,
+        Required("artifact-map"): [
+            {
+                Required("paths"): {
+                    Any(str): {
+                        Required("destinations"): [str],
+                    },
+                },
+                Required("taskId"): taskref_or_string,
+            }
+        ],
+        Required("release-properties"): {
+            Required("app-name"): str,
+            Required("app-version"): str,
+            Required("branch"): str,
+            Required("build-id"): str,
+            Optional("hash-type"): str,
+            Optional("platform"): str,
+        },
+        Required("upstream-artifacts"): [
+            {
+                Required("taskId"): taskref_or_string,
+                Required("taskType"): str,
+                Required("paths"): [str],
+            }
+        ],
+    },
+)
+def build_scriptworker_beetmover_payload(config, task, task_def):
+    task_def["tags"]["worker-implementation"] = "scriptworker"
+    worker = task["worker"]
+    artifact_map = worker["artifact-map"]
+    for map_ in artifact_map:
+        map_["locale"] = "multi"
+        for path_config in map_["paths"].values():
+            path_config["checksums_path"] = ""
+    for artifact in worker["upstream-artifacts"]:
+        artifact["locale"] = "multi"
+    release_properties = {
+        "appName": worker["release-properties"]["app-name"],
+        "appVersion": worker["release-properties"]["app-version"],
+        "branch": worker["release-properties"]["branch"],
+        "buildid": worker["release-properties"]["build-id"],
+        "hashType": worker["release-properties"].get("hash-type", "sha512"),
+        "platform": worker["release-properties"]["platform"],
+    }
+    scope_prefix = "project:mozillavpn:releng:beetmover:"
+    task_def["scopes"] = [
+        "{prefix}bucket:{bucket_scope}".format(
+            prefix=scope_prefix, bucket_scope=worker["bucket"]
+        ),
+        "{prefix}action:{action_scope}".format(
+            prefix=scope_prefix, action_scope=worker["action"]
+        ),
+    ]
+    task_def["payload"] = {
+        "maxRunTime": 600,
+        "artifactMap": artifact_map,
+        "releaseProperties": release_properties,
+        "upstreamArtifacts": worker["upstream-artifacts"],
+        "upload_date": int(datetime.now().timestamp()),
+    }


### PR DESCRIPTION
## Description

These code changes add tasks to upload VPN macos release candidates to https://ftp.mozilla.org/pub/vpn/candidates/ on `github-release` events.

I tried it out in staging. First I created a release with the tag `v0.0.16`. This triggered the release graph and uploaded release candidate [20220803200417](https://ftp.stage.mozaws.net/pub/vpn/candidates/0.0.16/)

To upload a second release candidate I deleted the release tag:

`git push --delete origin v0.0.16`

The release then turned back into a pre-release. I republished the release with the same tag. That uploaded release candidate [20220803202328](https://ftp.stage.mozaws.net/pub/vpn/candidates/0.0.16/)

[Here's is the latest release beetmover task I ran in staging](https://github.com/mozilla-releng/staging-mozilla-vpn-client/runs/7660304101)

## Reference

[RELENG-937](https://mozilla-hub.atlassian.net/browse/RELENG-937)

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
