### PR TITLE
Add auto generated l18nstrings to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,6 +168,8 @@ src/apps/vpn/glean/generated
 /qt/
 
 # Language files
+l18nstrings.h
+l18nstrings_p.cpp
 /translations/libtranslations.a
 /translations/translations_autogen/
 translations/*/*.ts


### PR DESCRIPTION

## Description

    We should not be able to commit these since they are automatically generated by Cmake

## Reference

    https://mozilla-hub.atlassian.net/browse/VPN-3604

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
