### PR TITLE
VPN-5019 - Downgrade com.android.billingclient:billing-ktx to 5.2.0

### DIFF
--- a/android/vpnClient/build.gradle
+++ b/android/vpnClient/build.gradle
@@ -73,7 +73,7 @@ dependencies {
 
     implementation SharedDependencies.androidx_core
     implementation "com.android.installreferrer:installreferrer:2.2"
-    implementation "com.android.billingclient:billing-ktx:6.0.0"
+    implementation "com.android.billingclient:billing-ktx:5.2.0"
     implementation "com.google.android.gms:play-services-ads-identifier:17.0.1"
     implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.5.1"
 


### PR DESCRIPTION
This was causing the crash described on VPN-5019. I don't really understand why this issue. We are using a version of desugar_jdk_libs that contains the aledgedly missing API.

I tried to add the desugar_jdk_libs with the right version as dependecy to the vpnClient project, but then I get the error "Execution failed for DexingNoClasspathTransform".

We may want to file a ticket to upgrad this back, but I guess unblocking QA ASAP is more important for now.