### PR TITLE
VPN-4150: Add multihop connection scoring

### DIFF
--- a/nebula/ui/components/VPNServerCountry.qml
+++ b/nebula/ui/components/VPNServerCountry.qml
@@ -18,7 +18,10 @@ VPNClickableRow {
     property string _countryCode: code
     property var currentCityIndex
     property alias serverCountryName: countryName.text
-    property bool showConnectionScores: (focusScope.currentServer.whichHop === "singleHopServer")
+
+    // The city connection score can be used for every case except the multihop exit location,
+    // where we need to use the scoring between the entry and exit locations instead.
+    property bool useMultiHopScore: (focusScope.currentServer.whichHop === "multiHopExitServer")
 
     property bool hasAvailableCities: cities.reduce((initialValue, city) => (initialValue || city.connectionScore >= 0), false)
 
@@ -207,8 +210,7 @@ VPNClickableRow {
                         rightMargin: VPNTheme.theme.hSpacing
                         verticalCenter: parent.verticalCenter
                     }
-                    score: (focusScope.currentServer.whichHop !== "multiHopExitServer") ? modelData.connectionScore
-                           : modelData.multiHopScore(segmentedNav.multiHopEntryServer[0], segmentedNav.multiHopEntryServer[1])
+                    score: useMultiHopScore ? modelData.multiHopScore(segmentedNav.multiHopEntryServer[0], segmentedNav.multiHopEntryServer[1]) : modelData.connectionScore
                 }
             }
         }

--- a/nebula/ui/components/VPNServerCountry.qml
+++ b/nebula/ui/components/VPNServerCountry.qml
@@ -207,7 +207,8 @@ VPNClickableRow {
                         rightMargin: VPNTheme.theme.hSpacing
                         verticalCenter: parent.verticalCenter
                     }
-                    score: showConnectionScores ? modelData.connectionScore : (isAvailable ? VPNServerCountryModel.NoData : VPNServerCountryModel.Unavailable)
+                    score: (focusScope.currentServer.whichHop !== "multiHopExitServer") ? modelData.connectionScore
+                           : modelData.multiHopScore(segmentedNav.multiHopEntryServer[0], segmentedNav.multiHopEntryServer[1])
                 }
             }
         }

--- a/nebula/ui/components/VPNServerLatencyIndicator.qml
+++ b/nebula/ui/components/VPNServerLatencyIndicator.qml
@@ -15,7 +15,7 @@ VPNIcon {
         // Low latency
         State {
             when: (score === VPNServerLatency.Good ||
-                score == VPNServerLatency.Excellent)
+                score === VPNServerLatency.Excellent)
             PropertyChanges {
                 target: latencyIndicator
                 source: "qrc:/nebula/resources/server-latency-strong.svg"

--- a/nebula/ui/components/VPNServerLatencyIndicator.qml
+++ b/nebula/ui/components/VPNServerLatencyIndicator.qml
@@ -7,15 +7,15 @@ import QtQuick 2.5
 import Mozilla.VPN 1.0
 
 VPNIcon {
-    property int score: VPNServerCountryModel.NoData
+    property int score: VPNServerLatency.NoData
 
     id: latencyIndicator
 
     states: [
         // Low latency
         State {
-            when: (score === VPNServerCountryModel.Excellent ||
-                score === VPNServerCountryModel.Good)
+            when: (score === VPNServerLatency.Good ||
+                score == VPNServerLatency.Excellent)
             PropertyChanges {
                 target: latencyIndicator
                 source: "qrc:/nebula/resources/server-latency-strong.svg"
@@ -24,7 +24,7 @@ VPNIcon {
         },
         // Moderate latency
         State {
-            when: (score === VPNServerCountryModel.Moderate)
+            when: (score === VPNServerLatency.Moderate)
             PropertyChanges {
                 target: latencyIndicator
                 source: "qrc:/nebula/resources/server-latency-moderate.svg"
@@ -33,7 +33,7 @@ VPNIcon {
         },
         // High latency
         State {
-            when: (score === VPNServerCountryModel.Poor)
+            when: (score === VPNServerLatency.Poor)
             PropertyChanges {
                 target: latencyIndicator
                 source: "qrc:/nebula/resources/server-latency-weak.svg"
@@ -42,7 +42,7 @@ VPNIcon {
         },
         // Very high latency or server unavailable
         State {
-            when: score === VPNServerCountryModel.Unavailable
+            when: score === VPNServerLatency.Unavailable
             PropertyChanges {
                 target: latencyIndicator
                 source: "qrc:/nebula/resources/server-latency-unavailable.svg"
@@ -51,7 +51,7 @@ VPNIcon {
         },
         // No data
         State {
-            when: score === VPNServerCountryModel.NoData
+            when: score === VPNServerLatency.NoData
             PropertyChanges {
                 target: latencyIndicator
                 source: ""

--- a/src/apps/vpn/models/location.cpp
+++ b/src/apps/vpn/models/location.cpp
@@ -107,10 +107,10 @@ double Location::distance(double latitude, double longitude) const {
 // The same algorithm as above, but static and accepts any QObject with
 // latitude and longitude properties.
 double Location::distance(const QObject* a, const QObject* b) {
-  bool aLatOkay;
-  bool aLongOkay;
-  bool bLatOkay;
-  bool bLongOkay;
+  bool aLatOkay = false;
+  bool aLongOkay = false;
+  bool bLatOkay = false;
+  bool bLongOkay = false;
   double aLat = a->property("latitude").toDouble(&aLatOkay);
   double aLong = a->property("longitude").toDouble(&aLongOkay);
   double bLat = b->property("latitude").toDouble(&bLatOkay);

--- a/src/apps/vpn/models/location.cpp
+++ b/src/apps/vpn/models/location.cpp
@@ -100,3 +100,27 @@ double Location::distance(double latitude, double longitude) const {
 
   return qAcos(m_latSin * otherSin + m_latCos * otherCos * diffCos);
 }
+
+// The same algorithm as above, but static and accepts any QObject with
+// latitude and longitude properties.
+double Location::distance(const QObject* a, const QObject* b) {
+  bool aLatOkay;
+  bool aLongOkay;
+  bool bLatOkay;
+  bool bLongOkay;
+  double aLat = a->property("latitude").toDouble(&aLatOkay);
+  double aLong = a->property("longitude").toDouble(&aLongOkay);
+  double bLat = b->property("latitude").toDouble(&bLatOkay);
+  double bLong = b->property("longitude").toDouble(&bLongOkay);
+  if (!aLatOkay || !aLongOkay || !bLatOkay || !bLongOkay) {
+    return 0.0;
+  }
+
+  double aSin = qSin(aLat * M_PI / 180.0);
+  double aCos = qCos(aLat * M_PI / 180.0);
+  double bSin = qSin(bLat * M_PI / 180.0);
+  double bCos = qCos(bLat * M_PI / 180.0);
+  double diffCos = qCos((aLong - bLong) * M_PI / 180.0);
+
+  return qAcos(aSin * bSin + aCos * bCos * diffCos);
+}

--- a/src/apps/vpn/models/location.cpp
+++ b/src/apps/vpn/models/location.cpp
@@ -89,6 +89,9 @@ bool Location::fromJson(const QByteArray& json) {
 // This is done in spherical coordinates, and will return a value in the range
 // of zero to pi. Multiply by the Earth's radius if you want meaningful units.
 double Location::distance(double latitude, double longitude) const {
+  if (qIsNaN(latitude) || qIsNaN(longitude)) {
+    return 0.0;
+  }
   if (qIsNaN(m_latitude) || qIsNaN(m_longitude)) {
     return 0.0;
   }

--- a/src/apps/vpn/models/location.cpp
+++ b/src/apps/vpn/models/location.cpp
@@ -115,7 +115,7 @@ double Location::distance(const QObject* a, const QObject* b) {
   if (!aLatOkay || !aLongOkay || !bLatOkay || !bLongOkay) {
     return 0.0;
   }
-  if (qIsNaN(aLat) || qIsNan(aLong) || qIsNaN(bLat) || qIsNan(bLong)) {
+  if (qIsNaN(aLat) || qIsNaN(aLong) || qIsNaN(bLat) || qIsNaN(bLong)) {
     return 0.0;
   }
 

--- a/src/apps/vpn/models/location.cpp
+++ b/src/apps/vpn/models/location.cpp
@@ -115,6 +115,9 @@ double Location::distance(const QObject* a, const QObject* b) {
   if (!aLatOkay || !aLongOkay || !bLatOkay || !bLongOkay) {
     return 0.0;
   }
+  if (qIsNaN(aLat) || qIsNan(aLong) || qIsNaN(bLat) || qIsNan(bLong)) {
+    return 0.0;
+  }
 
   double aSin = qSin(aLat * M_PI / 180.0);
   double aCos = qCos(aLat * M_PI / 180.0);

--- a/src/apps/vpn/models/location.h
+++ b/src/apps/vpn/models/location.h
@@ -43,6 +43,8 @@ class Location final : public QObject {
 
   double distance(double latitude, double longitude) const;
 
+  static double distance(const QObject* a, const QObject* b);
+
   QHostAddress ipAddress() const { return m_ipAddress; }
 
  signals:

--- a/src/apps/vpn/models/servercity.cpp
+++ b/src/apps/vpn/models/servercity.cpp
@@ -138,7 +138,8 @@ int ServerCity::baseCityScore(const QString& originCountryCode) const {
   }
 
   // Increase the score for connections made within the same country.
-  if ((!originCountryCode.isEmpty()) && (m_country == originCountryCode)) {
+  if ((!originCountryCode.isEmpty()) &&
+      (m_country.compare(originCountryCode, Qt::CaseInsensitive) == 0)) {
     score++;
   }
 

--- a/src/apps/vpn/models/servercity.cpp
+++ b/src/apps/vpn/models/servercity.cpp
@@ -169,7 +169,7 @@ int ServerCity::multiHopScore(const QString& country,
     return score;
   }
 
-  // Increase the score if the distance betweens servers is less than 1/8th of
+  // Increase the score if the distance between servers is less than 1/8th of
   // the earth's circumference.
   const ServerCountryModel* scm = MozillaVPN::instance()->serverCountryModel();
   const ServerCity& entryCity = scm->findCity(country, cityName);

--- a/src/apps/vpn/models/servercity.h
+++ b/src/apps/vpn/models/servercity.h
@@ -30,16 +30,6 @@ class ServerCity final : public QObject {
   ServerCity& operator=(const ServerCity& other);
   ~ServerCity();
 
-  enum CityConnectionScores {
-    Unavailable = -1,
-    NoData = 0,
-    Poor = 1,
-    Moderate = 2,
-    Good = 3,
-    Excellent = 4,
-  };
-  Q_ENUM(CityConnectionScores);
-
   [[nodiscard]] bool fromJson(const QJsonObject& obj, const QString& country);
 
   bool initialized() const { return !m_name.isEmpty(); }
@@ -72,8 +62,6 @@ class ServerCity final : public QObject {
   void scoreChanged() const;
 
  private:
-  int baseCityScore(const QString& originCountryCode = QString()) const;
-
   QString m_country;
   QString m_name;
   QString m_code;

--- a/src/apps/vpn/models/servercity.h
+++ b/src/apps/vpn/models/servercity.h
@@ -61,6 +61,9 @@ class ServerCity final : public QObject {
 
   int connectionScore() const;
 
+  Q_INVOKABLE int multiHopScore(const QString& country,
+                                const QString& cityName) const;
+
   unsigned int latency() const;
 
   const QList<QString> servers() const { return m_servers; }
@@ -69,6 +72,8 @@ class ServerCity final : public QObject {
   void scoreChanged() const;
 
  private:
+  int baseCityScore(const QString& originCountryCode = QString()) const;
+
   QString m_country;
   QString m_name;
   QString m_code;

--- a/src/apps/vpn/models/servercountrymodel.cpp
+++ b/src/apps/vpn/models/servercountrymodel.cpp
@@ -280,13 +280,6 @@ QList<QVariant> ServerCountryModel::recommendedLocations(
     cityRanking -= city.latency() / latencyScale;
     cityRanking -= distance;
 
-#ifdef MZ_DEBUG
-    logger.debug() << "Evaluating" << city.name() << "-" << city.latency()
-                   << "ms"
-                   << "-" << QString::number(distance) << "-"
-                   << QString::number(cityRanking);
-#endif
-
     // Insert into the result list
     qsizetype i;
     for (i = 0; i < rankResults.count(); i++) {

--- a/src/apps/vpn/models/servercountrymodel.h
+++ b/src/apps/vpn/models/servercountrymodel.h
@@ -25,16 +25,6 @@ class ServerCountryModel final : public QAbstractListModel {
     CitiesRole,
   };
 
-  enum ServerConnectionScores {
-    Unavailable = -1,
-    NoData = 0,
-    Poor = 1,
-    Moderate = 2,
-    Good = 3,
-    Excellent = 4,
-  };
-  Q_ENUM(ServerConnectionScores);
-
   ServerCountryModel();
   ~ServerCountryModel();
 

--- a/src/apps/vpn/serverlatency.cpp
+++ b/src/apps/vpn/serverlatency.cpp
@@ -256,9 +256,7 @@ void ServerLatency::recvPing(quint16 sequence) {
 
     qint64 latency(now - record.timestamp);
     if (latency <= std::numeric_limits<uint>::max()) {
-      m_sumLatencyMsec -= m_latency[record.publicKey];
-      m_sumLatencyMsec += latency;
-      m_latency[record.publicKey] = latency;
+      setLatency(record.publicKey, latency);
 
       const ServerCity& city =
           scm->findCity(record.countryCode, record.cityName);
@@ -282,6 +280,12 @@ unsigned int ServerLatency::avgLatency() const {
     return 0;
   }
   return (m_sumLatencyMsec + m_latency.count() - 1) / m_latency.count();
+}
+
+void ServerLatency::setLatency(const QString& pubkey, qint64 msec) {
+  m_sumLatencyMsec -= m_latency[pubkey];
+  m_sumLatencyMsec += msec;
+  m_latency[pubkey] = msec;
 }
 
 double ServerLatency::progress() const {

--- a/src/apps/vpn/serverlatency.cpp
+++ b/src/apps/vpn/serverlatency.cpp
@@ -29,6 +29,9 @@ constexpr const int SERVER_LATENCY_MAX_RETRIES = 2;
 // Delay the progressChanged() signal to rate-limit how often score changes.
 constexpr const uint32_t SERVER_LATENCY_PROGRESS_DELAY_MSEC = 500;
 
+// Minimum number of redundant servers we expect at a location.
+constexpr int SCORE_SERVER_REDUNDANCY_THRESHOLD = 3;
+
 namespace {
 Logger logger("ServerLatency");
 }
@@ -305,4 +308,37 @@ void ServerLatency::setCooldown(const QString& publicKey, qint64 timeout) {
   if (city.initialized()) {
     emit city.scoreChanged();
   }
+}
+
+int ServerLatency::baseCityScore(const ServerCity* city,
+                                 const QString& originCountry) const {
+  qint64 now = QDateTime::currentSecsSinceEpoch();
+  int score = Poor;
+  int activeServerCount = 0;
+  for (const QString& pubkey : city->servers()) {
+    if (getCooldown(pubkey) <= now) {
+      activeServerCount++;
+    }
+  }
+
+  // Ensure there is at least one reachable server.
+  if (activeServerCount == 0) {
+    return Unavailable;
+  }
+
+  // Increase the score if the location has sufficient redundancy.
+  if (activeServerCount >= SCORE_SERVER_REDUNDANCY_THRESHOLD) {
+    score++;
+  }
+
+  // Increase the score for connections made within the same country.
+  if ((!originCountry.isEmpty()) &&
+      (originCountry.compare(city->country(), Qt::CaseInsensitive) == 0)) {
+    score++;
+  }
+
+  if (score > Excellent) {
+    score = Excellent;
+  }
+  return score;
 }

--- a/src/apps/vpn/serverlatency.h
+++ b/src/apps/vpn/serverlatency.h
@@ -12,6 +12,8 @@
 #include "pingsender.h"
 #include "task.h"
 
+class ServerCity;
+
 class ServerLatency final : public QObject {
   Q_OBJECT
   Q_DISABLE_COPY_MOVE(ServerLatency)
@@ -25,6 +27,16 @@ class ServerLatency final : public QObject {
  public:
   ServerLatency();
   ~ServerLatency();
+
+  enum ConnectionScores {
+    Unavailable = -1,
+    NoData = 0,
+    Poor = 1,
+    Moderate = 2,
+    Good = 3,
+    Excellent = 4,
+  };
+  Q_ENUM(ConnectionScores);
 
   unsigned int avgLatency() const;
   unsigned int getLatency(const QString& pubkey) const {
@@ -44,6 +56,8 @@ class ServerLatency final : public QObject {
   void stop();
 
   Q_INVOKABLE void refresh();
+
+  int baseCityScore(const ServerCity* city, const QString& originCountry) const;
 
  signals:
   void progressChanged();

--- a/src/apps/vpn/serverlatency.h
+++ b/src/apps/vpn/serverlatency.h
@@ -38,13 +38,15 @@ class ServerLatency final : public QObject {
   };
   Q_ENUM(ConnectionScores);
 
+  const QDateTime& lastUpdateTime() const { return m_lastUpdateTime; }
+  bool isActive() const { return m_pingSender != nullptr; }
+  double progress() const;
+
   unsigned int avgLatency() const;
   unsigned int getLatency(const QString& pubkey) const {
     return m_latency.value(pubkey);
   };
-  const QDateTime& lastUpdateTime() const { return m_lastUpdateTime; }
-  bool isActive() const { return m_pingSender != nullptr; }
-  double progress() const;
+  void setLatency(const QString& pubkey, qint64 msec);
 
   qint64 getCooldown(const QString& pubkey) const {
     return m_cooldown.value(pubkey);

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -331,6 +331,8 @@ target_sources(unit_tests PRIVATE
     testreleasemonitor.h
     testserveri18n.cpp
     testserveri18n.h
+    testserverlatency.cpp
+    testserverlatency.h
     teststatusicon.cpp
     teststatusicon.h
     testtasksentry.cpp

--- a/tests/unit/testmodels.cpp
+++ b/tests/unit/testmodels.cpp
@@ -2204,7 +2204,7 @@ void TestModels::locationDistance_data() {
   obj.insert("lat_long", QJsonValue("-77.8400829,166.64453"));
   QTest::newRow("From McMurdo Station to Bering Island")
       << QJsonDocument(obj).toJson() << 55.0218511 << 165.9355717 << 14763.70;
-  
+
   obj.insert("lat_long", QJsonValue("90,0"));
   QTest::newRow("From North to South poles")
       << QJsonDocument(obj).toJson() << -90.0 << 123.456 << 20001.6;
@@ -2221,7 +2221,7 @@ void TestModels::locationDistance() {
   // here converts radians into kilometers using a spherical earth model with
   // 1 degree minute equal to 1 nautical mile.
   constexpr double scale = (1.852 * 360.0 * 60.0) / (M_PI * 2.0);
-  constexpr double epsilon = 0.1; // Maximum tolerated floating point error.
+  constexpr double epsilon = 0.1;  // Maximum tolerated floating point error.
   double distance;
   Location location;
   QVERIFY(location.fromJson(json));

--- a/tests/unit/testmodels.cpp
+++ b/tests/unit/testmodels.cpp
@@ -2163,4 +2163,84 @@ void TestModels::locationFromJson() {
   }
 }
 
+void TestModels::locationDistance_data() {
+  QTest::addColumn<QByteArray>("json");
+  QTest::addColumn<double>("latitude");
+  QTest::addColumn<double>("longitude");
+  QTest::addColumn<double>("result");
+
+  QJsonObject obj;
+  obj.insert("city", QJsonValue("Mordor"));
+  obj.insert("country", QJsonValue("XX"));
+  obj.insert("subdivision", QJsonValue("MTDOOM"));
+  obj.insert("ip", QJsonValue("169.254.0.1"));
+
+  // Check for error handling if the coordinates are missing.
+  QTest::newRow("Both invalid to zero distance")
+      << QJsonDocument(obj).toJson() << qQNaN() << qQNaN() << 0.0;
+
+  QTest::newRow("Model invalid to zero distance")
+      << QJsonDocument(obj).toJson() << 123.456 << 55.555 << 0.0;
+
+  obj.insert("lat_long", QJsonValue("123.456,55.555"));
+  QTest::newRow("Args invalid to zero distance")
+      << QJsonDocument(obj).toJson() << qQNaN() << qQNaN() << 0.0;
+
+  // Test vectors are generated from: http://edwilliams.org/gccalc.htm
+  // with coordinates scraped from google maps.
+  // distances are in km, and computed using a spherical earth model.
+  obj.insert("lat_long", QJsonValue("39.9033766,32.7627648"));
+  QTest::newRow("From Ankara to Izmir")
+      << QJsonDocument(obj).toJson() << 38.4178607 << 26.9396341 << 528.06;
+
+  obj.insert("lat_long", QJsonValue("43.1666908,131.8834184"));
+  QTest::newRow("From Vladivastok to Anchorage")
+      << QJsonDocument(obj).toJson() << 61.1083688 << -150.000681 << 5313.05;
+
+  obj.insert("lat_long", QJsonValue("1.3143269,103.5571562"));
+  QTest::newRow("From Singapore to Ecuador")
+      << QJsonDocument(obj).toJson() << -0.1862486 << -78.717632 << 19719.47;
+
+  obj.insert("lat_long", QJsonValue("-77.8400829,166.64453"));
+  QTest::newRow("From McMurdo Station to Bering Island")
+      << QJsonDocument(obj).toJson() << 55.0218511 << 165.9355717 << 14763.70;
+  
+  obj.insert("lat_long", QJsonValue("90,0"));
+  QTest::newRow("From North to South poles")
+      << QJsonDocument(obj).toJson() << -90.0 << 123.456 << 20001.6;
+}
+
+void TestModels::locationDistance() {
+  QFETCH(QByteArray, json);
+  QFETCH(double, latitude);
+  QFETCH(double, longitude);
+  QFETCH(double, result);
+
+  // A word about the scale. The Location class computes distance in radians,
+  // but the earth isn't actually round, it's squashed a little bit. This figure
+  // here converts radians into kilometers using a spherical earth model with
+  // 1 degree minute equal to 1 nautical mile.
+  constexpr double scale = (1.852 * 360.0 * 60.0) / (M_PI * 2.0);
+  constexpr double epsilon = 0.1; // Maximum tolerated floating point error.
+  double distance;
+  Location location;
+  QVERIFY(location.fromJson(json));
+
+  // Check that we get the expected distance.
+  distance = location.distance(latitude, longitude) * scale;
+  QVERIFY(qFabs<double>(distance - result) < epsilon);
+
+  // Check that we get the same result when called between two QObjects
+  // with latitude/longitude coordinates.
+  QObject obj;
+  obj.setProperty("latitude", QVariant(latitude));
+  obj.setProperty("longitude", QVariant(longitude));
+  distance = Location::distance(&location, &obj) * scale;
+  QVERIFY(qFabs<double>(distance - result) < epsilon);
+
+  // And the same result again if we transpose the arguments.
+  distance = Location::distance(&obj, &location) * scale;
+  QVERIFY(qFabs<double>(distance - result) < epsilon);
+}
+
 static TestModels s_testModels;

--- a/tests/unit/testmodels.h
+++ b/tests/unit/testmodels.h
@@ -56,4 +56,6 @@ class TestModels final : public TestHelper {
   void locationBasic();
   void locationFromJson_data();
   void locationFromJson();
+  void locationDistance_data();
+  void locationDistance();
 };

--- a/tests/unit/testserverlatency.cpp
+++ b/tests/unit/testserverlatency.cpp
@@ -1,0 +1,64 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "testserverlatency.h"
+
+#include "feature.h"
+#include "models/servercity.h"
+#include "models/location.h"
+#include "serverlatency.h"
+#include "settingsholder.h"
+
+#include <QDateTime>
+
+void TestServerLatency::init() {
+  SettingsHolder settingsHolder;
+  settingsHolder.setFeaturesFlippedOn(QStringList{"serverConnectionScore"});
+  QVERIFY(settingsHolder.featuresFlippedOn().contains("serverConnectionScore"));
+}
+
+void TestServerLatency::latency() {
+  constexpr int start = 1234;
+  int value;
+
+  // Insert some latency values and see that get/set/avg works as expected.
+  ServerLatency serverLatency;
+  for (int value = start; value < 5000; value += 100) {
+    QString serverPublicKey = "DummyServer" + QString::number(value);
+
+    // Getting the latency for a server that doesn't exist returns zero.
+    QCOMPARE(serverLatency.getLatency(serverPublicKey), 0);
+
+    // Set the latency and we should be able to retrive it.
+    serverLatency.setLatency(serverPublicKey, value);
+    QCOMPARE(serverLatency.getLatency(serverPublicKey), value);
+
+    // We are setting the latencies in an arithmetic sequence, so we have
+    // a fairly simple formula for the average too.
+    QCOMPARE(serverLatency.avgLatency(), (start + value) / 2);
+  }
+}
+
+void TestServerLatency::cooldown() {
+  ServerLatency serverLatency;
+
+  // The cooldown should be zero until otherwise set.
+  QCOMPARE(serverLatency.getCooldown("Some Server"), 0);
+  serverLatency.setCooldown("Some Server", 1234);
+  QVERIFY(serverLatency.getCooldown("Some Server") > QDateTime::currentSecsSinceEpoch());
+
+  // Clear the cooldown and it should re-set to zero.
+  serverLatency.setCooldown("Some Server", 0);
+  QCOMPARE(serverLatency.getCooldown("Some Server"), 0);
+}
+
+void TestServerLatency::baseCityScore_data() {
+  // TODO: Implement Me!
+}
+
+void TestServerLatency::baseCityScore() {
+  // TODO: Implement Me!
+}
+
+static TestServerLatency s_testServerLatency;

--- a/tests/unit/testserverlatency.cpp
+++ b/tests/unit/testserverlatency.cpp
@@ -4,15 +4,15 @@
 
 #include "testserverlatency.h"
 
-#include "appconstants.h"
-#include "feature.h"
-#include "models/servercity.h"
-#include "models/location.h"
-#include "serverlatency.h"
-#include "settingsholder.h"
-
 #include <QDateTime>
 #include <QJsonObject>
+
+#include "appconstants.h"
+#include "feature.h"
+#include "models/location.h"
+#include "models/servercity.h"
+#include "serverlatency.h"
+#include "settingsholder.h"
 
 void TestServerLatency::init() {
   SettingsHolder settingsHolder;
@@ -48,7 +48,8 @@ void TestServerLatency::cooldown() {
   // The cooldown should be zero until otherwise set.
   QCOMPARE(serverLatency.getCooldown("Some Server"), 0);
   serverLatency.setCooldown("Some Server", 1234);
-  QVERIFY(serverLatency.getCooldown("Some Server") > QDateTime::currentSecsSinceEpoch());
+  QVERIFY(serverLatency.getCooldown("Some Server") >
+          QDateTime::currentSecsSinceEpoch());
 
   // Clear the cooldown and it should re-set to zero.
   serverLatency.setCooldown("Some Server", 0);
@@ -89,9 +90,10 @@ void TestServerLatency::baseCityScore_data() {
   obj.insert("servers", servers);
   QTest::addRow("one server -> poor")
       << obj << "Example Country" << QStringList() << ServerLatency::Poor;
-  
+
   QTest::addRow("one server on cooldown -> unavailable")
-      << obj << "Example Country" << QStringList(server.value("public_key").toString())
+      << obj << "Example Country"
+      << QStringList(server.value("public_key").toString())
       << ServerLatency::Unavailable;
 
   // Add two more servers to meet the minimum redundancy requirements.

--- a/tests/unit/testserverlatency.h
+++ b/tests/unit/testserverlatency.h
@@ -1,0 +1,18 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "helper.h"
+
+class TestServerLatency : public TestHelper {
+  Q_OBJECT
+
+ private slots:
+  void init();
+
+  void latency();
+  void cooldown();
+
+  void baseCityScore_data();
+  void baseCityScore();
+};


### PR DESCRIPTION
## Description
Recently, it was decided that the connection scoring indicators for the multihop view weren't a reliable indicator of expected connection performance, and as such we removed them in PR #5984 until they could be re-implemented in a way that's cognizant of the entry/exit server pairing. However, I **really** just want to get this featured closed out and finished, so let's implement it.

This refactors the `ServerCity` object just a little bit, and adds a QML-invokable method to compute a connection score for a multihop pairing. This method follows mostly the same algorithm as for single-hop, but uses geographic distance between the cities as a proxy for expected latency. The common components of the scoring algorithm have been split out into a private method `ServerCity::baseCityScore()` which can then be modified by either the single/entry/exit use cases.

## Reference
Jira issue [VPN-4150](https://mozilla-hub.atlassian.net/browse/VPN-4150)

## Checklist
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed


[VPN-4150]: https://mozilla-hub.atlassian.net/browse/VPN-4150?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ