### PR TITLE
Add a section to download VS for Windows dev setup

### DIFF
--- a/docs/dev-setup/windows.md
+++ b/docs/dev-setup/windows.md
@@ -8,6 +8,13 @@ https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/mozillavpn.v2.mozil
 
 Unzip the folder and remember the location for the configure step.
 
+## Get Visual Studio 2017 or Later
+
+Please ensure that Visual Studio 2017 or later, or Build Tools for Visual Studio were installed with the Visual C++ option.
+You may need to restart your machine after installing Visual Studio for changes to take effect.
+
+[Download Visual Studio Here](https://visualstudio.microsoft.com/downloads/)
+
 ## Conda
 
 Have [miniconda installed](https://repo.anaconda.com/miniconda/Miniconda3-py310_23.1.0-1-Windows-x86_64.exe).


### PR DESCRIPTION
## Description

Added a section to mention we need to download VS 2017 or later to get this to work. I didn't realize this was missing from the steps until I completely wiped my machine back to factory settings and noticed this was required.

## Reference

    i.e Jira or Github issue URL

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
