### PR TITLE
Prevent disabled checkboxrows from being clicked

### DIFF
--- a/nebula/ui/components/VPNCheckBoxRow.qml
+++ b/nebula/ui/components/VPNCheckBoxRow.qml
@@ -14,7 +14,6 @@ RowLayout {
     property var labelText: ""
     property var subLabelText: ""
     property bool isChecked
-    property bool isEnabled: true
     property bool showDivider: true
     property var leftMargin: 18
     property bool showAppImage: false
@@ -30,8 +29,7 @@ RowLayout {
         objectName: "checkbox"
         onClicked: checkBoxRow.clicked()
         checked: isChecked
-        enabled: isEnabled
-        opacity: isEnabled ? 1 : 0.5
+        opacity: checkBoxRow.enabled ? 1 : 0.5
         Component.onCompleted: {
             if (!showAppImage) {
                 Layout.leftMargin = leftMargin

--- a/src/ui/screens/getHelp/developerMenu/ViewDeveloperMenu.qml
+++ b/src/ui/screens/getHelp/developerMenu/ViewDeveloperMenu.qml
@@ -41,7 +41,7 @@ VPNViewBase {
             labelText: VPNl18n.SettingsDevUseStagingTitle
             subLabelText: VPNl18n.SettingsDevUseStagingSubtitle
             isChecked: VPNSettings.stagingServer
-            isEnabled: root.vpnIsOff
+            enabled: root.vpnIsOff
             showDivider: false
             onClicked: {
                 if (root.vpnIsOff) {

--- a/src/ui/screens/settings/ViewNetworkSettings.qml
+++ b/src/ui/screens/settings/ViewNetworkSettings.qml
@@ -62,7 +62,7 @@ VPNViewBase {
             //% "Access printers, streaming sticks and all other devices on your local network"
             subLabelText: qsTrId("vpn.settings.lanAccess.description")
             isChecked: (VPNSettings.localNetworkAccess)
-            isEnabled: vpnFlickable.vpnIsOff
+            enabled: vpnFlickable.vpnIsOff
             onClicked: {
                 if (vpnFlickable.vpnIsOff) {
                     VPNSettings.localNetworkAccess = !VPNSettings.localNetworkAccess

--- a/src/ui/screens/settings/ViewNotifications.qml
+++ b/src/ui/screens/settings/ViewNotifications.qml
@@ -74,7 +74,7 @@ VPNViewBase {
             subLabelText: qsTrId("vpn.settings.unsecuredNetworkAlert.description")
             isChecked: (VPNSettings.unsecuredNetworkAlert)
             enabled: vpnFlickable.vpnIsOff
-            showDivider: enabled
+            showDivider: !enabled
             onClicked: {
                 if (vpnFlickable.vpnIsOff) {
                     VPNSettings.unsecuredNetworkAlert = !VPNSettings.unsecuredNetworkAlert

--- a/src/ui/screens/settings/ViewNotifications.qml
+++ b/src/ui/screens/settings/ViewNotifications.qml
@@ -53,7 +53,7 @@ VPNViewBase {
             //% "Get notified if a guest Wi-Fi portal is blocked due to VPN connection"
             subLabelText: qsTrId("vpn.settings.guestWifiAlert.description")
             isChecked: (VPNSettings.captivePortalAlert)
-            isEnabled: vpnFlickable.vpnIsOff
+            enabled: vpnFlickable.vpnIsOff
             showDivider: false
             onClicked: {
                 if (vpnFlickable.vpnIsOff) {
@@ -73,8 +73,8 @@ VPNViewBase {
             //% "Get notified if you connect to an unsecured Wi-Fi network"
             subLabelText: qsTrId("vpn.settings.unsecuredNetworkAlert.description")
             isChecked: (VPNSettings.unsecuredNetworkAlert)
-            isEnabled: vpnFlickable.vpnIsOff
-            showDivider: !isEnabled
+            enabled: vpnFlickable.vpnIsOff
+            showDivider: enabled
             onClicked: {
                 if (vpnFlickable.vpnIsOff) {
                     VPNSettings.unsecuredNetworkAlert = !VPNSettings.unsecuredNetworkAlert

--- a/src/ui/screens/settings/ViewPreferences.qml
+++ b/src/ui/screens/settings/ViewPreferences.qml
@@ -28,7 +28,6 @@ VPNViewBase {
             labelText: _startAtBootTitle
             subLabelText: VPNl18n.SettingsStartAtBootSubtitle
             isChecked: VPNSettings.startAtBoot
-            isEnabled: true
             showDivider: false
             onClicked: VPNSettings.startAtBoot = !VPNSettings.startAtBoot
             visible: VPNFeatureList.get("startOnBoot").isSupported

--- a/src/ui/screens/settings/appPermissions/AppPermissionsList.qml
+++ b/src/ui/screens/settings/appPermissions/AppPermissionsList.qml
@@ -143,7 +143,7 @@ ColumnLayout {
                 showAppImage: true
                 onClicked: VPNAppPermissions.flip(appID)
                 isChecked: !appIsEnabled
-                isEnabled: vpnIsOff && VPNSettings.protectSelectedApps
+                enabled: vpnIsOff && VPNSettings.protectSelectedApps
                 Layout.minimumHeight: VPNTheme.theme.rowHeight * 1.5
             }
         }


### PR DESCRIPTION
## Description

* Disabled VPNCheckBoxRow's can no longer be checked/unchecked by clicking on their primary label
* Remove superfluous isEnabled property from VPNCheckBoxRow

## Reference

[VPN-2947: “Add application” button from App permissions screen is active while the VPN is ON](https://mozilla-hub.atlassian.net/browse/VPN-2947)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
