### PR TITLE
Chore, pause dependabot for /tools

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -73,19 +73,19 @@ updates:
     schedule:
       interval: "weekly"
   # Inspector
-  - package-ecosystem: "npm"
-    directory: "/tools/inspector"
-    schedule:
-      interval: "weekly"
-    labels:
-      - "dependencies"
+  #- package-ecosystem: "npm"
+  #  directory: "/tools/inspector"
+  #  schedule:
+  #    interval: "weekly"
+  #  labels:
+  #    - "dependencies"
   # Language Localizer
-  - package-ecosystem: "npm"
-    directory: "/tools/languagelocalizer"
-    schedule:
-      interval: "monthly"
-    labels:
-      - "dependencies"
+  #- package-ecosystem: "npm"
+  #  directory: "/tools/languagelocalizer"
+  #  schedule:
+  #    interval: "monthly"
+  #  labels:
+  #    - "dependencies"
   # Glean/Rust
   - package-ecosystem: "cargo"
     directory: "/vpnglean"


### PR DESCRIPTION
## Description

We get quite a **lot** of dependabot updates. 
The flood of updates in `/tools` does quite overshadow the amount of updates we get from actual client code. 

Given nothing in `tools` is shipped to users, has no test coverage and is essentially only for us - we only risk breaking our workflows, and flooding important dependencies updates in a sea of small node tools. 
Note: this does not disable dependabot dependency-security reporting 
