### PR TITLE
Experiment: Auto-select server via GeoIP proximity

### DIFF
--- a/src/cmake/sources.cmake
+++ b/src/cmake/sources.cmake
@@ -314,6 +314,8 @@ target_sources(mozillavpn PRIVATE
     tasks/sendfeedback/tasksendfeedback.h
     tasks/servers/taskservers.cpp
     tasks/servers/taskservers.h
+    tasks/serverselect/taskserverselect.cpp
+    tasks/serverselect/taskserverselect.h
     telemetry.cpp
     telemetry.h
     theme.cpp

--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -33,6 +33,7 @@
 #include "tasks/heartbeat/taskheartbeat.h"
 #include "tasks/products/taskproducts.h"
 #include "tasks/removedevice/taskremovedevice.h"
+#include "tasks/serverselect/taskserverselect.h"
 #include "tasks/servers/taskservers.h"
 #include "tasks/sendfeedback/tasksendfeedback.h"
 #include "tasks/getfeaturelist/taskgetfeaturelist.h"
@@ -323,9 +324,7 @@ void MozillaVPN::initialize() {
 
   Q_ASSERT(!m_private->m_serverData.initialized());
   if (!m_private->m_serverData.fromSettings()) {
-    m_private->m_serverCountryModel.pickRandom(m_private->m_serverData);
-    Q_ASSERT(m_private->m_serverData.initialized());
-    m_private->m_serverData.writeSettings();
+    TaskScheduler::scheduleTask(new TaskServerSelect());
   }
 
   QList<Task*> refreshTasks{new TaskAccount(), new TaskServers(),
@@ -646,9 +645,7 @@ void MozillaVPN::serversFetched(const QByteArray& serverData) {
   // The serverData could be unset or invalid with the new server list.
   if (!m_private->m_serverData.initialized() ||
       !m_private->m_serverCountryModel.exists(m_private->m_serverData)) {
-    m_private->m_serverCountryModel.pickRandom(m_private->m_serverData);
-    Q_ASSERT(m_private->m_serverData.initialized());
-    m_private->m_serverData.writeSettings();
+    TaskScheduler::scheduleTask(new TaskServerSelect());
   }
 }
 

--- a/src/tasks/serverselect/taskserverselect.cpp
+++ b/src/tasks/serverselect/taskserverselect.cpp
@@ -1,0 +1,95 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "taskserverselect.h"
+#include "errorhandler.h"
+#include "leakdetector.h"
+#include "logger.h"
+#include "mozillavpn.h"
+#include "networkrequest.h"
+
+#include <QtMath>
+#include <QJsonDocument>
+#include <QJsonObject>
+
+// !!!DO NOT MERGE!!!
+// FIXME: Use of this API is permitted for project use only, we would need
+// to purchase an API key for commercial usage, or we just add lat/long client
+// coordinates to the guardian ipinfo API. But hopefully this is fine as a
+// proof-of-concept.
+constexpr const char* SERVER_GUESS_GEOIP_URL = "https://json.geoiplookup.io/";
+
+namespace {
+Logger logger(LOG_MAIN, "TaskServerSelect");
+}
+
+TaskServerSelect::TaskServerSelect() : Task("TaskServerSelect") {
+  MVPN_COUNT_CTOR(TaskServerSelect);
+}
+
+TaskServerSelect::~TaskServerSelect() { MVPN_COUNT_DTOR(TaskServerSelect); }
+
+void TaskServerSelect::run() {
+  NetworkRequest* request =
+      NetworkRequest::createForGetUrl(this, SERVER_GUESS_GEOIP_URL, 200);
+
+  connect(
+      request, &NetworkRequest::requestFailed, this,
+      [this](QNetworkReply::NetworkError error, const QByteArray&) {
+        logger.error() << "Failed to retrieve client GeoIP";
+        MozillaVPN::instance()->errorHandle(ErrorHandler::toErrorType(error));
+        emit completed();
+      });
+
+  connect(request, &NetworkRequest::requestCompleted, this,
+      [this](const QByteArray& data){
+        processData(data);
+        emit completed();
+      });
+}
+
+void TaskServerSelect::processData(const QByteArray& data) {
+  QJsonDocument json = QJsonDocument::fromJson(data);
+  if (!json.isObject()) {
+    logger.error() << "Invalid data returned from the GeoIP lookup";
+    return;
+  }
+  QJsonObject obj = json.object();
+  double latitude = obj.value("latitude").toDouble();
+  double longitude = obj.value("longitude").toDouble();
+  double clientSin = qSin(latitude * M_PI / 180.0);
+  double clientCos = qCos(latitude * M_PI / 180.0);
+  logger.debug() << "Client located at"
+                 << logger.sensitive(QString::number(latitude))
+                 << logger.sensitive(QString::number(longitude));
+
+  // We rank cities using the distance between two points on a great circle,
+  // which is given by:
+  //    d = acos(sin(lat1)*sin(lat2) + cos(lat1)*cos(lat2)*cos(long1-long2))
+  QString bestCountry;
+  QString bestCity;
+  double bestDistance = M_2_PI; 
+  ServerCountryModel* scm = MozillaVPN::instance()->serverCountryModel();
+  for (const ServerCountry& country : scm->countries()) {
+    for (const ServerCity& city : country.cities()) {
+      double citySin = qSin(city.latitude() * M_PI / 180.0);
+      double cityCos = qCos(city.latitude() * M_PI / 180.0);
+      double diffCos = qCos((city.longitude() - longitude) * M_PI / 180.0);
+      double distance = qAcos(clientSin*citySin + clientCos*cityCos*diffCos);
+
+      if (distance < bestDistance) {
+        bestCountry = country.code();
+        bestCity = city.name();
+        bestDistance = distance;
+      }
+    }
+  }
+
+  ServerData* sd = MozillaVPN::instance()->currentServer();
+  if (!bestCountry.isEmpty() && !bestCity.isEmpty()) {
+    sd->update(bestCountry, bestCity);
+    Q_ASSERT(sd->initialized());
+    sd->writeSettings();
+  }
+}

--- a/src/tasks/serverselect/taskserverselect.h
+++ b/src/tasks/serverselect/taskserverselect.h
@@ -1,0 +1,25 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef TASKSERVERSELECT_H
+#define TASKSERVERSELECT_H
+
+#include "task.h"
+
+#include <QObject>
+
+class TaskServerSelect final : public Task {
+  Q_DISABLE_COPY_MOVE(TaskServerSelect)
+
+ public:
+  TaskServerSelect();
+  ~TaskServerSelect();
+
+  void run() override;
+
+ private:
+  void processData(const QByteArray& data);
+};
+
+#endif  // TASKSERVERSELECT_H


### PR DESCRIPTION
## Description
A significant number of our users will often find themselves installing the VPN client, and using it in its default configuration indefinitely, meaning that they may never actually change their server away from the randomly-selected initial value. This can result in poor VPN performance if the random selection chooses a server on the opposite side of the internet.

A better approach for this initial selection would be to choose the nearest location and hope that it happens to correlate to the best network performance.

At present, we don't receive the client's latitude and longitude from the guardian, so for a proof of concept we are making use of a third party API to receive GeoIP data.

## Reference
Issue #3682 ([VPN-2333](https://mozilla-hub.atlassian.net/browse/VPN-2333))

## Checklist
- [ ] Implement or update a guardian API to provide GeoIP data (latitude/longitude).
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
