### PR TITLE
Use 1.5 for the version of desktop file specification

### DIFF
--- a/linux/extra/mozillavpn-startup.desktop.in
+++ b/linux/extra/mozillavpn-startup.desktop.in
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Name=MozillaVPN
-Version=@CMAKE_PROJECT_VERSION@
+Version=1.5
 Exec=@CMAKE_INSTALL_FULL_BINDIR@/mozillavpn ui -m -s
 Comment=A fast, secure and easy to use VPN. Built by the makers of Firefox.
 Type=Application

--- a/linux/extra/mozillavpn.desktop.in
+++ b/linux/extra/mozillavpn.desktop.in
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Name=MozillaVPN
-Version=@CMAKE_PROJECT_VERSION@
+Version=1.5
 Exec=@CMAKE_INSTALL_FULL_BINDIR@/mozillavpn
 Comment=A fast, secure and easy to use VPN. Built by the makers of Firefox.
 Type=Application


### PR DESCRIPTION
## Description

The “Version” field of a desktop entry refers to the version of the desktop entry specification to which this file complies, not the program version. This PR puts the version to “1.5”.

## Reference

https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#recognized-keys
https://wiki.archlinux.org/title/Desktop_entries

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
