### PR TITLE
VPN-4725 - Reset windows split tunnel drive if it's already initialized

### DIFF
--- a/src/apps/vpn/platforms/windows/daemon/windowssplittunnel.cpp
+++ b/src/apps/vpn/platforms/windows/daemon/windowssplittunnel.cpp
@@ -87,8 +87,16 @@ void WindowsSplitTunnel::initDriver() {
   }
   if (state >= STATE_INITIALIZED) {
     logger.debug() << "Driver already initialized: " << state;
-    return;
+    reset();
+
+    auto newState = getState();
+    logger.debug() << "New state after reset:" << newState;
+    if (newState >= STATE_INITIALIZED) {
+      logger.debug() << "Reset unsuccesfull";
+      return;
+    }
   }
+
   DWORD bytesReturned;
   auto ok = DeviceIoControl(m_driver, IOCTL_INITIALIZE, nullptr, 0, nullptr, 0,
                             &bytesReturned, nullptr);


### PR DESCRIPTION
This is a hunch. Neither me or @strseb were able to reproduce this issue on our own machines. 