### PR TITLE
VPN-4003 - Skip generating extra keys struct for events with no extra keys

### DIFF
--- a/vpnglean/glean_parser_ext/rust.py
+++ b/vpnglean/glean_parser_ext/rust.py
@@ -19,7 +19,7 @@ import jinja2
 
 from util import generate_metric_ids, generate_ping_ids, get_metrics
 from glean_parser import util
-from glean_parser.metrics import Rate
+from glean_parser.metrics import Rate, Event
 
 # The list of all args to CommonMetricData.
 # No particular order is required, but I have these in common_metric_data.rs
@@ -124,7 +124,7 @@ def type_name(obj):
     generate_enums = getattr(obj, "_generate_enums", [])  # Extra Keys? Reasons?
     if len(generate_enums):
         for name, suffix in generate_enums:
-            if not len(getattr(obj, name)) and suffix == "Keys":
+            if not len(getattr(obj, name)) and isinstance(obj, Event):
                 return class_name(obj.type) + "<NoExtraKeys>"
             else:
                 # we always use the `extra` suffix,

--- a/vpnglean/glean_parser_ext/templates/rust.jinja2
+++ b/vpnglean/glean_parser_ext/templates/rust.jinja2
@@ -18,7 +18,9 @@ use once_cell::sync::Lazy;
 {% macro generate_extra_keys(obj) -%}
 {% for name, _ in obj["_generate_enums"] %}
 {% set suffix = "Extra" %}
-{{ extra_keys_with_types(obj, name, suffix)|indent }}
+{% if obj|attr(name)|length %}
+    {{ extra_keys_with_types(obj, name, suffix)|indent }}
+{% endif %}
 {% endfor %}
 {%- endmacro -%}
 


### PR DESCRIPTION
This will address the warnings added by the quick fix on [#5757](https://github.com/mozilla-mobile/mozilla-vpn-client/pull/5757)