### PR TITLE
VPN-4214 - Fix AuthenticationInBrowser test.

### DIFF
--- a/tests/functional/helper.js
+++ b/tests/functional/helper.js
@@ -325,7 +325,7 @@ module.exports = {
       const urlObj = new URL(url);
 
       const options = {
-        hostname: urlObj.hostname,
+        hostname: '127.0.0.1',
         port: parseInt(urlObj.searchParams.get('port'), 10),
         path: '/?code=the_code',
         method: 'GET',

--- a/tests/functional/helper.js
+++ b/tests/functional/helper.js
@@ -335,9 +335,9 @@ module.exports = {
         const req = http.request(options, res => {});
         req.on('close', resolve);
         req.on('error', error => {
-          throw new error(
+          throw new Error(
               `Unable to connect to ${urlObj.hostname} to complete the
-              auth`);
+              auth. ${error.name}, ${error.message}, ${error.stack}`);
         });
         req.end();
       });


### PR DESCRIPTION
After debugging with @mozrokafor we honed in on the fact that the mocked call to the DesktopAuthenticationListener is failing.

The DesktopAuthenticationListener is listening on QHostAddress::LocalHost. Equivalent to QHostAddress("127.0.0.1"). https://doc.qt.io/qt-6.2/qhostaddress.html#SpecialAddress-enum

I don't have confirmation of this, but I'm wondering if the Github Actions CI images changed and stopped routing "localhost" (that the test was using) to "127.0.0.1" and that's why the test suddenly broke.