### PR TITLE
Disable "Add application" button when vpn is on

### DIFF
--- a/src/ui/screens/settings/appPermissions/AppPermissionsList.qml
+++ b/src/ui/screens/settings/appPermissions/AppPermissionsList.qml
@@ -155,6 +155,7 @@ ColumnLayout {
         width: undefined
         onClicked: VPNAppPermissions.openFilePicker()
         visible: Qt.platform.os === "windows"
+        enabled: vpnIsOff
         contentItem: Text {
             // for accessibility
             text: addApplication


### PR DESCRIPTION
## Description

- Addition to #4967 to also disable the "Add application" button in the App Permissions list

## Reference

[VPN-2947: “Add application” button from App permissions screen is active while the VPN is ON](https://mozilla-hub.atlassian.net/browse/VPN-2947)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
