### PR TITLE
Remove beetmover release triggers

### DIFF
--- a/taskcluster/ci/beetmover/kind.yml
+++ b/taskcluster/ci/beetmover/kind.yml
@@ -20,7 +20,7 @@ tasks:
         worker:
             chain-of-trust: true
             max-run-time: 1800
-        run-on-tasks-for: [github-release, action:release-promotion]
+        run-on-tasks-for: [action:release-promotion]
         release-artifacts: [MozillaVPN.pkg]
         dependencies:
             signing: signing-macos/opt
@@ -37,7 +37,7 @@ tasks:
         worker:
             chain-of-trust: true
             max-run-time: 1800
-        run-on-tasks-for: [github-release, action:release-promotion]
+        run-on-tasks-for: [action:release-promotion]
         release-artifacts: [MozillaVPN.msi]
         dependencies:
             repackage-signing: repackage-signing-msi


### PR DESCRIPTION
## Description

Stop uploading `release` graph client builds to the Mozilla archive automatically.

cc @bakulf @ahal 

## Reference

#4341 

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
