### PR TITLE
Tiniest fix for build docs (no ticket) 

### DIFF
--- a/docs/dev-setup/index.md
+++ b/docs/dev-setup/index.md
@@ -21,7 +21,7 @@ Wherever possible, dependencies are managed using [conda](https://docs.conda.io/
 Please install [miniconda](https://docs.conda.io/en/latest/miniconda.html).
 
 Then run:
-* `conda env create -f env.yaml`
+* `conda env create -f env.yml`
 * `conda activate vpn`
 
 For windows, see [windows docs]([./windows.md#conda])


### PR DESCRIPTION
## Description

This PR removes the  letter `a` from `env.yaml` in our build docs, so that if you are, like I was, copying and pasting you won't hit the following... 
`EnvironmentFileNotFound: '/path/to/where/your/vpn/things/live/env.yaml' file not found`


## Reference
No ticket

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
