### PR TITLE
VPN-4699: Disable "Subscription expiring" message

### DIFF
--- a/addons/message_subscription_expiring/manifest.json
+++ b/addons/message_subscription_expiring/manifest.json
@@ -5,7 +5,7 @@
   "type": "message",
   "conditions": {
     "javascript": "isExpiring.js",
-    "min_client_version": "2.15.0"
+    "min_client_version": "100.15.0"
   },
   "message": {
     "id": "message_subscription_expiring",


### PR DESCRIPTION
## Description

- Disables the "Subscription expiring" message until other bugs are resolved

## Reference

[VPN-4699: Disable "Subscription expiring" message addon for 2.15 addon RC](https://mozilla-hub.atlassian.net/browse/VPN-4699)
