### PR TITLE
Allow errored searchbar to accept input

### DIFF
--- a/nebula/ui/components/forms/VPNSearchBar.qml
+++ b/nebula/ui/components/forms/VPNSearchBar.qml
@@ -49,7 +49,6 @@ ColumnLayout {
         Keys.onPressed: event => {
             if (focus && _searchBarHasError && (/[\w\[\]`!@#$%\^&*()={}:;<>+'-]/).test(event.text)) {
                 _editCallback();
-                event.accepted = true;
             }
         }
     }


### PR DESCRIPTION
## Description

Prevent errored searchbar inputs from being eaten

## Reference

[VPN-2842: Strange behavior in the search-box in the messaging view](https://mozilla-hub.atlassian.net/browse/VPN-2842)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
