### PR TITLE
Fix edit mode bugs in message inbox

### DIFF
--- a/nebula/ui/components/forms/VPNSearchBar.qml
+++ b/nebula/ui/components/forms/VPNSearchBar.qml
@@ -31,7 +31,12 @@ ColumnLayout {
         leftPadding: 48
         onActiveFocusChanged: if (focus && vpnFlickable.ensureVisible) vpnFlickable.ensureVisible(searchBar)
         Layout.fillWidth: true
-        onTextChanged: hasError = _searchBarHasError
+        onTextChanged: {
+            hasError = _searchBarHasError
+            if (focus) {
+                _editCallback();
+            }
+        }
         onLengthChanged: text => model.invalidate()
 
         VPNIcon {
@@ -42,13 +47,6 @@ ColumnLayout {
             sourceSize.height: VPNTheme.theme.windowMargin
             sourceSize.width: VPNTheme.theme.windowMargin
             opacity: parent.focus ? 1 : 0.8
-        }
-
-
-        Keys.onPressed: event => {
-            if (focus && ((/[\w\[\]`!@#$%\^&*()={}:;<>+'-]/).test(event.text) || event.key === Qt.Key_Backspace || event.key === Qt.Key_Delete)) {
-                _editCallback();
-            }
         }
     }
 

--- a/src/ui/screens/messaging/ViewMessagesInbox.qml
+++ b/src/ui/screens/messaging/ViewMessagesInbox.qml
@@ -33,6 +33,11 @@ VPNViewBase {
         }
     }
 
+    signal editModeChanged
+
+    //Weird workaround to fix VPN-2895
+    onIsEditingChanged: editModeChanged()
+
     _menuTitle: VPNl18n.InAppMessagingMenuTitle
 
     onVisibleChanged: if (!visible) resetPage()
@@ -190,24 +195,14 @@ VPNViewBase {
                     Layout.preferredHeight: content.item.implicitHeight
                     Accessible.name: swipeDelegate.title + ". " + swipeDelegate.formattedDate + ". " +  swipeDelegate.subtitle
 
-                    onIsEditingChanged: {
-                        if(isEditing) {
-                            swipe.open(SwipeDelegate.Left)
-                        }
-                        else {
-                            swipe.close()
-                        }
-                    }
-
                     onSwipeOpen: () => {
                                      deleteLabelWidth = swipe.leftItem.width
                                      if (vpnFlickable.allSwipesOpen() && !vpnFlickable.isEditing) vpnFlickable.isEditing = true
                                  }
 
-                    onSwipeClose: () => {
-                                      if (!vpnFlickable.anySwipesOpen() && vpnFlickable.isEditing) vpnFlickable.isEditing = false
-
-                                  }
+                    onIsSwipeOpenChanged: {
+                        if(!isSwipeOpen && !vpnFlickable.anySwipesOpen() && vpnFlickable.isEditing) vpnFlickable.isEditing = false
+                    }
 
                     onClicked: {
                         if (vpnFlickable.anySwipesOpen()) vpnFlickable.closeAllSwipes()
@@ -230,6 +225,7 @@ VPNViewBase {
 
                         SwipeDelegate.onClicked: {
                             swipeDelegate.swipe.close() // prevents weird iOS animation bug
+                            swipeDelegate.isSwipeOpen = false
                             divider.visible = false
                             if(index === listView.count - 1) {
                                 dismissMessageAnimation.start()
@@ -316,6 +312,19 @@ VPNViewBase {
                             maximumLineCount: 1
                         }
                     }
+
+                    Connections {
+                        target: vpnFlickable
+                        function onEditModeChanged() {
+                            if(isEditing) {
+                                swipeDelegate.swipe.open(SwipeDelegate.Left)
+                            }
+                            else {
+                                swipeDelegate.swipe.close()
+                            }
+                        }
+                    }
+
                 }
 
                 Rectangle {

--- a/src/ui/screens/messaging/ViewMessagesInbox.qml
+++ b/src/ui/screens/messaging/ViewMessagesInbox.qml
@@ -183,7 +183,6 @@ VPNViewBase {
                 VPNSwipeDelegate {
                     id: swipeDelegate
 
-                    property bool isEditing: vpnFlickable.isEditing
                     property real deleteLabelWidth: 0.0
 
                     //avoids qml warnings when addon messages get disabled via condition
@@ -316,7 +315,7 @@ VPNViewBase {
                     Connections {
                         target: vpnFlickable
                         function onEditModeChanged() {
-                            if(isEditing) {
+                            if(vpnFlickable.isEditing) {
                                 swipeDelegate.swipe.open(SwipeDelegate.Left)
                             }
                             else {


### PR DESCRIPTION
## Description

- Always close message swipe delegate after search query changes
- Exit edit mode in inbox if the last swiped open message is deleted

## Reference

[VPN-2895: Messages are not swiped close when being in the “Edit” mode and using the search bar](https://mozilla-hub.atlassian.net/browse/VPN-2895)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
