### PR TITLE
VPN-4881: Fix 2.16 update message for old windows clients

### DIFF
--- a/addons/message_update_v2.16/enable.js
+++ b/addons/message_update_v2.16/enable.js
@@ -46,8 +46,8 @@
   api.addon.composer.remove('c_3');
 
   api.addon.setTitle(
-    'message.message_update_v2.15.block.extra_1', 'Download Mozilla VPN 2.15')
+    'message.message_update_v2.16.block.extra_1', 'Download Mozilla VPN 2.16')
   api.addon.setSubtitle(
-    'message.message_update_v2.15.block.extra_2',
-    'We’ve released an updated version of Mozilla VPN! Download it today to get the newest features and bug fixes:');
+    'message.message_update_v2.16.block.extra_2',
+    'We’ve released an updated version of Mozilla VPN! Download it today to get the newest features and bug fixes.');
 })

--- a/addons/message_update_v2.16/manifest.json
+++ b/addons/message_update_v2.16/manifest.json
@@ -48,14 +48,14 @@
         "javascript": "getHelp.js"
       },
       {
-        "id": "extra_1",
+        "id": "extra_1_216",
         "type": "text",
         "content": "Download Mozilla VPN 2.16"
       },
       {
-        "id": "extra_2",
+        "id": "extra_2_216",
         "type": "text",
-        "content": "We’ve released an updated version of Mozilla VPN! Download it today to get the newest features and bug fixes:"
+        "content": "We’ve released an updated version of Mozilla VPN! Download it today to get the newest features and bug fixes."
       }
     ]
   }


### PR DESCRIPTION
## Description

- Update strings for 2.16 update message for Windows clients on 2.10-2.12 who need to upgrade via web

## Reference

[VPN-4881: Implement 'What's New' and 'Update' message for 2.16](https://mozilla-hub.atlassian.net/browse/VPN-4881)
