### PR TITLE
Update WireGuard for iOS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,7 +9,7 @@
         ignore=all
 [submodule "3rdparty/wireguard-apple"]
 	path = 3rdparty/wireguard-apple
-	url = https://github.com/WireGuard/wireguard-apple
+	url = https://github.com/mozilla/wireguard-apple
         ignore=all
 [submodule "3rdparty/openSSL"]
 	path = 3rdparty/openSSL


### PR DESCRIPTION
## Description

This fixes the IPv6 bug present in iOS 16. There is a similar [PR up for wireguard](https://github.com/WireGuard/wireguard-apple/pull/17), and according to folks at Mullvad this is something that is on the radar of WireGuard folks. 

After WireGuard updates their code to include this 2 line fix, we'll put up a new PR so that we're using WireGuard's repo again, and we can remove our fork. 

After checking out this branch, you'll need to run this command in the main VPN project folder:
`git submodule sync && git submodule update --remote 3rdparty/wireguard-apple`

This bug occurs on IPv6 networks, like my cell provider. We've been unable to reproduce on WiFi, and so this may be hard to test. If you'd like me to verify the fix works in real time (by demoing connecting to my cell provider w/ the current code vs. this update), let me know.

## Reference

  https://mozilla-hub.atlassian.net/browse/VPN-3172

## Checklist
    
- [X] My code follows the style guidelines for this project
- [X] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [X] I have performed a self review of my own code
- [X] I have commented my code PARTICULARLY in hard to understand areas
- [X] I have added thorough tests where needed
