### PR TITLE
Remove center anchor for the multihop arrow

### DIFF
--- a/nebula/ui/components/VPNConnectionInfoContent.qml
+++ b/nebula/ui/components/VPNConnectionInfoContent.qml
@@ -107,7 +107,6 @@ VPNFlickable {
 
                         VPNIcon {
                             id: arrowIcon
-                            anchors.horizontalCenter: parent.horizontalCenter
                             source: "qrc:/nebula/resources/arrow-forward-white.svg"
                             sourceSize {
                                 height: VPNTheme.theme.iconSize * 1.25


### PR DESCRIPTION
## Description

    Remove anchor for the arrow to prevent overlapping 
    server location and arrow in case of longer location names

![Screenshot 2023-01-19 at 8 56 07 AM](https://user-images.githubusercontent.com/3746552/213526540-5475f179-ae2d-4575-991b-2d564b1e1218.png)


## Reference

   https://mozilla-hub.atlassian.net/browse/VPN-3945

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
