### PR TITLE
VPN-4933 - Stop DNSPingSender's UDP socket on idle

### DIFF
--- a/src/apps/vpn/connectionhealth.cpp
+++ b/src/apps/vpn/connectionhealth.cpp
@@ -72,7 +72,7 @@ void ConnectionHealth::startActive(const QString& serverIpv4Gateway,
                                    const QString& deviceIpv4Address) {
   logger.debug() << "ConnectionHealth started";
 
-  if (m_suspended || serverIpv4Gateway.isEmpty() ||
+  if (serverIpv4Gateway.isEmpty() ||
       MozillaVPN::instance()->controller()->state() != Controller::StateOn) {
     return;
   }
@@ -243,20 +243,20 @@ void ConnectionHealth::applicationStateChanged(Qt::ApplicationState state) {
 #else
   switch (state) {
     case Qt::ApplicationState::ApplicationActive:
-      if (m_suspended) {
-        m_suspended = false;
+      if (!m_suspended) return;
 
-        Q_ASSERT(!m_noSignalTimer.isActive());
-        logger.debug() << "Resuming connection check from Suspension";
-        startActive(m_currentGateway, m_deviceAddress);
-      }
+      m_suspended = false;
+      logger.debug() << "Resuming connection check from suspension";
+      connectionStateChanged();
       break;
 
     case Qt::ApplicationState::ApplicationSuspended:
     case Qt::ApplicationState::ApplicationInactive:
     case Qt::ApplicationState::ApplicationHidden:
-      logger.debug() << "Pausing connection for Suspension";
+      if (m_suspended) return;
+
       m_suspended = true;
+      logger.debug() << "Pausing connection for suspension";
       stop();
       break;
   }

--- a/src/apps/vpn/connectionhealth.cpp
+++ b/src/apps/vpn/connectionhealth.cpp
@@ -61,6 +61,8 @@ void ConnectionHealth::stop() {
   m_pingHelper.stop();
   m_noSignalTimer.stop();
   m_healthCheckTimer.stop();
+
+  m_dnsPingSender.stop();
   m_dnsPingTimer.stop();
 
   setStability(Stable);
@@ -80,6 +82,8 @@ void ConnectionHealth::startActive(const QString& serverIpv4Gateway,
   m_pingHelper.start(serverIpv4Gateway, deviceIpv4Address);
   m_noSignalTimer.start(PING_TIME_NOSIGNAL_SEC * 1000);
   m_healthCheckTimer.start(PING_TIME_UNSTABLE_SEC * 1000);
+
+  m_dnsPingSender.stop();
   m_dnsPingTimer.stop();
 }
 
@@ -94,6 +98,8 @@ void ConnectionHealth::startIdle() {
   m_dnsPingSequence = QRandomGenerator::global()->bounded(UINT16_MAX);
   m_dnsPingInitialized = false;
   m_dnsPingLatency = PING_TIME_UNSTABLE_SEC * 1000;
+
+  m_dnsPingSender.start();
   m_dnsPingTimer.start(PING_INTERVAL_IDLE_SEC * 1000);
 
   // Send an initial ping right away.

--- a/src/apps/vpn/dnspingsender.h
+++ b/src/apps/vpn/dnspingsender.h
@@ -9,7 +9,6 @@
 
 #include "pingsender.h"
 
-
 class DnsPingSender final : public PingSender {
   Q_OBJECT
   Q_DISABLE_COPY_MOVE(DnsPingSender)

--- a/src/apps/vpn/dnspingsender.h
+++ b/src/apps/vpn/dnspingsender.h
@@ -9,6 +9,8 @@
 
 #include "pingsender.h"
 
+class QThread;
+
 class DnsPingSender final : public PingSender {
   Q_OBJECT
   Q_DISABLE_COPY_MOVE(DnsPingSender)
@@ -19,11 +21,16 @@ class DnsPingSender final : public PingSender {
 
   void sendPing(const QHostAddress& dest, quint16 sequence) override;
 
+  void start();
+  void stop() { m_socket.close(); }
+
  private:
   void readData();
 
  private:
   QUdpSocket m_socket;
+  QThread* m_thread = nullptr;
+  QHostAddress m_source;
 };
 
 #endif  // DNSPINGSENDER_H

--- a/src/apps/vpn/dnspingsender.h
+++ b/src/apps/vpn/dnspingsender.h
@@ -9,7 +9,6 @@
 
 #include "pingsender.h"
 
-class QThread;
 
 class DnsPingSender final : public PingSender {
   Q_OBJECT


### PR DESCRIPTION
I believe the issue described in VPN-4933 was happening due to the UDP socket going into an error state after the application goes inactive, either by being backgrounded or by putting the device to sleep. That error state plus a bug in Qt's code that leads to an infinite retry loop for the kernal call `sendmsg` was causing the crash.

Going back to the VPN app. In the very specific case of 

1. Turning the VPN on, through the UI
2. Going inactive
3. Turning the VPN off, through the UI

The UDP socket would go into an error state, which could be fixed by a restart of the socket. The error state would cause every call to `writeDatagram` to result in a `NetworkError`. It's important context that `NetworkError` is [the fallback error type for `writeDatagram`](https://codebrowser.dev/qt6/qtbase/src/network/socket/qnativesocketengine_unix.cpp.html#1124). Since a restart addresses it, likely the error was something else.

This error state is not completely unexpected, in [Technical Note TN2277](https://developer.apple.com/library/archive/technotes/tn2277/_index.html) Apple says:

> If the system suspends your app and then, later on, reclaims the resources from underneath your listening socket, your app will no longer be listening for connections, even after it has been resumed. The app may or may not be notified of this, depending on how it manages the listening socket. It's generally easier to avoid this problem entirely by closing the listening socket when the app is in the background.

Instead of restarting the socket when restarting the connection health DNSPingTimer, I thought it made more sense to  instead stop the socket when the timer is off and restart it once it's turned back on.

I also fixed a bug here, that was preventing the connection health to be turned back on when coming back from inactivity.

