### PR TITLE
Separate AddonApi per addon

### DIFF
--- a/src/addons/addon.cpp
+++ b/src/addons/addon.cpp
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "addon.h"
+#include "addonapi.h"
 #include "addonguide.h"
 #include "addoni18n.h"
 #include "addonmessage.h"
@@ -469,4 +470,12 @@ void Addon::disable() {
   QCoreApplication::removeTranslator(&m_translator);
 
   emit conditionChanged(false);
+}
+
+AddonApi* Addon::api() {
+  if (!m_api) {
+    m_api = new AddonApi(this);
+  }
+
+  return m_api;
 }

--- a/src/addons/addon.h
+++ b/src/addons/addon.h
@@ -11,6 +11,8 @@
 class AddonConditionWatcher;
 class QJsonObject;
 
+class AddonApi;
+
 class Addon : public QObject {
   Q_OBJECT
   Q_DISABLE_COPY_MOVE(Addon)
@@ -34,6 +36,8 @@ class Addon : public QObject {
 
   virtual bool enabled() const;
 
+  AddonApi* api();
+
  signals:
   void conditionChanged(bool enabled);
   void retranslationCompleted();
@@ -56,6 +60,7 @@ class Addon : public QObject {
 
   QTranslator m_translator;
 
+  AddonApi* m_api = nullptr;
   AddonConditionWatcher* m_conditionWatcher = nullptr;
 };
 

--- a/src/addons/addonapi.cpp
+++ b/src/addons/addonapi.cpp
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "addonapi.h"
+#include "addon.h"
 #include "leakdetector.h"
 #include "logger.h"
 #include "mozillavpn.h"
@@ -13,20 +14,10 @@
 
 namespace {
 Logger logger(LOG_MAIN, "AddonApi");
-
-AddonApi* s_instance = nullptr;
-}  // namespace
-
-// static
-AddonApi* AddonApi::instance() {
-  if (!s_instance) {
-    s_instance = new AddonApi(qApp);
-  }
-
-  return s_instance;
 }
 
-AddonApi::AddonApi(QObject* parent) : QObject(parent) {
+AddonApi::AddonApi(Addon* addon) : QObject(addon) {
+  logger.debug() << "Create API for" << addon->id();
   MVPN_COUNT_CTOR(AddonApi);
 }
 

--- a/src/addons/addonapi.h
+++ b/src/addons/addonapi.h
@@ -11,6 +11,8 @@
 #include <QJSValue>
 #include <QObject>
 
+class Addon;
+
 /*
  * IMPORTANT!! If you add, change or remove this object, please update the
  * documentation in `docs/add-on-api.md`.
@@ -24,7 +26,7 @@ class AddonApi final : public QObject {
   Q_PROPERTY(QJSValue navigator READ navigator CONSTANT)
 
  public:
-  static AddonApi* instance();
+  explicit AddonApi(Addon* addon);
   ~AddonApi();
 
   Q_INVOKABLE void connectSignal(QObject* obj, const QString& signalName,

--- a/src/addons/conditionwatchers/addonconditionwatcherjavascript.cpp
+++ b/src/addons/conditionwatchers/addonconditionwatcherjavascript.cpp
@@ -50,12 +50,12 @@ AddonConditionWatcher* AddonConditionWatcherJavascript::maybeCreate(
 }
 
 AddonConditionWatcherJavascript::AddonConditionWatcherJavascript(
-    QObject* parent, const QJSValue& function)
-    : AddonConditionWatcher(parent) {
+    Addon* addon, const QJSValue& function)
+    : AddonConditionWatcher(addon) {
   MVPN_COUNT_CTOR(AddonConditionWatcherJavascript);
 
   QJSEngine* engine = QmlEngineHolder::instance()->engine();
-  QJSValue api = engine->newQObject(AddonApi::instance());
+  QJSValue api = engine->newQObject(addon->api());
   QJSValue self = engine->newQObject(this);
 
   QJSValue output = function.call(QJSValueList{api, self});

--- a/src/addons/conditionwatchers/addonconditionwatcherjavascript.h
+++ b/src/addons/conditionwatchers/addonconditionwatcherjavascript.h
@@ -27,7 +27,7 @@ class AddonConditionWatcherJavascript final : public AddonConditionWatcher {
   bool conditionApplied() const override;
 
  private:
-  AddonConditionWatcherJavascript(QObject* parent, const QJSValue& function);
+  AddonConditionWatcherJavascript(Addon* addon, const QJSValue& function);
 
  private:
   bool m_currentStatus = false;

--- a/src/composer/composerblockbutton.cpp
+++ b/src/composer/composerblockbutton.cpp
@@ -71,7 +71,7 @@ ComposerBlock* ComposerBlockButton::create(Composer* composer, Addon* addon,
   }
 
   ComposerBlockButton* block =
-      new ComposerBlockButton(composer, style, function);
+      new ComposerBlockButton(composer, addon, style, function);
 
   block->m_text.initialize(QString("%1.block.%2").arg(prefix).arg(blockId),
                            json["content"].toString());
@@ -79,9 +79,12 @@ ComposerBlock* ComposerBlockButton::create(Composer* composer, Addon* addon,
   return block;
 }
 
-ComposerBlockButton::ComposerBlockButton(Composer* composer, Style style,
-                                         const QJSValue& function)
-    : ComposerBlock(composer, "button"), m_style(style), m_function(function) {
+ComposerBlockButton::ComposerBlockButton(Composer* composer, Addon* addon,
+                                         Style style, const QJSValue& function)
+    : ComposerBlock(composer, "button"),
+      m_addon(addon),
+      m_style(style),
+      m_function(function) {
   MVPN_COUNT_CTOR(ComposerBlockButton);
 }
 
@@ -91,7 +94,7 @@ ComposerBlockButton::~ComposerBlockButton() {
 
 void ComposerBlockButton::click() const {
   QJSEngine* engine = QmlEngineHolder::instance()->engine();
-  QJSValue api = engine->newQObject(AddonApi::instance());
+  QJSValue api = engine->newQObject(m_addon->api());
 
   QJSValue output = m_function.call(QJSValueList{api});
   if (output.isError()) {

--- a/src/composer/composerblockbutton.h
+++ b/src/composer/composerblockbutton.h
@@ -36,10 +36,12 @@ class ComposerBlockButton final : public ComposerBlock {
   Q_INVOKABLE void click() const;
 
  private:
-  ComposerBlockButton(Composer* composer, Style style,
+  ComposerBlockButton(Composer* composer, Addon* addon, Style style,
                       const QJSValue& function);
 
  private:
+  Addon* m_addon = nullptr;
+
   AddonProperty m_text;
   const Style m_style;
   const QJSValue m_function;


### PR DESCRIPTION
Having an API object per add-on means that we can store data and we can keep separate state machines for each addon without conflicts.