### PR TITLE
VPN-4252: Add builds for Ubuntu/Lunar

### DIFF
--- a/.github/workflows/ppa-automation.yaml
+++ b/.github/workflows/ppa-automation.yaml
@@ -55,7 +55,7 @@ jobs:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
           GNUPGHOME: ${{ runner.temp }}/gnupg-data
-          PPA_TARGET_DISTS: bionic focal jammy kinetic
+          PPA_TARGET_DISTS: bionic focal jammy kinetic lunar
           PPA_URL: ${{ steps.gen-source.outputs.ppa-url }}
         run: |
           mkdir -m700 $GNUPGHOME

--- a/taskcluster/ci/build/linux.yml
+++ b/taskcluster/ci/build/linux.yml
@@ -65,6 +65,14 @@ linux/kinetic:
         name: linux-kinetic
         type: build
 
+linux/lunar:
+    description: "Linux Build (Ubuntu/Lunar)"
+    treeherder:
+        platform: linux/lunar
+    worker:
+        docker-image: {in-tree: linux-build-lunar}
+    add-index-routes: linux-lunar
+
 linux/fedora-fc36:
     description: "Linux Build (Fedora/36)"
     treeherder:

--- a/taskcluster/ci/build/linux.yml
+++ b/taskcluster/ci/build/linux.yml
@@ -71,7 +71,9 @@ linux/lunar:
         platform: linux/lunar
     worker:
         docker-image: {in-tree: linux-build-lunar}
-    add-index-routes: linux-lunar
+    add-index-routes:
+        name: linux-lunar
+        type: build
 
 linux/fedora-fc36:
     description: "Linux Build (Fedora/36)"

--- a/taskcluster/ci/docker-image/kind.yml
+++ b/taskcluster/ci/docker-image/kind.yml
@@ -101,6 +101,7 @@ tasks:
     linux-build-lunar:
         symbol: I(linux-lunar)
         definition: linux-dpkg-build
+        cache: false ## Disable caching while Ubuntu/Lunar is in beta.
         args:
             DOCKER_BASE_IMAGE: ubuntu:lunar
     linux-build-fedora-fc36:

--- a/taskcluster/ci/docker-image/kind.yml
+++ b/taskcluster/ci/docker-image/kind.yml
@@ -98,6 +98,11 @@ tasks:
         definition: linux-dpkg-build
         args:
             DOCKER_BASE_IMAGE: ubuntu:kinetic
+    linux-build-lunar:
+        symbol: I(linux-lunar)
+        definition: linux-dpkg-build
+        args:
+            DOCKER_BASE_IMAGE: ubuntu:lunar
     linux-build-fedora-fc36:
         symbol: I(linux-fedora-fc36)
         definition: linux-rpm-build

--- a/taskcluster/docker/linux-dpkg-build/Dockerfile
+++ b/taskcluster/docker/linux-dpkg-build/Dockerfile
@@ -44,7 +44,7 @@ RUN mk-build-deps -i -r  --tool="apt-get --no-install-recommends --yes" \
 
 # Add worker user
 RUN mkdir /builds && \
-    useradd -d /builds/worker -s /bin/bash -m worker && \
+    useradd -d /builds/worker -s /bin/bash -m worker -o -u 1000 -g 1000 && \
     chown worker:worker /builds/worker && \
     mkdir /builds/worker/artifacts && \
     chown worker:worker /builds/worker/artifacts

--- a/taskcluster/docker/linux-dpkg-build/Dockerfile
+++ b/taskcluster/docker/linux-dpkg-build/Dockerfile
@@ -42,13 +42,10 @@ RUN mk-build-deps -i -r  --tool="apt-get --no-install-recommends --yes" \
 #-- Worker User -------------------------------------------------------------------------------------------------------
 #----------------------------------------------------------------------------------------------------------------------
 
-# Add worker user
-RUN mkdir /builds && \
-    useradd -d /builds/worker -s /bin/bash -m worker -o -u 1000 -g 1000 && \
-    chown worker:worker /builds/worker && \
-    mkdir /builds/worker/artifacts && \
-    chown worker:worker /builds/worker/artifacts
-
+# Setup the worker user
+# %include taskcluster/scripts/setup-worker.sh
+ADD topsrcdir/taskcluster/scripts/setup-worker.sh /root/setup-worker.sh
+RUN /root/setup-worker.sh
 WORKDIR /builds/worker/
 
 # Grant the worker user the ability to install packages without login

--- a/taskcluster/docker/linux-rpm-build/Dockerfile
+++ b/taskcluster/docker/linux-rpm-build/Dockerfile
@@ -25,13 +25,10 @@ RUN yum-builddep -y /root/mozillavpn-rpm.spec -D "_version 0.0.1"
 #-- Worker User -------------------------------------------------------------------------------------------------------
 #----------------------------------------------------------------------------------------------------------------------
 
-# Add worker user
-RUN mkdir /builds && \
-    useradd -d /builds/worker -s /bin/bash -m worker && \
-    chown worker:worker /builds/worker && \
-    mkdir /builds/worker/artifacts && \
-    chown worker:worker /builds/worker/artifacts
-
+# Setup the worker user
+# %include taskcluster/scripts/setup-worker.sh
+ADD topsrcdir/taskcluster/scripts/setup-worker.sh /root/setup-worker.sh
+RUN /root/setup-worker.sh
 WORKDIR /builds/worker/
 
 #----------------------------------------------------------------------------------------------------------------------

--- a/taskcluster/scripts/setup-worker.sh
+++ b/taskcluster/scripts/setup-worker.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+mkdir -p /builds/worker
+mkdir /builds/worker/artifacts
+
+# Setup the worker account for docker images
+if getent passwd 1000; then
+    # Rename and modify an existing user
+    PREV_USER_NAME=$(getent passwd 1000 | cut -d: -f1)
+    usermod -l worker ${PREV_USER_NAME}
+    groupmod -n worker ${PREV_USER_NAME}
+    usermod -d /builds/worker -s /bin/bash -m worker
+else
+   # Create a new worker account
+   useradd -d /builds/worker -s /bin/bash -m worker -u 1000
+fi
+chown -R worker:worker /builds/worker


### PR DESCRIPTION
## Description
Ubuntu 23.04/Lunar Lobster is due to be released sometime in the next month or two, so it's important for us to make sure that we produce viable builds prior to its release.

## Reference
Github issue #6155 ([VPN-4252](https://mozilla-hub.atlassian.net/browse/VPN-4252))

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-4252]: https://mozilla-hub.atlassian.net/browse/VPN-4252?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ