### PR TITLE
VPN-3019 - Integrate vpnglean logs with VPN logs

### DIFF
--- a/src/apps/vpn/command.cpp
+++ b/src/apps/vpn/command.cpp
@@ -6,6 +6,7 @@
 
 #include "appconstants.h"
 #include "commandlineparser.h"
+#include "glean/glean.h"
 #include "leakdetector.h"
 #include "localizer.h"
 #include "logger.h"
@@ -91,7 +92,9 @@ int Command::runCommandLineApp(std::function<int()>&& a_callback) {
     LogHandler::enableStderr();
   }
 
+  VPNGlean::registerLogHandler(LogHandler::rustMessageHandler);
   qInstallMessageHandler(LogHandler::messageQTHandler);
+
   logger.info() << "MozillaVPN" << Constants::versionString();
   logger.info() << "User-Agent:" << NetworkManager::userAgent();
 
@@ -116,6 +119,7 @@ int Command::runGuiApp(std::function<int()>&& a_callback) {
     LogHandler::enableStderr();
   }
 
+  VPNGlean::registerLogHandler(LogHandler::rustMessageHandler);
   qInstallMessageHandler(LogHandler::messageQTHandler);
 
   logger.info() << "MozillaVPN" << Constants::versionString();
@@ -149,6 +153,7 @@ int Command::runQmlApp(std::function<int()>&& a_callback) {
     LogHandler::enableStderr();
   }
 
+  VPNGlean::registerLogHandler(LogHandler::rustMessageHandler);
   qInstallMessageHandler(LogHandler::messageQTHandler);
 
   // Ensure that external styling hints are disabled.

--- a/src/apps/vpn/glean/glean.cpp
+++ b/src/apps/vpn/glean/glean.cpp
@@ -51,6 +51,13 @@ VPNGlean::VPNGlean(QObject* parent) : QObject(parent) {
 VPNGlean::~VPNGlean() { MZ_COUNT_DTOR(VPNGlean); }
 
 // static
+void VPNGlean::registerLogHandler(void (*messageHandler)(int32_t, char*)) {
+#if not(defined(MZ_WASM) || defined(BUILD_QMAKE))
+  glean_register_log_handler(messageHandler);
+#endif
+}
+
+// static
 void VPNGlean::initialize() {
   logger.debug() << "Initializing VPNGlean";
 

--- a/src/apps/vpn/glean/glean.h
+++ b/src/apps/vpn/glean/glean.h
@@ -21,6 +21,8 @@ class VPNGlean final : public QObject {
  public:
   ~VPNGlean();
 
+  static void registerLogHandler(void (*messageHandler)(int32_t, char*));
+
   static void initialize();
   static void shutdown();
 };

--- a/src/shared/loghandler.cpp
+++ b/src/shared/loghandler.cpp
@@ -45,23 +45,6 @@ LogLevel qtTypeToLogLevel(QtMsgType type) {
   }
 }
 
-// This is based on values set from vpnglean/src/logger.rs
-LogLevel intToLogLevel(uint8_t type) {
-  switch (type) {
-    case 0:
-      return Trace;
-    case 1:
-      return Debug;
-    case 2:
-      return Info;
-    case 3:
-      return Warning;
-    case 4:
-      return Error;
-    default:
-      return Debug;
-  }
-}
 }  // namespace
 
 // static
@@ -92,7 +75,8 @@ void LogHandler::rustMessageHandler(int32_t logLevel, char* message) {
   MutexLocker lock(&s_mutex);
 
   maybeCreate(lock)->addLog(
-      Log(intToLogLevel(logLevel), "Rust", QString::fromUtf8(message)), lock);
+      Log(static_cast<LogLevel>(logLevel), "Rust", QString::fromUtf8(message)),
+      lock);
 }
 
 // static

--- a/src/shared/loghandler.cpp
+++ b/src/shared/loghandler.cpp
@@ -92,7 +92,7 @@ void LogHandler::rustMessageHandler(int32_t logLevel, char* message) {
   MutexLocker lock(&s_mutex);
 
   maybeCreate(lock)->addLog(
-      Log(intToLogLevel(logLevel), QString::fromUtf8(message)), lock);
+      Log(intToLogLevel(logLevel), "Rust", QString::fromUtf8(message)), lock);
 }
 
 // static

--- a/src/shared/loghandler.h
+++ b/src/shared/loghandler.h
@@ -28,12 +28,6 @@ class LogHandler final : public QObject {
   struct Log {
     Log() = default;
 
-    Log(LogLevel logLevel, const QString& message)
-        : m_logLevel(logLevel),
-          m_dateTime(QDateTime::currentDateTime()),
-          m_message(message),
-          m_fromQT(false) {}
-
     Log(LogLevel logLevel, const QString& className, const QString& message)
         : m_logLevel(logLevel),
           m_dateTime(QDateTime::currentDateTime()),

--- a/src/shared/loghandler.h
+++ b/src/shared/loghandler.h
@@ -28,6 +28,12 @@ class LogHandler final : public QObject {
   struct Log {
     Log() = default;
 
+    Log(LogLevel logLevel, const QString& message)
+        : m_logLevel(logLevel),
+          m_dateTime(QDateTime::currentDateTime()),
+          m_message(message),
+          m_fromQT(false) {}
+
     Log(LogLevel logLevel, const QString& className, const QString& message)
         : m_logLevel(logLevel),
           m_dateTime(QDateTime::currentDateTime()),
@@ -63,6 +69,8 @@ class LogHandler final : public QObject {
 
   static void messageHandler(LogLevel logLevel, const QString& className,
                              const QString& message);
+
+  static void rustMessageHandler(int32_t logLevel, char* message);
 
   static void prettyOutput(QTextStream& out, const LogHandler::Log& log);
 

--- a/src/shared/loglevel.h
+++ b/src/shared/loglevel.h
@@ -6,6 +6,7 @@
 #define LOGLEVEL_H
 
 enum LogLevel {
+  Trace,
   Debug,
   Info,
   Warning,

--- a/src/shared/loglevel.h
+++ b/src/shared/loglevel.h
@@ -6,7 +6,7 @@
 #define LOGLEVEL_H
 
 enum LogLevel {
-  Trace,
+  Trace = 0,
   Debug,
   Info,
   Warning,

--- a/vpnglean/src/lib.rs
+++ b/vpnglean/src/lib.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use std::env;
+use std::os::raw::c_char;
 
 use ffi_support::FfiStr;
 use glean::{ClientInfoMetrics, Configuration};
@@ -10,6 +11,7 @@ use glean::{ClientInfoMetrics, Configuration};
 use ffi::helpers::FallibleToString;
 use metrics::__generated_pings::register_pings;
 use uploader::VPNPingUploader;
+use logger::Logger;
 
 // Make internal Glean symbols public for mobile SDK consumption.
 pub use glean_core;
@@ -17,8 +19,15 @@ pub use glean_core;
 mod ffi;
 mod metrics;
 mod uploader;
+mod logger;
 
 const GLEAN_APPLICATION_ID: &str = "mozillavpn";
+
+#[no_mangle]
+pub extern "C" fn glean_register_log_handler(message_handler: extern fn(i32, *mut c_char)) {
+    let logger = Logger::new(message_handler);
+    logger.init();
+}
 
 #[no_mangle]
 pub extern "C" fn glean_initialize(is_telemetry_enabled: bool, data_path: FfiStr, channel: FfiStr) {

--- a/vpnglean/src/logger.rs
+++ b/vpnglean/src/logger.rs
@@ -7,7 +7,7 @@ use std::ffi::CString;
 
 use log::{Level, LevelFilter, Log, Metadata, Record};
 
-// Logger implementation to integrate the Rust logs with loghandler.cpp.
+// Logger implementation to integrate the Rust logs with src/shared/loghandler.cpp.
 //
 // This message handler should be initialized alogside the Qt message handler.
 pub struct Logger {
@@ -34,6 +34,8 @@ impl Log for Logger {
     }
 
     fn log(&self, record: &Record) {
+        // The numbers here are dictated by the order of the enum on
+        // src/shared/loglevel.h
         let log_level: i32 = match record.level() {
             Level::Error => 4,
             Level::Warn => 3,

--- a/vpnglean/src/logger.rs
+++ b/vpnglean/src/logger.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use std::os::raw::c_char;
+use std::ffi::CString;
 
 use log::{Level, LevelFilter, Log, Metadata, Record};
 
@@ -41,7 +42,9 @@ impl Log for Logger {
             Level::Trace => 0,
         };
 
-        (self.message_handler)(log_level, record.args().to_string().as_ptr() as *mut c_char);
+        if let Ok(message) = CString::new(record.args().to_string()) {
+            (self.message_handler)(log_level, message.as_ptr() as *mut c_char);
+        }
     }
 
     fn flush(&self) {}

--- a/vpnglean/src/logger.rs
+++ b/vpnglean/src/logger.rs
@@ -1,0 +1,48 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use std::os::raw::c_char;
+
+use log::{Level, LevelFilter, Log, Metadata, Record};
+
+// Logger implementation to integrate the Rust logs with loghandler.cpp.
+//
+// This message handler should be initialized alogside the Qt message handler.
+pub struct Logger {
+    message_handler: extern fn(i32, *mut c_char)
+}
+
+impl Logger {
+    pub fn new(f: extern fn(i32, *mut c_char)) -> Logger {
+        Logger {
+            message_handler: f
+        }
+    }
+
+    pub fn init(self) {
+        if log::set_boxed_logger(Box::new(self)).is_ok() {
+            log::set_max_level(LevelFilter::Debug);
+        }
+    }
+}
+
+impl Log for Logger {
+    fn enabled(&self, _metadata: &Metadata) -> bool {
+        true
+    }
+
+    fn log(&self, record: &Record) {
+        let log_level: i32 = match record.level() {
+            Level::Error => 4,
+            Level::Warn => 3,
+            Level::Info => 2,
+            Level::Debug => 1,
+            Level::Trace => 0,
+        };
+
+        (self.message_handler)(log_level, record.args().to_string().as_ptr() as *mut c_char);
+    }
+
+    fn flush(&self) {}
+}


### PR DESCRIPTION
This looks a big buggy, some logs are showing up like this: 
```
[05.01.2023 17:03:06.397] Info: New upload task with id 69e50ec2-9bff-4239-baf7-ff7079b71ec9 (path: /submit/mozillavpn/main/1/69e50ec2-9bff-4239-baf7-ff7079b71ec9)�(K�
                                  �UH��
```
Heh. Draft until that is figured out.

[UPDATE]: Fixed by [53757d0](https://github.com/mozilla-mobile/mozilla-vpn-client/pull/5432/commits/53757d0b16d142b43680ae7efdc87b4b1f97da75)

This is what messages will look like (after #5438 is merged). Grepping for "Rust" here:

```
[05.01.2023 18:57:33.441] (Feature) Debug: Initializing feature gleanRust
[05.01.2023 18:57:33.487] (Rust) Info: Creating new Glean v52.0.0
[05.01.2023 18:57:33.488] (Rust) Debug: Database path: "/home/brizental/.local/share/Mozilla VPN/glean/db"
[05.01.2023 18:57:33.488] (Rust) Debug: Migrating files in /home/brizental/.local/share/Mozilla VPN/glean/db
[05.01.2023 18:57:33.488] (Rust) Debug: No data to migrate.
[05.01.2023 18:57:33.488] (Rust) Info: Database initialized
[05.01.2023 18:57:33.496] (Rust) Info: Glean initialized
[05.01.2023 18:57:33.496] (Rust) Info: Processing ping at: /home/brizental/.local/share/Mozilla VPN/glean/pending_pings/47262e82-f2fb-4a5f-8801-e10cc40e9be9
[05.01.2023 18:57:33.497] (Rust) Info: The 'metrics' ping was last sent on 2023-01-05 14:43:00 +01:00
[05.01.2023 18:57:33.497] (Rust) Info: The 'metrics' ping was already sent today, 2023-01-05 18:57:33.497210247 +01:00
[05.01.2023 18:57:33.497] (Rust) Info: Scheduling for 32546.502789753s after 2023-01-05 18:57:33.497210247 +01:00, reason Tomorrow
[05.01.2023 18:57:33.502] (Rust) Info: New upload task with id 47262e82-f2fb-4a5f-8801-e10cc40e9be9 (path: /submit/mozillavpn/main/1/47262e82-f2fb-4a5f-8801-e10cc40e9be9)
[05.01.2023 18:57:33.502] (Rust) Debug: Duplicate ping named 'baseline'
[05.01.2023 18:57:33.502] (Rust) Debug: Duplicate ping named 'metrics'
[05.01.2023 18:57:33.502] (Rust) Debug: Duplicate ping named 'events'
[05.01.2023 18:57:33.502] (Rust) Debug: Duplicate ping named 'deletion-request'
[05.01.2023 18:57:33.502] (Rust) Debug: starting new connection: https://incoming.telemetry.mozilla.org/
[05.01.2023 18:57:33.750] (Rust) Info: Ping 47262e82-f2fb-4a5f-8801-e10cc40e9be9 successfully sent 200.
[05.01.2023 18:57:33.750] (Rust) Info: File was deleted /home/brizental/.local/share/Mozilla VPN/glean/pending_pings/47262e82-f2fb-4a5f-8801-e10cc40e9be9
[05.01.2023 18:57:33.750] (Rust) Info: No more pings to upload! You are done.
[05.01.2023 18:57:37.885] (Rust) Info: Collecting main
[05.01.2023 18:57:37.896] (Rust) Debug: Storing ping '26711526-ac04-4975-a49b-580243acd781' at '/home/brizental/.local/share/Mozilla VPN/glean/pending_pings/26711526-ac04-4975-a49b-580243acd781'
[05.01.2023 18:57:37.897] (Rust) Info: Processing ping at: /home/brizental/.local/share/Mozilla VPN/glean/pending_pings/26711526-ac04-4975-a49b-580243acd781
[05.01.2023 18:57:37.898] (Rust) Info: The ping 'main' was submitted and will be sent as soon as possible
[05.01.2023 18:57:37.898] (Rust) Info: New upload task with id 26711526-ac04-4975-a49b-580243acd781 (path: /submit/mozillavpn/main/1/26711526-ac04-4975-a49b-580243acd781)
[05.01.2023 18:57:38.121] (Rust) Info: Ping 26711526-ac04-4975-a49b-580243acd781 successfully sent 200.
[05.01.2023 18:57:38.121] (Rust) Info: File was deleted /home/brizental/.local/share/Mozilla VPN/glean/pending_pings/26711526-ac04-4975-a49b-580243acd781
[05.01.2023 18:57:38.121] (Rust) Info: No more pings to upload! You are done.
``` 

