### PR TITLE
Add tooltip to password input eye icon

### DIFF
--- a/nebula/ui/components/forms/VPNPasswordInput.qml
+++ b/nebula/ui/components/forms/VPNPasswordInput.qml
@@ -32,8 +32,9 @@ VPNTextField {
     VPNIconButton {
         id: toggleButton
 
-        // TODO: Add accesibleName string
-        accessibleName: ""
+        accessibleName: passwordInput.charactersMasked
+                        ? VPNl18n.InAppAuthShowPassword
+                        : VPNl18n.InAppAuthHidePassword
         anchors {
             right: parent.right
             rightMargin: VPNTheme.theme.listSpacing / 2

--- a/translations/strings.yaml
+++ b/translations/strings.yaml
@@ -467,6 +467,12 @@ inAppAuth:
   passwordHintCommonPassword:
     value: Must not be a common password
     comment: This is a hint for the user - password they provide must not be a common password. Ex. password.
+  showPassword:
+    value: Show password
+    comment: Tooltip label for the eye icon in password input
+  hidePassword:
+    value: Hide password
+    comment: Tooltip label for the eye icon in password input
   productUpdateOptInDescription:
     value: I’d like to receive product update emails from Firefox.
     comment: Checkbox label for users to opt in, when creating an account, to receive product update emails from Firefox.


### PR DESCRIPTION
## Description

This adds tooltip labels to the password input

<table>
<tr>
<td>

<img width="371" alt="Screen Shot 2022-11-23 at 5 17 26 PM" src="https://user-images.githubusercontent.com/22355127/203609265-547d0e7d-0a10-4e72-b41a-85e81563b34b.png">
</td>
<td>

<img width="346" alt="Screen Shot 2022-11-23 at 5 17 20 PM" src="https://user-images.githubusercontent.com/22355127/203609122-9fd44730-983a-4ff1-9d1c-fcc4cd4898c8.png">
</td>
</tr>
</table>

## Reference

Fixes #5013 / VPN-3341
## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
