### PR TITLE
Fix double leading / in mozillavpn.json path property

### DIFF
--- a/extension/CMakeLists.txt
+++ b/extension/CMakeLists.txt
@@ -20,7 +20,7 @@ set_property(TARGET mozillavpnnp PROPERTY
 ## Handle installation by platform.
 if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
     if(NOT DEFINED WEBEXT_INSTALL_LIBDIR)
-        set(WEBEXT_INSTALL_LIBDIR ${CMAKE_INSTALL_LIBDIR})
+        set(WEBEXT_INSTALL_LIBDIR ${CMAKE_INSTALL_FULL_LIBDIR})
     endif()
 
     install(PROGRAMS $<TARGET_FILE:mozillavpnnp> DESTINATION ${WEBEXT_INSTALL_LIBDIR}/mozillavpn)

--- a/extension/manifests/linux/mozillavpn.json.in
+++ b/extension/manifests/linux/mozillavpn.json.in
@@ -1,7 +1,7 @@
 {
   "name": "mozillavpn",
   "description": "A fast, secure and easy to use VPN. Built by the makers of Firefox. ",
-  "path": "/@WEBEXT_INSTALL_LIBDIR@/mozillavpn/mozillavpnnp",
+  "path": "@WEBEXT_INSTALL_LIBDIR@/mozillavpn/mozillavpnnp",
   "type": "stdio",
   "allowed_extensions": [ "vpn@mozilla.org", "@testpilot-containers" ]
 }

--- a/linux/debian/rules
+++ b/linux/debian/rules
@@ -21,7 +21,7 @@ endif
 	dh $@ --with=systemd --warn-missing
 
 override_dh_auto_configure:
-	dh_auto_configure -- -DWEBEXT_INSTALL_LIBDIR=lib -DBUILD_ID=$(DEB_VERSION) -DBUILD_TESTING=OFF
+	dh_auto_configure -- -DWEBEXT_INSTALL_LIBDIR=/lib -DBUILD_ID=$(DEB_VERSION) -DBUILD_TESTING=OFF
 
 override_dh_installdocs:
 


### PR DESCRIPTION
## Description

Change `WEBEXT_INSTALL_LIBDIR` to be consistently an absolute path.

Currently uses disagree on whether it is meant to be absolute or relative to /

From linux/mozillavpn.spec:
```
%cmake -DWEBEXT_INSTALL_LIBDIR=/usr/lib -DCMAKE_INSTALL_SYSCONFDIR=/etc -DBUILD_TESTING=OFF
```

From linux/debian/rules:
```
	dh_auto_configure -- -DWEBEXT_INSTALL_LIBDIR=lib -DBUILD_ID=$(DEB_VERSION) -DBUILD_TESTING=OFF
```

This caused rpm to generate paths like `//usr/lib/mozillavpn/mozillavpnnp` which in turn cause Firefox to not find the mozillavpnnp binary.

Using an absolute path be default for `WEBEXT_INSTALL_LIBDIR`, as it is easier when variables point to install dirs in build processes, i.e. `/${lib}` is easier than stripping a leading / from `%{_libdir}`.

## Reference

None

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
