### PR TITLE
Remove build-windows/clang-cl from release CI

### DIFF
--- a/taskcluster/ci/build/windows.yml
+++ b/taskcluster/ci/build/windows.yml
@@ -53,18 +53,3 @@ windows/opt:
             "3":
                 - secrets:get:project/mozillavpn/tokens
             default: []
-
-windows/clang-cl:
-    description: "Windows Build"
-    treeherder:
-        symbol: B(clang-cl)
-    scopes:
-        by-level:
-            "3":
-                - secrets:get:project/mozillavpn/tokens
-            default: []
-    run:
-        using: run-task
-        cwd: '{checkout}'
-        exec-with: powershell
-        command: taskcluster/scripts/build/windows_clang_cl.ps1


### PR DESCRIPTION
## Description

Removes unused and failing `clang-cl` from the release branch.

## Reference

VPN-5227

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
