### PR TITLE
[Uplift] Fix 2.17 messaging

### DIFF
--- a/.github/workflows/i18n_update.yaml
+++ b/.github/workflows/i18n_update.yaml
@@ -83,7 +83,7 @@ jobs:
           ref: 'releases/${{matrix.branch}}'
       - name: Checkout mozilla-vpn-client-l10n Git
         run: |
-          git submodule update --init --remote src/apps/vpn/translations/i18n/
+          git submodule update --init --remote src/translations/i18n/
       - uses: peter-evans/create-pull-request@v5
         id: cpr
         with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ if(NOT (IS_MULTI_CONFIG OR DEFINED CMAKE_BUILD_TYPE))
     message("Setting build type ${CMAKE_BUILD_TYPE}")
 endif()
 
-project("Mozilla VPN" VERSION 2.17.0 LANGUAGES C CXX
+project("Mozilla VPN" VERSION 2.18.0 LANGUAGES C CXX
         DESCRIPTION "Mozilla VPN"
         HOMEPAGE_URL "https://vpn.mozilla.org"
 )

--- a/addons/message_update_v2.17/manifest.json
+++ b/addons/message_update_v2.17/manifest.json
@@ -26,28 +26,8 @@
         "type": "ulist",
         "content": [
           {
-            "id": "l_1",
-            "content": "The ability to sign in using your Google or Apple account"
-          },
-          {
             "id": "l_2",
             "content": "A new “My Devices” screen that makes it easier to view and manage your devices"
-          },
-          {
-            "id": "l_3",
-            "content": "The ability to upgrade to an annual plan from within the app"
-          },
-          {
-            "id": "l_4",
-            "content": "Improved guidance for fixing VPN connection issues"
-          },
-          {
-            "id": "l_5",
-            "content": "Personalized suggestions for apps to exclude from VPN protection"
-          },
-          {
-            "id": "l_6",
-            "content": "More easily accessible help content throughout the app"
           }
         ]
       },    

--- a/addons/message_whats_new_v2.17/manifest.json
+++ b/addons/message_whats_new_v2.17/manifest.json
@@ -35,7 +35,7 @@
       {
         "id": "c_3",
         "type": "text",
-        "content": "Thank you for installing the latest version"
+        "content": "Thank you for installing the latest version!"
       }
     ]
   }

--- a/addons/message_whats_new_v2.17/manifest.json
+++ b/addons/message_whats_new_v2.17/manifest.json
@@ -27,28 +27,8 @@
         "type": "ulist",
         "content": [
           {
-            "id": "l_1",
-            "content": "The ability to sign in using your Google or Apple account"
-          },
-          {
             "id": "l_2",
             "content": "A new “My Devices” screen that makes it easier to view and manage your devices"
-          },
-          {
-            "id": "l_3",
-            "content": "The ability to upgrade to an annual plan from within the app"
-          },
-          {
-            "id": "l_4",
-            "content": "Improved guidance for fixing VPN connection issues"
-          },
-          {
-            "id": "l_5",
-            "content": "Personalized suggestions for apps to exclude from VPN protection"
-          },
-          {
-            "id": "l_6",
-            "content": "More easily accessible help content throughout the app"
           }
         ]
       },

--- a/tools/languagelocalizer/languageLocalizer.js
+++ b/tools/languagelocalizer/languageLocalizer.js
@@ -11,8 +11,7 @@ import inquirer from 'inquirer';
 import fetch from 'node-fetch';
 import WBK from 'wikibase-sdk';
 
-const I18N_SUBMODULE_PATH = '../../src/apps/vpn/translations/i18n';
-const DEFAULT_MOZILLAVPN = '../../build/src/mozillavpn';
+const I18N_SUBMODULE_PATH = '../../src/translations/i18n';
 const LANGUAGES_OUTPUT_FILE =
     '../../src/translations/extras/languages.json';
 
@@ -60,7 +59,7 @@ const LanguageLocalizer = {
     const __filename = fileURLToPath(import.meta.url);
     const __dirname = path.dirname(__filename);
     const submodule_path = path.resolve(__dirname, I18N_SUBMODULE_PATH)
-    const dir_entries = fs.readdirSync(submodule_path,{withFileTypes:true});
+    const dir_entries = fs.readdirSync(submodule_path, {withFileTypes: true});
     const language_folders = dir_entries
                               .filter(f => f.isDirectory())
                               .map(f=>f.name)


### PR DESCRIPTION
## Description

- Content parity with main branch for the 2.17 update and what's new messages

*Note: Translations consider all branches, so even though addons are built off of `main`, these strings would still be unnecessarily translated in the `releases/2.17.0` branch if they aren't removed. 

## Reference

N/A
