### PR TITLE
ci: resolve 'notify.recipients' in release_notify tasks

### DIFF
--- a/taskcluster/mozillavpn_taskgraph/transforms/release_notify.py
+++ b/taskcluster/mozillavpn_taskgraph/transforms/release_notify.py
@@ -10,6 +10,7 @@ from string import Template
 from textwrap import dedent
 
 from taskgraph.transforms.base import TransformSequence
+from taskgraph.util.schema import resolve_keyed_by
 
 transforms = TransformSequence()
 TEMPLATE = Template(
@@ -50,6 +51,21 @@ TEMPLATE = Template(
 ]
 """
 )
+
+
+@transforms.add
+def resolve_keys(config, tasks):
+    for task in tasks:
+        for key in ("notify.recipients",):
+            resolve_keyed_by(
+                task,
+                key,
+                item_name=task["name"],
+                **{
+                    "level": config.params["level"],
+                }
+            )
+        yield task
 
 
 @transforms.add


### PR DESCRIPTION
We added a `by-level` key to the notify tasks, but neglected to add the transform to resolve them.

## Description

    Fixes an error in the release promotion graphs.

## Reference

    i.e Jira or Github issue URL

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
