### PR TITLE
fix: Always set the status icon dimensions to the status bar height

### DIFF
--- a/src/platforms/macos/macosutils.mm
+++ b/src/platforms/macos/macosutils.mm
@@ -190,11 +190,9 @@ void MacOSUtils::patchNSStatusBarSetImageForBigSur() {
 - (void)setImagePatched:(NSImage*)image {
   NSImage* img = image;
 
-  if (@available(macOS 11.0, *)) {
-    if (image != nil) {
-      int thickness = [[NSStatusBar systemStatusBar] thickness];
-      img = [NSImageScalingHelper imageByScaling:image size:NSMakeSize(thickness, thickness)];
-    }
+  if (image != nil) {
+    int thickness = [[NSStatusBar systemStatusBar] thickness];
+    img = [NSImageScalingHelper imageByScaling:image size:NSMakeSize(thickness, thickness)];
   }
 
   [self setImagePatched:img];


### PR DESCRIPTION
## Description

Always scale the status bar icon to fit the status bar height.

## Reference
- [VPN-2520](https://mozilla-hub.atlassian.net/browse/VPN-2520): Status bar scaling issue: https://mozilla-hub.atlassian.net/browse/VPN-2520?focusedCommentId=582118

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
