### PR TITLE
Chore: Wait for deactivation to finish during shutdown

### DIFF
--- a/src/apps/vpn/commands/commandui.cpp
+++ b/src/apps/vpn/commands/commandui.cpp
@@ -370,7 +370,7 @@ int CommandUI::run(QStringList& tokens) {
 
     QObject::connect(
         qApp, &QGuiApplication::commitDataRequest, &vpn,
-        []() { MozillaVPN::instance()->deactivate(); }, Qt::DirectConnection);
+        []() { MozillaVPN::instance()->deactivate(true); }, Qt::DirectConnection);
 
     QObject::connect(vpn.controller(), &Controller::readyToQuit, &vpn,
                      &App::quit, Qt::QueuedConnection);

--- a/src/apps/vpn/commands/commandui.cpp
+++ b/src/apps/vpn/commands/commandui.cpp
@@ -370,7 +370,8 @@ int CommandUI::run(QStringList& tokens) {
 
     QObject::connect(
         qApp, &QGuiApplication::commitDataRequest, &vpn,
-        []() { MozillaVPN::instance()->deactivate(true); }, Qt::DirectConnection);
+        []() { MozillaVPN::instance()->deactivate(true); },
+        Qt::DirectConnection);
 
     QObject::connect(vpn.controller(), &Controller::readyToQuit, &vpn,
                      &App::quit, Qt::QueuedConnection);

--- a/src/apps/vpn/mozillavpn.cpp
+++ b/src/apps/vpn/mozillavpn.cpp
@@ -976,12 +976,19 @@ void MozillaVPN::activate() {
       new TaskControllerAction(TaskControllerAction::eActivate));
 }
 
-void MozillaVPN::deactivate() {
+void MozillaVPN::deactivate(bool block) {
   logger.debug() << "VPN tunnel deactivation";
 
   TaskScheduler::deleteTasks();
-  TaskScheduler::scheduleTask(
-      new TaskControllerAction(TaskControllerAction::eDeactivate));
+  Task* task = new TaskControllerAction(TaskControllerAction::eDeactivate);
+  if (block) {
+    connect(task, &Task::completed, this, [&]() { block = false; });
+  }
+  TaskScheduler::scheduleTask(task);
+
+  while (block) {
+    QCoreApplication::processEvents();
+  }
 }
 
 void MozillaVPN::silentSwitch() {

--- a/src/apps/vpn/mozillavpn.h
+++ b/src/apps/vpn/mozillavpn.h
@@ -115,7 +115,7 @@ class MozillaVPN final : public App {
   Q_INVOKABLE void telemetryPolicyCompleted();
   Q_INVOKABLE void mainWindowLoaded();
   Q_INVOKABLE void activate();
-  Q_INVOKABLE void deactivate();
+  Q_INVOKABLE void deactivate(bool block = false);
   Q_INVOKABLE void refreshDevices();
   Q_INVOKABLE void update();
   Q_INVOKABLE void backendServiceRestore();

--- a/tests/qml/mocmozillavpn.cpp
+++ b/tests/qml/mocmozillavpn.cpp
@@ -99,7 +99,7 @@ void MozillaVPN::requestAbout() {}
 
 void MozillaVPN::activate() {}
 
-void MozillaVPN::deactivate() {}
+void MozillaVPN::deactivate(bool block) {}
 
 void MozillaVPN::refreshDevices() {}
 

--- a/tests/unit/mocmozillavpn.cpp
+++ b/tests/unit/mocmozillavpn.cpp
@@ -110,7 +110,7 @@ void MozillaVPN::requestAbout() {}
 
 void MozillaVPN::activate() {}
 
-void MozillaVPN::deactivate() {}
+void MozillaVPN::deactivate(bool block) {}
 
 void MozillaVPN::refreshDevices() {}
 


### PR DESCRIPTION
## Description

For GUI environments, the shutdown of the client is signalled by the session manager sending a `QGuiApplication::commitDataRequest()` signal, during which we take steps to deactivate the VPN. However, this often leaves the deactivation task running in the queue when we start to deallocate objects.

On MacOS, this frequently results in an assert with the following stack trace:
```
Thread 0 Crashed::  Dispatch queue: com.apple.main-thread
0   libsystem_kernel.dylib        	       0x18a916d78 __pthread_kill + 8
1   libsystem_pthread.dylib       	       0x18a94bee0 pthread_kill + 288
2   libsystem_c.dylib             	       0x18a886340 abort + 168
3   QtCore                        	       0x10a1d8e18 qAbort() + 12 (qglobal.cpp:3369)
4   QtCore                        	       0x10a1dcb34 qt_message_fatal(QtMsgType, QMessageLogContext const&, QString const&) + 12 (qlogging.cpp:1916)
5   QtCore                        	       0x10a4b7e50 QMessageLogger::fatal(char const*, ...) const + 76 (qlogging.cpp:850)
6   QtCore                        	       0x10a4b7824 qt_assert(char const*, char const*, int) + 60 (qglobal.cpp:3276)
7   Mozilla VPN                   	       0x105dee5d8 MozillaVPN::instance() (.cold.1) + 28 (mozillavpn.cpp:107)
8   Mozilla VPN                   	       0x1050ac894 MozillaVPN::instance() + 32 (mozillavpn.cpp:107)
9   Mozilla VPN                   	       0x1050dca0c TaskControllerAction::checkStatus() + 20 (taskcontrolleraction.cpp:100)
10  QtCore                        	       0x10a2824b4 QtPrivate::QSlotObjectBase::call(QObject*, void**) + 28 (qobjectdefs_impl.h:363) [inlined]
11  QtCore                        	       0x10a2824b4 void doActivate<false>(QObject*, int, void**) + 772 (qobject.cpp:3979)
12  QtCore                        	       0x10a295780 QTimer::timeout(QTimer::QPrivateSignal) + 28 (moc_qtimer.cpp:244) [inlined]
13  QtCore                        	       0x10a295780 QTimer::timerEvent(QTimerEvent*) + 208 (qtimer.cpp:244)
14  QtCore                        	       0x10a27acb4 QObject::event(QEvent*) + 88
```

As a quick fix, we can add an optional `block` parameter to `MozillaVPN::deactivate()` to wait until the deactivation has completed before proceeding with the shutdown.

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
