### PR TITLE
VPN-2492: Tweak Location Scores

### DIFF
--- a/nebula/ui/components/VPNServerLatencyIndicator.qml
+++ b/nebula/ui/components/VPNServerLatencyIndicator.qml
@@ -14,7 +14,8 @@ VPNIcon {
     states: [
         // Low latency
         State {
-            when: score === VPNServerCountryModel.Good
+            when: (score === VPNServerCountryModel.Good ||
+                score == VPNServerCountryModel.Excellent)
             PropertyChanges {
                 target: latencyIndicator
                 source: "qrc:/nebula/resources/server-latency-strong.svg"

--- a/src/apps/vpn/models/servercity.cpp
+++ b/src/apps/vpn/models/servercity.cpp
@@ -15,6 +15,9 @@
 #include "servercountrymodel.h"
 #include "serveri18n.h"
 
+// Minimum number of redundant servers in a location in order to be "good"
+constexpr int SCORE_GOOD_SERVER_REDUNDANCY = 3;
+
 ServerCity::ServerCity() { MZ_COUNT_CTOR(ServerCity); }
 
 ServerCity::ServerCity(const ServerCity& other) {
@@ -132,7 +135,7 @@ int ServerCity::connectionScore() const {
   }
 
   // Increase the score if the location has 6 or more servers.
-  if (activeServerCount >= 6) {
+  if (activeServerCount >= SCORE_GOOD_SERVER_REDUNDANCY) {
     score++;
   }
 

--- a/src/apps/vpn/models/servercity.cpp
+++ b/src/apps/vpn/models/servercity.cpp
@@ -15,8 +15,8 @@
 #include "servercountrymodel.h"
 #include "serveri18n.h"
 
-// Minimum number of redundant servers in a location in order to be "good"
-constexpr int SCORE_GOOD_SERVER_REDUNDANCY = 3;
+// Minimum number of redundant servers we expect at a location.
+constexpr int SCORE_SERVER_REDUNDANCY_THRESHOLD = 3;
 
 // Latency threshold for excellent connections, set intentionally very low.
 constexpr int SCORE_EXCELLENT_LATENCY_THRESHOLD = 30;
@@ -143,7 +143,7 @@ int ServerCity::connectionScore() const {
   }
 
   // Increase the score if the location has sufficient redundancy.
-  if (activeServerCount >= SCORE_GOOD_SERVER_REDUNDANCY) {
+  if (activeServerCount >= SCORE_SERVER_REDUNDANCY_THRESHOLD) {
     score++;
   }
 

--- a/src/apps/vpn/models/servercity.h
+++ b/src/apps/vpn/models/servercity.h
@@ -36,6 +36,7 @@ class ServerCity final : public QObject {
     Poor = 1,
     Moderate = 2,
     Good = 3,
+    Excellent = 4,
   };
   Q_ENUM(CityConnectionScores);
 

--- a/src/apps/vpn/models/servercountrymodel.h
+++ b/src/apps/vpn/models/servercountrymodel.h
@@ -31,6 +31,7 @@ class ServerCountryModel final : public QAbstractListModel {
     Poor = 1,
     Moderate = 2,
     Good = 3,
+    Excellent = 4,
   };
   Q_ENUM(ServerConnectionScores);
 


### PR DESCRIPTION
## Description
Now that we only really have two "scores" that a server can show, the algorithm unfairly punishes some locations. Mostly this causes some really fast locations with low redundancy appear as "bad" choices. So let's try to improve upon this as follows:
- Reduce the location redundancy requirement to 3 servers (down from 6).
- Increase the internal score range to 6 values:
  - Unavailable (-1)
  - NoData (0)
  - Poor (1)
  - Moderate (2)
  - Good (3)
  - Excellent (4) -- **new**
- Give an extra score point to locations in the same country as the user.
- Give an extra score point to locations with less than 30ms latency (hardcoded threshold).

## Reference
JIRA epic [VPN-2492](https://mozilla-hub.atlassian.net/browse/VPN-2492)

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed


[VPN-2492]: https://mozilla-hub.atlassian.net/browse/VPN-2492?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ