### PR TITLE
Set the installation time in all the timing-related unit-test - VPN-3904

### DIFF
--- a/tests/unit/testaddon.cpp
+++ b/tests/unit/testaddon.cpp
@@ -447,6 +447,8 @@ void TestAddon::conditionWatcher_group() {
 }
 
 void TestAddon::conditionWatcher_triggerTime() {
+  SettingsHolder::instance()->setInstallationTime(QDateTime::currentDateTime());
+
   QObject parent;
   AddonConditionWatcher* acw =
       AddonConditionWatcherTriggerTimeSecs::maybeCreate(&parent, 1);


### PR DESCRIPTION
There is another similar issue to what you reviewed a few days ago. If the unit-test runs too slow, the addon+conditional watcher set to 1 sec, fails.