### PR TITLE
Fix 'es' language on iOS - VPN-2212

### DIFF
--- a/src/addons/addon.cpp
+++ b/src/addons/addon.cpp
@@ -16,6 +16,7 @@
 #include "conditionwatchers/addonconditionwatchertimestart.h"
 #include "conditionwatchers/addonconditionwatchertimeend.h"
 #include "leakdetector.h"
+#include "localizer.h"
 #include "logger.h"
 #include "models/feature.h"
 #include "mozillavpn.h"
@@ -427,7 +428,7 @@ void Addon::retranslate() {
 
   QLocale locale = QLocale(code);
   if (code.isEmpty()) {
-    locale = QLocale(QLocale::system().bcp47Name());
+    locale = QLocale(Localizer::systemLanguageCode());
   }
 
   if (!m_translator.load(

--- a/src/addons/conditionwatchers/addonconditionwatcherlocales.cpp
+++ b/src/addons/conditionwatchers/addonconditionwatcherlocales.cpp
@@ -41,7 +41,7 @@ AddonConditionWatcherLocales::~AddonConditionWatcherLocales() {
 bool AddonConditionWatcherLocales::conditionApplied() const {
   QString code = SettingsHolder::instance()->languageCode();
   if (code.isEmpty()) {
-    code = QLocale::system().bcp47Name();
+    code = Localizer::systemLanguageCode();
     if (code.isEmpty()) {
       code = "en";
     }

--- a/src/collator.cpp
+++ b/src/collator.cpp
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "collator.h"
+#include "localizer.h"
 
 #ifdef MVPN_IOS
 #  include "platforms/ios/iosutils.h"
@@ -30,7 +31,7 @@ int Collator::compare(const QString& a, const QString& b) {
   // strings.
   QString languageCode = SettingsHolder::instance()->languageCode();
   if (languageCode.isEmpty()) {
-    languageCode = QLocale::system().bcp47Name();
+    languageCode = Localizer::systemLanguageCode();
   }
 
   return vpnWasmCompareString(a.toLocal8Bit().constData(),

--- a/src/localizer.cpp
+++ b/src/localizer.cpp
@@ -39,6 +39,22 @@ QMap<QString, StaticLanguage> s_languageMap{
 }  // namespace
 
 // static
+QString Localizer::systemLanguageCode() {
+  QStringList uiLanguages = QLocale::system().uiLanguages();
+  if (uiLanguages.isEmpty()) {
+    return QLocale::system().bcp47Name();
+  }
+
+  for (const QString& language : uiLanguages) {
+    if (language.count("-") < 2) {
+      return language;
+    }
+  }
+
+  return QLocale::system().bcp47Name();
+}
+
+// static
 Localizer* Localizer::instance() {
   Q_ASSERT(s_instance);
   return s_instance;
@@ -64,7 +80,7 @@ Localizer::~Localizer() {
 }
 
 void Localizer::initialize() {
-  QString systemCode = QLocale::system().bcp47Name();
+  QString systemCode = systemLanguageCode();
 
   // In previous versions, we did not have the support for the system language.
   // If this is the first time we are here, we need to check if the current
@@ -139,7 +155,7 @@ bool Localizer::loadLanguageInternal(const QString& code) {
     // QLocale::system() directly because it would load the 'en' language
     // instead of the system one. Let's recreate a new QLocale object using the
     // bcp47 code.
-    locale = QLocale(QLocale::system().bcp47Name());
+    locale = QLocale(systemLanguageCode());
   }
 
   QLocale::setDefault(locale);
@@ -308,7 +324,7 @@ QString Localizer::localizeCurrency(double value,
                                     const QString& currencyIso4217) {
   QString code = SettingsHolder::instance()->languageCode();
   if (code.isEmpty()) {
-    code = QLocale::system().bcp47Name();
+    code = systemLanguageCode();
   }
 
   QLocale locale(code);

--- a/src/localizer.h
+++ b/src/localizer.h
@@ -34,6 +34,8 @@ class Localizer final : public QAbstractListModel {
     CodeRole,
   };
 
+  static QString systemLanguageCode();
+
   static Localizer* instance();
 
   Localizer();

--- a/tests/unit/testlocalizer.cpp
+++ b/tests/unit/testlocalizer.cpp
@@ -24,6 +24,8 @@ void TestLocalizer::basic() {
 
 void TestLocalizer::systemLanguage() {
   SettingsHolder settings;
+  settings.hardReset();
+
   Localizer l;
 
   l.setCode("");
@@ -31,11 +33,13 @@ void TestLocalizer::systemLanguage() {
 
   l.setCode("en");
   QCOMPARE(l.code(), "en");
-  QCOMPARE(l.previousCode(), "en");
+  QVERIFY(!l.previousCode().isEmpty());
 
   l.setCode("");
   QCOMPARE(l.code(), "");
   QCOMPARE(l.previousCode(), "en");
+
+  QVERIFY(!Localizer::systemLanguageCode().isEmpty());
 }
 
 void TestLocalizer::localizeCurrency() {


### PR DESCRIPTION
A bit of context: on IOS, bc47name() returns `es-US` when the language is set to spanish. The fix to this issue is to use the `uiLanguages` method (https://doc.qt.io/qt-6/qlocale.html#uiLanguages).

In this PR I also centralize the fetching of system language code in all the code base.