### PR TITLE
Fix MacOS build on Taskcluster

### DIFF
--- a/taskcluster/scripts/build/macos_build.sh
+++ b/taskcluster/scripts/build/macos_build.sh
@@ -51,6 +51,7 @@ export PATH="`pwd`/go/bin:$PATH"
 print Y "Installing python dependencies..."
 # use --user for permissions
 python3 -m pip install -r requirements.txt --user
+python3 -m pip install -r taskcluster/requirements.txt --user
 export PYTHONIOENCODING="UTF-8"
 
 print Y "Updating submodules..."


### PR DESCRIPTION
The level-3 macos task is broken and failing with: 
```

[task 2022-12-03T15:42:03.058Z] + ./taskcluster/scripts/get-secret.py -s project/mozillavpn/tokens -k sentry_dsn -f sentry_dsn
[task 2022-12-03T15:42:03.102Z] Traceback (most recent call last):
[task 2022-12-03T15:42:03.102Z]   File "./taskcluster/scripts/get-secret.py", line 12, in <module>
[task 2022-12-03T15:42:03.102Z]     import taskcluster
[task 2022-12-03T15:42:03.102Z] ModuleNotFoundError: No module named 'taskcluster'

```
So let's install the taskcluster dependencies :) 