### PR TITLE
Add wgconf command to generate a Wireguard config file.

### DIFF
--- a/src/apps/vpn/cmake/macos.cmake
+++ b/src/apps/vpn/cmake/macos.cmake
@@ -69,8 +69,6 @@ target_sources(mozillavpn PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/apps/vpn/platforms/macos/macosstartatbootwatcher.h
     ${CMAKE_CURRENT_SOURCE_DIR}/apps/vpn/platforms/macos/macossystemtraynotificationhandler.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/apps/vpn/platforms/macos/macossystemtraynotificationhandler.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/apps/vpn/wgquickprocess.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/apps/vpn/wgquickprocess.h
     ${CMAKE_CURRENT_SOURCE_DIR}/apps/vpn/platforms/macos/macosnetworkwatcher.mm
     ${CMAKE_CURRENT_SOURCE_DIR}/apps/vpn/platforms/macos/macosnetworkwatcher.h
     ${CMAKE_CURRENT_SOURCE_DIR}/apps/vpn/platforms/macos/macosstatusicon.mm

--- a/src/apps/vpn/cmake/sources.cmake
+++ b/src/apps/vpn/cmake/sources.cmake
@@ -119,6 +119,8 @@ target_sources(mozillavpn-sources INTERFACE
     ${CMAKE_CURRENT_SOURCE_DIR}/apps/vpn/commands/commandstatus.h
     ${CMAKE_CURRENT_SOURCE_DIR}/apps/vpn/commands/commandui.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/apps/vpn/commands/commandui.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/apps/vpn/commands/commandwgconf.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/apps/vpn/commands/commandwgconf.h
     ${CMAKE_CURRENT_SOURCE_DIR}/apps/vpn/composer/composer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/apps/vpn/composer/composer.h
     ${CMAKE_CURRENT_SOURCE_DIR}/apps/vpn/composer/composerblock.cpp
@@ -316,6 +318,8 @@ target_sources(mozillavpn-sources INTERFACE
     ${CMAKE_CURRENT_SOURCE_DIR}/apps/vpn/websocket/pushmessage.h
     ${CMAKE_CURRENT_SOURCE_DIR}/apps/vpn/websocket/websockethandler.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/apps/vpn/websocket/websockethandler.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/apps/vpn/wgquickprocess.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/apps/vpn/wgquickprocess.h
 )
 
 # VPN Client UI resources

--- a/src/apps/vpn/cmake/windows.cmake
+++ b/src/apps/vpn/cmake/windows.cmake
@@ -69,8 +69,6 @@ target_sources(mozillavpn PRIVATE
      ${CMAKE_CURRENT_SOURCE_DIR}/apps/vpn/platforms/windows/windowspingsender.h
      ${CMAKE_CURRENT_SOURCE_DIR}/apps/vpn/platforms/windows/windowsstartatbootwatcher.cpp
      ${CMAKE_CURRENT_SOURCE_DIR}/apps/vpn/platforms/windows/windowsstartatbootwatcher.h
-     ${CMAKE_CURRENT_SOURCE_DIR}/apps/vpn/wgquickprocess.cpp
-     ${CMAKE_CURRENT_SOURCE_DIR}/apps/vpn/wgquickprocess.h
 )
 
 # Windows Qt6 UI workaround resources

--- a/src/apps/vpn/command.cpp
+++ b/src/apps/vpn/command.cpp
@@ -66,6 +66,8 @@ bool Command::loadModels() {
     return false;
   }
 
+  vpn->serverData()->initialize();
+
   if (!vpn->deviceModel()->fromSettings(vpn->keys()) ||
       !vpn->serverCountryModel()->fromSettings() ||
       !vpn->user()->fromSettings() || !vpn->serverData()->fromSettings() ||

--- a/src/apps/vpn/commands/commandwgconf.cpp
+++ b/src/apps/vpn/commands/commandwgconf.cpp
@@ -1,0 +1,81 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "commandwgconf.h"
+
+#include <QEventLoop>
+#include <QTextStream>
+
+#include "commandlineparser.h"
+#include "daemon/interfaceconfig.h"
+#include "dnshelper.h"
+#include "leakdetector.h"
+#include "mozillavpn.h"
+#include "settingsholder.h"
+#include "wgquickprocess.h"
+
+CommandWgConf::CommandWgConf(QObject* parent)
+    : Command(parent, "wgconf", "Show the current VPN status.") {
+  MZ_COUNT_CTOR(CommandWgConf);
+}
+
+CommandWgConf::~CommandWgConf() { MZ_COUNT_DTOR(CommandWgConf); }
+
+int CommandWgConf::run(QStringList& tokens) {
+  Q_ASSERT(!tokens.isEmpty());
+  return runCommandLineApp([&]() {
+    Q_ASSERT(!tokens.isEmpty());
+    if (tokens.length() > 1) {
+      QList<CommandLineParser::Option*> options;
+      return CommandLineParser::unknownOption(this, tokens[1], tokens[0],
+                                              options, false);
+    }
+
+    MozillaVPN vpn;
+    QTextStream stream(stdout);
+
+    if (!userAuthenticated()) {
+      stream << "User is not authenticated" << Qt::endl;
+      return 1;
+    }
+
+    if (!loadModels()) {
+      return 1;
+    }
+
+    struct InterfaceConfig config;
+    DeviceModel* dm = vpn.deviceModel();
+    Q_ASSERT(dm);
+    if (!dm->hasCurrentDevice(vpn.keys())) {
+      stream << "Device is not registered" << Qt::endl;
+      return 1;
+    }
+    const Device* cd = dm->currentDevice(vpn.keys());
+    config.m_hopindex = 0;
+    config.m_privateKey = vpn.keys()->privateKey();
+    config.m_deviceIpv4Address = cd->ipv4Address();
+    config.m_deviceIpv6Address = cd->ipv6Address();
+
+    ServerData* sd = vpn.serverData();
+    Q_ASSERT(sd);
+    // Now we need to select a server.
+    Server exitServer = Server::weightChooser(sd->exitServers());
+    config.m_serverIpv4Gateway = exitServer.ipv4Gateway();
+    config.m_serverIpv6Gateway = exitServer.ipv6Gateway();
+    config.m_serverPublicKey = exitServer.publicKey();
+    config.m_serverIpv4AddrIn = exitServer.ipv4AddrIn();
+    config.m_serverIpv6AddrIn = exitServer.ipv6AddrIn();
+    config.m_serverPort = exitServer.choosePort();
+    config.m_dnsServer = DNSHelper::getDNS(exitServer.ipv4Gateway());
+    config.m_allowedIPAddressRanges =
+        Controller::getAllowedIPAddressRanges(exitServer);
+
+    // Stream it out to the user.
+    QMap<QString, QString> extras;
+    stream << WgQuickProcess::createConfigString(config, extras) << Qt::endl;
+    return 0;
+  });
+}
+
+static Command::RegistrationProxy<CommandWgConf> s_commandWgConf;

--- a/src/apps/vpn/commands/commandwgconf.cpp
+++ b/src/apps/vpn/commands/commandwgconf.cpp
@@ -66,7 +66,12 @@ int CommandWgConf::run(QStringList& tokens) {
     config.m_serverPublicKey = exitServer.publicKey();
     config.m_serverIpv4AddrIn = exitServer.ipv4AddrIn();
     config.m_serverIpv6AddrIn = exitServer.ipv6AddrIn();
-    config.m_serverPort = exitServer.choosePort();
+    if (sd->multihop()) {
+      Server entryServer = Server::weightChooser(sd->entryServers());
+      config.m_serverPort = entryServer.multihopPort();
+    } else {
+      config.m_serverPort = exitServer.choosePort();
+    }
     config.m_dnsServer = DNSHelper::getDNS(exitServer.ipv4Gateway());
     config.m_allowedIPAddressRanges =
         Controller::getAllowedIPAddressRanges(exitServer);

--- a/src/apps/vpn/commands/commandwgconf.cpp
+++ b/src/apps/vpn/commands/commandwgconf.cpp
@@ -16,7 +16,7 @@
 #include "wgquickprocess.h"
 
 CommandWgConf::CommandWgConf(QObject* parent)
-    : Command(parent, "wgconf", "Show the current VPN status.") {
+    : Command(parent, "wgconf", "Generate a wireguard configuration file.") {
   MZ_COUNT_CTOR(CommandWgConf);
 }
 

--- a/src/apps/vpn/commands/commandwgconf.cpp
+++ b/src/apps/vpn/commands/commandwgconf.cpp
@@ -72,8 +72,7 @@ int CommandWgConf::run(QStringList& tokens) {
         Controller::getAllowedIPAddressRanges(exitServer);
 
     // Stream it out to the user.
-    QMap<QString, QString> extras;
-    stream << WgQuickProcess::createConfigString(config, extras) << Qt::endl;
+    stream << WgQuickProcess::createConfigString(config) << Qt::endl;
     return 0;
   });
 }

--- a/src/apps/vpn/commands/commandwgconf.h
+++ b/src/apps/vpn/commands/commandwgconf.h
@@ -1,0 +1,18 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef COMMANDWGCONF_H
+#define COMMANDWGCONF_H
+
+#include "command.h"
+
+class CommandWgConf final : public Command {
+ public:
+  explicit CommandWgConf(QObject* parent);
+  ~CommandWgConf();
+
+  int run(QStringList& tokens) override;
+};
+
+#endif  // COMMANDWGCONF_H

--- a/src/apps/vpn/controller.h
+++ b/src/apps/vpn/controller.h
@@ -114,6 +114,8 @@ class Controller final : public QObject {
   QString currentServerString() const;
 #endif
 
+  static QList<IPAddress> getAllowedIPAddressRanges(const Server& server);
+
  public slots:
   // These 2 methods activate/deactivate the VPN. Return true if a signal will
   // be emitted at the end of the operation.
@@ -156,7 +158,6 @@ class Controller final : public QObject {
   void maybeEnableDisconnectInConfirming();
 
   bool processNextStep();
-  QList<IPAddress> getAllowedIPAddressRanges(const Server& server);
   QStringList getExcludedAddresses();
 
   void activateInternal(bool forceDNSPort = false);

--- a/src/apps/vpn/platforms/windows/daemon/wireguardutilswindows.cpp
+++ b/src/apps/vpn/platforms/windows/daemon/wireguardutilswindows.cpp
@@ -94,6 +94,14 @@ bool WireguardUtilsWindows::addInterface(const InterfaceConfig& config) {
     return false;
   }
 
+  // We don't want to pass a peer just yet, that will happen later with
+  // a UAPI command in WireguardUtilsWindows::updatePeer(), so truncate
+  // the config file to remove the [Peer] section.
+  qsizetype peerStart = configString.indexOf("[Peer]", 0, Qt::CaseSensitive);
+  if (peerStart >= 0) {
+    configString.truncate(peerStart);
+  }
+
   if (!m_tunnel.start(configString)) {
     logger.error() << "Failed to activate the tunnel service";
     return false;

--- a/src/apps/vpn/wgquickprocess.cpp
+++ b/src/apps/vpn/wgquickprocess.cpp
@@ -86,8 +86,5 @@ QString WgQuickProcess::createConfigString(
   out << "AllowedIPs = " << ranges.join(", ") << "\n";
 #endif
 
-#ifdef MZ_DEBUG
-  logger.debug() << content;
-#endif
   return content;
 }

--- a/src/apps/vpn/wgquickprocess.cpp
+++ b/src/apps/vpn/wgquickprocess.cpp
@@ -62,13 +62,6 @@ QString WgQuickProcess::createConfigString(
     out << key << " = " << extra[key] << "\n";
   }
 
-  // For windows, we don't want to include the peer configuration since they
-  // will be passed later as a UAPI command. and we need to fiddle with the
-  // interface in between creation and peer bringup.
-  //
-  // This function should go away as soon as we fixup the Mac implementation
-  // anyways.
-#if !defined(MZ_WINDOWS) && !defined(MZ_MACOS)
   out << "\n[Peer]\n";
   out << "PublicKey = " << config.m_serverPublicKey << "\n";
   out << "Endpoint = " << config.m_serverIpv4AddrIn.toUtf8() << ":"
@@ -84,7 +77,6 @@ QString WgQuickProcess::createConfigString(
     ranges.append(ip.toString());
   }
   out << "AllowedIPs = " << ranges.join(", ") << "\n";
-#endif
 
   return content;
 }

--- a/src/apps/vpn/wgquickprocess.h
+++ b/src/apps/vpn/wgquickprocess.h
@@ -14,8 +14,9 @@ class WgQuickProcess final {
   Q_DISABLE_COPY_MOVE(WgQuickProcess)
 
  public:
-  static QString createConfigString(const InterfaceConfig& config,
-                                    const QMap<QString, QString>& extra);
+  static QString createConfigString(
+      const InterfaceConfig& config,
+      const QMap<QString, QString>& extra = QMap<QString, QString>());
 };
 
 #endif  // WGQUICKPROCESS_H


### PR DESCRIPTION
## Description
This adds a command line tool to render the current device configuration in the form of a Wireguard configuration file that can be used by a 3rd party Wireguard client.

Usage is as follows:
```
[user@example ~]$ ./src/mozillavpn wgconf
[Interface]
PrivateKey = xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx=
Address = 10.112.171.249/32, fc00:bbbb:bbbb:bb01::31:abf8/128
DNS = 10.64.0.1, fc00:bbbb:bbbb:bb01::1

[Peer]
PublicKey = Hzf1JH0UERBRNxBSpTvGPZAREa93LoHtPKsJMwdcrV0=
Endpoint = 89.45.224.41:3406
AllowedIPs = 10.64.0.1/32, fc00:bbbb:bbbb:bb01::1/128, 10.124.0.0/20, 240.0.0.0/4, 208.0.0.0/4, 200.0.0.0/5, 196.0.0.0/6, 194.0.0.0/7, 193.0.0.0/8, 192.0.0.0/9, 192.192.0.0/10, 192.128.0.0/11, 192.176.0.0/12, 192.160.0.0/13, 192.172.0.0/14, 192.170.0.0/15, 192.169.0.0/16, 128.0.0.0/3, 176.0.0.0/4, 160.0.0.0/5, 168.0.0.0/6, 174.0.0.0/7, 173.0.0.0/8, 172.128.0.0/9, 172.64.0.0/10, 172.32.0.0/11, 172.0.0.0/12, 64.0.0.0/2, 32.0.0.0/3, 16.0.0.0/4, 0.0.0.0/5, 12.0.0.0/6, 8.0.0.0/7, 11.0.0.0/8, ::/1, 8000::/2, c000::/3, e000::/4, f000::/5, f800::/6, fe00::/8

[user@example ~]$
```

## Reference
Github issue #3165 ([VPN-1988](https://mozilla-hub.atlassian.net/browse/VPN-1988))

## Checklist
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-1988]: https://mozilla-hub.atlassian.net/browse/VPN-1988?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ