### PR TITLE
Kde dbus app tracking

### DIFF
--- a/src/apps/vpn/appfeaturelistcallback.h
+++ b/src/apps/vpn/appfeaturelistcallback.h
@@ -136,7 +136,7 @@ bool FeatureCallback_splitTunnel() {
     }
     /* The metadata we need (SourcePath) is only added since kio v5.75
      */
-    if (VersionApi::compareVersions(kdeVersion, "5.75") < 0) {
+    if (VersionUtils::compareVersions(kdeVersion, "5.75") < 0) {
       return false;
     }
   }

--- a/src/apps/vpn/appfeaturelistcallback.h
+++ b/src/apps/vpn/appfeaturelistcallback.h
@@ -129,6 +129,16 @@ bool FeatureCallback_splitTunnel() {
     if (VersionUtils::compareVersions(shellVersion, "3.34") < 0) {
       return false;
     }
+  } else if (desktop.contains("KDE")) {
+    QString kdeVersion = LinuxDependencies::kdeFrameworkVersion();
+    if (kdeVersion.isNull()) {
+      return false;
+    }
+    /* The metadata we need (SourcePath) is only added since kio v5.75
+     */
+    if (VersionApi::compareVersions(kdeVersion, "5.75") < 0) {
+      return false;
+    }
   }
   // TODO: These shells need more testing.
   else if (!desktop.contains("MATE") && !desktop.contains("Unity") &&

--- a/src/apps/vpn/platforms/linux/daemon/apptracker.h
+++ b/src/apps/vpn/platforms/linux/daemon/apptracker.h
@@ -58,6 +58,7 @@ class AppTracker final : public QObject {
   // Monitoring of the user's control groups.
   QString m_cgroupMount;
   QFileSystemWatcher m_cgroupWatcher;
+  QDBusInterface* m_systemdInterface = nullptr;
 
   // The set of applications that we have tracked.
   QHash<QString, AppData*> m_runningApps;

--- a/src/apps/vpn/platforms/linux/linuxdependencies.cpp
+++ b/src/apps/vpn/platforms/linux/linuxdependencies.cpp
@@ -138,3 +138,21 @@ QString LinuxDependencies::gnomeShellVersion() {
   }
   return shellVersion.toString();
 }
+
+// static
+QString LinuxDependencies::kdeFrameworkVersion() {
+  QProcess proc;
+  proc.start("kf5-config", QStringList{"--version"}, QIODeviceBase::ReadOnly);
+  if (!proc.waitForFinished()) {
+    return QString();
+  }
+
+  QByteArray result = proc.readAllStandardOutput();
+  for (const QByteArray& line : result.split('\n')) {
+    if (line.startsWith("KDE Frameworks: ")) {
+      return QString::fromUtf8(line.last(line.size() - 16));
+    }
+  }
+
+  return QString();
+}

--- a/src/apps/vpn/platforms/linux/linuxdependencies.h
+++ b/src/apps/vpn/platforms/linux/linuxdependencies.h
@@ -13,6 +13,7 @@ class LinuxDependencies final {
   static QString findCgroupPath(const QString& type);
   static QString findCgroup2Path();
   static QString gnomeShellVersion();
+  static QString kdeFrameworkVersion();
 
  private:
   LinuxDependencies() = default;


### PR DESCRIPTION
## Description

Support KDE as a split-tunneling desktop environment, by requesting the property of the systemd unit that is the full path to the desktop file. Only works for kio > 5.75 (in KDE frameworks) which is what is tested for the feature to be enabled.

## Reference

https://github.com/mozilla-mobile/mozilla-vpn-client/issues/1869

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
