### PR TITLE
Miscellaneous onboarding changes

### DIFF
--- a/src/settingslist.h
+++ b/src/settingslist.h
@@ -408,7 +408,7 @@ SETTING_BOOL(postAuthenticationShown,        // getter
              "postAuthenticationShown",      // key
              false,                          // default value
              true,                           // user setting
-             true,                           // remove when reset
+             false,                           // remove when reset
              false                           // sensitive (do not log)
 )
 

--- a/src/settingslist.h
+++ b/src/settingslist.h
@@ -408,7 +408,7 @@ SETTING_BOOL(postAuthenticationShown,        // getter
              "postAuthenticationShown",      // key
              false,                          // default value
              true,                           // user setting
-             false,                           // remove when reset
+             false,                          // remove when reset
              false                           // sensitive (do not log)
 )
 

--- a/src/ui/screens/onboarding/OnboardingPrivacySlide.qml
+++ b/src/ui/screens/onboarding/OnboardingPrivacySlide.qml
@@ -50,6 +50,7 @@ ColumnLayout {
 
     Item {
         Layout.fillHeight: true
+        Layout.minimumHeight: 24
     }
 
     MZButton {

--- a/tests/functional/helper.js
+++ b/tests/functional/helper.js
@@ -352,9 +352,9 @@ module.exports = {
     // Wait for VPN client screen to move from spinning wheel to next screen
     await this.waitForMozillaProperty(
         'Mozilla.VPN', 'VPN', 'userState', 'UserAuthenticated');
-    await this.waitForQuery(queries.screenPostAuthentication.BUTTON.visible());
 
     if (clickOnPostAuthenticate) {
+      await this.waitForQuery(queries.screenPostAuthentication.BUTTON.visible());
       await this.waitForQuery(queries.global.SCREEN_LOADER.ready());
       await this.clickOnQuery(
           queries.screenPostAuthentication.BUTTON.visible());


### PR DESCRIPTION
## Description

- [Deskop only] Don't show post authentication "quick access" screen on every login when the new onboarding experience is not enabled
- Add some padding between content and buttons on privacy slide

## Reference

[VPN-5660: [l10n] “Get more privacy” screen from new onboarding has no padding between the “Next” button and the description above](https://mozilla-hub.atlassian.net/browse/VPN-5660)