### PR TITLE
Make the Inspector check a User Setting

### DIFF
--- a/src/inspector/inspectorhandler.cpp
+++ b/src/inspector/inspectorhandler.cpp
@@ -643,7 +643,7 @@ void InspectorHandler::initialize() {
 #ifdef MZ_WASM
   WasmInspector::instance();
 #else
-  if (!Constants::inProduction()) {
+  if (SettingsHolder::instance()->inspectorEnabled()) {
     InspectorWebSocketServer* inspectWebSocketServer =
         new InspectorWebSocketServer(qApp);
     QObject::connect(qApp, &QCoreApplication::aboutToQuit,

--- a/src/settingslist.h
+++ b/src/settingslist.h
@@ -877,3 +877,20 @@ SETTING_STRING(sensitive,        // getter
                true              // sensitive (do not log)
 )
 #endif
+
+// Allow developers to compile using
+// -DFORCE_INSPECTOR=TRUE, enabling testing
+// independent of the server used.
+#ifndef FORCE_INSPECTOR
+#  define FORCE_INSPECTOR false
+#endif
+SETTING_BOOL(inspectorEnabled,        // getter
+             setInspectorEnabled,     // setter
+             removeInspectorEnabled,  // remover
+             hasInspectorEnabled,     // has
+             "InspectorEnabled",      // key
+             FORCE_INSPECTOR,         // default value
+             false,                   // user setting
+             true,                    // remove when reset
+             false                    // sensitive (do not log)
+)

--- a/src/ui/screens/getHelp/developerMenu/ViewDeveloperMenu.qml
+++ b/src/ui/screens/getHelp/developerMenu/ViewDeveloperMenu.qml
@@ -30,6 +30,16 @@ MZViewBase {
             isChecked: MZSettings.developerUnlock
             onClicked: MZSettings.developerUnlock = !MZSettings.developerUnlock
         }
+        MZCheckBoxRow {
+            id: inspectorUnlock
+
+            Layout.fillWidth: true
+            Layout.rightMargin: MZTheme.theme.windowMargin
+            labelText:  "Enable Inspector "
+            subLabelText: "Allow other programs to debug and remote-control this client."
+            isChecked: MZSettings.inspectorEnabled
+            onClicked: MZSettings.inspectorEnabled = !MZSettings.inspectorEnabled
+        }
 
         MZCheckBoxRow {
             id: checkBoxRowStagingServer

--- a/tests/dummyvpn/CMakeLists.txt
+++ b/tests/dummyvpn/CMakeLists.txt
@@ -61,6 +61,12 @@ target_compile_definitions(dummyvpn PRIVATE MZ_DUMMY)
 
 # Build the addons for functional testing.
 get_filename_component(QT6_PREFIX_PATH ${Qt6_DIR}/.. REALPATH)
+target_compile_definitions(dummyvpn PRIVATE FORCE_INSPECTOR true)
+# We should not build into the source dir
+# but that is how we are currently doing things, 
+# at least we no longer invoke python scripts to 
+# invoke cmake. 
+#  ¯\_(ツ)_/¯
 ExternalProject_Add(functional_test_addons
     SOURCE_DIR ${CMAKE_SOURCE_DIR}/tests/functional/addons
     BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/addons


### PR DESCRIPTION
## Description
Right now we only enable the inspector when the Guardian API is anything but the "prod" one. 
This makes debugging prod issues annoying and also stops any attempt to build test's that actually test against prod :) 

Let's make this a setting in the dev menu - and have the ability to enable this via compiler flags, so i can build a client version that can test against prod servers :) 