### PR TITLE
Reduce logging of tunnel service command line.

### DIFF
--- a/src/platforms/windows/daemon/windowstunnelservice.cpp
+++ b/src/platforms/windows/daemon/windowstunnelservice.cpp
@@ -97,7 +97,7 @@ void WindowsTunnelService::timeout() {
   emit backendFailure();
 }
 
-bool WindowsTunnelService::start(const QString& configFile) {
+bool WindowsTunnelService::start(const QString& configData) {
   logger.debug() << "Starting the tunnel service";
 
   m_logworker = new WindowsTunnelLogger(WindowsCommons::tunnelLogFile());
@@ -127,19 +127,19 @@ bool WindowsTunnelService::start(const QString& configFile) {
     service = nullptr;
   }
 
-  QString servicePath;
+  QString serviceCmdline;
   {
-    QTextStream out(&servicePath);
+    QTextStream out(&serviceCmdline);
     out << "\"" << qApp->applicationFilePath() << "\" tunneldaemon \""
-        << configFile << "\"";
+        << configData << "\"";
   }
 
-  logger.debug() << "Service name:" << servicePath;
+  logger.debug() << "Service:" << qApp->applicationFilePath();
 
   service = CreateService(scm, TUNNEL_SERVICE_NAME, L"Mozilla VPN (tunnel)",
                           SERVICE_ALL_ACCESS, SERVICE_WIN32_OWN_PROCESS,
                           SERVICE_DEMAND_START, SERVICE_ERROR_NORMAL,
-                          (const wchar_t*)servicePath.utf16(), nullptr, 0,
+                          (const wchar_t*)serviceCmdline.utf16(), nullptr, 0,
                           TEXT("Nsi\0TcpIp\0"), nullptr, nullptr);
   if (!service) {
     WindowsCommons::windowsLog("Failed to create the tunnel service");

--- a/src/platforms/windows/daemon/windowstunnelservice.h
+++ b/src/platforms/windows/daemon/windowstunnelservice.h
@@ -20,7 +20,7 @@ class WindowsTunnelService final : public QObject {
   WindowsTunnelService(QObject* parent = nullptr);
   ~WindowsTunnelService();
 
-  bool start(const QString& configFile);
+  bool start(const QString& configData);
   void stop();
   bool isRunning();
   QString uapiCommand(const QString& command);


### PR DESCRIPTION
## Description
After some refactoring of the windows daemon startup, we are now leaking a bit too much data into the backend logs. We can close some of this by stripping the arguments from the daemon command line.

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
