### PR TITLE
Re-enable caches for mac/iOS builds

### DIFF
--- a/taskcluster/ci/build/ios.yml
+++ b/taskcluster/ci/build/ios.yml
@@ -21,6 +21,6 @@ ios/debug:
         - MozillaVPN.tar.gz
     run:
         using: run-task
-        use-caches: false
+        use-caches: true
         cwd: '{checkout}'
         command: ./taskcluster/scripts/build/ios_build_no_adjust.sh

--- a/taskcluster/ci/build/macos.yml
+++ b/taskcluster/ci/build/macos.yml
@@ -25,7 +25,7 @@ task-defaults:
         - MozillaVPN.tar.gz
     run:
         using: run-task
-        use-caches: false
+        use-caches: true
         cwd: '{checkout}'
         command: ./taskcluster/scripts/build/macos_build.sh
 


### PR DESCRIPTION
While looking through the taskcluster code I happened to notice that caches were disabled for these builds. According to https://github.com/mozilla-mobile/mozilla-vpn-client/commit/5fe653860a0562651c7a60cb43cd3a5583dd4e40, the Mac one was disabled due to https://github.com/taskcluster/taskcluster/issues/5396, which I believe is now fixed and deployed? I assume it's off for iOS for the same reason, although those builds were added after the issue first came up so I'm not certain.