### PR TITLE
VPN-4018 - Do not get latest submodule version on Windows CI

### DIFF
--- a/taskcluster/scripts/build/windows.ps1
+++ b/taskcluster/scripts/build/windows.ps1
@@ -22,6 +22,7 @@ Remove-Item $FETCHES_PATH/VisualStudio/VC/Tools/MSVC/14.30.30705/bin/HostX64/x64
 python3 -m pip install -r requirements.txt --user
 python3 -m pip install -r taskcluster/scripts/requirements.txt --user
 git submodule update --init --force --recursive --depth=1
+git submodule update --remote i18n
 
 # Fix: pip scripts are not on path by default on tc, so glean would fail
 $PYTHON_SCRIPTS =resolve-path "$env:APPDATA\Python\Python36\Scripts"

--- a/taskcluster/scripts/build/windows.ps1
+++ b/taskcluster/scripts/build/windows.ps1
@@ -21,7 +21,7 @@ Remove-Item $FETCHES_PATH/VisualStudio/VC/Tools/MSVC/14.30.30705/bin/HostX64/x64
 # Fetch 3rdparty stuff.
 python3 -m pip install -r requirements.txt --user
 python3 -m pip install -r taskcluster/scripts/requirements.txt --user
-git submodule update --init --force --recursive --remote --depth=1
+git submodule update --init --force --recursive --depth=1
 
 # Fix: pip scripts are not on path by default on tc, so glean would fail
 $PYTHON_SCRIPTS =resolve-path "$env:APPDATA\Python\Python36\Scripts"
@@ -57,13 +57,13 @@ $BUILD_DIR =resolve-path "$TASK_WORKDIR/cmake_build"
 
 cmake --version
 if ($env:MOZ_SCM_LEVEL -eq "3") {
-    # Only on a release build we have access to those secrects. 
+    # Only on a release build we have access to those secrects.
     python3  ./taskcluster/scripts/get-secret.py -s project/mozillavpn/tokens -k sentry_dsn -f sentry_dsn
     python3  ./taskcluster/scripts/get-secret.py -s project/mozillavpn/tokens -k sentry_envelope_endpoint -f sentry_envelope_endpoint
     python3  ./taskcluster/scripts/get-secret.py -s project/mozillavpn/tokens -k sentry_debug_file_upload_key -f sentry_debug_file_upload_key
     $SENTRY_ENVELOPE_ENDPOINT = Get-Content sentry_envelope_endpoint
     $SENTRY_DSN = Get-Content sentry_dsn
-    # 
+    #
     cmake -S . -B $BUILD_DIR -GNinja -DCMAKE_BUILD_TYPE=Release -DSENTRY_DSN="$SENTRY_DSN" -DSENTRY_ENVELOPE_ENDPOINT="$SENTRY_ENVELOPE_ENDPOINT"
 } else {
     # Do the generic build
@@ -85,9 +85,9 @@ Get-ChildItem -Path $TASK_WORKDIR/artifacts
 
 if ($env:MOZ_SCM_LEVEL -eq "3") {
     sentry-cli-Windows-x86_64.exe login --auth-token $(Get-Content sentry_debug_file_upload_key)
-    # This will ask sentry to scan all files in there and upload 
+    # This will ask sentry to scan all files in there and upload
     # missing debug info, for symbolification
-    sentry-cli-Windows-x86_64.exe debug-files upload --org mozilla -p vpn-client $BUILD_DIR/src/CMakeFiles/mozillavpn.dir/vc140.pdb   
+    sentry-cli-Windows-x86_64.exe debug-files upload --org mozilla -p vpn-client $BUILD_DIR/src/CMakeFiles/mozillavpn.dir/vc140.pdb
 }
 
 # mspdbsrv might be stil running after the build, so we need to kill it


### PR DESCRIPTION
We should remove this `--remote` everywhere else it is used.
