### PR TITLE
Revert "Taskcluster/OSX: Upload symbols"

### DIFF
--- a/src/cmake/macos.cmake
+++ b/src/cmake/macos.cmake
@@ -7,9 +7,6 @@ enable_language(OBJCXX)
 
 set_target_properties(mozillavpn PROPERTIES OUTPUT_NAME "Mozilla VPN")
 
-# Force llvm to add DWARF info on Release builds
-SET(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -g")
-
 # Configure the application bundle Info.plist
 set_target_properties(mozillavpn PROPERTIES
     MACOSX_BUNDLE ON

--- a/taskcluster/ci/build/macos.yml
+++ b/taskcluster/ci/build/macos.yml
@@ -30,7 +30,6 @@ task-defaults:
         command: ./taskcluster/scripts/build/macos_build.sh
 
 
-
 macos/pr:
     description: "Mac Build"
     treeherder:


### PR DESCRIPTION
Reverts mozilla-mobile/mozilla-vpn-client#5057 
Breaks the CI again >:c
