### PR TITLE
Fix crash in Windows ping sender cleanup

### DIFF
--- a/src/platforms/windows/windowspingsender.cpp
+++ b/src/platforms/windows/windowspingsender.cpp
@@ -29,8 +29,7 @@ Logger logger({LOG_WINDOWS, LOG_NETWORKING}, "WindowsPingSender");
 }
 
 static DWORD icmpCleanupHelper(LPVOID data) {
-  struct WindowsPingSenderPrivate* p =
-      (struct WindowsPingSenderPrivate*)data;
+  struct WindowsPingSenderPrivate* p = (struct WindowsPingSenderPrivate*)data;
   if (p->m_event != INVALID_HANDLE_VALUE) {
     CloseHandle(p->m_event);
   }
@@ -104,8 +103,8 @@ void WindowsPingSender::sendPing(const QHostAddress& dest, quint16 sequence) {
 }
 
 void WindowsPingSender::pingEventReady() {
-  DWORD replyCount = IcmpParseReplies(m_private->m_buffer,
-                                      sizeof(m_private->m_buffer));
+  DWORD replyCount =
+      IcmpParseReplies(m_private->m_buffer, sizeof(m_private->m_buffer));
   if (replyCount == 0) {
     DWORD error = GetLastError();
     if (error == IP_REQ_TIMED_OUT) {

--- a/src/platforms/windows/windowspingsender.cpp
+++ b/src/platforms/windows/windowspingsender.cpp
@@ -9,12 +9,35 @@
 
 #include <QtEndian>
 
+#include <WS2tcpip.h>
+#include <Windows.h>
+#include <iphlpapi.h>
+#include <IcmpAPI.h>
+
+#pragma comment(lib, "Ws2_32")
+
+constexpr WORD WindowsPingPayloadSize = sizeof(quint16);
+
+struct WindowsPingSenderPrivate {
+  HANDLE m_handle;
+  HANDLE m_event;
+  unsigned char m_buffer[sizeof(ICMP_ECHO_REPLY) + WindowsPingPayloadSize + 8];
+};
+
 namespace {
 Logger logger({LOG_WINDOWS, LOG_NETWORKING}, "WindowsPingSender");
 }
 
-static DWORD icmpCleanupHelper(HANDLE h) {
-  IcmpCloseHandle(h);
+static DWORD icmpCleanupHelper(LPVOID data) {
+  struct WindowsPingSenderPrivate* p =
+      (struct WindowsPingSenderPrivate*)data;
+  if (p->m_event != INVALID_HANDLE_VALUE) {
+    CloseHandle(p->m_event);
+  }
+  if (p->m_handle != INVALID_HANDLE_VALUE) {
+    IcmpCloseHandle(p->m_handle);
+  }
+  delete p;
   return 0;
 }
 
@@ -23,14 +46,15 @@ WindowsPingSender::WindowsPingSender(const QHostAddress& source,
     : PingSender(parent) {
   MVPN_COUNT_CTOR(WindowsPingSender);
   m_source = source;
-  m_handle = IcmpCreateFile();
-  m_event = CreateEventA(NULL, FALSE, FALSE, NULL);
+  m_private = new struct WindowsPingSenderPrivate;
+  m_private->m_handle = IcmpCreateFile();
+  m_private->m_event = CreateEventA(NULL, FALSE, FALSE, NULL);
 
-  m_notifier = new QWinEventNotifier(m_event, this);
+  m_notifier = new QWinEventNotifier(m_private->m_event, this);
   QObject::connect(m_notifier, &QWinEventNotifier::activated, this,
                    &WindowsPingSender::pingEventReady);
 
-  memset(m_buffer, 0, sizeof(m_buffer));
+  memset(m_private->m_buffer, 0, sizeof(m_private->m_buffer));
 }
 
 WindowsPingSender::~WindowsPingSender() {
@@ -38,40 +62,36 @@ WindowsPingSender::~WindowsPingSender() {
   if (m_notifier) {
     delete m_notifier;
   }
-  if (m_event != INVALID_HANDLE_VALUE) {
-    CloseHandle(m_event);
-  }
-  if (m_handle != INVALID_HANDLE_VALUE) {
-    // Closing the ICMP handle can hang if there are lost ping replies. Moving
-    // the cleanup into a separate thread avoids deadlocking the application.
-    HANDLE h = CreateThread(NULL, 0, icmpCleanupHelper, m_handle, 0, NULL);
-    if (h == NULL) {
-      IcmpCloseHandle(m_handle);
-    } else {
-      CloseHandle(h);
-    }
+  // Closing the ICMP handle can hang if there are lost ping replies. Moving
+  // the cleanup into a separate thread avoids deadlocking the application.
+  HANDLE h = CreateThread(NULL, 0, icmpCleanupHelper, m_private, 0, NULL);
+  if (h == NULL) {
+    icmpCleanupHelper(m_private);
+  } else {
+    CloseHandle(h);
   }
 }
 
 void WindowsPingSender::sendPing(const QHostAddress& dest, quint16 sequence) {
-  if (m_handle == INVALID_HANDLE_VALUE) {
+  if (m_private->m_handle == INVALID_HANDLE_VALUE) {
     return;
   }
-  if (m_event == INVALID_HANDLE_VALUE) {
+  if (m_private->m_event == INVALID_HANDLE_VALUE) {
     return;
   }
 
   quint32 v4dst = dest.toIPv4Address();
   if (m_source.isNull()) {
-    IcmpSendEcho2(m_handle, m_event, nullptr, nullptr,
+    IcmpSendEcho2(m_private->m_handle, m_private->m_event, nullptr, nullptr,
                   qToBigEndian<quint32>(v4dst), &sequence, sizeof(sequence),
-                  nullptr, m_buffer, sizeof(m_buffer), 10000);
+                  nullptr, m_private->m_buffer, sizeof(m_private->m_buffer),
+                  10000);
   } else {
     quint32 v4src = m_source.toIPv4Address();
-    IcmpSendEcho2Ex(m_handle, m_event, nullptr, nullptr,
+    IcmpSendEcho2Ex(m_private->m_handle, m_private->m_event, nullptr, nullptr,
                     qToBigEndian<quint32>(v4src), qToBigEndian<quint32>(v4dst),
-                    &sequence, sizeof(sequence), nullptr, m_buffer,
-                    sizeof(m_buffer), 10000);
+                    &sequence, sizeof(sequence), nullptr, m_private->m_buffer,
+                    sizeof(m_private->m_buffer), 10000);
   }
 
   DWORD status = GetLastError();
@@ -84,7 +104,8 @@ void WindowsPingSender::sendPing(const QHostAddress& dest, quint16 sequence) {
 }
 
 void WindowsPingSender::pingEventReady() {
-  DWORD replyCount = IcmpParseReplies(m_buffer, sizeof(m_buffer));
+  DWORD replyCount = IcmpParseReplies(m_private->m_buffer,
+                                      sizeof(m_private->m_buffer));
   if (replyCount == 0) {
     DWORD error = GetLastError();
     if (error == IP_REQ_TIMED_OUT) {
@@ -95,7 +116,7 @@ void WindowsPingSender::pingEventReady() {
     return;
   }
 
-  const ICMP_ECHO_REPLY* replies = (const ICMP_ECHO_REPLY*)m_buffer;
+  const ICMP_ECHO_REPLY* replies = (const ICMP_ECHO_REPLY*)m_private->m_buffer;
   for (DWORD i = 0; i < replyCount; i++) {
     if (replies[i].DataSize < sizeof(quint16)) {
       continue;

--- a/src/platforms/windows/windowspingsender.h
+++ b/src/platforms/windows/windowspingsender.h
@@ -5,24 +5,12 @@
 #ifndef WINDOWSPINGSENDER_H
 #define WINDOWSPINGSENDER_H
 
-#pragma comment(lib, "Ws2_32")
-
 #include "pingsender.h"
 
 #include <QMap>
 #include <QWinEventNotifier>
 
-#include <WS2tcpip.h>
-#include <Windows.h>
-#include <iphlpapi.h>
-#include <IcmpAPI.h>
-
-constexpr WORD WindowsPingPayloadSize = sizeof(quint16);
-
-struct WindowsPingContext {
-  HANDLE event;
-  quint16 sequence;
-};
+struct WindowsPingSenderPrivate;
 
 class WindowsPingSender final : public PingSender {
   Q_OBJECT
@@ -39,11 +27,8 @@ class WindowsPingSender final : public PingSender {
 
  private:
   QHostAddress m_source;
-  HANDLE m_handle = INVALID_HANDLE_VALUE;
-  HANDLE m_event = INVALID_HANDLE_VALUE;
   QWinEventNotifier* m_notifier = nullptr;
-
-  unsigned char m_buffer[sizeof(ICMP_ECHO_REPLY) + WindowsPingPayloadSize + 8];
+  struct WindowsPingSenderPrivate* m_private = nullptr;
 };
 
 #endif  // WINDOWSPINGSENDER_H


### PR DESCRIPTION
## Description
In order to prevent hanging the client when terminating a `WindowsPingSender` we need to perform an asynchronous call to `IcmpCloseHandle` from a separate thread. This can lead to a possible use-after-free bug if the kernel still needs to write userspace memory. To resolve this, we need to wait until after `IcmpCloseHandle` returns before freeing userspace memory that it accesses.

## Reference
Github #4829 ([VPN-3175](https://mozilla-hub.atlassian.net/browse/VPN-3175))

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
