### PR TITLE
Message Update V2.12: Show different buttons based on platform and version

### DIFF
--- a/addons/message_update_v2.12/enable.js
+++ b/addons/message_update_v2.12/enable.js
@@ -1,0 +1,38 @@
+(function(api) {
+if (('updateTime' in api.settings)) {
+  api.addon.date = (api.settings.updateTime.getTime() / 1000);
+}
+
+// windows v2.10/v2.11 do require a web-based update.
+if (api.env.platform != 'windows') {
+  api.addon.composer.remove('c_4');
+  return;
+}
+
+const parts = api.env.versionString.split('.');
+
+// No idea which version we are in...
+if (parts.length < 3) {
+  api.addon.composer.remove('c_4');
+  return;
+}
+
+const version = parts.map(a => parseInt(a, 10));
+
+function versionCompare(a, b) {
+  for (let i = 0; i < 3; ++i) {
+    if (a[i] != b[i]) {
+      return a[i] > b[i] ? -1 : 1;
+    }
+  }
+  return 0;
+}
+
+if (versionCompare([2, 11, 1], version) >= 0 ||
+    versionCompare([2, 10, 0], version) < -1) {
+  api.addon.composer.remove('c_4');
+  return;
+}
+
+api.addon.composer.remove('c_3');
+})

--- a/addons/message_update_v2.12/manifest.json
+++ b/addons/message_update_v2.12/manifest.json
@@ -3,17 +3,17 @@
   "id": "message_update_v2.12",
   "name": "Update to Mozilla VPN 2.12",
   "type": "message",
-  "translatable": false,
   "conditions": {
     "max_client_version": "2.11.9"
   },
   "javascript": {
-    "enable": "setDate.js"
+    "enable": "enable.js"
   },
   "message": {
+    "date": 1668020390,
     "id": "message_update_v2.12",
     "title": "Update to Mozilla VPN 2.12",
-    "subtitle": "We see you’re using an out-of-date version of Mozilla VPN. Update to the latest version of Mozilla VPN to get the newest features and bug fixes:",
+    "subtitle": "We’ve released an updated version of Mozilla VPN! Update to the latest version to get the newest features and bug fixes:",
     "badge": "new_update",
     "blocks": [
       { "id": "c_1",
@@ -41,7 +41,14 @@
         "content": "Update now",
         "javascript": "update.js"
       },
-      { "id": "c_4",
+      {
+        "id": "c_4",
+        "type": "button",
+        "style": "primary",
+        "content": "Download update",
+        "javascript": "updateWeb.js"
+      },
+      { "id": "c_5",
         "type": "button",
         "style": "link",
         "content": "Get help",

--- a/addons/message_update_v2.12/setDate.js
+++ b/addons/message_update_v2.12/setDate.js
@@ -1,8 +1,0 @@
-(function(api) {
-if (!('updateTime' in api.settings)) {
-  api.addon.date = 1668020390;
-  return;
-}
-
-api.addon.date = (api.settings.updateTime.getTime() / 1000);
-})

--- a/addons/message_update_v2.12/update.js
+++ b/addons/message_update_v2.12/update.js
@@ -1,34 +1,3 @@
 ((api) => {
-  // windows v2.10/v2.11 do require a web-based update.
-  if (api.env.platform != 'windows') {
-    api.navigator.requestScreen(api.navigator.ScreenUpdateRecommended);
-    return;
-  }
-
-  const parts = api.env.versionString.split('.');
-
-  // No idea which version we are in...
-  if (parts.length < 3) {
-    api.navigator.requestScreen(api.navigator.ScreenUpdateRecommended);
-    return;
-  }
-
-  const version = parts.map(a => parseInt(a, 10));
-
-  function versionCompare(a, b) {
-    for (let i = 0; i < 3; ++i) {
-      if (a[i] != b[i]) {
-        return a[i] > b[i] ? -1 : 1;
-      }
-    }
-    return 0;
-  }
-
-  if (versionCompare([2, 11, 1], version) >= 0 ||
-      versionCompare([2, 10, 0], version) < -1) {
-    api.navigator.requestScreen(api.navigator.ScreenUpdateRecommended);
-    return;
-  }
-
-  api.urlOpener.openLink(api.urlOpener.LinkUpdate);
+  api.navigator.requestScreen(api.navigator.ScreenUpdateRecommended);
 });

--- a/addons/message_update_v2.12/updateWeb.js
+++ b/addons/message_update_v2.12/updateWeb.js
@@ -1,0 +1,3 @@
+((api) => {
+  api.urlOpener.openLink(api.urlOpener.LinkUpdate);
+});


### PR DESCRIPTION
From JIRA:
```
1. The message “Download Mozilla VPN 2.12” is shown to users on the Windows 2.10 and 2.11 client.
2. The CTA on this message takes them to the Mozilla VPN download page: https://www.mozilla.org/en-US/products/vpn/download/
3. The message “Update to Mozilla VPN 2.12” is shown to users on the non-Windows 2.10, 2.11 and 2.11.1 clients. It also shows to users on the Windows 2.11.1 client.
4. The CTA on this message triggers the update mechanism that would be normally triggered in “About Us” > “Check for Updates”
```

Technically we do all of this in 1 single message, with 2 buttons which only one is shown based on the `enable.js` code.