### PR TITLE
Consistent spacing between navbar and UI content

### DIFF
--- a/nebula/ui/components/VPNFlickable.qml
+++ b/nebula/ui/components/VPNFlickable.qml
@@ -12,7 +12,7 @@ Flickable {
     id: vpnFlickable
 
     property var flickContentHeight
-    property bool contentExceedsHeight: height < flickContentHeight
+    property bool contentExceedsHeight: height < contentHeight
     property bool hideScollBarOnStackTransition: false
     //This property should be true if the flickable appears behind the main navbar
     interactive: !VPNTutorial.playing && contentHeight > height || contentY > 0
@@ -64,7 +64,24 @@ Flickable {
         ensureVisAnimation.start();
     }
 
-    contentHeight: Math.max(window.safeContentHeight, flickContentHeight)
+    function recalculateContentHeight() {
+        if (navbar.visible && mapToItem(window.contentItem, 0, 0).y + height >= window.height - VPNTheme.theme.navBarHeightWithMargins
+                && flickContentHeight + mapToItem(window.contentItem, 0, 0).y >= window.height - VPNTheme.theme.navBarHeightWithMargins) {
+            vpnFlickable.contentHeight = flickContentHeight + (flickContentHeight >= height ? VPNTheme.theme.navBarHeightWithMargins : (mapToItem(window.contentItem, 0, 0).y + flickContentHeight) - (window.height - VPNTheme.theme.navBarHeightWithMargins) + (height - flickContentHeight))
+        }
+        else {
+            vpnFlickable.contentHeight = flickContentHeight
+        }
+    }
+
+    onFlickContentHeightChanged: {
+        recalculateContentHeight()
+    }
+
+    onHeightChanged: {
+        recalculateContentHeight()
+    }
+
     boundsBehavior: Flickable.StopAtBounds
     opacity: 0
 

--- a/nebula/ui/components/VPNFlickable.qml
+++ b/nebula/ui/components/VPNFlickable.qml
@@ -65,10 +65,14 @@ Flickable {
     }
 
     function recalculateContentHeight() {
+        //Checks if the flickable AND it's content interferes with the navbar area (bottom 146px for iOS, bottom 128px for other platforms)
+        //If it does, we pad the flickable's contentHeight with whatever bottom padding is needed so that there is always 48px (aka theme.navBarTopMargin)
+        //between the bottom of the flickable's content and the navbar
         if (navbar.visible && mapToItem(window.contentItem, 0, 0).y + height >= window.height - VPNTheme.theme.navBarHeightWithMargins
                 && flickContentHeight + mapToItem(window.contentItem, 0, 0).y >= window.height - VPNTheme.theme.navBarHeightWithMargins) {
             vpnFlickable.contentHeight = flickContentHeight + (flickContentHeight >= height ? VPNTheme.theme.navBarHeightWithMargins : (mapToItem(window.contentItem, 0, 0).y + flickContentHeight) - (window.height - VPNTheme.theme.navBarHeightWithMargins) + (height - flickContentHeight))
         }
+        //If the navbar isn't visible, or the flickable's content does not interfere with the navbar area, don't worry about adding any padding
         else {
             vpnFlickable.contentHeight = flickContentHeight
         }

--- a/nebula/ui/components/VPNFlickable.qml
+++ b/nebula/ui/components/VPNFlickable.qml
@@ -65,12 +65,17 @@ Flickable {
     }
 
     function recalculateContentHeight() {
+        //Absolute y coordinate position of the scroll view
+        const absoluteYPosition = mapToItem(window.contentItem, 0, 0).y
+        //Portion of the screen that a view's contents can reside without interfering with the navbar
+        const contentSpace = window.height - VPNTheme.theme.navBarHeightWithMargins
+
         //Checks if the flickable AND it's content interferes with the navbar area (bottom 146px for iOS, bottom 128px for other platforms)
         //If it does, we pad the flickable's contentHeight with whatever bottom padding is needed so that there is always 48px (aka theme.navBarTopMargin)
         //between the bottom of the flickable's content and the navbar
-        if (navbar.visible && mapToItem(window.contentItem, 0, 0).y + height >= window.height - VPNTheme.theme.navBarHeightWithMargins
-                && flickContentHeight + mapToItem(window.contentItem, 0, 0).y >= window.height - VPNTheme.theme.navBarHeightWithMargins) {
-            vpnFlickable.contentHeight = flickContentHeight + (flickContentHeight >= height ? VPNTheme.theme.navBarHeightWithMargins : (mapToItem(window.contentItem, 0, 0).y + flickContentHeight) - (window.height - VPNTheme.theme.navBarHeightWithMargins) + (height - flickContentHeight))
+        if (navbar.visible && absoluteYPosition + height >= contentSpace
+                && flickContentHeight + absoluteYPosition >= contentSpace) {
+            vpnFlickable.contentHeight = flickContentHeight + (flickContentHeight >= height ? VPNTheme.theme.navBarHeightWithMargins : (absoluteYPosition + flickContentHeight) - contentSpace + (height - flickContentHeight))
         }
         //If the navbar isn't visible, or the flickable's content does not interfere with the navbar area, don't worry about adding any padding
         else {

--- a/nebula/ui/components/VPNScreenBase.qml
+++ b/nebula/ui/components/VPNScreenBase.qml
@@ -48,7 +48,8 @@ Item {
     VPNStackView {
         id: stackview
         anchors.top: menu.bottom
-        height: parent.height - menu.height
+        implicitHeight: parent.height - menu.height
+        implicitWidth: parent.width
         onCurrentItemChanged: {
             menu.title = Qt.binding(() => currentItem._menuTitle || "");
             menu._menuOnBackClicked = currentItem._menuOnBackClicked ? currentItem._menuOnBackClicked : () => menu.maybeRequestPreviousScreen()

--- a/nebula/ui/components/VPNServerList.qml
+++ b/nebula/ui/components/VPNServerList.qml
@@ -66,7 +66,7 @@ FocusScope {
         id: vpnFlickable
         objectName: "serverCountryView"
 
-        flickContentHeight: serverList.implicitHeight + listOffset
+        flickContentHeight: serverList.implicitHeight + verticalSpacer.height
         anchors.fill: parent
 
         Rectangle {

--- a/nebula/ui/components/VPNTabNavigation.qml
+++ b/nebula/ui/components/VPNTabNavigation.qml
@@ -105,7 +105,7 @@ Item {
         width: parent.width
         currentIndex: bar.currentIndex
         anchors.top: bar.bottom
-        height: root.height - bar.contentHeight
+        height: root.height
         clip: true
 
 

--- a/nebula/ui/components/VPNViewBase.qml
+++ b/nebula/ui/components/VPNViewBase.qml
@@ -18,6 +18,8 @@ Item {
    property alias _viewContentData: viewContent.data
    property alias _interactive: vpnFlickable.interactive
 
+   height: menu.visible ? parent.implicitHeight - menu.visible : parent.implicitHeight
+
    anchors {
        top: if (parent) parent.top
        topMargin: menu.visible ? VPNTheme.theme.menuHeight : 0
@@ -28,30 +30,24 @@ Item {
        color: VPNTheme.theme.bgColor
    }
 
-
     VPNFlickable {
         id: vpnFlickable
         objectName: parent.objectName + "-flickable"
 
         anchors.fill: root
-        flickContentHeight: viewContent.implicitHeight +
-                            navigationBarClearance.height +
-                            root.anchors.topMargin
+        flickContentHeight: viewContent.implicitHeight + viewContent.anchors.topMargin + viewContent.anchors.bottomMargin
 
         ColumnLayout {
             id: viewContent
             spacing: VPNTheme.theme.windowMargin
             anchors {
                 top: parent.top
-                topMargin: VPNTheme.theme.windowMargin
                 left: parent.left
                 right: parent.right
+                topMargin: VPNTheme.theme.windowMargin
+                bottomMargin: navbar.visible ? 0 : 40
             }
         }
-    }
-
-    VPNFooterMargin {
-        id: navigationBarClearance
     }
 
     function ensureVisible(itm) {

--- a/nebula/ui/components/VPNViewBase.qml
+++ b/nebula/ui/components/VPNViewBase.qml
@@ -18,7 +18,7 @@ Item {
    property alias _viewContentData: viewContent.data
    property alias _interactive: vpnFlickable.interactive
 
-   height: menu.visible ? parent.implicitHeight - menu.visible : parent.implicitHeight
+   height: parent.implicitHeight
 
    anchors {
        top: if (parent) parent.top

--- a/nebula/ui/components/VPNViewBase.qml
+++ b/nebula/ui/components/VPNViewBase.qml
@@ -45,7 +45,7 @@ Item {
                 left: parent.left
                 right: parent.right
                 topMargin: VPNTheme.theme.windowMargin
-                bottomMargin: navbar.visible ? 0 : 40
+                bottomMargin: navbar.visible ? 0 : VPNTheme.theme.rowHeight
             }
         }
     }

--- a/nebula/ui/components/inAppAuth/VPNInAppAuthenticationBase.qml
+++ b/nebula/ui/components/inAppAuth/VPNInAppAuthenticationBase.qml
@@ -34,7 +34,6 @@ VPNFlickable {
     ColumnLayout {
         id: col
         anchors.top: parent.top
-        height: Math.max(parent.height, col.implicitHeight)
         anchors.left: parent.left
         anchors.right: parent.right
 
@@ -174,12 +173,9 @@ VPNFlickable {
             Layout.minimumWidth: col.width - VPNTheme.theme.vSpacing * 2
             Layout.leftMargin: VPNTheme.theme.vSpacing
             Layout.rightMargin: VPNTheme.theme.vSpacing
+            Layout.bottomMargin: navbar.visible ? 0 : 34
 
-        }
 
-        VPNVerticalSpacer {
-            Layout.minimumHeight: VPNTheme.theme.vSpacing * 2
-            Layout.fillWidth: true
         }
     }
 

--- a/src/ui/screens/ScreenCaptivePortal.qml
+++ b/src/ui/screens/ScreenCaptivePortal.qml
@@ -12,7 +12,9 @@ import components 0.1
 VPNFlickable {
     id: vpnFlickable
 
-    flickContentHeight: content.height
+    readonly property bool isMobile: window.fullScreenRequired()
+
+    flickContentHeight: content.implicitHeight
 
     state: (VPNController.state == VPNController.StateOff) ? "pre-activation" : "post-activation"
     states: [
@@ -44,13 +46,15 @@ VPNFlickable {
     ColumnLayout {
         id: content
 
-        anchors.horizontalCenter: parent.horizontalCenter
-        anchors.verticalCenter: parent.verticalCenter
+        height: vpnFlickable.height
         width: Math.min(vpnFlickable.width, VPNTheme.theme.maxHorizontalContentWidth)
+        spacing: 0
 
         VPNPanel {
             id: vpnPanel
-            property var childRectHeight: vpnPanel.childrenRect.height
+
+            anchors.horizontalCenter: undefined
+            Layout.topMargin: isMobile ? parent.height * 0.20 : parent.height * 0.12
 
             logo: "qrc:/ui/resources/globe-warning.svg"
             logoSize: 80
@@ -58,9 +62,6 @@ VPNFlickable {
             logoTitle: VPNl18n.CaptivePortalAlertTitle
             width: parent.width
 
-            anchors.horizontalCenter: undefined
-            Layout.alignment: Qt.AlignHCenter
-            Layout.fillWidth: true
         }
 
         VPNSubtitle {
@@ -69,22 +70,22 @@ VPNFlickable {
             color: VPNTheme.theme.fontColor
             font.pixelSize: VPNTheme.theme.fontSizeSmall
             font.family: VPNTheme.theme.fontBoldFamily
-            text: VPNl18n.CaptivePortalAlertPreActivation
             width: openPortalButton.width
 
-            Layout.alignment: Qt.AlignHCenter
             Layout.fillWidth: true
-            Layout.bottomMargin: VPNTheme.theme.vSpacingSmall
             Layout.topMargin: VPNTheme.theme.vSpacingSmall
             Layout.leftMargin: VPNTheme.theme.windowMargin * 2
             Layout.rightMargin: VPNTheme.theme.windowMargin * 2
+        }
+
+        Item {
+            Layout.fillHeight: isMobile
         }
 
         VPNButton {
             id: openPortalButton
 
             objectName: "captivePortalAlertActionButton"
-            text: VPNl18n.CaptivePortalAlertPreActivation
             radius: 4
             onClicked: {
                 if(vpnFlickable.state === "pre-activation"){
@@ -97,8 +98,14 @@ VPNFlickable {
             }
 
             Layout.fillWidth: true
+            Layout.topMargin: VPNTheme.theme.vSpacing
             Layout.leftMargin: VPNTheme.theme.windowMargin * 2
             Layout.rightMargin: VPNTheme.theme.windowMargin * 2
+            Layout.bottomMargin: 58
+        }
+
+        Item {
+            Layout.fillHeight: !isMobile
         }
     }
 }

--- a/src/ui/screens/ScreenGetHelp.qml
+++ b/src/ui/screens/ScreenGetHelp.qml
@@ -54,6 +54,8 @@ Item {
             top: menu.buttom
         }
 
+        implicitHeight: parent.height - menu.height
+
         Component.onCompleted: function() {
             VPNNavigator.addStackView(VPNNavigator.ScreenGetHelp, getHelpStackView)
             getHelpStackView.push("qrc:/ui/screens/getHelp/ViewGetHelp.qml")

--- a/src/ui/screens/getHelp/contactUs/ViewContactUsThankYou.qml
+++ b/src/ui/screens/getHelp/contactUs/ViewContactUsThankYou.qml
@@ -14,11 +14,15 @@ ColumnLayout {
     id: base
     property string _emailAddress: ""
 
-    spacing: 24
+    spacing: VPNTheme.theme.vSpacing
+
+    Item {
+        Layout.fillHeight: window.fullscreenRequired()
+    }
 
     VPNPanel {
         anchors.horizontalCenter: undefined
-        Layout.topMargin: base.height * (window.fullscreenRequired() ? 0.3 :  0.2)
+        Layout.topMargin: window.fullscreenRequired() ? 0 : base.height * 0.2
         Layout.preferredHeight: height
         Layout.preferredWidth: width
         Layout.alignment: Qt.AlignHCenter

--- a/src/ui/screens/getHelp/contactUs/ViewContactUsThankYou.qml
+++ b/src/ui/screens/getHelp/contactUs/ViewContactUsThankYou.qml
@@ -21,6 +21,7 @@ ColumnLayout {
         Layout.topMargin: base.height * (window.fullscreenRequired() ? 0.3 :  0.2)
         Layout.preferredHeight: height
         Layout.preferredWidth: width
+        Layout.alignment: Qt.AlignHCenter
 
         logo: "qrc:/ui/resources/heart-check.svg"
         logoTitle: VPNl18n.InAppSupportWorkflowSupportResponseHeader

--- a/src/ui/screens/getHelp/contactUs/ViewContactUsThankYou.qml
+++ b/src/ui/screens/getHelp/contactUs/ViewContactUsThankYou.qml
@@ -10,40 +10,42 @@ import Mozilla.VPN 1.0
 import components 0.1
 import components.forms 0.1
 
-VPNViewBase {
-    property string _emailAddress: ""
+ColumnLayout {
     id: base
+    property string _emailAddress: ""
 
-    _viewContentData: ColumnLayout {
-        Layout.minimumHeight: base.height
+    spacing: 24
 
-        ColumnLayout {
-            Layout.alignment: Qt.AlignVCenter
-            Layout.preferredWidth: Math.min(VPNTheme.theme.maxHorizontalContentWidth, parent.width - VPNTheme.theme.windowMargin * 4)
-            spacing: VPNTheme.theme.vSpacing
+    VPNPanel {
+        anchors.horizontalCenter: undefined
+        Layout.topMargin: base.height * (window.fullscreenRequired() ? 0.3 :  0.2)
+        Layout.preferredHeight: height
+        Layout.preferredWidth: width
 
-            VPNPanel {
-                id: panel
-                logo: "qrc:/ui/resources/heart-check.svg"
-                logoTitle: VPNl18n.InAppSupportWorkflowSupportResponseHeader
-                logoSubtitle: VPNl18n.InAppSupportWorkflowSupportResponseBody.arg(base._emailAddress)
-                anchors.horizontalCenter: undefined
-                Layout.fillWidth: true
-            }
+        logo: "qrc:/ui/resources/heart-check.svg"
+        logoTitle: VPNl18n.InAppSupportWorkflowSupportResponseHeader
+        logoSubtitle: VPNl18n.InAppSupportWorkflowSupportResponseBody.arg(base._emailAddress)
+    }
 
-            VPNButton {
-                text: VPNl18n.InAppSupportWorkflowSupportResponseButton
-                Layout.alignment: Qt.AlignHCenter
-                onClicked: {
-                    getHelpStackView.pop();
-                    getHelpStackView.pop();
-                }
-            }
+    Item {
+        Layout.fillHeight: window.fullscreenRequired()
+    }
 
-            VPNVerticalSpacer {
-                Layout.preferredHeight: VPNTheme.theme.rowHeight
-                Layout.fillWidth: true
-            }
+    VPNButton {
+        Layout.fillWidth: true
+        Layout.leftMargin: VPNTheme.theme.windowMargin * 2
+        Layout.rightMargin: VPNTheme.theme.windowMargin * 2
+        Layout.bottomMargin: navbar.visible ? VPNTheme.theme.navBarHeightWithMargins : 34
+
+        text: VPNl18n.InAppSupportWorkflowSupportResponseButton
+
+        onClicked: {
+            getHelpStackView.pop();
+            getHelpStackView.pop();
         }
+    }
+
+    Item {
+        Layout.fillHeight: !window.fullscreenRequired()
     }
 }

--- a/src/ui/screens/getHelp/developerMenu/ViewDeveloperMenu.qml
+++ b/src/ui/screens/getHelp/developerMenu/ViewDeveloperMenu.qml
@@ -11,6 +11,8 @@ import components 0.1
 import components.forms 0.1
 
 VPNViewBase {
+    anchors.bottom: parent.bottom
+
     _menuTitle: VPNl18n.SettingsDevTitle
     _viewContentData: ColumnLayout {
         id: root
@@ -280,10 +282,6 @@ VPNViewBase {
             Layout.fillWidth: true
 
             text: VPN.devVersion
-        }
-
-        VPNVerticalSpacer {
-            Layout.preferredHeight: VPNTheme.theme.windowMargin
         }
     }
 }

--- a/src/ui/screens/getHelp/developerMenu/ViewMessages.qml
+++ b/src/ui/screens/getHelp/developerMenu/ViewMessages.qml
@@ -23,7 +23,7 @@ Item {
 
     VPNFlickable {
         id: vpnFlickable
-        flickContentHeight: messagessHolder.height + 100
+        flickContentHeight: messagessHolder.implicitHeight
         anchors.top: menu.bottom
         height: root.height - menu.height
         anchors.left: parent.left

--- a/src/ui/screens/getHelp/giveFeedback/ViewGiveFeedbackReview.qml
+++ b/src/ui/screens/getHelp/giveFeedback/ViewGiveFeedbackReview.qml
@@ -10,51 +10,63 @@ import Mozilla.VPN 1.0
 import components 0.1
 import components.forms 0.1
 
+ColumnLayout {
+    id: layout
 
-VPNViewBase {
-    id: root
-    _viewContentData: ColumnLayout {
+    spacing: 0
 
-        Layout.minimumHeight: root.height
+    Item {
+        Layout.fillHeight: window.fullscreenRequired()
+    }
+
+    VPNPanel {
+        anchors.horizontalCenter: undefined
+        Layout.topMargin: window.fullscreenRequired() ? 0 : layout.height * 0.2
+        Layout.preferredHeight: height
+        Layout.preferredWidth: width
+        Layout.alignment: Qt.AlignHCenter
+
+        logo: "qrc:/ui/resources/app-rating.svg"
+        logoTitle: VPNl18n.FeedbackFormReviewHeader
+        logoSubtitle: VPNl18n.FeedbackFormReviewBody
+    }
+
+    Item {
+        Layout.fillHeight: window.fullscreenRequired()
+    }
+
+    VPNButton {
+        id: leaveReviewBtn
+
+        Layout.fillWidth: true
+        Layout.topMargin: VPNTheme.theme.vSpacing
         Layout.leftMargin: VPNTheme.theme.windowMargin * 2
         Layout.rightMargin: VPNTheme.theme.windowMargin * 2
 
-        ColumnLayout {
-            spacing: VPNTheme.theme.vSpacing
-            Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
-            Layout.fillWidth: true
-            Layout.bottomMargin: VPNTheme.theme.rowHeight * 2
-
-            Column {
-                Layout.fillWidth: true
-                VPNPanel {
-                    id: panel
-                    logo: "qrc:/ui/resources/app-rating.svg"
-                    logoTitle: VPNl18n.FeedbackFormReviewHeader
-                    logoSubtitle: VPNl18n.FeedbackFormReviewBody
-                }
-            }
-
-            VPNButton {
-                text: VPNl18n.FeedbackFormLeaveReviewButton
-                width: undefined
-                Layout.fillWidth: true
-                onClicked: {
-                    VPN.openAppStoreReviewLink();
-                    getHelpStackView.push("qrc:/ui/screens/getHelp/giveFeedback/ViewGiveFeedbackThankYou.qml");
-               }
-            }
-
-            VPNLinkButton {
-                id: skipLink
-
-                labelText: qsTrId("vpn.feedbackForm.skip")
-                onClicked: getHelpStackView.push("qrc:/ui/screens/getHelp/giveFeedback/ViewGiveFeedbackThankYou.qml");
-                implicitHeight: VPNTheme.theme.rowHeight
-                Layout.alignment: Qt.AlignHCenter
-            }
+        text: VPNl18n.FeedbackFormLeaveReviewButton
+        onClicked: {
+            VPN.openAppStoreReviewLink();
+            getHelpStackView.push("qrc:/ui/screens/getHelp/giveFeedback/ViewGiveFeedbackThankYou.qml");
         }
+    }
 
+    VPNLinkButton {
+        id: skipLink
+
+        Layout.fillWidth: true
+        Layout.topMargin: VPNTheme.theme.vSpacingSmall
+        Layout.leftMargin: VPNTheme.theme.windowMargin * 2
+        Layout.rightMargin: VPNTheme.theme.windowMargin * 2
+        Layout.bottomMargin: navbar.visible ? VPNTheme.theme.navBarHeightWithMargins : 34
+
+        labelText: qsTrId("vpn.feedbackForm.skip")
+        onClicked: getHelpStackView.push("qrc:/ui/screens/getHelp/giveFeedback/ViewGiveFeedbackThankYou.qml");
+        implicitHeight: VPNTheme.theme.rowHeight
+    }
+
+    Item {
+        Layout.fillHeight: !window.fullscreenRequired()
     }
 }
+
 

--- a/src/ui/screens/getHelp/giveFeedback/ViewGiveFeedbackThankYou.qml
+++ b/src/ui/screens/getHelp/giveFeedback/ViewGiveFeedbackThankYou.qml
@@ -10,40 +10,42 @@ import Mozilla.VPN 1.0
 import components 0.1
 import components.forms 0.1
 
-VPNViewBase {
-    id: root
-    _viewContentData: ColumnLayout {
+ColumnLayout {
+    id: layout
 
-        Layout.minimumHeight: root.height
+    spacing: 24
+
+    VPNPanel {
+        anchors.horizontalCenter: undefined
+        Layout.topMargin: layout.height * (window.fullscreenRequired() ? 0.3 :  0.2)
+        Layout.preferredHeight: height
+        Layout.preferredWidth: width
+
+
+        logo: "qrc:/ui/resources/heart-check.svg"
+        //% "Thank you!"
+        logoTitle: qsTrId("vpn.feedbackForm.thankyou")
+        //% "We appreciate your feedback. You’re helping us improve Mozilla VPN."
+        logoSubtitle: qsTrId("vpn.feedbackForm.thankyouSubtitle")
+    }
+
+    Item {
+        Layout.fillHeight: window.fullscreenRequired()
+    }
+
+    VPNButton {
+        Layout.fillWidth: true
         Layout.leftMargin: VPNTheme.theme.windowMargin * 2
         Layout.rightMargin: VPNTheme.theme.windowMargin * 2
+        Layout.bottomMargin: navbar.visible ? VPNTheme.theme.navBarHeightWithMargins : 34
 
+        //% "Done"
+        text: qsTrId("vpn.feedbackform.done")
+        onClicked: getHelpStackView.pop(null, StackView.Immediate)
 
-        ColumnLayout {
-            spacing: VPNTheme.theme.vSpacing
-            Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
-            Layout.fillWidth: true
-            Layout.bottomMargin: VPNTheme.theme.rowHeight * 2
+    }
 
-            Column {
-                Layout.fillWidth: true
-                VPNPanel {
-                    id: panel
-                    logo: "qrc:/ui/resources/heart-check.svg"
-                    //% "Thank you!"
-                    logoTitle: qsTrId("vpn.feedbackForm.thankyou")
-                    //% "We appreciate your feedback. You’re helping us improve Mozilla VPN."
-                    logoSubtitle: qsTrId("vpn.feedbackForm.thankyouSubtitle")
-                }
-            }
-            VPNButton {
-                //% "Done"
-                text: qsTrId("vpn.feedbackform.done")
-                width: undefined
-                Layout.fillWidth: true
-                onClicked: getHelpStackView.pop(null, StackView.Immediate)
-            }
-        }
+    Item {
+        Layout.fillHeight: !window.fullscreenRequired()
     }
 }
-

--- a/src/ui/screens/getHelp/giveFeedback/ViewGiveFeedbackThankYou.qml
+++ b/src/ui/screens/getHelp/giveFeedback/ViewGiveFeedbackThankYou.qml
@@ -13,11 +13,15 @@ import components.forms 0.1
 ColumnLayout {
     id: layout
 
-    spacing: 24
+    spacing: VPNTheme.theme.vSpacing
+
+    Item {
+        Layout.fillHeight: window.fullscreenRequired()
+    }
 
     VPNPanel {
         anchors.horizontalCenter: undefined
-        Layout.topMargin: layout.height * (window.fullscreenRequired() ? 0.3 :  0.2)
+        Layout.topMargin: window.fullscreenRequired() ? 0 : layout.height * 0.2
         Layout.preferredHeight: height
         Layout.preferredWidth: width
         Layout.alignment: Qt.AlignHCenter

--- a/src/ui/screens/getHelp/giveFeedback/ViewGiveFeedbackThankYou.qml
+++ b/src/ui/screens/getHelp/giveFeedback/ViewGiveFeedbackThankYou.qml
@@ -20,7 +20,7 @@ ColumnLayout {
         Layout.topMargin: layout.height * (window.fullscreenRequired() ? 0.3 :  0.2)
         Layout.preferredHeight: height
         Layout.preferredWidth: width
-
+        Layout.alignment: Qt.AlignHCenter
 
         logo: "qrc:/ui/resources/heart-check.svg"
         //% "Thank you!"

--- a/src/ui/screens/home/ViewHome.qml
+++ b/src/ui/screens/home/ViewHome.qml
@@ -16,7 +16,7 @@ VPNFlickable {
 
     objectName: "viewMainFlickable"
 
-    flickContentHeight: col.height + VPNTheme.theme.windowMargin / 2
+    flickContentHeight: col.height + col.anchors.topMargin
     anchors.left: parent.left
     anchors.right: parent.right
 

--- a/src/ui/screens/home/ViewMultiHop.qml
+++ b/src/ui/screens/home/ViewMultiHop.qml
@@ -16,7 +16,7 @@ StackView {
 
         id: vpnFlickable
 
-        flickContentHeight: col.implicitHeight + col.y + VPNTheme.theme.windowMargin
+        flickContentHeight: col.implicitHeight
         contentHeight: flickContentHeight
 
         ColumnLayout {

--- a/src/ui/screens/settings/ViewGuide.qml
+++ b/src/ui/screens/settings/ViewGuide.qml
@@ -97,9 +97,7 @@ Item {
             Layout.fillWidth: true
             Layout.fillHeight: true
 
-            contentHeight: layout.implicitHeight + layout.anchors.topMargin
-            flickContentHeight: contentHeight
-            interactive: contentHeight > height
+            flickContentHeight: layout.implicitHeight + layout.anchors.topMargin
 
             Column {
                 id: layout
@@ -157,10 +155,6 @@ Item {
                     VPNComposerView {
                         addon: guide
                         view: VPNComposerView.View.Guide
-                    }
-
-                    //padding for the bottom of the flickable
-                    VPNFooterMargin {
                     }
                 }
             }

--- a/src/ui/screens/settings/ViewLanguage.qml
+++ b/src/ui/screens/settings/ViewLanguage.qml
@@ -66,7 +66,9 @@ VPNViewBase {
             opacity: useSystemLanguageEnabled ? .5 : 1
             spacing: VPNTheme.theme.hSpacing
             Layout.fillWidth: true
-            Layout.margins: VPNTheme.theme.windowMargin * 1.5
+            Layout.topMargin: VPNTheme.theme.windowMargin * 1.5
+            Layout.leftMargin: VPNTheme.theme.windowMargin * 1.5
+            Layout.rightMargin: VPNTheme.theme.windowMargin * 1.5
 
             VPNSearchBar {
                 id: searchBar

--- a/src/ui/screens/settings/ViewSubscriptionManagement/ViewSubscriptionManagement.qml
+++ b/src/ui/screens/settings/ViewSubscriptionManagement/ViewSubscriptionManagement.qml
@@ -118,11 +118,6 @@ VPNViewBase {
                 Layout.alignment: Qt.AlignHCenter
                 Layout.topMargin: VPNTheme.theme.vSpacing
             }
-
-            VPNVerticalSpacer {
-                Layout.fillWidth: true
-                Layout.minimumHeight: VPNTheme.theme.rowHeight
-            }
         }
     }
 

--- a/src/ui/screens/settings/dnsSettings/DNSSettingsTabContent.qml
+++ b/src/ui/screens/settings/dnsSettings/DNSSettingsTabContent.qml
@@ -20,7 +20,9 @@ VPNFlickable {
     property bool vpnIsOff: (VPNController.state === VPNController.StateOff)
     property alias settingsListModel: repeater.model
 
-    flickContentHeight: col.height
+    anchors.fill: parent
+
+    flickContentHeight: col.height + col.anchors.topMargin
 
     ColumnLayout {
         id: col
@@ -146,6 +148,8 @@ VPNFlickable {
                             right: undefined
                         }
                         Layout.topMargin: VPNTheme.theme.listSpacing
+
+                        visible: ipInput.valueInvalid && ipInput.visible
 
                         messages: [
                             {

--- a/src/ui/screens/tipsAndTricks/ViewTipsAndTricks.qml
+++ b/src/ui/screens/tipsAndTricks/ViewTipsAndTricks.qml
@@ -129,8 +129,6 @@ VPNViewBase {
                             }
                         }
                     }
-
-                    VPNFooterMargin {}
                 }
             },
 
@@ -162,8 +160,6 @@ VPNViewBase {
                             customFilter: section.filter
                         }
                     }
-
-                    VPNFooterMargin {}
                 }
             },
 
@@ -195,8 +191,6 @@ VPNViewBase {
                             customFilter: section.filter
                         }
                     }
-
-                    VPNFooterMargin {}
                 }
             }
         ]

--- a/src/ui/sharedViews/ViewErrorFullScreen.qml
+++ b/src/ui/sharedViews/ViewErrorFullScreen.qml
@@ -12,6 +12,8 @@ import org.mozilla.Glean 0.30
 import telemetry 0.30
 
 VPNFlickable {
+    id: vpnFlickable
+
     property var headlineText
     property var errorMessage: ""
     property var errorMessage2: ""
@@ -28,11 +30,8 @@ VPNFlickable {
 
     property var getHelpLinkVisible: false
     property var statusLinkVisible: false
-    id: vpnFlickable
 
-    Component.onCompleted: {
-        flickContentHeight = col.implicitHeight + col.anchors.topMargin
-    }
+    flickContentHeight: col.height
 
     VPNHeaderLink {
         id: headerLink
@@ -45,16 +44,11 @@ VPNFlickable {
 
     ColumnLayout {
         id: col
-        width: Math.min(VPNTheme.theme.maxHorizontalContentWidth, vpnFlickable.width)
-        anchors.top: parent.top
-        anchors.topMargin: headerLink.height + vpnFlickable.height * 0.08
-        anchors.bottom: parent.bottom
-        anchors.horizontalCenter: parent.horizontalCenter
-        spacing: 32
-
-        Component.onCompleted: {
-            height = Math.max(window.height, childrenRect.height)
-        }
+        anchors.fill: parent
+        anchors.leftMargin: 16
+        anchors.rightMargin: 16
+        anchors.bottomMargin: navbar.visible ? VPNTheme.theme.navBarHeightWithMargins : 34
+        spacing: 0
 
         VPNHeadline {
             id: headline
@@ -63,11 +57,13 @@ VPNFlickable {
             Layout.preferredHeight: paintedHeight
             Layout.preferredWidth: col.width - (VPNTheme.theme.windowMargin * 2)
             Layout.maximumWidth: 500
+            Layout.topMargin: headerLink.height + vpnFlickable.height * (window.fullscreenRequired() ? 0.20 :  0.08)
         }
 
         ColumnLayout {
-            spacing: 24
+            Layout.topMargin: VPNTheme.theme.vSpacing
             Layout.alignment: Qt.AlignHCenter
+            spacing: 0
 
             Rectangle {
                 id: warningIconWrapper
@@ -88,8 +84,11 @@ VPNFlickable {
             }
 
             ColumnLayout {
-                spacing: VPNTheme.theme.windowMargin
+                Layout.topMargin: VPNTheme.theme.vSpacing
                 Layout.alignment: Qt.AlignHCenter
+
+                spacing: 0
+
                 VPNTextBlock {
                     id: copyBlock1
                     Layout.preferredWidth: col.width - (VPNTheme.theme.windowMargin * 3)
@@ -124,12 +123,16 @@ VPNFlickable {
             }
         }
 
+        Item {
+            Layout.fillHeight: window.fullscreenRequired()
+        }
+
         ColumnLayout {
-            spacing: VPNTheme.theme.windowMargin
             Layout.fillWidth: true
             Layout.preferredWidth: parent.width
             Layout.alignment: Qt.AlignHCenter
 
+            spacing: VPNTheme.theme.vSpacingSmall
 
             VPNButton {
                 id: primaryButton
@@ -169,9 +172,8 @@ VPNFlickable {
             }
         }
 
-
-        VPNVerticalSpacer {
-            Layout.preferredHeight: fullscreenRequired() ? VPNTheme.theme.windowMargin : 1
+        Item {
+            Layout.fillHeight: !window.fullscreenRequired()
         }
     }
 }

--- a/src/ui/sharedViews/ViewErrorFullScreen.qml
+++ b/src/ui/sharedViews/ViewErrorFullScreen.qml
@@ -31,7 +31,7 @@ VPNFlickable {
     id: vpnFlickable
 
     Component.onCompleted: {
-        flickContentHeight = col.childrenRect.height
+        flickContentHeight = col.implicitHeight + col.anchors.topMargin
     }
 
     VPNHeaderLink {

--- a/src/ui/sharedViews/ViewErrorFullScreen.qml
+++ b/src/ui/sharedViews/ViewErrorFullScreen.qml
@@ -45,8 +45,8 @@ VPNFlickable {
     ColumnLayout {
         id: col
         anchors.fill: parent
-        anchors.leftMargin: 16
-        anchors.rightMargin: 16
+        anchors.leftMargin: VPNTheme.theme.windowMargin
+        anchors.rightMargin: VPNTheme.theme.windowMargin
         anchors.bottomMargin: navbar.visible ? VPNTheme.theme.navBarHeightWithMargins : 34
         spacing: 0
 


### PR DESCRIPTION
## Description

- Make VPNFlickable calculate the amount of padding to add to it's `contentHeight` to support an even amount of spacing between the bottom of each page's content and the navbar
- Remove a bunch of arbitrary padding from views

## Reference

[VPN-2875: Inconsistent content height in scrollable content](https://mozilla-hub.atlassian.net/browse/VPN-2875)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
