### PR TITLE
Fix try again button on IAP error screen

### DIFF
--- a/src/ui/screens/ScreenNoSubscriptionFoundError.qml
+++ b/src/ui/screens/ScreenNoSubscriptionFoundError.qml
@@ -25,7 +25,7 @@ VPNStackView {
            // Try again
            primaryButtonText: VPNl18n.GenericPurchaseErrorGenericPurchaseErrorButton,
            primaryButtonObjectName: "errorTryAgainButton",
-           primaryButtonOnClick: stackView.pop,
+           primaryButtonOnClick: () => { VPNNavigator.requestScreen(VPNNavigator.ScreenSubscriptionNeeded) },
            secondaryButtonIsSignOff: true,
            getHelpLinkVisible: true,
            popWhenSignOff: true

--- a/src/ui/screens/ScreenSubscriptionExpiredError.qml
+++ b/src/ui/screens/ScreenSubscriptionExpiredError.qml
@@ -25,7 +25,7 @@ VPNStackView {
            // Try again
            primaryButtonText: VPNl18n.GenericPurchaseErrorGenericPurchaseErrorButton,
            primaryButtonObjectName: "errorTryAgainButton",
-           primaryButtonOnClick: stackView.pop,
+           primaryButtonOnClick: () => { VPNNavigator.requestScreen(VPNNavigator.ScreenSubscriptionNeeded) },
            secondaryButtonIsSignOff: false,
            getHelpLinkVisible: true
        });

--- a/src/ui/screens/ScreenSubscriptionGenericError.qml
+++ b/src/ui/screens/ScreenSubscriptionGenericError.qml
@@ -25,7 +25,7 @@ VPNStackView {
            // Try again
            primaryButtonText: VPNl18n.GenericPurchaseErrorGenericPurchaseErrorButton,
            primaryButtonObjectName: "errorTryAgainButton",
-           primaryButtonOnClick: stackView.pop,
+           primaryButtonOnClick: () => { VPNNavigator.requestScreen(VPNNavigator.ScreenSubscriptionNeeded) },
            secondaryButtonIsSignOff: false,
            getHelpLinkVisible: true
        });

--- a/src/ui/sharedViews/ViewErrorFullScreen.qml
+++ b/src/ui/sharedViews/ViewErrorFullScreen.qml
@@ -21,7 +21,7 @@ VPNFlickable {
     property var primaryButtonOnClick
 
     property var secondaryButtonText: ""
-    property var secondaryButtonObjectName
+    property var secondaryButtonObjectName: ""
     property var secondaryButtonOnClick
     property var secondaryButtonIsSignOff: false
     property var popWhenSignOff: false


### PR DESCRIPTION
## Description

Return user to `ViewSubscriptionNeeded` to re-select a subscription option when clicking "Try again" on an IAP full screen error

## Reference

[VPN-2892: [iOS] “Try again” button from “Problem confirming subscription” error screens does not work](https://mozilla-hub.atlassian.net/browse/VPN-2892)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
