### PR TITLE
VPN-4651: Uplift DNS setting bug fixes

### DIFF
--- a/nebula/ui/components/forms/MZTextField.qml
+++ b/nebula/ui/components/forms/MZTextField.qml
@@ -15,6 +15,7 @@ TextField {
     property bool showInteractionStates: true
     property bool forceBlurOnOutsidePress: true
     property alias _placeholderText: centeredPlaceholderText.text
+    property bool focusReasonA11y: false
 
     id: textField
 
@@ -31,7 +32,6 @@ TextField {
     color: MZTheme.colors.input.default.text
     cursorDelegate: MZCursorDelegate {}
     echoMode: TextInput.Normal
-    focus: true
     font.family: MZTheme.theme.fontInterFamily
     font.pixelSize: MZTheme.theme.fontSizeSmall
     inputMethodHints: Qt.ImhNoPredictiveText | Qt.ImhSensitiveData
@@ -55,8 +55,10 @@ TextField {
     // active focus the screen reader keeps working as expected.
     onTextChanged: {
         if (Qt.platform.os === "osx") {
+            textField.focusReasonA11y = true
             textField.focus = false;
             textField.forceActiveFocus();
+            textField.focusReasonA11y = false
         }
     }
 

--- a/src/apps/vpn/ui/screens/settings/ViewDNSSettings.qml
+++ b/src/apps/vpn/ui/screens/settings/ViewDNSSettings.qml
@@ -55,7 +55,9 @@ MZViewBase {
             return;
         }
 
-        MZSettings.dnsProviderFlags = MZSettings.Gateway;
+        if (MZSettings.userDNS === "" || !VPN.validateUserDNS(MZSettings.userDNS)) {
+            MZSettings.dnsProviderFlags = MZSettings.Gateway;
+        }
     }
 
     function reset() {
@@ -210,6 +212,12 @@ MZViewBase {
                     onTextChanged: {
                         ipInput.valueInvalid = ipInput.text !== "" && !VPN.validateUserDNS(ipInput.text);
                         ipInput.error = MZI18n.SettingsDnsSettingsCustomDNSError
+                    }
+
+                    onActiveFocusChanged: {
+                       if (!activeFocus && !ipInput.focusReasonA11y) {
+                           maybeSaveChange();
+                       }
                     }
                 }
 

--- a/src/apps/vpn/ui/screens/settings/ViewDNSSettings.qml
+++ b/src/apps/vpn/ui/screens/settings/ViewDNSSettings.qml
@@ -62,6 +62,7 @@ MZViewBase {
         root.customDNS = MZSettings.dnsProviderFlags === MZSettings.Custom;
         root.privacyDialogNeeded = MZSettings.dnsProviderFlags !== MZSettings.Custom &&
                                    MZSettings.dnsProviderFlags !== MZSettings.Gateway;
+        ipInput.text = MZSettings.userDNS;
     }
 
 
@@ -204,10 +205,6 @@ MZViewBase {
 
                     PropertyAnimation on opacity {
                         duration: 200
-                    }
-
-                    Component.onCompleted: {
-                        ipInput.text = MZSettings.userDNS;
                     }
 
                     onTextChanged: {

--- a/src/apps/vpn/ui/screens/settings/ViewDNSSettings.qml
+++ b/src/apps/vpn/ui/screens/settings/ViewDNSSettings.qml
@@ -37,6 +37,16 @@ MZViewBase {
         root.dnsSelectionChanged = true;
     }
 
+    function saveChange(dnsProviderFlags, userDNS = undefined) {
+        if (MZSettings.dnsProviderFlags !== dnsProviderFlags) {
+            MZSettings.dnsProviderFlags = dnsProviderFlags;
+        }
+
+        if (userDNS !== undefined && MZSettings.userDNS != userDNS) {
+            MZSettings.userDNS = userDNS;
+        }
+    }
+
     function maybeSaveChange() {
         if (!root.dnsSelectionChanged && ipInput.text === MZSettings.userDNS) {
             return;
@@ -45,18 +55,17 @@ MZViewBase {
         root.dnsSelectionChanged = false;
 
         if (!root.customDNS) {
-            MZSettings.dnsProviderFlags = MZSettings.Gateway;
+            saveChange(MZSettings.Gateway);
             return;
         }
 
         if (ipInput.text !== "" && VPN.validateUserDNS(ipInput.text)) {
-            MZSettings.userDNS = ipInput.text
-            MZSettings.dnsProviderFlags = MZSettings.Custom;
+            saveChange(MZSettings.Custom, ipInput.text);
             return;
         }
 
         if (MZSettings.userDNS === "" || !VPN.validateUserDNS(MZSettings.userDNS)) {
-            MZSettings.dnsProviderFlags = MZSettings.Gateway;
+            saveChange(MZSettings.Gateway);
         }
     }
 

--- a/tests/functional/testSettings.js
+++ b/tests/functional/testSettings.js
@@ -376,7 +376,7 @@ describe('Settings', function() {
     await vpn.waitForQueryAndClick(queries.navBar.HOME.visible());
     await vpn.waitForQuery(queries.global.SCREEN_LOADER.ready());
 
-    assert.equal(await vpn.getSetting('dnsProviderFlags'), 1);
+    assert.equal(await vpn.getSetting('dnsProviderFlags'), 0);
 
     // Check the modal
     await vpn.setSetting('dnsProviderFlags', 2);
@@ -411,6 +411,11 @@ describe('Settings', function() {
     await vpn.waitForQueryAndClick(
         queries.screenSettings.appPreferencesView.dnsSettingsView
             .MODAL_PRIMARY_BUTTON.visible());
+
+    await vpn.setQueryProperty(
+        queries.screenSettings.appPreferencesView.dnsSettingsView
+            .CUSTOM_DNS_INPUT.visible(),
+        'text', '1.2.3.4');
 
     await vpn.waitForQueryAndClick(queries.screenSettings.BACK.visible());
     await vpn.waitForQuery(queries.screenSettings.STACKVIEW.ready());

--- a/tests/functional/testSettings.js
+++ b/tests/functional/testSettings.js
@@ -105,7 +105,6 @@ describe('Settings', function() {
   it('Checking the privacy settings', async () => {
     await vpn.waitForQuery(queries.screenSettings.PRIVACY.visible());
 
-
     await vpn.scrollToQuery(
         queries.screenSettings.SCREEN, queries.screenSettings.PRIVACY);
 
@@ -294,6 +293,7 @@ describe('Settings', function() {
 
   it('Checking the DNS settings', async () => {
     await vpn.setSetting('userDNS', '');
+    await vpn.setSetting('dnsProviderFlags', 0);
 
     await vpn.waitForQueryAndClick(
         queries.screenSettings.APP_PREFERENCES.visible());
@@ -304,7 +304,6 @@ describe('Settings', function() {
     await vpn.waitForQuery(queries.screenSettings.STACKVIEW.ready());
 
     // Checking if the checkboxes are correctly set based on the settings prop
-    await vpn.setSetting('dnsProviderFlags', 0);
     await vpn.waitForQuery(
         queries.screenSettings.appPreferencesView.dnsSettingsView.STANDARD_DNS
             .visible()
@@ -314,7 +313,14 @@ describe('Settings', function() {
             .visible()
             .prop('checked', false));
 
+    await vpn.waitForQueryAndClick(queries.navBar.HOME.visible());
+    await vpn.waitForQuery(queries.global.SCREEN_LOADER.ready());
+
     await vpn.setSetting('dnsProviderFlags', 1);
+
+    await vpn.waitForQueryAndClick(queries.navBar.SETTINGS.visible());
+    await vpn.waitForQuery(queries.global.SCREEN_LOADER.ready());
+
     await vpn.waitForQuery(
         queries.screenSettings.appPreferencesView.dnsSettingsView.STANDARD_DNS
             .visible()
@@ -353,48 +359,63 @@ describe('Settings', function() {
         queries.screenSettings.appPreferencesView.dnsSettingsView.STANDARD_DNS
             .visible()
             .prop('checked', false));
+
+    await vpn.waitForQueryAndClick(queries.navBar.HOME.visible());
+    await vpn.waitForQuery(queries.global.SCREEN_LOADER.ready());
+
     assert.equal(await vpn.getSetting('dnsProviderFlags'), 0);
+
+    await vpn.waitForQueryAndClick(queries.navBar.SETTINGS.visible());
+    await vpn.waitForQuery(queries.global.SCREEN_LOADER.ready());
 
     await vpn.waitForQueryAndClick(
         queries.screenSettings.appPreferencesView.dnsSettingsView.CUSTOM_DNS
             .visible()
             .prop('checked', false));
+
+    await vpn.waitForQueryAndClick(queries.navBar.HOME.visible());
+    await vpn.waitForQuery(queries.global.SCREEN_LOADER.ready());
+
     assert.equal(await vpn.getSetting('dnsProviderFlags'), 1);
 
     // Check the modal
     await vpn.setSetting('dnsProviderFlags', 2);
-    await vpn.waitForQueryAndClick(
+
+    await vpn.waitForQueryAndClick(queries.navBar.SETTINGS.visible());
+    await vpn.waitForQuery(queries.global.SCREEN_LOADER.ready());
+
+    await vpn.waitForQuery(
         queries.screenSettings.appPreferencesView.dnsSettingsView.STANDARD_DNS
             .visible()
             .prop('checked', true));
-    assert.equal(await vpn.getSetting('dnsProviderFlags'), 2);
 
     await vpn.waitForQueryAndClick(
         queries.screenSettings.appPreferencesView.dnsSettingsView.CUSTOM_DNS
             .visible()
             .prop('checked', false));
-    assert.equal(await vpn.getSetting('dnsProviderFlags'), 2);
+
     await vpn.waitForQueryAndClick(
         queries.screenSettings.appPreferencesView.dnsSettingsView
             .MODAL_SECONDARY_BUTTON.visible());
-    assert.equal(await vpn.getSetting('dnsProviderFlags'), 2);
+
     await vpn.waitForQueryAndClick(queries.screenSettings.appPreferencesView
                                        .dnsSettingsView.CUSTOM_DNS.visible());
-    assert.equal(await vpn.getSetting('dnsProviderFlags'), 2);
+
     await vpn.waitForQueryAndClick(
         queries.screenSettings.appPreferencesView.dnsSettingsView
             .MODAL_CLOSE_BUTTON.visible());
-    assert.equal(await vpn.getSetting('dnsProviderFlags'), 2);
+
     await vpn.waitForQueryAndClick(queries.screenSettings.appPreferencesView
                                        .dnsSettingsView.CUSTOM_DNS.visible());
-    assert.equal(await vpn.getSetting('dnsProviderFlags'), 2);
+
     await vpn.waitForQueryAndClick(
         queries.screenSettings.appPreferencesView.dnsSettingsView
             .MODAL_PRIMARY_BUTTON.visible());
-    assert.equal(await vpn.getSetting('dnsProviderFlags'), 1);
 
     await vpn.waitForQueryAndClick(queries.screenSettings.BACK.visible());
     await vpn.waitForQuery(queries.screenSettings.STACKVIEW.ready());
+
+    assert.equal(await vpn.getSetting('dnsProviderFlags'), 1);
 
     await vpn.waitForQueryAndClick(queries.screenSettings.BACK.visible());
     await vpn.waitForQuery(queries.screenSettings.STACKVIEW.ready());
@@ -429,7 +450,6 @@ describe('Settings', function() {
         queries.screenSettings.appPreferencesView.dnsSettingsView.CUSTOM_DNS
             .visible()
             .prop('checked', false));
-    assert.equal(await vpn.getSetting('dnsProviderFlags'), 1);
 
     await vpn.setQueryProperty(
         queries.screenSettings.appPreferencesView.dnsSettingsView
@@ -461,7 +481,6 @@ describe('Settings', function() {
         queries.screenSettings.appPreferencesView.dnsSettingsView.CUSTOM_DNS
             .visible()
             .prop('checked', false));
-    assert.equal(await vpn.getSetting('dnsProviderFlags'), 1);
 
     // But with a valid DNS value...
     await vpn.setQueryProperty(

--- a/tests/functional/testSettings.js
+++ b/tests/functional/testSettings.js
@@ -376,7 +376,7 @@ describe('Settings', function() {
     await vpn.waitForQueryAndClick(queries.navBar.HOME.visible());
     await vpn.waitForQuery(queries.global.SCREEN_LOADER.ready());
 
-    assert.equal(await vpn.getSetting('dnsProviderFlags'), 0);
+    assert.equal(await vpn.getSetting('dnsProviderFlags'), 1);
 
     // Check the modal
     await vpn.setSetting('dnsProviderFlags', 2);
@@ -429,6 +429,7 @@ describe('Settings', function() {
   });
 
   it('Checking the DNS settings reset', async () => {
+    await vpn.setSetting('dnsProviderFlags', 0);
     await vpn.setSetting('userDNS', '');
 
     await vpn.waitForQueryAndClick(
@@ -440,7 +441,6 @@ describe('Settings', function() {
     await vpn.waitForQuery(queries.screenSettings.STACKVIEW.ready());
 
     // Checking if the checkboxes are correctly set based on the settings prop
-    await vpn.setSetting('dnsProviderFlags', 0);
     await vpn.waitForQuery(
         queries.screenSettings.appPreferencesView.dnsSettingsView.STANDARD_DNS
             .visible()
@@ -529,7 +529,7 @@ describe('Settings', function() {
     await vpn.waitForQuery(queries.screenSettings.STACKVIEW.ready());
 
     // We keep the custom DNS.
-    assert.equal(await vpn.getSetting('dnsProviderFlags'), 0);
+    assert.equal(await vpn.getSetting('dnsProviderFlags'), 1);
   });
 
   it('Checking the languages settings', async () => {


### PR DESCRIPTION
## Description

- Various DNS setting fixes that were uplifted to 2.14, but never uplifted to 2.15 

## Reference

[VPN-4651: Standard DNS fallback not applied after leaving the custom DNS field empty and navigating from the DNS screen using the “Settings” icon](https://mozilla-hub.atlassian.net/browse/VPN-4651)