### PR TITLE
VPN-4210: Screen reader support for latency indicators

### DIFF
--- a/src/apps/vpn/translations/strings.yaml
+++ b/src/apps/vpn/translations/strings.yaml
@@ -100,6 +100,18 @@ serversView:
     value: "Last updated: %1. To update this list please disconnect from the VPN."
     comment: The time (or in extremely rare circumstances, the date, day of the week, or "yesterday") which the recommended servers list was last updated and instructions to re-enable the refresh button. Argument is the time or date/day
   recommendedRefreshLastUpdatedLabelYesterday: yesterday
+  serverCityWithGoodConnection:
+    value: "%1. Good connectivity"
+    comment: Button label that reads out a city name whose connection is good. Argument is the city name.
+  serverCityWithModerateConnection:
+    value: "%1. Moderate connectivity"
+    comment: Button label that reads out a city name whose connection is moderate. Argument is the city name.
+  serverCityWithPoorConnection:
+    value: "%1. Poor connectivity"
+    comment: Button label that reads out a city name whose connection is poor. Argument is the city name.
+  serverCityWithNoConnection:
+    value: "%1. No connectivity"
+    comment: Button label that reads out a city name whose connection is unavailable. Argument is the city name.
 
 languageView:
   searchPlaceholder:

--- a/src/apps/vpn/ui/screens/home/servers/ServerCountry.qml
+++ b/src/apps/vpn/ui/screens/home/servers/ServerCountry.qml
@@ -185,7 +185,7 @@ MZClickableRow {
                 Keys.onDownPressed: if (citiesRepeater.itemAt(index + 1)) citiesRepeater.itemAt(index + 1).forceActiveFocus()
                 Keys.onUpPressed: if (citiesRepeater.itemAt(index - 1)) citiesRepeater.itemAt(index - 1).forceActiveFocus()
                 radioButtonLabelText: _localizedCityName
-                accessibleName: _localizedCityName
+                accessibleName: latencyIndicator.accessibleName.arg(_localizedCityName)
                 implicitWidth: parent.width
 
                 onClicked: {
@@ -207,6 +207,7 @@ MZClickableRow {
                 }
 
                 ServerLatencyIndicator {
+                    id: latencyIndicator
                     anchors {
                         right: parent.right
                         rightMargin: MZTheme.theme.hSpacing

--- a/src/apps/vpn/ui/screens/home/servers/ServerLatencyIndicator.qml
+++ b/src/apps/vpn/ui/screens/home/servers/ServerLatencyIndicator.qml
@@ -11,12 +11,27 @@ import components 0.1
 
 MZIcon {
     property int score: VPNServerLatency.NoData
+    property string accessibleName: {
+        switch(state) {
+        case "good":
+            return MZI18n.ServersViewServerCityWithGoodConnection
+        case "moderate":
+            return MZI18n.ServersViewServerCityWithModerateConnection
+        case "poor":
+            return MZI18n.ServersViewServerCityWithPoorConnection
+        case "unavailable":
+            return MZI18n.ServersViewServerCityWithNoConnection
+        default:
+            return "%1"
+        }
+    }
 
     id: latencyIndicator
 
     states: [
         // Low latency
         State {
+            name: "good"
             when: (score === VPNServerLatency.Good ||
                 score === VPNServerLatency.Excellent)
             PropertyChanges {
@@ -27,6 +42,7 @@ MZIcon {
         },
         // Moderate latency
         State {
+            name: "moderate"
             when: (score === VPNServerLatency.Moderate)
             PropertyChanges {
                 target: latencyIndicator
@@ -36,6 +52,7 @@ MZIcon {
         },
         // High latency
         State {
+            name: "poor"
             when: (score === VPNServerLatency.Poor)
             PropertyChanges {
                 target: latencyIndicator
@@ -45,6 +62,7 @@ MZIcon {
         },
         // Very high latency or server unavailable
         State {
+            name: "unavailable"
             when: score === VPNServerLatency.Unavailable
             PropertyChanges {
                 target: latencyIndicator
@@ -54,6 +72,7 @@ MZIcon {
         },
         // No data
         State {
+            name: "none"
             when: score === VPNServerLatency.NoData
             PropertyChanges {
                 target: latencyIndicator

--- a/src/apps/vpn/ui/screens/home/servers/ServerList.qml
+++ b/src/apps/vpn/ui/screens/home/servers/ServerList.qml
@@ -209,7 +209,8 @@ FocusScope {
                         property bool isAvailable: modelData.connectionScore >= 0
                         id: recommendedServer
 
-                        accessibleName: city.localizedName
+                        accessibleName: latencyIndicator.accessibleName.arg(modelData.localizedName)
+
                         onClicked: {
                             if (!isAvailable) {
                                 return;
@@ -237,6 +238,7 @@ FocusScope {
                             }
 
                             ServerLatencyIndicator {
+                                id: latencyIndicator
                                 Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
                                 score: city.connectionScore
                             }


### PR DESCRIPTION
## Description

- Add connectivity score to accessible names that are read out when navigating through city servers

## Reference

[VPN-4210: Server latency indicators should support screen readers](https://mozilla-hub.atlassian.net/browse/VPN-4210)
