### PR TITLE
Prevent navbar button tooltip on window focus

### DIFF
--- a/src/ui/navigator/navigationBar/VPNBottomNavigationBarButton.qml
+++ b/src/ui/navigator/navigationBar/VPNBottomNavigationBarButton.qml
@@ -20,8 +20,6 @@ VPNIconButton {
         VPNNavigator.requestScreen(_screen, VPNNavigator.screen === _screen ? VPNNavigator.ForceReload : VPNNavigator.NoFlags);
     }
 
-    onCheckedChanged: if (checked) btn.forceActiveFocus();
-
     width: VPNTheme.theme.navBarIconSize
     height: VPNTheme.theme.navBarIconSize
 


### PR DESCRIPTION
## Description

- Stop giving focus to selected navbar buttons to prevent unwanted tooltips

## Reference

[VPN-2767: Upon restoring from the System Tray, the navigation bar displays the tooltip without needing to hover over the icon](https://mozilla-hub.atlassian.net/browse/VPN-2767)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
