### PR TITLE
VPN 3047 - Remove call to log on addon destruction

### DIFF
--- a/src/addons/addon.cpp
+++ b/src/addons/addon.cpp
@@ -389,10 +389,7 @@ Addon::Addon(QObject* parent, const QString& manifestFileName,
   }
 }
 
-Addon::~Addon() {
-  MVPN_COUNT_DTOR(Addon);
-  disable();
-}
+Addon::~Addon() { MVPN_COUNT_DTOR(Addon); }
 
 void Addon::updateAddonState(State newState) {
   Q_ASSERT(newState != Unknown);

--- a/src/addons/addon.h
+++ b/src/addons/addon.h
@@ -59,6 +59,9 @@ class Addon : public QObject {
 
   AddonApi* api();
 
+  virtual void enable();
+  virtual void disable();
+
  signals:
   void conditionChanged(bool enabled);
   void retranslationCompleted();
@@ -66,9 +69,6 @@ class Addon : public QObject {
  protected:
   Addon(QObject* parent, const QString& manifestFileName, const QString& id,
         const QString& name, const QString& type);
-
-  virtual void enable();
-  virtual void disable();
 
  private:
   void updateAddonState(State newState);

--- a/src/addons/manager/addonmanager.cpp
+++ b/src/addons/manager/addonmanager.cpp
@@ -206,15 +206,8 @@ void AddonManager::unload(const QString& addonId) {
     return;
   }
 
-  bool addonEnabled = addon->enabled();
-  if (addonEnabled) {
-    beginResetModel();
-  }
-
-  m_addons.remove(addonId);
-
-  if (addonEnabled) {
-    endResetModel();
+  if (addon->enabled()) {
+    addon->disable();
   }
 
   QDir dir;


### PR DESCRIPTION
This is already on `main` and was implemented on #4642. 

I extracted only what mattered so that we can ship it with 2.10, because it causes a crash.

Fix for the issues with the debug build crashing on force quit I'll send another PR for.