### PR TITLE
VPN-4877 - Fix broken WASM simulator

### DIFF
--- a/tools/wasm_chrome/branch_selector.mjs
+++ b/tools/wasm_chrome/branch_selector.mjs
@@ -9,6 +9,7 @@ import { Octokit } from "https://cdn.skypack.dev/@octokit/core";
 const octokit = new Octokit({});
 
 const static_branch_info = fetch("./branch_runs.json").then((r) => r.json());
+const DEFAULT_SELECTED_BRANCH = "main";
 
 /**
  * <branch-selector></branch-selector>
@@ -106,6 +107,10 @@ class BranchSelector extends HTMLElement {
   }
 
   render() {
+    const urlParams = new URLSearchParams(window.location.search);
+    const selectedBranch = urlParams.get("branch") || DEFAULT_SELECTED_BRANCH;
+
+
     if (this.#dom.innerHTML != "") {
       this.update();
     }
@@ -115,7 +120,8 @@ class BranchSelector extends HTMLElement {
           --max-height: 300px;
       }
     </style>
-    <fluent-combobox id="selector" autocomplete="both" placeholder="Select a branch"></fluent-combobox>`;
+    <fluent-combobox id="selector" autocomplete="both" value="${selectedBranch}"></fluent-combobox>`;
+
     const selector = this.#dom.querySelector("#selector");
     selector.addEventListener("change", (e) => {
       // Forward the event to the parent element;
@@ -131,7 +137,6 @@ class BranchSelector extends HTMLElement {
   update() {
     const selector = this.#dom.querySelector("#selector");
     selector.innerHTML = `
-            <fluent-option value="">Select a VPN-Branch</fluent-option>
             ${this.#data.map((e) => {
       return `<fluent-option value="${e.commit.sha}">${e.name}</fluent-option>`;
     }).join("")

--- a/tools/wasm_chrome/helpers.mjs
+++ b/tools/wasm_chrome/helpers.mjs
@@ -1,0 +1,33 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export async function getGithubPaginatedData(octokit, request, options) {
+    let result = [];
+    let page = 1;
+    while (true) {
+        const response = await octokit.request(
+            request,
+            {
+                ...options,
+                per_page: 100, // This is the maximum.
+                page
+            },
+        );
+        console.log(`RateLimit -> ${response.headers["x-ratelimit-remaining"]}`);
+
+        if (response.status != 200) {
+            console.error(response);
+            Deno.exit(-1);
+        }
+
+        if (response.data.length === 0) {
+            break;
+        }
+
+        result = [...result, ...response.data];
+        page++;
+    }
+
+    return result;
+}

--- a/tools/wasm_chrome/index.html
+++ b/tools/wasm_chrome/index.html
@@ -78,12 +78,26 @@
             border: none;
         }
 
+        .input-group {
+            display: flex;
+        }
+
+        .input-group label {
+            color: white;
+            display: inline-block;
+            margin-right: 10px;
+            line-height: 32px;
+        }
+
     </style>
 </head>
 
 <body>
     <nav>
-        <branch-selector></branch-selector>
+        <div class="input-group">
+            <label>Select a branch:</label>
+            <branch-selector></branch-selector>
+        </div>
         <span href="#" class="menu-button">
             More ⬇
             <ul class="menu">

--- a/tools/wasm_chrome/index.html
+++ b/tools/wasm_chrome/index.html
@@ -1,133 +1,143 @@
 <!DOCTYPE html>
-<!-- 
+<!--
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 -->
 <html>
-    <head> 
-        <title>MozillaVPN Chrome</title>
-        <style>
-            taskcluster-frame{
-                width: 100vw;
-                background: #4a4a55;
-                flex-grow: 1;
-                overflow: hidden;
-            }
-            body{
-                display: flex;
-                justify-content: center;
-                flex-direction: column;
-                height: 100vh;
-                margin: 0;
-                padding: 0;
-            }
-            nav{
-                color: white;
-                background: #232328;
-                padding: 10px;
-                display: flex;
-                justify-content: space-between;
-                align-items: center;
-            }
-            :root {
-                --max-height: 300px;
-                font-family: sans-serif;
-            }
 
-            .menu-button{
-                position: relative;
-            }
-            .menu{
-                display: none;   
-            }
-            .menu-button:hover .menu{
-                display: block;
-                position: absolute;
-                right: 0px;
-                top: 0;
-                background: #232328;
-                list-style: none;
-                padding: 0px;
-                width: 200px;
-                display: flex;
-                flex-direction: column;
-                justify-content: end;
-                align-items: end;
+<head>
+    <title>MozillaVPN Chrome</title>
+    <style>
+        taskcluster-frame {
+            width: 100vw;
+            background: #4a4a55;
+            flex-grow: 1;
+            overflow: hidden;
+        }
 
-            }
-            .menu li{
-                padding: 10px 20px;
-            }
+        body {
+            display: flex;
+            justify-content: center;
+            flex-direction: column;
+            height: 100vh;
+            margin: 0;
+            padding: 0;
+        }
 
-            .menu a{
-                color:white;
-                text-decoration: none;
-            }
-            .menu button{
-                color: white;
-                background: transparent;
-                border: none;
-            }
+        nav {
+            color: white;
+            background: #232328;
+            padding: 10px;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
 
-        </style>
-    </head>
-    <body>
-        <nav>
-            <branch-selector></branch-selector>
-            <span href="#" class="menu-button">
-                More ⬇
-                <ul class="menu">
-                    <li>
-                        <a href="./inspector/">Inspector</a>  
-                    </li>
-                    <li>
-                        <a href="./logviewer/">Logviewer </a>
-                    </li>
-                    <hr>
-                    <li>
-                        <button id="copy">Copy Permalink 📋</button>
-                    </li>
-                    <li>
-                        <button id="open_task">Open Task ↗️</button>
-                    </li>
-                </ul>
-            </span>
-           
-        </nav>
-        <taskcluster-frame></taskcluster-frame>
-        <script type="module" src="branch_selector.mjs"></script>
-        <script type="module" src="taskcluster_frame.mjs"></script>
-        <script>
-            window.addEventListener("load",()=>{
-                let branchSelector = document.querySelector("branch-selector");
-                let taskclusterFrame = document.querySelector("taskcluster-frame");
-                let copy_btn = document.querySelector("#copy");
-                let open_btn = document.querySelector("#open_task");
-                
-                branchSelector.addEventListener("change",() =>{
-                    taskclusterFrame.target = {
-                        sha: branchSelector.value,
-                        name: branchSelector.name
-                    } 
+        :root {
+            --max-height: 300px;
+            font-family: sans-serif;
+        }
 
-                    const url = new URL(window.location);
-                    url.searchParams.set('branch', branchSelector.name);
-                    window.history.pushState(null, '', url.toString());
-                })
+        .menu-button {
+            position: relative;
+        }
 
-                copy_btn.addEventListener("click",()=>{
-                    navigator.clipboard.writeText(taskclusterFrame.artifact_url);
-                })
-                open_btn.addEventListener("click",()=>{
-                    window.open(`https://firefox-ci-tc.services.mozilla.com/tasks/${taskclusterFrame.taskID}`);
-                });
+        .menu {
+            display: none;
+        }
 
+        .menu-button:hover .menu {
+            display: block;
+            position: absolute;
+            right: 0px;
+            top: 0;
+            background: #232328;
+            list-style: none;
+            padding: 0px;
+            width: 200px;
+            display: flex;
+            flex-direction: column;
+            justify-content: end;
+            align-items: end;
 
-                console.log("ready");
+        }
+
+        .menu li {
+            padding: 10px 20px;
+        }
+
+        .menu a {
+            color: white;
+            text-decoration: none;
+        }
+
+        .menu button {
+            color: white;
+            background: transparent;
+            border: none;
+        }
+
+    </style>
+</head>
+
+<body>
+    <nav>
+        <branch-selector></branch-selector>
+        <span href="#" class="menu-button">
+            More ⬇
+            <ul class="menu">
+                <li>
+                    <a href="./inspector/">Inspector</a>
+                </li>
+                <li>
+                    <a href="./logviewer/">Logviewer </a>
+                </li>
+                <hr>
+                <li>
+                    <button id="copy">Copy Permalink 📋</button>
+                </li>
+                <li>
+                    <button id="open_task">Open Task ↗️</button>
+                </li>
+            </ul>
+        </span>
+
+    </nav>
+    <taskcluster-frame></taskcluster-frame>
+    <script type="module" src="branch_selector.mjs"></script>
+    <script type="module" src="taskcluster_frame.mjs"></script>
+    <script>
+        window.addEventListener("load", () => {
+            let branchSelector = document.querySelector("branch-selector");
+            let taskclusterFrame = document.querySelector("taskcluster-frame");
+            let copy_btn = document.querySelector("#copy");
+            let open_btn = document.querySelector("#open_task");
+
+            branchSelector.addEventListener("change", () => {
+                taskclusterFrame.target = {
+                    sha: branchSelector.value,
+                    name: branchSelector.name
+                }
+
+                const url = new URL(window.location);
+                url.searchParams.set('branch', branchSelector.name);
+                window.history.pushState(null, '', url.toString());
+            })
+
+            copy_btn.addEventListener("click", () => {
+                navigator.clipboard.writeText(taskclusterFrame.artifact_url);
+            })
+            open_btn.addEventListener("click", () => {
+                window.open(`https://firefox-ci-tc.services.mozilla.com/tasks/${taskclusterFrame.taskID}`);
             });
-        </script>
 
 
-    </body>
+            console.log("ready");
+        });
+    </script>
+
+
+</body>
+
 </html>


### PR DESCRIPTION
Ok, so. There was an issue with the branch list getter code. We were only getting the first 100 branches and `main` was not part of those. This fixes that + some papercut UI fixes on the branch selector.

I believe the whatever was the issue with the WASM simulator is not happening on `main` anymore, because locally I can reproduce the issue on branch such as `VPN-4867`, but not on `main`.

I will do some more time boxed investigation to see when exactly was this broken, but since it seems the main issue has been fixed already -- the main issue being the fact that `main` was not listed in the branches for the simulator -- this is ready for review.

[UPDATE]

The error happens because we are hitting this assertion: https://github.com/mozilla-mobile/mozilla-vpn-client/blob/main/src/shared/localizer.cpp#L436. I am not yet sure why we are. I will give this a bit more time, because we are having this issue on the releases/2.15 branch. It could be an issue with the release itself. Unfortunately I can't reproduce the issue with a local wasm build on that branch :/

[UPDATE 2]

So, the issue is the same one @oskirby described in: https://github.com/mozilla-mobile/mozilla-vpn-client/pull/6867. 

Due to the change in https://github.com/mozilla-mobile/mozilla-vpn-client/pull/6038#issue-1585147782, the latest i18n version is always downloaded. Even for branches where the `languages.json` file is not up to date. Implementing the fix described by Naomi would address this, until then the WASM client would be prone to breakage whenever languages.json is not up to date. Another fix would be to not download the latest i18n anymore, but this is something @strseb points out is a bad idea.