### PR TITLE
VPN-5017: add data entitlement

### DIFF
--- a/ios/app/main.entitlements
+++ b/ios/app/main.entitlements
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.developer.default-data-protection</key>
+	<string>NSFileProtectionComplete</string>
+	<key>com.apple.developer.device-information.user-assigned-device-name</key>
+	<true/>
 	<key>com.apple.developer.networking.networkextension</key>
 	<array>
 		<string>packet-tunnel-provider</string>
@@ -11,8 +15,6 @@
 		<string>$(GROUP_ID_IOS)</string>
 	</array>
 	<key>com.apple.security.files.user-selected.read-write</key>
-	<true/>
-	<key>com.apple.developer.device-information.user-assigned-device-name</key>
 	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
## Description

Per cure53, increasing security of our app's data (not including items in Keychain, which are already secured). This entitlement is turned into Xcode's entitlements during our build process.

## Reference

https://mozilla-hub.atlassian.net/browse/VPN-5017

## Checklist
    
- [X] My code follows the style guidelines for this project
- [X] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [X] I have performed a self review of my own code
- [X] I have commented my code PARTICULARLY in hard to understand areas
- [X] I have added thorough tests where needed
