### PR TITLE
VPN-4001 - Update glean_parser_ext to be compatible with glean_parser 7.0.0

### DIFF
--- a/vpnglean/glean_parser_ext/templates/rust.jinja2
+++ b/vpnglean/glean_parser_ext/templates/rust.jinja2
@@ -17,15 +17,8 @@ use once_cell::sync::Lazy;
 
 {% macro generate_extra_keys(obj) -%}
 {% for name, _ in obj["_generate_enums"] %}
-{# we always use the `extra` suffix, because we only expose the new event API #}
 {% set suffix = "Extra" %}
-{% if obj|attr(name)|length %}
-    {% if obj.has_extra_types %}
-    {{ extra_keys_with_types(obj, name, suffix)|indent }}
-    {% else %}
-    compile_error!("Untyped event extras not supported. Please annotate event extras with a type. See documentation for details. (Metric: {{obj.category}}.{{obj.name}}, defined in: {{obj.defined_in['filepath']}}:{{obj.defined_in['line']}})");
-    {% endif %}
-{% endif %}
+{{ extra_keys_with_types(obj, name, suffix)|indent }}
 {% endfor %}
 {%- endmacro -%}
 


### PR DESCRIPTION
With[ the breaking change on glean_parser](https://github.com/mozilla/glean_parser/releases/tag/v7.0.0) not to support untyped event extras, the `has_extra_types` property was removed.
