### PR TITLE
VPN-4456: Don't use staging server if a server address is not specified

### DIFF
--- a/src/apps/vpn/ui/screens/getHelp/developerMenu/ViewDeveloperMenu.qml
+++ b/src/apps/vpn/ui/screens/getHelp/developerMenu/ViewDeveloperMenu.qml
@@ -64,15 +64,17 @@ MZViewBase {
                 if (MZSettings.stagingServerAddress !== serverAddressInput.text) {
                     MZSettings.stagingServerAddress = serverAddressInput.text;
                 }
-
-                // If a server address is not specified, don't use a staging server
-                if (!MZSettings.stagingServerAddress) {
-                    MZSettings.stagingServer = false;
-                }
             }
 
             Component.onCompleted: {
                 serverAddressInput.text = MZSettings.stagingServerAddress;
+            }
+
+            Component.onDestruction: {
+                // If a server address is not specified, don't use a staging server
+                if (!MZSettings.stagingServerAddress) {
+                    MZSettings.stagingServer = false;
+                }
             }
         }
 

--- a/src/apps/vpn/ui/screens/getHelp/developerMenu/ViewDeveloperMenu.qml
+++ b/src/apps/vpn/ui/screens/getHelp/developerMenu/ViewDeveloperMenu.qml
@@ -72,7 +72,7 @@ MZViewBase {
 
             Component.onDestruction: {
                 // If a server address is not specified, don't use a staging server
-                if (!MZSettings.stagingServerAddress) {
+                if (serverAddressInput.text.length == 0) {
                     MZSettings.stagingServer = false;
                 }
             }

--- a/src/apps/vpn/ui/screens/getHelp/developerMenu/ViewDeveloperMenu.qml
+++ b/src/apps/vpn/ui/screens/getHelp/developerMenu/ViewDeveloperMenu.qml
@@ -61,10 +61,15 @@ MZViewBase {
             }
 
             onTextChanged: text => {
-                               if (MZSettings.stagingServerAddress !== serverAddressInput.text) {
-                                   MZSettings.stagingServerAddress = serverAddressInput.text;
-                               }
-                           }
+                if (MZSettings.stagingServerAddress !== serverAddressInput.text) {
+                    MZSettings.stagingServerAddress = serverAddressInput.text;
+                }
+
+                // If a server address is not specified, don't use a staging server
+                if (!MZSettings.stagingServerAddress) {
+                    MZSettings.stagingServer = false;
+                }
+            }
 
             Component.onCompleted: {
                 serverAddressInput.text = MZSettings.stagingServerAddress;


### PR DESCRIPTION
## Description

Turn off the use of a staging server if a server address is not specified. Otherwise the next startup code path will assert that the server address is non-null when a staging server is set, and the assert will crash the app in a debug build.

The assert is in `AppConstants::setStaging`:
    `Q_ASSERT(!s_stagingServerAddress.isEmpty());`

After this change, the 'Use Staging Servers' checkbox in the Developer Options page will be automatically unchecked if the server address field is made empty.

## Reference

  GitHub issue [6478](https://github.com/mozilla-mobile/mozilla-vpn-client/issues/6478), [VPN-4456](https://mozilla-hub.atlassian.net/browse/VPN-4456)

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-4456]: https://mozilla-hub.atlassian.net/browse/VPN-4456?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ