### PR TITLE
VPN-5496 - Update glean-core/uniffi.toml file earlier in Android build cycle

### DIFF
--- a/scripts/android/cmake.sh
+++ b/scripts/android/cmake.sh
@@ -132,6 +132,18 @@ else
   ADJUST="CONFIG-=adjust"
 fi
 
+# Warning: this is hacky.
+#
+# We build the Glean Android SDK from scratch in order to have it linked to the qtglean binary instead of the default glean one.
+# In order to do that we need to generate the Glean internal Kotlin bindings.
+#
+# We need to change the name of the binary in the Uniffi UDL file inside the Glean folder
+# for this to work.
+#
+# Here we go
+mv $WORKSPACE_ROOT/3rdparty/glean/glean-core/uniffi.toml $WORKSPACE_ROOT/3rdparty/glean/glean-core/uniffi.toml.backup
+cp $WORKSPACE_ROOT/qtglean/uniffi.toml 3rdparty/glean/glean-core/uniffi.toml
+
 if [[ "$RELEASE" ]]; then
   printn Y "Use release config"
   $QTPATH/bin/qt-cmake \
@@ -170,18 +182,6 @@ cmake --build .tmp -j$JOBS
 print Y "Generate Android Project"
 
 #androiddeployqt --input .tmp/src/android-mozillavpn-deployment-settings.json --output .tmp/src/android-build || die
-
-# Warning: this is hacky.
-#
-# We build the Glean Android SDK from scratch in order to have it linked to the qtglean binary instead of the default glean one.
-# In order to do that we need to generate the Glean internal Kotlin bindings.
-#
-# We need to change the name of the binary in the Uniffi UDL file inside the Glean folder
-# for this to work.
-#
-# Here we go
-mv $WORKSPACE_ROOT/3rdparty/glean/glean-core/uniffi.toml $WORKSPACE_ROOT/3rdparty/glean/glean-core/uniffi.toml.backup
-cp $WORKSPACE_ROOT/qtglean/uniffi.toml 3rdparty/glean/glean-core/uniffi.toml
 
 cd .tmp/src/android-build/
 # This will combine the qt-libs + qt-resources and the client


### PR DESCRIPTION
Apparently the step that generates the Kotlin bindings code happens earlier (i.e. on cmake build) now???

