### PR TITLE
VPN-4568: Fix tutorial tooltip stutter on android

### DIFF
--- a/nebula/ui/components/MZTutorialPopups.qml
+++ b/nebula/ui/components/MZTutorialPopups.qml
@@ -39,6 +39,9 @@ Item {
     // and is reset before the tutorial is opened in onTooltipNeeded()
     property var targetElement: parent
 
+    //Temporarily holds the next tooltips text (fixes bug on android where text was changing before the tooltip moved)
+    property var tempTooltipText
+
     anchors.fill: parent
     visible: tutorialTooltip.visible || tutorialPopup.opened
 
@@ -56,7 +59,7 @@ Item {
         onTriggered: {
             tutorialTooltip.repositionTooltip()
             notch.repositionNotch()
-            tutorialTooltip.open()
+            tutorialTooltip.tooltipText = root.tempTooltipText;
         }
     }
 
@@ -81,17 +84,21 @@ Item {
                if (targetElementDistanceFromTop + targetElement.height + tutorialTooltip.implicitHeight > windowHeight) {
                    tooltipPositionedAboveTargetElement = true;
                    y = targetElementDistanceFromTop - targetElement.height - notchHeight * 2.5;
+                   tutorialTooltip.open()
+                   tutorialTooltip.visible = true
                    return
                }
 
                tooltipPositionedAboveTargetElement = false;
                y = targetElementDistanceFromTop + targetElement.height + notchHeight;
+               tutorialTooltip.open()
+               tutorialTooltip.visible = true
                return
            }
         }
 
         width: root.width - MZTheme.theme.windowMargin * 2
-        visible: MZTutorial.tooltipShown
+        visible: false
         x: MZTheme.theme.windowMargin
 
         background: Rectangle {
@@ -294,14 +301,18 @@ Item {
         }
 
         function onPlayingChanged() {
-            if (!MZTutorial.playing && tutorialPopup.opened && tutorialPopup.dismissOnStop) {
-                tutorialPopup.close();
+            if (!MZTutorial.playing) {
+                tutorialTooltip.close()
+                tutorialTooltip.visible = false
+                if (tutorialPopup.opened && tutorialPopup.dismissOnStop) {
+                    tutorialPopup.close();
+                }
             }
         }
 
         function onTooltipNeeded(text, targetEl) {
             root.targetElement = targetEl;
-            tutorialTooltip.tooltipText = text;
+            root.tempTooltipText= text;
         }
 
         function onTutorialCompleted(tutorial) {

--- a/nebula/ui/components/MZTutorialPopups.qml
+++ b/nebula/ui/components/MZTutorialPopups.qml
@@ -98,7 +98,6 @@ Item {
         }
 
         width: root.width - MZTheme.theme.windowMargin * 2
-        visible: false
         x: MZTheme.theme.windowMargin
 
         background: Rectangle {


### PR DESCRIPTION
## Description

- Fix stutter that would occur when the first tooltip of a tutorial would show

Before:

https://user-images.githubusercontent.com/15353801/236956840-3183ea51-a593-4e41-a2e7-3fc76883ab63.mp4

After: 

https://user-images.githubusercontent.com/15353801/236956735-aaa2cde2-4565-49ba-9d5a-d339d63c0343.mov

## Reference

[VPN-4568: [Android]  First tooltip of the tutorials is glitchy ](https://mozilla-hub.atlassian.net/browse/VPN-4568)