### PR TITLE
fixing aqt download issues by using apt

### DIFF
--- a/.github/workflows/gh_pages.yaml
+++ b/.github/workflows/gh_pages.yaml
@@ -107,21 +107,16 @@ jobs:
             path: tools/inspector/dist
 
   addons:
-    runs-on: ubuntu-20.04
-    env:
-      QTVERSION: 6.2.4
-
+    runs-on: ubuntu-22.04
     steps:
       - name: Clone repository
         uses: actions/checkout@v3
         with: 
           submodules: 'true'
-
-      - name: Install Qt
-        shell: bash
+      - name: Install Linux packages
         run: |
-          python3 -m pip install aqtinstall
-          python3 -m aqt install-qt -O /opt linux desktop $QTVERSION
+          sudo apt-get update
+          sudo apt-get install -y $(./scripts/linux/getdeps.py -a linux/debian/control)
 
       - name: Install python dependencies
         shell: bash

--- a/.github/workflows/test_lottie.yaml
+++ b/.github/workflows/test_lottie.yaml
@@ -16,18 +16,13 @@ concurrency:
 
 jobs:
   linux-lottie-tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: Run Lottie tests on Linux
-    env:
-      QTVERSION: 6.2.4
     steps:
       - name: Install Linux packages
         run: |
-          sudo apt update
-          sudo apt install git libgl-dev libgles2-mesa-dev  libxkbcommon-x11-0 libgles2 libgl-dev libegl-dev clang-10 liboath-dev python3 xz-utils libbrotli-dev brotli -y
-          wget https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/mozillavpn.v2.mozillavpn.cache.level-3.toolchains.v3.qt-linux.latest/artifacts/public%2Fbuild%2Fqt6_linux.tar.xz -O /opt/qt.tar.xz
-          tar -xf /opt/qt.tar.xz -C /opt
-          ls /opt/
+          sudo apt-get update
+          sudo apt-get install -y $(./scripts/linux/getdeps.py -a linux/debian/control)
 
       - name: Clone repository
         uses: actions/checkout@v3
@@ -49,10 +44,7 @@ jobs:
         shell: bash
         run: |
           mkdir -p build
-          export PATH=/opt/qt_dist/bin/:$PATH
-          mkdir -p /usr/lib/x86_64-linux-gnu/
-          cp  /opt/qt_dist/lib/*.so /usr/lib/x86_64-linux-gnu/
-          /opt/qt_dist/bin/qt-cmake -S lottie -B $(pwd)/build -DBUILD_TESTING=ON \
+          cmake -S lottie -B $(pwd)/build -DBUILD_TESTING=ON \
             -DCMAKE_CXX_FLAGS=--coverage -DCMAKE_EXE_LINKER_FLAGS=--coverage
           cmake --build $(pwd)/build -j$(nproc)
 

--- a/.github/workflows/test_lottie.yaml
+++ b/.github/workflows/test_lottie.yaml
@@ -49,6 +49,10 @@ jobs:
         shell: bash
         run: |
           mkdir -p build
+          export PATH=/opt/qt_dist/bin/:$PATH
+          export $LD_LIBRARY_PATH=:$LD_LIBRARY_PATH
+          mkdir -p /usr/lib/x86_64-linux-gnu/
+          cp  /opt/qt_dist/lib/*.so /usr/lib/x86_64-linux-gnu/
           /opt/qt_dist/bin/qt-cmake -S lottie -B $(pwd)/build -DBUILD_TESTING=ON \
             -DCMAKE_CXX_FLAGS=--coverage -DCMAKE_EXE_LINKER_FLAGS=--coverage
           cmake --build $(pwd)/build -j$(nproc)

--- a/.github/workflows/test_lottie.yaml
+++ b/.github/workflows/test_lottie.yaml
@@ -24,9 +24,9 @@ jobs:
       - name: Install Linux packages
         run: |
           sudo apt update
-          sudo apt install git libgl-dev libegl-dev clang-10 liboath-dev python3 -y
-          python3 -m pip install aqtinstall
-          aqt install-qt --outputdir /opt linux desktop $QTVERSION gcc_64 -m all
+          sudo apt install git libgl-dev libegl-dev clang-10 liboath-dev python3 xz-utils -y
+          wget https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/mozillavpn.v2.mozillavpn.cache.level-3.toolchains.v3.qt-linux.latest/artifacts/public%2Fbuild%2Fqt6_linux.tar.xz -o /opt/taqt.tar.xz
+          tar -xf /opt/taqt.tar.xz
 
       - name: Clone repository
         uses: actions/checkout@v3
@@ -49,7 +49,7 @@ jobs:
         run: |
           mkdir -p build
           cmake -S lottie -B $(pwd)/build -DBUILD_TESTING=ON \
-            -DCMAKE_PREFIX_PATH=/opt/$QTVERSION/gcc_64/lib/cmake/ \
+            -DCMAKE_PREFIX_PATH=/opt/qt_dist/lib/cmake/ \
             -DCMAKE_CXX_FLAGS=--coverage -DCMAKE_EXE_LINKER_FLAGS=--coverage
           cmake --build $(pwd)/build -j$(nproc)
 

--- a/.github/workflows/test_lottie.yaml
+++ b/.github/workflows/test_lottie.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Install Linux packages
         run: |
           sudo apt update
-          sudo apt install git libgl-dev libegl-dev clang-10 liboath-dev python3 xz-utils libbrotli-dev brotli -y
+          sudo apt install git libgl-dev libgles2-mesa-dev libgles2 libgl-dev libegl-dev clang-10 liboath-dev python3 xz-utils libbrotli-dev brotli -y
           wget https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/mozillavpn.v2.mozillavpn.cache.level-3.toolchains.v3.qt-linux.latest/artifacts/public%2Fbuild%2Fqt6_linux.tar.xz -O /opt/qt.tar.xz
           tar -xf /opt/qt.tar.xz -C /opt
           ls /opt/

--- a/.github/workflows/test_lottie.yaml
+++ b/.github/workflows/test_lottie.yaml
@@ -50,7 +50,7 @@ jobs:
         run: |
           mkdir -p build
           export PATH=/opt/qt_dist/bin/:$PATH
-          export $LD_LIBRARY_PATH=:$LD_LIBRARY_PATH
+          export LD_LIBRARY_PATH=/opt/qt_dist/lib/:$LD_LIBRARY_PATH
           mkdir -p /usr/lib/x86_64-linux-gnu/
           cp  /opt/qt_dist/lib/*.so /usr/lib/x86_64-linux-gnu/
           /opt/qt_dist/bin/qt-cmake -S lottie -B $(pwd)/build -DBUILD_TESTING=ON \

--- a/.github/workflows/test_lottie.yaml
+++ b/.github/workflows/test_lottie.yaml
@@ -49,8 +49,7 @@ jobs:
         shell: bash
         run: |
           mkdir -p build
-          cmake -S lottie -B $(pwd)/build -DBUILD_TESTING=ON \
-            -DCMAKE_PREFIX_PATH=/opt/qt_dist/lib/cmake/ \
+          /opt/qt_dist/bin/qt-cmake -S lottie -B $(pwd)/build -DBUILD_TESTING=ON \
             -DCMAKE_CXX_FLAGS=--coverage -DCMAKE_EXE_LINKER_FLAGS=--coverage
           cmake --build $(pwd)/build -j$(nproc)
 

--- a/.github/workflows/test_lottie.yaml
+++ b/.github/workflows/test_lottie.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Install Linux packages
         run: |
           sudo apt update
-          sudo apt install git libgl-dev libgles2-mesa-dev libgles2 libgl-dev libegl-dev clang-10 liboath-dev python3 xz-utils libbrotli-dev brotli -y
+          sudo apt install git libgl-dev libgles2-mesa-dev  libxkbcommon-x11-0 libgles2 libgl-dev libegl-dev clang-10 liboath-dev python3 xz-utils libbrotli-dev brotli -y
           wget https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/mozillavpn.v2.mozillavpn.cache.level-3.toolchains.v3.qt-linux.latest/artifacts/public%2Fbuild%2Fqt6_linux.tar.xz -O /opt/qt.tar.xz
           tar -xf /opt/qt.tar.xz -C /opt
           ls /opt/

--- a/.github/workflows/test_lottie.yaml
+++ b/.github/workflows/test_lottie.yaml
@@ -25,8 +25,9 @@ jobs:
         run: |
           sudo apt update
           sudo apt install git libgl-dev libegl-dev clang-10 liboath-dev python3 xz-utils -y
-          wget https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/mozillavpn.v2.mozillavpn.cache.level-3.toolchains.v3.qt-linux.latest/artifacts/public%2Fbuild%2Fqt6_linux.tar.xz -o /opt/taqt.tar.xz
-          tar -xf /opt/taqt.tar.xz
+          wget https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/mozillavpn.v2.mozillavpn.cache.level-3.toolchains.v3.qt-linux.latest/artifacts/public%2Fbuild%2Fqt6_linux.tar.xz -O /opt/qt.tar.xz
+          tar -xf /opt/qt.tar.xz -C /opt
+          ls /opt/
 
       - name: Clone repository
         uses: actions/checkout@v3

--- a/.github/workflows/test_lottie.yaml
+++ b/.github/workflows/test_lottie.yaml
@@ -19,14 +19,12 @@ jobs:
     runs-on: ubuntu-22.04
     name: Run Lottie tests on Linux
     steps:
+      - name: Clone repository
+        uses: actions/checkout@v3
       - name: Install Linux packages
         run: |
           sudo apt-get update
           sudo apt-get install -y $(./scripts/linux/getdeps.py -a linux/debian/control)
-
-      - name: Clone repository
-        uses: actions/checkout@v3
-
       - name: Cache grcov
         id: cache-grcov
         uses: actions/cache@v3

--- a/.github/workflows/test_lottie.yaml
+++ b/.github/workflows/test_lottie.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Install Linux packages
         run: |
           sudo apt update
-          sudo apt install git libgl-dev libegl-dev clang-10 liboath-dev python3 xz-utils -y
+          sudo apt install git libgl-dev libegl-dev clang-10 liboath-dev python3 xz-utils libbrotli-dev brotli -y
           wget https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/mozillavpn.v2.mozillavpn.cache.level-3.toolchains.v3.qt-linux.latest/artifacts/public%2Fbuild%2Fqt6_linux.tar.xz -O /opt/qt.tar.xz
           tar -xf /opt/qt.tar.xz -C /opt
           ls /opt/

--- a/.github/workflows/test_lottie.yaml
+++ b/.github/workflows/test_lottie.yaml
@@ -50,7 +50,6 @@ jobs:
         run: |
           mkdir -p build
           export PATH=/opt/qt_dist/bin/:$PATH
-          export LD_LIBRARY_PATH=/opt/qt_dist/lib/:$LD_LIBRARY_PATH
           mkdir -p /usr/lib/x86_64-linux-gnu/
           cp  /opt/qt_dist/lib/*.so /usr/lib/x86_64-linux-gnu/
           /opt/qt_dist/bin/qt-cmake -S lottie -B $(pwd)/build -DBUILD_TESTING=ON \

--- a/.github/workflows/translations.yaml
+++ b/.github/workflows/translations.yaml
@@ -18,20 +18,19 @@ concurrency:
 jobs:
   translations:
     name: Translations
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       QTVERSION: 6.2.4
 
     steps:
       - name: Clone repository
         uses: actions/checkout@v3
-        with:
-          fetch-depth: '0'
-
-      - name: Install Qt
+        with: 
+          submodules: 'true'
+      - name: Install Linux packages
         run: |
-          python3 -m pip install aqtinstall
-          python3 -m aqt install-qt -O /opt linux desktop $QTVERSION
+          sudo apt-get update
+          sudo apt-get install -y $(./scripts/linux/getdeps.py -a linux/debian/control)
 
       - name: Install python dependencies
         run: |
@@ -39,7 +38,6 @@ jobs:
 
       - name: Generating translations
         run: |
-          export PATH=/opt/$QTVERSION/gcc_64/bin:$PATH
           ./scripts/utils/generate_ts.sh
 
       - name: Uploading


### PR DESCRIPTION
## Description
AQT has been brittle a bit lately. 
Let's switch to using the normal apt-packages, like we do on the unit-test tasks.
