### PR TITLE
Fix QML errors (#7156)

### DIFF
--- a/nebula/ui/components/MZSettingsToggle.qml
+++ b/nebula/ui/components/MZSettingsToggle.qml
@@ -20,6 +20,10 @@ CheckBox {
     onClicked: toolTip.hide()
     onActiveFocusChanged: if(activeFocus) MZUiUtils.scrollToComponent(vpnSettingsToggle)
 
+    // Workaround for https://bugreports.qt.io/browse/QTBUG-101026
+    // Prevents 'TypeError: Property 'styleFont' of object MZUIStates_QMLTYPE_14(0x600002d582a0) is not a function' 
+    font.pixelSize: undefined
+
     height: MZTheme.theme.vSpacing
     width: 45
     states: [

--- a/nebula/ui/components/MZTabNavigation.qml
+++ b/nebula/ui/components/MZTabNavigation.qml
@@ -101,7 +101,7 @@ Item {
         height: 2
         color: MZTheme.colors.purple70
         anchors.bottom: bar.bottom
-        x: (currentTab.x && currentTab.ListView.view) ? currentTab.x - currentTab.ListView.view.originX : 0
+        x: (currentTab && currentTab.x && currentTab.ListView.view) ? currentTab.x - currentTab.ListView.view.originX : 0
         visible: stack.children.length > 1
         Behavior on x {
             PropertyAnimation {


### PR DESCRIPTION
* Fix 'TypeError: Cannot read property 'x' of null (MZTabNavigation.qml:105)'

* Fix 'TypeError: Property 'styleFont'...'

## Description

Cherry-picking #7156 to release branch

## Reference

    i.e Jira or Github issue URL

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
