### PR TITLE
Transaction for settings

### DIFF
--- a/scripts/ci/jsonSchemas/tutorial.json
+++ b/scripts/ci/jsonSchemas/tutorial.json
@@ -40,6 +40,10 @@
       "type": "string",
       "description": "The image of the tutorial"
     },
+    "settings_rollback_needed": {
+      "type": "boolean",
+      "description": "Do we need to revert all the settings changes at the end of the tutorial?"
+    },
     "steps": {
       "type": "array",
       "description": "The list of text steps",

--- a/src/addons/addonmessage.cpp
+++ b/src/addons/addonmessage.cpp
@@ -165,9 +165,6 @@ QString AddonMessage::formattedDate() const {
 // static
 QString AddonMessage::dateInternal(const QDateTime& nowDateTime,
                                    const QDateTime& messageDateTime) {
-  logger.debug() << "Now" << nowDateTime.toString() << "date"
-                 << messageDateTime.toString();
-
   qint64 diff = messageDateTime.secsTo(nowDateTime);
   if (diff < 0) {
     // The addon has a date set in the future...?

--- a/src/addons/addontutorial.cpp
+++ b/src/addons/addontutorial.cpp
@@ -53,6 +53,8 @@ Addon* AddonTutorial::create(QObject* parent, const QString& manifestFileName,
   auto guard = qScopeGuard([&] { tutorial->deleteLater(); });
 
   tutorial->m_highlighted = tutorialObj["highlighted"].toBool();
+  tutorial->m_settingsRollbackNeeded =
+      tutorialObj["settings_rollback_needed"].toBool();
 
   tutorial->m_title.initialize(QString("tutorial.%1.title").arg(tutorialId),
                                tutorialObj["title"].toString());
@@ -112,12 +114,20 @@ AddonTutorial::~AddonTutorial() { MVPN_COUNT_DTOR(AddonTutorial); }
 void AddonTutorial::play(const QStringList& allowedItems) {
   m_allowedItems = allowedItems;
   m_currentStep = 0;
+  m_activeTransaction = false;
 
   if (m_navigatorReloader) {
     m_navigatorReloader->deleteLater();
   }
 
   m_navigatorReloader = new NavigatorReloader(this);
+
+  if (settingsRollbackNeeded()) {
+    m_activeTransaction = SettingsHolder::instance()->beginTransaction();
+    if (!m_activeTransaction) {
+      logger.warning() << "Unable to start a setting transaction";
+    }
+  }
 
   m_itemPicker->start();
 
@@ -133,8 +143,14 @@ void AddonTutorial::stop() {
     m_steps[m_currentStep]->stop();
   }
 
+  if (m_activeTransaction &&
+      !SettingsHolder::instance()->rollbackTransaction()) {
+    logger.warning() << "Unable to rollback a setting transaction";
+  }
+
   m_itemPicker->stop();
   m_currentStep = -1;
+  m_activeTransaction = false;
 
   if (m_navigatorReloader) {
     m_navigatorReloader->deleteLater();

--- a/src/addons/addontutorial.h
+++ b/src/addons/addontutorial.h
@@ -26,6 +26,7 @@ class AddonTutorial final : public Addon {
 
   Q_PROPERTY(QString image MEMBER m_image CONSTANT)
   Q_PROPERTY(bool highlighted READ highlighted CONSTANT)
+  Q_PROPERTY(bool settingsRollbackNeeded READ settingsRollbackNeeded CONSTANT)
 
   static Addon* create(QObject* parent, const QString& manifestFileName,
                        const QString& id, const QString& name,
@@ -39,6 +40,8 @@ class AddonTutorial final : public Addon {
   const QStringList& allowedItems() const { return m_allowedItems; }
 
   bool highlighted() const { return m_highlighted; }
+
+  bool settingsRollbackNeeded() const { return m_settingsRollbackNeeded; }
 
   bool itemPicked(const QList<QQuickItem*>& list);
 
@@ -60,6 +63,8 @@ class AddonTutorial final : public Addon {
   QList<TutorialStep*> m_steps;
   int32_t m_currentStep = -1;
   bool m_highlighted = false;
+  bool m_settingsRollbackNeeded = false;
+  bool m_activeTransaction = false;
 
   QStringList m_allowedItems;
 

--- a/src/adjust/adjusthandler.cpp
+++ b/src/adjust/adjusthandler.cpp
@@ -63,15 +63,13 @@ void AdjustHandler::initialize() {
     return;
   }
 
-  QObject::connect(settingsHolder, &SettingsHolder::gleanEnabledChanged,
-                   [](const bool& gleanEnabled) {
-                     if (!gleanEnabled) {
-                       forget();
-                       // Let's keep the proxy on. Maybe Adjust needs to send
-                       // requests to remove data on their servers.
-                       return;
-                     }
-                   });
+  QObject::connect(settingsHolder, &SettingsHolder::gleanEnabledChanged, []() {
+    if (!SettingsHolder::instance()->gleanEnabled()) {
+      forget();
+      // Let's keep the proxy on. Maybe Adjust needs to send
+      // requests to remove data on their servers.
+    }
+  });
 
   s_adjustProxy = new AdjustProxy(vpn);
   QObject::connect(vpn->controller(), &Controller::readyToQuit, s_adjustProxy,

--- a/src/commands/commandui.cpp
+++ b/src/commands/commandui.cpp
@@ -257,22 +257,12 @@ int CommandUI::run(QStringList& tokens) {
     vpn.initialize();
 
 #ifdef MVPN_MACOS
-    MacOSStartAtBootWatcher startAtBootWatcher(
-        SettingsHolder::instance()->startAtBoot());
-    QObject::connect(SettingsHolder::instance(),
-                     &SettingsHolder::startAtBootChanged, &startAtBootWatcher,
-                     &MacOSStartAtBootWatcher::startAtBootChanged);
-
+    MacOSStartAtBootWatcher startAtBootWatcher();
     MacOSUtils::setDockClickHandler();
 #endif
 
 #ifdef MVPN_WINDOWS
-    WindowsStartAtBootWatcher startAtBootWatcher(
-        SettingsHolder::instance()->startAtBoot());
-
-    QObject::connect(SettingsHolder::instance(),
-                     &SettingsHolder::startAtBootChanged, &startAtBootWatcher,
-                     &WindowsStartAtBootWatcher::startAtBootChanged);
+    WindowsStartAtBootWatcher startAtBootWatcher();
 #endif
 
 #ifdef MVPN_LINUX

--- a/src/glean/glean.cpp
+++ b/src/glean/glean.cpp
@@ -50,7 +50,10 @@ void Glean::initialize() {
 
     s_instance = new Glean();
     connect(SettingsHolder::instance(), &SettingsHolder::gleanEnabledChanged,
-            s_instance, &setUploadEnabled);
+            s_instance, []() {
+              s_instance->setUploadEnabled(
+                  SettingsHolder::instance()->gleanEnabled());
+            });
 
     SettingsHolder* settingsHolder = SettingsHolder::instance();
     MozillaVPN* vpn = MozillaVPN::instance();

--- a/src/networkwatcher.cpp
+++ b/src/networkwatcher.cpp
@@ -91,8 +91,7 @@ void NetworkWatcher::initialize() {
           &NetworkWatcher::settingsChanged);
 }
 
-void NetworkWatcher::settingsChanged(const bool& active) {
-  Q_UNUSED(active);
+void NetworkWatcher::settingsChanged() {
   SettingsHolder* settingsHolder = SettingsHolder::instance();
   m_active = settingsHolder->unsecuredNetworkAlert() ||
              settingsHolder->captivePortalAlert();

--- a/src/networkwatcher.h
+++ b/src/networkwatcher.h
@@ -32,7 +32,7 @@ class NetworkWatcher final : public QObject {
   void networkChange();
 
  private:
-  void settingsChanged(const bool& value);
+  void settingsChanged();
 
   void notificationClicked(NotificationHandler::Message message);
 

--- a/src/platforms/android/androidglean.cpp
+++ b/src/platforms/android/androidglean.cpp
@@ -111,11 +111,13 @@ void AndroidGlean::setGleanSourceTags(const QStringList& tags) {
       ServiceAction::ACTION_GLEAN_SET_SOURCE_TAGS, tags.join(","));
 }
 
-void AndroidGlean::gleanUploadEnabledChanged(bool enabled) {
+void AndroidGlean::gleanUploadEnabledChanged() {
+  bool enabled = SettingsHolder::instance()->gleanEnabled();
+  logger.debug() << " gleanEnabledChanged" << enabled;
+
   QJsonObject args;
   args["enabled"] = enabled;
   QJsonDocument doc(args);
-  logger.debug() << " gleanEnabledChanged" << enabled;
   AndroidVPNActivity::instance()->sendToService(
       ServiceAction::ACTION_GLEAN_ENABLED_CHANGED,
       doc.toJson(QJsonDocument::Compact));

--- a/src/platforms/android/androidvpnactivity.cpp
+++ b/src/platforms/android/androidvpnactivity.cpp
@@ -149,9 +149,9 @@ void AndroidVPNActivity::onServiceDisconnected(JNIEnv* env, jobject thiz) {
   logger.debug() << "service disconnected";
   emit AndroidVPNActivity::instance()->serviceDisconnected();
 }
-void AndroidVPNActivity::startAtBootChanged(const bool& startAtBoot) {
+void AndroidVPNActivity::startAtBootChanged() {
   QJsonObject args;
-  args["startOnBoot"] = startAtBoot;
+  args["startOnBoot"] = SettingsHolder::instance()->startAtBoot();
   QJsonDocument doc(args);
   sendToService(ServiceAction::ACTION_SET_START_ON_BOOT, doc.toJson());
 }

--- a/src/platforms/android/androidvpnactivity.h
+++ b/src/platforms/android/androidvpnactivity.h
@@ -92,7 +92,7 @@ class AndroidVPNActivity : public QObject {
 
  private:
   AndroidVPNActivity();
-  void startAtBootChanged(const bool& startAtBoot);
+  void startAtBootChanged();
 
   static void onServiceMessage(JNIEnv* env, jobject thiz, jint messageType,
                                jstring body);

--- a/src/platforms/macos/macosstartatbootwatcher.cpp
+++ b/src/platforms/macos/macosstartatbootwatcher.cpp
@@ -6,23 +6,30 @@
 #include "leakdetector.h"
 #include "logger.h"
 #include "macosutils.h"
+#include "settingsholder.h"
 
 namespace {
 Logger logger(LOG_MACOS, "MacOSStartAtBootWatcher");
 }
 
-MacOSStartAtBootWatcher::MacOSStartAtBootWatcher(bool startAtBoot) {
+MacOSStartAtBootWatcher::MacOSStartAtBootWatcher() {
   MVPN_COUNT_CTOR(MacOSStartAtBootWatcher);
 
   logger.debug() << "StartAtBoot watcher";
-  MacOSUtils::enableLoginItem(startAtBoot);
+
+  connect(SettingsHolder::instance(), &SettingsHolder::startAtBootChanged, this,
+          &MacOSStartAtBootWatcher::startAtBootChanged);
+
+  startAtBootChanged();
 }
 
 MacOSStartAtBootWatcher::~MacOSStartAtBootWatcher() {
   MVPN_COUNT_DTOR(MacOSStartAtBootWatcher);
 }
 
-void MacOSStartAtBootWatcher::startAtBootChanged(const bool& startAtBoot) {
+void MacOSStartAtBootWatcher::startAtBootChanged() {
+  bool startAtBoot = SettingsHolder::instance()->startAtBoot();
+
   logger.debug() << "StartAtBoot changed:" << startAtBoot;
   MacOSUtils::enableLoginItem(startAtBoot);
 }

--- a/src/platforms/macos/macosstartatbootwatcher.h
+++ b/src/platforms/macos/macosstartatbootwatcher.h
@@ -12,10 +12,11 @@ class MacOSStartAtBootWatcher final : public QObject {
   Q_DISABLE_COPY_MOVE(MacOSStartAtBootWatcher)
 
  public:
-  explicit MacOSStartAtBootWatcher(bool startAtBoot);
+  explicit MacOSStartAtBootWatcher();
   ~MacOSStartAtBootWatcher();
 
-  void startAtBootChanged(const bool& startAtBoot);
+ private:
+  void startAtBootChanged();
 };
 
 #endif  // MACOSSTARTATBOOTWATCHER_H

--- a/src/platforms/windows/windowsstartatbootwatcher.cpp
+++ b/src/platforms/windows/windowsstartatbootwatcher.cpp
@@ -14,18 +14,24 @@ namespace {
 Logger logger(LOG_WINDOWS, "WindowsStartAtBootWatcher");
 }
 
-WindowsStartAtBootWatcher::WindowsStartAtBootWatcher(bool startAtBoot) {
+WindowsStartAtBootWatcher::WindowsStartAtBootWatcher() {
   MVPN_COUNT_CTOR(WindowsStartAtBootWatcher);
 
   logger.debug() << "StartAtBoot watcher";
-  startAtBootChanged(startAtBoot);
+
+  connect(SettingsHolder::instance(), &SettingsHolder::startAtBootChanged, this,
+          &WindowsStartAtBootWatcher::startAtBootChanged);
+
+  startAtBootChanged();
 }
 
 WindowsStartAtBootWatcher::~WindowsStartAtBootWatcher() {
   MVPN_COUNT_DTOR(WindowsStartAtBootWatcher);
 }
 
-void WindowsStartAtBootWatcher::startAtBootChanged(const bool& startAtBoot) {
+void WindowsStartAtBootWatcher::startAtBootChanged() {
+  bool startAtBoot = SettingsHolder::instance()->startAtBoot();
+
   logger.debug() << "StartAtBoot changed:" << startAtBoot;
   QSettings settings(
       "HKEY_CURRENT_USER\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Run",

--- a/src/platforms/windows/windowsstartatbootwatcher.h
+++ b/src/platforms/windows/windowsstartatbootwatcher.h
@@ -12,10 +12,11 @@ class WindowsStartAtBootWatcher final : public QObject {
   Q_DISABLE_COPY_MOVE(WindowsStartAtBootWatcher)
 
  public:
-  explicit WindowsStartAtBootWatcher(bool startAtBoot);
+  explicit WindowsStartAtBootWatcher();
   ~WindowsStartAtBootWatcher();
 
-  void startAtBootChanged(const bool& startAtBoot);
+ private:
+  void startAtBootChanged();
 };
 
 #endif  // WINDOWSSTARTATBOOTWATCHER_H

--- a/src/settingsholder.cpp
+++ b/src/settingsholder.cpp
@@ -50,10 +50,8 @@ SettingsHolder::SettingsHolder()
 
   if (QFile::exists(journalSettingFileName())) {
     QString journalSettingFile(journalSettingFileName());
-    logger.warning() << "journal file exists" << journalSettingFile;
+    logger.info() << "journal file exists" << journalSettingFile;
 
-    // We cannot simply rename the journal settings file because the main
-    // QSettings could be not a file on some platforms (windows, for instance).
     {
       QSettings journalSettings(journalSettingFile, MozFormat);
       for (const QString& key : journalSettings.allKeys()) {
@@ -66,7 +64,7 @@ SettingsHolder::SettingsHolder()
                        << journalSettingFile;
     }
 
-    logger.warning() << "Recovering completed";
+    logger.info() << "Recovering completed";
   }
 
   Q_ASSERT(!s_instance);

--- a/src/settingsholder.cpp
+++ b/src/settingsholder.cpp
@@ -9,6 +9,7 @@
 #include "leakdetector.h"
 #include "logger.h"
 #include "models/feature.h"
+#include "telemetry/gleansample.h"
 
 #include <QDir>
 #include <QFile>

--- a/src/settingsholder.h
+++ b/src/settingsholder.h
@@ -6,9 +6,10 @@
 #define SETTINGSHOLDER_H
 
 #include <QDateTime>
-#include <QStringList>
+#include <QMap>
 #include <QObject>
 #include <QSettings>
+#include <QStringList>
 
 class SettingsHolder final : public QObject {
   Q_OBJECT
@@ -17,7 +18,7 @@ class SettingsHolder final : public QObject {
  public:
 #define SETTING(type, toType, getter, setter, ...)                        \
   Q_PROPERTY(type getter READ getter WRITE setter NOTIFY getter##Changed) \
-  Q_SIGNAL void getter##Changed(const type& value);
+  Q_SIGNAL void getter##Changed();
 
 #include "settingslist.h"
 #undef SETTING
@@ -40,11 +41,17 @@ class SettingsHolder final : public QObject {
   };
   Q_ENUM(DnsProvider)
 
+  // These 3 methods can be used to store/restore/rollback settings.
+  Q_INVOKABLE bool beginTransaction();
+  Q_INVOKABLE bool commitTransaction();
+  Q_INVOKABLE bool rollbackTransaction();
+
   // Don't use this directly!
   QVariant rawSetting(const QString& key) const;
 
 #ifdef UNIT_TEST
   void setRawSetting(const QString& key, const QVariant& value);
+  void doNotClearOnDTOR() { m_doNotClearOnDTOR = true; }
 #endif
 
   QString getReport() const;
@@ -90,6 +97,14 @@ class SettingsHolder final : public QObject {
 
   QString placeholderUserDNS() const;
 
+  bool finalizeTransaction();
+
+  QString journalSettingFileName() const;
+
+  void maybeSaveInTransaction(const QString& key, const QVariant& oldValue,
+                              const QVariant& newValue, const char* signalName,
+                              bool userSettings);
+
   // Addon specific
 
   static QString getAddonSettingKey(const AddonSettingQuery& query);
@@ -99,7 +114,15 @@ class SettingsHolder final : public QObject {
 
  private:
   QSettings m_settings;
+
   bool m_firstExecution = false;
+
+  QSettings* m_settingsJournal = nullptr;
+  QMap<QString, QPair<const char*, QVariant>> m_transactionChanges;
+
+#ifdef UNIT_TEST
+  bool m_doNotClearOnDTOR = false;
+#endif
 };
 
 #endif  // SETTINGSHOLDER_H

--- a/src/settingsholder.h
+++ b/src/settingsholder.h
@@ -46,6 +46,10 @@ class SettingsHolder final : public QObject {
   Q_INVOKABLE bool commitTransaction();
   Q_INVOKABLE bool rollbackTransaction();
 
+#ifdef UNIT_TEST
+  bool inTransaction() const { return m_settingsJournal; }
+#endif
+
   // Don't use this directly!
   QVariant rawSetting(const QString& key) const;
 
@@ -111,6 +115,7 @@ class SettingsHolder final : public QObject {
 
  signals:
   void addonSettingsChanged();
+  void inTransactionChanged();
 
  private:
   QSettings m_settings;

--- a/src/settingslist.h
+++ b/src/settingslist.h
@@ -36,6 +36,7 @@ SETTING_BOOL(addonCustomServer,     // getter
              hasAddonCustomServer,  // has
              "addon/customServer",  // key
              false,                 // default value
+             false,                 // user setting
              false                  // remove when reset
 )
 
@@ -46,6 +47,7 @@ SETTING_STRING(
     "addon/customServerAddress",  // key
     Constants::envOrDefault("MVPN_ADDON_URL",
                             Constants::ADDON_STAGING_URL),  // default value
+    false,                                                  // user setting
     false                                                   // remove when reset
 )
 
@@ -54,6 +56,7 @@ SETTING_BOOL(addonProdKeyInStaging,     // getter
              hasAddonProdKeyInStaging,  // has
              "addon/prodKeyInStaging",  // key
              false,                     // default value
+             false,                     // user setting
              false                      // remove when reset
 )
 
@@ -63,6 +66,7 @@ SETTING_BOOL(captivePortalAlert,     // getter
              "captivePortalAlert",   // key
              Feature::get(Feature::Feature_captivePortal)
                  ->isSupported(),  // default value
+             true,                 // user setting
              false                 // remove when reset
 )
 
@@ -71,6 +75,7 @@ SETTING_STRINGLIST(captivePortalIpv4Addresses,     // getter
                    hasCaptivePortalIpv4Addresses,  // has
                    "captivePortal/ipv4Addresses",  // key
                    QStringList(),                  // default value
+                   false,                          // user setting
                    false                           // remove when reset
 )
 
@@ -79,6 +84,7 @@ SETTING_STRINGLIST(captivePortalIpv6Addresses,     // getter
                    hasCaptivePortalIpv6Addresses,  // has
                    "captivePortal/ipv6Addresses",  // key
                    QStringList(),                  // default value
+                   false,                          // user setting
                    false                           // remove when reset
 )
 
@@ -87,6 +93,7 @@ SETTING_BOOL(connectionChangeNotification,     // getter
              hasConnectionChangeNotification,  // has
              "connectionChangeNotification",   // key
              true,                             // default value
+             true,                             // user setting
              false                             // remove when reset
 )
 
@@ -95,6 +102,7 @@ SETTING_STRING(currentServerCity,     // getter
                hasCurrentServerCity,  // has
                "currentServer/city",  // key
                "",                    // default value
+               true,                  // user setting
                true                   // remove when reset
 )
 
@@ -103,6 +111,7 @@ SETTING_STRING(currentServerCountryCode,     // getter
                hasCurrentServerCountryCode,  // has
                "currentServer/countryCode",  // key
                "",                           // default value
+               true,                         // user setting
                true                          // remove when reset
 )
 
@@ -111,6 +120,7 @@ SETTING_BOOL(developerUnlock,     // getter
              hasDeveloperUnlock,  // has
              "developerUnlock",   // key
              false,               // default value
+             false,               // user setting
              false                // remove when reset
 )
 
@@ -119,6 +129,7 @@ SETTING_STRING(deviceKeyVersion,     // getter
                hasDeviceKeyVersion,  // has
                "deviceKeyVersion",   // key
                "",                   // default value
+               false,                // user setting
                true                  // remove when reset
 )
 
@@ -127,6 +138,7 @@ SETTING_BYTEARRAY(devices,     // getter
                   hasDevices,  // has
                   "devices",   // key
                   "",          // default value
+                  false,       // user setting
                   true         // remove when reset
 )
 
@@ -135,6 +147,7 @@ SETTING_INT(dnsProvider,                           // getter
             hasDNSProvider,                        // has
             "dnsProvider",                         // key
             SettingsHolder::DnsProvider::Gateway,  // default value
+            true,                                  // user setting
             false                                  // remove when reset
 )
 
@@ -143,6 +156,7 @@ SETTING_STRING(entryServerCity,     // getter
                hasEntryServerCity,  // has
                "entryServer/city",  // key
                nullptr,             // default value
+               true,                // user setting
                true                 // remove when reset
 )
 
@@ -151,6 +165,7 @@ SETTING_STRING(entryServerCountryCode,     // getter
                hasEntryServerCountryCode,  // has
                "entryServer/countryCode",  // key
                nullptr,                    // default value
+               true,                       // user setting
                true                        // remove when reset
 )
 
@@ -159,6 +174,7 @@ SETTING_STRINGLIST(featuresFlippedOff,     // getter
                    hasFeaturesFlippedOff,  // has
                    "featuresFlippedOff",   // key
                    QStringList(),          // default value
+                   false,                  // user setting
                    false                   // remove when reset
 )
 
@@ -167,6 +183,7 @@ SETTING_STRINGLIST(featuresFlippedOn,     // getter
                    hasFeaturesFlippedOn,  // has
                    "featuresFlippedOn",   // key
                    QStringList(),         // default value
+                   false,                 // user setting
                    false                  // remove when reset
 )
 
@@ -175,6 +192,7 @@ SETTING_BOOL(featuresTourShown,     // getter
              hasFeaturesTourShown,  // has
              "featuresTourShown",   // key
              false,                 // default value
+             false,                 // user setting
              false                  // remove when reset
 )
 
@@ -186,6 +204,7 @@ SETTING_BOOL(gleanEnabled,     // getter
              hasGleanEnabled,  // has
              "gleanEnabled",   // key
              true,             // default value
+             true,             // user setting
              false             // remove when reset
 )
 
@@ -194,6 +213,7 @@ SETTING_STRINGLIST(iapProducts,     // getter
                    hasIapProducts,  // has
                    "iapProducts",   // key
                    QStringList(),   // default value
+                   false,           // user setting
                    true             // remove when reset
 )
 
@@ -202,6 +222,7 @@ SETTING_DATETIME(installationTime,     // getter
                  hasInstallationTime,  // has
                  "installationTime",   // key
                  QDateTime(),          // default value
+                 false,                // user setting
                  false                 // remove when reset
 )
 
@@ -218,6 +239,7 @@ SETTING_INT64(keyRegenerationTimeSec,     // getter
               hasKeyRegenerationTimeSec,  // has
               "keyRegenerationTimeSec",   // key
               0,                          // default value
+              false,                      // user setting
               true                        // remove when reset
 )
 
@@ -226,6 +248,7 @@ SETTING_STRING(languageCode,     // getter
                hasLanguageCode,  // has
                "languageCode",   // key
                "",               // default value
+               true,             // user setting
                false             // remove when reset
 )
 
@@ -234,6 +257,7 @@ SETTING_BOOL(localNetworkAccess,     // getter
              hasLocalNetworkAccess,  // has
              "localNetworkAccess",   // key
              false,                  // default value
+             true,                   // user setting
              false                   // remove when reset
 )
 
@@ -242,6 +266,7 @@ SETTING_STRINGLIST(missingApps,     // getter
                    hasMissingApps,  // has
                    "MissingApps",   // key
                    QStringList(),   // default value
+                   true,            // user setting
                    false            // remove when reset
 )
 
@@ -250,6 +275,7 @@ SETTING_BOOL(postAuthenticationShown,     // getter
              hasPostAuthenticationShown,  // has
              "postAuthenticationShown",   // key
              false,                       // default value
+             true,                        // user setting
              true                         // remove when reset
 )
 
@@ -258,6 +284,7 @@ SETTING_STRING(previousLanguageCode,     // getter
                hasPreviousLanguageCode,  // has
                "previousLanguageCode",   // key
                "",                       // default value
+               true,                     // user setting
                false                     // remove when reset
 )
 
@@ -266,6 +293,7 @@ SETTING_STRING(privateKey,     // getter
                hasPrivateKey,  // has
                "privateKey",   // key
                "",             // default value
+               false,          // user setting
                true            // remove when reset
 )
 
@@ -274,6 +302,7 @@ SETTING_STRING(privateKeyJournal,     // getter
                hasPrivateKeyJournal,  // has
                "privateKeyJournal",   // key
                "",                    // default value
+               false,                 // user setting
                true                   // remove when reset
 )
 
@@ -282,6 +311,7 @@ SETTING_BOOL(protectSelectedApps,     // getter
              hasProtectSelectedApps,  // has
              "protectSelectedApps",   // key
              false,                   // default value
+             true,                    // user setting
              false                    // remove when reset
 )
 
@@ -290,6 +320,7 @@ SETTING_STRING(publicKey,     // getter
                hasPublicKey,  // has
                "publicKey",   // key
                "",            // default value
+               false,         // user setting
                true           // remove when reset
 )
 
@@ -298,6 +329,7 @@ SETTING_STRING(publicKeyJournal,     // getter
                hasPublicKeyJournal,  // has
                "publicKeyJournal",   // key
                "",                   // default value
+               false,                // user setting
                true                  // remove when reset
 )
 
@@ -306,6 +338,7 @@ SETTING_STRINGLIST(recentConnections,     // getter
                    hasRecentConnections,  // has
                    "recentConnections",   // key
                    QStringList(),         // default value
+                   true,                  // user setting
                    true                   // remove when reset
 )
 
@@ -314,6 +347,7 @@ SETTING_STRINGLIST(seenFeatures,     // getter
                    hasSeenFeatures,  // has
                    "seenFeatures",   // key
                    QStringList(),    // default value
+                   false,            // user setting
                    false             // remove when reset
 )
 
@@ -322,6 +356,7 @@ SETTING_BYTEARRAY(servers,     // getter
                   hasServers,  // has
                   "servers",   // key
                   "",          // default value
+                  false,       // user setting
                   true         // remove when reset
 )
 
@@ -330,6 +365,7 @@ SETTING_BOOL(serverSwitchNotification,     // getter
              hasServerSwitchNotification,  // has
              "serverSwitchNotification",   // key
              true,                         // default value
+             true,                         // user setting
              false                         // remove when reset
 )
 
@@ -339,6 +375,7 @@ SETTING_BOOL(serverUnavailableNotification,     // getter
              "serverUnavailableNotification",   // key
              Feature::get(Feature::Feature_serverUnavailableNotification)
                  ->isSupported(),  // default value
+             true,                 // user setting
              false                 // remove when reset
 )
 
@@ -349,6 +386,7 @@ SETTING_STRING(
     "stagingServerAddress",   // key
     Constants::envOrDefault("MVPN_API_BASE_URL",
                             Constants::API_STAGING_URL),  // default value
+    false,                                                // user setting
     false                                                 // remove when reset
 )
 
@@ -357,6 +395,7 @@ SETTING_BOOL(stagingServer,     // getter
              hasStagingServer,  // has
              "stagingServer",   // key
              false,             // default value
+             false,             // user setting
              false              // remove when reset
 )
 
@@ -365,6 +404,7 @@ SETTING_BOOL(startAtBoot,     // getter
              hasStartAtBoot,  // has
              "startAtBoot",   // key
              false,           // default value
+             true,            // user setting
              false            // remove when reset
 )
 
@@ -373,6 +413,7 @@ SETTING_BOOL(systemLanguageCodeMigrated,     // getter
              hasSystemLanguageCodeMigrated,  // has
              "systemLanguageCodeMigrated",   // key
              false,                          // default value
+             false,                          // user setting
              true                            // remove when reset
 )
 
@@ -381,6 +422,7 @@ SETTING_BOOL(telemetryPolicyShown,     // getter
              hasTelemetryPolicyShown,  // has
              "telemetryPolicyShown",   // key
              false,                    // default value
+             false,                    // user setting
              false                     // remove when reset
 )
 
@@ -389,6 +431,7 @@ SETTING_BOOL(tipsAndTricksIntroShown,     // getter
              hasTipsAndTricksIntroShown,  // has
              "tipsAndTricksIntroShown",   // key
              false,                       // default value
+             false,                       // user setting
              false                        // remove when reset
 )
 
@@ -397,6 +440,7 @@ SETTING_STRING(token,     // getter
                hasToken,  // has
                "token",   // key
                "",        // default value
+               false,     // user setting
                true       // remove when reset
 )
 
@@ -405,6 +449,7 @@ SETTING_BOOL(tunnelPort53,     // getter
              hasTunnelPort53,  // has
              "tunnelPort53",   // key
              false,            // default value
+             true,             // user setting
              false             // remove when reset
 )
 
@@ -414,6 +459,7 @@ SETTING_BOOL(unsecuredNetworkAlert,     // getter
              "unsecuredNetworkAlert",   // key
              Feature::get(Feature::Feature_unsecuredNetworkNotification)
                  ->isSupported(),  // default value
+             true,                 // user setting
              false                 // remove when reset
 )
 
@@ -430,6 +476,7 @@ SETTING_STRING(userAvatar,     // getter
                hasUserAvatar,  // has
                "user/avatar",  // key
                "",             // default value
+               false,          // user setting
                true            // remove when reset
 )
 
@@ -438,6 +485,7 @@ SETTING_STRING(userDisplayName,     // getter
                hasUserDisplayName,  // has
                "user/displayName",  // key
                "",                  // default value
+               false,               // user setting
                true                 // remove when reset
 )
 
@@ -446,6 +494,7 @@ SETTING_STRING(userDNS,     // getter
                hasUserDNS,  // has
                "userDNS",   // key
                "",          // default value
+               true,        // user setting
                false        // remove when reset
 )
 
@@ -454,6 +503,7 @@ SETTING_STRING(userEmail,     // getter
                hasUserEmail,  // has
                "user/email",  // key
                "",            // default value
+               false,         // user setting
                true           // remove when reset
 )
 
@@ -462,6 +512,7 @@ SETTING_INT(userMaxDevices,     // getter
             hasUserMaxDevices,  // has
             "user/maxDevices",  // key
             0,                  // default value
+            false,              // user setting
             true                // remove when reset
 )
 
@@ -470,6 +521,7 @@ SETTING_BOOL(userSubscriptionNeeded,     // getter
              hasUserSubscriptionNeeded,  // has
              "user/subscriptionNeeded",  // key
              false,                      // default value
+             false,                      // user setting
              true                        // remove when reset
 )
 
@@ -478,6 +530,7 @@ SETTING_STRINGLIST(vpnDisabledApps,     // getter
                    hasVpnDisabledApps,  // has
                    "vpnDisabledApps",   // key
                    QStringList(),       // default value
+                   false,               // user setting
                    false                // remove when reset
 )
 
@@ -487,6 +540,7 @@ SETTING_BOOL(adjustActivatable,     // getter
              hasAdjustActivatable,  // has
              "adjustActivatable",   // key
              false,                 // default value
+             false,                 // user setting
              false                  // remove when reset
 )
 #endif
@@ -497,6 +551,7 @@ SETTING_BOOL(nativeAndroidDataMigrated,     // getter
              hasNativeAndroidDataMigrated,  // has
              "nativeAndroidDataMigrated",   // key
              false,                         // default value
+             false,                         // user setting
              false                          // remove when reset
 )
 #endif
@@ -507,6 +562,7 @@ SETTING_BOOL(nativeIOSDataMigrated,     // getter
              hasNativeIOSDataMigrated,  // has
              "nativeIOSDataMigrated",   // key
              false,                     // default value
+             false,                     // user setting
              false                      // remove when reset
 )
 
@@ -515,6 +571,7 @@ SETTING_STRINGLIST(subscriptionTransactions,     // getter
                    hasSubscriptionTransactions,  // has
                    "subscriptionTransactions",   // key
                    QStringList(),                // efault value
+                   false,                        // user setting
                    false                         // remove when reset
 )
 #endif
@@ -526,5 +583,6 @@ SETTING_STRING(theme,          // getter
                hasTheme,       // has
                "theme",        // key
                DEFAULT_THEME,  // default value
+               true,           // user setting
                true            // remove when reset
 )

--- a/src/settingslist.h
+++ b/src/settingslist.h
@@ -530,7 +530,7 @@ SETTING_STRINGLIST(vpnDisabledApps,     // getter
                    hasVpnDisabledApps,  // has
                    "vpnDisabledApps",   // key
                    QStringList(),       // default value
-                   false,               // user setting
+                   true,                // user setting
                    false                // remove when reset
 )
 

--- a/src/settingslist.h
+++ b/src/settingslist.h
@@ -231,6 +231,7 @@ SETTING_STRING(installedVersion,     // getter
                hasInstalledVersion,  // has
                "installedVersion",   // key
                "",                   // default value
+               false,                // user setting
                false                 // remove when reset
 )
 
@@ -468,6 +469,7 @@ SETTING_DATETIME(updateTime,     // getter
                  hasUpdateTime,  // has
                  "updateTime",   // key
                  QDateTime(),    // default value
+                 false,          // user setting
                  false           // remove when reset
 )
 

--- a/tests/auth/CMakeLists.txt
+++ b/tests/auth/CMakeLists.txt
@@ -47,11 +47,17 @@ target_sources(auth_tests PRIVATE
     ${MVPN_SOURCE_DIR}/constants.cpp
     ${MVPN_SOURCE_DIR}/constants.h
     ${MVPN_SOURCE_DIR}/controller.h
+    ${MVPN_SOURCE_DIR}/cryptosettings.cpp
+    ${MVPN_SOURCE_DIR}/cryptosettings.h
     ${MVPN_SOURCE_DIR}/dnspingsender.cpp
     ${MVPN_SOURCE_DIR}/dnspingsender.h
     ${MVPN_SOURCE_DIR}/env.h
     ${MVPN_SOURCE_DIR}/errorhandler.cpp
     ${MVPN_SOURCE_DIR}/errorhandler.h
+    ${MVPN_SOURCE_DIR}/hacl-star/Hacl_Chacha20.c
+    ${MVPN_SOURCE_DIR}/hacl-star/Hacl_Chacha20Poly1305_32.c
+    ${MVPN_SOURCE_DIR}/hacl-star/Hacl_Curve25519_51.c
+    ${MVPN_SOURCE_DIR}/hacl-star/Hacl_Poly1305_32.c
     ${MVPN_SOURCE_DIR}/hawkauth.cpp
     ${MVPN_SOURCE_DIR}/hawkauth.h
     ${MVPN_SOURCE_DIR}/hkdf.cpp
@@ -82,6 +88,7 @@ target_sources(auth_tests PRIVATE
     ${MVPN_SOURCE_DIR}/pingsender.h
     ${MVPN_SOURCE_DIR}/pingsenderfactory.cpp
     ${MVPN_SOURCE_DIR}/pingsenderfactory.h
+    ${MVPN_SOURCE_DIR}/platforms/dummy/dummycryptosettings.cpp
     ${MVPN_SOURCE_DIR}/platforms/dummy/dummypingsender.cpp
     ${MVPN_SOURCE_DIR}/platforms/dummy/dummypingsender.h
     ${MVPN_SOURCE_DIR}/rfc/rfc1918.cpp

--- a/tests/qml/CMakeLists.txt
+++ b/tests/qml/CMakeLists.txt
@@ -10,6 +10,9 @@ get_filename_component(MVPN_SOURCE_DIR ${CMAKE_SOURCE_DIR}/src ABSOLUTE)
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 include_directories(${MVPN_SOURCE_DIR})
+include_directories(${MVPN_SOURCE_DIR}/hacl-star)
+include_directories(${MVPN_SOURCE_DIR}/hacl-star/kremlin)
+include_directories(${MVPN_SOURCE_DIR}/hacl-star/kremlin/minimal)
 
 qt_add_executable(qml_tests EXCLUDE_FROM_ALL)
 set_target_properties(qml_tests PROPERTIES FOLDER "Tests")
@@ -30,6 +33,8 @@ target_link_libraries(qml_tests PRIVATE glean lottie nebula translations)
 target_sources(qml_tests PRIVATE
     ${MVPN_SOURCE_DIR}/constants.h
     ${MVPN_SOURCE_DIR}/controller.h
+    ${MVPN_SOURCE_DIR}/cryptosettings.cpp
+    ${MVPN_SOURCE_DIR}/cryptosettings.h
     ${MVPN_SOURCE_DIR}/dnspingsender.cpp
     ${MVPN_SOURCE_DIR}/dnspingsender.h
     ${MVPN_SOURCE_DIR}/env.h
@@ -39,6 +44,10 @@ target_sources(qml_tests PRIVATE
     ${MVPN_SOURCE_DIR}/filterproxymodel.h
     ${MVPN_SOURCE_DIR}/hawkauth.cpp
     ${MVPN_SOURCE_DIR}/hawkauth.h
+    ${MVPN_SOURCE_DIR}/hacl-star/Hacl_Chacha20.c
+    ${MVPN_SOURCE_DIR}/hacl-star/Hacl_Chacha20Poly1305_32.c
+    ${MVPN_SOURCE_DIR}/hacl-star/Hacl_Curve25519_51.c
+    ${MVPN_SOURCE_DIR}/hacl-star/Hacl_Poly1305_32.c
     ${MVPN_SOURCE_DIR}/hkdf.cpp
     ${MVPN_SOURCE_DIR}/hkdf.h
     ${MVPN_SOURCE_DIR}/ipaddress.cpp
@@ -68,6 +77,7 @@ target_sources(qml_tests PRIVATE
     ${MVPN_SOURCE_DIR}/pingsender.h
     ${MVPN_SOURCE_DIR}/pingsenderfactory.cpp
     ${MVPN_SOURCE_DIR}/pingsenderfactory.h
+    ${MVPN_SOURCE_DIR}/platforms/dummy/dummycryptosettings.cpp
     ${MVPN_SOURCE_DIR}/platforms/dummy/dummypingsender.cpp
     ${MVPN_SOURCE_DIR}/platforms/dummy/dummypingsender.h
     ${MVPN_SOURCE_DIR}/update/updater.cpp

--- a/tests/qml/helper.h
+++ b/tests/qml/helper.h
@@ -24,9 +24,9 @@ class TestHelper final : public QObject {
   Q_INVOKABLE void triggerRecordGleanEvent(const QString& event) const;
   Q_INVOKABLE void triggerSendGleanPings() const;
   Q_INVOKABLE void triggerSetGleanSourceTags(const QStringList& tags) const;
-  Q_PROPERTY(bool mainWindowLoadedCalled READ mainWindowLoadedCalled CONSTANT)
-  Q_PROPERTY(bool stagingMode READ stagingMode WRITE setStagingMode CONSTANT)
-  Q_PROPERTY(bool debugMode READ debugMode WRITE setDebugMode CONSTANT)
+  Q_PROPERTY(bool mainWindowLoadedCalled READ mainWindowLoadedCalled)
+  Q_PROPERTY(bool stagingMode READ stagingMode WRITE setStagingMode)
+  Q_PROPERTY(bool debugMode READ debugMode WRITE setDebugMode)
 
   bool mainWindowLoadedCalled() const;
   void setMainWindowLoadedCalled(bool val);

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -103,6 +103,8 @@ target_sources(unit_tests PRIVATE
     ${MVPN_SOURCE_DIR}/constants.cpp
     ${MVPN_SOURCE_DIR}/constants.h
     ${MVPN_SOURCE_DIR}/controller.h
+    ${MVPN_SOURCE_DIR}/cryptosettings.cpp
+    ${MVPN_SOURCE_DIR}/cryptosettings.h
     ${MVPN_SOURCE_DIR}/curve25519.cpp
     ${MVPN_SOURCE_DIR}/curve25519.h
     ${MVPN_SOURCE_DIR}/dnspingsender.cpp
@@ -185,6 +187,7 @@ target_sources(unit_tests PRIVATE
     ${MVPN_SOURCE_DIR}/platforms/android/androiddatamigration.h
     ${MVPN_SOURCE_DIR}/platforms/android/androidsharedprefs.cpp
     ${MVPN_SOURCE_DIR}/platforms/android/androidsharedprefs.h
+    ${MVPN_SOURCE_DIR}/platforms/dummy/dummycryptosettings.cpp
     ${MVPN_SOURCE_DIR}/platforms/dummy/dummynetworkwatcher.cpp
     ${MVPN_SOURCE_DIR}/platforms/dummy/dummynetworkwatcher.h
     ${MVPN_SOURCE_DIR}/platforms/dummy/dummypingsender.cpp
@@ -314,6 +317,8 @@ target_sources(unit_tests PRIVATE
     testreleasemonitor.h
     testserveri18n.cpp
     testserveri18n.h
+    testsettings.cpp
+    testsettings.h
     teststatusicon.cpp
     teststatusicon.h
     testtasks.cpp

--- a/tests/unit/testaddon.cpp
+++ b/tests/unit/testaddon.cpp
@@ -622,112 +622,127 @@ void TestAddon::tutorial_create_data() {
   QTest::addColumn<QString>("id");
   QTest::addColumn<QJsonObject>("content");
   QTest::addColumn<bool>("created");
+  QTest::addColumn<bool>("highlighted");
+  QTest::addColumn<bool>("transaction");
 
-  QTest::addRow("object-without-id") << "" << QJsonObject() << false;
+  QTest::addRow("object-without-id")
+      << "" << QJsonObject() << false << false << false;
 
   QJsonObject obj;
   obj["id"] = "foo";
-  QTest::addRow("invalid-id") << "foo" << obj << false;
-  QTest::addRow("no-image") << "foo" << obj << false;
+  QTest::addRow("invalid-id") << "foo" << obj << false << false << false;
+  QTest::addRow("no-image") << "foo" << obj << false << false << false;
 
   obj["image"] = "foo.png";
-  QTest::addRow("no-steps") << "foo" << obj << false;
+  QTest::addRow("no-steps") << "foo" << obj << false << false << false;
 
   QJsonArray steps;
   obj["steps"] = steps;
-  QTest::addRow("with-steps") << "foo" << obj << false;
+  QTest::addRow("with-steps") << "foo" << obj << false << false << false;
 
   steps.append("");
   obj["steps"] = steps;
-  QTest::addRow("with-invalid-step") << "foo" << obj << false;
+  QTest::addRow("with-invalid-step") << "foo" << obj << false << false << false;
 
   QJsonObject step;
   steps.replace(0, step);
   obj["steps"] = steps;
-  QTest::addRow("with-step-without-id") << "foo" << obj << false;
+  QTest::addRow("with-step-without-id")
+      << "foo" << obj << false << false << false;
 
   step["id"] = "s1";
   steps.replace(0, step);
   obj["steps"] = steps;
-  QTest::addRow("with-step-without-element") << "foo" << obj << false;
+  QTest::addRow("with-step-without-element")
+      << "foo" << obj << false << false << false;
 
   step["element"] = "wow";
   steps.replace(0, step);
   obj["steps"] = steps;
-  QTest::addRow("with-step-without-next") << "foo" << obj << false;
+  QTest::addRow("with-step-without-next")
+      << "foo" << obj << false << false << false;
 
   step["next"] = "wow";
   steps.replace(0, step);
   obj["steps"] = steps;
-  QTest::addRow("with-step-with-invalid-next") << "foo" << obj << false;
+  QTest::addRow("with-step-with-invalid-next")
+      << "foo" << obj << false << false << false;
 
   QJsonObject nextObj;
 
   step["next"] = nextObj;
   steps.replace(0, step);
   obj["steps"] = steps;
-  QTest::addRow("with-step-with-invalid-next-1") << "foo" << obj << false;
+  QTest::addRow("with-step-with-invalid-next-1")
+      << "foo" << obj << false << false << false;
 
   nextObj["op"] = "wow";
   step["next"] = nextObj;
   steps.replace(0, step);
   obj["steps"] = steps;
-  QTest::addRow("with-step-with-invalid-next-2") << "foo" << obj << false;
+  QTest::addRow("with-step-with-invalid-next-2")
+      << "foo" << obj << false << false << false;
 
   nextObj["op"] = "signal";
   step["next"] = nextObj;
   steps.replace(0, step);
   obj["steps"] = steps;
-  QTest::addRow("with-step-with-invalid-next-3") << "foo" << obj << false;
+  QTest::addRow("with-step-with-invalid-next-3")
+      << "foo" << obj << false << false << false;
 
   nextObj["signal"] = "a";
   step["next"] = nextObj;
   steps.replace(0, step);
   obj["steps"] = steps;
-  QTest::addRow("with-step-with-invalid-next-4") << "foo" << obj << false;
+  QTest::addRow("with-step-with-invalid-next-4")
+      << "foo" << obj << false << false << false;
 
   nextObj["qml_emitter"] = "a";
   step["next"] = nextObj;
   steps.replace(0, step);
   obj["steps"] = steps;
-  QTest::addRow("with-step-with-invalid-next-5") << "foo" << obj << true;
+  QTest::addRow("with-step-with-invalid-next-5")
+      << "foo" << obj << true << false << false;
 
   nextObj["vpn_emitter"] = "a";
   step["next"] = nextObj;
   steps.replace(0, step);
   obj["steps"] = steps;
-  QTest::addRow("with-step-with-invalid-next-6") << "foo" << obj << false;
+  QTest::addRow("with-step-with-invalid-next-6")
+      << "foo" << obj << false << false << false;
 
   nextObj.remove("qml_emitter");
   step["next"] = nextObj;
   steps.replace(0, step);
   obj["steps"] = steps;
-  QTest::addRow("with-step-with-invalid-next-7") << "foo" << obj << false;
+  QTest::addRow("with-step-with-invalid-next-7")
+      << "foo" << obj << false << false << false;
 
   nextObj["vpn_emitter"] = "settingsHolder";
   step["next"] = nextObj;
   steps.replace(0, step);
   obj["steps"] = steps;
-  QTest::addRow("with-step-with-invalid-next-8") << "foo" << obj << true;
+  QTest::addRow("with-step-with-invalid-next-8")
+      << "foo" << obj << true << false << false;
 
   obj["conditions"] = QJsonObject();
-  QTest::addRow("with-step-element and conditions") << "foo" << obj << true;
+  QTest::addRow("with-step-element and conditions")
+      << "foo" << obj << true << false << false;
 
-  obj["advanced"] = true;
-  QTest::addRow("advanced") << "foo" << obj << true;
-
-  obj["advanced"] = false;
-  QTest::addRow("not-advanced") << "foo" << obj << true;
-
-  obj["advanced"] = true;
   obj["highlighted"] = true;
-  QTest::addRow("advanced-and-highlighted") << "foo" << obj << true;
+  QTest::addRow("highlighted") << "foo" << obj << true << true << false;
+
+  obj["settings_rollback_needed"] = true;
+  QTest::addRow("advanced-and-highlighted")
+      << "foo" << obj << true << true << true;
 }
 
 void TestAddon::tutorial_create() {
   QFETCH(QString, id);
   QFETCH(QJsonObject, content);
   QFETCH(bool, created);
+  QFETCH(bool, highlighted);
+  QFETCH(bool, transaction);
 
   SettingsHolder settingsHolder;
 
@@ -750,17 +765,25 @@ void TestAddon::tutorial_create() {
   QCOMPARE(tutorial->property("subtitle").type(), QMetaType::QString);
   QCOMPARE(tutorial->property("completionMessage").type(), QMetaType::QString);
   QCOMPARE(tutorial->property("image").toString(), "foo.png");
+  QCOMPARE(tutorial->property("highlighted").toBool(), highlighted);
+  QCOMPARE(tutorial->property("settingsRollbackNeeded").toBool(), transaction);
 
   QQmlApplicationEngine engine;
   QmlEngineHolder qml(&engine);
 
   QSignalSpy signalSpy(tm, &Tutorial::playingChanged);
 
+  QVERIFY(!settingsHolder.inTransaction());
+
   tm->play(tutorial);
   QCOMPARE(signalSpy.count(), 1);
 
+  QCOMPARE(settingsHolder.inTransaction(), transaction);
+
   tm->stop();
   QCOMPARE(signalSpy.count(), 2);
+
+  QVERIFY(!settingsHolder.inTransaction());
 }
 
 void TestAddon::message_create_data() {

--- a/tests/unit/testsettings.cpp
+++ b/tests/unit/testsettings.cpp
@@ -1,0 +1,101 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "testsettings.h"
+#include "../../src/settingsholder.h"
+#include "helper.h"
+
+void TestSettings::transactionErrors() {
+  SettingsHolder settingsHolder;
+
+  QVERIFY(!settingsHolder.commitTransaction());
+  QVERIFY(!settingsHolder.rollbackTransaction());
+
+  QVERIFY(settingsHolder.beginTransaction());
+  QVERIFY(!settingsHolder.beginTransaction());
+  QVERIFY(settingsHolder.commitTransaction());
+  QVERIFY(!settingsHolder.commitTransaction());
+
+  QVERIFY(settingsHolder.beginTransaction());
+  QVERIFY(!settingsHolder.beginTransaction());
+  QVERIFY(settingsHolder.commitTransaction());
+  QVERIFY(!settingsHolder.rollbackTransaction());
+
+  QVERIFY(settingsHolder.beginTransaction());
+  QVERIFY(!settingsHolder.beginTransaction());
+  QVERIFY(settingsHolder.rollbackTransaction());
+  QVERIFY(!settingsHolder.rollbackTransaction());
+
+  QVERIFY(settingsHolder.beginTransaction());
+  QVERIFY(!settingsHolder.beginTransaction());
+  QVERIFY(settingsHolder.rollbackTransaction());
+  QVERIFY(!settingsHolder.commitTransaction());
+}
+
+void TestSettings::transactionCommit() {
+  SettingsHolder settingsHolder;
+
+  QVERIFY(settingsHolder.beginTransaction());
+  settingsHolder.setTheme("AAA");
+  QCOMPARE(settingsHolder.theme(), "AAA");
+  QVERIFY(settingsHolder.commitTransaction());
+  QCOMPARE(settingsHolder.theme(), "AAA");
+}
+
+void TestSettings::transactionRollback() {
+  SettingsHolder settingsHolder;
+
+  QVERIFY(settingsHolder.beginTransaction());
+
+  settingsHolder.setToken("TOKEN 1");
+  QCOMPARE(settingsHolder.token(), "TOKEN 1");
+
+  settingsHolder.setTheme("AAA");
+  settingsHolder.setTheme("BBB");
+  settingsHolder.setTheme("CCC");
+  QCOMPARE(settingsHolder.theme(), "CCC");
+
+  int count = 0;
+  connect(&settingsHolder, &SettingsHolder::themeChanged, [&]() { ++count; });
+
+  QVERIFY(settingsHolder.rollbackTransaction());
+
+  QCOMPARE(settingsHolder.theme(), DEFAULT_THEME);
+  QCOMPARE(settingsHolder.token(), "TOKEN 1");
+  QCOMPARE(count, 1);
+}
+
+void TestSettings::transactionRollbackStartup() {
+  {
+    SettingsHolder settingsHolder;
+    settingsHolder.doNotClearOnDTOR();
+
+    settingsHolder.setTheme("AAA");
+    QCOMPARE(settingsHolder.theme(), "AAA");
+    settingsHolder.setToken("TOKEN 1");
+    QCOMPARE(settingsHolder.token(), "TOKEN 1");
+  }
+
+  {
+    SettingsHolder settingsHolder;
+    settingsHolder.doNotClearOnDTOR();
+
+    QCOMPARE(settingsHolder.theme(), "AAA");
+    QCOMPARE(settingsHolder.token(), "TOKEN 1");
+
+    QVERIFY(settingsHolder.beginTransaction());
+    settingsHolder.setTheme("BBB");
+    QCOMPARE(settingsHolder.theme(), "BBB");
+    settingsHolder.setToken("TOKEN 2");
+    QCOMPARE(settingsHolder.token(), "TOKEN 2");
+  }
+
+  {
+    SettingsHolder settingsHolder;
+    QCOMPARE(settingsHolder.theme(), "AAA");
+    QCOMPARE(settingsHolder.token(), "TOKEN 2");
+  }
+}
+
+static TestSettings s_testSettings;

--- a/tests/unit/testsettings.cpp
+++ b/tests/unit/testsettings.cpp
@@ -67,6 +67,9 @@ void TestSettings::transactionRollback() {
 }
 
 void TestSettings::transactionRollbackStartup() {
+  // This test simulates a rollback at startup from a journal file.
+
+  // Step 1: let's add some entries in the settings
   {
     SettingsHolder settingsHolder;
     settingsHolder.doNotClearOnDTOR();
@@ -77,6 +80,7 @@ void TestSettings::transactionRollbackStartup() {
     QCOMPARE(settingsHolder.token(), "TOKEN 1");
   }
 
+  // Step 2: let's start a transaction without finalizing it
   {
     SettingsHolder settingsHolder;
     settingsHolder.doNotClearOnDTOR();
@@ -91,6 +95,8 @@ void TestSettings::transactionRollbackStartup() {
     QCOMPARE(settingsHolder.token(), "TOKEN 2");
   }
 
+  // Step 3: a new SettingsHolder object will rollback the changes using the
+  // journal file.
   {
     SettingsHolder settingsHolder;
     QCOMPARE(settingsHolder.theme(), "AAA");

--- a/tests/unit/testsettings.h
+++ b/tests/unit/testsettings.h
@@ -1,0 +1,15 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "helper.h"
+
+class TestSettings final : public TestHelper {
+  Q_OBJECT
+
+ private slots:
+  void transactionErrors();
+  void transactionCommit();
+  void transactionRollback();
+  void transactionRollbackStartup();
+};


### PR DESCRIPTION
This PR implements transactions for the settings. Addon tutorials will be able to start a transaction, change a few things, than revert all.

In order to support other setting changes during a tutorial, I marked all the settings with a new flag: 'user-settings'. A user-setting is something that is controlled by the user via the front-end code. Only those settings are reverted in case of a rollback or a crash.