### PR TITLE
VPN-4831: Set Accessibility names of ViewServers tabs and fix other Select Location a11y issues

### DIFF
--- a/nebula/ui/components/MZRadioDelegate.qml
+++ b/nebula/ui/components/MZRadioDelegate.qml
@@ -13,6 +13,7 @@ RadioDelegate {
     property bool isHoverable: true
     property var radioButtonLabelText
     property string accessibleName
+    property bool isRadioButtonLabelAccessible: true
     property var uiState: MZTheme.theme.uiState
     readonly property int labelX: radioButton.anchors.margins + radioButton.implicitWidth + radioButtonLabel.anchors.leftMargin
 
@@ -114,7 +115,7 @@ RadioDelegate {
 
     MZRadioButtonLabel {
         id: radioButtonLabel
-
+        Accessible.ignored: !isRadioButtonLabelAccessible
         anchors.verticalCenter: parent.verticalCenter
         anchors.left: radioButton.right
         anchors.right: parent.right

--- a/nebula/ui/components/MZStackView.qml
+++ b/nebula/ui/components/MZStackView.qml
@@ -9,6 +9,8 @@ import Mozilla.Shared 1.0
 
 StackView {
     id: stackView
+    // StackView's items will provide Accessibility, so the StackView itself doesn't need Accessibility.
+    Accessible.ignored: true
 
     Component.onCompleted: function(){
         if(!currentItem && initialItem) {

--- a/nebula/ui/components/MZTabNavigation.qml
+++ b/nebula/ui/components/MZTabNavigation.qml
@@ -47,6 +47,7 @@ Item {
                 id: btn
                 objectName: tabButtonId
                 height: bar.contentHeight
+                Accessible.name: MZI18n[tabLabelStringId]
 
                 onClicked: handleTabClick(btn)
 
@@ -74,6 +75,8 @@ Item {
                     horizontalAlignment: Text.AlignHCenter
                     verticalAlignment: Text.AlignVCenter
                     color: btn.checked ? MZTheme.colors.purple70 : btn.hovered || btn.activeFocus ? MZTheme.colors.grey50 : MZTheme.colors.grey40
+                    // Accessibility provided by btn's Accessible properties
+                    Accessible.ignored: true
 
                     Rectangle {
                         anchors.fill: parent
@@ -117,7 +120,8 @@ Item {
         anchors.top: bar.bottom
         height: root.height
         clip: true
-
+        Accessible.role: Accessible.List
+        Accessible.name: currentTab.Accessible.name
 
         PropertyAnimation {
             id: fadeIn

--- a/nebula/ui/components/navigator/MZNavigatorLoader.qml
+++ b/nebula/ui/components/navigator/MZNavigatorLoader.qml
@@ -12,6 +12,7 @@ StackView {
   // Let's force the visibility. See
   // https://doc.qt.io/qt-5/qml-qtquick-controls2-stackview.html#visible-attached-prop
   visible: true
+  Accessible.ignored: true
 
   property var screens: []
   property var currentLoadPolicy: null

--- a/nebula/ui/components/navigator/MZNavigatorLoader.qml
+++ b/nebula/ui/components/navigator/MZNavigatorLoader.qml
@@ -12,6 +12,7 @@ StackView {
   // Let's force the visibility. See
   // https://doc.qt.io/qt-5/qml-qtquick-controls2-stackview.html#visible-attached-prop
   visible: true
+   // StackView's items will provide Accessibility, so the StackView itself doesn't need Accessibility.
   Accessible.ignored: true
 
   property var screens: []

--- a/src/apps/vpn/ui/screens/home/ViewServers.qml
+++ b/src/apps/vpn/ui/screens/home/ViewServers.qml
@@ -16,7 +16,7 @@ import compat 0.1
 Item {
     id: root
     objectName: "viewServers"
-
+    Accessible.name: qsTrId("vpn.servers.selectLocation")
 
     MZMenu {
         property string defaultMenuTitle: qsTrId("vpn.servers.selectLocation")

--- a/src/apps/vpn/ui/screens/home/servers/ServerCountry.qml
+++ b/src/apps/vpn/ui/screens/home/servers/ServerCountry.qml
@@ -213,6 +213,9 @@ MZClickableRow {
                     Keys.onUpPressed: if (citiesRepeater.itemAt(index - 1)) citiesRepeater.itemAt(index - 1).forceActiveFocus()
                     radioButtonLabelText: _localizedCityName
                     accessibleName: latencyIndicator.accessibleName.arg(_localizedCityName)
+                    // Radio button label is ignored for Accesibility because accessibleName
+                    // provides all the necessary information
+                    isRadioButtonLabelAccessible: false
                     implicitWidth: parent.width
 
                     onClicked: {

--- a/src/apps/vpn/ui/screens/home/servers/ServerList.qml
+++ b/src/apps/vpn/ui/screens/home/servers/ServerList.qml
@@ -77,7 +77,6 @@ FocusScope {
 
     Layout.fillWidth: true
     Layout.fillHeight: true
-    Accessible.ignored: true
 
     ButtonGroup {
         id: radioButtonGroup

--- a/src/apps/vpn/ui/screens/home/servers/ServerList.qml
+++ b/src/apps/vpn/ui/screens/home/servers/ServerList.qml
@@ -77,8 +77,7 @@ FocusScope {
 
     Layout.fillWidth: true
     Layout.fillHeight: true
-    Accessible.name: menu.title
-    Accessible.role: Accessible.List
+    Accessible.ignored: true
 
     ButtonGroup {
         id: radioButtonGroup


### PR DESCRIPTION
## Description

The ViewServers tabs (Recommended and All) did not have accessible names. Fixed by providing names in ViewServers.qml.
Some parent elements had names which were not useful, so have been marked as ignored.

## Reference

 [VPN-4831](https://mozilla-hub.atlassian.net/browse/VPN-4831)

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-4831]: https://mozilla-hub.atlassian.net/browse/VPN-4831?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ