### PR TITLE
VPN-3914: Update index routes for linux build artifacts

### DIFF
--- a/taskcluster/ci/build/linux.yml
+++ b/taskcluster/ci/build/linux.yml
@@ -31,7 +31,9 @@ linux/bionic:
         platform: linux/bionic
     worker:
         docker-image: {in-tree: linux-build-bionic}
-    add-index-routes: linux-bionic
+    add-index-routes:
+        name: linux-bionic
+        type: build
 
 linux/focal:
     description: "Linux Build (Ubuntu/Focal)"
@@ -39,7 +41,9 @@ linux/focal:
         platform: linux/focal
     worker:
         docker-image: {in-tree: linux-build-focal}
-    add-index-routes: linux-focal
+    add-index-routes:
+        name: linux-focal
+        type: build
 
 linux/jammy:
     description: "Linux Build (Ubuntu/Jammy)"
@@ -47,7 +51,9 @@ linux/jammy:
         platform: linux/jammy
     worker:
         docker-image: {in-tree: linux-build-jammy}
-    add-index-routes: linux-jammy
+    add-index-routes:
+        name: linux-jammy
+        type: build
 
 linux/kinetic:
     description: "Linux Build (Ubuntu/Kinetic)"
@@ -55,7 +61,9 @@ linux/kinetic:
         platform: linux/kinetic
     worker:
         docker-image: {in-tree: linux-build-kinetic}
-    add-index-routes: linux-kinetic
+    add-index-routes:
+        name: linux-kinetic
+        type: build
 
 linux/fedora-fc36:
     description: "Linux Build (Fedora/36)"
@@ -63,7 +71,9 @@ linux/fedora-fc36:
         platform: linux/fedora-fc36
     worker:
         docker-image: {in-tree: linux-build-fedora-fc36}
-    add-index-routes: linux-fedora-fc36
+    add-index-routes:
+        name: linux-fedora-fc36
+        type: build
 
 linux/fedora-fc37:
     description: "Linux Build (Fedora/37)"
@@ -71,5 +81,6 @@ linux/fedora-fc37:
         platform: linux/fedora-fc37
     worker:
         docker-image: {in-tree: linux-build-fedora-fc37}
-    add-index-routes: linux-fedora-fc37
-
+    add-index-routes:
+        name: linux-fedora-fc37
+        type: build

--- a/taskcluster/ci/build/source.yml
+++ b/taskcluster/ci/build/source.yml
@@ -19,6 +19,9 @@ linux/source:
             - type: directory
               name: public/build
               path: /builds/worker/artifacts
+    add-index-routes:
+        name: source
+        type: build
     run:
         using: run-task
         use-caches: true


### PR DESCRIPTION
## Description
This attempts to update the indices for the Linux build artifacts to place them at `mozillavpn.v2.mozilla-vpn-client.branch.{xxxx}.latest.build` with the rest of the build artifacts, and to include the sources in there too.

## Reference
Github issue #5659 ([VPN-3914](https://mozilla-hub.atlassian.net/browse/VPN-3914))

## Checklist
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-3914]: https://mozilla-hub.atlassian.net/browse/VPN-3914?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ