### PR TITLE
Split dummy client into its own cmake target

### DIFF
--- a/.github/workflows/functional_tests.yaml
+++ b/.github/workflows/functional_tests.yaml
@@ -52,15 +52,15 @@ jobs:
 
           mkdir -p build/cmake
           mkdir -p build/profile
-          cmake -S $(pwd) -B build/cmake -DBUILD_DUMMY=ON \
+          cmake -S $(pwd) -B build/cmake \
               -DCMAKE_CXX_FLAGS="--coverage -fprofile-generate=$(pwd)/build/profile" \
               -DCMAKE_EXE_LINKER_FLAGS="--coverage -fprofile-generate=$(pwd)/build/profile"
-          cmake --build build/cmake -j$(nproc)
+          cmake --build build/cmake -j$(nproc) --target dummyvpn
 
           mkdir -p build/profile
           rsync -a --include '*/' --include '*.gcno' --exclude '*' \
-              build/cmake/src/CMakeFiles/mozillavpn.dir/ build/profile/
-          cp ./build/cmake/src/mozillavpn build/
+              build/cmake/tests/dummyvpn/CMakeFiles/dummyvpn.dir/ build/profile/
+          cp ./build/cmake/tests/dummyvpn/dummyvpn build/
 
       - uses: actions/upload-artifact@v3
         with:
@@ -122,8 +122,8 @@ jobs:
       - name: Check build
         shell: bash
         run: |
-            chmod +x ./build/mozillavpn
-            ./build/mozillavpn -v
+            chmod +x ./build/dummyvpn
+            ./build/dummyvpn -v
 
             chmod +x ${{github.workspace}}/grcov-build/bin/grcov
             ${{github.workspace}}/grcov-build/bin/grcov --version
@@ -146,7 +146,7 @@ jobs:
             xvfb-run -a npm run functionalTest -- ${{matrix.test.path}}
         env:
           ARTIFACT_DIR: ${{ runner.temp }}/artifacts
-          MVPN_BIN: ./build//mozillavpn
+          MVPN_BIN: ./build/dummyvpn
 
       - name: Generating grcov reports
         id: generateGrcov

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,8 +69,6 @@ if(APPLE)
     endif()
 endif()
 
-option(BUILD_DUMMY "Build for the dummy platform" OFF)
-
 if(NOT DEFINED BUILD_ID)
     string(TIMESTAMP BUILD_ID "${PROJECT_VERSION_MAJOR}.%Y%m%d%H%M")
     message("Generated BUILD_ID: ${BUILD_ID}")
@@ -150,6 +148,9 @@ if(NOT CMAKE_CROSSCOMPILING)
     add_subdirectory(tests/nativemessaging EXCLUDE_FROM_ALL)
     add_subdirectory(tests/unit EXCLUDE_FROM_ALL)
     add_subdirectory(tests/qml EXCLUDE_FROM_ALL)
+
+    # Dummy Testing Client
+    add_subdirectory(tests/dummyvpn EXCLUDE_FROM_ALL)
 endif()
 
 # Extra platform targets

--- a/README.md
+++ b/README.md
@@ -514,11 +514,15 @@ ctest --test-dir build
 
 > **Note**: Functional tests require a dummy build of the application, which is not
 > built by default. Ensure the `dummyvpn` target is built, by running:
-> `cmake --build build -j$(nproc) --target dummyvpn`
+> ```
+> cmake --build build -j$(nproc) --target dummyvpn
+> ```
 >
 > This will create a dummy build under the `tests/dummyvpn` folder. To run the functional
 > tests against this build, make sure the `MVPN_BIN` environment variable is set:
-> `export MVPN_BIN=$(pwd)/build/tests/dummyvpn/dummyvpn`
+> ```
+> export MVPN_BIN=$(pwd)/build/tests/dummyvpn/dummyvpn
+> ```
 
 ## Developer Options and staging environment
 

--- a/README.md
+++ b/README.md
@@ -512,16 +512,13 @@ ctest --test-dir build
  * `ARTIFACT_DIR` - optional (directory to put screenshots from test failures)
 * Run a test from the root of the project: `npm run functionalTest path/to/testFile.js`. To run, say, the authentication tests: `npm run functionalTest tests/functional/testAuthenticationInApp.js`.
 
-> **Note**: Functional tests require a dummy build of the application.
-> In order to create such a build, on the root folder of this repository run:
+> **Note**: Functional tests require a dummy build of the application, which is not
+> built by default. Ensure the `dummyvpn` target is built, by running:
+> `cmake --build build -j$(nproc) --target dummyvpn`
 >
-> ```
-> cmake -S . -B ./dummybuild -DBUILD_DUMMY=ON
-> cmake --build dummybuild -j$(nproc)
-> ```
->
-> This will create a dummy build under the `dummybuild/` folder. To run the functional tests against this build,
-> make sure the `MVPN_BIN` environment variable is pointing to the application under the `dummybuild/` folder.
+> This will create a dummy build under the `tests/dummyvpn` folder. To run the functional
+> tests against this build, make sure the `MVPN_BIN` environment variable is set:
+> `export MVPN_BIN=$(pwd)/build/tests/dummyvpn/dummyvpn`
 
 ## Developer Options and staging environment
 

--- a/lottie/tests/qml/CMakeLists.txt
+++ b/lottie/tests/qml/CMakeLists.txt
@@ -16,7 +16,7 @@ target_sources(lottie_qmltest PRIVATE
     qml.qrc
 )
 
-add_definitions(-DQUICK_TEST_SOURCE_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}\")
+target_compile_definitions(lottie_qmltest PRIVATE QUICK_TEST_SOURCE_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}\")
 
 if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
     list(APPEND QML_TEST_ARGS -platform offscreen)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,14 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-include_directories(${CMAKE_CURRENT_SOURCE_DIR})
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/addons)
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/composer)
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/hacl-star)
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/hacl-star/kremlin)
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/hacl-star/kremlin/minimal)
-include_directories(${CMAKE_CURRENT_BINARY_DIR})
-
 # For CMake versions prior to 3.19, we may need to perform manual
 # finalization in order to pick up QML dependencies when built
 # statically.
@@ -29,14 +21,10 @@ if(NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Emscripten"
     )
 endif()
 
-target_include_directories(mozillavpn PUBLIC
-                           $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>
-                           $<INSTALL_INTERFACE:include>)
-target_link_libraries(mozillavpn PUBLIC ${CMAKE_DL_LIBS})
-target_link_libraries(mozillavpn PRIVATE glean lottie nebula translations)
-
 include(cmake/sources.cmake)
 include(cmake/sentry.cmake)
+
+target_link_libraries(mozillavpn PRIVATE mozillavpn-sources glean lottie nebula translations)
 
 if(${BUILD_DUMMY})
     set(MVPN_PLATFORM_NAME "dummy")
@@ -62,5 +50,14 @@ if(NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Emscripten")
     add_subdirectory(crashreporter)
     target_link_libraries(mozillavpn PRIVATE crashreporter vpnglean)
 endif()
+
+if(NOT CMAKE_CROSSCOMPILING)
+    target_compile_definitions(mozillavpn PUBLIC MVPN_WEBEXTENSION)
+endif()
+
+qt6_add_qml_module(mozillavpn
+  URI Mozilla.VPN.qmlcomponents
+  VERSION 1.0
+)
 
 qt_finalize_target(mozillavpn)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,9 +26,7 @@ include(cmake/sentry.cmake)
 
 target_link_libraries(mozillavpn PRIVATE mozillavpn-sources glean lottie nebula translations)
 
-if(${BUILD_DUMMY})
-    set(MVPN_PLATFORM_NAME "dummy")
-elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
     set(MVPN_PLATFORM_NAME "linux")
 elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
     set(MVPN_PLATFORM_NAME "windows")
@@ -42,8 +40,8 @@ elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Emscripten")
     set(MVPN_PLATFORM_NAME "wasm")
 endif()
 
-add_compile_definitions("$<$<CONFIG:Debug>:MVPN_DEBUG>")
-add_compile_definitions("MVPN_$<UPPER_CASE:${MVPN_PLATFORM_NAME}>")
+target_compile_definitions(mozillavpn PRIVATE "$<$<CONFIG:Debug>:MVPN_DEBUG>")
+target_compile_definitions(mozillavpn PRIVATE "MVPN_$<UPPER_CASE:${MVPN_PLATFORM_NAME}>")
 include(cmake/${MVPN_PLATFORM_NAME}.cmake)
 
 if(NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Emscripten")

--- a/src/cmake/dummy.cmake
+++ b/src/cmake/dummy.cmake
@@ -1,9 +1,0 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-target_sources(mozillavpn PRIVATE
-    platforms/dummy/dummycontroller.cpp
-    platforms/dummy/dummycontroller.h
-    platforms/dummy/dummycryptosettings.cpp
-)

--- a/src/cmake/macos.cmake
+++ b/src/cmake/macos.cmake
@@ -90,7 +90,7 @@ include(cmake/golang.cmake)
 include(cmake/signature.cmake)
 
 # Enable Balrog for update support.
-add_definitions(-DMVPN_BALROG)
+target_compile_definitions(mozillavpn PRIVATE MVPN_BALROG)
 add_go_library(balrog-api ../balrog/balrog-api.go
     CGO_CFLAGS -mmacosx-version-min=${CMAKE_OSX_DEPLOYMENT_TARGET})
 target_link_libraries(mozillavpn PRIVATE balrog-api)

--- a/src/cmake/signature.cmake
+++ b/src/cmake/signature.cmake
@@ -30,4 +30,4 @@ target_sources(mozillavpn PRIVATE
 target_link_libraries(mozillavpn PRIVATE ${GENERATED_DIR}/${LIBNAME})
 target_link_libraries(mozillavpn PUBLIC ${CMAKE_DL_LIBS})
 
-add_definitions(-DMVPN_SIGNATURE)
+target_compile_definitions(mozillavpn PRIVATE MVPN_SIGNATURE)

--- a/src/cmake/sources.cmake
+++ b/src/cmake/sources.cmake
@@ -2,12 +2,27 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+# Group the core client sources together into an interface library.
+# This allows us to pull them into multiple builds like the dummy client.
+add_library(mozillavpn-sources INTERFACE)
+
+# VPN client include paths
+set_property(TARGET mozillavpn-sources PROPERTY INTERFACE_INCLUDE_DIRECTORIES
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}/addons
+    ${CMAKE_CURRENT_SOURCE_DIR}/composer
+    ${CMAKE_CURRENT_SOURCE_DIR}/hacl-star
+    ${CMAKE_CURRENT_SOURCE_DIR}/hacl-star/kremlin
+    ${CMAKE_CURRENT_SOURCE_DIR}/hacl-star/kremlin/minimal
+    ${CMAKE_CURRENT_BINARY_DIR}
+)
+
 # Generated version header file
 configure_file(version.h.in ${CMAKE_CURRENT_BINARY_DIR}/version.h)
-target_sources(mozillavpn PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/version.h)
+target_sources(mozillavpn-sources INTERFACE ${CMAKE_CURRENT_BINARY_DIR}/version.h)
 
 # VPN Client source files
-target_sources(mozillavpn PRIVATE
+target_sources(mozillavpn-sources INTERFACE
     addons/addon.cpp
     addons/addon.h
     addons/addonapi.cpp
@@ -364,7 +379,7 @@ target_sources(mozillavpn PRIVATE
 )
 
 # VPN Client UI resources
-target_sources(mozillavpn PRIVATE
+target_sources(mozillavpn-sources INTERFACE
     ui/license.qrc
     ui/resources.qrc
     ui/ui.qrc
@@ -374,7 +389,7 @@ target_sources(mozillavpn PRIVATE
 
 # Signal handling for unix platforms
 if(UNIX)
-    target_sources(mozillavpn PRIVATE
+    target_sources(mozillavpn-sources INTERFACE
         signalhandler.cpp
         signalhandler.h
     )
@@ -382,7 +397,7 @@ endif()
 
 # Sources for desktop platforms.
 if(NOT CMAKE_CROSSCOMPILING)
-    target_sources(mozillavpn PRIVATE
+    target_sources(mozillavpn-sources INTERFACE
         systemtraynotificationhandler.cpp
         systemtraynotificationhandler.h
         tasks/authenticate/desktopauthenticationlistener.cpp
@@ -392,11 +407,4 @@ if(NOT CMAKE_CROSSCOMPILING)
         server/serverhandler.cpp
         server/serverhandler.h
     )
-
-    add_compile_definitions(MVPN_WEBEXTENSION)
 endif()
-
-qt6_add_qml_module(mozillavpn
-  URI Mozilla.VPN.qmlcomponents
-  VERSION 1.0
-)

--- a/src/cmake/windows.cmake
+++ b/src/cmake/windows.cmake
@@ -104,7 +104,7 @@ add_dependencies(mozillavpn balrogdll)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/balrog.dll DESTINATION .)
 
 # Use Balrog for update support.
-add_definitions(-DMVPN_BALROG)
+target_compile_definitions(mozillavpn PRIVATE MVPN_BALROG)
 target_sources(mozillavpn PRIVATE
     update/balrog.cpp
     update/balrog.h

--- a/src/crashreporter/CMakeLists.txt
+++ b/src/crashreporter/CMakeLists.txt
@@ -2,23 +2,12 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-add_library(crashreporter STATIC)
+add_library(crashreporter INTERFACE)
 
-set_target_properties(crashreporter PROPERTIES FOLDER "Libs")
-target_include_directories(crashreporter PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
-
-target_link_libraries(crashreporter PRIVATE
-    Qt6::Core
-    Qt6::Gui
-    Qt6::WebSockets
-    Qt6::Widgets
-    Qt6::Qml
-    Qt6::Quick
-)
-target_link_libraries(crashreporter PRIVATE nebula translations)
+set_property(TARGET crashreporter PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_CURRENT_SOURCE_DIR})
 
 # Crash reporter source files
-target_sources(crashreporter PRIVATE
+target_sources(crashreporter INTERFACE
     crashclient.cpp
     crashclient.h
     crashreporter.cpp
@@ -38,14 +27,14 @@ target_sources(crashreporter PRIVATE
 )
 
 # Crash reporter UI resources
-target_sources(crashreporter PRIVATE
+target_sources(crashreporter INTERFACE
     crash_resources.qrc
     crashui.qrc
 )
 
 # Windows Crash reporter sources
 if(WIN32)
-    target_sources(crashreporter PRIVATE
+    target_sources(crashreporter INTERFACE
         platforms/windows/wincrashreporter.cpp
         platforms/windows/windowscrashclient.cpp
         platforms/windows/wincrashreporter.h

--- a/tests/auth/CMakeLists.txt
+++ b/tests/auth/CMakeLists.txt
@@ -2,10 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-add_definitions(-DUNIT_TEST)
-add_definitions(-DMVPN_DEBUG)
-add_definitions(-DMVPN_DUMMY)
-
 get_filename_component(MVPN_SOURCE_DIR ${CMAKE_SOURCE_DIR}/src ABSOLUTE)
 
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
@@ -29,8 +25,11 @@ target_link_libraries(auth_tests PRIVATE
     Qt6::Qml
     Qt6::Quick
 )
-
 target_link_libraries(auth_tests PRIVATE glean translations)
+
+target_compile_definitions(auth_tests PRIVATE UNIT_TEST)
+target_compile_definitions(auth_tests PRIVATE MVPN_DEBUG)
+target_compile_definitions(auth_tests PRIVATE MVPN_DUMMY)
 
 # VPN Client source files
 target_sources(auth_tests PRIVATE

--- a/tests/dummyvpn/CMakeLists.txt
+++ b/tests/dummyvpn/CMakeLists.txt
@@ -1,0 +1,47 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# For CMake versions prior to 3.19, we may need to perform manual
+# finalization in order to pick up QML dependencies when built
+# statically.
+qt_add_executable(dummyvpn MANUAL_FINALIZATION)
+
+target_link_libraries(dummyvpn PRIVATE
+    Qt6::Quick
+    Qt6::Test
+    Qt6::WebSockets
+    Qt6::Widgets
+)
+
+if(NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Emscripten" 
+   AND NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Android" )
+    target_link_libraries(dummyvpn PRIVATE
+        Qt6::NetworkAuth
+    )
+endif()
+
+target_link_libraries(dummyvpn PRIVATE
+    mozillavpn-sources
+    glean
+    lottie
+    nebula
+    translations
+    vpnglean
+)
+
+target_sources(dummyvpn PRIVATE
+    ${CMAKE_SOURCE_DIR}/src/platforms/dummy/dummycontroller.cpp
+    ${CMAKE_SOURCE_DIR}/src/platforms/dummy/dummycontroller.h
+    ${CMAKE_SOURCE_DIR}/src/platforms/dummy/dummycryptosettings.cpp
+)
+
+target_compile_definitions(dummyvpn PRIVATE MVPN_DEBUG)
+target_compile_definitions(dummyvpn PRIVATE MVPN_DUMMY)
+
+qt6_add_qml_module(dummyvpn
+  URI Mozilla.VPN.qmlcomponents
+  VERSION 1.0
+)
+
+qt_finalize_target(dummyvpn)

--- a/tests/qml/CMakeLists.txt
+++ b/tests/qml/CMakeLists.txt
@@ -2,10 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-add_definitions(-DQUICK_TEST_SOURCE_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}\")
-add_definitions(-DUNIT_TEST)
-add_definitions(-DMVPN_DUMMY)
-
 get_filename_component(MVPN_SOURCE_DIR ${CMAKE_SOURCE_DIR}/src ABSOLUTE)
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
@@ -28,6 +24,10 @@ target_link_libraries(qml_tests PRIVATE
 )
 
 target_link_libraries(qml_tests PRIVATE glean lottie nebula translations)
+
+target_compile_definitions(qml_tests PRIVATE QUICK_TEST_SOURCE_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}\")
+target_compile_definitions(qml_tests PRIVATE UNIT_TEST)
+target_compile_definitions(qml_tests PRIVATE MVPN_DUMMY)
 
 # VPN Client source files
 target_sources(qml_tests PRIVATE

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -2,9 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-add_definitions(-DUNIT_TEST)
-add_definitions(-DMVPN_ADJUST)
-
 get_filename_component(MVPN_SOURCE_DIR ${CMAKE_SOURCE_DIR}/src ABSOLUTE)
 
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
@@ -31,14 +28,12 @@ target_link_libraries(unit_tests PRIVATE
     Qt6::Quick
 )
 
+target_compile_definitions(unit_tests PRIVATE UNIT_TEST)
+target_compile_definitions(unit_tests PRIVATE MVPN_ADJUST)
+
 target_link_libraries(unit_tests PRIVATE glean lottie nebula translations)
 if(NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Emscripten")
-    target_link_libraries(unit_tests PRIVATE vpnglean -ldl)
-    add_dependencies(unit_tests vpnglean)
-
-    if (WIN32)
-        target_link_libraries(unit_tests PRIVATE ntdll)
-    endif()
+    target_link_libraries(unit_tests PRIVATE vpnglean)
 endif()
 
 # VPN Client source files

--- a/vpnglean/CMakeLists.txt
+++ b/vpnglean/CMakeLists.txt
@@ -147,8 +147,7 @@ set_property(TARGET vpnglean APPEND PROPERTY INTERFACE_INCLUDE_DIRECTORIES
 )
 
 ## Fixup any missing link dependencies to pass to the vpnglean consumer
-set_property(TARGET vpnglean APPEND PROPERTY
-        INTERFACE_LINK_LIBRARIES -ldl)
+set_property(TARGET vpnglean APPEND PROPERTY INTERFACE_LINK_LIBRARIES ${CMAKE_DL_LIBS})
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     find_package(OpenSSL REQUIRED)
     set_property(TARGET vpnglean APPEND PROPERTY


### PR DESCRIPTION
## Description
This allows us to generate both the genuine and dummy builds of the VPN client from the same cmake build directory, and eliminates the need for the `BUILD_DUMMY` configuration option. This also fixes building of the dummy client on MacOS, where cmake attempts to build the installer package.

This changes the path of the generated dummy client from `<build-dir>/src/mozillavpn` to `<build-dir>/tests/dummyvpn/dummyvpn`

This also lays some groundwork for making the dummy client runnable on mobile devices and their simulators (eg: by setting the `MACOSX_BUNDLE` attribute).

## References
Github issue #4114 ([VPN-2637](https://mozilla-hub.atlassian.net/browse/VPN-2637))
Github issue #5114 ([VPN-3427](https://mozilla-hub.atlassian.net/browse/VPN-3427))

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
