### PR TITLE
VPN-5288: Delay deletion of PingSender to avoid the risk of pending events being delivered after deletion

### DIFF
--- a/src/pinghelper.cpp
+++ b/src/pinghelper.cpp
@@ -47,7 +47,7 @@ void PingHelper::start(const QString& serverIpv4Gateway,
   // we happen to be on one of these unlucky devices, create a DnsPingSender
   // instead.
   if (!m_pingSender->isValid()) {
-    delete m_pingSender;
+    m_pingSender->deleteLater();
     m_pingSender = new DnsPingSender(m_source, this);
   }
 
@@ -71,7 +71,7 @@ void PingHelper::stop() {
   logger.debug() << "PingHelper deactivated";
 
   if (m_pingSender) {
-    delete m_pingSender;
+    m_pingSender->deleteLater();
     m_pingSender = nullptr;
   }
 

--- a/src/platforms/windows/windowspingsender.cpp
+++ b/src/platforms/windows/windowspingsender.cpp
@@ -7,6 +7,8 @@
 #include <WS2tcpip.h>
 #include <Windows.h>
 #include <iphlpapi.h>
+#include <winternl.h>
+
 // Note: This important must come after the previous three.
 // clang-format off
 #include <IcmpAPI.h>
@@ -26,7 +28,8 @@ constexpr WORD WindowsPingPayloadSize = sizeof(quint16);
 struct WindowsPingSenderPrivate {
   HANDLE m_handle;
   HANDLE m_event;
-  unsigned char m_buffer[sizeof(ICMP_ECHO_REPLY) + WindowsPingPayloadSize + 8];
+  unsigned char m_buffer[sizeof(ICMP_ECHO_REPLY) + WindowsPingPayloadSize + 8 +
+                         sizeof(IO_STATUS_BLOCK)];
 };
 
 namespace {

--- a/src/serverlatency.cpp
+++ b/src/serverlatency.cpp
@@ -205,7 +205,7 @@ void ServerLatency::stop() {
   m_pingSendTotal = 0;
 
   if (m_pingSender) {
-    delete m_pingSender;
+    m_pingSender->deleteLater();
     m_pingSender = nullptr;
   }
 


### PR DESCRIPTION
## Description

Sentry reports a NULL AV in WindowsPingSender::pingEventReady around the following code, but the absence of some stack frames have made it difficult to determine the exact cause.

```
memcpy(&sequence, replies[i].Data, sizeof(quint16));
emit recvPing(sequence);
```

The pingEventReady slot  is called asynchronously when IcmpSendEcho2Ex's event has been signaled to indicate that the ping has been received. A hunch is that this event was pending in the queue when WindowsPingSender was deleted and was delivered after deletion and while the icmpCleanupHelper thread was concurrently executing. [~QObject destructor docs](https://doc.qt.io/qt-6/qobject.html#dtor.QObject) say that that all signals to the object are disconnected and pending posted events for the objects are removed from the event queue. However, it also recommends that is often safer to use deleteLater in this scenario. 

So this fix uses deleteLater to delete the PingSender, to guarantee deletion after all pending events have been delivered to it. 

This also fixes the size of the replyBuffer, which needs an additional sizeof(IO_STATUS_BLOCK), as specified in the [IcmpSendEcho2Ex docs](https://learn.microsoft.com/en-us/windows/win32/api/icmpapi/nf-icmpapi-icmpsendecho2ex).

## Reference
[VPN-5288](https://mozilla-hub.atlassian.net/browse/VPN-5288), [GitHub 7626](https://github.com/mozilla-mobile/mozilla-vpn-client/issues/7626)
## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-5288]: https://mozilla-hub.atlassian.net/browse/VPN-5288?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ