### PR TITLE
Fix nits in v2.12 update/whasnew messages, update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,8 +1,8 @@
-# Francesco Lodolo as main contact for string changes
-addons/**/manifest.json @flodolo
-translations/strings.yaml @flodolo
-
 # Beatriz Rizental as main contact for addon related changes
 /addons/ @brizental
 /src/addons/ @brizental
 /signature/ @brizental
+
+# Francesco Lodolo as main contact for string changes
+addons/**/manifest.json @flodolo
+translations/strings.yaml @flodolo

--- a/addons/message_update_v2.12/manifest.json
+++ b/addons/message_update_v2.12/manifest.json
@@ -20,11 +20,11 @@
         "type": "ulist",
         "content": [
           { "id": "l_1",
-            "content": "On Android, you are now able to opt-in to start and connect the VPN automatically upon boot." },
+            "content": "On Android, you are now able to opt in to start and connect the VPN automatically upon boot." },
           { "id": "l_2",
             "content": "On desktop, you can now log in directly on the app, without needing to open the browser." },
           { "id": "l_3",
-            "content": "Released new guides on Multi-Hop, Custom DNS and App Permissions, to help you master the Mozilla VPN app." },
+            "content": "Released new guides on Multi-hop, Custom DNS and App Permissions, to help you master the Mozilla VPN app." },
           { "id": "l_4",
             "content": "We’ve also made bug fixes, UI adjustments and other performance improvements to make Mozilla VPN even better." }
         ]

--- a/addons/message_whats_new_v2.12/manifest.json
+++ b/addons/message_whats_new_v2.12/manifest.json
@@ -20,11 +20,11 @@
         "type": "ulist",
         "content": [
           { "id": "l_1",
-            "content": "On Android, you are now able to opt-in to start and connect the VPN automatically upon boot." },
+            "content": "On Android, you are now able to opt in to start and connect the VPN automatically upon boot." },
           { "id": "l_2",
             "content": "On desktop, you can now log in directly on the app, without needing to open the browser." },
           { "id": "l_3",
-            "content": "Released new guides on Multi-Hop, Custom DNS and App Permissions, to help you master the Mozilla VPN app." },
+            "content": "Released new guides on Multi-hop, Custom DNS and App Permissions, to help you master the Mozilla VPN app." },
           { "id": "l_4",
             "content": "We’ve also made bug fixes, UI adjustments and other performance improvements to make Mozilla VPN even better." }
         ]


### PR DESCRIPTION
## Description

I was once again ignored by CODEOWNERS in #5072, so I'm updating the order. From [GitHub docs](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners):

```
# Order is important; the last matching pattern takes the most
# precedence. When someone opens a pull request that only
# modifies JS files, only @js-owner and not the global
# owner(s) will be requested for a review.
*.js    @js-owner
```

As for the review/fixes:
* `Opt in` is the verb, `opt-in` is the noun (like `log-in`/`log in`)
* `Multi-hop` is [always spelled](https://transvision.flod.org/?recherche=multi-hop&repo=vpn_client&sourcelocale=en&locale=en&search_type=strings_entities) with lowercase h in the product