### PR TITLE
Modules 10: Introduce VPN GleanDeprecated

### DIFF
--- a/nebula/ui/components/VPNComposerView.qml
+++ b/nebula/ui/components/VPNComposerView.qml
@@ -149,7 +149,7 @@ ColumnLayout {
                     colorScheme: loader.composerBlock.style === VPNComposerBlockButton.Primary ? VPNTheme.theme.blueButton : VPNTheme.theme.redButton
 
                     onClicked: {
-                        VPN.recordGleanEventWithExtraKeys("addonCtaClicked", { "addon_id": addon.id });
+                        VPNGleanDeprecated.recordGleanEventWithExtraKeys("addonCtaClicked", { "addon_id": addon.id });
                         Glean.sample.addonCtaClicked.record({
                             addon_id: addon.id
                         });

--- a/nebula/ui/components/VPNControllerView.qml
+++ b/nebula/ui/components/VPNControllerView.qml
@@ -461,7 +461,7 @@ Item {
 
         onClicked: {
             if (!box.connectionInfoScreenVisible) {
-                VPN.recordGleanEvent("connectionInfoOpened");
+                VPNGleanDeprecated.recordGleanEvent("connectionInfoOpened");
                 Glean.sample.connectionInfoOpened.record();
             }
             box.connectionInfoScreenVisible = !box.connectionInfoScreenVisible;

--- a/nebula/ui/components/VPNGuideList.qml
+++ b/nebula/ui/components/VPNGuideList.qml
@@ -45,7 +45,7 @@ GridLayout {
 
             onClicked:{
                 stackview.push("qrc:/ui/screens/settings/ViewGuide.qml", {"guide": addon, "imageBgColor": imageBgColor})
-                VPN.recordGleanEventWithExtraKeys("guideOpened", {
+                VPNGleanDeprecated.recordGleanEventWithExtraKeys("guideOpened", {
                     "id": addon.id
                 });
                 Glean.sample.guideOpened.record({ id: addon.id });

--- a/nebula/ui/components/VPNTutorialPopups.qml
+++ b/nebula/ui/components/VPNTutorialPopups.qml
@@ -247,7 +247,7 @@ Item {
         }
 
         tutorialPopup.secondaryButtonOnClicked = () => {
-            VPN.recordGleanEventWithExtraKeys("tutorialAborted", {"id": VPNTutorial.currentTutorial.id});
+            VPNGleanDeprecated.recordGleanEventWithExtraKeys("tutorialAborted", {"id": VPNTutorial.currentTutorial.id});
             Glean.sample.tutorialAborted.record({ id: VPNTutorial.currentTutorial.id });
             tutorialPopup._onClosed = () => {
                 if (op !== null) VPNTutorial.interruptAccepted(op);

--- a/src/apps/vpn/addons/addon.cpp
+++ b/src/apps/vpn/addons/addon.cpp
@@ -25,10 +25,10 @@
 #include "conditionwatchers/addonconditionwatchertriggertimesecs.h"
 #include "feature.h"
 #include "glean/generated/metrics.h"
+#include "gleandeprecated.h"
 #include "leakdetector.h"
 #include "localizer.h"
 #include "logger.h"
-#include "mozillavpn.h"
 #include "qmlengineholder.h"
 #include "settingsholder.h"
 #include "telemetry/gleansample.h"
@@ -437,7 +437,7 @@ void Addon::updateAddonState(State newState) {
           ._addonId = m_id,
           ._state = newStateSetting,
       });
-  emit MozillaVPN::instance()->recordGleanEventWithExtraKeys(
+  emit GleanDeprecated::instance()->recordGleanEventWithExtraKeys(
       GleanSample::addonStateChanged,
       {{"addon_id", m_id}, {"state", newStateSetting}});
 }

--- a/src/apps/vpn/addons/addonmessage.cpp
+++ b/src/apps/vpn/addons/addonmessage.cpp
@@ -6,13 +6,14 @@
 
 #include <QJsonObject>
 #include <QMetaEnum>
+#include <QTimer>
 
 #include "glean/generated/metrics.h"
+#include "gleandeprecated.h"
 #include "l18nstrings.h"
 #include "leakdetector.h"
 #include "localizer.h"
 #include "logger.h"
-#include "mozillavpn.h"
 #include "notificationhandler.h"
 #include "settingsholder.h"
 #include "telemetry/gleansample.h"
@@ -118,7 +119,7 @@ void AddonMessage::updateMessageState(MessageState newState) {
           ._messageId = id(),
           ._messageState = newStateSetting,
       });
-  emit MozillaVPN::instance()->recordGleanEventWithExtraKeys(
+  emit GleanDeprecated::instance()->recordGleanEventWithExtraKeys(
       GleanSample::addonMessageStateChanged,
       {{"message_id", id()}, {"message_state", newStateSetting}});
 }

--- a/src/apps/vpn/authenticationinapp/authenticationinapp.cpp
+++ b/src/apps/vpn/authenticationinapp/authenticationinapp.cpp
@@ -12,10 +12,10 @@
 #include "authenticationinappsession.h"
 #include "glean/generated/metrics.h"
 #include "glean/metrictypes.h"
+#include "gleandeprecated.h"
 #include "incrementaldecoder.h"
 #include "leakdetector.h"
 #include "logger.h"
-#include "mozillavpn.h"
 #include "telemetry/gleansample.h"
 
 constexpr int PASSWORD_MIN_LENGTH = 8;
@@ -89,7 +89,7 @@ void AuthenticationInApp::setState(State state,
 
   Q_ASSERT(gleanSample);
 
-  emit MozillaVPN::instance()->recordGleanEventWithExtraKeys(
+  emit GleanDeprecated::instance()->recordGleanEventWithExtraKeys(
       gleanSample, {{"state", stateAsString}});
 }
 

--- a/src/apps/vpn/authenticationinapp/authenticationinappsession.cpp
+++ b/src/apps/vpn/authenticationinapp/authenticationinappsession.cpp
@@ -14,10 +14,10 @@
 #include "authenticationlistener.h"
 #include "feature.h"
 #include "glean/generated/metrics.h"
+#include "gleandeprecated.h"
 #include "hkdf.h"
 #include "leakdetector.h"
 #include "logger.h"
-#include "mozillavpn.h"
 #include "networkrequest.h"
 #include "telemetry/gleansample.h"
 
@@ -572,7 +572,7 @@ void AuthenticationInAppSession::deleteAccount() {
           });
 
   mozilla::glean::sample::delete_account_clicked.record();
-  emit MozillaVPN::instance()->recordGleanEvent(
+  emit GleanDeprecated::instance()->recordGleanEvent(
       GleanSample::deleteAccountClicked);
 }
 
@@ -757,7 +757,7 @@ void AuthenticationInAppSession::processErrorObject(const QJsonObject& obj) {
           mozilla::glean::sample::AuthenticationInappErrorExtra{
               ._errno = "107",
               ._validation = QJsonDocument(objValidation).toJson()});
-      emit MozillaVPN::instance()->recordGleanEventWithExtraKeys(
+      emit GleanDeprecated::instance()->recordGleanEventWithExtraKeys(
           GleanSample::authenticationInappError,
           {{"errno", "107"},
            {"validation", QJsonDocument(objValidation).toJson()}});
@@ -790,7 +790,7 @@ void AuthenticationInAppSession::processErrorObject(const QJsonObject& obj) {
       mozilla::glean::sample::authentication_inapp_error.record(
           mozilla::glean::sample::AuthenticationInappErrorExtra{
               ._errno = "125", ._verificationmethod = verificationMethod});
-      emit MozillaVPN::instance()->recordGleanEventWithExtraKeys(
+      emit GleanDeprecated::instance()->recordGleanEventWithExtraKeys(
           GleanSample::authenticationInappError,
           {{"errno", "125"}, {"verificationmethod", verificationMethod}});
 
@@ -964,7 +964,7 @@ void AuthenticationInAppSession::processErrorObject(const QJsonObject& obj) {
               ._errno = QString::number(errorCode),
               ._error = obj["error"].toString(),
               ._message = obj["message"].toString()});
-      emit MozillaVPN::instance()->recordGleanEventWithExtraKeys(
+      emit GleanDeprecated::instance()->recordGleanEventWithExtraKeys(
           GleanSample::authenticationInappError,
           {{"errno", QString::number(errorCode)},
            {"error", obj["error"].toString()},

--- a/src/apps/vpn/cmake/sources.cmake
+++ b/src/apps/vpn/cmake/sources.cmake
@@ -13,6 +13,7 @@ set_property(TARGET mozillavpn-sources PROPERTY INTERFACE_INCLUDE_DIRECTORIES
     ${CMAKE_CURRENT_SOURCE_DIR}/shared/hacl-star
     ${CMAKE_CURRENT_SOURCE_DIR}/shared/hacl-star/kremlin
     ${CMAKE_CURRENT_SOURCE_DIR}/shared/hacl-star/kremlin/minimal
+    ${CMAKE_CURRENT_SOURCE_DIR}/shared/glean
     ${CMAKE_CURRENT_SOURCE_DIR}/apps/vpn
     ${CMAKE_CURRENT_SOURCE_DIR}/apps/vpn/addons
     ${CMAKE_CURRENT_SOURCE_DIR}/apps/vpn/composer

--- a/src/apps/vpn/commands/commandui.cpp
+++ b/src/apps/vpn/commands/commandui.cpp
@@ -25,6 +25,7 @@
 // Relative path is required here,
 // otherwise this gets confused with the Glean.js implementation
 #include "../glean/glean.h"
+#include "gleandeprecated.h"
 #include "imageproviderfactory.h"
 #include "inspector/inspectorhandler.h"
 #include "keyregenerator.h"
@@ -248,7 +249,7 @@ int CommandUI::run(QStringList& tokens) {
               ._state =
                   QVariant::fromValue(Updater::ApplicationRestartedAfterUpdate)
                       .toString()});
-      emit vpn.recordGleanEventWithExtraKeys(
+      emit GleanDeprecated::instance()->recordGleanEventWithExtraKeys(
           GleanSample::updateStep,
           {{"state",
             QVariant::fromValue(Updater::ApplicationRestartedAfterUpdate)
@@ -298,6 +299,14 @@ int CommandUI::run(QStringList& tokens) {
         "Mozilla.VPN", 1, 0, "VPNFeatureList",
         [](QQmlEngine*, QJSEngine*) -> QObject* {
           QObject* obj = FeatureModel::instance();
+          QQmlEngine::setObjectOwnership(obj, QQmlEngine::CppOwnership);
+          return obj;
+        });
+
+    qmlRegisterSingletonType<MozillaVPN>(
+        "Mozilla.VPN", 1, 0, "VPNGleanDeprecated",
+        [](QQmlEngine*, QJSEngine*) -> QObject* {
+          QObject* obj = GleanDeprecated::instance();
           QQmlEngine::setObjectOwnership(obj, QQmlEngine::CppOwnership);
           return obj;
         });

--- a/src/apps/vpn/connectionhealth.cpp
+++ b/src/apps/vpn/connectionhealth.cpp
@@ -9,6 +9,7 @@
 #include <QRandomGenerator>
 
 #include "glean/generated/metrics.h"
+#include "gleandeprecated.h"
 #include "leakdetector.h"
 #include "logger.h"
 #include "models/server.h"
@@ -137,11 +138,11 @@ void ConnectionHealth::setStability(ConnectionStability stability) {
     MozillaVPN::instance()->silentSwitch();
 
     mozilla::glean::sample::connection_health_unstable.record();
-    emit MozillaVPN::instance()->recordGleanEvent(
+    emit GleanDeprecated::instance()->recordGleanEvent(
         GleanSample::connectionHealthUnstable);
   } else if (stability == NoSignal) {
     mozilla::glean::sample::connection_health_no_signal.record();
-    emit MozillaVPN::instance()->recordGleanEvent(
+    emit GleanDeprecated::instance()->recordGleanEvent(
         GleanSample::connectionHealthNoSignal);
   }
 

--- a/src/apps/vpn/errorhandler.cpp
+++ b/src/apps/vpn/errorhandler.cpp
@@ -7,6 +7,7 @@
 #include <QApplication>
 
 #include "glean/generated/metrics.h"
+#include "gleandeprecated.h"
 #include "leakdetector.h"
 #include "logger.h"
 #include "mozillavpn.h"
@@ -232,8 +233,6 @@ void ErrorHandler::errorHandle(ErrorHandler::ErrorType error,
 
   setAlert(alert);
 
-  MozillaVPN* vpn = MozillaVPN::instance();
-
   QVariantMap extraKeys;
   mozilla::glean::sample::ErrorAlertShownExtra extras;
 
@@ -253,16 +252,20 @@ void ErrorHandler::errorHandle(ErrorHandler::ErrorType error,
   }
 
   mozilla::glean::sample::error_alert_shown.record(extras);
-  vpn->recordGleanEventWithExtraKeys(GleanSample::errorAlertShown, extraKeys);
+  GleanDeprecated::instance()->recordGleanEventWithExtraKeys(
+      GleanSample::errorAlertShown, extraKeys);
 
   // Any error in authenticating state sends to the Initial state.
+  MozillaVPN* vpn = MozillaVPN::instance();
   if (vpn->state() == MozillaVPN::StateAuthenticating) {
     if (alert == GeoIpRestrictionAlert) {
       mozilla::glean::sample::authentication_failure_by_geo.record();
-      emit vpn->recordGleanEvent(GleanSample::authenticationFailureByGeo);
+      emit GleanDeprecated::instance()->recordGleanEvent(
+          GleanSample::authenticationFailureByGeo);
     } else {
       mozilla::glean::sample::authentication_failure.record();
-      emit vpn->recordGleanEvent(GleanSample::authenticationFailure);
+      emit GleanDeprecated::instance()->recordGleanEvent(
+          GleanSample::authenticationFailure);
     }
     vpn->reset(true);
     return;

--- a/src/apps/vpn/models/subscriptiondata.cpp
+++ b/src/apps/vpn/models/subscriptiondata.cpp
@@ -13,9 +13,9 @@
 
 #include "appconstants.h"
 #include "glean/generated/metrics.h"
+#include "gleandeprecated.h"
 #include "leakdetector.h"
 #include "logger.h"
-#include "mozillavpn.h"
 #include "settingsholder.h"
 #include "telemetry/gleansample.h"
 
@@ -136,7 +136,7 @@ bool SubscriptionData::fromJsonInternal(const QByteArray& json) {
     mozilla::glean::sample::unhandled_sub_plan_interval.record(
         mozilla::glean::sample::UnhandledSubPlanIntervalExtra{
             ._interval = planInterval});
-    emit MozillaVPN::instance()->recordGleanEventWithExtraKeys(
+    emit GleanDeprecated::instance()->recordGleanEventWithExtraKeys(
         GleanSample::unhandledSubPlanInterval, {{"interval", planInterval}});
     return false;
   }
@@ -167,7 +167,7 @@ bool SubscriptionData::fromJsonInternal(const QByteArray& json) {
       mozilla::glean::sample::unhandled_sub_plan_interval.record(
           mozilla::glean::sample::UnhandledSubPlanIntervalExtra{
               ._interval = planInterval, ._intervalCount = planIntervalCount});
-      emit MozillaVPN::instance()->recordGleanEventWithExtraKeys(
+      emit GleanDeprecated::instance()->recordGleanEventWithExtraKeys(
           GleanSample::unhandledSubPlanInterval,
           {{"interval", planInterval}, {"interval_count", planIntervalCount}});
       return false;

--- a/src/apps/vpn/mozillavpn.cpp
+++ b/src/apps/vpn/mozillavpn.cpp
@@ -13,6 +13,7 @@
 #include "glean/generated/metrics.h"
 #include "glean/generated/pings.h"
 #include "glean/glean.h"
+#include "glean/gleandeprecated.h"
 #include "leakdetector.h"
 #include "logger.h"
 #include "loghandler.h"
@@ -376,7 +377,7 @@ void MozillaVPN::setState(State state) {
 
   mozilla::glean::sample::app_step.record(mozilla::glean::sample::AppStepExtra{
       ._state = QVariant::fromValue(state).toString()});
-  emit MozillaVPN::instance()->recordGleanEventWithExtraKeys(
+  emit GleanDeprecated::instance()->recordGleanEventWithExtraKeys(
       GleanSample::appStep, {{"state", QVariant::fromValue(state).toString()}});
 
   // If we are activating the app, let's initialize the controller and the
@@ -423,7 +424,8 @@ void MozillaVPN::maybeStateMain() {
     Q_ASSERT(m_private->m_deviceModel.activeDevices() ==
              m_private->m_user.maxDevices());
     mozilla::glean::sample::max_device_reached.record();
-    emit recordGleanEvent(GleanSample::maxDeviceReached);
+    emit GleanDeprecated::instance()->recordGleanEvent(
+        GleanSample::maxDeviceReached);
     setState(StateDeviceLimit);
     return;
   }
@@ -491,7 +493,8 @@ void MozillaVPN::authenticateWithType(
   }
 
   mozilla::glean::sample::authentication_started.record();
-  emit recordGleanEvent(GleanSample::authenticationStarted);
+  emit GleanDeprecated::instance()->recordGleanEvent(
+      GleanSample::authenticationStarted);
 
   TaskScheduler::scheduleTask(new TaskHeartbeat());
   TaskScheduler::scheduleTask(new TaskAuthenticate(authenticationType));
@@ -503,7 +506,8 @@ void MozillaVPN::abortAuthentication() {
   setState(StateInitialize);
 
   mozilla::glean::sample::authentication_aborted.record();
-  emit recordGleanEvent(GleanSample::authenticationAborted);
+  emit GleanDeprecated::instance()->recordGleanEvent(
+      GleanSample::authenticationAborted);
 }
 
 void MozillaVPN::setToken(const QString& token) {
@@ -515,7 +519,8 @@ void MozillaVPN::authenticationCompleted(const QByteArray& json,
   logger.debug() << "Authentication completed";
 
   mozilla::glean::sample::authentication_completed.record();
-  emit recordGleanEvent(GleanSample::authenticationCompleted);
+  emit GleanDeprecated::instance()->recordGleanEvent(
+      GleanSample::authenticationCompleted);
 
   if (!m_private->m_user.fromJson(json)) {
     logger.error() << "Failed to parse the User JSON data";
@@ -643,7 +648,7 @@ void MozillaVPN::deviceRemoved(const QString& publicKey,
 
   mozilla::glean::sample::device_removed.record(
       mozilla::glean::sample::DeviceRemovedExtra{._source = source});
-  emit MozillaVPN::instance()->recordGleanEventWithExtraKeys(
+  emit GleanDeprecated::instance()->recordGleanEventWithExtraKeys(
       GleanSample::deviceRemoved, {{"source", source}});
   m_private->m_deviceModel.removeDeviceFromPublicKey(publicKey);
 
@@ -819,7 +824,8 @@ void MozillaVPN::cancelAuthentication() {
   }
 
   mozilla::glean::sample::authentication_aborted.record();
-  emit recordGleanEvent(GleanSample::authenticationAborted);
+  emit GleanDeprecated::instance()->recordGleanEvent(
+      GleanSample::authenticationAborted);
 
   reset(true);
 }
@@ -1293,8 +1299,8 @@ void MozillaVPN::subscriptionStarted(const QString& productIdentifier) {
   mozilla::glean::sample::iap_subscription_started.record(
       mozilla::glean::sample::IapSubscriptionStartedExtra{
           ._sku = productIdentifier});
-  emit recordGleanEventWithExtraKeys(GleanSample::iapSubscriptionStarted,
-                                     {{"sku", productIdentifier}});
+  emit GleanDeprecated::instance()->recordGleanEventWithExtraKeys(
+      GleanSample::iapSubscriptionStarted, {{"sku", productIdentifier}});
 }
 
 void MozillaVPN::restoreSubscriptionStarted() {
@@ -1303,7 +1309,8 @@ void MozillaVPN::restoreSubscriptionStarted() {
   PurchaseHandler::instance()->startRestoreSubscription();
 
   mozilla::glean::sample::iap_restore_sub_started.record();
-  emit recordGleanEvent(GleanSample::iapRestoreSubStarted);
+  emit GleanDeprecated::instance()->recordGleanEvent(
+      GleanSample::iapRestoreSubStarted);
 }
 
 void MozillaVPN::subscriptionCompleted() {
@@ -1328,7 +1335,7 @@ void MozillaVPN::subscriptionCompleted() {
   mozilla::glean::sample::iap_subscription_completed.record(
       mozilla::glean::sample::IapSubscriptionCompletedExtra{
           ._sku = PurchaseHandler::instance()->currentSKU()});
-  emit recordGleanEventWithExtraKeys(
+  emit GleanDeprecated::instance()->recordGleanEventWithExtraKeys(
       GleanSample::iapSubscriptionCompleted,
       {{"sku", PurchaseHandler::instance()->currentSKU()}});
 
@@ -1350,7 +1357,7 @@ void MozillaVPN::subscriptionNotValidated() {
       mozilla::glean::sample::IapSubscriptionFailedExtra{
           ._error = "not-validated",
           ._sku = PurchaseHandler::instance()->currentSKU()});
-  emit recordGleanEventWithExtraKeys(
+  emit GleanDeprecated::instance()->recordGleanEventWithExtraKeys(
       GleanSample::iapSubscriptionFailed,
       {{"error", "not-validated"},
        {"sku", PurchaseHandler::instance()->currentSKU()}});
@@ -1363,7 +1370,7 @@ void MozillaVPN::subscriptionFailed() {
       mozilla::glean::sample::IapSubscriptionFailedExtra{
           ._error = "failed",
           ._sku = PurchaseHandler::instance()->currentSKU()});
-  emit recordGleanEventWithExtraKeys(
+  emit GleanDeprecated::instance()->recordGleanEventWithExtraKeys(
       GleanSample::iapSubscriptionFailed,
       {{"error", "failed"},
        {"sku", PurchaseHandler::instance()->currentSKU()}});
@@ -1376,7 +1383,7 @@ void MozillaVPN::subscriptionCanceled() {
       mozilla::glean::sample::IapSubscriptionFailedExtra{
           ._error = "canceled",
           ._sku = PurchaseHandler::instance()->currentSKU()});
-  emit recordGleanEventWithExtraKeys(
+  emit GleanDeprecated::instance()->recordGleanEventWithExtraKeys(
       GleanSample::iapSubscriptionFailed,
       {{"error", "canceled"},
        {"sku", PurchaseHandler::instance()->currentSKU()}});
@@ -1429,8 +1436,8 @@ void MozillaVPN::alreadySubscribed() {
       mozilla::glean::sample::IapSubscriptionFailedExtra{
           ._error = "alrady-subscribed",
       });
-  emit recordGleanEventWithExtraKeys(GleanSample::iapSubscriptionFailed,
-                                     {{"error", "alrady-subscribed"}});
+  emit GleanDeprecated::instance()->recordGleanEventWithExtraKeys(
+      GleanSample::iapSubscriptionFailed, {{"error", "alrady-subscribed"}});
 }
 
 void MozillaVPN::update() {

--- a/src/apps/vpn/mozillavpn.h
+++ b/src/apps/vpn/mozillavpn.h
@@ -10,7 +10,6 @@
 #include <QObject>
 #include <QStandardPaths>
 #include <QTimer>
-#include <QVariant>
 
 #include "captiveportal/captiveportal.h"
 #include "captiveportal/captiveportaldetection.h"
@@ -316,9 +315,6 @@ class MozillaVPN final : public QObject {
   // For Glean
   void initializeGlean();
   void sendGleanPings();
-  void recordGleanEvent(const QString& gleanSampleName);
-  void recordGleanEventWithExtraKeys(const QString& gleanSampleName,
-                                     const QVariantMap& extraKeys);
   void setGleanSourceTags(const QStringList& tags);
 
   void aboutToQuit();

--- a/src/apps/vpn/profileflow.cpp
+++ b/src/apps/vpn/profileflow.cpp
@@ -8,6 +8,7 @@
 #include <QJsonObject>
 
 #include "glean/generated/metrics.h"
+#include "gleandeprecated.h"
 #include "leakdetector.h"
 #include "logger.h"
 #include "models/subscriptiondata.h"
@@ -38,7 +39,7 @@ void ProfileFlow::setState(State state) {
       mozilla::glean::sample::ProfileFlowStateChangedExtra{
           ._state = QVariant::fromValue(state).toString(),
       });
-  emit MozillaVPN::instance()->recordGleanEventWithExtraKeys(
+  emit GleanDeprecated::instance()->recordGleanEventWithExtraKeys(
       GleanSample::profileFlowStateChanged,
       {{"state", QVariant::fromValue(state).toString()}});
 }

--- a/src/apps/vpn/qmake/includes_and_defines.pri
+++ b/src/apps/vpn/qmake/includes_and_defines.pri
@@ -17,6 +17,7 @@ INCLUDEPATH += \
             $$PWD/../addons \
             $$PWD/../composer \
             $$PWD/../../../shared \
+            $$PWD/../../../shared/glean \
             $$PWD/../../../shared/hacl-star \
             $$PWD/../../../shared/hacl-star/kremlin \
             $$PWD/../../../shared/hacl-star/kremlin/minimal \

--- a/src/apps/vpn/telemetry.cpp
+++ b/src/apps/vpn/telemetry.cpp
@@ -6,6 +6,7 @@
 
 #include "appconstants.h"
 #include "glean/generated/metrics.h"
+#include "gleandeprecated.h"
 #include "leakdetector.h"
 #include "logger.h"
 #include "mozillavpn.h"
@@ -51,7 +52,7 @@ void Telemetry::initialize() {
                     ._transport = MozillaVPN::instance()
                                       ->networkWatcher()
                                       ->getCurrentTransport()});
-            emit MozillaVPN::instance()->recordGleanEventWithExtraKeys(
+            emit GleanDeprecated::instance()->recordGleanEventWithExtraKeys(
                 GleanSample::connectivityHandshakeTimeout,
                 {{"server", publicKey},
                  {"transport", MozillaVPN::instance()
@@ -75,17 +76,19 @@ void Telemetry::initialize() {
     mozilla::glean::sample::controller_step.record(
         mozilla::glean::sample::ControllerStepExtra{
             ._state = QVariant::fromValue(state).toString()});
-    emit vpn->recordGleanEventWithExtraKeys(
+    emit GleanDeprecated::instance()->recordGleanEventWithExtraKeys(
         GleanSample::controllerStep,
         {{"state", QVariant::fromValue(state).toString()}});
     // Specific events for on and off state to aid with analysis
     if (state == Controller::StateOn) {
       mozilla::glean::sample::controller_state_on.record();
-      emit vpn->recordGleanEvent(GleanSample::controllerStateOn);
+      emit GleanDeprecated::instance()->recordGleanEvent(
+          GleanSample::controllerStateOn);
     }
     if (state == Controller::StateOff) {
       mozilla::glean::sample::controller_state_off.record();
-      emit vpn->recordGleanEvent(GleanSample::controllerStateOff);
+      emit GleanDeprecated::instance()->recordGleanEvent(
+          GleanSample::controllerStateOff);
     }
   });
 
@@ -94,7 +97,8 @@ void Telemetry::initialize() {
     Q_ASSERT(vpn);
 
     mozilla::glean::sample::server_unavailable_error.record();
-    emit vpn->recordGleanEvent(GleanSample::serverUnavailableError);
+    emit GleanDeprecated::instance()->recordGleanEvent(
+        GleanSample::serverUnavailableError);
   });
 }
 
@@ -114,7 +118,7 @@ void Telemetry::connectionStabilityEvent() {
           ._server = vpn->currentServer()->exitServerPublicKey(),
           ._stddev = QString::number(vpn->connectionHealth()->stddev()),
           ._transport = vpn->networkWatcher()->getCurrentTransport()});
-  emit vpn->recordGleanEventWithExtraKeys(
+  emit GleanDeprecated::instance()->recordGleanEventWithExtraKeys(
       GleanSample::connectivityStable,
       {{"server", vpn->currentServer()->exitServerPublicKey()},
        {"latency", QString::number(vpn->connectionHealth()->latency())},
@@ -134,12 +138,12 @@ void Telemetry::periodicStateRecorder() {
 
   if (controllerState == Controller::StateOn) {
     mozilla::glean::sample::controller_state_on.record();
-    emit MozillaVPN::instance()->recordGleanEvent(
+    emit GleanDeprecated::instance()->recordGleanEvent(
         GleanSample::controllerStateOn);
   }
   if (controllerState == Controller::StateOff) {
     mozilla::glean::sample::controller_state_off.record();
-    emit MozillaVPN::instance()->recordGleanEvent(
+    emit GleanDeprecated::instance()->recordGleanEvent(
         GleanSample::controllerStateOff);
   }
 }

--- a/src/apps/vpn/tutorial/tutorial.cpp
+++ b/src/apps/vpn/tutorial/tutorial.cpp
@@ -10,6 +10,7 @@
 #include "addons/addontutorial.h"
 #include "frontend/navigator.h"
 #include "glean/generated/metrics.h"
+#include "gleandeprecated.h"
 #include "leakdetector.h"
 #include "logger.h"
 #include "mozillavpn.h"
@@ -79,7 +80,7 @@ void Tutorial::play(Addon* tutorial) {
   mozilla::glean::sample::tutorial_started.record(
       mozilla::glean::sample::TutorialStartedExtra{
           ._id = m_currentTutorial->id()});
-  emit MozillaVPN::instance()->recordGleanEventWithExtraKeys(
+  emit GleanDeprecated::instance()->recordGleanEventWithExtraKeys(
       GleanSample::tutorialStarted, {{"id", m_currentTutorial->id()}});
 
   m_currentTutorial->play(m_allowedItems);
@@ -108,7 +109,7 @@ void Tutorial::requireTooltipNeeded(AddonTutorial* tutorial,
   mozilla::glean::sample::tutorial_step_viewed.record(
       mozilla::glean::sample::TutorialStepViewedExtra{
           ._stepId = stepId, ._tutorialId = m_currentTutorial->id()});
-  emit MozillaVPN::instance()->recordGleanEventWithExtraKeys(
+  emit GleanDeprecated::instance()->recordGleanEventWithExtraKeys(
       GleanSample::tutorialStepViewed,
       {{"tutorial_id", m_currentTutorial->id()}, {"step_id", stepId}});
 }
@@ -120,7 +121,7 @@ void Tutorial::requireTutorialCompleted(AddonTutorial* tutorial) {
 
   mozilla::glean::sample::tutorial_completed.record(
       mozilla::glean::sample::TutorialCompletedExtra{._id = tutorial->id()});
-  emit MozillaVPN::instance()->recordGleanEventWithExtraKeys(
+  emit GleanDeprecated::instance()->recordGleanEventWithExtraKeys(
       GleanSample::tutorialCompleted, {{"id", tutorial->id()}});
 }
 

--- a/src/apps/vpn/ui/main.qml
+++ b/src/apps/vpn/ui/main.qml
@@ -195,6 +195,19 @@ Window {
             Pings.main.submit();
         }
 
+        function onAboutToQuit() {
+            console.debug("about to quit, shutdown Glean");
+            // Submit the main ping in case there are outstading metrics in storage before shutdown.
+            Pings.main.submit();
+            // Use glean's built-in shutdown method - https://mozilla.github.io/glean/book/reference/general/shutdown.html
+            Glean.shutdown();
+        }
+    }
+
+    Connections {
+        target: VPNGleanDeprecated
+        enabled: Qt.platform.os !== "android"
+
         function onRecordGleanEvent(sample) {
             console.debug("recording Glean event");
             Sample[sample].record();
@@ -203,14 +216,6 @@ Window {
         function onRecordGleanEventWithExtraKeys(sample, extraKeys) {
             console.debug("recording Glean event with extra keys");
             Sample[sample].record(extraKeys);
-        }
-
-        function onAboutToQuit() {
-            console.debug("about to quit, shutdown Glean");
-            // Submit the main ping in case there are outstading metrics in storage before shutdown.
-            Pings.main.submit();
-            // Use glean's built-in shutdown method - https://mozilla.github.io/glean/book/reference/general/shutdown.html
-            Glean.shutdown();
         }
     }
 

--- a/src/apps/vpn/ui/screens/ScreenBackendFailure.qml
+++ b/src/apps/vpn/ui/screens/ScreenBackendFailure.qml
@@ -37,7 +37,7 @@ VPNStackView {
             }
         );
 
-        VPN.recordGleanEvent("backendFailureViewed");
+        VPNGleanDeprecated.recordGleanEvent("backendFailureViewed");
         Glean.sample.backendFailureViewed.record();
     }
 }

--- a/src/apps/vpn/ui/screens/ScreenBillingNotAvailable.qml
+++ b/src/apps/vpn/ui/screens/ScreenBillingNotAvailable.qml
@@ -33,7 +33,7 @@ VPNStackView {
             getHelpLinkVisible: true
             }
         );
-        VPN.recordGleanEvent("billingNotAvailableViewed");
+        VPNGleanDeprecated.recordGleanEvent("billingNotAvailableViewed");
         Glean.sample.billingNotAvailableViewed.record();
     }
 }

--- a/src/apps/vpn/ui/screens/ScreenSubscriptionBlocked.qml
+++ b/src/apps/vpn/ui/screens/ScreenSubscriptionBlocked.qml
@@ -36,7 +36,7 @@ VPNStackView {
             getHelpLinkVisible: false
             }
         );
-        VPN.recordGleanEvent("subscriptionBlockedViewed");
+        VPNGleanDeprecated.recordGleanEvent("subscriptionBlockedViewed");
         Glean.sample.subscriptionBlockedViewed.record();
     }
 }

--- a/src/apps/vpn/ui/screens/ScreenSubscriptionNotValidated.qml
+++ b/src/apps/vpn/ui/screens/ScreenSubscriptionNotValidated.qml
@@ -33,7 +33,7 @@ VPNStackView {
             getHelpLinkVisible: true,
             }
         );
-        VPN.recordGleanEvent("subNotValidatedViewed");
+        VPNGleanDeprecated.recordGleanEvent("subNotValidatedViewed");
         Glean.record.subNotValidatedViewed.record();
     }
 }

--- a/src/apps/vpn/ui/screens/home/ViewHome.qml
+++ b/src/apps/vpn/ui/screens/home/ViewHome.qml
@@ -171,7 +171,7 @@ VPNFlickable {
 
             onClosed: {
                 tipsAndTricksIntroPopupLoader.active = false
-                VPN.recordGleanEventWithExtraKeys("tipsAndTricksModalClosed", {"action": closedByPrimaryButton ? "cta" : "dismissed"});
+                VPNGleanDeprecated.recordGleanEventWithExtraKeys("tipsAndTricksModalClosed", {"action": closedByPrimaryButton ? "cta" : "dismissed"});
                 Glean.sample.tipsAndTricksModalClosed.record({
                     action: closedByPrimaryButton ? "cta" : "dismissed"
                 });

--- a/src/apps/vpn/ui/screens/initialize/ViewInitialize.qml
+++ b/src/apps/vpn/ui/screens/initialize/ViewInitialize.qml
@@ -17,7 +17,7 @@ Item {
 
         labelText: qsTrId("vpn.main.getHelp2")
         onClicked: {
-            VPN.recordGleanEvent("getHelpClickedInitialize");
+            VPNGleanDeprecated.recordGleanEvent("getHelpClickedInitialize")
             Glean.sample.getHelpClickedInitialize.record();
             VPNNavigator.requestScreen(VPNNavigator.ScreenGetHelp);
         }
@@ -54,7 +54,7 @@ Item {
         //% "Learn more"
         labelText: qsTrId("vpn.main.learnMore")
         onClicked: {
-            VPN.recordGleanEvent("onboardingOpened");
+            VPNGleanDeprecated.recordGleanEvent("onboardingOpened");
             Glean.sample.onboardingOpened.record();
             stackview.push("ViewOnboarding.qml");
         }

--- a/src/apps/vpn/ui/screens/initialize/ViewMobileOnboarding.qml
+++ b/src/apps/vpn/ui/screens/initialize/ViewMobileOnboarding.qml
@@ -369,7 +369,7 @@ Item {
         }
 
         function recordGleanEvtAndStartAuth(ctaObjectName) {
-            VPN.recordGleanEventWithExtraKeys("onboardingCtaClick",{
+            VPNGleanDeprecated.recordGleanEventWithExtraKeys("onboardingCtaClick",{
                                               "panel_id": currentPanelValues._panelId,
                                               "panel_idx": swipeView.currentIndex.toString(),
                                               "panel_cta": ctaObjectName

--- a/src/apps/vpn/ui/screens/settings/ViewGuide.qml
+++ b/src/apps/vpn/ui/screens/settings/ViewGuide.qml
@@ -177,7 +177,7 @@ Item {
     Component.onCompleted: VPNNavigator.addView(VPNNavigator.ScreenSettings, root)
 
     Component.onDestruction: {
-        VPN.recordGleanEventWithExtraKeys("guideClosed",{
+        VPNGleanDeprecated.recordGleanEventWithExtraKeys("guideClosed",{
                                           "id": guide.id,
                                           "duration_ms": new Date().getTime() - timeOfOpen
         });

--- a/src/apps/vpn/ui/screens/settings/ViewNetworkSettings.qml
+++ b/src/apps/vpn/ui/screens/settings/ViewNetworkSettings.qml
@@ -77,10 +77,10 @@ VPNViewBase {
     }
 
     Component.onCompleted: {
-        VPN.recordGleanEvent("networkSettingsViewOpened");
+        VPNGleanDeprecated.recordGleanEvent("networkSettingsViewOpened");
         Glean.sample.networkSettingsViewOpened.record();
         if (!vpnIsOff) {
-            VPN.recordGleanEvent("networkSettingsViewWarning");
+            VPNGleanDeprecated.recordGleanEvent("networkSettingsViewWarning");
             Glean.sample.networkSettingsViewWarning.record();
         }
     }

--- a/src/apps/vpn/ui/screens/settings/ViewNotifications.qml
+++ b/src/apps/vpn/ui/screens/settings/ViewNotifications.qml
@@ -132,10 +132,10 @@ VPNViewBase {
         }
     }
     Component.onCompleted: {
-        VPN.recordGleanEvent("notificationsViewOpened");
+        VPNGleanDeprecated.recordGleanEvent("notificationsViewOpened");
         Glean.sample.notificationsViewOpened.record();
         if (!vpnIsOff) {
-            VPN.recordGleanEvent("notificationsViewWarning");
+            VPNGleanDeprecated.recordGleanEvent("notificationsViewWarning");
             Glean.sample.notificationsViewWarning.record();
         }
     }

--- a/src/apps/vpn/ui/screens/settings/ViewSettingsMenu.qml
+++ b/src/apps/vpn/ui/screens/settings/ViewSettingsMenu.qml
@@ -35,7 +35,7 @@ VPNViewBase {
                     if (subscriptionManagementEnabled) {
                         VPNProfileFlow.start();
                     } else {
-                        VPN.recordGleanEvent("manageAccountClicked");
+                        VPNGleanDeprecated.recordGleanEvent("manageAccountClicked")
                         Glean.sample.manageAccountClicked.record();
                         VPNUrlOpener.openUrlLabel("account");
                     }
@@ -122,7 +122,7 @@ VPNViewBase {
                 imageRightSrc: "qrc:/nebula/resources/chevron.svg"
                 imageRightMirror: VPNLocalizer.isRightToLeft
                 onClicked: {
-                    VPN.recordGleanEvent("getHelpClickedViewSettings");
+                    VPNGleanDeprecated.recordGleanEvent("getHelpClickedViewSettings");
                     Glean.sample.getHelpClickedViewSettings.record();
                     VPNNavigator.requestScreen(VPNNavigator.ScreenGetHelp);
                 }
@@ -188,7 +188,7 @@ VPNViewBase {
         }
     }
     Component.onCompleted: {
-        VPN.recordGleanEvent("settingsViewOpened");
+        VPNGleanDeprecated.recordGleanEvent("settingsViewOpened");
         Glean.sample.settingsViewOpened.record();
     }
 }

--- a/src/apps/vpn/ui/screens/settings/ViewSubscriptionManagement/SubscriptionManagementItem.qml
+++ b/src/apps/vpn/ui/screens/settings/ViewSubscriptionManagement/SubscriptionManagementItem.qml
@@ -195,7 +195,7 @@ ColumnLayout {
 
         Component.onCompleted: {
             if (visible) {
-                VPN.recordGleanEvent("bundle_upsell_viewed");
+                VPNGleanDeprecated.recordGleanEvent("bundle_upsell_viewed");
                 Glean.sample.bundleUpsellViewed.record();
             }
         }
@@ -225,7 +225,7 @@ ColumnLayout {
                 Layout.leftMargin: -4
 
                 onClicked: {
-                    VPN.recordGleanEvent("bundle_upsell_link_clicked");
+                    VPNGleanDeprecated.recordGleanEvent("bundle_upsell_link_clicked");
                     Glean.sample.bundleUpsellLinkClicked.record();
                     VPNUrlOpener.openUrlLabel("relayPremium");
                 }
@@ -236,7 +236,7 @@ ColumnLayout {
             objectName: _objectName + "-relayUpsell-upgradeButton"
 
             onClicked: {
-                VPN.recordGleanEvent("bundle_upsell_upgrade_clicked");
+                VPNGleanDeprecated.recordGleanEvent("bundle_upsell_upgrade_clicked");
                 Glean.sample.bundleUpsellUpgradeClicked.record();
                 VPNUrlOpener.openUrlLabel("upgradeToBundle");
             }

--- a/src/apps/vpn/ui/screens/settings/ViewSubscriptionManagement/ViewSubscriptionManagement.qml
+++ b/src/apps/vpn/ui/screens/settings/ViewSubscriptionManagement/ViewSubscriptionManagement.qml
@@ -37,7 +37,7 @@ VPNViewBase {
 
             _iconSource: "qrc:/nebula/resources/open-in-new.svg"
             _buttonOnClicked: () => {
-                VPN.recordGleanEvent("manageAccountClicked");
+                VPNGleanDeprecated.recordGleanEvent("manageAccountClicked");
                 Glean.sample.manageAccountClicked.record();
                 VPNUrlOpener.openUrlLabel("account");
             }
@@ -112,8 +112,7 @@ VPNViewBase {
                 visible: VPNFeatureList.get("accountDeletion").isSupported
 
                 onClicked: {
-                    VPN.recordGleanEvent("deleteAccountRequested");
-                    Glean.sample.deleteAccountRequested.record();
+                    VPNGleanDeprecated.recordGleanEvent("deleteAccountRequested");
                     VPNNavigator.requestScreen(VPNNavigator.ScreenDeleteAccount)
                 }
 
@@ -138,7 +137,7 @@ VPNViewBase {
                 VPNUrlOpener.openUrlLabel("account");
         }
 
-        VPN.recordGleanEvent("manageSubscriptionClicked");
+        VPNGleanDeprecated.recordGleanEvent("manageSubscriptionClicked");
         Glean.sample.manageSubscriptionClicked.record();
     }
 

--- a/src/apps/vpn/ui/screens/settings/appPermissions/ViewAppPermissions.qml
+++ b/src/apps/vpn/ui/screens/settings/appPermissions/ViewAppPermissions.qml
@@ -148,11 +148,11 @@ VPNViewBase {
     Component.onCompleted: {
         console.log("Component ready");
         VPNAppPermissions.requestApplist();
-        VPN.recordGleanEvent("appPermissionsViewOpened");
+        VPNGleanDeprecated.recordGleanEvent("appPermissionsViewOpened");
         Glean.sample.appPermissionsViewOpened.record();
 
         if (!vpnIsOff) {
-            VPN.recordGleanEvent("appPermissionsViewWarning");
+            VPNGleanDeprecated.recordGleanEvent("appPermissionsViewWarning");
             Glean.sample.appPermissionsViewWarning.record();
         }
     }

--- a/src/apps/vpn/update/balrog.cpp
+++ b/src/apps/vpn/update/balrog.cpp
@@ -15,9 +15,9 @@
 #include "appconstants.h"
 #include "errorhandler.h"
 #include "glean/generated/metrics.h"
+#include "gleandeprecated.h"
 #include "leakdetector.h"
 #include "logger.h"
-#include "mozillavpn.h"
 #include "networkrequest.h"
 #include "telemetry/gleansample.h"
 
@@ -86,7 +86,7 @@ void Balrog::start(Task* task) {
     mozilla::glean::sample::update_step.record(
         mozilla::glean::sample::UpdateStepExtra{
             ._state = QVariant::fromValue(UpdateProcessStarted).toString()});
-    emit MozillaVPN::instance()->recordGleanEventWithExtraKeys(
+    emit GleanDeprecated::instance()->recordGleanEventWithExtraKeys(
         GleanSample::updateStep,
         {{"state", QVariant::fromValue(UpdateProcessStarted).toString()}});
   }
@@ -383,7 +383,7 @@ bool Balrog::computeHash(const QString& url, const QByteArray& data,
   mozilla::glean::sample::update_step.record(
       mozilla::glean::sample::UpdateStepExtra{
           ._state = QVariant::fromValue(BalrogValidationCompleted).toString()});
-  emit MozillaVPN::instance()->recordGleanEventWithExtraKeys(
+  emit GleanDeprecated::instance()->recordGleanEventWithExtraKeys(
       GleanSample::updateStep,
       {{"state", QVariant::fromValue(BalrogValidationCompleted).toString()}});
 
@@ -428,7 +428,7 @@ bool Balrog::saveFileAndInstall(const QString& url, const QByteArray& data) {
   mozilla::glean::sample::update_step.record(
       mozilla::glean::sample::UpdateStepExtra{
           ._state = QVariant::fromValue(BalrogFileSaved).toString()});
-  emit MozillaVPN::instance()->recordGleanEventWithExtraKeys(
+  emit GleanDeprecated::instance()->recordGleanEventWithExtraKeys(
       GleanSample::updateStep,
       {{"state", QVariant::fromValue(BalrogFileSaved).toString()}});
 
@@ -509,7 +509,7 @@ bool Balrog::install(const QString& filePath) {
       mozilla::glean::sample::UpdateStepExtra{
           ._state =
               QVariant::fromValue(InstallationProcessExecuted).toString()});
-  emit MozillaVPN::instance()->recordGleanEventWithExtraKeys(
+  emit GleanDeprecated::instance()->recordGleanEventWithExtraKeys(
       GleanSample::updateStep,
       {{"state", QVariant::fromValue(InstallationProcessExecuted).toString()}});
 

--- a/src/apps/vpn/update/updater.cpp
+++ b/src/apps/vpn/update/updater.cpp
@@ -6,10 +6,10 @@
 
 #include "constants.h"
 #include "glean/generated/metrics.h"
+#include "gleandeprecated.h"
 #include "inspector/inspectorhandler.h"
 #include "leakdetector.h"
 #include "logger.h"
-#include "mozillavpn.h"
 #include "telemetry/gleansample.h"
 #include "versionapi.h"
 #include "webupdater.h"
@@ -48,7 +48,7 @@ Updater::Updater(QObject* parent) : QObject(parent) {
         mozilla::glean::sample::UpdateStepExtra{
             ._state =
                 QVariant::fromValue(RecommendedUpdateAvailable).toString()});
-    emit MozillaVPN::instance()->recordGleanEventWithExtraKeys(
+    emit GleanDeprecated::instance()->recordGleanEventWithExtraKeys(
         GleanSample::updateStep,
         {{"state",
           QVariant::fromValue(RecommendedUpdateAvailable).toString()}});
@@ -60,7 +60,7 @@ Updater::Updater(QObject* parent) : QObject(parent) {
     mozilla::glean::sample::update_step.record(
         mozilla::glean::sample::UpdateStepExtra{
             ._state = QVariant::fromValue(RequiredUpdateAvailable).toString()});
-    emit MozillaVPN::instance()->recordGleanEventWithExtraKeys(
+    emit GleanDeprecated::instance()->recordGleanEventWithExtraKeys(
         GleanSample::updateStep,
         {{"state", QVariant::fromValue(RequiredUpdateAvailable).toString()}});
   });
@@ -85,7 +85,7 @@ void Updater::updateViewShown() {
   mozilla::glean::sample::update_step.record(
       mozilla::glean::sample::UpdateStepExtra{
           ._state = QVariant::fromValue(UpdateViewShown).toString()});
-  emit MozillaVPN::instance()->recordGleanEventWithExtraKeys(
+  emit GleanDeprecated::instance()->recordGleanEventWithExtraKeys(
       GleanSample::updateStep,
       {{"state", QVariant::fromValue(UpdateViewShown).toString()}});
 }

--- a/src/apps/vpn/update/webupdater.cpp
+++ b/src/apps/vpn/update/webupdater.cpp
@@ -5,9 +5,9 @@
 #include "webupdater.h"
 
 #include "glean/generated/metrics.h"
+#include "gleandeprecated.h"
 #include "leakdetector.h"
 #include "logger.h"
-#include "mozillavpn.h"
 #include "task.h"
 #include "telemetry/gleansample.h"
 #include "urlopener.h"
@@ -30,7 +30,7 @@ void WebUpdater::start(Task*) {
   mozilla::glean::sample::update_step.record(
       mozilla::glean::sample::UpdateStepExtra{
           ._state = QVariant::fromValue(FallbackInBrowser).toString()});
-  emit MozillaVPN::instance()->recordGleanEventWithExtraKeys(
+  emit GleanDeprecated::instance()->recordGleanEventWithExtraKeys(
       GleanSample::updateStep,
       {{"state", QVariant::fromValue(FallbackInBrowser).toString()}});
 

--- a/src/apps/vpn/websocket/websockethandler.cpp
+++ b/src/apps/vpn/websocket/websockethandler.cpp
@@ -7,6 +7,7 @@
 #include "appconstants.h"
 #include "exponentialbackoffstrategy.h"
 #include "glean/generated/metrics.h"
+#include "gleandeprecated.h"
 #include "leakdetector.h"
 #include "logger.h"
 #include "mozillavpn.h"
@@ -118,7 +119,7 @@ void WebSocketHandler::onUserStateChanged() {
  */
 void WebSocketHandler::open() {
   mozilla::glean::sample::websocket_connection_attempted.record();
-  emit MozillaVPN::instance()->recordGleanEvent(
+  emit GleanDeprecated::instance()->recordGleanEvent(
       GleanSample::websocketConnectionAttempted);
 
   if (m_webSocket.state() != QAbstractSocket::UnconnectedState &&
@@ -147,7 +148,7 @@ void WebSocketHandler::onConnected() {
   m_aboutToClose = false;
 
   mozilla::glean::sample::websocket_connected.record();
-  emit MozillaVPN::instance()->recordGleanEvent(
+  emit GleanDeprecated::instance()->recordGleanEvent(
       GleanSample::websocketConnected);
 
   m_backoffStrategy.reset();
@@ -168,7 +169,7 @@ void WebSocketHandler::onConnected() {
  */
 void WebSocketHandler::close() {
   mozilla::glean::sample::websocket_close_attempted.record();
-  emit MozillaVPN::instance()->recordGleanEvent(
+  emit GleanDeprecated::instance()->recordGleanEvent(
       GleanSample::websocketCloseAttempted);
 
   // QAbstractSocket may throw a write error when attempting to close the
@@ -203,7 +204,7 @@ void WebSocketHandler::onClose() {
   mozilla::glean::sample::websocket_closed.record(
       mozilla::glean::sample::WebsocketClosedExtra{
           ._reason = m_webSocket.closeCode()});
-  emit MozillaVPN::instance()->recordGleanEventWithExtraKeys(
+  emit GleanDeprecated::instance()->recordGleanEventWithExtraKeys(
       GleanSample::websocketClosed, {{"reason", m_webSocket.closeCode()}});
 
   m_pingTimer.stop();
@@ -262,7 +263,7 @@ void WebSocketHandler::onPingTimeout() {
   logger.debug() << "Timed out waiting for ping response";
 
   mozilla::glean::sample::websocket_pong_timed_out.record();
-  emit MozillaVPN::instance()->recordGleanEvent(
+  emit GleanDeprecated::instance()->recordGleanEvent(
       GleanSample::websocketPongTimedOut);
 
   close();
@@ -280,7 +281,7 @@ void WebSocketHandler::onError(QAbstractSocket::SocketError error) {
   mozilla::glean::sample::websocket_errored.record(
       mozilla::glean::sample::WebsocketErroredExtra{
           ._type = QVariant::fromValue(error).toInt()});
-  emit MozillaVPN::instance()->recordGleanEventWithExtraKeys(
+  emit GleanDeprecated::instance()->recordGleanEventWithExtraKeys(
       GleanSample::websocketErrored,
       {{"type", QVariant::fromValue(error).toInt()}});
 
@@ -300,7 +301,7 @@ void WebSocketHandler::onMessageReceived(const QString& message) {
   mozilla::glean::sample::push_message_received.record(
       mozilla::glean::sample::PushMessageReceivedExtra{
           ._type = QVariant::fromValue(parsedMessage.type()).toString()});
-  emit MozillaVPN::instance()->recordGleanEventWithExtraKeys(
+  emit GleanDeprecated::instance()->recordGleanEventWithExtraKeys(
       GleanSample::pushMessageReceived,
       {{"type", QVariant::fromValue(parsedMessage.type()).toString()}});
 

--- a/src/shared/glean/gleandeprecated.cpp
+++ b/src/shared/glean/gleandeprecated.cpp
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "gleandeprecated.h"
+
+#include <QCoreApplication>
+
+#include "leakdetector.h"
+
+GleanDeprecated::GleanDeprecated(QObject* parent) : QObject(parent) {
+  MZ_COUNT_CTOR(GleanDeprecated);
+}
+
+GleanDeprecated::~GleanDeprecated() { MZ_COUNT_DTOR(GleanDeprecated); }
+
+// static
+GleanDeprecated* GleanDeprecated::instance() {
+  static GleanDeprecated* instance = nullptr;
+  if (!instance) {
+    instance = new GleanDeprecated(qApp);
+  }
+  return instance;
+}

--- a/src/shared/glean/gleandeprecated.h
+++ b/src/shared/glean/gleandeprecated.h
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef GLEANDEPRECATED_H
+#define GLEANDEPRECATED_H
+
+#include <QObject>
+#include <QVariant>
+
+class GleanDeprecated final : public QObject {
+  Q_OBJECT
+  Q_DISABLE_COPY_MOVE(GleanDeprecated)
+
+ public:
+  static GleanDeprecated* instance();
+  ~GleanDeprecated();
+
+ private:
+  explicit GleanDeprecated(QObject* parent);
+
+ signals:
+  void recordGleanEvent(const QString& gleanSampleName);
+  void recordGleanEventWithExtraKeys(const QString& gleanSampleName,
+                                     const QVariantMap& extraKeys);
+};
+
+#endif  // GLEANDEPRECATED_H

--- a/src/shared/sources.cmake
+++ b/src/shared/sources.cmake
@@ -11,6 +11,7 @@ target_sources(shared-sources INTERFACE ${CMAKE_CURRENT_BINARY_DIR}/version.h)
 set_property(TARGET shared-sources PROPERTY INTERFACE_INCLUDE_DIRECTORIES
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}/shared
+    ${CMAKE_CURRENT_SOURCE_DIR}/shared/glean
     ${CMAKE_CURRENT_BINARY_DIR}
 )
 
@@ -27,6 +28,8 @@ target_sources(shared-sources INTERFACE
     ${CMAKE_CURRENT_SOURCE_DIR}/shared/feature.h
     ${CMAKE_CURRENT_SOURCE_DIR}/shared/fontloader.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/shared/fontloader.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/shared/glean/gleandeprecated.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/shared/glean/gleandeprecated.h
     ${CMAKE_CURRENT_SOURCE_DIR}/shared/hacl-star/Hacl_Chacha20.c
     ${CMAKE_CURRENT_SOURCE_DIR}/shared/hacl-star/Hacl_Chacha20Poly1305_32.c
     ${CMAKE_CURRENT_SOURCE_DIR}/shared/hacl-star/Hacl_Curve25519_51.c

--- a/src/shared/sources.pri
+++ b/src/shared/sources.pri
@@ -8,6 +8,7 @@ SOURCES += \
         $$PWD/curve25519.cpp \
         $$PWD/feature.cpp \
         $$PWD/fontloader.cpp \
+        $$PWD/glean/gleandeprecated.cpp \
         $$PWD/hacl-star/Hacl_Chacha20.c \
         $$PWD/hacl-star/Hacl_Chacha20Poly1305_32.c \
         $$PWD/hacl-star/Hacl_Curve25519_51.c \
@@ -37,6 +38,7 @@ HEADERS += \
         $$PWD/env.h \
         $$PWD/feature.h \
         $$PWD/fontloader.h \
+        $$PWD/glean/gleandeprecated.h \
         $$PWD/hawkauth.h \
         $$PWD/hkdf.h \
         $$PWD/ipaddress.h \

--- a/tests/auth/CMakeLists.txt
+++ b/tests/auth/CMakeLists.txt
@@ -8,6 +8,7 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR})
 include_directories(${MZ_SOURCE_DIR})
 include_directories(${MZ_SOURCE_DIR}/apps/vpn)
 include_directories(${MZ_SOURCE_DIR}/shared)
+include_directories(${MZ_SOURCE_DIR}/shared/glean)
 include_directories(${MZ_SOURCE_DIR}/shared/hacl-star)
 include_directories(${MZ_SOURCE_DIR}/shared/hacl-star/kremlin)
 include_directories(${MZ_SOURCE_DIR}/shared/hacl-star/kremlin/minimal)
@@ -98,6 +99,8 @@ target_sources(auth_tests PRIVATE
     ${MZ_SOURCE_DIR}/shared/env.h
     ${MZ_SOURCE_DIR}/shared/feature.cpp
     ${MZ_SOURCE_DIR}/shared/feature.h
+    ${MZ_SOURCE_DIR}/shared/glean/gleandeprecated.cpp
+    ${MZ_SOURCE_DIR}/shared/glean/gleandeprecated.h
     ${MZ_SOURCE_DIR}/shared/hacl-star/Hacl_Chacha20.c
     ${MZ_SOURCE_DIR}/shared/hacl-star/Hacl_Chacha20Poly1305_32.c
     ${MZ_SOURCE_DIR}/shared/hacl-star/Hacl_Curve25519_51.c

--- a/tests/qml/CMakeLists.txt
+++ b/tests/qml/CMakeLists.txt
@@ -8,6 +8,7 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 include_directories(${MZ_SOURCE_DIR})
 include_directories(${MZ_SOURCE_DIR}/apps/vpn)
 include_directories(${MZ_SOURCE_DIR}/shared)
+include_directories(${MZ_SOURCE_DIR}/shared/glean)
 include_directories(${MZ_SOURCE_DIR}/shared/hacl-star)
 include_directories(${MZ_SOURCE_DIR}/shared/hacl-star/kremlin)
 include_directories(${MZ_SOURCE_DIR}/shared/hacl-star/kremlin/minimal)
@@ -79,6 +80,8 @@ target_sources(qml_tests PRIVATE
     ${MZ_SOURCE_DIR}/shared/env.h
     ${MZ_SOURCE_DIR}/shared/feature.cpp
     ${MZ_SOURCE_DIR}/shared/feature.h
+    ${MZ_SOURCE_DIR}/shared/glean/gleandeprecated.cpp
+    ${MZ_SOURCE_DIR}/shared/glean/gleandeprecated.h
     ${MZ_SOURCE_DIR}/shared/hacl-star/Hacl_Chacha20.c
     ${MZ_SOURCE_DIR}/shared/hacl-star/Hacl_Chacha20Poly1305_32.c
     ${MZ_SOURCE_DIR}/shared/hacl-star/Hacl_Curve25519_51.c

--- a/tests/qml/helper.cpp
+++ b/tests/qml/helper.cpp
@@ -7,6 +7,7 @@
 #include <glean.h>
 #include <nebula.h>
 
+#include "gleandeprecated.h"
 #include "qmlengineholder.h"
 
 TestHelper::TestHelper() {
@@ -41,7 +42,7 @@ void TestHelper::triggerInitializeGlean() const {
 }
 
 void TestHelper::triggerRecordGleanEvent(const QString& event) const {
-  emit MozillaVPN::instance()->recordGleanEvent(event);
+  emit GleanDeprecated::instance()->recordGleanEvent(event);
 }
 
 void TestHelper::triggerSendGleanPings() const {
@@ -103,6 +104,14 @@ void TestHelper::qmlEngineAvailable(QQmlEngine* engine) {
       [this](QQmlEngine*, QJSEngine* engine) -> QObject* {
         m_theme->initialize(engine);
         QObject* obj = m_theme;
+        QQmlEngine::setObjectOwnership(obj, QQmlEngine::CppOwnership);
+        return obj;
+      });
+
+  qmlRegisterSingletonType<MozillaVPN>(
+      "Mozilla.VPN", 1, 0, "VPNGleanDeprecated",
+      [](QQmlEngine*, QJSEngine*) -> QObject* {
+        QObject* obj = GleanDeprecated::instance();
         QQmlEngine::setObjectOwnership(obj, QQmlEngine::CppOwnership);
         return obj;
       });

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -8,6 +8,7 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR})
 include_directories(${CMAKE_BINARY_DIR}/vpnglean)
 include_directories(${MZ_SOURCE_DIR})
 include_directories(${MZ_SOURCE_DIR}/shared)
+include_directories(${MZ_SOURCE_DIR}/shared/glean)
 include_directories(${MZ_SOURCE_DIR}/apps/vpn)
 include_directories(${MZ_SOURCE_DIR}/apps/vpn/composer)
 include_directories(${MZ_SOURCE_DIR}/shared/hacl-star)
@@ -236,6 +237,8 @@ target_sources(unit_tests PRIVATE
     ${MZ_SOURCE_DIR}/shared/env.h
     ${MZ_SOURCE_DIR}/shared/feature.cpp
     ${MZ_SOURCE_DIR}/shared/feature.h
+    ${MZ_SOURCE_DIR}/shared/glean/gleandeprecated.cpp
+    ${MZ_SOURCE_DIR}/shared/glean/gleandeprecated.h
     ${MZ_SOURCE_DIR}/shared/hacl-star/Hacl_Chacha20.c
     ${MZ_SOURCE_DIR}/shared/hacl-star/Hacl_Chacha20Poly1305_32.c
     ${MZ_SOURCE_DIR}/shared/hacl-star/Hacl_Curve25519_51.c


### PR DESCRIPTION
Deprecated because this will be removed when we get rid of glean-js. This is needed to remove the dependency between components and MozillaVPN
