### PR TITLE
VPN-1990: Fix Linux split tunnel tracking on server switch

### DIFF
--- a/src/apps/vpn/platforms/linux/daemon/dbusservice.cpp
+++ b/src/apps/vpn/platforms/linux/daemon/dbusservice.cpp
@@ -124,6 +124,8 @@ bool DBusService::activate(const QString& jsonConfig) {
     return false;
   }
 
+  // (Re)load the split tunnelling configuration.
+  firewallClear();
   if (obj.contains("vpnDisabledApps")) {
     QJsonArray disabledApps = obj["vpnDisabledApps"].toArray();
     for (const QJsonValue& app : disabledApps) {


### PR DESCRIPTION
## Description
In the 2.15 release, we tried to add the ability to change VPN settings without requiring the user to deactivate the VPN, and this introduced a bug in the DBus `activate()` method where apps would be could be added to the exclusion list, but they were only removed upon deactivation. This leads to a situation where the user might turn off split tunnelling in the UI, but it still gets applied by the daemon.

## Reference
Github issue #3168 ([VPN-1990](https://mozilla-hub.atlassian.net/browse/VPN-1990))

## Checklist
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-1990]: https://mozilla-hub.atlassian.net/browse/VPN-1990?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ