### PR TITLE
VPN-2804 - Get notifications to work (again) on MacOS

### DIFF
--- a/src/platforms/macos/macosstatusicon.h
+++ b/src/platforms/macos/macosstatusicon.h
@@ -21,6 +21,7 @@ class MacOSStatusIcon final : public QObject {
   void setIndicatorColor(const QColor& indicatorColor);
   void setMenu(NSMenu* statusBarMenu);
   void setToolTip(const QString& tooltip);
+  void showMessage(const QString& title, const QString& message, int timerMsec);
 };
 
 #endif  // MACOSSTATUSICON_H

--- a/src/platforms/macos/macossystemtraynotificationhandler.cpp
+++ b/src/platforms/macos/macossystemtraynotificationhandler.cpp
@@ -58,6 +58,18 @@ void MacosSystemTrayNotificationHandler::showHideWindow() {
   }
 }
 
+void MacosSystemTrayNotificationHandler::notify(Message type,
+                                                const QString& title,
+                                                const QString& message,
+                                                int timerMsec) {
+  // This is very hacky, but necessary to circumvent a Qt bug where
+  // notifications are not shown when the icon is not visible.
+  // See: https://bugreports.qt.io/browse/QTBUG-108134
+  m_systemTrayIcon->show();
+  SystemTrayNotificationHandler::notify(type, title, message, timerMsec);
+  m_systemTrayIcon->hide();
+}
+
 void MacosSystemTrayNotificationHandler::updateIcon() {
   logger.debug() << "Update icon";
 

--- a/src/platforms/macos/macossystemtraynotificationhandler.h
+++ b/src/platforms/macos/macossystemtraynotificationhandler.h
@@ -26,6 +26,9 @@ class MacosSystemTrayNotificationHandler
 
   virtual void updateIcon() override;
 
+  virtual void notify(Message type, const QString& title,
+                      const QString& message, int timerMsec) override;
+
  private:
   void initialize() override;
 


### PR DESCRIPTION
This does _not_ cause the other systray icon to blink when a new notification is show. At least not that I could see.