### PR TITLE
VPN-3541 Obfuscate subscription data (2.13 fix)

### DIFF
--- a/src/shared/settingsholder.cpp
+++ b/src/shared/settingsholder.cpp
@@ -21,11 +21,11 @@ namespace {
 Logger logger("SettingsHolder");
 
 // Setting Keys That won't show up in a report;
-QVector<QString> SENSITIVE_SETTINGS({
-    "token", "privateKey",
-    "servers",  // Those 2 are not sensitive but
-    "devices",  // are more noise then info
-});
+QVector<QString> SENSITIVE_SETTINGS(
+    {"token", "privateKey",
+     "servers",  // Those 2 are not sensitive but
+     "devices",  // are more noise then info
+     "subscriptionData", "subscriptionTransactions"});
 
 SettingsHolder* s_instance = nullptr;
 


### PR DESCRIPTION
Note this is the simple fix being applied for 2.13. A more robust fix is implemented in PR #5526 for 2.14 and later.
