### PR TITLE
Fix the Android-Tile Service

### DIFF
--- a/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/VPNServiceBinder.kt
+++ b/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/VPNServiceBinder.kt
@@ -35,7 +35,7 @@ class VPNServiceBinder(service: VPNService) : Binder() {
         const val recordEvent = 10
         const val sendGleanPings = 11
         const val gleanUploadEnabledChanged = 12
-        const val controllerInit = 13
+        const val getStatus = 13
         const val gleanSetSourceTags = 14
         const val setStartOnBoot = 15
         const val reactivate = 16
@@ -118,7 +118,7 @@ class VPNServiceBinder(service: VPNService) : Binder() {
                 Log.i(tag, "Registered binder now: ${mListeners.size} Binders")
                 return true
             }
-            ACTIONS.controllerInit -> {
+            ACTIONS.getStatus -> {
                 val obj = JSONObject()
                 obj.put("connected", mService.isUp)
                 obj.put("time", mService.connectionTime)

--- a/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/VPNTileService.kt
+++ b/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/VPNTileService.kt
@@ -50,7 +50,9 @@ class VPNTileService : android.service.quicksettings.TileService() {
             out.writeStrongBinder(mServiceBinder)
             try {
                 // Register our IBinder Listener
-                vpnService?.transact(3, out, Parcel.obtain(), 0)
+                vpnService?.transact(VPNServiceBinder.ACTIONS.registerEventListener, out, Parcel.obtain(), 0)
+                // Ask the VPN Service for the current status
+                vpnService?.transact(VPNServiceBinder.ACTIONS.getStatus, out, Parcel.obtain(), 0)
                 mService = vpnService
             } catch (e: DeadObjectException) {
                 mService = null

--- a/src/platforms/android/androidcontroller.cpp
+++ b/src/platforms/android/androidcontroller.cpp
@@ -38,8 +38,7 @@ AndroidController::AndroidController() {
   connect(
       activity, &AndroidVPNActivity::serviceConnected, this,
       []() {
-        AndroidVPNActivity::sendToService(ServiceAction::ACTION_CONTROLLER_INIT,
-                                          "");
+        AndroidVPNActivity::sendToService(ServiceAction::ACTION_GET_STATUS, "");
       },
       Qt::QueuedConnection);
   connect(

--- a/src/platforms/android/androidnotificationhandler.cpp
+++ b/src/platforms/android/androidnotificationhandler.cpp
@@ -47,9 +47,11 @@ void AndroidNotificationHandler::notify(NotificationHandler::Message type,
 void AndroidNotificationHandler::applyStrings() {
   QJsonObject localisedMessages;
   localisedMessages["productName"] = qtTrId("vpn.main.productName");
-  //% "Ready for you to connect"
-  //: Refers to the app - which is currently running the background and waiting
-  localisedMessages["idleText"] = qtTrId("vpn.android.notification.isIDLE");
+  localisedMessages["connectedText"] =
+      qtTrId("vpn.systray.statusConnected.title");  // Connected
+  localisedMessages["disconnectedText"] =
+      qtTrId("vpn.systray.statusDisconnected.title");  // Disconnected
+
   localisedMessages["notification_group_name"] = L18nStrings::instance()->t(
       L18nStrings::AndroidNotificationsGeneralNotifications);
 

--- a/src/platforms/android/androidvpnactivity.h
+++ b/src/platforms/android/androidvpnactivity.h
@@ -43,8 +43,8 @@ enum ServiceAction {
   ACTION_SEND_GLEAN_MAIN_PING = 11,
   // Upload Enabled Changed
   ACTION_GLEAN_ENABLED_CHANGED = 12,
-  // Action Controller Init
-  ACTION_CONTROLLER_INIT = 13,
+  // Get's current status
+  ACTION_GET_STATUS = 13,
   // Set Glean Source tags
   ACTION_GLEAN_SET_SOURCE_TAGS = 14,
   // Set startOnBoot pref


### PR DESCRIPTION
This is a 3part patch to fix the issues QA had. Most of those are caused of me merging a patch that was written a year ago 😅 

## Patch 1: Fix bitrotting and let the Tile Query connection status
Well the PR was quite old on merge and was still under the assumption the Service will push the Current State on connect. Now Service-Clients need to request this themselves. 

## Patch 2: Retrive the Config from Storage on a Fresh start
The new `reconnect` function used for the toggle did not account that the Service might have been killed between activations - It now get's the last config from storage, like always-on.

## Patch 3: Polish the Notification fallback messages
This is really Polish. Currently the client has quite a bit of dept around notifications. It depends on the Client beeing alive and pushing the right notification text. 
This PR put's some band-aid on that, so both Tile-Service and Always-On at least show the translated "connected/disconnected" messages, when we have a vpn-session without the client.

