### PR TITLE
Schedule more tasks after a `TaskScheduler::deleteTasks()` - VPN-3010

### DIFF
--- a/src/taskscheduler.cpp
+++ b/src/taskscheduler.cpp
@@ -106,4 +106,6 @@ void TaskScheduler::deleteTasksInternal() {
     m_running_task->disconnect();
     m_running_task = nullptr;
   }
+
+  maybeRunTask();
 }

--- a/tests/unit/testtasks.h
+++ b/tests/unit/testtasks.h
@@ -18,4 +18,5 @@ class TestTasks final : public TestHelper {
 
   void deletePolicy();
   void deletePolicy_group();
+  void deletePolicy_async();
 };


### PR DESCRIPTION
When we delete tasks, maybe we do not delete them all because some of them could be marked as "not-deleteable". So, when this happens, we need to schedule the following task.