### PR TITLE
Fix start On boot

### DIFF
--- a/src/commands/commandui.cpp
+++ b/src/commands/commandui.cpp
@@ -254,12 +254,12 @@ int CommandUI::run(QStringList& tokens) {
     vpn.initialize();
 
 #ifdef MVPN_MACOS
-    MacOSStartAtBootWatcher startAtBootWatcher();
+    MacOSStartAtBootWatcher startAtBootWatcher;
     MacOSUtils::setDockClickHandler();
 #endif
 
 #ifdef MVPN_WINDOWS
-    WindowsStartAtBootWatcher startAtBootWatcher();
+    WindowsStartAtBootWatcher startAtBootWatcher;
 #endif
 
 #ifdef MVPN_LINUX


### PR DESCRIPTION
We want to create the variable, 
```
MacOSStartAtBootWatcher startAtBootWatcher
```
therefore the watchers never ran.