### PR TITLE
VPN-5159/5160: Fix systemd service launch on installation

### DIFF
--- a/linux/debian/mozillavpn.postinst
+++ b/linux/debian/mozillavpn.postinst
@@ -5,4 +5,5 @@ action="$1"
 if [ "$action" = "configure" ]; then
     setcap cap_net_raw+ep /usr/bin/mozillavpn
 fi
-exit 0
+
+#DEBHELPER#

--- a/linux/debian/mozillavpn.postrm
+++ b/linux/debian/mozillavpn.postrm
@@ -4,4 +4,5 @@ remove)
   killall -q mozillavpn || true
   ;;
 esac
-exit 0
+
+#DEBHELPER#

--- a/linux/debian/mozillavpn.preinst
+++ b/linux/debian/mozillavpn.preinst
@@ -5,3 +5,5 @@ if [ "$action" = "upgrade" ]; then
     killall -q mozillavpn || true
   fi
 fi
+
+#DEBHELPER#


### PR DESCRIPTION
## Description
It seems that when we create a custom Debian package maintainer script, it replaces the automatically generated scripts via debhelper. However, we can restore the intended debhelper behavior by adding the subsitution expression `#DEBHELPER#` back into the script. See [here](https://manpages.debian.org/testing/debhelper/dh_installdeb.1.en.html) from some breadcrumbs on the maintainer script substitution.

## Reference
Github issue #7403 ([VPN-5159](https://mozilla-hub.atlassian.net/browse/VPN-5159))
Github issue #7404 ([VPN-5160](https://mozilla-hub.atlassian.net/browse/VPN-5160))

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed


[VPN-5159]: https://mozilla-hub.atlassian.net/browse/VPN-5159?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[VPN-5160]: https://mozilla-hub.atlassian.net/browse/VPN-5160?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ