### PR TITLE
VPN-5222: Fix signal for VPN connection metrics on iOS/Android

### DIFF
--- a/src/apps/vpn/controller.cpp
+++ b/src/apps/vpn/controller.cpp
@@ -545,6 +545,8 @@ void Controller::connected(const QString& pubkey,
   // We have succesfully completed all pending connections.
   logger.debug() << "Connected from state:" << m_state;
   setState(StateOn);
+  emit newConnectionSucceeded();
+
   // In case the Controller provided a valid timestamp that
   // should be used.
   if (connectionTimestamp.isValid()) {

--- a/src/apps/vpn/controller.h
+++ b/src/apps/vpn/controller.h
@@ -159,6 +159,7 @@ class Controller final : public QObject, public LogSerializer {
   void activationBlockedForCaptivePortal();
   void handshakeFailed(const QString& serverHostname);
   void controllerDisconnected();
+  void newConnectionSucceeded();
 
 #ifdef MZ_DUMMY
   void currentServerChanged();

--- a/src/apps/vpn/telemetry.cpp
+++ b/src/apps/vpn/telemetry.cpp
@@ -200,26 +200,28 @@ void Telemetry::initialize() {
             ._sku = PurchaseHandler::instance()->currentSKU()});
   });
 
-  connect(controller, &Controller::stateChanged, this, [this, controller]() {
-    if (Feature::get(Feature::Feature_superDooperMetrics)->isSupported()) {
-      if (controller->state() == Controller::StateOn) {
-        mozilla::glean_pings::Vpnsession.submit("flush");
+  connect(
+      controller, &Controller::newConnectionSucceeded, this,
+      [this, controller]() {
+        if (Feature::get(Feature::Feature_superDooperMetrics)->isSupported()) {
+          if (controller->state() == Controller::StateOn) {
+            mozilla::glean_pings::Vpnsession.submit("flush");
 
-        mozilla::glean::session::session_id.generateAndSet();
-        mozilla::glean::session::session_start.set();
-        mozilla::glean::session::dns_type.set(DNSHelper::getDNSType());
-        mozilla::glean::session::apps_excluded.set(
-            AppPermission::instance()->disabledAppCount());
+            mozilla::glean::session::session_id.generateAndSet();
+            mozilla::glean::session::session_start.set();
+            mozilla::glean::session::dns_type.set(DNSHelper::getDNSType());
+            mozilla::glean::session::apps_excluded.set(
+                AppPermission::instance()->disabledAppCount());
 
-        mozilla::glean_pings::Vpnsession.submit("start");
-        m_vpnSessionPingTimer.start(
-            (SettingsHolder::instance()->vpnSessionPingTimeoutDebug()
-                 ? VPNSESSION_PING_TIMER_DEBUG_SEC
-                 : VPNSESSION_PING_TIMER_SEC) *
-            1000);
-      }
-    }
-  });
+            mozilla::glean_pings::Vpnsession.submit("start");
+            m_vpnSessionPingTimer.start(
+                (SettingsHolder::instance()->vpnSessionPingTimeoutDebug()
+                     ? VPNSESSION_PING_TIMER_DEBUG_SEC
+                     : VPNSESSION_PING_TIMER_SEC) *
+                1000);
+          }
+        }
+      });
 
   connect(
       controller, &Controller::controllerDisconnected, this,


### PR DESCRIPTION
## Description

We were sending an extra set of connection start pings when the mobile apps launched with an already-active VPN. This fixes the bug. See detailed diagnosis on the ticket.

To test, you'll need to add a line like `Glean.shared.setDebugViewTag("MattVPN")` in `iosgleanbridge.swift` after Glean is initialized (or before, I don't believe it matters). Alternatively, you could rely on an environment variable to test this, but then you must be sure to re-launch the app from xcode, and not on the device (as the re-run on the device won't have the environment var).

## Reference

https://mozilla-hub.atlassian.net/browse/VPN-5222

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
