### PR TITLE
Nit: Beetmove android releases to archive

### DIFF
--- a/taskcluster/ci/beetmover/kind.yml
+++ b/taskcluster/ci/beetmover/kind.yml
@@ -16,6 +16,78 @@ kind-dependencies:
     - repackage-signing
 
 tasks:
+    android-arm64:
+        requires-level: 3 
+        worker-type: beetmover
+        worker:
+            chain-of-trust: true
+            max-run-time: 1800
+        run-on-tasks-for: [action]
+        release-artifacts: [mozillavpn-arm64-v8a-release.apk]
+        dependencies:
+            signing: signing-android-arm64/release
+        if-dependencies: [signing]
+        attributes:
+            build-type: android/arm64-v8a
+        treeherder:
+            symbol: BM(android)
+            kind: build
+            tier: 1
+            platform: android/arm64-v8a
+    android-armv7:
+        requires-level: 3 
+        worker-type: beetmover
+        worker:
+            chain-of-trust: true
+            max-run-time: 1800
+        run-on-tasks-for: [action]
+        release-artifacts: [mozillavpn-armeabi-v7a-release.apk]
+        dependencies:
+            signing: signing-android-armv7/release
+        if-dependencies: [signing]
+        attributes:
+            build-type: android/armv7
+        treeherder:
+            symbol: BM(android)
+            kind: build
+            tier: 1
+            platform: android/armv7
+    android-x86:
+        requires-level: 3 
+        worker-type: beetmover
+        worker:
+            chain-of-trust: true
+            max-run-time: 1800
+        run-on-tasks-for: [action]
+        release-artifacts: [mozillavpn-x86-release.apk]
+        dependencies:
+            signing: signing-android-x86/release
+        if-dependencies: [signing]
+        attributes:
+            build-type: android/x86
+        treeherder:
+            symbol: BM(android)
+            kind: build
+            tier: 1
+            platform: android/x86
+    android-x64:
+        requires-level: 3 
+        worker-type: beetmover
+        worker:
+            chain-of-trust: true
+            max-run-time: 1800
+        run-on-tasks-for: [action]
+        release-artifacts: [mozillavpn-x64-release.apk]
+        dependencies:
+            signing: signing-android-x64/release
+        if-dependencies: [signing]
+        attributes:
+            build-type: android/x64
+        treeherder:
+            symbol: BM(android)
+            kind: build
+            tier: 1
+            platform: android/x64
     macos:
         requires-level: 3 
         worker-type: beetmover

--- a/taskcluster/mozillavpn_taskgraph/transforms/beetmover.py
+++ b/taskcluster/mozillavpn_taskgraph/transforms/beetmover.py
@@ -48,6 +48,10 @@ def add_beetmover_worker_config(config, tasks):
         build_type_os = {
             "macos/opt": "mac",
             "windows/opt": "windows",
+            "android/x86": "android",
+            "android/x64": "android",
+            "android/armv7": "android",
+            "android/arm64-v8a": "android",
         }
         build_os = build_type_os.get(build_type)
         shipping_phase = config.params.get("shipping_phase", "")


### PR DESCRIPTION
## Description

Support regulary ask's users to check if a downgrade fixes their problems. So they need a android builds to be published somewhere, so how about we also beetmove them to archive automatically? 

This is my first shot at touching beetmover. The generated task looks, somewhat reasonable calling `taskgraph full`, but how would one test that this is working? 😅 

```
  "beetmover-android-arm64": {
    "attributes": {
      "always_target": false,
      "build-type": "android/arm64-v8a",
      "kind": "beetmover",
      "release-artifacts": [
        {
          "name": "public/build/mozillavpn-arm64-v8a-release.apk",
          "path": "/builds/worker/artifacts/mozillavpn-arm64-v8a-release.apk",
          "type": "file"
        }
      ],
      "run_on_projects": [
        "all"
      ],
      "run_on_tasks_for": [
        "action"
      ],
      "shipping-phase": "",
      "shipping_phase": null
    },
    "dependencies": {
      "signing": "signing-android-arm64/release"
    },
    "description": "This beetmover task will upload a android release candidate for v to https://ftp.stage.mozaws.net//",
    "if_dependencies": [],
    "kind": "beetmover",
    "label": "beetmover-android-arm64",
    "optimization": null,
    "soft_dependencies": [],
    "task": {
      "created": {
        "relative-datestamp": "0 seconds"
      },
      "deadline": {
        "relative-datestamp": "1 day"
      },
      "expires": {
        "relative-datestamp": "1 year"
      },
      "extra": {
        "index": {
          "rank": 0
        },
        "parent": "",
        "release_destinations": []
      },
      "metadata": {
        "description": "This beetmover task will upload a android release candidate for v to https://ftp.stage.mozaws.net//",
        "name": "beetmover-android-arm64",
        "owner": "nobody@mozilla.com",
        "source": "https://github.com/mozilla-mobile/mozilla-vpn-client.git/blob/13cce4f137a410ef9cee45c2e9948fc87398b633/taskcluster/ci/beetmover"
      },
      "payload": {
        "artifactMap": [
          {
            "locale": "multi",
            "paths": {
              "public/build/mozillavpn-arm64-v8a-release.apk": {
                "checksums_path": "",
                "destinations": []
              }
            },
            "taskId": {
              "task-reference": "<signing>"
            }
          }
        ],
        "maxRunTime": 600,
        "releaseProperties": {
          "appName": "vpn",
          "appVersion": "",
          "branch": "main",
          "buildid": "20230530152720",
          "hashType": "sha512",
          "platform": "android/arm64-v8a"
        },
        "upload_date": 1685453300,
        "upstreamArtifacts": [
          {
            "locale": "multi",
            "paths": [
              "public/build/mozillavpn-arm64-v8a-release.apk"
            ],
            "taskId": {
              "task-reference": "<signing>"
            },
            "taskType": "scriptworker"
          }
        ]
      },
      "priority": "highest",
      "provisionerId": "scriptworker-k8s",
      "routes": [
        "checks"
      ],
      "scopes": [
        "project:mozillavpn:releng:beetmover:bucket:dep",
        "project:mozillavpn:releng:beetmover:action:push-to-candidates"
      ],
      "tags": {
        "createdForUser": "nobody@mozilla.com",
        "kind": "beetmover",
        "label": "beetmover-android-arm64",
        "os": "scriptworker",
        "worker-implementation": "scriptworker"
      },
      "workerType": "mozillavpn-3-beetmover"
    }
  },

```

## Reference

    i.e Jira or Github issue URL
