### PR TITLE
VPN-4832: Prevent task that shows Crash Reporting Screen from being canceled

### DIFF
--- a/src/shared/tasks/sentry/tasksentry.h
+++ b/src/shared/tasks/sentry/tasksentry.h
@@ -24,7 +24,9 @@ class TaskSentry final : public Task {
 
   // Reschedulable because user needs to be prompted always to send crash
   // reports
-  DeletePolicy deletePolicy() const override { return DeletePolicy::Reschedulable; }
+  DeletePolicy deletePolicy() const override {
+    return DeletePolicy::Reschedulable;
+  }
 
   enum ContentType { Unknown, Ping, CrashReport };
   Q_ENUM(ContentType);

--- a/src/shared/tasks/sentry/tasksentry.h
+++ b/src/shared/tasks/sentry/tasksentry.h
@@ -11,6 +11,8 @@
 
 #include "task.h"
 
+// Task to get user consent and send crash report to
+// Sentry (https://github.com/getsentry/sentry-native)
 class TaskSentry final : public Task {
   Q_DISABLE_COPY_MOVE(TaskSentry)
 
@@ -19,6 +21,10 @@ class TaskSentry final : public Task {
   ~TaskSentry();
 
   void run() override;
+
+  // NonDeletable because user needs to be prompted always to send crash
+  // reports
+  DeletePolicy deletePolicy() const override { return NonDeletable; }
 
   enum ContentType { Unknown, Ping, CrashReport };
   Q_ENUM(ContentType);

--- a/src/shared/tasks/sentry/tasksentry.h
+++ b/src/shared/tasks/sentry/tasksentry.h
@@ -22,9 +22,9 @@ class TaskSentry final : public Task {
 
   void run() override;
 
-  // NonDeletable because user needs to be prompted always to send crash
+  // Reschedulable because user needs to be prompted always to send crash
   // reports
-  DeletePolicy deletePolicy() const override { return NonDeletable; }
+  DeletePolicy deletePolicy() const override { return DeletePolicy::Reschedulable; }
 
   enum ContentType { Unknown, Ping, CrashReport };
   Q_ENUM(ContentType);


### PR DESCRIPTION
## Description

The VPN app uses SentryAdapter to check if there was a previous crash report. If so, it schedules a TaskSentry task to show the Crash Reporting screen, to get user consent and send the crash to Sentry. If 'Connect VPN on Startup' was set in App Preferences, the TaskSentry task was deleted when a high priority event like VPN tunnel activation occurred during app startup. Prevent this by changing TaskSentry's DeletePolicy to Reschedulable, so that TaskScheduler reschedules it after a high priority event, instead of deleting it.

## Reference

GitHub issue [6943](https://github.com/mozilla-mobile/mozilla-vpn-client/issues/6943), [VPN-4832](https://mozilla-hub.atlassian.net/browse/VPN-4832)

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-4832]: https://mozilla-hub.atlassian.net/browse/VPN-4832?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ