### PR TITLE
Android: Fix Connection Time

### DIFF
--- a/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/VPNService.kt
+++ b/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/VPNService.kt
@@ -276,13 +276,16 @@ class VPNService : android.net.VpnService() {
                 )
                 return
             }
-            // In case we do not have a config, currentConnectionTime needs to be now.
-            currentConnectionTime = System.currentTimeMillis()
             this.mConfig = JSONObject(lastConfString)
         }
         Log.v(tag, "Try to reconnect tunnel with same conf")
         this.turnOn(this.mConfig!!, forceFallBack)
-        mConnectionTime = currentConnectionTime
+        if (currentConnectionTime != 0.toLong()) {
+            // In case we have had a connection timestamp,
+            // restore that, so that the silent switch is not
+            // putting people off. :)
+            mConnectionTime = currentConnectionTime
+        }
     }
 
     fun turnOff() {


### PR DESCRIPTION
## Description
We restore the last connection Timestamp, so that the silent-server switch of connection health does not reset the time. We did not check if that is 0, so let's only restore it if that is the case. 