### PR TITLE
Ignore 2.15.* branches when extracting strings

### DIFF
--- a/scripts/utils/generate_ts.sh
+++ b/scripts/utils/generate_ts.sh
@@ -65,6 +65,15 @@ EOF
   cp build-addons/*.ts addon_ts
 
   for branch in $(git branch -r | grep origin/releases); do
+    # Temporarily skip 2.15.* branches. All translations for these versions
+    # have been removed from the l10n repository ahead of time, and we don't
+    # want to reintroduce these strings for translation.
+    # TODO: remove this check when 2.15.* branches are removed.
+    if [[ "$branch" == *"2.15"* ]]; then
+      echo "Skipping branch: $branch"
+      continue
+    fi
+
     git checkout $branch &>/dev/null || die
 
     print Y "Importing main strings from $branch..."


### PR DESCRIPTION
## Description

Per conversation in Slack: the `2.15.0` and `2.15.1` branches were removed yesterday from this repository. That means that thousands of translations were removed from the l10n repository (won't link the PR, as it's large enough to make Firefox stall).

Reintroducing these branches exposes about 150 strings for translation, and that's not something we can afford (we can't recover previous translations). We also can't stop translating until these branches are removed again, so I'm skipping them in the generation process.

I will file an issue to make sure we remove them once there are no more `2.15.*` branches in the repository.

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
