### PR TITLE
Disable auth inputs after clicking submit - Fix VPN-2702

### DIFF
--- a/nebula/ui/components/inAppAuth/VPNInAppAuthenticationInputs.qml
+++ b/nebula/ui/components/inAppAuth/VPNInAppAuthenticationInputs.qml
@@ -26,7 +26,7 @@ ColumnLayout {
     }
 
     function disableActiveInput() {
-        return activeInput().enabled = false;
+        activeInput().enabled = false;
     }
 
     Component.onCompleted: if (typeof(authError) === "undefined" || !authError.visible) activeInput().forceActiveFocus();

--- a/nebula/ui/components/inAppAuth/VPNInAppAuthenticationInputs.qml
+++ b/nebula/ui/components/inAppAuth/VPNInAppAuthenticationInputs.qml
@@ -25,13 +25,21 @@ ColumnLayout {
         return _isSignUpOrIn ? passwordInput : textInput
     }
 
+    function disableActiveInput() {
+        return activeInput().enabled = false;
+    }
+
     Component.onCompleted: if (typeof(authError) === "undefined" || !authError.visible) activeInput().forceActiveFocus();
 
     spacing: VPNTheme.theme.vSpacing - VPNTheme.theme.listSpacing
 
     ColumnLayout {
         function submitInfo(input) {
-            if (!input.hasError && input.text.length > 0 && btn.enabled) btn.clicked();
+            if (!input.hasError && input.text.length > 0 && btn.enabled)
+            {
+                disableActiveInput();
+                btn.clicked();
+            }
         }
 
         id: col
@@ -186,7 +194,10 @@ ColumnLayout {
                         VPNAuthInApp.state === VPNAuthInApp.StateSigningUp ||
                         VPNAuthInApp.state === VPNAuthInApp.StateVerifyingSessionEmailCode ||
                         VPNAuthInApp.state === VPNAuthInApp.StateVerifyingSessionTotpCode
-        onClicked: _buttonOnClicked(activeInput().text)
+        onClicked: {
+            disableActiveInput();
+            _buttonOnClicked(activeInput().text);
+        }
         width: undefined
 
     }
@@ -221,12 +232,14 @@ ColumnLayout {
             case VPNAuthInApp.ErrorConnectionTimeout:
                 // In case of a timeout we want to exit here 
                 // to skip setting hasError - so the user can retry instantly
+                activeInput().enabled = true;
                 return;
             }
 
             if (!authError.visible)
                 activeInput().forceActiveFocus();
             activeInput().hasError = true;
+            activeInput().enabled = true;
         }
     }
 }


### PR DESCRIPTION
## Description
Opening as draft until I can smoke test on a physical device (tomorrow). 

Disable authentication inputs after clicking submit. Re-enable auth inputs if there is an error and we are unable to proceed to next step in flow. 

## Reference

VPN-2702, #4219 

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
