### PR TITLE
Init and reset menu indicator color

### DIFF
--- a/src/statusicon.cpp
+++ b/src/statusicon.cpp
@@ -183,8 +183,11 @@ void StatusIcon::setIcon(const QString& iconUrl, bool shouldDrawIndicator) {
     m_icon = drawStatusIndicator(m_iconUrl);
   } else {
     m_icon = QIcon(m_iconUrl);
+
+#if !defined(UNIT_TEST)
     // Make sure the indicator color is set initially
     stabilityChanged();
+#endif
   }
 
   emit iconChanged();

--- a/src/statusicon.cpp
+++ b/src/statusicon.cpp
@@ -103,6 +103,7 @@ void StatusIcon::stateChanged() {
   // If we are in a non-main state, we don't need to show special icons.
   if (vpn->state() != MozillaVPN::StateMain) {
     setIcon(LOGO_GENERIC, false);
+    setIndicatorColor(QColor());
     return;
   }
 
@@ -182,6 +183,8 @@ void StatusIcon::setIcon(const QString& iconUrl, bool shouldDrawIndicator) {
     m_icon = drawStatusIndicator(m_iconUrl);
   } else {
     m_icon = QIcon(m_iconUrl);
+    // Make sure the indicator color is set initially
+    stabilityChanged();
   }
 
   emit iconChanged();


### PR DESCRIPTION
## Description

Make sure the indicator color is always set initially and is being reset if we are not in `StateMain`.

## Reference

[VPN-2520](https://mozilla-hub.atlassian.net/browse/VPN-2520): Menu bar status indicators

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
