### PR TITLE
Android crash fix on feedback

### DIFF
--- a/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/VPNLogger.kt
+++ b/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/VPNLogger.kt
@@ -60,14 +60,6 @@ class Log {
             e(prefix + tag, message)
         }
 
-        fun getContent(): String? {
-            return try {
-                instance?.file?.readText()
-            } catch (e: Exception) {
-                "=== Failed to read Daemon Logs === \n ${e.localizedMessage} "
-            }
-        }
-
         fun clearFile() {
             instance?.file?.writeText("")
         }

--- a/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/VPNServiceBinder.kt
+++ b/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/VPNServiceBinder.kt
@@ -27,7 +27,6 @@ class VPNServiceBinder(service: VPNService) : Binder() {
         const val deactivate = 2
         const val registerEventListener = 3
         const val requestStatistic = 4
-        const val requestGetLog = 5
         const val requestCleanupLog = 6
         const val resumeActivate = 7
         const val setNotificationText = 8
@@ -129,12 +128,6 @@ class VPNServiceBinder(service: VPNService) : Binder() {
 
             ACTIONS.requestStatistic -> {
                 dispatchEvent(EVENTS.statisticUpdate, mService.status.toString())
-                return true
-            }
-
-            ACTIONS.requestGetLog -> {
-                // Grabs all the Logs and dispatch new Log Event
-                dispatchEvent(EVENTS.backendLogs, Log.getContent())
                 return true
             }
             ACTIONS.requestCleanupLog -> {
@@ -260,7 +253,6 @@ class VPNServiceBinder(service: VPNService) : Binder() {
         const val connected = 1
         const val disconnected = 2
         const val statisticUpdate = 3
-        const val backendLogs = 4
         const val activationError = 5
         const val permissionRequired = 6
     }

--- a/src/platforms/android/androidcontroller.cpp
+++ b/src/platforms/android/androidcontroller.cpp
@@ -22,6 +22,8 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QRandomGenerator>
+#include <QFile>
+#include <QDir>
 
 namespace {
 Logger logger(LOG_ANDROID, "AndroidController");
@@ -66,14 +68,6 @@ AndroidController::AndroidController() {
       Qt::QueuedConnection);
   connect(activity, &AndroidVPNActivity::eventDisconnected, this,
           &AndroidController::disconnected, Qt::QueuedConnection);
-  connect(
-      activity, &AndroidVPNActivity::eventBackendLogs, this,
-      [this](const QString& parcelBody) {
-        if (m_logCallback) {
-          m_logCallback(parcelBody);
-        }
-      },
-      Qt::QueuedConnection);
   connect(
       activity, &AndroidVPNActivity::eventStatisticUpdate, this,
       [this](const QString& parcelBody) {
@@ -222,11 +216,16 @@ void AndroidController::checkStatus() {
 
 void AndroidController::getBackendLogs(
     std::function<void(const QString&)>&& a_callback) {
-  logger.debug() << "get logs";
-
-  m_logCallback = std::move(a_callback);
-  AndroidVPNActivity::sendToService(ServiceAction::ACTION_REQUEST_GET_LOG,
-                                    QString());
+  QString cacheFolderPath =
+      QStandardPaths::writableLocation(QStandardPaths::TempLocation);
+  auto cacheFolder = QDir(cacheFolderPath);
+  QFile logFile(cacheFolder.absoluteFilePath("mozilla_deamon_logs.txt"));
+  if (!logFile.open(QIODevice::ReadOnly | QIODevice::Text)) {
+    a_callback(QString());
+    return;
+  }
+  auto content = logFile.readAll();
+  a_callback(QString::fromUtf8(content));
 }
 
 void AndroidController::cleanupBackendLogs() {

--- a/src/platforms/android/androidvpnactivity.cpp
+++ b/src/platforms/android/androidvpnactivity.cpp
@@ -125,9 +125,6 @@ void AndroidVPNActivity::handleServiceMessage(int code, const QString& data) {
     case ServiceEvents::EVENT_STATISTIC_UPDATE:
       emit eventStatisticUpdate(data);
       break;
-    case ServiceEvents::EVENT_BACKEND_LOGS:
-      emit eventBackendLogs(data);
-      break;
     case ServiceEvents::EVENT_ACTIVATION_ERROR:
       emit eventActivationError(data);
       break;

--- a/src/platforms/android/androidvpnactivity.cpp
+++ b/src/platforms/android/androidvpnactivity.cpp
@@ -107,10 +107,6 @@ void AndroidVPNActivity::onServiceMessage(JNIEnv* env, jobject thiz,
 }
 
 void AndroidVPNActivity::handleServiceMessage(int code, const QString& data) {
-  if (code != ServiceEvents::EVENT_BACKEND_LOGS) {
-    // Don't put the logs in the log.
-    logger.debug() << "handleServiceMessage" << code << data;
-  }
   auto mode = (ServiceEvents)code;
   switch (mode) {
     case ServiceEvents::EVENT_INIT:

--- a/src/platforms/android/androidvpnactivity.h
+++ b/src/platforms/android/androidvpnactivity.h
@@ -83,7 +83,6 @@ class AndroidVPNActivity : public QObject {
   void eventConnected(const QString& data);
   void eventDisconnected(const QString& data);
   void eventStatisticUpdate(const QString& data);
-  void eventBackendLogs(const QString& data);
   void eventActivationError(const QString& data);
 
  private:

--- a/src/platforms/android/androidvpnactivity.h
+++ b/src/platforms/android/androidvpnactivity.h
@@ -24,8 +24,6 @@ enum ServiceAction {
   ACTION_REGISTERLISTENER = 3,
   // Requests an EVENT_STATISTIC_UPDATE to be send
   ACTION_REQUEST_STATISTIC = 4,
-  // Requests an EVENT_LOG_UPDATE to be send
-  ACTION_REQUEST_GET_LOG = 5,
   // Requests to clean up the internal log
   ACTION_REQUEST_CLEANUP_LOG = 6,
   // Retry activation using the last config
@@ -62,8 +60,6 @@ enum ServiceEvents {
   EVENT_DISCONNECTED = 2,
   // Contains the Current transfered bytes to endpoint x.
   EVENT_STATISTIC_UPDATE = 3,
-  // Contains the current log of the vpnservice
-  EVENT_BACKEND_LOGS = 4,
   // An Error happened during activation
   // Contains the error message
   EVENT_ACTIVATION_ERROR = 5,


### PR DESCRIPTION
Disclaimer: I don't quite understand the reason of this crash. 

Currently, when we want to have the logs, we ask the daemon. This reads the logfile and sends it over the binder. 
The controller passes that string into a QString and gets it to the client. 

The Client will feed that QString in a QTextStream into a QIODevice. Here's where the weirdness begins. 
- If that Device is a file or StdOut (like when we want to send the logfile) -> All good. 
- If that underlying Buffer is a QByteArray or QString, we will crash, if we add any more text after that backend-logfile has been appended.   

Anyway. This was a great reason to stop doing all of that. As the logfile just lives in the temp dir, we can also just have the client read that instead of having the deamon read and then IPC pass it. That works, no crashes. 

