### PR TITLE
Chore: Remove qmllint for now

### DIFF
--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -89,28 +89,3 @@ jobs:
           github_token: ${{ secrets.github_token }}
           reporter: github-pr-review # Change reporter
           android: true
-  qmllint:
-    name: Run QML-Lint
-    runs-on: ubuntu-latest
-    steps:
-      - name: Clone repo
-        uses: actions/checkout@master
-        with:
-          fetch-depth: 1
-      - name: Install Qt
-        shell: bash
-        run: |
-          python3 -m pip install aqtinstall
-          # qt6.2.4 for wasm needs the desktop linux installation
-          python3 -m aqt install-qt -O /opt linux desktop 6.2.4
-      - name: Run Lint
-        shell: bash
-        env:
-          QT_HOST_PATH: /opt/6.2.4/gcc_64
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.number }}
-        run: |
-          # Only check the files changed in the current pr
-          ./scripts/utils/lint_qml.sh -pr -s
-
-


### PR DESCRIPTION
## Description

With #5701 - around the corner, this task is not needed - not worth continue patching qmllint from the outside c:
