### PR TITLE
Try port53 fallback early

### DIFF
--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -413,15 +413,14 @@ void Controller::handshakeTimeout() {
   // Try again, again if there are sufficient retries left.
   ++m_connectionRetry;
   emit connectionRetryChanged();
-  if (m_connectionRetry < CONNECTION_MAX_RETRY) {
-    activateInternal();
-    return;
-  } else if (m_connectionRetry == CONNECTION_MAX_RETRY &&
-             !SettingsHolder::instance()->tunnelPort53()) {
-    logger.info() << "Last Connection Attempt: Using Port 53 Option this time.";
-    // On the last activation, opportunisticly try again using the port 53
+  if (m_connectionRetry == 1 && !SettingsHolder::instance()->tunnelPort53()) {
+    logger.info() << "Connection Attempt: Using Port 53 Option this time.";
+    // On the first retry, opportunisticly try again using the port 53
     // option enabled, if that feature is disabled.
     activateInternal(true);
+    return;
+  } else if (m_connectionRetry < CONNECTION_MAX_RETRY) {
+    activateInternal();
     return;
   }
 


### PR DESCRIPTION
## Description
Currently, I added a port53 fallback to the end of the activation-retry phase. 
However, not every City has 10 Servers, meaning we might try all servers on the City (and putting them on cooldown) before even attempting to connect to one with p53. 
Let's have the 2nd activation try port 53 and have the rest be classic :) 
