### PR TITLE
doc(README): remove typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,16 +42,16 @@ Moved here -> [Dev-Setup](./docs/dev-setup/index.md)
 ### Pre-commit formatting hook
 
 If you want to submit a pull-request, please, install the clang format
-pre-commit hook that lints code.
+pre-commit hook that links code.
 
-1. The standard conda environment includes the required clang-format libraries.
-If the conda environment is *not* being used, a clang-format library will need
+1. The standard condo environment includes the required clang-format libraries.
+If the condo environment is *not* being used, a clang-format library will need
 to manually installed. (For example, using Homebrew on macOS:
 `brew install clang-format`.)
 
 2. The linter will need to know where to find the `clang-format-diff.py` file, so
-`CLANG_FORMAT_DIFF` must be exported. On a standard conda installation:
-`export CLANG_FORMAT_DIFF=$(find ~/miniconda3/pkgs -name clang-format-diff.py)`
+`CLANG_FORMAT_DIFF` must be exported. On a standard condo installation:
+`export CLANG_FORMAT_DIFF=$(find ~/minicondo3/pkgs -name clang-format-diff.py)`
 
 3. Install the pre-commit hook: `./scripts/git-pre-commit-format install`
 


### PR DESCRIPTION
## Description:

This Pull Request fixes a typographical error in the README.md file.


## Changes Made:

 - Corrected "lints" to "links" in the README.md file.
 - Corrected "conda" to "condo" in the README.md file.

## Additional Information:

This fix is not related to any existing issue. It's a minor typo that I noticed while reviewing the README.

Thank you for considering this contribution.