### PR TITLE
VPN-5534: Fix 2.17 what's new message content

### DIFF
--- a/addons/message_whats_new_v2.17/manifest.json
+++ b/addons/message_whats_new_v2.17/manifest.json
@@ -35,7 +35,7 @@
       {
         "id": "c_3",
         "type": "text",
-        "content": "Thank you for installing the latest version"
+        "content": "Thank you for installing the latest version!"
       }
     ]
   }


### PR DESCRIPTION
## Description

- Add a missing "!"
- Complete re-translation is not needed since the same string was used in [the 2.16 what's new message](https://github.com/mozilla-mobile/mozilla-vpn-client/blob/2dabb3753f2e93313c85b24a23e001fbe9f0d192/addons/message_whats_new_v2.16/manifest.json#L23), meaning we can use translation memory

## Reference

[VPN-5534: “What’s new” message content has no ending mark](https://mozilla-hub.atlassian.net/browse/VPN-5534)