### PR TITLE
VPN-4451 Use the correct callback for web-purchase - VPN-4451

### DIFF
--- a/src/apps/vpn/purchasewebhandler.cpp
+++ b/src/apps/vpn/purchasewebhandler.cpp
@@ -43,7 +43,7 @@ void PurchaseWebHandler::startSubscription(const QString&) {
   connect(taskAuthenticate, &TaskAuthenticate::authenticationAborted, vpn,
           &MozillaVPN::abortAuthentication);
   connect(taskAuthenticate, &TaskAuthenticate::authenticationCompleted, vpn,
-          &MozillaVPN::authenticationCompleted);
+          &MozillaVPN::completeAuthentication);
 
   TaskScheduler::scheduleTask(taskAuthenticate);
 }


### PR DESCRIPTION
## Description

Use the correct callback for web purchases so after redirecting back to the VPN user is no longer stuck on the subscription screen.

## Reference

    https://mozilla-hub.atlassian.net/browse/VPN-4451

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
