### PR TITLE
Chore: Enable taskcluster image cache for Ubuntu/mantic

### DIFF
--- a/taskcluster/ci/docker-image/kind.yml
+++ b/taskcluster/ci/docker-image/kind.yml
@@ -60,7 +60,6 @@ tasks:
     linux-build-mantic:
         symbol: I(linux-mantic)
         definition: linux-dpkg-build
-        cache: false ## Disable caching while Ubuntu/Mantic is in beta.
         args:
             DOCKER_BASE_IMAGE: ubuntu:mantic
     linux-build-fedora-fc36:


### PR DESCRIPTION
## Description
Ubuntu 23.10 (Mantic Minotaur) was officially released on October 12th, 2023, so we can now consider the docker image we use for building to be stable enough to cache. This should speed up builds and waste less time and bandwidth rebuilding the docker image on each run.

## Reference
Ubuntu release announcement: https://lists.ubuntu.com/archives/ubuntu-announce/2023-October/000296.html

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
