### PR TITLE
Remove Usage of Ad-ID

### DIFF
--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -12,7 +12,6 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES"/>
-    <uses-permission android:name="com.google.android.gms.permission.AD_ID"/>
     <!-- The following comment will be replaced upon deployment with default features based on the dependencies of the application.
          Remove the comment if you do not require these default features. -->
     <!-- %%INSERT_FEATURES -->


### PR DESCRIPTION
## Description

We have introduced this for our filtered adjust - campain attribution. At v2.3
However we have not used that in 1+ years, so let's remove the permission, we can re-introduce at anytime if we ever need it. 
