### PR TITLE
Refactor beetmover tasks and add Windows candidates

### DIFF
--- a/taskcluster/ci/beetmover/kind.yml
+++ b/taskcluster/ci/beetmover/kind.yml
@@ -9,6 +9,10 @@ transforms:
     - mozillavpn_taskgraph.transforms.beetmover:transforms
     - taskgraph.transforms.task:transforms
 
+kind-dependencies:
+    - signing
+    - repackage-signing
+
 jobs:
     macos:
         worker-type: beetmover

--- a/taskcluster/ci/beetmover/kind.yml
+++ b/taskcluster/ci/beetmover/kind.yml
@@ -2,30 +2,45 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 ---
-loader: mozillavpn_taskgraph.loader.multi_dep:loader
+loader: taskgraph.loader.transform:loader
 
 transforms:
-    - mozillavpn_taskgraph.transforms.multi_dep:transforms
+    - mozillavpn_taskgraph.transforms.release_artifacts:transforms
     - mozillavpn_taskgraph.transforms.beetmover:transforms
     - taskgraph.transforms.task:transforms
 
-group-by: build-type
-
-only-for-build-types:
-    - macos/opt
-
-kind-dependencies:
-    - signing
-
-primary-dependency: signing
-
-job-template:
-    worker-type: beetmover
-    run-on-tasks-for: [action:release-promotion, github-release]
-    treeherder:
-        job-symbol: BM
-        kind: build
-        tier: 1
-        platform:
-            by-build-type:
-                macos/opt: macos/all
+jobs:
+    macos:
+        worker-type: beetmover
+        worker:
+            chain-of-trust: true
+            max-run-time: 3600
+        run-on-tasks-for: [github-release, action:release-promotion]
+        release-artifacts: [MozillaVPN.pkg]
+        dependencies:
+            signing: signing-macos/opt
+        if-dependencies: [signing]
+        attributes:
+            build-type: macos/opt
+        treeherder:
+            symbol: BM(macos)
+            kind: build
+            tier: 1
+            platform: macos/opt
+    windows:
+        worker-type: beetmover
+        worker:
+            chain-of-trust: true
+            max-run-time: 3600
+        run-on-tasks-for: [github-release, action:release-promotion]
+        release-artifacts: [MozillaVPN.msi]
+        dependencies:
+            repackage-signing: repackage-signing-msi
+        if-dependencies: [repackage-signing]
+        attributes:
+            build-type: windows/opt
+        treeherder:
+            symbol: BM(windows)
+            kind: build
+            tier: 1
+            platform: windows/x86_64

--- a/taskcluster/ci/config.yml
+++ b/taskcluster/ci/config.yml
@@ -10,6 +10,7 @@ treeherder:
         'Fetch': 'Fetching Tasks'
         'TL': 'Toolchain Tasks'
         'rpk': 'Re-Package Tasks'
+        'BM': 'Beetmover Tasks'
 
 task-priority:
     by-project:


### PR DESCRIPTION
## Description

Refactors the beetmover task kind and adds tasks to upload VPN windows release candidates to https://ftp.mozilla.org/pub/vpn/candidates/ on `github-release` events.

[Here's is the latest windows beetmover task I ran in staging](https://github.com/mozilla-releng/staging-mozilla-vpn-client/runs/7735897834)

## Reference

[RELENG-937](https://mozilla-hub.atlassian.net/browse/RELENG-937)

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed

