### PR TITLE
Remove sentry-secret from pull-requests

### DIFF
--- a/taskcluster/ci/build/macos.yml
+++ b/taskcluster/ci/build/macos.yml
@@ -16,10 +16,6 @@ task-defaults:
             - miniconda-osx
         toolchain:
             - qt-mac
-    scopes:
-        - project:releng:services/tooltool/api/download/public
-        - project:releng:services/tooltool/api/download/internal
-        - secrets:get:project/mozillavpn/level-1/sentry
     worker:
         taskcluster-proxy: true
         chain-of-trust: true
@@ -45,4 +41,6 @@ macos/opt:
     treeherder:
         symbol: B
     requires-level: 3 
+    scopes:
+        - secrets:get:project/mozillavpn/level-1/sentry
 

--- a/taskcluster/scripts/build/macos_build.sh
+++ b/taskcluster/scripts/build/macos_build.sh
@@ -89,7 +89,6 @@ if ! command -v sentry-cli &> /dev/null
 then
     npm install -g @sentry/cli
 fi
-sentry-cli login --auth-token $(cat sentry_debug_file_upload_key)
 
 
 print Y "Configuring the build..."
@@ -123,6 +122,7 @@ sentry-cli difutil bundle-sources tmp/MozillaVPN.dsym/Contents/Resources/DWARF/*
 
 if [[ "$RELEASE" ]]; then      
     print Y "Uploading the Symbols..." 
+    sentry-cli login --auth-token $(cat sentry_debug_file_upload_key)
     sentry-cli debug-files upload --org mozilla -p vpn-client tmp/MozillaVPN.dsym/Contents/Resources/DWARF/*
 fi
 

--- a/taskcluster/scripts/build/macos_build.sh
+++ b/taskcluster/scripts/build/macos_build.sh
@@ -71,9 +71,17 @@ git submodule update || die
 python3 -m pip install -r taskcluster/scripts/requirements.txt
 print Y "Fetching tokens..."
 # Only on a release build we have access to those secrects. 
-./taskcluster/scripts/get-secret.py -s project/mozillavpn/level-1/sentry -k sentry_dsn -f sentry_dsn
-./taskcluster/scripts/get-secret.py -s project/mozillavpn/level-1/sentry -k sentry_envelope_endpoint -f sentry_envelope_endpoint
-./taskcluster/scripts/get-secret.py -s project/mozillavpn/level-1/sentry -k sentry_debug_file_upload_key -f sentry_debug_file_upload_key
+if [[ "$RELEASE" ]]; then  
+   ./taskcluster/scripts/get-secret.py -s project/mozillavpn/level-1/sentry -k sentry_dsn -f sentry_dsn
+   ./taskcluster/scripts/get-secret.py -s project/mozillavpn/level-1/sentry -k sentry_envelope_endpoint -f sentry_envelope_endpoint
+   ./taskcluster/scripts/get-secret.py -s project/mozillavpn/level-1/sentry -k sentry_debug_file_upload_key -f sentry_debug_file_upload_key
+else
+    # write a dummy value in the files, so that we still compile sentry c: 
+    echo "dummy" > sentry_dsn
+    echo "dummy" > sentry_envelope_endpoint
+    echo "dummy" > sentry_debug_file_upload_key
+fi
+
 export SENTRY_ENVELOPE_ENDPOINT=$(cat sentry_envelope_endpoint)
 export SENTRY_DSN=$(cat sentry_dsn)
 #Install Sentry CLI, if' not already installed from previous run. 

--- a/taskcluster/test/params/pull-request-untrusted.yml
+++ b/taskcluster/test/params/pull-request-untrusted.yml
@@ -1,0 +1,32 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+---
+base_ref: origin/main
+base_repository: https://github.com/mozilla-mobile/mozilla-vpn-client
+base_rev: 8f3c09e652af74781e6301a68a48c4e861107dd6
+build_date: 1675877334
+build_number: 1
+do_not_optimize: []
+enable_always_target: true
+existing_tasks: {}
+filters:
+- target_tasks_method
+head_ref: dependabot/gradle/android/com.squareup.okhttp3-mockwebserver-4.10.0
+head_repository: https://github.com/mozilla-mobile/mozilla-vpn-client
+head_rev: 6d060577074f2260849cf97d5a5925d995ab6ea0
+head_tag: ''
+level: '1'
+moz_build_date: '20230208172854'
+next_version: null
+optimize_strategies: null
+optimize_target_tasks: true
+owner: dependabot[bot]@users.noreply.github.com
+project: mozilla-vpn-client
+pull_request_number: 5942
+pushdate: 0
+pushlog_id: '0'
+repository_type: git
+target_tasks_method: default
+tasks_for: github-pull-request-untrusted
+version: ''


### PR DESCRIPTION
## Description
I really thought it'd be neat to have sentry enabled on pr's... however external pr's like dependabot can't access them, so let's just use dummy values on pr's instead of the real secrets, so that we sill compile with sentry enabled, but it's not usable.
