### PR TITLE
VPN-5012 enforce https

### DIFF
--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -27,7 +27,7 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
         android:extractNativeLibs="true"
         android:theme="@style/AppTheme"
         android:icon="@mipmap/vpnicon"
-        android:usesCleartextTraffic="true">
+        android:usesCleartextTraffic="false">  <!-- Set this to "true" if you need to use http, i.e. for a local guardian instance -->
         <activity
             android:configChanges="orientation|uiMode|screenLayout|screenSize|smallestScreenSize|layoutDirection|locale|fontScale|keyboard|keyboardHidden|navigation|mcc|mnc|density"
             android:name="org.mozilla.firefox.vpn.qt.VPNActivity"


### PR DESCRIPTION
## Description

We are not using http anywhere, this was probably added so people 
can run against custom guardian instances :) 


