### PR TITLE
VPN-4535: Add metric for web purchases

### DIFF
--- a/src/apps/vpn/mozillavpn.cpp
+++ b/src/apps/vpn/mozillavpn.cpp
@@ -37,6 +37,7 @@
 #include "productshandler.h"
 #include "profileflow.h"
 #include "purchasehandler.h"
+#include "purchaseiaphandler.h"
 #include "qmlengineholder.h"
 #include "releasemonitor.h"
 #include "serveri18n.h"
@@ -197,15 +198,20 @@ MozillaVPN::MozillaVPN() : App(nullptr), m_private(new MozillaVPNPrivate()) {
   if (!Feature::get(Feature::Feature_webPurchase)->isSupported()) {
     ProductsHandler::createInstance();
   }
+
+#if defined(MZ_ANDROID) || defined(MZ_IOS)
+  PurchaseHandler* purchaseHandler = PurchaseIAPHandler::createInstance();
+  connect(purchaseHandler, &PurchaseIAPHandler::subscriptionCompleted, this,
+          &MozillaVPN::subscriptionCompleted);
+#else
   PurchaseHandler* purchaseHandler = PurchaseHandler::createInstance();
+#endif
   connect(purchaseHandler, &PurchaseHandler::subscriptionStarted, this,
           &MozillaVPN::subscriptionStarted);
   connect(purchaseHandler, &PurchaseHandler::subscriptionFailed, this,
           &MozillaVPN::subscriptionFailed);
   connect(purchaseHandler, &PurchaseHandler::subscriptionCanceled, this,
           &MozillaVPN::subscriptionCanceled);
-  connect(purchaseHandler, &PurchaseHandler::subscriptionCompleted, this,
-          &MozillaVPN::subscriptionCompleted);
   connect(purchaseHandler, &PurchaseHandler::restoreSubscriptionStarted, this,
           &MozillaVPN::restoreSubscriptionStarted);
   connect(purchaseHandler, &PurchaseHandler::alreadySubscribed, this,

--- a/src/apps/vpn/purchasewebhandler.cpp
+++ b/src/apps/vpn/purchasewebhandler.cpp
@@ -44,6 +44,8 @@ void PurchaseWebHandler::startSubscription(const QString&) {
           &MozillaVPN::abortAuthentication);
   connect(taskAuthenticate, &TaskAuthenticate::authenticationCompleted, vpn,
           &MozillaVPN::completeAuthentication);
+  connect(taskAuthenticate, &TaskAuthenticate::authenticationCompleted, this,
+          &PurchaseWebHandler::subscriptionDone);
 
   TaskScheduler::scheduleTask(taskAuthenticate);
 }
@@ -67,4 +69,10 @@ void PurchaseWebHandler::nativeRegisterProducts() {
   logger.error()
       << "nativeRegisterProducts should not be called for PurchaseWebHandler";
   Q_ASSERT(false);
+}
+
+void PurchaseWebHandler::subscriptionDone(const QByteArray& json,
+                                          const QString& token) {
+  // This calls a telemetry event recording
+  emit subscriptionCompleted();
 }

--- a/src/apps/vpn/purchasewebhandler.h
+++ b/src/apps/vpn/purchasewebhandler.h
@@ -19,6 +19,9 @@ class PurchaseWebHandler final : public PurchaseHandler {
   void nativeRegisterProducts() override;
   void startSubscription(const QString& productIdentifier) override;
   void startRestoreSubscription() override;
+
+ private slots:
+  void subscriptionDone(const QByteArray& json, const QString& token);
 };
 
 #endif  // PURCHASEWEBHANDLER_H


### PR DESCRIPTION
## Description

A signal of `subscriptionCompleted` causes us to record this metric in the telemetry file. It was not being triggered by web purchases, in part because of the two different routes to calling `completeActivation`:
- For Android/iOS IAP, a completed IAP calls `MozillaVPN::subscriptionCompleted`, which in turn calls `completeActivation`. 
- Successful web subscriptions call `MozillaVPN::completeAuthentication`, which also calls `completeActivation`. 

Thus, we need to call `subscriptionCompleted` in the Telemetry file (which happens for any `PurchaseHandler`'s `subscriptionCompleted` without hitting `MozillaVPN::subscriptionCompleted`. The work in `mozillavpn.cpp` is to make this more specific for the IAP case.

I've tested this for both iOS and macOS (web):
- Signing into an account with an active subscription
- Fresh subscription
- Opening the app when an account is already signed in

In all cases, this seems to work as expected, with no unexpected side effects that I can find.

## Reference

https://mozilla-hub.atlassian.net/browse/VPN-4535

## Checklist
    
- [X] My code follows the style guidelines for this project
- [X] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [X] I have performed a self review of my own code
- [X] I have commented my code PARTICULARLY in hard to understand areas
- [X] I have added thorough tests where needed
