### PR TITLE
VPN-5321 - Connection fix

### DIFF
--- a/src/apps/vpn/connectionhealth.cpp
+++ b/src/apps/vpn/connectionhealth.cpp
@@ -70,7 +70,7 @@ void ConnectionHealth::stop() {
 
 void ConnectionHealth::startActive(const QString& serverIpv4Gateway,
                                    const QString& deviceIpv4Address) {
-  logger.debug() << "ConnectionHealth started";
+  logger.debug() << "ConnectionHealth active started";
 
   if (serverIpv4Gateway.isEmpty() ||
       MozillaVPN::instance()->controller()->state() != Controller::StateOn) {
@@ -88,7 +88,7 @@ void ConnectionHealth::startActive(const QString& serverIpv4Gateway,
 }
 
 void ConnectionHealth::startIdle() {
-  logger.debug() << "ConnectionHealth started";
+  logger.debug() << "ConnectionHealth idle started";
 
   m_pingHelper.stop();
   m_noSignalTimer.stop();
@@ -247,7 +247,7 @@ void ConnectionHealth::applicationStateChanged(Qt::ApplicationState state) {
 
       m_suspended = false;
       logger.debug() << "Resuming connection check from suspension";
-      connectionStateChanged();
+      startActive(m_currentGateway, m_deviceAddress);
       break;
 
     case Qt::ApplicationState::ApplicationSuspended:


### PR DESCRIPTION
## Description

https://github.com/mozilla-mobile/mozilla-vpn-client/pull/7512/ introduced a bug, where the health check timers were not restarted when reentering the iOS client. 

(For instance, swipe into control center with the VPN active, turn off internet, back into app, and it should show no connectivity within 4 seconds.)

We realize there is no connectivity when a health check timer goes off, and we have not received a reply ping. #7512 changed from calling `startActive` (which restarts the timers) to calling `connectionStateChanged`. Within `connectionStateChanged`, this block of code is executed (when the VPN is on):
```
MozillaVPN::instance()->controller()->getStatus(
          [this](const QString& serverIpv4Gateway,
                 const QString& deviceIpv4Address, uint64_t txBytes,
                 uint64_t rxBytes) {
            Q_UNUSED(txBytes);
            Q_UNUSED(rxBytes);

            stop();
            startActive(serverIpv4Gateway, deviceIpv4Address);
          });
```

This looks like it should still call `startActive`, but it's within the callback that is given to `Controller::getStatus`.  With the current status of the VPN, `getStatus` appends that callback to `m_getStatusCallbacks`, not executing it - and so the timers are not started, and thus they never go off, and thus we never realize we have no connection.

Of course, the changes in #7512 were intentional to fix another bug, and so I want to make sure I'm not re-introducing any issues with this change.

## Reference

https://mozilla-hub.atlassian.net/browse/VPN-5321

## Checklist
    
- [X] My code follows the style guidelines for this project
- [X] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [X] I have performed a self review of my own code
- [X] I have commented my code PARTICULARLY in hard to understand areas
- [X] I have added thorough tests where needed
