### PR TITLE
VPN-3111: Prefer locations within the user's country

### DIFF
--- a/src/apps/vpn/models/servercountrymodel.cpp
+++ b/src/apps/vpn/models/servercountrymodel.cpp
@@ -283,14 +283,17 @@ QStringList ServerCountryModel::pickBest(const Location& location) const {
   // We rank cities using the distance between two points on a great circle,
   // which is given by:
   //    d = acos(sin(lat1)*sin(lat2) + cos(lat1)*cos(lat2)*cos(long1-long2))
-  //
-  // TODO: Include other ranking data, such as latency and number of servers.
   QString bestCountry;
   QString bestCity;
   double clientSin = qSin(latitude * M_PI / 180.0);
   double clientCos = qCos(latitude * M_PI / 180.0);
   double bestDistance = M_2_PI;
   for (const ServerCountry& country : m_countries) {
+    // If servers exist within the same country as the user, restrict the search
+    // to locations only within that country.
+    if (country.code() == location.countryCode()) {
+      bestDistance = M_2_PI;
+    }
     for (const ServerCity& city : country.cities()) {
       double citySin = qSin(city.latitude() * M_PI / 180.0);
       double cityCos = qCos(city.latitude() * M_PI / 180.0);
@@ -303,6 +306,10 @@ QStringList ServerCountryModel::pickBest(const Location& location) const {
         bestCity = city.name();
         bestDistance = distance;
       }
+    }
+    // If servers exist within the same country, then we are done.
+    if (country.code() == location.countryCode()) {
+      break;
     }
   }
 


### PR DESCRIPTION
## Description
It has been recommended that the default location selection should take the user's current country into account when selecting a server. This is to hopefully try and mitigate unexpected changes to the locale when browsing the web. Fortunately this can be made as a simple tweak to `ServerCountryModel::pickBest()`

Note that this is only needed for the `releases/2.14.0` branch. This algorithm has since been replaced by the recommended server algorithm in 2.15 and beyond.

## Reference
Github issue #3682
Github pull request #5398
JIRA [VPN-2333](https://mozilla-hub.atlassian.net/browse/VPN-2333) and [VPN-3111](https://mozilla-hub.atlassian.net/browse/VPN-3111)

## Checklist
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed


[VPN-2333]: https://mozilla-hub.atlassian.net/browse/VPN-2333?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[VPN-3111]: https://mozilla-hub.atlassian.net/browse/VPN-3111?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ