### PR TITLE
Make the TaskAddonIndex reschedulable - VPN-3094

### DIFF
--- a/src/tasks/addonindex/taskaddonindex.h
+++ b/src/tasks/addonindex/taskaddonindex.h
@@ -18,6 +18,9 @@ class TaskAddonIndex final : public Task {
 
   void run() override;
 
+  // If we cancel this task, we have to wait 1 hour before the next fetch.
+  DeletePolicy deletePolicy() const override { return Reschedulable; }
+
  private:
   void maybeComplete();
 


### PR DESCRIPTION
I don't know if we want to write a unit-test to check the delete state of each task. It seems not particularly useful. Note the the logic is fully tested already.