### PR TITLE
Possible fix to QML plugin scanner on static MacOS builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,8 @@ lottie/liblottie.a
 nebula/nebula_autogen/
 nebula/libnebula.a
 src/mozillavpn_autogen/
+/build-*/
+/build/
 
 # Node (for functional tests)
 node_modules

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,6 +10,9 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR}/hacl-star/kremlin)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/hacl-star/kremlin/minimal)
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
+# For CMake versions prior to 3.19, we may need to perform manual
+# finalization in order to pick up QML dependencies when built
+# statically.
 qt_add_executable(mozillavpn MANUAL_FINALIZATION)
 
 target_link_libraries(mozillavpn PRIVATE

--- a/src/cmake/macos.cmake
+++ b/src/cmake/macos.cmake
@@ -34,8 +34,6 @@ target_link_libraries(mozillavpn PRIVATE ${FW_SECURITY})
 target_link_libraries(mozillavpn PRIVATE ${FW_COREWLAN})
 target_link_libraries(mozillavpn PRIVATE ${FW_NETWORK})
 
-qt6_import_qml_plugins(mozillavpn)
-
 # MacOS platform source files
 target_sources(mozillavpn PRIVATE
     daemon/daemon.cpp


### PR DESCRIPTION
## Description
For static builds of Qt using CMake, we need to perform a scan to link in plugins required for the QML imports. For our MacOS builds, we are attempting to do this with an explicit call to `qt6_import_qml_plugins()` however, this only picks up dependencies that exist at the time of this call. It is far better to defer this to target finalization (eg: in `qt_finalze_target()`)

## Reference
Github issue #4920 ([VPN-3247](https://mozilla-hub.atlassian.net/browse/VPN-3247))

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
