### PR TITLE
Fix "Get help" page layouts when switching device orientation

### DIFF
--- a/src/ui/screens/getHelp/contactUs/ViewContactUsForm.qml
+++ b/src/ui/screens/getHelp/contactUs/ViewContactUsForm.qml
@@ -52,12 +52,11 @@ VPNViewBase {
        }
 
         spacing: VPNTheme.theme.windowMargin
-        Layout.leftMargin: VPNTheme.theme.windowMargin
-        Layout.rightMargin: VPNTheme.theme.windowMargin
+        Layout.leftMargin: VPNTheme.theme.windowMargin * 2
+        Layout.rightMargin: VPNTheme.theme.windowMargin * 2
 
         ColumnLayout {
             Layout.alignment: Qt.AlignTop
-            Layout.preferredWidth: parent.width
 
             spacing: 24
 
@@ -66,8 +65,6 @@ VPNViewBase {
                 spacing: 24
                 visible: VPN.userState !== VPN.UserAuthenticated
                 Layout.alignment: Qt.AlignHCenter
-                Layout.fillWidth: true
-                Layout.maximumWidth: parent.width - VPNTheme.theme.windowMargin
 
                 ColumnLayout {
                     spacing: 10
@@ -97,7 +94,6 @@ VPNViewBase {
                 VPNTextField {
                     id: confirmEmailInput
 
-                    width: parent.width
                     verticalAlignment: Text.AlignVCenter
                     Layout.fillWidth: true
                     hasError: !VPNAuthInApp.validateEmailAddress(confirmEmailInput.text) || emailInput.text != confirmEmailInput.text
@@ -108,20 +104,16 @@ VPNViewBase {
             VPNUserProfile {
                 objectName: "contactUs-userInfo"
                 enabled: false
-                Layout.preferredWidth: parent.width
+                Layout.fillWidth: true
                 visible: VPN.userState === VPN.UserAuthenticated
                 Layout.topMargin: -VPNTheme.theme.windowMargin / 2
                 Layout.bottomMargin: -VPNTheme.theme.windowMargin / 2
-                anchors {
-                    left: undefined
-                    right: undefined
-                }
+                Layout.leftMargin: undefined
+                Layout.rightMargin: undefined
             }
 
             ColumnLayout {
                 Layout.fillWidth: true
-                Layout.preferredWidth: parent.width - VPNTheme.theme.windowMargin
-                Layout.maximumWidth: parent.width - VPNTheme.theme.windowMargin
                 Layout.alignment: Qt.AlignHCenter
                 spacing: 10
 
@@ -133,7 +125,7 @@ VPNViewBase {
                     lineHeightMode: Text.FixedHeight
                     wrapMode: Text.WordWrap
                     verticalAlignment: Text.AlignVCenter
-                    Layout.preferredWidth: parent.width
+                    Layout.fillWidth: true
                     width: undefined
                 }
 
@@ -141,7 +133,8 @@ VPNViewBase {
                     id: dropDown
                     placeholderText: VPNl18n.InAppSupportWorkflowDropdownLabel
                     model: VPNSupportCategoryModel
-                    Layout.preferredWidth: parent.width
+                    Layout.fillWidth: true
+                    Layout.preferredWidth: undefined
                 }
             }
 
@@ -150,7 +143,7 @@ VPNViewBase {
 
                 verticalAlignment: Text.AlignVCenter
                 Layout.alignment: Qt.AlignHCenter
-                Layout.preferredWidth: parent.width - VPNTheme.theme.windowMargin
+                Layout.fillWidth: true
                 _placeholderText: VPNl18n.InAppSupportWorkflowSubjectFieldPlaceholder
             }
 
@@ -158,12 +151,12 @@ VPNViewBase {
                 id: textArea
                 placeholderText: VPNl18n.InAppSupportWorkflowIssueFieldPlaceholder
                 Layout.alignment: Qt.AlignHCenter
-                Layout.preferredWidth: parent.width - VPNTheme.theme.windowMargin
+                Layout.fillWidth: true
             }
         }
 
         ColumnLayout {
-            Layout.preferredWidth: parent.width - VPNTheme.theme.windowMargin * 2
+            Layout.fillWidth: true
             Layout.alignment: Qt.AlignHCenter
             Layout.fillHeight: true
             spacing: 24
@@ -178,20 +171,19 @@ VPNViewBase {
                 spacing: 0
                 Layout.fillWidth: true
 
-
                 VPNTextBlock {
                     font.pixelSize: VPNTheme.theme.fontSize
                     horizontalAlignment: Text.AlignHCenter
                     text: VPNl18n.InAppSupportWorkflowDisclaimerText
-                    width:parent.width
+                    anchors.left: parent.left
+                    anchors.right: parent.right
 
                 }
 
                 VPNLinkButton {
+                    anchors.horizontalCenter: parent.horizontalCenter
                     labelText: VPNl18n.InAppSupportWorkflowPrivacyNoticeLinkText
-                    Layout.alignment: Qt.AlignHCenter
                     onClicked: VPNUrlOpener.openLink(VPNUrlOpener.LinkPrivacyNotice)
-                    width: parent.width
                 }
             }
 
@@ -222,7 +214,8 @@ VPNViewBase {
 
                 VPNCancelButton {
                     Layout.minimumHeight: VPNTheme.theme.rowHeight
-                    Layout.fillWidth: true
+                    Layout.preferredWidth: width
+                    Layout.alignment: Qt.AlignHCenter
                     onClicked: getHelpStackView.pop()
                 }
             }

--- a/src/ui/screens/getHelp/giveFeedback/ViewGiveFeedback.qml
+++ b/src/ui/screens/getHelp/giveFeedback/ViewGiveFeedback.qml
@@ -10,152 +10,169 @@ import Mozilla.VPN 1.0
 import components 0.1
 import components.forms 0.1
 
+ColumnLayout {
+    property string _menuTitle: qsTrId("vpn.settings.giveFeedback")
 
-VPNViewBase {
     objectName: "giveFeedbackView"
 
-    _menuTitle: qsTrId("vpn.settings.giveFeedback")
+    anchors.top: parent.top
+    anchors.bottom: parent.bottom
 
-    _viewContentData: ColumnLayout {
-        Layout.fillHeight: true
+    spacing: 0
+
+    ButtonGroup {
+        id: btnGroup
+        buttons: row.children
+    }
+
+    VPNBoldLabel {
         Layout.fillWidth: true
-        Layout.leftMargin: VPNTheme.theme.windowMargin * 1.5
-        Layout.rightMargin: VPNTheme.theme.windowMargin * 1.5
+        Layout.topMargin: window.fullscreenRequired() ? VPNTheme.theme.windowMargin * 3 : VPNTheme.theme.vSpacing
+        Layout.leftMargin: VPNTheme.theme.windowMargin * 2
+        Layout.rightMargin: VPNTheme.theme.windowMargin * 2
 
-        ButtonGroup {
-            id: btnGroup
-            buttons: row.children
+        //% "How would you describe your Mozilla VPN experience so far?"
+        text: qsTrId("vpn.feedbackForm.ratingHeadline")
+        lineHeight: 24
+        lineHeightMode: Text.FixedHeight
+        wrapMode: Text.WordWrap
+        verticalAlignment: Text.AlignBottom
+    }
+
+    RowLayout {
+        id: row
+
+        Layout.topMargin: VPNTheme.theme.windowMargin * 2
+        Layout.leftMargin: VPNTheme.theme.windowMargin * 2
+        Layout.rightMargin: VPNTheme.theme.windowMargin * 2
+        Layout.preferredHeight: VPNTheme.theme.rowHeight
+
+        GiveFeedbackRadioDelegate {
+            //% "Very poor"
+            Accessible.name: qsTrId("vpn.feedbackForm.veryPoor")
+            iconSource: "qrc:/ui/resources/faces/veryPoor.svg"
+            value: 1
         }
-
-        ColumnLayout {
-            Layout.alignment: window.fullscreenRequired() ? Qt.AlignVCenter : Qt.AlignTop
-            spacing: window.fullscreenRequired() ? VPNTheme.theme.windowMargin : VPNTheme.theme.windowMargin * 2
-
-            VPNBoldLabel {
-                //% "How would you describe your Mozilla VPN experience so far?"
-                text: qsTrId("vpn.feedbackForm.ratingHeadline")
-                lineHeight: 24
-                lineHeightMode: Text.FixedHeight
-                Layout.preferredWidth: parent.width
-                wrapMode: Text.WordWrap
-                verticalAlignment: Text.AlignBottom
-            }
-
-            ColumnLayout {
-                spacing: 8
-
-                RowLayout {
-                    id: row
-                    Layout.preferredHeight: VPNTheme.theme.rowHeight
-
-                    GiveFeedbackRadioDelegate {
-                        //% "Very poor"
-                        Accessible.name: qsTrId("vpn.feedbackForm.veryPoor")
-                        iconSource: "qrc:/ui/resources/faces/veryPoor.svg"
-                        value: 1
-                    }
-                    VPNVerticalSpacer {
-                       Layout.preferredHeight: 1
-                       Layout.fillWidth: true
-                    }
-
-                    GiveFeedbackRadioDelegate {
-                        //% "Poor"
-                        Accessible.name: qsTrId("vpn.feedbackForm.poor")
-                        iconSource: "qrc:/ui/resources/faces/poor.svg"
-                        value: 2
-                    }
-
-                    VPNVerticalSpacer {
-                       Layout.preferredHeight: 1
-                       Layout.fillWidth: true
-                    }
-
-                    GiveFeedbackRadioDelegate {
-                        //% "Average"
-                        Accessible.name: qsTrId("vpn.feedbackForm.average")
-                        iconSource: "qrc:/ui/resources/faces/average.svg"
-                        value: 3
-                    }
-
-                    VPNVerticalSpacer {
-                       Layout.preferredHeight: 1
-                       Layout.fillWidth: true
-                    }
-
-                    GiveFeedbackRadioDelegate {
-                        //% "Good"
-                        Accessible.name: qsTrId("vpn.feedbackForm.good")
-                        iconSource: "qrc:/ui/resources/faces/good.svg"
-                        value: 4
-                    }
-
-                    VPNVerticalSpacer {
-                       Layout.preferredHeight: 1
-                       Layout.fillWidth: true
-                    }
-
-                    GiveFeedbackRadioDelegate {
-                        Accessible.name: VPNl18n.FeedbackFormExcellentLabel
-                        iconSource: "qrc:/ui/resources/faces/veryGood.svg"
-                        value: 5
-                    }
-                }
-                RowLayout {
-                    VPNInterLabel {
-                        Layout.alignment: Qt.AlignLeft
-                        horizontalAlignment: Qt.AlignLeft
-                        text: qsTrId("vpn.feedbackForm.veryPoor")
-                        Layout.fillWidth: true
-                        color: VPNTheme.theme.fontColor
-                    }
-                    VPNInterLabel {
-                        Layout.alignment: Qt.AlignRight
-                        horizontalAlignment: Qt.AlignRight
-                        text: VPNl18n.FeedbackFormExcellentLabel
-                        Layout.fillWidth: true
-                        color: VPNTheme.theme.fontColor
-                    }
-                }
-            }
-        }
-        VPNButton {
-            id: feebackContinueButton
-
-            //% "Continue"
-            text: qsTrId("vpn.feedbackForm.continue")
-            onClicked: {
-                if (btnGroup.checkedButton.value === null) {
-                    // This should not happen.
-                    return;
-                }
-
-                if (btnGroup.checkedButton.value >= 5) {
-                    VPN.submitFeedback("", btnGroup.checkedButton.value, 0);
-
-                    if (VPNFeatureList.get("appReview").isSupported) {
-                      getHelpStackView.push("qrc:/ui/screens/getHelp/giveFeedback/ViewGiveFeedbackReview.qml");
-                      return;
-                    }
-
-                    getHelpStackView.push("qrc:/ui/screens/getHelp/giveFeedback/ViewGiveFeedbackThankYou.qml");
-                    return;
-                }
-
-                getHelpStackView.push("qrc:/ui/screens/getHelp/giveFeedback/ViewGiveFeedbackForm.qml", { "appRating": btnGroup.checkedButton.value })
-            }
-
-
-            Layout.alignment: window.fullscreenRequired() ? Qt.AlignTop : Qt.AlignBottom
-            Layout.topMargin: VPNTheme.theme.vSpacing
+        VPNVerticalSpacer {
+            Layout.preferredHeight: 1
             Layout.fillWidth: true
-            enabled: btnGroup.checkedButton !== null
-            opacity: enabled ? 1 : .5
-            Behavior on opacity {
-                PropertyAnimation {
-                    duration: 100
+        }
+
+        GiveFeedbackRadioDelegate {
+            //% "Poor"
+            Accessible.name: qsTrId("vpn.feedbackForm.poor")
+            iconSource: "qrc:/ui/resources/faces/poor.svg"
+            value: 2
+        }
+
+        VPNVerticalSpacer {
+            Layout.preferredHeight: 1
+            Layout.fillWidth: true
+        }
+
+        GiveFeedbackRadioDelegate {
+            //% "Average"
+            Accessible.name: qsTrId("vpn.feedbackForm.average")
+            iconSource: "qrc:/ui/resources/faces/average.svg"
+            value: 3
+        }
+
+        VPNVerticalSpacer {
+            Layout.preferredHeight: 1
+            Layout.fillWidth: true
+        }
+
+        GiveFeedbackRadioDelegate {
+            //% "Good"
+            Accessible.name: qsTrId("vpn.feedbackForm.good")
+            iconSource: "qrc:/ui/resources/faces/good.svg"
+            value: 4
+        }
+
+        VPNVerticalSpacer {
+            Layout.preferredHeight: 1
+            Layout.fillWidth: true
+        }
+
+        GiveFeedbackRadioDelegate {
+            Accessible.name: VPNl18n.FeedbackFormExcellentLabel
+            iconSource: "qrc:/ui/resources/faces/veryGood.svg"
+            value: 5
+        }
+    }
+
+    RowLayout {
+        Layout.topMargin: VPNTheme.theme.vSpacingSmall
+        Layout.leftMargin: VPNTheme.theme.windowMargin * 2
+        Layout.rightMargin: VPNTheme.theme.windowMargin * 2
+
+        VPNInterLabel {
+            horizontalAlignment: Qt.AlignLeft
+            text: qsTrId("vpn.feedbackForm.veryPoor")
+            Layout.fillWidth: true
+            color: VPNTheme.theme.fontColor
+        }
+
+        Item {
+            Layout.fillWidth: true
+        }
+
+        VPNInterLabel {
+            horizontalAlignment: Qt.AlignRight
+            text: VPNl18n.FeedbackFormExcellentLabel
+            Layout.fillWidth: true
+            color: VPNTheme.theme.fontColor
+        }
+    }
+
+    Item {
+        Layout.fillHeight: window.fullscreenRequired()
+        Layout.preferredHeight: window.fullscreenRequired() ? undefined : VPNTheme.theme.windowMargin * 2
+    }
+
+
+    VPNButton {
+        id: feebackContinueButton
+
+        Layout.fillWidth: true
+        Layout.leftMargin: VPNTheme.theme.windowMargin * 2
+        Layout.rightMargin: VPNTheme.theme.windowMargin * 2
+        Layout.bottomMargin: VPNTheme.theme.navBarHeightWithMargins
+
+        //% "Continue"
+        text: qsTrId("vpn.feedbackForm.continue")
+        enabled: btnGroup.checkedButton !== null
+        opacity: enabled ? 1 : .5
+
+        onClicked: {
+            if (btnGroup.checkedButton.value === null) {
+                // This should not happen.
+                return;
+            }
+
+            if (btnGroup.checkedButton.value >= 5) {
+                VPN.submitFeedback("", btnGroup.checkedButton.value, 0);
+
+                if (VPNFeatureList.get("appReview").isSupported) {
+                    getHelpStackView.push("qrc:/ui/screens/getHelp/giveFeedback/ViewGiveFeedbackReview.qml");
+                    return;
                 }
+
+                getHelpStackView.push("qrc:/ui/screens/getHelp/giveFeedback/ViewGiveFeedbackThankYou.qml");
+                return;
+            }
+
+            getHelpStackView.push("qrc:/ui/screens/getHelp/giveFeedback/ViewGiveFeedbackForm.qml", { "appRating": btnGroup.checkedButton.value })
+        }
+
+        Behavior on opacity {
+            PropertyAnimation {
+                duration: 100
             }
         }
+    }
+
+    Item {
+        Layout.fillHeight: !window.fullscreenRequired()
     }
 }


### PR DESCRIPTION
## Description

- Resolve issue where the "Give feedback" and "Contact support" pages would overflow off the edge of the screen when rotating the device's orientation to from portrait, to landscape, and then back to portrait

## Reference

[VPN-3393: Some "Get help" page layouts get cut off on iPad after switching device orientation](https://mozilla-hub.atlassian.net/browse/VPN-3393)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
