### PR TITLE
i18n Update-Automation for Release branches 

### DIFF
--- a/.github/scripts/get_unreleased_branches.ps1
+++ b/.github/scripts/get_unreleased_branches.ps1
@@ -32,7 +32,7 @@ $UNRELEASED_BRANCHES = $REMOTE_RELEASE_BRANCHES | Where-Object { !($releases_on_
 # If we only have one Branch this will be a string, so let's json pack it. 
 # If not this is a list and we can just use ConvertTo-Json
 if ( $UNRELEASED_BRANCHES.GetType() -Eq [string] ){
-    $json_value = "[ $UNRELEASED_BRANCHES ]"
+    $json_value = "[ '$UNRELEASED_BRANCHES' ]"
 }else{
     $json_value = ConvertTo-Json $UNRELEASED_BRANCHES -Compress 
 }

--- a/.github/scripts/get_unreleased_branches.ps1
+++ b/.github/scripts/get_unreleased_branches.ps1
@@ -1,0 +1,29 @@
+#
+# This script fetches all remote branches
+# And filteres out branches that have a github release connected to that. 
+# It Writes a JSON array to GITHUB_OUTPUT to use it in workflows as step output c: 
+#
+
+git fetch
+$REMOTE_RELEASE_BRANCHES = $(git branch -r).Split([Environment]::NewLine) `
+                | ForEach-Object{ $_.Trim() } `
+                | Where-Object {$_.startsWith('origin/releases/')} `
+                | ForEach-Object{ $_.Replace("origin/releases/","") } `
+                    
+
+# Output of gh releases
+# v2.15.1 Latest  v2.15.1 2023-06-28T21:38:04Z
+# v2.15.1 Latest  v2.15.1 2023-06-28T21:38:04Z
+# v2.15.0         v2.15.0 2023-05-30T16:15:58Z
+# v2.14.1         v2.14.1 2023-03-30T16:09:25Z
+$releases_on_github  = @()
+$(gh release list).Split([Environment]::NewLine) | ForEach-Object{ 
+    # $_ is now one line "v2.15.1 Latest  v2.15.1 2023-06-28T21:38:04Z"
+    $tag = $_.Split([char]9)[0]
+    $releases_on_github += $tag.Replace("v","")
+} `
+# Now we have 2 Lists. 
+
+$UNRELEASED_BRANCHES = $REMOTE_RELEASE_BRANCHES | Where-Object { !($releases_on_github -contains $_) } 
+$json_value = ConvertTo-Json $UNRELEASED_BRANCHES -Compress 
+Write-Output "branches=$json_value"

--- a/.github/workflows/i18n_update.yaml
+++ b/.github/workflows/i18n_update.yaml
@@ -94,7 +94,7 @@ jobs:
           commit-message: "[Bot] Update i18n"
           branch: i18n_automation_for_${{matrix.branch}}
           delete-branch: true
-          title: "[Bot]  Update i18n on ${{matrix.branch}}"
+          title: "[Bot] Update i18n on ${{matrix.branch}}"
           token: ${{ secrets.WIKI_TOKEN }}
       - name: Approve l10n_branch.
         run: gh pr review --approve "$PR_URL"

--- a/.github/workflows/i18n_update.yaml
+++ b/.github/workflows/i18n_update.yaml
@@ -108,3 +108,4 @@ jobs:
         env:
           PR_URL: ${{ steps.cpr.outputs.pull-request-url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.github/workflows/i18n_update.yaml
+++ b/.github/workflows/i18n_update.yaml
@@ -88,7 +88,7 @@ jobs:
       - uses: peter-evans/create-pull-request@v5
         id: cpr
         with:
-          # This may not be github, cuz gh actions cannot self approve
+          # This may not be GitHub, because GitHub actions cannot self-approve
           author: GitHub <noreply@github.com>
           committer: GitHub <noreply@github.com>
           commit-message: "[Bot] Update i18n"

--- a/.github/workflows/i18n_update.yaml
+++ b/.github/workflows/i18n_update.yaml
@@ -68,7 +68,7 @@ jobs:
         run: |
           ./.github/scripts/get_unreleased_branches.ps1  >> $env:GITHUB_OUTPUT
   update_release_branches:
-    name: Update Release branch submodules
+    name: [v${{matrix.branch}}] Update submodules
     needs:
       - get_release_branches
     runs-on: ubuntu-latest
@@ -81,7 +81,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: 'true'
-          ref: 'refs/remotes/origin/releases/${{matrix.branch}}'
+          ref: 'releases/${{matrix.branch}}'
       - name: Checkout mozilla-vpn-client-l10n Git
         run: |
           git submodule update --init --remote src/apps/vpn/translations/i18n/

--- a/.github/workflows/i18n_update.yaml
+++ b/.github/workflows/i18n_update.yaml
@@ -50,4 +50,61 @@ jobs:
         env:
           PR_URL: ${{ steps.cpr.outputs.pull-request-url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
- 
+  get_release_branches: 
+    name: Get Unreleased Branches
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.gen.outputs.branches }}
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v3
+        with:
+          submodules: 'true'
+      - name: Generate Branch List
+        id: gen
+        shell: pwsh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ./.github/scripts/get_unreleased_branches.ps1  >> $env:GITHUB_OUTPUT
+  update_release_branches:
+    name: Update Release branch submodules
+    needs:
+      - get_release_branches
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false # Don't cancel other jobs if a test fails
+      matrix:
+        branch: ${{ fromJson(needs.get_release_branches.outputs.matrix) }}
+    steps:
+      - name: Clone repository and checkout ${{matrix.branch}}
+        uses: actions/checkout@v3
+        with:
+          submodules: 'true'
+          ref: 'refs/remotes/origin/releases/${{matrix.branch}}'
+      - name: Checkout mozilla-vpn-client-l10n Git
+        run: |
+          git submodule update --init --remote src/apps/vpn/translations/i18n/
+      - uses: peter-evans/create-pull-request@v5
+        id: cpr
+        with:
+          # This may not be github, cuz gh actions cannot self approve
+          author: GitHub <noreply@github.com>
+          committer: GitHub <noreply@github.com>
+          commit-message: "[Bot] Update i18n"
+          branch: i18n_automation_for_${{matrix.branch}}
+          delete-branch: true
+          title: "[Bot]  Update i18n on ${{matrix.branch}}"
+          token: ${{ secrets.WIKI_TOKEN }}
+      - name: Approve l10n_branch.
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ steps.cpr.outputs.pull-request-url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # Finally, this sets the PR to allow auto-merging for patch and minor
+      # updates if all checks pass
+      - name: Enable auto-merge the i18n PR
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ steps.cpr.outputs.pull-request-url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/i18n_update.yaml
+++ b/.github/workflows/i18n_update.yaml
@@ -68,7 +68,7 @@ jobs:
         run: |
           ./.github/scripts/get_unreleased_branches.ps1  >> $env:GITHUB_OUTPUT
   update_release_branches:
-    name: [v${{matrix.branch}}] Update submodules
+    name: ${{matrix.branch}} Update submodules
     needs:
       - get_release_branches
     runs-on: ubuntu-latest


### PR DESCRIPTION
## tldr

On Main we already have a workflow that daily pulls in the newest language-submodule.
This PR add's a bit of automation to do that too for every branch in `release/*`that has no Github Release or Release Draft present. 

## WHY

We want to get rid of: 

```
for i in src/apps/*/translations/i18n; do
            git submodule update --remote $i
```
Because that makes it impossible to trace what commit has been built with which language and  makes it impossible for the CI to build an older release, once the strings have been removed on the head of the strings repo. Which i just may have caused 😓 


## Examples: 

Example Run 1: 
https://github.com/mozilla-mobile/mozilla-vpn-client/actions/runs/5475097381
Created PR: https://github.com/mozilla-mobile/mozilla-vpn-client/pull/7439

Example Run before i added 2.15.2 as a draft: (note i cancelled the 2.15.2 update ) 
https://github.com/mozilla-mobile/mozilla-vpn-client/actions/runs/5474990930


