### PR TITLE
VPN-5413 - Fix Missing Notifications on SDK31

### DIFF
--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -12,6 +12,8 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES"/>
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
+
     <!-- The following comment will be replaced upon deployment with default features based on the dependencies of the application.
          Remove the comment if you do not require these default features. -->
     <!-- %%INSERT_FEATURES -->

--- a/android/common/src/main/java/org/mozilla/firefox/qt/common/CoreBinder.kt
+++ b/android/common/src/main/java/org/mozilla/firefox/qt/common/CoreBinder.kt
@@ -1,0 +1,35 @@
+package org.mozilla.firefox.qt.common
+
+import android.os.Binder
+
+open class CoreBinder : Binder() {
+    /** The codes this Binder does accept in [onTransact] */
+    object ACTIONS {
+        const val activate = 1
+        const val deactivate = 2
+        const val registerEventListener = 3
+        const val requestStatistic = 4
+        const val requestCleanupLog = 6
+        const val resumeActivate = 7
+        const val setNotificationText = 8
+        const val recordEvent = 10
+        const val getStatus = 13
+        const val setStartOnBoot = 15
+        const val reactivate = 16
+        const val clearStorage = 17
+        const val setGleanUploadEnabled = 18
+        const val notificationPermissionFired = 19
+    }
+
+    /** The codes we Are Using in case of [dispatchEvent] */
+    object EVENTS {
+        const val init = 0
+        const val connected = 1
+        const val disconnected = 2
+        const val statisticUpdate = 3
+        const val activationError = 5
+        const val permissionRequired = 6
+        const val requestGleanUploadEnabledState = 7
+        const val requestNotificationPermission = 8
+    }
+}

--- a/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/NotificationUtil.kt
+++ b/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/NotificationUtil.kt
@@ -2,184 +2,182 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
- package org.mozilla.firefox.vpn.daemon
+package org.mozilla.firefox.vpn.daemon
 
- import android.app.Activity
- import android.app.NotificationChannel
- import android.app.NotificationManager
- import android.app.PendingIntent
- import android.app.Service
- import android.content.Context
- import android.content.Intent
- import android.content.pm.PackageManager
- import android.os.Build
- import androidx.core.app.NotificationCompat
- import kotlinx.serialization.Serializable
- import org.json.JSONObject
- import org.mozilla.firefox.qt.common.Prefs
- 
- class NotificationUtil(ctx: Service) {
-     private val NOTIFICATION_PERMISSION_PREF_KEY ="com.mozilla.vpnNotification.didAskForPermission"
-     private val NOTIFICATION_CHANNEL_ID = "com.mozilla.vpnNotification"
-     private val CONNECTED_NOTIFICATION_ID = 1337
-     private val context: Service = ctx
-     private val mNotificationBuilder: NotificationCompat.Builder by lazy {
-         NotificationCompat.Builder(ctx, NOTIFICATION_CHANNEL_ID)
-     }
-     private val mNotificationManager: NotificationManager by lazy {
-         ctx.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-     }
-     private val mainActivityName = "org.mozilla.firefox.vpn.qt.VPNActivity"
- 
-     /**
-      * Creates a new Notification using the {CannedNotification}
-      * Will bring the service into the foreground using that.
-      */
-     fun show(message: CannedNotification) {
-         updateNotificationChannel()
-         // Create the Intent that Should be Fired if the User Clicks the notification
-         val activity = Class.forName(mainActivityName)
-         val intent = Intent(context, activity)
-         val pendingIntent =
-             PendingIntent.getActivity(context, 0, intent, PendingIntent.FLAG_IMMUTABLE)
-         // Build our notification
-         mNotificationBuilder
-             .setSmallIcon(R.drawable.icon_mozillavpn_notifiaction)
-             .setContentTitle(message.connectedMessage.header)
-             .setContentText(message.connectedMessage.body)
-             .setOnlyAlertOnce(true)
-             .setPriority(NotificationCompat.PRIORITY_DEFAULT)
-             .setContentIntent(pendingIntent)
-         context.startForeground(CONNECTED_NOTIFICATION_ID, mNotificationBuilder.build())
-     }
- 
-     /**
-      * Updates the Notification
-      * in case there is no notification currently,
-      * this is a no-op.
-      */
-     fun setNotificationText(msg: ClientNotification?) {
-         if (msg == null) {
-             return
-         }
-         mNotificationBuilder.let {
-             it.setContentTitle(msg.header)
-             it.setContentText(msg.body)
-             mNotificationManager.notify(CONNECTED_NOTIFICATION_ID, it.build())
-         }
-     }
- 
-     /**
-      * Should be called whenever a session is ended.
-      * Will upadte the notification to show the Disconnected Message
-      */
-     fun hide(message: CannedNotification) {
-         // Switch the notification to "Disconnected" / or translated version
-         // If the VPN-Client is alive, it will override this instantly
-         // If not, this fallback is shown.
-         setNotificationText(message.disconnectedMessage)
-     }
- 
-     // Creates / Updates the notification channel we will be using to post
-     // the notification to.
-     private fun updateNotificationChannel(name: String = "General", descriptionText: String = "") {
-         // From Oreo on we need to have a "notification channel" to post to.
-         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
-             return
-         }
-         val importance = NotificationManager.IMPORTANCE_LOW
-         val channel = NotificationChannel(NOTIFICATION_CHANNEL_ID, name, importance).apply {
-             description = descriptionText
-         }
-         // Register the channel with the system
-         mNotificationManager.createNotificationChannel(channel)
-     }
- 
-     /**
-      * Returns true if the permission "android.permission.POST_NOTIFICATIONS"
-      * needs to be requested before this class will be functional.
-      */
-     fun needsNotificationPermission():Boolean{
-         // Android 13
-         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
-             Log.e("NotificationUtil", "No need to request permissionf for ${Build.VERSION.SDK_INT}")
-             // Below android 13, we will request permissions on
-             // implicit due to us being a foreground service
-             return false;
-         }
-         val res = context.checkSelfPermission("android.permission.POST_NOTIFICATIONS");
-         if(res == PackageManager.PERMISSION_GRANTED ){
-                Log.e("NotificationUtil", "Permission Granted")
-             // We have the permission, all good
-             return false;
-         }
-         // We would need permissions but only ask the user once.
-         val prefs = Prefs.get(context)
-        // if(prefs.getBoolean(NOTIFICATION_PERMISSION_PREF_KEY,false)){
-         //   Log.e("NotificationUtil", "We already asked!")
-         //   return false
-        // }
-         Log.e("NotificationUtil", "Need to ask")
-         return true
-     }
- 
-     /**
-      * Should be fired once the user has been asked about their notification
-      * preference, so we will only ask once.
-      */
-     fun onNotificationPermissionPromptFired(){
-         val prefs = Prefs.get(context)
-         prefs.edit().putBoolean(NOTIFICATION_PERMISSION_PREF_KEY,true).apply()
-     }
- }
- 
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import kotlinx.serialization.Serializable
+import org.json.JSONObject
+import org.mozilla.firefox.qt.common.Prefs
+
+class NotificationUtil(ctx: Service) {
+    private val HAS_ASKED_FOR_PUSH_PERMISSION = "com.mozilla.vpnNotification.didAskForPermission"
+    private val NOTIFICATION_CHANNEL_ID = "com.mozilla.vpnNotification"
+    private val CONNECTED_NOTIFICATION_ID = 1337
+    private val context: Service = ctx
+    private val mNotificationBuilder: NotificationCompat.Builder by lazy {
+        NotificationCompat.Builder(ctx, NOTIFICATION_CHANNEL_ID)
+    }
+    private val mNotificationManager: NotificationManager by lazy {
+        ctx.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+    }
+    private val mainActivityName = "org.mozilla.firefox.vpn.qt.VPNActivity"
+
+    /**
+     * Creates a new Notification using the {CannedNotification}
+     * Will bring the service into the foreground using that.
+     */
+    fun show(message: CannedNotification) {
+        updateNotificationChannel()
+        // Create the Intent that Should be Fired if the User Clicks the notification
+        val activity = Class.forName(mainActivityName)
+        val intent = Intent(context, activity)
+        val pendingIntent =
+            PendingIntent.getActivity(context, 0, intent, PendingIntent.FLAG_IMMUTABLE)
+        // Build our notification
+        mNotificationBuilder
+            .setSmallIcon(R.drawable.icon_mozillavpn_notifiaction)
+            .setContentTitle(message.connectedMessage.header)
+            .setContentText(message.connectedMessage.body)
+            .setOnlyAlertOnce(true)
+            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+            .setContentIntent(pendingIntent)
+        context.startForeground(CONNECTED_NOTIFICATION_ID, mNotificationBuilder.build())
+    }
+
+    /**
+     * Updates the Notification
+     * in case there is no notification currently,
+     * this is a no-op.
+     */
+    fun setNotificationText(msg: ClientNotification?) {
+        if (msg == null) {
+            return
+        }
+        mNotificationBuilder.let {
+            it.setContentTitle(msg.header)
+            it.setContentText(msg.body)
+            mNotificationManager.notify(CONNECTED_NOTIFICATION_ID, it.build())
+        }
+    }
+
+    /**
+     * Should be called whenever a session is ended.
+     * Will upadte the notification to show the Disconnected Message
+     */
+    fun hide(message: CannedNotification) {
+        // Switch the notification to "Disconnected" / or translated version
+        // If the VPN-Client is alive, it will override this instantly
+        // If not, this fallback is shown.
+        setNotificationText(message.disconnectedMessage)
+    }
+
+    // Creates / Updates the notification channel we will be using to post
+    // the notification to.
+    private fun updateNotificationChannel(name: String = "General", descriptionText: String = "") {
+        // From Oreo on we need to have a "notification channel" to post to.
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+            return
+        }
+        val importance = NotificationManager.IMPORTANCE_LOW
+        val channel = NotificationChannel(NOTIFICATION_CHANNEL_ID, name, importance).apply {
+            description = descriptionText
+        }
+        // Register the channel with the system
+        mNotificationManager.createNotificationChannel(channel)
+    }
+
+    /**
+     * Returns true if the permission "android.permission.POST_NOTIFICATIONS"
+     * needs to be requested before this class will be functional.
+     */
+    fun needsNotificationPermission(): Boolean {
+        // Android 13
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+            Log.i("NotificationUtil", "No need to request permissionf for ${Build.VERSION.SDK_INT}")
+            // Below android 13, we will request permissions on
+            // implicit due to us being a foreground service
+            return false
+        }
+        val res = context.checkSelfPermission("android.permission.POST_NOTIFICATIONS")
+        if (res == PackageManager.PERMISSION_GRANTED) {
+            Log.i("NotificationUtil", "Permission Granted")
+            // We have the permission, all good
+            return false
+        }
+        // We would need permissions but only ask the user once.
+        val prefs = Prefs.get(context)
+        if (prefs.getBoolean(HAS_ASKED_FOR_PUSH_PERMISSION, false)) {
+            Log.i("NotificationUtil", "We already asked for push permission, not doing again")
+            return false
+        }
+        Log.e("NotificationUtil", "Need to ask for Notificaiton Permission")
+        return true
+    }
+
+    /**
+     * Should be fired once the user has been asked about their notification
+     * preference, so we will only ask once.
+     */
+    fun onNotificationPermissionPromptFired() {
+        val prefs = Prefs.get(context)
+        prefs.edit().putBoolean(HAS_ASKED_FOR_PUSH_PERMISSION, true).apply()
+    }
+}
+
  /*
   * ClientNotification
   * Message sent from the client manually.
   */
- @Serializable
- data class ClientNotification(val header: String, val body: String)
- 
+@Serializable
+data class ClientNotification(val header: String, val body: String)
+
  /*
   * A "Canned" Notification contains all strings needed for the "(dis-)/connected" flow
   * and is provided by the controller when asking for a connection.
   */
- @Serializable
- data class CannedNotification(
-     // Message to be shown when the Client connects
-     val connectedMessage: ClientNotification,
-     // Message to be shown when the client disconnects
-     val disconnectedMessage: ClientNotification,
-     // Product-Name -> Will be used as the Notification Header
-     val productName: String,
- ) {
-     companion object {
-         /**
-          * CannedNotification(json) -> Creates a Canned notification
-          * out of a VPN-Client JSON config.
-          */
-         operator fun invoke(value: JSONObject?): CannedNotification? {
-             if (value == null) {
-                 return null
-             }
-             val messages = value.getJSONObject("messages")
-             return try {
-                 CannedNotification(
-                     ClientNotification(
-                         messages.getString("connectedHeader"),
-                         messages.getString("connectedBody"),
-                     ),
-                     ClientNotification(
-                         messages.getString("disconnectedHeader"),
-                         messages.getString("disconnectedBody"),
-                     ),
-                     messages.getString("productName"),
-                 )
-             } catch (e: Exception) {
-                 Log.e("NotificationUtil", "Failed to Parse Notification Object $value")
-                 null
-             }
-         }
-     }
- }
- 
+@Serializable
+data class CannedNotification(
+    // Message to be shown when the Client connects
+    val connectedMessage: ClientNotification,
+    // Message to be shown when the client disconnects
+    val disconnectedMessage: ClientNotification,
+    // Product-Name -> Will be used as the Notification Header
+    val productName: String,
+) {
+    companion object {
+        /**
+         * CannedNotification(json) -> Creates a Canned notification
+         * out of a VPN-Client JSON config.
+         */
+        operator fun invoke(value: JSONObject?): CannedNotification? {
+            if (value == null) {
+                return null
+            }
+            val messages = value.getJSONObject("messages")
+            return try {
+                CannedNotification(
+                    ClientNotification(
+                        messages.getString("connectedHeader"),
+                        messages.getString("connectedBody"),
+                    ),
+                    ClientNotification(
+                        messages.getString("disconnectedHeader"),
+                        messages.getString("disconnectedBody"),
+                    ),
+                    messages.getString("productName"),
+                )
+            } catch (e: Exception) {
+                Log.e("NotificationUtil", "Failed to Parse Notification Object $value")
+                null
+            }
+        }
+    }
+}

--- a/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/NotificationUtil.kt
+++ b/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/NotificationUtil.kt
@@ -2,142 +2,184 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package org.mozilla.firefox.vpn.daemon
+ package org.mozilla.firefox.vpn.daemon
 
-import android.app.NotificationChannel
-import android.app.NotificationManager
-import android.app.PendingIntent
-import android.app.Service
-import android.content.Context
-import android.content.Intent
-import android.os.Build
-import androidx.core.app.NotificationCompat
-import kotlinx.serialization.Serializable
-import org.json.JSONObject
-
-class NotificationUtil(ctx: Service) {
-    private val NOTIFICATION_CHANNEL_ID = "com.mozilla.vpnNotification"
-    private val CONNECTED_NOTIFICATION_ID = 1337
-    private val context: Service = ctx
-    private val mNotificationBuilder: NotificationCompat.Builder by lazy {
-        NotificationCompat.Builder(ctx, NOTIFICATION_CHANNEL_ID)
-    }
-    private val mNotificationManager: NotificationManager by lazy {
-        ctx.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-    }
-    private val mainActivityName = "org.mozilla.firefox.vpn.qt.VPNActivity"
-
-    /**
-     * Creates a new Notification using the {CannedNotification}
-     * Will bring the service into the foreground using that.
-     */
-    fun show(message: CannedNotification) {
-        updateNotificationChannel()
-        // Create the Intent that Should be Fired if the User Clicks the notification
-        val activity = Class.forName(mainActivityName)
-        val intent = Intent(context, activity)
-        val pendingIntent =
-            PendingIntent.getActivity(context, 0, intent, PendingIntent.FLAG_IMMUTABLE)
-        // Build our notification
-        mNotificationBuilder
-            .setSmallIcon(R.drawable.icon_mozillavpn_notifiaction)
-            .setContentTitle(message.connectedMessage.header)
-            .setContentText(message.connectedMessage.body)
-            .setOnlyAlertOnce(true)
-            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
-            .setContentIntent(pendingIntent)
-        context.startForeground(CONNECTED_NOTIFICATION_ID, mNotificationBuilder.build())
-    }
-
-    /**
-     * Updates the Notification
-     * in case there is no notification currently,
-     * this is a no-op.
-     */
-    fun setNotificationText(msg: ClientNotification?) {
-        if (msg == null) {
-            return
-        }
-        mNotificationBuilder.let {
-            it.setContentTitle(msg.header)
-            it.setContentText(msg.body)
-            mNotificationManager.notify(CONNECTED_NOTIFICATION_ID, it.build())
-        }
-    }
-
-    /**
-     * Should be called whenever a session is ended.
-     * Will upadte the notification to show the Disconnected Message
-     */
-    fun hide(message: CannedNotification) {
-        // Switch the notification to "Disconnected" / or translated version
-        // If the VPN-Client is alive, it will override this instantly
-        // If not, this fallback is shown.
-        setNotificationText(message.disconnectedMessage)
-    }
-
-    // Creates / Updates the notification channel we will be using to post
-    // the notification to.
-    private fun updateNotificationChannel(name: String = "General", descriptionText: String = "") {
-        // From Oreo on we need to have a "notification channel" to post to.
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
-            return
-        }
-        val importance = NotificationManager.IMPORTANCE_LOW
-        val channel = NotificationChannel(NOTIFICATION_CHANNEL_ID, name, importance).apply {
-            description = descriptionText
-        }
-        // Register the channel with the system
-        mNotificationManager.createNotificationChannel(channel)
-    }
-}
-
-/*
- * ClientNotification
- * Message sent from the client manually.
- */
-@Serializable
-data class ClientNotification(val header: String, val body: String)
-
-/*
- * A "Canned" Notification contains all strings needed for the "(dis-)/connected" flow
- * and is provided by the controller when asking for a connection.
- */
-@Serializable
-data class CannedNotification(
-    // Message to be shown when the Client connects
-    val connectedMessage: ClientNotification,
-    // Message to be shown when the client disconnects
-    val disconnectedMessage: ClientNotification,
-    // Product-Name -> Will be used as the Notification Header
-    val productName: String,
-) {
-    companion object {
-        /**
-         * CannedNotification(json) -> Creates a Canned notification
-         * out of a VPN-Client JSON config.
-         */
-        operator fun invoke(value: JSONObject?): CannedNotification? {
-            if (value == null) {
-                return null
-            }
-            val messages = value.getJSONObject("messages")
-            return try {
-                CannedNotification(
-                    ClientNotification(
-                        messages.getString("connectedHeader"),
-                        messages.getString("connectedBody"),
-                    ),
-                    ClientNotification(
-                        messages.getString("disconnectedHeader"),
-                        messages.getString("disconnectedBody"),
-                    ),
-                    messages.getString("productName"),
-                )
-            } catch (e: Exception) {
-                Log.e("NotificationUtil", "Failed to Parse Notification Object $value")
-                null
-            }
-        }
-    }
-}
+ import android.app.Activity
+ import android.app.NotificationChannel
+ import android.app.NotificationManager
+ import android.app.PendingIntent
+ import android.app.Service
+ import android.content.Context
+ import android.content.Intent
+ import android.content.pm.PackageManager
+ import android.os.Build
+ import androidx.core.app.NotificationCompat
+ import kotlinx.serialization.Serializable
+ import org.json.JSONObject
+ import org.mozilla.firefox.qt.common.Prefs
+ 
+ class NotificationUtil(ctx: Service) {
+     private val NOTIFICATION_PERMISSION_PREF_KEY ="com.mozilla.vpnNotification.didAskForPermission"
+     private val NOTIFICATION_CHANNEL_ID = "com.mozilla.vpnNotification"
+     private val CONNECTED_NOTIFICATION_ID = 1337
+     private val context: Service = ctx
+     private val mNotificationBuilder: NotificationCompat.Builder by lazy {
+         NotificationCompat.Builder(ctx, NOTIFICATION_CHANNEL_ID)
+     }
+     private val mNotificationManager: NotificationManager by lazy {
+         ctx.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+     }
+     private val mainActivityName = "org.mozilla.firefox.vpn.qt.VPNActivity"
+ 
+     /**
+      * Creates a new Notification using the {CannedNotification}
+      * Will bring the service into the foreground using that.
+      */
+     fun show(message: CannedNotification) {
+         updateNotificationChannel()
+         // Create the Intent that Should be Fired if the User Clicks the notification
+         val activity = Class.forName(mainActivityName)
+         val intent = Intent(context, activity)
+         val pendingIntent =
+             PendingIntent.getActivity(context, 0, intent, PendingIntent.FLAG_IMMUTABLE)
+         // Build our notification
+         mNotificationBuilder
+             .setSmallIcon(R.drawable.icon_mozillavpn_notifiaction)
+             .setContentTitle(message.connectedMessage.header)
+             .setContentText(message.connectedMessage.body)
+             .setOnlyAlertOnce(true)
+             .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+             .setContentIntent(pendingIntent)
+         context.startForeground(CONNECTED_NOTIFICATION_ID, mNotificationBuilder.build())
+     }
+ 
+     /**
+      * Updates the Notification
+      * in case there is no notification currently,
+      * this is a no-op.
+      */
+     fun setNotificationText(msg: ClientNotification?) {
+         if (msg == null) {
+             return
+         }
+         mNotificationBuilder.let {
+             it.setContentTitle(msg.header)
+             it.setContentText(msg.body)
+             mNotificationManager.notify(CONNECTED_NOTIFICATION_ID, it.build())
+         }
+     }
+ 
+     /**
+      * Should be called whenever a session is ended.
+      * Will upadte the notification to show the Disconnected Message
+      */
+     fun hide(message: CannedNotification) {
+         // Switch the notification to "Disconnected" / or translated version
+         // If the VPN-Client is alive, it will override this instantly
+         // If not, this fallback is shown.
+         setNotificationText(message.disconnectedMessage)
+     }
+ 
+     // Creates / Updates the notification channel we will be using to post
+     // the notification to.
+     private fun updateNotificationChannel(name: String = "General", descriptionText: String = "") {
+         // From Oreo on we need to have a "notification channel" to post to.
+         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+             return
+         }
+         val importance = NotificationManager.IMPORTANCE_LOW
+         val channel = NotificationChannel(NOTIFICATION_CHANNEL_ID, name, importance).apply {
+             description = descriptionText
+         }
+         // Register the channel with the system
+         mNotificationManager.createNotificationChannel(channel)
+     }
+ 
+     /**
+      * Returns true if the permission "android.permission.POST_NOTIFICATIONS"
+      * needs to be requested before this class will be functional.
+      */
+     fun needsNotificationPermission():Boolean{
+         // Android 13
+         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+             Log.e("NotificationUtil", "No need to request permissionf for ${Build.VERSION.SDK_INT}")
+             // Below android 13, we will request permissions on
+             // implicit due to us being a foreground service
+             return false;
+         }
+         val res = context.checkSelfPermission("android.permission.POST_NOTIFICATIONS");
+         if(res == PackageManager.PERMISSION_GRANTED ){
+                Log.e("NotificationUtil", "Permission Granted")
+             // We have the permission, all good
+             return false;
+         }
+         // We would need permissions but only ask the user once.
+         val prefs = Prefs.get(context)
+        // if(prefs.getBoolean(NOTIFICATION_PERMISSION_PREF_KEY,false)){
+         //   Log.e("NotificationUtil", "We already asked!")
+         //   return false
+        // }
+         Log.e("NotificationUtil", "Need to ask")
+         return true
+     }
+ 
+     /**
+      * Should be fired once the user has been asked about their notification
+      * preference, so we will only ask once.
+      */
+     fun onNotificationPermissionPromptFired(){
+         val prefs = Prefs.get(context)
+         prefs.edit().putBoolean(NOTIFICATION_PERMISSION_PREF_KEY,true).apply()
+     }
+ }
+ 
+ /*
+  * ClientNotification
+  * Message sent from the client manually.
+  */
+ @Serializable
+ data class ClientNotification(val header: String, val body: String)
+ 
+ /*
+  * A "Canned" Notification contains all strings needed for the "(dis-)/connected" flow
+  * and is provided by the controller when asking for a connection.
+  */
+ @Serializable
+ data class CannedNotification(
+     // Message to be shown when the Client connects
+     val connectedMessage: ClientNotification,
+     // Message to be shown when the client disconnects
+     val disconnectedMessage: ClientNotification,
+     // Product-Name -> Will be used as the Notification Header
+     val productName: String,
+ ) {
+     companion object {
+         /**
+          * CannedNotification(json) -> Creates a Canned notification
+          * out of a VPN-Client JSON config.
+          */
+         operator fun invoke(value: JSONObject?): CannedNotification? {
+             if (value == null) {
+                 return null
+             }
+             val messages = value.getJSONObject("messages")
+             return try {
+                 CannedNotification(
+                     ClientNotification(
+                         messages.getString("connectedHeader"),
+                         messages.getString("connectedBody"),
+                     ),
+                     ClientNotification(
+                         messages.getString("disconnectedHeader"),
+                         messages.getString("disconnectedBody"),
+                     ),
+                     messages.getString("productName"),
+                 )
+             } catch (e: Exception) {
+                 Log.e("NotificationUtil", "Failed to Parse Notification Object $value")
+                 null
+             }
+         }
+     }
+ }
+ 

--- a/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/VPNService.kt
+++ b/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/VPNService.kt
@@ -2,604 +2,604 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
- package org.mozilla.firefox.vpn.daemon
+package org.mozilla.firefox.vpn.daemon
 
- import android.content.Context
- import android.content.Intent
- import android.os.Build
- import android.os.CountDownTimer
- import android.os.IBinder
- import android.system.OsConstants
- import com.wireguard.android.util.SharedLibraryLoader
- import com.wireguard.config.Config
- import com.wireguard.config.InetEndpoint
- import com.wireguard.config.InetNetwork
- import com.wireguard.config.Interface
- import com.wireguard.config.Peer
- import com.wireguard.crypto.Key
- import mozilla.telemetry.glean.BuildInfo
- import mozilla.telemetry.glean.Glean
- import mozilla.telemetry.glean.config.Configuration
- import org.json.JSONObject
- import org.mozilla.firefox.qt.common.Prefs
- import org.mozilla.firefox.vpn.daemon.GleanMetrics.Pings
- import org.mozilla.firefox.vpn.daemon.GleanMetrics.Session
- import java.io.File
- import java.util.*
- 
- class VPNService : android.net.VpnService() {
-     private val tag = "VPNService"
-     private var mBinder: VPNServiceBinder = VPNServiceBinder(this)
-     val mNotificationHandler by lazy { NotificationUtil(this) }
-     private var mConfig: JSONObject? = null
-     private var mConnectionTime: Long = 0
-     private var mAlreadyInitialised = false
-     val mConnectionHealth = ConnectionHealth(this)
-     private var mCityname = ""
-     private var mBackgroundPingTimerMSec: Long = 3 * 60 * 60 * 1000 // 3 hours, in milliseconds
-     private val mMetricsTimer: CountDownTimer = object : CountDownTimer(
-         mBackgroundPingTimerMSec,
-         mBackgroundPingTimerMSec / 4,
-     ) {
-         override fun onTick(millisUntilFinished: Long) {}
-         override fun onFinish() {
-             Log.i(tag, "Sending daemon_timer ping")
-             if (isSuperDooperMetricsActive) {
-                 Pings.daemonsession.submit(
-                     Pings.daemonsessionReasonCodes.daemonTimer,
-                 )
-             }
-             this.start()
-         }
-     }
- 
-     private val isSuperDooperMetricsActive: Boolean
-         get() {
-             return this.mConfig?.optBoolean("isSuperDooperFeatureActive", false) ?: false
-         }
- 
-     private val gleanDebugTag: String?
-         get() {
-             val gleanDebugTag = this.mConfig?.optString("gleanDebugTag", "") ?: ""
-             if (!(gleanDebugTag.isEmpty())) {
-                 return gleanDebugTag
-             } else {
-                 return null
-             }
-         }
- 
-     private var currentTunnelHandle = -1
-         set(value: Int) {
-             field = value
-             if (value > -1) {
-                 mConnectionTime = System.currentTimeMillis()
-                 Log.i(tag, "Dispatch Daemon State -> connected")
-                 mBinder.dispatchEvent(
-                     VPNServiceBinder.EVENTS.connected,
-                     JSONObject()
-                         .apply {
-                             put("time", mConnectionTime)
-                             put("city", mCityname)
-                         }
-                         .toString(),
-                 )
-                 return
-             }
-             Log.i(tag, "Dispatch Daemon State -> disconnected")
-             mBinder.dispatchEvent(VPNServiceBinder.EVENTS.disconnected, "")
-             mConnectionTime = 0
-         }
- 
-     fun init() {
-         if (mAlreadyInitialised) {
-             Log.i(tag, "VPN Service already initialized, ignoring.")
-             return
-         }
-         Log.init(this)
-         SharedLibraryLoader.loadSharedLibrary(this, "wg-go")
-         Log.i(tag, "Initialised Service with Wireguard Version ${wgVersion()}")
- 
-         // Check in with wg, if there is a tunnel.
-         // This should be 99% -1, however if the service get's destroyed and the
-         // wireguard tunnel lives on, we can recover from here :)
-         currentTunnelHandle = wgGetLatestHandle()
-         Log.i(tag, "Wireguard reported current tunnel: $currentTunnelHandle")
-         mAlreadyInitialised = true
- 
-         // It's usually a bad practice to initialize Glean with the wrong
-         // value for uploadEnabled... However, since this is a very controlled
-         // situation -- it should only happen when logging in to a brand new
-         // installation of the app -- we should be fine
-         //
-         // If the `glean_enabled` preference is not set, when a new event listener
-         // is bound to this service, it will request that the main app broadcast
-         // the user provided preference for this. So it should not be long until
-         // the correct value is set here. See VPNServiceBinder > onTransact > ACTIONS.registerEventListener.
-         // Lol it' so broken.
-         initializeGlean(Prefs.get(this).getBoolean("glean_enabled", false))
-     }
- 
-     override fun onUnbind(intent: Intent?): Boolean {
-         if (!isUp) {
-             Log.v(tag, "Client Disconnected, VPN is down - Service might shut down soon")
-             return super.onUnbind(intent)
-         }
-         Log.v(tag, "Client Disconnected, VPN is up")
-         return super.onUnbind(intent)
-     }
- 
-     override fun onDestroy() {
-         // Note: This might not get called (depending on how it got invoked)
-         // it for granted all exits will be here.
-         Log.v(tag, "Service got Destroyed")
-         super.onDestroy()
-     }
- 
-     /**
-      * EntryPoint for the Service, gets Called when AndroidController.cpp calles bindService.
-      * Returns the [VPNServiceBinder] so QT can send Requests to it.
-      */
-     override fun onBind(intent: Intent?): IBinder? {
-         Log.v(tag, "Got Bind request")
-         init()
-         if( mNotificationHandler.needsNotificationPermission() ){
-             mBinder.dispatchEvent(VPNServiceBinder.EVENTS.requestNotificationPermission)
-         }
-         return mBinder
-     }
- 
-     /**
-      * Might be the entryPoint if the Service gets Started via an Service Intent: Might be from
-      * Always-On-Vpn from Settings or from Booting the device and having "connect on boot" enabled.
-      */
-     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-         Log.i(tag, "Service Started by Intent")
-         init()
-         if (isUp) {
-             // In case a user has "always-on" and "start-on-boot" enabled, we might
-             // get this multiple times.
-             return START_NOT_STICKY
-         }
-         intent?.let {
-             if (intent.getBooleanExtra("startOnly", false)) {
-                 Log.i(tag, "Start only!")
-                 // If this is a Start Only request, the client will soon
-                 // bind to the service anyway.
-                 // We should return START_NOT_STICKY so that after an unbind()
-                 // the OS will not try to restart the service.
-                 return START_NOT_STICKY
-             }
-         }
-         // This start is from always-on
-         if (this.mConfig == null) {
-             // We don't have tunnel to turn on - Try to create one with last config the service got
-             val prefs = Prefs.get(this)
-             val lastConfString = prefs.getString("lastConf", "")
-             if (lastConfString.isNullOrEmpty()) {
-                 // We have nothing to connect to -> Exit
-                 Log.e(tag, "VPN service was triggered without defining a Server or having a tunnel")
-                 return super.onStartCommand(intent, flags, startId)
-             }
-             this.mConfig = JSONObject(lastConfString)
-         }
-         try {
-             turnOn(this.mConfig!!)
-         } catch (error: Exception) {
-             Log.e(tag, "Failed to start the VPN for always-on:")
-             Log.e(tag, error.toString())
-             Log.stack(tag, error.stackTrace)
-         }
- 
-         return super.onStartCommand(intent, flags, startId)
-     }
- 
-     // Invoked when the application is revoked.
-     // At this moment, the VPN interface is already deactivated by the system.
-     override fun onRevoke() {
-         Log.i(tag, "OS Revoked VPN permission")
-         this.turnOff()
-         super.onRevoke()
-     }
- 
-     var connectionTime: Long = 0
-         get() {
-             return mConnectionTime
-         }
- 
-     /**
-      * Checks if there is a config loaded or some available in the Storage to fetch. if this is
-      * false calling {reconnect()} will abort.
-      * @returns whether a config is found.
-      */
-     var canActivate: Boolean = false
-         get() {
-             if (mConfig != null) {
-                 return true
-             }
-             val lastConfString = Prefs.get(this).getString("lastConf", "")
-             return !lastConfString.isNullOrEmpty()
-         }
-     var cityname: String = ""
-         get() {
-             return mCityname
-         }
- 
-     var isUp: Boolean = false
-         get() {
-             return currentTunnelHandle >= 0
-         }
-     val status: JSONObject
-         get() {
-             val deviceIpv4: String = ""
-             return JSONObject().apply {
-                 putOpt("rx_bytes", getConfigValue("rx_bytes")?.toInt())
-                 putOpt("tx_bytes", getConfigValue("tx_bytes")?.toInt())
-                 putOpt("endpoint", mConfig?.getJSONObject("server")?.getString("ipv4Gateway"))
-                 putOpt("deviceIpv4", mConfig?.getJSONObject("device")?.getString("ipv4Address"))
-             }
-         }
- 
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.os.CountDownTimer
+import android.os.IBinder
+import android.system.OsConstants
+import com.wireguard.android.util.SharedLibraryLoader
+import com.wireguard.config.Config
+import com.wireguard.config.InetEndpoint
+import com.wireguard.config.InetNetwork
+import com.wireguard.config.Interface
+import com.wireguard.config.Peer
+import com.wireguard.crypto.Key
+import mozilla.telemetry.glean.BuildInfo
+import mozilla.telemetry.glean.Glean
+import mozilla.telemetry.glean.config.Configuration
+import org.json.JSONObject
+import org.mozilla.firefox.qt.common.CoreBinder
+import org.mozilla.firefox.qt.common.Prefs
+import org.mozilla.firefox.vpn.daemon.GleanMetrics.Pings
+import org.mozilla.firefox.vpn.daemon.GleanMetrics.Session
+import java.io.File
+import java.util.*
+
+class VPNService : android.net.VpnService() {
+    private val tag = "VPNService"
+    private var mBinder: VPNServiceBinder = VPNServiceBinder(this)
+    val mNotificationHandler by lazy { NotificationUtil(this) }
+    private var mConfig: JSONObject? = null
+    private var mConnectionTime: Long = 0
+    private var mAlreadyInitialised = false
+    val mConnectionHealth = ConnectionHealth(this)
+    private var mCityname = ""
+    private var mBackgroundPingTimerMSec: Long = 3 * 60 * 60 * 1000 // 3 hours, in milliseconds
+    private val mMetricsTimer: CountDownTimer = object : CountDownTimer(
+        mBackgroundPingTimerMSec,
+        mBackgroundPingTimerMSec / 4,
+    ) {
+        override fun onTick(millisUntilFinished: Long) {}
+        override fun onFinish() {
+            Log.i(tag, "Sending daemon_timer ping")
+            if (isSuperDooperMetricsActive) {
+                Pings.daemonsession.submit(
+                    Pings.daemonsessionReasonCodes.daemonTimer,
+                )
+            }
+            this.start()
+        }
+    }
+
+    private val isSuperDooperMetricsActive: Boolean
+        get() {
+            return this.mConfig?.optBoolean("isSuperDooperFeatureActive", false) ?: false
+        }
+
+    private val gleanDebugTag: String?
+        get() {
+            val gleanDebugTag = this.mConfig?.optString("gleanDebugTag", "") ?: ""
+            if (!(gleanDebugTag.isEmpty())) {
+                return gleanDebugTag
+            } else {
+                return null
+            }
+        }
+
+    private var currentTunnelHandle = -1
+        set(value: Int) {
+            field = value
+            if (value > -1) {
+                mConnectionTime = System.currentTimeMillis()
+                Log.i(tag, "Dispatch Daemon State -> connected")
+                mBinder.dispatchEvent(
+                    CoreBinder.EVENTS.connected,
+                    JSONObject()
+                        .apply {
+                            put("time", mConnectionTime)
+                            put("city", mCityname)
+                        }
+                        .toString(),
+                )
+                return
+            }
+            Log.i(tag, "Dispatch Daemon State -> disconnected")
+            mBinder.dispatchEvent(CoreBinder.EVENTS.disconnected, "")
+            mConnectionTime = 0
+        }
+
+    fun init() {
+        if (mAlreadyInitialised) {
+            Log.i(tag, "VPN Service already initialized, ignoring.")
+            return
+        }
+        Log.init(this)
+        SharedLibraryLoader.loadSharedLibrary(this, "wg-go")
+        Log.i(tag, "Initialised Service with Wireguard Version ${wgVersion()}")
+
+        // Check in with wg, if there is a tunnel.
+        // This should be 99% -1, however if the service get's destroyed and the
+        // wireguard tunnel lives on, we can recover from here :)
+        currentTunnelHandle = wgGetLatestHandle()
+        Log.i(tag, "Wireguard reported current tunnel: $currentTunnelHandle")
+        mAlreadyInitialised = true
+
+        // It's usually a bad practice to initialize Glean with the wrong
+        // value for uploadEnabled... However, since this is a very controlled
+        // situation -- it should only happen when logging in to a brand new
+        // installation of the app -- we should be fine
+        //
+        // If the `glean_enabled` preference is not set, when a new event listener
+        // is bound to this service, it will request that the main app broadcast
+        // the user provided preference for this. So it should not be long until
+        // the correct value is set here. See VPNServiceBinder > onTransact > ACTIONS.registerEventListener.
+        // Lol it' so broken.
+        initializeGlean(Prefs.get(this).getBoolean("glean_enabled", false))
+    }
+
+    override fun onUnbind(intent: Intent?): Boolean {
+        if (!isUp) {
+            Log.v(tag, "Client Disconnected, VPN is down - Service might shut down soon")
+            return super.onUnbind(intent)
+        }
+        Log.v(tag, "Client Disconnected, VPN is up")
+        return super.onUnbind(intent)
+    }
+
+    override fun onDestroy() {
+        // Note: This might not get called (depending on how it got invoked)
+        // it for granted all exits will be here.
+        Log.v(tag, "Service got Destroyed")
+        super.onDestroy()
+    }
+
+    /**
+     * EntryPoint for the Service, gets Called when AndroidController.cpp calles bindService.
+     * Returns the [VPNServiceBinder] so QT can send Requests to it.
+     */
+    override fun onBind(intent: Intent?): IBinder? {
+        Log.v(tag, "Got Bind request")
+        init()
+        if (mNotificationHandler.needsNotificationPermission()) {
+            mBinder.dispatchEvent(CoreBinder.EVENTS.requestNotificationPermission)
+        }
+        return mBinder
+    }
+
+    /**
+     * Might be the entryPoint if the Service gets Started via an Service Intent: Might be from
+     * Always-On-Vpn from Settings or from Booting the device and having "connect on boot" enabled.
+     */
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        Log.i(tag, "Service Started by Intent")
+        init()
+        if (isUp) {
+            // In case a user has "always-on" and "start-on-boot" enabled, we might
+            // get this multiple times.
+            return START_NOT_STICKY
+        }
+        intent?.let {
+            if (intent.getBooleanExtra("startOnly", false)) {
+                Log.i(tag, "Start only!")
+                // If this is a Start Only request, the client will soon
+                // bind to the service anyway.
+                // We should return START_NOT_STICKY so that after an unbind()
+                // the OS will not try to restart the service.
+                return START_NOT_STICKY
+            }
+        }
+        // This start is from always-on
+        if (this.mConfig == null) {
+            // We don't have tunnel to turn on - Try to create one with last config the service got
+            val prefs = Prefs.get(this)
+            val lastConfString = prefs.getString("lastConf", "")
+            if (lastConfString.isNullOrEmpty()) {
+                // We have nothing to connect to -> Exit
+                Log.e(tag, "VPN service was triggered without defining a Server or having a tunnel")
+                return super.onStartCommand(intent, flags, startId)
+            }
+            this.mConfig = JSONObject(lastConfString)
+        }
+        try {
+            turnOn(this.mConfig!!)
+        } catch (error: Exception) {
+            Log.e(tag, "Failed to start the VPN for always-on:")
+            Log.e(tag, error.toString())
+            Log.stack(tag, error.stackTrace)
+        }
+
+        return super.onStartCommand(intent, flags, startId)
+    }
+
+    // Invoked when the application is revoked.
+    // At this moment, the VPN interface is already deactivated by the system.
+    override fun onRevoke() {
+        Log.i(tag, "OS Revoked VPN permission")
+        this.turnOff()
+        super.onRevoke()
+    }
+
+    var connectionTime: Long = 0
+        get() {
+            return mConnectionTime
+        }
+
+    /**
+     * Checks if there is a config loaded or some available in the Storage to fetch. if this is
+     * false calling {reconnect()} will abort.
+     * @returns whether a config is found.
+     */
+    var canActivate: Boolean = false
+        get() {
+            if (mConfig != null) {
+                return true
+            }
+            val lastConfString = Prefs.get(this).getString("lastConf", "")
+            return !lastConfString.isNullOrEmpty()
+        }
+    var cityname: String = ""
+        get() {
+            return mCityname
+        }
+
+    var isUp: Boolean = false
+        get() {
+            return currentTunnelHandle >= 0
+        }
+    val status: JSONObject
+        get() {
+            val deviceIpv4: String = ""
+            return JSONObject().apply {
+                putOpt("rx_bytes", getConfigValue("rx_bytes")?.toInt())
+                putOpt("tx_bytes", getConfigValue("tx_bytes")?.toInt())
+                putOpt("endpoint", mConfig?.getJSONObject("server")?.getString("ipv4Gateway"))
+                putOpt("deviceIpv4", mConfig?.getJSONObject("device")?.getString("ipv4Address"))
+            }
+        }
+
      /*
       * Checks if the VPN Permission is given.
       * If the permission is given, returns true
       * Requests permission and returns false if not.
       */
-     fun checkPermissions(): Intent? {
-         // See https://developer.android.com/guide/topics/connectivity/vpn#connect_a_service
-         // Call Prepare, if we get an Intent back, we dont have the VPN Permission
-         // from the user. So we need to pass this to our main Activity and exit here.
-         val intent = prepare(this)
-         return intent
-     }
- 
-     fun turnOn(json: JSONObject?, useFallbackServer: Boolean = false, source: String? = null) {
-         if (json == null) {
-             throw Error("no json config provided")
-         }
-         Log.sensitive(tag, json.toString())
-         val wireguard_conf = buildWireguardConfig(json, useFallbackServer)
-         val wgConfig: String = wireguard_conf.toWgUserspaceString()
-         if (wgConfig.isEmpty()) {
-             throw Error("WG_Userspace config is empty, can't continue")
-         }
-         mCityname = json.getString("city")
- 
-         if (checkPermissions() != null) {
-             throw Error("turn on was called without vpn-permission!")
-         }
- 
-         val builder = Builder()
-         setupBuilder(wireguard_conf, builder)
-         builder.setSession("mvpn0")
-         builder.establish().use { tun ->
-             if (tun == null) {
-                 Log.e(tag, "Activation Error: did not get a TUN handle")
-                 return
-             }
-             // We should have everything to establish a new connection, turn down the old tunnel
-             // now.
-             if (currentTunnelHandle != -1) {
-                 Log.i(tag, "Currently have a connection, close old handle")
-                 wgTurnOff(currentTunnelHandle)
-             }
-             currentTunnelHandle = wgTurnOn("mvpn0", tun.detachFd(), wgConfig)
-         }
-         if (currentTunnelHandle < 0) {
-             throw Error("Activation Error Wireguard-Error -> $currentTunnelHandle")
-         }
-         protect(wgGetSocketV4(currentTunnelHandle))
-         protect(wgGetSocketV6(currentTunnelHandle))
-         mConfig = json
-         // Store the config in case the service gets
-         // asked boot vpn from the OS
-         val prefs = Prefs.get(this)
-         prefs.edit().putString("lastConf", json.toString()).apply()
- 
-         // Go foreground
-         CannedNotification(mConfig)?.let { mNotificationHandler.show(it) }
- 
-         if (useFallbackServer) {
-             mConnectionHealth.start(
-                 json.getJSONObject("serverFallback").getString("ipv4AddrIn"),
-                 json.getJSONObject("serverFallback").getString("ipv4Gateway"),
-                 json.getJSONObject("serverFallback").getString("ipv4Gateway"),
-                 json.getJSONObject("server").getString("ipv4AddrIn"),
-             )
-         } else {
-             var fallbackIpv4 = ""
-             if (json.has("serverFallback")) {
-                 fallbackIpv4 = json.getJSONObject("serverFallback").getString("ipv4AddrIn")
-             }
-             mConnectionHealth.start(
-                 json.getJSONObject("server").getString("ipv4AddrIn"),
-                 json.getJSONObject("server").getString("ipv4Gateway"),
-                 json.getString("dns"),
-                 fallbackIpv4,
-             )
-         }
- 
-         // For `isGleanDebugTagActive` and `isSuperDooperMetricsActive` to work,
-         // this must be after the mConfig is set to the latest data.
-         val gleanTag = gleanDebugTag
-         if (gleanTag != null) {
-             Log.i(tag, "Setting Glean debug tag for daemon.")
-             Glean.setDebugViewTag(gleanTag)
-         }
-         if (isSuperDooperMetricsActive) {
-             val installationIdString = json.getString("installationId")
-             installationIdString?.let {
-                 try {
-                     val installationId = UUID.fromString(installationIdString)
-                     Session.installationId.set(installationId)
-                 } catch (e: Exception) {
-                     Log.e(tag, "Daemon installation ID string was not UUID:")
-                     Log.e(tag, e.toString())
-                 }
-             }
-             Pings.daemonsession.submit(
-                 Pings.daemonsessionReasonCodes.daemonFlush
-             )
- 
-             Session.daemonSessionStart.set()
-             Session.daemonSessionId.generateAndSet()
-             if (source != null) {
-                 Session.daemonSessionSource.set(source)
-             }
-             Pings.daemonsession.submit(
-                 Pings.daemonsessionReasonCodes.daemonStart,
-             )
-         }
-         mMetricsTimer.start()
-     }
- 
-     fun reconnect(forceFallBack: Boolean = false, source: String? = null) {
-         // Save the current timestamp - so that a silent switch won't
-         // reset the timer in the app.
-         val currentConnectionTime = mConnectionTime
- 
-         val config =
-             if (this.mConfig != null) {
-                 this.mConfig
-             } else {
-                 val prefs = Prefs.get(this)
-                 val lastConfString = prefs.getString("lastConf", "")
-                 if (lastConfString.isNullOrEmpty()) {
-                     // We have nothing to connect to -> Exit
-                     Log.e(
-                         tag,
-                         "VPN service was triggered without defining a Server or having a tunnel",
-                     )
-                     throw Error("no config to use")
-                 }
-                 JSONObject(lastConfString)
-             }
- 
-         Log.v(tag, "Try to reconnect tunnel with same conf")
-         try {
-             this.turnOn(config, forceFallBack, source)
-         } catch (e: Exception) {
-             Log.e(tag, "VPN service - Reconnect failed")
-             // TODO: If we end up here, we might have screwed up the connection.
-             // we should put out a notification that the user go into the app and does a manual
-             // connection.
-         }
-         if (currentConnectionTime != 0.toLong()) {
-             // In case we have had a connection timestamp,
-             // restore that, so that the silent switch is not
-             // putting people off. :)
-             mConnectionTime = currentConnectionTime
-         }
-     }
-     fun clearConfig() {
-         Prefs.get(this).edit().apply() { putString("lastConf", "") }.apply()
-         mConfig = null
-     }
- 
-     fun turnOff() {
-         Log.v(tag, "Try to disable tunnel")
-         wgTurnOff(currentTunnelHandle)
-         currentTunnelHandle = -1
-         // If the client is "dead", on a disconnect the
-         // message won't be updated to 'you disconnected from X'
-         // so we should get rid of it. :)
-         val shouldClearNotification = !mBinder.isClientAttached
-         stopForeground(shouldClearNotification)
-         mConnectionHealth.stop()
-         // Clear the notification message, so the content
-         // is not "disconnected" in case we connect from a non-client.
-         CannedNotification(mConfig)?.let { mNotificationHandler.hide(it) }
-         if (isSuperDooperMetricsActive) {
-             Session.daemonSessionEnd.set()
-             Pings.daemonsession.submit(
-                 Pings.daemonsessionReasonCodes.daemonEnd
-             )
- 
-             // We are rotating the UUID here as a safety measure. It is rotated
-             // again before the next session start, and we expect to see the
-             // UUID created here in only one ping: The daemon ping with a
-             // "flush" reason, which should contain this UUID and no other
-             // metrics.
-             Session.daemonSessionId.generateAndSet()
-         }
-         mMetricsTimer.cancel()
-     }
- 
-     /** Configures an Android VPN Service Tunnel with a given Wireguard Config */
-     private fun setupBuilder(config: Config, builder: Builder) {
-         // Setup Split tunnel
-         for (
-             excludedApplication in
-             config.`interface`.excludedApplications
-             ) builder.addDisallowedApplication(
-                 excludedApplication,
-             )
- 
-         // Device IP
-         for (addr in config.`interface`.addresses) builder.addAddress(addr.address, addr.mask)
-         // DNS
-         for (addr in config.`interface`.dnsServers) builder.addDnsServer(addr.hostAddress)
-         // Add All routes the VPN may route tos
-         for (peer in config.peers) {
-             for (addr in peer.allowedIps) {
-                 builder.addRoute(addr.address, addr.mask)
-             }
-         }
-         builder.allowFamily(OsConstants.AF_INET)
-         builder.allowFamily(OsConstants.AF_INET6)
-         builder.setMtu(config.`interface`.mtu.orElse(1280))
- 
-         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) builder.setMetered(false)
-         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) setUnderlyingNetworks(null)
- 
-         builder.setBlocking(true)
-     }
- 
-     /** Gets config value for {key} from the Current running Wireguard tunnel */
-     private fun getConfigValue(key: String): String? {
-         if (!isUp) {
-             return null
-         }
-         val config = wgGetConfig(currentTunnelHandle) ?: return null
-         val lines = config.split("\n")
-         for (line in lines) {
-             val parts = line.split("=")
-             val k = parts.first()
-             val value = parts.last()
-             if (key == k) {
-                 return value
-             }
-         }
-         return null
-     }
- 
-     /**
-      * Create a Wireguard [Config] from a [json] string - The [json] will be created in
-      * AndroidController.cpp
-      */
-     private fun buildWireguardConfig(obj: JSONObject, useFallbackServer: Boolean = false): Config {
-         val confBuilder = Config.Builder()
-         val jServer: JSONObject =
-             if (useFallbackServer) {
-                 obj.getJSONObject("serverFallback")
-             } else {
-                 obj.getJSONObject("server")
-             }
- 
-         val peerBuilder = Peer.Builder()
-         val ep =
-             InetEndpoint.parse(
-                 jServer.getString("ipv4AddrIn") + ":" + jServer.getString("port"),
-             )
-         peerBuilder.setEndpoint(ep)
-         peerBuilder.setPublicKey(Key.fromBase64(jServer.getString("publicKey")))
- 
-         val jAllowedIPList = obj.getJSONArray("allowedIPs")
-         if (jAllowedIPList.length() == 0) {
-             val internet = InetNetwork.parse("0.0.0.0/0") // aka The whole internet.
-             peerBuilder.addAllowedIp(internet)
-         } else {
-             (0 until jAllowedIPList.length()).toList().forEach {
-                 val network = InetNetwork.parse(jAllowedIPList.getString(it))
-                 peerBuilder.addAllowedIp(network)
-             }
-         }
- 
-         confBuilder.addPeer(peerBuilder.build())
- 
-         val privateKey = obj.getJSONObject("keys").getString("privateKey")
-         val jDevice = obj.getJSONObject("device")
- 
-         val ifaceBuilder = Interface.Builder()
-         ifaceBuilder.parsePrivateKey(privateKey)
-         ifaceBuilder.addAddress(InetNetwork.parse(jDevice.getString("ipv4Address")))
-         ifaceBuilder.addAddress(InetNetwork.parse(jDevice.getString("ipv6Address")))
-         ifaceBuilder.addDnsServer(InetNetwork.parse(obj.getString("dns")).address)
-         if (useFallbackServer) {
-             // In case we have to use the fallback, add the default dns as fallback as well.
-             ifaceBuilder.addDnsServer(InetNetwork.parse(jServer.getString("ipv4Gateway")).address)
-         }
-         val jExcludedApplication = obj.getJSONArray("excludedApps")
-         (0 until jExcludedApplication.length()).toList().forEach {
-             val appName = jExcludedApplication.get(it).toString()
-             ifaceBuilder.excludeApplication(appName)
-         }
-         confBuilder.setInterface(ifaceBuilder.build())
-         return confBuilder.build()
-     }
- 
-     fun setGleanUploadEnabled(uploadEnabled: Boolean) {
-         Log.i(tag, "Setting glean upload enabled state: $uploadEnabled")
- 
-         Prefs.get(this).edit().apply {
-             putBoolean("glean_enabled", uploadEnabled)
-             apply()
-         }
- 
-         Glean.setUploadEnabled(uploadEnabled)
-     }
- 
-     private fun initializeGlean(uploadEnabled: Boolean) {
-         val customDataPath = File(applicationContext.applicationInfo.dataDir, GLEAN_DATA_DIR).path
-         val channel =
-             if (this.packageName.endsWith(".debug")) {
-                 "staging"
-             } else {
-                 "production"
-             }
- 
-         Glean.registerPings(Pings)
-         Glean.initialize(
-             applicationContext = this.applicationContext,
-             uploadEnabled = uploadEnabled,
-             // GleanBuildInfo can only be generated for application,
-             // We are in a library so we have to build it ourselves.
-             buildInfo =
-             BuildInfo(
-                 BuildConfig.VERSIONCODE,
-                 BuildConfig.SHORTVERSION,
-                 Calendar.getInstance(),
-             ),
-             configuration =
-             Configuration(
-                 channel = channel,
-                 // When initializing Glean from outside the main process,
-                 // we need to provide it with a dataPath manually.
-                 dataPath = customDataPath,
-             ),
-         )
- 
-         Log.i(tag, "Initialized Glean for daemon. Upload enabled state: $uploadEnabled")
-     }
- 
-     companion object {
-         // This value cannot be "glean_data",
-         // because that is the data path for the Glean data on the main application.
-         // See:
-         // https://mozilla.github.io/glean/book/reference/general/initializing.html#configuration
-         internal const val GLEAN_DATA_DIR: String = "glean_daemon_data"
- 
-         @JvmStatic
-         fun startService(c: Context) {
-             c.applicationContext.startService(
-                 Intent(c.applicationContext, VPNService::class.java).apply {
-                     putExtra("startOnly", true)
-                 },
-             )
-         }
- 
-         @JvmStatic private external fun wgGetConfig(handle: Int): String?
- 
-         @JvmStatic private external fun wgGetSocketV4(handle: Int): Int
- 
-         @JvmStatic private external fun wgGetSocketV6(handle: Int): Int
- 
-         @JvmStatic private external fun wgTurnOff(handle: Int)
- 
-         @JvmStatic private external fun wgTurnOn(ifName: String, tunFd: Int, settings: String): Int
- 
-         @JvmStatic private external fun wgVersion(): String?
- 
-         @JvmStatic private external fun wgGetLatestHandle(): Int
-     }
- }
- 
+    fun checkPermissions(): Intent? {
+        // See https://developer.android.com/guide/topics/connectivity/vpn#connect_a_service
+        // Call Prepare, if we get an Intent back, we dont have the VPN Permission
+        // from the user. So we need to pass this to our main Activity and exit here.
+        val intent = prepare(this)
+        return intent
+    }
+
+    fun turnOn(json: JSONObject?, useFallbackServer: Boolean = false, source: String? = null) {
+        if (json == null) {
+            throw Error("no json config provided")
+        }
+        Log.sensitive(tag, json.toString())
+        val wireguard_conf = buildWireguardConfig(json, useFallbackServer)
+        val wgConfig: String = wireguard_conf.toWgUserspaceString()
+        if (wgConfig.isEmpty()) {
+            throw Error("WG_Userspace config is empty, can't continue")
+        }
+        mCityname = json.getString("city")
+
+        if (checkPermissions() != null) {
+            throw Error("turn on was called without vpn-permission!")
+        }
+
+        val builder = Builder()
+        setupBuilder(wireguard_conf, builder)
+        builder.setSession("mvpn0")
+        builder.establish().use { tun ->
+            if (tun == null) {
+                Log.e(tag, "Activation Error: did not get a TUN handle")
+                return
+            }
+            // We should have everything to establish a new connection, turn down the old tunnel
+            // now.
+            if (currentTunnelHandle != -1) {
+                Log.i(tag, "Currently have a connection, close old handle")
+                wgTurnOff(currentTunnelHandle)
+            }
+            currentTunnelHandle = wgTurnOn("mvpn0", tun.detachFd(), wgConfig)
+        }
+        if (currentTunnelHandle < 0) {
+            throw Error("Activation Error Wireguard-Error -> $currentTunnelHandle")
+        }
+        protect(wgGetSocketV4(currentTunnelHandle))
+        protect(wgGetSocketV6(currentTunnelHandle))
+        mConfig = json
+        // Store the config in case the service gets
+        // asked boot vpn from the OS
+        val prefs = Prefs.get(this)
+        prefs.edit().putString("lastConf", json.toString()).apply()
+
+        // Go foreground
+        CannedNotification(mConfig)?.let { mNotificationHandler.show(it) }
+
+        if (useFallbackServer) {
+            mConnectionHealth.start(
+                json.getJSONObject("serverFallback").getString("ipv4AddrIn"),
+                json.getJSONObject("serverFallback").getString("ipv4Gateway"),
+                json.getJSONObject("serverFallback").getString("ipv4Gateway"),
+                json.getJSONObject("server").getString("ipv4AddrIn"),
+            )
+        } else {
+            var fallbackIpv4 = ""
+            if (json.has("serverFallback")) {
+                fallbackIpv4 = json.getJSONObject("serverFallback").getString("ipv4AddrIn")
+            }
+            mConnectionHealth.start(
+                json.getJSONObject("server").getString("ipv4AddrIn"),
+                json.getJSONObject("server").getString("ipv4Gateway"),
+                json.getString("dns"),
+                fallbackIpv4,
+            )
+        }
+
+        // For `isGleanDebugTagActive` and `isSuperDooperMetricsActive` to work,
+        // this must be after the mConfig is set to the latest data.
+        val gleanTag = gleanDebugTag
+        if (gleanTag != null) {
+            Log.i(tag, "Setting Glean debug tag for daemon.")
+            Glean.setDebugViewTag(gleanTag)
+        }
+        if (isSuperDooperMetricsActive) {
+            val installationIdString = json.getString("installationId")
+            installationIdString?.let {
+                try {
+                    val installationId = UUID.fromString(installationIdString)
+                    Session.installationId.set(installationId)
+                } catch (e: Exception) {
+                    Log.e(tag, "Daemon installation ID string was not UUID:")
+                    Log.e(tag, e.toString())
+                }
+            }
+            Pings.daemonsession.submit(
+                Pings.daemonsessionReasonCodes.daemonFlush,
+            )
+
+            Session.daemonSessionStart.set()
+            Session.daemonSessionId.generateAndSet()
+            if (source != null) {
+                Session.daemonSessionSource.set(source)
+            }
+            Pings.daemonsession.submit(
+                Pings.daemonsessionReasonCodes.daemonStart,
+            )
+        }
+        mMetricsTimer.start()
+    }
+
+    fun reconnect(forceFallBack: Boolean = false, source: String? = null) {
+        // Save the current timestamp - so that a silent switch won't
+        // reset the timer in the app.
+        val currentConnectionTime = mConnectionTime
+
+        val config =
+            if (this.mConfig != null) {
+                this.mConfig
+            } else {
+                val prefs = Prefs.get(this)
+                val lastConfString = prefs.getString("lastConf", "")
+                if (lastConfString.isNullOrEmpty()) {
+                    // We have nothing to connect to -> Exit
+                    Log.e(
+                        tag,
+                        "VPN service was triggered without defining a Server or having a tunnel",
+                    )
+                    throw Error("no config to use")
+                }
+                JSONObject(lastConfString)
+            }
+
+        Log.v(tag, "Try to reconnect tunnel with same conf")
+        try {
+            this.turnOn(config, forceFallBack, source)
+        } catch (e: Exception) {
+            Log.e(tag, "VPN service - Reconnect failed")
+            // TODO: If we end up here, we might have screwed up the connection.
+            // we should put out a notification that the user go into the app and does a manual
+            // connection.
+        }
+        if (currentConnectionTime != 0.toLong()) {
+            // In case we have had a connection timestamp,
+            // restore that, so that the silent switch is not
+            // putting people off. :)
+            mConnectionTime = currentConnectionTime
+        }
+    }
+    fun clearConfig() {
+        Prefs.get(this).edit().apply() { putString("lastConf", "") }.apply()
+        mConfig = null
+    }
+
+    fun turnOff() {
+        Log.v(tag, "Try to disable tunnel")
+        wgTurnOff(currentTunnelHandle)
+        currentTunnelHandle = -1
+        // If the client is "dead", on a disconnect the
+        // message won't be updated to 'you disconnected from X'
+        // so we should get rid of it. :)
+        val shouldClearNotification = !mBinder.isClientAttached
+        stopForeground(shouldClearNotification)
+        mConnectionHealth.stop()
+        // Clear the notification message, so the content
+        // is not "disconnected" in case we connect from a non-client.
+        CannedNotification(mConfig)?.let { mNotificationHandler.hide(it) }
+        if (isSuperDooperMetricsActive) {
+            Session.daemonSessionEnd.set()
+            Pings.daemonsession.submit(
+                Pings.daemonsessionReasonCodes.daemonEnd,
+            )
+
+            // We are rotating the UUID here as a safety measure. It is rotated
+            // again before the next session start, and we expect to see the
+            // UUID created here in only one ping: The daemon ping with a
+            // "flush" reason, which should contain this UUID and no other
+            // metrics.
+            Session.daemonSessionId.generateAndSet()
+        }
+        mMetricsTimer.cancel()
+    }
+
+    /** Configures an Android VPN Service Tunnel with a given Wireguard Config */
+    private fun setupBuilder(config: Config, builder: Builder) {
+        // Setup Split tunnel
+        for (
+            excludedApplication in
+            config.`interface`.excludedApplications
+            ) builder.addDisallowedApplication(
+                excludedApplication,
+            )
+
+        // Device IP
+        for (addr in config.`interface`.addresses) builder.addAddress(addr.address, addr.mask)
+        // DNS
+        for (addr in config.`interface`.dnsServers) builder.addDnsServer(addr.hostAddress)
+        // Add All routes the VPN may route tos
+        for (peer in config.peers) {
+            for (addr in peer.allowedIps) {
+                builder.addRoute(addr.address, addr.mask)
+            }
+        }
+        builder.allowFamily(OsConstants.AF_INET)
+        builder.allowFamily(OsConstants.AF_INET6)
+        builder.setMtu(config.`interface`.mtu.orElse(1280))
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) builder.setMetered(false)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) setUnderlyingNetworks(null)
+
+        builder.setBlocking(true)
+    }
+
+    /** Gets config value for {key} from the Current running Wireguard tunnel */
+    private fun getConfigValue(key: String): String? {
+        if (!isUp) {
+            return null
+        }
+        val config = wgGetConfig(currentTunnelHandle) ?: return null
+        val lines = config.split("\n")
+        for (line in lines) {
+            val parts = line.split("=")
+            val k = parts.first()
+            val value = parts.last()
+            if (key == k) {
+                return value
+            }
+        }
+        return null
+    }
+
+    /**
+     * Create a Wireguard [Config] from a [json] string - The [json] will be created in
+     * AndroidController.cpp
+     */
+    private fun buildWireguardConfig(obj: JSONObject, useFallbackServer: Boolean = false): Config {
+        val confBuilder = Config.Builder()
+        val jServer: JSONObject =
+            if (useFallbackServer) {
+                obj.getJSONObject("serverFallback")
+            } else {
+                obj.getJSONObject("server")
+            }
+
+        val peerBuilder = Peer.Builder()
+        val ep =
+            InetEndpoint.parse(
+                jServer.getString("ipv4AddrIn") + ":" + jServer.getString("port"),
+            )
+        peerBuilder.setEndpoint(ep)
+        peerBuilder.setPublicKey(Key.fromBase64(jServer.getString("publicKey")))
+
+        val jAllowedIPList = obj.getJSONArray("allowedIPs")
+        if (jAllowedIPList.length() == 0) {
+            val internet = InetNetwork.parse("0.0.0.0/0") // aka The whole internet.
+            peerBuilder.addAllowedIp(internet)
+        } else {
+            (0 until jAllowedIPList.length()).toList().forEach {
+                val network = InetNetwork.parse(jAllowedIPList.getString(it))
+                peerBuilder.addAllowedIp(network)
+            }
+        }
+
+        confBuilder.addPeer(peerBuilder.build())
+
+        val privateKey = obj.getJSONObject("keys").getString("privateKey")
+        val jDevice = obj.getJSONObject("device")
+
+        val ifaceBuilder = Interface.Builder()
+        ifaceBuilder.parsePrivateKey(privateKey)
+        ifaceBuilder.addAddress(InetNetwork.parse(jDevice.getString("ipv4Address")))
+        ifaceBuilder.addAddress(InetNetwork.parse(jDevice.getString("ipv6Address")))
+        ifaceBuilder.addDnsServer(InetNetwork.parse(obj.getString("dns")).address)
+        if (useFallbackServer) {
+            // In case we have to use the fallback, add the default dns as fallback as well.
+            ifaceBuilder.addDnsServer(InetNetwork.parse(jServer.getString("ipv4Gateway")).address)
+        }
+        val jExcludedApplication = obj.getJSONArray("excludedApps")
+        (0 until jExcludedApplication.length()).toList().forEach {
+            val appName = jExcludedApplication.get(it).toString()
+            ifaceBuilder.excludeApplication(appName)
+        }
+        confBuilder.setInterface(ifaceBuilder.build())
+        return confBuilder.build()
+    }
+
+    fun setGleanUploadEnabled(uploadEnabled: Boolean) {
+        Log.i(tag, "Setting glean upload enabled state: $uploadEnabled")
+
+        Prefs.get(this).edit().apply {
+            putBoolean("glean_enabled", uploadEnabled)
+            apply()
+        }
+
+        Glean.setUploadEnabled(uploadEnabled)
+    }
+
+    private fun initializeGlean(uploadEnabled: Boolean) {
+        val customDataPath = File(applicationContext.applicationInfo.dataDir, GLEAN_DATA_DIR).path
+        val channel =
+            if (this.packageName.endsWith(".debug")) {
+                "staging"
+            } else {
+                "production"
+            }
+
+        Glean.registerPings(Pings)
+        Glean.initialize(
+            applicationContext = this.applicationContext,
+            uploadEnabled = uploadEnabled,
+            // GleanBuildInfo can only be generated for application,
+            // We are in a library so we have to build it ourselves.
+            buildInfo =
+            BuildInfo(
+                BuildConfig.VERSIONCODE,
+                BuildConfig.SHORTVERSION,
+                Calendar.getInstance(),
+            ),
+            configuration =
+            Configuration(
+                channel = channel,
+                // When initializing Glean from outside the main process,
+                // we need to provide it with a dataPath manually.
+                dataPath = customDataPath,
+            ),
+        )
+
+        Log.i(tag, "Initialized Glean for daemon. Upload enabled state: $uploadEnabled")
+    }
+
+    companion object {
+        // This value cannot be "glean_data",
+        // because that is the data path for the Glean data on the main application.
+        // See:
+        // https://mozilla.github.io/glean/book/reference/general/initializing.html#configuration
+        internal const val GLEAN_DATA_DIR: String = "glean_daemon_data"
+
+        @JvmStatic
+        fun startService(c: Context) {
+            c.applicationContext.startService(
+                Intent(c.applicationContext, VPNService::class.java).apply {
+                    putExtra("startOnly", true)
+                },
+            )
+        }
+
+        @JvmStatic private external fun wgGetConfig(handle: Int): String?
+
+        @JvmStatic private external fun wgGetSocketV4(handle: Int): Int
+
+        @JvmStatic private external fun wgGetSocketV6(handle: Int): Int
+
+        @JvmStatic private external fun wgTurnOff(handle: Int)
+
+        @JvmStatic private external fun wgTurnOn(ifName: String, tunFd: Int, settings: String): Int
+
+        @JvmStatic private external fun wgVersion(): String?
+
+        @JvmStatic private external fun wgGetLatestHandle(): Int
+    }
+}

--- a/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/VPNService.kt
+++ b/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/VPNService.kt
@@ -2,599 +2,604 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package org.mozilla.firefox.vpn.daemon
+ package org.mozilla.firefox.vpn.daemon
 
-import android.content.Context
-import android.content.Intent
-import android.os.Build
-import android.os.CountDownTimer
-import android.os.IBinder
-import android.system.OsConstants
-import com.wireguard.android.util.SharedLibraryLoader
-import com.wireguard.config.Config
-import com.wireguard.config.InetEndpoint
-import com.wireguard.config.InetNetwork
-import com.wireguard.config.Interface
-import com.wireguard.config.Peer
-import com.wireguard.crypto.Key
-import mozilla.telemetry.glean.BuildInfo
-import mozilla.telemetry.glean.Glean
-import mozilla.telemetry.glean.config.Configuration
-import org.json.JSONObject
-import org.mozilla.firefox.qt.common.Prefs
-import org.mozilla.firefox.vpn.daemon.GleanMetrics.Pings
-import org.mozilla.firefox.vpn.daemon.GleanMetrics.Session
-import java.io.File
-import java.util.*
-
-class VPNService : android.net.VpnService() {
-    private val tag = "VPNService"
-    private var mBinder: VPNServiceBinder = VPNServiceBinder(this)
-    val mNotificationHandler by lazy { NotificationUtil(this) }
-    private var mConfig: JSONObject? = null
-    private var mConnectionTime: Long = 0
-    private var mAlreadyInitialised = false
-    val mConnectionHealth = ConnectionHealth(this)
-    private var mCityname = ""
-    private var mBackgroundPingTimerMSec: Long = 3 * 60 * 60 * 1000 // 3 hours, in milliseconds
-    private val mMetricsTimer: CountDownTimer = object : CountDownTimer(
-        mBackgroundPingTimerMSec,
-        mBackgroundPingTimerMSec / 4,
-    ) {
-        override fun onTick(millisUntilFinished: Long) {}
-        override fun onFinish() {
-            Log.i(tag, "Sending daemon_timer ping")
-            if (isSuperDooperMetricsActive) {
-                Pings.daemonsession.submit(
-                    Pings.daemonsessionReasonCodes.daemonTimer,
-                )
-            }
-            this.start()
-        }
-    }
-
-    private val isSuperDooperMetricsActive: Boolean
-        get() {
-            return this.mConfig?.optBoolean("isSuperDooperFeatureActive", false) ?: false
-        }
-
-    private val gleanDebugTag: String?
-        get() {
-            val gleanDebugTag = this.mConfig?.optString("gleanDebugTag", "") ?: ""
-            if (!(gleanDebugTag.isEmpty())) {
-                return gleanDebugTag
-            } else {
-                return null
-            }
-        }
-
-    private var currentTunnelHandle = -1
-        set(value: Int) {
-            field = value
-            if (value > -1) {
-                mConnectionTime = System.currentTimeMillis()
-                Log.i(tag, "Dispatch Daemon State -> connected")
-                mBinder.dispatchEvent(
-                    VPNServiceBinder.EVENTS.connected,
-                    JSONObject()
-                        .apply {
-                            put("time", mConnectionTime)
-                            put("city", mCityname)
-                        }
-                        .toString(),
-                )
-                return
-            }
-            Log.i(tag, "Dispatch Daemon State -> disconnected")
-            mBinder.dispatchEvent(VPNServiceBinder.EVENTS.disconnected, "")
-            mConnectionTime = 0
-        }
-
-    fun init() {
-        if (mAlreadyInitialised) {
-            Log.i(tag, "VPN Service already initialized, ignoring.")
-            return
-        }
-        Log.init(this)
-        SharedLibraryLoader.loadSharedLibrary(this, "wg-go")
-        Log.i(tag, "Initialised Service with Wireguard Version ${wgVersion()}")
-
-        // Check in with wg, if there is a tunnel.
-        // This should be 99% -1, however if the service get's destroyed and the
-        // wireguard tunnel lives on, we can recover from here :)
-        currentTunnelHandle = wgGetLatestHandle()
-        Log.i(tag, "Wireguard reported current tunnel: $currentTunnelHandle")
-        mAlreadyInitialised = true
-
-        // It's usually a bad practice to initialize Glean with the wrong
-        // value for uploadEnabled... However, since this is a very controlled
-        // situation -- it should only happen when logging in to a brand new
-        // installation of the app -- we should be fine
-        //
-        // If the `glean_enabled` preference is not set, when a new event listener
-        // is bound to this service, it will request that the main app broadcast
-        // the user provided preference for this. So it should not be long until
-        // the correct value is set here. See VPNServiceBinder > onTransact > ACTIONS.registerEventListener.
-        initializeGlean(Prefs.get(this).getBoolean("glean_enabled", false))
-    }
-
-    override fun onUnbind(intent: Intent?): Boolean {
-        if (!isUp) {
-            Log.v(tag, "Client Disconnected, VPN is down - Service might shut down soon")
-            return super.onUnbind(intent)
-        }
-        Log.v(tag, "Client Disconnected, VPN is up")
-        return super.onUnbind(intent)
-    }
-
-    override fun onDestroy() {
-        // Note: This might not get called (depending on how it got invoked)
-        // it for granted all exits will be here.
-        Log.v(tag, "Service got Destroyed")
-        super.onDestroy()
-    }
-
-    /**
-     * EntryPoint for the Service, gets Called when AndroidController.cpp calles bindService.
-     * Returns the [VPNServiceBinder] so QT can send Requests to it.
-     */
-    override fun onBind(intent: Intent?): IBinder? {
-        Log.v(tag, "Got Bind request")
-        init()
-        return mBinder
-    }
-
-    /**
-     * Might be the entryPoint if the Service gets Started via an Service Intent: Might be from
-     * Always-On-Vpn from Settings or from Booting the device and having "connect on boot" enabled.
-     */
-    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-        Log.i(tag, "Service Started by Intent")
-        init()
-        if (isUp) {
-            // In case a user has "always-on" and "start-on-boot" enabled, we might
-            // get this multiple times.
-            return START_NOT_STICKY
-        }
-        intent?.let {
-            if (intent.getBooleanExtra("startOnly", false)) {
-                Log.i(tag, "Start only!")
-                // If this is a Start Only request, the client will soon
-                // bind to the service anyway.
-                // We should return START_NOT_STICKY so that after an unbind()
-                // the OS will not try to restart the service.
-                return START_NOT_STICKY
-            }
-        }
-        // This start is from always-on
-        if (this.mConfig == null) {
-            // We don't have tunnel to turn on - Try to create one with last config the service got
-            val prefs = Prefs.get(this)
-            val lastConfString = prefs.getString("lastConf", "")
-            if (lastConfString.isNullOrEmpty()) {
-                // We have nothing to connect to -> Exit
-                Log.e(tag, "VPN service was triggered without defining a Server or having a tunnel")
-                return super.onStartCommand(intent, flags, startId)
-            }
-            this.mConfig = JSONObject(lastConfString)
-        }
-        try {
-            turnOn(this.mConfig!!)
-        } catch (error: Exception) {
-            Log.e(tag, "Failed to start the VPN for always-on:")
-            Log.e(tag, error.toString())
-            Log.stack(tag, error.stackTrace)
-        }
-
-        return super.onStartCommand(intent, flags, startId)
-    }
-
-    // Invoked when the application is revoked.
-    // At this moment, the VPN interface is already deactivated by the system.
-    override fun onRevoke() {
-        Log.i(tag, "OS Revoked VPN permission")
-        this.turnOff()
-        super.onRevoke()
-    }
-
-    var connectionTime: Long = 0
-        get() {
-            return mConnectionTime
-        }
-
-    /**
-     * Checks if there is a config loaded or some available in the Storage to fetch. if this is
-     * false calling {reconnect()} will abort.
-     * @returns whether a config is found.
-     */
-    var canActivate: Boolean = false
-        get() {
-            if (mConfig != null) {
-                return true
-            }
-            val lastConfString = Prefs.get(this).getString("lastConf", "")
-            return !lastConfString.isNullOrEmpty()
-        }
-    var cityname: String = ""
-        get() {
-            return mCityname
-        }
-
-    var isUp: Boolean = false
-        get() {
-            return currentTunnelHandle >= 0
-        }
-    val status: JSONObject
-        get() {
-            val deviceIpv4: String = ""
-            return JSONObject().apply {
-                putOpt("rx_bytes", getConfigValue("rx_bytes")?.toInt())
-                putOpt("tx_bytes", getConfigValue("tx_bytes")?.toInt())
-                putOpt("endpoint", mConfig?.getJSONObject("server")?.getString("ipv4Gateway"))
-                putOpt("deviceIpv4", mConfig?.getJSONObject("device")?.getString("ipv4Address"))
-            }
-        }
-
-    /*
-     * Checks if the VPN Permission is given.
-     * If the permission is given, returns true
-     * Requests permission and returns false if not.
-     */
-    fun checkPermissions(): Intent? {
-        // See https://developer.android.com/guide/topics/connectivity/vpn#connect_a_service
-        // Call Prepare, if we get an Intent back, we dont have the VPN Permission
-        // from the user. So we need to pass this to our main Activity and exit here.
-        val intent = prepare(this)
-        return intent
-    }
-
-    fun turnOn(json: JSONObject?, useFallbackServer: Boolean = false, source: String? = null) {
-        if (json == null) {
-            throw Error("no json config provided")
-        }
-        Log.sensitive(tag, json.toString())
-        val wireguard_conf = buildWireguardConfig(json, useFallbackServer)
-        val wgConfig: String = wireguard_conf.toWgUserspaceString()
-        if (wgConfig.isEmpty()) {
-            throw Error("WG_Userspace config is empty, can't continue")
-        }
-        mCityname = json.getString("city")
-
-        if (checkPermissions() != null) {
-            throw Error("turn on was called without vpn-permission!")
-        }
-
-        val builder = Builder()
-        setupBuilder(wireguard_conf, builder)
-        builder.setSession("mvpn0")
-        builder.establish().use { tun ->
-            if (tun == null) {
-                Log.e(tag, "Activation Error: did not get a TUN handle")
-                return
-            }
-            // We should have everything to establish a new connection, turn down the old tunnel
-            // now.
-            if (currentTunnelHandle != -1) {
-                Log.i(tag, "Currently have a connection, close old handle")
-                wgTurnOff(currentTunnelHandle)
-            }
-            currentTunnelHandle = wgTurnOn("mvpn0", tun.detachFd(), wgConfig)
-        }
-        if (currentTunnelHandle < 0) {
-            throw Error("Activation Error Wireguard-Error -> $currentTunnelHandle")
-        }
-        protect(wgGetSocketV4(currentTunnelHandle))
-        protect(wgGetSocketV6(currentTunnelHandle))
-        mConfig = json
-        // Store the config in case the service gets
-        // asked boot vpn from the OS
-        val prefs = Prefs.get(this)
-        prefs.edit().putString("lastConf", json.toString()).apply()
-
-        // Go foreground
-        CannedNotification(mConfig)?.let { mNotificationHandler.show(it) }
-
-        if (useFallbackServer) {
-            mConnectionHealth.start(
-                json.getJSONObject("serverFallback").getString("ipv4AddrIn"),
-                json.getJSONObject("serverFallback").getString("ipv4Gateway"),
-                json.getJSONObject("serverFallback").getString("ipv4Gateway"),
-                json.getJSONObject("server").getString("ipv4AddrIn"),
-            )
-        } else {
-            var fallbackIpv4 = ""
-            if (json.has("serverFallback")) {
-                fallbackIpv4 = json.getJSONObject("serverFallback").getString("ipv4AddrIn")
-            }
-            mConnectionHealth.start(
-                json.getJSONObject("server").getString("ipv4AddrIn"),
-                json.getJSONObject("server").getString("ipv4Gateway"),
-                json.getString("dns"),
-                fallbackIpv4,
-            )
-        }
-
-        // For `isGleanDebugTagActive` and `isSuperDooperMetricsActive` to work,
-        // this must be after the mConfig is set to the latest data.
-        val gleanTag = gleanDebugTag
-        if (gleanTag != null) {
-            Log.i(tag, "Setting Glean debug tag for daemon.")
-            Glean.setDebugViewTag(gleanTag)
-        }
-        if (isSuperDooperMetricsActive) {
-            val installationIdString = json.getString("installationId")
-            installationIdString?.let {
-                try {
-                    val installationId = UUID.fromString(installationIdString)
-                    Session.installationId.set(installationId)
-                } catch (e: Exception) {
-                    Log.e(tag, "Daemon installation ID string was not UUID:")
-                    Log.e(tag, e.toString())
-                }
-            }
-            Pings.daemonsession.submit(
-                Pings.daemonsessionReasonCodes.daemonFlush,
-            )
-
-            Session.daemonSessionStart.set()
-            Session.daemonSessionId.generateAndSet()
-            if (source != null) {
-                Session.daemonSessionSource.set(source)
-            }
-            Pings.daemonsession.submit(
-                Pings.daemonsessionReasonCodes.daemonStart,
-            )
-        }
-        mMetricsTimer.start()
-    }
-
-    fun reconnect(forceFallBack: Boolean = false, source: String? = null) {
-        // Save the current timestamp - so that a silent switch won't
-        // reset the timer in the app.
-        val currentConnectionTime = mConnectionTime
-
-        val config =
-            if (this.mConfig != null) {
-                this.mConfig
-            } else {
-                val prefs = Prefs.get(this)
-                val lastConfString = prefs.getString("lastConf", "")
-                if (lastConfString.isNullOrEmpty()) {
-                    // We have nothing to connect to -> Exit
-                    Log.e(
-                        tag,
-                        "VPN service was triggered without defining a Server or having a tunnel",
-                    )
-                    throw Error("no config to use")
-                }
-                JSONObject(lastConfString)
-            }
-
-        Log.v(tag, "Try to reconnect tunnel with same conf")
-        try {
-            this.turnOn(config, forceFallBack, source)
-        } catch (e: Exception) {
-            Log.e(tag, "VPN service - Reconnect failed")
-            // TODO: If we end up here, we might have screwed up the connection.
-            // we should put out a notification that the user go into the app and does a manual
-            // connection.
-        }
-        if (currentConnectionTime != 0.toLong()) {
-            // In case we have had a connection timestamp,
-            // restore that, so that the silent switch is not
-            // putting people off. :)
-            mConnectionTime = currentConnectionTime
-        }
-    }
-    fun clearConfig() {
-        Prefs.get(this).edit().apply() { putString("lastConf", "") }.apply()
-        mConfig = null
-    }
-
-    fun turnOff() {
-        Log.v(tag, "Try to disable tunnel")
-        wgTurnOff(currentTunnelHandle)
-        currentTunnelHandle = -1
-        // If the client is "dead", on a disconnect the
-        // message won't be updated to 'you disconnected from X'
-        // so we should get rid of it. :)
-        val shouldClearNotification = !mBinder.isClientAttached
-        stopForeground(shouldClearNotification)
-        mConnectionHealth.stop()
-        // Clear the notification message, so the content
-        // is not "disconnected" in case we connect from a non-client.
-        CannedNotification(mConfig)?.let { mNotificationHandler.hide(it) }
-        if (isSuperDooperMetricsActive) {
-            Session.daemonSessionEnd.set()
-            Pings.daemonsession.submit(
-                Pings.daemonsessionReasonCodes.daemonEnd,
-            )
-
-            // We are rotating the UUID here as a safety measure. It is rotated
-            // again before the next session start, and we expect to see the
-            // UUID created here in only one ping: The daemon ping with a
-            // "flush" reason, which should contain this UUID and no other
-            // metrics.
-            Session.daemonSessionId.generateAndSet()
-        }
-        mMetricsTimer.cancel()
-    }
-
-    /** Configures an Android VPN Service Tunnel with a given Wireguard Config */
-    private fun setupBuilder(config: Config, builder: Builder) {
-        // Setup Split tunnel
-        for (
-            excludedApplication in
-            config.`interface`.excludedApplications
-            ) builder.addDisallowedApplication(
-                excludedApplication,
-            )
-
-        // Device IP
-        for (addr in config.`interface`.addresses) builder.addAddress(addr.address, addr.mask)
-        // DNS
-        for (addr in config.`interface`.dnsServers) builder.addDnsServer(addr.hostAddress)
-        // Add All routes the VPN may route tos
-        for (peer in config.peers) {
-            for (addr in peer.allowedIps) {
-                builder.addRoute(addr.address, addr.mask)
-            }
-        }
-        builder.allowFamily(OsConstants.AF_INET)
-        builder.allowFamily(OsConstants.AF_INET6)
-        builder.setMtu(config.`interface`.mtu.orElse(1280))
-
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) builder.setMetered(false)
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) setUnderlyingNetworks(null)
-
-        builder.setBlocking(true)
-    }
-
-    /** Gets config value for {key} from the Current running Wireguard tunnel */
-    private fun getConfigValue(key: String): String? {
-        if (!isUp) {
-            return null
-        }
-        val config = wgGetConfig(currentTunnelHandle) ?: return null
-        val lines = config.split("\n")
-        for (line in lines) {
-            val parts = line.split("=")
-            val k = parts.first()
-            val value = parts.last()
-            if (key == k) {
-                return value
-            }
-        }
-        return null
-    }
-
-    /**
-     * Create a Wireguard [Config] from a [json] string - The [json] will be created in
-     * AndroidController.cpp
-     */
-    private fun buildWireguardConfig(obj: JSONObject, useFallbackServer: Boolean = false): Config {
-        val confBuilder = Config.Builder()
-        val jServer: JSONObject =
-            if (useFallbackServer) {
-                obj.getJSONObject("serverFallback")
-            } else {
-                obj.getJSONObject("server")
-            }
-
-        val peerBuilder = Peer.Builder()
-        val ep =
-            InetEndpoint.parse(
-                jServer.getString("ipv4AddrIn") + ":" + jServer.getString("port"),
-            )
-        peerBuilder.setEndpoint(ep)
-        peerBuilder.setPublicKey(Key.fromBase64(jServer.getString("publicKey")))
-
-        val jAllowedIPList = obj.getJSONArray("allowedIPs")
-        if (jAllowedIPList.length() == 0) {
-            val internet = InetNetwork.parse("0.0.0.0/0") // aka The whole internet.
-            peerBuilder.addAllowedIp(internet)
-        } else {
-            (0 until jAllowedIPList.length()).toList().forEach {
-                val network = InetNetwork.parse(jAllowedIPList.getString(it))
-                peerBuilder.addAllowedIp(network)
-            }
-        }
-
-        confBuilder.addPeer(peerBuilder.build())
-
-        val privateKey = obj.getJSONObject("keys").getString("privateKey")
-        val jDevice = obj.getJSONObject("device")
-
-        val ifaceBuilder = Interface.Builder()
-        ifaceBuilder.parsePrivateKey(privateKey)
-        ifaceBuilder.addAddress(InetNetwork.parse(jDevice.getString("ipv4Address")))
-        ifaceBuilder.addAddress(InetNetwork.parse(jDevice.getString("ipv6Address")))
-        ifaceBuilder.addDnsServer(InetNetwork.parse(obj.getString("dns")).address)
-        if (useFallbackServer) {
-            // In case we have to use the fallback, add the default dns as fallback as well.
-            ifaceBuilder.addDnsServer(InetNetwork.parse(jServer.getString("ipv4Gateway")).address)
-        }
-        val jExcludedApplication = obj.getJSONArray("excludedApps")
-        (0 until jExcludedApplication.length()).toList().forEach {
-            val appName = jExcludedApplication.get(it).toString()
-            ifaceBuilder.excludeApplication(appName)
-        }
-        confBuilder.setInterface(ifaceBuilder.build())
-        return confBuilder.build()
-    }
-
-    fun setGleanUploadEnabled(uploadEnabled: Boolean) {
-        Log.i(tag, "Setting glean upload enabled state: $uploadEnabled")
-
-        Prefs.get(this).edit().apply {
-            putBoolean("glean_enabled", uploadEnabled)
-            apply()
-        }
-
-        Glean.setUploadEnabled(uploadEnabled)
-    }
-
-    private fun initializeGlean(uploadEnabled: Boolean) {
-        val customDataPath = File(applicationContext.applicationInfo.dataDir, GLEAN_DATA_DIR).path
-        val channel =
-            if (this.packageName.endsWith(".debug")) {
-                "staging"
-            } else {
-                "production"
-            }
-
-        Glean.registerPings(Pings)
-        Glean.initialize(
-            applicationContext = this.applicationContext,
-            uploadEnabled = uploadEnabled,
-            // GleanBuildInfo can only be generated for application,
-            // We are in a library so we have to build it ourselves.
-            buildInfo =
-            BuildInfo(
-                BuildConfig.VERSIONCODE,
-                BuildConfig.SHORTVERSION,
-                Calendar.getInstance(),
-            ),
-            configuration =
-            Configuration(
-                channel = channel,
-                // When initializing Glean from outside the main process,
-                // we need to provide it with a dataPath manually.
-                dataPath = customDataPath,
-            ),
-        )
-
-        Log.i(tag, "Initialized Glean for daemon. Upload enabled state: $uploadEnabled")
-    }
-
-    companion object {
-        // This value cannot be "glean_data",
-        // because that is the data path for the Glean data on the main application.
-        // See:
-        // https://mozilla.github.io/glean/book/reference/general/initializing.html#configuration
-        internal const val GLEAN_DATA_DIR: String = "glean_daemon_data"
-
-        @JvmStatic
-        fun startService(c: Context) {
-            c.applicationContext.startService(
-                Intent(c.applicationContext, VPNService::class.java).apply {
-                    putExtra("startOnly", true)
-                },
-            )
-        }
-
-        @JvmStatic private external fun wgGetConfig(handle: Int): String?
-
-        @JvmStatic private external fun wgGetSocketV4(handle: Int): Int
-
-        @JvmStatic private external fun wgGetSocketV6(handle: Int): Int
-
-        @JvmStatic private external fun wgTurnOff(handle: Int)
-
-        @JvmStatic private external fun wgTurnOn(ifName: String, tunFd: Int, settings: String): Int
-
-        @JvmStatic private external fun wgVersion(): String?
-
-        @JvmStatic private external fun wgGetLatestHandle(): Int
-    }
-}
+ import android.content.Context
+ import android.content.Intent
+ import android.os.Build
+ import android.os.CountDownTimer
+ import android.os.IBinder
+ import android.system.OsConstants
+ import com.wireguard.android.util.SharedLibraryLoader
+ import com.wireguard.config.Config
+ import com.wireguard.config.InetEndpoint
+ import com.wireguard.config.InetNetwork
+ import com.wireguard.config.Interface
+ import com.wireguard.config.Peer
+ import com.wireguard.crypto.Key
+ import mozilla.telemetry.glean.BuildInfo
+ import mozilla.telemetry.glean.Glean
+ import mozilla.telemetry.glean.config.Configuration
+ import org.json.JSONObject
+ import org.mozilla.firefox.qt.common.Prefs
+ import org.mozilla.firefox.vpn.daemon.GleanMetrics.Pings
+ import org.mozilla.firefox.vpn.daemon.GleanMetrics.Session
+ import java.io.File
+ import java.util.*
+ 
+ class VPNService : android.net.VpnService() {
+     private val tag = "VPNService"
+     private var mBinder: VPNServiceBinder = VPNServiceBinder(this)
+     val mNotificationHandler by lazy { NotificationUtil(this) }
+     private var mConfig: JSONObject? = null
+     private var mConnectionTime: Long = 0
+     private var mAlreadyInitialised = false
+     val mConnectionHealth = ConnectionHealth(this)
+     private var mCityname = ""
+     private var mBackgroundPingTimerMSec: Long = 3 * 60 * 60 * 1000 // 3 hours, in milliseconds
+     private val mMetricsTimer: CountDownTimer = object : CountDownTimer(
+         mBackgroundPingTimerMSec,
+         mBackgroundPingTimerMSec / 4,
+     ) {
+         override fun onTick(millisUntilFinished: Long) {}
+         override fun onFinish() {
+             Log.i(tag, "Sending daemon_timer ping")
+             if (isSuperDooperMetricsActive) {
+                 Pings.daemonsession.submit(
+                     Pings.daemonsessionReasonCodes.daemonTimer,
+                 )
+             }
+             this.start()
+         }
+     }
+ 
+     private val isSuperDooperMetricsActive: Boolean
+         get() {
+             return this.mConfig?.optBoolean("isSuperDooperFeatureActive", false) ?: false
+         }
+ 
+     private val gleanDebugTag: String?
+         get() {
+             val gleanDebugTag = this.mConfig?.optString("gleanDebugTag", "") ?: ""
+             if (!(gleanDebugTag.isEmpty())) {
+                 return gleanDebugTag
+             } else {
+                 return null
+             }
+         }
+ 
+     private var currentTunnelHandle = -1
+         set(value: Int) {
+             field = value
+             if (value > -1) {
+                 mConnectionTime = System.currentTimeMillis()
+                 Log.i(tag, "Dispatch Daemon State -> connected")
+                 mBinder.dispatchEvent(
+                     VPNServiceBinder.EVENTS.connected,
+                     JSONObject()
+                         .apply {
+                             put("time", mConnectionTime)
+                             put("city", mCityname)
+                         }
+                         .toString(),
+                 )
+                 return
+             }
+             Log.i(tag, "Dispatch Daemon State -> disconnected")
+             mBinder.dispatchEvent(VPNServiceBinder.EVENTS.disconnected, "")
+             mConnectionTime = 0
+         }
+ 
+     fun init() {
+         if (mAlreadyInitialised) {
+             Log.i(tag, "VPN Service already initialized, ignoring.")
+             return
+         }
+         Log.init(this)
+         SharedLibraryLoader.loadSharedLibrary(this, "wg-go")
+         Log.i(tag, "Initialised Service with Wireguard Version ${wgVersion()}")
+ 
+         // Check in with wg, if there is a tunnel.
+         // This should be 99% -1, however if the service get's destroyed and the
+         // wireguard tunnel lives on, we can recover from here :)
+         currentTunnelHandle = wgGetLatestHandle()
+         Log.i(tag, "Wireguard reported current tunnel: $currentTunnelHandle")
+         mAlreadyInitialised = true
+ 
+         // It's usually a bad practice to initialize Glean with the wrong
+         // value for uploadEnabled... However, since this is a very controlled
+         // situation -- it should only happen when logging in to a brand new
+         // installation of the app -- we should be fine
+         //
+         // If the `glean_enabled` preference is not set, when a new event listener
+         // is bound to this service, it will request that the main app broadcast
+         // the user provided preference for this. So it should not be long until
+         // the correct value is set here. See VPNServiceBinder > onTransact > ACTIONS.registerEventListener.
+         // Lol it' so broken.
+         initializeGlean(Prefs.get(this).getBoolean("glean_enabled", false))
+     }
+ 
+     override fun onUnbind(intent: Intent?): Boolean {
+         if (!isUp) {
+             Log.v(tag, "Client Disconnected, VPN is down - Service might shut down soon")
+             return super.onUnbind(intent)
+         }
+         Log.v(tag, "Client Disconnected, VPN is up")
+         return super.onUnbind(intent)
+     }
+ 
+     override fun onDestroy() {
+         // Note: This might not get called (depending on how it got invoked)
+         // it for granted all exits will be here.
+         Log.v(tag, "Service got Destroyed")
+         super.onDestroy()
+     }
+ 
+     /**
+      * EntryPoint for the Service, gets Called when AndroidController.cpp calles bindService.
+      * Returns the [VPNServiceBinder] so QT can send Requests to it.
+      */
+     override fun onBind(intent: Intent?): IBinder? {
+         Log.v(tag, "Got Bind request")
+         init()
+         if( mNotificationHandler.needsNotificationPermission() ){
+             mBinder.dispatchEvent(VPNServiceBinder.EVENTS.requestNotificationPermission)
+         }
+         return mBinder
+     }
+ 
+     /**
+      * Might be the entryPoint if the Service gets Started via an Service Intent: Might be from
+      * Always-On-Vpn from Settings or from Booting the device and having "connect on boot" enabled.
+      */
+     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+         Log.i(tag, "Service Started by Intent")
+         init()
+         if (isUp) {
+             // In case a user has "always-on" and "start-on-boot" enabled, we might
+             // get this multiple times.
+             return START_NOT_STICKY
+         }
+         intent?.let {
+             if (intent.getBooleanExtra("startOnly", false)) {
+                 Log.i(tag, "Start only!")
+                 // If this is a Start Only request, the client will soon
+                 // bind to the service anyway.
+                 // We should return START_NOT_STICKY so that after an unbind()
+                 // the OS will not try to restart the service.
+                 return START_NOT_STICKY
+             }
+         }
+         // This start is from always-on
+         if (this.mConfig == null) {
+             // We don't have tunnel to turn on - Try to create one with last config the service got
+             val prefs = Prefs.get(this)
+             val lastConfString = prefs.getString("lastConf", "")
+             if (lastConfString.isNullOrEmpty()) {
+                 // We have nothing to connect to -> Exit
+                 Log.e(tag, "VPN service was triggered without defining a Server or having a tunnel")
+                 return super.onStartCommand(intent, flags, startId)
+             }
+             this.mConfig = JSONObject(lastConfString)
+         }
+         try {
+             turnOn(this.mConfig!!)
+         } catch (error: Exception) {
+             Log.e(tag, "Failed to start the VPN for always-on:")
+             Log.e(tag, error.toString())
+             Log.stack(tag, error.stackTrace)
+         }
+ 
+         return super.onStartCommand(intent, flags, startId)
+     }
+ 
+     // Invoked when the application is revoked.
+     // At this moment, the VPN interface is already deactivated by the system.
+     override fun onRevoke() {
+         Log.i(tag, "OS Revoked VPN permission")
+         this.turnOff()
+         super.onRevoke()
+     }
+ 
+     var connectionTime: Long = 0
+         get() {
+             return mConnectionTime
+         }
+ 
+     /**
+      * Checks if there is a config loaded or some available in the Storage to fetch. if this is
+      * false calling {reconnect()} will abort.
+      * @returns whether a config is found.
+      */
+     var canActivate: Boolean = false
+         get() {
+             if (mConfig != null) {
+                 return true
+             }
+             val lastConfString = Prefs.get(this).getString("lastConf", "")
+             return !lastConfString.isNullOrEmpty()
+         }
+     var cityname: String = ""
+         get() {
+             return mCityname
+         }
+ 
+     var isUp: Boolean = false
+         get() {
+             return currentTunnelHandle >= 0
+         }
+     val status: JSONObject
+         get() {
+             val deviceIpv4: String = ""
+             return JSONObject().apply {
+                 putOpt("rx_bytes", getConfigValue("rx_bytes")?.toInt())
+                 putOpt("tx_bytes", getConfigValue("tx_bytes")?.toInt())
+                 putOpt("endpoint", mConfig?.getJSONObject("server")?.getString("ipv4Gateway"))
+                 putOpt("deviceIpv4", mConfig?.getJSONObject("device")?.getString("ipv4Address"))
+             }
+         }
+ 
+     /*
+      * Checks if the VPN Permission is given.
+      * If the permission is given, returns true
+      * Requests permission and returns false if not.
+      */
+     fun checkPermissions(): Intent? {
+         // See https://developer.android.com/guide/topics/connectivity/vpn#connect_a_service
+         // Call Prepare, if we get an Intent back, we dont have the VPN Permission
+         // from the user. So we need to pass this to our main Activity and exit here.
+         val intent = prepare(this)
+         return intent
+     }
+ 
+     fun turnOn(json: JSONObject?, useFallbackServer: Boolean = false, source: String? = null) {
+         if (json == null) {
+             throw Error("no json config provided")
+         }
+         Log.sensitive(tag, json.toString())
+         val wireguard_conf = buildWireguardConfig(json, useFallbackServer)
+         val wgConfig: String = wireguard_conf.toWgUserspaceString()
+         if (wgConfig.isEmpty()) {
+             throw Error("WG_Userspace config is empty, can't continue")
+         }
+         mCityname = json.getString("city")
+ 
+         if (checkPermissions() != null) {
+             throw Error("turn on was called without vpn-permission!")
+         }
+ 
+         val builder = Builder()
+         setupBuilder(wireguard_conf, builder)
+         builder.setSession("mvpn0")
+         builder.establish().use { tun ->
+             if (tun == null) {
+                 Log.e(tag, "Activation Error: did not get a TUN handle")
+                 return
+             }
+             // We should have everything to establish a new connection, turn down the old tunnel
+             // now.
+             if (currentTunnelHandle != -1) {
+                 Log.i(tag, "Currently have a connection, close old handle")
+                 wgTurnOff(currentTunnelHandle)
+             }
+             currentTunnelHandle = wgTurnOn("mvpn0", tun.detachFd(), wgConfig)
+         }
+         if (currentTunnelHandle < 0) {
+             throw Error("Activation Error Wireguard-Error -> $currentTunnelHandle")
+         }
+         protect(wgGetSocketV4(currentTunnelHandle))
+         protect(wgGetSocketV6(currentTunnelHandle))
+         mConfig = json
+         // Store the config in case the service gets
+         // asked boot vpn from the OS
+         val prefs = Prefs.get(this)
+         prefs.edit().putString("lastConf", json.toString()).apply()
+ 
+         // Go foreground
+         CannedNotification(mConfig)?.let { mNotificationHandler.show(it) }
+ 
+         if (useFallbackServer) {
+             mConnectionHealth.start(
+                 json.getJSONObject("serverFallback").getString("ipv4AddrIn"),
+                 json.getJSONObject("serverFallback").getString("ipv4Gateway"),
+                 json.getJSONObject("serverFallback").getString("ipv4Gateway"),
+                 json.getJSONObject("server").getString("ipv4AddrIn"),
+             )
+         } else {
+             var fallbackIpv4 = ""
+             if (json.has("serverFallback")) {
+                 fallbackIpv4 = json.getJSONObject("serverFallback").getString("ipv4AddrIn")
+             }
+             mConnectionHealth.start(
+                 json.getJSONObject("server").getString("ipv4AddrIn"),
+                 json.getJSONObject("server").getString("ipv4Gateway"),
+                 json.getString("dns"),
+                 fallbackIpv4,
+             )
+         }
+ 
+         // For `isGleanDebugTagActive` and `isSuperDooperMetricsActive` to work,
+         // this must be after the mConfig is set to the latest data.
+         val gleanTag = gleanDebugTag
+         if (gleanTag != null) {
+             Log.i(tag, "Setting Glean debug tag for daemon.")
+             Glean.setDebugViewTag(gleanTag)
+         }
+         if (isSuperDooperMetricsActive) {
+             val installationIdString = json.getString("installationId")
+             installationIdString?.let {
+                 try {
+                     val installationId = UUID.fromString(installationIdString)
+                     Session.installationId.set(installationId)
+                 } catch (e: Exception) {
+                     Log.e(tag, "Daemon installation ID string was not UUID:")
+                     Log.e(tag, e.toString())
+                 }
+             }
+             Pings.daemonsession.submit(
+                 Pings.daemonsessionReasonCodes.daemonFlush
+             )
+ 
+             Session.daemonSessionStart.set()
+             Session.daemonSessionId.generateAndSet()
+             if (source != null) {
+                 Session.daemonSessionSource.set(source)
+             }
+             Pings.daemonsession.submit(
+                 Pings.daemonsessionReasonCodes.daemonStart,
+             )
+         }
+         mMetricsTimer.start()
+     }
+ 
+     fun reconnect(forceFallBack: Boolean = false, source: String? = null) {
+         // Save the current timestamp - so that a silent switch won't
+         // reset the timer in the app.
+         val currentConnectionTime = mConnectionTime
+ 
+         val config =
+             if (this.mConfig != null) {
+                 this.mConfig
+             } else {
+                 val prefs = Prefs.get(this)
+                 val lastConfString = prefs.getString("lastConf", "")
+                 if (lastConfString.isNullOrEmpty()) {
+                     // We have nothing to connect to -> Exit
+                     Log.e(
+                         tag,
+                         "VPN service was triggered without defining a Server or having a tunnel",
+                     )
+                     throw Error("no config to use")
+                 }
+                 JSONObject(lastConfString)
+             }
+ 
+         Log.v(tag, "Try to reconnect tunnel with same conf")
+         try {
+             this.turnOn(config, forceFallBack, source)
+         } catch (e: Exception) {
+             Log.e(tag, "VPN service - Reconnect failed")
+             // TODO: If we end up here, we might have screwed up the connection.
+             // we should put out a notification that the user go into the app and does a manual
+             // connection.
+         }
+         if (currentConnectionTime != 0.toLong()) {
+             // In case we have had a connection timestamp,
+             // restore that, so that the silent switch is not
+             // putting people off. :)
+             mConnectionTime = currentConnectionTime
+         }
+     }
+     fun clearConfig() {
+         Prefs.get(this).edit().apply() { putString("lastConf", "") }.apply()
+         mConfig = null
+     }
+ 
+     fun turnOff() {
+         Log.v(tag, "Try to disable tunnel")
+         wgTurnOff(currentTunnelHandle)
+         currentTunnelHandle = -1
+         // If the client is "dead", on a disconnect the
+         // message won't be updated to 'you disconnected from X'
+         // so we should get rid of it. :)
+         val shouldClearNotification = !mBinder.isClientAttached
+         stopForeground(shouldClearNotification)
+         mConnectionHealth.stop()
+         // Clear the notification message, so the content
+         // is not "disconnected" in case we connect from a non-client.
+         CannedNotification(mConfig)?.let { mNotificationHandler.hide(it) }
+         if (isSuperDooperMetricsActive) {
+             Session.daemonSessionEnd.set()
+             Pings.daemonsession.submit(
+                 Pings.daemonsessionReasonCodes.daemonEnd
+             )
+ 
+             // We are rotating the UUID here as a safety measure. It is rotated
+             // again before the next session start, and we expect to see the
+             // UUID created here in only one ping: The daemon ping with a
+             // "flush" reason, which should contain this UUID and no other
+             // metrics.
+             Session.daemonSessionId.generateAndSet()
+         }
+         mMetricsTimer.cancel()
+     }
+ 
+     /** Configures an Android VPN Service Tunnel with a given Wireguard Config */
+     private fun setupBuilder(config: Config, builder: Builder) {
+         // Setup Split tunnel
+         for (
+             excludedApplication in
+             config.`interface`.excludedApplications
+             ) builder.addDisallowedApplication(
+                 excludedApplication,
+             )
+ 
+         // Device IP
+         for (addr in config.`interface`.addresses) builder.addAddress(addr.address, addr.mask)
+         // DNS
+         for (addr in config.`interface`.dnsServers) builder.addDnsServer(addr.hostAddress)
+         // Add All routes the VPN may route tos
+         for (peer in config.peers) {
+             for (addr in peer.allowedIps) {
+                 builder.addRoute(addr.address, addr.mask)
+             }
+         }
+         builder.allowFamily(OsConstants.AF_INET)
+         builder.allowFamily(OsConstants.AF_INET6)
+         builder.setMtu(config.`interface`.mtu.orElse(1280))
+ 
+         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) builder.setMetered(false)
+         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) setUnderlyingNetworks(null)
+ 
+         builder.setBlocking(true)
+     }
+ 
+     /** Gets config value for {key} from the Current running Wireguard tunnel */
+     private fun getConfigValue(key: String): String? {
+         if (!isUp) {
+             return null
+         }
+         val config = wgGetConfig(currentTunnelHandle) ?: return null
+         val lines = config.split("\n")
+         for (line in lines) {
+             val parts = line.split("=")
+             val k = parts.first()
+             val value = parts.last()
+             if (key == k) {
+                 return value
+             }
+         }
+         return null
+     }
+ 
+     /**
+      * Create a Wireguard [Config] from a [json] string - The [json] will be created in
+      * AndroidController.cpp
+      */
+     private fun buildWireguardConfig(obj: JSONObject, useFallbackServer: Boolean = false): Config {
+         val confBuilder = Config.Builder()
+         val jServer: JSONObject =
+             if (useFallbackServer) {
+                 obj.getJSONObject("serverFallback")
+             } else {
+                 obj.getJSONObject("server")
+             }
+ 
+         val peerBuilder = Peer.Builder()
+         val ep =
+             InetEndpoint.parse(
+                 jServer.getString("ipv4AddrIn") + ":" + jServer.getString("port"),
+             )
+         peerBuilder.setEndpoint(ep)
+         peerBuilder.setPublicKey(Key.fromBase64(jServer.getString("publicKey")))
+ 
+         val jAllowedIPList = obj.getJSONArray("allowedIPs")
+         if (jAllowedIPList.length() == 0) {
+             val internet = InetNetwork.parse("0.0.0.0/0") // aka The whole internet.
+             peerBuilder.addAllowedIp(internet)
+         } else {
+             (0 until jAllowedIPList.length()).toList().forEach {
+                 val network = InetNetwork.parse(jAllowedIPList.getString(it))
+                 peerBuilder.addAllowedIp(network)
+             }
+         }
+ 
+         confBuilder.addPeer(peerBuilder.build())
+ 
+         val privateKey = obj.getJSONObject("keys").getString("privateKey")
+         val jDevice = obj.getJSONObject("device")
+ 
+         val ifaceBuilder = Interface.Builder()
+         ifaceBuilder.parsePrivateKey(privateKey)
+         ifaceBuilder.addAddress(InetNetwork.parse(jDevice.getString("ipv4Address")))
+         ifaceBuilder.addAddress(InetNetwork.parse(jDevice.getString("ipv6Address")))
+         ifaceBuilder.addDnsServer(InetNetwork.parse(obj.getString("dns")).address)
+         if (useFallbackServer) {
+             // In case we have to use the fallback, add the default dns as fallback as well.
+             ifaceBuilder.addDnsServer(InetNetwork.parse(jServer.getString("ipv4Gateway")).address)
+         }
+         val jExcludedApplication = obj.getJSONArray("excludedApps")
+         (0 until jExcludedApplication.length()).toList().forEach {
+             val appName = jExcludedApplication.get(it).toString()
+             ifaceBuilder.excludeApplication(appName)
+         }
+         confBuilder.setInterface(ifaceBuilder.build())
+         return confBuilder.build()
+     }
+ 
+     fun setGleanUploadEnabled(uploadEnabled: Boolean) {
+         Log.i(tag, "Setting glean upload enabled state: $uploadEnabled")
+ 
+         Prefs.get(this).edit().apply {
+             putBoolean("glean_enabled", uploadEnabled)
+             apply()
+         }
+ 
+         Glean.setUploadEnabled(uploadEnabled)
+     }
+ 
+     private fun initializeGlean(uploadEnabled: Boolean) {
+         val customDataPath = File(applicationContext.applicationInfo.dataDir, GLEAN_DATA_DIR).path
+         val channel =
+             if (this.packageName.endsWith(".debug")) {
+                 "staging"
+             } else {
+                 "production"
+             }
+ 
+         Glean.registerPings(Pings)
+         Glean.initialize(
+             applicationContext = this.applicationContext,
+             uploadEnabled = uploadEnabled,
+             // GleanBuildInfo can only be generated for application,
+             // We are in a library so we have to build it ourselves.
+             buildInfo =
+             BuildInfo(
+                 BuildConfig.VERSIONCODE,
+                 BuildConfig.SHORTVERSION,
+                 Calendar.getInstance(),
+             ),
+             configuration =
+             Configuration(
+                 channel = channel,
+                 // When initializing Glean from outside the main process,
+                 // we need to provide it with a dataPath manually.
+                 dataPath = customDataPath,
+             ),
+         )
+ 
+         Log.i(tag, "Initialized Glean for daemon. Upload enabled state: $uploadEnabled")
+     }
+ 
+     companion object {
+         // This value cannot be "glean_data",
+         // because that is the data path for the Glean data on the main application.
+         // See:
+         // https://mozilla.github.io/glean/book/reference/general/initializing.html#configuration
+         internal const val GLEAN_DATA_DIR: String = "glean_daemon_data"
+ 
+         @JvmStatic
+         fun startService(c: Context) {
+             c.applicationContext.startService(
+                 Intent(c.applicationContext, VPNService::class.java).apply {
+                     putExtra("startOnly", true)
+                 },
+             )
+         }
+ 
+         @JvmStatic private external fun wgGetConfig(handle: Int): String?
+ 
+         @JvmStatic private external fun wgGetSocketV4(handle: Int): Int
+ 
+         @JvmStatic private external fun wgGetSocketV6(handle: Int): Int
+ 
+         @JvmStatic private external fun wgTurnOff(handle: Int)
+ 
+         @JvmStatic private external fun wgTurnOn(ifName: String, tunFd: Int, settings: String): Int
+ 
+         @JvmStatic private external fun wgVersion(): String?
+ 
+         @JvmStatic private external fun wgGetLatestHandle(): Int
+     }
+ }
+ 

--- a/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/VPNServiceBinder.kt
+++ b/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/VPNServiceBinder.kt
@@ -2,264 +2,234 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
- package org.mozilla.firefox.vpn.daemon
+package org.mozilla.firefox.vpn.daemon
 
- import android.content.Intent
- import android.os.Binder
- import android.os.DeadObjectException
- import android.os.IBinder
- import android.os.Parcel
- import kotlinx.serialization.decodeFromString
- import kotlinx.serialization.json.Json
- import org.json.JSONObject
- import org.mozilla.firefox.qt.common.Prefs
- import kotlin.Exception
- 
- class VPNServiceBinder(service: VPNService) : Binder() {
- 
-     private val mService = service
-     private val tag = "VPNServiceBinder"
- 
-     private val mListeners = ArrayList<IBinder>()
-     private var mResumeConfig: JSONObject? = null
- 
-     /** The codes this Binder does accept in [onTransact] */
-     object ACTIONS {
-         const val activate = 1
-         const val deactivate = 2
-         const val registerEventListener = 3
-         const val requestStatistic = 4
-         const val requestCleanupLog = 6
-         const val resumeActivate = 7
-         const val setNotificationText = 8
-         const val recordEvent = 10
-         const val getStatus = 13
-         const val setStartOnBoot = 15
-         const val reactivate = 16
-         const val clearStorage = 17
-         const val setGleanUploadEnabled = 18
-         const val notificationPermissionFired = 19
-     }
- 
-     /**
-      * Gets called when the VPNServiceBinder gets a request from a Client. The [code] determines
-      * what action is requested. - see [ACTIONS] [data] may contain a utf-8 encoded json string with
-      * optional args or is null. [reply] is a pointer to a buffer in the clients memory, to reply
-      * results. we use this to send result data.
-      *
-      * returns true if the [code] was accepted
-      */
-     override fun onTransact(code: Int, data: Parcel, reply: Parcel?, flags: Int): Boolean {
-         when (code) {
-             ACTIONS.activate -> {
-                 try {
-                     Log.i(tag, "Activation Requested")
-                     // [data] is here a json containing the wireguard conf
-                     val buffer = data.createByteArray()
-                     val json = buffer?.let { String(it) }
-                     val config = json?.let { JSONObject(it) }
-                     if (config == null) {
-                         Log.e(tag, "Client provided config was not parsable")
-                         return true
-                     }
-                     val permissionIntent: Intent? = mService.checkPermissions()
-                     if (permissionIntent != null) {
-                         mResumeConfig = config
-                         val permissionParcel = Parcel.obtain()
-                         permissionIntent.writeToParcel(permissionParcel, 0)
-                         dispatchEvent(EVENTS.permissionRequired, permissionParcel)
-                         // The Permission prompt was already
-                         // send, in case it's accepted we will
-                         // receive ACTIONS.resumeActivate
-                         return true
-                     }
-                     this.mService.turnOn(json = config, source = "app")
-                 } catch (e: Exception) {
-                     Log.e(tag, "An Error occurred while enabling the VPN: ${e.localizedMessage}")
-                     Log.stack(tag, e.stackTrace)
-                     dispatchEvent(EVENTS.activationError, e.localizedMessage)
-                 }
-                 return true
-             }
-             ACTIONS.resumeActivate -> {
-                 // [data] is empty
-                 // Activate the current tunnel
-                 try {
-                     Log.i(tag, "Resume Activation requested")
-                     mResumeConfig?.let { this.mService.turnOn(it) }
-                 } catch (e: Exception) {
-                     Log.e(tag, "An Error occurred while enabling the VPN: ${e.localizedMessage}")
-                     dispatchEvent(EVENTS.activationError, e.localizedMessage)
-                 }
-                 return true
-             }
-             ACTIONS.reactivate -> {
-                 // [data] is empty
-                 // Activate the tunnel with the last config
-                 try {
-                     this.mService.reconnect(source = "system")
-                 } catch (e: Exception) {
-                     Log.e(tag, "An Error occurred while enabling the VPN: ${e.localizedMessage}")
-                     dispatchEvent(EVENTS.activationError, e.localizedMessage)
-                 }
-                 return true
-             }
-             ACTIONS.deactivate -> {
-                 Log.i(tag, "Deactivation requested")
-                 // [data] here is empty
-                 this.mService.turnOff()
-                 return true
-             }
-             ACTIONS.registerEventListener -> {
-                 Log.i(tag, "requested to add an Event Listener")
-                 // [data] contains the Binder that we need to dispatch the Events
-                 val binder = data.readStrongBinder()
-                 mListeners.add(binder)
-                 Log.i(tag, "Registered binder now: ${mListeners.size} Binders")
- 
-                 if (!Prefs.get(mService).contains("glean_enabled")) {
-                     Log.i(tag, "Requesting Glean upload enabled state. No value in storage.")
-                     dispatchEvent(
-                         VPNServiceBinder.EVENTS.requestGleanUploadEnabledState,
-                         "",
-                         binder,
-                     )
-                 }
- 
-                 return true
-             }
-             ACTIONS.getStatus -> {
-                 val obj = JSONObject()
-                 obj.put("connected", mService.isUp)
-                 obj.put("time", mService.connectionTime)
-                 obj.put("city", mService.cityname)
-                 obj.put("canActivate", mService.canActivate)
-                 obj.put("connection-health-status", mService.mConnectionHealth.getStatusString())
-                 dispatchEvent(EVENTS.init, obj.toString())
-                 return true
-             }
-             ACTIONS.requestStatistic -> {
-                 dispatchEvent(EVENTS.statisticUpdate, mService.status.toString())
-                 return true
-             }
-             ACTIONS.requestCleanupLog -> {
-                 Log.clearFile()
-                 return true
-             }
-             ACTIONS.setNotificationText -> {
-                 val buffer = data.createByteArray()
-                 val json = buffer?.let { String(it) }
-                 if (json.isNullOrEmpty()) {
-                     return false
-                 }
-                 try {
-                     val message = Json.decodeFromString<ClientNotification>(json)
-                     mService.mNotificationHandler.setNotificationText(message)
-                 } catch (e: Exception) {
-                     e.message?.let { Log.e(tag, it) }
-                 }
-                 return true
-             }
-             ACTIONS.setStartOnBoot -> {
-                 val buffer = data.createByteArray()
-                 val json = buffer?.let { String(it) }
-                 val args = JSONObject(json)
-                 val value = args.getBoolean("startOnBoot")
-                 Prefs.get(mService)
-                     .edit()
-                     .apply() { putBoolean(BootReceiver.START_ON_BOOT, value) }
-                     .apply()
-             }
-             ACTIONS.clearStorage -> {
-                 mService.clearConfig()
-             }
-             ACTIONS.setGleanUploadEnabled -> {
-                 val buffer = data.createByteArray()
-                 val json = buffer?.let { String(it) }
-                 val args = JSONObject(json)
-                 mService.setGleanUploadEnabled(args.getBoolean("uploadEnabled"))
-                 return true
-             }
-             ACTIONS.notificationPermissionFired ->{
-                 mService.mNotificationHandler.onNotificationPermissionPromptFired();
-                 return true;
-             }
-             IBinder.LAST_CALL_TRANSACTION -> {
-                 Log.e(tag, "The OS Requested to shut down the VPN")
-                 this.mService.turnOff()
-                 return true
-             }
-             else -> {
-                 Log.e(tag, "Received invalid bind request \t Code -> $code")
-                 // If we're hitting this there is probably something wrong in the client.
-                 return false
-             }
-         }
-         return false
-     }
- 
-     /**
-      * Dispatches an Event to all registered Binders [code] the Event that happened - see [EVENTS]
-      * To register an Eventhandler use [onTransact] with [ACTIONS.registerEventListener] When
-      * [targetBinder] is Provided, it will only dispatch the event to it.
-      */
-     fun dispatchEvent(code: Int, payload: String = "", targetBinder: IBinder? = null) {
-         val data = Parcel.obtain()
-         data.writeByteArray(payload?.toByteArray(charset("UTF-8")))
-         dispatchEvent(code, data, targetBinder)
-     }
-     fun dispatchEvent(code: Int, data: Parcel, targetBinder: IBinder? = null) {
-         Log.e("VPNServiceBinder", "Sending ${code}")
-         targetBinder?.let {
-             try {
-                 it.transact(code, data, Parcel.obtain(), 0)
-             } catch (e: DeadObjectException) {
-                 Log.e(tag, "Attempted to dispatch event '$code' to dead binder. Removing.")
-                 // The binder is not alive, so we can remove it
-                 // from the listeners list, if present.
-                 mListeners.remove(it)
-             }
-             return
-         }
-         val deadBinders = ArrayList<IBinder>()
-         mListeners.forEach {
-             if (it.isBinderAlive) {
-                 try {
-                     it.transact(code, data, Parcel.obtain(), 0)
-                 } catch (e: DeadObjectException) {
-                     // If the QT Process is killed (not just inactive)
-                     // we cant access isBinderAlive, so nothing to do here.
-                     deadBinders.add(it)
-                 }
-             } else {
-                 deadBinders.add(it)
-             }
-         }
-         if (deadBinders.size > 0) {
-             mListeners.removeAll(deadBinders)
-             Log.i(tag, "Removed ${deadBinders.size} dead Binders")
-         }
-     }
- 
-     val isClientAttached: Boolean
-         get() {
-             return try {
-                 mListeners.any { it.isBinderAlive }
-             } catch (e: DeadObjectException) {
-                 false
-             }
-         }
- 
-     /** The codes we Are Using in case of [dispatchEvent] */
-     object EVENTS {
-         const val init = 0
-         const val connected = 1
-         const val disconnected = 2
-         const val statisticUpdate = 3
-         const val activationError = 5
-         const val permissionRequired = 6
-         const val requestGleanUploadEnabledState = 7
-         const val requestNotificationPermission = 8
-     }
- }
- 
+import android.content.Intent
+import android.os.DeadObjectException
+import android.os.IBinder
+import android.os.Parcel
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
+import org.json.JSONObject
+import org.mozilla.firefox.qt.common.CoreBinder
+import org.mozilla.firefox.qt.common.Prefs
+import java.util.*
+import kotlin.Exception
+
+class VPNServiceBinder(service: VPNService) : CoreBinder() {
+
+    private val mService = service
+    private val tag = "VPNServiceBinder"
+
+    private val mListeners = ArrayList<IBinder>()
+    private var mResumeConfig: JSONObject? = null
+
+    /**
+     * Gets called when the VPNServiceBinder gets a request from a Client. The [code] determines
+     * what action is requested. - see [ACTIONS] [data] may contain a utf-8 encoded json string with
+     * optional args or is null. [reply] is a pointer to a buffer in the clients memory, to reply
+     * results. we use this to send result data.
+     *
+     * returns true if the [code] was accepted
+     */
+    override fun onTransact(code: Int, data: Parcel, reply: Parcel?, flags: Int): Boolean {
+        when (code) {
+            ACTIONS.activate -> {
+                try {
+                    Log.i(tag, "Activation Requested")
+                    // [data] is here a json containing the wireguard conf
+                    val buffer = data.createByteArray()
+                    val json = buffer?.let { String(it) }
+                    val config = json?.let { JSONObject(it) }
+                    if (config == null) {
+                        Log.e(tag, "Client provided config was not parsable")
+                        return true
+                    }
+                    val permissionIntent: Intent? = mService.checkPermissions()
+                    if (permissionIntent != null) {
+                        mResumeConfig = config
+                        val permissionParcel = Parcel.obtain()
+                        permissionIntent.writeToParcel(permissionParcel, 0)
+                        dispatchEvent(EVENTS.permissionRequired, permissionParcel)
+                        // The Permission prompt was already
+                        // send, in case it's accepted we will
+                        // receive ACTIONS.resumeActivate
+                        return true
+                    }
+                    this.mService.turnOn(json = config, source = "app")
+                } catch (e: Exception) {
+                    Log.e(tag, "An Error occurred while enabling the VPN: ${e.localizedMessage}")
+                    Log.stack(tag, e.stackTrace)
+                    dispatchEvent(EVENTS.activationError, e.localizedMessage)
+                }
+                return true
+            }
+            ACTIONS.resumeActivate -> {
+                // [data] is empty
+                // Activate the current tunnel
+                try {
+                    Log.i(tag, "Resume Activation requested")
+                    mResumeConfig?.let { this.mService.turnOn(it) }
+                } catch (e: Exception) {
+                    Log.e(tag, "An Error occurred while enabling the VPN: ${e.localizedMessage}")
+                    dispatchEvent(EVENTS.activationError, e.localizedMessage)
+                }
+                return true
+            }
+            ACTIONS.reactivate -> {
+                // [data] is empty
+                // Activate the tunnel with the last config
+                try {
+                    this.mService.reconnect(source = "system")
+                } catch (e: Exception) {
+                    Log.e(tag, "An Error occurred while enabling the VPN: ${e.localizedMessage}")
+                    dispatchEvent(EVENTS.activationError, e.localizedMessage)
+                }
+                return true
+            }
+            ACTIONS.deactivate -> {
+                Log.i(tag, "Deactivation requested")
+                // [data] here is empty
+                this.mService.turnOff()
+                return true
+            }
+            ACTIONS.registerEventListener -> {
+                Log.i(tag, "requested to add an Event Listener")
+                // [data] contains the Binder that we need to dispatch the Events
+                val binder = data.readStrongBinder()
+                mListeners.add(binder)
+                Log.i(tag, "Registered binder now: ${mListeners.size} Binders")
+
+                if (!Prefs.get(mService).contains("glean_enabled")) {
+                    Log.i(tag, "Requesting Glean upload enabled state. No value in storage.")
+                    dispatchEvent(
+                        EVENTS.requestGleanUploadEnabledState,
+                        "",
+                        binder,
+                    )
+                }
+
+                return true
+            }
+            ACTIONS.getStatus -> {
+                val obj = JSONObject()
+                obj.put("connected", mService.isUp)
+                obj.put("time", mService.connectionTime)
+                obj.put("city", mService.cityname)
+                obj.put("canActivate", mService.canActivate)
+                obj.put("connection-health-status", mService.mConnectionHealth.getStatusString())
+                dispatchEvent(EVENTS.init, obj.toString())
+                return true
+            }
+            ACTIONS.requestStatistic -> {
+                dispatchEvent(EVENTS.statisticUpdate, mService.status.toString())
+                return true
+            }
+            ACTIONS.requestCleanupLog -> {
+                Log.clearFile()
+                return true
+            }
+            ACTIONS.setNotificationText -> {
+                val buffer = data.createByteArray()
+                val json = buffer?.let { String(it) }
+                if (json.isNullOrEmpty()) {
+                    return false
+                }
+                try {
+                    val message = Json.decodeFromString<ClientNotification>(json)
+                    mService.mNotificationHandler.setNotificationText(message)
+                } catch (e: Exception) {
+                    e.message?.let { Log.e(tag, it) }
+                }
+                return true
+            }
+            ACTIONS.setStartOnBoot -> {
+                val buffer = data.createByteArray()
+                val json = buffer?.let { String(it) }
+                val args = JSONObject(json)
+                val value = args.getBoolean("startOnBoot")
+                Prefs.get(mService)
+                    .edit()
+                    .apply() { putBoolean(BootReceiver.START_ON_BOOT, value) }
+                    .apply()
+            }
+            ACTIONS.clearStorage -> {
+                mService.clearConfig()
+            }
+            ACTIONS.setGleanUploadEnabled -> {
+                val buffer = data.createByteArray()
+                val json = buffer?.let { String(it) }
+                val args = JSONObject(json)
+                mService.setGleanUploadEnabled(args.getBoolean("uploadEnabled"))
+                return true
+            }
+            ACTIONS.notificationPermissionFired -> {
+                mService.mNotificationHandler.onNotificationPermissionPromptFired()
+                return true
+            }
+            IBinder.LAST_CALL_TRANSACTION -> {
+                Log.e(tag, "The OS Requested to shut down the VPN")
+                this.mService.turnOff()
+                return true
+            }
+            else -> {
+                Log.e(tag, "Received invalid bind request \t Code -> $code")
+                // If we're hitting this there is probably something wrong in the client.
+                return false
+            }
+        }
+        return false
+    }
+
+    /**
+     * Dispatches an Event to all registered Binders [code] the Event that happened - see [EVENTS]
+     * To register an Eventhandler use [onTransact] with [ACTIONS.registerEventListener] When
+     * [targetBinder] is Provided, it will only dispatch the event to it.
+     */
+    fun dispatchEvent(code: Int, payload: String = "", targetBinder: IBinder? = null) {
+        val data = Parcel.obtain()
+        data.writeByteArray(payload?.toByteArray(charset("UTF-8")))
+        dispatchEvent(code, data, targetBinder)
+    }
+    fun dispatchEvent(code: Int, data: Parcel, targetBinder: IBinder? = null) {
+        Log.e("VPNServiceBinder", "Sending $code")
+        targetBinder?.let {
+            try {
+                it.transact(code, data, Parcel.obtain(), 0)
+            } catch (e: DeadObjectException) {
+                Log.e(tag, "Attempted to dispatch event '$code' to dead binder. Removing.")
+                // The binder is not alive, so we can remove it
+                // from the listeners list, if present.
+                mListeners.remove(it)
+            }
+            return
+        }
+        val deadBinders = ArrayList<IBinder>()
+        mListeners.forEach {
+            if (it.isBinderAlive) {
+                try {
+                    it.transact(code, data, Parcel.obtain(), 0)
+                } catch (e: DeadObjectException) {
+                    // If the QT Process is killed (not just inactive)
+                    // we cant access isBinderAlive, so nothing to do here.
+                    deadBinders.add(it)
+                }
+            } else {
+                deadBinders.add(it)
+            }
+        }
+        if (deadBinders.size > 0) {
+            mListeners.removeAll(deadBinders)
+            Log.i(tag, "Removed ${deadBinders.size} dead Binders")
+        }
+    }
+
+    val isClientAttached: Boolean
+        get() {
+            return try {
+                mListeners.any { it.isBinderAlive }
+            } catch (e: DeadObjectException) {
+                false
+            }
+        }
+}

--- a/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/VPNServiceBinder.kt
+++ b/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/VPNServiceBinder.kt
@@ -2,256 +2,264 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package org.mozilla.firefox.vpn.daemon
+ package org.mozilla.firefox.vpn.daemon
 
-import android.content.Intent
-import android.os.Binder
-import android.os.DeadObjectException
-import android.os.IBinder
-import android.os.Parcel
-import kotlinx.serialization.decodeFromString
-import kotlinx.serialization.json.Json
-import org.json.JSONObject
-import org.mozilla.firefox.qt.common.Prefs
-import kotlin.Exception
-
-class VPNServiceBinder(service: VPNService) : Binder() {
-
-    private val mService = service
-    private val tag = "VPNServiceBinder"
-
-    private val mListeners = ArrayList<IBinder>()
-    private var mResumeConfig: JSONObject? = null
-
-    /** The codes this Binder does accept in [onTransact] */
-    object ACTIONS {
-        const val activate = 1
-        const val deactivate = 2
-        const val registerEventListener = 3
-        const val requestStatistic = 4
-        const val requestCleanupLog = 6
-        const val resumeActivate = 7
-        const val setNotificationText = 8
-        const val recordEvent = 10
-        const val getStatus = 13
-        const val setStartOnBoot = 15
-        const val reactivate = 16
-        const val clearStorage = 17
-        const val setGleanUploadEnabled = 18
-    }
-
-    /**
-     * Gets called when the VPNServiceBinder gets a request from a Client. The [code] determines
-     * what action is requested. - see [ACTIONS] [data] may contain a utf-8 encoded json string with
-     * optional args or is null. [reply] is a pointer to a buffer in the clients memory, to reply
-     * results. we use this to send result data.
-     *
-     * returns true if the [code] was accepted
-     */
-    override fun onTransact(code: Int, data: Parcel, reply: Parcel?, flags: Int): Boolean {
-        when (code) {
-            ACTIONS.activate -> {
-                try {
-                    Log.i(tag, "Activation Requested")
-                    // [data] is here a json containing the wireguard conf
-                    val buffer = data.createByteArray()
-                    val json = buffer?.let { String(it) }
-                    val config = json?.let { JSONObject(it) }
-                    if (config == null) {
-                        Log.e(tag, "Client provided config was not parsable")
-                        return true
-                    }
-                    val permissionIntent: Intent? = mService.checkPermissions()
-                    if (permissionIntent != null) {
-                        mResumeConfig = config
-                        val permissionParcel = Parcel.obtain()
-                        permissionIntent.writeToParcel(permissionParcel, 0)
-                        dispatchEvent(EVENTS.permissionRequired, permissionParcel)
-                        // The Permission prompt was already
-                        // send, in case it's accepted we will
-                        // receive ACTIONS.resumeActivate
-                        return true
-                    }
-                    this.mService.turnOn(json = config, source = "app")
-                } catch (e: Exception) {
-                    Log.e(tag, "An Error occurred while enabling the VPN: ${e.localizedMessage}")
-                    Log.stack(tag, e.stackTrace)
-                    dispatchEvent(EVENTS.activationError, e.localizedMessage)
-                }
-                return true
-            }
-            ACTIONS.resumeActivate -> {
-                // [data] is empty
-                // Activate the current tunnel
-                try {
-                    Log.i(tag, "Resume Activation requested")
-                    mResumeConfig?.let { this.mService.turnOn(it) }
-                } catch (e: Exception) {
-                    Log.e(tag, "An Error occurred while enabling the VPN: ${e.localizedMessage}")
-                    dispatchEvent(EVENTS.activationError, e.localizedMessage)
-                }
-                return true
-            }
-            ACTIONS.reactivate -> {
-                // [data] is empty
-                // Activate the tunnel with the last config
-                try {
-                    this.mService.reconnect(source = "system")
-                } catch (e: Exception) {
-                    Log.e(tag, "An Error occurred while enabling the VPN: ${e.localizedMessage}")
-                    dispatchEvent(EVENTS.activationError, e.localizedMessage)
-                }
-                return true
-            }
-            ACTIONS.deactivate -> {
-                Log.i(tag, "Deactivation requested")
-                // [data] here is empty
-                this.mService.turnOff()
-                return true
-            }
-            ACTIONS.registerEventListener -> {
-                Log.i(tag, "requested to add an Event Listener")
-                // [data] contains the Binder that we need to dispatch the Events
-                val binder = data.readStrongBinder()
-                mListeners.add(binder)
-                Log.i(tag, "Registered binder now: ${mListeners.size} Binders")
-
-                if (!Prefs.get(mService).contains("glean_enabled")) {
-                    Log.i(tag, "Requesting Glean upload enabled state. No value in storage.")
-                    dispatchEvent(
-                        VPNServiceBinder.EVENTS.requestGleanUploadEnabledState,
-                        "",
-                        binder,
-                    )
-                }
-
-                return true
-            }
-            ACTIONS.getStatus -> {
-                val obj = JSONObject()
-                obj.put("connected", mService.isUp)
-                obj.put("time", mService.connectionTime)
-                obj.put("city", mService.cityname)
-                obj.put("canActivate", mService.canActivate)
-                obj.put("connection-health-status", mService.mConnectionHealth.getStatusString())
-                dispatchEvent(EVENTS.init, obj.toString())
-                return true
-            }
-            ACTIONS.requestStatistic -> {
-                dispatchEvent(EVENTS.statisticUpdate, mService.status.toString())
-                return true
-            }
-            ACTIONS.requestCleanupLog -> {
-                Log.clearFile()
-                return true
-            }
-            ACTIONS.setNotificationText -> {
-                val buffer = data.createByteArray()
-                val json = buffer?.let { String(it) }
-                if (json.isNullOrEmpty()) {
-                    return false
-                }
-                try {
-                    val message = Json.decodeFromString<ClientNotification>(json)
-                    mService.mNotificationHandler.setNotificationText(message)
-                } catch (e: Exception) {
-                    e.message?.let { Log.e(tag, it) }
-                }
-                return true
-            }
-            ACTIONS.setStartOnBoot -> {
-                val buffer = data.createByteArray()
-                val json = buffer?.let { String(it) }
-                val args = JSONObject(json)
-                val value = args.getBoolean("startOnBoot")
-                Prefs.get(mService)
-                    .edit()
-                    .apply() { putBoolean(BootReceiver.START_ON_BOOT, value) }
-                    .apply()
-            }
-            ACTIONS.clearStorage -> {
-                mService.clearConfig()
-            }
-            ACTIONS.setGleanUploadEnabled -> {
-                val buffer = data.createByteArray()
-                val json = buffer?.let { String(it) }
-                val args = JSONObject(json)
-                mService.setGleanUploadEnabled(args.getBoolean("uploadEnabled"))
-                return true
-            }
-            IBinder.LAST_CALL_TRANSACTION -> {
-                Log.e(tag, "The OS Requested to shut down the VPN")
-                this.mService.turnOff()
-                return true
-            }
-            else -> {
-                Log.e(tag, "Received invalid bind request \t Code -> $code")
-                // If we're hitting this there is probably something wrong in the client.
-                return false
-            }
-        }
-        return false
-    }
-
-    /**
-     * Dispatches an Event to all registered Binders [code] the Event that happened - see [EVENTS]
-     * To register an Eventhandler use [onTransact] with [ACTIONS.registerEventListener] When
-     * [targetBinder] is Provided, it will only dispatch the event to it.
-     */
-    fun dispatchEvent(code: Int, payload: String = "", targetBinder: IBinder? = null) {
-        val data = Parcel.obtain()
-        data.writeByteArray(payload?.toByteArray(charset("UTF-8")))
-        dispatchEvent(code, data, targetBinder)
-    }
-    fun dispatchEvent(code: Int, data: Parcel, targetBinder: IBinder? = null) {
-        targetBinder?.let {
-            try {
-                it.transact(code, data, Parcel.obtain(), 0)
-            } catch (e: DeadObjectException) {
-                Log.e(tag, "Attempted to dispatch event '$code' to dead binder. Removing.")
-                // The binder is not alive, so we can remove it
-                // from the listeners list, if present.
-                mListeners.remove(it)
-            }
-            return
-        }
-        val deadBinders = ArrayList<IBinder>()
-        mListeners.forEach {
-            if (it.isBinderAlive) {
-                try {
-                    it.transact(code, data, Parcel.obtain(), 0)
-                } catch (e: DeadObjectException) {
-                    // If the QT Process is killed (not just inactive)
-                    // we cant access isBinderAlive, so nothing to do here.
-                    deadBinders.add(it)
-                }
-            } else {
-                deadBinders.add(it)
-            }
-        }
-        if (deadBinders.size > 0) {
-            mListeners.removeAll(deadBinders)
-            Log.i(tag, "Removed ${deadBinders.size} dead Binders")
-        }
-    }
-
-    val isClientAttached: Boolean
-        get() {
-            return try {
-                mListeners.any { it.isBinderAlive }
-            } catch (e: DeadObjectException) {
-                false
-            }
-        }
-
-    /** The codes we Are Using in case of [dispatchEvent] */
-    object EVENTS {
-        const val init = 0
-        const val connected = 1
-        const val disconnected = 2
-        const val statisticUpdate = 3
-        const val activationError = 5
-        const val permissionRequired = 6
-        const val requestGleanUploadEnabledState = 7
-    }
-}
+ import android.content.Intent
+ import android.os.Binder
+ import android.os.DeadObjectException
+ import android.os.IBinder
+ import android.os.Parcel
+ import kotlinx.serialization.decodeFromString
+ import kotlinx.serialization.json.Json
+ import org.json.JSONObject
+ import org.mozilla.firefox.qt.common.Prefs
+ import kotlin.Exception
+ 
+ class VPNServiceBinder(service: VPNService) : Binder() {
+ 
+     private val mService = service
+     private val tag = "VPNServiceBinder"
+ 
+     private val mListeners = ArrayList<IBinder>()
+     private var mResumeConfig: JSONObject? = null
+ 
+     /** The codes this Binder does accept in [onTransact] */
+     object ACTIONS {
+         const val activate = 1
+         const val deactivate = 2
+         const val registerEventListener = 3
+         const val requestStatistic = 4
+         const val requestCleanupLog = 6
+         const val resumeActivate = 7
+         const val setNotificationText = 8
+         const val recordEvent = 10
+         const val getStatus = 13
+         const val setStartOnBoot = 15
+         const val reactivate = 16
+         const val clearStorage = 17
+         const val setGleanUploadEnabled = 18
+         const val notificationPermissionFired = 19
+     }
+ 
+     /**
+      * Gets called when the VPNServiceBinder gets a request from a Client. The [code] determines
+      * what action is requested. - see [ACTIONS] [data] may contain a utf-8 encoded json string with
+      * optional args or is null. [reply] is a pointer to a buffer in the clients memory, to reply
+      * results. we use this to send result data.
+      *
+      * returns true if the [code] was accepted
+      */
+     override fun onTransact(code: Int, data: Parcel, reply: Parcel?, flags: Int): Boolean {
+         when (code) {
+             ACTIONS.activate -> {
+                 try {
+                     Log.i(tag, "Activation Requested")
+                     // [data] is here a json containing the wireguard conf
+                     val buffer = data.createByteArray()
+                     val json = buffer?.let { String(it) }
+                     val config = json?.let { JSONObject(it) }
+                     if (config == null) {
+                         Log.e(tag, "Client provided config was not parsable")
+                         return true
+                     }
+                     val permissionIntent: Intent? = mService.checkPermissions()
+                     if (permissionIntent != null) {
+                         mResumeConfig = config
+                         val permissionParcel = Parcel.obtain()
+                         permissionIntent.writeToParcel(permissionParcel, 0)
+                         dispatchEvent(EVENTS.permissionRequired, permissionParcel)
+                         // The Permission prompt was already
+                         // send, in case it's accepted we will
+                         // receive ACTIONS.resumeActivate
+                         return true
+                     }
+                     this.mService.turnOn(json = config, source = "app")
+                 } catch (e: Exception) {
+                     Log.e(tag, "An Error occurred while enabling the VPN: ${e.localizedMessage}")
+                     Log.stack(tag, e.stackTrace)
+                     dispatchEvent(EVENTS.activationError, e.localizedMessage)
+                 }
+                 return true
+             }
+             ACTIONS.resumeActivate -> {
+                 // [data] is empty
+                 // Activate the current tunnel
+                 try {
+                     Log.i(tag, "Resume Activation requested")
+                     mResumeConfig?.let { this.mService.turnOn(it) }
+                 } catch (e: Exception) {
+                     Log.e(tag, "An Error occurred while enabling the VPN: ${e.localizedMessage}")
+                     dispatchEvent(EVENTS.activationError, e.localizedMessage)
+                 }
+                 return true
+             }
+             ACTIONS.reactivate -> {
+                 // [data] is empty
+                 // Activate the tunnel with the last config
+                 try {
+                     this.mService.reconnect(source = "system")
+                 } catch (e: Exception) {
+                     Log.e(tag, "An Error occurred while enabling the VPN: ${e.localizedMessage}")
+                     dispatchEvent(EVENTS.activationError, e.localizedMessage)
+                 }
+                 return true
+             }
+             ACTIONS.deactivate -> {
+                 Log.i(tag, "Deactivation requested")
+                 // [data] here is empty
+                 this.mService.turnOff()
+                 return true
+             }
+             ACTIONS.registerEventListener -> {
+                 Log.i(tag, "requested to add an Event Listener")
+                 // [data] contains the Binder that we need to dispatch the Events
+                 val binder = data.readStrongBinder()
+                 mListeners.add(binder)
+                 Log.i(tag, "Registered binder now: ${mListeners.size} Binders")
+ 
+                 if (!Prefs.get(mService).contains("glean_enabled")) {
+                     Log.i(tag, "Requesting Glean upload enabled state. No value in storage.")
+                     dispatchEvent(
+                         VPNServiceBinder.EVENTS.requestGleanUploadEnabledState,
+                         "",
+                         binder,
+                     )
+                 }
+ 
+                 return true
+             }
+             ACTIONS.getStatus -> {
+                 val obj = JSONObject()
+                 obj.put("connected", mService.isUp)
+                 obj.put("time", mService.connectionTime)
+                 obj.put("city", mService.cityname)
+                 obj.put("canActivate", mService.canActivate)
+                 obj.put("connection-health-status", mService.mConnectionHealth.getStatusString())
+                 dispatchEvent(EVENTS.init, obj.toString())
+                 return true
+             }
+             ACTIONS.requestStatistic -> {
+                 dispatchEvent(EVENTS.statisticUpdate, mService.status.toString())
+                 return true
+             }
+             ACTIONS.requestCleanupLog -> {
+                 Log.clearFile()
+                 return true
+             }
+             ACTIONS.setNotificationText -> {
+                 val buffer = data.createByteArray()
+                 val json = buffer?.let { String(it) }
+                 if (json.isNullOrEmpty()) {
+                     return false
+                 }
+                 try {
+                     val message = Json.decodeFromString<ClientNotification>(json)
+                     mService.mNotificationHandler.setNotificationText(message)
+                 } catch (e: Exception) {
+                     e.message?.let { Log.e(tag, it) }
+                 }
+                 return true
+             }
+             ACTIONS.setStartOnBoot -> {
+                 val buffer = data.createByteArray()
+                 val json = buffer?.let { String(it) }
+                 val args = JSONObject(json)
+                 val value = args.getBoolean("startOnBoot")
+                 Prefs.get(mService)
+                     .edit()
+                     .apply() { putBoolean(BootReceiver.START_ON_BOOT, value) }
+                     .apply()
+             }
+             ACTIONS.clearStorage -> {
+                 mService.clearConfig()
+             }
+             ACTIONS.setGleanUploadEnabled -> {
+                 val buffer = data.createByteArray()
+                 val json = buffer?.let { String(it) }
+                 val args = JSONObject(json)
+                 mService.setGleanUploadEnabled(args.getBoolean("uploadEnabled"))
+                 return true
+             }
+             ACTIONS.notificationPermissionFired ->{
+                 mService.mNotificationHandler.onNotificationPermissionPromptFired();
+                 return true;
+             }
+             IBinder.LAST_CALL_TRANSACTION -> {
+                 Log.e(tag, "The OS Requested to shut down the VPN")
+                 this.mService.turnOff()
+                 return true
+             }
+             else -> {
+                 Log.e(tag, "Received invalid bind request \t Code -> $code")
+                 // If we're hitting this there is probably something wrong in the client.
+                 return false
+             }
+         }
+         return false
+     }
+ 
+     /**
+      * Dispatches an Event to all registered Binders [code] the Event that happened - see [EVENTS]
+      * To register an Eventhandler use [onTransact] with [ACTIONS.registerEventListener] When
+      * [targetBinder] is Provided, it will only dispatch the event to it.
+      */
+     fun dispatchEvent(code: Int, payload: String = "", targetBinder: IBinder? = null) {
+         val data = Parcel.obtain()
+         data.writeByteArray(payload?.toByteArray(charset("UTF-8")))
+         dispatchEvent(code, data, targetBinder)
+     }
+     fun dispatchEvent(code: Int, data: Parcel, targetBinder: IBinder? = null) {
+         Log.e("VPNServiceBinder", "Sending ${code}")
+         targetBinder?.let {
+             try {
+                 it.transact(code, data, Parcel.obtain(), 0)
+             } catch (e: DeadObjectException) {
+                 Log.e(tag, "Attempted to dispatch event '$code' to dead binder. Removing.")
+                 // The binder is not alive, so we can remove it
+                 // from the listeners list, if present.
+                 mListeners.remove(it)
+             }
+             return
+         }
+         val deadBinders = ArrayList<IBinder>()
+         mListeners.forEach {
+             if (it.isBinderAlive) {
+                 try {
+                     it.transact(code, data, Parcel.obtain(), 0)
+                 } catch (e: DeadObjectException) {
+                     // If the QT Process is killed (not just inactive)
+                     // we cant access isBinderAlive, so nothing to do here.
+                     deadBinders.add(it)
+                 }
+             } else {
+                 deadBinders.add(it)
+             }
+         }
+         if (deadBinders.size > 0) {
+             mListeners.removeAll(deadBinders)
+             Log.i(tag, "Removed ${deadBinders.size} dead Binders")
+         }
+     }
+ 
+     val isClientAttached: Boolean
+         get() {
+             return try {
+                 mListeners.any { it.isBinderAlive }
+             } catch (e: DeadObjectException) {
+                 false
+             }
+         }
+ 
+     /** The codes we Are Using in case of [dispatchEvent] */
+     object EVENTS {
+         const val init = 0
+         const val connected = 1
+         const val disconnected = 2
+         const val statisticUpdate = 3
+         const val activationError = 5
+         const val permissionRequired = 6
+         const val requestGleanUploadEnabledState = 7
+         const val requestNotificationPermission = 8
+     }
+ }
+ 

--- a/android/vpnClient/src/main/java/org/mozilla/firefox/vpn/qt/VPNActivity.java
+++ b/android/vpnClient/src/main/java/org/mozilla/firefox/vpn/qt/VPNActivity.java
@@ -165,12 +165,18 @@ public class VPNActivity extends org.qtproject.qt.android.bindings.QtActivity {
 
 
   public void onPermissionRequest(int code, Parcel data) {
+    onNotificationPermissionRequest();
     if(code != EVENT_PERMISSION_REQURED){
       return;
     }
     Intent x = new Intent();
     x.readFromParcel(data);
     startActivityForResult(x,PERMISSION_TRANSACTION);
+  }
+  public void onNotificationPermissionRequest() {
+    String permissions[] = new String[1];
+    permissions[0] = "android.permission.POST_NOTIFICATIONS";
+    requestPermissions(permissions, 1);
   }
 
   @Override

--- a/android/vpnClient/src/main/java/org/mozilla/firefox/vpn/qt/VPNActivity.java
+++ b/android/vpnClient/src/main/java/org/mozilla/firefox/vpn/qt/VPNActivity.java
@@ -154,18 +154,17 @@ public class VPNActivity extends org.qtproject.qt.android.bindings.QtActivity {
     bindService(new Intent(this, VPNService.class), mConnection,
             Context.BIND_AUTO_CREATE);
   }
-  // TODO: Move all ipc codes into a shared lib.
-  // this is getting out of hand. 
+  // TODO: we need to port this class to kotlin
+  // so we can use that Shared Code
+  // Editors Note: we need to port this class to kotlin
   private final int PERMISSION_TRANSACTION = 1337;
   private final int ACTION_REGISTER_LISTENER = 3;
   private final int ACTION_RESUME_ACTIVATE = 7;
+  private final int ACTION_NOTIFICATION_PROMPT_SENT = 19;
   private final int EVENT_PERMISSION_REQURED = 6;
   private final int EVENT_DISCONNECTED = 2;
 
-
-
   public void onPermissionRequest(int code, Parcel data) {
-    onNotificationPermissionRequest();
     if(code != EVENT_PERMISSION_REQURED){
       return;
     }
@@ -177,6 +176,7 @@ public class VPNActivity extends org.qtproject.qt.android.bindings.QtActivity {
     String permissions[] = new String[1];
     permissions[0] = "android.permission.POST_NOTIFICATIONS";
     requestPermissions(permissions, 1);
+    dispatchParcel(ACTION_NOTIFICATION_PROMPT_SENT, "");
   }
 
   @Override

--- a/android/vpnClient/src/main/java/org/mozilla/firefox/vpn/qt/VPNClientBinder.kt
+++ b/android/vpnClient/src/main/java/org/mozilla/firefox/vpn/qt/VPNClientBinder.kt
@@ -6,15 +6,20 @@ package org.mozilla.firefox.vpn
 import android.os.Binder
 import android.os.Parcel
 import org.mozilla.firefox.vpn.qt.VPNActivity
+import android.util.Log
 
-const val permissionRequired = 6
+const val vpnPermissionRequired = 6
+const val notificationPermissionRequired= 8
 
 class VPNClientBinder() : Binder() {
 
     override fun onTransact(code: Int, data: Parcel, reply: Parcel?, flags: Int): Boolean {
-        if (code == permissionRequired) {
+        if (code == vpnPermissionRequired) {
             VPNActivity.getInstance().onPermissionRequest(code, data)
             return true
+        }else if(code == notificationPermissionRequired){
+            Log.e("VPNActivity", "ASKING FOR PERMISSIOOONS")
+            VPNActivity.getInstance().onNotificationPermissionRequest()
         }
 
         val buffer = data.createByteArray()

--- a/android/vpnClient/src/main/java/org/mozilla/firefox/vpn/qt/VPNClientBinder.kt
+++ b/android/vpnClient/src/main/java/org/mozilla/firefox/vpn/qt/VPNClientBinder.kt
@@ -3,28 +3,28 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 package org.mozilla.firefox.vpn
-import android.os.Binder
 import android.os.Parcel
+import org.mozilla.firefox.qt.common.CoreBinder
 import org.mozilla.firefox.vpn.qt.VPNActivity
-import android.util.Log
 
-const val vpnPermissionRequired = 6
-const val notificationPermissionRequired= 8
-
-class VPNClientBinder() : Binder() {
+class VPNClientBinder() : CoreBinder() {
 
     override fun onTransact(code: Int, data: Parcel, reply: Parcel?, flags: Int): Boolean {
-        if (code == vpnPermissionRequired) {
-            VPNActivity.getInstance().onPermissionRequest(code, data)
-            return true
-        }else if(code == notificationPermissionRequired){
-            Log.e("VPNActivity", "ASKING FOR PERMISSIOOONS")
-            VPNActivity.getInstance().onNotificationPermissionRequest()
+        when (code) {
+            EVENTS.permissionRequired -> {
+                VPNActivity.getInstance().onPermissionRequest(code, data)
+                return true
+            }
+            EVENTS.requestNotificationPermission -> {
+                VPNActivity.getInstance().onNotificationPermissionRequest()
+                return true
+            }
+            else -> {
+                val buffer = data.createByteArray()
+                val stringData = buffer?.let { String(it) }
+                VPNActivity.getInstance().onServiceMessage(code, stringData)
+                return true
+            }
         }
-
-        val buffer = data.createByteArray()
-        val stringData = buffer?.let { String(it) }
-        VPNActivity.getInstance().onServiceMessage(code, stringData)
-        return true
     }
 }

--- a/scripts/android/cmake.sh
+++ b/scripts/android/cmake.sh
@@ -144,6 +144,8 @@ fi
 mv $WORKSPACE_ROOT/3rdparty/glean/glean-core/uniffi.toml $WORKSPACE_ROOT/3rdparty/glean/glean-core/uniffi.toml.backup
 cp $WORKSPACE_ROOT/qtglean/uniffi.toml 3rdparty/glean/glean-core/uniffi.toml
 
+
+
 if [[ "$RELEASE" ]]; then
   printn Y "Use release config"
   $QTPATH/bin/qt-cmake \

--- a/src/platforms/android/androidvpnactivity.cpp
+++ b/src/platforms/android/androidvpnactivity.cpp
@@ -135,6 +135,10 @@ void AndroidVPNActivity::handleServiceMessage(int code, const QString& data) {
     case ServiceEvents::EVENT_REQUEST_GLEAN_UPLOAD_ENABLED:
       emit eventRequestGleanUploadEnabledState();
       break;
+    case ServiceEvents::EVENT_REQUEST_NOTIFICATION_PERMISSION:
+      // This is completely handled in Java-Land
+      // See VPNActivity.java
+      break;
     default:
       Q_ASSERT(false);
   }

--- a/src/platforms/android/androidvpnactivity.h
+++ b/src/platforms/android/androidvpnactivity.h
@@ -69,6 +69,9 @@ enum ServiceEvents {
   // When this event is received, the app should broadcast
   // the telemetry preferences to the daemon ASAP.
   EVENT_REQUEST_GLEAN_UPLOAD_ENABLED = 7,
+  // The Daemon need's the app to ask to notification
+  // permissions, to show the "you're connected" messages.
+  EVENT_REQUEST_NOTIFICATION_PERMISSION = 8,
 };
 typedef enum ServiceEvents ServiceEvents;
 


### PR DESCRIPTION
Note: There are a lot of formatting changes, they will be gone once https://github.com/mozilla-mobile/mozilla-vpn-client/pull/7977 has merged, so i can rebase 😅 

What is this fix?
On android sdk 31, we no longer implicit get a "allow vpn to send notifications" prompt when we create the notification channel. Therefore we need to add that to our permissions list. 
`NotificationUtil.kt` - now will check if permissions may be needed and if so will try to dispatch that to `VPNActivity`. 
It will fire the prompt and after sends a signal to`NotificationUtil`, so that it will remember that we have asked the user. 

In any case `NotificationUtil` will only prompt once, so that users are not asked repeatedly if they press no.
Note: Users can go into Settings->Notifications in the app to always change their mind. 
