### PR TITLE
Custom code to retrieve the iOS language - VPN-3336

### DIFF
--- a/src/addons/addon.cpp
+++ b/src/addons/addon.cpp
@@ -438,17 +438,12 @@ void Addon::retranslate() {
   SettingsHolder* settingsHolder = SettingsHolder::instance();
   Q_ASSERT(settingsHolder);
 
-  QString code = settingsHolder->languageCode();
-
-  QLocale locale = QLocale(code);
-  if (code.isEmpty()) {
-    locale = QLocale(Localizer::systemLanguageCode());
-  }
+  QLocale locale = Localizer::instance()->locale();
 
   if (!m_translator.load(
           locale, "locale", "_",
           QFileInfo(m_manifestFileName).dir().filePath("i18n"))) {
-    logger.error() << "Loading the locale failed. - code:" << code;
+    logger.error() << "Loading the locale failed.";
   }
 
   emit retranslationCompleted();

--- a/src/addons/conditionwatchers/addonconditionwatcherlocales.cpp
+++ b/src/addons/conditionwatchers/addonconditionwatcherlocales.cpp
@@ -39,13 +39,8 @@ AddonConditionWatcherLocales::~AddonConditionWatcherLocales() {
 }
 
 bool AddonConditionWatcherLocales::conditionApplied() const {
-  QString code = SettingsHolder::instance()->languageCode();
-  if (code.isEmpty()) {
-    code = Localizer::systemLanguageCode();
-    if (code.isEmpty()) {
-      code = "en";
-    }
-  }
+  QString code = Localizer::instance()->languageCodeOrSystem();
+  Q_ASSERT(!code.isEmpty());
 
   code = Localizer::majorLanguageCode(code);
   return m_locales.contains(code.toLower());

--- a/src/collator.cpp
+++ b/src/collator.cpp
@@ -29,10 +29,8 @@ int Collator::compare(const QString& a, const QString& b) {
 #elif defined(MVPN_WASM)
   // For WASM, we have a similar issue (no ICU). Let's use the JS API to sort
   // strings.
-  QString languageCode = SettingsHolder::instance()->languageCode();
-  if (languageCode.isEmpty()) {
-    languageCode = Localizer::systemLanguageCode();
-  }
+  QString languageCode = Localizer::instance()->languageCodeOrSystem();
+  Q_ASSERT(!languageCode.isEmpty());
 
   return vpnWasmCompareString(a.toLocal8Bit().constData(),
                               b.toLocal8Bit().constData(),

--- a/src/localizer.h
+++ b/src/localizer.h
@@ -22,6 +22,8 @@ class Localizer final : public QAbstractListModel {
 
   struct Language {
     QString m_code;
+    QString m_languageCode;
+    QString m_countryCode;
     QString m_name;
     QString m_localizedName;
   };
@@ -33,8 +35,6 @@ class Localizer final : public QAbstractListModel {
     CodeRole,
   };
 
-  static QString systemLanguageCode();
-
   static Localizer* instance();
 
   Localizer();
@@ -42,7 +42,11 @@ class Localizer final : public QAbstractListModel {
 
   void initialize();
 
-  bool hasLanguages() const { return m_languages.length() > 1; }
+  bool hasLanguages() const { return !m_languages.isEmpty(); }
+
+  // This returns the language code from the settings, and, if it's null, it
+  // returns the system language code.
+  QString languageCodeOrSystem() const;
 
   QStringList languages() const;
 
@@ -56,6 +60,11 @@ class Localizer final : public QAbstractListModel {
   QLocale locale() const { return m_locale; }
 
   bool isRightToLeft() const;
+
+  static QList<QPair<QString, QString>> parseBCP47Languages(
+      const QStringList& languages);
+  static QList<QPair<QString, QString>> parseIOSLanguages(
+      const QStringList& languages);
 
   // QAbstractListModel methods
 
@@ -74,7 +83,12 @@ class Localizer final : public QAbstractListModel {
   static bool languageSort(const Language& a, const Language& b,
                            Collator* collator);
 
+  QString systemLanguageCode() const;
+
+  void loadLanguagesFromI18n();
   bool loadLanguage(const QString& code);
+  QString findLanguageCode(const QString& languageCode,
+                           const QString& countryCode) const;
 
   // This method is not used. It exists just to add the installer strings into
   // the QT language files.

--- a/src/platforms/ios/iosutils.h
+++ b/src/platforms/ios/iosutils.h
@@ -25,6 +25,8 @@ class IOSUtils final {
 
   static bool verifySignature(const QByteArray& publicKey, const QByteArray& content,
                               const QByteArray& signature);
+
+  static QStringList systemLanguageCodes();
 };
 
 #endif  // IOSUTILS_H

--- a/src/platforms/ios/iosutils.mm
+++ b/src/platforms/ios/iosutils.mm
@@ -149,3 +149,14 @@ bool IOSUtils::verifySignature(const QByteArray& publicKey, const QByteArray& co
   logger.warning() << "Signature verification failed";
   return false;
 }
+
+// static
+QStringList IOSUtils::systemLanguageCodes() {
+  NSArray<NSString*>* languages = [NSLocale preferredLanguages];
+
+  QStringList codes;
+  for (NSString* language in languages) {
+    codes.append(QString::fromNSString(language));
+  }
+  return codes;
+}

--- a/tests/unit/testaddon.cpp
+++ b/tests/unit/testaddon.cpp
@@ -281,6 +281,7 @@ void TestAddon::conditionWatcher_javascript() {
 
 void TestAddon::conditionWatcher_locale() {
   SettingsHolder settingsHolder;
+  Localizer l;
 
   QObject parent;
 
@@ -852,6 +853,7 @@ void TestAddon::message_load_state() {
 
 void TestAddon::message_notification_data() {
   SettingsHolder settingsHolder;
+  Localizer l;
 
   QObject parent;
   SystemTrayNotificationHandler nh(&parent);
@@ -1072,6 +1074,7 @@ void TestAddon::message_date() {
 
 void TestAddon::message_dismiss() {
   SettingsHolder settingsHolder;
+  Localizer l;
 
   QJsonObject messageObj;
   messageObj["id"] = "foo";

--- a/tests/unit/testlocalizer.cpp
+++ b/tests/unit/testlocalizer.cpp
@@ -30,16 +30,17 @@ void TestLocalizer::systemLanguage() {
 
   settings.setLanguageCode("");
   QCOMPARE(settings.languageCode(), "");
+  QCOMPARE(l.languageCodeOrSystem(), "en");
 
   settings.setLanguageCode("en");
   QCOMPARE(settings.languageCode(), "en");
   QVERIFY(!settings.previousLanguageCode().isEmpty());
+  QCOMPARE(l.languageCodeOrSystem(), "en");
 
   settings.setLanguageCode("");
   QCOMPARE(settings.languageCode(), "");
   QCOMPARE(settings.previousLanguageCode(), "en");
-
-  QVERIFY(!Localizer::systemLanguageCode().isEmpty());
+  QCOMPARE(l.languageCodeOrSystem(), "en");
 }
 
 void TestLocalizer::localizeCurrency() {
@@ -66,6 +67,104 @@ void TestLocalizer::majorLanguageCode() {
   QCOMPARE(Localizer::majorLanguageCode("fo"), "fo");
   QCOMPARE(Localizer::majorLanguageCode("fo-BA"), "fo");
   QCOMPARE(Localizer::majorLanguageCode("fo_BA"), "fo");
+}
+
+// QFETCH fails with double templates. Let's use a typedef to make it happy.
+typedef QList<QPair<QString, QString>> LanguageList;
+
+void TestLocalizer::parseBCP47Languages_data() {
+  QTest::addColumn<QStringList>("input");
+  QTest::addColumn<LanguageList>("output");
+
+  QTest::addRow("empty") << QStringList() << QList<QPair<QString, QString>>();
+
+  {
+    LanguageList a;
+    a.append(QPair<QString, QString>{"aa", ""});
+    QTest::addRow("simple") << QStringList("aa") << a;
+  }
+
+  {
+    LanguageList a;
+    a.append(QPair<QString, QString>{"aa", "bb"});
+    QTest::addRow("language-country") << QStringList("aa-bb") << a;
+  }
+  {
+    LanguageList a;
+    a.append(QPair<QString, QString>{"aa", ""});
+    QTest::addRow("language-extension") << QStringList("aa-ccc") << a;
+  }
+  {
+    LanguageList a;
+    a.append(QPair<QString, QString>{"aa", "bb"});
+    QTest::addRow("language-extension-country")
+        << QStringList("aa-ccc-bb") << a;
+  }
+  {
+    LanguageList a;
+    a.append(QPair<QString, QString>{"aa", "bb"});
+    QTest::addRow("language-extension2-country")
+        << QStringList("aa-ccc--dd-bb") << a;
+  }
+}
+
+void TestLocalizer::parseBCP47Languages() {
+  QFETCH(QStringList, input);
+  QFETCH(LanguageList, output);
+
+  QList<QPair<QString, QString>> list = Localizer::parseBCP47Languages(input);
+  QCOMPARE(list.length(), output.length());
+
+  for (int i = 0; i < list.length(); ++i) {
+    const QPair<QString, QString>& a = list[i];
+    const QPair<QString, QString>& b = output[i];
+    QCOMPARE(a.first, b.first);
+    QCOMPARE(a.second, b.second);
+  }
+}
+
+void TestLocalizer::parseIOSLanguages_data() {
+  QTest::addColumn<QStringList>("input");
+  QTest::addColumn<LanguageList>("output");
+
+  QTest::addRow("empty") << QStringList() << QList<QPair<QString, QString>>();
+
+  {
+    LanguageList a;
+    a.append(QPair<QString, QString>{"aa", ""});
+    QTest::addRow("simple") << QStringList("aa") << a;
+  }
+
+  {
+    LanguageList a;
+    a.append(QPair<QString, QString>{"aa", "bb"});
+    QTest::addRow("language_country") << QStringList("aa_bb") << a;
+  }
+  {
+    LanguageList a;
+    a.append(QPair<QString, QString>{"aa", ""});
+    QTest::addRow("language-script") << QStringList("aa-cc") << a;
+  }
+  {
+    LanguageList a;
+    a.append(QPair<QString, QString>{"aa", "bb"});
+    QTest::addRow("language-script_country") << QStringList("aa-cc_bb") << a;
+  }
+}
+
+void TestLocalizer::parseIOSLanguages() {
+  QFETCH(QStringList, input);
+  QFETCH(LanguageList, output);
+
+  QList<QPair<QString, QString>> list = Localizer::parseIOSLanguages(input);
+  QCOMPARE(list.length(), output.length());
+
+  for (int i = 0; i < list.length(); ++i) {
+    const QPair<QString, QString>& a = list[i];
+    const QPair<QString, QString>& b = output[i];
+    QCOMPARE(a.first, b.first);
+    QCOMPARE(a.second, b.second);
+  }
 }
 
 static TestLocalizer s_testLocalizer;

--- a/tests/unit/testlocalizer.h
+++ b/tests/unit/testlocalizer.h
@@ -15,4 +15,10 @@ class TestLocalizer final : public TestHelper {
   void localizeCurrency();
 
   void majorLanguageCode();
+
+  void parseBCP47Languages_data();
+  void parseBCP47Languages();
+
+  void parseIOSLanguages_data();
+  void parseIOSLanguages();
 };


### PR DESCRIPTION
In theory QLocale::system()::uiLanguages() should return the list of ui-languages sorted. But, for some languages (es), on IOS, en-US is on top of the list even when it should not be.