### PR TITLE
VPN-5540 Remove obsolete permission

### DIFF
--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -7,7 +7,6 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 <manifest package="org.mozilla.firefox.vpn" xmlns:android="http://schemas.android.com/apk/res/android" android:versionName="-- %%INSERT_VERSION_NAME%% --" android:versionCode="-- %%INSERT_VERSION_CODE%% --" android:installLocation="auto">
 
     <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />


### PR DESCRIPTION
## Description

Apparently we've had this since ... [forever](https://github.com/mozilla-mobile/mozilla-vpn-client/blob/v2.0.1/android/AndroidManifest.xml#L10) ? So this is probably [a thing we just got by default from qt](https://sourcegraph.com/github.com/qt/qtbase@6.2.4/-/blob/src/corelib/CMakeLists.txt?L364) when we first generated this file. 

Just checked, the only thing we export to an external storage are the logfiles (so we can get a share intent without giving other apps access to our fs ) - that still works, given we use mediastore which does not need additional permissions, not surprising. 


