### PR TITLE
VPN-5628: Fix misisng forms and inAppAuth plugin registration

### DIFF
--- a/nebula/ui/components/CMakeLists.txt
+++ b/nebula/ui/components/CMakeLists.txt
@@ -102,5 +102,7 @@ add_subdirectory(inAppAuth)
 set_target_properties(components PROPERTIES FOLDER "Libs")
 target_link_libraries(components PRIVATE 
     forms
+    formsplugin
     inAppAuth
+    inAppAuthplugin
 )


### PR DESCRIPTION
## Description
In order to ensure that QML modules are properly registered, we need to include both the backing target, as well as the plugin target. Unfortunately, the plugin targets were missing for the `components.forms` and `components.inAppAuth` modules, which can cause the UI to fail to load some screens.

To fix it, we just need to ensure that these targets are linked.

## Reference
Github issue #8163 ([VPN-5628](https://mozilla-hub.atlassian.net/browse/VPN-5628))

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed


[VPN-5628]: https://mozilla-hub.atlassian.net/browse/VPN-5628?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ