### PR TITLE
VPN-4441: Add controller step metric to session ping

### DIFF
--- a/glean/metrics.yaml
+++ b/glean/metrics.yaml
@@ -1032,6 +1032,7 @@ sample:
     lifetime: ping
     send_in_pings:
       - main
+      - vpnsession
     description: |
       The controller state flow (off, connecting, switching, etc).
     bugs:


### PR DESCRIPTION
## Description

Adding existing metric to session ping

## Reference

https://mozilla-hub.atlassian.net/browse/VPN-4441

## Checklist
    
- [X] My code follows the style guidelines for this project
- [X] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [X] I have performed a self review of my own code
- [X] I have commented my code PARTICULARLY in hard to understand areas
- [X] I have added thorough tests where needed
