### PR TITLE
Handle install bin dir in dbus service file

### DIFF
--- a/src/apps/vpn/cmake/linux.cmake
+++ b/src/apps/vpn/cmake/linux.cmake
@@ -114,7 +114,9 @@ install(FILES apps/vpn/platforms/linux/daemon/org.mozilla.vpn.policy
 install(FILES apps/vpn/platforms/linux/daemon/org.mozilla.vpn.conf
     DESTINATION /usr/share/dbus-1/system.d)
 
-install(FILES apps/vpn/platforms/linux/daemon/org.mozilla.vpn.dbus.service
+configure_file(apps/vpn/platforms/linux/daemon/org.mozilla.vpn.dbus.service.in
+    ${CMAKE_CURRENT_BINARY_DIR}/org.mozilla.vpn.dbus.service)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/org.mozilla.vpn.dbus.service
     DESTINATION /usr/share/dbus-1/system-services)
 
 pkg_check_modules(SYSTEMD systemd)

--- a/src/apps/vpn/platforms/linux/daemon/org.mozilla.vpn.dbus.service.in
+++ b/src/apps/vpn/platforms/linux/daemon/org.mozilla.vpn.dbus.service.in
@@ -1,5 +1,5 @@
 [D-BUS Service]
 User=root
 Name=org.mozilla.vpn.dbus
-Exec=/usr/bin/mozillavpn linuxdaemon
+Exec=@CMAKE_INSTALL_FULL_BINDIR@/mozillavpn linuxdaemon
 SystemdService=mozillavpn.service


### PR DESCRIPTION
## Description

Just like the systemd service file [`linux/mozillavpn.service.in`](https://github.com/mozilla-mobile/mozilla-vpn-client/blob/b9152c9b50773a5ca7301b75f16e35b0ed9e1f5d/linux/mozillavpn.service.in), the D-Bus service file [`apps/vpn/platforms/linux/daemon/org.mozilla.vpn.dbus.service`](https://github.com/mozilla-mobile/mozilla-vpn-client/blob/b9152c9b50773a5ca7301b75f16e35b0ed9e1f5d/src/apps/vpn/platforms/linux/daemon/org.mozilla.vpn.dbus.service) should be configured with the proper path to the binary instead of hardcoding `/usr/bin`.

## Reference

None

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
  - nothing hard to understand
- [x] I have added thorough tests where needed
  - no tests for similar items
