### PR TITLE
VPN-4913: Fix data collection screen layout

### DIFF
--- a/src/apps/vpn/ui/screens/ScreenTelemetryPolicy.qml
+++ b/src/apps/vpn/ui/screens/ScreenTelemetryPolicy.qml
@@ -45,7 +45,7 @@ MZFlickable {
 
         ColumnLayout {
             spacing: MZTheme.theme.windowMargin * 1.25
-            Layout.fillWidth: true
+            Layout.preferredWidth: parent.width
             Layout.alignment: Qt.AlignHCenter
 
             MZSubtitle {


### PR DESCRIPTION
## Description

- Fix the layout of the data collection screen

| Before  | After |
| ------------- | ------------- |
| <img width="472" alt="Screenshot 2023-06-29 at 10 37 46 AM" src="https://github.com/mozilla-mobile/mozilla-vpn-client/assets/15353801/ad3d9585-2783-48f8-9e26-4634f45fb184"> | <img width="472" alt="Screenshot 2023-06-29 at 10 35 15 AM" src="https://github.com/mozilla-mobile/mozilla-vpn-client/assets/15353801/614b77a7-85a9-48ed-867a-fdeeb035bd02"> |

## Reference

[VPN-4913: Investigate and fix QML layout issues in Qt 6.4.3](https://mozilla-hub.atlassian.net/browse/VPN-4913)
