### PR TITLE
Revert Qt back to 6.2.4

### DIFF
--- a/env.yml
+++ b/env.yml
@@ -26,4 +26,4 @@ dependencies:
     - -r requirements.txt
     - -r taskcluster/scripts/requirements.txt
 variables:
-  QT_VERSION: 6.5.1
+  QT_VERSION: 6.2.4

--- a/taskcluster/ci/fetch/kind.yml
+++ b/taskcluster/ci/fetch/kind.yml
@@ -81,9 +81,9 @@ tasks:
             size: 46574107
         fetch-alias: miniconda-osx
     qt-source-tarball:
-        description: Qt 6.5.1 Source Tarball
+        description: Qt 6.2.4 Source Tarball
         fetch:
             type: static-url
-            url: https://download.qt.io/archive/qt/6.5/6.5.1/single/qt-everywhere-src-6.5.1.tar.xz
-            sha256: a2d88a6f8c3835dca52f3b7433149c3de606a96bbf024640c27657276cc7350a
-            size: 796599948
+            url: https://download.qt.io/archive/qt/6.2/6.2.4/single/qt-everywhere-src-6.2.4.tar.xz
+            sha256: cfe41905b6bde3712c65b102ea3d46fc80a44c9d1487669f14e4a6ee82ebb8fd
+            size: 661663792

--- a/taskcluster/ci/toolchain/qt.yml
+++ b/taskcluster/ci/toolchain/qt.yml
@@ -5,8 +5,8 @@
 task-defaults:
     worker:
         env:
-            QT_VERSION: "6.5.1"
-            QT_MAJOR: "6.5"
+            QT_VERSION: "6.2.4"
+            QT_MAJOR: "6.2"
         max-run-time: 14400
 
 qt-mac:
@@ -18,7 +18,6 @@ qt-mac:
         script: compile_qt_6_mac.sh
         resources:
             - scripts/utils/qt6_compile.sh
-            - env.yml
         toolchain-alias: qt-mac
         toolchain-artifact: public/build/qt6_mac.zip
     treeherder:
@@ -39,17 +38,11 @@ qt-win:
         script: compile_qt_6.ps1
         resources:
             - taskcluster/scripts/toolchain/configure_qt.ps1
-            - env.yml
         toolchain-alias: qt-win
         toolchain-artifact: public/build/qt6_win.zip
     treeherder:
         symbol: TL(qt-win)
     worker-type: b-win2012
-    worker:
-        env:
-            # Keep this at 6.2 until we have solved build issues
-            QT_VERSION: "6.2.4"
-            QT_MAJOR: "6.2"
 
 qt-ios:
     description: "QT ios bundle Task"
@@ -57,7 +50,6 @@ qt-ios:
         script: bundle_qt_ios.sh
         resources:
             - taskcluster/scripts/toolchain/bundle_qt_ios.sh
-            - env.yml
         toolchain-alias: qt-ios
         toolchain-artifact: public/build/qt6_ios.zip
     treeherder:

--- a/taskcluster/scripts/toolchain/bundle_qt_ios.sh
+++ b/taskcluster/scripts/toolchain/bundle_qt_ios.sh
@@ -10,8 +10,8 @@
 python3 -m pip install --upgrade pip
 python3 -m pip install --upgrade aqtinstall
 
-aqt install-qt -O qt_ios mac desktop $QT_VERSION -m all
-aqt install-qt -O qt_ios mac ios $QT_VERSION -m all
+aqt install-qt -O qt_ios mac desktop $QT_VERSION -m qtwebsockets qt5compat qtnetworkauth
+aqt install-qt -O qt_ios mac ios $QT_VERSION -m qtwebsockets qt5compat qtnetworkauth
 
 zip -qr $UPLOAD_DIR/qt6_ios.zip qt_ios/*
 


### PR DESCRIPTION
This reverts commit 412add0f6ab90d4961d983c3a33bd2ec4a6e8935, which was PR https://github.com/mozilla-mobile/mozilla-vpn-client/pull/7604/

## Description

1. macOS unit tests are failing on 6.5.1 ([Jira](https://mozilla-hub.atlassian.net/browse/VPN-5460)), currently blocking all PRs. 
2. Due to [a bug in our build system](https://mozilla-hub.atlassian.net/browse/VPN-5461), PRs changing the Qt version are tested with the existing Qt version, which is why this wasn't caught in tests on the PR.
3. A corollary of number 2: We expect the macOS unit tests to be failing on this PR, and we'll need to merge this in anyway.

## Reference

https://mozilla-hub.atlassian.net/browse/VPN-5462

## Checklist
    
- [X] My code follows the style guidelines for this project
- [X] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [X] I have performed a self review of my own code
- [X] I have commented my code PARTICULARLY in hard to understand areas
- [X] I have added thorough tests where needed
