### PR TITLE
VPN-5436: Email and password screens took longer to appear after Accessible.ignored was added in MZStackView

### DIFF
--- a/nebula/ui/components/MZStackView.qml
+++ b/nebula/ui/components/MZStackView.qml
@@ -9,8 +9,6 @@ import Mozilla.Shared 1.0
 
 StackView {
     id: stackView
-    // StackView's items will provide Accessibility, so the StackView itself doesn't need Accessibility.
-    Accessible.ignored: true
 
     Component.onCompleted: function(){
         if(!currentItem && initialItem) {

--- a/nebula/ui/components/navigator/MZNavigatorLoader.qml
+++ b/nebula/ui/components/navigator/MZNavigatorLoader.qml
@@ -12,7 +12,7 @@ StackView {
   // Let's force the visibility. See
   // https://doc.qt.io/qt-5/qml-qtquick-controls2-stackview.html#visible-attached-prop
   visible: true
-   // StackView's items will provide Accessibility, so the StackView itself doesn't need Accessibility.
+  // StackView's items will provide Accessibility, so the StackView itself doesn't need Accessibility.
   Accessible.ignored: true
 
   property var screens: []


### PR DESCRIPTION
## Description

`Accessible.ignored: true `was added in `MZStackView ` in the fix for [VPN-4831](https://mozilla-hub.atlassian.net/browse/VPN-4831), to remove it from the Accessibility tree for a better experience. However that caused a large performance regression, which seems to be a Qt issue. Specifically, geometry changes during Qt layout are notified using a `QAccessible::LocationChanged` Accessible event if the element has an Accessible attached property. This can cause an expensive `QAccessible::queryAccessibleInterface` to occur  because of a cache miss. This is expensive because it tries to find the accessibleInterface using the plug in loader and repeats this by going up the parent chain:
  
Here is a call stack excerpt when this occurs:
```
00 Mozilla_VPN!QFactoryLoader::metaData
01 Mozilla_VPN!QFactoryLoader::indexOf
02 Mozilla_VPN!QAccessible::queryAccessibleInterface
03 Mozilla_VPN!QAccessibleEvent::accessibleInterface
04 Mozilla_VPN!QAccessible::updateAccessibility
05 Mozilla_VPN!QQuickItem::geometryChange
06 Mozilla_VPN!QQuickLayout::geometryChange
```

Since there doesn't seem to be a good workaround, `Accessible.ignored: true `is removed in this fix. A Qt bug report will be opened. The screen reader will say 'Custom' when the user navigates to the StackView using a screen-reader shortcut, as was the case before [VPN-4831](https://mozilla-hub.atlassian.net/browse/VPN-4831) was fixed, but that seems acceptable because it was not a core part of that fix.

## Reference

 [VPN-5436](https://mozilla-hub.atlassian.net/browse/VPN-5436) 

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
