### PR TITLE
VPN-5117: Replace "Firefox account" with "Mozilla account"

### DIFF
--- a/src/translations/strings.yaml
+++ b/src/translations/strings.yaml
@@ -696,7 +696,6 @@ postAuthentication:
   subtitle: You can quickly access Mozilla VPN from your status bar.
 
 deleteAccount:
-  authSubheadline: To delete your VPN account, please sign in with your Mozilla account password.
   authButtonLabel: Continue
   headline2: Delete Mozilla account
   subheadline2:

--- a/src/translations/strings.yaml
+++ b/src/translations/strings.yaml
@@ -228,7 +228,7 @@ notSignedInGoogle:
 # IAP Android edge case 2
 multiFxaAccountError:
   fxaAccountErrorHeader: Problem confirming subscription
-  fxaAccountErrorText2: Your subscription is linked to another Mozilla account. You may need to sign in with a different email address.
+  mozAccountErrorText: Your subscription is linked to another Mozilla account. You may need to sign in with a different email address.
   visitOurHelpCenter: Visit our help center to learn more about managing your subscriptions.
 
 # IAP Android edge case 3
@@ -696,6 +696,7 @@ postAuthentication:
   subtitle: You can quickly access Mozilla VPN from your status bar.
 
 deleteAccount:
+  authSubheadline: To delete your VPN account, please sign in with your Mozilla account password.
   authButtonLabel: Continue
   headline2: Delete Mozilla account
   subheadline2:

--- a/src/translations/strings.yaml
+++ b/src/translations/strings.yaml
@@ -228,7 +228,7 @@ notSignedInGoogle:
 # IAP Android edge case 2
 multiFxaAccountError:
   fxaAccountErrorHeader: Problem confirming subscription
-  fxaAccountErrorText: Your subscription is linked to another Firefox Account. You may need to sign in with a different email address.
+  fxaAccountErrorText2: Your subscription is linked to another Mozilla account. You may need to sign in with a different email address.
   visitOurHelpCenter: Visit our help center to learn more about managing your subscriptions.
 
 # IAP Android edge case 3
@@ -247,11 +247,11 @@ restorePurchaseGenericPurchaseError:
 
 # IAP iOS restore expired error
 restorePurchaseExpiredError:
-  restorePurchaseExpiredErrorText: Sorry, we are unable to connect your Firefox Account to a current subscription. Please try again or contact our support team for further assistance.
+  restorePurchaseExpiredErrorText2: Sorry, we are unable to connect your Mozilla account to a current subscription. Please try again or contact our support team for further assistance.
 
 # IAP iOS restore in use error
 restorePurchaseInUseError:
-  restorePurchaseInUseErrorText: Another Firefox Account has already subscribed using this Apple ID. Please sign out and try again or contact our support team for help.
+  restorePurchaseInUseErrorText2: Another Mozilla account has already subscribed using this Apple ID. Please sign out and try again or contact our support team for help.
 
 purchaseWeb:
   title: Subscribe to Mozilla VPN
@@ -588,8 +588,8 @@ inAppAuth:
   emailInputPlaceholder: Enter email
   changeEmailLink: Change email
   signInButton: Sign in
-  signInSubtitle: Continue to Mozilla VPN by signing in with your Firefox account
-  reauthSignInSubtitle: To continue, please confirm with your Firefox account password.
+  signInSubtitle2: Continue to Mozilla VPN by signing in with your Mozilla account
+  reauthSignInSubtitle2: To continue, please confirm with your Mozilla account password.
   createPasswordLabel:
     value: Create password
     comment: This is a label displayed on the password creation screen.
@@ -615,8 +615,8 @@ inAppAuth:
     value: I’d like to receive product update emails from Firefox.
     comment: Checkbox label for users to opt in, when creating an account, to receive product update emails from Firefox.
   createAccountButton: Create account
-  finishAccountCreationDescription:
-    value: Finish creating your Firefox account to continue to Mozilla VPN
+  finishAccountCreationDescription2:
+    value: Finish creating your Mozilla account to continue to Mozilla VPN
     comment: User message prompting user to finish creating their account to use Mozilla VPN.
   emailVerificationDescription:
     value: Open your email and enter the verification code that was sent.
@@ -696,11 +696,10 @@ postAuthentication:
   subtitle: You can quickly access Mozilla VPN from your status bar.
 
 deleteAccount:
-  authSubheadline: To delete your VPN account, please sign in with your Firefox account password.
   authButtonLabel: Continue
-  headline: Delete Firefox account
-  subheadline:
-    value: "Your Firefox account (%1) is connected to Mozilla products that keep you secure and productive on the web. Please acknowledge that by deleting your account:"
+  headline2: Delete Mozilla account
+  subheadline2:
+    value: "Your Mozilla account (%1) is connected to Mozilla products that keep you secure and productive on the web. Please acknowledge that by deleting your account:"
     comment: "%1 is the email address that is associated with the current account"
   optionDescriptionOne:
     value: Any paid subscriptions you have will be cancelled (Except Pocket)

--- a/src/ui/authenticationInApp/ViewAuthenticationSignIn.qml
+++ b/src/ui/authenticationInApp/ViewAuthenticationSignIn.qml
@@ -21,7 +21,7 @@ MZInAppAuthenticationBase {
                 target: authSignIn
 
                 _changeEmailLinkVisible: false
-                _subtitleText: MZI18n.InAppAuthReauthSignInSubtitle
+                _subtitleText: MZI18n.InAppAuthReauthSignInSubtitle2
             }
 
             PropertyChanges {
@@ -51,7 +51,7 @@ MZInAppAuthenticationBase {
     }
     _menuButtonAccessibleName: MZI18n.GlobalGoBack
     _headlineText: MZAuthInApp.emailAddress
-    _subtitleText: MZI18n.InAppAuthSignInSubtitle
+    _subtitleText: MZI18n.InAppAuthSignInSubtitle2
     _imgSource: "qrc:/nebula/resources/avatar.svg"
     _inputLabel: MZI18n.InAppAuthPasswordInputLabel
 

--- a/src/ui/authenticationInApp/ViewAuthenticationSignUp.qml
+++ b/src/ui/authenticationInApp/ViewAuthenticationSignUp.qml
@@ -22,7 +22,7 @@ MZInAppAuthenticationBase {
     }
     _menuButtonAccessibleName: MZI18n.GlobalGoBack
     _headlineText: MZAuthInApp.emailAddress
-    _subtitleText: MZI18n.InAppAuthFinishAccountCreationDescription
+    _subtitleText: MZI18n.InAppAuthFinishAccountCreationDescription2
     _imgSource: "qrc:/nebula/resources/avatar.svg"
     _inputLabel: MZI18n.InAppAuthCreatePasswordLabel
 

--- a/src/ui/deleteAccount/ViewDeleteAccountRequest.qml
+++ b/src/ui/deleteAccount/ViewDeleteAccountRequest.qml
@@ -46,7 +46,7 @@ MZInAppAuthenticationBase {
     _menuButtonOnClick: () => {
         cancelAuthenticationFlow();
     }
-    _headlineText: MZI18n.DeleteAccountHeadline
+    _headlineText: MZI18n.DeleteAccountHeadline2
     _imgSource: "qrc:/nebula/resources/avatar-delete-account.svg"
 
     _inputs: ColumnLayout {
@@ -55,7 +55,7 @@ MZInAppAuthenticationBase {
             objectName: "accountDeletionLabel"
             color: MZTheme.theme.fontColor
             horizontalAlignment: Text.AlignLeft
-            text: MZI18n.DeleteAccountSubheadline
+            text: MZI18n.DeleteAccountSubheadline2
                 .arg("<b style='color:" + MZTheme.theme.fontColorDark + ";'>"
                     + MZAuthInApp.emailAddress + "</b>")
             textFormat: Text.RichText

--- a/src/ui/screens/ScreenSubscriptionBlocked.qml
+++ b/src/ui/screens/ScreenSubscriptionBlocked.qml
@@ -23,8 +23,8 @@ MZStackView {
             // "Problem confirming subscription…"
             headlineText: MZI18n.MultiFxaAccountErrorFxaAccountErrorHeader,
 
-            // "Your subscription is linked to another Firefox Account....."
-            errorMessage: MZI18n.MultiFxaAccountErrorFxaAccountErrorText,
+            // "Your subscription is linked to another Mozilla account....."
+            errorMessage: MZI18n.MultiFxaAccountErrorFxaAccountErrorText2,
 
             errorMessage2:  MZI18n.MultiFxaAccountErrorVisitOurHelpCenter,
 

--- a/src/ui/screens/ScreenSubscriptionBlocked.qml
+++ b/src/ui/screens/ScreenSubscriptionBlocked.qml
@@ -24,7 +24,7 @@ MZStackView {
             headlineText: MZI18n.MultiFxaAccountErrorFxaAccountErrorHeader,
 
             // "Your subscription is linked to another Mozilla account....."
-            errorMessage: MZI18n.MultiFxaAccountErrorFxaAccountErrorText2,
+            errorMessage: MZI18n.MultiFxaAccountErrorMozAccountErrorText,
 
             errorMessage2:  MZI18n.MultiFxaAccountErrorVisitOurHelpCenter,
 

--- a/src/ui/screens/ScreenSubscriptionExpiredError.qml
+++ b/src/ui/screens/ScreenSubscriptionExpiredError.qml
@@ -19,9 +19,9 @@ MZStackView {
            // Problem confirming subscription...
            headlineText: MZI18n.GenericPurchaseErrorGenericPurchaseErrorHeader,
 
-           // Sorry we are unable to connect your Firefox Account to a current subscription.
+           // Sorry we are unable to connect your Mozilla account to a current subscription.
            // Please try again or contact our support team for further assistance.
-           errorMessage: MZI18n.RestorePurchaseExpiredErrorRestorePurchaseExpiredErrorText,
+           errorMessage: MZI18n.RestorePurchaseExpiredErrorRestorePurchaseExpiredErrorText2,
 
            // Try again (Error SubscriptionExpiredError only happens on iOS, so ok to point to ScreenSubscriptionNeeded)
            primaryButtonText: MZI18n.GenericPurchaseErrorGenericPurchaseErrorButton,

--- a/src/ui/screens/ScreenSubscriptionInUseError.qml
+++ b/src/ui/screens/ScreenSubscriptionInUseError.qml
@@ -19,9 +19,9 @@ MZStackView {
            // Problem confirming subscription...
            headlineText: MZI18n.GenericPurchaseErrorGenericPurchaseErrorHeader,
 
-           // Another Firefox Account has already subscribed using this Apple ID.
+           // Another Mozilla account has already subscribed using this Apple ID.
            // Visit our help center below to learn more about how to manage your subscriptions.
-           errorMessage: MZI18n.RestorePurchaseInUseErrorRestorePurchaseInUseErrorText,
+           errorMessage: MZI18n.RestorePurchaseInUseErrorRestorePurchaseInUseErrorText2,
 
            // Sign out
            primaryButtonText: MZI18n.GlobalSignOut,


### PR DESCRIPTION
## Description

- Replaces all (8) in-app instances of "Firefox account" with "Mozilla account"
- `DeleteAccount.AuthSubheadline` was deleted as it is no longer used in-app
- All modified strings were given new string id's

## Reference

[VPN-5117: Update account branding in mozillavpn.xliff](https://mozilla-hub.atlassian.net/browse/VPN-5117)
