### PR TITLE
Fix VPN-3280: Update DNS input placeholder text and inputMethodHints

### DIFF
--- a/nebula/ui/components/forms/VPNInputStates.qml
+++ b/nebula/ui/components/forms/VPNInputStates.qml
@@ -12,6 +12,22 @@ Item {
 
     states: [
         State {
+            name: "disabled"
+            when: !itemToTarget.enabled
+
+            PropertyChanges {
+                target: itemToTarget
+                color: VPNTheme.colors.input.disabled.text
+                placeholderTextColor: VPNTheme.colors.input.disabled.placeholder
+            }
+
+            PropertyChanges {
+                target: itemToTarget.background
+                border.color: VPNTheme.colors.input.disabled.border
+                border.width: 1
+            }
+        },
+        State {
             name: "empty"
             when: itemToTarget.text === ""
                 && itemToTarget.enabled
@@ -111,22 +127,6 @@ Item {
             PropertyChanges {
                 target: itemToTarget.background
                 border.color: VPNTheme.colors.input.error.border
-                border.width: 1
-            }
-        },
-        State {
-            name: "disabled"
-            when: !itemToTarget.enabled
-
-            PropertyChanges {
-                target: itemToTarget
-                color: VPNTheme.colors.input.disabled.text
-                placeholderTextColor: VPNTheme.colors.input.disabled.placeholder
-            }
-
-            PropertyChanges {
-                target: itemToTarget.background
-                border.color: VPNTheme.colors.input.disabled.border
                 border.width: 1
             }
         }

--- a/src/apps/vpn/appconstants.h
+++ b/src/apps/vpn/appconstants.h
@@ -201,7 +201,6 @@ PRODBETAEXPR(qint64, keyRegeneratorTimeSec, 604800, 300);
 
 #undef PRODBETAEXPR
 
-constexpr const char* PLACEHOLDER_USER_DNS = "127.0.0.1";
 
 #if defined(MVPN_ADJUST)
 // These are the two auto-generated token from the Adjust dashboard for the

--- a/src/apps/vpn/appconstants.h
+++ b/src/apps/vpn/appconstants.h
@@ -201,7 +201,6 @@ PRODBETAEXPR(qint64, keyRegeneratorTimeSec, 604800, 300);
 
 #undef PRODBETAEXPR
 
-
 #if defined(MVPN_ADJUST)
 // These are the two auto-generated token from the Adjust dashboard for the
 // "Subscription Completed" event. We have two since in the Adjust dashboard we

--- a/src/apps/vpn/mozillavpn.cpp
+++ b/src/apps/vpn/mozillavpn.cpp
@@ -1689,7 +1689,6 @@ void MozillaVPN::scheduleRefreshDataTasks(bool refreshProducts) {
   TaskScheduler::scheduleTask(new TaskGroup(refreshTasks));
 }
 
-
 // static
 void MozillaVPN::registerUrlOpenerLabels() {
   UrlOpener* uo = UrlOpener::instance();

--- a/src/apps/vpn/mozillavpn.cpp
+++ b/src/apps/vpn/mozillavpn.cpp
@@ -1689,9 +1689,6 @@ void MozillaVPN::scheduleRefreshDataTasks(bool refreshProducts) {
   TaskScheduler::scheduleTask(new TaskGroup(refreshTasks));
 }
 
-QString MozillaVPN::placeholderUserDNS() const {
-  return AppConstants::PLACEHOLDER_USER_DNS;
-}
 
 // static
 void MozillaVPN::registerUrlOpenerLabels() {

--- a/src/apps/vpn/mozillavpn.h
+++ b/src/apps/vpn/mozillavpn.h
@@ -89,7 +89,6 @@ class MozillaVPN final : public QObject {
   Q_PROPERTY(bool updating READ updating NOTIFY updatingChanged)
   Q_PROPERTY(bool stagingMode READ stagingMode CONSTANT)
   Q_PROPERTY(bool debugMode READ debugMode CONSTANT)
-  Q_PROPERTY(QString placeholderUserDNS READ placeholderUserDNS CONSTANT)
 
  public:
   MozillaVPN();
@@ -296,7 +295,6 @@ class MozillaVPN final : public QObject {
 
   bool checkCurrentDevice();
 
-  QString placeholderUserDNS() const;
 
  public slots:
   void requestAbout();

--- a/src/apps/vpn/mozillavpn.h
+++ b/src/apps/vpn/mozillavpn.h
@@ -295,7 +295,6 @@ class MozillaVPN final : public QObject {
 
   bool checkCurrentDevice();
 
-
  public slots:
   void requestAbout();
 

--- a/src/apps/vpn/ui/screens/settings/ViewDNSSettings.qml
+++ b/src/apps/vpn/ui/screens/settings/ViewDNSSettings.qml
@@ -135,10 +135,11 @@ VPNViewBase {
                     enabled: VPNSettings.dnsProviderFlags === VPNSettings.Custom
                     onEnabledChanged: if(enabled) forceActiveFocus()
 
-                    _placeholderText: VPN.placeholderUserDNS
+                    _placeholderText: VPNl18n.SettingsDnsSettingsInputPlaceholder
                     text: ""
                     Layout.fillWidth: true
                     Layout.topMargin: 12
+                    inputMethodHints: Qt.ImhNoPredictiveText | Qt.ImhFormattedNumbersOnly
 
                     PropertyAnimation on opacity {
                         duration: 200

--- a/tests/auth/mocmozillavpn.cpp
+++ b/tests/auth/mocmozillavpn.cpp
@@ -164,8 +164,6 @@ void MozillaVPN::updateViewShown() {}
 
 void MozillaVPN::scheduleRefreshDataTasks(bool refreshProducts) {}
 
-QString MozillaVPN::placeholderUserDNS() const { return ""; }
-
 void MozillaVPN::registerUrlOpenerLabels() {}
 
 ServerData* MozillaVPN::serverData() {

--- a/tests/qml/mocmozillavpn.cpp
+++ b/tests/qml/mocmozillavpn.cpp
@@ -172,8 +172,6 @@ void MozillaVPN::updateViewShown() {}
 
 void MozillaVPN::scheduleRefreshDataTasks(bool refreshProducts) {}
 
-QString MozillaVPN::placeholderUserDNS() const { return ""; }
-
 void MozillaVPN::registerUrlOpenerLabels() {}
 
 ServerData* MozillaVPN::serverData() {

--- a/tests/unit/mocmozillavpn.cpp
+++ b/tests/unit/mocmozillavpn.cpp
@@ -177,8 +177,6 @@ bool MozillaVPN::checkCurrentDevice() { return true; }
 
 void MozillaVPN::scheduleRefreshDataTasks(bool refreshProducts) {}
 
-QString MozillaVPN::placeholderUserDNS() const { return ""; }
-
 void MozillaVPN::registerUrlOpenerLabels() {}
 
 // static

--- a/translations/strings.yaml
+++ b/translations/strings.yaml
@@ -313,6 +313,7 @@ settings:
   dnsSettingsCustomDNSBody: Resolve websites using a custom DNS
   dnsSettingsCustomDNSError: Invalid DNS, please try a new one
   dnsSettingsWarning: These options may cause some websites to break or not display content correctly.
+  dnsSettingsInputPlaceholder: Enter custom DNS
 
 dnsOverwriteDialog:
   titleDNS: Override DNS settings?


### PR DESCRIPTION
## Description

- Adds placeholder text to DNS input (no ticket)
- Removes VPN.placeholderUserDNS (no ticket)
- Adds `Qt.ImhFormattedNumbersOnly` to `inputMethodHints` to fix VPN-3280. Note: We use `Qt.ImhFormattedNumbersOnly` instead of `Qt.ImhDigitsOnly` so that decimal points remain available. See screenshot. 

<img width="260" alt="Screen Shot 2023-01-23 at 3 39 47 PM" src="https://user-images.githubusercontent.com/22355127/214158114-c77bbe1f-0ff8-4fc3-947c-bb61cbd60bba.png">


## Reference

VPN-3280

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
