### PR TITLE
Logout-Observer: Remove invalid assert

### DIFF
--- a/src/apps/vpn/logoutobserver.cpp
+++ b/src/apps/vpn/logoutobserver.cpp
@@ -11,7 +11,6 @@ LogoutObserver::LogoutObserver(QObject* parent) : QObject(parent) {
   MZ_COUNT_CTOR(LogoutObserver);
 
   MozillaVPN* vpn = MozillaVPN::instance();
-  Q_ASSERT(vpn->userState() == MozillaVPN::UserLoggingOut);
 
   connect(vpn, &MozillaVPN::userStateChanged, this,
           &LogoutObserver::userStateChanged);

--- a/src/apps/vpn/logoutobserver.h
+++ b/src/apps/vpn/logoutobserver.h
@@ -6,7 +6,13 @@
 #define LOGOUTOBSERVER_H
 
 #include <QObject>
-
+/**
+ * @brief Observes the User State.
+ *
+ * Will fire the event ready(), whenever
+ * a user session ended.
+ * After that happens the Observer will delete itself.
+ */
 class LogoutObserver final : public QObject {
   Q_OBJECT
   Q_DISABLE_COPY_MOVE(LogoutObserver)


### PR DESCRIPTION
## Description

In PR https://github.com/mozilla-mobile/mozilla-vpn-client/pull/5278
I added a LogoutObserver to the VPNActivity, so that post-logout cleanup will be triggered. 
This means the LogoutObserver will be created even if there is no current logout happening. 

This means this Q_ASSERT currently crashes android debug builds


## Reference
Nobug.

