### PR TITLE
VPN-3392 - update wireguard repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,7 +7,7 @@
 	url = https://github.com/WireGuard/wireguard-tools
 [submodule "3rdparty/wireguard-apple"]
 	path = 3rdparty/wireguard-apple
-	url = https://github.com/mozilla/wireguard-apple
+	url = https://github.com/WireGuard/wireguard-apple
 [submodule "3rdparty/openSSL"]
 	path = 3rdparty/openSSL
 	url = https://github.com/KDAB/android_openssl


### PR DESCRIPTION
## Description

This undoes [a prior PR](https://github.com/mozilla-mobile/mozilla-vpn-client/pull/4954), as Wireguard has updated their repo to fix the bug.

I've tested this on my personal device, which was able to replicate the original issue with IPv6 networks and iOS 16.

We can’t go to the [latest](https://github.com/WireGuard/wireguard-apple/compare/c229b7c1535f748c3b0f614e933fcfab2d3d5a50...2fec12a6e1f6e3460b6ee483aa00ad29cddadab1) wireguard-apple commit, as they bumped the minimum iOS version to 15.0 in a [recent commit](https://github.com/WireGuard/wireguard-apple/commit/901fe1cf58dc40e551088cac3bf00d68e3e86db3#diff-f913940c58e8744a2af1c68b909bb6383e49007e6c5a12fb03104a9006ae677e). Our VPN app supports 13.0 and above, and so we’d have to bump the minimum version of our app.

Luckily, the commit we need comes before that one, so we can still use this branch. 

## Reference

https://mozilla-hub.atlassian.net/browse/VPN-3392

## Checklist
    
- [X] My code follows the style guidelines for this project
- [X] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [X] I have performed a self review of my own code
- [X] I have commented my code PARTICULARLY in hard to understand areas
- [X] I have added thorough tests where needed
