### PR TITLE
Linux improved desktop file search

### DIFF
--- a/src/apps/vpn/platforms/linux/linuxapplistprovider.cpp
+++ b/src/apps/vpn/platforms/linux/linuxapplistprovider.cpp
@@ -35,7 +35,8 @@ void LinuxAppListProvider::fetchEntries(const QString& dataDir,
                                         const QSet<QString>& desktopEnv) {
   logger.debug() << "Fetch Application list from" << dataDir;
 
-  QDirIterator iter(dataDir, QStringList() << "*.desktop", QDir::Files);
+  QDirIterator iter(dataDir, QStringList() << "*.desktop", QDir::Files,
+                    QDirIterator::Subdirectories);
   while (iter.hasNext()) {
     QFileInfo fileinfo(iter.next());
     QSettings entry(fileinfo.filePath(), QSettings::IniFormat);

--- a/src/apps/vpn/platforms/linux/linuxapplistprovider.h
+++ b/src/apps/vpn/platforms/linux/linuxapplistprovider.h
@@ -18,7 +18,8 @@ class LinuxAppListProvider final : public AppListProvider {
   void getApplicationList() override;
 
  private:
-  void fetchEntries(const QString& dataDir, QMap<QString, QString>& map);
+  void fetchEntries(const QString& dataDir, QMap<QString, QString>& map,
+                    const QSet<QString>& desktopEnv);
 };
 
 #endif  // LINUXAPPLISTPROVIDER_H


### PR DESCRIPTION
## Description

Improve the search for desktop files on Linux by following freedesktop specs closer

- correct user directories (from `$XDG_DATA_HOME` if defined before `$HOME/local/data`) 
- correct system fallbacks (both `/usr/locale/share/applications` and `/use/share/applications`)
- added missing desktop-file hiding mechanisms `OnlyShowIn`, `NotShowIn`, and `Hidden`
- added autostart desktop files to cover applications started at launch (because autostart is implemented by copied desktop files which means they are referenced as different application “ids”)

## Reference

None

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
