### PR TITLE
VPN-4048: Use the default nameserver in the benchmark test

### DIFF
--- a/src/apps/vpn/connectionbenchmark/benchmarktasktransfer.cpp
+++ b/src/apps/vpn/connectionbenchmark/benchmarktasktransfer.cpp
@@ -15,10 +15,6 @@
 #include "networkrequest.h"
 #include "uploaddatagenerator.h"
 
-#if !defined(MZ_DUMMY) && !defined(MZ_ANDROID) && !defined(MZ_WASM)
-constexpr const char* MULLVAD_DEFAULT_DNS = "10.64.0.1";
-#endif
-
 namespace {
 Logger logger("BenchmarkTaskTransfer");
 }
@@ -54,7 +50,6 @@ void BenchmarkTaskTransfer::handleState(BenchmarkTask::State state) {
     createNetworkRequest();
 #else
     // Start DNS resolution
-    m_dnsLookup.setNameserver(QHostAddress(MULLVAD_DEFAULT_DNS));
     m_dnsLookup.lookup();
 #endif
 


### PR DESCRIPTION
## Description
The download benchmark task that runs as a part of the speed test/CI screen is using a hardcoded DNS server of 10.64.0.1 (otherwise known as the default mullvad DNS server), but when we setup the windows kill switch, we permit DNS traffic *only* for the user's selected DNS server. This leads to a situation where the speedtest fails if the user has selected any DNS server other than the default.

I don't think we really need to force the address of the nameserver anyways, we can just rely on the system's nameserver which ought to be a more representative test of the network anyways.

## Reference
Github issue #5834 ([VPN-4048](https://mozilla-hub.atlassian.net/browse/VPN-4048))

## Checklist
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-4048]: https://mozilla-hub.atlassian.net/browse/VPN-4048?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ