### PR TITLE
Support 2.14.0 client for message_paid_research

### DIFF
--- a/addons/message_paid_research_old/OpenSurveyURL.js
+++ b/addons/message_paid_research_old/OpenSurveyURL.js
@@ -1,0 +1,4 @@
+((api) => {
+  api.urlOpener.openUrl(
+      'https://survey.alchemer.com/s3/7296281/VPN-Better-Together-Survey');
+});

--- a/addons/message_paid_research_old/currencyCheck.js
+++ b/addons/message_paid_research_old/currencyCheck.js
@@ -1,0 +1,14 @@
+(function(api, condition) {
+function computeCondition() {
+  if (['USD', 'CAD'].includes(api.subscriptionData.planCurrency)) {
+    condition.enable();
+    return;
+  }
+
+  condition.disable();
+}
+
+api.connectSignal(api.subscriptionData, 'changed', () => computeCondition());
+
+computeCondition();
+});

--- a/addons/message_paid_research_old/manifest.json
+++ b/addons/message_paid_research_old/manifest.json
@@ -5,8 +5,7 @@
   "type": "message",
   "translatable": false,
   "conditions": {
-    "min_client_version": "2.15.0",
-    "translation_threshold": 0,
+    "max_client_version": "2.14.99",
     "locales": ["en"],
     "javascript": "currencyCheck.js"
   },

--- a/addons/message_paid_research_old/setDate.js
+++ b/addons/message_paid_research_old/setDate.js
@@ -1,0 +1,3 @@
+(function(api) {
+api.addon.date = (api.settings.updateTime.getTime() / 1000);
+})


### PR DESCRIPTION
We need to dup this addon because in 2.14 we do not have `threshold_completeness" property and the addon is rejected (correctly). 