### PR TITLE
VPN-4712: add installation ID for iOS

### DIFF
--- a/src/apps/vpn/appsettingslist.h
+++ b/src/apps/vpn/appsettingslist.h
@@ -183,6 +183,17 @@ SETTING_STRINGLIST(iapProducts,        // getter
                    false               // sensitive (do not log)
 )
 
+SETTING_STRING(installationId,        // getter
+               setInstallationId,     // setter
+               removeInstallationId,  // remover
+               hasInstallationId,     // has
+               "installationId",      // key
+               "",                    // default value
+               false,                 // user setting
+               true,                  // remove when reset
+               true                   // sensitive (do not log)
+)
+
 SETTING_INT64(keyRegenerationTimeSec,        // getter
               setKeyRegenerationTimeSec,     // setter
               removeKeyRegenerationTimeSec,  // remover

--- a/src/apps/vpn/controller.cpp
+++ b/src/apps/vpn/controller.cpp
@@ -310,6 +310,7 @@ void Controller::activateInternal(DNSPortPolicy dnsPort,
 
   MozillaVPN* vpn = MozillaVPN::instance();
   const Device* device = vpn->deviceModel()->currentDevice(vpn->keys());
+  SettingsHolder* settingsHolder = SettingsHolder::instance();
 
   // Prepare the exit server's connection data.
   InterfaceConfig exitConfig;
@@ -325,9 +326,11 @@ void Controller::activateInternal(DNSPortPolicy dnsPort,
   exitConfig.m_allowedIPAddressRanges = getAllowedIPAddressRanges(exitServer);
   exitConfig.m_excludedAddresses = getExcludedAddresses();
   exitConfig.m_dnsServer = DNSHelper::getDNS(exitServer.ipv4Gateway());
+#if defined(MZ_ANDROID) || defined(MZ_IOS)
+  exitConfig.m_installationId = settingsHolder->installationId();
+#endif
   logger.debug() << "DNS Set" << exitConfig.m_dnsServer;
 
-  SettingsHolder* settingsHolder = SettingsHolder::instance();
   // Splittunnel-feature could have been disabled due to a driver conflict.
   if (Feature::get(Feature::Feature_splitTunnel)->isSupported()) {
     exitConfig.m_vpnDisabledApps = settingsHolder->vpnDisabledApps();

--- a/src/apps/vpn/interfaceconfig.h
+++ b/src/apps/vpn/interfaceconfig.h
@@ -35,6 +35,9 @@ class InterfaceConfig {
   QList<IPAddress> m_allowedIPAddressRanges;
   QStringList m_excludedAddresses;
   QStringList m_vpnDisabledApps;
+#if defined(MZ_ANDROID) || defined(MZ_IOS)
+  QString m_installationId;
+#endif
 
   QJsonObject toJson() const;
   QString toWgConf(

--- a/src/apps/vpn/mozillavpn.cpp
+++ b/src/apps/vpn/mozillavpn.cpp
@@ -236,6 +236,8 @@ MozillaVPN::MozillaVPN() : App(nullptr), m_private(new MozillaVPNPrivate()) {
 
   connect(ErrorHandler::instance(), &ErrorHandler::errorHandled, this,
           &MozillaVPN::errorHandled);
+
+  ensureApplicationIdExists();
 }
 
 MozillaVPN::~MozillaVPN() {
@@ -2244,4 +2246,14 @@ void MozillaVPN::registerPushMessageTypes() {
         MozillaVPN::instance()->removeDevice(publicKey, "PushMessage");
         return true;
       });
+}
+
+void MozillaVPN::ensureApplicationIdExists() {
+#if defined(MZ_ANDROID) || defined(MZ_IOS)
+  SettingsHolder* settingsHolder = SettingsHolder::instance();
+  if (!settingsHolder->hasInstallationId()) {
+    QString uuid = mozilla::glean::session::installation_id.generateAndSet();
+    settingsHolder->setInstallationId(uuid);
+  }
+#endif
 }

--- a/src/apps/vpn/mozillavpn.h
+++ b/src/apps/vpn/mozillavpn.h
@@ -246,6 +246,8 @@ class MozillaVPN final : public App {
 
   void scheduleRefreshDataTasks();
 
+  static void ensureApplicationIdExists();
+
   static void registerUrlOpenerLabels();
 
   static void registerErrorHandlers();

--- a/src/apps/vpn/platforms/ios/ioscontroller.mm
+++ b/src/apps/vpn/platforms/ios/ioscontroller.mm
@@ -138,6 +138,7 @@ void IOSController::activate(const InterfaceConfig& config, Controller::Reason r
           allowedIPAddressRanges:allowedIPAddressRangesNS
                           reason:reason
       isSuperDooperFeatureActive:Feature::get(Feature::Feature_superDooperMetrics)->isSupported()
+                  installationId:config.m_installationId.toNSString()
                  failureCallback:^() {
                    logger.error() << "IOSSWiftController - connection failed";
                    emit disconnected();

--- a/src/apps/vpn/platforms/ios/ioscontroller.swift
+++ b/src/apps/vpn/platforms/ios/ioscontroller.swift
@@ -116,7 +116,7 @@ public class IOSControllerImpl : NSObject {
         }
     }
 
-    @objc func connect(dnsServer: String, serverIpv6Gateway: String, serverPublicKey: String, serverIpv4AddrIn: String, serverPort: Int,  allowedIPAddressRanges: Array<VPNIPAddressRange>, reason: Int, isSuperDooperFeatureActive: Bool, failureCallback: @escaping () -> Void) {
+    @objc func connect(dnsServer: String, serverIpv6Gateway: String, serverPublicKey: String, serverIpv4AddrIn: String, serverPort: Int,  allowedIPAddressRanges: Array<VPNIPAddressRange>, reason: Int, isSuperDooperFeatureActive: Bool, installationId: String, failureCallback: @escaping () -> Void) {
         IOSControllerImpl.logger.debug(message: "Connecting")
 
         let _ = TunnelManager.withTunnel { tunnel in
@@ -152,11 +152,11 @@ public class IOSControllerImpl : NSObject {
 
             let config = TunnelConfiguration(name: VPN_NAME, interface: interface, peers: peerConfigurations)
 
-            return self.configureTunnel(config: config, reason: reason, serverName: serverIpv4AddrIn + ":\(serverPort )", isSuperDooperFeatureActive: isSuperDooperFeatureActive, failureCallback: failureCallback)
+            return self.configureTunnel(config: config, reason: reason, serverName: serverIpv4AddrIn + ":\(serverPort )", isSuperDooperFeatureActive: isSuperDooperFeatureActive, installationId: installationId, failureCallback: failureCallback)
         }
     }
 
-    func configureTunnel(config: TunnelConfiguration, reason: Int, serverName: String, isSuperDooperFeatureActive: Bool, failureCallback: @escaping () -> Void) {
+    func configureTunnel(config: TunnelConfiguration, reason: Int, serverName: String, isSuperDooperFeatureActive: Bool, installationId: String, failureCallback: @escaping () -> Void) {
         let _ = TunnelManager.withTunnel { tunnel in
             let proto = NETunnelProviderProtocol(tunnelConfiguration: config)
             proto!.providerBundleIdentifier = TunnelManager.vpnBundleId
@@ -176,6 +176,7 @@ public class IOSControllerImpl : NSObject {
 
             var configHack = proto?.providerConfiguration ?? [:]
             configHack["isSuperDooperFeatureActive"] = isSuperDooperFeatureActive
+            configHack["installationId"] = installationId
             proto?.providerConfiguration = configHack
 
             tunnel.protocolConfiguration = proto

--- a/src/apps/vpn/platforms/ios/iostunnel.swift
+++ b/src/apps/vpn/platforms/ios/iostunnel.swift
@@ -61,6 +61,14 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         }
 
         if isSuperDooperFeatureActive {
+            if let installationIdString = ((protocolConfiguration as? NETunnelProviderProtocol)?.providerConfiguration?["installationId"] as? String),
+                let installationId = UUID(uuidString: installationIdString) {
+                logger.info(message: "Setting installation ID in network extension")
+                GleanMetrics.Session.installationId.set(installationId)
+            } else {
+                logger.error(message: "No installation ID found for network extension Glean instance")
+            }
+
             GleanMetrics.Pings.shared.daemonsession.submit(reason: .daemonFlush)
         }
 

--- a/src/apps/vpn/telemetry/metrics.yaml
+++ b/src/apps/vpn/telemetry/metrics.yaml
@@ -122,7 +122,7 @@ session:
     bugs:
       - https://mozilla-hub.atlassian.net/browse/VPN-4712
     data_reviews:
-      - ADD THIS ONCE DONE
+      - https://github.com/mozilla-mobile/mozilla-vpn-client/pull/7581#pullrequestreview-1544692201
     send_in_pings:
       - vpnsession
       - daemonsession

--- a/src/apps/vpn/telemetry/metrics.yaml
+++ b/src/apps/vpn/telemetry/metrics.yaml
@@ -114,6 +114,25 @@ session:
       - vpn-telemetry@mozilla.com
     expires: never
 
+  installation_id:
+    type: uuid
+    lifetime: user
+    description: |
+      A unique identifier to connect the app and daemon Glean instances.
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/VPN-4712
+    data_reviews:
+      - ADD THIS ONCE DONE
+    send_in_pings:
+      - vpnsession
+      - daemonsession
+    data_sensitivity:
+      - technical
+    notification_emails:
+      - mcleinman@mozilla.com
+      - vpn-telemetry@mozilla.com
+    expires: never
+
   dns_type:
     type: string
     description: |


### PR DESCRIPTION
## Description

Android work will come in a separate PR.

To test, you likely want to add a debug tag (`Glean.shared.setDebugViewTag("VPNTest")`) after the two Glean initialization calls in Swift. Then, look at the pings [in Glean's tool](https://debug-ping-preview.firebaseapp.com/pings/VPNTest).

## Reference

https://mozilla-hub.atlassian.net/browse/VPN-4712
https://mozilla-hub.atlassian.net/wiki/spaces/SECPRV/pages/184419319/VPN+session+pings+-+Tech+spec

## Checklist
    
- [X] My code follows the style guidelines for this project
- [X] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [X] I have performed a self review of my own code
- [X] I have commented my code PARTICULARLY in hard to understand areas
- [X] I have added thorough tests where needed
