### PR TITLE
VPN-4816: Linux postinst script to set cap_net_raw

### DIFF
--- a/linux/debian/control
+++ b/linux/debian/control
@@ -39,6 +39,7 @@ Vcs-Git: https://github.com/mozilla-mobile/mozilla-vpn-client
 Package: mozillavpn
 Architecture: any
 Depends: libpolkit-gobject-1-0 (>=0.105),
+         libcap2-bin (>=1:2.32),
          wireguard (>=1.0.20200319),
          wireguard-tools (>=1.0.20200319),
          libqt6quick6 (>=6.2.0~),

--- a/linux/debian/mozillavpn.postinst
+++ b/linux/debian/mozillavpn.postinst
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+action="$1"
+if [ "$action" = "configure" ]; then
+    setcap cap_net_raw+ep /usr/bin/mozillavpn
+fi
+exit 0


### PR DESCRIPTION
## Description
In playing with Ubuntu Lunar, I have been finding that user-accessible ICMP sockets are blocked by the system configuration. So let's see if we can get things working by running `setcap` as a postinst hook to enable raw socket access.

We need this capability for the recommended server list to generate latency data.

## Reference
Github issue #6930 ([VPN-4816](https://mozilla-hub.atlassian.net/browse/VPN-4816))

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-4816]: https://mozilla-hub.atlassian.net/browse/VPN-4816?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ