### PR TITLE
Experiment: Merge functional test coverage results

### DIFF
--- a/.github/workflows/functional_tests.yaml
+++ b/.github/workflows/functional_tests.yaml
@@ -193,7 +193,7 @@ jobs:
         run: |          
           export PATH=${{github.workspace}}/grcov-build/bin:$PATH
           export TESTDIRS=$(echo ${TESTJSON} | jq -r '.[] | .name' | xargs -I name echo name-Results/profile)
-          grcov ${TESTDIRS} \
+          grcov ${TESTDIRS} test-client-${{ github.sha }}/profile \
               -s checkout/src -t lcov --branch --ignore-not-existing \
               -o ${{runner.temp}}/functional_lcov.info
 

--- a/.github/workflows/functional_tests.yaml
+++ b/.github/workflows/functional_tests.yaml
@@ -31,19 +31,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y $(./scripts/linux/getdeps.py -a linux/debian/control)
 
-      - name: Cache grcov
-        id: cache-grcov
-        uses: actions/cache@v3
-        with:
-          path: grcov-build/
-          key: ${{runner.os}}-grcov-v0.8.13
-
-      - name: Install Grcov
-        if: steps.cache-grcov.outputs.cache-hit != 'true'
-        shell: bash
-        run: |
-          cargo install grcov --root ${{github.workspace}}/grcov-build --version 0.8.13
-
       - name: Compile test client
         shell: bash
         if: steps.cache-build.outputs.cache-hit != 'true'
@@ -112,13 +99,6 @@ jobs:
           pip3 install -r requirements.txt
           npm install
 
-      - name: Cache grcov
-        id: cache-grcov
-        uses: actions/cache@v3
-        with:
-          path: grcov-build/
-          key: ${{runner.os}}-grcov-v0.8.13
-
       - name: Check build
         shell: bash
         run: |
@@ -168,21 +148,11 @@ jobs:
               -s src -t lcov --branch --ignore-not-existing \
               -o ${{runner.temp}}/artifacts/functional_lcov.info
 
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
-        if: steps.generateGrcov.outcome == 'success'
-        with:
-          directory: .
-          flags: functional_tests
-          name: codecov-poc
-          files: ${{runner.temp}}/artifacts/functional_lcov.info
-          verbose: true
-
       - name: Uploading results
         uses: actions/upload-artifact@v3
         if: ${{ always() }}
         with:
-          name: ${{matrix.test.name}} Results
+          name: ${{matrix.test.name}}-Results
           path: ${{ runner.temp }}/artifacts
 
   gen_coverage:
@@ -192,6 +162,8 @@ jobs:
     steps:
       - name: Clone repository
         uses: actions/checkout@v3
+        with:
+          path: checkout
 
       - name: Download artifacts
         uses: actions/download-artifact@v3
@@ -203,13 +175,36 @@ jobs:
           path: grcov-build/
           key: ${{runner.os}}-grcov-v0.8.13
 
-      - name: Check build
+      - name: Install Grcov
+        if: steps.cache-grcov.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          cargo install grcov --root ${{github.workspace}}/grcov-build --version 0.8.13
+
+      - name: Check artifacts
         shell: bash
         run: |
           ls -al $(pwd)
 
-          chmod +x ./build/mozillavpn
-          ./build/mozillavpn -v
-
           chmod +x ${{github.workspace}}/grcov-build/bin/grcov
           ${{github.workspace}}/grcov-build/bin/grcov --version
+
+      - name: Generate grcov report
+        shell: bash
+        env:
+          TESTJSON: ${{ needs.build_test_app.outputs.matrix }}
+        run: |          
+          export PATH=${{github.workspace}}/grcov-build/bin:$PATH
+          export TESTNAMES=$(echo ${TESTJSON} | jq -r '.[] | .name')
+          grcov $(echo $TESTNAMES | xargs -I name echo name-Results/profile | tr '\n' ' ') \
+              -s checkout/src -t lcov --branch --ignore-not-existing \
+              -o ${{runner.temp}}/functional_lcov.info
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          directory: .
+          flags: functional_tests
+          name: codecov-poc
+          files: ${{runner.temp}}/functional_lcov.info
+          verbose: true

--- a/.github/workflows/functional_tests.yaml
+++ b/.github/workflows/functional_tests.yaml
@@ -105,9 +105,6 @@ jobs:
             chmod +x ./build/mozillavpn
             ./build/mozillavpn -v
 
-            chmod +x ${{github.workspace}}/grcov-build/bin/grcov
-            ${{github.workspace}}/grcov-build/bin/grcov --version
-
       - name: Build addons
         shell: bash
         if: steps.cache-build.outputs.cache-hit != 'true'

--- a/.github/workflows/functional_tests.yaml
+++ b/.github/workflows/functional_tests.yaml
@@ -164,7 +164,7 @@ jobs:
 
       - name: Download artifacts
         uses: actions/download-artifact@v3
-      
+
       - name: Cache grcov
         id: cache-grcov
         uses: actions/cache@v3

--- a/.github/workflows/functional_tests.yaml
+++ b/.github/workflows/functional_tests.yaml
@@ -192,8 +192,8 @@ jobs:
           TESTJSON: ${{ needs.build_test_app.outputs.matrix }}
         run: |          
           export PATH=${{github.workspace}}/grcov-build/bin:$PATH
-          export TESTNAMES=$(echo ${TESTJSON} | jq -r '.[] | .name')
-          grcov $(echo $TESTNAMES | xargs -I name echo name-Results/profile | tr '\n' ' ') \
+          export TESTDIRS=$(echo ${TESTJSON} | jq -r '.[] | .name' | xargs -I name echo name-Results/profile)
+          grcov ${TESTDIRS} \
               -s checkout/src -t lcov --branch --ignore-not-existing \
               -o ${{runner.temp}}/functional_lcov.info
 

--- a/.github/workflows/functional_tests.yaml
+++ b/.github/workflows/functional_tests.yaml
@@ -85,7 +85,7 @@ jobs:
         run: |
           echo $TEST_LIST | jq
 
-  functionaltests:
+  functional_tests:
     name: Functional tests
     needs: 
       - build_test_app
@@ -150,9 +150,13 @@ jobs:
             export TZ=Europe/London
             mkdir -p $ARTIFACT_DIR
             xvfb-run -a npm run functionalTest -- ${{matrix.test.path}}
+
+            mkdir -p $ARTIFACT_DIR/profile
+            rsync -a --include '*/' --include '*.gcda' --exclude '*' \
+                build/profile/ $ARTIFACT_DIR/profile/
         env:
           ARTIFACT_DIR: ${{ runner.temp }}/artifacts
-          MVPN_BIN: ./build//mozillavpn
+          MVPN_BIN: ./build/mozillavpn
 
       - name: Generating grcov reports
         id: generateGrcov
@@ -174,9 +178,38 @@ jobs:
           files: ${{runner.temp}}/artifacts/functional_lcov.info
           verbose: true
 
-      - name: Uploading artifacts
+      - name: Uploading results
         uses: actions/upload-artifact@v3
         if: ${{ always() }}
         with:
-          name: ${{matrix.test.name}} Logs
+          name: ${{matrix.test.name}} Results
           path: ${{ runner.temp }}/artifacts
+
+  gen_coverage:
+    name: Generate coverage report
+    needs: [build_test_app, functional_tests]
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v3
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+      
+      - name: Cache grcov
+        id: cache-grcov
+        uses: actions/cache@v3
+        with:
+          path: grcov-build/
+          key: ${{runner.os}}-grcov-v0.8.13
+
+      - name: Check build
+        shell: bash
+        run: |
+          ls -al $(pwd)
+
+          chmod +x ./build/mozillavpn
+          ./build/mozillavpn -v
+
+          chmod +x ${{github.workspace}}/grcov-build/bin/grcov
+          ${{github.workspace}}/grcov-build/bin/grcov --version


### PR DESCRIPTION
## Description
I have a hypothesis: is the cause of our erratic codecov reports due to the parallel nature of our functional tests? What if we were to wait until the very end of the tests, gather all the profiling data together and uploading a single test report. Let's give it a try.

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
