### PR TITLE
Add step to turn off vpn in new getting started tutorial

### DIFF
--- a/addons/tutorial_01_get_started_recommended_locations/manifest.json
+++ b/addons/tutorial_01_get_started_recommended_locations/manifest.json
@@ -15,6 +15,19 @@
     "completion_message": "You’ve learned how to choose the most reliable server location. Would you like to learn more tips and tricks?",
     "steps": [
       {
+        "id": "turnOffVPN",
+        "query": "//controllerToggle{visible=true}",
+        "tooltip": "Toggle this switch to deactivate the VPN",
+        "conditions": {
+           "javascript": "vpnIsOn.js"
+        },
+        "next": {
+          "op": "signal",
+          "vpn_emitter": "controller",
+          "signal": "stateChanged"
+        }
+      },
+      {
         "id": "mainScreen",
         "query": "//serverListButton-btn{visible=true}",
         "tooltip": "Select your location",

--- a/addons/tutorial_01_get_started_recommended_locations/manifest.json
+++ b/addons/tutorial_01_get_started_recommended_locations/manifest.json
@@ -32,8 +32,6 @@
         "query": "//serverListButton-btn{visible=true}",
         "tooltip": "Select your location",
         "before": [{
-          "op": "vpn_off"
-        },{
           "op": "vpn_location_set",
           "exitCountryCode": "it",
           "exitCity": "Milan",

--- a/addons/tutorial_01_get_started_recommended_locations/vpnIsOn.js
+++ b/addons/tutorial_01_get_started_recommended_locations/vpnIsOn.js
@@ -1,0 +1,22 @@
+// Let's use a global variable to keep track of the split-tunneling settings.
+// This will be replaced with addon properties as soon as they will be
+// implemented (v2.13~).
+splitTunnelTutorialVpnWasOn = false;
+
+(function(api, condition) {
+api.connectSignal(api.addon, 'playingChanged', () => {
+  if (!api.addon.playing) {
+    return;
+  }
+
+  if (api.controller.state === api.controller.StateOff) {
+    condition.disable();
+    splitTunnelTutorialVpnWasOn = false;
+  } else {
+    condition.enable();
+    splitTunnelTutorialVpnWasOn = true;
+  }
+});
+
+condition.disable();
+});


### PR DESCRIPTION
## Description

- Adds a step at the beginning of the new "Getting started" tutorial to have the user manually turn the VPN off if it is already on (instead of having it done automatically) 

## Reference

[VPN-3368: Implement the new "Get Started" Tutorial](https://mozilla-hub.atlassian.net/browse/VPN-3368)