### PR TITLE
Revert MacOS universal builds

### DIFF
--- a/macos/pkg/Distribution
+++ b/macos/pkg/Distribution
@@ -4,7 +4,7 @@
     <background mime-type="image/png" file="background.png" alignment="left"/>
     <welcome file="welcome.html" mime-type="text/html" />
     <conclusion file="conclusion.html" mime-type="text/html" />
-    <options customize="never" allow-external-scripts="no" hostArchitectures="x86_64,arm64"/>
+    <options customize="never" allow-external-scripts="no" hostArchitectures="x86_64"/>
     <domains enable_localSystem="true" />
     <installation-check script="installCheck();"/>
     <script>

--- a/taskcluster/scripts/build/macos_build.sh
+++ b/taskcluster/scripts/build/macos_build.sh
@@ -98,7 +98,7 @@ cmake -S . -B ${MOZ_FETCHES_DIR}/build -GNinja \
         -DSENTRY_DSN=$SENTRY_DSN \
         -DSENTRY_ENVELOPE_ENDPOINT=$SENTRY_ENVELOPE_ENDPOINT \
         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-        -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64"
+        -DCMAKE_OSX_ARCHITECTURES="x86_64"
 
 print Y "Building the client..."
 cmake --build ${MOZ_FETCHES_DIR}/build


### PR DESCRIPTION
## Description

We have recently found out that something in between Golang and Qt is resulting in a crash when compiled for aarch64/arm64 on MacOS. This crash only occurs when attempting to verify installer signatures fetched from Balrog, as that is the only place that MacOS uses Golang. As an emergency workaround, we have decided to evaluate reverting to an x86_64 build and relying on Rosetta for M1/M2 Macs.

## Reference
Github issue #8018 ([VPN-5537](https://mozilla-hub.atlassian.net/browse/VPN-5537))
Github issue #8019 ([VPN-5538](https://mozilla-hub.atlassian.net/browse/VPN-5538))

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-5537]: https://mozilla-hub.atlassian.net/browse/VPN-5537?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[VPN-5538]: https://mozilla-hub.atlassian.net/browse/VPN-5538?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ