### PR TITLE
Chore: Enable cache for Ubuntu/lunar docker image

### DIFF
--- a/taskcluster/ci/docker-image/kind.yml
+++ b/taskcluster/ci/docker-image/kind.yml
@@ -101,7 +101,6 @@ tasks:
     linux-build-lunar:
         symbol: I(linux-lunar)
         definition: linux-dpkg-build
-        cache: false ## Disable caching while Ubuntu/Lunar is in beta.
         args:
             DOCKER_BASE_IMAGE: ubuntu:lunar
     linux-build-fedora-fc36:


### PR DESCRIPTION
## Description
We had disabled the cache for the Ubuntu/lunar docker image while Ubuntu/lunar was in beta so that we would receive updates as they resolved issues, but now that Ubuntu/lunar has received an official release we can  enable the cache again to reduce the load on Taskcluster.

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
