### PR TITLE
VPN-3652: Refocus auth inputs after clicking the paste button

### DIFF
--- a/nebula/ui/components/inAppAuth/VPNInAppAuthenticationInputs.qml
+++ b/nebula/ui/components/inAppAuth/VPNInAppAuthenticationInputs.qml
@@ -77,6 +77,7 @@ ColumnLayout {
                 width: undefined
                 onClicked: {
                    activeInput().paste();
+                   activeInput().forceActiveFocus();
                 }
             }
         }


### PR DESCRIPTION
## Description

This forces focus back to auth inputs after hitting the paste button. In the password creation view, the shift of focus back to the password input opens the password requirements tooltip fixing VPN-3652. 

## Reference

VPN-3652

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
