### PR TITLE
Chore: Improve connectivity-related error logging in Windows

### DIFF
--- a/src/apps/vpn/platforms/windows/windowsnetworkwatcher.cpp
+++ b/src/apps/vpn/platforms/windows/windowsnetworkwatcher.cpp
@@ -78,7 +78,7 @@ void WindowsNetworkWatcher::processWlan(PWLAN_NOTIFICATION_DATA data) {
   }
 
   if (data->NotificationCode != wlan_notification_msm_connected) {
-    logger.debug() << "The wlan code is not MSM connected";
+    logger.debug() << "Wlan unprocessed code: " << data->NotificationCode;
     return;
   }
 

--- a/src/apps/vpn/platforms/windows/windowspingsender.cpp
+++ b/src/apps/vpn/platforms/windows/windowspingsender.cpp
@@ -116,7 +116,8 @@ void WindowsPingSender::pingEventReady() {
       return;
     }
     QString errmsg = WindowsUtils::getErrorMessage();
-    logger.error() << "failed with error:" << errmsg;
+    logger.error() << "No ping reply. Code: " << error
+                   << " Message: " << errmsg;
     return;
   }
 


### PR DESCRIPTION
## Description

Improve Windows error logging in some connectivity-related classes:

1. The WLAN notification callback indicated that it was MSM disconnected despite being connected and receiving notification codes like wlan_notification_msm_radio_state_change, wlan_notification_msm_signal_quality_change,  indicating state changes while still remaining connected.  Fixed by logging the actual notification code.

2. WindowsPingSender did not log the error code.  The returned error code might correspond to an IP_* status code, potentially leading to value conflicts with actual error codes. For instance, the value 11006 is shared by WSA_QOS_SENDERS and IP_NO_RESOURCES, and the error message from FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM) corresponds to WSA_QOS_SENDERS. Improved this by logging the error code.

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
