### PR TITLE
Prevent link button in contact form from overflow

### DIFF
--- a/nebula/ui/components/MZLinkButton.qml
+++ b/nebula/ui/components/MZLinkButton.qml
@@ -127,6 +127,8 @@ MZButtonBase {
         Label {
             id: label
 
+            Layout.fillWidth: true
+
             text: labelText
             color: root.linkColor.defaultColor
             horizontalAlignment: textAlignment

--- a/src/apps/vpn/ui/screens/getHelp/contactUs/ViewContactUsForm.qml
+++ b/src/apps/vpn/ui/screens/getHelp/contactUs/ViewContactUsForm.qml
@@ -184,7 +184,8 @@ MZViewBase {
                 }
 
                 MZLinkButton {
-                    anchors.horizontalCenter: parent.horizontalCenter
+                    anchors.left: parent.left
+                    anchors.right: parent.right
                     labelText: MZI18n.InAppSupportWorkflowPrivacyNoticeLinkText
                     onClicked: MZUrlOpener.openUrlLabel("privacyNotice")
                 }


### PR DESCRIPTION
## Description

- Prevents the label in MZLinkButton from overflowing

| Before  | After |
| ------------- | ------------- |
| <img width="472" alt="Screen Shot 2023-03-10 at 11 07 05 AM" src="https://user-images.githubusercontent.com/15353801/224365507-47b8479e-a4b3-44c1-8c68-17b94139263a.png"> | <img width="472" alt="Screen Shot 2023-03-10 at 11 06 29 AM" src="https://user-images.githubusercontent.com/15353801/224365556-c8115959-3780-4d59-bf2e-f5577daf66dc.png"> |

## Reference

[VPN-4290: [l10n] “Mozilla VPN Privacy Notice” link from “Contact support” screen has UI issues in some languages](https://mozilla-hub.atlassian.net/browse/VPN-4290)