### PR TITLE
VPN-3685 - add string metric to new glean

### DIFF
--- a/qtglean/CMakeLists.txt
+++ b/qtglean/CMakeLists.txt
@@ -12,10 +12,12 @@ execute_process(
 
 ## Add a static library for the Glean C++ code.
 add_library(qtglean STATIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/glean/string.h
     ${CMAKE_CURRENT_SOURCE_DIR}/include/glean/counter.h
     ${CMAKE_CURRENT_SOURCE_DIR}/include/glean/event.h
     ${CMAKE_CURRENT_SOURCE_DIR}/include/glean/ping.h
     ${CMAKE_CURRENT_SOURCE_DIR}/include/glean/timingdistribution.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/string.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/counter.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/event.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/ping.cpp

--- a/qtglean/glean_parser_ext/rust.py
+++ b/qtglean/glean_parser_ext/rust.py
@@ -210,6 +210,7 @@ def output_rust(objs, output_fd, options={}):
         # Implemented metric types needs to be added here.
         ("TIMING_DISTRIBUTION_MAP", "TimingDistributionMetric"): [],
         ("COUNTER_MAP", "CounterMetric"): [],
+        ("STRING_MAP", "StringMetric"): [],
     }
 
     # Map from a metric ID to the fully qualified path of the event object in Rust.

--- a/qtglean/include/glean/metrictypes.h
+++ b/qtglean/include/glean/metrictypes.h
@@ -8,6 +8,7 @@
 #include "counter.h"
 #include "event.h"
 #include "ping.h"
+#include "string.h"
 #include "timingdistribution.h"
 
 #endif

--- a/qtglean/include/glean/string.h
+++ b/qtglean/include/glean/string.h
@@ -1,0 +1,36 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef STRING_H
+#define STRING_H
+#include <QObject>
+#include <QString>
+
+#include "errortype.h"
+
+class StringMetric final {
+  Q_GADGET
+
+ public:
+  // QML custom types require these three declarations.
+  // See: https://doc.qt.io/qt-6/custom-types.html#creating-a-custom-type
+  StringMetric() = default;
+  StringMetric(const StringMetric&) = default;
+  StringMetric& operator=(const StringMetric&) = default;
+
+  explicit StringMetric(int aId);
+  ~StringMetric() = default;
+
+  Q_INVOKABLE void set(QString value = "") const;
+
+  // Test  only functions
+
+  Q_INVOKABLE QString testGetValue(const QString& pingName = "") const;
+  Q_INVOKABLE int32_t testGetNumRecordedErrors(ErrorType errorType) const;
+
+ private:
+  int m_id;
+};
+
+#endif  // STRING_H

--- a/qtglean/src/cpp/string.cpp
+++ b/qtglean/src/cpp/string.cpp
@@ -7,7 +7,7 @@
 #include <QDebug>
 
 #if not(defined(__wasm__) || defined(BUILD_QMAKE))
-#  include "vpnglean.h"
+#  include "qtglean.h"
 #endif
 
 StringMetric::StringMetric(int id) : m_id(id) {}

--- a/qtglean/src/cpp/string.cpp
+++ b/qtglean/src/cpp/string.cpp
@@ -1,0 +1,33 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "glean/string.h"
+
+#include <QDebug>
+
+#if not(defined(__wasm__) || defined(BUILD_QMAKE))
+#  include "vpnglean.h"
+#endif
+
+StringMetric::StringMetric(int id) : m_id(id) {}
+
+void StringMetric::set(QString value) const {
+#if not(defined(__wasm__) || defined(BUILD_QMAKE))
+  return glean_string_set(m_id, value.toLocal8Bit());
+#endif
+}
+
+int32_t StringMetric::testGetNumRecordedErrors(ErrorType errorType) const {
+#if not(defined(__wasm__) || defined(BUILD_QMAKE))
+  return glean_string_test_get_num_recorded_errors(m_id, errorType);
+#endif
+  return 0;
+}
+
+QString StringMetric::testGetValue(const QString& pingName) const {
+#if not(defined(__wasm__) || defined(BUILD_QMAKE))
+  return glean_string_test_get_value(m_id, pingName.toLocal8Bit());
+#endif
+  return "";
+}

--- a/qtglean/src/ffi/mod.rs
+++ b/qtglean/src/ffi/mod.rs
@@ -10,4 +10,5 @@ pub mod helpers;
 pub mod counter;
 pub mod event;
 pub mod ping;
+pub mod string;
 pub mod timing_distribution;

--- a/qtglean/src/ffi/string.rs
+++ b/qtglean/src/ffi/string.rs
@@ -1,0 +1,45 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use ffi_support::FfiStr;
+use std::ffi::CString;
+use std::os::raw::c_char;
+use glean::ErrorType;
+
+use crate::ffi::helpers;
+
+#[no_mangle]
+pub extern "C" fn glean_string_set(id: u32, value: FfiStr) {
+    with_metric!(STRING_MAP, id, metric, metric.set(value.into_string()))
+}
+
+#[no_mangle]
+pub extern "C" fn glean_string_test_get_value(
+    id: u32,
+    ping_name: FfiStr
+) -> *mut c_char {
+    let returnString = with_metric!(
+        STRING_MAP,
+        id,
+        metric,
+        metric.test_get_value(helpers::ping_name_from_ffi(ping_name)).unwrap_or("".to_string())
+    );
+
+    CString::new(returnString)
+        .expect("Unable to create CString.")
+        .into_raw()
+}
+
+#[no_mangle]
+pub extern "C" fn glean_string_test_get_num_recorded_errors(
+    id: u32,
+    error_type: ErrorType,
+) -> i32 {
+    with_metric!(
+        STRING_MAP,
+        id,
+        metric,
+        metric.test_get_num_recorded_errors(error_type)
+    )
+}

--- a/qtglean/vpnglean.pri
+++ b/qtglean/vpnglean.pri
@@ -13,11 +13,13 @@ else{
     error(Glean generated files are missing. Please run `python3 ./qtglean/glean_parser_ext/run_glean_parser.py`)
 }
 
+SOURCES += $$PWD/src/cpp/string.cpp
 SOURCES += $$PWD/src/cpp/counter.cpp
 SOURCES += $$PWD/src/cpp/event.cpp
 SOURCES += $$PWD/src/cpp/ping.cpp
 SOURCES += $$PWD/src/cpp/timingdistribution.cpp
 
+HEADERS += $$PWD/include/glean/string.h
 HEADERS += $$PWD/include/glean/counter.h
 HEADERS += $$PWD/include/glean/event.h
 HEADERS += $$PWD/include/glean/ping.h


### PR DESCRIPTION
## Description

Adding string metric type to new glean implementation

## Reference

https://mozilla-hub.atlassian.net/browse/VPN-3685

## Checklist
    
- [X] My code follows the style guidelines for this project
- [X] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [X] I have performed a self review of my own code
- [X] I have commented my code PARTICULARLY in hard to understand areas
- [X] I have added thorough tests where needed
