### PR TITLE
CI: remove geckodriver.

### DIFF
--- a/.github/workflows/wasm.yaml
+++ b/.github/workflows/wasm.yaml
@@ -45,9 +45,6 @@ jobs:
       - name: Setup emsdk
         uses: mymindstorm/setup-emsdk@v7
 
-      - name: Set up gecko driver
-        uses: browser-actions/setup-geckodriver@latest
-
       - name: Compiling
         shell: bash
         run: |


### PR DESCRIPTION
## Description

In https://github.com/mozilla-mobile/mozilla-vpn-client/pull/5264/files
geckodriver was actually removed from the running task. It's green. 
We certainly dont need it to build the client.
