### PR TITLE
BUGFIX: Stop ping timer once websocket is closed

### DIFF
--- a/src/websocket/websockethandler.cpp
+++ b/src/websocket/websockethandler.cpp
@@ -189,6 +189,7 @@ void WebSocketHandler::close() {
 void WebSocketHandler::onClose() {
   // https://doc.qt.io/qt-6/qwebsocketprotocol.html#CloseCode-enum
   logger.debug() << "WebSocket closed:" << m_webSocket.closeCode();
+  m_pingTimer.stop();
 
   if (isUserAuthenticated()) {
     int nextAttemptIn = m_backoffStrategy.scheduleNextAttempt();


### PR DESCRIPTION
There is no point in leaving the timer going once the websocket is closed. This is not a critical bug it is just superfluous execution of code, but didn't do real harm to the functionality. Either way, should be fixed so here is the fix.

No bug for this one, just saw it and fixed it. A test would be way too complicated to justify, so no test.