### PR TITLE
VPN-3614: Tutorial content changes

### DIFF
--- a/addons/tutorial_03_multi_hop/manifest.json
+++ b/addons/tutorial_03_multi_hop/manifest.json
@@ -13,7 +13,7 @@
     "title": "Using multi-hop VPN",
     "settings_rollback_needed": true,
     "subtitle": "Follow this walkthrough to learn how to use multi-hop VPN.",
-    "completion_message": "You’ve turned on multi-hop VPN and changed your exit location. Would you like to see more tips and tricks?",
+    "completion_message": "You’ve learned how to use multi-hop VPN and change your exit location. Would you like to learn more tips and tricks?",
     "steps": [
       {
         "id": "s1",

--- a/nebula/ui/components/VPNTutorialPopups.qml
+++ b/nebula/ui/components/VPNTutorialPopups.qml
@@ -257,7 +257,7 @@ Item {
         }
 
         tutorialPopup.primaryButtonText = VPNl18n.TutorialPopupTutorialLeavePrimaryButtonLabel;
-        tutorialPopup.secondaryButtonText = VPNl18n.TutorialPopupSecondaryButtonLabel;
+        tutorialPopup.secondaryButtonText = VPNl18n.TutorialPopupTutorialFinishedSecondaryButtonLabel;
         tutorialPopup.title = VPNl18n.TutorialPopupTutorialLeaveHeadline;
         tutorialPopup.description = VPNl18n.TutorialPopupTutorialLeaveSubtitle;
         tutorialPopup.open();
@@ -300,7 +300,7 @@ Item {
             tutorialPopup.primaryButtonOnClicked = () => openTipsAndTricks();
             tutorialPopup.primaryButtonText = VPNl18n.TutorialPopupTutorialCompletePrimaryButtonLabel;
             tutorialPopup.secondaryButtonOnClicked = () => tutorialPopup.close();
-            tutorialPopup.secondaryButtonText = VPNl18n.TutorialPopupSecondaryButtonLabel
+            tutorialPopup.secondaryButtonText = VPNl18n.TutorialPopupTutorialFinishedSecondaryButtonLabel
             tutorialPopup.title =  VPNl18n.TutorialPopupTutorialCompleteHeadline;
             tutorialPopup.description = tutorial.completionMessage;
             tutorialPopup._onClosed = () => {};

--- a/translations/strings.yaml
+++ b/translations/strings.yaml
@@ -718,7 +718,7 @@ paymentMethods:
 tutorialPopup:
   tutorialCompleteHeadline: Well done!
   tutorialCompletePrimaryButtonLabel: Let’s go!
-  secondaryButtonLabel: Come back later
+  secondaryButtonLabel: Dismiss
   leaveTutorialButton: Leave tutorial
 
   tutorialLeaveHeadline: Leave tutorial?

--- a/translations/strings.yaml
+++ b/translations/strings.yaml
@@ -718,7 +718,7 @@ paymentMethods:
 tutorialPopup:
   tutorialCompleteHeadline: Well done!
   tutorialCompletePrimaryButtonLabel: Let’s go!
-  secondaryButtonLabel: Dismiss
+  tutorialFinishedSecondaryButtonLabel: Dismiss
   leaveTutorialButton: Leave tutorial
 
   tutorialLeaveHeadline: Leave tutorial?


### PR DESCRIPTION
## Description

- Change the completion text for the multi hop tutorial on the tutorial completion modal
- Change secondary button text on the tutorial completion modal

## Reference

[VPN-3614: Confusing text in the “Well done” Multi-hop tutorial modal](https://mozilla-hub.atlassian.net/browse/VPN-3614)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
