### PR TITLE
[RFC] VPN-4736 - Sharing a session identifier between app and daemon

### DIFF
--- a/docs/rfcs/0002-session-id-sharing.md
+++ b/docs/rfcs/0002-session-id-sharing.md
@@ -218,6 +218,5 @@ for cases such as iOS where the daemon process is only alive while a session is 
 ### Share the management burdens of the shared session id
 
 The first iteration of the proposed solution, included the main application storing and managing
-the `shared_session_id` and passing it along to the daemon when possible. That can be read on
-[7e20c2c933fc868b3ea50d6eb35651b904628658](https://github.com/mozilla-mobile/mozilla-vpn-client/tree/7e20c2c933fc868b3ea50d6eb35651b904628658).
+the `shared_session_id` and passing it along to the daemon when possible.
 Ultimately, that is an overly complex way to achieve the same end goal as the current proposal.

--- a/docs/rfcs/0002-session-id-sharing.md
+++ b/docs/rfcs/0002-session-id-sharing.md
@@ -1,0 +1,226 @@
+- Status:
+- Date: 2023-06-07
+- Author: [@brizental](https://github.com/brizental)
+- RFC PR: [#TODO](https://github.com/mozilla-mobile/mozilla-vpn-client/pull/TODO)
+- Implementation GitHub issue: TODO
+
+## Problem Statement
+
+The VPN application is divided in two processes: the main application and the daemon. The main application is where the user interface runs and the daemon is what manages the VPN configuration and tunnel.
+
+In desktop environments, even while backgrounded the main application process is still running, but in mobile environments it is not. Due to this caveat, the mobile daemon processes have a separate instance of Glean to be able to collect telemetry about the connection while the application is in the background.
+
+This architecture poses a problem for analyzers. It is not possible to easily join the data from the same session between daemon and main application. The session ids are different due to these being two different Glean instances.
+
+For more information on this topic, refer to [Mozilla VPN Telemetry Refactor](https://docs.google.com/document/d/1jyNZ_g_cUpZZsEr2hYwnwZgkxlvqTmoFUJKp_LAOPts/edit#heading=h.xararkvsnpss).
+
+## Proposed Solution
+
+> **Note** Honestly, I think for this proposed solution it's just easier to look at the pseudo-code in Appendix 1.
+
+A new metric will be added to both the daemonsession and the session pings: shared_session_id. This metric will have lifetime ping i.e. it is cleared from storage whenever a ping containing it is submitted. Thus it needs to be set again every time a new session/daemonsession ping is submitted.
+
+Both daemon and main application will store the value of this metric in their local storages for synchronization purposes. More about this in the sections below.
+
+A new reason will be added to the session pings “flush_init”. As better described in the sections below, the processes will be able to identify that either the VPN tunnel or main application did not gracefully hit the deactivation signal i.e. were force killed. The “flush_init” ping will be used to flush any data remaining from the previous session.
+
+There will be four key triggers that will handle the shared_session_id: initialization, on VPN activation, ping timer and on VPN deactivation.
+
+### ON VPN ACTIVATION
+
+#### MAIN APPLICATION
+
+In case the VPN is started from the main application, a session id will be created and shared through the activation signal with the daemon. The generated UUID will be stored in the main application local storage and the session ping will be submitted.
+
+#### DAEMON
+
+If the VPN is being activated through the main application, a session id will have been passed through the activation signal. Otherwise the Daemon will generate this value itself. The UUID will be stored in the daemon local storage and the session ping will be submitted.
+
+### ON PING TIMER
+
+#### MAIN APPLICATION
+
+The session id is retrieved from local storage and recorded. The session ping is submitted.
+
+#### DAEMON
+
+The session id is retrieved from local storage and recorded. The session ping is submitted.
+
+### ON VPN DEACTIVATION
+
+The deactivation signal may not be hit in both the main application and the daemon, because both processes may be force killed. The local storage that contains the session id will be cleared after submitting the final session ping. This will be a flag at initialization that the final session ping was not submitted and there may be lingering data from a previous session in storage that needs to be submitted.
+
+#### MAIN APPLICATION
+
+The session id is retrieved from local storage and recorded. The session ping is submitted. Finally local storage for the session id is cleared.
+
+#### DAEMON
+
+The session id is retrieved from local storage and recorded. The session ping is submitted. Finally local storage for the session id is cleared.
+
+### ON INITIALIZATION
+
+#### MAIN APPLICATION
+
+The session id is retrieved from local storage. If it is not empty, there are four possibilities:
+
+1. The same session from a previous app run is still ongoing. No action is required
+2. Another session is ongoing in which case a flush ping is required to data from a previous session and start recording data for the new session
+3. No session is ongoing but there is a lingering session id indicating that there is still lingering data from a previous session in storage and a flush ping is required
+4. No session is ongoing and no lingering session id is in storage. No action is required
+
+#### DAEMON
+
+On the daemon there are only two possibilities:
+
+1. No session is ongoing but there is a lingering session id indicating that there is still lingering data from a previous session in storage and a flush ping is required
+2. No session is ongoing and no lingering session id is in storage. No action is required
+
+## APPENDIX
+
+### APPENDIX 1: PSEUDO CODE
+
+#### Main application
+
+```cpp
+MainApp::init() {
+  String lingeringSessionId = LocalStorage::get(SESSION_ID_STORAGE_KEY);
+  // If this is not empty, the VPN was not deactivated from the app.
+  if (!lingeringSessionId.isEmpty()) {
+    if (Daemon::vpnIsOn()) {
+      try {
+        String sessionId = Daemon::getSessionId();
+        // Check if we are still in the same session
+        if (sessionId != lingeringSessionId) {
+          // Flush any lingering data from a previous session
+          pings::main_app::session.submit(INIT_FLUSH_REASON);
+
+          metrics::main_app::sessionId.set(sessionId);
+          // Record session::* context metrics e.g. app_exclusions.
+
+          LocalStorage::set(SESSION_ID_STORAGE_KEY, sessionId);
+        }
+
+        // Schedule the timer.
+        MainApp::schedulePingTimer();
+      } catch {
+        // Note: If communication with the daemon doesn't work,
+        // let's assume the VPN is off. This is very unlikely, given we
+        // have just communicated with the daemon through Daemon::vpnIsOn();
+
+        // Flush any lingering data from a previous session
+        pings::main_app::session.submit(INIT_FLUSH_REASON);
+        // Clear the sessionId storage
+        LocalStorage::clear(SESSION_ID_STORAGE_KEY);
+      }
+    } else {
+      // Flush any lingering data from a previous session
+      pings::main_app::session.submit(INIT_FLUSH_REASON);
+      // Clear the sessionId storage
+      LocalStorage::clear(SESSION_ID_STORAGE_KEY);
+    }
+  }
+}
+
+MainApp::onActivate() {
+  // Let's flush any lingering data for before activating the VPN.
+  // We want the active session pings to only include data from the current session.
+  //
+  // This ping should be always empty. This is a way to monitor if it isn't
+  pings::main_app::session.submit(FLUSH_REASON);
+
+  String sessionId = generateUUID();
+  try {
+    Daemon::activate(config, sessionId);
+    // Note: session::* metrics should only be recorded from now on,
+    // so that flush pings don't contain unexpected data.
+
+    metrics::main_app::sessionId.set(sessionId);
+    // Record session::* context metrics e.g. app_exclusions.
+
+    LocalStorage::set(SESSION_ID_STORAGE_KEY, sessionId);
+
+    // Submit the start ping
+    pings::main_app::session.submit(START_REASON);
+  } catch {
+    // TODO: Record error.
+    LocalStorage::clear(SESSION_ID_STORAGE_KEY);
+  }
+}
+
+MainApp::onPingTimer() {
+  String sessionId = LocalStorage::get(SESSION_ID_STORAGE_KEY);
+  metrics::main_app::sessionId.set(sessionId);
+
+  // Submit the timer ping
+  pings::main_app::session.submit(TIMER_REASON);
+}
+
+MainApp::onDeactivate() {
+  // Stop the timer.
+  MainApp::stopPingTimer();
+
+  String sessionId = LocalStorage::get(SESSION_ID_STORAGE_KEY);
+  metrics::main_app::sessionId.set(sessionId);
+
+  // Submit the stop ping
+  pings::main_app::session.submit(TIMER_REASON);
+  LocalStorage::clear(SESSION_ID_STORAGE_KEY);
+}
+```
+
+#### Daemon
+
+```cpp
+Daemon::init() {
+  String lingeringSessionId = LocalStorage::get(SESSION_ID_STORAGE_KEY);
+
+  // If this is not empty, the tunnel was force killed
+  if (!lingeringSessionId.isEmpty()) {
+    metrics::daemon::sessionId.set(lingeringSessionId);
+    // Flush lingering data
+    pings::daemonsession.submit(INIT_FLUSH_REASON);
+    LocalStorage::clear(SESSION_ID_STORAGE_KEY);
+  }
+}
+
+Daemon::onActivate(Config config, String sessionId = "") {
+  // Let's flush any lingering data for before activating the VPN.
+  // We want the active session pings to only include data from the current session.
+  //
+  // This ping should be always empty. This is a way to monitor if it isn't
+  pings::daemonsession.submit(FLUSH_REASON);
+
+  auto sessionId = sessionId;
+  if (sessionId.isEmpty()) {
+    logger.info() << "Starting VPN from somewhere other than the main app";
+    sessionId = metrics::daemon::sessionId.generateAndSet();
+  } else {
+    metrics::daemon::sessionId.set(sessionId);
+  }
+  LocalStorage::set(SESSION_ID_STORAGE_KEY, sessionId);
+
+  // Submit the start ping
+  pings::daemonsession.submit(START_REASON);
+}
+
+Daemon::onPingTimer() {
+  String sessionId = LocalStorage::get(SESSION_ID_STORAGE_KEY);
+  metrics::daemon::sessionId.set(sessionId);
+
+  // Submit the timer ping
+  pings::daemonsession.submit(TIMER_REASON);
+}
+
+Daemon::onDeactivate() {
+  String sessionId = LocalStorage::get(SESSION_ID_STORAGE_KEY);
+  metrics::daemon::sessionId.set(sessionId);
+
+  // Submit the stop ping
+  pings::daemonsession.submit(STOP_REASON);
+
+  // Clear the local storage
+  LocalStorage::clear(SESSION_ID_STORAGE_KEY);
+}
+
+```

--- a/docs/rfcs/0002-session-id-sharing.md
+++ b/docs/rfcs/0002-session-id-sharing.md
@@ -2,7 +2,7 @@
 - Date: 2023-06-07
 - Author: [@brizental](https://github.com/brizental)
 - RFC PR: [#7112](https://github.com/mozilla-mobile/mozilla-vpn-client/pull/7112)
-- Implementation GitHub issue: TODO
+- Implementation GitHub issue: https://github.com/mozilla-mobile/mozilla-vpn-client/issues/7588
 
 ## Problem Statement
 

--- a/docs/rfcs/0002-session-id-sharing.md
+++ b/docs/rfcs/0002-session-id-sharing.md
@@ -146,14 +146,14 @@ If the main application is active during a session start it will,
 
 1. Signal to the daemon that a new session is to be started.
 2. It will then ask the daemon for the value of the shared session id it created.
-3. If the previous two communications where successful
+3. If the previous two communications were successful
    1. The `vpnsession` ping will be submitted with reason `flush`.
    2. The value of the retrieved `shared_session_id` is recorded.
    3. Other session metrics may be recorded from this point.
    4. If the communication with the daemon fails, an error metric is recorded.
 
 > **Note**: If the retrieved session id is the known inactive session id,
-> this is considered an unsuccessful retrieval and the error path is taken.
+> this is considered an unsuccessful retrieval and the error path -- i.e. step 4 of the above steps -- is taken.
 
 #### On session end
 

--- a/docs/rfcs/0002-session-id-sharing.md
+++ b/docs/rfcs/0002-session-id-sharing.md
@@ -147,13 +147,13 @@ If the main application is active during a session start it will,
 1. Signal to the daemon that a new session is to be started.
 2. It will then ask the daemon for the value of the shared session id it created.
 3. If the previous two communications where successful
-   3.a. The `vpnsession` ping will be submitted with reason `flush`.
-   3.b. The value of the retrieved `shared_session_id` is recorded.
-   3.c. Other session metrics may be recorded from this point.
+   1. The `vpnsession` ping will be submitted with reason `flush`.
+   2. The value of the retrieved `shared_session_id` is recorded.
+   3. Other session metrics may be recorded from this point.
+   4. If the communication with the daemon fails, an error metric is recorded.
 
-> **Note**: If the communication with the daemon fails, an error metric is recorded. If the
-> retrieved session id is the known inactive session id, this is considered an unsuccessful
-> retrieval and the error path is taken.
+> **Note**: If the retrieved session id is the known inactive session id,
+> this is considered an unsuccessful retrieval and the error path is taken.
 
 #### On session end
 

--- a/docs/rfcs/0002-session-id-sharing.md
+++ b/docs/rfcs/0002-session-id-sharing.md
@@ -1,226 +1,223 @@
 - Status:
 - Date: 2023-06-07
 - Author: [@brizental](https://github.com/brizental)
-- RFC PR: [#TODO](https://github.com/mozilla-mobile/mozilla-vpn-client/pull/TODO)
+- RFC PR: [#7112](https://github.com/mozilla-mobile/mozilla-vpn-client/pull/7112)
 - Implementation GitHub issue: TODO
 
 ## Problem Statement
 
-The VPN application is divided in two processes: the main application and the daemon. The main application is where the user interface runs and the daemon is what manages the VPN configuration and tunnel.
+### The two processes: Main Application and Daemon
 
-In desktop environments, even while backgrounded the main application process is still running, but in mobile environments it is not. Due to this caveat, the mobile daemon processes have a separate instance of Glean to be able to collect telemetry about the connection while the application is in the background.
+The Mozilla VPN application is split in two processes: the main application and the daemon
+(a background process). The main application is where the user interface runs and the
+daemon is what manages the VPN configuration and tunnel.
 
-This architecture poses a problem for analyzers. It is not possible to easily join the data from the same session between daemon and main application. The session ids are different due to these being two different Glean instances.
+> **Note**: The daemon process may also be referred to as "network extension" on iOS
+> or "broker" in multiple platforms. Throughout this document the term "daemon" will be used.
 
-For more information on this topic, refer to [Mozilla VPN Telemetry Refactor](https://docs.google.com/document/d/1jyNZ_g_cUpZZsEr2hYwnwZgkxlvqTmoFUJKp_LAOPts/edit#heading=h.xararkvsnpss).
+#### The lifetime of each process varies between the supported platforms
+
+On Android the daemon process starts alongside the main application process once the application is
+launched and remains active until killed, regardless on whether the VPN is turned on or not.
+The main application process is only active while the application is in the foreground.
+iOS is similar, but the daemon process is only active while the VPN is turned ON.
+
+On Desktop environments the main application process is active while the application is active,
+independent of the application being foregrounded or backgrounded. Due to OS specific mechanisms
+such as [App Nap](https://developer.apple.com/library/archive/documentation/Performance/Conceptual/power_efficiency_guidelines_osx/AppNap.html)
+this process may go dormant intermittently after the application is backgrounded for a long time.
+
+#### The daemon process may be started independently from the main application on mobile platforms
+
+Both the operational system and the Mozilla VPN application expose features that allow the user
+to turn on the VPN without interacting with the main application. On mobile environments, when
+the VPN is turned on through any of these methods, the main application process is never launched
+while the daemon process is.
+
+### The issue with mobile session based telemetry
+
+When analyzing incoming telemetry from the Mozilla VPN application, it's a recurring requirement
+to be able to partition the incoming data by session. **A VPN session starts when the VPN is turned
+on through some user action and ends once it is turned off through some user action.**
+
+That is easily addressed on desktop environments, by having the main application manage a session_id
+metric and add that to all session pings. Data from a given session all have the same session_id
+and can be joined using that identifier.
+
+On mobile environments, due to the lack of guarantees on the main application process being alive
+throughout most or any of the VPN session, having the main application manage the session_id is unreliable.
+This identifier needs to be rotated on every session start/end and the main application process may
+not be running at these times.
+
+Moreover, on mobile platforms, the fact that the main application process is killed whenever
+the application goes to the background makes the main application telemetry insufficient for collecting
+all the telemetry required to understand the health of the Mozilla VPN application and its usage patterns.
+To address this issue, mobile daemons have a separate instance of Glean, used to collect telemetry
+while the application is backgrounded. In order to get a full picture of a mobile user's session,
+joining the daemon data with the main application is necessary. However, the telemetry clients in
+each process are independent so manually sharing an identifier is required for such joins.
+
+On [VPN session pings - Tech Spec](https://mozilla-hub.atlassian.net/wiki/spaces/SECPRV/pages/184419319/VPN+session+pings+-+Tech+spec)
+an installation_id metric is introduced that would allows joins between daemon and main application
+data. That still does not make it possible to join specific sessions i.e. we are able to infer that
+a given daemon session is coming from the same installation as a main application session, but we
+cannot reliably or easily infer that a given daemon session is the same as a given main application session.
+
+## Document Purpose
+
+Propose a solution to reliably join mobile session data between daemon and main application telemetry.
+
+## Requirements
+
+The main transport for session related data are the session pings, namely
+the [`vpnsession`](https://dictionary.telemetry.mozilla.org/apps/mozilla_vpn/pings/vpnsession) ping
+and the [`daemonsession`](https://dictionary.telemetry.mozilla.org/apps/mozilla_vpn/pings/daemonsession) ping.
+
+It is a requirement on the proposed solution, that the metrics included in each ping are all
+recorded during the session related to the shared session id in it i.e. the ping does not contain
+any metric from a previous session.
 
 ## Proposed Solution
 
-> **Note** Honestly, I think for this proposed solution it's just easier to look at the pseudo-code in Appendix 1.
+A new metric will be introduced to mobile platforms: `shared_session_id`. This metric will be the
+primary session identifier metric for Mozilla VPN mobile telemetry. This metric will have lifetime
+`User`, with this lifetime, once a metric is set it can only be overwritten but never cleared from
+the telemetry storage.
 
-A new metric will be added to both the daemonsession and the session pings: shared_session_id. This metric will have lifetime ping i.e. it is cleared from storage whenever a ping containing it is submitted. Thus it needs to be set again every time a new session/daemonsession ping is submitted.
+The daemon process will be responsible for managing this metric. The daemon is the preferred
+place for this, because it is _guaranteed_ to be running throughout the whole VPN session.
 
-Both daemon and main application will store the value of this metric in their local storages for synchronization purposes. More about this in the sections below.
+The main application will communicate with the daemon in order to get the correct value for
+this metric whenever necessary.
 
-A new reason will be added to the session pings “flush_init”. As better described in the sections below, the processes will be able to identify that either the VPN tunnel or main application did not gracefully hit the deactivation signal i.e. were force killed. The “flush_init” ping will be used to flush any data remaining from the previous session.
+The scheduling of the `vpnsession` and `daemonsession` pings will be tweaked to meet
+the requirements of isolating session data per ping.
 
-There will be four key triggers that will handle the shared_session_id: initialization, on VPN activation, ping timer and on VPN deactivation.
+### On the daemon
 
-### ON VPN ACTIVATION
+There are three important triggers that require action on the shared session id and
+the `daemonsession` ping on the daemon process.
 
-#### MAIN APPLICATION
+#### On session start
 
-In case the VPN is started from the main application, a session id will be created and shared through the activation signal with the daemon. The generated UUID will be stored in the main application local storage and the session ping will be submitted.
+Once a new session is started,
 
-#### DAEMON
+1. The `daemonsession` ping will be submitted with reason `flush`, in order to flush out
+   any lingering data before starting collection telemetry related to the new session.
+2. The `shared_session_id` is generated and recorded.
+3. The value recorded to telemetry is also persisted on the daemon's local storage.
+4. Session metrics may be recorded from this point on.
+5. Session is started.
 
-If the VPN is being activated through the main application, a session id will have been passed through the activation signal. Otherwise the Daemon will generate this value itself. The UUID will be stored in the daemon local storage and the session ping will be submitted.
+The `flush` ping submitted on step one is expected to be empty. The submission of it right
+before the start of a new session is a safety measure to guarantee no lingering data makes it
+to the actual session ping.
 
-### ON PING TIMER
+#### On session end
 
-#### MAIN APPLICATION
+Once an ongoing session is ended,
 
-The session id is retrieved from local storage and recorded. The session ping is submitted.
+1. The `daemonsession` ping is submitted with the reason `daemon_end`.
+2. The daemon's local storage for the `shared_session_id` is cleared.
+3. The `shared_session_id` metric is set to a known value. Due to it's `User` lifetime,
+   this metric cannot be cleared from storage ever. To indicate a period of inactivity,
+   we will leverage a known UUID.
 
-#### DAEMON
+#### On daemon process start
 
-The session id is retrieved from local storage and recorded. The session ping is submitted.
+The session end trigger may not be hit, if the daemon process is force killed. Therefore,
+whenever the daemon process is started the local storage will be searched for a lingering
+`shared_session_id` value. That is a clear signal that the session end trigger was not hit
+and that there may be lingering data from a previous session on the Glean storage.
 
-### ON VPN DEACTIVATION
+When that is the case,
 
-The deactivation signal may not be hit in both the main application and the daemon, because both processes may be force killed. The local storage that contains the session id will be cleared after submitting the final session ping. This will be a flag at initialization that the final session ping was not submitted and there may be lingering data from a previous session in storage that needs to be submitted.
+1. The lingering `shared_session_id` value is recorded to Glean.
+2. The `daemonsession` ping is submitted with the reason `flush_init`.
 
-#### MAIN APPLICATION
+### On the main application
 
-The session id is retrieved from local storage and recorded. The session ping is submitted. Finally local storage for the session id is cleared.
+The same three triggers which are important for the daemon and the `daemonsession` ping,
+are also important for the main application and the `vpnsession` ping.
 
-#### DAEMON
+#### On session start
 
-The session id is retrieved from local storage and recorded. The session ping is submitted. Finally local storage for the session id is cleared.
+If the main application is active during a session start it will,
 
-### ON INITIALIZATION
+1. Signal to the daemon that a new session is to be started.
+2. It will then ask the daemon for the value of the shared session id it created.
+3. If the previous two communications where successful
+   3.a. The `vpnsession` ping will be submitted with reason `flush`.
+   3.b. The value of the retrieved `shared_session_id` is recorded.
+   3.c. Other session metrics may be recorded from this point.
 
-#### MAIN APPLICATION
+> **Note**: If the communication with the daemon fails, an error metric is recorded. If the
+> retrieved session id is the known inactive session id, this is considered an unsuccessful
+> retrieval and the error path is taken.
 
-The session id is retrieved from local storage. If it is not empty, there are four possibilities:
+#### On session end
 
-1. The same session from a previous app run is still ongoing. No action is required
-2. Another session is ongoing in which case a flush ping is required to data from a previous session and start recording data for the new session
-3. No session is ongoing but there is a lingering session id indicating that there is still lingering data from a previous session in storage and a flush ping is required
-4. No session is ongoing and no lingering session id is in storage. No action is required
+If the main application is active during a session end it will,
 
-#### DAEMON
+1. Submit the session ping with reason `end`.
+2. Set `shared_session_id` metric is set to a known value. The same known value used for inactive
+   sessions on the `daemonsession` ping.
 
-On the daemon there are only two possibilities:
+#### On application start
 
-1. No session is ongoing but there is a lingering session id indicating that there is still lingering data from a previous session in storage and a flush ping is required
-2. No session is ongoing and no lingering session id is in storage. No action is required
+When the main application is started, just like in the daemon, there may be some lingering data
+from a previous session in storage. Om the main application, the session_id is not directly managed,
+so there is no way to know if there is lingering data or not.
 
-## APPENDIX
+In this case, the main application will submit the `vpnsession` ping with reason `flush_init` on
+_every_ initialization. In case there is no lingering data, this is not really an issue. The ping
+will be sent with only the currently stored session id value.
 
-### APPENDIX 1: PSEUDO CODE
+After sending the `flush_init` ping, the VPN will query the daemon for a session id.
+If a session id is received, that means there is an ongoing VPN session. In that case, the
+retrieved session id is recorded to the `shared_session_id` metric. If nothing is received from
+the daemon, it is assumed there is no ongoing VPN session and the `shared_session_id` metric is
+set to the known value, to indicate inactivity.
 
-#### Main application
+### Validation
 
-```cpp
-MainApp::init() {
-  String lingeringSessionId = LocalStorage::get(SESSION_ID_STORAGE_KEY);
-  // If this is not empty, the VPN was not deactivated from the app.
-  if (!lingeringSessionId.isEmpty()) {
-    if (Daemon::vpnIsOn()) {
-      try {
-        String sessionId = Daemon::getSessionId();
-        // Check if we are still in the same session
-        if (sessionId != lingeringSessionId) {
-          // Flush any lingering data from a previous session
-          pings::main_app::session.submit(INIT_FLUSH_REASON);
+In order to validate this feature after release, these questions need to be answered:
 
-          metrics::main_app::sessionId.set(sessionId);
-          // Record session::* context metrics e.g. app_exclusions.
+- Are we getting too much data assigned to the inactive session id?
+  If the design is completely air tight i.e. all collected data is related to an active session id,
+  there should be no data on inactive session flush pings. If there is too much data on these pings,
+  that would signal a possible bug on the design or on the implementation.
+- Does every session coming from the daemon have a `start` and `end` or `flush_init` pings?
+  One of the core assumptions in this proposal is that the daemon process is always capable of
+  capturing the whole VPN session. As such it should always have these pings in a given session.
+- Are there too many error metrics being recorded due to unsuccessful retrieval of the session id
+  from the daemon?
+  Another core assumption here is that, if the daemon has an ongoing session the main application will,
+  most of the time, not run into any issues retrieving the shared_session_id from it. If there are too
+  many errors in communication that would mean that assumption was incorrect or there is a bug in the
+  implementation.
 
-          LocalStorage::set(SESSION_ID_STORAGE_KEY, sessionId);
-        }
+## Considered Alternatives
 
-        // Schedule the timer.
-        MainApp::schedulePingTimer();
-      } catch {
-        // Note: If communication with the daemon doesn't work,
-        // let's assume the VPN is off. This is very unlikely, given we
-        // have just communicated with the daemon through Daemon::vpnIsOn();
+Following are the other considered alternatives to address the same issue as the proposed solution
+and the reasoning on why these were ultimately not the chosen alternatives.
 
-        // Flush any lingering data from a previous session
-        pings::main_app::session.submit(INIT_FLUSH_REASON);
-        // Clear the sessionId storage
-        LocalStorage::clear(SESSION_ID_STORAGE_KEY);
-      }
-    } else {
-      // Flush any lingering data from a previous session
-      pings::main_app::session.submit(INIT_FLUSH_REASON);
-      // Clear the sessionId storage
-      LocalStorage::clear(SESSION_ID_STORAGE_KEY);
-    }
-  }
-}
+### Collect all data on the daemon
 
-MainApp::onActivate() {
-  // Let's flush any lingering data for before activating the VPN.
-  // We want the active session pings to only include data from the current session.
-  //
-  // This ping should be always empty. This is a way to monitor if it isn't
-  pings::main_app::session.submit(FLUSH_REASON);
+If all data were collected on the daemon, instead of having the two Glean architecture that is
+currently implemented that would not also fix the issue of joining daemon data with main application
+data, simply by not having main application data at all.
 
-  String sessionId = generateUUID();
-  try {
-    Daemon::activate(config, sessionId);
-    // Note: session::* metrics should only be recorded from now on,
-    // so that flush pings don't contain unexpected data.
+The issue with this approach, is that most of the telemetry collected on the Mozilla VPN application
+is in the main application. Button clicks, configuration, performance metrics and so on. If there were
+only a Glean instance of the daemon process, every time an event that requires telemetry happened on
+the main application that would need to be passed through to the daemon. Not only does that significantly
+increase the overhead of adding any new telemetry to the application, but it is also not possible
+for cases such as iOS where the daemon process is only alive while a session is active.
 
-    metrics::main_app::sessionId.set(sessionId);
-    // Record session::* context metrics e.g. app_exclusions.
+### Share the management burdens of the shared session id
 
-    LocalStorage::set(SESSION_ID_STORAGE_KEY, sessionId);
-
-    // Submit the start ping
-    pings::main_app::session.submit(START_REASON);
-  } catch {
-    // TODO: Record error.
-    LocalStorage::clear(SESSION_ID_STORAGE_KEY);
-  }
-}
-
-MainApp::onPingTimer() {
-  String sessionId = LocalStorage::get(SESSION_ID_STORAGE_KEY);
-  metrics::main_app::sessionId.set(sessionId);
-
-  // Submit the timer ping
-  pings::main_app::session.submit(TIMER_REASON);
-}
-
-MainApp::onDeactivate() {
-  // Stop the timer.
-  MainApp::stopPingTimer();
-
-  String sessionId = LocalStorage::get(SESSION_ID_STORAGE_KEY);
-  metrics::main_app::sessionId.set(sessionId);
-
-  // Submit the stop ping
-  pings::main_app::session.submit(TIMER_REASON);
-  LocalStorage::clear(SESSION_ID_STORAGE_KEY);
-}
-```
-
-#### Daemon
-
-```cpp
-Daemon::init() {
-  String lingeringSessionId = LocalStorage::get(SESSION_ID_STORAGE_KEY);
-
-  // If this is not empty, the tunnel was force killed
-  if (!lingeringSessionId.isEmpty()) {
-    metrics::daemon::sessionId.set(lingeringSessionId);
-    // Flush lingering data
-    pings::daemonsession.submit(INIT_FLUSH_REASON);
-    LocalStorage::clear(SESSION_ID_STORAGE_KEY);
-  }
-}
-
-Daemon::onActivate(Config config, String sessionId = "") {
-  // Let's flush any lingering data for before activating the VPN.
-  // We want the active session pings to only include data from the current session.
-  //
-  // This ping should be always empty. This is a way to monitor if it isn't
-  pings::daemonsession.submit(FLUSH_REASON);
-
-  auto sessionId = sessionId;
-  if (sessionId.isEmpty()) {
-    logger.info() << "Starting VPN from somewhere other than the main app";
-    sessionId = metrics::daemon::sessionId.generateAndSet();
-  } else {
-    metrics::daemon::sessionId.set(sessionId);
-  }
-  LocalStorage::set(SESSION_ID_STORAGE_KEY, sessionId);
-
-  // Submit the start ping
-  pings::daemonsession.submit(START_REASON);
-}
-
-Daemon::onPingTimer() {
-  String sessionId = LocalStorage::get(SESSION_ID_STORAGE_KEY);
-  metrics::daemon::sessionId.set(sessionId);
-
-  // Submit the timer ping
-  pings::daemonsession.submit(TIMER_REASON);
-}
-
-Daemon::onDeactivate() {
-  String sessionId = LocalStorage::get(SESSION_ID_STORAGE_KEY);
-  metrics::daemon::sessionId.set(sessionId);
-
-  // Submit the stop ping
-  pings::daemonsession.submit(STOP_REASON);
-
-  // Clear the local storage
-  LocalStorage::clear(SESSION_ID_STORAGE_KEY);
-}
-
-```
+The first iteration of the proposed solution, included the main application storing and managing
+the `shared_session_id` and passing it along to the daemon when possible. That can be read on
+[7e20c2c933fc868b3ea50d6eb35651b904628658](https://github.com/mozilla-mobile/mozilla-vpn-client/tree/7e20c2c933fc868b3ea50d6eb35651b904628658).
+Ultimately, that is an overly complex way to achieve the same end goal as the current proposal.

--- a/docs/rfcs/0002-session-id-sharing.md
+++ b/docs/rfcs/0002-session-id-sharing.md
@@ -119,7 +119,7 @@ Once an ongoing session is ended,
 
 1. The `daemonsession` ping is submitted with the reason `daemon_end`.
 2. The daemon's local storage for the `shared_session_id` is cleared.
-3. The `shared_session_id` metric is set to a known value. Due to it's `User` lifetime,
+3. The `shared_session_id` metric is set to a known value. Due to its `User` lifetime,
    this metric cannot be cleared from storage ever. To indicate a period of inactivity,
    we will leverage a known UUID.
 
@@ -166,7 +166,7 @@ If the main application is active during a session end it will,
 #### On application start
 
 When the main application is started, just like in the daemon, there may be some lingering data
-from a previous session in storage. Om the main application, the session_id is not directly managed,
+from a previous session in storage. On the main application, the session_id is not directly managed,
 so there is no way to know if there is lingering data or not.
 
 In this case, the main application will submit the `vpnsession` ping with reason `flush_init` on
@@ -200,7 +200,7 @@ In order to validate this feature after release, these questions need to be answ
 ## Considered Alternatives
 
 Following are the other considered alternatives to address the same issue as the proposed solution
-and the reasoning on why these were ultimately not the chosen alternatives.
+and the reasoning on why these were ultimately not the chosen solution.
 
 ### Collect all data on the daemon
 

--- a/docs/rfcs/0002-session-id-sharing.md
+++ b/docs/rfcs/0002-session-id-sharing.md
@@ -29,7 +29,7 @@ this process may go dormant intermittently after the application is backgrounded
 
 #### The daemon process may be started independently from the main application on mobile platforms
 
-Both the operational system and the Mozilla VPN application expose features that allow the user
+Both the operating system and the Mozilla VPN application expose features that allow the user
 to turn on the VPN without interacting with the main application. On mobile environments, when
 the VPN is turned on through any of these methods, the main application process is never launched
 while the daemon process is.
@@ -49,7 +49,7 @@ throughout most or any of the VPN session, having the main application manage th
 This identifier needs to be rotated on every session start/end and the main application process may
 not be running at these times.
 
-Moreover, on mobile platforms, the fact that the main application process is killed whenever
+Moreover, on mobile platforms, the fact that the main application process may be killed whenever
 the application goes to the background makes the main application telemetry insufficient for collecting
 all the telemetry required to understand the health of the Mozilla VPN application and its usage patterns.
 To address this issue, mobile daemons have a separate instance of Glean, used to collect telemetry
@@ -103,7 +103,7 @@ the `daemonsession` ping on the daemon process.
 Once a new session is started,
 
 1. The `daemonsession` ping will be submitted with reason `flush`, in order to flush out
-   any lingering data before starting collection telemetry related to the new session.
+   any lingering data before starting to collect telemetry related to the new session.
 2. The `shared_session_id` is generated and recorded.
 3. The value recorded to telemetry is also persisted on the daemon's local storage.
 4. Session metrics may be recorded from this point on.


### PR DESCRIPTION
One of the main concerns that prompted this RFC, was the concern on how to keep the identifiers in sync between main application and daemon and how to know if they are not in sync. 

I believe the first concern is addressed by the design itself and the second concern doesn't seem like a plausible scenario given the design. I am adding this note as a call for the reviewers  close attention to the synchronization aspect of the proposed solution. Thanks!