### PR TITLE
Flag addon changes for l10n review

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,3 @@
 # Francesco Lodolo as main contact for string changes
+addons/**/manifest.json
 translations/strings.yaml @flodolo


### PR DESCRIPTION
## Description

I've realized addon changes (including strings) are not flagged for review (e.g. https://github.com/mozilla-mobile/mozilla-vpn-client/pull/4351).

This fix is less than ideal, since it will pick up more changes than needed, but the proper approach would be a lot more complex (as part of a workflow actually compare strings.yaml, see if it changes, then flag the l10n reviewer in the PR via gh commands, probably requiring a PAT).

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
