### PR TITLE
VPN-2952: Initial dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,7 @@ version: 2
 updates:
   # gitsubmodules in 3rdparty
   - package-ecosystem: "gitsubmodule"
-    directory: "/3rdparty"
+    directory: "/"
     schedule:
       interval: "monthly"
     labels:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,16 @@
 version: 2
 updates:
-  # gitsubmodules in 3rdparty
-  - package-ecosystem: "gitsubmodule"
-    directory: "/"
-    schedule:
-      interval: "monthly"
-    labels:
-      - "dependencies"
+#  # gitsubmodules in 3rdparty
+## Why is this disabled? 
+##  Dependabot cannot currently update from Tag -> Newer Tag
+#   Only to newer commits. Therefore it is not providing us the 
+#   updates we need :c
+#  - package-ecosystem: "gitsubmodule"
+#    directory: "/"
+#    schedule:
+#      interval: "monthly"
+#    labels:
+#      - "dependencies"
   # Windows Wireguard-Go
   - package-ecosystem: "gomod"
     directory: "/windows/tunnel"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,91 @@
+version: 2
+updates:
+  # gitsubmodules in 3rdparty
+  - package-ecosystem: "gitsubmodule"
+    directory: "/3rdparty"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "dependencies"
+  # Windows Wireguard-Go
+  - package-ecosystem: "gomod"
+    directory: "/windows/tunnel"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+  # Android Wireguard-Go
+  - package-ecosystem: "gomod"
+    directory: "/android/daemon/tunnel/libwg-go"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+  # Balrog Updater
+  - package-ecosystem: "gomod"
+    directory: "/balrog"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+  # Android JVM Dependencies 
+  - package-ecosystem: "gradle"
+    directory: "/android/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+  # Mac Native Messagging 
+  - package-ecosystem: "cargo"
+    directory: "/extension/bridge"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+  # Addon signature
+  - package-ecosystem: "cargo"
+    directory: "/signature"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+  # Addon signature
+  - package-ecosystem: "pip"
+    directory: "/taskcluster"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+  # Python build deps
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "dependencies"
+  # Functional Tests etc
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  # Inspector
+  - package-ecosystem: "npm"
+    directory: "/tools/inspector"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+  # Language Localizer
+  - package-ecosystem: "npm"
+    directory: "/tools/languagelocalizer"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "dependencies"
+  # Glean/Rust
+  - package-ecosystem: "cargo"
+    directory: "/vpnglean"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"


### PR DESCRIPTION
## Description

This should give dependabot the ability to see our deps. 
I'm not quite sure we want that to run weekly, but for now it'd be nice just to check out the workflow. 


See: https://github.com/mozilla-mobile/mozilla-vpn-client/network/updates
https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file