### PR TITLE
Update wg-go on osx

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -18,7 +18,6 @@
 [submodule "3rdparty/wireguard-go"]
 	path = 3rdparty/wireguard-go
 	url = https://github.com/WireGuard/wireguard-go
-        ignore=all
 [submodule "3rdparty/adjust-ios-sdk"]
 	path = 3rdparty/adjust-ios-sdk
 	url = https://github.com/adjust/ios_sdk.git


### PR DESCRIPTION
## Description

We've seen failures of wg-go to build on OSX.
This was caused due to us updating to golang 1.18, this was however not noticed as the runner never "cleaned" properly after a run, and since we build in the `/3rdparty/wireguard-go` folder not the cmake_bin_dir, i never noticed too. 
Now we could rollback go... or upgrade :) 
