### PR TITLE
Fix VPN-4348

### DIFF
--- a/src/apps/vpn/ui/screens/settings/ViewDNSSettings.qml
+++ b/src/apps/vpn/ui/screens/settings/ViewDNSSettings.qml
@@ -45,6 +45,7 @@ MZViewBase {
         Loader {
             objectName: "DNSSettingsInformationCardLoader"
             active: !VPNController.silentServerSwitchingSupported && VPNController.state !== VPNController.StateOff
+            visible: active
             Layout.alignment: Qt.AlignHCenter
             sourceComponent: InformationCard {
                 objectName: "DNSSettingsViewInformationCard"


### PR DESCRIPTION
## Description

This prevents an inactive loader from erroneously soaking up vertical space when going from  
`DNS settings view with VPN on` -> `home view via the nav bar and turning vpn off` -> `back to DNS settings view`.  

## Reference

VPN-4348

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
