### PR TITLE
Hide navigation bar during speed test

### DIFF
--- a/src/ui/navigator/navigationBar/VPNBottomNavigationBar.qml
+++ b/src/ui/navigator/navigationBar/VPNBottomNavigationBar.qml
@@ -125,6 +125,19 @@ Rectangle {
        }
     }
 
+    Behavior on opacity {
+        PropertyAnimation {
+            duration: 500
+        }
+    }
+
+    Connections {
+        target: VPNConnectionBenchmark
+        onStateChanged: {
+            navbar.opacity = VPNConnectionBenchmark.state === VPNConnectionBenchmark.StateInitial ? 1 : 0
+        }
+    }
+
     ButtonGroup {
         id: navBarButtonGroup
     }

--- a/src/ui/navigator/navigationBar/VPNBottomNavigationBarButton.qml
+++ b/src/ui/navigator/navigationBar/VPNBottomNavigationBarButton.qml
@@ -8,7 +8,7 @@ import Mozilla.VPN 1.0
 import components 0.1
 
 VPNIconButton {
-    id: root
+    id: btn
 
     property var _screen
     property alias _source: image.source
@@ -22,7 +22,8 @@ VPNIconButton {
         VPNNavigator.requestScreen(_screen, VPNNavigator.screen === _screen);
     }
 
-    onCheckedChanged: if (checked) root.forceActiveFocus();
+    onCheckedChanged: if (checked) btn.forceActiveFocus();
+    enabled: root.opacity !== 0
 
 
     Layout.alignment: Qt.AlignHCenter


### PR DESCRIPTION
## Description

   This hides the bottom navigation bar and disables the navigation buttons during connection speed tests

## Reference

VPN-2768, nothing in GH yet.

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
