### PR TITLE
Fix 2758/#4293

### DIFF
--- a/nebula/ui/components/VPNSettingsItem.qml
+++ b/nebula/ui/components/VPNSettingsItem.qml
@@ -23,8 +23,7 @@ VPNClickableRow {
 
     Layout.alignment: Qt.AlignHCenter
     Layout.minimumHeight: VPNTheme.theme.rowHeight
-    Layout.preferredWidth: parent.width
-    Layout.maximumWidth: parent.width
+    Layout.fillWidth: true
     canGrowVertical: true
     Layout.preferredHeight: title.lineCount > 1 ? title.implicitHeight + VPNTheme.theme.windowMargin : VPNTheme.theme.rowHeight
 

--- a/src/ui/screens/getHelp/developerMenu/ViewDeveloperMenu.qml
+++ b/src/ui/screens/getHelp/developerMenu/ViewDeveloperMenu.qml
@@ -16,7 +16,7 @@ VPNViewBase {
         id: root
         property bool vpnIsOff: (VPNController.state === VPNController.StateOff) ||
                                     (VPNController.state === VPNController.StateInitializing)
-
+        Layout.fillWidth: true
 
         spacing: VPNTheme.theme.windowMargin
 
@@ -95,10 +95,10 @@ VPNViewBase {
         VPNTextField {
             id: addonCustomServerInput
 
-            Layout.topMargin: VPNTheme.theme.windowMargin
             Layout.rightMargin: VPNTheme.theme.windowMargin * 2
-            implicitWidth: checkBoxRowStagingServer.labelWidth - VPNTheme.theme.windowMargin
+            Layout.leftMargin: VPNTheme.theme.windowMargin * 3
             Layout.alignment: Qt.AlignRight
+            Layout.fillWidth: true
 
             enabled: VPNSettings.addonCustomServer
             _placeholderText: "Addon Custom Server Address"
@@ -122,7 +122,6 @@ VPNViewBase {
         VPNCheckBoxRow {
             id: checkBoxRowProdKeyInStaging
 
-            Layout.fillWidth: true
             Layout.rightMargin: VPNTheme.theme.windowMargin
             labelText: "Add-on production signature key in staging"
             subLabelText: "Use the add-on production signature key in staging"
@@ -170,7 +169,8 @@ VPNViewBase {
                imageLeftSrc: "qrc:/ui/resources/settings/whatsnew.svg"
                imageRightSrc: "qrc:/nebula/resources/chevron.svg"
                onClicked: getHelpStackView.push(viewQrc)
-               Layout.preferredWidth: parent.width - VPNTheme.theme.windowMargin
+               Layout.leftMargin: VPNTheme.theme.windowMargin / 2
+               Layout.rightMargin: VPNTheme.theme.windowMargin / 2
             }
         }
 

--- a/src/ui/screens/getHelp/developerMenu/ViewFeatureList.qml
+++ b/src/ui/screens/getHelp/developerMenu/ViewFeatureList.qml
@@ -33,10 +33,9 @@ VPNViewBase {
 
                 RowLayout {
 
-                    Layout.preferredWidth: featureListHolder.width
+                    Layout.fillWidth: true
 
                     ColumnLayout {
-
                         Layout.fillWidth: true
 
                         VPNLightLabel {
@@ -48,6 +47,12 @@ VPNViewBase {
                             text: `id: ${feature.id}`
                             font.pixelSize: VPNTheme.theme.fontSizeSmall
                         }
+                    }
+
+                    Rectangle {
+                        Layout.preferredHeight: 1
+                        Layout.fillWidth: true
+                        color: VPNTheme.theme.transparent
                     }
 
                     VPNSettingsToggle {
@@ -65,7 +70,7 @@ VPNViewBase {
                 }
                 Rectangle {
                     Layout.alignment: Qt.AlignBottom
-                    Layout.preferredWidth: parent.width
+                    Layout.fillWidth: true
                     Layout.preferredHeight: 1
                     color: VPNTheme.colors.grey10
                     visible: index < rep.count - 1

--- a/src/ui/screens/settings/ViewSettingsMenu.qml
+++ b/src/ui/screens/settings/ViewSettingsMenu.qml
@@ -60,8 +60,9 @@ VPNViewBase {
 
         // TODO: Move to subscription management
         ColumnLayout {
-            Layout.preferredWidth: parent.width - VPNTheme.theme.windowMargin
-            Layout.maximumWidth: parent.width - VPNTheme.theme.windowMargin
+            Layout.fillWidth: true
+            Layout.leftMargin: VPNTheme.theme.windowMargin /2
+            Layout.rightMargin: VPNTheme.theme.windowMargin /2
             Layout.alignment: Qt.AlignHCenter
 
             VPNSettingsItem {


### PR DESCRIPTION
## Description

Fixes the breaking layout in the settings menu after transitioning from landscape to portrait mode. 

## Reference

#4293 (layout breakage only, does not address native ui color changes in guides)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
