### PR TITLE
Totp error code should be treated correctly - VPN-3340

### DIFF
--- a/src/authenticationinapp/authenticationinappsession.cpp
+++ b/src/authenticationinapp/authenticationinappsession.cpp
@@ -732,6 +732,18 @@ void AuthenticationInAppSession::processErrorObject(const QJsonObject& obj) {
 
       if (keys.contains("code")) {
         AuthenticationInApp* aia = AuthenticationInApp::instance();
+        // Code invalid can be received both in totp and in email verification
+        // steps. We need to check the current step in order to send the correct
+        // message.
+        if (aia->state() ==
+            AuthenticationInApp::StateVerifyingSessionTotpCode) {
+          aia->requestState(
+              AuthenticationInApp::StateVerificationSessionByTotpNeeded, this);
+          aia->requestErrorPropagation(
+              this, AuthenticationInApp::ErrorInvalidTotpCode);
+          return;
+        }
+
         aia->requestState(
             AuthenticationInApp::StateVerificationSessionByEmailNeeded, this);
         aia->requestErrorPropagation(

--- a/tests/auth/testsignupandin.cpp
+++ b/tests/auth/testsignupandin.cpp
@@ -440,33 +440,8 @@ void TestSignUpAndIn::waitForTotpCodes() {
   connect(aia, &AuthenticationInApp::errorOccurred, aia,
           [this](AuthenticationInApp::ErrorType error, uint32_t) {
             if (error == AuthenticationInApp::ErrorInvalidTotpCode) {
-              qDebug() << "Invalid code. Let's send the right one";
-
-              AuthenticationInApp* aia = AuthenticationInApp::instance();
-              QCOMPARE(
-                  aia->state(),
-                  AuthenticationInApp::StateVerificationSessionByTotpNeeded);
-
-              QString otp;
-              {
-                QProcess process;
-                process.start("python3",
-                              QStringList{"-m", "oathtool", m_totpSecret});
-                QVERIFY(process.waitForStarted());
-
-                process.closeWriteChannel();
-                QVERIFY(process.waitForFinished());
-                QCOMPARE(process.exitStatus(), QProcess::NormalExit);
-                QCOMPARE(process.exitCode(), 0);
-
-                otp = process.readAll().trimmed();
-              }
-
-              qDebug() << "Code:" << otp;
-              aia->verifySessionTotpCode(otp);
-              QCOMPARE(aia->state(),
-                       AuthenticationInApp::StateVerifyingSessionTotpCode);
-              m_sendWrongTotpCode = true;
+              qDebug() << "Invalid code. Current state:" << m_sendTotpCodeState;
+              sendNextTotpCode();
             }
           });
 
@@ -481,18 +456,69 @@ void TestSignUpAndIn::waitForTotpCodes() {
 
   connect(aia, &AuthenticationInApp::stateChanged, aia, [this]() {
     AuthenticationInApp* aia = AuthenticationInApp::instance();
-    qDebug() << "Send wrong code:" << m_sendWrongTotpCode;
+    qDebug() << "Send wrong code:" << m_sendTotpCodeState;
 
-    if (m_sendWrongTotpCode &&
+    if (m_sendTotpCodeState == NoCodeSent &&
         aia->state() ==
             AuthenticationInApp::StateVerificationSessionByTotpNeeded) {
-      m_sendWrongTotpCode = false;
-      qDebug() << "Code required. Let's write a wrong code first.";
-      aia->verifySessionTotpCode("123456");
-      QCOMPARE(aia->state(),
-               AuthenticationInApp::StateVerifyingSessionTotpCode);
+      sendNextTotpCode();
     }
   });
+}
+
+void TestSignUpAndIn::sendNextTotpCode() {
+  AuthenticationInApp* aia = AuthenticationInApp::instance();
+  QCOMPARE(aia->state(),
+           AuthenticationInApp::StateVerificationSessionByTotpNeeded);
+
+  Q_ASSERT(m_sendTotpCodeState < GoodTotpCode);
+  m_sendTotpCodeState = static_cast<SendTotpCodeState>(m_sendTotpCodeState + 1);
+  switch (m_sendTotpCodeState) {
+    case SendWrongTotpCodeNumber:
+      qDebug() << "Code required. Let's write a wrong code first (numeric).";
+      aia->verifySessionTotpCode("123456");
+      break;
+
+    case SendWrongTotpCodeString:
+      qDebug() << "Code required. Let's write a wrong code first (string).";
+      aia->verifySessionTotpCode("aabbcc");
+      break;
+
+    case SendWrongTotpCodeAlphaNumeric:
+      qDebug()
+          << "Code required. Let's write a wrong code first (alphanmeric).";
+      aia->verifySessionTotpCode("12345a");
+      break;
+
+    case GoodTotpCode: {
+      QString otp;
+      {
+        QProcess process;
+        process.start("python3", QStringList{"-m", "oathtool", m_totpSecret});
+        QVERIFY(process.waitForStarted());
+
+        process.closeWriteChannel();
+        QVERIFY(process.waitForFinished());
+        QCOMPARE(process.exitStatus(), QProcess::NormalExit);
+        QCOMPARE(process.exitCode(), 0);
+
+        otp = process.readAll().trimmed();
+      }
+
+      qDebug() << "Code required. Let's write a good code:" << otp;
+      aia->verifySessionTotpCode(otp);
+    }
+
+      // Let's reset the state for the next cycle.
+      m_sendTotpCodeState = NoCodeSent;
+      break;
+
+    default:
+      Q_ASSERT(false);
+      break;
+  }
+
+  QCOMPARE(aia->state(), AuthenticationInApp::StateVerifyingSessionTotpCode);
 }
 
 QString TestSignUpAndIn::fetchCode(const QString& code) {

--- a/tests/auth/testsignupandin.h
+++ b/tests/auth/testsignupandin.h
@@ -8,6 +8,17 @@ class TestSignUpAndIn final : public QObject {
   Q_OBJECT
 
  public:
+  // We want to send the wrong totp code a few times using strings, numbers,
+  // etc. at the first StateVerificationSessionByTotpNeeded state change.
+  enum SendTotpCodeState {
+    NoCodeSent = 0,
+    SendWrongTotpCodeNumber,
+    SendWrongTotpCodeString,
+    SendWrongTotpCodeAlphaNumeric,
+    GoodTotpCode,
+  };
+  Q_ENUM(SendTotpCodeState);
+
   TestSignUpAndIn(const QString& pattern, bool totpCreation = false);
   ~TestSignUpAndIn() = default;
 
@@ -24,13 +35,12 @@ class TestSignUpAndIn final : public QObject {
   QString fetchCode(const QString& code);
   void waitForTotpCodes();
   void fetchAndSendUnblockCode();
+  void sendNextTotpCode();
 
   QString m_emailAccount;
   bool m_totpCreation = false;
 
-  // We want to send the wrong totp code only once. At the first
-  // StateVerificationSessionByTotpNeeded state change.
-  bool m_sendWrongTotpCode = true;
+  SendTotpCodeState m_sendTotpCodeState = NoCodeSent;
 
   QString m_totpSecret;
 };


### PR DESCRIPTION
We were treating the `code` error message as a verification email step instead of a totp.