### PR TITLE
Add the controller API to addons - VPN-3236

### DIFF
--- a/src/addons/addonapi.cpp
+++ b/src/addons/addonapi.cpp
@@ -110,6 +110,17 @@ QJSValue AddonApi::urlOpener() const {
   return value;
 }
 
+QJSValue AddonApi::controller() const {
+  QJSEngine* engine = QmlEngineHolder::instance()->engine();
+
+  QObject* obj = MozillaVPN::instance()->controller();
+  QQmlEngine::setObjectOwnership(obj, QQmlEngine::CppOwnership);
+
+  QJSValue value = engine->newQObject(obj);
+  value.setPrototype(engine->newQMetaObject(&Controller::staticMetaObject));
+  return value;
+}
+
 QJSValue AddonApi::featureList() const {
   QJSEngine* engine = QmlEngineHolder::instance()->engine();
 

--- a/src/addons/addonapi.h
+++ b/src/addons/addonapi.h
@@ -22,11 +22,12 @@ class AddonApi final : public QObject {
   Q_DISABLE_COPY_MOVE(AddonApi)
 
   Q_PROPERTY(QJSValue addon READ addon CONSTANT)
+  Q_PROPERTY(QJSValue controller READ controller CONSTANT)
   Q_PROPERTY(const Env* env READ env CONSTANT)
   Q_PROPERTY(QJSValue featureList READ featureList CONSTANT)
   Q_PROPERTY(QJSValue navigator READ navigator CONSTANT)
-  Q_PROPERTY(QJSValue urlOpener READ urlOpener CONSTANT)
   Q_PROPERTY(QJSValue settings READ settings CONSTANT)
+  Q_PROPERTY(QJSValue urlOpener READ urlOpener CONSTANT)
 
  public:
   explicit AddonApi(Addon* addon);
@@ -37,6 +38,7 @@ class AddonApi final : public QObject {
 
  private:
   QJSValue addon() const;
+  QJSValue controller() const;
   const Env* env() const { return &m_env; }
   QJSValue featureList() const;
   QJSValue navigator() const;

--- a/tests/unit/addons/addons.qrc
+++ b/tests/unit/addons/addons.qrc
@@ -9,12 +9,13 @@
         <file>button2.js</file>
         <file>button3.js</file>
         <file>button4.js</file>
-        <file>api_env.js</file>
         <file>message1.json</file>
         <file>message2.json</file>
         <file>message3.json</file>
         <file>message4.json</file>
         <file>message5.json</file>
+        <file>api_controller.js</file>
+        <file>api_env.js</file>
         <file>api_featurelist.js</file>
         <file>api_navigator.js</file>
         <file>api_settings.js</file>

--- a/tests/unit/addons/api_controller.js
+++ b/tests/unit/addons/api_controller.js
@@ -1,0 +1,11 @@
+(function(vpn, condition) {
+if (!('controller' in vpn)) {
+  return;
+}
+
+if (!('state' in vpn.controller)) {
+  return;
+}
+
+condition.enable();
+})

--- a/tests/unit/testaddonapi.cpp
+++ b/tests/unit/testaddonapi.cpp
@@ -13,6 +13,30 @@
 
 #include <QQmlApplicationEngine>
 
+void TestAddonApi::controller() {
+  MozillaVPN vpn;
+  SettingsHolder settingsHolder;
+
+  QQmlApplicationEngine engine;
+  QmlEngineHolder qml(&engine);
+
+  QJsonObject content;
+  content["id"] = "foo";
+  content["blocks"] = QJsonArray();
+
+  QJsonObject obj;
+  obj["message"] = content;
+
+  QObject parent;
+  Addon* message = AddonMessage::create(&parent, "foo", "bar", "name", obj);
+  QVERIFY(!!message);
+
+  AddonConditionWatcher* a = AddonConditionWatcherJavascript::maybeCreate(
+      message, ":/addons_test/api_controller.js");
+  QVERIFY(!!a);
+  QVERIFY(a->conditionApplied());
+}
+
 void TestAddonApi::env() {
   MozillaVPN vpn;
   SettingsHolder settingsHolder;

--- a/tests/unit/testaddonapi.h
+++ b/tests/unit/testaddonapi.h
@@ -8,6 +8,7 @@ class TestAddonApi final : public TestHelper {
   Q_OBJECT
 
  private slots:
+  void controller();
   void env();
   void featurelist();
   void navigator();


### PR DESCRIPTION
This is needed for the split-tunnel tutorial because we want to expose it only if the VPN is off.