### PR TITLE
Android: Do not link against libs we are not using

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,7 +87,8 @@ find_package(Qt6 COMPONENTS
     Widgets
     Xml
 )
-if(NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Emscripten")
+if(NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Emscripten" AND 
+   NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Android")
     find_package(Qt6 COMPONENTS
         NetworkAuth
         Sql

--- a/glean/CMakeLists.txt
+++ b/glean/CMakeLists.txt
@@ -7,7 +7,8 @@ add_library(glean STATIC)
 set_target_properties(glean PROPERTIES FOLDER "Libs")
 target_link_libraries(glean PRIVATE Qt6::Core Qt6::Qml)
 
-if(NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Emscripten")
+if( NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Emscripten" AND 
+    NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Android" )
     target_link_libraries(glean PRIVATE Qt6::Sql)
 endif()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,7 +22,8 @@ target_link_libraries(mozillavpn PRIVATE
     Qt6::Widgets
 )
 
-if(NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Emscripten")
+if(NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Emscripten" 
+   AND NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Android" )
     target_link_libraries(mozillavpn PRIVATE
         Qt6::NetworkAuth
     )


### PR DESCRIPTION
This seems to confuse qml-importscanner, as it's omitting those libs. However DLopen will still be looking for them - therefore we can crash here.