### PR TITLE
VPN-5574: Ignore route changes with RTF_IFSCOPE

### DIFF
--- a/src/platforms/macos/daemon/macosroutemonitor.cpp
+++ b/src/platforms/macos/daemon/macosroutemonitor.cpp
@@ -95,7 +95,8 @@ void MacosRouteMonitor::handleRtmDelete(const struct rt_msghdr* rtm,
       !(rtm->rtm_addrs & RTA_NETMASK) || (addrlist.count() < 3)) {
     return;
   }
-  // Ignore interface-scoped routes.
+  // Ignore interface-scoped routes, we want to find the default route to the
+  // internet in the global scope.
   if (rtm->rtm_flags & RTF_IFSCOPE) {
     return;
   }
@@ -160,7 +161,8 @@ void MacosRouteMonitor::handleRtmUpdate(const struct rt_msghdr* rtm,
       !(rtm->rtm_addrs & RTA_NETMASK) || (addrlist.count() < 3)) {
     return;
   }
-  // Ignore interface-scoped routes.
+  // Ignore interface-scoped routes, we want to find the default route to the
+  // internet in the global scope.
   if (rtm->rtm_flags & RTF_IFSCOPE) {
     return;
   }

--- a/src/platforms/macos/daemon/macosroutemonitor.cpp
+++ b/src/platforms/macos/daemon/macosroutemonitor.cpp
@@ -95,6 +95,10 @@ void MacosRouteMonitor::handleRtmDelete(const struct rt_msghdr* rtm,
       !(rtm->rtm_addrs & RTA_NETMASK) || (addrlist.count() < 3)) {
     return;
   }
+  // Ignore interface-scoped routes.
+  if (rtm->rtm_flags & RTF_IFSCOPE) {
+    return;
+  }
 
   // Check for a default route, which should have a netmask of zero.
   const struct sockaddr* sa =
@@ -154,6 +158,10 @@ void MacosRouteMonitor::handleRtmUpdate(const struct rt_msghdr* rtm,
   // We expect all useful routes to contain a destination, netmask and gateway.
   if (!(rtm->rtm_addrs & RTA_DST) || !(rtm->rtm_addrs & RTA_GATEWAY) ||
       !(rtm->rtm_addrs & RTA_NETMASK) || (addrlist.count() < 3)) {
+    return;
+  }
+  // Ignore interface-scoped routes.
+  if (rtm->rtm_flags & RTF_IFSCOPE) {
     return;
   }
   // Ignore route changes that we caused, or routes on the tunnel interface.


### PR DESCRIPTION
## Description
In MacOS, routing table entries can be scoped to a network interface, which permits the existence of multiple routes to the same prefix. However, the default-route monitor assumes that duplicate routing table entries can't exist. When multiple default routes exist, but they aren't all capable of reaching the internet it can result in a loss of VPN connectivity. Changes in these default routes can also confuse the VPN when trying to manage exclusion routing (eg: an ifscoped default route is removed, causing the VPN to think that internet connectivity is lost even if there is a second default route).

I think the correct behaviour here is to ignore routes flagged with `RTF_IFSCOPE` when monitoring the routing table.

## Reference
Github issue #8088 ([VPN-5574](https://mozilla-hub.atlassian.net/browse/VPN-5574))

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-5574]: https://mozilla-hub.atlassian.net/browse/VPN-5574?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ