### PR TITLE
Polkit auth

### DIFF
--- a/.dictionary
+++ b/.dictionary
@@ -127,6 +127,7 @@ javascript
 js
 json
 libcap
+libpolkit
 libsecret
 licensable
 licensor
@@ -157,6 +158,7 @@ ons
 os
 perl
 podman
+polkit
 powershell
 ppa
 pre

--- a/.github/workflows/test_lottie.yaml
+++ b/.github/workflows/test_lottie.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Install Linux packages
         run: |
           sudo apt update
-          sudo apt install git libgl-dev libegl-dev clang-10 liboath-dev python3 -y
+          sudo apt install git libgl-dev libegl-dev libpolkit-gobject-1-dev clang-10 liboath-dev python3 -y
           python3 -m pip install aqtinstall
           aqt install-qt --outputdir /opt linux desktop $QTVERSION gcc_64 -m all
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -18,10 +18,12 @@ the MIT Public License (*MIT*), a copy of which is [available
 here](https://opensource.org/licenses/MIT) and a copy is provided below.
 
 The Linux release of this project also relies on several files from the
-[WireGuard Tools](https://git.zx2c4.com/wireguard-tools) repository under the
-terms of the Lesser GNU Public License 2.0 (*LGPL-2.0*). A copy of the LGPL-2.0
-is [available here](https://opensource.org/licenses/LGPL-2.0) and a copy is
-provided below.
+[WireGuard Tools](https://git.zx2c4.com/wireguard-tools) repository, as well as
+the FreeDesktop project's [polkit
+library](https://gitlab.freedesktop.org/polkit/polkit/), all of which are
+provided under the terms of the Lesser GNU Public License 2.0 (*LGPL-2.0*). A
+copy of the LGPL-2.0 is [available
+here](https://opensource.org/licenses/LGPL-2.0) and a copy is provided below.
 
 The Windows release of this project also includes several files from the
 [WireGuard Windows](https://git.zx2c4.com/wireguard-windows) repository under

--- a/docs/dev-setup/linux.md
+++ b/docs/dev-setup/linux.md
@@ -22,6 +22,7 @@ Install all of Qt version 6.2.4 and you'll have everything you need.
 On Ubuntu, apt install the following dependencies
 
 * libsecret-1 (>=0.18)
+* libpolkit-gobject-1-0 (>=0.105)
 * libcap2-bin (>=1:2.32)
 * wireguard (>=1.0.20200319)
 * wireguard-tools (>=1.0.20200319)

--- a/linux/debian/control
+++ b/linux/debian/control
@@ -30,14 +30,16 @@ Build-Depends: debhelper (>= 11.2),
                qt6-declarative-dev (>=6.2.0~),
                qt6-declarative-dev-tools (>=6.2.0~),
                qt6-l10n-tools (>=6.2.0~),
-               qt6-tools-dev-tools (>=6.2.0~)
+               qt6-tools-dev-tools (>=6.2.0~),
+               libpolkit-gobject-1-dev
 Standards-Version: 4.4.1
 Homepage: https://vpn.mozilla.org/
 Vcs-Git: https://github.com/mozilla-mobile/mozilla-vpn-client
 
 Package: mozillavpn
 Architecture: any
-Depends: libcap2-bin (>=1:2.32),
+Depends: libpolkit-gobject-1-0 (>=0.105),
+         libcap2-bin (>=1:2.32),
          wireguard (>=1.0.20200319),
          wireguard-tools (>=1.0.20200319),
          libqt6quick6 (>=6.2.0~),

--- a/linux/debian/copyright
+++ b/linux/debian/copyright
@@ -26,10 +26,12 @@ License: MPL-2.0
  here.](https://opensource.org/licenses/MIT) and a copy is provided below.
  .
  The Linux release of this project also relies on several files from the
- [WireGuard Tools] (https://github.com/WireGuard/wireguard-tools/) repository
- under the terms of the Lesser GNU Public License 2.0 (*LGPL-2.0*), a copy of
- the LGPL-2.0 is [available here](https://opensource.org/licenses/LGPL-2.0),
- and a copy is provided below.
+ [WireGuard Tools] (https://github.com/WireGuard/wireguard-tools/) repository,
+ as well as the FreeDesktop project's [polkit
+ library](https://gitlab.freedesktop.org/polkit/polkit/), all of which are
+ provided under the terms of the Lesser GNU Public License 2.0 (*LGPL-2.0*). A
+ copy of the LGPL-2.0 is [available
+ here.](https://opensource.org/licenses/LGPL-2.0) and a copy is provided below.
  .
  Finally, this project uses EC25519 and CHACHA-POLY implementations from HACL\*,
  available under the terms of the MIT Public License (*MIT*) and copyright (c)

--- a/linux/mozillavpn.service.in
+++ b/linux/mozillavpn.service.in
@@ -8,5 +8,8 @@ Type=dbus
 BusName=org.mozilla.vpn.dbus
 ExecStart=@CMAKE_INSTALL_FULL_BINDIR@/mozillavpn linuxdaemon
 
+# net admin capability to set up vpn device and routing + setuid to connect to bus and monitor cgroups
+CapabilityBoundingSet=CAP_NET_ADMIN CAP_SETUID
+
 [Install]
 WantedBy=multi-user.target

--- a/linux/mozillavpn.spec
+++ b/linux/mozillavpn.spec
@@ -19,6 +19,7 @@ BuildRequires: cargo
 BuildRequires: golang >= 1.18
 BuildRequires: libsecret-devel
 BuildRequires: openssl-devel
+BuildRequires: polkit-devel
 BuildRequires: python3-yaml
 BuildRequires: qt6-qtbase-devel >= 6.0
 BuildRequires: qt6-qtnetworkauth-devel >= 6.0
@@ -67,3 +68,4 @@ install %{_srcdir}/LICENSE.md %{buildroot}/%{_licensedir}/%{name}/
 %{_datadir}/icons/hicolor/32x32/apps/mozillavpn.png
 %{_datadir}/icons/hicolor/48x48/apps/mozillavpn.png
 %{_datadir}/icons/hicolor/64x64/apps/mozillavpn.png
+%{_datadir}/polkit-1/actions/org.mozilla.vpn.policy

--- a/src/apps/vpn/cmake/linux.cmake
+++ b/src/apps/vpn/cmake/linux.cmake
@@ -6,8 +6,9 @@ find_package(Qt6 REQUIRED COMPONENTS DBus)
 target_link_libraries(mozillavpn PRIVATE Qt6::DBus)
 
 find_package(PkgConfig REQUIRED)
+pkg_check_modules(polkit REQUIRED IMPORTED_TARGET polkit-gobject-1)
 pkg_check_modules(libsecret REQUIRED IMPORTED_TARGET libsecret-1)
-target_link_libraries(mozillavpn PRIVATE PkgConfig::libsecret)
+target_link_libraries(mozillavpn PRIVATE PkgConfig::polkit PkgConfig::libsecret)
 
 # Linux platform source files
 target_sources(mozillavpn PRIVATE
@@ -55,6 +56,8 @@ target_sources(mozillavpn PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/apps/vpn/platforms/linux/daemon/linuxdaemon.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/apps/vpn/platforms/linux/daemon/pidtracker.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/apps/vpn/platforms/linux/daemon/pidtracker.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/apps/vpn/platforms/linux/daemon/polkithelper.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/apps/vpn/platforms/linux/daemon/polkithelper.h
     ${CMAKE_CURRENT_SOURCE_DIR}/apps/vpn/platforms/linux/daemon/wireguardutilslinux.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/apps/vpn/platforms/linux/daemon/wireguardutilslinux.h
 )
@@ -103,6 +106,10 @@ install(FILES ../linux/extra/icons/64x64/mozillavpn.png
 
 install(FILES ../linux/extra/icons/128x128/mozillavpn.png
     DESTINATION ${CMAKE_INSTALL_DATADIR}/icons/hicolor/128x128/apps)
+
+pkg_get_variable(POLKIT_POLICY_DIR polkit-gobject-1 policydir)
+install(FILES apps/vpn/platforms/linux/daemon/org.mozilla.vpn.policy
+    DESTINATION ${POLKIT_POLICY_DIR})
 
 install(FILES apps/vpn/platforms/linux/daemon/org.mozilla.vpn.conf
     DESTINATION /usr/share/dbus-1/system.d)

--- a/src/apps/vpn/platforms/linux/daemon/dbusservice.cpp
+++ b/src/apps/vpn/platforms/linux/daemon/dbusservice.cpp
@@ -15,6 +15,7 @@
 #include "leakdetector.h"
 #include "logger.h"
 #include "loghandler.h"
+#include "polkithelper.h"
 
 namespace {
 Logger logger("DBusService");
@@ -98,6 +99,12 @@ QString DBusService::version() {
 
 bool DBusService::activate(const QString& jsonConfig) {
   logger.debug() << "Activate";
+
+  if (!PolkitHelper::instance()->checkAuthorization(
+          "org.mozilla.vpn.activate")) {
+    logger.error() << "Polkit rejected";
+    return false;
+  }
 
   QJsonDocument json = QJsonDocument::fromJson(jsonConfig.toLocal8Bit());
   if (!json.isObject()) {

--- a/src/apps/vpn/platforms/linux/daemon/dbusservice.h
+++ b/src/apps/vpn/platforms/linux/daemon/dbusservice.h
@@ -5,6 +5,8 @@
 #ifndef DBUSSERVICE_H
 #define DBUSSERVICE_H
 
+#include <QDBusContext>
+
 #include "apptracker.h"
 #include "daemon/daemon.h"
 #include "dnsutilslinux.h"
@@ -14,7 +16,7 @@
 
 class DbusAdaptor;
 
-class DBusService final : public Daemon {
+class DBusService final : public Daemon, protected QDBusContext {
   Q_OBJECT
   Q_DISABLE_COPY_MOVE(DBusService)
   Q_CLASSINFO("D-Bus Interface", "org.mozilla.vpn.dbus")
@@ -51,6 +53,7 @@ class DBusService final : public Daemon {
 
  private:
   bool removeInterfaceIfExists();
+  unsigned requesterPid();
 
  private slots:
   void appLaunched(const QString& cgroup, const QString& appId, int rootpid);

--- a/src/apps/vpn/platforms/linux/daemon/org.mozilla.vpn.dbus.service.in
+++ b/src/apps/vpn/platforms/linux/daemon/org.mozilla.vpn.dbus.service.in
@@ -1,5 +1,6 @@
 [D-BUS Service]
 User=root
 Name=org.mozilla.vpn.dbus
-Exec=@CMAKE_INSTALL_FULL_BINDIR@/mozillavpn linuxdaemon
+# Start systemd service don’t exec
+Exec=/usr/bin/false
 SystemdService=mozillavpn.service

--- a/src/apps/vpn/platforms/linux/daemon/org.mozilla.vpn.policy
+++ b/src/apps/vpn/platforms/linux/daemon/org.mozilla.vpn.policy
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE policyconfig PUBLIC
+ "-//freedesktop//DTD PolicyKit Policy Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/PolicyKit/1.0/policyconfig.dtd">
+<policyconfig>
+
+  <action id="org.mozilla.vpn.activate">
+    <description>Activate the Mozilla VPN</description>
+    <message>Activate the Mozilla VPN</message>
+    <defaults>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>auth_admin</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.mozilla.vpn.deactivate">
+    <description>Deactivate the Mozilla VPN</description>
+    <message>Deactivate the Mozilla VPN</message>
+    <defaults>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>auth_admin</allow_active>
+    </defaults>
+  </action>
+</policyconfig>
+

--- a/src/apps/vpn/platforms/linux/daemon/org.mozilla.vpn.policy
+++ b/src/apps/vpn/platforms/linux/daemon/org.mozilla.vpn.policy
@@ -9,8 +9,9 @@
     <message>Activate the Mozilla VPN</message>
     <defaults>
       <allow_inactive>no</allow_inactive>
-      <allow_active>auth_admin</allow_active>
+      <allow_active>auth_admin_keep</allow_active>
     </defaults>
+    <annotate key="org.freedesktop.policykit.imply">org.mozilla.vpn.firewallApp org.mozilla.vpn.firewallPid org.mozilla.vpn.firewallClear</annotate>
   </action>
 
   <action id="org.mozilla.vpn.deactivate">
@@ -18,8 +19,39 @@
     <message>Deactivate the Mozilla VPN</message>
     <defaults>
       <allow_inactive>no</allow_inactive>
-      <allow_active>auth_admin</allow_active>
+      <allow_active>auth_admin_keep</allow_active>
     </defaults>
+    <annotate key="org.freedesktop.policykit.imply">org.mozilla.vpn.firewallApp org.mozilla.vpn.firewallPid org.mozilla.vpn.firewallClear</annotate>
+  </action>
+
+  <action id="org.mozilla.vpn.firewallApp">
+    <description>Add/remove an app from the VPN exclude list</description>
+    <message>Add/remove an app from the VPN exclude list</message>
+    <defaults>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>auth_admin_keep</allow_active>
+    </defaults>
+    <annotate key="org.freedesktop.policykit.imply">org.mozilla.vpn.firewallPid org.mozilla.vpn.firewallClear</annotate>
+  </action>
+
+  <action id="org.mozilla.vpn.firewallPid">
+    <description>Add/remove a PID from the VPN exclude list</description>
+    <message>Add/remove a PID from the VPN exclude list</message>
+    <defaults>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>auth_admin_keep</allow_active>
+    </defaults>
+    <annotate key="org.freedesktop.policykit.imply">org.mozilla.vpn.firewallApp org.mozilla.vpn.firewallClear</annotate>
+  </action>
+
+  <action id="org.mozilla.vpn.firewallClear">
+    <description>Clear the VPN exclude list</description>
+    <message>Clear the VPN exclude list</message>
+    <defaults>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>auth_admin_keep</allow_active>
+    </defaults>
+    <annotate key="org.freedesktop.policykit.imply">org.mozilla.vpn.firewallApp org.mozilla.vpn.firewallPid</annotate>
   </action>
 </policyconfig>
 

--- a/src/apps/vpn/platforms/linux/daemon/polkithelper.cpp
+++ b/src/apps/vpn/platforms/linux/daemon/polkithelper.cpp
@@ -43,7 +43,8 @@ PolkitHelper* PolkitHelper::instance() {
   return &s_instance;
 }
 
-bool PolkitHelper::checkAuthorization(const QString& actionId) {
+bool PolkitHelper::checkAuthorization(const QString& actionId,
+                                      const uint32_t requesterPid) {
   logger.debug() << "Check Authorization for" << actionId;
 
   Helper h;
@@ -55,7 +56,7 @@ bool PolkitHelper::checkAuthorization(const QString& actionId) {
     return false;
   }
 
-  h.m_subject = polkit_unix_process_new_for_owner(getpid(), 0, -1);
+  h.m_subject = polkit_unix_process_new_for_owner(requesterPid, 0, -1);
 
   h.m_result = polkit_authority_check_authorization_sync(
       authority, h.m_subject, actionId.toLatin1().data(), nullptr,

--- a/src/apps/vpn/platforms/linux/daemon/polkithelper.cpp
+++ b/src/apps/vpn/platforms/linux/daemon/polkithelper.cpp
@@ -1,0 +1,70 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "polkithelper.h"
+
+#include "logger.h"
+
+// No extra QT includes after this line!
+#undef Q_SIGNALS
+#include "polkit/polkit.h"
+
+namespace {
+Logger logger("PolkitHelper");
+}  // namespace
+
+class Helper final {
+ public:
+  Helper() = default;
+  ~Helper() {
+    if (m_error) {
+      g_error_free(m_error);
+    }
+
+    if (m_subject) {
+      g_object_unref(m_subject);
+    }
+
+    if (m_result) {
+      g_object_unref(m_result);
+    }
+  }
+
+ public:
+  GError* m_error = nullptr;
+  PolkitSubject* m_subject = nullptr;
+  PolkitAuthorizationResult* m_result = nullptr;
+};
+
+// static
+PolkitHelper* PolkitHelper::instance() {
+  static PolkitHelper s_instance;
+  return &s_instance;
+}
+
+bool PolkitHelper::checkAuthorization(const QString& actionId) {
+  logger.debug() << "Check Authorization for" << actionId;
+
+  Helper h;
+
+  PolkitAuthority* authority = polkit_authority_get_sync(NULL, &h.m_error);
+  if (h.m_error) {
+    logger.debug() << "Fail to generate a polkit authority object:"
+                   << h.m_error->message;
+    return false;
+  }
+
+  h.m_subject = polkit_unix_process_new_for_owner(getpid(), 0, -1);
+
+  h.m_result = polkit_authority_check_authorization_sync(
+      authority, h.m_subject, actionId.toLatin1().data(), nullptr,
+      POLKIT_CHECK_AUTHORIZATION_FLAGS_ALLOW_USER_INTERACTION, nullptr,
+      &h.m_error);
+  if (h.m_error) {
+    logger.debug() << "Authorization sync failed:" << h.m_error->message;
+    return false;
+  }
+
+  return polkit_authorization_result_get_is_authorized(h.m_result);
+}

--- a/src/apps/vpn/platforms/linux/daemon/polkithelper.h
+++ b/src/apps/vpn/platforms/linux/daemon/polkithelper.h
@@ -11,7 +11,7 @@ class PolkitHelper final {
  public:
   static PolkitHelper* instance();
 
-  bool checkAuthorization(const QString& actionId);
+  bool checkAuthorization(const QString& actionId, unsigned requesterPid);
 
  private:
   PolkitHelper() = default;

--- a/src/apps/vpn/platforms/linux/daemon/polkithelper.h
+++ b/src/apps/vpn/platforms/linux/daemon/polkithelper.h
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef POLKITHELPER_H
+#define POLKITHELPER_H
+
+#include <QString>
+
+class PolkitHelper final {
+ public:
+  static PolkitHelper* instance();
+
+  bool checkAuthorization(const QString& actionId);
+
+ private:
+  PolkitHelper() = default;
+  ~PolkitHelper() = default;
+
+  Q_DISABLE_COPY(PolkitHelper)
+};
+
+#endif  // POLKITHELPER_H


### PR DESCRIPTION
## Description

- Check polkit authorization for all actions that affect tunnel setup and routing:
    - activate
    - deactivate
    - add app to excluded cgroups
    - add pid to excluded cgroups
    - clear excluded cgroups
- When checking authorization, check whether DBus message _sender_ is authorized, optionally using a password popup+
   - Done by inheriting [`QDbusContext`](https://doc.qt.io/qt-6/qdbuscontext.html) on the DBus service to access info about DBus message sender
- Limit capabilities of daemon process to minimum required (CAP_NET_ADMIN and CAP_SETUID)
- Remove binary path from service file that isn’t used to start the daemon (it only serves to point to the dbus service file)

When connecting and disconnecting the VPN we now get an authorization popup as expected. If we try to change firewalled apps on the fly while connected (only via dbus messages) authorization is also checked.

## Reference

Follow-up on #7055

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
