### PR TITLE
VPN-4881: Fix 2.16 update/download message

### DIFF
--- a/addons/message_update_v2.16/enable.js
+++ b/addons/message_update_v2.16/enable.js
@@ -1,7 +1,6 @@
 (function (api) {
   // Extra_1 and extra_2 are used only to have a localized string.
-  api.addon.composer.remove('extra_1');
-  api.addon.composer.remove('extra_2');
+  api.addon.composer.remove('extra_1_216');
 
   if (('updateTime' in api.settings)) {
     api.addon.date = (api.settings.updateTime.getTime() / 1000);
@@ -11,7 +10,6 @@
   // with the exception on v2.11.1.
   if (api.env.platform !== 'windows' || api.env.versionString === '2.11.1') {
     api.addon.composer.remove('c_4');
-    api.addon.composer.remove('c_2b');
     return;
   }
 
@@ -20,7 +18,6 @@
   // No idea which version we are in...
   if (parts.length < 3) {
     api.addon.composer.remove('c_4');
-    api.addon.composer.remove('c_2b');
     return;
   }
 
@@ -38,16 +35,11 @@
   if (versionCompare([2, 13, 0], version) >= 0 ||
     versionCompare([2, 10, 0], version) < -1) {
     api.addon.composer.remove('c_4');
-    api.addon.composer.remove('c_2b');
     return;
   }
 
-  api.addon.composer.remove('c_2');
   api.addon.composer.remove('c_3');
 
   api.addon.setTitle(
-    'message.message_update_v2.16.block.extra_1', 'Download Mozilla VPN 2.16')
-  api.addon.setSubtitle(
-    'message.message_update_v2.16.block.extra_2',
-    'We’ve released an updated version of Mozilla VPN! Download it today to get the newest features and bug fixes.');
+    'message.message_update_v2.16.block.extra_1_216', 'Download the new Mozilla VPN')
 })

--- a/addons/message_update_v2.16/manifest.json
+++ b/addons/message_update_v2.16/manifest.json
@@ -22,11 +22,6 @@
         "content": "Be sure to update the app to make it even easier to protect your devices and your activity online!"
       },
       {
-        "id": "c_2b",
-        "type": "text",
-        "content": "Be sure to get the latest version to make it even easier to protect your devices and your activity online!"
-      },
-      {
         "id": "c_3",
         "type": "button",
         "style": "primary",
@@ -50,12 +45,7 @@
       {
         "id": "extra_1_216",
         "type": "text",
-        "content": "Download Mozilla VPN 2.16"
-      },
-      {
-        "id": "extra_2_216",
-        "type": "text",
-        "content": "We’ve released an updated version of Mozilla VPN! Download it today to get the newest features and bug fixes."
+        "content": "Download the new Mozilla VPN"
       }
     ]
   }


### PR DESCRIPTION
## Description

- Remove unnecessary blocks from the 2.16 update / download message when showing for Windows 2.10, Windows 2.11, and Windows 2.12 (see [here](https://mozilla-hub.atlassian.net/browse/VPN-4034) for more info on why this is an issue)

## Reference

[VPN-4881: Implement 'What's New' and 'Update' message for 2.16](https://mozilla-hub.atlassian.net/browse/VPN-4881)
