### PR TITLE
VPN-5443: Notify accessibility clients of alerts

### DIFF
--- a/nebula/ui/components/MZAlert.qml
+++ b/nebula/ui/components/MZAlert.qml
@@ -354,7 +354,6 @@ Rectangle {
     }
 
     function onShowCompleted() {
-        console.log("MZAccessibleNotification " + alertBox.alertText + " "  + alertBox.alertActionText);
         MZAccessibleNotification.notify(label, alertBox.alertText + " " + alertBox.alertActionText);
     }
 

--- a/nebula/ui/components/MZAlert.qml
+++ b/nebula/ui/components/MZAlert.qml
@@ -190,6 +190,7 @@ Rectangle {
 
             Label {
                 id: label
+                Accessible.role: Accessible.StaticText
                 anchors.centerIn: parent
                 text: alertBox.alertText + " " + "<b><u>" + alertBox.alertActionText + "</b></u>"
                 horizontalAlignment: Text.AlignHCenter
@@ -331,7 +332,9 @@ Rectangle {
             to: 1
             duration: 100
         }
+        ScriptAction { script: onShowCompleted(); }
     }
+
     function show() {
         if (!isLayout) {
             height = style.alertHeight;
@@ -348,6 +351,11 @@ Rectangle {
             console.log("Toastbox timer start")
             autoHideTimer.start()
         }
+    }
+
+    function onShowCompleted() {
+        console.log("MZAccessibleNotification " + alertBox.alertText + " "  + alertBox.alertActionText);
+        MZAccessibleNotification.notify(label, alertBox.alertText + " " + alertBox.alertActionText);
     }
 
     function remove() {

--- a/nebula/ui/components/forms/MZContextualAlert.qml
+++ b/nebula/ui/components/forms/MZContextualAlert.qml
@@ -51,8 +51,14 @@ RowLayout {
                     duration: 100
                 }
             }
+            ScriptAction { script: onShowCompleted(); }
         }
     ]
+
+    function onShowCompleted() {
+        console.log("MZAccessibleNotification " + messageText.text);
+        MZAccessibleNotification.notify(messageText, messageText.text);
+    }
 
     MZIcon {
         id: warningIcon
@@ -73,6 +79,7 @@ RowLayout {
 
     MZTextBlock {
         id: messageText
+        Accessible.role: Accessible.StaticText
 
         color: fontColor
         text: modelData.message

--- a/nebula/ui/components/forms/MZContextualAlert.qml
+++ b/nebula/ui/components/forms/MZContextualAlert.qml
@@ -56,7 +56,6 @@ RowLayout {
     ]
 
     function onShowCompleted() {
-        console.log("MZAccessibleNotification " + messageText.text);
         MZAccessibleNotification.notify(messageText, messageText.text);
     }
 

--- a/src/accessiblenotification.cpp
+++ b/src/accessiblenotification.cpp
@@ -1,0 +1,18 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "accessiblenotification.h"
+
+// static
+AccessibleNotification* AccessibleNotification::instance() {
+  static AccessibleNotification s_instance;
+  return &s_instance;
+}
+
+Q_INVOKABLE void AccessibleNotification::notify(QQuickItem* sourceItem,
+                                                const QString& notification) {
+  QAccessibleValueChangeEvent event(sourceItem, QAccessible::ValueChanged);
+  event.setValue(notification);
+  QAccessible::updateAccessibility(&event);
+}

--- a/src/accessiblenotification.cpp
+++ b/src/accessiblenotification.cpp
@@ -4,6 +4,12 @@
 
 #include "accessiblenotification.h"
 
+#include "logger.h"
+
+namespace {
+Logger logger("AccessibleNotification");
+}
+
 // static
 AccessibleNotification* AccessibleNotification::instance() {
   static AccessibleNotification s_instance;
@@ -12,6 +18,8 @@ AccessibleNotification* AccessibleNotification::instance() {
 
 Q_INVOKABLE void AccessibleNotification::notify(QQuickItem* sourceItem,
                                                 const QString& notification) {
+  logger.debug() << notification;
+
   QAccessibleValueChangeEvent event(sourceItem, QAccessible::ValueChanged);
   event.setValue(notification);
   QAccessible::updateAccessibility(&event);

--- a/src/accessiblenotification.h
+++ b/src/accessiblenotification.h
@@ -1,0 +1,35 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef ACCESSIBLENOTIFICATION_H
+#define ACCESSIBLENOTIFICATION_H
+
+#include <QAccessible>
+#include <QObject>
+#include <QQuickItem>
+#include <QString>
+
+// Singleton that notifies accessibility clients, like screen readers, using
+// a string. This can be used to notify the clients of any state change, and
+// a screen reader will read the provided string.
+//
+// Currently Qt supports this only for Windows. VPN-5489 tracks the work to be
+// done for other platforms.
+class AccessibleNotification : public QObject {
+  Q_OBJECT
+  Q_DISABLE_COPY_MOVE(AccessibleNotification)
+
+  AccessibleNotification() = default;
+  virtual ~AccessibleNotification() = default;
+
+ public:
+  static AccessibleNotification* instance();
+
+  // Notify accessibility client of the notification string.
+  // sourceItem: source of the change. It should have an Accessible
+  // attached property (if in QML) or QAccessibleInterface.
+  Q_INVOKABLE void notify(QQuickItem* sourceItem, const QString& notification);
+};
+
+#endif  // ACCESSIBLENOTIFICATION_H

--- a/src/cmake/sources.cmake
+++ b/src/cmake/sources.cmake
@@ -25,6 +25,7 @@ set_property(TARGET mozillavpn-sources PROPERTY INTERFACE_INCLUDE_DIRECTORIES
 
 # VPN Client source files
 target_sources(mozillavpn-sources INTERFACE
+    ${CMAKE_CURRENT_SOURCE_DIR}/accessiblenotification.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/featurelistcallback.h
     ${CMAKE_CURRENT_SOURCE_DIR}/featurelist.h
     ${CMAKE_CURRENT_SOURCE_DIR}/appimageprovider.h

--- a/src/commands/commandui.cpp
+++ b/src/commands/commandui.cpp
@@ -10,6 +10,7 @@
 #include <QQmlApplicationEngine>
 #include <QQmlContext>
 
+#include "accessiblenotification.h"
 #include "addons/manager/addonmanager.h"
 #include "apppermission.h"
 #include "captiveportal/captiveportaldetection.h"
@@ -354,6 +355,10 @@ int CommandUI::run(QStringList& tokens) {
       qmlRegisterSingletonInstance("Mozilla.VPN", 1, 0, "VPNProducts",
                                    ProductsHandler::instance());
     }
+
+    qmlRegisterSingletonInstance("Mozilla.Shared", 1, 0,
+                                 "MZAccessibleNotification",
+                                 AccessibleNotification::instance());
 
     // TODO: MZI18n should be moved to QmlEngineHolder but it requires extra
     // work for the generation of i18nstrings.h/cpp for the unit-test app.

--- a/src/ui/screens/home/controller/ConnectionStability.qml
+++ b/src/ui/screens/home/controller/ConnectionStability.qml
@@ -22,6 +22,19 @@ Item {
         grid.flow = grid.children[0].width > (window.width - MZTheme.theme.windowMargin * 2) ? Grid.TopToBottom : Grid.LeftToRight;
         col.handleMultilineText();
     }
+
+    function handleConnectionHealthStateChange() {
+        // If the stability item is not visible, there are no connection health problems to be be processed
+        if (!visible) {
+            return;
+        }
+
+        // Notify accessibility client of connection health problems
+        let notificationText = stabilityLabel.text + " " + stabilityLabelInstruction.text;
+        console.log("MZAccessibleNotification " + notificationText);
+        MZAccessibleNotification.notify(stabilityLabel, notificationText);
+    }
+
     GridLayout {
         id: grid
 
@@ -69,6 +82,7 @@ Item {
                     target: warningIcon
                     source: "qrc:/nebula/resources/warning-orange.svg"
                 }
+                StateChangeScript { script: handleConnectionHealthStateChange(); }
             },
             State {
                 name: VPNConnectionHealth.NoSignal
@@ -85,6 +99,7 @@ Item {
                     target: logoSubtitleOn
                     visible: false
                 }
+                StateChangeScript { script: handleConnectionHealthStateChange(); }
             }
         ]
 
@@ -121,6 +136,9 @@ Item {
                 text: VPNConnectionHealth.stability
                       === VPNConnectionHealth.Unstable ? textUnstable : textNoSignal
                 horizontalAlignment: Text.AlignLeft
+
+                Accessible.role: Accessible.StaticText
+                Accessible.name: text
             }
         }
 
@@ -134,6 +152,7 @@ Item {
         }
 
         MZInterLabel {
+             id: stabilityLabelInstruction
             //% "Check Connection"
             //: Message displayed to the user when the connection is unstable or
             //: missing, asking them to check their connection.
@@ -143,6 +162,9 @@ Item {
             Layout.alignment: Qt.AlignCenter
             onPaintedWidthChanged: stability.setColumns()
             lineHeight: grid.flow === Grid.LeftToRight ? MZTheme.theme.controllerInterLineHeight : 10
+
+            Accessible.role: Accessible.StaticText
+            Accessible.name: text
         }
     }
 

--- a/src/ui/screens/home/controller/ConnectionStability.qml
+++ b/src/ui/screens/home/controller/ConnectionStability.qml
@@ -31,7 +31,6 @@ Item {
 
         // Notify accessibility client of connection health problems
         let notificationText = stabilityLabel.text + " " + stabilityLabelInstruction.text;
-        console.log("MZAccessibleNotification " + notificationText);
         MZAccessibleNotification.notify(stabilityLabel, notificationText);
     }
 

--- a/src/ui/screens/home/controller/ControllerView.qml
+++ b/src/ui/screens/home/controller/ControllerView.qml
@@ -27,7 +27,6 @@ Item {
         if (connectedStateDescription.visible)
             notificationText += (connectedStateDescription.text + ' ');
 
-        console.log("MZAccessibleNotification " + notificationText);
         MZAccessibleNotification.notify(logoTitle, notificationText);
     }
 

--- a/src/ui/screens/home/controller/ControllerView.qml
+++ b/src/ui/screens/home/controller/ControllerView.qml
@@ -19,6 +19,18 @@ Item {
         box.connectionInfoScreenVisible = false;
     }
 
+    function handleConnectionStateChange() {
+        // Notify accessibility client of connection state
+        let notificationText = (logoTitle.text + ' ');
+        if (logoSubtitle.visible)
+            notificationText += (logoSubtitle.text + ' ');
+        if (connectedStateDescription.visible)
+            notificationText += (connectedStateDescription.text + ' ');
+
+        console.log("MZAccessibleNotification " + notificationText);
+        MZAccessibleNotification.notify(logoTitle, notificationText);
+    }
+
     Layout.preferredHeight: 318
     Layout.fillWidth: true
     Layout.leftMargin: MZTheme.theme.listSpacing
@@ -538,6 +550,7 @@ Item {
             Accessible.description: logoSubtitle.text
             width: parent.width
             onPaintedHeightChanged: if (visible) col.handleMultilineText()
+            onTextChanged: handleConnectionStateChange()
         }
 
         MZVerticalSpacer {
@@ -555,6 +568,7 @@ Item {
             anchors.horizontalCenter: parent.horizontalCenter
             onPaintedHeightChanged: if (visible) col.handleMultilineText()
             onVisibleChanged: if (visible) col.handleMultilineText()
+            onTextChanged: handleConnectionStateChange()
         }
 
         RowLayout {
@@ -562,13 +576,16 @@ Item {
 
           anchors.horizontalCenter: parent.horizontalCenter
           opacity: 0.8
+          onVisibleChanged: handleConnectionStateChange()
 
           MZInterLabel {
+            id: connectedStateDescription
             objectName: "secureAndPrivateSubtitle"
 
             color: MZTheme.theme.white
             lineHeight: MZTheme.theme.controllerInterLineHeight
-            Accessible.ignored: true
+            Accessible.role: Accessible.StaticText
+            Accessible.name: text
 
             //% "Secure and private"
             //: This refers to the user’s internet connection.


### PR DESCRIPTION
## Description

   Notify accessibility clients, like screen readers, of alert strings like "Incorrect password", "Signed out and device disconnected", so that the screen reader will read those. Also notify when connection state and health changes.
   This uses the QAccessible::ValueChanged and QAccessible::updateAccessibility, which has been verified to work on Windows. Unfortunately, Qt doesn't implement this fully on other platforms. Another ticket will be opened to track investigation of potential fixes on other platforms.

## Reference

[VPN-5443](https://mozilla-hub.atlassian.net/browse/VPN-5443), [GitHub 7863](https://github.com/mozilla-mobile/mozilla-vpn-client/issues/7863)

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-5443]: https://mozilla-hub.atlassian.net/browse/VPN-5443?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ