### PR TITLE
ci: re-enable Linux signing tasks

### DIFF
--- a/taskcluster/ci/build/source.yml
+++ b/taskcluster/ci/build/source.yml
@@ -22,6 +22,8 @@ source/vpn:
     add-index-routes:
         name: source
         type: build
+    release-artifacts:
+        - mozillavpn-sources.tar.gz
     run:
         using: run-task
         use-caches: true

--- a/taskcluster/ci/config.yml
+++ b/taskcluster/ci/config.yml
@@ -66,7 +66,7 @@ workers:
             provisioner: scriptworker-k8s
             implementation: scriptworker-signing
             os: scriptworker
-            worker-type: mozillavpn-t-signing
+            worker-type: mozillavpn-t-signing-dev
         signing:
             provisioner: scriptworker-k8s
             implementation: scriptworker-signing
@@ -74,7 +74,7 @@ workers:
             worker-type:
                 by-level:
                     "3": mozillavpn-3-signing
-                    default: mozillavpn-t-signing
+                    default: mozillavpn-t-signing-dev
         macos-dep-signing:
             provisioner: scriptworker-prov-v1
             implementation: scriptworker-signing

--- a/taskcluster/ci/signing/kind.yml
+++ b/taskcluster/ci/signing/kind.yml
@@ -22,7 +22,7 @@ only-for-build-types:
     - android-x86/release
     - android-arm64/release
     - android-armv7/release
-    # - linux/opt
+    - source/vpn
     - macos/opt
     - windows/opt
     - addons/opt
@@ -37,7 +37,7 @@ job-template:
     signing-format:
         by-build-type:
             android.*: autograph_apk
-            linux.*: autograph_debsign
+            source/vpn: autograph_debsign
             macos.*: macapp
             windows/opt: autograph_authenticode
             addons/opt: autograph_rsa
@@ -55,7 +55,7 @@ job-template:
                 android-x86/release: android/x86
                 android-arm64/release: android/arm64-v8a
                 android-armv7/release: android/armv7
-                linux/opt: linux/opt
+                source/vpn: linux/opt
                 macos/opt: macos/opt
                 windows/opt: windows/x86_64
                 addons/opt: addons/opt

--- a/taskcluster/mozillavpn_taskgraph/parameters.py
+++ b/taskcluster/mozillavpn_taskgraph/parameters.py
@@ -4,6 +4,7 @@
 
 import os
 
+from taskgraph.target_tasks import _target_task
 from taskgraph.parameters import extend_parameters_schema
 from voluptuous import All, Any, Range, Required
 
@@ -24,9 +25,15 @@ extend_parameters_schema(
 )
 
 
+@_target_task("testing")
+def test_target_task(*args):
+    return ["signing-source/vpn"]
+
+
 def get_decision_parameters(graph_config, parameters):
     head_tag = parameters["head_tag"]
     parameters["version"] = head_tag[1:] if head_tag else ""
 
     pr_number = os.environ.get("MOZILLAVPN_PULL_REQUEST_NUMBER", None)
     parameters["pull_request_number"] = None if pr_number is None else int(pr_number)
+    parameters["target_tasks_method"] = "testing"

--- a/taskcluster/mozillavpn_taskgraph/transforms/signing.py
+++ b/taskcluster/mozillavpn_taskgraph/transforms/signing.py
@@ -17,7 +17,6 @@ PRODUCTION_SIGNING_BUILD_TYPES = [
     "android-x86/release",
     "android-arm64/release",
     "android-armv7/release",
-    "linux/opt",
     "macos/opt",
     "windows/opt",
     "addons/opt",
@@ -28,6 +27,7 @@ SIGNING_BUILD_TYPES = PRODUCTION_SIGNING_BUILD_TYPES + [
     # android builds. Contact releng if you need it :)
     # "android-debug",
     # "addons/opt",  # TODO: Add addons debug builds? We have the infra to debug sign them.
+    "source/vpn",  # Needs testing / validation
 ]
 
 

--- a/taskcluster/mozillavpn_taskgraph/transforms/signing.py
+++ b/taskcluster/mozillavpn_taskgraph/transforms/signing.py
@@ -35,7 +35,7 @@ SIGNING_BUILD_TYPES = PRODUCTION_SIGNING_BUILD_TYPES + [
 def set_run_on_tasks_for(config, tasks):
     for task in tasks:
         if task["attributes"]["build-type"] in SIGNING_BUILD_TYPES:
-            task["run-on-tasks-for"] = ["github-push"]
+            task["run-on-tasks-for"] = ["github-push", "github-pull-request"]
         yield task
 
 


### PR DESCRIPTION
## Description

Re-enable Linux signing tasks without using the production key.
