### PR TITLE
VPN-5628: Increase minimum CMake to 3.18

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.18)
 
 message("Configuring for ${CMAKE_GENERATOR}")
 get_property(IS_MULTI_CONFIG GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
@@ -89,9 +89,6 @@ endif()
 ## Toolchain Setup
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-if(${CMAKE_VERSION} VERSION_GREATER_EQUAL 3.17)
-    cmake_policy(SET CMP0099 OLD)
-endif()
 
 find_program(PYTHON_EXECUTABLE NAMES python3 python)
 if(MSVC)

--- a/addons/CMakeLists.txt
+++ b/addons/CMakeLists.txt
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.18)
 
 project(addons VERSION 1.0.0 LANGUAGES CXX
         DESCRIPTION "Mozilla VPN Addons"

--- a/linux/debian/control
+++ b/linux/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: mozilla <vpn@mozilla.com>
 Build-Depends: debhelper (>= 11.2),
                cdbs,
-               cmake (>= 3.16~),
+               cmake (>= 3.18~),
                flex,
                gcc (>=4:8.0.0~),
                g++ (>=4:8.0.0~),

--- a/lottie/CMakeLists.txt
+++ b/lottie/CMakeLists.txt
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.18)
 
 project(lottie VERSION 1.0.0 LANGUAGES CXX
         DESCRIPTION "Lightweight scalable animations: QML Wrapper library"
@@ -13,9 +13,6 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_AUTOUIC ON)
 if(NOT CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
     set(CMAKE_FOLDER "Lottie")
-endif()
-if(${CMAKE_VERSION} VERSION_GREATER_EQUAL 3.17)
-    cmake_policy(SET CMP0099 OLD)
 endif()
 
 add_library(lottie STATIC)

--- a/tests/functional/addons/CMakeLists.txt
+++ b/tests/functional/addons/CMakeLists.txt
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.18)
 
 project(testing_addons VERSION 1.0.0 LANGUAGES CXX
         DESCRIPTION "Mozilla VPN Addons for Functional Testing"


### PR DESCRIPTION
## Description
The introduction of QML modules in the 2.17 release revealed a bug in the registration of QML modules where resources from those modules would fail to load when built with CMake 3.16. This scenario only occurs on Ubuntu 20.04 (Focal Fossa). To resolve the issue, we need to upgrade the version of CMake available to our build workers.

While this PR looks simple, the real work is in backporting CMake 3.18 to Ubuntu/focal. This was done in the `ppa:okirby/qt6-backports` repository, with the addition of this [package](https://launchpad.net/~okirby/+archive/ubuntu/qt6-backports/+sourcepub/15217683/+listing-archive-extra)

## Reference
Github #8163 ([VPN-5628](https://mozilla-hub.atlassian.net/browse/VPN-5628))
CMake backport: https://github.com/oskirby/qt6-packaging/commit/6c80f268b1987dfe371bdac6158654014638e639

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-5628]: https://mozilla-hub.atlassian.net/browse/VPN-5628?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ