### PR TITLE
Chore: Disable test that relies on new qmlpath work on releases/2.13

### DIFF
--- a/tests/functional/testIpInfo.js
+++ b/tests/functional/testIpInfo.js
@@ -23,7 +23,8 @@ describe('IP info', function() {
     assert(await vpn.getElementProperty(homeScreen.IP_INFO_PANEL, 'isOpen') === 'false');
   });
 
-  it('Closes when VPN is deactivated', async () => {
+  // Skip this test on 2.13 branch where queries is not available
+  it.skip('Closes when VPN is deactivated', async () => {
     await vpn.waitForQuery(queries.screenHome.CONTROLLER_TITLE.visible());
     await vpn.activate(true);
 


### PR DESCRIPTION
## Description

Disable test that relies on new qmlpath work on releases/2.13. It is causing red ci on 2.13 as "queries" is not available in 2.13.

## Reference

https://github.com/mozilla-mobile/mozilla-vpn-client/actions/runs/4027715768/jobs/6923941961
