### PR TITLE
Taskcluster/OSX: Upload symbols

### DIFF
--- a/src/cmake/macos.cmake
+++ b/src/cmake/macos.cmake
@@ -7,6 +7,9 @@ enable_language(OBJCXX)
 
 set_target_properties(mozillavpn PROPERTIES OUTPUT_NAME "Mozilla VPN")
 
+# Force llvm to add DWARF info on Release builds
+SET(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -g")
+
 # Configure the application bundle Info.plist
 set_target_properties(mozillavpn PROPERTIES
     MACOSX_BUNDLE ON


### PR DESCRIPTION
Currently based on #5054. 
This pr will force debug-symbols for our release build and makes sure those get uploaded to the symbol-server