### PR TITLE
Chore: Upload PPA workflow artifacts, even if dput fails.

### DIFF
--- a/.github/workflows/ppa-automation.yaml
+++ b/.github/workflows/ppa-automation.yaml
@@ -67,6 +67,7 @@ jobs:
           KEYGRIP=$(gpg --with-colons --with-keygrip --list-keys | grep -m1 '^grp:' | tr -d [grp:])
           echo "$GPG_PASSWORD" | /lib/gnupg2/gpg-preset-passphrase --preset $KEYGRIP
 
+          JOB_EXIT_CODE=0
           PACKAGE_DSC_FILE=$(find . -name '*.dsc')
           for dist in ${PPA_TARGET_DISTS}; do
             dpkg-source -x ${PACKAGE_DSC_FILE} $(pwd)/mozillavpn-source/
@@ -78,12 +79,15 @@ jobs:
             dch -c $(pwd)/mozillavpn-source/debian/changelog -v ${PACKAGE_DIST_VERSION} -D ${dist}  "Release for ${dist}"
             (cd mozillavpn-source && dpkg-buildpackage --build=source --sign-key=$KEYID -sa --no-check-builddeps)
 
-            dput $PPA_URL ${PACKAGE_SOURCE_NAME}_${PACKAGE_DIST_VERSION}_source.changes
+            dput $PPA_URL ${PACKAGE_SOURCE_NAME}_${PACKAGE_DIST_VERSION}_source.changes || JOB_EXIT_CODE=1
             rm -rf $(pwd)/mozillavpn-source
           done
 
+          exit $JOB_EXIT_CODE
+
       - name: Uploading sources
         uses: actions/upload-artifact@v3
+        if: always()
         with:
             name: Sources
             path: .tmp


### PR DESCRIPTION
## Description
We rely on the PPA automation workflow a little more than we would like to admit as a part of our Linux release process, and as such, when the job fails to run (eg: to produce a dot release when a later RC already exist), this tends to cause a lot of pain for release engineering. As such, we should try our best to make sure that the workflow always produces its artifacts, even if `dput` fails for some reason.

To achieve this, we need to ensure that the `for` loop tries to upload for all distributions (even if one of them fails) and that we always upload the github workflow artifacts.

## Reference
Github issue: #7119 ([VPN-4958](https://mozilla-hub.atlassian.net/browse/VPN-4958))

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-4958]: https://mozilla-hub.atlassian.net/browse/VPN-4958?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ