### PR TITLE
Run the i18n Task every day at 6:00

### DIFF
--- a/.github/workflows/i18n_update.yaml
+++ b/.github/workflows/i18n_update.yaml
@@ -7,10 +7,8 @@ name: i18n Updater
 
 
 on:
-  # Triggers the workflow on pull request events but only for the main branch
-  # For now let's only have it manually, until we know this works! 
-  # schedule:
-  #  - cron: '0 5 * * *'
+  schedule:
+    - cron: '0 6 * * *' # Every Day 6:00 UTC
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Description

Under the Premise that our CI is not failing - the i18n submodule update task is working as expected: 
https://github.com/mozilla-mobile/mozilla-vpn-client/pull/7049

So let's have the Languages updated every day.
As a side effect that also means we will be publishing a fresh wasm build using that strings every day cc @flodolo 