### PR TITLE
VPN-4336 - remove snippet of uplifted code

### DIFF
--- a/scripts/utils/import_languages.py
+++ b/scripts/utils/import_languages.py
@@ -179,10 +179,6 @@ for l10n_file in l10n_files:
 
 os.system(f"{lupdate} translations/generated/dummy_language.pro")
 for l10n_file in l10n_files:
-    # Let's remove the non-translated strings if needed
-    if l10n_file['locale'] != 'en':
-        print(f"{lconvert} -i {l10n_file['ts']} -no-untranslated -o {l10n_file['ts']}")
-        os.system(f"{lconvert} -i {l10n_file['ts']} -no-untranslated -o {l10n_file['ts']}")
     os.system(f"{lrelease} -idbased {l10n_file['ts']}")
 
 print(f'Imported {len(l10n_files)} locales')


### PR DESCRIPTION
## Description

This code was removing non-translated strings, leaving us with no fallback.

This is being merged into `2.14.0` and not `main` because it is working on `main`:
- A "smarter fallbacks" PR was merged on Feb 14: https://github.com/mozilla-mobile/mozilla-vpn-client/pull/5987
- Some follow up work was merged on Feb 16: https://github.com/mozilla-mobile/mozilla-vpn-client/pull/6059
- https://github.com/mozilla-mobile/mozilla-vpn-client/pull/6059 was uplifted to the `releases/2.14.0` on Mar 9. 
- But the original work wasn't uplifted, and so a bug was introduced in the release branch only

## Reference
https://mozilla-hub.atlassian.net/browse/VPN-4336

## Checklist
    
- [X] My code follows the style guidelines for this project
- [X] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [X] I have performed a self review of my own code
- [X] I have commented my code PARTICULARLY in hard to understand areas
- [X] I have added thorough tests where needed
