### PR TITLE
Only show city name for multihop server names

### DIFF
--- a/nebula/ui/components/VPNConnectionInfoContent.qml
+++ b/nebula/ui/components/VPNConnectionInfoContent.qml
@@ -93,7 +93,7 @@ VPNFlickable {
                         VPNConnectionInfoItem {
                             id: entryServerLabel
                             title: serverLocations.isMultipHop
-                                ? VPNServerCountryModel.getLocalizedCountryName(VPNCurrentServer.entryCountryCode)
+                                ? VPNCurrentServer.localizedEntryCityName
                                 : ""
                             subtitle: ""
                             iconPath: serverLocations.isMultipHop
@@ -119,9 +119,7 @@ VPNFlickable {
                         }
 
                         VPNConnectionInfoItem {
-                            title: VPNServerCountryModel.getLocalizedCountryName(
-                                VPNCurrentServer.exitCountryCode
-                            )
+                            title: VPNCurrentServer.localizedExitCityName
                             subtitle: serverLocations.isMultipHop
                                 ? ""
                                 : VPNCurrentServer.localizedExitCityName

--- a/nebula/ui/components/VPNConnectionInfoContent.qml
+++ b/nebula/ui/components/VPNConnectionInfoContent.qml
@@ -107,6 +107,7 @@ VPNFlickable {
 
                         VPNIcon {
                             id: arrowIcon
+                            anchors.horizontalCenter: parent.horizontalCenter
                             source: "qrc:/nebula/resources/arrow-forward-white.svg"
                             sourceSize {
                                 height: VPNTheme.theme.iconSize * 1.25


### PR DESCRIPTION
## Description

Remove the country name and only show the name of the city for each server in multihop, also center the arrow in the row. This will uniform the UI experience following issue VPN-3514 ([PR](https://github.com/mozilla-mobile/mozilla-vpn-client/pull/5302)).

![2](https://user-images.githubusercontent.com/3746552/210924935-1cb32a94-9a3b-471d-a332-0dbcafea0682.png)

## Reference

    https://mozilla-hub.atlassian.net/browse/VPN-3639

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
