### PR TITLE
Maybe fix wonky Windows App Exclusions images

### DIFF
--- a/src/apps/vpn/ui/screens/settings/appPermissions/AppPermissionsList.qml
+++ b/src/apps/vpn/ui/screens/settings/appPermissions/AppPermissionsList.qml
@@ -96,19 +96,20 @@ ColumnLayout {
                     Layout.maximumWidth: MZTheme.theme.windowMargin * 2
                     Layout.alignment: Qt.AlignVCenter
                     color: MZTheme.theme.transparent
-                    radius: MZTheme.theme.cornerRadius
 
                     Image {
+                        height: MZTheme.theme.windowMargin * 2
+                        width: MZTheme.theme.windowMargin * 2
                         sourceSize.width: MZTheme.theme.windowMargin * 2
                         sourceSize.height: MZTheme.theme.windowMargin * 2
                         anchors.centerIn: parent
-                        asynchronous: true
                         fillMode:  Image.PreserveAspectFit
                         Component.onCompleted: {
                             if (appID !== "") {
                                 source = "image://app/"+appID
                             }
                         }
+                        
                     }
                 }
 


### PR DESCRIPTION
## Description
"Screen cap" of App Images on Windows display 
<img width="300" alt="Screen Shot 2023-04-03 at 3 58 30 PM" src="https://user-images.githubusercontent.com/22355127/229626130-fd08f875-be44-4ac0-ad72-89aced1043bf.png">


## Reference

VPN-2953

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
