### PR TITLE
VPN-4579 add daemon ping

### DIFF
--- a/src/apps/vpn/telemetry/pings.yaml
+++ b/src/apps/vpn/telemetry/pings.yaml
@@ -13,13 +13,27 @@ vpnsession:
   description: |
     Data for one VPN session, defined as a user turning on and eventually
     turning off the VPN in the app. This ping will record start/end datestamp,
-    session-based metrics, etc. It will be sent after the user turns off the
-    VPN, and a end datestamp is recorded.
+    session-based metrics, etc.
   include_client_id: true
   send_if_empty: false
   bugs:
     - https://mozilla-hub.atlassian.net/browse/VPN-4095
   data_reviews:
-    - N/A, will be done for metrics within
+    - https://github.com/mozilla-mobile/mozilla-vpn-client/pull/6130#pullrequestreview-1312098471
+  notification_emails:
+    - vpn@mozilla.com, mcleinman@mozilla.com
+
+daemonsession:
+  description: |
+    Only on iOS and Android.
+    Data for VPN sessions, as recorded from the Android daemon and
+    iOS Network Extension. This ping will record start/end datestamp,
+    session-based metrics, etc.
+  include_client_id: true
+  send_if_empty: false
+  bugs:
+    - https://mozilla-hub.atlassian.net/browse/VPN-4579
+  data_reviews:
+    - ADD AFTER THIS IS DONE - DO NOT MERGE WITH THIS TEXT
   notification_emails:
     - vpn@mozilla.com, mcleinman@mozilla.com

--- a/src/apps/vpn/telemetry/pings.yaml
+++ b/src/apps/vpn/telemetry/pings.yaml
@@ -34,6 +34,6 @@ daemonsession:
   bugs:
     - https://mozilla-hub.atlassian.net/browse/VPN-4579
   data_reviews:
-    - ADD AFTER THIS IS DONE - DO NOT MERGE WITH THIS TEXT
+    - N/A, will be done for metrics within
   notification_emails:
     - vpn@mozilla.com, mcleinman@mozilla.com


### PR DESCRIPTION
## Description

Adds new ping, to set up for future metrics work.

Also updates description for `vpnsession` ping to match latest plans per the [tech spec](https://mozilla-hub.atlassian.net/wiki/spaces/SECPRV/pages/184419319/VPN+session+pings+-+Tech+spec).

## Reference

https://mozilla-hub.atlassian.net/browse/VPN-4579

## Checklist
    
- [X] My code follows the style guidelines for this project
- [X] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [X] I have performed a self review of my own code
- [X] I have commented my code PARTICULARLY in hard to understand areas
- [X] I have added thorough tests where needed
