### PR TITLE
Add a delay to avoid race-condition Qt/QML when simulating clicks

### DIFF
--- a/src/apps/vpn/inspector/inspectorhandler.cpp
+++ b/src/apps/vpn/inspector/inspectorhandler.cpp
@@ -311,8 +311,20 @@ static QList<InspectorCommand> s_commands{
                        QPoint point = pointF.toPoint();
                        point.rx() += item->width() / 2;
                        point.ry() += item->height() / 2;
+
+                       // It seems that in QT/QML there is a race-condition bug
+                       // between the rendering thread and the main one when
+                       // simulating clicks using QTest. At this point, all the
+                       // properties are synchronized, the animation is
+                       // probably already completed (otherwise it's a bug in
+                       // the test!) but it could be that he following
+                       // `mouse`Click` is ignored.
+                       // The horrible/temporary solution is to wait a bit more
+                       // and to add a delay (VPN-3697)
+                       QTest::qWait(150);
                        QTest::mouseClick(item->window(), Qt::LeftButton,
                                          Qt::NoModifier, point);
+
                        return obj;
                      }},
 


### PR DESCRIPTION
I managed to reproduce this issue with a small app that has a flickerable object + a loader + a stackView + a button.
After a few seconds, the issue can be reproduced. I did the following extra debugging steps:
- I logged out all the QT events (via `installEventFilter`) and a working sequence of events and a broken one are the same.
- I also checked all the properties of _all_ the chain of elements starting from the button, and they match in a working and a broken session.

Because of this, I suspect it's a race condition between the QT rendering thread and the main one. This issue goes away adding an extra timer before the click.

Why now? Because QmlPath makes our tests faster! We have reduced the number of operations using qmlPath and the property checks. So, for instance, instead of:
1. wait for the rendering of an element
2. wait for the visible=true property of that element
3. finally click on the element,

with qmlPath we can do it all in 1 step: wait for an element X with visiblity=true, then click on it.

This is a temporary solution. I'll file a bug to the Qt repo to inform them about this issue. I'll keep you posted!