### PR TITLE
No ticket - Remove all Q_ASSERT(vpn) after using MozillaVPN::instance

### DIFF
--- a/src/adjust/adjusthandler.cpp
+++ b/src/adjust/adjusthandler.cpp
@@ -42,7 +42,6 @@ void AdjustHandler::initialize() {
   }
 
   MozillaVPN* vpn = MozillaVPN::instance();
-  Q_ASSERT(vpn);
 
   // If the app has not started yet, let's wait.
   if (vpn->state() == MozillaVPN::StateInitialize) {

--- a/src/captiveportal/captiveportaldetection.cpp
+++ b/src/captiveportal/captiveportaldetection.cpp
@@ -36,7 +36,6 @@ void CaptivePortalDetection::initialize() {
 
 void CaptivePortalDetection::networkChanged() {
   MozillaVPN* vpn = MozillaVPN::instance();
-  Q_ASSERT(vpn);
 
   // The captive portal background monitor is looking
   // wheter a portal on the current network is gone.
@@ -64,7 +63,6 @@ void CaptivePortalDetection::stateChanged() {
   }
 
   MozillaVPN* vpn = MozillaVPN::instance();
-  Q_ASSERT(vpn);
   Controller::State state = vpn->controller()->state();
 
   if (state == Controller::StateOff) {
@@ -111,7 +109,6 @@ void CaptivePortalDetection::detectCaptivePortal() {
   captivePortalMonitor()->stop();
 
   MozillaVPN* vpn = MozillaVPN::instance();
-  Q_ASSERT(vpn);
 
   // This method is called by the inspector too. Let's check the status of the
   // VPN.
@@ -178,7 +175,6 @@ void CaptivePortalDetection::captivePortalDetected() {
   Navigator::instance()->requestScreen(Navigator::ScreenCaptivePortal);
 
   MozillaVPN* vpn = MozillaVPN::instance();
-  Q_ASSERT(vpn);
 
   if (vpn->controller()->state() == Controller::StateOn) {
     captivePortalNotifier()->notifyCaptivePortalBlock();

--- a/src/connectionbenchmark/connectionbenchmark.cpp
+++ b/src/connectionbenchmark/connectionbenchmark.cpp
@@ -27,7 +27,6 @@ ConnectionBenchmark::~ConnectionBenchmark() {
 
 void ConnectionBenchmark::initialize() {
   MozillaVPN* vpn = MozillaVPN::instance();
-  Q_ASSERT(vpn);
 
   Controller* controller = vpn->controller();
   Q_ASSERT(controller);
@@ -67,7 +66,6 @@ void ConnectionBenchmark::start() {
   Q_ASSERT(m_state != StateRunning);
 
   MozillaVPN* vpn = MozillaVPN::instance();
-  Q_ASSERT(vpn);
 
   Controller* controller = vpn->controller();
   Controller::State controllerState = controller->state();

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -129,7 +129,6 @@ void Controller::initialize() {
   });
 
   MozillaVPN* vpn = MozillaVPN::instance();
-  Q_ASSERT(vpn);
 
   const Device* device = vpn->deviceModel()->currentDevice(vpn->keys());
   m_impl->initialize(device, vpn->keys());
@@ -199,7 +198,6 @@ void Controller::activateInternal(bool forcePort53) {
   m_activationQueue.clear();
 
   MozillaVPN* vpn = MozillaVPN::instance();
-  Q_ASSERT(vpn);
 
   Server exitServer = Server::weightChooser(vpn->exitServers());
   if (!exitServer.initialized()) {
@@ -316,7 +314,6 @@ bool Controller::silentSwitchServers() {
   }
 
   MozillaVPN* vpn = MozillaVPN::instance();
-  Q_ASSERT(vpn);
 
   // Set a cooldown timer on the current server.
   QList<Server> servers = vpn->exitServers();
@@ -402,7 +399,6 @@ void Controller::handshakeTimeout() {
   logger.debug() << "Timeout while waiting for handshake";
 
   MozillaVPN* vpn = MozillaVPN::instance();
-  Q_ASSERT(vpn);
   Q_ASSERT(!m_activationQueue.isEmpty());
 
   // Block the offending server and try again.
@@ -441,7 +437,6 @@ void Controller::setCooldownForAllServersInACity(const QString& countryCode,
   Q_ASSERT(!Constants::inProduction());
 
   MozillaVPN* vpn = MozillaVPN::instance();
-  Q_ASSERT(vpn);
 
   vpn->setCooldownForAllServersInACity(countryCode, cityCode);
 }
@@ -481,7 +476,6 @@ void Controller::changeServer(const QString& countryCode, const QString& city,
   Q_ASSERT(m_state == StateOn || m_state == StateOff);
 
   MozillaVPN* vpn = MozillaVPN::instance();
-  Q_ASSERT(vpn);
 
   if (vpn->currentServer()->exitCountryCode() == countryCode &&
       vpn->currentServer()->exitCityName() == city &&

--- a/src/errorhandler.cpp
+++ b/src/errorhandler.cpp
@@ -136,7 +136,6 @@ void ErrorHandler::errorHandle(ErrorHandler::ErrorType error) {
   AlertType alert = NoAlert;
 
   MozillaVPN* vpn = MozillaVPN::instance();
-  Q_ASSERT(vpn);
 
   switch (error) {
     case ErrorHandler::VPNDependentConnectionError:

--- a/src/externalophandler.cpp
+++ b/src/externalophandler.cpp
@@ -49,7 +49,6 @@ void ExternalOpHandler::request(Op op) {
   logger.debug() << "Op request received";
 
   MozillaVPN* vpn = MozillaVPN::instance();
-  Q_ASSERT(vpn);
 
   for (Blocker* blocker : m_blockers) {
     if (blocker->maybeBlockRequest(op)) {

--- a/src/ipaddresslookup.cpp
+++ b/src/ipaddresslookup.cpp
@@ -32,7 +32,6 @@ IpAddressLookup::~IpAddressLookup() { MVPN_COUNT_DTOR(IpAddressLookup); }
 
 void IpAddressLookup::initialize() {
   MozillaVPN* vpn = MozillaVPN::instance();
-  Q_ASSERT(vpn);
 
   connect(vpn, &MozillaVPN::stateChanged, this, &IpAddressLookup::stateChanged);
 

--- a/src/keyregenerator.cpp
+++ b/src/keyregenerator.cpp
@@ -22,7 +22,6 @@ KeyRegenerator::KeyRegenerator() {
   MVPN_COUNT_CTOR(KeyRegenerator);
 
   MozillaVPN* vpn = MozillaVPN::instance();
-  Q_ASSERT(vpn);
 
   connect(vpn, &MozillaVPN::stateChanged, this, &KeyRegenerator::stateChanged);
   connect(vpn->controller(), &Controller::stateChanged, this,
@@ -47,7 +46,6 @@ void KeyRegenerator::stateChanged() {
   }
 
   MozillaVPN* vpn = MozillaVPN::instance();
-  Q_ASSERT(vpn);
 
   if (vpn->state() != MozillaVPN::StateMain ||
       vpn->controller()->state() != Controller::StateOff) {

--- a/src/networkwatcher.cpp
+++ b/src/networkwatcher.cpp
@@ -121,7 +121,6 @@ void NetworkWatcher::unsecuredNetwork(const QString& networkName,
   }
 
   MozillaVPN* vpn = MozillaVPN::instance();
-  Q_ASSERT(vpn);
 
   if (vpn->state() != MozillaVPN::StateMain) {
     logger.debug() << "VPN not ready. Ignoring unsecured network";

--- a/src/platforms/ios/iosdatamigration.mm
+++ b/src/platforms/ios/iosdatamigration.mm
@@ -21,7 +21,6 @@ Logger logger(LOG_IOS, "IOSDataMigration");
 
 void migrateUserDefaultData() {
   MozillaVPN* vpn = MozillaVPN::instance();
-  Q_ASSERT(vpn);
 
   NSUserDefaults* sud = [NSUserDefaults standardUserDefaults];
   if (!sud) {

--- a/src/platforms/macos/macossystemtraynotificationhandler.cpp
+++ b/src/platforms/macos/macossystemtraynotificationhandler.cpp
@@ -39,7 +39,6 @@ void MacosSystemTrayNotificationHandler::setStatusMenu() {
   logger.debug() << "Set status menu";
 
   MozillaVPN* vpn = MozillaVPN::instance();
-  Q_ASSERT(vpn);
 
   connect(vpn->statusIcon(), &StatusIcon::iconUpdateNeeded, this,
           &MacosSystemTrayNotificationHandler::updateIconIndicator);
@@ -66,7 +65,6 @@ void MacosSystemTrayNotificationHandler::updateIcon() {
   logger.debug() << "Update icon";
 
   MozillaVPN* vpn = MozillaVPN::instance();
-  Q_ASSERT(vpn);
   m_macOSStatusIcon->setIcon(vpn->statusIcon()->iconString());
 }
 
@@ -74,6 +72,5 @@ void MacosSystemTrayNotificationHandler::updateIconIndicator() {
   logger.debug() << "Update icon indicator";
 
   MozillaVPN* vpn = MozillaVPN::instance();
-  Q_ASSERT(vpn);
   m_macOSStatusIcon->setIndicatorColor(vpn->statusIcon()->indicatorColor());
 }

--- a/src/profileflow.cpp
+++ b/src/profileflow.cpp
@@ -51,7 +51,6 @@ void ProfileFlow::start() {
   setState(StateLoading);
 
   MozillaVPN* vpn = MozillaVPN::instance();
-  Q_ASSERT(vpn);
   User* user = vpn->user();
   Q_ASSERT(user);
 

--- a/src/server/serverconnection.cpp
+++ b/src/server/serverconnection.cpp
@@ -84,7 +84,6 @@ void serializeServerCountry(ServerCountryModel* model, QJsonObject& obj) {
 
 QJsonObject serializeStatus() {
   MozillaVPN* vpn = MozillaVPN::instance();
-  Q_ASSERT(vpn);
   QJsonObject obj;
 
   obj["authenticated"] = vpn->userState() == MozillaVPN::UserAuthenticated;
@@ -173,7 +172,6 @@ ServerConnection::ServerConnection(QObject* parent, QTcpSocket* connection)
           &ServerConnection::readData);
 
   MozillaVPN* vpn = MozillaVPN::instance();
-  Q_ASSERT(vpn);
 
   connect(vpn, &MozillaVPN::stateChanged, this, &ServerConnection::writeState);
   connect(vpn->controller(), &Controller::stateChanged, this,

--- a/src/statusicon.cpp
+++ b/src/statusicon.cpp
@@ -85,7 +85,6 @@ const QString StatusIcon::iconString() {
   logger.debug() << "Icon string" << m_animatedIconIndex;
 
   MozillaVPN* vpn = MozillaVPN::instance();
-  Q_ASSERT(vpn);
 
   // If we are in a non-main state, we don't need to show special icons.
   if (vpn->state() != MozillaVPN::StateMain) {
@@ -124,7 +123,6 @@ const QColor StatusIcon::indicatorColor() const {
   logger.debug() << "Set color";
 
   MozillaVPN* vpn = MozillaVPN::instance();
-  Q_ASSERT(vpn);
 
   if (vpn->state() != MozillaVPN::StateMain ||
       vpn->controller()->state() != Controller::StateOn) {
@@ -160,7 +158,6 @@ QIcon StatusIcon::drawStatusIndicator() {
   QPixmap iconPixmap = QPixmap(iconString());
 
   MozillaVPN* vpn = MozillaVPN::instance();
-  Q_ASSERT(vpn);
 
   // Only draw a status indicator if the VPN is connected
   if (vpn->controller()->state() == Controller::StateOn) {

--- a/src/systemtraynotificationhandler.cpp
+++ b/src/systemtraynotificationhandler.cpp
@@ -34,6 +34,8 @@ void SystemTrayNotificationHandler::initialize() {
   m_menu.reset(new QMenu());
   m_systemTrayIcon = new QSystemTrayIcon(parent());
 
+  MozillaVPN* vpn = MozillaVPN::instance();
+
   connect(vpn, &MozillaVPN::stateChanged, this,
           &SystemTrayNotificationHandler::updateContextMenu);
 

--- a/src/systemtraynotificationhandler.cpp
+++ b/src/systemtraynotificationhandler.cpp
@@ -238,9 +238,8 @@ void SystemTrayNotificationHandler::updateContextMenu() {
 void SystemTrayNotificationHandler::updateIcon() {
   logger.debug() << "Update icon";
 
-  MozillaVPN* vpn = MozillaVPN::instance();
-
 #if defined(MVPN_LINUX) || defined(MVPN_WINDOWS)
+  MozillaVPN* vpn = MozillaVPN::instance();
   m_systemTrayIcon->setIcon(vpn->statusIcon()->icon());
 #endif
 }

--- a/src/systemtraynotificationhandler.cpp
+++ b/src/systemtraynotificationhandler.cpp
@@ -32,7 +32,6 @@ SystemTrayNotificationHandler::~SystemTrayNotificationHandler() {
 
 void SystemTrayNotificationHandler::initialize() {
   MozillaVPN* vpn = MozillaVPN::instance();
-  Q_ASSERT(vpn);
 
   m_menu.reset(new QMenu());
   m_systemTrayIcon = new QSystemTrayIcon(parent());
@@ -112,7 +111,6 @@ void SystemTrayNotificationHandler::setStatusMenu() {
   logger.debug() << "Set status menu";
 
   MozillaVPN* vpn = MozillaVPN::instance();
-  Q_ASSERT(vpn);
 
   // TODO: Check if method is called on these devices.
 #if defined(MVPN_LINUX) || defined(MVPN_WINDOWS)
@@ -241,7 +239,6 @@ void SystemTrayNotificationHandler::updateIcon() {
   logger.debug() << "Update icon";
 
   MozillaVPN* vpn = MozillaVPN::instance();
-  Q_ASSERT(vpn);
 
 #if defined(MVPN_LINUX) || defined(MVPN_WINDOWS)
   m_systemTrayIcon->setIcon(vpn->statusIcon()->icon());

--- a/src/systemtraynotificationhandler.cpp
+++ b/src/systemtraynotificationhandler.cpp
@@ -110,10 +110,9 @@ void SystemTrayNotificationHandler::createStatusMenu() {
 void SystemTrayNotificationHandler::setStatusMenu() {
   logger.debug() << "Set status menu";
 
-  MozillaVPN* vpn = MozillaVPN::instance();
-
   // TODO: Check if method is called on these devices.
 #if defined(MVPN_LINUX) || defined(MVPN_WINDOWS)
+  MozillaVPN* vpn = MozillaVPN::instance();
   m_systemTrayIcon->setToolTip(qtTrId("vpn.main.productName"));
   m_systemTrayIcon->setContextMenu(m_menu.get());
   m_systemTrayIcon->show();

--- a/src/systemtraynotificationhandler.cpp
+++ b/src/systemtraynotificationhandler.cpp
@@ -31,8 +31,6 @@ SystemTrayNotificationHandler::~SystemTrayNotificationHandler() {
 }
 
 void SystemTrayNotificationHandler::initialize() {
-  MozillaVPN* vpn = MozillaVPN::instance();
-
   m_menu.reset(new QMenu());
   m_systemTrayIcon = new QSystemTrayIcon(parent());
 

--- a/src/telemetry.cpp
+++ b/src/telemetry.cpp
@@ -88,7 +88,6 @@ void Telemetry::connectionStabilityEvent() {
   logger.info() << "Send a connection stability event";
 
   MozillaVPN* vpn = MozillaVPN::instance();
-  Q_ASSERT(vpn);
 
   Controller* controller = vpn->controller();
   Q_ASSERT(controller);
@@ -107,7 +106,6 @@ void Telemetry::connectionStabilityEvent() {
 void Telemetry::periodicStateRecorder() {
   // On mobile this is handled seperately in a background process
   MozillaVPN* vpn = MozillaVPN::instance();
-  Q_ASSERT(vpn);
   Controller* controller = vpn->controller();
   Q_ASSERT(controller);
 

--- a/src/tutorial/tutorial.cpp
+++ b/src/tutorial/tutorial.cpp
@@ -31,7 +31,6 @@ Tutorial::Tutorial(QObject* parent) : QObject(parent) {
   MVPN_COUNT_CTOR(Tutorial);
 
   MozillaVPN* vpn = MozillaVPN::instance();
-  Q_ASSERT(vpn);
 
   connect(vpn, &MozillaVPN::stateChanged, this, &Tutorial::stop);
 

--- a/src/update/webupdater.cpp
+++ b/src/update/webupdater.cpp
@@ -25,8 +25,6 @@ WebUpdater::~WebUpdater() {
 }
 
 void WebUpdater::start(Task*) {
-  MozillaVPN* vpn = MozillaVPN::instance();
-
   emit MozillaVPN::instance()->recordGleanEventWithExtraKeys(
       GleanSample::updateStep,
       {{"state", QVariant::fromValue(FallbackInBrowser).toString()}});

--- a/src/update/webupdater.cpp
+++ b/src/update/webupdater.cpp
@@ -26,7 +26,6 @@ WebUpdater::~WebUpdater() {
 
 void WebUpdater::start(Task*) {
   MozillaVPN* vpn = MozillaVPN::instance();
-  Q_ASSERT(vpn);
 
   emit MozillaVPN::instance()->recordGleanEventWithExtraKeys(
       GleanSample::updateStep,

--- a/src/websocket/pushmessage.cpp
+++ b/src/websocket/pushmessage.cpp
@@ -137,7 +137,6 @@ bool PushMessage::handleDeviceDeleted(const QJsonObject& payload) {
   }
 
   MozillaVPN* vpn = MozillaVPN::instance();
-  Q_ASSERT(vpn);
   if (vpn->keys()->publicKey() == publicKey) {
     logger.info() << "Current device has been deleted from this subscription.";
     vpn->reset(true);

--- a/src/websocket/websockethandler.cpp
+++ b/src/websocket/websockethandler.cpp
@@ -84,7 +84,6 @@ void WebSocketHandler::initialize() {
   logger.debug() << "Initialize";
 
   MozillaVPN* vpn = MozillaVPN::instance();
-  Q_ASSERT(vpn);
 
   connect(vpn, &MozillaVPN::userStateChanged, this,
           &WebSocketHandler::onUserStateChanged);


### PR DESCRIPTION
That is not necessary. MozillaVPN::instance already asserts that.