### PR TITLE
Fix sign-comparison compiler error on i386 builds.

### DIFF
--- a/src/apps/vpn/models/servercountrymodel.cpp
+++ b/src/apps/vpn/models/servercountrymodel.cpp
@@ -288,17 +288,17 @@ QList<QVariant> ServerCountryModel::recommendedLocations(
 #endif
 
     // Insert into the result list
-    unsigned int i;
+    qsizetype i;
     for (i = 0; i < rankResults.count(); i++) {
       if (rankResults[i] < cityRanking) {
         break;
       }
     }
-    if (i < maxResults) {
+    if (i < static_cast<qsizetype>(maxResults)) {
       rankResults.insert(i, cityRanking);
       cityResults.insert(i, QVariant::fromValue(&city));
     }
-    if (rankResults.count() > maxResults) {
+    if (rankResults.count() > static_cast<qsizetype>(maxResults)) {
       rankResults.resize(maxResults);
       cityResults.resize(maxResults);
     }

--- a/src/apps/vpn/platforms/linux/daemon/wireguardutilslinux.cpp
+++ b/src/apps/vpn/platforms/linux/daemon/wireguardutilslinux.cpp
@@ -576,7 +576,7 @@ bool WireguardUtilsLinux::rtmSendRule(int action, int flags, int addrfamily) {
   nlmsg_append_attr32(nlmsg, sizeof(buf), FRA_TABLE, WG_ROUTE_TABLE);
   ssize_t result = sendto(m_nlsock, buf, nlmsg->nlmsg_len, 0,
                           (struct sockaddr*)&nladdr, sizeof(nladdr));
-  if (result != nlmsg->nlmsg_len) {
+  if (result != static_cast<ssize_t>(nlmsg->nlmsg_len)) {
     return false;
   }
 
@@ -597,7 +597,7 @@ bool WireguardUtilsLinux::rtmSendRule(int action, int flags, int addrfamily) {
   nlmsg_append_attr32(nlmsg, sizeof(buf), FRA_SUPPRESS_PREFIXLEN, 0);
   result = sendto(m_nlsock, buf, nlmsg->nlmsg_len, 0, (struct sockaddr*)&nladdr,
                   sizeof(nladdr));
-  if (result != nlmsg->nlmsg_len) {
+  if (result != static_cast<ssize_t>(nlmsg->nlmsg_len)) {
     return false;
   }
 
@@ -647,7 +647,7 @@ bool WireguardUtilsLinux::rtmSendExclude(int action, int flags,
 
   ssize_t result = sendto(m_nlsock, buf, nlmsg->nlmsg_len, 0,
                           (struct sockaddr*)&nladdr, sizeof(nladdr));
-  if (result != nlmsg->nlmsg_len) {
+  if (result != static_cast<ssize_t>(nlmsg->nlmsg_len)) {
     return false;
   }
 


### PR DESCRIPTION
## Description
After turning on `-Werror` for our builds, I have been getting build errors from the PPA automation job when trying to compile the VPN client for Ubuntu/bionic and targeting the i386 architecture. This is truly the lowest-of-low issues, but it fills my inbox with junk and so it must be fixed.

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
