### PR TITLE
GH-CI: Fix addon task for untrusted contributers

### DIFF
--- a/.github/workflows/gh_pages.yaml
+++ b/.github/workflows/gh_pages.yaml
@@ -119,6 +119,7 @@ jobs:
           python3 scripts/addon/generate_all.py
 
       - name: Sign manifest
+        if: github.ref == 'refs/heads/main'
         shell: bash
         env:
           ADDON_PRIVATE_KEY: ${{ secrets.ADDON_PRIVATE_KEY }}


### PR DESCRIPTION
## Description
Pull requests opened from external contributers can't access this secret, therefore this workflow will always fail. 
Let's only attemt signing on main branch, as only this will be published anyway.

This theoretically should allow dependabot-pr to get that sweet green ✅ 
