### PR TITLE
VPN-3970: Use native API for mac os notifications

### DIFF
--- a/src/apps/vpn/cmake/macos.cmake
+++ b/src/apps/vpn/cmake/macos.cmake
@@ -26,12 +26,14 @@ find_library(FW_SERVICEMGMT ServiceManagement)
 find_library(FW_SECURITY Security)
 find_library(FW_COREWLAN CoreWLAN)
 find_library(FW_NETWORK Network)
+find_library(FW_USER_NOTIFICATIONS UserNotifications)
 
 target_link_libraries(mozillavpn PRIVATE ${FW_SYSTEMCONFIG})
 target_link_libraries(mozillavpn PRIVATE ${FW_SERVICEMGMT})
 target_link_libraries(mozillavpn PRIVATE ${FW_SECURITY})
 target_link_libraries(mozillavpn PRIVATE ${FW_COREWLAN})
 target_link_libraries(mozillavpn PRIVATE ${FW_NETWORK})
+target_link_libraries(mozillavpn PRIVATE ${FW_USER_NOTIFICATIONS})
 
 # MacOS platform source files
 target_sources(mozillavpn PRIVATE

--- a/src/apps/vpn/platforms/macos/macosstatusicon.h
+++ b/src/apps/vpn/platforms/macos/macosstatusicon.h
@@ -21,7 +21,7 @@ class MacOSStatusIcon final : public QObject {
   void setIndicatorColor(const QColor& indicatorColor);
   void setMenu(NSMenu* statusBarMenu);
   void setToolTip(const QString& tooltip);
-  void showMessage(const QString& title, const QString& message, int timerMsec);
+  void showMessage(const QString& title, const QString& message);
 };
 
 #endif  // MACOSSTATUSICON_H

--- a/src/apps/vpn/platforms/macos/macossystemtraynotificationhandler.cpp
+++ b/src/apps/vpn/platforms/macos/macossystemtraynotificationhandler.cpp
@@ -62,12 +62,7 @@ void MacosSystemTrayNotificationHandler::notify(Message type,
                                                 const QString& title,
                                                 const QString& message,
                                                 int timerMsec) {
-  // This is very hacky, but necessary to circumvent a Qt bug where
-  // notifications are not shown when the icon is not visible.
-  // See: https://bugreports.qt.io/browse/QTBUG-108134
-  m_systemTrayIcon->show();
-  SystemTrayNotificationHandler::notify(type, title, message, timerMsec);
-  m_systemTrayIcon->hide();
+  m_macOSStatusIcon->showMessage(title, message);
 }
 
 void MacosSystemTrayNotificationHandler::updateIcon() {


### PR DESCRIPTION
## Description

- Directly utilize `UserNotifications` on macOS to avoid duplicate menu bar icons and accept click events for each notification
- Clicking on a notification on macOS will now always show the UI and give the window focus, regardless of whether it is: 
  - Hidden behind other windows
  - System hidden (Right click dock icon > hide or CMD+H)
  - In-App hidden (Implemented by us to hide the dock icon when the app is running)
  - Minimized


## Reference

- [VPN-3970: Implement persistent, clickable notifications on macos ](https://mozilla-hub.atlassian.net/browse/VPN-3970)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
