### PR TITLE
VPN-4214 Add comments to testAuthenticationInBrowser.js

### DIFF
--- a/src/apps/vpn/tasks/authenticate/desktopauthenticationlistener.cpp
+++ b/src/apps/vpn/tasks/authenticate/desktopauthenticationlistener.cpp
@@ -21,7 +21,7 @@ DesktopAuthenticationListener::DesktopAuthenticationListener(QObject* parent)
     : AuthenticationListener(parent) {
   MZ_COUNT_CTOR(DesktopAuthenticationListener);
 
-  m_server = new QOAuthHttpServerReplyHandler(QHostAddress::Any, this);
+  m_server = new QOAuthHttpServerReplyHandler(this);
   connect(m_server, &QAbstractOAuthReplyHandler::callbackReceived, this,
           [this](const QVariantMap& values) {
             logger.debug() << "DesktopAuthenticationListener data received";
@@ -53,7 +53,8 @@ void DesktopAuthenticationListener::start(Task* task,
                                    emailAddress));
 
   if (!m_server->isListening()) {
-    m_server->listen(QHostAddress::Any);
+    m_server->listen(QHostAddress::LocalHost);
+    m_server->listen(QHostAddress::LocalHostIPv6);
   }
 
   if (!m_server->isListening()) {

--- a/src/apps/vpn/tasks/authenticate/desktopauthenticationlistener.cpp
+++ b/src/apps/vpn/tasks/authenticate/desktopauthenticationlistener.cpp
@@ -21,7 +21,7 @@ DesktopAuthenticationListener::DesktopAuthenticationListener(QObject* parent)
     : AuthenticationListener(parent) {
   MZ_COUNT_CTOR(DesktopAuthenticationListener);
 
-  m_server = new QOAuthHttpServerReplyHandler(QHostAddress::LocalHost, this);
+  m_server = new QOAuthHttpServerReplyHandler(QHostAddress::Any, this);
   connect(m_server, &QAbstractOAuthReplyHandler::callbackReceived, this,
           [this](const QVariantMap& values) {
             logger.debug() << "DesktopAuthenticationListener data received";
@@ -53,7 +53,7 @@ void DesktopAuthenticationListener::start(Task* task,
                                    emailAddress));
 
   if (!m_server->isListening()) {
-    m_server->listen(QHostAddress::LocalHost);
+    m_server->listen(QHostAddress::Any);
   }
 
   if (!m_server->isListening()) {

--- a/src/apps/vpn/tasks/authenticate/desktopauthenticationlistener.cpp
+++ b/src/apps/vpn/tasks/authenticate/desktopauthenticationlistener.cpp
@@ -21,7 +21,7 @@ DesktopAuthenticationListener::DesktopAuthenticationListener(QObject* parent)
     : AuthenticationListener(parent) {
   MZ_COUNT_CTOR(DesktopAuthenticationListener);
 
-  m_server = new QOAuthHttpServerReplyHandler(this);
+  m_server = new QOAuthHttpServerReplyHandler(QHostAddress::LocalHost, this);
   connect(m_server, &QAbstractOAuthReplyHandler::callbackReceived, this,
           [this](const QVariantMap& values) {
             logger.debug() << "DesktopAuthenticationListener data received";
@@ -54,7 +54,6 @@ void DesktopAuthenticationListener::start(Task* task,
 
   if (!m_server->isListening()) {
     m_server->listen(QHostAddress::LocalHost);
-    m_server->listen(QHostAddress::LocalHostIPv6);
   }
 
   if (!m_server->isListening()) {

--- a/tests/functional/helper.js
+++ b/tests/functional/helper.js
@@ -320,7 +320,9 @@ module.exports = {
       await this.wait();
 
       // We don't really want to go through the authentication flow because we
-      // are mocking everything.
+      // are mocking everything. So this next chunk of code manually
+      // makes a call to the DesktopAuthenticationListener to mock
+      // a successful authentication in browser.
       const url = await this.getLastUrl();
       const urlObj = new URL(url);
 

--- a/tests/functional/helper.js
+++ b/tests/functional/helper.js
@@ -324,11 +324,12 @@ module.exports = {
       // makes a call to the DesktopAuthenticationListener to mock
       // a successful authentication in browser.
       const url = await this.getLastUrl();
-      const urlObj = new URL(url);
-
+      const authListenerPort = (new URL(url)).searchParams.get('port');
       const options = {
-        hostname: urlObj.hostname,
-        port: parseInt(urlObj.searchParams.get('port'), 10),
+        // We hardcode 127.0.0.1 to match listening on QHostAddress:LocalHost
+        // and hardcoded in guardian's vpnClientPixelImageAuthUrl
+        hostname: '127.0.0.1',
+        port: parseInt(authListenerPort, 10),
         path: '/?code=the_code',
         method: 'GET',
       };

--- a/tests/functional/helper.js
+++ b/tests/functional/helper.js
@@ -325,7 +325,7 @@ module.exports = {
       const urlObj = new URL(url);
 
       const options = {
-        hostname: '127.0.0.1',
+        hostname: urlObj.hostname,
         port: parseInt(urlObj.searchParams.get('port'), 10),
         path: '/?code=the_code',
         method: 'GET',


### PR DESCRIPTION
After discussing further with @bakulf we've agreed that the original fix in #6141 is correct and this PR now is just extra comments to help make this clear for our future selves.

====
# Old Description

In #6141 we hard-coded 127.0.0.1 to get the AuthenticationInBrowser.js test working again:

```patch
-        hostname: urlObj.hostname,
+        hostname: '127.0.0.1',
```

This PR reverses the above change and updates the `DesktopAuthenticationListener`.

In [d553d3f](https://github.com/mozilla-mobile/mozilla-vpn-client/pull/6144/commits/d553d3fabab9e7d43dafb084f31d4912612e8be4) I update `DesktopAuthenticaitonListener` to be listening on `QHostAddress::Any` which is, both IPv4 and IPv6 addresses https://doc.qt.io/qt-6.2/qhostaddress.html#SpecialAddress-enum. @oskirby posed the question "is this secure?" to me in slack. I'm not sure....I'm not exactly sure what `QHostAddress::Any` but I think it's "0.0.0.0" which seems to me like we don't want to open a server on. 

In ebfc80759 I update this so that we don't initialize the ReplyHandler with a host and I call listen to the two localhost addresses. 

I had a hard time finding documentation on `QOAuthHttpServerReplyHandler`, so here's the source: https://code.qt.io/cgit/qt/qtnetworkauth.git/tree/src/oauth/qoauthhttpserverreplyhandler.cpp?h=6.2.4

===

Some more info about the bug. I initially was able to repro on my machine by updated /etc/hosts. But that stopped working for me so I've only verified this fix in CI. 

I'll also note that in [this run](https://github.com/mozilla-mobile/mozilla-vpn-client/actions/runs/4258689859/jobs/7410278691#step:8:9) I changed the `/etc/hosts` file and not the `DesktopAuthenticationListener` and was also able to get the tests to pass continuing to point to some kind of local DNS issue.