### PR TITLE
Disable sign in button if input is empty

### DIFF
--- a/src/apps/vpn/ui/authenticationInApp/ViewAuthenticationSignIn.qml
+++ b/src/apps/vpn/ui/authenticationInApp/ViewAuthenticationSignIn.qml
@@ -59,7 +59,7 @@ MZInAppAuthenticationBase {
         objectName: "authSignIn"
         id: authInputs
 
-        _buttonEnabled: MZAuthInApp.state === MZAuthInApp.StateSignIn && !activeInput().hasError
+        _buttonEnabled: MZAuthInApp.state === MZAuthInApp.StateSignIn && !activeInput().hasError && activeInput().text.length > 0
         _buttonOnClicked: (inputText) => {
              MZAuthInApp.setPassword(inputText);
              MZAuthInApp.signIn();

--- a/tests/functional/testAuthenticationInApp.js
+++ b/tests/functional/testAuthenticationInApp.js
@@ -575,6 +575,30 @@ describe('User authentication', function() {
       await vpn.waitForQuery(queries.screenAuthenticationInApp
                                  .AUTH_SIGNIN_PASSWORD_INPUT.visible());
 
+      // Sign in button is diabled when view loads
+      await vpn.waitForQuery(
+          queries.screenAuthenticationInApp.AUTH_SIGNIN_BUTTON.visible()
+              .disabled());
+
+      // Sign in button is enabled when the password input has a text.length
+      // of at least 1 character
+      await vpn.setQueryProperty(
+          queries.screenAuthenticationInApp.AUTH_SIGNIN_PASSWORD_INPUT
+              .visible(),
+          'text', '1');
+      await vpn.waitForQuery(
+          queries.screenAuthenticationInApp.AUTH_SIGNIN_BUTTON.visible()
+              .enabled());
+
+      // Sign in button is disabled again if when the input is empty
+      await vpn.setQueryProperty(
+          queries.screenAuthenticationInApp.AUTH_SIGNIN_PASSWORD_INPUT
+              .visible(),
+          'text', '');
+      await vpn.waitForQuery(
+          queries.screenAuthenticationInApp.AUTH_SIGNIN_BUTTON.visible()
+              .disabled());
+
       await vpn.copyToClipboard('pa$$vv0rd');
       await vpn.waitForQueryAndClick(
           queries.screenAuthenticationInApp.AUTH_SIGNIN_PASSWORD_PASTE_BUTTON


### PR DESCRIPTION
## Description

This PR:
- Disables the 'Sign in' button when the password input has a text.length of 0. 
- Updates the functional test for this view

Note: The password length requirement to create an account in the client is 8 BUT I _think_, and will confirm, that it has historically possible to create an account with a password that is fewer than 8 characters. I'm therefore hesitant to stipulate that the 'Sign in' button stay disabled until the password input text.length === 8. 


## Reference


## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
