### PR TITLE
Minor fix and doc improvement for Android build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,6 +144,9 @@ windows/split-tunnel/*.sys
 windows/split-tunnel/*.dll
 windows/split-tunnel/.status
 
+# Mac OS X
+.DS_Store
+
 # Rust
 .cargo_home/
 .rustc_info.json

--- a/README.md
+++ b/README.md
@@ -410,9 +410,11 @@ to point to the Android SDK and NDK installation directories. Required NDK versi
 5. Add the Android NDK llvm prebuilt tools to your `PATH`. These are located under the Android NDK installation
 directory on `${ANDROID_NDK_ROOT}/toolchains/llvm/prebuilt/*/bin`.
 
-6. Install the Rust Android targets `rustup target add x86_64-linux-android i686-linux-android armv7-linux-androideabi aarch64-linux-android`.
+6. The Android build additionally requires cmake 3.10.2. You can install it using: `./sdkmanager --install "cmake;3.10.2.4988404"`.
 
-7. Build the apk
+7. Install the Rust Android targets `rustup target add x86_64-linux-android i686-linux-android armv7-linux-androideabi aarch64-linux-android`.
+
+8. Build the apk
 ```bash
 ./scripts/android/cmake.sh -d </path/to/Qt6/> -A <architecture> <debug|release>
 ```
@@ -420,10 +422,10 @@ Add the Adjust SDK token with `-a | --adjust <adjust_token>`.
 
 Valid architecture values: `x86`, `x86_64`, `armeabi-v7a` `arm64-v8a`, by default it will use all.
 
-8. The apk will be located in
+9. The apk will be located in
 `.tmp/src/android-build/build/outputs/apk/debug/android-build-debug.apk`
 
-9. Install with adb on device/emulator
+10. Install with adb on device/emulator
 ```bash
 adb install .tmp/src/android-build/build/outputs/apk/debug/android-build-debug.apk
 ```

--- a/scripts/android/cmake.sh
+++ b/scripts/android/cmake.sh
@@ -69,7 +69,7 @@ while [[ $# -gt 0 ]]; do
     helpFunction
     ;;
   *)
-    if ! [[ "$$1" ]]; then
+    if [[ "$$1" ]]; then
       QTPATH="$1"
     fi
     shift


### PR DESCRIPTION
Kudos for the thorough documentation! There are just some minor things I ran into when setting up the build. Happy to split into separate PRs, if you prefer.

## Description
- According to the [README](https://github.com/mozilla-mobile/mozilla-vpn-client#how-to-build-from-source-code-for-android), it should be possible to pass the `QTPATH` as the first argument to `/scripts/android/cmake.sh`, but the condition for the parameter check is currently inverted.
- The Android build requires `cmake` 3.10.2 in addition to cmake > 3.16 for the main build. I added a note to the README on how to install it. See also: https://github.com/mozilla-mobile/mozilla-vpn-client/blob/main/taskcluster/docker/android-qt6-build/Dockerfile#L61.
- Added .DS_Store to .gitignore for Mac OS X builds

## Reference

N/A

## Checklist
    
- [X] My code follows the style guidelines for this project
- [X] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [X] I have performed a self review of my own code
- [X] I have commented my code PARTICULARLY in hard to understand areas
- [X] I have added thorough tests where needed
