### PR TITLE
VPN-3745: Verify subscription when disconnecting after a "No signal" state

### DIFF
--- a/src/apps/vpn/cmake/sources.cmake
+++ b/src/apps/vpn/cmake/sources.cmake
@@ -231,6 +231,8 @@ target_sources(mozillavpn-sources INTERFACE
     ${CMAKE_CURRENT_SOURCE_DIR}/apps/vpn/settingswatcher.h
     ${CMAKE_CURRENT_SOURCE_DIR}/apps/vpn/statusicon.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/apps/vpn/statusicon.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/apps/vpn/subscriptionmonitor.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/apps/vpn/subscriptionmonitor.h
     ${CMAKE_CURRENT_SOURCE_DIR}/apps/vpn/tasks/account/taskaccount.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/apps/vpn/tasks/account/taskaccount.h
     ${CMAKE_CURRENT_SOURCE_DIR}/apps/vpn/tasks/adddevice/taskadddevice.cpp

--- a/src/apps/vpn/mozillavpn.cpp
+++ b/src/apps/vpn/mozillavpn.cpp
@@ -68,6 +68,8 @@
 #include "websocket/pushmessage.h"
 #include "websocket/websockethandler.h"
 
+#include "subscriptionmonitor.h"
+
 #ifdef SENTRY_ENABLED
 #  include "sentry/sentryadapter.h"
 #endif
@@ -277,6 +279,8 @@ void MozillaVPN::initialize() {
 
   SettingsHolder* settingsHolder = SettingsHolder::instance();
   Q_ASSERT(settingsHolder);
+
+  SubscriptionMonitor::instance();
 
 #ifdef MZ_ANDROID
   AndroidVPNActivity::maybeInit();

--- a/src/apps/vpn/mozillavpn.cpp
+++ b/src/apps/vpn/mozillavpn.cpp
@@ -69,8 +69,6 @@
 #include "websocket/pushmessage.h"
 #include "websocket/websockethandler.h"
 
-// #include "subscriptionmonitor.h"
-
 #ifdef SENTRY_ENABLED
 #  include "sentry/sentryadapter.h"
 #endif

--- a/src/apps/vpn/mozillavpn.cpp
+++ b/src/apps/vpn/mozillavpn.cpp
@@ -41,6 +41,7 @@
 #include "serveri18n.h"
 #include "settingsholder.h"
 #include "settingswatcher.h"
+#include "subscriptionmonitor.h"
 #include "tasks/account/taskaccount.h"
 #include "tasks/adddevice/taskadddevice.h"
 #include "tasks/addonindex/taskaddonindex.h"
@@ -68,7 +69,7 @@
 #include "websocket/pushmessage.h"
 #include "websocket/websockethandler.h"
 
-#include "subscriptionmonitor.h"
+// #include "subscriptionmonitor.h"
 
 #ifdef SENTRY_ENABLED
 #  include "sentry/sentryadapter.h"

--- a/src/apps/vpn/qmake/sources.pri
+++ b/src/apps/vpn/qmake/sources.pri
@@ -99,6 +99,7 @@ SOURCES += \
         apps/vpn/serverlatency.cpp \
         apps/vpn/settingswatcher.cpp \
         apps/vpn/statusicon.cpp \
+        apps/vpn/subscriptionmonitor.cpp \
         apps/vpn/tasks/account/taskaccount.cpp \
         apps/vpn/tasks/adddevice/taskadddevice.cpp \
         apps/vpn/tasks/addon/taskaddon.cpp \
@@ -232,6 +233,7 @@ HEADERS += \
         apps/vpn/serverlatency.h \
         apps/vpn/settingswatcher.h \
         apps/vpn/statusicon.h \
+        apps/vpn/subscriptionmonitor.h \
         apps/vpn/tasks/account/taskaccount.h \
         apps/vpn/tasks/adddevice/taskadddevice.h \
         apps/vpn/tasks/addon/taskaddon.h \

--- a/src/apps/vpn/subscriptionmonitor.cpp
+++ b/src/apps/vpn/subscriptionmonitor.cpp
@@ -8,12 +8,16 @@
 #include <QMetaMethod>
 #include <QMetaObject>
 
+#include "appconstants.h"
+#include "controller.h"
 #include "dnshelper.h"
 #include "leakdetector.h"
 #include "logger.h"
 #include "mozillavpn.h"
+#include "networkrequest.h"
 #include "settingsholder.h"
 #include "tasks/controlleraction/taskcontrolleraction.h"
+#include "tasks/function/taskfunction.h"
 #include "taskscheduler.h"
 
 namespace {
@@ -29,46 +33,40 @@ Logger logger("SubscriptionMonitor");
 SubscriptionMonitor::SubscriptionMonitor(QObject* parent) : QObject(parent) {
   MZ_COUNT_CTOR(SubscriptionMonitor);
 
-//   SettingsHolder* settingsHolder = SettingsHolder::instance();
+/**
+ * Here we need to setup 2 connections:
+ * connection health: to monitor no signal state)
+ * controller: to monitor if/when user turns their VPN off 
+ *             so we can ping guardian and then show the sub expired page.
+ */
+ 
 
-// #define CONNECT(x)                                  \
-//   connect(settingsHolder, &SettingsHolder::x, this, \
-//           &SubscriptionMonitor::maybeServerSwitch);
+  connect(MozillaVPN::instance()->controller(), &Controller::stateChanged, this,
+          [this]() {
+            Controller::State state =
+                MozillaVPN::instance()->controller()->state();
+            // m_operationRunning is set to true when the Controller is in
+            // StateOn. So, if we see a change, it means that the new settings
+            // values have been taken in consideration. We are ready to
+            // schedule a new TaskControllerAction if needed.
+            if (state == Controller::StateOff) {
+              logger.debug() << "User has toggled the VPN off";
+              m_operationRunning = false;
 
-//   CONNECT(captivePortalAlertChanged);
-//   CONNECT(protectSelectedAppsChanged);
-//   CONNECT(vpnDisabledAppsChanged);
+              // Check the subscription status
+              // MozillaVPN::instance()->controller()->setState(Controller::StateCheckSubscription);
+              TaskFunction* task = new TaskFunction([]() {});
+              NetworkRequest* request = new NetworkRequest(task, 200);
+              request->auth(MozillaVPN::authorizationHeader());
+              request->get(AppConstants::apiUrl(AppConstants::Account));
 
-// #undef CONNECT
-
-// #define DNS_CONNECT(x)                                                  \
-//   connect(settingsHolder, &SettingsHolder::x, this, [this]() {          \
-//     SettingsHolder* settingsHolder = SettingsHolder::instance();        \
-//     if (settingsHolder->dnsProviderFlags() != SettingsHolder::Custom || \
-//         DNSHelper::validateUserDNS(settingsHolder->userDNS())) {        \
-//       maybeServerSwitch();                                              \
-//     }                                                                   \
-//   });
-
-//   DNS_CONNECT(dnsProviderFlagsChanged);
-//   DNS_CONNECT(userDNSChanged);
-
-// #undef DNS_CONNECT
-
-//   connect(MozillaVPN::instance()->controller(), &Controller::stateChanged, this,
-//           [this]() {
-//             Controller::State state =
-//                 MozillaVPN::instance()->controller()->state();
-//             // m_operationRunning is set to true when the Controller is in
-//             // StateOn. So, if we see a change, it means that the new settings
-//             // values have been taken in consideration. We are ready to
-//             // schedule a new TaskControllerAction if needed.
-//             if (state != Controller::StateOn && state != Controller::StateOff &&
-//                 m_operationRunning) {
-//               logger.debug() << "Resetting the operation running state";
-//               m_operationRunning = false;
-//             }
-//           });
+              // connect(request, &NetworkRequest::requestFailed, this,
+              //         [this](QNetworkReply::NetworkError error, const QByteArray&) {
+              //           logger.error() << "Account request failed" << error;
+              //           REPORTNETWORKERROR(error, ErrorHandler::DoNotPropagateError,
+              //                             "PreActivationSubscriptionCheck");
+            }
+          });
 }
 
 SubscriptionMonitor::~SubscriptionMonitor() { MZ_COUNT_DTOR(SubscriptionMonitor); }
@@ -81,21 +79,5 @@ SubscriptionMonitor* SubscriptionMonitor::instance() {
   }
   return s_instance;
 }
-
-// void SubscriptionMonitor::maybeServerSwitch() {
-//   logger.debug() << "Settings changed!";
-
-//   if (MozillaVPN::instance()->controller()->state() != Controller::StateOn ||
-//       m_operationRunning) {
-//     return;
-//   }
-
-//   m_operationRunning = true;
-
-//   TaskScheduler::deleteTasks();
-//   TaskScheduler::scheduleTask(
-//       new TaskControllerAction(TaskControllerAction::eSilentSwitch,
-//                                TaskControllerAction::eServerCoolDownNotNeeded));
-// }
 
 void SubscriptionMonitor::operationCompleted() { m_operationRunning = false; }

--- a/src/apps/vpn/subscriptionmonitor.cpp
+++ b/src/apps/vpn/subscriptionmonitor.cpp
@@ -1,0 +1,95 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "settingswatcher.h"
+
+#include <QCoreApplication>
+#include <QMetaMethod>
+#include <QMetaObject>
+
+#include "dnshelper.h"
+#include "leakdetector.h"
+#include "logger.h"
+#include "mozillavpn.h"
+#include "settingsholder.h"
+#include "tasks/controlleraction/taskcontrolleraction.h"
+#include "taskscheduler.h"
+
+namespace {
+Logger logger("SettingsWatcher");
+}
+
+SettingsWatcher::SettingsWatcher(QObject* parent) : QObject(parent) {
+  MZ_COUNT_CTOR(SettingsWatcher);
+
+  SettingsHolder* settingsHolder = SettingsHolder::instance();
+
+#define CONNECT(x)                                  \
+  connect(settingsHolder, &SettingsHolder::x, this, \
+          &SettingsWatcher::maybeServerSwitch);
+
+  CONNECT(captivePortalAlertChanged);
+  CONNECT(protectSelectedAppsChanged);
+  CONNECT(vpnDisabledAppsChanged);
+
+#undef CONNECT
+
+#define DNS_CONNECT(x)                                                  \
+  connect(settingsHolder, &SettingsHolder::x, this, [this]() {          \
+    SettingsHolder* settingsHolder = SettingsHolder::instance();        \
+    if (settingsHolder->dnsProviderFlags() != SettingsHolder::Custom || \
+        DNSHelper::validateUserDNS(settingsHolder->userDNS())) {        \
+      maybeServerSwitch();                                              \
+    }                                                                   \
+  });
+
+  DNS_CONNECT(dnsProviderFlagsChanged);
+  DNS_CONNECT(userDNSChanged);
+
+#undef DNS_CONNECT
+
+  connect(MozillaVPN::instance()->controller(), &Controller::stateChanged, this,
+          [this]() {
+            Controller::State state =
+                MozillaVPN::instance()->controller()->state();
+            // m_operationRunning is set to true when the Controller is in
+            // StateOn. So, if we see a change, it means that the new settings
+            // values have been taken in consideration. We are ready to
+            // schedule a new TaskControllerAction if needed.
+            if (state != Controller::StateOn && state != Controller::StateOff &&
+                m_operationRunning) {
+              logger.debug() << "Resetting the operation running state";
+              m_operationRunning = false;
+            }
+          });
+}
+
+SettingsWatcher::~SettingsWatcher() { MZ_COUNT_DTOR(SettingsWatcher); }
+
+// static
+SettingsWatcher* SettingsWatcher::instance() {
+  static SettingsWatcher* s_instance = nullptr;
+  if (!s_instance) {
+    s_instance = new SettingsWatcher(qApp);
+  }
+  return s_instance;
+}
+
+void SettingsWatcher::maybeServerSwitch() {
+  logger.debug() << "Settings changed!";
+
+  if (MozillaVPN::instance()->controller()->state() != Controller::StateOn ||
+      m_operationRunning) {
+    return;
+  }
+
+  m_operationRunning = true;
+
+  TaskScheduler::deleteTasks();
+  TaskScheduler::scheduleTask(
+      new TaskControllerAction(TaskControllerAction::eSilentSwitch,
+                               TaskControllerAction::eServerCoolDownNotNeeded));
+}
+
+void SettingsWatcher::operationCompleted() { m_operationRunning = false; }

--- a/src/apps/vpn/subscriptionmonitor.cpp
+++ b/src/apps/vpn/subscriptionmonitor.cpp
@@ -11,15 +11,11 @@
 #include "appconstants.h"
 #include "connectionhealth.h"
 #include "controller.h"
-#include "dnshelper.h"
 #include "leakdetector.h"
 #include "logger.h"
 #include "mozillavpn.h"
 #include "networkrequest.h"
-#include "settingsholder.h"
-#include "tasks/controlleraction/taskcontrolleraction.h"
 #include "tasks/function/taskfunction.h"
-#include "taskscheduler.h"
 
 namespace {
 Logger logger("SubscriptionMonitor");
@@ -28,52 +24,42 @@ Logger logger("SubscriptionMonitor");
 SubscriptionMonitor::SubscriptionMonitor(QObject* parent) : QObject(parent) {
   MZ_COUNT_CTOR(SubscriptionMonitor);
 
-/**
- * Here we need to setup 2 connections:
- * connection health: to monitor no signal state
- * controller: to monitor if/when user turns their VPN off 
- *             so we can ping guardian and then show the sub expired page.
- */
+  /*
+   * Here we setup 2 connections:
+   * ConnectionHealth: to monitor No Signal state
+   * Controller: to monitor when user turns their VPN off
+   * so we can ping guardian and then show the subscription expired page.
+   */
 
-  connect(MozillaVPN::instance()->connectionHealth(), &ConnectionHealth::stabilityChanged, this, [] () {
-    if (MozillaVPN::instance()->connectionHealth()->stability() == ConnectionHealth::NoSignal)
-    {
-      logger.debug() << "VPN connection stability is NoSignal";
-      //What else do I need to do here?
-    }
-  });
- 
+  connect(MozillaVPN::instance()->connectionHealth(),
+          &ConnectionHealth::stabilityChanged, this, []() {
+            if (MozillaVPN::instance()->connectionHealth()->stability() ==
+                ConnectionHealth::NoSignal) {
+              logger.debug() << "VPN connection stability is NoSignal";
+              // TODO: What else do I need to do here?
+            }
+          });
+
   connect(MozillaVPN::instance()->controller(), &Controller::stateChanged, this,
-          [this]() {
+          []() {
             Controller::State state =
                 MozillaVPN::instance()->controller()->state();
-            // m_operationRunning is set to true when the Controller is in
-            // StateOn. So, if we see a change, it means that the new settings
-            // values have been taken in consideration. We are ready to
-            // schedule a new TaskControllerAction if needed.
             if (state == Controller::StateOff) {
               logger.debug() << "User has toggled the VPN off";
-              m_operationRunning = false; //not sure we need this
 
-              // Check the subscription status. setStatus() ia private 
-              // so I think instead of setting controller status, we can just go ahead and send in the network request directly
-              // MozillaVPN::instance()->controller()->setState(Controller::StateCheckSubscription); // Can't do this here
+              // Send a network request to check if the subscription status is
+              // active
               TaskFunction* task = new TaskFunction([]() {});
               NetworkRequest* request = new NetworkRequest(task, 200);
               request->auth(MozillaVPN::authorizationHeader());
               request->get(AppConstants::apiUrl(AppConstants::Account));
-
-              // TODO: We most likely need to listen for request failures
-              // connect(request, &NetworkRequest::requestFailed, this,
-              //         [this](QNetworkReply::NetworkError error, const QByteArray&) {
-              //           logger.error() << "Account request failed" << error;
-              //           REPORTNETWORKERROR(error, ErrorHandler::DoNotPropagateError,
-              //                             "PreActivationSubscriptionCheck");
             }
           });
 }
 
-SubscriptionMonitor::~SubscriptionMonitor() { MZ_COUNT_DTOR(SubscriptionMonitor); }
+SubscriptionMonitor::~SubscriptionMonitor() {
+  MZ_COUNT_DTOR(SubscriptionMonitor);
+}
 
 // static
 SubscriptionMonitor* SubscriptionMonitor::instance() {
@@ -83,5 +69,3 @@ SubscriptionMonitor* SubscriptionMonitor::instance() {
   }
   return s_instance;
 }
-
-void SubscriptionMonitor::operationCompleted() { m_operationRunning = false; }

--- a/src/apps/vpn/subscriptionmonitor.cpp
+++ b/src/apps/vpn/subscriptionmonitor.cpp
@@ -35,10 +35,11 @@ SubscriptionMonitor::SubscriptionMonitor(QObject* parent) : QObject(parent) {
  *             so we can ping guardian and then show the sub expired page.
  */
 
-  connect(MozillaVPN::instance()->connectionHealth(), &ConnectionHealth::stabilityChanged, this, [this] () {
+  connect(MozillaVPN::instance()->connectionHealth(), &ConnectionHealth::stabilityChanged, this, [] () {
     if (MozillaVPN::instance()->connectionHealth()->stability() == ConnectionHealth::NoSignal)
     {
       logger.debug() << "VPN connection stability is NoSignal";
+      //What else do I need to do here?
     }
   });
  

--- a/src/apps/vpn/subscriptionmonitor.h
+++ b/src/apps/vpn/subscriptionmonitor.h
@@ -1,0 +1,34 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef SUBSCRIPTIONMONITOR_H
+#define SUBSCRIPTIONMONITOR_H
+
+#include <QObject>
+
+/**
+ * @brief this class watches a few setting properties to see if we need to
+ * trigger a silent-server-switch
+ */
+class SubscriptionMonitor final : public QObject {
+  Q_OBJECT
+  Q_DISABLE_COPY_MOVE(SubscriptionMonitor)
+
+ public:
+  static SubscriptionMonitor* instance();
+
+  ~SubscriptionMonitor();
+
+ private:
+  explicit SubscriptionMonitor(QObject* parent);
+
+  void operationCompleted();
+
+ private:
+  class TaskSubscriptionMonitor;
+
+  bool m_operationRunning = false;
+};
+
+#endif  // SUBSCRIPTIONMONITOR_H

--- a/src/apps/vpn/subscriptionmonitor.h
+++ b/src/apps/vpn/subscriptionmonitor.h
@@ -8,8 +8,8 @@
 #include <QObject>
 
 /**
- * @brief this class watches a few setting properties to see if we need to
- * trigger a silent-server-switch
+ * @brief this class monitors the Controller and ConnectionHealth to check for
+ * subscription status after the controller enters the No Signal state
  */
 class SubscriptionMonitor final : public QObject {
   Q_OBJECT
@@ -22,13 +22,6 @@ class SubscriptionMonitor final : public QObject {
 
  private:
   explicit SubscriptionMonitor(QObject* parent);
-
-  void operationCompleted();
-
- private:
-  class TaskSubscriptionMonitor;
-
-  bool m_operationRunning = false;
 };
 
 #endif  // SUBSCRIPTIONMONITOR_H


### PR DESCRIPTION
## Description

- Introduce **SubscriptionMonitor**: This is a singleton class that has an `instance()` function and 2 connections for `ConnectionHealth` (to monitor No Signal state) and `Controller` (to monitor when user toggles off VPN) so we can ping Guardian and then show the subscription expired page.

## Reference

    https://mozilla-hub.atlassian.net/browse/VPN-3745

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed - tests will be added as part of VPN-4406
