### PR TITLE
VPN-4406 [Part 2] Add functional test to verify subscription after a "No signal" state

### DIFF
--- a/tests/functional/helper.js
+++ b/tests/functional/helper.js
@@ -600,12 +600,6 @@ module.exports = {
   },
 
   async forceConnectionStabilityStatus(connectionStabilityStatus) {
-    // const json = await this._writeCommand('force_connection_health');
-    // assert(
-    //     json.type === 'force_connection_health' && !('error' in json),
-    //     `Command failed: ${json.error}`);
-
-
     const json = await this._writeCommand(`force_connection_health ${
         encodeURIComponent(connectionStabilityStatus)}`);
     assert(

--- a/tests/functional/helper.js
+++ b/tests/functional/helper.js
@@ -599,6 +599,21 @@ module.exports = {
     return json.value;
   },
 
+  async forceConnectionStabilityStatus(connectionStabilityStatus) {
+    // const json = await this._writeCommand('force_connection_health');
+    // assert(
+    //     json.type === 'force_connection_health' && !('error' in json),
+    //     `Command failed: ${json.error}`);
+
+
+    const json = await this._writeCommand(`force_connection_health ${
+        encodeURIComponent(connectionStabilityStatus)}`);
+    assert(
+        json.type === 'force_connection_health' && !('error' in json),
+        `Command failed: ${json.error}`);
+    return json.value;
+  },
+
   // Internal methods.
 
   _writeCommand(command) {

--- a/tests/functional/testSubscription.js
+++ b/tests/functional/testSubscription.js
@@ -136,6 +136,41 @@ describe('Subscription manager', function() {
                'VPN is on';
          });
        });
+
+    it('Go to "Subscribe to Mozilla VPN" screen once user toggles off VPN after subscription expires and they enter No Signal',
+       async () => {
+         // This test verifies the case where a user is logged in
+         // and the VPN is on when their subscription expires.
+         // They enter No Signal, and once they toggle the VPN off
+         // they get the "Subscribe to Mozilla VPN" screen.
+
+         await vpn.authenticateInApp(true, true);
+
+         // toggle on VPN here
+         await vpn.waitForQuery(queries.screenHome.CONTROLLER_TITLE.visible());
+         await vpn.clickOnQuery(queries.screenHome.CONTROLLER_TOGGLE.visible());
+
+         await vpn.waitForCondition(async () => {
+           return await vpn.getQueryProperty(
+                      queries.screenHome.CONTROLLER_TITLE, 'text') ==
+               'VPN is on';
+         });
+
+         // Override the Guardian endpoint to mock an expired
+         // subscription.
+         this.ctx.guardianOverrideEndpoints.GETs['/api/v1/vpn/account'].body =
+             userDataInactive;
+
+         // Because the subscription has expired, client enter the No Signal
+         // state
+         await vpn.forceConnectionStabilityStatus('nosignal');
+
+         // Once the VPN is toggled off, we are redirected to the "Subscribe to
+         // Mozilla VPN" screen.
+         await vpn.clickOnQuery(queries.screenHome.CONTROLLER_TOGGLE.visible());
+         await vpn.waitForQuery(
+             queries.screenHome.SUBSCRIPTION_NEEDED.visible());
+       });
   });
 });
 
@@ -855,8 +890,8 @@ describe('Subscription view', function() {
             queries.screenSettings.subscriptionView.PLAN.visible());
         assert.equal(
             await vpn.getQueryProperty(
-                queries.screenSettings.subscriptionView.PLAN.visible(),
-                'text'), data.plan.expected);
+                queries.screenSettings.subscriptionView.PLAN.visible(), 'text'),
+            data.plan.expected);
       }
 
       if (data.subscription.expected.activated) {
@@ -865,7 +900,8 @@ describe('Subscription view', function() {
         assert.equal(
             await vpn.getQueryProperty(
                 queries.screenSettings.subscriptionView.ACTIVATED.visible(),
-                'text'), data.subscription.expected.activated);
+                'text'),
+            data.subscription.expected.activated);
       }
 
       await vpn.waitForQuery(
@@ -873,11 +909,13 @@ describe('Subscription view', function() {
       assert.equal(
           await vpn.getQueryProperty(
               queries.screenSettings.subscriptionView.CANCELLED.visible(),
-              'text'), data.subscription.expected.cancelled);
+              'text'),
+          data.subscription.expected.cancelled);
       assert.equal(
           await vpn.getQueryProperty(
               queries.screenSettings.subscriptionView.CANCELLED_LABEL.visible(),
-              'text'), data.subscription.expected.label);
+              'text'),
+          data.subscription.expected.label);
 
       if (data.subscription.value._subscription_type == 'web') {
         if (data.payment.expected.card) {
@@ -886,7 +924,8 @@ describe('Subscription view', function() {
           assert.equal(
               await vpn.getQueryProperty(
                   queries.screenSettings.subscriptionView.BRAND.visible(),
-                  'text'), data.payment.expected.card);
+                  'text'),
+              data.payment.expected.card);
         }
         if (data.payment.expected.expires) {
           await vpn.waitForQuery(
@@ -894,7 +933,8 @@ describe('Subscription view', function() {
           assert.equal(
               await vpn.getQueryProperty(
                   queries.screenSettings.subscriptionView.EXPIRES.visible(),
-                  'text'), data.payment.expected.expires);
+                  'text'),
+              data.payment.expected.expires);
         }
         if (data.payment.expected.brand) {
           await vpn.waitForQuery(
@@ -903,7 +943,8 @@ describe('Subscription view', function() {
               await vpn.getQueryProperty(
                   queries.screenSettings.subscriptionView.PAYMENT_METHOD
                       .visible(),
-                  'text'), data.payment.expected.brand);
+                  'text'),
+              data.payment.expected.brand);
         }
         if (data.payment.expected.payment) {
           await vpn.waitForQuery(queries.screenSettings.subscriptionView
@@ -912,7 +953,8 @@ describe('Subscription view', function() {
               await vpn.getQueryProperty(
                   queries.screenSettings.subscriptionView.PAYMENT_METHOD_LABEL
                       .visible(),
-                  'text'), data.payment.expected.payment);
+                  'text'),
+              data.payment.expected.payment);
         }
       }
 


### PR DESCRIPTION
## Description

Add a test where user is logged in, their subscription is active and VPN is on. Then they enter No Signal state (mocked using the inspector command), turn off the VPN and should get the subscription not found screen.

## Reference

    https://mozilla-hub.atlassian.net/browse/VPN-4406

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
