### PR TITLE
Disable radio button labels in DNS settings

### DIFF
--- a/src/apps/vpn/ui/screens/settings/dnsSettings/DNSSettingsTabContent.qml
+++ b/src/apps/vpn/ui/screens/settings/dnsSettings/DNSSettingsTabContent.qml
@@ -84,6 +84,7 @@ VPNFlickable {
                             anchors.left: parent.left
                             anchors.bottom: parent.bottom
 
+                            enabled: radioButton.enabled
                             width: Math.min(parent.implicitWidth, parent.width)
                             propagateClickToParent: false
                             onClicked: VPNSettings.dnsProvider = settingValue
@@ -122,7 +123,7 @@ VPNFlickable {
                                 enabled: (VPNSettings.dnsProvider === VPNSettings.Custom) && vpnIsOff
                                 onEnabledChanged: if(enabled) forceActiveFocus()
 
-                                _placeholderText: VPNSettings.placeholderUserDNS
+                                _placeholderText: VPN.placeholderUserDNS
                                 text: ""
                                 Layout.fillWidth: true
                                 Layout.preferredHeight: 40


### PR DESCRIPTION
## Description

- Prevent DNS radio buttons from being selected by clicking on their labels when the radio button is disabled (VPN is turned on)
- Restore custom DNS text field placeholder text

## Reference

[VPN-3546: DNS settings can be modified while the VPN is ON ](https://mozilla-hub.atlassian.net/browse/VPN-3546)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
