### PR TITLE
Fix android exception when no fallback server is present.

### DIFF
--- a/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/VPNService.kt
+++ b/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/VPNService.kt
@@ -235,17 +235,21 @@ class VPNService : android.net.VpnService() {
 
         if (useFallbackServer) {
             mConnectionHealth.start(
-                json.getJSONObject("server").getString("ipv4AddrIn"),
+                json.getJSONObject("serverFallback").getString("ipv4AddrIn"),
                 json.getJSONObject("serverFallback").getString("ipv4Gateway"),
                 json.getJSONObject("serverFallback").getString("ipv4Gateway"),
-                json.getJSONObject("serverFallback").getString("ipv4AddrIn")
+                json.getJSONObject("server").getString("ipv4AddrIn")
             )
         } else {
+            var fallbackIpv4 = ""
+            if (json.has("serverFallback")) {
+                fallbackIpv4 = json.getJSONObject("serverFallback").getString("ipv4AddrIn")
+            }
             mConnectionHealth.start(
                 json.getJSONObject("server").getString("ipv4AddrIn"),
                 json.getJSONObject("server").getString("ipv4Gateway"),
                 json.getString("dns"),
-                json.getJSONObject("serverFallback").getString("ipv4Gateway")
+                fallbackIpv4
             )
         }
     }


### PR DESCRIPTION
## Description
For some locations, it is possible that we might find ourselves without any fallback servers (eg: Skopje, Macedonia has only a single server). When trying to connect to such a location, we encounter an exception in `VPNService.kt` when parsing the connection parameters from JSON.

To fix this, we attempt to check for the existence of `serverFallback` before attempting to parse it.

## Reference
Github #4569 ([VPN-2978](https://mozilla-hub.atlassian.net/browse/VPN-2978))

## Checklist
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
