### PR TITLE
Revert windows executable rename back to MozillaVPN.exe

### DIFF
--- a/src/cmake/windows.cmake
+++ b/src/cmake/windows.cmake
@@ -5,7 +5,7 @@
 add_definitions(-DWIN32_LEAN_AND_MEAN)
 
 set_target_properties(mozillavpn PROPERTIES
-    OUTPUT_NAME "Mozilla VPN"
+    OUTPUT_NAME "MozillaVPN"
     VERSION ${CMAKE_PROJECT_VERSION}
     WIN32_EXECUTABLE ON
 )

--- a/src/platforms/windows/daemon/windowsfirewall.cpp
+++ b/src/platforms/windows/daemon/windowsfirewall.cpp
@@ -183,12 +183,13 @@ bool WindowsFirewall::enableKillSwitch(int vpnAdapterIndex) {
   }
 
   logger.info() << "Enabling Killswitch Using Adapter:" << vpnAdapterIndex;
+  QFileInfo appFileInfo(qApp->applicationFilePath());
   FW_OK(allowTrafficOfAdapter(vpnAdapterIndex, MED_WEIGHT,
                               "Allow usage of VPN Adapter"));
   FW_OK(allowDHCPTraffic(MED_WEIGHT, "Allow DHCP Traffic"));
   FW_OK(allowHyperVTraffic(MED_WEIGHT, "Allow Hyper-V Traffic"));
   FW_OK(allowTrafficForAppOnAll(getCurrentPath(), MAX_WEIGHT,
-                                "Allow all for Mozilla VPN.exe"));
+                                "Allow all for MozillaVPN.exe"));
   FW_OK(blockTrafficOnPort(53, MED_WEIGHT, "Block all DNS"));
   FW_OK(
       allowLoopbackTraffic(MED_WEIGHT, "Allow Loopback traffic on device %1"));

--- a/taskcluster/ci/build/windows.yml
+++ b/taskcluster/ci/build/windows.yml
@@ -27,8 +27,8 @@ windows/opt:
               name: public/build/MozillaVPN.msi
               path: artifacts/MozillaVPN.msi
             - type: file
-              name: public/build/Mozilla VPN.pdb
-              path: artifacts/Mozilla VPN.pdb
+              name: public/build/MozillaVPN.pdb
+              path: artifacts/MozillaVPN.pdb
     release-artifacts:
         - unsigned.zip
     run:

--- a/taskcluster/scripts/build/windows.ps1
+++ b/taskcluster/scripts/build/windows.ps1
@@ -65,7 +65,7 @@ New-Item -ItemType Directory -Path "$TASK_WORKDIR/artifacts" -Force
 $ARTIFACTS_PATH =resolve-path "$TASK_WORKDIR/artifacts"
 Copy-Item -Path $BUILD_DIR/windows/installer/MozillaVPN.msi -Destination $ARTIFACTS_PATH/MozillaVPN.msi
 # Note: vc140.pdb is just the default name for pdb files (as we are using vc14x)
-Copy-Item -Path "$BUILD_DIR/src/CMakeFiles/mozillavpn.dir/vc140.pdb" -Destination "$ARTIFACTS_PATH/Mozilla VPN.pdb"
+Copy-Item -Path "$BUILD_DIR/src/CMakeFiles/mozillavpn.dir/vc140.pdb" -Destination "$ARTIFACTS_PATH/MozillaVPN.pdb"
 Compress-Archive -Path $TASK_WORKDIR/unsigned/* -Destination $ARTIFACTS_PATH/unsigned.zip
 Write-Output "Artifacts Location:$TASK_WORKDIR/artifacts"
 Get-ChildItem -Path $TASK_WORKDIR/artifacts

--- a/windows/installer/MozillaVPN_cmake.wxs
+++ b/windows/installer/MozillaVPN_cmake.wxs
@@ -74,7 +74,7 @@
     -->
     <ComponentGroup Id="MozillaVPNComponents">
       <Component Directory="MozillaVPNFolder" Id="MozillaVPNExecutable" Guid="EF353A73-A10B-4A2D-87AC-4389BBD9313B">
-        <File Id="MozillaVPNExecutable" Source="Mozilla VPN.exe" KeyPath="yes">
+        <File Id="MozillaVPNExecutable" Source="MozillaVPN.exe" KeyPath="yes">
           <Shortcut Id="MozillaVPNShortcut" Directory="ProgramMenuFolder" Name="Mozilla VPN" Description="A fast, secure and easy to use VPN. Built by the makers of Firefox." WorkingDirectory="MozillaVPNFolder" Advertise="yes" />
         </File>
         <File Source="balrog.dll" />

--- a/windows/installer/MozillaVPN_prod.wxs
+++ b/windows/installer/MozillaVPN_prod.wxs
@@ -74,7 +74,7 @@
     -->
     <ComponentGroup Id="MozillaVPNComponents">
       <Component Directory="MozillaVPNFolder" Id="MozillaVPNExecutable" Guid="EF353A73-A10B-4A2D-87AC-4389BBD9313B">
-        <File Id="MozillaVPNExecutable" Source="../../Mozilla VPN.exe" KeyPath="yes">
+        <File Id="MozillaVPNExecutable" Source="../../MozillaVPN.exe" KeyPath="yes">
           <Shortcut Id="MozillaVPNShortcut" Directory="ProgramMenuFolder" Name="Mozilla VPN" Description="A fast, secure and easy to use VPN. Built by the makers of Firefox." WorkingDirectory="MozillaVPNFolder" Advertise="yes" />
         </File>
         <File Source="../../balrog.dll" />


### PR DESCRIPTION
## Description
In the 2.10 release, we have a problem where the upgrade from 2.9 to 2.10 over an existing installation leaves the client partially installed, with many of the supporting DLLs missing. This appears to be a result of the WIX installer bundling everything together into a single component, which appears to be discouraged by [MSDN](https://learn.microsoft.com/en-us/windows/win32/msi/defining-installer-components).

This leads to the installer assuming that the component has been renamed and that it is safe to install the new component in parallel with the old one, and then deleting the old one, but because some of the files didn't change names this results in some files being deleted after the upgrade.

I think the proper long term fix is to create unique components for each file being installed, so that they can be versioned independently by MSI. Unfortunately that's going to be tricky to get right in the short term, but we can avoid the immediate breakage by reverting the executable filename back to `MozillaVPN.exe`.

## Reference
Github #4650 ([VPN-3029](https://mozilla-hub.atlassian.net/browse/VPN-3029))
Github #4649 ([VPN-3028](https://mozilla-hub.atlassian.net/browse/VPN-3028))

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
