### PR TITLE
Chore: Truncate logs instead of clearing them

### DIFF
--- a/src/apps/auth_tests/main.cpp
+++ b/src/apps/auth_tests/main.cpp
@@ -41,7 +41,7 @@ int main(int argc, char* argv[]) {
   settingsHolder.setFeaturesFlippedOn(QStringList{
       "inAppAccountCreate", "inAppAuthentication", "accountDeletion"});
 
-  LogHandler::enableStderr();
+  LogHandler::setStderr(true);
   MZGlean::registerLogHandler(LogHandler::rustMessageHandler);
 
   QString nonce = QString::number(QDateTime::currentSecsSinceEpoch());

--- a/src/apps/unit_tests/main.cpp
+++ b/src/apps/unit_tests/main.cpp
@@ -58,7 +58,7 @@ int main(int argc, char* argv[]) {
 
   int failures = 0;
 
-  LogHandler::enableStderr();
+  LogHandler::setStderr(true);
 
   // If arguments were passed, then run a subset of tests.
   QStringList args = app.arguments();

--- a/src/apps/unit_tests/testlogger.h
+++ b/src/apps/unit_tests/testlogger.h
@@ -11,4 +11,6 @@ class TestLogger final : public TestHelper {
   void logger();
 
   void logHandler();
+
+  void logTruncation();
 };

--- a/src/apps/vpn/command.cpp
+++ b/src/apps/vpn/command.cpp
@@ -97,7 +97,7 @@ int Command::runCommandLineApp(std::function<int()>&& a_callback) {
 
   if (settingsHolder.stagingServer()) {
     AppConstants::setStaging();
-    LogHandler::enableStderr();
+    LogHandler::setStderr(true);
   }
 
   MZGlean::registerLogHandler(LogHandler::rustMessageHandler);
@@ -124,7 +124,7 @@ int Command::runGuiApp(std::function<int()>&& a_callback) {
 
   if (settingsHolder.stagingServer()) {
     AppConstants::setStaging();
-    LogHandler::enableStderr();
+    LogHandler::setStderr(true);
   }
 
   MZGlean::registerLogHandler(LogHandler::rustMessageHandler);
@@ -158,7 +158,7 @@ int Command::runQmlApp(std::function<int()>&& a_callback) {
 
   if (settingsHolder.stagingServer()) {
     AppConstants::setStaging();
-    LogHandler::enableStderr();
+    LogHandler::setStderr(true);
   }
 
   MZGlean::registerLogHandler(LogHandler::rustMessageHandler);

--- a/src/shared/loghandler.h
+++ b/src/shared/loghandler.h
@@ -82,7 +82,7 @@ class LogHandler final : public QObject {
 
   static void setLocation(const QString& path);
 
-  static void enableStderr();
+  static void setStderr(bool enabled = true);
 
   void serializeLogs(QTextStream* out,
                      std::function<void()>&& finalizeCallback);
@@ -108,6 +108,9 @@ class LogHandler final : public QObject {
   void closeLogFile(const QMutexLocker<QMutex>& proofOfLock);
 
   static void cleanupLogFile(const QMutexLocker<QMutex>& proofOfLock);
+
+  static void truncateLogFile(const QMutexLocker<QMutex>& proofOfLock,
+                              const QString& filename);
 
   bool writeAndShowLogs(QStandardPaths::StandardLocation location);
 

--- a/tests/unit/main.cpp
+++ b/tests/unit/main.cpp
@@ -86,7 +86,7 @@ int main(int argc, char* argv[]) {
       TestHelper::networkRequestPost, TestHelper::networkRequestPostIODevice);
 
   I18nStrings::initialize();
-  LogHandler::enableStderr();
+  LogHandler::setStderr(true);
   MZGlean::registerLogHandler(LogHandler::rustMessageHandler);
 
   // If arguments were passed, then run a subset of tests.


### PR DESCRIPTION
## Description
A common problem that I have encountered when analyzing log files is that the user will report an issue and when we ask for logs, we only receive a file that contains the launch of the client and the user clicking the export logs button. What I suspect is really occuring is that the VPN client is left to run for an extended period of time such that the log file exceeds `LOG_MAX_FILE_SIZE`. Then the next time the log file gets opened, its contents are simply erased and we lose the logs of the issue.

This is probably more common that we expect, since the client never really closes, it just goes into the background. Meaning that many users have the VPN client generating log data for days at a time.

To try and make an attempt to preserve logs, instead of clearing an oversize log file, we should instead make an attempt to truncate the file down to `LOG_MAX_FILE_SIZE / 2` while retaining the tail of the log.

## Reference

    i.e Jira or Github issue URL

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
