### PR TITLE
VPN-4725: Apply app exclusions when server switching

### DIFF
--- a/src/apps/vpn/daemon/daemon.cpp
+++ b/src/apps/vpn/daemon/daemon.cpp
@@ -83,9 +83,13 @@ bool Daemon::activate(const InterfaceConfig& config) {
         return false;
       }
 
-      m_connections[config.m_hopindex] = ConnectionState(config);
-      m_handshakeTimer.start(HANDSHAKE_POLL_MSEC);
-      return true;
+      bool status = run(Switch, config);
+      logger.debug() << "Connection status:" << status;
+      if (status) {
+        m_connections[config.m_hopindex] = ConnectionState(config);
+        m_handshakeTimer.start(HANDSHAKE_POLL_MSEC);
+      }
+      return status;
     }
 
     logger.warning() << "Already connected. Server switching not supported.";

--- a/src/apps/vpn/daemon/daemon.h
+++ b/src/apps/vpn/daemon/daemon.h
@@ -20,6 +20,7 @@ class Daemon : public QObject {
   enum Op {
     Up,
     Down,
+    Switch,
   };
 
   explicit Daemon(QObject* parent);

--- a/src/apps/vpn/platforms/windows/daemon/windowsdaemon.cpp
+++ b/src/apps/vpn/platforms/windows/daemon/windowsdaemon.cpp
@@ -50,22 +50,25 @@ void WindowsDaemon::prepareActivation(const InterfaceConfig& config) {
 }
 
 bool WindowsDaemon::run(Op op, const InterfaceConfig& config) {
-  bool splitTunnelEnabled = config.m_vpnDisabledApps.length() > 0;
-
   if (op == Down) {
-    if (splitTunnelEnabled) {
-      m_splitTunnelManager.stop();
-    }
+    m_splitTunnelManager.stop();
     return true;
   }
-  if (splitTunnelEnabled) {
+
+  if (op == Up) {
     logger.debug() << "Tunnel UP, Starting SplitTunneling";
     if (!WindowsSplitTunnel::isInstalled()) {
       logger.warning() << "Split Tunnel Driver not Installed yet, fixing this.";
       WindowsSplitTunnel::installDriver();
     }
+  }
+
+  if (config.m_vpnDisabledApps.length() > 0) {
     m_splitTunnelManager.start(m_inetAdapterIndex);
     m_splitTunnelManager.setRules(config.m_vpnDisabledApps);
+  }
+  else {
+    m_splitTunnelManager.stop();
   }
   return true;
 }

--- a/src/apps/vpn/platforms/windows/daemon/windowsdaemon.cpp
+++ b/src/apps/vpn/platforms/windows/daemon/windowsdaemon.cpp
@@ -66,8 +66,7 @@ bool WindowsDaemon::run(Op op, const InterfaceConfig& config) {
   if (config.m_vpnDisabledApps.length() > 0) {
     m_splitTunnelManager.start(m_inetAdapterIndex);
     m_splitTunnelManager.setRules(config.m_vpnDisabledApps);
-  }
-  else {
+  } else {
     m_splitTunnelManager.stop();
   }
   return true;


### PR DESCRIPTION
## Description
The Windows platform applies the App exclusions in the `Daemon::run()` method, but this method is only invoked during the `Up` and `Down` events. It is not called during server switching, which prevents the user from changing app exclusion settings while the VPN is active. Even worse, by gating the split tunnelling driver operations on the length of the exclusion list (even during deactivation), this can also lead to cases where the driver is still applying an app exclusion even after manually toggling the VPN state.

To address these cases, we need to add a `Daemon::run()` operation for the silent server switch, and we should be a little more rigorous in our attempts to start and stop the driver in all cases.

## Reference
Github issue #6842 ([VPN-4725](https://mozilla-hub.atlassian.net/browse/VPN-4725))

## Checklist
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-4725]: https://mozilla-hub.atlassian.net/browse/VPN-4725?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ