### PR TITLE
Fallback to port 53 before failing 

### DIFF
--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -181,7 +181,7 @@ bool Controller::activate() {
   return true;
 }
 
-void Controller::activateInternal() {
+void Controller::activateInternal(bool forcePort53) {
   logger.debug() << "Activation internal";
   Q_ASSERT(m_impl);
 
@@ -223,7 +223,7 @@ void Controller::activateInternal() {
     exitHop.m_excludedAddresses.append(exitHop.m_server.ipv6AddrIn());
 
     // If requested, force the use of port 53/DNS.
-    if (settingsHolder->tunnelPort53()) {
+    if (settingsHolder->tunnelPort53() || forcePort53) {
       exitHop.m_server.forcePort(53);
     }
     // For single-hop, they are the same
@@ -241,7 +241,7 @@ void Controller::activateInternal() {
       return;
     }
     // If requested, force the use of port 53/DNS.
-    if (settingsHolder->tunnelPort53()) {
+    if (settingsHolder->tunnelPort53() || forcePort53) {
       hop.m_server.forcePort(53);
     }
 
@@ -400,6 +400,13 @@ void Controller::handshakeTimeout() {
   emit connectionRetryChanged();
   if (m_connectionRetry < CONNECTION_MAX_RETRY) {
     activateInternal();
+    return;
+  } else if (m_connectionRetry == CONNECTION_MAX_RETRY &&
+             !SettingsHolder::instance()->tunnelPort53()) {
+    logger.info() << "Last Connection Attempt: Using Port 53 Option this time.";
+    // On the last activation, opportunisticly try again using the port 53
+    // option enabled, if that feature is disabled.
+    activateInternal(true);
     return;
   }
 

--- a/src/controller.h
+++ b/src/controller.h
@@ -148,7 +148,7 @@ class Controller final : public QObject {
   QList<IPAddress> getAllowedIPAddressRanges(const Server& server);
   QStringList getExcludedAddresses(const Server& server);
 
-  void activateInternal();
+  void activateInternal(bool forceDNSPort = false);
   void activateNext();
 
   void clearRetryCounter();

--- a/tests/qml/moccontroller.cpp
+++ b/tests/qml/moccontroller.cpp
@@ -16,7 +16,7 @@ void Controller::implInitialized(bool, bool, const QDateTime&) {}
 
 bool Controller::activate() { return false; }
 
-void Controller::activateInternal() {}
+void Controller::activateInternal(bool forcePort53) { Q_UNUSED(forcePort53) }
 
 bool Controller::deactivate() { return false; }
 

--- a/tests/unit/moccontroller.cpp
+++ b/tests/unit/moccontroller.cpp
@@ -17,7 +17,7 @@ void Controller::implInitialized(bool, bool, const QDateTime&) {}
 
 bool Controller::activate() { return false; }
 
-void Controller::activateInternal() {}
+void Controller::activateInternal(bool forcePort53) { Q_UNUSED(forcePort53) }
 
 bool Controller::deactivate() { return false; }
 


### PR DESCRIPTION
## Description

This patch add's a last attempt to establish a connection, forcefully using port 53. 

## Reference

    closes https://github.com/mozilla-mobile/mozilla-vpn-client/issues/3268

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
