### PR TITLE
VPN-5643 - Ensure we always use an English backup language

### DIFF
--- a/scripts/addon/build.py
+++ b/scripts/addon/build.py
@@ -438,6 +438,11 @@ with open(args.source, "r", encoding="utf-8") as file:
                 xlifftool_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "utils", "xlifftool.py")
                 xlifftool_cmd = [sys.executable, xlifftool_path, "-C", f"--locale={locale}", xliff_path]
                 xlifftool = subprocess.run(xlifftool_cmd, capture_output=True)
+                # This completeness metric can be out-of-date, sometimes reporting a higher-than-actual completeness after a new string is
+                # added to the app. This happens because the .xliff file doesn't have all the source strings, so an incorrect denomenator is used.
+                # To show up in the .xliff, there must be a complete cycle of a new string being pulled into pontoon (via the `extract new strings`
+                # job being run and merged into the translation repo) and then the VPN repo merging in a new translations commit.
+                # We protect against this by always loading English as a fallback language.
                 completeness_output = xlifftool.stdout.decode("utf-8")
                 completeness.append(f"{locale}:{completeness_output}")
 

--- a/scripts/addon/build.py
+++ b/scripts/addon/build.py
@@ -439,7 +439,7 @@ with open(args.source, "r", encoding="utf-8") as file:
                 xlifftool_cmd = [sys.executable, xlifftool_path, "-C", f"--locale={locale}", xliff_path]
                 xlifftool = subprocess.run(xlifftool_cmd, capture_output=True)
                 # This completeness metric can be out-of-date, sometimes reporting a higher-than-actual completeness after a new string is
-                # added to the app. This happens because the .xliff file doesn't have all the source strings, so an incorrect denomenator is used.
+                # added to the app. This happens because the .xliff file doesn't have all the source strings, so an incorrect denominator is used.
                 # To show up in the .xliff, there must be a complete cycle of a new string being pulled into pontoon (via the `extract new strings`
                 # job being run and merged into the translation repo) and then the VPN repo merging in a new translations commit.
                 # We protect against this by always loading English as a fallback language.

--- a/scripts/addon/build.py
+++ b/scripts/addon/build.py
@@ -440,7 +440,7 @@ with open(args.source, "r", encoding="utf-8") as file:
                 xlifftool = subprocess.run(xlifftool_cmd, capture_output=True)
                 # This completeness metric can be out-of-date, sometimes reporting a higher-than-actual completeness after a new string is
                 # added to the app. This happens because the .xliff file doesn't have all the source strings, so an incorrect denominator is used.
-                # To show up in the .xliff, there must be a complete cycle of a new string being pulled into pontoon (via the `extract new strings`
+                # To show up in the .xliff, there must be a complete cycle of a new string being pulled into Pontoon (via the `extract new strings`
                 # job being run and merged into the translation repo) and then the VPN repo merging in a new translations commit.
                 # We protect against this by always loading English as a fallback language.
                 completeness_output = xlifftool.stdout.decode("utf-8")

--- a/scripts/utils/import_languages.py
+++ b/scripts/utils/import_languages.py
@@ -131,6 +131,11 @@ os.makedirs(gendir, exist_ok=True)
 
 # Step 4
 title("Write the translations.completeness file...")
+# This completeness metric can be out-of-date, sometimes reporting a higher-than-actual completeness after a new string is
+# added to the app. This happens because the .xliff file doesn't have all the source strings, so an incorrect denomenator is used.
+# To show up in the .xliff, there must be a complete cycle of a new string being pulled into pontoon (via the `extract new strings`
+# job being run and merged into the translation repo) and then the VPN repo merging in a new translations commit.
+# We protect against this by always loading English as a fallback language.
 with open(os.path.join(gendir, 'translations.completeness'), 'w') as file:
     for l10n_file in l10n_files:
         file.write(f'{l10n_file["locale"]}:{l10n_file["completeness"]}\n')

--- a/src/addons/addon.cpp
+++ b/src/addons/addon.cpp
@@ -494,12 +494,9 @@ void Addon::retranslate() {
 
   QString localeCode = Localizer::instance()->languageCodeOrSystem();
 
-  double completeness = m_translationCompleteness.value(localeCode, 0);
-  if (completeness < 1) {
-    logger.debug() << "Let's try to load another language as fallback for code"
-                   << localeCode;
-    maybeLoadLanguageFallback(localeCode);
-  }
+  logger.debug() << "Let's try to load another language as fallback for code"
+                 << localeCode;
+  maybeLoadLanguageFallback(localeCode);
 
   QLocale locale = Localizer::instance()->locale();
 

--- a/src/localizer.cpp
+++ b/src/localizer.cpp
@@ -344,12 +344,9 @@ bool Localizer::loadLanguage(const QString& requestedLocalCode) {
     localeCode = systemLanguageCode();
   }
 
-  double completeness = m_translationCompleteness.value(localeCode, 0);
-  if (completeness < 1) {
-    logger.debug() << "Let's try to load another language as fallback for code"
-                   << localeCode;
-    maybeLoadLanguageFallback(localeCode);
-  }
+  logger.debug() << "Let's try to load another language as fallback for code"
+                 << localeCode;
+  maybeLoadLanguageFallback(localeCode);
 
   QLocale locale = QLocale(localeCode);
   QLocale::setDefault(locale);


### PR DESCRIPTION
## Description

We were showing strings like `vpn.inAppAuth.signInSubtitle2` in some languages, but not others. Description of why follows, but the ultimate fix (done in this PR) is to always fall back to English.

- When we load a language's fallback languages, we always load English. But we don't load backup languages when the build believes the translation completeness is 1.0. Which was happening here.
- This completeness comes from a `translations.completeness` file, which we build ourselves.
- The translations.completeness counts the targets (translated string) and sources (English string) in each language's .xliff file (which comes from the translation repo), and uses that ratio to determine the completeness.
- The .xliff file usually has unstranslated strings  as a source.
- However, at the point the bug was filed .xliff didn't have the brand new strings (aka sources), and so it erroneously calculated some languages as 100% translated. (Which explains why the bug was happening only for languages that were fully translated, except for those new strings - as they reported in as 100% translated. Languages that already weren’t fully translated load fallbacks, including the final English fallback.)
- Thus, we should ensure we always fall back to English.

## To test this
1. Checkout the commit that merged the new strings (at this point, there hadn't been a roundtrip to pontoon, so the bug exists): f84b5af2bd5ba57afb1fb71f3b4278e47c697c13
2. Clean your repo (if you don't clean, it will retain the cached newer translations)
3.  run `git submodule update --recursive -f`(make sure you have the translations repo that is missing those strings)
4. Run the app
5. Set app language is Chilean Spanish
6. Most of the new strings are in the onboarding. The easiest place I found to view this problem (and the fix) is in the delete account flow (don't worry, you won't actually delete the account), on the screen where you put in the account password.

## Reference

https://mozilla-hub.atlassian.net/browse/VPN-5643

## Checklist
    
- [X] My code follows the style guidelines for this project
- [X] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [X] I have performed a self review of my own code
- [X] I have commented my code PARTICULARLY in hard to understand areas
- [X] I have added thorough tests where needed
