### PR TITLE
VPN-3705 - Close websocket when mobile app goes to the background

### DIFF
--- a/src/apps/vpn/websocket/websockethandler.h
+++ b/src/apps/vpn/websocket/websockethandler.h
@@ -60,6 +60,7 @@ class WebSocketHandler final : public QObject {
   ExponentialBackoffStrategy m_backoffStrategy;
 
   bool m_aboutToClose = false;
+  bool m_initialized = false;
 
   static QString s_customWebSocketServerUrl;
 };


### PR DESCRIPTION
tl;dr; Turns out websocket is not closed when mobile applications go to the background. They go into this gray area "suspended" state and connection may or may not be resumed once the app is back on the foreground. So now we close and reopen manually on mobile when the app is backgrounded / foregrounded.

See more on: https://developer.apple.com/library/archive/technotes/tn2277/_index.html