### PR TITLE
VPN-2531: Expose method to refresh server connection scores.

### DIFF
--- a/nebula/ui/components/VPNServerList.qml
+++ b/nebula/ui/components/VPNServerList.qml
@@ -245,7 +245,6 @@ FocusScope {
                     id: recommendedLocationsRefreshTimer
                     interval: 2000
                     running: VPNServerLatency.isActive
-                    repeat: false
                     onTriggered: {
                         if (VPNServerLatency.isActive) {
                             recommendedLocationsRefreshTimer.start();

--- a/nebula/ui/components/VPNServerList.qml
+++ b/nebula/ui/components/VPNServerList.qml
@@ -167,7 +167,9 @@ FocusScope {
                             horizontalAlignment: Text.AlignLeft
                             // TODO: Replace placeholder strings and generate
                             // values that will be set instead of `%1`
-                            text: !statusComponent.rowShouldBeDisabled
+                            text: VPNServerLatency.progress < 1.0
+                                ? "Checking... %1%".arg(Math.round(VPNServerLatency.progress * 100))
+                                : !statusComponent.rowShouldBeDisabled
                                 ? "Last updated %1 ago.".arg(VPNServerLatency.lastUpdateTime)
                                 : "Last updated %1 ago. To update this list please first disconnect from the VPN."
                             wrapMode: Text.WordWrap

--- a/nebula/ui/components/VPNServerList.qml
+++ b/nebula/ui/components/VPNServerList.qml
@@ -137,7 +137,7 @@ FocusScope {
                     rowShouldBeDisabled: !(VPNController.state === VPNController.StateOff)
 
                     onClicked: {
-                        console.log("TODO: Request server data refresh");
+                        VPNServerLatency.refresh();
                     }
 
                     RowLayout {
@@ -168,7 +168,7 @@ FocusScope {
                             // TODO: Replace placeholder strings and generate
                             // values that will be set instead of `%1`
                             text: !statusComponent.rowShouldBeDisabled
-                                ? "Last updated %1 ago."
+                                ? "Last updated %1 ago.".arg(VPNServerLatency.lastUpdateTime)
                                 : "Last updated %1 ago. To update this list please first disconnect from the VPN."
                             wrapMode: Text.WordWrap
                         }

--- a/src/apps/vpn/commands/commandui.cpp
+++ b/src/apps/vpn/commands/commandui.cpp
@@ -421,6 +421,14 @@ int CommandUI::run(QStringList& tokens) {
         });
 
     qmlRegisterSingletonType<MozillaVPN>(
+        "Mozilla.VPN", 1, 0, "VPNServerLatency",
+        [](QQmlEngine*, QJSEngine*) -> QObject* {
+          QObject* obj = MozillaVPN::instance()->serverLatency();
+          QQmlEngine::setObjectOwnership(obj, QQmlEngine::CppOwnership);
+          return obj;
+        });
+
+    qmlRegisterSingletonType<MozillaVPN>(
         "Mozilla.VPN", 1, 0, "VPNConnectionHealth",
         [](QQmlEngine*, QJSEngine*) -> QObject* {
           QObject* obj = MozillaVPN::instance()->connectionHealth();

--- a/src/apps/vpn/controller.cpp
+++ b/src/apps/vpn/controller.cpp
@@ -4,6 +4,7 @@
 
 #include "controller.h"
 
+#include "appconstants.h"
 #include "controllerimpl.h"
 #include "dnshelper.h"
 #include "feature.h"
@@ -374,8 +375,9 @@ bool Controller::silentSwitchServers(bool serverCoolDownNeeded) {
       return false;
     }
 
-    MozillaVPN::instance()->serverCountryModel()->setServerCooldown(
-        m_serverData.exitServerPublicKey());
+    MozillaVPN::instance()->serverLatency()->setCooldown(
+        m_serverData.exitServerPublicKey(),
+        AppConstants::SERVER_UNRESPONSIVE_COOLDOWN_SEC);
   }
 
   m_nextServerData = m_serverData;
@@ -475,7 +477,8 @@ void Controller::handshakeTimeout() {
 
   // Block the offending server and try again.
   HopConnection& hop = m_activationQueue.first();
-  vpn->serverCountryModel()->setServerCooldown(hop.m_server.publicKey());
+  vpn->serverLatency()->setCooldown(
+      hop.m_server.publicKey(), AppConstants::SERVER_UNRESPONSIVE_COOLDOWN_SEC);
 
   emit handshakeFailed(hop.m_server.publicKey());
 

--- a/src/apps/vpn/models/server.cpp
+++ b/src/apps/vpn/models/server.cpp
@@ -38,7 +38,6 @@ Server& Server::operator=(const Server& other) {
   m_weight = other.m_weight;
   m_socksName = other.m_socksName;
   m_multihopPort = other.m_multihopPort;
-  m_cooldownTimeout = other.m_cooldownTimeout;
   m_countryCode = other.m_countryCode;
   m_cityName = other.m_cityName;
 
@@ -128,7 +127,6 @@ bool Server::fromJson(const QJsonObject& obj) {
   m_weight = weight.toInt();
   m_socksName = socks5_name.toString();
   m_multihopPort = multihop_port.toInt();
-  m_cooldownTimeout = 0;
 
   return true;
 }
@@ -140,7 +138,6 @@ bool Server::fromMultihop(const Server& exit, const Server& entry) {
   m_publicKey = exit.m_publicKey;
   m_socksName = exit.m_socksName;
   m_multihopPort = exit.m_multihopPort;
-  m_cooldownTimeout = exit.m_cooldownTimeout;
 
   m_ipv4AddrIn = entry.m_ipv4AddrIn;
   m_ipv6AddrIn = entry.m_ipv6AddrIn;
@@ -151,14 +148,6 @@ bool Server::forcePort(uint32_t port) {
   m_portRanges.clear();
   m_portRanges.append(QPair<uint32_t, uint32_t>(port, port));
   return true;
-}
-
-void Server::setCooldownTimeout(qint64 timeout) {
-  if (timeout <= 0) {
-    m_cooldownTimeout = 0;
-  } else {
-    m_cooldownTimeout = QDateTime::currentSecsSinceEpoch() + timeout;
-  }
 }
 
 // static

--- a/src/apps/vpn/models/server.cpp
+++ b/src/apps/vpn/models/server.cpp
@@ -39,7 +39,6 @@ Server& Server::operator=(const Server& other) {
   m_socksName = other.m_socksName;
   m_multihopPort = other.m_multihopPort;
   m_cooldownTimeout = other.m_cooldownTimeout;
-  m_latency = other.m_latency;
   m_countryCode = other.m_countryCode;
   m_cityName = other.m_cityName;
 
@@ -130,7 +129,6 @@ bool Server::fromJson(const QJsonObject& obj) {
   m_socksName = socks5_name.toString();
   m_multihopPort = multihop_port.toInt();
   m_cooldownTimeout = 0;
-  m_latency = 0;
 
   return true;
 }
@@ -143,7 +141,6 @@ bool Server::fromMultihop(const Server& exit, const Server& entry) {
   m_socksName = exit.m_socksName;
   m_multihopPort = exit.m_multihopPort;
   m_cooldownTimeout = exit.m_cooldownTimeout;
-  m_latency = exit.m_latency;
 
   m_ipv4AddrIn = entry.m_ipv4AddrIn;
   m_ipv6AddrIn = entry.m_ipv6AddrIn;

--- a/src/apps/vpn/models/server.h
+++ b/src/apps/vpn/models/server.h
@@ -40,9 +40,6 @@ class Server final {
 
   const QString& socksName() const { return m_socksName; }
 
-  qint64 cooldownTimeout() const { return m_cooldownTimeout; }
-  void setCooldownTimeout(qint64 timeout);
-
   uint32_t weight() const { return m_weight; }
 
   uint32_t choosePort() const;
@@ -75,7 +72,6 @@ class Server final {
   QString m_socksName;
   uint32_t m_weight = 0;
   uint32_t m_multihopPort = 0;
-  qint64 m_cooldownTimeout = 0;
   QString m_countryCode;
   QString m_cityName;
 };

--- a/src/apps/vpn/models/server.h
+++ b/src/apps/vpn/models/server.h
@@ -43,9 +43,6 @@ class Server final {
   qint64 cooldownTimeout() const { return m_cooldownTimeout; }
   void setCooldownTimeout(qint64 timeout);
 
-  uint32_t latency() const { return m_latency; }
-  void setLatency(uint32_t msec) { m_latency = msec; }
-
   uint32_t weight() const { return m_weight; }
 
   uint32_t choosePort() const;
@@ -79,7 +76,6 @@ class Server final {
   uint32_t m_weight = 0;
   uint32_t m_multihopPort = 0;
   qint64 m_cooldownTimeout = 0;
-  uint32_t m_latency = 0;
   QString m_countryCode;
   QString m_cityName;
 };

--- a/src/apps/vpn/models/servercity.cpp
+++ b/src/apps/vpn/models/servercity.cpp
@@ -115,14 +115,14 @@ const QString ServerCity::localizedName() const {
 }
 
 int ServerCity::connectionScore() const {
-  ServerLatency* sl = MozillaVPN::instance()->serverLatency();
+  ServerLatency* serverLatency = MozillaVPN::instance()->serverLatency();
   qint64 now = QDateTime::currentSecsSinceEpoch();
   int score = Poor;
   int activeServerCount = 0;
   uint32_t sumLatencyMsec = 0;
   for (const QString& pubkey : m_servers) {
-    if (sl->getCooldown(pubkey) <= now) {
-      sumLatencyMsec += sl->getLatency(pubkey);
+    if (serverLatency->getCooldown(pubkey) <= now) {
+      sumLatencyMsec += serverLatency->getLatency(pubkey);
       activeServerCount++;
     }
   }
@@ -140,7 +140,7 @@ int ServerCity::connectionScore() const {
 
   // Increase the score if the location has better than average latency.
   uint32_t cityLatencyMsec = sumLatencyMsec / activeServerCount;
-  if (cityLatencyMsec < sl->avgLatency()) {
+  if (cityLatencyMsec < serverLatency->avgLatency()) {
     score++;
     // Give the location another point if the latency is *very* fast.
     if (cityLatencyMsec < SCORE_EXCELLENT_LATENCY_THRESHOLD) {
@@ -165,13 +165,13 @@ int ServerCity::connectionScore() const {
 }
 
 unsigned int ServerCity::latency() const {
-  ServerLatency* sl = MozillaVPN::instance()->serverLatency();
+  ServerLatency* serverLatency = MozillaVPN::instance()->serverLatency();
   qint64 now = QDateTime::currentSecsSinceEpoch();
   int activeServerCount = 0;
   uint32_t sumLatencyMsec = 0;
   for (const QString& pubkey : m_servers) {
-    if (sl->getCooldown(pubkey) <= now) {
-      sumLatencyMsec += sl->getLatency(pubkey);
+    if (serverLatency->getCooldown(pubkey) <= now) {
+      sumLatencyMsec += serverLatency->getLatency(pubkey);
       activeServerCount++;
     }
   }

--- a/src/apps/vpn/models/servercity.cpp
+++ b/src/apps/vpn/models/servercity.cpp
@@ -12,8 +12,8 @@
 #include "feature.h"
 #include "leakdetector.h"
 #include "mozillavpn.h"
-#include "servercountrymodel.h"
 #include "serveri18n.h"
+#include "serverlatency.h"
 
 // Minimum number of redundant servers we expect at a location.
 constexpr int SCORE_SERVER_REDUNDANCY_THRESHOLD = 3;
@@ -108,15 +108,13 @@ const QString ServerCity::localizedName() const {
 }
 
 int ServerCity::connectionScore() const {
-  ServerCountryModel* scm = MozillaVPN::instance()->serverCountryModel();
   ServerLatency* sl = MozillaVPN::instance()->serverLatency();
   qint64 now = QDateTime::currentSecsSinceEpoch();
   int score = Poor;
   int activeServerCount = 0;
   uint32_t sumLatencyMsec = 0;
   for (const QString& pubkey : m_servers) {
-    const Server& server = scm->server(pubkey);
-    if (server.cooldownTimeout() <= now) {
+    if (sl->getCooldown(pubkey) <= now) {
       sumLatencyMsec += sl->getLatency(pubkey);
       activeServerCount++;
     }
@@ -160,14 +158,12 @@ int ServerCity::connectionScore() const {
 }
 
 unsigned int ServerCity::latency() const {
-  ServerCountryModel* scm = MozillaVPN::instance()->serverCountryModel();
   ServerLatency* sl = MozillaVPN::instance()->serverLatency();
   qint64 now = QDateTime::currentSecsSinceEpoch();
   int activeServerCount = 0;
   uint32_t sumLatencyMsec = 0;
   for (const QString& pubkey : m_servers) {
-    const Server& server = scm->server(pubkey);
-    if (server.cooldownTimeout() <= now) {
+    if (sl->getCooldown(pubkey) <= now) {
       sumLatencyMsec += sl->getLatency(pubkey);
       activeServerCount++;
     }

--- a/src/apps/vpn/models/servercity.cpp
+++ b/src/apps/vpn/models/servercity.cpp
@@ -26,6 +26,14 @@ ServerCity::ServerCity() { MZ_COUNT_CTOR(ServerCity); }
 ServerCity::ServerCity(const ServerCity& other) {
   MZ_COUNT_CTOR(ServerCity);
   *this = other;
+
+  // Changes in the average latency may cause the connection score to change.
+  MozillaVPN* vpn = MozillaVPN::instance();
+  if (vpn) {
+    connect(vpn->serverLatency(), &ServerLatency::progressChanged, this, [this]{
+      emit scoreChanged();
+    });
+  }
 }
 
 ServerCity& ServerCity::operator=(const ServerCity& other) {

--- a/src/apps/vpn/models/servercity.cpp
+++ b/src/apps/vpn/models/servercity.cpp
@@ -109,6 +109,7 @@ const QString ServerCity::localizedName() const {
 
 int ServerCity::connectionScore() const {
   ServerCountryModel* scm = MozillaVPN::instance()->serverCountryModel();
+  ServerLatency* sl = MozillaVPN::instance()->serverLatency();
   qint64 now = QDateTime::currentSecsSinceEpoch();
   int score = Poor;
   int activeServerCount = 0;
@@ -134,7 +135,7 @@ int ServerCity::connectionScore() const {
 
   // Increase the score if the location has better than average latency.
   uint32_t cityLatencyMsec = sumLatencyMsec / activeServerCount;
-  if (cityLatencyMsec < scm->avgLatency()) {
+  if (cityLatencyMsec < sl->avgLatency()) {
     score++;
     // Give the location another point if the latency is *very* fast.
     if (cityLatencyMsec < SCORE_EXCELLENT_LATENCY_THRESHOLD) {

--- a/src/apps/vpn/models/servercity.cpp
+++ b/src/apps/vpn/models/servercity.cpp
@@ -31,7 +31,7 @@ ServerCity::ServerCity(const ServerCity& other) {
   MozillaVPN* vpn = MozillaVPN::instance();
   if (vpn) {
     connect(vpn->serverLatency(), &ServerLatency::progressChanged, this,
-            [this]{ emit scoreChanged(); });
+            [this] { emit scoreChanged(); });
   }
 }
 

--- a/src/apps/vpn/models/servercity.cpp
+++ b/src/apps/vpn/models/servercity.cpp
@@ -117,7 +117,7 @@ int ServerCity::connectionScore() const {
   for (const QString& pubkey : m_servers) {
     const Server& server = scm->server(pubkey);
     if (server.cooldownTimeout() <= now) {
-      sumLatencyMsec += server.latency();
+      sumLatencyMsec += sl->getLatency(pubkey);
       activeServerCount++;
     }
   }
@@ -161,13 +161,14 @@ int ServerCity::connectionScore() const {
 
 unsigned int ServerCity::latency() const {
   ServerCountryModel* scm = MozillaVPN::instance()->serverCountryModel();
+  ServerLatency* sl = MozillaVPN::instance()->serverLatency();
   qint64 now = QDateTime::currentSecsSinceEpoch();
   int activeServerCount = 0;
   uint32_t sumLatencyMsec = 0;
   for (const QString& pubkey : m_servers) {
     const Server& server = scm->server(pubkey);
     if (server.cooldownTimeout() <= now) {
-      sumLatencyMsec += server.latency();
+      sumLatencyMsec += sl->getLatency(pubkey);
       activeServerCount++;
     }
   }

--- a/src/apps/vpn/models/servercity.cpp
+++ b/src/apps/vpn/models/servercity.cpp
@@ -30,9 +30,8 @@ ServerCity::ServerCity(const ServerCity& other) {
   // Changes in the average latency may cause the connection score to change.
   MozillaVPN* vpn = MozillaVPN::instance();
   if (vpn) {
-    connect(vpn->serverLatency(), &ServerLatency::progressChanged, this, [this]{
-      emit scoreChanged();
-    });
+    connect(vpn->serverLatency(), &ServerLatency::progressChanged, this,
+            [this]{ emit scoreChanged(); });
   }
 }
 

--- a/src/apps/vpn/models/servercountrymodel.cpp
+++ b/src/apps/vpn/models/servercountrymodel.cpp
@@ -243,27 +243,6 @@ void ServerCountryModel::retranslate() {
   endResetModel();
 }
 
-void ServerCountryModel::setServerLatency(const QString& publicKey,
-                                          unsigned int msec) {
-  if (!m_servers.contains(publicKey)) {
-    return;
-  }
-
-  const Server& server = m_servers[publicKey];
-  auto iter = m_cities.find(
-      ServerCity::hashKey(server.countryCode(), server.cityName()));
-  if (iter != m_cities.end()) {
-    emit iter->scoreChanged();
-  }
-}
-
-void ServerCountryModel::clearServerLatency() {
-  // Emit changed signals for the connection scores.
-  for (const ServerCity& city : m_cities) {
-    emit city.scoreChanged();
-  }
-}
-
 void ServerCountryModel::setServerCooldown(const QString& publicKey) {
   auto serverIterator = m_servers.find(publicKey);
   if (serverIterator == m_servers.end()) {

--- a/src/apps/vpn/models/servercountrymodel.cpp
+++ b/src/apps/vpn/models/servercountrymodel.cpp
@@ -249,9 +249,7 @@ void ServerCountryModel::setServerLatency(const QString& publicKey,
     return;
   }
 
-  Server& server = m_servers[publicKey];
-  server.setLatency(msec);
-
+  const Server& server = m_servers[publicKey];
   auto iter = m_cities.find(
       ServerCity::hashKey(server.countryCode(), server.cityName()));
   if (iter != m_cities.end()) {
@@ -260,11 +258,6 @@ void ServerCountryModel::setServerLatency(const QString& publicKey,
 }
 
 void ServerCountryModel::clearServerLatency() {
-  // Invalidate the latency data.
-  for (Server& server : m_servers) {
-    server.setLatency(0);
-  }
-
   // Emit changed signals for the connection scores.
   for (const ServerCity& city : m_cities) {
     emit city.scoreChanged();

--- a/src/apps/vpn/models/servercountrymodel.cpp
+++ b/src/apps/vpn/models/servercountrymodel.cpp
@@ -243,22 +243,6 @@ void ServerCountryModel::retranslate() {
   endResetModel();
 }
 
-void ServerCountryModel::setServerCooldown(const QString& publicKey) {
-  auto serverIterator = m_servers.find(publicKey);
-  if (serverIterator == m_servers.end()) {
-    return;
-  }
-
-  serverIterator->setCooldownTimeout(
-      AppConstants::SERVER_UNRESPONSIVE_COOLDOWN_SEC);
-
-  auto cityIterator = m_cities.find(ServerCity::hashKey(
-      serverIterator->countryCode(), serverIterator->cityName()));
-  if (cityIterator != m_cities.end()) {
-    emit cityIterator->scoreChanged();
-  }
-}
-
 void ServerCountryModel::setCooldownForAllServersInACity(
     const QString& countryCode, const QString& cityCode) {
   logger.debug() << "Set cooldown for all servers for: "
@@ -269,12 +253,9 @@ void ServerCountryModel::setCooldownForAllServersInACity(
       continue;
     }
     for (const QString& pubkey : city.servers()) {
-      if (m_servers.contains(pubkey)) {
-        m_servers[pubkey].setCooldownTimeout(
-            AppConstants::SERVER_UNRESPONSIVE_COOLDOWN_SEC);
-      }
+      MozillaVPN::instance()->serverLatency()->setCooldown(
+          pubkey, AppConstants::SERVER_UNRESPONSIVE_COOLDOWN_SEC);
     }
-    emit city.scoreChanged();
   }
 }
 

--- a/src/apps/vpn/models/servercountrymodel.h
+++ b/src/apps/vpn/models/servercountrymodel.h
@@ -57,7 +57,6 @@ class ServerCountryModel final : public QAbstractListModel {
   const QList<ServerCountry>& countries() const { return m_countries; }
 
   void retranslate();
-  void setServerCooldown(const QString& publicKey);
   void setCooldownForAllServersInACity(const QString& countryCode,
                                        const QString& cityCode);
 

--- a/src/apps/vpn/models/servercountrymodel.h
+++ b/src/apps/vpn/models/servercountrymodel.h
@@ -57,8 +57,6 @@ class ServerCountryModel final : public QAbstractListModel {
   const QList<ServerCountry>& countries() const { return m_countries; }
 
   void retranslate();
-  void setServerLatency(const QString& publicKey, unsigned int msec);
-  void clearServerLatency();
   void setServerCooldown(const QString& publicKey);
   void setCooldownForAllServersInACity(const QString& countryCode,
                                        const QString& cityCode);

--- a/src/apps/vpn/models/servercountrymodel.h
+++ b/src/apps/vpn/models/servercountrymodel.h
@@ -57,7 +57,6 @@ class ServerCountryModel final : public QAbstractListModel {
   const QList<ServerCountry>& countries() const { return m_countries; }
 
   void retranslate();
-  unsigned int avgLatency() const;
   void setServerLatency(const QString& publicKey, unsigned int msec);
   void clearServerLatency();
   void setServerCooldown(const QString& publicKey);
@@ -90,9 +89,6 @@ class ServerCountryModel final : public QAbstractListModel {
   QList<ServerCountry> m_countries;
   QHash<QString, ServerCity> m_cities;
   QHash<QString, Server> m_servers;
-
-  qint64 m_sumLatencyMsec;
-  qint64 m_numLatencySamples;
 };
 
 #endif  // SERVERCOUNTRYMODEL_H

--- a/src/apps/vpn/models/serverdata.cpp
+++ b/src/apps/vpn/models/serverdata.cpp
@@ -225,14 +225,14 @@ void ServerData::forget() {
 QList<Server> ServerData::getServerList(const QString& countryCode,
                                         const QString& cityName) {
   ServerCountryModel* scm = MozillaVPN::instance()->serverCountryModel();
-  ServerLatency* sl = MozillaVPN::instance()->serverLatency();
+  ServerLatency* serverLatency = MozillaVPN::instance()->serverLatency();
   const ServerCity& city = scm->findCity(countryCode, cityName);
   QList<Server> results;
   qint64 now = QDateTime::currentSecsSinceEpoch();
 
   for (const QString& pubkey : city.servers()) {
     const Server& server = scm->server(pubkey);
-    if (server.initialized() && (sl->getCooldown(pubkey) <= now)) {
+    if (server.initialized() && (serverLatency->getCooldown(pubkey) <= now)) {
       results.append(server);
     }
   }

--- a/src/apps/vpn/models/serverdata.cpp
+++ b/src/apps/vpn/models/serverdata.cpp
@@ -225,13 +225,14 @@ void ServerData::forget() {
 QList<Server> ServerData::getServerList(const QString& countryCode,
                                         const QString& cityName) {
   ServerCountryModel* scm = MozillaVPN::instance()->serverCountryModel();
+  ServerLatency* sl = MozillaVPN::instance()->serverLatency();
   const ServerCity& city = scm->findCity(countryCode, cityName);
   QList<Server> results;
   qint64 now = QDateTime::currentSecsSinceEpoch();
 
   for (const QString& pubkey : city.servers()) {
     const Server& server = scm->server(pubkey);
-    if (server.initialized() && server.cooldownTimeout() <= now) {
+    if (server.initialized() && (sl->getCooldown(pubkey) <= now)) {
       results.append(server);
     }
   }

--- a/src/apps/vpn/mozillavpn.cpp
+++ b/src/apps/vpn/mozillavpn.cpp
@@ -233,6 +233,10 @@ ServerCountryModel* MozillaVPN::serverCountryModel() {
   return &m_private->m_serverCountryModel;
 }
 
+ServerLatency* MozillaVPN::serverLatency() const {
+  return &m_private->m_serverLatency;
+}
+
 SubscriptionData* MozillaVPN::subscriptionData() {
   return &m_private->m_subscriptionData;
 }

--- a/src/apps/vpn/mozillavpn.h
+++ b/src/apps/vpn/mozillavpn.h
@@ -174,7 +174,7 @@ class MozillaVPN final : public QObject {
   ProfileFlow* profileFlow() { return &m_private->m_profileFlow; }
   ReleaseMonitor* releaseMonitor() { return &m_private->m_releaseMonitor; }
   ServerCountryModel* serverCountryModel();
-  ServerLatency* serverLatency() const { return &m_private->m_serverLatency; }
+  ServerLatency* serverLatency() const;
   StatusIcon* statusIcon() { return &m_private->m_statusIcon; }
   SubscriptionData* subscriptionData();
   Telemetry* telemetry() { return &m_private->m_telemetry; }

--- a/src/apps/vpn/mozillavpn.h
+++ b/src/apps/vpn/mozillavpn.h
@@ -174,6 +174,7 @@ class MozillaVPN final : public QObject {
   ProfileFlow* profileFlow() { return &m_private->m_profileFlow; }
   ReleaseMonitor* releaseMonitor() { return &m_private->m_releaseMonitor; }
   ServerCountryModel* serverCountryModel();
+  ServerLatency* serverLatency() const { return &m_private->m_serverLatency; }
   StatusIcon* statusIcon() { return &m_private->m_statusIcon; }
   SubscriptionData* subscriptionData();
   Telemetry* telemetry() { return &m_private->m_telemetry; }

--- a/src/apps/vpn/serverlatency.cpp
+++ b/src/apps/vpn/serverlatency.cpp
@@ -204,9 +204,7 @@ void ServerLatency::stop() {
   }
 
   emit progressChanged();
-  if (m_progressDelayTimer.isActive()) {
-    m_progressDelayTimer.stop();
-  }
+  m_progressDelayTimer.stop();
   if (!m_refreshTimer.isActive()) {
     m_refreshTimer.start(SERVER_LATENCY_REFRESH_MSEC);
   }

--- a/src/apps/vpn/serverlatency.cpp
+++ b/src/apps/vpn/serverlatency.cpp
@@ -282,3 +282,20 @@ double ServerLatency::progress() const {
   double remaining = m_pingReplyList.count() + m_pingSendQueue.count();
   return 1.0 - (remaining / m_pingSendTotal);
 }
+
+void ServerLatency::setCooldown(const QString& publicKey, qint64 timeout) {
+  if (timeout <= 0) {
+    m_cooldown.remove(publicKey);
+  } else {
+    m_cooldown[publicKey] = QDateTime::currentSecsSinceEpoch() + timeout;
+  }
+
+  // Emit signals that the connection score may have changed.
+  ServerCountryModel* scm = MozillaVPN::instance()->serverCountryModel();
+  const Server& server = scm->server(publicKey);
+  const ServerCity& city =
+      scm->findCity(server.countryCode(), server.cityName());
+  if (city.initialized()) {
+    emit city.scoreChanged();
+  }
+}

--- a/src/apps/vpn/serverlatency.cpp
+++ b/src/apps/vpn/serverlatency.cpp
@@ -74,6 +74,7 @@ void ServerLatency::start() {
   m_sequence = 0;
   m_wantRefresh = false;
   m_pingSender = PingSenderFactory::create(QHostAddress(), this);
+  m_lastUpdateTime = QDateTime::currentDateTime();
 
   connect(m_pingSender, SIGNAL(recvPing(quint16)), this,
           SLOT(recvPing(quint16)), Qt::QueuedConnection);
@@ -187,6 +188,15 @@ void ServerLatency::stop() {
   if (!m_refreshTimer.isActive()) {
     m_refreshTimer.start(SERVER_LATENCY_REFRESH_MSEC);
   }
+}
+
+void ServerLatency::refresh() {
+  if (m_pingSender) {
+    return;
+  }
+
+  MozillaVPN::instance()->serverCountryModel()->clearServerLatency();
+  start();
 }
 
 void ServerLatency::stateChanged() {

--- a/src/apps/vpn/serverlatency.cpp
+++ b/src/apps/vpn/serverlatency.cpp
@@ -186,13 +186,12 @@ void ServerLatency::stop() {
   m_pingReplyList.clear();
   m_pingSendTotal = 0;
 
-  emit progressChanged();
-
   if (m_pingSender) {
     delete m_pingSender;
     m_pingSender = nullptr;
   }
 
+  emit progressChanged();
   if (!m_refreshTimer.isActive()) {
     m_refreshTimer.start(SERVER_LATENCY_REFRESH_MSEC);
   }

--- a/src/apps/vpn/serverlatency.cpp
+++ b/src/apps/vpn/serverlatency.cpp
@@ -101,8 +101,8 @@ void ServerLatency::start() {
 
       // Insert the servers into the list.
       for (const QString& pubkey : city.servers()) {
-        ServerPingRecord rec =
-            {pubkey, city.country(), city.name(), 0, 0, distance, 0};
+        ServerPingRecord rec = {
+            pubkey, city.country(), city.name(), 0, 0, distance, 0};
         i = m_pingSendQueue.insert(i, rec);
       }
     }
@@ -162,7 +162,7 @@ void ServerLatency::maybeSendPings() {
     const Server& server = scm->server(record.publicKey);
     m_pingSender->sendPing(QHostAddress(server.ipv4AddrIn()), record.sequence);
   }
-  
+
   emit progressChanged();
 
   if (m_pingReplyList.isEmpty()) {
@@ -276,9 +276,9 @@ unsigned int ServerLatency::avgLatency() const {
 
 double ServerLatency::progress() const {
   if ((m_pingSender == nullptr) || (m_pingSendTotal == 0)) {
-    return 1.0; // Operation is complete.
+    return 1.0;  // Operation is complete.
   }
-  
+
   double remaining = m_pingReplyList.count() + m_pingSendQueue.count();
   return 1.0 - (remaining / m_pingSendTotal);
 }

--- a/src/apps/vpn/serverlatency.cpp
+++ b/src/apps/vpn/serverlatency.cpp
@@ -50,9 +50,8 @@ void ServerLatency::initialize() {
   connect(&m_refreshTimer, &QTimer::timeout, this, &ServerLatency::start);
 
   m_progressDelayTimer.setSingleShot(true);
-  connect(&m_progressDelayTimer, &QTimer::timeout, this, [this]() {
-    emit progressChanged();
-  });
+  connect(&m_progressDelayTimer, &QTimer::timeout, this,
+          [this]() { emit progressChanged(); });
 
   const Feature* feature = Feature::get(Feature::Feature_serverConnectionScore);
   connect(feature, &Feature::supportedChanged, this, &ServerLatency::start);

--- a/src/apps/vpn/serverlatency.h
+++ b/src/apps/vpn/serverlatency.h
@@ -5,6 +5,7 @@
 #ifndef SERVERLATENCY_H
 #define SERVERLATENCY_H
 
+#include <QDateTime>
 #include <QObject>
 #include <QTimer>
 
@@ -15,13 +16,19 @@ class ServerLatency final : public QObject {
   Q_OBJECT
   Q_DISABLE_COPY_MOVE(ServerLatency)
 
+  Q_PROPERTY(QDateTime lastUpdateTime READ lastUpdateTime CONSTANT)
+
  public:
   ServerLatency();
   ~ServerLatency();
 
+  const QDateTime& lastUpdateTime() const { return m_lastUpdateTime; }
+
   void initialize();
   void start();
   void stop();
+
+  Q_INVOKABLE void refresh();
 
  private:
   void maybeSendPings();
@@ -39,6 +46,7 @@ class ServerLatency final : public QObject {
   QList<ServerPingRecord> m_pingSendQueue;
   QList<ServerPingRecord> m_pingReplyList;
 
+  QDateTime m_lastUpdateTime;
   QTimer m_pingTimeout;
   QTimer m_refreshTimer;
   bool m_wantRefresh = false;

--- a/src/apps/vpn/serverlatency.h
+++ b/src/apps/vpn/serverlatency.h
@@ -16,7 +16,8 @@ class ServerLatency final : public QObject {
   Q_OBJECT
   Q_DISABLE_COPY_MOVE(ServerLatency)
 
-  Q_PROPERTY(QDateTime lastUpdateTime READ lastUpdateTime NOTIFY progressChanged)
+  Q_PROPERTY(
+      QDateTime lastUpdateTime READ lastUpdateTime NOTIFY progressChanged)
   Q_PROPERTY(unsigned int avgLatency READ avgLatency NOTIFY progressChanged)
   Q_PROPERTY(bool isActive READ isActive NOTIFY progressChanged)
   Q_PROPERTY(double progress READ progress NOTIFY progressChanged)

--- a/src/apps/vpn/serverlatency.h
+++ b/src/apps/vpn/serverlatency.h
@@ -17,11 +17,16 @@ class ServerLatency final : public QObject {
   Q_DISABLE_COPY_MOVE(ServerLatency)
 
   Q_PROPERTY(QDateTime lastUpdateTime READ lastUpdateTime CONSTANT)
+  Q_PROPERTY(unsigned int avgLatency READ avgLatency CONSTANT)
 
  public:
   ServerLatency();
   ~ServerLatency();
 
+  unsigned int avgLatency() const;
+  unsigned int getLatency(const QString& pubkey) const {
+    return m_latency.value(pubkey);
+  };
   const QDateTime& lastUpdateTime() const { return m_lastUpdateTime; }
 
   void initialize();
@@ -46,7 +51,10 @@ class ServerLatency final : public QObject {
   QList<ServerPingRecord> m_pingSendQueue;
   QList<ServerPingRecord> m_pingReplyList;
 
+  QHash<QString, qint64> m_latency;
+  qint64 m_sumLatencyMsec = 0;
   QDateTime m_lastUpdateTime;
+
   QTimer m_pingTimeout;
   QTimer m_refreshTimer;
   bool m_wantRefresh = false;

--- a/src/apps/vpn/serverlatency.h
+++ b/src/apps/vpn/serverlatency.h
@@ -34,6 +34,11 @@ class ServerLatency final : public QObject {
   bool isActive() const { return m_pingSender != nullptr; }
   double progress() const;
 
+  qint64 getCooldown(const QString& pubkey) const {
+    return m_cooldown.value(pubkey);
+  }
+  void setCooldown(const QString& pubkey, qint64 timeout);
+
   void initialize();
   void start();
   void stop();
@@ -64,6 +69,7 @@ class ServerLatency final : public QObject {
   qsizetype m_pingSendTotal = 0;
 
   QHash<QString, qint64> m_latency;
+  QHash<QString, qint64> m_cooldown;
   qint64 m_sumLatencyMsec = 0;
   QDateTime m_lastUpdateTime;
 

--- a/src/apps/vpn/serverlatency.h
+++ b/src/apps/vpn/serverlatency.h
@@ -75,6 +75,7 @@ class ServerLatency final : public QObject {
 
   QTimer m_pingTimeout;
   QTimer m_refreshTimer;
+  QTimer m_progressDelayTimer;
   bool m_wantRefresh = false;
 
  private slots:

--- a/src/apps/vpn/serverlatency.h
+++ b/src/apps/vpn/serverlatency.h
@@ -16,8 +16,10 @@ class ServerLatency final : public QObject {
   Q_OBJECT
   Q_DISABLE_COPY_MOVE(ServerLatency)
 
-  Q_PROPERTY(QDateTime lastUpdateTime READ lastUpdateTime CONSTANT)
-  Q_PROPERTY(unsigned int avgLatency READ avgLatency CONSTANT)
+  Q_PROPERTY(QDateTime lastUpdateTime READ lastUpdateTime NOTIFY progressChanged)
+  Q_PROPERTY(unsigned int avgLatency READ avgLatency NOTIFY progressChanged)
+  Q_PROPERTY(bool isActive READ isActive NOTIFY progressChanged)
+  Q_PROPERTY(double progress READ progress NOTIFY progressChanged)
 
  public:
   ServerLatency();
@@ -28,12 +30,17 @@ class ServerLatency final : public QObject {
     return m_latency.value(pubkey);
   };
   const QDateTime& lastUpdateTime() const { return m_lastUpdateTime; }
+  bool isActive() const { return m_pingSender != nullptr; }
+  double progress() const;
 
   void initialize();
   void start();
   void stop();
 
   Q_INVOKABLE void refresh();
+
+ signals:
+  void progressChanged();
 
  private:
   void maybeSendPings();
@@ -50,6 +57,7 @@ class ServerLatency final : public QObject {
   PingSender* m_pingSender = nullptr;
   QList<ServerPingRecord> m_pingSendQueue;
   QList<ServerPingRecord> m_pingReplyList;
+  qsizetype m_pingSendTotal = 0;
 
   QHash<QString, qint64> m_latency;
   qint64 m_sumLatencyMsec = 0;

--- a/src/apps/vpn/serverlatency.h
+++ b/src/apps/vpn/serverlatency.h
@@ -44,10 +44,13 @@ class ServerLatency final : public QObject {
 
  private:
   void maybeSendPings();
+  void clear();
 
  private:
   struct ServerPingRecord {
     QString publicKey;
+    QString countryCode;
+    QString cityName;
     quint64 timestamp;
     quint16 sequence;
     double distance;

--- a/tests/auth/CMakeLists.txt
+++ b/tests/auth/CMakeLists.txt
@@ -84,6 +84,8 @@ target_sources(auth_tests PRIVATE
     ${MZ_SOURCE_DIR}/apps/vpn/platforms/dummy/dummypingsender.h
     ${MZ_SOURCE_DIR}/apps/vpn/serveri18n.cpp
     ${MZ_SOURCE_DIR}/apps/vpn/serveri18n.h
+    ${MZ_SOURCE_DIR}/apps/vpn/serverlatency.cpp
+    ${MZ_SOURCE_DIR}/apps/vpn/serverlatency.h
     ${MZ_SOURCE_DIR}/apps/vpn/tasks/authenticate/desktopauthenticationlistener.cpp
     ${MZ_SOURCE_DIR}/apps/vpn/tasks/authenticate/desktopauthenticationlistener.h
     ${MZ_SOURCE_DIR}/apps/vpn/tasks/authenticate/taskauthenticate.cpp

--- a/tests/auth/mocmozillavpn.cpp
+++ b/tests/auth/mocmozillavpn.cpp
@@ -36,8 +36,8 @@ ServerCountryModel* MozillaVPN::serverCountryModel() {
 }
 
 ServerLatency* MozillaVPN::serverLatency() const {
-  static ServerLatency* sl = new ServerLatency();
-  return sl;
+  static ServerLatency* serverLatency = new ServerLatency();
+  return serverLatency;
 }
 
 Location* MozillaVPN::location() const {

--- a/tests/auth/mocmozillavpn.cpp
+++ b/tests/auth/mocmozillavpn.cpp
@@ -35,6 +35,11 @@ ServerCountryModel* MozillaVPN::serverCountryModel() {
   return new ServerCountryModel();
 }
 
+ServerLatency* MozillaVPN::serverLatency() const {
+  static ServerLatency* sl = new ServerLatency();
+  return sl;
+}
+
 Location* MozillaVPN::location() const {
   static Location* location = new Location();
   return location;

--- a/tests/qml/CMakeLists.txt
+++ b/tests/qml/CMakeLists.txt
@@ -70,6 +70,8 @@ target_sources(qml_tests PRIVATE
     ${MZ_SOURCE_DIR}/apps/vpn/platforms/dummy/dummypingsender.h
     ${MZ_SOURCE_DIR}/apps/vpn/serveri18n.cpp
     ${MZ_SOURCE_DIR}/apps/vpn/serveri18n.h
+    ${MZ_SOURCE_DIR}/apps/vpn/serverlatency.cpp
+    ${MZ_SOURCE_DIR}/apps/vpn/serverlatency.h
     ${MZ_SOURCE_DIR}/apps/vpn/tasks/controlleraction/taskcontrolleraction.cpp
     ${MZ_SOURCE_DIR}/apps/vpn/tasks/controlleraction/taskcontrolleraction.h
     ${MZ_SOURCE_DIR}/apps/vpn/update/updater.cpp

--- a/tests/qml/mocmozillavpn.cpp
+++ b/tests/qml/mocmozillavpn.cpp
@@ -38,8 +38,8 @@ ServerCountryModel* MozillaVPN::serverCountryModel() {
 }
 
 ServerLatency* MozillaVPN::serverLatency() const {
-  static ServerLatency* sl = new ServerLatency();
-  return sl;
+  static ServerLatency* serverLatency = new ServerLatency();
+  return serverLatency;
 }
 
 Location* MozillaVPN::location() const {

--- a/tests/qml/mocmozillavpn.cpp
+++ b/tests/qml/mocmozillavpn.cpp
@@ -37,6 +37,11 @@ ServerCountryModel* MozillaVPN::serverCountryModel() {
   return new ServerCountryModel();
 }
 
+ServerLatency* MozillaVPN::serverLatency() const {
+  static ServerLatency* sl = new ServerLatency();
+  return sl;
+}
+
 Location* MozillaVPN::location() const {
   static Location* location = new Location();
   return location;

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -174,6 +174,8 @@ target_sources(unit_tests PRIVATE
     ${MZ_SOURCE_DIR}/apps/vpn/releasemonitor.h
     ${MZ_SOURCE_DIR}/apps/vpn/serveri18n.cpp
     ${MZ_SOURCE_DIR}/apps/vpn/serveri18n.h
+    ${MZ_SOURCE_DIR}/apps/vpn/serverlatency.cpp
+    ${MZ_SOURCE_DIR}/apps/vpn/serverlatency.h
     ${MZ_SOURCE_DIR}/apps/vpn/sentry/sentryadapter.h
     ${MZ_SOURCE_DIR}/apps/vpn/statusicon.cpp
     ${MZ_SOURCE_DIR}/apps/vpn/statusicon.h

--- a/tests/unit/mocmozillavpn.cpp
+++ b/tests/unit/mocmozillavpn.cpp
@@ -47,6 +47,11 @@ ServerCountryModel* MozillaVPN::serverCountryModel() {
   return new ServerCountryModel();
 }
 
+ServerLatency* MozillaVPN::serverLatency() const {
+  static ServerLatency* sl = new ServerLatency();
+  return sl;
+}
+
 SubscriptionData* MozillaVPN::subscriptionData() {
   return new SubscriptionData();
 }

--- a/tests/unit/mocmozillavpn.cpp
+++ b/tests/unit/mocmozillavpn.cpp
@@ -48,8 +48,8 @@ ServerCountryModel* MozillaVPN::serverCountryModel() {
 }
 
 ServerLatency* MozillaVPN::serverLatency() const {
-  static ServerLatency* sl = new ServerLatency();
-  return sl;
+  static ServerLatency* serverLatency = new ServerLatency();
+  return serverLatency;
 }
 
 SubscriptionData* MozillaVPN::subscriptionData() {


### PR DESCRIPTION
## Description
Expose the `ServerLatency` object to QML, and provide a `refresh()` method to trigger a new ping sweep of the available servers, plus some useful properties about the progress of that ping sweep.

And, as some extra cleanup, I have moved the latency and cooldown properties out of the `Server` model and into the `ServerLatency` object.

## Reference
Github issue #3990 ([VPN-2531](https://mozilla-hub.atlassian.net/browse/VPN-2531))

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed


[VPN-2531]: https://mozilla-hub.atlassian.net/browse/VPN-2531?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ