### PR TITLE
[Sentry] Print where to find the crashreport

### DIFF
--- a/src/shared/tasks/sentry/tasksentry.cpp
+++ b/src/shared/tasks/sentry/tasksentry.cpp
@@ -94,7 +94,7 @@ void TaskSentry::sendRequest() {
             Q_UNUSED(data);
             // Let's note the event id in the logs, so we can
             // connect customer support logs with sentry :)
-            logger.debug() << "Sentry sent event (" << m_eventID << ")";
+            logger.debug() << "Sentry reported crash: << https://mozilla.sentry.io/discover/vpn-client:"<< m_eventID;
             emit completed();
           });
 }

--- a/src/shared/tasks/sentry/tasksentry.cpp
+++ b/src/shared/tasks/sentry/tasksentry.cpp
@@ -94,7 +94,9 @@ void TaskSentry::sendRequest() {
             Q_UNUSED(data);
             // Let's note the event id in the logs, so we can
             // connect customer support logs with sentry :)
-            logger.debug() << "Sentry reported crash: << https://mozilla.sentry.io/discover/vpn-client:"<< m_eventID;
+            logger.debug() << "Sentry reported crash: << "
+                              "https://mozilla.sentry.io/discover/vpn-client:"
+                           << m_eventID;
             emit completed();
           });
 }


### PR DESCRIPTION
## Description

Small nit: right now we only record the event id. This makes lookup of a sentry report possible, but you need to remember where to go. 
Let's just print the url for the report, so everony can quickly lookup what we collected. 
