### PR TITLE
Server data via settings

### DIFF
--- a/addons/tutorial_03_multi_hop/manifest.json
+++ b/addons/tutorial_03_multi_hop/manifest.json
@@ -10,6 +10,7 @@
     "id": "03_multi_hop",
     "image": "qrc:/addons/tutorial_03_multi_hop/image.svg",
     "title": "Using multi-hop VPN",
+    "settings_rollback_needed": true,
     "subtitle": "Follow this walkthrough to learn how to use multi-hop VPN.",
     "completion_message": "You’ve turned on multi-hop VPN and changed your exit location. Would you like to see more tips and tricks?",
     "steps": [

--- a/nebula/ui/components/VPNControllerView.qml
+++ b/nebula/ui/components/VPNControllerView.qml
@@ -358,7 +358,7 @@ Item {
                 target: logoSubtitle
                 //% "From %1 to %2"
                 //: Switches from location 1 to location 2
-                text: qsTrId("vpn.controller.switchingDetail").arg(VPNController.currentLocalizedCityName).arg(VPNController.switchingLocalizedCityName)
+                text: qsTrId("vpn.controller.switchingDetail").arg(VPNCurrentServer.localizedPreviousExitCityName).arg(VPNCurrentServer.localizedCityName)
                 color: "#FFFFFF"
                 opacity: 0.8
                 visible: true

--- a/nebula/ui/components/VPNRecentConnections.qml
+++ b/nebula/ui/components/VPNRecentConnections.qml
@@ -123,10 +123,10 @@ ColumnLayout {
                     popStack();
 
                     if (modelData.isMultiHop) {
-                        return VPNController.changeServer(modelData.connection[1].countryCode, modelData.connection[1].serverCityName, modelData.connection[0].countryCode, modelData.connection[0].serverCityName)
+                        return VPNCurrentServer.changeServer(modelData.connection[1].countryCode, modelData.connection[1].serverCityName, modelData.connection[0].countryCode, modelData.connection[0].serverCityName)
                     }
 
-                    return VPNController.changeServer(modelData.connection[0].countryCode, modelData.connection[0].serverCityName)
+                    return VPNCurrentServer.changeServer(modelData.connection[0].countryCode, modelData.connection[0].serverCityName)
 
                 }
 

--- a/nebula/ui/components/VPNServerList.qml
+++ b/nebula/ui/components/VPNServerList.qml
@@ -70,7 +70,7 @@ FocusScope {
 
     function setSelectedServer(countryCode, cityName, localizedCityName) {
         if (currentServer.whichHop === "singleHopServer") {
-            VPNController.changeServer(countryCode, cityName);
+            VPNCurrentServer.changeServer(countryCode, cityName);
             stackview.pop();
             return;
         }

--- a/src/commands/commandselect.cpp
+++ b/src/commands/commandselect.cpp
@@ -56,8 +56,8 @@ int CommandSelect::run(QStringList& tokens) {
       return 1;
     }
 
-    vpn.changeServer(exitCountryCode, exitCityName, entryCountryCode,
-                     entryCityName);
+    vpn.currentServer()->changeServer(exitCountryCode, exitCityName,
+                                      entryCountryCode, entryCityName);
     return 0;
   });
 }

--- a/src/commands/commandselect.h
+++ b/src/commands/commandselect.h
@@ -7,8 +7,6 @@
 
 #include "command.h"
 
-class ServerData;
-
 class CommandSelect final : public Command {
  public:
   explicit CommandSelect(QObject* parent);

--- a/src/commands/commandstatus.cpp
+++ b/src/commands/commandstatus.cpp
@@ -102,12 +102,12 @@ int CommandStatus::run(QStringList& tokens) {
 
     ServerCountryModel* model = vpn.serverCountryModel();
     ServerData* sd = vpn.currentServer();
-    if (sd) {
-      stream << "Server country code: " << sd->exitCountryCode() << Qt::endl;
-      stream << "Server country: " << model->countryName(sd->exitCountryCode())
-             << Qt::endl;
-      stream << "Server city: " << sd->exitCityName() << Qt::endl;
-    }
+    Q_ASSERT(sd);
+
+    stream << "Server country code: " << sd->exitCountryCode() << Qt::endl;
+    stream << "Server country: " << model->countryName(sd->exitCountryCode())
+           << Qt::endl;
+    stream << "Server city: " << sd->exitCityName() << Qt::endl;
 
     Controller controller;
 

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -231,7 +231,7 @@ void Controller::activateInternal(bool forcePort53) {
 
   // For single-hop connections, exclude the entry server
   if (!Feature::get(Feature::Feature_multiHop)->isSupported() ||
-      !vpn->multihop()) {
+      !vpn->currentServer()->multihop()) {
     exitHop.m_excludedAddresses.append(exitHop.m_server.ipv4AddrIn());
     exitHop.m_excludedAddresses.append(exitHop.m_server.ipv6AddrIn());
 

--- a/src/controller.h
+++ b/src/controller.h
@@ -52,10 +52,6 @@ class Controller final : public QObject {
  private:
   Q_PROPERTY(State state READ state NOTIFY stateChanged)
   Q_PROPERTY(qint64 time READ time NOTIFY timeChanged)
-  Q_PROPERTY(QString currentLocalizedCityName READ currentLocalizedCityName
-                 NOTIFY stateChanged)
-  Q_PROPERTY(QString switchingLocalizedCityName READ switchingLocalizedCityName
-                 NOTIFY stateChanged)
   Q_PROPERTY(
       int connectionRetry READ connectionRetry NOTIFY connectionRetryChanged);
   Q_PROPERTY(bool enableDisconnectInConfirming READ enableDisconnectInConfirming
@@ -69,17 +65,9 @@ class Controller final : public QObject {
 
   State state() const;
 
-  Q_INVOKABLE void changeServer(const QString& countryCode, const QString& city,
-                                const QString& entryCountryCode = QString(),
-                                const QString& entryCity = QString());
-
   Q_INVOKABLE void logout();
 
   qint64 time() const;
-
-  QString currentLocalizedCityName() const;
-
-  QString switchingLocalizedCityName() const;
 
   bool silentSwitchServers();
 
@@ -156,6 +144,8 @@ class Controller final : public QObject {
   void clearConnectedTime();
   void resetConnectedTime();
 
+  void serverDataChanged();
+
  private:
   State m_state = StateInitializing;
 
@@ -169,14 +159,6 @@ class Controller final : public QObject {
   bool m_ping_received = false;
 
   QScopedPointer<ControllerImpl> m_impl;
-
-  QString m_currentCountryCode;
-  QString m_currentCity;
-
-  QString m_switchingExitCountry;
-  QString m_switchingExitCity;
-  QString m_switchingEntryCountry;
-  QString m_switchingEntryCity;
 
   QTimer m_connectingTimer;
   QTimer m_handshakeTimer;

--- a/src/controller.h
+++ b/src/controller.h
@@ -90,8 +90,6 @@ class Controller final : public QObject {
 
   void backendFailure();
   void serverUnavailable();
-  void setCooldownForAllServersInACity(const QString& countryCode,
-                                       const QString& cityCode);
 
   void captivePortalPresent();
   void captivePortalGone();

--- a/src/inspector/inspectorhandler.cpp
+++ b/src/inspector/inspectorhandler.cpp
@@ -559,7 +559,7 @@ static QList<InspectorCommand> s_commands{
           QJsonObject obj;
           if (QString(arguments[1]) != "" && QString(arguments[2]) != "") {
             MozillaVPN::instance()
-                ->controller()
+                ->serverCountryModel()
                 ->setCooldownForAllServersInACity(QString(arguments[1]),
                                                   QString(arguments[2]));
           } else {

--- a/src/models/servercountry.cpp
+++ b/src/models/servercountry.cpp
@@ -78,9 +78,10 @@ bool ServerCountry::fromJson(const QJsonObject& countryObj) {
   return true;
 }
 
-const QList<QString> ServerCountry::servers(const ServerData& data) const {
+const QList<QString> ServerCountry::serversFromCityName(
+    const QString& cityName) const {
   for (const ServerCity& city : m_cities) {
-    if (city.name() == data.exitCityName()) {
+    if (city.name() == cityName) {
       return city.servers();
     }
   }

--- a/src/models/servercountry.h
+++ b/src/models/servercountry.h
@@ -10,7 +10,6 @@
 #include <QList>
 #include <QString>
 
-class ServerData;
 class QJsonObject;
 
 class ServerCountry final {
@@ -28,7 +27,7 @@ class ServerCountry final {
 
   const QList<ServerCity>& cities() const { return m_cities; }
 
-  const QList<QString> servers(const ServerData& data) const;
+  const QList<QString> serversFromCityName(const QString& cityName) const;
 
   void sortCities();
 

--- a/src/models/servercountrymodel.cpp
+++ b/src/models/servercountrymodel.cpp
@@ -4,6 +4,7 @@
 
 #include "servercountrymodel.h"
 #include "collator.h"
+#include "constants.h"
 #include "leakdetector.h"
 #include "logger.h"
 #include "models/feature.h"
@@ -334,16 +335,15 @@ void ServerCountryModel::setServerLatency(const QString& publicKey,
   }
 }
 
-void ServerCountryModel::setServerCooldown(const QString& publicKey,
-                                           unsigned int duration) {
+void ServerCountryModel::setServerCooldown(const QString& publicKey) {
   if (m_servers.contains(publicKey)) {
-    m_servers[publicKey].setCooldownTimeout(duration);
+    m_servers[publicKey].setCooldownTimeout(
+        Constants::SERVER_UNRESPONSIVE_COOLDOWN_SEC);
   }
 }
 
 void ServerCountryModel::setCooldownForAllServersInACity(
-    const QString& countryCode, const QString& cityCode,
-    unsigned int duration) {
+    const QString& countryCode, const QString& cityCode) {
   logger.debug() << "Set cooldown for all servers for: "
                  << logger.sensitive(countryCode) << logger.sensitive(cityCode);
 
@@ -352,7 +352,7 @@ void ServerCountryModel::setCooldownForAllServersInACity(
       for (const ServerCity& city : country.cities()) {
         if (city.code() == cityCode) {
           for (const QString& pubkey : city.servers()) {
-            setServerCooldown(pubkey, duration);
+            setServerCooldown(pubkey);
           }
           break;
         }

--- a/src/models/servercountrymodel.cpp
+++ b/src/models/servercountrymodel.cpp
@@ -243,27 +243,6 @@ int ServerCountryModel::cityConnectionScore(const ServerCity& city) const {
   return score;
 }
 
-bool ServerCountryModel::pickIfExists(const QString& countryCode,
-                                      const QString& cityCode,
-                                      ServerData& data) const {
-  logger.debug() << "Checking if a server exists"
-                 << logger.sensitive(countryCode) << logger.sensitive(cityCode);
-
-  for (const ServerCountry& country : m_countries) {
-    if (country.code() == countryCode) {
-      for (const ServerCity& city : country.cities()) {
-        if (city.code() == cityCode) {
-          data.update(country.code(), city.name());
-          return true;
-        }
-      }
-      break;
-    }
-  }
-
-  return false;
-}
-
 QStringList ServerCountryModel::pickRandom() {
   logger.debug() << "Choosing a random server";
 
@@ -284,48 +263,14 @@ QStringList ServerCountryModel::pickRandom() {
   return serverTuple;
 }
 
-void ServerCountryModel::pickRandom(ServerData& data) const {
-  logger.debug() << "Choosing a random server";
-
-  quint32 countryId =
-      QRandomGenerator::global()->generate() % m_countries.length();
-  const ServerCountry& country = m_countries[countryId];
-
-  quint32 cityId =
-      QRandomGenerator::global()->generate() % country.cities().length();
-  const ServerCity& city = country.cities().at(cityId);
-
-  data.update(country.code(), city.name());
-}
-
-bool ServerCountryModel::pickByIPv4Address(const QString& ipv4Address,
-                                           ServerData& data) const {
-  logger.debug() << "Choosing a server with addres:"
-                 << logger.sensitive(ipv4Address);
-
-  for (const ServerCountry& country : m_countries) {
-    for (const ServerCity& city : country.cities()) {
-      for (const QString& pubkey : city.servers()) {
-        const Server server = m_servers.value(pubkey);
-        if (server.ipv4AddrIn() == ipv4Address) {
-          data.update(country.code(), city.name());
-          return true;
-        }
-      }
-    }
-  }
-
-  return false;
-}
-
-bool ServerCountryModel::exists(ServerData& data) const {
+bool ServerCountryModel::exists(const QString& countryCode,
+                                const QString& cityName) const {
   logger.debug() << "Check if the server is still valid.";
-  Q_ASSERT(data.initialized());
 
   for (const ServerCountry& country : m_countries) {
-    if (country.code() == data.exitCountryCode()) {
+    if (country.code() == countryCode) {
       for (const ServerCity& city : country.cities()) {
-        if (data.exitCityName() == city.name()) {
+        if (cityName == city.name()) {
           return true;
         }
       }
@@ -337,12 +282,13 @@ bool ServerCountryModel::exists(ServerData& data) const {
   return false;
 }
 
-const QList<Server> ServerCountryModel::servers(const ServerData& data) const {
+const QList<Server> ServerCountryModel::servers(const QString& countryCode,
+                                                const QString& cityName) const {
   QList<Server> results;
 
   for (const ServerCountry& country : m_countries) {
-    if (country.code() == data.exitCountryCode()) {
-      for (const QString& pubkey : country.servers(data)) {
+    if (country.code() == countryCode) {
+      for (const QString& pubkey : country.serversFromCityName(cityName)) {
         if (m_servers.contains(pubkey)) {
           results.append(m_servers.value(pubkey));
         }

--- a/src/models/servercountrymodel.h
+++ b/src/models/servercountrymodel.h
@@ -60,10 +60,9 @@ class ServerCountryModel final : public QAbstractListModel {
 
   void retranslate();
   void setServerLatency(const QString& publicKey, unsigned int msec);
-  void setServerCooldown(const QString& publicKey, unsigned int duration);
+  void setServerCooldown(const QString& publicKey);
   void setCooldownForAllServersInACity(const QString& countryCode,
-                                       const QString& cityCode,
-                                       unsigned int duration);
+                                       const QString& cityCode);
 
   Q_INVOKABLE int cityConnectionScore(const QString& countryCode,
                                       const QString& cityCode) const;

--- a/src/models/servercountrymodel.h
+++ b/src/models/servercountrymodel.h
@@ -11,8 +11,6 @@
 #include <QByteArray>
 #include <QObject>
 
-class ServerData;
-
 class ServerCountryModel final : public QAbstractListModel {
   Q_OBJECT
   Q_DISABLE_COPY_MOVE(ServerCountryModel)
@@ -45,17 +43,10 @@ class ServerCountryModel final : public QAbstractListModel {
 
   Q_INVOKABLE QStringList pickRandom();
 
-  void pickRandom(ServerData& data) const;
+  bool exists(const QString& countryCode, const QString& cityName) const;
 
-  bool pickIfExists(const QString& countryCode, const QString& cityCode,
-                    ServerData& data) const;
-
-  // For windows data migration.
-  bool pickByIPv4Address(const QString& ipv4Address, ServerData& data) const;
-
-  bool exists(ServerData& data) const;
-
-  const QList<Server> servers(const ServerData& data) const;
+  const QList<Server> servers(const QString& countryCode,
+                              const QString& cityName) const;
   const QList<Server> servers() const { return m_servers.values(); };
   Server server(const QString& pubkey) const { return m_servers.value(pubkey); }
 

--- a/src/models/serverdata.cpp
+++ b/src/models/serverdata.cpp
@@ -35,35 +35,6 @@ bool ServerData::fromSettings() {
   return true;
 }
 
-bool ServerData::fromString(const QString& data) {
-  QStringList serverList = data.split("->");
-
-  QString exit = serverList.last();
-  qsizetype index = exit.lastIndexOf(',');
-  if (index < 0) {
-    return false;
-  }
-  QString exitCountryCode = exit.mid(index + 1).trimmed();
-  QString exitCityName = exit.left(index).trimmed();
-  QString entryCountryCode;
-  QString entryCityName;
-
-  if (serverList.count() > 1) {
-    QString entry = serverList.first();
-    index = entry.lastIndexOf(',');
-    if (index > 0) {
-      entryCityName = entry.left(index).trimmed();
-      entryCountryCode = entry.mid(index + 1).trimmed();
-    }
-  }
-
-  initializeInternal(exitCountryCode, exitCityName, entryCountryCode,
-                     entryCityName);
-
-  logger.debug() << toString();
-  return true;
-}
-
 void ServerData::writeSettings() {
   SettingsHolder* settingsHolder = SettingsHolder::instance();
   Q_ASSERT(settingsHolder);

--- a/src/models/serverdata.cpp
+++ b/src/models/serverdata.cpp
@@ -109,7 +109,7 @@ QString ServerData::localizedCityName() const {
   return ServerI18N::translateCityName(m_exitCountryCode, m_exitCityName);
 }
 
-QString ServerData::localizedEntryCity() const {
+QString ServerData::localizedEntryCityName() const {
   return ServerI18N::translateCityName(m_entryCountryCode, m_entryCityName);
 }
 

--- a/src/models/serverdata.cpp
+++ b/src/models/serverdata.cpp
@@ -27,11 +27,15 @@ ServerData::ServerData() { MVPN_COUNT_CTOR(ServerData); }
 ServerData::~ServerData() { MVPN_COUNT_DTOR(ServerData); }
 
 void ServerData::initialize() {
+  m_initialized = true;
+
   connect(SettingsHolder::instance(), &SettingsHolder::serverDataChanged, this,
           &ServerData::settingsChanged);
 }
 
 bool ServerData::fromSettings() {
+  Q_ASSERT(m_initialized);
+
   SettingsHolder* settingsHolder = SettingsHolder::instance();
   Q_ASSERT(settingsHolder);
 
@@ -60,6 +64,8 @@ void ServerData::update(const QString& exitCountryCode,
                         const QString& exitCityName,
                         const QString& entryCountryCode,
                         const QString& entryCityName) {
+  Q_ASSERT(m_initialized);
+
   m_previousExitCountryCode = m_exitCountryCode;
   m_previousExitCityName = m_exitCityName;
 
@@ -77,6 +83,8 @@ void ServerData::update(const QString& exitCountryCode,
 }
 
 bool ServerData::settingsChanged() {
+  Q_ASSERT(m_initialized);
+
   SettingsHolder* settingsHolder = SettingsHolder::instance();
   Q_ASSERT(settingsHolder);
 
@@ -101,20 +109,23 @@ bool ServerData::settingsChanged() {
 }
 
 QString ServerData::localizedCityName() const {
+  Q_ASSERT(m_initialized);
   return ServerI18N::translateCityName(m_exitCountryCode, m_exitCityName);
 }
 
 QString ServerData::localizedEntryCityName() const {
+  Q_ASSERT(m_initialized);
   return ServerI18N::translateCityName(m_entryCountryCode, m_entryCityName);
 }
 
 QString ServerData::localizedPreviousExitCityName() const {
+  Q_ASSERT(m_initialized);
   return ServerI18N::translateCityName(m_previousExitCountryCode,
                                        m_previousExitCityName);
 }
 
 QString ServerData::toString() const {
-  if (!initialized()) {
+  if (!hasServerData()) {
     return QString();
   }
 
@@ -158,4 +169,15 @@ void ServerData::changeServer(const QString& countryCode,
   }
   recent.prepend(description);
   SettingsHolder::instance()->setRecentConnections(recent);
+}
+
+void ServerData::forget() {
+  Q_ASSERT(m_initialized);
+
+  m_exitCountryCode.clear();
+  m_exitCityName.clear();
+  m_entryCountryCode.clear();
+  m_entryCityName.clear();
+  m_previousExitCountryCode.clear();
+  m_previousExitCityName.clear();
 }

--- a/src/models/serverdata.h
+++ b/src/models/serverdata.h
@@ -21,9 +21,17 @@ class ServerData final : public QObject {
   Q_PROPERTY(QString localizedCityName READ localizedCityName NOTIFY changed)
 
   Q_PROPERTY(bool multihop READ multihop NOTIFY changed)
+
   Q_PROPERTY(QString entryCountryCode READ entryCountryCode NOTIFY changed)
   Q_PROPERTY(QString entryCityName READ entryCityName NOTIFY changed)
   Q_PROPERTY(QString localizedEntryCity READ localizedEntryCity NOTIFY changed)
+
+  Q_PROPERTY(QString previousExitCountryCode READ previousExitCountryCode NOTIFY
+                 changed)
+  Q_PROPERTY(
+      QString previousExitCityName READ previousExitCityName NOTIFY changed)
+  Q_PROPERTY(QString localizedPreviousExitCityName READ
+                 localizedPreviousExitCityName NOTIFY changed)
 
  public:
   ServerData();
@@ -31,14 +39,17 @@ class ServerData final : public QObject {
 
   [[nodiscard]] bool fromSettings();
 
+  Q_INVOKABLE void changeServer(const QString& countryCode,
+                                const QString& cityName,
+                                const QString& entryCountryCode = QString(),
+                                const QString& entryCityName = QString());
+
   void writeSettings();
 
   bool initialized() const { return m_initialized; }
 
   const QString& exitCountryCode() const { return m_exitCountryCode; }
-
   const QString& exitCityName() const { return m_exitCityName; }
-
   QString localizedCityName() const;
 
   bool multihop() const {
@@ -46,10 +57,14 @@ class ServerData final : public QObject {
   }
 
   const QString& entryCountryCode() const { return m_entryCountryCode; }
-
   const QString& entryCityName() const { return m_entryCityName; }
-
   QString localizedEntryCity() const;
+
+  const QString& previousExitCountryCode() const {
+    return m_previousExitCountryCode;
+  }
+  const QString& previousExitCityName() const { return m_previousExitCityName; }
+  QString localizedPreviousExitCityName() const;
 
   void forget() { m_initialized = false; }
 
@@ -78,6 +93,9 @@ class ServerData final : public QObject {
 
   QString m_entryCountryCode;
   QString m_entryCityName;
+
+  QString m_previousExitCountryCode;
+  QString m_previousExitCityName;
 };
 
 #endif  // SERVERDATA_H

--- a/src/models/serverdata.h
+++ b/src/models/serverdata.h
@@ -30,7 +30,6 @@ class ServerData final : public QObject {
   ~ServerData();
 
   [[nodiscard]] bool fromSettings();
-  [[nodiscard]] bool fromString(const QString& data);
 
   void writeSettings();
 

--- a/src/models/serverdata.h
+++ b/src/models/serverdata.h
@@ -38,6 +38,8 @@ class ServerData final : public QObject {
   ServerData();
   ~ServerData();
 
+  void initialize();
+
   [[nodiscard]] bool fromSettings();
 
   Q_INVOKABLE void changeServer(const QString& countryCode,
@@ -45,9 +47,7 @@ class ServerData final : public QObject {
                                 const QString& entryCountryCode = QString(),
                                 const QString& entryCityName = QString());
 
-  void writeSettings();
-
-  bool initialized() const { return m_initialized; }
+  bool initialized() const { return !m_exitCountryCode.isEmpty(); }
 
   const QString& exitCountryCode() const { return m_exitCountryCode; }
   const QString& exitCityName() const { return m_exitCityName; }
@@ -67,7 +67,7 @@ class ServerData final : public QObject {
   const QString& previousExitCityName() const { return m_previousExitCityName; }
   QString localizedPreviousExitCityName() const;
 
-  void forget() { m_initialized = false; }
+  void forget() { m_exitCountryCode.clear(); }
 
   void update(const QString& exitCountryCode, const QString& exitCityName,
               const QString& entryCountryCode = QString(),
@@ -81,14 +81,9 @@ class ServerData final : public QObject {
   void changed();
 
  private:
-  void initializeInternal(const QString& exitCountryCode,
-                          const QString& exitCityName,
-                          const QString& entryCountryCode,
-                          const QString& entryCityName);
+  bool settingsChanged();
 
  private:
-  bool m_initialized = false;
-
   QString m_exitCountryCode;
   QString m_exitCityName;
 

--- a/src/models/serverdata.h
+++ b/src/models/serverdata.h
@@ -24,7 +24,8 @@ class ServerData final : public QObject {
 
   Q_PROPERTY(QString entryCountryCode READ entryCountryCode NOTIFY changed)
   Q_PROPERTY(QString entryCityName READ entryCityName NOTIFY changed)
-  Q_PROPERTY(QString localizedEntryCity READ localizedEntryCity NOTIFY changed)
+  Q_PROPERTY(
+      QString localizedEntryCityName READ localizedEntryCityName NOTIFY changed)
 
   Q_PROPERTY(QString previousExitCountryCode READ previousExitCountryCode NOTIFY
                  changed)
@@ -58,7 +59,7 @@ class ServerData final : public QObject {
 
   const QString& entryCountryCode() const { return m_entryCountryCode; }
   const QString& entryCityName() const { return m_entryCityName; }
-  QString localizedEntryCity() const;
+  QString localizedEntryCityName() const;
 
   const QString& previousExitCountryCode() const {
     return m_previousExitCountryCode;

--- a/src/models/serverdata.h
+++ b/src/models/serverdata.h
@@ -48,6 +48,9 @@ class ServerData final : public QObject {
                                 const QString& entryCityName = QString());
   bool hasServerData() const { return !m_exitCountryCode.isEmpty(); }
 
+  const QList<Server> exitServers() const;
+  const QList<Server> entryServers() const;
+
   const QString& exitCountryCode() const { return m_exitCountryCode; }
   const QString& exitCityName() const { return m_exitCityName; }
   QString localizedCityName() const;
@@ -76,6 +79,12 @@ class ServerData final : public QObject {
 
   void retranslate() { emit changed(); }
 
+  void setEntryServerPublicKey(const QString& publicKey);
+  void setExitServerPublicKey(const QString& publicKey);
+
+  const QString& exitServerPublicKey() const { return m_exitServerPublicKey; }
+  const QString& entryServerPublicKey() const { return m_entryServerPublicKey; }
+
  signals:
   void changed();
 
@@ -93,6 +102,9 @@ class ServerData final : public QObject {
 
   QString m_previousExitCountryCode;
   QString m_previousExitCityName;
+
+  QString m_exitServerPublicKey;
+  QString m_entryServerPublicKey;
 };
 
 #endif  // SERVERDATA_H

--- a/src/models/serverdata.h
+++ b/src/models/serverdata.h
@@ -46,8 +46,7 @@ class ServerData final : public QObject {
                                 const QString& cityName,
                                 const QString& entryCountryCode = QString(),
                                 const QString& entryCityName = QString());
-
-  bool initialized() const { return !m_exitCountryCode.isEmpty(); }
+  bool hasServerData() const { return !m_exitCountryCode.isEmpty(); }
 
   const QString& exitCountryCode() const { return m_exitCountryCode; }
   const QString& exitCityName() const { return m_exitCityName; }
@@ -67,7 +66,7 @@ class ServerData final : public QObject {
   const QString& previousExitCityName() const { return m_previousExitCityName; }
   QString localizedPreviousExitCityName() const;
 
-  void forget() { m_exitCountryCode.clear(); }
+  void forget();
 
   void update(const QString& exitCountryCode, const QString& exitCityName,
               const QString& entryCountryCode = QString(),
@@ -84,6 +83,8 @@ class ServerData final : public QObject {
   bool settingsChanged();
 
  private:
+  bool m_initialized = false;
+
   QString m_exitCountryCode;
   QString m_exitCityName;
 

--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -332,13 +332,13 @@ void MozillaVPN::initialize() {
     return;
   }
 
-  Q_ASSERT(!m_private->m_serverData.initialized());
+  Q_ASSERT(!m_private->m_serverData.hasServerData());
   if (!m_private->m_serverData.fromSettings()) {
     QStringList list = m_private->m_serverCountryModel.pickRandom();
     Q_ASSERT(list.length() >= 2);
 
     m_private->m_serverData.update(list[0], list[1]);
-    Q_ASSERT(m_private->m_serverData.initialized());
+    Q_ASSERT(m_private->m_serverData.hasServerData());
   }
 
   scheduleRefreshDataTasks(true);
@@ -413,7 +413,7 @@ void MozillaVPN::maybeStateMain() {
     return;
   }
 
-  Q_ASSERT(m_private->m_serverData.initialized());
+  Q_ASSERT(m_private->m_serverData.hasServerData());
 
   // For 2.5 we need to regenerate the device key to allow the the custom DNS
   // feature. We can do it in background when the main view is shown.
@@ -671,7 +671,7 @@ void MozillaVPN::serversFetched(const QByteArray& serverData) {
   }
 
   // The serverData could be unset or invalid with the new server list.
-  if (!m_private->m_serverData.initialized() ||
+  if (!m_private->m_serverData.hasServerData() ||
       !m_private->m_serverCountryModel.exists(
           m_private->m_serverData.exitCountryCode(),
           m_private->m_serverData.exitCityName())) {
@@ -679,7 +679,7 @@ void MozillaVPN::serversFetched(const QByteArray& serverData) {
     Q_ASSERT(list.length() >= 2);
 
     m_private->m_serverData.update(list[0], list[1]);
-    Q_ASSERT(m_private->m_serverData.initialized());
+    Q_ASSERT(m_private->m_serverData.hasServerData());
   }
 }
 

--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -930,33 +930,6 @@ const QList<Server> MozillaVPN::entryServers() const {
   return filterServerList(m_private->m_serverCountryModel.servers(sd));
 }
 
-void MozillaVPN::changeServer(const QString& countryCode, const QString& city,
-                              const QString& entryCountryCode,
-                              const QString& entryCity) {
-  m_private->m_serverData.update(countryCode, city, entryCountryCode,
-                                 entryCity);
-  m_private->m_serverData.writeSettings();
-
-  // Update the list of recent connections.
-  QString description = m_private->m_serverData.toString();
-  QStringList recent = SettingsHolder::instance()->recentConnections();
-  qsizetype index = recent.indexOf(description);
-  if (index == 0) {
-    // This is already the most-recent connection.
-    return;
-  }
-
-  if (index > 0) {
-    recent.removeAt(index);
-  } else {
-    while (recent.count() >= Constants::RECENT_CONNECTIONS_MAX_COUNT) {
-      recent.removeLast();
-    }
-  }
-  recent.prepend(description);
-  SettingsHolder::instance()->setRecentConnections(recent);
-}
-
 void MozillaVPN::postAuthenticationCompleted() {
   logger.debug() << "Post authentication completed";
 

--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -434,16 +434,6 @@ void MozillaVPN::maybeStateMain() {
 #endif
 }
 
-void MozillaVPN::setEntryServerPublicKey(const QString& publicKey) {
-  logger.debug() << "Set entry-server public key:" << logger.keys(publicKey);
-  m_entryServerPublicKey = publicKey;
-}
-
-void MozillaVPN::setExitServerPublicKey(const QString& publicKey) {
-  logger.debug() << "Set exit-server public key:" << logger.keys(publicKey);
-  m_exitServerPublicKey = publicKey;
-}
-
 void MozillaVPN::getStarted() {
   logger.debug() << "Get started";
   authenticate();
@@ -897,45 +887,6 @@ void MozillaVPN::reset(bool forceInitialState) {
   if (forceInitialState) {
     setState(StateInitialize);
   }
-}
-
-void MozillaVPN::setServerCooldown(const QString& publicKey) {
-  m_private->m_serverCountryModel.setServerCooldown(
-      publicKey, Constants::SERVER_UNRESPONSIVE_COOLDOWN_SEC);
-}
-
-void MozillaVPN::setCooldownForAllServersInACity(const QString& countryCode,
-                                                 const QString& cityCode) {
-  m_private->m_serverCountryModel.setCooldownForAllServersInACity(
-      countryCode, cityCode, Constants::SERVER_UNRESPONSIVE_COOLDOWN_SEC);
-}
-
-QList<Server> MozillaVPN::filterServerList(const QList<Server>& servers) const {
-  QList<Server> results;
-  qint64 now = QDateTime::currentSecsSinceEpoch();
-
-  for (const Server& server : servers) {
-    if (server.cooldownTimeout() <= now) {
-      results.append(server);
-    }
-  }
-
-  return results;
-}
-
-const QList<Server> MozillaVPN::exitServers() const {
-  return filterServerList(m_private->m_serverCountryModel.servers(
-      m_private->m_serverData.exitCountryCode(),
-      m_private->m_serverData.exitCityName()));
-}
-
-const QList<Server> MozillaVPN::entryServers() const {
-  if (!m_private->m_serverData.multihop()) {
-    return exitServers();
-  }
-  return filterServerList(m_private->m_serverCountryModel.servers(
-      m_private->m_serverData.entryCountryCode(),
-      m_private->m_serverData.entryCityName()));
 }
 
 void MozillaVPN::postAuthenticationCompleted() {

--- a/src/mozillavpn.h
+++ b/src/mozillavpn.h
@@ -213,10 +213,6 @@ class MozillaVPN final : public QObject {
 
   void abortAuthentication();
 
-  void changeServer(const QString& countryCode, const QString& city,
-                    const QString& entryCountryCode = QString(),
-                    const QString& entryCity = QString());
-
   void silentSwitch();
 
   static QString devVersion();

--- a/src/mozillavpn.h
+++ b/src/mozillavpn.h
@@ -105,9 +105,6 @@ class MozillaVPN final : public QObject {
 
   State state() const;
 
-  const QString& exitServerPublicKey() const { return m_exitServerPublicKey; }
-  const QString& entryServerPublicKey() const { return m_entryServerPublicKey; }
-
   bool stagingMode() const;
   bool debugMode() const;
 
@@ -207,9 +204,6 @@ class MozillaVPN final : public QObject {
 
   void accountChecked(const QByteArray& json);
 
-  const QList<Server> exitServers() const;
-  const QList<Server> entryServers() const;
-
   void abortAuthentication();
 
   void silentSwitch();
@@ -248,12 +242,6 @@ class MozillaVPN final : public QObject {
   void setUpdating(bool updating);
 
   void heartbeatCompleted(bool success);
-
-  void setEntryServerPublicKey(const QString& publicKey);
-  void setExitServerPublicKey(const QString& publicKey);
-  void setServerCooldown(const QString& publicKey);
-  void setCooldownForAllServersInACity(const QString& countryCode,
-                                       const QString& cityCode);
 
   void addCurrentDeviceAndRefreshData(bool refreshProducts);
 
@@ -305,8 +293,6 @@ class MozillaVPN final : public QObject {
   void controllerStateChanged();
 
   void maybeRegenerateDeviceKey();
-
-  QList<Server> filterServerList(const QList<Server>& servers) const;
 
   bool checkCurrentDevice();
 
@@ -376,9 +362,6 @@ class MozillaVPN final : public QObject {
   State m_state = StateInitialize;
 
   UserState m_userState = UserNotAuthenticated;
-
-  QString m_exitServerPublicKey;
-  QString m_entryServerPublicKey;
 
   QTimer m_periodicOperationsTimer;
   QTimer m_gleanTimer;

--- a/src/mozillavpn.h
+++ b/src/mozillavpn.h
@@ -209,7 +209,6 @@ class MozillaVPN final : public QObject {
 
   const QList<Server> exitServers() const;
   const QList<Server> entryServers() const;
-  bool multihop() const { return m_private->m_serverData.multihop(); }
 
   void abortAuthentication();
 

--- a/src/notificationhandler.cpp
+++ b/src/notificationhandler.cpp
@@ -113,8 +113,15 @@ void NotificationHandler::showNotification() {
           // Dont show notification if it's turned off.
           return;
         }
-        if ((m_switchingLocalizedServerCountry == localizedCountryName) &&
-            (m_switchingLocalizedServerCity == localizedCityName)) {
+
+        QString localizedPreviousExitCountryName =
+            vpn->serverCountryModel()->localizedCountryName(
+                vpn->currentServer()->previousExitCountryCode());
+        QString localizedPreviousExitCityName =
+            vpn->currentServer()->localizedPreviousExitCityName();
+
+        if ((localizedPreviousExitCountryName == localizedCountryName) &&
+            (localizedPreviousExitCityName == localizedCityName)) {
           // Don't show notifications unless the exit server changed, see:
           // https://github.com/mozilla-mobile/mozilla-vpn-client/issues/1719
           return;
@@ -126,8 +133,8 @@ void NotificationHandler::showNotification() {
         //: Shown as message body in a notification. %1 and %3 are countries, %2
         //: and %4 are cities.
         message = qtTrId("vpn.systray.statusSwtich.message")
-                      .arg(m_switchingLocalizedServerCountry,
-                           m_switchingLocalizedServerCity, localizedCountryName,
+                      .arg(localizedPreviousExitCountryName,
+                           localizedPreviousExitCityName, localizedCountryName,
                            localizedCityName);
       } else {
         if (!SettingsHolder::instance()->connectionChangeNotification()) {
@@ -164,10 +171,7 @@ void NotificationHandler::showNotification() {
 
     case Controller::StateSwitching:
       m_connected = true;
-
       m_switching = true;
-      m_switchingLocalizedServerCountry = localizedCountryName;
-      m_switchingLocalizedServerCity = localizedCityName;
       break;
 
     default:

--- a/src/notificationhandler.h
+++ b/src/notificationhandler.h
@@ -75,8 +75,6 @@ class NotificationHandler : public QObject {
   Message m_lastMessage = None;
 
  private:
-  QString m_switchingLocalizedServerCountry;
-  QString m_switchingLocalizedServerCity;
   bool m_switching = false;
 
   // We want to show a 'disconnected' notification only if we were actually

--- a/src/platforms/android/androidcontroller.cpp
+++ b/src/platforms/android/androidcontroller.cpp
@@ -161,7 +161,8 @@ void AndroidController::activate(const HopConnection& hop, const Device* device,
 
   // Find a Server as Fallback in the Same Location in case
   // the original one becomes unstable / unavailable
-  const QList<Server> serverList = MozillaVPN::instance()->exitServers();
+  const QList<Server> serverList =
+      MozillaVPN::instance()->currentServer()->exitServers();
   Server* fallbackServer = nullptr;
   foreach (auto item, serverList) {
     if (item.publicKey() != hop.m_server.publicKey()) {

--- a/src/platforms/ios/iosnetworkwatcher.mm
+++ b/src/platforms/ios/iosnetworkwatcher.mm
@@ -94,8 +94,8 @@ void IOSNetworkWatcher::controllerStateChanged() {
   auto vpn = MozillaVPN::instance();
   // When multihop is used, we need to connect to the entry server,
   // otherwise the exit server is the target
-  auto key = vpn->entryServerPublicKey();
-  auto serverlist = vpn->entryServers();
+  auto key = vpn->currentServer()->entryServerPublicKey();
+  auto serverlist = vpn->currentServer()->entryServers();
   auto index = serverlist.indexOf(key);
   // No such server
   if (index == -1) {

--- a/src/settingsholder.cpp
+++ b/src/settingsholder.cpp
@@ -119,11 +119,11 @@ SettingsHolder::~SettingsHolder() {
 void SettingsHolder::clear() {
   logger.debug() << "Clean up the settings";
 
-#define SETTING(type, toType, getter, setter, has, key, defvalue, \
-                userSettings, removeWhenReset)                    \
-  if (removeWhenReset) {                                          \
-    m_settings.remove(key);                                       \
-    emit getter##Changed();                                       \
+#define SETTING(type, toType, getter, setter, remover, has, key, defvalue, \
+                userSettings, removeWhenReset)                             \
+  if (removeWhenReset) {                                                   \
+    m_settings.remove(key);                                                \
+    emit getter##Changed();                                                \
   }
 
 #include "settingslist.h"
@@ -182,22 +182,26 @@ QString SettingsHolder::getReport() const {
   return buff;
 }
 
-#define SETTING(type, toType, getter, setter, has, key, defvalue,       \
-                userSettings, ...)                                      \
-  bool SettingsHolder::has() const { return m_settings.contains(key); } \
-  type SettingsHolder::getter() const {                                 \
-    if (!has()) {                                                       \
-      return defvalue;                                                  \
-    }                                                                   \
-    return m_settings.value(key).toType();                              \
-  }                                                                     \
-  void SettingsHolder::setter(const type& value) {                      \
-    if (!has() || getter() != value) {                                  \
-      maybeSaveInTransaction(key, getter(), value, #getter "Changed",   \
-                             userSettings);                             \
-      m_settings.setValue(key, value);                                  \
-      emit getter##Changed();                                           \
-    }                                                                   \
+#define SETTING(type, toType, getter, setter, remover, has, key, defvalue, \
+                userSettings, ...)                                         \
+  bool SettingsHolder::has() const { return m_settings.contains(key); }    \
+  type SettingsHolder::getter() const {                                    \
+    if (!has()) {                                                          \
+      return defvalue;                                                     \
+    }                                                                      \
+    return m_settings.value(key).toType();                                 \
+  }                                                                        \
+  void SettingsHolder::setter(const type& value) {                         \
+    if (!has() || getter() != value) {                                     \
+      maybeSaveInTransaction(key, getter(), value, #getter "Changed",      \
+                             userSettings);                                \
+      m_settings.setValue(key, value);                                     \
+      emit getter##Changed();                                              \
+    }                                                                      \
+  }                                                                        \
+  void SettingsHolder::remover() {                                         \
+    m_settings.remove(key);                                                \
+    emit getter##Changed();                                                \
   }
 
 #include "settingslist.h"

--- a/src/settingsholder.h
+++ b/src/settingsholder.h
@@ -65,10 +65,11 @@ class SettingsHolder final : public QObject {
 
   void sync();
 
-#define SETTING(type, toType, getter, setter, has, ...) \
-  bool has() const;                                     \
-  type getter() const;                                  \
-  void setter(const type& value);
+#define SETTING(type, toType, getter, setter, remover, has, ...) \
+  bool has() const;                                              \
+  type getter() const;                                           \
+  void setter(const type& value);                                \
+  void remover();
 
 #include "settingslist.h"
 #undef SETTING

--- a/src/settingslist.h
+++ b/src/settingslist.h
@@ -31,119 +31,132 @@
 
 // Please! Keep the alphabetic order!
 
-SETTING_BOOL(addonCustomServer,     // getter
-             setAddonCustomServer,  // setter
-             hasAddonCustomServer,  // has
-             "addon/customServer",  // key
-             false,                 // default value
-             false,                 // user setting
-             false                  // remove when reset
+SETTING_BOOL(addonCustomServer,        // getter
+             setAddonCustomServer,     // setter
+             removeAddonCustomServer,  // remover
+             hasAddonCustomServer,     // has
+             "addon/customServer",     // key
+             false,                    // default value
+             false,                    // user setting
+             false                     // remove when reset
 )
 
 SETTING_STRING(
-    addonCustomServerAddress,     // getter
-    setAddonCustomServerAddress,  // setter
-    hasAddonCustomServerAddress,  // has
-    "addon/customServerAddress",  // key
+    addonCustomServerAddress,        // getter
+    setAddonCustomServerAddress,     // setter
+    removeAddonCustomServerAddress,  // remover
+    hasAddonCustomServerAddress,     // has
+    "addon/customServerAddress",     // key
     Constants::envOrDefault("MVPN_ADDON_URL",
                             Constants::ADDON_STAGING_URL),  // default value
     false,                                                  // user setting
     false                                                   // remove when reset
 )
 
-SETTING_BOOL(addonProdKeyInStaging,     // getter
-             setAddonProdKeyInStaging,  // setter
-             hasAddonProdKeyInStaging,  // has
-             "addon/prodKeyInStaging",  // key
-             false,                     // default value
-             false,                     // user setting
-             false                      // remove when reset
+SETTING_BOOL(addonProdKeyInStaging,        // getter
+             setAddonProdKeyInStaging,     // setter
+             removeAddonProdKeyInStaging,  // remover
+             hasAddonProdKeyInStaging,     // has
+             "addon/prodKeyInStaging",     // key
+             false,                        // default value
+             false,                        // user setting
+             false                         // remove when reset
 )
 
-SETTING_BOOL(captivePortalAlert,     // getter
-             setCaptivePortalAlert,  // setter
-             hasCaptivePortalAlert,  // has
-             "captivePortalAlert",   // key
+SETTING_BOOL(captivePortalAlert,        // getter
+             setCaptivePortalAlert,     // setter
+             removeCaptivePortalAlert,  // remover
+             hasCaptivePortalAlert,     // has
+             "captivePortalAlert",      // key
              Feature::get(Feature::Feature_captivePortal)
                  ->isSupported(),  // default value
              true,                 // user setting
              false                 // remove when reset
 )
 
-SETTING_STRINGLIST(captivePortalIpv4Addresses,     // getter
-                   setCaptivePortalIpv4Addresses,  // setter
-                   hasCaptivePortalIpv4Addresses,  // has
-                   "captivePortal/ipv4Addresses",  // key
-                   QStringList(),                  // default value
-                   false,                          // user setting
-                   false                           // remove when reset
+SETTING_STRINGLIST(captivePortalIpv4Addresses,        // getter
+                   setCaptivePortalIpv4Addresses,     // setter
+                   removeCaptivePortalIpv4Addresses,  // remover
+                   hasCaptivePortalIpv4Addresses,     // has
+                   "captivePortal/ipv4Addresses",     // key
+                   QStringList(),                     // default value
+                   false,                             // user setting
+                   false                              // remove when reset
 )
 
-SETTING_STRINGLIST(captivePortalIpv6Addresses,     // getter
-                   setCaptivePortalIpv6Addresses,  // setter
-                   hasCaptivePortalIpv6Addresses,  // has
-                   "captivePortal/ipv6Addresses",  // key
-                   QStringList(),                  // default value
-                   false,                          // user setting
-                   false                           // remove when reset
+SETTING_STRINGLIST(captivePortalIpv6Addresses,         // getter
+                   setCaptivePortalIpv6Addresses,      // setter
+                   removerCaptivePortalIpv6Addresses,  // remover
+                   hasCaptivePortalIpv6Addresses,      // has
+                   "captivePortal/ipv6Addresses",      // key
+                   QStringList(),                      // default value
+                   false,                              // user setting
+                   false                               // remove when reset
 )
 
-SETTING_BOOL(connectionChangeNotification,     // getter
-             setConnectionChangeNotification,  // setter
-             hasConnectionChangeNotification,  // has
-             "connectionChangeNotification",   // key
-             true,                             // default value
-             true,                             // user setting
-             false                             // remove when reset
+SETTING_BOOL(connectionChangeNotification,        // getter
+             setConnectionChangeNotification,     // setter
+             removeConnectionChangeNotification,  // remover
+             hasConnectionChangeNotification,     // has
+             "connectionChangeNotification",      // key
+             true,                                // default value
+             true,                                // user setting
+             false                                // remove when reset
 )
 
-SETTING_STRING(currentServerCity,     // getter
-               setCurrentServerCity,  // setter
-               hasCurrentServerCity,  // has
-               "currentServer/city",  // key
-               "",                    // default value
-               true,                  // user setting
-               true                   // remove when reset
+SETTING_STRING(currentServerCityDeprecated,        // getter
+               setCurrentServerCityDeprecated,     // setter
+               removeCurrentServerCityDeprecated,  // remover
+               hasCurrentServerCityDeprecated,     // has
+               "currentServer/city",               // key
+               "",                                 // default value
+               true,                               // user setting
+               true                                // remove when reset
 )
 
-SETTING_STRING(currentServerCountryCode,     // getter
-               setCurrentServerCountryCode,  // setter
-               hasCurrentServerCountryCode,  // has
-               "currentServer/countryCode",  // key
-               "",                           // default value
-               true,                         // user setting
-               true                          // remove when reset
+SETTING_STRING(currentServerCountryCodeDeprecated,        // getter
+               setCurrentServerCountryCodeDeprecated,     // setter
+               removeCurrentServerCountryCodeDeprecated,  // remover
+               hasCurrentServerCountryCodeDeprecated,     // has
+               "currentServer/countryCode",               // key
+               "",                                        // default value
+               true,                                      // user setting
+               true                                       // remove when reset
 )
 
-SETTING_BOOL(developerUnlock,     // getter
-             setDeveloperUnlock,  // setter
-             hasDeveloperUnlock,  // has
-             "developerUnlock",   // key
-             false,               // default value
-             false,               // user setting
-             false                // remove when reset
+SETTING_BOOL(developerUnlock,        // getter
+             setDeveloperUnlock,     // setter
+             removeDeveloperUnlock,  // remover
+             hasDeveloperUnlock,     // has
+             "developerUnlock",      // key
+             false,                  // default value
+             false,                  // user setting
+             false                   // remove when reset
 )
 
-SETTING_STRING(deviceKeyVersion,     // getter
-               setDeviceKeyVersion,  // setter
-               hasDeviceKeyVersion,  // has
-               "deviceKeyVersion",   // key
-               "",                   // default value
-               false,                // user setting
-               true                  // remove when reset
+SETTING_STRING(deviceKeyVersion,        // getter
+               setDeviceKeyVersion,     // setter
+               removeDeviceKeyVersion,  // remover
+               hasDeviceKeyVersion,     // has
+               "deviceKeyVersion",      // key
+               "",                      // default value
+               false,                   // user setting
+               true                     // remove when reset
 )
 
-SETTING_BYTEARRAY(devices,     // getter
-                  setDevices,  // setter
-                  hasDevices,  // has
-                  "devices",   // key
-                  "",          // default value
-                  false,       // user setting
-                  true         // remove when reset
+SETTING_BYTEARRAY(devices,        // getter
+                  setDevices,     // setter
+                  removeDevices,  // remover
+                  hasDevices,     // has
+                  "devices",      // key
+                  "",             // default value
+                  false,          // user setting
+                  true            // remove when reset
 )
 
 SETTING_INT(dnsProvider,                           // getter
             setDNSProvider,                        // setter
+            removeDNSProvider,                     // remover
             hasDNSProvider,                        // has
             "dnsProvider",                         // key
             SettingsHolder::DnsProvider::Gateway,  // default value
@@ -151,229 +164,264 @@ SETTING_INT(dnsProvider,                           // getter
             false                                  // remove when reset
 )
 
-SETTING_STRING(entryServerCity,     // getter
-               setEntryServerCity,  // setter
-               hasEntryServerCity,  // has
-               "entryServer/city",  // key
-               nullptr,             // default value
-               true,                // user setting
-               true                 // remove when reset
+SETTING_STRING(entryServerCityDeprecated,        // getter
+               setEntryServerCityDeprecated,     // setter
+               removeEntryServerCityDeprecated,  // remover
+               hasEntryServerCityDeprecated,     // has
+               "entryServer/city",               // key
+               nullptr,                          // default value
+               true,                             // user setting
+               true                              // remove when reset
 )
 
-SETTING_STRING(entryServerCountryCode,     // getter
-               setEntryServerCountryCode,  // setter
-               hasEntryServerCountryCode,  // has
-               "entryServer/countryCode",  // key
-               nullptr,                    // default value
-               true,                       // user setting
-               true                        // remove when reset
+SETTING_STRING(entryServerCountryCodeDeprecated,        // getter
+               setEntryServerCountryCodeDeprecated,     // setter
+               removeEntryServerCountryCodeDeprecated,  // remover
+               hasEntryServerCountryCodeDeprecated,     // has
+               "entryServer/countryCode",               // key
+               nullptr,                                 // default value
+               true,                                    // user setting
+               true                                     // remove when reset
 )
 
-SETTING_STRINGLIST(featuresFlippedOff,     // getter
-                   setFeaturesFlippedOff,  // setter
-                   hasFeaturesFlippedOff,  // has
-                   "featuresFlippedOff",   // key
-                   QStringList(),          // default value
-                   false,                  // user setting
-                   false                   // remove when reset
+SETTING_STRINGLIST(featuresFlippedOff,        // getter
+                   setFeaturesFlippedOff,     // setter
+                   removeFeaturesFlippedOff,  // remover
+                   hasFeaturesFlippedOff,     // has
+                   "featuresFlippedOff",      // key
+                   QStringList(),             // default value
+                   false,                     // user setting
+                   false                      // remove when reset
 )
 
-SETTING_STRINGLIST(featuresFlippedOn,     // getter
-                   setFeaturesFlippedOn,  // setter
-                   hasFeaturesFlippedOn,  // has
-                   "featuresFlippedOn",   // key
-                   QStringList(),         // default value
-                   false,                 // user setting
-                   false                  // remove when reset
+SETTING_STRINGLIST(featuresFlippedOn,        // getter
+                   setFeaturesFlippedOn,     // setter
+                   removeFeaturesFlippedOn,  // remover
+                   hasFeaturesFlippedOn,     // has
+                   "featuresFlippedOn",      // key
+                   QStringList(),            // default value
+                   false,                    // user setting
+                   false                     // remove when reset
 )
 
-SETTING_BOOL(featuresTourShown,     // getter
-             setFeaturesTourShown,  // setter
-             hasFeaturesTourShown,  // has
-             "featuresTourShown",   // key
-             false,                 // default value
-             false,                 // user setting
-             false                  // remove when reset
+SETTING_BOOL(featuresTourShown,        // getter
+             setFeaturesTourShown,     // setter
+             removeFeaturesTourShown,  // remover
+             hasFeaturesTourShown,     // has
+             "featuresTourShown",      // key
+             false,                    // default value
+             false,                    // user setting
+             false                     // remove when reset
 )
 
 // TODO - This would be better named "telemetryEnabled", but as we already
 // shipped with it called gleanEnabled it's non-trivial to change
 // the name. https://github.com/mozilla-mobile/mozilla-vpn-client/issues/2050
-SETTING_BOOL(gleanEnabled,     // getter
-             setGleanEnabled,  // setter
-             hasGleanEnabled,  // has
-             "gleanEnabled",   // key
-             true,             // default value
-             true,             // user setting
-             false             // remove when reset
+SETTING_BOOL(gleanEnabled,        // getter
+             setGleanEnabled,     // setter
+             removeGleanEnabled,  // remover
+             hasGleanEnabled,     // has
+             "gleanEnabled",      // key
+             true,                // default value
+             true,                // user setting
+             false                // remove when reset
 )
 
-SETTING_STRINGLIST(iapProducts,     // getter
-                   setIapProducts,  // setter
-                   hasIapProducts,  // has
-                   "iapProducts",   // key
-                   QStringList(),   // default value
-                   false,           // user setting
-                   true             // remove when reset
+SETTING_STRINGLIST(iapProducts,        // getter
+                   setIapProducts,     // setter
+                   removeIapProducts,  // remover
+                   hasIapProducts,     // has
+                   "iapProducts",      // key
+                   QStringList(),      // default value
+                   false,              // user setting
+                   true                // remove when reset
 )
 
-SETTING_DATETIME(installationTime,     // getter
-                 setInstallationTime,  // setter
-                 hasInstallationTime,  // has
-                 "installationTime",   // key
-                 QDateTime(),          // default value
-                 false,                // user setting
-                 false                 // remove when reset
+SETTING_DATETIME(installationTime,        // getter
+                 setInstallationTime,     // setter
+                 removeInstallationTime,  // remover
+                 hasInstallationTime,     // has
+                 "installationTime",      // key
+                 QDateTime(),             // default value
+                 false,                   // user setting
+                 false                    // remove when reset
 )
 
-SETTING_STRING(installedVersion,     // getter
-               setInstalledVersion,  // setter
-               hasInstalledVersion,  // has
-               "installedVersion",   // key
-               "",                   // default value
-               false,                // user setting
-               false                 // remove when reset
+SETTING_STRING(installedVersion,        // getter
+               setInstalledVersion,     // setter
+               removeInstalledVersion,  // remover
+               hasInstalledVersion,     // has
+               "installedVersion",      // key
+               "",                      // default value
+               false,                   // user setting
+               false                    // remove when reset
 )
 
-SETTING_INT64(keyRegenerationTimeSec,     // getter
-              setKeyRegenerationTimeSec,  // setter
-              hasKeyRegenerationTimeSec,  // has
-              "keyRegenerationTimeSec",   // key
-              0,                          // default value
-              false,                      // user setting
-              true                        // remove when reset
+SETTING_INT64(keyRegenerationTimeSec,        // getter
+              setKeyRegenerationTimeSec,     // setter
+              removeKeyRegenerationTimeSec,  // remover
+              hasKeyRegenerationTimeSec,     // has
+              "keyRegenerationTimeSec",      // key
+              0,                             // default value
+              false,                         // user setting
+              true                           // remove when reset
 )
 
-SETTING_STRING(languageCode,     // getter
-               setLanguageCode,  // setter
-               hasLanguageCode,  // has
-               "languageCode",   // key
-               "",               // default value
-               true,             // user setting
-               false             // remove when reset
+SETTING_STRING(languageCode,        // getter
+               setLanguageCode,     // setter
+               removeLanguageCode,  // remover
+               hasLanguageCode,     // has
+               "languageCode",      // key
+               "",                  // default value
+               true,                // user setting
+               false                // remove when reset
 )
 
-SETTING_BOOL(localNetworkAccess,     // getter
-             setLocalNetworkAccess,  // setter
-             hasLocalNetworkAccess,  // has
-             "localNetworkAccess",   // key
-             false,                  // default value
-             true,                   // user setting
-             false                   // remove when reset
+SETTING_BOOL(localNetworkAccess,        // getter
+             setLocalNetworkAccess,     // setter
+             removeLocalNetworkAccess,  // remover
+             hasLocalNetworkAccess,     // has
+             "localNetworkAccess",      // key
+             false,                     // default value
+             true,                      // user setting
+             false                      // remove when reset
 )
 
-SETTING_STRINGLIST(missingApps,     // getter
-                   setMissingApps,  // setter
-                   hasMissingApps,  // has
-                   "MissingApps",   // key
-                   QStringList(),   // default value
-                   true,            // user setting
-                   false            // remove when reset
+SETTING_STRINGLIST(missingApps,        // getter
+                   setMissingApps,     // setter
+                   removeMissingApps,  // remover
+                   hasMissingApps,     // has
+                   "MissingApps",      // key
+                   QStringList(),      // default value
+                   true,               // user setting
+                   false               // remove when reset
 )
 
-SETTING_BOOL(postAuthenticationShown,     // getter
-             setPostAuthenticationShown,  // setter
-             hasPostAuthenticationShown,  // has
-             "postAuthenticationShown",   // key
-             false,                       // default value
-             true,                        // user setting
-             true                         // remove when reset
+SETTING_BOOL(postAuthenticationShown,        // getter
+             setPostAuthenticationShown,     // setter
+             removePostAuthenticationShown,  // remover
+             hasPostAuthenticationShown,     // has
+             "postAuthenticationShown",      // key
+             false,                          // default value
+             true,                           // user setting
+             true                            // remove when reset
 )
 
-SETTING_STRING(previousLanguageCode,     // getter
-               setPreviousLanguageCode,  // setter
-               hasPreviousLanguageCode,  // has
-               "previousLanguageCode",   // key
+SETTING_STRING(previousLanguageCode,        // getter
+               setPreviousLanguageCode,     // setter
+               removePreviousLanguageCode,  // remover
+               hasPreviousLanguageCode,     // has
+               "previousLanguageCode",      // key
+               "",                          // default value
+               true,                        // user setting
+               false                        // remove when reset
+)
+
+SETTING_STRING(privateKey,        // getter
+               setPrivateKey,     // setter
+               removePrivateKey,  // remover
+               hasPrivateKey,     // has
+               "privateKey",      // key
+               "",                // default value
+               false,             // user setting
+               true               // remove when reset
+)
+
+SETTING_STRING(privateKeyJournal,        // getter
+               setPrivateKeyJournal,     // setter
+               removePrivateKeyJournal,  // remover
+               hasPrivateKeyJournal,     // has
+               "privateKeyJournal",      // key
                "",                       // default value
-               true,                     // user setting
-               false                     // remove when reset
+               false,                    // user setting
+               true                      // remove when reset
 )
 
-SETTING_STRING(privateKey,     // getter
-               setPrivateKey,  // setter
-               hasPrivateKey,  // has
-               "privateKey",   // key
-               "",             // default value
-               false,          // user setting
-               true            // remove when reset
+SETTING_BOOL(protectSelectedApps,        // getter
+             setProtectSelectedApps,     // setter
+             removeProtectSelectedApps,  // remover
+             hasProtectSelectedApps,     // has
+             "protectSelectedApps",      // key
+             false,                      // default value
+             true,                       // user setting
+             false                       // remove when reset
 )
 
-SETTING_STRING(privateKeyJournal,     // getter
-               setPrivateKeyJournal,  // setter
-               hasPrivateKeyJournal,  // has
-               "privateKeyJournal",   // key
-               "",                    // default value
-               false,                 // user setting
-               true                   // remove when reset
+SETTING_STRING(publicKey,        // getter
+               setPublicKey,     // setter
+               removePublicKey,  // remover
+               hasPublicKey,     // has
+               "publicKey",      // key
+               "",               // default value
+               false,            // user setting
+               true              // remove when reset
 )
 
-SETTING_BOOL(protectSelectedApps,     // getter
-             setProtectSelectedApps,  // setter
-             hasProtectSelectedApps,  // has
-             "protectSelectedApps",   // key
-             false,                   // default value
-             true,                    // user setting
-             false                    // remove when reset
+SETTING_STRING(publicKeyJournal,        // getter
+               setPublicKeyJournal,     // setter
+               removePublicKeyJournal,  // remover
+               hasPublicKeyJournal,     // has
+               "publicKeyJournal",      // key
+               "",                      // default value
+               false,                   // user setting
+               true                     // remove when reset
 )
 
-SETTING_STRING(publicKey,     // getter
-               setPublicKey,  // setter
-               hasPublicKey,  // has
-               "publicKey",   // key
-               "",            // default value
-               false,         // user setting
-               true           // remove when reset
+SETTING_STRINGLIST(recentConnections,        // getter
+                   setRecentConnections,     // setter
+                   removeRecentConnections,  // remover
+                   hasRecentConnections,     // has
+                   "recentConnections",      // key
+                   QStringList(),            // default value
+                   true,                     // user setting
+                   true                      // remove when reset
 )
 
-SETTING_STRING(publicKeyJournal,     // getter
-               setPublicKeyJournal,  // setter
-               hasPublicKeyJournal,  // has
-               "publicKeyJournal",   // key
-               "",                   // default value
-               false,                // user setting
-               true                  // remove when reset
+SETTING_STRINGLIST(seenFeatures,        // getter
+                   setSeenFeatures,     // setter
+                   removeSeenFeatures,  // remover
+                   hasSeenFeatures,     // has
+                   "seenFeatures",      // key
+                   QStringList(),       // default value
+                   false,               // user setting
+                   false                // remove when reset
 )
 
-SETTING_STRINGLIST(recentConnections,     // getter
-                   setRecentConnections,  // setter
-                   hasRecentConnections,  // has
-                   "recentConnections",   // key
-                   QStringList(),         // default value
-                   true,                  // user setting
-                   true                   // remove when reset
+SETTING_BYTEARRAY(servers,        // getter
+                  setServers,     // setter
+                  removeServers,  // remover
+                  hasServers,     // has
+                  "servers",      // key
+                  "",             // default value
+                  false,          // user setting
+                  true            // remove when reset
 )
 
-SETTING_STRINGLIST(seenFeatures,     // getter
-                   setSeenFeatures,  // setter
-                   hasSeenFeatures,  // has
-                   "seenFeatures",   // key
-                   QStringList(),    // default value
-                   false,            // user setting
-                   false             // remove when reset
+SETTING_BYTEARRAY(serverData,        // getter
+                  setServerData,     // setter
+                  removeServerData,  // remover
+                  hasServerData,     // has
+                  "serverData",      // key
+                  "",                // default value
+                  true,              // user setting
+                  true               // remove when reset
 )
 
-SETTING_BYTEARRAY(servers,     // getter
-                  setServers,  // setter
-                  hasServers,  // has
-                  "servers",   // key
-                  "",          // default value
-                  false,       // user setting
-                  true         // remove when reset
+SETTING_BOOL(serverSwitchNotification,        // getter
+             setServerSwitchNotification,     // setter
+             removeServerSwitchNotification,  // remover
+             hasServerSwitchNotification,     // has
+             "serverSwitchNotification",      // key
+             true,                            // default value
+             true,                            // user setting
+             false                            // remove when reset
 )
 
-SETTING_BOOL(serverSwitchNotification,     // getter
-             setServerSwitchNotification,  // setter
-             hasServerSwitchNotification,  // has
-             "serverSwitchNotification",   // key
-             true,                         // default value
-             true,                         // user setting
-             false                         // remove when reset
-)
-
-SETTING_BOOL(serverUnavailableNotification,     // getter
-             setServerUnavailableNotification,  // setter
-             hasServerUnavailableNotification,  // has
-             "serverUnavailableNotification",   // key
+SETTING_BOOL(serverUnavailableNotification,        // getter
+             setServerUnavailableNotification,     // setter
+             removeServerUnavailableNotification,  // remover
+             hasServerUnavailableNotification,     // has
+             "serverUnavailableNotification",      // key
              Feature::get(Feature::Feature_serverUnavailableNotification)
                  ->isSupported(),  // default value
              true,                 // user setting
@@ -381,189 +429,209 @@ SETTING_BOOL(serverUnavailableNotification,     // getter
 )
 
 SETTING_STRING(
-    stagingServerAddress,     // getter
-    setStagingServerAddress,  // setter
-    hasStagingServerAddress,  // has
-    "stagingServerAddress",   // key
+    stagingServerAddress,        // getter
+    setStagingServerAddress,     // setter
+    removeStagingServerAddress,  // remover
+    hasStagingServerAddress,     // has
+    "stagingServerAddress",      // key
     Constants::envOrDefault("MVPN_API_BASE_URL",
                             Constants::API_STAGING_URL),  // default value
     false,                                                // user setting
     false                                                 // remove when reset
 )
 
-SETTING_BOOL(stagingServer,     // getter
-             setStagingServer,  // setter
-             hasStagingServer,  // has
-             "stagingServer",   // key
-             false,             // default value
-             false,             // user setting
-             false              // remove when reset
+SETTING_BOOL(stagingServer,        // getter
+             setStagingServer,     // setter
+             removeStagingServer,  // remover
+             hasStagingServer,     // has
+             "stagingServer",      // key
+             false,                // default value
+             false,                // user setting
+             false                 // remove when reset
 )
 
-SETTING_BOOL(startAtBoot,     // getter
-             setStartAtBoot,  // setter
-             hasStartAtBoot,  // has
-             "startAtBoot",   // key
-             false,           // default value
-             true,            // user setting
-             false            // remove when reset
+SETTING_BOOL(startAtBoot,        // getter
+             setStartAtBoot,     // setter
+             removeStartAtBoot,  // remover
+             hasStartAtBoot,     // has
+             "startAtBoot",      // key
+             false,              // default value
+             true,               // user setting
+             false               // remove when reset
 )
 
-SETTING_BYTEARRAY(subscriptionData,     // getter
-                  setSubscriptionData,  // setter
-                  hasSubscriptionData,  // has
-                  "subscriptionData",   // key
-                  "",                   // default value
-                  false,                // user setting
-                  true                  // remove when reset
+SETTING_BYTEARRAY(subscriptionData,        // getter
+                  setSubscriptionData,     // setter
+                  removeSubscriptionData,  // remover
+                  hasSubscriptionData,     // has
+                  "subscriptionData",      // key
+                  "",                      // default value
+                  false,                   // user setting
+                  true                     // remove when reset
 )
 
-SETTING_BOOL(systemLanguageCodeMigrated,     // getter
-             setSystemLanguageCodeMigrated,  // setter
-             hasSystemLanguageCodeMigrated,  // has
-             "systemLanguageCodeMigrated",   // key
-             false,                          // default value
-             false,                          // user setting
-             true                            // remove when reset
+SETTING_BOOL(systemLanguageCodeMigrated,        // getter
+             setSystemLanguageCodeMigrated,     // setter
+             removeSystemLanguageCodeMigrated,  // remover
+             hasSystemLanguageCodeMigrated,     // has
+             "systemLanguageCodeMigrated",      // key
+             false,                             // default value
+             false,                             // user setting
+             true                               // remove when reset
 )
 
-SETTING_BOOL(telemetryPolicyShown,     // getter
-             setTelemetryPolicyShown,  // setter
-             hasTelemetryPolicyShown,  // has
-             "telemetryPolicyShown",   // key
-             false,                    // default value
-             false,                    // user setting
-             false                     // remove when reset
-)
-
-SETTING_BOOL(tipsAndTricksIntroShown,     // getter
-             setTipsAndTricksIntroShown,  // setter
-             hasTipsAndTricksIntroShown,  // has
-             "tipsAndTricksIntroShown",   // key
+SETTING_BOOL(telemetryPolicyShown,        // getter
+             setTelemetryPolicyShown,     // setter
+             removeTelemetryPolicyShown,  // remover
+             hasTelemetryPolicyShown,     // has
+             "telemetryPolicyShown",      // key
              false,                       // default value
              false,                       // user setting
              false                        // remove when reset
 )
 
-SETTING_STRING(token,     // getter
-               setToken,  // setter
-               hasToken,  // has
-               "token",   // key
-               "",        // default value
-               false,     // user setting
-               true       // remove when reset
+SETTING_BOOL(tipsAndTricksIntroShown,        // getter
+             setTipsAndTricksIntroShown,     // setter
+             removeTipsAndTricksIntroShown,  // remover
+             hasTipsAndTricksIntroShown,     // has
+             "tipsAndTricksIntroShown",      // key
+             false,                          // default value
+             false,                          // user setting
+             false                           // remove when reset
 )
 
-SETTING_BOOL(tunnelPort53,     // getter
-             setTunnelPort53,  // setter
-             hasTunnelPort53,  // has
-             "tunnelPort53",   // key
-             false,            // default value
-             true,             // user setting
-             false             // remove when reset
+SETTING_STRING(token,        // getter
+               setToken,     // setter
+               removeToken,  // remover
+               hasToken,     // has
+               "token",      // key
+               "",           // default value
+               false,        // user setting
+               true          // remove when reset
 )
 
-SETTING_BOOL(unsecuredNetworkAlert,     // getter
-             setUnsecuredNetworkAlert,  // setter
-             hasUnsecuredNetworkAlert,  // has
-             "unsecuredNetworkAlert",   // key
+SETTING_BOOL(tunnelPort53,        // getter
+             setTunnelPort53,     // setter
+             removeTunnelPort53,  // remover
+             hasTunnelPort53,     // has
+             "tunnelPort53",      // key
+             false,               // default value
+             true,                // user setting
+             false                // remove when reset
+)
+
+SETTING_BOOL(unsecuredNetworkAlert,        // getter
+             setUnsecuredNetworkAlert,     // setter
+             removeUnsecuredNetworkAlert,  // remover
+             hasUnsecuredNetworkAlert,     // has
+             "unsecuredNetworkAlert",      // key
              Feature::get(Feature::Feature_unsecuredNetworkNotification)
                  ->isSupported(),  // default value
              true,                 // user setting
              false                 // remove when reset
 )
 
-SETTING_DATETIME(updateTime,     // getter
-                 setUpdateTime,  // setter
-                 hasUpdateTime,  // has
-                 "updateTime",   // key
-                 QDateTime(),    // default value
-                 false,          // user setting
-                 false           // remove when reset
+SETTING_DATETIME(updateTime,        // getter
+                 setUpdateTime,     // setter
+                 removeUpdateTime,  // remover
+                 hasUpdateTime,     // has
+                 "updateTime",      // key
+                 QDateTime(),       // default value
+                 false,             // user setting
+                 false              // remove when reset
 )
 
-SETTING_STRING(userAvatar,     // getter
-               setUserAvatar,  // setter
-               hasUserAvatar,  // has
-               "user/avatar",  // key
+SETTING_STRING(userAvatar,        // getter
+               setUserAvatar,     // setter
+               removeUserAvatar,  // remover
+               hasUserAvatar,     // has
+               "user/avatar",     // key
+               "",                // default value
+               false,             // user setting
+               true               // remove when reset
+)
+
+SETTING_STRING(userDisplayName,        // getter
+               setUserDisplayName,     // setter
+               removeUserDisplayName,  // remover
+               hasUserDisplayName,     // has
+               "user/displayName",     // key
+               "",                     // default value
+               false,                  // user setting
+               true                    // remove when reset
+)
+
+SETTING_STRING(userDNS,        // getter
+               setUserDNS,     // setter
+               removeUserDNS,  // remover
+               hasUserDNS,     // has
+               "userDNS",      // key
                "",             // default value
-               false,          // user setting
-               true            // remove when reset
+               true,           // user setting
+               false           // remove when reset
 )
 
-SETTING_STRING(userDisplayName,     // getter
-               setUserDisplayName,  // setter
-               hasUserDisplayName,  // has
-               "user/displayName",  // key
-               "",                  // default value
-               false,               // user setting
-               true                 // remove when reset
+SETTING_STRING(userEmail,        // getter
+               setUserEmail,     // setter
+               removeUserEmail,  // remover
+               hasUserEmail,     // has
+               "user/email",     // key
+               "",               // default value
+               false,            // user setting
+               true              // remove when reset
 )
 
-SETTING_STRING(userDNS,     // getter
-               setUserDNS,  // setter
-               hasUserDNS,  // has
-               "userDNS",   // key
-               "",          // default value
-               true,        // user setting
-               false        // remove when reset
+SETTING_INT(userMaxDevices,        // getter
+            setUserMaxDevices,     // setter
+            removeUserMaxDevices,  // remover
+            hasUserMaxDevices,     // has
+            "user/maxDevices",     // key
+            0,                     // default value
+            false,                 // user setting
+            true                   // remove when reset
 )
 
-SETTING_STRING(userEmail,     // getter
-               setUserEmail,  // setter
-               hasUserEmail,  // has
-               "user/email",  // key
-               "",            // default value
-               false,         // user setting
-               true           // remove when reset
+SETTING_BOOL(userSubscriptionNeeded,        // getter
+             setUserSubscriptionNeeded,     // setter
+             removeUserSubscriptionNeeded,  // remover
+             hasUserSubscriptionNeeded,     // has
+             "user/subscriptionNeeded",     // key
+             false,                         // default value
+             false,                         // user setting
+             true                           // remove when reset
 )
 
-SETTING_INT(userMaxDevices,     // getter
-            setUserMaxDevices,  // setter
-            hasUserMaxDevices,  // has
-            "user/maxDevices",  // key
-            0,                  // default value
-            false,              // user setting
-            true                // remove when reset
-)
-
-SETTING_BOOL(userSubscriptionNeeded,     // getter
-             setUserSubscriptionNeeded,  // setter
-             hasUserSubscriptionNeeded,  // has
-             "user/subscriptionNeeded",  // key
-             false,                      // default value
-             false,                      // user setting
-             true                        // remove when reset
-)
-
-SETTING_STRINGLIST(vpnDisabledApps,     // getter
-                   setVpnDisabledApps,  // setter
-                   hasVpnDisabledApps,  // has
-                   "vpnDisabledApps",   // key
-                   QStringList(),       // default value
-                   true,                // user setting
-                   false                // remove when reset
+SETTING_STRINGLIST(vpnDisabledApps,        // getter
+                   setVpnDisabledApps,     // setter
+                   removeVpnDisabledApps,  // remover
+                   hasVpnDisabledApps,     // has
+                   "vpnDisabledApps",      // key
+                   QStringList(),          // default value
+                   true,                   // user setting
+                   false                   // remove when reset
 )
 
 #if defined(MVPN_ADJUST)
-SETTING_BOOL(adjustActivatable,     // getter
-             setAdjustActivatable,  // setter
-             hasAdjustActivatable,  // has
-             "adjustActivatable",   // key
-             false,                 // default value
-             false,                 // user setting
-             false                  // remove when reset
+SETTING_BOOL(adjustActivatable,        // getter
+             setAdjustActivatable,     // setter
+             removeAdjustActivatable,  // remover
+             hasAdjustActivatable,     // has
+             "adjustActivatable",      // key
+             false,                    // default value
+             false,                    // user setting
+             false                     // remove when reset
 )
 #endif
 
 #if defined(MVPN_IOS)
-SETTING_STRINGLIST(subscriptionTransactions,     // getter
-                   setSubscriptionTransactions,  // setter
-                   hasSubscriptionTransactions,  // has
-                   "subscriptionTransactions",   // key
-                   QStringList(),                // efault value
-                   false,                        // user setting
-                   false                         // remove when reset
+SETTING_STRINGLIST(subscriptionTransactions,        // getter
+                   setSubscriptionTransactions,     // setter
+                   removeSubscriptionTransactions,  // remover
+                   hasSubscriptionTransactions,     // has
+                   "subscriptionTransactions",      // key
+                   QStringList(),                   // efault value
+                   false,                           // user setting
+                   false                            // remove when reset
 )
 #endif
 
@@ -571,6 +639,7 @@ SETTING_STRINGLIST(subscriptionTransactions,     // getter
 
 SETTING_STRING(theme,          // getter
                setTheme,       // setter
+               removeTheme,    // remover
                hasTheme,       // has
                "theme",        // key
                DEFAULT_THEME,  // default value

--- a/src/telemetry.cpp
+++ b/src/telemetry.cpp
@@ -95,7 +95,7 @@ void Telemetry::connectionStabilityEvent() {
 
   emit vpn->recordGleanEventWithExtraKeys(
       GleanSample::connectivityStable,
-      {{"server", vpn->exitServerPublicKey()},
+      {{"server", vpn->currentServer()->exitServerPublicKey()},
        {"latency", QString::number(vpn->connectionHealth()->latency())},
        {"loss", QString::number(vpn->connectionHealth()->loss())},
        {"stddev", QString::number(vpn->connectionHealth()->stddev())},

--- a/src/tutorial/tutorialstepbefore.cpp
+++ b/src/tutorial/tutorialstepbefore.cpp
@@ -190,11 +190,8 @@ class TutorialStepBeforeVpnLocationSet final : public TutorialStepBefore {
   }
 
   bool run() override {
-    Controller* controller = MozillaVPN::instance()->controller();
-    Q_ASSERT(controller);
-
-    controller->changeServer(m_exitCountryCode, m_exitCity, m_entryCountryCode,
-                             m_entryCity);
+    MozillaVPN::instance()->currentServer()->changeServer(
+        m_exitCountryCode, m_exitCity, m_entryCountryCode, m_entryCity);
     return true;
   }
 

--- a/src/ui/screens/home/ViewHome.qml
+++ b/src/ui/screens/home/ViewHome.qml
@@ -112,7 +112,7 @@ VPNFlickable {
                     serversList: [
                         {
                             countryCode: typeof(VPNCurrentServer.entryCountryCode) !== 'undefined' ? VPNCurrentServer.entryCountryCode : "" ,
-                            localizedCityName: typeof(VPNCurrentServer.localizedEntryCity) !== 'undefined' ? VPNCurrentServer.localizedEntryCity : "",
+                            localizedCityName: typeof(VPNCurrentServer.localizedEntryCityName) !== 'undefined' ? VPNCurrentServer.localizedEntryCityName : "",
                             cityName: typeof(VPNCurrentServer.entryCityName) !== "undefined" ? VPNCurrentServer.entryCityName : ""
                         },
                         {

--- a/src/ui/screens/home/ViewServers.qml
+++ b/src/ui/screens/home/ViewServers.qml
@@ -49,7 +49,7 @@ Item {
     VPNSegmentedNavigation {
         id: segmentedNav
 
-        property var multiHopEntryServer: [VPNCurrentServer.entryCountryCode, VPNCurrentServer.entryCityName, VPNCurrentServer.localizedEntryCity]
+        property var multiHopEntryServer: [VPNCurrentServer.entryCountryCode, VPNCurrentServer.entryCityName, VPNCurrentServer.localizedEntryCityName]
         property var multiHopExitServer: [VPNCurrentServer.exitCountryCode, VPNCurrentServer.exitCityName, VPNCurrentServer.localizedCityName]
 
         anchors {

--- a/src/ui/screens/home/ViewServers.qml
+++ b/src/ui/screens/home/ViewServers.qml
@@ -34,12 +34,12 @@ Item {
 
             if (segmentedNav.selectedSegment.objectName === "tabMultiHop" && multiHopStackView.depth === 1) {
                 // User clicked back button from the Multi-hop tab main view
-                VPNController.changeServer(...segmentedNav.multiHopExitServer.slice(0,2), ...segmentedNav.multiHopEntryServer.slice(0,2));
+                VPNCurrentServer.changeServer(...segmentedNav.multiHopExitServer.slice(0,2), ...segmentedNav.multiHopEntryServer.slice(0,2));
             }
 
             if (segmentedNav.selectedSegment.objectName === "tabSingleHop") {
                 // User clicked back button from the Single-hop tab view but didn't select a new server
-                VPNController.changeServer(VPNCurrentServer.exitCountryCode, VPNCurrentServer.exitCityName)
+                VPNCurrentServer.changeServer(VPNCurrentServer.exitCountryCode, VPNCurrentServer.exitCityName)
             }
 
             return stackview.pop()

--- a/tests/auth/mocmozillavpn.cpp
+++ b/tests/auth/mocmozillavpn.cpp
@@ -72,9 +72,6 @@ const QList<Server> MozillaVPN::exitServers() const { return QList<Server>(); }
 
 const QList<Server> MozillaVPN::entryServers() const { return QList<Server>(); }
 
-void MozillaVPN::changeServer(const QString&, const QString&, const QString&,
-                              const QString&) {}
-
 void MozillaVPN::postAuthenticationCompleted() {}
 
 void MozillaVPN::mainWindowLoaded() {}

--- a/tests/auth/mocmozillavpn.cpp
+++ b/tests/auth/mocmozillavpn.cpp
@@ -68,10 +68,6 @@ void MozillaVPN::cancelAuthentication() {}
 
 void MozillaVPN::logout() {}
 
-const QList<Server> MozillaVPN::exitServers() const { return QList<Server>(); }
-
-const QList<Server> MozillaVPN::entryServers() const { return QList<Server>(); }
-
 void MozillaVPN::postAuthenticationCompleted() {}
 
 void MozillaVPN::mainWindowLoaded() {}

--- a/tests/qml/moccontroller.cpp
+++ b/tests/qml/moccontroller.cpp
@@ -27,9 +27,6 @@ void Controller::disconnected() {}
 
 void Controller::timerTimeout() {}
 
-void Controller::changeServer(const QString&, const QString&, const QString&,
-                              const QString&) {}
-
 void Controller::logout() {}
 
 bool Controller::processNextStep() { return false; }
@@ -70,10 +67,6 @@ void Controller::backendFailure() {}
 void Controller::captivePortalPresent() {}
 
 void Controller::captivePortalGone() {}
-
-QString Controller::currentLocalizedCityName() const { return ""; }
-
-QString Controller::switchingLocalizedCityName() const { return ""; }
 
 void Controller::handshakeTimeout() {}
 

--- a/tests/qml/moccontroller.cpp
+++ b/tests/qml/moccontroller.cpp
@@ -69,9 +69,3 @@ void Controller::captivePortalPresent() {}
 void Controller::captivePortalGone() {}
 
 void Controller::handshakeTimeout() {}
-
-void Controller::setCooldownForAllServersInACity(const QString& countryCode,
-                                                 const QString& cityCode) {
-  Q_UNUSED(countryCode);
-  Q_UNUSED(cityCode);
-}

--- a/tests/qml/mocmozillavpn.cpp
+++ b/tests/qml/mocmozillavpn.cpp
@@ -74,10 +74,6 @@ void MozillaVPN::cancelAuthentication() {}
 
 void MozillaVPN::logout() {}
 
-const QList<Server> MozillaVPN::exitServers() const { return QList<Server>(); }
-
-const QList<Server> MozillaVPN::entryServers() const { return QList<Server>(); }
-
 void MozillaVPN::postAuthenticationCompleted() {}
 
 void MozillaVPN::mainWindowLoaded() {

--- a/tests/qml/mocmozillavpn.cpp
+++ b/tests/qml/mocmozillavpn.cpp
@@ -78,9 +78,6 @@ const QList<Server> MozillaVPN::exitServers() const { return QList<Server>(); }
 
 const QList<Server> MozillaVPN::entryServers() const { return QList<Server>(); }
 
-void MozillaVPN::changeServer(const QString&, const QString&, const QString&,
-                              const QString&) {}
-
 void MozillaVPN::postAuthenticationCompleted() {}
 
 void MozillaVPN::mainWindowLoaded() {

--- a/tests/unit/moccontroller.cpp
+++ b/tests/unit/moccontroller.cpp
@@ -28,9 +28,6 @@ void Controller::disconnected() {}
 
 void Controller::timerTimeout() {}
 
-void Controller::changeServer(const QString&, const QString&, const QString&,
-                              const QString&) {}
-
 void Controller::logout() {}
 
 bool Controller::processNextStep() { return false; }
@@ -73,10 +70,6 @@ void Controller::backendFailure() {}
 void Controller::captivePortalPresent() {}
 
 void Controller::captivePortalGone() {}
-
-QString Controller::currentLocalizedCityName() const { return ""; }
-
-QString Controller::switchingLocalizedCityName() const { return ""; }
 
 void Controller::handshakeTimeout() {}
 

--- a/tests/unit/moccontroller.cpp
+++ b/tests/unit/moccontroller.cpp
@@ -72,9 +72,3 @@ void Controller::captivePortalPresent() {}
 void Controller::captivePortalGone() {}
 
 void Controller::handshakeTimeout() {}
-
-void Controller::setCooldownForAllServersInACity(const QString& countryCode,
-                                                 const QString& cityCode) {
-  Q_UNUSED(countryCode);
-  Q_UNUSED(cityCode);
-}

--- a/tests/unit/mocmozillavpn.cpp
+++ b/tests/unit/mocmozillavpn.cpp
@@ -77,9 +77,6 @@ const QList<Server> MozillaVPN::exitServers() const { return QList<Server>(); }
 
 const QList<Server> MozillaVPN::entryServers() const { return QList<Server>(); }
 
-void MozillaVPN::changeServer(const QString&, const QString&, const QString&,
-                              const QString&) {}
-
 void MozillaVPN::postAuthenticationCompleted() {}
 
 void MozillaVPN::mainWindowLoaded() {}

--- a/tests/unit/mocmozillavpn.cpp
+++ b/tests/unit/mocmozillavpn.cpp
@@ -73,10 +73,6 @@ void MozillaVPN::cancelAuthentication() {}
 
 void MozillaVPN::logout() {}
 
-const QList<Server> MozillaVPN::exitServers() const { return QList<Server>(); }
-
-const QList<Server> MozillaVPN::entryServers() const { return QList<Server>(); }
-
 void MozillaVPN::postAuthenticationCompleted() {}
 
 void MozillaVPN::mainWindowLoaded() {}

--- a/tests/unit/testmodels.cpp
+++ b/tests/unit/testmodels.cpp
@@ -1175,25 +1175,6 @@ void TestModels::serverCountryModelPick() {
   QCOMPARE(m.fromJson(json), true);
 
   {
-    ServerData sd;
-    QCOMPARE(m.pickIfExists("serverCountryCode", "serverCityCode", sd), true);
-    QCOMPARE(sd.exitCountryCode(), "serverCountryCode");
-    QCOMPARE(sd.exitCityName(), "serverCityName");
-    QCOMPARE(m.exists(sd), true);
-
-    QCOMPARE(m.pickIfExists("serverCountryCode2", "serverCityCode", sd), false);
-    QCOMPARE(m.pickIfExists("serverCountryCode", "serverCityCode2", sd), false);
-  }
-
-  {
-    ServerData sd;
-    m.pickRandom(sd);
-    QCOMPARE(sd.exitCountryCode(), "serverCountryCode");
-    QCOMPARE(sd.exitCityName(), "serverCityName");
-    QCOMPARE(m.exists(sd), true);
-  }
-
-  {
     SettingsHolder settingsHolder;
     QStringList tuple = m.pickRandom();
     QCOMPARE(tuple.length(), 3);
@@ -1201,26 +1182,20 @@ void TestModels::serverCountryModelPick() {
     QCOMPARE(tuple.at(1), "serverCityName");
     QCOMPARE(tuple.at(2), "serverCityName");  // Localized?
   }
-
-  {
-    ServerData sd;
-    QCOMPARE(m.pickByIPv4Address("ipv4AddrIn", sd), true);
-    QCOMPARE(sd.exitCountryCode(), "serverCountryCode");
-    QCOMPARE(sd.exitCityName(), "serverCityName");
-    QCOMPARE(m.exists(sd), true);
-
-    QCOMPARE(m.pickByIPv4Address("ipv4AddrIn2", sd), false);
-  }
 }
 
 // ServerData
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 void TestModels::serverDataBasic() {
+  SettingsHolder settingsHolder;
+
   ServerData sd;
+  sd.initialize();
+
   QSignalSpy spy(&sd, &ServerData::changed);
 
-  QVERIFY(!sd.initialized());
+  QVERIFY(!sd.hasServerData());
   QCOMPARE(sd.exitCountryCode(), "");
   QCOMPARE(sd.exitCityName(), "");
   QVERIFY(!sd.multihop());
@@ -1248,7 +1223,7 @@ void TestModels::serverDataBasic() {
     sd.update(country.code(), city.name());
     QCOMPARE(spy.count(), 1);
 
-    QVERIFY(sd.initialized());
+    QVERIFY(sd.hasServerData());
     QCOMPARE(sd.exitCountryCode(), "serverCountryCode");
     QCOMPARE(sd.exitCityName(), "serverCityName");
     QVERIFY(!sd.multihop());
@@ -1259,13 +1234,11 @@ void TestModels::serverDataBasic() {
     QCOMPARE(sd.toString(), "serverCityName, serverCountryCode");
 
     {
-      SettingsHolder settingsHolder;
-
-      sd.writeSettings();
-
       ServerData sd2;
+      sd2.initialize();
+
       QVERIFY(sd2.fromSettings());
-      QVERIFY(sd2.initialized());
+      QVERIFY(sd2.hasServerData());
       QCOMPARE(sd2.exitCountryCode(), "serverCountryCode");
       QCOMPARE(sd2.exitCityName(), "serverCityName");
       QVERIFY(!sd2.multihop());
@@ -1282,7 +1255,7 @@ void TestModels::serverDataBasic() {
   sd.update("new Country Code", "new City");
   QCOMPARE(spy.count(), 2);
 
-  QVERIFY(sd.initialized());
+  QVERIFY(sd.hasServerData());
   QCOMPARE(sd.exitCountryCode(), "new Country Code");
   QCOMPARE(sd.exitCityName(), "new City");
   QVERIFY(!sd.multihop());
@@ -1295,24 +1268,21 @@ void TestModels::serverDataBasic() {
   sd.forget();
   QCOMPARE(spy.count(), 2);
 
-  QVERIFY(!sd.initialized());
-  QCOMPARE(sd.exitCountryCode(), "new Country Code");
-  QCOMPARE(sd.exitCityName(), "new City");
+  QVERIFY(!sd.hasServerData());
+  QCOMPARE(sd.exitCountryCode(), "");
+  QCOMPARE(sd.exitCityName(), "");
   QVERIFY(!sd.multihop());
   QCOMPARE(sd.entryCountryCode(), "");
   QCOMPARE(sd.entryCityName(), "");
-  QCOMPARE(sd.previousExitCountryCode(), "serverCountryCode");
-  QCOMPARE(sd.previousExitCityName(), "serverCityName");
+  QCOMPARE(sd.previousExitCountryCode(), "");
+  QCOMPARE(sd.previousExitCityName(), "");
   QCOMPARE(sd.toString(), "");
 
-  {
-    SettingsHolder settingsHolder;
-    QVERIFY(!sd.fromSettings());
-    QCOMPARE(spy.count(), 2);
-  }
+  QVERIFY(sd.fromSettings());
+  QCOMPARE(spy.count(), 3);
 
   sd.update("new Country Code", "new City", "entry Country Code", "entry City");
-  QVERIFY(sd.initialized());
+  QVERIFY(sd.hasServerData());
   QCOMPARE(sd.exitCountryCode(), "new Country Code");
   QCOMPARE(sd.exitCityName(), "new City");
   QVERIFY(sd.multihop());
@@ -1324,16 +1294,16 @@ void TestModels::serverDataBasic() {
            "entry City, entry Country Code -> new City, new Country Code");
 
   sd.forget();
-  QCOMPARE(spy.count(), 3);
+  QCOMPARE(spy.count(), 4);
 
-  QVERIFY(!sd.initialized());
-  QCOMPARE(sd.exitCountryCode(), "new Country Code");
-  QCOMPARE(sd.exitCityName(), "new City");
-  QVERIFY(sd.multihop());
-  QCOMPARE(sd.entryCountryCode(), "entry Country Code");
-  QCOMPARE(sd.entryCityName(), "entry City");
-  QCOMPARE(sd.previousExitCountryCode(), "new Country Code");
-  QCOMPARE(sd.previousExitCityName(), "new City");
+  QVERIFY(!sd.hasServerData());
+  QCOMPARE(sd.exitCountryCode(), "");
+  QCOMPARE(sd.exitCityName(), "");
+  QVERIFY(!sd.multihop());
+  QCOMPARE(sd.entryCountryCode(), "");
+  QCOMPARE(sd.entryCityName(), "");
+  QCOMPARE(sd.previousExitCountryCode(), "");
+  QCOMPARE(sd.previousExitCityName(), "");
 }
 
 void TestModels::serverDataMigrate() {
@@ -1343,6 +1313,8 @@ void TestModels::serverDataMigrate() {
     settingsHolder.setCurrentServerCityDeprecated("bar");
 
     ServerData sd;
+    sd.initialize();
+
     QVERIFY(sd.fromSettings());
 
     QCOMPARE(sd.exitCountryCode(), "foo");
@@ -1358,6 +1330,8 @@ void TestModels::serverDataMigrate() {
     QVERIFY(!settingsHolder.hasEntryServerCityDeprecated());
 
     ServerData sd2;
+    sd2.initialize();
+
     QVERIFY(sd2.fromSettings());
 
     QCOMPARE(sd2.exitCountryCode(), "foo");
@@ -1381,6 +1355,8 @@ void TestModels::serverDataMigrate() {
     settingsHolder.setEntryServerCityDeprecated("bb");
 
     ServerData sd;
+    sd.initialize();
+
     QVERIFY(sd.fromSettings());
 
     QCOMPARE(sd.exitCountryCode(), "foo");
@@ -1396,6 +1372,8 @@ void TestModels::serverDataMigrate() {
     QVERIFY(!settingsHolder.hasEntryServerCityDeprecated());
 
     ServerData sd2;
+    sd2.initialize();
+
     QVERIFY(sd2.fromSettings());
 
     QCOMPARE(sd2.exitCountryCode(), "foo");

--- a/tests/unit/testmodels.cpp
+++ b/tests/unit/testmodels.cpp
@@ -1254,6 +1254,8 @@ void TestModels::serverDataBasic() {
     QVERIFY(!sd.multihop());
     QCOMPARE(sd.entryCountryCode(), "");
     QCOMPARE(sd.entryCityName(), "");
+    QCOMPARE(sd.previousExitCountryCode(), "");
+    QCOMPARE(sd.previousExitCityName(), "");
     QCOMPARE(sd.toString(), "serverCityName, serverCountryCode");
 
     {
@@ -1269,6 +1271,8 @@ void TestModels::serverDataBasic() {
       QVERIFY(!sd2.multihop());
       QCOMPARE(sd2.entryCountryCode(), "");
       QCOMPARE(sd2.entryCityName(), "");
+      QCOMPARE(sd2.previousExitCountryCode(), "");
+      QCOMPARE(sd2.previousExitCityName(), "");
       QCOMPARE(sd2.toString(), "serverCityName, serverCountryCode");
 
       QCOMPARE(spy.count(), 1);
@@ -1284,6 +1288,8 @@ void TestModels::serverDataBasic() {
   QVERIFY(!sd.multihop());
   QCOMPARE(sd.entryCountryCode(), "");
   QCOMPARE(sd.entryCityName(), "");
+  QCOMPARE(sd.previousExitCountryCode(), "serverCountryCode");
+  QCOMPARE(sd.previousExitCityName(), "serverCityName");
   QCOMPARE(sd.toString(), "new City, new Country Code");
 
   sd.forget();
@@ -1295,6 +1301,8 @@ void TestModels::serverDataBasic() {
   QVERIFY(!sd.multihop());
   QCOMPARE(sd.entryCountryCode(), "");
   QCOMPARE(sd.entryCityName(), "");
+  QCOMPARE(sd.previousExitCountryCode(), "serverCountryCode");
+  QCOMPARE(sd.previousExitCityName(), "serverCityName");
   QCOMPARE(sd.toString(), "");
 
   {
@@ -1310,6 +1318,8 @@ void TestModels::serverDataBasic() {
   QVERIFY(sd.multihop());
   QCOMPARE(sd.entryCountryCode(), "entry Country Code");
   QCOMPARE(sd.entryCityName(), "entry City");
+  QCOMPARE(sd.previousExitCountryCode(), "new Country Code");
+  QCOMPARE(sd.previousExitCityName(), "new City");
   QCOMPARE(sd.toString(),
            "entry City, entry Country Code -> new City, new Country Code");
 
@@ -1322,6 +1332,8 @@ void TestModels::serverDataBasic() {
   QVERIFY(sd.multihop());
   QCOMPARE(sd.entryCountryCode(), "entry Country Code");
   QCOMPARE(sd.entryCityName(), "entry City");
+  QCOMPARE(sd.previousExitCountryCode(), "new Country Code");
+  QCOMPARE(sd.previousExitCityName(), "new City");
 }
 
 void TestModels::serverDataMigrate() {

--- a/tests/unit/testmodels.cpp
+++ b/tests/unit/testmodels.cpp
@@ -1322,16 +1322,82 @@ void TestModels::serverDataBasic() {
   QVERIFY(sd.multihop());
   QCOMPARE(sd.entryCountryCode(), "entry Country Code");
   QCOMPARE(sd.entryCityName(), "entry City");
+}
 
-  sd.forget();
-  QVERIFY(sd.fromString("Eureka, CA, us -> McMurdo Station, aq"));
-  QVERIFY(sd.initialized());
-  QCOMPARE(sd.exitCountryCode(), "aq");
-  QCOMPARE(sd.exitCityName(), "McMurdo Station");
-  QVERIFY(sd.multihop());
-  QCOMPARE(sd.entryCountryCode(), "us");
-  QCOMPARE(sd.entryCityName(), "Eureka, CA");
-  QCOMPARE(sd.toString(), "Eureka, CA, us -> McMurdo Station, aq");
+void TestModels::serverDataMigrate() {
+  {
+    SettingsHolder settingsHolder;
+    settingsHolder.setCurrentServerCountryCodeDeprecated("foo");
+    settingsHolder.setCurrentServerCityDeprecated("bar");
+
+    ServerData sd;
+    QVERIFY(sd.fromSettings());
+
+    QCOMPARE(sd.exitCountryCode(), "foo");
+    QCOMPARE(sd.exitCityName(), "bar");
+    QVERIFY(!sd.multihop());
+    QCOMPARE(sd.entryCountryCode(), "");
+    QCOMPARE(sd.entryCityName(), "");
+
+    QVERIFY(settingsHolder.hasServerData());
+    QVERIFY(!settingsHolder.hasCurrentServerCountryCodeDeprecated());
+    QVERIFY(!settingsHolder.hasCurrentServerCityDeprecated());
+    QVERIFY(!settingsHolder.hasEntryServerCountryCodeDeprecated());
+    QVERIFY(!settingsHolder.hasEntryServerCityDeprecated());
+
+    ServerData sd2;
+    QVERIFY(sd2.fromSettings());
+
+    QCOMPARE(sd2.exitCountryCode(), "foo");
+    QCOMPARE(sd2.exitCityName(), "bar");
+    QVERIFY(!sd2.multihop());
+    QCOMPARE(sd2.entryCountryCode(), "");
+    QCOMPARE(sd2.entryCityName(), "");
+
+    QVERIFY(settingsHolder.hasServerData());
+    QVERIFY(!settingsHolder.hasCurrentServerCountryCodeDeprecated());
+    QVERIFY(!settingsHolder.hasCurrentServerCityDeprecated());
+    QVERIFY(!settingsHolder.hasEntryServerCountryCodeDeprecated());
+    QVERIFY(!settingsHolder.hasEntryServerCityDeprecated());
+  }
+
+  {
+    SettingsHolder settingsHolder;
+    settingsHolder.setCurrentServerCountryCodeDeprecated("foo");
+    settingsHolder.setCurrentServerCityDeprecated("bar");
+    settingsHolder.setEntryServerCountryCodeDeprecated("aa");
+    settingsHolder.setEntryServerCityDeprecated("bb");
+
+    ServerData sd;
+    QVERIFY(sd.fromSettings());
+
+    QCOMPARE(sd.exitCountryCode(), "foo");
+    QCOMPARE(sd.exitCityName(), "bar");
+    QVERIFY(sd.multihop());
+    QCOMPARE(sd.entryCountryCode(), "aa");
+    QCOMPARE(sd.entryCityName(), "bb");
+
+    QVERIFY(settingsHolder.hasServerData());
+    QVERIFY(!settingsHolder.hasCurrentServerCountryCodeDeprecated());
+    QVERIFY(!settingsHolder.hasCurrentServerCityDeprecated());
+    QVERIFY(!settingsHolder.hasEntryServerCountryCodeDeprecated());
+    QVERIFY(!settingsHolder.hasEntryServerCityDeprecated());
+
+    ServerData sd2;
+    QVERIFY(sd2.fromSettings());
+
+    QCOMPARE(sd2.exitCountryCode(), "foo");
+    QCOMPARE(sd2.exitCityName(), "bar");
+    QVERIFY(sd2.multihop());
+    QCOMPARE(sd2.entryCountryCode(), "aa");
+    QCOMPARE(sd2.entryCityName(), "bb");
+
+    QVERIFY(settingsHolder.hasServerData());
+    QVERIFY(!settingsHolder.hasCurrentServerCountryCodeDeprecated());
+    QVERIFY(!settingsHolder.hasCurrentServerCityDeprecated());
+    QVERIFY(!settingsHolder.hasEntryServerCountryCodeDeprecated());
+    QVERIFY(!settingsHolder.hasEntryServerCityDeprecated());
+  }
 }
 
 // User

--- a/tests/unit/testmodels.h
+++ b/tests/unit/testmodels.h
@@ -41,6 +41,7 @@ class TestModels final : public TestHelper {
   void serverCountryModelPick();
 
   void serverDataBasic();
+  void serverDataMigrate();
 
   void userBasic();
   void userFromJson_data();


### PR DESCRIPTION
After the ending of some tutorials, we want to restore the previous settings and the previous VPN connections. In order to do this we need to make the SettingsHolder drive the VPN exit/entry server values. I achieved this result in few steps. Reviewing by commit is probably better. The commits are:

1. Remove unused methods - nothing special to say here
2. Migrate server-config to a single settings key - we need 1 single setting key for the servers in order to avoid multiple controller operations. The new key is called 'serverData' and it's a JSON object. This commit contains the migration from the current 4 key settings. Unit-test included
3. Move the server city/country logic in ServerData - this is mainly cleanup. The selection of servers now is handled by ServerData instead of the controller. The controller waits for SettingsHolder events.
4. Be consistent with the property names - this cleans up the property names in ServerData
5. No dup ServerData in the codebase - it turned out that we were creating multiple ServerData for funny reasons.
6. Revert multi-hop changes - finally we can change the tutorial manifests!
7. Fix the unit-test - update of unit-tests