### PR TITLE
[2.16] - Pin Qt Toolchain artifact

### DIFF
--- a/taskcluster/ci/build/macos.yml
+++ b/taskcluster/ci/build/macos.yml
@@ -14,8 +14,7 @@ task-defaults:
     fetches:
         fetch:
             - miniconda-osx
-        toolchain:
-            - qt-mac
+            - qt-hotfix
     worker:
         taskcluster-proxy: true
         chain-of-trust: true

--- a/taskcluster/ci/fetch/kind.yml
+++ b/taskcluster/ci/fetch/kind.yml
@@ -101,3 +101,4 @@ tasks:
             url: https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/ZswGg-syTMWyn2UTOaMVQg/runs/0/artifacts/public%2Fbuild%2Fqt6_mac.zip
             size: 446046644
             sha256: 68ec769ed98206784234c1c8dfae7ebb3f1be869cddfca984bb81104542a6721
+            artifact-name: qt.zip

--- a/taskcluster/ci/fetch/kind.yml
+++ b/taskcluster/ci/fetch/kind.yml
@@ -94,3 +94,10 @@ tasks:
             url: https://download.qt.io/archive/qt/6.2/6.2.4/single/qt-everywhere-src-6.2.4.tar.xz
             sha256: cfe41905b6bde3712c65b102ea3d46fc80a44c9d1487669f14e4a6ee82ebb8fd
             size: 661663792
+    qt-hotfix:
+        description: Qt 6.2.4 Status build
+        fetch:
+            type: static-url
+            url: https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/ZswGg-syTMWyn2UTOaMVQg/runs/0/artifacts/public%2Fbuild%2Fqt6_mac.zip
+            size: 446046644
+            sha256: 68ec769ed98206784234c1c8dfae7ebb3f1be869cddfca984bb81104542a6721


### PR DESCRIPTION
## Description

Due to us updating x-code it seems 
```
      toolchain: qt-mac
```
is broken. We want to upgrade qt anyway in 2.17. 
So for 2.16 let's fetch & use the toolchain artifact used in 2.15.1 
