### PR TITLE
VPN-5678 / VPN-5709 / VPN-5710: Onboarding layout improvements

### DIFF
--- a/nebula/ui/components/MZStepNavigation.qml
+++ b/nebula/ui/components/MZStepNavigation.qml
@@ -102,7 +102,7 @@ ColumnLayout {
         Layout.fillWidth: true
 
         //Always goes to bottom of the screen - can expose this property if we ever need a custom height
-        implicitHeight: window.height - mapToItem(window.contentItem, 0, 0).y - stepProgressBar.implicitHeight
+        implicitHeight: window.height - window.safeAreaHeightByDevice() - stepProgressBar.implicitHeight - stepNavigation.anchors.topMargin
         flickContentHeight: stackView.currentItem.implicitHeight + stackView.currentItem.anchors.topMargin + stackView.currentItem.anchors.bottomMargin
 
         StackView {
@@ -115,5 +115,10 @@ ColumnLayout {
 
             implicitHeight: flickable.height
         }
+    }
+
+    //Fix for VPN-5663
+    Item {
+        Layout.fillHeight: true
     }
 }

--- a/nebula/ui/components/MZStepNavigation.qml
+++ b/nebula/ui/components/MZStepNavigation.qml
@@ -102,7 +102,7 @@ ColumnLayout {
         Layout.fillWidth: true
 
         //Always goes to bottom of the screen - can expose this property if we ever need a custom height
-        implicitHeight: window.height - window.safeAreaHeightByDevice() - stepProgressBar.implicitHeight - stepNavigation.anchors.topMargin
+        implicitHeight: window.height - mapToItem(window.contentItem, 0, 0).y - stepProgressBar.implicitHeight
         flickContentHeight: stackView.currentItem.implicitHeight + stackView.currentItem.anchors.topMargin + stackView.currentItem.anchors.bottomMargin
 
         StackView {
@@ -115,10 +115,5 @@ ColumnLayout {
 
             implicitHeight: flickable.height
         }
-    }
-
-    //Fix for VPN-5663
-    Item {
-        Layout.fillHeight: true
     }
 }

--- a/nebula/ui/themes/main/theme.js
+++ b/nebula/ui/themes/main/theme.js
@@ -79,6 +79,7 @@ theme.popupMargin = 24;
 theme.desktopAppHeight = 640;
 theme.desktopAppWidth = 360;
 theme.tabletMinimumWidth = 600;
+theme.largePhoneHeight = 852
 theme.menuHeight = 56;
 theme.viewBaseTopMargin = 16;
 theme.checkBoxRowSubLabelTopMargin = 2;

--- a/nebula/ui/themes/main/theme.js
+++ b/nebula/ui/themes/main/theme.js
@@ -87,7 +87,6 @@ theme.checkBoxRowSubLabelTopMargin = 2;
 theme.tutorialCardHeight = 144
 theme.guideCardHeight = 172
 
-theme.tutorialCardHeight = 144;
 theme.navBarHeight = 64;
 theme.navBarMaxWidth = 608;
 theme.navBarTopMargin = 48;
@@ -97,6 +96,8 @@ theme.navBarHeight + theme.navBarTopMargin + theme.navBarBottomMargin;
 theme.navBarIconSize = 48
 theme.navBarMaxPaddingTablet = 120
 theme.navBarMaxPadding = 48
+
+theme.onboardingMinimumVerticalSpacing = 16;
 
 theme.swipeDelegateActionWidth = 56;
 theme.badgeHorizontalPadding = 8

--- a/nebula/ui/utils/MZUiUtils.js
+++ b/nebula/ui/utils/MZUiUtils.js
@@ -11,3 +11,7 @@ function scrollToComponent(root) {
 function isMobile() {
     return Qt.platform.os === "android" || Qt.platform.os === "ios"
 }
+
+function isLargePhone() {
+    return window.height > MZTheme.theme.largePhoneHeight
+}

--- a/src/ui/screens/onboarding/OnboardingDataSlide.qml
+++ b/src/ui/screens/onboarding/OnboardingDataSlide.qml
@@ -56,7 +56,7 @@ ColumnLayout {
 
     Item {
         Layout.fillHeight: true
-        Layout.minimumHeight: 16
+        Layout.minimumHeight: MZTheme.theme.onboardingMinimumVerticalSpacing
     }
 
     Image {
@@ -68,7 +68,7 @@ ColumnLayout {
 
     Item {
         Layout.fillHeight: true
-        Layout.minimumHeight: 16
+        Layout.minimumHeight: MZTheme.theme.onboardingMinimumVerticalSpacing
     }
 
     MZButton {

--- a/src/ui/screens/onboarding/OnboardingDataSlide.qml
+++ b/src/ui/screens/onboarding/OnboardingDataSlide.qml
@@ -38,25 +38,10 @@ ColumnLayout {
         color: MZTheme.theme.fontColor
    }
 
-    Item {
-        Layout.fillHeight: true
-        Layout.minimumHeight: 24
-    }
-
-    Image {
-        Layout.alignment: Qt.AlignHCenter
-
-        source: "qrc:/ui/resources/data-collection.svg"
-    }
-
-    Item {
-        Layout.fillHeight: true
-        Layout.minimumHeight: 24
-    }
-
     MZCheckBoxRow {
         objectName: "dataCollectionCheckBox"
 
+        Layout.topMargin: MZUiUtils.isMobile() ? MZTheme.theme.vSpacing * 1.5 : MZTheme.theme.vSpacing
         Layout.leftMargin: MZTheme.theme.windowMargin * 2
         Layout.rightMargin: MZTheme.theme.windowMargin * 2
         Layout.fillWidth: true
@@ -71,7 +56,19 @@ ColumnLayout {
 
     Item {
         Layout.fillHeight: true
-        Layout.minimumHeight: 24
+        Layout.minimumHeight: 16
+    }
+
+    Image {
+        Layout.alignment: Qt.AlignHCenter
+
+        source: "qrc:/ui/resources/data-collection.svg"
+        sourceSize: MZUiUtils.isLargePhone() ? Qt.size(209,144) : Qt.size(151,104)
+    }
+
+    Item {
+        Layout.fillHeight: true
+        Layout.minimumHeight: 16
     }
 
     MZButton {
@@ -106,5 +103,4 @@ ColumnLayout {
         labelText: MZI18n.InAppSupportWorkflowPrivacyNoticeLinkText
         onClicked: MZUrlOpener.openUrlLabel("privacyNotice")
     }
-
 }

--- a/src/ui/screens/onboarding/OnboardingDevicesSlide.qml
+++ b/src/ui/screens/onboarding/OnboardingDevicesSlide.qml
@@ -104,7 +104,7 @@ ColumnLayout {
 
     Item {
         Layout.fillHeight: true
-        Layout.minimumHeight: 16
+        Layout.minimumHeight: MZTheme.theme.onboardingMinimumVerticalSpacing
     }
 
     //Views in the stack layout must be in the same order as items in the above list model
@@ -193,7 +193,7 @@ ColumnLayout {
 
     Item {
         Layout.fillHeight: true
-        Layout.minimumHeight: 16
+        Layout.minimumHeight: MZTheme.theme.onboardingMinimumVerticalSpacing
     }
 
     MZButton {

--- a/src/ui/screens/onboarding/OnboardingDevicesSlide.qml
+++ b/src/ui/screens/onboarding/OnboardingDevicesSlide.qml
@@ -102,11 +102,18 @@ ColumnLayout {
         }
     }
 
+    Item {
+        Layout.fillHeight: true
+        Layout.minimumHeight: 16
+    }
+
     //Views in the stack layout must be in the same order as items in the above list model
     StackLayout {
-        Layout.topMargin: MZTheme.theme.vSpacingSmall
-        Layout.maximumHeight: 152
-        Layout.maximumWidth: 152
+        id: qrcodeStack
+        readonly property int qrcodeSize: MZUiUtils.isLargePhone() ? 208 : 152
+
+        Layout.maximumHeight: qrcodeSize
+        Layout.maximumWidth: qrcodeSize
         Layout.alignment: Qt.AlignHCenter
 
         currentIndex: deviceTypeToggle.selectedIndex
@@ -115,10 +122,10 @@ ColumnLayout {
         Rectangle {
             color: MZTheme.theme.white
 
-            Layout.preferredHeight: 152
-            Layout.preferredWidth: 152
-            Layout.maximumHeight: 152
-            Layout.maximumWidth: 152
+            Layout.preferredHeight: qrcodeStack.qrcodeSize
+            Layout.preferredWidth: qrcodeStack.qrcodeSize
+            Layout.maximumHeight: qrcodeStack.qrcodeSize
+            Layout.maximumWidth: qrcodeStack.qrcodeSize
 
             MZDropShadow {
                 anchors.fill: parent
@@ -135,8 +142,8 @@ ColumnLayout {
             Image {
                 objectName: "playStoreQrCode"
 
-                width: 152
-                height: 152
+                height: qrcodeStack.qrcodeSize
+                width: qrcodeStack.qrcodeSize
 
                 //QR coded generated via Adobe Express
                 source: "qrc:/ui/resources/qrcodes/play-store-qrcode.png"
@@ -151,10 +158,10 @@ ColumnLayout {
         Rectangle {
             color: MZTheme.theme.white
 
-            Layout.preferredHeight: 152
-            Layout.preferredWidth: 152
-            Layout.maximumHeight: 152
-            Layout.maximumWidth: 152
+            Layout.preferredHeight: qrcodeStack.qrcodeSize
+            Layout.preferredWidth: qrcodeStack.qrcodeSize
+            Layout.maximumHeight: qrcodeStack.qrcodeSize
+            Layout.maximumWidth: qrcodeStack.qrcodeSize
 
             MZDropShadow {
                 anchors.fill: parent
@@ -171,8 +178,8 @@ ColumnLayout {
             Image {
                 objectName: "appStoreQrCode"
 
-                width: 152
-                height: 152
+                height: qrcodeStack.qrcodeSize
+                width: qrcodeStack.qrcodeSize
 
                 //QR coded generated via Adobe Express
                 source: "qrc:/ui/resources/qrcodes/app-store-qrcode.png"
@@ -186,7 +193,7 @@ ColumnLayout {
 
     Item {
         Layout.fillHeight: true
-        Layout.minimumHeight: 32
+        Layout.minimumHeight: 16
     }
 
     MZButton {

--- a/src/ui/screens/onboarding/OnboardingPrivacySlide.qml
+++ b/src/ui/screens/onboarding/OnboardingPrivacySlide.qml
@@ -50,7 +50,7 @@ ColumnLayout {
 
     Item {
         Layout.fillHeight: true
-        Layout.minimumHeight: 16
+        Layout.minimumHeight: MZTheme.theme.onboardingMinimumVerticalSpacing
     }
 
     MZButton {

--- a/src/ui/screens/onboarding/OnboardingPrivacySlide.qml
+++ b/src/ui/screens/onboarding/OnboardingPrivacySlide.qml
@@ -42,7 +42,7 @@ ColumnLayout {
     }
 
     PrivacyFeaturesList {
-        Layout.topMargin: MZUiUtils.isMobile() ? 32 : 24
+        Layout.topMargin: MZUiUtils.isMobile() ? MZTheme.theme.vSpacing * 1.5 : MZTheme.theme.vSpacing
         Layout.leftMargin: 32
         Layout.rightMargin: 32
         Layout.fillWidth: true
@@ -50,7 +50,7 @@ ColumnLayout {
 
     Item {
         Layout.fillHeight: true
-        Layout.minimumHeight: 24
+        Layout.minimumHeight: 16
     }
 
     MZButton {

--- a/src/ui/screens/onboarding/OnboardingStartSlideDesktop.qml
+++ b/src/ui/screens/onboarding/OnboardingStartSlideDesktop.qml
@@ -57,7 +57,7 @@ ColumnLayout {
 
     Item {
         Layout.fillHeight: true
-        Layout.minimumHeight: 16
+        Layout.minimumHeight: MZTheme.theme.onboardingMinimumVerticalSpacing
     }
 
     Image {
@@ -69,7 +69,7 @@ ColumnLayout {
 
     Item {
         Layout.fillHeight: true
-        Layout.minimumHeight: 16
+        Layout.minimumHeight: MZTheme.theme.onboardingMinimumVerticalSpacing
     }
 
     MZButton {

--- a/src/ui/screens/onboarding/OnboardingStartSlideDesktop.qml
+++ b/src/ui/screens/onboarding/OnboardingStartSlideDesktop.qml
@@ -40,23 +40,6 @@ ColumnLayout {
         color: MZTheme.theme.fontColor
     }
 
-    Item {
-        Layout.fillHeight: true
-        Layout.minimumHeight: 24
-    }
-
-    Image {
-        Layout.topMargin: MZTheme.theme.vSpacing
-        Layout.alignment: Qt.AlignHCenter
-
-        source: "qrc:/ui/resources/launch.svg"
-    }
-
-    Item {
-        Layout.fillHeight: true
-        Layout.minimumHeight: 24
-    }
-
     MZCheckBoxRow {
         objectName: "startAtBootCheckBox"
 
@@ -74,7 +57,19 @@ ColumnLayout {
 
     Item {
         Layout.fillHeight: true
-        Layout.minimumHeight: 48
+        Layout.minimumHeight: 16
+    }
+
+    Image {
+        Layout.alignment: Qt.AlignHCenter
+
+        sourceSize: MZUiUtils.isLargePhone() ? Qt.size(209,144) : Qt.size(151,104)
+        source: "qrc:/ui/resources/launch.svg"
+    }
+
+    Item {
+        Layout.fillHeight: true
+        Layout.minimumHeight: 16
     }
 
     MZButton {

--- a/src/ui/screens/onboarding/OnboardingStartSlideMobile.qml
+++ b/src/ui/screens/onboarding/OnboardingStartSlideMobile.qml
@@ -8,6 +8,7 @@ import QtQuick.Layouts 1.15
 import Mozilla.Shared 1.0
 import Mozilla.VPN 1.0
 import components 0.1
+import "qrc:/nebula/utils/MZUiUtils.js" as MZUiUtils
 
 ColumnLayout {
     id: root
@@ -39,15 +40,21 @@ ColumnLayout {
         color: MZTheme.theme.fontColor
     }
 
+    Item {
+        Layout.fillHeight: true
+        Layout.minimumHeight: 16
+    }
+
     Image {
-        Layout.topMargin: 48
         Layout.alignment: Qt.AlignHCenter
 
+        sourceSize: MZUiUtils.isLargePhone() ? Qt.size(209,144) : Qt.size(151,104)
         source: "qrc:/ui/resources/link.svg"
     }
 
     Item {
         Layout.fillHeight: true
+        Layout.minimumHeight: 16
     }
 
     MZButton {

--- a/src/ui/screens/onboarding/OnboardingStartSlideMobile.qml
+++ b/src/ui/screens/onboarding/OnboardingStartSlideMobile.qml
@@ -42,7 +42,7 @@ ColumnLayout {
 
     Item {
         Layout.fillHeight: true
-        Layout.minimumHeight: 16
+        Layout.minimumHeight: MZTheme.theme.onboardingMinimumVerticalSpacing
     }
 
     Image {
@@ -54,7 +54,7 @@ ColumnLayout {
 
     Item {
         Layout.fillHeight: true
-        Layout.minimumHeight: 16
+        Layout.minimumHeight: MZTheme.theme.onboardingMinimumVerticalSpacing
     }
 
     MZButton {


### PR DESCRIPTION
## Description

- Moved checkboxes above images on relevant slides (data and start (desktop) slides)
- Made images larger on screen sizes > 852px (Plus / Max iPhones + tablets)
- Set even spacing above and below images (including QR codes)

## Reference

[VPN-5678: [iOS][iPad] Extra padding on the new onboarding screens](https://mozilla-hub.atlassian.net/browse/VPN-5678)
[VPN-5709: QR code not centered in the "Install Mozilla VPN on up to 5 devices" screen](https://mozilla-hub.atlassian.net/browse/VPN-5709)
[VPN-5710: Unexpected scrolling needed "Connect Mozilla VPN on startup" screen](https://mozilla-hub.atlassian.net/browse/VPN-5710)