### PR TITLE
VPN-5492: Some elements in 'Select Location' screen are not read by screen reader

### DIFF
--- a/src/ui/screens/home/ViewMultiHop.qml
+++ b/src/ui/screens/home/ViewMultiHop.qml
@@ -76,7 +76,8 @@ StackView {
 
                 objectName: "buttonSelectEntry"
                 titleText: MZI18n.MultiHopFeatureMultiHopEntryLocationHeader
-                descriptionText: VPNCurrentServer.localizedEntryCityName
+                // The entry server may not be set in VPNCurrentServer.localizedEntryCityName if the user has just switched to the MultiHop screen, so use multiHopEntryServer
+                descriptionText: segmentedNav.multiHopEntryServer[2]
                 contentChildren: [
                     ServerLabel {
                         id: entryLabel
@@ -110,7 +111,7 @@ StackView {
                     objectName: "buttonSelectExit"
                     btnObjectName: "buttonSelectExit-btn"
                     titleText: MZI18n.MultiHopFeatureMultiHopExitLocationHeader
-                    descriptionText: VPNCurrentServer.localizedExitCityName
+                    descriptionText: segmentedNav.multiHopExitServer[2]
                     contentChildren: [
 
                         ServerLabel {

--- a/src/ui/screens/home/ViewMultiHop.qml
+++ b/src/ui/screens/home/ViewMultiHop.qml
@@ -76,7 +76,7 @@ StackView {
 
                 objectName: "buttonSelectEntry"
                 titleText: MZI18n.MultiHopFeatureMultiHopEntryLocationHeader
-                descriptionText: titleText
+                descriptionText: VPNCurrentServer.localizedEntryCityName
                 contentChildren: [
                     ServerLabel {
                         id: entryLabel
@@ -110,7 +110,7 @@ StackView {
                     objectName: "buttonSelectExit"
                     btnObjectName: "buttonSelectExit-btn"
                     titleText: MZI18n.MultiHopFeatureMultiHopExitLocationHeader
-                    descriptionText: titleText
+                    descriptionText: VPNCurrentServer.localizedExitCityName
                     contentChildren: [
 
                         ServerLabel {

--- a/src/ui/screens/home/ViewMultiHop.qml
+++ b/src/ui/screens/home/ViewMultiHop.qml
@@ -76,7 +76,7 @@ StackView {
 
                 objectName: "buttonSelectEntry"
                 titleText: MZI18n.MultiHopFeatureMultiHopEntryLocationHeader
-                // The entry server may not be set in VPNCurrentServer.localizedEntryCityName if the user has just switched to the MultiHop screen, so use multiHopEntryServer
+                // If the current VPN configuration is single hop, VPNCurrentServer.localizedEntryCityName will be empty, so use multiHopEntryServer
                 descriptionText: segmentedNav.multiHopEntryServer[2]
                 contentChildren: [
                     ServerLabel {

--- a/src/ui/screens/home/ViewServers.qml
+++ b/src/ui/screens/home/ViewServers.qml
@@ -61,6 +61,8 @@ Item {
     MZSegmentedNavigation {
         id: segmentedNav
 
+        // If the current VPN configuration is single hop, the Entry server values of VPNCurrentServer will be empty, and multiHopEntryServer will be
+        // set to a recommended server in handleSegmentClick
         property var multiHopEntryServer: [VPNCurrentServer.entryCountryCode, VPNCurrentServer.entryCityName, VPNCurrentServer.localizedEntryCityName]
         property var multiHopExitServer: [VPNCurrentServer.exitCountryCode, VPNCurrentServer.exitCityName, VPNCurrentServer.localizedExitCityName]
 

--- a/src/ui/screens/home/servers/ServerList.qml
+++ b/src/ui/screens/home/servers/ServerList.qml
@@ -178,7 +178,7 @@ FocusScope {
                             leftMargin: MZTheme.theme.windowMargin * 0.5
                             rightMargin: MZTheme.theme.windowMargin * 0.5
                         }
-                        accessibleName: MZI18n.ServersViewRecommendedRefreshLabel
+                        accessibleName: statusTitle.text + '. ' + MZI18n.ServersViewRecommendedRefreshLabel
                         canGrowVertical: true
                         height: statusTitle.implicitHeight + MZTheme.theme.vSpacingSmall
                         rowShouldBeDisabled: !(VPNController.state === VPNController.StateOff) || VPNServerLatency.isActive


### PR DESCRIPTION
## Description

Some elements in the 'Select Location' screen did not have the correct Accessible names.

## Reference

[VPN-5492](https://mozilla-hub.atlassian.net/browse/VPN-5492), [GitHub 7952](https://github.com/mozilla-mobile/mozilla-vpn-client/issues/7952)

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-5492]: https://mozilla-hub.atlassian.net/browse/VPN-5492?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ