### PR TITLE
VPN-4379:  Fix the fetching of Sentry secrets in Windows CI

### DIFF
--- a/taskcluster/scripts/build/windows.ps1
+++ b/taskcluster/scripts/build/windows.ps1
@@ -26,7 +26,7 @@ $SOURCE_DIR = resolve-path "$TASK_WORKDIR/mozillavpn-$SOURCE_VERSION"
 Remove-Item $FETCHES_PATH/VisualStudio/VC/Tools/MSVC/14.30.30705/bin/HostX64/x64/VCTIP.EXE
 
 # Ensure user scripts are accessible in the path.
-$PYTHON_SCRIPTS =$(python3 -c "import site, os; print(os.path.join(site.getuserbase(), 'Scripts')")
+$PYTHON_SCRIPTS =$(python3 -c "import site, os; print(os.path.join(site.getuserbase(), 'Scripts'))")
 Write-Output "Python Scripts: $PYTHON_SCRIPTS" 
 $env:PATH ="$FETCHES_PATH;$QTPATH;$PYTHON_SCRIPTS;$env:PATH"
 

--- a/taskcluster/scripts/build/windows.ps1
+++ b/taskcluster/scripts/build/windows.ps1
@@ -25,14 +25,14 @@ $SOURCE_DIR = resolve-path "$TASK_WORKDIR/mozillavpn-$SOURCE_VERSION"
 # and __sometimes__ taskcluster will fail to do cleanup once the task is done
 Remove-Item $FETCHES_PATH/VisualStudio/VC/Tools/MSVC/14.30.30705/bin/HostX64/x64/VCTIP.EXE
 
+# Ensure user scripts are accessible in the path.
+$PYTHON_SCRIPTS =$(python3 -c "import site, os; print(os.path.join(site.getuserbase(), 'Scripts')")
+Write-Output "Python Scripts: $PYTHON_SCRIPTS" 
+$env:PATH ="$FETCHES_PATH;$QTPATH;$PYTHON_SCRIPTS;$env:PATH"
+
 # Install python build tooling
 python3 -m pip install -r $SOURCE_DIR/requirements.txt --user
 python3 -m pip install -r $SOURCE_DIR/taskcluster/scripts/requirements.txt --user
-
-# Fix: pip scripts are not on path by default on tc, so glean would fail
-$PYTHON_SCRIPTS =$(python3 -c "import site; print(';'.join(site.getsitepackages()))")
-Write-Output "Python Paths: $PYTHON_SCRIPTS" 
-$env:PATH ="$FETCHES_PATH;$QTPATH;$PYTHON_SCRIPTS;$env:PATH"
 
 # DEBUG: Confirm that we can actually run `get-secret.py`
 python3 $SOURCE_DIR/taskcluster/scripts/get-secret.py --help

--- a/taskcluster/scripts/build/windows.ps1
+++ b/taskcluster/scripts/build/windows.ps1
@@ -26,7 +26,7 @@ $SOURCE_DIR = resolve-path "$TASK_WORKDIR/mozillavpn-$SOURCE_VERSION"
 Remove-Item $FETCHES_PATH/VisualStudio/VC/Tools/MSVC/14.30.30705/bin/HostX64/x64/VCTIP.EXE
 
 # Ensure user scripts are accessible in the path.
-$PYTHON_SCRIPTS =$(python3 -c "import site, os; print(os.path.join(site.getuserbase(), 'Scripts'))")
+$PYTHON_SCRIPTS =$(python3 -c "import sysconfig, os; sysconfig.get_path('scripts', f'{os.name}_user')")
 Write-Output "Python Scripts: $PYTHON_SCRIPTS" 
 $env:PATH ="$FETCHES_PATH;$QTPATH;$PYTHON_SCRIPTS;$env:PATH"
 

--- a/taskcluster/scripts/build/windows.ps1
+++ b/taskcluster/scripts/build/windows.ps1
@@ -30,7 +30,8 @@ python3 -m pip install -r $SOURCE_DIR/requirements.txt --user
 python3 -m pip install -r $SOURCE_DIR/taskcluster/scripts/requirements.txt --user
 
 # Fix: pip scripts are not on path by default on tc, so glean would fail
-$PYTHON_SCRIPTS =resolve-path "$env:APPDATA\Python\Python36\Scripts"
+$PYTHON_SCRIPTS =$(python3 -c 'import site; print(":".join(site.getsitepackages()))')
+Write-Output "Python Paths: $PYTHON_SCRIPTS" 
 $env:PATH ="$FETCHES_PATH;$QTPATH;$PYTHON_SCRIPTS;$env:PATH"
 
 # Setup Go and MinGW up (for gco)

--- a/taskcluster/scripts/build/windows.ps1
+++ b/taskcluster/scripts/build/windows.ps1
@@ -65,9 +65,9 @@ $BUILD_DIR =resolve-path "$TASK_WORKDIR/cmake_build"
 cmake --version
 if ($env:MOZ_SCM_LEVEL -eq "3") {
     # Only on a release build we have access to those secrects.
-    python3  ./taskcluster/scripts/get-secret.py -s project/mozillavpn/tokens -k sentry_dsn -f sentry_dsn
-    python3  ./taskcluster/scripts/get-secret.py -s project/mozillavpn/tokens -k sentry_envelope_endpoint -f sentry_envelope_endpoint
-    python3  ./taskcluster/scripts/get-secret.py -s project/mozillavpn/tokens -k sentry_debug_file_upload_key -f sentry_debug_file_upload_key
+    python3  $SOURCE_DIR/taskcluster/scripts/get-secret.py -s project/mozillavpn/tokens -k sentry_dsn -f sentry_dsn
+    python3  $SOURCE_DIR/taskcluster/scripts/get-secret.py -s project/mozillavpn/tokens -k sentry_envelope_endpoint -f sentry_envelope_endpoint
+    python3  $SOURCE_DIR/taskcluster/scripts/get-secret.py -s project/mozillavpn/tokens -k sentry_debug_file_upload_key -f sentry_debug_file_upload_key
     $SENTRY_ENVELOPE_ENDPOINT = Get-Content sentry_envelope_endpoint
     $SENTRY_DSN = Get-Content sentry_dsn
     #

--- a/taskcluster/scripts/build/windows.ps1
+++ b/taskcluster/scripts/build/windows.ps1
@@ -9,6 +9,7 @@ $QTPATH =resolve-path "$FETCHES_PATH/QT_OUT/bin/"
 $PERL_GCC_PATH =resolve-path "$FETCHES_PATH/c/bin"
 # Prep Env:
 # Switch to the work dir, enable qt, enable msvc, enable rust
+$env:PATH ="$FETCHES_PATH;$QTPATH;$env:PATH"
 Set-Location -Path $TASK_WORKDIR
 . "$FETCHES_PATH/VisualStudio/enter_dev_shell.ps1"
 . "$FETCHES_PATH/QT_OUT/configure_qt.ps1"
@@ -24,11 +25,6 @@ $SOURCE_DIR = resolve-path "$TASK_WORKDIR/mozillavpn-$SOURCE_VERSION"
 # This will sometimes live longer then our compile
 # and __sometimes__ taskcluster will fail to do cleanup once the task is done
 Remove-Item $FETCHES_PATH/VisualStudio/VC/Tools/MSVC/14.30.30705/bin/HostX64/x64/VCTIP.EXE
-
-# Ensure user scripts are accessible in the path.
-$PYTHON_SCRIPTS =$(python3 -c "import sysconfig, os; sysconfig.get_path('scripts', f'{os.name}_user')")
-Write-Output "Python Scripts: $PYTHON_SCRIPTS" 
-$env:PATH ="$FETCHES_PATH;$QTPATH;$PYTHON_SCRIPTS;$env:PATH"
 
 # Install python build tooling
 python3 -m pip install -r $SOURCE_DIR/requirements.txt --user

--- a/taskcluster/scripts/build/windows.ps1
+++ b/taskcluster/scripts/build/windows.ps1
@@ -34,6 +34,9 @@ $PYTHON_SCRIPTS =$(python3 -c "import site; print(';'.join(site.getsitepackages(
 Write-Output "Python Paths: $PYTHON_SCRIPTS" 
 $env:PATH ="$FETCHES_PATH;$QTPATH;$PYTHON_SCRIPTS;$env:PATH"
 
+# DEBUG: Confirm that we can actually run `get-secret.py`
+python3 $SOURCE_DIR/taskcluster/scripts/get-secret.py --help
+
 # Setup Go and MinGW up (for gco)
 $env:GOROOT="$FETCHES_PATH\go\"
 $env:PATH ="$FETCHES_PATH\go\bin;$env:PATH"

--- a/taskcluster/scripts/build/windows.ps1
+++ b/taskcluster/scripts/build/windows.ps1
@@ -30,9 +30,6 @@ Remove-Item $FETCHES_PATH/VisualStudio/VC/Tools/MSVC/14.30.30705/bin/HostX64/x64
 python3 -m pip install -r $SOURCE_DIR/requirements.txt --user
 python3 -m pip install -r $SOURCE_DIR/taskcluster/scripts/requirements.txt --user
 
-# DEBUG: Confirm that we can actually run `get-secret.py`
-python3 $SOURCE_DIR/taskcluster/scripts/get-secret.py --help
-
 # Setup Go and MinGW up (for gco)
 $env:GOROOT="$FETCHES_PATH\go\"
 $env:PATH ="$FETCHES_PATH\go\bin;$env:PATH"

--- a/taskcluster/scripts/build/windows.ps1
+++ b/taskcluster/scripts/build/windows.ps1
@@ -30,7 +30,7 @@ python3 -m pip install -r $SOURCE_DIR/requirements.txt --user
 python3 -m pip install -r $SOURCE_DIR/taskcluster/scripts/requirements.txt --user
 
 # Fix: pip scripts are not on path by default on tc, so glean would fail
-$PYTHON_SCRIPTS =$(python3 -c 'import site; print(":".join(site.getsitepackages()))')
+$PYTHON_SCRIPTS =$(python3 -c "import site; print(';'.join(site.getsitepackages()))")
 Write-Output "Python Paths: $PYTHON_SCRIPTS" 
 $env:PATH ="$FETCHES_PATH;$QTPATH;$PYTHON_SCRIPTS;$env:PATH"
 


### PR DESCRIPTION
## Description
We are encountering some build difficulty in CI, we have a couple hypothesis that might be the culprit. I suspect the problem is due to an error in the python path setup, as denoted by the following snippet in the logs:

```
[task 2023-03-17T07:52:14.208Z] resolve-path : Cannot find path 'Z:\task_167903922024535\AppData\Roaming\Python\Python36\Scripts' because it does not exist.
[task 2023-03-17T07:52:14.208Z] At Z:\task_167903922024535\build\src\taskcluster\scripts\build\windows.ps1:33 char:18
[task 2023-03-17T07:52:14.208Z] + $PYTHON_SCRIPTS =resolve-path "$env:APPDATA\Python\Python36\Scripts"
[task 2023-03-17T07:52:14.208Z] +                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[task 2023-03-17T07:52:14.214Z]     + CategoryInfo          : ObjectNotFound: (Z:\task_1679039...ython36\Scripts:String) [Resolve-Path], ItemNotFoundException
[task 2023-03-17T07:52:14.214Z]     + FullyQualifiedErrorId : PathNotFound,Microsoft.PowerShell.Commands.ResolvePathCommand
[task 2023-03-17T07:52:14.214Z]  
[task 2023-03-17T07:52:14.259Z] 
[task 2023-03-17T07:52:14.259Z] 
[task 2023-03-17T07:52:14.260Z]     Directory: Z:\task_167903922024535
[task 2023-03-17T07:52:14.260Z] 
[task 2023-03-17T07:52:14.260Z] 
[task 2023-03-17T07:52:14.260Z] Mode                LastWriteTime         Length Name                                                                                                          
[task 2023-03-17T07:52:14.260Z] ----                -------------         ------ ----                                                                                                          
[task 2023-03-17T07:52:14.261Z] d-----        3/17/2023   7:52 AM                cmake_build                                                                                                   
[task 2023-03-17T07:52:15.481Z] cmake version 3.21.21080301-MSVC_2
[task 2023-03-17T07:52:15.481Z] 
[task 2023-03-17T07:52:15.481Z] CMake suite maintained and supported by Kitware (kitware.com/cmake).
[task 2023-03-17T07:52:15.501Z] C:\mozilla-build\python3\python3.exe: can't open file 'Z:\task_167903922024535\taskcluster\scripts\get-secret.py': [Errno 2] No such file or directory
[task 2023-03-17T07:52:15.532Z] C:\mozilla-build\python3\python3.exe: can't open file 'Z:\task_167903922024535\taskcluster\scripts\get-secret.py': [Errno 2] No such file or directory
[task 2023-03-17T07:52:15.551Z] C:\mozilla-build\python3\python3.exe: can't open file 'Z:\task_167903922024535\taskcluster\scripts\get-secret.py': [Errno 2] No such file or directory
[task 2023-03-17T07:52:15.577Z] Get-Content : Cannot find path 'Z:\task_167903922024535\sentry_envelope_endpoint' because it does not exist.
[task 2023-03-17T07:52:15.577Z] At Z:\task_167903922024535\build\src\taskcluster\scripts\build\windows.ps1:70 char:33
[task 2023-03-17T07:52:15.577Z] +     $SENTRY_ENVELOPE_ENDPOINT = Get-Content sentry_envelope_endpoint
[task 2023-03-17T07:52:15.580Z] +                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[task 2023-03-17T07:52:15.580Z]     + CategoryInfo          : ObjectNotFound: (Z:\task_1679039...velope_endpoint:String) [Get-Content], ItemNotFoundException
[task 2023-03-17T07:52:15.580Z]     + FullyQualifiedErrorId : PathNotFound,Microsoft.PowerShell.Commands.GetContentCommand
```

## Reference
Github #6358 ([VPN-4379](https://mozilla-hub.atlassian.net/browse/VPN-4379))

## Checklist
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed


[VPN-4379]: https://mozilla-hub.atlassian.net/browse/VPN-4379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ