### PR TITLE
MSI: Use afterInstallValidate schedule during upgrades

### DIFF
--- a/windows/installer/MozillaVPN.wxs
+++ b/windows/installer/MozillaVPN.wxs
@@ -54,7 +54,7 @@
       AllowDowngrades="no"
       AllowSameVersionUpgrades="yes"
       DowngradeErrorMessage="A newer version of [ProductName] is already installed."
-      Schedule="afterInstallExecute" />
+      Schedule="afterInstallValidate" />
 
     <!--
       Folders

--- a/windows/installer/MozillaVPN_cmake.wxs
+++ b/windows/installer/MozillaVPN_cmake.wxs
@@ -55,7 +55,7 @@
       AllowDowngrades="no"
       AllowSameVersionUpgrades="yes"
       DowngradeErrorMessage="A newer version of [ProductName] is already installed."
-      Schedule="afterInstallExecute" />
+      Schedule="afterInstallValidate" />
 
     <!--
       Folders

--- a/windows/installer/MozillaVPN_prod.wxs
+++ b/windows/installer/MozillaVPN_prod.wxs
@@ -55,7 +55,7 @@
       AllowDowngrades="no"
       AllowSameVersionUpgrades="yes"
       DowngradeErrorMessage="A newer version of [ProductName] is already installed."
-      Schedule="afterInstallExecute" />
+      Schedule="afterInstallValidate" />
 
     <!--
       Folders


### PR DESCRIPTION
## Description
For MSI installers, the typical upgrade flow when installing over an already-installed version of the client is to check the file version numbers, and update the files only if the version has changed. When installing or updating a beta or release candidate build we don't always change the version number leading to incomplete installations.

To address this situation, we change the `MajorUpgrade` schedule to use the `afterInstallValidate` which will force uninstallation of the old version first, and ensuring that we always apply the update correctly at the expense of more time spent copying files.

## Reference
Github #4617 ([VPN-3002](https://mozilla-hub.atlassian.net/browse/VPN-3002))

## Checklist
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
