### PR TITLE
Enable Visual-Studio Hot C++ Reloading :) 

### DIFF
--- a/src/cmake/msvc.cmake
+++ b/src/cmake/msvc.cmake
@@ -12,7 +12,7 @@ else()
     # /MP -> Compile Files Paraell
     # /Zc:preprocessor -> Enable Modern Macros, needed for settingsholder
     set(CMAKE_CXX_FLAGS  "/MP /Zc:preprocessor")
-    # Enanble "edit and continue" when using msvc + debug build
+    # Enable "edit and continue" when using msvc + debug build
     set(CMAKE_CXX_FLAGS_DEBUG  "/MTd /ZI /Ob0 /Od /RTC1")
     set(CMAKE_CXX_FLAGS_DEBUG  "/MTd /ZI /Ob0 /Od /RTC1")
     set(CMAKE_MODULE_LINKER_FLAGS_DEBUG  "/debug /INCREMENTAL /LTCG:OFF")

--- a/src/cmake/msvc.cmake
+++ b/src/cmake/msvc.cmake
@@ -5,12 +5,19 @@
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang$")
     # We're using clang in msvc mode so we can only use 
     # msvc style compile flags
+    # We cannot use mt.exe as clang's replacement is ... not done. 
+    set(CMAKE_EXE_LINKER_FLAGS    "${CMAKE_EXE_LINKER_FLAGS} /MANIFEST:NO")
+    set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} /MANIFEST:NO")
 else()
-    # These compile flags are only supported on cl.exe 
-    # they do nothing on clang. 
-    add_compile_options(/MP /Zc:preprocessor)
+    # /MP -> Compile Files Paraell
+    # /Zc:preprocessor -> Enable Modern Macros, needed for settingsholder
+    set(CMAKE_CXX_FLAGS  "/MP /Zc:preprocessor")
+    # Enanble "edit and continue" when using msvc + debug build
+    set(CMAKE_CXX_FLAGS_DEBUG  "/MTd /ZI /Ob0 /Od /RTC1")
+    set(CMAKE_CXX_FLAGS_DEBUG  "/MTd /ZI /Ob0 /Od /RTC1")
+    set(CMAKE_MODULE_LINKER_FLAGS_DEBUG  "/debug /INCREMENTAL /LTCG:OFF")
+    set(CMAKE_SHARED_LINKER_FLAGS_DEBUG "/debug /INCREMENTAL /LTCG:OFF")
+    set(CMAKE_EXE_LINKER_FLAGS_DEBUG  "/debug /INCREMENTAL /LTCG:OFF")
+    
 endif()
 
-
-set(CMAKE_EXE_LINKER_FLAGS    "${CMAKE_EXE_LINKER_FLAGS} /MANIFEST:NO")
-set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} /MANIFEST:NO")

--- a/src/cmake/msvc.cmake
+++ b/src/cmake/msvc.cmake
@@ -5,7 +5,8 @@
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang$")
     # We're using clang in msvc mode so we can only use 
     # msvc style compile flags
-    # We cannot use mt.exe as clang's replacement is ... not done. 
+    # We need to disable /Manifest tool as clang's implementation
+    # of mt.exe (llvm-mt) is not a complete drop in soloution. 
     set(CMAKE_EXE_LINKER_FLAGS    "${CMAKE_EXE_LINKER_FLAGS} /MANIFEST:NO")
     set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} /MANIFEST:NO")
 else()


### PR DESCRIPTION
## Description
[c++ hot code reloading is now a thing](https://learn.microsoft.com/en-us/visualstudio/debugger/hot-reload?view=vs-2022#visual-studio-2022-with-a-net-app-when-using-the-debugger) when using vs-studio. 
 For that we need to enable "edit and continue" -> so some flags should be set when we compile `DEBUG` with msvc.
That way people can just open the project in vsstudio and it "should just work" (when you have a preset) 


## Checklist

https://github.com/mozilla-mobile/mozilla-vpn-client/assets/9611612/51b356f5-629c-4670-b0eb-4aa01d95f599


