### PR TITLE
Add taskcluster jobs to build Ubuntu packages.

### DIFF
--- a/taskcluster/ci/build/linux.yml
+++ b/taskcluster/ci/build/linux.yml
@@ -31,7 +31,7 @@ linux/source:
             ./scripts/linux/script.sh --source &&
             tar -C .tmp -zvcf /builds/worker/artifacts/mozillavpn-sources.tar.gz .
 
-linxu/bionic:
+linux/bionic:
     description: "Linux Build (Ubuntu/Bionic)"
     treeherder:
         platform: linux/bionic

--- a/taskcluster/ci/build/linux.yml
+++ b/taskcluster/ci/build/linux.yml
@@ -2,23 +2,95 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 ---
-linux/opt:
-    description: "Linux Build"
+task-defaults:
     treeherder:
-        symbol: B
-        kind: build
-        tier: 1
-        platform: linux/opt
+            symbol: B
+            kind: build
+            tier: 1
     worker-type: b-linux
+    requires-level: 1
+    worker:
+          max-run-time: 3600
+          chain-of-trust: true
+    run:
+          using: run-task
+          use-caches: true
+
+linux/source:
+    description: "Linux Source Build"
+    treeherder:
+        platform: linux/source
     worker:
         docker-image: {in-tree: build}
-        max-run-time: 3600
-        chain-of-trust: true
     release-artifacts:
         # release-artifacts expects file to be in /builds/worker/artifacts/
-        - target.tar.gz
+        - mozillavpn-sources.tar.gz
     run:
-        using: run-task
-        use-caches: true
         cwd: '{checkout}'
-        command: ./taskcluster/scripts/build/linux.sh
+        command: >-
+            ./scripts/linux/script.sh --source &&
+            tar -C .tmp -zvcf /builds/worker/artifacts/mozillavpn-sources.tar.gz .
+
+linxu/bionic:
+    description: "Linux Build (Ubuntu/Bionic)"
+    treeherder:
+        platform: linux/bionic
+    fetches:
+        build:
+            - artifact: mozillavpn-sources.tar.gz
+    dependencies:
+        build: build-linux/source
+    worker:
+        docker-image: {in-tree: linux-build-bionic}
+    release-artifacts:
+        - mozillavpn-bionic.tar.gz
+    run:
+        command: /builds/worker/linux.sh --ppa ppa:okirby/qt6-backports
+
+linux/focal:
+    description: "Linux Build (Ubuntu/Focal)"
+    treeherder:
+        platform: linux/focal
+    fetches:
+        build:
+            - artifact: mozillavpn-sources.tar.gz
+    dependencies:
+        build: build-linux/source
+    worker:
+        docker-image: {in-tree: linux-build-focal}
+    release-artifacts:
+        - mozillavpn-focal.tar.gz
+    run:
+        command: /builds/worker/linux.sh --ppa ppa:okirby/qt6-backports
+
+linux/jammy:
+    description: "Linux Build (Ubuntu/Jammy)"
+    treeherder:
+        platform: linux/jammy
+    fetches:
+        build:
+            - artifact: mozillavpn-sources.tar.gz
+    dependencies:
+        build: build-linux/source
+    worker:
+        docker-image: {in-tree: linux-build-jammy}
+    release-artifacts:
+        - mozillavpn-jammy.tar.gz
+    run:
+        command: /builds/worker/linux.sh
+
+linux/kinetic:
+    description: "Linux Build (Ubuntu/Kinetic)"
+    treeherder:
+        platform: linux/kinetic
+    fetches:
+        build:
+            - artifact: mozillavpn-sources.tar.gz
+    dependencies:
+        build: build-linux/source
+    worker:
+        docker-image: {in-tree: linux-build-kinetic}
+    release-artifacts:
+        - mozillavpn-kinetic.tar.gz
+    run:
+        command: /builds/worker/linux.sh

--- a/taskcluster/ci/build/linux.yml
+++ b/taskcluster/ci/build/linux.yml
@@ -4,14 +4,17 @@
 ---
 task-defaults:
     treeherder:
-            symbol: B
-            kind: build
-            tier: 1
+        symbol: B
+        kind: build
+        tier: 1
     worker-type: b-linux
-    requires-level: 1
     worker:
-          max-run-time: 3600
-          chain-of-trust: true
+        max-run-time: 3600
+        chain-of-trust: true
+        artifacts:
+            - type: directory
+              name: public/build
+              path: /builds/worker/artifacts
     run:
           using: run-task
           use-caches: true
@@ -22,9 +25,6 @@ linux/source:
         platform: linux/source
     worker:
         docker-image: {in-tree: build}
-    release-artifacts:
-        # release-artifacts expects file to be in /builds/worker/artifacts/
-        - mozillavpn-sources.tar.gz
     run:
         cwd: '{checkout}'
         command: >-
@@ -42,8 +42,6 @@ linux/bionic:
         build: build-linux/source
     worker:
         docker-image: {in-tree: linux-build-bionic}
-    release-artifacts:
-        - mozillavpn-bionic.tar.gz
     run:
         command: /builds/worker/linux.sh --ppa ppa:okirby/qt6-backports
 
@@ -58,8 +56,6 @@ linux/focal:
         build: build-linux/source
     worker:
         docker-image: {in-tree: linux-build-focal}
-    release-artifacts:
-        - mozillavpn-focal.tar.gz
     run:
         command: /builds/worker/linux.sh --ppa ppa:okirby/qt6-backports
 
@@ -74,8 +70,6 @@ linux/jammy:
         build: build-linux/source
     worker:
         docker-image: {in-tree: linux-build-jammy}
-    release-artifacts:
-        - mozillavpn-jammy.tar.gz
     run:
         command: /builds/worker/linux.sh
 
@@ -90,7 +84,5 @@ linux/kinetic:
         build: build-linux/source
     worker:
         docker-image: {in-tree: linux-build-kinetic}
-    release-artifacts:
-        - mozillavpn-kinetic.tar.gz
     run:
         command: /builds/worker/linux.sh

--- a/taskcluster/ci/docker-image/kind.yml
+++ b/taskcluster/ci/docker-image/kind.yml
@@ -76,3 +76,23 @@ tasks:
         args:
             ANDROID_ARCH: android_armv7
             QT_VERSION: 6.4.0
+    linux-build-bionic:
+        symbol: I(linux-bionic)
+        definition: linux-dpkg-build
+        args:
+            DOCKER_BASE_IMAGE: ubuntu:bionic
+    linux-build-focal:
+        symbol: I(linux-focal)
+        definition: linux-dpkg-build
+        args:
+            DOCKER_BASE_IMAGE: ubuntu:focal
+    linux-build-jammy:
+        symbol: I(linux-jammy)
+        definition: linux-dpkg-build
+        args:
+            DOCKER_BASE_IMAGE: ubuntu:jammy
+    linux-build-kinetic:
+        symbol: I(linux-kinetic)
+        definition: linux-dpkg-build
+        args:
+            DOCKER_BASE_IMAGE: ubuntu:kinetic

--- a/taskcluster/docker/linux-dpkg-build/Dockerfile
+++ b/taskcluster/docker/linux-dpkg-build/Dockerfile
@@ -1,0 +1,60 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+ARG DOCKER_BASE_IMAGE=ubuntu:20:04
+
+FROM $DOCKER_BASE_IMAGE
+
+MAINTAINER Owen Kirby <okirby@mozilla.com>
+
+#----------------------------------------------------------------------------------------------------------------------
+#-- Extra Packages ----------------------------------------------------------------------------------------------------
+#----------------------------------------------------------------------------------------------------------------------
+ENV CURL='curl --location --retry 5' \
+    DEBIAN_FRONTENT='noninteractive' \
+    LANG='en_US.UTF-8' \
+    TERM='dumb'
+
+RUN apt-get update \
+    && apt-get install -y tzdata \
+    && apt-get install -y debhelper \
+                          devscripts \
+                          equivs \
+                          gpg-agent \
+                          locales \
+                          software-properties-common \
+                          sudo \
+    && apt-get clean
+
+RUN locale-gen "$LANG"
+
+#----------------------------------------------------------------------------------------------------------------------
+#-- Worker User -------------------------------------------------------------------------------------------------------
+#----------------------------------------------------------------------------------------------------------------------
+
+# Add worker user
+RUN mkdir /builds && \
+    useradd -d /builds/worker -s /bin/bash -m worker && \
+    chown worker:worker /builds/worker && \
+    mkdir /builds/worker/artifacts && \
+    chown worker:worker /builds/worker/artifacts
+
+WORKDIR /builds/worker/
+
+# Grant the worker user the ability to install packages without login
+RUN echo "worker ALL=(ALL) SETENV:NOPASSWD:/usr/bin/apt,/usr/bin/apt-get,/usr/bin/dpkg,/usr/bin/add-apt-repository" > /etc/sudoers.d/worker-packages
+
+#----------------------------------------------------------------------------------------------------------------------
+#-- Task Setup --------------------------------------------------------------------------------------------------------
+#----------------------------------------------------------------------------------------------------------------------
+
+# %include-run-task
+# %include taskcluster/scripts/build/linux.sh
+ADD topsrcdir/taskcluster/scripts/build/linux.sh /builds/worker/linux.sh
+
+VOLUME /builds/worker/checkouts
+VOLUME /builds/worker/.cache
+
+# run-task expects to run as root
+USER root

--- a/taskcluster/scripts/build/linux.sh
+++ b/taskcluster/scripts/build/linux.sh
@@ -5,7 +5,80 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 set -e
-bash scripts/linux/script.sh --source
 
-cd .tmp
-tar -zvcf /builds/worker/artifacts/target.tar.gz .
+## Get the default distribution to build from /etc/os-release
+source /etc/os-release
+
+helpFunction() {
+  echo "Usage: $0 [options]"
+  echo ""
+  echo "Build options:"
+  echo "  -d, --dist DIST     Build packages for distribution DIST (defaut: ${VERSION_CODENAME})"
+  echo "  -p, --ppa REPO      Add additional PPA archive from REPO"
+  echo "  -h, --help          Display this message and exit"
+}
+
+## Parse arguments
+while [[ $# -gt 0 ]]; do
+  key="$1"
+
+  case $key in
+    -d|--dist)
+      DIST="$2"
+      shift
+      shift
+      ;;
+
+    -p|--ppa)
+      QTPPA="$2"
+      shift
+      shift
+      ;;
+
+    -h|--help)
+      helpFunction
+      shift
+      exit 0
+      ;;
+
+    *)
+      echo "Unknown argument: $1" >&2
+      helpFunction
+      shift
+      exit 1
+      ;;
+  esac
+done
+
+# Fall back to the host operating system if no distribution was specified
+if [[ -z "$DIST" ]]; then
+  DIST="${VERSION_CODENAME}"
+fi
+
+# Install a PPA for Qt packages, if necessary.
+if [[ -n "$QTPPA" ]]; then
+    sudo add-apt-repository -y ${QTPPA}
+fi
+
+# Find and extract the package source
+DSCFILE=$(find ${MOZ_FETCHES_DIR} -name '*.dsc' | grep -E -- "-${DIST}[0-9]+.dsc")
+if [[ ! -f "$DSCFILE" ]]; then
+    echo "Unable to locate DSC file to build for ${DIST}" >&2
+    echo "${MOZ_FETCHES_DIR} contained:" >2&
+    find ${MOZ_FETCHES_DIR} -name '*.dsc' >2&
+    exit 1
+fi
+dpkg-source -x ${DSCFILE} $(pwd)/mozillavpn-source/
+DPKG_PACKAGE_SRCNAME=$(dpkg-parsechangelog -l mozillavpn-source/debian/changelog -S Source)
+DPKG_PACKAGE_VERSION=$(dpkg-parsechangelog -l mozillavpn-source/debian/changelog -S Version)
+DPKG_PACkAGE_BINNAME=$(cat mozillavpn-source/debian/control | grep "^Package:" | awk '{print $2}')
+
+# Install the package build dependencies.
+mk-build-deps $(pwd)/mozillavpn-source/debian/control
+sudo apt -y install ./${DPKG_PACKAGE_SRCNAME}-build-deps_${DPKG_PACKAGE_VERSION}_all.deb
+
+# Build the packages
+(cd mozillavpn-source/ && dpkg-buildpackage --unsigned-source --build=binary)
+
+# Gather the build artifacts for export
+tar -cvzf /builds/worker/artifacts/mozillavpn-${DIST}.tar.gz *.deb *.ddeb *.buildinfo *.changes


### PR DESCRIPTION
## Description
This PR adds Taskcluster jobs to produce packages for our supported Ubuntu releases (at present: `bionic`, `focal`, `jammy` and `kinetic`). This starts with an initial job to produce a source bundle, which is then shared by a separate build worker for each target release. The magic here is in producing a generic Docker image that matches an official Ubuntu build worker as closely as possible, but permits us to swap out the base container image.

Because we have split the build tasks up, the `build-linux/opt` task no longer really exists, and we will need to update Github's branch protection rules in order to merge this.

I haven't gone so far as to force offline builds like the official build workers do, so it is possible that a bug the golang and rust module vendoring could creep into the PPA.

So far this only produces build artifacts. We still need release tasks to publish them to archive.mozilla.org and/or push the source builds to a PPA. And there is some room for future improvement by targeting Debian and some of the RPM distributions too.

## Reference
JIRA issue [VPN-1706](https://mozilla-hub.atlassian.net/browse/VPN-1706)

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
