### PR TITLE
version bump to 2.18

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ if(NOT (IS_MULTI_CONFIG OR DEFINED CMAKE_BUILD_TYPE))
     message("Setting build type ${CMAKE_BUILD_TYPE}")
 endif()
 
-project("Mozilla VPN" VERSION 2.17.0 LANGUAGES C CXX
+project("Mozilla VPN" VERSION 2.18.0 LANGUAGES C CXX
         DESCRIPTION "Mozilla VPN"
         HOMEPAGE_URL "https://vpn.mozilla.org"
 )


### PR DESCRIPTION
Bumping main branch to 2.18 (per release checklist), now that there is a 2.17 release branch.