### PR TITLE
NIT: Icebox start on boot for android

### DIFF
--- a/src/apps/vpn/appfeaturelistcallback.h
+++ b/src/apps/vpn/appfeaturelistcallback.h
@@ -142,7 +142,7 @@ bool FeatureCallback_splitTunnel() {
 
 bool FeatureCallback_startOnBoot() {
 #if defined(MZ_LINUX) || defined(MZ_MACOS) || defined(MZ_WINDOWS) || \
-    defined(MZ_DUMMY) || defined(MZ_WASM) || defined(MZ_ANDROID)
+    defined(MZ_DUMMY) || defined(MZ_WASM)
   return true;
 #else
   return false;


### PR DESCRIPTION
## Description

We have flipped this off in the last 2 releases in a row, it's still not ready, so it should be disabled until we have a plan