### PR TITLE
Move common strings to a shared `strings.yaml`

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -69,6 +69,7 @@ src/apps/vpn/tasks/ @bakulf
 /ools/serverlocalizer/ @bakulf
 /tools/wasm_chrome/ @strseb
 /translations/ @bakulf
+/src/shared/translations/strings.yaml @flodolo
 /src/apps/**/translations/strings.yaml @flodolo
 /src/apps/**/translations/extras @flodolo
 

--- a/scripts/utils/generate_strings.py
+++ b/scripts/utils/generate_strings.py
@@ -225,7 +225,7 @@ if __name__ == "__main__":
         metavar="SOURCE",
         type=str,
         action="store",
-        nargs="?",
+        nargs='+',
         help="YAML strings file to process",
     )
     parser.add_argument(
@@ -238,7 +238,7 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    if args.source is None:
+    if not args.source:
         exit("No source argument.")
 
     # If no output directory was provided, use the current directory.
@@ -246,7 +246,10 @@ if __name__ == "__main__":
         args.output = os.getcwd()
 
     # Parse the inputs for their sweet juicy strings.
-    strings = parseTranslationStrings(args.source)
+    strings = {}
+    for source in args.source:
+        substrings = parseTranslationStrings(source)
+        strings.update(substrings)
 
     # Render the strings into generated content.
     generateStrings(strings, args.output)

--- a/scripts/utils/generate_strings.py
+++ b/scripts/utils/generate_strings.py
@@ -36,7 +36,7 @@ class UniqueKeyLoader(yaml.SafeLoader):
         return super().construct_mapping(node, deep)
 
 
-def parseTranslationStrings(yamlfile):
+def parseTranslationStrings(project, yamlfile):
     if not os.path.isfile(yamlfile):
         exit(f"Unable to find {yamlfile}")
 
@@ -58,7 +58,7 @@ def parseTranslationStrings(yamlfile):
 
         for category in yaml_content:
             for key in yaml_content[category]:
-                string_id = f"vpn.{category}.{key}"
+                string_id = f"{project}.{category}.{key}"
                 obj = yaml_content[category][key]
                 value = []
                 comments = []
@@ -115,7 +115,7 @@ def parseTranslationStrings(yamlfile):
 
 
 # Render a dictionary of strings into the i18nstrings module.
-def generateStrings(strings, outdir):
+def generateStrings(strings, project, outdir):
     os.makedirs(outdir, exist_ok=True)
     with open(os.path.join(outdir, "i18nstrings.h"), "w", encoding="utf-8") as output:
         output.write(
@@ -199,7 +199,7 @@ const char* const I18nStrings::_ids[] = {
 
         # This is done to make windows compiler happy
         if len(strings) == 0:
-            output.write(f'    "vpn.dummy.ignore",\n\n')
+            output.write(f'    "{project}.dummy.ignore",\n\n')
 
         output.write(
             """
@@ -236,10 +236,21 @@ if __name__ == "__main__":
         action="store",
         help="Output directory for generated files",
     )
+    parser.add_argument(
+        "-p",
+        "--project",
+        metavar="PROJECT",
+        type=str,
+        action="store",
+        help="The project name",
+    )
     args = parser.parse_args()
 
     if not args.source:
         exit("No source argument.")
+
+    if args.project is None:
+        exit("No project name argument.")
 
     # If no output directory was provided, use the current directory.
     if args.output is None:
@@ -248,8 +259,8 @@ if __name__ == "__main__":
     # Parse the inputs for their sweet juicy strings.
     strings = {}
     for source in args.source:
-        substrings = parseTranslationStrings(source)
+        substrings = parseTranslationStrings(args.project, source)
         strings.update(substrings)
 
     # Render the strings into generated content.
-    generateStrings(strings, args.output)
+    generateStrings(strings, args.project, args.output)

--- a/scripts/utils/generate_ts.sh
+++ b/scripts/utils/generate_ts.sh
@@ -29,7 +29,7 @@ for project in src/apps/*; do
   mkdir -p translations/generated/$project || die
 
   printn Y "$project - Generating strings... "
-  python3 cache/generate_strings.py src/apps/$project/translations/strings.yaml src/shared/translations/strings.yaml -o translations/generated/$project
+  python3 cache/generate_strings.py src/apps/$project/translations/strings.yaml src/shared/translations/strings.yaml -o translations/generated/$project -p $project
   print G "done."
 
   printn Y "$project - Generating a dummy PRO file... "
@@ -70,17 +70,17 @@ EOF
     printn Y "Importing main strings from $branch..."
     if [ -f translations/strings.yaml ]; then
       if [ $project = "vpn" ]; then
-        python3 cache/generate_strings.py -o translations/generated/$project translations/strings.yaml || die
+        python3 cache/generate_strings.py -o translations/generated/$project -p $project translations/strings.yaml || die
       else
         echo "# dummy" > translations/generated/dummy_strings.yaml
-        python3 cache/generate_strings.py -o translations/generated/$project translations/generated/dummy_strings.yaml || die
+        python3 cache/generate_strings.py -o translations/generated/$project -p $project translations/generated/dummy_strings.yaml || die
       fi
     elif [ -f src/apps/$project/translations/strings.yaml ]; then
       EXTRA_STRINGS=
       if [ -f src/shared/translations/strings.yaml ]; then
         EXTRA_STRINGS=src/shared/translations/strings.yaml
       fi
-      python3 cache/generate_strings.py -o translations/generated/$project src/apps/$project/translations/strings.yaml $EXTRA_STRINGS || die
+      python3 cache/generate_strings.py -o translations/generated/$project -p $project src/apps/$project/translations/strings.yaml $EXTRA_STRINGS || die
     else
       die "Unable to find the strings.yaml"
     fi

--- a/scripts/utils/generate_ts.sh
+++ b/scripts/utils/generate_ts.sh
@@ -29,7 +29,7 @@ for project in src/apps/*; do
   mkdir -p translations/generated/$project || die
 
   printn Y "$project - Generating strings... "
-  python3 cache/generate_strings.py src/apps/$project/translations/strings.yaml -o translations/generated/$project
+  python3 cache/generate_strings.py src/apps/$project/translations/strings.yaml src/shared/translations/strings.yaml -o translations/generated/$project
   print G "done."
 
   printn Y "$project - Generating a dummy PRO file... "
@@ -76,7 +76,11 @@ EOF
         python3 cache/generate_strings.py -o translations/generated/$project translations/generated/dummy_strings.yaml || die
       fi
     elif [ -f src/apps/$project/translations/strings.yaml ]; then
-      python3 cache/generate_strings.py -o translations/generated/$project src/apps/$project/translations/strings.yaml || die
+      EXTRA_STRINGS=
+      if [ -f src/shared/translations/strings.yaml ]; then
+        EXTRA_STRINGS=src/shared/translations/strings.yaml
+      fi
+      python3 cache/generate_strings.py -o translations/generated/$project src/apps/$project/translations/strings.yaml $EXTRA_STRINGS || die
     else
       die "Unable to find the strings.yaml"
     fi

--- a/scripts/utils/import_languages.py
+++ b/scripts/utils/import_languages.py
@@ -164,6 +164,7 @@ for project in os.listdir(os.path.join('src', 'apps')):
     title("Generate the Js/C++ string definitions...")
     try:
         subprocess.call([sys.executable, os.path.join('scripts', 'utils', 'generate_strings.py'),
+                         '-p', project,
                          '-o', gendir,
                          os.path.join('src', 'apps', project, 'translations', 'strings.yaml'),
                          os.path.join('src', 'shared', 'translations', 'strings.yaml')])

--- a/scripts/utils/import_languages.py
+++ b/scripts/utils/import_languages.py
@@ -164,7 +164,9 @@ for project in os.listdir(os.path.join('src', 'apps')):
     title("Generate the Js/C++ string definitions...")
     try:
         subprocess.call([sys.executable, os.path.join('scripts', 'utils', 'generate_strings.py'),
-                         '-o', gendir, os.path.join('src', 'apps', project, 'translations', 'strings.yaml')])
+                         '-o', gendir,
+                         os.path.join('src', 'apps', project, 'translations', 'strings.yaml'),
+                         os.path.join('src', 'shared', 'translations', 'strings.yaml')])
     except Exception as e:
         print("generate_strings.py failed. Try with:\n\tpip3 install -r requirements.txt --user")
         print(e)

--- a/src/apps/auth_tests/translations/strings.yaml
+++ b/src/apps/auth_tests/translations/strings.yaml
@@ -1,2 +1,1 @@
-inAppMessaging:
-  dateTimeYesterday: Yesterday
+# nothing here yet

--- a/src/apps/relay/translations/strings.yaml
+++ b/src/apps/relay/translations/strings.yaml
@@ -71,6 +71,3 @@
 # Remember! When you change this file, you must run the
 # `./scripts/utils/generate_strings.py` script to regenerate the string files.
 #
-
-inAppMessaging:
-  dateTimeYesterday: Yesterday

--- a/src/apps/template/translations/strings.yaml
+++ b/src/apps/template/translations/strings.yaml
@@ -71,6 +71,3 @@
 # Remember! When you change this file, you must run the
 # `./scripts/utils/generate_strings.py` script to regenerate the string files.
 #
-
-inAppMessaging:
-  dateTimeYesterday: Yesterday

--- a/src/apps/unit_tests/translations/strings.yaml
+++ b/src/apps/unit_tests/translations/strings.yaml
@@ -1,2 +1,1 @@
-inAppMessaging:
-  dateTimeYesterday: Yesterday
+# nothing here

--- a/src/apps/vpn/translations/strings.yaml
+++ b/src/apps/vpn/translations/strings.yaml
@@ -817,7 +817,6 @@ inAppMessaging:
   menuTitle: Messages
   editButton: Edit
   searchBarPlaceholderText: Search messages
-  dateTimeYesterday: Yesterday
   emptyStateTitle: No messages
   emptyStateDescription: You’re up to date!
   deleteMessage:

--- a/src/shared/translations/strings.yaml
+++ b/src/shared/translations/strings.yaml
@@ -1,0 +1,8 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# This file contains shared strings for the Mozilla P&S products.
+
+inAppMessaging:
+  dateTimeYesterday: Yesterday

--- a/translations/CMakeLists.txt
+++ b/translations/CMakeLists.txt
@@ -61,8 +61,8 @@ foreach(PROJECT ${PROJECTS_NAMES})
     ## Generate the string database (language agnostic) for the current ${PROJECT}
     add_custom_command(
         OUTPUT ${GENERATED_DIR}/${PROJECT}/i18nstrings_p.cpp ${GENERATED_DIR}/${PROJECT}/i18nstrings.h
-        MAIN_DEPENDENCY ${PROJECTS_DIR}/${PROJECT}/translations/strings.yaml
-        COMMAND ${PYTHON_EXECUTABLE} ${MVPN_SCRIPT_DIR}/utils/generate_strings.py -o ${GENERATED_DIR}/${PROJECT} ${PROJECTS_DIR}/${PROJECT}/translations/strings.yaml
+        MAIN_DEPENDENCY ${PROJECTS_DIR}/${PROJECT}/translations/strings.yaml ${CMAKE_SOURCE_DIR}/src/shared/translations/strings.yaml
+        COMMAND ${PYTHON_EXECUTABLE} ${MVPN_SCRIPT_DIR}/utils/generate_strings.py -o ${GENERATED_DIR}/${PROJECT} ${PROJECTS_DIR}/${PROJECT}/translations/strings.yaml ${CMAKE_SOURCE_DIR}/src/shared/translations/strings.yaml
     )
 
     ## Build the list of supported locales and add rules to build them.

--- a/translations/CMakeLists.txt
+++ b/translations/CMakeLists.txt
@@ -62,7 +62,7 @@ foreach(PROJECT ${PROJECTS_NAMES})
     add_custom_command(
         OUTPUT ${GENERATED_DIR}/${PROJECT}/i18nstrings_p.cpp ${GENERATED_DIR}/${PROJECT}/i18nstrings.h
         MAIN_DEPENDENCY ${PROJECTS_DIR}/${PROJECT}/translations/strings.yaml ${CMAKE_SOURCE_DIR}/src/shared/translations/strings.yaml
-        COMMAND ${PYTHON_EXECUTABLE} ${MVPN_SCRIPT_DIR}/utils/generate_strings.py -o ${GENERATED_DIR}/${PROJECT} ${PROJECTS_DIR}/${PROJECT}/translations/strings.yaml ${CMAKE_SOURCE_DIR}/src/shared/translations/strings.yaml
+        COMMAND ${PYTHON_EXECUTABLE} ${MVPN_SCRIPT_DIR}/utils/generate_strings.py -p ${PROJECT} -o ${GENERATED_DIR}/${PROJECT} ${PROJECTS_DIR}/${PROJECT}/translations/strings.yaml ${CMAKE_SOURCE_DIR}/src/shared/translations/strings.yaml
     )
 
     ## Build the list of supported locales and add rules to build them.

--- a/translations/translations.pri
+++ b/translations/translations.pri
@@ -13,7 +13,9 @@ exists($$PWD/generated/vpn/translations.qrc) {
 INCLUDEPATH += $$PWD/generated
 SOURCES += $$PWD/i18nstrings.cpp
 
-STRING_SOURCES = $$PWD/../src/apps/vpn/translations/strings.yaml
+STRING_SOURCES = \
+    $$PWD/../src/shared/translations/strings.yaml \
+    $$PWD/../src/apps/vpn/translations/strings.yaml
 
 ## This is necessary to ensure MOC picks up this class.
 HEADERS += $$PWD/generated/vpn/i18nstrings.h
@@ -26,6 +28,7 @@ stringgen.commands = @echo Generating strings from ${QMAKE_FILE_IN} \
         -o ${QMAKE_FILE_OUT_PATH} ${QMAKE_FILE_IN}
 stringgen.depends += ${QMAKE_FILE_IN}
 stringgen.variable_out = HEADERS
+stringgen.CONFIG = combine
 
 ## Dummy rule for the private source file.
 stringsrc.input = STRING_SOURCES
@@ -33,5 +36,6 @@ stringsrc.output = $$PWD/generated/vpn/i18nstrings_p.cpp
 stringsrc.commands = $$escape_expand(\\n)  # force creation of rule
 stringsrc.depends += $$PWD/generated/vpn/i18nstrings.h
 stringsrc.variable_out = SOURCES
+stringsrc.CONFIG = combine
 
 QMAKE_EXTRA_COMPILERS += stringgen stringsrc

--- a/translations/translations.pri
+++ b/translations/translations.pri
@@ -25,7 +25,7 @@ stringgen.input = STRING_SOURCES
 stringgen.output = $$PWD/generated/vpn/i18nstrings.h
 stringgen.commands = @echo Generating strings from ${QMAKE_FILE_IN} \
     && python3 $$PWD/../scripts/utils/generate_strings.py \
-        -o ${QMAKE_FILE_OUT_PATH} ${QMAKE_FILE_IN}
+        -o ${QMAKE_FILE_OUT_PATH} -p vpn ${QMAKE_FILE_IN}
 stringgen.depends += ${QMAKE_FILE_IN}
 stringgen.variable_out = HEADERS
 stringgen.CONFIG = combine


### PR DESCRIPTION
There a few strings that have to be included in all the P&S products. Instead of duplicating them in all the `strings.yaml`, in this PR I introduce a shared strings.yaml which is "merged" with the product specific ones at build time.