### PR TITLE
Revert "Only show city name for multihop server names (#5442)"

### DIFF
--- a/nebula/ui/components/VPNConnectionInfoContent.qml
+++ b/nebula/ui/components/VPNConnectionInfoContent.qml
@@ -106,7 +106,7 @@ VPNFlickable {
                         VPNConnectionInfoItem {
                             id: entryServerLabel
                             title: serverLocations.isMultipHop
-                                ? VPNCurrentServer.localizedEntryCityName
+                                ? VPNServerCountryModel.getLocalizedCountryName(VPNCurrentServer.entryCountryCode)
                                 : ""
                             subtitle: ""
                             iconPath: serverLocations.isMultipHop
@@ -120,7 +120,6 @@ VPNFlickable {
 
                         VPNIcon {
                             id: arrowIcon
-                            anchors.horizontalCenter: parent.horizontalCenter
                             source: "qrc:/nebula/resources/arrow-forward-white.svg"
                             sourceSize {
                                 height: VPNTheme.theme.iconSize * 1.25
@@ -133,7 +132,9 @@ VPNFlickable {
                         }
 
                         VPNConnectionInfoItem {
-                            title: VPNCurrentServer.localizedExitCityName
+                            title: VPNServerCountryModel.getLocalizedCountryName(
+                                VPNCurrentServer.exitCountryCode
+                            )
                             subtitle: serverLocations.isMultipHop
                                 ? ""
                                 : VPNCurrentServer.localizedCityName


### PR DESCRIPTION
**Description:**

I originally cherry-picked this commit from `main` to bring the changes over to 2.13. For some reason, the 2.13 version of VPN did not like these changes at all and the CI screen looks a little funky even though it looks just fine in Main. 

So I am reverting this change in 2.13 and going to address the VPN-3639 bug in 2.13 specifically as a separate bug given that the fix seems to be entirely different from 2.14/main. 

Reverts mozilla-mobile/mozilla-vpn-client#5486

