### PR TITLE
Load the tunnel before leaving flow

### DIFF
--- a/src/platforms/ios/ioscontroller.swift
+++ b/src/platforms/ios/ioscontroller.swift
@@ -195,15 +195,7 @@ public class IOSControllerImpl : NSObject {
                     return
                 }
 
-                IOSControllerImpl.logger.info(message: "Saving the tunnel succeeded")
-                
-                //Used to create a VPN configuration without connecting during onboarding
-                if isOnboarding {
-                    IOSControllerImpl.logger.info(message: "Finishing onboarding... do not turn on the VPN after gaining permission")
-                    disconnectCallback()
-                    onboardingCompletedCallback()
-                    return
-                }
+               IOSControllerImpl.logger.info(message: "Saving the tunnel succeeded")
 
                tunnel.loadFromPreferences { error in
                     if let error = error {
@@ -212,7 +204,15 @@ public class IOSControllerImpl : NSObject {
                         return
                     }
 
-                   IOSControllerImpl.logger.info(message: "Loading the tunnel succeeded")
+                    IOSControllerImpl.logger.info(message: "Loading the tunnel succeeded")
+
+                    // Used to create a VPN configuration without connecting during onboarding
+                    if isOnboarding {
+                        IOSControllerImpl.logger.info(message: "Finishing onboarding... do not turn on the VPN after gaining permission")
+                        disconnectCallback()
+                        onboardingCompletedCallback()
+                        return
+                    }
 
                     do {
                         if (reason == 1 /* ReasonSwitching */) {


### PR DESCRIPTION
## Description

We were leaving the tunnel setup flow after saving the tunnel, but not after loading it. It seems like without loading it, Apple briefly disconnects the tunnel on the next save, which is sending a disconnected message, which we pass on until we turn off the toggle. 

I'm not yet sure if this fixed VPN-5681, but I believe it solves the problem when the app is first loaded.

## Reference

N/A

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
