### PR TITLE
Fix release-promotion trying to push to dep bucket in prod

### DIFF
--- a/taskcluster/ci/beetmover/kind.yml
+++ b/taskcluster/ci/beetmover/kind.yml
@@ -20,7 +20,7 @@ tasks:
         worker:
             chain-of-trust: true
             max-run-time: 1800
-        run-on-tasks-for: [github-release, action:release-promotion]
+        run-on-tasks-for: [action]
         release-artifacts: [MozillaVPN.pkg]
         dependencies:
             signing: signing-macos/opt
@@ -37,7 +37,7 @@ tasks:
         worker:
             chain-of-trust: true
             max-run-time: 1800
-        run-on-tasks-for: [github-release, action:release-promotion]
+        run-on-tasks-for: [action]
         release-artifacts: [MozillaVPN.msi]
         dependencies:
             repackage-signing: repackage-signing-msi
@@ -54,7 +54,7 @@ tasks:
         worker:
             chain-of-trust: true
             max-run-time: 1800
-        run-on-tasks-for: [action:release-promotion]
+        run-on-tasks-for: [action]
         # The addons-bundle release-artifacts are dynamically generated in the beetmover transform
         release-artifacts: []
         dependencies:
@@ -72,7 +72,7 @@ tasks:
         worker:
             chain-of-trust: true
             max-run-time: 1800
-        run-on-tasks-for: [action:release-promotion]
+        run-on-tasks-for: [action]
         release-artifacts:
             - manifest.json
             - manifest.json.sig


### PR DESCRIPTION
## Description

`action:release-promotion` checks if the `"task_for"` is in the tasks `"run-on-tasks-for"` [here](https://github.com/mozilla-mobile/mozilla-vpn-client/blob/df7517bc5aeda13601891d9ff448cef0b8249e19/taskcluster/mozillavpn_taskgraph/transforms/beetmover.py#L36)

The `"task_for"` in the action's decision task is `"action"`. The beetmover task thinks this is not an real `release-promotion` action because `"action"` is not in `["github-release", "action:release-promotion"]`

[Here's a busted task](https://firefox-ci-tc.services.mozilla.com/tasks/WGbSR9wKSgiMRlN7IJMGkw)

## Reference

[RELENG-981](https://mozilla-hub.atlassian.net/browse/RELENG-981)