### PR TITLE
Remove external references to http resources for benchmark tests - VPN-3879

### DIFF
--- a/src/apps/vpn/appconstants.h
+++ b/src/apps/vpn/appconstants.h
@@ -96,8 +96,6 @@ constexpr uint32_t BENCHMARK_MAX_DURATION_PING = 3000;
 constexpr uint32_t BENCHMARK_MAX_DURATION_TRANSFER = 15000;
 constexpr uint32_t BENCHMARK_THRESHOLD_SPEED_FAST = 25000000;    // 25 Megabit
 constexpr uint32_t BENCHMARK_THRESHOLD_SPEED_MEDIUM = 10000000;  // 10 Megabit
-constexpr const char* BENCHMARK_DOWNLOAD_URL =
-    "https://archive.mozilla.org/pub/vpn/speedtest/50m.data";
 
 #if defined(UNIT_TEST)
 #  define CONSTEXPR(type, functionName, releaseValue, debugValue, \
@@ -168,9 +166,18 @@ PRODBETAEXPR(QString, addonBaseUrl,
                  "MZ_ADDON_URL",
                  "https://mozilla-mobile.github.io/mozilla-vpn-client/addons/"))
 
+PRODBETAEXPR(QString, benchmarkDownloadUrl,
+             "https://archive.mozilla.org/pub/vpn/speedtest/50m.data",
+             Constants::envOrDefault(
+                 "MZ_BENCHMARK_DOWNLOAD_URL",
+                 "https://archive.mozilla.org/pub/vpn/speedtest/50m.data"));
+
 PRODBETAEXPR(
-    const char*, benchmarkUploadUrl, "https://benchmark.vpn.mozilla.org/upload",
-    "https://dev.vpn-network-benchmark.nonprod.webservices.mozgcp.net/upload");
+    QString, benchmarkUploadUrl, "https://benchmark.vpn.mozilla.org/upload",
+    Constants::envOrDefault(
+        "MZ_BENCHMARK_UPLOAD_URL",
+        "https://dev.vpn-network-benchmark.nonprod.webservices.mozgcp.net/"
+        "upload"));
 
 PRODBETAEXPR(
     const char*, balrogUrl,

--- a/src/apps/vpn/connectionbenchmark/connectionbenchmark.cpp
+++ b/src/apps/vpn/connectionbenchmark/connectionbenchmark.cpp
@@ -92,7 +92,7 @@ void ConnectionBenchmark::start() {
   // Create download benchmark
   BenchmarkTaskTransfer* downloadTask = new BenchmarkTaskTransfer(
       "BenchmarkTaskDownload", BenchmarkTaskTransfer::BenchmarkDownload,
-      m_downloadUrl);
+      AppConstants::benchmarkDownloadUrl());
   connect(downloadTask, &BenchmarkTaskTransfer::finished, this,
           &ConnectionBenchmark::downloadBenchmarked);
   connect(downloadTask->sentinel(), &BenchmarkTaskSentinel::sentinelDestroyed,
@@ -105,7 +105,7 @@ void ConnectionBenchmark::start() {
   if (Feature::get(Feature::Feature_benchmarkUpload)->isSupported()) {
     BenchmarkTaskTransfer* uploadTask = new BenchmarkTaskTransfer(
         "BenchmarkTaskUpload", BenchmarkTaskTransfer::BenchmarkUpload,
-        m_uploadUrl);
+        AppConstants::benchmarkUploadUrl());
     Q_UNUSED(uploadTask);
 
     connect(uploadTask, &BenchmarkTaskTransfer::finished, this,

--- a/src/apps/vpn/connectionbenchmark/connectionbenchmark.h
+++ b/src/apps/vpn/connectionbenchmark/connectionbenchmark.h
@@ -9,7 +9,6 @@
 #include <QObject>
 #include <QUrl>
 
-#include "appconstants.h"
 #include "benchmarktask.h"
 
 class ConnectionHealth;
@@ -18,10 +17,6 @@ class ConnectionBenchmark final : public QObject {
   Q_OBJECT;
   Q_DISABLE_COPY_MOVE(ConnectionBenchmark);
 
-  Q_PROPERTY(QString downloadUrl READ downloadUrl WRITE setDownloadUrl NOTIFY
-                 downloadUrlChanged)
-  Q_PROPERTY(QString uploadUrl READ uploadUrl WRITE setUploadUrl NOTIFY
-                 uploadUrlChanged)
   Q_PROPERTY(State state READ state NOTIFY stateChanged);
   Q_PROPERTY(Speed speed READ speed NOTIFY speedChanged);
   Q_PROPERTY(quint64 downloadBps READ downloadBps NOTIFY downloadBpsChanged);
@@ -58,26 +53,12 @@ class ConnectionBenchmark final : public QObject {
   quint64 downloadBps() const { return m_downloadBps; }
   quint64 uploadBps() const { return m_uploadBps; }
 
-  QString downloadUrl() const { return m_downloadUrl.toString(); }
-  void setDownloadUrl(QString url) {
-    m_downloadUrl.setUrl(url);
-    emit downloadUrlChanged();
-  }
-
-  QString uploadUrl() const { return m_uploadUrl.toString(); }
-  void setUploadUrl(QString url) {
-    m_uploadUrl.setUrl(url);
-    emit uploadUrlChanged();
-  }
-
  signals:
   void downloadBpsChanged();
   void pingLatencyChanged();
   void uploadBpsChanged();
   void speedChanged();
   void stateChanged();
-  void downloadUrlChanged();
-  void uploadUrlChanged();
 
  private:
   void downloadBenchmarked(quint64 bitsPerSec, bool hasUnexpectedError);
@@ -91,9 +72,6 @@ class ConnectionBenchmark final : public QObject {
   void stop();
 
  private:
-  QUrl m_downloadUrl = QUrl(AppConstants::BENCHMARK_DOWNLOAD_URL);
-  QUrl m_uploadUrl = QUrl(AppConstants::benchmarkUploadUrl());
-
   QList<BenchmarkTask*> m_benchmarkTasks;
 
   State m_state = StateInitial;

--- a/tests/functional/constants.js
+++ b/tests/functional/constants.js
@@ -9,5 +9,5 @@ module.exports = {
   WASM_PORT : 3002,
   ADDON_PORT : 3003,
   ADDON_URL : 'http://localhost:3003',
-  UPLOAD_BENCHMARK_PORT: 3004,
+  NETWORK_BENCHMARK_PORT : 3004,
 };

--- a/tests/functional/servers/networkBenchmark.js
+++ b/tests/functional/servers/networkBenchmark.js
@@ -11,17 +11,32 @@ let server = null;
 module.exports = {
   start(headerCheck = true) {
     server = new Server(
-        'VPN Network Benchmark', constants.UPLOAD_BENCHMARK_PORT, {
+        'VPN Network Benchmark', constants.NETWORK_BENCHMARK_PORT, {
+          GETs: {
+            '/': {
+              status: 200,
+              bodyRaw: new Array(1024).join('a'),
+              callback: req => {}
+            }
+          },
           POSTs: {
             '/': {status: 200, body: {}},
           },
         },
         headerCheck);
-    return constants.UPLOAD_BENCHMARK_PORT;
+    return constants.NETWORK_BENCHMARK_PORT;
   },
 
   stop() {
     server.stop();
+  },
+
+  get overrideEndpoints() {
+    return server.overrideEndpoints;
+  },
+
+  set overrideEndpoints(value) {
+    server.overrideEndpoints = value;
   },
 
   throwExceptionsIfAny() {

--- a/tests/functional/servers/server.js
+++ b/tests/functional/servers/server.js
@@ -52,7 +52,7 @@ class Server {
     }
   }
 
-  processRequest(req, res, paths, overriddenPaths) {
+  async processRequest(req, res, paths, overriddenPaths) {
     function findPath(path, paths) {
       if (path in paths) {
         return paths[path];
@@ -84,7 +84,7 @@ class Server {
       return;
     }
 
-    if (responseData.callback) responseData.callback(req);
+    if (responseData.callback) await responseData.callback(req);
 
     if (this._headerCheck) {
       for (let header of responseData.requiredHeaders || []) {

--- a/tests/functional/setupVpn.js
+++ b/tests/functional/setupVpn.js
@@ -65,8 +65,12 @@ exports.mochaHooks = {
     process.env['MZ_ADDON_URL'] =
         `http://localhost:${addonServer.start()}/01_empty_manifest/`;
     process.env['MVPN_SKIP_ADDON_SIGNATURE'] = '1';
-    process.env['MVPN_BENCHMARK_URL'] =
-        `http://localhost:${networkBenchmark.start()}`;
+
+    const networkBenchmarkPort = networkBenchmark.start();
+    process.env['MZ_BENCHMARK_DOWNLOAD_URL'] =
+        `http://localhost:${networkBenchmarkPort}`;
+    process.env['MZ_BENCHMARK_UPLOAD_URL'] =
+        `http://localhost:${networkBenchmarkPort}`;
   },
 
   async afterAll() {
@@ -88,6 +92,7 @@ exports.mochaHooks = {
 
       guardian.overrideEndpoints = null;
       fxaServer.overrideEndpoints = null;
+      networkBenchmark.overrideEndpoints = null;
 
       await startAndConnect();
       await vpn.reset();
@@ -107,6 +112,8 @@ exports.mochaHooks = {
         this.currentTest.ctx.guardianOverrideEndpoints || null;
     fxaServer.overrideEndpoints =
         this.currentTest.ctx.fxaOverrideEndpoints || null;
+    networkBenchmark.overrideEndpoints =
+        this.currentTest.ctx.networkBenchmarkOverrideEndpoints || null;
 
     if (this.currentTest.ctx.authenticationNeeded) {
       fs.writeFileSync(

--- a/tests/functional/setupWasm.js
+++ b/tests/functional/setupWasm.js
@@ -70,6 +70,8 @@ exports.mochaHooks = {
         this.currentTest.ctx.guardianOverrideEndpoints || null;
     fxaServer.overrideEndpoints =
         this.currentTest.ctx.fxaOverrideEndpoints || null;
+    networkBenchmark.overrideEndpoints =
+        this.currentTest.ctx.networkBenchmarkOverrideEndpoints || null;
 
     await startAndConnect();
     await vpn.setGleanAutomationHeader();

--- a/wasm/test.html
+++ b/wasm/test.html
@@ -76,7 +76,8 @@ function init() {
         MZ_FXA_API_BASE_URL: u.searchParams.get('fxa'),
         MZ_ADDON_URL: u.searchParams.get('addon'),
         MVPN_SKIP_ADDON_SIGNATURE: '1',
-        MVPN_BENCHMARK_URL: u.searchParams.get('benchmark'),
+        MZ_BENCHMARK_DOWNLOAD_URL: u.searchParams.get('benchmark'),
+        MZ_BENCHMARK_UPLOAD_URL: u.searchParams.get('benchmark'),
       }
     });
     qtLoader.loadEmscriptenModule('mozillavpn');
@@ -88,17 +89,6 @@ function mvpnNetworkRequest(id, method, url, body) {
   if (url.endsWith("/success.txt")) {
     setTimeout(() => {
             Module.mvpnNetworkResponse(id, JSON.stringify({status: 200, body: btoa('success')})); }, 200);
-    return;
-  }
-
-  if (url === "https://archive.mozilla.org/pub/vpn/speedtest/50m.data") {
-    // 50mb of data is too much to be handled in the browser.
-   setTimeout(() => Module.mvpnNetworkResponse(id, JSON.stringify({ status: 200, body: btoa(String.fromCharCode.apply(null, new Uint8Array(1024))) })), 1000);
-    return;
-  }
-
-  if (url == "https://dev.vpn-network-benchmark.nonprod.webservices.mozgcp.net/upload") {
-   setTimeout(() => Module.mvpnNetworkResponse(id, JSON.stringify({ status: 200, body: ""})), 1000);
     return;
   }
 


### PR DESCRIPTION
Why: functional tests should run offline. The main blocker is the benchmark test because it uses external resources such as archive.m.o and httpstats.us. With this PR, I remove these dependencies.