### PR TITLE
VPN-4238 Hide Speedtest restart button when VPN is disabled

### DIFF
--- a/src/apps/vpn/ui/screens/home/controller/connectionInfo/ConnectionInfoScreen.qml
+++ b/src/apps/vpn/ui/screens/home/controller/connectionInfo/ConnectionInfoScreen.qml
@@ -146,7 +146,7 @@ Rectangle {
     MZIconButton {
         id: connectionInfoRestartButton
 
-        visible: connectionInfoContent.visible || connectionInfoError.visible
+        visible: VPNController.state === VPNController.StateOn && (connectionInfoContent.visible || connectionInfoError.visible)
 
         anchors {
             top: parent.top


### PR DESCRIPTION
## Description

It does not make sense to restart the speedtest when you are not connected to the VPN. I would suggest hiding the restart button so you cannot enter an invalid state.

## Reference

https://mozilla-hub.atlassian.net/browse/VPN-4238

https://github.com/mozilla-mobile/mozilla-vpn-client/assets/1068037/661f30cf-bc05-45b1-92fd-fcd679154576