### PR TITLE
VPN-4192: Encode Glean FFI strings as UTF-8

### DIFF
--- a/qtglean/src/cpp/boolean.cpp
+++ b/qtglean/src/cpp/boolean.cpp
@@ -27,7 +27,7 @@ int32_t BooleanMetric::testGetNumRecordedErrors(ErrorType errorType) const {
 
 bool BooleanMetric::testGetValue(const QString& pingName) const {
 #ifndef __wasm__
-  return glean_boolean_test_get_value(m_id, pingName.toLocal8Bit());
+  return glean_boolean_test_get_value(m_id, pingName.toUtf8());
 #endif
   return false;
 }

--- a/qtglean/src/cpp/counter.cpp
+++ b/qtglean/src/cpp/counter.cpp
@@ -31,7 +31,7 @@ int32_t CounterMetric::testGetNumRecordedErrors(ErrorType errorType) const {
 
 int32_t CounterMetric::testGetValue(const QString& pingName) const {
 #ifndef __wasm__
-  return glean_counter_test_get_value(m_id, pingName.toLocal8Bit());
+  return glean_counter_test_get_value(m_id, pingName.toUtf8());
 #else
   Q_UNUSED(pingName);
   return 0;

--- a/qtglean/src/cpp/datetime.cpp
+++ b/qtglean/src/cpp/datetime.cpp
@@ -27,7 +27,7 @@ int32_t DatetimeMetric::testGetNumRecordedErrors(ErrorType errorType) const {
 
 QString DatetimeMetric::testGetValueAsString(const QString& pingName) const {
 #ifndef __wasm__
-  return glean_datetime_test_get_value_as_string(m_id, pingName.toLocal8Bit());
+  return glean_datetime_test_get_value_as_string(m_id, pingName.toUtf8());
 #endif
   return "";
 }

--- a/qtglean/src/cpp/event.cpp
+++ b/qtglean/src/cpp/event.cpp
@@ -100,7 +100,7 @@ int32_t EventMetric::testGetNumRecordedErrors(ErrorType errorType) const {
 
 QList<QJsonObject> EventMetric::testGetValue(const QString& pingName) const {
 #ifndef __wasm__
-  auto value = glean_event_test_get_value(m_id, pingName.toLocal8Bit());
+  auto value = glean_event_test_get_value(m_id, pingName.toUtf8());
   auto recordedEvents = QJsonDocument::fromJson(value).array();
   QList<QJsonObject> result;
   if (!recordedEvents.isEmpty()) {

--- a/qtglean/src/cpp/quantity.cpp
+++ b/qtglean/src/cpp/quantity.cpp
@@ -27,7 +27,7 @@ int32_t QuantityMetric::testGetNumRecordedErrors(ErrorType errorType) const {
 
 int64_t QuantityMetric::testGetValue(const QString& pingName) const {
 #ifndef __wasm__
-  return glean_quantity_test_get_value(m_id, pingName.toLocal8Bit());
+  return glean_quantity_test_get_value(m_id, pingName.toUtf8());
 #endif
   return 0;
 }

--- a/qtglean/src/cpp/string.cpp
+++ b/qtglean/src/cpp/string.cpp
@@ -14,7 +14,7 @@ StringMetric::StringMetric(int id) : m_id(id) {}
 
 void StringMetric::set(QString value) const {
 #ifndef __wasm__
-  return glean_string_set(m_id, value.toLocal8Bit());
+  return glean_string_set(m_id, value.toUtf8());
 #endif
 }
 
@@ -27,7 +27,7 @@ int32_t StringMetric::testGetNumRecordedErrors(ErrorType errorType) const {
 
 QString StringMetric::testGetValue(const QString& pingName) const {
 #ifndef __wasm__
-  return glean_string_test_get_value(m_id, pingName.toLocal8Bit());
+  return glean_string_test_get_value(m_id, pingName.toUtf8());
 #endif
   return "";
 }

--- a/qtglean/src/cpp/timingdistribution.cpp
+++ b/qtglean/src/cpp/timingdistribution.cpp
@@ -54,7 +54,7 @@ DistributionData TimingDistributionMetric::testGetValue(
     const QString& pingName) const {
 #ifndef __wasm__
   auto value = QJsonDocument::fromJson(
-      glean_timing_distribution_test_get_value(m_id, pingName.toLocal8Bit()));
+      glean_timing_distribution_test_get_value(m_id, pingName.toUtf8()));
 
   DistributionData result;
   if (!value.isEmpty()) {

--- a/qtglean/src/cpp/uuid.cpp
+++ b/qtglean/src/cpp/uuid.cpp
@@ -14,7 +14,7 @@ UuidMetric::UuidMetric(int id) : m_id(id) {}
 
 void UuidMetric::set(const QString& uuid) const {
 #ifndef __wasm__
-  return glean_uuid_set(m_id, uuid.toLocal8Bit());
+  return glean_uuid_set(m_id, uuid.toUtf8());
 #endif
 }
 
@@ -34,7 +34,7 @@ int32_t UuidMetric::testGetNumRecordedErrors(ErrorType errorType) const {
 
 QString UuidMetric::testGetValue(const QString& pingName) const {
 #ifndef __wasm__
-  return glean_uuid_test_get_value(m_id, pingName.toLocal8Bit());
+  return glean_uuid_test_get_value(m_id, pingName.toUtf8());
 #endif
   return "";
 }

--- a/src/shared/glean/mzglean.cpp
+++ b/src/shared/glean/mzglean.cpp
@@ -108,7 +108,7 @@ void MZGlean::initialize() {
 
 #if defined(UNIT_TEST)
     glean_test_reset_glean(SettingsHolder::instance()->gleanEnabled(),
-                           gleanDirectory.absolutePath().toLocal8Bit());
+                           gleanDirectory.absolutePath().toUtf8());
 #elif defined(MZ_IOS)
     new IOSGleanBridge(SettingsHolder::instance()->gleanEnabled(),
                        Constants::inProduction() ? "production" : "staging");
@@ -118,7 +118,7 @@ void MZGlean::initialize() {
         Constants::inProduction() ? "production" : "staging");
 #elif not(defined(MZ_WASM))
     glean_initialize(SettingsHolder::instance()->gleanEnabled(),
-                     gleanDirectory.absolutePath().toLocal8Bit(),
+                     gleanDirectory.absolutePath().toUtf8(),
                      Constants::inProduction() ? "production" : "staging");
 #endif
   }


### PR DESCRIPTION
## Description
Windows has its own 8-bit character encoding (CP-1251) which is generated by `QString::toLocal8Bit()` on Windows, but our FFI wrappers for Rust only accepts UTF-8. Normally, this difference in encoding goes unnoticed because both are supersets of ASCII. However, when the Windows account has a username containing non-ASCII characters, this results in an invalid UTF-8 string being generated for the glean directory path, but only on Windows. This causes the Glean initialization to fail, which prevents the app from launching.

To fix this, we should be using `QString::toUtf8()` when converting `QStrings` into a Rust `FfiStr`

## Reference
Github issue #6063 ([VPN-4192](https://mozilla-hub.atlassian.net/browse/VPN-4192))

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-4192]: https://mozilla-hub.atlassian.net/browse/VPN-4192?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ