### PR TITLE
VPN-4586 Android Dev-Containers v2

### DIFF
--- a/.devcontainer/android_arm64/.devcontainer.json
+++ b/.devcontainer/android_arm64/.devcontainer.json
@@ -6,7 +6,8 @@
     "containerEnv": {
         "CMAKE_C_COMPILER_LAUNCHER": "ccache",
         "CMAKE_CXX_COMPILER_LAUNCHER": "ccache",
-        "CMAKE_EXPORT_COMPILE_COMMANDS":"true"
+        "CMAKE_EXPORT_COMPILE_COMMANDS":"true",
+        "IS_DEV_CONTAINER":"ANDROID_ARM64"
     },
 
     "mounts": [

--- a/.devcontainer/android_x86_64/.devcontainer.json
+++ b/.devcontainer/android_x86_64/.devcontainer.json
@@ -5,7 +5,8 @@
     "containerEnv": {
         "CMAKE_C_COMPILER_LAUNCHER": "ccache",
         "CMAKE_CXX_COMPILER_LAUNCHER": "ccache",
-        "CMAKE_EXPORT_COMPILE_COMMANDS":"true"
+        "CMAKE_EXPORT_COMPILE_COMMANDS":"true",
+        "IS_DEV_CONTAINER":"ANDROID_x86"
     },
 	"customizations": {
 		// Configure properties specific to VS Code.

--- a/.devcontainer/wasm/.devcontainer.json
+++ b/.devcontainer/wasm/.devcontainer.json
@@ -6,7 +6,8 @@
     "containerEnv": {
         "CMAKE_C_COMPILER_LAUNCHER": "ccache",
         "CMAKE_CXX_COMPILER_LAUNCHER": "ccache",
-        "CMAKE_EXPORT_COMPILE_COMMANDS":"true"
+        "CMAKE_EXPORT_COMPILE_COMMANDS":"true",
+        "IS_DEV_CONTAINER":"WASM"
     },
 	"customizations": {
 		// Configure properties specific to VS Code.

--- a/.dictionary
+++ b/.dictionary
@@ -174,6 +174,7 @@ rlottie
 runtime
 sdk
 serverData
+servicedesk
 settingHolder
 shader
 shaders

--- a/.dictionary
+++ b/.dictionary
@@ -1,5 +1,6 @@
 personal_ws-1.1 en 188 utf-8
 APIs
+amd
 Adblock
 AdjustSdk
 Affero
@@ -98,6 +99,7 @@ cpp
 de
 deeplink
 determing
+dockerfile
 dev
 dll
 embeddable
@@ -114,6 +116,7 @@ frontend
 gobject
 golang
 gps
+gradle
 iap
 idfv
 ie
@@ -135,6 +138,7 @@ makefiles
 md
 miniconda
 mozilla
+Mozillians
 mozillavpn
 mozillavpnbionic
 multicast
@@ -197,6 +201,7 @@ wgconf
 wgutils
 wifi
 wireguard
+WSA
 xcode
 xcodes
 xcodeproj

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+# Required to Build Release Builds for iOS & Android 
+## export MVPN_IOS_ADJUST_TOKEN=abcdefg
+## export MVPN_ANDROID_ADJUST_TOKEN=abcdefg
+
+# If you want crashreporting to work
+## export SENTRY_DSN="https://<12344>.ingest.sentry.io/1234"
+## export SENTRY_ENVELOPE_ENDPOINT="https://<1234>.ingest.sentry.io/api/<1234>/envelope/?sentry_key=hello!"
+
+
+# If you want to run Static analysis at somepoint
+##export CMAKE_EXPORT_COMPILE_COMMANDS=true
+
+if [ -n "$IS_DEV_CONTAINER" ]; then
+  # All Default-Dev-Containers set this, feel free to devide this further
+  # if you want to have per container .env
+
+else 
+  # Set all Your Host env-need's here c: 
+
+# --- MacOS related enviroment variables ---
+# These are required for iOS compile Script:
+## export QT_MACOS_BIN=/Users/<name>/Qt/6.2.4/macos
+## export QT_IOS_BIN=~/Code/qt_ios/6.2.3/ios/bin
+
+# Required to build Macos:
+## export SDKROOT="/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.3.sdk"
+
+# Set This if you want cmake to help you with codesigning.
+## export MACOS_CODESIGN_ID="Apple Development: yourmail@mozilla.com"
+
+
+# --- Android related enviroment variables ---
+# These are required for androic/cmake compile Script:
+## export JAVA_HOME=/Applications/Android\ Studio.app/Contents/jre/Contents/Home # 
+## export ANDROID_SDK_ROOT=/Users/$USER/Library/Android/sdk
+## export ANDROID_NDK_HOME=/Users/$USER/Library/Android/sdk/ndk/21.1.6352462
+## export ANDROID_NDK_ROOT=$ANDROID_NDK_HOME
+## export QT_HOST_PATH=/Users/$USER/Qt/6.2.4/<your host folder>
+##export PATH=~/Qt/6.2.4/macos/bin:$PATH
+## export PATH=$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/<YOUR HOST TOOLCHAIN>/bin:$PATH
+
+# Enable SCCache for speed:
+## export RUSTC_WRAPPER=/opt/homebrew/bin/sccache
+## export CMAKE_C_COMPILER_LAUNCHER=/opt/homebrew/bin/sccache
+## export CMAKE_CXX_COMPILER_LAUNCHER=/opt/homebrew/bin/sccache
+
+fi
+
+

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,9 @@ qtglean/Cargo.lock
 # Translation pipeline
 addon_ts/
 
+# Cmake Presets
+# https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html
+CMakeUserPresets.json
 # CMake build artifacts
 cmake_install.cmake
 CMakeCache.txt

--- a/README.md
+++ b/README.md
@@ -397,36 +397,8 @@ for iOS devices, or select any of the simulation targets when building for the s
 
 ### How to build from source code for Android
 
-1. You need to install go >= v1.18. If you don't have it done already, download
-it from the [official website](https://golang.org/dl/).
+Moved: See [Wiki Article](https://github.com/mozilla-mobile/mozilla-vpn-client/wiki/android)
 
-2. Follow the [Getting started](https://doc.qt.io/qt-6/android-getting-started.html) page.
-
-3. Set the `QT_HOST_PATH` environment variable to point to the location of the `androiddeployqt` tool  -- minus the `/bin` suffix i.e. if `$(which androiddeployqt)` is `$HOME/Qt/6.2.4/gcc_64/bin/androiddeployqt`, `QT_HOST_PATH` is `$HOME/Qt/6.2.4/gcc_64/`.
-
-4. Set the `ANDROID_SDK_ROOT` and `ANDROID_NDK_ROOT` environment variables,
-to point to the Android SDK and NDK installation directories. Required NDK versions: 23.1.7779620 and 21.0.6113669.
-
-5. Add the Android NDK llvm prebuilt tools to your `PATH`. These are located under the Android NDK installation
-directory on `${ANDROID_NDK_ROOT}/toolchains/llvm/prebuilt/*/bin`.
-
-6. Install the Rust Android targets `rustup target add x86_64-linux-android i686-linux-android armv7-linux-androideabi aarch64-linux-android`.
-
-7. Build the apk
-```bash
-./scripts/android/cmake.sh -d </path/to/Qt6/> -A <architecture> <debug|release>
-```
-Add the Adjust SDK token with `-a | --adjust <adjust_token>`.
-
-Valid architecture values: `x86`, `x86_64`, `armeabi-v7a` `arm64-v8a`, by default it will use all.
-
-8. The apk will be located in
-`.tmp/src/android-build/build/outputs/apk/debug/android-build-debug.apk`
-
-9. Install with adb on device/emulator
-```bash
-adb install .tmp/src/android-build/build/outputs/apk/debug/android-build-debug.apk
-```
 
 ### How to build from source code for Windows
 

--- a/docs/building/android.md
+++ b/docs/building/android.md
@@ -46,7 +46,7 @@ In case you want to purge all build things do `rm .tmp/*` inside the container.
 6. Good Luck!
 
 ## Archive: Building on your host System. 
-> This part of the guide is no longer maintained and might be out of date - Most accurate tip rn is to [Read the dockerfile](https://github.com/mozilla-mobile/mozilla-vpn-client/blob/main/taskcluster/docker/android-qt6-build/Dockerfile) to see how we setup the build enviroment. 
+> This part of the guide is no longer maintained and might be out of date - Most accurate place for that is to [Read the dockerfile](https://github.com/mozilla-mobile/mozilla-vpn-client/blob/main/taskcluster/docker/android-qt6-build/Dockerfile) to see how we setup the build environment. 
 
 1. You need to install go >= v1.18. If you don't have it done already, download
 it from the [official website](https://golang.org/dl/).

--- a/docs/building/android.md
+++ b/docs/building/android.md
@@ -21,7 +21,7 @@
     - `npm run android_x86_64:build`
     - `npm run android_arm64:build`
     
-7. You should now have a `debug/` folder containg *.apk
+7. You should now have a `debug/` folder containing *.apk
 
 ## Cleaning: 
 In case you want to purge all build things do `rm .tmp/*` inside the container. 

--- a/docs/building/android.md
+++ b/docs/building/android.md
@@ -3,7 +3,7 @@
 
 ## Building the Client (using Dev-Containers) 
 
-1. You need Docker (or compatible) with the ability to run Linux/AMD64 images. 
+1. You need Docker (or compatible) with the ability to run Linux/AMD64 images. Checkout the Setup Section in the [Dev-Container Wiki](https://github.com/mozilla-mobile/mozilla-vpn-client/wiki/dev-containers#setup)
 
 2. Make sure to run `npm install` 
 

--- a/docs/building/android.md
+++ b/docs/building/android.md
@@ -7,21 +7,25 @@
 
 2. Make sure to run `npm install` 
 
-3. We offer 2 dev-image configs: 
+3. We offer 2 dev-images: 
     - Android-x86_64 - If you are on Intel/AMD and want to run on an Emulator/Chromebook/WSA
     - Android-Arm64 - If you are on an M1+Emulator or want to run this on a real device. 
 
 4. Build a dev container:
     - `npm run android_x86_64:devcontainer:build` 
-    - `npm run android_arm64:devcontainer:build` 
+    - `npm run android_arm64:devcontainer:build`
+
     This will take a while, grab a coffee! 
 5. (Optional): [If you want to use that container with VS-Code learn more](https://github.com/mozilla-mobile/mozilla-vpn-client/wiki/dev-containers)
 6. Trigger a Build directly from the Terminal: 
     - `npm run android_x86_64:build`
     - `npm run android_arm64:build`
     
-7. You should now have a `debug/` folder containg an *.apk
+7. You should now have a `debug/` folder containg *.apk
 
+## Cleaning: 
+In case you want to purge all build things do `rm .tmp/*` inside the container. 
+**Do not remove the .tmp folder** as that is a volume. 
 
 ## Installing on a Device / Emulator
 1. Install android command-line tools either:

--- a/docs/building/android.md
+++ b/docs/building/android.md
@@ -1,0 +1,76 @@
+
+# Android 
+
+## Building the Client (using Dev-Containers) 
+
+1. You need Docker (or compatible) with the ability to run Linux/AMD64 images. 
+
+2. Make sure to run `npm install` 
+
+3. We offer 2 dev-image configs: 
+    - Android-x86_64 - If you are on Intel/AMD and want to run on an Emulator/Chromebook/WSA
+    - Android-Arm64 - If you are on an M1+Emulator or want to run this on a real device. 
+
+4. Build a dev container:
+    - `npm run android_x86_64:devcontainer:build` 
+    - `npm run android_arm64:devcontainer:build` 
+    This will take a while, grab a coffee! 
+5. (Optional): [If you want to use that container with VS-Code learn more](https://github.com/mozilla-mobile/mozilla-vpn-client/wiki/dev-containers)
+6. Trigger a Build directly from the Terminal: 
+    - `npm run android_x86_64:build`
+    - `npm run android_arm64:build`
+    
+7. You should now have a `debug/` folder containg an *.apk
+
+
+## Installing on a Device / Emulator
+1. Install android command-line tools either:
+    - `brew install --cask android-platform-tools`
+    - `<ANDROID_SDK_PATH>/cmdline-tools/latest/bin/sdkmanager --install "plattform-tools;version`
+    - Download [here](https://developer.android.com/tools/releases/platform-tools)
+
+2. Install 
+    - Make sure the Device is visible `adb devices` should list your device/emulator
+    - `adb install path/to/the.apk`
+
+## Debugging 
+1. Install Android Studio
+2. Open the mozilla-vpn/android folder as a project. 
+3. Wait for the gradle Sync. 
+4. Open the app. 
+5. In android Studio to go Run->Attach to Process-> Select `org.mozilla.firefox.vpn.debug`
+6. Good Luck!
+
+## Archive: Building on your host System. 
+> This part of the guide is no longer maintained and might be out of date - Most accurate tip rn is to [Read the dockerfile](https://github.com/mozilla-mobile/mozilla-vpn-client/blob/main/taskcluster/docker/android-qt6-build/Dockerfile) to see how we setup the build enviroment. 
+
+1. You need to install go >= v1.18. If you don't have it done already, download
+it from the [official website](https://golang.org/dl/).
+
+2. Follow the [Getting started](https://doc.qt.io/qt-6/android-getting-started.html) page.
+
+3. Set the `QT_HOST_PATH` environment variable to point to the location of the `androiddeployqt` tool  -- minus the `/bin` suffix i.e. if `$(which androiddeployqt)` is `$HOME/Qt/6.2.4/gcc_64/bin/androiddeployqt`, `QT_HOST_PATH` is `$HOME/Qt/6.2.4/gcc_64/`.
+
+4. Set the `ANDROID_SDK_ROOT` and `ANDROID_NDK_ROOT` environment variables,
+to point to the Android SDK and NDK installation directories. Required NDK versions: 23.1.7779620 and 21.0.6113669.
+
+5. Add the Android NDK llvm prebuilt tools to your `PATH`. These are located under the Android NDK installation
+directory on `${ANDROID_NDK_ROOT}/toolchains/llvm/prebuilt/*/bin`.
+
+6. Install the Rust Android targets `rustup target add x86_64-linux-android i686-linux-android armv7-linux-androideabi aarch64-linux-android`.
+
+7. Build the apk
+```bash
+./scripts/android/cmake.sh -d </path/to/Qt6/> -A <architecture> <debug|release>
+```
+Add the Adjust SDK token with `-a | --adjust <adjust_token>`.
+
+Valid architecture values: `x86`, `x86_64`, `armeabi-v7a` `arm64-v8a`, by default it will use all.
+
+8. The apk will be located in
+`.tmp/src/android-build/build/outputs/apk/debug/android-build-debug.apk`
+
+9. Install with adb on device/emulator
+```bash
+adb install .tmp/src/android-build/build/outputs/apk/debug/android-build-debug.apk
+```

--- a/docs/dev-containers.md
+++ b/docs/dev-containers.md
@@ -6,7 +6,7 @@ Dev-Containers are a small experiment, they allow you to run our CI docker Image
 - Node
 - A docker Compatible Container engine ([rancher](https://rancherdesktop.io/), [colima](https://github.com/abiosoft/colima), [podman](https://podman-desktop.io/))
 - For simplicity we will continue with [Docker Desktop](https://www.docker.com/products/docker-desktop/)
-> Note: Mozillians: Get a licence in servicedesk!
+> Note: Mozillians: Get a license in servicedesk!
 - Install With Recommended Settings. 
 - (In case you are running on an M1 Mac)
   - Go to Docker Settings -> "Features in development" 
@@ -22,7 +22,7 @@ CONTAINER ID   IMAGE                       COMMAND                  CREATED     
 
 ```
 
-- Optional: Install reccomended VS-Code plugins:
+- Optional: Install the recommended VS-Code plugins:
   - [VS-Code Remote Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
   - [VS-Code Docker](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-docker)
 

--- a/docs/dev-containers.md
+++ b/docs/dev-containers.md
@@ -64,24 +64,38 @@ Should just work / or give you the same error as in CI.
 Currently all Tasks are probably writing to the workspace-folder, which is mounted on the Host's OS. Unless you are running this on Linux, this is very costly. 
 
 ### Q: Get a Container Engine On MacOS: 
-Given that docker-desktop is not on option due to it's license -  big fan of [colima](https://github.com/abiosoft/colima). 
-```
-brew install colima
-# Feel free to adjust this to your specs:
-colima start --cpu 12 \
-             --memory 32 \
-             --disk 40 \
-             --aarch x86_64
+- Grab [Docker Desktop](https://www.docker.com/products/docker-desktop/) (Mozillians: Get a Licence in Servicedesk!)
+- Install With Recommended Settings
+- If on M1
+  - Go to Docker Settings -> "Features in development" 
+  - Enable "Use Rosetta for x86/amd64 emulation"
+TODO: ADD IMAGES
 
-# In case of an m1 Mac, you can use rosetta to help
-# This requires MacOS 13
-colima start --vm-type vz --vz-rosetta -m 32 -d 40  --cpu 12
 
-```
-In case colima at some point uses too much storage, feel free to nuke the vm with `colima delete` and re-create with colima start. 
 
-### Q: (M1) - My vscode consumes all i/o to do sig-checks: 
+
+
+### Q: (M1) - Vscode consumes all i/o to do sig-checks: 
 If you feel fancy, you can disable them, or wait until it's done. 
 ```
 "extensions.verifySignature": false
+```
+
+### How can i quickly run something in a container?
+Step 1: 
+Get the Container ID using `docker ps`
+```
+docker ps
+CONTAINER ID   IMAGE                       COMMAND                  CREATED          STATUS          PORTS     NAMES
+584389fe6cc2   cuddlebuild:android-arm64   "/bin/sh -c 'echo Co…"   26 minutes ago   Up 26 minutes             sweet_franklin
+```
+
+The Container ID of the container i want is `584389fe6cc2` - therefore you can now run for example:
+
+```
+docker exec -it 584389fe6cc2 watch ccache -s
+```
+or to get an interactive shell: 
+```
+docker exec -it 584389fe6cc2 bash
 ```

--- a/docs/dev-containers.md
+++ b/docs/dev-containers.md
@@ -66,7 +66,7 @@ Should just work / or give you the same error as in CI.
 Currently all Tasks are probably writing to the workspace-folder, which is mounted on the Host's OS. Unless you are running this on Linux, this is very costly. 
 
 ### Q: Get a Container Engine On MacOS: 
-- Grab [Docker Desktop](https://www.docker.com/products/docker-desktop/) (Mozillians: Get a Licence in Servicedesk!)
+- Grab [Docker Desktop](https://www.docker.com/products/docker-desktop/) (Mozillians: Get a licence in servicedesk!)
 - Install With Recommended Settings
 - If on M1
   - Go to Docker Settings -> "Features in development" 

--- a/docs/dev-containers.md
+++ b/docs/dev-containers.md
@@ -2,13 +2,30 @@
 
 Dev-Containers are a small experiment, they allow you to run our CI docker Images locally. 
 
-## Requirements: 
+## Setup: 
 - Node
-- A Docker compatible Container Engine: 
-    - docker, podman, colima, rancher) 
-    - MacOS users see Q/A
-    - VS-Code Extension: [Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
-    
+- A docker Compatible Container engine ([rancher](https://rancherdesktop.io/), [colima](https://github.com/abiosoft/colima), [podman](https://podman-desktop.io/))
+- For simplicity we will continue with [Docker Desktop](https://www.docker.com/products/docker-desktop/)
+> Note: Mozillians: Get a licence in servicedesk!
+- Install With Recommended Settings. 
+- (In case you are running on an M1 Mac)
+  - Go to Docker Settings -> "Features in development" 
+  - Enable "Use Rosetta for x86/amd64 emulation"
+
+![Screenshot Of docker setting](https://user-images.githubusercontent.com/9611612/233135351-563d42bb-8d5c-44c2-acf4-61d04a6354d0.png)
+
+- If docker was loaded correctly, open new terminal and run `docker ps`. Everything is setup correctly if the output looks similar to: 
+
+```bash 
+(base) basti@MBP-von-Basti ~ % docker ps
+CONTAINER ID   IMAGE                       COMMAND                  CREATED       STATUS       PORTS     NAMES
+
+```
+
+- Optional: Install reccomended VS-Code plugins:
+  - [VS-Code Remote Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
+  - [VS-Code Docker](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-docker)
+
  
 
 ## Example Build using CLI only: 
@@ -64,24 +81,6 @@ Should just work / or give you the same error as in CI.
 ## Help Section 
 ### Q: Why is it slow?
 Currently all Tasks are probably writing to the workspace-folder, which is mounted on the Host's OS. Unless you are running this on Linux, this is very costly. 
-
-### Q: Get a Container Engine On MacOS: 
-- Grab [Docker Desktop](https://www.docker.com/products/docker-desktop/) (Mozillians: Get a licence in servicedesk!)
-- Install With Recommended Settings
-- If on M1
-  - Go to Docker Settings -> "Features in development" 
-  - Enable "Use Rosetta for x86/amd64 emulation"
-
-![Screenshot Of docker setting](https://user-images.githubusercontent.com/9611612/233135351-563d42bb-8d5c-44c2-acf4-61d04a6354d0.png)
-- If Docker was loaded correctly, in a new terminal `docker ps` should not error and instead show something similar to: 
-
-```bash 
-(base) basti@MBP-von-Basti ~ % docker ps
-CONTAINER ID   IMAGE                       COMMAND                  CREATED       STATUS       PORTS     NAMES
-
-```
-
-
 
 
 ### Q: (M1) - Vscode consumes all i/o to do sig-checks: 

--- a/docs/dev-containers.md
+++ b/docs/dev-containers.md
@@ -58,6 +58,8 @@ therefore running a build like
 ```
 Should just work / or give you the same error as in CI. 
 
+![Screen_Recording_Of_Going_Into_VS_CODE](https://user-images.githubusercontent.com/9611612/233138266-4dd49973-0474-44c3-84fc-060dc19716b3.gif)
+
 
 ## Help Section 
 ### Q: Why is it slow?
@@ -69,8 +71,15 @@ Currently all Tasks are probably writing to the workspace-folder, which is mount
 - If on M1
   - Go to Docker Settings -> "Features in development" 
   - Enable "Use Rosetta for x86/amd64 emulation"
-TODO: ADD IMAGES
 
+![Screenshot Of docker setting](https://user-images.githubusercontent.com/9611612/233135351-563d42bb-8d5c-44c2-acf4-61d04a6354d0.png)
+- If Docker was loaded correctly, in a new terminal `docker ps` should not error and instead show something similar to: 
+
+```bash 
+(base) basti@MBP-von-Basti ~ % docker ps
+CONTAINER ID   IMAGE                       COMMAND                  CREATED       STATUS       PORTS     NAMES
+
+```
 
 
 

--- a/package.json
+++ b/package.json
@@ -6,15 +6,15 @@
     "android_arm64:build": "devcontainer exec --id-label=\"arch=android_arm64\" --workspace-folder . --override-config ./.devcontainer/android_arm64/.devcontainer.json ./scripts/android/cmake.sh -d",
     "android_arm64:devcontainer:up": "devcontainer up --id-label=\"arch=android_arm64\" --workspace-folder . --override-config ./.devcontainer/android_arm64/.devcontainer.json",
     "android_arm64:devcontainer:fresh": "devcontainer up  --id-label=\"arch=android_arm64\" --workspace-folder . --override-config ./.devcontainer/android_arm64/.devcontainer.json --remove-existing-container",
-    "android_arm64:devcontainer:build": "devcontainer build --image-name=\"cuddlebuild:android-arm64\" --workspace-folder .devcontainer/android_arm64.build",
+    "android_arm64:devcontainer:build": "devcontainer build --platform=\"linux/amd64\" --image-name=\"cuddlebuild:android-arm64\" --workspace-folder .devcontainer/android_arm64.build",
     "android_x86_64:build": "devcontainer exec --id-label=\"arch=android_intel\" --workspace-folder . --override-config ./.devcontainer/android_x86_64/.devcontainer.json ./scripts/android/cmake.sh -d",
     "android_x86_64:devcontainer:up": "devcontainer up --id-label=\"arch=android_intel\" --workspace-folder . --override-config ./.devcontainer/android_x86_64/.devcontainer.json",
     "android_x86_64:devcontainer:fresh": "devcontainer up --id-label=\"arch=android_intel\" --workspace-folder . --override-config ./.devcontainer/android_x86_64/.devcontainer.json --remove-existing-container",
-    "android_x86_64:devcontainer:build": "devcontainer build --image-name=\"cuddlebuild:android-x86_64\" --workspace-folder .devcontainer/android_x86_64.build",
+    "android_x86_64:devcontainer:build": "devcontainer build --platform=\"linux/amd64\" --image-name=\"cuddlebuild:android-x86_64\" --workspace-folder .devcontainer/android_x86_64.build",
     "wasm:build": "devcontainer exec --id-label=\"arch=wasm\" --workspace-folder . --override-config ./.devcontainer/wasm/.devcontainer.json ./taskcluster/scripts/build/wasm.sh ",
     "wasm:devcontainer:up": "devcontainer up --id-label=\"arch=wasm\" --workspace-folder . --override-config ./.devcontainer/wasm/.devcontainer.json",
     "wasm:devcontainer:fresh": "devcontainer up --id-label=\"arch=wasm\" --workspace-folder . --override-config ./.devcontainer/wasm/.devcontainer.json --remove-existing-container",
-    "wasm:devcontainer:build": "devcontainer build --image-name=\"cuddlebuild:wasm\" --workspace-folder .devcontainer/wasm.build"
+    "wasm:devcontainer:build": "devcontainer build --platform=\"linux/amd64\" --image-name=\"cuddlebuild:wasm\" --workspace-folder .devcontainer/wasm.build"
     
   },
   "devDependencies": {

--- a/scripts/android/cmake.sh
+++ b/scripts/android/cmake.sh
@@ -167,7 +167,7 @@ fi
 
 print Y "Compiling apk_install_target in .tmp/"
 # This compiles the client and generates a mozillavpn.so
-cmake --build .tmp -j$JOBS
+cmake --build .tmp -j$JOBS --target mozillavpn_make_apk
 
 # Generate a valid gradle project and pre-compile it.
 print Y "Generate Android Project"
@@ -199,12 +199,27 @@ if [[ "$RELEASE" ]]; then
 
   print G "Done 🎉"
   print G "Your Release APK is under .tmp/src/android-build/build/outputs/apk/release/"
+
+  if [ -n "$IS_DEV_CONTAINER" ]; then
+    echo "In dev Container, Copying binary:"
+    cp .tmp/src/android-build/build/outputs/apk/release  $WORKSPACE_ROOT
+  else 
+    print G "Your Release APK is under .tmp/src/android-build/build/outputs/apk/release/"
+  fi
+
+
 else
   print Y "Generating Debug APK..."
   ./gradlew compileDebugSources
   ./gradlew assembleDebug || die
   print G "Done 🎉"
-  print G "Your Debug APK is under .tmp/src/android-build/build/outputs/apk/debug/"
+
+  if [ -n "$IS_DEV_CONTAINER" ]; then
+    echo "In dev Container, Copying binary:"
+    cp .tmp/src/android-build/build/outputs/apk/debug  $WORKSPACE_ROOT
+  else 
+     print G "Your Debug APK is under .tmp/src/android-build/build/outputs/apk/debug/"
+  fi
 fi
 
 rm $WORKSPACE_ROOT/3rdparty/glean/glean-core/uniffi.toml

--- a/scripts/android/cmake.sh
+++ b/scripts/android/cmake.sh
@@ -175,7 +175,7 @@ cmake --build .tmp -j$JOBS --target mozillavpn_prepare_apk_dir
 # Generate a valid gradle project and pre-compile it.
 print Y "Generate Android Project"
 # We need to pass --no-build here, otherwise we get one useless timecostly invokation of gradle.
-androiddeployqt --input .tmp/src/android-mozillavpn-deployment-settings.json --output .tmp/src/android-build || die
+androiddeployqt --input .tmp/src/android-mozillavpn-deployment-settings.json --output .tmp/src/android-build
 
 # Warning: this is hacky.
 #

--- a/scripts/android/cmake.sh
+++ b/scripts/android/cmake.sh
@@ -175,7 +175,7 @@ cmake --build .tmp -j$JOBS --target mozillavpn_prepare_apk_dir
 # Generate a valid gradle project and pre-compile it.
 print Y "Generate Android Project"
 # We need to pass --no-build here, otherwise we get one useless timecostly invokation of gradle.
-androiddeployqt --input .tmp/src/android-mozillavpn-deployment-settings.json --output .tmp/src/android-build --no-build || die
+androiddeployqt --input .tmp/src/android-mozillavpn-deployment-settings.json --output .tmp/src/android-build || die
 
 # Warning: this is hacky.
 #

--- a/scripts/android/cmake.sh
+++ b/scripts/android/cmake.sh
@@ -198,28 +198,26 @@ cd .tmp/src/android-build/
 if [[ "$RELEASE" ]]; then
   print Y "Generating Release APK..."
   ./gradlew compileReleaseSources
-  ./gradlew assemble || die
+  ./gradlew assemble
 
   print G "Done 🎉"
   print G "Your Release APK is under .tmp/src/android-build/build/outputs/apk/release/"
 
   if [ -n "$IS_DEV_CONTAINER" ]; then
     echo "In dev Container, Copying binary to ./release"
-    cp -r .tmp/src/android-build/build/outputs/apk/release .
+    cp -r build/outputs/apk/release $WORKSPACE_ROOT
   else 
     print G "Your Release APK is under .tmp/src/android-build/build/outputs/apk/release/"
   fi
-
-
 else
   print Y "Generating Debug APK..."
   ./gradlew compileDebugSources
-  ./gradlew assembleDebug || die
+  ./gradlew assembleDebug
   print G "Done 🎉"
 
   if [ -n "$IS_DEV_CONTAINER" ]; then
     echo "In dev Container, Copying binary: to ./debug"
-    cp -r .tmp/src/android-build/build/outputs/apk/debug .
+    cp -r build/outputs/apk/debug $WORKSPACE_ROOT
   else 
      print G "Your Debug APK is under .tmp/src/android-build/build/outputs/apk/debug/"
   fi

--- a/taskcluster/docker/android-qt6-build/Dockerfile
+++ b/taskcluster/docker/android-qt6-build/Dockerfile
@@ -17,7 +17,7 @@ ARG SENTRY_CLI_VERSION="2.9.0"
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get -q update &&\
-    apt-get -yq install --no-install-recommends gnupg curl ca-certificates libglib2.0-dev cargo python3-dev &&\
+    apt-get -yq install --no-install-recommends gnupg curl ca-certificates ninja-build libglib2.0-dev cargo python3-dev &&\
     # add zulu-jdk to the
     apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 &&\
     curl -O https://cdn.azul.com/zulu/bin/zulu-repo_1.0.0-3_all.deb &&\
@@ -56,9 +56,9 @@ RUN echo y | /opt/cmdline-tools/bin/sdkmanager --sdk_root=/opt/android/sdk --ins
     echo y | /opt/cmdline-tools/bin/sdkmanager --sdk_root=/opt/android/sdk --install "build-tools;29.0.2" &&\
     echo y | /opt/cmdline-tools/bin/sdkmanager --sdk_root=/opt/android/sdk --install "build-tools;30.0.3" &&\
     echo y | /opt/cmdline-tools/bin/sdkmanager --sdk_root=/opt/android/sdk --install "build-tools;31.0.0" &&\
-    echo y | /opt/cmdline-tools/bin/sdkmanager --sdk_root=/opt/android/sdk --install "build-tools;33.0.0" &&\
+    echo y | /opt/cmdline-tools/bin/sdkmanager --sdk_root=/opt/android/sdk --install "build-tools;33.0.0"
     # Todo: Dedupe cmake deps
-    echo y | /opt/cmdline-tools/bin/sdkmanager --sdk_root=/opt/android/sdk --install "cmake;3.10.2.4988404" &&\
+RUN echo y | /opt/cmdline-tools/bin/sdkmanager --sdk_root=/opt/android/sdk --install "cmake;3.10.2.4988404" &&\
     echo y | /opt/cmdline-tools/bin/sdkmanager --sdk_root=/opt/android/sdk --install "cmake;${CMAKE_VERSION}" &&\
         # Note: Not sure why we need emulator, need to investiage the gradle dependencies
     echo y | /opt/cmdline-tools/bin/sdkmanager --sdk_root=/opt/android/sdk --install "emulator" &&\


### PR DESCRIPTION
Changelog:
- Step 1: Really enforce amd64/linux builds >:c
- Step 2: Give an example .env file, show how to set env's per context
- Step 3: Split Large Layers, so they are easy to re-run; add ninja
- Step 4: Write more documentation
- Step 5: Auto Copy the apk's out of dev-images, make a build a tiny bit faster
- reduce usless calls to gradle

## Description

    Describe your changes

## Reference

## --- Image Dumping ground ----

![Screenshot 2023-04-18 at 19 06 54](https://user-images.githubusercontent.com/9611612/233135351-563d42bb-8d5c-44c2-acf4-61d04a6354d0.png)


![Screen_Recording_2023-04-19_at_18_12_00_AdobeExpress](https://user-images.githubusercontent.com/9611612/233138266-4dd49973-0474-44c3-84fc-060dc19716b3.gif)




