### PR TITLE
Add subscription not found OS notification

### DIFF
--- a/src/constants.h
+++ b/src/constants.h
@@ -32,6 +32,9 @@ constexpr uint32_t SERVER_UNAVAILABLE_ALERT_MSEC = 4000;
 // Number of msecs for the new in app message alert.
 constexpr uint32_t NEW_IN_APP_MESSAGE_ALERT_MSEC = 4000;
 
+// Default number of msecs for OS notifications.
+constexpr uint32_t DEFAULT_OS_NOTIFICATION_MSEC = 4000;
+
 // Number of recent connections to retain.
 constexpr int RECENT_CONNECTIONS_MAX_COUNT = 5;
 

--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -773,6 +773,7 @@ void MozillaVPN::accountChecked(const QByteArray& json) {
   m_private->m_deviceModel.writeSettings();
 
   if (m_private->m_user.subscriptionNeeded() && m_state == StateMain) {
+    NotificationHandler::instance()->subscriptionNotFoundNotification();
     maybeStateMain();
     return;
   }

--- a/src/notificationhandler.cpp
+++ b/src/notificationhandler.cpp
@@ -264,6 +264,21 @@ void NotificationHandler::newInAppMessageNotification(const QString& title,
                  Constants::NEW_IN_APP_MESSAGE_ALERT_MSEC);
 }
 
+void NotificationHandler::subscriptionNotFoundNotification() {
+  logger.debug() << "Subscription not found notification";
+
+  L18nStrings* l18nStrings = L18nStrings::instance();
+  Q_ASSERT(l18nStrings);
+
+  QString notificationTitle =
+      l18nStrings->t(L18nStrings::MobileOnboardingPanelOneTitle);
+  QString notificationBody =
+      l18nStrings->t(L18nStrings::NotificationsSubscriptionNotFound);
+
+  notifyInternal(SubscriptionNotFound, notificationTitle, notificationBody,
+                 Constants::DEFAULT_OS_NOTIFICATION_MSEC);
+}
+
 void NotificationHandler::notifyInternal(Message type, const QString& title,
                                          const QString& message,
                                          int timerMsec) {

--- a/src/notificationhandler.h
+++ b/src/notificationhandler.h
@@ -21,6 +21,7 @@ class NotificationHandler : public QObject {
     CaptivePortalUnblock,
     ServerUnavailable,
     NewInAppMessage,
+    SubscriptionNotFound,
   };
 
   static NotificationHandler* create(QObject* parent);
@@ -38,6 +39,8 @@ class NotificationHandler : public QObject {
 
   void newInAppMessageNotification(const QString& title,
                                    const QString& message);
+
+  void subscriptionNotFoundNotification();
 
   void showNotification();
 

--- a/translations/strings.yaml
+++ b/translations/strings.yaml
@@ -257,6 +257,7 @@ notifications:
   captivePortalBlockMessage2: The guest Wi-Fi network you’re connected to requires action. Click to turn off VPN to see the portal.
   captivePortalUnblockTitle: Guest Wi-Fi portal detected
   captivePortalUnblockMessage2: The guest Wi-Fi network you’re connected to may not be secure. Click to turn on VPN to secure your device.
+  subscriptionNotFound: Your Mozilla VPN subscription cannot be found. Please open the app to resolve this subscription issue.
   unsecuredNetworkTitle: Unsecured Wi-Fi network detected
   unsecuredNetworkMessage:
     value: "%1 is not secure. Click here to turn on VPN and secure your device."


### PR DESCRIPTION
## Description

This adds a new `SubscriptionNotFound` OS notification which is sent when the client becomes aware, for now via periodic pings to Guardian, that a valid subscription does not exist. 

## Reference
VPN-3240 / #4910 

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
