### PR TITLE
Mark OSX builds as universal in Treeherder.

### DIFF
--- a/taskcluster/ci/build/macos.yml
+++ b/taskcluster/ci/build/macos.yml
@@ -8,7 +8,7 @@ task-defaults:
             symbol: BD
             kind: build
             tier: 1
-            platform: macos/x86_64
+            platform: macos/universal
     requires-level: 1
     worker-type: b-macos
     fetches:


### PR DESCRIPTION
## Description

Looking at the task output of the Mac Builder - Since 2.16 this is a universal build - the taskcluster row should reflect that :) 

```
 ~/D/M/M/C/MacOS  file 'Mozilla VPN'                                                                    9  18:40 
Mozilla VPN: Mach-O universal binary with 2 architectures: [x86_64:Mach-O 64-bit executable x86_64] [arm64]
Mozilla VPN (for architecture x86_64):	Mach-O 64-bit executable x86_64
Mozilla VPN (for architecture arm64):	Mach-O 64-bit executable arm64
``? 

