### PR TITLE
Add `cmake --build build -j$(nproc)` to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ The following variables may be of use:
 
 2. Once the makefiles have been generated, the next step is to compile the source code:
 ```bash
-cmake --build build
+cmake --build build -j$(nproc)
 ```
 
 The following sections go into further detail for each of the supported platforms.
@@ -240,7 +240,7 @@ Some variables that might be useful when configuring the project:
 
 4. Compile the source code:
 ```bash
-cmake --build build
+cmake --build build -j$(nproc)
 ```
 
 This will produce the application bundle in `build/src/Mozilla VPN.app`.


### PR DESCRIPTION


## Description

    Update readme build command instruction for Desktop and MacOS to specify passing in the maximum number of processors to speed up the build.

## Reference

    n/a

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
