### PR TITLE
VPN-4913: Fix various UI issues with Qt 6.4

### DIFF
--- a/nebula/ui/components/MZCheckBoxRow.qml
+++ b/nebula/ui/components/MZCheckBoxRow.qml
@@ -61,7 +61,6 @@ RowLayout {
             id: subLabel
 
             Layout.fillWidth: true
-            Layout.preferredWidth: parent.width
             text: subLabelText
             visible: !!subLabelText.length
             wrapMode: Text.WordWrap

--- a/nebula/ui/components/MZHeadline.qml
+++ b/nebula/ui/components/MZHeadline.qml
@@ -12,7 +12,6 @@ Text {
     horizontalAlignment: Text.AlignHCenter
     verticalAlignment: Text.AlignVCenter
     wrapMode: Text.WordWrap
-    width: MZTheme.theme.maxTextWidth
     color: MZTheme.theme.fontColorDark
     font.family: MZTheme.theme.fontFamily
     font.pixelSize: 22

--- a/nebula/ui/components/MZSubtitle.qml
+++ b/nebula/ui/components/MZSubtitle.qml
@@ -12,7 +12,6 @@ Text {
     font.pixelSize: MZTheme.theme.fontSize
     font.family: MZTheme.theme.fontInterFamily
     wrapMode: Text.Wrap
-    width: MZTheme.theme.maxTextWidth
     color: MZTheme.theme.fontColor
     lineHeightMode: Text.FixedHeight
     lineHeight: MZTheme.theme.labelLineHeight

--- a/nebula/ui/components/MZTextBlock.qml
+++ b/nebula/ui/components/MZTextBlock.qml
@@ -14,7 +14,6 @@ Text {
     font.pixelSize: MZTheme.theme.fontSizeSmall
     lineHeightMode: Text.FixedHeight
     lineHeight: 21
-    width: MZTheme.theme.maxTextWidth
     wrapMode: Text.Wrap
     Layout.alignment: Qt.AlignLeft
     horizontalAlignment: Qt.AlignLeft

--- a/nebula/ui/components/inAppAuth/MZInAppAuthenticationBase.qml
+++ b/nebula/ui/components/inAppAuth/MZInAppAuthenticationBase.qml
@@ -109,13 +109,14 @@ MZFlickable {
 
             ColumnLayout {
                 Layout.topMargin: MZTheme.theme.windowMargin / 2
+                Layout.preferredWidth: parent.width
+
                 spacing: MZTheme.theme.windowMargin / 2
 
                 MZHeadline {
                     id: headline
                     width: undefined
-                    Layout.maximumWidth: col.width - MZTheme.theme.vSpacing * 2
-                    Layout.minimumWidth: col.width - MZTheme.theme.vSpacing * 2
+                    Layout.fillWidth: true
                     Component.onCompleted: {
                         if (
                                 MZAuthInApp.state === MZAuthInApp.StateSignIn ||
@@ -129,18 +130,20 @@ MZFlickable {
                     }
                 }
 
-                MZLinkButton {
+                Loader {
                     Layout.alignment: Qt.AlignHCenter
-                    labelText: MZI18n.InAppAuthChangeEmailLink
-                    visible: _changeEmailLinkVisible
-                    onClicked: MZAuthInApp.reset()
+                    active: _changeEmailLinkVisible
+                    sourceComponent: MZLinkButton {
+                        labelText: MZI18n.InAppAuthChangeEmailLink
+                        visible: _changeEmailLinkVisible
+                        onClicked: MZAuthInApp.reset()
+                    }
                 }
 
                 MZSubtitle {
                     id: subtitle
-                    horizontalAlignment: Text.AlignHCenter
-                    Layout.maximumWidth: col.width - MZTheme.theme.vSpacing * 2
-                    Layout.minimumWidth: col.width - MZTheme.theme.vSpacing * 2
+                    width: undefined
+                    Layout.fillWidth: true
                 }
 
             }
@@ -151,7 +154,7 @@ MZFlickable {
 
             ColumnLayout {
                 id: inputs
-                Layout.maximumWidth: col.width - MZTheme.theme.vSpacing * 2
+                Layout.preferredWidth: parent.width
             }
         }
 

--- a/nebula/ui/components/inAppAuth/MZInAppAuthenticationInputs.qml
+++ b/nebula/ui/components/inAppAuth/MZInAppAuthenticationInputs.qml
@@ -32,6 +32,7 @@ ColumnLayout {
     Component.onCompleted: if (typeof(authError) === "undefined" || !authError.visible) activeInput().forceActiveFocus();
 
     spacing: MZTheme.theme.vSpacing - MZTheme.theme.listSpacing
+    Layout.preferredWidth: parent.width
 
     ColumnLayout {
         function submitInfo(input) {
@@ -45,15 +46,16 @@ ColumnLayout {
         id: col
 
         spacing: MZTheme.theme.listSpacing
+        Layout.preferredWidth: parent.width
 
-        RowLayout {
-            Layout.fillWidth: true
+        Row {
             spacing: MZTheme.theme.windowMargin / 2
 
             MZTextField {
                 id: textInput
                 objectName: base.objectName + "-textInput"
-                Layout.fillWidth: true
+                width: base.width - (inputPasteButton.visible ? inputPasteButton.width - parent.spacing : 0)
+                height: MZTheme.theme.rowHeight
                 _placeholderText: _inputPlaceholderText
                 Keys.onReturnPressed: col.submitInfo(textInput)
                 onTextChanged: if (hasError) hasError = false
@@ -64,17 +66,16 @@ ColumnLayout {
                 objectName: base.objectName + "-passwordInput"
                 _placeholderText: _inputPlaceholderText
                 Keys.onReturnPressed: col.submitInfo(passwordInput)
-                Layout.fillWidth: true
+                width: base.width - inputPasteButton.width - parent.spacing
+                height: MZTheme.theme.rowHeight
                 onTextChanged: if (hasError) hasError = false
             }
 
             MZPasteButton {
                 id: inputPasteButton
                 objectName: base.objectName + "-inputPasteButton"
-                Layout.preferredWidth: MZTheme.theme.rowHeight
-                Layout.preferredHeight: MZTheme.theme.rowHeight
-                height: undefined
-                width: undefined
+                width: MZTheme.theme.rowHeight
+                height: MZTheme.theme.rowHeight
                 onClicked: {
                    activeInput().paste();
                    activeInput().forceActiveFocus();

--- a/nebula/ui/components/navigationBar/MZBottomNavigationBar.qml
+++ b/nebula/ui/components/navigationBar/MZBottomNavigationBar.qml
@@ -32,7 +32,7 @@ Rectangle {
         verticalOffset: 2
         opacity: 0.6
         spread: 0
-        radius: parent.radius
+        radius: 6
         color: MZTheme.colors.grey60
         cached: true
     }

--- a/src/apps/vpn/ui/authenticationInApp/ViewAuthenticationSignUp.qml
+++ b/src/apps/vpn/ui/authenticationInApp/ViewAuthenticationSignUp.qml
@@ -43,7 +43,10 @@ MZInAppAuthenticationBase {
         _inputPlaceholderText: MZI18n.InAppAuthPasswordInputPlaceholder
     }
 
-    _disclaimers: MZInAppAuthenticationLegalDisclaimer {}
+    _disclaimers: Column {
+        Layout.alignment: Qt.AlignHCenter
+        MZInAppAuthenticationLegalDisclaimer {}
+    }
 
     _footerContent: Column {
         Layout.alignment: Qt.AlignHCenter

--- a/src/apps/vpn/ui/screens/ScreenPostAuthentication.qml
+++ b/src/apps/vpn/ui/screens/ScreenPostAuthentication.qml
@@ -26,6 +26,8 @@ Item {
 
         text: MZI18n.PostAuthenticationSubtitle
         anchors.top: headline.bottom
+        anchors.left: parent.left
+        anchors.right: parent.right
         anchors.topMargin: 12
         anchors.horizontalCenter: parent.horizontalCenter
     }

--- a/src/apps/vpn/ui/screens/getHelp/contactUs/ViewContactUsForm.qml
+++ b/src/apps/vpn/ui/screens/getHelp/contactUs/ViewContactUsForm.qml
@@ -18,6 +18,7 @@ MZViewBase {
     _menuTitle: MZI18n.InAppSupportWorkflowSupportNavLinkText
    _viewContentData: ColumnLayout {
        property string _emailAddress: ""
+       Layout.preferredWidth: parent.width
 
        id: contactUsRoot
 

--- a/src/apps/vpn/ui/screens/getHelp/developerMenu/ViewDeveloperMenu.qml
+++ b/src/apps/vpn/ui/screens/getHelp/developerMenu/ViewDeveloperMenu.qml
@@ -15,7 +15,7 @@ MZViewBase {
     _menuTitle: MZI18n.SettingsDevTitle
     _viewContentData: ColumnLayout {
         id: root
-        Layout.fillWidth: true
+        Layout.preferredWidth: parent.width
 
         spacing: MZTheme.theme.windowMargin
 

--- a/src/apps/vpn/ui/screens/messaging/ViewMessage.qml
+++ b/src/apps/vpn/ui/screens/messaging/ViewMessage.qml
@@ -84,7 +84,7 @@ MZViewBase {
             spacing: 20
 
             Loader {
-                Layout.preferredWidth: item.width
+                Layout.preferredWidth: item.implicitWidth
                 active: message.badge !== MZAddonMessage.None
                 sourceComponent: MZBadge {
 

--- a/src/apps/vpn/ui/screens/settings/ViewAboutUs.qml
+++ b/src/apps/vpn/ui/screens/settings/ViewAboutUs.qml
@@ -20,7 +20,7 @@ MZViewBase {
 
     _viewContentData: ColumnLayout {
         spacing: MZTheme.theme.windowMargin
-        Layout.fillWidth: true
+        Layout.preferredWidth: parent.width
         objectName: "aboutUsList"
 
         ColumnLayout {

--- a/src/apps/vpn/ui/screens/settings/ViewLanguage.qml
+++ b/src/apps/vpn/ui/screens/settings/ViewLanguage.qml
@@ -40,7 +40,7 @@ MZViewBase {
         id: col
         objectName: "languageList"
 
-        Layout.fillWidth: true
+        Layout.preferredWidth: parent.width
 
         spacing: MZTheme.theme.vSpacing
 

--- a/src/apps/vpn/ui/screens/settings/ViewPrivacy.qml
+++ b/src/apps/vpn/ui/screens/settings/ViewPrivacy.qml
@@ -20,6 +20,7 @@ MZViewBase {
 
     _viewContentData: ColumnLayout {
         spacing: MZTheme.theme.windowMargin * 1.5
+        Layout.preferredWidth: parent.width
 
         MZInformationCard {
             objectName: "privacySettingsViewInformationCard"

--- a/src/apps/vpn/ui/screens/settings/ViewSubscriptionManagement/SubscriptionManagementItem.qml
+++ b/src/apps/vpn/ui/screens/settings/ViewSubscriptionManagement/SubscriptionManagementItem.qml
@@ -21,19 +21,11 @@ ColumnLayout {
             when: type === "text"
 
             PropertyChanges {
-                target: rowLabel
-                visible: true
-            }
-            PropertyChanges {
                 target: rowText
                 visible: true
             }
             PropertyChanges {
                 target: rowPill
-                visible: false
-            }
-            PropertyChanges {
-                target: paymentMethod
                 visible: false
             }
             PropertyChanges {
@@ -45,19 +37,11 @@ ColumnLayout {
             when: type === "text-upgrade"
 
             PropertyChanges {
-                target: rowLabel
-                visible: true
-            }
-            PropertyChanges {
                 target: rowText
                 visible: true
             }
             PropertyChanges {
                 target: rowPill
-                visible: false
-            }
-            PropertyChanges {
-                target: paymentMethod
                 visible: false
             }
             PropertyChanges {
@@ -69,20 +53,12 @@ ColumnLayout {
             when: type === "pill"
 
             PropertyChanges {
-                target: rowLabel
-                visible: true
-            }
-            PropertyChanges {
                 target: rowText
                 visible: false
             }
             PropertyChanges {
                 target: rowPill
                 visible: true
-            }
-            PropertyChanges {
-                target: paymentMethod
-                visible: false
             }
             PropertyChanges {
                 target: relayUpsell
@@ -93,20 +69,12 @@ ColumnLayout {
             when: type === "payment"
 
             PropertyChanges {
-                target: rowLabel
-                visible: false
-            }
-            PropertyChanges {
                 target: rowText
                 visible: true
             }
             PropertyChanges {
                 target: rowPill
                 visible: false
-            }
-            PropertyChanges {
-                target: paymentMethod
-                visible: true
             }
             PropertyChanges {
                 target: relayUpsell
@@ -131,6 +99,7 @@ ColumnLayout {
 
             horizontalAlignment: Text.AlignLeft
             font.pixelSize: MZTheme.theme.fontSizeSmall
+            visible: !paymentMethod.visible
             text: labelText
             wrapMode: Text.WordWrap
 
@@ -140,7 +109,9 @@ ColumnLayout {
         MZPaymentMethod {
             id: paymentMethod
             objectName: _objectName + "-paymentMethod"
+            Layout.alignment: Qt.AlignLeft
             paymentMethod: labelText
+            visible: type === "payment"
         }
 
         MZInterLabel {

--- a/src/apps/vpn/ui/screens/settings/ViewSubscriptionManagement/ViewSubscriptionManagement.qml
+++ b/src/apps/vpn/ui/screens/settings/ViewSubscriptionManagement/ViewSubscriptionManagement.qml
@@ -19,6 +19,7 @@ MZViewBase {
     _menuTitle: MZI18n.SubscriptionManagementMenuTitle
     _menuOnBackClicked: () => { stackview.pop(null) }
     _viewContentData: ColumnLayout {
+        Layout.preferredWidth: parent.width
         spacing: MZTheme.theme.windowMargin
 
         ListModel {
@@ -50,6 +51,7 @@ MZViewBase {
             Layout.alignment: Qt.AlignTop
             Layout.leftMargin: MZTheme.theme.windowMargin
             Layout.rightMargin: MZTheme.theme.windowMargin
+            Layout.preferredWidth: parent.width
 
 
             MZMetropolisLabel {


### PR DESCRIPTION
## Description

- Fix various layout issues so that UI is no longer clumped together
- Fix `MZBottomNavigationBar` drop shadow

\* Did not check every aspect of the UI, but this should at least cover the most common screens
\* Tested fixes on Qt 6.4.3 and spot checked Qt 6.2.4 and Qt 6.5.1 to ensure all UI's appear visibly intact

## Reference

Main Ticket: 
- [VPN-4913: Investigate and fix QML layout issues in Qt 6.4.3](https://mozilla-hub.atlassian.net/browse/VPN-4913)

Related Tickets:
- [VPN-4494: Mozilla VPN multiple screens have layout issues on Linux (Ubuntu 23.04)](https://mozilla-hub.atlassian.net/browse/VPN-4494)
- [VPN-4499: [Linux] Some of the Developer options are not available](https://mozilla-hub.atlassian.net/browse/VPN-4499)
- [VPN-2986: Rendering issues with qt6.4 on linux](https://mozilla-hub.atlassian.net/browse/VPN-2986)