### PR TITLE
NIT: Finalize Sentry release on GH Release step

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,25 @@
+name: Post GH releases Actions
+
+on:
+  release:
+    types: [published] 
+  workflow_dispatch:
+
+jobs:
+  update_sentry_info:
+    name: Sentry - Mark as Released
+    runs-on: ubuntu-latest
+    steps:
+        - name: Clone repository
+          uses: actions/checkout@v2
+        - name: Get Files
+          env:
+            SENTRY_KEY: ${{ secrets.SENTRY_KEY }}
+          run: | 
+            TAG=${{github.ref_name}}
+            VERSION=${TAG:1}
+            npm install -g @sentry/cli
+            sentry-cli login --auth-token $SENTRY_KEY            
+            sentry-cli releases --org mozilla -p vpn-client finalize $VERSION
+
+          

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,7 +12,7 @@ jobs:
     steps:
         - name: Clone repository
           uses: actions/checkout@v2
-        - name: Get Files
+        - name: Finalize sentry-cli release
           env:
             SENTRY_KEY: ${{ secrets.SENTRY_KEY }}
           run: | 
@@ -22,4 +22,3 @@ jobs:
             sentry-cli login --auth-token $SENTRY_KEY            
             sentry-cli releases --org mozilla -p vpn-client finalize $VERSION
 
-          


### PR DESCRIPTION
## Description
Sentry does not parse versions, but orders them by "newest" seen. 
This is annoying, because if we do a dot release, the timeline is fucked. 
And that ruin's regressions, i.e i mark a bug solved in 2.17 - it will instantly pop up again because sentry thinks 2.15.1 is newer .___. 


<img width="144" alt="image" src="https://github.com/mozilla-mobile/mozilla-vpn-client/assets/9611612/ab772ba7-72db-4b96-909f-ccd7f085b6db">


So let's mark a release as "done" whenever we publish them on gh, that will make sure the order is correct... or at least the same as our gh releases :) 
