### PR TITLE
VPN-5740 - Add force_backend_failure to inspector commands

### DIFF
--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -1997,6 +1997,13 @@ void MozillaVPN::registerInspectorCommands() {
       });
 
   InspectorHandler::registerCommand(
+      "force_heartbeat_failure", "Force a heartbeat failure", 0,
+      [](InspectorHandler*, const QList<QByteArray>&) {
+        MozillaVPN::instance()->heartbeatCompleted(false /* success */);
+        return QJsonObject();
+      });
+
+  InspectorHandler::registerCommand(
       "force_server_unavailable",
       "Timeout all servers in a city using force_server_unavailable "
       "{countryCode} "

--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -2074,8 +2074,7 @@ void MozillaVPN::registerInspectorCommands() {
       });
 
   InspectorHandler::registerCommand(
-      "force_backend_failure",
-      "Force a backend failure", 0,
+      "force_backend_failure", "Force a backend failure", 0,
       [](InspectorHandler*, const QList<QByteArray>&) {
         MozillaVPN::instance()->connectionManager()->backendFailure();
         return QJsonObject();

--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -2074,8 +2074,8 @@ void MozillaVPN::registerInspectorCommands() {
       });
 
   InspectorHandler::registerCommand(
-      "mockSomethingWentWrong",
-      "Force the UI to show the Something Went Wrong screen", 0,
+      "force_backend_failure",
+      "Force a backend failure", 0,
       [](InspectorHandler*, const QList<QByteArray>&) {
         MozillaVPN::instance()->connectionManager()->backendFailure();
         return QJsonObject();

--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -1973,6 +1973,13 @@ void MozillaVPN::registerInspectorCommands() {
       });
 
   InspectorHandler::registerCommand(
+      "force_backend_failure", "Force a backend failure", 0,
+      [](InspectorHandler*, const QList<QByteArray>&) {
+        MozillaVPN::instance()->connectionManager()->backendFailure();
+        return QJsonObject();
+      });
+
+  InspectorHandler::registerCommand(
       "force_captive_portal_check", "Force a captive portal check", 0,
       [](InspectorHandler*, const QList<QByteArray>&) {
         MozillaVPN::instance()->captivePortalDetection()->detectCaptivePortal();
@@ -2070,13 +2077,6 @@ void MozillaVPN::registerInspectorCommands() {
       "mockFreeTrial", "Force the UI to show 7 day trial on 1 year plan", 0,
       [](InspectorHandler*, const QList<QByteArray>&) {
         s_mockFreeTrial = true;
-        return QJsonObject();
-      });
-
-  InspectorHandler::registerCommand(
-      "force_backend_failure", "Force a backend failure", 0,
-      [](InspectorHandler*, const QList<QByteArray>&) {
-        MozillaVPN::instance()->connectionManager()->backendFailure();
         return QJsonObject();
       });
 

--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -1990,13 +1990,6 @@ void MozillaVPN::registerInspectorCommands() {
       });
 
   InspectorHandler::registerCommand(
-      "force_heartbeat_failure", "Force a heartbeat failure", 0,
-      [](InspectorHandler*, const QList<QByteArray>&) {
-        MozillaVPN::instance()->heartbeatCompleted(false /* success */);
-        return QJsonObject();
-      });
-
-  InspectorHandler::registerCommand(
       "force_server_unavailable",
       "Timeout all servers in a city using force_server_unavailable "
       "{countryCode} "
@@ -2077,6 +2070,14 @@ void MozillaVPN::registerInspectorCommands() {
       "mockFreeTrial", "Force the UI to show 7 day trial on 1 year plan", 0,
       [](InspectorHandler*, const QList<QByteArray>&) {
         s_mockFreeTrial = true;
+        return QJsonObject();
+      });
+
+  InspectorHandler::registerCommand(
+      "mockSomethingWentWrong",
+      "Force the UI to show the Something Went Wrong screen", 0,
+      [](InspectorHandler*, const QList<QByteArray>&) {
+        MozillaVPN::instance()->connectionManager()->backendFailure();
         return QJsonObject();
       });
 


### PR DESCRIPTION
## Description
The work involved [here](https://github.com/mozilla-mobile/mozilla-vpn-client/pull/8300) changed when we show the “Something went wrong” screen to avoid disrupting the VPN flow. While this is intended, these changes broke the inspector command `force_heartbeat_failure` which the QA uses for UI testing purposes. 

This PR adds a command `force_backend_failure` to show that screen on demand so QA can continue to perform UI tests.

## Reference

    https://mozilla-hub.atlassian.net/browse/VPN-5740

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
