### PR TITLE
ci: put Mac and Linux signing tasks on the same line as their builds …

### DIFF
--- a/taskcluster/ci/signing/kind.yml
+++ b/taskcluster/ci/signing/kind.yml
@@ -47,5 +47,5 @@ job-template:
                 android-x86/release: android/x86
                 android-arm64/release: android/arm64-v8a
                 android-armv7/release: android/armv7
-                linux/opt: linux/all
-                macos/opt: macos/all
+                linux/opt: linux/opt
+                macos/opt: macos/opt


### PR DESCRIPTION
…in Treeherder
