### PR TITLE
Implement addon-replacer type - VPN-4260

### DIFF
--- a/.dictionary
+++ b/.dictionary
@@ -40,10 +40,13 @@ NDK
 NONINFRINGEMENT
 OpenSSL
 QMake
+QML
+QMLs
 Qt's
 QtLottie
 RCC
 README
+Replacer
 RSA
 SDKs
 SHA
@@ -157,6 +160,7 @@ rdparty
 reftag
 relink
 relinking
+replacer
 repo
 resolvconf
 rlottie
@@ -176,6 +180,7 @@ tooltip
 ui
 ulist
 uploader
+urls
 utils
 uuid
 vml

--- a/docs/add-on.md
+++ b/docs/add-on.md
@@ -31,7 +31,7 @@ least a manifest.json file. The properties of this JSON file are:
 | state | Object describing the state of the addon | Collection of state objects | No |
 
 Based on the add-on type, extra properties can be in added. See the [tutorial](https://github.com/mozilla-mobile/mozilla-vpn-client/blob/main/docs/tutorials.md),
-[guide](https://github.com/mozilla-mobile/mozilla-vpn-client/blob/main/docs/guides.md), and [message](https://github.com/mozilla-mobile/mozilla-vpn-client/blob/main/docs/message.md) documentation.
+[guide](https://github.com/mozilla-mobile/mozilla-vpn-client/blob/main/docs/guides.md), [message](https://github.com/mozilla-mobile/mozilla-vpn-client/blob/main/docs/message.md), and [replacer](https://github.com/mozilla-mobile/mozilla-vpn-client/blob/main/docs/replacer.md) documentation.
 
 ## State Object
 

--- a/docs/replacer.md
+++ b/docs/replacer.md
@@ -1,0 +1,34 @@
+# Replacer
+
+Replacer addons can be used to replace QRC resources at execution time. The addon must include all the required files in its bundle.
+
+The JSON files are validated via [JSON Schema](https://json-schema.org/) files:
+
+https://github.com/mozilla-mobile/mozilla-vpn-client/tree/main/scripts/ci/jsonSchemas
+
+On this page, we want to describe how to write a replacer addon.
+
+### Considerations
+
+ * Replacing QML files can be hazardous! The application will break if the QMLs are broken, or the dependencies are unsatisfied.
+
+ * Replacing an entire folder is even more dangerous! Image what happens if you replace the whole `i18n` folder with broken translation files.
+
+## JSON format
+
+The Replacer JSON files are addon JSON objects with the type "replacer" and a
+"replacer" property object with the following properties:
+
+| Property | Description  | Type | Required |
+| -- | -- | --| -- |
+| urls | An array of Replace objects | Array of objects | Yes |
+
+### Replace object
+
+This object must have the following structure:
+
+| Property | Description  | Type | Required |
+| -- | -- | --| -- |
+| request | The QRC URL to be replaced | string | Yes |
+| response | The relative path of the file/directory to use to replace the `request` | string | Yes |
+| type | The type of the request (`file` or `directory`). By default: `file` | string | No |

--- a/scripts/addon/build.py
+++ b/scripts/addon/build.py
@@ -356,8 +356,10 @@ with open(args.source, "r", encoding="utf-8") as file:
             strings = retrieve_strings_guide(manifest, args.source)
         elif manifest["type"] == "message":
             strings = retrieve_strings_message(manifest, args.source)
+        elif manifest["type"] == "replacer":
+          pass
         else:
-            exit(f"Unupported manifest type `{manifest['type']}`")
+            exit(f"Unsupported manifest type `{manifest['type']}`")
 
         print("Create localization file...")
         os.mkdir(os.path.join(tmp_path, "i18n"))

--- a/scripts/ci/jsonSchemas/addon.json
+++ b/scripts/ci/jsonSchemas/addon.json
@@ -21,7 +21,7 @@
     },
     "type": {
       "type": "string",
-      "description": "The type of the addon: tutorial, guide, i18n"
+      "description": "The type of the addon: tutorial, guide, i18n, message, replacer, ..."
     },
     "conditions": {
       "$ref": "conditions.json"
@@ -67,6 +67,9 @@
     },
     "message": {
       "$ref": "message.json#"
+    },
+    "replacer": {
+      "$ref": "replacer.json#"
     },
     "javascript": {
       "$ref": "javascript.json#"

--- a/scripts/ci/jsonSchemas/replacer.json
+++ b/scripts/ci/jsonSchemas/replacer.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "urls": {
+      "type": "array",
+      "description": "List of URLs to replace",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "description": "A single URL to be replaced",
+        "properties": {
+          "request": {
+            "type": "string",
+            "description": "The requested URL"
+          },
+          "response": {
+            "type": "string",
+            "description": "The file to be used to replace the requested URL"
+          },
+          "type": {
+            "type": "string",
+            "description": "The URL type. It can be 'file' or 'directory'. By default: 'file'"
+          }
+        }
+      }
+    }
+  },
+  "required": [ "replacer" ]
+}

--- a/src/apps/unit_tests/CMakeLists.txt
+++ b/src/apps/unit_tests/CMakeLists.txt
@@ -111,6 +111,8 @@ target_sources(app_unit_tests PRIVATE
     testnetworkmanager.h
     testqmlpath.cpp
     testqmlpath.h
+    testresourceloader.cpp
+    testresourceloader.h
     testtasksentry.cpp
     testtasksentry.h
     testsettings.cpp
@@ -167,6 +169,7 @@ target_sources(app_unit_tests PRIVATE
     qml/qml.qrc
     themes/themes.qrc
     tutorials/tutorials.qrc
+    resourceloader/resourceloader.qrc
 )
 
 qt_finalize_target(app_unit_tests)

--- a/src/apps/unit_tests/resourceloader/LICENSE.md
+++ b/src/apps/unit_tests/resourceloader/LICENSE.md
@@ -1,0 +1,4 @@
+Hello world!
+============
+
+Feel free to use this code, if it works...

--- a/src/apps/unit_tests/resourceloader/encodedPassword.txt
+++ b/src/apps/unit_tests/resourceloader/encodedPassword.txt
@@ -1,0 +1,1 @@
+0ciaociao

--- a/src/apps/unit_tests/resourceloader/languages.json
+++ b/src/apps/unit_tests/resourceloader/languages.json
@@ -1,0 +1,12 @@
+[
+ {
+  "languageCode": "tlh",
+  "languages": {}
+  },
+ {
+  "languageCode": "gr",
+  "languages": {
+   "tlh": "Κλίνγκον γλώσσα"
+  }
+ }
+]

--- a/src/apps/unit_tests/resourceloader/resourceloader.qrc
+++ b/src/apps/unit_tests/resourceloader/resourceloader.qrc
@@ -1,0 +1,8 @@
+<RCC>
+    <qresource prefix="/">
+        <file alias="replace/encodedPassword.txt">encodedPassword.txt</file>
+        <file alias="resources/encodedPassword.txt">../../../shared/resources/encodedPassword.txt</file>
+        <file alias="replace/languages.json">languages.json</file>
+        <file alias="replace/LICENSE.md">LICENSE.md</file>
+    </qresource>
+</RCC>

--- a/src/apps/unit_tests/testlanguagei18n.cpp
+++ b/src/apps/unit_tests/testlanguagei18n.cpp
@@ -9,31 +9,37 @@
 #include "settingsholder.h"
 
 void TestLanguageI18n::translations() {
-  QVERIFY(LanguageI18N::languageExists("tlh"));
-  QVERIFY(!LanguageI18N::languageExists("FOO"));
+  QVERIFY(LanguageI18N::instance()->languageExists("tlh"));
+  QVERIFY(!LanguageI18N::instance()->languageExists("FOO"));
 
   // Non existing language
-  QVERIFY(LanguageI18N::translateLanguage("FOO", "FOO").isEmpty());
+  QVERIFY(LanguageI18N::instance()->translateLanguage("FOO", "FOO").isEmpty());
 
   // Self-translation
-  QCOMPARE(LanguageI18N::translateLanguage("tlh", "tlh"), " ");
+  QCOMPARE(LanguageI18N::instance()->translateLanguage("tlh", "tlh"),
+           " ");
 
   // Other language
-  QCOMPARE(LanguageI18N::translateLanguage("fr", "tlh"), "klingon");
+  QCOMPARE(LanguageI18N::instance()->translateLanguage("fr", "tlh"), "klingon");
 
   // Non existing translation
-  QVERIFY(LanguageI18N::translateLanguage("fi", "tlh").isEmpty());
+  QVERIFY(LanguageI18N::instance()->translateLanguage("fi", "tlh").isEmpty());
 }
 
 void TestLanguageI18n::currencies() {
   // Non existing language
-  QVERIFY(LanguageI18N::currencySymbolForLanguage("FOO", "FOO").isEmpty());
+  QVERIFY(LanguageI18N::instance()
+              ->currencySymbolForLanguage("FOO", "FOO")
+              .isEmpty());
 
   // Not existing currency
-  QVERIFY(LanguageI18N::currencySymbolForLanguage("tlh", "FOO").isEmpty());
+  QVERIFY(LanguageI18N::instance()
+              ->currencySymbolForLanguage("tlh", "FOO")
+              .isEmpty());
 
   // OK
-  QCOMPARE(LanguageI18N::currencySymbolForLanguage("tlh", "EUR"), "€");
+  QCOMPARE(LanguageI18N::instance()->currencySymbolForLanguage("tlh", "EUR"),
+           "€");
 }
 
 static TestLanguageI18n s_testLanguageI18n;

--- a/src/apps/unit_tests/testresourceloader.cpp
+++ b/src/apps/unit_tests/testresourceloader.cpp
@@ -1,0 +1,212 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "testresourceloader.h"
+
+#include <QQmlAbstractUrlInterceptor>
+#include <QQmlApplicationEngine>
+#include <QUrl>
+
+#include "addons/addonreplacer.h"
+#include "authenticationinapp/authenticationinapp.h"
+#include "helper.h"
+#include "languagei18n.h"
+#include "localizer.h"
+#include "models/licensemodel.h"
+#include "qmlengineholder.h"
+#include "resourceloader.h"
+#include "settingsholder.h"
+
+class Interceptor final : public QQmlAbstractUrlInterceptor {
+ public:
+  Interceptor(const QUrl& a, const QUrl& b) : m_a(a), m_b(b) {}
+
+  QUrl intercept(const QUrl& url, QQmlAbstractUrlInterceptor::DataType type) {
+    if (url == m_a) {
+      return m_b;
+    }
+    return url;
+  }
+
+ private:
+  const QUrl m_a;
+  const QUrl m_b;
+};
+
+void TestResourceLoader::loadFile() {
+  SettingsHolder settingsHolder;
+  Localizer l;
+
+  QQmlApplicationEngine engine;
+  QmlEngineHolder qml(&engine);
+
+  ResourceLoader* rl = ResourceLoader::instance();
+  QVERIFY(!!rl);
+
+  QCOMPARE(rl->loadFile(":aa"), ":aa");
+
+  Interceptor i(QUrl("qrc:aa"), QUrl("qrc:bb"));
+
+  rl->addUrlInterceptor(&i);
+  QCOMPARE(rl->loadFile(":aa"), ":bb");
+
+  rl->removeUrlInterceptor(&i);
+  QCOMPARE(rl->loadFile(":aa"), ":aa");
+}
+
+void TestResourceLoader::loadDir() {
+  SettingsHolder settingsHolder;
+  Localizer l;
+
+  QQmlApplicationEngine engine;
+  QmlEngineHolder qml(&engine);
+
+  ResourceLoader* rl = ResourceLoader::instance();
+  QVERIFY(!!rl);
+
+  QCOMPARE(rl->loadDir(":aa"), ":aa");
+
+  Interceptor i(QUrl("qrc:aa/"), QUrl("qrc:bb/"));
+
+  rl->addUrlInterceptor(&i);
+  QCOMPARE(rl->loadDir(":aa"), ":bb/");
+
+  rl->removeUrlInterceptor(&i);
+  QCOMPARE(rl->loadDir(":aa"), ":aa");
+}
+
+void TestResourceLoader::commonPasswords() {
+  SettingsHolder settingsHolder;
+  Localizer l;
+
+  QQmlApplicationEngine engine;
+  QmlEngineHolder qml(&engine);
+
+  AuthenticationInApp* aia = AuthenticationInApp::instance();
+  QVERIFY(!!aia);
+
+  QCOMPARE(aia->validatePasswordCommons("12345678"), false);
+
+  Interceptor i(QUrl("qrc:/resources/encodedPassword.txt"),
+                QUrl("qrc:/replace/encodedPassword.txt"));
+
+  ResourceLoader* rl = ResourceLoader::instance();
+
+  rl->addUrlInterceptor(&i);
+  QCOMPARE(aia->validatePasswordCommons("12345678"), true);
+  QCOMPARE(aia->validatePasswordCommons("ciaociao"), false);
+
+  rl->removeUrlInterceptor(&i);
+  QCOMPARE(aia->validatePasswordCommons("12345678"), false);
+}
+
+void TestResourceLoader::languageI18N() {
+  SettingsHolder settingsHolder;
+  Localizer l;
+
+  QQmlApplicationEngine engine;
+  QmlEngineHolder qml(&engine);
+
+  QCOMPARE(LanguageI18N::instance()->translateLanguage("fr", "tlh"), "klingon");
+  QVERIFY(LanguageI18N::instance()->translateLanguage("gr", "tlh").isEmpty());
+
+  Interceptor i(QUrl("qrc:/i18n/languages.json"),
+                QUrl("qrc:/replace/languages.json"));
+
+  ResourceLoader* rl = ResourceLoader::instance();
+
+  rl->addUrlInterceptor(&i);
+  QVERIFY(LanguageI18N::instance()->translateLanguage("fr", "tlh").isEmpty());
+  QCOMPARE(LanguageI18N::instance()->translateLanguage("gr", "tlh"),
+           "Κλίνγκον γλώσσα");
+
+  rl->removeUrlInterceptor(&i);
+  QCOMPARE(LanguageI18N::instance()->translateLanguage("fr", "tlh"), "klingon");
+  QVERIFY(LanguageI18N::instance()->translateLanguage("gr", "tlh").isEmpty());
+}
+
+void TestResourceLoader::licenseModel() {
+  SettingsHolder settingsHolder;
+  Localizer l;
+
+  QQmlApplicationEngine engine;
+  QmlEngineHolder qml(&engine);
+
+  LicenseModel* lm = LicenseModel::instance();
+
+  lm->initialize();
+  QVERIFY(lm->contentLicense().length() > 0);
+  QVERIFY(lm->rowCount(QModelIndex()) > 0);
+
+  QString title = lm->data(lm->index(0, 0), LicenseModel::TitleRole).toString();
+
+  Interceptor i(QUrl("qrc:/license/LICENSE.md"),
+                QUrl("qrc:/replace/LICENSE.md"));
+
+  ResourceLoader* rl = ResourceLoader::instance();
+
+  rl->addUrlInterceptor(&i);
+  QVERIFY(lm->data(lm->index(0, 0), LicenseModel::TitleRole).toString() !=
+          title);
+
+  rl->removeUrlInterceptor(&i);
+  QCOMPARE(lm->data(lm->index(0, 0), LicenseModel::TitleRole).toString(),
+           title);
+}
+
+void TestResourceLoader::addon() {
+  SettingsHolder settingsHolder;
+  Localizer l;
+
+  QQmlApplicationEngine engine;
+  QmlEngineHolder qml(&engine);
+
+  QJsonArray urls;
+
+  {
+    QJsonObject urlObj;
+    urlObj["request"] = "qrc:/foo/file.txt";
+    urlObj["response"] = "replace/LICENSE.md";
+    urls.append(urlObj);
+  }
+
+  {
+    QJsonObject urlObj;
+    urlObj["request"] = "qrc:/dir";
+    urlObj["response"] = "replace";
+    urlObj["type"] = "directory";
+    urls.append(urlObj);
+  }
+
+  {
+    QJsonObject urlObj;
+    urlObj["request"] = "qrc:/dir2/";
+    urlObj["response"] = "replace";
+    urlObj["type"] = "directory";
+    urls.append(urlObj);
+  }
+
+  QJsonObject content;
+  content["urls"] = urls;
+
+  QJsonObject obj;
+  obj["replacer"] = content;
+
+  QObject parent;
+  Addon* replacer =
+      AddonReplacer::create(&parent, ":/manifest.json", "bar", "name", obj);
+  QVERIFY(!!replacer);
+
+  replacer->enable();
+  QVERIFY(replacer->enabled());
+
+  ResourceLoader* rl = ResourceLoader::instance();
+  QCOMPARE(rl->loadFile(":aa"), ":aa");
+  QCOMPARE(rl->loadFile(":/foo/file.txt"), ":/replace/LICENSE.md");
+  QCOMPARE(rl->loadFile(":/dir/file.txt"), ":/replace/file.txt");
+  QCOMPARE(rl->loadDir(":/dir"), ":/replace/");
+  QCOMPARE(rl->loadDir(":/dir/"), ":/replace/");
+}
+
+static TestResourceLoader s_testResourceLoader;

--- a/src/apps/unit_tests/testresourceloader.h
+++ b/src/apps/unit_tests/testresourceloader.h
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "helper.h"
+
+class TestResourceLoader final : public TestHelper {
+  Q_OBJECT
+
+ private slots:
+  void loadFile();
+  void loadDir();
+
+  void commonPasswords();
+  void languageI18N();
+  void licenseModel();
+
+  void addon();
+};

--- a/src/apps/vpn/models/recentconnections.cpp
+++ b/src/apps/vpn/models/recentconnections.cpp
@@ -177,8 +177,8 @@ QVariant RecentConnectionModel::data(const QModelIndex& index, int role) const {
 
     case LocalizedExitCityNameRole: {
       const RecentConnection& rc = m_list.at(id);
-      return QVariant(ServerI18N::translateCityName(rc.m_exitCountryCode,
-                                                    rc.m_exitCityName));
+      return QVariant(ServerI18N::instance()->translateCityName(
+          rc.m_exitCountryCode, rc.m_exitCityName));
     }
 
     case IsMultiHopRole: {
@@ -195,8 +195,8 @@ QVariant RecentConnectionModel::data(const QModelIndex& index, int role) const {
 
     case LocalizedEntryCityNameRole: {
       const RecentConnection& rc = m_list.at(id);
-      return QVariant(ServerI18N::translateCityName(rc.m_entryCountryCode,
-                                                    rc.m_entryCityName));
+      return QVariant(ServerI18N::instance()->translateCityName(
+          rc.m_entryCountryCode, rc.m_entryCityName));
     }
 
     default:

--- a/src/apps/vpn/models/servercity.cpp
+++ b/src/apps/vpn/models/servercity.cpp
@@ -110,7 +110,7 @@ QString ServerCity::hashKey(const QString& country, const QString cityName) {
 }
 
 const QString ServerCity::localizedName() const {
-  return ServerI18N::translateCityName(m_country, m_name);
+  return ServerI18N::instance()->translateCityName(m_country, m_name);
 }
 
 unsigned int ServerCity::latency() const {

--- a/src/apps/vpn/models/servercountry.cpp
+++ b/src/apps/vpn/models/servercountry.cpp
@@ -78,8 +78,9 @@ namespace {
 bool sortCityCallback(const QString& a, const QString& b,
                       const QString& countryCode, Collator* collator) {
   Q_ASSERT(collator);
-  return collator->compare(ServerI18N::translateCityName(countryCode, a),
-                           ServerI18N::translateCityName(countryCode, b)) < 0;
+  return collator->compare(
+             ServerI18N::instance()->translateCityName(countryCode, a),
+             ServerI18N::instance()->translateCityName(countryCode, b)) < 0;
 }
 
 }  // anonymous namespace

--- a/src/apps/vpn/models/servercountrymodel.cpp
+++ b/src/apps/vpn/models/servercountrymodel.cpp
@@ -161,8 +161,8 @@ QVariant ServerCountryModel::data(const QModelIndex& index, int role) const {
 
     case LocalizedNameRole: {
       const ServerCountry& country = m_countries.at(index.row());
-      return QVariant(
-          ServerI18N::translateCountryName(country.code(), country.name()));
+      return QVariant(ServerI18N::instance()->translateCountryName(
+          country.code(), country.name()));
     }
 
     case CodeRole:
@@ -306,8 +306,9 @@ bool sortCountryCallback(const ServerCountry& a, const ServerCountry& b,
                          Collator* collator) {
   Q_ASSERT(collator);
   return collator->compare(
-             ServerI18N::translateCountryName(a.code(), a.name()),
-             ServerI18N::translateCountryName(b.code(), b.name())) < 0;
+             ServerI18N::instance()->translateCountryName(a.code(), a.name()),
+             ServerI18N::instance()->translateCountryName(b.code(), b.name())) <
+         0;
 }
 
 }  // anonymous namespace

--- a/src/apps/vpn/models/serverdata.cpp
+++ b/src/apps/vpn/models/serverdata.cpp
@@ -163,35 +163,38 @@ bool ServerData::settingsChanged() {
 
 QString ServerData::localizedExitCityName() const {
   Q_ASSERT(m_initialized);
-  return ServerI18N::translateCityName(m_exitCountryCode, m_exitCityName);
+  return ServerI18N::instance()->translateCityName(m_exitCountryCode,
+                                                   m_exitCityName);
 }
 
 QString ServerData::localizedEntryCityName() const {
   Q_ASSERT(m_initialized);
-  return ServerI18N::translateCityName(m_entryCountryCode, m_entryCityName);
+  return ServerI18N::instance()->translateCityName(m_entryCountryCode,
+                                                   m_entryCityName);
 }
 
 QString ServerData::localizedPreviousExitCountryName() const {
   Q_ASSERT(m_initialized);
-  return ServerI18N::translateCityName(m_previousExitCountryCode,
-                                       m_previousExitCountryName);
+  return ServerI18N::instance()->translateCityName(m_previousExitCountryCode,
+                                                   m_previousExitCountryName);
 }
 
 QString ServerData::localizedPreviousExitCityName() const {
   Q_ASSERT(m_initialized);
-  return ServerI18N::translateCityName(m_previousExitCountryCode,
-                                       m_previousExitCityName);
+  return ServerI18N::instance()->translateCityName(m_previousExitCountryCode,
+                                                   m_previousExitCityName);
 }
 
 QString ServerData::localizedEntryCountryName() const {
   Q_ASSERT(m_initialized);
-  return ServerI18N::translateCountryName(m_entryCountryCode,
-                                          m_entryCountryName);
+  return ServerI18N::instance()->translateCountryName(m_entryCountryCode,
+                                                      m_entryCountryName);
 }
 
 QString ServerData::localizedExitCountryName() const {
   Q_ASSERT(m_initialized);
-  return ServerI18N::translateCountryName(m_exitCountryCode, m_exitCountryName);
+  return ServerI18N::instance()->translateCountryName(m_exitCountryCode,
+                                                      m_exitCountryName);
 }
 
 void ServerData::changeServer(const QString& countryCode,

--- a/src/apps/vpn/mozillavpn.cpp
+++ b/src/apps/vpn/mozillavpn.cpp
@@ -2096,7 +2096,8 @@ void MozillaVPN::registerInspectorCommands() {
             QJsonObject cityObj;
             cityObj["name"] = city.name();
             cityObj["localizedName"] =
-                ServerI18N::translateCityName(country.code(), city.name());
+                ServerI18N::instance()->translateCityName(country.code(),
+                                                          city.name());
             cityObj["code"] = city.code();
             cityArray.append(cityObj);
           }
@@ -2104,7 +2105,8 @@ void MozillaVPN::registerInspectorCommands() {
           QJsonObject countryObj;
           countryObj["name"] = country.name();
           countryObj["localizedName"] =
-              ServerI18N::translateCountryName(country.code(), country.name());
+              ServerI18N::instance()->translateCountryName(country.code(),
+                                                           country.name());
           countryObj["code"] = country.code();
           countryObj["cities"] = cityArray;
 

--- a/src/apps/vpn/serveri18n.h
+++ b/src/apps/vpn/serveri18n.h
@@ -5,15 +5,38 @@
 #ifndef SERVERI18N_H
 #define SERVERI18N_H
 
-#include <QString>
+#include <QHash>
+#include <QObject>
 
-class ServerI18N final {
+class ServerI18N final : public QObject {
  public:
-  static QString translateCountryName(const QString& countryCode,
-                                      const QString& countryName);
+  static ServerI18N* instance();
 
-  static QString translateCityName(const QString& countryCode,
-                                   const QString& cityName);
+  ~ServerI18N();
+
+  QString translateCountryName(const QString& countryCode,
+                               const QString& countryName);
+
+  QString translateCityName(const QString& countryCode,
+                            const QString& cityName);
+
+ private:
+  ServerI18N(QObject* parent);
+
+  void initialize();
+
+  QString translateItem(const QString& countryCode, const QString& cityName,
+                        const QString& fallback);
+
+  QString translateItemWithLanguage(const QString& languageCode,
+                                    const QString& countryCode,
+                                    const QString& cityName);
+
+  void addCity(const QString& countryCode, const QJsonValue& value);
+  void addCountry(const QJsonValue& value);
+
+ private:
+  QHash<QString, QString> m_items;
 };
 
 #endif  // SERVERI18N_H

--- a/src/shared/addons/addon.cpp
+++ b/src/shared/addons/addon.cpp
@@ -15,6 +15,7 @@
 #include "addonguide.h"
 #include "addoni18n.h"
 #include "addonmessage.h"
+#include "addonreplacer.h"
 #include "addontutorial.h"
 #include "conditionwatchers/addonconditionwatcherfeaturesenabled.h"
 #include "conditionwatchers/addonconditionwatchergroup.h"
@@ -372,6 +373,10 @@ Addon* Addon::create(QObject* parent, const QString& manifestFileName) {
 
   else if (type == "message") {
     addon = AddonMessage::create(parent, manifestFileName, id, name, obj);
+  }
+
+  else if (type == "replacer") {
+    addon = AddonReplacer::create(parent, manifestFileName, id, name, obj);
   }
 
   else {

--- a/src/shared/addons/addonreplacer.cpp
+++ b/src/shared/addons/addonreplacer.cpp
@@ -1,0 +1,154 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "addonreplacer.h"
+
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QJsonArray>
+#include <QJsonObject>
+#include <QQmlEngine>
+#include <QScopeGuard>
+
+#include "leakdetector.h"
+#include "logger.h"
+#include "qmlengineholder.h"
+#include "resourceloader.h"
+
+namespace {
+Logger logger("AddonReplacer");
+
+QUrl normalizeUrlScheme(const QUrl& url, const QString& response) {
+  // QT is a strange framework. Sometimes the files are loaded using 'qrc:'
+  // scheme, sometimes, just ':'. Let's normalize the final URL based on the
+  // incoming one.
+
+  if (url.scheme() == "qrc" && response.startsWith(':')) {
+    return QString("qrc%1").arg(response);
+  }
+  return response;
+}
+}  // namespace
+
+// static
+Addon* AddonReplacer::create(QObject* parent, const QString& manifestFileName,
+                             const QString& id, const QString& name,
+                             const QJsonObject& obj) {
+  QJsonObject replacerObj = obj["replacer"].toObject();
+
+  QJsonArray urls = replacerObj["urls"].toArray();
+  if (urls.isEmpty()) {
+    logger.warning() << "Empty URLs";
+    return nullptr;
+  }
+
+  AddonReplacer* replacer =
+      new AddonReplacer(parent, manifestFileName, id, name);
+  auto guard = qScopeGuard([&] { replacer->deleteLater(); });
+
+  QFileInfo manifestFileInfo(manifestFileName);
+  QDir addonPath = manifestFileInfo.dir();
+
+  for (const QJsonValue& urlValue : urls) {
+    QJsonObject urlObj = urlValue.toObject();
+
+    QString urlRequest = urlObj["request"].toString();
+    QString urlResponse = urlObj["response"].toString();
+    QString urlResponseFile(addonPath.filePath(urlResponse));
+
+    if (urlRequest.isEmpty() || urlResponse.isEmpty()) {
+      logger.warning() << "Invalid URL content";
+      return nullptr;
+    }
+
+    if (!urlRequest.startsWith("qrc:")) {
+      logger.warning() << "Invalid URL content (QRC scheme only)";
+      return nullptr;
+    }
+
+    QString type = urlObj["type"].toString();
+    if (type.isEmpty() || type == "file") {
+      if (!QFile::exists(urlResponseFile)) {
+        logger.warning() << "The addon does not contain the file `"
+                         << urlResponseFile << "' required for `" << urlRequest
+                         << "'";
+        return nullptr;
+      }
+
+      replacer->m_replaces.append({eUrlFile, urlRequest, urlResponseFile});
+    } else if (type == "directory") {
+      if (!QDir(urlResponseFile).exists()) {
+        logger.warning() << "The addon does not contain the directory `"
+                         << urlResponseFile << "' required for `" << urlRequest
+                         << "'";
+        return nullptr;
+      }
+
+      // To simplify the path comparison, let's add a final '/' in both
+      // request/response strings.
+
+      if (!urlRequest.endsWith('/')) {
+        urlRequest.append('/');
+      }
+
+      if (!urlResponseFile.endsWith('/')) {
+        urlResponseFile.append('/');
+      }
+
+      replacer->m_replaces.append({eUrlDirectory, urlRequest, urlResponseFile});
+    } else {
+      logger.warning() << "Invalid URL type:" << type;
+      return nullptr;
+    }
+  }
+
+  guard.dismiss();
+  return replacer;
+}
+
+AddonReplacer::AddonReplacer(QObject* parent, const QString& manifestFileName,
+                             const QString& id, const QString& name)
+    : Addon(parent, manifestFileName, id, name, "replacer") {
+  MZ_COUNT_CTOR(AddonReplacer);
+}
+
+AddonReplacer::~AddonReplacer() { MZ_COUNT_DTOR(AddonReplacer); }
+
+void AddonReplacer::enable() {
+  Addon::enable();
+  QmlEngineHolder::instance()->engine()->addUrlInterceptor(this);
+  ResourceLoader::instance()->addUrlInterceptor(this);
+}
+
+void AddonReplacer::disable() {
+  Addon::disable();
+  QmlEngineHolder::instance()->engine()->removeUrlInterceptor(this);
+  ResourceLoader::instance()->removeUrlInterceptor(this);
+}
+
+QUrl AddonReplacer::intercept(const QUrl& url,
+                              QQmlAbstractUrlInterceptor::DataType type) {
+  if (type != DataType::QmlFile) {
+    return url;
+  }
+
+  QString urlRequest = url.toString();
+
+  for (const Replace& replace : m_replaces) {
+    if (replace.m_type == eUrlFile) {
+      if (replace.m_request != urlRequest) continue;
+      return normalizeUrlScheme(url, replace.m_response);
+    }
+
+    Q_ASSERT(replace.m_type == eUrlDirectory);
+    if (!urlRequest.startsWith(replace.m_request)) continue;
+
+    QString newPath = urlRequest;
+    newPath.replace(0, replace.m_request.length(), replace.m_response);
+    return normalizeUrlScheme(url, newPath);
+  }
+
+  return url;
+}

--- a/src/shared/addons/addonreplacer.h
+++ b/src/shared/addons/addonreplacer.h
@@ -1,0 +1,53 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef ADDONREPLACER_H
+#define ADDONREPLACER_H
+
+#include <QMap>
+#include <QQmlAbstractUrlInterceptor>
+
+#include "addon.h"
+
+class QUrl;
+class QJsonObject;
+
+class AddonReplacer final : public Addon, public QQmlAbstractUrlInterceptor {
+  Q_OBJECT
+  Q_DISABLE_COPY_MOVE(AddonReplacer)
+
+ public:
+  static Addon* create(QObject* parent, const QString& manifestFileName,
+                       const QString& id, const QString& name,
+                       const QJsonObject& obj);
+
+  ~AddonReplacer();
+
+  // QQmlAbstractUrlInterceptor class
+  QUrl intercept(const QUrl& url,
+                 QQmlAbstractUrlInterceptor::DataType type) override;
+
+ private:
+  AddonReplacer(QObject* parent, const QString& manifestFileName,
+                const QString& id, const QString& name);
+
+  void enable() override;
+  void disable() override;
+
+ private:
+  enum UrlType {
+    eUrlFile,
+    eUrlDirectory,
+  };
+
+  struct Replace {
+    UrlType m_type;
+    QString m_request;
+    QString m_response;
+  };
+
+  QList<Replace> m_replaces;
+};
+
+#endif  // ADDONREPLACER_H

--- a/src/shared/fontloader.cpp
+++ b/src/shared/fontloader.cpp
@@ -8,6 +8,7 @@
 #include <QFontDatabase>
 
 #include "logger.h"
+#include "resourceloader.h"
 
 namespace {
 Logger logger("FontLoader");
@@ -15,7 +16,7 @@ Logger logger("FontLoader");
 
 // static
 void FontLoader::loadFonts() {
-  QDir dir(":/nebula/resources/fonts");
+  QDir dir(ResourceLoader::instance()->loadDir(":/nebula/resources/fonts"));
   QStringList files = dir.entryList();
   for (const QString& file : files) {
     logger.debug() << "Loading font:" << file;

--- a/src/shared/languagei18n.cpp
+++ b/src/shared/languagei18n.cpp
@@ -4,6 +4,7 @@
 
 #include "languagei18n.h"
 
+#include <QCoreApplication>
 #include <QFile>
 #include <QHash>
 #include <QJsonArray>
@@ -11,24 +12,66 @@
 #include <QJsonObject>
 
 #include "constants.h"
+#include "leakdetector.h"
 #include "localizer.h"
 #include "logger.h"
+#include "resourceloader.h"
 #include "settingsholder.h"
 
 namespace {
 Logger logger("LanguageI18N");
 
-bool s_initialized = false;
-
-QList<QString> s_languageList;
-QHash<QString, QString> s_translations;
-QHash<QString, QString> s_currencies;
-
 QString itemKey(const QString& translationCode, const QString& languageCode) {
   return QString("%1^%2").arg(translationCode, languageCode);
 }
 
-void addLanguage(const QJsonValue& value) {
+}  // namespace
+
+// static
+LanguageI18N* LanguageI18N::instance() {
+  static LanguageI18N* s_instance = nullptr;
+  if (!s_instance) {
+    s_instance = new LanguageI18N(qApp);
+    s_instance->initialize();
+  }
+
+  return s_instance;
+}
+
+LanguageI18N::LanguageI18N(QObject* parent) : QObject(parent) {
+  MZ_COUNT_CTOR(LanguageI18N);
+
+  connect(ResourceLoader::instance(), &ResourceLoader::cacheFlushNeeded, this,
+          [this]() {
+            m_languageList.clear();
+            m_translations.clear();
+            m_currencies.clear();
+            initialize();
+          });
+}
+
+LanguageI18N::~LanguageI18N() { MZ_COUNT_DTOR(LanguageI18N); }
+
+void LanguageI18N::initialize() {
+  QFile file(ResourceLoader::instance()->loadFile(":/i18n/languages.json"));
+  if (!file.open(QFile::ReadOnly | QFile::Text)) {
+    logger.error() << "Failed to open the languages.json";
+    return;
+  }
+
+  QJsonDocument json = QJsonDocument::fromJson(file.readAll());
+  if (!json.isArray()) {
+    logger.error() << "Invalid format (expected array)";
+    return;
+  }
+
+  QJsonArray array = json.array();
+  for (const QJsonValue& language : array) {
+    addLanguage(language);
+  }
+}
+
+void LanguageI18N::addLanguage(const QJsonValue& value) {
   if (!value.isObject()) {
     return;
   }
@@ -50,7 +93,7 @@ void addLanguage(const QJsonValue& value) {
   QJsonObject translationObj = translations.toObject();
   for (const QString& translationCode : translationObj.keys()) {
     QString translation(translationObj[translationCode].toString());
-    s_translations.insert(itemKey(languageCode, translationCode),
+    m_translations.insert(itemKey(languageCode, translationCode),
                           translationObj[translationCode].toString());
   }
 
@@ -62,58 +105,26 @@ void addLanguage(const QJsonValue& value) {
 
   QJsonObject currencyObj = currencies.toObject();
   for (const QString& currencyIso4217 : currencyObj.keys()) {
-    s_currencies.insert(itemKey(currencyIso4217, languageCode),
+    m_currencies.insert(itemKey(currencyIso4217, languageCode),
                         currencyObj[currencyIso4217].toString());
   }
 
-  s_languageList.append(languageCode);
+  m_languageList.append(languageCode);
 }
 
-void maybeInitialize() {
-  if (s_initialized) {
-    return;
-  }
-
-  s_initialized = true;
-
-  QFile file(":/i18n/languages.json");
-  if (!file.open(QFile::ReadOnly | QFile::Text)) {
-    logger.error() << "Failed to open the languages.json";
-    return;
-  }
-
-  QJsonDocument json = QJsonDocument::fromJson(file.readAll());
-  if (!json.isArray()) {
-    logger.error() << "Invalid format (expected array)";
-    return;
-  }
-
-  QJsonArray array = json.array();
-  for (const QJsonValue& language : array) {
-    addLanguage(language);
-  }
-}
-
-}  // namespace
-
-// static
 bool LanguageI18N::languageExists(const QString& languageCode) {
-  maybeInitialize();
-  return s_languageList.contains(languageCode);
+  return m_languageList.contains(languageCode);
 }
 
-// static
 QString LanguageI18N::translateLanguage(const QString& translationCode,
                                         const QString& languageCode) {
-  maybeInitialize();
-  return s_translations.value(itemKey(translationCode, languageCode));
+  return m_translations.value(itemKey(translationCode, languageCode));
 }
 
-// static
 int LanguageI18N::languageCompare(const QString& languageCodeA,
                                   const QString& languageCodeB) {
-  int a = s_languageList.indexOf(languageCodeA);
-  int b = s_languageList.indexOf(languageCodeB);
+  int a = m_languageList.indexOf(languageCodeA);
+  int b = m_languageList.indexOf(languageCodeB);
 
 #ifndef UNIT_TEST
   if (a < 0 || b < 0) {
@@ -139,9 +150,7 @@ int LanguageI18N::languageCompare(const QString& languageCodeA,
   return 1;
 }
 
-// static
 QString LanguageI18N::currencySymbolForLanguage(
     const QString& languageCode, const QString& currencyIso4217) {
-  maybeInitialize();
-  return s_currencies.value(itemKey(currencyIso4217, languageCode));
+  return m_currencies.value(itemKey(currencyIso4217, languageCode));
 }

--- a/src/shared/languagei18n.h
+++ b/src/shared/languagei18n.h
@@ -5,20 +5,43 @@
 #ifndef LANGUAGEI18N_H
 #define LANGUAGEI18N_H
 
+#include <QHash>
+#include <QList>
+#include <QObject>
 #include <QString>
 
-class LanguageI18N final {
+class QJsonValue;
+
+class LanguageI18N final : public QObject {
+  Q_OBJECT
+  Q_DISABLE_COPY_MOVE(LanguageI18N)
+
  public:
-  static bool languageExists(const QString& languageCode);
+  static LanguageI18N* instance();
 
-  static QString translateLanguage(const QString& translationCode,
-                                   const QString& languageCode);
+  ~LanguageI18N();
 
-  static QString currencySymbolForLanguage(const QString& languageCode,
-                                           const QString& currencyIso4217);
+  QString currencySymbolForLanguage(const QString& languageCode,
+                                    const QString& currencyIso4217);
 
-  static int languageCompare(const QString& languageCodeA,
-                             const QString& languageCodeB);
+  bool languageExists(const QString& languageCode);
+
+  QString translateLanguage(const QString& translationCode,
+                            const QString& languageCode);
+
+  int languageCompare(const QString& languageCodeA,
+                      const QString& languageCodeB);
+
+ private:
+  explicit LanguageI18N(QObject* parent);
+
+  void initialize();
+  void addLanguage(const QJsonValue& value);
+
+ private:
+  QList<QString> m_languageList;
+  QHash<QString, QString> m_translations;
+  QHash<QString, QString> m_currencies;
 };
 
 #endif  // LANGUAGEI18N_H

--- a/src/shared/localizer.cpp
+++ b/src/shared/localizer.cpp
@@ -20,6 +20,7 @@
 #include "languagei18n.h"
 #include "leakdetector.h"
 #include "logger.h"
+#include "resourceloader.h"
 #include "settingsholder.h"
 #include "telemetry/gleansample.h"
 
@@ -169,13 +170,24 @@ void Localizer::initialize() {
   connect(settingsHolder, &SettingsHolder::languageCodeChanged, this,
           &Localizer::settingsChanged);
   settingsChanged();
+
+  connect(ResourceLoader::instance(), &ResourceLoader::cacheFlushNeeded, this,
+          [this]() {
+            m_translationFallback.clear();
+            m_translationCompleteness.clear();
+            m_languages.clear();
+
+            loadLanguagesFromI18n();
+          });
 }
 
 void Localizer::loadLanguagesFromI18n() {
+  beginResetModel();
+
   m_translationCompleteness =
       loadTranslationCompleteness(":/i18n/translations.completeness");
 
-  QDir dir(":/i18n");
+  QDir dir(ResourceLoader::instance()->loadDir(":/i18n"));
   QStringList files = dir.entryList();
   for (const QString& file : files) {
     if (!file.startsWith(AppConstants::LOCALIZER_FILENAME_PREFIX) ||
@@ -213,8 +225,11 @@ void Localizer::loadLanguagesFromI18n() {
 
   std::sort(m_languages.begin(), m_languages.end(),
             [&](const Language& a, const Language& b) -> bool {
-              return LanguageI18N::languageCompare(a.m_code, b.m_code) < 0;
+              return LanguageI18N::instance()->languageCompare(a.m_code,
+                                                               b.m_code) < 0;
             });
+
+  endResetModel();
 }
 
 // static
@@ -365,7 +380,8 @@ bool Localizer::createTranslator(const QLocale& locale) {
 
 void Localizer::maybeLoadLanguageFallback(const QString& code) {
   if (m_translationFallback.isEmpty()) {
-    QFile file(":/i18n/translations_fallback.json");
+    QFile file(ResourceLoader::instance()->loadFile(
+        ":/i18n/translations_fallback.json"));
     Q_ASSERT(file.exists());
 
     if (!file.open(QIODevice::ReadOnly)) {
@@ -408,14 +424,14 @@ QString Localizer::nativeLanguageName(const QLocale& locale,
                                       const QString& code) {
 #ifndef UNIT_TEST
   if (!Constants::inProduction()) {
-    Q_ASSERT_X(LanguageI18N::languageExists(code), "localizer",
+    Q_ASSERT_X(LanguageI18N::instance()->languageExists(code), "localizer",
                "Languages are out of sync with the translations");
   }
 #endif
 
   // Let's see if we have the translation of this language in this language. We
   // can use it as native language name.
-  QString name = LanguageI18N::translateLanguage(code, code);
+  QString name = LanguageI18N::instance()->translateLanguage(code, code);
   if (!name.isEmpty()) {
     return toUpper(locale, name);
   }
@@ -455,8 +471,8 @@ QString Localizer::localizedLanguageName(const Language& language) const {
     translationCode = Localizer::instance()->languageCodeOrSystem();
   }
 
-  QString value =
-      LanguageI18N::translateLanguage(translationCode, language.m_code);
+  QString value = LanguageI18N::instance()->translateLanguage(translationCode,
+                                                              language.m_code);
   if (!value.isEmpty()) {
     return toUpper(QLocale(translationCode), value);
   }
@@ -465,7 +481,8 @@ QString Localizer::localizedLanguageName(const Language& language) const {
   if (translationCode.contains('_')) {
     QStringList parts = translationCode.split('_');
 
-    QString value = LanguageI18N::translateLanguage(parts[0], language.m_code);
+    QString value =
+        LanguageI18N::instance()->translateLanguage(parts[0], language.m_code);
     if (!value.isEmpty()) {
       return toUpper(QLocale(translationCode), value);
     }
@@ -538,8 +555,8 @@ QString Localizer::localizeCurrency(double value,
     return locale.toCurrencyString(value);
   }
 
-  QString symbol =
-      LanguageI18N::currencySymbolForLanguage(languageCode, currencyIso4217);
+  QString symbol = LanguageI18N::instance()->currencySymbolForLanguage(
+      languageCode, currencyIso4217);
   if (!symbol.isEmpty()) {
     return locale.toCurrencyString(value, symbol);
   }

--- a/src/shared/resourceloader.cpp
+++ b/src/shared/resourceloader.cpp
@@ -1,0 +1,77 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "resourceloader.h"
+
+#include <QCoreApplication>
+#include <QQmlAbstractUrlInterceptor>
+#include <QUrl>
+
+#include "leakdetector.h"
+
+// static
+ResourceLoader* ResourceLoader::instance() {
+  static ResourceLoader* s_instance = nullptr;
+  if (!s_instance) {
+    s_instance = new ResourceLoader(qApp);
+  }
+  return s_instance;
+}
+
+ResourceLoader::ResourceLoader(QObject* parent) : QObject(parent) {
+  MZ_COUNT_CTOR(ResourceLoader);
+}
+
+ResourceLoader::~ResourceLoader() { MZ_COUNT_DTOR(ResourceLoader); }
+
+QString ResourceLoader::loadFile(const QString& fileName) {
+  Q_ASSERT(fileName[0] == ':');
+
+  QUrl url(QString("qrc%1").arg(fileName));
+
+  for (QQmlAbstractUrlInterceptor* interceptor : m_interceptors) {
+    QUrl newUrl =
+        interceptor->intercept(url, QQmlAbstractUrlInterceptor::QmlFile);
+    if (newUrl != url) {
+      return QString(":%1").arg(newUrl.path());
+    }
+  }
+
+  return fileName;
+}
+
+QString ResourceLoader::loadDir(const QString& fileName) {
+  Q_ASSERT(fileName[0] == ':');
+
+  QString dirName(QString("qrc%1").arg(fileName));
+  if (!dirName.endsWith('/')) {
+    dirName.append('/');
+  }
+
+  QUrl url(dirName);
+
+  for (QQmlAbstractUrlInterceptor* interceptor : m_interceptors) {
+    QUrl newUrl =
+        interceptor->intercept(url, QQmlAbstractUrlInterceptor::QmlFile);
+    if (newUrl != url) {
+      return QString(":%1").arg(newUrl.path());
+    }
+  }
+
+  return fileName;
+}
+
+void ResourceLoader::addUrlInterceptor(
+    QQmlAbstractUrlInterceptor* interceptor) {
+  Q_ASSERT(!m_interceptors.contains(interceptor));
+  m_interceptors.append(interceptor);
+  emit cacheFlushNeeded();
+}
+
+void ResourceLoader::removeUrlInterceptor(
+    QQmlAbstractUrlInterceptor* interceptor) {
+  Q_ASSERT(m_interceptors.contains(interceptor));
+  m_interceptors.removeOne(interceptor);
+  emit cacheFlushNeeded();
+}

--- a/src/shared/resourceloader.h
+++ b/src/shared/resourceloader.h
@@ -1,0 +1,52 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef RESOURCELOADER_H
+#define RESOURCELOADER_H
+
+#include <QList>
+#include <QObject>
+
+class QQmlAbstractUrlInterceptor;
+
+class ResourceLoader final : public QObject {
+  Q_OBJECT
+  Q_DISABLE_COPY_MOVE(ResourceLoader)
+
+ public:
+  static ResourceLoader* instance();
+
+  ~ResourceLoader();
+
+  /**
+   * @brief returns the path of the file the caller wants to load.
+   */
+  QString loadFile(const QString& fileName);
+
+  /**
+   * @brief returns the path of the directory the caller wants to load.
+   */
+  QString loadDir(const QString& dirName);
+
+  /**
+   * @brief add a new URL interceptor. Ownership does not change.
+   */
+  void addUrlInterceptor(QQmlAbstractUrlInterceptor* interceptor);
+
+  /**
+   * @brief remove an existing URL interceptor. Ownership does not change.
+   */
+  void removeUrlInterceptor(QQmlAbstractUrlInterceptor* interceptor);
+
+ private:
+  ResourceLoader(QObject* parent);
+
+ signals:
+  void cacheFlushNeeded();
+
+ private:
+  QList<QQmlAbstractUrlInterceptor*> m_interceptors;
+};
+
+#endif  // RESOURCELOADER_H

--- a/src/shared/sources.cmake
+++ b/src/shared/sources.cmake
@@ -35,6 +35,8 @@ target_sources(shared-sources INTERFACE
     ${CMAKE_CURRENT_SOURCE_DIR}/shared/addons/addonproperty.h
     ${CMAKE_CURRENT_SOURCE_DIR}/shared/addons/addonpropertylist.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/shared/addons/addonpropertylist.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/shared/addons/addonreplacer.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/shared/addons/addonreplacer.h
     ${CMAKE_CURRENT_SOURCE_DIR}/shared/addons/addontutorial.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/shared/addons/addontutorial.h
     ${CMAKE_CURRENT_SOURCE_DIR}/shared/addons/conditionwatchers/addonconditionwatcher.cpp
@@ -170,6 +172,8 @@ target_sources(shared-sources INTERFACE
     ${CMAKE_CURRENT_SOURCE_DIR}/shared/qmlengineholder.h
     ${CMAKE_CURRENT_SOURCE_DIR}/shared/qmlpath.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/shared/qmlpath.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/shared/resourceloader.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/shared/resourceloader.h
     ${CMAKE_CURRENT_SOURCE_DIR}/shared/rfc/rfc1112.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/shared/rfc/rfc1112.h
     ${CMAKE_CURRENT_SOURCE_DIR}/shared/rfc/rfc1918.cpp

--- a/src/shared/sources.pri
+++ b/src/shared/sources.pri
@@ -10,6 +10,7 @@ SOURCES += \
         $$PWD/addons/addonmessage.cpp \
         $$PWD/addons/addonproperty.cpp \
         $$PWD/addons/addonpropertylist.cpp \
+        $$PWD/addons/addonreplacer.cpp \
         $$PWD/addons/addontutorial.cpp \
         $$PWD/addons/conditionwatchers/addonconditionwatcher.cpp \
         $$PWD/addons/conditionwatchers/addonconditionwatcherfeaturesenabled.cpp \
@@ -78,6 +79,7 @@ SOURCES += \
         $$PWD/networkrequest.cpp \
         $$PWD/qmlengineholder.cpp \
         $$PWD/qmlpath.cpp \
+        $$PWD/resourceloader.cpp \
         $$PWD/rfc/rfc1112.cpp \
         $$PWD/rfc/rfc1918.cpp \
         $$PWD/rfc/rfc4193.cpp \
@@ -115,6 +117,7 @@ HEADERS += \
         $$PWD/addons/addonmessage.h \
         $$PWD/addons/addonproperty.h \
         $$PWD/addons/addonpropertylist.h \
+        $$PWD/addons/addonreplacer.h \
         $$PWD/addons/addontutorial.h \
         $$PWD/addons/conditionwatchers/addonconditionwatcher.h \
         $$PWD/addons/conditionwatchers/addonconditionwatcherfeaturesenabled.h \
@@ -182,6 +185,7 @@ HEADERS += \
         $$PWD/networkrequest.h \
         $$PWD/qmlengineholder.h \
         $$PWD/qmlpath.h \
+        $$PWD/resourceloader.h \
         $$PWD/rfc/rfc1112.h \
         $$PWD/rfc/rfc1918.h \
         $$PWD/rfc/rfc4193.h \

--- a/tests/functional/addons/07_replacer/replacer_01/fs/home.qml
+++ b/tests/functional/addons/07_replacer/replacer_01/fs/home.qml
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import components 0.1
+
+MZLoader {
+    objectName: "replacedHome"
+    headlineText: MZI18n.InAppAuthWaitingForSignIn
+}

--- a/tests/functional/addons/07_replacer/replacer_01/manifest.json
+++ b/tests/functional/addons/07_replacer/replacer_01/manifest.json
@@ -1,0 +1,15 @@
+{
+  "api_version": "0.1",
+  "id": "replacer_01",
+  "name": "Replacer test",
+  "type": "replacer",
+  "conditions": {
+    "locales": [ "en" ],
+    "translation_threshold": 0
+  },
+  "replacer": {
+    "urls": [
+      { "request": "qrc:/ui/screens/home/ViewHome.qml", "response": "fs/home.qml" }
+    ]
+  }
+}

--- a/tests/functional/addons/07_replacer/replacer_02/fs/servers.json
+++ b/tests/functional/addons/07_replacer/replacer_02/fs/servers.json
@@ -1,0 +1,57 @@
+[
+ {
+  "countryCode": "au",
+  "languages": {
+   "en": "4ustr4l14"
+  },
+  "cities": [
+   {
+    "city": "Melbourne",
+    "languages": {
+     "en": "М4lb0urn3"
+    },
+    "wikiDataID": "Q3141"
+   },
+   {
+    "city": "Sydney",
+    "languages": {
+     "en": "S1dn3y"
+    },
+    "wikiDataID": "Q3130"
+   }
+  ],
+  "wikiDataID": "Q408"
+ },
+ {
+  "countryCode": "at",
+  "languages": {
+   "en": "4ustr14"
+  },
+  "cities": [
+   {
+    "city": "Vienna",
+    "languages": {
+     "en": "V13nn4"
+    },
+    "wikiDataID": "Q1741"
+   }
+  ],
+  "wikiDataID": "Q40"
+ },
+ {
+  "countryCode": "be",
+  "languages": {
+   "en": "B3lg1um"
+  },
+  "cities": [
+   {
+    "city": "Brussels",
+    "languages": {
+     "en": "C1ty 0f Bruss3ls"
+    },
+    "wikiDataID": "Q239"
+   }
+  ],
+  "wikiDataID": "Q31"
+ }
+]

--- a/tests/functional/addons/07_replacer/replacer_02/manifest.json
+++ b/tests/functional/addons/07_replacer/replacer_02/manifest.json
@@ -1,0 +1,14 @@
+{
+  "api_version": "0.1",
+  "id": "replacer_02",
+  "name": "Replacer test",
+  "type": "replacer",
+  "conditions": {
+    "translation_threshold": 0
+  },
+  "replacer": {
+    "urls": [
+      { "request": "qrc:/i18n/servers.json", "response": "fs/servers.json" }
+    ]
+  }
+}

--- a/tests/functional/testReplacer.js
+++ b/tests/functional/testReplacer.js
@@ -1,0 +1,68 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const assert = require('assert');
+const vpn = require('./helper.js');
+const queries = require('./queries.js');
+
+describe('Addon content replacer', function() {
+  this.timeout(60000);
+
+  describe('Addon replacer', function() {
+    beforeEach(async () => {
+      await vpn.resetAddons('07_replacer');
+    });
+
+    it('Replace the home', async () => {
+      await vpn.authenticateInApp(true, false);
+
+      await vpn.waitForQuery(queries.screenTelemetry.BUTTON.visible());
+      await vpn.clickOnQuery(queries.screenTelemetry.BUTTON.visible());
+      await vpn.waitForQuery('//replacedHome{visible=true}');
+    });
+
+    it('Replace the country/city names', async () => {
+      // In this way we disable the 'home-replacement' addon.
+      await vpn.setSetting('languageCode', 'it');
+      await vpn.authenticateInApp(true, true);
+
+      await vpn.waitForQueryAndClick(
+          queries.screenHome.SERVER_LIST_BUTTON.visible());
+      await vpn.waitForQuery(queries.screenHome.STACKVIEW.ready());
+      await vpn.waitForQueryAndClick(
+          queries.screenHome.serverListView.ALL_SERVERS_TAB.visible());
+
+      const servers = await vpn.servers();
+
+      for (let server of servers) {
+        const countryId =
+            queries.screenHome.serverListView.generateCountryId(server.code);
+        await vpn.waitForQuery(countryId.visible());
+
+        await vpn.scrollToQuery(
+            queries.screenHome.serverListView.COUNTRY_VIEW, countryId);
+
+        if (await vpn.getQueryProperty(countryId, 'cityListVisible') ===
+            'false') {
+          await vpn.clickOnQuery(countryId);
+        }
+
+        for (let city of server.cities) {
+          const cityId = queries.screenHome.serverListView.generateCityId(
+              countryId, city.name);
+          const cityName =
+              await vpn.getQueryProperty(cityId, 'radioButtonLabelText');
+          assert(
+              cityName.length > 0 && !cityName.includes('a') &&
+              !cityName.includes('A') && !cityName.includes('e') &&
+              !cityName.includes('E') && !cityName.includes('i') &&
+              !cityName.includes('I') && !cityName.includes('o') &&
+              !cityName.includes('O'))
+        }
+      }
+
+      await vpn.setSetting('languageCode', '');
+    });
+  });
+});

--- a/tests/qml/CMakeLists.txt
+++ b/tests/qml/CMakeLists.txt
@@ -92,6 +92,8 @@ target_sources(qml_tests PRIVATE
     ${MZ_SOURCE_DIR}/shared/addons/addonproperty.h
     ${MZ_SOURCE_DIR}/shared/addons/addonpropertylist.cpp
     ${MZ_SOURCE_DIR}/shared/addons/addonpropertylist.h
+    ${MZ_SOURCE_DIR}/shared/addons/addonreplacer.cpp
+    ${MZ_SOURCE_DIR}/shared/addons/addonreplacer.h
     ${MZ_SOURCE_DIR}/shared/addons/addontutorial.cpp
     ${MZ_SOURCE_DIR}/shared/addons/addontutorial.h
     ${MZ_SOURCE_DIR}/shared/addons/conditionwatchers/addonconditionwatcher.cpp
@@ -216,6 +218,8 @@ target_sources(qml_tests PRIVATE
     ${MZ_SOURCE_DIR}/shared/qmlengineholder.h
     ${MZ_SOURCE_DIR}/shared/qmlpath.cpp
     ${MZ_SOURCE_DIR}/shared/qmlpath.h
+    ${MZ_SOURCE_DIR}/shared/resourceloader.cpp
+    ${MZ_SOURCE_DIR}/shared/resourceloader.h
     ${MZ_SOURCE_DIR}/shared/rfc/rfc1918.cpp
     ${MZ_SOURCE_DIR}/shared/rfc/rfc1918.h
     ${MZ_SOURCE_DIR}/shared/rfc/rfc4193.cpp

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -137,6 +137,8 @@ target_sources(unit_tests PRIVATE
     ${MZ_SOURCE_DIR}/shared/addons/addonproperty.h
     ${MZ_SOURCE_DIR}/shared/addons/addonpropertylist.cpp
     ${MZ_SOURCE_DIR}/shared/addons/addonpropertylist.h
+    ${MZ_SOURCE_DIR}/shared/addons/addonreplacer.cpp
+    ${MZ_SOURCE_DIR}/shared/addons/addonreplacer.h
     ${MZ_SOURCE_DIR}/shared/addons/addontutorial.cpp
     ${MZ_SOURCE_DIR}/shared/addons/addontutorial.h
     ${MZ_SOURCE_DIR}/shared/addons/conditionwatchers/addonconditionwatcher.cpp
@@ -260,6 +262,8 @@ target_sources(unit_tests PRIVATE
     ${MZ_SOURCE_DIR}/shared/qmlengineholder.cpp
     ${MZ_SOURCE_DIR}/shared/qmlengineholder.h
     ${MZ_SOURCE_DIR}/shared/qmlpath.h
+    ${MZ_SOURCE_DIR}/shared/resourceloader.cpp
+    ${MZ_SOURCE_DIR}/shared/resourceloader.h
     ${MZ_SOURCE_DIR}/shared/rfc/rfc1918.cpp
     ${MZ_SOURCE_DIR}/shared/rfc/rfc1918.h
     ${MZ_SOURCE_DIR}/shared/rfc/rfc4193.cpp

--- a/tests/unit/testserveri18n.cpp
+++ b/tests/unit/testserveri18n.cpp
@@ -13,21 +13,25 @@ void TestServerI18n::basic() {
   Localizer l;
 
   // Non existing countries/cities
-  QCOMPARE(ServerI18N::translateCountryName("FOO", "FOO"), "FOO");
-  QCOMPARE(ServerI18N::translateCityName("FOO", "FOO"), "FOO");
-  QCOMPARE(ServerI18N::translateCityName("au", "FOO"), "FOO");
+  QCOMPARE(ServerI18N::instance()->translateCountryName("FOO", "FOO"), "FOO");
+  QCOMPARE(ServerI18N::instance()->translateCityName("FOO", "FOO"), "FOO");
+  QCOMPARE(ServerI18N::instance()->translateCityName("au", "FOO"), "FOO");
 
   // Existing language
   settingsHolder.setLanguageCode("sk");
-  QCOMPARE(ServerI18N::translateCountryName("au", "FOO"), "au_SK");
-  QCOMPARE(ServerI18N::translateCityName("au", "Melbourne"), "Melbourne_SK");
-  QCOMPARE(ServerI18N::translateCityName("au", "Sydney"), "Sydney_SK");
+  QCOMPARE(ServerI18N::instance()->translateCountryName("au", "FOO"), "au_SK");
+  QCOMPARE(ServerI18N::instance()->translateCityName("au", "Melbourne"),
+           "Melbourne_SK");
+  QCOMPARE(ServerI18N::instance()->translateCityName("au", "Sydney"),
+           "Sydney_SK");
 
   // Non-existing language with fallback to en
   settingsHolder.setLanguageCode("fr");
-  QCOMPARE(ServerI18N::translateCountryName("au", "FOO"), "au_EN");
-  QCOMPARE(ServerI18N::translateCityName("au", "Melbourne"), "Melbourne");
-  QCOMPARE(ServerI18N::translateCityName("au", "Sydney"), "Sydney_EN");
+  QCOMPARE(ServerI18N::instance()->translateCountryName("au", "FOO"), "au_EN");
+  QCOMPARE(ServerI18N::instance()->translateCityName("au", "Melbourne"),
+           "Melbourne");
+  QCOMPARE(ServerI18N::instance()->translateCityName("au", "Sydney"),
+           "Sydney_EN");
 }
 
 static TestServerI18n s_testServerI18n;


### PR DESCRIPTION
This PR introduces a new addon type: "Replacer". This addon is able to intercept the loading of QRC resources and replace them with something included in its QRC storage. For instance, a manifest like this will replace the home view with the `fs/home.qml` file:

```
{
  ...
  "replacer": {
    "urls": [
      { "request": "qrc:/ui/screens/home/ViewHome.qml", "response": "fs/home.qml" }
    ]
  ...
}
```

But we can also replace/remove/add languages and city/country names. See the functional and unit tests.