### PR TITLE
No ticket: Fix 'Warning: Texture 0x7f21e601ac70 () used with...' QML warning

### DIFF
--- a/nebula/ui/compat/qt6/MZColorOverlay.qml
+++ b/nebula/ui/compat/qt6/MZColorOverlay.qml
@@ -6,4 +6,7 @@ import QtQuick 2.0
 import Qt5Compat.GraphicalEffects
 
 ColorOverlay {
+  // See https://forum.qt.io/topic/127404/qt-6-replacement-for-coloroverlay
+  // Fixes "Warning: Texture 0x7f21e601ac70 () used with different accesses within the same pass, this is not allowed."
+  cached: true
 }


### PR DESCRIPTION
## Description

Cleans up a spammy QML warning I noticed while perusing the logs from VPN-4975 / #7152. Strangely, I don't see this warning on mac builds. 

`Warning: Texture 0x7f21e601ac70 () used with different accesses within the same pass, this is not allowed.`

<img width="1337" alt="Screen Shot 2023-06-13 at 5 18 27 PM" src="https://github.com/mozilla-mobile/mozilla-vpn-client/assets/22355127/0fa818b0-2a67-43be-a977-ecc5cd8fbbc7">


## Reference

No ticket. Opportunistic one-pointer. 

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
