### PR TITLE
Cache the conditionEnabled status to avoid race conditions - VPN-3006

### DIFF
--- a/src/addons/addon.h
+++ b/src/addons/addon.h
@@ -55,7 +55,7 @@ class Addon : public QObject {
 
   virtual void retranslate();
 
-  virtual bool enabled() const;
+  virtual bool enabled() const { return m_enabled; }
 
   AddonApi* api();
 
@@ -100,6 +100,8 @@ class Addon : public QObject {
 
   QJSValue m_jsEnableFunction;
   QJSValue m_jsDisableFunction;
+
+  bool m_enabled = false;
 };
 
 #endif  // ADDON_H

--- a/src/addons/manager/addonmanager.cpp
+++ b/src/addons/manager/addonmanager.cpp
@@ -174,11 +174,9 @@ bool AddonManager::loadManifest(const QString& manifestFileName) {
       }
       if (!enabled) {
         beginRemoveRows(QModelIndex(), pos, pos);
-        removeRow(pos);
         endRemoveRows();
       } else {
         beginInsertRows(QModelIndex(), pos, pos);
-        insertRow(pos);
         endInsertRows();
       }
       break;

--- a/src/addons/manager/addonmanager.cpp
+++ b/src/addons/manager/addonmanager.cpp
@@ -89,6 +89,11 @@ void AddonManager::updateIndex(const QByteArray& index,
 void AddonManager::updateAddonsList(QList<AddonData> addons) {
   logger.debug() << "Updating addons list";
 
+  // Maybe this is not the first time we load the addon list. So, technically,
+  // the addonManager has already complete the first addon loading. No need to
+  // reset m_loadCompleted.
+  bool loadCompleted = false;
+
   // Remove unknown addons
   QStringList addonsToBeRemoved;
   for (QMap<QString, AddonData>::const_iterator i(m_addons.constBegin());
@@ -128,7 +133,7 @@ void AddonManager::updateAddonsList(QList<AddonData> addons) {
     }
   }
 
-  if (!m_loadCompleted) {
+  if (!loadCompleted) {
     if (taskAdded) {
       TaskScheduler::scheduleTask(new TaskFunction(
           [this]() {

--- a/src/addons/manager/addonmanager.cpp
+++ b/src/addons/manager/addonmanager.cpp
@@ -89,11 +89,6 @@ void AddonManager::updateIndex(const QByteArray& index,
 void AddonManager::updateAddonsList(QList<AddonData> addons) {
   logger.debug() << "Updating addons list";
 
-  // Maybe this is not the first time we load the addon list. So, technically,
-  // the addonManager has already complete the first addon loading. No need to
-  // reset m_loadCompleted.
-  bool loadCompleted = false;
-
   // Remove unknown addons
   QStringList addonsToBeRemoved;
   for (QMap<QString, AddonData>::const_iterator i(m_addons.constBegin());
@@ -133,18 +128,16 @@ void AddonManager::updateAddonsList(QList<AddonData> addons) {
     }
   }
 
-  if (!loadCompleted) {
-    if (taskAdded) {
-      TaskScheduler::scheduleTask(new TaskFunction(
-          [this]() {
-            m_loadCompleted = true;
-            emit loadCompletedChanged();
-          },
-          Task::Reschedulable));
-    } else {
-      m_loadCompleted = true;
-      emit loadCompletedChanged();
-    }
+  if (taskAdded) {
+    TaskScheduler::scheduleTask(new TaskFunction(
+        [this]() {
+          m_loadCompleted = true;
+          emit loadCompletedChanged();
+        },
+        Task::Reschedulable));
+  } else {
+    m_loadCompleted = true;
+    emit loadCompletedChanged();
   }
 }
 

--- a/tests/unit/testaddon.cpp
+++ b/tests/unit/testaddon.cpp
@@ -26,6 +26,7 @@
 #include "helper.h"
 
 #include <QQmlApplicationEngine>
+#include <QTemporaryFile>
 
 void TestAddon::property() {
   AddonProperty p;
@@ -1052,9 +1053,18 @@ void TestAddon::message_dismiss() {
 
   QJsonObject obj;
   obj["message"] = messageObj;
+  obj["type"] = "message";
+  obj["api_version"] = "0.1";
+  obj["id"] = "bar";
+  obj["name"] = "bar";
+
+  QTemporaryFile file;
+  QVERIFY(file.open());
+  file.write(QJsonDocument(obj).toJson());
+  file.close();
 
   QObject parent;
-  Addon* message = AddonMessage::create(&parent, "foo", "bar", "name", obj);
+  Addon* message = Addon::create(&parent, file.fileName());
   QVERIFY(!!message);
   QVERIFY(message->enabled());
 


### PR DESCRIPTION
This is a nasty bug. The STR/bug is the following:

1. using the jira STR, we have only 2 addons with a conditional-watcher locale set to 'it'
2. set the locale to 'ru'; the addons are disabled. AddonManager has 0 active addons.
3. change the language to 'it'
4. the conditional watcher of addon A emits `conditionChanged(true)`
5. the addonManager adds the addon in the list.. but to do this, QT calls `rowCount` which calls, for each addon `->enabled()`, which calls `addon->m_conditionalWatcher->conditionApplied()` which returns `true` for both addons. `rowCount` _before_ adding the first addon return 2 - the bug.
6. QT thinks there are 2 addons and we are adding a 3rd one.
7. in the log we see an error message about an invalid QModelIndex
8. In the frontend code we use a FilterableProxyModel which calls `lessThan` for all the 3(?) addons
9. when we compare the second one with the 3rd one(?), the `QModelIndex` of the 3rd one is invalid
10. the frontend code we do: `_sortProxyCallback: (obj1, obj2) => obj1.addon.date > obj2.addon.date` and the code throws an exception because `date` is not a property of `undefined`.

So, the fix is to do not call `conditionApplied()` in `enabled` but to use a cached value. The code will process 1 signal/slot at the time.