### PR TITLE
Chore: Fix Wasm_Chrome workflow

### DIFF
--- a/tools/wasm_chrome/generate_branch_file.ts
+++ b/tools/wasm_chrome/generate_branch_file.ts
@@ -11,7 +11,7 @@
  * api calls to github and also allow us to filter :)
  */
 import { parse } from "https://deno.land/std/flags/mod.ts";
-import { Octokit } from "https://cdn.skypack.dev/@octokit/core";
+import { Octokit } from "https://esm.sh/@octokit/core";
 import { getGithubPaginatedData } from "./helpers.mjs";
 
 interface Commit {


### PR DESCRIPTION
## Description
Recently the Wasm_Chrome workflow has been failing on Github CI due to a missing package `Octokit`. Some quick googling suggests that we are loading it from the wrong URL (see [here](https://github.com/octokit/octokit.js) for the recommended way to import it).

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
