### PR TITLE
VPN-5473 Mark the Macos PKG as universal

### DIFF
--- a/macos/pkg/Distribution
+++ b/macos/pkg/Distribution
@@ -4,7 +4,7 @@
     <background mime-type="image/png" file="background.png" alignment="left"/>
     <welcome file="welcome.html" mime-type="text/html" />
     <conclusion file="conclusion.html" mime-type="text/html" />
-    <options customize="never" allow-external-scripts="no"/>
+    <options customize="never" allow-external-scripts="no" hostArchitectures="x86_64,arm64"/>
     <domains enable_localSystem="true" />
     <installation-check script="installCheck();"/>
     <script>


### PR DESCRIPTION
## Description

We've been publishing a universal binary since 2.16 - However we totally forgot to update the installer.  This still causes rosetta to be prompted, even though it's not needed anymore q_q (See https://github.com/mozilla-mobile/mozilla-vpn-client/issues/286#issuecomment-1703937187) 
According to the docs [here](https://developer.apple.com/library/archive/documentation/DeveloperTools/Reference/DistributionDefinitionRef/Chapters/Distribution_XML_Ref.html#//apple_ref/doc/uid/TP40005370-CH100-SW7) we need to mark the cpu_arches our pkg supports. And according to [this blog post](https://scriptingosx.com/2020/12/platform-support-in-macos-installer-packages-pkg/), we can add arm :) 


