### PR TITLE
Fallback to source locale when dumping strings from an xliff

### DIFF
--- a/scripts/utils/xlifftool.py
+++ b/scripts/utils/xlifftool.py
@@ -55,6 +55,8 @@ class xliff_language:
                 print(f'String ID {trid} was not found', file=sys.stderr)
             return
 
+        target = self.translate(trid)
+
         while len(trid) > 0 and strip_trid > 0:
             index = trid.find('.')
             if index < 0:
@@ -62,7 +64,6 @@ class xliff_language:
             strip_trid = strip_trid - 1
             trid = trid[index+1:]
 
-        target = self.translate(trid)
         if format == 'env':
             escstring = target.replace('"', '\\"')
             return f"{trid.upper().replace('.', '_')}=\"{escstring}\""

--- a/scripts/utils/xlifftool.py
+++ b/scripts/utils/xlifftool.py
@@ -55,8 +55,6 @@ class xliff_language:
                 print(f'String ID {trid} was not found', file=sys.stderr)
             return
 
-        trdata = self.__stringdb[trid]
-
         while len(trid) > 0 and strip_trid > 0:
             index = trid.find('.')
             if index < 0:
@@ -64,7 +62,7 @@ class xliff_language:
             strip_trid = strip_trid - 1
             trid = trid[index+1:]
 
-        target = trdata['target']
+        target = self.translate(trid)
         if format == 'env':
             escstring = target.replace('"', '\\"')
             return f"{trid.upper().replace('.', '_')}=\"{escstring}\""


### PR DESCRIPTION
## Description
When dumping strings from an xliff file, and there is no translation found, use the source value instead. This was causing a bug in the MacOS installer for `en_US` because there aren't actually any target values for that locale. We already have similar code to handle this path for translations, but it just wasn't being called for the `--get` operation.

## Reference
Github #5131 ([VPN-3439](https://mozilla-hub.atlassian.net/browse/VPN-3439))

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
