### PR TITLE
VPN-5733: Fix account deletion word wrapping

### DIFF
--- a/nebula/ui/components/MZCheckBoxRow.qml
+++ b/nebula/ui/components/MZCheckBoxRow.qml
@@ -64,7 +64,7 @@ RowLayout {
             Layout.fillWidth: true
             text: subLabelText
             visible: !!subLabelText.length
-            wrapMode: Text.WordWrap
+            wrapMode: Text.Wrap
             verticalAlignment: label.visible ? Text.AlignTop : Text.AlignVCenter
             Layout.topMargin: label.visible || (!label.visible && lineCount > 1) ? 0 : MZTheme.theme.checkBoxRowSubLabelTopMargin //accounts for the topMargin of the MZCheckbox
 


### PR DESCRIPTION
## Description

- For our `MZCheckBoxRow` sublabels, let wrap on a word ending if possible, otherwise, wrap on character (instead of only wrapping on word ending)

| Before  | After |
| ------------- | ------------- |
| <img width="472" alt="Screenshot 2023-10-18 at 11 59 50 AM" src="https://github.com/mozilla-mobile/mozilla-vpn-client/assets/15353801/1c90d022-554b-455d-8140-4bb10f194ede"> | <img width="472" alt="Screenshot 2023-10-18 at 12 00 04 PM" src="https://github.com/mozilla-mobile/mozilla-vpn-client/assets/15353801/6b761b37-3de0-4a2c-9465-976b15a19633"> |

## Reference

[VPN-5733: Delete  Mozilla account screen has UI issues for some languages](https://mozilla-hub.atlassian.net/browse/VPN-5733)
