### PR TITLE
Sentry-Nit: Report Proper Plattform

### DIFF
--- a/src/shared/sentry/sentryadapter.cpp
+++ b/src/shared/sentry/sentryadapter.cpp
@@ -207,7 +207,7 @@ void SentryAdapter::captureQMLStacktrace(const char* description) {
 #endif
 }
 
-void SentryAdapter::setPlatformTags() const {
+void SentryAdapter::setPlatformTag() const {
 #if defined(MZ_LINUX)
   sentry_set_tag("platform", "Linux");
 #elif defined(MZ_MACOS)

--- a/src/shared/sentry/sentryadapter.cpp
+++ b/src/shared/sentry/sentryadapter.cpp
@@ -96,7 +96,7 @@ void SentryAdapter::init() {
     return;
   };
   m_initialized = true;
-  setPlatformTags();
+  setPlatformTag();
   logger.info() << "Sentry initialized";
 }
 

--- a/src/shared/sentry/sentryadapter.cpp
+++ b/src/shared/sentry/sentryadapter.cpp
@@ -96,6 +96,7 @@ void SentryAdapter::init() {
     return;
   };
   m_initialized = true;
+  setPlatformTags();
   logger.info() << "Sentry initialized";
 }
 
@@ -203,5 +204,21 @@ void SentryAdapter::captureQMLStacktrace(const char* description) {
   sentry_add_breadcrumb(crumb);
 #else
   Q_UNUSED(description);
+#endif
+}
+
+void SentryAdapter::setPlatformTags() const {
+#if defined(MZ_LINUX)
+  sentry_set_tag("platform", "Linux");
+#elif defined(MZ_MACOS)
+  sentry_set_tag("platform", "MacOS");
+#elif defined(MZ_WINDOWS)
+  sentry_set_tag("platform", "Windows");
+#elif defined(MZ_IOS)
+  sentry_set_tag("platform", "iOS");
+#elif defined(MZ_ANDROID)
+  sentry_set_tag("platform", "Android");
+#else
+  sentry_set_tag("platform", "Dummy");
 #endif
 }

--- a/src/shared/sentry/sentryadapter.h
+++ b/src/shared/sentry/sentryadapter.h
@@ -145,6 +145,11 @@ class SentryAdapter final : public QObject {
   void needsCrashReportScreen() const;
 
  private:
+  /**
+   * @brief Set's Tags related to the Platform
+   */
+  void setPlatformTags() const;
+
   bool m_initialized = false;
   UserConsentResult m_userConsent = UserConsentResult::Pending;
   SentryAdapter();

--- a/src/shared/sentry/sentryadapter.h
+++ b/src/shared/sentry/sentryadapter.h
@@ -148,7 +148,7 @@ class SentryAdapter final : public QObject {
   /**
    * @brief Set's Tags related to the Platform
    */
-  void setPlatformTags() const;
+  void setPlatformTag() const;
 
   bool m_initialized = false;
   UserConsentResult m_userConsent = UserConsentResult::Pending;

--- a/src/shared/sentry/sentryadapter.h
+++ b/src/shared/sentry/sentryadapter.h
@@ -146,7 +146,7 @@ class SentryAdapter final : public QObject {
 
  private:
   /**
-   * @brief Set's Tags related to the Platform
+   * @brief Sets Tags related to the Platform
    */
   void setPlatformTag() const;
 


### PR DESCRIPTION
## Description

Sentry Native is not making a difference between Mobile OS'ses and Desktop: 
So Android and Linux are reported as Linux
Macos is "macOS" and iOS is Darwin 😅.

This PR add's a new tag, splitting this by `MZ_Platform`, making sure we can [quickly sort those](field=event.type&field=project&field=user.display&field=timestamp&field=replayId&name=All+Events&project=4504197915607040&query=platform%3A"MacOS"&sort=-timestamp&statsPeriod=14d&yAxis=count()) :) 