### PR TITLE
Update via web for 2.10/2.11 windows clients

### DIFF
--- a/addons/message_update_v2.12/manifest.json
+++ b/addons/message_update_v2.12/manifest.json
@@ -3,6 +3,7 @@
   "id": "message_update_v2.12",
   "name": "Update to Mozilla VPN 2.12",
   "type": "message",
+  "translatable": false,
   "conditions": {
     "max_client_version": "2.11.9"
   },

--- a/addons/message_update_v2.12/update.js
+++ b/addons/message_update_v2.12/update.js
@@ -1,3 +1,34 @@
 ((api) => {
-  api.navigator.requestScreen(api.navigator.ScreenUpdateRecommended);
+  // windows v2.10/v2.11 do require a web-based update.
+  if (api.env.platform != 'windows') {
+    api.navigator.requestScreen(api.navigator.ScreenUpdateRecommended);
+    return;
+  }
+
+  const parts = api.env.versionString.split('.');
+
+  // No idea which version we are in...
+  if (parts.length < 3) {
+    api.navigator.requestScreen(api.navigator.ScreenUpdateRecommended);
+    return;
+  }
+
+  const version = parts.map(a => parseInt(a, 10));
+
+  function versionCompare(a, b) {
+    for (let i = 0; i < 3; ++i) {
+      if (a[i] != b[i]) {
+        return a[i] > b[i] ? -1 : 1;
+      }
+    }
+    return 0;
+  }
+
+  if (versionCompare([2, 11, 1], version) >= 0 ||
+      versionCompare([2, 10, 0], version) < -1) {
+    api.navigator.requestScreen(api.navigator.ScreenUpdateRecommended);
+    return;
+  }
+
+  api.urlOpener.openLink(api.urlOpener.LinkUpdate);
 });


### PR DESCRIPTION
This is the change in the addon to force the update via web for windows if the range is [2.10.0, 2.11.0]