### PR TITLE
Chore: Better logging of tunnel launch errors

### DIFF
--- a/src/apps/vpn/platforms/windows/daemon/windowstunnelservice.h
+++ b/src/apps/vpn/platforms/windows/daemon/windowstunnelservice.h
@@ -30,7 +30,7 @@ class WindowsTunnelService final : public QObject {
 
  private:
   void timeout();
-  static QString exitCodeToFailure(unsigned int code);
+  static QString exitCodeToFailure(const void* status);
 
  private:
   QTimer m_timer;

--- a/src/shared/platforms/windows/windowsutils.cpp
+++ b/src/shared/platforms/windows/windowsutils.cpp
@@ -19,19 +19,22 @@ Logger logger("WindowsUtils");
 constexpr const int WINDOWS_11_BUILD =
     22000;  // Build Number of the first release win 11 iso
 
-QString WindowsUtils::getErrorMessage() {
-  DWORD errorId = GetLastError();
+QString WindowsUtils::getErrorMessage(quint32 code) {
   LPSTR messageBuffer = nullptr;
   size_t size = FormatMessageA(
       FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM |
           FORMAT_MESSAGE_IGNORE_INSERTS,
-      nullptr, errorId, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+      nullptr, code, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
       (LPSTR)&messageBuffer, 0, nullptr);
 
   std::string message(messageBuffer, size);
   QString result(message.c_str());
   LocalFree(messageBuffer);
   return result;
+}
+
+QString WindowsUtils::getErrorMessage() {
+  return getErrorMessage(GetLastError());
 }
 
 // A simple function to log windows error messages.

--- a/src/shared/platforms/windows/windowsutils.h
+++ b/src/shared/platforms/windows/windowsutils.h
@@ -10,6 +10,7 @@
 class WindowsUtils final {
  public:
   static QString getErrorMessage();
+  static QString getErrorMessage(quint32 code);
   static void windowsLog(const QString& msg);
 
   // Returns the major version of Windows


### PR DESCRIPTION
## Description
In a recent ticket ([VPN-4754](https://mozilla-hub.atlassian.net/browse/VPN-4754)/#6868) we are finding that the wireguard tunnel is exiting with a status of `ERROR_SERVICE_SPECIFIC_ERROR` which means that the wireguard tunnel itself detected a problem and refused to launch. However, the meaning of that error message is not printed to the logs because we ignore the value of `dwServiceSpecificExitCode`

This PR should update the error messaging to handle this exit condition correctly. While it does not fix the issue for this user, it should enable us to get better debug the next time it happens.

## Reference
Github issue #6868 ([VPN-4754](https://mozilla-hub.atlassian.net/browse/VPN-4754))

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-4754]: https://mozilla-hub.atlassian.net/browse/VPN-4754?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[VPN-4754]: https://mozilla-hub.atlassian.net/browse/VPN-4754?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ