### PR TITLE
VPN-5520: Decouple data collection checkbox from setting during onboarding

### DIFF
--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -919,14 +919,6 @@ void MozillaVPN::mainWindowLoaded() {
 void MozillaVPN::onboardingCompleted() {
   SettingsHolder* settingsHolder = SettingsHolder::instance();
 
-  // Set glean based on data collection checkbox checked state
-  // Extracting this property from QML seems like the best approach to avoid
-  // creating a disposable member variable or setting
-  QObject* dataCollectionCheckbox =
-      InspectorUtils::queryObject("//dataCollectionCheckBox");
-  settingsHolder->setGleanEnabled(
-      dataCollectionCheckbox->property("isChecked").toBool());
-
   if (Feature::get(Feature::Feature_newOnboarding)->isSupported()) {
     logger.debug() << "onboarding completed";
     settingsHolder->setOnboardingCompleted(true);
@@ -936,7 +928,12 @@ void MozillaVPN::onboardingCompleted() {
     // will never see onboarding again
     settingsHolder->setOnboardingStep(0);
 
-    // Mark the old onboarding expereince as completed as well, ensuring that
+    // Toggle glean on or off at the end of onboarding, depending on what the
+    // user selected
+    settingsHolder->setGleanEnabled(
+        settingsHolder->onboardingDataCollectionEnabled());
+
+    // Mark the old onboarding experience as completed as well, ensuring that
     // users do not have to go through it if the new onboaring feature is turned
     // off
     settingsHolder->setPostAuthenticationShown(true);

--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -823,7 +823,6 @@ bool MozillaVPN::checkCurrentDevice() {
 }
 
 void MozillaVPN::logout() {
-  SettingsHolder::instance()->setOnboardingCompleted(false);
   logger.debug() << "Logout";
 
   ErrorHandler::instance()->requestAlert(ErrorHandler::LogoutAlert);

--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -920,9 +920,13 @@ void MozillaVPN::mainWindowLoaded() {
 void MozillaVPN::onboardingCompleted() {
   SettingsHolder* settingsHolder = SettingsHolder::instance();
 
-  //Set glean based on data collection checkbox checked state
-  QObject* dataCollectionCheckbox = InspectorUtils::queryObject("//dataCollectionCheckBox");
-  settingsHolder->setGleanEnabled(dataCollectionCheckbox->property("isChecked").toBool());
+  // Set glean based on data collection checkbox checked state
+  // Extracting this property from QML seems like the best approach to avoid
+  // creating a disposable member variable or setting
+  QObject* dataCollectionCheckbox =
+      InspectorUtils::queryObject("//dataCollectionCheckBox");
+  settingsHolder->setGleanEnabled(
+      dataCollectionCheckbox->property("isChecked").toBool());
 
   if (Feature::get(Feature::Feature_newOnboarding)->isSupported()) {
     logger.debug() << "onboarding completed";

--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -21,7 +21,6 @@
 #include "glean/mzglean.h"
 #include "i18nstrings.h"
 #include "inspector/inspectorhandler.h"
-#include "inspector/inspectorutils.h"
 #include "leakdetector.h"
 #include "logger.h"
 #include "loghandler.h"
@@ -923,11 +922,6 @@ void MozillaVPN::onboardingCompleted() {
     logger.debug() << "onboarding completed";
     settingsHolder->setOnboardingCompleted(true);
 
-    // Resetting for the benefit of testing so that we only have to reset one
-    // setting (onboardingCompleted) manually. No real affect on user since they
-    // will never see onboarding again
-    settingsHolder->setOnboardingStep(0);
-
     // Toggle glean on or off at the end of onboarding, depending on what the
     // user selected
     settingsHolder->setGleanEnabled(
@@ -937,6 +931,12 @@ void MozillaVPN::onboardingCompleted() {
     // users do not have to go through it if the new onboaring feature is turned
     // off
     settingsHolder->setPostAuthenticationShown(true);
+
+    // Resetting for the benefit of testing so that we only have to reset one
+    // setting (onboardingCompleted) manually. No real affect on user since they
+    // *should* never see onboarding more than once
+    settingsHolder->setOnboardingStep(0);
+    settingsHolder->setOnboardingDataCollectionEnabled(false);
 
   } else {
     logger.debug() << "telemetry policy completed";

--- a/src/settingslist.h
+++ b/src/settingslist.h
@@ -379,6 +379,17 @@ SETTING_BOOL(onboardingCompleted,        // getter
              false                       // sensitive (do not log)
 )
 
+SETTING_BOOL(onboardingDataCollectionEnabled,        // getter
+             setOnboardingDataCollectionEnabled,     // setter
+             removeOnboardingDataCollectionEnabled,  // remover
+             hasOnboardingDataCollectionEnabled,     // has
+             "onboardingDataCollectionEnabled",      // key
+             false,                                  // default value
+             false,                                  // user setting
+             false,                                  // remove when reset
+             false                                   // sensitive (do not log)
+)
+
 SETTING_INT(onboardingStep,        // getter
             setOnboardingStep,     // setter
             removeOnboardingStep,  // remover

--- a/src/settingslist.h
+++ b/src/settingslist.h
@@ -368,17 +368,6 @@ SETTING_STRINGLIST(missingApps,        // getter
                    false               // sensitive (do not log)
 )
 
-SETTING_BOOL(onboardingStarted,        // getter
-             setOnboardingStarted,     // setter
-             removeOnboardingStarted,  // remover
-             hasOnboardingStarted,     // has
-             "onboardingStarted",      // key
-             false,                    // default value
-             false,                    // user setting
-             false,                    // remove when reset
-             false                     // sensitive (do not log)
-)
-
 SETTING_BOOL(onboardingCompleted,        // getter
              setOnboardingCompleted,     // setter
              removeOnboardingCompleted,  // remover

--- a/src/ui/screens/onboarding/OnboardingDataSlide.qml
+++ b/src/ui/screens/onboarding/OnboardingDataSlide.qml
@@ -65,8 +65,9 @@ ColumnLayout {
         leftMargin: 0
         subLabelText: MZI18n.OnboardingDataSlideCheckboxLabel
         showDivider: false
+        isChecked: MZSettings.onboardingDataCollectionEnabled
 
-        onClicked: isChecked = !isChecked
+        onClicked: MZSettings.onboardingDataCollectionEnabled = !MZSettings.onboardingDataCollectionEnabled
     }
 
     Item {

--- a/src/ui/screens/onboarding/OnboardingDataSlide.qml
+++ b/src/ui/screens/onboarding/OnboardingDataSlide.qml
@@ -55,19 +55,18 @@ ColumnLayout {
     }
 
     MZCheckBoxRow {
+        id: dataCollectionCheckBox
         objectName: "dataCollectionCheckBox"
 
         Layout.leftMargin: MZTheme.theme.windowMargin * 2
         Layout.rightMargin: MZTheme.theme.windowMargin * 2
         Layout.fillWidth: true
 
-        subLabelText: MZI18n.OnboardingDataSlideCheckboxLabel
         leftMargin: 0
-        isChecked: MZSettings.gleanEnabled
+        subLabelText: MZI18n.OnboardingDataSlideCheckboxLabel
         showDivider: false
-        onClicked: {
-            MZSettings.gleanEnabled = !MZSettings.gleanEnabled
-       }
+
+        onClicked: isChecked = !isChecked
     }
 
     Item {

--- a/src/ui/screens/onboarding/OnboardingDataSlide.qml
+++ b/src/ui/screens/onboarding/OnboardingDataSlide.qml
@@ -55,7 +55,6 @@ ColumnLayout {
     }
 
     MZCheckBoxRow {
-        id: dataCollectionCheckBox
         objectName: "dataCollectionCheckBox"
 
         Layout.leftMargin: MZTheme.theme.windowMargin * 2

--- a/tests/functional/testOnboarding.js
+++ b/tests/functional/testOnboarding.js
@@ -89,6 +89,8 @@ describe('Onboarding', function() {
     //Clicks block trackers checkbox
     await vpn.waitForQueryAndClick(queries.screenOnboarding.PRIVACY_BLOCK_MALWARE_CHECKBOX.visible());
     assert.equal(await vpn.getQueryProperty(queries.screenOnboarding.PRIVACY_BLOCK_MALWARE_CHECKBOX, 'checked'), 'true');
+    //dnsProviderFlags is a bitfield mapping of hex flags that can handle bitwise operations to combine multiple flags
+    //here, we combine blockAds (0x02), blockTrackers (0x04), and blockMalware (0x08) which totals to 0xE or 14 in decimal
     assert.equal(await vpn.getSetting('dnsProviderFlags'), 14);
 
     //Test back button

--- a/tests/functional/testOnboarding.js
+++ b/tests/functional/testOnboarding.js
@@ -103,7 +103,6 @@ describe('Onboarding', function() {
     assert.equal(await vpn.getSetting('onboardingStep'), 2);
 
     //Switch between toggle buttons
-    console.log(await vpn.getQueryProperty(queries.screenOnboarding.DEVICES_DEVICE_TYPE_TOGGLE.visible(), 'selectedIndex'))
     if (await vpn.getQueryProperty(queries.screenOnboarding.DEVICES_DEVICE_TYPE_TOGGLE.visible(), 'selectedIndex') === 0) {
       //Starting with Android - switch to iOS and back to Android
       await vpn.waitForQueryAndClick(queries.screenOnboarding.DEVICES_TOGGLE_BTN_IOS.visible());
@@ -282,6 +281,24 @@ describe('Onboarding', function() {
   });
 
   it.only('Verify data collection checkbox and setting are decoupled', async () => {
+
+    //This function completes onboarding, and checks that the gleanEnabled setting remains enabled throughout the flow
+    async function completeOnboarding() {
+      await vpn.waitForQueryAndClick(queries.screenOnboarding.DATA_NEXT_BUTTON.visible());
+      await vpn.waitForQuery(queries.screenOnboarding.STEP_NAV_STACK_VIEW.ready());
+      assert.equal(await vpn.getSetting('gleanEnabled'), true);
+      await vpn.waitForQueryAndClick(queries.screenOnboarding.PRIVACY_NEXT_BUTTON.visible());
+      await vpn.waitForQuery(queries.screenOnboarding.STEP_NAV_STACK_VIEW.ready());
+      assert.equal(await vpn.getSetting('gleanEnabled'), true);
+      await vpn.waitForQueryAndClick(queries.screenOnboarding.DEVICES_NEXT_BUTTON.visible());
+      await vpn.waitForQuery(queries.screenOnboarding.STEP_NAV_STACK_VIEW.ready());
+      assert.equal(await vpn.getSetting('gleanEnabled'), true);
+      await vpn.waitForQueryAndClick(queries.screenOnboarding.START_NEXT_BUTTON.visible());
+      await vpn.waitForQuery(queries.screenHome.SCREEN.visible());
+      assert.equal(await vpn.getSetting('onboardingCompleted'), true);
+    }
+
+    //Ensure we are in onboarding
     await vpn.waitForQuery(queries.screenOnboarding.DATA_SLIDE.visible());
 
     //Ensure that the data collection checkbox and internal setting are decoupled
@@ -295,19 +312,8 @@ describe('Onboarding', function() {
     assert.equal(await vpn.getQueryProperty(queries.screenOnboarding.DATA_CHECKBOX, 'isChecked'), 'false');
     assert.equal(await vpn.getSetting('gleanEnabled'), true);
 
-    //Complete onboarding, and check that the gleanEnabled setting does not change between steps until onboarding is completed
-    await vpn.waitForQueryAndClick(queries.screenOnboarding.DATA_NEXT_BUTTON.visible());
-    await vpn.waitForQuery(queries.screenOnboarding.STEP_NAV_STACK_VIEW.ready());
-    assert.equal(await vpn.getSetting('gleanEnabled'), true);
-    await vpn.waitForQueryAndClick(queries.screenOnboarding.PRIVACY_NEXT_BUTTON.visible());
-    await vpn.waitForQuery(queries.screenOnboarding.STEP_NAV_STACK_VIEW.ready());
-    assert.equal(await vpn.getSetting('gleanEnabled'), true);
-    await vpn.waitForQueryAndClick(queries.screenOnboarding.DEVICES_NEXT_BUTTON.visible());
-    await vpn.waitForQuery(queries.screenOnboarding.STEP_NAV_STACK_VIEW.ready());
-    assert.equal(await vpn.getSetting('gleanEnabled'), true);
-    await vpn.waitForQueryAndClick(queries.screenOnboarding.START_NEXT_BUTTON.visible());
-    await vpn.waitForQuery(queries.screenHome.SCREEN.visible());
-    assert.equal(await vpn.getSetting('onboardingCompleted'), true);
+    //Complete onboarding, and check that the gleanEnabled setting remains enabled throughout onboarding
+    await completeOnboarding();
 
     //Now that onboarding is complete, make sure the gleanEnabled setting is now disabled
     assert.equal(await vpn.getSetting('gleanEnabled'), false);
@@ -328,19 +334,8 @@ describe('Onboarding', function() {
     assert.equal(await vpn.getQueryProperty(queries.screenOnboarding.DATA_CHECKBOX, 'isChecked'), 'true');
     assert.equal(await vpn.getSetting('gleanEnabled'), true);
 
-    //Complete onboarding, and check that the gleanEnabled setting does not change between steps
-    await vpn.waitForQueryAndClick(queries.screenOnboarding.DATA_NEXT_BUTTON.visible());
-    await vpn.waitForQuery(queries.screenOnboarding.STEP_NAV_STACK_VIEW.ready());
-    assert.equal(await vpn.getSetting('gleanEnabled'), true);
-    await vpn.waitForQueryAndClick(queries.screenOnboarding.PRIVACY_NEXT_BUTTON.visible());
-    await vpn.waitForQuery(queries.screenOnboarding.STEP_NAV_STACK_VIEW.ready());
-    assert.equal(await vpn.getSetting('gleanEnabled'), true);
-    await vpn.waitForQueryAndClick(queries.screenOnboarding.DEVICES_NEXT_BUTTON.visible());
-    await vpn.waitForQuery(queries.screenOnboarding.STEP_NAV_STACK_VIEW.ready());
-    assert.equal(await vpn.getSetting('gleanEnabled'), true);
-    await vpn.waitForQueryAndClick(queries.screenOnboarding.START_NEXT_BUTTON.visible());
-    await vpn.waitForQuery(queries.screenHome.SCREEN.visible());
-    assert.equal(await vpn.getSetting('onboardingCompleted'), true);
+    //Complete onboarding, and check that the gleanEnabled setting remains enabled throughout onboarding
+    await completeOnboarding();
 
     //Now that onboarding is complete, make sure the gleanEnabled setting is still enabled
     assert.equal(await vpn.getSetting('gleanEnabled'), true);

--- a/tests/functional/testOnboarding.js
+++ b/tests/functional/testOnboarding.js
@@ -299,8 +299,8 @@ describe('Onboarding', function() {
     assert.equal(await vpn.getSetting('onboardingStep'), 3);
   });
 
-  //Tests that the data collection checkbox is bound to onboardingDataCollectionEnabled, and it's default state
-  it('Data collection checkbox default and binding', async () => {
+  it('Complete onboarding with data collection disabled', async () => {
+
     //Ensure we are in onboarding
     await vpn.waitForQuery(queries.screenOnboarding.DATA_SLIDE.visible());
 
@@ -310,18 +310,6 @@ describe('Onboarding', function() {
     assert.equal(await vpn.getSetting('onboardingDataCollectionEnabled'), false);
     assert.equal(await vpn.getSetting('gleanEnabled'), true);
 
-    await vpn.waitForQueryAndClick(queries.screenOnboarding.DATA_CHECKBOX.visible());
-    assert.equal(await vpn.getQueryProperty(queries.screenOnboarding.DATA_CHECKBOX, 'isChecked'), 'true');
-    assert.equal(await vpn.getSetting('onboardingDataCollectionEnabled'), true);
-    assert.equal(await vpn.getSetting('gleanEnabled'), true);
-  });
-
-  //Tests completing onboarding with the data collection checkbox disabled
-  it('Complete onboarding with data collection disabled', async () => {
-
-    //Ensure we are in onboarding
-    await vpn.waitForQuery(queries.screenOnboarding.DATA_SLIDE.visible());
-
     //Complete onboarding and get to the home screen
     await completeOnboarding(await vpn.getSetting('onboardingStep'));
 
@@ -329,23 +317,25 @@ describe('Onboarding', function() {
     assert.equal(await vpn.getSetting('gleanEnabled'), false);
   });
 
-  //Tests completing onboarding with the data collection checkbox enabled
   it('Complete onboarding with data collection enabled', async () => {
 
     //Ensure we are in onboarding
     await vpn.waitForQuery(queries.screenOnboarding.DATA_SLIDE.visible());
 
-    //Click the data collection checkbox
+    //Ensure that the data collection checkbox state remains bound to onboardingDataCollectionEnabled when clicked
+    //and that this checkboxes state does not affect gleanEnabled
     await vpn.waitForQueryAndClick(queries.screenOnboarding.DATA_CHECKBOX.visible());
+    assert.equal(await vpn.getQueryProperty(queries.screenOnboarding.DATA_CHECKBOX, 'isChecked'), 'true');
+    assert.equal(await vpn.getSetting('onboardingDataCollectionEnabled'), true);
+    assert.equal(await vpn.getSetting('gleanEnabled'), true);
 
     //Complete onboarding and get to the home screen
     await completeOnboarding(await vpn.getSetting('onboardingStep'));
 
-    //Ensure glean is disabled
+    //Ensure glean is enabled
     assert.equal(await vpn.getSetting('gleanEnabled'), true);
   });
 
-  //Tests onboardingDataCollectionEnabled setting persists across app sessions
   it('Data collection checkbox state persists across app sessions', async () => {
     // Skip WASM because this test involves quitting and relaunching
     if (this.ctx.wasm) {
@@ -364,7 +354,14 @@ describe('Onboarding', function() {
     //Ensure we are still in onboarding
     await vpn.waitForQuery(queries.screenOnboarding.DATA_SLIDE.visible());
 
-    //Ensure onboardingDataCollectionEnabled is set to true
+    //Ensure that the data collection checkbox state remains bound to onboardingDataCollectionEnabled upon relaunch
+    //and that this checkboxes state does not affect gleanEnabled
+    assert.equal(await vpn.getQueryProperty(queries.screenOnboarding.DATA_CHECKBOX, 'isChecked'), 'true');
+    assert.equal(await vpn.getSetting('onboardingDataCollectionEnabled'), true);
+    assert.equal(await vpn.getSetting('gleanEnabled'), true);
+
+    //Ensure the data collection checkbox is checked and onboardingDataCollectionEnabled is set to true
+    assert.equal(await vpn.getQueryProperty(queries.screenOnboarding.DATA_CHECKBOX, 'isChecked'), 'true');
     assert.equal(await vpn.getSetting('onboardingDataCollectionEnabled'), true);
   });
 });


### PR DESCRIPTION
## Description

- Prevent data collection checkbox in onboarding from modifying internal `gleanEnabled` setting until onboarding is completed
  - The reasoning for this is because we want the initial state of the checkbox to be unchecked so that no changes are necessary to be made by the user to opt out of data collection (aside from completing onboarding), but coupling this with the internal `gleanEnabled` setting would wipe all authentication telemetry for the user.

## Reference

[VPN-5520: All pre-onboarding glean data being deleted upon reaching the Data Collection Consent screen](https://mozilla-hub.atlassian.net/browse/VPN-5520)