### PR TITLE
VPN-4695: Force version downgrade for openssl and openssl-sys crates

### DIFF
--- a/qtglean/Cargo.toml
+++ b/qtglean/Cargo.toml
@@ -20,3 +20,8 @@ serde_json = "1.0.93"
 
 [build-dependencies]
 cbindgen = "0.24.3"
+
+# Ubuntu/bionic has a build failure, so let's force the rust-openssl version for this realease
+[patch.crates-io]
+openssl = { git = "https://github.com/sfackler/rust-openssl.git", version = "0.10.51" }
+openssl-sys = { git = "https://github.com/sfackler/rust-openssl.git", version = "0.9.86" }


### PR DESCRIPTION
## Description
Recently we have been failing to build the VPN client on Ubuntu/bionic due to a linker error between qtglean and libssl the offending symbols are `X509_get0_authority_issuer` and `X509_get0_authority_serial`. We have filed an upstream PR to fix the issue properly, but in order to get the 2.15.0 release building again, we may need to force a downgrade of the `openssl` and `openssl-sys` crates.

Note that this PR is only targeting the 2.15.0 release. I predict that we are either going to deprecate Ubuntu/bionic for 2.16.0, or the upstream project will release a fix.

## Reference
Github issue #6772 ([VPN-4695](https://mozilla-hub.atlassian.net/browse/VPN-4695))

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed


[VPN-4695]: https://mozilla-hub.atlassian.net/browse/VPN-4695?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ