### PR TITLE
[Uplift] Fix 2.17 messaging

### DIFF
--- a/addons/message_update_v2.17/manifest.json
+++ b/addons/message_update_v2.17/manifest.json
@@ -26,28 +26,8 @@
         "type": "ulist",
         "content": [
           {
-            "id": "l_1",
-            "content": "The ability to sign in using your Google or Apple account"
-          },
-          {
             "id": "l_2",
             "content": "A new “My Devices” screen that makes it easier to view and manage your devices"
-          },
-          {
-            "id": "l_3",
-            "content": "The ability to upgrade to an annual plan from within the app"
-          },
-          {
-            "id": "l_4",
-            "content": "Improved guidance for fixing VPN connection issues"
-          },
-          {
-            "id": "l_5",
-            "content": "Personalized suggestions for apps to exclude from VPN protection"
-          },
-          {
-            "id": "l_6",
-            "content": "More easily accessible help content throughout the app"
           }
         ]
       },    

--- a/addons/message_whats_new_v2.17/manifest.json
+++ b/addons/message_whats_new_v2.17/manifest.json
@@ -27,35 +27,15 @@
         "type": "ulist",
         "content": [
           {
-            "id": "l_1",
-            "content": "The ability to sign in using your Google or Apple account"
-          },
-          {
             "id": "l_2",
             "content": "A new “My Devices” screen that makes it easier to view and manage your devices"
-          },
-          {
-            "id": "l_3",
-            "content": "The ability to upgrade to an annual plan from within the app"
-          },
-          {
-            "id": "l_4",
-            "content": "Improved guidance for fixing VPN connection issues"
-          },
-          {
-            "id": "l_5",
-            "content": "Personalized suggestions for apps to exclude from VPN protection"
-          },
-          {
-            "id": "l_6",
-            "content": "More easily accessible help content throughout the app"
           }
         ]
       },
       {
         "id": "c_3",
         "type": "text",
-        "content": "Thank you for installing the latest version"
+        "content": "Thank you for installing the latest version!"
       }
     ]
   }


### PR DESCRIPTION
## Description

- Content parity with main branch for the 2.17 update and what's new messages

*Note: Translations consider all branches, so even though addons are built off of `main`, these strings would still be unnecessarily translated in the `releases/2.17.0` branch if they aren't removed. 

## Reference

N/A
