### PR TITLE
VPN-5697 - Allow account deletion on Android

### DIFF
--- a/nebula/ui/components/inAppAuth/MZInAppAuthenticationBase.qml
+++ b/nebula/ui/components/inAppAuth/MZInAppAuthenticationBase.qml
@@ -14,6 +14,7 @@ import components.forms 0.1
 MZFlickable {
     property var _menuButtonOnClick
     property bool _changeEmailLinkVisible: false
+    property bool _disclaimersVisible: true
     property string _viewObjectName: ""
 
     property alias _menuButtonImageSource: menuButtonImage.source
@@ -142,6 +143,7 @@ MZFlickable {
 
                 MZSubtitle {
                     id: subtitle
+                    visible: _subtitleText.length > 0
                     width: undefined
                     Layout.fillWidth: true
                 }
@@ -150,6 +152,7 @@ MZFlickable {
 
             MZBoldLabel {
                 id: inputLabel
+                visible: inputLabel.text.length > 0
             }
 
             ColumnLayout {
@@ -160,6 +163,7 @@ MZFlickable {
 
         ColumnLayout {
             id: disclaimers
+            visible: _disclaimersVisible
             Layout.maximumWidth: col.width - MZTheme.theme.vSpacing * 2
             Layout.leftMargin: MZTheme.theme.vSpacing
             Layout.rightMargin: MZTheme.theme.vSpacing

--- a/src/cmake/android.cmake
+++ b/src/cmake/android.cmake
@@ -51,6 +51,7 @@ set_property(TARGET mozillavpn PROPERTY QT_ANDROID_EXTRA_LIBS
     ${Qt6_DIR}/../../libQt6Widgets_${ANDROID_ABI}.so
     ${Qt6_DIR}/../../libQt6Xml_${ANDROID_ABI}.so
     ${Qt6_DIR}/../../libQt6Test_${ANDROID_ABI}.so
+    ${Qt6_DIR}/../../libQt6Svg_${ANDROID_ABI}.so
      ## --- END PILE OF SHAME --- ##
     
     ${OPENSSL_LIBS_DIR}/libcrypto.so

--- a/src/featurelist.h
+++ b/src/featurelist.h
@@ -17,7 +17,7 @@ FEATURE(accountDeletion,        // Feature ID
         FeatureCallback_true,   // Can be flipped on
         FeatureCallback_false,  // Can be flipped off
         QStringList(),          // feature dependencies
-        FeatureCallback_accountDeletion)
+        FeatureCallback_iosOrAndroid)
 
 FEATURE(addon,                 // Feature ID
         "Addon support",       // Feature name

--- a/src/featurelistcallback.h
+++ b/src/featurelistcallback.h
@@ -48,14 +48,6 @@ bool FeatureCallback_sentry() {
 #endif
 }
 
-bool FeatureCallback_accountDeletion() {
-#if defined(MZ_IOS)
-  return true;
-#else
-  return false;
-#endif
-}
-
 bool FeatureCallback_captivePortal() {
 #if defined(MZ_LINUX) || defined(MZ_MACOS) || defined(MZ_WINDOWS) || \
     defined(MZ_DUMMY) || defined(MZ_WASM)

--- a/src/ui/deleteAccount/ViewDeleteAccountRequest.qml
+++ b/src/ui/deleteAccount/ViewDeleteAccountRequest.qml
@@ -64,7 +64,7 @@ MZInAppAuthenticationBase {
             font.pixelSize: MZTheme.theme.fontSize
 
             Layout.fillWidth: true
-            Layout.bottomMargin: MZTheme.theme.vSpacingSmall
+            Layout.bottomMargin: MZTheme.theme.listSpacing
         }
 
         Repeater {
@@ -103,7 +103,6 @@ MZInAppAuthenticationBase {
         MZLinkButton {
             Layout.fillWidth: true
 
-            fontName: MZTheme.theme.fontFamily
             // Cancel
             labelText: MZI18n.InAppSupportWorkflowSupportSecondaryActionText
             onClicked: {

--- a/src/ui/deleteAccount/ViewDeleteAccountRequest.qml
+++ b/src/ui/deleteAccount/ViewDeleteAccountRequest.qml
@@ -39,6 +39,7 @@ MZInAppAuthenticationBase {
     property bool allowAccountDeletion: false
 
     _changeEmailLinkVisible: false
+    _disclaimersVisible: false
     _viewObjectName: "authDeleteAccountRequest"
     _menuButtonAccessibleName: MZI18n.GlobalGoBack
     _menuButtonImageSource: "qrc:/nebula/resources/back.svg"
@@ -51,6 +52,7 @@ MZInAppAuthenticationBase {
 
     _inputs: ColumnLayout {
         objectName: "accountDeletionLayout"
+        spacing: MZTheme.theme.vSpacingSmall
         MZTextBlock {
             objectName: "accountDeletionLabel"
             color: MZTheme.theme.fontColor
@@ -59,9 +61,10 @@ MZInAppAuthenticationBase {
                 .arg("<b style='color:" + MZTheme.theme.fontColorDark + ";'>"
                     + MZAuthInApp.emailAddress + "</b>")
             textFormat: Text.RichText
+            font.pixelSize: MZTheme.theme.fontSize
 
             Layout.fillWidth: true
-            Layout.bottomMargin: MZTheme.theme.vSpacing
+            Layout.bottomMargin: MZTheme.theme.vSpacingSmall
         }
 
         Repeater {
@@ -100,10 +103,9 @@ MZInAppAuthenticationBase {
         MZLinkButton {
             Layout.fillWidth: true
 
-            fontName: MZTheme.theme.fontBoldFamily
+            fontName: MZTheme.theme.fontFamily
             // Cancel
             labelText: MZI18n.InAppSupportWorkflowSupportSecondaryActionText
-            linkColor: MZTheme.theme.redLinkButton
             onClicked: {
                 cancelAuthenticationFlow();
             }


### PR DESCRIPTION
## Description

This was already implemented on iOS, so this was essentially just turning on the feature for Android. However, there were also some requests to improve the formatting and colors and spacing, so that is the bulk of this PR.

- The formatting changes: Better spacing, more consistent font sizes, blue button color for the "Cancel" button.
- Hiding elements w/ no content is to remove the additional spacing they were providing.
- The addition to `android.cmake` (`${Qt6_DIR}/../../libQt6Svg_${ANDROID_ABI}.so`) is due to a note a few lines above what I added (along with a build error I experienced): `android-deploy-qt is bad and randomly decides to not deploy some lib's we are linking to. So as long as qt is behaving bad, let's force the deployment. Feel free to add libs that are breaking on your build locally.`

Mocks: https://www.figma.com/file/CIelhzmFVyDqn6gNvMXolc/Subscription-Management-In-App?type=design&node-id=2375-1618&mode=design&t=xmGujHUgHm1ldZDW-0

### Before (cut off the red Cancel button, sorry)
<img src="https://github.com/mozilla-mobile/mozilla-vpn-client/assets/9295855/8206b637-f665-40a9-9412-f52678a22607" width=200>

### After
<img src="https://github.com/mozilla-mobile/mozilla-vpn-client/assets/9295855/a2164c48-441d-4b8a-a6ff-3cf208d90e0b" width=200>
<img src="https://github.com/mozilla-mobile/mozilla-vpn-client/assets/9295855/bfde53a1-b297-4dd9-aec5-a7f56054489e" width=200>


## Reference

https://mozilla-hub.atlassian.net/browse/VPN-5697

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
