### PR TITLE
VPN-5511: Deactivate VPN on hard reset and quit

### DIFF
--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -1292,7 +1292,8 @@ void MozillaVPN::hardReset() {
 void MozillaVPN::hardResetAndQuit() {
   logger.debug() << "Hard reset and quit";
   hardReset();
-  quit();
+  // Deactivate VPN and quit
+  connectionManager()->quit();
 }
 
 void MozillaVPN::requestDeleteAccount() {


### PR DESCRIPTION
## Description

Previously, when a user selected "Reset and Quit" from Developer Options, client settings were cleared, and the client was closed. However, the VPN tunnel was left active and used the old device public key. When the user restarted the client, they were required to re-login, resulting in the generation of a new device key.

If this new device key was not provided to the tunnel within a few minutes, the Mullvad server would drop the connection because the old key was no longer valid. This meant that if the user waited in the post-authentication UI (either the old or new onboarding UI) until Mullvad dropped the connection, the device internet would be lost. To workaround this, the user had to toggle the VPN off and then back on, to deactivate the old tunnel and to activate a new tunnel with the new device key.

The fix deactivates the VPN tunnel when the user selects "Reset and Quit" from Developer Options, matching the "Sign Out" and the System Tray's "Quit VPN" behavior. 

## Reference

[VPN-5511](https://mozilla-hub.atlassian.net/browse/VPN-5511), [GitHub 7974](https://github.com/mozilla-mobile/mozilla-vpn-client/issues/7974)

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-5511]: https://mozilla-hub.atlassian.net/browse/VPN-5511?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ