### PR TITLE
VPN-5321 follow up - show error screen if no connection at start of speed test

### DIFF
--- a/src/apps/vpn/connectionbenchmark/connectionbenchmark.cpp
+++ b/src/apps/vpn/connectionbenchmark/connectionbenchmark.cpp
@@ -129,7 +129,7 @@ void ConnectionBenchmark::start() {
 
   // Need this check to show error screen if there is no connection when
   // starting test.
-  checkStability();
+  showErrorIfNoSignal();
 }
 
 void ConnectionBenchmark::stop() {
@@ -223,10 +223,10 @@ void ConnectionBenchmark::handleStabilityChange() {
     return;
   }
   logger.debug() << "Handle stability change";
-  checkStability();
+  showErrorIfNoSignal();
 }
 
-void ConnectionBenchmark::checkStability() {
+void ConnectionBenchmark::showErrorIfNoSignal() {
   ConnectionHealth::ConnectionStability stability =
       MozillaVPN::instance()->connectionHealth()->stability();
   logger.debug() << "Current stability: " << stability;

--- a/src/apps/vpn/connectionbenchmark/connectionbenchmark.cpp
+++ b/src/apps/vpn/connectionbenchmark/connectionbenchmark.cpp
@@ -126,6 +126,10 @@ void ConnectionBenchmark::start() {
     m_benchmarkTasks.append(uploadTask);
     TaskScheduler::scheduleTask(uploadTask);
   }
+
+  // Need this check to show error screen if there is no connection when
+  // starting test.
+  checkStability();
 }
 
 void ConnectionBenchmark::stop() {
@@ -218,11 +222,14 @@ void ConnectionBenchmark::handleStabilityChange() {
   if (m_state == StateInitial || m_state == StateReady) {
     return;
   }
+  logger.debug() << "Handle stability change";
+  checkStability();
+}
 
+void ConnectionBenchmark::checkStability() {
   ConnectionHealth::ConnectionStability stability =
       MozillaVPN::instance()->connectionHealth()->stability();
-  logger.debug() << "Handle stability change" << stability;
-
+  logger.debug() << "Current stability: " << stability;
   if (stability == ConnectionHealth::NoSignal) {
     setState(StateError);
     stop();

--- a/src/apps/vpn/connectionbenchmark/connectionbenchmark.h
+++ b/src/apps/vpn/connectionbenchmark/connectionbenchmark.h
@@ -70,6 +70,7 @@ class ConnectionBenchmark final : public QObject {
   void setConnectionSpeed();
   void setState(State state);
   void stop();
+  void checkStability();
 
  private:
   QList<BenchmarkTask*> m_benchmarkTasks;

--- a/src/apps/vpn/connectionbenchmark/connectionbenchmark.h
+++ b/src/apps/vpn/connectionbenchmark/connectionbenchmark.h
@@ -70,7 +70,7 @@ class ConnectionBenchmark final : public QObject {
   void setConnectionSpeed();
   void setState(State state);
   void stop();
-  void checkStability();
+  void showErrorIfNoSignal();
 
  private:
   QList<BenchmarkTask*> m_benchmarkTasks;

--- a/tests/functional/testBenchmark.js
+++ b/tests/functional/testBenchmark.js
@@ -204,4 +204,25 @@ describe('Benchmark', function() {
     // Exit the benchmark
     await vpn.waitForQueryAndClick(queries.screenHome.CONNECTION_INFO_TOGGLE);
   });
+
+  it('Error when starting with no connection', async () => {
+    await vpn.waitForQuery(queries.screenHome.CONTROLLER_TITLE.visible());
+    await vpn.activate(true);
+
+    // Force a No Signal situation
+    await vpn.forceConnectionStabilityStatus('nosignal');
+
+    // Start the connection benchmark; it goes into Running state before Error.
+    await vpn.waitForQueryAndClick(queries.screenHome.CONNECTION_INFO_TOGGLE);
+
+    // We expect the benchmark to fail.
+    assert.strictEqual(
+        await vpn.getMozillaProperty(
+            'Mozilla.VPN', 'VPNConnectionBenchmark', 'state'),
+        'StateError');
+    await vpn.waitForQuery(queries.screenHome.CONNECTION_INFO_ERROR.visible());
+
+    // Exit the benchmark
+    await vpn.waitForQueryAndClick(queries.screenHome.CONNECTION_INFO_TOGGLE);
+  });
 });


### PR DESCRIPTION
## Description

Per comment on VPN-5321, the original work neglected to catch if the connection was already gone (but the VPN tunnel was active) when the user started their speed test.

## Reference

https://mozilla-hub.atlassian.net/browse/VPN-5321

## Checklist
    
- [X] My code follows the style guidelines for this project
- [X] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [X] I have performed a self review of my own code
- [X] I have commented my code PARTICULARLY in hard to understand areas
- [X] I have added thorough tests where needed
