### PR TITLE
TC: Windows add Scopes for level-3 Builds

### DIFF
--- a/taskcluster/ci/build/windows.yml
+++ b/taskcluster/ci/build/windows.yml
@@ -8,7 +8,7 @@ task-defaults:
         symbol: B
         kind: build
         tier: 1
-        platform: windows/x64
+        platform: windows/x86_64
     worker-type: b-win2012
     fetches:
         fetch:
@@ -43,12 +43,9 @@ windows/opt:
     description: "Windows Build"
     treeherder:
         symbol: B
-    requires-level: 3 
     scopes:
-        - secrets:get:project/mozillavpn/tokens
+        by-level:
+            "3":
+                - secrets:get:project/mozillavpn/tokens
+            default: []
 
-windows/pr:
-    description: "Windows Build for Pull Requests"
-    treeherder:
-        symbol: BD
-    requires-level: 1 

--- a/taskcluster/ci/build/windows.yml
+++ b/taskcluster/ci/build/windows.yml
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 ---
-windows/opt:
+task-defaults:
     description: "Windows Build"
     treeherder:
         symbol: B
@@ -37,3 +37,18 @@ windows/opt:
         cwd: '{checkout}'
         exec-with: powershell
         command: taskcluster/scripts/build/windows.ps1
+
+
+windows/opt:
+    description: "Windows Build"
+    treeherder:
+        symbol: B
+    requires-level: 3 
+    scopes:
+        - secrets:get:project/mozillavpn/tokens
+
+windows/pr:
+    description: "Windows Build for Pull Requests"
+    treeherder:
+        symbol: BD
+    requires-level: 1 

--- a/taskcluster/mozillavpn_taskgraph/transforms/build.py
+++ b/taskcluster/mozillavpn_taskgraph/transforms/build.py
@@ -5,8 +5,9 @@
 Apply some defaults and minor modifications to the jobs defined in the build
 kind.
 """
-from taskgraph.transforms.base import TransformSequence
+from taskgraph.transforms.base import TransformSequence 
 from taskgraph.util.schema import Schema
+from taskgraph.util.schema import resolve_keyed_by
 from voluptuous import Optional, Required, Extra
 
 
@@ -43,4 +44,26 @@ def add_variant_config(config, tasks):
         attributes = task.setdefault("attributes", {})
         if not attributes.get("build-type"):
             attributes["build-type"] = task["name"]
+        yield task
+
+
+
+@transforms.add
+def resolve_keys_scope(config, tasks):
+    # Enables the by-level:
+    # resolver for the "scopes field"
+    # usage:
+    # scopes:
+    #   by-level:
+    #     3: [scope-a,scope-b]
+    #     1: [scope-a]
+    for task in tasks:
+        resolve_keyed_by(
+            task,
+            "scopes",
+            item_name=task["name"],
+            **{
+                "level": config.params["level"],
+            },
+        )
         yield task


### PR DESCRIPTION
## Description
In order for the sentry-stuff to actually work the build needs access to the tokens. Let's enable it for level-3 tasks :) 
