### PR TITLE
Fix the compilation of Qt6.4

### DIFF
--- a/src/connectionbenchmark/benchmarktaskdownload.cpp
+++ b/src/connectionbenchmark/benchmarktaskdownload.cpp
@@ -47,7 +47,7 @@ void BenchmarkTaskDownload::handleState(BenchmarkTask::State state) {
     m_dnsLookup.setNameserver(QHostAddress(MULLVAD_DEFAULT_DNS));
 #endif
 
-#if QT_VERSION >= 0x060400
+#if QT_VERSION >= 0x060500
 #  error Check if QT added support for QDnsLookup::lookup() on Android
 #endif
 


### PR DESCRIPTION
QDnsLookup is still not implemented for android. Let's see with qt6.5