### PR TITLE
Fix l10n linter when strings/comments are empty

### DIFF
--- a/.github/l10n/check_l10n_issues.py
+++ b/.github/l10n/check_l10n_issues.py
@@ -55,25 +55,25 @@ for f in files:
         )
         print(f, message_id)
 
-        # Check if there are misused characters in the strings
-        if message_id not in exceptions["characters"]:
-            for character in misused_characters.keys():
-                if character in source_text:
-                    errors[relative_filename][message_id] = misused_characters[
-                        character
-                    ]
-
-        # Check if the string is empty
-        if message_id not in exceptions["empty"]:
-            if source_text == "":
+        if source_text is None:
+            # Check if the string is empty
+            if message_id not in exceptions["empty"]:
                 errors[relative_filename][message_id] = "String should not be empty."
+        else:
+            # Check if there are misused characters in the strings
+            if message_id not in exceptions["characters"]:
+                for character in misused_characters.keys():
+                    if character in source_text:
+                        errors[relative_filename][message_id] = misused_characters[
+                            character
+                        ]
 
-        # Check if there are variables in the string but no comments
-        if message_id not in exceptions["comments"]:
-            if "%" in source_text and source_comment == "":
-                errors[relative_filename][
-                    message_id
-                ] = "Strings with variables should always have a comment."
+            # Check if there are variables in the string but no comments
+            if message_id not in exceptions["comments"]:
+                if "%" in source_text and source_comment is None:
+                    errors[relative_filename][
+                        message_id
+                    ] = "Strings with variables should always have a comment."
 
 if errors:
     print("\n----\nERRORS:")

--- a/.github/workflows/translations.yaml
+++ b/.github/workflows/translations.yaml
@@ -36,9 +36,6 @@ jobs:
       - name: Install python dependencies
         run: |
           pip install -r requirements.txt
-        
-          # lxml might be in use by old releases
-          pip install lxml
 
       - name: Generating translations
         run: |


### PR DESCRIPTION
Noticed in [this run](https://github.com/mozilla-mobile/mozilla-vpn-client/actions/runs/4495825421/jobs/7909875419?pr=6422) for #6422 that the linter dies on an empty string.

Turns out the script was changed to not use lxml, which apparently causes an empty string to return None. That means that the script breaks like in the run before, and wouldn't report missing comments either.

Checked the oldest release branch (2.13) and it's already using the script without lxml.