### PR TITLE
Fix qml warning in ViewTipsAndTricks.qml

### DIFF
--- a/src/apps/vpn/ui/screens/tipsAndTricks/ViewTipsAndTricks.qml
+++ b/src/apps/vpn/ui/screens/tipsAndTricks/ViewTipsAndTricks.qml
@@ -79,7 +79,7 @@ VPNViewBase {
             // All
             VPNViewBase {
                 objectName: 'allTab'
-                anchors.topMargin: 0
+                anchors.top: undefined
 
                 _viewContentData: ColumnLayout {
                     id: layoutAll
@@ -134,7 +134,7 @@ VPNViewBase {
 
             // Tutorials
             VPNViewBase {
-                anchors.topMargin: 0
+                anchors.top: undefined
 
                 _viewContentData: ColumnLayout {
                     id: layoutTutorial
@@ -165,7 +165,7 @@ VPNViewBase {
 
             // Tips
             VPNViewBase {
-                anchors.topMargin: 0
+                anchors.top: undefined
 
                 _viewContentData: ColumnLayout {
                     id: layoutGuide


### PR DESCRIPTION
## Description

Fixes `QML VPNViewBase: Detected anchors on an item that is managed by a layout. This is undefined behavior; use Layout.alignment instead.` in ViewTripsAndTricks.qml

## Reference

    i.e Jira or Github issue URL

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
