### PR TITLE
Schedule the periodic tasks only when the app is in the main state - VPN-3115

### DIFF
--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -355,17 +355,13 @@ void MozillaVPN::setState(State state) {
   emit MozillaVPN::instance()->recordGleanEventWithExtraKeys(
       GleanSample::appStep, {{"state", QVariant::fromValue(state).toString()}});
 
-  // If we have a token, we can start periodic operations.
-  // If the timer is already started, this is a no-op.
-  if (SettingsHolder::instance()->hasToken()) {
+  // If we are activating the app, let's initialize the controller and the
+  // periodic tasks.
+  if (m_state == StateMain) {
+    m_private->m_controller.initialize();
     startSchedulingPeriodicOperations();
   } else {
     stopSchedulingPeriodicOperations();
-  }
-
-  // If we are activating the app, let's initialize the controller.
-  if (m_state == StateMain) {
-    m_private->m_controller.initialize();
   }
 }
 


### PR DESCRIPTION
Sarah debugged the issue. This PR is only the result of her work.

In VPN-2934, https://github.com/mozilla-mobile/mozilla-vpn-client/commit/37de80e874b6701d43ccdb03b7c18e4406317aee - we changed how the periodic tasks are scheduled: instead of checking the app state, we checked the existence of the JWT .
But during the subscription, we have the token, but the device has not been registered yet.
In staging, the scheduling of the periodic tasks is more aggressive (10/4-secs) and, when this happens, we reset the settings because the current device is not found the the account data from guardian.
This PR reverts part of VPN-2934. @brizental can you please check if this breaks VPN-2934?