### PR TITLE
VPN-3848: Remove ignore=all from .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,19 +2,15 @@
 	path = i18n
 	url = https://github.com/mozilla-l10n/mozilla-vpn-client-l10n.git
 	branch = main
-	ignore=all
 [submodule "3rdparty/wireguard-tools"]
 	path = 3rdparty/wireguard-tools
 	url = https://github.com/WireGuard/wireguard-tools
-        ignore=all
 [submodule "3rdparty/wireguard-apple"]
 	path = 3rdparty/wireguard-apple
 	url = https://github.com/mozilla/wireguard-apple
-        ignore=all
 [submodule "3rdparty/openSSL"]
 	path = 3rdparty/openSSL
 	url = https://github.com/KDAB/android_openssl
-        ignore=all
 [submodule "3rdparty/wireguard-go"]
 	path = 3rdparty/wireguard-go
 	url = https://github.com/WireGuard/wireguard-go


### PR DESCRIPTION
## Description

Uniform handling of gitsubmodules when it comes to "ignore"

## Reference

https://mozilla-hub.atlassian.net/browse/VPN-3848
