### PR TITLE
VPN-3690 - Add UUID metric type to qtglean

### DIFF
--- a/qtglean/CMakeLists.txt
+++ b/qtglean/CMakeLists.txt
@@ -20,6 +20,7 @@ add_library(qtglean STATIC
     ${CMAKE_CURRENT_SOURCE_DIR}/include/glean/event.h
     ${CMAKE_CURRENT_SOURCE_DIR}/include/glean/ping.h
     ${CMAKE_CURRENT_SOURCE_DIR}/include/glean/timingdistribution.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/glean/uuid.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/boolean.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/datetime.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/quantity.cpp
@@ -28,6 +29,7 @@ add_library(qtglean STATIC
     ${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/event.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/ping.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/timingdistribution.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/uuid.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/glean/generated/metrics.h
     ${CMAKE_CURRENT_BINARY_DIR}/glean/generated/pings.h
     ${CMAKE_CURRENT_BINARY_DIR}/glean/generated/metrics.cpp

--- a/qtglean/glean_parser_ext/rust.py
+++ b/qtglean/glean_parser_ext/rust.py
@@ -214,6 +214,7 @@ def output_rust(objs, output_fd, options={}):
         ("QUANTITY_MAP", "QuantityMetric"): [],
         ("DATETIME_MAP", "DatetimeMetric"): [],
         ("BOOLEAN_MAP", "BooleanMetric"): [],
+        ("UUID_MAP", "UuidMetric"): [],
     }
 
     # Map from a metric ID to the fully qualified path of the event object in Rust.

--- a/qtglean/include/glean/metrictypes.h
+++ b/qtglean/include/glean/metrictypes.h
@@ -13,5 +13,6 @@
 #include "quantity.h"
 #include "string.h"
 #include "timingdistribution.h"
+#include "uuid.h"
 
 #endif

--- a/qtglean/include/glean/uuid.h
+++ b/qtglean/include/glean/uuid.h
@@ -1,0 +1,35 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef UUID_H
+#define UUID_H
+#include <QObject>
+
+#include "errortype.h"
+
+class UuidMetric final {
+  Q_GADGET
+
+ public:
+  // QML custom types require these three declarations.
+  // See: https://doc.qt.io/qt-6/custom-types.html#creating-a-custom-type
+  UuidMetric() = default;
+  UuidMetric(const UuidMetric&) = default;
+  UuidMetric& operator=(const UuidMetric&) = default;
+
+  explicit UuidMetric(int aId);
+  ~UuidMetric() = default;
+
+  Q_INVOKABLE void set(const QString& uuid) const;
+  Q_INVOKABLE QString generateAndSet() const;
+
+  // Test  only functions
+  Q_INVOKABLE QString testGetValue(const QString& pingName = "") const;
+  Q_INVOKABLE int32_t testGetNumRecordedErrors(ErrorType errorType) const;
+
+ private:
+  int m_id;
+};
+
+#endif  // UUID_H

--- a/qtglean/qtglean.pri
+++ b/qtglean/qtglean.pri
@@ -21,6 +21,7 @@ SOURCES += $$PWD/src/cpp/quantity.cpp
 SOURCES += $$PWD/src/cpp/string.cpp
 SOURCES += $$PWD/src/cpp/ping.cpp
 SOURCES += $$PWD/src/cpp/timingdistribution.cpp
+SOURCES += $$PWD/src/cpp/uuid.cpp
 
 HEADERS += $$PWD/include/glean/boolean.h
 HEADERS += $$PWD/include/glean/counter.h
@@ -30,5 +31,6 @@ HEADERS += $$PWD/include/glean/quantity.h
 HEADERS += $$PWD/include/glean/string.h
 HEADERS += $$PWD/include/glean/ping.h
 HEADERS += $$PWD/include/glean/timingdistribution.h
+HEADERS += $$PWD/include/glean/uuid.h
 HEADERS += $$PWD/include/glean/metrictypes.h
 INCLUDEPATH += $$PWD/include

--- a/qtglean/src/cpp/uuid.cpp
+++ b/qtglean/src/cpp/uuid.cpp
@@ -1,0 +1,39 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "glean/uuid.h"
+
+#include <QDebug>
+
+#if not(defined(__wasm__) || defined(BUILD_QMAKE))
+#  include "qtglean.h"
+#endif
+
+UuidMetric::UuidMetric(int id) : m_id(id) {}
+
+void UuidMetric::set(const QString& uuid) const {
+#if not(defined(__wasm__) || defined(BUILD_QMAKE))
+  return glean_uuid_set(m_id, uuid.toLocal8Bit());
+#endif
+}
+
+QString UuidMetric::generateAndSet() const {
+#if not(defined(__wasm__) || defined(BUILD_QMAKE))
+  return glean_uuid_generate_and_set(m_id);
+#endif
+}
+
+int32_t UuidMetric::testGetNumRecordedErrors(ErrorType errorType) const {
+#if not(defined(__wasm__) || defined(BUILD_QMAKE))
+  return glean_uuid_test_get_num_recorded_errors(m_id, errorType);
+#endif
+  return 0;
+}
+
+QString UuidMetric::testGetValue(const QString& pingName) const {
+#if not(defined(__wasm__) || defined(BUILD_QMAKE))
+  return glean_uuid_test_get_value(m_id, pingName.toLocal8Bit());
+#endif
+  return "";
+}

--- a/qtglean/src/cpp/uuid.cpp
+++ b/qtglean/src/cpp/uuid.cpp
@@ -22,6 +22,7 @@ QString UuidMetric::generateAndSet() const {
 #if not(defined(__wasm__) || defined(BUILD_QMAKE))
   return glean_uuid_generate_and_set(m_id);
 #endif
+  return QString();
 }
 
 int32_t UuidMetric::testGetNumRecordedErrors(ErrorType errorType) const {

--- a/qtglean/src/ffi/mod.rs
+++ b/qtglean/src/ffi/mod.rs
@@ -15,3 +15,4 @@ pub mod ping;
 pub mod quantity;
 pub mod string;
 pub mod timing_distribution;
+pub mod uuid;

--- a/qtglean/src/ffi/uuid.rs
+++ b/qtglean/src/ffi/uuid.rs
@@ -1,0 +1,55 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use ffi_support::FfiStr;
+use std::ffi::CString;
+use std::os::raw::c_char;
+use glean::ErrorType;
+
+use crate::ffi::helpers;
+
+#[no_mangle]
+pub extern "C" fn glean_uuid_set(id: u32, uuid: FfiStr) {
+    with_metric!(UUID_MAP, id, metric, metric.set(uuid.into_string()))
+}
+
+#[no_mangle]
+pub extern "C" fn glean_uuid_generate_and_set(id: u32) 
+-> *mut c_char {
+    let return_string = with_metric!(UUID_MAP, id, metric, metric.generate_and_set());
+
+    CString::new(return_string)
+        .expect("Unable to create CString.")
+        .into_raw()  
+}
+
+#[no_mangle]
+pub extern "C" fn glean_uuid_test_get_value(
+    id: u32,
+    ping_name: FfiStr
+) -> *mut c_char {
+    let return_string = with_metric!(
+        UUID_MAP,
+        id,
+        metric,
+        metric.test_get_value(helpers::ping_name_from_ffi(ping_name)).unwrap_or("".to_string())
+    );
+
+    CString::new(return_string)
+        .expect("Unable to create CString.")
+        .into_raw()
+}
+
+#[no_mangle]
+pub extern "C" fn glean_uuid_test_get_num_recorded_errors(
+    id: u32,
+    error_type: ErrorType,
+) -> i32 {
+    with_metric!(
+        UUID_MAP,
+        id,
+        metric,
+        metric.test_get_num_recorded_errors(error_type)
+    )
+}


### PR DESCRIPTION
## Description

Adding UUID metric type. Tested locally, and working.

## Reference

https://mozilla-hub.atlassian.net/browse/VPN-3690

## Checklist
    
- [X] My code follows the style guidelines for this project
- [X] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [X] I have performed a self review of my own code
- [X] I have commented my code PARTICULARLY in hard to understand areas
- [X] I have added thorough tests where needed
