### PR TITLE
Linux fix rc suffix

### DIFF
--- a/scripts/linux/script.sh
+++ b/scripts/linux/script.sh
@@ -118,7 +118,7 @@ if [[ "$GITREF" =~ ^refs/pull/([0-9]+)/merge ]]; then
 elif [[ "$GITREF" =~ ^refs/tags/v([0-9a-z.]+) ]]; then
   SHORTVERSION=${BASH_REMATCH[1]}
 elif [[ "$GITREF" =~ ^refs/heads/releases/([0-9][^/]*) ]]; then
-  git fetch $([ $(git rev-parse --is-shallow-repository) = 'false' ] && echo --unshallow)
+  [[ $(git rev-parse --is-shallow-repository) == "true" ]] && git fetch --unshallow
   RCVERSION="~rc$(git rev-list --count --first-parent origin/main..HEAD)"
   SHORTVERSION="${BASH_REMATCH[1]}${RCVERSION}"
 elif [[ "$GITREF" == "refs/heads/main" ]]; then


### PR DESCRIPTION
## Description
So, I think the bug here is simply that we have the logic backwards. If the repository is shallow then unshallow it, otherwise there is no need to fetch anything. This is a little bit thorny to test, because this path is only followed on the the release branches. So we kind of have to merge it before we have any idea if it works.

## Reference
Github #5159 ([VPN-3472](https://mozilla-hub.atlassian.net/browse/VPN-3472))

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
