### PR TITLE
Clean up Taskgraph definition test

### DIFF
--- a/taskcluster/ci/test/kind.yml
+++ b/taskcluster/ci/test/kind.yml
@@ -26,9 +26,6 @@ tasks:
             use-caches: true
             cwd: '{checkout}'
             command: >-
-                pip3 install -r requirements.txt &&
                 pip3 install -r taskcluster/requirements.txt &&
-                taskgraph full --p taskcluster/test/params/main-push.yml &&
-                taskgraph full --p taskcluster/test/params/pull-request.yml &&
-                taskgraph full --p taskcluster/test/params/release-push.yml &&
+                taskgraph full --p taskcluster/test/params &&
                 taskgraph full


### PR DESCRIPTION
## Description

- Don't install extra dependencies that won't be in the `taskgraph` decision task on the test
- Use `taskgraph full -p taskcluster/test/params` to run `taskgraph` with the parameter files

cc @strseb 

## Reference

#4341 

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
