### PR TITLE
Uplift PR #7679 to 2.16.1 release branch (VPN-5246 - Turn off sentry for iOS)

### DIFF
--- a/src/shared/featurelist.h
+++ b/src/shared/featurelist.h
@@ -59,7 +59,7 @@ FEATURE(sentry,                     // Feature ID
         FeatureCallback_true,       // Can be flipped on
         FeatureCallback_true,       // Can be flipped off
         QStringList(),              // feature dependencies
-        FeatureCallback_true)
+        FeatureCallback_sentry)
 
 FEATURE(shareLogs,              // Feature ID
         "Share Logs",           // Feature name

--- a/src/shared/featurelistcallback.h
+++ b/src/shared/featurelistcallback.h
@@ -29,6 +29,14 @@ bool FeatureCallback_iosOrAndroid() {
 // Custom callback functions
 // -------------------------
 
+bool FeatureCallback_sentry() {
+#if defined(MZ_IOS)
+  return false;
+#else
+  return true;
+#endif
+}
+
 bool FeatureCallback_shareLogs() {
 #if defined(MZ_WINDOWS) || defined(MZ_LINUX) || defined(MZ_MACOS) || \
     defined(MZ_IOS) || defined(MZ_DUMMY)


### PR DESCRIPTION
Uplift https://github.com/mozilla-mobile/mozilla-vpn-client/pull/7679 to 2.16.1. 

iOS is not getting the 2.16.0 release; we're holding the iOS release on this cherry pick. Once merged, we'll roll out 2.16.1 to iOS.
