### PR TITLE
VPN-4535 add metric for web purchases

### DIFF
--- a/src/apps/vpn/mozillavpn.cpp
+++ b/src/apps/vpn/mozillavpn.cpp
@@ -1045,6 +1045,7 @@ void MozillaVPN::restoreSubscriptionStarted() {
 }
 
 void MozillaVPN::subscriptionCompleted() {
+  emit logSubscriptionCompleted();
 #ifdef MZ_ANDROID
   // This is Android only
   // iOS can end up here if the subsciption get finished outside of the IAP

--- a/src/apps/vpn/mozillavpn.h
+++ b/src/apps/vpn/mozillavpn.h
@@ -277,6 +277,7 @@ class MozillaVPN final : public App {
   void initializeGlean();
   void sendGleanPings();
   void setGleanSourceTags(const QStringList& tags);
+  void logSubscriptionCompleted();
 
   void aboutToQuit();
 

--- a/src/apps/vpn/purchasewebhandler.cpp
+++ b/src/apps/vpn/purchasewebhandler.cpp
@@ -44,6 +44,8 @@ void PurchaseWebHandler::startSubscription(const QString&) {
           &MozillaVPN::abortAuthentication);
   connect(taskAuthenticate, &TaskAuthenticate::authenticationCompleted, vpn,
           &MozillaVPN::completeAuthentication);
+  connect(taskAuthenticate, &TaskAuthenticate::authenticationCompleted, vpn,
+          &MozillaVPN::logSubscriptionCompleted);
 
   TaskScheduler::scheduleTask(taskAuthenticate);
 }

--- a/src/apps/vpn/telemetry.cpp
+++ b/src/apps/vpn/telemetry.cpp
@@ -221,14 +221,15 @@ void Telemetry::initialize() {
                 GleanSample::iapRestoreSubStarted);
           });
 
-  connect(purchaseHandler, &PurchaseHandler::subscriptionCompleted, this, []() {
-    mozilla::glean::sample::iap_subscription_completed.record(
-        mozilla::glean::sample::IapSubscriptionCompletedExtra{
-            ._sku = PurchaseHandler::instance()->currentSKU()});
-    emit GleanDeprecated::instance()->recordGleanEventWithExtraKeys(
-        GleanSample::iapSubscriptionCompleted,
-        {{"sku", PurchaseHandler::instance()->currentSKU()}});
-  });
+  connect(MozillaVPN::instance(), &MozillaVPN::logSubscriptionCompleted, this,
+          []() {
+            mozilla::glean::sample::iap_subscription_completed.record(
+                mozilla::glean::sample::IapSubscriptionCompletedExtra{
+                    ._sku = PurchaseHandler::instance()->currentSKU()});
+            emit GleanDeprecated::instance()->recordGleanEventWithExtraKeys(
+                GleanSample::iapSubscriptionCompleted,
+                {{"sku", PurchaseHandler::instance()->currentSKU()}});
+          });
 
   connect(purchaseHandler, &PurchaseHandler::subscriptionFailed, this, []() {
     mozilla::glean::sample::iap_subscription_failed.record(


### PR DESCRIPTION
## Description

A signal of `subscriptionCompleted` causes us to record this metric in the telemetry file. It was not being triggered by web purchases, in part because of the two different routes to calling `completeActivation`:
- For Android/iOS IAP, a completed IAP calls `MozillaVPN::subscriptionCompleted`, which in turn calls `completeActivation`. 
- Successful web subscriptions call `MozillaVPN::completeAuthentication`, which also calls `completeActivation`. 

To have the metric recorded for both routes, we disconnect the telemetry file from `subscriptionCompleted`, and add a new signal that triggers it.

I've tested this for both iOS (IAP) and macOS (web):
- Signing into an account with an active subscription (no IAP completed metric expected)
- Fresh subscription (IAP metric expected with appropriate extra of "sku" whose value is "web" or the IAP ID)
- Opening the app when an account is already signed in (no IAP completed metric expected)

In all cases, this seems to work as expected, with no unexpected side effects that I can find.

## Reference

https://mozilla-hub.atlassian.net/browse/VPN-4535

## Checklist
    
- [X] My code follows the style guidelines for this project
- [X] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [X] I have performed a self review of my own code
- [X] I have commented my code PARTICULARLY in hard to understand areas
- [X] I have added thorough tests where needed
