### PR TITLE
VPN-4867: Support "reason" parameter for ping submission

### DIFF
--- a/qtglean/include/glean/ping.h
+++ b/qtglean/include/glean/ping.h
@@ -14,7 +14,7 @@ class Ping final : public QObject {
  public:
   explicit Ping(int aId);
 
-  Q_INVOKABLE void submit() const;
+  Q_INVOKABLE void submit(const QString& reason = QString()) const;
 
  private:
   const int m_id;

--- a/qtglean/src/cpp/ping.cpp
+++ b/qtglean/src/cpp/ping.cpp
@@ -9,8 +9,8 @@
 
 Ping::Ping(int aId) : m_id(aId) {}
 
-void Ping::submit() const {
+void Ping::submit(const QString& reason) const {
 #ifndef __wasm__
-  glean_submit_ping_by_id(m_id);
+  glean_submit_ping_by_id(m_id, reason.toUtf8());
 #endif
 }

--- a/qtglean/src/ffi/boolean.rs
+++ b/qtglean/src/ffi/boolean.rs
@@ -21,7 +21,7 @@ pub extern "C" fn glean_boolean_test_get_value(
         BOOLEAN_MAP,
         id,
         metric,
-        metric.test_get_value(helpers::ping_name_from_ffi(ping_name)).unwrap_or(true)
+        metric.test_get_value(helpers::option_from_ffi(ping_name)).unwrap_or(true)
     )
 }
 

--- a/qtglean/src/ffi/counter.rs
+++ b/qtglean/src/ffi/counter.rs
@@ -21,7 +21,7 @@ pub extern "C" fn glean_counter_test_get_value(
         COUNTER_MAP,
         id,
         metric,
-        metric.test_get_value(helpers::ping_name_from_ffi(ping_name)).unwrap_or(0)
+        metric.test_get_value(helpers::option_from_ffi(ping_name)).unwrap_or(0)
     )
 }
 

--- a/qtglean/src/ffi/datetime.rs
+++ b/qtglean/src/ffi/datetime.rs
@@ -23,7 +23,7 @@ pub extern "C" fn glean_datetime_test_get_value_as_string(
         DATETIME_MAP,
         id,
         metric,
-        metric.test_get_value_as_string(helpers::ping_name_from_ffi(ping_name)).unwrap_or("".to_string())
+        metric.test_get_value_as_string(helpers::option_from_ffi(ping_name)).unwrap_or("".to_string())
     );
 
     CString::new(return_string)

--- a/qtglean/src/ffi/event.rs
+++ b/qtglean/src/ffi/event.rs
@@ -51,7 +51,7 @@ pub extern "C" fn glean_event_test_get_num_recorded_errors(id: u32, error_type: 
 
 #[no_mangle]
 pub extern "C" fn glean_event_test_get_value(id: u32, ping_name: FfiStr) -> *mut c_char {
-    let value_as_json = if let Some(value) = metric_maps::event_test_get_value(id, helpers::ping_name_from_ffi(ping_name)) {
+    let value_as_json = if let Some(value) = metric_maps::event_test_get_value(id, helpers::option_from_ffi(ping_name)) {
         serde_json::to_string(&value).expect("Unable to serialize recorded value")
     } else {
         "".into()

--- a/qtglean/src/ffi/helpers.rs
+++ b/qtglean/src/ffi/helpers.rs
@@ -66,7 +66,7 @@ pub fn from_raw_string_array(
     }
 }
 
-pub fn ping_name_from_ffi(ping_name: FfiStr) -> Option<String> {
+pub fn option_from_ffi(ping_name: FfiStr) -> Option<String> {
     if let Ok(name) = ping_name.to_string_fallible() {
         if name.is_empty() {
             None

--- a/qtglean/src/ffi/ping.rs
+++ b/qtglean/src/ffi/ping.rs
@@ -3,10 +3,10 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use ffi_support::FfiStr;
+use crate::ffi::helpers;
 use crate::metrics::__generated_pings::submit_ping_by_id;
-
 
 #[no_mangle]
 pub extern "C" fn glean_submit_ping_by_id(id: u32, reason: FfiStr) {
-    submit_ping_by_id(id, Some(&reason.into_string()));
+    submit_ping_by_id(id, helpers::option_from_ffi(reason).as_deref());
 }

--- a/qtglean/src/ffi/ping.rs
+++ b/qtglean/src/ffi/ping.rs
@@ -2,9 +2,11 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+use ffi_support::FfiStr;
 use crate::metrics::__generated_pings::submit_ping_by_id;
 
+
 #[no_mangle]
-pub extern "C" fn glean_submit_ping_by_id(id: u32) {
-    submit_ping_by_id(id, None);
+pub extern "C" fn glean_submit_ping_by_id(id: u32, reason: FfiStr) {
+    submit_ping_by_id(id, Some(&reason.into_string()));
 }

--- a/qtglean/src/ffi/quantity.rs
+++ b/qtglean/src/ffi/quantity.rs
@@ -21,7 +21,7 @@ pub extern "C" fn glean_quantity_test_get_value(
         QUANTITY_MAP,
         id,
         metric,
-        metric.test_get_value(helpers::ping_name_from_ffi(ping_name)).unwrap_or(0)
+        metric.test_get_value(helpers::option_from_ffi(ping_name)).unwrap_or(0)
     )
 }
 

--- a/qtglean/src/ffi/string.rs
+++ b/qtglean/src/ffi/string.rs
@@ -23,7 +23,7 @@ pub extern "C" fn glean_string_test_get_value(
         STRING_MAP,
         id,
         metric,
-        metric.test_get_value(helpers::ping_name_from_ffi(ping_name)).unwrap_or("".to_string())
+        metric.test_get_value(helpers::option_from_ffi(ping_name)).unwrap_or("".to_string())
     );
 
     CString::new(return_string)

--- a/qtglean/src/ffi/timing_distribution.rs
+++ b/qtglean/src/ffi/timing_distribution.rs
@@ -44,7 +44,7 @@ pub extern "C" fn glean_timing_distribution_test_get_value(
         TIMING_DISTRIBUTION_MAP,
         id,
         metric,
-        metric.test_get_value(helpers::ping_name_from_ffi(ping_name))
+        metric.test_get_value(helpers::option_from_ffi(ping_name))
     );
 
     let value_as_json = match value {

--- a/qtglean/src/ffi/uuid.rs
+++ b/qtglean/src/ffi/uuid.rs
@@ -33,7 +33,7 @@ pub extern "C" fn glean_uuid_test_get_value(
         UUID_MAP,
         id,
         metric,
-        metric.test_get_value(helpers::ping_name_from_ffi(ping_name)).unwrap_or("".to_string())
+        metric.test_get_value(helpers::option_from_ffi(ping_name)).unwrap_or("".to_string())
     );
 
     CString::new(return_string)


### PR DESCRIPTION
## Description

- Add "Reason" parameter to qtglean wrapper

## Reference

[VPN-4867: Support "reason" parameter for custom ping submissions](https://mozilla-hub.atlassian.net/browse/VPN-4867)
