### PR TITLE
Disable timers for add-device requests

### DIFF
--- a/src/tasks/adddevice/taskadddevice.cpp
+++ b/src/tasks/adddevice/taskadddevice.cpp
@@ -53,6 +53,8 @@ void TaskAddDevice::run() {
   NetworkRequest* request = NetworkRequest::createForDeviceCreation(
       this, m_deviceName, publicKey, m_deviceID);
 
+  request->disableTimeout();
+
   connect(request, &NetworkRequest::requestFailed, this,
           [this](QNetworkReply::NetworkError error, const QByteArray&) {
             logger.error() << "Failed to add the device" << error;

--- a/tests/unit/mocnetworkrequest.cpp
+++ b/tests/unit/mocnetworkrequest.cpp
@@ -149,3 +149,5 @@ void NetworkRequest::sslErrors(const QList<QSslError>& errors) {
   Q_UNUSED(errors);
 }
 #endif
+
+void NetworkRequest::disableTimeout() {}


### PR DESCRIPTION
This can be a good fix for the key-rotation