### PR TITLE
If in multihop, then only show city names in the CI page

### DIFF
--- a/nebula/ui/components/VPNConnectionInfoContent.qml
+++ b/nebula/ui/components/VPNConnectionInfoContent.qml
@@ -106,7 +106,7 @@ VPNFlickable {
                         VPNConnectionInfoItem {
                             id: entryServerLabel
                             title: serverLocations.isMultipHop
-                                ? VPNServerCountryModel.getLocalizedCountryName(VPNCurrentServer.entryCountryCode)
+                                ? VPNCurrentServer.localizedEntryCityName
                                 : ""
                             subtitle: ""
                             iconPath: serverLocations.isMultipHop
@@ -120,6 +120,7 @@ VPNFlickable {
 
                         VPNIcon {
                             id: arrowIcon
+                            anchors.horizontalCenter: parent.horizontalCenter
                             source: "qrc:/nebula/resources/arrow-forward-white.svg"
                             sourceSize {
                                 height: VPNTheme.theme.iconSize * 1.25
@@ -132,9 +133,9 @@ VPNFlickable {
                         }
 
                         VPNConnectionInfoItem {
-                            title: VPNServerCountryModel.getLocalizedCountryName(
-                                VPNCurrentServer.exitCountryCode
-                            )
+                            title: serverLocations.isMultipHop
+                            ? VPNCurrentServer.localizedCityName
+                            : VPNServerCountryModel.getLocalizedCountryName(VPNCurrentServer.exitCountryCode);
                             subtitle: serverLocations.isMultipHop
                                 ? ""
                                 : VPNCurrentServer.localizedCityName


### PR DESCRIPTION
## Description

If in multihop, then only show city names in the CI page. This change does not affect the UI in single hop mode.

## Reference

    https://mozilla-hub.atlassian.net/browse/VPN-3639

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
