### PR TITLE
Bug 1835689 - don't include cached tasks in existing_tasks for release promotion

### DIFF
--- a/taskcluster/ci/config.yml
+++ b/taskcluster/ci/config.yml
@@ -115,3 +115,8 @@ release-promotion:
             target-tasks-method: client-target-tasks
         ship-client:
             target-tasks-method: client-target-tasks
+    rebuild-kinds:
+        - docker-image
+        - fetch
+        - toolchain
+        - toolchain-openssl

--- a/taskcluster/mozillavpn_taskgraph/actions/release_promotion.py
+++ b/taskcluster/mozillavpn_taskgraph/actions/release_promotion.py
@@ -86,11 +86,11 @@ def release_promotion_action(parameters, graph_config, input, task_group_id, tas
     target_tasks_method = promotion_config["target-tasks-method"].format(
         project=parameters["project"]
     )
-    rebuild_kinds = input.get("rebuild_kinds") or promotion_config.get(
-        "rebuild-kinds", []
+    rebuild_kinds = input.get(
+        "rebuild_kinds", promotion_config.get("rebuild-kinds", [])
     )
-    do_not_optimize = input.get("do_not_optimize") or promotion_config.get(
-        "do-not-optimize", []
+    do_not_optimize = input.get(
+        "do_not_optimize", promotion_config.get("do-not-optimize", [])
     )
 
     # make parameters read-write

--- a/taskcluster/mozillavpn_taskgraph/actions/release_promotion.py
+++ b/taskcluster/mozillavpn_taskgraph/actions/release_promotion.py
@@ -56,6 +56,7 @@ def is_release_promotion_available(parameters):
                     "Optional: an array of kinds to ignore from the previous "
                     "graph(s)."
                 ),
+                "default": graph_config["release-promotion"].get("rebuild-kinds", []),
                 "items": {
                     "type": "string",
                 },


### PR DESCRIPTION
## Description

Release promotion reuses tasks generated by the on-push decision task, to
avoid duplicating work.  For cached tasks however, that means reusing
index lookups that can be out of date by the time relpro runs, and
requiring a new push to pick up rebuilt cached tasks.  By listing the
cached kinds in rebuild-kinds, we force new index lookups at release
promotion time, to pick up e.g. new docker images without an extra push.


## Reference

    https://bugzilla.mozilla.org/show_bug.cgi?id=1835689

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
