### PR TITLE
Pass sentry info in android release builds

### DIFF
--- a/scripts/android/cmake.sh
+++ b/scripts/android/cmake.sh
@@ -20,7 +20,7 @@ export ARCH="arm64-v8a"
 
 helpFunction() {
   print G "Usage:"
-  print N "\t$0 <path to QT> [-d|--debug] [-j|--jobs <jobs>] [-a|--adjusttoken <adjust_token>]  [-A | --arch] architectures to build"
+  print N "\t$0 <path to QT> [-d|--debug] [-j|--jobs <jobs>] [-a|--adjusttoken <adjust_token>]  [-A | --arch <architectures to build>] [--sentrydsn <dsn>] [--sentryendpoint <endpoint>]"
   print N ""
   print N "By default, the android build is compiled in release mode. Use -d or --debug for a debug build."
   print N ""
@@ -53,6 +53,16 @@ while [[ $# -gt 0 ]]; do
     ;;
   -d | --debug)
     RELEASE=
+    shift
+    ;;
+  --sentrydsn)
+    SENTRY_DSN="$2"
+    shift
+    shift
+    ;;
+  --sentryendpoint)
+    SENTRY_ENVELOPE_ENDPOINT="$2"
+    shift
     shift
     ;;
   -h | --help)

--- a/taskcluster/scripts/build/android_build_release.sh
+++ b/taskcluster/scripts/build/android_build_release.sh
@@ -16,6 +16,8 @@ echo "Importing translations"
 # Get Secrets for building
 echo "Fetching Tokens!"
 ./taskcluster/scripts/get-secret.py -s project/mozillavpn/tokens -k adjust -f adjust_token
+./taskcluster/scripts/get-secret.py -s project/mozillavpn/tokens -k sentry_dsn -f sentry_dsn
+./taskcluster/scripts/get-secret.py -s project/mozillavpn/tokens -k sentry_envelope_endpoint -f sentry_envelope_endpoint
 
 # Artifacts should be placed here!
 mkdir -p /builds/worker/artifacts/
@@ -27,7 +29,7 @@ mkdir -p /builds/worker/artifacts/
 # aqt-name "arm64_v8a"   -> qmake-name: "arm64-v8a"
 # aqt-name "x86"         -> qmake-name: "x86"
 # aqt-name "x86_64"      -> qmake-name: "x86_64"
-./scripts/android/cmake.sh $QTPATH -A $1 -a $(cat adjust_token)
+./scripts/android/cmake.sh $QTPATH -A $1 -a $(cat adjust_token) --sentrydsn $(cat sentry_dsn) --sentryendpoint $(cat sentry_envelope_endpoint)
 
 # Artifacts should be placed here!
 mkdir -p /builds/worker/artifacts/


### PR DESCRIPTION
We now have a vpn-sentry project. It's url / key are secret so let's get those from taskcluster :) 