### PR TITLE
Fix 'App exclusions' capitalization in tunneling addon

### DIFF
--- a/addons/tutorial_04_split_tunneling2/manifest.json
+++ b/addons/tutorial_04_split_tunneling2/manifest.json
@@ -28,7 +28,7 @@
       }, {
         "id": "s2",
         "query": "//appPermissionSettings{visible=true}",
-        "tooltip": "Select “App Exclusions”",
+        "tooltip": "Select “App exclusions”",
         "next": {
           "op": "signal",
           "query_emitter": "//appPermissionSettings{visible=true}",

--- a/addons/tutorial_04_split_tunneling3/manifest.json
+++ b/addons/tutorial_04_split_tunneling3/manifest.json
@@ -27,7 +27,7 @@
       }, {
         "id": "s2",
         "query": "//appExclusionSettings{visible=true}",
-        "tooltip": "Select “App Exclusions”",
+        "tooltip": "Select “App exclusions”",
         "conditions": {
           "javascript": "resetAppPermissions.js"
         },


### PR DESCRIPTION
## Description

    Fix wrong capitalization for "App exclusions"

## Reference

    i.e Jira or Github issue URL

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
