### PR TITLE
VPN-4795: Remove redundant exclusion routing on Android

### DIFF
--- a/src/platforms/android/androidcontroller.cpp
+++ b/src/platforms/android/androidcontroller.cpp
@@ -152,21 +152,9 @@ void AndroidController::activate(const InterfaceConfig& config,
   jServer["publicKey"] = config.m_serverPublicKey;
   jServer["port"] = (double)config.m_serverPort;
 
-  QList<IPAddress> allowedIPs;
-  QList<IPAddress> excludedIPs;
-  QJsonArray fullAllowedIPs;
+  QJsonArray jAllowedIPs;
   foreach (auto item, config.m_allowedIPAddressRanges) {
-    allowedIPs.append(IPAddress(item.toString()));
-  }
-
-  if (!config.m_serverIpv4AddrIn.isEmpty()) {
-    excludedIPs.append(IPAddress(config.m_serverIpv4AddrIn));
-  }
-  if (!config.m_serverIpv6AddrIn.isEmpty()) {
-    excludedIPs.append(IPAddress(config.m_serverIpv6AddrIn));
-  }
-  foreach (auto item, IPAddress::excludeAddresses(allowedIPs, excludedIPs)) {
-    fullAllowedIPs.append(QJsonValue(item.toString()));
+    jAllowedIPs.append(QJsonValue(item.toString()));
   }
 
   QJsonArray excludedApps;
@@ -202,7 +190,7 @@ void AndroidController::activate(const InterfaceConfig& config,
   args["keys"] = jKeys;
   args["server"] = jServer;
   args["reason"] = (int)reason;
-  args["allowedIPs"] = fullAllowedIPs;
+  args["allowedIPs"] = jAllowedIPs;
   args["excludedApps"] = excludedApps;
   args["dns"] = config.m_dnsServer;
   if (fallbackServer) {


### PR DESCRIPTION
## Description
It turns out that we don't need to explicitly exclude the VPN server's address when setting up the allowed IP addresses on Android, as this is already handled by the UID routing provided by Anrdoid. This should help simplify the routing configuration and eliminate strange routing quirks.

## Reference
JIRA issue [VPN-4795](https://mozilla-hub.atlassian.net/browse/VPN-4795)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-4795]: https://mozilla-hub.atlassian.net/browse/VPN-4795?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ