### PR TITLE
basti/fix sentry 2.14

### DIFF
--- a/src/apps/vpn/cmake/sentry.cmake
+++ b/src/apps/vpn/cmake/sentry.cmake
@@ -35,6 +35,10 @@ if( ${_SUPPORTED} GREATER -1 )
     target_compile_definitions(mozillavpn PRIVATE SENTRY_ENVELOPE_ENDPOINT="${SENTRY_ENVELOPE_ENDPOINT}")
     target_compile_definitions(mozillavpn PRIVATE SENTRY_DSN="${SENTRY_DSN}")
     target_compile_definitions(mozillavpn PRIVATE SENTRY_ENABLED)
+    # Let's the app know we need to provide the upload client
+    target_compile_definitions(shared-sources INTERFACE SENTRY_NONE_TRANSPORT)
+
+
     # Sentry support is given
     target_sources(mozillavpn PRIVATE
         apps/vpn/sentry/sentryadapter.cpp
@@ -65,7 +69,7 @@ if( ${_SUPPORTED} GREATER -1 )
         target_link_libraries(mozillavpn PUBLIC breakpad_client.lib)
         target_link_libraries(mozillavpn PUBLIC dbghelp.lib)
         # Windows will use the winhttp transport btw
-        SET(SENTRY_ARGS -DSENTRY_BUILD_SHARED_LIBS=false -DSENTRY_BACKEND=breakpad -DCMAKE_BUILD_TYPE=Release)
+        SET(SENTRY_ARGS -DSENTRY_BUILD_SHARED_LIBS=false -DSENTRY_BACKEND=breakpad -DSENTRY_TRANSPORT=none -DCMAKE_BUILD_TYPE=Release)
     endif()
 
     if(ANDROID)

--- a/src/apps/vpn/mozillavpn.cpp
+++ b/src/apps/vpn/mozillavpn.cpp
@@ -1596,7 +1596,21 @@ void MozillaVPN::exitForUnrecoverableError(const QString& reason) {
 
 void MozillaVPN::crashTest() {
   logger.debug() << "Crashing Application";
+
+#ifdef MZ_WINDOWS
+  // Windows does not have "signals"
+  //   qFatal("Ready to crash!") does not work as expected.
+  // QT raises a debugmessage (in debugmode) - which we would handle
+  // in release-mode however this end's with QT just doing a clean shutdown
+  // so breakpad does not kick in.
+  int i = 1;
+  QString* ohno = (QString*)i--;
+  ohno->at(1);
+#else
+  // On Linux/osx this generates a Sigabort, which is handled
   qFatal("Ready to crash!");
+#endif
+
 }
 
 // static


### PR DESCRIPTION
Backport of the VPN-4409 fix for 2.14, as that patch does not apply