### PR TITLE
VPN-5246 - Turn off Sentry for iOS to prevent crashes

### DIFF
--- a/src/shared/featurelist.h
+++ b/src/shared/featurelist.h
@@ -59,7 +59,7 @@ FEATURE(sentry,                     // Feature ID
         FeatureCallback_true,       // Can be flipped on
         FeatureCallback_true,       // Can be flipped off
         QStringList(),              // feature dependencies
-        FeatureCallback_true)
+        FeatureCallback_sentry)
 
 FEATURE(shareLogs,              // Feature ID
         "Share Logs",           // Feature name

--- a/src/shared/featurelistcallback.h
+++ b/src/shared/featurelistcallback.h
@@ -29,6 +29,14 @@ bool FeatureCallback_iosOrAndroid() {
 // Custom callback functions
 // -------------------------
 
+bool FeatureCallback_sentry() {
+#if defined(MZ_IOS)
+  return false;
+#else
+  return true;
+#endif
+}
+
 bool FeatureCallback_shareLogs() {
 #if defined(MZ_WINDOWS) || defined(MZ_LINUX) || defined(MZ_MACOS) || \
     defined(MZ_IOS) || defined(MZ_DUMMY)


### PR DESCRIPTION
## Description

VPN-5246's crash is caused by Sentry on iOS. Sentry creates Android and iOS specific SDKs, but we’re using the native (C/C++) one for all platforms. It seems like this Sentry native SDK [explicitly includes Qt support](https://docs.sentry.io/platforms/native/guides/qt/). However, from that documentation: `The Qt integration is part of the sentry-native SDK, which currently supports Windows, macOS, Linux, and Android.` Additionally, in the sentry-[native SDK readme](https://github.com/getsentry/sentry-native/#platform-and-feature-support), iOS support is nowhere to be found.

Thus, I believe we should not include use the Sentry native SDK on iOS. Per discussion on the ticket, we're feature flagging this for now so we can investigate this further. I've also added a new ticket to re-add Sentry back in: https://mozilla-hub.atlassian.net/browse/VPN-5324

## Reference

https://mozilla-hub.atlassian.net/browse/VPN-5324

## Checklist
    
- [X] My code follows the style guidelines for this project
- [X] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [X] I have performed a self review of my own code
- [X] I have commented my code PARTICULARLY in hard to understand areas
- [X] I have added thorough tests where needed
