### PR TITLE
VPN-5008 Remove ability to deactivate connection via web extension

### DIFF
--- a/src/apps/vpn/server/serverconnection.cpp
+++ b/src/apps/vpn/server/serverconnection.cpp
@@ -136,12 +136,6 @@ static QList<RequestType> s_types{
                   return QJsonObject();
                 }},
 
-    RequestType{"deactivate",
-                [](const QJsonObject&) {
-                  MozillaVPN::instance()->deactivate();
-                  return QJsonObject();
-                }},
-
     RequestType{"servers",
                 [](const QJsonObject&) {
                   QJsonObject servers;


### PR DESCRIPTION
## Description

This removes the ability to deactivate the vpn via :8754. 
This can be verified by running `perl -e 'print pack("I", 18) . "{\"t\":\"deactivate\"}"' | nc -v 127.0.0.1 8754` which now returns `{"t":"invalidRequest"}`. 

## Reference
VPN-5008

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
