### PR TITLE
Hide bundle upgrade if already subscribed

### DIFF
--- a/src/constants.h
+++ b/src/constants.h
@@ -127,6 +127,9 @@ PRODBETAEXPR(
 PRODBETAEXPR(const char*, relayUrl, "https://relay.firefox.com",
              "https://stage.fxprivaterelay.nonprod.cloudops.mozgcp.net");
 
+PRODBETAEXPR(QString, privacyBundleProductId, "prod_MIex7Q079igFZJ",
+             "prod_LcfR3EzYMVJlZQ");
+
 PRODBETAEXPR(qint64, keyRegeneratorTimeSec, 604800, 300);
 
 #undef PRODBETAEXPR

--- a/src/models/subscriptiondata.cpp
+++ b/src/models/subscriptiondata.cpp
@@ -163,8 +163,8 @@ bool SubscriptionData::fromJson(const QByteArray& json) {
     }
 
     QJsonArray subscriptionsList = paymentData["subscriptions"].toArray();
-    for (int i = 0; i < subscriptionsList.count(); i++) {
-      QJsonObject subscription = subscriptionsList.at(i).toObject();
+    for (QJsonValue subscriptionValue : subscriptionsList) {
+      QJsonObject subscription = subscriptionValue.toObject();
       if (subscription["product_id"] == Constants::privacyBundleProductId()) {
         m_isPrivacyBundleSubscriber = true;
         break;

--- a/src/models/subscriptiondata.cpp
+++ b/src/models/subscriptiondata.cpp
@@ -164,8 +164,8 @@ bool SubscriptionData::fromJson(const QByteArray& json) {
 
     QJsonArray subscriptionsList = paymentData["subscriptions"].toArray();
     for (int i = 0; i < subscriptionsList.count(); i++) {
-      if (subscriptionsList.at(i)["product_id"] ==
-          Constants::privacyBundleProductId()) {
+      QJsonObject subscription = subscriptionsList.at(i).toObject();
+      if (subscription["product_id"] == Constants::privacyBundleProductId()) {
         m_isPrivacyBundleSubscriber = true;
         break;
       }

--- a/src/models/subscriptiondata.cpp
+++ b/src/models/subscriptiondata.cpp
@@ -10,6 +10,7 @@
 #include "telemetry/gleansample.h"
 
 #include <QDateTime>
+#include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QJsonValue>
@@ -161,6 +162,15 @@ bool SubscriptionData::fromJson(const QByteArray& json) {
       return false;
     }
 
+    QJsonArray subscriptionsList = paymentData["subscriptions"].toArray();
+    for (int i = 0; i < subscriptionsList.count(); i++) {
+      if (subscriptionsList.at(i)["product_id"] ==
+          Constants::privacyBundleProductId()) {
+        m_isPrivacyBundleSubscriber = true;
+        break;
+      }
+    }
+
     // We show card details only for stripe
     if (m_paymentProvider == "stripe") {
       m_creditCardBrand = paymentData["brand"].toString();
@@ -237,6 +247,7 @@ void SubscriptionData::resetData() {
   m_createdAt = 0;
   m_expiresOn = 0;
   m_isCancelled = false;
+  m_isPrivacyBundleSubscriber = false;
 
   m_planBillingInterval = BillingIntervalUnknown;
   m_planAmount = 0;

--- a/src/models/subscriptiondata.h
+++ b/src/models/subscriptiondata.h
@@ -19,6 +19,8 @@ class SubscriptionData final : public QObject {
   Q_PROPERTY(quint64 createdAt MEMBER m_createdAt CONSTANT)
   Q_PROPERTY(quint64 expiresOn MEMBER m_expiresOn CONSTANT)
   Q_PROPERTY(bool isCancelled MEMBER m_isCancelled CONSTANT)
+  Q_PROPERTY(bool isPrivacyBundleSubscriber MEMBER m_isPrivacyBundleSubscriber
+                 CONSTANT)
 
   // Plan
   Q_PROPERTY(TypeBillingInterval planBillingInterval MEMBER
@@ -79,6 +81,7 @@ class SubscriptionData final : public QObject {
   quint64 m_createdAt = 0;
   quint64 m_expiresOn = 0;
   bool m_isCancelled = false;
+  bool m_isPrivacyBundleSubscriber = false;
 
   TypeBillingInterval m_planBillingInterval = BillingIntervalUnknown;
   int m_planAmount = 0;

--- a/src/ui/screens/settings/ViewSubscriptionManagement/ViewSubscriptionManagement.qml
+++ b/src/ui/screens/settings/ViewSubscriptionManagement/ViewSubscriptionManagement.qml
@@ -159,7 +159,7 @@ VPNViewBase {
                     VPNSubscriptionData.planCurrency,
                     VPNSubscriptionData.planAmount,
                 ),
-                type: (Qt.locale().name === "en_US" || Qt.locale().name === "en_CA" ) && VPNFeatureList.get("bundleUpgrade").isSupported ? "text-upgrade" : "text",
+                type: (!VPNSubscriptionData.isPrivacyBundleSubscriber && Qt.locale().name === "en_US" || Qt.locale().name === "en_CA" ) && VPNFeatureList.get("bundleUpgrade").isSupported ? "text-upgrade" : "text",
             });
         }
 


### PR DESCRIPTION
## Description
This PR:
1.) looks through the user's list of subscriptions for a bundle subscription and
2.) hides bundle upgrade paths in ViewSubscriptionManagement if a bundle subscription exists

@flozia , @bakulf These changes were requested by PM on Thursday. You two are more familiar with the gotchas and things that can go wrong here. If this doesn't seem scary, it'd be nice to get it in but I don't want to introduce something that could cause us a lot of potential grief at this late stage. What do we think?

## Reference

[VPN-2913](https://mozilla-hub.atlassian.net/browse/VPN-2913)
## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
