### PR TITLE
Do a canary ping while connecting, pass info to the unavailable notification

### DIFF
--- a/nebula/ui/components/VPNServerUnavailablePopup.qml
+++ b/nebula/ui/components/VPNServerUnavailablePopup.qml
@@ -10,12 +10,14 @@ import Mozilla.VPN 1.0
 
 VPNSimplePopup {
     id: root
+    property bool recivedPing: false;
 
     anchors.centerIn: parent
     imageSrc: "qrc:/nebula/resources/server-unavailable.svg"
     imageSize: Qt.size(80, 80)
     title: VPNl18n.ServerUnavailableModalHeaderText
-    description: VPNl18n.ServerUnavailableModalBodyText
+    // In case the handshake failed but the ping succeeded - use the Firewall Error Message
+    description: recivedPing ? VPNl18n.ServerUnavailableNotificationBodyTextFireWallBlocked : VPNl18n.ServerUnavailableModalBodyText
     buttons: [
         VPNButton {
             text: VPNl18n.ServerUnavailableModalButtonLabel

--- a/nebula/ui/components/VPNServerUnavailablePopup.qml
+++ b/nebula/ui/components/VPNServerUnavailablePopup.qml
@@ -10,14 +10,14 @@ import Mozilla.VPN 1.0
 
 VPNSimplePopup {
     id: root
-    property bool recivedPing: false;
+    property bool receivedPing: false;
 
     anchors.centerIn: parent
     imageSrc: "qrc:/nebula/resources/server-unavailable.svg"
     imageSize: Qt.size(80, 80)
     title: VPNl18n.ServerUnavailableModalHeaderText
     // In case the handshake failed but the ping succeeded - use the Firewall Error Message
-    description: recivedPing ? VPNl18n.ServerUnavailableNotificationBodyTextFireWallBlocked : VPNl18n.ServerUnavailableModalBodyText
+    description: receivedPing ? VPNl18n.ServerUnavailableNotificationBodyTextFireWallBlocked : VPNl18n.ServerUnavailableModalBodyText
     buttons: [
         VPNButton {
             text: VPNl18n.ServerUnavailableModalButtonLabel

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -13,7 +13,6 @@
 #include "models/feature.h"
 #include "models/server.h"
 #include "mozillavpn.h"
-#include "pinghelper.h"
 #include "rfc/rfc1112.h"
 #include "rfc/rfc1918.h"
 #include "rfc/rfc4193.h"
@@ -125,7 +124,7 @@ void Controller::initialize() {
 
   connect(&m_ping_canary, &PingHelper::pingSentAndReceived, [this]() {
     m_ping_canary.stop();
-    m_ping_recieved = true;
+    m_ping_received = true;
     logger.info() << "Canary Ping Succeeded";
   });
 
@@ -281,7 +280,7 @@ void Controller::activateInternal() {
   }
 
   m_activationQueue.append(exitHop);
-  m_ping_recieved = false;
+  m_ping_received = false;
   m_ping_canary.start(m_activationQueue.first().m_server.ipv4AddrIn(),
                       "0.0.0.0/0");
   logger.info() << "Canary Ping Started";
@@ -600,8 +599,8 @@ bool Controller::processNextStep() {
   }
 
   if (nextStep == ServerUnavailable) {
-    logger.info() << "Server Unavailable - Ping succeeded: " << m_ping_recieved;
-    emit readyToServerUnavailable(m_ping_recieved);
+    logger.info() << "Server Unavailable - Ping succeeded: " << m_ping_received;
+    emit readyToServerUnavailable(m_ping_received);
     return true;
   }
 

--- a/src/controller.h
+++ b/src/controller.h
@@ -166,7 +166,7 @@ class Controller final : public QObject {
   QDateTime m_connectedTimeInUTC;
 
   PingHelper m_ping_canary;
-  bool m_ping_recieved = false;
+  bool m_ping_received = false;
 
   QScopedPointer<ControllerImpl> m_impl;
 

--- a/src/controller.h
+++ b/src/controller.h
@@ -7,6 +7,7 @@
 
 #include "models/server.h"
 #include "ipaddress.h"
+#include "pinghelper.h"
 
 #include <QElapsedTimer>
 #include <QHostAddress>
@@ -132,7 +133,7 @@ class Controller final : public QObject {
   void readyToQuit();
   void readyToUpdate();
   void readyToBackendFailure();
-  void readyToServerUnavailable();
+  void readyToServerUnavailable(bool pingReceived);
   void connectionRetryChanged();
   void enableDisconnectInConfirmingChanged();
   void silentSwitchDone();
@@ -163,6 +164,9 @@ class Controller final : public QObject {
   bool m_portalDetected = false;
 
   QDateTime m_connectedTimeInUTC;
+
+  PingHelper m_ping_canary;
+  bool m_ping_recieved = false;
 
   QScopedPointer<ControllerImpl> m_impl;
 

--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -140,8 +140,9 @@ MozillaVPN::MozillaVPN() : m_private(new Private()) {
           });
 
   connect(&m_private->m_controller, &Controller::readyToServerUnavailable, this,
-          []() {
-            NotificationHandler::instance()->serverUnavailableNotification();
+          [](bool pingReceived) {
+            NotificationHandler::instance()->serverUnavailableNotification(
+                pingReceived);
           });
 
   connect(&m_private->m_controller, &Controller::stateChanged, this,

--- a/src/notificationhandler.cpp
+++ b/src/notificationhandler.cpp
@@ -217,7 +217,7 @@ void NotificationHandler::unsecuredNetworkNotification(
                  Constants::UNSECURED_NETWORK_ALERT_MSEC);
 }
 
-void NotificationHandler::serverUnavailableNotification() {
+void NotificationHandler::serverUnavailableNotification(bool pingRecieved) {
   logger.debug() << "Server unavailable notification shown";
 
   if (!SettingsHolder::instance()->serverUnavailableNotification()) {
@@ -230,7 +230,11 @@ void NotificationHandler::serverUnavailableNotification() {
 
   QString title = l18nStrings->t(L18nStrings::ServerUnavailableModalHeaderText);
   QString message =
-      l18nStrings->t(L18nStrings::ServerUnavailableNotificationBodyText);
+      pingRecieved
+          ? l18nStrings->t(
+                L18nStrings::
+                    ServerUnavailableNotificationBodyTextFireWallBlocked)
+          : l18nStrings->t(L18nStrings::ServerUnavailableNotificationBodyText);
 
   notifyInternal(ServerUnavailable, title, message,
                  Constants::SERVER_UNAVAILABLE_ALERT_MSEC);

--- a/src/notificationhandler.h
+++ b/src/notificationhandler.h
@@ -33,7 +33,7 @@ class NotificationHandler : public QObject {
 
   void unsecuredNetworkNotification(const QString& networkName);
 
-  void serverUnavailableNotification();
+  void serverUnavailableNotification(bool pingRecieved);
 
   void showNotification();
 

--- a/src/ui/main.qml
+++ b/src/ui/main.qml
@@ -206,8 +206,8 @@ Window {
 
     Connections {
         target: VPNController
-        function onReadyToServerUnavailable(recievedPing) {
-            serverUnavailablePopup.recivedPing = recievedPing
+        function onReadyToServerUnavailable(receivedPing) {
+            serverUnavailablePopup.receivedPing = receivedPing
             serverUnavailablePopup.open();
         }
     }

--- a/src/ui/main.qml
+++ b/src/ui/main.qml
@@ -206,7 +206,8 @@ Window {
 
     Connections {
         target: VPNController
-        function onReadyToServerUnavailable() {
+        function onReadyToServerUnavailable(recievedPing) {
+            serverUnavailablePopup.recivedPing = recievedPing
             serverUnavailablePopup.open();
         }
     }

--- a/tests/qml/CMakeLists.txt
+++ b/tests/qml/CMakeLists.txt
@@ -61,6 +61,16 @@ target_sources(qml_tests PRIVATE
     ${MVPN_SOURCE_DIR}/settingsholder.h
     ${MVPN_SOURCE_DIR}/theme.cpp
     ${MVPN_SOURCE_DIR}/theme.h
+    ${MVPN_SOURCE_DIR}/pinghelper.cpp
+    ${MVPN_SOURCE_DIR}/pinghelper.h
+    ${MVPN_SOURCE_DIR}/pingsender.cpp
+    ${MVPN_SOURCE_DIR}/pingsender.h
+    ${MVPN_SOURCE_DIR}/platforms/dummy/dummypingsender.cpp
+    ${MVPN_SOURCE_DIR}/platforms/dummy/dummypingsender.h
+    ${MVPN_SOURCE_DIR}/dnspingsender.cpp
+    ${MVPN_SOURCE_DIR}/dnspingsender.h
+    ${MVPN_SOURCE_DIR}/pingsenderfactory.cpp
+    ${MVPN_SOURCE_DIR}/pingsenderfactory.h
     ${MVPN_SOURCE_DIR}/update/updater.cpp
     ${MVPN_SOURCE_DIR}/update/updater.h
     ${MVPN_SOURCE_DIR}/update/versionapi.cpp

--- a/tests/qml/moccontroller.cpp
+++ b/tests/qml/moccontroller.cpp
@@ -5,6 +5,7 @@
 #include "../../src/controllerimpl.h"
 #include "../../src/ipaddress.h"
 #include "../../src/mozillavpn.h"
+#include "../../src/pinghelper.h"
 
 Controller::Controller() {}
 

--- a/tests/qml/qml.pro
+++ b/tests/qml/qml.pro
@@ -61,6 +61,11 @@ SOURCES += \
     ../../src/update/updater.cpp \
     ../../src/update/versionapi.cpp \
     ../../src/update/webupdater.cpp \
+    ../../src/pinghelper.cpp \ 
+    ../../src/pingsender.cpp \
+    ../../src/platforms/dummy/dummypingsender.cpp \
+    ../../src/dnspingsender.cpp \
+    ../../src/pingsenderfactory.cpp \
     ../../src/qmlengineholder.cpp
 
 HEADERS += \
@@ -82,6 +87,11 @@ HEADERS += \
     ../../src/networkmanager.h \
     ../../src/networkrequest.h \
     ../../src/settingsholder.h \
+    ../../src/pinghelper.h \ 
+    ../../src/pingsender.h \
+    ../../src/platforms/dummy/dummypingsender.h \
+    ../../src/dnspingsender.h \
+    ../../src/pingsenderfactory.h \
     ../../src/theme.h \
     ../../src/update/updater.h \
     ../../src/update/versionapi.h \

--- a/tests/unit/moccontroller.cpp
+++ b/tests/unit/moccontroller.cpp
@@ -5,6 +5,7 @@
 #include "../../src/controllerimpl.h"
 #include "../../src/ipaddress.h"
 #include "../../src/mozillavpn.h"
+#include "../../src/pinghelper.h"
 #include "helper.h"
 
 Controller::Controller() {}

--- a/translations/strings.yaml
+++ b/translations/strings.yaml
@@ -437,6 +437,7 @@ serverUnavailableModal:
 
 serverUnavailableNotification:
   bodyText: This server location is temporarily unavailable. Please open the app to choose a new location.
+  bodyTextFireWallBlocked: The server has been blocked. Check your firewall settings.
   preferencesLabel: Server unavailable notification
   preferencesSubLabel: Get notified when connecting to a server location failed
 


### PR DESCRIPTION
## Description
Fixes: Server unavailable message is misleading if blocked by firewall

-> In parallel with the handshake, we attempt to ping the server.
-> If the ping succeeds and the handshake fails, the error message is changed to reflect that this might be a firewall issue. 

![Screenshot 2022-08-29 160220](https://user-images.githubusercontent.com/9611612/187219348-754b81e9-b610-47ff-a9c6-b3a294c9bf4a.png)

## Reference

[ Jira VPN-1748 ](https://mozilla-hub.atlassian.net/browse/VPN-1748)

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
