### PR TITLE
Feedback radio delegate fixes

### DIFF
--- a/src/apps/vpn/ui/screens/getHelp/giveFeedback/GiveFeedbackRadioDelegate.qml
+++ b/src/apps/vpn/ui/screens/getHelp/giveFeedback/GiveFeedbackRadioDelegate.qml
@@ -44,8 +44,10 @@ RadioDelegate {
             anchors.fill: parent
             source: img
             color: VPNTheme.colors.blue
-            visible: radio.checked || radio.state === uiState.stateHovered
-                || radio.state === uiState.statePressed
+            //prevents iOS and Android from getting into a weird hover state
+            visible: radio.checked || radio.state === uiState.statePressed
+                     || ((Qt.platform.os !== "android" && Qt.platform.os !== "ios")
+                         && radio.state === uiState.stateHovered)
         }
     }
 
@@ -80,7 +82,7 @@ RadioDelegate {
         id: mouseArea
         onMouseAreaClicked: function() {
             radio.forceActiveFocus();
-            radio.checked = !radio.checked;
+            radio.checked = true
         }
     }
 }

--- a/src/apps/vpn/ui/screens/getHelp/giveFeedback/GiveFeedbackRadioDelegate.qml
+++ b/src/apps/vpn/ui/screens/getHelp/giveFeedback/GiveFeedbackRadioDelegate.qml
@@ -16,6 +16,7 @@ RadioDelegate {
     property alias iconSource: img.source
     property real iconSize: 30
     property var uiState: VPNTheme.theme.uiState
+    readonly property bool isMobile: (Qt.platform.os === "android" || Qt.platform.os === "ios")
 
     id: radio
 
@@ -46,8 +47,7 @@ RadioDelegate {
             color: VPNTheme.colors.blue
             //prevents iOS and Android from getting into a weird hover state
             visible: radio.checked || radio.state === uiState.statePressed
-                     || ((Qt.platform.os !== "android" && Qt.platform.os !== "ios")
-                         && radio.state === uiState.stateHovered)
+                     || (!radio.isMobile && radio.state === uiState.stateHovered)
         }
     }
 
@@ -68,7 +68,7 @@ RadioDelegate {
         border.width: VPNTheme.theme.focusBorderWidth * 2
         color: VPNTheme.theme.transparent
         //OS Check to prevent multi-touch issue
-        opacity: radio.checked || ((Qt.platform.os !== "android" && Qt.platform.os !== "ios") && radio.activeFocus) ? 1 : 0
+        opacity: radio.checked || (!radio.isMobile && radio.activeFocus) ? 1 : 0
         radius: height
 
         Behavior on opacity {


### PR DESCRIPTION
## Description

- Prevents feedback form from appearing like two feedback options were selected at the same time
- Prevents unchecking feedback radio buttons by tapping on a selected feedback radio button (this was a visual bug that allowed the user to progress to the next step when it looked like no feedback radio buttons were selected)

## Reference

[VPN-912: [mobile] More than one option can be selected on the “Give Feedback” screen](https://mozilla-hub.atlassian.net/browse/VPN-912)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
