### PR TITLE
Fix VPN-5587: Prompt web download for mac users on v2.16

### DIFF
--- a/addons/message_update_v2.17/enable.js
+++ b/addons/message_update_v2.17/enable.js
@@ -6,6 +6,15 @@
     api.addon.date = (api.settings.updateTime.getTime() / 1000);
   }
 
+
+  // Macos v2.16.0 requires a web-based update.
+  if (api.env.platform === 'macos' && api.env.versionString === '2.16.0') {
+    api.addon.setTitle(
+        'message.message_update_v2.17.block.extra_1_217',
+        'Download the new Mozilla VPN');
+    return api.addon.composer.remove('c_3');
+  }
+
   // Windows v2.10 to v2.12 do require a web-based update,
   // with the exception on v2.11.1.
   if (api.env.platform !== 'windows' || api.env.versionString === '2.11.1') {
@@ -41,5 +50,6 @@
   api.addon.composer.remove('c_3');
 
   api.addon.setTitle(
-    'message.message_update_v2.17.block.extra_1_217', 'Download the new Mozilla VPN')
+      'message.message_update_v2.17.block.extra_1_217',
+      'Download the new Mozilla VPN');
 })

--- a/addons/message_update_v2.17/enable.js
+++ b/addons/message_update_v2.17/enable.js
@@ -12,7 +12,8 @@
     api.addon.setTitle(
         'message.message_update_v2.17.block.extra_1_217',
         'Download the new Mozilla VPN');
-    return api.addon.composer.remove('c_3');
+    api.addon.composer.remove('c_3');
+    return;
   }
 
   // Windows v2.10 to v2.12 do require a web-based update,


### PR DESCRIPTION
## Description

This PR updates `message_update_v2.17` to prompt mac users on v2.16 to update via the web-based download/install flow, instead of the traditional Balrog/in-app flow. 

## Reference

VPN-5587 and related VPN-5537, VPN-5538

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
