### PR TITLE
VPN-5745 - Change the id for updated whats new and update messages

### DIFF
--- a/addons/message_update_v2.18/manifest.json
+++ b/addons/message_update_v2.18/manifest.json
@@ -17,7 +17,7 @@
     "badge": "new_update",
     "blocks": [
       {
-        "id": "c_1",
+        "id": "c_1-1",
         "type": "text",
         "content": "This update includes minor bug fixes, UI adjustments and other performance improvements."
       },

--- a/addons/message_whats_new_v2.18/manifest.json
+++ b/addons/message_whats_new_v2.18/manifest.json
@@ -18,7 +18,7 @@
     "badge": "whats_new",
     "blocks": [
       {
-        "id": "c_1",
+        "id": "c_1-1",
         "type": "text",
         "content": "This update includes minor bug fixes, UI adjustments and other performance improvements."
       },

--- a/src/addons/addonapi.cpp
+++ b/src/addons/addonapi.cpp
@@ -92,6 +92,8 @@ void AddonApi::initialize() {
   }
 }
 
+void AddonApi::log(const QString& message) { logger.debug() << message; }
+
 void AddonApi::connectSignal(QObject* obj, const QString& signalName,
                              const QJSValue& callback) {
   if (!obj) {

--- a/src/addons/addonapi.h
+++ b/src/addons/addonapi.h
@@ -25,6 +25,7 @@ class AddonApi final : public QQmlPropertyMap {
 
   Q_INVOKABLE void connectSignal(QObject* obj, const QString& signalName,
                                  const QJSValue& callback);
+  Q_INVOKABLE void log(const QString& message);
 
   /**
    * @brief callback executed when a new AddonApi is created. Use it to add

--- a/src/addons/addonproperty.h
+++ b/src/addons/addonproperty.h
@@ -9,7 +9,7 @@
 
 #define ADDON_PROPERTY(name, member, getter, setter, signal)            \
   Q_PROPERTY(QString name READ getter NOTIFY signal)                    \
-  QString getter() const { return member.get(); }                       \
+  Q_INVOKABLE QString getter() const { return member.get(); }           \
   Q_INVOKABLE void setter(const QString& id, const QString& fallback) { \
     member.set(id, fallback);                                           \
     emit signal();                                                      \


### PR DESCRIPTION
Yeah, this is hacky. I thought it would be better than changing the string id so late though. Let me know.

Little bonus for addon JavaScript file logging. 

I also reverted the changes from https://github.com/mozilla-mobile/mozilla-vpn-client/pull/8365 just to keep the repo in line with i18n repo.