### PR TITLE
VPN-4226: Enable automatic restart of linuxdaemon

### DIFF
--- a/linux/mozillavpn.service.in
+++ b/linux/mozillavpn.service.in
@@ -6,6 +6,7 @@ After=modprobe@xt_cgroup.service
 [Service]
 Type=dbus
 BusName=org.mozilla.vpn.dbus
+Restart=on-failure
 ExecStart=@CMAKE_INSTALL_FULL_BINDIR@/mozillavpn linuxdaemon
 
 [Install]

--- a/src/platforms/linux/dbusclient.cpp
+++ b/src/platforms/linux/dbusclient.cpp
@@ -39,6 +39,8 @@ DBusClient::DBusClient(QObject* parent) : QObject(parent) {
 
 DBusClient::~DBusClient() { MZ_COUNT_DTOR(DBusClient); }
 
+QString DBusClient::serviceName() const { return DBUS_SERVICE; }
+
 QDBusPendingCallWatcher* DBusClient::version() {
   logger.debug() << "Version via DBus";
   QDBusPendingReply<QString> reply = m_dbus->version();

--- a/src/platforms/linux/dbusclient.h
+++ b/src/platforms/linux/dbusclient.h
@@ -38,6 +38,10 @@ class DBusClient final : public QObject {
 
   QDBusPendingCallWatcher* cleanupLogs();
 
+  QString interface() const {
+    return (m_dbus != nullptr) ? m_dbus->interface() : "";
+  }
+
  signals:
   void connected(const QString& pubkey);
   void disconnected();

--- a/src/platforms/linux/dbusclient.h
+++ b/src/platforms/linux/dbusclient.h
@@ -38,9 +38,7 @@ class DBusClient final : public QObject {
 
   QDBusPendingCallWatcher* cleanupLogs();
 
-  QString interface() const {
-    return (m_dbus != nullptr) ? m_dbus->interface() : "";
-  }
+  QString serviceName() const;
 
  signals:
   void connected(const QString& pubkey);

--- a/src/platforms/linux/linuxcontroller.cpp
+++ b/src/platforms/linux/linuxcontroller.cpp
@@ -33,6 +33,13 @@ LinuxController::LinuxController() {
           [this](auto key) { emit connected(key, QDateTime()); });
   connect(m_dbus, &DBusClient::disconnected, this,
           &LinuxController::disconnected);
+
+  // Watch for restarts of the D-Bus service.
+  m_serviceWatcher = new QDBusServiceWatcher(this);
+  m_serviceWatcher->setConnection(QDBusConnection::systemBus());
+  m_serviceWatcher->addWatchedService("org.mozilla.vpn.dbus");
+  connect(m_serviceWatcher, &QDBusServiceWatcher::serviceOwnerChanged, this,
+          &LinuxController::dbusNameOwnerChanged);
 }
 
 LinuxController::~LinuxController() { MZ_COUNT_DTOR(LinuxController); }
@@ -66,6 +73,16 @@ void LinuxController::initializeCompleted(QDBusPendingCallWatcher* call) {
   Q_ASSERT(statusValue.isBool());
 
   emit initialized(true, statusValue.toBool(), QDateTime::currentDateTime());
+}
+
+void LinuxController::dbusNameOwnerChanged(const QString& name,
+                                           const QString& prevOwner,
+                                           const QString& newOwner) {
+  // If the daemon stops, or re-starts then we have been disconnected.
+  if (name != m_dbus->interface()) {
+    logger.info() << "DBus name" << name << "has changed owner to" << newOwner;
+    emit disconnected();
+  }
 }
 
 void LinuxController::activate(const InterfaceConfig& config,

--- a/src/platforms/linux/linuxcontroller.cpp
+++ b/src/platforms/linux/linuxcontroller.cpp
@@ -79,7 +79,7 @@ void LinuxController::dbusNameOwnerChanged(const QString& name,
                                            const QString& prevOwner,
                                            const QString& newOwner) {
   // If the daemon stops, or re-starts then we have been disconnected.
-  if (name != m_dbus->interface()) {
+  if (name == m_dbus->serviceName()) {
     logger.info() << "DBus name" << name << "has changed owner to" << newOwner;
     emit disconnected();
   }

--- a/src/platforms/linux/linuxcontroller.h
+++ b/src/platforms/linux/linuxcontroller.h
@@ -12,6 +12,7 @@
 
 class DBusClient;
 class QDBusPendingCallWatcher;
+class QDBusServiceWatcher;
 
 class LinuxController final : public ControllerImpl {
   Q_DISABLE_COPY_MOVE(LinuxController)
@@ -39,9 +40,12 @@ class LinuxController final : public ControllerImpl {
   void checkStatusCompleted(QDBusPendingCallWatcher* call);
   void initializeCompleted(QDBusPendingCallWatcher* call);
   void operationCompleted(QDBusPendingCallWatcher* call);
+  void dbusNameOwnerChanged(const QString& name, const QString& prevOwner,
+                            const QString& newOwner);
 
  private:
   DBusClient* m_dbus = nullptr;
+  QDBusServiceWatcher* m_serviceWatcher = nullptr;
 };
 
 #endif  // LINUXCONTROLLER_H


### PR DESCRIPTION
## Description
We are concerned that in the event that the Linux daemon crashes, it may leave the user in an unprotected state and the VPN broken. The first step in tightening this failure mode up is to enable the automatic restart of the daemon upon an abnormal exit condition.

## Reference
JIRA subtask [VPN-4226](https://mozilla-hub.atlassian.net/browse/VPN-4226)

## Checklist
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-4226]: https://mozilla-hub.atlassian.net/browse/VPN-4226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ