### PR TITLE
VPN-3171: Don't show password requirements immediately on input.activeFocus

### DIFF
--- a/nebula/ui/components/inAppAuth/VPNInAppAuthenticationInputs.qml
+++ b/nebula/ui/components/inAppAuth/VPNInAppAuthenticationInputs.qml
@@ -67,7 +67,7 @@ ColumnLayout {
         ToolTip {
             property bool _isSignUp: VPNAuthInApp.state === VPNAuthInApp.StateSignUp
             id: toolTip
-            visible: _isSignUp && passwordInput.activeFocus
+            visible: _isSignUp && passwordInput.text.length > 0 && passwordInput.activeFocus
             padding: VPNTheme.theme.windowMargin
             x: VPNTheme.theme.vSpacing
             y: passwordInput.y - height - 4


### PR DESCRIPTION
## Description

This adjusts the visibility rule of the password requirements tooltip so that it stays hidden until at least one character has been entered.

## Reference

VPN-3171

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
