### PR TITLE
Remove instances of 'qsTrId("...close")', 'qsTrId("...back")', and 'qsTrId("...getHelp") 

### DIFF
--- a/nebula/ui/components/MZMenu.qml
+++ b/nebula/ui/components/MZMenu.qml
@@ -49,7 +49,7 @@ Item {
         anchors.left: parent.left
         anchors.leftMargin: MZTheme.theme.windowMargin / 2
 
-        accessibleName: _menuIconButtonSource.includes("close") ? qsTrId("vpn.connectionInfo.close") : qsTrId("vpn.main.back")
+        accessibleName: _menuIconButtonSource.includes("close") ? qsTrId("vpn.connectionInfo.close") : MZI18n.GlobalGoBack
         Accessible.ignored: accessibleIgnored
         height: MZTheme.theme.rowHeight
         width: MZTheme.theme.rowHeight

--- a/nebula/ui/components/MZMenu.qml
+++ b/nebula/ui/components/MZMenu.qml
@@ -49,7 +49,7 @@ Item {
         anchors.left: parent.left
         anchors.leftMargin: MZTheme.theme.windowMargin / 2
 
-        accessibleName: _menuIconButtonSource.includes("close") ? qsTrId("vpn.connectionInfo.close") : MZI18n.GlobalGoBack
+        accessibleName: _menuIconButtonSource.includes("close") ? MZI18n.GlobalClose : MZI18n.GlobalGoBack
         Accessible.ignored: accessibleIgnored
         height: MZTheme.theme.rowHeight
         width: MZTheme.theme.rowHeight

--- a/nebula/ui/components/MZPopup.qml
+++ b/nebula/ui/components/MZPopup.qml
@@ -39,7 +39,7 @@ Popup {
         visible: showCloseButton
 
         objectName: closeButtonObjectName
-        accessibleName: qsTrId("menubar.file.close")
+        accessibleName: MZI18n.GlobalClose
 
         onClicked: {
             popup.close();

--- a/nebula/ui/components/MZScreenBase.qml
+++ b/nebula/ui/components/MZScreenBase.qml
@@ -36,7 +36,7 @@ Item {
 
             _menuIconButtonSource: stackview.depth === 1 ? "qrc:/nebula/resources/close-dark.svg" : "qrc:/nebula/resources/back.svg"
             _menuIconButtonMirror:  stackview.depth !== 1 && MZLocalizer.isRightToLeft
-            _iconButtonAccessibleName: stackview.depth === 1 ? qsTrId("vpn.connectionInfo.close") : MZI18n.GlobalGoBack
+            _iconButtonAccessibleName: stackview.depth === 1 ? MZI18n.GlobalClose : MZI18n.GlobalGoBack
             _menuOnBackClicked: () => maybeRequestPreviousScreen()
             titleComponent: stackview.currentItem.titleComponent ? stackview.currentItem.titleComponent : null
             rightButtonComponent: stackview.currentItem.rightMenuButton ? stackview.currentItem.rightMenuButton : null

--- a/nebula/ui/components/MZScreenBase.qml
+++ b/nebula/ui/components/MZScreenBase.qml
@@ -36,7 +36,7 @@ Item {
 
             _menuIconButtonSource: stackview.depth === 1 ? "qrc:/nebula/resources/close-dark.svg" : "qrc:/nebula/resources/back.svg"
             _menuIconButtonMirror:  stackview.depth !== 1 && MZLocalizer.isRightToLeft
-            _iconButtonAccessibleName: stackview.depth === 1 ? qsTrId("vpn.connectionInfo.close") : qsTrId("vpn.main.back")
+            _iconButtonAccessibleName: stackview.depth === 1 ? qsTrId("vpn.connectionInfo.close") : MZI18n.GlobalGoBack
             _menuOnBackClicked: () => maybeRequestPreviousScreen()
             titleComponent: stackview.currentItem.titleComponent ? stackview.currentItem.titleComponent : null
             rightButtonComponent: stackview.currentItem.rightMenuButton ? stackview.currentItem.rightMenuButton : null

--- a/nebula/ui/components/inAppAuth/MZInAppAuthenticationBase.qml
+++ b/nebula/ui/components/inAppAuth/MZInAppAuthenticationBase.qml
@@ -73,7 +73,7 @@ MZFlickable {
                 Layout.preferredHeight: menuButton.height
                 Layout.alignment: Qt.AlignRight
                 Layout.rightMargin: MZTheme.theme.windowMargin
-                labelText: MZI18n.GlobalGetHelp
+                labelText: MZI18n.GetHelpLinkTitle
                 horizontalPadding: MZTheme.theme.windowMargin / 2
                 onClicked: MZNavigator.requestScreen(VPN.ScreenGetHelp)
             }

--- a/nebula/ui/components/inAppAuth/MZInAppAuthenticationBase.qml
+++ b/nebula/ui/components/inAppAuth/MZInAppAuthenticationBase.qml
@@ -73,7 +73,7 @@ MZFlickable {
                 Layout.preferredHeight: menuButton.height
                 Layout.alignment: Qt.AlignRight
                 Layout.rightMargin: MZTheme.theme.windowMargin
-                labelText: qsTrId("vpn.main.getHelp2")
+                labelText: MZI18n.GlobalGetHelp
                 horizontalPadding: MZTheme.theme.windowMargin / 2
                 onClicked: MZNavigator.requestScreen(VPN.ScreenGetHelp)
             }

--- a/src/apps/vpn/ui/authenticationInApp/ViewAuthenticationSignIn.qml
+++ b/src/apps/vpn/ui/authenticationInApp/ViewAuthenticationSignIn.qml
@@ -49,7 +49,7 @@ MZInAppAuthenticationBase {
             MZAuthInApp.reset();
         }
     }
-    _menuButtonAccessibleName: qsTrId("vpn.main.back")
+    _menuButtonAccessibleName: MZI18n.GlobalGoBack
     _headlineText: MZAuthInApp.emailAddress
     _subtitleText: MZI18n.InAppAuthSignInSubtitle
     _imgSource: "qrc:/nebula/resources/avatar.svg"

--- a/src/apps/vpn/ui/authenticationInApp/ViewAuthenticationSignUp.qml
+++ b/src/apps/vpn/ui/authenticationInApp/ViewAuthenticationSignUp.qml
@@ -20,7 +20,7 @@ MZInAppAuthenticationBase {
     _menuButtonOnClick: () => {
         MZAuthInApp.reset();
     }
-    _menuButtonAccessibleName: qsTrId("vpn.main.back")
+    _menuButtonAccessibleName: MZI18n.GlobalGoBack
     _headlineText: MZAuthInApp.emailAddress
     _subtitleText: MZI18n.InAppAuthFinishAccountCreationDescription
     _imgSource: "qrc:/nebula/resources/avatar.svg"

--- a/src/apps/vpn/ui/authenticationInApp/ViewAuthenticationStart.qml
+++ b/src/apps/vpn/ui/authenticationInApp/ViewAuthenticationStart.qml
@@ -15,7 +15,7 @@ MZInAppAuthenticationBase {
     _menuButtonOnClick: () => { VPN.cancelAuthentication() }
     _menuButtonImageSource: "qrc:/nebula/resources/back.svg"
     _menuButtonImageMirror: MZLocalizer.isRightToLeft
-    _menuButtonAccessibleName:  qsTrId("vpn.main.back")
+    _menuButtonAccessibleName:  MZI18n.GlobalGoBack
     _headlineText: "Mozilla VPN"
     _subtitleText: MZI18n.InAppAuthEnterEmailAddressDescription
     _imgSource: "qrc:/ui/resources/logo.svg"

--- a/src/apps/vpn/ui/authenticationInApp/ViewAuthenticationUnblockCodeNeeded.qml
+++ b/src/apps/vpn/ui/authenticationInApp/ViewAuthenticationUnblockCodeNeeded.qml
@@ -21,7 +21,7 @@ MZInAppAuthenticationBase {
             MZAuthInApp.reset();
         }
     }
-    _menuButtonAccessibleName: qsTrId("vpn.connectionInfo.close")
+    _menuButtonAccessibleName: MZI18n.GlobalClose
     _headlineText: MZI18n.InAppAuthVerificationCodeTitle
     _subtitleText: MZI18n.InAppAuthEmailVerificationDescription
     _imgSource: "qrc:/nebula/resources/verification-code.svg"

--- a/src/apps/vpn/ui/authenticationInApp/ViewAuthenticationVerificationSessionByEmailNeeded.qml
+++ b/src/apps/vpn/ui/authenticationInApp/ViewAuthenticationVerificationSessionByEmailNeeded.qml
@@ -22,7 +22,7 @@ MZInAppAuthenticationBase {
             MZAuthInApp.reset();
         }
     }
-    _menuButtonAccessibleName: qsTrId("vpn.connectionInfo.close")
+    _menuButtonAccessibleName: MZI18n.GlobalClose
     _headlineText: MZI18n.InAppAuthVerificationCodeTitle
     _subtitleText: MZI18n.InAppAuthEmailVerificationDescription
     _imgSource: "qrc:/nebula/resources/verification-code.svg"

--- a/src/apps/vpn/ui/authenticationInApp/ViewAuthenticationVerificationSessionByTotpNeeded.qml
+++ b/src/apps/vpn/ui/authenticationInApp/ViewAuthenticationVerificationSessionByTotpNeeded.qml
@@ -20,7 +20,7 @@ MZInAppAuthenticationBase {
             VPN.cancelAuthentication();
         }
     }
-    _menuButtonAccessibleName: qsTrId("vpn.connectionInfo.close")
+    _menuButtonAccessibleName: MZI18n.GlobalClose
     _headlineText: MZI18n.InAppAuthSecurityCodeTitle
     _subtitleText: MZI18n.InAppAuthSecurityCodeSubtitle
     _imgSource: "qrc:/nebula/resources/verification-code.svg"

--- a/src/apps/vpn/ui/deleteAccount/ViewDeleteAccountRequest.qml
+++ b/src/apps/vpn/ui/deleteAccount/ViewDeleteAccountRequest.qml
@@ -40,7 +40,7 @@ MZInAppAuthenticationBase {
 
     _changeEmailLinkVisible: false
     _viewObjectName: "authDeleteAccountRequest"
-    _menuButtonAccessibleName: qsTrId("vpn.main.back")
+    _menuButtonAccessibleName: MZI18n.GlobalGoBack
     _menuButtonImageSource: "qrc:/nebula/resources/back.svg"
     _menuButtonImageMirror: MZLocalizer.isRightToLeft
     _menuButtonOnClick: () => {

--- a/src/apps/vpn/ui/screens/ScreenSubscriptionBlocked.qml
+++ b/src/apps/vpn/ui/screens/ScreenSubscriptionBlocked.qml
@@ -29,7 +29,7 @@ MZStackView {
             //% "Visit our help center to learn more about managing your subscriptions."
             errorMessage2: qsTrId("vpn.subscriptionBlocked.visitHelpCenter"),
 
-            primaryButtonText: MZI18n.GlobalGetHelp,
+            primaryButtonText: MZI18n.GetHelpLinkTitle,
             primaryButtonObjectName: "errorGetHelpButton",
             primaryButtonOnClick: stackview.handleButtonClick,
             secondaryButtonIsSignOff: true,

--- a/src/apps/vpn/ui/screens/ScreenSubscriptionBlocked.qml
+++ b/src/apps/vpn/ui/screens/ScreenSubscriptionBlocked.qml
@@ -29,8 +29,7 @@ MZStackView {
             //% "Visit our help center to learn more about managing your subscriptions."
             errorMessage2: qsTrId("vpn.subscriptionBlocked.visitHelpCenter"),
 
-            //% "Get Help"
-            primaryButtonText: qsTrId("vpn.subscriptionBlocked.getHelp"),
+            primaryButtonText: MZI18n.GlobalGetHelp,
             primaryButtonObjectName: "errorGetHelpButton",
             primaryButtonOnClick: stackview.handleButtonClick,
             secondaryButtonIsSignOff: true,

--- a/src/apps/vpn/ui/screens/devices/ViewDevices.qml
+++ b/src/apps/vpn/ui/screens/devices/ViewDevices.qml
@@ -72,7 +72,7 @@ MZViewBase {
             MZLinkButton {
                 id: getHelpLink
 
-                labelText: qsTrId("vpn.main.getHelp2")
+                labelText: MZI18n.GetHelpLinkTitle
                 Layout.alignment: Qt.AlignHCenter
                 onClicked: MZNavigator.requestScreen(VPN.ScreenGetHelp)
                 Layout.preferredHeight: MZTheme.theme.rowHeight

--- a/src/apps/vpn/ui/screens/getHelp/ViewGetHelp.qml
+++ b/src/apps/vpn/ui/screens/getHelp/ViewGetHelp.qml
@@ -12,8 +12,7 @@ import components 0.1
 
 MZViewBase {
     id: vpnFlickable
-    //% "Get help"
-    _menuTitle: qsTrId("vpn.main.getHelp2")
+    _menuTitle: MZI18n.GlobalGetHelp
     _menuOnBackClicked: () => MZNavigator.requestPreviousScreen()
     _viewContentData: Column {
 

--- a/src/apps/vpn/ui/screens/getHelp/ViewGetHelp.qml
+++ b/src/apps/vpn/ui/screens/getHelp/ViewGetHelp.qml
@@ -12,7 +12,7 @@ import components 0.1
 
 MZViewBase {
     id: vpnFlickable
-    _menuTitle: MZI18n.GlobalGetHelp
+    _menuTitle: MZI18n.GetHelpLinkTitle
     _menuOnBackClicked: () => MZNavigator.requestPreviousScreen()
     _viewContentData: Column {
 

--- a/src/apps/vpn/ui/screens/home/controller/ControllerView.qml
+++ b/src/apps/vpn/ui/screens/home/controller/ControllerView.qml
@@ -450,7 +450,7 @@ Item {
         objectName: "connectionInfoToggleButton"
 
         //% "Close"
-        property var connectionInfoCloseText: qsTrId("vpn.connectionInfo.close")
+        property var connectionInfoCloseText: MZI18n.GlobalClose
 
         anchors {
             left: parent.left
@@ -638,7 +638,7 @@ Item {
         objectName: "ipInfoToggleButton"
 
         //% "Close"
-        property var connectionInfoCloseText: qsTrId("vpn.connectionInfo.close")
+        property var connectionInfoCloseText: MZI18n.GlobalClose
 
         anchors {
             right: parent.right

--- a/src/apps/vpn/ui/screens/home/controller/ControllerView.qml
+++ b/src/apps/vpn/ui/screens/home/controller/ControllerView.qml
@@ -449,7 +449,6 @@ Item {
         id: connectionInfoToggleButton
         objectName: "connectionInfoToggleButton"
 
-        //% "Close"
         property var connectionInfoCloseText: MZI18n.GlobalClose
 
         anchors {
@@ -637,7 +636,6 @@ Item {
         id: ipInfoToggleButton
         objectName: "ipInfoToggleButton"
 
-        //% "Close"
         property var connectionInfoCloseText: MZI18n.GlobalClose
 
         anchors {

--- a/src/apps/vpn/ui/screens/initialize/ViewInitialize.qml
+++ b/src/apps/vpn/ui/screens/initialize/ViewInitialize.qml
@@ -237,7 +237,7 @@ Item {
         MZHeaderLink {
             id: headerLink
             objectName: "getHelpLink"
-            labelText: MZI18n.GlobalGetHelp
+            labelText: MZI18n.GetHelpLinkTitle
             isLightTheme: false
             onClicked: {
                 MZGleanDeprecated.recordGleanEvent("getHelpClickedInitialize")

--- a/src/apps/vpn/ui/screens/initialize/ViewInitialize.qml
+++ b/src/apps/vpn/ui/screens/initialize/ViewInitialize.qml
@@ -237,7 +237,7 @@ Item {
         MZHeaderLink {
             id: headerLink
             objectName: "getHelpLink"
-            labelText: qsTrId("vpn.main.getHelp2")
+            labelText: MZI18n.GlobalGetHelp
             isLightTheme: false
             onClicked: {
                 MZGleanDeprecated.recordGleanEvent("getHelpClickedInitialize")

--- a/src/apps/vpn/ui/screens/settings/ViewGuide.qml
+++ b/src/apps/vpn/ui/screens/settings/ViewGuide.qml
@@ -43,9 +43,7 @@ Item {
                     'focusBorder': MZTheme.theme.lightFocusBorder
                 }
                 skipEnsureVisible: true
-                //% "Back"
-                //: Go back
-                accessibleName: qsTrId("vpn.main.back")
+                accessibleName: MZI18n.GlobalGoBack
 
                 onClicked: {
                     statusBarModifier.resetDefaults()

--- a/src/apps/vpn/ui/screens/settings/ViewSettingsMenu.qml
+++ b/src/apps/vpn/ui/screens/settings/ViewSettingsMenu.qml
@@ -122,7 +122,7 @@ MZViewBase {
                 //% "Give feedback"
                 property string giveFeedbackTitle: qsTrId("vpn.settings.giveFeedback")
                 objectName: "settingsGetHelp"
-                settingTitle: qsTrId("vpn.main.getHelp2")
+                settingTitle: MZI18n.GlobalGetHelp
                 imageLeftSrc: "qrc:/ui/resources/settings/questionMark.svg"
                 imageRightSrc: "qrc:/nebula/resources/chevron.svg"
                 imageRightMirror: MZLocalizer.isRightToLeft

--- a/src/apps/vpn/ui/screens/settings/ViewSettingsMenu.qml
+++ b/src/apps/vpn/ui/screens/settings/ViewSettingsMenu.qml
@@ -122,7 +122,7 @@ MZViewBase {
                 //% "Give feedback"
                 property string giveFeedbackTitle: qsTrId("vpn.settings.giveFeedback")
                 objectName: "settingsGetHelp"
-                settingTitle: MZI18n.GlobalGetHelp
+                settingTitle: MZI18n.GetHelpLinkTitle
                 imageLeftSrc: "qrc:/ui/resources/settings/questionMark.svg"
                 imageRightSrc: "qrc:/nebula/resources/chevron.svg"
                 imageRightMirror: MZLocalizer.isRightToLeft

--- a/src/apps/vpn/ui/screens/subscriptionNeeded/ViewSubscriptionNeededIAP.qml
+++ b/src/apps/vpn/ui/screens/subscriptionNeeded/ViewSubscriptionNeededIAP.qml
@@ -25,7 +25,7 @@ MZFlickable {
     MZHeaderLink {
         id: headerLink
 
-        labelText: MZI18n.GlobalGetHelp
+        labelText: MZI18n.GetHelpLinkTitle
         onClicked: MZNavigator.requestScreen(VPN.ScreenGetHelp)
     }
 

--- a/src/apps/vpn/ui/screens/subscriptionNeeded/ViewSubscriptionNeededIAP.qml
+++ b/src/apps/vpn/ui/screens/subscriptionNeeded/ViewSubscriptionNeededIAP.qml
@@ -25,7 +25,7 @@ MZFlickable {
     MZHeaderLink {
         id: headerLink
 
-        labelText: qsTrId("vpn.main.getHelp2")
+        labelText: MZI18n.GlobalGetHelp
         onClicked: MZNavigator.requestScreen(VPN.ScreenGetHelp)
     }
 

--- a/src/apps/vpn/ui/screens/subscriptionNeeded/ViewSubscriptionNeededWeb.qml
+++ b/src/apps/vpn/ui/screens/subscriptionNeeded/ViewSubscriptionNeededWeb.qml
@@ -27,7 +27,7 @@ MZFlickable {
     MZHeaderLink {
         id: headerLink
 
-        labelText: qsTrId("vpn.main.getHelp2")
+        labelText: MZI18n.GlobalGetHelp
         onClicked: MZNavigator.requestScreen(VPN.ScreenGetHelp)
     }
 

--- a/src/apps/vpn/ui/screens/subscriptionNeeded/ViewSubscriptionNeededWeb.qml
+++ b/src/apps/vpn/ui/screens/subscriptionNeeded/ViewSubscriptionNeededWeb.qml
@@ -27,7 +27,7 @@ MZFlickable {
     MZHeaderLink {
         id: headerLink
 
-        labelText: MZI18n.GlobalGetHelp
+        labelText: MZI18n.GetHelpLinkTitle
         onClicked: MZNavigator.requestScreen(VPN.ScreenGetHelp)
     }
 

--- a/src/apps/vpn/ui/sharedViews/ViewErrorFullScreen.qml
+++ b/src/apps/vpn/ui/sharedViews/ViewErrorFullScreen.qml
@@ -39,7 +39,7 @@ MZFlickable {
         objectName: "getHelpLink"
         visible: getHelpLinkVisible
 
-        labelText: qsTrId("vpn.main.getHelp2")
+        labelText: MZI18n.GlobalGetHelp
         onClicked: MZNavigator.requestScreen(VPN.ScreenGetHelp)
     }
 

--- a/src/apps/vpn/ui/sharedViews/ViewErrorFullScreen.qml
+++ b/src/apps/vpn/ui/sharedViews/ViewErrorFullScreen.qml
@@ -39,7 +39,7 @@ MZFlickable {
         objectName: "getHelpLink"
         visible: getHelpLinkVisible
 
-        labelText: MZI18n.GlobalGetHelp
+        labelText: MZI18n.GetHelpLinkTitle
         onClicked: MZNavigator.requestScreen(VPN.ScreenGetHelp)
     }
 

--- a/translations/strings.yaml
+++ b/translations/strings.yaml
@@ -835,6 +835,9 @@ global:
   paste:
     value: Paste
     comment: Label for button to paste value from clipboard into input
+  close:
+    value: Close
+    comment: Accessible label for close button
 
 getHelp:
   helpCenter: Help Center

--- a/translations/strings.yaml
+++ b/translations/strings.yaml
@@ -838,6 +838,9 @@ global:
   close:
     value: Close
     comment: Accessible label for close button
+  getHelp: 
+    value: Get help
+    comment: Button label
 
 getHelp:
   helpCenter: Help Center

--- a/translations/strings.yaml
+++ b/translations/strings.yaml
@@ -838,15 +838,13 @@ global:
   close:
     value: Close
     comment: Accessible label for close button
-  getHelp: 
-    value: Get help
-    comment: Button label
 
 getHelp:
   helpCenter: Help Center
   viewLogs:
     value: View Logs
     comment: Label for a clickable item in the Get-Help view
+  linkTitle: Get help
 
 navBar:
   homeTab:


### PR DESCRIPTION
## Description

- Adds new "Close" and "Get help" strings to strings.yaml 
- Specifically removes instances of `qsTrId("...")` from MZScreenBase and MZMenu so that these can actually be shared and opportunistically updates other files still using `qsTrId` for 'Close', 'Go back', and 'Get help' strings. 

## Reference


## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
