### PR TITLE
VPN-4164: Add dev menu option for forcing port 53

### DIFF
--- a/src/apps/vpn/appfeaturelist.h
+++ b/src/apps/vpn/appfeaturelist.h
@@ -11,6 +11,13 @@ FEATURE(accountDeletion,        // Feature ID
         QStringList(),          // feature dependencies
         FeatureCallback_accountDeletion)
 
+FEATURE(alwaysPort53,          // Feature ID
+        "Always use port 53",  // Feature name
+        FeatureCallback_true,  // Can be flipped on
+        FeatureCallback_true,  // Can be flipped off
+        QStringList(),         // feature dependencies
+        FeatureCallback_false)
+
 FEATURE(benchmarkUpload,       // Feature ID
         "Benchmark Upload",    // Feature name
         FeatureCallback_true,  // Can be flipped on

--- a/src/apps/vpn/controller.cpp
+++ b/src/apps/vpn/controller.cpp
@@ -336,7 +336,9 @@ void Controller::activateInternal(DNSPortPolicy dnsPort,
     exitHop.m_excludedAddresses.append(exitHop.m_server.ipv6AddrIn());
 
     // If requested, force the use of port 53/DNS.
-    if (dnsPort == ForceDNSPort) {
+    if (dnsPort == ForceDNSPort ||
+        Feature::get(Feature::Feature_alwaysPort53)->isSupported()) {
+      logger.info() << "Forcing port 53";
       exitHop.m_server.forcePort(53);
     }
     // For single-hop, they are the same
@@ -564,6 +566,7 @@ void Controller::handshakeTimeout() {
   // Try again, again if there are sufficient retries left.
   ++m_connectionRetry;
   emit connectionRetryChanged();
+  logger.info() << "Connection attempt " << m_connectionRetry;
   if (m_connectionRetry == 1) {
     logger.info() << "Connection Attempt: Using Port 53 Option this time.";
     // On the first retry, opportunisticly try again using the port 53


### PR DESCRIPTION
## Description

In discussion around VPN-4164, we decided to add back an option to force port 53, but hide it in the dev menu. Once this goes live, this user will then be able to test by always forcing port 53.

## Reference

https://mozilla-hub.atlassian.net/browse/VPN-4164

## Checklist
    
- [X] My code follows the style guidelines for this project
- [X] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [X] I have performed a self review of my own code
- [X] I have commented my code PARTICULARLY in hard to understand areas
- [X] I have added thorough tests where needed
