### PR TITLE
feedback form: Open thank you view before app store review

### DIFF
--- a/src/ui/screens/getHelp/giveFeedback/ViewGiveFeedbackReview.qml
+++ b/src/ui/screens/getHelp/giveFeedback/ViewGiveFeedbackReview.qml
@@ -45,8 +45,8 @@ ColumnLayout {
 
         text: VPNl18n.FeedbackFormLeaveReviewButton
         onClicked: {
+            getHelpStackView.push("qrc:/ui/screens/getHelp/giveFeedback/ViewGiveFeedbackThankYou.qml", StackView.Immediate);
             VPN.openAppStoreReviewLink();
-            getHelpStackView.push("qrc:/ui/screens/getHelp/giveFeedback/ViewGiveFeedbackThankYou.qml");
         }
     }
 


### PR DESCRIPTION
## Description
This changes the give feedback flow to transition first to "Thank you" view before opening the app store after clicking the "Leave a Review" button. 

## Reference
VPN-3031

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
