### PR TITLE
Fixed typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -593,7 +593,7 @@ you're embedding glean v0.21.2 then it will still, for Qt's purpose, be v0.21.
 ### Working on tickets with new Glean instrumentation
 
 If you are responsible for a piece of work that adds new Glean instrumentation you will need to do a data review.
-Follwoing is the recommended process along with some pointers.
+Following is the recommended process along with some pointers.
 
 > The data review process is also described here: https://wiki.mozilla.org/Data_Collection
 


### PR DESCRIPTION
## Description

    Corrected a very small typo in the *Glean* section of the README.

## Reference

    No issue opened. I can open one if needed.

## Checklist
    
- [X] My code follows the style guidelines for this project
- [X] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [X] I have performed a self review of my own code
- [X] I have commented my code PARTICULARLY in hard to understand areas
- [X] I have added thorough tests where needed
