### PR TITLE
VPN-4141 - Remove Glean Android daemon telemetry

### DIFF
--- a/android/daemon/build.gradle
+++ b/android/daemon/build.gradle
@@ -23,22 +23,15 @@ buildscript {
 
     dependencies {
         classpath SharedDependencies.com_android_tools_build_gradle
-        classpath "org.mozilla.telemetry:glean-gradle-plugin:52.2.0"
     }
 }
 
 plugins {
     id 'org.jetbrains.kotlin.plugin.serialization'
-    id "com.jetbrains.python.envs" version "0.0.26"
 }
 
 apply plugin: "com.android.library"
 apply plugin: "org.jetbrains.kotlin.android"
-apply plugin: "org.mozilla.telemetry.glean-gradle-plugin"
-
-dependencies {
-    implementation project(path: ':vpnglean')
-}
 
 android {
     compileSdkVersion Config.compileSdkVersion
@@ -111,8 +104,3 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-reflect:1.6.20"
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.4.1")
 }
-
-ext.gleanNamespace = "mozilla.telemetry.glean"
-// TODO: We should spin off the daemon telemetry into a self contained thing.
-// This is soft blocked by https://bugzilla.mozilla.org/show_bug.cgi?id=1807019
-ext.gleanYamlFiles = ["$rootDir/../../../glean/metrics.yaml"]


### PR DESCRIPTION
The Glean Migration work has caused this to crash on the Android client.

This is unfortunate, however it is temporary. We can reinstate daemon telemetry on https://mozilla-hub.atlassian.net/browse/VPN-3872.
