### PR TITLE
Fix thinking CMakeLists.txt is an rcc addon

### DIFF
--- a/taskcluster/mozillavpn_taskgraph/transforms/beetmover.py
+++ b/taskcluster/mozillavpn_taskgraph/transforms/beetmover.py
@@ -17,7 +17,12 @@ def add_addons_release_artifacts(config, tasks):
             task["attributes"]["build-type"] == "addons/opt"
             and task["name"] == "addons-bundle"
         ):
-            addons = set(os.listdir("addons"))
+            addons = set(
+                name
+                for name in os.listdir("addons")
+                if os.path.isdir(os.path.join("addons", name))
+                and os.path.isfile(os.path.join("addons", name, "manifest.json"))
+            )
             for addon in addons:
                 task["attributes"]["release-artifacts"].append(
                     {
@@ -141,9 +146,13 @@ def add_beetmover_worker_config(config, tasks):
             "shipping-phase": shipping_phase,
         }
 
-        dest = f"{archive_url}{destination_paths[0]}" if destination_paths else archive_url
+        dest = (
+            f"{archive_url}{destination_paths[0]}" if destination_paths else archive_url
+        )
         if build_type == "addons/opt":
-            task_description = f"This {worker_type} task will upload the {task['name']} to {dest}/"
+            task_description = (
+                f"This {worker_type} task will upload the {task['name']} to {dest}/"
+            )
         elif shipping_phase == "ship-client":
             task_description = f"This {worker_type} task will copy build {build_id} from candidates to releases"
         else:
@@ -159,7 +168,9 @@ def add_beetmover_worker_config(config, tasks):
             raise Exception(f"Invalid shipping_phase `{shipping_phase}`")
 
         extra = {
-            "release_destinations": [f"{archive_url}{dest}/" for dest in destination_paths]
+            "release_destinations": [
+                f"{archive_url}{dest}/" for dest in destination_paths
+            ]
         }
         worker = {
             "upstream-artifacts": upstream_artifacts,


### PR DESCRIPTION
## Description

Before we assumed only addon directories would be included under the `addons` path. This patch updates the logic to "this is an addon if it is a directory with a manifest.json file."

## Reference

N/A

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
