### PR TITLE
VPN-4974 - Do not Store raw Pointers of ServerCountryModel

### DIFF
--- a/src/apps/vpn/models/recommendedlocationmodel.cpp
+++ b/src/apps/vpn/models/recommendedlocationmodel.cpp
@@ -61,8 +61,7 @@ void RecommendedLocationModel::refreshModel() {
     m_recommendedCities.clear();
     for (auto& city : cities) {
       // Wrap that pointers into a
-      // QPointer, so that we are notified if they are
-      // deleted.
+      // QPointer, so that we can check if the object has been deleted
       m_recommendedCities.append(QPointer((ServerCity*)city));
     }
     endResetModel();

--- a/src/apps/vpn/models/recommendedlocationmodel.h
+++ b/src/apps/vpn/models/recommendedlocationmodel.h
@@ -26,7 +26,7 @@ class RecommendedLocationModel final : public QAbstractListModel {
 
   void initialize();
 
-  Q_INVOKABLE static QList<QPointer<ServerCity>> recommendedLocations(
+  Q_INVOKABLE static QList<const ServerCity*> recommendedLocations(
       unsigned int maxResults);
 
   // QAbstractListModel methods

--- a/src/apps/vpn/models/recommendedlocationmodel.h
+++ b/src/apps/vpn/models/recommendedlocationmodel.h
@@ -6,6 +6,7 @@
 #define RECOMMENDEDLOCATIONMODEL_H
 
 #include <QAbstractListModel>
+#include <QPointer>
 #include <QSet>
 #include <QTimer>
 
@@ -25,7 +26,7 @@ class RecommendedLocationModel final : public QAbstractListModel {
 
   void initialize();
 
-  Q_INVOKABLE static QList<const ServerCity*> recommendedLocations(
+  Q_INVOKABLE static QList<QPointer<ServerCity>> recommendedLocations(
       unsigned int maxResults);
 
   // QAbstractListModel methods
@@ -45,7 +46,7 @@ class RecommendedLocationModel final : public QAbstractListModel {
   void refreshModel();
 
  private:
-  QList<const ServerCity*> m_recommendedCities;
+  QList<QPointer<ServerCity>> m_recommendedCities;
   QTimer m_timer;
 };
 

--- a/src/apps/vpn/models/recommendedlocationmodel.h
+++ b/src/apps/vpn/models/recommendedlocationmodel.h
@@ -26,7 +26,10 @@ class RecommendedLocationModel final : public QAbstractListModel {
 
   void initialize();
 
-  Q_INVOKABLE static QList<const ServerCity*> recommendedLocations(
+  Q_INVOKABLE static QList<const ServerCity*> recommendedLocationsRaw(
+      unsigned int maxResults);
+
+  static QList<QPointer<ServerCity>> recommendedLocations(
       unsigned int maxResults);
 
   // QAbstractListModel methods

--- a/src/apps/vpn/models/servercountrymodel.cpp
+++ b/src/apps/vpn/models/servercountrymodel.cpp
@@ -189,7 +189,7 @@ QVariant ServerCountryModel::data(const QModelIndex& index, int role) const {
 
 // Select the city that we think is going to perform the best
 QStringList ServerCountryModel::pickBest() const {
-  QList<QPointer<ServerCity>> list =
+  QList<const ServerCity*> list =
       RecommendedLocationModel::recommendedLocations(1);
   if (list.isEmpty()) {
     return QStringList();

--- a/src/apps/vpn/models/servercountrymodel.cpp
+++ b/src/apps/vpn/models/servercountrymodel.cpp
@@ -189,7 +189,7 @@ QVariant ServerCountryModel::data(const QModelIndex& index, int role) const {
 
 // Select the city that we think is going to perform the best
 QStringList ServerCountryModel::pickBest() const {
-  QList<const ServerCity*> list =
+  QList<QPointer<ServerCity>> list =
       RecommendedLocationModel::recommendedLocations(1);
   if (list.isEmpty()) {
     return QStringList();

--- a/src/apps/vpn/models/servercountrymodel.cpp
+++ b/src/apps/vpn/models/servercountrymodel.cpp
@@ -189,13 +189,13 @@ QVariant ServerCountryModel::data(const QModelIndex& index, int role) const {
 
 // Select the city that we think is going to perform the best
 QStringList ServerCountryModel::pickBest() const {
-  QList<const ServerCity*> list =
+  QList<QPointer<ServerCity>> list =
       RecommendedLocationModel::recommendedLocations(1);
   if (list.isEmpty()) {
     return QStringList();
   }
 
-  const ServerCity* city = list.first();
+  const ServerCity* city = list.first().data();
   return QStringList({city->country(), city->name()});
 }
 

--- a/src/apps/vpn/ui/screens/home/ViewServers.qml
+++ b/src/apps/vpn/ui/screens/home/ViewServers.qml
@@ -111,7 +111,7 @@ Item {
                             }
                             else if (multiHopEntryServer[0] === "") {
                                 // Choose a random entry server when switching to multihop
-                                var best = VPNRecommendedLocationModel.recommendedLocations(2);
+                                var best = VPNRecommendedLocationModel.recommendedLocationsRaw(2);
                                 if ((best[0].country != multiHopExitServer[0]) || (best[0].name != multiHopExitServer[1])) {
                                     multiHopEntryServer = [best[0].country, best[0].name, best[0].localizedName];
                                 } else {

--- a/tests/dummyvpn/CMakeLists.txt
+++ b/tests/dummyvpn/CMakeLists.txt
@@ -6,7 +6,7 @@
 # finalization in order to pick up QML dependencies when built
 # statically.
 qt_add_executable(dummyvpn MANUAL_FINALIZATION)
-
+include(ExternalProject)
 target_link_libraries(dummyvpn PRIVATE
     Qt6::Quick
     Qt6::Test
@@ -46,6 +46,19 @@ endif()
 
 target_compile_definitions(dummyvpn PRIVATE MZ_DEBUG)
 target_compile_definitions(dummyvpn PRIVATE MZ_DUMMY)
+
+# We should not build into the source dir
+# but that is how we are currently doing things, 
+# at least we no longer invoke python scripts to 
+# invoke cmake. 
+#  ¯\_(ツ)_/¯
+ExternalProject_Add(functional_test_addons
+    SOURCE_DIR ${CMAKE_SOURCE_DIR}/tests/functional/addons
+    BINARY_DIR ${CMAKE_SOURCE_DIR}/tests/functional/addons/generated
+    CMAKE_CACHE_ARGS -DQt6_DIR:PATH=${Qt6_DIR} -DQt6QmlTools_DIR:PATH=${Qt6QmlTools_DIR} -DQt6CoreTools_DIR:PATH=${Qt6CoreTools_DIR}
+    INSTALL_COMMAND ""
+)
+add_dependencies(dummyvpn functional_test_addons)
 
 qt6_add_qml_module(dummyvpn
   URI Mozilla.Shared.qmlcomponents

--- a/tests/unit/testmodels.cpp
+++ b/tests/unit/testmodels.cpp
@@ -1646,8 +1646,7 @@ void TestModels::serverCountryModelPick() {
     QCOMPARE(MozillaVPN::instance()->serverCountryModel()->fromJson(json),
              true);
 
-    QList<const ServerCity*> results =
-        RecommendedLocationModel::recommendedLocations(1);
+    auto results = RecommendedLocationModel::recommendedLocations(1);
     QCOMPARE(results.length(), 1);
 
     const ServerCity* city = results.first();


### PR DESCRIPTION
## Description

I'm hunting the `QJSEngine::qt_metacall Segfault`
We now have a [QML trace:](
https://mozilla.sentry.io/discover/vpn-client:22dd932716d94b8b6a08d705d1b262d5/?field=title&field=event.type&field=project&field=user.display&field=timestamp&field=release&homepage=true&name=All+Events&project=4504197915607040&query=release%3A2.16.0&sort=-timestamp&statsPeriod=14d&yAxis=count%28%29)
it's crashing at: 
```
0: {column: -1, function: expression for score, line: 242, source: qrc:/ui/screens/home/servers/ServerList.qml}, 
```

So it's the an evaluated binding on `VPNRecommendedLocationModel`.

My current hunch, given that just before in the logs we can see the client fetched new servers`(ServerCountryModel) Debug: Reading from JSON`. 

So if the ServerCountryModel, calls `m_cities.clear()` - `VPNRecommendedLocationModel` can still hold pointers to those objects. Until Serverlatency refreshes those. 

This Pr Wraps the Raw pointers to `QPointers`, so if the underlying object is deleted, the pointer will be set to `nullptr`. 
Also `VPNRecommendedLocationModel` will now listen to updates on `ServerCountryModel` and update itself. 