### PR TITLE
Enable TC-Proxy on windows builds

### DIFF
--- a/taskcluster/ci/build/windows.yml
+++ b/taskcluster/ci/build/windows.yml
@@ -20,7 +20,7 @@ task-defaults:
         toolchain:
             - qt-win
     worker:
-        taskcluster-proxy: false
+        taskcluster-proxy: true
         chain-of-trust: true
         max-run-time: 3600
         artifacts:


### PR DESCRIPTION
## Description

On windows it still seems the CI is failing to fetch secrets. 
Debugging level 3 tasks is not really a thing so here's my theory. 
Get-Secrets is trying to get the TC-Instance via the env:
https://github.com/mozilla-mobile/mozilla-vpn-client/blob/main/taskcluster/scripts/get-secret.py#L48
But we did not set that - see latest main push params:
https://firefox-ci-tc.services.mozilla.com/tasks/cYij-t8aSbCx8DBjeVPZLA/definition

So let's enable the proxy-mode to have that env set.