### PR TITLE
Chore: ADB logs if not in production

### DIFF
--- a/src/shared/loghandler.cpp
+++ b/src/shared/loghandler.cpp
@@ -240,14 +240,15 @@ void LogHandler::addLog(const Log& log,
 
   emit logEntryAdded(buffer);
 
-  #if defined(MZ_ANDROID) 
-    if(!Constants::inProduction()){
-      const char* str = buffer.constData();
-      if (str) {
-        __android_log_write(ANDROID_LOG_DEBUG, AppConstants::ANDROID_LOG_NAME, str);
-      }
+#if defined(MZ_ANDROID)
+  if (!Constants::inProduction()) {
+    const char* str = buffer.constData();
+    if (str) {
+      __android_log_write(ANDROID_LOG_DEBUG, AppConstants::ANDROID_LOG_NAME,
+                          str);
     }
-  #endif
+  }
+#endif
 }
 
 // static

--- a/src/shared/loghandler.cpp
+++ b/src/shared/loghandler.cpp
@@ -240,12 +240,14 @@ void LogHandler::addLog(const Log& log,
 
   emit logEntryAdded(buffer);
 
-#if defined(MZ_ANDROID) && defined(MZ_DEBUG)
-  const char* str = buffer.constData();
-  if (str) {
-    __android_log_write(ANDROID_LOG_DEBUG, AppConstants::ANDROID_LOG_NAME, str);
-  }
-#endif
+  #if defined(MZ_ANDROID) 
+    if(!Constants::inProduction()){
+      const char* str = buffer.constData();
+      if (str) {
+        __android_log_write(ANDROID_LOG_DEBUG, AppConstants::ANDROID_LOG_NAME, str);
+      }
+    }
+  #endif
 }
 
 // static


### PR DESCRIPTION
## Description
This is something i apply on my branches all the time. 
We should not do that in release && prod. 
However limiting this only to debug builds makes testing iAP & updating annoying. 


