### PR TITLE
Fix tips and tricks layout with no addons

### DIFF
--- a/nebula/ui/components/VPNGuideList.qml
+++ b/nebula/ui/components/VPNGuideList.qml
@@ -17,6 +17,8 @@ ColumnLayout {
     property var customGuideFilter: () => true
     property var count: guideRepeater.count
 
+    visible: count > 0
+
     // Title
     VPNBoldLabel {
         Layout.fillWidth: true

--- a/nebula/ui/components/VPNTutorialList.qml
+++ b/nebula/ui/components/VPNTutorialList.qml
@@ -17,6 +17,7 @@ GridLayout {
     columns: width < VPNTheme.theme.tabletMinimumWidth ? 1 : 2
     columnSpacing: VPNTheme.theme.vSpacingSmall
     rowSpacing: VPNTheme.theme.vSpacingSmall
+    visible: count > 0
 
     function tutorialFilter(addon) {
         return addon.type === "tutorial" && customTutorialFilter(addon);

--- a/src/ui/screens/tipsAndTricks/ViewTipsAndTricks.qml
+++ b/src/ui/screens/tipsAndTricks/ViewTipsAndTricks.qml
@@ -66,9 +66,10 @@ VPNViewBase {
                 ColumnLayout {
                     id: layoutAll
 
-                    anchors.fill: parent
+                    anchors.top: parent.top
+                    anchors.left: parent.left
+                    anchors.right: parent.right
                     anchors.topMargin: VPNTheme.theme.vSpacing
-                    anchors.bottomMargin: VPNTheme.theme.vSpacing
                     anchors.leftMargin: VPNTheme.theme.windowMargin
                     anchors.rightMargin: VPNTheme.theme.windowMargin
                     spacing: VPNTheme.theme.vSpacingSmall
@@ -155,9 +156,10 @@ VPNViewBase {
                 ColumnLayout {
                     id: layoutGuide
 
-                    anchors.fill: parent
+                    anchors.top: parent.top
+                    anchors.left: parent.left
+                    anchors.right: parent.right
                     anchors.topMargin: VPNTheme.theme.vSpacing
-                    anchors.bottomMargin: VPNTheme.theme.vSpacing
                     anchors.leftMargin: VPNTheme.theme.windowMargin
                     anchors.rightMargin: VPNTheme.theme.windowMargin
 


### PR DESCRIPTION
## Description

Fix the layout of the tips and tricks "all" tab when no addons are active

## Reference

[VPN-2753: Tips & Tricks feature has UI issues for a inexistent add-on URL](https://mozilla-hub.atlassian.net/browse/VPN-2753)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
