### PR TITLE
Linux deduplicate applications

### DIFF
--- a/src/platforms/linux/daemon/apptracker.h
+++ b/src/platforms/linux/daemon/apptracker.h
@@ -15,14 +15,28 @@ class QDBusInterface;
 
 class AppData {
  public:
-  AppData(const QString& path) : cgroup(path) { MZ_COUNT_CTOR(AppData); }
+  AppData(const QString& path) : m_cgroup(path) { MZ_COUNT_CTOR(AppData); }
   ~AppData() { MZ_COUNT_DTOR(AppData); }
 
-  QList<int> pids() const;
+  static QString getDesktopFileId(const QString& filePath);
 
-  const QString cgroup;
-  QString appId;
-  int rootpid = 0;
+  QList<int> pids() const;
+  const QString& cgroup() const { return m_cgroup; }
+  const QString& appId() const { return m_appId; }
+  const QString& desktopFileId() const { return m_appDesktopFileId; }
+  int rootpid() const { return m_rootpid; }
+
+  void setAppId(const QString& appId) {
+    m_appId = appId;
+    m_appDesktopFileId = getDesktopFileId(appId);
+  }
+  void setRootPid(int rootpid) { m_rootpid = rootpid; }
+
+ private:
+  const QString m_cgroup;
+  QString m_appId;
+  QString m_appDesktopFileId;
+  int m_rootpid = 0;
 };
 
 class AppTracker final : public QObject {

--- a/src/platforms/linux/daemon/dbusservice.cpp
+++ b/src/platforms/linux/daemon/dbusservice.cpp
@@ -220,6 +220,7 @@ QString DBusService::runningApps() {
     appObject.insert("appId", QJsonValue(data->appId()));
     appObject.insert("cgroup", QJsonValue(data->cgroup()));
     appObject.insert("rootpid", QJsonValue(data->rootpid()));
+    appObject.insert("desktopFileId", QJsonValue(data->desktopFileId()));
 
     for (int pid : data->pids()) {
       pidList.append(QJsonValue(pid));

--- a/src/platforms/linux/linuxapplistprovider.h
+++ b/src/platforms/linux/linuxapplistprovider.h
@@ -18,7 +18,8 @@ class LinuxAppListProvider final : public AppListProvider {
   void getApplicationList() override;
 
  private:
-  void fetchEntries(const QString& dataDir, QMap<QString, QString>& map,
+  void fetchEntries(const QString& dataDir,
+                    QMap<QString, QPair<QString, QString>>& map,
                     const QSet<QString>& desktopEnv);
 };
 


### PR DESCRIPTION
## Description

Continuation of #6748. Reduces deduplication of listed applications by using spec-defined “desktop file id” to determine which desktop files describe the same applications. The id used remains a full path, which is the path to the highest-priority of synonymous desktop files.

Enabling split-tunnelling with the path to a desktop file:
```
> dbus-send --system --print-reply --dest=org.mozilla.vpn.dbus / org.mozilla.vpn.dbus.firewallApp string:/usr/share/applications/org.kde.konsole.desktop string:excluded
method return time=1682532218.386327 sender=:1.2484 -> destination=:1.2490 serial=16 reply_serial=2
   boolean true
```
Disabling split-tunnelling with the path to a _different_ desktop file for the _same_ application:
```
> dbus-send --system --print-reply --dest=org.mozilla.vpn.dbus / org.mozilla.vpn.dbus.firewallApp string:/home/me/.local/share/applications/org.kde.konsole.desktop string:enabled
method return time=1682532257.420923 sender=:1.2484 -> destination=:1.2492 serial=18 reply_serial=2
   boolean true
```

Logs correctly match the same cgroups on disabling and enabling:
```
[26.04.2023 19:03:36.256] (LogHandler) Debug: Log file: /var/log/mozillavpn.txt
[26.04.2023 19:03:38.385] (DBusService) Debug: Setting /usr/share/applications/org.kde.konsole.desktop to firewall state excluded
[26.04.2023 19:03:38.385] (WireguardUtilsLinux) Info: Excluding traffic from /user.slice/user-1000.slice/user@1000.service/app.slice/app-org.kde.konsole-d6fd723a47e742bd8ffa9da7339a7f15.scope
[26.04.2023 19:03:38.385] (WireguardUtilsLinux) Debug: NetfilterGo: Marking traffic from cgroup /user.slice/user-1000.slice/user@1000.service/app.slice/app-org.kde.konsole-d6fd723a47e742bd8ffa9da7339a7f15.scope
[26.04.2023 19:03:38.385] (WireguardUtilsLinux) Info: Excluding traffic from /user.slice/user-1000.slice/user@1000.service/app.slice/app-org.kde.konsole-5afc15d0d51f47fca579aeae8c3e5025.scope
[26.04.2023 19:03:38.385] (WireguardUtilsLinux) Debug: NetfilterGo: Marking traffic from cgroup /user.slice/user-1000.slice/user@1000.service/app.slice/app-org.kde.konsole-5afc15d0d51f47fca579aeae8c3e5025.scope
[26.04.2023 19:04:17.376] (DBusService) Debug: Setting /home/user/.local/share/applications/org.kde.konsole.desktop to firewall state enabled
[26.04.2023 19:04:17.377] (WireguardUtilsLinux) Info: Permitting traffic from /user.slice/user-1000.slice/user@1000.service/app.slice/app-org.kde.konsole-d6fd723a47e742bd8ffa9da7339a7f15.scope
[26.04.2023 19:04:17.377] (WireguardUtilsLinux) Debug: NetfilterGo: Deleting mozvpn-mangle rule handle 15
[26.04.2023 19:04:17.377] (WireguardUtilsLinux) Debug: NetfilterGo: Deleting mozvpn-nat rule handle 16
[26.04.2023 19:04:17.400] (WireguardUtilsLinux) Info: Permitting traffic from /user.slice/user-1000.slice/user@1000.service/app.slice/app-org.kde.konsole-5afc15d0d51f47fca579aeae8c3e5025.scope
[26.04.2023 19:04:17.400] (WireguardUtilsLinux) Debug: NetfilterGo: Deleting mozvpn-mangle rule handle 17
[26.04.2023 19:04:17.400] (WireguardUtilsLinux) Debug: NetfilterGo: Deleting mozvpn-nat rule handle 18
[26.04.2023 19:04:20.399] (DBusService) Debug: Log request
```

I’ve also created a synonymous desktop file to test the feature, here I override the thunderbird Icon entry:
```
> diff -u /usr/share/applications/thunderbird.desktop ~/.local/share/applications/thunderbird.desktop
--- /usr/share/applications/thunderbird.desktop 2023-03-27 19:29:46.000000000 +0100
+++ /home/  /.local/share/applications/thunderbird.desktop 2023-04-26 19:13:32.276234999 +0100
@@ -6,7 +6,7 @@
 Comment=Mail/News Client
 TryExec=thunderbird
 Exec=thunderbird %u
-Icon=thunderbird
+Icon=mail-client
 Terminal=false
 Type=Application
 StartupNotify=true
```

Result is as expected, using the highest priority file instead of listing 2 duplicates:

![screen](https://user-images.githubusercontent.com/6126377/234969386-5e3b8e2d-7496-4818-a4f8-bbdcacac2687.png)



## Reference

None

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
