### PR TITLE
VPN-5663: Fix onboarding UI on Android without gesture nav

### DIFF
--- a/nebula/ui/components/MZStepNavigation.qml
+++ b/nebula/ui/components/MZStepNavigation.qml
@@ -102,7 +102,7 @@ ColumnLayout {
         Layout.fillWidth: true
 
         //Always goes to bottom of the screen - can expose this property if we ever need a custom height
-        implicitHeight: window.height - mapToItem(window.contentItem, 0, 0).y - stepProgressBar.implicitHeight
+        implicitHeight: window.height - window.safeAreaHeightByDevice() - stepProgressBar.implicitHeight - stepNavigation.anchors.topMargin
         flickContentHeight: stackView.currentItem.implicitHeight + stackView.currentItem.anchors.topMargin + stackView.currentItem.anchors.bottomMargin
 
         StackView {
@@ -115,5 +115,10 @@ ColumnLayout {
 
             implicitHeight: flickable.height
         }
+    }
+
+    //Fix for VPN-5663
+    Item {
+        Layout.fillHeight: true
     }
 }


### PR DESCRIPTION
## Description

- Resolve UI issue in onboarding on Android devices without gesture navigation (on-screen buttons) after returning from standby

Before: 

https://github.com/mozilla-mobile/mozilla-vpn-client/assets/15353801/97e0e823-3c78-4515-9d14-67c921e1ea96

After: 

https://github.com/mozilla-mobile/mozilla-vpn-client/assets/15353801/70b58580-f907-4239-8341-f1b85fbf3a9a

## Reference

[VPN-5663: UI issues on the new onboarding screens if device enters in standby](https://mozilla-hub.atlassian.net/browse/VPN-5663)
