### PR TITLE
VPN-5405: turn on super dooper

### DIFF
--- a/src/featurelist.h
+++ b/src/featurelist.h
@@ -193,7 +193,7 @@ FEATURE(superDooperMetrics,      // Feature ID
         FeatureCallback_true,    // Can be flipped on
         FeatureCallback_true,    // Can be flipped off
         QStringList(),           // feature dependencies
-        FeatureCallback_false)
+        FeatureCallback_true)
 
 FEATURE(unsecuredNetworkNotification,      // Feature ID
         "Unsecured network notification",  // Feature name


### PR DESCRIPTION
Ticket: https://mozilla-hub.atlassian.net/browse/VPN-5405

Per discussion w/ Santiago, we'll turn this on in advance of VPN-4578 being done. We'll do that testing during the QA period for 2.17. I'm leaving this as a feature flag in case we need to turn this back off.