### PR TITLE
VPN-4449: Allow connection scoring without latency

### DIFF
--- a/src/apps/vpn/models/servercity.cpp
+++ b/src/apps/vpn/models/servercity.cpp
@@ -139,11 +139,10 @@ int ServerCity::connectionScore() const {
     return score;
   }
 
-  // If there is no latency data, then we haven't actually measured anything
-  // and have no connectivity signals to report.
+  // If there is no latency data (zero), then we haven't measured anything yet.
   unsigned int cityLatencyMsec = latency();
   if (cityLatencyMsec == 0) {
-    return ServerLatency::NoData;
+    return score;
   }
 
   // Increase the score if the location has better than average latency.


### PR DESCRIPTION
## Description
In 2.15 we replaced the initial distance-based server selection with the recommended-server algorithm. This algorithm has a clause wherein a server with no reported latency is reported with a score of zero, which overrides the preference given to locations within the user's originating country. To try and restore this preferential treatment of the user's country, let's try showing the connection score even in the absence of latency data.

## Reference
Github issue #6469 ([VPN-4449](https://mozilla-hub.atlassian.net/browse/VPN-4449))

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-4449]: https://mozilla-hub.atlassian.net/browse/VPN-4449?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ