### PR TITLE
VPN-4195 Improve Multi-Hop OS notifications

### DIFF
--- a/src/apps/vpn/notificationhandler.cpp
+++ b/src/apps/vpn/notificationhandler.cpp
@@ -152,13 +152,33 @@ void NotificationHandler::showNotification() {
         }
 
         // "VPN Connected"
-        notifyInternal(None,
-                       I18nStrings::instance()->t(
-                           I18nStrings::NotificationsVPNConnectedTitle),
-                       I18nStrings::instance()
-                           ->t(I18nStrings::NotificationsVPNConnectedMessage)
-                           .arg(localizedCityName),
-                       NOTIFICATION_TIME_MSEC);
+        // notifyInternal(None,
+        //                I18nStrings::instance()->t(
+        //                    I18nStrings::NotificationsVPNConnectedTitle),
+        //                I18nStrings::instance()
+        //                    ->t(I18nStrings::NotificationsVPNConnectedMessage)
+        //                    .arg(localizedCityName),
+        //                NOTIFICATION_TIME_MSEC);
+
+        ServerData* serverData = vpn->serverData();
+
+        if (serverData->multihop()) {
+          // Create a string for both servers
+          notifyInternal(None,
+                        I18nStrings::instance()->t(
+                            I18nStrings::NotificationsVPNConnectedTitle),
+                        "Multihop server names here",
+                        NOTIFICATION_TIME_MSEC);                      
+        } else {
+          // "VPN Connected"
+          notifyInternal(None,
+                        I18nStrings::instance()->t(
+                            I18nStrings::NotificationsVPNConnectedTitle),
+                        I18nStrings::instance()
+                            ->t(I18nStrings::NotificationsVPNConnectedMessage)
+                            .arg(localizedCityName),
+                        NOTIFICATION_TIME_MSEC);
+        }
       }
       return;
 

--- a/src/apps/vpn/notificationhandler.cpp
+++ b/src/apps/vpn/notificationhandler.cpp
@@ -155,29 +155,28 @@ void NotificationHandler::showNotification() {
         ServerData* serverData = vpn->serverData();
 
         if (serverData->multihop()) {
-        QString localizedEntryCityName =
-            vpn->controller()
-                ->currentServer()
-                .localizedEntryCityName();
+          QString localizedEntryCityName =
+              vpn->controller()->currentServer().localizedEntryCityName();
 
-        QString localizedExitCityName =
-            vpn->controller()->currentServer().localizedExitCityName();
+          QString localizedExitCityName =
+              vpn->controller()->currentServer().localizedExitCityName();
 
-            notifyInternal(None,
-                          I18nStrings::instance()->t(
-                              I18nStrings::NotificationsVPNConnectedTitle),
-                          I18nStrings::instance()
-                              ->t(I18nStrings::NotificationsVPNMultihopConnectedMessage)
-                              .arg(localizedExitCityName, localizedEntryCityName),
-                          NOTIFICATION_TIME_MSEC);                    
+          notifyInternal(
+              None,
+              I18nStrings::instance()->t(
+                  I18nStrings::NotificationsVPNConnectedTitle),
+              I18nStrings::instance()
+                  ->t(I18nStrings::NotificationsVPNMultihopConnectedMessage)
+                  .arg(localizedExitCityName, localizedEntryCityName),
+              NOTIFICATION_TIME_MSEC);
         } else {
           notifyInternal(None,
-                        I18nStrings::instance()->t(
-                            I18nStrings::NotificationsVPNConnectedTitle),
-                        I18nStrings::instance()
-                            ->t(I18nStrings::NotificationsVPNConnectedMessage)
-                            .arg(localizedCityName),
-                        NOTIFICATION_TIME_MSEC);
+                         I18nStrings::instance()->t(
+                             I18nStrings::NotificationsVPNConnectedTitle),
+                         I18nStrings::instance()
+                             ->t(I18nStrings::NotificationsVPNConnectedMessage)
+                             .arg(localizedCityName),
+                         NOTIFICATION_TIME_MSEC);
         }
       }
       return;

--- a/src/apps/vpn/notificationhandler.cpp
+++ b/src/apps/vpn/notificationhandler.cpp
@@ -152,23 +152,30 @@ void NotificationHandler::showNotification() {
         }
 
         // "VPN Connected"
-        // notifyInternal(None,
-        //                I18nStrings::instance()->t(
-        //                    I18nStrings::NotificationsVPNConnectedTitle),
-        //                I18nStrings::instance()
-        //                    ->t(I18nStrings::NotificationsVPNConnectedMessage)
-        //                    .arg(localizedCityName),
-        //                NOTIFICATION_TIME_MSEC);
-
         ServerData* serverData = vpn->serverData();
 
         if (serverData->multihop()) {
           // Create a string for both servers
-          notifyInternal(None,
-                        I18nStrings::instance()->t(
-                            I18nStrings::NotificationsVPNConnectedTitle),
-                        "Multihop server names here",
-                        NOTIFICATION_TIME_MSEC);                      
+          //VPNMultihopConnectedMessage
+          // notifyInternal(None,
+          //               I18nStrings::instance()->t(
+          //                   I18nStrings::NotificationsVPNConnectedTitle),
+          //               "Multihop server names here",
+          //               NOTIFICATION_TIME_MSEC);  
+        QString localizedPreviousExitCountryName =
+            vpn->controller()
+                ->currentServer()
+                .localizedPreviousExitCountryName();
+        QString localizedPreviousExitCityName =
+            vpn->controller()->currentServer().localizedPreviousExitCityName();
+
+            notifyInternal(None,
+                          I18nStrings::instance()->t(
+                              I18nStrings::NotificationsVPNConnectedTitle),
+                          I18nStrings::instance()
+                              ->t(I18nStrings::NotificationsVPNMultihopConnectedMessage)
+                              .arg(localizedPreviousExitCityName, localizedCityName),
+                          NOTIFICATION_TIME_MSEC);                    
         } else {
           // "VPN Connected"
           notifyInternal(None,

--- a/src/apps/vpn/notificationhandler.cpp
+++ b/src/apps/vpn/notificationhandler.cpp
@@ -170,7 +170,6 @@ void NotificationHandler::showNotification() {
                   .arg(localizedExitCityName, localizedEntryCityName),
               NOTIFICATION_TIME_MSEC);
         } else {
-          // "VPN Connected"
           notifyInternal(None,
                          I18nStrings::instance()->t(
                              I18nStrings::NotificationsVPNConnectedTitle),

--- a/src/apps/vpn/notificationhandler.cpp
+++ b/src/apps/vpn/notificationhandler.cpp
@@ -155,28 +155,29 @@ void NotificationHandler::showNotification() {
         ServerData* serverData = vpn->serverData();
 
         if (serverData->multihop()) {
-          QString localizedEntryCityName =
-              vpn->controller()->currentServer().localizedEntryCityName();
+        QString localizedEntryCityName =
+            vpn->controller()
+                ->currentServer()
+                .localizedEntryCityName();
 
-          QString localizedExitCityName =
-              vpn->controller()->currentServer().localizedExitCityName();
+        QString localizedExitCityName =
+            vpn->controller()->currentServer().localizedExitCityName();
 
-          notifyInternal(
-              None,
-              I18nStrings::instance()->t(
-                  I18nStrings::NotificationsVPNConnectedTitle),
-              I18nStrings::instance()
-                  ->t(I18nStrings::NotificationsVPNMultihopConnectedMessage)
-                  .arg(localizedExitCityName, localizedEntryCityName),
-              NOTIFICATION_TIME_MSEC);
+            notifyInternal(None,
+                          I18nStrings::instance()->t(
+                              I18nStrings::NotificationsVPNConnectedTitle),
+                          I18nStrings::instance()
+                              ->t(I18nStrings::NotificationsVPNMultihopConnectedMessage)
+                              .arg(localizedExitCityName, localizedEntryCityName),
+                          NOTIFICATION_TIME_MSEC);                    
         } else {
           notifyInternal(None,
-                         I18nStrings::instance()->t(
-                             I18nStrings::NotificationsVPNConnectedTitle),
-                         I18nStrings::instance()
-                             ->t(I18nStrings::NotificationsVPNConnectedMessage)
-                             .arg(localizedCityName),
-                         NOTIFICATION_TIME_MSEC);
+                        I18nStrings::instance()->t(
+                            I18nStrings::NotificationsVPNConnectedTitle),
+                        I18nStrings::instance()
+                            ->t(I18nStrings::NotificationsVPNConnectedMessage)
+                            .arg(localizedCityName),
+                        NOTIFICATION_TIME_MSEC);
         }
       }
       return;

--- a/src/apps/vpn/notificationhandler.cpp
+++ b/src/apps/vpn/notificationhandler.cpp
@@ -155,26 +155,20 @@ void NotificationHandler::showNotification() {
         ServerData* serverData = vpn->serverData();
 
         if (serverData->multihop()) {
-          // Create a string for both servers
-          //VPNMultihopConnectedMessage
-          // notifyInternal(None,
-          //               I18nStrings::instance()->t(
-          //                   I18nStrings::NotificationsVPNConnectedTitle),
-          //               "Multihop server names here",
-          //               NOTIFICATION_TIME_MSEC);  
-        QString localizedPreviousExitCountryName =
+        QString localizedEntryCityName =
             vpn->controller()
                 ->currentServer()
-                .localizedPreviousExitCountryName();
-        QString localizedPreviousExitCityName =
-            vpn->controller()->currentServer().localizedPreviousExitCityName();
+                .localizedEntryCityName();
+
+        QString localizedExitCityName =
+            vpn->controller()->currentServer().localizedExitCityName();
 
             notifyInternal(None,
                           I18nStrings::instance()->t(
                               I18nStrings::NotificationsVPNConnectedTitle),
                           I18nStrings::instance()
                               ->t(I18nStrings::NotificationsVPNMultihopConnectedMessage)
-                              .arg(localizedPreviousExitCityName, localizedCityName),
+                              .arg(localizedExitCityName, localizedEntryCityName),
                           NOTIFICATION_TIME_MSEC);                    
         } else {
           // "VPN Connected"

--- a/src/apps/vpn/notificationhandler.cpp
+++ b/src/apps/vpn/notificationhandler.cpp
@@ -155,30 +155,29 @@ void NotificationHandler::showNotification() {
         ServerData* serverData = vpn->serverData();
 
         if (serverData->multihop()) {
-        QString localizedEntryCityName =
-            vpn->controller()
-                ->currentServer()
-                .localizedEntryCityName();
+          QString localizedEntryCityName =
+              vpn->controller()->currentServer().localizedEntryCityName();
 
-        QString localizedExitCityName =
-            vpn->controller()->currentServer().localizedExitCityName();
+          QString localizedExitCityName =
+              vpn->controller()->currentServer().localizedExitCityName();
 
-            notifyInternal(None,
-                          I18nStrings::instance()->t(
-                              I18nStrings::NotificationsVPNConnectedTitle),
-                          I18nStrings::instance()
-                              ->t(I18nStrings::NotificationsVPNMultihopConnectedMessage)
-                              .arg(localizedExitCityName, localizedEntryCityName),
-                          NOTIFICATION_TIME_MSEC);                    
+          notifyInternal(
+              None,
+              I18nStrings::instance()->t(
+                  I18nStrings::NotificationsVPNConnectedTitle),
+              I18nStrings::instance()
+                  ->t(I18nStrings::NotificationsVPNMultihopConnectedMessage)
+                  .arg(localizedExitCityName, localizedEntryCityName),
+              NOTIFICATION_TIME_MSEC);
         } else {
           // "VPN Connected"
           notifyInternal(None,
-                        I18nStrings::instance()->t(
-                            I18nStrings::NotificationsVPNConnectedTitle),
-                        I18nStrings::instance()
-                            ->t(I18nStrings::NotificationsVPNConnectedMessage)
-                            .arg(localizedCityName),
-                        NOTIFICATION_TIME_MSEC);
+                         I18nStrings::instance()->t(
+                             I18nStrings::NotificationsVPNConnectedTitle),
+                         I18nStrings::instance()
+                             ->t(I18nStrings::NotificationsVPNConnectedMessage)
+                             .arg(localizedCityName),
+                         NOTIFICATION_TIME_MSEC);
         }
       }
       return;

--- a/tests/functional/testServerSearch.js
+++ b/tests/functional/testServerSearch.js
@@ -120,7 +120,7 @@ describe("Server list", function () {
     assert.strictEqual(vpn.lastNotification().title, "VPN Connected");
     assert.strictEqual(
       vpn.lastNotification().message,
-      `Connected to ${currentCity}`
+      `Connected to ${currentCity}, through ${currentCity}`
     );
   });
 

--- a/tests/functional/testServerSearch.js
+++ b/tests/functional/testServerSearch.js
@@ -2,11 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const assert = require('assert');
-const queries = require('./queries.js');
-const vpn = require('./helper.js');
+const assert = require("assert");
+const queries = require("./queries.js");
+const vpn = require("./helper.js");
 
-describe('Server list', function() {
+describe("Server list", function () {
   let servers;
   let currentCountryCode;
   let currentCity;
@@ -19,9 +19,11 @@ describe('Server list', function() {
     await vpn.waitForQuery(queries.screenHome.STACKVIEW.ready());
 
     servers = await vpn.servers();
-    currentCountryCode =
-        await vpn.getVPNProperty('VPNCurrentServer', 'exitCountryCode');
-    currentCity = await vpn.getVPNProperty('VPNCurrentServer', 'exitCityName');
+    currentCountryCode = await vpn.getVPNProperty(
+      "VPNCurrentServer",
+      "exitCountryCode"
+    );
+    currentCity = await vpn.getVPNProperty("VPNCurrentServer", "exitCityName");
 
     for (let server of servers) {
       if (currentCountryCode === server.code) {
@@ -34,47 +36,62 @@ describe('Server list', function() {
       }
     }
     console.log(
-        'Current city (localized):', currentCity,
-        '| Current country code:', currentCountryCode);
+      "Current city (localized):",
+      currentCity,
+      "| Current country code:",
+      currentCountryCode
+    );
   });
 
-  it('multihop valid search', async () => {
+  it("multihop valid search", async () => {
     await vpn.waitForQueryAndClick(
-        queries.screenHome.serverListView.MULTIHOP_SELECTOR_TAB.visible());
+      queries.screenHome.serverListView.MULTIHOP_SELECTOR_TAB.visible()
+    );
     await vpn.waitForQuery(
-        queries.screenHome.serverListView.ENTRY_BUTTON.visible());
+      queries.screenHome.serverListView.ENTRY_BUTTON.visible()
+    );
     await vpn.waitForQueryAndClick(
-        queries.screenHome.serverListView.EXIT_BUTTON.visible());
+      queries.screenHome.serverListView.EXIT_BUTTON.visible()
+    );
 
     const server = servers[servers.length - 1];
-    console.log('server name: ', server.name);
+    console.log("server name: ", server.name);
     await vpn.waitForQueryAndWriteInTextField(
-        queries.screenHome.serverListView.SEARCH_BAR_TEXT_FIELD.visible(),
-        server.name);
+      queries.screenHome.serverListView.SEARCH_BAR_TEXT_FIELD.visible(),
+      server.name
+    );
 
-    const countryId =
-        queries.screenHome.serverListView.generateCountryId(server.code);
+    const countryId = queries.screenHome.serverListView.generateCountryId(
+      server.code
+    );
     await vpn.waitForQuery(countryId.visible());
     await vpn.scrollToQuery(
-        queries.screenHome.serverListView.COUNTRY_VIEW, countryId);
+      queries.screenHome.serverListView.COUNTRY_VIEW,
+      countryId
+    );
 
-    if ((await vpn.getQueryProperty(countryId, 'cityListVisible')) ===
-        'false') {
+    if (
+      (await vpn.getQueryProperty(countryId, "cityListVisible")) === "false"
+    ) {
       await vpn.waitForQueryAndClick(countryId.visible());
     }
 
-    await vpn.waitForQuery(countryId.visible().prop('cityListVisible', true));
+    await vpn.waitForQuery(countryId.visible().prop("cityListVisible", true));
 
     const city = server.cities[0]
-    console.log('Start test for city:', city);
-    const cityId =
-        queries.screenHome.serverListView.generateCityId(countryId, city.name);
+    console.log("Start test for city:", city);
+    const cityId = queries.screenHome.serverListView.generateCityId(
+      countryId,
+      city.name
+    );
     await vpn.waitForQuery(cityId.visible());
 
     await vpn.setQueryProperty(
-        queries.screenHome.serverListView.COUNTRY_VIEW, 'contentY',
-        parseInt(await vpn.getQueryProperty(cityId, 'y')) +
-            parseInt(await vpn.getQueryProperty(countryId, 'y')));
+      queries.screenHome.serverListView.COUNTRY_VIEW,
+      "contentY",
+      parseInt(await vpn.getQueryProperty(cityId, "y")) +
+        parseInt(await vpn.getQueryProperty(countryId, "y"))
+    );
     await vpn.waitForQuery(cityId.visible());
 
     await vpn.waitForQueryAndClick(cityId.visible());
@@ -82,7 +99,8 @@ describe('Server list', function() {
 
     // navigate back to connection view
     await vpn.waitForQueryAndClick(
-        queries.screenHome.serverListView.BACK_BUTTON.visible());
+      queries.screenHome.serverListView.BACK_BUTTON.visible()
+    );
 
     // define connected server
     currentCity = city.localizedName;
@@ -93,43 +111,56 @@ describe('Server list', function() {
     // wait and assert vpn connection
     await vpn.waitForCondition(async () => {
       return (
-          (await vpn.getQueryProperty(
-              queries.screenHome.CONTROLLER_TITLE, 'text')) == 'VPN is on');
+        (await vpn.getQueryProperty(
+          queries.screenHome.CONTROLLER_TITLE,
+          "text"
+        )) == "VPN is on"
+      );
     });
-    assert.strictEqual(vpn.lastNotification().title, 'VPN Connected');
+    assert.strictEqual(vpn.lastNotification().title, "VPN Connected");
     assert.strictEqual(
-        vpn.lastNotification().message,
-        `Connected to ${currentCity}, through ${currentCity}`);
+      vpn.lastNotification().message,
+      `Connected to ${currentCity}`
+    );
   });
 
-  it('singlehop valid search', async () => {
+  it("singlehop valid search", async () => {
     const server = servers[0];
-    console.log('server name: ', server.name);
+    console.log("server name: ", server.name);
     await vpn.waitForQueryAndWriteInTextField(
-        queries.screenHome.serverListView.SEARCH_BAR_TEXT_FIELD.visible(),
-        server.name);
+      queries.screenHome.serverListView.SEARCH_BAR_TEXT_FIELD.visible(),
+      server.name
+    );
 
-    const countryId =
-        queries.screenHome.serverListView.generateCountryId(server.code);
+    const countryId = queries.screenHome.serverListView.generateCountryId(
+      server.code
+    );
     await vpn.waitForQuery(countryId.visible());
     await vpn.scrollToQuery(
-        queries.screenHome.serverListView.COUNTRY_VIEW, countryId);
+      queries.screenHome.serverListView.COUNTRY_VIEW,
+      countryId
+    );
 
-    if ((await vpn.getQueryProperty(countryId, 'cityListVisible')) ===
-        'false') {
+    if (
+      (await vpn.getQueryProperty(countryId, "cityListVisible")) === "false"
+    ) {
       await vpn.waitForQueryAndClick(countryId.visible());
     }
-    await vpn.waitForQuery(countryId.visible().prop('cityListVisible', true));
+    await vpn.waitForQuery(countryId.visible().prop("cityListVisible", true));
 
-    console.log('Start test for city:', server.cities[0]);
+    console.log("Start test for city:", server.cities[0]);
     const cityId = queries.screenHome.serverListView.generateCityId(
-        countryId, server.cities[0].name);
+      countryId,
+      server.cities[0].name
+    );
     await vpn.waitForQuery(cityId.visible());
 
     await vpn.setQueryProperty(
-        queries.screenHome.serverListView.COUNTRY_VIEW, 'contentY',
-        parseInt(await vpn.getQueryProperty(cityId, 'y')) +
-            parseInt(await vpn.getQueryProperty(countryId, 'y')));
+      queries.screenHome.serverListView.COUNTRY_VIEW,
+      "contentY",
+      parseInt(await vpn.getQueryProperty(cityId, "y")) +
+        parseInt(await vpn.getQueryProperty(countryId, "y"))
+    );
     await vpn.waitForQuery(cityId.visible());
 
     await vpn.waitForQueryAndClick(cityId.visible());
@@ -142,75 +173,83 @@ describe('Server list', function() {
 
     await vpn.waitForCondition(async () => {
       return (
-          (await vpn.getQueryProperty(
-              queries.screenHome.CONTROLLER_TITLE, 'text')) == 'VPN is on');
+        (await vpn.getQueryProperty(
+          queries.screenHome.CONTROLLER_TITLE,
+          "text"
+        )) == "VPN is on"
+      );
     });
-    assert.strictEqual(vpn.lastNotification().title, 'VPN Connected');
+    assert.strictEqual(vpn.lastNotification().title, "VPN Connected");
     assert.strictEqual(
-        vpn.lastNotification().message, `Connected to ${currentCity}`);
+      vpn.lastNotification().message,
+      `Connected to ${currentCity}`
+    );
   });
 
   it('Invalid searchs and multi results for singlehop', async () => {
-    const australia = queries.screenHome.serverListView.generateCountryId('au');
-    const austria = queries.screenHome.serverListView.generateCountryId('at');
-    const belgium = queries.screenHome.serverListView.generateCountryId('be');
+    const australia = queries.screenHome.serverListView.generateCountryId("au");
+    const austria = queries.screenHome.serverListView.generateCountryId("at");
+    const belgium = queries.screenHome.serverListView.generateCountryId("be");
 
     // No result search
     await vpn.waitForQueryAndWriteInTextField(
-        queries.screenHome.serverListView.SEARCH_BAR_TEXT_FIELD.visible(),
-        'invalid search');
-    await vpn
-        .waitForQuery(
-            queries.screenHome.serverListView.SEARCH_BAR_ERROR.visible())
-            await vpn
-        .waitForQueryAndWriteInTextField(
-            queries.screenHome.serverListView.SEARCH_BAR_TEXT_FIELD.visible(),
-            '');
+      queries.screenHome.serverListView.SEARCH_BAR_TEXT_FIELD.visible(),
+      "invalid search"
+    );
+    await vpn.waitForQuery(queries.screenHome.serverListView.SEARCH_BAR_ERROR.visible())
+    await vpn.waitForQueryAndWriteInTextField(
+      queries.screenHome.serverListView.SEARCH_BAR_TEXT_FIELD.visible(),
+      ""
+    );
 
     // multi result search
     await vpn.waitForQueryAndWriteInTextField(
-        queries.screenHome.serverListView.SEARCH_BAR_TEXT_FIELD.visible(),
-        'Au');
+      queries.screenHome.serverListView.SEARCH_BAR_TEXT_FIELD.visible(),
+      "Au"
+    );
 
     await vpn.waitForQuery(australia.visible())
-        await vpn.waitForQuery(austria.visible())
-            await vpn.query(belgium.hidden())
+    await vpn.waitForQuery(austria.visible())
+    await vpn.query(belgium.hidden())
   })
 
   it('Invalid searchs and multi results for multihop', async () => {
-    const australia = queries.screenHome.serverListView.generateCountryId('au');
-    const austria = queries.screenHome.serverListView.generateCountryId('at');
-    const belgium = queries.screenHome.serverListView.generateCountryId('be');
+    const australia = queries.screenHome.serverListView.generateCountryId("au");
+    const austria = queries.screenHome.serverListView.generateCountryId("at");
+    const belgium = queries.screenHome.serverListView.generateCountryId("be");
 
     await vpn.waitForQueryAndClick(
-        queries.screenHome.serverListView.MULTIHOP_SELECTOR_TAB.visible());
+      queries.screenHome.serverListView.MULTIHOP_SELECTOR_TAB.visible()
+    );
     await vpn.waitForQuery(
-        queries.screenHome.serverListView.ENTRY_BUTTON.visible());
+      queries.screenHome.serverListView.ENTRY_BUTTON.visible()
+    );
     await vpn.waitForQueryAndClick(
-        queries.screenHome.serverListView.EXIT_BUTTON.visible());
+      queries.screenHome.serverListView.EXIT_BUTTON.visible()
+    );
 
     // invalid server search
     await vpn.waitForQueryAndWriteInTextField(
-        queries.screenHome.serverListView.SEARCH_BAR_TEXT_FIELD.visible(),
-        'invalid search');
-    await vpn
-        .waitForQuery(
-            queries.screenHome.serverListView.SEARCH_BAR_ERROR.visible())
-        // await vpn.waitForQuery(australia.hidden())
-        await vpn.waitForQuery(austria.hidden()) await vpn
-        .waitForQuery(belgium.hidden())
+      queries.screenHome.serverListView.SEARCH_BAR_TEXT_FIELD.visible(),
+      "invalid search"
+    );
+    await vpn.waitForQuery(queries.screenHome.serverListView.SEARCH_BAR_ERROR.visible())
+    // await vpn.waitForQuery(australia.hidden())
+    await vpn.waitForQuery(austria.hidden())
+    await vpn.waitForQuery(belgium.hidden())
 
-            await vpn
-        .waitForQueryAndWriteInTextField(
-            queries.screenHome.serverListView.SEARCH_BAR_TEXT_FIELD.visible(),
-            '');
+    await vpn.waitForQueryAndWriteInTextField(
+      queries.screenHome.serverListView.SEARCH_BAR_TEXT_FIELD.visible(),
+      ""
+    );
 
     // multi result search
     await vpn.waitForQueryAndWriteInTextField(
-        queries.screenHome.serverListView.SEARCH_BAR_TEXT_FIELD.visible(),
-        'Au');
+      queries.screenHome.serverListView.SEARCH_BAR_TEXT_FIELD.visible(),
+      "Au"
+    );
     await vpn.waitForQuery(australia.visible())
-        await vpn.waitForQuery(austria.visible())
-            await vpn.waitForQuery(belgium.hidden())
+    await vpn.waitForQuery(austria.visible())
+    await vpn.waitForQuery(belgium.hidden())
   })
 });

--- a/tests/functional/testServerSearch.js
+++ b/tests/functional/testServerSearch.js
@@ -2,11 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const assert = require("assert");
-const queries = require("./queries.js");
-const vpn = require("./helper.js");
+const assert = require('assert');
+const queries = require('./queries.js');
+const vpn = require('./helper.js');
 
-describe("Server list", function () {
+describe('Server list', function() {
   let servers;
   let currentCountryCode;
   let currentCity;
@@ -19,11 +19,9 @@ describe("Server list", function () {
     await vpn.waitForQuery(queries.screenHome.STACKVIEW.ready());
 
     servers = await vpn.servers();
-    currentCountryCode = await vpn.getVPNProperty(
-      "VPNCurrentServer",
-      "exitCountryCode"
-    );
-    currentCity = await vpn.getVPNProperty("VPNCurrentServer", "exitCityName");
+    currentCountryCode =
+        await vpn.getVPNProperty('VPNCurrentServer', 'exitCountryCode');
+    currentCity = await vpn.getVPNProperty('VPNCurrentServer', 'exitCityName');
 
     for (let server of servers) {
       if (currentCountryCode === server.code) {
@@ -36,62 +34,47 @@ describe("Server list", function () {
       }
     }
     console.log(
-      "Current city (localized):",
-      currentCity,
-      "| Current country code:",
-      currentCountryCode
-    );
+        'Current city (localized):', currentCity,
+        '| Current country code:', currentCountryCode);
   });
 
-  it("multihop valid search", async () => {
+  it('multihop valid search', async () => {
     await vpn.waitForQueryAndClick(
-      queries.screenHome.serverListView.MULTIHOP_SELECTOR_TAB.visible()
-    );
+        queries.screenHome.serverListView.MULTIHOP_SELECTOR_TAB.visible());
     await vpn.waitForQuery(
-      queries.screenHome.serverListView.ENTRY_BUTTON.visible()
-    );
+        queries.screenHome.serverListView.ENTRY_BUTTON.visible());
     await vpn.waitForQueryAndClick(
-      queries.screenHome.serverListView.EXIT_BUTTON.visible()
-    );
+        queries.screenHome.serverListView.EXIT_BUTTON.visible());
 
     const server = servers[servers.length - 1];
-    console.log("server name: ", server.name);
+    console.log('server name: ', server.name);
     await vpn.waitForQueryAndWriteInTextField(
-      queries.screenHome.serverListView.SEARCH_BAR_TEXT_FIELD.visible(),
-      server.name
-    );
+        queries.screenHome.serverListView.SEARCH_BAR_TEXT_FIELD.visible(),
+        server.name);
 
-    const countryId = queries.screenHome.serverListView.generateCountryId(
-      server.code
-    );
+    const countryId =
+        queries.screenHome.serverListView.generateCountryId(server.code);
     await vpn.waitForQuery(countryId.visible());
     await vpn.scrollToQuery(
-      queries.screenHome.serverListView.COUNTRY_VIEW,
-      countryId
-    );
+        queries.screenHome.serverListView.COUNTRY_VIEW, countryId);
 
-    if (
-      (await vpn.getQueryProperty(countryId, "cityListVisible")) === "false"
-    ) {
+    if ((await vpn.getQueryProperty(countryId, 'cityListVisible')) ===
+        'false') {
       await vpn.waitForQueryAndClick(countryId.visible());
     }
 
-    await vpn.waitForQuery(countryId.visible().prop("cityListVisible", true));
+    await vpn.waitForQuery(countryId.visible().prop('cityListVisible', true));
 
     const city = server.cities[0]
-    console.log("Start test for city:", city);
-    const cityId = queries.screenHome.serverListView.generateCityId(
-      countryId,
-      city.name
-    );
+    console.log('Start test for city:', city);
+    const cityId =
+        queries.screenHome.serverListView.generateCityId(countryId, city.name);
     await vpn.waitForQuery(cityId.visible());
 
     await vpn.setQueryProperty(
-      queries.screenHome.serverListView.COUNTRY_VIEW,
-      "contentY",
-      parseInt(await vpn.getQueryProperty(cityId, "y")) +
-        parseInt(await vpn.getQueryProperty(countryId, "y"))
-    );
+        queries.screenHome.serverListView.COUNTRY_VIEW, 'contentY',
+        parseInt(await vpn.getQueryProperty(cityId, 'y')) +
+            parseInt(await vpn.getQueryProperty(countryId, 'y')));
     await vpn.waitForQuery(cityId.visible());
 
     await vpn.waitForQueryAndClick(cityId.visible());
@@ -99,8 +82,7 @@ describe("Server list", function () {
 
     // navigate back to connection view
     await vpn.waitForQueryAndClick(
-      queries.screenHome.serverListView.BACK_BUTTON.visible()
-    );
+        queries.screenHome.serverListView.BACK_BUTTON.visible());
 
     // define connected server
     currentCity = city.localizedName;
@@ -111,56 +93,43 @@ describe("Server list", function () {
     // wait and assert vpn connection
     await vpn.waitForCondition(async () => {
       return (
-        (await vpn.getQueryProperty(
-          queries.screenHome.CONTROLLER_TITLE,
-          "text"
-        )) == "VPN is on"
-      );
+          (await vpn.getQueryProperty(
+              queries.screenHome.CONTROLLER_TITLE, 'text')) == 'VPN is on');
     });
-    assert.strictEqual(vpn.lastNotification().title, "VPN Connected");
+    assert.strictEqual(vpn.lastNotification().title, 'VPN Connected');
     assert.strictEqual(
-      vpn.lastNotification().message,
-      `Connected to ${currentCity}`
-    );
+        vpn.lastNotification().message,
+        `Connected to ${currentCity}, through ${currentCity}`);
   });
 
-  it("singlehop valid search", async () => {
+  it('singlehop valid search', async () => {
     const server = servers[0];
-    console.log("server name: ", server.name);
+    console.log('server name: ', server.name);
     await vpn.waitForQueryAndWriteInTextField(
-      queries.screenHome.serverListView.SEARCH_BAR_TEXT_FIELD.visible(),
-      server.name
-    );
+        queries.screenHome.serverListView.SEARCH_BAR_TEXT_FIELD.visible(),
+        server.name);
 
-    const countryId = queries.screenHome.serverListView.generateCountryId(
-      server.code
-    );
+    const countryId =
+        queries.screenHome.serverListView.generateCountryId(server.code);
     await vpn.waitForQuery(countryId.visible());
     await vpn.scrollToQuery(
-      queries.screenHome.serverListView.COUNTRY_VIEW,
-      countryId
-    );
+        queries.screenHome.serverListView.COUNTRY_VIEW, countryId);
 
-    if (
-      (await vpn.getQueryProperty(countryId, "cityListVisible")) === "false"
-    ) {
+    if ((await vpn.getQueryProperty(countryId, 'cityListVisible')) ===
+        'false') {
       await vpn.waitForQueryAndClick(countryId.visible());
     }
-    await vpn.waitForQuery(countryId.visible().prop("cityListVisible", true));
+    await vpn.waitForQuery(countryId.visible().prop('cityListVisible', true));
 
-    console.log("Start test for city:", server.cities[0]);
+    console.log('Start test for city:', server.cities[0]);
     const cityId = queries.screenHome.serverListView.generateCityId(
-      countryId,
-      server.cities[0].name
-    );
+        countryId, server.cities[0].name);
     await vpn.waitForQuery(cityId.visible());
 
     await vpn.setQueryProperty(
-      queries.screenHome.serverListView.COUNTRY_VIEW,
-      "contentY",
-      parseInt(await vpn.getQueryProperty(cityId, "y")) +
-        parseInt(await vpn.getQueryProperty(countryId, "y"))
-    );
+        queries.screenHome.serverListView.COUNTRY_VIEW, 'contentY',
+        parseInt(await vpn.getQueryProperty(cityId, 'y')) +
+            parseInt(await vpn.getQueryProperty(countryId, 'y')));
     await vpn.waitForQuery(cityId.visible());
 
     await vpn.waitForQueryAndClick(cityId.visible());
@@ -173,83 +142,75 @@ describe("Server list", function () {
 
     await vpn.waitForCondition(async () => {
       return (
-        (await vpn.getQueryProperty(
-          queries.screenHome.CONTROLLER_TITLE,
-          "text"
-        )) == "VPN is on"
-      );
+          (await vpn.getQueryProperty(
+              queries.screenHome.CONTROLLER_TITLE, 'text')) == 'VPN is on');
     });
-    assert.strictEqual(vpn.lastNotification().title, "VPN Connected");
+    assert.strictEqual(vpn.lastNotification().title, 'VPN Connected');
     assert.strictEqual(
-      vpn.lastNotification().message,
-      `Connected to ${currentCity}`
-    );
+        vpn.lastNotification().message, `Connected to ${currentCity}`);
   });
 
   it('Invalid searchs and multi results for singlehop', async () => {
-    const australia = queries.screenHome.serverListView.generateCountryId("au");
-    const austria = queries.screenHome.serverListView.generateCountryId("at");
-    const belgium = queries.screenHome.serverListView.generateCountryId("be");
+    const australia = queries.screenHome.serverListView.generateCountryId('au');
+    const austria = queries.screenHome.serverListView.generateCountryId('at');
+    const belgium = queries.screenHome.serverListView.generateCountryId('be');
 
     // No result search
     await vpn.waitForQueryAndWriteInTextField(
-      queries.screenHome.serverListView.SEARCH_BAR_TEXT_FIELD.visible(),
-      "invalid search"
-    );
-    await vpn.waitForQuery(queries.screenHome.serverListView.SEARCH_BAR_ERROR.visible())
-    await vpn.waitForQueryAndWriteInTextField(
-      queries.screenHome.serverListView.SEARCH_BAR_TEXT_FIELD.visible(),
-      ""
-    );
+        queries.screenHome.serverListView.SEARCH_BAR_TEXT_FIELD.visible(),
+        'invalid search');
+    await vpn
+        .waitForQuery(
+            queries.screenHome.serverListView.SEARCH_BAR_ERROR.visible())
+            await vpn
+        .waitForQueryAndWriteInTextField(
+            queries.screenHome.serverListView.SEARCH_BAR_TEXT_FIELD.visible(),
+            '');
 
     // multi result search
     await vpn.waitForQueryAndWriteInTextField(
-      queries.screenHome.serverListView.SEARCH_BAR_TEXT_FIELD.visible(),
-      "Au"
-    );
+        queries.screenHome.serverListView.SEARCH_BAR_TEXT_FIELD.visible(),
+        'Au');
 
     await vpn.waitForQuery(australia.visible())
-    await vpn.waitForQuery(austria.visible())
-    await vpn.query(belgium.hidden())
+        await vpn.waitForQuery(austria.visible())
+            await vpn.query(belgium.hidden())
   })
 
   it('Invalid searchs and multi results for multihop', async () => {
-    const australia = queries.screenHome.serverListView.generateCountryId("au");
-    const austria = queries.screenHome.serverListView.generateCountryId("at");
-    const belgium = queries.screenHome.serverListView.generateCountryId("be");
+    const australia = queries.screenHome.serverListView.generateCountryId('au');
+    const austria = queries.screenHome.serverListView.generateCountryId('at');
+    const belgium = queries.screenHome.serverListView.generateCountryId('be');
 
     await vpn.waitForQueryAndClick(
-      queries.screenHome.serverListView.MULTIHOP_SELECTOR_TAB.visible()
-    );
+        queries.screenHome.serverListView.MULTIHOP_SELECTOR_TAB.visible());
     await vpn.waitForQuery(
-      queries.screenHome.serverListView.ENTRY_BUTTON.visible()
-    );
+        queries.screenHome.serverListView.ENTRY_BUTTON.visible());
     await vpn.waitForQueryAndClick(
-      queries.screenHome.serverListView.EXIT_BUTTON.visible()
-    );
+        queries.screenHome.serverListView.EXIT_BUTTON.visible());
 
     // invalid server search
     await vpn.waitForQueryAndWriteInTextField(
-      queries.screenHome.serverListView.SEARCH_BAR_TEXT_FIELD.visible(),
-      "invalid search"
-    );
-    await vpn.waitForQuery(queries.screenHome.serverListView.SEARCH_BAR_ERROR.visible())
-    // await vpn.waitForQuery(australia.hidden())
-    await vpn.waitForQuery(austria.hidden())
-    await vpn.waitForQuery(belgium.hidden())
+        queries.screenHome.serverListView.SEARCH_BAR_TEXT_FIELD.visible(),
+        'invalid search');
+    await vpn
+        .waitForQuery(
+            queries.screenHome.serverListView.SEARCH_BAR_ERROR.visible())
+        // await vpn.waitForQuery(australia.hidden())
+        await vpn.waitForQuery(austria.hidden()) await vpn
+        .waitForQuery(belgium.hidden())
 
-    await vpn.waitForQueryAndWriteInTextField(
-      queries.screenHome.serverListView.SEARCH_BAR_TEXT_FIELD.visible(),
-      ""
-    );
+            await vpn
+        .waitForQueryAndWriteInTextField(
+            queries.screenHome.serverListView.SEARCH_BAR_TEXT_FIELD.visible(),
+            '');
 
     // multi result search
     await vpn.waitForQueryAndWriteInTextField(
-      queries.screenHome.serverListView.SEARCH_BAR_TEXT_FIELD.visible(),
-      "Au"
-    );
+        queries.screenHome.serverListView.SEARCH_BAR_TEXT_FIELD.visible(),
+        'Au');
     await vpn.waitForQuery(australia.visible())
-    await vpn.waitForQuery(austria.visible())
-    await vpn.waitForQuery(belgium.hidden())
+        await vpn.waitForQuery(austria.visible())
+            await vpn.waitForQuery(belgium.hidden())
   })
 });

--- a/translations/strings.yaml
+++ b/translations/strings.yaml
@@ -273,7 +273,7 @@ notifications:
     comment: "%1 is the name of the city the VPN is connected to."
   VPNMultihopConnectedMessage:
     value: "Connected to %1, through %2"
-    comment: "%1 is the name of the entry server, %2 is the name of the exit server."
+    comment: "%1 is the name of the exit server, %2 is the name of the entry server."
   VPNDisconnectedTitle: VPN Disconnected
   VPNDisconnectedMessage:
     value: "Disconnected from %1"

--- a/translations/strings.yaml
+++ b/translations/strings.yaml
@@ -271,6 +271,9 @@ notifications:
   VPNConnectedMessage:
     value: "Connected to %1"
     comment: "%1 is the name of the city the VPN is connected to."
+  VPNMultihopConnectedMessage:
+    value: "Connected to %1, through %2"
+    comment: "%1 is the name of the entry server, %2 is the name of the exit server."
   VPNDisconnectedTitle: VPN Disconnected
   VPNDisconnectedMessage:
     value: "Disconnected from %1"


### PR DESCRIPTION
## Description

Add a new string in strings.yaml to include both exit and entry server locations in the multihop VPN connected notification. 
Format: “Connected to X, through Y”. 

## Reference

    https://mozilla-hub.atlassian.net/browse/VPN-4195

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
