### PR TITLE
Avoid multiple reconnect when changing custom DNS - VPN-4304

### DIFF
--- a/src/apps/vpn/settingswatcher.h
+++ b/src/apps/vpn/settingswatcher.h
@@ -20,11 +20,17 @@ class SettingsWatcher final : public QObject {
 
   ~SettingsWatcher();
 
- private slots:
-  void maybeServerSwitch();
-
  private:
   explicit SettingsWatcher(QObject* parent);
+
+  void maybeServerSwitch();
+
+  void operationCompleted();
+
+ private:
+  class TaskSettingsWatcher;
+
+  bool m_operationRunning = false;
 };
 
 #endif  // SETTINGSWATCHER_H


### PR DESCRIPTION
somehow, on mac, `onEditingFinished` does not work as expected (VPN-4166). Let's add an extra check to avoid multiple activation.