### PR TITLE
VPN-5592: Fix DNS settings layout (Qt 6.4)

### DIFF
--- a/src/ui/screens/settings/ViewDNSSettings.qml
+++ b/src/ui/screens/settings/ViewDNSSettings.qml
@@ -81,6 +81,7 @@ MZViewBase {
         spacing: MZTheme.theme.windowMargin * 1.5
         Layout.leftMargin: MZTheme.theme.windowMargin
         Layout.rightMargin: MZTheme.theme.windowMargin
+        Layout.preferredWidth: parent.width
 
         Loader {
             objectName: "DNSSettingsInformationCardLoader"


### PR DESCRIPTION
## Description

Another Qt 6.4 layout issue 😪 

- Properly layout/render the DNS settings view after re-visiting the view while custom DNS is selected and has a value in the text field

## Reference

[VPN-5592: Linux: DNS Settings screen doesn't always render correctly](https://mozilla-hub.atlassian.net/browse/VPN-5592)
