### PR TITLE
Add bundle upgrade UI to subscription management view

### DIFF
--- a/glean/metrics.yaml
+++ b/glean/metrics.yaml
@@ -450,7 +450,7 @@ sample:
     bugs:
       - https://github.com/mozilla-mobile/mozilla-vpn-client/pull/4310
     data_reviews:
-      - https://bugzilla.mozilla.org/show_bug.cgi?id=1711123#c1
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1789284
     data_sensitivity:
       - interaction
     notification_emails:
@@ -467,7 +467,7 @@ sample:
     bugs:
       - https://github.com/mozilla-mobile/mozilla-vpn-client/pull/4310
     data_reviews:
-      - https://bugzilla.mozilla.org/show_bug.cgi?id=1711123#c1
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1789284
     data_sensitivity:
       - interaction
     notification_emails:
@@ -484,7 +484,7 @@ sample:
     bugs:
       - https://github.com/mozilla-mobile/mozilla-vpn-client/pull/4310
     data_reviews:
-      - https://bugzilla.mozilla.org/show_bug.cgi?id=1711123#c1
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1789284
     data_sensitivity:
       - interaction
     notification_emails:

--- a/glean/metrics.yaml
+++ b/glean/metrics.yaml
@@ -448,7 +448,7 @@ sample:
     description: |
       - "Learn more" link clicked in subscription management bundle upsell.
     bugs:
-      - https://bugzilla.mozilla.org/show_bug.cgi?id=1711123
+      - https://github.com/mozilla-mobile/mozilla-vpn-client/pull/4310
     data_reviews:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1711123#c1
     data_sensitivity:
@@ -465,7 +465,7 @@ sample:
     description: |
       The user clicked the bundle upsell Upgrade button.
     bugs:
-      - https://bugzilla.mozilla.org/show_bug.cgi?id=1711123
+      - https://github.com/mozilla-mobile/mozilla-vpn-client/pull/4310
     data_reviews:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1711123#c1
     data_sensitivity:
@@ -482,7 +482,7 @@ sample:
     description: |
       - The user viewed the bundle upsell in the subscription management view.
     bugs:
-      - https://bugzilla.mozilla.org/show_bug.cgi?id=1711123
+      - https://github.com/mozilla-mobile/mozilla-vpn-client/pull/4310
     data_reviews:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1711123#c1
     data_sensitivity:

--- a/glean/metrics.yaml
+++ b/glean/metrics.yaml
@@ -440,6 +440,58 @@ sample:
       - amarchesini@mozilla.com
     expires: never
 
+  bundle_upsell_link_clicked:
+    type: event
+    lifetime: ping
+    send_in_pings:
+      - main
+    description: |
+      - "Learn more" link clicked in subscription management bundle upsell.
+    bugs:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1711123
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1711123#c1
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - amarchesini@mozilla.com
+    expires: never
+
+  bundle_upsell_upgrade_clicked:
+    type: event
+    lifetime: ping
+    send_in_pings:
+      - main
+    description: |
+      The user clicked the bundle upsell Upgrade button.
+    bugs:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1711123
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1711123#c1
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - amarchesini@mozilla.com
+    expires: never
+
+  bundle_upsell_viewed:
+    type: event
+    lifetime: ping
+    send_in_pings:
+      - main
+    description: |
+      - The user viewed the bundle upsell in the subscription management view.
+    bugs:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1711123
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1711123#c1
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - amarchesini@mozilla.com
+    expires: never
+
+
   connection_health_no_signal:
     type: event
     lifetime: ping

--- a/src/constants.h
+++ b/src/constants.h
@@ -119,6 +119,9 @@ PRODBETAEXPR(
     "97e8ba9cf12fb3de53cc42a4e6577ed64df493c247b414fea036818d3823560e",
     "3c01446abe9036cea9a09acaa3a520ac628f20a7ae32ce861cb2efb70fa0c745");
 
+PRODBETAEXPR(const char*, relayUrl, "https://relay.firefox.com",
+             "https://stage.fxprivaterelay.nonprod.cloudops.mozgcp.net");
+
 PRODBETAEXPR(qint64, keyRegeneratorTimeSec, 604800, 300);
 
 #undef PRODBETAEXPR

--- a/src/featureslist.h
+++ b/src/featureslist.h
@@ -50,6 +50,14 @@ FEATURE_SIMPLE(appReview,      // Feature ID
                QStringList(),  // feature dependencies
                FeatureCallback_iosOrAndroid)
 
+FEATURE_SIMPLE(bundleUpgrade,     // Feature ID
+               "Bundle Upgrade",  // Feature name
+               "2.10",            // released
+               true,              // Can be flipped on
+               true,              // Can be flipped off
+               QStringList(),     // feature dependencies
+               FeatureCallback_true)
+
 FEATURE_SIMPLE(captivePortal,     // Feature ID
                "Captive Portal",  // Feature name
                "2.1",             // released

--- a/src/featureslist.h
+++ b/src/featureslist.h
@@ -56,7 +56,7 @@ FEATURE_SIMPLE(bundleUpgrade,     // Feature ID
                true,              // Can be flipped on
                true,              // Can be flipped off
                QStringList(),     // feature dependencies
-               FeatureCallback_true)
+               FeatureCallback_false)
 
 FEATURE_SIMPLE(captivePortal,     // Feature ID
                "Captive Portal",  // Feature name

--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -582,6 +582,11 @@ void MozillaVPN::openLink(LinkType linkType) {
                          .first());
       break;
 
+    case LinkRelayPremium:
+      url = Constants::relayUrl();
+      url.append("/premium");
+      break;
+
     case LinkSubscriptionFxa:
       url = Constants::fxaUrl();
       url.append("/subscriptions");
@@ -593,6 +598,13 @@ void MozillaVPN::openLink(LinkType linkType) {
 
     case LinkSubscriptionIapGoogle:
       url = Constants::GOOGLE_SUBSCRIPTIONS_URL;
+      break;
+
+    case LinkUpgradeToBundle:
+      url = Constants::inProduction() ? Constants::API_PRODUCTION_URL
+                                      : Constants::API_STAGING_URL;
+      url.append(
+          "/someGuardianEndpoint/&entrypoint=subscriptionManagement");  // TODO
       break;
 
     default:

--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -603,8 +603,7 @@ void MozillaVPN::openLink(LinkType linkType) {
     case LinkUpgradeToBundle:
       url = Constants::inProduction() ? Constants::API_PRODUCTION_URL
                                       : Constants::API_STAGING_URL;
-      url.append(
-          "/someGuardianEndpoint/&entrypoint=subscriptionManagement");  // TODO
+      url.append("/r/vpn/upgradeToPrivacyBundle");
       break;
 
     default:

--- a/src/mozillavpn.h
+++ b/src/mozillavpn.h
@@ -111,9 +111,11 @@ class MozillaVPN final : public QObject {
     LinkSubscriptionBlocked,
     LinkSplitTunnelHelp,
     LinkCaptivePortal,
+    LinkRelayPremium,
     LinkSubscriptionIapApple,
     LinkSubscriptionFxa,
     LinkSubscriptionIapGoogle,
+    LinkUpgradeToBundle,
   };
   Q_ENUM(LinkType)
 

--- a/src/ui/screens/settings/ViewSubscriptionManagement/SubscriptionManagementItem.qml
+++ b/src/ui/screens/settings/ViewSubscriptionManagement/SubscriptionManagementItem.qml
@@ -119,7 +119,7 @@ ColumnLayout {
         spacing: VPNTheme.theme.listSpacing
 
         Layout.alignment: Qt.AlignVCenter
-        Layout.bottomMargin:  VPNTheme.theme.listSpacing
+        Layout.bottomMargin: VPNTheme.theme.listSpacing
         Layout.fillWidth: true
         Layout.preferredHeight: VPNTheme.theme.rowHeight
         Layout.topMargin: VPNTheme.theme.listSpacing

--- a/src/ui/screens/settings/ViewSubscriptionManagement/SubscriptionManagementItem.qml
+++ b/src/ui/screens/settings/ViewSubscriptionManagement/SubscriptionManagementItem.qml
@@ -193,7 +193,11 @@ ColumnLayout {
         Layout.topMargin: VPNTheme.theme.listSpacing
         Layout.bottomMargin: VPNTheme.theme.windowMargin
 
-        Component.onCompleted: { /* TODO: Send "upsell viewed" glean ping */ console.log(VPNLocalizer.code, "localizer code") }
+        Component.onCompleted: {
+            if (visible) {
+                VPN.recordGleanEvent("bundle_upsell_viewed");
+            }
+        }
 
         ColumnLayout {
             Layout.fillWidth: true
@@ -221,7 +225,7 @@ ColumnLayout {
                 Layout.leftMargin: -4
 
                 onClicked: {
-                    /* TODO: Send "upsell learn more link clicked" glean ping */
+                    VPN.recordGleanEvent("bundle_upsell_link_clicked");
                     VPN.openLink(VPN.LinkRelayPremium);
                 }
             }
@@ -231,7 +235,7 @@ ColumnLayout {
             objectName: _objectName + "-relayUpsell-upgradeButton"
 
             onClicked: {
-                /* TODO: Send upsell upgrade button clicked */
+                VPN.recordGleanEvent("bundle_upsell_upgrade_clicked");
                 VPN.openLink(VPN.LinkUpgradeToBundle);
             }
 

--- a/src/ui/screens/settings/ViewSubscriptionManagement/SubscriptionManagementItem.qml
+++ b/src/ui/screens/settings/ViewSubscriptionManagement/SubscriptionManagementItem.qml
@@ -220,7 +220,6 @@ ColumnLayout {
                 fontSize: VPNTheme.theme.fontSizeSmall
                 labelText: VPNl18n.SplittunnelInfoLinkText // "Learn more"
                 Layout.alignment: Qt.AlignLeft
-                Layout.fillWidth: true
                 padding: 4
                 Layout.leftMargin: -4
 

--- a/src/ui/screens/settings/ViewSubscriptionManagement/SubscriptionManagementItem.qml
+++ b/src/ui/screens/settings/ViewSubscriptionManagement/SubscriptionManagementItem.qml
@@ -4,6 +4,7 @@
 
 import QtQuick 2.5
 import QtQuick.Layouts 1.14
+import QtQuick.Controls 2.14
 
 import Mozilla.VPN 1.0
 import components 0.1
@@ -34,6 +35,34 @@ ColumnLayout {
                 target: paymentMethod
                 visible: false
             }
+            PropertyChanges {
+                target: relayUpsell
+                visible: false
+            }
+        },
+        State {
+            when: type === "text-upgrade"
+
+            PropertyChanges {
+                target: rowLabel
+                visible: true
+            }
+            PropertyChanges {
+                target: rowText
+                visible: true
+            }
+            PropertyChanges {
+                target: rowPill
+                visible: false
+            }
+            PropertyChanges {
+                target: paymentMethod
+                visible: false
+            }
+            PropertyChanges {
+                target: relayUpsell
+                visible: true
+            }
         },
         State {
             when: type === "pill"
@@ -52,6 +81,10 @@ ColumnLayout {
             }
             PropertyChanges {
                 target: paymentMethod
+                visible: false
+            }
+            PropertyChanges {
+                target: relayUpsell
                 visible: false
             }
         },
@@ -74,6 +107,10 @@ ColumnLayout {
                 target: paymentMethod
                 visible: true
             }
+            PropertyChanges {
+                target: relayUpsell
+                visible: false
+            }
         }
     ]
 
@@ -82,7 +119,7 @@ ColumnLayout {
         spacing: VPNTheme.theme.listSpacing
 
         Layout.alignment: Qt.AlignVCenter
-        Layout.bottomMargin: VPNTheme.theme.listSpacing
+        Layout.bottomMargin:  VPNTheme.theme.listSpacing
         Layout.fillWidth: true
         Layout.preferredHeight: VPNTheme.theme.rowHeight
         Layout.topMargin: VPNTheme.theme.listSpacing
@@ -143,6 +180,80 @@ ColumnLayout {
                     right: parent.right
                     verticalCenter: parent.verticalCenter
                 }
+            }
+        }
+    }
+
+    RowLayout {
+        id: relayUpsell
+        objectName: _objectName + "-relayUpsell-layout"
+
+        visible: false
+        Layout.fillWidth: true
+        Layout.topMargin: VPNTheme.theme.listSpacing
+        Layout.bottomMargin: VPNTheme.theme.windowMargin
+
+        Component.onCompleted: { /* TODO: Send "upsell viewed" glean ping */ console.log(VPNLocalizer.code, "localizer code") }
+
+        ColumnLayout {
+            Layout.fillWidth: true
+
+            VPNInterLabel {
+                color: VPNTheme.theme.fontColorDark
+                horizontalAlignment: Text.AlignLeft
+                font.pixelSize: VPNTheme.theme.fontSizeSmall
+                text: VPNl18n.SubscriptionManagementAddFirefoxRelay // "Add Firefox Relay"
+                wrapMode: Text.WordWrap
+                lineHeight: 13
+                Layout.alignment: Qt.AlignLeft
+                Layout.fillWidth: true
+                elide: Text.ElideRight
+            }
+
+            VPNLinkButton {
+                objectName: _objectName + "-relayUpsell-learnMoreLink"
+                linkColor: VPNTheme.theme.blueButton
+                fontSize: VPNTheme.theme.fontSizeSmall
+                labelText: VPNl18n.SplittunnelInfoLinkText // "Learn more"
+                Layout.alignment: Qt.AlignLeft
+                Layout.fillWidth: True
+                padding: 4
+                Layout.leftMargin: -4
+
+                onClicked: {
+                    /* TODO: Send "upsell learn more link clicked" glean ping */
+                    VPN.openLink(VPN.LinkRelayPremium);
+                }
+            }
+        }
+
+        VPNButtonBase {
+            objectName: _objectName + "-relayUpsell-upgradeButton"
+
+            onClicked: {
+                /* TODO: Send upsell upgrade button clicked */
+                VPN.openLink(VPN.LinkUpgradeToBundle);
+            }
+
+            contentItem: Label {
+                text: VPNl18n.SubscriptionManagementUpgrade // "Upgrade"
+                font.family: VPNTheme.theme.fontInterFamily
+                font.pixelSize: VPNTheme.theme.fontSizeSmall
+                color: VPNTheme.theme.white
+                anchors.centerIn: parent
+                leftPadding: VPNTheme.theme.windowMargin
+                rightPadding: VPNTheme.theme.windowMargin
+            }
+
+            Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
+            Layout.preferredHeight: VPNTheme.theme.windowMarginb * 2
+
+            VPNUIStates {
+                colorScheme:VPNTheme.theme.blueButton
+                setMargins: -3
+            }
+            VPNMouseArea {
+                id: buttonMouseArea
             }
         }
     }

--- a/src/ui/screens/settings/ViewSubscriptionManagement/SubscriptionManagementItem.qml
+++ b/src/ui/screens/settings/ViewSubscriptionManagement/SubscriptionManagementItem.qml
@@ -216,7 +216,7 @@ ColumnLayout {
                 fontSize: VPNTheme.theme.fontSizeSmall
                 labelText: VPNl18n.SplittunnelInfoLinkText // "Learn more"
                 Layout.alignment: Qt.AlignLeft
-                Layout.fillWidth: True
+                Layout.fillWidth: true
                 padding: 4
                 Layout.leftMargin: -4
 

--- a/src/ui/screens/settings/ViewSubscriptionManagement/ViewSubscriptionManagement.qml
+++ b/src/ui/screens/settings/ViewSubscriptionManagement/ViewSubscriptionManagement.qml
@@ -159,7 +159,7 @@ VPNViewBase {
                     VPNSubscriptionData.planCurrency,
                     VPNSubscriptionData.planAmount,
                 ),
-                type: Qt.locale().nativeCountryName === "United States" && VPNFeatureList.get("bundleUpgrade").isSupported ? "text-upgrade" : "text",
+                type: (Qt.locale().name === "en_US" || Qt.locale().name === "en_CA" ) && VPNFeatureList.get("bundleUpgrade").isSupported ? "text-upgrade" : "text",
             });
         }
 

--- a/src/ui/screens/settings/ViewSubscriptionManagement/ViewSubscriptionManagement.qml
+++ b/src/ui/screens/settings/ViewSubscriptionManagement/ViewSubscriptionManagement.qml
@@ -159,7 +159,7 @@ VPNViewBase {
                     VPNSubscriptionData.planCurrency,
                     VPNSubscriptionData.planAmount,
                 ),
-                type: "text",
+                type: Qt.locale().nativeCountryName === "United States" && VPNFeatureList.get("bundleUpgrade").isSupported ? "text-upgrade" : "text",
             });
         }
 

--- a/translations/strings.yaml
+++ b/translations/strings.yaml
@@ -628,6 +628,13 @@ subscriptionManagement:
   manageSubscriptionButton:
     value: Manage subscription
     comment: Label for a button that will take the user to a view where they can manage their subscription.
+  upgrade:
+    value: Upgrade
+    comment: Label for a button that will take users into the upgrade to VPN / Relay bundle purchase flow.
+  addFirefoxRelay:
+    value: Add Firefox Relay
+    comment: Block of text appearing above a link to learn more about the VPN / Relay bundle offering.
+  
 
 paymentMethods:
   amex: American Express


### PR DESCRIPTION
## Description

This PR:
- Adds "bundleUpgrade" feature
- Adds bundle upgrade UI to in-app subscription management view. This UI is hidden unless:
   -  the bundleUpgrade feature is enabled
   -  the subscription type is "web"
   -  the locale is en_US or en_CA



![Screen Shot 2022-09-01 at 5 53 47 PM](https://user-images.githubusercontent.com/22355127/188026340-766820ea-3e6e-4cde-ba4f-5d07bae30e7f.png)

## Reference
VPN-2726, #4243 

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
