### PR TITLE
VPN-4379: get-secret.py should write files relative to working directory

### DIFF
--- a/taskcluster/scripts/get-secret.py
+++ b/taskcluster/scripts/get-secret.py
@@ -15,12 +15,8 @@ import taskcluster
 def write_secret_to_file(
     path, data, key, base64decode=False, json_secret=False, append=False, prefix=""
 ):
-    path = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../" + path))
-    try:
-        os.makedirs(os.path.dirname(path))
-    except OSError as error:
-        if error.errno != errno.EEXIST:
-            raise
+    path = os.path.abspath(path)
+    os.makedirs(os.path.dirname(path), exist_ok=True)
     print("Outputting secret to: {}".format(path))
 
     with open(path, "a" if append else "w") as f:


### PR DESCRIPTION
## Description
It seems that `taskcluster/scripts/get-secret.py` is implicitly assuming that scripts are always being executed from the root of the project checkout, but this may not be correct anymore now that some CI tasks are using separate directories for sources and build artifacts, and `get-secret.py` will wind up writing the secrets into the source directory.

To resolve this, I propose that we augment `get-secret.py` to write files relative to the current working directory instead.

## Reference
Github issue #6358 ([VPN-4379](https://mozilla-hub.atlassian.net/browse/VPN-4379))

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-4379]: https://mozilla-hub.atlassian.net/browse/VPN-4379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ