### PR TITLE
VPN-5524: Mark StepProgressBar's button as not focusable when disabled, Fix a11y name

### DIFF
--- a/nebula/ui/components/MZButtonBase.qml
+++ b/nebula/ui/components/MZButtonBase.qml
@@ -45,8 +45,10 @@ RoundButton {
 
     Accessible.role: Accessible.Button
     Accessible.onPressAction: enabled ? handleKeyClick() : function() { }
-    Accessible.focusable: true
-
+    Accessible.focusable: enabled
+    // In Qt 6.2.4, Windows Accessibility's focusable property is mapped to activeFocusOnTab instead of Accessible.focusable or enabled.
+    // Use activeFocusOnTab as a workaround. The issue has been fixed in Qt 6.5.1. (See QAccessibleQuickItem::state)
+    activeFocusOnTab: enabled
 
     onActiveFocusChanged: {
         if (!activeFocus) {

--- a/nebula/ui/components/MZStepProgressBar.qml
+++ b/nebula/ui/components/MZStepProgressBar.qml
@@ -88,7 +88,7 @@ Item {
                             return MZI18n.OnboardingProgressBarAccessibilityStepCurrent.arg(labelText).arg(index + 1).arg(progressBar.model.count)
                         case MZStepProgressBarDelegate.State.Incomplete:
                         default:
-                            return MZI18n.OnboardingProgressBarAccessibilityStepIncomplete.arg(labelText).arg(index + 1).arg(progressBar.model.count)
+                            return MZI18n.OnboardingProgressBarAccessibilityStepIncomplete2.arg(labelText).arg(index + 1).arg(progressBar.model.count)
                     }
                 }
             }

--- a/src/translations/strings.yaml
+++ b/src/translations/strings.yaml
@@ -568,7 +568,7 @@ onboarding:
     value: "Onboarding step “%1” (%2 of %3). You are currently on this step."
     comment: Accessibility read out for the current step in the step progress bar. %1 is the name of the step. %2 is the index of the current step. %3 is the total number of steps.
   progressBarAccessibilityStepIncomplete:
-    value: "Onboarding step “%1” (%2 of %3)."
+    value: "Onboarding step “%1” (%2 of %3)"
     comment: Accessibility read out for incomplete future steps in the step progress bar. %1 is the name of the step. %2 is the index of the current step. %3 is the total number of steps.
   dataSlideHeader: Data collection and use
   dataSlideBody: We strive to provide you with choices and collect only the technical data we need to improve Mozilla VPN. Sharing data with Mozilla is optional.

--- a/src/translations/strings.yaml
+++ b/src/translations/strings.yaml
@@ -567,9 +567,6 @@ onboarding:
   progressBarAccessibilityStepCurrent:
     value: "Onboarding step “%1” (%2 of %3). You are currently on this step."
     comment: Accessibility read out for the current step in the step progress bar. %1 is the name of the step. %2 is the index of the current step. %3 is the total number of steps.
-  progressBarAccessibilityStepIncomplete:
-    value: "Onboarding step “%1” (%2 of %3)."
-    comment: Obsolete string, replaced by progressBarAccessibilityStepIncomplete2.
   progressBarAccessibilityStepIncomplete2:
     value: "Onboarding step “%1” (%2 of %3)"
     comment: Accessibility read out for incomplete future steps in the step progress bar. %1 is the name of the step. %2 is the index of the current step. %3 is the total number of steps.

--- a/src/translations/strings.yaml
+++ b/src/translations/strings.yaml
@@ -568,6 +568,9 @@ onboarding:
     value: "Onboarding step “%1” (%2 of %3). You are currently on this step."
     comment: Accessibility read out for the current step in the step progress bar. %1 is the name of the step. %2 is the index of the current step. %3 is the total number of steps.
   progressBarAccessibilityStepIncomplete:
+    value: "Onboarding step “%1” (%2 of %3)."
+    comment: Obsolete string, replaced by progressBarAccessibilityStepIncomplete2.
+  progressBarAccessibilityStepIncomplete2:
     value: "Onboarding step “%1” (%2 of %3)"
     comment: Accessibility read out for incomplete future steps in the step progress bar. %1 is the name of the step. %2 is the index of the current step. %3 is the total number of steps.
   dataSlideHeader: Data collection and use


### PR DESCRIPTION
## Description

1. StepProgressBar's disabled button was mistakenly identified as focusable by the Windows Narrator screen reader, causing Narrator to attempt focusing to it during the Move Next command. This focus attempt failed inside the Qt framework due to the button's disabled state, causing Qt to fall back to setting focus on the parent Focus Scope (StackView). As Narrator follows focus, this resulted in the navigation looping issue described in the bug. A disabled button is expected to be non-focusable for Accessibility, but Qt 6.2.4 has a bug where it used only activeFocusOnTab to determine focusability. (See QAccessibleQuickItem::state.) The fix also sets activeFocusOnTab to workaround this. This issue has been resolved in Qt 6.5.1.

2. The incomplete (disabled) step in StepProgressBar contained a period at the end of the name, "Onboarding step “%1” (%2 of %3)." The Narrator screen reader reads it as 'Dot', likely due to confusion with the  preceding ')'. This issue doesn't occur without a preceding parentheses. Fixed by removing the period.

## Reference

[VPN-5524](https://mozilla-hub.atlassian.net/browse/VPN-5524), [Github 7995](https://github.com/mozilla-mobile/mozilla-vpn-client/issues/7995)

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-5524]: https://mozilla-hub.atlassian.net/browse/VPN-5524?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ