### PR TITLE
Chore: Use Ninja for Linux

### DIFF
--- a/linux/debian/control
+++ b/linux/debian/control
@@ -2,7 +2,7 @@ Source: mozillavpn
 Section: net
 Priority: optional
 Maintainer: mozilla <vpn@mozilla.com>
-Build-Depends: debhelper (>= 9.20160709),
+Build-Depends: debhelper (>= 11.2),
                cdbs,
                cmake (>= 3.16~),
                flex,
@@ -23,6 +23,7 @@ Build-Depends: debhelper (>= 9.20160709),
                libsecret-1-dev,
                libssl-dev,
                libxkbcommon-dev,
+               ninja-build,
                qmake6 (>=6.2.0~),
                qt6-base-dev (>=6.2.0~),
                qt6-base-dev-tools (>=6.2.0~),

--- a/linux/debian/rules
+++ b/linux/debian/rules
@@ -12,7 +12,7 @@ ifneq (ok,$(shell dpkg --compare-versions $(GOLANG_NATIVE_VERSION) ge 2:1.18 && 
 endif
 
 %:
-	dh $@ --with=systemd --warn-missing
+	dh $@ --with=systemd --buildsystem=cmake+ninja --warn-missing
 
 override_dh_auto_configure:
 	dh_auto_configure -- -DWEBEXT_INSTALL_LIBDIR=/lib -DBUILD_ID=$(DEB_VERSION) -DBUILD_TESTING=OFF

--- a/linux/debian/rules
+++ b/linux/debian/rules
@@ -17,6 +17,8 @@ endif
 override_dh_auto_configure:
 	dh_auto_configure -- -DWEBEXT_INSTALL_LIBDIR=/lib -DBUILD_ID=$(DEB_VERSION) -DBUILD_TESTING=OFF
 
+override_dh_auto_test:
+
 override_dh_installdocs:
 
 override_dh_installinfo:


### PR DESCRIPTION
## Description
Now that we are no longer required to support Ubuntu/bionic, we can switch to using Ninja as the official build system on Linux. It's faster and tends to manage dependencies significantly better than Make.

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
