### PR TITLE
ConnectionHealth for Android Daemon

### DIFF
--- a/android/daemon/src/main/AndroidManifest.xml
+++ b/android/daemon/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="org.mozilla.firefox.vpn.daemon">
 
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <application>
         <service android:name=".VPNService"
             android:permission="android.permission.BIND_VPN_SERVICE"

--- a/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/ConnectionHealth.kt
+++ b/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/ConnectionHealth.kt
@@ -1,128 +1,199 @@
 package org.mozilla.firefox.vpn.daemon
 
-import android.annotation.SuppressLint
 import android.content.Context
 import android.net.*
 import android.os.Build
 import android.os.CountDownTimer
-import android.os.Handler
-import androidx.annotation.RequiresApi
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 
-
-@RequiresApi(Build.VERSION_CODES.R)
-class ConnectionHealth (service: VPNService): ConnectivityDiagnosticsManager.ConnectivityDiagnosticsCallback(){
-    private val mService: VPNService = service;
+class ConnectionHealth(service: VPNService) {
+    private val TAG = "DaemonConnectionHealth"
+    private val mService: VPNService = service
     private val PING_TIMEOUT = 3000 // ms
 
-    private var mEndPoint : String =""
-    private var mGateway : String =""
+    private var mEndPoint: String = ""
+    private var mDNS: String = ""
+    private var mGateway: String = ""
+    private var mAltEndpoint: String = ""
+    private var mResetUsed = false
 
-    var mActive = false;
-    var mVPNNetwork:Network? = null;
-    var mWorker = Executors.newSingleThreadExecutor();
+    var mActive = false
+    var mVPNNetwork: Network? = null
+    var mWorker: ExecutorService = Executors.newSingleThreadExecutor()
 
-    fun start(endpoint:String, gateway:String){
-        if(mActive){
-            return;
+    fun start(endpoint: String, gateway: String, dns: String, altEndpoint: String) {
+        mEndPoint = endpoint
+        mGateway = gateway
+        mDNS = dns
+        mAltEndpoint = altEndpoint
+        if (mActive) {
+            return
         }
-        Log.e("BASTI", "REGISTERING")
-        mEndPoint=endpoint;
-        mGateway = gateway;
-
-
+        mResetUsed = false
         val mConnectivityManager = mService.getSystemService(Context.CONNECTIVITY_SERVICE)
-                as ConnectivityManager;
-        mConnectivityManager.registerNetworkCallback(vpnNetworkRequest,networkCallbackHandler);
-        mActive=true;
-        mTaskTimer.start();
+            as ConnectivityManager
+        mConnectivityManager.registerNetworkCallback(vpnNetworkRequest, networkCallbackHandler)
+        mActive = true
+        mTaskTimer.start()
+        Log.e(TAG, "Started ConnectionHealth")
     }
-    fun stop(){
-        mActive=false;
+    fun stop() {
+        mActive = false
         mTaskTimer.cancel()
+        val mConnectivityManager = mService.getSystemService(Context.CONNECTIVITY_SERVICE)
+            as ConnectivityManager
+        mConnectivityManager.unregisterNetworkCallback(networkCallbackHandler)
     }
 
+    private fun taskDone() {
+        if (!mActive) {
+            return
+        }
+        mTaskTimer.start()
+    }
 
-    private val connectionHealthTimerMSec: Long = 10000
+    private val connectionHealthTimerMSec: Long = 30000
+    /**
+     * mTaskTimer
+     * Queues TaskCheckConnection on the WorkerThread every 30s
+     */
     private val mTaskTimer = object : CountDownTimer(
         connectionHealthTimerMSec,
         connectionHealthTimerMSec / 4
     ) {
         override fun onTick(millisUntilFinished: Long) {}
         override fun onFinish() {
-            if(!mActive){
-                return;
+            if (!mActive) {
+                return
             }
-            mWorker.submit(Runnable {
-                kotlin.run {
-                    val mConnectivityManager = mService.getSystemService(Context.CONNECTIVITY_SERVICE)
-                            as ConnectivityManager;
-                    val currentNetwork = mVPNNetwork ?: return@Runnable
-                    val networkCaps = mConnectivityManager.getNetworkCapabilities(currentNetwork);
-                    if(networkCaps?.hasTransport(NetworkCapabilities.TRANSPORT_VPN) != true){
-                        Log.e("BASTI", "ACTIVE NETWORK NOT VPN")
-                        return@Runnable
-                    }
-                    Log.e("BASTI", "ACTIVE NETWORK IS VPN")
-                    val canReachGateway = currentNetwork.getByName(mEndPoint).isReachable(PING_TIMEOUT)
-                    if(canReachGateway){
-                        Log.i("BASTI", "Connection is fine")
-                        return@Runnable
-                    }
-                    val anyNetworkCanConnect = mConnectivityManager.allNetworks.map {
-                           it.getByName(mEndPoint).isReachable(PING_TIMEOUT)
-                    }.any{ it }
-
-                    if(anyNetworkCanConnect){
-                        Log.i("BASTI", "Connection is refreshable")
-                        // We the server is online but the connection got stale, let's reconnect
-                        mService.mainLooper.run {
-                            // Silent server switch to the same server
-                            mService.reconnect();
-                        }
-                    }
-                    Log.i("BASTI", "Connection is deeply broken!")
-                    // The We can't reach the Server endpoint on any server,
-                    // So we can't escalate that.
-                }
-            })
-            this.start();
+            mWorker.submit(TaskCheckConnection)
         }
     }
 
-    private val networkCallbackHandler = object : ConnectivityManager.NetworkCallback(){
+    /**
+     * networkCallbackHandler
+     * This will update mVPNNetwork to match the current vpn, or set it to null on disconnect.
+     */
+    private val networkCallbackHandler = object : ConnectivityManager.NetworkCallback() {
         override fun onAvailable(network: Network) {
-            // We're connected to the vpn, let's use that for
-            // status reports
-            mVPNNetwork = network;
-            super.onAvailable(network)
+            mVPNNetwork = network
         }
         override fun onLost(network: Network) {
-            mVPNNetwork = null;
-            super.onLost(network)
+            mVPNNetwork = null
         }
         override fun onUnavailable() {
-            mVPNNetwork = null;
-            super.onUnavailable()
+            mVPNNetwork = null
         }
-    };
+    }
 
-
+    /**
+     * vpnNetworkRequest
+     * This will build a NetworkRequest that only matches
+     * VPN networks on any transport.
+     * Can be used for ConnectivityManager and ConnectivityDiagonsticsManager
+     */
     private val vpnNetworkRequest: NetworkRequest by lazy {
         // Network requests are & - conditions, so let's only request for
         // networks that use a VPN transport type.
         NetworkRequest.Builder().apply {
-            clearCapabilities()
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                clearCapabilities()
+            }
             // There might be default's set, docs are not clear
             // So let's remove all that we don't need
-            removeTransportType(NetworkCapabilities.TRANSPORT_CELLULAR);
-            removeTransportType(NetworkCapabilities.TRANSPORT_BLUETOOTH);
-            removeTransportType(NetworkCapabilities.TRANSPORT_WIFI);
-            removeTransportType(NetworkCapabilities.TRANSPORT_LOWPAN);
-            removeTransportType(NetworkCapabilities.TRANSPORT_ETHERNET);
-            removeTransportType(NetworkCapabilities.TRANSPORT_WIFI_AWARE);
+            removeTransportType(NetworkCapabilities.TRANSPORT_CELLULAR)
+            removeTransportType(NetworkCapabilities.TRANSPORT_BLUETOOTH)
+            removeTransportType(NetworkCapabilities.TRANSPORT_WIFI)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1) {
+                removeTransportType(NetworkCapabilities.TRANSPORT_LOWPAN)
+            }
+            removeTransportType(NetworkCapabilities.TRANSPORT_ETHERNET)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                removeTransportType(NetworkCapabilities.TRANSPORT_WIFI_AWARE)
+            }
             addTransportType(NetworkCapabilities.TRANSPORT_VPN)
         }.build()
+    }
+
+    /**
+     * TaskCheck Connection.
+     * This task will check if the Server&DNS are still reachable.
+     * In case of a problem it will attempt once to reconnect to the server
+     * and Ask the VPNService to switch to a fallback server, in case a reconnect did not resolve
+     * the connection issue.
+     */
+    private val TaskCheckConnection = Runnable {
+        kotlin.run {
+            // capture stuff, as this the members will be set by another thread
+            val gateway = mGateway; // This lives inside the tunnel
+            val endpoint = mEndPoint; // This is the wg-endpoint (not in the tunnel)
+            val dns = mDNS
+            val fallbackEndpoint = mAltEndpoint
+
+            // Step 1: Make sure the current active network really is the VPN
+            val mConnectivityManager = mService.getSystemService(Context.CONNECTIVITY_SERVICE)
+                as ConnectivityManager
+            val vpnNetwork = mVPNNetwork ?: return@Runnable
+            val networkCaps = mConnectivityManager.getNetworkCapabilities(vpnNetwork)
+            if (networkCaps?.hasTransport(NetworkCapabilities.TRANSPORT_VPN) != true) {
+                // In case it's not anymore, just end here.
+                taskDone()
+                return@Runnable
+            }
+
+            // Step 2: Are both the VPN-Gateway and the DNS reachable? (i.e is internet working?)
+            val canReachGateway = vpnNetwork.getByName(gateway).isReachable(PING_TIMEOUT)
+            val canReachDNS = vpnNetwork.getByName(dns).isReachable(PING_TIMEOUT)
+            if (canReachGateway && canReachDNS) {
+                // Internet should be fine :)
+                mResetUsed = false
+                taskDone()
+                return@Runnable
+            }
+
+            if (!canReachGateway)
+                Log.e(TAG, "Failed to Reach VPN-Gateway")
+            if (!canReachDNS)
+                Log.e(TAG, "Failed to reach DNS")
+
+            // Step 3: We have found a connection Issue, check if we can ping the wireguard
+            // endpoint on any Network, maybe the handoff from WIFI-> GSM did not work correctly
+            val anyNetworkCanConnect = mConnectivityManager.allNetworks.firstOrNull() {
+                it.getByName(endpoint).isReachable(PING_TIMEOUT)
+            } != null
+            if (anyNetworkCanConnect && canReachDNS && !mResetUsed) {
+                // The server seems to be online but the connection broke,
+                // Let's just try to force a reconnect ... but only once.
+                mService.mainLooper.run {
+                    // Silent server switch to the same server
+                    mService.reconnect()
+                }
+                mResetUsed = true
+                taskDone()
+                return@Runnable
+            }
+            // Step 4: Either the server is unreachable or the "reconnect" did not
+            // fix the issue. Try to switch to the fallback server.
+            val fallbackServerIsReachable = mConnectivityManager.allNetworks.firstOrNull() {
+                it.getByName(fallbackEndpoint).isReachable(PING_TIMEOUT)
+            } != null
+            if (fallbackServerIsReachable) {
+                Log.i("BASTI", "Switch to fallback VPN server")
+                // We the server is online but the connection broke up, let's rest it
+                mService.mainLooper.run {
+                    // Silent server switch to the same server
+                    mService.reconnect(true)
+                    NotificationUtil.instance?.show(mService)
+                }
+                mResetUsed = true
+                taskDone()
+                return@Runnable
+            }
+            // If we land here: The server and the fallback are unreachable
+            // Nothing we can do here to help.
+            Log.e(TAG, "Both Server / Serverfallback seem to be unreachable.")
+            taskDone()
+        }
     }
 }

--- a/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/ConnectionHealth.kt
+++ b/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/ConnectionHealth.kt
@@ -1,0 +1,128 @@
+package org.mozilla.firefox.vpn.daemon
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.net.*
+import android.os.Build
+import android.os.CountDownTimer
+import android.os.Handler
+import androidx.annotation.RequiresApi
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+
+
+@RequiresApi(Build.VERSION_CODES.R)
+class ConnectionHealth (service: VPNService): ConnectivityDiagnosticsManager.ConnectivityDiagnosticsCallback(){
+    private val mService: VPNService = service;
+    private val PING_TIMEOUT = 3000 // ms
+
+    private var mEndPoint : String =""
+    private var mGateway : String =""
+
+    var mActive = false;
+    var mVPNNetwork:Network? = null;
+    var mWorker = Executors.newSingleThreadExecutor();
+
+    fun start(endpoint:String, gateway:String){
+        if(mActive){
+            return;
+        }
+        Log.e("BASTI", "REGISTERING")
+        mEndPoint=endpoint;
+        mGateway = gateway;
+
+
+        val mConnectivityManager = mService.getSystemService(Context.CONNECTIVITY_SERVICE)
+                as ConnectivityManager;
+        mConnectivityManager.registerNetworkCallback(vpnNetworkRequest,networkCallbackHandler);
+        mActive=true;
+        mTaskTimer.start();
+    }
+    fun stop(){
+        mActive=false;
+        mTaskTimer.cancel()
+    }
+
+
+    private val connectionHealthTimerMSec: Long = 10000
+    private val mTaskTimer = object : CountDownTimer(
+        connectionHealthTimerMSec,
+        connectionHealthTimerMSec / 4
+    ) {
+        override fun onTick(millisUntilFinished: Long) {}
+        override fun onFinish() {
+            if(!mActive){
+                return;
+            }
+            mWorker.submit(Runnable {
+                kotlin.run {
+                    val mConnectivityManager = mService.getSystemService(Context.CONNECTIVITY_SERVICE)
+                            as ConnectivityManager;
+                    val currentNetwork = mVPNNetwork ?: return@Runnable
+                    val networkCaps = mConnectivityManager.getNetworkCapabilities(currentNetwork);
+                    if(networkCaps?.hasTransport(NetworkCapabilities.TRANSPORT_VPN) != true){
+                        Log.e("BASTI", "ACTIVE NETWORK NOT VPN")
+                        return@Runnable
+                    }
+                    Log.e("BASTI", "ACTIVE NETWORK IS VPN")
+                    val canReachGateway = currentNetwork.getByName(mEndPoint).isReachable(PING_TIMEOUT)
+                    if(canReachGateway){
+                        Log.i("BASTI", "Connection is fine")
+                        return@Runnable
+                    }
+                    val anyNetworkCanConnect = mConnectivityManager.allNetworks.map {
+                           it.getByName(mEndPoint).isReachable(PING_TIMEOUT)
+                    }.any{ it }
+
+                    if(anyNetworkCanConnect){
+                        Log.i("BASTI", "Connection is refreshable")
+                        // We the server is online but the connection got stale, let's reconnect
+                        mService.mainLooper.run {
+                            // Silent server switch to the same server
+                            mService.reconnect();
+                        }
+                    }
+                    Log.i("BASTI", "Connection is deeply broken!")
+                    // The We can't reach the Server endpoint on any server,
+                    // So we can't escalate that.
+                }
+            })
+            this.start();
+        }
+    }
+
+    private val networkCallbackHandler = object : ConnectivityManager.NetworkCallback(){
+        override fun onAvailable(network: Network) {
+            // We're connected to the vpn, let's use that for
+            // status reports
+            mVPNNetwork = network;
+            super.onAvailable(network)
+        }
+        override fun onLost(network: Network) {
+            mVPNNetwork = null;
+            super.onLost(network)
+        }
+        override fun onUnavailable() {
+            mVPNNetwork = null;
+            super.onUnavailable()
+        }
+    };
+
+
+    private val vpnNetworkRequest: NetworkRequest by lazy {
+        // Network requests are & - conditions, so let's only request for
+        // networks that use a VPN transport type.
+        NetworkRequest.Builder().apply {
+            clearCapabilities()
+            // There might be default's set, docs are not clear
+            // So let's remove all that we don't need
+            removeTransportType(NetworkCapabilities.TRANSPORT_CELLULAR);
+            removeTransportType(NetworkCapabilities.TRANSPORT_BLUETOOTH);
+            removeTransportType(NetworkCapabilities.TRANSPORT_WIFI);
+            removeTransportType(NetworkCapabilities.TRANSPORT_LOWPAN);
+            removeTransportType(NetworkCapabilities.TRANSPORT_ETHERNET);
+            removeTransportType(NetworkCapabilities.TRANSPORT_WIFI_AWARE);
+            addTransportType(NetworkCapabilities.TRANSPORT_VPN)
+        }.build()
+    }
+}

--- a/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/NotificationUtil.kt
+++ b/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/NotificationUtil.kt
@@ -29,6 +29,9 @@ class NotificationUtil {
         updateNotificationChannel(null, null) // Will create the channel, will update
     }
 
+    private var mLastMessage = ""
+    private var mLastHeader = ""
+
     companion object {
         var instance: NotificationUtil? = null
         fun get(ctx: Context?): NotificationUtil? {
@@ -55,13 +58,15 @@ class NotificationUtil {
     /**
      * Updates the current shown notification
      */
-    fun update(heading: String, message: String) {
+    private fun update(heading: String, message: String) {
         val notificationManager: NotificationManager =
-            sCurrentContext?.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            sCurrentContext.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
 
-        mNotificationBuilder?.let {
+        mLastHeader = heading
+        mLastMessage = message
+        mNotificationBuilder.let {
             it.setContentTitle(heading)
-                .setContentText(message)
+            it.setContentText(message)
             notificationManager.notify(CONNECTED_NOTIFICATION_ID, it.build())
         }
     }
@@ -98,9 +103,12 @@ class NotificationUtil {
         // In case we do not have gotten a message to show from the Frontend
         // try to populate the notification with a translated Fallback message
         val prefs = Prefs.get(service)
-        val message =
+        val message = mLastMessage.ifEmpty {
             "" + prefs.getString("fallbackNotificationMessage", "Running in the Background")
-        val header = "" + prefs.getString("fallbackNotificationHeader", "Mozilla VPN")
+        }
+        val header = mLastHeader.ifEmpty {
+            "" + prefs.getString("fallbackNotificationHeader", "Mozilla VPN")
+        }
 
         // Create the Intent that Should be Fired if the User Clicks the notification
         val mainActivityName = "org.mozilla.firefox.vpn.qt.VPNActivity"

--- a/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/VPNLogger.kt
+++ b/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/VPNLogger.kt
@@ -25,6 +25,7 @@ class Log {
     }
 
     companion object {
+        val prefix = "Daemon-"
         var instance: Log? = null
         fun init(ctx: Context) {
             if (instance == null) {
@@ -34,17 +35,17 @@ class Log {
         fun i(tag: String, message: String) {
             instance?.write("[info] - ($tag) - $message")
             if (!BuildConfig.DEBUG) { return; }
-            nativeLog.i(tag, message)
+            nativeLog.i(prefix + tag, message)
         }
         fun v(tag: String, message: String) {
             instance?.write("($tag) - $message")
             if (!BuildConfig.DEBUG) { return; }
-            nativeLog.v(tag, message)
+            nativeLog.v(prefix + tag, message)
         }
         fun e(tag: String, message: String) {
             instance?.write("[error] - ($tag) - $message")
             if (!BuildConfig.DEBUG) { return; }
-            nativeLog.e(tag, message)
+            nativeLog.e(prefix + tag, message)
         }
         fun stack(tag: String, message: Array<StackTraceElement>) {
             e(tag, "StackTrace:")
@@ -56,7 +57,7 @@ class Log {
         fun sensitive(tag: String, message: String?) {
             if (!BuildConfig.DEBUG) { return; }
             if (message == null) { return; }
-            e(tag, message)
+            e(prefix + tag, message)
         }
 
         fun getContent(): String? {

--- a/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/VPNService.kt
+++ b/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/VPNService.kt
@@ -28,12 +28,7 @@ class VPNService : android.net.VpnService() {
     private var mConnectionTime: Long = 0
     private var mAlreadyInitialised = false
     private val controllerPeriodicStateRecorderMsec: Long = 10800000
-    private val mDiagnosticsAdapter = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-        ConnectionHealth(this)
-    } else {
-        TODO("VERSION.SDK_INT < R")
-        null
-    }
+    private val mConnectionHealth = ConnectionHealth(this)
 
     private val mGleanTimer = object : CountDownTimer(
         controllerPeriodicStateRecorderMsec,
@@ -41,7 +36,6 @@ class VPNService : android.net.VpnService() {
     ) {
         override fun onTick(millisUntilFinished: Long) {}
         override fun onFinish() {
-            Log.i(tag, "Timer Done!")
             if (currentTunnelHandle == -1) {
                 mGlean.recordGleanEvent("controllerStateOff")
             } else {
@@ -61,8 +55,7 @@ class VPNService : android.net.VpnService() {
         Log.init(this)
         mGlean.initializeGlean()
         SharedLibraryLoader.loadSharedLibrary(this, "wg-go")
-        Log.i(tag, "loaded lib")
-        Log.e(tag, "Wireguard Version ${wgVersion()}")
+        Log.i(tag, "Initialised Service with Wireguard Version ${wgVersion()}")
         mAlreadyInitialised = true
     }
 
@@ -71,8 +64,17 @@ class VPNService : android.net.VpnService() {
             // If the Qt Client got closed while we were not connected
             // we do not need to stay as a foreground service.
             stopForeground(true)
+            Log.v(tag, "Client Disconnected, VPN is down - Service might shut down soon")
         }
+        Log.v(tag, "Client Disconnected, VPN is up")
         return super.onUnbind(intent)
+    }
+
+    override fun onDestroy() {
+        // Note: This might not get called (depending on how it got invoked)
+        // it for granted all exits will be here.
+        Log.v(tag, "Service got Destroyed")
+        super.onDestroy()
     }
 
     /**
@@ -91,6 +93,7 @@ class VPNService : android.net.VpnService() {
      * or from Booting the device and having "connect on boot" enabled.
      */
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        Log.i(tag, "Service Started by Intent")
         init()
         intent?.let {
             if (intent.getBooleanExtra("startOnly", false)) {
@@ -131,6 +134,7 @@ class VPNService : android.net.VpnService() {
     // Invoked when the application is revoked.
     // At this moment, the VPN interface is already deactivated by the system.
     override fun onRevoke() {
+        Log.i(tag, "OS Revoked VPN permission")
         this.turnOff()
         super.onRevoke()
     }
@@ -146,10 +150,12 @@ class VPNService : android.net.VpnService() {
         }
         private set(value) {
             if (value) {
+                Log.i(tag, "Dispatch Daemon State -> connected")
                 mBinder.dispatchEvent(VPNServiceBinder.EVENTS.connected, "")
                 mConnectionTime = System.currentTimeMillis()
                 return
             }
+            Log.i(tag, "Dispatch Daemon State -> disconnected")
             mBinder.dispatchEvent(VPNServiceBinder.EVENTS.disconnected, "")
             mConnectionTime = 0
         }
@@ -174,25 +180,24 @@ class VPNService : android.net.VpnService() {
         // from the user. So we need to pass this to our main Activity and exit here.
         val intent = prepare(this)
         if (intent == null) {
-            Log.e(tag, "VPN Permission Already Present")
+            Log.i(tag, "VPN Permission Already Present")
             return true
         }
         Log.e(tag, "Requesting VPN Permission")
         return false
     }
 
-    fun turnOn(json: JSONObject) {
+    fun turnOn(json: JSONObject, useFallbackServer: Boolean = false) {
         Log.sensitive(tag, json.toString())
-        val wireguard_conf = buildWireugardConfig(json)
+        val wireguard_conf = buildWireugardConfig(json, useFallbackServer)
 
         if (!checkPermissions()) {
-            Log.e(tag, "turn on was called without no permissions present!")
+            Log.e(tag, "turn on was called without vpn-permission!")
             isUp = false
             return
         }
-        Log.i(tag, "Permission okay")
         if (currentTunnelHandle != -1) {
-            Log.e(tag, "Tunnel already up")
+            Log.i(tag, "Currently have a connection, start switching")
             // Turn the tunnel down because this might be a switch
             wgTurnOff(currentTunnelHandle)
         }
@@ -201,12 +206,15 @@ class VPNService : android.net.VpnService() {
         setupBuilder(wireguard_conf, builder)
         builder.setSession("mvpn0")
         builder.establish().use { tun ->
-            if (tun == null)return
-            Log.i(tag, "Go backend " + wgVersion())
+            if (tun == null) {
+                isUp = false
+                Log.e(tag, "Activation Error: did not get a TUN handle")
+                return
+            }
             currentTunnelHandle = wgTurnOn("mvpn0", tun.detachFd(), wgConfig)
         }
         if (currentTunnelHandle < 0) {
-            Log.e(tag, "Activation Error Code -> $currentTunnelHandle")
+            Log.e(tag, "WActivation Error Wireguard-Error -> $currentTunnelHandle")
             isUp = false
             return
         }
@@ -224,21 +232,35 @@ class VPNService : android.net.VpnService() {
 
         NotificationUtil.get(this)?.show(this) // Go foreground
         mGleanTimer.start()
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            mDiagnosticsAdapter?.start(
-                    mConfig?.getJSONObject("server")?.getString("ipv4AddrIn")!!,
-                    mConfig?.getJSONObject("server")?.getString("ipv4Gateway")!!
+
+        if (useFallbackServer) {
+            mConnectionHealth.start(
+                json.getJSONObject("server").getString("ipv4AddrIn"),
+                json.getJSONObject("serverFallback").getString("ipv4Gateway"),
+                json.getJSONObject("serverFallback").getString("ipv4Gateway"),
+                json.getJSONObject("serverFallback").getString("ipv4AddrIn"),
+            )
+        } else {
+            mConnectionHealth.start(
+                json.getJSONObject("server").getString("ipv4AddrIn"),
+                json.getJSONObject("server").getString("ipv4Gateway"),
+                json.getString("dns"),
+                json.getJSONObject("serverFallback").getString("ipv4Gateway"),
             )
         }
     }
 
-    fun reconnect(){
-        if(this.mConfig == null){
+    fun reconnect(forceFallBack: Boolean = false) {
+        if (this.mConfig == null) {
             Log.e(tag, "Called reconnect without setting any conf first?")
-            return;
+            return
         }
+        // Don't reset the connection time,
+        // so the users won't be surprised :)
+        val oldConnectionTime = mConnectionTime
         Log.v(tag, "Try to reconnect tunnel with same conf")
-        this.turnOn(this.mConfig!!)
+        this.turnOn(this.mConfig!!, forceFallBack)
+        mConnectionTime = oldConnectionTime
     }
 
     fun turnOff() {
@@ -248,6 +270,7 @@ class VPNService : android.net.VpnService() {
         stopForeground(false)
         isUp = false
         mGleanTimer.cancel()
+        mConnectionHealth.stop()
     }
 
     /**
@@ -304,9 +327,14 @@ class VPNService : android.net.VpnService() {
      * Create a Wireguard [Config]  from a [json] string -
      * The [json] will be created in AndroidController.cpp
      */
-    private fun buildWireugardConfig(obj: JSONObject): Config {
+    private fun buildWireugardConfig(obj: JSONObject, useFallbackServer: Boolean = false): Config {
         val confBuilder = Config.Builder()
-        val jServer = obj.getJSONObject("server")
+        val jServer: JSONObject = if (useFallbackServer) {
+            obj.getJSONObject("serverFallback")
+        } else {
+            obj.getJSONObject("server")
+        }
+
         val peerBuilder = Peer.Builder()
         val ep =
             InetEndpoint.parse(jServer.getString("ipv4AddrIn") + ":" + jServer.getString("port"))
@@ -334,6 +362,10 @@ class VPNService : android.net.VpnService() {
         ifaceBuilder.addAddress(InetNetwork.parse(jDevice.getString("ipv4Address")))
         ifaceBuilder.addAddress(InetNetwork.parse(jDevice.getString("ipv6Address")))
         ifaceBuilder.addDnsServer(InetNetwork.parse(obj.getString("dns")).address)
+        if (useFallbackServer) {
+            // In case we have to use the fallback, add the default dns as fallback as well.
+            ifaceBuilder.addDnsServer(InetNetwork.parse(jServer.getString("ipv4Gateway")).address)
+        }
         val jExcludedApplication = obj.getJSONArray("excludedApps")
         (0 until jExcludedApplication.length()).toList().forEach {
             val appName = jExcludedApplication.get(it).toString()

--- a/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/VPNServiceBinder.kt
+++ b/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/VPNServiceBinder.kt
@@ -50,12 +50,11 @@ class VPNServiceBinder(service: VPNService) : Binder() {
         when (code) {
             ACTIONS.activate -> {
                 try {
-                    Log.i(tag, "Activiation Requested, parsing Config")
+                    Log.i(tag, "Activation Requested")
                     // [data] is here a json containing the wireguard conf
                     val buffer = data.createByteArray()
                     val json = buffer?.let { String(it) }
                     val config = JSONObject(json)
-                    Log.v(tag, "Stored new Tunnel config in Service")
 
                     if (!mService.checkPermissions()) {
                         mResumeConfig = config
@@ -77,6 +76,7 @@ class VPNServiceBinder(service: VPNService) : Binder() {
                 // [data] is empty
                 // Activate the current tunnel
                 try {
+                    Log.i(tag, "Resume Activation requested")
                     mResumeConfig?.let { this.mService.turnOn(it) }
                 } catch (e: Exception) {
                     Log.e(tag, "An Error occurred while enabling the VPN: ${e.localizedMessage}")
@@ -85,12 +85,14 @@ class VPNServiceBinder(service: VPNService) : Binder() {
             }
 
             ACTIONS.deactivate -> {
+                Log.i(tag, "Deactivation requested")
                 // [data] here is empty
                 this.mService.turnOff()
                 return true
             }
 
             ACTIONS.registerEventListener -> {
+                Log.i(tag, "requested to add an Event Listener")
                 // [data] contains the Binder that we need to dispatch the Events
                 val binder = data.readStrongBinder()
                 mListener = binder

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip


### PR DESCRIPTION
Issue:
>The VPN loses connection after checking the uptime (basically opening the app to see how much time you've been successfully connected to the VPN). All data traffic stops even though the VPN looks like it is connected. The only way to get it working again is to open the VPN application. When they do this they see the uptime counter reset to 0 and the connection starts working. Happening on Celluar and WiFI.

Looking at the description - "When they do this they see the uptime counter reset to 0 and the connection starts working. " This clearly is ConnectionHealth, switching to the next server :) 

Of course that can't be used while the app is in the background, so this re-implements part's of this in the daemon. 
Essentially, it run's on a timer, checks the connection. The client, will provide a fallback server in the same city and we will silently switch to that in case the original server becomes unavailable :) 


Closes https://github.com/mozilla-mobile/mozilla-vpn-client/issues/3655
