### PR TITLE
l10n linter: regenerate ts files, include add-ons

### DIFF
--- a/.github/l10n/check_l10n_issues.py
+++ b/.github/l10n/check_l10n_issues.py
@@ -3,63 +3,83 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+from collections import defaultdict
+from glob import glob
 import xml.etree.ElementTree as etree
 import json
 import os
 import sys
 
 script_folder = os.path.abspath(os.path.dirname(__file__))
-vpn_root_folder = os.path.join(script_folder, os.pardir, os.pardir)
+vpn_root_folder = os.path.realpath(os.path.join(script_folder, os.pardir, os.pardir))
 
-# Extract all strings in the .ts file
-srcFile = os.path.join(vpn_root_folder, "translations", "generated", "dummy.pro")
-os.system(f"lupdate {srcFile} -ts")
+# Paths are relative to the root folder
+paths = [
+    "translations.ts",
+    "addon_ts/*.ts",
+]
+
+# Get a list of files to analyze
+files = []
+for p in paths:
+    for f in glob(f"{vpn_root_folder}/{p}", recursive=False):
+        files.append(f)
+files.sort()
 
 # Load the exceptions file. String IDs can be added to each category to
 # ignore errors.
 with open(os.path.join(script_folder, "exceptions.json")) as f:
     exceptions = json.load(f)
 
-# Load the .ts file
-ts_file = os.path.join(vpn_root_folder, "translations", "generated", "mozillavpn_en.ts")
-tree = etree.parse(ts_file)
-root = tree.getroot()
-
 misused_characters = {
     "'": "Invalid character ' in string. Use a typographic apostrophe ’ instead, or add an exception.",
     '"': 'Invalid character " in string. Use typographic quotes “” instead, or add an exception.',
     "...": 'Invalid "..." in string: use proper ellipsis (…) instead.',
 }
-errors = {}
-for message in root.findall(".//message"):
-    message_id = message.get("id")
-    source_text = message.find("./source").text
-    source_comment = (
-        message.find("./extracomment").text
-        if message.find("./extracomment") is not None
-        else ""
-    )
+errors = defaultdict(dict)
 
-    # Check if there are misused characters in the strings
-    if message_id not in exceptions["characters"]:
-        for character in misused_characters.keys():
-            if character in source_text:
-                errors[message_id] = misused_characters[character]
+for f in files:
+    relative_filename = os.path.relpath(f, vpn_root_folder)
+    # Load the .ts file
+    ts_file = os.path.join(f)
+    tree = etree.parse(ts_file)
+    root = tree.getroot()
 
-    # Check if the string is empty
-    if message_id not in exceptions["empty"]:
-        if source_text == "":
-            errors[message_id] = "String should not be empty."
+    for message in root.findall(".//message"):
+        message_id = message.get("id")
+        source_text = message.find("./source").text
+        source_comment = (
+            message.find("./extracomment").text
+            if message.find("./extracomment") is not None
+            else ""
+        )
+        print(f, message_id)
 
-    # Check if there are variables in the string but no comments
-    if message_id not in exceptions["comments"]:
-        if "%" in source_text and source_comment == "":
-            errors[message_id] = "Strings with variables should always have a comment."
+        # Check if there are misused characters in the strings
+        if message_id not in exceptions["characters"]:
+            for character in misused_characters.keys():
+                if character in source_text:
+                    errors[relative_filename][message_id] = misused_characters[
+                        character
+                    ]
+
+        # Check if the string is empty
+        if message_id not in exceptions["empty"]:
+            if source_text == "":
+                errors[relative_filename][message_id] = "String should not be empty."
+
+        # Check if there are variables in the string but no comments
+        if message_id not in exceptions["comments"]:
+            if "%" in source_text and source_comment == "":
+                errors[relative_filename][
+                    message_id
+                ] = "Strings with variables should always have a comment."
 
 if errors:
     print("\n----\nERRORS:")
-    for message_id, error in errors.items():
-        print(f"{message_id}:\n  {error}")
+    for filename, errors in errors.items():
+        for message_id, error in errors.items():
+            print(f"{message_id} ({filename}):\n  {error}")
     sys.exit(1)
 else:
     print("\nNo errors found.")

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -5,7 +5,10 @@ on:
     branches:
       - main
       - 'releases/**'
-    types: [ opened, synchronize, reopened ]
+    types:
+      - opened
+      - synchronize
+      - reopened
 
 jobs:
   linter:
@@ -46,10 +49,10 @@ jobs:
           export PATH=/opt/$QTVERSION/gcc_64/bin:$PATH
           python3 scripts/utils/import_languages.py
 
-      - name: Check for l10n errors
+      - name: Generate updated .ts files and check for l10n errors
         run: |
           export PATH=/opt/$QTVERSION/gcc_64/bin:$PATH
-          lupdate -version
+          ./scripts/utils/generate_ts.sh
           python .github/l10n/check_l10n_issues.py
 
       - name: Check for QRC errors
@@ -100,7 +103,7 @@ jobs:
           python3 -m pip install aqtinstall
           # qt6.2.4 for wasm needs the desktop linux installation
           python3 -m aqt install-qt -O /opt linux desktop 6.2.4
-      - name: Run Lint 
+      - name: Run Lint
         shell: bash
         env:
           QT_HOST_PATH: /opt/6.2.4/gcc_64
@@ -108,6 +111,6 @@ jobs:
           PR_NUMBER: ${{ github.event.number }}
         run: |
           # Only check the files changed in the current pr
-          ./scripts/utils/lint_qml.sh -pr -s 
+          ./scripts/utils/lint_qml.sh -pr -s
 
-        
+


### PR DESCRIPTION
## Description

This removes the `lupdate` command from the Python script, and use the full `generate_ts.sh` script to extract string for both the main app and the add-ons. Then checks all these files for l10n errors.

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
