### PR TITLE
VPN-5132 [macOS] Mozilla VPN app crashes when entering specific symbols using Czech keyboard

### DIFF
--- a/nebula/ui/components/forms/MZTextArea.qml
+++ b/nebula/ui/components/forms/MZTextArea.qml
@@ -76,8 +76,8 @@ Item {
                 // fails to narrate any accessible content and action. After regaining
                 // active focus the screen reader keeps working as expected.
                 if (Qt.platform.os === "osx") {
-                    textArea.focus = false;
-                    textArea.forceActiveFocus();
+                    Accessible.focused = false
+                    Accessible.focused = true
                 }
             }
 


### PR DESCRIPTION
## Description
Cherry pick https://github.com/mozilla-mobile/mozilla-vpn-client/pull/7558 to release 2.16.

## Reference

    https://mozilla-hub.atlassian.net/browse/VPN-5132

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
