### PR TITLE
Fix VPN-3494 - Use correct SUMO url

### DIFF
--- a/src/apps/vpn/appconstants.h
+++ b/src/apps/vpn/appconstants.h
@@ -109,6 +109,9 @@ constexpr const char* ADDON_SETTINGS_GROUP = "addons";
 #define PRODBETAEXPR(type, functionName, prod, beta) \
   inline type functionName() { return Constants::inProduction() ? prod : beta; }
 
+constexpr const char* MOZILLA_VPN_SUMO_URL =
+    "https://support.mozilla.org/en-US/products/firefox-private-network-vpn";
+
 PRODBETAEXPR(
     const char*, benchmarkUploadUrl, "https://benchmark.vpn.mozilla.org/upload",
     "https://dev.vpn-network-benchmark.nonprod.webservices.mozgcp.net/upload");

--- a/src/apps/vpn/ui/screens/getHelp/ViewGetHelp.qml
+++ b/src/apps/vpn/ui/screens/getHelp/ViewGetHelp.qml
@@ -26,7 +26,7 @@ VPNViewBase {
 
             accessibleName: VPNl18n.GetHelpHelpCenter
             title: VPNl18n.GetHelpHelpCenter
-            onClicked: VPNUrlOpener.openLink(VPNUrlOpener.LinkHelpSupport)
+            onClicked: VPNUrlOpener.openLink(VPNUrlOpener.LinkSumo)
             iconSource: "qrc:/nebula/resources/externalLink.svg"
             backgroundColor: VPNTheme.theme.clickableRowBlue
             width: parent.width - VPNTheme.theme.windowMargin

--- a/src/apps/vpn/ui/screens/getHelp/contactUs/ViewContactUsForm.qml
+++ b/src/apps/vpn/ui/screens/getHelp/contactUs/ViewContactUsForm.qml
@@ -42,7 +42,7 @@ VPNViewBase {
                        secondaryButtonText: VPNl18n.InAppSupportWorkflowSupportErrorBrowserButton,
                        secondaryButtonObjectName: "errorFxALinkButton",
                        secondaryButtonOnClick: () => {
-                               VPNUrlOpener.openLink(VPNUrlOpener.LinkHelpSupport);
+                               VPNUrlOpener.openLink(VPNUrlOpener.LinkSumo);
                                getHelpStackView.pop();
                            },
                        }

--- a/src/apps/vpn/urlopener.cpp
+++ b/src/apps/vpn/urlopener.cpp
@@ -70,9 +70,8 @@ void UrlOpener::openLink(LinkType linkType) {
       url.append("/reset_password");
       break;
 
-    case LinkHelpSupport:
-      url = NetworkRequest::apiBaseUrl();
-      url.append("/r/vpn/support");
+    case LinkSumo:
+      url = AppConstants::MOZILLA_VPN_SUMO_URL;
       break;
 
     case LinkLeaveReview:

--- a/src/apps/vpn/urlopener.h
+++ b/src/apps/vpn/urlopener.h
@@ -22,7 +22,6 @@ class UrlOpener final : public QObject {
     LinkContact,
     LinkForgotPassword,
     LinkLeaveReview,
-    LinkHelpSupport,
     LinkTermsOfService,
     LinkPrivacyNotice,
     LinkUpdate,
@@ -34,6 +33,7 @@ class UrlOpener final : public QObject {
     LinkSubscriptionIapApple,
     LinkSubscriptionFxa,
     LinkSubscriptionIapGoogle,
+    LinkSumo,
     LinkUpgradeToBundle,
   };
   Q_ENUM(LinkType)

--- a/tests/functional/testOnboarding.js
+++ b/tests/functional/testOnboarding.js
@@ -50,7 +50,7 @@ describe('Initial view and onboarding', function() {
     await vpn.clickOnElement('helpCenter');
     await vpn.waitForCondition(async () => {
       const url = await vpn.getLastUrl();
-      return url.endsWith('/r/vpn/support');
+      return url.endsWith('/firefox-private-network-vpn');
     });
 
     await vpn.clickOnElement(getHelpScreen.SUPPORT);

--- a/tests/functional/testSettings.js
+++ b/tests/functional/testSettings.js
@@ -374,7 +374,7 @@ describe('Settings', function () {
     await vpn.clickOnElement(getHelpScreen.HELP_CENTER);
     await vpn.waitForCondition(async () => {
       const url = await vpn.getLastUrl();
-      return url.endsWith('/r/vpn/support');
+      return url.endsWith('/firefox-private-network-vpn');
     });
 
     await vpn.wait();


### PR DESCRIPTION
## Description
This routes users directly to the Mozilla VPN SUMO page, instead of redirecting through Guardian first. After discussing with Santiago and Baku the thinking is this: a Guardian outage would likely result in folks clicking the 'Help center' link, which the downed Guardian would not be able to redirect to SUMO. 

## Reference

VPN-3494

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
