### PR TITLE
VPN-5305: Fix edit button in devices view

### DIFF
--- a/nebula/ui/themes/main/theme.js
+++ b/nebula/ui/themes/main/theme.js
@@ -30,9 +30,9 @@ theme.orangeHovered = '#E27F2E';
 theme.orangeFocus = '#4DE27F2E';
 theme.orangePressed = '#C45A27';
 theme.purple60 = '#7542E5';
-theme.red = '#FF4F5E';
-theme.redHovered = '#E22850';
-theme.redPressed = '#C50042';
+theme.red = '#E22850';
+theme.redHovered = '#C50042';
+theme.redPressed = '#810220';
 theme.redDisabled = '#FFBDC5';
 theme.redfocusOutline = '#66C50042';
 theme.redBadgeText = "#810220";
@@ -204,8 +204,8 @@ theme.redButton = {
   'buttonHovered': theme.redHovered,
   'buttonPressed': theme.redPressed,
   'buttonDisabled': theme.redDisabled,
-  'focusOutline': theme.redfocusOutline,
-  'focusBorder': theme.redPressed,
+  'focusOutline': theme.redDisabled,
+  'focusBorder': theme.redHovered,
 };
 
 theme.redLinkButton = {

--- a/src/apps/vpn/ui/screens/devices/VPNDeviceList.qml
+++ b/src/apps/vpn/ui/screens/devices/VPNDeviceList.qml
@@ -115,7 +115,7 @@ ListView {
     Connections {
         target: VPNDeviceModel
         function onActiveDevicesChanged() {
-            if(!listView.anySwipesOpen()) listView.isEditing(false)
+            if (!listView.anySwipesOpen()) listView.isEditing(false)
         }
     }
 

--- a/src/apps/vpn/ui/screens/devices/VPNDeviceList.qml
+++ b/src/apps/vpn/ui/screens/devices/VPNDeviceList.qml
@@ -112,6 +112,13 @@ ListView {
         }
     }
 
+    Connections {
+        target: VPNDeviceModel
+        function onActiveDevicesChanged() {
+            if(!listView.anySwipesOpen()) listView.isEditing(false)
+        }
+    }
+
     Timer {
         id: delayTimer
         interval: 300

--- a/src/apps/vpn/ui/screens/devices/ViewDevices.qml
+++ b/src/apps/vpn/ui/screens/devices/ViewDevices.qml
@@ -25,7 +25,7 @@ MZViewBase {
             property bool skipEnsureVisible: true
 
             enabled: VPNDeviceModel.activeDevices > 1
-            labelText: !vpnFlickable.isEditing || VPNDeviceModel.activeDevices < 2 ? MZI18n.InAppMessagingEditButton : MZI18n.InAppSupportWorkflowSupportResponseButton
+            labelText: (!vpnFlickable.isEditing || VPNDeviceModel.activeDevices < 2) ? MZI18n.InAppMessagingEditButton : MZI18n.InAppSupportWorkflowSupportResponseButton
             onClicked: {
                 vpnFlickable.isEditing = !vpnFlickable.isEditing
             }

--- a/src/apps/vpn/ui/screens/devices/ViewDevices.qml
+++ b/src/apps/vpn/ui/screens/devices/ViewDevices.qml
@@ -24,8 +24,8 @@ MZViewBase {
             property bool isEditing: false
             property bool skipEnsureVisible: true
 
-            enabled: VPNDeviceModel.rowCount() > 1
-            labelText: !vpnFlickable.isEditing ? MZI18n.InAppMessagingEditButton : MZI18n.InAppSupportWorkflowSupportResponseButton
+            enabled: VPNDeviceModel.activeDevices > 1
+            labelText: !vpnFlickable.isEditing || VPNDeviceModel.activeDevices < 2 ? MZI18n.InAppMessagingEditButton : MZI18n.InAppSupportWorkflowSupportResponseButton
             onClicked: {
                 vpnFlickable.isEditing = !vpnFlickable.isEditing
             }


### PR DESCRIPTION
## Description

- "Edit" button "enabled" state in devices view is now bound to active device count, so that if a second device is added or all devices (excluding the current device) are removed, the "Edit" button will enable/disable accordingly (without the need to reload the view)
- "Edit" / "Done" label text now updates to the correct state when a device is added/removed from the list by signing in/out from another device (without the need to reload the view)
-  Fix the Red Button theme to match the design system (it is now more accessible with better contrast)

## Reference

[VPN-5305: The “Edit” button from My devices screen remains disabled when new device is added](https://mozilla-hub.atlassian.net/browse/VPN-5305)
