### PR TITLE
Fix CODEOWNERS for addon manifests

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,5 @@
 # Francesco Lodolo as main contact for string changes
-addons/**/manifest.json
+addons/**/manifest.json @flodolo
 translations/strings.yaml @flodolo
 
 # Beatriz Rizental as main contact for addon related changes


### PR DESCRIPTION
L10n wasn't pinged in a recent change (#4824) to addons.

Not sure why it used to work, probably because nobody else was set as owner in the file for /addons