### PR TITLE
Assert when a network request should include the JWT but this has not been set yet - VPN-3181

### DIFF
--- a/src/networkrequest.cpp
+++ b/src/networkrequest.cpp
@@ -66,6 +66,11 @@ NetworkRequest::NetworkRequest(Task* parent, int status,
   m_request.setOriginatingObject(parent);
 
   if (setAuthorizationHeader) {
+    if (SettingsHolder::instance()->token().isEmpty()) {
+      logger.error() << "INVALID TOKEN! This network request is going to fail.";
+      Q_ASSERT(false);
+    }
+
     QByteArray authorizationHeader = "Bearer ";
     authorizationHeader.append(
         SettingsHolder::instance()->token().toLocal8Bit());


### PR DESCRIPTION
This is nice to have to spot errors like VPN-3115.