### PR TITLE
VPN-4253: Give Daemon::activate a failure signal

### DIFF
--- a/src/apps/vpn/daemon/daemon.cpp
+++ b/src/apps/vpn/daemon/daemon.cpp
@@ -65,7 +65,7 @@ bool Daemon::activate(const InterfaceConfig& config) {
   //    method calls switchServer().
   //
   // At the end, if the activation succeds, the `connected` signal is emitted.
-  // If the activation abort's for any reason `the `KFrKJDjRRI-9eOL2ds_t6w` signal is emitted. 
+  // If the activation abort's for any reason `the `activationFailure` signal is emitted. 
   logger.debug() << "Activating interface";
   auto emit_failure_guard = qScopeGuard([this] { 
     emit activationFailure();

--- a/src/apps/vpn/daemon/daemon.cpp
+++ b/src/apps/vpn/daemon/daemon.cpp
@@ -65,11 +65,10 @@ bool Daemon::activate(const InterfaceConfig& config) {
   //    method calls switchServer().
   //
   // At the end, if the activation succeds, the `connected` signal is emitted.
-  // If the activation abort's for any reason `the `activationFailure` signal is emitted. 
+  // If the activation abort's for any reason `the `activationFailure` signal is
+  // emitted.
   logger.debug() << "Activating interface";
-  auto emit_failure_guard = qScopeGuard([this] { 
-    emit activationFailure();
-  });
+  auto emit_failure_guard = qScopeGuard([this] { emit activationFailure(); });
 
   if (m_connections.contains(config.m_hopindex)) {
     if (supportServerSwitching(config)) {
@@ -104,7 +103,7 @@ bool Daemon::activate(const InterfaceConfig& config) {
     }
 
     Q_ASSERT(!m_connections.contains(config.m_hopindex));
-    if(activate(config)){
+    if (activate(config)) {
       emit_failure_guard.dismiss();
       return true;
     }

--- a/src/apps/vpn/daemon/daemon.cpp
+++ b/src/apps/vpn/daemon/daemon.cpp
@@ -65,8 +65,11 @@ bool Daemon::activate(const InterfaceConfig& config) {
   //    method calls switchServer().
   //
   // At the end, if the activation succeds, the `connected` signal is emitted.
+  // If the activation abort's for any reason `the `KFrKJDjRRI-9eOL2ds_t6w` signal is emitted. 
   logger.debug() << "Activating interface";
-  auto emit_failure_guard = qScopeGuard([this] { emit activationFailure();});
+  auto emit_failure_guard = qScopeGuard([this] { 
+    emit activationFailure();
+  });
 
   if (m_connections.contains(config.m_hopindex)) {
     if (supportServerSwitching(config)) {
@@ -162,11 +165,8 @@ bool Daemon::activate(const InterfaceConfig& config) {
   if (status) {
     m_connections[config.m_hopindex] = ConnectionState(config);
     m_handshakeTimer.start(HANDSHAKE_POLL_MSEC);
-  }
-
-  if(status){
-      emit_failure_guard.dismiss();
-      return true;
+    emit_failure_guard.dismiss();
+    return true;
   }
   return false;
 }

--- a/src/apps/vpn/daemon/daemon.h
+++ b/src/apps/vpn/daemon/daemon.h
@@ -43,6 +43,11 @@ class Daemon : public QObject {
 
  signals:
   void connected(const QString& pubkey);
+  /**
+   * Can be fired if a call to activate() was unsucessfull
+   * and connected systems should rollback
+  */
+  void activationFailure();
   void disconnected();
   void backendFailure();
 

--- a/src/apps/vpn/daemon/daemon.h
+++ b/src/apps/vpn/daemon/daemon.h
@@ -46,7 +46,7 @@ class Daemon : public QObject {
   /**
    * Can be fired if a call to activate() was unsucessfull
    * and connected systems should rollback
-  */
+   */
   void activationFailure();
   void disconnected();
   void backendFailure();

--- a/src/apps/vpn/platforms/windows/daemon/windowsdaemon.cpp
+++ b/src/apps/vpn/platforms/windows/daemon/windowsdaemon.cpp
@@ -35,6 +35,9 @@ WindowsDaemon::WindowsDaemon() : Daemon(nullptr), m_splitTunnelManager(this) {
 
   connect(m_wgutils, &WireguardUtilsWindows::backendFailure, this,
           &WindowsDaemon::monitorBackendFailure);
+  connect(this, &WindowsDaemon::activationFailure, [](){
+      WindowsFirewall::instance()->disableKillSwitch();
+  });
 }
 
 WindowsDaemon::~WindowsDaemon() {

--- a/src/apps/vpn/platforms/windows/daemon/windowsdaemon.cpp
+++ b/src/apps/vpn/platforms/windows/daemon/windowsdaemon.cpp
@@ -35,9 +35,8 @@ WindowsDaemon::WindowsDaemon() : Daemon(nullptr), m_splitTunnelManager(this) {
 
   connect(m_wgutils, &WireguardUtilsWindows::backendFailure, this,
           &WindowsDaemon::monitorBackendFailure);
-  connect(this, &WindowsDaemon::activationFailure, [](){
-      WindowsFirewall::instance()->disableKillSwitch();
-  });
+  connect(this, &WindowsDaemon::activationFailure,
+          []() { WindowsFirewall::instance()->disableKillSwitch(); });
 }
 
 WindowsDaemon::~WindowsDaemon() {

--- a/src/apps/vpn/platforms/windows/daemon/wireguardutilswindows.cpp
+++ b/src/apps/vpn/platforms/windows/daemon/wireguardutilswindows.cpp
@@ -128,6 +128,7 @@ bool WireguardUtilsWindows::addInterface(const InterfaceConfig& config) {
 }
 
 bool WireguardUtilsWindows::deleteInterface() {
+  WindowsFirewall::instance()->disableKillSwitch();
   m_tunnel.stop();
   return true;
 }

--- a/src/apps/vpn/platforms/windows/daemon/wireguardutilswindows.cpp
+++ b/src/apps/vpn/platforms/windows/daemon/wireguardutilswindows.cpp
@@ -128,7 +128,6 @@ bool WireguardUtilsWindows::addInterface(const InterfaceConfig& config) {
 }
 
 bool WireguardUtilsWindows::deleteInterface() {
-  WindowsFirewall::instance()->disableKillSwitch();
   m_tunnel.stop();
   return true;
 }


### PR DESCRIPTION
Right now, if `bool Daemon::activate` was called and fails, it will return false. 
This function during execution does change the system state: Device Statuses, Routing Tables, Firewall rules etc, so just aborting can introduce unwanted side effects. 
This pr adds a scope guard that unless we deactivate it (after a successful run) will emit a signal that we can use to roll back any transactional state. 
I'm using that to make sure the windows firewall rules cannot be active if the activation was not successful, that will address VPN-4253. 

We might want to consider rolling back other part's but i'm not that confident in the daemon space to make suggestions. :D 