### PR TITLE
Android: Bump target sdk

### DIFF
--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -36,6 +36,7 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
             android:screenOrientation="portrait"
             android:theme="@style/AppTheme.Splash"
             android:windowSoftInputMode="adjustPan"
+            android:exported="true"
             android:launchMode="singleTop">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -13,9 +13,9 @@ buildscript {
         }
     }
     dependencies {
-        classpath Dependencies.com_android_tools_build_gradle
-        classpath Dependencies.org_jetbrains_kotlin_kotlin_gradle_plugin
-        classpath Dependencies.org_jetbrains_kotlin_kotlin_serialization
+        classpath SharedDependencies.com_android_tools_build_gradle
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.10"
+        classpath "org.jetbrains.kotlin:kotlin-serialization:1.4.30-M1"
     }
 }
 repositories {
@@ -46,17 +46,14 @@ dependencies {
     implementation project(path: ':daemon')
     implementation project(path: ':qtBindings')
 
-    implementation Dependencies.androidx_core
-    implementation Dependencies.android_installreferrer
-    implementation Dependencies.android_billingclient
-    implementation Dependencies.androidx_lifecycle
-    implementation Dependencies.androidx_security_security_crypto
-    implementation Dependencies.androidx_security_security_identity_credential
-    implementation Dependencies.com_google_android_gms_play_services_ads_identifier
-    implementation Dependencies.org_jetbrains_kotlinx_kotlinx_serialization_json
+    implementation SharedDependencies.androidx_core
+    implementation "com.android.installreferrer:installreferrer:2.2"
+    implementation "com.android.billingclient:billing-ktx:4.0.0"
+    implementation "com.google.android.gms:play-services-ads-identifier:17.0.1"
+    implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.2.2"
     implementation 'org.bouncycastle:bcprov-jdk15on:1.70'
 
-    coreLibraryDesugaring Dependencies.com_android_tools_desugar_jdk_libs
+    coreLibraryDesugaring SharedDependencies.com_android_tools_desugar_jdk_libs
 }
 
 android {

--- a/android/buildSrc/src/main/kotlin/Config.kt
+++ b/android/buildSrc/src/main/kotlin/Config.kt
@@ -3,9 +3,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 object Config {
-    const val compileSdkVersion = 30
+    const val compileSdkVersion = 31
     const val buildToolsVersion = "30.0.3"
     const val minSdkVersion = 24
-    const val targetSdkVersion = 30
+    const val targetSdkVersion = 31
     const val ndkVersion = "23.1.7779620"
 }

--- a/android/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/android/buildSrc/src/main/kotlin/Dependencies.kt
@@ -2,21 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const val Mozilla_ANDROID_COMPONENT_VERSION = "101.0.7"
-
-object Dependencies {
-    const val org_jetbrains_kotlin_kotlin_serialization = "org.jetbrains.kotlin:kotlin-serialization:1.4.30-M1"
-    const val org_jetbrains_kotlin_kotlin_gradle_plugin = "org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.10"
+// Dependencies used by at least more then 1 Subproject.
+object SharedDependencies {
     const val com_android_tools_build_gradle = "com.android.tools.build:gradle:4.0.0"
-    const val androidx_core = "androidx.core:core-ktx:1.6.0"
-    const val android_installreferrer = "com.android.installreferrer:installreferrer:2.2"
-    const val android_billingclient = "com.android.billingclient:billing-ktx:4.0.0"
-    const val androidx_lifecycle = "androidx.lifecycle:lifecycle-livedata-ktx:2.4.0-alpha02"
-    const val androidx_security_security_crypto = "androidx.security:security-crypto:1.1.0-alpha03"
-    const val androidx_security_security_identity_credential = "androidx.security:security-identity-credential:1.0.0-alpha02"
-    const val com_google_android_gms_play_services_ads_identifier = "com.google.android.gms:play-services-ads-identifier:17.0.1"
-    const val org_jetbrains_kotlinx_kotlinx_serialization_json = "org.jetbrains.kotlinx:kotlinx-serialization-json:1.2.2"
+    const val androidx_core = "androidx.core:core-ktx:1.9.0"
     const val com_android_tools_desugar_jdk_libs = "com.android.tools:desugar_jdk_libs:1.0.10"
-    const val org_mozilla_components_tooling_glean_gradle = "org.mozilla.components:tooling-glean-gradle:$Mozilla_ANDROID_COMPONENT_VERSION"
-    const val org_mozilla_telemetry_glean = "org.mozilla.telemetry:glean:44.2.0"
 }

--- a/android/daemon/build.gradle
+++ b/android/daemon/build.gradle
@@ -23,8 +23,8 @@ buildscript {
     }
 
     dependencies {
-        classpath Dependencies.com_android_tools_build_gradle
-        classpath Dependencies.org_mozilla_components_tooling_glean_gradle
+        classpath SharedDependencies.com_android_tools_build_gradle
+        classpath "org.mozilla.components:tooling-glean-gradle:107.0.2"
     }
 }
 
@@ -102,17 +102,11 @@ dependencies {
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
 
-    implementation Dependencies.androidx_core
-    implementation Dependencies.android_installreferrer
-    implementation Dependencies.android_billingclient
-    implementation Dependencies.androidx_lifecycle
-    implementation Dependencies.androidx_security_security_crypto
-    implementation Dependencies.androidx_security_security_identity_credential
-    implementation Dependencies.com_google_android_gms_play_services_ads_identifier
-    implementation Dependencies.org_jetbrains_kotlinx_kotlinx_serialization_json
-    implementation Dependencies.org_mozilla_telemetry_glean
-    coreLibraryDesugaring Dependencies.com_android_tools_desugar_jdk_libs
-    implementation "org.jetbrains.kotlin:kotlin-reflect:1.6.10"
+    implementation SharedDependencies.androidx_core
+    implementation "androidx.security:security-crypto:1.1.0-alpha03"
+    implementation "androidx.security:security-identity-credential:1.0.0-alpha03"
+    implementation "org.mozilla.telemetry:glean:51.6.0"
+    implementation "org.jetbrains.kotlin:kotlin-reflect:1.6.20"
 }
 
 ext.gleanNamespace = "mozilla.telemetry.glean"

--- a/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/NotificationUtil.kt
+++ b/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/NotificationUtil.kt
@@ -114,7 +114,7 @@ class NotificationUtil {
         val mainActivityName = "org.mozilla.firefox.vpn.qt.VPNActivity"
         val activity = Class.forName(mainActivityName)
         val intent = Intent(service, activity)
-        val pendingIntent = PendingIntent.getActivity(service, 0, intent, 0)
+        val pendingIntent = PendingIntent.getActivity(service, 0, intent, PendingIntent.FLAG_IMMUTABLE)
         // Build our notification
         mNotificationBuilder
             .setSmallIcon(R.drawable.icon_mozillavpn_notifiaction)

--- a/taskcluster/docker/android-qt6-build/Dockerfile
+++ b/taskcluster/docker/android-qt6-build/Dockerfile
@@ -41,10 +41,11 @@ RUN python3 -m aqt install-qt --outputdir /opt linux android ${QT_VERSION} ${AND
     pip install -r requirements.txt &&\
     unzip commandlinetools-linux-7583922_latest.zip -d /opt &&\
     unzip ${NDK_FILE} -d /opt/NDK/ &&\
-    echo y | /opt/cmdline-tools/bin/sdkmanager --sdk_root=/opt/android/sdk --install "platforms;android-30" &&\
+    echo y | /opt/cmdline-tools/bin/sdkmanager --sdk_root=/opt/android/sdk --install "platforms;android-31" &&\
     # :qtBindings:compileDebugAidl requires build-tools;29.0.2
     echo y | /opt/cmdline-tools/bin/sdkmanager --sdk_root=/opt/android/sdk --install "build-tools;29.0.2" &&\ 
     echo y | /opt/cmdline-tools/bin/sdkmanager --sdk_root=/opt/android/sdk --install "build-tools;30.0.3" &&\
+    echo y | /opt/cmdline-tools/bin/sdkmanager --sdk_root=/opt/android/sdk --install "build-tools;31.0.0" &&\
     echo y | /opt/cmdline-tools/bin/sdkmanager --sdk_root=/opt/android/sdk --install "cmake;3.10.2.4988404" &&\
         # Note: Not sure why we need emulator, need to investiage the gradle dependencies
     echo y | /opt/cmdline-tools/bin/sdkmanager --sdk_root=/opt/android/sdk --install "emulator" &&\ 


### PR DESCRIPTION
## Description

    As per Google Play policy, the next Update needs to Target SDK version 31. 

This PR: 
-> Bumps the target sdk,
-> Fixes new violations
-> Updates old deps
-> Cleans up our dependency tree 

