### PR TITLE
Implement a way to reload all the screens - VPN-2800

### DIFF
--- a/src/frontend/navigator.h
+++ b/src/frontend/navigator.h
@@ -19,6 +19,8 @@ class Navigator final : public QObject {
       Screen screen MEMBER m_currentScreen NOTIFY currentComponentChanged)
   Q_PROPERTY(LoadPolicy loadPolicy MEMBER m_currentLoadPolicy NOTIFY
                  currentComponentChanged)
+  Q_PROPERTY(LoadingFlags loadingFlags MEMBER m_currentLoadingFlags NOTIFY
+                 currentComponentChanged)
   Q_PROPERTY(QQmlComponent* component MEMBER m_currentComponent NOTIFY
                  currentComponentChanged)
 
@@ -26,9 +28,15 @@ class Navigator final : public QObject {
   enum LoadPolicy {
     LoadPersistently,
     LoadTemporarily,
-    ReloadAndLoadPersistently,
   };
   Q_ENUM(LoadPolicy);
+
+  enum LoadingFlags {
+    NoFlags,
+    ForceReload,
+    ForceReloadAll,
+  };
+  Q_ENUM(LoadingFlags);
 
   enum Screen {
     ScreenAuthenticating,
@@ -63,7 +71,8 @@ class Navigator final : public QObject {
 
   ~Navigator();
 
-  Q_INVOKABLE void requestScreen(Screen screen, bool forceReload = false);
+  Q_INVOKABLE void requestScreen(Screen screen,
+                                 LoadingFlags loadingFlags = NoFlags);
   Q_INVOKABLE void requestPreviousScreen();
 
   Q_INVOKABLE void addStackView(Screen screen, const QVariant& stackView);
@@ -83,13 +92,14 @@ class Navigator final : public QObject {
 
   void computeComponent();
   void loadScreen(Screen screen, LoadPolicy loadPolicy,
-                  QQmlComponent* component, bool forceReload);
+                  QQmlComponent* component, LoadingFlags loadingFlags);
 
   void removeItem(QObject* obj);
 
  private:
   Screen m_currentScreen = ScreenInitialize;
   LoadPolicy m_currentLoadPolicy = LoadTemporarily;
+  LoadingFlags m_currentLoadingFlags = NoFlags;
   QQmlComponent* m_currentComponent = nullptr;
 
   QList<Screen> m_screenHistory;

--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -1453,7 +1453,8 @@ void MozillaVPN::requestSettings() {
   logger.debug() << "Settings required";
 
   QmlEngineHolder::instance()->showWindow();
-  Navigator::instance()->requestScreen(Navigator::ScreenSettings, true);
+  Navigator::instance()->requestScreen(Navigator::ScreenSettings,
+                                       Navigator::ForceReload);
 }
 
 void MozillaVPN::requestAbout() {
@@ -1467,7 +1468,7 @@ void MozillaVPN::requestGetHelp() {
   logger.debug() << "Get help menu requested";
 
   QmlEngineHolder::instance()->showWindow();
-  Navigator::instance()->requestScreen(Navigator::ScreenGetHelp, true);
+  Navigator::instance()->requestScreen(Navigator::ScreenGetHelp);
 }
 
 void MozillaVPN::requestViewLogs() {

--- a/src/ui/navigator/navigationBar/VPNBottomNavigationBarButton.qml
+++ b/src/ui/navigator/navigationBar/VPNBottomNavigationBarButton.qml
@@ -19,7 +19,7 @@ VPNIconButton {
     checked: VPNNavigator.screen === _screen
 
     onClicked: {
-        VPNNavigator.requestScreen(_screen, VPNNavigator.screen === _screen);
+        VPNNavigator.requestScreen(_screen, VPNNavigator.screen === _screen ? VPNNavigator.ForceReload : VPNNavigator.NoFlags);
     }
 
     onCheckedChanged: if (checked) btn.forceActiveFocus();

--- a/src/ui/navigator/navigatorLoader.qml
+++ b/src/ui/navigator/navigatorLoader.qml
@@ -25,6 +25,12 @@ StackView {
 
       stackView.currentLoadPolicy = VPNNavigator.loadPolicy;
 
+      if (VPNNavigator.loadingFlags === VPNNavigator.ForceReloadAll) {
+        for (let i = 0; i < stackView.screens.length; ++i) {
+          stackView.get(i+1).sourceComponent = null;
+        }
+      }
+
       // Let's hide the initial empty screen.
       stackView.get(0).visible = false;
 
@@ -34,8 +40,7 @@ StackView {
           stackView.get(i+1).visible = false;
         }
 
-        if (stackView.currentLoadPolicy === VPNNavigator.LoadPersistently ||
-          stackView.currentLoadPolicy === VPNNavigator.ReloadAndLoadPersistently) {
+        if (stackView.currentLoadPolicy === VPNNavigator.LoadPersistently) {
           stackView.screens.push(VPNNavigator.screen);
         }
 
@@ -45,8 +50,9 @@ StackView {
         return;
       }
 
-      if (stackView.currentLoadPolicy === VPNNavigator.ReloadAndLoadPersistently) {
-        stackView.get(pos+1).sourceComponent = undefined;
+      if (stackView.get(pos+1).sourceComponent === null ||
+          (VPNNavigator.loadingFlags === VPNNavigator.ForceReload)) {
+        stackView.get(pos+1).sourceComponent = null;
         stackView.get(pos+1).sourceComponent = VPNNavigator.component;
       }
 


### PR DESCRIPTION
In this PR I introduce a LoadingFlags enum where I can specify the type of loading I want:
- reload the current one
- reload all of them

Then, I use 'reload all of them' when the MozillaVPN state changes. This fixes VPN-2800