### PR TITLE
QML Perf: Single-Hop - only load the current selected tab

### DIFF
--- a/src/apps/vpn/ui/screens/home/servers/ServerList.qml
+++ b/src/apps/vpn/ui/screens/home/servers/ServerList.qml
@@ -368,12 +368,12 @@ FocusScope {
                 Loader {
                     id: loaderServersRecommended
                     sourceComponent: listServersRecommended
-                    active: serverTabs.currentTab.objectName == "tabRecommendedServers"
+                    active: serverTabs.currentTab.objectName === "tabRecommendedServers"
                 },
                 Loader {
                     id: loaderServersAll
                     sourceComponent: listServersAll
-                    active: serverTabs.currentTab.objectName == "tabAllServers"
+                    active: serverTabs.currentTab.objectName === "tabAllServers"
                 }
             ]
 

--- a/src/apps/vpn/ui/screens/home/servers/ServerList.qml
+++ b/src/apps/vpn/ui/screens/home/servers/ServerList.qml
@@ -368,10 +368,12 @@ FocusScope {
                 Loader {
                     id: loaderServersRecommended
                     sourceComponent: listServersRecommended
+                    active: serverTabs.currentTab.objectName == "tabRecommendedServers"
                 },
                 Loader {
                     id: loaderServersAll
                     sourceComponent: listServersAll
+                    active: serverTabs.currentTab.objectName == "tabAllServers"
                 }
             ]
 


### PR DESCRIPTION
See also 🔗 https://github.com/mozilla-mobile/mozilla-vpn-client/pull/7745

## Description
We are loading both the "recomended" part and the whole list - which consumes time and actually makes them both navigateable from talkback. 

Let's unload the part that we don't want to show
