### PR TITLE
Do not change server name info in singlehop CI

### DIFF
--- a/nebula/ui/components/VPNConnectionInfoContent.qml
+++ b/nebula/ui/components/VPNConnectionInfoContent.qml
@@ -120,7 +120,9 @@ VPNFlickable {
                         }
 
                         VPNConnectionInfoItem {
-                            title: VPNCurrentServer.localizedExitCityName
+                            title: serverLocations.isMultipHop
+                            ? VPNCurrentServer.localizedExitCityName
+                            : VPNServerCountryModel.getLocalizedCountryName(VPNCurrentServer.exitCountryCode);
                             subtitle: serverLocations.isMultipHop
                                 ? ""
                                 : VPNCurrentServer.localizedExitCityName


### PR DESCRIPTION
## Description

This [PR](https://github.com/mozilla-mobile/mozilla-vpn-client/pull/5442) from last week unintentionally made changes to the single hop CI screen where we would only list the server city name twice instead of listing country AND city. This PR fixes that regression and maintains the fix for multihop where we only want to show the entry and exit city names (and not the countries).

## Reference

   https://mozilla-hub.atlassian.net/browse/VPN-3639

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
