### PR TITLE
Add theme for red text buttons links

### DIFF
--- a/nebula/ui/components/VPNCancelButton.qml
+++ b/nebula/ui/components/VPNCancelButton.qml
@@ -12,5 +12,5 @@ import components 0.1
 VPNLinkButton {
     labelText: VPNl18n.InAppSupportWorkflowSupportSecondaryActionText // "Cancel"
     fontName: VPNTheme.theme.fontBoldFamily
-    linkColor: VPNTheme.theme.redButton
+    linkColor: VPNTheme.theme.redLinkButton
 }

--- a/nebula/ui/components/VPNSignOut.qml
+++ b/nebula/ui/components/VPNSignOut.qml
@@ -11,7 +11,7 @@ VPNFooterLink {
     //% "Sign out"
     labelText: qsTrId("vpn.main.signOut2")
     fontName: VPNTheme.theme.fontBoldFamily
-    linkColor: VPNTheme.theme.redButton
+    linkColor: VPNTheme.theme.redLinkButton
     onClicked: () => {
                    VPNController.logout();
                }

--- a/nebula/ui/themes/themes.js
+++ b/nebula/ui/themes/themes.js
@@ -203,6 +203,15 @@ theme.redButton = {
   'focusBorder': theme.redPressed,
 };
 
+theme.redLinkButton = {
+  'defaultColor': theme.redHovered,
+  'buttonHovered': theme.redPressed,
+  'buttonPressed': theme.redPressed,
+  'buttonDisabled': theme.redDisabled,
+  'focusOutline': theme.redfocusOutline,
+  'focusBorder': theme.redPressed,
+};
+
 theme.removeDeviceBtn = {
   'defaultColor': theme.bgColorTransparent,
   'buttonHovered': '#FFDFE7',

--- a/src/ui/deleteAccount/ViewDeleteAccountRequest.qml
+++ b/src/ui/deleteAccount/ViewDeleteAccountRequest.qml
@@ -102,7 +102,7 @@ VPNInAppAuthenticationBase {
             fontName: VPNTheme.theme.fontBoldFamily
             // Cancel
             labelText: VPNl18n.InAppSupportWorkflowSupportSecondaryActionText
-            linkColor: VPNTheme.theme.redButton
+            linkColor: VPNTheme.theme.redLinkButton
             onClicked: {
                 cancelAuthenticationFlow();
             }

--- a/src/ui/screens/settings/ViewSubscriptionManagement/ViewSubscriptionManagement.qml
+++ b/src/ui/screens/settings/ViewSubscriptionManagement/ViewSubscriptionManagement.qml
@@ -107,7 +107,7 @@ VPNViewBase {
                 objectName: "accountDeletionButton"
                 fontName: VPNTheme.theme.fontBoldFamily
                 labelText: VPNl18n.DeleteAccountButtonLabel
-                linkColor: VPNTheme.theme.redButton
+                linkColor: VPNTheme.theme.redLinkButton
                 visible: VPNFeatureList.get("accountDeletion").isSupported
 
                 onClicked: {


### PR DESCRIPTION
## Description

Adds theme for red text button links.

## Reference

- [VPN-3052](https://mozilla-hub.atlassian.net/browse/VPN-3052): Change main red color for red text buttons to #E22850

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
