### PR TITLE
Move telementry glean events out of MozillaVPN - VPN-4309

### DIFF
--- a/src/apps/vpn/mozillavpn.h
+++ b/src/apps/vpn/mozillavpn.h
@@ -166,12 +166,12 @@ class MozillaVPN final : public QObject {
 
   // Called at the end of the authentication flow. We can continue adding the
   // device if it doesn't exist yet, or we can go to OFF state.
-  void authenticationCompleted(const QByteArray& json, const QString& token);
+  void completeAuthentication(const QByteArray& json, const QString& token);
 
   void deviceAdded(const QString& deviceName, const QString& publicKey,
                    const QString& privateKey);
 
-  void deviceRemoved(const QString& publicKey, const QString& source);
+  void removeDevice(const QString& publicKey, const QString& source);
   void deviceRemovalCompleted(const QString& publicKey);
 
   void setJournalPublicAndPrivateKeys(const QString& publicKey,
@@ -282,9 +282,14 @@ class MozillaVPN final : public QObject {
   void stateChanged();
   void userStateChanged();
   void deviceRemoving(const QString& publicKey);
+  void deviceRemoved(const QString& source);
   void aboutNeeded();
   void updatingChanged();
   void accountDeleted();
+
+  void authenticationStarted();
+  void authenticationAborted();
+  void authenticationCompleted();
 
   // For Glean
   void initializeGlean();

--- a/src/apps/vpn/tasks/removedevice/taskremovedevice.cpp
+++ b/src/apps/vpn/tasks/removedevice/taskremovedevice.cpp
@@ -56,8 +56,8 @@ void TaskRemoveDevice::run() {
             if (error == QNetworkReply::ContentNotFoundError) {
               logger.error() << "The device has been removed in the meantime. "
                                 "Let's consider it a success";
-              MozillaVPN::instance()->deviceRemoved(m_publicKey,
-                                                    "TaskRemoveDevice");
+              MozillaVPN::instance()->removeDevice(m_publicKey,
+                                                   "TaskRemoveDevice");
               emit completed();
               return;
             }
@@ -71,8 +71,8 @@ void TaskRemoveDevice::run() {
           [this](const QByteArray&) {
             logger.debug() << "Device removed";
 
-            MozillaVPN::instance()->deviceRemoved(m_publicKey,
-                                                  "TaskRemoveDevice");
+            MozillaVPN::instance()->removeDevice(m_publicKey,
+                                                 "TaskRemoveDevice");
             emit completed();
           });
 }

--- a/src/apps/vpn/telemetry.cpp
+++ b/src/apps/vpn/telemetry.cpp
@@ -13,6 +13,7 @@
 #include "logger.h"
 #include "mozillavpn.h"
 #include "networkwatcher.h"
+#include "purchasehandler.h"
 #include "telemetry/gleansample.h"
 
 #if defined(MZ_ANDROID)
@@ -49,7 +50,70 @@ Telemetry::~Telemetry() { MZ_COUNT_DTOR(Telemetry); }
 void Telemetry::initialize() {
   logger.debug() << "Initialize";
 
-  Controller* controller = MozillaVPN::instance()->controller();
+  MozillaVPN* vpn = MozillaVPN::instance();
+  connect(vpn, &MozillaVPN::stateChanged, this, []() {
+    MozillaVPN::State state = MozillaVPN::instance()->state();
+
+    mozilla::glean::sample::app_step.record(
+        mozilla::glean::sample::AppStepExtra{
+            ._state = QVariant::fromValue(state).toString()});
+    emit GleanDeprecated::instance()->recordGleanEventWithExtraKeys(
+        GleanSample::appStep,
+        {{"state", QVariant::fromValue(state).toString()}});
+
+    if (state == MozillaVPN::StateDeviceLimit) {
+      mozilla::glean::sample::max_device_reached.record();
+      emit GleanDeprecated::instance()->recordGleanEvent(
+          GleanSample::maxDeviceReached);
+    }
+
+    if (state == MozillaVPN::StateSubscriptionNotValidated) {
+      mozilla::glean::sample::iap_subscription_failed.record(
+          mozilla::glean::sample::IapSubscriptionFailedExtra{
+              ._error = "not-validated",
+              ._sku = PurchaseHandler::instance()->currentSKU()});
+      emit GleanDeprecated::instance()->recordGleanEventWithExtraKeys(
+          GleanSample::iapSubscriptionFailed,
+          {{"error", "not-validated"},
+           {"sku", PurchaseHandler::instance()->currentSKU()}});
+    }
+
+    if (state == MozillaVPN::StateSubscriptionBlocked) {
+      mozilla::glean::sample::iap_subscription_failed.record(
+          mozilla::glean::sample::IapSubscriptionFailedExtra{
+              ._error = "alrady-subscribed",
+          });
+      emit GleanDeprecated::instance()->recordGleanEventWithExtraKeys(
+          GleanSample::iapSubscriptionFailed, {{"error", "alrady-subscribed"}});
+    }
+  });
+
+  connect(vpn, &MozillaVPN::authenticationStarted, this, []() {
+    mozilla::glean::sample::authentication_started.record();
+    emit GleanDeprecated::instance()->recordGleanEvent(
+        GleanSample::authenticationStarted);
+  });
+
+  connect(vpn, &MozillaVPN::authenticationAborted, this, []() {
+    mozilla::glean::sample::authentication_aborted.record();
+    emit GleanDeprecated::instance()->recordGleanEvent(
+        GleanSample::authenticationAborted);
+  });
+
+  connect(vpn, &MozillaVPN::authenticationCompleted, this, []() {
+    mozilla::glean::sample::authentication_completed.record();
+    emit GleanDeprecated::instance()->recordGleanEvent(
+        GleanSample::authenticationCompleted);
+  });
+
+  connect(vpn, &MozillaVPN::deviceRemoved, this, [](const QString& source) {
+    mozilla::glean::sample::device_removed.record(
+        mozilla::glean::sample::DeviceRemovedExtra{._source = source});
+    emit GleanDeprecated::instance()->recordGleanEventWithExtraKeys(
+        GleanSample::deviceRemoved, {{"source", source}});
+  });
+
+  Controller* controller = vpn->controller();
   Q_ASSERT(controller);
 
 #if defined(MZ_ANDROID)
@@ -114,6 +178,55 @@ void Telemetry::initialize() {
     mozilla::glean::sample::server_unavailable_error.record();
     emit GleanDeprecated::instance()->recordGleanEvent(
         GleanSample::serverUnavailableError);
+  });
+
+  PurchaseHandler* purchaseHandler = PurchaseHandler::instance();
+  connect(purchaseHandler, &PurchaseHandler::subscriptionStarted, this,
+          [](const QString& productIdentifier) {
+            mozilla::glean::sample::iap_subscription_started.record(
+                mozilla::glean::sample::IapSubscriptionStartedExtra{
+                    ._sku = productIdentifier});
+            emit GleanDeprecated::instance()->recordGleanEventWithExtraKeys(
+                GleanSample::iapSubscriptionStarted,
+                {{"sku", productIdentifier}});
+          });
+
+  connect(purchaseHandler, &PurchaseHandler::restoreSubscriptionStarted, this,
+          []() {
+            mozilla::glean::sample::iap_restore_sub_started.record();
+            emit GleanDeprecated::instance()->recordGleanEvent(
+                GleanSample::iapRestoreSubStarted);
+          });
+
+  connect(purchaseHandler, &PurchaseHandler::subscriptionCompleted, this, []() {
+    mozilla::glean::sample::iap_subscription_completed.record(
+        mozilla::glean::sample::IapSubscriptionCompletedExtra{
+            ._sku = PurchaseHandler::instance()->currentSKU()});
+    emit GleanDeprecated::instance()->recordGleanEventWithExtraKeys(
+        GleanSample::iapSubscriptionCompleted,
+        {{"sku", PurchaseHandler::instance()->currentSKU()}});
+  });
+
+  connect(purchaseHandler, &PurchaseHandler::subscriptionFailed, this, []() {
+    mozilla::glean::sample::iap_subscription_failed.record(
+        mozilla::glean::sample::IapSubscriptionFailedExtra{
+            ._error = "failed",
+            ._sku = PurchaseHandler::instance()->currentSKU()});
+    emit GleanDeprecated::instance()->recordGleanEventWithExtraKeys(
+        GleanSample::iapSubscriptionFailed,
+        {{"error", "failed"},
+         {"sku", PurchaseHandler::instance()->currentSKU()}});
+  });
+
+  connect(purchaseHandler, &PurchaseHandler::subscriptionCanceled, this, []() {
+    mozilla::glean::sample::iap_subscription_failed.record(
+        mozilla::glean::sample::IapSubscriptionFailedExtra{
+            ._error = "canceled",
+            ._sku = PurchaseHandler::instance()->currentSKU()});
+    emit GleanDeprecated::instance()->recordGleanEventWithExtraKeys(
+        GleanSample::iapSubscriptionFailed,
+        {{"error", "canceled"},
+         {"sku", PurchaseHandler::instance()->currentSKU()}});
   });
 }
 

--- a/src/apps/vpn/websocket/pushmessage.cpp
+++ b/src/apps/vpn/websocket/pushmessage.cpp
@@ -145,6 +145,6 @@ bool PushMessage::handleDeviceDeleted(const QJsonObject& payload) {
     return true;
   }
 
-  MozillaVPN::instance()->deviceRemoved(publicKey, "PushMessage");
+  MozillaVPN::instance()->removeDevice(publicKey, "PushMessage");
   return true;
 }

--- a/tests/qml/mocmozillavpn.cpp
+++ b/tests/qml/mocmozillavpn.cpp
@@ -79,11 +79,11 @@ void MozillaVPN::authenticateWithType(
 
 void MozillaVPN::setToken(const QString&) {}
 
-void MozillaVPN::authenticationCompleted(const QByteArray&, const QString&) {}
+void MozillaVPN::completeAuthentication(const QByteArray&, const QString&) {}
 
 void MozillaVPN::deviceAdded(const QString&, const QString&, const QString&) {}
 
-void MozillaVPN::deviceRemoved(const QString&, const QString&) {}
+void MozillaVPN::removeDevice(const QString&, const QString&) {}
 
 void MozillaVPN::deviceRemovalCompleted(const QString&) {}
 

--- a/tests/unit/mocmozillavpn.cpp
+++ b/tests/unit/mocmozillavpn.cpp
@@ -85,11 +85,11 @@ void MozillaVPN::authenticateWithType(
 
 void MozillaVPN::setToken(const QString&) {}
 
-void MozillaVPN::authenticationCompleted(const QByteArray&, const QString&) {}
+void MozillaVPN::completeAuthentication(const QByteArray&, const QString&) {}
 
 void MozillaVPN::deviceAdded(const QString&, const QString&, const QString&) {}
 
-void MozillaVPN::deviceRemoved(const QString&, const QString&) {}
+void MozillaVPN::removeDevice(const QString&, const QString&) {}
 
 void MozillaVPN::deviceRemovalCompleted(const QString&) {}
 


### PR DESCRIPTION
This is one step in the direction of clean up MozillaVPN class.