### PR TITLE
VPN-4674: Fix subscription expiring message buttons

### DIFF
--- a/addons/message_subscription_expiring/contactSupportLink.js
+++ b/addons/message_subscription_expiring/contactSupportLink.js
@@ -1,3 +1,3 @@
 ((api) => {
-  api.urlOpener.openLink(api.urlOpener.LinkHelpSupport);
+  api.urlOpener.openUrlLabel("contactSupport");
 });

--- a/addons/message_subscription_expiring/manageAccountLink.js
+++ b/addons/message_subscription_expiring/manageAccountLink.js
@@ -1,3 +1,3 @@
 ((api) => {  
-  api.urlOpener.openLink(api.urlOpener.LinkAccount);
+  api.urlOpener.openUrlLabel("manageSubscriptions");
 });

--- a/addons/message_subscription_expiring/manageAccountLink.js
+++ b/addons/message_subscription_expiring/manageAccountLink.js
@@ -1,3 +1,16 @@
 ((api) => {  
-  api.urlOpener.openUrlLabel("manageSubscriptions");
+  switch(api.subscriptionData.type) {
+    case api.subscriptionData.SubscriptionApple:
+      api.urlOpener.openUrlLabel("subscriptionIapApple");
+      break;
+    case api.subscriptionData.SubscriptionGoogle:
+      api.urlOpener.openUrlLabel("subscriptionIapGoogle");
+      break;
+    case api.subscriptionData.SubscriptionWeb:
+      api.urlOpener.openUrlLabel("subscriptionFxa");
+      break;
+    default:
+      api.urlOpener.openUrlLabel("account");
+      break;
+  }
 });

--- a/src/apps/vpn/appconstants.h
+++ b/src/apps/vpn/appconstants.h
@@ -158,8 +158,7 @@ constexpr const char* GOOGLE_SUBSCRIPTIONS_URL =
 constexpr const char* MOZILLA_VPN_SUMO_URL =
     "https://support.mozilla.org/en-US/products/firefox-private-network-vpn";
 
-PRODBETAEXPR(QString, contactSupportUrl,
-             "https://accounts.firefox.com/support",
+PRODBETAEXPR(QString, contactSupportUrl, "https://accounts.firefox.com/support",
              "https://accounts.stage.mozaws.net/support")
 
 PRODBETAEXPR(QString, addonBaseUrl,

--- a/src/apps/vpn/appconstants.h
+++ b/src/apps/vpn/appconstants.h
@@ -158,6 +158,14 @@ constexpr const char* GOOGLE_SUBSCRIPTIONS_URL =
 constexpr const char* MOZILLA_VPN_SUMO_URL =
     "https://support.mozilla.org/en-US/products/firefox-private-network-vpn";
 
+PRODBETAEXPR(QString, mozillaSubscriptionsUrl,
+             "https://subscriptions.firefox.com/subscriptions",
+             "https://payments-stage.fxa.nonprod.cloudops.mozgcp.net/subscriptions")
+
+PRODBETAEXPR(QString, contactSupportUrl,
+             "https://accounts.firefox.com/support",
+             "https://accounts.stage.mozaws.net/support")
+
 PRODBETAEXPR(QString, addonBaseUrl,
              "https://archive.mozilla.org/pub/vpn/addons/releases/latest/",
              Constants::envOrDefault(

--- a/src/apps/vpn/appconstants.h
+++ b/src/apps/vpn/appconstants.h
@@ -158,10 +158,6 @@ constexpr const char* GOOGLE_SUBSCRIPTIONS_URL =
 constexpr const char* MOZILLA_VPN_SUMO_URL =
     "https://support.mozilla.org/en-US/products/firefox-private-network-vpn";
 
-PRODBETAEXPR(QString, mozillaSubscriptionsUrl,
-             "https://subscriptions.firefox.com/subscriptions",
-             "https://payments-stage.fxa.nonprod.cloudops.mozgcp.net/subscriptions")
-
 PRODBETAEXPR(QString, contactSupportUrl,
              "https://accounts.firefox.com/support",
              "https://accounts.stage.mozaws.net/support")

--- a/src/apps/vpn/mozillavpn.cpp
+++ b/src/apps/vpn/mozillavpn.cpp
@@ -1357,8 +1357,16 @@ void MozillaVPN::registerUrlOpenerLabels() {
     return AppConstants::GOOGLE_SUBSCRIPTIONS_URL;
   });
 
+  uo->registerUrlLabel("manageSubscriptions", []() -> QString {
+    return AppConstants::mozillaSubscriptionsUrl();
+  });
+
   uo->registerUrlLabel("subscriptionFxa", []() -> QString {
     return QString("%1/subscriptions").arg(Constants::fxaUrl());
+  });
+
+  uo->registerUrlLabel("contactSupport", []() -> QString {
+    return AppConstants::contactSupportUrl();
   });
 
   uo->registerUrlLabel(

--- a/src/apps/vpn/mozillavpn.cpp
+++ b/src/apps/vpn/mozillavpn.cpp
@@ -1357,10 +1357,6 @@ void MozillaVPN::registerUrlOpenerLabels() {
     return AppConstants::GOOGLE_SUBSCRIPTIONS_URL;
   });
 
-  uo->registerUrlLabel("manageSubscriptions", []() -> QString {
-    return AppConstants::mozillaSubscriptionsUrl();
-  });
-
   uo->registerUrlLabel("subscriptionFxa", []() -> QString {
     return QString("%1/subscriptions").arg(Constants::fxaUrl());
   });


### PR DESCRIPTION
## Description

- Utilize correct addon api to open web links to subscription management and support pages

*This will be uplifted to 2.15

## Reference

[VPN-4674: Buttons in "Subscription Expiring" message do not work](https://mozilla-hub.atlassian.net/browse/VPN-4674?search_id=6d2f1509-d6d7-42a5-9d32-fe8d82acea16)