### PR TITLE
VPN-5337: 2.17 update message fixes

### DIFF
--- a/addons/message_update_v2.17/getHelp.js
+++ b/addons/message_update_v2.17/getHelp.js
@@ -1,3 +1,25 @@
 (function(api) {
-api.navigator.requestScreen(api.vpn.ScreenGetHelp);
+  function versionCompare(a, b) {
+    for (let i = 0; i < 3; ++i) {
+      if (a[i] != b[i]) {
+        return a[i] > b[i] ? -1 : 1;
+      }
+    }
+    return 0;
+  }
+
+  const parts = api.env.versionString.split('.');
+
+  const version = parts.map(a => parseInt(a, 10));
+
+  //Post 2.16 API
+  if (versionCompare([2, 16, 0], version) >= 0) {
+	api.navigator.requestScreen(api.vpn.ScreenGetHelp);
+    return;
+  }
+  //Pre 2.16 API
+  else {
+  	api.navigator.requestScreen(api.navigator.ScreenGetHelp);
+  	return;
+  }
 })

--- a/addons/message_update_v2.17/manifest.json
+++ b/addons/message_update_v2.17/manifest.json
@@ -4,7 +4,7 @@
   "name": "Update to Mozilla VPN 2.17",
   "type": "message",
   "conditions": {
-    "max_client_version": "2.160000000.9"
+    "max_client_version": "2.16.9"
   },
   "javascript": {
     "enable": "enable.js"


### PR DESCRIPTION
## Description

- Fix `max_client_version` so that it is not a number used for local testing
- Fix `Get help` button so that it works on versions before 2.16.0

## Reference

[VPN-5337: Implement 'Update' / 'Download' message for 2.17](https://mozilla-hub.atlassian.net/browse/VPN-5337)
