### PR TITLE
VPN-5559: Scroll to off screen components via keyboard nav

### DIFF
--- a/nebula/ui/components/MZFlickable.qml
+++ b/nebula/ui/components/MZFlickable.qml
@@ -98,15 +98,17 @@ Flickable {
         }
 
         const isItemBehindNavbar = item.mapToItem(window.contentItem, 0, 0).y + item.height > window.height - MZTheme.theme.navBarHeightWithMargins
+        const isItemOffScreen = item.mapToItem(window.contentItem, 0, 0).y + item.height > window.height
         const buffer = navbar.visible && isItemBehindNavbar ? MZTheme.theme.navBarHeightWithMargins : MZTheme.theme.contentBottomMargin
         const itemHeight = Math.max(item.height, MZTheme.theme.rowHeight) + buffer
         let destinationY
 
-        //When focusing on an item behind the navbar in the downward direction, make sure it is not blocked by the navbar
-        if(navbar.visible && isItemBehindNavbar) {
-            const distanceToGetOutFromBehindNavbar = item.mapToItem(window.contentItem, 0, 0).y + item.height - (window.height - buffer)
+        //When focusing on an item either behind the navbar and/or that is partially or fully off screen in the downward direction
+        //scroll to it so that it is visible
+        if((navbar.visible && isItemBehindNavbar) || (!navbar.visible && isItemOffScreen)) {
+            const scrollDistance = item.mapToItem(window.contentItem, 0, 0).y + item.height - (window.height - buffer)
 
-            destinationY = contentY + distanceToGetOutFromBehindNavbar
+            destinationY = contentY + scrollDistance
         }
         else {
             //When focusing on an item that is off screen in the upward direction

--- a/nebula/ui/components/MZSwipeAction.qml
+++ b/nebula/ui/components/MZSwipeAction.qml
@@ -6,6 +6,7 @@ import QtQuick 2.15
 import QtQuick.Controls 2.15
 
 import Mozilla.Shared 1.0
+import "qrc:/nebula/utils/MZUiUtils.js" as MZUiUtils
 
 Rectangle {
     id: swipeAction
@@ -16,6 +17,8 @@ Rectangle {
     color: SwipeDelegate.pressed ? Qt.darker(bgColor, 1.2) : bgColor
     height: parent.height
     width: MZTheme.theme.swipeDelegateActionWidth
+
+    onActiveFocusChanged: MZUiUtils.scrollToComponent(swipeAction)
 
     Accessible.role: Accessible.Button
     Accessible.onPressAction: SwipeDelegate.clicked()


### PR DESCRIPTION
## Description

- When navigating keyboard focus to a component that is either partially or completely off screen in the downward direction, scroll the view downward so that component is fully visible (even when the navbar is not visible)

## Reference

[VPN-5559: [a11y] Some screens from the app are not scrollable when navigating via keyboard](https://mozilla-hub.atlassian.net/browse/VPN-5559)
