### PR TITLE
VPN-2830: Close modals when screen changes

### DIFF
--- a/nebula/ui/components/MZPopup.qml
+++ b/nebula/ui/components/MZPopup.qml
@@ -25,6 +25,14 @@ Popup {
     horizontalPadding: 0
     verticalPadding: 0
 
+    //Close popup if screen changes
+    Connections {
+        target: MZNavigator
+        function onCurrentComponentChanged() {
+            close()
+        }
+    }
+
     // Close button
     MZIconButton {
         id: closeButton


### PR DESCRIPTION
## Description

- Dismiss all modals whenever the screen behind the modal changes

## Reference

[VPN-2830: Modal displayed on top of the “Get started” screen after a device removal if the modal is not closed before the removal action](https://mozilla-hub.atlassian.net/browse/VPN-2830)
