### PR TITLE
VPN-3368 / VPN-4481 / VPN-4482 / VPN-3869 -"Getting started" tutorial improvements for 2.15

### DIFF
--- a/addons/tutorial_01_get_started/condition.js
+++ b/addons/tutorial_01_get_started/condition.js
@@ -1,0 +1,15 @@
+(function(api, condition) {
+    api.connectSignal(api.featureList.get('recommendedServers'), 'supportedChanged', () => {
+        if(!api.featureList.get('recommendedServers').isSupported) {
+            condition.enable()
+            return
+        }
+        condition.disable()
+      });
+
+    if(!api.featureList.get('recommendedServers').isSupported) {
+        condition.enable()
+        return
+    }
+    condition.disable()
+  })

--- a/addons/tutorial_01_get_started/manifest.json
+++ b/addons/tutorial_01_get_started/manifest.json
@@ -3,6 +3,9 @@
   "id": "tutorial_01_get_started",
   "name": "Tutorial: get started",
   "type": "tutorial",
+  "conditions": {
+    "javascript": "condition.js"
+  },
   "tutorial": {
     "id": "01_get_started",
     "highlighted": true,
@@ -35,7 +38,7 @@
       {
         "id": "countryAU",
         "element": "serverCountryList/serverCountry-au",
-        "query": "//serverCountryList/{className=VPNServerCountry}{hasAvailableCities=true}[0]{visible=true}",
+        "query": "//serverCountryList/{hasAvailableCities=true}[0]{visible=true}",
         "tooltip": "Select a different country",
         "before": [{
           "op": "property_set",
@@ -47,19 +50,19 @@
         "next": {
           "op": "signal",
           "qml_emitter": "serverCountryList/serverCountry-au",
-          "query_emitter": "//serverCountryList/{className=VPNServerCountry}{hasAvailableCities=true}[0]{visible=true}",
+          "query_emitter": "//serverCountryList/{hasAvailableCities=true}[0]{visible=true}",
           "signal": "cityListVisibleChanged"
         }
       },
       {
         "id": "cityAU",
         "element": "serverCountryList/serverCountry-au/serverCityList/serverCity-Melbourne/radioIndicator",
-        "query": "//serverCountryList/{className=VPNServerCountry}{hasAvailableCities=true}[0]//serverCityList/{className=VPNRadioDelegate}{isAvailable=true}[0]{visible=true}",
+        "query": "//serverCountryList/{hasAvailableCities=true}[0]//serverCityList/{isAvailable=true}[0]{visible=true}",
         "tooltip": "Select a different server location",
         "next": {
           "op": "signal",
           "qml_emitter": "serverCountryList/serverCountry-au/serverCityList/serverCity-Melbourne/radioIndicator",
-          "query_emitter": "//serverCountryList/{className=VPNServerCountry}{hasAvailableCities=true}[0]//serverCityList/{className=VPNRadioDelegate}{isAvailable=true}[0]{visible=true}",
+          "query_emitter": "//serverCountryList/{hasAvailableCities=true}[0]//serverCityList/{isAvailable=true}[0]{visible=true}",
           "signal": "visibleChanged"
         }
       },

--- a/addons/tutorial_01_get_started_recommended_locations/isRecommendedSelected.js
+++ b/addons/tutorial_01_get_started_recommended_locations/isRecommendedSelected.js
@@ -1,0 +1,15 @@
+(function(api, condition) {
+    api.connectSignal(api.settings, 'recommendedServerSelectedChanged', () => {
+        if(api.settings.recommendedServerSelected === false) {
+            condition.enable()
+            return
+        }
+        condition.disable()
+      });
+    
+    if(api.settings.recommendedServerSelected === false) {
+        condition.enable()
+        return
+    }
+    condition.disable()
+  })

--- a/addons/tutorial_01_get_started_recommended_locations/manifest.json
+++ b/addons/tutorial_01_get_started_recommended_locations/manifest.json
@@ -1,0 +1,71 @@
+{
+  "api_version": "0.1",
+  "id": "tutorial_01_get_started_recommended_locations",
+  "name": "Tutorial: get started recommended locations",
+  "type": "tutorial",
+  "conditions": {
+    "enabled_features": ["recommendedServers"]
+  },
+  "tutorial": {
+    "id": "01_get_started_recommended_locations",
+    "highlighted": true,
+    "image": "qrc:/addons/tutorial_01_get_started_recommended_locations/image.svg",
+    "title": "Getting started with VPN",
+    "subtitle": "Follow this walkthrough to learn how to get started with using your VPN.",
+    "completion_message": "You’ve learned how to choose the most reliable server location. Would you like to learn more tips and tricks?",
+    "steps": [
+      {
+        "id": "mainScreen",
+        "query": "//serverListButton-btn{visible=true}",
+        "tooltip": "Select your location",
+        "before": [{
+          "op": "vpn_off"
+        },{
+          "op": "vpn_location_set",
+          "exitCountryCode": "it",
+          "exitCity": "Milan",
+          "entryCountryCode": "",
+          "entryCity": ""
+        }],
+        "next": {
+          "op": "signal",
+          "query_emitter": "//serverListButton-btn{visible=true}",
+          "signal": "visibleChanged"
+        }
+      },
+      {
+        "id": "recommendedTab",
+        "query": "//tabRecommendedServers",
+        "tooltip": "Select the “Recommended” tab",
+        "conditions": {
+           "javascript": "isRecommendedSelected.js"
+        },
+        "next": {
+          "op": "signal",
+          "query_emitter": "//tabRecommendedServers",
+          "signal": "clicked"
+        }
+      },
+      {
+        "id": "firstCity",
+        "query": "//serverListRecommended/{isAvailable=true}[0]",
+        "tooltip": "Select the top recommended location",
+        "next": {
+          "op": "signal",
+          "query_emitter": "//serverListRecommended/{isAvailable=true}[0]",
+          "signal": "clicked"
+        }
+      },
+      {
+        "id": "toggle",
+        "query": "//controllerToggle{visible=true}",
+        "tooltip": "Toggle this switch to activate the VPN",
+        "next": {
+          "op": "signal",
+          "vpn_emitter": "controller",
+          "signal": "stateChanged"
+        }
+      }
+    ]
+  }
+}

--- a/addons/tutorial_03_multi_hop/manifest.json
+++ b/addons/tutorial_03_multi_hop/manifest.json
@@ -56,7 +56,7 @@
       },
       {
         "id": "s4",
-        "query": "//serverCountryList/{className=VPNServerCountry}{hasAvailableCities=true}[0]//serverCityList/{className=VPNRadioDelegate}{isAvailable=true}[0]{visible=true}",
+        "query": "//serverCountryList/{hasAvailableCities=true}[0]//serverCityList/{isAvailable=true}[0]{visible=true}",
         "tooltip": "Select a new exit location",
         "before": [{
           "op": "property_set",
@@ -65,13 +65,13 @@
           "value": 0
         },{
           "op": "property_set",
-          "query": "//serverCountryList/{className=VPNServerCountry}{hasAvailableCities=true}[0]{visible=true}",
+          "query": "//serverCountryList/{hasAvailableCities=true}[0]{visible=true}",
           "property": "cityListVisible",
           "value": true
         }],
         "next": {
           "op": "signal",
-          "query_emitter": "//serverCountryList/{className=VPNServerCountry}{hasAvailableCities=true}[0]//serverCityList/{className=VPNRadioDelegate}{isAvailable=true}[0]{visible=true}",
+          "query_emitter": "//serverCountryList/{hasAvailableCities=true}[0]//serverCityList/{isAvailable=true}[0]{visible=true}",
           "signal": "visibleChanged"
         }
       },

--- a/nebula/ui/components/MZSegmentedToggle.qml
+++ b/nebula/ui/components/MZSegmentedToggle.qml
@@ -113,7 +113,7 @@ Rectangle {
                 Rectangle {
                     anchors.fill: parent
                     border.width: MZTheme.theme.focusBorderWidth
-                    border.color: "black"
+                    border.color: MZTheme.theme.fontColor
                     color: MZTheme.theme.transparent
                     visible: VPNTutorial.playing && parent.focus
                     radius: root.radius

--- a/nebula/ui/components/MZTabNavigation.qml
+++ b/nebula/ui/components/MZTabNavigation.qml
@@ -7,6 +7,7 @@ import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
 
 import Mozilla.Shared 1.0
+import Mozilla.VPN 1.0
 
 Item {
     id: root
@@ -59,7 +60,7 @@ Item {
                         anchors.right: parent.right
                         anchors.bottom: parent.bottom
                         color: MZTheme.colors.purple70
-                        opacity: btn.activeFocus ? 1 : 0
+                        opacity: btn.checked ? 1 : 0
                         Behavior on opacity {
                             PropertyAnimation {
                                 duration: 100
@@ -73,7 +74,17 @@ Item {
                     elide: Qt.ElideRight
                     horizontalAlignment: Text.AlignHCenter
                     verticalAlignment: Text.AlignVCenter
-                    color: btn.checked || btn.activeFocus ? MZTheme.colors.purple70 : btn.hovered ? MZTheme.colors.grey50 : MZTheme.colors.grey40
+                    color: btn.checked ? MZTheme.colors.purple70 : btn.hovered || btn.activeFocus ? MZTheme.colors.grey50 : MZTheme.colors.grey40
+
+                    Rectangle {
+                        anchors.fill: parent
+                        anchors.margins: 2
+                        border.width: MZTheme.theme.focusBorderWidth
+                        border.color: MZTheme.theme.fontColor
+                        color: MZTheme.theme.transparent
+                        visible: VPNTutorial.playing && btn.activeFocus
+                        radius: 4
+                    }
 
                     Behavior on color {
                         PropertyAnimation {

--- a/nebula/ui/components/MZTutorialPopups.qml
+++ b/nebula/ui/components/MZTutorialPopups.qml
@@ -42,15 +42,21 @@ Item {
     anchors.fill: parent
     visible: tutorialTooltip.visible || tutorialPopup.opened
 
-    onTargetElementChanged: tooltipRepositionTimer.start()
+    onTargetElementChanged: {
+        if(targetElement && VPNTutorial.playing) {
+            tutorialTooltip.close()
+            pauseTimer.start()
+        }
+    }
 
-    //Bandaid fix to position *ALL* tutorial tooltips in the correct position
+    //Adds a delay between tooltip popups in tutorials
     Timer {
-        id: tooltipRepositionTimer
-        interval: 1
+        id: pauseTimer
+        interval: 300
         onTriggered: {
             tutorialTooltip.repositionTooltip()
             notch.repositionNotch()
+            tutorialTooltip.open()
         }
     }
 
@@ -296,7 +302,6 @@ Item {
         function onTooltipNeeded(text, targetEl) {
             root.targetElement = targetEl;
             tutorialTooltip.tooltipText = text;
-            tutorialTooltip.open();
         }
 
         function onTutorialCompleted(tutorial) {
@@ -345,7 +350,7 @@ Item {
                 return
 
             if (!targetElement.activeFocus && (!targetElement.parent || !targetElement.parent.activeFocus) && !leaveTutorialBtn.activeFocus && !tutorialPopup.opened) {
-                tutorialTooltip.forceActiveFocus();
+                leaveTutorialBtn.forceActiveFocus();
             }
         }
     }

--- a/src/apps/vpn/ui/screens/home/servers/ServerList.qml
+++ b/src/apps/vpn/ui/screens/home/servers/ServerList.qml
@@ -98,6 +98,8 @@ FocusScope {
 
             Column {
                 id: serverListRecommended
+                objectName: "serverListRecommended"
+
                 spacing: MZTheme.theme.listSpacing * 1.5
                 width: parent.width
 


### PR DESCRIPTION
## Description

- Allows both the new and old "Getting started" tutorials to function on 2.15 
  - Since the "Recommended servers" feature is shipping with 2.15, the only time a user should see the old "Getting started" tutorial is if the feature is turned off

## Reference

[VPN-3368: Implement the new "Get Started" Tutorial](https://mozilla-hub.atlassian.net/browse/VPN-3368)
[VPN-4481: Users who have never selected the “All” tab are not able to finalize the “Getting started with VPN” tutorial](https://mozilla-hub.atlassian.net/browse/VPN-4481)
[VPN-4482: Users are not able to finalize the “Using multi-hop VPN” / “Getting started with VPN” tutorials](https://mozilla-hub.atlassian.net/browse/VPN-4482)
[VPN-3869: Make tooltips display with a slight delay](https://mozilla-hub.atlassian.net/browse/VPN-3869)
