### PR TITLE
Ignore directories starting with . for translations

### DIFF
--- a/translations/CMakeLists.txt
+++ b/translations/CMakeLists.txt
@@ -31,6 +31,7 @@ find_program(QT_LRELEASE_EXECUTABLE
 ## Let's retrieve the list of projects. Foreach one, let's create a library.
 get_filename_component(PROJECTS_DIR ${CMAKE_SOURCE_DIR}/src/apps ABSOLUTE)
 file(GLOB PROJECTS_NAMES LIST_DIRECTORIES true RELATIVE ${PROJECTS_DIR} ${PROJECTS_DIR}/*)
+list(FILTER PROJECTS_NAMES EXCLUDE REGEX "^\\..+")
 foreach(PROJECT ${PROJECTS_NAMES})
     message("Creating library translations_${PROJECT}")
     add_library(translations_${PROJECT} STATIC)


### PR DESCRIPTION
## Description

This was causing build errors because we were looking in ALL directories previously, including places like .DS_Store. Thank you Bea for helping track this down 😌

## Reference

   n/a

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
