### PR TITLE
VPN-4532: Fix subscription expiring message buttons

### DIFF
--- a/addons/message_subscription_expiring/contactSupportLink.js
+++ b/addons/message_subscription_expiring/contactSupportLink.js
@@ -1,3 +1,3 @@
 ((api) => {
-  api.urlOpener.openLink(api.urlOpener.LinkHelpSupport);
+  api.urlOpener.openUrlLabel("contactSupport");
 });

--- a/addons/message_subscription_expiring/manageAccountLink.js
+++ b/addons/message_subscription_expiring/manageAccountLink.js
@@ -1,3 +1,3 @@
 ((api) => {  
-  api.urlOpener.openLink(api.urlOpener.LinkAccount);
+  api.urlOpener.openUrlLabel("manageSubscriptions");
 });

--- a/src/apps/vpn/appconstants.h
+++ b/src/apps/vpn/appconstants.h
@@ -158,6 +158,14 @@ constexpr const char* GOOGLE_SUBSCRIPTIONS_URL =
 constexpr const char* MOZILLA_VPN_SUMO_URL =
     "https://support.mozilla.org/en-US/products/firefox-private-network-vpn";
 
+PRODBETAEXPR(QString, mozillaSubscriptionsUrl,
+             "https://subscriptions.firefox.com/subscriptions",
+             "https://payments-stage.fxa.nonprod.cloudops.mozgcp.net/subscriptions")
+
+PRODBETAEXPR(QString, contactSupportUrl,
+             "https://accounts.firefox.com/support",
+             "https://accounts.stage.mozaws.net/support")
+
 PRODBETAEXPR(QString, addonBaseUrl,
              "https://archive.mozilla.org/pub/vpn/addons/releases/latest/",
              Constants::envOrDefault(

--- a/src/apps/vpn/mozillavpn.cpp
+++ b/src/apps/vpn/mozillavpn.cpp
@@ -1357,8 +1357,16 @@ void MozillaVPN::registerUrlOpenerLabels() {
     return AppConstants::GOOGLE_SUBSCRIPTIONS_URL;
   });
 
+  uo->registerUrlLabel("manageSubscriptions", []() -> QString {
+    return AppConstants::mozillaSubscriptionsUrl();
+  });
+
   uo->registerUrlLabel("subscriptionFxa", []() -> QString {
     return QString("%1/subscriptions").arg(Constants::fxaUrl());
+  });
+
+  uo->registerUrlLabel("contactSupport", []() -> QString {
+    return AppConstants::contactSupportUrl();
   });
 
   uo->registerUrlLabel(


### PR DESCRIPTION
## Description

- Utilize correct addon api to open web links to subscription management and support

*This will be uplifted to 2.15

## Reference

[VPN-4532: The first tooltip from the App exclusion tutorial is written differently than in the Figma file](https://mozilla-hub.atlassian.net/browse/VPN-4532)