### PR TITLE
VPN-5215 - Test generated addons are valid

### DIFF
--- a/addons/CMakeLists.txt
+++ b/addons/CMakeLists.txt
@@ -27,6 +27,8 @@ endif()
 add_executable(validation validate.cpp)
 target_link_libraries(validation PRIVATE Qt6::Core)
 
+add_dependencies(addons validation)
+
 # Validate the generated addons
 add_custom_command(
     TARGET addons

--- a/addons/CMakeLists.txt
+++ b/addons/CMakeLists.txt
@@ -22,3 +22,16 @@ add_addon_target(addons
 if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
     set_target_properties(addons PROPERTIES EXCLUDE_FROM_ALL FALSE)
 endif()
+
+# Generate the validation executable
+add_executable(validation validate.cpp)
+target_link_libraries(validation PRIVATE Qt6::Core)
+
+# Validate the generated addons
+add_custom_command(
+    TARGET addons
+    DEPENDS validation
+    COMMENT "Validating generated addons"
+    COMMAND ${CMAKE_BINARY_DIR}/validation ${CMAKE_BINARY_DIR}
+    POST_BUILD
+)

--- a/addons/validate.cpp
+++ b/addons/validate.cpp
@@ -1,0 +1,50 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Script that validates the generate addon RCC files
+// can all be loaded by a Qt application.
+
+#include <QDir>
+#include <QDebug>
+#include <QResource>
+
+int main(int argc, char *argv[]) {
+    if (argc != 2) {
+        qDebug() << "Usage: " << argv[0] << " <directory_path>";
+        return 1;
+    }
+
+    QString directoryPath = argv[1];
+    QDir directory(directoryPath);
+
+    if (!directory.exists()) {
+        qDebug() << "\033[1;31mDirectory does not exist: " << directoryPath << "\033[0m\n";
+        return 1;
+    }
+
+    directory.setFilter(QDir::Files | QDir::NoDotAndDotDot);
+    QFileInfoList fileInfoList = directory.entryInfoList();
+
+    bool foundBrokenAddons = false;
+
+    foreach (const QFileInfo& fileInfo, fileInfoList) {
+        QString filePath = fileInfo.absoluteFilePath();
+        QString fileExtension = fileInfo.suffix();
+        if (fileExtension == "rcc") {
+            if (!QResource::registerResource(filePath)) {
+                qDebug() << "\033[1;31mGenerated resource file" << filePath << "cannot be registered by Qt.\033[0m";
+                foundBrokenAddons = true;
+                continue;
+            }
+
+            qDebug() << "Generated resource file" << filePath << "is valid.";
+        }
+    }
+
+    if (foundBrokenAddons) {
+        return 1;
+    } else {
+        return 0;
+    }
+}

--- a/addons/validate.cpp
+++ b/addons/validate.cpp
@@ -5,46 +5,48 @@
 // Script that validates the generate addon RCC files
 // can all be loaded by a Qt application.
 
-#include <QDir>
 #include <QDebug>
+#include <QDir>
 #include <QResource>
 
-int main(int argc, char *argv[]) {
-    if (argc != 2) {
-        qDebug() << "Usage: " << argv[0] << " <directory_path>";
-        return 1;
+int main(int argc, char* argv[]) {
+  if (argc != 2) {
+    qDebug() << "Usage: " << argv[0] << " <directory_path>";
+    return 1;
+  }
+
+  QString directoryPath = argv[1];
+  QDir directory(directoryPath);
+
+  if (!directory.exists()) {
+    qDebug() << "\033[1;31mDirectory does not exist: " << directoryPath
+             << "\033[0m\n";
+    return 1;
+  }
+
+  directory.setFilter(QDir::Files | QDir::NoDotAndDotDot);
+  QFileInfoList fileInfoList = directory.entryInfoList();
+
+  bool foundBrokenAddons = false;
+
+  foreach (const QFileInfo& fileInfo, fileInfoList) {
+    QString filePath = fileInfo.absoluteFilePath();
+    QString fileExtension = fileInfo.suffix();
+    if (fileExtension == "rcc") {
+      if (!QResource::registerResource(filePath)) {
+        qDebug() << "\033[1;31mGenerated resource file" << filePath
+                 << "cannot be registered by Qt.\033[0m";
+        foundBrokenAddons = true;
+        continue;
+      }
+
+      qDebug() << "Generated resource file" << filePath << "is valid.";
     }
+  }
 
-    QString directoryPath = argv[1];
-    QDir directory(directoryPath);
-
-    if (!directory.exists()) {
-        qDebug() << "\033[1;31mDirectory does not exist: " << directoryPath << "\033[0m\n";
-        return 1;
-    }
-
-    directory.setFilter(QDir::Files | QDir::NoDotAndDotDot);
-    QFileInfoList fileInfoList = directory.entryInfoList();
-
-    bool foundBrokenAddons = false;
-
-    foreach (const QFileInfo& fileInfo, fileInfoList) {
-        QString filePath = fileInfo.absoluteFilePath();
-        QString fileExtension = fileInfo.suffix();
-        if (fileExtension == "rcc") {
-            if (!QResource::registerResource(filePath)) {
-                qDebug() << "\033[1;31mGenerated resource file" << filePath << "cannot be registered by Qt.\033[0m";
-                foundBrokenAddons = true;
-                continue;
-            }
-
-            qDebug() << "Generated resource file" << filePath << "is valid.";
-        }
-    }
-
-    if (foundBrokenAddons) {
-        return 1;
-    } else {
-        return 0;
-    }
+  if (foundBrokenAddons) {
+    return 1;
+  } else {
+    return 0;
+  }
 }


### PR DESCRIPTION
It seems sometimes the addons may pass all of our linting scripts and still generate invalid resources. Or maybe it's the rcc generation script that may sometimes fail.

I do not address the failure here, because locally my builds just work so I am guessing this will be fixed by a rebuild. But if I download the RCC files in https://mozilla-mobile.github.io/mozilla-vpn-client/addons/ it fails when it gets to the problematic addons described in VNP-5215... so at least we are preventing against that guess???

This is the output against the staging addons:

```
Generated resource file "/Users/beatrizrizental/Library/Application Support/Mozilla VPN/addons/guide_01_how_to_vpn.rcc" is valid.
Generated resource file "/Users/beatrizrizental/Library/Application Support/Mozilla VPN/addons/guide_02_is_my_vpn_working_correctly.rcc" is valid.
Generated resource file "/Users/beatrizrizental/Library/Application Support/Mozilla VPN/addons/guide_03_adding_and_removing_devices.rcc" is valid.
Generated resource file "/Users/beatrizrizental/Library/Application Support/Mozilla VPN/addons/guide_05_what_is_multi_hop.rcc" is valid.
Generated resource file "/Users/beatrizrizental/Library/Application Support/Mozilla VPN/addons/guide_08_privacy_features.rcc" is valid.
[1;31mGenerated resource file "/Users/beatrizrizental/Library/Application Support/Mozilla VPN/addons/guide_09_custom_dns.rcc" cannot be registered by Qt.[0m
Generated resource file "/Users/beatrizrizental/Library/Application Support/Mozilla VPN/addons/guide_09_custom_dns.rcc" is valid.
Generated resource file "/Users/beatrizrizental/Library/Application Support/Mozilla VPN/addons/guide_10_app_exclusions.rcc" is valid.
[1;31mGenerated resource file "/Users/beatrizrizental/Library/Application Support/Mozilla VPN/addons/guide_11_recommended_servers.rcc" cannot be registered by Qt.[0m
Generated resource file "/Users/beatrizrizental/Library/Application Support/Mozilla VPN/addons/guide_11_recommended_servers.rcc" is valid.
Generated resource file "/Users/beatrizrizental/Library/Application Support/Mozilla VPN/addons/guide_12_multi_account_containers.rcc" is valid.
Generated resource file "/Users/beatrizrizental/Library/Application Support/Mozilla VPN/addons/message_dom.rcc" is valid.
Generated resource file "/Users/beatrizrizental/Library/Application Support/Mozilla VPN/addons/message_subscription_expiring.rcc" is valid.
Generated resource file "/Users/beatrizrizental/Library/Application Support/Mozilla VPN/addons/message_survey.rcc" is valid.
Generated resource file "/Users/beatrizrizental/Library/Application Support/Mozilla VPN/addons/message_survey_staging_1h.rcc" is valid.
Generated resource file "/Users/beatrizrizental/Library/Application Support/Mozilla VPN/addons/message_survey_staging_30m.rcc" is valid.
Generated resource file "/Users/beatrizrizental/Library/Application Support/Mozilla VPN/addons/message_update_v2.16.rcc" is valid.
Generated resource file "/Users/beatrizrizental/Library/Application Support/Mozilla VPN/addons/message_whats_new_v2.16.rcc" is valid.
[1;31mGenerated resource file "/Users/beatrizrizental/Library/Application Support/Mozilla VPN/addons/tutorial_01_get_started.rcc" cannot be registered by Qt.[0m
Generated resource file "/Users/beatrizrizental/Library/Application Support/Mozilla VPN/addons/tutorial_01_get_started.rcc" is valid.
[1;31mGenerated resource file "/Users/beatrizrizental/Library/Application Support/Mozilla VPN/addons/tutorial_01_get_started_recommended_locations.rcc" cannot be registered by Qt.[0m
Generated resource file "/Users/beatrizrizental/Library/Application Support/Mozilla VPN/addons/tutorial_01_get_started_recommended_locations.rcc" is valid.
Generated resource file "/Users/beatrizrizental/Library/Application Support/Mozilla VPN/addons/tutorial_02_connect_on_startup.rcc" is valid.
[1;31mGenerated resource file "/Users/beatrizrizental/Library/Application Support/Mozilla VPN/addons/tutorial_03_multi_hop.rcc" cannot be registered by Qt.[0m
Generated resource file "/Users/beatrizrizental/Library/Application Support/Mozilla VPN/addons/tutorial_03_multi_hop.rcc" is valid.
Generated resource file "/Users/beatrizrizental/Library/Application Support/Mozilla VPN/addons/tutorial_04_split_tunneling3.rcc" is valid.
```

On production everyone is valid, so at least that is good
```
Generated resource file "/Users/beatrizrizental/Library/Application Support/Mozilla VPN/addons/guide_01_how_to_vpn.rcc" is valid.
Generated resource file "/Users/beatrizrizental/Library/Application Support/Mozilla VPN/addons/guide_02_is_my_vpn_working_correctly.rcc" is valid.
Generated resource file "/Users/beatrizrizental/Library/Application Support/Mozilla VPN/addons/guide_03_adding_and_removing_devices.rcc" is valid.
Generated resource file "/Users/beatrizrizental/Library/Application Support/Mozilla VPN/addons/guide_05_what_is_multi_hop.rcc" is valid.
Generated resource file "/Users/beatrizrizental/Library/Application Support/Mozilla VPN/addons/guide_06_benefits_of_custom_dns.rcc" is valid.
Generated resource file "/Users/beatrizrizental/Library/Application Support/Mozilla VPN/addons/guide_07_app_permissions.rcc" is valid.
Generated resource file "/Users/beatrizrizental/Library/Application Support/Mozilla VPN/addons/guide_08_privacy_features.rcc" is valid.
Generated resource file "/Users/beatrizrizental/Library/Application Support/Mozilla VPN/addons/guide_09_custom_dns.rcc" is valid.
Generated resource file "/Users/beatrizrizental/Library/Application Support/Mozilla VPN/addons/guide_10_app_exclusions.rcc" is valid.
Generated resource file "/Users/beatrizrizental/Library/Application Support/Mozilla VPN/addons/guide_11_recommended_servers.rcc" is valid.
Generated resource file "/Users/beatrizrizental/Library/Application Support/Mozilla VPN/addons/guide_12_multi_account_containers.rcc" is valid.
Generated resource file "/Users/beatrizrizental/Library/Application Support/Mozilla VPN/addons/message_dom.rcc" is valid.
Generated resource file "/Users/beatrizrizental/Library/Application Support/Mozilla VPN/addons/message_subscription_expiring.rcc" is valid.
Generated resource file "/Users/beatrizrizental/Library/Application Support/Mozilla VPN/addons/message_survey.rcc" is valid.
Generated resource file "/Users/beatrizrizental/Library/Application Support/Mozilla VPN/addons/message_survey_staging_1h.rcc" is valid.
Generated resource file "/Users/beatrizrizental/Library/Application Support/Mozilla VPN/addons/message_survey_staging_30m.rcc" is valid.
Generated resource file "/Users/beatrizrizental/Library/Application Support/Mozilla VPN/addons/message_update_v2.15.rcc" is valid.
Generated resource file "/Users/beatrizrizental/Library/Application Support/Mozilla VPN/addons/message_whats_new_v2.10.rcc" is valid.
Generated resource file "/Users/beatrizrizental/Library/Application Support/Mozilla VPN/addons/message_whats_new_v2.11.rcc" is valid.
Generated resource file "/Users/beatrizrizental/Library/Application Support/Mozilla VPN/addons/message_whats_new_v2.12.rcc" is valid.
Generated resource file "/Users/beatrizrizental/Library/Application Support/Mozilla VPN/addons/message_whats_new_v2.13.rcc" is valid.
Generated resource file "/Users/beatrizrizental/Library/Application Support/Mozilla VPN/addons/message_whats_new_v2.14.rcc" is valid.
Generated resource file "/Users/beatrizrizental/Library/Application Support/Mozilla VPN/addons/message_whats_new_v2.15.rcc" is valid.
Generated resource file "/Users/beatrizrizental/Library/Application Support/Mozilla VPN/addons/tutorial_01_get_started.rcc" is valid.
Generated resource file "/Users/beatrizrizental/Library/Application Support/Mozilla VPN/addons/tutorial_01_get_started_recommended_locations.rcc" is valid.
Generated resource file "/Users/beatrizrizental/Library/Application Support/Mozilla VPN/addons/tutorial_02_connect_on_startup.rcc" is valid.
Generated resource file "/Users/beatrizrizental/Library/Application Support/Mozilla VPN/addons/tutorial_03_multi_hop.rcc" is valid.
Generated resource file "/Users/beatrizrizental/Library/Application Support/Mozilla VPN/addons/tutorial_04_split_tunneling.rcc" is valid.
Generated resource file "/Users/beatrizrizental/Library/Application Support/Mozilla VPN/addons/tutorial_04_split_tunneling2.rcc" is valid.
Generated resource file "/Users/beatrizrizental/Library/Application Support/Mozilla VPN/addons/tutorial_04_split_tunneling3.rcc" is valid.
```
