### PR TITLE
Ignore deprecated addons when populating release-artifacts

### DIFF
--- a/taskcluster/mozillavpn_taskgraph/transforms/beetmover.py
+++ b/taskcluster/mozillavpn_taskgraph/transforms/beetmover.py
@@ -16,6 +16,7 @@ def add_addons_release_artifacts(config, tasks):
         if task["attributes"]["build-type"] == "addons/opt" and task["name"] == "addons-bundle":
             addons = set(os.listdir("addons"))
             addons.remove("examples")
+            addons.remove("deprecated")
             for addon in addons:
                 task["attributes"]["release-artifacts"].append(
                     {


### PR DESCRIPTION
## Description

Ignore deprecated addons when populating the addons release-artifacts.

## Reference

[RELENG-981](https://mozilla-hub.atlassian.net/browse/RELENG-981)
