### PR TITLE
Fix Glean documentation to match current code

### DIFF
--- a/src/apps/vpn/telemetry/metrics_deprecated.yaml
+++ b/src/apps/vpn/telemetry/metrics_deprecated.yaml
@@ -845,8 +845,9 @@ sample:
       state:
         description: |
           The name of the app state, e.g. "authenticating", "device-limit",
-          "main", "subscription-needed", etc. The list can be found in
-          `mozillavpn.h`.
+          "main", "subscription-needed", etc. The complete list is
+          `app.h`'s `State` enum along with the `CustomState` enum in the
+          app's header file (e.g. `mozillavpn.h`).
         type: string
 
   controller_step:


### PR DESCRIPTION
## Description

Based on a question from the data team, I realized this entry was out of date with how our code changed to become a multi-product app. This updates the code, which will eventually update the Glean data dictionary.

## Reference

N/A

## Checklist
    
- [X] My code follows the style guidelines for this project
- [X] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [X] I have performed a self review of my own code
- [X] I have commented my code PARTICULARLY in hard to understand areas
- [X] I have added thorough tests where needed
