### PR TITLE
VPN-5538 & VPN-5537: Fix crashing M1s at update checks

### DIFF
--- a/src/signalhandler.cpp
+++ b/src/signalhandler.cpp
@@ -42,7 +42,7 @@ SignalHandler::SignalHandler() {
   struct sigaction sa;
   sa.sa_handler = SignalHandler::saHandler;
   sa.sa_mask = mask;
-  sa.sa_flags = 0;
+  sa.sa_flags = SA_ONSTACK;
 
   for (auto sig : quitSignals) {
     sigaction(sig, &sa, nullptr);


### PR DESCRIPTION
## Description
TBD but so far...

This PR sets sigaction sa_flags to SA_ONSTACK in SignalHandler::SignalHandler. 

After disabling half of our scheduled tasks and switching off most features, XCode produced a helpful error: 

```
signal 16 received but handler not on signal stack
mp.gsignal stack [0x14000054000 0x1400005c000], mp.g0 stack [0x16cf00000 0x16d6fc000], sp=0x14000105e78

fatal error: non-Go code set up signal handler without SA_ONSTACK flag
```
From the[ Go docs](https://pkg.go.dev/os/signal#hdr-Go_programs_that_use_cgo_or_SWIG), 

> In a Go program that includes non-Go code, typically C/C++ code accessed using cgo or SWIG, Go's startup code normally runs first. It configures the signal handlers as expected by the Go runtime, before the non-Go startup code runs. If the non-Go startup code wishes to install its own signal handlers, it must take certain steps to keep Go working well. 
> ...
> If the non-Go code installs any signal handlers, it must use the SA_ONSTACK flag with sigaction. Failing to do so is likely to cause the program to crash if the signal is received. Go programs routinely run with a limited stack, and therefore set up an alternate signal stack

Working to resolve...
- The signal that triggered this is SIGSTKFLT, we would not expect SignalHandler to be affected. What's up?
- What is the cause of the stack fault?
- Why are we just seeing this now?
- Why just on M1s? 

## Reference
VPN-5538, VPN-5537

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
