### PR TITLE
Experiment: Use prepared source bundle for Windows builds

### DIFF
--- a/taskcluster/ci/build/linux.yml
+++ b/taskcluster/ci/build/linux.yml
@@ -11,7 +11,7 @@ task-defaults:
         build:
             - artifact: mozillavpn-sources.tar.gz
     dependencies:
-        build: build-linux/source
+        build: build-source/vpn
     worker-type: b-linux
     worker:
         max-run-time: 3600

--- a/taskcluster/ci/build/source.yml
+++ b/taskcluster/ci/build/source.yml
@@ -4,7 +4,7 @@
 ---
 
 source/vpn:
-    description: "Linux Source Build"
+    description: "VPN Source Build"
     treeherder:
         symbol: B
         kind: build

--- a/taskcluster/ci/build/source.yml
+++ b/taskcluster/ci/build/source.yml
@@ -3,13 +3,13 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 ---
 
-linux/source:
+source/vpn:
     description: "Linux Source Build"
     treeherder:
         symbol: B
         kind: build
         tier: 1
-        platform: linux/source
+        platform: source/vpn
     worker-type: b-linux
     worker:
         docker-image: {in-tree: build}

--- a/taskcluster/ci/build/windows.yml
+++ b/taskcluster/ci/build/windows.yml
@@ -10,6 +10,8 @@ task-defaults:
         tier: 1
         platform: windows/x86_64
     worker-type: b-win2012
+    dependencies:
+        build: build-linux/source
     fetches:
         fetch:
             - win-dev-env
@@ -17,6 +19,8 @@ task-defaults:
             - win-go
             - win-perl
             - win-sentry-cli
+        build:
+            - artifact: mozillavpn-sources.tar.gz
         toolchain:
             - qt-win
     worker:

--- a/taskcluster/ci/build/windows.yml
+++ b/taskcluster/ci/build/windows.yml
@@ -11,7 +11,7 @@ task-defaults:
         platform: windows/x86_64
     worker-type: b-win2012
     dependencies:
-        build: build-linux/source
+        build: build-source/vpn
     fetches:
         fetch:
             - win-dev-env

--- a/taskcluster/scripts/build/windows.ps1
+++ b/taskcluster/scripts/build/windows.ps1
@@ -50,6 +50,12 @@ $SSL_PATH = resolve-path "$FETCHES_PATH/QT_OUT/SSL"
 $env:OPENSSL_ROOT_DIR = (resolve-path "$SSL_PATH").toString()
 $env:OPENSSL_USE_STATIC_LIBS = "TRUE"
 
+# Extract the sources
+$SOURCE_DSC = resolve-path "$FETCHES_PATH/mozillavpn_*.dsc"
+$SOURCE_VERSION = ((select-string $SOURCE_DSC -Pattern '^Version:') -split " ")[1]
+$SOURCE_DIR = $TASK_WORKDIR/mozillavpn-$SOURCE_VERSION
+tar -C $TASK_WORKDIR -xzvf $FETCHES_PATH/mozillavpn_$SOURCE_VERSION.orig.tar.gz
+
 #Do not continune from this point on when we encounter an error
 $ErrorActionPreference = "Stop"
 mkdir $TASK_WORKDIR/cmake_build
@@ -65,10 +71,10 @@ if ($env:MOZ_SCM_LEVEL -eq "3") {
     $SENTRY_ENVELOPE_ENDPOINT = Get-Content sentry_envelope_endpoint
     $SENTRY_DSN = Get-Content sentry_dsn
     #
-    cmake -S . -B $BUILD_DIR -GNinja -DCMAKE_BUILD_TYPE=Release -DSENTRY_DSN="$SENTRY_DSN" -DSENTRY_ENVELOPE_ENDPOINT="$SENTRY_ENVELOPE_ENDPOINT"
+    cmake -S $SOURCE_DIR -B $BUILD_DIR -GNinja -DCMAKE_BUILD_TYPE=Release -DSENTRY_DSN="$SENTRY_DSN" -DSENTRY_ENVELOPE_ENDPOINT="$SENTRY_ENVELOPE_ENDPOINT"
 } else {
     # Do the generic build
-   cmake -S . -B $BUILD_DIR -GNinja -DCMAKE_BUILD_TYPE=Release
+   cmake -S $SOURCE_DIR -B $BUILD_DIR -GNinja -DCMAKE_BUILD_TYPE=Release
 }
 cmake --build $BUILD_DIR
 cmake --build $BUILD_DIR --target msi

--- a/taskcluster/scripts/build/windows.ps1
+++ b/taskcluster/scripts/build/windows.ps1
@@ -53,8 +53,8 @@ $env:OPENSSL_USE_STATIC_LIBS = "TRUE"
 # Extract the sources
 $SOURCE_DSC = resolve-path "$FETCHES_PATH/mozillavpn_*.dsc"
 $SOURCE_VERSION = ((select-string $SOURCE_DSC -Pattern '^Version:') -split " ")[1]
-$SOURCE_DIR = $TASK_WORKDIR/mozillavpn-$SOURCE_VERSION
 tar -C $TASK_WORKDIR -xzvf $FETCHES_PATH/mozillavpn_$SOURCE_VERSION.orig.tar.gz
+$SOURCE_DIR = resolve-path "$TASK_WORKDIR/mozillavpn-$SOURCE_VERSION"
 
 #Do not continune from this point on when we encounter an error
 $ErrorActionPreference = "Stop"

--- a/taskcluster/scripts/build/windows.ps1
+++ b/taskcluster/scripts/build/windows.ps1
@@ -13,6 +13,14 @@ $PERL_GCC_PATH =resolve-path "$FETCHES_PATH/c/bin"
 . "$FETCHES_PATH/QT_OUT/configure_qt.ps1"
 . "$REPO_ROOT_PATH/taskcluster/scripts/fetch/enable_win_rust.ps1"
 
+# Extract the sources
+$SOURCE_DSC = resolve-path "$FETCHES_PATH/mozillavpn_*.dsc"
+$SOURCE_VERSION = ((select-string $SOURCE_DSC -Pattern '^Version:') -split " ")[1]
+$SOURCE_TARGZ = resolve-path "$FETCHES_PATH/mozillavpn_$SOURCE_VERSION.orig.tar.gz" -Relative
+cd $TASK_WORKDIR
+tar -xzvf $SOURCE_TARGZ
+$SOURCE_DIR = resolve-path "$TASK_WORKDIR/mozillavpn-$SOURCE_VERSION"
+
 # Remove Long lasting ms-compiler-telemetry service:
 # This will sometimes live longer then our compile
 # and __sometimes__ taskcluster will fail to do cleanup once the task is done
@@ -49,13 +57,6 @@ Copy-Item -Path $env:VCToolsRedistDir\\MergeModules\\Microsoft_VC143_CRT_x86.msm
 $SSL_PATH = resolve-path "$FETCHES_PATH/QT_OUT/SSL"
 $env:OPENSSL_ROOT_DIR = (resolve-path "$SSL_PATH").toString()
 $env:OPENSSL_USE_STATIC_LIBS = "TRUE"
-
-# Extract the sources
-$SOURCE_DSC = resolve-path "$FETCHES_PATH/mozillavpn_*.dsc"
-$SOURCE_VERSION = ((select-string $SOURCE_DSC -Pattern '^Version:') -split " ")[1]
-$SOURCE_TARGZ = resolve-path "$FETCHES_PATH/mozillavpn_$SOURCE_VERSION.orig.tar.gz"
-tar -C $TASK_WORKDIR -xzvf $SOURCE_TARGZ
-$SOURCE_DIR = resolve-path "$TASK_WORKDIR/mozillavpn-$SOURCE_VERSION"
 
 #Do not continune from this point on when we encounter an error
 $ErrorActionPreference = "Stop"

--- a/taskcluster/scripts/build/windows.ps1
+++ b/taskcluster/scripts/build/windows.ps1
@@ -53,7 +53,8 @@ $env:OPENSSL_USE_STATIC_LIBS = "TRUE"
 # Extract the sources
 $SOURCE_DSC = resolve-path "$FETCHES_PATH/mozillavpn_*.dsc"
 $SOURCE_VERSION = ((select-string $SOURCE_DSC -Pattern '^Version:') -split " ")[1]
-tar -C $TASK_WORKDIR -xzvf $FETCHES_PATH/mozillavpn_$SOURCE_VERSION.orig.tar.gz
+$SOURCE_TARGZ = resolve-path "$FETCHES_PATH/mozillavpn_$SOURCE_VERSION.orig.tar.gz"
+tar -C $TASK_WORKDIR -xzvf $SOURCE_TARGZ
 $SOURCE_DIR = resolve-path "$TASK_WORKDIR/mozillavpn-$SOURCE_VERSION"
 
 #Do not continune from this point on when we encounter an error

--- a/taskcluster/scripts/build/windows.ps1
+++ b/taskcluster/scripts/build/windows.ps1
@@ -8,13 +8,13 @@ $FETCHES_PATH =resolve-path "$TASK_WORKDIR/fetches"
 $QTPATH =resolve-path "$FETCHES_PATH/QT_OUT/bin/"
 $PERL_GCC_PATH =resolve-path "$FETCHES_PATH/c/bin"
 # Prep Env:
-# Enable qt, enable msvc, enable rust
+# Switch to the work dir, enable qt, enable msvc, enable rust
+Set-Location -Path $TASK_WORKDIR
 . "$FETCHES_PATH/VisualStudio/enter_dev_shell.ps1"
 . "$FETCHES_PATH/QT_OUT/configure_qt.ps1"
 . "$REPO_ROOT_PATH/taskcluster/scripts/fetch/enable_win_rust.ps1"
 
 # Extract the sources
-cd $TASK_WORKDIR
 $SOURCE_DSC = resolve-path "$FETCHES_PATH/mozillavpn_*.dsc"
 $SOURCE_VERSION = ((select-string $SOURCE_DSC -Pattern '^Version:') -split " ")[1]
 tar -xzvf (resolve-path "$FETCHES_PATH/mozillavpn_$SOURCE_VERSION.orig.tar.gz" -Relative)

--- a/taskcluster/scripts/build/windows.ps1
+++ b/taskcluster/scripts/build/windows.ps1
@@ -14,11 +14,10 @@ $PERL_GCC_PATH =resolve-path "$FETCHES_PATH/c/bin"
 . "$REPO_ROOT_PATH/taskcluster/scripts/fetch/enable_win_rust.ps1"
 
 # Extract the sources
+cd $TASK_WORKDIR
 $SOURCE_DSC = resolve-path "$FETCHES_PATH/mozillavpn_*.dsc"
 $SOURCE_VERSION = ((select-string $SOURCE_DSC -Pattern '^Version:') -split " ")[1]
-$SOURCE_TARGZ = resolve-path "$FETCHES_PATH/mozillavpn_$SOURCE_VERSION.orig.tar.gz" -Relative
-cd $TASK_WORKDIR
-tar -xzvf $SOURCE_TARGZ
+tar -xzvf (resolve-path "$FETCHES_PATH/mozillavpn_$SOURCE_VERSION.orig.tar.gz" -Relative)
 $SOURCE_DIR = resolve-path "$TASK_WORKDIR/mozillavpn-$SOURCE_VERSION"
 
 # Remove Long lasting ms-compiler-telemetry service:
@@ -26,11 +25,9 @@ $SOURCE_DIR = resolve-path "$TASK_WORKDIR/mozillavpn-$SOURCE_VERSION"
 # and __sometimes__ taskcluster will fail to do cleanup once the task is done
 Remove-Item $FETCHES_PATH/VisualStudio/VC/Tools/MSVC/14.30.30705/bin/HostX64/x64/VCTIP.EXE
 
-# Reqs
-git submodule update --init --depth 1
-git submodule update --remote i18n
-python3 -m pip install -r requirements.txt --user
-python3 -m pip install -r taskcluster/scripts/requirements.txt --user
+# Install python build tooling
+python3 -m pip install -r $SOURCE_DIR/requirements.txt --user
+python3 -m pip install -r $SOURCE_DIR/taskcluster/scripts/requirements.txt --user
 
 # Fix: pip scripts are not on path by default on tc, so glean would fail
 $PYTHON_SCRIPTS =resolve-path "$env:APPDATA\Python\Python36\Scripts"


### PR DESCRIPTION
## Description
Lately we have been encountering some pain in the Windows builds due to taskcluster failing to fetch Rust dependencies. We might be able to fix it by switching to use the Linux source bundle, which has already vendored all the Rust code and doesn't need to perform any fetching.

## References
Github issue #6261 ([VPN-4319](https://mozilla-hub.atlassian.net/browse/VPN-4319))

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed


[VPN-4319]: https://mozilla-hub.atlassian.net/browse/VPN-4319?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ