### PR TITLE
Compile wasm in release mode

### DIFF
--- a/.github/workflows/wasm.yaml
+++ b/.github/workflows/wasm.yaml
@@ -56,7 +56,7 @@ jobs:
           export PATH=/opt/$QTVERSION/wasm_32/bin:/opt/$QTVERSION/gcc_64/bin:$PATH
           mkdir build
           /opt/$QTVERSION/wasm_32/bin/qt-cmake -S . -B build -DQT_HOST_PATH=/opt/$QTVERSION/gcc_64 -DQT_HOST_PATH_CMAKE_DIR=/opt/$QTVERSION/gcc_64/lib/cmake
-          cmake --build build -j4
+          cmake --build build -j4 --config Release
           cp $(pwd)/build/src/mozillavpn.wasm wasm
           cp $(pwd)/build/src/mozillavpn.js wasm
           cp $(pwd)/build/src/qtloader.js wasm


### PR DESCRIPTION
Compiling in debug mode (the default mode) creates a >100mb wasm file and this cannot be uploaded to github.io