### PR TITLE
VPN-4019: Better messaging when failing the glean_parser version check

### DIFF
--- a/vpnglean/CMakeLists.txt
+++ b/vpnglean/CMakeLists.txt
@@ -115,7 +115,8 @@ else()
     add_dependencies(mozillavpn vpnglean_telemetry)
 endif()
 
-if(GLEAN_PARSER_VERSION VERSION_GREATER_EQUAL 5.0)
+set(GLEAN_PARSER_VERSION_MIN 5.0)
+if(GLEAN_PARSER_VERSION VERSION_GREATER_EQUAL ${GLEAN_PARSER_VERSION_MIN})
     # If the glean parser exists, then we can build the telemetry bindings.
     set(GENERATE_GLEAN_CMD
         ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/glean_parser_ext/run_glean_parser.py
@@ -129,6 +130,11 @@ elseif(IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/prebuilt)
         ${CMAKE_COMMAND} -E copy_directory
             ${CMAKE_CURRENT_SOURCE_DIR}/prebuilt/glean/generated
             ${CMAKE_CURRENT_BINARY_DIR}/glean/generated
+    )
+elseif(GLEAN_PARSER_VERSION)
+    message(FATAL_ERROR
+        "Unsupported glean_parser version ${GLEAN_PARSER_VERSION} found.\n"
+        "Please update to version ${GLEAN_PARSER_VERSION_MIN} or later."
     )
 else()
     message(FATAL_ERROR


### PR DESCRIPTION
## Description
When we fail the glean_parser version check. The resulting error message may suggest that the user run a script, when in practice they may be better served by updating their glean_parser version. Let's add a bit more verbosity to that message.

## Reference
Github issue #5785 ([VPN-4019](https://mozilla-hub.atlassian.net/browse/VPN-4019))

## Checklist
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed


[VPN-4019]: https://mozilla-hub.atlassian.net/browse/VPN-4019?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ