### PR TITLE
Better condition support for addon-tutorial steps

### DIFF
--- a/src/addons/addon.h
+++ b/src/addons/addon.h
@@ -47,6 +47,9 @@ class Addon : public QObject {
 
   static bool evaluateConditions(const QJsonObject& conditions);
 
+  static AddonConditionWatcher* maybeCreateConditionWatchers(
+      Addon* addon, const QJsonObject& conditions);
+
   virtual ~Addon();
 
   const QString& id() const { return m_id; }
@@ -72,8 +75,6 @@ class Addon : public QObject {
 
  private:
   void updateAddonState(State newState);
-
-  void maybeCreateConditionWatchers(const QJsonObject& conditions);
 
   bool evaluateJavascript(const QJsonObject& javascript);
   bool evaluateJavascriptInternal(const QString& javascript, QJSValue* value);

--- a/src/tutorial/tutorialstep.cpp
+++ b/src/tutorial/tutorialstep.cpp
@@ -4,6 +4,7 @@
 
 #include "tutorialstep.h"
 #include "addons/addontutorial.h"
+#include "addons/conditionwatchers/addonconditionwatcher.h"
 #include "inspector/inspectorutils.h"
 #include "leakdetector.h"
 #include "logger.h"
@@ -73,22 +74,35 @@ TutorialStep::TutorialStep(AddonTutorial* parent, const QString& element,
       m_parent(parent),
       m_stepId(stepId),
       m_element(element),
-      m_conditions(conditions),
       m_before(before),
-      m_next(next) {
+      m_next(next),
+      m_enabled(Addon::evaluateConditions(conditions)) {
   MVPN_COUNT_CTOR(TutorialStep);
 
   m_string.initialize(stepId, fallback);
 
   m_timer.setSingleShot(true);
   connect(&m_timer, &QTimer::timeout, this, &TutorialStep::startInternal);
+
+  m_conditionWatcher = Addon::maybeCreateConditionWatchers(parent, conditions);
+
+  if (m_conditionWatcher) {
+    connect(m_conditionWatcher, &AddonConditionWatcher::conditionChanged, this,
+            [this](bool enabled) {
+              if (enabled) {
+                if (enabled && m_state == StateConditionCheck) {
+                  startInternal();
+                }
+              }
+            });
+  }
 }
 
 TutorialStep::~TutorialStep() { MVPN_COUNT_DTOR(TutorialStep); }
 
 void TutorialStep::stop() {
-  Q_ASSERT(m_started);
-  m_started = false;
+  Q_ASSERT(m_state != StateStopped);
+  m_state = StateStopped;
 
   m_timer.stop();
 
@@ -99,49 +113,74 @@ void TutorialStep::stop() {
 }
 
 void TutorialStep::start() {
-  Q_ASSERT(!m_started);
-  m_started = true;
+  Q_ASSERT(m_state == StateStopped);
+  m_state = StateConditionCheck;
+
   m_currentBeforeStep = 0;
 
   startInternal();
 }
 
 void TutorialStep::startInternal() {
-  Q_ASSERT(m_started);
+  Q_ASSERT(m_state != StateStopped);
 
-  if (!Addon::evaluateConditions(m_conditions)) {
-    logger.info()
-        << "Exclude the tutorial step because conditions do not match";
-    emit completed();
-    return;
-  }
+  switch (m_state) {
+    case StateConditionCheck: {
+      if (!m_enabled) {
+        logger.info()
+            << "Exclude the tutorial step because conditions do not match";
+        emit completed();
+        return;
+      }
 
-  while (m_currentBeforeStep < m_before.length()) {
-    if (!m_before[m_currentBeforeStep]->run()) {
-      m_timer.start(TIMEOUT_ITEM_TIMER_MSEC);
-      return;
+      if (m_conditionWatcher && !m_conditionWatcher->conditionApplied()) {
+        return;
+      }
+
+      m_state = StateBeforeRun;
+      [[fallthrough]];
     }
 
-    ++m_currentBeforeStep;
+    case StateBeforeRun: {
+      while (m_currentBeforeStep < m_before.length()) {
+        if (!m_before[m_currentBeforeStep]->run()) {
+          m_timer.start(TIMEOUT_ITEM_TIMER_MSEC);
+          return;
+        }
+
+        ++m_currentBeforeStep;
+      }
+
+      m_state = StateTooltip;
+      [[fallthrough]];
+    }
+
+    case StateTooltip: {
+      QObject* element = InspectorUtils::findObject(m_element);
+      if (!element) {
+        m_timer.start(TIMEOUT_ITEM_TIMER_MSEC);
+        return;
+      }
+
+      QQuickItem* item = qobject_cast<QQuickItem*>(element);
+      Q_ASSERT(item);
+
+      Tutorial* tutorial = Tutorial::instance();
+      Q_ASSERT(tutorial);
+
+      tutorial->requireTooltipShown(m_parent, true);
+      tutorial->requireTooltipNeeded(m_parent, m_stepId, m_string.get(),
+                                     element);
+
+      connect(m_next, &TutorialStepNext::completed, this,
+              &TutorialStep::completed);
+      m_next->start();
+      break;
+    }
+
+    default:
+      Q_ASSERT(false);
   }
-
-  QObject* element = InspectorUtils::findObject(m_element);
-  if (!element) {
-    m_timer.start(TIMEOUT_ITEM_TIMER_MSEC);
-    return;
-  }
-
-  QQuickItem* item = qobject_cast<QQuickItem*>(element);
-  Q_ASSERT(item);
-
-  Tutorial* tutorial = Tutorial::instance();
-  Q_ASSERT(tutorial);
-
-  tutorial->requireTooltipShown(m_parent, true);
-  tutorial->requireTooltipNeeded(m_parent, m_stepId, m_string.get(), element);
-
-  connect(m_next, &TutorialStepNext::completed, this, &TutorialStep::completed);
-  m_next->start();
 }
 
 bool TutorialStep::itemPicked(const QList<QQuickItem*>& list) {

--- a/src/tutorial/tutorialstep.h
+++ b/src/tutorial/tutorialstep.h
@@ -12,6 +12,7 @@
 #include <QJsonObject>
 #include <QTimer>
 
+class AddonConditionWatcher;
 class AddonTutorial;
 class QJsonValue;
 class QQuickItem;
@@ -46,16 +47,25 @@ class TutorialStep final : public QObject {
 
  private:
   AddonTutorial* m_parent = nullptr;
+  AddonConditionWatcher* m_conditionWatcher = nullptr;
+
   const QString m_stepId;
   const QString m_element;
   AddonProperty m_string;
-  const QJsonObject m_conditions;
   const QList<TutorialStepBefore*> m_before;
   TutorialStepNext* m_next = nullptr;
 
   QTimer m_timer;
-  bool m_started = false;
   int m_currentBeforeStep = 0;
+
+  bool m_enabled = false;
+
+  enum {
+    StateConditionCheck,
+    StateBeforeRun,
+    StateTooltip,
+    StateStopped,
+  } m_state = StateStopped;
 };
 
 #endif  // TUTORIALSTEP_H


### PR DESCRIPTION
I would like to add an unit-test but I don't want a good way to retrieve data from the JS execution. As soon as we have: `addon.states.session` we can write a test. @brizental would it work for you?