### PR TITLE
Actually generate 10MB of data for the upload benchmark (VPN-3561)

### DIFF
--- a/src/apps/vpn/appconstants.h
+++ b/src/apps/vpn/appconstants.h
@@ -44,7 +44,7 @@ constexpr int RECENT_CONNECTIONS_MAX_COUNT = 2;
 constexpr uint32_t SERVER_UNRESPONSIVE_COOLDOWN_SEC = 300;
 
 // Number of msecs for max runtime of the connection benchmarks.
-constexpr uint32_t BENCHMARK_MAX_BITS_UPLOAD = 80000000;  // 10 Megabyte
+constexpr uint32_t BENCHMARK_MAX_BYTES_UPLOAD = 10485760;  // 10 Megabyte
 constexpr uint32_t BENCHMARK_MAX_DURATION_PING = 3000;
 constexpr uint32_t BENCHMARK_MAX_DURATION_TRANSFER = 15000;
 constexpr uint32_t BENCHMARK_THRESHOLD_SPEED_FAST = 25000000;    // 25 Megabit

--- a/src/apps/vpn/connectionbenchmark/benchmarktasktransfer.cpp
+++ b/src/apps/vpn/connectionbenchmark/benchmarktasktransfer.cpp
@@ -79,7 +79,7 @@ void BenchmarkTaskTransfer::createNetworkRequest() {
     }
     case BenchmarkUpload: {
       UploadDataGenerator* uploadData =
-          new UploadDataGenerator(AppConstants::BENCHMARK_MAX_BITS_UPLOAD);
+          new UploadDataGenerator(AppConstants::BENCHMARK_MAX_BYTES_UPLOAD);
 
       if (!uploadData->open(UploadDataGenerator::ReadOnly)) {
         emit finished(0, true);
@@ -108,7 +108,7 @@ void BenchmarkTaskTransfer::createNetworkRequestWithRecord(
     }
     case BenchmarkUpload: {
       UploadDataGenerator* uploadData =
-          new UploadDataGenerator(AppConstants::BENCHMARK_MAX_BITS_UPLOAD);
+          new UploadDataGenerator(AppConstants::BENCHMARK_MAX_BYTES_UPLOAD);
 
       if (!uploadData->open(UploadDataGenerator::ReadOnly)) {
         emit finished(0, true);


### PR DESCRIPTION
## Description

After adjustments to the _VPN Network Benchmark_ ([PR #10](https://github.com/mozilla-services/vpn-network-benchmark/pull/10)) where we limit the data that can be uploaded per request to `10MB` I noticed that the `BenchmarkUpload` unintentionally generates `~80MB`. This results in a `QNetworkReply::RemoteHostClosedError` and is the expected behaviour of the benchmark microservice.

With the _VPN Network Benchmark_ now being deployed to prod and with the `UploadDataGenerator` as of this change actually generating `10MB` the speed test within the VPN should now run fine for stage and prod.

## Reference

- Jira [VPN-3561](https://mozilla-hub.atlassian.net/browse/VPN-3561): Unexpected error at CI screen access


[VPN-3561]: https://mozilla-hub.atlassian.net/browse/VPN-3561?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ