### PR TITLE
Remove platform condition from bundle message

### DIFF
--- a/addons/message_privacy_bundle_staging/manifest.json
+++ b/addons/message_privacy_bundle_staging/manifest.json
@@ -7,7 +7,6 @@
   "conditions": {
     "env": "staging",
     "locales": ["en"],
-    "platforms": ["macos", "linux", "windows"],
     "javascript": "EnableBundleUpgrade.js"
   },
   "message": {


### PR DESCRIPTION
## Description

This removes the platform condition from the privacy bundle in-app message. This means that 
- All devices which meet the locale condition will be eligible to receive the bundle message
- The 'bundleUpgrade' feature will be enabled on devices which receive the bundle message, which unlocks the UI in the subscription management view for a larger pool of people.
- There is additional visibility logic in the subscription management view which will still prevent the upgrade UI in that view from being exposed to users who purchased their subscription through IAP (though they may still receive the bundle message)

## Reference

VPN-2898


## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
