### PR TITLE
VPN-2529: Fetch recommended servers

### DIFF
--- a/nebula/ui/components/VPNServerCountry.qml
+++ b/nebula/ui/components/VPNServerCountry.qml
@@ -19,7 +19,7 @@ VPNClickableRow {
     property var currentCityIndex
     property alias serverCountryName: countryName.text
 
-    property bool hasAvailableCities: cities.reduce((initialValue, city) => (initialValue || VPNServerCountryModel.cityConnectionScore(code, city.code) >= 0), false)
+    property bool hasAvailableCities: cities.reduce((initialValue, city) => (initialValue || city.connectionScore >= 0), false)
 
     function openCityList() {
         cityListVisible = !cityListVisible;
@@ -171,7 +171,7 @@ VPNClickableRow {
                 property string _cityName: modelData.name
                 property string _countryCode: code
                 property string _localizedCityName: modelData.localizedName
-                property string locationScore: VPNServerCountryModel.cityConnectionScore(code, modelData.code)
+                property string locationScore: modelData.connectionScore
                 property bool isAvailable: locationScore >= 0
                 property int itemHeight: 54
 

--- a/nebula/ui/components/VPNServerList.qml
+++ b/nebula/ui/components/VPNServerList.qml
@@ -21,53 +21,6 @@ FocusScope {
         && VPNFeatureList.get("recommendedServers").isSupported)
     property var currentServer
 
-    ListModel {
-        id: testRecommendedModel
-    }
-
-    // TODO: Replace dummy data with recommended servers list
-    function updateServerData() {
-        testRecommendedModel.clear();
-
-        const data = [
-            {
-                countryCode: "ca",
-                cityName: "Toronto",
-                localizedCityName: "Toronto",
-                code: "tor"
-            },
-            {
-                countryCode: "ca",
-                cityName: "Montreal",
-                localizedCityName: "Montreal",
-                code: "mtr"
-            },
-            {
-                countryCode: "ca",
-                cityName: "Vancouver",
-                localizedCityName: "Vancouver",
-                code: "van"
-            },
-            {
-                countryCode: "us",
-                cityName: "New York City",
-                localizedCityName: "New York City",
-                code: "nyc"
-            },
-            {
-                countryCode: "us",
-                cityName: "Chicago",
-                localizedCityName: "Chicago",
-                code: "chi"
-            }
-        ];
-        const shuffledData = data.sort((a, b) => 0.5 - Math.random());
-
-        shuffledData.forEach((d) => {
-            testRecommendedModel.append(d);
-        });
-    }
-
     function setSelectedServer(countryCode, cityName, localizedCityName) {
         if (currentServer.whichHop === "singleHopServer") {
             VPNCurrentServer.changeServer(countryCode, cityName);
@@ -252,18 +205,18 @@ FocusScope {
 
                 Repeater {
                     id: recommendedRepeater
-                    model: testRecommendedModel
+                    model: VPNServerCountryModel.recommendedLocations(5)
                     delegate: VPNClickableRow {
-                        property string locationScore: VPNServerCountryModel.cityConnectionScore(countryCode, code)
+                        property string locationScore: modelData.connectionScore
                         property bool isAvailable: locationScore >= 0
                         id: recommendedServer
 
-                        accessibleName: localizedCityName
+                        accessibleName: modelData.localizedName
                         onClicked: {
                             if (!isAvailable) {
                                 return;
                             }
-                            focusScope.setSelectedServer(countryCode, cityName, localizedCityName);
+                            focusScope.setSelectedServer(modelData.country, modelData.name, modelData.localizedName);
                         }
 
                         RowLayout {
@@ -278,9 +231,9 @@ FocusScope {
                                 fontColor: VPNTheme.theme.fontColorDark
                                 narrowStyle: false
                                 serversList: [{
-                                    countryCode,
-                                    cityName,
-                                    localizedCityName
+                                    countryCode: modelData.country,
+                                    cityName: modelData.name,
+                                    localizedCityName: modelData.localizedName
                                 }]
                             }
 

--- a/nebula/ui/components/VPNServerList.qml
+++ b/nebula/ui/components/VPNServerList.qml
@@ -83,10 +83,6 @@ FocusScope {
     }
 
     Component.onCompleted: {
-        if (showRecommendedConnections) {
-            focusScope.updateServerData();
-        }
-
         centerActiveServer();
     }
 
@@ -141,7 +137,7 @@ FocusScope {
                     rowShouldBeDisabled: !(VPNController.state === VPNController.StateOff)
 
                     onClicked: {
-                        focusScope.updateServerData();
+                        console.log("TODO: Request server data refresh");
                     }
 
                     RowLayout {
@@ -187,10 +183,8 @@ FocusScope {
                             VPNIcon {
                                 id: refreshIcon
                                 source: "qrc:/nebula/resources/refresh.svg"
-                                sourceSize {
-                                    height: parent.height
-                                    width: parent.width
-                                }
+                                sourceSize.height: parent.height
+                                sourceSize.width: parent.width
                             }
 
                             VPNColorOverlay {
@@ -207,8 +201,7 @@ FocusScope {
                     id: recommendedRepeater
                     model: VPNServerCountryModel.recommendedLocations(5)
                     delegate: VPNClickableRow {
-                        property string locationScore: modelData.connectionScore
-                        property bool isAvailable: locationScore >= 0
+                        property bool isAvailable: modelData.connectionScore >= 0
                         id: recommendedServer
 
                         accessibleName: modelData.localizedName
@@ -239,7 +232,7 @@ FocusScope {
 
                             VPNServerLatencyIndicator {
                                 Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
-                                score: recommendedServer.locationScore
+                                score: modelData.connectionScore
                             }
                         }
                     }

--- a/src/apps/vpn/commands/commandselect.cpp
+++ b/src/apps/vpn/commands/commandselect.cpp
@@ -67,7 +67,11 @@ bool CommandSelect::pickServer(const QString& hostname, QString& countryCode,
                                QString& cityName) {
   ServerCountryModel* model = MozillaVPN::instance()->serverCountryModel();
   for (const ServerCountry& country : model->countries()) {
-    for (const ServerCity& city : country.cities()) {
+    for (const QString& name : country.cities()) {
+      const ServerCity& city = model->findCity(country.code(), name);
+      if (!city.initialized()) {
+        continue;
+      }
       for (const QString& pubkey : city.servers()) {
         const Server& server = model->server(pubkey);
         if (server.hostname() == hostname) {

--- a/src/apps/vpn/commands/commandservers.cpp
+++ b/src/apps/vpn/commands/commandservers.cpp
@@ -79,7 +79,7 @@ int CommandServers::run(QStringList& tokens) {
 
         QJsonArray cityArray;
         for (const QString& cityName : country.cities()) {
-          const ServerCity& city = scm->findCity(country.code(), cityName); 
+          const ServerCity& city = scm->findCity(country.code(), cityName);
           if (!city.initialized()) {
             continue;
           }

--- a/src/apps/vpn/commands/commandservers.cpp
+++ b/src/apps/vpn/commands/commandservers.cpp
@@ -78,7 +78,11 @@ int CommandServers::run(QStringList& tokens) {
         countryObj["code"] = country.code();
 
         QJsonArray cityArray;
-        for (const ServerCity& city : country.cities()) {
+        for (const QString& cityName : country.cities()) {
+          const ServerCity& city = scm->findCity(country.code(), cityName); 
+          if (!city.initialized()) {
+            continue;
+          }
           QJsonObject cityObj;
           cityObj["name"] = city.name();
           cityObj["code"] = city.code();
@@ -114,7 +118,11 @@ int CommandServers::run(QStringList& tokens) {
       for (const ServerCountry& country : scm->countries()) {
         stream << "- Country: " << country.name()
                << " (code: " << country.code() << ")" << Qt::endl;
-        for (const ServerCity& city : country.cities()) {
+        for (const QString& cityName : country.cities()) {
+          const ServerCity& city = scm->findCity(country.code(), cityName);
+          if (!city.initialized()) {
+            continue;
+          }
           stream << "  - City: " << city.name() << " (" << city.code() << ")"
                  << Qt::endl;
           for (const QString& pubkey : city.servers()) {

--- a/src/apps/vpn/commands/commandservers.cpp
+++ b/src/apps/vpn/commands/commandservers.cpp
@@ -85,7 +85,7 @@ int CommandServers::run(QStringList& tokens) {
 
           QJsonArray serverArray;
           for (const QString& pubkey : city.servers()) {
-            const Server server = vpn.serverCountryModel()->server(pubkey);
+            const Server& server = vpn.serverCountryModel()->server(pubkey);
             if (!server.initialized()) {
               continue;
             }
@@ -118,7 +118,7 @@ int CommandServers::run(QStringList& tokens) {
           stream << "  - City: " << city.name() << " (" << city.code() << ")"
                  << Qt::endl;
           for (const QString& pubkey : city.servers()) {
-            const Server server = vpn.serverCountryModel()->server(pubkey);
+            const Server& server = vpn.serverCountryModel()->server(pubkey);
             if (!server.initialized()) {
               continue;
             }

--- a/src/apps/vpn/inspector/inspectorhandler.cpp
+++ b/src/apps/vpn/inspector/inspectorhandler.cpp
@@ -621,7 +621,11 @@ static QList<InspectorCommand> s_commands{
               MozillaVPN::instance()->serverCountryModel();
           for (const ServerCountry& country : scm->countries()) {
             QJsonArray cityArray;
-            for (const ServerCity& city : country.cities()) {
+            for (const QString& cityName : country.cities()) {
+              const ServerCity& city = scm->findCity(country.code(), cityName);
+              if (!city.initialized()) {
+                continue;
+              }
               QJsonObject cityObj;
               cityObj["name"] = city.name();
               cityObj["localizedName"] =

--- a/src/apps/vpn/models/location.h
+++ b/src/apps/vpn/models/location.h
@@ -41,7 +41,7 @@ class Location final : public QObject {
 
   double longitude() const { return m_longitude; }
 
-  double distance(double latitude, double longitude) const; 
+  double distance(double latitude, double longitude) const;
 
   QHostAddress ipAddress() const { return m_ipAddress; }
 

--- a/src/apps/vpn/models/location.h
+++ b/src/apps/vpn/models/location.h
@@ -41,6 +41,8 @@ class Location final : public QObject {
 
   double longitude() const { return m_longitude; }
 
+  double distance(double latitude, double longitude) const; 
+
   QHostAddress ipAddress() const { return m_ipAddress; }
 
  signals:
@@ -53,6 +55,8 @@ class Location final : public QObject {
   QHostAddress m_ipAddress;
   double m_latitude;
   double m_longitude;
+  double m_latSin;
+  double m_latCos;
   bool m_initialized = false;
 };
 

--- a/src/apps/vpn/models/server.cpp
+++ b/src/apps/vpn/models/server.cpp
@@ -14,6 +14,12 @@
 
 Server::Server() { MZ_COUNT_CTOR(Server); }
 
+Server::Server(const QString& countryCode, const QString& cityName) {
+  MZ_COUNT_CTOR(Server);
+  m_countryCode = countryCode;
+  m_cityName = cityName;
+}
+
 Server::Server(const Server& other) {
   MZ_COUNT_CTOR(Server);
   *this = other;
@@ -34,6 +40,8 @@ Server& Server::operator=(const Server& other) {
   m_multihopPort = other.m_multihopPort;
   m_cooldownTimeout = other.m_cooldownTimeout;
   m_latency = other.m_latency;
+  m_countryCode = other.m_countryCode;
+  m_cityName = other.m_cityName;
 
   return *this;
 }

--- a/src/apps/vpn/models/server.h
+++ b/src/apps/vpn/models/server.h
@@ -14,6 +14,7 @@ class QJsonObject;
 class Server final {
  public:
   Server();
+  Server(const QString& countryCode, const QString& cityName);
   Server(const Server& other);
   Server& operator=(const Server& other);
   ~Server();
@@ -51,6 +52,10 @@ class Server final {
 
   uint32_t multihopPort() const { return m_multihopPort; }
 
+  const QString& countryCode() const { return m_countryCode; }
+
+  const QString& cityName() const { return m_cityName; }
+
   bool forcePort(uint32_t port);
 
   bool operator==(const Server& other) const {
@@ -75,6 +80,8 @@ class Server final {
   uint32_t m_multihopPort = 0;
   qint64 m_cooldownTimeout = 0;
   uint32_t m_latency = 0;
+  QString m_countryCode;
+  QString m_cityName;
 };
 
 #endif  // SERVER_H

--- a/src/apps/vpn/models/servercity.cpp
+++ b/src/apps/vpn/models/servercity.cpp
@@ -84,11 +84,17 @@ bool ServerCity::fromJson(const QJsonObject& obj, const QString& country) {
   m_name = name.toString();
   m_code = code.toString();
   m_country = country;
+  m_hashKey = hashKey(m_country, m_name);
   m_latitude = latitude.toDouble();
   m_longitude = longitude.toDouble();
   m_servers.swap(servers);
 
   return true;
+}
+
+// static
+QString ServerCity::hashKey(const QString& country, const QString cityName) {
+  return cityName + "," + country;
 }
 
 const QString ServerCity::localizedName() const {

--- a/src/apps/vpn/models/servercity.cpp
+++ b/src/apps/vpn/models/servercity.cpp
@@ -124,8 +124,8 @@ int ServerCity::connectionScore() const {
     return NoData;
   }
 
-  // Increase the score if the location has less than 100ms of latency.
-  if ((sumLatencyMsec / activeServerCount) < 100) {
+  // Increase the score if the location has better than average latency.
+  if ((sumLatencyMsec / activeServerCount) < scm->avgLatency()) {
     score++;
   }
 

--- a/src/apps/vpn/models/servercity.cpp
+++ b/src/apps/vpn/models/servercity.cpp
@@ -139,3 +139,19 @@ int ServerCity::connectionScore() const {
   }
   return score;
 }
+
+unsigned int ServerCity::latency() const {
+  ServerCountryModel* scm = MozillaVPN::instance()->serverCountryModel();
+  qint64 now = QDateTime::currentSecsSinceEpoch();
+  int activeServerCount = 0;
+  uint32_t sumLatencyMsec = 0;
+  for (const QString& pubkey : m_servers) {
+    const Server server = scm->server(pubkey);
+    if (server.cooldownTimeout() <= now) {
+      sumLatencyMsec += server.latency();
+      activeServerCount++;
+    }
+  }
+  
+  return (sumLatencyMsec + activeServerCount - 1) / activeServerCount;
+}

--- a/src/apps/vpn/models/servercity.cpp
+++ b/src/apps/vpn/models/servercity.cpp
@@ -12,8 +12,8 @@
 #include "feature.h"
 #include "leakdetector.h"
 #include "mozillavpn.h"
-#include "serveri18n.h"
 #include "servercountrymodel.h"
+#include "serveri18n.h"
 
 ServerCity::ServerCity() { MZ_COUNT_CTOR(ServerCity); }
 
@@ -148,6 +148,6 @@ unsigned int ServerCity::latency() const {
       activeServerCount++;
     }
   }
-  
+
   return (sumLatencyMsec + activeServerCount - 1) / activeServerCount;
 }

--- a/src/apps/vpn/models/servercity.cpp
+++ b/src/apps/vpn/models/servercity.cpp
@@ -114,10 +114,6 @@ int ServerCity::connectionScore() const {
     return Unavailable;
   }
 
-  // If the feature is disabled, we have no data to return.
-  if (!Feature::get(Feature::Feature_serverConnectionScore)->isSupported()) {
-    return NoData;
-  }
   // In the unlikely event that the sum of the latencies is zero, then we
   // haven't actually measured anything and have nothing to report.
   if (sumLatencyMsec == 0) {

--- a/src/apps/vpn/models/servercity.cpp
+++ b/src/apps/vpn/models/servercity.cpp
@@ -102,7 +102,7 @@ int ServerCity::connectionScore() const {
   int activeServerCount = 0;
   uint32_t sumLatencyMsec = 0;
   for (const QString& pubkey : m_servers) {
-    const Server server = scm->server(pubkey);
+    const Server& server = scm->server(pubkey);
     if (server.cooldownTimeout() <= now) {
       sumLatencyMsec += server.latency();
       activeServerCount++;
@@ -142,7 +142,7 @@ unsigned int ServerCity::latency() const {
   int activeServerCount = 0;
   uint32_t sumLatencyMsec = 0;
   for (const QString& pubkey : m_servers) {
-    const Server server = scm->server(pubkey);
+    const Server& server = scm->server(pubkey);
     if (server.cooldownTimeout() <= now) {
       sumLatencyMsec += server.latency();
       activeServerCount++;

--- a/src/apps/vpn/models/servercity.h
+++ b/src/apps/vpn/models/servercity.h
@@ -41,6 +41,8 @@ class ServerCity final : public QObject {
 
   [[nodiscard]] bool fromJson(const QJsonObject& obj, const QString& country);
 
+  const bool initialized() const { return !m_name.isEmpty(); }
+
   const QString& name() const { return m_name; }
 
   const QString& code() const { return m_code; }
@@ -48,6 +50,9 @@ class ServerCity final : public QObject {
   const QString& country() const { return m_country; }
 
   const QString localizedName() const;
+
+  const QString& hashKey() const { return m_hashKey; }
+  static QString hashKey(const QString& country, const QString cityName);
 
   double latitude() const { return m_latitude; }
 
@@ -66,6 +71,7 @@ class ServerCity final : public QObject {
   QString m_country;
   QString m_name;
   QString m_code;
+  QString m_hashKey;
   double m_latitude;
   double m_longitude;
 

--- a/src/apps/vpn/models/servercity.h
+++ b/src/apps/vpn/models/servercity.h
@@ -18,7 +18,7 @@ class ServerCity final : public QObject {
 
   Q_PROPERTY(QString name READ name CONSTANT)
   Q_PROPERTY(QString code READ code CONSTANT)
-  Q_PROPERTY(QString coutnry READ country CONSTANT)
+  Q_PROPERTY(QString country READ country CONSTANT)
   Q_PROPERTY(QString localizedName READ localizedName CONSTANT)
   Q_PROPERTY(double latitude READ latitude CONSTANT)
   Q_PROPERTY(double longitude READ longitude CONSTANT)

--- a/src/apps/vpn/models/servercity.h
+++ b/src/apps/vpn/models/servercity.h
@@ -55,6 +55,8 @@ class ServerCity final : public QObject {
 
   int connectionScore() const;
 
+  unsigned int latency() const;
+
   const QList<QString> servers() const { return m_servers; }
 
  signals:

--- a/src/apps/vpn/models/servercity.h
+++ b/src/apps/vpn/models/servercity.h
@@ -22,12 +22,22 @@ class ServerCity final : public QObject {
   Q_PROPERTY(QString localizedName READ localizedName CONSTANT)
   Q_PROPERTY(double latitude READ latitude CONSTANT)
   Q_PROPERTY(double longitude READ longitude CONSTANT)
+  Q_PROPERTY(int connectionScore READ connectionScore NOTIFY scoreChanged)
 
  public:
   ServerCity();
   ServerCity(const ServerCity& other);
   ServerCity& operator=(const ServerCity& other);
   ~ServerCity();
+
+  enum CityConnectionScores {
+    Unavailable = -1,
+    NoData = 0,
+    Poor = 1,
+    Moderate = 2,
+    Good = 3,
+  };
+  Q_ENUM(CityConnectionScores);
 
   [[nodiscard]] bool fromJson(const QJsonObject& obj, const QString& country);
 
@@ -43,7 +53,12 @@ class ServerCity final : public QObject {
 
   double longitude() const { return m_longitude; }
 
+  int connectionScore() const;
+
   const QList<QString> servers() const { return m_servers; }
+
+ signals:
+  void scoreChanged() const;
 
  private:
   QString m_country;

--- a/src/apps/vpn/models/servercountry.cpp
+++ b/src/apps/vpn/models/servercountry.cpp
@@ -79,17 +79,6 @@ bool ServerCountry::fromJson(const QJsonObject& countryObj) {
   return true;
 }
 
-const QList<QString> ServerCountry::serversFromCityName(
-    const QString& cityName) const {
-  for (const ServerCity& city : m_cities) {
-    if (city.name() == cityName) {
-      return city.servers();
-    }
-  }
-
-  return QList<QString>();
-}
-
 namespace {
 
 bool sortCityCallback(const ServerCity& a, const ServerCity& b,

--- a/src/apps/vpn/models/servercountry.cpp
+++ b/src/apps/vpn/models/servercountry.cpp
@@ -49,7 +49,7 @@ bool ServerCountry::fromJson(const QJsonObject& countryObj) {
     return false;
   }
 
-  QList<ServerCity> scList;
+  QList<QString> cityNames;
   QJsonArray citiesArray = cities.toArray();
   for (const QJsonValue& cityValue : citiesArray) {
     if (!cityValue.isObject()) {
@@ -57,22 +57,16 @@ bool ServerCountry::fromJson(const QJsonObject& countryObj) {
     }
 
     QJsonObject cityObject = cityValue.toObject();
-
-    ServerCity serverCity;
-    if (!serverCity.fromJson(cityObject, countryCode.toString())) {
+    QString cityName = cityObject.value("name").toString();
+    if (cityName.isEmpty()) {
       return false;
     }
-
-    if (serverCity.servers().isEmpty()) {
-      continue;
-    }
-
-    scList.append(serverCity);
+    cityNames.append(cityName);
   }
 
   m_name = countryName.toString();
   m_code = countryCode.toString();
-  m_cities.swap(scList);
+  m_cities.swap(cityNames);
 
   sortCities();
 
@@ -81,12 +75,12 @@ bool ServerCountry::fromJson(const QJsonObject& countryObj) {
 
 namespace {
 
-bool sortCityCallback(const ServerCity& a, const ServerCity& b,
+bool sortCityCallback(const QString& a, const QString& b,
                       const QString& countryCode, Collator* collator) {
   Q_ASSERT(collator);
   return collator->compare(
-             ServerI18N::translateCityName(countryCode, a.name()),
-             ServerI18N::translateCityName(countryCode, b.name())) < 0;
+             ServerI18N::translateCityName(countryCode, a),
+             ServerI18N::translateCityName(countryCode, b)) < 0;
 }
 
 }  // anonymous namespace

--- a/src/apps/vpn/models/servercountry.cpp
+++ b/src/apps/vpn/models/servercountry.cpp
@@ -78,9 +78,8 @@ namespace {
 bool sortCityCallback(const QString& a, const QString& b,
                       const QString& countryCode, Collator* collator) {
   Q_ASSERT(collator);
-  return collator->compare(
-             ServerI18N::translateCityName(countryCode, a),
-             ServerI18N::translateCityName(countryCode, b)) < 0;
+  return collator->compare(ServerI18N::translateCityName(countryCode, a),
+                           ServerI18N::translateCityName(countryCode, b)) < 0;
 }
 
 }  // anonymous namespace

--- a/src/apps/vpn/models/servercountry.h
+++ b/src/apps/vpn/models/servercountry.h
@@ -25,7 +25,7 @@ class ServerCountry final {
 
   const QString& code() const { return m_code; }
 
-  const QList<ServerCity>& cities() const { return m_cities; }
+  const QList<QString>& cities() const { return m_cities; }
 
   void sortCities();
 
@@ -33,7 +33,7 @@ class ServerCountry final {
   QString m_name;
   QString m_code;
 
-  QList<ServerCity> m_cities;
+  QList<QString> m_cities;
 };
 
 #endif  // SERVERCOUNTRY_H

--- a/src/apps/vpn/models/servercountry.h
+++ b/src/apps/vpn/models/servercountry.h
@@ -27,8 +27,6 @@ class ServerCountry final {
 
   const QList<ServerCity>& cities() const { return m_cities; }
 
-  const QList<QString> serversFromCityName(const QString& cityName) const;
-
   void sortCities();
 
  private:

--- a/src/apps/vpn/models/servercountrymodel.cpp
+++ b/src/apps/vpn/models/servercountrymodel.cpp
@@ -177,19 +177,6 @@ QVariant ServerCountryModel::data(const QModelIndex& index, int role) const {
       return QVariant();
   }
 }
-
-int ServerCountryModel::cityConnectionScore(const QString& countryCode,
-                                            const QString& cityCode) const {
-  for (const ServerCity& city : cities(countryCode)) {
-    if (city.code() == cityCode) {
-      return city.connectionScore();
-    }
-  }
-
-  // No such country was found.
-  return NoData;
-}
-
 QStringList ServerCountryModel::pickRandom() const {
   logger.debug() << "Choosing a random server";
   qsizetype index = QRandomGenerator::global()->generate() % m_servers.count();

--- a/src/apps/vpn/models/servercountrymodel.cpp
+++ b/src/apps/vpn/models/servercountrymodel.cpp
@@ -207,8 +207,8 @@ bool ServerCountryModel::exists(const QString& countryCode,
   return m_cities.contains(ServerCity::hashKey(countryCode, cityName));
 }
 
-const ServerCity& ServerCountryModel::findCity(
-    const QString& countryCode, const QString& cityName) const {
+const ServerCity& ServerCountryModel::findCity(const QString& countryCode,
+                                               const QString& cityName) const {
   auto index = m_cities.constFind(ServerCity::hashKey(countryCode, cityName));
   if (index == m_cities.end()) {
     static const ServerCity emptycity;

--- a/src/apps/vpn/models/servercountrymodel.cpp
+++ b/src/apps/vpn/models/servercountrymodel.cpp
@@ -218,23 +218,6 @@ const ServerCity& ServerCountryModel::findCity(
   return *index;
 }
 
-const QList<Server> ServerCountryModel::servers(const QString& countryCode,
-                                                const QString& cityName) const {
-  QList<Server> results;
-  const ServerCity& city = findCity(countryCode, cityName);
-  if (city.initialized()) {
-    return results;
-  }
-  
-  for (const QString& pubkey : city.servers()) {
-    if (m_servers.contains(pubkey)) {
-      results.append(m_servers.value(pubkey));
-    }
-  }
-
-  return results;
-}
-
 const Server& ServerCountryModel::server(const QString& pubkey) const {
   auto iterator = m_servers.constFind(pubkey);
   if (iterator != m_servers.constEnd()) {

--- a/src/apps/vpn/models/servercountrymodel.cpp
+++ b/src/apps/vpn/models/servercountrymodel.cpp
@@ -297,9 +297,8 @@ void ServerCountryModel::setServerCooldown(const QString& publicKey) {
   serverIterator->setCooldownTimeout(
       AppConstants::SERVER_UNRESPONSIVE_COOLDOWN_SEC);
 
-  auto cityIterator =
-      m_cities.find(ServerCity::hashKey(serverIterator->countryCode(),
-                                        serverIterator->cityName()));
+  auto cityIterator = m_cities.find(ServerCity::hashKey(
+      serverIterator->countryCode(), serverIterator->cityName()));
   if (cityIterator != m_cities.end()) {
     emit cityIterator->scoreChanged();
   }

--- a/src/apps/vpn/models/servercountrymodel.cpp
+++ b/src/apps/vpn/models/servercountrymodel.cpp
@@ -306,9 +306,8 @@ void ServerCountryModel::retranslate() {
 unsigned int ServerCountryModel::avgLatency() const {
   if (m_numLatencySamples == 0) {
     return 0;
-  } else {
-    return (m_sumLatencyMsec + m_numLatencySamples - 1) / m_numLatencySamples;
   }
+  return (m_sumLatencyMsec + m_numLatencySamples - 1) / m_numLatencySamples;
 }
 
 void ServerCountryModel::setServerLatency(const QString& publicKey,

--- a/src/apps/vpn/models/servercountrymodel.cpp
+++ b/src/apps/vpn/models/servercountrymodel.cpp
@@ -276,6 +276,16 @@ const QList<Server> ServerCountryModel::servers(const QString& countryCode,
   return results;
 }
 
+const Server& ServerCountryModel::server(const QString& pubkey) const {
+  auto iterator = m_servers.constFind(pubkey);
+  if (iterator != m_servers.constEnd()) {
+    return iterator.value();
+  }
+
+  static const Server emptyserver;
+  return emptyserver;
+}
+
 const QString ServerCountryModel::countryName(
     const QString& countryCode) const {
   for (const ServerCountry& country : m_countries) {

--- a/src/apps/vpn/models/servercountrymodel.cpp
+++ b/src/apps/vpn/models/servercountrymodel.cpp
@@ -177,34 +177,6 @@ QVariant ServerCountryModel::data(const QModelIndex& index, int role) const {
       return QVariant();
   }
 }
-QStringList ServerCountryModel::pickRandom() const {
-  logger.debug() << "Choosing a random server";
-  qsizetype index = QRandomGenerator::global()->generate() % m_servers.count();
-
-  // Iterate to find the selected country and city. This winds up weighting the
-  // choice of city proportional to the number of servers hosted there.
-  for (auto country = m_countries.cbegin(); country != m_countries.cend();
-       country++) {
-    for (auto city = country->cities().cbegin();
-         city != country->cities().cend(); city++) {
-      if (index >= city->servers().count()) {
-        // Keep searching.
-        index -= city->servers().count();
-      } else {
-        // We found our selection.
-        QStringList serverChoice = {
-            city->country(), city->name(),
-            ServerI18N::translateCityName(city->country(), city->name())};
-        return serverChoice;
-      }
-    }
-  }
-
-  // We should not get here, unless the model has more entries in m_servers()
-  // than actually exist in the country and city lists.
-  Q_ASSERT(false);
-  return QStringList();
-}
 
 // Select the city that we think is going to perform the best
 QStringList ServerCountryModel::pickBest() const {

--- a/src/apps/vpn/models/servercountrymodel.cpp
+++ b/src/apps/vpn/models/servercountrymodel.cpp
@@ -328,6 +328,22 @@ void ServerCountryModel::setServerLatency(const QString& publicKey,
   }
 }
 
+void ServerCountryModel::clearServerLatency() {
+  // Invalidate the latency data.
+  m_sumLatencyMsec = 0;
+  m_numLatencySamples = 0;
+  for (Server& server : m_servers) {
+    server.setLatency(0);
+  }
+
+  // Emit changed signals for the connection scores.
+  for (const ServerCountry& country : m_countries) {
+    for (const ServerCity& city : country.cities()) {
+      emit city.scoreChanged();
+    }
+  }
+}
+
 void ServerCountryModel::setServerCooldown(const QString& publicKey) {
   if (m_servers.contains(publicKey)) {
     m_servers[publicKey].setCooldownTimeout(

--- a/src/apps/vpn/models/servercountrymodel.cpp
+++ b/src/apps/vpn/models/servercountrymodel.cpp
@@ -363,7 +363,7 @@ QList<QVariant> ServerCountryModel::recommendedLocations(
 #endif
 
       // Insert into the result list
-      int i;
+      unsigned int i;
       for (i = 0; i < rankResults.count(); i++) {
         if (rankResults[i] < cityRanking) {
           break;

--- a/src/apps/vpn/models/servercountrymodel.cpp
+++ b/src/apps/vpn/models/servercountrymodel.cpp
@@ -318,7 +318,7 @@ void ServerCountryModel::setServerLatency(const QString& publicKey,
   }
 
   Server& server = m_servers[publicKey];
-  if(server.latency() != 0) {
+  if (server.latency() != 0) {
     m_sumLatencyMsec -= server.latency();
   } else {
     m_numLatencySamples++;
@@ -385,23 +385,23 @@ QList<QVariant> ServerCountryModel::recommendedLocations(
 
   QVector<QVariant> cityResults;
   QVector<double> rankResults;
-  cityResults.reserve(maxResults+1);
-  rankResults.reserve(maxResults+1);
+  cityResults.reserve(maxResults + 1);
+  rankResults.reserve(maxResults + 1);
   for (const ServerCountry& country : m_countries) {
     for (const ServerCity& city : country.cities()) {
       double cityRanking = city.connectionScore() * 256.0;
 
       // For tiebreaking, use the geographic distance and latency.
       double distance = MozillaVPN::instance()->location()->distance(
-                            city.latitude(), city.longitude());
+          city.latitude(), city.longitude());
       cityRanking -= city.latency() / latencyScale;
       cityRanking -= distance;
 
 #ifdef MZ_DEBUG
-      logger.debug() << "Evaluating" << city.name() << "-"
-                     << city.latency() << "ms" << "-"
-                     << QString::number(distance) << "-"
-                     << QString::number(cityRanking);
+      logger.debug() << "Evaluating" << city.name() << "-" << city.latency()
+                     << "ms"
+                     << "-" << QString::number(distance)
+                     << "-" << QString::number(cityRanking);
 #endif
 
       // Insert into the result list

--- a/src/apps/vpn/models/servercountrymodel.cpp
+++ b/src/apps/vpn/models/servercountrymodel.cpp
@@ -400,8 +400,8 @@ QList<QVariant> ServerCountryModel::recommendedLocations(
 #ifdef MZ_DEBUG
       logger.debug() << "Evaluating" << city.name() << "-" << city.latency()
                      << "ms"
-                     << "-" << QString::number(distance)
-                     << "-" << QString::number(cityRanking);
+                     << "-" << QString::number(distance) << "-"
+                     << QString::number(cityRanking);
 #endif
 
       // Insert into the result list

--- a/src/apps/vpn/models/servercountrymodel.cpp
+++ b/src/apps/vpn/models/servercountrymodel.cpp
@@ -369,6 +369,25 @@ void ServerCountryModel::setCooldownForAllServersInACity(
   }
 }
 
+QList<QVariant> ServerCountryModel::recommendedLocations(
+    unsigned int count) const {
+  QList<QVariant> results;
+
+  // For testing - just return the first city of each country.
+  for (const ServerCountry& country : m_countries) {
+    const QList<ServerCity>& cities = country.cities();
+    if (results.count() >= count) {
+      break;
+    }
+    if (cities.isEmpty()) {
+      continue;
+    }
+    results.append(QVariant::fromValue(&cities.first()));
+  }
+
+  return results;
+}
+
 namespace {
 
 bool sortCountryCallback(const ServerCountry& a, const ServerCountry& b,

--- a/src/apps/vpn/models/servercountrymodel.h
+++ b/src/apps/vpn/models/servercountrymodel.h
@@ -43,7 +43,6 @@ class ServerCountryModel final : public QAbstractListModel {
 
   bool initialized() const { return !m_rawJson.isEmpty(); }
 
-  Q_INVOKABLE QStringList pickRandom() const;
   QStringList pickBest() const;
 
   bool exists(const QString& countryCode, const QString& cityName) const;

--- a/src/apps/vpn/models/servercountrymodel.h
+++ b/src/apps/vpn/models/servercountrymodel.h
@@ -50,8 +50,7 @@ class ServerCountryModel final : public QAbstractListModel {
 
   const QList<Server> servers(const QString& countryCode,
                               const QString& cityName) const;
-  const QList<Server> servers() const { return m_servers.values(); };
-  Server server(const QString& pubkey) const { return m_servers.value(pubkey); }
+  const Server& server(const QString& pubkey) const;
 
   const QString countryName(const QString& countryCode) const;
 

--- a/src/apps/vpn/models/servercountrymodel.h
+++ b/src/apps/vpn/models/servercountrymodel.h
@@ -59,6 +59,7 @@ class ServerCountryModel final : public QAbstractListModel {
   const QList<ServerCountry>& countries() const { return m_countries; }
 
   void retranslate();
+  unsigned int avgLatency() const;
   void setServerLatency(const QString& publicKey, unsigned int msec);
   void setServerCooldown(const QString& publicKey);
   void setCooldownForAllServersInACity(const QString& countryCode,
@@ -92,6 +93,9 @@ class ServerCountryModel final : public QAbstractListModel {
 
   QList<ServerCountry> m_countries;
   QHash<QString, Server> m_servers;
+
+  qint64 m_sumLatencyMsec;
+  qint64 m_numLatencySamples;
 };
 
 #endif  // SERVERCOUNTRYMODEL_H

--- a/src/apps/vpn/models/servercountrymodel.h
+++ b/src/apps/vpn/models/servercountrymodel.h
@@ -65,9 +65,6 @@ class ServerCountryModel final : public QAbstractListModel {
   void setCooldownForAllServersInACity(const QString& countryCode,
                                        const QString& cityCode);
 
-  Q_INVOKABLE int cityConnectionScore(const QString& countryCode,
-                                      const QString& cityCode) const;
-
   Q_INVOKABLE QList<QVariant> recommendedLocations(unsigned int count) const;
 
   // QAbstractListModel methods

--- a/src/apps/vpn/models/servercountrymodel.h
+++ b/src/apps/vpn/models/servercountrymodel.h
@@ -83,7 +83,6 @@ class ServerCountryModel final : public QAbstractListModel {
   [[nodiscard]] bool fromJsonInternal(const QByteArray& data);
 
   void sortCountries();
-  int cityConnectionScore(const ServerCity& city) const;
 
  private:
   QByteArray m_rawJson;

--- a/src/apps/vpn/models/servercountrymodel.h
+++ b/src/apps/vpn/models/servercountrymodel.h
@@ -55,6 +55,7 @@ class ServerCountryModel final : public QAbstractListModel {
 
   const QString countryName(const QString& countryCode) const;
 
+  const QList<ServerCity>& cities(const QString& countryCode) const;
   const QList<ServerCountry>& countries() const { return m_countries; }
 
   void retranslate();

--- a/src/apps/vpn/models/servercountrymodel.h
+++ b/src/apps/vpn/models/servercountrymodel.h
@@ -49,8 +49,6 @@ class ServerCountryModel final : public QAbstractListModel {
   const ServerCity& findCity(const QString& countryCode,
                              const QString& cityName) const;
 
-  const QList<Server> servers(const QString& countryCode,
-                              const QString& cityName) const;
   const Server& server(const QString& pubkey) const;
 
   const QString countryName(const QString& countryCode) const;

--- a/src/apps/vpn/models/servercountrymodel.h
+++ b/src/apps/vpn/models/servercountrymodel.h
@@ -66,6 +66,8 @@ class ServerCountryModel final : public QAbstractListModel {
   Q_INVOKABLE int cityConnectionScore(const QString& countryCode,
                                       const QString& cityCode) const;
 
+  Q_INVOKABLE QList<QVariant> recommendedLocations(unsigned int count) const;
+
   // QAbstractListModel methods
 
   QHash<int, QByteArray> roleNames() const override;

--- a/src/apps/vpn/models/servercountrymodel.h
+++ b/src/apps/vpn/models/servercountrymodel.h
@@ -46,6 +46,8 @@ class ServerCountryModel final : public QAbstractListModel {
   QStringList pickBest() const;
 
   bool exists(const QString& countryCode, const QString& cityName) const;
+  const ServerCity& findCity(const QString& countryCode,
+                             const QString& cityName) const;
 
   const QList<Server> servers(const QString& countryCode,
                               const QString& cityName) const;
@@ -53,7 +55,6 @@ class ServerCountryModel final : public QAbstractListModel {
 
   const QString countryName(const QString& countryCode) const;
 
-  const QList<ServerCity>& cities(const QString& countryCode) const;
   const QList<ServerCountry>& countries() const { return m_countries; }
 
   void retranslate();
@@ -88,6 +89,7 @@ class ServerCountryModel final : public QAbstractListModel {
   QByteArray m_rawJson;
 
   QList<ServerCountry> m_countries;
+  QHash<QString, ServerCity> m_cities;
   QHash<QString, Server> m_servers;
 
   qint64 m_sumLatencyMsec;

--- a/src/apps/vpn/models/servercountrymodel.h
+++ b/src/apps/vpn/models/servercountrymodel.h
@@ -44,7 +44,7 @@ class ServerCountryModel final : public QAbstractListModel {
   bool initialized() const { return !m_rawJson.isEmpty(); }
 
   Q_INVOKABLE QStringList pickRandom() const;
-  QStringList pickBest(const Location& location) const;
+  QStringList pickBest() const;
 
   bool exists(const QString& countryCode, const QString& cityName) const;
 

--- a/src/apps/vpn/models/servercountrymodel.h
+++ b/src/apps/vpn/models/servercountrymodel.h
@@ -61,6 +61,7 @@ class ServerCountryModel final : public QAbstractListModel {
   void retranslate();
   unsigned int avgLatency() const;
   void setServerLatency(const QString& publicKey, unsigned int msec);
+  void clearServerLatency();
   void setServerCooldown(const QString& publicKey);
   void setCooldownForAllServersInACity(const QString& countryCode,
                                        const QString& cityCode);

--- a/src/apps/vpn/models/serverdata.h
+++ b/src/apps/vpn/models/serverdata.h
@@ -101,6 +101,8 @@ class ServerData final : public QObject {
 
  private:
   bool settingsChanged();
+  static QList<Server> getServerList(const QString& countryCode,
+                                     const QString& cityName);
 
  private:
   bool m_initialized = false;

--- a/src/apps/vpn/mozillavpn.cpp
+++ b/src/apps/vpn/mozillavpn.cpp
@@ -237,6 +237,8 @@ SubscriptionData* MozillaVPN::subscriptionData() {
   return &m_private->m_subscriptionData;
 }
 
+Location* MozillaVPN::location() const { return &m_private->m_location; }
+
 MozillaVPN::State MozillaVPN::state() const { return m_state; }
 
 MozillaVPN::UserState MozillaVPN::userState() const { return m_userState; }

--- a/src/apps/vpn/mozillavpn.cpp
+++ b/src/apps/vpn/mozillavpn.cpp
@@ -367,8 +367,7 @@ void MozillaVPN::initialize() {
 
   Q_ASSERT(!m_private->m_serverData.hasServerData());
   if (!m_private->m_serverData.fromSettings()) {
-    QStringList list =
-        m_private->m_serverCountryModel.pickBest(m_private->m_location);
+    QStringList list = m_private->m_serverCountryModel.pickBest();
     Q_ASSERT(list.length() >= 2);
 
     m_private->m_serverData.update(list[0], list[1]);
@@ -706,8 +705,7 @@ void MozillaVPN::serversFetched(const QByteArray& serverData) {
       !m_private->m_serverCountryModel.exists(
           m_private->m_serverData.exitCountryCode(),
           m_private->m_serverData.exitCityName())) {
-    QStringList list =
-        m_private->m_serverCountryModel.pickBest(m_private->m_location);
+    QStringList list = m_private->m_serverCountryModel.pickBest();
     Q_ASSERT(list.length() >= 2);
 
     m_private->m_serverData.update(list[0], list[1]);

--- a/src/apps/vpn/mozillavpn.h
+++ b/src/apps/vpn/mozillavpn.h
@@ -169,7 +169,7 @@ class MozillaVPN final : public QObject {
     return &m_private->m_supportCategoryModel;
   }
   Keys* keys() { return &m_private->m_keys; }
-  Location* location() { return &m_private->m_location; }
+  Location* location() const;
   NetworkWatcher* networkWatcher() { return &m_private->m_networkWatcher; }
   ProfileFlow* profileFlow() { return &m_private->m_profileFlow; }
   ReleaseMonitor* releaseMonitor() { return &m_private->m_releaseMonitor; }

--- a/src/apps/vpn/server/serverconnection.cpp
+++ b/src/apps/vpn/server/serverconnection.cpp
@@ -47,7 +47,7 @@ void serializeServerCountry(ServerCountryModel* model, QJsonObject& obj) {
 
       QJsonArray servers;
       for (const QString& pubkey : city.servers()) {
-        const Server server = model->server(pubkey);
+        const Server& server = model->server(pubkey);
         if (!server.initialized()) {
           continue;
         }

--- a/src/apps/vpn/server/serverconnection.cpp
+++ b/src/apps/vpn/server/serverconnection.cpp
@@ -38,7 +38,11 @@ void serializeServerCountry(ServerCountryModel* model, QJsonObject& obj) {
     countryObj["code"] = country.code();
 
     QJsonArray cities;
-    for (const ServerCity& city : country.cities()) {
+    for (const QString& cityName : country.cities()) {
+      const ServerCity& city = model->findCity(country.code(), cityName);
+      if (!city.initialized()) {
+        continue;
+      }
       QJsonObject cityObj;
       cityObj["name"] = city.name();
       cityObj["code"] = city.code();

--- a/src/apps/vpn/serverlatency.cpp
+++ b/src/apps/vpn/serverlatency.cpp
@@ -132,7 +132,7 @@ void ServerLatency::maybeSendPings() {
       retry.timestamp = now;
       m_pingReplyList.append(retry);
 
-      Server server = scm->server(retry.publicKey);
+      const Server& server = scm->server(retry.publicKey);
       m_pingSender->sendPing(QHostAddress(server.ipv4AddrIn()), retry.sequence);
     }
 
@@ -152,7 +152,7 @@ void ServerLatency::maybeSendPings() {
     record.retries = 0;
     m_pingReplyList.append(record);
 
-    Server server = scm->server(record.publicKey);
+    const Server& server = scm->server(record.publicKey);
     m_pingSender->sendPing(QHostAddress(server.ipv4AddrIn()), record.sequence);
   }
 

--- a/src/apps/vpn/serverlatency.cpp
+++ b/src/apps/vpn/serverlatency.cpp
@@ -83,9 +83,12 @@ void ServerLatency::start() {
   // Generate a list of servers to ping. If possible, sort them by geographic
   // distance to try and get data for the quickest servers first.
   for (const ServerCountry& country : vpn->serverCountryModel()->countries()) {
-    for (const ServerCity& city : country.cities()) {
+    for (const QString& cityName : country.cities()) {
+      const ServerCity& city =
+          vpn->serverCountryModel()->findCity(country.code(), cityName);
       double distance =
           vpn->location()->distance(city.latitude(), city.longitude());
+      Q_ASSERT(city.initialized());
 
       // Search for where in the list to insert this city's servers.
       auto i = m_pingSendQueue.begin();

--- a/src/apps/vpn/serverlatency.cpp
+++ b/src/apps/vpn/serverlatency.cpp
@@ -46,7 +46,7 @@ void ServerLatency::initialize() {
   m_refreshTimer.setSingleShot(true);
   connect(&m_refreshTimer, &QTimer::timeout, this, &ServerLatency::start);
 
-  const Feature *feature = Feature::get(Feature::Feature_serverConnectionScore);
+  const Feature* feature = Feature::get(Feature::Feature_serverConnectionScore);
   connect(feature, &Feature::supportedChanged, this, &ServerLatency::start);
   if (feature->isSupported()) {
     m_refreshTimer.start(SERVER_LATENCY_INITIAL_MSEC);
@@ -84,8 +84,8 @@ void ServerLatency::start() {
   // distance to try and get data for the quickest servers first.
   for (const ServerCountry& country : vpn->serverCountryModel()->countries()) {
     for (const ServerCity& city : country.cities()) {
-      double distance = vpn->location()->distance(city.latitude(),
-                                                  city.longitude());
+      double distance =
+          vpn->location()->distance(city.latitude(), city.longitude());
 
       // Search for where in the list to insert this city's servers.
       auto i = m_pingSendQueue.begin();
@@ -98,7 +98,7 @@ void ServerLatency::start() {
 
       // Insert the servers into the list.
       for (const QString& pubkey : city.servers()) {
-        ServerPingRecord rec = { pubkey, 0, 0, distance, 0};
+        ServerPingRecord rec = {pubkey, 0, 0, distance, 0};
         i = m_pingSendQueue.insert(i, rec);
       }
     }

--- a/src/apps/vpn/serverlatency.h
+++ b/src/apps/vpn/serverlatency.h
@@ -31,11 +31,12 @@ class ServerLatency final : public QObject {
     QString publicKey;
     quint64 timestamp;
     quint16 sequence;
+    double distance;
     int retries;
   };
   quint16 m_sequence = 0;
   PingSender* m_pingSender = nullptr;
-  QList<QString> m_pingSendQueue;
+  QList<ServerPingRecord> m_pingSendQueue;
   QList<ServerPingRecord> m_pingReplyList;
 
   QTimer m_pingTimeout;

--- a/src/apps/vpn/ui/screens/home/ViewServers.qml
+++ b/src/apps/vpn/ui/screens/home/ViewServers.qml
@@ -109,7 +109,12 @@ Item {
                             }
                             else if (multiHopEntryServer[0] === "") {
                                 // Choose a random entry server when switching to multihop
-                                multiHopEntryServer = VPNServerCountryModel.pickRandom();
+                                var best = VPNServerCountryModel.recommendedLocations(2);
+                                if ((best[0].country != multiHopExitServer[0]) || (best[0].name != multiHopExitServer[1])) {
+                                    multiHopEntryServer = [best[0].country, best[0].name, best[0].localizedName];
+                                } else {
+                                    multiHopEntryServer = [best[1].country, best[1].name, best[1].localizedName];
+                                }
                             }
                         }
 

--- a/src/shared/logger.cpp
+++ b/src/shared/logger.cpp
@@ -35,7 +35,7 @@ CREATE_LOG_OP_REF(uint64_t);
 CREATE_LOG_OP_REF(const char*);
 CREATE_LOG_OP_REF(const QString&);
 CREATE_LOG_OP_REF(const QByteArray&);
-CREATE_LOG_OP_REF(void*);
+CREATE_LOG_OP_REF(const void*);
 
 #undef CREATE_LOG_OP_REF
 

--- a/src/shared/logger.h
+++ b/src/shared/logger.h
@@ -32,7 +32,7 @@ class Logger {
     Log& operator<<(const QByteArray& t);
     Log& operator<<(const QJsonObject& t);
     Log& operator<<(QTextStreamFunction t);
-    Log& operator<<(void* t);
+    Log& operator<<(const void* t);
 
     // Q_ENUM
     template <typename T>

--- a/tests/auth/CMakeLists.txt
+++ b/tests/auth/CMakeLists.txt
@@ -59,6 +59,8 @@ target_sources(auth_tests PRIVATE
     ${MZ_SOURCE_DIR}/apps/vpn/inspector/inspectorhandler.h
     ${MZ_SOURCE_DIR}/apps/vpn/models/featuremodel.cpp
     ${MZ_SOURCE_DIR}/apps/vpn/models/featuremodel.h
+    ${MZ_SOURCE_DIR}/apps/vpn/models/location.cpp
+    ${MZ_SOURCE_DIR}/apps/vpn/models/location.h
     ${MZ_SOURCE_DIR}/apps/vpn/models/server.cpp
     ${MZ_SOURCE_DIR}/apps/vpn/models/server.h
     ${MZ_SOURCE_DIR}/apps/vpn/models/servercity.cpp

--- a/tests/auth/mocmozillavpn.cpp
+++ b/tests/auth/mocmozillavpn.cpp
@@ -35,6 +35,11 @@ ServerCountryModel* MozillaVPN::serverCountryModel() {
   return new ServerCountryModel();
 }
 
+Location* MozillaVPN::location() const {
+  static Location* location = new Location();
+  return location;
+}
+
 MozillaVPN::State MozillaVPN::state() const { return StateInitialize; }
 MozillaVPN::UserState MozillaVPN::userState() const {
   return UserNotAuthenticated;

--- a/tests/functional/testMultihop.js
+++ b/tests/functional/testMultihop.js
@@ -113,10 +113,7 @@ describe('Server list', function() {
         const cityId = queries.screenHome.serverListView.generateCityId(
             countryId, city.name);
         console.log('  Waiting for cityId:', cityId);
-        await vpn.waitForQuery(cityId.visible().prop(
-            'checked',
-            currentCountryCode === server.code &&
-                currentCity === city.localizedName));
+        await vpn.waitForQuery(cityId.visible());
       }
     }
   })

--- a/tests/qml/CMakeLists.txt
+++ b/tests/qml/CMakeLists.txt
@@ -45,6 +45,8 @@ target_sources(qml_tests PRIVATE
     ${MZ_SOURCE_DIR}/apps/vpn/inspector/inspectorhandler.h
     ${MZ_SOURCE_DIR}/apps/vpn/models/featuremodel.cpp
     ${MZ_SOURCE_DIR}/apps/vpn/models/featuremodel.h
+    ${MZ_SOURCE_DIR}/apps/vpn/models/location.cpp
+    ${MZ_SOURCE_DIR}/apps/vpn/models/location.h
     ${MZ_SOURCE_DIR}/apps/vpn/models/server.cpp
     ${MZ_SOURCE_DIR}/apps/vpn/models/server.h
     ${MZ_SOURCE_DIR}/apps/vpn/models/servercity.cpp

--- a/tests/qml/mocmozillavpn.cpp
+++ b/tests/qml/mocmozillavpn.cpp
@@ -37,6 +37,11 @@ ServerCountryModel* MozillaVPN::serverCountryModel() {
   return new ServerCountryModel();
 }
 
+Location* MozillaVPN::location() const {
+  static Location* location = new Location();
+  return location;
+}
+
 MozillaVPN::State MozillaVPN::state() const { return StateInitialize; }
 MozillaVPN::UserState MozillaVPN::userState() const {
   return UserNotAuthenticated;

--- a/tests/unit/mocmozillavpn.cpp
+++ b/tests/unit/mocmozillavpn.cpp
@@ -51,6 +51,11 @@ SubscriptionData* MozillaVPN::subscriptionData() {
   return new SubscriptionData();
 }
 
+Location* MozillaVPN::location() const {
+  static Location* location = new Location();
+  return location;
+}
+
 void MozillaVPN::initialize() {}
 
 void MozillaVPN::setState(State) {}

--- a/tests/unit/testmodels.cpp
+++ b/tests/unit/testmodels.cpp
@@ -1672,11 +1672,17 @@ void TestModels::serverCountryModelPick() {
     SettingsHolder settingsHolder;
     Localizer l;
 
-    QStringList tuple = m.pickRandom();
-    QCOMPARE(tuple.length(), 3);
-    QCOMPARE(tuple.at(0), "serverCountryCode");
-    QCOMPARE(tuple.at(1), "serverCityName");
-    QCOMPARE(tuple.at(2), "serverCityName");  // Localized?
+    QList<QVariant> results = m.recommendedLocations(1);
+    QCOMPARE(results.length(), 1);
+
+    QVariant qv = results.first();
+    QVERIFY(qv.canConvert<const ServerCity*>());
+
+    const ServerCity* city = qv.value<const ServerCity*>();
+    QVERIFY(city != nullptr);
+    QCOMPARE(city->country(), "serverCountryCode");
+    QCOMPARE(city->name(), "serverCityName");
+    QCOMPARE(city->localizedName(), "serverCityName");  // Localized?
   }
 }
 

--- a/tests/unit/testmodels.cpp
+++ b/tests/unit/testmodels.cpp
@@ -1475,7 +1475,7 @@ void TestModels::serverCountryModelFromJson_data() {
   countries.replace(0, d);
   obj.insert("countries", countries);
   QTest::addRow("good with one empty city")
-      << QJsonDocument(obj).toJson() << true << 0
+      << QJsonDocument(obj).toJson() << true << 1
       << QVariant("serverCountryName") << QVariant("serverCountryCode")
       << QVariant(QList<QVariant>{
              QStringList{"serverCityName", "serverCityName", "0"}});


### PR DESCRIPTION
## Description
This implements a method to return a list of recommended servers, `ServerCountryModel::recommendedServers()` which returns a list of `ServerCity` objects. Along the way we also tackled some cleanup:
- `cityConnectionScore()` has been converted to a property of the `ServerCity` object, allowing QML to update itself as scores change.
- Move the great-circle distance algorithm into the `Location` model.
- Trigger server latency updates on changes to the underlying features.
- Sort the order of server latency fetches by geographic distance, to try and get the best-performing results first.
- Make `ServerCountryModel::pickBest()` a wrapper for `ServerCountryModel::recommendedServers(1)`

## Reference
Github #3988 ([VPN-2529](https://mozilla-hub.atlassian.net/browse/VPN-2529))
Github #4966 ([VPN-3297](https://mozilla-hub.atlassian.net/browse/VPN-3297))

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-2529]: https://mozilla-hub.atlassian.net/browse/VPN-2529?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[VPN-3297]: https://mozilla-hub.atlassian.net/browse/VPN-3297?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ