### PR TITLE
Fix list margin for Welcome paragraph on WASM page

### DIFF
--- a/wasm/main.css
+++ b/wasm/main.css
@@ -56,6 +56,10 @@ p {
 	margin: .5rem;
 }
 
+#presetInfo li {
+	margin-left: 1.5rem;
+}
+
 header,
 footer {
 	display: flex;


### PR DESCRIPTION
## Description

The list added in #5404 looks a bit awkward without margin. Since there are other lists, focusing only on the section.

![Screenshot 2023-01-05 alle 15 35 30](https://user-images.githubusercontent.com/3644868/210812928-80450c5b-d0b2-4424-82ef-7c33b54d5e26.png)

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
