### PR TITLE
Use a timestamp for release candidate suffixes

### DIFF
--- a/.github/workflows/ppa-automation.yaml
+++ b/.github/workflows/ppa-automation.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3
         with:
-          fetch-depth: 0
+          submodules: 'true'
 
       - name: Install dependencies
         shell: bash

--- a/scripts/linux/script.sh
+++ b/scripts/linux/script.sh
@@ -118,9 +118,7 @@ if [[ "$GITREF" =~ ^refs/pull/([0-9]+)/merge ]]; then
 elif [[ "$GITREF" =~ ^refs/tags/v([0-9a-z.]+) ]]; then
   SHORTVERSION=${BASH_REMATCH[1]}
 elif [[ "$GITREF" =~ ^refs/heads/releases/([0-9][^/]*) ]]; then
-  git fetch $([ $(git rev-parse --is-shallow-repository) = 'false' ] && echo --unshallow)
-  RCVERSION="~rc$(git rev-list --count --first-parent origin/main..HEAD)"
-  SHORTVERSION="${BASH_REMATCH[1]}${RCVERSION}"
+  SHORTVERSION="${BASH_REMATCH[1]}~rc$(date +%Y%m%d%H%M%S)"
 elif [[ "$GITREF" == "refs/heads/main" ]]; then
   SHORTVERSION="${SHORTVERSION}~nightly$(date +%Y%m%d)"
 fi

--- a/scripts/linux/script.sh
+++ b/scripts/linux/script.sh
@@ -118,9 +118,9 @@ if [[ "$GITREF" =~ ^refs/pull/([0-9]+)/merge ]]; then
 elif [[ "$GITREF" =~ ^refs/tags/v([0-9a-z.]+) ]]; then
   SHORTVERSION=${BASH_REMATCH[1]}
 elif [[ "$GITREF" =~ ^refs/heads/releases/([0-9][^/]*) ]]; then
-  SHORTVERSION="${BASH_REMATCH[1]}~rc$(date +%Y%m%d%H%M%S)"
+  SHORTVERSION="${BASH_REMATCH[1]}~rc$(date -u +%Y%m%d%H%M%S)"
 elif [[ "$GITREF" == "refs/heads/main" ]]; then
-  SHORTVERSION="${SHORTVERSION}~nightly$(date +%Y%m%d)"
+  SHORTVERSION="${SHORTVERSION}~nightly$(date -u +%Y%m%d)"
 fi
 WORKDIR=mozillavpn-${SHORTVERSION}
 print G "${SHORTVERSION}"


### PR DESCRIPTION
## Description
Recently we ran into some difficulty with the PPA automation workflow failing to unshallow the branches to compute the release candidate suffix. And after some discussion with @birdsarah we decided that we ought to try and do a better job aligning the version suffix with the build IDs that we generate on taskcluster. To that effect, let's just scrap the entire unshallow and refcounting process and just replace it with a timestamp instead.

This gets us a little bit closer, but we really want to just move this whole thing into taskcluster and get it to match the release process for Mac and Windows too but that's a bigger change for another PR.

## Reference
Github #5159 ([VPN-3472](https://mozilla-hub.atlassian.net/browse/VPN-3472))

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
