### PR TITLE
VPN-1990: Split tunnel boot-time fixes

### DIFF
--- a/src/platforms/linux/daemon/apptracker.cpp
+++ b/src/platforms/linux/daemon/apptracker.cpp
@@ -47,8 +47,8 @@ AppTracker::~AppTracker() {
   m_runningApps.clear();
 }
 
-void AppTracker::userCreated(uint userid, const QDBusObjectPath& path) {
-  logger.debug() << "User created uid:" << userid << "at:" << path.path();
+void AppTracker::userCreated(uint userid, const QString& xdgRuntimePath) {
+  logger.debug() << "User created uid:" << userid << "at:" << xdgRuntimePath;
 
   /* Acquire the effective UID of the user to connect to their session bus. */
   uid_t realuid = getuid();
@@ -63,8 +63,8 @@ void AppTracker::userCreated(uint userid, const QDBusObjectPath& path) {
     logger.warning() << "Failed to set effective UID";
   }
 
-  /* For correctness we should ask systemd for the user's runtime directory. */
-  QString busPath = "unix:path=/run/user/" + QString::number(userid) + "/bus";
+  /* Connect to the user's session bus. */
+  QString busPath = "unix:path=" + xdgRuntimePath + "/bus";
   logger.debug() << "Connection to" << busPath;
   QDBusConnection connection =
       QDBusConnection::connectToBus(busPath, "user-" + QString::number(userid));
@@ -98,8 +98,8 @@ void AppTracker::userCreated(uint userid, const QDBusObjectPath& path) {
   }
 }
 
-void AppTracker::userRemoved(uint userid, const QDBusObjectPath& path) {
-  logger.debug() << "User removed uid:" << userid << "at:" << path.path();
+void AppTracker::userRemoved(uint userid) {
+  logger.debug() << "User removed uid:" << userid;
 
   QDBusConnection::disconnectFromBus("user-" + QString::number(userid));
 }

--- a/src/platforms/linux/daemon/apptracker.h
+++ b/src/platforms/linux/daemon/apptracker.h
@@ -5,8 +5,8 @@
 #ifndef APPTRACKER_H
 #define APPTRACKER_H
 
-#include <QDBusObjectPath>
 #include <QFileSystemWatcher>
+#include <QHash>
 #include <QString>
 
 #include "leakdetector.h"
@@ -33,8 +33,8 @@ class AppTracker final : public QObject {
   explicit AppTracker(QObject* parent = nullptr);
   ~AppTracker();
 
-  void userCreated(uint userid, const QDBusObjectPath& path);
-  void userRemoved(uint userid, const QDBusObjectPath& path);
+  void userCreated(uint userid, const QString& xdgRuntimePath);
+  void userRemoved(uint userid);
 
   QHash<QString, AppData*>::iterator begin() { return m_runningApps.begin(); }
   QHash<QString, AppData*>::iterator end() { return m_runningApps.end(); }

--- a/src/platforms/linux/daemon/dbusservice.cpp
+++ b/src/platforms/linux/daemon/dbusservice.cpp
@@ -442,9 +442,7 @@ bool DBusService::isCallerAuthorized() {
 #if QT_VERSION < 0x060403
 class QtbugRegistrationProxy {
  public:
-  QtbugRegistrationProxy() {
-    qDBusRegisterMetaType<QDBusObjectPath>();
-  }
+  QtbugRegistrationProxy() { qDBusRegisterMetaType<QDBusObjectPath>(); }
 };
 
 static QtbugRegistrationProxy s_qtbugRegistrationProxy;

--- a/src/platforms/linux/daemon/dbusservice.cpp
+++ b/src/platforms/linux/daemon/dbusservice.cpp
@@ -50,10 +50,17 @@ DBusService::DBusService(QObject* parent) : Daemon(parent) {
 
   // Setup to track user login sessions.
   QDBusConnection bus = QDBusConnection::systemBus();
-  bus.connect("", DBUS_LOGIN_PATH, DBUS_LOGIN_MANAGER, "UserNew", this,
-              SLOT(userCreated(uint, QDBusObjectPath)));
-  bus.connect("", DBUS_LOGIN_PATH, DBUS_LOGIN_MANAGER, "UserRemoved", this,
-              SLOT(userRemoved(uint, QDBusObjectPath)));
+  if (!bus.isConnected()) {
+    logger.error() << "System bus is not connected?";
+  }
+  if (!bus.connect("", DBUS_LOGIN_PATH, DBUS_LOGIN_MANAGER, "UserNew", this,
+              SLOT(userCreated(uint, QDBusObjectPath)))) {
+    logger.error() << "Failed to connect to UserNew signal";
+  }
+  if (!bus.connect("", DBUS_LOGIN_PATH, DBUS_LOGIN_MANAGER, "UserRemoved", this,
+              SLOT(userRemoved(uint, QDBusObjectPath)))) {
+    logger.error() << "Failed to connect to UserRemoved signal";
+  }
 
   QDBusMessage listUsersCall = QDBusMessage::createMethodCall(
       DBUS_LOGIN_SERVICE, DBUS_LOGIN_PATH, DBUS_LOGIN_MANAGER, "ListUsers");
@@ -399,3 +406,16 @@ bool DBusService::isCallerAuthorized() {
   }
   return (flag == CAP_SET);
 }
+
+// Workaround for QTBUG-108822 by manually registering QDBusObjectPath with the
+// D-Bus meta-type system, otherwise we are unable to connect to some signals.
+#if QT_VERSION < 0x060403
+class QtbugRegistrationProxy {
+ public:
+  QtbugRegistrationProxy() {
+    qDBusRegisterMetaType<QDBusObjectPath>();
+  }
+};
+
+static QtbugRegistrationProxy s_qtbugRegistrationProxy;
+#endif


### PR DESCRIPTION
## Description
Currently, the split tunneling works great, but only if you launch the service sometime after the user login sessions are complete. If you let the daemon at boot (as is normally the case) then the we often detect user creation while systemd is still busy initializing things, often resulting in a failure to connect to the user's session bus because it doesn't exist yet. And without that connection to the user's session bus, we are unable to detect application launch events needed for split tunneling to work.

Unfortunately, there doesn't seem to be a signal that we can listen on to detect when the initialization is complete, so we work around the problem by polling the D-Bus user object until we get a state change out of the undocumented "opening" state.

This was also hampered by a bug in Qt, for which we needed to apply a workaround on certain Qt versions.

## Reference
Github issue #3168 ([VPN-1990](https://mozilla-hub.atlassian.net/browse/VPN-1990))
Qt issue [QTBUG-108822](https://bugreports.qt.io/browse/QTBUG-108822)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-1990]: https://mozilla-hub.atlassian.net/browse/VPN-1990?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ