### PR TITLE
Chore: A more reliable crash testing method for Windows

### DIFF
--- a/src/shared/platforms/windows/windowsutils.cpp
+++ b/src/shared/platforms/windows/windowsutils.cpp
@@ -5,6 +5,7 @@
 #include "windowsutils.h"
 
 #include <Windows.h>
+#include <errhandlingapi.h>
 
 #include <QSettings>
 #include <QSysInfo>
@@ -50,4 +51,9 @@ QString WindowsUtils::windowsVersion() {
     return "11";
   }
   return QSysInfo::productVersion();
+}
+
+// static
+void WindowsUtils::forceCrash() {
+  RaiseException(0x0000DEAD, EXCEPTION_NONCONTINUABLE, 0, NULL);
 }

--- a/src/shared/platforms/windows/windowsutils.h
+++ b/src/shared/platforms/windows/windowsutils.h
@@ -14,6 +14,9 @@ class WindowsUtils final {
 
   // Returns the major version of Windows
   static QString windowsVersion();
+
+  // Force an application crash for testing
+  static void forceCrash();
 };
 
 #endif  // WINDOWSUTILS_H

--- a/src/shared/utils.cpp
+++ b/src/shared/utils.cpp
@@ -14,6 +14,9 @@
 #ifdef MZ_ANDROID
 #  include "platforms/android/androidcommons.h"
 #endif
+#ifdef MZ_WINDOWS
+#  include "platforms/windows/windowsutils.h"
+#endif
 
 #include <QApplication>
 #include <QClipboard>
@@ -46,13 +49,7 @@ void Utils::crashTest() {
 
 #ifdef MZ_WINDOWS
   // Windows does not have "signals"
-  //   qFatal("Ready to crash!") does not work as expected.
-  // QT raises a debugmessage (in debugmode) - which we would handle
-  // in release-mode however this end's with QT just doing a clean shutdown
-  // so breakpad does not kick in.
-  int i = 1;
-  QString* ohno = (QString*)i--;
-  ohno->at(1);
+  WindowsUtils::forceCrash();
 #else
   // On Linux/osx this generates a Sigabort, which is handled
   qFatal("Ready to crash!");


### PR DESCRIPTION
## Description
While trying to make sure that the crash reporter is working, I encountered a few intermittent builds where the `Test Crash Reporter` button wasn't able to actually crash the client. So I felt like making this a more reliable crash by using the Win32 API `RaiseException()` instead.

## Checklist
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
