### PR TITLE
Fix VPN-3565: Don't reorder language list after selecting language

### DIFF
--- a/src/apps/vpn/localizer.cpp
+++ b/src/apps/vpn/localizer.cpp
@@ -222,15 +222,6 @@ bool Localizer::loadLanguage(const QString& code) {
 
   m_locale = locale;
   emit localeChanged();
-
-  // Sorting languages.
-  beginResetModel();
-  Collator collator;
-  std::sort(m_languages.begin(), m_languages.end(),
-            std::bind(languageSort, std::placeholders::_1,
-                      std::placeholders::_2, &collator));
-  endResetModel();
-
   return true;
 }
 
@@ -404,6 +395,15 @@ QString Localizer::localizeCurrency(double value,
   }
 
   return locale.toCurrencyString(value, symbol);
+}
+
+void Localizer::sortLanguages() {
+  beginResetModel();
+  Collator collator;
+  std::sort(m_languages.begin(), m_languages.end(),
+            std::bind(languageSort, std::placeholders::_1,
+                      std::placeholders::_2, &collator));
+  endResetModel();
 }
 
 // static

--- a/src/apps/vpn/localizer.h
+++ b/src/apps/vpn/localizer.h
@@ -59,6 +59,8 @@ class Localizer final : public QAbstractListModel {
 
   QLocale locale() const { return m_locale; }
 
+  Q_INVOKABLE void sortLanguages();
+
   bool isRightToLeft() const;
 
   static QList<QPair<QString, QString>> parseBCP47Languages(

--- a/src/apps/vpn/ui/screens/settings/ViewPreferences.qml
+++ b/src/apps/vpn/ui/screens/settings/ViewPreferences.qml
@@ -95,7 +95,10 @@ VPNViewBase {
                 imageLeftSrc: "qrc:/ui/resources/settings/language.svg"
                 imageRightSrc: "qrc:/nebula/resources/chevron.svg"
                 imageRightMirror: VPNLocalizer.isRightToLeft
-                onClicked: stackview.push("qrc:/ui/screens/settings/ViewLanguage.qml")
+                onClicked: {
+                    VPNLocalizer.sortLanguages();
+                    stackview.push("qrc:/ui/screens/settings/ViewLanguage.qml")
+                }
                 visible: VPNLocalizer.hasLanguages
                 width: parent.width - VPNTheme.theme.windowMargin
             }


### PR DESCRIPTION
## Description

I don't love this. Very open to other approaches.
This prevents the language list from reordering itself back into alphabetical itself when switching between some languages. 

## Reference

VPN-3565

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
