### PR TITLE
iOS: Add entitlement for device name

### DIFF
--- a/ios/app/main.entitlements
+++ b/ios/app/main.entitlements
@@ -12,5 +12,7 @@
 	</array>
 	<key>com.apple.security.files.user-selected.read-write</key>
 	<true/>
+	<key>com.apple.developer.device-information.user-assigned-device-name</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
## Description

We now need an entitlement to read the user-defined device name in iOS 16. This had been [added](https://github.com/mozilla-mobile/mozilla-vpn-client/pull/4768) and then reverted once. 

This PR has been tested with some changes we made in our Apple Developer account, and it now is working end-to-end.

## Checklist
    
- [X] My code follows the style guidelines for this project
- [X] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [X] I have performed a self review of my own code
- [X] I have commented my code PARTICULARLY in hard to understand areas
- [X] I have added thorough tests where needed
