### PR TITLE
VPN-5328: Fix device list item text layout

### DIFF
--- a/src/apps/vpn/ui/screens/devices/VPNDeviceListItem.qml
+++ b/src/apps/vpn/ui/screens/devices/VPNDeviceListItem.qml
@@ -74,7 +74,10 @@ MZSwipeDelegate {
                 spacing: 0
 
                 MZInterLabel {
+                    Layout.fillWidth: true
+
                     text: name
+                    maximumLineCount: 1
                     elide: Text.ElideRight
                     horizontalAlignment: Text.AlignLeft
                 }
@@ -82,10 +85,10 @@ MZSwipeDelegate {
                 MZTextBlock {
                     Layout.fillWidth: true
 
-                    verticalAlignment: Text.AlignVCenter
-                    wrapMode: Text.WrapAtWordBoundaryOrAnywhere
-
                     text: deviceSubtitle()
+                    maximumLineCount: 1
+                    elide: Text.ElideRight
+                    verticalAlignment: Text.AlignVCenter
                 }
             }
         }


### PR DESCRIPTION
## Description

- Elide device name and subtitle after 1 line

| Before  | After |
| ------------- | ------------- |
| ![image](https://github.com/mozilla-mobile/mozilla-vpn-client/assets/15353801/61a4cd88-ec6c-4ef9-97b7-ce24ba98dc2a) | ![image](https://github.com/mozilla-mobile/mozilla-vpn-client/assets/15353801/0e9ca000-06e9-4894-8501-81ad409fe9c5) |

## Reference

[VPN-5328: Long device name is not wrapped in “My devices” screen](https://mozilla-hub.atlassian.net/browse/VPN-5328)
