### PR TITLE
Functional test cleanup and speedups

### DIFF
--- a/.github/workflows/functional_tests.yaml
+++ b/.github/workflows/functional_tests.yaml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   build_test_app:
     name: Build Test Client
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       matrix: ${{ steps.testGen.outputs.tests }}
     steps:
@@ -34,10 +34,8 @@ jobs:
           # Install grcov into the build directory, to reduce downstream compilation times.
           cargo install --root $(pwd)/build grcov 
 
-          # Add external PPA for Qt6 support on Ubuntu 20.04
-          sudo add-apt-repository ppa:okirby/qt6-backports
-
           # Download the build and runtime package dependencies.
+          sudo apt-get update
           sudo apt-get -o "Dir::Cache::archives=$(pwd)/build/archive" install -y \
                $(./scripts/linux/getdeps.py -a linux/debian/control)
           sudo chown -R $USER:$USER build/archive
@@ -78,7 +76,7 @@ jobs:
     name: Functional tests
     needs: 
       - build_test_app
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 45
     strategy:
       fail-fast: false # Don't cancel other jobs if a test fails

--- a/.github/workflows/functional_tests.yaml
+++ b/.github/workflows/functional_tests.yaml
@@ -31,14 +31,24 @@ jobs:
         run: |
           mkdir -p build/archive
 
-          # Install grcov into the build directory, to reduce downstream compilation times.
-          cargo install --root $(pwd)/build grcov 
-
           # Download the build and runtime package dependencies.
           sudo apt-get update
           sudo apt-get -o "Dir::Cache::archives=$(pwd)/build/archive" install -y \
                $(./scripts/linux/getdeps.py -a linux/debian/control)
           sudo chown -R $USER:$USER build/archive
+
+      - name: Cache grcov
+        id: cache-grcov
+        uses: actions/cache@v3
+        with:
+          path: grcov-build/
+          key: ${{runner.os}}-grcov-v0.8.13
+
+      - name: Install Grcov
+        if: steps.cache-grcov.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          cargo install grcov --root ${{github.workspace}}/grcov-build --version 0.8.13
 
       - name: Compile test client
         shell: bash
@@ -97,11 +107,21 @@ jobs:
           pip3 install -r requirements.txt
           npm install
       
+      - name: Cache grcov
+        id: cache-grcov
+        uses: actions/cache@v3
+        with:
+          path: grcov-build/
+          key: ${{runner.os}}-grcov-v0.8.13
+
       - name: Check build
         shell: bash
         run: |
             chmod +x ./build/cmake/src/mozillavpn
             ./build/cmake/src/mozillavpn -v
+
+            chmod +x ${{github.workspace}}/grcov-build/bin/grcov
+            ${{github.workspace}}/grcov-build/bin/grcov --version
 
       - name: Build addons
         shell: bash
@@ -134,8 +154,8 @@ jobs:
         continue-on-error: true # Ignore GRCOV parsing errors, see github.com/mozilla/grcov/issues/570
         timeout-minutes: 1 # Give GRCOV a short timeout in case it hangs after a panic
         run: |
-          chmod +x ./build/bin/grcov
-          ./build/bin/grcov build/cmake/src/CMakeFiles/mozillavpn.dir \
+          export PATH=${{github.workspace}}/grcov-build/bin:$PATH
+          grcov build/cmake/src/CMakeFiles/mozillavpn.dir \
               -s src -t lcov --branch --ignore-not-existing \
               -o ${{runner.temp}}/artifacts/functional_lcov.info
 

--- a/.github/workflows/functional_tests.yaml
+++ b/.github/workflows/functional_tests.yaml
@@ -57,14 +57,23 @@ jobs:
           pip3 install -r requirements.txt
 
           mkdir -p build/cmake
+          mkdir -p build/profile
           cmake -S $(pwd) -B build/cmake -DBUILD_DUMMY=ON \
-              -DCMAKE_CXX_FLAGS=--coverage -DCMAKE_EXE_LINKER_FLAGS=--coverage
+              -DCMAKE_CXX_FLAGS="--coverage $(pwd)/build/profile" \
+              -DCMAKE_EXE_LINKER_FLAGS="--coverage $(pwd)/build/profile"
           cmake --build build/cmake -j$(nproc)
+
+          mkdir -p build/profile
+          rsync -a --include '*/' --include '*.gcno' --exclude '*' \
+              build/cmake/src/CMakeFiles/mozillavpn.dir/ build/profile/
+          cp ./build/cmake/src/mozillavpn build/
 
       - uses: actions/upload-artifact@v3
         with:
           name: test-client-${{ github.sha }}
-          path: build/
+          path: |
+            build/
+            !build/cmake/
 
       - name: Generate tasklist
         id: testGen
@@ -95,6 +104,7 @@ jobs:
     steps:
       - name: Clone repository
         uses: actions/checkout@v3
+
       - uses: actions/download-artifact@v3
         with:
           name: test-client-${{ github.sha }}
@@ -117,8 +127,8 @@ jobs:
       - name: Check build
         shell: bash
         run: |
-            chmod +x ./build/cmake/src/mozillavpn
-            ./build/cmake/src/mozillavpn -v
+            chmod +x ./build/mozillavpn
+            ./build/mozillavpn -v
 
             chmod +x ${{github.workspace}}/grcov-build/bin/grcov
             ${{github.workspace}}/grcov-build/bin/grcov --version
@@ -147,7 +157,7 @@ jobs:
             xvfb-run -a npm run functionalTest -- ${{matrix.test.path}}
         env:
           ARTIFACT_DIR: ${{ runner.temp }}/artifacts
-          MVPN_BIN: ./build/cmake/src/mozillavpn
+          MVPN_BIN: ./build//mozillavpn
 
       - name: Generating grcov reports
         id: generateGrcov
@@ -155,7 +165,7 @@ jobs:
         timeout-minutes: 1 # Give GRCOV a short timeout in case it hangs after a panic
         run: |
           export PATH=${{github.workspace}}/grcov-build/bin:$PATH
-          grcov build/cmake/src/CMakeFiles/mozillavpn.dir \
+          grcov build/profile \
               -s src -t lcov --branch --ignore-not-existing \
               -o ${{runner.temp}}/artifacts/functional_lcov.info
 

--- a/.github/workflows/functional_tests.yaml
+++ b/.github/workflows/functional_tests.yaml
@@ -26,16 +26,10 @@ jobs:
         with: 
           submodules: 'true'
 
-      - name: Install dependecies
-        if: steps.cache-build.outputs.cache-hit != 'true'
+      - name: Install build dependecies
         run: |
-          mkdir -p build/archive
-
-          # Download the build and runtime package dependencies.
           sudo apt-get update
-          sudo apt-get -o "Dir::Cache::archives=$(pwd)/build/archive" install -y \
-               $(./scripts/linux/getdeps.py -a linux/debian/control)
-          sudo chown -R $USER:$USER build/archive
+          sudo apt-get install -y $(./scripts/linux/getdeps.py -a linux/debian/control)
 
       - name: Cache grcov
         id: cache-grcov
@@ -110,13 +104,14 @@ jobs:
           name: test-client-${{ github.sha }}
           path: build/
 
-      - name: Install dependecies
+      - name: Install runtime dependecies
         run: |
-          sudo apt install ./build/archive/*.deb
+          sudo apt-get update
+          sudo apt-get install -y $(./scripts/linux/getdeps.py -r linux/debian/control)
           sudo apt install --no-upgrade firefox xvfb -y
           pip3 install -r requirements.txt
           npm install
-      
+
       - name: Cache grcov
         id: cache-grcov
         uses: actions/cache@v3

--- a/.github/workflows/functional_tests.yaml
+++ b/.github/workflows/functional_tests.yaml
@@ -25,6 +25,7 @@ jobs:
         uses: actions/checkout@v3
         with: 
           submodules: 'true'
+
       - name: Install dependecies
         if: steps.cache-build.outputs.cache-hit != 'true'
         run: |
@@ -61,10 +62,11 @@ jobs:
         id: testGen
         shell: bash
         run: |
-          echo -n "::set-output name=tests::"
+          echo -n "tests=" >> $GITHUB_OUTPUT
           for test in $(find tests/functional -name 'test*.js' | sort); do
             printf '{"name": "%s", "path": "%s"}' $(basename ${test%.js} | sed -n 's/test//p') $test
-          done | jq -s -c
+          done | jq -s -c >> $GITHUB_OUTPUT
+
       - name: Check tests
         shell: bash
         env:

--- a/.github/workflows/functional_tests.yaml
+++ b/.github/workflows/functional_tests.yaml
@@ -104,10 +104,10 @@ jobs:
           name: test-client-${{ github.sha }}
           path: build/
 
-      - name: Install runtime dependecies
+      - name: Install test dependecies
         run: |
           sudo apt-get update
-          sudo apt-get install -y $(./scripts/linux/getdeps.py -r linux/debian/control)
+          sudo apt-get install -y $(./scripts/linux/getdeps.py -a linux/debian/control)
           sudo apt install --no-upgrade firefox xvfb -y
           pip3 install -r requirements.txt
           npm install

--- a/.github/workflows/functional_tests.yaml
+++ b/.github/workflows/functional_tests.yaml
@@ -59,8 +59,8 @@ jobs:
           mkdir -p build/cmake
           mkdir -p build/profile
           cmake -S $(pwd) -B build/cmake -DBUILD_DUMMY=ON \
-              -DCMAKE_CXX_FLAGS="--coverage $(pwd)/build/profile" \
-              -DCMAKE_EXE_LINKER_FLAGS="--coverage $(pwd)/build/profile"
+              -DCMAKE_CXX_FLAGS="--coverage -fprofile-generate=$(pwd)/build/profile" \
+              -DCMAKE_EXE_LINKER_FLAGS="--coverage -fprofile-generate=$(pwd)/build/profile"
           cmake --build build/cmake -j$(nproc)
 
           mkdir -p build/profile

--- a/.github/workflows/ppa-automation.yaml
+++ b/.github/workflows/ppa-automation.yaml
@@ -49,7 +49,7 @@ jobs:
 
           if [[ "$GITREF" == "refs/heads/main" ]]; then
             if [[ ! -z $(git rev-list --after="25 hours" ${{github.sha}}) ]]; then
-              echo "::set-output name=nightly-changes::true"
+              echo "nightly-changes=true" >> $GITHUB_OUTPUT
             fi
           fi
 

--- a/.github/workflows/test_lottie.yaml
+++ b/.github/workflows/test_lottie.yaml
@@ -36,13 +36,13 @@ jobs:
         uses: actions/cache@v3
         with:
           path: grcov-build/
-          key: ${{runner.os}}-grcov-v0.8.9
+          key: ${{runner.os}}-grcov-v0.8.13
 
       - name: Install Grcov
         if: steps.cache-grcov.outputs.cache-hit != 'true'
         shell: bash
         run: |
-          cargo install grcov --root ${{github.workspace}}/grcov-build --version 0.8.9
+          cargo install grcov --root ${{github.workspace}}/grcov-build --version 0.8.13
 
       - name: Building tests
         shell: bash
@@ -96,13 +96,13 @@ jobs:
         uses: actions/cache@v3
         with:
           path: grcov-build/
-          key: ${{runner.os}}-grcov-v0.8.9
+          key: ${{runner.os}}-grcov-v0.8.13
 
       - name: Install Grcov
         if: steps.cache-grcov.outputs.cache-hit != 'true'
         shell: bash
         run: |
-          cargo install grcov --root ${{github.workspace}}/grcov-build --version 0.8.9
+          cargo install grcov --root ${{github.workspace}}/grcov-build --version 0.8.13
 
       - name: Building tests
         shell: bash

--- a/.github/workflows/test_unit.yaml
+++ b/.github/workflows/test_unit.yaml
@@ -93,10 +93,12 @@ jobs:
         uses: actions/checkout@v3
         with: 
           submodules: 'true'
-      - name: Install python dependencies
+
+      - name: Install dependencies
         shell: bash
         run: |
           pip3 install -r requirements.txt
+          brew install ninja
 
       - name: Install Qt6
         shell: bash
@@ -127,7 +129,7 @@ jobs:
         run: |
           export PATH=/opt/qt6/bin:${{github.workspace}}/grcov-build/bin:$PATH
           mkdir -p build
-          cmake -S . -B $(pwd)/build -DBUILD_TESTING=ON \
+          cmake -S . -B $(pwd)/build -GNinja \
             -DCMAKE_CXX_FLAGS=--coverage -DCMAKE_EXE_LINKER_FLAGS=--coverage
           cmake --build $(pwd)/build --target build_tests
 

--- a/.github/workflows/test_unit.yaml
+++ b/.github/workflows/test_unit.yaml
@@ -16,9 +16,7 @@ concurrency:
 
 jobs:
   linux-unit-tests:
-    runs-on: ubuntu-20.04
-    env:
-      QTVERSION: 6.2.4
+    runs-on: ubuntu-22.04
     name: Run Unit tests on Linux
     steps:
       - name: Clone repository
@@ -28,11 +26,9 @@ jobs:
 
       - name: Install dependences
         run: |
-          sudo apt update
-          sudo apt install git libgl-dev libegl-dev libpolkit-gobject-1-dev clang-10 liboath-dev python3 -y
-          python3 -m pip install -r requirements.txt
-          python3 -m pip install aqtinstall
-          aqt install-qt --outputdir /opt linux desktop $QTVERSION gcc_64 -m all
+          sudo apt-get update
+          sudo apt-get install -y $(./scripts/linux/getdeps.py -a linux/debian/control)
+          pip3 install -r requirements.txt
 
       - name: Cache grcov
         id: cache-grcov
@@ -51,8 +47,7 @@ jobs:
         shell: bash
         run: |
           mkdir -p build
-          cmake -S . -B $(pwd)/build -DBUILD_TESTING=ON \
-            -DCMAKE_PREFIX_PATH=/opt/$QTVERSION/gcc_64/lib/cmake/ \
+          cmake -S . -B $(pwd)/build \
             -DCMAKE_CXX_FLAGS=--coverage -DCMAKE_EXE_LINKER_FLAGS=--coverage
           cmake --build $(pwd)/build --target build_tests -j$(nproc)
 

--- a/.github/workflows/test_unit.yaml
+++ b/.github/workflows/test_unit.yaml
@@ -39,13 +39,13 @@ jobs:
         uses: actions/cache@v3
         with:
           path: grcov-build/
-          key: ${{runner.os}}-grcov-v0.8.9
+          key: ${{runner.os}}-grcov-v0.8.13
 
       - name: Install Grcov
         if: steps.cache-grcov.outputs.cache-hit != 'true'
         shell: bash
         run: |
-          cargo install grcov --root ${{github.workspace}}/grcov-build --version 0.8.9
+          cargo install grcov --root ${{github.workspace}}/grcov-build --version 0.8.13
 
       - name: Building tests
         shell: bash
@@ -114,13 +114,13 @@ jobs:
         uses: actions/cache@v3
         with:
           path: grcov-build/
-          key: ${{runner.os}}-grcov-v0.8.9
+          key: ${{runner.os}}-grcov-v0.8.13
 
       - name: Install Grcov
         if: steps.cache-grcov.outputs.cache-hit != 'true'
         shell: bash
         run: |
-          cargo install grcov --root ${{github.workspace}}/grcov-build --version 0.8.9
+          cargo install grcov --root ${{github.workspace}}/grcov-build --version 0.8.13
 
       - name: Building tests
         shell: bash

--- a/.github/workflows/wasm.yaml
+++ b/.github/workflows/wasm.yaml
@@ -63,10 +63,10 @@ jobs:
         id: testGen
         shell: bash
         run: |
-          echo -n "::set-output name=tests::"
+          echo -n "tests=" >> $GITHUB_OUTPUT
           for test in $(find tests/functional -name 'test*.js' | sort); do
             grep "$(basename ${test%.js})" tests/functional/wasm-test-ignore &>/dev/null || printf '{"name": "%s", "path": "%s"}' $(basename ${test%.js} | sed -n 's/test//p') $test
-          done | jq -s -c
+          done | jq -s -c >> $GITHUB_OUTPUT
 
       - name: Check tests
         shell: bash


### PR DESCRIPTION
## Description
I have become frustrated at the functional tests taking 25 minutes to build. Let's see if we can do better.

Here is a quick breakdown of what I changed, and why it helped:
- Updating the github runners to `ubuntu-22.04` means that we no longer need to bring in a PPA for Qt6 support, and we can instead get those packages from the official repositories, which have much better caching and CDNs behind them.
- Caching `grcov` between runs saves us about 5 minuntes of compilation time.
- Minimizing the profiling data dramatically reduces the storage and bandwidth required to move the build artifacts around (3.5GB down to 250MB!).
- Now that the PPA is no longer necessary, copying the installed `.deb` files from build to test runners is actually slower than just installing fresh dependencies from the official repositories.
- Building the unit tests with Ninja does a much better job of building in parallel.

Some other room for improvement that I did not address:
- Building the addons could be done during the build stage. This would save CPU time, but not calendar time, and would be a more representative test.
- Ninja is way faster for Windows too, but it falls apart somewhere in the rust libraries.
- Do something with `ccache` between workflow runs? That would be outrageously fast!

## Reference
Github #4877 ([VPN-3204](https://mozilla-hub.atlassian.net/browse/VPN-3204))

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
