### PR TITLE
VPN-4007: Fix symbol generation for Windows builds.

### DIFF
--- a/src/apps/vpn/cmake/windows.cmake
+++ b/src/apps/vpn/cmake/windows.cmake
@@ -9,13 +9,6 @@ set_target_properties(mozillavpn PROPERTIES
     VERSION ${CMAKE_PROJECT_VERSION}
     WIN32_EXECUTABLE ON
 )
-# Todo: This will force the generation of a .pdb
-# ignoring buildmode. we need to fix the relwithdebug target
-# and then we can remove this :) 
-target_compile_options(mozillavpn
-    PRIVATE 
-    $<$<CONFIG:Release>:/ZI>
-)
 
 # Generate the Windows version resource file.
 configure_file(../windows/version.rc.in ${CMAKE_CURRENT_BINARY_DIR}/version.rc)

--- a/src/apps/vpn/cmake/windows.cmake
+++ b/src/apps/vpn/cmake/windows.cmake
@@ -10,6 +10,17 @@ set_target_properties(mozillavpn PROPERTIES
     WIN32_EXECUTABLE ON
 )
 
+# When used with MSVC, we find that RelWithDebInfo produces rather suboptimal
+# compiler flags. If we want to generate debugging symbols, then we should
+# add them to the Release configuration instead.
+#
+# See: https://gitlab.kitware.com/cmake/cmake/-/issues/20812
+#
+if(MSVC)
+    target_compile_options(mozillavpn PRIVATE $<$<CONFIG:Release>:/Zi>)
+    target_link_options(mozillavpn PRIVATE $<$<CONFIG:Release>:/debug>)
+endif()
+
 # Generate the Windows version resource file.
 configure_file(../windows/version.rc.in ${CMAKE_CURRENT_BINARY_DIR}/version.rc)
 target_sources(mozillavpn PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/version.rc)

--- a/taskcluster/scripts/build/windows.ps1
+++ b/taskcluster/scripts/build/windows.ps1
@@ -68,10 +68,10 @@ if ($env:MOZ_SCM_LEVEL -eq "3") {
     $SENTRY_ENVELOPE_ENDPOINT = Get-Content sentry_envelope_endpoint
     $SENTRY_DSN = Get-Content sentry_dsn
     #
-    cmake -S $SOURCE_DIR -B $BUILD_DIR -GNinja -DCMAKE_BUILD_TYPE=Release -DSENTRY_DSN="$SENTRY_DSN" -DSENTRY_ENVELOPE_ENDPOINT="$SENTRY_ENVELOPE_ENDPOINT"
+    cmake -S $SOURCE_DIR -B $BUILD_DIR -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DSENTRY_DSN="$SENTRY_DSN" -DSENTRY_ENVELOPE_ENDPOINT="$SENTRY_ENVELOPE_ENDPOINT"
 } else {
     # Do the generic build
-   cmake -S $SOURCE_DIR -B $BUILD_DIR -GNinja -DCMAKE_BUILD_TYPE=Release
+   cmake -S $SOURCE_DIR -B $BUILD_DIR -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo
 }
 cmake --build $BUILD_DIR
 cmake --build $BUILD_DIR --target msi

--- a/taskcluster/scripts/build/windows.ps1
+++ b/taskcluster/scripts/build/windows.ps1
@@ -67,11 +67,11 @@ if ($env:MOZ_SCM_LEVEL -eq "3") {
     python3  $SOURCE_DIR/taskcluster/scripts/get-secret.py -s project/mozillavpn/tokens -k sentry_debug_file_upload_key -f sentry_debug_file_upload_key
     $SENTRY_ENVELOPE_ENDPOINT = Get-Content sentry_envelope_endpoint
     $SENTRY_DSN = Get-Content sentry_dsn
-    #
-    cmake -S $SOURCE_DIR -B $BUILD_DIR -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DSENTRY_DSN="$SENTRY_DSN" -DSENTRY_ENVELOPE_ENDPOINT="$SENTRY_ENVELOPE_ENDPOINT"
+    # Do the release build
+    cmake -S $SOURCE_DIR -B $BUILD_DIR -GNinja -DCMAKE_BUILD_TYPE=Release -DSENTRY_DSN="$SENTRY_DSN" -DSENTRY_ENVELOPE_ENDPOINT="$SENTRY_ENVELOPE_ENDPOINT"
 } else {
     # Do the generic build
-   cmake -S $SOURCE_DIR -B $BUILD_DIR -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo
+    cmake -S $SOURCE_DIR -B $BUILD_DIR -GNinja -DCMAKE_BUILD_TYPE=Release
 }
 cmake --build $BUILD_DIR
 cmake --build $BUILD_DIR --target msi

--- a/taskcluster/scripts/build/windows.ps1
+++ b/taskcluster/scripts/build/windows.ps1
@@ -81,8 +81,7 @@ Write-Output "Writing Artifacts"
 New-Item -ItemType Directory -Path "$TASK_WORKDIR/artifacts" -Force
 $ARTIFACTS_PATH =resolve-path "$TASK_WORKDIR/artifacts"
 Copy-Item -Path $BUILD_DIR/windows/installer/MozillaVPN.msi -Destination $ARTIFACTS_PATH/MozillaVPN.msi
-# Note: vc140.pdb is just the default name for pdb files (as we are using vc14x)
-Copy-Item -Path "$BUILD_DIR/src/CMakeFiles/mozillavpn.dir/vc140.pdb" -Destination "$ARTIFACTS_PATH/Mozilla VPN.pdb"
+Copy-Item -Path "$BUILD_DIR/src/Mozilla VPN.pdb" -Destination "$ARTIFACTS_PATH/Mozilla VPN.pdb"
 Compress-Archive -Path $TASK_WORKDIR/unsigned/* -Destination $ARTIFACTS_PATH/unsigned.zip
 Write-Output "Artifacts Location:$TASK_WORKDIR/artifacts"
 Get-ChildItem -Path $TASK_WORKDIR/artifacts
@@ -91,7 +90,7 @@ if ($env:MOZ_SCM_LEVEL -eq "3") {
     sentry-cli-Windows-x86_64.exe login --auth-token $(Get-Content sentry_debug_file_upload_key)
     # This will ask sentry to scan all files in there and upload
     # missing debug info, for symbolification
-    sentry-cli-Windows-x86_64.exe debug-files upload --org mozilla -p vpn-client $BUILD_DIR/src/CMakeFiles/mozillavpn.dir/vc140.pdb
+    sentry-cli-Windows-x86_64.exe debug-files upload --org mozilla -p vpn-client "$BUILD_DIR/src/Mozilla VPN.pdb"
 }
 
 # mspdbsrv might be stil running after the build, so we need to kill it


### PR DESCRIPTION
## Description
Due to some suboptimal support for `RelWithDebInfo` in CMake, we find that we have to manually enable debug symbol generation using the `/Zi` flag, unfortunately it seems that we missed that we also need to specify `/debug` as a linker option in order to produce the PDB file too.

Furthermore, the generated `vc140.pdb` with just `/Zi` was a red herring. Those were the debug symbols for the C++ runtime which don't actually include any symbols for our application.

I'm not entirely sure how to test this without pushing to the main branch, but I am significantly happier with the build artifacts that we are generating now.

## Reference
Github issue #5766 ([VPN-4007](https://mozilla-hub.atlassian.net/browse/VPN-4007))
CMake `RelWithDebInfo` issue: https://gitlab.kitware.com/cmake/cmake/-/issues/20812

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-4007]: https://mozilla-hub.atlassian.net/browse/VPN-4007?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ