### PR TITLE
Only install requirements for get_secret.py

### DIFF
--- a/taskcluster/scripts/build/macos_build.sh
+++ b/taskcluster/scripts/build/macos_build.sh
@@ -51,7 +51,7 @@ export PATH="`pwd`/go/bin:$PATH"
 print Y "Installing python dependencies..."
 # use --user for permissions
 python3 -m pip install -r requirements.txt --user
-python3 -m pip install -r taskcluster/requirements.txt --user
+python3 -m pip install -r taskcluster/scripts/requirements.txt --user
 export PYTHONIOENCODING="UTF-8"
 
 print Y "Updating submodules..."

--- a/taskcluster/scripts/requirements.txt
+++ b/taskcluster/scripts/requirements.txt
@@ -1,0 +1,1 @@
+taskcluster==44.7.1


### PR DESCRIPTION
Currently, we try to install all task cluster requirements. Not just the ones for get_secret.py
 - however, our level-3 (main) runners have only python 3.6
 - The level-1 (pr) have 3.8 
 One of the packages requires 3.7 therefore this fails on main but not on pull-requests. >:c 

So let's only install the required packets for the script to run, which supports python 3.6
