### PR TITLE
Accessibility improvements to authentication flow

### DIFF
--- a/nebula/ui/components/VPNSubtitle.qml
+++ b/nebula/ui/components/VPNSubtitle.qml
@@ -17,4 +17,6 @@ Text {
     color: VPNTheme.theme.fontColor
     lineHeightMode: Text.FixedHeight
     lineHeight: VPNTheme.theme.labelLineHeight
+    Accessible.role: Accessible.StaticText
+    Accessible.name: text
 }

--- a/nebula/ui/components/forms/VPNPasswordInput.qml
+++ b/nebula/ui/components/forms/VPNPasswordInput.qml
@@ -11,8 +11,7 @@ import components.forms 0.1
 VPNTextField {
     property bool charactersMasked: true
     property bool isValid: true
-    property alias button: toggleButton
-    property alias placeholder: passwordInput._placeholderText
+    property alias button: showHidePasswordButton
 
     id: passwordInput
 
@@ -25,12 +24,10 @@ VPNTextField {
 
     echoMode: charactersMasked ? TextInput.Password : TextInput.Normal
     hasError: !isValid
-    height: VPNTheme.theme.rowHeight
-    rightPadding: VPNTheme.theme.windowMargin * 0.5 + toggleButton.width
-    width: parent.width
+    rightPadding: VPNTheme.theme.windowMargin * 0.5 + showHidePasswordButton.width
 
     VPNIconButton {
-        id: toggleButton
+        id: showHidePasswordButton
 
         accessibleName: passwordInput.charactersMasked
                         ? VPNl18n.InAppAuthShowPassword
@@ -42,9 +39,10 @@ VPNTextField {
         }
         height: parent.height - VPNTheme.theme.listSpacing
         width: parent.height - VPNTheme.theme.listSpacing
+        onClicked: passwordInput.charactersMasked = !passwordInput.charactersMasked
 
         Image {
-            anchors.centerIn: toggleButton
+            anchors.centerIn: showHidePasswordButton
             fillMode: Image.PreserveAspectFit
             source: passwordInput.charactersMasked
               ? "qrc:/nebula/resources/eye-hidden.svg"
@@ -53,18 +51,13 @@ VPNTextField {
             sourceSize.width: VPNTheme.theme.iconSize * 1.5
         }
 
-        function toggleVisibility() {
-            passwordInput.charactersMasked = !passwordInput.charactersMasked;
-        }
-
-        // Temporary workaround for QTBUG-78813: TextInput prevents touch events
+        // workaround for QTBUG-78813: TextInput prevents touch events
         // from reaching other MouseAreas.
         // https://bugreports.qt.io/browse/QTBUG-78813
         MouseArea {
+            onPressed: showHidePasswordButton.clicked()
             anchors.fill: parent
-            onPressed: {
-                toggleButton.toggleVisibility();
-            }
+            enabled: ["android", "ios"].includes(Qt.platform.os)
         }
     }
 }

--- a/nebula/ui/components/forms/VPNSearchBar.qml
+++ b/nebula/ui/components/forms/VPNSearchBar.qml
@@ -29,7 +29,6 @@ ColumnLayout {
         Accessible.searchEdit: true
         Layout.fillWidth: true
 
-        _accessibleName: _placeholderText
         background: VPNInputBackground {}
         leftInset: VPNTheme.theme.windowMargin * 3
         leftPadding: VPNTheme.theme.windowMargin * 3

--- a/nebula/ui/components/forms/VPNTextField.qml
+++ b/nebula/ui/components/forms/VPNTextField.qml
@@ -14,13 +14,11 @@ TextField {
     property bool showInteractionStates: true
     property bool forceBlurOnOutsidePress: true
     property alias _placeholderText: centeredPlaceholderText.text
-    property string _accessibleName: _placeholderText
-    property string _accessibleDescription: ""
 
     id: textField
 
-    Accessible.name: _accessibleName
-    Accessible.description: _accessibleDescription
+    Accessible.name: centeredPlaceholderText.text
+    Accessible.description:  centeredPlaceholderText.text
     Accessible.focused: textField.focus
     Layout.alignment: Qt.AlignVCenter
     Layout.preferredHeight: VPNTheme.theme.rowHeight


### PR DESCRIPTION
## Description
- Fixes password input show/hide button keyboard accessibility on desktop
- Adds accessibility rules to VPNSubtitle.qml for screen readers

## Reference

This PR fixes some of the issues noted by QA in **VPN-3387**
`“Enter your email address to continue using Mozilla VPN” text between the Mozilla VPN logo and “Enter email” field is not narrated;`

`“Finish creating your Firefox account to continue to Mozilla VPN” text between the “Change email” button and 
“Create password” field is not narrated;`

`“Open your email and enter the verification code that was sent” text between the “Enter verification code” and text field is not narrated;`

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
