### PR TITLE
Fix the wasm client functional test: testServers.js

### DIFF
--- a/tests/functional/testServers.js
+++ b/tests/functional/testServers.js
@@ -137,8 +137,6 @@ describe('Server list', function() {
 
     await vpn.waitForQueryAndClick(
         queries.screenHome.serverListView.BACK_BUTTON.visible());
-    await vpn.waitForQueryAndClick(
-        queries.screenHome.SERVER_LIST_BUTTON.visible());
 
     await vpn.activate();
 


### PR DESCRIPTION
The rollback of modules 8,9,10 was not correct. The real fix was related to the qmlPath porting of our tests.
Somehow there was a extra line which was "fine" for faster clients (dummyvpn), but not for wasm. The extra line was opening the server-list, closing the main view. On wasm, the main view is "released" too soon. That line needs to be removed.