### PR TITLE
VPN-4038: Add metrics to daemon

### DIFF
--- a/src/apps/vpn/platforms/ios/ioscontroller.swift
+++ b/src/apps/vpn/platforms/ios/ioscontroller.swift
@@ -207,7 +207,7 @@ public class IOSControllerImpl : NSObject {
                             IOSControllerImpl.logger.info(message: "Sending new message \(message)")
                             try TunnelManager.session?.sendProviderMessage(message.encode()) {_ in return}
                         } else {
-                            try TunnelManager.session?.startTunnel()
+                            try TunnelManager.session?.startTunnel(options: ["source":"app"])
                         }
                     } catch let error {
                         IOSControllerImpl.logger.error(message: "Something went wrong: \(error)")

--- a/src/apps/vpn/platforms/ios/iostunnel.swift
+++ b/src/apps/vpn/platforms/ios/iostunnel.swift
@@ -120,6 +120,12 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
             if self.isSuperDooperFeatureActive {
                 GleanMetrics.Session.daemonSessionEnd.set()
                 GleanMetrics.Pings.shared.daemonsession.submit(reason: .daemonEnd)
+
+                // We are rotating the UUID here as a safety measure. It is rotated
+                // again before the next session start, and we expect to see the
+                // UUID created here in only one ping: The daemon ping with a
+                // "flush" reason, which should contain this UUID and no other
+                // metrics.
                 GleanMetrics.Session.daemonSessionId.generateAndSet()
             }
 

--- a/src/apps/vpn/platforms/ios/iostunnel.swift
+++ b/src/apps/vpn/platforms/ios/iostunnel.swift
@@ -49,14 +49,11 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
     }
 
     override func startTunnel(options: [String: NSObject]?, completionHandler: @escaping (Error?) -> Void) {
-        let activationAttemptId = options?["activationAttemptId"] as? String
-        let errorNotifier = ErrorNotifier(activationAttemptId: activationAttemptId)
-
-        logger.info(message: "Starting tunnel from the " + (activationAttemptId == nil ? "OS directly, rather than the app" : "app"))
+        let isSourceApp = ((options?["source"] as? String) ?? "") == "app"
+        logger.info(message: "Starting tunnel from the " + (isSourceApp ? "app" : "OS directly, rather than the app"))
 
         guard let tunnelProviderProtocol = self.protocolConfiguration as? NETunnelProviderProtocol,
               let tunnelConfiguration = tunnelProviderProtocol.asTunnelConfiguration() else {
-            errorNotifier.notify(PacketTunnelProviderError.savedProtocolConfigurationIsInvalid)
             completionHandler(PacketTunnelProviderError.savedProtocolConfigurationIsInvalid)
             return
         }
@@ -73,6 +70,9 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
                 self.logger.info(message: "Tunnel interface is \(interfaceName)")
 
                 if self.isSuperDooperFeatureActive {
+                    GleanMetrics.Session.daemonSessionSource.set(isSourceApp ? "app" : "system settings")
+                    GleanMetrics.Session.daemonSessionId.generateAndSet()
+                    GleanMetrics.Session.daemonSessionStart.set()
                     GleanMetrics.Pings.shared.daemonsession.submit(reason: .daemonStart)
                 }
 
@@ -83,24 +83,20 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
             switch adapterError {
             case .cannotLocateTunnelFileDescriptor:
                 self.logger.error(message: "Starting tunnel failed: could not determine file descriptor")
-                errorNotifier.notify(PacketTunnelProviderError.couldNotDetermineFileDescriptor)
                 completionHandler(PacketTunnelProviderError.couldNotDetermineFileDescriptor)
 
             case .dnsResolution(let dnsErrors):
                 let hostnamesWithDnsResolutionFailure = dnsErrors.map { $0.address }
                     .joined(separator: ", ")
                 self.logger.error(message: "DNS resolution failed for the following hostnames: \(hostnamesWithDnsResolutionFailure)")
-                errorNotifier.notify(PacketTunnelProviderError.dnsResolutionFailure)
                 completionHandler(PacketTunnelProviderError.dnsResolutionFailure)
 
             case .setNetworkSettings(let error):
                 self.logger.error(message: "Starting tunnel failed with setTunnelNetworkSettings returning \(error.localizedDescription)")
-                errorNotifier.notify(PacketTunnelProviderError.couldNotSetNetworkSettings)
                 completionHandler(PacketTunnelProviderError.couldNotSetNetworkSettings)
 
             case .startWireGuardBackend(let errorCode):
                 self.logger.error(message: "Starting tunnel failed with wgTurnOn returning \(errorCode)")
-                errorNotifier.notify(PacketTunnelProviderError.couldNotStartBackend)
                 completionHandler(PacketTunnelProviderError.couldNotStartBackend)
 
             case .invalidState:
@@ -116,7 +112,9 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         adapter.stop { error in
             ErrorNotifier.removeLastErrorFile()
             if self.isSuperDooperFeatureActive {
+                GleanMetrics.Session.daemonSessionEnd.set()
                 GleanMetrics.Pings.shared.daemonsession.submit(reason: .daemonEnd)
+                GleanMetrics.Session.daemonSessionId.generateAndSet()
             }
 
             if let error = error {

--- a/src/apps/vpn/telemetry/metrics.yaml
+++ b/src/apps/vpn/telemetry/metrics.yaml
@@ -97,10 +97,10 @@ session:
     type: uuid
     lifetime: user
     description: |
-      A unique identifier for each session, shared with the daemon instance
-      of Glean. This is used to connect unique VPN sessions across pings, and
-      as a safety check on edge cases of VPN activation/deactivation, such as
-      a session being started/ended from mobile system settings.
+      A unique identifier for each session. This is used to connect unique VPN
+      sessions across pings, and as a safety check on edge cases of VPN
+      activation/deactivation, such as a session being started/ended from mobile
+      system settings.
     bugs:
       - https://mozilla-hub.atlassian.net/browse/VPN-4064
     data_reviews:
@@ -174,6 +174,79 @@ session:
       - https://github.com/mozilla-mobile/mozilla-vpn-client/pull/6783#pullrequestreview-1407551157
     data_sensitivity:
       - technical
+    notification_emails:
+      - mcleinman@mozilla.com
+      - vpn-telemetry@mozilla.com
+    expires: never
+
+daemon_session_start:
+    type: datetime
+    description: |
+      (Mobile-only) The time the user starts a VPN session from the daemon or network extension
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/VPN-4038
+    data_reviews:
+      - ADD THIS IN AFTER REVIEW
+    send_in_pings:
+      - daemonsession
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - mcleinman@mozilla.com
+      - vpn-telemetry@mozilla.com
+    expires: never
+
+  daemon_session_end:
+    type: datetime
+    description: |
+      (Mobile-only) The time the user ends a VPN session from the daemon or network extension
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/VPN-4038
+    data_reviews:
+      - ADD THIS IN AFTER REVIEW
+    send_in_pings:
+      - daemonsession
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - mcleinman@mozilla.com
+      - vpn-telemetry@mozilla.com
+    expires: never
+
+  daemon_session_id:
+    type: uuid
+    lifetime: user
+    description: |
+      (Mobile-only) A unique identifier for each session. This is used to connect
+      unique VPN sessions across pings, and as a safety check on edge cases of VPN
+      activation/deactivation, such as a session being started/ended from mobile
+      system settings.
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/VPN-4038
+    data_reviews:
+      - ADD THIS IN AFTER REVIEW
+    send_in_pings:
+      - daemonsession
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - mcleinman@mozilla.com
+      - vpn-telemetry@mozilla.com
+    expires: never
+
+daemon_session_source:
+    type: string
+    description: |
+      (Mobile-only) Where the session started from. Should be "app", "system settings",
+      or "autostart on boot".
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/VPN-4038
+    data_reviews:
+      - ADD THIS IN AFTER REVIEW
+    send_in_pings:
+      - daemonsession
+    data_sensitivity:
+      - interaction
     notification_emails:
       - mcleinman@mozilla.com
       - vpn-telemetry@mozilla.com

--- a/src/apps/vpn/telemetry/metrics.yaml
+++ b/src/apps/vpn/telemetry/metrics.yaml
@@ -186,7 +186,7 @@ session:
     bugs:
       - https://mozilla-hub.atlassian.net/browse/VPN-4038
     data_reviews:
-      - ADD THIS IN AFTER REVIEW
+      - https://github.com/mozilla-mobile/mozilla-vpn-client/pull/7513#pullrequestreview-1529674762
     send_in_pings:
       - daemonsession
     data_sensitivity:
@@ -203,7 +203,7 @@ session:
     bugs:
       - https://mozilla-hub.atlassian.net/browse/VPN-4038
     data_reviews:
-      - ADD THIS IN AFTER REVIEW
+      - https://github.com/mozilla-mobile/mozilla-vpn-client/pull/7513#pullrequestreview-1529674762
     send_in_pings:
       - daemonsession
     data_sensitivity:
@@ -224,7 +224,7 @@ session:
     bugs:
       - https://mozilla-hub.atlassian.net/browse/VPN-4038
     data_reviews:
-      - ADD THIS IN AFTER REVIEW
+      - https://github.com/mozilla-mobile/mozilla-vpn-client/pull/7513#pullrequestreview-1529674762
     send_in_pings:
       - daemonsession
     data_sensitivity:
@@ -242,7 +242,7 @@ session:
     bugs:
       - https://mozilla-hub.atlassian.net/browse/VPN-4038
     data_reviews:
-      - ADD THIS IN AFTER REVIEW
+      - https://github.com/mozilla-mobile/mozilla-vpn-client/pull/7513#pullrequestreview-1529674762
     send_in_pings:
       - daemonsession
     data_sensitivity:

--- a/src/apps/vpn/telemetry/metrics.yaml
+++ b/src/apps/vpn/telemetry/metrics.yaml
@@ -179,7 +179,7 @@ session:
       - vpn-telemetry@mozilla.com
     expires: never
 
-daemon_session_start:
+  daemon_session_start:
     type: datetime
     description: |
       (Mobile-only) The time the user starts a VPN session from the daemon or network extension
@@ -234,7 +234,7 @@ daemon_session_start:
       - vpn-telemetry@mozilla.com
     expires: never
 
-daemon_session_source:
+  daemon_session_source:
     type: string
     description: |
       (Mobile-only) Where the session started from. Should be "app", "system settings",


### PR DESCRIPTION
## Description

This is the iOS-side work for VPN-4038. A separate PR will be put up for Android.

This adds in the iOS network extension metrics. 

Additionally, `activationAttemptId` was no longer sent to `startTunnel` as an option, and so we had an erroneous log line regarding the source of the VPN activation. This bug was filed as https://mozilla-hub.atlassian.net/browse/VPN-5053, and is fixed here.

To test this, at the end of the `init` of `iostunnel.swift`, add one or both of these lines:
```
Glean.shared.setDebugViewTag("VPNTest") // if you want to check in the Glean debug pings viewer
Glean.shared.setLogPings(true) // if you want to test in app logs
```

## Reference

https://mozilla-hub.atlassian.net/browse/VPN-4038

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
