### PR TITLE
Swap Tokens in i18n chain

### DIFF
--- a/.github/workflows/i18n_update.yaml
+++ b/.github/workflows/i18n_update.yaml
@@ -39,16 +39,17 @@ jobs:
           branch: i18n_automation
           delete-branch: true
           title: "[Bot] Update i18n"
+          token: ${{ secrets.WIKI_TOKEN }}
       - name: Approve l10n_branch.
         run: gh pr review --approve "$PR_URL"
         env:
           PR_URL: ${{ steps.cpr.outputs.pull-request-url }}
-          GITHUB_TOKEN: ${{ secrets.WIKI_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       # Finally, this sets the PR to allow auto-merging for patch and minor
       # updates if all checks pass
       - name: Enable auto-merge the i18n PR
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ steps.cpr.outputs.pull-request-url }}
-          GITHUB_TOKEN: ${{ secrets.WIKI_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
  


### PR DESCRIPTION
## Description
Check: 
https://github.com/mozilla-mobile/mozilla-vpn-client/pull/7049

As the PR was opened by Github, it will not trigger github workflows, only taskcluster ones. 
So let's swap who's opening and who's r+ ing. :) 


