### PR TITLE
Fix VPN-3548: Tooltips appearing when nav bar buttons are disabled

### DIFF
--- a/src/apps/vpn/ui/navigator/navigationBar/VPNBottomNavigationBar.qml
+++ b/src/apps/vpn/ui/navigator/navigationBar/VPNBottomNavigationBar.qml
@@ -92,6 +92,7 @@ Rectangle {
                 ButtonGroup.group: navBarButtonGroup
 
                 accessibleName: VPNl18n[navAccessibleName]
+                enabled: root.visible
 
                 Component.onCompleted: {
                     if(objectName === "navButton-messages") root.messagesNavButton = this


### PR DESCRIPTION
## Description

Fixes VPN-3548 (part of it, see thread for details) by disabling nav buttons when they are hidden. 


## Reference

VPN-3548

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
