### PR TITLE
VPN-4541: Fix channel for staging mode on Glean initialization

### DIFF
--- a/src/apps/vpn/ui/main.qml
+++ b/src/apps/vpn/ui/main.qml
@@ -180,7 +180,7 @@ Window {
                 //
                 // Glean.setDebugViewTag("MozillaVPN");
             }
-            var channel = VPN.stagingMode ? "staging" : "production";
+            var channel = MZEnv.stagingMode ? "staging" : "production";
 
             console.debug("Initializing glean with channel set to:", channel);
             Glean.initialize("mozillavpn", MZSettings.gleanEnabled, {

--- a/src/shared/env.cpp
+++ b/src/shared/env.cpp
@@ -95,7 +95,9 @@ bool Env::stagingMode() { return !Constants::inProduction(); }
 
 #ifdef UNIT_TEST
 void Env::setStagingMode(bool stagingMode) {
-  Constants::setStaging();
+  if (stagingMode) {
+    Constants::setStaging();
+  }
   emit stagingModeChanged();
 }
 #endif

--- a/tests/qml/mocconstants.cpp
+++ b/tests/qml/mocconstants.cpp
@@ -6,7 +6,11 @@
 
 #include "appconstants.h"
 
-bool Constants::inProduction() { return false; }
+namespace {
+bool s_productionMode = true;
+}  // namespace
+
+bool Constants::inProduction() { return s_productionMode; }
 
 const QString& AppConstants::getStagingServerAddress() {
   static QString stagingServerAddress = AppConstants::API_STAGING_URL;
@@ -17,8 +21,8 @@ QString AppConstants::apiBaseUrl() { return AppConstants::API_STAGING_URL; }
 
 QString AppConstants::apiUrl(ApiEndpoint) { return "something here"; }
 
-void Constants::setStaging() {}
-void AppConstants::setStaging() {}
+void Constants::setStaging() { s_productionMode = false; }
+void AppConstants::setStaging() { s_productionMode = false; }
 
 QString Constants::versionString() {
   return QStringLiteral("QMLTest_AppVersion");

--- a/tests/qml/tst_mainWindowGleanMocks.qml
+++ b/tests/qml/tst_mainWindowGleanMocks.qml
@@ -106,7 +106,7 @@ Item {
 
             MZEnv.stagingMode = true
             TestHelper.triggerInitializeGlean()
-            compare(spyConfig.channel, "production")
+            compare(spyConfig.channel, "staging")
         }
 
         function test_onInitializeGleanByDebugMode() {


### PR DESCRIPTION
## Description
During some recent refactoring, we moved many of the properties out of the `MozillaVPN` class and into a shared `MZEnv` component. Unfortunately, during that refactoring we missed the migration of `VPN.stagingMode` to `MZEnv.stagingMode` when initializing glean, resulting in many of our tests sending their telemetry pings to the production channel.

## Reference
Github PR #6289 
Github issue #6586 [VPN-4541](https://mozilla-hub.atlassian.net/browse/VPN-4541)

## Checklist
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-4541]: https://mozilla-hub.atlassian.net/browse/VPN-4541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ