### PR TITLE
VPN-Glean: Make Python a valid candidate for PYTHON_EXECUTABLE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,7 +84,7 @@ if(${CMAKE_VERSION} VERSION_GREATER_EQUAL 3.17)
     cmake_policy(SET CMP0099 OLD)
 endif()
 
-find_program(PYTHON_EXECUTABLE NAMES python3)
+find_program(PYTHON_EXECUTABLE NAMES python3 python)
 if(MSVC)
     include(src/apps/vpn/cmake/msvc.cmake)
 endif()


### PR DESCRIPTION
## Description
Currently only python3 is checked. In a conda env it seems we have python3 as the default `python` command. 