### PR TITLE
WasmLoader: Load main branch from the Taskcluster index

### DIFF
--- a/tools/wasm_chrome/branch_selector.mjs
+++ b/tools/wasm_chrome/branch_selector.mjs
@@ -24,7 +24,10 @@ class BranchSelector extends HTMLElement {
 
   #data = [];
 
+  // SHA of the Head Commit of the selected Branch
   value = "";
+  // Name of the Selected branch
+  name = "";
 
   #firedOnload = false;
 

--- a/tools/wasm_chrome/index.html
+++ b/tools/wasm_chrome/index.html
@@ -46,7 +46,10 @@
                 let open_btn = document.querySelector("#open_task");
                 
                 branchSelector.addEventListener("change",() =>{
-                    taskclusterFrame.git_sha = branchSelector.value;
+                    taskclusterFrame.target = {
+                        sha: branchSelector.value,
+                        name: branchSelector.name
+                    } 
 
                     const url = new URL(window.location);
                     url.searchParams.set('branch', branchSelector.name);


### PR DESCRIPTION
We have the "main" branch now on the index. In case we want to load main, let's use that build. So we can load up the latest "successfull" commit instead of getting an error when the build is still running.