### PR TITLE
Bug: Source Bundle does not contain sentry submodules

### DIFF
--- a/scripts/linux/script.sh
+++ b/scripts/linux/script.sh
@@ -121,7 +121,7 @@ rm -rf .tmp || die "Failed to remove the temporary directory"
 mkdir .tmp || die "Failed to create the temporary directory"
 
 print Y "Get the submodules..."
-git submodule update --init --depth 1 || die "Failed to init submodules"
+git submodule update --init --recursive || die "Failed to init submodules"
 
 for i in src/apps/*/translations/i18n; do
   git submodule update --remote $i || die "Failed to pull latest i18n from remote ($i)"


### PR DESCRIPTION
## Description
In https://github.com/mozilla-mobile/mozilla-vpn-client/pull/6661 - i stopped cmake from fetching sentry, instead it should use whatever we have locally, relying on git-submodules working. 

I forgot to make sure the linux source bundle also fetches recusive git submodules. 

This causes the windows level-3 builds to fail. 

