### PR TITLE
Weight random server selection by number of servers.

### DIFF
--- a/src/models/servercountrymodel.cpp
+++ b/src/models/servercountrymodel.cpp
@@ -246,22 +246,31 @@ int ServerCountryModel::cityConnectionScore(const ServerCity& city) const {
 
 QStringList ServerCountryModel::pickRandom() {
   logger.debug() << "Choosing a random server";
+  qsizetype index = QRandomGenerator::global()->generate() % m_servers.count();
 
-  QStringList serverTuple;
+  // Iterate to find the selected country and city. This winds up weighting the
+  // choice of city proportional to the number of servers hosted there.
+  for (auto country = m_countries.cbegin(); country != m_countries.cend();
+       country++) {
+    for (auto city = country->cities().cbegin();
+         city != country->cities().cend(); city++) {
+      if (index >= city->servers().count()) {
+        // Keep searching.
+        index -= city->servers().count();
+      } else {
+        // We found our selection.
+        QStringList serverChoice = {
+          country->code(), city->name(),
+          ServerI18N::translateCityName(country->code(), city->name())
+        };
+        return serverChoice;
+      }
+    }
+  }
 
-  quint32 countryId =
-      QRandomGenerator::global()->generate() % m_countries.length();
-  const ServerCountry& country = m_countries[countryId];
-
-  quint32 cityId =
-      QRandomGenerator::global()->generate() % country.cities().length();
-  const ServerCity& city = country.cities().at(cityId);
-
-  serverTuple.append(country.code());
-  serverTuple.append(city.name());
-  serverTuple.append(
-      ServerI18N::translateCityName(country.code(), city.name()));
-  return serverTuple;
+  // We should not get here, unless the model has more entries in m_servers()
+  // than actually exist in the country and city lists.
+  Q_ASSERT(false);
 }
 
 bool ServerCountryModel::exists(const QString& countryCode,

--- a/src/models/servercountrymodel.cpp
+++ b/src/models/servercountrymodel.cpp
@@ -260,9 +260,8 @@ QStringList ServerCountryModel::pickRandom() {
       } else {
         // We found our selection.
         QStringList serverChoice = {
-          country->code(), city->name(),
-          ServerI18N::translateCityName(country->code(), city->name())
-        };
+            country->code(), city->name(),
+            ServerI18N::translateCityName(country->code(), city->name())};
         return serverChoice;
       }
     }

--- a/src/models/servercountrymodel.h
+++ b/src/models/servercountrymodel.h
@@ -83,6 +83,8 @@ class ServerCountryModel final : public QAbstractListModel {
  private:
   [[nodiscard]] bool fromJsonInternal(const QByteArray& data);
 
+  void pickRandomInternal(QString& countryCode, QString& cityName) const;
+
   void sortCountries();
   int cityConnectionScore(const ServerCity& city) const;
 


### PR DESCRIPTION
## Description
Our current algorithm to pick a random location does so in a non-uniform manner by choosing a random country and then choosting a random city within it. This disproportionately causes the selection algorithm to bias unfairly towards locations in smaller countries with fewer cities. For example, `Skopje, Macedonia` with a single server is given an equal proportion of the generated selections as all of the United States combined.

We feel that it is fairer to select a location that is weighted by the number of servers available to it. This should result in a fairer distribution of load that better matches the capacity of a given location.

## Reference

    i.e Jira or Github issue URL

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
