### PR TITLE
vpnglean: Use message() to report an error from CMake

### DIFF
--- a/vpnglean/CMakeLists.txt
+++ b/vpnglean/CMakeLists.txt
@@ -21,7 +21,7 @@ if(NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Emscripten")
     if(RUSTC_VERSION_RAW MATCHES "host: ([^\n]+)")
         set(RUSTC_HOST_ARCH ${CMAKE_MATCH_1})
     else()
-        error("Failed to find rustc host arch")
+        message(FATAL_ERROR "Failed to find rustc host arch")
     endif()
 
     if(NOT CMAKE_CROSSCOMPILING)


### PR DESCRIPTION
## Description

`error()` is not a CMake command.

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
