### PR TITLE
VPN-4595: Fix Collapsible Card drop shadow

### DIFF
--- a/nebula/ui/components/MZCollapsibleCard.qml
+++ b/nebula/ui/components/MZCollapsibleCard.qml
@@ -21,7 +21,6 @@ Rectangle {
     implicitHeight: expanded ? cardWrapper.wrapperHeight : accordionHeader.headerHeight
     radius: MZTheme.theme.cornerRadius
     width: parent.width
-    clip: true
 
     Behavior on implicitHeight {
         NumberAnimation {


### PR DESCRIPTION
## Description

- Prevent drop shadows on collapsible cards from being clipped

## Reference

[VPN-4595: Recommended locations info card and Multi-hop info card are missing box shadows ](https://mozilla-hub.atlassian.net/browse/VPN-4595)
