### PR TITLE
VPN-5740 - Add force_backend_failure to inspector commands (#8341)

### DIFF
--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -1973,6 +1973,13 @@ void MozillaVPN::registerInspectorCommands() {
       });
 
   InspectorHandler::registerCommand(
+      "force_backend_failure", "Force a backend failure", 0,
+      [](InspectorHandler*, const QList<QByteArray>&) {
+        MozillaVPN::instance()->connectionManager()->backendFailure();
+        return QJsonObject();
+      });
+
+  InspectorHandler::registerCommand(
       "force_captive_portal_check", "Force a captive portal check", 0,
       [](InspectorHandler*, const QList<QByteArray>&) {
         MozillaVPN::instance()->captivePortalDetection()->detectCaptivePortal();


### PR DESCRIPTION
## Description

Cherry pick [this PR ](https://github.com/mozilla-mobile/mozilla-vpn-client/pull/8341)to 2.18 so QA can test certain functionalities.

## Reference

    main branch PR: https://github.com/mozilla-mobile/mozilla-vpn-client/pull/8341

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
