### PR TITLE
Enable Start On Boot-ish for iOS

### DIFF
--- a/src/apps/vpn/appfeaturelistcallback.h
+++ b/src/apps/vpn/appfeaturelistcallback.h
@@ -146,6 +146,8 @@ bool FeatureCallback_startOnBoot() {
 #if defined(MZ_LINUX) || defined(MZ_MACOS) || defined(MZ_WINDOWS) || \
     defined(MZ_DUMMY) || defined(MZ_WASM) || defined(MZ_IOS)
   return true;
+#endif
+  return false;
 }
 
 bool FeatureCallback_unsecuredNetworkNotification() {

--- a/src/apps/vpn/appfeaturelistcallback.h
+++ b/src/apps/vpn/appfeaturelistcallback.h
@@ -144,7 +144,8 @@ bool FeatureCallback_splitTunnel() {
 
 bool FeatureCallback_startOnBoot() {
 #if defined(MZ_LINUX) || defined(MZ_MACOS) || defined(MZ_WINDOWS) || \
-    defined(MZ_DUMMY) || defined(MZ_WASM) || defined(MZ_IOS)
+    defined(MZ_DUMMY) || defined(MZ_WASM) || defined(MZ_ANDROID) ||  \
+    defined(MZ_IOS)
   return true;
 #else
   return false;

--- a/src/apps/vpn/appfeaturelistcallback.h
+++ b/src/apps/vpn/appfeaturelistcallback.h
@@ -146,8 +146,9 @@ bool FeatureCallback_startOnBoot() {
 #if defined(MZ_LINUX) || defined(MZ_MACOS) || defined(MZ_WINDOWS) || \
     defined(MZ_DUMMY) || defined(MZ_WASM) || defined(MZ_IOS)
   return true;
-#endif
+#else
   return false;
+#endif
 }
 
 bool FeatureCallback_unsecuredNetworkNotification() {

--- a/src/apps/vpn/appfeaturelistcallback.h
+++ b/src/apps/vpn/appfeaturelistcallback.h
@@ -144,11 +144,8 @@ bool FeatureCallback_splitTunnel() {
 
 bool FeatureCallback_startOnBoot() {
 #if defined(MZ_LINUX) || defined(MZ_MACOS) || defined(MZ_WINDOWS) || \
-    defined(MZ_DUMMY) || defined(MZ_WASM) || defined(MZ_ANDROID)
+    defined(MZ_DUMMY) || defined(MZ_WASM) || defined(MZ_IOS)
   return true;
-#else
-  return false;
-#endif
 }
 
 bool FeatureCallback_unsecuredNetworkNotification() {

--- a/src/apps/vpn/platforms/ios/ioscontroller.h
+++ b/src/apps/vpn/platforms/ios/ioscontroller.h
@@ -29,6 +29,8 @@ class IOSController final : public ControllerImpl {
 
   void cleanupBackendLogs() override;
 
+  void onStartAtBootChanged();
+
  private:
   bool m_checkingStatus = false;
   QString m_serverPublicKey;

--- a/src/apps/vpn/platforms/ios/ioscontroller.h
+++ b/src/apps/vpn/platforms/ios/ioscontroller.h
@@ -29,8 +29,6 @@ class IOSController final : public ControllerImpl {
 
   void cleanupBackendLogs() override;
 
-  void onStartAtBootChanged();
-
  private:
   bool m_checkingStatus = false;
   QString m_serverPublicKey;

--- a/src/apps/vpn/platforms/ios/ioscontroller.h
+++ b/src/apps/vpn/platforms/ios/ioscontroller.h
@@ -37,6 +37,11 @@ class IOSController final : public ControllerImpl {
    */
   void importAlwaysOnSetting();
 
+  /**
+   * @brief Called when the Client's always on value changed
+   */
+  void onAlwaysOnSettingChanged();
+
   bool m_checkingStatus = false;
   QString m_serverPublicKey;
 };

--- a/src/apps/vpn/platforms/ios/ioscontroller.h
+++ b/src/apps/vpn/platforms/ios/ioscontroller.h
@@ -30,6 +30,13 @@ class IOSController final : public ControllerImpl {
   void cleanupBackendLogs() override;
 
  private:
+  /**
+   * @brief Checks if the System's always On setting exists and syncs the client
+   * value to that.
+   *
+   */
+  void importAlwaysOnSetting();
+
   bool m_checkingStatus = false;
   QString m_serverPublicKey;
 };

--- a/src/apps/vpn/platforms/ios/ioscontroller.mm
+++ b/src/apps/vpn/platforms/ios/ioscontroller.mm
@@ -71,18 +71,25 @@ void IOSController::initialize(const Device* device, const Keys* keys) {
         logger.debug() << "Creation completed with connection state:" << state;
         creating = false;
 
+          // Check if the tunnel has a diffrent value for "startOnBoot" // onDemand
+          // then we recorded for the last time, if that's the case, update our local value.
+          bool userSetStartOnBoot = [impl getStartOnBoot];
+          if (SettingsHolder::instance()->startAtBoot() != userSetStartOnBoot) {
+            SettingsHolder::instance()->setStartAtBoot(userSetStartOnBoot);
+          }
+
         switch (state) {
           case ConnectionStateError: {
             [impl dealloc];
             impl = nullptr;
             emit initialized(false, false, QDateTime());
-            break;
+            return;
           }
           case ConnectionStateConnected: {
             Q_ASSERT(date);
             QDateTime qtDate(QDateTime::fromNSDate(date));
             emit initialized(true, true, qtDate);
-            break;
+            return;
           }
           case ConnectionStateDisconnected:
             Controller* controller = MozillaVPN::instance()->controller();
@@ -93,13 +100,7 @@ void IOSController::initialize(const Device* device, const Keys* keys) {
             }
 
             emit initialized(true, false, QDateTime());
-            break;
-        }
-        // Check if the tunnel has a diffrent value for "startOnBoot" // onDemand
-        // then we recorded for the last time, if that's the case, update our local value.
-        bool userSetStartOnBoot = [impl getStartOnBoot];
-        if (SettingsHolder::instance()->startAtBoot() != userSetStartOnBoot) {
-          SettingsHolder::instance()->setStartAtBoot(userSetStartOnBoot);
+            return;
         }
       }
       callback:^(BOOL a_connected) {

--- a/src/apps/vpn/platforms/ios/ioscontroller.mm
+++ b/src/apps/vpn/platforms/ios/ioscontroller.mm
@@ -60,6 +60,8 @@ void IOSController::initialize(const Device* device, const Keys* keys) {
     }
     importAlwaysOnSetting();
   });
+  connect(SettingsHolder::instance(), &SettingsHolder::startAtBootChanged, this,
+          &IOSController::onAlwaysOnSettingChanged);
 
   static bool creating = false;
   // No nested creation!
@@ -264,5 +266,13 @@ void IOSController::importAlwaysOnSetting() {
     if (SettingsHolder::instance()->startAtBoot() != userSetAlwaysOn) {
       SettingsHolder::instance()->setStartAtBoot(userSetAlwaysOn);
     }
+  }
+}
+
+void IOSController::onAlwaysOnSettingChanged() {
+  bool iosSystemAlwaysON = [impl getAlwaysOn];
+  bool vpnClientAlwaysOn = SettingsHolder::instance()->startAtBoot();
+  if (vpnClientAlwaysOn != iosSystemAlwaysON) {
+    [impl setAlwaysOnSetEnabled:vpnClientAlwaysOn];
   }
 }

--- a/src/apps/vpn/platforms/ios/ioscontroller.mm
+++ b/src/apps/vpn/platforms/ios/ioscontroller.mm
@@ -51,7 +51,6 @@ void IOSController::initialize(const Device* device, const Keys* keys) {
   Q_ASSERT(!impl);
   Q_UNUSED(device);
 
-
   logger.debug() << "Initializing Swift Controller";
 
   static bool creating = false;
@@ -69,12 +68,12 @@ void IOSController::initialize(const Device* device, const Keys* keys) {
         logger.debug() << "Creation completed with connection state:" << state;
         creating = false;
 
-        // After init, check if the network exentsion has info about always on
-        // we might not if this is frist execution or the user removed our vpn permission
+        // After init, check if the network exentsion has info about always on;
+        // We might not if this is the first execution or the user removed our vpn permission
         bool alwaysOnRulePresent = [impl hasAlwaysOn];
         if(alwaysOnRulePresent){
-            // If we have info about that, make sure that the value in the system settings is
-            // is matching what we have - if not, the user changed that and we should update our side.
+            // Make sure that the value in the system settings is
+            // is matching what we have. If not, the user changed that and we should update our side.
             bool userSetAlwaysOn = [impl getAlwaysOn];
             if (SettingsHolder::instance()->startAtBoot() != userSetAlwaysOn) {
                 SettingsHolder::instance()->setStartAtBoot(userSetAlwaysOn);

--- a/src/apps/vpn/platforms/ios/ioscontroller.mm
+++ b/src/apps/vpn/platforms/ios/ioscontroller.mm
@@ -261,7 +261,7 @@ void IOSController::importAlwaysOnSetting() {
   bool alwaysOnRulePresent = [impl hasAlwaysOn];
   if (alwaysOnRulePresent) {
     // Make sure that the value in the system settings is
-    // is matching what we have. If not, the user changed that and we should update our side.
+    // is matching what we have. If not, the user changed it in iOS Settings (under VPN) and we should update our side.
     bool userSetAlwaysOn = [impl getAlwaysOn];
     if (SettingsHolder::instance()->startAtBoot() != userSetAlwaysOn) {
       SettingsHolder::instance()->setStartAtBoot(userSetAlwaysOn);

--- a/src/apps/vpn/platforms/ios/ioscontroller.mm
+++ b/src/apps/vpn/platforms/ios/ioscontroller.mm
@@ -270,9 +270,14 @@ void IOSController::importAlwaysOnSetting() {
 }
 
 void IOSController::onAlwaysOnSettingChanged() {
-  bool iosSystemAlwaysON = [impl getAlwaysOn];
-  bool vpnClientAlwaysOn = SettingsHolder::instance()->startAtBoot();
-  if (vpnClientAlwaysOn != iosSystemAlwaysON) {
-    [impl setAlwaysOnSetEnabled:vpnClientAlwaysOn];
-  }
+    // When this Setting is touched, we should activate / deactivate the VPN.
+    // A: This ensures the Setting-Value is Consistent with the iOS Settings.
+    // B: This ensures the behavior is the same as touching the button
+    //    in the iOS Settings.
+    if(SettingsHolder::instance()->startAtBoot()){
+        MozillaVPN::instance()->activate();
+    }
+    else{
+        MozillaVPN::instance()->deactivate();
+    }
 }

--- a/src/apps/vpn/platforms/ios/ioscontroller.swift
+++ b/src/apps/vpn/platforms/ios/ioscontroller.swift
@@ -257,24 +257,21 @@ public class IOSControllerImpl : NSObject {
         }
     }
     @objc func setAlwaysOn(setEnabled: Bool){
-            if(!setEnabled){
-                tunnel!.isOnDemandEnabled = false;
-                tunnel!.onDemandRules = []
-                return;
-            }
-            let alwaysConnect = NEOnDemandRuleConnect()
-            alwaysConnect.interfaceTypeMatch = .any
-            tunnel!.isOnDemandEnabled = true
-            tunnel!.onDemandRules = [alwaysConnect]
+        if(!setEnabled){
+            tunnel!.isOnDemandEnabled = false;
+            tunnel!.onDemandRules = []
+            return;
+        }
+        let alwaysConnect = NEOnDemandRuleConnect()
+        alwaysConnect.interfaceTypeMatch = .any
+        tunnel!.isOnDemandEnabled = true
+        tunnel!.onDemandRules = [alwaysConnect]
     }
     
     @objc func getAlwaysOn() -> Bool{
         return tunnel!.isOnDemandEnabled;
     }
-    // Only if the onDemand rules is set
-    // and contains our "always on rule"
-    // the use would have had the option
-    // to make a choise
+    
     @objc func hasAlwaysOn() -> Bool{
         let rules = tunnel!.onDemandRules;
         if( rules == nil){
@@ -288,8 +285,8 @@ public class IOSControllerImpl : NSObject {
     @objc func disconnect() {
         Logger.global?.log(message: "Disconnecting")
         assert(tunnel != nil)
-        // Turn off always-on, as this would
-        // oterwise imediatly trigger a reconnect from the OS
+        // Turn off "always-on", as this rule would
+        // trigger a reconnect from the OS
         setAlwaysOn(setEnabled: false)
         tunnel!.saveToPreferences { [unowned self] saveError in
             if saveError != nil {

--- a/src/apps/vpn/platforms/ios/ioscontroller.swift
+++ b/src/apps/vpn/platforms/ios/ioscontroller.swift
@@ -165,7 +165,7 @@ public class IOSControllerImpl : NSObject {
         return true
     }
 
-    @objc func connect(dnsServer: String, serverIpv6Gateway: String, serverPublicKey: String, serverIpv4AddrIn: String, serverPort: Int,  allowedIPAddressRanges: Array<VPNIPAddressRange>, reason: Int, enableAlwaysConnect:Bool , failureCallback: @escaping () -> Void) {
+    @objc func connect(dnsServer: String, serverIpv6Gateway: String, serverPublicKey: String, serverIpv4AddrIn: String, serverPort: Int,  allowedIPAddressRanges: Array<VPNIPAddressRange>, reason: Int, failureCallback: @escaping () -> Void) {
         Logger.global?.log(message: "Connecting")
         assert(tunnel != nil)
 

--- a/src/apps/vpn/platforms/ios/ioscontroller.swift
+++ b/src/apps/vpn/platforms/ios/ioscontroller.swift
@@ -2,30 +2,29 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import Foundation import NetworkExtension
+import Foundation
+import NetworkExtension
 
-    let vpnName = "Mozilla VPN" var vpnBundleID = "";
+let vpnName = "Mozilla VPN"
+var vpnBundleID = "";
 
 @objc class VPNIPAddressRange : NSObject {
- public
-  var address : NSString = "" public var networkPrefixLength
-      : UInt8 = 0 public var isIpv6 : Bool = false
+    public var address: NSString = ""
+    public var networkPrefixLength: UInt8 = 0
+    public var isIpv6: Bool = false
 
-                                      @objc
-                                      init(address
-                                           : NSString, networkPrefixLength
-                                           : UInt8, isIpv6
-                                           : Bool) {
-    super
-        .init()
+    @objc init(address: NSString, networkPrefixLength: UInt8, isIpv6: Bool) {
+        super.init()
 
-            self.address = address self.networkPrefixLength =
-        networkPrefixLength self.isIpv6 = isIpv6
-  }
+        self.address = address
+        self.networkPrefixLength = networkPrefixLength
+        self.isIpv6 = isIpv6
+    }
 }
 
 public class IOSControllerImpl : NSObject {
- private var tunnel: NETunnelProviderManager? = nil
+
+    private var tunnel: NETunnelProviderManager? = nil
     private var stateChangeCallback: ((Bool) -> Void?)? = nil
     private var privateKey : PrivateKey? = nil
     private var deviceIpv4Address: String? = nil
@@ -34,218 +33,159 @@ public class IOSControllerImpl : NSObject {
     @objc enum ConnectionState: Int { case Error, Connected, Disconnected }
 
     @objc init(bundleID: String, privateKey: Data, deviceIpv4Address: String, deviceIpv6Address: String, closure: @escaping (ConnectionState, Date?) -> Void, callback: @escaping (Bool) -> Void) {
-    super
-        .init()
+        super.init()
 
-            Logger.configureGlobal(tagged
-                                               : "APP", withFilePath
-                                               : "")
+        Logger.configureGlobal(tagged: "APP", withFilePath: "")
 
-                vpnBundleID = bundleID;
-    precondition(!vpnBundleID.isEmpty)
+        vpnBundleID = bundleID;
+        precondition(!vpnBundleID.isEmpty)
 
-        stateChangeCallback = callback self.privateKey =
-            PrivateKey(rawValue
-                                   : privateKey) self.deviceIpv4Address =
-                deviceIpv4Address self.deviceIpv6Address =
-                    deviceIpv6Address
+        stateChangeCallback = callback
+        self.privateKey = PrivateKey(rawValue: privateKey)
+        self.deviceIpv4Address = deviceIpv4Address
+        self.deviceIpv6Address = deviceIpv6Address
 
-                        NotificationCenter.default
-                            .addObserver(
-                                self, selector
-                                : #selector(
-                                      self.vpnStatusDidChange(notification:)),
-                                  name
-                                : Notification.Name.NEVPNStatusDidChange, object
-                                : nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(self.vpnStatusDidChange(notification:)), name: Notification.Name.NEVPNStatusDidChange, object: nil)
 
-                                NETunnelProviderManager.loadAllFromPreferences {
-      [weak self] managers, error in if let error = error {
-        Logger.global ?.log(message
-                                        : "Loading from preference failed: \(error)")
-                           closure(ConnectionState.Error, nil) return
-      }
+        NETunnelProviderManager.loadAllFromPreferences { [weak self] managers, error in
+            if let error = error {
+                Logger.global?.log(message: "Loading from preference failed: \(error)")
+                closure(ConnectionState.Error, nil)
+                return
+            }
 
-      if self
-        == nil{Logger.global ?.log(message
-                                               : "We are shutting down.") return }
+            if self == nil {
+                Logger.global?.log(message: "We are shutting down.")
+                return
+            }
 
-                              let nsManagers =
-                                  managers ? ? [] Logger.global
-                           ?.log(message
-                                 : "We have received \(nsManagers.count) managers.")
+            let nsManagers = managers ?? []
+            Logger.global?.log(message: "We have received \(nsManagers.count) managers.")
 
-                    let tunnel =
-                    nsManagers.first(where
-                                                 : IOSControllerImpl.isOurManager(_
-            :)) if tunnel == nil{Logger.global
-                                 ?.log(message
-                                       : "Creating the tunnel") self !.tunnel =
-                          NETunnelProviderManager() closure(
-                              ConnectionState.Disconnected, nil) return }
+            let tunnel = nsManagers.first(where: IOSControllerImpl.isOurManager(_:))
+            if tunnel == nil {
+                Logger.global?.log(message: "Creating the tunnel")
+                self!.tunnel = NETunnelProviderManager()
+                closure(ConnectionState.Disconnected, nil)
+                return
+            }
 
-                      Logger.global
-                                 ?.log(message
-                                       : "Tunnel already exists")
+            Logger.global?.log(message: "Tunnel already exists")
 
-                          self !.tunnel =
-                          tunnel if tunnel ?.connection.status ==.connected {
+            self!.tunnel = tunnel
+            if tunnel?.connection.status == .connected {
                 closure(ConnectionState.Connected, tunnel?.connection.connectedDate)
+            } else {
+                closure(ConnectionState.Disconnected, nil)
+            }
         }
-      else {
-        closure(ConnectionState.Disconnected, nil)
-      }
     }
-  }
 
-  @objc private func vpnStatusDidChange(notification : Notification) {
-        guard let session = (notification.object as? NETunnelProviderSession), tunnel?.connection == session else {
-          return
+    @objc private func vpnStatusDidChange(notification: Notification) {
+        guard let session = (notification.object as? NETunnelProviderSession), tunnel?.connection == session else { return }
+
+        switch session.status {
+        case .connected:
+            Logger.global?.log(message: "STATE CHANGED: connected")
+        case .connecting:
+            Logger.global?.log(message: "STATE CHANGED: connecting")
+        case .disconnected:
+            Logger.global?.log(message: "STATE CHANGED: disconnected")
+        case .disconnecting:
+            Logger.global?.log(message: "STATE CHANGED: disconnecting")
+        case .invalid:
+            Logger.global?.log(message: "STATE CHANGED: invalid")
+        case .reasserting:
+            Logger.global?.log(message: "STATE CHANGED: reasserting")
+        default:
+            Logger.global?.log(message: "STATE CHANGED: unknown status")
         }
-
-        switch
-          session.status {
-            case.connected:
-            Logger.global ?.log(message
-                                : "STATE CHANGED: connected") case.connecting
-                          :
-            Logger.global ?.log(message
-                                : "STATE CHANGED: connecting") case.disconnected
-                          :
-            Logger.global
-                ?.log(message
-                      : "STATE CHANGED: disconnected") case.disconnecting
-                :
-            Logger.global ?.log(message
-                                : "STATE CHANGED: disconnecting") case.invalid
-                          :
-            Logger.global ?.log(message
-                                : "STATE CHANGED: invalid") case.reasserting
-                          :
-                Logger.global ?.log(message
-                                    : "STATE CHANGED: reasserting") default
-                              : Logger.global
-                    ?.log(message
-                          : "STATE CHANGED: unknown status")
-          }
 
         // We care about "unknown" state changes.
-        if (session.status !=.connected && session.status !=.disconnected) {
-          return
+        if (session.status != .connected && session.status != .disconnected) {
+            return
         }
 
         // If disconnected, we know for sure that this is true
-        if (session.status ==.disconnected) {
-          stateChangeCallback ? (false) return
+        if (session.status == .disconnected) {
+            stateChangeCallback?(false)
+            return
         }
 
-        // This timer is used to workaround a Schrödinger's cat bug: if we check
-        // the connection status immediately when connected, we alter the iOS16
-        // connectivity state and we break the VPN tunnel (intermittently). With
-        // a timer this does not happen.
-        _ = Timer.scheduledTimer(withTimeInterval : 0.5, repeats : false) {
-          _ in self.monitorConnection()
+       // This timer is used to workaround a Schrödinger's cat bug: if we check
+       // the connection status immediately when connected, we alter the iOS16
+       // connectivity state and we break the VPN tunnel (intermittently). With
+       // a timer this does not happen.
+        _ = Timer.scheduledTimer(withTimeInterval: 0.5, repeats: false) {_ in
+            self.monitorConnection()
         }
-  }
+    }
 
- private
-  func monitorConnection()->Void {
+    private func monitorConnection() -> Void {
         // Let's call `stateChangeCallback` if connected and if
         // last_handshake_time_sec is not 0.
-        self.checkStatus {
-          _, _,
-              configString in if self.tunnel ?.connection.status !=.connected {
-            return;
-          }
+        self.checkStatus { _, _, configString in
+            if self.tunnel?.connection.status != .connected { return; }
 
-          let lines = configString.splitToArray(separator
-                                                : "\n") if let line =
-              lines.first(where
-                          : {$0.starts(with
-                                       : "last_handshake_time_sec")}) {
-            let parts = line.splitToArray(separator
-                                          : "=") if parts.count > 1 &&
-                        Int(parts[1])
-                ? ? 0 > 0 {
-                self.stateChangeCallback ? (true) return
+            let lines = configString.splitToArray(separator: "\n")
+            if let line = lines.first(where: { $0.starts(with: "last_handshake_time_sec") }) {
+                let parts = line.splitToArray(separator: "=")
+                if parts.count > 1 && Int(parts[1]) ?? 0 > 0 {
+                    self.stateChangeCallback?(true)
+                    return
+                }
             }
-          }
 
-          _ = Timer.scheduledTimer(withTimeInterval : 0.5, repeats : false) {
-            _ in self.monitorConnection()
-          }
+            _ = Timer.scheduledTimer(withTimeInterval: 0.5, repeats: false) { _ in
+                self.monitorConnection()
+            }
         }
-  }
+    }
 
- private
-  static func isOurManager(_ manager : NETunnelProviderManager)->Bool {
-        guard let proto = manager.protocolConfiguration,
-                  let tunnelProto = proto as ? NETunnelProviderProtocol else {
-          Logger.global ?.log(message
-                              : "Ignoring manager because the proto is "
-                                "invalid.") return false
+    private static func isOurManager(_ manager: NETunnelProviderManager) -> Bool {
+        guard
+            let proto = manager.protocolConfiguration,
+            let tunnelProto = proto as? NETunnelProviderProtocol
+        else {
+            Logger.global?.log(message: "Ignoring manager because the proto is invalid.")
+            return false
         }
 
         if (tunnelProto.providerBundleIdentifier == nil) {
-          Logger.global ?.log(message
-                              : "Ignoring manager because the bundle "
-                                "identifier is null.") return false
+            Logger.global?.log(message: "Ignoring manager because the bundle identifier is null.")
+            return false
         }
 
         if (tunnelProto.providerBundleIdentifier != vpnBundleID) {
-          Logger.global ?.log(message
-                              : "Ignoring manager because the bundle "
-                                "identifier doesn't match.") return false;
+            Logger.global?.log(message: "Ignoring manager because the bundle identifier doesn't match.")
+            return false;
         }
 
-        Logger.global
-            ?.log(message
-                  : "Found the manager with the correct bundle identifier: "
-                    "\(tunnelProto.providerBundleIdentifier!)") return true
-  }
+        Logger.global?.log(message: "Found the manager with the correct bundle identifier: \(tunnelProto.providerBundleIdentifier!)")
+        return true
+    }
 
-  @objc func connect(dnsServer
-                     : String, serverIpv6Gateway
-                     : String, serverPublicKey
-                     : String, serverIpv4AddrIn
-                     : String, serverPort
-                     : Int, allowedIPAddressRanges
-                     : Array<VPNIPAddressRange>, reason
-                     : Int, failureCallback
-                     : @escaping()->Void) {
-        Logger.global
-            ?.log(message
-                  : "Connecting") assert(tunnel != nil)
+    @objc func connect(dnsServer: String, serverIpv6Gateway: String, serverPublicKey: String, serverIpv4AddrIn: String, serverPort: Int,  allowedIPAddressRanges: Array<VPNIPAddressRange>, reason: Int, enableAlwaysConnect:Bool , failureCallback: @escaping () -> Void) {
+        Logger.global?.log(message: "Connecting")
+        assert(tunnel != nil)
 
-             // Let's remove the previous config if it exists.
-             (tunnel !.protocolConfiguration as ? NETunnelProviderProtocol)
-             ?.destroyConfigurationReference()
+        // Let's remove the previous config if it exists.
+        (tunnel!.protocolConfiguration as? NETunnelProviderProtocol)?.destroyConfigurationReference()
 
-                  let keyData = PublicKey(base64Key
-                                          : serverPublicKey) !let dnsServerIP =
-                  IPv4Address(dnsServer) let ipv6GatewayIP = IPv6Address(
-                      serverIpv6Gateway)
+        let keyData = PublicKey(base64Key: serverPublicKey)!
+        let dnsServerIP = IPv4Address(dnsServer)
+        let ipv6GatewayIP = IPv6Address(serverIpv6Gateway)
 
-                      var peerConfiguration = PeerConfiguration(publicKey
-                                                                : keyData)
-                                                  peerConfiguration.endpoint =
-                          Endpoint(from
-                                   : serverIpv4AddrIn + ":\(serverPort )")
-                              peerConfiguration.allowedIPs =
-                              []
+        var peerConfiguration = PeerConfiguration(publicKey: keyData)
+        peerConfiguration.endpoint = Endpoint(from: serverIpv4AddrIn + ":\(serverPort )")
+        peerConfiguration.allowedIPs = []
 
-                              allowedIPAddressRanges.forEach {
-          if (!$0.isIpv6) {
-            peerConfiguration.allowedIPs.append(IPAddressRange(
-                address
-                : IPv4Address($0.address as String) !, networkPrefixLength
-                : $0.networkPrefixLength))
-          } else {
-            peerConfiguration.allowedIPs.append(IPAddressRange(
-                address
-                : IPv6Address($0.address as String) !, networkPrefixLength
-                : $0.networkPrefixLength))
-          }
+        allowedIPAddressRanges.forEach {
+            if (!$0.isIpv6) {
+                peerConfiguration.allowedIPs.append(IPAddressRange(address: IPv4Address($0.address as String)!, networkPrefixLength: $0.networkPrefixLength))
+            } else {
+                peerConfiguration.allowedIPs.append(IPAddressRange(address: IPv6Address($0.address as String)!, networkPrefixLength: $0.networkPrefixLength))
+            }
         }
 
         var peerConfigurations: [PeerConfiguration] = []
@@ -262,140 +202,129 @@ public class IOSControllerImpl : NSObject {
         let config = TunnelConfiguration(name: vpnName, interface: interface, peers: peerConfigurations)
 
         self.configureTunnel(config: config, reason: reason, serverName: serverIpv4AddrIn + ":\(serverPort )", failureCallback: failureCallback)
-  }
+    }
 
-  func configureTunnel(config
-                       : TunnelConfiguration, reason
-                       : Int, serverName
-                       : String, failureCallback
-                       : @escaping()->Void) {
-        let proto = NETunnelProviderProtocol(tunnelConfiguration
-                                             : config)
-                        proto !.providerBundleIdentifier =
-            vpnBundleID proto !.disconnectOnSleep =
-                false proto !.serverAddress = serverName;
+    func configureTunnel(config: TunnelConfiguration, reason: Int, serverName: String, failureCallback: @escaping () -> Void) {
+        let proto = NETunnelProviderProtocol(tunnelConfiguration: config)
+        proto!.providerBundleIdentifier = vpnBundleID
+        proto!.disconnectOnSleep = false
+        proto!.serverAddress = serverName;
 
-        if
-#          available(iOS 15.1, *){Logger.global
-                                  ?.log(message
-                                        : "Activating includeAllNetworks")
-                                       proto !.includeAllNetworks = true }
+        if #available(iOS 15.1, *) {
+            Logger.global?.log(message: "Activating includeAllNetworks")
+            proto!.includeAllNetworks = true
+        }
 
-                                   tunnel !.protocolConfiguration =
-                                       proto tunnel !.localizedDescription =
-                                           vpnName tunnel !.isEnabled =
-                                               true
+        tunnel!.protocolConfiguration = proto
+        tunnel!.localizedDescription = vpnName
+        tunnel!.isEnabled = true
+        
+        tunnel!.saveToPreferences { [unowned self] saveError in
+            if let error = saveError {
+                Logger.global?.log(message: "Connect Tunnel Save Error: \(error)")
+                failureCallback()
+                return
+            }
 
-                                               tunnel !.saveToPreferences {
-            [unowned self] saveError in if let error =
-                saveError{Logger.global
-                          ?.log(message
-                                : "Connect Tunnel Save Error: \(error)")
-                               failureCallback() return }
+            Logger.global?.log(message: "Saving the tunnel succeeded")
 
-                          Logger.global
-                ?.log(message
-                      : "Saving the tunnel succeeded")
+            self.tunnel!.loadFromPreferences { error in
+                if let error = error {
+                    Logger.global?.log(message: "Connect Tunnel Load Error: \(error)")
+                    failureCallback()
+                    return
+                }
 
-                     self.tunnel !.loadFromPreferences {
-                error in if let error =
-                    error{Logger.global
-                          ?.log(message
-                                : "Connect Tunnel Load Error: \(error)")
-                               failureCallback() return }
+                Logger.global?.log(message: "Loading the tunnel succeeded")
 
-                          Logger.global
-                    ?.log(message
-                          : "Loading the tunnel succeeded")
-
-                         do {
-                  if (reason == 1 /* ReasonSwitching */) {
+                do {
+                    if (reason == 1 /* ReasonSwitching */) {
                         let settings = config.asWgQuickConfig()
                         let settingsData = settings.data(using: .utf8)!
                         try (self.tunnel!.connection as? NETunnelProviderSession)?
-                                .sendProviderMessage(settingsData) {
-                          _ in return
-                        }
-                  } else {
+                                .sendProviderMessage(settingsData) {_ in return}
+                    } else {
                         try (self.tunnel!.connection as? NETunnelProviderSession)?.startTunnel()
-                  }
-                }
-                catch let error {
-                  Logger.global ?.log(message
-                                      : "Something went wrong: \(error)")
-                                     failureCallback() return
+                    }
+                } catch let error {
+                    Logger.global?.log(message: "Something went wrong: \(error)")
+                    failureCallback()
+                    return
                 }
             }
-          }
-  }
-
-  @objc func setStartOnBoot(setEnabled : Bool) {
-        if (!setEnabled) {
-          return;
         }
-        let alwaysConnect =
-            NEOnDemandRuleConnect() alwaysConnect.interfaceTypeMatch =
-                .any tunnel !.isOnDemandEnabled =
-                    true tunnel !.onDemandRules = [alwaysConnect]
-  }
+    }
+    
+    @objc func setStartOnBoot(setEnabled: Bool){
+        if(!setEnabled){
+            return;
+        }
+        let alwaysConnect = NEOnDemandRuleConnect()
+        alwaysConnect.interfaceTypeMatch = .any
+        tunnel!.isOnDemandEnabled = true
+        tunnel!.onDemandRules = [alwaysConnect]
+    }
+    
+    @objc func getStartOnBoot() -> Bool{
+        return tunnel!.isOnDemandEnabled;
+    }
+    
 
-  @objc func getStartOnBoot()->Bool {
-        return tunnel !.isOnDemandEnabled;
-  }
+    @objc func disconnect() {
+        Logger.global?.log(message: "Disconnecting")
+        assert(tunnel != nil)
+        (tunnel!.connection as? NETunnelProviderSession)?.stopTunnel()
+    }
 
-  @objc func disconnect() {
-        Logger.global ?.log(message
-                            : "Disconnecting")
-                           assert(tunnel != nil)(tunnel !.connection as
-                                                 ? NETunnelProviderSession)
-                       ?.stopTunnel()
-  }
+    @objc func checkStatus(callback: @escaping (String, String, String) -> Void) {
+        Logger.global?.log(message: "Check status")
+        assert(tunnel != nil)
 
-  @objc func checkStatus(callback : @escaping(String, String, String)->Void) {
-        Logger.global
-            ?.log(message
-                  : "Check status") assert(tunnel != nil)
+        let proto = tunnel!.protocolConfiguration as? NETunnelProviderProtocol
+        if proto == nil {
+            callback("", "", "")
+            return
+        }
 
-                 let proto = tunnel !.protocolConfiguration as
-             ? NETunnelProviderProtocol if proto ==
-                   nil{callback("", "", "") return }
+        let tunnelConfiguration = proto?.asTunnelConfiguration()
+        if tunnelConfiguration == nil {
+            callback("", "", "")
+            return
+        }
 
-                   let tunnelConfiguration = proto
-               ?.asTunnelConfiguration() if tunnelConfiguration ==
-                    nil{callback("", "", "") return }
+        let serverIpv4Gateway = tunnelConfiguration?.interface.dns[0].address
+        if serverIpv4Gateway == nil {
+            callback("", "", "")
+            return
+        }
 
-                    let serverIpv4Gateway = tunnelConfiguration
-                ?.interface.dns[0].address if serverIpv4Gateway ==
-                     nil{callback("", "", "") return }
+        let deviceIpv4Address = tunnelConfiguration?.interface.addresses[0].address
+        if deviceIpv4Address == nil {
+            callback("", "", "")
+            return
+        }
 
-                     let deviceIpv4Address = tunnelConfiguration
-                 ?.interface.addresses[0].address if deviceIpv4Address ==
-                      nil{callback("", "", "") return }
-
-                      guard let session =
-                      tunnel ?.connection as ? NETunnelProviderSession else {
-          callback("", "", "") return
+        guard let session = tunnel?.connection as? NETunnelProviderSession
+        else {
+            callback("", "", "")
+            return
         }
 
         do {
-          try session.sendProviderMessage(Data([UInt8(0)])) {
-            [callback] data in guard let
-                data = data,
-                let configString = String(data
-                                          : data, encoding
-                                          :.utf8) else {
-                    Logger.global ?.log(message
-                                        : "Failed to convert data to string")
-                                       callback("", "", "") return }
+            try session.sendProviderMessage(Data([UInt8(0)])) { [callback] data in
+                guard let data = data,
+                      let configString = String(data: data, encoding: .utf8)
+                else {
+                    Logger.global?.log(message: "Failed to convert data to string")
+                    callback("", "", "")
+                    return
+                }
 
-                    callback("\(serverIpv4Gateway!)", "\(deviceIpv4Address!)",
-                             configString)
-          }
+                callback("\(serverIpv4Gateway!)", "\(deviceIpv4Address!)", configString)
+            }
+        } catch {
+            Logger.global?.log(message: "Failed to retrieve data from session")
+            callback("", "", "")
         }
-        catch {
-          Logger.global ?.log(message
-                              : "Failed to retrieve data from session")
-                             callback("", "", "")
-        }
-  }
+    }
 }

--- a/src/apps/vpn/platforms/ios/ioscontroller.swift
+++ b/src/apps/vpn/platforms/ios/ioscontroller.swift
@@ -269,14 +269,12 @@ public class IOSControllerImpl : NSObject {
         if (!setEnabled) {
             tunnel!.isOnDemandEnabled = false;
             tunnel!.onDemandRules = []
-            tunnel!.saveToPreferences()
             return;
         }
         let alwaysConnect = NEOnDemandRuleConnect()
         alwaysConnect.interfaceTypeMatch = .any
         tunnel!.isOnDemandEnabled = true
         tunnel!.onDemandRules = [alwaysConnect]
-        tunnel!.saveToPreferences()
     }
     
     @objc func getAlwaysOn() -> Bool {

--- a/src/apps/vpn/platforms/ios/ioscontroller.swift
+++ b/src/apps/vpn/platforms/ios/ioscontroller.swift
@@ -263,20 +263,20 @@ public class IOSControllerImpl : NSObject {
     * We are setting a rule matching * any network change
     * which will cause the phone to start the VPN after the phone boots.
     *
-    * Note: For the Setting to be applied to the iOS settings: 
-    *       tunnel!.saveToPreferences needs to be called.  
     * @param setEnabled: bool If the rule should be added or removed.
     **/
     @objc func setAlwaysOn(setEnabled: Bool){
         if(!setEnabled){
             tunnel!.isOnDemandEnabled = false;
             tunnel!.onDemandRules = []
+            tunnel!.saveToPreferences()
             return;
         }
         let alwaysConnect = NEOnDemandRuleConnect()
         alwaysConnect.interfaceTypeMatch = .any
         tunnel!.isOnDemandEnabled = true
         tunnel!.onDemandRules = [alwaysConnect]
+        tunnel!.saveToPreferences()
     }
     
     @objc func getAlwaysOn() -> Bool{

--- a/src/apps/vpn/platforms/ios/ioscontroller.swift
+++ b/src/apps/vpn/platforms/ios/ioscontroller.swift
@@ -165,7 +165,7 @@ public class IOSControllerImpl : NSObject {
         return true
     }
 
-    @objc func connect(dnsServer: String, serverIpv6Gateway: String, serverPublicKey: String, serverIpv4AddrIn: String, serverPort: Int,  allowedIPAddressRanges: Array<VPNIPAddressRange>, reason: Int,enableAlwaysOn:Bool, failureCallback: @escaping () -> Void) {
+    @objc func connect(dnsServer: String, serverIpv6Gateway: String, serverPublicKey: String, serverIpv4AddrIn: String, serverPort: Int,  allowedIPAddressRanges: Array<VPNIPAddressRange>, reason: Int, enableAlwaysOn: Bool, failureCallback: @escaping () -> Void) {
         Logger.global?.log(message: "Connecting")
         assert(tunnel != nil)
 

--- a/src/apps/vpn/platforms/ios/ioscontroller.swift
+++ b/src/apps/vpn/platforms/ios/ioscontroller.swift
@@ -201,10 +201,10 @@ public class IOSControllerImpl : NSObject {
 
         let config = TunnelConfiguration(name: vpnName, interface: interface, peers: peerConfigurations)
 
-        self.configureTunnel(config: config, reason: reason, serverName: serverIpv4AddrIn + ":\(serverPort )",enableAlwaysOn:enableAlwaysOn, failureCallback: failureCallback)
+        self.configureTunnel(config: config, reason: reason, serverName: serverIpv4AddrIn + ":\(serverPort )", enableAlwaysOn: enableAlwaysOn, failureCallback: failureCallback)
     }
 
-    func configureTunnel(config: TunnelConfiguration, reason: Int, serverName: String,enableAlwaysOn:Bool, failureCallback: @escaping () -> Void) {
+    func configureTunnel(config: TunnelConfiguration, reason: Int, serverName: String, enableAlwaysOn: Bool, failureCallback: @escaping () -> Void) {
         let proto = NETunnelProviderProtocol(tunnelConfiguration: config)
         proto!.providerBundleIdentifier = vpnBundleID
         proto!.disconnectOnSleep = false
@@ -265,8 +265,8 @@ public class IOSControllerImpl : NSObject {
     *
     * @param setEnabled: bool If the rule should be added or removed.
     **/
-    @objc func setAlwaysOn(setEnabled: Bool){
-        if(!setEnabled){
+    @objc func setAlwaysOn(setEnabled: Bool) {
+        if (!setEnabled) {
             tunnel!.isOnDemandEnabled = false;
             tunnel!.onDemandRules = []
             tunnel!.saveToPreferences()
@@ -279,11 +279,11 @@ public class IOSControllerImpl : NSObject {
         tunnel!.saveToPreferences()
     }
     
-    @objc func getAlwaysOn() -> Bool{
+    @objc func getAlwaysOn() -> Bool {
         return tunnel!.isOnDemandEnabled;
     }
     
-    @objc func hasAlwaysOn() -> Bool{
+    @objc func hasAlwaysOn() -> Bool {
        guard let rules = tunnel?.onDemandRules else {
             return false;
         }
@@ -295,6 +295,7 @@ public class IOSControllerImpl : NSObject {
     @objc func disconnect() {
         Logger.global?.log(message: "Disconnecting")
         assert(tunnel != nil)
+        (tunnel!.connection as? NETunnelProviderSession)?.stopTunnel()
         // Turn off "always-on", as this rule would
         // trigger an immediate reconnect from the OS
         setAlwaysOn(setEnabled: false)
@@ -302,7 +303,6 @@ public class IOSControllerImpl : NSObject {
             if let error = saveError {
                 Logger.global?.log(message: "Tunnel Save Error: \(error)")
             }
-            (tunnel!.connection as? NETunnelProviderSession)?.stopTunnel()
         }
         
     }

--- a/src/apps/vpn/platforms/ios/ioscontroller.swift
+++ b/src/apps/vpn/platforms/ios/ioscontroller.swift
@@ -256,6 +256,17 @@ public class IOSControllerImpl : NSObject {
             }
         }
     }
+    
+    /**
+    * @brief Enables / Disables the Always-On Rule on the runnel
+    * This is used for the "start-on-boot" feature. 
+    * We are setting a rule matching * any network change
+    * which will cause the phone to start the VPN after the phone boots.
+    *
+    * Note: For the Setting to be applied to the iOS settings: 
+    *       tunnel!.saveToPreferences needs to be called.  
+    * @param setEnabled: bool If the rule should be added or removed.
+    **/
     @objc func setAlwaysOn(setEnabled: Bool){
         if(!setEnabled){
             tunnel!.isOnDemandEnabled = false;

--- a/src/apps/vpn/platforms/ios/ioscontroller.swift
+++ b/src/apps/vpn/platforms/ios/ioscontroller.swift
@@ -284,11 +284,10 @@ public class IOSControllerImpl : NSObject {
     }
     
     @objc func hasAlwaysOn() -> Bool{
-        let rules = tunnel!.onDemandRules;
-        if( rules == nil){
+       guard let rules = tunnel?.onDemandRules else {
             return false;
         }
-        return !(rules!.isEmpty)
+        return !(rules.isEmpty)
     }
 
     
@@ -297,11 +296,11 @@ public class IOSControllerImpl : NSObject {
         Logger.global?.log(message: "Disconnecting")
         assert(tunnel != nil)
         // Turn off "always-on", as this rule would
-        // trigger a reconnect from the OS
+        // trigger an immediate reconnect from the OS
         setAlwaysOn(setEnabled: false)
         tunnel!.saveToPreferences { [unowned self] saveError in
-            if saveError != nil {
-                Logger.global?.log(message: "Save Error")
+            if let error = saveError {
+                Logger.global?.log(message: "Tunnel Save Error: \(error)")
             }
             (tunnel!.connection as? NETunnelProviderSession)?.stopTunnel()
         }

--- a/src/apps/vpn/platforms/ios/ioscontroller.swift
+++ b/src/apps/vpn/platforms/ios/ioscontroller.swift
@@ -258,7 +258,7 @@ public class IOSControllerImpl : NSObject {
     }
     
     /**
-    * @brief Enables / Disables the Always-On Rule on the runnel
+    * @brief Enables / Disables the Always-On Rule on the tunnel
     * This is used for the "start-on-boot" feature. 
     * We are setting a rule matching * any network change
     * which will cause the phone to start the VPN after the phone boots.
@@ -280,7 +280,10 @@ public class IOSControllerImpl : NSObject {
     @objc func getAlwaysOn() -> Bool {
         return tunnel!.isOnDemandEnabled;
     }
-    
+    /**
+    * @brief Returns true/false if there is an "always-on" rule
+    * registered with the iOS system settings app. 
+    */ 
     @objc func hasAlwaysOn() -> Bool {
        guard let rules = tunnel?.onDemandRules else {
             return false;
@@ -297,7 +300,7 @@ public class IOSControllerImpl : NSObject {
         // Turn off "always-on", as this rule would
         // trigger an immediate reconnect from the OS
         setAlwaysOn(setEnabled: false)
-        tunnel!.saveToPreferences { [unowned self] saveError in
+        tunnel!.saveToPreferences { saveError in
             if let error = saveError {
                 Logger.global?.log(message: "Tunnel Save Error: \(error)")
             }

--- a/src/apps/vpn/platforms/ios/ioscontroller.swift
+++ b/src/apps/vpn/platforms/ios/ioscontroller.swift
@@ -2,29 +2,30 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import Foundation
-import NetworkExtension
+import Foundation import NetworkExtension
 
-let vpnName = "Mozilla VPN"
-var vpnBundleID = "";
+    let vpnName = "Mozilla VPN" var vpnBundleID = "";
 
 @objc class VPNIPAddressRange : NSObject {
-    public var address: NSString = ""
-    public var networkPrefixLength: UInt8 = 0
-    public var isIpv6: Bool = false
+ public
+  var address : NSString = "" public var networkPrefixLength
+      : UInt8 = 0 public var isIpv6 : Bool = false
 
-    @objc init(address: NSString, networkPrefixLength: UInt8, isIpv6: Bool) {
-        super.init()
+                                      @objc
+                                      init(address
+                                           : NSString, networkPrefixLength
+                                           : UInt8, isIpv6
+                                           : Bool) {
+    super
+        .init()
 
-        self.address = address
-        self.networkPrefixLength = networkPrefixLength
-        self.isIpv6 = isIpv6
-    }
+            self.address = address self.networkPrefixLength =
+        networkPrefixLength self.isIpv6 = isIpv6
+  }
 }
 
 public class IOSControllerImpl : NSObject {
-
-    private var tunnel: NETunnelProviderManager? = nil
+ private var tunnel: NETunnelProviderManager? = nil
     private var stateChangeCallback: ((Bool) -> Void?)? = nil
     private var privateKey : PrivateKey? = nil
     private var deviceIpv4Address: String? = nil
@@ -33,159 +34,218 @@ public class IOSControllerImpl : NSObject {
     @objc enum ConnectionState: Int { case Error, Connected, Disconnected }
 
     @objc init(bundleID: String, privateKey: Data, deviceIpv4Address: String, deviceIpv6Address: String, closure: @escaping (ConnectionState, Date?) -> Void, callback: @escaping (Bool) -> Void) {
-        super.init()
+    super
+        .init()
 
-        Logger.configureGlobal(tagged: "APP", withFilePath: "")
+            Logger.configureGlobal(tagged
+                                               : "APP", withFilePath
+                                               : "")
 
-        vpnBundleID = bundleID;
-        precondition(!vpnBundleID.isEmpty)
+                vpnBundleID = bundleID;
+    precondition(!vpnBundleID.isEmpty)
 
-        stateChangeCallback = callback
-        self.privateKey = PrivateKey(rawValue: privateKey)
-        self.deviceIpv4Address = deviceIpv4Address
-        self.deviceIpv6Address = deviceIpv6Address
+        stateChangeCallback = callback self.privateKey =
+            PrivateKey(rawValue
+                                   : privateKey) self.deviceIpv4Address =
+                deviceIpv4Address self.deviceIpv6Address =
+                    deviceIpv6Address
 
-        NotificationCenter.default.addObserver(self, selector: #selector(self.vpnStatusDidChange(notification:)), name: Notification.Name.NEVPNStatusDidChange, object: nil)
+                        NotificationCenter.default
+                            .addObserver(
+                                self, selector
+                                : #selector(
+                                      self.vpnStatusDidChange(notification:)),
+                                  name
+                                : Notification.Name.NEVPNStatusDidChange, object
+                                : nil)
 
-        NETunnelProviderManager.loadAllFromPreferences { [weak self] managers, error in
-            if let error = error {
-                Logger.global?.log(message: "Loading from preference failed: \(error)")
-                closure(ConnectionState.Error, nil)
-                return
-            }
+                                NETunnelProviderManager.loadAllFromPreferences {
+      [weak self] managers, error in if let error = error {
+        Logger.global ?.log(message
+                                        : "Loading from preference failed: \(error)")
+                           closure(ConnectionState.Error, nil) return
+      }
 
-            if self == nil {
-                Logger.global?.log(message: "We are shutting down.")
-                return
-            }
+      if self
+        == nil{Logger.global ?.log(message
+                                               : "We are shutting down.") return }
 
-            let nsManagers = managers ?? []
-            Logger.global?.log(message: "We have received \(nsManagers.count) managers.")
+                              let nsManagers =
+                                  managers ? ? [] Logger.global
+                           ?.log(message
+                                 : "We have received \(nsManagers.count) managers.")
 
-            let tunnel = nsManagers.first(where: IOSControllerImpl.isOurManager(_:))
-            if tunnel == nil {
-                Logger.global?.log(message: "Creating the tunnel")
-                self!.tunnel = NETunnelProviderManager()
-                closure(ConnectionState.Disconnected, nil)
-                return
-            }
+                    let tunnel =
+                    nsManagers.first(where
+                                                 : IOSControllerImpl.isOurManager(_
+            :)) if tunnel == nil{Logger.global
+                                 ?.log(message
+                                       : "Creating the tunnel") self !.tunnel =
+                          NETunnelProviderManager() closure(
+                              ConnectionState.Disconnected, nil) return }
 
-            Logger.global?.log(message: "Tunnel already exists")
+                      Logger.global
+                                 ?.log(message
+                                       : "Tunnel already exists")
 
-            self!.tunnel = tunnel
-            if tunnel?.connection.status == .connected {
+                          self !.tunnel =
+                          tunnel if tunnel ?.connection.status ==.connected {
                 closure(ConnectionState.Connected, tunnel?.connection.connectedDate)
-            } else {
-                closure(ConnectionState.Disconnected, nil)
-            }
         }
+      else {
+        closure(ConnectionState.Disconnected, nil)
+      }
     }
+  }
 
-    @objc private func vpnStatusDidChange(notification: Notification) {
-        guard let session = (notification.object as? NETunnelProviderSession), tunnel?.connection == session else { return }
-
-        switch session.status {
-        case .connected:
-            Logger.global?.log(message: "STATE CHANGED: connected")
-        case .connecting:
-            Logger.global?.log(message: "STATE CHANGED: connecting")
-        case .disconnected:
-            Logger.global?.log(message: "STATE CHANGED: disconnected")
-        case .disconnecting:
-            Logger.global?.log(message: "STATE CHANGED: disconnecting")
-        case .invalid:
-            Logger.global?.log(message: "STATE CHANGED: invalid")
-        case .reasserting:
-            Logger.global?.log(message: "STATE CHANGED: reasserting")
-        default:
-            Logger.global?.log(message: "STATE CHANGED: unknown status")
+  @objc private func vpnStatusDidChange(notification : Notification) {
+        guard let session = (notification.object as? NETunnelProviderSession), tunnel?.connection == session else {
+          return
         }
+
+        switch
+          session.status {
+            case.connected:
+            Logger.global ?.log(message
+                                : "STATE CHANGED: connected") case.connecting
+                          :
+            Logger.global ?.log(message
+                                : "STATE CHANGED: connecting") case.disconnected
+                          :
+            Logger.global
+                ?.log(message
+                      : "STATE CHANGED: disconnected") case.disconnecting
+                :
+            Logger.global ?.log(message
+                                : "STATE CHANGED: disconnecting") case.invalid
+                          :
+            Logger.global ?.log(message
+                                : "STATE CHANGED: invalid") case.reasserting
+                          :
+                Logger.global ?.log(message
+                                    : "STATE CHANGED: reasserting") default
+                              : Logger.global
+                    ?.log(message
+                          : "STATE CHANGED: unknown status")
+          }
 
         // We care about "unknown" state changes.
-        if (session.status != .connected && session.status != .disconnected) {
-            return
+        if (session.status !=.connected && session.status !=.disconnected) {
+          return
         }
 
         // If disconnected, we know for sure that this is true
-        if (session.status == .disconnected) {
-            stateChangeCallback?(false)
-            return
+        if (session.status ==.disconnected) {
+          stateChangeCallback ? (false) return
         }
 
-       // This timer is used to workaround a Schrödinger's cat bug: if we check
-       // the connection status immediately when connected, we alter the iOS16
-       // connectivity state and we break the VPN tunnel (intermittently). With
-       // a timer this does not happen.
-        _ = Timer.scheduledTimer(withTimeInterval: 0.5, repeats: false) {_ in
-            self.monitorConnection()
+        // This timer is used to workaround a Schrödinger's cat bug: if we check
+        // the connection status immediately when connected, we alter the iOS16
+        // connectivity state and we break the VPN tunnel (intermittently). With
+        // a timer this does not happen.
+        _ = Timer.scheduledTimer(withTimeInterval : 0.5, repeats : false) {
+          _ in self.monitorConnection()
         }
-    }
+  }
 
-    private func monitorConnection() -> Void {
+ private
+  func monitorConnection()->Void {
         // Let's call `stateChangeCallback` if connected and if
         // last_handshake_time_sec is not 0.
-        self.checkStatus { _, _, configString in
-            if self.tunnel?.connection.status != .connected { return; }
+        self.checkStatus {
+          _, _,
+              configString in if self.tunnel ?.connection.status !=.connected {
+            return;
+          }
 
-            let lines = configString.splitToArray(separator: "\n")
-            if let line = lines.first(where: { $0.starts(with: "last_handshake_time_sec") }) {
-                let parts = line.splitToArray(separator: "=")
-                if parts.count > 1 && Int(parts[1]) ?? 0 > 0 {
-                    self.stateChangeCallback?(true)
-                    return
-                }
+          let lines = configString.splitToArray(separator
+                                                : "\n") if let line =
+              lines.first(where
+                          : {$0.starts(with
+                                       : "last_handshake_time_sec")}) {
+            let parts = line.splitToArray(separator
+                                          : "=") if parts.count > 1 &&
+                        Int(parts[1])
+                ? ? 0 > 0 {
+                self.stateChangeCallback ? (true) return
             }
+          }
 
-            _ = Timer.scheduledTimer(withTimeInterval: 0.5, repeats: false) { _ in
-                self.monitorConnection()
-            }
+          _ = Timer.scheduledTimer(withTimeInterval : 0.5, repeats : false) {
+            _ in self.monitorConnection()
+          }
         }
-    }
+  }
 
-    private static func isOurManager(_ manager: NETunnelProviderManager) -> Bool {
-        guard
-            let proto = manager.protocolConfiguration,
-            let tunnelProto = proto as? NETunnelProviderProtocol
-        else {
-            Logger.global?.log(message: "Ignoring manager because the proto is invalid.")
-            return false
+ private
+  static func isOurManager(_ manager : NETunnelProviderManager)->Bool {
+        guard let proto = manager.protocolConfiguration,
+                  let tunnelProto = proto as ? NETunnelProviderProtocol else {
+          Logger.global ?.log(message
+                              : "Ignoring manager because the proto is "
+                                "invalid.") return false
         }
 
         if (tunnelProto.providerBundleIdentifier == nil) {
-            Logger.global?.log(message: "Ignoring manager because the bundle identifier is null.")
-            return false
+          Logger.global ?.log(message
+                              : "Ignoring manager because the bundle "
+                                "identifier is null.") return false
         }
 
         if (tunnelProto.providerBundleIdentifier != vpnBundleID) {
-            Logger.global?.log(message: "Ignoring manager because the bundle identifier doesn't match.")
-            return false;
+          Logger.global ?.log(message
+                              : "Ignoring manager because the bundle "
+                                "identifier doesn't match.") return false;
         }
 
-        Logger.global?.log(message: "Found the manager with the correct bundle identifier: \(tunnelProto.providerBundleIdentifier!)")
-        return true
-    }
+        Logger.global
+            ?.log(message
+                  : "Found the manager with the correct bundle identifier: "
+                    "\(tunnelProto.providerBundleIdentifier!)") return true
+  }
 
-    @objc func connect(dnsServer: String, serverIpv6Gateway: String, serverPublicKey: String, serverIpv4AddrIn: String, serverPort: Int,  allowedIPAddressRanges: Array<VPNIPAddressRange>, reason: Int, failureCallback: @escaping () -> Void) {
-        Logger.global?.log(message: "Connecting")
-        assert(tunnel != nil)
+  @objc func connect(dnsServer
+                     : String, serverIpv6Gateway
+                     : String, serverPublicKey
+                     : String, serverIpv4AddrIn
+                     : String, serverPort
+                     : Int, allowedIPAddressRanges
+                     : Array<VPNIPAddressRange>, reason
+                     : Int, failureCallback
+                     : @escaping()->Void) {
+        Logger.global
+            ?.log(message
+                  : "Connecting") assert(tunnel != nil)
 
-        // Let's remove the previous config if it exists.
-        (tunnel!.protocolConfiguration as? NETunnelProviderProtocol)?.destroyConfigurationReference()
+             // Let's remove the previous config if it exists.
+             (tunnel !.protocolConfiguration as ? NETunnelProviderProtocol)
+             ?.destroyConfigurationReference()
 
-        let keyData = PublicKey(base64Key: serverPublicKey)!
-        let dnsServerIP = IPv4Address(dnsServer)
-        let ipv6GatewayIP = IPv6Address(serverIpv6Gateway)
+                  let keyData = PublicKey(base64Key
+                                          : serverPublicKey) !let dnsServerIP =
+                  IPv4Address(dnsServer) let ipv6GatewayIP = IPv6Address(
+                      serverIpv6Gateway)
 
-        var peerConfiguration = PeerConfiguration(publicKey: keyData)
-        peerConfiguration.endpoint = Endpoint(from: serverIpv4AddrIn + ":\(serverPort )")
-        peerConfiguration.allowedIPs = []
+                      var peerConfiguration = PeerConfiguration(publicKey
+                                                                : keyData)
+                                                  peerConfiguration.endpoint =
+                          Endpoint(from
+                                   : serverIpv4AddrIn + ":\(serverPort )")
+                              peerConfiguration.allowedIPs =
+                              []
 
-        allowedIPAddressRanges.forEach {
-            if (!$0.isIpv6) {
-                peerConfiguration.allowedIPs.append(IPAddressRange(address: IPv4Address($0.address as String)!, networkPrefixLength: $0.networkPrefixLength))
-            } else {
-                peerConfiguration.allowedIPs.append(IPAddressRange(address: IPv6Address($0.address as String)!, networkPrefixLength: $0.networkPrefixLength))
-            }
+                              allowedIPAddressRanges.forEach {
+          if (!$0.isIpv6) {
+            peerConfiguration.allowedIPs.append(IPAddressRange(
+                address
+                : IPv4Address($0.address as String) !, networkPrefixLength
+                : $0.networkPrefixLength))
+          } else {
+            peerConfiguration.allowedIPs.append(IPAddressRange(
+                address
+                : IPv6Address($0.address as String) !, networkPrefixLength
+                : $0.networkPrefixLength))
+          }
         }
 
         var peerConfigurations: [PeerConfiguration] = []
@@ -202,114 +262,140 @@ public class IOSControllerImpl : NSObject {
         let config = TunnelConfiguration(name: vpnName, interface: interface, peers: peerConfigurations)
 
         self.configureTunnel(config: config, reason: reason, serverName: serverIpv4AddrIn + ":\(serverPort )", failureCallback: failureCallback)
-    }
+  }
 
-    func configureTunnel(config: TunnelConfiguration, reason: Int, serverName: String, failureCallback: @escaping () -> Void) {
-        let proto = NETunnelProviderProtocol(tunnelConfiguration: config)
-        proto!.providerBundleIdentifier = vpnBundleID
-        proto!.disconnectOnSleep = false
-        proto!.serverAddress = serverName;
+  func configureTunnel(config
+                       : TunnelConfiguration, reason
+                       : Int, serverName
+                       : String, failureCallback
+                       : @escaping()->Void) {
+        let proto = NETunnelProviderProtocol(tunnelConfiguration
+                                             : config)
+                        proto !.providerBundleIdentifier =
+            vpnBundleID proto !.disconnectOnSleep =
+                false proto !.serverAddress = serverName;
 
-        if #available(iOS 15.1, *) {
-            Logger.global?.log(message: "Activating includeAllNetworks")
-            proto!.includeAllNetworks = true
-        }
+        if
+#          available(iOS 15.1, *){Logger.global
+                                  ?.log(message
+                                        : "Activating includeAllNetworks")
+                                       proto !.includeAllNetworks = true }
 
-        tunnel!.protocolConfiguration = proto
-        tunnel!.localizedDescription = vpnName
-        tunnel!.isEnabled = true
+                                   tunnel !.protocolConfiguration =
+                                       proto tunnel !.localizedDescription =
+                                           vpnName tunnel !.isEnabled =
+                                               true
 
-        tunnel!.saveToPreferences { [unowned self] saveError in
-            if let error = saveError {
-                Logger.global?.log(message: "Connect Tunnel Save Error: \(error)")
-                failureCallback()
-                return
-            }
+                                               tunnel !.saveToPreferences {
+            [unowned self] saveError in if let error =
+                saveError{Logger.global
+                          ?.log(message
+                                : "Connect Tunnel Save Error: \(error)")
+                               failureCallback() return }
 
-            Logger.global?.log(message: "Saving the tunnel succeeded")
+                          Logger.global
+                ?.log(message
+                      : "Saving the tunnel succeeded")
 
-            self.tunnel!.loadFromPreferences { error in
-                if let error = error {
-                    Logger.global?.log(message: "Connect Tunnel Load Error: \(error)")
-                    failureCallback()
-                    return
-                }
+                     self.tunnel !.loadFromPreferences {
+                error in if let error =
+                    error{Logger.global
+                          ?.log(message
+                                : "Connect Tunnel Load Error: \(error)")
+                               failureCallback() return }
 
-                Logger.global?.log(message: "Loading the tunnel succeeded")
+                          Logger.global
+                    ?.log(message
+                          : "Loading the tunnel succeeded")
 
-                do {
-                    if (reason == 1 /* ReasonSwitching */) {
+                         do {
+                  if (reason == 1 /* ReasonSwitching */) {
                         let settings = config.asWgQuickConfig()
                         let settingsData = settings.data(using: .utf8)!
                         try (self.tunnel!.connection as? NETunnelProviderSession)?
-                                .sendProviderMessage(settingsData) {_ in return}
-                    } else {
+                                .sendProviderMessage(settingsData) {
+                          _ in return
+                        }
+                  } else {
                         try (self.tunnel!.connection as? NETunnelProviderSession)?.startTunnel()
-                    }
-                } catch let error {
-                    Logger.global?.log(message: "Something went wrong: \(error)")
-                    failureCallback()
-                    return
+                  }
+                }
+                catch let error {
+                  Logger.global ?.log(message
+                                      : "Something went wrong: \(error)")
+                                     failureCallback() return
                 }
             }
+          }
+  }
+
+  @objc func setStartOnBoot(setEnabled : Bool) {
+        if (!setEnabled) {
+          return;
         }
-    }
+        let alwaysConnect =
+            NEOnDemandRuleConnect() alwaysConnect.interfaceTypeMatch =
+                .any tunnel !.isOnDemandEnabled =
+                    true tunnel !.onDemandRules = [alwaysConnect]
+  }
 
-    @objc func disconnect() {
-        Logger.global?.log(message: "Disconnecting")
-        assert(tunnel != nil)
-        (tunnel!.connection as? NETunnelProviderSession)?.stopTunnel()
-    }
+  @objc func getStartOnBoot()->Bool {
+        return tunnel !.isOnDemandEnabled;
+  }
 
-    @objc func checkStatus(callback: @escaping (String, String, String) -> Void) {
-        Logger.global?.log(message: "Check status")
-        assert(tunnel != nil)
+  @objc func disconnect() {
+        Logger.global ?.log(message
+                            : "Disconnecting")
+                           assert(tunnel != nil)(tunnel !.connection as
+                                                 ? NETunnelProviderSession)
+                       ?.stopTunnel()
+  }
 
-        let proto = tunnel!.protocolConfiguration as? NETunnelProviderProtocol
-        if proto == nil {
-            callback("", "", "")
-            return
-        }
+  @objc func checkStatus(callback : @escaping(String, String, String)->Void) {
+        Logger.global
+            ?.log(message
+                  : "Check status") assert(tunnel != nil)
 
-        let tunnelConfiguration = proto?.asTunnelConfiguration()
-        if tunnelConfiguration == nil {
-            callback("", "", "")
-            return
-        }
+                 let proto = tunnel !.protocolConfiguration as
+             ? NETunnelProviderProtocol if proto ==
+                   nil{callback("", "", "") return }
 
-        let serverIpv4Gateway = tunnelConfiguration?.interface.dns[0].address
-        if serverIpv4Gateway == nil {
-            callback("", "", "")
-            return
-        }
+                   let tunnelConfiguration = proto
+               ?.asTunnelConfiguration() if tunnelConfiguration ==
+                    nil{callback("", "", "") return }
 
-        let deviceIpv4Address = tunnelConfiguration?.interface.addresses[0].address
-        if deviceIpv4Address == nil {
-            callback("", "", "")
-            return
-        }
+                    let serverIpv4Gateway = tunnelConfiguration
+                ?.interface.dns[0].address if serverIpv4Gateway ==
+                     nil{callback("", "", "") return }
 
-        guard let session = tunnel?.connection as? NETunnelProviderSession
-        else {
-            callback("", "", "")
-            return
+                     let deviceIpv4Address = tunnelConfiguration
+                 ?.interface.addresses[0].address if deviceIpv4Address ==
+                      nil{callback("", "", "") return }
+
+                      guard let session =
+                      tunnel ?.connection as ? NETunnelProviderSession else {
+          callback("", "", "") return
         }
 
         do {
-            try session.sendProviderMessage(Data([UInt8(0)])) { [callback] data in
-                guard let data = data,
-                      let configString = String(data: data, encoding: .utf8)
-                else {
-                    Logger.global?.log(message: "Failed to convert data to string")
-                    callback("", "", "")
-                    return
-                }
+          try session.sendProviderMessage(Data([UInt8(0)])) {
+            [callback] data in guard let
+                data = data,
+                let configString = String(data
+                                          : data, encoding
+                                          :.utf8) else {
+                    Logger.global ?.log(message
+                                        : "Failed to convert data to string")
+                                       callback("", "", "") return }
 
-                callback("\(serverIpv4Gateway!)", "\(deviceIpv4Address!)", configString)
-            }
-        } catch {
-            Logger.global?.log(message: "Failed to retrieve data from session")
-            callback("", "", "")
+                    callback("\(serverIpv4Gateway!)", "\(deviceIpv4Address!)",
+                             configString)
+          }
         }
-    }
+        catch {
+          Logger.global ?.log(message
+                              : "Failed to retrieve data from session")
+                             callback("", "", "")
+        }
+  }
 }


### PR DESCRIPTION
## Description

This PR adds support for the "start-on-boot" settings option using the ios `onDemandRules` provider. 
calling this only "Start On Boot-ish" (and marking as WIP) as there is a catch, it will start the vpn on boot, if it was not manually disconnected at the time of of the reboot.

-> i.e. connecting. Closing app, reboot -> will restart vpn on reboot.
-> disconnecting. Closing app, reboot -> will not. 

Reason for this: 
The `onDemand` rule matching `any` will apparently trigger on a manual disconnect, so the OS would just bring the tunnel back up. I'm not really smart enough to know if we can somehow write a rule that would match only a reboot?

Smart ideas welcome on how to better do that :D 

## Reference

VPN-3113

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
