### PR TITLE
Nit: Reduce Android builds created for PRs

### DIFF
--- a/taskcluster/ci/build/android.yml
+++ b/taskcluster/ci/build/android.yml
@@ -26,6 +26,7 @@ android-qt-next/debug:
         fetches:
             toolchain: 
                 - conda-android-arm64
+        requires-level: 3
         run:
             command: ./taskcluster/scripts/build/android_build_debug.sh arm64-v8a
         release-artifacts:

--- a/taskcluster/ci/build/android.yml
+++ b/taskcluster/ci/build/android.yml
@@ -47,31 +47,6 @@ android-arm64/debug:
             # APK Artifacts expects file to be in /builds/worker/artifacts/
             - mozillavpn-arm64-v8a-debug.apk
 
-android-armv7/debug:
-        description: "Android Debug (armv7)"
-        treeherder:
-            platform: android/armv7
-        fetches:
-            toolchain: 
-                    - conda-android-armeabi-v7a
-        run:
-            command: ./taskcluster/scripts/build/android_build_debug.sh armeabi-v7a
-        release-artifacts:
-            # APK Artifacts expects file to be in /builds/worker/artifacts/
-            - mozillavpn-armv7-debug.apk
-
-android-x86/debug:
-        description: "Android Debug (x86)"
-        treeherder:
-            platform: android/x86
-        fetches:
-            toolchain: 
-                    - conda-android-x86
-        run:
-            command: ./taskcluster/scripts/build/android_build_debug.sh x86
-        release-artifacts:
-            # APK Artifacts expects file to be in /builds/worker/artifacts/
-            - mozillavpn-x86-debug.apk
 android-x64/debug:
         description: "Android Debug (x86_64)"
         treeherder:

--- a/taskcluster/ci/build/android.yml
+++ b/taskcluster/ci/build/android.yml
@@ -67,7 +67,8 @@ android-arm64/release:
         requires-level: 1
         scopes:
             by-level:
-                "3": - secrets:get:project/mozillavpn/tokens
+                "3": 
+                    - secrets:get:project/mozillavpn/tokens
                 default: []
         fetches:
             toolchain: 

--- a/taskcluster/ci/build/android.yml
+++ b/taskcluster/ci/build/android.yml
@@ -89,9 +89,11 @@ android-x64/debug:
 
 android-arm64/release:
         description: "Android Release (arm64-v8a)"
-        requires-level: 3
+        requires-level: 1
         scopes:
-            - 'secrets:get:project/mozillavpn/tokens'
+            by-level:
+                "3": - secrets:get:project/mozillavpn/tokens
+                default: []
         fetches:
             toolchain: 
                     - conda-android-arm64

--- a/taskcluster/scripts/build/android_build_release.sh
+++ b/taskcluster/scripts/build/android_build_release.sh
@@ -60,7 +60,7 @@ if [[ "$MOZ_SCM_LEVEL" == "3" ]]; then
   # missing debug info, for symbolification
   sentry-cli debug-files upload --org mozilla -p vpn-client --include-sources .tmp/src/android-build/build/intermediates/merged_native_libs
 else
-   sentry-cli difutil check .tmp/src/android-build/build/intermediates/merged_native_libs
+  echo "Skipping sentry stuff"
 fi
 
 

--- a/taskcluster/scripts/build/android_build_release.sh
+++ b/taskcluster/scripts/build/android_build_release.sh
@@ -53,10 +53,15 @@ mkdir -p /builds/worker/artifacts/
 ./scripts/android/cmake.sh $QTPATH -A $1 -a $(cat adjust_token) --sentrydsn $(cat sentry_dsn) --sentryendpoint $(cat sentry_envelope_endpoint)
 
 npm install -g @sentry/cli
-sentry-cli login --auth-token $(cat sentry_debug_file_upload_key)
-# This will ask sentry to scan all files in there and upload
-# missing debug info, for symbolification
-sentry-cli debug-files upload --org mozilla -p vpn-client --include-sources .tmp/src/android-build/build/intermediates/merged_native_libs
+
+if [[ "$MOZ_SCM_LEVEL" == "3" ]]; then
+  sentry-cli login --auth-token $(cat sentry_debug_file_upload_key)
+  # This will ask sentry to scan all files in there and upload
+  # missing debug info, for symbolification
+  sentry-cli debug-files upload --org mozilla -p vpn-client --include-sources .tmp/src/android-build/build/intermediates/merged_native_libs
+else
+   sentry-cli difutil check .tmp/src/android-build/build/intermediates/merged_native_libs
+fi
 
 # Artifacts should be placed here!
 mkdir -p /builds/worker/artifacts/

--- a/taskcluster/scripts/build/android_build_release.sh
+++ b/taskcluster/scripts/build/android_build_release.sh
@@ -23,15 +23,21 @@ env
 
 
 # Get Secrets for building
-echo "Fetching Tokens!"
+if [[ "$MOZ_SCM_LEVEL" == "3" ]]; then
+  echo "Fetching Tokens!"
+  ./taskcluster/scripts/get-secret.py -s project/mozillavpn/tokens -k adjust -f adjust_token
+  ./taskcluster/scripts/get-secret.py -s project/mozillavpn/tokens -k sentry_dsn -f sentry_dsn
+  ./taskcluster/scripts/get-secret.py -s project/mozillavpn/tokens -k sentry_envelope_endpoint -f sentry_envelope_endpoint
+  ./taskcluster/scripts/get-secret.py -s project/mozillavpn/tokens -k sentry_debug_file_upload_key -f sentry_debug_file_upload_key
+else
+    echo "Using dummy Tokens!"
+    # write a dummy value in the files, so that we still compile sentry c:
+    echo "dummy" > sentry_dsn
+    echo "dummy" > sentry_envelope_endpoint
+    echo "dummy" > sentry_debug_file_upload_key
+    echo "dummy" > adjust_token
+fi
 
-# Note: We cannot run `conda run -n vpn <commadn>` or conda activate vpn
-# as our current shell is not setup to do that.
-# So we need to call bash with a login shell and conda activate the env :/ 
-./taskcluster/scripts/get-secret.py -s project/mozillavpn/tokens -k adjust -f adjust_token
-./taskcluster/scripts/get-secret.py -s project/mozillavpn/tokens -k sentry_dsn -f sentry_dsn
-./taskcluster/scripts/get-secret.py -s project/mozillavpn/tokens -k sentry_envelope_endpoint -f sentry_envelope_endpoint
-./taskcluster/scripts/get-secret.py -s project/mozillavpn/tokens -k sentry_debug_file_upload_key -f sentry_debug_file_upload_key
 
 # Artifacts should be placed here!
 mkdir -p /builds/worker/artifacts/
@@ -44,7 +50,7 @@ mkdir -p /builds/worker/artifacts/
 # aqt-name "x86"         -> qmake-name: "x86"
 # aqt-name "x86_64"      -> qmake-name: "x86_64"
 
-./scripts/android/cmake.sh -d $QTPATH -A $1  -a $(cat adjust_token) --sentrydsn $(cat sentry_dsn) --sentryendpoint $(cat sentry_envelope_endpoint)
+./scripts/android/cmake.sh $QTPATH -A $1 -a $(cat adjust_token) --sentrydsn $(cat sentry_dsn) --sentryendpoint $(cat sentry_envelope_endpoint)
 
 sentry-cli login --auth-token $(cat sentry_debug_file_upload_key)
 # This will ask sentry to scan all files in there and upload

--- a/taskcluster/scripts/build/android_build_release.sh
+++ b/taskcluster/scripts/build/android_build_release.sh
@@ -52,6 +52,7 @@ mkdir -p /builds/worker/artifacts/
 
 ./scripts/android/cmake.sh $QTPATH -A $1 -a $(cat adjust_token) --sentrydsn $(cat sentry_dsn) --sentryendpoint $(cat sentry_envelope_endpoint)
 
+npm install -g @sentry/cli
 sentry-cli login --auth-token $(cat sentry_debug_file_upload_key)
 # This will ask sentry to scan all files in there and upload
 # missing debug info, for symbolification


### PR DESCRIPTION
## Description
We are building 6x the Android Client - yet most of those builds are unused or checking the same thing. 
So let's trim the task's we are creating :)  

- Remove Android-Armv-7 Next ( never been used )
- Remove unused debug-intel builds
- Reduce the 'next' builds to only main (not critical if they break)
- Build a fake release build on pr's (so we know main does not explode) 



