### PR TITLE
Addition of setting for whitelisting of IP address ranges

### DIFF
--- a/src/apps/unit_tests/testipaddress.cpp
+++ b/src/apps/unit_tests/testipaddress.cpp
@@ -256,17 +256,29 @@ void TestIpAddress::excludeAddresses_data() {
          "98,::8.0.0.0/101,::8/125,::80/121,::800/117,::8000/113,::8000:0:0/"
          "81,::8000:0:0:0/65,::800:0:0/85,::800:0:0:0/69,::80:0:0/"
          "89,::80:0:0:0/73,::8:0:0/93,::8:0:0:0/77";
+
+  QTest::addRow("world vs rfc1918 (part)")
+      << "0.0.0.0/5,11.0.0.0/8,12.0.0.0/6,128.0.0.0/1,16.0.0.0/4,32.0.0.0/"
+         "3,64.0.0.0/2,8.0.0.0/7"
+      << "8.0.0.0/5"
+      << "0.0.0.0/5,128.0.0.0/1,16.0.0.0/4,32.0.0.0/3,64.0.0.0/2";
 }
 
 void TestIpAddress::excludeAddresses() {
   QFETCH(QString, input);
-  IPAddress a = IPAddress(input);
+  QList<IPAddress> a;
+  for (const QString& addrString : input.split(",")) {
+    a.append(IPAddress(addrString));
+  }
 
   QFETCH(QString, excludeAddresses);
-  IPAddress b = IPAddress(excludeAddresses);
+  QList<IPAddress> b;
+  for (const QString& addrString : excludeAddresses.split(",")) {
+    b.append(IPAddress(addrString));
+  }
 
   QStringList list;
-  for (const IPAddress& r : a.excludeAddresses(b)) {
+  for (const IPAddress& r : IPAddress::excludeAddresses(a, b)) {
     list.append(r.toString());
   }
 

--- a/src/apps/vpn/appsettingslist.h
+++ b/src/apps/vpn/appsettingslist.h
@@ -150,6 +150,28 @@ SETTING_STRING(entryServerCountryCodeDeprecated,        // getter
                false  // sensitive (do not log)
 )
 
+SETTING_STRINGLIST(excludedIpv4Addresses,        // getter
+                   setExcludedIpv4Addresses,     // setter
+                   removeExcludedIpv4Addresses,  // remover
+                   hasExcludedIpv4Addresses,     // has
+                   "excluded/ipv4Addresses",     // key
+                   QStringList(),                // default value
+                   false,                        // user setting
+                   false,                        // remove when reset
+                   false                         // sensitive (do not log)
+)
+
+SETTING_STRINGLIST(excludedIpv6Addresses,         // getter
+                   setExcludedIpv6Addresses,      // setter
+                   removerExcludedIpv6Addresses,  // remover
+                   hasExcludedIpv6Addresses,      // has
+                   "excluded/ipv6Addresses",      // key
+                   QStringList(),                 // default value
+                   false,                         // user setting
+                   false,                         // remove when reset
+                   false                          // sensitive (do not log)
+)
+
 SETTING_STRINGLIST(iapProducts,        // getter
                    setIapProducts,     // setter
                    removeIapProducts,  // remover

--- a/src/apps/vpn/cmake/sources.cmake
+++ b/src/apps/vpn/cmake/sources.cmake
@@ -104,6 +104,8 @@ target_sources(mozillavpn-sources INTERFACE
     ${CMAKE_CURRENT_SOURCE_DIR}/apps/vpn/commands/commanddeactivate.h
     ${CMAKE_CURRENT_SOURCE_DIR}/apps/vpn/commands/commanddevice.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/apps/vpn/commands/commanddevice.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/apps/vpn/commands/commandexcludeip.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/apps/vpn/commands/commandexcludeip.h
     ${CMAKE_CURRENT_SOURCE_DIR}/apps/vpn/commands/commandlogin.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/apps/vpn/commands/commandlogin.h
     ${CMAKE_CURRENT_SOURCE_DIR}/apps/vpn/commands/commandlogout.cpp

--- a/src/apps/vpn/commands/commandexcludeip.cpp
+++ b/src/apps/vpn/commands/commandexcludeip.cpp
@@ -1,0 +1,117 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "commandexcludeip.h"
+
+#include <QHostAddress>
+#include <QTextStream>
+
+#include "ipaddress.h"
+#include "leakdetector.h"
+#include "mozillavpn.h"
+#include "settingsholder.h"
+
+constexpr const int LIST = 0;
+constexpr const int ADD = 1;
+constexpr const int REMOVE = 2;
+
+CommandExcludeIP::CommandExcludeIP(QObject* parent)
+    : Command(parent, "excludeip", "Exclude IP addresses from VPN routing") {
+  MZ_COUNT_CTOR(CommandExcludeIP);
+}
+
+CommandExcludeIP::~CommandExcludeIP() { MZ_COUNT_DTOR(CommandExcludeIP); }
+
+int CommandExcludeIP::run(QStringList& tokens) {
+  Q_ASSERT(!tokens.isEmpty());
+  return runCommandLineApp([&]() {
+    QStringList commandList{"list", "add", "remove"};
+
+    int command = -1;
+    if (tokens.length() > 1) {
+      command = commandList.indexOf(tokens[1]);
+    }
+
+    QTextStream stream(stdout);
+    if (command < 0) {
+      stream << "usage: " << tokens[0] << " <list|add|remove> [ip]" << Qt::endl;
+      return 1;
+    }
+    if (command == LIST && tokens.length() != 2) {
+      stream << "usage: " << tokens[0] << " " << tokens[1] << Qt::endl;
+      return 1;
+    }
+    if (command != LIST && tokens.length() != 3) {
+      stream << "usage: " << tokens[0] << " " << tokens[1] << " <ip>"
+             << Qt::endl;
+      stream << Qt::endl;
+      stream << "The list of excluded <ips> can be obtained using: 'list'"
+             << Qt::endl;
+      return 1;
+    }
+
+    if (!userAuthenticated()) {
+      return 1;
+    }
+
+    MozillaVPN vpn;
+    if (!loadModels()) {
+      return 1;
+    }
+
+    SettingsHolder* settingsHolder = SettingsHolder::instance();
+    QStringList ipv4Addresses = settingsHolder->excludedIpv4Addresses();
+    QStringList ipv6Addresses = settingsHolder->excludedIpv6Addresses();
+
+    if (command == LIST) {
+      stream << "Excluded IP v4 addresses:" << Qt::endl;
+      for (const QString& ipv4String : ipv4Addresses) {
+        stream << "- " << ipv4String << Qt::endl;
+      }
+      stream << "Excluded IP v6 addresses:" << Qt::endl;
+      for (const QString& ipv6String : ipv6Addresses) {
+        stream << "- " << ipv6String << Qt::endl;
+      }
+      return 0;
+    }
+
+    // parseSubnet allows generous parsing, also works on IPs without /prefix
+    QHostAddress ip;
+    int prefix;
+    std::tie(ip, prefix) = QHostAddress::parseSubnet(tokens[2]);
+
+    if (ip.isNull() || prefix < 0) {
+      stream << tokens[2] << " is not a valid IP address." << Qt::endl;
+      return 1;
+    }
+
+    // Use IPAddress to get a canonical string representation
+    QString ipString = IPAddress(ip, prefix).toString();
+    if (ip.protocol() == QAbstractSocket::IPv4Protocol) {
+      if (command == ADD && !ipv4Addresses.contains(ipString)) {
+        ipv4Addresses << ipString;
+      } else if (command == REMOVE && ipv4Addresses.removeAll(ipString) == 0) {
+        stream << ipString << " is not currently an excluded IP address."
+               << Qt::endl;
+        return 1;
+      }
+      settingsHolder->setExcludedIpv4Addresses(ipv4Addresses);
+    } else if (ip.protocol() == QAbstractSocket::IPv6Protocol) {
+      if (command == ADD && !ipv6Addresses.contains(ipString)) {
+        ipv6Addresses << ipString;
+      } else if (command == REMOVE && ipv6Addresses.removeAll(ipString) == 0) {
+        stream << ipString << " is not currently an excluded IP address."
+               << Qt::endl;
+        return 1;
+      }
+      settingsHolder->setExcludedIpv6Addresses(ipv6Addresses);
+    } else {
+      Q_ASSERT(false);
+    }
+
+    return 0;
+  });
+}
+
+static Command::RegistrationProxy<CommandExcludeIP> s_commandDevice;

--- a/src/apps/vpn/commands/commandexcludeip.h
+++ b/src/apps/vpn/commands/commandexcludeip.h
@@ -1,0 +1,18 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef COMMANDDEVICE_H
+#define COMMANDDEVICE_H
+
+#include "command.h"
+
+class CommandExcludeIP final : public Command {
+ public:
+  explicit CommandExcludeIP(QObject* parent);
+  ~CommandExcludeIP();
+
+  int run(QStringList& tokens) override;
+};
+
+#endif  // COMMANDDEVICE_H

--- a/src/apps/vpn/controller.cpp
+++ b/src/apps/vpn/controller.cpp
@@ -832,6 +832,16 @@ QList<IPAddress> Controller::getAllowedIPAddressRanges(
   excludeIPv4s.append(RFC1112::ipv4MulticastAddressBlock());
   excludeIPv6s.append(RFC4291::ipv6MulticastAddressBlock());
 
+  logger.debug() << "Filtering out explicitely-set network address ranges";
+  for (const QString& ipv4String :
+       SettingsHolder::instance()->excludedIpv4Addresses()) {
+    excludeIPv4s.append(IPAddress(ipv4String));
+  }
+  for (const QString& ipv6String :
+       SettingsHolder::instance()->excludedIpv6Addresses()) {
+    excludeIPv6s.append(IPAddress(ipv6String));
+  }
+
   // Allow access to the internal gateway addresses.
   logger.debug() << "Allow the IPv4 gateway:" << exitServer.ipv4Gateway();
   list.append(IPAddress(QHostAddress(exitServer.ipv4Gateway()), 32));

--- a/src/shared/ipaddress.cpp
+++ b/src/shared/ipaddress.cpp
@@ -243,11 +243,11 @@ QList<IPAddress> IPAddress::excludeAddresses(
     QList<IPAddress> newResults;
 
     for (const IPAddress& ip : results) {
-      if (ip.overlaps(exclude)) {
+      if (!ip.overlaps(exclude)) {
+        newResults.append(ip);
+      } else if (exclude.subnetOf(ip) && exclude != ip) {
         QList<IPAddress> range = ip.excludeAddresses(exclude);
         newResults.append(range);
-      } else {
-        newResults.append(ip);
       }
     }
 


### PR DESCRIPTION
## Description

Adds a setting to allow whitelisting of IP address ranges, to extend split-tunnelling capabilities.

Unfortunately I haven’t yet figured out how to efficiently modify the qml to add a settings view for it, so this is only the function bit so far.

In the mean time any feedback would be helpful. I use this as a patch and edit the json settings directly.

## Reference

As described in #5182 

## Checklist
    
- [x] My code follows the style guidelines for this project
        I’ve ran clang-format-11.0.1
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
       “Where needed” is quite unclear but there seem to not be much testing for similar settings?
