### PR TITLE
Fix the get-started tutorial when a server is not available - VPN-3552

### DIFF
--- a/addons/tutorial_01_get_started/manifest.json
+++ b/addons/tutorial_01_get_started/manifest.json
@@ -20,8 +20,8 @@
           "op": "vpn_off"
         },{
           "op": "vpn_location_set",
-          "exitCountryCode": "at",
-          "exitCity": "Vienna",
+          "exitCountryCode": "it",
+          "exitCity": "Milan",
           "entryCountryCode": "",
           "entryCity": ""
         }],
@@ -35,7 +35,7 @@
       {
         "id": "countryAU",
         "element": "serverCountryList/serverCountry-au",
-        "query": "//serverCountryList/{className=VPNServerCountry}[0]{visible=true}",
+        "query": "//serverCountryList/{className=VPNServerCountry}{hasAvailableCities=true}[0]{visible=true}",
         "tooltip": "Select a different country",
         "before": [{
           "op": "property_set",
@@ -47,19 +47,19 @@
         "next": {
           "op": "signal",
           "qml_emitter": "serverCountryList/serverCountry-au",
-          "query_emitter": "//serverCountryList/{className=VPNServerCountry}[0]{visible=true}",
+          "query_emitter": "//serverCountryList/{className=VPNServerCountry}{hasAvailableCities=true}[0]{visible=true}",
           "signal": "cityListVisibleChanged"
         }
       },
       {
         "id": "cityAU",
         "element": "serverCountryList/serverCountry-au/serverCityList/serverCity-Melbourne/radioIndicator",
-        "query": "//serverCountryList/{className=VPNServerCountry}[0]//serverCityList/{className=VPNRadioDelegate}[0]{visible=true}",
+        "query": "//serverCountryList/{className=VPNServerCountry}{hasAvailableCities=true}[0]//serverCityList/{className=VPNRadioDelegate}{isAvailable=true}[0]{visible=true}",
         "tooltip": "Select a different server location",
         "next": {
           "op": "signal",
           "qml_emitter": "serverCountryList/serverCountry-au/serverCityList/serverCity-Melbourne/radioIndicator",
-          "query_emitter": "//serverCountryList/{className=VPNServerCountry}[0]//serverCityList/{className=VPNRadioDelegate}[0]{visible=true}",
+          "query_emitter": "//serverCountryList/{className=VPNServerCountry}{hasAvailableCities=true}[0]//serverCityList/{className=VPNRadioDelegate}{isAvailable=true}[0]{visible=true}",
           "signal": "visibleChanged"
         }
       },

--- a/nebula/ui/components/VPNServerCountry.qml
+++ b/nebula/ui/components/VPNServerCountry.qml
@@ -20,6 +20,8 @@ VPNClickableRow {
     property var currentCityIndex
     property alias serverCountryName: countryName.text
 
+    property bool hasAvailableCities: cities.reduce((initialValue, city) => (initialValue || VPNServerCountryModel.cityConnectionScore(code, city.code) >= 0), false)
+
     function openCityList() {
         cityListVisible = !cityListVisible;
         const itemDistanceFromWindowTop = serverCountry.mapToItem(null, 0, 0).y - multiHopMenuHeight;


### PR DESCRIPTION
This is a fix in case:
- 1 city from the first country is unavailable
- all the cities from the first country are unavailable

It's not a fix in case, the first and the second countries do not have cities available. If we want to support this scenario, we need to implement the scrolling. And this becomes out-of-scope for 2.13/2.14.