### PR TITLE
Add some unit test coverage for connection health

### DIFF
--- a/src/apps/vpn/pinghelper.h
+++ b/src/apps/vpn/pinghelper.h
@@ -59,6 +59,10 @@ class PingHelper final : public QObject {
 
   QTimer m_pingTimer;
   PingSender* m_pingSender = nullptr;
+
+#ifdef UNIT_TEST
+  friend class TestConnectionHealth;
+#endif
 };
 
 #endif  // PINGHELPER_H

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -43,6 +43,8 @@ target_sources(unit_tests PRIVATE
     ${MZ_SOURCE_DIR}/apps/vpn/appconstants.h
     ${MZ_SOURCE_DIR}/apps/vpn/captiveportal/captiveportal.cpp
     ${MZ_SOURCE_DIR}/apps/vpn/captiveportal/captiveportal.h
+    ${MZ_SOURCE_DIR}/apps/vpn/connectionhealth.cpp
+    ${MZ_SOURCE_DIR}/apps/vpn/connectionhealth.h
     ${MZ_SOURCE_DIR}/apps/vpn/command.cpp
     ${MZ_SOURCE_DIR}/apps/vpn/command.h
     ${MZ_SOURCE_DIR}/apps/vpn/commandlineparser.cpp
@@ -333,6 +335,8 @@ target_sources(unit_tests PRIVATE
     helper.h
     testaddon.cpp
     testaddon.h
+    testconnectionhealth.cpp
+    testconnectionhealth.h
     testcommandlineparser.cpp
     testcommandlineparser.h
     testdnshelper.cpp

--- a/tests/unit/mocmozillavpn.cpp
+++ b/tests/unit/mocmozillavpn.cpp
@@ -114,6 +114,8 @@ void MozillaVPN::deactivate(bool block) {}
 
 void MozillaVPN::refreshDevices() {}
 
+void MozillaVPN::silentSwitch() {}
+
 void MozillaVPN::update() {}
 
 void MozillaVPN::setUpdating(bool) {}

--- a/tests/unit/testconnectionhealth.cpp
+++ b/tests/unit/testconnectionhealth.cpp
@@ -1,0 +1,81 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "testconnectionhealth.h"
+
+#include "connectionhealth.h"
+
+void TestConnectionHealth::dnsPingReceived() {
+  ConnectionHealth connectionHealth;
+  connectionHealth.startIdle();
+  QVERIFY(!connectionHealth.m_dnsPingInitialized);
+
+  // Ping for invalid sequence number should not be accepted
+  connectionHealth.dnsPingReceived(42);
+  QVERIFY(!connectionHealth.m_dnsPingInitialized);
+
+  // Ping for matching sequence number should be accepted
+  connectionHealth.dnsPingReceived(connectionHealth.m_dnsPingSequence);
+  QVERIFY(connectionHealth.m_dnsPingInitialized);
+}
+
+void TestConnectionHealth::updateDnsPingLatency() {
+  ConnectionHealth connectionHealth;
+  std::vector<int> pings({100, 110, 120, 130, 140, 150, 160, 170, 180, 190});
+  float weight = 1.0 / PING_BASELINE_EWMA_DIVISOR;
+
+  // Verify latency measurement for each ping by calculating the
+  // Exponentially Weighted Moving Average.
+  for (int i = 0; i < pings.size(); i++) {
+    connectionHealth.updateDnsPingLatency(pings[i]);
+    int expectedLatency =
+        ewma(std::vector<int>(pings.begin(), pings.begin() + i + 1), weight);
+    QCOMPARE(connectionHealth.m_dnsPingLatency, expectedLatency);
+  }
+}
+
+void TestConnectionHealth::healthCheckup() {
+  ConnectionHealth connectionHealth;
+
+  // Signal timer is not active -> NoSignal
+  connectionHealth.healthCheckup();
+  QCOMPARE(connectionHealth.m_stability,
+           ConnectionHealth::ConnectionStability::NoSignal);
+
+  // Signal timer is active, but recent pings were lost -> Unstable
+  connectionHealth.startIdle();
+  connectionHealth.m_noSignalTimer.start();
+  for (int i = 0; i < connectionHealth.m_pingHelper.m_pingData.size(); i++) {
+    connectionHealth.m_pingHelper.m_pingData[i].timestamp =
+        QDateTime::currentMSecsSinceEpoch() - (60 * 1000);
+  }
+  connectionHealth.healthCheckup();
+  QCOMPARE(connectionHealth.m_stability,
+           ConnectionHealth::ConnectionStability::Unstable);
+
+  // Signal timer is active, recent pings not lost -> Stable
+  for (int i = 0; i < connectionHealth.m_pingHelper.m_pingData.size(); i++) {
+    connectionHealth.m_pingHelper.m_pingData[i].timestamp =
+        QDateTime::currentMSecsSinceEpoch();
+  }
+  connectionHealth.healthCheckup();
+  QCOMPARE(connectionHealth.m_stability,
+           ConnectionHealth::ConnectionStability::Stable);
+
+  // Signal timer is active, recent ping(s) took too long -> Unstable
+  connectionHealth.dnsPingReceived(connectionHealth.m_dnsPingSequence);
+  connectionHealth.m_pingHelper.m_pingData[0].latency = INT_MAX;
+  connectionHealth.healthCheckup();
+  QCOMPARE(connectionHealth.m_stability,
+           ConnectionHealth::ConnectionStability::Unstable);
+
+  // Signal timer is active, recent ping(s) arrived on time -> Back to Stable
+  connectionHealth.dnsPingReceived(connectionHealth.m_dnsPingSequence);
+  connectionHealth.m_pingHelper.m_pingData[0].latency = 0;
+  connectionHealth.healthCheckup();
+  QCOMPARE(connectionHealth.m_stability,
+           ConnectionHealth::ConnectionStability::Stable);
+}
+
+static TestConnectionHealth s_testConnectionHealth;

--- a/tests/unit/testconnectionhealth.h
+++ b/tests/unit/testconnectionhealth.h
@@ -1,0 +1,35 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "float.h"
+#include "helper.h"
+#include "pinghelper.h"
+
+class TestConnectionHealth final : public TestHelper {
+  Q_OBJECT
+
+ private slots:
+  void dnsPingReceived();
+  void healthCheckup();
+  void updateDnsPingLatency();
+
+  /**
+   * @brief Calculates the Exponentially Weighted Moving Average of the
+   * provided observations.
+   *
+   * @param obs Observations ordered by time from older to newer.
+   * @param weight The weight to increase relevance of recent observations.
+   * @return int The exponentially weighted moving average.
+   */
+  int ewma(std::vector<int> obs, float weight) {
+    if (obs.empty()) {
+      return 0;
+    }
+    if (obs.size() == 1) {
+      return obs.front();
+    }
+    return weight * obs.back() +
+           (1 - weight) * ewma(std::vector(obs.begin(), obs.end() - 1), weight);
+  }
+};


### PR DESCRIPTION
## Description

This may seem a bit random :). I wanted to see what it "feels like" to add some unit test coverage to existing components, and picked the first function I came across that seemed interesting. I couldn't convince myself easily that the EWMA calculation works correctly just by looking at the code so I tried to write a test for it. (Spoiler: Yes, it all works correctly)

I chose the path of minimal refactoring and give the tests access to some internals, which I think is fine. The alternative would be to make these internals publicly accessible, which doesn't seem right as it would make the components fragile. The trade-off here is of course that the tests are then more fragile i.e., internal changes of the component can break the tests, but that seems better than exposing those internals via public API. I figured I put this up as a PR, because even in case we don't want to land it in this shape, it's a good discussion to have.

## Checklist
    
- [X] My code follows the style guidelines for this project
- [X] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [X] I have performed a self review of my own code
- [X] I have commented my code PARTICULARLY in hard to understand areas
- [X] I have added thorough tests where needed
