### PR TITLE
Chore: do not search for strings in .ds_store

### DIFF
--- a/scripts/utils/generate_ts.sh
+++ b/scripts/utils/generate_ts.sh
@@ -24,7 +24,7 @@ print G "done."
 for project in src/apps/*; do
   project=$(basename $project)
 
-  [ $project = "auth_tests" ] || [ $project = "template" ] || [ "$project" = "unit_tests" ] && continue
+  [ $project = "auth_tests" ] || [ $project = "template" ] || [ "$project" = "unit_tests" ] || [ "$project" = ".DS_Store" ] && continue
 
   mkdir -p translations/generated/$project || die
 


### PR DESCRIPTION
## Description

This folder is a os-detail, we should not attempt to look for strings in there :) 