### PR TITLE
Chore - Remove annual plan content from update addons

### DIFF
--- a/addons/message_update_v2.18/manifest.json
+++ b/addons/message_update_v2.18/manifest.json
@@ -22,16 +22,6 @@
         "content": "This update includes minor bug fixes, UI adjustments and other performance improvements, including:"
       },
       {
-        "id": "c_2",
-        "type": "ulist",
-        "content": [
-          {
-            "id": "l_2",
-            "content": "The ability to upgrade to an annual plan from within the app"
-          }
-        ]
-      },    
-      {
         "id": "c_3",
         "type": "button",
         "style": "primary",

--- a/addons/message_whats_new_v2.18/manifest.json
+++ b/addons/message_whats_new_v2.18/manifest.json
@@ -23,16 +23,6 @@
         "content": "This update includes minor bug fixes, UI adjustments and other performance improvements, including:"
       },
       {
-        "id": "c_2",
-        "type": "ulist",
-        "content": [
-          {
-            "id": "l_2",
-            "content": "The ability to upgrade to an annual plan from within the app"
-          }
-        ]
-      },
-      {
         "id": "c_3",
         "type": "text",
         "content": "Thank you for installing the latest version!"


### PR DESCRIPTION
Annual plan feature is shipping in 2.18 behind a feature flag still. Therefore it needs to be gone from the update messages.
