### PR TITLE
 VPN-3617 & VPN-3662: Ensure components are visible on focus #5673 

### DIFF
--- a/nebula/ui/components/VPNButtonBase.qml
+++ b/nebula/ui/components/VPNButtonBase.qml
@@ -53,8 +53,8 @@ RoundButton {
         }
         visualStateItem.state = uiState.stateFocused;
 
-        if (typeof(ensureVisible) !== "undefined")
-            ensureVisible(root);
+        if (focus && typeof(vpnFlickable) !== "undefined" && typeof(vpnFlickable.ensureVisible) !== "undefined")
+            vpnFlickable.ensureVisible(root)
     }
 
     background: Rectangle {

--- a/nebula/ui/components/VPNFlickable.qml
+++ b/nebula/ui/components/VPNFlickable.qml
@@ -91,13 +91,13 @@ Flickable {
             ensureVisAnimation.stop()
         }
 
-        let yPosition = item.mapToItem(contentItem, 0, 0).y
+        const yPosition = item.mapToItem(contentItem, 0, 0).y
         if (!contentExceedsHeight || item.skipEnsureVisible || yPosition < 0) {
             return
         }
 
         const isItemBehindNavbar = item.mapToItem(window.contentItem, 0, 0).y + item.height > window.height - VPNTheme.theme.navBarHeightWithMargins
-        const buffer = navbar.visible && isItemBehindNavbar ? VPNTheme.theme.navBarHeightWithMargins : 20
+        const buffer = navbar.visible && isItemBehindNavbar ? VPNTheme.theme.navBarHeightWithMargins : VPNTheme.theme.contentBottomMargin
         const itemHeight = Math.max(item.height, VPNTheme.theme.rowHeight) + buffer
         let destinationY
 

--- a/nebula/ui/components/VPNFlickable.qml
+++ b/nebula/ui/components/VPNFlickable.qml
@@ -99,7 +99,6 @@ Flickable {
         const isItemBehindNavbar = item.mapToItem(window.contentItem, 0, 0).y + item.height > window.height - VPNTheme.theme.navBarHeightWithMargins
         const buffer = navbar.visible && isItemBehindNavbar ? VPNTheme.theme.navBarHeightWithMargins : 20
         const itemHeight = Math.max(item.height, VPNTheme.theme.rowHeight) + buffer
-        let ext = item.height + yPosition
         let destinationY
 
         //When focusing on an item behind the navbar in the downward direction, make sure it is not blocked by the navbar
@@ -110,7 +109,7 @@ Flickable {
         }
         else {
             //When focusing on an item that is off screen in the upward direction
-            if (yPosition < vpnFlickable.contentY /*|| yPosition > vpnFlickable.contentY + vpnFlickable.height || ext < vpnFlickable.contentY || ext > vpnFlickable.contentY + vpnFlickable.height*/) {
+            if (yPosition < vpnFlickable.contentY) {
                 destinationY = yPosition - buffer
             }
         }

--- a/nebula/ui/components/VPNFlickable.qml
+++ b/nebula/ui/components/VPNFlickable.qml
@@ -15,72 +15,9 @@ Flickable {
     property bool hideScollBarOnStackTransition: false
     //This property should be true if the flickable appears behind the main navbar
     interactive: !VPNTutorial.playing && contentHeight > height || contentY > 0
-
-    MouseArea {
-
-        anchors.fill: parent
-        propagateComposedEvents: true
-
-        onPressed: mouse => {
-            if (window.activeFocusItem &&
-                window.activeFocusItem.forceBlurOnOutsidePress &&
-                (Qt.platform.os === "android" || Qt.platform.os === "ios")) {
-                vpnFlickable.focus = true;
-            }
-            mouse.accepted = false;
-        }
-    }
-
     clip: true
-
-    function ensureVisible(item) {
-        let yPosition = item.mapToItem(contentItem, 0, 0).y;
-        if (!contentExceedsHeight || item.skipEnsureVisible || yPosition < 0) {
-            return;
-        }
-
-        const buffer = 20;
-        const itemHeight = Math.max(item.height, VPNTheme.theme.rowHeight) + buffer
-        let ext = item.height + yPosition;
-        let destinationY;
-
-
-        if (yPosition < vpnFlickable.contentY || yPosition > vpnFlickable.contentY + vpnFlickable.height || ext < vpnFlickable.contentY || ext > vpnFlickable.contentY + vpnFlickable.height) {
-            destinationY = Math.min(yPosition - vpnFlickable.height + itemHeight, vpnFlickable.contentHeight - vpnFlickable.height);
-        }
-
-        if (yPosition < vpnFlickable.contentY) {
-            const diff = vpnFlickable.contentY - yPosition;
-            if (diff < itemHeight) {
-                destinationY = vpnFlickable.contentY - (vpnFlickable.contentY - yPosition);
-                destinationY = (destinationY - buffer) > 0 ? (destinationY - buffer) : destinationY;
-            }
-
-        }
-        if (typeof(destinationY) === "undefined") return;
-
-        ensureVisAnimation.to = destinationY > 0 ? destinationY : 0;
-        ensureVisAnimation.start();
-    }
-
-    function recalculateContentHeight() {
-        //Absolute y coordinate position of the scroll view
-        const absoluteYPosition = mapToItem(window.contentItem, 0, 0).y
-        //Portion of the screen that a view's contents can reside without interfering with the navbar
-        const contentSpace = window.height - VPNTheme.theme.navBarHeightWithMargins
-
-        //Checks if the flickable AND it's content interferes with the navbar area (bottom 146px for iOS, bottom 128px for other platforms)
-        //If it does, we pad the flickable's contentHeight with whatever bottom padding is needed so that there is always 48px (aka theme.navBarTopMargin)
-        //between the bottom of the flickable's content and the navbar
-        if (navbar.visible && absoluteYPosition + height >= contentSpace
-                && flickContentHeight + absoluteYPosition >= contentSpace) {
-            vpnFlickable.contentHeight = flickContentHeight + (flickContentHeight >= height ? VPNTheme.theme.navBarHeightWithMargins : (absoluteYPosition + flickContentHeight) - contentSpace + (height - flickContentHeight))
-        }
-        //If the navbar isn't visible, or the flickable's content does not interfere with the navbar area, don't worry about adding any padding
-        else {
-            vpnFlickable.contentHeight = flickContentHeight
-        }
-    }
+    boundsBehavior: Flickable.StopAtBounds
+    opacity: 0
 
     onFlickContentHeightChanged: {
         recalculateContentHeight()
@@ -90,25 +27,17 @@ Flickable {
         recalculateContentHeight()
     }
 
-    boundsBehavior: Flickable.StopAtBounds
-    opacity: 0
+    onContentYChanged: {
+        if(VPNTutorial.playing) {
+            window.repositionTutorialTooltip()
+        }
+    }
 
     Component.onCompleted: {
         opacity = 1;
         if (Qt.platform.os === "windows") {
             maximumFlickVelocity = 700;
         }
-    }
-
-    NumberAnimation on contentY {
-        id: ensureVisAnimation
-
-        duration: 300
-        easing.type: Easing.OutQuad
-    }
-
-    PropertyAnimation on opacity {
-        duration: 200
     }
 
     ScrollBar.vertical: ScrollBar {
@@ -157,4 +86,91 @@ Flickable {
         }
     }
 
+    function ensureVisible(item) {
+        if(ensureVisAnimation.running) {
+            ensureVisAnimation.stop()
+        }
+
+        let yPosition = item.mapToItem(contentItem, 0, 0).y
+        if (!contentExceedsHeight || item.skipEnsureVisible || yPosition < 0) {
+            return
+        }
+
+        const isItemBehindNavbar = item.mapToItem(window.contentItem, 0, 0).y + item.height > window.height - VPNTheme.theme.navBarHeightWithMargins
+        const buffer = navbar.visible && isItemBehindNavbar ? VPNTheme.theme.navBarHeightWithMargins : 20
+        const itemHeight = Math.max(item.height, VPNTheme.theme.rowHeight) + buffer
+        let ext = item.height + yPosition
+        let destinationY
+
+        //When focusing on an item behind the navbar in the downward direction, make sure it is not blocked by the navbar
+        if(navbar.visible && isItemBehindNavbar) {
+            const distanceToGetOutFromBehindNavbar = item.mapToItem(window.contentItem, 0, 0).y + item.height - (window.height - buffer)
+
+            destinationY = contentY + distanceToGetOutFromBehindNavbar
+        }
+        else {
+            //When focusing on an item that is off screen in the upward direction
+            if (yPosition < vpnFlickable.contentY /*|| yPosition > vpnFlickable.contentY + vpnFlickable.height || ext < vpnFlickable.contentY || ext > vpnFlickable.contentY + vpnFlickable.height*/) {
+                destinationY = yPosition - buffer
+            }
+        }
+
+        if (typeof(destinationY) === "undefined") return;
+
+        //For some reaason during tutorials, mobile devices won't perform an animated scroll??
+        if(VPNTutorial.playing && window.fullscreenRequired()) {
+            contentY = destinationY
+        }
+        else {
+            ensureVisAnimation.to = destinationY
+            ensureVisAnimation.start()
+        }
+
+        return
+    }
+
+    function recalculateContentHeight() {
+        //Absolute y coordinate position of the scroll view
+        const absoluteYPosition = mapToItem(window.contentItem, 0, 0).y
+        //Portion of the screen that a view's contents can reside without interfering with the navbar
+        const contentSpace = window.height - VPNTheme.theme.navBarHeightWithMargins
+
+        //Checks if the flickable AND it's content interferes with the navbar area (bottom 146px for iOS, bottom 128px for other platforms)
+        //If it does, we pad the flickable's contentHeight with whatever bottom padding is needed so that there is always 48px (aka theme.navBarTopMargin)
+        //between the bottom of the flickable's content and the navbar
+        if (navbar.visible && absoluteYPosition + height >= contentSpace
+                && flickContentHeight + absoluteYPosition >= contentSpace) {
+            vpnFlickable.contentHeight = flickContentHeight + (flickContentHeight >= height ? VPNTheme.theme.navBarHeightWithMargins : (absoluteYPosition + flickContentHeight) - contentSpace + (height - flickContentHeight))
+        }
+        //If the navbar isn't visible, or the flickable's content does not interfere with the navbar area, don't worry about adding any padding
+        else {
+            vpnFlickable.contentHeight = flickContentHeight
+        }
+    }
+
+    NumberAnimation on contentY {
+        id: ensureVisAnimation
+
+        duration: 300
+        easing.type: Easing.OutQuad
+    }
+
+    PropertyAnimation on opacity {
+        duration: 200
+    }
+
+    MouseArea {
+
+        anchors.fill: parent
+        propagateComposedEvents: true
+
+        onPressed: mouse => {
+            if (window.activeFocusItem &&
+                window.activeFocusItem.forceBlurOnOutsidePress &&
+                (Qt.platform.os === "android" || Qt.platform.os === "ios")) {
+                vpnFlickable.focus = true;
+            }
+            mouse.accepted = false;
+        }
+    }
 }

--- a/nebula/ui/components/VPNServerCountry.qml
+++ b/nebula/ui/components/VPNServerCountry.qml
@@ -38,7 +38,6 @@ VPNClickableRow {
         if (event.key === Qt.Key_Space) handleKeyClick()
     }
 
-    onActiveFocusChanged: vpnFlickable.ensureVisible(serverCountry)
     handleMouseClick: openCityList
     handleKeyClick: openCityList
     clip: true
@@ -180,7 +179,6 @@ VPNClickableRow {
                 activeFocusOnTab: cityListVisible
                 Keys.onDownPressed: if (citiesRepeater.itemAt(index + 1)) citiesRepeater.itemAt(index + 1).forceActiveFocus()
                 Keys.onUpPressed: if (citiesRepeater.itemAt(index - 1)) citiesRepeater.itemAt(index - 1).forceActiveFocus()
-                onActiveFocusChanged: vpnFlickable.ensureVisible(del)
                 radioButtonLabelText: _localizedCityName
                 accessibleName: _localizedCityName
                 implicitWidth: parent.width

--- a/nebula/ui/components/VPNSettingsToggle.qml
+++ b/nebula/ui/components/VPNSettingsToggle.qml
@@ -16,7 +16,7 @@ CheckBox {
     property var toolTipTitle
 
     onClicked: toolTip.hide()
-    onActiveFocusChanged: if (focus && typeof(ensureVisible) !== "undefined") ensureVisible(vpnSettingsToggle)
+    onActiveFocusChanged: if (focus && typeof(vpnFlickable) !== "undefined" && typeof(vpnFlickable.ensureVisible) !== "undefined") ensureVisible(vpnSettingsToggle)
 
     height: VPNTheme.theme.vSpacing
     width: 45

--- a/nebula/ui/components/VPNSwipeDelegate.qml
+++ b/nebula/ui/components/VPNSwipeDelegate.qml
@@ -39,6 +39,12 @@ SwipeDelegate {
         onSwipeClose()
     }
 
+    onActiveFocusChanged: {
+        if (focus && typeof(vpnFlickable) !== "undefined" && typeof(vpnFlickable.ensureVisible) !== "undefined") {
+            vpnFlickable.ensureVisible(swipeDelegate)
+        }
+    }
+
     contentItem: Item {
         id: swipeDelegateContentItem
 

--- a/nebula/ui/components/VPNTextBlock.qml
+++ b/nebula/ui/components/VPNTextBlock.qml
@@ -21,4 +21,10 @@ Text {
 
     Accessible.role: Accessible.StaticText
     Accessible.name: text
+
+    onActiveFocusChanged: {
+        if (focus && typeof(vpnFlickable) !== "undefined" && typeof(vpnFlickable.ensureVisible) !== "undefined") {
+            vpnFlickable.ensureVisible(root)
+        }
+    }
 }

--- a/nebula/ui/components/VPNTutorialPopups.qml
+++ b/nebula/ui/components/VPNTutorialPopups.qml
@@ -11,6 +11,8 @@ import compat 0.1
 
 
 Item {
+    id: root
+    objectName: "tutorialUiRoot"
 
     /*
         TODOs
@@ -36,9 +38,6 @@ Item {
     // targetElement is set to `parent` here to get around `Cannot call method ... of undefined` warnings
     // and is reset before the tutorial is opened in onTooltipNeeded()
     property var targetElement: parent
-
-    id: root
-    objectName: "tutorialUiRoot"
 
     anchors.fill: parent
     visible: tutorialTooltip.visible || tutorialPopup.opened
@@ -274,6 +273,10 @@ Item {
         if (targetElement) {
             targetElement.forceActiveFocus();
         }
+    }
+
+    function repositionTutorialTooltip() {
+        tutorialTooltip.repositionTooltip()
     }
 
     Connections {

--- a/nebula/ui/components/forms/VPNComboBox.qml
+++ b/nebula/ui/components/forms/VPNComboBox.qml
@@ -24,6 +24,11 @@ ComboBox {
         z: -1
     }
 
+    onActiveFocusChanged: {
+        if (focus && vpnFlickable && typeof(vpnFlickable.ensureVisible) !== "undefined")
+            vpnFlickable.ensureVisible(combo)
+    }
+
     indicator: VPNIcon {
         anchors.verticalCenter: combo.verticalCenter
         anchors.right: combo.right

--- a/nebula/ui/components/forms/VPNSearchBar.qml
+++ b/nebula/ui/components/forms/VPNSearchBar.qml
@@ -35,9 +35,6 @@ ColumnLayout {
         rightInset: VPNTheme.theme.windowMargin * 3
         hasError: _searchBarHasError
 
-        onActiveFocusChanged: if (focus && vpnFlickable.ensureVisible) {
-            vpnFlickable.ensureVisible(searchBar);
-        }
         onLengthChanged: text => model.invalidate()
         onTextChanged: {
             if (focus) {

--- a/nebula/ui/components/forms/VPNTextArea.qml
+++ b/nebula/ui/components/forms/VPNTextArea.qml
@@ -80,6 +80,12 @@ Item {
                 }
             }
 
+            onActiveFocusChanged: {
+                if (focus && typeof(vpnFlickable) !== "undefined" && typeof(vpnFlickable.ensureVisible) !== "undefined") {
+                    vpnFlickable.ensureVisible(textArea)
+                }
+            }
+
             Connections {
                 target: window
                 function onScreenClicked(x, y) {

--- a/nebula/ui/components/forms/VPNTextField.qml
+++ b/nebula/ui/components/forms/VPNTextField.qml
@@ -42,7 +42,7 @@ TextField {
     verticalAlignment: TextInput.AlignVCenter
     horizontalAlignment: TextInput.AlignLeft
 
-    onActiveFocusChanged: if (focus && typeof(vpnFlickable) !== "undefined" && vpnFlickable.ensureVisible) {
+    onActiveFocusChanged: if (focus && typeof(vpnFlickable) !== "undefined" && typeof(vpnFlickable.ensureVisible) !== "undefined") {
         vpnFlickable.ensureVisible(textField);
     }
     // This is a workaround for VoiceOver on macOS: https://bugreports.qt.io/browse/QTBUG-108189

--- a/nebula/ui/themes/themes.js
+++ b/nebula/ui/themes/themes.js
@@ -267,6 +267,7 @@ theme.settingsMaxContentHeight = 740;
 theme.maxHorizontalContentWidth = 460;
 theme.contentTopMarginDesktop = 20;
 theme.contentTopMarginMobile = 48;
+theme.contentBottomMargin = 20;
 
 theme.uiState = {
   'stateDefault': 'state-default',

--- a/src/apps/vpn/ui/main.qml
+++ b/src/apps/vpn/ui/main.qml
@@ -65,6 +65,10 @@ Window {
         }
     }
 
+    function repositionTutorialTooltip() {
+        tutorialUI.repositionTutorialTooltip()
+    }
+
     screen: Qt.platform.os === "wasm" && Qt.application.screens.length > 1 ? Qt.application.screens[1] : Qt.application.screens[0]
     flags: Qt.platform.os === "ios" ? Qt.MaximizeUsingFullscreenGeometryHint : Qt.Window
     visible: true

--- a/src/apps/vpn/ui/navigator/navigationBar/VPNBottomNavigationBar.qml
+++ b/src/apps/vpn/ui/navigator/navigationBar/VPNBottomNavigationBar.qml
@@ -87,6 +87,7 @@ Rectangle {
                 Layout.preferredHeight: height
                 Layout.preferredWidth: width
 
+                skipEnsureVisible: true
                 _screen: VPNNavigator[screen]
                 _source: checked ? (_hasNotification ? sourceCheckedNotification : sourceChecked) : (_hasNotification ? sourceUncheckedNotification : sourceUnchecked)
                 ButtonGroup.group: navBarButtonGroup

--- a/src/apps/vpn/ui/screens/getHelp/ViewGetHelp.qml
+++ b/src/apps/vpn/ui/screens/getHelp/ViewGetHelp.qml
@@ -11,6 +11,7 @@ import components 0.1
 
 
 VPNViewBase {
+    id: vpnFlickable
     //% "Get help"
     _menuTitle: qsTrId("vpn.main.getHelp2")
     _menuOnBackClicked: () => VPNNavigator.requestPreviousScreen()

--- a/src/apps/vpn/ui/screens/getHelp/contactUs/ViewContactUsForm.qml
+++ b/src/apps/vpn/ui/screens/getHelp/contactUs/ViewContactUsForm.qml
@@ -11,6 +11,8 @@ import components 0.1
 import components.forms 0.1
 
 VPNViewBase {
+    id: vpnFlickable
+
     objectName: "contactUs"
     _menuTitle: VPNl18n.InAppSupportWorkflowSupportNavLinkText
    _viewContentData: ColumnLayout {

--- a/src/apps/vpn/ui/screens/messaging/ViewMessage.qml
+++ b/src/apps/vpn/ui/screens/messaging/ViewMessage.qml
@@ -11,6 +11,7 @@ import components 0.1
 import Mozilla.VPN.qmlcomponents 1.0
 
 VPNViewBase {
+    id: vpnFlickable
     property var message
 
     property Component titleComponent: Component {

--- a/src/apps/vpn/ui/screens/messaging/ViewMessagesInbox.qml
+++ b/src/apps/vpn/ui/screens/messaging/ViewMessagesInbox.qml
@@ -23,6 +23,7 @@ VPNViewBase {
             id: editLink
 
             property bool isEditing: false
+            property bool skipEnsureVisible: true
 
             horizontalPadding: VPNTheme.theme.hSpacing / 5
             enabled: !isEmptyState

--- a/src/apps/vpn/ui/screens/settings/ViewPreferences.qml
+++ b/src/apps/vpn/ui/screens/settings/ViewPreferences.qml
@@ -10,6 +10,7 @@ import Mozilla.VPN 1.0
 import components 0.1
 
 VPNViewBase {
+    id: vpnFlickable
     property string _startAtBootTitle: ""
     property string _notificationsTitle: ""
     property string _languageTitle: ""

--- a/src/apps/vpn/ui/screens/settings/ViewSettingsMenu.qml
+++ b/src/apps/vpn/ui/screens/settings/ViewSettingsMenu.qml
@@ -11,7 +11,7 @@ import components 0.1
 
 
 VPNViewBase {
-    id: settingsList
+    id: vpnFlickable
     objectName: "settingsView"
 
     _viewContentData: ColumnLayout {


### PR DESCRIPTION
## Description

- Modify the `ensureVisible` function in all flickables such that the navbar is considered and UI components are visible and not blocked when gaining focus via keyboard navigation
- Auto-scroll the screen to focused UI components during a tutorial so that all steps of a tutorial are easily accessible

## Reference

[VPN-3617: [Google Pixel 4][Android] Select exit location option is overlapped by nav bar inside the Multi-hop tutorial](https://mozilla-hub.atlassian.net/browse/VPN-3617)
[VPN-3662: [a11y] Some elements are obscured by the navigation bar when scrolled into view via `ensureVisible()`](https://mozilla-hub.atlassian.net/browse/VPN-3662)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
