### PR TITLE
VPN-4496 - Record health metrics on the Android daemon

### DIFF
--- a/android/daemon/build.gradle
+++ b/android/daemon/build.gradle
@@ -37,8 +37,11 @@ apply plugin: "org.jetbrains.kotlin.android"
 apply plugin: "org.mozilla.telemetry.glean-gradle-plugin"
 
 ext.gleanNamespace = "mozilla.telemetry.glean"
-ext.gleanYamlFiles = ["$rootDir/../../../src/apps/vpn/telemetry/metrics.yaml"]
-ext.gleanYamlFiles = ["$rootDir/../../../src/apps/vpn/telemetry/pings.yaml"]
+ext.gleanYamlFiles = [
+    "$rootDir/../../../src/apps/vpn/telemetry/metrics.yaml",
+    "$rootDir/../../../src/apps/vpn/telemetry/metrics_deprecated.yaml",
+    "$rootDir/../../../src/apps/vpn/telemetry/pings.yaml"
+]
 
 android {
     compileSdkVersion Config.compileSdkVersion

--- a/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/ConnectionHealth.kt
+++ b/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/ConnectionHealth.kt
@@ -166,8 +166,8 @@ class ConnectionHealth(service: VPNService) {
     private val TaskCheckConnection = Runnable {
         kotlin.run {
             // capture stuff, as this the members will be set by another thread
-            val gateway = mGateway; // This lives inside the tunnel
-            val endpoint = mEndPoint; // This is the wg-endpoint (not in the tunnel)
+            val gateway = mGateway // This lives inside the tunnel
+            val endpoint = mEndPoint // This is the wg-endpoint (not in the tunnel)
             val dns = mDNS
             val fallbackEndpoint = mAltEndpoint
 
@@ -186,7 +186,7 @@ class ConnectionHealth(service: VPNService) {
             val canReachGateway = vpnNetwork.getByName(gateway).isReachable(PING_TIMEOUT)
             val canReachDNS = vpnNetwork.getByName(dns).isReachable(PING_TIMEOUT)
             if (canReachGateway && canReachDNS) {
-                Session.connectionHealthStableCount.add();
+                Session.connectionHealthStableCount.add()
 
                 // Internet should be fine :)
                 mResetUsed = false
@@ -207,7 +207,7 @@ class ConnectionHealth(service: VPNService) {
                 it.getByName(endpoint).isReachable(PING_TIMEOUT)
             } != null
             if (anyNetworkCanConnect && canReachDNS && !mResetUsed) {
-                Sample.connectionHealthUnstable.record();
+                Sample.connectionHealthUnstable.record()
 
                 // The server seems to be online but the connection broke,
                 // Let's just try to force a reconnect ... but only once.
@@ -225,7 +225,7 @@ class ConnectionHealth(service: VPNService) {
                 it.getByName(fallbackEndpoint).isReachable(PING_TIMEOUT)
             } != null
             if (fallbackServerIsReachable) {
-                Sample.connectionHealthUnstable.record();
+                Sample.connectionHealthUnstable.record()
 
                 Log.i(TAG, "Switch to fallback VPN server")
                 // We the server is online but the connection broke up, let's rest it
@@ -241,7 +241,7 @@ class ConnectionHealth(service: VPNService) {
             // Nothing we can do here to help.
             Log.e(TAG, "Both Server / Serverfallback seem to be unreachable.")
 
-            Sample.connectionHealthNoSignal.record();
+            Sample.connectionHealthNoSignal.record()
             mPanicStateReached = true
             taskDone()
         }

--- a/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/ConnectionHealth.kt
+++ b/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/ConnectionHealth.kt
@@ -10,8 +10,8 @@ import android.os.Build
 import android.os.CountDownTimer
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
-import org.mozilla.firefox.vpn.qt.GleanMetrics.Sample
-import org.mozilla.firefox.vpn.qt.GleanMetrics.Session
+import org.mozilla.firefox.vpn.daemon.GleanMetrics.Sample
+import org.mozilla.firefox.vpn.daemon.GleanMetrics.Session
 
 class ConnectionHealth(service: VPNService) {
     private val TAG = "DaemonConnectionHealth"

--- a/src/apps/vpn/telemetry/metrics.yaml
+++ b/src/apps/vpn/telemetry/metrics.yaml
@@ -164,6 +164,7 @@ session:
     lifetime: ping
     send_in_pings:
       - vpnsession
+      - daemonsession
     description: |
       Count of times that the connection health check succeeds.
       Collected only on mobile apps.

--- a/src/apps/vpn/telemetry/metrics_deprecated.yaml
+++ b/src/apps/vpn/telemetry/metrics_deprecated.yaml
@@ -423,8 +423,19 @@ sample:
     send_in_pings:
       - main
       - vpnsession
+      - daemonsession
     description: |
-      The connection has no signal
+      The connection has no signal.
+
+      This event is recorded in both main application and daemon.
+      The logic and cadence of health checks for each of these 
+      is not the same. On the daemon this checks are only
+      done on the Android daemon and not on the iOS network extension.
+
+      A no signal event event happens when the connection is showing issues,
+      and a silent switch will not address the issue. On when the connection
+      is showing issues and there have been previous silent switches which
+      did not address the issue.
     bugs:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1711123
     data_reviews:
@@ -442,8 +453,18 @@ sample:
     send_in_pings:
       - main
       - vpnsession
+      - daemonsession
     description: |
-      The connection is unstable
+      The connection is unstable.
+
+      This event is recorded in both main application and daemon.
+      The logic and cadence of health checks for each of these 
+      is not the same. On the daemon this checks are only
+      done on the Android daemon and not on the iOS network extension.
+
+      An unstable event happens when the connection is showing issues,
+      but a silent switch may still address the issue and no previous
+      silent switches have happened yet.
     bugs:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1711123
     data_reviews:

--- a/src/apps/vpn/telemetry/metrics_deprecated.yaml
+++ b/src/apps/vpn/telemetry/metrics_deprecated.yaml
@@ -428,7 +428,7 @@ sample:
       The connection has no signal.
 
       This event is recorded in both main application and daemon.
-      The logic and cadence of health checks for each of these 
+      The logic and cadence of health checks for each of these
       is not the same. On the daemon this checks are only
       done on the Android daemon and not on the iOS network extension.
 
@@ -458,7 +458,7 @@ sample:
       The connection is unstable.
 
       This event is recorded in both main application and daemon.
-      The logic and cadence of health checks for each of these 
+      The logic and cadence of health checks for each of these
       is not the same. On the daemon this checks are only
       done on the Android daemon and not on the iOS network extension.
 


### PR DESCRIPTION
The connection health checks on the Daemon are different from the connection health checks on the client. This is a caveat worth noting at analysis time. I have added a longer description to the metrics to make this more explicit.

For this work I have considered that an unstable event happens when the connection is deemed worh a silent server switch while a no signal even happens when we have given up hope. Does that make sense?