### PR TITLE
Clean up glean types - VPN-4455

### DIFF
--- a/qtglean/glean_parser_ext/templates/cpp_metrics_header.jinja2
+++ b/qtglean/glean_parser_ext/templates/cpp_metrics_header.jinja2
@@ -39,11 +39,11 @@ extern {{ obj|type_name }} {{obj.name|snake_case }};
 } // namespace mozilla::glean
 
 {% for category_name, objs in all_objs.items() %}
-class __DONOTUSE__{{ category_name|Camelize }} final {
-  Q_GADGET
+class __DONOTUSE__{{ category_name|Camelize }} final : public QObject {
+  Q_OBJECT
 
 {% for obj in objs.values() %}
-  Q_PROPERTY({{ obj|type_name }} {{obj.name|camelize }} READ {{ obj.name|camelize }} CONSTANT);
+  Q_PROPERTY({{ obj|type_name }}* {{obj.name|camelize }} READ {{ obj.name|camelize }}Getter CONSTANT);
 {% endfor %}
 
   public:
@@ -51,7 +51,8 @@ class __DONOTUSE__{{ category_name|Camelize }} final {
     ~__DONOTUSE__{{ category_name|Camelize }}() = default;
 
     {% for obj in objs.values() %}
-    {{ obj|type_name }} {{obj.name|camelize }} () const { return mozilla::glean::{{ category_name|snake_case }}::{{obj.name|snake_case }}; };
+    {{ obj|type_name }}* {{obj.name|camelize }}Getter () { return &mozilla::glean::{{ category_name|snake_case }}::{{obj.name|snake_case }}; };
+    const {{ obj|type_name }}& {{obj.name|camelize }} () const { return mozilla::glean::{{ category_name|snake_case }}::{{obj.name|snake_case }}; };
     {% endfor %}
 };
 {% endfor %}
@@ -67,7 +68,7 @@ class __DONOTUSE__GleanMetrics final : public QObject {
     Q_DISABLE_COPY_MOVE(__DONOTUSE__GleanMetrics)
 
     {% for category_name, _ in all_objs.items() %}
-    Q_PROPERTY(__DONOTUSE__{{ category_name|Camelize }} {{ category_name|camelize }} READ {{ category_name|camelize }} CONSTANT);
+    Q_PROPERTY(__DONOTUSE__{{ category_name|Camelize }}* {{ category_name|camelize }} READ {{ category_name|camelize }}Getter CONSTANT);
     {% endfor %}
 
     private:
@@ -85,7 +86,8 @@ class __DONOTUSE__GleanMetrics final : public QObject {
         }
 
         {% for category_name, _ in all_objs.items() %}
-        __DONOTUSE__{{ category_name|Camelize }} {{ category_name|camelize }} () const { return m_{{ category_name|camelize }}; };
+        __DONOTUSE__{{ category_name|Camelize }}* {{ category_name|camelize }}Getter () { return &m_{{ category_name|camelize }}; };
+        const __DONOTUSE__{{ category_name|Camelize }}& {{ category_name|camelize }} () const { return m_{{ category_name|camelize }}; };
         {% endfor %}
 
     private:

--- a/qtglean/glean_parser_ext/templates/cpp_pings_header.jinja2
+++ b/qtglean/glean_parser_ext/templates/cpp_pings_header.jinja2
@@ -26,7 +26,7 @@ class __DONOTUSE__GleanPings final : public QObject {
     Q_DISABLE_COPY_MOVE(__DONOTUSE__GleanPings)
 
     {% for obj in all_objs['pings'].values() %}
-    Q_PROPERTY(Ping {{ obj.name|Camelize }} READ {{ obj.name|Camelize }} CONSTANT)
+    Q_PROPERTY(Ping* {{ obj.name|Camelize }} READ {{ obj.name|Camelize }}Getter CONSTANT)
     {% endfor %}
 
     private:
@@ -44,7 +44,8 @@ class __DONOTUSE__GleanPings final : public QObject {
         }
 
         {% for obj in all_objs['pings'].values() %}
-        Ping {{ obj.name|Camelize }} () const { return m_{{ obj.name|camelize }}; };
+        Ping* {{ obj.name|Camelize }}Getter () { return &m_{{ obj.name|camelize }}; };
+        const Ping& {{ obj.name|Camelize }} () const { return m_{{ obj.name|camelize }}; };
         {% endfor %}
 
     private:
@@ -62,7 +63,7 @@ namespace mozilla::glean_pings {
      *
      * {{ obj.description|wordwrap() | replace('\n', '\n * ') }}
      */
-    inline Ping {{ obj.name|Camelize }} = __DONOTUSE__GleanPings::instance()->{{ obj.name|Camelize }}();
+    inline const Ping& {{ obj.name|Camelize }} = __DONOTUSE__GleanPings::instance()->{{ obj.name|Camelize }}();
     {% endfor %}
 } // namespace mozilla::glean_pings
 

--- a/qtglean/include/glean/boolean.h
+++ b/qtglean/include/glean/boolean.h
@@ -8,18 +8,12 @@
 
 #include "errortype.h"
 
-class BooleanMetric final {
-  Q_GADGET
+class BooleanMetric final : public QObject {
+  Q_OBJECT
+  Q_DISABLE_COPY_MOVE(BooleanMetric)
 
  public:
-  // QML custom types require these three declarations.
-  // See: https://doc.qt.io/qt-6/custom-types.html#creating-a-custom-type
-  BooleanMetric() = default;
-  BooleanMetric(const BooleanMetric&) = default;
-  BooleanMetric& operator=(const BooleanMetric&) = default;
-
   explicit BooleanMetric(int aId);
-  ~BooleanMetric() = default;
 
   Q_INVOKABLE void set(bool value = true) const;
 
@@ -28,7 +22,7 @@ class BooleanMetric final {
   Q_INVOKABLE int32_t testGetNumRecordedErrors(ErrorType errorType) const;
 
  private:
-  int m_id;
+  const int m_id;
 };
 
 #endif  // BOOLEAN_H

--- a/qtglean/include/glean/counter.h
+++ b/qtglean/include/glean/counter.h
@@ -8,18 +8,12 @@
 
 #include "errortype.h"
 
-class CounterMetric final {
-  Q_GADGET
+class CounterMetric final : public QObject {
+  Q_OBJECT
+  Q_DISABLE_COPY_MOVE(CounterMetric)
 
  public:
-  // QML custom types require these three declarations.
-  // See: https://doc.qt.io/qt-6/custom-types.html#creating-a-custom-type
-  CounterMetric() = default;
-  CounterMetric(const CounterMetric&) = default;
-  CounterMetric& operator=(const CounterMetric&) = default;
-
   explicit CounterMetric(int aId);
-  ~CounterMetric() = default;
 
   Q_INVOKABLE void add(int amount = 1) const;
 
@@ -29,7 +23,7 @@ class CounterMetric final {
   Q_INVOKABLE int32_t testGetNumRecordedErrors(ErrorType errorType) const;
 
  private:
-  int m_id;
+  const int m_id;
 };
 
 #endif  // COUNTER_H

--- a/qtglean/include/glean/datetime.h
+++ b/qtglean/include/glean/datetime.h
@@ -1,10 +1,10 @@
-
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #ifndef DATETIME_H
 #define DATETIME_H
+
 #include <QDateTime>
 #include <QObject>
 #include <QString>
@@ -15,18 +15,12 @@
 // - The ability to set an arbitrary datestamp
 // More details: https://mozilla-hub.atlassian.net/browse/VPN-4173
 
-class DatetimeMetric final {
-  Q_GADGET
+class DatetimeMetric final : public QObject {
+  Q_OBJECT
+  Q_DISABLE_COPY_MOVE(DatetimeMetric)
 
  public:
-  // QML custom types require these three declarations.
-  // See: https://doc.qt.io/qt-6/custom-types.html#creating-a-custom-type
-  DatetimeMetric() = default;
-  DatetimeMetric(const DatetimeMetric&) = default;
-  DatetimeMetric& operator=(const DatetimeMetric&) = default;
-
   explicit DatetimeMetric(int aId);
-  ~DatetimeMetric() = default;
 
   Q_INVOKABLE void set() const;
 
@@ -37,7 +31,7 @@ class DatetimeMetric final {
   Q_INVOKABLE int32_t testGetNumRecordedErrors(ErrorType errorType) const;
 
  private:
-  int m_id;
+  const int m_id;
 };
 
 #endif  // DATETIME_H

--- a/qtglean/include/glean/event.h
+++ b/qtglean/include/glean/event.h
@@ -25,8 +25,8 @@ struct EventMetricExtra {
   // a static cast of a specific extra struct into an `EventMetricExtra` struct.
   //
   // We need to static cast, because template classes cannot be annotated with
-  // Q_GADGET or Q_OBJECT like the EventMetric class needs to be, so we have to
-  // have this generic class to use as an argument for `record()`.
+  // Q_OBJECT like the EventMetric class needs to be, so we have to have this
+  // generic class to use as an argument for `record()`.
   //
   // Aggregate initialization is also not available for structs with private
   // fields, so we stick to this ugly __PRIVATE__ prefix.
@@ -53,19 +53,13 @@ struct EventMetricExtraParser {
   }
 };
 
-class EventMetric final {
-  Q_GADGET
+class EventMetric final : public QObject {
+  Q_OBJECT
+  Q_DISABLE_COPY_MOVE(EventMetric)
 
  public:
-  // QML custom types require these three declarations.
-  // See: https://doc.qt.io/qt-6/custom-types.html#creating-a-custom-type
-  EventMetric() = default;
-  EventMetric(const EventMetric&) = default;
-  EventMetric& operator=(const EventMetric&) = default;
-
   explicit EventMetric(
       int id, EventMetricExtraParser* parser = new EventMetricExtraParser());
-  ~EventMetric() = default;
 
   Q_INVOKABLE void record() const;
 
@@ -81,7 +75,7 @@ class EventMetric final {
       const QString& pingName = "") const;
 
  private:
-  int m_id;
+  const int m_id;
   EventMetricExtraParser* m_parser;
 };
 

--- a/qtglean/include/glean/ping.h
+++ b/qtglean/include/glean/ping.h
@@ -7,23 +7,17 @@
 
 #include <QObject>
 
-class Ping final {
-  Q_GADGET
+class Ping final : public QObject {
+  Q_OBJECT
+  Q_DISABLE_COPY_MOVE(Ping)
 
  public:
-  // QML custom types require these three declarations.
-  // See: https://doc.qt.io/qt-6/custom-types.html#creating-a-custom-type
-  Ping() = default;
-  Ping(const Ping&) = default;
-  Ping& operator=(const Ping&) = default;
-
   explicit Ping(int aId);
-  ~Ping() = default;
 
   Q_INVOKABLE void submit() const;
 
  private:
-  int m_id;
+  const int m_id;
 };
 
 #endif  // PING_H

--- a/qtglean/include/glean/quantity.h
+++ b/qtglean/include/glean/quantity.h
@@ -9,18 +9,12 @@
 
 #include "errortype.h"
 
-class QuantityMetric final {
-  Q_GADGET
+class QuantityMetric final : public QObject {
+  Q_OBJECT
+  Q_DISABLE_COPY_MOVE(QuantityMetric)
 
  public:
-  // QML custom types require these three declarations.
-  // See: https://doc.qt.io/qt-6/custom-types.html#creating-a-custom-type
-  QuantityMetric() = default;
-  QuantityMetric(const QuantityMetric&) = default;
-  QuantityMetric& operator=(const QuantityMetric&) = default;
-
   explicit QuantityMetric(int aId);
-  ~QuantityMetric() = default;
 
   Q_INVOKABLE void set(int value = 0) const;
 
@@ -30,7 +24,7 @@ class QuantityMetric final {
   Q_INVOKABLE int32_t testGetNumRecordedErrors(ErrorType errorType) const;
 
  private:
-  int m_id;
+  const int m_id;
 };
 
 #endif  // QUANTITY_H

--- a/qtglean/include/glean/string.h
+++ b/qtglean/include/glean/string.h
@@ -9,18 +9,12 @@
 
 #include "errortype.h"
 
-class StringMetric final {
-  Q_GADGET
+class StringMetric final : public QObject {
+  Q_OBJECT
+  Q_DISABLE_COPY_MOVE(StringMetric)
 
  public:
-  // QML custom types require these three declarations.
-  // See: https://doc.qt.io/qt-6/custom-types.html#creating-a-custom-type
-  StringMetric() = default;
-  StringMetric(const StringMetric&) = default;
-  StringMetric& operator=(const StringMetric&) = default;
-
   explicit StringMetric(int aId);
-  ~StringMetric() = default;
 
   Q_INVOKABLE void set(QString value = "") const;
 
@@ -30,7 +24,7 @@ class StringMetric final {
   Q_INVOKABLE int32_t testGetNumRecordedErrors(ErrorType errorType) const;
 
  private:
-  int m_id;
+  const int m_id;
 };
 
 #endif  // STRING_H

--- a/qtglean/include/glean/timingdistribution.h
+++ b/qtglean/include/glean/timingdistribution.h
@@ -27,19 +27,12 @@ struct DistributionData {
   DistributionData() : sum(0), count(0) {}
 };
 
-class TimingDistributionMetric final {
-  Q_GADGET
+class TimingDistributionMetric final : public QObject {
+  Q_OBJECT
+  Q_DISABLE_COPY_MOVE(TimingDistributionMetric)
 
  public:
-  // QML custom types require these three declarations.
-  // See: https://doc.qt.io/qt-6/custom-types.html#creating-a-custom-type
-  TimingDistributionMetric() = default;
-  TimingDistributionMetric(const TimingDistributionMetric&) = default;
-  TimingDistributionMetric& operator=(const TimingDistributionMetric&) =
-      default;
-
   explicit TimingDistributionMetric(int aId);
-  ~TimingDistributionMetric() = default;
 
   Q_INVOKABLE int start() const;
   Q_INVOKABLE void stopAndAccumulate(int timerId) const;
@@ -51,7 +44,7 @@ class TimingDistributionMetric final {
   Q_INVOKABLE int32_t testGetNumRecordedErrors(ErrorType errorType) const;
 
  private:
-  int m_id;
+  const int m_id;
 };
 
 #endif  // TIMING_DISTRIBUTION_H

--- a/qtglean/include/glean/uuid.h
+++ b/qtglean/include/glean/uuid.h
@@ -8,16 +8,11 @@
 
 #include "errortype.h"
 
-class UuidMetric final {
-  Q_GADGET
+class UuidMetric final : public QObject {
+  Q_OBJECT
+  Q_DISABLE_COPY_MOVE(UuidMetric)
 
  public:
-  // QML custom types require these three declarations.
-  // See: https://doc.qt.io/qt-6/custom-types.html#creating-a-custom-type
-  UuidMetric() = default;
-  UuidMetric(const UuidMetric&) = default;
-  UuidMetric& operator=(const UuidMetric&) = default;
-
   explicit UuidMetric(int aId);
   ~UuidMetric() = default;
 
@@ -29,7 +24,7 @@ class UuidMetric final {
   Q_INVOKABLE int32_t testGetNumRecordedErrors(ErrorType errorType) const;
 
  private:
-  int m_id;
+  const int m_id;
 };
 
 #endif  // UUID_H


### PR DESCRIPTION
There was nothing wrong in the previous implementation. Just 2 things we can do better:
- we exposed a CTOR for every glean type which left `m_id` not initialized. This CTOR can be removed.
- we duplicated/copied the glean types multiple times (in the QT world) every time we use them.

About this second point the issues are:
- why allocating more memory when we can use references/pointers?
- we have all these copy-CTORs without tests
- `m_id` cannot be `const` because of the copy-CTOR.
- all of this copying is because we use Q_GADGET with works with simple struct, copied all the times.

Q_GADGET does not work with pointers. I had to replace it with Q_OBJECT. I also add `Q_DISABLE_COPY_MOVE` to remove unwanted CTORs.

No changes in the API.