### PR TITLE
VPN-4712: Add installation ID on Android daemon

### DIFF
--- a/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/VPNService.kt
+++ b/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/VPNService.kt
@@ -256,12 +256,13 @@ class VPNService : android.net.VpnService() {
 
         if (isSuperDooperMetricsActive) {
             val installationIdString = json.getString("installationId")
-            installationIdString?.let{
+            installationIdString?.let {
                 try {
                     val installationId = UUID.fromString(installationIdString)
                     Session.installationId.set(installationId)
                 } catch (e: Exception) {
-                    Log.e(tag, "Daemon installation ID string was not UUID")
+                    Log.e(tag, "Daemon installation ID string was not UUID:")
+                    Log.e(tag, e.toString())
                 }
             }
             Pings.daemonsession.submit(

--- a/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/VPNService.kt
+++ b/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/VPNService.kt
@@ -23,6 +23,7 @@ import mozilla.telemetry.glean.config.Configuration
 import org.json.JSONObject
 import org.mozilla.firefox.qt.common.Prefs
 import org.mozilla.firefox.vpn.daemon.GleanMetrics.Pings
+import org.mozilla.firefox.vpn.daemon.GleanMetrics.Session
 import java.io.File
 import java.util.*
 
@@ -254,6 +255,15 @@ class VPNService : android.net.VpnService() {
         }
 
         if (isSuperDooperMetricsActive) {
+            val installationIdString = json.getString("installationId")
+            installationIdString?.let{
+                try {
+                    val installationId = UUID.fromString(installationIdString)
+                    Session.installationId.set(installationId)
+                } catch (e: Exception) {
+                    Log.e(tag, "Daemon installation ID string was not UUID")
+                }
+            }
             Pings.daemonsession.submit(
                 Pings.daemonsessionReasonCodes.daemonFlush,
             )

--- a/src/apps/vpn/platforms/android/androidcontroller.cpp
+++ b/src/apps/vpn/platforms/android/androidcontroller.cpp
@@ -227,6 +227,7 @@ void AndroidController::activate(const InterfaceConfig& config,
 
   args["isSuperDooperFeatureActive"] =
       Feature::get(Feature::Feature_superDooperMetrics)->isSupported();
+  args["installationId"] = config.m_installationId;
 
   QJsonDocument doc(args);
   AndroidVPNActivity::sendToService(ServiceAction::ACTION_ACTIVATE,

--- a/src/shared/glean/mzglean.cpp
+++ b/src/shared/glean/mzglean.cpp
@@ -143,7 +143,7 @@ void MZGlean::setUploadEnabled(bool isTelemetryEnabled) {
     // clear out the former installation ID immediately
     SettingsHolder::instance()->removeInstallationId();
   }
-  #endif
+#endif
 }
 
 // static

--- a/src/shared/glean/mzglean.cpp
+++ b/src/shared/glean/mzglean.cpp
@@ -133,6 +133,17 @@ void MZGlean::setUploadEnabled(bool isTelemetryEnabled) {
 #endif
 
   broadcastUploadEnabledChange(isTelemetryEnabled);
+
+#if defined(MZ_ANDROID) || defined(MZ_IOS)
+  if (isTelemetryEnabled) {
+    // need to reset installation ID, as it would have been cleared
+    QString uuid = mozilla::glean::session::installation_id.generateAndSet();
+    SettingsHolder::instance()->setInstallationId(uuid);
+  } else {
+    // clear out the former installation ID immediately
+    SettingsHolder::instance()->removeInstallationId();
+  }
+  #endif
 }
 
 // static


### PR DESCRIPTION
## Description

iOS partner work done in https://github.com/mozilla-mobile/mozilla-vpn-client/pull/7581. This adds the Android daemon work.

Additionally, I realized that there was a bug when users removed Glean permissions - Glean would automatically clear the installation ID, but it wasn't cleared from settings. Then, if a user reactivated Glean permissions, the app Glean would report no installation ID but the daemon Glean would report the old installation ID - which would have allowed their old and new sessions to be linked, which we definitely do not want. I've added some code to fix that bug.

To test, you likely want to add these lines before the two instances of `Glean.initialize(`:
```
Glean.setDebugViewTag("VPNTest")
Glean.setLogPings(true)
```   
Then, look at the pings [in Glean's tool](https://debug-ping-preview.firebaseapp.com/pings/VPNTest).

## Reference

https://mozilla-hub.atlassian.net/browse/VPN-4712

## Checklist
    
- [X] My code follows the style guidelines for this project
- [X] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [X] I have performed a self review of my own code
- [X] I have commented my code PARTICULARLY in hard to understand areas
- [X] I have added thorough tests where needed
