### PR TITLE
Do not treat settings reset as a location change - VPN-3293

### DIFF
--- a/nebula/ui/components/VPNRecentConnections.qml
+++ b/nebula/ui/components/VPNRecentConnections.qml
@@ -11,10 +11,12 @@ import Mozilla.VPN 1.0
 import Mozilla.VPN.qmlcomponents 1.0
 
 ColumnLayout {
+    id: root
+
     property bool hasVisibleConnections: false
     property bool showMultiHopRecentConnections: true
     property real numVisibleConnections: recentConnectionsRepeater.count
-    property var recentConnectionsModel: showMultiHopRecentConnections ? VPNRecentConnections.multiHopModel : VPNRecentConnections.singleHopModel
+    property var recentConnectionsModel: showMultiHopRecentConnections ? VPNRecentConnectionsModel.multiHopModel : VPNRecentConnectionsModel.singleHopModel
 
     function focusItemAt(idx) {
         if (!visible) {
@@ -40,8 +42,6 @@ ColumnLayout {
         return list;
     }
 
-    id: root
-
     spacing: VPNTheme.theme.windowMargin / 2
     visible: !root.recentConnectionsModel.isEmpty
 
@@ -50,7 +50,6 @@ ColumnLayout {
     }
 
     VPNBoldLabel {
-        id: recentConnectionsHeader
         text: VPNl18n.MultiHopFeatureMultiHopConnectionsHeader
         Layout.leftMargin: VPNTheme.theme.windowMargin
         Layout.minimumHeight: VPNTheme.theme.vSpacing
@@ -60,8 +59,6 @@ ColumnLayout {
     }
 
     ColumnLayout {
-        id: connectionsCol
-
         spacing: VPNTheme.theme.windowMargin / 2
         Layout.fillWidth: true
 
@@ -71,8 +68,6 @@ ColumnLayout {
             id: recentConnectionsRepeater
             model: root.recentConnectionsModel
             delegate: VPNClickableRow {
-                id: del
-
                 accessibleName: isMultiHop ?
                     VPNl18n.MultiHopFeatureAccessibleNameRecentConnection
                         .arg(localizedEntryCityName).arg(localizedExitCityName)

--- a/src/apps/vpn/commands/commandui.cpp
+++ b/src/apps/vpn/commands/commandui.cpp
@@ -375,7 +375,7 @@ int CommandUI::run(QStringList& tokens) {
         });
 
     qmlRegisterSingletonType<MozillaVPN>(
-        "Mozilla.VPN", 1, 0, "VPNRecentConnections",
+        "Mozilla.VPN", 1, 0, "VPNRecentConnectionsModel",
         [](QQmlEngine*, QJSEngine*) -> QObject* {
           QObject* obj = RecentConnections::instance();
           QQmlEngine::setObjectOwnership(obj, QQmlEngine::CppOwnership);

--- a/src/apps/vpn/models/recentconnections.cpp
+++ b/src/apps/vpn/models/recentconnections.cpp
@@ -95,6 +95,7 @@ bool RecentConnections::migrate() {
 }
 
 void RecentConnections::serverChanged() {
+  logger.info() << "server changed";
   ServerData* sd = MozillaVPN::instance()->currentServer();
 
   RecentConnection newRecentConnection{

--- a/src/apps/vpn/models/serverdata.cpp
+++ b/src/apps/vpn/models/serverdata.cpp
@@ -151,6 +151,7 @@ bool ServerData::settingsChanged() {
   }
 
   emit changed();
+  emit retranslationNeeded();
   return true;
 }
 

--- a/src/apps/vpn/models/serverdata.h
+++ b/src/apps/vpn/models/serverdata.h
@@ -18,28 +18,20 @@ class ServerData final : public QObject {
 
   Q_PROPERTY(QString exitCountryCode READ exitCountryCode NOTIFY changed)
   Q_PROPERTY(QString exitCityName READ exitCityName NOTIFY changed)
-  Q_PROPERTY(
-      QString localizedExitCityName READ localizedExitCityName NOTIFY changed)
-  Q_PROPERTY(QString localizedExitCountryName READ localizedExitCountryName
-                 NOTIFY changed)
+  Q_PROPERTY(QString localizedExitCountryName READ localizedExitCountryName NOTIFY retranslationNeeded)
+  Q_PROPERTY( QString localizedExitCityName READ localizedExitCityName NOTIFY retranslationNeeded)
 
   Q_PROPERTY(bool multihop READ multihop NOTIFY changed)
 
   Q_PROPERTY(QString entryCountryCode READ entryCountryCode NOTIFY changed)
   Q_PROPERTY(QString entryCityName READ entryCityName NOTIFY changed)
-  Q_PROPERTY(
-      QString localizedEntryCityName READ localizedEntryCityName NOTIFY changed)
-  Q_PROPERTY(QString localizedEntryCountryName READ localizedEntryCountryName
-                 NOTIFY changed)
+  Q_PROPERTY(QString localizedEntryCountryName READ localizedEntryCountryName NOTIFY retranslationNeeded)
+  Q_PROPERTY( QString localizedEntryCityName READ localizedEntryCityName NOTIFY retranslationNeeded)
 
-  Q_PROPERTY(QString previousExitCountryCode READ previousExitCountryCode NOTIFY
-                 changed)
-  Q_PROPERTY(QString localizedPreviousExitCountryName READ
-                 localizedPreviousExitCountryName NOTIFY changed)
-  Q_PROPERTY(QString localizedPreviousExitCityName READ
-                 localizedPreviousExitCityName NOTIFY changed)
-  Q_PROPERTY(
-      QString previousExitCityName READ previousExitCityName NOTIFY changed)
+  Q_PROPERTY(QString previousExitCountryCode READ previousExitCountryCode NOTIFY changed)
+  Q_PROPERTY( QString previousExitCityName READ previousExitCityName NOTIFY changed)
+  Q_PROPERTY(QString localizedPreviousExitCountryName READ localizedPreviousExitCountryName NOTIFY retranslationNeeded)
+  Q_PROPERTY(QString localizedPreviousExitCityName READ localizedPreviousExitCityName NOTIFY retranslationNeeded)
 
  public:
   ServerData();
@@ -85,7 +77,7 @@ class ServerData final : public QObject {
               const QString& entryCountryCode = QString(),
               const QString& entryCityName = QString());
 
-  void retranslate() { emit changed(); }
+  void retranslate() { emit retranslationNeeded(); }
 
   void setEntryServerPublicKey(const QString& publicKey);
   void setExitServerPublicKey(const QString& publicKey);
@@ -95,6 +87,7 @@ class ServerData final : public QObject {
 
  signals:
   void changed();
+  void retranslationNeeded();
 
  private:
   bool settingsChanged();


### PR DESCRIPTION
VPN-3293

    Note that this could be reproducible via a simple logout.  The bug is in the
    retranslate request (ServerData::changed signal) when the language code changes
    because of a setting reset.  The signal is received by the RecentConnection
    model, which adds the "new" server location to its lists.
    
    This PR renames VPNRecentConnections to VPNRecentConnectionsModel to avoid
    conflicts with a nebula QML component.
