### PR TITLE
fix iOS crash on fresh install

### DIFF
--- a/src/shared/platforms/ios/iosgleanbridge.swift
+++ b/src/shared/platforms/ios/iosgleanbridge.swift
@@ -29,7 +29,7 @@ public class IOSGleanBridgeImpl : NSObject {
       
       do {
             Logger.global?.log(message: "Sending telemetry state change message.");
-          try TunnelManager.session!.sendProviderMessage(
+          try TunnelManager.session?.sendProviderMessage(
               TunnelMessage.telemetryEnabledChanged(isTelemetryEnabled).encode()
           ) { _ in
               Logger.global?.log(message: "Telemetry state change message sent.")


### PR DESCRIPTION
## Description

On a fresh install (so no VPN profile already installed), I got a crash b/c we're force unwrapping this object after the user clicks the button in the onboarding "collect data?" screen, but this object doesn't exist yet. This fixes the crash.

This bug got uplifted to the 2.16 release branch, so this fix will also have to.

## Reference

N/A

## Checklist
    
- [X] My code follows the style guidelines for this project
- [X] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [X] I have performed a self review of my own code
- [X] I have commented my code PARTICULARLY in hard to understand areas
- [X] I have added thorough tests where needed
