### PR TITLE
Fix feedback radio delegate ui

### DIFF
--- a/src/ui/screens/getHelp/giveFeedback/GiveFeedbackRadioDelegate.qml
+++ b/src/ui/screens/getHelp/giveFeedback/GiveFeedbackRadioDelegate.qml
@@ -65,7 +65,8 @@ RadioDelegate {
         border.color: VPNTheme.theme.blueFocusOutline
         border.width: VPNTheme.theme.focusBorderWidth * 2
         color: VPNTheme.theme.transparent
-        opacity: radio.checked || radio.activeFocus ? 1 : 0
+        //OS Check to prevent multi-touch issue
+        opacity: radio.checked || ((Qt.platform.os !== "android" && Qt.platform.os !== "ios") && radio.activeFocus) ? 1 : 0
         radius: height
 
         Behavior on opacity {


### PR DESCRIPTION
## Description

- Prevents hover/focus outline from showing on iOS/Android when multiple delegates are tapped at the same time using multi-touch

## Reference

[VPN-912: [mobile] More than one option can be selected on the “Give Feedback” screen](https://mozilla-hub.atlassian.net/browse/VPN-912)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
