### PR TITLE
Pin Qt version used by Xcode Cloud

### DIFF
--- a/ci_scripts/ci_post_clone.sh
+++ b/ci_scripts/ci_post_clone.sh
@@ -31,7 +31,9 @@ APP_ID_IOS = org.mozilla.ios.FirefoxVPN
 NETEXT_ID_IOS = org.mozilla.ios.FirefoxVPN.network-extension
 EOF
 
-curl -L https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/mozillavpn.v2.mozillavpn.cache.level-3.toolchains.v3.qt-ios.latest/artifacts/public%2Fbuild%2Fqt6_ios.zip --output qt_ios.zip
+# THIS IS A QT HOTFIX, TO CONTINUE USING 6.2.4 - Change back to curling `latest` when we move to Qt 6.5.1.
+# curl -L https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/mozillavpn.v2.mozillavpn.cache.level-3.toolchains.v3.qt-ios.latest/artifacts/public%2Fbuild%2Fqt6_ios.zip --output qt_ios.zip
+curl -L https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/c9a9Uw_7Tm2L2T_QU5_Ydg/runs/0/artifacts/public%2Fbuild%2Fqt6_ios.zip --output qt_ios.zip
 unzip -q qt_ios.zip
 ls
 


### PR DESCRIPTION
## Description

This work was done for Taskcluster here: https://github.com/mozilla-mobile/mozilla-vpn-client/pull/7889/

However, our Xcode Cloud build system is different from TaskCluster, so this PR fixes it for XCode Cloud.

Xcode Cloud builds have failed for the last several days; they should work after this is merged.

