### PR TITLE
VPN-3368 / VPN-4481 / VPN-4482 / VPN-3869 - "Getting started" tutorial improvements

### DIFF
--- a/addons/tutorial_01_get_started/condition.js
+++ b/addons/tutorial_01_get_started/condition.js
@@ -1,4 +1,12 @@
 (function(api, condition) {
+    api.connectSignal(api.featureList.get('recommendedServers'), 'supportedChanged', () => {
+        if(!api.featureList.get('recommendedServers').isSupported) {
+            condition.enable()
+            return
+        }
+        condition.disable()
+      });
+
     if(!api.featureList.get('recommendedServers').isSupported) {
         condition.enable()
         return

--- a/addons/tutorial_01_get_started/condition.js
+++ b/addons/tutorial_01_get_started/condition.js
@@ -1,0 +1,7 @@
+(function(api, condition) {
+    if(!api.featureList.get('recommendedServers').isSupported) {
+        condition.enable()
+        return
+    }
+    condition.disable()
+  })

--- a/addons/tutorial_01_get_started/manifest.json
+++ b/addons/tutorial_01_get_started/manifest.json
@@ -38,7 +38,7 @@
       {
         "id": "countryAU",
         "element": "serverCountryList/serverCountry-au",
-        "query": "//serverCountryList/{className=VPNServerCountry}{hasAvailableCities=true}[0]{visible=true}",
+        "query": "//serverCountryList/{hasAvailableCities=true}[0]{visible=true}",
         "tooltip": "Select a different country",
         "before": [{
           "op": "property_set",
@@ -50,19 +50,19 @@
         "next": {
           "op": "signal",
           "qml_emitter": "serverCountryList/serverCountry-au",
-          "query_emitter": "//serverCountryList/{className=VPNServerCountry}{hasAvailableCities=true}[0]{visible=true}",
+          "query_emitter": "//serverCountryList/{hasAvailableCities=true}[0]{visible=true}",
           "signal": "cityListVisibleChanged"
         }
       },
       {
         "id": "cityAU",
         "element": "serverCountryList/serverCountry-au/serverCityList/serverCity-Melbourne/radioIndicator",
-        "query": "//serverCountryList/{className=VPNServerCountry}{hasAvailableCities=true}[0]//serverCityList/{className=VPNRadioDelegate}{isAvailable=true}[0]{visible=true}",
+        "query": "//serverCountryList/{hasAvailableCities=true}[0]//serverCityList/{isAvailable=true}[0]{visible=true}",
         "tooltip": "Select a different server location",
         "next": {
           "op": "signal",
           "qml_emitter": "serverCountryList/serverCountry-au/serverCityList/serverCity-Melbourne/radioIndicator",
-          "query_emitter": "//serverCountryList/{className=VPNServerCountry}{hasAvailableCities=true}[0]//serverCityList/{className=VPNRadioDelegate}{isAvailable=true}[0]{visible=true}",
+          "query_emitter": "//serverCountryList/{hasAvailableCities=true}[0]//serverCityList/{isAvailable=true}[0]{visible=true}",
           "signal": "visibleChanged"
         }
       },

--- a/addons/tutorial_01_get_started/manifest.json
+++ b/addons/tutorial_01_get_started/manifest.json
@@ -4,7 +4,7 @@
   "name": "Tutorial: get started",
   "type": "tutorial",
   "conditions": {
-    "max_client_version": "2.14.9"  
+    "javascript": "condition.js"
   },
   "tutorial": {
     "id": "01_get_started",

--- a/addons/tutorial_01_get_started_recommended_locations/isRecommendedSelected.js
+++ b/addons/tutorial_01_get_started_recommended_locations/isRecommendedSelected.js
@@ -1,0 +1,15 @@
+(function(api, condition) {
+    api.connectSignal(api.settings, 'recommendedServerSelectedChanged', () => {
+        if(api.settings.recommendedServerSelected === false) {
+            condition.enable()
+            return
+        }
+        condition.disable()
+      });
+    
+    if(api.settings.recommendedServerSelected === false) {
+        condition.enable()
+        return
+    }
+    condition.disable()
+  })

--- a/addons/tutorial_01_get_started_recommended_locations/manifest.json
+++ b/addons/tutorial_01_get_started_recommended_locations/manifest.json
@@ -4,7 +4,6 @@
   "name": "Tutorial: get started recommended locations",
   "type": "tutorial",
   "conditions": {
-    "min_client_version": "2.15.0",
     "enabled_features": ["recommendedServers"]
   },
   "tutorial": {

--- a/addons/tutorial_01_get_started_recommended_locations/manifest.json
+++ b/addons/tutorial_01_get_started_recommended_locations/manifest.json
@@ -34,6 +34,19 @@
         }
       },
       {
+        "id": "recommendedTab",
+        "query": "//tabRecommendedServers",
+        "tooltip": "Select the “Recommended” tab",
+        "conditions": {
+           "javascript": "isRecommendedSelected.js"
+        },
+        "next": {
+          "op": "signal",
+          "query_emitter": "//tabRecommendedServers",
+          "signal": "clicked"
+        }
+      },
+      {
         "id": "firstCity",
         "query": "//serverListRecommended/{isAvailable=true}[0]",
         "tooltip": "Select the top recommended location",

--- a/addons/tutorial_03_multi_hop/manifest.json
+++ b/addons/tutorial_03_multi_hop/manifest.json
@@ -56,7 +56,7 @@
       },
       {
         "id": "s4",
-        "query": "//serverCountryList/{className=VPNServerCountry}{hasAvailableCities=true}[0]//serverCityList/{className=VPNRadioDelegate}{isAvailable=true}[0]{visible=true}",
+        "query": "//serverCountryList/{hasAvailableCities=true}[0]//serverCityList/{isAvailable=true}[0]{visible=true}",
         "tooltip": "Select a new exit location",
         "before": [{
           "op": "property_set",
@@ -65,13 +65,13 @@
           "value": 0
         },{
           "op": "property_set",
-          "query": "//serverCountryList/{className=VPNServerCountry}{hasAvailableCities=true}[0]{visible=true}",
+          "query": "//serverCountryList/{hasAvailableCities=true}[0]{visible=true}",
           "property": "cityListVisible",
           "value": true
         }],
         "next": {
           "op": "signal",
-          "query_emitter": "//serverCountryList/{className=VPNServerCountry}{hasAvailableCities=true}[0]//serverCityList/{className=VPNRadioDelegate}{isAvailable=true}[0]{visible=true}",
+          "query_emitter": "//serverCountryList/{hasAvailableCities=true}[0]//serverCityList/{isAvailable=true}[0]{visible=true}",
           "signal": "visibleChanged"
         }
       },

--- a/nebula/ui/components/MZSegmentedToggle.qml
+++ b/nebula/ui/components/MZSegmentedToggle.qml
@@ -112,7 +112,7 @@ Rectangle {
                 Rectangle {
                     anchors.fill: parent
                     border.width: MZTheme.theme.focusBorderWidth
-                    border.color: "black"
+                    border.color: MZTheme.theme.fontColor
                     color: MZTheme.theme.transparent
                     visible: MZTutorial.playing && parent.focus
                     radius: root.radius

--- a/nebula/ui/components/MZTabNavigation.qml
+++ b/nebula/ui/components/MZTabNavigation.qml
@@ -59,7 +59,7 @@ Item {
                         anchors.right: parent.right
                         anchors.bottom: parent.bottom
                         color: MZTheme.colors.purple70
-                        opacity: btn.activeFocus ? 1 : 0
+                        opacity: btn.checked ? 1 : 0
                         Behavior on opacity {
                             PropertyAnimation {
                                 duration: 100
@@ -73,7 +73,17 @@ Item {
                     elide: Qt.ElideRight
                     horizontalAlignment: Text.AlignHCenter
                     verticalAlignment: Text.AlignVCenter
-                    color: btn.checked || btn.activeFocus ? MZTheme.colors.purple70 : btn.hovered ? MZTheme.colors.grey50 : MZTheme.colors.grey40
+                    color: btn.checked ? MZTheme.colors.purple70 : btn.hovered || btn.activeFocus ? MZTheme.colors.grey50 : MZTheme.colors.grey40
+
+                    Rectangle {
+                        anchors.fill: parent
+                        anchors.margins: 2
+                        border.width: MZTheme.theme.focusBorderWidth
+                        border.color: MZTheme.theme.fontColor
+                        color: MZTheme.theme.transparent
+                        visible: MZTutorial.playing && btn.activeFocus
+                        radius: 4
+                    }
 
                     Behavior on color {
                         PropertyAnimation {

--- a/nebula/ui/components/MZTutorialPopups.qml
+++ b/nebula/ui/components/MZTutorialPopups.qml
@@ -42,15 +42,21 @@ Item {
     anchors.fill: parent
     visible: tutorialTooltip.visible || tutorialPopup.opened
 
-    onTargetElementChanged: tooltipRepositionTimer.start()
+    onTargetElementChanged: {
+        if(targetElement && MZTutorial.playing) {
+            tutorialTooltip.close()
+            pauseTimer.start()
+        }
+    }
 
-    //Bandaid fix to position *ALL* tutorial tooltips in the correct position
+
     Timer {
-        id: tooltipRepositionTimer
-        interval: 1
+        id: pauseTimer
+        interval: 100
         onTriggered: {
             tutorialTooltip.repositionTooltip()
             notch.repositionNotch()
+            tutorialTooltip.open()
         }
     }
 
@@ -296,7 +302,6 @@ Item {
         function onTooltipNeeded(text, targetEl) {
             root.targetElement = targetEl;
             tutorialTooltip.tooltipText = text;
-            tutorialTooltip.open();
         }
 
         function onTutorialCompleted(tutorial) {

--- a/nebula/ui/components/MZTutorialPopups.qml
+++ b/nebula/ui/components/MZTutorialPopups.qml
@@ -49,7 +49,7 @@ Item {
         }
     }
 
-
+    //Adds a delay between tooltip popups in tutorials
     Timer {
         id: pauseTimer
         interval: 300

--- a/nebula/ui/components/MZTutorialPopups.qml
+++ b/nebula/ui/components/MZTutorialPopups.qml
@@ -350,7 +350,7 @@ Item {
                 return
 
             if (!targetElement.activeFocus && (!targetElement.parent || !targetElement.parent.activeFocus) && !leaveTutorialBtn.activeFocus && !tutorialPopup.opened) {
-                tutorialTooltip.forceActiveFocus();
+                leaveTutorialBtn.forceActiveFocus();
             }
         }
     }

--- a/nebula/ui/components/MZTutorialPopups.qml
+++ b/nebula/ui/components/MZTutorialPopups.qml
@@ -52,7 +52,7 @@ Item {
 
     Timer {
         id: pauseTimer
-        interval: 100
+        interval: 300
         onTriggered: {
             tutorialTooltip.repositionTooltip()
             notch.repositionNotch()


### PR DESCRIPTION
## Description

- Improvements to both the old and new "Getting started" tutorials, including:
  - Replace `min_client_version` and `max_client_version` conditions with a feature check for `recommendedServers`
    - This ensures that we always have a "Getting started" tutorial to show (but should only happen in the event that the "Recommended Servers" feature flag is turned off in version 2.15+)
- Close and re-open tutorial tooltips with a small delay
- Fix old "Getting started" tutorial for 2.15+ 
  - As mentioned above, we most likely won't see the old "Getting started" tutorial on 2.15+, but at least it works if we do
- Add an extra step to the new "Getting started" tutorial to have the user select the "Recommended" tab for when the user's preferences is set to the "All" tab

## Reference

[VPN-3368: Implement the new "Get Started" Tutorial](https://mozilla-hub.atlassian.net/browse/VPN-3368)
[VPN-4481: Users who have never selected the “All” tab are not able to finalize the “Getting started with VPN” tutorial](https://mozilla-hub.atlassian.net/browse/VPN-4481)
[VPN-4482: Users are not able to finalize the “Using multi-hop VPN” / “Getting started with VPN” tutorials](https://mozilla-hub.atlassian.net/browse/VPN-4482)
[VPN-3869: Make tooltips display with a slight delay](https://mozilla-hub.atlassian.net/browse/VPN-3869)
