### PR TITLE
fix test

### DIFF
--- a/tools/languagelocalizer/languageLocalizer.js
+++ b/tools/languagelocalizer/languageLocalizer.js
@@ -11,7 +11,7 @@ import inquirer from 'inquirer';
 import fetch from 'node-fetch';
 import WBK from 'wikibase-sdk';
 
-const I18N_SUBMODULE_PATH = '../src/apps/vpn/translations/i18n';
+const I18N_SUBMODULE_PATH = '../../src/translations/i18n';
 const LANGUAGES_OUTPUT_FILE =
     '../../src/translations/extras/languages.json';
 

--- a/tools/languagelocalizer/languageLocalizer.js
+++ b/tools/languagelocalizer/languageLocalizer.js
@@ -11,8 +11,7 @@ import inquirer from 'inquirer';
 import fetch from 'node-fetch';
 import WBK from 'wikibase-sdk';
 
-const I18N_SUBMODULE_PATH = '../../src/apps/vpn/translations/i18n';
-const DEFAULT_MOZILLAVPN = '../../build/src/mozillavpn';
+const I18N_SUBMODULE_PATH = '/src/apps/vpn/translations/i18n';
 const LANGUAGES_OUTPUT_FILE =
     '../../src/translations/extras/languages.json';
 

--- a/tools/languagelocalizer/languageLocalizer.js
+++ b/tools/languagelocalizer/languageLocalizer.js
@@ -11,7 +11,7 @@ import inquirer from 'inquirer';
 import fetch from 'node-fetch';
 import WBK from 'wikibase-sdk';
 
-const I18N_SUBMODULE_PATH = '/src/apps/vpn/translations/i18n';
+const I18N_SUBMODULE_PATH = '../src/apps/vpn/translations/i18n';
 const LANGUAGES_OUTPUT_FILE =
     '../../src/translations/extras/languages.json';
 
@@ -59,7 +59,7 @@ const LanguageLocalizer = {
     const __filename = fileURLToPath(import.meta.url);
     const __dirname = path.dirname(__filename);
     const submodule_path = path.resolve(__dirname, I18N_SUBMODULE_PATH)
-    const dir_entries = fs.readdirSync(submodule_path,{withFileTypes:true});
+    const dir_entries = fs.readdirSync(submodule_path, {withFileTypes: true});
     const language_folders = dir_entries
                               .filter(f => f.isDirectory())
                               .map(f=>f.name)


### PR DESCRIPTION
Fix from https://github.com/mozilla-mobile/mozilla-vpn-client/pull/7667/

Failing like this: https://github.com/mozilla-mobile/mozilla-vpn-client/actions/runs/6175637752/job/16763343087?pr=8005

I believe this is because we're getting the full path with `../..`, but then appending the local directory to it again - giving the erroneous `Error: ENOENT: no such file or directory, scandir '/home/runner/work/mozilla-vpn-client/mozilla-vpn-client/src/apps/vpn/translations/i18n'` with two `mozilla-vpn-client`s. 

Additionally, `DEFAULT_MOZILLAVPN` isn't used in this file (was copied over from another file), so I removed it.