### PR TITLE
VPN-5612 Do not deactivate VPN upon encountering backendfailure

### DIFF
--- a/src/connectionmanager.cpp
+++ b/src/connectionmanager.cpp
@@ -863,12 +863,18 @@ bool ConnectionManager::switchServers(const ServerData& serverData) {
 void ConnectionManager::backendFailure() {
   logger.error() << "backend failure";
 
-  if (m_state == StateInitializing || m_state == StateOff) {
+  if (m_state == StateInitializing || m_state == StateOff ||
+      m_state == StateOn) {
     emit readyToBackendFailure();
     return;
   }
 
   m_nextStep = BackendFailure;
+
+  if (m_state == StateDisconnecting) {
+    deactivate();
+    return;
+  }
 }
 
 #ifdef MZ_DUMMY

--- a/src/connectionmanager.cpp
+++ b/src/connectionmanager.cpp
@@ -872,8 +872,7 @@ void ConnectionManager::backendFailure() {
 
   if (m_state == StateOn || m_state == StateSwitching ||
       m_state == StateSilentSwitching || m_state == StateConnecting ||
-      m_state == StateCheckSubscription || m_state == StateConfirming ||
-      m_state == StateDisconnecting) {
+      m_state == StateCheckSubscription || m_state == StateConfirming) {
     deactivate();
     return;
   }

--- a/src/connectionmanager.cpp
+++ b/src/connectionmanager.cpp
@@ -869,13 +869,6 @@ void ConnectionManager::backendFailure() {
   }
 
   m_nextStep = BackendFailure;
-
-  if (m_state == StateOn || m_state == StateSwitching ||
-      m_state == StateSilentSwitching || m_state == StateConnecting ||
-      m_state == StateCheckSubscription || m_state == StateConfirming) {
-    deactivate();
-    return;
-  }
 }
 
 #ifdef MZ_DUMMY

--- a/src/connectionmanager.cpp
+++ b/src/connectionmanager.cpp
@@ -863,15 +863,17 @@ bool ConnectionManager::switchServers(const ServerData& serverData) {
 void ConnectionManager::backendFailure() {
   logger.error() << "backend failure";
 
-  if (m_state == StateInitializing || m_state == StateOff ||
-      m_state == StateOn) {
+  if (m_state == StateInitializing || m_state == StateOff) {
     emit readyToBackendFailure();
     return;
   }
 
   m_nextStep = BackendFailure;
 
-  if (m_state == StateDisconnecting) {
+  if (m_state == StateOn || m_state == StateSwitching ||
+      m_state == StateSilentSwitching || m_state == StateConnecting ||
+      m_state == StateCheckSubscription || m_state == StateConfirming ||
+      m_state == StateDisconnecting) {
     deactivate();
     return;
   }

--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -1217,7 +1217,8 @@ void MozillaVPN::heartbeatCompleted(bool success) {
   logger.debug() << "Server-side check done:" << success;
 
   if (!success) {
-    m_private->m_connectionManager.backendFailure();
+    logger.debug() << "Heartbeat completed in Mozilla VPN but Guardian "
+                      "encountered an error";
     return;
   }
 

--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -1218,6 +1218,14 @@ void MozillaVPN::heartbeatCompleted(bool success) {
 
   // In the event of a Guardian error during authentication,
   // the "something went wrong" screen is displayed to the user.
+  // This is important because the service used for authentication is
+  // unavailable and causes an interruption in the authentication process.
+  // Alternatively if the user is already authenticated, we intentionally avoid
+  // presenting them with the "something went wrong" screen to avoid unnecessary
+  // interruptions. If the user is already authenticated, it is possible that a
+  // Guardian service may momentarily become unavailable but there is nothing
+  // for the user to do and it may not affect the connectivity at all so it is
+  // not necessary to take additional actions.
   if (!success && state() == StateAuthenticating) {
     m_private->m_connectionManager.backendFailure();
     return;

--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -1216,9 +1216,10 @@ void MozillaVPN::backendServiceRestore() {
 void MozillaVPN::heartbeatCompleted(bool success) {
   logger.debug() << "Server-side check done:" << success;
 
-  if (!success) {
-    logger.debug() << "Heartbeat completed in Mozilla VPN but Guardian "
-                      "encountered an error";
+  // In the event of a Guardian error during authentication,
+  // the "something went wrong" screen is displayed to the user.
+  if (!success && state() == StateAuthenticating) {
+    m_private->m_connectionManager.backendFailure();
     return;
   }
 

--- a/src/tasks/heartbeat/taskheartbeat.cpp
+++ b/src/tasks/heartbeat/taskheartbeat.cpp
@@ -29,16 +29,12 @@ void TaskHeartbeat::run() {
 
   connect(request, &NetworkRequest::requestFailed, this,
           [this, request](QNetworkReply::NetworkError, const QByteArray&) {
-            logger.error() << "Failed to talk with the server";
+            int statusCode = request->statusCode();
+            logger.error() << "Failed to talk with the server. Status code: "
+                           << statusCode;
 
             MozillaVPN* vpn = MozillaVPN::instance();
             Q_ASSERT(vpn);
-
-            int statusCode = request->statusCode();
-
-            logger.debug() << "Guardian network request encountered an issue. "
-                              "HTTP status code: "
-                           << statusCode;
 
             // Internal server errors.
             if (statusCode >= 500 && statusCode <= 509) {

--- a/src/tasks/heartbeat/taskheartbeat.cpp
+++ b/src/tasks/heartbeat/taskheartbeat.cpp
@@ -36,19 +36,17 @@ void TaskHeartbeat::run() {
 
             int statusCode = request->statusCode();
 
+            logger.debug() << "Guardian network request encountered an issue. "
+                              "HTTP status code: "
+                           << statusCode;
+
             // Internal server errors.
             if (statusCode >= 500 && statusCode <= 509) {
-              logger.debug()
-                  << "Internal server error from Guardian. HTTP status code: "
-                  << statusCode;
               vpn->heartbeatCompleted(false);
             }
 
-            // Request failure.
+            // Client errors.
             else if (statusCode >= 400 && statusCode <= 409) {
-              logger.debug()
-                  << "Request failure error from Guardian. HTTP status code: "
-                  << statusCode;
               vpn->heartbeatCompleted(false);
             }
 

--- a/src/tasks/heartbeat/taskheartbeat.cpp
+++ b/src/tasks/heartbeat/taskheartbeat.cpp
@@ -38,11 +38,17 @@ void TaskHeartbeat::run() {
 
             // Internal server errors.
             if (statusCode >= 500 && statusCode <= 509) {
+              logger.debug()
+                  << "Internal server error from Guardian. HTTP status code: "
+                  << statusCode;
               vpn->heartbeatCompleted(false);
             }
 
-            // Request failure ((?!?)
+            // Request failure.
             else if (statusCode >= 400 && statusCode <= 409) {
+              logger.debug()
+                  << "Request failure error from Guardian. HTTP status code:  "
+                  << statusCode;
               vpn->heartbeatCompleted(false);
             }
 

--- a/src/tasks/heartbeat/taskheartbeat.cpp
+++ b/src/tasks/heartbeat/taskheartbeat.cpp
@@ -47,7 +47,7 @@ void TaskHeartbeat::run() {
             // Request failure.
             else if (statusCode >= 400 && statusCode <= 409) {
               logger.debug()
-                  << "Request failure error from Guardian. HTTP status code:  "
+                  << "Request failure error from Guardian. HTTP status code: "
                   << statusCode;
               vpn->heartbeatCompleted(false);
             }

--- a/tests/functional/testHeartbeat.js
+++ b/tests/functional/testHeartbeat.js
@@ -112,11 +112,12 @@ describe('Backend failure', function() {
       await vpn.forceHeartbeatFailure();
 
       await vpn.waitForQuery(queries.screenHome.CONTROLLER_TITLE.visible());
-      // TODO Should this go back to VPN off instead of connecting?
-      assert.equal(
-          await vpn.getQueryProperty(
-              queries.screenHome.CONTROLLER_TITLE.visible(), 'text'),
-          'Connecting…');
+      
+      await vpn.waitForCondition(async () => {
+        return await vpn.getQueryProperty(
+                   queries.screenHome.CONTROLLER_TITLE.visible(), 'text') ===
+            'VPN is on';
+      });
     });
 
     it('BackendFailure when connected', async () => {

--- a/tests/functional/testHeartbeat.js
+++ b/tests/functional/testHeartbeat.js
@@ -9,31 +9,26 @@ const vpn = require('./helper.js');
 describe('Backend failure', function() {
   this.timeout(300000);
 
-  async function backendFailureAndRestore() {
-    await vpn.forceHeartbeatFailure();
-    await vpn.waitForQueryAndClick(
-        queries.screenBackendFailure.HEARTBEAT_TRY_BUTTON.visible());
-  }
-
   it('Backend failure during the main view', async () => {
     await vpn.waitForInitialView();
-    await backendFailureAndRestore();
+    await vpn.forceHeartbeatFailure();
 
     await vpn.waitForQueryAndClick(queries.screenInitialize.GET_HELP_LINK);
     await vpn.waitForQuery(queries.screenGetHelp.LINKS.visible());
   });
 
-  /* TODO:
-    it('Backend failure in the help menu', async () => {
+  it('Backend failure in the help menu', async () => {
       await vpn.waitForQueryAndClick(
         queries.screenInitialize.GET_HELP_LINK.visible());
 
       await
     vpn.waitForQuery(queries.screenGetHelp.BACK_BUTTON.visible());
 
-      await backendFailureAndRestore();
-    });
-  */
+    await vpn.forceHeartbeatFailure();
+
+    await
+    vpn.waitForQuery(queries.screenGetHelp.BACK_BUTTON.visible());
+  });
 
   it('BackendFailure during browser authentication', async () => {
     if (this.ctx.wasm) {
@@ -54,21 +49,30 @@ describe('Backend failure', function() {
     await vpn.waitForQuery(
         queries.screenInitialize.AUTHENTICATE_VIEW.visible());
 
-    await backendFailureAndRestore();
+    await vpn.forceHeartbeatFailure();
+
+    // TODO: without call to click on cancel this test fails because 
+    // we get stuck on the loading spinner 
+    // after authenticating following the changes in mozillavpn.cpp
+    // to remove the call to backend failure in heartbeatCompleted().
+    // Is clicking on "cancel" here okay?
+    await vpn.waitForQueryAndClick(
+      queries.screenAuthenticating.CANCEL_FOOTER_LINK.visible());
+
     await vpn.waitForQuery(queries.screenInitialize.GET_HELP_LINK.visible());
   });
 
   it('BackendFailure in the Post authentication view', async () => {
     await vpn.authenticateInApp();
     await vpn.waitForQuery(queries.screenPostAuthentication.BUTTON.visible());
-    await backendFailureAndRestore();
+    await vpn.forceHeartbeatFailure();
     await vpn.waitForQuery(queries.screenPostAuthentication.BUTTON.visible());
   });
 
   it('BackendFailure in the Telemetry policy view', async () => {
     await vpn.authenticateInApp(true, false);
     await vpn.waitForQuery(queries.screenTelemetry.BUTTON.visible());
-    await backendFailureAndRestore();
+    await vpn.forceHeartbeatFailure();
     await vpn.waitForQuery(queries.screenTelemetry.BUTTON.visible());
   });
 
@@ -82,7 +86,7 @@ describe('Backend failure', function() {
               queries.screenHome.CONTROLLER_TITLE.visible(), 'text'),
           'VPN is off');
 
-      await backendFailureAndRestore();
+      await vpn.forceHeartbeatFailure();
 
       await vpn.waitForQuery(queries.screenHome.CONTROLLER_TITLE.visible());
       assert.equal(
@@ -105,13 +109,14 @@ describe('Backend failure', function() {
               queries.screenHome.CONTROLLER_SUBTITLE, 'text'),
           'Masking connection and location');
 
-      await backendFailureAndRestore();
+      await vpn.forceHeartbeatFailure();
 
       await vpn.waitForQuery(queries.screenHome.CONTROLLER_TITLE.visible());
+      // TODO Should this go back to VPN off instead of connecting?
       assert.equal(
           await vpn.getQueryProperty(
               queries.screenHome.CONTROLLER_TITLE.visible(), 'text'),
-          'VPN is off');
+          'Connecting…');
     });
 
     it('BackendFailure when connected', async () => {
@@ -122,15 +127,14 @@ describe('Backend failure', function() {
             'VPN is on';
       });
 
-      await backendFailureAndRestore();
+      await vpn.forceHeartbeatFailure();
 
       await vpn.waitForQuery(queries.screenHome.CONTROLLER_TITLE.visible());
       assert.equal(
           await vpn.getQueryProperty(
               queries.screenHome.CONTROLLER_TITLE.visible(), 'text'),
-          'VPN is off');
+          'VPN is on');
     });
-
 
     it('disconnecting', async () => {
       await vpn.activate();
@@ -145,13 +149,13 @@ describe('Backend failure', function() {
         return msg === 'Disconnecting…' || msg === 'VPN is off';
       });
 
-      await backendFailureAndRestore();
+      await vpn.forceHeartbeatFailure();
 
-      await vpn.waitForQuery(queries.screenHome.CONTROLLER_TITLE.visible());
-      assert.equal(
-          await vpn.getQueryProperty(
-              queries.screenHome.CONTROLLER_TITLE.visible(), 'text'),
-          'VPN is off');
+      await vpn.waitForCondition(async () => {
+        const msg = await vpn.getQueryProperty(
+            queries.screenHome.CONTROLLER_TITLE.visible(), 'text');
+        return msg === 'VPN is off';
+      });
     });
   });
 });

--- a/tests/functional/testHeartbeat.js
+++ b/tests/functional/testHeartbeat.js
@@ -49,17 +49,11 @@ describe('Backend failure', function() {
     await vpn.waitForQuery(
         queries.screenInitialize.AUTHENTICATE_VIEW.visible());
 
+    // Ensure that in the event of a Guardian error during authentication,
+    // the "something went wrong" screen is displayed to the user.    
     await vpn.forceHeartbeatFailure();
     await vpn.waitForQueryAndClick(
       queries.screenBackendFailure.HEARTBEAT_TRY_BUTTON.visible());
-
-    // // TODO: without call to click on cancel this test fails because 
-    // // we get stuck on the loading spinner 
-    // // after authenticating following the changes in mozillavpn.cpp
-    // // to remove the call to backend failure in heartbeatCompleted().
-    // // Is clicking on "cancel" here okay?
-    // await vpn.waitForQueryAndClick(
-    //   queries.screenAuthenticating.CANCEL_FOOTER_LINK.visible());
 
     await vpn.waitForQuery(queries.screenInitialize.GET_HELP_LINK.visible());
   });

--- a/tests/functional/testHeartbeat.js
+++ b/tests/functional/testHeartbeat.js
@@ -50,7 +50,7 @@ describe('Backend failure', function() {
         queries.screenInitialize.AUTHENTICATE_VIEW.visible());
 
     // Ensure that in the event of a Guardian error during authentication,
-    // the "something went wrong" screen is displayed to the user.    
+    // the "something went wrong" screen is displayed to the user.
     await vpn.forceHeartbeatFailure();
     await vpn.waitForQueryAndClick(
       queries.screenBackendFailure.HEARTBEAT_TRY_BUTTON.visible());
@@ -109,6 +109,9 @@ describe('Backend failure', function() {
 
       await vpn.waitForQuery(queries.screenHome.CONTROLLER_TITLE.visible());
 
+      // VPN should not be disconnected after a heartbeat failure. 
+      // This ensures that the VPN remains on to avoid potentially leaking traffic
+      // and leaving the user unprotected.
       await vpn.waitForCondition(async () => {
         return await vpn.getQueryProperty(
                    queries.screenHome.CONTROLLER_TITLE.visible(), 'text') ===
@@ -127,6 +130,10 @@ describe('Backend failure', function() {
       await vpn.forceHeartbeatFailure();
 
       await vpn.waitForQuery(queries.screenHome.CONTROLLER_TITLE.visible());
+      
+      // VPN should not be disconnected after a heartbeat failure. 
+      // This ensures that the VPN remains on to avoid potentially leaking traffic
+      // and leaving the user unprotected.
       assert.equal(
           await vpn.getQueryProperty(
               queries.screenHome.CONTROLLER_TITLE.visible(), 'text'),
@@ -148,6 +155,9 @@ describe('Backend failure', function() {
 
       await vpn.forceHeartbeatFailure();
 
+      // Because the user has already initiated the deactivation of the VPN
+      // even if we encounter a heartbeat failure during the process, 
+      // we proceed with deactivation as usual.
       await vpn.waitForCondition(async () => {
         const msg = await vpn.getQueryProperty(
             queries.screenHome.CONTROLLER_TITLE.visible(), 'text');

--- a/tests/functional/testHeartbeat.js
+++ b/tests/functional/testHeartbeat.js
@@ -50,14 +50,16 @@ describe('Backend failure', function() {
         queries.screenInitialize.AUTHENTICATE_VIEW.visible());
 
     await vpn.forceHeartbeatFailure();
-
-    // TODO: without call to click on cancel this test fails because 
-    // we get stuck on the loading spinner 
-    // after authenticating following the changes in mozillavpn.cpp
-    // to remove the call to backend failure in heartbeatCompleted().
-    // Is clicking on "cancel" here okay?
     await vpn.waitForQueryAndClick(
-      queries.screenAuthenticating.CANCEL_FOOTER_LINK.visible());
+      queries.screenBackendFailure.HEARTBEAT_TRY_BUTTON.visible());
+
+    // // TODO: without call to click on cancel this test fails because 
+    // // we get stuck on the loading spinner 
+    // // after authenticating following the changes in mozillavpn.cpp
+    // // to remove the call to backend failure in heartbeatCompleted().
+    // // Is clicking on "cancel" here okay?
+    // await vpn.waitForQueryAndClick(
+    //   queries.screenAuthenticating.CANCEL_FOOTER_LINK.visible());
 
     await vpn.waitForQuery(queries.screenInitialize.GET_HELP_LINK.visible());
   });
@@ -112,7 +114,7 @@ describe('Backend failure', function() {
       await vpn.forceHeartbeatFailure();
 
       await vpn.waitForQuery(queries.screenHome.CONTROLLER_TITLE.visible());
-      
+
       await vpn.waitForCondition(async () => {
         return await vpn.getQueryProperty(
                    queries.screenHome.CONTROLLER_TITLE.visible(), 'text') ===


### PR DESCRIPTION
## Description

A failed Guardian heartbeat will lead to a back-end failure in the client code, but we should not be ever deactivating the VPN without the user specifically attempting to do so as it can go unnoticed by the user.
This PR removes the call to `backendFailure()` in the connection manager when user is already authenticated if the heartbeat completes with an error code. 

## Reference

    https://mozilla-hub.atlassian.net/browse/VPN-5612

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
