### PR TITLE
basti/filteredWasmChrome

### DIFF
--- a/.github/workflows/gh_pages.yaml
+++ b/.github/workflows/gh_pages.yaml
@@ -123,17 +123,24 @@ jobs:
           path: _site/inspector
 
       - name: Create Artifact
-        shell: bash}
+        shell: bash
         run: |
           tar \
             --dereference --hard-dereference \
             --directory _site \
             -cvf ${{ runner.temp }}/artifact.tar \
             .
-
+      - name: Upload artifact (no-deploy)
+        uses: actions/upload-artifact@main
+        if: github.ref != 'refs/heads/main'  
+        with:
+          name: github-pages_test
+          path: ${{ runner.temp }}/artifact.tar
+          retention-days: ${{ inputs.retention-days }}
       - name: Upload artifact
         uses: actions/upload-artifact@main
+        if: github.ref == 'refs/heads/main'  # Only publish on main branch.
         with:
-          name: github-pages
+          name: github-pages # This name will trigger the deploy
           path: ${{ runner.temp }}/artifact.tar
           retention-days: ${{ inputs.retention-days }}

--- a/.github/workflows/gh_pages.yaml
+++ b/.github/workflows/gh_pages.yaml
@@ -138,8 +138,8 @@ jobs:
         url: ${{ steps.deployment.outputs.page_url }}
       runs-on: ubuntu-latest
       needs: ghPages
+      if: github.ref == 'refs/heads/main'
       steps:
-        - name: Deploy to GitHub Pages
-          if: github.ref == 'refs/heads/main'  
+        - name: Deploy to GitHub Pages  
           id: deployment
           uses: actions/deploy-pages@v1

--- a/.github/workflows/gh_pages.yaml
+++ b/.github/workflows/gh_pages.yaml
@@ -8,6 +8,11 @@ on:
     branches:
       - main
 
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -15,6 +20,7 @@ concurrency:
 
 jobs:
   wasm_chrome: 
+    name: Add Wasm_Chrome
     runs-on: ubuntu-20.04
     steps:
       - name: Clone repository
@@ -26,6 +32,7 @@ jobs:
             path: tools/wasm_chrome
 
   inspector:
+    name: Add Inspector
     runs-on: ubuntu-20.04
     steps:
       - name: Clone repository
@@ -47,7 +54,6 @@ jobs:
         with:
             name: Inspector Build
             path: tools/inspector/dist
-
   addons:
     runs-on: ubuntu-20.04
     env:
@@ -98,8 +104,8 @@ jobs:
 
   ghPages:
     runs-on: ubuntu-20.04
-    needs: [wasm_chrome, inspector, addons]
-    name: Publish Wasm on Github Pages
+    needs: [wasm_chrome, inspector,addons]
+    name: Compile Github Page from Components
     env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
@@ -122,25 +128,18 @@ jobs:
           name: Inspector Build
           path: _site/inspector
 
-      - name: Create Artifact
-        shell: bash
-        run: |
-          tar \
-            --dereference --hard-dereference \
-            --directory _site \
-            -cvf ${{ runner.temp }}/artifact.tar \
-            .
-      - name: Upload artifact (no-deploy)
-        uses: actions/upload-artifact@main
-        if: github.ref != 'refs/heads/main'  
-        with:
-          name: github-pages_test
-          path: ${{ runner.temp }}/artifact.tar
-          retention-days: ${{ inputs.retention-days }}
       - name: Upload artifact
-        uses: actions/upload-artifact@main
-        if: github.ref == 'refs/heads/main'  # Only publish on main branch.
-        with:
-          name: github-pages # This name will trigger the deploy
-          path: ${{ runner.temp }}/artifact.tar
-          retention-days: ${{ inputs.retention-days }}
+        uses: actions/upload-pages-artifact@v1
+
+  deploy:
+      name: Deploy Github Page
+      environment:
+        name: github-pages
+        url: ${{ steps.deployment.outputs.page_url }}
+      runs-on: ubuntu-latest
+      needs: ghPages
+      steps:
+        - name: Deploy to GitHub Pages
+          if: github.ref == 'refs/heads/main'  
+          id: deployment
+          uses: actions/deploy-pages@v1

--- a/.github/workflows/gh_pages.yaml
+++ b/.github/workflows/gh_pages.yaml
@@ -8,11 +8,6 @@ on:
     branches:
       - main
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
-permissions:
-  contents: read
-  pages: write
-  id-token: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -20,7 +15,6 @@ concurrency:
 
 jobs:
   wasm_chrome: 
-    name: Add Wasm_Chrome
     runs-on: ubuntu-20.04
     steps:
       - name: Clone repository
@@ -32,7 +26,6 @@ jobs:
             path: tools/wasm_chrome
 
   inspector:
-    name: Add Inspector
     runs-on: ubuntu-20.04
     steps:
       - name: Clone repository
@@ -54,6 +47,7 @@ jobs:
         with:
             name: Inspector Build
             path: tools/inspector/dist
+
   addons:
     runs-on: ubuntu-20.04
     env:
@@ -104,8 +98,8 @@ jobs:
 
   ghPages:
     runs-on: ubuntu-20.04
-    needs: [wasm_chrome, inspector,addons]
-    name: Compile Github Page from Components
+    needs: [wasm_chrome, inspector, addons]
+    name: Publish Wasm on Github Pages
     env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
@@ -128,18 +122,18 @@ jobs:
           name: Inspector Build
           path: _site/inspector
 
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+      - name: Create Artifact
+        shell: bash}
+        run: |
+          tar \
+            --dereference --hard-dereference \
+            --directory _site \
+            -cvf ${{ runner.temp }}/artifact.tar \
+            .
 
-  deploy:
-      name: Deploy Github Page
-      environment:
-        name: github-pages
-        url: ${{ steps.deployment.outputs.page_url }}
-      runs-on: ubuntu-latest
-      needs: ghPages
-      if: github.ref == 'refs/heads/main'
-      steps:
-        - name: Deploy to GitHub Pages  
-          id: deployment
-          uses: actions/deploy-pages@v1
+      - name: Upload artifact
+        uses: actions/upload-artifact@main
+        with:
+          name: github-pages
+          path: ${{ runner.temp }}/artifact.tar
+          retention-days: ${{ inputs.retention-days }}

--- a/.github/workflows/gh_pages.yaml
+++ b/.github/workflows/gh_pages.yaml
@@ -25,6 +25,13 @@ jobs:
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
+      - uses: denoland/setup-deno@v1.0.0
+        with:
+          deno-version: v1.x # Run with latest stable Deno.
+      - name: Generate Dynamic Files
+        run: |
+         cd tools/wasm_chrome
+         deno run --allow-all generate_branch_file.ts -T ${{ secrets.GITHUB_TOKEN }}
       - name: Uploading
         uses: actions/upload-artifact@v1
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -182,6 +182,8 @@ tools/inspector/.cache
 tools/inspector/.parcel-cache
 tools/inspector/dist
 tools/inspector/node_modules
+tools/wasm_chrome/branch_runs.json
+!tools/wasm_chrome/*.ts
 
 *.PDB
 

--- a/tools/wasm_chrome/branch_selector.mjs
+++ b/tools/wasm_chrome/branch_selector.mjs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import { Octokit } from "https://cdn.skypack.dev/@octokit/core";
 const octokit = new Octokit({  });
 

--- a/tools/wasm_chrome/branch_selector.mjs
+++ b/tools/wasm_chrome/branch_selector.mjs
@@ -1,7 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 import { Octokit } from "https://cdn.skypack.dev/@octokit/core";
 const octokit = new Octokit({  });
 

--- a/tools/wasm_chrome/generate_branch_file.ts
+++ b/tools/wasm_chrome/generate_branch_file.ts
@@ -1,0 +1,136 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+
+ /** Generate Wasm-Chrome Hydration
+  * 
+  * This is a deno script.
+  * usage: deno -a generate_branch_file -T <github_api_token>
+  * 
+  * This will generate a file containing current sha->taskClusterID mappings, to save 
+  * api calls to github and also allow us to filter :) 
+  * 
+  */
+import { parse } from "https://deno.land/std/flags/mod.ts";
+import { Octokit } from "https://cdn.skypack.dev/@octokit/core";
+
+interface Commit{
+    sha: string,
+}
+interface GhCheck{
+    name: string,
+}
+interface Branch{
+    commit:Commit
+    name:string;
+}
+enum TaskStatus {
+    ok = "ok",
+    noRun = "noGithubRunInfo", // There was never a wasm task scheudeled for this branch 
+    notFound = "notFound",
+    error = "error",
+    tooOld = "tooOld",
+    unknown = "unknown", 
+  }
+interface StatusResult{
+    sha: string,
+    name: string,
+    task_id:string,
+    task_status: TaskStatus,
+}
+
+interface TaskClusterStatus{
+    error:string
+    code:string,
+    status: {
+        taskId: string,
+        state: string, 
+    }
+}
+
+async function getTaskStatusOf(task_id:string): Promise<TaskStatus> {
+    let task_status:TaskClusterStatus;
+    try {
+        task_status = await fetch(`${TASKCLUSTER_INSTANCE}/api/queue/v1/task/${task_id}/status`).then((r)=>r.json());
+    } catch (_) {
+        return TaskStatus.unknown;
+    }
+    if(task_status.error == "Not found" || task_status.code == "ResourceNotFound"){
+        return TaskStatus.notFound;
+    }
+    if(task_status.status.state == "running"){
+        return TaskStatus.ok;
+    }
+    if(task_status.status.state != "completed"){
+        return TaskStatus.error;
+    }
+    return TaskStatus.ok;
+}
+
+
+const {T} = parse(Deno.args)
+
+console.log(parse(Deno.args))
+
+const TASKCLUSTER_INSTANCE ="https://firefox-ci-tc.services.mozilla.com"
+const TASKCLUSTER_TASK_NAME = "build-wasm/opt";
+
+
+if(T == ""){
+    console.error("No Github Key - Exit");
+    console.error("Run with -GH_KEY <your key>");
+    Deno.exit(-1);
+}
+
+const octokit = new Octokit({
+    auth:T
+})
+console.log(await octokit.request('GET /rate_limit', {}));
+
+
+// Get Branch data
+const branch_response = await octokit.request('GET /repos/{owner}/{repo}/branches', {
+    owner: 'mozilla-mobile',
+    repo: 'mozilla-vpn-client',
+    per_page: 100
+});
+
+const out: {[index: string]: any } = {}
+
+const jobs = branch_response.data.map( async (branch:Branch) => {
+    const sha = branch.commit.sha;
+    const name = branch.name
+    
+    const result = {
+        name,sha,
+        task_status:TaskStatus.unknown,
+        task_id:""
+    }
+
+    // Get All Runs For the Branch
+    const response = await octokit.request('GET /repos/{owner}/{repo}/commits/{ref}/check-runs', {
+        owner: 'mozilla-mobile',
+        repo: 'mozilla-vpn-client',
+        ref: sha,
+        per_page: 100
+    });
+    const checks = response.data.check_runs;
+    const wasm_run = checks.find((e: GhCheck) => e.name == TASKCLUSTER_TASK_NAME);
+    if(!wasm_run){
+        result.task_status= TaskStatus.noRun;
+        out[sha]=result;
+        console.log(`${result.task_status} \t \t -> ${name}`)
+        return;
+    }
+    const task_url = wasm_run.details_url;
+    result.task_id = task_url.split("/").at(-1);
+    result.task_status= await getTaskStatusOf(result.task_id);
+    console.log(`${result.task_status} \t \t -> ${name}`)
+    out[sha]=result;
+});
+
+await Promise.all(jobs);
+const encoder = new TextEncoder();
+const data = encoder.encode(JSON.stringify(out));
+Deno.writeFileSync("branch_runs.json", data);

--- a/tools/wasm_chrome/index.html
+++ b/tools/wasm_chrome/index.html
@@ -4,7 +4,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 -->
-
 <html>
     <head> 
         <title>MozillaVPN Chrome</title>

--- a/tools/wasm_chrome/index.html
+++ b/tools/wasm_chrome/index.html
@@ -4,6 +4,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 -->
+
 <html>
     <head> 
         <title>MozillaVPN Chrome</title>

--- a/tools/wasm_chrome/taskcluster_frame.mjs
+++ b/tools/wasm_chrome/taskcluster_frame.mjs
@@ -81,12 +81,7 @@ class TaskclusterFrame extends HTMLElement{
             alert("Unable to find a Task for this branch");
             return;
         }
-        const task_status = await fetch(`${TASKCLUSTER_INSTANCE}/api/queue/v1/task/${this.taskID}/status`).then((r)=>r.json());
-        if(task_status?.status?.state != "completed"){
-            alert("Task is missing or not complete");
-            return;
-        }
-
+ 
         this.#iframe.src =`${TASKCLUSTER_INSTANCE}api/queue/v1/task/${this.taskID}/artifacts/public/build/index.html`;
         this.dispatchEvent(new CustomEvent("taskChanged", {}));
     }


### PR DESCRIPTION
The wasm-viewer currently has a small problem: 
Of our roughly 100 branches we can only load up 22, as pr-artifacts are discarded after 30 days (any not even every branch has an open pr).
We can't query that on the webpage, as we would instantly reach the api-call limit. So let's "cache" up the current state on every push on main. 
goal is the wasm-thingy can:
-> Remove branches from the list if we certainly know that their head-sha does not have a taskcluster run attached.
-> Instantly get the taskID, in case the branch did not change since the last file-generation. 