### PR TITLE
VPN-5026: Fix reference error in ScreenInitialize.qml

### DIFF
--- a/src/apps/vpn/ui/screens/ScreenInitialize.qml
+++ b/src/apps/vpn/ui/screens/ScreenInitialize.qml
@@ -5,6 +5,8 @@
 import QtQuick 2.5
 import QtQuick.Controls 2.14
 
+
+import Mozilla.Shared 1.0
 import Mozilla.VPN 1.0
 import components 0.1
 
@@ -13,7 +15,7 @@ MZStackView {
     objectName: "initialStackView"
     anchors.fill: parent
 
-    Component.onCompleted: function() {
+    Component.onCompleted: {
         stackview.push("qrc:/ui/screens/initialize/ViewInitialize.qml")
         MZNavigator.addStackView(VPN.ScreenInitialize, stackview)
     }


### PR DESCRIPTION
## Description

Fixes `Warning: qrc:/ui/screens/ScreenInitialize.qml:18: ReferenceError: MZNavigator is not defined (ScreenInitialize.qml:18)`
- The client crashes on this error when running a debug build on my iPhone (14 Pro). 
- The client does not crash here when running the same build in an iPhone 14 Pro simulator. 

## Reference

VPN-5026

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
