### PR TITLE
Stop depending on vpnFlickable id on focus change

### DIFF
--- a/nebula/CMakeLists.txt
+++ b/nebula/CMakeLists.txt
@@ -16,4 +16,5 @@ target_sources(nebula PRIVATE
     ui/nebula_resources.qrc
     ui/compatQt6.qrc
     ui/resourcesQt6.qrc
+    ui/utils.qrc
 )

--- a/nebula/nebula.cpp
+++ b/nebula/nebula.cpp
@@ -13,6 +13,7 @@ void Nebula::Initialize(QQmlEngine* engine) {
   Q_INIT_RESOURCE(nebula_resources);
   Q_INIT_RESOURCE(compatQt6);
   Q_INIT_RESOURCE(resourcesQt6);
+  Q_INIT_RESOURCE(utils);
 #endif
 
   engine->addImportPath(QRC_ROOT);

--- a/nebula/ui/components/MZButtonBase.qml
+++ b/nebula/ui/components/MZButtonBase.qml
@@ -48,13 +48,21 @@ RoundButton {
 
 
     onActiveFocusChanged: {
-        if (!focus) {
+        if (!activeFocus) {
             return visualStateItem.state = uiState.stateDefault;
         }
         visualStateItem.state = uiState.stateFocused;
 
-        if (focus && typeof(vpnFlickable) !== "undefined" && typeof(vpnFlickable.ensureVisible) !== "undefined")
-            vpnFlickable.ensureVisible(root)
+        var parentComponent = parent
+        while(parentComponent && parentComponent !== "undefined") {
+            if(typeof(parentComponent.ensureVisible) !== "undefined") {
+                parentComponent.ensureVisible(root)
+                return
+            }
+            else {
+                parentComponent = parentComponent.parent
+            }
+        }
     }
 
     background: Rectangle {

--- a/nebula/ui/components/MZButtonBase.qml
+++ b/nebula/ui/components/MZButtonBase.qml
@@ -6,6 +6,7 @@ import QtQuick 2.0
 import QtQuick.Controls 2.5
 
 import Mozilla.Shared 1.0
+import utils 0.1
 
 RoundButton {
     id: root
@@ -53,16 +54,7 @@ RoundButton {
         }
         visualStateItem.state = uiState.stateFocused;
 
-        var parentComponent = parent
-        while(parentComponent && parentComponent !== "undefined") {
-            if(typeof(parentComponent.ensureVisible) !== "undefined") {
-                parentComponent.ensureVisible(root)
-                return
-            }
-            else {
-                parentComponent = parentComponent.parent
-            }
-        }
+        MZUtils.scrollToComponent(root)
     }
 
     background: Rectangle {

--- a/nebula/ui/components/MZCheckBox.qml
+++ b/nebula/ui/components/MZCheckBox.qml
@@ -24,11 +24,18 @@ CheckBox {
     hoverEnabled: false
     onActiveFocusChanged: {
         if (!activeFocus)
-            mouseArea.changeState(uiState.stateDefault);
+            return mouseArea.changeState(uiState.stateDefault);
 
-        if (activeFocus && typeof(vpnFlickable) !== "undefined" && vpnFlickable.ensureVisible)
-            vpnFlickable.ensureVisible(checkBox);
-
+        var parentComponent = parent
+        while(parentComponent && parentComponent !== "undefined") {
+            if(typeof(parentComponent.ensureVisible) !== "undefined") {
+                parentComponent.ensureVisible(checkBox)
+                return
+            }
+            else {
+                parentComponent = parentComponent.parent
+            }
+        }
     }
     Keys.onPressed: event => {
         if (event.key === Qt.Key_Return || event.key === Qt.Key_Space)

--- a/nebula/ui/components/MZCheckBox.qml
+++ b/nebula/ui/components/MZCheckBox.qml
@@ -7,6 +7,7 @@ import QtQuick.Controls 2.14
 import QtQuick.Layouts 1.14
 
 import Mozilla.Shared 1.0
+import utils 0.1
 
 CheckBox {
     property var uiState: MZTheme.theme.uiState
@@ -26,16 +27,7 @@ CheckBox {
         if (!activeFocus)
             return mouseArea.changeState(uiState.stateDefault);
 
-        var parentComponent = parent
-        while(parentComponent && parentComponent !== "undefined") {
-            if(typeof(parentComponent.ensureVisible) !== "undefined") {
-                parentComponent.ensureVisible(checkBox)
-                return
-            }
-            else {
-                parentComponent = parentComponent.parent
-            }
-        }
+        MZUtils.scrollToComponent(checkBox)
     }
     Keys.onPressed: event => {
         if (event.key === Qt.Key_Return || event.key === Qt.Key_Space)

--- a/nebula/ui/components/MZSettingsToggle.qml
+++ b/nebula/ui/components/MZSettingsToggle.qml
@@ -17,7 +17,20 @@ CheckBox {
     property string accessibleName
 
     onClicked: toolTip.hide()
-    onActiveFocusChanged: if (focus && typeof(vpnFlickable) !== "undefined" && typeof(vpnFlickable.ensureVisible) !== "undefined") ensureVisible(vpnSettingsToggle)
+    onActiveFocusChanged: {
+        if(activeFocus) {
+            var parentComponent = parent
+            while(parentComponent && parentComponent !== "undefined") {
+                if(typeof(parentComponent.ensureVisible) !== "undefined") {
+                    parentComponent.ensureVisible(vpnSettingsToggle)
+                    return
+                }
+                else {
+                    parentComponent = parentComponent.parent
+                }
+            }
+        }
+    }
 
     height: MZTheme.theme.vSpacing
     width: 45

--- a/nebula/ui/components/MZSettingsToggle.qml
+++ b/nebula/ui/components/MZSettingsToggle.qml
@@ -6,6 +6,7 @@ import QtQuick 2.0
 import QtQuick.Controls 2.5
 
 import Mozilla.Shared 1.0
+import utils 0.1
 
 CheckBox {
     id: vpnSettingsToggle
@@ -17,20 +18,7 @@ CheckBox {
     property string accessibleName
 
     onClicked: toolTip.hide()
-    onActiveFocusChanged: {
-        if(activeFocus) {
-            var parentComponent = parent
-            while(parentComponent && parentComponent !== "undefined") {
-                if(typeof(parentComponent.ensureVisible) !== "undefined") {
-                    parentComponent.ensureVisible(vpnSettingsToggle)
-                    return
-                }
-                else {
-                    parentComponent = parentComponent.parent
-                }
-            }
-        }
-    }
+    onActiveFocusChanged: if(activeFocus) MZUtils.scrollToComponent(vpnSettingsToggle)
 
     height: MZTheme.theme.vSpacing
     width: 45

--- a/nebula/ui/components/MZSwipeDelegate.qml
+++ b/nebula/ui/components/MZSwipeDelegate.qml
@@ -44,8 +44,17 @@ SwipeDelegate {
     }
 
     onActiveFocusChanged: {
-        if (focus && typeof(vpnFlickable) !== "undefined" && typeof(vpnFlickable.ensureVisible) !== "undefined") {
-            vpnFlickable.ensureVisible(swipeDelegate)
+        if(activeFocus) {
+            var parentComponent = parent
+            while(parentComponent && parentComponent !== "undefined") {
+                if(typeof(parentComponent.ensureVisible) !== "undefined") {
+                    parentComponent.ensureVisible(swipeDelegate)
+                    return
+                }
+                else {
+                    parentComponent = parentComponent.parent
+                }
+            }
         }
     }
 

--- a/nebula/ui/components/MZSwipeDelegate.qml
+++ b/nebula/ui/components/MZSwipeDelegate.qml
@@ -6,6 +6,7 @@ import QtQuick 2.15
 import QtQuick.Controls 2.15
 
 import Mozilla.Shared 1.0
+import utils 0.1
 
 SwipeDelegate {
     id: swipeDelegate
@@ -43,20 +44,7 @@ SwipeDelegate {
         onSwipeClose()
     }
 
-    onActiveFocusChanged: {
-        if(activeFocus) {
-            var parentComponent = parent
-            while(parentComponent && parentComponent !== "undefined") {
-                if(typeof(parentComponent.ensureVisible) !== "undefined") {
-                    parentComponent.ensureVisible(swipeDelegate)
-                    return
-                }
-                else {
-                    parentComponent = parentComponent.parent
-                }
-            }
-        }
-    }
+    onActiveFocusChanged: if(activeFocus) MZUtils.scrollToComponent(swipeDelegate)
 
     contentItem: Item {
         id: swipeDelegateContentItem

--- a/nebula/ui/components/MZTextBlock.qml
+++ b/nebula/ui/components/MZTextBlock.qml
@@ -21,10 +21,4 @@ Text {
 
     Accessible.role: Accessible.StaticText
     Accessible.name: text
-
-    onActiveFocusChanged: {
-        if (focus && typeof(vpnFlickable) !== "undefined" && typeof(vpnFlickable.ensureVisible) !== "undefined") {
-            vpnFlickable.ensureVisible(root)
-        }
-    }
 }

--- a/nebula/ui/components/forms/MZRadioButton.qml
+++ b/nebula/ui/components/forms/MZRadioButton.qml
@@ -7,7 +7,7 @@ import QtQuick.Controls 2.14
 
 import Mozilla.Shared 1.0
 import components 0.1
-import util 0.1
+import utils 0.1
 
 RadioDelegate {
     id: radioControl
@@ -24,8 +24,8 @@ RadioDelegate {
         state = uiState.stateDefault
     }
 
-    onFocusChanged: {
-        if (!radioControl.focus)
+    onActiveFocusChanged: {
+        if (!radioControl.activeFocus)
             return mouseArea.changeState(uiState.stateDefault);
 
         MZUtils.scrollToComponent(radioControl)

--- a/nebula/ui/components/forms/MZRadioButton.qml
+++ b/nebula/ui/components/forms/MZRadioButton.qml
@@ -26,8 +26,18 @@ RadioDelegate {
     onFocusChanged: {
         if (!radioControl.focus)
             return mouseArea.changeState(uiState.stateDefault);
-        if (typeof(vpnFlickable) !== "undefined" && vpnFlickable.ensureVisible)
-            vpnFlickable.ensureVisible(radioControl);
+
+        var parentComponent = parent
+        while(parentComponent && parentComponent !== "undefined") {
+            if(typeof(parentComponent.ensureVisible) !== "undefined") {
+                parentComponent.ensureVisible(radioControl)
+                return
+            }
+            else {
+                parentComponent = parentComponent.parent
+            }
+        }
+
     }
 
     Keys.onPressed: event => {

--- a/nebula/ui/components/forms/MZRadioButton.qml
+++ b/nebula/ui/components/forms/MZRadioButton.qml
@@ -7,6 +7,7 @@ import QtQuick.Controls 2.14
 
 import Mozilla.Shared 1.0
 import components 0.1
+import util 0.1
 
 RadioDelegate {
     id: radioControl
@@ -27,17 +28,7 @@ RadioDelegate {
         if (!radioControl.focus)
             return mouseArea.changeState(uiState.stateDefault);
 
-        var parentComponent = parent
-        while(parentComponent && parentComponent !== "undefined") {
-            if(typeof(parentComponent.ensureVisible) !== "undefined") {
-                parentComponent.ensureVisible(radioControl)
-                return
-            }
-            else {
-                parentComponent = parentComponent.parent
-            }
-        }
-
+        MZUtils.scrollToComponent(radioControl)
     }
 
     Keys.onPressed: event => {

--- a/nebula/ui/components/forms/MZTextArea.qml
+++ b/nebula/ui/components/forms/MZTextArea.qml
@@ -81,8 +81,17 @@ Item {
             }
 
             onActiveFocusChanged: {
-                if (focus && typeof(vpnFlickable) !== "undefined" && typeof(vpnFlickable.ensureVisible) !== "undefined") {
-                    vpnFlickable.ensureVisible(textArea)
+                if(activeFocus) {
+                    var parentComponent = parent
+                    while(parentComponent && parentComponent !== "undefined") {
+                        if(typeof(parentComponent.ensureVisible) !== "undefined") {
+                            parentComponent.ensureVisible(textArea)
+                            return
+                        }
+                        else {
+                            parentComponent = parentComponent.parent
+                        }
+                    }
                 }
             }
 

--- a/nebula/ui/components/forms/MZTextArea.qml
+++ b/nebula/ui/components/forms/MZTextArea.qml
@@ -8,6 +8,7 @@ import QtQuick.Layouts 1.14
 
 import Mozilla.Shared 1.0
 import components 0.1
+import utils 0.1
 
 Item {
     property alias placeholderText: formattedPlaceholderText.text
@@ -80,20 +81,7 @@ Item {
                 }
             }
 
-            onActiveFocusChanged: {
-                if(activeFocus) {
-                    var parentComponent = parent
-                    while(parentComponent && parentComponent !== "undefined") {
-                        if(typeof(parentComponent.ensureVisible) !== "undefined") {
-                            parentComponent.ensureVisible(textArea)
-                            return
-                        }
-                        else {
-                            parentComponent = parentComponent.parent
-                        }
-                    }
-                }
-            }
+            onActiveFocusChanged: if(activeFocus)  MZUtils.scrollToComponent(textArea)
 
             Connections {
                 target: window

--- a/nebula/ui/components/forms/MZTextField.qml
+++ b/nebula/ui/components/forms/MZTextField.qml
@@ -42,8 +42,19 @@ TextField {
     verticalAlignment: TextInput.AlignVCenter
     horizontalAlignment: TextInput.AlignLeft
 
-    onActiveFocusChanged: if (focus && typeof(vpnFlickable) !== "undefined" && typeof(vpnFlickable.ensureVisible) !== "undefined") {
-        vpnFlickable.ensureVisible(textField);
+    onActiveFocusChanged: {
+        if(activeFocus) {
+            var parentComponent = parent
+            while(parentComponent && parentComponent !== "undefined") {
+                if(typeof(parentComponent.ensureVisible) !== "undefined") {
+                    parentComponent.ensureVisible(textField)
+                    return
+                }
+                else {
+                    parentComponent = parentComponent.parent
+                }
+            }
+        }
     }
     // This is a workaround for VoiceOver on macOS: https://bugreports.qt.io/browse/QTBUG-108189
     // After gaining initial focus or typing in TextField the screen reader

--- a/nebula/ui/components/forms/MZTextField.qml
+++ b/nebula/ui/components/forms/MZTextField.qml
@@ -8,6 +8,7 @@ import QtQuick.Layouts 1.14
 
 import Mozilla.Shared 1.0
 import components 0.1
+import utils 0.1
 
 TextField {
     property bool hasError: false
@@ -42,20 +43,8 @@ TextField {
     verticalAlignment: TextInput.AlignVCenter
     horizontalAlignment: TextInput.AlignLeft
 
-    onActiveFocusChanged: {
-        if(activeFocus) {
-            var parentComponent = parent
-            while(parentComponent && parentComponent !== "undefined") {
-                if(typeof(parentComponent.ensureVisible) !== "undefined") {
-                    parentComponent.ensureVisible(textField)
-                    return
-                }
-                else {
-                    parentComponent = parentComponent.parent
-                }
-            }
-        }
-    }
+    onActiveFocusChanged: if(activeFocus) MZUtils.scrollToComponent(textField)
+
     // This is a workaround for VoiceOver on macOS: https://bugreports.qt.io/browse/QTBUG-108189
     // After gaining initial focus or typing in TextField the screen reader
     // fails to narrate any accessible content and action. After regaining

--- a/nebula/ui/utils.qrc
+++ b/nebula/ui/utils.qrc
@@ -1,0 +1,6 @@
+<RCC>
+    <qresource prefix="/nebula">
+        <file>utils/qmldir</file>
+        <file>utils/MZUtils.qml</file>
+    </qresource>
+</RCC>

--- a/nebula/ui/utils/MZUtils.qml
+++ b/nebula/ui/utils/MZUtils.qml
@@ -1,0 +1,15 @@
+pragma Singleton
+
+import QtQuick 2.15
+
+QtObject {
+    function scrollToComponent(root) {
+        let parentComponent = root.parent
+        while(parentComponent && parentComponent !== "undefined") {
+            if(typeof(parentComponent.ensureVisible) !== "undefined") {
+                return parentComponent.ensureVisible(root)
+            }
+            parentComponent = parentComponent.parent
+        }
+    }
+}

--- a/nebula/ui/utils/qmldir
+++ b/nebula/ui/utils/qmldir
@@ -1,0 +1,1 @@
+singleton MZUtils 0.1 MZUtils.qml


### PR DESCRIPTION
## Description

- Instead of depending on a component specifically named `vpnFlickable` when ensuring a component is visible when gaining focus, iterate through it's view hierarchy to see if it is an ancestor of a scrollable view
  - Results in a fix for keyboard nav scrolling on the tips and tricks page
- Introduce MZUtils - a home for generic qml utility functions in nebula

https://user-images.githubusercontent.com/15353801/223855212-c2136daa-756b-4e24-8321-a57829c583ed.mov

## Reference

[VPN-2958: [a11y] Scroll is not working as expected using keyboard](https://mozilla-hub.atlassian.net/browse/VPN-2958)

