### PR TITLE
VPN-4462: Use tarball instead of zip sources for MacOS/Qt compilation

### DIFF
--- a/taskcluster/scripts/toolchain/compile_qt_6_mac.sh
+++ b/taskcluster/scripts/toolchain/compile_qt_6_mac.sh
@@ -16,8 +16,8 @@ brew install cmake
 brew install ninja
 
 echo "Download QT $QT_VERSION"
-curl -o qt.zip -L https://download.qt.io/archive/qt/$QT_MAJOR/$QT_VERSION/single/qt-everywhere-src-$QT_VERSION.zip
-unzip -q -aa qt.zip || true
+curl -o qt.tar.xz -L https://download.qt.io/archive/qt/$QT_MAJOR/$QT_VERSION/single/qt-everywhere-src-$QT_VERSION.tar.xz
+tar -xf qt.tar.xz
 
 echo "Building QT"
 ./scripts/utils/qt6_compile.sh qt-everywhere-src-$QT_VERSION qt_dist


### PR DESCRIPTION
## Description
Lately, we have been encountering some problems loading shaders on our MacOS builds, and this appears to be responsible for error messages in the console of the form:

```
[31.03.2023 14:17:49.960] Warning: qUncompress: Z_DATA_ERROR: Input data is corrupted
[31.03.2023 14:17:49.960] Warning: Attempted to deserialize QShader with unknown version 0.
[31.03.2023 14:17:49.960] Warning: ShaderEffect: Failed to deserialize QShader from :/qt-project.org/imports/Qt5Compat/GraphicalEffects/shaders_ng/radialgradient.vert.qsb. Either the filename is incorrect, or it is not a valid .qsb file. In Qt 6 shaders must be preprocessed using the Qt Shader Tools infrastructure. The vertexShader and fragmentShader properties are now URLs that are expected to point to .qsb files generated by the qsb tool. See https://doc.qt.io/qt-6/qtshadertools-index.html for more information.
[31.03.2023 14:17:49.960] Warning: ShaderEffect: shader preparation failed for qrc:/qt-project.org/imports/Qt5Compat/GraphicalEffects/shaders_ng/radialgradient.vert.qsb
```

After some debugging, I was able to find that the shaders do exist and Qt tries to load them, but they appear to have been subtly corrupted, resulting in a decompression error at runtime. It seems that the root cause of this corruption is the extraction of the Qt sources in our taskcluster job, which attempts to convert between UNIX and Windows line-endings, and erroneously attempts to convert the compiled shader file.

In hindsight, we should just use the tarballed sources, as they ought to use UNIX line endings from the start.

## Reference
Github issue #6487 ([VPN-4462](https://mozilla-hub.atlassian.net/browse/VPN-4462))

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
