### PR TITLE
NIT: Enforce compiler warnings as Errors

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -63,4 +63,5 @@ if(NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Emscripten")
     target_link_libraries(mozillavpn PRIVATE crashreporter vpnglean)
 endif()
 
+set_target_properties(mozillavpn PROPERTIES COMPILE_WARNING_AS_ERROR ON )
 qt_finalize_target(mozillavpn)

--- a/src/models/servercountrymodel.cpp
+++ b/src/models/servercountrymodel.cpp
@@ -270,6 +270,7 @@ QStringList ServerCountryModel::pickRandom() {
   // We should not get here, unless the model has more entries in m_servers()
   // than actually exist in the country and city lists.
   Q_ASSERT(false);
+  return QStringList();
 }
 
 bool ServerCountryModel::exists(const QString& countryCode,


### PR DESCRIPTION
## Description

The problem of #https://github.com/mozilla-mobile/mozilla-vpn-client/pull/5066 was actually pointed out as a warning. Let's make sure those become red so we see them more :) 
