### PR TITLE
[macOS]Mozilla VPN app crashes when entering specific symbols using Czech keyboard

### DIFF
--- a/nebula/ui/components/forms/MZTextField.qml
+++ b/nebula/ui/components/forms/MZTextField.qml
@@ -56,8 +56,8 @@ TextField {
     onTextChanged: {
         if (Qt.platform.os === "osx") {
             textField.focusReasonA11y = true
-            textField.focus = false;
-            textField.forceActiveFocus();
+            Accessible.focused = false
+            Accessible.focused = true
             textField.focusReasonA11y = false
         }
     }


### PR DESCRIPTION
## Description

VPN client crashes if we enter a special character in various keyboards such as Czech and German on OSX only due to the check `if (Qt.platform.os === "osx")` here. This change was causing an infinite loop when QT autocompletes the special character, causing a crash.

## Reference

    https://mozilla-hub.atlassian.net/browse/VPN-5132

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
