### PR TITLE
VPN-3681 - add datetime metric to glean

### DIFF
--- a/qtglean/CMakeLists.txt
+++ b/qtglean/CMakeLists.txt
@@ -12,11 +12,13 @@ execute_process(
 
 ## Add a static library for the Glean C++ code.
 add_library(qtglean STATIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/glean/datetime.h
     ${CMAKE_CURRENT_SOURCE_DIR}/include/glean/string.h
     ${CMAKE_CURRENT_SOURCE_DIR}/include/glean/counter.h
     ${CMAKE_CURRENT_SOURCE_DIR}/include/glean/event.h
     ${CMAKE_CURRENT_SOURCE_DIR}/include/glean/ping.h
     ${CMAKE_CURRENT_SOURCE_DIR}/include/glean/timingdistribution.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/datetime.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/string.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/counter.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/event.cpp

--- a/qtglean/glean_parser_ext/rust.py
+++ b/qtglean/glean_parser_ext/rust.py
@@ -211,6 +211,7 @@ def output_rust(objs, output_fd, options={}):
         ("TIMING_DISTRIBUTION_MAP", "TimingDistributionMetric"): [],
         ("COUNTER_MAP", "CounterMetric"): [],
         ("STRING_MAP", "StringMetric"): [],
+        ("DATETIME_MAP", "DatetimeMetric"): [],
     }
 
     # Map from a metric ID to the fully qualified path of the event object in Rust.

--- a/qtglean/include/glean/datetime.h
+++ b/qtglean/include/glean/datetime.h
@@ -11,7 +11,7 @@
 
 #include "errortype.h"
 
-// NOTE: While most of datetime is implemented, one pieces are not yet:
+// NOTE: While most of datetime is implemented, one piece is not yet:
 // - The ability to set an arbitrary datestamp
 // More details: https://mozilla-hub.atlassian.net/browse/VPN-4173
 

--- a/qtglean/include/glean/datetime.h
+++ b/qtglean/include/glean/datetime.h
@@ -29,12 +29,12 @@ class DatetimeMetric final {
   ~DatetimeMetric() = default;
 
   Q_INVOKABLE void set() const;
-  
+
   // Test  only functions
 
   Q_INVOKABLE QString testGetValueAsString(const QString& pingName = "") const;
   Q_INVOKABLE int32_t testGetNumRecordedErrors(ErrorType errorType) const;
-  
+
  private:
   int m_id;
 };

--- a/qtglean/include/glean/datetime.h
+++ b/qtglean/include/glean/datetime.h
@@ -5,14 +5,14 @@
 
 #ifndef DATETIME_H
 #define DATETIME_H
+#include <QDateTime>
 #include <QObject>
 #include <QString>
 
 #include "errortype.h"
 
-// NOTE: While most of datetime is implemented, two pieces are not yet:
+// NOTE: While most of datetime is implemented, one pieces are not yet:
 // - The ability to set an arbitrary datestamp
-// - testGetValue, which provides a language-specific object
 // More details: https://mozilla-hub.atlassian.net/browse/VPN-4173
 
 class DatetimeMetric final {
@@ -32,6 +32,7 @@ class DatetimeMetric final {
 
   // Test  only functions
 
+  Q_INVOKABLE QDateTime testGetValue(const QString& pingName = "") const;
   Q_INVOKABLE QString testGetValueAsString(const QString& pingName = "") const;
   Q_INVOKABLE int32_t testGetNumRecordedErrors(ErrorType errorType) const;
 

--- a/qtglean/include/glean/datetime.h
+++ b/qtglean/include/glean/datetime.h
@@ -1,0 +1,42 @@
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef DATETIME_H
+#define DATETIME_H
+#include <QObject>
+#include <QString>
+
+#include "errortype.h"
+
+// NOTE: While most of datetime is implemented, two pieces are not yet:
+// - The ability to set an arbitrary datestamp
+// - testGetValue, which provides a language-specific object
+// More details: https://mozilla-hub.atlassian.net/browse/VPN-4173
+
+class DatetimeMetric final {
+  Q_GADGET
+
+ public:
+  // QML custom types require these three declarations.
+  // See: https://doc.qt.io/qt-6/custom-types.html#creating-a-custom-type
+  DatetimeMetric() = default;
+  DatetimeMetric(const DatetimeMetric&) = default;
+  DatetimeMetric& operator=(const DatetimeMetric&) = default;
+
+  explicit DatetimeMetric(int aId);
+  ~DatetimeMetric() = default;
+
+  Q_INVOKABLE void set() const;
+  
+  // Test  only functions
+
+  Q_INVOKABLE QString testGetValueAsString(const QString& pingName = "") const;
+  Q_INVOKABLE int32_t testGetNumRecordedErrors(ErrorType errorType) const;
+  
+ private:
+  int m_id;
+};
+
+#endif  // DATETIME_H

--- a/qtglean/include/glean/metrictypes.h
+++ b/qtglean/include/glean/metrictypes.h
@@ -6,6 +6,7 @@
 #define METRICTYPES_H
 
 #include "counter.h"
+#include "datetime.h"
 #include "event.h"
 #include "ping.h"
 #include "string.h"

--- a/qtglean/src/cpp/datetime.cpp
+++ b/qtglean/src/cpp/datetime.cpp
@@ -31,3 +31,8 @@ QString DatetimeMetric::testGetValueAsString(const QString& pingName) const {
 #endif
   return "";
 }
+
+QDateTime DatetimeMetric::testGetValue(const QString& pingName) const {
+  return QDateTime::fromString(testGetValueAsString(pingName),
+                               Qt::ISODateWithMs);
+}

--- a/qtglean/src/cpp/datetime.cpp
+++ b/qtglean/src/cpp/datetime.cpp
@@ -1,0 +1,33 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "glean/datetime.h"
+
+#include <QDebug>
+
+#if not(defined(__wasm__) || defined(BUILD_QMAKE))
+#  include "qtglean.h"
+#endif
+
+DatetimeMetric::DatetimeMetric(int id) : m_id(id) {}
+
+void DatetimeMetric::set() const {
+#if not(defined(__wasm__) || defined(BUILD_QMAKE))
+  return glean_datetime_set(m_id);
+#endif
+}
+
+int32_t DatetimeMetric::testGetNumRecordedErrors(ErrorType errorType) const {
+#if not(defined(__wasm__) || defined(BUILD_QMAKE))
+  return glean_datetime_test_get_num_recorded_errors(m_id, errorType);
+#endif
+  return 0;
+}
+
+QString DatetimeMetric::testGetValueAsString(const QString& pingName) const {
+#if not(defined(__wasm__) || defined(BUILD_QMAKE))
+  return glean_datetime_test_get_value_as_string(m_id, pingName.toLocal8Bit());
+#endif
+  return "";
+}

--- a/qtglean/src/ffi/datetime.rs
+++ b/qtglean/src/ffi/datetime.rs
@@ -1,0 +1,45 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use ffi_support::FfiStr;
+use std::ffi::CString;
+use std::os::raw::c_char;
+use glean::ErrorType;
+
+use crate::ffi::helpers;
+
+#[no_mangle]
+pub extern "C" fn glean_datetime_set(id: u32) {
+    with_metric!(DATETIME_MAP, id, metric, metric.set(None))
+}
+
+#[no_mangle]
+pub extern "C" fn glean_datetime_test_get_value_as_string(
+    id: u32,
+    ping_name: FfiStr
+) -> *mut c_char {
+    let return_string = with_metric!(
+        DATETIME_MAP,
+        id,
+        metric,
+        metric.test_get_value_as_string(helpers::ping_name_from_ffi(ping_name)).unwrap_or("".to_string())
+    );
+
+    CString::new(return_string)
+        .expect("Unable to create CString.")
+        .into_raw()
+}
+
+#[no_mangle]
+pub extern "C" fn glean_datetime_test_get_num_recorded_errors(
+    id: u32,
+    error_type: ErrorType,
+) -> i32 {
+    with_metric!(
+        DATETIME_MAP,
+        id,
+        metric,
+        metric.test_get_num_recorded_errors(error_type)
+    )
+}

--- a/qtglean/src/ffi/mod.rs
+++ b/qtglean/src/ffi/mod.rs
@@ -8,6 +8,7 @@ mod macros;
 pub mod helpers;
 
 pub mod counter;
+pub mod datetime;
 pub mod event;
 pub mod ping;
 pub mod string;

--- a/qtglean/vpnglean.pri
+++ b/qtglean/vpnglean.pri
@@ -13,12 +13,14 @@ else{
     error(Glean generated files are missing. Please run `python3 ./qtglean/glean_parser_ext/run_glean_parser.py`)
 }
 
+SOURCES += $$PWD/src/cpp/datetime.cpp
 SOURCES += $$PWD/src/cpp/string.cpp
 SOURCES += $$PWD/src/cpp/counter.cpp
 SOURCES += $$PWD/src/cpp/event.cpp
 SOURCES += $$PWD/src/cpp/ping.cpp
 SOURCES += $$PWD/src/cpp/timingdistribution.cpp
 
+HEADERS += $$PWD/include/glean/datetime.h
 HEADERS += $$PWD/include/glean/string.h
 HEADERS += $$PWD/include/glean/counter.h
 HEADERS += $$PWD/include/glean/event.h


### PR DESCRIPTION
## Description

Adding datetime metric to glean. From some local tests, it seems to work.

While most of the `datetime` object is covering in this PR, two pieces were left for the future (if they're ever needed). This work is captured [in a ticket](https://mozilla-hub.atlassian.net/browse/VPN-4173), as well as a comment within `datetime.h`.

## Reference

https://mozilla-hub.atlassian.net/browse/VPN-3681

## Checklist
    
- [X] My code follows the style guidelines for this project
- [X] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [X] I have performed a self review of my own code
- [X] I have commented my code PARTICULARLY in hard to understand areas
- [X] I have added thorough tests where needed
