### PR TITLE
VPN-4379: Fix path expansion to 3rdparty/sentry

### DIFF
--- a/src/shared/cmake/sentry.cmake
+++ b/src/shared/cmake/sentry.cmake
@@ -91,7 +91,7 @@ if( ${_SUPPORTED} GREATER -1 )
 
     include(ExternalProject)
     ExternalProject_Add(sentry
-        SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}../3rdparty/sentry
+        SOURCE_DIR ${CMAKE_SOURCE_DIR}/3rdparty/sentry
         GIT_REPOSITORY https://github.com/getsentry/sentry-native/
         GIT_TAG 0.5.0
         CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${EXTERNAL_INSTALL_LOCATION} ${SENTRY_ARGS}


### PR DESCRIPTION
## Description
It seems like we have a path expansion error on Windows when invoking the external build tool for Sentry. In particular, the existence of a trailing backslash on Windows is not guaranteed, which means that `${CMAKE_CURRENT_SOURCE_DIR}../3rdparty/sentry` doesn't evaluate into a sensible path. We can simplify this, and fix the bug by using `${CMAKE_SOURCE_DIR}/3rdparty/sentry` instead.

## Reference
Github issue #6358 ([VPN-4379](https://mozilla-hub.atlassian.net/browse/VPN-4379))

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-4379]: https://mozilla-hub.atlassian.net/browse/VPN-4379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ