### PR TITLE
Bug 1774273 - Part (1/2) - Add signingscript macos notarization task

### DIFF
--- a/taskcluster/ci/mac-notarization/kind.yml
+++ b/taskcluster/ci/mac-notarization/kind.yml
@@ -1,0 +1,39 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+---
+loader: taskgraph.loader.transform:loader
+
+transforms:
+    - mozillavpn_taskgraph.transforms.requires_level:transforms
+    - mozillavpn_taskgraph.transforms.release_index:transforms
+    - taskgraph.transforms.task:transforms
+
+kind-dependencies:
+    - signing
+
+tasks:
+    macos/opt:
+        description: notarize mozillavpn macos app
+        worker-type: signing
+        requires-level: 3
+        dependencies:
+            signing: signing-macos/opt
+        if-dependencies:
+            - signing
+        treeherder:
+            symbol: Bn
+            kind: build
+            tier: 1
+            platform: macos/opt
+        worker:
+            implementation: scriptworker-signing
+            signing-type: "release-apple-notarization"
+            upstream-artifacts:
+                - taskId:
+                      task-reference: <signing>
+                  taskType: scriptworker
+                  paths:
+                      - public/build/MozillaVPN.pkg
+                  formats:
+                      - apple_notarization


### PR DESCRIPTION
## Description

  MacOS notarization is moving from iscript to signingscript and requires a separate task.
    
  There are no ways of testing notarization outside production. So, this change only adds the notarization task, but *DOES NOT* affect any other tasks.
  The current signing still notarizes, and is treated as source/upstream by the beetmover task.

## Reference

[Bug 1774273](https://bugzilla.mozilla.org/show_bug.cgi?id=1774273)

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
