### PR TITLE
VPN-4834: Disable free trial feature

### DIFF
--- a/src/apps/vpn/appfeaturelist.h
+++ b/src/apps/vpn/appfeaturelist.h
@@ -46,13 +46,12 @@ FEATURE(customDNS,              // Feature ID
         QStringList(),          // feature dependencies
         FeatureCallback_true)
 
-FEATURE(freeTrial,             // Feature ID
-        "Free trial",          // Feature name
-        FeatureCallback_true,  // Can be flipped on
-        FeatureCallback_true,  // Can be flipped off
-        QStringList(),         // feature dependencies
-        FeatureCallback_false) // Disabled while we rethink free trials
-
+FEATURE(freeTrial,              // Feature ID
+        "Free trial",           // Feature name
+        FeatureCallback_true,   // Can be flipped on
+        FeatureCallback_true,   // Can be flipped off
+        QStringList(),          // feature dependencies
+        FeatureCallback_false)  // Disabled while we rethink free trials
 
 FEATURE(keyRegeneration,       // Feature ID
         "Key Regeneration",    // Feature name

--- a/src/apps/vpn/appfeaturelist.h
+++ b/src/apps/vpn/appfeaturelist.h
@@ -51,7 +51,8 @@ FEATURE(freeTrial,             // Feature ID
         FeatureCallback_true,  // Can be flipped on
         FeatureCallback_true,  // Can be flipped off
         QStringList(),         // feature dependencies
-        FeatureCallback_freeTrial)
+        FeatureCallback_false) // Disabled while we rethink free trials
+
 
 FEATURE(keyRegeneration,       // Feature ID
         "Key Regeneration",    // Feature name

--- a/src/apps/vpn/appfeaturelistcallback.h
+++ b/src/apps/vpn/appfeaturelistcallback.h
@@ -123,6 +123,8 @@ bool FeatureCallback_unsecuredNetworkNotification() {
 #endif
 }
 
+// Free trials are currently not being used on any platforms
+// Leaving this code in case we want to re-enable them in the future
 bool FeatureCallback_freeTrial() {
 #if defined(MZ_IOS)
   return true;


### PR DESCRIPTION
## Description

- Disable the free trial feature (which was only currently supported on iOS) 
- Left code in tact in case we want to bring this feature back

## Reference

[VPN-4834: [iOS] 7-day free trial text still displayed in the onboarding screen](https://mozilla-hub.atlassian.net/browse/VPN-4834)