### PR TITLE
Interrupt tutorials on Get help clicks

### DIFF
--- a/src/externalophandler.cpp
+++ b/src/externalophandler.cpp
@@ -69,7 +69,7 @@ void ExternalOpHandler::request(Op op) {
       vpn->controller()->deactivate();
       break;
     case OpGetHelp:
-      Navigator::instance()->requestScreen(Navigator::ScreenGetHelp);
+      vpn->requestGetHelp();
       break;
     case OpSettings:
       vpn->requestSettings();

--- a/src/externalophandler.cpp
+++ b/src/externalophandler.cpp
@@ -6,6 +6,7 @@
 #include "leakdetector.h"
 #include "logger.h"
 #include "mozillavpn.h"
+#include "navigator.h"
 
 #include <QCoreApplication>
 
@@ -66,6 +67,9 @@ void ExternalOpHandler::request(Op op) {
       break;
     case OpDeactivate:
       vpn->controller()->deactivate();
+      break;
+    case OpGetHelp:
+      Navigator::instance()->requestScreen(Navigator::ScreenGetHelp);
       break;
     case OpSettings:
       vpn->requestSettings();

--- a/src/externalophandler.cpp
+++ b/src/externalophandler.cpp
@@ -6,7 +6,7 @@
 #include "leakdetector.h"
 #include "logger.h"
 #include "mozillavpn.h"
-#include "navigator.h"
+#include "frontend/navigator.h"
 
 #include <QCoreApplication>
 

--- a/src/externalophandler.h
+++ b/src/externalophandler.h
@@ -17,6 +17,7 @@ class ExternalOpHandler final : public QObject {
     OpActivate,
     OpCloseEvent,
     OpDeactivate,
+    OpGetHelp,
     OpNotificationClicked,
     OpSettings,
     OpQuit,
@@ -33,6 +34,7 @@ class ExternalOpHandler final : public QObject {
   void request(Op op);
   void requestOpActivate() { return request(OpActivate); }
   void requestOpDeactivate() { return request(OpDeactivate); }
+  void requestOpGetHelp() { return request(OpGetHelp); }
   void requestOpSettings() { return request(OpSettings); }
   void requestOpQuit() { return request(OpQuit); }
 

--- a/src/externalophandler.h
+++ b/src/externalophandler.h
@@ -34,7 +34,6 @@ class ExternalOpHandler final : public QObject {
   void request(Op op);
   void requestOpActivate() { return request(OpActivate); }
   void requestOpDeactivate() { return request(OpDeactivate); }
-  void requestOpGetHelp() { return request(OpGetHelp); }
   void requestOpSettings() { return request(OpSettings); }
   void requestOpQuit() { return request(OpQuit); }
 

--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -1450,6 +1450,13 @@ void MozillaVPN::requestAbout() {
   emit aboutNeeded();
 }
 
+void MozillaVPN::requestGetHelp() {
+  logger.debug() << "Get help menu requested";
+
+  QmlEngineHolder::instance()->showWindow();
+  Navigator::instance()->requestScreen(Navigator::ScreenGetHelp);
+}
+
 void MozillaVPN::requestViewLogs() {
   logger.debug() << "View log requested";
   emit viewLogsNeeded();

--- a/src/mozillavpn.h
+++ b/src/mozillavpn.h
@@ -398,6 +398,7 @@ class MozillaVPN final : public QObject {
  public slots:
   void requestSettings();
   void requestAbout();
+  void requestGetHelp();
 
  signals:
   void stateChanged();

--- a/src/platforms/macos/macosmenubar.cpp
+++ b/src/platforms/macos/macosmenubar.cpp
@@ -107,6 +107,6 @@ void MacOSMenuBar::retranslate() {
   Q_ASSERT(l18nStrings);
 
   m_helpMenu->addAction(l18nStrings->t(L18nStrings::SystrayGetHelp), []() {
-    Navigator::instance()->requestScreen(Navigator::ScreenGetHelp);
+    ExternalOpHandler::instance()->request(ExternalOpHandler::OpGetHelp);
   });
 }

--- a/src/systemtraynotificationhandler.cpp
+++ b/src/systemtraynotificationhandler.cpp
@@ -118,7 +118,7 @@ void SystemTrayNotificationHandler::retranslate() {
   }
 
   m_helpMenu->addAction(l18nStrings->t(L18nStrings::SystrayGetHelp), []() {
-    Navigator::instance()->requestScreen(Navigator::ScreenGetHelp);
+    ExternalOpHandler::instance()->request(ExternalOpHandler::OpGetHelp);
   });
 
   m_preferencesAction->setText(l18nStrings->t(L18nStrings::SystrayPreferences));

--- a/tests/auth/mocmozillavpn.cpp
+++ b/tests/auth/mocmozillavpn.cpp
@@ -105,6 +105,8 @@ bool MozillaVPN::modelsInitialized() const { return true; }
 
 void MozillaVPN::requestSettings() {}
 
+void MozillaVPN::requestGetHelp() {}
+
 void MozillaVPN::requestAbout() {}
 
 void MozillaVPN::requestViewLogs() {}

--- a/tests/qml/mocmozillavpn.cpp
+++ b/tests/qml/mocmozillavpn.cpp
@@ -113,6 +113,8 @@ bool MozillaVPN::modelsInitialized() const { return true; }
 
 void MozillaVPN::requestSettings() {}
 
+void MozillaVPN::requestGetHelp() {}
+
 void MozillaVPN::requestAbout() {}
 
 void MozillaVPN::requestViewLogs() {}

--- a/tests/unit/mocmozillavpn.cpp
+++ b/tests/unit/mocmozillavpn.cpp
@@ -110,6 +110,8 @@ bool MozillaVPN::modelsInitialized() const { return true; }
 
 void MozillaVPN::requestSettings() {}
 
+void MozillaVPN::requestGetHelp() {}
+
 void MozillaVPN::requestAbout() {}
 
 void MozillaVPN::requestViewLogs() {}


### PR DESCRIPTION
## Description

This restores tutorial interruptions when Get help is opened from the systray/menu bar during a tutorial.

## Reference

#4247 / VPN-2731

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
