### PR TITLE
VPN-4722: Remove glean/yaml linter.

### DIFF
--- a/qtglean/glean_parser_ext/run_glean_parser.py
+++ b/qtglean/glean_parser_ext/run_glean_parser.py
@@ -37,11 +37,7 @@ def parse_with_options(input_files, options):
     # Derived heavily from glean_parser.translate.translate.
     # Adapted to how mozbuild sends us a fd, and to expire on versions not dates.
 
-    # Lint the yaml first, then lint the metrics.
-    if lint.lint_yaml_files(input_files, parser_config=options):
-        # Warnings are Errors
-        raise ParserError("linter found problems")
-
+    # Parse and lint the metrics
     all_objs = parser.parse_objects(input_files, options)
     if util.report_validation_errors(all_objs):
         raise ParserError("found validation errors during parse")


### PR DESCRIPTION
## Description
Glean removed the YAML linter in version 7.2.0 due to a licensing conflict and this results in an error when trying to generate the metrics and bindings.

## Reference
Github issue #6828 [VPN-4722](https://mozilla-hub.atlassian.net/browse/VPN-4722)
Bugzilla issue: https://bugzilla.mozilla.org/show_bug.cgi?id=1830049

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
