### PR TITLE
VPN-5027 - Disable Hardware rendering in ChromeOS vm's

### DIFF
--- a/src/apps/vpn/command.cpp
+++ b/src/apps/vpn/command.cpp
@@ -30,6 +30,13 @@
 #  include "platforms/windows/windowscommons.h"
 #endif
 
+#ifdef MZ_ANDROID
+#  include <QQuickWindow>
+#  include <QSGRendererInterface>
+
+#  include "platforms/android/androidutils.h"
+#endif
+
 #ifdef MZ_MACOS
 #  include "platforms/macos/macosutils.h"
 #endif
@@ -178,6 +185,12 @@ int Command::runQmlApp(std::function<int()>&& a_callback) {
 
 #ifdef MZ_WINDOWS
   if (WindowsCommons::requireSoftwareRendering()) {
+    QQuickWindow::setGraphicsApi(QSGRendererInterface::Software);
+  }
+#endif
+
+#ifdef MZ_ANDROID
+  if (AndroidUtils::isChromeOSContext()) {
     QQuickWindow::setGraphicsApi(QSGRendererInterface::Software);
   }
 #endif

--- a/src/apps/vpn/models/device.cpp
+++ b/src/apps/vpn/models/device.cpp
@@ -42,7 +42,7 @@ QString Device::currentDeviceName() {
       // status.
       MacOSUtils::computerName();
 #elif MZ_ANDROID
-      AndroidUtils::getDeviceModel();
+      AndroidUtils::getDeviceName();
 #elif MZ_WASM
       "WASM";
 #elif MZ_WINDOWS

--- a/src/apps/vpn/models/device.cpp
+++ b/src/apps/vpn/models/device.cpp
@@ -42,7 +42,7 @@ QString Device::currentDeviceName() {
       // status.
       MacOSUtils::computerName();
 #elif MZ_ANDROID
-      AndroidUtils::GetDeviceName();
+      AndroidUtils::getDeviceModel();
 #elif MZ_WASM
       "WASM";
 #elif MZ_WINDOWS

--- a/src/apps/vpn/platforms/android/androidutils.cpp
+++ b/src/apps/vpn/platforms/android/androidutils.cpp
@@ -30,20 +30,11 @@ constexpr auto UTILS_CLASS = "org/mozilla/firefox/vpn/qt/VPNUtils";
 
 // static
 QString AndroidUtils::getDeviceName() {
-  QJniEnvironment env;
-  jclass BUILD = env->FindClass("android/os/Build");
-  jfieldID model = env->GetStaticFieldID(BUILD, "DEVICE", "Ljava/lang/String;");
-  jstring value = (jstring)env->GetStaticObjectField(BUILD, model);
-  if (!value) {
-    return QString("Android Device");
+  auto name = readStaticString("android/os/Build", "DEVICE");
+  if(name.isNull()){
+    return QString("Unknown Device");
   }
-  const char* buffer = env->GetStringUTFChars(value, nullptr);
-  if (!buffer) {
-    return QString("Android Device");
-  }
-  QString res(buffer);
-  env->ReleaseStringUTFChars(value, buffer);
-  return res;
+  return name;
 };
 
 bool AndroidUtils::isChromeOSContext() {
@@ -58,21 +49,31 @@ bool AndroidUtils::isChromeOSContext() {
 
 // static
 QString AndroidUtils::getDeviceModel() {
-  QJniEnvironment env;
-  jclass BUILD = env->FindClass("android/os/Build");
-  jfieldID model = env->GetStaticFieldID(BUILD, "MODEL", "Ljava/lang/String;");
-  jstring value = (jstring)env->GetStaticObjectField(BUILD, model);
-  if (!value) {
-    return QString("Android Device");
+  auto model = readStaticString("android/os/Build", "MODEL");
+  if(model.isNull()){
+    return QString("Unknown Model");
   }
-  const char* buffer = env->GetStringUTFChars(value, nullptr);
-  if (!buffer) {
-    return QString("Android Device");
-  }
-  QString res(buffer);
-  env->ReleaseStringUTFChars(value, buffer);
-  return res;
+  return model;
 };
+
+
+// static
+QString AndroidUtils::readStaticString(const char* classname, const char* propertyName) {
+  QJniEnvironment env;
+  jclass targetClass = env->FindClass(classname);
+  jfieldID propertyID = env->GetStaticFieldID(targetClass, propertyName, "Ljava/lang/String;");
+  jstring propertyValue = (jstring)env->GetStaticObjectField(targetClass, propertyID);
+  if (!propertyValue) {
+    return QString();
+  }
+  const char* propertyValueBuffer = env->GetStringUTFChars(value, nullptr);
+  if (!propertyValueBuffer) {
+    return QString();
+  }
+  auto guard = qScopeGuard([&] { env->ReleaseStringUTFChars(propertyValue, propertyValueBuffer); });
+  QString res(propertyValueBuffer);
+  return res;
+}
 
 // static
 AndroidUtils* AndroidUtils::instance() {

--- a/src/apps/vpn/platforms/android/androidutils.cpp
+++ b/src/apps/vpn/platforms/android/androidutils.cpp
@@ -39,7 +39,7 @@ QString AndroidUtils::getDeviceCodename() {
 
 bool AndroidUtils::isChromeOSContext() {
   /*
-   * If the device name ends or starts with "cheets" we're
+   * If the device code name ends or starts with "cheets" we're
    * running in a Chrome OS / Android Runtime Container
    * Situation.
    */

--- a/src/apps/vpn/platforms/android/androidutils.cpp
+++ b/src/apps/vpn/platforms/android/androidutils.cpp
@@ -29,10 +29,10 @@ constexpr auto UTILS_CLASS = "org/mozilla/firefox/vpn/qt/VPNUtils";
 }  // namespace
 
 // static
-QString AndroidUtils::getDeviceName() {
+QString AndroidUtils::getDeviceCodename() {
   auto name = readStaticString("android/os/Build", "DEVICE");
   if (name.isNull()) {
-    return QString("Unknown Device");
+    return QString("Android Device");
   }
   return name;
 };
@@ -43,12 +43,12 @@ bool AndroidUtils::isChromeOSContext() {
    * running in a Chrome OS / Android Runtime Container
    * Situation.
    */
-  auto name = getDeviceName();
+  auto name = getDeviceCodename();
   return name.endsWith("_cheets") || name.startsWith("cheets_");
 }
 
 // static
-QString AndroidUtils::getDeviceModel() {
+QString AndroidUtils::getDeviceName() {
   auto model = readStaticString("android/os/Build", "MODEL");
   if (model.isNull()) {
     return QString("Unknown Model");
@@ -68,7 +68,8 @@ QString AndroidUtils::readStaticString(const char* classname,
   if (!propertyValue) {
     return QString();
   }
-  const char* propertyValueBuffer = env->GetStringUTFChars(value, nullptr);
+  const char* propertyValueBuffer =
+      env->GetStringUTFChars(propertyValue, nullptr);
   if (!propertyValueBuffer) {
     return QString();
   }

--- a/src/apps/vpn/platforms/android/androidutils.cpp
+++ b/src/apps/vpn/platforms/android/androidutils.cpp
@@ -49,7 +49,7 @@ QString AndroidUtils::getDeviceName() {
 bool AndroidUtils::isChromeOSContext() {
   /*
    * If the device name ends or starts with "cheets" we're
-   * we are running in a Chrome OS / Android Runtime Container
+   * running in a Chrome OS / Android Runtime Container
    * Situation.
    */
   auto name = getDeviceName();

--- a/src/apps/vpn/platforms/android/androidutils.cpp
+++ b/src/apps/vpn/platforms/android/androidutils.cpp
@@ -29,7 +29,34 @@ constexpr auto UTILS_CLASS = "org/mozilla/firefox/vpn/qt/VPNUtils";
 }  // namespace
 
 // static
-QString AndroidUtils::GetDeviceName() {
+QString AndroidUtils::getDeviceName() {
+  QJniEnvironment env;
+  jclass BUILD = env->FindClass("android/os/Build");
+  jfieldID model = env->GetStaticFieldID(BUILD, "DEVICE", "Ljava/lang/String;");
+  jstring value = (jstring)env->GetStaticObjectField(BUILD, model);
+  if (!value) {
+    return QString("Android Device");
+  }
+  const char* buffer = env->GetStringUTFChars(value, nullptr);
+  if (!buffer) {
+    return QString("Android Device");
+  }
+  QString res(buffer);
+  env->ReleaseStringUTFChars(value, buffer);
+  return res;
+};
+
+bool AndroidUtils::isChromeOSContext() {
+  /*
+   * If the device name end's with "_cheets" we're
+   * we are running in a Chrome OS / Android Emulator
+   * Situation.
+   */
+  return getDeviceName().endsWith("_cheets");
+}
+
+// static
+QString AndroidUtils::getDeviceModel() {
   QJniEnvironment env;
   jclass BUILD = env->FindClass("android/os/Build");
   jfieldID model = env->GetStaticFieldID(BUILD, "MODEL", "Ljava/lang/String;");

--- a/src/apps/vpn/platforms/android/androidutils.cpp
+++ b/src/apps/vpn/platforms/android/androidutils.cpp
@@ -31,7 +31,7 @@ constexpr auto UTILS_CLASS = "org/mozilla/firefox/vpn/qt/VPNUtils";
 // static
 QString AndroidUtils::getDeviceName() {
   auto name = readStaticString("android/os/Build", "DEVICE");
-  if(name.isNull()){
+  if (name.isNull()) {
     return QString("Unknown Device");
   }
   return name;
@@ -50,19 +50,21 @@ bool AndroidUtils::isChromeOSContext() {
 // static
 QString AndroidUtils::getDeviceModel() {
   auto model = readStaticString("android/os/Build", "MODEL");
-  if(model.isNull()){
+  if (model.isNull()) {
     return QString("Unknown Model");
   }
   return model;
 };
 
-
 // static
-QString AndroidUtils::readStaticString(const char* classname, const char* propertyName) {
+QString AndroidUtils::readStaticString(const char* classname,
+                                       const char* propertyName) {
   QJniEnvironment env;
   jclass targetClass = env->FindClass(classname);
-  jfieldID propertyID = env->GetStaticFieldID(targetClass, propertyName, "Ljava/lang/String;");
-  jstring propertyValue = (jstring)env->GetStaticObjectField(targetClass, propertyID);
+  jfieldID propertyID =
+      env->GetStaticFieldID(targetClass, propertyName, "Ljava/lang/String;");
+  jstring propertyValue =
+      (jstring)env->GetStaticObjectField(targetClass, propertyID);
   if (!propertyValue) {
     return QString();
   }
@@ -70,7 +72,8 @@ QString AndroidUtils::readStaticString(const char* classname, const char* proper
   if (!propertyValueBuffer) {
     return QString();
   }
-  auto guard = qScopeGuard([&] { env->ReleaseStringUTFChars(propertyValue, propertyValueBuffer); });
+  auto guard = qScopeGuard(
+      [&] { env->ReleaseStringUTFChars(propertyValue, propertyValueBuffer); });
   QString res(propertyValueBuffer);
   return res;
 }

--- a/src/apps/vpn/platforms/android/androidutils.cpp
+++ b/src/apps/vpn/platforms/android/androidutils.cpp
@@ -51,7 +51,7 @@ bool AndroidUtils::isChromeOSContext() {
 QString AndroidUtils::getDeviceName() {
   auto model = readStaticString("android/os/Build", "MODEL");
   if (model.isNull()) {
-    return QString("Unknown Model");
+    return QString("Android Device");
   }
   return model;
 };

--- a/src/apps/vpn/platforms/android/androidutils.cpp
+++ b/src/apps/vpn/platforms/android/androidutils.cpp
@@ -48,11 +48,12 @@ QString AndroidUtils::getDeviceName() {
 
 bool AndroidUtils::isChromeOSContext() {
   /*
-   * If the device name end's with "_cheets" we're
-   * we are running in a Chrome OS / Android Emulator
+   * If the device name ends or starts with "cheets" we're
+   * we are running in a Chrome OS / Android Runtime Container
    * Situation.
    */
-  return getDeviceName().endsWith("_cheets");
+  auto name = getDeviceName();
+  return name.endsWith("_cheets") || name.startsWith("cheets_");
 }
 
 // static

--- a/src/apps/vpn/platforms/android/androidutils.h
+++ b/src/apps/vpn/platforms/android/androidutils.h
@@ -55,8 +55,8 @@ class AndroidUtils final : public QObject {
   static QJsonObject getQJsonObjectFromJString(JNIEnv* env, jstring data);
 
  private:
-  static QSting readStaticString(const char* classname, const char* propertyName);
-
+  static QSting readStaticString(const char* classname,
+                                 const char* propertyName);
 
   AndroidUtils(QObject* parent);
   ~AndroidUtils();

--- a/src/apps/vpn/platforms/android/androidutils.h
+++ b/src/apps/vpn/platforms/android/androidutils.h
@@ -20,7 +20,29 @@ class AndroidUtils final : public QObject {
   Q_DISABLE_COPY_MOVE(AndroidUtils)
 
  public:
-  static QString GetDeviceName();
+  /**
+   * @brief Returns the name of the Device.
+   * Checks: Build.DEVICE
+   * Unlike GetDeviceName, returns the internal model name.
+   * I.e "Google Pixel 7" is 'Panther'
+   * @return QString of Build.DEVICE
+   */
+  static QString getDeviceName();
+
+  /**
+   * @brief Get the Device Model Name
+   * Checks: Build.Model
+   * Name here means how the manufacturer calls it.
+   * I.e "Google Pixel 7" is .. a Google Pixel 7
+   * @return QString of Build.Model
+   */
+  static QString getDeviceModel();
+
+  /**
+   * @brief Checks if we are running on ChromeOS+ Android Subsystem
+   *
+   */
+  static bool isChromeOSContext();
 
   static QByteArray DeviceId();
 

--- a/src/apps/vpn/platforms/android/androidutils.h
+++ b/src/apps/vpn/platforms/android/androidutils.h
@@ -55,6 +55,9 @@ class AndroidUtils final : public QObject {
   static QJsonObject getQJsonObjectFromJString(JNIEnv* env, jstring data);
 
  private:
+  static QSting readStaticString(const char* classname, const char* propertyName);
+
+
   AndroidUtils(QObject* parent);
   ~AndroidUtils();
 };

--- a/src/apps/vpn/platforms/android/androidutils.h
+++ b/src/apps/vpn/platforms/android/androidutils.h
@@ -27,7 +27,7 @@ class AndroidUtils final : public QObject {
    * I.e "Google Pixel 7" is 'Panther'
    * @return QString of Build.DEVICE
    */
-  static QString getDeviceName();
+  static QString getDeviceCodename();
 
   /**
    * @brief Get the Device Model Name
@@ -36,7 +36,7 @@ class AndroidUtils final : public QObject {
    * I.e "Google Pixel 7" is .. a Google Pixel 7
    * @return QString of Build.Model
    */
-  static QString getDeviceModel();
+  static QString getDeviceName();
 
   /**
    * @brief Checks if we are running on ChromeOS+ Android Subsystem
@@ -55,8 +55,8 @@ class AndroidUtils final : public QObject {
   static QJsonObject getQJsonObjectFromJString(JNIEnv* env, jstring data);
 
  private:
-  static QSting readStaticString(const char* classname,
-                                 const char* propertyName);
+  static QString readStaticString(const char* classname,
+                                  const char* propertyName);
 
   AndroidUtils(QObject* parent);
   ~AndroidUtils();

--- a/src/apps/vpn/ui/screens/initialize/ViewInitialize.qml
+++ b/src/apps/vpn/ui/screens/initialize/ViewInitialize.qml
@@ -15,10 +15,21 @@ Item {
     property int safeAreaHeight: window.safeContentHeight
     property string logoSubtitle: MZI18n.ProductDescription
 
-    MZRadialGradient {
+    Rectangle {
+        // This is a fallback for MZRadialGradient
+        color: MZTheme.theme.onBoardingGradient.end
         height: Screen.height
         width: Screen.width
 
+        anchors {
+            top: parent.top
+            topMargin:  -window.safeAreaHeightByDevice()
+        }
+    }
+
+    MZRadialGradient {  
+        height: Screen.height
+        width: Screen.width
         anchors {
             top: parent.top
             topMargin:  -window.safeAreaHeightByDevice()

--- a/src/apps/vpn/ui/screens/initialize/ViewInitialize.qml
+++ b/src/apps/vpn/ui/screens/initialize/ViewInitialize.qml
@@ -29,8 +29,6 @@ Item {
     }
 
     MZRadialGradient {  
-        height: Screen.height
-        width: Screen.width
         anchors.fill: fallBackBackground
 
         gradient: Gradient {

--- a/src/apps/vpn/ui/screens/initialize/ViewInitialize.qml
+++ b/src/apps/vpn/ui/screens/initialize/ViewInitialize.qml
@@ -16,6 +16,7 @@ Item {
     property string logoSubtitle: MZI18n.ProductDescription
 
     Rectangle {
+        id: fallBackBackground
         // This is a fallback for MZRadialGradient
         color: MZTheme.theme.onBoardingGradient.end
         height: Screen.height
@@ -30,10 +31,7 @@ Item {
     MZRadialGradient {  
         height: Screen.height
         width: Screen.width
-        anchors {
-            top: parent.top
-            topMargin:  -window.safeAreaHeightByDevice()
-        }
+        anchors.fill: fallBackBackground
 
         gradient: Gradient {
             GradientStop {


### PR DESCRIPTION
## Description
So i was pretty sure this is not a "Mozilla VPN issue" but i was supposed to look into that. So i did. 

```
SIGSEGV: Segfault
  ?, in rx::vk::ImageViewHelper::getLevelLayerDrawImageView

```
The segfault is actually not much to go after. The only online content i found related to that is us and ... chrome. 
Also this is actually in a system library, so something out of our control is going wrong. 

However, looking at google-play, we can clearly see the only devices encountering this crash are ChromeOS tablet's with mediatec chips... So maybe it's their driver? ( Also it would be neat if sentry told me that 😅  ) 

For my smol experiment, we can simply detect chrome-os android-vm's and put them into software rendering. If i am correct, this should stop that from happening :) 
i also added a fallback for the login screen, so it shows not the whole screen with a white background 😅, if we put the client into software rendering fallback.


