### PR TITLE
VPN-5279: adjust spacing

### DIFF
--- a/nebula/ui/components/inAppAuth/MZInAppAuthenticationBase.qml
+++ b/nebula/ui/components/inAppAuth/MZInAppAuthenticationBase.qml
@@ -134,6 +134,7 @@ MZFlickable {
                 Loader {
                     Layout.alignment: Qt.AlignHCenter
                     active: _changeEmailLinkVisible
+                    visible: _changeEmailLinkVisible
                     sourceComponent: MZLinkButton {
                         labelText: MZI18n.InAppAuthChangeEmailLink
                         visible: _changeEmailLinkVisible


### PR DESCRIPTION
## Description

On Android it had an extra space (per the image in the ticket). This was due to the spacing for the "change email" link. This adjustment makes it not take up space on Android. (It already this looked okay on iOS.)

## Reference

https://mozilla-hub.atlassian.net/browse/VPN-5279

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
