### PR TITLE
Sentry: Auto Upload debug symbols for level-3 commits

### DIFF
--- a/taskcluster/docker/android-qt6-build/Dockerfile
+++ b/taskcluster/docker/android-qt6-build/Dockerfile
@@ -18,6 +18,7 @@ ARG NDK_FILE=${NDK_VERSION}-linux.zip
 ARG QT_VERSION=6.2.1
 ARG CMAKE_VERSION=3.22.1
 ARG ANDROID_ARCH=android_armv7
+ARG SENTRY_CLI_VERSION="2.9.0"
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get -q update &&\
@@ -35,6 +36,7 @@ RUN apt-get -q update &&\
     python3 -m pip install aqtinstall
 RUN wget https://sh.rustup.rs && CARGO_HOME=/opt/.cargo sh index.html -y &&\
     /opt/.cargo/bin/rustup target add x86_64-linux-android i686-linux-android armv7-linux-androideabi aarch64-linux-android
+RUN curl -sL https://sentry.io/get-cli/ | SENTRY_CLI_VERSION=${SENTRY_CLI_VERSION} bash
 RUN python3 -m aqt install-qt --outputdir /opt linux desktop ${QT_VERSION} gcc_64
 RUN python3 -m aqt install-qt --outputdir /opt linux android ${QT_VERSION} ${ANDROID_ARCH} -m all &&\
     #Download Additional stuff that is not in a repo

--- a/taskcluster/scripts/build/android_build_release.sh
+++ b/taskcluster/scripts/build/android_build_release.sh
@@ -18,6 +18,7 @@ echo "Fetching Tokens!"
 ./taskcluster/scripts/get-secret.py -s project/mozillavpn/tokens -k adjust -f adjust_token
 ./taskcluster/scripts/get-secret.py -s project/mozillavpn/tokens -k sentry_dsn -f sentry_dsn
 ./taskcluster/scripts/get-secret.py -s project/mozillavpn/tokens -k sentry_envelope_endpoint -f sentry_envelope_endpoint
+./taskcluster/scripts/get-secret.py -s project/mozillavpn/tokens -k sentry_debug_file_upload_key -f sentry_debug_file_upload_key
 
 # Artifacts should be placed here!
 mkdir -p /builds/worker/artifacts/
@@ -30,6 +31,12 @@ mkdir -p /builds/worker/artifacts/
 # aqt-name "x86"         -> qmake-name: "x86"
 # aqt-name "x86_64"      -> qmake-name: "x86_64"
 ./scripts/android/cmake.sh $QTPATH -A $1 -a $(cat adjust_token) --sentrydsn $(cat sentry_dsn) --sentryendpoint $(cat sentry_envelope_endpoint)
+
+
+sentry-cli login --auth-token $(cat sentry_debug_file_upload_key)
+# This will ask sentry to scan all files in there and upload 
+# missing debug info, for symbolification
+sentry-cli debug-files upload --org mozilla -p vpn-client .tmp/src/android-build/build/intermediates/merged_native_libs
 
 # Artifacts should be placed here!
 mkdir -p /builds/worker/artifacts/


### PR DESCRIPTION
For sentry to properly work with the stack-traces we need it to give the debug symbols. This pr's inits the sentry-cli and will upload missing info on any level-3 (main, releases) commit.