### PR TITLE
Fix nav bar visibility bugs

### DIFF
--- a/nebula/ui/components/VPNConnectionInfoScreen.qml
+++ b/nebula/ui/components/VPNConnectionInfoScreen.qml
@@ -195,6 +195,8 @@ Rectangle {
         id: timer
     }
 
+    Component.onDestruction: VPNConnectionBenchmark.reset()
+
     Connections {
       target: VPNNavigator
 

--- a/nebula/ui/components/VPNConnectionInfoScreen.qml
+++ b/nebula/ui/components/VPNConnectionInfoScreen.qml
@@ -195,4 +195,14 @@ Rectangle {
         id: timer
     }
 
+    Connections {
+      target: VPNNavigator
+
+      function onCurrentComponentChanged() {
+          // Stop connection speed test when navigating away from ScreenHome
+          if (isOpen) {
+            closeConnectionInfo();
+          }
+       }
+    }
 }

--- a/src/ui/navigator/navigationBar/VPNBottomNavigationBar.qml
+++ b/src/ui/navigator/navigationBar/VPNBottomNavigationBar.qml
@@ -29,7 +29,7 @@ Rectangle {
     radius: height / 2
     color: VPNTheme.theme.ink
 
-    visible: showNavigationBar.includes(VPNNavigator.screen) && VPN.userState === VPN.UserAuthenticated
+    visible: showNavigationBar.includes(VPNNavigator.screen) && VPN.userState === VPN.UserAuthenticated && VPN.state === VPN.StateMain
 
     anchors {
         horizontalCenter: parent.horizontalCenter
@@ -133,6 +133,7 @@ Rectangle {
                   return;
               }
           }
+          setNavBarOpacity();
        }
     }
 
@@ -145,7 +146,7 @@ Rectangle {
     Connections {
         target: VPNConnectionBenchmark
         function onStateChanged() {
-            navbar.opacity = VPNConnectionBenchmark.state === VPNConnectionBenchmark.StateInitial ? 1 : 0
+            setNavBarOpacity();
         }
     }
 
@@ -157,6 +158,14 @@ Rectangle {
         target: VPNSettings
         function onAddonSettingsChanged() {
             root.getUnreadNotificationStatus()
+        }
+    }
+
+    function setNavBarOpacity() {
+        if (VPNNavigator.screen === VPNNavigator.ScreenHome) {
+            navbar.opacity = VPNConnectionBenchmark.state === VPNConnectionBenchmark.StateInitial ? 1 : 0
+        } else {
+            navbar.opacity = 1;
         }
     }
 


### PR DESCRIPTION
## Description

This PR:
- Prevents the nav bar from becoming visible when VPN.state !== VPN.StateMain (VPN-2828)
- Closes connection speed tests when a user navigates away from ScreenHome, and resets nav bar opacity on Navigator current component changes. (VPN-2891, VPN-2897)

## Reference

VPN-2891, VPN-2828, VPN-2897
## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
