### PR TITLE
Taskcluster: Check compat with "next" QT

### DIFF
--- a/src/commands/commandui.cpp
+++ b/src/commands/commandui.cpp
@@ -199,8 +199,8 @@ int CommandUI::run(QStringList& tokens) {
     // https://bugreports.qt.io/browse/QTBUG-82617
     // Currently there is a crash happening on exit with Huawei devices.
     // Until this is fixed, setting this variable is the "official" workaround.
-    // We certainly should look at this once 6.4 is out.
-#  if QT_VERSION >= 0x060400
+    // We certainly should look at this once 6.6 is out.
+#  if QT_VERSION >= 0x060600
 #    error We have forgotten to remove this Huawei hack!
 #  endif
     if (AndroidUtils::GetManufacturer() == "Huawei") {

--- a/src/connectionbenchmark/benchmarktasktransfer.cpp
+++ b/src/connectionbenchmark/benchmarktasktransfer.cpp
@@ -53,7 +53,7 @@ void BenchmarkTaskTransfer::handleState(BenchmarkTask::State state) {
     m_dnsLookup.lookup();
 #endif
 
-#if QT_VERSION >= 0x060400
+#if QT_VERSION >= 0x060500
 #  error Check if QT added support for QDnsLookup::lookup() on Android
 #endif
 

--- a/taskcluster/ci/build/android.yml
+++ b/taskcluster/ci/build/android.yml
@@ -17,6 +17,21 @@ task-defaults:
           use-caches: true
           cwd: '{checkout}'
 
+android-qt-next:
+        description: "Android Next QT Build (arm64-v8a)"
+        treeherder:
+            symbol: Android
+            kind: build
+            tier: 1
+            platform: QT-Next
+        worker:
+            docker-image: {in-tree: android-qt-next}
+        run:
+            command: ./taskcluster/scripts/build/android_build_debug.sh arm64-v8a
+        release-artifacts:
+            # APK Artifacts expects file to be in /builds/worker/artifacts/
+            - mozillavpn-arm64-v8a-debug.apk
+
 # Debug Builds:
 android-arm64/debug:
         description: "Android Debug (arm64-v8a)"

--- a/taskcluster/ci/build/android.yml
+++ b/taskcluster/ci/build/android.yml
@@ -17,13 +17,11 @@ task-defaults:
           use-caches: true
           cwd: '{checkout}'
 
-android-qt-next:
+android-qt-next/debug:
         description: "Android Next QT Build (arm64-v8a)"
         treeherder:
-            symbol: Android
-            kind: build
-            tier: 1
-            platform: QT-Next
+            platform: android/arm64-v8a
+            symbol: NEXT
         worker:
             docker-image: {in-tree: android-qt-next}
         run:

--- a/taskcluster/ci/docker-image/kind.yml
+++ b/taskcluster/ci/docker-image/kind.yml
@@ -62,3 +62,10 @@ tasks:
         args:
             ANDROID_ARCH: android_x86_64
             QT_VERSION: 6.2.4
+    android-qt-next:
+        parent: base
+        symbol: I(android_arm64_v8a_next)
+        definition: android-qt6-build
+        args:
+            ANDROID_ARCH: android_arm64_v8a
+            QT_VERSION: 6.4.0


### PR DESCRIPTION
I want to have a task that will assert we can get builds with the "next" version of QT - so we can either QA that or throw this in some automation ... or let me check if my build tools break :)  