### PR TITLE
Fix text alignment in guide cards for RTL locales

### DIFF
--- a/nebula/ui/components/VPNBoldInterLabel.qml
+++ b/nebula/ui/components/VPNBoldInterLabel.qml
@@ -13,6 +13,7 @@ Text {
     lineHeight: VPNTheme.theme.controllerInterLineHeight
     color: VPNTheme.theme.fontColorDark
     wrapMode: Text.Wrap
+    horizontalAlignment: Qt.AlignLeft
 
     Accessible.role: Accessible.StaticText
     Accessible.name: text


### PR DESCRIPTION
## Description

This fixes alignment of guide card text in RTL locales.
<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>

<tr>
<td>
<img width="450" alt="202287122-c3064f4d-9c2f-482d-8de7-b8aed324dbe8" src="https://user-images.githubusercontent.com/22355127/207682813-3ea23980-e93d-424f-aca0-0deaac0471b3.png">


</td>
<td>

<img width="440" alt="Screen Shot 2022-12-14 at 12 41 48 PM" src="https://user-images.githubusercontent.com/22355127/207684420-88747593-72e8-487c-bed9-ec22b6ee7747.png">


</td>
</tr>
</table>

## Reference

    i.e Jira or Github issue URL

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
