### PR TITLE
VPN-2736 Fix Windows notification title

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ if(NOT (IS_MULTI_CONFIG OR DEFINED CMAKE_BUILD_TYPE))
 endif()
 
 project("Mozilla VPN" VERSION 2.15.0 LANGUAGES C CXX
-        DESCRIPTION "A fast, secure and easy to use VPN. Built by the makers of Firefox."
+        DESCRIPTION "Mozilla VPN"
         HOMEPAGE_URL "https://vpn.mozilla.org"
 )
 


### PR DESCRIPTION
## Description

Correct the title to say "Mozilla VPN" instead

![fixedTitle](https://user-images.githubusercontent.com/3746552/217377760-0a0c60f7-4302-4e47-acfb-64cd228c388e.png)


## Reference

    https://mozilla-hub.atlassian.net/browse/VPN-2736

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
