### PR TITLE
VPN-3382 - Do not use QVector to pass data to through the FFI boundary

### DIFF
--- a/vpnglean/glean_parser_ext/run_glean_parser.py
+++ b/vpnglean/glean_parser_ext/run_glean_parser.py
@@ -89,7 +89,7 @@ if __name__ == "__main__":
         # Generate C++ files
         for [ output, input ] in [
             [os.path.join(generated_files_path, "pings.h"), os.path.join(yaml_files_path, "pings.yaml")],
-            [os.path.join(generated_files_path, "metrics.h"), os.path.join(yaml_files_path, "pings.yaml")],
+            [os.path.join(generated_files_path, "metrics.h"), os.path.join(yaml_files_path, "metrics.yaml")],
         ]:
             print("Generating {} from {}".format(output, input))
             with open(output, 'w+', encoding='utf-8') as f:

--- a/vpnglean/glean_parser_ext/templates/cpp.jinja2
+++ b/vpnglean/glean_parser_ext/templates/cpp.jinja2
@@ -41,20 +41,23 @@ struct {{ obj.name|Camelize }}{{ suffix }} {
     const char* extraKeys[{{ obj|attr(name)|length }} + 1];
     const char* extraValues[{{ obj|attr(name)|length }} + 1];
     int count = 0;
+
+    QVector<QByteArray> _keepStringsAlive;
     {% for item, type in obj|attr(name) %}
     if (_{{item|camelize}}.canConvert<{{type|extra_type_name}}>()) {
       extraKeys[count] = "{{item}}";
       {% if type == "string" %}
-      extraValues[count] = _{{item|camelize}}.toString().toUtf8().constData();
+      _keepStringsAlive.append(_{{item|camelize}}.toString().toUtf8());
+      extraValues[count] = _keepStringsAlive[count].constData();
       {% elif type == "boolean" %}
-      extraValues[count] = _{{item|camelize}}.toBool() ? "true" : "false";
+      _keepStringsAlive.append(_{{item|camelize}}.toBool() ? "true" : "false");
+      extraValues[count] = _keepStringsAlive[count];
       {% elif type == "quantity" %}
-      std::string s = std::to_string(_{{item|camelize}}.toInt());
-      extraValues[count] = s.c_str();
+      _keepStringsAlive.append(QString::number(_{{item|camelize}}.toInt()).toUtf8());
+      extraValues[count] = _keepStringsAlive[count].constData();
       {% else %}
 #error "Glean: Invalid extra key type for metric {{obj.category}}.{{obj.name}}, defined in: {{obj.defined_in['filepath']}}:{{obj.defined_in['line']}})"
       {% endif %}
-
       count++;
     }
     {% endfor %}

--- a/vpnglean/glean_parser_ext/templates/cpp.jinja2
+++ b/vpnglean/glean_parser_ext/templates/cpp.jinja2
@@ -45,11 +45,12 @@ struct {{ obj.name|Camelize }}{{ suffix }} {
     QVector<QByteArray> _keepStringsAlive;
     {% for item, type in obj|attr(name) %}
     if (_{{item|camelize}}.canConvert<{{type|extra_type_name}}>()) {
-      extraKeys[count] = "{{item}}";
       {% if type == "string" %}
       _keepStringsAlive.append(_{{item|camelize}}.toString().toUtf8());
       extraValues[count] = _keepStringsAlive[count].constData();
       {% elif type == "boolean" %}
+      // We don't need to actually keep these alive since they are literal strings.
+      // However we want to keep the indexes of keepStringsAlive in sync with the indexes of extraValues, so we keep this.
       _keepStringsAlive.append(_{{item|camelize}}.toBool() ? "true" : "false");
       extraValues[count] = _keepStringsAlive[count];
       {% elif type == "quantity" %}
@@ -58,6 +59,7 @@ struct {{ obj.name|Camelize }}{{ suffix }} {
       {% else %}
 #error "Glean: Invalid extra key type for metric {{obj.category}}.{{obj.name}}, defined in: {{obj.defined_in['filepath']}}:{{obj.defined_in['line']}})"
       {% endif %}
+      extraKeys[count] = "{{item}}";
       count++;
     }
     {% endfor %}

--- a/vpnglean/glean_parser_ext/templates/cpp.jinja2
+++ b/vpnglean/glean_parser_ext/templates/cpp.jinja2
@@ -38,19 +38,20 @@ struct {{ obj.name|Camelize }}{{ suffix }} {
   {% endfor %}
 
   FfiExtra ToFfiExtra() const {
+    m_keepStringsAlive.clear();
+
     const char* extraKeys[{{ obj|attr(name)|length }} + 1];
     const char* extraValues[{{ obj|attr(name)|length }} + 1];
     int count = 0;
 
-    QVector<QByteArray> _keepStringsAlive;
     {% for item, type in obj|attr(name) %}
     if (_{{item|camelize}}.canConvert<{{type|extra_type_name}}>()) {
       {% if type == "string" %}
       QByteArray s = _{{item|camelize}}.toString().toUtf8();
-      _keepStringsAlive.append(s);
+      m_keepStringsAlive.append(s);
       extraValues[count] = s.constData();
       {% elif type == "boolean" %}
-      extraValues[count] = _keepStringsAlive[count];
+      extraValues[count] = m_keepStringsAlive[count];
       {% elif type == "quantity" %}
       QByteArray s = QString::number(_{{item|camelize}}.toInt()).toUtf8();
       extraValues[count] = s.constData();
@@ -68,6 +69,11 @@ struct {{ obj.name|Camelize }}{{ suffix }} {
     extras.count = count;
     return extras;
   };
+
+  private:
+    // Helper vector to extend the lifetime of the strings
+    // that hold the extra key values until they are used.
+    QVector<QByteArray> m_keepStringsAlive;
 };
 {%- endmacro %}
 

--- a/vpnglean/glean_parser_ext/templates/cpp.jinja2
+++ b/vpnglean/glean_parser_ext/templates/cpp.jinja2
@@ -38,28 +38,31 @@ struct {{ obj.name|Camelize }}{{ suffix }} {
   {% endfor %}
 
   FfiExtra ToFfiExtra() const {
-    QVector<const char*> extraKeys;
-    QVector<const char*> extraValues;
+    const char* extraKeys[{{ obj|attr(name)|length }} + 1];
+    const char* extraValues[{{ obj|attr(name)|length }} + 1];
+    int count = 0;
     {% for item, type in obj|attr(name) %}
     if (_{{item|camelize}}.canConvert<{{type|extra_type_name}}>()) {
-      extraKeys.append("{{item}}");
+      extraKeys[count] = "{{item}}";
       {% if type == "string" %}
-      extraValues.append(_{{item|camelize}}.toString().toUtf8().constData());
+      extraValues[count] = _{{item|camelize}}.toString().toUtf8().constData();
       {% elif type == "boolean" %}
-      extraValues.append(_{{item|camelize}}.toBool() ? "true" : "false");
+      extraValues[count] = _{{item|camelize}}.toBool() ? "true" : "false";
       {% elif type == "quantity" %}
       std::string s = std::to_string(_{{item|camelize}}.toInt());
-      extraValues.append(s.c_str());
+      extraValues[count] = s.c_str();
       {% else %}
 #error "Glean: Invalid extra key type for metric {{obj.category}}.{{obj.name}}, defined in: {{obj.defined_in['filepath']}}:{{obj.defined_in['line']}})"
       {% endif %}
+
+      count++;
     }
     {% endfor %}
 
     FfiExtra extras;
-    extras.keys = std::move(extraKeys.begin());
-    extras.values = std::move(extraValues.begin());
-    extras.count = extraValues.count();
+    extras.keys = std::move(extraKeys);
+    extras.values = std::move(extraValues);
+    extras.count = count;
     return extras;
   };
 };

--- a/vpnglean/glean_parser_ext/templates/cpp.jinja2
+++ b/vpnglean/glean_parser_ext/templates/cpp.jinja2
@@ -46,16 +46,14 @@ struct {{ obj.name|Camelize }}{{ suffix }} {
     {% for item, type in obj|attr(name) %}
     if (_{{item|camelize}}.canConvert<{{type|extra_type_name}}>()) {
       {% if type == "string" %}
-      _keepStringsAlive.append(_{{item|camelize}}.toString().toUtf8());
-      extraValues[count] = _keepStringsAlive[count].constData();
+      QByteArray s = _{{item|camelize}}.toString().toUtf8();
+      _keepStringsAlive.append(s);
+      extraValues[count] = s.constData();
       {% elif type == "boolean" %}
-      // We don't need to actually keep these alive since they are literal strings.
-      // However we want to keep the indexes of keepStringsAlive in sync with the indexes of extraValues, so we keep this.
-      _keepStringsAlive.append(_{{item|camelize}}.toBool() ? "true" : "false");
       extraValues[count] = _keepStringsAlive[count];
       {% elif type == "quantity" %}
-      _keepStringsAlive.append(QString::number(_{{item|camelize}}.toInt()).toUtf8());
-      extraValues[count] = _keepStringsAlive[count].constData();
+      QByteArray s = QString::number(_{{item|camelize}}.toInt()).toUtf8();
+      extraValues[count] = s.constData();
       {% else %}
 #error "Glean: Invalid extra key type for metric {{obj.category}}.{{obj.name}}, defined in: {{obj.defined_in['filepath']}}:{{obj.defined_in['line']}})"
       {% endif %}


### PR DESCRIPTION
This is what the generated code looks like right now:

```cpp
struct AddonStateChangedExtra {
  QVariant _addonId = QVariant();
  QVariant _state = QVariant();

  FfiExtra ToFfiExtra() const {
    QVector<const char*> extraKeys;
    QVector<const char*> extraValues;
    if (_addonId.canConvert<QString>()) {
      extraKeys.append("addon_id");
      extraValues.append(_addonId.toString().toUtf8().constData());
    }
    if (_state.canConvert<QString>()) {
      extraKeys.append("state");
      extraValues.append(_state.toString().toUtf8().constData());
    }

    FfiExtra extras;
    extras.keys = std::move(extraKeys.begin());
    extras.values = std::move(extraValues.begin());
    extras.count = extraValues.count();
    return extras;
  };
};
```

And what it looks like with this change:

```cpp
struct AddonStateChangedExtra {
  QVariant _addonId = QVariant();
  QVariant _state = QVariant();

  FfiExtra ToFfiExtra() const {
    const char* extraKeys[2 + 1];
    const char* extraValues[2 + 1];
    int count = 0;
    if (_addonId.canConvert<QString>()) {
      extraKeys[count] = "addon_id";
      extraValues[count] = _addonId.toString().toUtf8().constData();

      count++;
    }
    if (_state.canConvert<QString>()) {
      extraKeys[count] = "state";
      extraValues[count] = _state.toString().toUtf8().constData();

      count++;
    }

    FfiExtra extras;
    extras.keys = std::move(extraKeys);
    extras.values = std::move(extraValues);
    extras.count = count;
    return extras;
  };
};
```