### PR TITLE
fix: VPN disconnects after swipe kill on iOS

### DIFF
--- a/src/platforms/ios/ioscontroller.mm
+++ b/src/platforms/ios/ioscontroller.mm
@@ -4,6 +4,7 @@
 
 #include "ioscontroller.h"
 #include "Mozilla_VPN-Swift.h"
+#include "controller.h"
 #include "device.h"
 #include "ipaddress.h"
 #include "keys.h"
@@ -81,8 +82,13 @@ void IOSController::initialize(const Device* device, const Keys* keys) {
             return;
           }
           case ConnectionStateDisconnected:
-            // Just in case we are connecting, let's call disconnect.
-            [impl disconnect];
+            Controller* controller = MozillaVPN::instance()->controller();
+            Q_ASSERT(controller);
+            if (controller->state() != Controller::StateInitializing) {
+              // Just in case we are connecting, let's call disconnect.
+              [impl disconnect];
+            }
+
             emit initialized(true, false, QDateTime());
             return;
         }


### PR DESCRIPTION
## Description

Only disconnect preventively if we are not in `Controller::StateInitializing`.

## Reference

- #4553
- Jira issue: [VPN-2965](https://mozilla-hub.atlassian.net/browse/VPN-2965)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
