### PR TITLE
Chore: Add pauses between substrings of notification read by screen reader

### DIFF
--- a/nebula/ui/components/MZAlert.qml
+++ b/nebula/ui/components/MZAlert.qml
@@ -354,7 +354,7 @@ Rectangle {
     }
 
     function onShowCompleted() {
-        MZAccessibleNotification.notify(label, alertBox.alertText + " " + alertBox.alertActionText);
+        MZAccessibleNotification.notify(label, alertBox.alertText + ". " + alertBox.alertActionText);
     }
 
     function remove() {

--- a/src/ui/screens/home/controller/ConnectionStability.qml
+++ b/src/ui/screens/home/controller/ConnectionStability.qml
@@ -30,7 +30,7 @@ Item {
         }
 
         // Notify accessibility client of connection health problems
-        let notificationText = stabilityLabel.text + " " + stabilityLabelInstruction.text;
+        let notificationText = stabilityLabel.text + ". " + stabilityLabelInstruction.text;
         MZAccessibleNotification.notify(stabilityLabel, notificationText);
     }
 

--- a/src/ui/screens/home/controller/ControllerView.qml
+++ b/src/ui/screens/home/controller/ControllerView.qml
@@ -21,11 +21,11 @@ Item {
 
     function handleConnectionStateChange() {
         // Notify accessibility client of connection state
-        let notificationText = (logoTitle.text + ' ');
+        let notificationText = (logoTitle.text + '. ');
         if (logoSubtitle.visible)
-            notificationText += (logoSubtitle.text + ' ');
+            notificationText += (logoSubtitle.text + '. ');
         if (connectedStateDescription.visible)
-            notificationText += (connectedStateDescription.text + ' ');
+            notificationText += (connectedStateDescription.text + '. ');
 
         MZAccessibleNotification.notify(logoTitle, notificationText);
     }


### PR DESCRIPTION
## Description

    Add periods between substrings of the notification read by screen reader, to introduce pauses for better clarity.

## Reference

[VPN-5443](https://mozilla-hub.atlassian.net/browse/VPN-5443), [Github 7863](https://github.com/mozilla-mobile/mozilla-vpn-client/issues/7863)

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-5443]: https://mozilla-hub.atlassian.net/browse/VPN-5443?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ