### PR TITLE
Android: Grab OpenSSL builds from Google

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,10 @@ if(APPLE)
     endif()
 endif()
 
+if(ANDROID)
+    include(src/cmake/android_openssl.cmake)
+endif()
+
 if(NOT DEFINED BUILD_ID)
     string(TIMESTAMP BUILD_ID "${PROJECT_VERSION_MAJOR}.%Y%m%d%H%M")
     message("Generated BUILD_ID: ${BUILD_ID}")

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -212,26 +212,3 @@ task ktlintFormat(type: JavaExec, group: "formatting") {
     main = "com.pinterest.ktlint.Main"
     args "-F", "src/**/*.kt", "!**/build/**/*.kt", "buildSrc/**/*.kt",  "daemon/**/*.kt", "**/*.kts"
 }
-
-
-// Tasks to Import the Platform plugins
-task importOpenSSL(type: Copy) {
-    with(copySpec(){
-        from("../../../3rdparty/openSSL/latest/arm")
-        into("armeabi-v7a")
-    })
-    with(copySpec(){
-        from("../../../3rdparty/openSSL/latest/arm64")
-        into("arm64-v8a")
-    })
-    with(copySpec(){
-        from("../../../3rdparty/openSSL/latest/x86")
-        into("x86")
-    })
-    with(copySpec(){
-        from("../../../3rdparty/openSSL/latest/x86_64")
-        into("x86_64")
-    })
-    into("build/ssl")
-}
-preBuild.dependsOn importOpenSSL

--- a/src/cmake/android.cmake
+++ b/src/cmake/android.cmake
@@ -2,6 +2,11 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+add_dependencies(mozillavpn ndk_openssl_merged)
+
+get_property(crypto_module GLOBAL PROPERTY OPENSSL_CRYPTO_MODULE)
+get_property(ssl_module GLOBAL PROPERTY OPENSSL_SSL_MODULE)
+
 
 set_property(TARGET mozillavpn APPEND PROPERTY QT_ANDROID_PACKAGE_SOURCE_DIR
     ${CMAKE_CURRENT_SOURCE_DIR}/../android/
@@ -66,3 +71,16 @@ else()
         message( FATAL_ERROR "Adjust token cannot be empty for release builds")
     endif()
 endif()
+
+
+target_include_directories(mozillavpn PUBLIC ${ssl_module}/include)
+
+
+get_property(openssl_libs GLOBAL PROPERTY OPENSSL_LIBS)
+set_property(TARGET mozillavpn PROPERTY QT_ANDROID_EXTRA_LIBS
+    ${openssl_libs}/libcrypto_1_1.so
+    ${openssl_libs}/libssl_1_1.so)
+
+target_link_directories( mozillavpn PUBLIC ${openssl_libs})
+target_link_libraries(mozillavpn PRIVATE libcrypto.so)
+target_link_libraries(mozillavpn PRIVATE libssl.so)

--- a/src/cmake/android_openssl.cmake
+++ b/src/cmake/android_openssl.cmake
@@ -1,0 +1,61 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+# This cmake file integrates the OpenSSL-Prefab into our build system.
+# Google Publishes builds of openSSL for android on maven. 
+
+
+include(ExternalProject)
+ExternalProject_Add(ndk_openssl
+  URL https://maven.google.com/com/android/ndk/thirdparty/openssl/1.1.1q-beta-1/openssl-1.1.1q-beta-1.aar
+  URL_HASH SHA256=a5b05c4b362d35c022238ef9b2e4e2196248adea3bac9dd683845ee75a3a8d66
+  BUILD_IN_SOURCE 1
+  DOWNLOAD_NAME "openssl_android.zip" # Save it as zip, so cmake knows to extract.
+  CONFIGURE_COMMAND ""
+  BUILD_COMMAND ""
+  INSTALL_COMMAND ""
+  DOWNLOAD_EXTRACT_TIMESTAMP true
+)
+
+# Sadly, since we're not building the client in the gradle enviroment
+# We can't use this "raw". 
+# These 2 Tasks fetch the artifact and unpack them, making it usable for us.
+
+# It will Set 3 Global Properties to read from 
+# OPENSSL_CRYPTO_MODULE -> the prefab path of ssl::crypto (abi-checked)
+# OPENSSL_SSL_MODULE -> the prefab path of ssl::ssl (abi-checked)
+# OPENSSL_LIBS -> a folder containing both shared libarys.
+# Note: OPENSSL_LIBS has each file 2 times:
+# once named <libname>.so and <libname>_1_1.so
+# QT only seeems to load them if they are called x.1_1.so
+# For the Rust/Openssl-sys crate we need x.so
+
+
+SET( _OPENSSL_CRYPTO_MODULE "${CMAKE_BINARY_DIR}/ndk_openssl-prefix/src/ndk_openssl/prefab/modules/crypto")
+SET( _OPENSSL_SSL_MODULE "${CMAKE_BINARY_DIR}/ndk_openssl-prefix/src/ndk_openssl/prefab/modules/ssl")
+SET( _OPENSSL_LIBS "${CMAKE_BINARY_DIR}/ndk_openssl/libs") 
+SET( _OPENSSL_INCLUDE "${CMAKE_BINARY_DIR}/ndk_openssl/include") 
+
+file(MAKE_DIRECTORY ${_OPENSSL_LIBS})
+file(MAKE_DIRECTORY ${_OPENSSL_INCLUDE})
+
+
+
+set_property(GLOBAL PROPERTY OPENSSL_CRYPTO_MODULE ${_OPENSSL_CRYPTO_MODULE})
+set_property(GLOBAL PROPERTY OPENSSL_SSL_MODULE ${_OPENSSL_SSL_MODULE})
+set_property(GLOBAL PROPERTY OPENSSL_LIBS ${_OPENSSL_LIBS}) 
+
+# Copy them in one folder so that they can be used in 
+# rust-openssl's env:OPENSSL_LIB_DIR
+# and qt's extra libs. 
+add_custom_target(ndk_openssl_merged)
+add_dependencies(ndk_openssl_merged ndk_openssl)
+add_custom_command(
+        TARGET ndk_openssl_merged
+        COMMAND ${CMAKE_COMMAND} -E copy ${_OPENSSL_SSL_MODULE}/libs/android.${ANDROID_ABI}/libssl.so ${_OPENSSL_LIBS}/libssl_1_1.so
+        COMMAND ${CMAKE_COMMAND} -E copy ${_OPENSSL_CRYPTO_MODULE}/libs/android.${ANDROID_ABI}/libcrypto.so ${_OPENSSL_LIBS}/libcrypto_1_1.so
+        COMMAND ${CMAKE_COMMAND} -E copy ${_OPENSSL_SSL_MODULE}/libs/android.${ANDROID_ABI}/libssl.so ${_OPENSSL_LIBS}/libssl.so
+        COMMAND ${CMAKE_COMMAND} -E copy ${_OPENSSL_CRYPTO_MODULE}/libs/android.${ANDROID_ABI}/libcrypto.so ${_OPENSSL_LIBS}/libcrypto.so)
+

--- a/src/cmake/android_openssl.cmake
+++ b/src/cmake/android_openssl.cmake
@@ -1,11 +1,8 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-
 # This cmake file integrates the OpenSSL-Prefab into our build system.
 # Google Publishes builds of openSSL for android on maven. 
-
 
 include(ExternalProject)
 ExternalProject_Add(ndk_openssl
@@ -16,7 +13,6 @@ ExternalProject_Add(ndk_openssl
   CONFIGURE_COMMAND ""
   BUILD_COMMAND ""
   INSTALL_COMMAND ""
-  DOWNLOAD_EXTRACT_TIMESTAMP true
 )
 
 # Sadly, since we're not building the client in the gradle enviroment
@@ -32,7 +28,6 @@ ExternalProject_Add(ndk_openssl
 # QT only seeems to load them if they are called x.1_1.so
 # For the Rust/Openssl-sys crate we need x.so
 
-
 SET( _OPENSSL_CRYPTO_MODULE "${CMAKE_BINARY_DIR}/ndk_openssl-prefix/src/ndk_openssl/prefab/modules/crypto")
 SET( _OPENSSL_SSL_MODULE "${CMAKE_BINARY_DIR}/ndk_openssl-prefix/src/ndk_openssl/prefab/modules/ssl")
 SET( _OPENSSL_LIBS "${CMAKE_BINARY_DIR}/ndk_openssl/libs") 
@@ -40,8 +35,6 @@ SET( _OPENSSL_INCLUDE "${CMAKE_BINARY_DIR}/ndk_openssl/include")
 
 file(MAKE_DIRECTORY ${_OPENSSL_LIBS})
 file(MAKE_DIRECTORY ${_OPENSSL_INCLUDE})
-
-
 
 set_property(GLOBAL PROPERTY OPENSSL_CRYPTO_MODULE ${_OPENSSL_CRYPTO_MODULE})
 set_property(GLOBAL PROPERTY OPENSSL_SSL_MODULE ${_OPENSSL_SSL_MODULE})
@@ -58,4 +51,3 @@ add_custom_command(
         COMMAND ${CMAKE_COMMAND} -E copy ${_OPENSSL_CRYPTO_MODULE}/libs/android.${ANDROID_ABI}/libcrypto.so ${_OPENSSL_LIBS}/libcrypto_1_1.so
         COMMAND ${CMAKE_COMMAND} -E copy ${_OPENSSL_SSL_MODULE}/libs/android.${ANDROID_ABI}/libssl.so ${_OPENSSL_LIBS}/libssl.so
         COMMAND ${CMAKE_COMMAND} -E copy ${_OPENSSL_CRYPTO_MODULE}/libs/android.${ANDROID_ABI}/libcrypto.so ${_OPENSSL_LIBS}/libcrypto.so)
-

--- a/src/models/device.cpp
+++ b/src/models/device.cpp
@@ -13,7 +13,7 @@
 #include "keys.h"
 #include "leakdetector.h"
 
-#ifdef MVPN_WINDOWS
+#if defined(MVPN_WINDOWS) || defined(MVPN_ANDROID)
 #  include <QSslSocket>
 #endif
 
@@ -77,7 +77,7 @@ QString Device::currentDeviceReport() {
   out << "Build ID -> " << Constants::buildNumber() << Qt::endl;
   out << "Device ID -> " << uniqueDeviceId() << Qt::endl;
 
-#ifdef MVPN_WINDOWS
+#if defined(MVPN_WINDOWS) || defined(MVPN_ANDROID)
   out << "SSL Lib:" << QSslSocket::sslLibraryVersionString()
       << QSslSocket::sslLibraryVersionNumber() << Qt::endl;
 #endif

--- a/src/models/device.cpp
+++ b/src/models/device.cpp
@@ -13,7 +13,7 @@
 #include "keys.h"
 #include "leakdetector.h"
 
-#if defined(MVPN_WINDOWS) || defined(MVPN_ANDROID)
+#ifndef QT_NO_SSL
 #  include <QSslSocket>
 #endif
 
@@ -77,7 +77,7 @@ QString Device::currentDeviceReport() {
   out << "Build ID -> " << Constants::buildNumber() << Qt::endl;
   out << "Device ID -> " << uniqueDeviceId() << Qt::endl;
 
-#if defined(MVPN_WINDOWS) || defined(MVPN_ANDROID)
+#ifndef QT_NO_SSL
   out << "SSL Lib:" << QSslSocket::sslLibraryVersionString()
       << QSslSocket::sslLibraryVersionNumber() << Qt::endl;
 #endif

--- a/vpnglean/CMakeLists.txt
+++ b/vpnglean/CMakeLists.txt
@@ -11,6 +11,18 @@ find_program(RUSTC_EXECUTABLE NAMES rustc REQUIRED)
 
 add_library(vpnglean STATIC IMPORTED GLOBAL)
 
+if(ANDROID)
+    add_dependencies(vpnglean ndk_openssl_merged)
+    get_property(crypto_module GLOBAL PROPERTY OPENSSL_CRYPTO_MODULE)
+    get_property(ssl_module GLOBAL PROPERTY OPENSSL_SSL_MODULE)
+    get_property(openssl_libs GLOBAL PROPERTY OPENSSL_LIBS)
+
+    set(OPENSSL_LIBS ${openssl_libs})
+    set(SSL_INCLUDE ${ssl_module}/include)
+    set(SSL_LIB ${ssl_module}/libs/android.${ANDROID_ABI})
+    set(CRYPTO_LIB ${crypto_module}/libs/android.${ANDROID_ABI})
+endif()
+
 set_target_properties(vpnglean PROPERTIES FOLDER "Libs")
 
 # glean-core cannot be compiled to WASM
@@ -29,16 +41,12 @@ if(NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Emscripten")
     elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Android")
         if(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "aarch64")
             set(RUST_ARCH "aarch64-linux-android")
-            set(OPENSSL_ARCH "arm64")
         elseif(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "armv7-a")
             set(RUST_ARCH "armv7-linux-androideabi")
-            set(OPENSSL_ARCH "arm")
         elseif(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "i686")
             set(RUST_ARCH "i686-linux-android")
-            set(OPENSSL_ARCH "x86")
         elseif(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "x86_64")
             set(RUST_ARCH "x86_64-linux-android")
-            set(OPENSSL_ARCH "x86_64")
         endif()
     elseif(${CMAKE_SYSTEM_NAME} STREQUAL "iOS")
         if(${CMAKE_OSX_SYSROOT} STREQUAL "iphonesimulator")
@@ -58,8 +66,8 @@ if(NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Emscripten")
 
     if(ANDROID)
         list(APPEND CARGO_ENV
-            OPENSSL_LIB_DIR=${CMAKE_CURRENT_SOURCE_DIR}/../3rdparty/openSSL/static/lib/${OPENSSL_ARCH}
-            OPENSSL_INCLUDE_DIR=${CMAKE_CURRENT_SOURCE_DIR}/../3rdparty/openSSL/static/include
+            OPENSSL_LIB_DIR=${OPENSSL_LIBS}/
+            OPENSSL_INCLUDE_DIR=${SSL_INCLUDE}/
             AR=llvm-ar)
     elseif(APPLE AND XCODE)
         ## Don't trust Xcode to provide us with a usable linker.


### PR DESCRIPTION
## Description
Our 3rdpary/openSSL submodule did fall behind in versions. 
Google actually [provides builds of OpenSSL themselves](https://mvnrepository.com/artifact/com.android.ndk.thirdparty/openssl), however only in an aar-prefab. 
This PR adds some cmake logic to pull those, extract the right libs and feed them into our build system. 

## Reference

https://mozilla-hub.atlassian.net/browse/VPN-3069


