### PR TITLE
Chore: Tighten up PPA Automation branch matching

### DIFF
--- a/.github/workflows/ppa-automation.yaml
+++ b/.github/workflows/ppa-automation.yaml
@@ -2,7 +2,7 @@ name: PPA Automated Releases
 on:
   push:
     branches:
-      - 'releases/**'
+      - 'releases/[0-9]+.[0-9a-z]+.[0-9a-z]+'
     tags:
       - 'v[0-9]+.[0-9a-z]+.[0-9a-z]+'
   schedule:


### PR DESCRIPTION
## Description
My test PPA recently had an erroneous push, which was trigger by the creation of a branch named `releases/addon_releases/2.14_mid_cycle_ship_paid_research` and this has fouled up the version numbering in the PPA. To prevent such issues from happening again, we should tighten the branch matching syntax.

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
