### PR TITLE
Fix when edit callback is triggered for search bar

### DIFF
--- a/nebula/ui/components/forms/VPNSearchBar.qml
+++ b/nebula/ui/components/forms/VPNSearchBar.qml
@@ -46,7 +46,7 @@ ColumnLayout {
 
 
         Keys.onPressed: event => {
-            if (focus && _searchBarHasError && (/[\w\[\]`!@#$%\^&*()={}:;<>+'-]/).test(event.text)) {
+            if (focus && ((/[\w\[\]`!@#$%\^&*()={}:;<>+'-]/).test(event.text) || event.key === Qt.Key_Backspace || event.key === Qt.Key_Delete)) {
                 _editCallback();
             }
         }


### PR DESCRIPTION
## Description

- Trigger the search bar edit callback when text is deleted (not just added) and remove `_searchBarHasError` criteria

## Reference

[VPN-2895: Messages are not swiped close when being in the “Edit” mode and using the search bar](https://mozilla-hub.atlassian.net/browse/VPN-2895)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
