### PR TITLE
Nit: Don't pull sentry, just use the submodule

### DIFF
--- a/src/shared/cmake/sentry.cmake
+++ b/src/shared/cmake/sentry.cmake
@@ -89,8 +89,8 @@ if( ${_SUPPORTED} GREATER -1 )
     include(ExternalProject)
     ExternalProject_Add(sentry
         SOURCE_DIR ${CMAKE_SOURCE_DIR}/3rdparty/sentry
-        GIT_REPOSITORY https://github.com/getsentry/sentry-native/
-        GIT_TAG 0.5.0
+        GIT_SUBMODULES 3rdparty/sentry
+        GIT_SUBMODULES_RECURSE true
         CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${EXTERNAL_INSTALL_LOCATION} ${SENTRY_ARGS}
     )
 

--- a/taskcluster/scripts/build/android_build_debug.sh
+++ b/taskcluster/scripts/build/android_build_debug.sh
@@ -5,7 +5,7 @@
 set -e
 
 # This script is used in the Android Debug (universal) build task
-git submodule update --init --depth 1
+git submodule update --init --recursive
 
 for i in src/apps/*/translations/i18n; do
   git submodule update --remote $i

--- a/taskcluster/scripts/build/android_build_release.sh
+++ b/taskcluster/scripts/build/android_build_release.sh
@@ -5,7 +5,7 @@
 set -e
 
 # This script is used in the Android Build Release (universal) build task
-git submodule update --init --depth 1
+git submodule update --init --recursive
 
 for i in src/apps/*/translations/i18n; do
   git submodule update --remote $i

--- a/taskcluster/scripts/build/ios_build_no_adjust.sh
+++ b/taskcluster/scripts/build/ios_build_no_adjust.sh
@@ -50,7 +50,7 @@ cd $PROJECT_HOME
 ln -s ../../fetches/qt_ios/ qt_ios
 
 print Y "Get the submodules..."
-git submodule update --init --depth 1 || die "Failed to init submodules"
+git submodule update --init --recursive || die "Failed to init submodules"
 # Technically we do not need the following line because we later call the
 # apple compile script which calls import languages. However when we move to cmake
 # for iOS we can remove the call to import languages and this step will be necessary

--- a/taskcluster/scripts/build/ios_build_no_adjust_cmake.sh
+++ b/taskcluster/scripts/build/ios_build_no_adjust_cmake.sh
@@ -46,7 +46,7 @@ brew install cmake
 export PATH=$PATH:$GOROOT/bin
 
 print Y "Get the submodules..."
-git submodule update --init --depth 1 || die "Failed to init submodules"
+git submodule update --init --recursive || die "Failed to init submodules"
 for i in src/apps/*/translations/i18n; do
   git submodule update --remote $i || die "Failed to pull latest i18n from remote ($i)"
 done

--- a/taskcluster/scripts/build/macos_build.sh
+++ b/taskcluster/scripts/build/macos_build.sh
@@ -63,7 +63,7 @@ export SDKROOT=$(xcrun --sdk macosx --show-sdk-path)
 
 # Should already have been done by taskcluser, but double checking c:
 print Y "Get the submodules..."
-git submodule update --init --depth 1 || die "Failed to init submodules"
+git submodule update --init --recursive || die "Failed to init submodules"
 for i in src/apps/*/translations/i18n; do
   git submodule update --remote $i || die "Failed to pull latest i18n from remote ($i)"
 done

--- a/taskcluster/scripts/build/macos_universal_build.sh
+++ b/taskcluster/scripts/build/macos_universal_build.sh
@@ -56,7 +56,7 @@ python3 -m pip install -r requirements.txt --user
 
 # Should already have been done by taskcluser, but double checking c:
 print Y "Get the submodules..."
-git submodule update --init --depth 1 || die "Failed to init submodules"
+git submodule update --init --recursive || die "Failed to init submodules"
 for i in src/apps/*/translations/i18n; do
   git submodule update --remote $i || die "Failed to pull latest i18n from remote ($i)"
 done

--- a/taskcluster/scripts/build/windows.ps1
+++ b/taskcluster/scripts/build/windows.ps1
@@ -46,6 +46,7 @@ Copy-Item -Path $env:VCToolsRedistDir\\MergeModules\\Microsoft_VC143_CRT_x86.msm
 Copy-Item -Path $env:VCToolsRedistDir\\MergeModules\\Microsoft_VC143_CRT_x64.msm -Destination $env:VCToolsRedistDir\\MergeModules\\Microsoft_VC142_CRT_x64.msm
 Copy-Item -Path $env:VCToolsRedistDir\\MergeModules\\Microsoft_VC143_CRT_x86.msm -Destination $env:VCToolsRedistDir\\MergeModules\\Microsoft_VC142_CRT_x86.msm
 
+git submodule update --init --recursive
 
 # Setup Openssl Import
 $SSL_PATH = resolve-path "$FETCHES_PATH/QT_OUT/SSL"


### PR DESCRIPTION
## Description

We have sentry as submodule. 
Let's cmake use the submodule instead of attempting to pull the repo into the submodule itself. 
This should make that step faster :) 
