### PR TITLE
VPN-5688: Prevent VPN activation when completing onboarding

### DIFF
--- a/src/connectionmanager.cpp
+++ b/src/connectionmanager.cpp
@@ -687,6 +687,9 @@ void ConnectionManager::resetConnectedTime() {
 void ConnectionManager::disconnected() {
   logger.debug() << "Disconnected from state:" << m_state;
 
+  m_pingCanary.stop();
+  m_handshakeTimer.stop();
+  m_activationQueue.clear();
   clearConnectedTime();
   clearRetryCounter();
 

--- a/src/platforms/android/androidcontroller.cpp
+++ b/src/platforms/android/androidcontroller.cpp
@@ -102,10 +102,11 @@ AndroidController::AndroidController() {
       Qt::QueuedConnection);
   connect(
       activity, &AndroidVPNActivity::eventOnboardingCompleted, this,
-      []() {
+      [this]() {
         auto vpn = MozillaVPN::instance();
         if (vpn->state() == App::StateOnboarding) {
           vpn->onboardingCompleted();
+          emit disconnected();
         }
       },
       Qt::QueuedConnection);

--- a/src/platforms/ios/ioscontroller.mm
+++ b/src/platforms/ios/ioscontroller.mm
@@ -154,8 +154,8 @@ void IOSController::activate(const InterfaceConfig& config, ConnectionManager::R
       isSuperDooperFeatureActive:Feature::get(Feature::Feature_superDooperMetrics)->isSupported()
                   installationId:config.m_installationId.toNSString()
                   isOnboarding:MozillaVPN::instance()->state() == App::StateOnboarding
-                 failureCallback:^() {
-                   logger.error() << "IOSSWiftController - connection failed";
+                 disconnectCallback:^() {
+                   logger.error() << "IOSSWiftController - disconnecting";
                    emit disconnected();
                  }
                 onboardingCompletedCallback:^() {

--- a/src/platforms/ios/ioscontroller.swift
+++ b/src/platforms/ios/ioscontroller.swift
@@ -116,7 +116,7 @@ public class IOSControllerImpl : NSObject {
         }
     }
 
-    @objc func connect(dnsServer: String, serverIpv6Gateway: String, serverPublicKey: String, serverIpv4AddrIn: String, serverPort: Int,  allowedIPAddressRanges: Array<VPNIPAddressRange>, reason: Int, gleanDebugTag: String, isSuperDooperFeatureActive: Bool, installationId: String, isOnboarding: Bool, failureCallback: @escaping () -> Void, onboardingCompletedCallback: @escaping () -> Void) {
+    @objc func connect(dnsServer: String, serverIpv6Gateway: String, serverPublicKey: String, serverIpv4AddrIn: String, serverPort: Int,  allowedIPAddressRanges: Array<VPNIPAddressRange>, reason: Int, gleanDebugTag: String, isSuperDooperFeatureActive: Bool, installationId: String, isOnboarding: Bool, disconnectCallback: @escaping () -> Void, onboardingCompletedCallback: @escaping () -> Void) {
         IOSControllerImpl.logger.debug(message: "Connecting")
 
         let _ = TunnelManager.withTunnel { tunnel in
@@ -152,11 +152,11 @@ public class IOSControllerImpl : NSObject {
 
             let config = TunnelConfiguration(name: VPN_NAME, interface: interface, peers: peerConfigurations)
 
-            return self.configureTunnel(config: config, reason: reason, serverName: serverIpv4AddrIn + ":\(serverPort )", gleanDebugTag: gleanDebugTag, isSuperDooperFeatureActive: isSuperDooperFeatureActive, installationId: installationId, isOnboarding: isOnboarding, failureCallback: failureCallback, onboardingCompletedCallback: onboardingCompletedCallback)
+            return self.configureTunnel(config: config, reason: reason, serverName: serverIpv4AddrIn + ":\(serverPort )", gleanDebugTag: gleanDebugTag, isSuperDooperFeatureActive: isSuperDooperFeatureActive, installationId: installationId, isOnboarding: isOnboarding, disconnectCallback: disconnectCallback, onboardingCompletedCallback: onboardingCompletedCallback)
         }
     }
 
-    func configureTunnel(config: TunnelConfiguration, reason: Int, serverName: String, gleanDebugTag: String, isSuperDooperFeatureActive: Bool, installationId: String, isOnboarding: Bool, failureCallback: @escaping () -> Void, onboardingCompletedCallback: @escaping () -> Void) {
+    func configureTunnel(config: TunnelConfiguration, reason: Int, serverName: String, gleanDebugTag: String, isSuperDooperFeatureActive: Bool, installationId: String, isOnboarding: Bool, disconnectCallback: @escaping () -> Void, onboardingCompletedCallback: @escaping () -> Void) {
         let _ = TunnelManager.withTunnel { tunnel in
             let proto = NETunnelProviderProtocol(tunnelConfiguration: config)
             proto!.providerBundleIdentifier = TunnelManager.vpnBundleId
@@ -187,7 +187,7 @@ public class IOSControllerImpl : NSObject {
             return tunnel.saveToPreferences { saveError in
                 if let error = saveError {
                     IOSControllerImpl.logger.error(message: "Connect Tunnel Save Error: \(error)")
-                    failureCallback()
+                    disconnectCallback()
                     if isOnboarding {
                         IOSControllerImpl.logger.info(message: "Finishing onboarding, but saving tunnel resulted in error...")
                         onboardingCompletedCallback()
@@ -200,7 +200,7 @@ public class IOSControllerImpl : NSObject {
                 //Used to create a VPN configuration without connecting during onboarding
                 if isOnboarding {
                     IOSControllerImpl.logger.info(message: "Finishing onboarding... do not turn on the VPN after gaining permission")
-                    failureCallback()
+                    disconnectCallback()
                     onboardingCompletedCallback()
                     return
                 }
@@ -208,7 +208,7 @@ public class IOSControllerImpl : NSObject {
                tunnel.loadFromPreferences { error in
                     if let error = error {
                         IOSControllerImpl.logger.error(message: "Connect Tunnel Load Error: \(error)")
-                        failureCallback()
+                        disconnectCallback()
                         return
                     }
 
@@ -225,7 +225,7 @@ public class IOSControllerImpl : NSObject {
                         }
                     } catch let error {
                         IOSControllerImpl.logger.error(message: "Something went wrong: \(error)")
-                        failureCallback()
+                        disconnectCallback()
                         return
                     }
                 }

--- a/src/platforms/ios/ioscontroller.swift
+++ b/src/platforms/ios/ioscontroller.swift
@@ -200,6 +200,7 @@ public class IOSControllerImpl : NSObject {
                 //Used to create a VPN configuration without connecting during onboarding
                 if isOnboarding {
                     IOSControllerImpl.logger.info(message: "Finishing onboarding... do not turn on the VPN after gaining permission")
+                    failureCallback()
                     onboardingCompletedCallback()
                     return
                 }

--- a/src/platforms/ios/ioscontroller.swift
+++ b/src/platforms/ios/ioscontroller.swift
@@ -195,15 +195,7 @@ public class IOSControllerImpl : NSObject {
                     return
                 }
 
-                IOSControllerImpl.logger.info(message: "Saving the tunnel succeeded")
-                
-                //Used to create a VPN configuration without connecting during onboarding
-                if isOnboarding {
-                    IOSControllerImpl.logger.info(message: "Finishing onboarding... do not turn on the VPN after gaining permission")
-                    disconnectCallback()
-                    onboardingCompletedCallback()
-                    return
-                }
+               IOSControllerImpl.logger.info(message: "Saving the tunnel succeeded")
 
                tunnel.loadFromPreferences { error in
                     if let error = error {
@@ -212,7 +204,15 @@ public class IOSControllerImpl : NSObject {
                         return
                     }
 
-                   IOSControllerImpl.logger.info(message: "Loading the tunnel succeeded")
+                    IOSControllerImpl.logger.info(message: "Loading the tunnel succeeded")
+
+                    // Used to create a VPN configuration without connecting during onboarding
+                    if isOnboarding {
+                        IOSControllerImpl.logger.info(message: "Finishing onboarding... do not turn on the VPN after gaining permission")
+                        disconnectCallback()
+                        onboardingCompletedCallback()
+                        return
+                    }
 
                     do {
                         if (reason == 1 /* ReasonSwitching */) {

--- a/src/telemetry.cpp
+++ b/src/telemetry.cpp
@@ -219,7 +219,8 @@ void Telemetry::initialize() {
       connectionManager, &ConnectionManager::controllerDisconnected, this,
       [this, connectionManager]() {
         if (Feature::get(Feature::Feature_superDooperMetrics)->isSupported()) {
-          if (connectionManager->state() == ConnectionManager::StateOff) {
+          if (connectionManager->state() == ConnectionManager::StateOff &&
+              SettingsHolder::instance()->onboardingCompleted()) {
             mozilla::glean::session::session_end.set();
 
             mozilla::glean_pings::Vpnsession.submit("end");


### PR DESCRIPTION
## Description

- After allowing the system to create a VPN configuration at the end of the mobile onboarding flow, prevent the controller from re-attempting to connect
- iOS and Android only

## Reference

[VPN-5688: Client is turned ON when the user allows to create a VPN connection](https://mozilla-hub.atlassian.net/browse/VPN-5688)
