### PR TITLE
VPN-5143: Fix re-auth page layout

### DIFF
--- a/src/apps/vpn/ui/authenticationInApp/ViewAuthenticationSignIn.qml
+++ b/src/apps/vpn/ui/authenticationInApp/ViewAuthenticationSignIn.qml
@@ -77,6 +77,7 @@ MZInAppAuthenticationBase {
 
     _footerContent: Column {
         Layout.alignment: Qt.AlignHCenter
+        Layout.preferredWidth: parent.width
         spacing: MZTheme.theme.windowMargin
 
         MZLinkButton {

--- a/src/apps/vpn/ui/authenticationInApp/ViewAuthenticationVerificationSessionByTotpNeeded.qml
+++ b/src/apps/vpn/ui/authenticationInApp/ViewAuthenticationVerificationSessionByTotpNeeded.qml
@@ -38,6 +38,7 @@ MZInAppAuthenticationBase {
 
     _footerContent: Column {
         Layout.alignment: Qt.AlignHCenter
+        Layout.preferredWidth: parent.width
 
         MZCancelButton {
             anchors.horizontalCenter: parent.horizontalCenter


### PR DESCRIPTION
## Description

- Fixes layout issues in the "password confirmation" and "TOTP confirmation" pages in the re-auth flow for Qt 6.4

| Before  | After |
| ------------- | ------------- |
| <img width="428" alt="Screenshot 2023-06-29 at 6 35 40 PM" src="https://github.com/mozilla-mobile/mozilla-vpn-client/assets/15353801/b8821049-0f1e-46df-b4a1-ac132e671a85"> | <img width="472" alt="Screenshot 2023-06-29 at 6 36 18 PM" src="https://github.com/mozilla-mobile/mozilla-vpn-client/assets/15353801/c67cab24-3995-4866-9d11-5aa0f03866df"> |
| <img width="472" alt="Screenshot 2023-06-29 at 6 35 48 PM" src="https://github.com/mozilla-mobile/mozilla-vpn-client/assets/15353801/7f713437-f040-40d8-9647-9cf9925ad144"> | <img width="472" alt="Screenshot 2023-06-29 at 6 36 25 PM" src="https://github.com/mozilla-mobile/mozilla-vpn-client/assets/15353801/c0cb9584-f4df-40c1-8a71-b3d9bc66002d"> |

## Reference

[VPN-5143: [Qt 6.4] Layout issues in auth views](https://mozilla-hub.atlassian.net/browse/VPN-5143)