### PR TITLE
Make legal disclaimer accessible to screen readers

### DIFF
--- a/nebula/ui/components/inAppAuth/VPNInAppAuthenticationLegalDisclaimer.qml
+++ b/nebula/ui/components/inAppAuth/VPNInAppAuthenticationLegalDisclaimer.qml
@@ -28,5 +28,11 @@ ColumnLayout {
             }
             VPNUrlOpener.openLink(VPNUrlOpener.LinkPrivacyNotice);
         }
+
+        Accessible.role: Accessible.StaticText
+        //prevent html tags from being read by screen readers
+        //NOTE: This is not a robust way of removing html tags,
+        //and should only be used for this particular case
+        Accessible.name: text.replace(/<[^>]*>/g, "")
     }
 }


### PR DESCRIPTION
## Description

- Makes the legal disclaimer text on the create password/enter password authentication views accessible to a screen reader. It also prevents the HTML tags from being read by the screen reader
- NOTE: The "Terms of Service" and "Privacy Notice" links within the legal disclaimer are still unaccessible using keyboard navigation - this may need a workaround solution as I am not sure if in-line links in QML are keyboard navigable

## Reference

n/a

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
