### PR TITLE
Cleanup Glean/Rust openssl dependencies

### DIFF
--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -101,21 +101,6 @@ jobs:
 
       - name: Install Build Dependencies
         run: |
-          # Install and build OpenSSL from scratch.
-          #
-          # Using `yum install openssl` doesn't seem to make cmake happy,
-          # so we have to do it the hard way.
-          yum -y install perl git
-          git clone https://github.com/openssl/openssl.git
-          cd openssl
-          ./Configure
-          make
-          # I think the issue with `yum install` is that it will install the package
-          # in a folder Cmake is not expecting, while this command always users /usr/local
-          make install
-          cd ..
-
-          # Install the other (not picky) build deps.
           yum -y install rpm-build rpmdevtools yum-utils
           yum-builddep -y mozillavpn.spec
 

--- a/linux/mozillavpn.spec
+++ b/linux/mozillavpn.spec
@@ -19,7 +19,7 @@ BuildRequires: golang >= 1.13
 BuildRequires: polkit-devel
 BuildRequires: python3-yaml
 BuildRequires: cargo
-BuildRequires: openssl
+BuildRequires: openssl-devel
 BuildRequires: qt6-qtbase-devel >= 6.0
 BuildRequires: qt6-qtnetworkauth-devel >= 6.0
 BuildRequires: qt6-qtdeclarative-devel >= 6.0

--- a/vpnglean/CMakeLists.txt
+++ b/vpnglean/CMakeLists.txt
@@ -6,29 +6,19 @@ add_library(vpnglean STATIC IMPORTED GLOBAL)
 
 set_target_properties(vpnglean PROPERTIES FOLDER "Libs")
 
-if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
-    set(OPENSSL_USE_STATIC_LIBS TRUE)
-    find_package(OpenSSL REQUIRED)
-    get_filename_component(OPENSSL_LIB_DIR ${OPENSSL_SSL_LIBRARY} DIRECTORY)
-endif()
-
-if (CMAKE_BUILD_TYPE STREQUAL "Debug")
-    set(CARGO_CMD cargo build)
-    set(TARGET_DIR "debug")
-else ()
-    set(CARGO_CMD cargo build --release)
-    set(TARGET_DIR "release")
-endif ()
-
-set (HEADER_FILE vpnglean.h)
+set(HEADER_FILE vpnglean.h)
 set(LIBNAME ${CMAKE_STATIC_LIBRARY_PREFIX}vpnglean${CMAKE_STATIC_LIBRARY_SUFFIX})
-get_filename_component(GENERATED_DIR ${CMAKE_CURRENT_BINARY_DIR}/${TARGET_DIR} ABSOLUTE)
 
-set(VPNGLEAN_ENV BUILD_ID=${BUILD_ID} APP_VERSION=${CMAKE_PROJECT_VERSION} CARGO_TARGET_DIR=${CMAKE_CURRENT_BINARY_DIR})
-set(OPENSSL_ENV OPENSSL_STATIC=yes OPENSSL_LIB_DIR=${OPENSSL_LIB_DIR} OPENSSL_INCLUDE_DIR=${OPENSSL_INCLUDE_DIR})
 add_custom_target(vpnglean_ffi
-    BYPRODUCTS ${GENERATED_DIR}/${LIBNAME} ${CMAKE_CURRENT_BINARY_DIR}/${HEADER_FILE}
-    COMMAND ${CMAKE_COMMAND} -E env ${VPNGLEAN_ENV} ${OPENSSL_ENV} ${CARGO_CMD}
+    BYPRODUCTS
+        ${CMAKE_CURRENT_BINARY_DIR}/debug/${LIBNAME}
+        ${CMAKE_CURRENT_BINARY_DIR}/release/${LIBNAME}
+        ${CMAKE_CURRENT_BINARY_DIR}/${HEADER_FILE}
+    COMMAND ${CMAKE_COMMAND} -E env
+                BUILD_ID=${BUILD_ID}
+                APP_VERSION=${CMAKE_PROJECT_VERSION}
+                CARGO_TARGET_DIR=${CMAKE_CURRENT_BINARY_DIR}
+            cargo build $<IF:$<CONFIG:Debug>,,--release>
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 set_target_properties(vpnglean_ffi PROPERTIES FOLDER "Libs")
@@ -36,7 +26,16 @@ set_target_properties(vpnglean_ffi PROPERTIES FOLDER "Libs")
 add_dependencies(vpnglean vpnglean_ffi)
 add_dependencies(mozillavpn vpnglean)
 set_target_properties(vpnglean PROPERTIES
-    IMPORTED_LOCATION ${GENERATED_DIR}/${LIBNAME}
+    IMPORTED_LOCATION ${CMAKE_CURRENT_BINARY_DIR}/release/${LIBNAME}
+    IMPORTED_LOCATION_DEBUG ${CMAKE_CURRENT_BINARY_DIR}/debug/${LIBNAME}
 )
+
+## TODO: It's not clear if we will also need this on other platforms, or
+## if we just don't notice it due to statically linked Qt.
+if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+    find_package(OpenSSL REQUIRED)
+    set_target_properties(vpnglean PROPERTIES
+        IMPORTED_LINK_INTERFACE_LIBRARIES OpenSSL::SSL
+endif()
 
 target_include_directories(mozillavpn PRIVATE ${CMAKE_CURRENT_BINARY_DIR})

--- a/vpnglean/CMakeLists.txt
+++ b/vpnglean/CMakeLists.txt
@@ -36,6 +36,7 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
     find_package(OpenSSL REQUIRED)
     set_target_properties(vpnglean PROPERTIES
         IMPORTED_LINK_INTERFACE_LIBRARIES OpenSSL::SSL
+    )
 endif()
 
 target_include_directories(mozillavpn PRIVATE ${CMAKE_CURRENT_BINARY_DIR})

--- a/vpnglean/CMakeLists.txt
+++ b/vpnglean/CMakeLists.txt
@@ -32,11 +32,15 @@ set_target_properties(vpnglean PROPERTIES
 
 ## TODO: It's not clear if we will also need this on other platforms, or
 ## if we just don't notice it due to statically linked Qt.
-if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     find_package(OpenSSL REQUIRED)
-    set_target_properties(vpnglean PROPERTIES
-        IMPORTED_LINK_INTERFACE_LIBRARIES OpenSSL::SSL
+    set_property(TARGET vpnglean APPEND PROPERTY
+        INTERFACE_LINK_LIBRARIES OpenSSL::SSL
     )
+elseif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+    ## Windows seems to miss some system libraries when importing static OpenSSL
+    set_property(TARGET vpnglean APPEND PROPERTY
+        INTERFACE_LINK_LIBRARIES crypt32 Secur32)
 endif()
 
 target_include_directories(mozillavpn PRIVATE ${CMAKE_CURRENT_BINARY_DIR})


### PR DESCRIPTION
## Description
The recent introduction of glean.rs as a build step introduced a dependency on OpenSSL that was failing on Fedora-based distributions due to an expectation that we could find a static SSL library. For security reasons, Fedora does not provide such a library.

We also do a little bit of cleanup in terms of the rust build steps to ensure we honour the Release/Debug configuration for multi-config generators.

## Reference
Github #4780 ([VPN-3116](https://mozilla-hub.atlassian.net/browse/VPN-3116))

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
