### PR TITLE
add wasm builds to the index

### DIFF
--- a/taskcluster/ci/build/wasm.yml
+++ b/taskcluster/ci/build/wasm.yml
@@ -4,6 +4,7 @@
 ---
 wasm/opt:
     description: "Wasm Build"
+    add-index-routes: "build"
     treeherder:
         symbol: B
         kind: build


### PR DESCRIPTION
The wasm builds are not indexed, let's add them so we can load those up in the wasm viewer as fallback :) 