### PR TITLE
Non default auth-in-app flows should not go back to StateStart becaus…

### DIFF
--- a/src/authenticationinapp/authenticationinappsession.cpp
+++ b/src/authenticationinapp/authenticationinappsession.cpp
@@ -749,7 +749,14 @@ void AuthenticationInAppSession::processErrorObject(const QJsonObject& obj) {
     }
 
     case 114:  // Client has sent too many requests
-      aia->requestState(AuthenticationInApp::StateStart, this);
+      if (m_typeAuthentication == TypeDefault) {
+        aia->requestState(AuthenticationInApp::StateStart, this);
+      } else {
+        // For non-default authentication flows, we go back to the password
+        // request, because the email request step is implicit.
+        aia->requestState(AuthenticationInApp::StateSignIn, this);
+      }
+
       aia->requestErrorPropagation(this,
                                    AuthenticationInApp::ErrorTooManyRequests,
                                    obj["retryAfter"].toInt());


### PR DESCRIPTION
…e it's not supported by the front-end code - VPN-3092
