### PR TITLE
Try building Qt6 for apple universal binaries.

### DIFF
--- a/scripts/utils/qt6_compile.sh
+++ b/scripts/utils/qt6_compile.sh
@@ -69,7 +69,9 @@ LINUX="
 MACOS="
   -appstore-compliant \
   -no-feature-qdbus \
-  -no-dbus
+  -no-dbus \
+  -- \
+  -DCMAKE_OSX_ARCHITECTURES='arm64;x86_64'
 "
 
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then

--- a/taskcluster/ci/toolchain/qt.yml
+++ b/taskcluster/ci/toolchain/qt.yml
@@ -12,10 +12,9 @@ task-defaults:
 qt-mac:
     description: "Mac QT compile Task"
     run:
+        using: run-task
         use-caches: false
-        script: compile_qt_6_mac.sh
-        resources:
-            - scripts/utils/qt6_compile.sh
+        command: ./taskcluster/scripts/toolchain/compile_qt_6_mac.sh
         toolchain-alias: qt-mac
         toolchain-artifact: public/build/qt6_mac.zip
     treeherder:

--- a/taskcluster/ci/toolchain/qt.yml
+++ b/taskcluster/ci/toolchain/qt.yml
@@ -12,6 +12,7 @@ task-defaults:
 qt-mac:
     description: "Mac QT compile Task"
     run:
+        use-caches: false
         script: compile_qt_6_mac.sh
         resources:
             - scripts/utils/qt6_compile.sh

--- a/taskcluster/ci/toolchain/qt.yml
+++ b/taskcluster/ci/toolchain/qt.yml
@@ -13,6 +13,8 @@ qt-mac:
     description: "Mac QT compile Task"
     run:
         script: compile_qt_6_mac.sh
+        resources:
+            - scripts/utils/qt6_compile.sh
         toolchain-alias: qt-mac
         toolchain-artifact: public/build/qt6_mac.zip
     treeherder:

--- a/taskcluster/scripts/build/macos_build.sh
+++ b/taskcluster/scripts/build/macos_build.sh
@@ -79,10 +79,12 @@ if [[ "$RELEASE" ]]; then
         -DCMAKE_PREFIX_PATH=${MOZ_FETCHES_DIR}/qt_dist/lib/cmake \
         -DSENTRY_DSN=$SENTRY_DSN \
         -DSENTRY_ENVELOPE_ENDPOINT=$SENTRY_ENVELOPE_ENDPOINT \
+        -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64" \
         -DCMAKE_BUILD_TYPE=Release
 else 
     cmake -S . -B ${MOZ_FETCHES_DIR}/build -GNinja \
         -DCMAKE_PREFIX_PATH=${MOZ_FETCHES_DIR}/qt_dist/lib/cmake \
+        -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64" \
         -DCMAKE_BUILD_TYPE=Release
 fi 
 


### PR DESCRIPTION
## Description
The next step in supporting Apple universal binaries is to rebuild Qt6 to target both x86_64 and arm64. Once this is done it should be a simple matter of tweaking the CMake configuration for the MacOS builds.

## Reference
Github issue #286 ([VPN-82](https://mozilla-hub.atlassian.net/browse/VPN-82))

## Checklist
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-82]: https://mozilla-hub.atlassian.net/browse/VPN-82?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ