### PR TITLE
Bug 1841849 - add matrix notifications to release promotion tasks

### DIFF
--- a/taskcluster/ci/release-notify/kind.yml
+++ b/taskcluster/ci/release-notify/kind.yml
@@ -24,7 +24,11 @@ task-defaults:
                 "3":
                     - type: slack-channel
                       channel-id: C01DCUKG95E  # mozilla-vpn-release
-                default: []
+                    - type: matrix-room
+                      room-id: "!tBWwNyfeKqGvkNpdDL:mozilla.org"  # #releaseduty:mozilla.org
+                default:
+                    - type: matrix-room
+                      room-id: "!wGgsWXnVncJLSBYmuf:mozilla.org"  # #releaseduty-dev:mozilla.org
 
 tasks:
     promote-addons:


### PR DESCRIPTION
## Description

Send a matrix notification to #releaseduty on successful release promotion, modeled after the existing slack notification.

## Reference

https://bugzilla.mozilla.org/show_bug.cgi?id=1841849

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
