### PR TITLE
Cherry-Pick: Fix missing forms and inAppAuth plugin registration

### DIFF
--- a/nebula/ui/components/CMakeLists.txt
+++ b/nebula/ui/components/CMakeLists.txt
@@ -102,5 +102,7 @@ add_subdirectory(inAppAuth)
 set_target_properties(components PROPERTIES FOLDER "Libs")
 target_link_libraries(components PRIVATE 
     forms
+    formsplugin
     inAppAuth
+    inAppAuthplugin
 )


### PR DESCRIPTION
## Description
Cherry pick of PR #8337 to fix QML plugin registration on Ubuntu/Focal

## Reference
Github PR #8337 ([VPN-5628](https://mozilla-hub.atlassian.net/browse/VPN-5628))

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-5628]: https://mozilla-hub.atlassian.net/browse/VPN-5628?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ