### PR TITLE
VPN-4773: add Bundle Display Name to info.plist

### DIFF
--- a/ios/app/Info.plist.in
+++ b/ios/app/Info.plist.in
@@ -16,6 +16,8 @@
 	<string>6.0</string>
 	<key>CFBundleName</key>
 	<string>${MACOSX_BUNDLE_BUNDLE_NAME}</string>
+	<key>CFBundleDisplayName</key>
+	<string>${MACOSX_BUNDLE_BUNDLE_NAME}</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>


### PR DESCRIPTION
## Description

The lack of Bundle Display Name was causing this bug. (It seems like other similar features - like notifications permissions prompt - fall back on Bundle Name, but for some reason the VPN did not.) 

## Reference

https://mozilla-hub.atlassian.net/browse/VPN-4773

## Checklist
    
- [X] My code follows the style guidelines for this project
- [X] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [X] I have performed a self review of my own code
- [X] I have commented my code PARTICULARLY in hard to understand areas
- [X] I have added thorough tests where needed
