### PR TITLE
VPN-4131 - Implement addon session state

### DIFF
--- a/docs/add-on.md
+++ b/docs/add-on.md
@@ -65,7 +65,7 @@ Session state is _not_ persisted throughout user sessions i.e. it is wiped once 
 
 ### Local state
 
-> **Note**: Global state is not supported yet, if you need to implement an addon that requires it please refer to [VPN-3929](https://mozilla-hub.atlassian.net/browse/VPN-3929).
+> **Note**: Local state is not supported yet, if you need to implement an addon that requires it please refer to [VPN-3929](https://mozilla-hub.atlassian.net/browse/VPN-3929).
 
 Local state is persisted throughout user sessions i.e. not wiped after the application is killed. It is _not_ synced among the devices of a given user. It is local to each device.
 

--- a/docs/add-on.md
+++ b/docs/add-on.md
@@ -27,10 +27,54 @@ least a manifest.json file. The properties of this JSON file are:
 | name | The name of the add-on | String | Yes |
 | api_version | The version of the add-on framework | String | Yes |
 | type | One of the supported types (message, guide, tutorial, ...) | String | Yes |
-| conditions | List of conditions to met | Array of Condition objects | No |
+| conditions | List of conditions to meet | Array of Condition objects | No |
+| state | Object describing the state of the addon | Collection of state objects | No |
 
-Based on the add-on type, extra properties can be included. See the [tutorial](https://github.com/mozilla-mobile/mozilla-vpn-client/blob/main/docs/tutorials.md),
+Based on the add-on type, extra properties can be in added. See the [tutorial](https://github.com/mozilla-mobile/mozilla-vpn-client/blob/main/docs/tutorials.md),
 [guide](https://github.com/mozilla-mobile/mozilla-vpn-client/blob/main/docs/guides.md), and [message](https://github.com/mozilla-mobile/mozilla-vpn-client/blob/main/docs/message.md) documentation.
+
+## State Object
+
+An addon may have three different types of state: `session`, `local` or `global`.
+
+| Property | Description | Type | Required |
+| --- | --- | --- | --- |
+| session | An object describing the addons session state | State | No |
+| local | An object describing the addons local state | State | No |
+| global | An object describing the addons global state | State | No |
+
+The `State` interface is the same, regardless of the type of state.
+There is no limit of properties for a state, however the only supported state types are `string`, `number` and `boolean`.
+The state object may _not_ be nested.
+
+Following is the state interface, described using Typescript notation.
+
+```ts
+interface State {
+    [key: string]: {
+        type: “string” | “number” | “boolean”,
+        default: string | number | boolean,
+    }
+}
+
+```
+
+### Session state
+
+Session state is _not_ persisted throughout user sessions i.e. it is wiped once the application is killed.
+
+### Local state
+
+> **Note**: Global state is not supported yet, if you need to implement an addon that requires it please refer to [VPN-3929](https://mozilla-hub.atlassian.net/browse/VPN-3929).
+
+Local state is persisted throughout user sessions i.e. not wiped after the application is killed. It is _not_ synced among the devices of a given user. It is local to each device.
+
+### Global state
+
+> **Note**: Global state is not supported yet, if you need to implement an addon that requires it please refer to [VPN-2795](https://mozilla-hub.atlassian.net/browse/VPN-2795).
+
+Global state is persisted throughout user sessions and synced among user devices.
+
 
 ## Condition object
 
@@ -48,7 +92,7 @@ Add-ons can enable and disable themselves using the `conditions` key in the mani
 | trigger_time | A number identifying the number of seconds from the first execution of the client | Integer |  No | Yes |
 | start_time | The epoch time that activates the current add-on | Integer | No | Yes |
 | end_time | The epoch time that deactivates the current add-on | Integer | No | Yes |
-| javascript | A script file is executed to change the condition status. See below | String | No | Yes | 
+| javascript | A script file is executed to change the condition status. See below | String | No | Yes |
 | translation_threshold | The translation threshold to use. By default 1 (full translation required) | Number | No | No |
 
 Some conditions are dynamic. This means that the value can change their status dynamically during the app execution.
@@ -69,7 +113,7 @@ The list of setting keys can be found here: https://github.com/mozilla-mobile/mo
 
 ### Javascript conditions
 
-When the add-on manifest contains a `javascript` property in the `conditions` object, its value must be a javascript filename. 
+When the add-on manifest contains a `javascript` property in the `conditions` object, its value must be a javascript filename.
 
 The javascript file is executed when the add-on is loaded and it has to expose a function. For instance:
 

--- a/scripts/ci/jsonSchemas/addon.json
+++ b/scripts/ci/jsonSchemas/addon.json
@@ -26,6 +26,39 @@
     "conditions": {
       "$ref": "conditions.json"
     },
+    "state": {
+      "type": "object",
+      "description": "State properties related to the addon",
+      "properties": {
+        "session": {
+          "type": "object",
+          "description": "Session state is not synced across user devices and is not persisted throughout device sessions",
+          "additionalProperties": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "enum": [
+                  "boolean",
+                  "string",
+                  "number"
+                ]
+              },
+              "default": {
+                "type": [
+                  "integer",
+                  "string",
+                  "boolean"
+                ]
+              }
+            },
+            "required": [
+              "type",
+              "default"
+            ]
+          }
+        }
+      }
+    },
     "tutorial": {
       "$ref": "tutorial.json#"
     },
@@ -39,6 +72,10 @@
       "$ref": "javascript.json#"
     }
   },
-  "required": [ "id", "name", "api_version", "type" ]
+  "required": [
+    "id",
+    "name",
+    "api_version",
+    "type"
+  ]
 }
-

--- a/src/apps/vpn/addons/addon.cpp
+++ b/src/apps/vpn/addons/addon.cpp
@@ -382,7 +382,7 @@ Addon* Addon::create(QObject* parent, const QString& manifestFileName) {
     return nullptr;
   }
 
-  addon->m_state.setManifest(obj["state"].toObject());
+  addon->m_state = new AddonState(addon, obj["state"].toObject());
 
   QJsonObject javascript = obj["javascript"].toObject();
   if (!addon->evaluateJavascript(javascript)) {

--- a/src/apps/vpn/addons/addon.cpp
+++ b/src/apps/vpn/addons/addon.cpp
@@ -32,6 +32,7 @@
 #include "logger.h"
 #include "qmlengineholder.h"
 #include "settingsholder.h"
+#include "state/addonsessionstate.h"
 #include "telemetry/gleansample.h"
 #include "versionutils.h"
 
@@ -380,6 +381,8 @@ Addon* Addon::create(QObject* parent, const QString& manifestFileName) {
   if (!addon) {
     return nullptr;
   }
+
+  addon->m_state.setManifest(obj["state"].toObject());
 
   QJsonObject javascript = obj["javascript"].toObject();
   if (!addon->evaluateJavascript(javascript)) {

--- a/src/apps/vpn/addons/addon.cpp
+++ b/src/apps/vpn/addons/addon.cpp
@@ -423,49 +423,49 @@ Addon::Addon(QObject* parent, const QString& manifestFileName,
   SettingsHolder* settingsHolder = SettingsHolder::instance();
   Q_ASSERT(settingsHolder);
 
-  QString stateSetting = settingsHolder->getAddonSetting(StateQuery(id));
-  QMetaEnum stateMetaEnum = QMetaEnum::fromType<State>();
+  QString statusSetting = settingsHolder->getAddonSetting(StatusQuery(id));
+  QMetaEnum statusMetaEnum = QMetaEnum::fromType<Status>();
 
-  bool isValidState = false;
-  int persistedState = stateMetaEnum.keyToValue(
-      stateSetting.toLocal8Bit().constData(), &isValidState);
+  bool isValidStatus = false;
+  int persistedStatus = statusMetaEnum.keyToValue(
+      statusSetting.toLocal8Bit().constData(), &isValidStatus);
 
-  if (isValidState) {
-    m_state = static_cast<State>(persistedState);
+  if (isValidStatus) {
+    m_status = static_cast<Status>(persistedStatus);
   }
 
-  if (m_state == Unknown) {
-    updateAddonState(Installed);
+  if (m_status == Unknown) {
+    updateAddonStatus(Installed);
   }
 }
 
 Addon::~Addon() { MZ_COUNT_DTOR(Addon); }
 
-void Addon::updateAddonState(State newState) {
-  Q_ASSERT(newState != Unknown);
+void Addon::updateAddonStatus(Status newStatus) {
+  Q_ASSERT(newStatus != Unknown);
 
-  if (m_state == newState) {
+  if (m_status == newStatus) {
     return;
   }
 
-  m_state = newState;
+  m_status = newStatus;
 
-  QMetaEnum stateMetaEnum = QMetaEnum::fromType<State>();
-  QString newStateSetting = stateMetaEnum.valueToKey(newState);
+  QMetaEnum statusMetaEnum = QMetaEnum::fromType<Status>();
+  QString newStatusSetting = statusMetaEnum.valueToKey(newStatus);
 
   SettingsHolder* settingsHolder = SettingsHolder::instance();
   Q_ASSERT(settingsHolder);
 
-  settingsHolder->setAddonSetting(StateQuery(id()), newStateSetting);
+  settingsHolder->setAddonSetting(StatusQuery(id()), newStatusSetting);
 
   mozilla::glean::sample::addon_state_changed.record(
       mozilla::glean::sample::AddonStateChangedExtra{
           ._addonId = m_id,
-          ._state = newStateSetting,
+          ._state = newStatusSetting,
       });
   emit GleanDeprecated::instance()->recordGleanEventWithExtraKeys(
       GleanSample::addonStateChanged,
-      {{"addon_id", m_id}, {"state", newStateSetting}});
+      {{"addon_id", m_id}, {"state", newStatusSetting}});
 }
 
 void Addon::retranslate() {
@@ -560,7 +560,7 @@ void Addon::enable() {
     }
   }
 
-  updateAddonState(State::Enabled);
+  updateAddonStatus(Status::Enabled);
   emit conditionChanged(true);
 }
 
@@ -581,7 +581,7 @@ void Addon::disable() {
     }
   }
 
-  updateAddonState(State::Disabled);
+  updateAddonStatus(Status::Disabled);
   emit conditionChanged(false);
 }
 

--- a/src/apps/vpn/addons/addon.h
+++ b/src/apps/vpn/addons/addon.h
@@ -58,7 +58,10 @@ class Addon : public QObject {
   const QString& id() const { return m_id; }
   const QString& type() const { return m_type; }
   const QString& manifestFileName() const { return m_manifestFileName; }
-  AddonState* state() const { return m_state; }
+  AddonState* state() const {
+    Q_ASSERT(m_state);
+    return m_state;
+  }
 
   virtual void retranslate();
 

--- a/src/apps/vpn/addons/addon.h
+++ b/src/apps/vpn/addons/addon.h
@@ -16,8 +16,8 @@ class QJsonObject;
 
 class AddonApi;
 constexpr const char* ADDON_SETTINGS_GROUP = "addon";
-constexpr const char* ADDON_DEFAULT_STATE = "Unknown";
-constexpr const char* ADDON_SETTINGS_STATE_KEY = "state";
+constexpr const char* ADDON_DEFAULT_STATUS = "Unknown";
+constexpr const char* ADDON_SETTINGS_STATUS_KEY = "state";
 
 class Addon : public QObject {
   Q_OBJECT
@@ -28,8 +28,8 @@ class Addon : public QObject {
   Q_PROPERTY(QString type READ type CONSTANT)
 
  public:
-  enum State {
-    // Initial state. This should be used only during the loading.
+  enum Status {
+    // Initial status. This should be used only during the loading.
     Unknown,
 
     // The add-on has just been installed. This is the first time the device
@@ -42,7 +42,7 @@ class Addon : public QObject {
     // The add-on is disabled.
     Disabled,
   };
-  Q_ENUM(State);
+  Q_ENUM(Status);
 
   static Addon* create(QObject* parent, const QString& manifestFileName);
 
@@ -75,16 +75,16 @@ class Addon : public QObject {
         const QString& name, const QString& type);
 
  private:
-  void updateAddonState(State newState);
+  void updateAddonStatus(Status newStatus);
 
   bool evaluateJavascript(const QJsonObject& javascript);
   bool evaluateJavascriptInternal(const QString& javascript, QJSValue* value);
 
-  struct StateQuery final : public SettingsHolder::AddonSettingQuery {
-    explicit StateQuery(const QString& ai)
+  struct StatusQuery final : public SettingsHolder::AddonSettingQuery {
+    explicit StatusQuery(const QString& ai)
         : SettingsHolder::AddonSettingQuery(ai, QString(ADDON_SETTINGS_GROUP),
-                                            QString(ADDON_SETTINGS_STATE_KEY),
-                                            QString(ADDON_DEFAULT_STATE)) {}
+                                            QString(ADDON_SETTINGS_STATUS_KEY),
+                                            QString(ADDON_DEFAULT_STATUS)) {}
   };
 
  private:
@@ -98,7 +98,7 @@ class Addon : public QObject {
   AddonApi* m_api = nullptr;
   AddonConditionWatcher* m_conditionWatcher = nullptr;
 
-  State m_state = Unknown;
+  Status m_status = Unknown;
 
   QJSValue m_jsEnableFunction;
   QJSValue m_jsDisableFunction;

--- a/src/apps/vpn/addons/addon.h
+++ b/src/apps/vpn/addons/addon.h
@@ -27,7 +27,7 @@ class Addon : public QObject {
   Q_PROPERTY(QString id READ id CONSTANT)
   Q_PROPERTY(QString name MEMBER m_name CONSTANT)
   Q_PROPERTY(QString type READ type CONSTANT)
-  Q_PROPERTY(AddonState state READ state CONSTANT)
+  Q_PROPERTY(AddonState* state READ state CONSTANT)
 
  public:
   enum Status {
@@ -58,7 +58,7 @@ class Addon : public QObject {
   const QString& id() const { return m_id; }
   const QString& type() const { return m_type; }
   const QString& manifestFileName() const { return m_manifestFileName; }
-  const AddonState state() { return m_state; }
+  AddonState* state() const { return m_state; }
 
   virtual void retranslate();
 
@@ -98,7 +98,7 @@ class Addon : public QObject {
 
   QTranslator m_translator;
 
-  AddonState m_state;
+  AddonState* m_state = nullptr;
 
   AddonApi* m_api = nullptr;
   AddonConditionWatcher* m_conditionWatcher = nullptr;

--- a/src/apps/vpn/addons/addon.h
+++ b/src/apps/vpn/addons/addon.h
@@ -10,6 +10,7 @@
 #include <QTranslator>
 
 #include "settingsholder.h"
+#include "state/addonstate.h"
 
 class AddonConditionWatcher;
 class QJsonObject;
@@ -26,6 +27,7 @@ class Addon : public QObject {
   Q_PROPERTY(QString id READ id CONSTANT)
   Q_PROPERTY(QString name MEMBER m_name CONSTANT)
   Q_PROPERTY(QString type READ type CONSTANT)
+  Q_PROPERTY(AddonState state READ state CONSTANT)
 
  public:
   enum Status {
@@ -56,6 +58,7 @@ class Addon : public QObject {
   const QString& id() const { return m_id; }
   const QString& type() const { return m_type; }
   const QString& manifestFileName() const { return m_manifestFileName; }
+  const AddonState state() { return m_state; }
 
   virtual void retranslate();
 
@@ -94,6 +97,8 @@ class Addon : public QObject {
   const QString m_type;
 
   QTranslator m_translator;
+
+  AddonState m_state;
 
   AddonApi* m_api = nullptr;
   AddonConditionWatcher* m_conditionWatcher = nullptr;

--- a/src/apps/vpn/addons/addonmessage.h
+++ b/src/apps/vpn/addons/addonmessage.h
@@ -17,8 +17,8 @@ class TestAddon;
 #endif
 
 constexpr const char* ADDON_MESSAGE_SETTINGS_GROUP = "message";
-constexpr const char* ADDON_MESSAGE_SETTINGS_STATE_KEY = "state";
-constexpr const char* ADDON_MESSAGE_DEFAULT_STATE = "Received";
+constexpr const char* ADDON_MESSAGE_SETTINGS_STATUS_KEY = "state";
+constexpr const char* ADDON_MESSAGE_DEFAULT_STATUS = "Received";
 
 class AddonMessage final : public Addon {
   Q_OBJECT
@@ -32,7 +32,7 @@ class AddonMessage final : public Addon {
                  retranslationCompleted)
 
   Q_PROPERTY(Composer* composer READ composer CONSTANT)
-  Q_PROPERTY(bool isRead READ isRead NOTIFY stateChanged)
+  Q_PROPERTY(bool isRead READ isRead NOTIFY statusChanged)
   Q_PROPERTY(qint64 date MEMBER m_date WRITE setDate NOTIFY dateChanged)
   Q_PROPERTY(
       QString formattedDate READ formattedDate NOTIFY retranslationCompleted)
@@ -47,7 +47,7 @@ class AddonMessage final : public Addon {
 
   ~AddonMessage();
 
-  enum MessageState {
+  enum MessageStatus {
     // A message has been received
     Received,
     // A notification has been shown to the user i.e it's been enabled
@@ -57,7 +57,7 @@ class AddonMessage final : public Addon {
     // Message has been dismissed
     Dismissed
   };
-  Q_ENUM(MessageState);
+  Q_ENUM(MessageStatus);
 
   Q_INVOKABLE void dismiss();
   Q_INVOKABLE void markAsRead();
@@ -66,7 +66,7 @@ class AddonMessage final : public Addon {
   void setBadge(Badge badge);
   void setDate(qint64 date);
 
-  bool isRead() const { return m_state == MessageState::Read; }
+  bool isRead() const { return m_status == MessageStatus::Read; }
 
   QString formattedDate() const;
 
@@ -79,7 +79,7 @@ class AddonMessage final : public Addon {
                                               const QDateTime& messageDateTime);
 
  signals:
-  void stateChanged(AddonMessage::MessageState state);
+  void statusChanged(AddonMessage::MessageStatus status);
   void badgeChanged();
   void dateChanged();
 
@@ -87,15 +87,15 @@ class AddonMessage final : public Addon {
   AddonMessage(QObject* parent, const QString& manifestFileName,
                const QString& id, const QString& name);
 
-  struct MessageStateQuery final : public SettingsHolder::AddonSettingQuery {
-    explicit MessageStateQuery(const QString& ai)
+  struct MessageStatusQuery final : public SettingsHolder::AddonSettingQuery {
+    explicit MessageStatusQuery(const QString& ai)
         : SettingsHolder::AddonSettingQuery(
               ai, QString(ADDON_MESSAGE_SETTINGS_GROUP),
-              QString(ADDON_MESSAGE_SETTINGS_STATE_KEY),
-              QString(ADDON_MESSAGE_DEFAULT_STATE)) {}
+              QString(ADDON_MESSAGE_SETTINGS_STATUS_KEY),
+              QString(ADDON_MESSAGE_DEFAULT_STATUS)) {}
   };
-  static MessageState loadMessageState(const QString& id);
-  void updateMessageState(MessageState newState);
+  static MessageStatus loadMessageStatus(const QString& id);
+  void updateMessageStatus(MessageStatus newStatus);
 
   void planDateRetranslation();
   void setBadge(const QString& badge);
@@ -109,7 +109,7 @@ class AddonMessage final : public Addon {
 
   qint64 m_date = 0;
 
-  MessageState m_state = MessageState::Received;
+  MessageStatus m_status = MessageStatus::Received;
 
   Badge m_badge;
 

--- a/src/apps/vpn/addons/state/addonsessionstate.cpp
+++ b/src/apps/vpn/addons/state/addonsessionstate.cpp
@@ -4,22 +4,10 @@
 
 #include "addonsessionstate.h"
 
-#include <QHash>
-#include <QJsonValue>
-#include <QObject>
-#include <QString>
-
-#include "addonstatebase.h"
 #include "leakdetector.h"
 
-// static
-AddonSessionState* AddonSessionState::fromManifest(
-    const QJsonObject& manifest) {
-  return new AddonSessionState(AddonStateBase::parseManifest(manifest));
-}
-
-AddonSessionState::AddonSessionState(QHash<QString, QJsonValue> spec)
-    : AddonStateBase(spec) {
+AddonSessionState::AddonSessionState(const QJsonObject& manifest)
+    : AddonStateBase(manifest) {
   MZ_COUNT_CTOR(AddonSessionState);
 }
 

--- a/src/apps/vpn/addons/state/addonsessionstate.cpp
+++ b/src/apps/vpn/addons/state/addonsessionstate.cpp
@@ -1,0 +1,43 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "addonsessionstate.h"
+
+#include <QHash>
+#include <QJsonValue>
+#include <QObject>
+#include <QString>
+
+#include "addonstatebase.h"
+#include "leakdetector.h"
+
+// static
+AddonSessionState* AddonSessionState::fromManifest(
+    const QJsonObject& manifest) {
+  return new AddonSessionState(AddonStateBase::parseManifest(manifest));
+}
+
+AddonSessionState::AddonSessionState(QHash<QString, QJsonValue> spec)
+    : AddonStateBase(spec) {
+  MZ_COUNT_CTOR(AddonSessionState);
+}
+
+AddonSessionState::~AddonSessionState() { MZ_COUNT_DTOR(AddonSessionState); }
+
+QJsonValue AddonSessionState::getInternal(const QString& key) const {
+  return m_state[key];
+}
+
+void AddonSessionState::setInternal(const QString& key,
+                                    const QJsonValue& value) {
+  m_state[key] = value;
+}
+
+void AddonSessionState::clearInternal(const QString& key) {
+  if (key.isEmpty()) {
+    m_state.clear();
+  }
+
+  m_state.remove(key);
+}

--- a/src/apps/vpn/addons/state/addonsessionstate.h
+++ b/src/apps/vpn/addons/state/addonsessionstate.h
@@ -1,0 +1,56 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef ADDONSESSIONSTATE_H
+#define ADDONSESSIONSTATE_H
+
+#include <QHash>
+#include <QJsonValue>
+#include <QObject>
+#include <QString>
+
+#include "addonstatebase.h"
+
+/**
+ * @brief Addon State implementation,
+ * in which state does not persist throughout restarts.
+ */
+class AddonSessionState final : public AddonStateBase {
+ public:
+  ~AddonSessionState();
+  AddonSessionState(StateHash spec);
+
+  /**
+   * @brief Construct an AddonSessionState object from the JSON object under the
+   * `state` key of an Addon's manifest.
+   *
+   * The manifest should be in the following format:
+   *
+   * ```
+   * {
+   *    [key: string]: {
+   *      "type": "boolean" | "string" | "number",
+   *      "default": boolean | string | number
+   *    }
+   * }
+   * ```
+   *
+   * Invalid properties on the manifest will be ignored. In the worst case if
+   * the manifest is completely wrong an empty state will be generated.
+   *
+   * @param manifest The addon's manifest.
+   * @return AddonState the generated state.
+   */
+  static AddonSessionState* fromManifest(const QJsonObject& manifest);
+
+ protected:
+  QJsonValue getInternal(const QString& key) const override;
+  void setInternal(const QString& key, const QJsonValue& value) override;
+  void clearInternal(const QString& key = "") override;
+
+ private:
+  StateHash m_state;
+};
+
+#endif  // ADDONSESSIONSTATE_H

--- a/src/apps/vpn/addons/state/addonsessionstate.h
+++ b/src/apps/vpn/addons/state/addonsessionstate.h
@@ -5,11 +5,6 @@
 #ifndef ADDONSESSIONSTATE_H
 #define ADDONSESSIONSTATE_H
 
-#include <QHash>
-#include <QJsonValue>
-#include <QObject>
-#include <QString>
-
 #include "addonstatebase.h"
 
 /**
@@ -19,7 +14,6 @@
 class AddonSessionState final : public AddonStateBase {
  public:
   ~AddonSessionState();
-  AddonSessionState(StateHash spec);
 
   /**
    * @brief Construct an AddonSessionState object from the JSON object under the
@@ -42,14 +36,12 @@ class AddonSessionState final : public AddonStateBase {
    * @param manifest The addon's manifest.
    * @return AddonState the generated state.
    */
-  static AddonSessionState* fromManifest(const QJsonObject& manifest);
+  AddonSessionState(const QJsonObject& manifest);
 
- protected:
+ private:
   QJsonValue getInternal(const QString& key) const override;
   void setInternal(const QString& key, const QJsonValue& value) override;
   void clearInternal(const QString& key = "") override;
-
- private:
   StateHash m_state;
 };
 

--- a/src/apps/vpn/addons/state/addonstate.h
+++ b/src/apps/vpn/addons/state/addonstate.h
@@ -6,6 +6,7 @@
 #define ADDONSTATE_H
 
 #include <QJsonObject>
+#include <QObject>
 
 #include "addonsessionstate.h"
 
@@ -18,35 +19,32 @@
  * sessions.
  *
  */
-struct AddonState {
-  Q_GADGET
+struct AddonState : public QObject {
+  Q_OBJECT
   Q_PROPERTY(AddonSessionState* session READ session)
 
  public:
-  AddonState() = default;
-  ~AddonState() { delete m_session; }
-
   /**
    * @brief Construct a new Addon State object.
    *
    * No validation is required here.
    *
    * 1. The session object construction will validate the object.
-   * 2. In case it is empty, an empty state will be generated. Empty states are
-   * allowed so that the state APIs will always be available. Attempts to record
-   * to invalid keys will simply be no-ops.
+   * 2. In case it is empty, an empty state will be generated. Empty states
+   * are allowed so that the state APIs will always be available. Attempts
+   * to record to invalid keys will simply be no-ops.
    *
    * @param manifest The JSON object in the "state" property of an addon
    * manifest.
    */
-  void setManifest(const QJsonObject& manifest) {
-    m_session = AddonSessionState::fromManifest(manifest["session"].toObject());
-  }
+  AddonState(QObject* parent, const QJsonObject& manifest)
+      : QObject(parent), m_session(manifest["session"].toObject()) {}
+  ~AddonState() = default;
 
-  AddonSessionState* session() const { return m_session; }
+  AddonSessionState* session() { return &m_session; }
 
  private:
-  AddonSessionState* m_session = nullptr;
+  AddonSessionState m_session;
 };
 
 #endif  // ADDONSTATE_H

--- a/src/apps/vpn/addons/state/addonstate.h
+++ b/src/apps/vpn/addons/state/addonstate.h
@@ -1,0 +1,52 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef ADDONSTATE_H
+#define ADDONSTATE_H
+
+#include <QJsonObject>
+
+#include "addonsessionstate.h"
+
+/**
+ * @brief Struct containing the different types of state an addon can hold.
+ *
+ * These are:
+ *
+ * - `session` state: A type of state with is not persisted throughout device
+ * sessions.
+ *
+ */
+struct AddonState {
+  Q_GADGET
+  Q_PROPERTY(AddonSessionState* session READ session)
+
+ public:
+  AddonState() = default;
+  ~AddonState() = default;
+
+  /**
+   * @brief Construct a new Addon State object.
+   *
+   * No validation is required here.
+   *
+   * 1. The session object construction will validate the object.
+   * 2. In case it is empty, an empty state will be generated. Empty states are
+   * allowed so that the state APIs will always be available. Attempts to record
+   * to invalid keys will simply be no-ops.
+   *
+   * @param manifest The JSON object in the "state" property of an addon
+   * manifest.
+   */
+  void setManifest(const QJsonObject& manifest) {
+    m_session = AddonSessionState::fromManifest(manifest["session"].toObject());
+  }
+
+  AddonSessionState* session() const { return m_session; }
+
+ private:
+  AddonSessionState* m_session = nullptr;
+};
+
+#endif  // ADDONSTATE_H

--- a/src/apps/vpn/addons/state/addonstate.h
+++ b/src/apps/vpn/addons/state/addonstate.h
@@ -24,7 +24,7 @@ struct AddonState {
 
  public:
   AddonState() = default;
-  ~AddonState() = default;
+  ~AddonState() { delete m_session; }
 
   /**
    * @brief Construct a new Addon State object.

--- a/src/apps/vpn/addons/state/addonstatebase.cpp
+++ b/src/apps/vpn/addons/state/addonstatebase.cpp
@@ -4,7 +4,6 @@
 
 #include "addonstatebase.h"
 
-#include <QHash>
 #include <QJsonObject>
 
 #include "logger.h"
@@ -31,9 +30,8 @@ QJsonValue::Type AddonStateBase::typeToQJsonValueType(QString type) {
 }
 
 // static
-QHash<QString, QJsonValue> AddonStateBase::parseManifest(
-    const QJsonObject& manifest) {
-  QHash<QString, QJsonValue> spec;
+StateHash AddonStateBase::parseManifest(const QJsonObject& manifest) {
+  StateHash spec;
 
   foreach (const QString& key, manifest.keys()) {
     QJsonValue value = manifest.value(key);
@@ -71,8 +69,8 @@ QHash<QString, QJsonValue> AddonStateBase::parseManifest(
   return spec;
 }
 
-AddonStateBase::AddonStateBase(QHash<QString, QJsonValue> spec)
-    : m_defaults(spec) {}
+AddonStateBase::AddonStateBase(const QJsonObject& spec)
+    : m_defaults(AddonStateBase::parseManifest(spec)) {}
 
 QJsonValue AddonStateBase::get(const QString& key) const {
   if (!m_defaults.contains(key)) {
@@ -108,6 +106,7 @@ void AddonStateBase::set(const QString& key, QJsonValue value) {
 void AddonStateBase::clear(const QString& key) {
   if (key.isEmpty()) {
     clearInternal();
+    return;
   }
 
   if (!m_defaults.contains(key)) {

--- a/src/apps/vpn/addons/state/addonstatebase.cpp
+++ b/src/apps/vpn/addons/state/addonstatebase.cpp
@@ -1,0 +1,122 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "addonstatebase.h"
+
+#include <QHash>
+#include <QJsonObject>
+
+#include "logger.h"
+
+namespace {
+Logger logger("AddonStateBase");
+}
+
+// static
+QJsonValue::Type AddonStateBase::typeToQJsonValueType(QString type) {
+  if (type == "boolean") {
+    return QJsonValue::Bool;
+  }
+
+  if (type == "number") {
+    return QJsonValue::Double;
+  }
+
+  if (type == "string") {
+    return QJsonValue::String;
+  }
+
+  return QJsonValue::Undefined;
+}
+
+// static
+QHash<QString, QJsonValue> AddonStateBase::parseManifest(
+    const QJsonObject& manifest) {
+  QHash<QString, QJsonValue> spec;
+
+  foreach (const QString& key, manifest.keys()) {
+    QJsonValue value = manifest.value(key);
+
+    if (!value.isObject()) {
+      logger.error() << "Addon state value for key" << key
+                     << "is incorrectly formatted. Ignoring.";
+      continue;
+    }
+
+    QJsonValue type = value["type"];
+    if (!type.isString()) {
+      logger.error() << "Addon state value for key" << key
+                     << "has is incorrect 'type' property. Ignoring.";
+      continue;
+    }
+
+    QJsonValue::Type expectedType = typeToQJsonValueType(type.toString());
+    if (expectedType == QJsonValue::Undefined) {
+      logger.error() << "Unkown type" << type.toString()
+                     << "provided for addon state property.";
+      continue;
+    }
+
+    QJsonValue def = value["default"];
+    if (def.type() != expectedType) {
+      logger.error() << "Addon state default value for key" << key
+                     << "has incorrectly typed 'default' property. Ignoring.";
+      continue;
+    }
+
+    spec.insert(key, def);
+  }
+
+  return spec;
+}
+
+AddonStateBase::AddonStateBase(QHash<QString, QJsonValue> spec)
+    : m_defaults(spec) {}
+
+QJsonValue AddonStateBase::get(const QString& key) const {
+  if (!m_defaults.contains(key)) {
+    logger.error()
+        << "Attempted to get key" << key
+        << "from addon state, but that key is invalid for this state. ";
+    return QJsonValue();
+  }
+
+  QJsonValue value = getInternal(key);
+  if (value.type() != QJsonValue::Null) return value;
+
+  return m_defaults[key];
+}
+
+void AddonStateBase::set(const QString& key, QJsonValue value) {
+  if (!m_defaults.contains(key)) {
+    logger.error() << "Attempted to set key" << key
+                   << "to addon state, but that key is invalid for this state. "
+                      "Ignoring.";
+    return;
+  }
+
+  if (value.type() != m_defaults[key].type()) {
+    logger.error() << "Attempted to set state" << key
+                   << "to value of incorrect type. Ignoring.";
+    return;
+  }
+
+  setInternal(key, value);
+}
+
+void AddonStateBase::clear(const QString& key) {
+  if (key.isEmpty()) {
+    clearInternal();
+  }
+
+  if (!m_defaults.contains(key)) {
+    logger.error()
+        << "Attempted to clear key" << key
+        << "from addon state, but that key is invalid for this state. "
+           "Ignoring.";
+    return;
+  }
+
+  clearInternal(key);
+}

--- a/src/apps/vpn/addons/state/addonstatebase.h
+++ b/src/apps/vpn/addons/state/addonstatebase.h
@@ -7,7 +7,6 @@
 
 #include <QHash>
 #include <QJsonValue>
-#include <QObject>
 #include <QString>
 
 typedef QHash<QString, QJsonValue> StateHash;
@@ -24,12 +23,11 @@ typedef QHash<QString, QJsonValue> StateHash;
  * The values can be changed, but the kays are limited to whatever is defined in
  * the addon manifest. The type of the value cannot be changed.
  */
-class AddonStateBase : public QObject {
-  Q_OBJECT
-  Q_DISABLE_COPY_MOVE(AddonStateBase)
+class AddonStateBase {
+  Q_GADGET
 
  public:
-  ~AddonStateBase() = default;
+  virtual ~AddonStateBase() {}
 
   /**
    * @brief Get the value for a given key in the state.
@@ -71,10 +69,9 @@ class AddonStateBase : public QObject {
   Q_INVOKABLE void clear(const QString& key = "");
 
  protected:
-  AddonStateBase(StateHash spec);
+  AddonStateBase(const QJsonObject& spec);
+  AddonStateBase(const StateHash& spec) : m_defaults(spec) {}
   StateHash m_defaults;
-
-  static StateHash parseManifest(const QJsonObject& manifest);
 
   // Methods to override.
   virtual QJsonValue getInternal(const QString& key) const = 0;
@@ -83,6 +80,7 @@ class AddonStateBase : public QObject {
 
  private:
   static QJsonValue::Type typeToQJsonValueType(QString type);
+  static StateHash parseManifest(const QJsonObject& manifest);
 };
 
 #endif  // ADDONSTATEBASE_H

--- a/src/apps/vpn/addons/state/addonstatebase.h
+++ b/src/apps/vpn/addons/state/addonstatebase.h
@@ -27,7 +27,7 @@ class AddonStateBase {
   Q_GADGET
 
  public:
-  virtual ~AddonStateBase() {}
+  virtual ~AddonStateBase() = default;
 
   /**
    * @brief Get the value for a given key in the state.

--- a/src/apps/vpn/addons/state/addonstatebase.h
+++ b/src/apps/vpn/addons/state/addonstatebase.h
@@ -1,0 +1,88 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef ADDONSTATEBASE_H
+#define ADDONSTATEBASE_H
+
+#include <QHash>
+#include <QJsonValue>
+#include <QObject>
+#include <QString>
+
+typedef QHash<QString, QJsonValue> StateHash;
+
+/**
+ * @brief Abstract base class describing the state of an addon.
+ *
+ * The state of an addon is a collection of properties that can change how the
+ * addon is presented or how it behaves.
+ *
+ * A given addon's state is defined in it's manifest under the `state` key. In
+ * practice, it is a dictionary of key/value pairs. The keys are strings and the
+ * values may be either boolean, numbers or strings. The keys are not dinamic.
+ * The values can be changed, but the kays are limited to whatever is defined in
+ * the addon manifest. The type of the value cannot be changed.
+ */
+class AddonStateBase : public QObject {
+  Q_OBJECT
+  Q_DISABLE_COPY_MOVE(AddonStateBase)
+
+ public:
+  ~AddonStateBase() = default;
+
+  /**
+   * @brief Get the value for a given key in the state.
+   *
+   * If key was not defined in the manifest,
+   * QJsonValue::Undefined will be returned.
+   *
+   * If the key has never been written to, the default value will be
+   * returned.
+   *
+   * @return QJsonValue The stored value for the given key. A nullptr is
+   * returned if the key is invalid i.e. not provided on the manifest on
+   * init.
+   */
+  Q_INVOKABLE QJsonValue get(const QString& key) const;
+
+  /**
+   * @brief Sets the value for a given key in the addon state.
+   *
+   * If key was not defined in the manifest, operation will be ignored.
+   *
+   * `value` must be of the type defined in the manifest,
+   * otherwise it will be ignored.
+   *
+   * @param key The key to set.
+   * @param value The value to set.
+   */
+  Q_INVOKABLE void set(const QString& key, QJsonValue value);
+
+  /**
+   * @brief Clears stored values in the state.
+   *
+   * If key was not defined in the manifest, operation will be ignored.
+   *
+   * If the key has never been written to, this is a no-op.
+   *
+   * @param key The key to clear.
+   */
+  Q_INVOKABLE void clear(const QString& key = "");
+
+ protected:
+  AddonStateBase(StateHash spec);
+  StateHash m_defaults;
+
+  static StateHash parseManifest(const QJsonObject& manifest);
+
+  // Methods to override.
+  virtual QJsonValue getInternal(const QString& key) const = 0;
+  virtual void setInternal(const QString& key, const QJsonValue& value) = 0;
+  virtual void clearInternal(const QString& key = "") = 0;
+
+ private:
+  static QJsonValue::Type typeToQJsonValueType(QString type);
+};
+
+#endif  // ADDONSTATEBASE_H

--- a/src/apps/vpn/cmake/sources.cmake
+++ b/src/apps/vpn/cmake/sources.cmake
@@ -66,6 +66,7 @@ target_sources(mozillavpn-sources INTERFACE
     ${CMAKE_CURRENT_SOURCE_DIR}/apps/vpn/addons/manager/addonindex.h
     ${CMAKE_CURRENT_SOURCE_DIR}/apps/vpn/addons/manager/addonmanager.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/apps/vpn/addons/manager/addonmanager.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/apps/vpn/addons/state/addonstate.h
     ${CMAKE_CURRENT_SOURCE_DIR}/apps/vpn/addons/state/addonstatebase.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/apps/vpn/addons/state/addonstatebase.h
     ${CMAKE_CURRENT_SOURCE_DIR}/apps/vpn/addons/state/addonsessionstate.cpp

--- a/src/apps/vpn/cmake/sources.cmake
+++ b/src/apps/vpn/cmake/sources.cmake
@@ -66,6 +66,10 @@ target_sources(mozillavpn-sources INTERFACE
     ${CMAKE_CURRENT_SOURCE_DIR}/apps/vpn/addons/manager/addonindex.h
     ${CMAKE_CURRENT_SOURCE_DIR}/apps/vpn/addons/manager/addonmanager.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/apps/vpn/addons/manager/addonmanager.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/apps/vpn/addons/state/addonstatebase.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/apps/vpn/addons/state/addonstatebase.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/apps/vpn/addons/state/addonsessionstate.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/apps/vpn/addons/state/addonsessionstate.h
     ${CMAKE_CURRENT_SOURCE_DIR}/apps/vpn/appconstants.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/apps/vpn/appconstants.h
     ${CMAKE_CURRENT_SOURCE_DIR}/apps/vpn/appfeaturelistcallback.h

--- a/src/apps/vpn/qmake/sources.pri
+++ b/src/apps/vpn/qmake/sources.pri
@@ -22,6 +22,8 @@ SOURCES += \
         apps/vpn/addons/manager/addondirectory.cpp \
         apps/vpn/addons/manager/addonindex.cpp \
         apps/vpn/addons/manager/addonmanager.cpp \
+        apps/vpn/addons/state/addonsessionstate.cpp \
+        apps/vpn/addons/state/addonstatebase.cpp \
         apps/vpn/appconstants.cpp \
         apps/vpn/apppermission.cpp \
         apps/vpn/authenticationlistener.cpp \
@@ -165,6 +167,9 @@ HEADERS += \
         apps/vpn/addons/manager/addondirectory.h \
         apps/vpn/addons/manager/addonindex.h \
         apps/vpn/addons/manager/addonmanager.h \
+        apps/vpn/addons/state/addonsessionstate.h \
+        apps/vpn/addons/state/addonstatebase.h \
+        apps/vpn/addons/state/addonstate.h \
         apps/vpn/appconstants.h \
         apps/vpn/appimageprovider.h \
         apps/vpn/apppermission.h \

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -79,6 +79,10 @@ target_sources(unit_tests PRIVATE
     ${MZ_SOURCE_DIR}/apps/vpn/addons/manager/addonindex.h
     ${MZ_SOURCE_DIR}/apps/vpn/addons/manager/addonmanager.cpp
     ${MZ_SOURCE_DIR}/apps/vpn/addons/manager/addonmanager.h
+    ${MZ_SOURCE_DIR}/apps/vpn/addons/state/addonstatebase.cpp
+    ${MZ_SOURCE_DIR}/apps/vpn/addons/state/addonstatebase.h
+    ${MZ_SOURCE_DIR}/apps/vpn/addons/state/addonsessionstate.cpp
+    ${MZ_SOURCE_DIR}/apps/vpn/addons/state/addonsessionstate.h
     ${MZ_SOURCE_DIR}/apps/vpn/adjust/adjustfiltering.cpp
     ${MZ_SOURCE_DIR}/apps/vpn/adjust/adjustfiltering.h
     ${MZ_SOURCE_DIR}/apps/vpn/adjust/adjustproxypackagehandler.cpp
@@ -309,6 +313,10 @@ target_sources(unit_tests PRIVATE
     testaddonapi.h
     testaddonindex.cpp
     testaddonindex.h
+    testaddonstatebase.cpp
+    testaddonstatebase.h
+    testaddonsessionstate.cpp
+    testaddonsessionstate.h
     testadjust.cpp
     testadjust.h
     testcommandlineparser.cpp

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -79,6 +79,7 @@ target_sources(unit_tests PRIVATE
     ${MZ_SOURCE_DIR}/apps/vpn/addons/manager/addonindex.h
     ${MZ_SOURCE_DIR}/apps/vpn/addons/manager/addonmanager.cpp
     ${MZ_SOURCE_DIR}/apps/vpn/addons/manager/addonmanager.h
+    ${MZ_SOURCE_DIR}/apps/vpn/addons/state/addonstate.h
     ${MZ_SOURCE_DIR}/apps/vpn/addons/state/addonstatebase.cpp
     ${MZ_SOURCE_DIR}/apps/vpn/addons/state/addonstatebase.h
     ${MZ_SOURCE_DIR}/apps/vpn/addons/state/addonsessionstate.cpp

--- a/tests/unit/testaddon.cpp
+++ b/tests/unit/testaddon.cpp
@@ -41,7 +41,7 @@ void TestAddon::init() {
   // Glean operations are queued and applied once Glean is initialized.
   // If we only initialize it in the test that actually tests telemetry all
   // of the Glean operations from previous tests will be applied and mess with
-  // the state of the test that actually is testing telemetry.
+  // the status of the test that actually is testing telemetry.
   //
   // Note: on tests Glean::initialize clears Glean's storage.
   MZGlean::initialize();
@@ -820,30 +820,30 @@ void TestAddon::message_create() {
   QCOMPARE(message->property("title").type(), QMetaType::QString);
 }
 
-void TestAddon::message_load_state_data() {
-  QTest::addColumn<AddonMessage::MessageState>("state");
+void TestAddon::message_load_status_data() {
+  QTest::addColumn<AddonMessage::MessageStatus>("status");
   QTest::addColumn<QString>("setting");
 
-  QTest::addRow("empty-setting") << AddonMessage::MessageState::Received << "";
+  QTest::addRow("empty-setting") << AddonMessage::MessageStatus::Received << "";
   QTest::addRow("wrong-setting")
-      << AddonMessage::MessageState::Received << "WRONG!";
+      << AddonMessage::MessageStatus::Received << "WRONG!";
 
   QTest::addRow("received")
-      << AddonMessage::MessageState::Received << "Received";
+      << AddonMessage::MessageStatus::Received << "Received";
   QTest::addRow("notified")
-      << AddonMessage::MessageState::Notified << "Notified";
-  QTest::addRow("read") << AddonMessage::MessageState::Read << "Read";
+      << AddonMessage::MessageStatus::Notified << "Notified";
+  QTest::addRow("read") << AddonMessage::MessageStatus::Read << "Read";
   QTest::addRow("dismissed")
-      << AddonMessage::MessageState::Dismissed << "Dismissed";
+      << AddonMessage::MessageStatus::Dismissed << "Dismissed";
 }
 
-void TestAddon::message_load_state() {
-  QFETCH(AddonMessage::MessageState, state);
+void TestAddon::message_load_status() {
+  QFETCH(AddonMessage::MessageStatus, status);
   QFETCH(QString, setting);
 
   SettingsHolder::instance()->setAddonSetting(
-      AddonMessage::MessageStateQuery("foo"), setting);
-  QCOMPARE(AddonMessage::loadMessageState("foo"), state);
+      AddonMessage::MessageStatusQuery("foo"), setting);
+  QCOMPARE(AddonMessage::loadMessageStatus("foo"), status);
 }
 
 void TestAddon::message_notification_data() {
@@ -991,7 +991,7 @@ void TestAddon::message_dismiss() {
             addonSetting = SettingsHolder::instance()->getAddonSetting(
                 SettingsHolder::AddonSettingQuery(
                     "bar", ADDON_MESSAGE_SETTINGS_GROUP,
-                    ADDON_MESSAGE_SETTINGS_STATE_KEY, "?!?"));
+                    ADDON_MESSAGE_SETTINGS_STATUS_KEY, "?!?"));
           });
 
   QCOMPARE(addonSetting, "");
@@ -1011,7 +1011,7 @@ void TestAddon::message_dismiss() {
   QVERIFY(!message2);
 }
 
-void TestAddon::telemetry_state_change() {
+void TestAddon::telemetry_status_change() {
   Localizer localizer;
 
   QJsonObject content;

--- a/tests/unit/testaddon.h
+++ b/tests/unit/testaddon.h
@@ -37,11 +37,11 @@ class TestAddon final : public TestHelper {
   void message_create();
   void message_notification_data();
   void message_notification();
-  void message_load_state_data();
-  void message_load_state();
+  void message_load_status_data();
+  void message_load_status();
   void message_dismiss();
 
-  void telemetry_state_change();
+  void telemetry_status_change();
 
  private:
   SettingsHolder* m_settingsHolder = nullptr;

--- a/tests/unit/testaddonsessionstate.cpp
+++ b/tests/unit/testaddonsessionstate.cpp
@@ -13,12 +13,12 @@ void TestAddonSessionState::testGetAndSet() {
   QJsonObject manifest;
   manifest["numProp"] = numProp;
 
-  AddonSessionState* state = AddonSessionState::fromManifest(manifest);
+  AddonSessionState state(manifest);
 
-  QCOMPARE(state->get("numProp"), 10);
+  QCOMPARE(state.get("numProp"), 10);
 
-  state->set("numProp", QJsonValue(11));
-  QCOMPARE(state->get("numProp"), 11);
+  state.set("numProp", QJsonValue(11));
+  QCOMPARE(state.get("numProp"), 11);
 }
 
 void TestAddonSessionState::testClear() {
@@ -28,20 +28,20 @@ void TestAddonSessionState::testClear() {
   QJsonObject manifest;
   manifest["numProp"] = numProp;
 
-  AddonSessionState* state = AddonSessionState::fromManifest(manifest);
+  AddonSessionState state(manifest);
 
-  QCOMPARE(state->get("numProp"), 10);
+  QCOMPARE(state.get("numProp"), 10);
 
   // Clear without having recorded anything.
-  state->clear("numProp");
-  QCOMPARE(state->get("numProp"), 10);
+  state.clear("numProp");
+  QCOMPARE(state.get("numProp"), 10);
 
-  state->set("numProp", QJsonValue(11));
-  QCOMPARE(state->get("numProp"), 11);
+  state.set("numProp", QJsonValue(11));
+  QCOMPARE(state.get("numProp"), 11);
 
   // Clear after having recorded.
-  state->clear("numProp");
-  QCOMPARE(state->get("numProp"), 10);
+  state.clear("numProp");
+  QCOMPARE(state.get("numProp"), 10);
 }
 
 void TestAddonSessionState::testClearAll() {
@@ -59,39 +59,39 @@ void TestAddonSessionState::testClearAll() {
   manifest["prop2"] = prop2;
   manifest["prop3"] = prop3;
 
-  AddonSessionState* state = AddonSessionState::fromManifest(manifest);
+  AddonSessionState state(manifest);
 
-  QCOMPARE(state->get("prop1"), 10);
-  QCOMPARE(state->get("prop2"), 11);
-  QCOMPARE(state->get("prop3"), 12);
+  QCOMPARE(state.get("prop1"), 10);
+  QCOMPARE(state.get("prop2"), 11);
+  QCOMPARE(state.get("prop3"), 12);
   // Clear all without having recorded anything.
-  state->clear();
-  QCOMPARE(state->get("prop1"), 10);
-  QCOMPARE(state->get("prop2"), 11);
-  QCOMPARE(state->get("prop3"), 12);
+  state.clear();
+  QCOMPARE(state.get("prop1"), 10);
+  QCOMPARE(state.get("prop2"), 11);
+  QCOMPARE(state.get("prop3"), 12);
 
-  state->set("prop1", QJsonValue(1));
-  state->set("prop2", QJsonValue(2));
-  QCOMPARE(state->get("prop1"), 1);
-  QCOMPARE(state->get("prop2"), 2);
-  QCOMPARE(state->get("prop3"), 12);
+  state.set("prop1", QJsonValue(1));
+  state.set("prop2", QJsonValue(2));
+  QCOMPARE(state.get("prop1"), 1);
+  QCOMPARE(state.get("prop2"), 2);
+  QCOMPARE(state.get("prop3"), 12);
   // Clear all having recorded part of the properties anything.
-  state->clear();
-  QCOMPARE(state->get("prop1"), 10);
-  QCOMPARE(state->get("prop2"), 11);
-  QCOMPARE(state->get("prop3"), 12);
+  state.clear();
+  QCOMPARE(state.get("prop1"), 10);
+  QCOMPARE(state.get("prop2"), 11);
+  QCOMPARE(state.get("prop3"), 12);
 
-  state->set("prop1", QJsonValue(0));
-  state->set("prop2", QJsonValue(0));
-  state->set("prop3", QJsonValue(0));
-  QCOMPARE(state->get("prop1"), 0);
-  QCOMPARE(state->get("prop2"), 0);
-  QCOMPARE(state->get("prop3"), 0);
+  state.set("prop1", QJsonValue(0));
+  state.set("prop2", QJsonValue(0));
+  state.set("prop3", QJsonValue(0));
+  QCOMPARE(state.get("prop1"), 0);
+  QCOMPARE(state.get("prop2"), 0);
+  QCOMPARE(state.get("prop3"), 0);
   // Clear after having recorded all props
-  state->clear();
-  QCOMPARE(state->get("prop1"), 10);
-  QCOMPARE(state->get("prop2"), 11);
-  QCOMPARE(state->get("prop3"), 12);
+  state.clear();
+  QCOMPARE(state.get("prop1"), 10);
+  QCOMPARE(state.get("prop2"), 11);
+  QCOMPARE(state.get("prop3"), 12);
 }
 
 static TestAddonSessionState s_testAddonSessionState;

--- a/tests/unit/testaddonsessionstate.cpp
+++ b/tests/unit/testaddonsessionstate.cpp
@@ -1,0 +1,97 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "testaddonsessionstate.h"
+
+#include "addons/state/addonsessionstate.h"
+
+void TestAddonSessionState::testGetAndSet() {
+  QJsonObject numProp;
+  numProp["type"] = "number";
+  numProp["default"] = 10;
+  QJsonObject manifest;
+  manifest["numProp"] = numProp;
+
+  AddonSessionState* state = AddonSessionState::fromManifest(manifest);
+
+  QCOMPARE(state->get("numProp"), 10);
+
+  state->set("numProp", QJsonValue(11));
+  QCOMPARE(state->get("numProp"), 11);
+}
+
+void TestAddonSessionState::testClear() {
+  QJsonObject numProp;
+  numProp["type"] = "number";
+  numProp["default"] = 10;
+  QJsonObject manifest;
+  manifest["numProp"] = numProp;
+
+  AddonSessionState* state = AddonSessionState::fromManifest(manifest);
+
+  QCOMPARE(state->get("numProp"), 10);
+
+  // Clear without having recorded anything.
+  state->clear("numProp");
+  QCOMPARE(state->get("numProp"), 10);
+
+  state->set("numProp", QJsonValue(11));
+  QCOMPARE(state->get("numProp"), 11);
+
+  // Clear after having recorded.
+  state->clear("numProp");
+  QCOMPARE(state->get("numProp"), 10);
+}
+
+void TestAddonSessionState::testClearAll() {
+  QJsonObject prop1;
+  prop1["type"] = "number";
+  prop1["default"] = 10;
+  QJsonObject prop2;
+  prop2["type"] = "number";
+  prop2["default"] = 11;
+  QJsonObject prop3;
+  prop3["type"] = "number";
+  prop3["default"] = 12;
+  QJsonObject manifest;
+  manifest["prop1"] = prop1;
+  manifest["prop2"] = prop2;
+  manifest["prop3"] = prop3;
+
+  AddonSessionState* state = AddonSessionState::fromManifest(manifest);
+
+  QCOMPARE(state->get("prop1"), 10);
+  QCOMPARE(state->get("prop2"), 11);
+  QCOMPARE(state->get("prop3"), 12);
+  // Clear all without having recorded anything.
+  state->clear();
+  QCOMPARE(state->get("prop1"), 10);
+  QCOMPARE(state->get("prop2"), 11);
+  QCOMPARE(state->get("prop3"), 12);
+
+  state->set("prop1", QJsonValue(1));
+  state->set("prop2", QJsonValue(2));
+  QCOMPARE(state->get("prop1"), 1);
+  QCOMPARE(state->get("prop2"), 2);
+  QCOMPARE(state->get("prop3"), 12);
+  // Clear all having recorded part of the properties anything.
+  state->clear();
+  QCOMPARE(state->get("prop1"), 10);
+  QCOMPARE(state->get("prop2"), 11);
+  QCOMPARE(state->get("prop3"), 12);
+
+  state->set("prop1", QJsonValue(0));
+  state->set("prop2", QJsonValue(0));
+  state->set("prop3", QJsonValue(0));
+  QCOMPARE(state->get("prop1"), 0);
+  QCOMPARE(state->get("prop2"), 0);
+  QCOMPARE(state->get("prop3"), 0);
+  // Clear after having recorded all props
+  state->clear();
+  QCOMPARE(state->get("prop1"), 10);
+  QCOMPARE(state->get("prop2"), 11);
+  QCOMPARE(state->get("prop3"), 12);
+}
+
+static TestAddonSessionState s_testAddonSessionState;

--- a/tests/unit/testaddonsessionstate.h
+++ b/tests/unit/testaddonsessionstate.h
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "helper.h"
+
+class TestAddonSessionState final : public TestHelper {
+  Q_OBJECT
+
+ private slots:
+  void testGetAndSet();
+  void testClear();
+  void testClearAll();
+};

--- a/tests/unit/testaddonstatebase.cpp
+++ b/tests/unit/testaddonstatebase.cpp
@@ -1,0 +1,370 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "testaddonstatebase.h"
+
+#include <QHash>
+#include <QJsonObject>
+
+#include "addons/state/addonstatebase.h"
+
+/**
+ * @brief Empty state class that doesn't do anything other than server as a
+ * testing class for the Base abstract class.
+ */
+class StateSpy : public AddonStateBase {
+ public:
+  static StateSpy fromManifest(const QJsonObject& manifest) {
+    return StateSpy(AddonStateBase::parseManifest(manifest));
+  }
+
+  StateSpy(StateHash spec) : AddonStateBase(spec) {}
+
+  StateHash defaults() { return m_defaults; }
+
+  QJsonValue getInternalReturnValue = QJsonValue();
+  bool setInternalCalled = false;
+  bool clearInternalCalled = false;
+
+ private:
+  QJsonValue getInternal(const QString& key) const override {
+    return getInternalReturnValue;
+  }
+
+  void setInternal(const QString& key, const QJsonValue& value) override {
+    setInternalCalled = true;
+  }
+
+  void clearInternal(const QString& key) override {
+    clearInternalCalled = true;
+  }
+};
+
+void TestAddonStateBase::testParseManifest_data() {
+  QTest::addColumn<QJsonObject>("manifest");
+  QTest::addColumn<StateHash>("hash");
+
+  // Cases when the provided manifest is completely in the WRONG format.
+
+  {
+    QJsonObject obj;
+    obj["prop1"] = 1;
+    obj["prop2"] = "prop";
+    obj["prop3"] = false;
+    QTest::addRow("no_objects") << obj << StateHash();
+  }
+
+  {
+    QJsonObject obj;
+    obj["prop1"] = QJsonObject();
+    QTest::addRow("missing_type_and_default") << obj << StateHash();
+  }
+
+  {
+    QJsonObject prop;
+    prop["default"] = false;
+    QJsonObject obj;
+    obj["prop"] = prop;
+    QTest::addRow("missing_type") << obj << StateHash();
+  }
+
+  {
+    QJsonObject prop1;
+    prop1["type"] = "unsupported_type";
+    prop1["default"] = false;
+    QJsonObject prop2;
+    prop2["type"] = 42;
+    prop2["default"] = false;
+    QJsonObject obj;
+    obj["prop1"] = prop1;
+    obj["prop2"] = prop2;
+    QTest::addRow("invalid_type") << obj << StateHash();
+  }
+
+  {
+    QJsonObject prop;
+    prop["type"] = "boolean";
+    QJsonObject obj;
+    obj["prop"] = prop;
+    QTest::addRow("missing_default") << obj << StateHash();
+  }
+
+  {
+    QJsonObject boolProp;
+    boolProp["type"] = "boolean";
+    boolProp["default"] = 0;
+    QJsonObject numProp;
+    numProp["type"] = "number";
+    numProp["default"] = "42";
+    QJsonObject strProp;
+    strProp["type"] = "string";
+    strProp["default"] = QJsonObject();
+    QJsonObject obj;
+    obj["boolProp"] = boolProp;
+    obj["numProp"] = numProp;
+    obj["strProp"] = strProp;
+    QTest::addRow("mismatched_type") << obj << StateHash();
+  }
+
+  // Cases when the provided manifest is completely in the RIGHT format.
+
+  QTest::addRow("empty_manifest") << QJsonObject() << StateHash();
+
+  {
+    QJsonObject bool1;
+    bool1["type"] = "boolean";
+    bool1["default"] = false;
+    QJsonObject bool2;
+    bool2["type"] = "boolean";
+    bool2["default"] = true;
+    QJsonObject obj;
+    obj["bool1"] = bool1;
+    obj["bool2"] = bool2;
+    QTest::addRow("bool_prop_correct")
+        << obj << StateHash({{"bool1", false}, {"bool2", true}});
+  }
+
+  {
+    QJsonObject str1;
+    str1["type"] = "string";
+    str1["default"] = "hello";
+    QJsonObject str2;
+    str2["type"] = "string";
+    str2["default"] = "world";
+    QJsonObject obj;
+    obj["str1"] = str1;
+    obj["str2"] = str2;
+    QTest::addRow("str_prop_correct")
+        << obj << StateHash({{"str1", "hello"}, {"str2", "world"}});
+  }
+
+  {
+    QJsonObject num1;
+    num1["type"] = "number";
+    num1["default"] = 0;
+    QJsonObject num2;
+    num2["type"] = "number";
+    num2["default"] = 2147483647;
+    QJsonObject obj;
+    obj["num1"] = num1;
+    obj["num2"] = num2;
+    QTest::addRow("num_prop_correct")
+        << obj << StateHash({{"num1", 0}, {"num2", 2147483647}});
+  }
+
+  {
+    QJsonObject boolProp;
+    boolProp["type"] = "boolean";
+    boolProp["default"] = false;
+    QJsonObject numProp;
+    numProp["type"] = "number";
+    numProp["default"] = 24;
+    QJsonObject strProp;
+    strProp["type"] = "string";
+    strProp["default"] = "hello/world";
+    QJsonObject obj;
+    obj["boolProp"] = boolProp;
+    obj["numProp"] = numProp;
+    obj["strProp"] = strProp;
+    QTest::addRow("all_types_correct")
+        << obj
+        << StateHash({{"boolProp", false},
+                      {"numProp", 24},
+                      {"strProp", "hello/world"}});
+  }
+
+  // Cases when the provided manifest is completely PARTIALLY right.
+
+  {
+    QJsonObject oops;
+    oops["type"] = "boolean";
+    oops["default"] = "false";
+    QJsonObject aBool;
+    aBool["type"] = "boolean";
+    aBool["default"] = true;
+    QJsonObject obj;
+    obj["oops"] = oops;
+    obj["aBool"] = aBool;
+    QTest::addRow("wrong_boolean_only") << obj << StateHash({{"aBool", true}});
+  }
+
+  {
+    QJsonObject str1;
+    str1["type"] = "string";
+    str1["default"] = "hello";
+    QJsonObject empty;
+    QJsonObject obj;
+    obj["str1"] = str1;
+    obj["empty"] = empty;
+    QTest::addRow("one_wrong_object") << obj << StateHash({{"str1", "hello"}});
+  }
+
+  {
+    QJsonObject boolProp;
+    boolProp["type"] = "boolean";
+    boolProp["default"] = false;
+    QJsonObject numProp;
+    numProp["type"] = "number";
+    numProp["default"] = 24;
+    QJsonObject strProp;
+    strProp["type"] = "string";
+    strProp["default"] = "hello/world";
+    QJsonObject obj;
+    QJsonObject empty;
+    obj["empty"] = empty;
+    obj["boolProp"] = boolProp;
+    obj["numProp"] = numProp;
+    obj["strProp"] = strProp;
+    QTest::addRow("all_types_correct_one_wrong")
+        << obj
+        << StateHash({{"boolProp", false},
+                      {"numProp", 24},
+                      {"strProp", "hello/world"}});
+  }
+}
+
+void TestAddonStateBase::testParseManifest() {
+  QFETCH(QJsonObject, manifest);
+  QFETCH(StateHash, hash);
+
+  StateSpy expectedState(hash);
+  StateSpy actualState = StateSpy::fromManifest(manifest);
+  QCOMPARE(expectedState.defaults(), actualState.defaults());
+}
+
+void TestAddonStateBase::testGet_data() {
+  QTest::addColumn<QString>("key");
+  QTest::addColumn<StateHash>("defaults");
+  QTest::addColumn<QJsonValue>("getInternalReturnValue");
+  QTest::addColumn<QJsonValue>("expectedValue");
+
+  StateHash defaults =
+      StateHash({{"boolProp", false}, {"numProp", 0}, {"strProp", "aTest"}});
+
+  // Cases when the default should be returned i.e. getInternalReturnValue ==
+  // QJsonValue::Null.
+
+  QTest::addRow("no_bool_recorded") << "boolProp" << defaults << QJsonValue()
+                                    << QJsonValue(defaults.value("boolProp"));
+
+  QTest::addRow("no_num_recorded") << "numProp" << defaults << QJsonValue()
+                                   << QJsonValue(defaults.value("numProp"));
+
+  QTest::addRow("no_str_recorded") << "strProp" << defaults << QJsonValue()
+                                   << QJsonValue(defaults.value("strProp"));
+
+  // Cases when the state should be returned i.e. getInternalReturnValue !==
+  // QJsonValue::Null.
+
+  QTest::addRow("bool_recorded")
+      << "boolProp" << defaults << QJsonValue(true) << QJsonValue(true);
+
+  QTest::addRow("num_recorded")
+      << "numProp" << defaults << QJsonValue(42) << QJsonValue(42);
+
+  QTest::addRow("str_recorded")
+      << "strProp" << defaults << QJsonValue("ha!") << QJsonValue("ha!");
+
+  // Error cases
+
+  QTest::addRow("invalid_key")
+      << "invalid" << defaults << QJsonValue("should never see this")
+      << QJsonValue();
+}
+
+void TestAddonStateBase::testGet() {
+  QFETCH(QString, key);
+  QFETCH(StateHash, defaults);
+  QFETCH(QJsonValue, getInternalReturnValue);
+  QFETCH(QJsonValue, expectedValue);
+
+  StateSpy state(defaults);
+  state.getInternalReturnValue = getInternalReturnValue;
+
+  QCOMPARE(state.get(key), expectedValue);
+}
+
+void TestAddonStateBase::testSet_data() {
+  QTest::addColumn<QString>("key");
+  QTest::addColumn<QJsonValue>("value");
+  QTest::addColumn<StateHash>("defaults");
+  QTest::addColumn<bool>("setInternalCalled");
+
+  StateHash defaults =
+      StateHash({{"boolProp", false}, {"numProp", 0}, {"strProp", "aTest"}});
+
+  // Cases when the set is called i.e. a valid key is being set with a valid
+  // value is being set.
+
+  QTest::addRow("set_bool_correctly")
+      << "boolProp" << QJsonValue(true) << defaults << true;
+  QTest::addRow("set_num_correctly")
+      << "numProp" << QJsonValue(42) << defaults << true;
+  QTest::addRow("set_str_correctly")
+      << "strProp" << QJsonValue("ha!") << defaults << true;
+
+  // Cases when the set is NOT called
+
+  // 1. An invalid key is being set.
+
+  QTest::addRow("invalid_key")
+      << "invalid" << QJsonValue(true) << defaults << false;
+
+  // 2. An invalid value is being set for a valid key.
+
+  QTest::addRow("invalid_bool")
+      << "boolProp" << QJsonValue() << defaults << false;
+
+  QTest::addRow("invalid_num")
+      << "numProp" << QJsonValue() << defaults << false;
+
+  QTest::addRow("invalid_str")
+      << "strProp" << QJsonValue() << defaults << false;
+}
+
+void TestAddonStateBase::testSet() {
+  QFETCH(QString, key);
+  QFETCH(QJsonValue, value);
+  QFETCH(StateHash, defaults);
+  QFETCH(bool, setInternalCalled);
+
+  StateSpy state(defaults);
+  state.set(key, value);
+
+  QCOMPARE(state.setInternalCalled, setInternalCalled);
+}
+
+void TestAddonStateBase::testClear_data() {
+  QTest::addColumn<QString>("key");
+  QTest::addColumn<StateHash>("defaults");
+  QTest::addColumn<bool>("clearInternalCalled");
+
+  StateHash defaults =
+      StateHash({{"boolProp", false}, {"numProp", 0}, {"strProp", "aTest"}});
+
+  // Cases when the set is called i.e. a valid key is being set with a valid
+  // value is being set.
+
+  QTest::addRow("clear_bool_correctly") << "boolProp" << defaults << true;
+  QTest::addRow("clear_num_correctly") << "numProp" << defaults << true;
+  QTest::addRow("clear_str_correctly") << "strProp" << defaults << true;
+  QTest::addRow("clear_all_correctly") << "" << defaults << true;
+
+  // Cases when the set is NOT called i.e. an invalid key is being cleared.
+
+  QTest::addRow("invalid_key") << "invalid" << defaults << false;
+}
+
+void TestAddonStateBase::testClear() {
+  QFETCH(QString, key);
+  QFETCH(StateHash, defaults);
+  QFETCH(bool, clearInternalCalled);
+
+  StateSpy state(defaults);
+  state.clear(key);
+
+  QCOMPARE(state.clearInternalCalled, clearInternalCalled);
+}
+
+static TestAddonStateBase s_testAddonStateBase;

--- a/tests/unit/testaddonstatebase.cpp
+++ b/tests/unit/testaddonstatebase.cpp
@@ -15,11 +15,8 @@
  */
 class StateSpy : public AddonStateBase {
  public:
-  static StateSpy fromManifest(const QJsonObject& manifest) {
-    return StateSpy(AddonStateBase::parseManifest(manifest));
-  }
-
-  StateSpy(StateHash spec) : AddonStateBase(spec) {}
+  StateSpy(const QJsonObject& manifest) : AddonStateBase(manifest) {}
+  StateSpy(const StateHash& manifest) : AddonStateBase(manifest) {}
 
   StateHash defaults() { return m_defaults; }
 
@@ -229,7 +226,7 @@ void TestAddonStateBase::testParseManifest() {
   QFETCH(StateHash, hash);
 
   StateSpy expectedState(hash);
-  StateSpy actualState = StateSpy::fromManifest(manifest);
+  StateSpy actualState(manifest);
   QCOMPARE(expectedState.defaults(), actualState.defaults());
 }
 

--- a/tests/unit/testaddonstatebase.h
+++ b/tests/unit/testaddonstatebase.h
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "helper.h"
+
+class TestAddonStateBase final : public TestHelper {
+  Q_OBJECT
+
+ private slots:
+  void testParseManifest_data();
+  void testParseManifest();
+  void testGet_data();
+  void testGet();
+  void testSet_data();
+  void testSet();
+  void testClear_data();
+  void testClear();
+};


### PR DESCRIPTION
**This is a large PR, so I suggest going commit by commit during the review.**

One note about [DO NOT MERGE THIS ONE: Refactor split tunneling tutorial to use state](https://github.com/mozilla-mobile/mozilla-vpn-client/commit/afd6e095194e41a47762e146782ea20de5a5ecc2). Turns out we were too late to the party as this addon is actually disabled starting from 2.14... I added a commit with the refactor for illustration purposes, but we can't merge this change because this tutorial will not be enabled in versions that will have addon state support.

- [x] Oh I just realized there are leaks on the AddonSessionState. Gotta fix that before merging as well!