### PR TITLE
Chore - Schedule Sentry Tasks instantly

### DIFF
--- a/src/apps/vpn/mozillavpn.cpp
+++ b/src/apps/vpn/mozillavpn.cpp
@@ -897,6 +897,8 @@ void MozillaVPN::mainWindowLoaded() {
 #endif
 #ifdef SENTRY_ENABLED
   SentryAdapter::instance()->init();
+  QObject::connect(controller(), &Controller::readyToQuit,
+                   SentryAdapter::instance(), &SentryAdapter::onBeforeShutdown);
 #endif
 }
 

--- a/src/shared/sentry/sentryadapter.cpp
+++ b/src/shared/sentry/sentryadapter.cpp
@@ -64,8 +64,6 @@ void SentryAdapter::init() {
       QStandardPaths::writableLocation(QStandardPaths::AppLocalDataLocation));
   QString sentryFolder = dataDir.absoluteFilePath("sentry");
 
-  connect(qApp, &QCoreApplication::aboutToQuit, this,
-          &SentryAdapter::onBeforeShutdown);
   connect(log, &LogHandler::logEntryAdded, this,
           &SentryAdapter::onLoglineAdded);
 
@@ -115,7 +113,10 @@ void SentryAdapter::report(const QString& errorType, const QString& message,
   sentry_capture_event(event);
 }
 
-void SentryAdapter::onBeforeShutdown() { sentry_close(); }
+void SentryAdapter::onBeforeShutdown() {
+  sentry_end_session();
+  sentry_close();
+}
 
 void SentryAdapter::onLoglineAdded(const QByteArray& line) {
   if (!m_initialized) {
@@ -149,11 +150,10 @@ void SentryAdapter::transportEnvelope(sentry_envelope_t* envelope,
   sentry_free(sentry_buf);
 
   auto t = new TaskSentry(qt_owned_buffer);
-  TaskScheduler::scheduleTask(t);
+  TaskScheduler::scheduleTaskNow(t);
 }
 
 SentryAdapter::UserConsentResult SentryAdapter::hasCrashUploadConsent() const {
-  Q_ASSERT(m_initialized);
   // We have not yet asked the user - let's do that.
   if (m_userConsent == UserConsentResult::Pending) {
     emit needsCrashReportScreen();

--- a/src/shared/sentry/sentryadapter.h
+++ b/src/shared/sentry/sentryadapter.h
@@ -61,7 +61,7 @@ class SentryAdapter final : public QObject {
    * or drisk writes.
    * After calling this, any call to sentry is UB.
    */
-  Q_SLOT void onBeforeShutdown();
+  static void onBeforeShutdown();
 
   /**
    * @brief Callback for when sentry's backend recieved a crash.

--- a/src/shared/tasks/sentry/tasksentry.cpp
+++ b/src/shared/tasks/sentry/tasksentry.cpp
@@ -34,6 +34,8 @@ void TaskSentry::run() {
   }
   // If it's still unknown, parsing failed. abort.
   if (m_Type == ContentType::Unknown) {
+    logger.info() << "Dropping Sentry-Ping:Unknown";
+    logger.info() << m_envelope;
     emit completed();
     return;
   }


### PR DESCRIPTION
## Description

I've been looking why we have so many "Abnormal" sessions in sentry and so little healthy ones. 
Problem is, session_end will attempt to send a request, if that fails we're abnormal. 

So let's try to do that immediatly instead of scheudling a new task. So we have better channces to get that out. 
This also makes the crash report screen pop instantly, which also is nice c: 


