### PR TITLE
Enable Sentry on iOS in Staging

### DIFF
--- a/src/shared/featurelistcallback.h
+++ b/src/shared/featurelistcallback.h
@@ -31,7 +31,7 @@ bool FeatureCallback_iosOrAndroid() {
 
 bool FeatureCallback_sentry() {
 #if defined(MZ_IOS)
-  return false;
+  return FeatureCallback_inStaging();
 #else
   return true;
 #endif


### PR DESCRIPTION
## Description

This PR enables Sentry crash reports on iOS in Staging. Opening as Draft until we have confirmation this has not broken anyone's ability to build in an emulator. 

Because iOS is not listed as an officially supported platform in the [Sentry SDK docs](https://docs.sentry.io/platforms/native/#install) we are enabling this only in Staging in the interest of easier crash debugging and to watch for any undesirable/unexpected behavior.

@MattLichtenstein @mcleinman When you can, mind taking this branch for a spin in the ios emulator of your choice? Sentry was reportedly breaking emulator builds at some point in recent history but so far this is 'working on my machine' and I want to make sure this doesn't cause any grief on your ends.  

## Reference

VPN-5324

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
