### PR TITLE
Fix cache calc

### DIFF
--- a/tools/wasm_chrome/branch_selector.mjs
+++ b/tools/wasm_chrome/branch_selector.mjs
@@ -3,145 +3,148 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { Octokit } from "https://cdn.skypack.dev/@octokit/core";
-const octokit = new Octokit({ });
+const octokit = new Octokit({});
 
-const static_branch_info = fetch("./branch_runs.json").then(r=>r.json());
-
+const static_branch_info = fetch("./branch_runs.json").then((r) => r.json());
 
 /**
- * 
  * <branch-selector></branch-selector>
- * 
+ *
  * BranchSelector is a custom element, extendins a <select> element, that
  * allows the user to select a branch from a list of branches, from the Mozilla-VPN repo
- * 
+ *
  * currently caches the branches for 24h ... needs an api key to get around that
- * 
+ *
  * fires a "change" event when the user selects a branch
  * the current branch is stored in the "value" property of the element
  */
-class BranchSelector extends HTMLElement{
-    /** @type {ShadowRoot} */
-    #dom = null;
+class BranchSelector extends HTMLElement {
+  /** @type {ShadowRoot} */
+  #dom = null;
 
-    #data = [];
+  #data = [];
 
-    value = "";
+  value = "";
 
-    #firedOnload= false;
+  #firedOnload = false;
 
-    constructor(){
-        super();
+  constructor() {
+    super();
+  }
+
+  async connectedCallback() {
+    this.#dom = this.attachShadow({ mode: "open" });
+    this.render();
+    this.#data = await this.getData();
+    this.update();
+  }
+
+  async getData() {
+    const maybeStored = localStorage.getItem("branches");
+
+    if (maybeStored) {
+      const stored = JSON.parse(maybeStored);
+      const stored_age = new Date() - new Date(stored.date);
+      // The branches should be cached for 1 hour
+      if (stored_age < 1000 * 60 * 60 * 1) {
+        console.log("Using Cached Data");
+        return stored.data;
+      }
     }
-
-
-    async connectedCallback(){
-        this.#dom = this.attachShadow({mode: 'open'});
-        this.render();
-        this.#data = await this.getData();
-        this.update();
+    // We can't use the stored ones >:c - Too old
+    const response = await octokit.request(
+      "GET /repos/{owner}/{repo}/branches",
+      {
+        owner: "mozilla-mobile",
+        repo: "mozilla-vpn-client",
+        per_page: 100,
+      },
+    );
+    let branch_info = [];
+    try {
+      branch_info = await static_branch_info; // Make Sure this is ready
+    } catch (error) {
+      console.error(error);
     }
+    const unfiltered_branches = response.data;
+    // Filter the branches we just got from github:
+    // if we know the head-sha of the breanch does not have
+    // a taskcluster run (because too told), drop it.
+    const data = unfiltered_branches.filter((branch) => {
+      const branch_metadata = branch_info[branch.commit.sha];
+      if (!branch_metadata) {
+        // We don't know anything about that branch, add it to final list
+        return true;
+      }
+      if (branch_metadata.name === "main") {
+        // It's okay if we did not have valid info about main
+        // on build time, as gh pages task could have been faster
+        // as the taskcluster-wasm task
+        return true;
+      }
+      // It's ok if it has a running or completed task attached.
+      return branch_metadata.task_status == "ok";
+    });
 
+    console.log(`RateLimit -> ${response.headers["x-ratelimit-remaining"]}`);
 
-    async getData(){
-        const maybeStored = localStorage.getItem("branches");
+    localStorage.setItem(
+      "branches",
+      JSON.stringify({
+        date: new Date(),
+        data,
+      }),
+    );
+    return data;
+  }
 
-        if(maybeStored){
-            const stored = JSON.parse(maybeStored);
-            const stored_age = new Date() - new Date(stored.date) ;
-            // The branches should be cached for 1 hour
-            if(stored_age < 1000 * 60 * 60 * 1){
-                console.log("Using Cached Data");
-                return stored.data;
-            }
-        }
-        // We can't use the stored ones >:c - Too old
-        const response = await octokit.request('GET /repos/{owner}/{repo}/branches', {
-            owner: 'mozilla-mobile',
-            repo: 'mozilla-vpn-client',
-            per_page: 100
-        });
-        let branch_info = []
-        try {
-            branch_info = await static_branch_info; // Make Sure this is ready
-        } catch (error) {
-            console.error(error);
-        }
-        const unfiltered_branches = response.data;
-        // Filter the branches we just got from github:
-        // if we know the head-sha of the breanch does not have 
-        // a taskcluster run (because too told), drop it. 
-        const data = unfiltered_branches.filter((branch) => {
-            const branch_metadata = branch_info[branch.commit.sha]
-            if(!branch_metadata){
-                // We don't know anything about that branch, add it to final list
-                return true;
-            }
-            if(branch_metadata.name === "main"){
-                // It's okay if we did not have valid info about main
-                // on build time, as gh pages task could have been faster
-                // as the taskcluster-wasm task
-                return true;
-            }
-            // It's ok if it has a running or completed task attached.
-            return branch_metadata.task_status == "ok";
-        })
-        
-
-        console.log(`RateLimit -> ${response.headers["x-ratelimit-remaining"]}`)
-
-        localStorage.setItem("branches", JSON.stringify({
-            date: new Date(),
-            data,
-        }));
-        return data;
+  render() {
+    if (this.#dom.innerHTML != "") {
+      this.update();
     }
-
-    render(){
-        if(this.#dom.innerHTML != ''){
-            this.update();
-        }
-        this.#dom.innerHTML = `
+    this.#dom.innerHTML = `
             <select id="selector">
                     <option value="">Select a VPN</option>
             </select>
         `;
-        const selector = this.#dom.querySelector("#selector");
-        selector.addEventListener("change", e => {
-            // Forward the event to the parent element;
-            this.value = selector.value;
-            this.name = selector.options[selector.selectedIndex].text;
-            this.dispatchEvent(new CustomEvent("change", e));
-        });
-    }
-    update(){
-        const selector = this.#dom.querySelector("#selector");
-        selector.innerHTML = `
+    const selector = this.#dom.querySelector("#selector");
+    selector.addEventListener("change", (e) => {
+      // Forward the event to the parent element;
+      this.value = selector.value;
+      this.name = selector.options[selector.selectedIndex].text;
+      this.dispatchEvent(new CustomEvent("change", e));
+    });
+  }
+  update() {
+    const selector = this.#dom.querySelector("#selector");
+    selector.innerHTML = `
             <option value="">Select a VPN-Branch</option>
-            ${this.#data.map((e)=>{
-                return `<option value="${e.commit.sha}">${e.name}</option>`	
-            })};
+            ${
+      this.#data.map((e) => {
+        return `<option value="${e.commit.sha}">${e.name}</option>`;
+      })
+    };
         `;
 
-        if(!this.#firedOnload){
-            requestIdleCallback(()=>{
-                const url = new URL(window.location);
-                let name = url.searchParams.get('branch');
-                if(!name){
-                    name="main";
-                }
-                const option = Array.from(selector.querySelectorAll(`option`)).find(e => e.text == name);
-                if(option){
-                    option.selected = true;
-                    this.value = option.value;
-                    this.name = option.text;
-                    this.dispatchEvent(new CustomEvent("change", {}));
-                }
-            });
+    if (!this.#firedOnload) {
+      requestIdleCallback(() => {
+        const url = new URL(window.location);
+        let name = url.searchParams.get("branch");
+        if (!name) {
+          name = "main";
         }
-
-        
+        const option = Array.from(selector.querySelectorAll(`option`)).find(
+          (e) => e.text == name,
+        );
+        if (option) {
+          option.selected = true;
+          this.value = option.value;
+          this.name = option.text;
+          this.dispatchEvent(new CustomEvent("change", {}));
+        }
+      });
     }
+  }
 }
 
 customElements.define("branch-selector", BranchSelector);

--- a/tools/wasm_chrome/branch_selector.mjs
+++ b/tools/wasm_chrome/branch_selector.mjs
@@ -72,6 +72,12 @@ class BranchSelector extends HTMLElement{
                 // We don't know anything about that branch, add it to final list
                 return true;
             }
+            if(branch_metadata.name === "main"){
+                // It's okay if we did not have valid info about main
+                // on build time, as gh pages task could have been faster
+                // as the taskcluster-wasm task
+                return true;
+            }
             // It's ok if it has a running or completed task attached.
             return branch_metadata.task_status == "ok";
         })

--- a/tools/wasm_chrome/branch_selector.mjs
+++ b/tools/wasm_chrome/branch_selector.mjs
@@ -61,7 +61,12 @@ class BranchSelector extends HTMLElement{
             repo: 'mozilla-vpn-client',
             per_page: 100
         });
-        const branch_info = await static_branch_info; // Make Sure this is ready
+        let branch_info = []
+        try {
+            branch_info = await static_branch_info; // Make Sure this is ready
+        } catch (error) {
+            console.error(error);
+        }
         const unfiltered_branches = response.data;
         // Filter the branches we just got from github:
         // if we know the head-sha of the breanch does not have 
@@ -123,8 +128,7 @@ class BranchSelector extends HTMLElement{
                 const url = new URL(window.location);
                 let name = url.searchParams.get('branch');
                 if(!name){
-                    this.#firedOnload=true;
-                    return;
+                    name="main";
                 }
                 const option = Array.from(selector.querySelectorAll(`option`)).find(e => e.text == name);
                 if(option){

--- a/tools/wasm_chrome/branch_selector.mjs
+++ b/tools/wasm_chrome/branch_selector.mjs
@@ -48,7 +48,7 @@ class BranchSelector extends HTMLElement{
 
         if(maybeStored){
             const stored = JSON.parse(maybeStored);
-            const stored_age = new Date(stored.date) - new Date();
+            const stored_age = new Date() - new Date(stored.date) ;
             // The branches should be cached for 1 hour
             if(stored_age < 1000 * 60 * 60 * 1){
                 console.log("Using Cached Data");

--- a/tools/wasm_chrome/deno.json
+++ b/tools/wasm_chrome/deno.json
@@ -1,7 +1,7 @@
 {
-    "tasks": {
-      "build": "deno run --allow-all generate_branch_file.ts",
-      "run": "deno run --allow-net --allow-read https://deno.land/std@0.153.0/http/file_server.ts",
-      "format": "deno fmt ."
-    }
+  "tasks": {
+    "build": "deno run --allow-all generate_branch_file.ts",
+    "run": "deno run --allow-net --allow-read https://deno.land/std@0.153.0/http/file_server.ts",
+    "format": "deno fmt ."
   }
+}

--- a/tools/wasm_chrome/deno.json
+++ b/tools/wasm_chrome/deno.json
@@ -1,0 +1,7 @@
+{
+    "tasks": {
+      "build": "deno run --allow-all generate_branch_file.ts",
+      "run": "deno run --allow-net --allow-read https://deno.land/std@0.153.0/http/file_server.ts",
+      "format": "deno fmt ."
+    }
+  }

--- a/tools/wasm_chrome/generate_branch_file.ts
+++ b/tools/wasm_chrome/generate_branch_file.ts
@@ -2,132 +2,138 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-
- /** Generate Wasm-Chrome Hydration
-  * 
-  * This is a deno script.
-  * usage: deno -a generate_branch_file -T <github_api_token>
-  * 
-  * This will generate a file containing current sha->taskClusterID mappings, to save 
-  * api calls to github and also allow us to filter :) 
-  * 
-  */
+/** Generate Wasm-Chrome Hydration
+ *
+ * This is a deno script.
+ * usage: deno -a generate_branch_file -T <github_api_token>
+ *
+ * This will generate a file containing current sha->taskClusterID mappings, to save
+ * api calls to github and also allow us to filter :)
+ */
 import { parse } from "https://deno.land/std/flags/mod.ts";
 import { Octokit } from "https://cdn.skypack.dev/@octokit/core";
 
-interface Commit{
-    sha: string,
+interface Commit {
+  sha: string;
 }
-interface GhCheck{
-    name: string,
+interface GhCheck {
+  name: string;
 }
-interface Branch{
-    commit:Commit
-    name:string;
+interface Branch {
+  commit: Commit;
+  name: string;
 }
 enum TaskStatus {
-    ok = "ok",
-    noRun = "noGithubRunInfo", // There was never a wasm task scheudeled for this branch 
-    notFound = "notFound",
-    error = "error",
-    tooOld = "tooOld",
-    unknown = "unknown", 
+  ok = "ok",
+  noRun = "noGithubRunInfo", // There was never a wasm task scheudeled for this branch
+  notFound = "notFound",
+  error = "error",
+  tooOld = "tooOld",
+  unknown = "unknown",
+}
+interface StatusResult {
+  sha: string;
+  name: string;
+  task_id: string;
+  task_status: TaskStatus;
+}
+
+interface TaskClusterStatus {
+  error: string;
+  code: string;
+  status: {
+    taskId: string;
+    state: string;
+  };
+}
+
+async function getTaskStatusOf(task_id: string): Promise<TaskStatus> {
+  let task_status: TaskClusterStatus;
+  try {
+    task_status = await fetch(
+      `${TASKCLUSTER_INSTANCE}/api/queue/v1/task/${task_id}/status`,
+    ).then((r) => r.json());
+  } catch (_) {
+    return TaskStatus.unknown;
   }
-interface StatusResult{
-    sha: string,
-    name: string,
-    task_id:string,
-    task_status: TaskStatus,
-}
-
-interface TaskClusterStatus{
-    error:string
-    code:string,
-    status: {
-        taskId: string,
-        state: string, 
-    }
-}
-
-async function getTaskStatusOf(task_id:string): Promise<TaskStatus> {
-    let task_status:TaskClusterStatus;
-    try {
-        task_status = await fetch(`${TASKCLUSTER_INSTANCE}/api/queue/v1/task/${task_id}/status`).then((r)=>r.json());
-    } catch (_) {
-        return TaskStatus.unknown;
-    }
-    if(task_status.error == "Not found" || task_status.code == "ResourceNotFound"){
-        return TaskStatus.notFound;
-    }
-    if(task_status.status.state == "running"){
-        return TaskStatus.ok;
-    }
-    if(task_status.status.state != "completed"){
-        return TaskStatus.error;
-    }
+  if (
+    task_status.error == "Not found" || task_status.code == "ResourceNotFound"
+  ) {
+    return TaskStatus.notFound;
+  }
+  if (task_status.status.state == "running") {
     return TaskStatus.ok;
+  }
+  if (task_status.status.state != "completed") {
+    return TaskStatus.error;
+  }
+  return TaskStatus.ok;
 }
 
+const { T } = parse(Deno.args);
 
-const {T} = parse(Deno.args)
+console.log(parse(Deno.args));
 
-console.log(parse(Deno.args))
-
-const TASKCLUSTER_INSTANCE ="https://firefox-ci-tc.services.mozilla.com"
+const TASKCLUSTER_INSTANCE = "https://firefox-ci-tc.services.mozilla.com";
 const TASKCLUSTER_TASK_NAME = "build-wasm/opt";
 
-
-if(T == ""){
-    console.error("No Github Key - Exit");
-    console.error("Run with -GH_KEY <your key>");
-    Deno.exit(-1);
+if (T == "") {
+  console.error("No Github Key - Exit");
+  console.error("Run with -GH_KEY <your key>");
+  Deno.exit(-1);
 }
 
 const octokit = new Octokit({
-    auth:T
-})
-console.log(await octokit.request('GET /rate_limit', {}));
-
+  auth: T,
+});
+console.log(await octokit.request("GET /rate_limit", {}));
 
 // Get Branch data
-const branch_response = await octokit.request('GET /repos/{owner}/{repo}/branches', {
-    owner: 'mozilla-mobile',
-    repo: 'mozilla-vpn-client',
-    per_page: 100
-});
+const branch_response = await octokit.request(
+  "GET /repos/{owner}/{repo}/branches",
+  {
+    owner: "mozilla-mobile",
+    repo: "mozilla-vpn-client",
+    per_page: 100,
+  },
+);
 
-const out: {[index: string]: any } = {}
+const out: { [index: string]: any } = {};
 
-const jobs = branch_response.data.map( async (branch:Branch) => {
-    const sha = branch.commit.sha;
-    const name = branch.name
-    
-    const result = {
-        name,sha,
-        task_status:TaskStatus.unknown,
-        task_id:""
-    }
+const jobs = branch_response.data.map(async (branch: Branch) => {
+  const sha = branch.commit.sha;
+  const name = branch.name;
 
-    // Get All Runs For the Branch
-    const response = await octokit.request('GET /repos/{owner}/{repo}/commits/{ref}/check-runs', {
-        owner: 'mozilla-mobile',
-        repo: 'mozilla-vpn-client',
-        ref: sha,
-        per_page: 100
-    });
-    const checks = response.data.check_runs;
-    const wasm_run = checks.find((e: GhCheck) => e.name == TASKCLUSTER_TASK_NAME);
-    if(!wasm_run){
-        result.task_status= TaskStatus.noRun;
-        out[sha]=result;
-        console.log(`${result.task_status} \t \t -> ${name}`)
-        return;
-    }
-    const task_url = wasm_run.details_url;
-    result.task_id = task_url.split("/").at(-1);
-    result.task_status= await getTaskStatusOf(result.task_id);
-    console.log(`${result.task_status} \t \t -> ${name}`)
-    out[sha]=result;
+  const result = {
+    name,
+    sha,
+    task_status: TaskStatus.unknown,
+    task_id: "",
+  };
+
+  // Get All Runs For the Branch
+  const response = await octokit.request(
+    "GET /repos/{owner}/{repo}/commits/{ref}/check-runs",
+    {
+      owner: "mozilla-mobile",
+      repo: "mozilla-vpn-client",
+      ref: sha,
+      per_page: 100,
+    },
+  );
+  const checks = response.data.check_runs;
+  const wasm_run = checks.find((e: GhCheck) => e.name == TASKCLUSTER_TASK_NAME);
+  if (!wasm_run) {
+    result.task_status = TaskStatus.noRun;
+    out[sha] = result;
+    console.log(`${result.task_status} \t \t -> ${name}`);
+    return;
+  }
+  const task_url = wasm_run.details_url;
+  result.task_id = task_url.split("/").at(-1);
+  result.task_status = await getTaskStatusOf(result.task_id);
+  console.log(`${result.task_status} \t \t -> ${name}`);
+  out[sha] = result;
 });
 
 await Promise.all(jobs);

--- a/tools/wasm_chrome/taskcluster_frame.mjs
+++ b/tools/wasm_chrome/taskcluster_frame.mjs
@@ -52,7 +52,12 @@ class TaskclusterFrame extends HTMLElement{
         this.render();
         this.update();
 
-        this.#static_info = await static_branch_info
+        this.#static_info = [];
+        try {
+            this.#static_info = await static_branch_info;
+        } catch (error) {
+            console.error(error);
+        }
     }
 
 

--- a/tools/wasm_chrome/taskcluster_frame.mjs
+++ b/tools/wasm_chrome/taskcluster_frame.mjs
@@ -2,70 +2,65 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-
 import { Octokit } from "https://cdn.skypack.dev/@octokit/core";
-const octokit = new Octokit({ });
-const static_branch_info = fetch("./branch_runs.json").then(r=>r.json());
+const octokit = new Octokit({});
+const static_branch_info = fetch("./branch_runs.json").then((r) => r.json());
 
-const TASKCLUSTER_INSTANCE ="https://firefox-ci-tc.services.mozilla.com/"
+const TASKCLUSTER_INSTANCE = "https://firefox-ci-tc.services.mozilla.com/";
 const TASKCLUSTER_TASK_NAME = "build-wasm/opt";
 /**
  *  <taskcluster-frame></taskcluster-frame>
- * 
- *  Custom Element that will load the wasm client from the given taskname 
- *  and a git commit sha. 
- *  Usage: 
- *  -> set element.git_sha="asdjko3131" 
+ *
+ *  Custom Element that will load the wasm client from the given taskname
+ *  and a git commit sha.
+ *  Usage:
+ *  -> set element.git_sha="asdjko3131"
  *  -> Profit.
  */
-class TaskclusterFrame extends HTMLElement{
-    
-     /** @type {ShadowRoot} */
-    #dom= null;
-    /** @type {String} */
-    #sha ="";
-    /** @type {HTMLIFrameElement} */
-    #iframe = null;
-    /** @type {String} */
-    taskID = "";
+class TaskclusterFrame extends HTMLElement {
+  /** @type {ShadowRoot} */
+  #dom = null;
+  /** @type {String} */
+  #sha = "";
+  /** @type {HTMLIFrameElement} */
+  #iframe = null;
+  /** @type {String} */
+  taskID = "";
 
-    #static_info = {};
+  #static_info = {};
 
-    artifact_url="";
+  artifact_url = "";
 
-    constructor(){
-        super();
+  constructor() {
+    super();
+  }
+
+  get git_sha() {
+    return this.#sha;
+  }
+  set git_sha(value) {
+    this.#sha = value;
+    this.update();
+  }
+
+  async connectedCallback() {
+    this.#dom = this.attachShadow({ mode: "open" });
+    this.render();
+    this.update();
+
+    this.#static_info = [];
+    try {
+      this.#static_info = await static_branch_info;
+    } catch (error) {
+      console.error(error);
     }
+  }
 
-
-    get git_sha() {
-        return this.#sha;
+  render() {
+    if (this.#dom.innerHTML != "") {
+      this.update();
     }
-    set git_sha(value){
-        this.#sha = value;
-        this.update();
-    }
-
-
-    async connectedCallback(){
-        this.#dom = this.attachShadow({mode: 'open'});
-        this.render();
-        this.update();
-
-        this.#static_info = [];
-        try {
-            this.#static_info = await static_branch_info;
-        } catch (error) {
-            console.error(error);
-        }
-    }
-
-
-    render(){
-        if(this.#dom.innerHTML != ''){
-            this.update();
-        }
-        this.#dom.innerHTML = `
+    this.#dom.innerHTML = `
             <style>
                 iframe{
                     width: 100%;
@@ -74,62 +69,69 @@ class TaskclusterFrame extends HTMLElement{
             </style>
            <iframe src="about:blank"></iframe>
         `;
-        this.#iframe= this.#dom.querySelector("iframe");   
-        //this.#iframe.srcdoc="Select Branch :)";  
+    this.#iframe = this.#dom.querySelector("iframe");
+    //this.#iframe.srcdoc="Select Branch :)";
+  }
+  async update() {
+    if (this.#sha == "") {
+      return;
     }
-    async update(){
-        if(this.#sha == ""){
-            return;
-        }
-        this.taskID = await this.getTaskID(this.#sha);
-        if(this.taskID == ""){
-            alert("Unable to find a Task for this branch");
-            return;
-        }
- 
-        this.#iframe.src =`${TASKCLUSTER_INSTANCE}api/queue/v1/task/${this.taskID}/artifacts/public/build/index.html`;
-        this.dispatchEvent(new CustomEvent("taskChanged", {}));
+    this.taskID = await this.getTaskID(this.#sha);
+    if (this.taskID == "") {
+      alert("Unable to find a Task for this branch");
+      return;
     }
 
-    async getTaskID(sha){
-        // Before doing any api call, see if we have a ref for that sha in the static files.
-        const static_data = this.#static_info[sha]
-        if(static_data && static_data.task_status == "ok" && static_data.task_id != ""){
-            return static_data.task_id;
-        }
+    this.#iframe.src =
+      `${TASKCLUSTER_INSTANCE}api/queue/v1/task/${this.taskID}/artifacts/public/build/index.html`;
+    this.dispatchEvent(new CustomEvent("taskChanged", {}));
+  }
 
-        const wasm_run = await this.getGithubRun(sha);
-        if(wasm_run == undefined){ 
-            return "";
-        }
-        const task_url = wasm_run.details_url;
-        const task_id = task_url.split("/").at(-1);
-        return task_id;
+  async getTaskID(sha) {
+    // Before doing any api call, see if we have a ref for that sha in the static files.
+    const static_data = this.#static_info[sha];
+    if (
+      static_data && static_data.task_status == "ok" &&
+      static_data.task_id != ""
+    ) {
+      return static_data.task_id;
     }
 
-    async getGithubRun(sha){
-        const maybe_stored = localStorage.getItem(sha);
-        if(maybe_stored){
-            return JSON.parse(maybe_stored);
-        }
-
-        const response = await octokit.request('GET /repos/{owner}/{repo}/commits/{ref}/check-runs', {
-            owner: 'mozilla-mobile',
-            repo: 'mozilla-vpn-client',
-            ref: sha,
-            per_page: 100
-        });
-        console.log(response);
-        /** @type {Array<Object>} */
-        const checks = response.data.check_runs;
-        const wasm_run = checks.find(e => e.name == TASKCLUSTER_TASK_NAME);
-        if(!wasm_run){
-            return undefined;
-        }
-        // The SHA -> Taskcluster Mapping is pretty permanent
-        localStorage.setItem(sha, JSON.stringify(wasm_run));
-        return wasm_run;
+    const wasm_run = await this.getGithubRun(sha);
+    if (wasm_run == undefined) {
+      return "";
     }
+    const task_url = wasm_run.details_url;
+    const task_id = task_url.split("/").at(-1);
+    return task_id;
+  }
+
+  async getGithubRun(sha) {
+    const maybe_stored = localStorage.getItem(sha);
+    if (maybe_stored) {
+      return JSON.parse(maybe_stored);
+    }
+
+    const response = await octokit.request(
+      "GET /repos/{owner}/{repo}/commits/{ref}/check-runs",
+      {
+        owner: "mozilla-mobile",
+        repo: "mozilla-vpn-client",
+        ref: sha,
+        per_page: 100,
+      },
+    );
+    console.log(response);
+    /** @type {Array<Object>} */
+    const checks = response.data.check_runs;
+    const wasm_run = checks.find((e) => e.name == TASKCLUSTER_TASK_NAME);
+    if (!wasm_run) {
+      return undefined;
+    }
+    // The SHA -> Taskcluster Mapping is pretty permanent
+    localStorage.setItem(sha, JSON.stringify(wasm_run));
+    return wasm_run;
+  }
 }
 
 customElements.define("taskcluster-frame", TaskclusterFrame);


### PR DESCRIPTION
2 Bugs in the wasm-viewer. 

I miscalculated the cache time, the age getting smaller instead of bigger, therefore you would never fetch new branches. 

Also fixed a race. The wasm-info json, might not have info of the "main" branch, as taskcluster might not have started building the wasm client. Currently, the script will mark it as "no-run" info, like a stale branch. Let's never have that for main.  