### PR TITLE
Android: Disable start-on-boot for 2.12 

### DIFF
--- a/src/featureslistcallback.h
+++ b/src/featureslistcallback.h
@@ -150,7 +150,7 @@ bool FeatureCallback_splitTunnel() {
 
 bool FeatureCallback_startOnBoot() {
 #if defined(MVPN_LINUX) || defined(MVPN_MACOS) || defined(MVPN_WINDOWS) || \
-    defined(MVPN_DUMMY) || defined(MVPN_WASM) || defined(MVPN_ANDROID)
+    defined(MVPN_DUMMY) || defined(MVPN_WASM)
   return true;
 #else
   return false;


### PR DESCRIPTION
This PR disables the Start-On boot feature on the 2.12 branch. 
It did not pass QA verification, therefore let's disable it here :) 