### PR TITLE
VPN-4456: Don't use staging server if a server address is not specified

### DIFF
--- a/src/apps/vpn/appconstants.cpp
+++ b/src/apps/vpn/appconstants.cpp
@@ -21,10 +21,10 @@ void AppConstants::setStaging() {
   Constants::setStaging();
 
   // Get staging server address. If it was set to empty by the user, remove it
-  // from SettingsHolder, and then query for it again to get the default address.
+  // from SettingsHolder, and then query for it again to get the default
+  // address.
   s_stagingServerAddress = SettingsHolder::instance()->stagingServerAddress();
-  if (s_stagingServerAddress.isEmpty())
-  {
+  if (s_stagingServerAddress.isEmpty()) {
     SettingsHolder::instance()->removeStagingServerAddress();
     s_stagingServerAddress = SettingsHolder::instance()->stagingServerAddress();
   }

--- a/src/apps/vpn/appconstants.cpp
+++ b/src/apps/vpn/appconstants.cpp
@@ -19,7 +19,15 @@ const QString& AppConstants::getStagingServerAddress() {
 
 void AppConstants::setStaging() {
   Constants::setStaging();
+
+  // Get staging server address. If it was set to empty by the user, remove it
+  // from SettingsHolder, and then query for it again to get the default address.
   s_stagingServerAddress = SettingsHolder::instance()->stagingServerAddress();
+  if (s_stagingServerAddress.isEmpty())
+  {
+    SettingsHolder::instance()->removeStagingServerAddress();
+    s_stagingServerAddress = SettingsHolder::instance()->stagingServerAddress();
+  }
   Q_ASSERT(!s_stagingServerAddress.isEmpty());
 }
 

--- a/src/apps/vpn/ui/screens/getHelp/developerMenu/ViewDeveloperMenu.qml
+++ b/src/apps/vpn/ui/screens/getHelp/developerMenu/ViewDeveloperMenu.qml
@@ -64,17 +64,19 @@ MZViewBase {
                 if (MZSettings.stagingServerAddress !== serverAddressInput.text) {
                     MZSettings.stagingServerAddress = serverAddressInput.text;
                 }
+
+                // If the server address has been deleted, uncheck checkBoxRowStagingServer to not use a
+                // staging server. Also reset the server address to the default, so the user can easily switch
+                // back to it by rechecking the checkbox.
+                if (serverAddressInput.text.length == 0) {
+                    MZSettings.stagingServer = false;
+                    serverAddressInput.text = "https://stage.guardian.nonprod.cloudops.mozgcp.net";
+                    MZSettings.stagingServerAddress = serverAddressInput.text;
+                }
             }
 
             Component.onCompleted: {
                 serverAddressInput.text = MZSettings.stagingServerAddress;
-            }
-
-            Component.onDestruction: {
-                // If a server address is not specified, don't use a staging server
-                if (serverAddressInput.text.length == 0) {
-                    MZSettings.stagingServer = false;
-                }
             }
         }
 

--- a/src/apps/vpn/ui/screens/getHelp/developerMenu/ViewDeveloperMenu.qml
+++ b/src/apps/vpn/ui/screens/getHelp/developerMenu/ViewDeveloperMenu.qml
@@ -64,15 +64,6 @@ MZViewBase {
                 if (MZSettings.stagingServerAddress !== serverAddressInput.text) {
                     MZSettings.stagingServerAddress = serverAddressInput.text;
                 }
-
-                // If the server address has been deleted, uncheck checkBoxRowStagingServer to not use a
-                // staging server. Also reset the server address to the default, so the user can easily switch
-                // back to it by rechecking the checkbox.
-                if (serverAddressInput.text.length == 0) {
-                    MZSettings.stagingServer = false;
-                    serverAddressInput.text = "https://stage.guardian.nonprod.cloudops.mozgcp.net";
-                    MZSettings.stagingServerAddress = serverAddressInput.text;
-                }
             }
 
             Component.onCompleted: {


### PR DESCRIPTION
## Description

 If the user did not specify a server address, change the empty address to the default server address on startup. Otherwise the startup code path will assert that the server address is non-null, and the assert will crash the app in a debug build.

The assert is in AppConstants::setStaging:
Q_ASSERT(!s_stagingServerAddress.isEmpty());

Other solution that was considered:
Use Component.onDestruction in QML to uncheck staging server if an address was not specified. However onDestruction is not called when the window is closed. This may be a Qt issue.

## Reference

GitHub issue [6478](https://github.com/mozilla-mobile/mozilla-vpn-client/issues/6478), [VPN-4456](https://mozilla-hub.atlassian.net/browse/VPN-4456)

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-4456]: https://mozilla-hub.atlassian.net/browse/VPN-4456?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ