### PR TITLE
Set upload benchmark endpoints

### DIFF
--- a/src/connectionbenchmark/benchmarktasktransfer.cpp
+++ b/src/connectionbenchmark/benchmarktasktransfer.cpp
@@ -204,7 +204,9 @@ void BenchmarkTaskTransfer::transferProgressed(qint64 bytesSent,
     }
     case BenchmarkUpload: {
       Q_UNUSED(reply);
-      m_bytesTransferred += bytesSent;
+      if (bytesSent > 0) {
+        m_bytesTransferred = bytesSent;
+      }
       break;
     }
     default: {

--- a/src/connectionbenchmark/connectionbenchmark.h
+++ b/src/connectionbenchmark/connectionbenchmark.h
@@ -92,7 +92,7 @@ class ConnectionBenchmark final : public QObject {
 
  private:
   QUrl m_downloadUrl = QUrl(Constants::BENCHMARK_DOWNLOAD_URL);
-  QUrl m_uploadUrl = QUrl(Constants::BENCHMARK_UPLOAD_URL);
+  QUrl m_uploadUrl = QUrl(Constants::benchmarkUploadUrl());
 
   QList<BenchmarkTask*> m_benchmarkTasks;
 

--- a/src/constants.h
+++ b/src/constants.h
@@ -46,8 +46,6 @@ constexpr uint32_t BENCHMARK_THRESHOLD_SPEED_FAST = 25000000;    // 25 Megabit
 constexpr uint32_t BENCHMARK_THRESHOLD_SPEED_MEDIUM = 10000000;  // 10 Megabit
 constexpr const char* BENCHMARK_DOWNLOAD_URL =
     "https://archive.mozilla.org/pub/vpn/speedtest/50m.data";
-// TODO: Add url for upload benchmark
-constexpr const char* BENCHMARK_UPLOAD_URL = "";
 
 #if defined(UNIT_TEST)
 #  define CONSTEXPR(type, functionName, releaseValue, debugValue, \
@@ -111,6 +109,11 @@ constexpr const char* GOOGLE_SUBSCRIPTIONS_URL =
     "https://play.google.com/store/account/subscriptions";
 
 constexpr const char* ADDON_SETTINGS_GROUP = "addons";
+
+PRODBETAEXPR(
+    const char*, benchmarkUploadUrl,
+    "https://benchmark.vpn.mozilla.org/upload",
+    "https://dev.vpn-network-benchmark.nonprod.webservices.mozgcp.net/upload");
 
 PRODBETAEXPR(QString, fxaApiBaseUrl, "https://api.accounts.firefox.com",
              envOrDefault("MVPN_FXA_API_BASE_URL",

--- a/src/constants.h
+++ b/src/constants.h
@@ -111,8 +111,7 @@ constexpr const char* GOOGLE_SUBSCRIPTIONS_URL =
 constexpr const char* ADDON_SETTINGS_GROUP = "addons";
 
 PRODBETAEXPR(
-    const char*, benchmarkUploadUrl,
-    "https://benchmark.vpn.mozilla.org/upload",
+    const char*, benchmarkUploadUrl, "https://benchmark.vpn.mozilla.org/upload",
     "https://dev.vpn-network-benchmark.nonprod.webservices.mozgcp.net/upload");
 
 PRODBETAEXPR(QString, fxaApiBaseUrl, "https://api.accounts.firefox.com",


### PR DESCRIPTION
## Description

Add upload benchmark endpoints and fixes the calculation for transferred bytes.

## Reference

- Jira: [VPN-2519](https://mozilla-hub.atlassian.net/browse/VPN-2519)
- #4948

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
