### PR TITLE
Fix console warning in ViewAdvancedDNSSettings.qml

### DIFF
--- a/src/apps/vpn/ui/screens/settings/dnsSettings/DNSSettingsTabContent.qml
+++ b/src/apps/vpn/ui/screens/settings/dnsSettings/DNSSettingsTabContent.qml
@@ -20,8 +20,6 @@ VPNFlickable {
     property bool vpnIsOff: (VPNController.state === VPNController.StateOff)
     property alias settingsListModel: repeater.model
 
-    anchors.fill: parent
-
     flickContentHeight: col.height + col.anchors.topMargin
 
     ColumnLayout {


### PR DESCRIPTION
## Description

Fixes console warning `qrc:/ui/screens/settings/dnsSettings/ViewAdvancedDNSSettings.qml:60:13: QML DNSSettingsTabContent: Detected anchors on an item that is managed by a layout. This is undefined behavior; use Layout.alignment instead. (ViewAdvancedDNSSettings.qml:60)`

## Reference

    i.e Jira or Github issue URL

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
