### PR TITLE
VPN-3940 - Deactivate VPN on logout

### DIFF
--- a/src/apps/vpn/mozillavpn.cpp
+++ b/src/apps/vpn/mozillavpn.cpp
@@ -910,7 +910,7 @@ void MozillaVPN::logout() {
 void MozillaVPN::reset(bool forceInitialState) {
   logger.debug() << "Cleaning up all";
 
-  TaskScheduler::deleteTasks();
+  deactivate();
 
   SettingsHolder::instance()->clear();
   m_private->m_keys.forgetKeys();


### PR DESCRIPTION
The issue described on VPN-3940 would happen only when the user logged out and the server went into silent server switch mode. With this fix that doesn't happen anymore.

It is unclear to me yet how exactly that leads the user's internet connection to break _after a while_ because in fact the controller does turn off after silen server switch is unsuccesfull. I will attempt to investigate that on Monday, but this fixes it so there you go.

Tests are not possible because the Mozilla VPN singleton is not testable.