### PR TITLE
VPN-5650: Wrap "Device type" label in onboarding

### DIFF
--- a/src/ui/screens/onboarding/OnboardingDevicesSlide.qml
+++ b/src/ui/screens/onboarding/OnboardingDevicesSlide.qml
@@ -47,6 +47,7 @@ ColumnLayout {
 
         MZBoldInterLabel {
             Layout.alignment: Qt.AlignVCenter
+            Layout.fillWidth: true
 
             text: MZI18n.OnboardingDevicesSlideDeviceTypeLabel
             font.pixelSize: MZTheme.theme.fontSize


### PR DESCRIPTION
## Description

| Before  | After |
| ------------- | ------------- |
| <img width="472" alt="Screenshot 2023-10-04 at 4 55 38 PM" src="https://github.com/mozilla-mobile/mozilla-vpn-client/assets/15353801/69bf3b38-94aa-4389-afc3-ce43ab639110"> |  <img width="472" alt="Screenshot 2023-10-04 at 4 54 06 PM" src="https://github.com/mozilla-mobile/mozilla-vpn-client/assets/15353801/1a245a70-981c-459d-98b6-86d8ea3f5b93"> |

## Reference

[VPN-5650:  [l10n] “Install Mozilla VPN on up to 5 devices” screen from the new onboarding flow is not wrapped in some languages](https://mozilla-hub.atlassian.net/browse/VPN-5650)
