### PR TITLE
VPN-3111: Fix case sensitivity when matching for intra-country locations.

### DIFF
--- a/src/apps/vpn/models/servercountrymodel.cpp
+++ b/src/apps/vpn/models/servercountrymodel.cpp
@@ -283,6 +283,7 @@ QStringList ServerCountryModel::pickBest(const Location& location) const {
   // We rank cities using the distance between two points on a great circle,
   // which is given by:
   //    d = acos(sin(lat1)*sin(lat2) + cos(lat1)*cos(lat2)*cos(long1-long2))
+  QString userCountry = location.countryCode();
   QString bestCountry;
   QString bestCity;
   double clientSin = qSin(latitude * M_PI / 180.0);
@@ -291,7 +292,7 @@ QStringList ServerCountryModel::pickBest(const Location& location) const {
   for (const ServerCountry& country : m_countries) {
     // If servers exist within the same country as the user, restrict the search
     // to locations only within that country.
-    if (country.code() == location.countryCode()) {
+    if (userCountry.compare(country.code(), Qt::CaseInsensitive) == 0) {
       bestDistance = M_2_PI;
     }
     for (const ServerCity& city : country.cities()) {
@@ -308,7 +309,7 @@ QStringList ServerCountryModel::pickBest(const Location& location) const {
       }
     }
     // If servers exist within the same country, then we are done.
-    if (country.code() == location.countryCode()) {
+    if (userCountry.compare(bestCountry, Qt::CaseInsensitive) == 0) {
       break;
     }
   }


### PR DESCRIPTION
## Description
Yet another attempt to get intra-country preferences working when selecting the default location. It seems that we can't use an exact comparison with the country codes since we are receiving a mix of uppercase and lowercase country codes from various guardian endpoints.

## Reference
JIRA issue [VPN-3111](https://mozilla-hub.atlassian.net/browse/VPN-3111)

## Checklist
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-3111]: https://mozilla-hub.atlassian.net/browse/VPN-3111?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ