### PR TITLE
Fix link button crash when clicked via space bar

### DIFF
--- a/nebula/ui/components/VPNLinkButton.qml
+++ b/nebula/ui/components/VPNLinkButton.qml
@@ -27,7 +27,6 @@ VPNButtonBase {
             return
         }
         if (event.key === Qt.Key_Return || event.key === Qt.Key_Space) {
-            root.clicked();
             state = uiState.stateDefault;
         }
     }


### PR DESCRIPTION
## Description

Fix crash when clicking link buttons with space bar (specifically ones that call VPNNavigator.requestScreen())

## Reference

[VPN-3012: Keyboard navigation through VPN screens before being signed in causes the app to quit](https://mozilla-hub.atlassian.net/browse/VPN-3012)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
