### PR TITLE
Update windows/taskcluster builds to go1.18.8

### DIFF
--- a/balrog/build.cmd
+++ b/balrog/build.cmd
@@ -14,7 +14,7 @@ if exist .deps\prepared goto :build
 	rmdir /s /q .deps 2> NUL
 	mkdir .deps || goto :error
 	cd .deps || goto :error
-	call :download go.zip https://dl.google.com/go/go1.13.3.windows-amd64.zip 9585efeab37783152c81c6ce373b22e68f45c6801dc2c208bfd1e47b646efbef || goto :error
+	call :download go.zip https://go.dev/dl/go1.18.8.windows-amd64.zip 980788761e75ed33ffc4f2a7a3ff07cd90949bd023eb1a8d855ef0b5de9cbcba || goto :error
 	rem Mirror of https://musl.cc/i686-w64-mingw32-native.zip
 	call :download mingw-x86.zip https://download.wireguard.com/windows-toolchain/distfiles/i686-w64-mingw32-native-20200907.zip c972c00993727ac9bff83c799f4df65662adb95bc871fa30cfa8857e744a7fbd || goto :error
 	rem Mirror of https://musl.cc/x86_64-w64-mingw32-native.zip

--- a/taskcluster/ci/fetch/kind.yml
+++ b/taskcluster/ci/fetch/kind.yml
@@ -50,9 +50,9 @@ tasks:
             sha256: 2220ddb49fea0e0945b1b5913e33d66bd223a67f19fd1c116be0318de7ed9d9c
             size: 10077696
     win-go:
-        description: go1.17beta1
+        description: go1.18.8
         fetch:
             type: static-url
-            url: https://download.wireguard.com/windows-toolchain/distfiles/go1.17beta1-windows_amd64_2021-06-11.zip
-            sha256: 09601956a35ee4c2fa199da301c4b210fd365a46d286a7160388a1cdc07b7a6d
-            size: 83720417
+            url: https://go.dev/dl/go1.18.8.windows-amd64.zip
+            sha256: 980788761e75ed33ffc4f2a7a3ff07cd90949bd023eb1a8d855ef0b5de9cbcba
+            size: 155201453

--- a/windows/tunnel/build.cmd
+++ b/windows/tunnel/build.cmd
@@ -13,7 +13,7 @@ if exist .deps\prepared goto :build
 	rmdir /s /q .deps 2> NUL
 	mkdir .deps || goto :error
 	cd .deps || goto :error
-	call :download go.zip https://download.wireguard.com/windows-toolchain/distfiles/go1.17beta1-windows_amd64_2021-06-11.zip 09601956a35ee4c2fa199da301c4b210fd365a46d286a7160388a1cdc07b7a6d || goto :error
+	call :download go.zip https://go.dev/dl/go1.18.8.windows-amd64.zip 980788761e75ed33ffc4f2a7a3ff07cd90949bd023eb1a8d855ef0b5de9cbcba || goto :error
 	rem Mirror of https://github.com/mstorsjo/llvm-mingw/releases/download/20201020/llvm-mingw-20201020-msvcrt-x86_64.zip
 	call :download llvm-mingw-msvcrt.zip https://download.wireguard.com/windows-toolchain/distfiles/llvm-mingw-20201020-msvcrt-x86_64.zip 2e46593245090df96d15e360e092f0b62b97e93866e0162dca7f93b16722b844 || goto :error
 	call :download wintun.zip https://www.wintun.net/builds/wintun-0.12.zip eba90e26686ed86595ae0a6d4d3f4f022924b1758f5148a32a91c60cc6e604df || goto :error


### PR DESCRIPTION
## Description
During the conversion to CMake, we began relying on the environment's golang version when building `tunnel.dll` and `balrog.dll`. This had a wonderful effect on build times, but we recently found that the resulting `balrog.dll` seems to have issues parsing certificates, and results in breakage of the update flow.

In my local builds, updating to the latest stable go1.18 seems to resolve the issue.

## Reference
Github issue #4937 ([VPN-3255](https://mozilla-hub.atlassian.net/browse/VPN-3255))

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
