### PR TITLE
Fix android workaround check breaking builds on Qt>6.4

### DIFF
--- a/src/connectionbenchmark/benchmarktaskdownload.cpp
+++ b/src/connectionbenchmark/benchmarktaskdownload.cpp
@@ -48,9 +48,9 @@ void BenchmarkTaskDownload::handleState(BenchmarkTask::State state) {
 #endif
 
 #if defined(MVPN_ANDROID) || defined(MVPN_WASM)
-# if QT_VERSION >= 0x060500
-#  error Check if QT added support for QDnsLookup::lookup() on Android
-# endif
+#  if QT_VERSION >= 0x060500
+#    error Check if QT added support for QDnsLookup::lookup() on Android
+#  endif
 
     NetworkRequest* request =
         NetworkRequest::createForGetUrl(this, m_fileUrl.toString());

--- a/src/connectionbenchmark/benchmarktaskdownload.cpp
+++ b/src/connectionbenchmark/benchmarktaskdownload.cpp
@@ -47,11 +47,11 @@ void BenchmarkTaskDownload::handleState(BenchmarkTask::State state) {
     m_dnsLookup.setNameserver(QHostAddress(MULLVAD_DEFAULT_DNS));
 #endif
 
-#if QT_VERSION >= 0x060500
-#  error Check if QT added support for QDnsLookup::lookup() on Android
-#endif
-
 #if defined(MVPN_ANDROID) || defined(MVPN_WASM)
+# if QT_VERSION >= 0x060500
+#  error Check if QT added support for QDnsLookup::lookup() on Android
+# endif
+
     NetworkRequest* request =
         NetworkRequest::createForGetUrl(this, m_fileUrl.toString());
     connectNetworkRequest(request);

--- a/src/connectionbenchmark/benchmarktasktransfer.cpp
+++ b/src/connectionbenchmark/benchmarktasktransfer.cpp
@@ -46,15 +46,15 @@ void BenchmarkTaskTransfer::handleState(BenchmarkTask::State state) {
 
   if (state == BenchmarkTask::StateActive) {
 #if defined(MVPN_DUMMY) || defined(MVPN_ANDROID) || defined(MVPN_WASM)
+#if QT_VERSION >= 0x060500
+#  error Check if QT added support for QDnsLookup::lookup() on Android
+#endif
+
     createNetworkRequest();
 #else
     // Start DNS resolution
     m_dnsLookup.setNameserver(QHostAddress(MULLVAD_DEFAULT_DNS));
     m_dnsLookup.lookup();
-#endif
-
-#if QT_VERSION >= 0x060500
-#  error Check if QT added support for QDnsLookup::lookup() on Android
 #endif
 
     m_elapsedTimer.start();

--- a/src/connectionbenchmark/benchmarktasktransfer.cpp
+++ b/src/connectionbenchmark/benchmarktasktransfer.cpp
@@ -46,9 +46,9 @@ void BenchmarkTaskTransfer::handleState(BenchmarkTask::State state) {
 
   if (state == BenchmarkTask::StateActive) {
 #if defined(MVPN_DUMMY) || defined(MVPN_ANDROID) || defined(MVPN_WASM)
-#if QT_VERSION >= 0x060500
-#  error Check if QT added support for QDnsLookup::lookup() on Android
-#endif
+#  if QT_VERSION >= 0x060500
+#    error Check if QT added support for QDnsLookup::lookup() on Android
+#  endif
 
     createNetworkRequest();
 #else


### PR DESCRIPTION
## Description
Some users are starting to build the VPN client on Qt version 6.4 and newer on Linux, which is leading to breakage in the Android `QDnsLookup::lookup()` workaround. We should nest the workaround checks for this to throw an error only when built for one of the affected platforms.

## Reference
Github issue #4940 

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
