### PR TITLE
Change LAN Bypass default value to true

### DIFF
--- a/src/settingslist.h
+++ b/src/settingslist.h
@@ -280,7 +280,7 @@ SETTING_BOOL(localNetworkAccess,        // getter
              removeLocalNetworkAccess,  // remover
              hasLocalNetworkAccess,     // has
              "localNetworkAccess",      // key
-             false,                     // default value
+             true,                     // default value
              true,                      // user setting
              false                      // remove when reset
 )


### PR DESCRIPTION
## Description

- LAN Bypass will now be set on by default for Windows, macOS, Linux, and Android
- a) new users and b) existing users who have never manually toggled this setting, will have LAN bypass turned on by default
- Users who haved manually toggled this setting in the past, either to on or off, will not have their settings changed from their preference

## Reference

[VPN-3229: Make the LAN outgoing traffic be default-allowed on Windows, Linux, macOS and Android.](https://mozilla-hub.atlassian.net/browse/VPN-3229)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
