### PR TITLE
Use `ListView` for server list to increase performance

### DIFF
--- a/src/apps/vpn/models/servercountrymodel.cpp
+++ b/src/apps/vpn/models/servercountrymodel.cpp
@@ -239,14 +239,16 @@ const QString ServerCountryModel::countryName(
 
 const int ServerCountryModel::indexOfCountryCode(
     const QString& countryCode) const {
-  int i = 0;
-  for (const ServerCountry& country : m_countries) {
-    if (country.code() == countryCode) {
-      return i;
-    }
-    i++;
+  auto it = std::find_if(m_countries.begin(), m_countries.end(),
+                         [&countryCode](const ServerCountry& country) {
+                           return country.code() == countryCode;
+                         });
+
+  if (it != m_countries.end()) {
+    return std::distance(m_countries.begin(), it);
+  } else {
+    return -1;
   }
-  return -1;
 }
 
 void ServerCountryModel::retranslate() {

--- a/src/apps/vpn/models/servercountrymodel.cpp
+++ b/src/apps/vpn/models/servercountrymodel.cpp
@@ -237,6 +237,18 @@ const QString ServerCountryModel::countryName(
   return QString();
 }
 
+const int ServerCountryModel::indexOfCountryCode(
+    const QString& countryCode) const {
+  int i = 0;
+  for (const ServerCountry& country : m_countries) {
+    if (country.code() == countryCode) {
+      return i;
+    }
+    i++;
+  }
+  return -1;
+}
+
 void ServerCountryModel::retranslate() {
   beginResetModel();
   sortCountries();

--- a/src/apps/vpn/models/servercountrymodel.h
+++ b/src/apps/vpn/models/servercountrymodel.h
@@ -44,6 +44,8 @@ class ServerCountryModel final : public QAbstractListModel {
 
   const QString countryName(const QString& countryCode) const;
 
+  Q_INVOKABLE const int indexOfCountryCode(const QString& countryCode) const;
+
   const QHash<QString, ServerCity>& cities() const { return m_cities; }
 
   const QList<ServerCountry>& countries() const { return m_countries; }

--- a/src/apps/vpn/ui/screens/home/ViewServers.qml
+++ b/src/apps/vpn/ui/screens/home/ViewServers.qml
@@ -106,7 +106,6 @@ Item {
                             if (segment.objectName === "tabSingleHop") {
                                 // Do single hop things
                                 menu.title = menu.defaultMenuTitle;
-                                singleHopServerList.centerActiveServer();
                                 return;
                             }
                             else if (multiHopEntryServer[0] === "") {

--- a/src/apps/vpn/ui/screens/home/servers/RecentConnections.qml
+++ b/src/apps/vpn/ui/screens/home/servers/RecentConnections.qml
@@ -82,7 +82,7 @@ ColumnLayout {
                 anchors.leftMargin: undefined
                 anchors.rightMargin: undefined
 
-                Keys.onDownPressed: recentConnectionsRepeater.itemAt(index + 1) ? recentConnectionsRepeater.itemAt(index + 1).forceActiveFocus() : countriesRepeater.itemAt(0).forceActiveFocus()
+                Keys.onDownPressed: recentConnectionsRepeater.itemAt(index + 1) ? recentConnectionsRepeater.itemAt(index + 1).forceActiveFocus() : countriesListView.itemAtIndex(0).forceActiveFocus()
                 Keys.onUpPressed: recentConnectionsRepeater.itemAt(index - 1) ? recentConnectionsRepeater.itemAt(index - 1).forceActiveFocus() : serverSearchInput.forceActiveFocus()
 
                 onClicked: {

--- a/src/apps/vpn/ui/screens/home/servers/ServerCountry.qml
+++ b/src/apps/vpn/ui/screens/home/servers/ServerCountry.qml
@@ -29,15 +29,6 @@ MZClickableRow {
 
     function openCityList() {
         cityListVisible = !cityListVisible;
-        const itemDistanceFromWindowTop = serverCountry.mapToItem(null, 0, 0).y - multiHopMenuHeight;
-        const listScrollPosition = vpnFlickable.contentY
-
-        if (itemDistanceFromWindowTop + cityList.height < vpnFlickable.height || !cityListVisible) {
-            return;
-        }
-        scrollAnimation.to = (cityList.height > vpnFlickable.height) ? listScrollPosition + itemDistanceFromWindowTop - MZTheme.theme.rowHeight * 1.5 : listScrollPosition + cityList.height + MZTheme.theme.rowHeight;
-        scrollAnimation.duration = animationDuration
-        scrollAnimation.start();
     }
 
     Keys.onReleased: event => {
@@ -50,8 +41,8 @@ MZClickableRow {
 
     activeFocusOnTab: true
     accessibleName: localizedName
-    Keys.onDownPressed: countriesRepeater.itemAt(index + 1) ? countriesRepeater.itemAt(index + 1).forceActiveFocus() : countriesRepeater.itemAt(0).forceActiveFocus()
-    Keys.onUpPressed: countriesRepeater.itemAt(index - 1) ? countriesRepeater.itemAt(index - 1).forceActiveFocus() : recentConnections.focusItemAt(recentConnections.numVisibleConnections - 1)
+    Keys.onDownPressed: countriesListView.itemAtIndex(index + 1) ? countriesListView.itemAtIndex(index + 1).forceActiveFocus() : countriesListView.itemAtIndex(0).forceActiveFocus()
+    Keys.onUpPressed: countriesListView.itemAtIndex(index - 1) ? countriesListView.itemAtIndex(index - 1).forceActiveFocus() : recentConnections.focusItemAt(recentConnections.numVisibleConnections - 1)
     Keys.onBacktabPressed: {
         serverSearchInput.forceActiveFocus();
     }

--- a/src/apps/vpn/ui/screens/home/servers/ServerList.qml
+++ b/src/apps/vpn/ui/screens/home/servers/ServerList.qml
@@ -291,9 +291,11 @@ FocusScope {
                     spacing: 10
                     header: (showRecentConnections && searchBar.getSearchBarText().length === 0) ? countriesListViewHeader : Item
                     footer: countriesListViewFooter
-                    Component.onCompleted: {
-                        const index = VPNServerCountryModel.indexOfCountryCode(currentServer.countryCode);
-                        positionViewAtIndex(index, ListView.Beginning);
+                    onVisibleChanged: {
+                        if (visible) {
+                            const index = VPNServerCountryModel.indexOfCountryCode(currentServer.countryCode);
+                            positionViewAtIndex(index, ListView.Beginning);
+                        }
                     }
                 }
             }

--- a/src/apps/vpn/ui/screens/home/servers/ServerList.qml
+++ b/src/apps/vpn/ui/screens/home/servers/ServerList.qml
@@ -288,6 +288,7 @@ FocusScope {
                     clip: true
                     height: vpnFlickable.height - searchBar.height - serverListSpacer.height - serverList.spacing
                     width: parent.width
+                    spacing: 10
                     header: (showRecentConnections && searchBar.getSearchBarText().length === 0) ? countriesListViewHeader : Item
                     footer: countriesListViewFooter
                     Component.onCompleted: {


### PR DESCRIPTION
## Description

As more countries and servers are added, the server list screen becomes slower. The `Repeater` QML type creates all items at once. The `ListView` creates only a few visible items and loads more as needed. As a result, the performance increases enormously.

## Reference

* https://mozilla-hub.atlassian.net/browse/VPN-5021
* #7197