### PR TITLE
Revert "Bump taskcluster-taskgraph from 5.1.1 to 5.2.0 in /taskcluster"

### DIFF
--- a/taskcluster/requirements.txt
+++ b/taskcluster/requirements.txt
@@ -266,9 +266,9 @@ slugid==2.0.0 \
     --hash=sha256:a950d98b72691178bdd4d6c52743c4a2aa039207cf7a97d71060a111ff9ba297 \
     --hash=sha256:aec8b0e01c4ad32e38e12d609eab3ec912fd129aaf6b2ded0199b56a5f8fd67c
     # via taskcluster-taskgraph
-taskcluster-taskgraph==5.2.0 \
-    --hash=sha256:9fbf51d32dc8182b6ff256433d51557e655e5980997d81588c182b793d204a65 \
-    --hash=sha256:d6e5f5c14e8b75679c3a28e6580cc4bb41fc74395a6b5ea9e349d6d91c8dfa0a
+taskcluster-taskgraph==5.1.1 \
+    --hash=sha256:4f02699b4e8d65fd0178e8829f9436585580c5d11a1f4be9535c2f2ca865283e \
+    --hash=sha256:5b7968c940b2f5d66cca85c41d0dc417f2e273374a9ea98be3910af1a009310d
     # via -r requirements.in
 taskcluster-urls==13.0.1 \
     --hash=sha256:5e25e7e6818e8877178b175ff43d2e6548afad72694aa125f404a7329ece0973 \


### PR DESCRIPTION
Reverts mozilla-mobile/mozilla-vpn-client#7010

This caused all builds to fail with: https://firefox-ci-tc.services.mozilla.com/tasks/CgsuoED1S8WWMUYsGf348A/runs/0/logs/live/public/logs/live.log