### PR TITLE
VPN-4128: Remove connection scores from the multihop view

### DIFF
--- a/nebula/ui/components/VPNServerCountry.qml
+++ b/nebula/ui/components/VPNServerCountry.qml
@@ -18,6 +18,7 @@ VPNClickableRow {
     property string _countryCode: code
     property var currentCityIndex
     property alias serverCountryName: countryName.text
+    property bool showConnectionScores: (focusScope.currentServer.whichHop === "singleHopServer")
 
     property bool hasAvailableCities: cities.reduce((initialValue, city) => (initialValue || city.connectionScore >= 0), false)
 
@@ -170,8 +171,7 @@ VPNClickableRow {
                 property string _cityName: modelData.name
                 property string _countryCode: code
                 property string _localizedCityName: modelData.localizedName
-                property string locationScore: modelData.connectionScore
-                property bool isAvailable: locationScore >= 0
+                property bool isAvailable: modelData.connectionScore >= 0
                 property int itemHeight: 54
 
                 id: del
@@ -207,7 +207,7 @@ VPNClickableRow {
                         rightMargin: VPNTheme.theme.hSpacing
                         verticalCenter: parent.verticalCenter
                     }
-                    score: del.locationScore
+                    score: showConnectionScores ? modelData.connectionScore : (isAvailable ? VPNServerCountryModel.NoData : VPNServerCountryModel.Unavailable)
                 }
             }
         }


### PR DESCRIPTION
## Description
There is some concern that the connection scores shown in the multihop exit server selection may not be good enough to direct the user to a performant connection, since the latency data doesn't necessarily correlate to the user's location anymore. In the interest in only showing users information that we can be assured is correct, we have decided to remove the scores entirely from the multihop view.

## Reference
JIRA issue [VPN-4128](https://mozilla-hub.atlassian.net/browse/VPN-4128)

## Checklist
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-4128]: https://mozilla-hub.atlassian.net/browse/VPN-4128?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ