### PR TITLE
Fix tab navigation glitch / VPN-2850

### DIFF
--- a/nebula/ui/components/VPNTabNavigation.qml
+++ b/nebula/ui/components/VPNTabNavigation.qml
@@ -47,7 +47,6 @@ Item {
                 id: btn
                 objectName: tabButtonId
                 height: bar.contentHeight
-                width: stack.children.length > 0 ? (bar.width / stack.children.length) : bar.width
                 onClicked: handleTabClick(btn)
 
                 background: Rectangle {
@@ -59,7 +58,7 @@ Item {
                         anchors.right: parent.right
                         anchors.bottom: parent.bottom
                         color: VPNTheme.colors.purple70
-                        opacity: btn.activeFocus ? 1 : 0
+                        opacity: btn.checked || btn.activeFocus ? 1 : 0
                         Behavior on opacity {
                             PropertyAnimation {
                                 duration: 100
@@ -81,21 +80,6 @@ Item {
                         }
                     }
                 }
-            }
-        }
-    }
-
-    Rectangle {
-        objectName: "activeTabIndicator"
-        width: (bar.visible && bar.currentItem) ? bar.currentItem.width : 0
-        height: 2
-        color: VPNTheme.colors.purple70
-        anchors.bottom: bar.bottom
-        x: (bar.visible && bar.currentItem) ? bar.currentItem.x : 0
-        visible: stack.children.length > 1
-        Behavior on x {
-            PropertyAnimation {
-                duration: 100
             }
         }
     }

--- a/nebula/ui/components/VPNTabNavigation.qml
+++ b/nebula/ui/components/VPNTabNavigation.qml
@@ -91,7 +91,7 @@ Item {
         height: 2
         color: VPNTheme.colors.purple70
         anchors.bottom: bar.bottom
-        x: (bar.visible && currentTab) ? currentTab.x - currentTab.ListView.view.originX : 0
+        x: (currentTab.x && currentTab.ListView.view.originX) ? currentTab.x - currentTab.ListView.view.originX : 0
         visible: stack.children.length > 1
         Behavior on x {
             PropertyAnimation {

--- a/nebula/ui/components/VPNTabNavigation.qml
+++ b/nebula/ui/components/VPNTabNavigation.qml
@@ -47,6 +47,7 @@ Item {
                 id: btn
                 objectName: tabButtonId
                 height: bar.contentHeight
+
                 onClicked: handleTabClick(btn)
 
                 background: Rectangle {
@@ -58,7 +59,7 @@ Item {
                         anchors.right: parent.right
                         anchors.bottom: parent.bottom
                         color: VPNTheme.colors.purple70
-                        opacity: btn.checked || btn.activeFocus ? 1 : 0
+                        opacity: btn.activeFocus ? 1 : 0
                         Behavior on opacity {
                             PropertyAnimation {
                                 duration: 100
@@ -80,6 +81,21 @@ Item {
                         }
                     }
                 }
+            }
+        }
+    }
+
+    Rectangle {
+        objectName: "activeTabIndicator"
+        width: (bar.visible && bar.currentItem) ? bar.currentItem.width : 0
+        height: 2
+        color: VPNTheme.colors.purple70
+        anchors.bottom: bar.bottom
+        x: (bar.visible && currentTab) ? currentTab.x - currentTab.ListView.view.originX : 0
+        visible: stack.children.length > 1
+        Behavior on x {
+            PropertyAnimation {
+                duration: 100
             }
         }
     }


### PR DESCRIPTION
## Description

This fixes the glitch in `VPNTabNavigation` when the `currentItem` changes, which was caused by explicitly assigning a `width` to tab buttons. There is a trade-off: It also removes the sliding "active tab" indicator. This is because the sliding indicator relied on the `x` value of the tab buttons, which becomes a rubbish value when the tab button `width` is not explicitly set. If we feel strongly about the sliding indicator I am happy to open a ticket to re-implement.

https://user-images.githubusercontent.com/22355127/203120760-be36d138-5d4c-4f6b-ba29-719ef5c0d973.mov


## Reference

VPN-2850

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
