### PR TITLE
Restrict check to Android only

### DIFF
--- a/src/connectionbenchmark/benchmarktasktransfer.cpp
+++ b/src/connectionbenchmark/benchmarktasktransfer.cpp
@@ -43,7 +43,7 @@ void BenchmarkTaskTransfer::handleState(BenchmarkTask::State state) {
 
   if (state == BenchmarkTask::StateActive) {
 #if defined(MZ_DUMMY) || defined(MZ_ANDROID) || defined(MZ_WASM)
-#  if QT_VERSION >= 0x060500
+#  if QT_VERSION >= 0x060500 && defined(MZ_ANDROID)
 #    error Check if QT added support for QDnsLookup::lookup() on Android
 #  endif
 


### PR DESCRIPTION
## Description

Redoing this PR to avoid rebase drama https://github.com/mozilla-mobile/mozilla-vpn-client/pull/7844
QDnsLookup is still not supported on Android so keeping this check for now [[Qt Documentation](https://sourcegraph.com/github.com/qt/qtbase@6.5.3/-/blob/src/network/kernel/qdnslookup_android.cpp)]

## Reference

    i.e Jira or Github issue URL

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
