### PR TITLE
VPN-4695: Patch rust/openssl for Ubuntu bionic

### DIFF
--- a/linux/debian/patches/0001-Fix-link-errors-for-X509_get0_authority_xxx-methods-.patch
+++ b/linux/debian/patches/0001-Fix-link-errors-for-X509_get0_authority_xxx-methods-.patch
@@ -1,0 +1,81 @@
+From 7756ab8a9a0faed77b674f2b44736ec31a726713 Mon Sep 17 00:00:00 2001
+From: Naomi Kirby <oskirby@gmail.com>
+Date: Wed, 26 Apr 2023 14:46:10 -0700
+Subject: [PATCH 1/2] Fix link errors for X509_get0_authority_xxx methods on
+ Ubuntu/bionic
+
+---
+ qtglean/vendor/openssl-sys/build/cfgs.rs             | 3 +++
+ qtglean/vendor/openssl-sys/src/handwritten/x509v3.rs | 4 ++--
+ qtglean/vendor/openssl/src/x509/mod.rs               | 4 ++--
+ qtglean/vendor/openssl/src/x509/tests.rs             | 2 +-
+ 4 files changed, 8 insertions(+), 5 deletions(-)
+
+diff --git a/qtglean/vendor/openssl-sys/build/cfgs.rs b/qtglean/vendor/openssl-sys/build/cfgs.rs
+index 960515f0..f09ec29b 100644
+--- a/qtglean/vendor/openssl-sys/build/cfgs.rs
++++ b/qtglean/vendor/openssl-sys/build/cfgs.rs
+@@ -91,6 +91,9 @@ pub fn get(openssl_version: Option<u64>, libressl_version: Option<u64>) -> Vec<&
+         if openssl_version >= 0x1_01_01_03_0 {
+             cfgs.push("ossl111c");
+         }
++        if openssl_version >= 0x1_01_01_04_0 {
++            cfgs.push("ossl111d");
++        }
+     }
+ 
+     cfgs
+diff --git a/qtglean/vendor/openssl-sys/src/handwritten/x509v3.rs b/qtglean/vendor/openssl-sys/src/handwritten/x509v3.rs
+index 09a92640..7789b629 100644
+--- a/qtglean/vendor/openssl-sys/src/handwritten/x509v3.rs
++++ b/qtglean/vendor/openssl-sys/src/handwritten/x509v3.rs
+@@ -106,9 +106,9 @@ extern "C" {
+     pub fn X509_get0_subject_key_id(x: *mut X509) -> *const ASN1_OCTET_STRING;
+     #[cfg(ossl110)]
+     pub fn X509_get0_authority_key_id(x: *mut X509) -> *const ASN1_OCTET_STRING;
+-    #[cfg(ossl111)]
++    #[cfg(ossl111d)]
+     pub fn X509_get0_authority_issuer(x: *mut X509) -> *const stack_st_GENERAL_NAME;
+-    #[cfg(ossl111)]
++    #[cfg(ossl111d)]
+     pub fn X509_get0_authority_serial(x: *mut X509) -> *const ASN1_INTEGER;
+ }
+ 
+diff --git a/qtglean/vendor/openssl/src/x509/mod.rs b/qtglean/vendor/openssl/src/x509/mod.rs
+index 2753d091..a8e298bf 100644
+--- a/qtglean/vendor/openssl/src/x509/mod.rs
++++ b/qtglean/vendor/openssl/src/x509/mod.rs
+@@ -505,7 +505,7 @@ impl X509Ref {
+ 
+     /// Returns this certificate's authority issuer name entries, if they exist.
+     #[corresponds(X509_get0_authority_issuer)]
+-    #[cfg(ossl111)]
++    #[cfg(ossl111d)]
+     pub fn authority_issuer(&self) -> Option<&StackRef<GeneralName>> {
+         unsafe {
+             let stack = ffi::X509_get0_authority_issuer(self.as_ptr());
+@@ -515,7 +515,7 @@ impl X509Ref {
+ 
+     /// Returns this certificate's authority serial number, if it exists.
+     #[corresponds(X509_get0_authority_serial)]
+-    #[cfg(ossl111)]
++    #[cfg(ossl111d)]
+     pub fn authority_serial(&self) -> Option<&Asn1IntegerRef> {
+         unsafe {
+             let r = ffi::X509_get0_authority_serial(self.as_ptr());
+diff --git a/qtglean/vendor/openssl/src/x509/tests.rs b/qtglean/vendor/openssl/src/x509/tests.rs
+index d4dbf316..c5ea6acc 100644
+--- a/qtglean/vendor/openssl/src/x509/tests.rs
++++ b/qtglean/vendor/openssl/src/x509/tests.rs
+@@ -195,7 +195,7 @@ fn test_authority_key_id() {
+ }
+ 
+ #[test]
+-#[cfg(ossl111)]
++#[cfg(ossl111d)]
+ fn test_authority_issuer_and_serial() {
+     let cert = include_bytes!("../../test/authority_key_identifier.pem");
+     let cert = X509::from_pem(cert).unwrap();
+-- 
+2.40.0
+

--- a/linux/debian/patches/0002-Fix-tests-on-Ubuntu-bionic-too.patch
+++ b/linux/debian/patches/0002-Fix-tests-on-Ubuntu-bionic-too.patch
@@ -1,0 +1,32 @@
+From cd3803ec016258366b56607355f1a63738ddaf2c Mon Sep 17 00:00:00 2001
+From: Naomi Kirby <oskirby@gmail.com>
+Date: Wed, 26 Apr 2023 15:53:11 -0700
+Subject: [PATCH 2/2] Fix tests on Ubuntu/bionic too
+
+---
+ qtglean/vendor/openssl-sys/src/handwritten/ssl.rs | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/qtglean/vendor/openssl-sys/src/handwritten/ssl.rs b/qtglean/vendor/openssl-sys/src/handwritten/ssl.rs
+index f179a04a..039e2d91 100644
+--- a/qtglean/vendor/openssl-sys/src/handwritten/ssl.rs
++++ b/qtglean/vendor/openssl-sys/src/handwritten/ssl.rs
+@@ -905,9 +905,13 @@ extern "C" {
+     #[cfg(ossl111)]
+     pub fn SSL_set_num_tickets(s: *mut SSL, num_tickets: size_t) -> c_int;
+ 
+-    #[cfg(ossl111)]
++    #[cfg(ossl111b)]
+     pub fn SSL_CTX_get_num_tickets(ctx: *const SSL_CTX) -> size_t;
++    #[cfg(all(ossl111, not(ossl111b)))]
++    pub fn SSL_CTX_get_num_tickets(ctx: *mut SSL_CTX) -> size_t;
+ 
+-    #[cfg(ossl111)]
++    #[cfg(ossl111b)]
+     pub fn SSL_get_num_tickets(s: *const SSL) -> size_t;
++    #[cfg(all(ossl111, not(ossl111b)))]
++    pub fn SSL_get_num_tickets(s: *mut SSL) -> size_t;
+ }
+-- 
+2.40.0
+

--- a/scripts/linux/script.sh
+++ b/scripts/linux/script.sh
@@ -192,6 +192,11 @@ build_deb_source() {
   sed -i -e "s/SHORTVERSION/$SHORTVERSION/g" $WORKDIR/debian/changelog || die "Failed"
   sed -i -e "s/DATE/$(date -R)/g" $WORKDIR/debian/changelog || die "Failed"
 
+  # If there are patches to be applied, (re)generate the debian/patches/series file.
+  if [[ -d $WORKDIR/debian/patches ]]; then
+    ls $WORKDIR/debian/patches | grep -v '^series$' > $WORKDIR/debian/patches/series
+  fi
+
   # If a target distribution was provided, add a changelog entry targeting that distro.
   if [[ $# -gt 0 ]]; then
     export DEBEMAIL=${DEBEMAIL:-"vpn@mozilla.com"}


### PR DESCRIPTION
## Description
We are currently experiencing build issues on Ubuntu/bionic due to a bug upstream in the Rust/OpenSSL bindings. In order to work around the problem, add the upstream fixes to the vendored rust libraries during Debian packaging.

## Reference
Github issue #6772 ([VPN-4695](https://mozilla-hub.atlassian.net/browse/VPN-4695))
Upstream fix sfackler/rust-openssl#1909

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-4695]: https://mozilla-hub.atlassian.net/browse/VPN-4695?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ