### PR TITLE
VPN-5749: Enable annual upgrades on Stage desktop

### DIFF
--- a/src/featurelist.h
+++ b/src/featurelist.h
@@ -45,7 +45,7 @@ FEATURE(annualUpgrade,         // Feature ID
         FeatureCallback_true,  // Can be flipped on
         FeatureCallback_true,  // Can be flipped off
         QStringList(),         // feature dependencies
-        FeatureCallback_false)
+        FeatureCallback_annualUpgrade)
 
 FEATURE(appReview,              // Feature ID
         "App Review",           // Feature name

--- a/src/featurelistcallback.h
+++ b/src/featurelistcallback.h
@@ -40,6 +40,16 @@ bool FeatureCallback_iosOrAndroid() {
 // Custom callback functions
 // -------------------------
 
+bool FeatureCallback_annualUpgrade() {
+  if (Constants::inProduction()) {
+    return false;
+  }
+  if (FeatureCallback_iosOrAndroid()) {
+    return false;
+  }
+  return true;
+}
+
 bool FeatureCallback_sentry() {
 #if defined(MZ_IOS)
   return FeatureCallback_inStaging();


### PR DESCRIPTION
## Description

Per a request from QA, this PR enables the `annualUpgrade` feature on Stage desktop only. This means that the upgrade path in the Subscription Management view should now be visible by default for someone who: 
- Is on stage &&
- Is on a desktop device &&
- Has a monthly subscription which was purchased through SubPlat (not the App Store, not the Play Store)

## Reference

VPN-5749

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
