### PR TITLE
Nit: Support deployment of online-installer qt

### DIFF
--- a/scripts/cmake/osxtools.cmake
+++ b/scripts/cmake/osxtools.cmake
@@ -154,3 +154,22 @@ function(osx_codesign_target TARGET)
         endforeach()
     endif()
 endfunction()
+
+
+## A helper to copy qt-files into the app
+function(osx_deploy_qt TARGET)
+    # Deploy Qt runtime dependencies during installation.
+    get_target_property(QT_QMLLINT_EXECUTABLE Qt6::qmllint LOCATION)
+    get_filename_component(QT_TOOL_PATH ${QT_QMLLINT_EXECUTABLE} PATH)
+    find_program(QT_DEPLOY_BIN
+        NAMES macdeployqt
+        PATHS ${QT_TOOL_PATH}
+        NO_DEFAULT_PATH)
+    get_target_property(TARGET_SOURCE_DIR ${TARGET} SOURCE_DIR)
+
+    add_custom_command(TARGET ${TARGET} POST_BUILD
+            COMMAND_EXPAND_LISTS
+            COMMAND ${QT_DEPLOY_BIN} $<TARGET_BUNDLE_DIR:${TARGET}> -qmldir=${TARGET_SOURCE_DIR} -always-overwrite   
+            COMMAND ${COMMENT_ECHO_COMMAND} "Bundling ${FILE}"
+        )
+endfunction(osx_deploy_qt)

--- a/scripts/macos/conda_setup_qt.sh
+++ b/scripts/macos/conda_setup_qt.sh
@@ -17,9 +17,9 @@ fi
 
 export QT_DIR=$CONDA_PREFIX/Qt
 # QT_Host Tools
-python -m aqt install-qt --outputdir $QT_DIR $HOST_TARGET
+python -m aqt install-qt --outputdir $QT_DIR $HOST_TARGET -m qt5compat qtimageformats qtnetworkauth qtshadertools qtwebsockets 
 # QT Android Tools
-python -m aqt install-qt --outputdir $QT_DIR $HOST ios ${QT_VERSION} -m all 
+python -m aqt install-qt --outputdir $QT_DIR $HOST ios ${QT_VERSION} -m qt5compat qtimageformats qtnetworkauth qtshadertools qtwebsockets 
 
 echo "$QT_DIR/$QT_VERSION/ios/bin/qt-cmake"
 

--- a/src/apps/vpn/cmake/macos.cmake
+++ b/src/apps/vpn/cmake/macos.cmake
@@ -202,3 +202,10 @@ osx_bundle_assetcatalog(mozillavpn CATALOG ${CMAKE_SOURCE_DIR}/macos/app/Images.
 
 # Perform codesigning.
 osx_codesign_target(mozillavpn FORCE)
+
+if(NOT QT_FEATURE_static)
+    # If we are not using a static build of QT, auto deploy all 
+    # qt dependencies into the .app bundle c: 
+    message("Enabling macdeployqt")
+    osx_deploy_qt(mozillavpn)
+endif()


### PR DESCRIPTION
## Description

@oskirby - We've talked about considering using qt-prebuilds from the online installer. Given the Qt-Toolchain is busted, i thought i experiment with this just as an option :) 


This PR add's a check, that if the app is not build using a static version of QT, it will invoke macdeployqt. This will copy all dependencies we have into the `.app` bundle. 
 
