### PR TITLE
VPN-4919: Fix cmake build invocation when extracting strings

### DIFF
--- a/scripts/utils/generate_ts.sh
+++ b/scripts/utils/generate_ts.sh
@@ -101,7 +101,7 @@ EOF
         # Use the CMake project to generate addons.
         mkdir -p build-addons-$branch/
         cmake -S addons/ -B build-addons-$branch/
-        cmake --build -B build-addons-$branch/
+        cmake --build build-addons-$branch/
         ts_files="build-addons-$branch/*.ts"
       else
         # No addons to process.

--- a/scripts/utils/generate_ts.sh
+++ b/scripts/utils/generate_ts.sh
@@ -119,8 +119,8 @@ EOF
           printn Y "File ${ts_name} does not exist, copying over..."
           cp "$f" addon_ts/
         fi
+        rm $f || die
       done
-      rm addons/generated/addons/*.ts || die
     fi
   done
 

--- a/scripts/utils/generate_ts.sh
+++ b/scripts/utils/generate_ts.sh
@@ -58,17 +58,16 @@ EOF
   print Y "$project - Generating the main translation file... "
   ${QT_HOST_BINS}/lupdate translations/generated/$project/dummy_ts.pro -ts translations.ts || die
 
-  printn Y "$project - Generating strings for addons... "
+  print Y "$project - Generating strings for addons... "
   cmake cmake -S $(pwd)/addons -B build-addons/
   cmake --build build-addons/
   mkdir -p addon_ts || die
   cp build-addons/*.ts addon_ts
-  print G "done."
 
   for branch in $(git branch -r | grep origin/releases); do
     git checkout $branch &>/dev/null || die
 
-    printn Y "Importing main strings from $branch..."
+    print Y "Importing main strings from $branch..."
     if [ -f translations/strings.yaml ]; then
       if [ $project = "vpn" ]; then
         python3 cache/generate_strings.py -o translations/generated/$project -p $project translations/strings.yaml || die
@@ -92,7 +91,7 @@ EOF
     rm branch.ts || die
 
     if [ "$project" = "vpn" ]; then
-      printn Y "Importing addon strings from $branch..."
+      print Y "Importing addon strings from $branch..."
       if [ -f "scripts/addon/generate_all.py" ]; then
         # Use the old python scripts to generate addons.
         python3 scripts/addon/generate_all.py
@@ -112,11 +111,11 @@ EOF
       do
         ts_name=$(basename "$f")
         if [ -f "addon_ts/${ts_name}" ]; then
-          printn Y "File ${ts_name} exists, updating with branch strings..."
+          print Y "File ${ts_name} exists, updating with branch strings..."
           ${QT_HOST_BINS}/lconvert -i "addon_ts/${ts_name}" "$f" -o tmp.ts || die
           mv tmp.ts "addon_ts/${ts_name}"
         else
-          printn Y "File ${ts_name} does not exist, copying over..."
+          print Y "File ${ts_name} does not exist, copying over..."
           cp "$f" addon_ts/
         fi
         rm $f || die


### PR DESCRIPTION
## Description
In the last round of refactoring on the addon generation, we needed to update the `genetrate_ts.sh` script, but I left a typo in there that would fail to build the addons from release branches when CMake was used.

## Reference
Github issue #7084 ([VPN-4919](https://mozilla-hub.atlassian.net/browse/VPN-4919))

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-4919]: https://mozilla-hub.atlassian.net/browse/VPN-4919?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ