### PR TITLE
Fix VPN-3565: use localeAwareCompare(a,b) to order languages list

### DIFF
--- a/src/apps/vpn/collator.cpp
+++ b/src/apps/vpn/collator.cpp
@@ -38,6 +38,6 @@ int Collator::compare(const QString& a, const QString& b) {
                               b.toLocal8Bit().constData(),
                               languageCode.toLocal8Bit().constData());
 #else
-  return m_collator.compare(a, b);
+  return QString::localeAwareCompare(a, b);
 #endif
 }

--- a/src/apps/vpn/collator.h
+++ b/src/apps/vpn/collator.h
@@ -17,9 +17,6 @@ class Collator final : public QObject {
   ~Collator() = default;
 
   int compare(const QString& a, const QString& b);
-
- private:
-  QCollator m_collator;
 };
 
 #endif  // COLLATOR_H


### PR DESCRIPTION
## Description

    Describe your changes

## Reference

VPN-3565

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
