### PR TITLE
Horrible hack to make iOS work

### DIFF
--- a/src/connectionhealth.cpp
+++ b/src/connectionhealth.cpp
@@ -137,6 +137,10 @@ void ConnectionHealth::setStability(ConnectionStability stability) {
     emit MozillaVPN::instance()->recordGleanEvent(
         GleanSample::connectionHealthUnstable);
   } else if (stability == NoSignal) {
+#ifdef MVPN_IOS
+    MozillaVPN::instance()->silentSwitch();
+#endif
+
     emit MozillaVPN::instance()->recordGleanEvent(
         GleanSample::connectionHealthNoSignal);
   }


### PR DESCRIPTION
This is a horrible temporary solution. But here a few considerations:
- We used to have a connectionCheck component that was in charge of restarting the controllerimpl connection. Maybe removing it was a bad idea.
- We still don't know why this happens. It seems a bug in wireguard, but why does it happen only with MozillaVPN? (no data to prove it works elsewhere...)
- So far, what I understood is that the problem is in the network setup. Somehow when the networkExtensions starts, "something" is not ready yet and the wireguard handshake fails. We do not recover from this scenario even if the handshake is restarted every 5 secs.