### PR TITLE
Android: Add Themed Icon support

### DIFF
--- a/android/resources/all/drawable/ic_mozvpn_mono.xml
+++ b/android/resources/all/drawable/ic_mozvpn_mono.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<inset
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:drawable="@drawable/ic_launcher_foreground"
+    android:insetTop="2.5dp"
+    android:insetRight="2.5dp"
+    android:insetBottom="2.5dp"
+    android:insetLeft="2.5dp"/>

--- a/android/resources/debug/mipmap-anydpi-v26/vpnicon.xml
+++ b/android/resources/debug/mipmap-anydpi-v26/vpnicon.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/vpnicon_background"/>
     <foreground android:drawable="@mipmap/vpnicon_foreground"/>
+    <monochrome android:drawable="@drawable/ic_mozvpn_mono" />
 </adaptive-icon>

--- a/android/resources/release/mipmap-anydpi-v26/vpnicon.xml
+++ b/android/resources/release/mipmap-anydpi-v26/vpnicon.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/vpnicon_background"/>
     <foreground android:drawable="@mipmap/vpnicon_foreground"/>
+    <monochrome android:drawable="@drawable/ic_mozvpn_mono" />
 </adaptive-icon>


### PR DESCRIPTION
Android 13 allowed 3rdparty apps to use the themed icon feature -  https://developer.android.com/about/versions/13/features#themed-app-icons
Android will when the app is on the home screen generate a themed version of the app icon. The app-list is unaffected :) 

![Screenshot_20220912-225928](https://user-images.githubusercontent.com/9611612/189757870-745060de-5783-41b1-b311-5b4104c30dc8.png)
