### PR TITLE
VPN-4406 [Part 1] Add Inspector command to overwrite connection health stability

### DIFF
--- a/src/apps/vpn/connectionhealth.cpp
+++ b/src/apps/vpn/connectionhealth.cpp
@@ -129,6 +129,15 @@ void ConnectionHealth::startIdle() {
 }
 
 void ConnectionHealth::setStability(ConnectionStability stability) {
+  // Check the stability overwritten flag to see if we are attempting to force
+  // overwrite the stability through the inspector command.
+  if (m_stabilityOverwritten) {
+    logger.debug() << "Connection health stability is overwritten through the "
+                      "Inspector commandline. Forced stability value: "
+                   << stability;
+    return;
+  }
+
   if (stability == Unstable) {
     MozillaVPN::instance()->silentSwitch();
 

--- a/src/apps/vpn/connectionhealth.h
+++ b/src/apps/vpn/connectionhealth.h
@@ -34,6 +34,10 @@ class ConnectionHealth final : public QObject {
   ConnectionStability stability() const { return m_stability; }
 
   void overwriteStabilityForInspector(ConnectionStability stability) {
+    // Only allow overriding the connection health stability in dev mode.
+    if (Constants::inProduction()) {
+      qFatal << "Illegal invokation";
+    }
     m_stabilityOverwritten = true;
     m_stability = stability;
     emit stabilityChanged();

--- a/src/apps/vpn/connectionhealth.h
+++ b/src/apps/vpn/connectionhealth.h
@@ -33,6 +33,12 @@ class ConnectionHealth final : public QObject {
 
   ConnectionStability stability() const { return m_stability; }
 
+  void overwriteStabilityForInspector(ConnectionStability stability) {
+    m_stabilityOverwritten = true;
+    m_stability = stability;
+    emit stabilityChanged();
+  }
+
   uint latency() const { return m_pingHelper.latency(); }
   double loss() const { return m_pingHelper.loss(); }
   double stddev() const { return m_pingHelper.stddev(); }
@@ -63,6 +69,10 @@ class ConnectionHealth final : public QObject {
 
  private:
   ConnectionStability m_stability = Stable;
+
+  // This flag is used to check if the connection stability has been overwritten
+  // by the inspector command.
+  bool m_stabilityOverwritten = false;
 
   QTimer m_settlingTimer;
   QTimer m_noSignalTimer;

--- a/src/apps/vpn/connectionhealth.h
+++ b/src/apps/vpn/connectionhealth.h
@@ -5,7 +5,7 @@
 #ifndef CONNECTIONHEALTH_H
 #define CONNECTIONHEALTH_H
 
-#include "appconstants.h"
+#include "constants.h"
 #include "dnspingsender.h"
 #include "pinghelper.h"
 

--- a/src/apps/vpn/connectionhealth.h
+++ b/src/apps/vpn/connectionhealth.h
@@ -5,6 +5,7 @@
 #ifndef CONNECTIONHEALTH_H
 #define CONNECTIONHEALTH_H
 
+#include "appconstants.h"
 #include "dnspingsender.h"
 #include "pinghelper.h"
 
@@ -34,9 +35,10 @@ class ConnectionHealth final : public QObject {
   ConnectionStability stability() const { return m_stability; }
 
   void overwriteStabilityForInspector(ConnectionStability stability) {
-    // Only allow overriding the connection health stability in dev mode.
     if (Constants::inProduction()) {
-      qFatal << "Illegal invokation";
+      qFatal(
+          "Connection health stability mode can only be overwritten in Dev "
+          "mode!");
     }
     m_stabilityOverwritten = true;
     m_stability = stability;

--- a/src/apps/vpn/mozillavpn.cpp
+++ b/src/apps/vpn/mozillavpn.cpp
@@ -102,7 +102,8 @@ MozillaVPN* s_instance = nullptr;
 bool s_mockFreeTrial = false;
 QString s_updateVersion;
 
-ConnectionHealth::ConnectionStability s_stability = ConnectionHealth::ConnectionStability::Stable;
+ConnectionHealth::ConnectionStability s_stability =
+    ConnectionHealth::ConnectionStability::Stable;
 }  // namespace
 
 // static
@@ -1824,8 +1825,7 @@ MozillaVPN::forceNoSignalConnectionHealth() {
 }
 
 // static
-void MozillaVPN::setUnstableStability()
-{
+void MozillaVPN::setUnstableStability() {
   s_stability = ConnectionHealth::ConnectionStability::Unstable;
 }
 
@@ -2173,8 +2173,8 @@ void MozillaVPN::registerInspectorCommands() {
   InspectorHandler::registerCommand(
       "force_unstable_connection", "Force VPN connection to Unstable", 0,
       [](InspectorHandler*, const QList<QByteArray>&) {
-        // MozillaVPN::instance()->forceUnstableConnectionHealth();
-        MozillaVPN::instance()->setUnstableStability();
+        MozillaVPN::instance()->forceUnstableConnectionHealth();
+        // MozillaVPN::instance()->setUnstableStability();
         return QJsonObject();
       });
 }

--- a/src/apps/vpn/mozillavpn.cpp
+++ b/src/apps/vpn/mozillavpn.cpp
@@ -1807,10 +1807,19 @@ void MozillaVPN::registerNavigationBarButtons() {
 
 // static
 bool MozillaVPN::mockFreeTrial() { return s_mockFreeTrial; }
-//ConnectionStability stability() const { return m_stability; }
-bool MozillaVPN::forceStableConnectionHealth() { return ConnectionHealth::ConnectionStability::Stable; }
-bool MozillaVPN::forceUnstableConnectionHealth() { return ConnectionHealth::ConnectionStability::Unstable; }
-bool MozillaVPN::forceNoSignalConnectionHealth() { return ConnectionHealth::ConnectionStability::NoSignal; }
+// ConnectionStability stability() const { return m_stability; }
+ConnectionHealth::ConnectionStability
+MozillaVPN::forceStableConnectionHealth() {
+  return ConnectionHealth::ConnectionStability::Stable;
+}
+ConnectionHealth::ConnectionStability
+MozillaVPN::forceUnstableConnectionHealth() {
+  return ConnectionHealth::ConnectionStability::Unstable;
+}
+ConnectionHealth::ConnectionStability
+MozillaVPN::forceNoSignalConnectionHealth() {
+  return ConnectionHealth::ConnectionStability::NoSignal;
+}
 
 // static
 void MozillaVPN::registerInspectorCommands() {
@@ -2140,28 +2149,24 @@ void MozillaVPN::registerInspectorCommands() {
       });
 
   InspectorHandler::registerCommand(
-      "force_no_signal_connection",
-      "Force VPN connection to No Signal", 0,
+      "force_no_signal_connection", "Force VPN connection to No Signal", 0,
       [](InspectorHandler*, const QList<QByteArray>&) {
-          MozillaVPN::instance()->forceNoSignalConnectionHealth();
-          return QJsonObject();
+        MozillaVPN::instance()->forceNoSignalConnectionHealth();
+        return QJsonObject();
       });
 
-      InspectorHandler::registerCommand(
-      "force_stable_connection",
-      "Force VPN connection to Stable", 0,
+  InspectorHandler::registerCommand(
+      "force_stable_connection", "Force VPN connection to Stable", 0,
       [](InspectorHandler*, const QList<QByteArray>&) {
-          MozillaVPN::instance()->forceStableConnectionHealth();
-          return QJsonObject();
-
+        MozillaVPN::instance()->forceStableConnectionHealth();
+        return QJsonObject();
       });
 
-      InspectorHandler::registerCommand(
-      "force_unstable_connection",
-      "Force VPN connection to Unstable", 0,
+  InspectorHandler::registerCommand(
+      "force_unstable_connection", "Force VPN connection to Unstable", 0,
       [](InspectorHandler*, const QList<QByteArray>&) {
-          MozillaVPN::instance()->forceUnstableConnectionHealth();
-          return QJsonObject();
+        MozillaVPN::instance()->forceUnstableConnectionHealth();
+        return QJsonObject();
       });
 }
 

--- a/src/apps/vpn/mozillavpn.cpp
+++ b/src/apps/vpn/mozillavpn.cpp
@@ -1807,7 +1807,7 @@ void MozillaVPN::registerNavigationBarButtons() {
 
 // static
 bool MozillaVPN::mockFreeTrial() { return s_mockFreeTrial; }
-// ConnectionStability stability() const { return m_stability; }
+
 ConnectionHealth::ConnectionStability
 MozillaVPN::forceStableConnectionHealth() {
   return ConnectionHealth::ConnectionStability::Stable;

--- a/src/apps/vpn/mozillavpn.cpp
+++ b/src/apps/vpn/mozillavpn.cpp
@@ -1808,24 +1808,6 @@ void MozillaVPN::registerNavigationBarButtons() {
 // static
 bool MozillaVPN::mockFreeTrial() { return s_mockFreeTrial; }
 
-// ConnectionHealth::ConnectionStability
-// MozillaVPN::forceStableConnectionHealth() {
-//   return ConnectionHealth::ConnectionStability::Stable;
-// }
-// ConnectionHealth::ConnectionStability
-// MozillaVPN::forceUnstableConnectionHealth() {
-//   return ConnectionHealth::ConnectionStability::Unstable;
-// }
-// ConnectionHealth::ConnectionStability
-// MozillaVPN::forceNoSignalConnectionHealth() {
-//   return ConnectionHealth::ConnectionStability::NoSignal;
-// }
-
-// static
-// void MozillaVPN::setUnstableStability() {
-//   s_stability = ConnectionHealth::ConnectionStability::Unstable;
-// }
-
 // static
 void MozillaVPN::registerInspectorCommands() {
   InspectorHandler::setConstructorCallback(
@@ -2154,32 +2136,31 @@ void MozillaVPN::registerInspectorCommands() {
       });
 
   InspectorHandler::registerCommand(
-      "force_no_signal_connection", "Force VPN connection to No Signal", 0,
-      [](InspectorHandler*, const QList<QByteArray>&) {
-        MozillaVPN::instance()
-            ->connectionHealth()
-            ->overwriteStabilityForInspector(
-                ConnectionHealth::ConnectionStability::NoSignal);
-        return QJsonObject();
-      });
+      "force_connection_health",
+      "Force VPN connection health stability. Possible values are: stable, "
+      "unstable, nosignal",
+      1, [](InspectorHandler*, const QList<QByteArray>& arguments) {
+        QJsonObject obj;
+        auto stabilityMode = arguments[1];
 
-  InspectorHandler::registerCommand(
-      "force_stable_connection", "Force VPN connection to Stable", 0,
-      [](InspectorHandler*, const QList<QByteArray>&) {
-        MozillaVPN::instance()
-            ->connectionHealth()
-            ->overwriteStabilityForInspector(
-                ConnectionHealth::ConnectionStability::Stable);
-        return QJsonObject();
-      });
-
-  InspectorHandler::registerCommand(
-      "force_unstable_connection", "Force VPN connection to Unstable", 0,
-      [](InspectorHandler*, const QList<QByteArray>&) {
-        MozillaVPN::instance()
-            ->connectionHealth()
-            ->overwriteStabilityForInspector(
-                ConnectionHealth::ConnectionStability::Unstable);
+        if (stabilityMode == "stable") {
+          MozillaVPN::instance()
+              ->connectionHealth()
+              ->overwriteStabilityForInspector(
+                  ConnectionHealth::ConnectionStability::Stable);
+        } else if (stabilityMode == "unstable") {
+          MozillaVPN::instance()
+              ->connectionHealth()
+              ->overwriteStabilityForInspector(
+                  ConnectionHealth::ConnectionStability::Unstable);
+        } else if (stabilityMode == "nosignal") {
+          MozillaVPN::instance()
+              ->connectionHealth()
+              ->overwriteStabilityForInspector(
+                  ConnectionHealth::ConnectionStability::NoSignal);
+        } else {
+          obj["error"] = QString("Please enter a valid stability mode value.");
+        }
         return QJsonObject();
       });
 }

--- a/src/apps/vpn/mozillavpn.cpp
+++ b/src/apps/vpn/mozillavpn.cpp
@@ -101,6 +101,8 @@ Logger logger("MozillaVPN");
 MozillaVPN* s_instance = nullptr;
 bool s_mockFreeTrial = false;
 QString s_updateVersion;
+
+ConnectionHealth::ConnectionStability s_stability = ConnectionHealth::ConnectionStability::Stable;
 }  // namespace
 
 // static
@@ -1822,6 +1824,12 @@ MozillaVPN::forceNoSignalConnectionHealth() {
 }
 
 // static
+void MozillaVPN::setUnstableStability()
+{
+  s_stability = ConnectionHealth::ConnectionStability::Unstable;
+}
+
+// static
 void MozillaVPN::registerInspectorCommands() {
   InspectorHandler::setConstructorCallback(
       [](InspectorHandler* inspectorHandler) {
@@ -2165,7 +2173,8 @@ void MozillaVPN::registerInspectorCommands() {
   InspectorHandler::registerCommand(
       "force_unstable_connection", "Force VPN connection to Unstable", 0,
       [](InspectorHandler*, const QList<QByteArray>&) {
-        MozillaVPN::instance()->forceUnstableConnectionHealth();
+        // MozillaVPN::instance()->forceUnstableConnectionHealth();
+        MozillaVPN::instance()->setUnstableStability();
         return QJsonObject();
       });
 }

--- a/src/apps/vpn/mozillavpn.cpp
+++ b/src/apps/vpn/mozillavpn.cpp
@@ -101,9 +101,6 @@ Logger logger("MozillaVPN");
 MozillaVPN* s_instance = nullptr;
 bool s_mockFreeTrial = false;
 QString s_updateVersion;
-
-ConnectionHealth::ConnectionStability s_stability =
-    ConnectionHealth::ConnectionStability::Stable;
 }  // namespace
 
 // static
@@ -1811,23 +1808,23 @@ void MozillaVPN::registerNavigationBarButtons() {
 // static
 bool MozillaVPN::mockFreeTrial() { return s_mockFreeTrial; }
 
-ConnectionHealth::ConnectionStability
-MozillaVPN::forceStableConnectionHealth() {
-  return ConnectionHealth::ConnectionStability::Stable;
-}
-ConnectionHealth::ConnectionStability
-MozillaVPN::forceUnstableConnectionHealth() {
-  return ConnectionHealth::ConnectionStability::Unstable;
-}
-ConnectionHealth::ConnectionStability
-MozillaVPN::forceNoSignalConnectionHealth() {
-  return ConnectionHealth::ConnectionStability::NoSignal;
-}
+// ConnectionHealth::ConnectionStability
+// MozillaVPN::forceStableConnectionHealth() {
+//   return ConnectionHealth::ConnectionStability::Stable;
+// }
+// ConnectionHealth::ConnectionStability
+// MozillaVPN::forceUnstableConnectionHealth() {
+//   return ConnectionHealth::ConnectionStability::Unstable;
+// }
+// ConnectionHealth::ConnectionStability
+// MozillaVPN::forceNoSignalConnectionHealth() {
+//   return ConnectionHealth::ConnectionStability::NoSignal;
+// }
 
 // static
-void MozillaVPN::setUnstableStability() {
-  s_stability = ConnectionHealth::ConnectionStability::Unstable;
-}
+// void MozillaVPN::setUnstableStability() {
+//   s_stability = ConnectionHealth::ConnectionStability::Unstable;
+// }
 
 // static
 void MozillaVPN::registerInspectorCommands() {
@@ -2159,22 +2156,30 @@ void MozillaVPN::registerInspectorCommands() {
   InspectorHandler::registerCommand(
       "force_no_signal_connection", "Force VPN connection to No Signal", 0,
       [](InspectorHandler*, const QList<QByteArray>&) {
-        MozillaVPN::instance()->forceNoSignalConnectionHealth();
+        MozillaVPN::instance()
+            ->connectionHealth()
+            ->overwriteStabilityForInspector(
+                ConnectionHealth::ConnectionStability::NoSignal);
         return QJsonObject();
       });
 
   InspectorHandler::registerCommand(
       "force_stable_connection", "Force VPN connection to Stable", 0,
       [](InspectorHandler*, const QList<QByteArray>&) {
-        MozillaVPN::instance()->forceStableConnectionHealth();
+        MozillaVPN::instance()
+            ->connectionHealth()
+            ->overwriteStabilityForInspector(
+                ConnectionHealth::ConnectionStability::Stable);
         return QJsonObject();
       });
 
   InspectorHandler::registerCommand(
       "force_unstable_connection", "Force VPN connection to Unstable", 0,
       [](InspectorHandler*, const QList<QByteArray>&) {
-        MozillaVPN::instance()->forceUnstableConnectionHealth();
-        // MozillaVPN::instance()->setUnstableStability();
+        MozillaVPN::instance()
+            ->connectionHealth()
+            ->overwriteStabilityForInspector(
+                ConnectionHealth::ConnectionStability::Unstable);
         return QJsonObject();
       });
 }

--- a/src/apps/vpn/mozillavpn.cpp
+++ b/src/apps/vpn/mozillavpn.cpp
@@ -1807,6 +1807,10 @@ void MozillaVPN::registerNavigationBarButtons() {
 
 // static
 bool MozillaVPN::mockFreeTrial() { return s_mockFreeTrial; }
+//ConnectionStability stability() const { return m_stability; }
+bool MozillaVPN::forceStableConnectionHealth() { return ConnectionHealth::ConnectionStability::Stable; }
+bool MozillaVPN::forceUnstableConnectionHealth() { return ConnectionHealth::ConnectionStability::Unstable; }
+bool MozillaVPN::forceNoSignalConnectionHealth() { return ConnectionHealth::ConnectionStability::NoSignal; }
 
 // static
 void MozillaVPN::registerInspectorCommands() {
@@ -2133,6 +2137,31 @@ void MozillaVPN::registerInspectorCommands() {
       [](InspectorHandler*, const QList<QByteArray>&) {
         MozillaVPN::instance()->controller()->quit();
         return QJsonObject();
+      });
+
+  InspectorHandler::registerCommand(
+      "force_no_signal_connection",
+      "Force VPN connection to No Signal", 0,
+      [](InspectorHandler*, const QList<QByteArray>&) {
+          MozillaVPN::instance()->forceNoSignalConnectionHealth();
+          return QJsonObject();
+      });
+
+      InspectorHandler::registerCommand(
+      "force_stable_connection",
+      "Force VPN connection to Stable", 0,
+      [](InspectorHandler*, const QList<QByteArray>&) {
+          MozillaVPN::instance()->forceStableConnectionHealth();
+          return QJsonObject();
+
+      });
+
+      InspectorHandler::registerCommand(
+      "force_unstable_connection",
+      "Force VPN connection to Unstable", 0,
+      [](InspectorHandler*, const QList<QByteArray>&) {
+          MozillaVPN::instance()->forceUnstableConnectionHealth();
+          return QJsonObject();
       });
 }
 

--- a/src/apps/vpn/mozillavpn.h
+++ b/src/apps/vpn/mozillavpn.h
@@ -209,6 +209,10 @@ class MozillaVPN final : public App {
   static QString appVersionForUpdate();
   static bool mockFreeTrial();
 
+  static bool forceStableConnectionHealth();
+  static bool forceUnstableConnectionHealth();
+  static bool forceNoSignalConnectionHealth();
+
  private:
   void maybeStateMain();
 

--- a/src/apps/vpn/mozillavpn.h
+++ b/src/apps/vpn/mozillavpn.h
@@ -214,6 +214,9 @@ class MozillaVPN final : public App {
   static ConnectionHealth::ConnectionStability forceUnstableConnectionHealth();
   static ConnectionHealth::ConnectionStability forceNoSignalConnectionHealth();
 
+
+  static void setUnstableStability();
+
  private:
   void maybeStateMain();
 

--- a/src/apps/vpn/mozillavpn.h
+++ b/src/apps/vpn/mozillavpn.h
@@ -12,7 +12,6 @@
 
 #include "app.h"
 #include "authenticationlistener.h"
-#include "connectionhealth.h"
 #include "errorhandler.h"
 #include "externalophandler.h"
 #include "frontend/navigator.h"
@@ -209,13 +208,6 @@ class MozillaVPN final : public App {
 
   static QString appVersionForUpdate();
   static bool mockFreeTrial();
-
-  static ConnectionHealth::ConnectionStability forceStableConnectionHealth();
-  static ConnectionHealth::ConnectionStability forceUnstableConnectionHealth();
-  static ConnectionHealth::ConnectionStability forceNoSignalConnectionHealth();
-
-
-  static void setUnstableStability();
 
  private:
   void maybeStateMain();

--- a/src/apps/vpn/mozillavpn.h
+++ b/src/apps/vpn/mozillavpn.h
@@ -12,6 +12,7 @@
 
 #include "app.h"
 #include "authenticationlistener.h"
+#include "connectionhealth.h"
 #include "errorhandler.h"
 #include "externalophandler.h"
 #include "frontend/navigator.h"
@@ -209,9 +210,9 @@ class MozillaVPN final : public App {
   static QString appVersionForUpdate();
   static bool mockFreeTrial();
 
-  static bool forceStableConnectionHealth();
-  static bool forceUnstableConnectionHealth();
-  static bool forceNoSignalConnectionHealth();
+  static ConnectionHealth::ConnectionStability forceStableConnectionHealth();
+  static ConnectionHealth::ConnectionStability forceUnstableConnectionHealth();
+  static ConnectionHealth::ConnectionStability forceNoSignalConnectionHealth();
 
  private:
   void maybeStateMain();


### PR DESCRIPTION
## Description

Add a new inspector command to override connection health stability: stable, unstable and no_signal in mozillavpn.cpp which will be used in functional tests and by QA.

## Reference

    https://mozilla-hub.atlassian.net/browse/VPN-4406

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
