### PR TITLE
VPN-5567: Fix tips and tricks layout with qt 6.4

### DIFF
--- a/src/ui/screens/tipsAndTricks/ViewTipsAndTricks.qml
+++ b/src/ui/screens/tipsAndTricks/ViewTipsAndTricks.qml
@@ -46,9 +46,9 @@ MZViewBase {
             model: guidesSections.count
 
             delegate: MZTipsAndTricksSection {
-                Layout.fillWidth: true
-
                 property var section: guidesSections.get(index)
+
+                Layout.preferredWidth: parent.width
 
                 title: section.title
                 description: section.description


### PR DESCRIPTION
## Description

- Fixes the tips and tricks layout (with tutorials removed) when built with using Qt 6.4 (often used on Linux)

| Before  | After |
| ------------- | ------------- |
| <img width="428" alt="Screenshot 2023-09-20 at 11 47 50 AM" src="https://github.com/mozilla-mobile/mozilla-vpn-client/assets/15353801/efd94b87-40d0-4710-9e3d-0cd1ac86bf75"> | <img width="428" alt="Screenshot 2023-09-20 at 11 47 24 AM" src="https://github.com/mozilla-mobile/mozilla-vpn-client/assets/15353801/6cf28c20-a1d6-4265-a32c-0cb0a75d5ae1"> |

## Reference

[VPN-5567: [Linux Lunar] Tips & Tricks screen has overlapped content and is not scrollable](https://mozilla-hub.atlassian.net/browse/VPN-5567)