### PR TITLE
QOL: Conda/iOS - Auto Qt setup

### DIFF
--- a/docs/dev-setup/ios.md
+++ b/docs/dev-setup/ios.md
@@ -11,21 +11,28 @@ Apple ID. If you are a Mozilla developer, this is an Apple ID associated with yo
 
 ## Activate conda
 
-    conda activate vpn
+```bash 
+$ conda env create -f env.yml -n vpn
+$ conda activate vpn
+```
 
 See [here](./index.md#conda) for conda environment instructions.
 
 Install extra conda packages
 
-    ./scripts/macos/conda_install_extras.sh
+```bash 
+$ conda activate vpn
+$ ./scripts/macos/conda_install_extras.sh
+```
+
 
 ## Get Qt
 
-Get a static build of Qt made built in our CI.
+```bash 
+$ conda activate vpn
+$ ./scripts/macos/conda_setup_qt.sh
+```
 
-https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/mozillavpn.v2.mozillavpn.cache.level-3.toolchains.v3.qt-ios.latest/artifacts/public%2Fbuild%2Fqt6_ios.zip
-
-Unzip the folder and remember the location for the configure step.
 
 # Build with Xcode
 
@@ -39,10 +46,9 @@ Make the build directory
 
     mkdir build-ios
 
-Configure, using the cmake in the downloaded Qt folder, and setting QT_HOST_PATH to point
-to macOS.
+Configure, using the qt-cmake
 
-    <Qt unzipped path>/6.2.4/ios/bin/qt-cmake -S . -B build-ios -GXcode -DQT_HOST_PATH=<Qt unzipped path>/6.2.4/macos
+   qt-cmake -S . -B build-ios 
 
 
 This will generate an Xcode project file at `build-ios/Mozilla VPN.xcodeproj` which can be opened

--- a/env.yml
+++ b/env.yml
@@ -26,5 +26,4 @@ dependencies:
     - -r requirements.txt
     - -r taskcluster/scripts/requirements.txt
 variables:
-  CXXFLAGS: -O3
   QT_VERSION: 6.2.4

--- a/scripts/cmake/golang.cmake
+++ b/scripts/cmake/golang.cmake
@@ -55,6 +55,7 @@ function(build_go_archive OUTPUT_NAME MODULE_FILE)
                     CGO_LDFLAGS="${GOBUILD_CGO_LDFLAGS}"
                     GOOS=${GOBUILD_GOOS}
                     GOARCH=${GOBUILD_GOARCH}
+                    GOROOT=$ENV{GOROOT}
                 ${GOLANG_BUILD_TOOL} build ${GOBUILD_ARGS} -o ${ABS_OUTPUT_NAME}
     )
 endfunction(build_go_archive)

--- a/scripts/macos/conda_setup_qt.sh
+++ b/scripts/macos/conda_setup_qt.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+BASE_PREFIX=$(conda info --base)
+if [[ "$CONDA_PREFIX" == "$BASE_PREFIX" ]]; then
+    echo "Please run this script inside a non-base conda environment."
+    exit 1
+fi
+
+if [[ "$(uname)" == "Darwin" ]]; then
+    HOST_TARGET="mac desktop ${QT_VERSION}"
+    HOST="mac"
+    HOST_FOLDER_NAME="macos"
+else
+    echo "Unsupported operating system. Please run this script on or macOS."
+    exit 1
+fi
+
+export QT_DIR=$CONDA_PREFIX/Qt
+# QT_Host Tools
+python -m aqt install-qt --outputdir $QT_DIR $HOST_TARGET
+# QT Android Tools
+python -m aqt install-qt --outputdir $QT_DIR $HOST ios ${QT_VERSION} -m all 
+
+echo "$QT_DIR/$QT_VERSION/$ANDROID_ARCH/bin/qt-cmake"
+
+## Generate activation/deactivation scripts, so stuff stays portable.
+
+# Set vars on activation of the env
+mkdir -p $CONDA_PREFIX/etc/conda/activate.d/
+mkdir -p $CONDA_PREFIX/etc/conda/deactivate.d/
+cat <<EOF > $CONDA_PREFIX/etc/conda/activate.d/vpn_ios_qt.sh
+#!/bin/bash
+export QT_HOST_PATH=\$CONDA_PREFIX/Qt/$QT_VERSION/$HOST_FOLDER_NAME
+EOF
+chmod +x $CONDA_PREFIX/etc/conda/activate.d/vpn_ios_qt.sh
+## Remove Vars on deactivation
+cat <<EOF > $CONDA_PREFIX/etc/conda/deactivate.d/vpn_ios_qt.sh
+#!/bin/bash
+unset QT_HOST_PATH
+EOF
+chmod +x $CONDA_PREFIX/etc/conda/deactivate.d/vpn_ios_qt.sh
+
+## Add a Helper script to call the right qt-cmake
+
+cat <<EOF > $CONDA_PREFIX/bin/qt-cmake
+#!/bin/bash
+$CONDA_PREFIX/Qt/$QT_VERSION/ios/bin/qt-cmake -DQT_HOST_PATH=$QT_HOST_PATH -GXcode "\$@"
+EOF
+chmod +x $CONDA_PREFIX/etc/conda/deactivate.d/vpn_ios_qt.sh
+
+
+
+echo "finished setup $QT_VERSION QT to compile for MacOS + iOS "
+echo "please re-enable the VPN env to apply changes."
+
+

--- a/scripts/macos/conda_setup_qt.sh
+++ b/scripts/macos/conda_setup_qt.sh
@@ -24,15 +24,16 @@ python -m aqt install-qt --outputdir $QT_DIR $HOST ios ${QT_VERSION} -m all
 echo "$QT_DIR/$QT_VERSION/$ANDROID_ARCH/bin/qt-cmake"
 
 ## Generate activation/deactivation scripts, so stuff stays portable.
-
-# Set vars on activation of the env
 mkdir -p $CONDA_PREFIX/etc/conda/activate.d/
 mkdir -p $CONDA_PREFIX/etc/conda/deactivate.d/
+
+# Set vars on activation of the env
 cat <<EOF > $CONDA_PREFIX/etc/conda/activate.d/vpn_ios_qt.sh
 #!/bin/bash
 export QT_HOST_PATH=\$CONDA_PREFIX/Qt/$QT_VERSION/$HOST_FOLDER_NAME
 EOF
 chmod +x $CONDA_PREFIX/etc/conda/activate.d/vpn_ios_qt.sh
+
 ## Remove Vars on deactivation
 cat <<EOF > $CONDA_PREFIX/etc/conda/deactivate.d/vpn_ios_qt.sh
 #!/bin/bash
@@ -40,13 +41,13 @@ unset QT_HOST_PATH
 EOF
 chmod +x $CONDA_PREFIX/etc/conda/deactivate.d/vpn_ios_qt.sh
 
-## Add a Helper script to call the right qt-cmake
 
+## Add a Helper script to call the right qt-cmake
 cat <<EOF > $CONDA_PREFIX/bin/qt-cmake
 #!/bin/bash
 $CONDA_PREFIX/Qt/$QT_VERSION/ios/bin/qt-cmake -DQT_HOST_PATH=$QT_HOST_PATH -GXcode "\$@"
 EOF
-chmod +x $CONDA_PREFIX/etc/conda/deactivate.d/vpn_ios_qt.sh
+chmod +x $CONDA_PREFIX/bin/qt-cmake
 
 
 


### PR DESCRIPTION
On Windows + Android we have a `conda-setup-qt.sh` that will download and setup qt for the current env. 

Since i'm too lazy to remember where qt-lives for every platform i like to have that setuped. 

- This does download + install QT of the .env's qt-version. 
- Add's activation scripts to set `QT_HOST_PATH` -> (so we can conda-pack the env for xcode-cloud) 
- add's a `qt-cmake` helper wrapper script that calls `<Qt unzipped path>/6.2.4/ios/bin/qt-cmake -S . -B build-ios -GXcode -DQT_HOST_PATH=<Qt unzipped path>/6.2.4/macos`, so i don't need to care about that. 
