### PR TITLE
Fix silent-server switch on iOS

### DIFF
--- a/src/apps/vpn/controller.cpp
+++ b/src/apps/vpn/controller.cpp
@@ -55,6 +55,10 @@ namespace {
 Logger logger("Controller");
 
 ControllerImpl::Reason stateToReason(Controller::State state) {
+  if (state == Controller::StateOn) {
+    // This is a silent-server switch.
+    return ControllerImpl::ReasonSwitching;
+  }
   if (state == Controller::StateSwitching) {
     return ControllerImpl::ReasonSwitching;
   }

--- a/src/apps/vpn/controller.cpp
+++ b/src/apps/vpn/controller.cpp
@@ -657,7 +657,7 @@ void Controller::statusUpdated(const QString& serverIpv4Gateway,
 
   list.swap(m_getStatusCallbacks);
   for (const std::function<void(
-           const QString& serverIpv4Gateway, const QString& deviceIpv4Address,
+           const QString&serverIpv4Gateway, const QString&deviceIpv4Address,
            uint64_t txBytes, uint64_t rxBytes)>&func : list) {
     func(serverIpv4Gateway, deviceIpv4Address, txBytes, rxBytes);
   }

--- a/src/apps/vpn/controller.h
+++ b/src/apps/vpn/controller.h
@@ -48,6 +48,12 @@ class Controller final : public QObject {
   };
   Q_ENUM(State)
 
+  enum Reason {
+    ReasonNone = 0,
+    ReasonSwitching,
+    ReasonConfirming,
+  };
+
  private:
   Q_PROPERTY(State state READ state NOTIFY stateChanged)
   Q_PROPERTY(qint64 time READ time NOTIFY timeChanged)
@@ -134,8 +140,8 @@ class Controller final : public QObject {
   QList<IPAddress> getAllowedIPAddressRanges(const Server& server);
   QStringList getExcludedAddresses(const Server& server);
 
-  void activateInternal(bool forceDNSPort = false);
-  void activateNext();
+  void activateInternal(Reason reason, bool forceDNSPort = false);
+  void activateNext(Reason reason);
 
   void clearRetryCounter();
   void clearConnectedTime();

--- a/src/apps/vpn/controllerimpl.h
+++ b/src/apps/vpn/controllerimpl.h
@@ -30,12 +30,6 @@ class ControllerImpl : public QObject {
 
   virtual ~ControllerImpl() = default;
 
-  enum Reason {
-    ReasonNone = 0,
-    ReasonSwitching,
-    ReasonConfirming,
-  };
-
   // This method is called to initialize the controller. The initialization
   // is completed when the signal "initialized" is emitted.
   virtual void initialize(const Device* device, const Keys* keys) = 0;
@@ -46,11 +40,11 @@ class ControllerImpl : public QObject {
   // state terminates when the "connected" (or the "disconnected") signal is
   // received.
   virtual void activate(const HopConnection& hop, const Device* device,
-                        const Keys* keys, Reason Reason) = 0;
+                        const Keys* keys, Controller::Reason Reason) = 0;
 
   // This method terminates the VPN tunnel. The VPN client is in
   // "disconnecting" state until the "disconnected" signal is received.
-  virtual void deactivate(Reason reason) = 0;
+  virtual void deactivate(Controller::Reason reason) = 0;
 
   // This method is used to retrieve the VPN tunnel status (mainly the number
   // of bytes sent and received). It's called always when the VPN tunnel is

--- a/src/apps/vpn/localsocketcontroller.cpp
+++ b/src/apps/vpn/localsocketcontroller.cpp
@@ -116,7 +116,7 @@ void LocalSocketController::daemonConnected() {
 
 void LocalSocketController::activate(const HopConnection& hop,
                                      const Device* device, const Keys* keys,
-                                     Reason reason) {
+                                     Controller::Reason reason) {
   Q_UNUSED(reason);
 
   QJsonObject json;
@@ -161,7 +161,7 @@ void LocalSocketController::activate(const HopConnection& hop,
   write(json);
 }
 
-void LocalSocketController::deactivate(Reason reason) {
+void LocalSocketController::deactivate(Controller::Reason reason) {
   logger.debug() << "Deactivating";
 
   if (m_daemonState != eReady) {
@@ -170,7 +170,7 @@ void LocalSocketController::deactivate(Reason reason) {
     return;
   }
 
-  if (reason == ReasonSwitching) {
+  if (reason == Controller::ReasonSwitching) {
     logger.debug() << "No disconnect for quick server switching";
     emit disconnected();
     return;

--- a/src/apps/vpn/localsocketcontroller.h
+++ b/src/apps/vpn/localsocketcontroller.h
@@ -24,9 +24,9 @@ class LocalSocketController final : public ControllerImpl {
   void initialize(const Device* device, const Keys* keys) override;
 
   void activate(const HopConnection& hop, const Device* device,
-                const Keys* keys, Reason Reason) override;
+                const Keys* keys, Controller::Reason Reason) override;
 
-  void deactivate(Reason reason) override;
+  void deactivate(Controller::Reason reason) override;
 
   void checkStatus() override;
 

--- a/src/apps/vpn/platforms/android/androidcontroller.cpp
+++ b/src/apps/vpn/platforms/android/androidcontroller.cpp
@@ -194,10 +194,10 @@ void AndroidController::activate(const HopConnection& hop, const Device* device,
                                     doc.toJson());
 }
 
-void AndroidController::deactivate(Reason reason) {
+void AndroidController::deactivate(Controller::Reason reason) {
   logger.debug() << "deactivation";
 
-  if (reason != ReasonNone) {
+  if (reason != Controller::ReasonNone) {
     // Just show that we're disconnected
     // we're doing the actual disconnect once
     // the vpn-service has the new server ready in Action->Activate

--- a/src/apps/vpn/platforms/android/androidcontroller.cpp
+++ b/src/apps/vpn/platforms/android/androidcontroller.cpp
@@ -108,7 +108,7 @@ void AndroidController::initialize(const Device* device, const Keys* keys) {
 }
 
 void AndroidController::activate(const HopConnection& hop, const Device* device,
-                                 const Keys* keys, Reason reason) {
+                                 const Keys* keys, Controller::Reason reason) {
   Q_ASSERT(hop.m_hopindex == 0);
   logger.debug() << "Activation";
 

--- a/src/apps/vpn/platforms/android/androidcontroller.h
+++ b/src/apps/vpn/platforms/android/androidcontroller.h
@@ -20,9 +20,9 @@ class AndroidController final : public ControllerImpl {
   void initialize(const Device* device, const Keys* keys) override;
 
   void activate(const HopConnection& hop, const Device* device,
-                const Keys* keys, Reason Reason) override;
+                const Keys* keys, Controller::Reason Reason) override;
 
-  void deactivate(Reason reason) override;
+  void deactivate(Controller::Reason reason) override;
 
   void checkStatus() override;
 

--- a/src/apps/vpn/platforms/dummy/dummycontroller.cpp
+++ b/src/apps/vpn/platforms/dummy/dummycontroller.cpp
@@ -33,7 +33,7 @@ DummyController::DummyController() : m_delayTimer(this) {
 DummyController::~DummyController() { MVPN_COUNT_DTOR(DummyController); }
 
 void DummyController::activate(const HopConnection& hop, const Device* device,
-                               const Keys* keys, Reason reason) {
+                               const Keys* keys, Controller::Reason reason) {
   Q_UNUSED(device);
   Q_UNUSED(keys);
   Q_UNUSED(reason);
@@ -46,7 +46,7 @@ void DummyController::activate(const HopConnection& hop, const Device* device,
   m_delayTimer.start(DUMMY_CONNECTION_DELAY_MSEC);
 }
 
-void DummyController::deactivate(Reason reason) {
+void DummyController::deactivate(Controller::Reason reason) {
   Q_UNUSED(reason);
 
   logger.debug() << "DummyController deactivated";

--- a/src/apps/vpn/platforms/dummy/dummycontroller.h
+++ b/src/apps/vpn/platforms/dummy/dummycontroller.h
@@ -25,9 +25,9 @@ class DummyController final : public ControllerImpl {
   }
 
   void activate(const HopConnection& hop, const Device* device,
-                const Keys* keys, Reason reason) override;
+                const Keys* keys, Controller::Reason reason) override;
 
-  void deactivate(Reason reason) override;
+  void deactivate(Controller::Reason reason) override;
 
   void checkStatus() override;
 

--- a/src/apps/vpn/platforms/ios/ioscontroller.h
+++ b/src/apps/vpn/platforms/ios/ioscontroller.h
@@ -19,9 +19,9 @@ class IOSController final : public ControllerImpl {
   void initialize(const Device* device, const Keys* keys) override;
 
   void activate(const HopConnection& hop, const Device* device,
-                const Keys* keys, Reason reason) override;
+                const Keys* keys, Controller::Reason reason) override;
 
-  void deactivate(Reason reason) override;
+  void deactivate(Controller::Reason reason) override;
 
   void checkStatus() override;
 

--- a/src/apps/vpn/platforms/ios/ioscontroller.mm
+++ b/src/apps/vpn/platforms/ios/ioscontroller.mm
@@ -105,7 +105,7 @@ void IOSController::initialize(const Device* device, const Keys* keys) {
 }
 
 void IOSController::activate(const HopConnection& hop, const Device* device, const Keys* keys,
-                             Reason reason) {
+                             Controller::Reason reason) {
   Q_UNUSED(device);
   Q_UNUSED(keys);
 
@@ -146,10 +146,10 @@ void IOSController::activate(const HopConnection& hop, const Device* device, con
              }];
 }
 
-void IOSController::deactivate(Reason reason) {
+void IOSController::deactivate(Controller::Reason reason) {
   logger.debug() << "IOSController deactivated";
 
-  if (reason != ReasonNone) {
+  if (reason != Controller::ReasonNone) {
     logger.debug() << "We do not need to disable the VPN for switching or connection check.";
     emit disconnected();
     return;

--- a/src/apps/vpn/platforms/linux/linuxcontroller.cpp
+++ b/src/apps/vpn/platforms/linux/linuxcontroller.cpp
@@ -68,7 +68,7 @@ void LinuxController::initializeCompleted(QDBusPendingCallWatcher* call) {
 }
 
 void LinuxController::activate(const HopConnection& hop, const Device* device,
-                               const Keys* keys, Reason reason) {
+                               const Keys* keys, Controller::Reason reason) {
   Q_UNUSED(reason);
 
   connect(
@@ -81,10 +81,10 @@ void LinuxController::activate(const HopConnection& hop, const Device* device,
   logger.debug() << "LinuxController activated";
 }
 
-void LinuxController::deactivate(Reason reason) {
+void LinuxController::deactivate(Controller::Reason reason) {
   logger.debug() << "LinuxController deactivated";
 
-  if (reason == ReasonSwitching) {
+  if (reason == Controller::ReasonSwitching) {
     logger.debug() << "No disconnect for quick server switching";
     emit disconnected();
     return;

--- a/src/apps/vpn/platforms/linux/linuxcontroller.h
+++ b/src/apps/vpn/platforms/linux/linuxcontroller.h
@@ -23,9 +23,9 @@ class LinuxController final : public ControllerImpl {
   void initialize(const Device* device, const Keys* keys) override;
 
   void activate(const HopConnection& hop, const Device* device,
-                const Keys* keys, Reason reason) override;
+                const Keys* keys, Controller::Reason reason) override;
 
-  void deactivate(Reason reason) override;
+  void deactivate(Controller::Reason reason) override;
 
   void checkStatus() override;
 

--- a/tests/qml/moccontroller.cpp
+++ b/tests/qml/moccontroller.cpp
@@ -17,7 +17,7 @@ void Controller::implInitialized(bool, bool, const QDateTime&) {}
 
 bool Controller::activate() { return false; }
 
-void Controller::activateInternal(Reason reason,bool forcePort53) {Q_UNUSED(reason); Q_UNUSED(forcePort53) }
+void Controller::activateInternal(Reason reason, bool forcePort53) { Q_UNUSED(reason); Q_UNUSED(forcePort53) }
 
 bool Controller::deactivate() { return false; }
 

--- a/tests/qml/moccontroller.cpp
+++ b/tests/qml/moccontroller.cpp
@@ -17,7 +17,10 @@ void Controller::implInitialized(bool, bool, const QDateTime&) {}
 
 bool Controller::activate() { return false; }
 
-void Controller::activateInternal(Reason reason, bool forcePort53) { Q_UNUSED(reason); Q_UNUSED(forcePort53) }
+void Controller::activateInternal(Reason reason, bool forcePort53) {
+  Q_UNUSED(reason);
+  Q_UNUSED(forcePort53)
+}
 
 bool Controller::deactivate() { return false; }
 

--- a/tests/qml/moccontroller.cpp
+++ b/tests/qml/moccontroller.cpp
@@ -17,7 +17,7 @@ void Controller::implInitialized(bool, bool, const QDateTime&) {}
 
 bool Controller::activate() { return false; }
 
-void Controller::activateInternal(bool forcePort53) { Q_UNUSED(forcePort53) }
+void Controller::activateInternal(Reason reason,bool forcePort53) {Q_UNUSED(reason); Q_UNUSED(forcePort53) }
 
 bool Controller::deactivate() { return false; }
 

--- a/tests/unit/moccontroller.cpp
+++ b/tests/unit/moccontroller.cpp
@@ -18,7 +18,7 @@ void Controller::implInitialized(bool, bool, const QDateTime&) {}
 
 bool Controller::activate() { return false; }
 
-void Controller::activateInternal(bool forcePort53) { Q_UNUSED(forcePort53) }
+void Controller::activateInternal(Reason reason,bool forcePort53) {Q_UNUSED(reason); Q_UNUSED(forcePort53) }
 
 bool Controller::deactivate() { return false; }
 

--- a/tests/unit/moccontroller.cpp
+++ b/tests/unit/moccontroller.cpp
@@ -18,7 +18,7 @@ void Controller::implInitialized(bool, bool, const QDateTime&) {}
 
 bool Controller::activate() { return false; }
 
-void Controller::activateInternal(Reason reason,bool forcePort53) {Q_UNUSED(reason); Q_UNUSED(forcePort53) }
+void Controller::activateInternal(Reason reason, bool forcePort53) { Q_UNUSED(reason); Q_UNUSED(forcePort53) }
 
 bool Controller::deactivate() { return false; }
 

--- a/tests/unit/moccontroller.cpp
+++ b/tests/unit/moccontroller.cpp
@@ -18,7 +18,10 @@ void Controller::implInitialized(bool, bool, const QDateTime&) {}
 
 bool Controller::activate() { return false; }
 
-void Controller::activateInternal(Reason reason, bool forcePort53) { Q_UNUSED(reason); Q_UNUSED(forcePort53) }
+void Controller::activateInternal(Reason reason, bool forcePort53) {
+  Q_UNUSED(reason);
+  Q_UNUSED(forcePort53)
+}
 
 bool Controller::deactivate() { return false; }
 


### PR DESCRIPTION
## Description

Currently we send ``ReasonNone`` to the iOS controller for a silent-server switch. This means it will try to activate the tunnel instead of switching. Therefore we never get a ```connected``` event back, timeout in the activation, try all servers until none is left and show the "no servers" error. 


## Reference

[    i.e Jira or Github issue URL](https://mozilla-hub.atlassian.net/jira/software/c/projects/VPN/boards/344?modal=detail&selectedIssue=VPN-3352&assignee=6047c4eeaddbcd006ba87be8)

