### PR TITLE
Chore: Add Ubuntu/mantic and deprecate Ubuntu/kinetic

### DIFF
--- a/.github/workflows/ppa-automation.yaml
+++ b/.github/workflows/ppa-automation.yaml
@@ -55,7 +55,7 @@ jobs:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
           GNUPGHOME: ${{ runner.temp }}/gnupg-data
-          PPA_TARGET_DISTS: focal jammy kinetic lunar
+          PPA_TARGET_DISTS: focal jammy lunar mantic
           PPA_URL: ${{ steps.gen-source.outputs.ppa-url }}
         run: |
           mkdir -m700 $GNUPGHOME

--- a/taskcluster/ci/build/linux.yml
+++ b/taskcluster/ci/build/linux.yml
@@ -45,16 +45,6 @@ linux/jammy:
         name: linux-jammy
         type: build
 
-linux/kinetic:
-    description: "Linux Build (Ubuntu/Kinetic)"
-    treeherder:
-        platform: linux/kinetic
-    worker:
-        docker-image: {in-tree: linux-build-kinetic}
-    add-index-routes:
-        name: linux-kinetic
-        type: build
-
 linux/lunar:
     description: "Linux Build (Ubuntu/Lunar)"
     treeherder:
@@ -63,6 +53,16 @@ linux/lunar:
         docker-image: {in-tree: linux-build-lunar}
     add-index-routes:
         name: linux-lunar
+        type: build
+
+linux/mantic:
+    description: "Linux Build (Ubuntu/Mantic)"
+    treeherder:
+        platform: linux/mantic
+    worker:
+        docker-image: {in-tree: linux-build-mantic}
+    add-index-routes:
+        name: linux-mantic
         type: build
 
 linux/fedora-fc36:

--- a/taskcluster/ci/docker-image/kind.yml
+++ b/taskcluster/ci/docker-image/kind.yml
@@ -52,16 +52,17 @@ tasks:
         definition: linux-dpkg-build
         args:
             DOCKER_BASE_IMAGE: ubuntu:jammy
-    linux-build-kinetic:
-        symbol: I(linux-kinetic)
-        definition: linux-dpkg-build
-        args:
-            DOCKER_BASE_IMAGE: ubuntu:kinetic
     linux-build-lunar:
         symbol: I(linux-lunar)
         definition: linux-dpkg-build
         args:
             DOCKER_BASE_IMAGE: ubuntu:lunar
+    linux-build-mantic:
+        symbol: I(linux-mantic)
+        definition: linux-dpkg-build
+        cache: false ## Disable caching while Ubuntu/Mantic is in beta.
+        args:
+            DOCKER_BASE_IMAGE: ubuntu:mantic
     linux-build-fedora-fc36:
         symbol: I(linux-fedora-fc36)
         definition: linux-rpm-build


### PR DESCRIPTION
## Description
Updating the set of supported Ubuntu distributions. This adds 23.10 Mantic Minotaur which is currently in beta, and removes 22.10 Kinetic Kudu which reached EOL status on July 30th.

## Reference
Ubuntu: [EOL Announcement](https://fridge.ubuntu.com/2023/06/14/ubuntu-22-10-kinetic-kudu-reaches-end-of-life-on-july-20-2023/)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
