### PR TITLE
VPN-4139 - Add back auth header to products requests

### DIFF
--- a/src/apps/vpn/tasks/products/taskproducts.cpp
+++ b/src/apps/vpn/tasks/products/taskproducts.cpp
@@ -8,6 +8,7 @@
 #include "errorhandler.h"
 #include "leakdetector.h"
 #include "logger.h"
+#include "mozillavpn.h"
 #include "networkrequest.h"
 #include "productshandler.h"
 
@@ -23,6 +24,7 @@ TaskProducts::~TaskProducts() { MZ_COUNT_DTOR(TaskProducts); }
 
 void TaskProducts::run() {
   NetworkRequest* request = new NetworkRequest(this, 200);
+  request->auth(MozillaVPN::authorizationHeader());
   request->get(AppConstants::apiUrl(AppConstants::Products));
 
   connect(request, &NetworkRequest::requestFailed, this,

--- a/tests/functional/servers/guardian_endpoints.js
+++ b/tests/functional/servers/guardian_endpoints.js
@@ -239,6 +239,7 @@ exports.endpoints = {
 
     '/api/v3/vpn/products': {
       status: 200,
+      requiredHeaders: ['Authorization'],
       body: {
         products: [
           {


### PR DESCRIPTION
This was accidentally removed by https://github.com/mozilla-mobile/mozilla-vpn-client/pull/5503.

I wonder if we could have tests that would have caught this. I had two ideas 1. Running a local instance of Guardian alongside unit / functional tests instead of mocking everything. 2. Creating a suite of integration tests that run on merge or on the release branch that do not mock Guardian at all. WDYT?
