### PR TITLE
VPN-4244: Handle the QNetworkReply::readyRead signal to avoid dropped data

### DIFF
--- a/src/apps/vpn/connectionbenchmark/benchmarktasktransfer.cpp
+++ b/src/apps/vpn/connectionbenchmark/benchmarktasktransfer.cpp
@@ -229,23 +229,13 @@ void BenchmarkTaskTransfer::transferProgressed(qint64 bytesSent,
   Q_UNUSED(bytesTotal);
 #endif
 
-  switch (m_type) {
-    case BenchmarkDownload: {
-      // Count and discard downloaded data
-      m_bytesTransferred += reply->skip(bytesTotal);
-      break;
-    }
-    case BenchmarkUpload: {
-      Q_UNUSED(reply);
-      if (bytesSent > 0) {
-        m_bytesTransferred = bytesSent;
-      }
-      break;
-    }
-    default: {
-      logger.error() << "Unhandled benchmark type";
-      break;
-    }
+  NetworkRequest* request = qobject_cast<NetworkRequest*>(sender());
+  if (request != nullptr) {
+    request->discardData();
+  }
+
+  if (bytesSent > 0) {
+    m_bytesTransferred = bytesSent;
   }
 }
 

--- a/src/shared/networkrequest.cpp
+++ b/src/shared/networkrequest.cpp
@@ -200,6 +200,7 @@ void NetworkRequest::replyFinished() {
   logger.debug() << "Network reply received - status:" << status
                  << "- expected:" << expect;
 
+  m_replyData.append(m_reply->readAll());
   processData(m_reply->error(), m_reply->errorString(), status, m_replyData);
 }
 

--- a/src/shared/networkrequest.cpp
+++ b/src/shared/networkrequest.cpp
@@ -200,8 +200,7 @@ void NetworkRequest::replyFinished() {
   logger.debug() << "Network reply received - status:" << status
                  << "- expected:" << expect;
 
-  QByteArray data = m_reply->readAll();
-  processData(m_reply->error(), m_reply->errorString(), status, data);
+  processData(m_reply->error(), m_reply->errorString(), status, m_replyData);
 }
 
 void NetworkRequest::processData(QNetworkReply::NetworkError error,
@@ -313,6 +312,11 @@ void NetworkRequest::handleReply(QNetworkReply* reply) {
 
   connect(m_reply, &QNetworkReply::finished, this,
           &NetworkRequest::replyFinished);
+
+  m_replyData.clear();
+  connect(m_reply, &QIODevice::readyRead, this,
+          [&]() { m_replyData.append(m_reply->readAll()); });
+
 #ifndef QT_NO_SSL
   connect(m_reply, &QNetworkReply::sslErrors, this, &NetworkRequest::sslErrors);
 #endif

--- a/src/shared/networkrequest.cpp
+++ b/src/shared/networkrequest.cpp
@@ -235,6 +235,15 @@ void NetworkRequest::processData(QNetworkReply::NetworkError error,
   emit requestCompleted(data);
 }
 
+qint64 NetworkRequest::discardData() {
+  qint64 bytes = m_replyData.count();
+  if (m_reply != nullptr) {
+    bytes += m_reply->skip(m_reply->bytesAvailable());
+  }
+  m_replyData.clear();
+  return bytes;
+}
+
 bool NetworkRequest::isRedirect() const {
   int status = statusCode();
   return status >= 300 && status < 400;

--- a/src/shared/networkrequest.h
+++ b/src/shared/networkrequest.h
@@ -110,6 +110,7 @@ class NetworkRequest final : public QObject {
 #endif
 
   QNetworkReply* m_reply = nullptr;
+  QByteArray m_replyData;
   int m_expectedStatusCode = 0;
 #ifdef MZ_WASM
   // In wasm network request, m_reply is null. So we need to store the "status

--- a/src/shared/networkrequest.h
+++ b/src/shared/networkrequest.h
@@ -62,6 +62,8 @@ class NetworkRequest final : public QObject {
                    const QString& errorString, int status,
                    const QByteArray& data);
 
+  qint64 discardData();
+
  private:
   void getResource();
 


### PR DESCRIPTION
## Description
I have been noticing that some of the unit tests fail on Qt 6.3.2, and when digging into it I have discovered that we are not receiving the payload data when handling an HTTP error, and this is required for some of the authentication flows (eg: TOTP or e-mail verification is required). To resolve this, we must handle the `QNetworkReply::readyRead()` signal.

## Reference
Github issue #6143 ([VPN-4244](https://mozilla-hub.atlassian.net/browse/VPN-4244))

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed


[VPN-4244]: https://mozilla-hub.atlassian.net/browse/VPN-4244?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ