### PR TITLE
Fix VPN-3032 : Missing strings on Windows builds

### DIFF
--- a/taskcluster/scripts/build/windows.ps1
+++ b/taskcluster/scripts/build/windows.ps1
@@ -20,7 +20,7 @@ Remove-Item $FETCHES_PATH/VisualStudio/VC/Tools/MSVC/14.30.30705/bin/HostX64/x64
 
 # Fetch 3rdparty stuff.
 python3 -m pip install -r requirements.txt --user
-git submodule update --init --force --recursive --depth=1
+git submodule update --init --force --recursive --remote --depth=1
 
 # Fix: pip scripts are not on path by default on tc, so glean would fail
 $PYTHON_SCRIPTS =resolve-path "$env:APPDATA\Python\Python36\Scripts"


### PR DESCRIPTION
## Description

Adds `--remote` to the submodule init incantation in the TaskCluster windows build script

## Reference

VPN-3032, #4653 

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
