### PR TITLE
No ticket - Check count before removing rows from AddonManager

### DIFF
--- a/src/addons/manager/addonmanager.cpp
+++ b/src/addons/manager/addonmanager.cpp
@@ -170,7 +170,7 @@ bool AddonManager::loadManifest(const QString& manifestFileName) {
         if (i.value().m_addon->enabled()) ++pos;
         continue;
       }
-      if (!enabled) {
+      if (!enabled && pos < count()) {
         beginRemoveRows(QModelIndex(), pos, pos);
         endRemoveRows();
       } else {


### PR DESCRIPTION
This was triggering a Q_ASSERT and thus causing a segfault.
