### PR TITLE
Bug 1799194 - Migrate mozilla-vpn-client from AWS to GCP

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -136,7 +136,7 @@ tasks:
                             name: "Decision Task for cron job ${cron.job_name}"
                             description: 'Created by a [cron task](https://firefox-ci-tc.services.mozilla.com/tasks/${cron.task_id})'
                 provisionerId: "mozillavpn-${level}"
-                workerType: "decision"
+                workerType: "decision-gcp"
 
                 tags:
                     $if: 'tasks_for in ["github-push", "github-pull-request"]'

--- a/taskcluster/ci/config.yml
+++ b/taskcluster/ci/config.yml
@@ -38,12 +38,12 @@ workers:
             provisioner: 'mozillavpn-{level}'
             implementation: docker-worker
             os: linux
-            worker-type: b-linux
+            worker-type: b-linux-gcp
         b-linux-large:
             provisioner: 'mozillavpn-{level}'
             implementation: docker-worker
             os: linux
-            worker-type: b-linux-large
+            worker-type: b-linux-large-gcp
         b-win2012:
             provisioner: 'mozillavpn-{level}'
             implementation: generic-worker
@@ -61,7 +61,7 @@ workers:
             provisioner: 'mozillavpn-{level}'
             implementation: docker-worker
             os: linux
-            worker-type: 'images'
+            worker-type: 'images-gcp'
         dep-signing:
             provisioner: scriptworker-k8s
             implementation: scriptworker-signing


### PR DESCRIPTION
## Description

Migrate mozilla-vpn-client from AWS to GCP
**Requires https://phabricator.services.mozilla.com/D161329 to land first before merging!**

## Reference

https://bugzilla.mozilla.org/show_bug.cgi?id=1799194

## Checklist
    
- [X] My code follows the style guidelines for this project
- [X] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [X] I have performed a self review of my own code
- [X] I have commented my code PARTICULARLY in hard to understand areas
- [X] I have added thorough tests where needed
