### PR TITLE
VPN-5400: Fix 2 iOS crashes

### DIFF
--- a/ios/app/main.entitlements
+++ b/ios/app/main.entitlements
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>com.apple.developer.default-data-protection</key>
-	<string>NSFileProtectionComplete</string>
 	<key>com.apple.developer.device-information.user-assigned-device-name</key>
 	<true/>
 	<key>com.apple.developer.networking.networkextension</key>

--- a/src/connectionmanager.cpp
+++ b/src/connectionmanager.cpp
@@ -222,7 +222,19 @@ qint64 ConnectionManager::time() const {
 
 void ConnectionManager::timerTimeout() {
   Q_ASSERT(m_state == StateOn);
+#ifdef MZ_IOS
+  // When locking an iOS device with an app in the foreground, the app's JS
+  // runtime is stopped pretty quick by the system. For this VPN app, that
+  // caused a crash here when Qt tried to pass this emit off to QML, as QML
+  // is JS and is no longer available. This check is to prevent that crash
+  // when the device is locked.
+  if (QGuiApplication::applicationState() ==
+      Qt::ApplicationState::ApplicationActive) {
+    emit timeChanged();
+  }
+#else
   emit timeChanged();
+#endif
 }
 
 void ConnectionManager::quit() {


### PR DESCRIPTION
## Description

VPN-5400 was about a crash when the app is in the background. I fixed one crash, and then there was another crash which was identical from a user's perspective - so I fixed it too.

After this is merged, it will be uplifted to the 2.17.1 release branch.

_First crash_
This was due to Qt's handoff to QML-land, which is JS under the hood. The JS runtime is stopped pretty quick by iOS when the app is no longer foregrounded, so when the device was locked, that JS runtime didn't exist when Qt's C++ tried to hand it off to QML-land... and hence the crash.

This is a gross hacky fix. I'm open to better solutions, but after extensive testing (see ticket for details) I wasn't able to find a better way. Please let me know if you have thoughts.

I've left an explanatory comment in code to reduce risk of a future engineer removing this check because they don't understand its value.

_Second crash_
After fixing that, there was still a crash when backgrounding, but a different one. This one was related to glean and a network request. Oddly enough, it only seemed to reproduce once on each install of the app, though this was a bit inconsistent. I *believe* (though I'm not 100% confident) that this is due to how we're treating disk access when the device is locked - namely, it's encrypted. This was done in https://github.com/mozilla-mobile/mozilla-vpn-client/pull/7583, and was a Cure53 recommendation - though they acknowledged they couldn't consider an exploit that didn't require a jailbreak AND physical device access, which makes it a really low risk thing. I think the lack of crash is more valuable, and thus propose removing it in this PR.

## Reference

https://mozilla-hub.atlassian.net/browse/VPN-5400

## Checklist
    
- [X] My code follows the style guidelines for this project
- [X] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [X] I have performed a self review of my own code
- [X] I have commented my code PARTICULARLY in hard to understand areas
- [X] I have added thorough tests where needed
