### PR TITLE
VPN-5680: Complete mobile onboarding without internet

### DIFF
--- a/src/connectionmanager.cpp
+++ b/src/connectionmanager.cpp
@@ -813,7 +813,7 @@ void ConnectionManager::statusUpdated(const QString& serverIpv4Gateway,
 
   list.swap(m_getStatusCallbacks);
   for (const std::function<void(
-           const QString& serverIpv4Gateway, const QString& deviceIpv4Address,
+           const QString&serverIpv4Gateway, const QString&deviceIpv4Address,
            uint64_t txBytes, uint64_t rxBytes)>&func : list) {
     func(serverIpv4Gateway, deviceIpv4Address, txBytes, rxBytes);
   }
@@ -938,7 +938,9 @@ bool ConnectionManager::activate(const ServerData& serverData,
 
               // Check if the error propagation has changed the Mozilla VPN
               // state. Continue only if the user is still authenticated and
-              // subscribed.
+              // subscribed. We can ignore this during onboarding because we are
+              // not actually turning the VPN on (only asking for VPN system
+              // config permissions)
               if (App::instance()->state() != App::StateMain &&
                   App::instance()->state() != App::StateOnboarding) {
                 return;

--- a/src/connectionmanager.cpp
+++ b/src/connectionmanager.cpp
@@ -813,7 +813,7 @@ void ConnectionManager::statusUpdated(const QString& serverIpv4Gateway,
 
   list.swap(m_getStatusCallbacks);
   for (const std::function<void(
-           const QString&s erverIpv4Gateway, const QString& deviceIpv4Address,
+           const QString& erverIpv4Gateway, const QString& deviceIpv4Address,
            uint64_t txBytes, uint64_t rxBytes)>&func : list) {
     func(serverIpv4Gateway, deviceIpv4Address, txBytes, rxBytes);
   }

--- a/src/connectionmanager.cpp
+++ b/src/connectionmanager.cpp
@@ -813,7 +813,7 @@ void ConnectionManager::statusUpdated(const QString& serverIpv4Gateway,
 
   list.swap(m_getStatusCallbacks);
   for (const std::function<void(
-           const QString& erverIpv4Gateway, const QString& deviceIpv4Address,
+           const QString& serverIpv4Gateway, const QString& deviceIpv4Address,
            uint64_t txBytes, uint64_t rxBytes)>&func : list) {
     func(serverIpv4Gateway, deviceIpv4Address, txBytes, rxBytes);
   }

--- a/src/connectionmanager.cpp
+++ b/src/connectionmanager.cpp
@@ -939,7 +939,8 @@ bool ConnectionManager::activate(const ServerData& serverData,
               // Check if the error propagation has changed the Mozilla VPN
               // state. Continue only if the user is still authenticated and
               // subscribed.
-              if (App::instance()->state() != App::StateMain) {
+              if (App::instance()->state() != App::StateMain &&
+                  App::instance()->state() != App::StateOnboarding) {
                 return;
               }
 

--- a/src/connectionmanager.cpp
+++ b/src/connectionmanager.cpp
@@ -813,7 +813,7 @@ void ConnectionManager::statusUpdated(const QString& serverIpv4Gateway,
 
   list.swap(m_getStatusCallbacks);
   for (const std::function<void(
-           const QString&serverIpv4Gateway, const QString&deviceIpv4Address,
+           const QString&s erverIpv4Gateway, const QString& deviceIpv4Address,
            uint64_t txBytes, uint64_t rxBytes)>&func : list) {
     func(serverIpv4Gateway, deviceIpv4Address, txBytes, rxBytes);
   }


### PR DESCRIPTION
## Description

- While attempting to request system permissions to configure the VPN in the final step of mobile onboarding, a failed subscription check was blocking the activation process due to no internet access. We are not attempting to enable (turn on) the VPN here (just request permissions) so we can ignore the results of this check

## Reference

[VPN-5680: [mobile] Unable to finalize the new onboarding flow after disconnecting from Wi-Fi](https://mozilla-hub.atlassian.net/browse/VPN-5680)