### PR TITLE
TemporaryDir component - VPN-3074

### DIFF
--- a/src/cmake/sources.cmake
+++ b/src/cmake/sources.cmake
@@ -318,6 +318,8 @@ target_sources(mozillavpn PRIVATE
     tasks/servers/taskservers.h
     telemetry.cpp
     telemetry.h
+    temporarydir.cpp
+    temporarydir.h
     theme.cpp
     theme.h
     timersingleshot.cpp

--- a/src/commands/commandui.cpp
+++ b/src/commands/commandui.cpp
@@ -26,6 +26,7 @@
 #include "qmlengineholder.h"
 #include "settingsholder.h"
 #include "telemetry/gleansample.h"
+#include "temporarydir.h"
 #include "theme.h"
 #include "tutorial/tutorial.h"
 #include "update/updater.h"
@@ -215,6 +216,9 @@ int CommandUI::run(QStringList& tokens) {
     Lottie::initialize(engine, QString(NetworkManager::userAgent()));
     Nebula::Initialize(engine);
     L18nStrings::initialize();
+
+    // Cleanup previous temporary files.
+    TemporaryDir::cleanupAll();
 
     MozillaVPN vpn;
 

--- a/src/qmake/sources.pri
+++ b/src/qmake/sources.pri
@@ -157,6 +157,7 @@ SOURCES += \
         tasks/servers/taskservers.cpp \
         taskscheduler.cpp \
         telemetry.cpp \
+        temporarydir.cpp \
         theme.cpp \
         timersingleshot.cpp \
         tutorial/tutorial.cpp \
@@ -328,6 +329,7 @@ HEADERS += \
         tasks/servers/taskservers.h \
         taskscheduler.h \
         telemetry.h \
+        temporarydir.h \
         theme.h \
         tutorial/tutorial.h \
         tutorial/tutorialstep.h \

--- a/src/temporarydir.cpp
+++ b/src/temporarydir.cpp
@@ -1,0 +1,158 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "temporarydir.h"
+#include "leakdetector.h"
+#include "logger.h"
+
+#include <QStandardPaths>
+#include <QUuid>
+
+namespace {
+Logger logger(LOG_MAIN, "TemporaryDir");
+
+constexpr const char* TMP_FOLDER = "tmp";
+
+QString rootAppFolder() {
+#ifdef MVPN_WASM
+  // https://wiki.qt.io/Qt_for_WebAssembly#Files_and_local_file_system_access
+  return "/";
+#elif defined(UNIT_TEST)
+  return QStandardPaths::writableLocation(QStandardPaths::TempLocation);
+#else
+  return QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
+#endif
+}
+}  // namespace
+
+TemporaryDir::TemporaryDir(QObject* parent) : QObject(parent) {
+  MVPN_COUNT_CTOR(TemporaryDir);
+}
+
+TemporaryDir::~TemporaryDir() {
+  MVPN_COUNT_DTOR(TemporaryDir);
+
+  if (m_state == Fallback && !m_fallbackDir.removeRecursively()) {
+    logger.debug() << "Failed to remove the fallback dir"
+                   << m_fallbackDir.path();
+  }
+}
+
+QString TemporaryDir::errorString() {
+  if (isValid()) {
+    return QString();
+  }
+
+  if (m_state == QT) {
+    return m_tmpDir.errorString();
+  }
+
+  return "Unable to create the fallback directory";
+}
+
+QString TemporaryDir::filePath(const QString& fileName) {
+  if (!isValid()) {
+    return QString();
+  }
+
+  if (m_state == QT) {
+    return m_tmpDir.filePath(fileName);
+  }
+
+  return m_fallbackDir.filePath(fileName);
+}
+
+void TemporaryDir::fallback() {
+  m_fallbackDir = QDir(rootAppFolder());
+
+  if (!m_fallbackDir.exists(TMP_FOLDER) && !m_fallbackDir.mkpath(TMP_FOLDER)) {
+    logger.error() << "Unable to create the tmp fallback folder"
+                   << rootAppFolder();
+    return;
+  }
+
+  if (!m_fallbackDir.cd(TMP_FOLDER)) {
+    logger.error() << "Unable to open the tmp fallback folder"
+                   << m_fallbackDir.path();
+    return;
+  }
+
+  int retry = 0;
+  while (true) {
+    if (++retry > 10) {
+      logger.error()
+          << "Unable to find a valid UUID for the tmp fallback folder"
+          << m_fallbackDir.path();
+      return;
+    }
+
+    QByteArray uuid = QUuid::createUuid().toByteArray(QUuid::WithoutBraces);
+    if (m_fallbackDir.exists(uuid)) {
+      continue;
+    }
+
+    if (!m_fallbackDir.mkpath(uuid)) {
+      logger.error() << "Unable to create the tmp fallback folder"
+                     << m_fallbackDir.path() << uuid;
+      return;
+    }
+
+    if (!m_fallbackDir.cd(uuid)) {
+      logger.error() << "Unable to open the tmp fallback folder"
+                     << m_fallbackDir.path() << uuid;
+      return;
+    }
+
+    break;
+  }
+
+  m_state = Fallback;
+}
+
+bool TemporaryDir::isValid() {
+  if (m_state == QT) {
+    if (m_tmpDir.isValid()) {
+      return true;
+    }
+
+    fallback();
+  }
+
+  if (m_state == QT) {
+    return m_tmpDir.isValid();
+  }
+
+  return m_fallbackDir.exists();
+}
+
+QString TemporaryDir::path() {
+  if (!isValid()) {
+    return QString();
+  }
+
+  if (m_state == QT) {
+    return m_tmpDir.path();
+  }
+
+  return m_fallbackDir.path();
+}
+
+// static
+void TemporaryDir::cleanupAll() {
+  QDir fallbackDir(rootAppFolder());
+
+  if (!fallbackDir.exists(TMP_FOLDER)) {
+    return;
+  }
+
+  if (!fallbackDir.cd(TMP_FOLDER)) {
+    logger.error() << "Unable to open the tmp fallback folder"
+                   << fallbackDir.path();
+    return;
+  }
+
+  if (!fallbackDir.removeRecursively()) {
+    logger.debug() << "Failed to remove the fallback dir" << fallbackDir.path();
+  }
+}

--- a/src/temporarydir.h
+++ b/src/temporarydir.h
@@ -1,0 +1,40 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef TEMPORARYDIR_H
+#define TEMPORARYDIR_H
+
+#include <QDir>
+#include <QObject>
+#include <QTemporaryDir>
+
+class TemporaryDir final : public QObject {
+  Q_OBJECT
+  Q_DISABLE_COPY_MOVE(TemporaryDir)
+
+ public:
+  TemporaryDir(QObject* parent = nullptr);
+  ~TemporaryDir();
+
+  static void cleanupAll();
+
+  QString errorString();
+  QString filePath(const QString& fileName);
+  bool isValid();
+  QString path();
+
+  // public to be used in unit-tests
+  void fallback();
+
+ private:
+  enum {
+    QT,
+    Fallback,
+  } m_state = QT;
+
+  QTemporaryDir m_tmpDir;
+  QDir m_fallbackDir;
+};
+
+#endif  // TEMPORARYDIR_H

--- a/src/update/balrog.cpp
+++ b/src/update/balrog.cpp
@@ -18,7 +18,6 @@
 #include <QScopeGuard>
 #include <QSslCertificate>
 #include <QSslKey>
-#include <QTemporaryDir>
 
 // Terrible hacking for Windows
 #if defined(MVPN_WINDOWS)

--- a/src/update/balrog.h
+++ b/src/update/balrog.h
@@ -7,10 +7,10 @@
 
 #include "errorhandler.h"
 #include "updater.h"
+#include "temporarydir.h"
 
 #include <QCryptographicHash>
 #include <QNetworkReply>
-#include <QTemporaryDir>
 
 class NetworkRequest;
 
@@ -44,7 +44,7 @@ class Balrog final : public Updater {
                       QNetworkReply::NetworkError error);
 
  private:
-  QTemporaryDir m_tmpDir;
+  TemporaryDir m_tmpDir;
   bool m_downloadAndInstall;
   ErrorHandler::ErrorPropagationPolicy m_errorPropagationPolicy =
       ErrorHandler::DoNotPropagateError;

--- a/src/wgquickprocess.cpp
+++ b/src/wgquickprocess.cpp
@@ -6,7 +6,6 @@
 #include "../../src/logger.h"
 
 #include <QCoreApplication>
-#include <QTemporaryDir>
 #include <QProcess>
 
 namespace {

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -231,6 +231,8 @@ target_sources(unit_tests PRIVATE
     ${MVPN_SOURCE_DIR}/tasks/servers/taskservers.h
     ${MVPN_SOURCE_DIR}/taskscheduler.cpp
     ${MVPN_SOURCE_DIR}/taskscheduler.h
+    ${MVPN_SOURCE_DIR}/temporarydir.cpp
+    ${MVPN_SOURCE_DIR}/temporarydir.h
     ${MVPN_SOURCE_DIR}/theme.cpp
     ${MVPN_SOURCE_DIR}/theme.h
     ${MVPN_SOURCE_DIR}/timersingleshot.cpp
@@ -316,6 +318,8 @@ target_sources(unit_tests PRIVATE
     teststatusicon.h
     testtasks.cpp
     testtasks.h
+    testtemporarydir.cpp
+    testtemporarydir.h
     testthemes.cpp
     testthemes.h
     testtimersingleshot.cpp

--- a/tests/unit/testtemporarydir.cpp
+++ b/tests/unit/testtemporarydir.cpp
@@ -1,0 +1,48 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "testtemporarydir.h"
+#include "../../src/temporarydir.h"
+
+void TestTemporaryDir::basic() {
+  TemporaryDir td;
+  QVERIFY(td.isValid());
+  QVERIFY(td.errorString().isEmpty());
+  QVERIFY(!td.path().isEmpty());
+  QVERIFY(!td.filePath("wow").isEmpty());
+}
+
+void TestTemporaryDir::fallback() {
+  QString path;
+  {
+    TemporaryDir td;
+    td.fallback();
+
+    QVERIFY(td.isValid());
+    QVERIFY(td.errorString().isEmpty());
+    path = td.path();
+    QVERIFY(!path.isEmpty());
+    QVERIFY(!td.filePath("wow").isEmpty());
+
+    QVERIFY(QDir(path).exists());
+  }
+
+  QVERIFY(!path.isEmpty());
+  QVERIFY(!QDir(path).exists());
+}
+
+void TestTemporaryDir::cleanupAll() {
+  TemporaryDir td;
+  td.fallback();
+
+  QVERIFY(td.isValid());
+  QString path = td.path();
+  QVERIFY(QDir(path).exists());
+
+  TemporaryDir::cleanupAll();
+  QVERIFY(!QDir(path).exists());
+  QVERIFY(!td.isValid());
+}
+
+static TestTemporaryDir s_testTemporaryDir;

--- a/tests/unit/testtemporarydir.h
+++ b/tests/unit/testtemporarydir.h
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "helper.h"
+
+class TestTemporaryDir final : public TestHelper {
+  Q_OBJECT
+
+ private slots:
+  void basic();
+  void fallback();
+  void cleanupAll();
+};

--- a/tests/unit/unit.pro
+++ b/tests/unit/unit.pro
@@ -142,6 +142,7 @@ HEADERS += \
     ../../src/tasks/release/taskrelease.h \
     ../../src/tasks/servers/taskservers.h \
     ../../src/taskscheduler.h \
+    ../../src/temporarydir.h \
     ../../src/theme.h \
     ../../src/timersingleshot.h \
     ../../src/tutorial/tutorial.h \
@@ -177,6 +178,7 @@ HEADERS += \
     testserveri18n.h \
     teststatusicon.h \
     testtasks.h \
+    testtemporarydir.h \
     testthemes.h \
     testtimersingleshot.h \
     testurlopener.h \
@@ -280,6 +282,7 @@ SOURCES += \
     ../../src/tasks/ipfinder/taskipfinder.cpp \
     ../../src/tasks/servers/taskservers.cpp \
     ../../src/taskscheduler.cpp \
+    ../../src/temporarydir.cpp \
     ../../src/theme.cpp \
     ../../src/timersingleshot.cpp \
     ../../src/tutorial/tutorial.cpp \
@@ -320,6 +323,7 @@ SOURCES += \
     testserveri18n.cpp \
     teststatusicon.cpp \
     testtasks.cpp \
+    testtemporarydir.cpp \
     testthemes.cpp \
     testtimersingleshot.cpp \
     testurlopener.cpp \


### PR DESCRIPTION
Somehow when the app is executed by the PKG installer on macos, it runs in a sandbox that does not have access to the temporary folder. This does not happen when the app is executed by the user.

The result is that, QTemporaryDir is invalid at the first execution. We use QTemporaryDir with balrog to download the new version of the app so, it must work. This is a TemporaryDir implementation with fallback in the App-Data directory.