### PR TITLE
VPN-4274 Improve OS notifications

### DIFF
--- a/src/apps/vpn/notificationhandler.cpp
+++ b/src/apps/vpn/notificationhandler.cpp
@@ -196,13 +196,31 @@ void NotificationHandler::showNotification() {
           return;
         }
         // "VPN Disconnected"
-        notifyInternal(None,
-                       I18nStrings::instance()->t(
-                           I18nStrings::NotificationsVPNDisconnectedTitle),
-                       I18nStrings::instance()
-                           ->t(I18nStrings::NotificationsVPNDisconnectedMessage)
-                           .arg(localizedCityName),
-                       NOTIFICATION_TIME_MSEC);
+        ServerData* serverData = vpn->serverData();
+        if (serverData->multihop())
+        {
+            QString localizedEntryCityName =
+                vpn->controller()->currentServer().localizedEntryCityName();
+
+            QString localizedExitCityName =
+                vpn->controller()->currentServer().localizedExitCityName();
+            
+            notifyInternal(None,
+                           I18nStrings::instance()->t(
+                               I18nStrings::NotificationsVPNDisconnectedTitle),
+                           I18nStrings::instance()
+                               ->t(I18nStrings::NotificationsVPNMultihopDisconnectedMessage)
+                               .arg(localizedExitCityName, localizedEntryCityName),
+                           NOTIFICATION_TIME_MSEC);
+        } else {
+            notifyInternal(None,
+                           I18nStrings::instance()->t(
+                               I18nStrings::NotificationsVPNDisconnectedTitle),
+                           I18nStrings::instance()
+                               ->t(I18nStrings::NotificationsVPNDisconnectedMessage)
+                               .arg(localizedCityName),
+                           NOTIFICATION_TIME_MSEC);
+        }
       }
       return;
 

--- a/src/apps/vpn/notificationhandler.cpp
+++ b/src/apps/vpn/notificationhandler.cpp
@@ -149,12 +149,12 @@ void NotificationHandler::showNotification() {
             QString localizedExitCityName =
                 vpn->controller()->currentServer().localizedExitCityName();
             
-            // We hit this when going single to multihop
-            if (!localizedEntryCityName.isEmpty()) {
+            // We hit this when going multi to single hop ?
+            if (localizedEntryCityName.isEmpty()) {
                 notifyInternal(
                     None,
                     I18nStrings::instance()->t(
-                        I18nStrings::NotificationsVPNSwitchedServersTitle),
+                        I18nStrings::NotificationsVPNConnectedTitle),
                     I18nStrings::instance()
                         ->t(I18nStrings::NotificationsVPNSwitchedSingleToMultiHopMessage)
                         .arg(localizedExitCityName, localizedCityName),
@@ -167,15 +167,15 @@ void NotificationHandler::showNotification() {
 
             QString localizedExitCityName =
                 vpn->controller()->currentServer().localizedExitCityName();
-            // check if we are going to singlehop. We hit this when going multihop to singlehop
+            // singlehop to singlehop
             if (localizedEntryCityName.isEmpty()) {
                 notifyInternal(
                     None,
                     I18nStrings::instance()->t(
-                        I18nStrings::NotificationsVPNSwitchedServersTitle),
+                        I18nStrings::NotificationsVPNConnectedTitle),
                     I18nStrings::instance()
-                        ->t(I18nStrings::NotificationsVPNSwitchedMultiToSingleHopMessage)
-                        .arg(localizedCityName),
+                        ->t(I18nStrings::NotificationsVPNSwitchedServersMessage)
+                        .arg(localizedPreviousExitCityName, localizedCityName),
                     NOTIFICATION_TIME_MSEC);
             }
             
@@ -215,7 +215,7 @@ void NotificationHandler::showNotification() {
               I18nStrings::instance()->t(
                   I18nStrings::NotificationsVPNConnectedTitle),
               I18nStrings::instance()
-                  ->t(I18nStrings::NotificationsVPNMultihopConnectedMessage)
+                  ->t(I18nStrings::NotificationsVPNMultihopConnectedMessages)
                   .arg(localizedExitCityName, localizedEntryCityName),
               NOTIFICATION_TIME_MSEC);
         } else {
@@ -223,7 +223,7 @@ void NotificationHandler::showNotification() {
                          I18nStrings::instance()->t(
                              I18nStrings::NotificationsVPNConnectedTitle),
                          I18nStrings::instance()
-                             ->t(I18nStrings::NotificationsVPNConnectedMessage)
+                             ->t(I18nStrings::NotificationsVPNConnectedMessages)
                              .arg(localizedCityName),
                          NOTIFICATION_TIME_MSEC);
         }

--- a/src/apps/vpn/notificationhandler.cpp
+++ b/src/apps/vpn/notificationhandler.cpp
@@ -139,14 +139,56 @@ void NotificationHandler::showNotification() {
         }
 
         // "VPN Switched Servers"
-        notifyInternal(
-            None,
-            I18nStrings::instance()->t(
-                I18nStrings::NotificationsVPNSwitchedServersTitle),
-            I18nStrings::instance()
-                ->t(I18nStrings::NotificationsVPNSwitchedServersMessage)
-                .arg(localizedPreviousExitCityName, localizedCityName),
-            NOTIFICATION_TIME_MSEC);
+        ServerData* serverData = vpn->serverData();
+        
+        if (serverData->multihop()) {
+            
+            QString localizedEntryCityName =
+                vpn->controller()->currentServer().localizedEntryCityName();
+
+            QString localizedExitCityName =
+                vpn->controller()->currentServer().localizedExitCityName();
+            
+            // We hit this when going single to multihop
+            if (!localizedEntryCityName.isEmpty()) {
+                notifyInternal(
+                    None,
+                    I18nStrings::instance()->t(
+                        I18nStrings::NotificationsVPNSwitchedServersTitle),
+                    I18nStrings::instance()
+                        ->t(I18nStrings::NotificationsVPNSwitchedSingleToMultiHopMessage)
+                        .arg(localizedExitCityName, localizedCityName),
+                    NOTIFICATION_TIME_MSEC);
+            }
+              
+        } else {
+            QString localizedEntryCityName =
+                vpn->controller()->currentServer().localizedEntryCityName();
+
+            QString localizedExitCityName =
+                vpn->controller()->currentServer().localizedExitCityName();
+            // check if we are going to singlehop. We hit this when going multihop to singlehop
+            if (localizedEntryCityName.isEmpty()) {
+                notifyInternal(
+                    None,
+                    I18nStrings::instance()->t(
+                        I18nStrings::NotificationsVPNSwitchedServersTitle),
+                    I18nStrings::instance()
+                        ->t(I18nStrings::NotificationsVPNSwitchedMultiToSingleHopMessage)
+                        .arg(localizedCityName),
+                    NOTIFICATION_TIME_MSEC);
+            }
+            
+//            notifyInternal(
+//                None,
+//                I18nStrings::instance()->t(
+//                    I18nStrings::NotificationsVPNSwitchedServersTitle),
+//                I18nStrings::instance()
+//                    ->t(I18nStrings::NotificationsVPNSwitchedServersMessage)
+//                    .arg(localizedPreviousExitCityName, localizedCityName),
+//                NOTIFICATION_TIME_MSEC);
+        }
+          
         return;
       }
 

--- a/src/apps/vpn/notificationhandler.cpp
+++ b/src/apps/vpn/notificationhandler.cpp
@@ -139,56 +139,15 @@ void NotificationHandler::showNotification() {
         }
 
         // "VPN Switched Servers"
-        ServerData* serverData = vpn->serverData();
-        
-        if (serverData->multihop()) {
-            
-            QString localizedEntryCityName =
-                vpn->controller()->currentServer().localizedEntryCityName();
+        notifyInternal(
+            None,
+            I18nStrings::instance()->t(
+                I18nStrings::NotificationsVPNSwitchedServersTitle),
+            I18nStrings::instance()
+                ->t(I18nStrings::NotificationsVPNSwitchedServersMessage)
+                .arg(localizedPreviousExitCityName, localizedCityName),
+            NOTIFICATION_TIME_MSEC);
 
-            QString localizedExitCityName =
-                vpn->controller()->currentServer().localizedExitCityName();
-            
-            // We hit this when going multi to single hop ?
-            if (localizedEntryCityName.isEmpty()) {
-                notifyInternal(
-                    None,
-                    I18nStrings::instance()->t(
-                        I18nStrings::NotificationsVPNConnectedTitle),
-                    I18nStrings::instance()
-                        ->t(I18nStrings::NotificationsVPNSwitchedSingleToMultiHopMessage)
-                        .arg(localizedExitCityName, localizedCityName),
-                    NOTIFICATION_TIME_MSEC);
-            }
-              
-        } else {
-            QString localizedEntryCityName =
-                vpn->controller()->currentServer().localizedEntryCityName();
-
-            QString localizedExitCityName =
-                vpn->controller()->currentServer().localizedExitCityName();
-            // singlehop to singlehop
-            if (localizedEntryCityName.isEmpty()) {
-                notifyInternal(
-                    None,
-                    I18nStrings::instance()->t(
-                        I18nStrings::NotificationsVPNConnectedTitle),
-                    I18nStrings::instance()
-                        ->t(I18nStrings::NotificationsVPNSwitchedServersMessage)
-                        .arg(localizedPreviousExitCityName, localizedCityName),
-                    NOTIFICATION_TIME_MSEC);
-            }
-            
-//            notifyInternal(
-//                None,
-//                I18nStrings::instance()->t(
-//                    I18nStrings::NotificationsVPNSwitchedServersTitle),
-//                I18nStrings::instance()
-//                    ->t(I18nStrings::NotificationsVPNSwitchedServersMessage)
-//                    .arg(localizedPreviousExitCityName, localizedCityName),
-//                NOTIFICATION_TIME_MSEC);
-        }
-          
         return;
       }
 
@@ -239,29 +198,30 @@ void NotificationHandler::showNotification() {
         }
         // "VPN Disconnected"
         ServerData* serverData = vpn->serverData();
-        if (serverData->multihop())
-        {
-            QString localizedEntryCityName =
-                vpn->controller()->currentServer().localizedEntryCityName();
+        if (serverData->multihop()) {
+          QString localizedEntryCityName =
+              vpn->controller()->currentServer().localizedEntryCityName();
 
-            QString localizedExitCityName =
-                vpn->controller()->currentServer().localizedExitCityName();
-            
-            notifyInternal(None,
-                           I18nStrings::instance()->t(
-                               I18nStrings::NotificationsVPNDisconnectedTitle),
-                           I18nStrings::instance()
-                               ->t(I18nStrings::NotificationsVPNMultihopDisconnectedMessage)
-                               .arg(localizedExitCityName, localizedEntryCityName),
-                           NOTIFICATION_TIME_MSEC);
+          QString localizedExitCityName =
+              vpn->controller()->currentServer().localizedExitCityName();
+
+          notifyInternal(
+              None,
+              I18nStrings::instance()->t(
+                  I18nStrings::NotificationsVPNDisconnectedTitle),
+              I18nStrings::instance()
+                  ->t(I18nStrings::NotificationsVPNMultihopDisconnectedMessage)
+                  .arg(localizedExitCityName, localizedEntryCityName),
+              NOTIFICATION_TIME_MSEC);
         } else {
-            notifyInternal(None,
-                           I18nStrings::instance()->t(
-                               I18nStrings::NotificationsVPNDisconnectedTitle),
-                           I18nStrings::instance()
-                               ->t(I18nStrings::NotificationsVPNDisconnectedMessage)
-                               .arg(localizedCityName),
-                           NOTIFICATION_TIME_MSEC);
+          notifyInternal(
+              None,
+              I18nStrings::instance()->t(
+                  I18nStrings::NotificationsVPNDisconnectedTitle),
+              I18nStrings::instance()
+                  ->t(I18nStrings::NotificationsVPNDisconnectedMessage)
+                  .arg(localizedCityName),
+              NOTIFICATION_TIME_MSEC);
         }
       }
       return;

--- a/src/apps/vpn/notificationhandler.cpp
+++ b/src/apps/vpn/notificationhandler.cpp
@@ -109,7 +109,7 @@ void NotificationHandler::showNotification() {
   // We want to show notifications about the location in use by the controller,
   // which could be different than MozillaVPN::serverData in the rare case of a
   // server-switch request processed in the meantime.
-  QString localizedCityName =
+  QString localizedExitCityName =
       vpn->controller()->currentServer().localizedExitCityName();
   QString localizedCountryName =
       vpn->controller()->currentServer().localizedExitCountryName();
@@ -132,7 +132,7 @@ void NotificationHandler::showNotification() {
             vpn->controller()->currentServer().localizedPreviousExitCityName();
 
         if ((localizedPreviousExitCountryName == localizedCountryName) &&
-            (localizedPreviousExitCityName == localizedCityName)) {
+            (localizedPreviousExitCityName == localizedExitCityName)) {
           // Don't show notifications unless the exit server changed, see:
           // https://github.com/mozilla-mobile/mozilla-vpn-client/issues/1719
           return;
@@ -145,7 +145,7 @@ void NotificationHandler::showNotification() {
                 I18nStrings::NotificationsVPNSwitchedServersTitle),
             I18nStrings::instance()
                 ->t(I18nStrings::NotificationsVPNSwitchedServersMessage)
-                .arg(localizedPreviousExitCityName, localizedCityName),
+                .arg(localizedPreviousExitCityName, localizedExitCityName),
             NOTIFICATION_TIME_MSEC);
 
         return;
@@ -183,7 +183,7 @@ void NotificationHandler::showNotification() {
                              I18nStrings::NotificationsVPNConnectedTitle),
                          I18nStrings::instance()
                              ->t(I18nStrings::NotificationsVPNConnectedMessages)
-                             .arg(localizedCityName),
+                             .arg(localizedExitCityName),
                          NOTIFICATION_TIME_MSEC);
         }
       }
@@ -220,7 +220,7 @@ void NotificationHandler::showNotification() {
                   I18nStrings::NotificationsVPNDisconnectedTitle),
               I18nStrings::instance()
                   ->t(I18nStrings::NotificationsVPNDisconnectedMessage)
-                  .arg(localizedCityName),
+                  .arg(localizedExitCityName),
               NOTIFICATION_TIME_MSEC);
         }
       }

--- a/src/apps/vpn/platforms/android/androidcontroller.cpp
+++ b/src/apps/vpn/platforms/android/androidcontroller.cpp
@@ -206,7 +206,7 @@ void AndroidController::activate(const HopConnection& hop, const Device* device,
       I18nStrings::NotificationsVPNConnectedTitle);  // Connected
   messages["connectedBody"] =
       I18nStrings::instance()
-          ->t(I18nStrings::NotificationsVPNConnectedMessage)
+          ->t(I18nStrings::NotificationsVPNConnectedMessages)
           .arg(localizedCityName);
   messages["disconnectedHeader"] = I18nStrings::instance()->t(
       I18nStrings::NotificationsVPNDisconnectedTitle);

--- a/src/apps/vpn/translations/strings.yaml
+++ b/src/apps/vpn/translations/strings.yaml
@@ -286,6 +286,12 @@ notifications:
   VPNSwitchedServersMessage:
     value: "Switched from %1 to %2"
     comment: "%1 is the name of the initial server, %2 is the name of the destination server."
+  VPNSwitchedMultiToSingleHopMessage:
+    value: "Now connected through %1"
+    comment: "%1 is the name of the city the VPN is connected to."
+  VPNSwitchedSingleToMultiHopMessage:
+    value: "Now connected through %1 via %2"
+    comment: "%2 is the name of the initial server, %1 is the name of the destination server."
 
 systray:
   hide: Hide Mozilla VPN

--- a/src/apps/vpn/translations/strings.yaml
+++ b/src/apps/vpn/translations/strings.yaml
@@ -270,15 +270,18 @@ notifications:
     comment: "%1 is the Wi-Fi network name"
   VPNConnectedTitle: VPN Connected
   VPNConnectedMessage:
-    value: "Connected to %1"
+    value: "Connected through %1"
     comment: "%1 is the name of the city the VPN is connected to."
   VPNMultihopConnectedMessage:
-    value: "Connected to %1, through %2"
+    value: "Connected to %1 through %2"
     comment: "%1 is the name of the exit server, %2 is the name of the entry server."
   VPNDisconnectedTitle: VPN Disconnected
   VPNDisconnectedMessage:
     value: "Disconnected from %1"
     comment: "%1 is the name of the city the VPN disconnected from."
+  VPNMultihopDisconnectedMessage:
+    value: "Disconnected from %1 and %2"
+    comment: "%1 is the name of the exit server, %2 is the name of the entry server."
   VPNSwitchedServersTitle: VPN Switched Servers
   VPNSwitchedServersMessage:
     value: "Switched from %1 to %2"

--- a/src/apps/vpn/translations/strings.yaml
+++ b/src/apps/vpn/translations/strings.yaml
@@ -286,12 +286,6 @@ notifications:
   VPNSwitchedServersMessage:
     value: "Switched from %1 to %2"
     comment: "%1 is the name of the initial server, %2 is the name of the destination server."
-  VPNSwitchedMultiToSingleHopMessage:
-    value: "Now connected through %1"
-    comment: "%1 is the name of the city the VPN is connected to."
-  VPNSwitchedSingleToMultiHopMessage:
-    value: "Now connected through %1 via %2"
-    comment: "%2 is the name of the initial server, %1 is the name of the destination server."
 
 systray:
   hide: Hide Mozilla VPN

--- a/src/apps/vpn/translations/strings.yaml
+++ b/src/apps/vpn/translations/strings.yaml
@@ -269,11 +269,11 @@ notifications:
     value: "%1 is not secure. Click here to turn on VPN and secure your device."
     comment: "%1 is the Wi-Fi network name"
   VPNConnectedTitle: VPN Connected
-  VPNConnectedMessage:
+  VPNConnectedMessages:
     value: "Connected through %1"
     comment: "%1 is the name of the city the VPN is connected to."
-  VPNMultihopConnectedMessage:
-    value: "Connected to %1 through %2"
+  VPNMultihopConnectedMessages:
+    value: "Connected through %1 via %2"
     comment: "%1 is the name of the exit server, %2 is the name of the entry server."
   VPNDisconnectedTitle: VPN Disconnected
   VPNDisconnectedMessage:

--- a/tests/functional/testConnection.js
+++ b/tests/functional/testConnection.js
@@ -55,7 +55,7 @@ describe('Connectivity', function() {
     });
 
     assert.equal(vpn.lastNotification().title, 'VPN Connected');
-    assert(vpn.lastNotification().message.startsWith('Connected to '));
+    assert(vpn.lastNotification().message.startsWith('Connected through '));
   });
 
   it('Disconnecting and disconnected', async () => {

--- a/tests/functional/testServerSearch.js
+++ b/tests/functional/testServerSearch.js
@@ -181,7 +181,7 @@ describe("Server list", function () {
     assert.strictEqual(vpn.lastNotification().title, "VPN Connected");
     assert.strictEqual(
       vpn.lastNotification().message,
-      `Connected to ${currentCity}`
+      `Connected through ${currentCity}`
     );
   });
 

--- a/tests/functional/testServerSearch.js
+++ b/tests/functional/testServerSearch.js
@@ -119,7 +119,7 @@ describe("Server list", function () {
     assert.strictEqual(vpn.lastNotification().title, "VPN Connected");
     assert.strictEqual(
       vpn.lastNotification().message,
-      `Connected to ${currentCity}, through ${currentCity}`
+      `Connected through ${currentCity} via ${currentCity}`
     );
   });
 

--- a/tests/functional/testServers.js
+++ b/tests/functional/testServers.js
@@ -160,7 +160,7 @@ describe('Server list', function() {
     assert.strictEqual(vpn.lastNotification().title, 'VPN Connected');
     assert.strictEqual(
         vpn.lastNotification().message,
-        `Connected to ${currentCity}`);
+        `Connected through ${currentCity}`);
 
     await vpn.waitForQueryAndClick(
         queries.screenHome.SERVER_LIST_BUTTON.visible());


### PR DESCRIPTION
## Description

Change the notification text for connecting and disconnecting the VPN to distinguish between singlehop and multihop settings. 
Please visit the original issue for the details. The only caveat is that because we don't have a way to track the previous state of the VPN, when we are switching from single to multihop and the other way around, we don't know anything about the previous state. For example, when going from multihop to single hop, we only know we are currently switching to single hop (without knowing if before it was single or multihop). For that reason there is no way to differentiate between multi to single hop and single to single hop scenarios when switching. So for now this PR only addresses changes other than "Switching".

## Reference

    https://mozilla-hub.atlassian.net/browse/VPN-4274

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
