### PR TITLE
Rollback vpn controller for rollback tutorials

### DIFF
--- a/src/apps/vpn/controller.cpp
+++ b/src/apps/vpn/controller.cpp
@@ -130,6 +130,17 @@ void Controller::initialize() {
     logger.info() << "Canary Ping Succeeded";
   });
 
+  connect(SettingsHolder::instance(), &SettingsHolder::transactionBegan, this,
+          [this]() { m_connectedBeforeTransaction = m_state == StateOn; });
+
+  connect(SettingsHolder::instance(),
+          &SettingsHolder::transactionAboutToRollBack, this, [this]() {
+            if (m_connectedBeforeTransaction)
+              MozillaVPN::instance()->activate();
+            else
+              MozillaVPN::instance()->deactivate();
+          });
+
   MozillaVPN* vpn = MozillaVPN::instance();
 
   const Device* device = vpn->deviceModel()->currentDevice(vpn->keys());

--- a/src/apps/vpn/controller.cpp
+++ b/src/apps/vpn/controller.cpp
@@ -135,10 +135,14 @@ void Controller::initialize() {
 
   connect(SettingsHolder::instance(),
           &SettingsHolder::transactionAboutToRollBack, this, [this]() {
+            if (!m_connectedBeforeTransaction)
+              MozillaVPN::instance()->deactivate();
+          });
+
+  connect(SettingsHolder::instance(), &SettingsHolder::transactionRolledBack,
+          this, [this]() {
             if (m_connectedBeforeTransaction)
               MozillaVPN::instance()->activate();
-            else
-              MozillaVPN::instance()->deactivate();
           });
 
   MozillaVPN* vpn = MozillaVPN::instance();

--- a/src/apps/vpn/controller.h
+++ b/src/apps/vpn/controller.h
@@ -187,6 +187,8 @@ class Controller final : public QObject {
                            const QString& deviceIpv4Address, uint64_t txBytes,
                            uint64_t rxBytes)>>
       m_getStatusCallbacks;
+
+  bool m_connectedBeforeTransaction = false;
 };
 
 #endif  // CONTROLLER_H

--- a/src/shared/settingsholder.cpp
+++ b/src/shared/settingsholder.cpp
@@ -300,6 +300,8 @@ bool SettingsHolder::rollbackTransaction() {
     QMetaObject::invokeMethod(this, i.value().first, Qt::DirectConnection);
   }
 
+  emit transactionRolledBack();
+
   return true;
 }
 

--- a/src/shared/settingsholder.cpp
+++ b/src/shared/settingsholder.cpp
@@ -264,6 +264,8 @@ bool SettingsHolder::beginTransaction() {
 
   m_settingsJournal =
       new QSettings(m_settingsJournalFileName, m_settings.format(), this);
+
+  emit transactionBegan();
   return true;
 }
 
@@ -281,6 +283,8 @@ bool SettingsHolder::rollbackTransaction() {
     logger.warning() << "We are not in a transaction";
     return false;
   }
+
+  emit transactionAboutToRollBack();
 
   QMap<QString, QPair<const char*, QVariant>> transactionChanges(
       m_transactionChanges);

--- a/src/shared/settingsholder.cpp
+++ b/src/shared/settingsholder.cpp
@@ -289,6 +289,8 @@ bool SettingsHolder::rollbackTransaction() {
   QMap<QString, QPair<const char*, QVariant>> transactionChanges(
       m_transactionChanges);
 
+  auto guard = qScopeGuard([&] { emit transactionRolledBack(); });
+
   if (!finalizeTransaction()) {
     return false;
   }
@@ -299,8 +301,6 @@ bool SettingsHolder::rollbackTransaction() {
     m_settings.setValue(i.key(), i.value().second);
     QMetaObject::invokeMethod(this, i.value().first, Qt::DirectConnection);
   }
-
-  emit transactionRolledBack();
 
   return true;
 }

--- a/src/shared/settingsholder.h
+++ b/src/shared/settingsholder.h
@@ -110,6 +110,9 @@ class SettingsHolder final : public QObject {
  signals:
   void addonSettingsChanged();
   void inTransactionChanged();
+  void transactionBegan();
+  void transactionAboutToRollBack();
+  void transactionRolledBack();
 
  private:
   QSettings m_settings;


### PR DESCRIPTION
## Description

- Rollback the state of the VPN controller to what it was prior to starting a "needs rollback" tutorial

*Note: This relies on: #5450

## Reference

[VPN-3125: Implement the Multi-hop Tutorial](https://mozilla-hub.atlassian.net/browse/VPN-3125)
[VPN-3124: Implement the App Permissions Tutorial](https://mozilla-hub.atlassian.net/browse/VPN-3124)
[VPN-3593: VPN previous state not restored after interrupting the “How to exclude apps from VPN protection” tutorial](https://mozilla-hub.atlassian.net/browse/VPN-3593)
[VPN-3677: The VPN state should be restored after a tutorial](https://mozilla-hub.atlassian.net/browse/VPN-3677)
[VPN-3596: [iOS] VPN is turned OFF after completing the multi-hop tutorial](https://mozilla-hub.atlassian.net/browse/VPN-3596)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
