### PR TITLE
VPN-3292 & VPN-3284: Add "+ tax" to subscription plan pricing

### DIFF
--- a/android/vpnClient/src/main/java/org/mozilla/firefox/vpn/qt/InAppPurchase.kt
+++ b/android/vpnClient/src/main/java/org/mozilla/firefox/vpn/qt/InAppPurchase.kt
@@ -62,6 +62,7 @@ data class GooglePlaySubscriptionInfo(
     val monthlyPriceString: String,
     val monthlyPrice: Double,
     val trialDays: Int,
+    val currencyCode: String,
 )
 
 @Serializable
@@ -375,6 +376,7 @@ class InAppPurchase private constructor(ctx: Context) :
         }
 
         return GooglePlaySubscriptionInfo(
+            currencyCode = details.priceCurrencyCode
             totalPriceString = details.price,
             trialDays = trialDays,
             monthlyPriceString = monthlyPriceString,

--- a/android/vpnClient/src/main/java/org/mozilla/firefox/vpn/qt/InAppPurchase.kt
+++ b/android/vpnClient/src/main/java/org/mozilla/firefox/vpn/qt/InAppPurchase.kt
@@ -376,7 +376,7 @@ class InAppPurchase private constructor(ctx: Context) :
         }
 
         return GooglePlaySubscriptionInfo(
-            currencyCode = details.priceCurrencyCode
+            currencyCode = details.priceCurrencyCode,
             totalPriceString = details.price,
             trialDays = trialDays,
             monthlyPriceString = monthlyPriceString,

--- a/nebula/ui/components/VPNSubscriptionOption.qml
+++ b/nebula/ui/components/VPNSubscriptionOption.qml
@@ -123,16 +123,9 @@ RadioDelegate {
             // TODO (maybe) - Do we want to add the subscription duration in months to the model?
             property var subscriptionDuration: getSubscriptionDuration(productType)
 
-            //% "Monthly plan"
-            property string productSingleMonth: qsTrId("vpn.subscription.monthlyPlan")
-
             //: %1 is replaced by the subscription duration in months. %2 is replaced by the total subscription cost.
             //% "%1-month plan: %2"
             property string productMultiMonth: qsTrId("vpn.subscription.multiMonthPlan").arg(col.subscriptionDuration).arg(productPrice)
-
-            //: “/month” stands for “per month”. %1 is replaced by the monthly cost (including currency).
-            //% "%1/month"
-            property string monthlyPrice: VPNI18n.SubscriptionManagementPlanMonthly.arg(productMonthlyPrice)
 
             property int trialDays: productTrialDays
 
@@ -144,7 +137,7 @@ RadioDelegate {
                 font.pixelSize: 16
                 lineHeight: VPNTheme.theme.labelLineHeight + 2
                 lineHeightMode: Text.FixedHeight
-                text: col.subscriptionDuration > 1 ? col.productMultiMonth : col.monthlyPrice
+                text: col.subscriptionDuration > 1 ? col.productMultiMonth : VPNI18n.SubscriptionManagementPlanMonthly.arg(productMonthlyPrice)
                 verticalAlignment: Text.AlignVCenter
                 wrapMode: Text.WordWrap
 
@@ -160,16 +153,11 @@ RadioDelegate {
                 lineHeight: 17.68
                 lineHeightMode: Text.FixedHeight
                 text: {
-                    const isUsOrCa = VPN.countryCode === "US" || VPN.countryCode === "CA"
-
-                    if(col.subscriptionDuration === -1)
-                        return ""
-                    else if(col.subscriptionDuration > 1) {
-                        return isUsOrCa ? VPNI18n.SubscriptionManagementPlanMonthlyPlusTax.arg(productMonthlyPrice) : col.monthlyPrice
+                    if(col.subscriptionDuration > 0) {
+                        return VPNSubscriptionData.plusTax ? VPNI18n.SubscriptionManagementPlanMonthlyPlusTax.arg(productMonthlyPrice) : VPNI18n.SubscriptionManagementPlanMonthlyWithoutTax.arg(productMonthlyPrice)
                     }
-                    //col.subscriptionDuration === 1
                     else {
-                        return isUsOrCa ? VPNI18n.SubscriptionManagementPlanMonthlyPlusTax.arg(productMonthlyPrice) : col.productSingleMonth
+                        return ""
                     }
                 }
                 wrapMode: Text.WordWrap

--- a/nebula/ui/components/VPNSubscriptionOption.qml
+++ b/nebula/ui/components/VPNSubscriptionOption.qml
@@ -156,9 +156,7 @@ RadioDelegate {
                     if(col.subscriptionDuration > 0) {
                         return VPNSubscriptionData.plusTax ? VPNI18n.SubscriptionManagementPlanMonthlyPlusTax.arg(productMonthlyPrice) : VPNI18n.SubscriptionManagementPlanMonthlyWithoutTax.arg(productMonthlyPrice)
                     }
-                    else {
-                        return ""
-                    }
+                    return ""
                 }
                 wrapMode: Text.WordWrap
 

--- a/nebula/ui/components/VPNSubscriptionOption.qml
+++ b/nebula/ui/components/VPNSubscriptionOption.qml
@@ -154,7 +154,7 @@ RadioDelegate {
                 lineHeightMode: Text.FixedHeight
                 text: {
                     if(col.subscriptionDuration > 0) {
-                        return VPNSubscriptionData.plusTax ? VPNI18n.SubscriptionManagementPlanMonthlyPlusTax.arg(productMonthlyPrice) : VPNI18n.SubscriptionManagementPlanMonthlyWithoutTax.arg(productMonthlyPrice)
+                        return ["USD", "CAD"].includes(productCurrencyCode) ? VPNI18n.SubscriptionManagementPlanMonthlyPlusTax.arg(productMonthlyPrice) : VPNI18n.SubscriptionManagementPlanMonthlyWithoutTax.arg(productMonthlyPrice)
                     }
                     return ""
                 }

--- a/nebula/ui/components/VPNSubscriptionOption.qml
+++ b/nebula/ui/components/VPNSubscriptionOption.qml
@@ -132,7 +132,7 @@ RadioDelegate {
 
             //: “/month” stands for “per month”. %1 is replaced by the monthly cost (including currency).
             //% "%1/month"
-            property string monthlyPrice: qsTrId("vpn.subscription.price").arg(productMonthlyPrice)
+            property string monthlyPrice: VPNI18n.SubscriptionManagementPlanMonthly.arg(productMonthlyPrice)
 
             property int trialDays: productTrialDays
 
@@ -159,7 +159,19 @@ RadioDelegate {
                 font.pixelSize: VPNTheme.theme.fontSize
                 lineHeight: 17.68
                 lineHeightMode: Text.FixedHeight
-                text: col.subscriptionDuration !== -1 ? (col.subscriptionDuration > 1 ? col.monthlyPrice : col.productSingleMonth) : ""
+                text: {
+                    const isUsOrCa = VPN.countryCode === "US" || VPN.countryCode === "CA"
+
+                    if(col.subscriptionDuration === -1)
+                        return ""
+                    else if(col.subscriptionDuration > 1) {
+                        return isUsOrCa ? VPNI18n.SubscriptionManagementPlanMonthlyPlusTax.arg(productMonthlyPrice) : col.monthlyPrice
+                    }
+                    //col.subscriptionDuration === 1
+                    else {
+                        return isUsOrCa ? VPNI18n.SubscriptionManagementPlanMonthlyPlusTax.arg(productMonthlyPrice) : col.productSingleMonth
+                    }
+                }
                 wrapMode: Text.WordWrap
 
                 Layout.fillWidth: true

--- a/src/apps/vpn/models/subscriptiondata.cpp
+++ b/src/apps/vpn/models/subscriptiondata.cpp
@@ -183,7 +183,7 @@ bool SubscriptionData::fromJsonInternal(const QByteArray& json) {
     return false;
   }
 
-  //Payments made using USD or CAD are subject to tax
+  // Payments made using USD or CAD are subject to tax
   m_planRequiresTax = QStringList({"USD", "CAD"}).contains(m_planCurrency);
 
   // Payment
@@ -230,7 +230,8 @@ void SubscriptionData::writeSettings() {
 bool SubscriptionData::plusTax() {
   MozillaVPN* vpn = MozillaVPN::instance();
 
-  //This function is only meant to be used if there is no subscription data available
+  // This function is only meant to be used if there is no subscription data
+  // available
   Q_ASSERT(vpn->state() != MozillaVPN::StateMain);
 
   QString countryCode = vpn->location()->countryCode();

--- a/src/apps/vpn/models/subscriptiondata.cpp
+++ b/src/apps/vpn/models/subscriptiondata.cpp
@@ -225,14 +225,13 @@ void SubscriptionData::writeSettings() {
 }
 
 bool SubscriptionData::plusTax() {
-    MozillaVPN* vpn = MozillaVPN::instance();
-    QString countryCode = vpn->location()->countryCode();
+  MozillaVPN* vpn = MozillaVPN::instance();
+  QString countryCode = vpn->location()->countryCode();
 
-    connect(vpn->location(), &Location::changed, [this](){
-        emit plusTaxChanged();
-    });
+  connect(vpn->location(), &Location::changed,
+          [this]() { emit plusTaxChanged(); });
 
-    return countryCode == "US" || countryCode == "CA";
+  return countryCode == "US" || countryCode == "CA";
 }
 
 bool SubscriptionData::parseSubscriptionDataIap(

--- a/src/apps/vpn/models/subscriptiondata.cpp
+++ b/src/apps/vpn/models/subscriptiondata.cpp
@@ -16,6 +16,8 @@
 #include "gleandeprecated.h"
 #include "leakdetector.h"
 #include "logger.h"
+#include "models/location.h"
+#include "mozillavpn.h"
 #include "settingsholder.h"
 #include "telemetry/gleansample.h"
 
@@ -220,6 +222,13 @@ bool SubscriptionData::fromJsonInternal(const QByteArray& json) {
 
 void SubscriptionData::writeSettings() {
   SettingsHolder::instance()->setSubscriptionData(m_rawJson);
+}
+
+bool SubscriptionData::plusTax() {
+    MozillaVPN* vpn = MozillaVPN::instance();
+    QString countryCode = vpn->location()->countryCode();
+
+    return countryCode == "US" || countryCode == "CA";
 }
 
 bool SubscriptionData::parseSubscriptionDataIap(

--- a/src/apps/vpn/models/subscriptiondata.cpp
+++ b/src/apps/vpn/models/subscriptiondata.cpp
@@ -183,6 +183,9 @@ bool SubscriptionData::fromJsonInternal(const QByteArray& json) {
     return false;
   }
 
+  //Payments made using USD or CAD are subject to tax
+  m_planRequiresTax = QStringList({"USD", "CAD"}).contains(m_planCurrency);
+
   // Payment
   QJsonObject paymentData = obj["payment"].toObject();
 
@@ -226,6 +229,10 @@ void SubscriptionData::writeSettings() {
 
 bool SubscriptionData::plusTax() {
   MozillaVPN* vpn = MozillaVPN::instance();
+
+  //This function is only meant to be used if there is no subscription data available
+  Q_ASSERT(vpn->state() != MozillaVPN::StateMain);
+
   QString countryCode = vpn->location()->countryCode();
 
   connect(vpn->location(), &Location::changed,
@@ -295,6 +302,7 @@ void SubscriptionData::resetData() {
   m_expiresOn = 0;
   m_isCancelled = false;
   m_isPrivacyBundleSubscriber = false;
+  m_planRequiresTax = false;
 
   m_planBillingInterval = BillingIntervalUnknown;
   m_planAmount = 0;

--- a/src/apps/vpn/models/subscriptiondata.cpp
+++ b/src/apps/vpn/models/subscriptiondata.cpp
@@ -227,21 +227,6 @@ void SubscriptionData::writeSettings() {
   SettingsHolder::instance()->setSubscriptionData(m_rawJson);
 }
 
-bool SubscriptionData::plusTax() {
-  MozillaVPN* vpn = MozillaVPN::instance();
-
-  // This function is only meant to be used if there is no subscription data
-  // available
-  Q_ASSERT(vpn->state() != MozillaVPN::StateMain);
-
-  QString countryCode = vpn->location()->countryCode();
-
-  connect(vpn->location(), &Location::changed,
-          [this]() { emit plusTaxChanged(); });
-
-  return countryCode == "US" || countryCode == "CA";
-}
-
 bool SubscriptionData::parseSubscriptionDataIap(
     const QJsonObject& subscriptionData) {
   logger.debug() << "Parse IAP start" << m_type;

--- a/src/apps/vpn/models/subscriptiondata.cpp
+++ b/src/apps/vpn/models/subscriptiondata.cpp
@@ -228,6 +228,10 @@ bool SubscriptionData::plusTax() {
     MozillaVPN* vpn = MozillaVPN::instance();
     QString countryCode = vpn->location()->countryCode();
 
+    connect(vpn->location(), &Location::changed, [this](){
+        emit plusTaxChanged();
+    });
+
     return countryCode == "US" || countryCode == "CA";
 }
 

--- a/src/apps/vpn/models/subscriptiondata.h
+++ b/src/apps/vpn/models/subscriptiondata.h
@@ -27,6 +27,7 @@ class SubscriptionData final : public QObject {
                  m_planBillingInterval CONSTANT)
   Q_PROPERTY(int planAmount MEMBER m_planAmount CONSTANT)
   Q_PROPERTY(QString planCurrency MEMBER m_planCurrency CONSTANT)
+  Q_PROPERTY(bool planRequiresTax MEMBER m_planRequiresTax CONSTANT)
 
   // Payment
   Q_PROPERTY(QString paymentProvider MEMBER m_paymentProvider CONSTANT)
@@ -99,6 +100,7 @@ class SubscriptionData final : public QObject {
   TypeBillingInterval m_planBillingInterval = BillingIntervalUnknown;
   int m_planAmount = 0;
   QString m_planCurrency;
+  bool m_planRequiresTax;
 
   QString m_paymentProvider;
   QString m_creditCardBrand;

--- a/src/apps/vpn/models/subscriptiondata.h
+++ b/src/apps/vpn/models/subscriptiondata.h
@@ -74,7 +74,6 @@ class SubscriptionData final : public QObject {
 
  signals:
   void changed();
-  void plusTaxChanged();
 
  private:
   bool fromJsonInternal(const QByteArray& json);

--- a/src/apps/vpn/models/subscriptiondata.h
+++ b/src/apps/vpn/models/subscriptiondata.h
@@ -36,8 +36,6 @@ class SubscriptionData final : public QObject {
   Q_PROPERTY(int creditCardExpMonth MEMBER m_creditCardExpMonth CONSTANT)
   Q_PROPERTY(int creditCardExpYear MEMBER m_creditCardExpYear CONSTANT)
 
-  Q_PROPERTY(bool plusTax READ plusTax NOTIFY plusTaxChanged)
-
  public:
   SubscriptionData();
   ~SubscriptionData();
@@ -73,8 +71,6 @@ class SubscriptionData final : public QObject {
   void reset() { m_rawJson.clear(); }
 
   void writeSettings();
-
-  bool plusTax();
 
  signals:
   void changed();

--- a/src/apps/vpn/models/subscriptiondata.h
+++ b/src/apps/vpn/models/subscriptiondata.h
@@ -100,7 +100,7 @@ class SubscriptionData final : public QObject {
   TypeBillingInterval m_planBillingInterval = BillingIntervalUnknown;
   int m_planAmount = 0;
   QString m_planCurrency;
-  bool m_planRequiresTax;
+  bool m_planRequiresTax = false;
 
   QString m_paymentProvider;
   QString m_creditCardBrand;

--- a/src/apps/vpn/models/subscriptiondata.h
+++ b/src/apps/vpn/models/subscriptiondata.h
@@ -35,7 +35,7 @@ class SubscriptionData final : public QObject {
   Q_PROPERTY(int creditCardExpMonth MEMBER m_creditCardExpMonth CONSTANT)
   Q_PROPERTY(int creditCardExpYear MEMBER m_creditCardExpYear CONSTANT)
 
-  Q_PROPERTY(bool plusTax READ plusTax CONSTANT)
+  Q_PROPERTY(bool plusTax READ plusTax NOTIFY plusTaxChanged)
 
  public:
   SubscriptionData();
@@ -77,6 +77,7 @@ class SubscriptionData final : public QObject {
 
  signals:
   void changed();
+  void plusTaxChanged();
 
  private:
   bool fromJsonInternal(const QByteArray& json);

--- a/src/apps/vpn/models/subscriptiondata.h
+++ b/src/apps/vpn/models/subscriptiondata.h
@@ -35,6 +35,8 @@ class SubscriptionData final : public QObject {
   Q_PROPERTY(int creditCardExpMonth MEMBER m_creditCardExpMonth CONSTANT)
   Q_PROPERTY(int creditCardExpYear MEMBER m_creditCardExpYear CONSTANT)
 
+  Q_PROPERTY(bool plusTax READ plusTax CONSTANT)
+
  public:
   SubscriptionData();
   ~SubscriptionData();
@@ -70,6 +72,8 @@ class SubscriptionData final : public QObject {
   void reset() { m_rawJson.clear(); }
 
   void writeSettings();
+
+  bool plusTax();
 
  signals:
   void changed();

--- a/src/apps/vpn/mozillavpn.cpp
+++ b/src/apps/vpn/mozillavpn.cpp
@@ -859,6 +859,10 @@ bool MozillaVPN::checkCurrentDevice() {
   return true;
 }
 
+QString MozillaVPN::countryCode() {
+    return m_private->m_location.countryCode();
+}
+
 void MozillaVPN::logout() {
   logger.debug() << "Logout";
 

--- a/src/apps/vpn/mozillavpn.cpp
+++ b/src/apps/vpn/mozillavpn.cpp
@@ -860,7 +860,7 @@ bool MozillaVPN::checkCurrentDevice() {
 }
 
 QString MozillaVPN::countryCode() {
-    return m_private->m_location.countryCode();
+  return m_private->m_location.countryCode();
 }
 
 void MozillaVPN::logout() {

--- a/src/apps/vpn/mozillavpn.cpp
+++ b/src/apps/vpn/mozillavpn.cpp
@@ -859,10 +859,6 @@ bool MozillaVPN::checkCurrentDevice() {
   return true;
 }
 
-QString MozillaVPN::countryCode() {
-  return m_private->m_location.countryCode();
-}
-
 void MozillaVPN::logout() {
   logger.debug() << "Logout";
 

--- a/src/apps/vpn/mozillavpn.cpp
+++ b/src/apps/vpn/mozillavpn.cpp
@@ -14,7 +14,9 @@
 #include "glean/generated/pings.h"
 #include "glean/gleandeprecated.h"
 #include "glean/mzglean.h"
+#include "i18nstrings.h"
 #include "leakdetector.h"
+#include "localizer.h"
 #include "logger.h"
 #include "loghandler.h"
 #include "logoutobserver.h"
@@ -307,7 +309,6 @@ void MozillaVPN::initialize() {
     setUserState(UserAuthenticated);
     setState(StateAuthenticating);
     if (!Feature::get(Feature::Feature_webPurchase)->isSupported()) {
-      scheduleTaskGetLocation();
       TaskScheduler::scheduleTask(new TaskProducts());
     }
     TaskScheduler::scheduleTask(
@@ -538,7 +539,6 @@ void MozillaVPN::authenticationCompleted(const QByteArray& json,
 
   if (m_private->m_user.subscriptionNeeded()) {
     if (!Feature::get(Feature::Feature_webPurchase)->isSupported()) {
-      scheduleTaskGetLocation();
       TaskScheduler::scheduleTask(new TaskProducts());
     }
     TaskScheduler::scheduleTask(
@@ -859,17 +859,6 @@ bool MozillaVPN::checkCurrentDevice() {
   settingsHolder->setPublicKey(settingsHolder->publicKey());
   resetJournalPublicAndPrivateKeys();
   return true;
-}
-
-void MozillaVPN::scheduleTaskGetLocation() {
-  // The VPN needs to be off in order to determine the client's real location.
-  if (!m_private->m_location.initialized()) {
-    Controller::State st = m_private->m_controller.state();
-    if (st == Controller::StateOff || st == Controller::StateInitializing) {
-      TaskScheduler::scheduleTask(
-          new TaskGetLocation(ErrorHandler::PropagateError));
-    }
-  }
 }
 
 void MozillaVPN::logout() {
@@ -1661,13 +1650,20 @@ void MozillaVPN::scheduleRefreshDataTasks(bool refreshProducts) {
           TaskGetSubscriptionDetails::NoAuthenticationFlow,
           ErrorHandler::PropagateError)};
 
-  // TaskGetLocation needs to complete before TaskServers in case this triggers
-  // an automatic server selection.
+  // The VPN needs to be off in order to determine the client's real location.
+  // And it also needs to complete before TaskServers in case this triggers an
+  // automatic server selection.
   //
   // TODO: This ordering requirement can be relaxed in the future once automatic
   // server selection is implemented upon activation. See JIRA issue
   // https://mozilla-hub.atlassian.net/browse/VPN-3726 for more information.
-  scheduleTaskGetLocation();
+  if (!m_private->m_location.initialized()) {
+    Controller::State st = m_private->m_controller.state();
+    if (st == Controller::StateOff || st == Controller::StateInitializing) {
+      TaskScheduler::scheduleTask(
+          new TaskGetLocation(ErrorHandler::PropagateError));
+    }
+  }
 
   if (refreshProducts) {
     if (!Feature::get(Feature::Feature_webPurchase)->isSupported()) {

--- a/src/apps/vpn/mozillavpn.h
+++ b/src/apps/vpn/mozillavpn.h
@@ -286,6 +286,8 @@ class MozillaVPN final : public QObject {
 
   bool checkCurrentDevice();
 
+  void scheduleTaskGetLocation();
+
  public slots:
   void requestAbout();
 

--- a/src/apps/vpn/mozillavpn.h
+++ b/src/apps/vpn/mozillavpn.h
@@ -286,8 +286,6 @@ class MozillaVPN final : public QObject {
 
   bool checkCurrentDevice();
 
-  void scheduleTaskGetLocation();
-
  public slots:
   void requestAbout();
 

--- a/src/apps/vpn/mozillavpn.h
+++ b/src/apps/vpn/mozillavpn.h
@@ -291,7 +291,7 @@ class MozillaVPN final : public QObject {
  public slots:
   void requestAbout();
 
-  Q_INVOKABLE void scheduleRefreshDataTasks(bool refreshProducts);
+  void scheduleRefreshDataTasks(bool refreshProducts);
 
   static void registerUrlOpenerLabels();
 

--- a/src/apps/vpn/mozillavpn.h
+++ b/src/apps/vpn/mozillavpn.h
@@ -89,6 +89,7 @@ class MozillaVPN final : public QObject {
   Q_PROPERTY(bool updating READ updating NOTIFY updatingChanged)
   Q_PROPERTY(bool stagingMode READ stagingMode CONSTANT)
   Q_PROPERTY(bool debugMode READ debugMode CONSTANT)
+  Q_PROPERTY(QString countryCode READ countryCode CONSTANT)
 
  public:
   MozillaVPN();
@@ -285,6 +286,8 @@ class MozillaVPN final : public QObject {
   void maybeRegenerateDeviceKey();
 
   bool checkCurrentDevice();
+
+  QString countryCode();
 
  public slots:
   void requestAbout();

--- a/src/apps/vpn/mozillavpn.h
+++ b/src/apps/vpn/mozillavpn.h
@@ -289,7 +289,7 @@ class MozillaVPN final : public QObject {
  public slots:
   void requestAbout();
 
-  void scheduleRefreshDataTasks(bool refreshProducts);
+  Q_INVOKABLE void scheduleRefreshDataTasks(bool refreshProducts);
 
   static void registerUrlOpenerLabels();
 

--- a/src/apps/vpn/mozillavpn.h
+++ b/src/apps/vpn/mozillavpn.h
@@ -89,7 +89,6 @@ class MozillaVPN final : public QObject {
   Q_PROPERTY(bool updating READ updating NOTIFY updatingChanged)
   Q_PROPERTY(bool stagingMode READ stagingMode CONSTANT)
   Q_PROPERTY(bool debugMode READ debugMode CONSTANT)
-  Q_PROPERTY(QString countryCode READ countryCode CONSTANT)
 
  public:
   MozillaVPN();
@@ -286,8 +285,6 @@ class MozillaVPN final : public QObject {
   void maybeRegenerateDeviceKey();
 
   bool checkCurrentDevice();
-
-  QString countryCode();
 
  public slots:
   void requestAbout();

--- a/src/apps/vpn/platforms/android/androidiaphandler.cpp
+++ b/src/apps/vpn/platforms/android/androidiaphandler.cpp
@@ -279,6 +279,7 @@ void AndroidIAPHandler::updateProductsInfo(const QJsonArray& returnedProducts) {
     productData->m_price = product[QString("totalPriceString")].toString();
     productData->m_monthlyPrice =
         product[QString("monthlyPriceString")].toString();
+    productData->m_currencyCode = product[QString("currencyCode")].toString();
     productData->m_nonLocalizedMonthlyPrice =
         product[QString("monthlyPrice")].toDouble();
 

--- a/src/apps/vpn/platforms/ios/iosiaphandler.mm
+++ b/src/apps/vpn/platforms/ios/iosiaphandler.mm
@@ -315,6 +315,7 @@ void IOSIAPHandler::productRegistered(void* a_product) {
   productData->m_trialDays = discountDays;
   productData->m_monthlyPrice = monthlyPriceValue;
   productData->m_nonLocalizedMonthlyPrice = [monthlyPriceNS doubleValue];
+  productData->m_currencyCode = QString::fromNSString(product.priceLocale.currencyCode);
   productData->m_extra = product;
 }
 

--- a/src/apps/vpn/platforms/wasm/wasmiaphandler.cpp
+++ b/src/apps/vpn/platforms/wasm/wasmiaphandler.cpp
@@ -41,6 +41,7 @@ void WasmIAPHandler::nativeRegisterProducts() {
     product.m_nonLocalizedMonthlyPrice = 123;
     product.m_currencyCode = QStringList({"USD", "CAD", "EUR"})
                                  .at(QRandomGenerator::system()->bounded(0, 3));
+  }
 
   QTimer::singleShot(200, this, []() {
     emit ProductsHandler::instance()->productsRegistrationCompleted();

--- a/src/apps/vpn/platforms/wasm/wasmiaphandler.cpp
+++ b/src/apps/vpn/platforms/wasm/wasmiaphandler.cpp
@@ -39,6 +39,7 @@ void WasmIAPHandler::nativeRegisterProducts() {
             .arg(QRandomGenerator::system()->bounded(1, 100));
     product.m_trialDays = trialDays--;
     product.m_nonLocalizedMonthlyPrice = 123;
+    product.m_currencyCode = QStringList({"USD", "CAD", "EUR"}).at(QRandomGenerator::system()->bounded(0, 3))
   }
 
   QTimer::singleShot(200, this, []() {

--- a/src/apps/vpn/platforms/wasm/wasmiaphandler.cpp
+++ b/src/apps/vpn/platforms/wasm/wasmiaphandler.cpp
@@ -39,8 +39,8 @@ void WasmIAPHandler::nativeRegisterProducts() {
             .arg(QRandomGenerator::system()->bounded(1, 100));
     product.m_trialDays = trialDays--;
     product.m_nonLocalizedMonthlyPrice = 123;
-    product.m_currencyCode = QStringList({"USD", "CAD", "EUR"}).at(QRandomGenerator::system()->bounded(0, 3))
-  }
+    product.m_currencyCode = QStringList({"USD", "CAD", "EUR"})
+                                 .at(QRandomGenerator::system()->bounded(0, 3));
 
   QTimer::singleShot(200, this, []() {
     emit ProductsHandler::instance()->productsRegistrationCompleted();

--- a/src/apps/vpn/productshandler.cpp
+++ b/src/apps/vpn/productshandler.cpp
@@ -178,6 +178,7 @@ QHash<int, QByteArray> ProductsHandler::roleNames() const {
   roles[ProductIdentifierRole] = "productIdentifier";
   roles[ProductPriceRole] = "productPrice";
   roles[ProductMonthlyPriceRole] = "productMonthlyPrice";
+  roles[ProductCurrencyCodeRole] = "productCurrencyCode";
   roles[ProductTrialDaysRole] = "productTrialDays";
   roles[ProductTypeRole] = "productType";
   roles[ProductFeaturedRole] = "productFeatured";
@@ -207,6 +208,9 @@ QVariant ProductsHandler::data(const QModelIndex& index, int role) const {
 
     case ProductMonthlyPriceRole:
       return QVariant(m_products.at(index.row()).m_monthlyPrice);
+
+    case ProductCurrencyCodeRole:
+      return QVariant(m_products.at(index.row()).m_currencyCode);
 
     case ProductTypeRole:
       return QVariant(m_products.at(index.row()).m_type);

--- a/src/apps/vpn/productshandler.h
+++ b/src/apps/vpn/productshandler.h
@@ -26,6 +26,7 @@ class ProductsHandler : public QAbstractListModel {
     ProductIdentifierRole = Qt::UserRole + 1,
     ProductPriceRole,
     ProductMonthlyPriceRole,
+    ProductCurrencyCodeRole,
     ProductTypeRole,
     ProductFeaturedRole,
     ProductSavingsRole,
@@ -36,6 +37,7 @@ class ProductsHandler : public QAbstractListModel {
     QString m_name;
     QString m_price;
     QString m_monthlyPrice;
+    QString m_currencyCode;
     int m_trialDays = 0;
     // This is not exposed and it's not localized. It's used to compute the
     // saving %.

--- a/src/apps/vpn/ui/screens/settings/ViewSubscriptionManagement/ViewSubscriptionManagement.qml
+++ b/src/apps/vpn/ui/screens/settings/ViewSubscriptionManagement/ViewSubscriptionManagement.qml
@@ -280,17 +280,21 @@ VPNViewBase {
     function getPlanText(currencyCode, amount) {
         const amountDisplay = (amount || 0) / 100;
         const localizedCurrency = VPNLocalizer.localizeCurrency(amountDisplay, currencyCode);
+        const isUsOrCa = VPN.countryCode === "US" || VPN.countryCode === "CA"
 
         switch (VPNSubscriptionData.planBillingInterval) {
             case VPNSubscriptionData.BillingIntervalMonthly:
                 // {¤amount} Monthly
-                return VPNI18n.SubscriptionManagementPlanValueMonthly.arg(localizedCurrency);
+                return isUsOrCa ? VPNI18n.SubscriptionManagementPlanValueMonthlyPlusTax.arg(localizedCurrency)
+                                : VPNI18n.SubscriptionManagementPlanValueMonthly.arg(localizedCurrency);
             case VPNSubscriptionData.BillingIntervalHalfYearly:
                 // {¤amount} Half-yearly
-                return VPNI18n.SubscriptionManagementPlanValueHalfYearly.arg(localizedCurrency);
+                return isUsOrCa ? VPNI18n.SubscriptionManagementPlanValueHalfYearlyPlusTax.arg(localizedCurrency)
+                                : VPNI18n.SubscriptionManagementPlanValueHalfYearly.arg(localizedCurrency);
             case VPNSubscriptionData.BillingIntervalYearly:
                 // {¤amount} Yearly
-                return VPNI18n.SubscriptionManagementPlanValueYearly.arg(localizedCurrency);
+                return isUsOrCa ? VPNI18n.SubscriptionManagementPlanValueYearlyPlusTax.arg(localizedCurrency)
+                                : VPNI18n.SubscriptionManagementPlanValueYearly.arg(localizedCurrency);
             default:
                 // If we made it here something went wrong. In case we encounter
                 // an unhandled TypeBillingInterval we should have should have

--- a/src/apps/vpn/ui/screens/settings/ViewSubscriptionManagement/ViewSubscriptionManagement.qml
+++ b/src/apps/vpn/ui/screens/settings/ViewSubscriptionManagement/ViewSubscriptionManagement.qml
@@ -280,20 +280,19 @@ VPNViewBase {
     function getPlanText(currencyCode, amount) {
         const amountDisplay = (amount || 0) / 100;
         const localizedCurrency = VPNLocalizer.localizeCurrency(amountDisplay, currencyCode);
-        const isUsdOrCad = ["USD", "CAD"].includes(VPNSubscriptionData.planCurrency)
 
         switch (VPNSubscriptionData.planBillingInterval) {
             case VPNSubscriptionData.BillingIntervalMonthly:
                 // {¤amount} Monthly
-                return isUsdOrCad ? VPNI18n.SubscriptionManagementPlanValueMonthlyPlusTax.arg(localizedCurrency)
+                return VPNSubscriptionData.planRequiresTax ? VPNI18n.SubscriptionManagementPlanValueMonthlyPlusTax.arg(localizedCurrency)
                                 : VPNI18n.SubscriptionManagementPlanValueMonthly.arg(localizedCurrency);
             case VPNSubscriptionData.BillingIntervalHalfYearly:
                 // {¤amount} Half-yearly
-                return isUsdOrCad ? VPNI18n.SubscriptionManagementPlanValueHalfYearlyPlusTax.arg(localizedCurrency)
+                return VPNSubscriptionData.planRequiresTax ? VPNI18n.SubscriptionManagementPlanValueHalfYearlyPlusTax.arg(localizedCurrency)
                                 : VPNI18n.SubscriptionManagementPlanValueHalfYearly.arg(localizedCurrency);
             case VPNSubscriptionData.BillingIntervalYearly:
                 // {¤amount} Yearly
-                return isUsdOrCad ? VPNI18n.SubscriptionManagementPlanValueYearlyPlusTax.arg(localizedCurrency)
+                return VPNSubscriptionData.planRequiresTax ? VPNI18n.SubscriptionManagementPlanValueYearlyPlusTax.arg(localizedCurrency)
                                 : VPNI18n.SubscriptionManagementPlanValueYearly.arg(localizedCurrency);
             default:
                 // If we made it here something went wrong. In case we encounter

--- a/src/apps/vpn/ui/screens/settings/ViewSubscriptionManagement/ViewSubscriptionManagement.qml
+++ b/src/apps/vpn/ui/screens/settings/ViewSubscriptionManagement/ViewSubscriptionManagement.qml
@@ -280,20 +280,20 @@ VPNViewBase {
     function getPlanText(currencyCode, amount) {
         const amountDisplay = (amount || 0) / 100;
         const localizedCurrency = VPNLocalizer.localizeCurrency(amountDisplay, currencyCode);
-        const isUsOrCa = VPN.countryCode === "US" || VPN.countryCode === "CA"
+        const isUsdOrCad = ["USD", "CAD"].includes(VPNSubscriptionData.planCurrency)
 
         switch (VPNSubscriptionData.planBillingInterval) {
             case VPNSubscriptionData.BillingIntervalMonthly:
                 // {¤amount} Monthly
-                return isUsOrCa ? VPNI18n.SubscriptionManagementPlanValueMonthlyPlusTax.arg(localizedCurrency)
+                return isUsdOrCad ? VPNI18n.SubscriptionManagementPlanValueMonthlyPlusTax.arg(localizedCurrency)
                                 : VPNI18n.SubscriptionManagementPlanValueMonthly.arg(localizedCurrency);
             case VPNSubscriptionData.BillingIntervalHalfYearly:
                 // {¤amount} Half-yearly
-                return isUsOrCa ? VPNI18n.SubscriptionManagementPlanValueHalfYearlyPlusTax.arg(localizedCurrency)
+                return isUsdOrCad ? VPNI18n.SubscriptionManagementPlanValueHalfYearlyPlusTax.arg(localizedCurrency)
                                 : VPNI18n.SubscriptionManagementPlanValueHalfYearly.arg(localizedCurrency);
             case VPNSubscriptionData.BillingIntervalYearly:
                 // {¤amount} Yearly
-                return isUsOrCa ? VPNI18n.SubscriptionManagementPlanValueYearlyPlusTax.arg(localizedCurrency)
+                return isUsdOrCad ? VPNI18n.SubscriptionManagementPlanValueYearlyPlusTax.arg(localizedCurrency)
                                 : VPNI18n.SubscriptionManagementPlanValueYearly.arg(localizedCurrency);
             default:
                 // If we made it here something went wrong. In case we encounter

--- a/src/apps/vpn/ui/screens/subscriptionNeeded/ViewSubscriptionNeededIAP.qml
+++ b/src/apps/vpn/ui/screens/subscriptionNeeded/ViewSubscriptionNeededIAP.qml
@@ -189,4 +189,8 @@ VPNFlickable {
             }
         }
     }
+
+    Component.onCompleted: {
+        VPN.scheduleRefreshDataTasks(false)
+    }
 }

--- a/src/apps/vpn/ui/screens/subscriptionNeeded/ViewSubscriptionNeededIAP.qml
+++ b/src/apps/vpn/ui/screens/subscriptionNeeded/ViewSubscriptionNeededIAP.qml
@@ -189,8 +189,4 @@ VPNFlickable {
             }
         }
     }
-
-    Component.onCompleted: {
-        VPN.scheduleRefreshDataTasks(false)
-    }
 }

--- a/src/apps/vpn/ui/screens/subscriptionNeeded/ViewSubscriptionNeededIAP.qml
+++ b/src/apps/vpn/ui/screens/subscriptionNeeded/ViewSubscriptionNeededIAP.qml
@@ -63,20 +63,17 @@ VPNFlickable {
             Layout.alignment: Qt.AlignHCenter
 
             VPNCallout {
-                //% "No activity logs"
-                calloutCopy: qsTrId("vpn.subscription.featureTitle1")
+                calloutCopy: VPNI18n.SubscriptionManagementValueProp1
                 calloutImage: "qrc:/ui/resources/onboarding/onboarding4.svg"
             }
 
             VPNCallout {
-                // "Device level encryption" - String defined in ViewOnboarding.qml
-                calloutCopy: qsTrId("vpn.onboarding.headline.1")
+                calloutCopy: VPNI18n.SubscriptionManagementValueProp2
                 calloutImage: "qrc:/ui/resources/onboarding/onboarding1.svg"
             }
 
             VPNCallout {
-                // Servers in 30+ countries - String defined in ViewOnboarding.qml
-                calloutCopy: qsTrId("vpn.onboarding.headline.2")
+                calloutCopy: VPNI18n.SubscriptionManagementValueProp3
                 calloutImage: "qrc:/ui/resources/onboarding/onboarding2.svg"
             }
 

--- a/tests/functional/testSubscription.js
+++ b/tests/functional/testSubscription.js
@@ -266,7 +266,7 @@ describe('Subscription view', function() {
             interval: 'year',
             interval_count: 1
           },
-          expected: '$1.23 Yearly'
+          expected: '$1.23 Yearly + tax'
         }
       },
       {
@@ -278,7 +278,7 @@ describe('Subscription view', function() {
             interval: 'month',
             interval_count: 6
           },
-          expected: '$1.23 Half-yearly'
+          expected: '$1.23 Half-yearly + tax'
         }
       },
       {
@@ -290,7 +290,7 @@ describe('Subscription view', function() {
             interval: 'month',
             interval_count: 1
           },
-          expected: '$1.23 Monthly'
+          expected: '$1.23 Monthly + tax'
         }
       },
       {
@@ -660,7 +660,7 @@ describe('Subscription view', function() {
             interval: 'year',
             interval_count: 1
           },
-          expected: '$1.23 Yearly'
+          expected: '$1.23 Yearly + tax'
         };
       }
       if (!('payment' in data)) {

--- a/translations/strings.yaml
+++ b/translations/strings.yaml
@@ -673,13 +673,19 @@ subscriptionManagement:
     comment: The %1 represents a localized currency string.
   planValueMonthlyPlusTax:
     value: "%1 Monthly + tax"
-    comment: The %1 represents a localized currency string. This string is only used in US and Canada
+    comment: The %1 represents a localized currency string
   planValueHalfYearlyPlusTax:
     value: "%1 Half-yearly + tax"
-    comment: The %1 represents a localized currency string. This string is only used in US and Canada
+    comment: The %1 represents a localized currency string
   planValueYearlyPlusTax:
     value: "%1 Yearly + tax"
-    comment: The %1 represents a localized currency string. This string is only used in US and Canada
+    comment: The %1 represents a localized currency string
+  planMonthly:
+    value: Monthly plan: %1
+    comment: Price for a monthly subscription. %1 represents the localized currency string
+  planMonthlyPlusTax:
+    value: %1/month + tax"
+    comment: Price for a monthly subscription plus tax. %1 represents the localized currency string
   statusLabel:
     value: Status
     comment: Label for the current status of the subscription.

--- a/translations/strings.yaml
+++ b/translations/strings.yaml
@@ -683,6 +683,9 @@ subscriptionManagement:
   planMonthly:
     value: "Monthly plan: %1"
     comment: Price for a monthly subscription. %1 represents the localized currency string
+  planMonthlyWithoutTax:
+    value: "%1/month"
+    comment: Price for a monthly subscription without tax. %1 represents the localized currency string
   planMonthlyPlusTax:
     value: "%1/month + tax"
     comment: Price for a monthly subscription plus tax. %1 represents the localized currency string
@@ -724,9 +727,15 @@ subscriptionManagement:
   addFirefoxRelay:
     value: Add Firefox Relay
     comment: Block of text appearing above a link to learn more about the VPN / Relay bundle offering.
-  valueProp1: No logging of your network activity
-  valueProp2: No one can track you
-  valueProp3: 500+ servers in 30+ countries
+  valueProp1:
+    value: No logging of your network activity
+    comment: Value proposition used to upsell the product
+  valueProp2:
+    value: No one can track you
+    comment: Value proposition used to upsell the product
+  valueProp3:
+    value: 500+ servers in 30+ countries
+    comment: Value proposition used to upsell the product
 
 paymentMethods:
   amex: American Express

--- a/translations/strings.yaml
+++ b/translations/strings.yaml
@@ -681,10 +681,10 @@ subscriptionManagement:
     value: "%1 Yearly + tax"
     comment: The %1 represents a localized currency string
   planMonthly:
-    value: Monthly plan: %1
+    value: "Monthly plan: %1"
     comment: Price for a monthly subscription. %1 represents the localized currency string
   planMonthlyPlusTax:
-    value: %1/month + tax"
+    value: "%1/month + tax"
     comment: Price for a monthly subscription plus tax. %1 represents the localized currency string
   statusLabel:
     value: Status
@@ -724,6 +724,9 @@ subscriptionManagement:
   addFirefoxRelay:
     value: Add Firefox Relay
     comment: Block of text appearing above a link to learn more about the VPN / Relay bundle offering.
+  valueProp1: No logging of your network activity
+  valueProp2: No one can track you
+  valueProp3: 500+ servers in 30+ countries
 
 paymentMethods:
   amex: American Express

--- a/translations/strings.yaml
+++ b/translations/strings.yaml
@@ -671,6 +671,15 @@ subscriptionManagement:
   planValueYearly:
     value: "%1 Yearly"
     comment: The %1 represents a localized currency string.
+  planValueMonthlyPlusTax:
+    value: "%1 Monthly + tax"
+    comment: The %1 represents a localized currency string. This string is only used in US and Canada
+  planValueHalfYearlyPlusTax:
+    value: "%1 Half-yearly + tax"
+    comment: The %1 represents a localized currency string. This string is only used in US and Canada
+  planValueYearlyPlusTax:
+    value: "%1 Yearly + tax"
+    comment: The %1 represents a localized currency string. This string is only used in US and Canada
   statusLabel:
     value: Status
     comment: Label for the current status of the subscription.

--- a/translations/strings.yaml
+++ b/translations/strings.yaml
@@ -729,13 +729,13 @@ subscriptionManagement:
     comment: Block of text appearing above a link to learn more about the VPN / Relay bundle offering.
   valueProp1:
     value: No logging of your network activity
-    comment: Value proposition used to upsell the product
+    comment: Value proposition used to promote the product
   valueProp2:
     value: No one can track you
-    comment: Value proposition used to upsell the product
+    comment: Value proposition used to promote the product
   valueProp3:
     value: 500+ servers in 30+ countries
-    comment: Value proposition used to upsell the product
+    comment: Value proposition used to promote the product
 
 paymentMethods:
   amex: American Express


### PR DESCRIPTION
## Description

Subscription management screen: 
- Add "+ tax" string to the subscription plan value in the subscription management view for US + Canada based users

Mobile IAP screen: 
- Update value props to match new content
- Add "+ tax" to US and Canadian pricing sublabels
- Update monthly plan content to match other pricing tiers

~*Note: [VPN-3284](https://mozilla-hub.atlassian.net/browse/VPN-3284) depends on https://github.com/mozilla-services/guardian-website/pull/1610 to call this API before showing the mobile IAP screen~ we now use currency code from the respective mobile app stores to determine whether or not a product is subject to tax (instead of location of account creation via Guardian ip lookup)

## Reference

[VPN-3292: Implement change in the in-app Subscription Management page to mention US and Canada prices are '+ tax'](https://mozilla-hub.atlassian.net/browse/VPN-3292)
[VPN-3284: Implement change in the in-app mobile pricing page to mention that US and Canada prices are '+ tax'.](https://mozilla-hub.atlassian.net/browse/VPN-3284)

[VPN-3284]: https://mozilla-hub.atlassian.net/browse/VPN-3284?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ