### PR TITLE
Move troubleshooting info for multi-hop into list

### DIFF
--- a/nebula/ui/components/VPNConnectionInfoContent.qml
+++ b/nebula/ui/components/VPNConnectionInfoContent.qml
@@ -78,19 +78,6 @@ VPNFlickable {
                     Layout.rightMargin: VPNTheme.theme.windowMargin
                 }
 
-                VPNCallout {
-                    calloutCopy: VPNl18n.ConnectionInfoMultiHopCallout
-                    calloutImage: "qrc:/nebula/resources/connection-info.svg"
-                    color: VPNTheme.theme.white
-                    fontPixelSize: VPNTheme.theme.fontSizeSmall
-                    iconSize: VPNTheme.theme.iconSize * 1.25
-                    spacing: VPNTheme.theme.listSpacing * 0.5
-                    visible: serverLocations.isMultipHop
-
-                    Layout.bottomMargin: VPNTheme.theme.windowMargin
-                    Layout.leftMargin: VPNTheme.theme.windowMargin
-                }
-
                 ColumnLayout {
                     property bool isMultipHop: (typeof(VPNCurrentServer.entryCountryCode) !== undefined
                         && VPNCurrentServer.entryCountryCode !== "")
@@ -280,6 +267,13 @@ VPNFlickable {
                 title: VPNl18n.ConnectionInfoTroubleshootingBulletTwo,
                 type: "arrow",
             });
+
+            if (serverLocations.isMultipHop) {
+                checkmarkListModel.append({
+                    title: VPNl18n.ConnectionInfoTroubleshootingBulletThree,
+                    type: "arrow",
+                });
+            }
         }
     }
 

--- a/translations/strings.yaml
+++ b/translations/strings.yaml
@@ -378,6 +378,9 @@ connectionInfo:
   troubleshootingBulletTwo:
     value: Checking your internet connection
     comment: This is a bullet item in the connection troubleshooting section
+  troubleshootingBulletThree:
+    value: Switching back to a single-hop connection
+    comment: This is a bullet item in the connection troubleshooting section for multi-hop connections
   # Bullet items for medium speedtest results
   mediumBulletOne:
     value: Browsing the internet


### PR DESCRIPTION
## Description

Moves the dedicated callout info into the bullet list. Instead of always showing this string for multi-hop connection we decided to only show it for speed test results that we mark as “slow”.

## Reference

- Jira [VPN-3218](https://mozilla-hub.atlassian.net/browse/VPN-3218): Improvements to the Speed test UI
- Figma: https://www.figma.com/file/3V7aahpQ096Qsp2L3SCT6h/Connection-Screen-Speedtest?node-id=1103%3A4728

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
