### PR TITLE
Android: fix cmake stuff

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -72,7 +72,7 @@ android {
             manifest.srcFile 'AndroidManifest.xml'
             renderscript.srcDirs = ['src']
             assets.srcDirs = ['assets']
-            jniLibs.srcDirs = ['libs']
+            jniLibs.srcDirs = ['libs','build/ssl']
        }
         debug{
             try {
@@ -212,3 +212,26 @@ task ktlintFormat(type: JavaExec, group: "formatting") {
     main = "com.pinterest.ktlint.Main"
     args "-F", "src/**/*.kt", "!**/build/**/*.kt", "buildSrc/**/*.kt",  "daemon/**/*.kt", "**/*.kts"
 }
+
+
+// Tasks to Import the Platform plugins
+task importOpenSSL(type: Copy) {
+    with(copySpec(){
+        from("../../../3rdparty/openSSL/latest/arm")
+        into("armeabi-v7a")
+    })
+    with(copySpec(){
+        from("../../../3rdparty/openSSL/latest/arm64")
+        into("arm64-v8a")
+    })
+    with(copySpec(){
+        from("../../../3rdparty/openSSL/latest/x86")
+        into("x86")
+    })
+    with(copySpec(){
+        from("../../../3rdparty/openSSL/latest/x86_64")
+        into("x86_64")
+    })
+    into("build/ssl")
+}
+preBuild.dependsOn importOpenSSL

--- a/src/cmake/android.cmake
+++ b/src/cmake/android.cmake
@@ -8,6 +8,7 @@ set_property(TARGET mozillavpn APPEND PROPERTY QT_ANDROID_PACKAGE_SOURCE_DIR
 )
 
 target_link_libraries(mozillavpn PRIVATE
+    Qt6::Test
     Qt6::Xml)
 
 


### PR DESCRIPTION
Forgot about ssl >:c - Also link against qt-test so it's picked up by the qmlimportscanner (it's used in the inspector it seems)