### PR TITLE
No ticket - Do not set Glean debug view tag by default

### DIFF
--- a/src/ui/main.qml
+++ b/src/ui/main.qml
@@ -141,7 +141,10 @@ Window {
             if (VPN.debugMode) {
                 console.debug("Initializing glean with debug mode");
                 Glean.setLogPings(true);
-                Glean.setDebugViewTag("MozillaVPN");
+                // Uncomment for debugging purposes.
+                // See: https://mozilla.github.io/glean/book/reference/debug/debugViewTag.html#debug-view-tag
+                //
+                // Glean.setDebugViewTag("MozillaVPN");
             }
             var channel = VPN.stagingMode ? "staging" : "production";
 
@@ -176,7 +179,7 @@ Window {
         }
 
         function onAboutToQuit() {
-            console.debug("about to quit, shutdown Glean"); 
+            console.debug("about to quit, shutdown Glean");
             // Submit the main ping in case there are outstading metrics in storage before shutdown.
             Pings.main.submit();
             // Use glean's built-in shutdown method - https://mozilla.github.io/glean/book/reference/general/shutdown.html

--- a/tests/qml/tst_mainWindowGleanMocks.qml
+++ b/tests/qml/tst_mainWindowGleanMocks.qml
@@ -19,7 +19,6 @@ Item {
         property var spyConfig
         property var spyTags
         property var spyLogPings
-        property var spySetDebugViewTag
         property var spyShutdownCalled: false
         property var spyUploadEnabled
 
@@ -40,10 +39,6 @@ Item {
                 spyLogPings = flag
             }
             Glean.setLogPings = mockGleanSetLogPings;
-            function mockGleanSetDebugViewTag(tag) {
-                spySetDebugViewTag = tag
-            }
-            Glean.setDebugViewTag = mockGleanSetDebugViewTag;
             function mockGleanShutdown() {
                 // Should be false before setting it to true in this function.
                 // Helps protect us from bad testing state.
@@ -112,22 +107,20 @@ Item {
             TestHelper.debugMode = false
             TestHelper.triggerInitializeGlean()
             compare(spyLogPings, undefined)
-            compare(spySetDebugViewTag, undefined)
 
             TestHelper.debugMode = true
             TestHelper.triggerInitializeGlean()
             compare(spyLogPings, true)
-            compare(spySetDebugViewTag, "MozillaVPN")
         }
 
         /*
-         * TODO - We should also have a companion unit test for the 
+         * TODO - We should also have a companion unit test for the
          * mozillavpn method mainWindowLoaded that checks that:
          * a) mainWindowLoaded calls initializeGlean
          * b) sets up a timer
          *
          * But we don't have a way to test mozillavpn.cpp functions yet.
-         * I have added to the integration test cases to cover our bases 
+         * I have added to the integration test cases to cover our bases
          * on these test cases.
         */
     }


### PR DESCRIPTION
The debug view tag is a feature that should really only be used when developing / testing Glean instrumentation, because it will redirect pings to the Glean ping debug viewer (https://debug-ping-preview.firebaseapp.com/pings/MozillaVPN).

By leaving it default on we are in practice just flooding the data pipeline and debug viewer for no reason.