### PR TITLE
VPN-5147: Create MZStepNavigation nebula component

### DIFF
--- a/nebula/ui/components/CMakeLists.txt
+++ b/nebula/ui/components/CMakeLists.txt
@@ -88,6 +88,7 @@ qt_add_qml_module(components
          MZInformationCard.qml
          MZStepProgressBar.qml
          MZStepProgressBarDelegate.qml
+         MZStepNavigation.qml
          navigationBar/MZBottomNavigationBar.qml
          navigationBar/MZBottomNavigationBarButton.qml
          navigator/MZNavigatorLoader.qml

--- a/nebula/ui/components/MZStepNavigation.qml
+++ b/nebula/ui/components/MZStepNavigation.qml
@@ -4,9 +4,15 @@ import QtQuick.Layouts 1.15
 
 import Mozilla.Shared 1.0
 
-//Usage: pass views to this component using views property
-//Note: views must be passed in order that they will appear within the navigation
-//Note: Glitchy when used inside MZViewBase and does not consider the navbar
+//MZStepNavigation is a navigation component(similar to MZSegmentedNavigation and MZTabNavigation) comprised of an MZStepProgressBar in which each step corresponds to a view
+//Views reside within a StackView, and as the navigation progresses, new views are pushed on top of the previous views
+
+//Note: Views must be passed in order that they will appear within the navigation
+//Note: Does not consider the navbar
+//Warning: MZSegmentedNavigation does not currently function properly when placed directly inside an MZViewBase's `_viewContentData` (something isn't sizing right).
+//Current workaround is to disable clipping, but provides a glitchy-looking experience (due to the lack of clipping)
+
+//Usage: pass a list of views to this component using the `views` property
 /*
         views: [
             Item {
@@ -31,15 +37,19 @@ ColumnLayout {
     property int currentIndex: 0
 
     function next() {
-        stackView.push(views[stepProgressBar.activeIndex + 1])
-        currentIndex = stepProgressBar.activeIndex + 1
-        stepProgressBar.activeIndex++
+        if (stepProgressBar.activeIndex + 1 < stepProgressBar.model.count) {
+            stackView.push(views[stepProgressBar.activeIndex + 1])
+            currentIndex = stepProgressBar.activeIndex + 1
+            stepProgressBar.activeIndex++
+        }
     }
 
     function back() {
-        stackView.pop()
-        currentIndex = stepProgressBar.activeIndex - 1
-        stepProgressBar.activeIndex--
+        if (stepProgressBar.activeIndex - 1 >= 0) {
+            stackView.pop()
+            currentIndex = stepProgressBar.activeIndex - 1
+            stepProgressBar.activeIndex--
+        }
     }
 
     function activeIndexChanged() {

--- a/nebula/ui/components/MZStepNavigation.qml
+++ b/nebula/ui/components/MZStepNavigation.qml
@@ -1,0 +1,88 @@
+import QtQuick 2.5
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+
+//Usage: pass views to this component using views property
+//Note: views must be passed in order that they will appear within the navigation
+/*
+        views: [
+            Item {
+                property string labelText: <labelText>
+                property string iconSource: <iconSource>
+
+                ...
+            },
+            Item {
+                property string labelText: <labelText>
+                property string iconSource: <iconSource>
+
+                ...
+            }
+        ]
+*/
+
+ColumnLayout {
+    id: stepNavigation
+
+    property list<Item> views
+    property int currentIndex: 0
+
+    function next() {
+        stackView.push(views[stepProgressBar.activeIndex + 1])
+        currentIndex = stepProgressBar.activeIndex + 1
+        stepProgressBar.activeIndex++
+    }
+
+    function back() {
+        stackView.pop()
+        currentIndex = stepProgressBar.activeIndex - 1
+        stepProgressBar.activeIndex--
+    }
+
+    function activeIndexChanged() {
+        let temp = currentIndex
+        for (let i = 0; i < currentIndex - stepProgressBar.activeIndex; i++) {
+            temp--
+            stackView.pop()
+        }
+        currentIndex = temp
+    }
+
+    spacing: 0
+
+    Component.onCompleted: {
+        //Fill the MZStepProgressBar model with labels and icons
+        for (let i = 0; i < views.length; i++) {
+            stepProgressBarListModel.append({"labelText": views[i].labelText, "iconSource": views[i].iconSource})
+        }
+    }
+
+    ListModel { id: stepProgressBarListModel }
+
+    MZStepProgressBar {
+        id: stepProgressBar
+
+        //May need to eventually make these margins top-level properties so they can be modified externally
+        Layout.topMargin: 24
+        Layout.leftMargin: 44
+        Layout.rightMargin: 44
+        Layout.fillWidth: true
+        Layout.maximumWidth: 500
+
+        onActiveIndexChanged: {
+            stepNavigation.activeIndexChanged()
+        }
+
+        model: stepProgressBarListModel
+    }
+
+    StackView {
+        id: stackView
+        Layout.fillWidth: true
+        implicitHeight: 502
+
+        Component.onCompleted: {
+            push(stepNavigation.views[0])
+        }
+    }
+}

--- a/nebula/ui/components/MZStepNavigation.qml
+++ b/nebula/ui/components/MZStepNavigation.qml
@@ -2,6 +2,8 @@ import QtQuick 2.5
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
 
+import Mozilla.Shared 1.0
+
 //Usage: pass views to this component using views property
 //Note: views must be passed in order that they will appear within the navigation
 /*
@@ -26,6 +28,8 @@ ColumnLayout {
 
     property list<Item> views
     property int currentIndex: 0
+//    property alias stackView: stackView
+//    property alias stepProgressBar: stepProgressBar
 
     function next() {
         stackView.push(views[stepProgressBar.activeIndex + 1])
@@ -62,27 +66,39 @@ ColumnLayout {
     MZStepProgressBar {
         id: stepProgressBar
 
-        //May need to eventually make these margins top-level properties so they can be modified externally
+        //May need to eventually expose these margins so they can be modified externally
         Layout.topMargin: 24
         Layout.leftMargin: 44
         Layout.rightMargin: 44
         Layout.fillWidth: true
-        Layout.maximumWidth: 500
+        Layout.maximumWidth: 500 //Max size of progess bar for tablets
 
-        onActiveIndexChanged: {
-            stepNavigation.activeIndexChanged()
-        }
+        onActiveIndexChanged: stepNavigation.activeIndexChanged()
 
         model: stepProgressBarListModel
     }
 
-    StackView {
-        id: stackView
-        Layout.fillWidth: true
-        implicitHeight: 502
+    MZFlickable {
+        id: flickable
 
-        Component.onCompleted: {
-            push(stepNavigation.views[0])
+        Layout.fillWidth: true
+        Layout.fillHeight: true
+        flickContentHeight: stackView.currentItem.implicitHeight + stackView.currentItem.anchors.topMargin + stackView.currentItem.anchors.bottomMargin
+
+        StackView {
+            id: stackView
+
+            anchors.top: parent.top
+            anchors.left: parent.left
+            anchors.right: parent.right
+
+            implicitWidth: flickable.width
+            implicitHeight: flickable.height
+
+            Component.onCompleted: {
+                push(stepNavigation.views[0])
+            }
         }
     }
+
 }

--- a/nebula/ui/components/MZStepNavigation.qml
+++ b/nebula/ui/components/MZStepNavigation.qml
@@ -6,6 +6,7 @@ import Mozilla.Shared 1.0
 
 //Usage: pass views to this component using views property
 //Note: views must be passed in order that they will appear within the navigation
+//Note: Glitchy when used inside MZViewBase and does not consider the navbar
 /*
         views: [
             Item {
@@ -28,8 +29,6 @@ ColumnLayout {
 
     property list<Item> views
     property int currentIndex: 0
-//    property alias stackView: stackView
-//    property alias stepProgressBar: stepProgressBar
 
     function next() {
         stackView.push(views[stepProgressBar.activeIndex + 1])
@@ -66,8 +65,6 @@ ColumnLayout {
     MZStepProgressBar {
         id: stepProgressBar
 
-        //May need to eventually expose these margins so they can be modified externally
-        Layout.topMargin: 24
         Layout.leftMargin: 44
         Layout.rightMargin: 44
         Layout.fillWidth: true
@@ -83,6 +80,10 @@ ColumnLayout {
 
         Layout.fillWidth: true
         Layout.fillHeight: true
+
+        //Necessary to function inside an MZViewBase, but is glitchy and should be revisted if we ever need to use with an MZViewBase
+        clip: false
+
         flickContentHeight: stackView.currentItem.implicitHeight + stackView.currentItem.anchors.topMargin + stackView.currentItem.anchors.bottomMargin
 
         StackView {
@@ -92,7 +93,6 @@ ColumnLayout {
             anchors.left: parent.left
             anchors.right: parent.right
 
-            implicitWidth: flickable.width
             implicitHeight: flickable.height
 
             Component.onCompleted: {

--- a/nebula/ui/components/MZStepProgressBar.qml
+++ b/nebula/ui/components/MZStepProgressBar.qml
@@ -55,8 +55,8 @@ Item {
             model: progressBar.model
             delegate:  MZStepProgressBarDelegate {
                 id: progressBarDelegate
-                iconSource: model.iconSource
-                labelText: MZI18n[model.labelText]
+                source: model.source
+                labelText: model.labelText
                 labelWidth: progressBar.width / progressBar.model.count
                 currentState: {
                     if (index === activeIndex) {

--- a/nebula/ui/components/MZStepProgressBar.qml
+++ b/nebula/ui/components/MZStepProgressBar.qml
@@ -72,7 +72,8 @@ Item {
 
                 onClicked: activeIndex = index
 
-                accessibleName: currentState === MZStepProgressBarDelegate.State.Complete ? MZI18n.OnboardingProgressBarAccessibilityStepComplete.arg(labelText).arg(index + 1).arg(progressBar.model.count)                                                                                           : MZI18n.OnboardingProgressBarAccessibilityStepCurrent.arg(labelText).arg(index + 1).arg(progressBar.model.count)
+                accessibleName: currentState === MZStepProgressBarDelegate.State.Complete ? MZI18n.OnboardingProgressBarAccessibilityStepComplete.arg(labelText).arg(index + 1).arg(progressBar.model.count)
+                                                                                          : MZI18n.OnboardingProgressBarAccessibilityStepCurrent.arg(labelText).arg(index + 1).arg(progressBar.model.count)
             }
         }
     }

--- a/nebula/ui/components/MZStepProgressBar.qml
+++ b/nebula/ui/components/MZStepProgressBar.qml
@@ -55,8 +55,8 @@ Item {
             model: progressBar.model
             delegate:  MZStepProgressBarDelegate {
                 id: progressBarDelegate
-                source: model.source
-                labelText: model.labelText
+                iconSource: model.iconSource
+                labelText: MZI18n[model.labelText]
                 labelWidth: progressBar.width / progressBar.model.count
                 currentState: {
                     if (index === activeIndex) {

--- a/nebula/ui/components/MZStepProgressBar.qml
+++ b/nebula/ui/components/MZStepProgressBar.qml
@@ -70,10 +70,9 @@ Item {
                     }
                 }
 
-                accessibleName: currentState === MZStepProgressBarDelegate.State.Complete ? MZI18n.OnboardingProgressBarAccessibilityStepComplete.arg(labelText).arg(index + 1).arg(progressBar.model.count)
-                                                                                           : MZI18n.OnboardingProgressBarAccessibilityStepCurrent.arg(labelText).arg(index + 1).arg(progressBar.model.count)
-
                 onClicked: activeIndex = index
+
+                accessibleName: currentState === MZStepProgressBarDelegate.State.Complete ? MZI18n.OnboardingProgressBarAccessibilityStepComplete.arg(labelText).arg(index + 1).arg(progressBar.model.count)                                                                                           : MZI18n.OnboardingProgressBarAccessibilityStepCurrent.arg(labelText).arg(index + 1).arg(progressBar.model.count)
             }
         }
     }

--- a/nebula/ui/components/MZStepProgressBarDelegate.qml
+++ b/nebula/ui/components/MZStepProgressBarDelegate.qml
@@ -9,7 +9,7 @@ import compat 0.1
 
 Column {
     id: delegate
-    property string iconSource
+    property string source
     property alias labelText: label.text
     property alias labelWidth: label.width
     property string accessibleName: ""
@@ -88,7 +88,7 @@ Column {
             MZIcon {
                 id: icon
 
-                source: delegate.currentState === MZStepProgressBarDelegate.State.Complete ? "qrc:/nebula/resources/checkmark-green.svg" : delegate.iconSource
+                source: delegate.currentState === MZStepProgressBarDelegate.State.Complete ? "qrc:/nebula/resources/checkmark-green.svg" : delegate.source
             }
 
             MZColorOverlay {

--- a/nebula/ui/components/MZStepProgressBarDelegate.qml
+++ b/nebula/ui/components/MZStepProgressBarDelegate.qml
@@ -9,7 +9,7 @@ import compat 0.1
 
 Column {
     id: delegate
-    property string source
+    property string iconSource
     property alias labelText: label.text
     property alias labelWidth: label.width
     property string accessibleName: ""
@@ -88,7 +88,7 @@ Column {
             MZIcon {
                 id: icon
 
-                source: delegate.currentState === MZStepProgressBarDelegate.State.Complete ? "qrc:/nebula/resources/checkmark-green.svg" : delegate.source
+                source: delegate.currentState === MZStepProgressBarDelegate.State.Complete ? "qrc:/nebula/resources/checkmark-green.svg" : delegate.iconSource
             }
 
             MZColorOverlay {

--- a/src/apps/vpn/ui/screens/getHelp/developerMenu/ViewUiTesting.qml
+++ b/src/apps/vpn/ui/screens/getHelp/developerMenu/ViewUiTesting.qml
@@ -11,6 +11,7 @@ import components 0.1
 
 MZViewBase {
     _menuTitle: "UI Testing"
+    _interactive: false
     _viewContentData: ColumnLayout {
         spacing: MZTheme.theme.windowMargin
         Layout.fillWidth: true
@@ -27,146 +28,208 @@ MZViewBase {
 
     Component {
         id: stepNavComponent
+
         MZViewBase {
             _menuTitle: "MZStepNavigation"
-            _viewContentData: ColumnLayout {
+            _interactive: false
+            _viewContentData: MZStepNavigation {
+                id: stepNav
 
-                spacing: 32
+                Layout.topMargin: 8
+                Layout.fillWidth: true
 
-                MZStepNavigation {
-                    id: stepNav
+                views: [
+                    ColumnLayout {
 
-                    views: [
-                        ColumnLayout {
+                        property string labelText: "OnboardingProgressBarDataUse"
+                        property string iconSource: "qrc:/nebula/resources/lock.svg"
 
-                            property string labelText: "OnboardingProgressBarDataUse"
-                            property string iconSource: "qrc:/nebula/resources/lock.svg"
 
-                            spacing: 24
+                        spacing: 24
 
-                            Item {
-                                Layout.fillHeight: true
-                            }
+                        Item {
+                            Layout.fillHeight: true
+                        }
 
-                            Text {
-                                Layout.alignment: Qt.AlignHCenter
-                                text: "Slide 1"
-                            }
+                        Text {
+                            Layout.alignment: Qt.AlignHCenter
+                            text: "Slide 1"
+                        }
 
-                            MZButton {
-                                text: "Next"
-                                onClicked: {
-                                    stepNav.next()
-                                }
-                            }
-
-                            Item {
-                                Layout.fillHeight: true
-                            }
-
-                        },
-                        ColumnLayout {
-
-                            property string labelText: "OnboardingProgressBarMorePrivacy"
-                            property string iconSource: "qrc:/ui/resources/settings/privacy.svg"
-
-                            spacing: 24
-
-                            Item {
-                                Layout.fillHeight: true
-                            }
-
-                            Text {
-                                Layout.alignment: Qt.AlignHCenter
-                                text: "Slide 2"
-                            }
-
-                            MZButton {
-                                text: "Next"
-                                onClicked: {
-                                    stepNav.next()
-                                }
-                            }
-
-                            MZLinkButton {
-                                Layout.fillWidth: true
-                                labelText: "Back"
-                                onClicked: {
-                                    stepNav.back()
-                                }
-                            }
-
-                            Item {
-                                Layout.fillHeight: true
-                            }
-
-                        },
-                        ColumnLayout {
-
-                            property string labelText: "OnboardingProgressBarAddDevices"
-                            property string iconSource: "qrc:/ui/resources/devices.svg"
-
-                            spacing: 24
-
-                            Item {
-                                Layout.fillHeight: true
-                            }
-
-                            Text {
-                                Layout.alignment: Qt.AlignHCenter
-                                text: "Slide 3"
-                            }
-
-                            MZButton {
-                                text: "Next"
-                                onClicked: {
-                                    stepNav.next()
-                                }
-                            }
-
-                            MZLinkButton {
-                                Layout.fillWidth: true
-                                labelText: "Back"
-                                onClicked: {
-                                    stepNav.back()
-                                }
-                            }
-
-                            Item {
-                                Layout.fillHeight: true
-                            }
-
-                        },
-                        ColumnLayout {
-
-                            property string labelText: "OnboardingProgressBarGetStarted"
-                            property string iconSource: "qrc:/nebula/resources/startup.svg"
-
-                            spacing: 24
-
-                            Item {
-                                Layout.fillHeight: true
-                            }
-
-                            Text {
-                                Layout.alignment: Qt.AlignHCenter
-                                text: "Slide 4"
-                            }
-
-                            MZButton {
-                                text: "Back"
-                                onClicked: {
-                                    stepNav.back()
-                                }
-                            }
-
-                            Item {
-                                Layout.fillHeight: true
+                        MZButton {
+                            text: "Next"
+                            onClicked: {
+                                stepNav.next()
                             }
                         }
-                    ]
-                }
 
+                        Item {
+                            Layout.fillHeight: true
+                        }
+
+                    },
+                    ColumnLayout {
+
+                        property string labelText: "OnboardingProgressBarMorePrivacy"
+                        property string iconSource: "qrc:/ui/resources/settings/privacy.svg"
+
+                        spacing: 0
+
+                        MZHeadline {
+                            Layout.topMargin: MZTheme.theme.windowMargin * 1.5
+                            Layout.leftMargin: MZTheme.theme.windowMargin * 2
+                            Layout.rightMargin: MZTheme.theme.windowMargin * 2
+
+                            Layout.fillWidth: true
+
+                            text: "Get more privacy"
+                            horizontalAlignment: Text.AlignLeft
+                        }
+
+                        MZInterLabel {
+                            Layout.topMargin: 8
+                            Layout.leftMargin: MZTheme.theme.windowMargin * 2
+                            Layout.rightMargin: MZTheme.theme.windowMargin * 2
+                            Layout.fillWidth: true
+
+                            text: "Use these features for more protection. They may cause issues on some sites, so you can turn them off anytime in settings."
+                            horizontalAlignment: Text.AlignLeft
+                            color: "#6D6D6E"
+                        }
+
+                        MZCheckBoxRow {
+                            Layout.topMargin: 24
+                            Layout.leftMargin: MZTheme.theme.windowMargin * 2
+                            Layout.rightMargin: MZTheme.theme.windowMargin * 2
+                            leftMargin: 0
+
+                            labelText: "Block ads"
+                            subLabelText: "Reduces the amount of ads you see when you’re using Mozilla VPN"
+                            showDivider: false
+                        }
+
+                        MZCheckBoxRow {
+                            Layout.topMargin: 8
+                            Layout.leftMargin: MZTheme.theme.windowMargin * 2
+                            Layout.rightMargin: MZTheme.theme.windowMargin * 2
+                            leftMargin: 0
+
+                            labelText: "Block trackers"
+                            subLabelText: "Fewer harmful domains will be able to track you"
+                            showDivider: false
+                        }
+
+                        MZCheckBoxRow {
+                            Layout.topMargin: 8
+                            Layout.leftMargin: MZTheme.theme.windowMargin * 2
+                            Layout.rightMargin: MZTheme.theme.windowMargin * 2
+                            leftMargin: 0
+
+                            labelText: "Block malware"
+                            subLabelText: "Helps protect you from ransomware, phishing, spyware, viruses, and malware"
+                            showDivider: false
+                        }
+
+                        Item {
+                            Layout.fillHeight: true
+                            Layout.minimumHeight: 20
+                        }
+
+                        MZButton {
+                            Layout.leftMargin: MZTheme.theme.windowMargin * 2
+                            Layout.rightMargin: MZTheme.theme.windowMargin * 2
+                            Layout.fillWidth: true
+
+                            width: undefined
+                            text: "Continue"
+
+                            onClicked: {
+                                stepNav.next()
+                            }
+                        }
+
+                        MZLinkButton {
+                            Layout.topMargin: 16
+                            Layout.leftMargin: MZTheme.theme.windowMargin * 2
+                            Layout.rightMargin: MZTheme.theme.windowMargin * 2
+                            Layout.bottomMargin: MZTheme.theme.windowMargin
+                            Layout.fillWidth: true
+
+                            implicitHeight: MZTheme.theme.rowHeight
+
+                            labelText: "Go back"
+
+                            onClicked: {
+                                stepNav.back()
+                            }
+                        }
+
+                    },
+                    ColumnLayout {
+
+                        property string labelText: "OnboardingProgressBarAddDevices"
+                        property string iconSource: "qrc:/ui/resources/devices.svg"
+
+                        spacing: 24
+
+                        Item {
+                            Layout.fillHeight: true
+                        }
+
+                        Text {
+                            Layout.alignment: Qt.AlignHCenter
+                            text: "Slide 3"
+                        }
+
+                        MZButton {
+                            text: "Next"
+                            onClicked: {
+                                stepNav.next()
+                            }
+                        }
+
+                        MZLinkButton {
+                            Layout.fillWidth: true
+                            labelText: "Back"
+                            onClicked: {
+                                stepNav.back()
+                            }
+                        }
+
+                        Item {
+                            Layout.fillHeight: true
+                        }
+
+                    },
+                    ColumnLayout {
+
+                        property string labelText: "OnboardingProgressBarGetStarted"
+                        property string iconSource: "qrc:/nebula/resources/startup.svg"
+
+                        spacing: 24
+
+                        Item {
+                            Layout.fillHeight: true
+                        }
+
+                        Text {
+                            Layout.alignment: Qt.AlignHCenter
+                            text: "Slide 4"
+                        }
+
+                        MZButton {
+                            text: "Back"
+                            onClicked: {
+                                stepNav.back()
+                            }
+                        }
+
+                        Item {
+                            Layout.fillHeight: true
+                        }
+
+                    }
+                ]
             }
         }
     }

--- a/src/apps/vpn/ui/screens/getHelp/developerMenu/ViewUiTesting.qml
+++ b/src/apps/vpn/ui/screens/getHelp/developerMenu/ViewUiTesting.qml
@@ -16,72 +16,157 @@ MZViewBase {
         Layout.fillWidth: true
 
         MZSettingsItem {
-            settingTitle: "MZStepProgressBar"
+            settingTitle: "MZStepNavigation"
             imageRightSrc: "qrc:/nebula/resources/chevron.svg"
             imageRightMirror: MZLocalizer.isRightToLeft
-            onClicked: getHelpStackView.push(progressBar)
+            onClicked: getHelpStackView.push(stepNavComponent)
             Layout.leftMargin: MZTheme.theme.windowMargin / 2
             Layout.rightMargin: MZTheme.theme.windowMargin / 2
         }
     }
 
     Component {
-        id: progressBar
+        id: stepNavComponent
         MZViewBase {
-            _menuTitle: "MZStepProgressBar"
+            _menuTitle: "MZStepNavigation"
             _viewContentData: ColumnLayout {
-                Layout.leftMargin: 36
-                Layout.rightMargin: 36
 
                 spacing: 32
 
-                MZStepProgressBar {
-                    id: stepProgress
-                    Layout.alignment: Qt.AlignHCenter
-                    Layout.fillWidth: true
-                    Layout.maximumWidth: 500
+                MZStepNavigation {
+                    id: stepNav
 
-                    model: ListModel {
-                        id: stepProgressModel
+                    views: [
+                        ColumnLayout {
 
-                        ListElement {
-                            labelText: "OnboardingProgressBarDataUse"
-                            iconSource: "qrc:/nebula/resources/lock.svg"
+                            property string labelText: "OnboardingProgressBarDataUse"
+                            property string iconSource: "qrc:/nebula/resources/lock.svg"
+
+                            spacing: 24
+
+                            Item {
+                                Layout.fillHeight: true
+                            }
+
+                            Text {
+                                Layout.alignment: Qt.AlignHCenter
+                                text: "Slide 1"
+                            }
+
+                            MZButton {
+                                text: "Next"
+                                onClicked: {
+                                    stepNav.next()
+                                }
+                            }
+
+                            Item {
+                                Layout.fillHeight: true
+                            }
+
+                        },
+                        ColumnLayout {
+
+                            property string labelText: "OnboardingProgressBarMorePrivacy"
+                            property string iconSource: "qrc:/ui/resources/settings/privacy.svg"
+
+                            spacing: 24
+
+                            Item {
+                                Layout.fillHeight: true
+                            }
+
+                            Text {
+                                Layout.alignment: Qt.AlignHCenter
+                                text: "Slide 2"
+                            }
+
+                            MZButton {
+                                text: "Next"
+                                onClicked: {
+                                    stepNav.next()
+                                }
+                            }
+
+                            MZLinkButton {
+                                Layout.fillWidth: true
+                                labelText: "Back"
+                                onClicked: {
+                                    stepNav.back()
+                                }
+                            }
+
+                            Item {
+                                Layout.fillHeight: true
+                            }
+
+                        },
+                        ColumnLayout {
+
+                            property string labelText: "OnboardingProgressBarAddDevices"
+                            property string iconSource: "qrc:/ui/resources/devices.svg"
+
+                            spacing: 24
+
+                            Item {
+                                Layout.fillHeight: true
+                            }
+
+                            Text {
+                                Layout.alignment: Qt.AlignHCenter
+                                text: "Slide 3"
+                            }
+
+                            MZButton {
+                                text: "Next"
+                                onClicked: {
+                                    stepNav.next()
+                                }
+                            }
+
+                            MZLinkButton {
+                                Layout.fillWidth: true
+                                labelText: "Back"
+                                onClicked: {
+                                    stepNav.back()
+                                }
+                            }
+
+                            Item {
+                                Layout.fillHeight: true
+                            }
+
+                        },
+                        ColumnLayout {
+
+                            property string labelText: "OnboardingProgressBarGetStarted"
+                            property string iconSource: "qrc:/nebula/resources/startup.svg"
+
+                            spacing: 24
+
+                            Item {
+                                Layout.fillHeight: true
+                            }
+
+                            Text {
+                                Layout.alignment: Qt.AlignHCenter
+                                text: "Slide 4"
+                            }
+
+                            MZButton {
+                                text: "Back"
+                                onClicked: {
+                                    stepNav.back()
+                                }
+                            }
+
+                            Item {
+                                Layout.fillHeight: true
+                            }
                         }
-                        ListElement {
-                            labelText: "OnboardingProgressBarMorePrivacy"
-                            iconSource: "qrc:/ui/resources/settings/privacy.svg"
-                        }
-                        ListElement {
-                            labelText: "OnboardingProgressBarAddDevices"
-                            iconSource: "qrc:/ui/resources/devices.svg"
-                        }
-                        ListElement {
-                            labelText: "OnboardingProgressBarGetStarted"
-                            iconSource: "qrc:/nebula/resources/startup.svg"
-                        }
-                    }
+                    ]
                 }
 
-                RowLayout {
-                    MZButton {
-                        Layout.fillWidth: true
-
-                        text: "Back"
-                        onClicked: {
-                            if(stepProgress.activeIndex > 0) stepProgress.activeIndex = stepProgress.activeIndex - 1
-                        }
-                    }
-
-                    MZButton {
-                        Layout.fillWidth: true
-
-                        text: "Next"
-                        onClicked: {
-                            if(stepProgress.activeIndex < stepProgressModel.count - 1)  stepProgress.activeIndex = stepProgress.activeIndex + 1
-                        }
-                    }
-                }
             }
         }
     }

--- a/src/apps/vpn/ui/screens/getHelp/developerMenu/ViewUiTesting.qml
+++ b/src/apps/vpn/ui/screens/getHelp/developerMenu/ViewUiTesting.qml
@@ -40,10 +40,8 @@ MZViewBase {
 
                 views: [
                     ColumnLayout {
-
                         property string labelText: "OnboardingProgressBarDataUse"
                         property string iconSource: "qrc:/nebula/resources/lock.svg"
-
 
                         spacing: 24
 
@@ -69,7 +67,6 @@ MZViewBase {
 
                     },
                     ColumnLayout {
-
                         property string labelText: "OnboardingProgressBarMorePrivacy"
                         property string iconSource: "qrc:/ui/resources/settings/privacy.svg"
 
@@ -166,7 +163,6 @@ MZViewBase {
 
                     },
                     ColumnLayout {
-
                         property string labelText: "OnboardingProgressBarAddDevices"
                         property string iconSource: "qrc:/ui/resources/devices.svg"
 
@@ -202,7 +198,6 @@ MZViewBase {
 
                     },
                     ColumnLayout {
-
                         property string labelText: "OnboardingProgressBarGetStarted"
                         property string iconSource: "qrc:/nebula/resources/startup.svg"
 


### PR DESCRIPTION
## Description

- Create a navigation component that utilizes `MZStepProgressBar`
  - `MZStepNavigation` is a navigation component(similar to [MZSegmentedNavigation](https://github.com/mozilla-mobile/mozilla-vpn-client/blob/acfa3dc5684913a021988e9c340802517b6e1a75/nebula/ui/components/MZSegmentedNavigation.qml#L4) and [MZTabNavigation](https://github.com/mozilla-mobile/mozilla-vpn-client/blob/main/nebula/ui/components/MZTabNavigation.qml)) comprised of an [MZStepProgressBar](https://github.com/mozilla-mobile/mozilla-vpn-client/blob/acfa3dc5684913a021988e9c340802517b6e1a75/nebula/ui/components/MZStepProgressBar.qml#L4) in which each step corresponds to a view. 
  - Views reside within a `StackView`, and as the navigation progresses, new views are pushed on top of the previous views

Notes: 
- Glitchy when used inside of an `MZViewBase`

## Reference

[VPN-5147: Create MZStepNavigation Nebula component](https://mozilla-hub.atlassian.net/browse/VPN-5147)
