### PR TITLE
Override LD in the windows openssl toolchain script

### DIFF
--- a/taskcluster/scripts/toolchain/compile_openssl.ps1
+++ b/taskcluster/scripts/toolchain/compile_openssl.ps1
@@ -21,7 +21,10 @@ Expand-Archive openssl.zip -DestinationPath .
 Set-Location openssl-OpenSSL_1_1_1m
 
 $NASM_PATH = resolve-path ../nasm-2.15.05
-$env:PATH = "$env:PATH;$NASM_PATH"
+$env:PATH = "$FETCHES_PATH/VisualStudio/VC/Tools/MSVC/14.30.30705/bin/Hostx64/x64;$env:PATH;$NASM_PATH"
+$env:LD = resolve-path "$FETCHES_PATH/VisualStudio/VC/Tools/MSVC/14.30.30705/bin/Hostx64/x64/link.exe"
+
+where link
 
 if(!(Test-Path ../SSL)){
     New-Item -Path ../SSL -ItemType "directory"


### PR DESCRIPTION
Since the switch to azure, link.exe from GNU coreutils comes before VisualStudio's in $PATH.

## Description

    Describe your changes

## Reference

    i.e Jira or Github issue URL

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
