### PR TITLE
ci: update Taskgraph to version 5.1.1

### DIFF
--- a/taskcluster/requirements.in
+++ b/taskcluster/requirements.in
@@ -1,4 +1,4 @@
 # For instructions on managing dependencies, see:
 # https://taskcluster-taskgraph.readthedocs.io/en/latest/howto/bootstrap-taskgraph.html
 
-taskcluster-taskgraph >= 1.7.1
+taskcluster-taskgraph >= 5.1.1

--- a/taskcluster/requirements.txt
+++ b/taskcluster/requirements.txt
@@ -266,10 +266,10 @@ slugid==2.0.0 \
     --hash=sha256:a950d98b72691178bdd4d6c52743c4a2aa039207cf7a97d71060a111ff9ba297 \
     --hash=sha256:aec8b0e01c4ad32e38e12d609eab3ec912fd129aaf6b2ded0199b56a5f8fd67c
     # via taskcluster-taskgraph
-taskcluster-taskgraph==5.1.0 \
-    --hash=sha256:12d1fa73c9149400458018d78d1c2a33912f290283c16bfaf9bd356051a11dc7 \
-    --hash=sha256:93df9c2a2f94411a88788f79fbcc51576003a8d7795af70b195f123ff3886777
-    # via -r taskcluster/requirements.in
+taskcluster-taskgraph==5.1.1 \
+    --hash=sha256:4f02699b4e8d65fd0178e8829f9436585580c5d11a1f4be9535c2f2ca865283e \
+    --hash=sha256:5b7968c940b2f5d66cca85c41d0dc417f2e273374a9ea98be3910af1a009310d
+    # via -r requirements.in
 taskcluster-urls==13.0.1 \
     --hash=sha256:5e25e7e6818e8877178b175ff43d2e6548afad72694aa125f404a7329ece0973 \
     --hash=sha256:b25e122ecec249c4299ac7b20b08db76e3e2025bdaeb699a9d444556de5fd367 \


### PR DESCRIPTION
This picks up a regression fix that was causing VPN indexes to not get updated.

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
