### PR TITLE
Measure and display latency in server view.

### DIFF
--- a/nebula/ui/components/VPNServerCountry.qml
+++ b/nebula/ui/components/VPNServerCountry.qml
@@ -170,7 +170,7 @@ VPNClickableRow {
                 property string _countryCode: code
                 property string _localizedCityName: modelData[1]
                 property string locationScore: modelData[2]
-                property bool isAvailable: locationScore > 0
+                property bool isAvailable: locationScore >= 0
                 property int itemHeight: 54
 
                 id: del
@@ -216,13 +216,13 @@ VPNClickableRow {
                         top: del.top
                         verticalCenter: del.verticalCenter
                     }
-                    source: del.locationScore == 0 ? "qrc:/nebula/resources/warning.svg" :
-                        "qrc:/nebula/resources/wifi-" + (del.locationScore-1) + ".svg"
+                    source: del.locationScore < 0 ? "qrc:/nebula/resources/warning.svg" :
+                        "qrc:/nebula/resources/wifi-" + del.locationScore + ".svg"
                     sourceSize {
                         height: VPNTheme.theme.iconSizeSmall
                         width: VPNTheme.theme.iconSizeSmall
                     }
-                    visible: true
+                    visible: del.locationScore != 0
                 }
 
             }

--- a/nebula/ui/components/VPNServerCountry.qml
+++ b/nebula/ui/components/VPNServerCountry.qml
@@ -166,10 +166,10 @@ VPNClickableRow {
             model: cities
 
             delegate: VPNRadioDelegate {
-                property string _cityName: modelData[0]
+                property string _cityName: modelData.name
                 property string _countryCode: code
-                property string _localizedCityName: modelData[1]
-                property string locationScore: modelData[2]
+                property string _localizedCityName: modelData.localizedName
+                property string locationScore: VPNServerCountryModel.cityConnectionScore(code, modelData.code)
                 property bool isAvailable: locationScore >= 0
                 property int itemHeight: 54
 
@@ -179,8 +179,8 @@ VPNClickableRow {
                 Keys.onDownPressed: if (citiesRepeater.itemAt(index + 1)) citiesRepeater.itemAt(index + 1).forceActiveFocus()
                 Keys.onUpPressed: if (citiesRepeater.itemAt(index - 1)) citiesRepeater.itemAt(index - 1).forceActiveFocus()
                 onActiveFocusChanged: vpnFlickable.ensureVisible(del)
-                radioButtonLabelText: modelData[1]
-                accessibleName: modelData[1]
+                radioButtonLabelText: _localizedCityName
+                accessibleName: _localizedCityName
                 implicitWidth: parent.width
 
                 onClicked: {

--- a/nebula/ui/components/VPNServerCountry.qml
+++ b/nebula/ui/components/VPNServerCountry.qml
@@ -167,10 +167,10 @@ VPNClickableRow {
 
             delegate: VPNRadioDelegate {
                 property string _cityName: modelData[0]
-                property string _localizedCityName: modelData[1]
-                property string _activeServerCount: modelData[2]
                 property string _countryCode: code
-                property bool isAvailable: _activeServerCount > 0
+                property string _localizedCityName: modelData[1]
+                property string locationScore: modelData[2]
+                property bool isAvailable: locationScore > 0
                 property int itemHeight: 54
 
                 id: del
@@ -216,12 +216,13 @@ VPNClickableRow {
                         top: del.top
                         verticalCenter: del.verticalCenter
                     }
-                    source: "qrc:/nebula/resources/warning.svg"
+                    source: del.locationScore == 0 ? "qrc:/nebula/resources/warning.svg" :
+                        "qrc:/nebula/resources/wifi-" + (del.locationScore-1) + ".svg"
                     sourceSize {
                         height: VPNTheme.theme.iconSizeSmall
                         width: VPNTheme.theme.iconSizeSmall
                     }
-                    visible: !del.isAvailable
+                    visible: true
                 }
 
             }

--- a/nebula/ui/nebula_resources.qrc
+++ b/nebula/ui/nebula_resources.qrc
@@ -337,6 +337,10 @@
         <file>resources/check-green70.svg</file>
         <file>resources/shield-green50.svg</file>
         <file>resources/checkmark-blue50.svg</file>
+        <file>resources/wifi-0.svg</file>
+        <file>resources/wifi-1.svg</file>
+        <file>resources/wifi-2.svg</file>
+        <file>resources/wifi-3.svg</file>
         <file>resources/navbar/home.svg</file>
         <file>resources/navbar/home-selected.svg</file>
         <file>resources/navbar/messages.svg</file>

--- a/nebula/ui/resources/wifi-0.svg
+++ b/nebula/ui/resources/wifi-0.svg
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   viewBox="0 0 24 24"
+   fill="none"
+   version="1.1"
+   id="svg8"
+   sodipodi:docname="wifi-0.svg"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)">
+  <metadata
+     id="metadata14">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs12" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1397"
+     inkscape:window-height="723"
+     id="namedview10"
+     showgrid="false"
+     inkscape:zoom="9.8333333"
+     inkscape:cx="5.9491525"
+     inkscape:cy="10.474576"
+     inkscape:window-x="1960"
+     inkscape:window-y="65"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg8" />
+  <path
+     d="M 10.1956,15.6956 C 10.641,15.2502 11.2451,15 11.875,15 c 0.6299,0 1.234,0.2502 1.6794,0.6956 0.9275,0.9275 0.9275,2.4313 0,3.3588 -0.9275,0.9275 -2.4313,0.9275 -3.3588,0 -0.92747,-0.9275 -0.92747,-2.4313 0,-3.3588 z"
+     id="path2"
+     inkscape:connector-curvature="0"
+     style="fill:#d5d3e0;fill-opacity:1" />
+  <path
+     d="M 3.27791,8.4684 C 5.5737,6.25022 8.71766,5 12,5 c 3.2823,0 6.4263,1.25022 8.7221,3.4684 0.3705,0.35037 0.3705,0.91844 0,1.26882 -0.3706,0.35038 -0.9713,0.35038 -1.3419,0 C 17.4377,7.86025 14.7774,6.80233 12,6.80233 c -2.77738,0 -5.43767,1.05792 -7.38023,2.93489 -0.37055,0.35038 -0.97132,0.35038 -1.34186,0 -0.37055,-0.35038 -0.37055,-0.91845 0,-1.26882 z"
+     id="path4"
+     inkscape:connector-curvature="0"
+     style="fill:#d5d3e0;fill-opacity:1" />
+  <path
+     d="M 6.26399,12.4429 C 7.77325,10.8807 9.84106,10 12,10 c 2.1589,0 4.2268,0.8807 5.736,2.4429 0.352,0.3562 0.352,0.9337 0,1.2899 -0.352,0.3563 -0.9227,0.3563 -1.2747,0 C 15.287,12.5186 13.6789,11.8343 12,11.8343 c -1.6789,0 -3.28701,0.6843 -4.46134,1.8985 -0.35199,0.3563 -0.92268,0.3563 -1.27467,0 -0.35199,-0.3562 -0.35199,-0.9337 0,-1.2899 z"
+     id="path6"
+     style="fill:#d5d3e0;fill-opacity:1"
+     inkscape:connector-curvature="0" />
+</svg>

--- a/nebula/ui/resources/wifi-1.svg
+++ b/nebula/ui/resources/wifi-1.svg
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   viewBox="0 0 24 24"
+   fill="none"
+   version="1.1"
+   id="svg8"
+   sodipodi:docname="wifi-1.svg"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)">
+  <metadata
+     id="metadata14">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs12" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1397"
+     inkscape:window-height="723"
+     id="namedview10"
+     showgrid="false"
+     inkscape:zoom="9.8333333"
+     inkscape:cx="9.8135593"
+     inkscape:cy="12.20339"
+     inkscape:window-x="1960"
+     inkscape:window-y="65"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg8" />
+  <path
+     d="M 10.1956,15.6956 C 10.641,15.2502 11.2451,15 11.875,15 c 0.6299,0 1.234,0.2502 1.6794,0.6956 0.9275,0.9275 0.9275,2.4313 0,3.3588 -0.9275,0.9275 -2.4313,0.9275 -3.3588,0 -0.92747,-0.9275 -0.92747,-2.4313 0,-3.3588 z"
+     id="path2"
+     inkscape:connector-curvature="0"
+     style="fill:#1cc4a0;fill-opacity:1" />
+  <path
+     d="M 3.27791,8.4684 C 5.5737,6.25022 8.71766,5 12,5 c 3.2823,0 6.4263,1.25022 8.7221,3.4684 0.3705,0.35037 0.3705,0.91844 0,1.26882 -0.3706,0.35038 -0.9713,0.35038 -1.3419,0 C 17.4377,7.86025 14.7774,6.80233 12,6.80233 c -2.77738,0 -5.43767,1.05792 -7.38023,2.93489 -0.37055,0.35038 -0.97132,0.35038 -1.34186,0 -0.37055,-0.35038 -0.37055,-0.91845 0,-1.26882 z"
+     id="path4"
+     inkscape:connector-curvature="0"
+     style="fill:#d5d3e0;fill-opacity:1" />
+  <path
+     d="M 6.26399,12.4429 C 7.77325,10.8807 9.84106,10 12,10 c 2.1589,0 4.2268,0.8807 5.736,2.4429 0.352,0.3562 0.352,0.9337 0,1.2899 -0.352,0.3563 -0.9227,0.3563 -1.2747,0 C 15.287,12.5186 13.6789,11.8343 12,11.8343 c -1.6789,0 -3.28701,0.6843 -4.46134,1.8985 -0.35199,0.3563 -0.92268,0.3563 -1.27467,0 -0.35199,-0.3562 -0.35199,-0.9337 0,-1.2899 z"
+     id="path6"
+     style="fill:#d5d3e0;fill-opacity:1"
+     inkscape:connector-curvature="0" />
+</svg>

--- a/nebula/ui/resources/wifi-2.svg
+++ b/nebula/ui/resources/wifi-2.svg
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   viewBox="0 0 24 24"
+   fill="none"
+   version="1.1"
+   id="svg8"
+   sodipodi:docname="wifi-2.svg"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)">
+  <metadata
+     id="metadata14">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs12" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1397"
+     inkscape:window-height="723"
+     id="namedview10"
+     showgrid="false"
+     inkscape:zoom="9.8333333"
+     inkscape:cx="6.1016949"
+     inkscape:cy="10.372881"
+     inkscape:window-x="1960"
+     inkscape:window-y="65"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg8" />
+  <path
+     d="M 10.1956,15.6956 C 10.641,15.2502 11.2451,15 11.875,15 c 0.6299,0 1.234,0.2502 1.6794,0.6956 0.9275,0.9275 0.9275,2.4313 0,3.3588 -0.9275,0.9275 -2.4313,0.9275 -3.3588,0 -0.92747,-0.9275 -0.92747,-2.4313 0,-3.3588 z"
+     id="path2"
+     inkscape:connector-curvature="0"
+     style="fill:#1cc4a0;fill-opacity:1" />
+  <path
+     d="M 3.27791,8.4684 C 5.5737,6.25022 8.71766,5 12,5 c 3.2823,0 6.4263,1.25022 8.7221,3.4684 0.3705,0.35037 0.3705,0.91844 0,1.26882 -0.3706,0.35038 -0.9713,0.35038 -1.3419,0 C 17.4377,7.86025 14.7774,6.80233 12,6.80233 c -2.77738,0 -5.43767,1.05792 -7.38023,2.93489 -0.37055,0.35038 -0.97132,0.35038 -1.34186,0 -0.37055,-0.35038 -0.37055,-0.91845 0,-1.26882 z"
+     id="path4"
+     inkscape:connector-curvature="0"
+     style="fill:#d5d3e0;fill-opacity:1" />
+  <path
+     d="M 6.26399,12.4429 C 7.77325,10.8807 9.84106,10 12,10 c 2.1589,0 4.2268,0.8807 5.736,2.4429 0.352,0.3562 0.352,0.9337 0,1.2899 -0.352,0.3563 -0.9227,0.3563 -1.2747,0 C 15.287,12.5186 13.6789,11.8343 12,11.8343 c -1.6789,0 -3.28701,0.6843 -4.46134,1.8985 -0.35199,0.3563 -0.92268,0.3563 -1.27467,0 -0.35199,-0.3562 -0.35199,-0.9337 0,-1.2899 z"
+     id="path6"
+     style="fill:#1cc4a0;fill-opacity:1"
+     inkscape:connector-curvature="0" />
+</svg>

--- a/nebula/ui/resources/wifi-3.svg
+++ b/nebula/ui/resources/wifi-3.svg
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   viewBox="0 0 24 24"
+   fill="none"
+   version="1.1"
+   id="svg8"
+   sodipodi:docname="wifi-3.svg"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)">
+  <metadata
+     id="metadata14">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs12" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1397"
+     inkscape:window-height="723"
+     id="namedview10"
+     showgrid="false"
+     inkscape:zoom="9.8333333"
+     inkscape:cx="5.5423729"
+     inkscape:cy="12.813559"
+     inkscape:window-x="1960"
+     inkscape:window-y="65"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg8" />
+  <path
+     d="M 10.1956,15.6956 C 10.641,15.2502 11.2451,15 11.875,15 c 0.6299,0 1.234,0.2502 1.6794,0.6956 0.9275,0.9275 0.9275,2.4313 0,3.3588 -0.9275,0.9275 -2.4313,0.9275 -3.3588,0 -0.92747,-0.9275 -0.92747,-2.4313 0,-3.3588 z"
+     id="path2"
+     inkscape:connector-curvature="0"
+     style="fill:#1cc4a0;fill-opacity:1" />
+  <path
+     d="M 3.27791,8.4684 C 5.5737,6.25022 8.71766,5 12,5 c 3.2823,0 6.4263,1.25022 8.7221,3.4684 0.3705,0.35037 0.3705,0.91844 0,1.26882 -0.3706,0.35038 -0.9713,0.35038 -1.3419,0 C 17.4377,7.86025 14.7774,6.80233 12,6.80233 c -2.77738,0 -5.43767,1.05792 -7.38023,2.93489 -0.37055,0.35038 -0.97132,0.35038 -1.34186,0 -0.37055,-0.35038 -0.37055,-0.91845 0,-1.26882 z"
+     id="path4"
+     inkscape:connector-curvature="0"
+     style="fill:#1cc4a0;fill-opacity:1" />
+  <path
+     d="M 6.26399,12.4429 C 7.77325,10.8807 9.84106,10 12,10 c 2.1589,0 4.2268,0.8807 5.736,2.4429 0.352,0.3562 0.352,0.9337 0,1.2899 -0.352,0.3563 -0.9227,0.3563 -1.2747,0 C 15.287,12.5186 13.6789,11.8343 12,11.8343 c -1.6789,0 -3.28701,0.6843 -4.46134,1.8985 -0.35199,0.3563 -0.92268,0.3563 -1.27467,0 -0.35199,-0.3562 -0.35199,-0.9337 0,-1.2899 z"
+     id="path6"
+     style="fill:#1cc4a0;fill-opacity:1"
+     inkscape:connector-curvature="0" />
+</svg>

--- a/src/cmake/sources.cmake
+++ b/src/cmake/sources.cmake
@@ -266,6 +266,8 @@ target_sources(mozillavpn PRIVATE
     rfc/rfc5735.h
     serveri18n.cpp
     serveri18n.h
+    serverlatency.cpp
+    serverlatency.h
     settingsholder.cpp
     settingsholder.h
     signature.cpp
@@ -305,8 +307,6 @@ target_sources(mozillavpn PRIVATE
     tasks/heartbeat/taskheartbeat.h
     tasks/ipfinder/taskipfinder.cpp
     tasks/ipfinder/taskipfinder.h
-    tasks/latency/tasklatency.cpp
-    tasks/latency/tasklatency.h
     tasks/products/taskproducts.cpp
     tasks/products/taskproducts.h
     tasks/release/taskrelease.cpp

--- a/src/cmake/sources.cmake
+++ b/src/cmake/sources.cmake
@@ -305,6 +305,8 @@ target_sources(mozillavpn PRIVATE
     tasks/heartbeat/taskheartbeat.h
     tasks/ipfinder/taskipfinder.cpp
     tasks/ipfinder/taskipfinder.h
+    tasks/latency/tasklatency.cpp
+    tasks/latency/tasklatency.h
     tasks/products/taskproducts.cpp
     tasks/products/taskproducts.h
     tasks/release/taskrelease.cpp

--- a/src/constants.h
+++ b/src/constants.h
@@ -66,7 +66,7 @@ CONSTEXPR(uint32_t, releaseMonitorMsec, 21600000, 4000, 0)
 
 // in milliseconds, how often we should fetch the server list, the account and
 // so on.
-CONSTEXPR(uint32_t, schedulePeriodicTaskTimerMsec, 3600000, 4000, 0)
+CONSTEXPR(uint32_t, schedulePeriodicTaskTimerMsec, 3600000, 30000, 0)
 
 // how often we check the captive portal when the VPN is on.
 CONSTEXPR(uint32_t, captivePortalRequestTimeoutMsec, 10000, 4000, 0)

--- a/src/featureslist.h
+++ b/src/featureslist.h
@@ -169,6 +169,14 @@ FEATURE_SIMPLE(serverUnavailableNotification,      // Feature ID
                QStringList(),                      // feature dependencies
                FeatureCallback_true)
 
+FEATURE_SIMPLE(serverConnectionScore,      // Feature ID
+               "Server connection score",  // Feature name
+               "2.10",                     // released
+               FeatureCallback_true,       // Can be flipped on
+               FeatureCallback_true,       // Can be flipped off
+               QStringList(),              // feature dependencies
+               FeatureCallback_true)
+
 FEATURE_SIMPLE(shareLogs,              // Feature ID
                "Share Logs",           // Feature name
                "2.6",                  // released

--- a/src/models/server.cpp
+++ b/src/models/server.cpp
@@ -121,6 +121,7 @@ bool Server::fromJson(const QJsonObject& obj) {
   m_socksName = socks5_name.toString();
   m_multihopPort = multihop_port.toInt();
   m_cooldownTimeout = 0;
+  m_latency = 0;
 
   return true;
 }

--- a/src/models/server.cpp
+++ b/src/models/server.cpp
@@ -32,6 +32,7 @@ Server& Server::operator=(const Server& other) {
   m_socksName = other.m_socksName;
   m_multihopPort = other.m_multihopPort;
   m_cooldownTimeout = other.m_cooldownTimeout;
+  m_latency = other.m_latency;
 
   return *this;
 }
@@ -132,6 +133,7 @@ bool Server::fromMultihop(const Server& exit, const Server& entry) {
   m_socksName = exit.m_socksName;
   m_multihopPort = exit.m_multihopPort;
   m_cooldownTimeout = exit.m_cooldownTimeout;
+  m_latency = exit.m_latency;
 
   m_ipv4AddrIn = entry.m_ipv4AddrIn;
   m_ipv6AddrIn = entry.m_ipv6AddrIn;

--- a/src/models/server.h
+++ b/src/models/server.h
@@ -74,7 +74,7 @@ class Server final {
   uint32_t m_weight = 0;
   uint32_t m_multihopPort = 0;
   qint64 m_cooldownTimeout = 0;
-  uint32_t m_latency;
+  uint32_t m_latency = 0;
 };
 
 #endif  // SERVER_H

--- a/src/models/server.h
+++ b/src/models/server.h
@@ -42,6 +42,9 @@ class Server final {
   qint64 cooldownTimeout() const { return m_cooldownTimeout; }
   void setCooldownTimeout(qint64 timeout);
 
+  uint32_t latency() const { return m_latency; }
+  void setLatency(uint32_t msec) { m_latency = msec; }
+
   uint32_t weight() const { return m_weight; }
 
   uint32_t choosePort() const;
@@ -71,6 +74,7 @@ class Server final {
   uint32_t m_weight = 0;
   uint32_t m_multihopPort = 0;
   qint64 m_cooldownTimeout = 0;
+  uint32_t m_latency;
 };
 
 #endif  // SERVER_H

--- a/src/models/servercity.cpp
+++ b/src/models/servercity.cpp
@@ -5,6 +5,7 @@
 #include "servercity.h"
 #include "constants.h"
 #include "leakdetector.h"
+#include "serveri18n.h"
 
 #include <QJsonArray>
 #include <QJsonObject>
@@ -22,6 +23,7 @@ ServerCity& ServerCity::operator=(const ServerCity& other) {
 
   m_name = other.m_name;
   m_code = other.m_code;
+  m_country = other.m_country;
   m_latitude = other.m_latitude;
   m_longitude = other.m_longitude;
   m_servers = other.m_servers;
@@ -31,7 +33,7 @@ ServerCity& ServerCity::operator=(const ServerCity& other) {
 
 ServerCity::~ServerCity() { MVPN_COUNT_DTOR(ServerCity); }
 
-bool ServerCity::fromJson(const QJsonObject& obj) {
+bool ServerCity::fromJson(const QJsonObject& obj, const QString& country) {
   QJsonValue name = obj.value("name");
   if (!name.isString()) {
     return false;
@@ -77,9 +79,14 @@ bool ServerCity::fromJson(const QJsonObject& obj) {
 
   m_name = name.toString();
   m_code = code.toString();
+  m_country = country;
   m_latitude = latitude.toDouble();
   m_longitude = longitude.toDouble();
   m_servers.swap(servers);
 
   return true;
+}
+
+const QString ServerCity::localizedName() const {
+  return ServerI18N::translateCityName(m_country, m_name);
 }

--- a/src/models/servercity.h
+++ b/src/models/servercity.h
@@ -8,22 +8,37 @@
 #include "server.h"
 
 #include <QList>
+#include <QObject>
 #include <QString>
 
 class QJsonObject;
 
-class ServerCity final {
+class ServerCity final : public QObject {
+  Q_OBJECT
+
+  Q_PROPERTY(QString name READ name CONSTANT)
+  Q_PROPERTY(QString code READ code CONSTANT)
+  Q_PROPERTY(QString coutnry READ country CONSTANT)
+  Q_PROPERTY(QString localizedName READ localizedName CONSTANT)
+  Q_PROPERTY(double latitude READ latitude CONSTANT)
+  Q_PROPERTY(double longitude READ longitude CONSTANT)
+
  public:
+
   ServerCity();
   ServerCity(const ServerCity& other);
   ServerCity& operator=(const ServerCity& other);
   ~ServerCity();
 
-  [[nodiscard]] bool fromJson(const QJsonObject& obj);
+  [[nodiscard]] bool fromJson(const QJsonObject& obj, const QString& country);
 
   const QString& name() const { return m_name; }
 
   const QString& code() const { return m_code; }
+
+  const QString& country() const { return m_country; }
+
+  const QString localizedName() const;
 
   double latitude() const { return m_latitude; }
 
@@ -32,6 +47,7 @@ class ServerCity final {
   const QList<QString> servers() const { return m_servers; }
 
  private:
+  QString m_country;
   QString m_name;
   QString m_code;
   double m_latitude;

--- a/src/models/servercity.h
+++ b/src/models/servercity.h
@@ -24,7 +24,6 @@ class ServerCity final : public QObject {
   Q_PROPERTY(double longitude READ longitude CONSTANT)
 
  public:
-
   ServerCity();
   ServerCity(const ServerCity& other);
   ServerCity& operator=(const ServerCity& other);

--- a/src/models/servercountry.cpp
+++ b/src/models/servercountry.cpp
@@ -58,7 +58,7 @@ bool ServerCountry::fromJson(const QJsonObject& countryObj) {
     QJsonObject cityObject = cityValue.toObject();
 
     ServerCity serverCity;
-    if (!serverCity.fromJson(cityObject)) {
+    if (!serverCity.fromJson(cityObject, countryCode.toString())) {
       return false;
     }
 

--- a/src/models/servercountrymodel.cpp
+++ b/src/models/servercountrymodel.cpp
@@ -56,6 +56,7 @@ bool ServerCountryModel::fromJson(const QByteArray& s) {
   }
 
   m_rawJson = s;
+  emit changed();
   return true;
 }
 

--- a/src/models/servercountrymodel.cpp
+++ b/src/models/servercountrymodel.cpp
@@ -199,17 +199,15 @@ int ServerCountryModel::cityConnectionScore(const ServerCity& city) const {
 
   // Otherwise, return a score depending on the average latency.
   avgLatencyMsec /= activeServerCount;
-  logger.debug() << "Server data" << city.code() << avgLatencyMsec << activeServerCount;
+  logger.debug() << "Server data" << city.code() << avgLatencyMsec
+                 << activeServerCount;
   if (avgLatencyMsec < 50) {
     return 4; // Great!
-  }
-  else if (avgLatencyMsec < 100) {
+  } else if (avgLatencyMsec < 100) {
     return 3; // Acceptable
-  }
-  else if (avgLatencyMsec < 200) {
+  } else if (avgLatencyMsec < 200) {
     return 2; // Poor
-  }
-  else {
+  } else {
     return 1; // Really Bad!
   }
 }

--- a/src/models/servercountrymodel.cpp
+++ b/src/models/servercountrymodel.cpp
@@ -195,28 +195,28 @@ int ServerCountryModel::cityConnectionScore(const ServerCity& city) const {
 
   // If there are no reachable servers, then return a negative score.
   if (activeServerCount == 0) {
-    return -1;
+    return Unavailable;
   }
 
   // If the feature is disabled, return a score of zero, to indicate
   // that we have no data to report.
   if (!Feature::get(Feature::Feature_serverConnectionScore)->isSupported()) {
-    return 0;
+    return NoData;
   }
   // In the unlikely event that the sum of the latencies is zero, then we
   // haven't actually measured anything and have nothing to report.
   if (avgLatencyMsec == 0) {
-    return 0;
+    return NoData;
   }
 
   // Otherwise, return a score depending on the average latency.
   avgLatencyMsec /= activeServerCount;
   if (avgLatencyMsec < 50) {
-    return 3;  // Great!
+    return Good;
   } else if (avgLatencyMsec < 100) {
-    return 2;  // Acceptable
+    return Moderate;
   } else {
-    return 1;  // Poor
+    return Poor;
   }
 }
 

--- a/src/models/servercountrymodel.cpp
+++ b/src/models/servercountrymodel.cpp
@@ -179,7 +179,6 @@ QVariant ServerCountryModel::data(const QModelIndex& index, int role) const {
   }
 }
 
-
 int ServerCountryModel::cityConnectionScore(const ServerCity& city) const {
   qint64 now = QDateTime::currentSecsSinceEpoch();
   int activeServerCount = 0;
@@ -202,13 +201,13 @@ int ServerCountryModel::cityConnectionScore(const ServerCity& city) const {
   logger.debug() << "Server data" << city.code() << avgLatencyMsec
                  << activeServerCount;
   if (avgLatencyMsec < 50) {
-    return 4; // Great!
+    return 4;  // Great!
   } else if (avgLatencyMsec < 100) {
-    return 3; // Acceptable
+    return 3;  // Acceptable
   } else if (avgLatencyMsec < 200) {
-    return 2; // Poor
+    return 2;  // Poor
   } else {
-    return 1; // Really Bad!
+    return 1;  // Really Bad!
   }
 }
 

--- a/src/models/servercountrymodel.cpp
+++ b/src/models/servercountrymodel.cpp
@@ -325,6 +325,13 @@ void ServerCountryModel::retranslate() {
   endResetModel();
 }
 
+void ServerCountryModel::setServerLatency(const QString& publicKey,
+                                          unsigned int msec) {
+  if (m_servers.contains(publicKey)) {
+    m_servers[publicKey].setLatency(msec);
+  }
+}
+
 void ServerCountryModel::setServerCooldown(const QString& publicKey,
                                            unsigned int duration) {
   if (m_servers.contains(publicKey)) {

--- a/src/models/servercountrymodel.h
+++ b/src/models/servercountrymodel.h
@@ -79,6 +79,7 @@ class ServerCountryModel final : public QAbstractListModel {
   [[nodiscard]] bool fromJsonInternal(const QByteArray& data);
 
   void sortCountries();
+  int cityConnectionScore(const ServerCity& city) const;
 
  private:
   QByteArray m_rawJson;

--- a/src/models/servercountrymodel.h
+++ b/src/models/servercountrymodel.h
@@ -59,6 +59,7 @@ class ServerCountryModel final : public QAbstractListModel {
   const QList<ServerCountry>& countries() const { return m_countries; }
 
   void retranslate();
+  void setServerLatency(const QString& publicKey, unsigned int msec);
   void setServerCooldown(const QString& publicKey, unsigned int duration);
   void setCooldownForAllServersInACity(const QString& countryCode,
                                        const QString& cityCode,

--- a/src/models/servercountrymodel.h
+++ b/src/models/servercountrymodel.h
@@ -75,6 +75,9 @@ class ServerCountryModel final : public QAbstractListModel {
 
   QVariant data(const QModelIndex& index, int role) const override;
 
+ signals:
+  void changed();
+
  private:
   [[nodiscard]] bool fromJsonInternal(const QByteArray& data);
 

--- a/src/models/servercountrymodel.h
+++ b/src/models/servercountrymodel.h
@@ -24,6 +24,7 @@ class ServerCountryModel final : public QAbstractListModel {
     CodeRole,
     CitiesRole,
   };
+
   enum ServerConnectionScores {
     Unavailable = -1,
     NoData = 0,
@@ -31,6 +32,7 @@ class ServerCountryModel final : public QAbstractListModel {
     Moderate = 2,
     Good = 3,
   };
+  Q_ENUM(ServerConnectionScores);
 
   ServerCountryModel();
   ~ServerCountryModel();
@@ -71,6 +73,9 @@ class ServerCountryModel final : public QAbstractListModel {
   void setCooldownForAllServersInACity(const QString& countryCode,
                                        const QString& cityCode,
                                        unsigned int duration);
+
+  Q_INVOKABLE int cityConnectionScore(const QString& countryCode,
+                                      const QString& cityCode) const;
 
   // QAbstractListModel methods
 

--- a/src/models/servercountrymodel.h
+++ b/src/models/servercountrymodel.h
@@ -24,6 +24,13 @@ class ServerCountryModel final : public QAbstractListModel {
     CodeRole,
     CitiesRole,
   };
+  enum ServerConnectionScores {
+    Unavailable = -1,
+    NoData = 0,
+    Poor = 1,
+    Moderate = 2,
+    Good = 3,
+  };
 
   ServerCountryModel();
   ~ServerCountryModel();

--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -33,6 +33,7 @@
 #include "tasks/getfeaturelist/taskgetfeaturelist.h"
 #include "tasks/group/taskgroup.h"
 #include "tasks/heartbeat/taskheartbeat.h"
+#include "tasks/latency/tasklatency.h"
 #include "tasks/products/taskproducts.h"
 #include "tasks/removedevice/taskremovedevice.h"
 #include "tasks/sendfeedback/tasksendfeedback.h"
@@ -341,6 +342,7 @@ void MozillaVPN::initialize() {
   }
 
   TaskScheduler::scheduleTask(new TaskGroup(refreshTasks));
+  TaskScheduler::scheduleTask(new TaskLatency());
 
   setUserState(UserAuthenticated);
   maybeStateMain();

--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -229,6 +229,8 @@ void MozillaVPN::initialize() {
 
   m_private->m_ipAddressLookup.initialize();
 
+  m_private->m_serverLatency.initialize();
+
   if (Feature::get(Feature::Feature_websocket)->isSupported()) {
     m_private->m_webSocketHandler.initialize();
   }
@@ -342,7 +344,6 @@ void MozillaVPN::initialize() {
   }
 
   TaskScheduler::scheduleTask(new TaskGroup(refreshTasks));
-  TaskScheduler::scheduleTask(new TaskLatency());
 
   setUserState(UserAuthenticated);
   maybeStateMain();
@@ -678,6 +679,9 @@ void MozillaVPN::serversFetched(const QByteArray& serverData) {
     Q_ASSERT(m_private->m_serverData.initialized());
     m_private->m_serverData.writeSettings();
   }
+
+  // After fetching the servers, schedule a refresh of the latency data.
+  m_private->m_serverLatency.start();
 }
 
 void MozillaVPN::deviceRemovalCompleted(const QString& publicKey) {

--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -678,9 +678,6 @@ void MozillaVPN::serversFetched(const QByteArray& serverData) {
     Q_ASSERT(m_private->m_serverData.initialized());
     m_private->m_serverData.writeSettings();
   }
-
-  // After fetching the servers, schedule a refresh of the latency data.
-  m_private->m_serverLatency.start();
 }
 
 void MozillaVPN::deviceRemovalCompleted(const QString& publicKey) {

--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -33,7 +33,6 @@
 #include "tasks/getfeaturelist/taskgetfeaturelist.h"
 #include "tasks/group/taskgroup.h"
 #include "tasks/heartbeat/taskheartbeat.h"
-#include "tasks/latency/tasklatency.h"
 #include "tasks/products/taskproducts.h"
 #include "tasks/removedevice/taskremovedevice.h"
 #include "tasks/sendfeedback/tasksendfeedback.h"

--- a/src/mozillavpn.h
+++ b/src/mozillavpn.h
@@ -26,6 +26,7 @@
 #include "networkwatcher.h"
 #include "profileflow.h"
 #include "releasemonitor.h"
+#include "serverlatency.h"
 #include "statusicon.h"
 #include "telemetry.h"
 #include "theme.h"
@@ -363,6 +364,7 @@ class MozillaVPN final : public QObject {
     ReleaseMonitor m_releaseMonitor;
     ServerCountryModel m_serverCountryModel;
     ServerData m_serverData;
+    ServerLatency m_serverLatency;
     StatusIcon m_statusIcon;
     SubscriptionData m_subscriptionData;
     ProfileFlow m_profileFlow;

--- a/src/platforms/linux/linuxpingsender.cpp
+++ b/src/platforms/linux/linuxpingsender.cpp
@@ -75,7 +75,10 @@ LinuxPingSender::LinuxPingSender(const QHostAddress& source, QObject* parent)
     return;
   }
 
-  quint32 ipv4addr = source.toIPv4Address();
+  quint32 ipv4addr = INADDR_ANY;
+  if (!source.isNull()) {
+    ipv4addr = source.toIPv4Address();
+  }
   struct sockaddr_in addr;
   memset(&addr, 0, sizeof addr);
   addr.sin_family = AF_INET;

--- a/src/platforms/macos/macospingsender.cpp
+++ b/src/platforms/macos/macospingsender.cpp
@@ -40,7 +40,10 @@ MacOSPingSender::MacOSPingSender(const QHostAddress& source, QObject* parent)
     return;
   }
 
-  quint32 ipv4addr = source.toIPv4Address();
+  quint32 ipv4addr = INADDR_ANY;
+  if (!source.isNull()) {
+    ipv4addr = source.toIPv4Address();
+  }
   struct sockaddr_in addr;
   bzero(&addr, sizeof(addr));
   addr.sin_family = AF_INET;

--- a/src/platforms/windows/windowspingsender.cpp
+++ b/src/platforms/windows/windowspingsender.cpp
@@ -61,13 +61,19 @@ void WindowsPingSender::sendPing(const QHostAddress& dest, quint16 sequence) {
     return;
   }
 
-  quint32 v4src = m_source.toIPv4Address();
   quint32 v4dst = dest.toIPv4Address();
-  IcmpSendEcho2Ex(m_handle, m_event, nullptr, nullptr,
-                  qToBigEndian<quint32>(v4src), qToBigEndian<quint32>(v4dst),
-                  &sequence, sizeof(sequence), nullptr, m_buffer,
-                  sizeof(m_buffer), 10000);
-
+  if (m_source.isNull()) {
+    IcmpSendEcho2(m_handle, m_event, nullptr, nullptr,
+                  qToBigEndian<quint32>(v4dst), &sequence, sizeof(sequence),
+                  nullptr, m_buffer, sizeof(m_buffer), 10000);
+  } else {
+    quint32 v4src = m_source.toIPv4Address();
+    IcmpSendEcho2Ex(m_handle, m_event, nullptr, nullptr,
+                    qToBigEndian<quint32>(v4src), qToBigEndian<quint32>(v4dst),
+                    &sequence, sizeof(sequence), nullptr, m_buffer,
+                    sizeof(m_buffer), 10000);
+  }
+  
   DWORD status = GetLastError();
   if (status != ERROR_IO_PENDING) {
     QString errmsg = WindowsCommons::getErrorMessage();

--- a/src/platforms/windows/windowspingsender.cpp
+++ b/src/platforms/windows/windowspingsender.cpp
@@ -73,7 +73,7 @@ void WindowsPingSender::sendPing(const QHostAddress& dest, quint16 sequence) {
                     &sequence, sizeof(sequence), nullptr, m_buffer,
                     sizeof(m_buffer), 10000);
   }
-  
+
   DWORD status = GetLastError();
   if (status != ERROR_IO_PENDING) {
     QString errmsg = WindowsCommons::getErrorMessage();

--- a/src/qmake/sources.pri
+++ b/src/qmake/sources.pri
@@ -151,6 +151,7 @@ SOURCES += \
         tasks/group/taskgroup.cpp \
         tasks/heartbeat/taskheartbeat.cpp \
         tasks/ipfinder/taskipfinder.cpp \
+        tasks/latency/tasklatency.cpp \
         tasks/products/taskproducts.cpp \
         tasks/release/taskrelease.cpp \
         tasks/removedevice/taskremovedevice.cpp \
@@ -324,6 +325,7 @@ HEADERS += \
         tasks/group/taskgroup.h \
         tasks/heartbeat/taskheartbeat.h \
         tasks/ipfinder/taskipfinder.h \
+        tasks/latency/tasklatency.h \
         tasks/products/taskproducts.h \
         tasks/release/taskrelease.h \
         tasks/removedevice/taskremovedevice.h \

--- a/src/qmake/sources.pri
+++ b/src/qmake/sources.pri
@@ -132,6 +132,7 @@ SOURCES += \
         rfc/rfc4291.cpp \
         rfc/rfc5735.cpp \
         serveri18n.cpp \
+        serverlatency.cpp \
         settingsholder.cpp \
         signature.cpp \
         simplenetworkmanager.cpp \
@@ -151,7 +152,6 @@ SOURCES += \
         tasks/group/taskgroup.cpp \
         tasks/heartbeat/taskheartbeat.cpp \
         tasks/ipfinder/taskipfinder.cpp \
-        tasks/latency/tasklatency.cpp \
         tasks/products/taskproducts.cpp \
         tasks/release/taskrelease.cpp \
         tasks/removedevice/taskremovedevice.cpp \
@@ -305,6 +305,7 @@ HEADERS += \
         rfc/rfc4291.h \
         rfc/rfc5735.h \
         serveri18n.h \
+        serverlatency.h \
         settingsholder.h \
         signature.h \
         simplenetworkmanager.h \
@@ -325,7 +326,6 @@ HEADERS += \
         tasks/group/taskgroup.h \
         tasks/heartbeat/taskheartbeat.h \
         tasks/ipfinder/taskipfinder.h \
-        tasks/latency/tasklatency.h \
         tasks/products/taskproducts.h \
         tasks/release/taskrelease.h \
         tasks/removedevice/taskremovedevice.h \

--- a/src/serverlatency.cpp
+++ b/src/serverlatency.cpp
@@ -73,8 +73,7 @@ void ServerLatency::stateChanged() {
   if (state != Controller::StateOff) {
     // If the VPN is active, then do not attempt to measure the server latency.
     stop();
-  }
-  else if (m_wantRefresh) {
+  } else if (m_wantRefresh) {
     // If the VPN has been deactivated, start a refresh if desired.
     start();
   }
@@ -89,7 +88,8 @@ void ServerLatency::recvPing(quint16 sequence) {
 
   ServerCountryModel* scm = MozillaVPN::instance()->serverCountryModel();
   quint64 latency = QDateTime::currentMSecsSinceEpoch() - record.timestamp;
-  logger.debug() << "Server" << logger.keys(record.publicKey) << "latency" << latency << "msec";
+  logger.debug() << "Server" << logger.keys(record.publicKey) << "latency"
+                 << latency << "msec";
   scm->setServerLatency(record.publicKey, latency);
 
   if (m_pingReplyList.isEmpty()) {

--- a/src/serverlatency.cpp
+++ b/src/serverlatency.cpp
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#include "tasklatency.h"
+#include "serverlatency.h"
 #include "leakdetector.h"
 #include "logger.h"
 #include "mozillavpn.h"
@@ -13,27 +13,35 @@
 constexpr const uint32_t SERVER_LATENCY_TIMEOUT_MSEC = 5000;
 
 namespace {
-Logger logger(LOG_MAIN, "TaskLatency");
+Logger logger(LOG_MAIN, "ServerLatency");
 }
 
-TaskLatency::TaskLatency() : Task("TaskLatency") {
-  MVPN_COUNT_CTOR(TaskLatency);
+ServerLatency::ServerLatency() { MVPN_COUNT_CTOR(ServerLatency); }
+
+ServerLatency::~ServerLatency() { MVPN_COUNT_DTOR(ServerLatency); }
+
+void ServerLatency::initialize() {
+  MozillaVPN* vpn = MozillaVPN::instance();
+  connect(vpn->controller(), &Controller::stateChanged, this,
+          &ServerLatency::stateChanged);
 }
 
-TaskLatency::~TaskLatency() { MVPN_COUNT_DTOR(TaskLatency); }
+void ServerLatency::start() {
+  MozillaVPN* vpn = MozillaVPN::instance();
+  if (vpn->controller()->state() != Controller::StateOff) {
+    m_wantRefresh = true;
+    return;
+  }
 
-void TaskLatency::run() {
+  m_wantRefresh = false;
   m_pingSender = PingSenderFactory::create(QHostAddress(), this);
-  ServerCountryModel* scm = MozillaVPN::instance()->serverCountryModel();
+  ServerCountryModel* scm = vpn->serverCountryModel();
 
   connect(m_pingSender, SIGNAL(recvPing(quint16)), this,
           SLOT(recvPing(quint16)));
   connect(m_pingSender, SIGNAL(criticalPingError()), this,
           SLOT(criticalPingError()));
-  connect(&m_timeout, &QTimer::timeout, this, [&] {
-    m_pingReplyList.clear();
-    emit completed();
-  });
+  connect(&m_timeout, &QTimer::timeout, this, &ServerLatency::stop);
 
   // Send a ping to every server.
   quint16 seq = 1;
@@ -47,10 +55,30 @@ void TaskLatency::run() {
     seq++;
   }
 
-    m_timeout.start(SERVER_LATENCY_TIMEOUT_MSEC);
+  m_timeout.start(SERVER_LATENCY_TIMEOUT_MSEC);
 }
 
-void TaskLatency::recvPing(quint16 sequence) {
+void ServerLatency::stop() {
+  m_timeout.stop();
+  m_pingReplyList.clear();
+
+  delete m_pingSender;
+  m_pingSender = nullptr;
+}
+
+void ServerLatency::stateChanged() {
+  Controller::State state = MozillaVPN::instance()->controller()->state();
+  if (state != Controller::StateOff) {
+    // If the VPN is active, then do not attempt to measure the server latency.
+    stop();
+  }
+  else if (m_wantRefresh) {
+    // If the VPN has been deactivated, start a refresh if desired.
+    start();
+  }
+}
+
+void ServerLatency::recvPing(quint16 sequence) {
   ServerPingRecord record = m_pingReplyList.take(sequence);
   if (record.publicKey.isEmpty()) {
     // We didn't expect this ping reply.
@@ -63,10 +91,10 @@ void TaskLatency::recvPing(quint16 sequence) {
   scm->setServerLatency(record.publicKey, latency);
 
   if (m_pingReplyList.isEmpty()) {
-    emit completed();
+    stop();
   }
 }
 
-void TaskLatency::criticalPingError() {
+void ServerLatency::criticalPingError() {
   logger.info() << "Encountered Unrecoverable ping error";
 }

--- a/src/serverlatency.cpp
+++ b/src/serverlatency.cpp
@@ -5,6 +5,7 @@
 #include "serverlatency.h"
 #include "leakdetector.h"
 #include "logger.h"
+#include "models/feature.h"
 #include "mozillavpn.h"
 #include "pingsenderfactory.h"
 
@@ -44,6 +45,10 @@ void ServerLatency::initialize() {
 }
 
 void ServerLatency::start() {
+  if (!Feature::get(Feature::Feature_serverConnectionScore)->isSupported()) {
+    return;
+  }
+
   MozillaVPN* vpn = MozillaVPN::instance();
   if (vpn->controller()->state() != Controller::StateOff) {
     // Don't attempt to refresh latency when the VPN is active, or

--- a/src/serverlatency.cpp
+++ b/src/serverlatency.cpp
@@ -35,7 +35,9 @@ void ServerLatency::initialize() {
   connect(vpn->controller(), &Controller::stateChanged, this,
           &ServerLatency::stateChanged);
 
-  connect(&m_pingTimeout, &QTimer::timeout, this, &ServerLatency::maybeSendPings);
+  connect(&m_pingTimeout, &QTimer::timeout, this,
+          &ServerLatency::maybeSendPings);
+
   connect(&m_refreshTimer, &QTimer::timeout, this, &ServerLatency::start);
 
   m_refreshTimer.start(SERVER_LATENCY_INITIAL_MSEC);

--- a/src/serverlatency.cpp
+++ b/src/serverlatency.cpp
@@ -62,8 +62,10 @@ void ServerLatency::stop() {
   m_timeout.stop();
   m_pingReplyList.clear();
 
-  delete m_pingSender;
-  m_pingSender = nullptr;
+  if (m_pingSender) {
+    delete m_pingSender;
+    m_pingSender = nullptr;
+  }
 }
 
 void ServerLatency::stateChanged() {

--- a/src/serverlatency.h
+++ b/src/serverlatency.h
@@ -37,7 +37,8 @@ class ServerLatency final : public QObject {
   QList<QString> m_pingSendQueue;
   QList<ServerPingRecord> m_pingReplyList;
 
-  QTimer m_timeout;
+  QTimer m_pingTimeout;
+  QTimer m_refreshTimer;
   bool m_wantRefresh = false;
 
  private slots:

--- a/src/serverlatency.h
+++ b/src/serverlatency.h
@@ -2,8 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#ifndef TASKLATENCY_H
-#define TASKLATENCY_H
+#ifndef SERVERLATENCY_H
+#define SERVERLATENCY_H
 
 #include "pingsender.h"
 #include "task.h"
@@ -11,15 +11,17 @@
 #include <QObject>
 #include <QTimer>
 
-class TaskLatency final : public Task {
+class ServerLatency final : public QObject {
   Q_OBJECT
-  Q_DISABLE_COPY_MOVE(TaskLatency)
+  Q_DISABLE_COPY_MOVE(ServerLatency)
 
  public:
-  TaskLatency();
-  ~TaskLatency();
+  ServerLatency();
+  ~ServerLatency();
 
-  void run() override;
+  void initialize();
+  void start();
+  void stop();
 
  private:
   struct ServerPingRecord {
@@ -29,10 +31,12 @@ class TaskLatency final : public Task {
   PingSender* m_pingSender = nullptr;
   QMap<int, ServerPingRecord> m_pingReplyList;
   QTimer m_timeout;
+  bool m_wantRefresh = false;
 
  private slots:
+  void stateChanged();
   void recvPing(quint16 sequence);
   void criticalPingError();
 };
 
-#endif  // TASKLATENCY_H
+#endif  // SERVERLATENCY_H

--- a/src/serverlatency.h
+++ b/src/serverlatency.h
@@ -31,6 +31,7 @@ class ServerLatency final : public QObject {
     QString publicKey;
     quint64 timestamp;
     quint16 sequence;
+    int retries;
   };
   quint16 m_sequence = 0;
   PingSender* m_pingSender = nullptr;

--- a/src/serverlatency.h
+++ b/src/serverlatency.h
@@ -24,12 +24,19 @@ class ServerLatency final : public QObject {
   void stop();
 
  private:
+  void maybeSendPings();
+
+ private:
   struct ServerPingRecord {
     QString publicKey;
     quint64 timestamp;
+    quint16 sequence;
   };
+  quint16 m_sequence = 0;
   PingSender* m_pingSender = nullptr;
-  QMap<int, ServerPingRecord> m_pingReplyList;
+  QList<QString> m_pingSendQueue;
+  QList<ServerPingRecord> m_pingReplyList;
+
   QTimer m_timeout;
   bool m_wantRefresh = false;
 

--- a/src/tasks/latency/tasklatency.cpp
+++ b/src/tasks/latency/tasklatency.cpp
@@ -59,6 +59,7 @@ void TaskLatency::recvPing(quint16 sequence) {
 
   ServerCountryModel* scm = MozillaVPN::instance()->serverCountryModel();
   quint64 latency = QDateTime::currentMSecsSinceEpoch() - record.timestamp;
+  logger.debug() << "Server" << logger.keys(record.publicKey) << "latency" << latency << "msec";
   scm->setServerLatency(record.publicKey, latency);
 
   if (m_pingReplyList.isEmpty()) {

--- a/src/tasks/latency/tasklatency.cpp
+++ b/src/tasks/latency/tasklatency.cpp
@@ -1,0 +1,71 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "tasklatency.h"
+#include "leakdetector.h"
+#include "logger.h"
+#include "mozillavpn.h"
+#include "pingsenderfactory.h"
+
+#include <QDateTime>
+
+constexpr const uint32_t SERVER_LATENCY_TIMEOUT_MSEC = 5000;
+
+namespace {
+Logger logger(LOG_MAIN, "TaskLatency");
+}
+
+TaskLatency::TaskLatency() : Task("TaskLatency") {
+  MVPN_COUNT_CTOR(TaskLatency);
+}
+
+TaskLatency::~TaskLatency() { MVPN_COUNT_DTOR(TaskLatency); }
+
+void TaskLatency::run() {
+  m_pingSender = PingSenderFactory::create(QHostAddress(), this);
+  ServerCountryModel* scm = MozillaVPN::instance()->serverCountryModel();
+
+  connect(m_pingSender, SIGNAL(recvPing(quint16)), this,
+          SLOT(recvPing(quint16)));
+  connect(m_pingSender, SIGNAL(criticalPingError()), this,
+          SLOT(criticalPingError()));
+  connect(&m_timeout, &QTimer::timeout, this, [&] {
+    m_pingReplyList.clear();
+    emit completed();
+  });
+
+  // Send a ping to every server.
+  quint16 seq = 1;
+  for (const Server& server : scm->servers()) {
+    m_pingSender->sendPing(QHostAddress(server.ipv4AddrIn()), seq);
+
+    ServerPingRecord record;
+    record.publicKey = server.publicKey();
+    record.timestamp = QDateTime::currentMSecsSinceEpoch();
+    m_pingReplyList[seq] = record;
+    seq++;
+  }
+
+    m_timeout.start(SERVER_LATENCY_TIMEOUT_MSEC);
+}
+
+void TaskLatency::recvPing(quint16 sequence) {
+  ServerPingRecord record = m_pingReplyList.take(sequence);
+  if (record.publicKey.isEmpty()) {
+    // We didn't expect this ping reply.
+    return;
+  }
+
+  ServerCountryModel* scm = MozillaVPN::instance()->serverCountryModel();
+  quint64 latency = QDateTime::currentMSecsSinceEpoch() - record.timestamp;
+  scm->setServerLatency(record.publicKey, latency);
+
+  if (m_pingReplyList.isEmpty()) {
+    emit completed();
+  }
+}
+
+void TaskLatency::criticalPingError() {
+  logger.info() << "Encountered Unrecoverable ping error";
+}

--- a/src/tasks/latency/tasklatency.h
+++ b/src/tasks/latency/tasklatency.h
@@ -1,0 +1,38 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef TASKLATENCY_H
+#define TASKLATENCY_H
+
+#include "pingsender.h"
+#include "task.h"
+
+#include <QObject>
+#include <QTimer>
+
+class TaskLatency final : public Task {
+  Q_OBJECT
+  Q_DISABLE_COPY_MOVE(TaskLatency)
+
+ public:
+  TaskLatency();
+  ~TaskLatency();
+
+  void run() override;
+
+ private:
+  struct ServerPingRecord {
+    QString publicKey;
+    quint64 timestamp;
+  };
+  PingSender* m_pingSender = nullptr;
+  QMap<int, ServerPingRecord> m_pingReplyList;
+  QTimer m_timeout;
+
+ private slots:
+  void recvPing(quint16 sequence);
+  void criticalPingError();
+};
+
+#endif  // TASKLATENCY_H

--- a/tests/unit/testmodels.cpp
+++ b/tests/unit/testmodels.cpp
@@ -1010,7 +1010,7 @@ void TestModels::serverCountryModelFromJson_data() {
       << QJsonDocument(obj).toJson() << true << 1
       << QVariant("serverCountryName") << QVariant("serverCountryCode")
       << QVariant(QList<QVariant>{
-             QStringList{"serverCityName", "serverCityName", "1"}});
+             QStringList{"serverCityName", "serverCityName", "4"}});
 
   cities.append(city);
   d.insert("cities", cities);
@@ -1020,7 +1020,7 @@ void TestModels::serverCountryModelFromJson_data() {
       << QJsonDocument(obj).toJson() << true << 2
       << QVariant("serverCountryName") << QVariant("serverCountryCode")
       << QVariant(QList<QVariant>{
-             QStringList{"serverCityName", "serverCityName", "1"}});
+             QStringList{"serverCityName", "serverCityName", "4"}});
 }
 
 void TestModels::serverCountryModelFromJson() {

--- a/tests/unit/testmodels.cpp
+++ b/tests/unit/testmodels.cpp
@@ -802,10 +802,11 @@ void TestModels::serverCityFromJson() {
   QFETCH(bool, result);
 
   ServerCity sc;
-  QCOMPARE(sc.fromJson(json), result);
+  QCOMPARE(sc.fromJson(json, "test"), result);
   if (!result) {
     QCOMPARE(sc.name(), "");
     QCOMPARE(sc.code(), "");
+    QCOMPARE(sc.country(), "");
     QVERIFY(sc.servers().isEmpty());
     return;
   }
@@ -1010,7 +1011,7 @@ void TestModels::serverCountryModelFromJson_data() {
       << QJsonDocument(obj).toJson() << true << 1
       << QVariant("serverCountryName") << QVariant("serverCountryCode")
       << QVariant(QList<QVariant>{
-             QStringList{"serverCityName", "serverCityName", "4"}});
+             QStringList{"serverCityName", "serverCityName"}});
 
   cities.append(city);
   d.insert("cities", cities);
@@ -1020,7 +1021,7 @@ void TestModels::serverCountryModelFromJson_data() {
       << QJsonDocument(obj).toJson() << true << 2
       << QVariant("serverCountryName") << QVariant("serverCountryCode")
       << QVariant(QList<QVariant>{
-             QStringList{"serverCityName", "serverCityName", "4"}});
+             QStringList{"serverCityName", "serverCityName"}});
 }
 
 void TestModels::serverCountryModelFromJson() {
@@ -1062,8 +1063,12 @@ void TestModels::serverCountryModelFromJson() {
         QVariant cityData = m.data(index, ServerCountryModel::CitiesRole);
         QCOMPARE(cityData.typeId(), QVariant::List);
         QCOMPARE(cities.toList().length(), cityData.toList().length());
-        if (!cities.toList().isEmpty()) {
-          QCOMPARE(m.data(index, ServerCountryModel::CitiesRole), cities);
+        for (int i = 0; i < cities.toList().length(); i++) {
+          QVERIFY(cityData.toList().at(0).canConvert<ServerCity*>());
+          ServerCity* cityObj = cityData.toList().at(i).value<ServerCity*>();
+          QStringList cityList = cities.toList().at(i).toStringList();
+          QCOMPARE(cityObj->name(), cityList.at(0));
+          QCOMPARE(cityObj->localizedName(), cityList.at(1));
         }
 
         QCOMPARE(m.countryName(code.toString()), name.toString());
@@ -1107,7 +1112,16 @@ void TestModels::serverCountryModelFromJson() {
         QCOMPARE(m.data(index, ServerCountryModel::CodeRole), code);
 
         QFETCH(QVariant, cities);
-        QCOMPARE(m.data(index, ServerCountryModel::CitiesRole), cities);
+        QVariant cityData = m.data(index, ServerCountryModel::CitiesRole);
+        QCOMPARE(cityData.typeId(), QVariant::List);
+        QCOMPARE(cities.toList().length(), cityData.toList().length());
+        for (int i = 0; i < cities.toList().length(); i++) {
+          QVERIFY(cityData.toList().at(0).canConvert<ServerCity*>());
+          ServerCity* cityObj = cityData.toList().at(i).value<ServerCity*>();
+          QStringList cityList = cities.toList().at(i).toStringList();
+          QCOMPARE(cityObj->name(), cityList.at(0));
+          QCOMPARE(cityObj->localizedName(), cityList.at(1));
+        }
 
         QCOMPARE(m.data(index, ServerCountryModel::CitiesRole + 1), QVariant());
 
@@ -1229,7 +1243,7 @@ void TestModels::serverDataBasic() {
     cityObj.insert("servers", QJsonArray());
 
     ServerCity city;
-    QVERIFY(city.fromJson(cityObj));
+    QVERIFY(city.fromJson(cityObj, "serverCountryCode"));
 
     sd.update(country.code(), city.name());
     QCOMPARE(spy.count(), 1);

--- a/tests/unit/testmodels.cpp
+++ b/tests/unit/testmodels.cpp
@@ -1010,8 +1010,8 @@ void TestModels::serverCountryModelFromJson_data() {
   QTest::addRow("good with one city")
       << QJsonDocument(obj).toJson() << true << 1
       << QVariant("serverCountryName") << QVariant("serverCountryCode")
-      << QVariant(QList<QVariant>{
-             QStringList{"serverCityName", "serverCityName"}});
+      << QVariant(
+             QList<QVariant>{QStringList{"serverCityName", "serverCityName"}});
 
   cities.append(city);
   d.insert("cities", cities);
@@ -1020,8 +1020,8 @@ void TestModels::serverCountryModelFromJson_data() {
   QTest::addRow("good with two cities")
       << QJsonDocument(obj).toJson() << true << 2
       << QVariant("serverCountryName") << QVariant("serverCountryCode")
-      << QVariant(QList<QVariant>{
-             QStringList{"serverCityName", "serverCityName"}});
+      << QVariant(
+             QList<QVariant>{QStringList{"serverCityName", "serverCityName"}});
 }
 
 void TestModels::serverCountryModelFromJson() {


### PR DESCRIPTION
## Description
This adds storage of server latency data into the `Server` class, and adds a mechanism to refresh the server latency information whenever we update the server list, and then display that latency data to the user through a wifi with a variable number of bars.

## Reference
JIRA: [VPN-2526](https://mozilla-hub.atlassian.net/browse/VPN-2526)

## Checklist

- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
