### PR TITLE
Remove excess padding at bottom of server list

### DIFF
--- a/nebula/ui/components/VPNServerList.qml
+++ b/nebula/ui/components/VPNServerList.qml
@@ -304,16 +304,8 @@ FocusScope {
             property alias countries: countriesRepeater
             id: vpnFlickable
 
-            flickContentHeight: serverList.implicitHeight + listOffset
+            flickContentHeight: serverList.implicitHeight
             anchors.fill: parent
-
-            Rectangle {
-                id: verticalSpacer
-
-                height: VPNTheme.theme.vSpacing
-                width: parent.width
-                color: VPNTheme.theme.transparent
-            }
 
             NumberAnimation on contentY {
                 id: scrollAnimation
@@ -328,7 +320,12 @@ FocusScope {
 
                 spacing: VPNTheme.theme.listSpacing * 1.75
                 width: parent.width
-                anchors.top: verticalSpacer.bottom
+                anchors.top: parent.top
+
+                Item {
+                    height: VPNTheme.theme.vSpacing - parent.spacing
+                    width: parent.width
+                }
 
                 VPNSearchBar {
                     id: searchBar


### PR DESCRIPTION
## Description

- Fixes a regression where extra padding was added to the bottom of the server list

## Reference

[VPN-3429: Excess padding at the bottom of the server list view](https://mozilla-hub.atlassian.net/browse/VPN-3429)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
