### PR TITLE
Sometimes MOZILLAVPN_HEAD_REF is a full ref, just use it

### DIFF
--- a/taskcluster/scripts/build/source.sh
+++ b/taskcluster/scripts/build/source.sh
@@ -6,6 +6,8 @@
 
 if [[ -n "$PULL_REQUEST_NUMBER" ]]; then
     GITREF="refs/pull/${PULL_REQUEST_NUMBER}/merge"
+elif [[ "$MOZILLAVPN_HEAD_REF" =~ ^refs/heads/ ]]; then
+    GITREF="$MOZILLAVPN_HEAD_REF"
 elif [[ "$MOZILLAVPN_HEAD_REF" =~ ^releases.([0-9][^/]*) ]]; then
     GITREF="refs/heads/releases/${BASH_REMATCH[1]}"
 else


### PR DESCRIPTION
## Description
In PR #5607 we added some logic to help taskcluster reconstruct the gitref when we are on a branch or PR, but this didnt quite work as expected on push to main, where we wind up being given a full ref to the destination branch (eg: `refs/heads/main` instead of just `main`). Check for this occurrence, and just use the value of `$MOZILLAVPN_HEAD_REF` in these cases.

## Reference
Github PR #5607
Github #5516 ([VPN-3735](https://mozilla-hub.atlassian.net/browse/VPN-3735))

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed


[VPN-3735]: https://mozilla-hub.atlassian.net/browse/VPN-3735?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ