### PR TITLE
VPN-2916 - Implement "time to main screen" metric

### DIFF
--- a/src/apps/vpn/commands/commandui.cpp
+++ b/src/apps/vpn/commands/commandui.cpp
@@ -110,6 +110,9 @@ CommandUI::~CommandUI() { MZ_COUNT_DTOR(CommandUI); }
 int CommandUI::run(QStringList& tokens) {
   Q_ASSERT(!tokens.isEmpty());
   return runQmlApp([&]() {
+    MozillaVPN vpn;
+    vpn.telemetry()->startTimeToFirstScreenTimer();
+
     QString appName = tokens[0];
 
     CommandLineParser::Option hOption = CommandLineParser::helpOption();
@@ -242,8 +245,6 @@ int CommandUI::run(QStringList& tokens) {
 
     // Cleanup previous temporary files.
     TemporaryDir::cleanupAll();
-
-    MozillaVPN vpn;
 
     vpn.setStartMinimized(minimizedOption.m_set ||
                           (qgetenv("MVPN_MINIMIZED") == "1"));
@@ -680,7 +681,6 @@ int CommandUI::run(QStringList& tokens) {
 #endif
 
     KeyRegenerator keyRegenerator;
-
     // Let's go.
     return qApp->exec();
   });

--- a/src/apps/vpn/commands/commandui.cpp
+++ b/src/apps/vpn/commands/commandui.cpp
@@ -681,7 +681,6 @@ int CommandUI::run(QStringList& tokens) {
 #endif
 
     KeyRegenerator keyRegenerator;
-    
     // Let's go.
     return qApp->exec();
   });

--- a/src/apps/vpn/commands/commandui.cpp
+++ b/src/apps/vpn/commands/commandui.cpp
@@ -681,6 +681,7 @@ int CommandUI::run(QStringList& tokens) {
 #endif
 
     KeyRegenerator keyRegenerator;
+    
     // Let's go.
     return qApp->exec();
   });

--- a/src/apps/vpn/main.cpp
+++ b/src/apps/vpn/main.cpp
@@ -4,15 +4,12 @@
 
 #include "commandlineparser.h"
 #include "leakdetector.h"
-#include "telemetry.h"
 
 Q_DECL_EXPORT int main(int argc, char* argv[]) {
 #ifdef MZ_DEBUG
   LeakDetector leakDetector;
   Q_UNUSED(leakDetector);
 #endif
-
-  Telemetry::startTimeToMainScreenTimer();
 
   CommandLineParser clp;
   return clp.parse(argc, argv);

--- a/src/apps/vpn/main.cpp
+++ b/src/apps/vpn/main.cpp
@@ -4,12 +4,15 @@
 
 #include "commandlineparser.h"
 #include "leakdetector.h"
+#include "telemetry.h"
 
 Q_DECL_EXPORT int main(int argc, char* argv[]) {
 #ifdef MZ_DEBUG
   LeakDetector leakDetector;
   Q_UNUSED(leakDetector);
 #endif
+
+  Telemetry::startTimeToMainScreenTimer();
 
   CommandLineParser clp;
   return clp.parse(argc, argv);

--- a/src/apps/vpn/mozillavpn.cpp
+++ b/src/apps/vpn/mozillavpn.cpp
@@ -941,7 +941,7 @@ void MozillaVPN::postAuthenticationCompleted() {
 void MozillaVPN::mainWindowLoaded() {
   logger.debug() << "main window loaded";
 
-  Telemetry::stopTimeToMainScreenTimer();
+  m_private->m_telemetry.stopTimeToFirstScreenTimer();
 
 #ifndef MZ_WASM
   // Initialize glean with an async call because at this time,

--- a/src/apps/vpn/mozillavpn.cpp
+++ b/src/apps/vpn/mozillavpn.cpp
@@ -45,6 +45,7 @@
 #include "tasks/sendfeedback/tasksendfeedback.h"
 #include "tasks/servers/taskservers.h"
 #include "taskscheduler.h"
+#include "telemetry.h"
 #include "telemetry/gleansample.h"
 #include "update/updater.h"
 #include "urlopener.h"
@@ -940,9 +941,12 @@ void MozillaVPN::postAuthenticationCompleted() {
 void MozillaVPN::mainWindowLoaded() {
   logger.debug() << "main window loaded";
 
+  Telemetry::stopTimeToMainScreenTimer();
+
 #ifndef MZ_WASM
-  // Initialize glean with an async call because at this time, QQmlEngine does
-  // not have root objects yet to see the current graphics API in use.
+  // Initialize glean with an async call because at this time,
+  // QQmlEngine does not have root objects yet to see the current
+  // graphics API in use.
   logger.debug() << "Initializing Glean";
   QTimer::singleShot(0, this, &MozillaVPN::initializeGlean);
 

--- a/src/apps/vpn/telemetry.cpp
+++ b/src/apps/vpn/telemetry.cpp
@@ -16,7 +16,10 @@ constexpr int CONNECTION_STABILITY_MSEC = 45000;
 
 namespace {
 Logger logger("Telemetry");
-}
+
+// The Glean timer id for the performance.time_to_main_screen metric.
+int s_timeToMainScreenTimerId = 0;
+}  // namespace
 
 Telemetry::Telemetry() {
   MZ_COUNT_CTOR(Telemetry);
@@ -128,6 +131,20 @@ void Telemetry::connectionStabilityEvent() {
        {"loss", QString::number(vpn->connectionHealth()->loss())},
        {"stddev", QString::number(vpn->connectionHealth()->stddev())},
        {"transport", vpn->networkWatcher()->getCurrentTransport()}});
+}
+
+void Telemetry::startTimeToMainScreenTimer() {
+  logger.info() << "Start performance.time_to_main_screen timer";
+
+  s_timeToMainScreenTimerId =
+      mozilla::glean::performance::time_to_main_screen.start();
+}
+
+void Telemetry::stopTimeToMainScreenTimer() {
+  logger.info() << "Stop performance.time_to_main_screen timer";
+
+  mozilla::glean::performance::time_to_main_screen.stopAndAccumulate(
+      s_timeToMainScreenTimerId);
 }
 
 #if defined(MZ_WINDOWS) || defined(MZ_LINUX) || defined(MZ_MACOS)

--- a/src/apps/vpn/telemetry.cpp
+++ b/src/apps/vpn/telemetry.cpp
@@ -16,9 +16,6 @@ constexpr int CONNECTION_STABILITY_MSEC = 45000;
 
 namespace {
 Logger logger("Telemetry");
-
-// The Glean timer id for the performance.time_to_main_screen metric.
-int s_timeToMainScreenTimerId = 0;
 }  // namespace
 
 Telemetry::Telemetry() {
@@ -133,18 +130,18 @@ void Telemetry::connectionStabilityEvent() {
        {"transport", vpn->networkWatcher()->getCurrentTransport()}});
 }
 
-void Telemetry::startTimeToMainScreenTimer() {
+void Telemetry::startTimeToFirstScreenTimer() {
   logger.info() << "Start performance.time_to_main_screen timer";
 
-  s_timeToMainScreenTimerId =
+  m_timeToFirstScreenTimerId =
       mozilla::glean::performance::time_to_main_screen.start();
 }
 
-void Telemetry::stopTimeToMainScreenTimer() {
+void Telemetry::stopTimeToFirstScreenTimer() {
   logger.info() << "Stop performance.time_to_main_screen timer";
 
   mozilla::glean::performance::time_to_main_screen.stopAndAccumulate(
-      s_timeToMainScreenTimerId);
+      m_timeToFirstScreenTimerId);
 }
 
 #if defined(MZ_WINDOWS) || defined(MZ_LINUX) || defined(MZ_MACOS)

--- a/src/apps/vpn/telemetry.h
+++ b/src/apps/vpn/telemetry.h
@@ -15,6 +15,9 @@ class Telemetry final : public QObject {
 
   void initialize();
 
+  static void startTimeToMainScreenTimer();
+  static void stopTimeToMainScreenTimer();
+
  private:
   void connectionStabilityEvent();
 #if defined(MZ_WINDOWS) || defined(MZ_LINUX) || defined(MZ_MACOS)

--- a/src/apps/vpn/telemetry.h
+++ b/src/apps/vpn/telemetry.h
@@ -15,8 +15,8 @@ class Telemetry final : public QObject {
 
   void initialize();
 
-  static void startTimeToMainScreenTimer();
-  static void stopTimeToMainScreenTimer();
+  void startTimeToFirstScreenTimer();
+  void stopTimeToFirstScreenTimer();
 
  private:
   void connectionStabilityEvent();
@@ -29,6 +29,9 @@ class Telemetry final : public QObject {
 #if defined(MZ_WINDOWS) || defined(MZ_LINUX) || defined(MZ_MACOS)
   QTimer m_gleanControllerUpTimer;
 #endif
+
+  // The Glean timer id for the performance.time_to_main_screen metric.
+  int m_timeToFirstScreenTimerId = 0;
 };
 
 #endif  // TELEMETRY_H

--- a/vpnglean/CMakeLists.txt
+++ b/vpnglean/CMakeLists.txt
@@ -148,6 +148,7 @@ add_custom_command(
         ${CMAKE_CURRENT_SOURCE_DIR}/glean_parser_ext/templates/macros.jinja2
         ${CMAKE_CURRENT_SOURCE_DIR}/glean_parser_ext/templates/rust_pings.jinja2
         ${CMAKE_CURRENT_SOURCE_DIR}/glean_parser_ext/templates/rust.jinja2
+        ${CMAKE_CURRENT_SOURCE_DIR}/metrics.yaml
         ${CMAKE_SOURCE_DIR}/glean/pings.yaml
         ${CMAKE_SOURCE_DIR}/glean/metrics.yaml
     COMMAND ${GENERATE_GLEAN_CMD}

--- a/vpnglean/glean_parser_ext/run_glean_parser.py
+++ b/vpnglean/glean_parser_ext/run_glean_parser.py
@@ -92,7 +92,7 @@ def create_dir(path):
 if __name__ == "__main__":
     argparser = argparse.ArgumentParser(
         description='Parse glean telemetry definitions and generate C++/Rust code')
-    
+
     argparser.add_argument('filename', metavar='FILE', type=str, nargs='?',
         help='Specific file to generate')
     argparser.add_argument('gleanargs', metavar='ARG', type=str, nargs='*',
@@ -110,35 +110,36 @@ if __name__ == "__main__":
         print("Generating Mozilla VPN Glean files.")
 
         yaml_files_path = os.path.join(workspace_root, "glean")
+        vpnglean_yaml_files_path = os.path.join(workspace_root, "vpnglean")
 
         os.makedirs(args.outdir, exist_ok=True)
 
         # Generate C++ header files
         for [ output, input ] in [
-            [os.path.join(args.outdir, "pings.h"), os.path.join(yaml_files_path, "pings.yaml")],
-            [os.path.join(args.outdir, "metrics.h"), os.path.join(yaml_files_path, "metrics.yaml")],
+            [os.path.join(args.outdir, "pings.h"), [os.path.join(yaml_files_path, "pings.yaml")]],
+            [os.path.join(args.outdir, "metrics.h"), [os.path.join(yaml_files_path, "metrics.yaml"), os.path.join(vpnglean_yaml_files_path, "metrics.yaml")]],
         ]:
             print("Generating {} from {}".format(output, input))
             with open(output, 'w+', encoding='utf-8') as f:
-                cpp_headers(f, input)
+                cpp_headers(f, *input)
 
         # Generate C++ source files
         for [ output, input ] in [
-            [os.path.join(args.outdir, "pings.cpp"), os.path.join(yaml_files_path, "pings.yaml")],
-            [os.path.join(args.outdir, "metrics.cpp"), os.path.join(yaml_files_path, "metrics.yaml")],
+            [os.path.join(args.outdir, "pings.cpp"), [os.path.join(yaml_files_path, "pings.yaml")]],
+            [os.path.join(args.outdir, "metrics.cpp"), [os.path.join(yaml_files_path, "metrics.yaml"), os.path.join(vpnglean_yaml_files_path, "metrics.yaml")]],
         ]:
             print("Generating {} from {}".format(output, input))
             with open(output, 'w+', encoding='utf-8') as f:
-                cpp_metrics(f, input)
+                cpp_metrics(f, *input)
 
         # Generate Rust files
         for [ output, input ] in [
-            [os.path.join(args.outdir, "pings.rs"), os.path.join(yaml_files_path, "pings.yaml")],
-            [os.path.join(args.outdir, "metrics.rs"), os.path.join(yaml_files_path, "metrics.yaml")],
+            [os.path.join(args.outdir, "pings.rs"), [os.path.join(yaml_files_path, "pings.yaml")]],
+            [os.path.join(args.outdir, "metrics.rs"), [os.path.join(yaml_files_path, "metrics.yaml"), os.path.join(vpnglean_yaml_files_path, "metrics.yaml")]],
         ]:
             print("Generating {} from {}".format(output, input))
             with open(output, 'w+', encoding='utf-8') as f:
-                rust_metrics(f, input)
+                rust_metrics(f, *input)
     else:
         # Guess language and operation from the file extension.
         file_split = os.path.splitext(args.filename)
@@ -149,7 +150,7 @@ if __name__ == "__main__":
             fn = cpp_metrics
             lang = 'c++'
         elif file_split[1] == '.h':
-            fp = cpp_headers 
+            fp = cpp_headers
             lang = 'c++'
         else:
             print(f'Unknown language for extension: "{file_split[1]}"', file=sys.stderr)

--- a/vpnglean/metrics.yaml
+++ b/vpnglean/metrics.yaml
@@ -1,0 +1,9 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# This file contains metrics definitions for metrics collected by the
+# Mozilla VPN application using only the vpnglean integration.
+
+---
+$schema: moz://mozilla.org/schemas/glean/metrics/2-0-0

--- a/vpnglean/metrics.yaml
+++ b/vpnglean/metrics.yaml
@@ -7,3 +7,19 @@
 
 ---
 $schema: moz://mozilla.org/schemas/glean/metrics/2-0-0
+
+performance:
+  time_to_main_screen:
+    type: timing_distribution
+    description: |
+      The time the app took between starting and rendering the main screen.
+    bugs:
+      - https://github.com/mozilla-mobile/mozilla-vpn-client/issues/4486
+    data_reviews:
+      - TODO
+    data_sensitivity:
+      - technical
+    notification_emails:
+      - brizental@mozilla.com
+    expires: never
+    time_unit: nanosecond

--- a/vpnglean/metrics.yaml
+++ b/vpnglean/metrics.yaml
@@ -22,4 +22,4 @@ performance:
     notification_emails:
       - brizental@mozilla.com
     expires: never
-    time_unit: nanosecond
+    time_unit: microsecond

--- a/vpnglean/metrics.yaml
+++ b/vpnglean/metrics.yaml
@@ -16,7 +16,7 @@ performance:
     bugs:
       - https://github.com/mozilla-mobile/mozilla-vpn-client/issues/4486
     data_reviews:
-      - TODO
+      - https://github.com/mozilla-mobile/mozilla-vpn-client/pull/5529#pullrequestreview-1253522353
     data_sensitivity:
       - technical
     notification_emails:


### PR DESCRIPTION
Still to do:

- [ ] Data review
- [ ] ~Add test (not sure if feasible)~
  - Neither `main()` nor the `MozillaVPN` singleton are available on tests. Feels unncessary to test the actual `Telemetry` functions so... No tests.

This is build on top of: https://github.com/mozilla-mobile/mozilla-vpn-client/pull/5523. The commits that matter for this PR are 047553d781399d4684c3503c12bcdc91b9b3b5b7 and a0094253b6ef675b5b283df8dd0a4231e5a4c06c.

This is based on: https://github.com/mozilla-mobile/mozilla-vpn-client/pull/4493 