### PR TITLE
[Uplift] Fix tips and tricks layout with qt 6.4 (#8089)

### DIFF
--- a/src/ui/screens/tipsAndTricks/ViewTipsAndTricks.qml
+++ b/src/ui/screens/tipsAndTricks/ViewTipsAndTricks.qml
@@ -46,9 +46,9 @@ MZViewBase {
             model: guidesSections.count
 
             delegate: MZTipsAndTricksSection {
-                Layout.fillWidth: true
-
                 property var section: guidesSections.get(index)
+
+                Layout.preferredWidth: parent.width
 
                 title: section.title
                 description: section.description


### PR DESCRIPTION
## Description

- Uplift changes from #8089

## Reference

[VPN-5567: [Linux Lunar] Tips & Tricks screen has overlapped content and is not scrollable](https://mozilla-hub.atlassian.net/browse/VPN-5567)