### PR TITLE
VPN-5275: Fix app permissions and collapsible card layouts

### DIFF
--- a/nebula/ui/components/MZCollapsibleCard.qml
+++ b/nebula/ui/components/MZCollapsibleCard.qml
@@ -163,14 +163,13 @@ Rectangle {
         Column {
             id: column
 
-            Layout.preferredWidth: accordionTitle.width
             Layout.leftMargin: icon.width + MZTheme.theme.listSpacing * 4
             Layout.rightMargin: MZTheme.theme.listSpacing
 
             ColumnLayout {
                 id: cardContent
 
-                width: parent.width
+                width: accordionTitle.width
 
                 //becomes invisible so that it is no longer calculated in the implicitHeight (or picked up by screen readers)
                 visible: opacity > 0

--- a/src/apps/vpn/ui/screens/settings/appPermissions/AppPermissionsList.qml
+++ b/src/apps/vpn/ui/screens/settings/appPermissions/AppPermissionsList.qml
@@ -20,6 +20,8 @@ ColumnLayout {
 
     spacing: MZTheme.theme.vSpacing
 
+    Layout.preferredWidth: parent.width
+
     MZSearchBar {
         property bool sorted: false;
         id: searchBarWrapper
@@ -38,7 +40,8 @@ ColumnLayout {
         objectName: "appExclusionsList"
 
         spacing: MZTheme.theme.windowMargin / 2
-        Layout.fillWidth: true
+
+        Layout.preferredWidth: parent.width
 
         MZLinkButton {
             property int numDisabledApps: MZSettings.vpnDisabledApps.length

--- a/src/apps/vpn/ui/screens/settings/appPermissions/ViewAppPermissions.qml
+++ b/src/apps/vpn/ui/screens/settings/appPermissions/ViewAppPermissions.qml
@@ -26,6 +26,8 @@ MZViewBase {
     _menuTitle: MZI18n.SettingsAppExclusionSettings
     _viewContentData: ColumnLayout {
 
+        Layout.preferredWidth: parent.width
+
         Loader {
             Layout.leftMargin: MZTheme.theme.windowMargin
             Layout.rightMargin: MZTheme.theme.windowMargin


### PR DESCRIPTION
## Description

- Fix layout for app permissions view and collapsible card components on Qt 6.4

| Before | After |
| ------------- | ------------- |
| <img width="472" alt="Screenshot 2023-07-27 at 2 42 52 PM" src="https://github.com/mozilla-mobile/mozilla-vpn-client/assets/15353801/e56b6a57-4efc-456b-aea5-094cb864a067"> | <img width="472" alt="Screenshot 2023-07-27 at 2 41 53 PM" src="https://github.com/mozilla-mobile/mozilla-vpn-client/assets/15353801/7daa7ed4-0e0e-4e7f-aba4-f244cbe68ee8"> |
| <img width="472" alt="Screenshot 2023-07-27 at 2 42 30 PM" src="https://github.com/mozilla-mobile/mozilla-vpn-client/assets/15353801/9e64f0d0-3c69-4b0f-b58e-c117ec23ee3e"> | <img width="472" alt="Screenshot 2023-07-27 at 2 41 41 PM" src="https://github.com/mozilla-mobile/mozilla-vpn-client/assets/15353801/f0aaa379-f768-420d-bfde-309442932586"> |

## Reference

[VPN-5275: Layout/UI issues in the client (Qt 6.4.2)](https://mozilla-hub.atlassian.net/browse/VPN-5275)