### PR TITLE
silent switch for settings changes - VPN-3601

### DIFF
--- a/glean/metrics.yaml
+++ b/glean/metrics.yaml
@@ -287,24 +287,6 @@ sample:
       - amarchesini@mozilla.com
     expires: never
 
-  app_permissions_view_warning:
-    type: event
-    lifetime: ping
-    send_in_pings:
-      - main
-    description: |
-      The user has opened the app permissions view but is unable
-      to make changes because the VPN is on.
-    bugs:
-      - https://bugzilla.mozilla.org/show_bug.cgi?id=1711123
-    data_reviews:
-      - https://bugzilla.mozilla.org/show_bug.cgi?id=1711123#c1
-    data_sensitivity:
-      - technical
-    notification_emails:
-      - amarchesini@mozilla.com
-    expires: never
-
   authentication_aborted:
     type: event
     lifetime: ping
@@ -700,24 +682,6 @@ sample:
       - amarchesini@mozilla.com
     expires: never
 
-  network_settings_view_warning:
-    type: event
-    lifetime: ping
-    send_in_pings:
-      - main
-    description: |
-      The user has opened network settings but is unable
-      to make changes because the VPN is on.
-    bugs:
-      - https://bugzilla.mozilla.org/show_bug.cgi?id=1711123
-    data_reviews:
-      - https://bugzilla.mozilla.org/show_bug.cgi?id=1711123#c1
-    data_sensitivity:
-      - technical
-    notification_emails:
-      - amarchesini@mozilla.com
-    expires: never
-
   notifications_view_opened:
     type: event
     lifetime: ping
@@ -731,24 +695,6 @@ sample:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1711123#c1
     data_sensitivity:
       - interaction
-    notification_emails:
-      - amarchesini@mozilla.com
-    expires: never
-
-  notifications_view_warning:
-    type: event
-    lifetime: ping
-    send_in_pings:
-      - main
-    description: |
-      The user has opened notification settings and is unable
-      to make changes because the VPN is on.
-    bugs:
-      - https://bugzilla.mozilla.org/show_bug.cgi?id=1711123
-    data_reviews:
-      - https://bugzilla.mozilla.org/show_bug.cgi?id=1711123#c1
-    data_sensitivity:
-      - technical
     notification_emails:
       - amarchesini@mozilla.com
     expires: never

--- a/nebula/ui/components/VPNControllerView.qml
+++ b/nebula/ui/components/VPNControllerView.qml
@@ -18,7 +18,6 @@ Item {
         box.connectionInfoScreenVisible = false;
     }
 
-    state: VPNController.state
     Layout.preferredHeight: 318
     Layout.fillWidth: true
     Layout.leftMargin: VPNTheme.theme.listSpacing
@@ -64,7 +63,8 @@ Item {
 
     states: [
         State {
-            name: VPNController.StateInitializing
+            name: "stateInitializing"
+            when: VPNController.state === VPNController.StateInitializing
 
             PropertyChanges {
                 target: boxBackground
@@ -108,7 +108,8 @@ Item {
 
         },
         State {
-            name: VPNController.StateOff
+            name: "stateOff"
+            when: VPNController.state === VPNController.StateOff
 
             PropertyChanges {
                 target: boxBackground
@@ -151,7 +152,8 @@ Item {
 
         },
         State {
-            name: VPNController.StateConnecting
+            name: "stateConnecting"
+            when: VPNController.state === VPNController.StateConnecting
 
             PropertyChanges {
                 target: boxBackground
@@ -196,7 +198,8 @@ Item {
 
         },
         State {
-            name: VPNController.StateConfirming
+            name: "stateConfirming"
+            when: VPNController.state === VPNController.StateConfirming
 
             PropertyChanges {
                 target: boxBackground
@@ -242,7 +245,9 @@ Item {
 
         },
         State {
-            name: VPNController.StateOn
+            name: "stateOn"
+            when: (VPNController.state === VPNController.StateOn ||
+                   VPNController.state === VPNController.StateSilentSwitching)
 
             PropertyChanges {
                 target: boxBackground
@@ -279,7 +284,8 @@ Item {
             }
         },
         State {
-            name: VPNController.StateDisconnecting
+            name: "stateDisconnecting"
+            when: VPNController.state === VPNController.StateDisconnecting
 
             PropertyChanges {
                 target: boxBackground
@@ -323,7 +329,8 @@ Item {
             }
         },
         State {
-            name: VPNController.StateSwitching
+            name: "stateSwitching"
+            when: VPNController.state === VPNController.StateSwitching
 
             PropertyChanges {
                 target: boxBackground
@@ -372,7 +379,7 @@ Item {
     ]
     transitions: [
         Transition {
-            to: VPNController.StateConnecting
+            to: "stateConnecting"
 
             ColorAnimation {
                 target: boxBackground
@@ -394,7 +401,7 @@ Item {
 
         },
         Transition {
-            to: VPNController.StateDisconnecting
+            to: "stateDisconnecting"
 
             ColorAnimation {
                 target: boxBackground

--- a/nebula/ui/components/VPNDropShadowWithStates.qml
+++ b/nebula/ui/components/VPNDropShadowWithStates.qml
@@ -19,42 +19,21 @@ VPNDropShadow {
 
     states: [
         State {
-            name: VPNController.StateConnecting
+            name: "on"
+            when: (state === VPNController.StateConnecting ||
+                   state === VPNController.StateConfirming ||
+                   state === VPNController.StateOn ||
+                   state === VPNController.StateSilentSwitching ||
+                   state === VPNController.StateSwitching)
             PropertyChanges {
                 target: dropShadow
                 opacity: .3
             }
         },
         State {
-            name: VPNController.StateConfirming
-            PropertyChanges {
-                target: dropShadow
-                opacity: .3
-            }
-        },
-        State {
-            name: VPNController.StateOn
-            PropertyChanges {
-                target: dropShadow
-                opacity: .3
-            }
-        },
-        State {
-            name: VPNController.StateSwitching
-            PropertyChanges {
-                target: dropShadow
-                opacity: .3
-            }
-        },
-        State {
-            name: VPNController.StateDisconnecting
-            PropertyChanges {
-                target:dropShadow
-                opacity: .1
-            }
-        },
-        State {
-            name: VPNController.StateOff
+            name: "off"
+            when: (state === VPNController.StateDisconnecting ||
+                   state === VPNController.StateOff)
             PropertyChanges {
                 target: dropShadow
                 opacity: .1

--- a/nebula/ui/components/VPNMainImage.qml
+++ b/nebula/ui/components/VPNMainImage.qml
@@ -132,7 +132,8 @@ Rectangle {
         },
         State {
             name: "stateOn"
-            when: VPNController.state === VPNController.StateOn &&
+            when: (VPNController.state === VPNController.StateOn ||
+                   VPNController.state === VPNController.StateSilentSwitching) &&
                 VPNConnectionHealth.stability === VPNConnectionHealth.Stable
 
             PropertyChanges {
@@ -151,7 +152,8 @@ Rectangle {
         },
         State {
             name: "unstableOn"
-            when: VPNController.state === VPNController.StateOn &&
+            when: (VPNController.state === VPNController.StateOn ||
+                   VPNController.state === VPNController.StateSilentSwitching) &&
                 VPNConnectionHealth.stability === VPNConnectionHealth.Unstable
 
             PropertyChanges {
@@ -171,7 +173,8 @@ Rectangle {
         },
         State {
             name: "noSignalOn"
-            when: VPNController.state === VPNController.StateOn &&
+            when: (VPNController.state === VPNController.StateOn ||
+                   VPNController.state === VPNController.StateSilentSwitching) &&
                 VPNConnectionHealth.stability === VPNConnectionHealth.NoSignal
 
             PropertyChanges {

--- a/nebula/ui/components/VPNToggle.qml
+++ b/nebula/ui/components/VPNToggle.qml
@@ -44,7 +44,8 @@ VPNButtonBase {
 
     states: [
         State {
-            name: VPNController.StateInitializing
+            name: "stateInitializing"
+            when: VPNController.state === VPNController.StateInitializing
 
             PropertyChanges {
                 target: cursor
@@ -64,7 +65,8 @@ VPNButtonBase {
 
         },
         State {
-            name: VPNController.StateOff
+            name: "stateOff"
+            when: VPNController.state === VPNController.StateOff
 
             PropertyChanges {
                 target: cursor
@@ -85,7 +87,8 @@ VPNButtonBase {
 
         },
         State {
-            name: VPNController.StateConnecting
+            name: "stateConnecting"
+            when: VPNController.state === VPNController.StateConnecting
 
             PropertyChanges {
                 target: cursor
@@ -108,7 +111,8 @@ VPNButtonBase {
 
         },
         State {
-            name: VPNController.StateConfirming
+            name: "stateConfirming"
+            when: VPNController.state === VPNController.StateConfirming
 
             PropertyChanges {
                 target: cursor
@@ -131,7 +135,9 @@ VPNButtonBase {
 
         },
         State {
-            name: VPNController.StateOn
+            name: "stateOn"
+            when: (VPNController.state === VPNController.StateOn ||
+                   VPNController.state === VPNController.StateSilentSwitching)
 
             PropertyChanges {
                 target: cursor
@@ -152,7 +158,8 @@ VPNButtonBase {
 
         },
         State {
-            name: VPNController.StateDisconnecting
+            name: "stateDisconnecting"
+            when: VPNController.state === VPNController.StateDisconnecting
 
             PropertyChanges {
                 target: cursor
@@ -173,7 +180,8 @@ VPNButtonBase {
 
         },
         State {
-            name: VPNController.StateSwitching
+            name: "stateSwitching"
+            when: VPNController.state === VPNController.StateSwitching
 
             PropertyChanges {
                 target: cursor
@@ -222,7 +230,7 @@ VPNButtonBase {
         radius: height / 2
         border.color: toggleColor.focusBorder
         color: VPNTheme.theme.transparent
-        opacity: toggleButton.activeFocus && (VPNController.state === VPNController.StateOn || VPNController.state === VPNController.StateOff) ? 1 : 0
+        opacity: toggleButton.activeFocus && (VPNController.state === VPNController.StateOn || VPNController.state === VPNController.StateSilentSwitching || VPNController.state === VPNController.StateOff) ? 1 : 0
 
         VPNFocusOutline {
             id: vpnFocusOutline
@@ -268,6 +276,7 @@ VPNButtonBase {
     function toggleClickable() {
         return VPN.state === VPN.StateMain &&
                (VPNController.state === VPNController.StateOn ||
+                VPNController.state === VPNController.StateSilentSwitching ||
                 VPNController.state === VPNController.StateOff ||
                 (VPNController.state === VPNController.StateConfirming &&
                  (connectionRetryOverX || enableDisconnectInConfirming)));

--- a/src/apps/vpn/cmake/sources.cmake
+++ b/src/apps/vpn/cmake/sources.cmake
@@ -247,6 +247,8 @@ target_sources(mozillavpn-sources INTERFACE
     ${CMAKE_CURRENT_SOURCE_DIR}/apps/vpn/serveri18n.h
     ${CMAKE_CURRENT_SOURCE_DIR}/apps/vpn/serverlatency.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/apps/vpn/serverlatency.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/apps/vpn/settingswatcher.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/apps/vpn/settingswatcher.h
     ${CMAKE_CURRENT_SOURCE_DIR}/apps/vpn/statusicon.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/apps/vpn/statusicon.h
     ${CMAKE_CURRENT_SOURCE_DIR}/apps/vpn/tasks/account/taskaccount.cpp

--- a/src/apps/vpn/commands/commandstatus.cpp
+++ b/src/apps/vpn/commands/commandstatus.cpp
@@ -141,6 +141,8 @@ int CommandStatus::run(QStringList& tokens) {
         break;
 
       case Controller::StateOn:
+        [[fallthrough]];
+      case Controller::StateSilentSwitching:
         stream << "on";
         break;
 

--- a/src/apps/vpn/controller.cpp
+++ b/src/apps/vpn/controller.cpp
@@ -55,7 +55,8 @@ namespace {
 Logger logger("Controller");
 
 Controller::Reason stateToReason(Controller::State state) {
-  if (state == Controller::StateSwitching) {
+  if (state == Controller::StateSwitching ||
+      state == Controller::StateSilentSwitching) {
     return Controller::ReasonSwitching;
   }
 
@@ -192,7 +193,8 @@ void Controller::implInitialized(bool status, bool a_connected,
 bool Controller::activate(const ServerData& serverData) {
   logger.debug() << "Activation" << m_state;
 
-  if (m_state != StateOff && m_state != StateSwitching) {
+  if (m_state != StateOff && m_state != StateSwitching &&
+      m_state != StateSilentSwitching) {
     logger.debug() << "Already connected";
     return false;
   }
@@ -216,11 +218,11 @@ bool Controller::activate(const ServerData& serverData) {
 
   clearRetryCounter();
 
-  activateInternal(stateToReason(m_state));
+  activateInternal();
   return true;
 }
 
-void Controller::activateInternal(Reason reason, bool forcePort53) {
+void Controller::activateInternal(bool forcePort53) {
   logger.debug() << "Activation internal";
   Q_ASSERT(m_impl);
 
@@ -313,10 +315,10 @@ void Controller::activateInternal(Reason reason, bool forcePort53) {
   m_ping_canary.start(m_activationQueue.first().m_server.ipv4AddrIn(),
                       "0.0.0.0/0");
   logger.info() << "Canary Ping Started";
-  activateNext(reason);
+  activateNext();
 }
 
-void Controller::activateNext(Reason reason) {
+void Controller::activateNext() {
   MozillaVPN* vpn = MozillaVPN::instance();
   const Device* device = vpn->deviceModel()->currentDevice(vpn->keys());
   if (device == nullptr) {
@@ -328,13 +330,13 @@ void Controller::activateNext(Reason reason) {
 
   logger.debug() << "Activating peer" << logger.keys(hop.m_server.publicKey());
   m_handshakeTimer.start(HANDSHAKE_TIMEOUT_SEC * 1000);
-  m_impl->activate(hop, device, vpn->keys(), reason);
+  m_impl->activate(hop, device, vpn->keys(), stateToReason(m_state));
 
   // Move to the confirming state if we are awaiting any connection handshakes.
   setState(StateConfirming);
 }
 
-bool Controller::silentSwitchServers() {
+bool Controller::silentSwitchServers(bool serverCoolDownNeeded) {
   logger.debug() << "Silently switch servers";
 
   if (m_state != StateOn) {
@@ -352,27 +354,37 @@ bool Controller::silentSwitchServers() {
     return false;
   }
 
-  MozillaVPN::instance()->serverCountryModel()->setServerCooldown(
-      m_serverData.exitServerPublicKey());
+  if (serverCoolDownNeeded) {
+    MozillaVPN::instance()->serverCountryModel()->setServerCooldown(
+        m_serverData.exitServerPublicKey());
+  }
 
-  // Activate the first connection to kick off the server switch.
-  activateInternal(ReasonSwitching);
+  clearConnectedTime();
+  clearRetryCounter();
+
+  logger.debug() << "Switching to a different server";
+
+  setState(StateSilentSwitching);
+  deactivate();
+
   return true;
 }
 
 bool Controller::deactivate() {
   logger.debug() << "Deactivation" << m_state;
 
-  if ((m_state != StateOn) && (m_state != StateSwitching) &&
-      (m_state != StateConfirming) && (m_state != StateConnecting)) {
+  if (m_state != StateOn && m_state != StateSwitching &&
+      m_state != StateSilentSwitching && m_state != StateConfirming &&
+      m_state != StateConnecting) {
     logger.warning() << "Already disconnected";
     return false;
   }
 
-  if ((m_state == StateOn) || (m_state == StateConfirming) ||
-      (m_state == StateConnecting)) {
+  if (m_state == StateOn || m_state == StateConfirming ||
+      m_state == StateConnecting) {
     setState(StateDisconnecting);
   }
+
   m_ping_canary.stop();
   m_handshakeTimer.stop();
   m_activationQueue.clear();
@@ -400,7 +412,7 @@ void Controller::connected(const QString& pubkey) {
     // Start the next connection if there is more work to do.
     m_activationQueue.removeFirst();
     if (!m_activationQueue.isEmpty()) {
-      activateNext(stateToReason(m_state));
+      activateNext();
       return;
     }
   }
@@ -446,10 +458,10 @@ void Controller::handshakeTimeout() {
     logger.info() << "Connection Attempt: Using Port 53 Option this time.";
     // On the first retry, opportunisticly try again using the port 53
     // option enabled, if that feature is disabled.
-    activateInternal(stateToReason(m_state), true);
+    activateInternal(true);
     return;
   } else if (m_connectionRetry < CONNECTION_MAX_RETRY) {
-    activateInternal(stateToReason(m_state));
+    activateInternal();
     return;
   }
 
@@ -471,7 +483,8 @@ void Controller::disconnected() {
     return;
   }
 
-  if (nextStep == None && m_state == StateSwitching) {
+  if (nextStep == None &&
+      (m_state == StateSwitching || m_state == StateSilentSwitching)) {
     activate(m_nextServerData);
     return;
   }
@@ -494,8 +507,8 @@ void Controller::quit() {
 
   m_nextStep = Quit;
 
-  if ((m_state == StateOn) || (m_state == StateSwitching) ||
-      (m_state == StateConnecting)) {
+  if (m_state == StateOn || m_state == StateSwitching ||
+      m_state == StateSilentSwitching || m_state == StateConnecting) {
     deactivate();
     return;
   }
@@ -511,8 +524,9 @@ void Controller::backendFailure() {
 
   m_nextStep = BackendFailure;
 
-  if ((m_state == StateOn) || (m_state == StateSwitching) ||
-      (m_state == StateConnecting) || (m_state == StateConfirming)) {
+  if (m_state == StateOn || m_state == StateSwitching ||
+      m_state == StateSilentSwitching || m_state == StateConnecting ||
+      m_state == StateConfirming) {
     deactivate();
     return;
   }
@@ -523,8 +537,9 @@ void Controller::serverUnavailable() {
 
   m_nextStep = ServerUnavailable;
 
-  if ((m_state == StateOn) || (m_state == StateSwitching) ||
-      (m_state == StateConnecting) || (m_state == StateConfirming)) {
+  if (m_state == StateOn || m_state == StateSwitching ||
+      m_state == StateSilentSwitching || m_state == StateConnecting ||
+      m_state == StateConfirming) {
     deactivate();
     return;
   }

--- a/src/apps/vpn/controller.h
+++ b/src/apps/vpn/controller.h
@@ -45,6 +45,7 @@ class Controller final : public QObject {
     StateConfirming,
     StateOn,
     StateDisconnecting,
+    StateSilentSwitching,
     StateSwitching,
   };
   Q_ENUM(State)
@@ -82,7 +83,7 @@ class Controller final : public QObject {
   qint64 time() const;
 
   bool switchServers(const ServerData& serverData);
-  bool silentSwitchServers();
+  bool silentSwitchServers(bool serverCoolDownNeeded);
 
   void updateRequired();
 
@@ -141,7 +142,6 @@ class Controller final : public QObject {
   void readyToServerUnavailable(bool pingReceived);
   void connectionRetryChanged();
   void enableDisconnectInConfirmingChanged();
-  void silentSwitchDone();
   void activationBlockedForCaptivePortal();
   void handshakeFailed(const QString& serverHostname);
 
@@ -158,8 +158,8 @@ class Controller final : public QObject {
   QList<IPAddress> getAllowedIPAddressRanges(const Server& server);
   QStringList getExcludedAddresses();
 
-  void activateInternal(Reason reason, bool forceDNSPort = false);
-  void activateNext(Reason reason);
+  void activateInternal(bool forceDNSPort = false);
+  void activateNext();
 
   void clearRetryCounter();
   void clearConnectedTime();

--- a/src/apps/vpn/mozillavpn.cpp
+++ b/src/apps/vpn/mozillavpn.cpp
@@ -26,6 +26,7 @@
 #include "purchasehandler.h"
 #include "qmlengineholder.h"
 #include "settingsholder.h"
+#include "settingswatcher.h"
 #include "tasks/account/taskaccount.h"
 #include "tasks/adddevice/taskadddevice.h"
 #include "tasks/addonindex/taskaddonindex.h"
@@ -297,6 +298,8 @@ void MozillaVPN::initialize() {
 
   m_private->m_captivePortalDetection.initialize();
   m_private->m_networkWatcher.initialize();
+
+  SettingsWatcher::instance();
 
   if (!settingsHolder->hasToken()) {
     return;

--- a/src/apps/vpn/mozillavpn.cpp
+++ b/src/apps/vpn/mozillavpn.cpp
@@ -1256,7 +1256,8 @@ void MozillaVPN::silentSwitch() {
   // to run the silenct-switch.
   TaskScheduler::deleteTasks();
   TaskScheduler::scheduleTask(
-      new TaskControllerAction(TaskControllerAction::eSilentSwitch));
+      new TaskControllerAction(TaskControllerAction::eSilentSwitch,
+                               TaskControllerAction::eServerCoolDownNeeded));
 }
 
 void MozillaVPN::refreshDevices() {

--- a/src/apps/vpn/networkwatcher.cpp
+++ b/src/apps/vpn/networkwatcher.cpp
@@ -128,7 +128,8 @@ void NetworkWatcher::unsecuredNetwork(const QString& networkName,
 
   Controller::State state = vpn->controller()->state();
   if (state == Controller::StateOn || state == Controller::StateConnecting ||
-      state == Controller::StateSwitching) {
+      state == Controller::StateSwitching ||
+      state == Controller::StateSilentSwitching) {
     logger.debug() << "VPN on. Ignoring unsecured network";
     return;
   }

--- a/src/apps/vpn/notificationhandler.cpp
+++ b/src/apps/vpn/notificationhandler.cpp
@@ -159,7 +159,7 @@ void NotificationHandler::showNotification() {
                            .arg(localizedCityName),
                        NOTIFICATION_TIME_MSEC);
       }
-        return;
+      return;
 
     case Controller::StateOff:
       if (m_connected) {

--- a/src/apps/vpn/notificationhandler.cpp
+++ b/src/apps/vpn/notificationhandler.cpp
@@ -30,6 +30,8 @@
 
 #include "systemtraynotificationhandler.h"
 
+constexpr int NOTIFICATION_TIME_MSEC = 2000;
+
 namespace {
 Logger logger("NotificationHandler");
 
@@ -96,9 +98,6 @@ void NotificationHandler::showNotification() {
     return;
   }
 
-  QString title;
-  QString message;
-
   // We want to show notifications about the location in use by the controller,
   // which could be different than MozillaVPN::serverData in the rare case of a
   // server-switch request processed in the meantime.
@@ -109,8 +108,6 @@ void NotificationHandler::showNotification() {
 
   switch (vpn->controller()->state()) {
     case Controller::StateOn:
-      m_connected = true;
-
       if (m_switching) {
         m_switching = false;
 
@@ -132,25 +129,37 @@ void NotificationHandler::showNotification() {
           // https://github.com/mozilla-mobile/mozilla-vpn-client/issues/1719
           return;
         }
+
         // "VPN Switched Servers"
-        title = L18nStrings::instance()->t(
-            L18nStrings::NotificationsVPNSwitchedServersTitle);
-        message = L18nStrings::instance()
-                      ->t(L18nStrings::NotificationsVPNSwitchedServersMessage)
-                      .arg(localizedPreviousExitCityName, localizedCityName);
-      } else {
+        notifyInternal(
+            None,
+            L18nStrings::instance()->t(
+                L18nStrings::NotificationsVPNSwitchedServersTitle),
+            L18nStrings::instance()
+                ->t(L18nStrings::NotificationsVPNSwitchedServersMessage)
+                .arg(localizedPreviousExitCityName, localizedCityName),
+            NOTIFICATION_TIME_MSEC);
+        return;
+      }
+
+      if (!m_connected) {
+        m_connected = true;
+
         if (!SettingsHolder::instance()->connectionChangeNotification()) {
           // Notifications for ConnectionChange are disabled
           return;
         }
+
         // "VPN Connected"
-        title = L18nStrings::instance()->t(
-            L18nStrings::NotificationsVPNConnectedTitle);
-        message = L18nStrings::instance()
-                      ->t(L18nStrings::NotificationsVPNConnectedMessage)
-                      .arg(localizedCityName);
+        notifyInternal(None,
+                       L18nStrings::instance()->t(
+                           L18nStrings::NotificationsVPNConnectedTitle),
+                       L18nStrings::instance()
+                           ->t(L18nStrings::NotificationsVPNConnectedMessage)
+                           .arg(localizedCityName),
+                       NOTIFICATION_TIME_MSEC);
       }
-      break;
+        return;
 
     case Controller::StateOff:
       if (m_connected) {
@@ -160,28 +169,31 @@ void NotificationHandler::showNotification() {
           return;
         }
         // "VPN Disconnected"
-        title = L18nStrings::instance()->t(
-            L18nStrings::NotificationsVPNDisconnectedTitle);
-        message = L18nStrings::instance()
-                      ->t(L18nStrings::NotificationsVPNDisconnectedMessage)
-                      .arg(localizedCityName);
+        notifyInternal(None,
+                       L18nStrings::instance()->t(
+                           L18nStrings::NotificationsVPNDisconnectedTitle),
+                       L18nStrings::instance()
+                           ->t(L18nStrings::NotificationsVPNDisconnectedMessage)
+                           .arg(localizedCityName),
+                       NOTIFICATION_TIME_MSEC);
       }
-      break;
+      return;
+
+    case Controller::StateSilentSwitching:
+      m_connected = true;
+      m_switching = false;
+      return;
 
     case Controller::StateSwitching:
       m_connected = true;
       m_switching = true;
-      break;
+      return;
 
     default:
-      break;
+      return;
   }
 
-  Q_ASSERT(title.isEmpty() == message.isEmpty());
-
-  if (!title.isEmpty()) {
-    notifyInternal(None, title, message, 2000);
-  }
+  Q_ASSERT(false);
 }
 
 void NotificationHandler::captivePortalBlockNotificationRequired() {

--- a/src/apps/vpn/qmake/sources.pri
+++ b/src/apps/vpn/qmake/sources.pri
@@ -110,6 +110,8 @@ SOURCES += \
         apps/vpn/releasemonitor.cpp \
         apps/vpn/serveri18n.cpp \
         apps/vpn/serverlatency.cpp \
+        apps/vpn/settingswatcher.cpp \
+        apps/vpn/settingswatcher.h \
         apps/vpn/statusicon.cpp \
         apps/vpn/tasks/account/taskaccount.cpp \
         apps/vpn/tasks/adddevice/taskadddevice.cpp \

--- a/src/apps/vpn/qmake/sources.pri
+++ b/src/apps/vpn/qmake/sources.pri
@@ -111,7 +111,6 @@ SOURCES += \
         apps/vpn/serveri18n.cpp \
         apps/vpn/serverlatency.cpp \
         apps/vpn/settingswatcher.cpp \
-        apps/vpn/settingswatcher.h \
         apps/vpn/statusicon.cpp \
         apps/vpn/tasks/account/taskaccount.cpp \
         apps/vpn/tasks/adddevice/taskadddevice.cpp \
@@ -261,6 +260,7 @@ HEADERS += \
         apps/vpn/releasemonitor.h \
         apps/vpn/serveri18n.h \
         apps/vpn/serverlatency.h \
+        apps/vpn/settingswatcher.h \
         apps/vpn/statusicon.h \
         apps/vpn/tasks/account/taskaccount.h \
         apps/vpn/tasks/adddevice/taskadddevice.h \

--- a/src/apps/vpn/settingswatcher.cpp
+++ b/src/apps/vpn/settingswatcher.cpp
@@ -1,0 +1,60 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "settingswatcher.h"
+
+#include <QCoreApplication>
+#include <QMetaMethod>
+#include <QMetaObject>
+
+#include "leakdetector.h"
+#include "logger.h"
+#include "mozillavpn.h"
+#include "settingsholder.h"
+#include "tasks/controlleraction/taskcontrolleraction.h"
+#include "taskscheduler.h"
+
+namespace {
+Logger logger("SettingsWatcher");
+}
+
+SettingsWatcher::SettingsWatcher(QObject* parent) : QObject(parent) {
+  MZ_COUNT_CTOR(SettingsWatcher);
+
+  SettingsHolder* settingsHolder = SettingsHolder::instance();
+
+#define CONNECT(x)                                  \
+  connect(settingsHolder, &SettingsHolder::x, this, \
+          &SettingsWatcher::maybeServerSwitch);
+
+  CONNECT(captivePortalAlertChanged);
+  CONNECT(protectSelectedAppsChanged);
+  CONNECT(dnsProviderChanged);
+  CONNECT(userDNSChanged);
+
+#undef CONNECT
+}
+
+SettingsWatcher::~SettingsWatcher() { MZ_COUNT_DTOR(SettingsWatcher); }
+
+// static
+SettingsWatcher* SettingsWatcher::instance() {
+  static SettingsWatcher* s_instance = nullptr;
+  if (!s_instance) {
+    s_instance = new SettingsWatcher(qApp);
+  }
+  return s_instance;
+}
+
+void SettingsWatcher::maybeServerSwitch() {
+  logger.debug() << "Settings changed!";
+
+  if (MozillaVPN::instance()->controller()->state() != Controller::StateOn) {
+    return;
+  }
+
+  TaskScheduler::deleteTasks();
+  TaskScheduler::scheduleTask(
+      new TaskControllerAction(TaskControllerAction::eSilentSwitch));
+}

--- a/src/apps/vpn/settingswatcher.cpp
+++ b/src/apps/vpn/settingswatcher.cpp
@@ -56,5 +56,6 @@ void SettingsWatcher::maybeServerSwitch() {
 
   TaskScheduler::deleteTasks();
   TaskScheduler::scheduleTask(
-      new TaskControllerAction(TaskControllerAction::eSilentSwitch));
+      new TaskControllerAction(TaskControllerAction::eSilentSwitch,
+                               TaskControllerAction::eServerCoolDownNotNeeded));
 }

--- a/src/apps/vpn/settingswatcher.h
+++ b/src/apps/vpn/settingswatcher.h
@@ -7,6 +7,10 @@
 
 #include <QObject>
 
+/**
+ * @brief this class watches a few setting properties to see if we need to
+ * trigger a silent-server-switch
+ */
 class SettingsWatcher final : public QObject {
   Q_OBJECT
   Q_DISABLE_COPY_MOVE(SettingsWatcher)

--- a/src/apps/vpn/settingswatcher.h
+++ b/src/apps/vpn/settingswatcher.h
@@ -1,0 +1,26 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef SETTINGSWATCHER_H
+#define SETTINGSWATCHER_H
+
+#include <QObject>
+
+class SettingsWatcher final : public QObject {
+  Q_OBJECT
+  Q_DISABLE_COPY_MOVE(SettingsWatcher)
+
+ public:
+  static SettingsWatcher* instance();
+
+  ~SettingsWatcher();
+
+ private slots:
+  void maybeServerSwitch();
+
+ private:
+  explicit SettingsWatcher(QObject* parent);
+};
+
+#endif  // SETTINGSWATCHER_H

--- a/src/apps/vpn/statusicon.cpp
+++ b/src/apps/vpn/statusicon.cpp
@@ -94,6 +94,8 @@ const QString StatusIcon::iconString() {
 
   switch (vpn->controller()->state()) {
     case Controller::StateOn:
+      [[fallthrough]];
+    case Controller::StateSilentSwitching:
       m_animatedIconTimer.stop();
       return LOGO_GENERIC_ON;
       break;

--- a/src/apps/vpn/systemtraynotificationhandler.cpp
+++ b/src/apps/vpn/systemtraynotificationhandler.cpp
@@ -174,6 +174,8 @@ void SystemTrayNotificationHandler::updateContextMenu() {
 
   switch (vpn->controller()->state()) {
     case Controller::StateOn:
+      [[fallthrough]];
+    case Controller::StateSilentSwitching:
       statusLabel = l18nStrings->t(L18nStrings::SystrayStatusConnectedTo);
       break;
 

--- a/src/apps/vpn/tasks/controlleraction/taskcontrolleraction.cpp
+++ b/src/apps/vpn/tasks/controlleraction/taskcontrolleraction.cpp
@@ -15,13 +15,15 @@ Logger logger("TaskControllerAction");
 }
 
 TaskControllerAction::TaskControllerAction(
-    TaskControllerAction::TaskAction action)
+    TaskControllerAction::TaskAction action,
+    ServerCoolDownPolicyForSilentSwitch serverCoolDownPolicy)
     : Task("TaskControllerAction"),
       m_action(action),
       m_lastState(Controller::State::StateOff),
       // Let's take a copy of the current server-data to activate/switch to the
       // current locations even if the settings change in the meantime.
-      m_serverData(*MozillaVPN::instance()->serverData()) {
+      m_serverData(*MozillaVPN::instance()->serverData()),
+      m_serverCoolDownPolicy(serverCoolDownPolicy) {
   MZ_COUNT_CTOR(TaskControllerAction);
 
   logger.debug() << "TaskControllerAction created" << action;
@@ -38,13 +40,8 @@ void TaskControllerAction::run() {
   Controller* controller = MozillaVPN::instance()->controller();
   Q_ASSERT(controller);
 
-  if (m_action == eSilentSwitch) {
-    connect(controller, &Controller::silentSwitchDone, this,
-            &TaskControllerAction::silentSwitchDone, Qt::QueuedConnection);
-  } else {
-    connect(controller, &Controller::stateChanged, this,
-            &TaskControllerAction::stateChanged, Qt::QueuedConnection);
-  }
+  connect(controller, &Controller::stateChanged, this,
+          &TaskControllerAction::stateChanged, Qt::QueuedConnection);
 
   bool expectSignal = false;
 
@@ -60,7 +57,8 @@ void TaskControllerAction::run() {
       break;
 
     case eSilentSwitch:
-      expectSignal = controller->silentSwitchServers();
+      expectSignal = controller->silentSwitchServers(m_serverCoolDownPolicy ==
+                                                     eServerCoolDownNeeded);
       break;
 
     case eSwitch:
@@ -96,12 +94,6 @@ void TaskControllerAction::stateChanged() {
     m_timer.stop();
     emit completed();
   }
-}
-
-void TaskControllerAction::silentSwitchDone() {
-  logger.debug() << "Operation completed";
-  m_timer.stop();
-  emit completed();
 }
 
 void TaskControllerAction::checkStatus() {

--- a/src/apps/vpn/tasks/controlleraction/taskcontrolleraction.h
+++ b/src/apps/vpn/tasks/controlleraction/taskcontrolleraction.h
@@ -27,7 +27,15 @@ class TaskControllerAction final : public Task {
   };
   Q_ENUM(TaskAction);
 
-  explicit TaskControllerAction(TaskAction action);
+  enum ServerCoolDownPolicyForSilentSwitch {
+    eServerCoolDownNeeded,
+    eServerCoolDownNotNeeded,
+  };
+
+  explicit TaskControllerAction(
+      TaskAction action,
+      ServerCoolDownPolicyForSilentSwitch serverCoolDownPolicy =
+          eServerCoolDownNotNeeded);
   ~TaskControllerAction();
 
   void run() override;
@@ -36,7 +44,6 @@ class TaskControllerAction final : public Task {
 
  private:
   void stateChanged();
-  void silentSwitchDone();
   void checkStatus();
 
  private:
@@ -44,6 +51,8 @@ class TaskControllerAction final : public Task {
   Controller::State m_lastState;
   ServerData m_serverData;
   QTimer m_timer;
+  ServerCoolDownPolicyForSilentSwitch m_serverCoolDownPolicy =
+      eServerCoolDownNotNeeded;
 };
 
 #endif  // TASKCONTROLLERACTION_H

--- a/src/apps/vpn/ui/screens/getHelp/developerMenu/ViewDeveloperMenu.qml
+++ b/src/apps/vpn/ui/screens/getHelp/developerMenu/ViewDeveloperMenu.qml
@@ -14,8 +14,6 @@ VPNViewBase {
     _menuTitle: VPNl18n.SettingsDevTitle
     _viewContentData: ColumnLayout {
         id: root
-        property bool vpnIsOff: (VPNController.state === VPNController.StateOff) ||
-                                    (VPNController.state === VPNController.StateInitializing)
         Layout.fillWidth: true
 
         spacing: VPNTheme.theme.windowMargin
@@ -39,12 +37,9 @@ VPNViewBase {
             labelText: VPNl18n.SettingsDevUseStagingTitle
             subLabelText: VPNl18n.SettingsDevUseStagingSubtitle
             isChecked: VPNSettings.stagingServer
-            enabled: root.vpnIsOff
             showDivider: false
             onClicked: {
-                if (root.vpnIsOff) {
-                    VPNSettings.stagingServer = !VPNSettings.stagingServer
-                }
+                VPNSettings.stagingServer = !VPNSettings.stagingServer
             }
         }
 
@@ -56,7 +51,7 @@ VPNViewBase {
             Layout.leftMargin: VPNTheme.theme.windowMargin * 3
 
             Layout.alignment: Qt.AlignHCenter
-            enabled: root.vpnIsOff && VPNSettings.stagingServer
+            enabled: VPNSettings.stagingServer
             _placeholderText: "Staging server address"
             Layout.preferredHeight: VPNTheme.theme.rowHeight
 
@@ -65,7 +60,7 @@ VPNViewBase {
             }
 
             onTextChanged: text => {
-                               if (root.vpnIsOff && VPNSettings.stagingServerAddress !== serverAddressInput.text) {
+                               if (VPNSettings.stagingServerAddress !== serverAddressInput.text) {
                                    VPNSettings.stagingServerAddress = serverAddressInput.text;
                                }
                            }
@@ -86,9 +81,7 @@ VPNViewBase {
             isChecked: VPNSettings.addonCustomServer
             showDivider: false
             onClicked: {
-                if (root.vpnIsOff) {
-                    VPNSettings.addonCustomServer = !VPNSettings.addonCustomServer
-                }
+                VPNSettings.addonCustomServer = !VPNSettings.addonCustomServer
             }
         }
 

--- a/src/apps/vpn/ui/screens/settings/ViewNetworkSettings.qml
+++ b/src/apps/vpn/ui/screens/settings/ViewNetworkSettings.qml
@@ -15,7 +15,6 @@ VPNViewBase {
     objectName: "settingsNetworkingBackButton"
 
     property string _appPermissionsTitle
-    property bool vpnIsOff: (VPNController.state === VPNController.StateOff)
 
     //% "Network settings"
     _menuTitle: qsTrId("vpn.settings.networking")
@@ -23,25 +22,6 @@ VPNViewBase {
         id: col
         spacing: VPNTheme.theme.windowMargin
         Layout.fillWidth: true
-
-        VPNContextualAlerts {
-            anchors {
-                left: parent.left
-                right: parent.right
-                leftMargin: VPNTheme.theme.windowMargin
-                rightMargin: VPNTheme.theme.windowMargin
-            }
-
-            messages: [
-                {
-                    type: "warning",
-                    //% "VPN must be off to edit these settings"
-                    //: Associated to a group of settings that require the VPN to be disconnected to change
-                    message: qsTrId("vpn.settings.vpnMustBeOff"),
-                    visible: VPNController.state !== VPNController.StateOff
-                }
-            ]
-        }
 
         Column {
             width: parent.width
@@ -79,9 +59,5 @@ VPNViewBase {
     Component.onCompleted: {
         VPNGleanDeprecated.recordGleanEvent("networkSettingsViewOpened");
         Glean.sample.networkSettingsViewOpened.record();
-        if (!vpnIsOff) {
-            VPNGleanDeprecated.recordGleanEvent("networkSettingsViewWarning");
-            Glean.sample.networkSettingsViewWarning.record();
-        }
     }
 }

--- a/src/apps/vpn/ui/screens/settings/ViewNotifications.qml
+++ b/src/apps/vpn/ui/screens/settings/ViewNotifications.qml
@@ -12,8 +12,6 @@ import components.forms 0.1
 
 
 VPNViewBase {
-    property bool vpnIsOff: (VPNController.state === VPNController.StateOff)
-
     id: vpnFlickable
     objectName: "settingsNotifications"
 
@@ -25,24 +23,6 @@ VPNViewBase {
         Layout.rightMargin: VPNTheme.theme.windowMargin
         spacing: VPNTheme.theme.windowMargin
 
-        VPNContextualAlerts {
-            anchors {
-                left: parent.left
-                leftMargin: VPNTheme.theme.windowMargin
-                right: parent.right
-                topMargin: VPNTheme.theme.windowMargin
-            }
-            messages: [
-                {
-                    type: "warning",
-                    //% "VPN must be off to edit these settings"
-                    //: Associated to a group of settings that require the VPN to be disconnected to change
-                    message: qsTrId("vpn.settings.vpnMustBeOff"),
-                    visible: !vpnFlickable.vpnIsOff && (captivePortalAlert.visible || unsecuredNetworkAlert.visible)
-                }
-            ]
-        }
-
         VPNCheckBoxRow {
             id: captivePortalAlert
             objectName: "settingCaptivePortalAlert"
@@ -53,12 +33,10 @@ VPNViewBase {
             //% "Get notified if a guest Wi-Fi portal is blocked due to VPN connection"
             subLabelText: qsTrId("vpn.settings.guestWifiAlert.description")
             isChecked: (VPNSettings.captivePortalAlert)
-            enabled: vpnFlickable.vpnIsOff
+            enabled: true
             showDivider: false
             onClicked: {
-                if (vpnFlickable.vpnIsOff) {
-                    VPNSettings.captivePortalAlert = !VPNSettings.captivePortalAlert
-                }
+                VPNSettings.captivePortalAlert = !VPNSettings.captivePortalAlert
             }
         }
 
@@ -73,12 +51,10 @@ VPNViewBase {
             //% "Get notified if you connect to an unsecured Wi-Fi network"
             subLabelText: qsTrId("vpn.settings.unsecuredNetworkAlert.description")
             isChecked: (VPNSettings.unsecuredNetworkAlert)
-            enabled: vpnFlickable.vpnIsOff
+            enabled: true
             showDivider: !enabled
             onClicked: {
-                if (vpnFlickable.vpnIsOff) {
-                    VPNSettings.unsecuredNetworkAlert = !VPNSettings.unsecuredNetworkAlert
-                }
+                VPNSettings.unsecuredNetworkAlert = !VPNSettings.unsecuredNetworkAlert
             }
         }
 
@@ -134,9 +110,5 @@ VPNViewBase {
     Component.onCompleted: {
         VPNGleanDeprecated.recordGleanEvent("notificationsViewOpened");
         Glean.sample.notificationsViewOpened.record();
-        if (!vpnIsOff) {
-            VPNGleanDeprecated.recordGleanEvent("notificationsViewWarning");
-            Glean.sample.notificationsViewWarning.record();
-        }
     }
 }

--- a/src/apps/vpn/ui/screens/settings/ViewNotifications.qml
+++ b/src/apps/vpn/ui/screens/settings/ViewNotifications.qml
@@ -33,7 +33,6 @@ VPNViewBase {
             //% "Get notified if a guest Wi-Fi portal is blocked due to VPN connection"
             subLabelText: qsTrId("vpn.settings.guestWifiAlert.description")
             isChecked: (VPNSettings.captivePortalAlert)
-            enabled: true
             showDivider: false
             onClicked: {
                 VPNSettings.captivePortalAlert = !VPNSettings.captivePortalAlert

--- a/src/apps/vpn/ui/screens/settings/appPermissions/AppPermissionsList.qml
+++ b/src/apps/vpn/ui/screens/settings/appPermissions/AppPermissionsList.qml
@@ -29,21 +29,13 @@ ColumnLayout {
     states: [
         State {
             name: "visibleAndEnabled"
-            when: VPNSettings.protectSelectedApps && vpnIsOff
+            when: VPNSettings.protectSelectedApps
             PropertyChanges {
                 target: appListContainer
                 opacity: 1
                 visible: true
             }
 
-        },
-        State {
-            when: VPNSettings.protectSelectedApps && !vpnIsOff
-            PropertyChanges {
-                target: appListContainer
-                opacity: .5
-                visible: true
-            }
         },
         State {
             name: "hidden"
@@ -115,7 +107,7 @@ ColumnLayout {
         _searchBarHasError: applist.count === 0
         _searchBarPlaceholderText: searchBarPlaceholder
 
-        enabled: vpnIsOff && VPNSettings.protectSelectedApps
+        enabled: VPNSettings.protectSelectedApps
         Layout.fillWidth: true
     }
 
@@ -143,7 +135,7 @@ ColumnLayout {
                 showAppImage: true
                 onClicked: VPNAppPermissions.flip(appID)
                 isChecked: !appIsEnabled
-                enabled: vpnIsOff && VPNSettings.protectSelectedApps
+                enabled: VPNSettings.protectSelectedApps
                 Layout.minimumHeight: VPNTheme.theme.rowHeight * 1.5
             }
         }
@@ -155,7 +147,6 @@ ColumnLayout {
         width: undefined
         onClicked: VPNAppPermissions.openFilePicker()
         visible: Qt.platform.os === "windows"
-        enabled: vpnIsOff
         contentItem: Text {
             // for accessibility
             text: addApplication

--- a/src/apps/vpn/ui/screens/settings/appPermissions/ViewAppPermissions.qml
+++ b/src/apps/vpn/ui/screens/settings/appPermissions/ViewAppPermissions.qml
@@ -12,8 +12,6 @@ import components.forms 0.1
 
 
 VPNViewBase {
-    property bool vpnIsOff: (VPNController.state === VPNController.StateOff)
-
     //% "Search apps"
     //: Search bar placeholder text
     property string searchApps: qsTrId("vpn.protectSelectedApps.searchApps")
@@ -38,22 +36,6 @@ VPNViewBase {
             Layout.fillWidth: true
             Layout.fillHeight: false
             spacing: 0
-
-            VPNContextualAlerts {
-                id: vpnOnAlert
-                Layout.fillWidth: true
-                Layout.fillHeight: false
-
-                messages: [
-                    {
-                        type: "warning",
-                        //% "VPN must be off to edit App Permissions"
-                        //: Associated to a group of settings that require the VPN to be disconnected to change
-                        message: qsTrId("vpn.settings.protectSelectedApps.vpnMustBeOff"),
-                        visible: !vpnFlickable.vpnIsOff
-                    }
-                ]
-            }
 
             Connections {
                 target: VPNAppPermissions
@@ -89,7 +71,7 @@ VPNViewBase {
             id: toggleCard
 
             toggleObjectName: "settingsAppPermissionsToggle"
-            toggleEnabled: vpnFlickable.vpnIsOff
+            toggleEnabled: true
             Layout.fillWidth: true
             Layout.preferredHeight: childrenRect.height + VPNTheme.theme.windowMargin
 
@@ -104,9 +86,7 @@ VPNViewBase {
             toggleChecked: (!VPNSettings.protectSelectedApps)
 
             function handleClick() {
-                if (vpnFlickable.vpnIsOff) {
-                    VPNSettings.protectSelectedApps = !VPNSettings.protectSelectedApps
-                }
+                VPNSettings.protectSelectedApps = !VPNSettings.protectSelectedApps
             }
         }
 
@@ -150,11 +130,6 @@ VPNViewBase {
         VPNAppPermissions.requestApplist();
         VPNGleanDeprecated.recordGleanEvent("appPermissionsViewOpened");
         Glean.sample.appPermissionsViewOpened.record();
-
-        if (!vpnIsOff) {
-            VPNGleanDeprecated.recordGleanEvent("appPermissionsViewWarning");
-            Glean.sample.appPermissionsViewWarning.record();
-        }
     }
 
 }

--- a/src/apps/vpn/ui/screens/settings/dnsSettings/DNSSettingsTabContent.qml
+++ b/src/apps/vpn/ui/screens/settings/dnsSettings/DNSSettingsTabContent.qml
@@ -17,7 +17,6 @@ import telemetry 0.30
 VPNFlickable {
 
     id: vpnFlickable
-    property bool vpnIsOff: (VPNController.state === VPNController.StateOff)
     property alias settingsListModel: repeater.model
 
     flickContentHeight: col.height + col.anchors.topMargin
@@ -32,17 +31,6 @@ VPNFlickable {
         anchors.right: parent.right
         anchors.rightMargin: VPNTheme.theme.windowMargin
         spacing: VPNTheme.theme.vSpacing
-
-        VPNCheckBoxAlert {
-            id: alert
-            //% "VPN must be off to edit these settings"
-            //: Associated to a group of settings that require the VPN to be disconnected to change
-            errorMessage: qsTrId("vpn.settings.vpnMustBeOff")
-            anchors {
-                left: undefined
-                right: undefined
-            }
-        }
 
         Repeater {
             id: repeater
@@ -60,7 +48,7 @@ VPNFlickable {
                     checked: VPNSettings.dnsProvider == settingValue
                     ButtonGroup.group: radioButtonGroup
                     accessibleName: settingTitle
-                    enabled: vpnIsOff
+                    enabled: true
                     onClicked: VPNSettings.dnsProvider = settingValue
                 }
 
@@ -73,7 +61,6 @@ VPNFlickable {
 
                         text: settingTitle
                         wrapMode: Text.WordWrap
-                        opacity: vpnIsOff ? 1 : .5
                         horizontalAlignment: Text.AlignLeft
 
                         VPNMouseArea {
@@ -91,8 +78,6 @@ VPNFlickable {
 
                     VPNTextBlock {
                         text: settingDescription
-                        opacity: vpnIsOff ? 1 : .5
-
                         Layout.fillWidth: true
                     }
 
@@ -118,7 +103,7 @@ VPNFlickable {
 
                                 hasError: valueInvalid
                                 visible: showDNSInput
-                                enabled: (VPNSettings.dnsProvider === VPNSettings.Custom) && vpnIsOff
+                                enabled: (VPNSettings.dnsProvider === VPNSettings.Custom)
                                 onEnabledChanged: if(enabled) forceActiveFocus()
 
                                 _placeholderText: VPN.placeholderUserDNS

--- a/tests/functional/helper.js
+++ b/tests/functional/helper.js
@@ -62,7 +62,7 @@ module.exports = {
   async activateViaToggle() {
     await this.waitForQueryAndClick(
         queries.screenHome.CONTROLLER_TOGGLE.visible().prop(
-            'state', /* VPNController.StateOff: */ 1));
+            'state', 'stateOff'));
   },
 
   async activate(awaitConnectionOkay = false) {

--- a/tests/qml/moccontroller.cpp
+++ b/tests/qml/moccontroller.cpp
@@ -19,12 +19,9 @@ bool Controller::activate(const ServerData&) { return false; }
 
 bool Controller::switchServers(const ServerData& serverData) { return false; }
 
-bool Controller::silentSwitchServers() { return false; }
+bool Controller::silentSwitchServers(bool) { return false; }
 
-void Controller::activateInternal(Reason reason, bool forcePort53) {
-  Q_UNUSED(reason);
-  Q_UNUSED(forcePort53)
-}
+void Controller::activateInternal(bool forcePort53) { Q_UNUSED(forcePort53) }
 
 bool Controller::deactivate() { return false; }
 

--- a/tests/unit/moccontroller.cpp
+++ b/tests/unit/moccontroller.cpp
@@ -20,12 +20,9 @@ bool Controller::activate(const ServerData&) { return false; }
 
 bool Controller::switchServers(const ServerData& serverData) { return false; }
 
-bool Controller::silentSwitchServers() { return false; }
+bool Controller::silentSwitchServers(bool) { return false; }
 
-void Controller::activateInternal(Reason reason, bool forcePort53) {
-  Q_UNUSED(reason);
-  Q_UNUSED(forcePort53)
-}
+void Controller::activateInternal(bool forcePort53) { Q_UNUSED(forcePort53) }
 
 bool Controller::deactivate() { return false; }
 


### PR DESCRIPTION
Tech Doc:

- We want to use silent-switch functionality to apply setting changes when the VPN is on. Silent-switch is something we already have implemented for unstable servers.
- We need a `SettingsWatcher` obj that observers settings change. When the VPN is on, and there is a setting change, this component triggers a server-switch appending a TaskControllerAction task to the queue.
- We also need to remove a few glean events and the VPN-is-off warning alerts
- The best way to make the silent-switch code more readable, I introduce a StateSilentSwitching. In this way we can reduce the `stateToReason` calls.