### PR TITLE
Remove incorrect string from message_whats_new_v2.10

### DIFF
--- a/addons/message_whats_new_v2.10/manifest.json
+++ b/addons/message_whats_new_v2.10/manifest.json
@@ -23,8 +23,6 @@
             "content": "Easier-to-use navigation bar" },
           { "id": "l_3",
             "content": "New tips and tricks to help you use the app’s features and settings" },
-          { "id": "l_4",
-            "content": "The speed test feature now also tests upload speeds in addition to download speeds" },
           { "id": "l_5",
             "content": "Other bug fixes and UI adjustments" },
           { "id": "l_6",


### PR DESCRIPTION
## Description

This removes an incorrect bullet point from the Whats New message.
<img width="300" alt="Screen Shot 2022-10-10 at 1 04 57 PM" src="https://user-images.githubusercontent.com/22355127/194927641-dc19d424-91e1-4f08-8580-813058cba0ca.png">


## Reference
VPN-2992, #4595 

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
