### PR TITLE
Bump MAC guide version requirement down to 2.14

### DIFF
--- a/addons/guide_12_multi_account_containers/manifest.json
+++ b/addons/guide_12_multi_account_containers/manifest.json
@@ -4,7 +4,7 @@
   "name": "Guide: Multi-Account Containers",
   "type": "guide",
   "conditions": {
-    "min_client_version": "2.15.0"
+    "min_client_version": "2.14.0"
   },
   "guide": {
     "id": "guide_multi_account_containers",


### PR DESCRIPTION
## Description

- Change Multi Account Container guide to require a minimum client version of 2.14 instead of 2.15

## Reference

[VPN-4036: Create Multi-Account Container guide client addon](https://mozilla-hub.atlassian.net/browse/VPN-4036)