### PR TITLE
VPN-5189: Pin i18n submodule for 2.15.2 (Linux only)

### DIFF
--- a/scripts/linux/script.sh
+++ b/scripts/linux/script.sh
@@ -122,7 +122,8 @@ mkdir .tmp || die "Failed to create the temporary directory"
 
 print Y "Get the submodules..."
 git submodule update --init --depth 1 || die "Failed to init submodules"
-git submodule update --remote i18n || die "Failed to pull latest i18n from remote"
+# !!!! Commenting this out for 2.15.2, as we need to pin the i18n commit
+# git submodule update --remote i18n || die "Failed to pull latest i18n from remote"
 print G "done."
 
 print G "Creating the orig tarball"

--- a/scripts/utils/import_languages.py
+++ b/scripts/utils/import_languages.py
@@ -66,7 +66,8 @@ lrelease = os.path.join(qtbinpath, 'lrelease')
 
 # Step 1 (continued)
 # Get the latest translations from i18n remote
-os.system(f"git submodule update --init --remote --depth 1 i18n")
+# !!!! Commenting this out for 2.15.2, as we need to pin the i18n commit
+# os.system(f"git submodule update --init --remote --depth 1 i18n")
 
 # Step 2
 # Go through the i18n repo, check each XLIFF file and take


### PR DESCRIPTION
## Description

We need to pin the i18n branch we're using for 2.15.2, which is only going to be available on Linux. I believe this does that. It:
- updates to the proper i18n commit 
- comments out the i18n update (not sure which of these two will be run, so commented out both)

While this is ugly, it's only going into the 2.15.2 branch, so I think this is okay.

## Reference

https://mozilla-hub.atlassian.net/browse/VPN-5189

## Checklist
    
- [X] My code follows the style guidelines for this project
- [X] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [X] I have performed a self review of my own code
- [X] I have commented my code PARTICULARLY in hard to understand areas
- [X] I have added thorough tests where needed
