### PR TITLE
VPN-4641: Fix "Subscribe now" button on IAP page

### DIFF
--- a/nebula/ui/components/MZSubscriptionOption.qml
+++ b/nebula/ui/components/MZSubscriptionOption.qml
@@ -19,7 +19,6 @@ RadioDelegate {
 
     activeFocusOnTab: true
     checked: productFeatured
-    ButtonGroup.group: subscriptionOptions
 
     Layout.fillWidth: true
     Layout.preferredHeight: Math.max(96, row.implicitHeight + row.anchors.topMargin + row.anchors.bottomMargin)

--- a/src/apps/vpn/ui/screens/subscriptionNeeded/ViewSubscriptionNeeded.qml
+++ b/src/apps/vpn/ui/screens/subscriptionNeeded/ViewSubscriptionNeeded.qml
@@ -80,6 +80,10 @@ MZFlickable {
             Accessible.name: text.replace(/<[^>]*>/g, "")
         }
 
+        ButtonGroup {
+            id: subscriptionOptions
+        }
+
         Loader {
             Layout.topMargin: MZTheme.theme.vSpacing
             Layout.leftMargin: MZTheme.theme.windowMargin
@@ -92,18 +96,15 @@ MZFlickable {
             sourceComponent: ColumnLayout {
                 spacing: 16
 
-                ButtonGroup {
-                    id: subscriptionOptions
-                }
-
                 Repeater {
                     id: productList
                     model: VPNProducts
-                    delegate: MZSubscriptionOption {}
+                    delegate: MZSubscriptionOption {
+                        ButtonGroup.group: subscriptionOptions
+                    }
                 }
             }
         }
-
 
         MZButton {
             id: subscribeNow
@@ -118,7 +119,6 @@ MZFlickable {
 
             onClicked: isMobile ? VPNPurchase.subscribe(subscriptionOptions.checkedButton.productId) : VPNPurchase.subscribe("web")
         }
-
 
         RowLayout {
             Layout.fillWidth: true


### PR DESCRIPTION
## Description

- Fixes the "Subscribe now" button on the IAP page for mobile. Tapping "Subscribe now" again has the same effect as tapping a selected subscription option

## Reference

[VPN-4641: "Subscribe now" button on mobile IAP screen does not work](https://mozilla-hub.atlassian.net/browse/VPN-4641)
