### PR TITLE
Fix 'Server location' spelling to be consistent with the app

### DIFF
--- a/addons/message_update_v2.15/manifest.json
+++ b/addons/message_update_v2.15/manifest.json
@@ -22,7 +22,7 @@
         "content": [
           {
             "id": "l_1",
-            "content": "We will now recommend a few of the highest-performing server locations when you’re on the Select Location screen."
+            "content": "We will now recommend a few of the highest-performing server locations when you’re on the Select location screen."
           },
           {
             "id": "l_2",

--- a/addons/message_whats_new_v2.15/manifest.json
+++ b/addons/message_whats_new_v2.15/manifest.json
@@ -23,7 +23,7 @@
         "content": [
           {
             "id": "l_1",
-            "content": "We will now recommend a few of the highest-performing server locations when you’re on the Select Location screen."
+            "content": "We will now recommend a few of the highest-performing server locations when you’re on the Select location screen."
           },
           {
             "id": "l_2",


### PR DESCRIPTION
Found another spelling inconsistency while reviewing the strings for 2.15.