### PR TITLE
ci: update hash and size for newer version of 'rustup-init'

### DIFF
--- a/taskcluster/ci/fetch/kind.yml
+++ b/taskcluster/ci/fetch/kind.yml
@@ -47,8 +47,8 @@ jobs:
         fetch:
             type: static-url
             url: https://static.rust-lang.org/rustup/dist/x86_64-pc-windows-msvc/rustup-init.exe
-            sha256: 780b445ee18bdc5a31ad6a4a63943927e5c0bba8bff664e8ecc8d5bca3906c7b
-            size: 9284608
+            sha256: 2220ddb49fea0e0945b1b5913e33d66bd223a67f19fd1c116be0318de7ed9d9c
+            size: 10077696
     win-go:
         description: go1.17beta1
         fetch:


### PR DESCRIPTION
This is only a bandaid fix as we'll see the same error the next time a
new version of 'rustup-init' is released. Ideally we should either find
a URL that is pinned to a specific version, or else find another way to
bootstrap rustup.

Issue: #4162
