### PR TITLE
Fix the license to be correctly shown on the license view - VPN-4016

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1445,7 +1445,7 @@ limitations under the License.
 
 
 The MIT License (MIT) - sentry-native
-=================================
+=====================================
 
 Copyright (c) 2019 Sentry (https://sentry.io) and individual contributors.
 All rights reserved.


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/515957/214820568-6a6b1061-f155-4075-bb0f-252702c4b5e7.png)

From @ValentinaPC - she is filing a jira issue. But in the meantime, here is the fix.