### PR TITLE
Chore: Update fedora taskcluster builds

### DIFF
--- a/taskcluster/ci/build/linux.yml
+++ b/taskcluster/ci/build/linux.yml
@@ -65,16 +65,6 @@ linux/mantic:
         name: linux-mantic
         type: build
 
-linux/fedora-fc36:
-    description: "Linux Build (Fedora/36)"
-    treeherder:
-        platform: linux/fedora-fc36
-    worker:
-        docker-image: {in-tree: linux-build-fedora-fc36}
-    add-index-routes:
-        name: linux-fedora-fc36
-        type: build
-
 linux/fedora-fc37:
     description: "Linux Build (Fedora/37)"
     treeherder:
@@ -83,6 +73,16 @@ linux/fedora-fc37:
         docker-image: {in-tree: linux-build-fedora-fc37}
     add-index-routes:
         name: linux-fedora-fc37
+        type: build
+
+linux/fedora-fc38:
+    description: "Linux Build (Fedora/38)"
+    treeherder:
+        platform: linux/fedora-fc38
+    worker:
+        docker-image: {in-tree: linux-build-fedora-fc38}
+    add-index-routes:
+        name: linux-fedora-fc38
         type: build
 
 linux/static:

--- a/taskcluster/ci/docker-image/kind.yml
+++ b/taskcluster/ci/docker-image/kind.yml
@@ -62,13 +62,13 @@ tasks:
         definition: linux-dpkg-build
         args:
             DOCKER_BASE_IMAGE: ubuntu:mantic
-    linux-build-fedora-fc36:
-        symbol: I(linux-fedora-fc36)
-        definition: linux-rpm-build
-        args:
-            DOCKER_BASE_IMAGE: fedora:36
     linux-build-fedora-fc37:
         symbol: I(linux-fedora-fc37)
         definition: linux-rpm-build
         args:
             DOCKER_BASE_IMAGE: fedora:37
+    linux-build-fedora-fc38:
+        symbol: I(linux-fedora-fc38)
+        definition: linux-rpm-build
+        args:
+            DOCKER_BASE_IMAGE: fedora:38


### PR DESCRIPTION
## Description
Fedora 36 has been out of support for a few months now, and Fedora 38 is also out of beta. We should update our taskcluster build artifacts to match.

Note, this requires a sentry update to resolve some compile errors in breakpad.

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
