### PR TITLE
RELOPS-539 Update cmake to 3.26.3

### DIFF
--- a/env.yml
+++ b/env.yml
@@ -15,7 +15,7 @@ dependencies:
   - rust-std-x86_64-apple-ios=1.69
   - go=1.18
   - compiler-rt
-  - cmake=3.25
+  - cmake=3.26.3
   - ninja=1.11.0
   - pip:
     - -r requirements.txt


### PR DESCRIPTION
## Description

    Updates `cmake` to 3.26.3 which is the minimum version required for updating the macOS builder machines to xcode 14.2

## Reference

    See original request at https://mozilla-hub.atlassian.net/browse/RELOPS-539

## Checklist
    
- [X] My code follows the style guidelines for this project
- [X] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [X] I have performed a self review of my own code
- [X] I have commented my code PARTICULARLY in hard to understand areas
- [X] I have added thorough tests where needed
