### PR TITLE
Center menu title and elide when appropriate

### DIFF
--- a/nebula/ui/components/VPNMenu.qml
+++ b/nebula/ui/components/VPNMenu.qml
@@ -12,7 +12,6 @@ Item {
 
     property alias objectName: iconButton.objectName
     property alias title: title.text
-    property alias rightTitle: rightTitle.text
     property bool accessibleIgnored: false
     property bool btnDisabled: false
     property alias forceFocus: iconButton.focus
@@ -38,77 +37,51 @@ Item {
         anchors.fill: parent
     }
 
-    RowLayout {
-        id: row
+    VPNIconButton {
+        id: iconButton
 
-        objectName: "menuBar"
-        anchors {
-            fill: parent
-            margins: VPNTheme.theme.windowMargin / 2
+        skipEnsureVisible: true // prevents scrolling of lists when this is focused
+
+        onClicked: _menuOnBackClicked()
+
+        anchors.verticalCenter: parent.verticalCenter
+        anchors.left: parent.left
+        anchors.leftMargin: VPNTheme.theme.windowMargin / 2
+
+        accessibleName: _menuIconButtonSource.includes("close") ? qsTrId("vpn.connectionInfo.close") : qsTrId("vpn.main.back")
+        Accessible.ignored: accessibleIgnored
+        height: VPNTheme.theme.rowHeight
+        width: VPNTheme.theme.rowHeight
+        enabled: !btnDisabled
+        opacity: enabled ? 1 : .4
+
+        Image {
+            objectName: "menuIcon"
+            source: _menuIconButtonSource
+            sourceSize.width: VPNTheme.theme.iconSize
+            fillMode: Image.PreserveAspectFit
+            anchors.centerIn: iconButton
         }
-        spacing: VPNTheme.theme.windowMargin / 4
+    }
 
-        VPNIconButton {
-            id: iconButton
+    VPNBoldLabel {
+        id: title
 
-            skipEnsureVisible: true // prevents scrolling of lists when this is focused
+        anchors.centerIn: parent
+        width: getTitleWidth()
 
-            onClicked: _menuOnBackClicked()
-            Layout.alignment: Qt.AlignLeft
-
-            accessibleName: _menuIconButtonSource.includes("close") ? qsTrId("vpn.connectionInfo.close") : qsTrId("vpn.main.back")
-            Accessible.ignored: accessibleIgnored
-            Layout.preferredHeight: VPNTheme.theme.rowHeight
-            Layout.preferredWidth: VPNTheme.theme.rowHeight
-            enabled: !btnDisabled
-            opacity: enabled ? 1 : .4
-
-            Image {
-                objectName: "menuIcon"
-                source: _menuIconButtonSource
-                sourceSize.width: VPNTheme.theme.iconSize
-                fillMode: Image.PreserveAspectFit
-                anchors.centerIn: iconButton
-            }
-        }
-
-        // This is a hack to preven the menu title from being thrown off horizontal center by varying 'rightTitle' widths.
-        Rectangle {
-            Layout.preferredWidth: rightTitle.width > VPNTheme.theme.rowHeight ? Math.max(rightTitle.width - VPNTheme.theme.rowHeight - row.spacing, 0) : 0
-            Layout.preferredHeight: parent.height
-            color: VPNTheme.theme.transparent
-        }
-
-        VPNBoldLabel {
-            id: title
-
-            Layout.alignment: Qt.AlignHCenter
-            Layout.fillWidth: true
-            visible: text !== ""
-            elide: Text.ElideRight
-            Accessible.ignored: accessibleIgnored
-            horizontalAlignment: Text.AlignHCenter
-            verticalAlignment: Text.AlignVCenter
-        }
-
-        VPNLightLabel {
-            id: rightTitle
-
-            visible: text !== ""
-            Layout.alignment: Qt.AlignVCenter | Qt.AlignRight
-            Layout.minimumWidth: VPNTheme.theme.rowHeight
-            Layout.maximumWidth: row.width / 3
-            elide: Text.ElideRight
-            Accessible.ignored: accessibleIgnored
-            rightPadding: VPNTheme.theme.windowMargin / 2
-            horizontalAlignment: Text.AlignRight
-        }
+        visible: text !== ""
+        elide: Text.ElideRight
+        Accessible.ignored: accessibleIgnored
+        horizontalAlignment: Text.AlignHCenter
+        verticalAlignment: Text.AlignVCenter
     }
 
     Loader {
         id: titleLoader
 
         anchors.centerIn: parent
+        width: getTitleWidth()
 
         sourceComponent: menuBar.titleComponent
     }
@@ -121,6 +94,14 @@ Item {
         anchors.rightMargin: VPNTheme.theme.windowMargin
 
         sourceComponent: menuBar.rightButtonComponent
+        onItemChanged: {
+            if (item instanceof Text) {
+                anchors.rightMargin = VPNTheme.theme.windowMargin
+            }
+            else if(item instanceof VPNIconButton) {
+                anchors.rightMargin = VPNTheme.theme.windowMargin / 2
+            }
+        }
     }
 
     Rectangle {
@@ -128,5 +109,10 @@ Item {
         anchors.bottom: parent.bottom
         width: parent.width
         height: 1
+    }
+
+    function getTitleWidth() {
+        return Math.min(parent.width - iconButton.width - rightMenuButtonLoader.width - iconButton.anchors.leftMargin - rightMenuButtonLoader.anchors.rightMargin,
+                        parent.width - (Math.max(rightMenuButtonLoader.width + rightMenuButtonLoader.anchors.rightMargin, iconButton.width + iconButton.anchors.leftMargin)) * 2 - 8)
     }
 }

--- a/src/ui/screens/devices/ViewDevices.qml
+++ b/src/ui/screens/devices/ViewDevices.qml
@@ -10,10 +10,17 @@ import Mozilla.VPN 1.0
 import components 0.1
 
 VPNViewBase {
+    id: vpnFlickable
     property var isModalDialogOpened: removePopup.visible
     property var wasmView
-
-    id: vpnFlickable
+    property string deviceCountLabelText: ""
+    property Component rightMenuButton: Component {
+        VPNLightLabel {
+            text: vpnFlickable.deviceCountLabelText
+            elide: Text.ElideRight
+            horizontalAlignment: Text.AlignRight
+        }
+    }
 
     state: VPN.state !== VPN.StateDeviceLimit ? "active" : "deviceLimit"
 
@@ -113,10 +120,10 @@ VPNViewBase {
             name: "active" // normal mode
 
             PropertyChanges {
-                target: menu
+                target: vpnFlickable
                 //% "%1 of %2"
                 //: Example: You have "x of y" devices in your account, where y is the limit of allowed devices.
-                rightTitle: qsTrId("vpn.devices.activeVsMaxDeviceCount").arg(VPNDeviceModel.activeDevices).arg(VPNUser.maxDevices)
+                deviceCountLabelText: qsTrId("vpn.devices.activeVsMaxDeviceCount").arg(VPNDeviceModel.activeDevices).arg(VPNUser.maxDevices)
             }
             PropertyChanges {
                 target: col
@@ -131,10 +138,10 @@ VPNViewBase {
             name: "deviceLimit"
 
             PropertyChanges {
-                target: menu
+                target: vpnFlickable
                 //% "%1 of %2"
                 //: Example: You have "x of y" devices in yor account, where y is the limit of allowed devices.
-                rightTitle: qsTrId("vpn.devices.activeVsMaxDeviceCount").arg(VPNDeviceModel.activeDevices + 1).arg(VPNUser.maxDevices)
+                deviceCountLabelText: qsTrId("vpn.devices.activeVsMaxDeviceCount").arg(VPNDeviceModel.activeDevices + 1).arg(VPNUser.maxDevices)
             }
             PropertyChanges {
                 target: col

--- a/src/ui/screens/messaging/ViewMessage.qml
+++ b/src/ui/screens/messaging/ViewMessage.qml
@@ -15,20 +15,32 @@ VPNViewBase {
 
     property Component titleComponent: Component {
         RowLayout {
+            id: row
             spacing: 6
 
+            Item {
+                Layout.fillWidth: true
+            }
+
             VPNIcon {
+                id: logo
                 source: "qrc:/ui/resources/logo.svg"
                 sourceSize.height: 20
                 sourceSize.width: 20
                 antialiasing: true
-                Layout.alignment: Qt.AlignVCenter
             }
 
             VPNBoldLabel {
                 text: qsTrId("MozillaVPN")
                 color: "#000000"
-                Layout.alignment: Qt.AlignVCenter
+                horizontalAlignment: Text.AlignHCenter
+                verticalAlignment: Text.AlignVCenter
+                elide: Text.ElideRight
+                Layout.preferredWidth: Math.min(implicitWidth, row.width - row.spacing - logo.sourceSize.width)
+            }
+
+            Item {
+                Layout.fillWidth: true
             }
         }
     }
@@ -37,6 +49,7 @@ VPNViewBase {
             id: deleteButton
 
             accessibleName: VPNl18n.InAppMessagingDeleteMessage
+            anchors.rightMargin: 32
 
             VPNIcon {
                 id: icon
@@ -44,6 +57,7 @@ VPNViewBase {
                 anchors.centerIn: parent
                 source: "qrc:/nebula/resources/delete-gray.svg"
             }
+
             onClicked: {
                 stackview.pop()
                 message.dismiss()


### PR DESCRIPTION
## Description

- Menu title is always centered
- Menu title elides instead of overlapping menu actions

Examples of eliding:
<img width="472" alt="Screen Shot 2022-09-19 at 10 43 09 AM" src="https://user-images.githubusercontent.com/15353801/191044881-1dabdf97-d8a1-4c4e-9dd5-926fa16d1db6.png">
<img width="472" alt="Screen Shot 2022-09-19 at 10 44 34 AM" src="https://user-images.githubusercontent.com/15353801/191045207-396cf137-0049-4f76-8355-2ae688d50a12.png">


## Reference

[VPN-2799: Menu title is glitchy, off-center on some views](https://mozilla-hub.atlassian.net/browse/VPN-2799)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
