### PR TITLE
Validate email before enabling submit button

### DIFF
--- a/src/ui/authenticationInApp/ViewAuthenticationStart.qml
+++ b/src/ui/authenticationInApp/ViewAuthenticationStart.qml
@@ -21,7 +21,7 @@ VPNInAppAuthenticationBase {
 
     _inputs: VPNInAppAuthenticationInputs {
         objectName: "authStart"
-        _buttonEnabled: VPNAuthInApp.state === VPNAuthInApp.StateStart && activeInput().text.length !== 0 && !activeInput().hasError
+        _buttonEnabled: VPNAuthInApp.state === VPNAuthInApp.StateStart && activeInput().text.length !== 0 && !activeInput().hasError && VPNAuthInApp.validateEmailAddress(activeInput().text)
         _buttonOnClicked: (inputText) => { VPNAuthInApp.checkAccount(inputText); }
         _buttonText: qsTrId("vpn.postAuthentication.continue")
         _inputMethodHints: Qt.ImhNoPredictiveText | Qt.ImhEmailCharactersOnly | Qt.ImhNoAutoUppercase | Qt.ImhSensitiveData


### PR DESCRIPTION
## Description

Check for valid email address formatting before enabling the "Continue" button on the start in-app auth view.

... 

I could have _sworn_ we used to check for valid email formatting before enabling the "Continue" button. Anyone remember if/why we removed it? cc @flozia 

## Reference

    i.e Jira or Github issue URL

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
