### PR TITLE
QML-Perf: Load City Elements On demand

### DIFF
--- a/src/apps/vpn/ui/screens/home/servers/ServerCountry.qml
+++ b/src/apps/vpn/ui/screens/home/servers/ServerCountry.qml
@@ -21,7 +21,13 @@ MZClickableRow {
     property string _countryCode: code
     property var currentCityIndex
     property alias serverCountryName: countryName.text
-    property alias cityList: cityLoader.item
+    property var cityList: cityListVisible ? cityLoader.item : cityLoader
+
+    Component.onCompleted:{
+        if(cityListVisible){
+            cityLoader.active = true
+        }
+    }
 
     // The city connection score can be used for every case except the multihop exit location,
     // where we need to use the scoring between the entry and exit locations instead.
@@ -82,10 +88,10 @@ MZClickableRow {
             name: "listOpen"
 
             PropertyChanges {
-                target: serverCountry
-                height: serverCountryRow.height + cityList.height
+                        target: serverCountry
+                        height: serverCountryRow.height + cityList.height
             }
-
+            
             PropertyChanges {
                 target: cityList
                 opacity: 1
@@ -120,18 +126,18 @@ MZClickableRow {
                 
         },
         Transition {
-            to: "listOpen"
-            PropertyAnimation {
-                target: serverCountry
-                property: "height"
-                to: serverCountryRow.height + cityList.implicitHeight
-                duration: animationDuration
-            }
-            PropertyAnimation {
-                target: cityList
-                property: "opacity"
-                duration: 0
-            }
+            to: "listOpen"               
+                    PropertyAnimation {
+                        target: serverCountry
+                        property: "height"
+                        to: serverCountryRow.height + cityList.implicitHeight
+                        duration: animationDuration
+                    }
+                    PropertyAnimation {
+                        target: cityList
+                        property: "opacity"
+                        duration: 0
+                    }
         }
 
     ]

--- a/tools/inspector/views/view-ui.js
+++ b/tools/inspector/views/view-ui.js
@@ -208,15 +208,34 @@ export class ViewUi extends LitElement {
     this.requestUpdate('data')
   }
 
+  getElementCount(node) {
+    if (!node) {
+      return 0;
+    }
+    if (node.subItems.length == 0) {
+      return 1;
+    }
+    return node.subItems.reduce((i, n) => i + this.getElementCount(n), 0)
+  }
+
   render () {
     return html`
          <nav>
-            <pill-toggle noActive="true"  @click=${(e) => {this.saveImage()}}>Download Image</pill-toggle>
+            <span>Total Elements: ${
+        this.data ? this.getElementCount(this.data[0]) : 0}</span>
+            <pill-toggle noActive="true"  @click=${(e) => {
+      this.saveImage()
+    }}>Download Image</pill-toggle>
             <span>Settings:</span>
-            ${Object.keys(this.settings).map(e => html` <pill-toggle id="${e}" @click=${() => this.quickFilterChange(e)}>${e}</pill-toggle>`)}
+            ${
+        Object.keys(this.settings)
+            .map(
+                e => html` <pill-toggle id="${e}" @click=${
+                    () => this.quickFilterChange(e)}>${e}</pill-toggle>`)}
         </nav>
         <main>
-          <live-view .qmlHighlight=${this.detail} .showRulers=${this.settings['Show Rulers']}></live-view>
+          <live-view .qmlHighlight=${this.detail} .showRulers=${
+        this.settings['Show Rulers']}></live-view>
           <ul style="flex:1;">
             ${this.data ? this.renderNode(this.data[0]) : ''}
           </ul>


### PR DESCRIPTION
- [QML] Serverlist: Only Create CityElements if the Country is expanded
- Auto activate the loader, if this is the currnet list
- Expand the Inspector to count elements

## Description

    Describe your changes

## Reference

    i.e Jira or Github issue URL

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
