### PR TITLE
Bug 1774273 - Part (2/2) - Use notarization task in graph (#7063)

### DIFF
--- a/taskcluster/ci/beetmover/kind.yml
+++ b/taskcluster/ci/beetmover/kind.yml
@@ -6,6 +6,7 @@ loader: taskgraph.loader.transform:loader
 
 transforms:
     - mozillavpn_taskgraph.transforms.requires_level:transforms
+    - mozillavpn_taskgraph.transforms.beetmover_mac_upstream:transforms
     - mozillavpn_taskgraph.transforms.release_artifacts:transforms
     - mozillavpn_taskgraph.transforms.beetmover:transforms
     - taskgraph.transforms.task:transforms
@@ -13,11 +14,12 @@ transforms:
 kind-dependencies:
     - build
     - signing
+    - mac-notarization
     - repackage-signing
 
 tasks:
     android-arm64:
-        requires-level: 3 
+        requires-level: 3
         worker-type: beetmover
         worker:
             chain-of-trust: true
@@ -35,7 +37,7 @@ tasks:
             tier: 1
             platform: android/arm64-v8a
     android-armv7:
-        requires-level: 3 
+        requires-level: 3
         worker-type: beetmover
         worker:
             chain-of-trust: true
@@ -53,7 +55,7 @@ tasks:
             tier: 1
             platform: android/armv7
     android-x86:
-        requires-level: 3 
+        requires-level: 3
         worker-type: beetmover
         worker:
             chain-of-trust: true
@@ -71,7 +73,7 @@ tasks:
             tier: 1
             platform: android/x86
     android-x64:
-        requires-level: 3 
+        requires-level: 3
         worker-type: beetmover
         worker:
             chain-of-trust: true
@@ -89,7 +91,7 @@ tasks:
             tier: 1
             platform: android/x64
     macos:
-        requires-level: 3 
+        requires-level: 3
         worker-type: beetmover
         worker:
             chain-of-trust: true
@@ -98,6 +100,7 @@ tasks:
         release-artifacts: [MozillaVPN.pkg]
         dependencies:
             signing: signing-macos/opt
+            mac-notarization: mac-notarization-macos/opt
         if-dependencies: [signing]
         attributes:
             build-type: macos/opt

--- a/taskcluster/mozillavpn_taskgraph/transforms/beetmover_mac_upstream.py
+++ b/taskcluster/mozillavpn_taskgraph/transforms/beetmover_mac_upstream.py
@@ -1,0 +1,26 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+import os.path
+
+from taskgraph.transforms.base import TransformSequence
+
+transforms = TransformSequence()
+
+
+@transforms.add
+def resolve_upstream_mac_task(config, tasks):
+    for task in tasks:
+        if "mac-notarization" not in task["dependencies"]:
+            yield task
+            continue
+
+        # Remove upstream signing if notarization is available
+        if "mac-notarization-macos/opt" in config.kind_dependencies_tasks:
+            del task["dependencies"]["signing"]
+        # Otherwise, remove notarization
+        else:
+            del task["dependencies"]["mac-notarization"]
+        yield task

--- a/taskcluster/mozillavpn_taskgraph/transforms/signing.py
+++ b/taskcluster/mozillavpn_taskgraph/transforms/signing.py
@@ -103,7 +103,7 @@ def set_mac_behavior(config, tasks):
             yield task
             continue
 
-        task["worker"]["mac-behavior"] = "mac_notarize_vpn"
+        task["worker"]["mac-behavior"] = "mac_sign_and_pkg_vpn"
         task["worker"]["entitlementsUrl"] = script_url(
             config.params, "taskcluster/scripts/signing/entitlements.xml"
         )

--- a/taskcluster/mozillavpn_taskgraph/worker_types.py
+++ b/taskcluster/mozillavpn_taskgraph/worker_types.py
@@ -30,7 +30,7 @@ from voluptuous import Any, Optional, Required
         ],
         # behavior for mac iscript
         Optional("mac-behavior"): Any(
-            "mac_notarize_vpn",
+            "mac_sign_and_pkg_vpn",
         ),
         Optional("entitlementsUrl"): str,
         Optional("loginItemsEntitlementsUrl"): str,


### PR DESCRIPTION
Switches singing task behavior to only sign
Beetmover now uses notarization task as upstream dependency if possible

## Description
Cherry-picks #7063 to release branch


## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
