### PR TITLE
Remove qsTrId() from Nebula and *some* soon to be shared screens

### DIFF
--- a/nebula/ui/components/MZSignOut.qml
+++ b/nebula/ui/components/MZSignOut.qml
@@ -6,8 +6,7 @@ import Mozilla.Shared 1.0
 import Mozilla.VPN 1.0
 
 MZFooterLink {
-    //% "Sign out"
-    labelText: qsTrId("vpn.main.signOut2")
+    labelText: MZI18n.GlobalSignOut
     fontName: MZTheme.theme.fontBoldFamily
     linkColor: MZTheme.theme.redLinkButton
     onClicked: () => {

--- a/nebula/ui/components/MZSubscriptionOption.qml
+++ b/nebula/ui/components/MZSubscriptionOption.qml
@@ -216,9 +216,7 @@ RadioDelegate {
             Layout.fillWidth: true
 
             MZInterLabel {
-                //: Appears on the in-app purchase view beside a subscription plan. "%1" is replaced by the percentage amount saved when selecting that plan.
-                //% "Save %1%"
-                text: qsTrId("vpn.subscription.savePercent").arg(productSavings)
+                text: MZI18n.PurchasePercentSaved.arg(productSavings)
 
                 color: MZTheme.theme.purple60
                 font.family: MZTheme.theme.fontBoldFamily

--- a/nebula/ui/components/MZSubscriptionOption.qml
+++ b/nebula/ui/components/MZSubscriptionOption.qml
@@ -124,9 +124,7 @@ RadioDelegate {
             // TODO (maybe) - Do we want to add the subscription duration in months to the model?
             property var subscriptionDuration: getSubscriptionDuration(productType)
 
-            //: %1 is replaced by the subscription duration in months. %2 is replaced by the total subscription cost.
-            //% "%1-month plan: %2"
-            property string productMultiMonth: qsTrId("vpn.subscription.multiMonthPlan").arg(col.subscriptionDuration).arg(productPrice)
+            property string productMultiMonth: MZI18n.PurchaseSubscriptionOption.arg(col.subscriptionDuration).arg(productPrice)
 
             property int trialDays: productTrialDays
 

--- a/nebula/ui/components/MZSystemAlert.qml
+++ b/nebula/ui/components/MZSystemAlert.qml
@@ -61,8 +61,7 @@ MZAlert {
                 name: MZErrorHandler.NoConnectionAlert
                 PropertyChanges {
                     target: alertBox
-                    //% "No internet connection"
-                    alertText: qsTrId("vpn.alert.noInternet")
+                    alertText: MZI18n.GlobalNoInternetConnection
                     alertActionText: qsTrId("vpn.alert.tryAgain")
                     visible: true
                 }

--- a/nebula/ui/components/MZUserProfile.qml
+++ b/nebula/ui/components/MZUserProfile.qml
@@ -24,7 +24,7 @@ MZClickableRow {
     Layout.fillWidth: true
     Layout.leftMargin: MZTheme.theme.windowMargin / 2
     Layout.rightMargin: MZTheme.theme.windowMargin / 2
-    accessibleName: qsTrId("vpn.main.manageAccount")
+    accessibleName: MZI18n.SettingsManageAccount
     objectName: _objNameBase + "-manageAccountButton"
     onClicked: _buttonOnClicked()
     height: undefined

--- a/nebula/ui/components/inAppAuth/MZInAppAuthenticationErrorPopup.qml
+++ b/nebula/ui/components/inAppAuth/MZInAppAuthenticationErrorPopup.qml
@@ -65,7 +65,7 @@ MZSimplePopup {
                 authError.open()
                 break;
             case MZAuthInApp.ErrorConnectionTimeout:
-                authError.description = qsTrId("vpn.alert.noInternet")
+                authError.description = MZI18n.GlobalNoInternetConnection
                 authError.open()
                 break;
             case MZAuthInApp.ErrorFailedToSendEmail:

--- a/src/apps/vpn/commands/commandui.cpp
+++ b/src/apps/vpn/commands/commandui.cpp
@@ -172,7 +172,8 @@ int CommandUI::run(QStringList& tokens) {
 
 #if defined(MZ_WINDOWS) || defined(MZ_LINUX)
     // If there is another instance, the execution terminates here.
-    if (!EventListener::checkOtherInstances(I18nStrings::instance()->t(I18nStrings::ProductName))) {
+    if (!EventListener::checkOtherInstances(
+            I18nStrings::instance()->t(I18nStrings::ProductName))) {
       return 0;
     }
 

--- a/src/apps/vpn/commands/commandui.cpp
+++ b/src/apps/vpn/commands/commandui.cpp
@@ -172,7 +172,7 @@ int CommandUI::run(QStringList& tokens) {
 
 #if defined(MZ_WINDOWS) || defined(MZ_LINUX)
     // If there is another instance, the execution terminates here.
-    if (!EventListener::checkOtherInstances(qtTrId("vpn.main.productName"))) {
+    if (!EventListener::checkOtherInstances(I18nStrings::instance()->t(I18nStrings::ProductName))) {
       return 0;
     }
 

--- a/src/apps/vpn/platforms/android/androidcontroller.cpp
+++ b/src/apps/vpn/platforms/android/androidcontroller.cpp
@@ -200,8 +200,8 @@ void AndroidController::activate(const HopConnection& hop, const Device* device,
   args["city"] = localizedCityName;
 
   QJsonObject messages;
-  messages["productName"] = I18nStrings::instance()->t(
-      I18nStrings::ProductName);
+  messages["productName"] =
+      I18nStrings::instance()->t(I18nStrings::ProductName);
   messages["connectedHeader"] = I18nStrings::instance()->t(
       I18nStrings::NotificationsVPNConnectedTitle);  // Connected
   messages["connectedBody"] =

--- a/src/apps/vpn/platforms/android/androidcontroller.cpp
+++ b/src/apps/vpn/platforms/android/androidcontroller.cpp
@@ -200,7 +200,8 @@ void AndroidController::activate(const HopConnection& hop, const Device* device,
   args["city"] = localizedCityName;
 
   QJsonObject messages;
-  messages["productName"] = qtTrId("vpn.main.productName");
+  messages["productName"] = I18nStrings::instance()->t(
+      I18nStrings::ProductName);
   messages["connectedHeader"] = I18nStrings::instance()->t(
       I18nStrings::NotificationsVPNConnectedTitle);  // Connected
   messages["connectedBody"] =

--- a/src/apps/vpn/platforms/macos/macossystemtraynotificationhandler.cpp
+++ b/src/apps/vpn/platforms/macos/macossystemtraynotificationhandler.cpp
@@ -8,6 +8,7 @@
 #include <QMenu>
 #include <QWindow>
 
+#include "i18nstrings.h"
 #include "leakdetector.h"
 #include "logger.h"
 #include "macosutils.h"
@@ -42,7 +43,7 @@ void MacosSystemTrayNotificationHandler::setStatusMenu() {
           &MacosSystemTrayNotificationHandler::updateIconIndicator);
 
   m_macOSStatusIcon = new MacOSStatusIcon(this);
-  m_macOSStatusIcon->setToolTip(qtTrId("vpn.main.productName"));
+  m_macOSStatusIcon->setToolTip(I18nStrings::instance()->t(I18nStrings::ProductName));
   m_macOSStatusIcon->setMenu(m_menu->toNSMenu());
 }
 

--- a/src/apps/vpn/platforms/macos/macossystemtraynotificationhandler.cpp
+++ b/src/apps/vpn/platforms/macos/macossystemtraynotificationhandler.cpp
@@ -43,7 +43,8 @@ void MacosSystemTrayNotificationHandler::setStatusMenu() {
           &MacosSystemTrayNotificationHandler::updateIconIndicator);
 
   m_macOSStatusIcon = new MacOSStatusIcon(this);
-  m_macOSStatusIcon->setToolTip(I18nStrings::instance()->t(I18nStrings::ProductName));
+  m_macOSStatusIcon->setToolTip(
+      I18nStrings::instance()->t(I18nStrings::ProductName));
   m_macOSStatusIcon->setMenu(m_menu->toNSMenu());
 }
 

--- a/src/apps/vpn/systemtraynotificationhandler.cpp
+++ b/src/apps/vpn/systemtraynotificationhandler.cpp
@@ -106,7 +106,7 @@ void SystemTrayNotificationHandler::setStatusMenu() {
 
   // TODO: Check if method is called on these devices.
 #if defined(MZ_LINUX) || defined(MZ_WINDOWS)
-  m_systemTrayIcon->setToolTip(qtTrId("vpn.main.productName"));
+  m_systemTrayIcon->setToolTip(I18nStrings::instance()->t(I18nStrings::ProductName));
   m_systemTrayIcon->setContextMenu(m_menu.get());
   m_systemTrayIcon->show();
 #endif

--- a/src/apps/vpn/systemtraynotificationhandler.cpp
+++ b/src/apps/vpn/systemtraynotificationhandler.cpp
@@ -106,7 +106,8 @@ void SystemTrayNotificationHandler::setStatusMenu() {
 
   // TODO: Check if method is called on these devices.
 #if defined(MZ_LINUX) || defined(MZ_WINDOWS)
-  m_systemTrayIcon->setToolTip(I18nStrings::instance()->t(I18nStrings::ProductName));
+  m_systemTrayIcon->setToolTip(
+      I18nStrings::instance()->t(I18nStrings::ProductName));
   m_systemTrayIcon->setContextMenu(m_menu.get());
   m_systemTrayIcon->show();
 #endif

--- a/src/apps/vpn/translations/strings.yaml
+++ b/src/apps/vpn/translations/strings.yaml
@@ -870,6 +870,9 @@ global:
   copy:
     value: Copy
     comment: Accessible button label
+  clear: 
+    value: Clear
+    comment: Accessible label for clear button
 
 getHelp:
   helpCenter: Help Center

--- a/src/apps/vpn/translations/strings.yaml
+++ b/src/apps/vpn/translations/strings.yaml
@@ -216,6 +216,7 @@ notSignedInGoogle:
 multiFxaAccountError:
   fxaAccountErrorHeader: Problem confirming subscription
   fxaAccountErrorText: Your subscription is linked to another Firefox Account. You may need to sign in with a different email address.
+  visitOurHelpCenter: Visit our help center to learn more about managing your subscriptions.
 
 # IAP Android edge case 3
 genericPurchaseError:

--- a/src/apps/vpn/translations/strings.yaml
+++ b/src/apps/vpn/translations/strings.yaml
@@ -354,6 +354,7 @@ aboutUs:
     value: Copy %1
     comment: "Accessible name for a button. %1 is the version number of the VPN client."
   privacyNotice: Privacy notice
+  termsOfService: Terms of service
 
 AndroidNotifications:
   GeneralNotifications:

--- a/src/apps/vpn/translations/strings.yaml
+++ b/src/apps/vpn/translations/strings.yaml
@@ -611,6 +611,9 @@ inAppAuth:
   waitingForSignIn:
     value: Waiting for sign in and subscription confirmation…
     comment: Headline on loading screen
+  pleaseWait:
+    value: Please wait…
+    comment: Headline on loading screen
   
 postAuthentication:
   headline: Quick access

--- a/src/apps/vpn/translations/strings.yaml
+++ b/src/apps/vpn/translations/strings.yaml
@@ -838,6 +838,9 @@ global:
   close:
     value: Close
     comment: Accessible label for close button
+  signOut:
+    value: Sign out
+    comment: Link title
 
 getHelp:
   helpCenter: Help Center

--- a/src/apps/vpn/translations/strings.yaml
+++ b/src/apps/vpn/translations/strings.yaml
@@ -246,6 +246,10 @@ purchaseWeb:
     comment: "%1 is the user’s email address."
   inProgress2: Please continue subscribing in your browser…
 
+purchase:
+  subscriptionOption: "%1-month plan: %2"
+  comment: "%1 is replaced by the subscription duration in months. %2 is replaced by the total subscription cost."
+
 networkSettings:
   multihopTitle: Multi-hop tunnel
 

--- a/src/apps/vpn/translations/strings.yaml
+++ b/src/apps/vpn/translations/strings.yaml
@@ -360,6 +360,9 @@ aboutUs:
     comment: Accessible name for a button. %1 is the version number of the VPN client.
   privacyNotice: Privacy notice
   termsOfService: Terms of service
+  releaseVersion: 
+    value: Release version
+    comment:  "Refers to the installed version. For example: 'Release Version: 1.23'"
 
 AndroidNotifications:
   GeneralNotifications:

--- a/src/apps/vpn/translations/strings.yaml
+++ b/src/apps/vpn/translations/strings.yaml
@@ -852,6 +852,9 @@ global:
   noInternetConnection:
     value: No internet connection
     comment: Status alert text
+  continue:
+    value: Continue
+    comment: Button label
 
 getHelp:
   helpCenter: Help Center

--- a/src/apps/vpn/translations/strings.yaml
+++ b/src/apps/vpn/translations/strings.yaml
@@ -250,6 +250,9 @@ purchase:
   subscriptionOption: 
     value: "%1-month plan: %2"
     comment: "%1 is replaced by the subscription duration in months. %2 is replaced by the total subscription cost."
+  percentSaved:
+    value: Save %1%
+    comment: Appears on the in-app purchase view beside a subscription plan. "%1" is replaced by the percentage amount saved when selecting that plan
 
 networkSettings:
   multihopTitle: Multi-hop tunnel

--- a/src/apps/vpn/translations/strings.yaml
+++ b/src/apps/vpn/translations/strings.yaml
@@ -353,6 +353,7 @@ aboutUs:
   copyVersionNumber:
     value: Copy %1
     comment: "Accessible name for a button. %1 is the version number of the VPN client."
+  privacyNotice: Privacy notice
 
 AndroidNotifications:
   GeneralNotifications:

--- a/src/apps/vpn/translations/strings.yaml
+++ b/src/apps/vpn/translations/strings.yaml
@@ -776,6 +776,8 @@ subscriptionManagement:
   valueProp3:
     value: 500+ servers in 30+ countries
     comment: Value proposition used to promote the product
+  manageAccount:
+    value: Manage account
 
 paymentMethods:
   amex: American Express

--- a/src/apps/vpn/translations/strings.yaml
+++ b/src/apps/vpn/translations/strings.yaml
@@ -349,6 +349,7 @@ dnsOverwriteDialog:
   secondaryButton: Maybe later
 
 aboutUs:
+  title: About us
   licenses: Licenses
   copyVersionNumber:
     value: Copy %1

--- a/src/apps/vpn/translations/strings.yaml
+++ b/src/apps/vpn/translations/strings.yaml
@@ -882,6 +882,9 @@ getHelp:
     comment: Label for a clickable item in the Get-Help view
   linkTitle: Get help
 
+product: 
+  name: Mozilla VPN
+
 navBar:
   homeTab:
     value: Home

--- a/src/apps/vpn/translations/strings.yaml
+++ b/src/apps/vpn/translations/strings.yaml
@@ -254,6 +254,9 @@ purchase:
   percentSaved:
     value: Save %1%
     comment: Appears on the in-app purchase view beside a subscription plan. "%1" is replaced by the percentage amount saved when selecting that plan
+  subscribeNow: 
+    value: Subscribe now
+    comment: Button label
 
 networkSettings:
   multihopTitle: Multi-hop tunnel

--- a/src/apps/vpn/translations/strings.yaml
+++ b/src/apps/vpn/translations/strings.yaml
@@ -357,7 +357,7 @@ aboutUs:
   licenses: Licenses
   copyVersionNumber:
     value: Copy %1
-    comment: "Accessible name for a button. %1 is the version number of the VPN client."
+    comment: Accessible name for a button. %1 is the version number of the VPN client.
   privacyNotice: Privacy notice
   termsOfService: Terms of service
 
@@ -897,6 +897,9 @@ getHelp:
     value: View Logs
     comment: Label for a clickable item in the Get-Help view
   linkTitle: Get help
+  developerOptions: 
+    value: Developer options
+    comment: Button label
 
 product: 
   name: Mozilla VPN

--- a/src/apps/vpn/translations/strings.yaml
+++ b/src/apps/vpn/translations/strings.yaml
@@ -608,6 +608,9 @@ inAppAuth:
   emailTokenResentAlert:
     value: We’ve resent your code to your email.
     comment: User has requested to send a new email containing the 6-digit pin to confirm their email address.
+  waitingForSignIn:
+    value: Waiting for sign in and subscription confirmation…
+    comment: Headline on loading screen
 
 deleteAccount:
   authSubheadline: To delete your VPN account, please sign in with your Firefox account password.

--- a/src/apps/vpn/translations/strings.yaml
+++ b/src/apps/vpn/translations/strings.yaml
@@ -845,6 +845,9 @@ global:
   signOut:
     value: Sign out
     comment: Link title
+  noInternetConnection:
+    value: No internet connection
+    comment: Status alert text
 
 getHelp:
   helpCenter: Help Center

--- a/src/apps/vpn/translations/strings.yaml
+++ b/src/apps/vpn/translations/strings.yaml
@@ -884,6 +884,7 @@ getHelp:
 
 product: 
   name: Mozilla VPN
+  description: A fast, secure and easy to use VPN. Built by the makers of Firefox.
 
 navBar:
   homeTab:

--- a/src/apps/vpn/translations/strings.yaml
+++ b/src/apps/vpn/translations/strings.yaml
@@ -247,8 +247,9 @@ purchaseWeb:
   inProgress2: Please continue subscribing in your browser…
 
 purchase:
-  subscriptionOption: "%1-month plan: %2"
-  comment: "%1 is replaced by the subscription duration in months. %2 is replaced by the total subscription cost."
+  subscriptionOption: 
+    value: "%1-month plan: %2"
+    comment: "%1 is replaced by the subscription duration in months. %2 is replaced by the total subscription cost."
 
 networkSettings:
   multihopTitle: Multi-hop tunnel

--- a/src/apps/vpn/translations/strings.yaml
+++ b/src/apps/vpn/translations/strings.yaml
@@ -884,9 +884,6 @@ global:
   noInternetConnection:
     value: No internet connection
     comment: Status alert text
-  continue:
-    value: Continue
-    comment: Button label
   copy:
     value: Copy
     comment: Accessible button label

--- a/src/apps/vpn/translations/strings.yaml
+++ b/src/apps/vpn/translations/strings.yaml
@@ -619,7 +619,6 @@ postAuthentication:
   headline: Quick access
   subtitle: You can quickly access Mozilla VPN from your status bar.
 
-
 deleteAccount:
   authSubheadline: To delete your VPN account, please sign in with your Firefox account password.
   authButtonLabel: Continue
@@ -866,6 +865,9 @@ global:
   continue:
     value: Continue
     comment: Button label
+  copy:
+    value: Copy
+    comment: Accessible button label
 
 getHelp:
   helpCenter: Help Center

--- a/src/apps/vpn/translations/strings.yaml
+++ b/src/apps/vpn/translations/strings.yaml
@@ -378,6 +378,13 @@ telemetryPolicyView:
   dataCollectionAndUse: 
     value: Data collection and use
     comment: Headline of telemetry policy view and checkbox label
+  doNotAllow: 
+    value: Don’t allow
+    comment: Button label
+  allow: 
+    value: Allow on this device
+    comment: Button label
+  learnMore: Learn more about what data Mozilla collects and how it’s used.
 
 genericError:
   unexpected: Unexpected error

--- a/src/apps/vpn/translations/strings.yaml
+++ b/src/apps/vpn/translations/strings.yaml
@@ -375,6 +375,9 @@ updateButton:
 telemetryPolicyView:
   description: We strive to provide you with choices and collect only the data we need to improve Mozilla VPN. Sharing this data with Mozilla is optional.
   question: Allow Mozilla VPN to send technical, interaction, and campaign and referral data to Mozilla?
+  dataCollectionAndUse: 
+    value: Data collection and use
+    comment: Headline of telemetry policy view and checkbox label
 
 genericError:
   unexpected: Unexpected error

--- a/src/apps/vpn/translations/strings.yaml
+++ b/src/apps/vpn/translations/strings.yaml
@@ -611,6 +611,11 @@ inAppAuth:
   waitingForSignIn:
     value: Waiting for sign in and subscription confirmation…
     comment: Headline on loading screen
+  
+postAuthentication:
+  headline: Quick access
+  subtitle: You can quickly access Mozilla VPN from your status bar.
+
 
 deleteAccount:
   authSubheadline: To delete your VPN account, please sign in with your Firefox account password.

--- a/src/apps/vpn/ui/authenticationInApp/ViewAuthenticationStart.qml
+++ b/src/apps/vpn/ui/authenticationInApp/ViewAuthenticationStart.qml
@@ -25,7 +25,7 @@ MZInAppAuthenticationBase {
         objectName: "authStart"
         _buttonEnabled: MZAuthInApp.state === MZAuthInApp.StateStart && activeInput().text.length !== 0 && !activeInput().hasError && MZAuthInApp.validateEmailAddress(activeInput().text)
         _buttonOnClicked: (inputText) => { MZAuthInApp.checkAccount(inputText); }
-        _buttonText: qsTrId("vpn.postAuthentication.continue")
+        _buttonText: MZI18n.GlobalContinue
         _inputMethodHints: Qt.ImhNoPredictiveText | Qt.ImhEmailCharactersOnly | Qt.ImhNoAutoUppercase | Qt.ImhSensitiveData
         _inputPlaceholderText: MZI18n.InAppSupportWorkflowSupportEmailFieldPlaceholder
     }

--- a/src/apps/vpn/ui/main.qml
+++ b/src/apps/vpn/ui/main.qml
@@ -81,8 +81,7 @@ Window {
     maximumWidth: fullscreenRequired() ? Screen.width : MZTheme.theme.desktopAppWidth;
     maximumHeight: fullscreenRequired() ? Screen.height : MZTheme.theme.desktopAppHeight;
 
-    //% "Mozilla VPN"
-    title: qsTrId("vpn.main.productName")
+    title: MZI18n.ProductName
     color: MZTheme.theme.bgColor
     onClosing: close => {
         console.log("Closing request handling");

--- a/src/apps/vpn/ui/screens/ScreenAuthenticating.qml
+++ b/src/apps/vpn/ui/screens/ScreenAuthenticating.qml
@@ -6,7 +6,5 @@ import components 0.1
 
 MZLoader {
     objectName: "authenticatingView"
-
-    //% "Waiting for sign in and subscription confirmation…"
-    headlineText: qsTrId("vpn.authenticating.waitForSignIn")
+    headlineText: MZI18n.InAppAuthWaitingForSignIn
 }

--- a/src/apps/vpn/ui/screens/ScreenPostAuthentication.qml
+++ b/src/apps/vpn/ui/screens/ScreenPostAuthentication.qml
@@ -17,15 +17,13 @@ Item {
         anchors.top: parent.top
         anchors.topMargin: parent.height * 0.08
         anchors.horizontalCenter: parent.horizontalCenter
-        //% "Quick access"
-        text: qsTrId("vpn.postAuthentication..quickAccess")
+        text: MZI18n.PostAuthenticationHeadline
     }
 
     MZSubtitle {
         id: logoSubtitle
 
-        //% "You can quickly access Mozilla VPN from your status bar."
-        text: qsTrId("vpn.postAuthentication.statusBarIntro")
+        text: MZI18n.PostAuthenticationSubtitle
         anchors.top: headline.bottom
         anchors.topMargin: 12
         anchors.horizontalCenter: parent.horizontalCenter

--- a/src/apps/vpn/ui/screens/ScreenPostAuthentication.qml
+++ b/src/apps/vpn/ui/screens/ScreenPostAuthentication.qml
@@ -43,8 +43,7 @@ Item {
         id: button
         objectName: "postAuthenticationButton"
 
-        //% "Continue"
-        text: qsTrId("vpn.postAuthentication.continue")
+        text: MZI18n.GlobalContinue
         anchors.horizontalCenterOffset: 0
         anchors.horizontalCenter: parent.horizontalCenter
         anchors.bottom: parent.bottom

--- a/src/apps/vpn/ui/screens/ScreenPostAuthentication.qml
+++ b/src/apps/vpn/ui/screens/ScreenPostAuthentication.qml
@@ -5,6 +5,7 @@
 import QtQuick 2.5
 import QtQuick.Controls 2.14
 
+import Mozilla.Shared 1.0
 import Mozilla.VPN 1.0
 import components 0.1
 

--- a/src/apps/vpn/ui/screens/ScreenSubscriptionBlocked.qml
+++ b/src/apps/vpn/ui/screens/ScreenSubscriptionBlocked.qml
@@ -26,8 +26,7 @@ MZStackView {
             // "Your subscription is linked to another Firefox Account....."
             errorMessage: MZI18n.MultiFxaAccountErrorFxaAccountErrorText,
 
-            //% "Visit our help center to learn more about managing your subscriptions."
-            errorMessage2: qsTrId("vpn.subscriptionBlocked.visitHelpCenter"),
+            errorMessage2:  MZI18n.MultiFxaAccountErrorVisitOurHelpCenter,
 
             primaryButtonText: MZI18n.GetHelpLinkTitle,
             primaryButtonObjectName: "errorGetHelpButton",

--- a/src/apps/vpn/ui/screens/ScreenSubscriptionInProgressIAP.qml
+++ b/src/apps/vpn/ui/screens/ScreenSubscriptionInProgressIAP.qml
@@ -7,7 +7,6 @@ import components 0.1
 MZLoader {
     objectName: "subscriptionInProgressIAP"
 
-    //% "Please wait…"
-    headlineText: qsTrId("vpn.subscription.pleaseWait")
+    headlineText: MZI18n.InAppAuthPleaseWait
     footerLinkIsVisible: false
 }

--- a/src/apps/vpn/ui/screens/ScreenSubscriptionInUseError.qml
+++ b/src/apps/vpn/ui/screens/ScreenSubscriptionInUseError.qml
@@ -24,7 +24,7 @@ MZStackView {
            errorMessage: MZI18n.RestorePurchaseInUseErrorRestorePurchaseInUseErrorText,
 
            // Sign out
-           primaryButtonText: qsTrId("vpn.main.signOut2"),
+           primaryButtonText: MZI18n.GlobalSignOut,
            primaryButtonObjectName: "errorSignOutButton",
            primaryButtonOnClick: () => {
                VPNController.logout();

--- a/src/apps/vpn/ui/screens/ScreenTelemetryPolicy.qml
+++ b/src/apps/vpn/ui/screens/ScreenTelemetryPolicy.qml
@@ -62,8 +62,7 @@ MZFlickable {
             MZButton {
                 id: button
                 objectName: "telemetryPolicyButton"
-                //% "Allow on this device"
-                text: qsTrId("vpn.telemetryPolicy.allowOnThisDevice")
+                text: MZI18n.TelemetryPolicyViewAllow
                 radius: 5
                 onClicked: {
                     MZSettings.gleanEnabled = true;
@@ -74,8 +73,7 @@ MZFlickable {
             MZLinkButton {
                 id: linkBtn
                 objectName: "declineTelemetryLink"
-                //% "Don’t allow"
-                labelText: qsTrId("vpn.telemetryPolicy.doNotAllow")
+                labelText: MZI18n.TelemetryPolicyViewDoNotAllow
                 Layout.alignment: Qt.AlignHCenter
                 onClicked: {
                     MZSettings.gleanEnabled = false;
@@ -94,8 +92,7 @@ MZFlickable {
                 Layout.rightMargin: MZTheme.theme.windowMargin * 3
                 Layout.maximumWidth: MZTheme.theme.maxHorizontalContentWidth
                 Layout.fillWidth: true
-                //% "Learn more about what data Mozilla collects and how it’s used."
-                text: qsTrId("vpn.telemetryPolicy.learnMoreAboutData")
+                text: MZI18n.TelemetryPolicyViewLearnMore
             }
 
             MZLinkButton {

--- a/src/apps/vpn/ui/screens/ScreenTelemetryPolicy.qml
+++ b/src/apps/vpn/ui/screens/ScreenTelemetryPolicy.qml
@@ -33,7 +33,7 @@ MZFlickable {
 
         MZPanel {
             logo: "qrc:/ui/resources/updateRecommended.svg"
-            logoTitle: qsTrId("vpn.settings.dataCollection")
+            logoTitle: MZI18n.TelemetryPolicyViewDataCollectionAndUse
             logoSubtitle: MZI18n.TelemetryPolicyViewDescription
             Layout.fillWidth: true
             anchors.horizontalCenter: undefined

--- a/src/apps/vpn/ui/screens/ScreenTelemetryPolicy.qml
+++ b/src/apps/vpn/ui/screens/ScreenTelemetryPolicy.qml
@@ -100,8 +100,7 @@ MZFlickable {
 
             MZLinkButton {
                 objectName: "privacyLink"
-                //% "Mozilla VPN Privacy Notice"
-                labelText: qsTrId("vpn.telemetryPolicy.MozillaVPNPrivacyNotice")
+                labelText: MZI18n.InAppSupportWorkflowPrivacyNoticeLinkText
                 Layout.alignment: Qt.AlignHCenter
                 onClicked: MZUrlOpener.openUrlLabel("privacyNotice")
             }

--- a/src/apps/vpn/ui/screens/ScreenViewLogs.qml
+++ b/src/apps/vpn/ui/screens/ScreenViewLogs.qml
@@ -96,8 +96,7 @@ Item {
             }
 
             MZLogsButton {
-                //% "Clear"
-                buttonText: qsTrId("vpn.logs.clear")
+                buttonText: MZI18n.GlobalClear
                 iconSource: "qrc:/nebula/resources/delete.svg"
                 onClicked: {
                     MZLog.flushLogs();

--- a/src/apps/vpn/ui/screens/ScreenViewLogs.qml
+++ b/src/apps/vpn/ui/screens/ScreenViewLogs.qml
@@ -21,8 +21,7 @@ Item {
     MZMenu {
         id: menu
 
-        //% "View Logs"
-        title: qsTrId("vpn.viewlogs.title")
+        title: MZI18n.GetHelpViewLogs
         _menuOnBackClicked: () => MZNavigator.requestPreviousScreen()
     }
 

--- a/src/apps/vpn/ui/screens/ScreenViewLogs.qml
+++ b/src/apps/vpn/ui/screens/ScreenViewLogs.qml
@@ -80,8 +80,7 @@ Item {
             width: copyClearWrapper.width
 
             MZLogsButton {
-                //% "Copy"
-                buttonText: qsTrId("vpn.logs.copy")
+                buttonText: MZI18n.GlobalCopy
                 iconSource: "qrc:/ui/resources/copy.svg"
                 onClicked: {
                     MZUtils.storeInClipboard(logText.text);

--- a/src/apps/vpn/ui/screens/ScreenViewLogs.qml
+++ b/src/apps/vpn/ui/screens/ScreenViewLogs.qml
@@ -84,8 +84,7 @@ Item {
                 iconSource: "qrc:/ui/resources/copy.svg"
                 onClicked: {
                     MZUtils.storeInClipboard(logText.text);
-                    //% "Copied!"
-                    buttonText = qsTrId("vpn.logs.copied");
+                    buttonText = MZI18n.GlobalCopied
                 }
             }
 

--- a/src/apps/vpn/ui/screens/getHelp/ViewGetHelp.qml
+++ b/src/apps/vpn/ui/screens/getHelp/ViewGetHelp.qml
@@ -88,8 +88,7 @@ MZViewBase {
             spacing: MZTheme.theme.listSpacing
             anchors.horizontalCenter: parent.horizontalCenter
 
-            //% "Developer Options"
-            settingTitle: qsTrId("vpn.settings.developer")
+            settingTitle: MZI18n.GetHelpDeveloperOptions
             imageLeftSrc: "qrc:/ui/resources/developer.svg"
             imageRightSrc: "qrc:/nebula/resources/chevron.svg"
             imageRightMirror: MZLocalizer.isRightToLeft

--- a/src/apps/vpn/ui/screens/initialize/ViewInitialize.qml
+++ b/src/apps/vpn/ui/screens/initialize/ViewInitialize.qml
@@ -13,10 +13,7 @@ import compat 0.1
 
 Item {
     property int safeAreaHeight: window.safeContentHeight
-
-    // Legacy string, defined here but used in ViewAboutUs.qml
-    //% "A fast, secure and easy to use VPN. Built by the makers of Firefox."
-    property string logoSubtitle: qsTrId("vpn.main.productDescription")
+    property string logoSubtitle: MZI18n.ProductDescription
 
     MZRadialGradient {
         height: Screen.height

--- a/src/apps/vpn/ui/screens/settings/ViewAboutUs.qml
+++ b/src/apps/vpn/ui/screens/settings/ViewAboutUs.qml
@@ -33,7 +33,7 @@ MZViewBase {
                 spacing: MZTheme.theme.windowMargin / 2
 
                 MZBoldLabel {
-                    text: qsTrId("vpn.main.productName")
+                    text: MZI18n.ProductName
                     Layout.fillWidth: true
                 }
                 MZTextBlock {

--- a/src/apps/vpn/ui/screens/settings/ViewAboutUs.qml
+++ b/src/apps/vpn/ui/screens/settings/ViewAboutUs.qml
@@ -16,8 +16,7 @@ MZViewBase {
     property bool listenForUpdateEvents:false
     property string licenseURL: ""
 
-    //% "About us"
-    _menuTitle: qsTrId("vpn.settings.aboutUs")
+    _menuTitle: MZI18n.AboutUsTitle
 
     _viewContentData: ColumnLayout {
         spacing: MZTheme.theme.windowMargin

--- a/src/apps/vpn/ui/screens/settings/ViewAboutUs.qml
+++ b/src/apps/vpn/ui/screens/settings/ViewAboutUs.qml
@@ -39,7 +39,7 @@ MZViewBase {
                 MZTextBlock {
                     Layout.fillWidth: true
                     width: undefined
-                    text: qsTrId("vpn.main.productDescription")
+                    text: MZI18n.ProductDescription
                 }
             }
             MZBoldLabel {

--- a/src/apps/vpn/ui/screens/settings/ViewAboutUs.qml
+++ b/src/apps/vpn/ui/screens/settings/ViewAboutUs.qml
@@ -119,8 +119,7 @@ MZViewBase {
                ListElement {
                    linkId: "privacy"
 
-                   //% "Privacy notice"
-                   linkTitle: qsTrId("vpn.aboutUs.privacyNotice2")
+                   linkTitle: MZI18n.AboutUsPrivacyNotice
                    openUrl: "link-privacy-notice"
                    openView: ""
                }

--- a/src/apps/vpn/ui/screens/settings/ViewAboutUs.qml
+++ b/src/apps/vpn/ui/screens/settings/ViewAboutUs.qml
@@ -107,7 +107,7 @@ MZViewBase {
                ListElement {
                    linkId: "tos"
 
-                   linkTitle: MZI18n.AboutUsTermsOfService
+                   linkTitleId: "AboutUsTermsOfService"
                    openUrl: "terms-of-service"
                    openView: ""
                }
@@ -115,14 +115,14 @@ MZViewBase {
                ListElement {
                    linkId: "privacy"
 
-                   linkTitle: MZI18n.AboutUsPrivacyNotice
+                   linkTitleId: "AboutUsPrivacyNotice"
                    openUrl: "link-privacy-notice"
                    openView: ""
                }
            }
            delegate: MZExternalLinkListItem {
                objectName: "aboutUsList-" + linkId
-               title: linkTitle
+               title: MZI18n[linkTitleId]
                accessibleName: title
                Layout.fillWidth: true
                Layout.preferredHeight: MZTheme.theme.rowHeight
@@ -150,7 +150,7 @@ MZViewBase {
            Component.onCompleted: {
               aboutUsListModel.append({
                    linkId: "license",
-                   linkTitle: MZI18n.AboutUsLicenses,
+                   linkTitleId: "AboutUsLicenses",
                    openView: "qrc:/ui/screens/settings/ViewLicenses.qml"
               });
            }

--- a/src/apps/vpn/ui/screens/settings/ViewAboutUs.qml
+++ b/src/apps/vpn/ui/screens/settings/ViewAboutUs.qml
@@ -110,8 +110,7 @@ MZViewBase {
                ListElement {
                    linkId: "tos"
 
-                   //% "Terms of service"
-                   linkTitle: qsTrId("vpn.aboutUs.tos2")
+                   linkTitle: MZI18n.AboutUsTermsOfService
                    openUrl: "terms-of-service"
                    openView: ""
                }

--- a/src/apps/vpn/ui/screens/settings/ViewAboutUs.qml
+++ b/src/apps/vpn/ui/screens/settings/ViewAboutUs.qml
@@ -43,9 +43,7 @@ MZViewBase {
                 }
             }
             MZBoldLabel {
-                //% "Release version"
-                //: Refers to the installed version. For example: "Release Version: 1.23"
-                text: qsTrId("vpn.aboutUs.releaseVersion2")
+                text: MZI18n.AboutUsReleaseVersion
                 Accessible.role: Accessible.StaticText
             }
             MZClickableRow {

--- a/src/apps/vpn/ui/screens/settings/ViewPreferences.qml
+++ b/src/apps/vpn/ui/screens/settings/ViewPreferences.qml
@@ -50,8 +50,8 @@ MZViewBase {
                 rightMargin: MZTheme.theme.windowMargin
             }
 
-            //% "Data collection and use"
-            labelText: qsTrId("vpn.settings.dataCollection")
+
+            labelText: MZI18n.TelemetryPolicyViewDataCollectionAndUse
             subLabelText: MZI18n.SettingsDataCollectionDescription
             isChecked: MZSettings.gleanEnabled
             onClicked: {

--- a/src/apps/vpn/ui/screens/settings/ViewSettingsMenu.qml
+++ b/src/apps/vpn/ui/screens/settings/ViewSettingsMenu.qml
@@ -135,7 +135,7 @@ MZViewBase {
 
             MZSettingsItem {
                 objectName: "settingsAboutUs"
-                settingTitle: qsTrId("vpn.settings.aboutUs")
+                settingTitle: MZI18n.AboutUsTitle
                 imageLeftSrc: "qrc:/ui/resources/settings/aboutUs.svg"
                 imageRightSrc: "qrc:/nebula/resources/chevron.svg"
                 imageRightMirror: MZLocalizer.isRightToLeft

--- a/src/apps/vpn/ui/screens/subscriptionNeeded/ViewSubscriptionNeededIAP.qml
+++ b/src/apps/vpn/ui/screens/subscriptionNeeded/ViewSubscriptionNeededIAP.qml
@@ -114,8 +114,7 @@ MZFlickable {
                 id: subscribeNow
                 objectName: "vpnSubscriptionNeededView"
 
-                //% "Subscribe now"
-                text: qsTrId("vpn.updates.subscribeNow")
+                text: MZI18n.PurchaseSubscribeNow
 
                 Layout.topMargin: MZTheme.theme.windowMargin
                 Layout.leftMargin: MZTheme.theme.windowMargin

--- a/src/apps/vpn/ui/screens/subscriptionNeeded/ViewSubscriptionNeededIAP.qml
+++ b/src/apps/vpn/ui/screens/subscriptionNeeded/ViewSubscriptionNeededIAP.qml
@@ -159,8 +159,7 @@ MZFlickable {
                 MZGreyLink {
                     id: privacyNotice
 
-                    // Privacy Notice - string defined in ViewAboutUs.qml
-                    labelText: qsTrId("vpn.aboutUs.privacyNotice2")
+                    labelText: MZI18n.AboutUsPrivacyNotice
                     onClicked: MZUrlOpener.openUrlLabel("privacyNotice")
                     textAlignment: grid.columns > 1 ? Text.AlignLeft : Text.AlignHCenter
                     Layout.alignment: grid.columns > 1 ? Qt.AlignLeft : Qt.AlignHCenter

--- a/src/apps/vpn/ui/screens/subscriptionNeeded/ViewSubscriptionNeededIAP.qml
+++ b/src/apps/vpn/ui/screens/subscriptionNeeded/ViewSubscriptionNeededIAP.qml
@@ -43,7 +43,7 @@ MZFlickable {
 
     MZHeadline {
         id: headline
-        text: qsTrId("vpn.main.productName")
+        text: MZI18n.ProductName
         anchors.top: logo.bottom
         anchors.topMargin: MZTheme.theme.windowMargin
         anchors.horizontalCenter: parent.horizontalCenter

--- a/src/apps/vpn/ui/screens/subscriptionNeeded/ViewSubscriptionNeededIAP.qml
+++ b/src/apps/vpn/ui/screens/subscriptionNeeded/ViewSubscriptionNeededIAP.qml
@@ -139,8 +139,7 @@ MZFlickable {
                 MZGreyLink {
                     id: termsOfService
 
-                    // Terms of Service - string defined in ViewAboutUs.qml
-                    labelText: qsTrId("vpn.aboutUs.tos2")
+                    labelText: MZI18n.AboutUsTermsOfService
                     Layout.alignment: grid.columns > 1 ? Qt.AlignRight : Qt.AlignHCenter
                     textAlignment: grid.columns > 1 ? Text.AlignRight : Text.AlignHCenter
                     onClicked: MZUrlOpener.openUrlLabel("termsOfService")

--- a/src/apps/vpn/ui/screens/subscriptionNeeded/ViewSubscriptionNeededWeb.qml
+++ b/src/apps/vpn/ui/screens/subscriptionNeeded/ViewSubscriptionNeededWeb.qml
@@ -109,8 +109,7 @@ MZFlickable {
             MZGreyLink {
                 id: termsOfService
 
-                // Terms of Service - string defined in ViewAboutUs.qml
-                labelText: qsTrId("vpn.aboutUs.tos2")
+                labelText: MZI18n.AboutUsTermsOfService
                 textAlignment: grid.columns > 1 ? Text.AlignRight : Text.AlignHCenter
 
                 onClicked: MZUrlOpener.openUrlLabel("termsOfService")

--- a/src/apps/vpn/ui/screens/subscriptionNeeded/ViewSubscriptionNeededWeb.qml
+++ b/src/apps/vpn/ui/screens/subscriptionNeeded/ViewSubscriptionNeededWeb.qml
@@ -130,8 +130,7 @@ MZFlickable {
 
             MZGreyLink {
                 id: privacyNotice
-                // Privacy Notice - string defined in ViewAboutUs.qml
-                labelText: qsTrId("vpn.aboutUs.privacyNotice2")
+                labelText: MZI18n.AboutUsPrivacyNotice
                 textAlignment: grid.columns > 1 ? Text.AlignLeft : Text.AlignHCenter
 
                 onClicked: MZUrlOpener.openUrlLabel("privacyNotice")

--- a/src/apps/vpn/ui/screens/subscriptionNeeded/ViewSubscriptionNeededWeb.qml
+++ b/src/apps/vpn/ui/screens/subscriptionNeeded/ViewSubscriptionNeededWeb.qml
@@ -79,8 +79,7 @@ MZFlickable {
         MZButton {
             id: subscribeNow
             objectName: "vpnSubscriptionNeededView"
-            //% "Subscribe now"
-            text: qsTrId("vpn.updates.subscribeNow")
+            text: MZI18n.PurchaseSubscribeNow
 
             onClicked: VPNPurchase.subscribe("web")
 

--- a/src/apps/vpn/ui/sharedViews/ViewUpdate.qml
+++ b/src/apps/vpn/ui/sharedViews/ViewUpdate.qml
@@ -178,8 +178,7 @@ MZFlickable {
 
             //% "Not now"
             readonly property var textNotNow: qsTrId("vpn.updates.notNow")
-            //% "Manage account"
-            readonly property var textManageAccount: qsTrId("vpn.main.manageAccount")
+            readonly property var textManageAccount: MZI18n.SettingsManageAccount
 
             Layout.alignment: Qt.AlignHCenter
             labelText: (vpnFlickable.state === "recommended") ? textNotNow : textManageAccount


### PR DESCRIPTION
## Description

This PR
- Removes instances of `qsTrId("...")` from Nebula files
  - Ignores MZToggle, which is up for relocation to vpn/ in #6354 
  - Ignores MZSystemAlert which needs a larger refactor that will likely make the switch to MZI18n unnecessary.
- Removes instances of `qsTrId("..")` from *some* shareable screens 
  - Pretends Give Feedback flow doesn't exist since soon it really won't 
  - Ignores Languages view since #6417 
  - Ignores views like settings/IAP where larger needed refactors will likely make the change unnecessary


## Reference

    i.e Jira or Github issue URL

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
