### PR TITLE
VPN-4980: Fix build on Qt 6.4+

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,6 +123,10 @@ if(NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Emscripten" AND
     )
 endif()
 
+if(QT_KNOWN_POLICY_QTP0001)
+    qt_policy(SET QTP0001 NEW)
+endif()
+
 message("Using Qt version ${Qt6_VERSION}")
 add_definitions(-DQT_DEPRECATED_WARNINGS)
 add_definitions(-DQT_DISABLE_DEPRECATED_BEFORE=0x050F00)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,7 @@ if(APPLE)
     if(IOS)
         set(CMAKE_OSX_DEPLOYMENT_TARGET 13.0)
     else()
-        set(CMAKE_OSX_DEPLOYMENT_TARGET 10.14)
+        set(CMAKE_OSX_DEPLOYMENT_TARGET 10.15)
     endif()
 endif()
 

--- a/glean/CMakeLists.txt
+++ b/glean/CMakeLists.txt
@@ -72,7 +72,8 @@ set_source_files_properties(
 )
 
 # Statically link to the SQLite driver, if it exists.
-if(TARGET Qt6::QSQLiteDriverPlugin)
+if(QT_FEATURE_static AND TARGET Qt6::QSQLiteDriverPlugin)
+    message("Statically linking to SQLite plugin")
     target_link_libraries(glean PUBLIC Qt6::QSQLiteDriverPlugin)
     qt_import_plugins(glean INCLUDE Qt6::QSQLiteDriverPlugin)
 endif()


### PR DESCRIPTION
## Description
At present, the VPN client fails to build on Qt 6.4 and beyond. This seems to be due to a few issues:
 - Plugins are now compiled as frameworks.
 - Qt 6.5 now has policies, and generates warnings if left unset.
 - Qt 6.5 requires a MacOS deployment target of 10.15 or later.

## Reference
Github issue: #7155 ([VPN-4980](https://mozilla-hub.atlassian.net/browse/VPN-4980))

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed


[VPN-4980]: https://mozilla-hub.atlassian.net/browse/VPN-4980?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ