### PR TITLE
Do not initially setup status icon twice

### DIFF
--- a/src/platforms/macos/macossystemtraynotificationhandler.cpp
+++ b/src/platforms/macos/macossystemtraynotificationhandler.cpp
@@ -30,9 +30,6 @@ MacosSystemTrayNotificationHandler::~MacosSystemTrayNotificationHandler() {
 
 void MacosSystemTrayNotificationHandler::initialize() {
   SystemTrayNotificationHandler::initialize();
-
-  setStatusMenu();
-  updateIcon();
 }
 
 void MacosSystemTrayNotificationHandler::setStatusMenu() {


### PR DESCRIPTION
## Description

Fixes duplicate status icons and a potential crash on init for macOS.

## Reference

- Fixes #4663

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
