### PR TITLE
Move 'exitForUnrecoverableError'  to shared utils

### DIFF
--- a/nebula/ui/components/MZStackView.qml
+++ b/nebula/ui/components/MZStackView.qml
@@ -6,7 +6,6 @@ import QtQuick 2.0
 import QtQuick.Controls 2.14
 
 import Mozilla.Shared 1.0
-import Mozilla.VPN 1.0
 
 StackView {
     id: stackView
@@ -19,7 +18,7 @@ StackView {
             // 
             // See https://github.com/mozilla-mobile/mozilla-vpn-client/pull/2638
             console.error("Using the initialItem property does not work on some platforms. Use Component.onCompleted: stackview.push(someURI)");
-            VPN.exitForUnrecoverableError("Setting initialItem on a StackView is illegal. See previous logs for more information.");
+            MZUtils.exitForUnrecoverableError("Setting initialItem on a StackView is illegal. See previous logs for more information.")
 
         }
 

--- a/src/apps/vpn/mozillavpn.cpp
+++ b/src/apps/vpn/mozillavpn.cpp
@@ -1268,12 +1268,6 @@ void MozillaVPN::hardResetAndQuit() {
   quit();
 }
 
-void MozillaVPN::exitForUnrecoverableError(const QString& reason) {
-  Q_ASSERT(!reason.isEmpty());
-  logger.error() << "Unrecoverable error detected: " << reason;
-  quit();
-}
-
 void MozillaVPN::requestDeleteAccount() {
   logger.debug() << "delete account";
   Q_ASSERT(Feature::get(Feature::Feature_accountDeletion)->isSupported());

--- a/src/apps/vpn/mozillavpn.h
+++ b/src/apps/vpn/mozillavpn.h
@@ -120,7 +120,6 @@ class MozillaVPN final : public App {
                                        const QString& category);
   Q_INVOKABLE bool validateUserDNS(const QString& dns) const;
   Q_INVOKABLE void hardResetAndQuit();
-  Q_INVOKABLE void exitForUnrecoverableError(const QString& reason);
   Q_INVOKABLE void requestDeleteAccount();
   Q_INVOKABLE void cancelReauthentication();
   Q_INVOKABLE void updateViewShown();

--- a/src/shared/utils.cpp
+++ b/src/shared/utils.cpp
@@ -4,6 +4,7 @@
 
 #include "utils.h"
 
+#include "app.h"
 #include "appconstants.h"
 #include "feature.h"
 #include "logger.h"
@@ -25,6 +26,12 @@ Logger logger("Utils");
 Utils* Utils::instance() {
   static Utils s_instance;
   return &s_instance;
+}
+
+void Utils::exitForUnrecoverableError(const QString& reason) {
+  Q_ASSERT(!reason.isEmpty());
+  logger.error() << "Unrecoverable error detected: " << reason;
+  App::instance()->quit();
 }
 
 // static

--- a/src/shared/utils.h
+++ b/src/shared/utils.h
@@ -15,6 +15,8 @@ class Utils final : public QObject {
   static Utils* instance();
   ~Utils() = default;
 
+  Q_INVOKABLE void exitForUnrecoverableError(const QString& reason);
+
   Q_INVOKABLE static void storeInClipboard(const QString& text);
 
   Q_INVOKABLE static void openAppStoreReviewLink();

--- a/tests/qml/mocmozillavpn.cpp
+++ b/tests/qml/mocmozillavpn.cpp
@@ -134,8 +134,6 @@ void MozillaVPN::hardResetAndQuit() {}
 
 void MozillaVPN::hardReset() {}
 
-void MozillaVPN::exitForUnrecoverableError(const QString& reason) {}
-
 void MozillaVPN::requestDeleteAccount() {}
 
 void MozillaVPN::cancelReauthentication() {}

--- a/tests/unit/mocmozillavpn.cpp
+++ b/tests/unit/mocmozillavpn.cpp
@@ -139,8 +139,6 @@ void MozillaVPN::hardResetAndQuit() {}
 
 void MozillaVPN::hardReset() {}
 
-void MozillaVPN::exitForUnrecoverableError(const QString& reason) {}
-
 void MozillaVPN::requestDeleteAccount() {}
 
 void MozillaVPN::cancelReauthentication() {}


### PR DESCRIPTION
## Description

This moves 'exitForUnrecoverableError()' to MZUtils so that MZStackView can be shared across products.

## Reference

    i.e Jira or Github issue URL

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
