### PR TITLE
Fix segfault on QML load error

### DIFF
--- a/src/commands/commandui.cpp
+++ b/src/commands/commandui.cpp
@@ -567,16 +567,11 @@ int CommandUI::run(QStringList& tokens) {
 
     // Here is the main QML file.
     const QUrl url(QStringLiteral("qrc:/ui/main.qml"));
-    QObject::connect(
-        engine, &QQmlApplicationEngine::objectCreated, qApp,
-        [url](QObject* obj, const QUrl& objUrl) {
-          if (!obj && url == objUrl) {
-            logger.error() << "Failed to load " << objUrl.toString();
-            QGuiApplication::exit(-1);
-          }
-        },
-        Qt::QueuedConnection);
     engine->load(url);
+    if (!engineHolder->hasWindow()) {
+      logger.error() << "Failed to load " << url.toString();
+      return -1;
+    }
 
     NotificationHandler* notificationHandler =
         NotificationHandler::create(&engineHolder);

--- a/src/qmlengineholder.cpp
+++ b/src/qmlengineholder.cpp
@@ -57,6 +57,7 @@ QWindow* QmlEngineHolder::window() const {
       qobject_cast<QQmlApplicationEngine*>(m_engine);
   if (!engine) return nullptr;
 
+  Q_ASSERT(hasWindow());
   QObject* rootObject = engine->rootObjects().first();
   return qobject_cast<QWindow*>(rootObject);
 }

--- a/src/qmlengineholder.cpp
+++ b/src/qmlengineholder.cpp
@@ -61,6 +61,10 @@ QWindow* QmlEngineHolder::window() const {
   return qobject_cast<QWindow*>(rootObject);
 }
 
+bool QmlEngineHolder::hasWindow() const {
+  return !m_engine.rootObjects().isEmpty();
+}
+
 void QmlEngineHolder::showWindow() {
   QWindow* w = window();
   Q_ASSERT(w);

--- a/src/qmlengineholder.h
+++ b/src/qmlengineholder.h
@@ -32,6 +32,7 @@ class QmlEngineHolder final : public NetworkManager {
   QWindow* window() const;
   void showWindow();
   void hideWindow();
+  bool hasWindow() const;
 
  protected:
   void clearCacheInternal() override;


### PR DESCRIPTION
## Description

- When building from source, dependencies may be missing that cause QML to fail to load. 
   (There may be other situations but this is the scenario I ran into, as well as other users see #3749)
- The queued error handling code is never executed, because `QmlEngineHolder::instance()->window()` is dereferenced before the main loop (`app.qExec()`) is started
- This dereference of non-existing pointer causes a segfault
- Expected behaviour is to log `"Failed to load " << objUrl.toString()` and exit with `-1` as specified in error handling code
- Effectively the error handing code is currently dead code

This PR changes the delayed check for a check just after loading.

Alternately, all `QmlEngineHolder::instance()->window()` could be wrapped in a check of the window existing.
(This is a duplicate of #4121 but I mistakenly made the initial PR from my main branch. Sorry for the noise.)


## Reference

https://mozilla-hub.atlassian.net/browse/VPN-2403
https://github.com/mozilla-mobile/mozilla-vpn-client/issues/3749

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
