### PR TITLE
VPN-2542 - Disable sub expiring addon

### DIFF
--- a/addons/message_subscription_expiring/manifest.json
+++ b/addons/message_subscription_expiring/manifest.json
@@ -5,7 +5,7 @@
   "type": "message",
   "conditions": {
     "javascript": "isExpiring.js",
-    "min_client_version": "2.15.0"
+    "min_client_version": "100.15.0"
   },
   "message": {
     "id": "message_subscription_expiring",


### PR DESCRIPTION
This addon has a bug as described by QA on the ticket. Disabling it -- in a hacky way, we should just have a `enabled: false` field on the manifest. 
