### PR TITLE
Gracefully handle external activation of VPN service.

### DIFF
--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -369,12 +369,10 @@ void Controller::connected(const QString& pubkey) {
     }
     // Continue anyways if the VPN service was activated externally.
     logger.info() << "Unexpected handshake: external VPN activation.";
-  }
-  else if (m_activationQueue.first().m_server.publicKey() != pubkey) {
+  } else if (m_activationQueue.first().m_server.publicKey() != pubkey) {
     logger.warning() << "Unexpected handshake: public key mismatch.";
     return;
-  }
-  else {
+  } else {
     // Start the next connection if there is more work to do.
     m_activationQueue.removeFirst();
     if (!m_activationQueue.isEmpty()) {
@@ -384,7 +382,6 @@ void Controller::connected(const QString& pubkey) {
   }
   m_handshakeTimer.stop();
   m_ping_canary.stop();
-
 
   // Clear the retry counter after all connections have succeeded.
   m_connectionRetry = 0;


### PR DESCRIPTION
## Description
On iOS 16, the operating system now has the ability to activate VPN services directly through the settings menu, and much to my surprise it *almost* works. The only thing that falls apart is the UI which doesn't handle the unexpected `connected()` signal from the VPN service, leading to deadlocks and UI breakage.

To fix this, the `Controller` simply needs to be prepared to handle such an unexpected signal, and transition states correctly. 

## Reference
Github #4558 ([VPN-2970](https://mozilla-hub.atlassian.net/browse/VPN-2970))

## Checklist
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
