### PR TITLE
Optimize the filtering of messages

### DIFF
--- a/nebula/ui/components/forms/VPNSearchBar.qml
+++ b/nebula/ui/components/forms/VPNSearchBar.qml
@@ -14,6 +14,7 @@ import components.forms 0.1
 ColumnLayout {
     property var _filterProxyCallback: () => {}
     property var _sortProxyCallback: () => {}
+    property var _editCallback: () => {}
     property alias _filterProxySource: model.source
     property bool _searchBarHasError: false
     property alias _searchBarPlaceholderText: searchBar._placeholderText
@@ -47,6 +48,7 @@ ColumnLayout {
 
         Keys.onPressed: event => {
             if (focus && _searchBarHasError && (/[\w\[\]`!@#$%\^&*()={}:;<>+'-]/).test(event.text)) {
+                _editCallback();
                 event.accepted = true;
             }
         }

--- a/src/ui/screens/messaging/ViewMessagesInbox.qml
+++ b/src/ui/screens/messaging/ViewMessagesInbox.qml
@@ -87,15 +87,9 @@ VPNViewBase {
             _searchBarHasError: !root.isEmptyState && listView.count === 0
 
             _filterProxySource: VPNAddonManager
-            _filterProxyCallback: obj => {
-                                      root.closeAllSwipes()
-                                      root.isEditing = false
-                                      const filterValue = getSearchBarText();
-                                      return obj.addon.type === "message" && obj.addon.containsSearchString(filterValue)
-                                  }
-            _sortProxyCallback: (obj1, obj2) => {
-                                    return obj1.addon.date > obj2.addon.date
-                                }
+            _filterProxyCallback: obj => obj.addon.type === "message" && obj.addon.containsSearchString(getSearchBarText())
+            _sortProxyCallback: (obj1, obj2) => obj1.addon.date > obj2.addon.date
+            _editCallback: () => { root.isEditing = false }
         }
 
         Image {


### PR DESCRIPTION
Without this PR, we close all the swipe at each filtering callback execution which means at least for each message. We just need to do it once when the search input-field value changes.
