### PR TITLE
VPN-4022 - Apply serializer plugin on Android

### DIFF
--- a/android/vpnClient/build.gradle
+++ b/android/vpnClient/build.gradle
@@ -19,6 +19,7 @@ buildscript {
 }
 plugins {
     id "com.jetbrains.python.envs" version "0.0.26"
+    id "org.jetbrains.kotlin.plugin.serialization"
 }
 
 plugins {


### PR DESCRIPTION
See https://mozilla-hub.atlassian.net/browse/VPN-4022 for a bunch of description on the investigation, but...

**tl;dr;** TaskProduct was never completing due to this serialization error, blocking us from moving forward to main state.
