### PR TITLE
VPN-3849 Align git submodule usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,10 +87,10 @@ Qt6 can be installed in a number of ways:
 ```bash
 ./scripts/utils/qt6_compile.sh </qt6/source/code/path> </destination/path>
 ```
-- Grab a Static Qt-Build used in Mozilla CI: 
+- Grab a Static Qt-Build used in Mozilla CI:
   - [iOS](https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/mozillavpn.v2.mozillavpn.cache.level-3.toolchains.v3.qt-ios.latest/artifacts/public%2Fbuild%2Fqt6_ios.zip)
   - [MacOS](https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/mozillavpn.v2.mozillavpn.cache.level-3.toolchains.v3.qt-mac.latest/artifacts/public%2Fbuild%2Fqt6_mac.zip)
-  - [Windows](https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/mozillavpn.v2.mozillavpn.cache.level-3.toolchains.v3.qt-win.latest/artifacts/public%2Fbuild%2Fqt6_win.zip) 
+  - [Windows](https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/mozillavpn.v2.mozillavpn.cache.level-3.toolchains.v3.qt-win.latest/artifacts/public%2Fbuild%2Fqt6_win.zip)
 
 ### Installing Python 3
 
@@ -317,27 +317,27 @@ This step needs to be executed each time Xcode updates.
 
 #### Building using Conda on MacOS
 
-We provide a Conda env for easy Setup. 
-Prerequisites: 
-- Have miniconda installed. 
+We provide a Conda env for easy Setup.
+Prerequisites:
+- Have miniconda installed.
 
-```bash 
+```bash
 $ conda env create -f env.yml
 $ conda activate VPN
 ```
- - Get a copy of a MacOS-SDK (every X-Code install ships this, or you can find it on the internet :) ) 
+ - Get a copy of a MacOS-SDK (every X-Code install ships this, or you can find it on the internet :) )
     - Set `SDKROOT` to the target SDK.
     - Add it to the conda env via: `conda env config vars set SDKROOT=<>`
-    - Default Paths where you probably find your SDK: 
+    - Default Paths where you probably find your SDK:
       - Default Xcode-command-line tool path: `/Library/Developer/CommandLineTools/SDKs/MacOSX.<VersionNumber>.sdk`
       - Default Xcode.app path: `/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk`
  - Get a Build of QT (See: [Installing Qt6](#Installing-Qt6) )
- 
+
 You are now ready to build!
 
-```bash 
+```bash
 (vpn) $ mkdir build && cmake -S . -B build -DCMAKE_PREFIX_PATH=${Path to QT}/lib/cmake
-(vpn) $ cmake --build build 
+(vpn) $ cmake --build build
 ```
 
 

--- a/ci_scripts/ci_post_clone.sh
+++ b/ci_scripts/ci_post_clone.sh
@@ -10,8 +10,7 @@ cd /Volumes/workspace/repository
 
 # make sure submodules are up to date
 # should already be done by XCode cloud cloning but just to make sure
-git submodule init
-git submodule update
+git submodule update --init
 
 # add necessary directories to path
 export PATH=/Users/local/.gem/ruby/2.6.0/bin:/Users/local/Library/Python/3.8/bin:$PATH

--- a/scripts/linux/ppa_script.sh
+++ b/scripts/linux/ppa_script.sh
@@ -108,9 +108,8 @@ else
   cd .tmp/mozillavpn-$SHORTVERSION || die "Failed"
   print G "done."
 
-  print Y "Update the submodules..."
-  git submodule init || die "Failed"
-  git submodule update --remote --depth 1 3rdparty/wireguard-tools || die "Failed"
+  print Y "Get the submodules..."
+  git submodule update --init --depth 1 || die "Failed"
   print G "done."
 
   print Y "Importing translation files..."

--- a/scripts/linux/ppa_script.sh
+++ b/scripts/linux/ppa_script.sh
@@ -108,8 +108,9 @@ else
   cd .tmp/mozillavpn-$SHORTVERSION || die "Failed"
   print G "done."
 
-  print Y "Get the submodules..."
-  git submodule update --init --depth 1 || die "Failed"
+  print Y "Update the submodules..."
+  git submodule init || die "Failed"
+  git submodule update --remote --depth 1 3rdparty/wireguard-tools || die "Failed"
   print G "done."
 
   print Y "Importing translation files..."

--- a/scripts/linux/script.sh
+++ b/scripts/linux/script.sh
@@ -120,11 +120,8 @@ print G "${SHORTVERSION}"
 rm -rf .tmp || die "Failed to remove the temporary directory"
 mkdir .tmp || die "Failed to create the temporary directory"
 
-print Y "Update the submodules..."
-git submodule init || die "Failed"
-git submodule update --remote --depth 1 i18n || die "Failed"
-git submodule update --remote --depth 1 3rdparty/wireguard-tools || die "Failed"
-git submodule update --depth 1 3rdparty/glean || die "Failed"
+print Y "Get the submodules..."
+git submodule update --init --depth 1 || die "Failed"
 print G "done."
 
 print G "Creating the orig tarball"
@@ -139,6 +136,9 @@ mkdir -p .tmp/${WORKDIR} || die "Failed"
 rsync -a --exclude='.*' ${RSYNC_EXCLUDE_DIRS} . .tmp/${WORKDIR} || die "Failed"
 print G "done."
 cd .tmp
+
+print Y "Importing translation files..."
+(cd $WORKDIR && python3 scripts/utils/import_languages.py) || die "Failed to import languages"
 
 print Y "Generating glean samples..."
 (cd $WORKDIR && python3 scripts/utils/generate_glean.py) || die "Failed to generate glean samples"

--- a/scripts/linux/script.sh
+++ b/scripts/linux/script.sh
@@ -121,7 +121,8 @@ rm -rf .tmp || die "Failed to remove the temporary directory"
 mkdir .tmp || die "Failed to create the temporary directory"
 
 print Y "Get the submodules..."
-git submodule update --init --depth 1 || die "Failed"
+git submodule update --init --depth 1 || die "Failed to init submodules"
+git submodule update --remote i18n || die "Failed to pull latest i18n from remote"
 print G "done."
 
 print G "Creating the orig tarball"
@@ -136,9 +137,6 @@ mkdir -p .tmp/${WORKDIR} || die "Failed"
 rsync -a --exclude='.*' ${RSYNC_EXCLUDE_DIRS} . .tmp/${WORKDIR} || die "Failed"
 print G "done."
 cd .tmp
-
-print Y "Importing translation files..."
-(cd $WORKDIR && python3 scripts/utils/import_languages.py) || die "Failed to import languages"
 
 print Y "Generating glean samples..."
 (cd $WORKDIR && python3 scripts/utils/generate_glean.py) || die "Failed to generate glean samples"

--- a/scripts/utils/import_languages.py
+++ b/scripts/utils/import_languages.py
@@ -65,9 +65,8 @@ lconvert = os.path.join(qtbinpath, 'lconvert')
 lrelease = os.path.join(qtbinpath, 'lrelease')
 
 # Step 1 (continued)
-# Let's update the i18n repo
-os.system(f"git submodule init")
-os.system(f"git submodule update --remote --depth 1 i18n")
+# Get the latest translations from i18n remote
+os.system(f"git submodule update --init --remote --depth 1 i18n")
 
 # Step 2
 # Go through the i18n repo, check each XLIFF file and take

--- a/taskcluster/scripts/addons/build.sh
+++ b/taskcluster/scripts/addons/build.sh
@@ -5,11 +5,9 @@
 
 set -e
 
-git submodule sync --recursive
-git submodule update --init --force --recursive --depth=1
-
-
 # Reqs
+git submodule update --init --depth 1
+git submodule update --remote i18n
 pip3 install -r requirements.txt
 
 python3 scripts/addon/generate_all.py

--- a/taskcluster/scripts/build/android_build_debug.sh
+++ b/taskcluster/scripts/build/android_build_debug.sh
@@ -5,12 +5,8 @@
 set -e
 
 # This script is used in the Android Debug (universal) build task
-git submodule init
-git submodule update
-# glean
-./scripts/utils/generate_glean.py
-# translations
-./scripts/utils/import_languages.py
+git submodule update --init --depth 1
+git submodule update --remote i18n
 
 # $1 should be the qmake arch.
 # Note this is different from what aqt expects as arch:

--- a/taskcluster/scripts/build/android_build_release.sh
+++ b/taskcluster/scripts/build/android_build_release.sh
@@ -5,13 +5,8 @@
 set -e
 
 # This script is used in the Android Build Release (universal) build task
-git submodule init
-git submodule update
-# glean
-./scripts/utils/generate_glean.py
-# translations
-echo "Importing translations"
-./scripts/utils/import_languages.py
+git submodule update --init --depth 1
+git submodule update --remote i18n
 
 # Get Secrets for building
 echo "Fetching Tokens!"
@@ -34,7 +29,7 @@ mkdir -p /builds/worker/artifacts/
 
 
 sentry-cli login --auth-token $(cat sentry_debug_file_upload_key)
-# This will ask sentry to scan all files in there and upload 
+# This will ask sentry to scan all files in there and upload
 # missing debug info, for symbolification
 sentry-cli debug-files upload --org mozilla -p vpn-client --include-sources .tmp/src/android-build/build/intermediates/merged_native_libs
 

--- a/taskcluster/scripts/build/ios_build_no_adjust.sh
+++ b/taskcluster/scripts/build/ios_build_no_adjust.sh
@@ -47,12 +47,15 @@ export PATH=$QT_IOS_BIN:$PATH
 cd $PROJECT_HOME
 # So ios qmake is just a wrapper script
 # and expects to find pwd/qt_ios/mac/bin/qmake >:c
-ln -s ../../fetches/qt_ios/ qt_ios 
+ln -s ../../fetches/qt_ios/ qt_ios
 
-
-print Y "Updating submodules..."
-git submodule init || die
-git submodule update || die
+print Y "Get the submodules..."
+git submodule update --init --depth 1 || die "Failed to init submodules"
+# Technically we do not need the following line because we later call the
+# apple compile script which calls import languages. However when we move to cmake
+# for iOS we can remove the call to import languages and this step will be necessary
+git submodule update --remote i18n || die "Failed to pull latest i18n from remote"
+print G "done."
 
 print Y "Configuring the build..."
 

--- a/taskcluster/scripts/build/macos_build.sh
+++ b/taskcluster/scripts/build/macos_build.sh
@@ -31,8 +31,8 @@ print N "Taskcluster macOS compilation script"
 print N ""
 
 
-# TC NIT: we need to assert 
-# that everything is UTF-8 
+# TC NIT: we need to assert
+# that everything is UTF-8
 export LC_ALL=en_US.utf-8
 export LANG=en_US.utf-8
 export PYTHONIOENCODING="UTF-8"
@@ -46,13 +46,13 @@ source ${TASK_HOME}/miniconda/bin/activate
 
 print Y "Installing provided conda env..."
 # TODO: Check why --force is needed if we install into TASK_HOME?
-conda env create --force -f env.yml       
-conda activate VPN         
-conda info 
+conda env create --force -f env.yml
+conda activate VPN
+conda info
 
 # Conda Cannot know installed MacOS SDK'S
 # and as we use conda'provided clang/llvm
-# we need to manually provide the Path. 
+# we need to manually provide the Path.
 #
 print G "Checking Available SDK'S..."
 # Now you would guess the SDK path is the same on all runners
@@ -61,22 +61,22 @@ print G "Checking Available SDK'S..."
 export SDKROOT=$(xcrun --sdk macosx --show-sdk-path)
 
 
-# Should already have been done by taskcluser, 
-# but double checking c: 
-print Y "Updating submodules..."
-git submodule init || die
-git submodule update || die
+# Should already have been done by taskcluser, but double checking c:
+print Y "Get the submodules..."
+git submodule update --init --depth 1 || die "Failed to init submodules"
+git submodule update --remote i18n || die "Failed to pull latest i18n from remote"
+print G "done."
 
-# Install dependendy got get-secret.py 
+# Install dependendy got get-secret.py
 python3 -m pip install -r taskcluster/scripts/requirements.txt
 print Y "Fetching tokens..."
-# Only on a release build we have access to those secrects. 
-if [[ "$RELEASE" ]]; then  
+# Only on a release build we have access to those secrects.
+if [[ "$RELEASE" ]]; then
    ./taskcluster/scripts/get-secret.py -s project/mozillavpn/level-1/sentry -k sentry_dsn -f sentry_dsn
    ./taskcluster/scripts/get-secret.py -s project/mozillavpn/level-1/sentry -k sentry_envelope_endpoint -f sentry_envelope_endpoint
    ./taskcluster/scripts/get-secret.py -s project/mozillavpn/level-1/sentry -k sentry_debug_file_upload_key -f sentry_debug_file_upload_key
 else
-    # write a dummy value in the files, so that we still compile sentry c: 
+    # write a dummy value in the files, so that we still compile sentry c:
     echo "dummy" > sentry_dsn
     echo "dummy" > sentry_envelope_endpoint
     echo "dummy" > sentry_debug_file_upload_key
@@ -84,7 +84,7 @@ fi
 
 export SENTRY_ENVELOPE_ENDPOINT=$(cat sentry_envelope_endpoint)
 export SENTRY_DSN=$(cat sentry_dsn)
-#Install Sentry CLI, if' not already installed from previous run. 
+#Install Sentry CLI, if' not already installed from previous run.
 if ! command -v sentry-cli &> /dev/null
 then
     npm install -g @sentry/cli
@@ -120,8 +120,8 @@ ls tmp/MozillaVPN.dsym/Contents/Resources/DWARF/
 sentry-cli difutil check tmp/MozillaVPN.dsym/Contents/Resources/DWARF/*
 sentry-cli difutil bundle-sources tmp/MozillaVPN.dsym/Contents/Resources/DWARF/*
 
-if [[ "$RELEASE" ]]; then      
-    print Y "Uploading the Symbols..." 
+if [[ "$RELEASE" ]]; then
+    print Y "Uploading the Symbols..."
     sentry-cli login --auth-token $(cat sentry_debug_file_upload_key)
     sentry-cli debug-files upload --org mozilla -p vpn-client tmp/MozillaVPN.dsym/Contents/Resources/DWARF/*
 fi

--- a/taskcluster/scripts/build/wasm.sh
+++ b/taskcluster/scripts/build/wasm.sh
@@ -6,9 +6,9 @@ set -e
 
 source /opt/emsdk/emsdk_env.sh
 
-git submodule init
-git submodule update
-
+# Reqs
+git submodule update --init --depth 1
+git submodule update --remote i18n
 pip3 install -r requirements.txt
 
 export PATH="$QTPATH/wasm_32/bin:$PATH"

--- a/taskcluster/scripts/build/windows.ps1
+++ b/taskcluster/scripts/build/windows.ps1
@@ -18,11 +18,11 @@ $PERL_GCC_PATH =resolve-path "$FETCHES_PATH/c/bin"
 # and __sometimes__ taskcluster will fail to do cleanup once the task is done
 Remove-Item $FETCHES_PATH/VisualStudio/VC/Tools/MSVC/14.30.30705/bin/HostX64/x64/VCTIP.EXE
 
-# Fetch 3rdparty stuff.
+# Reqs
+git submodule update --init --depth 1
+git submodule update --remote i18n
 python3 -m pip install -r requirements.txt --user
 python3 -m pip install -r taskcluster/scripts/requirements.txt --user
-git submodule update --init --force --recursive --depth=1
-git submodule update --remote i18n
 
 # Fix: pip scripts are not on path by default on tc, so glean would fail
 $PYTHON_SCRIPTS =resolve-path "$env:APPDATA\Python\Python36\Scripts"

--- a/taskcluster/scripts/push-addons/deploy.sh
+++ b/taskcluster/scripts/push-addons/deploy.sh
@@ -6,7 +6,8 @@
 set -e
 
 # Reqs
-git submodule update --init --depth=1
+git submodule update --init --depth 1
+git submodule update --remote i18n
 pip3 install -r requirements.txt
 
 # Get Secrets for building

--- a/taskcluster/scripts/push-addons/deploy.sh
+++ b/taskcluster/scripts/push-addons/deploy.sh
@@ -5,15 +5,14 @@
 
 set -e
 
-git submodule sync --recursive
-git submodule update --init --force --recursive --depth=1
 # Reqs
+git submodule update --init --recursive --depth=1
 pip3 install -r requirements.txt
 
 # Get Secrets for building
 echo "Fetching Tokens!"
 ./taskcluster/scripts/get-secret.py -s project/mozillavpn/tokens -k addons_key -f addons_key.pem
-ls 
+ls
 cd /builds/worker/fetches/
 ls
 openssl dgst -sha256 -sign /builds/worker/checkouts/vcs/addons_key.pem -out addons/manifest.json.sig addons/manifest.json

--- a/taskcluster/scripts/push-addons/deploy.sh
+++ b/taskcluster/scripts/push-addons/deploy.sh
@@ -6,7 +6,7 @@
 set -e
 
 # Reqs
-git submodule update --init --recursive --depth=1
+git submodule update --init --depth=1
 pip3 install -r requirements.txt
 
 # Get Secrets for building


### PR DESCRIPTION
## Description

Use `git submodule update --init` throughout codebase in order to:
* standardize usage
* not update submodules ahead of committed versions

The exception to this is i18n which we want to pull from remote. I've isolated this to just the `import_languages.py` script.

@oskirby In making these changes, I realized that `ppa_script.sh` did not include a call to `import_languages.py`. Can you review my change.

@strseb `taskcluster/scripts/push-addons/deploy.sh`. I haven't changed it but wanted to check in with you. Why is this file:
* doing a sync first - can we document why this is necessary
* doing --recursive (it's the only place in the repo we do)
* doing --force (again only place we do it)
