### PR TITLE
fix: use new worker-type names for MacOS dep signing pools

### DIFF
--- a/taskcluster/ci/config.yml
+++ b/taskcluster/ci/config.yml
@@ -79,7 +79,7 @@ workers:
             provisioner: scriptworker-prov-v1
             implementation: scriptworker-signing
             os: macosx
-            worker-type: mozillavpn-t-signing-mac
+            worker-type: vpn-depsigning-mac-v1
         macos-signing:
             provisioner: scriptworker-prov-v1
             implementation: scriptworker-signing
@@ -87,7 +87,7 @@ workers:
             worker-type:
                 by-level:
                     "3": mozillavpn-3-signing-mac
-                    default: mozillavpn-t-signing-mac
+                    default: vpn-depsigning-mac-v1
         push-apk:
             provisioner: scriptworker-k8s
             implementation: scriptworker-pushapk


### PR DESCRIPTION
## Description

The worker-type for MacOS signing changed awhile back but we never updated the definition in config.yml. So currently Mac signing tasks on level 1 (staging-mozilla-vpn-client or pull-requests) just time out as the configured pool doesn't have any workers.

## Checklist
    
- [ x ] My code follows the style guidelines for this project
- [ x ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ x ] I have performed a self review of my own code
- [ x ] I have commented my code PARTICULARLY in hard to understand areas
- [ x ] I have added thorough tests where needed
