### PR TITLE
Remove Port 53 UI / Fix VPN-3234

### DIFF
--- a/src/ui/screens/settings/ViewNetworkSettings.qml
+++ b/src/ui/screens/settings/ViewNetworkSettings.qml
@@ -65,23 +65,6 @@ VPNViewBase {
             }
         }
 
-        VPNCheckBoxRow {
-            id: tunnelPort53
-            objectName: "settingTunnelPort53"
-            width: parent.width - VPNTheme.theme.windowMargin
-            showDivider: true
-
-            labelText: VPNl18n.SettingsTunnelPort53
-            subLabelText: VPNl18n.SettingsTunnelPort53Description
-            isChecked: (VPNSettings.tunnelPort53)
-            isEnabled: vpnFlickable.vpnIsOff
-            onClicked: {
-                if (vpnFlickable.vpnIsOff) {
-                    VPNSettings.tunnelPort53 = !VPNSettings.tunnelPort53
-                }
-            }
-        }
-
         Column {
             width: parent.width
             spacing: VPNTheme.theme.windowMargin  /2


### PR DESCRIPTION
## Description

This removes Port 53 checkbox from the Network Settings view. 

Note: An awkward result of this is that the Network Settings view on iOS now consists of a sub-menu with only option: Advanced DNS Settings and feels like a very pointless drill down.

<img width="300" alt="Screen Shot 2022-11-15 at 7 22 09 PM" src="https://user-images.githubusercontent.com/22355127/202007223-7fb9eb1e-0e9e-4411-a5d3-19c1f9af22d3.png">

## Reference

VPN-3234

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
