### PR TITLE
Fix a race condition in the Addon unit test - VPN-3904

### DIFF
--- a/tests/unit/testaddon.cpp
+++ b/tests/unit/testaddon.cpp
@@ -401,6 +401,8 @@ void TestAddon::conditionWatcher_featuresEnabled() {
 }
 
 void TestAddon::conditionWatcher_group() {
+  SettingsHolder::instance()->setInstallationTime(QDateTime::currentDateTime());
+
   QObject parent;
   AddonConditionWatcher* acw1 =
       AddonConditionWatcherTriggerTimeSecs::maybeCreate(&parent, 1);
@@ -865,8 +867,6 @@ void TestAddon::message_notification_data() {
   TestHelper::resetLastSystemNotification();
   // Message is created for the first time,
   // but user is not logged in, no  message sent
-  static_cast<AddonMessage*>(
-      Addon::create(&parent, ":/addons_test/message1.json"));
   QTest::addRow("not-logged-in")
       << QString() << QString() << TestHelper::lastSystemNotification.title
       << TestHelper::lastSystemNotification.message;


### PR DESCRIPTION
If the unit-test runs slow, it can happen that the installation time is < 1 second. We need to reset the installation time before running the time-conditional addons

VPN-3904