### PR TITLE
ci: remove bogus check for destination_paths in beermover

### DIFF
--- a/taskcluster/mozillavpn_taskgraph/transforms/beetmover.py
+++ b/taskcluster/mozillavpn_taskgraph/transforms/beetmover.py
@@ -99,9 +99,6 @@ def add_beetmover_worker_config(config, tasks):
                 )
             )
 
-        if shipping_phase and not destination_paths:
-            raise Exception(f"Invalid shipping phase '{shipping_phase}'!")
-
         archive_url = (
             "https://ftp.mozilla.org/" if is_relpro else "https://ftp.stage.mozaws.net/"
         )


### PR DESCRIPTION
## Description

This unbreaks release promotion.

This check neglects to take into account the fact that there are two products being beetmoved. Addons and the client. E.g, when the shipping-phase is `promote-addons`, the client tasks will have no destination paths, and that is totally valid.

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
