### PR TITLE
Stop tutorial when rollback warning modal is closed

### DIFF
--- a/nebula/ui/components/VPNTutorialPopups.qml
+++ b/nebula/ui/components/VPNTutorialPopups.qml
@@ -308,18 +308,24 @@ Item {
         }
 
         function onShowWarningNeeded(tutorial) {
+            let shouldPlayTutorial = false
             tutorialPopup.imageSrc = "qrc:/ui/resources/logo-warning.svg";
             tutorialPopup.primaryButtonOnClicked = () => {
-                                                           tutorialPopup.close()
-                                                           VPNTutorial.play(tutorial);
-                                                           VPNNavigator.requestScreen(VPNNavigator.ScreenHome)
-                                                         }
+                shouldPlayTutorial = true
+                tutorialPopup.close()
+            }
             tutorialPopup.primaryButtonText = VPNl18n.GlobalContinue
             tutorialPopup.secondaryButtonOnClicked = () => tutorialPopup.close();
             tutorialPopup.secondaryButtonText = VPNl18n.GlobalNoThanks
             tutorialPopup.title = VPNl18n.TutorialPopupTutorialWarningTitle;
             tutorialPopup.description = VPNl18n.TutorialPopupTutorialWarningDescription
-            tutorialPopup._onClosed = () => {};
+            tutorialPopup._onClosed = () => {
+                VPNTutorial.stop()
+                if(shouldPlayTutorial) {
+                    VPNTutorial.play(tutorial)
+                    VPNNavigator.requestScreen(VPNNavigator.ScreenHome)
+                }
+            }
             tutorialPopup.dismissOnStop = false;
             tutorialPopup.open();
         }


### PR DESCRIPTION
## Description

* Prevents an issue where the tips and tricks view wouldn't scroll after selecting a rollback tutorial, clicking "no thanks", and then exiting and re-entering the tips and tricks screen (flickable is no longer interactive because it thinks a tutorial is playing)
* Prevents a crash after clicking "no thanks" on a rollback tutorial and then starting a non-rollback tutorial

## Reference

[VPN-3449: Tips and tricks view unscrollable after rejecting tutorial containing settings rollback](https://mozilla-hub.atlassian.net/browse/VPN-3449)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
