### PR TITLE
VPN-3071 Unify mobile and desktop auth (WIP)

### DIFF
--- a/src/featureslist.h
+++ b/src/featureslist.h
@@ -93,18 +93,18 @@ FEATURE_SIMPLE(freeTrial,             // Feature ID
 FEATURE_SIMPLE(inAppAccountCreate,                  // Feature ID
                "In-app Account Cretion",            // Feature name
                "2.6",                               // released
-               FeatureCallback_true,                // Can be flipped on
+               FeatureCallback_false,               // Can be flipped on
                FeatureCallback_false,               // Can be flipped off
                QStringList{"inAppAuthentication"},  // feature dependencies
-               FeatureCallback_iosOrAndroid)
+               FeatureCallback_true)
 
 FEATURE_SIMPLE(inAppAuthentication,      // Feature ID
                "In-app Authentication",  // Feature name
                "2.4",                    // released
-               FeatureCallback_true,     // Can be flipped on
+               FeatureCallback_false,    // Can be flipped on
                FeatureCallback_false,    // Can be flipped off
                QStringList(),            // feature dependencies
-               FeatureCallback_iosOrAndroid)
+               FeatureCallback_true)
 
 FEATURE_SIMPLE(inAppPurchase,          // Feature ID
                "In app Purchase",      // Feature name
@@ -112,7 +112,7 @@ FEATURE_SIMPLE(inAppPurchase,          // Feature ID
                FeatureCallback_false,  // Can be flipped on
                FeatureCallback_false,  // Can be flipped off
                QStringList(),          // feature dependencies
-               FeatureCallback_inAppPurchase)
+               FeatureCallback_true)
 
 FEATURE_SIMPLE(keyRegeneration,       // Feature ID
                "Key Regeneration",    // Feature name
@@ -131,13 +131,13 @@ FEATURE_SIMPLE(lanAccess,                    // Feature ID
                QStringList(),                // feature dependencies
                FeatureCallback_lanAccess)
 
-FEATURE_SIMPLE(mobileOnboarding,       // Feature ID
-               "Mobile Onboarding",    // Feature name
-               "2.8",                  // released
-               FeatureCallback_true,   // Can be flipped on
-               FeatureCallback_false,  // Can be flipped off
-               QStringList(),          // feature dependencies
-               FeatureCallback_iosOrAndroid)
+FEATURE_SIMPLE(mobileOnboarding,      // Feature ID
+               "Mobile Onboarding",   // Feature name
+               "2.8",                 // released
+               FeatureCallback_true,  // Can be flipped on
+               FeatureCallback_true,  // Can be flipped off
+               QStringList(),         // feature dependencies
+               FeatureCallback_true)
 
 #if defined(MVPN_ANDROID) || defined(MVPN_IOS)
 #  define MULTIHOP_RELEASE "2.7"

--- a/src/featureslistcallback.h
+++ b/src/featureslistcallback.h
@@ -69,14 +69,6 @@ bool FeatureCallback_captivePortal() {
 #endif
 }
 
-bool FeatureCallback_inAppPurchase() {
-#if defined(MVPN_IOS) || defined(MVPN_ANDROID) || defined(MVPN_WASM)
-  return true;
-#else
-  return false;
-#endif
-}
-
 bool FeatureCallback_lanAccess() {
 #if defined(MVPN_IOS)
   // managed by the OS automatically. No need to

--- a/src/iaphandler.cpp
+++ b/src/iaphandler.cpp
@@ -106,12 +106,19 @@ void IAPHandler::registerProducts(const QByteArray& data) {
   }
 
   if (m_products.isEmpty()) {
+#if defined(MVPN_ANDROID) or defined(MVPN_IOS)
+    logger.error() << "No pending products (nothing has been registered). "
+                      "Unable to recover from "
+                      "this scenario.";
+    return;
+#else
     // Add a "web" product placeholder
     Product product;
     product.m_name = "web";
     product.m_type = ProductUnknown;
     product.m_featuredProduct = true;
     m_products.append(product);
+#endif
   }
 
   nativeRegisterProducts();

--- a/src/iaphandler.cpp
+++ b/src/iaphandler.cpp
@@ -106,10 +106,12 @@ void IAPHandler::registerProducts(const QByteArray& data) {
   }
 
   if (m_products.isEmpty()) {
-    logger.error() << "No pending products (nothing has been registered). "
-                      "Unable to recover from "
-                      "this scenario.";
-    return;
+    // Add a "web" product placeholder
+    Product product;
+    product.m_name = "web";
+    product.m_type = ProductUnknown;
+    product.m_featuredProduct = true;
+    m_products.append(product);
   }
 
   nativeRegisterProducts();

--- a/src/mozillavpn.h
+++ b/src/mozillavpn.h
@@ -268,13 +268,12 @@ class MozillaVPN final : public QObject {
   }
 
   void hardReset();
+  void setUserState(UserState userState);
 
  private:
   void setState(State state);
 
   void maybeStateMain();
-
-  void setUserState(UserState userState);
 
   void startSchedulingPeriodicOperations();
 

--- a/src/platforms/dummy/dummyiaphandler.cpp
+++ b/src/platforms/dummy/dummyiaphandler.cpp
@@ -27,7 +27,8 @@ void DummyIAPHandler::nativeRegisterProducts() {
 
 void DummyIAPHandler::nativeStartSubscription(Product* product) {
   Q_ASSERT(product->m_name == "web");
-  MozillaVPN::instance()->logout();
+  // This is a hack. Should we make a new state?
+  MozillaVPN::instance()->setUserState(MozillaVPN::UserNotAuthenticated);
   MozillaVPN::instance()->authenticateWithType(
       MozillaVPN::AuthenticationType::AuthenticationInBrowser);
 }

--- a/src/platforms/dummy/dummyiaphandler.cpp
+++ b/src/platforms/dummy/dummyiaphandler.cpp
@@ -5,8 +5,10 @@
 #include "platforms/dummy/dummyiaphandler.h"
 #include "leakdetector.h"
 #include "logger.h"
+#include "mozillavpn.h"
 
 #include <QCoreApplication>
+#include <QTimer>
 
 namespace {
 Logger logger(LOG_IAP, "DummyIAPHandler");
@@ -18,10 +20,16 @@ DummyIAPHandler::DummyIAPHandler(QObject* parent) : IAPHandler(parent) {
 
 DummyIAPHandler::~DummyIAPHandler() { MVPN_COUNT_DTOR(DummyIAPHandler); }
 
-void DummyIAPHandler::nativeRegisterProducts() {}
+void DummyIAPHandler::nativeRegisterProducts() {
+  QTimer::singleShot(200, this,
+                     [this]() { emit productsRegistrationCompleted(); });
+}
 
 void DummyIAPHandler::nativeStartSubscription(Product* product) {
-  Q_UNUSED(product)
+  Q_ASSERT(product->m_name == "web");
+  MozillaVPN::instance()->logout();
+  MozillaVPN::instance()->authenticateWithType(
+      MozillaVPN::AuthenticationType::AuthenticationInBrowser);
 }
 
 void DummyIAPHandler::nativeRestoreSubscription() {}

--- a/src/tasks/authenticate/taskauthenticate.cpp
+++ b/src/tasks/authenticate/taskauthenticate.cpp
@@ -10,6 +10,7 @@
 #include "models/user.h"
 #include "mozillavpn.h"
 #include "networkrequest.h"
+#include "settingsholder.h"
 
 #include <QJSValue>
 #include <QJsonDocument>
@@ -81,8 +82,12 @@ void TaskAuthenticate::run() {
             m_authenticationListener->aboutToFinish();
           });
 
+  SettingsHolder* settingsHolder = SettingsHolder::instance();
+  Q_ASSERT(settingsHolder);
+  QString email = settingsHolder->userEmail();
+
   m_authenticationListener->start(this, pkceCodeChallenge,
-                                  CODE_CHALLENGE_METHOD);
+                                  CODE_CHALLENGE_METHOD, email);
 }
 
 void TaskAuthenticate::authenticationCompleted(const QByteArray& data) {


### PR DESCRIPTION
## Description

* Use the same on-boarding screen for desktop and mobile
* Uses IAP flow for all platforms
* Defines a new dummy product "web" (need to work on UI for this)
* Uses DummyIAPHandler (this needs to move) to redirect back to the webflow in the case of a subscription being needed
* Adds email to the authenticate call if it's available in the settings holder (which it won't be if a user most recently logged out, but will be in this new flow) - this lets us pre-populate fxa screen nicely.

## Reference

    [VPN-3071](https://mozilla-hub.atlassian.net/browse/VPN-3071) (and some others)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
