### PR TITLE
Fix VPN-4871 / Remove device name from logs

### DIFF
--- a/src/apps/vpn/models/devicemodel.cpp
+++ b/src/apps/vpn/models/devicemodel.cpp
@@ -295,7 +295,6 @@ void DeviceModel::serializeLogs(
 
   QString buffer;
   QTextStream out(&buffer);
-  out << "Name -> " << Device::currentDeviceName() << Qt::endl;
   out << "ABI -> " << QSysInfo::buildAbi() << Qt::endl;
   out << "Machine arch -> " << QSysInfo::currentCpuArchitecture() << Qt::endl;
   out << "OS -> " << QSysInfo::productType() << Qt::endl;


### PR DESCRIPTION
## Description

This removes the user's device name from logs. 

## Reference

VPN-4871

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
