### PR TITLE
Fix VPN-5051 - Wrap privacy policy link

### DIFF
--- a/src/apps/vpn/ui/screens/ScreenTelemetryPolicy.qml
+++ b/src/apps/vpn/ui/screens/ScreenTelemetryPolicy.qml
@@ -100,6 +100,7 @@ MZFlickable {
                 labelText: MZI18n.InAppSupportWorkflowPrivacyNoticeLinkText
                 Layout.alignment: Qt.AlignHCenter
                 onClicked: MZUrlOpener.openUrlLabel("privacyNotice")
+                Layout.fillWidth: true
             }
 
         }


### PR DESCRIPTION
## Description

## Description

Allows the wrapping of the privacy policy link on `ScreenTelemetryPolicy`
<img width="360" alt="Screen Shot 2023-06-28 at 12 25 40 PM" src="https://github.com/mozilla-mobile/mozilla-vpn-client/assets/22355127/a602b11d-3d94-4784-919b-a878bd026cfb">

## Reference

VPN-5051

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
