### PR TITLE
Refactor some Swift in iOS Tunnel Manager

### DIFF
--- a/src/apps/vpn/platforms/ios/iostunnelmanager.swift
+++ b/src/apps/vpn/platforms/ios/iostunnelmanager.swift
@@ -5,6 +5,10 @@
 import Foundation
 import NetworkExtension
 
+class TunnelError: Error {
+
+}
+
 // Singleton that manages the VPN tunnel and exposes functions
 // for interacting with it.
 class TunnelManager {
@@ -32,13 +36,14 @@ class TunnelManager {
         
         logger.debug(message: "Attempting to initialize VPN tunnel")
         
-        TunnelManager.instance.setTunnel { 
-            if let tunnel = TunnelManager.instance.tunnel {
-                logger.info(message: "Tunnel initialized succesfully")
-                return completionHandler(nil, tunnel)
-            } else {
-                fatalError("IMPOSSIBLE: Attempted to set the VPN tunnel, but didn't get an error nor a tunnel.")
+        TunnelManager.instance.setTunnel {
+            guard let tunnel = TunnelManager.instance.tunnel else {
+                completionHandler(TunnelError(), nil)
+                return
             }
+
+            logger.info(message: "Tunnel initialized succesfully")
+            completionHandler(nil, tunnel)
         }
     }
     

--- a/src/apps/vpn/platforms/ios/iostunnelmanager.swift
+++ b/src/apps/vpn/platforms/ios/iostunnelmanager.swift
@@ -14,22 +14,14 @@ class TunnelManager {
 
     private static let instance = TunnelManager()
 
-    private var tunnel: Result<NETunnelProviderManager, Error>?
+    private var tunnel: NETunnelProviderManager?
     
     static var session: NETunnelProviderSession? {
-        get {
-            return withTunnel { tunnel in
-                return (tunnel.connection as? NETunnelProviderSession)!
-            } as! NETunnelProviderSession?
-        }
+            return TunnelManager.instance.tunnel?.connection as? NETunnelProviderSession
     }
     
     static var protocolConfiguration: NETunnelProviderProtocol? {
-        get {
-            return withTunnel { tunnel in
-                return (tunnel.protocolConfiguration as? NETunnelProviderProtocol)!
-            } as! NETunnelProviderProtocol?
-        }
+        return TunnelManager.instance.tunnel?.protocolConfiguration as? NETunnelProviderProtocol
     }
 
     private init() {}
@@ -41,39 +33,33 @@ class TunnelManager {
         logger.debug(message: "Attempting to initialize VPN tunnel")
         
         TunnelManager.instance.setTunnel { 
-            switch TunnelManager.instance.tunnel {
-            case .failure(let error):
-                logger.error(message: "Error initializing tunnel: \(error).")
-                return completionHandler(error, nil)
-            case .success(let tunnel):
+            if let tunnel = TunnelManager.instance.tunnel {
                 logger.info(message: "Tunnel initialized succesfully")
                 return completionHandler(nil, tunnel)
-            case .none:
+            } else {
                 fatalError("IMPOSSIBLE: Attempted to set the VPN tunnel, but didn't get an error nor a tunnel.")
             }
-            
-        };
+        }
     }
     
     static func withTunnel(_ f: (_ tunnel: NETunnelProviderManager) throws -> Any) -> Any? {
-        switch TunnelManager.instance.tunnel {
-        case .success(let tunnel):
-            do {
-                let result = try f(tunnel)
-                return result
-            } catch {
-                logger.error(message: "Error executing callback: \(error).")
-                return nil
-            }
-        case .failure, .none:
+        guard let tunnel = TunnelManager.instance.tunnel else {
             logger.error(message: "Attempted to use the VPN tunnel, but it's not available.")
+            return nil
+        }
+
+        do {
+            let result = try f(tunnel)
+            return result
+        } catch {
+            logger.error(message: "Error executing callback: \(error).")
             return nil
         }
     }
 
     private func setTunnel(_ completionHandler: @escaping () -> Void) {
         NETunnelProviderManager.loadAllFromPreferences { [weak self] managers, error in
-            if self == nil {
+            guard let self = self else {
                 TunnelManager.logger.debug(message: "We are shutting down.")
                 completionHandler();
                 return
@@ -88,17 +74,16 @@ class TunnelManager {
             let nsManagers = managers ?? []
             TunnelManager.logger.debug(message: "We have received \(nsManagers.count) managers.")
 
-            let tunnel = nsManagers.first(where: TunnelManager.isOurManager(_:))
-            if tunnel == nil {
+            guard let tunnel = nsManagers.first(where: TunnelManager.isOurManager(_:)) else {
                 TunnelManager.logger.debug(message: "Creating the tunnel")
-                self!.tunnel = .success(NETunnelProviderManager())
+                self.tunnel = NETunnelProviderManager()
                 completionHandler();
                 return
             }
 
             TunnelManager.logger.debug(message: "Tunnel already exists")
-            self!.tunnel = .success(tunnel!)
-            completionHandler();
+            self.tunnel = tunnel
+            completionHandler()
         }
     }
 
@@ -111,17 +96,17 @@ class TunnelManager {
             return false
         }
 
-        if (tunnelProto.providerBundleIdentifier == nil) {
+        guard let bundleIdentifier = tunnelProto.providerBundleIdentifier else {
             logger.debug(message: "Ignoring manager because the bundle identifier is null.")
             return false
         }
 
-        if (tunnelProto.providerBundleIdentifier != vpnBundleId) {
+        if (bundleIdentifier != vpnBundleId) {
             logger.debug(message: "Ignoring manager because the bundle identifier doesn't match.")
             return false;
         }
 
-        logger.debug(message: "Found the manager with the correct bundle identifier: \(tunnelProto.providerBundleIdentifier!)")
+        logger.debug(message: "Found the manager with the correct bundle identifier: \(bundleIdentifier)")
         return true
     }
 }


### PR DESCRIPTION
## Description

When the [IOSTunnelManager was added](https://github.com/mozilla-mobile/mozilla-vpn-client/pull/7085/), I talked with Bea about putting up a follow up PR to refactor it to be a bit more Swift-y. 

This PR:
- Removes a bunch of force unwraps
- Makes it a bit more Swift-y with optional chaining, additional guard checks, etc.
- Removes some unnecessary small things (semicolons, the `get` in the computed vars, the return in front of completion handler)
- It removes a fatal error. The caller deals with the lack of tunnel when an error is returned, so we don't need to crash the app - the caller can deal with this. 
- I didn't see where the failure state for the tunnel was ever used, so I removed it to simplify.

I considered removing the `withTunnel` function, but decided to save that for another time - As of now, it's only used in `IOSControllerImpl`.

## Reference

N/A

## Checklist
    
- [X] My code follows the style guidelines for this project
- [X] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [X] I have performed a self review of my own code
- [X] I have commented my code PARTICULARLY in hard to understand areas
- [X] I have added thorough tests where needed
