### PR TITLE
VPN-5899: Handle FxA stub accounts

### DIFF
--- a/nebula/ui/components/inAppAuth/MZInAppAuthenticationErrorPopup.qml
+++ b/nebula/ui/components/inAppAuth/MZInAppAuthenticationErrorPopup.qml
@@ -52,6 +52,10 @@ MZSimplePopup {
                 showGenericAuthError();
                 break;
 
+            case MZAuthInApp.ErrorAccountHasNoPassword:
+                showGenericAuthError();
+                break;
+
             case MZAuthInApp.ErrorUnknownAccount:
                 showGenericAuthError();
                 break;

--- a/src/authenticationinapp/authenticationinapp.h
+++ b/src/authenticationinapp/authenticationinapp.h
@@ -69,6 +69,7 @@ class AuthenticationInApp final : public QObject {
 
   enum ErrorType {
     ErrorAccountAlreadyExists,
+    ErrorAccountHasNoPassword,
     ErrorEmailCanNotBeUsedToLogin,
     ErrorEmailTypeNotSupported,
     ErrorFailedToSendEmail,

--- a/src/authenticationinapp/authenticationinappsession.h
+++ b/src/authenticationinapp/authenticationinappsession.h
@@ -81,7 +81,7 @@ class AuthenticationInAppSession final : public QObject {
 
   QByteArray generateAuthPw() const;
 
-  void accountChecked(bool exists);
+  void accountChecked(bool exists, bool hasPassword);
   void signInOrUpCompleted(const QString& sessionToken, bool accountVerified,
                            const QString& verificationMethod);
   void unblockCodeNeeded();

--- a/src/commands/commandlogin.cpp
+++ b/src/commands/commandlogin.cpp
@@ -164,6 +164,9 @@ int CommandLogin::run(QStringList& tokens) {
             switch (error) {
               case AuthenticationInApp::ErrorAccountAlreadyExists:
                 [[fallthrough]];
+              case AuthenticationInApp::ErrorAccountHasNoPassword:
+                stream << "This Mozilla account has no password." << Qt::endl;
+                break;
               case AuthenticationInApp::ErrorUnknownAccount:
                 stream << "Unknown account" << Qt::endl;
                 break;

--- a/tests/functional/servers/fxa_endpoints.js
+++ b/tests/functional/servers/fxa_endpoints.js
@@ -7,7 +7,10 @@
 const VALIDATORS = {
   fxaStatus: {
     type: 'object',
-    properties: {email: {type: 'string'}},
+    properties: {
+      email: {type: 'string'},
+      thirdPartyAuthStatus: {type: 'boolean'}
+    },
     required: ['email']
   },
 
@@ -138,7 +141,7 @@ exports.generateEndpoints = function(guardianUrl) {
       '/v1/account/status': {
         status: 200,
         bodyValidator: VALIDATORS.fxaStatus,
-        body: {exists: true}
+        body: {exists: true, hasLinkedAccount: false, hasPassword: true}
       },
 
       '/v1/account/login': {

--- a/tests/functional/testAuthenticationInApp.js
+++ b/tests/functional/testAuthenticationInApp.js
@@ -454,6 +454,82 @@ describe('User authentication', function() {
     });
   });
 
+  describe('Account creation with stub account', function() {
+    this.ctx.fxaOverrideEndpoints = {
+      GETs: {},
+      POSTs: {
+        '/v1/account/status': {
+          status: 200,
+          bodyValidator: fxaEndpoints.validators.fxaStatus,
+          body: {exists: true, hasLinkedAccount: false, hasPassword: false}
+        },
+      },
+      DELETEs: {},
+    };
+
+    it('Account creation with stub account', async () => {
+      if (!(await vpn.isFeatureFlippedOn('inAppAuthentication'))) {
+        await vpn.flipFeatureOn('inAppAuthentication');
+        await vpn.flipFeatureOn('inAppAccountCreate');
+      }
+
+      await vpn.waitForInitialView();
+
+      await vpn.clickOnQuery(queries.screenInitialize.SIGN_UP_BUTTON.visible());
+      await vpn.waitForQuery(
+          queries.screenAuthenticationInApp.AUTH_START_TEXT_INPUT.visible());
+      await vpn.waitForQuery(
+          queries.screenAuthenticationInApp.AUTH_START_BUTTON.visible()
+              .disabled());
+      await vpn.setQueryProperty(
+          queries.screenAuthenticationInApp.AUTH_START_TEXT_INPUT.visible(),
+          'text', 'test@test.com');
+      await vpn.waitForQueryAndClick(
+          queries.screenAuthenticationInApp.AUTH_START_BUTTON.visible()
+              .enabled());
+
+      await vpn.waitForQuery(queries.screenAuthenticationInApp.AUTH_ERROR_POPUP_BUTTON.visible());
+    });
+  });
+
+  describe('Account creation with SSO account', function() {
+    this.ctx.fxaOverrideEndpoints = {
+      GETs: {},
+      POSTs: {
+        '/v1/account/status': {
+          status: 200,
+          bodyValidator: fxaEndpoints.validators.fxaStatus,
+          body: {exists: true, hasLinkedAccount: true, hasPassword: false}
+        },
+      },
+      DELETEs: {},
+    };
+
+    it('Account creation with stub account', async () => {
+      if (!(await vpn.isFeatureFlippedOn('inAppAuthentication'))) {
+        await vpn.flipFeatureOn('inAppAuthentication');
+        await vpn.flipFeatureOn('inAppAccountCreate');
+      }
+
+      await vpn.waitForInitialView();
+
+      await vpn.clickOnQuery(queries.screenInitialize.SIGN_UP_BUTTON.visible());
+      await vpn.waitForQuery(
+          queries.screenAuthenticationInApp.AUTH_START_TEXT_INPUT.visible());
+      await vpn.waitForQuery(
+          queries.screenAuthenticationInApp.AUTH_START_BUTTON.visible()
+              .disabled());
+      await vpn.setQueryProperty(
+          queries.screenAuthenticationInApp.AUTH_START_TEXT_INPUT.visible(),
+          'text', 'test@test.com');
+      await vpn.waitForQueryAndClick(
+          queries.screenAuthenticationInApp.AUTH_START_BUTTON.visible()
+              .enabled());
+
+      await vpn.waitForQuery(queries.screenAuthenticationInApp.AUTH_ERROR_POPUP_BUTTON.visible());
+    });
+  });
+
   describe('auth in app related telemetry tests', () => {
     if(vpn.runningOnWasm()) {
         // No Glean on WASM.

--- a/tests/functional/testAuthenticationInAppAccountCreationNav.js
+++ b/tests/functional/testAuthenticationInAppAccountCreationNav.js
@@ -88,7 +88,7 @@ describe('User authentication', function() {
       // Step 5: start -> sign-in -> help -> sign-in
       this.ctx.fxaStatusCallback = (req) => {
         this.ctx.fxaOverrideEndpoints.POSTs['/v1/account/status'].body = {
-          exists: true
+          exists: true, hasPassword: true
         }
       };
       await vpn.setQueryProperty(

--- a/tests/functional/testAuthenticationInAppErrors.js
+++ b/tests/functional/testAuthenticationInAppErrors.js
@@ -121,7 +121,7 @@ describe('User authentication', function() {
       // Step 3: start -> 151 error (failed to send email)
       this.ctx.fxaStatusCallback = (req) => {
         this.ctx.fxaOverrideEndpoints.POSTs['/v1/account/status'].body = {
-          exists: true
+          exists: true, hasPassword: true
         };
         this.ctx.fxaOverrideEndpoints.POSTs['/v1/account/status'].status = 200;
       };
@@ -299,7 +299,7 @@ describe('User authentication', function() {
 
       this.ctx.fxaStatusCallback = (req) => {
         this.ctx.fxaOverrideEndpoints.POSTs['/v1/account/status'].body = {
-          exists: true
+          exists: true, hasPassword: true
         };
         this.ctx.fxaOverrideEndpoints.POSTs['/v1/account/status'].status = 200;
       };


### PR DESCRIPTION
## Description

Fixes VPN-5899

Use the `thirdPartyAuthStatus` param of the FxA [`/account/status`](https://mozilla.github.io/ecosystem-platform/api#tag/Account/operation/postAccountStatus) endpoint to determine if the account has a password or not. If the account _does not_ have a password, this means it is either a stub account (created at subscription time with only an email, and the user has not yet visited their email to set their password) or it is an SSO-linked account.

Up to this point, if a user with a passwordless account attempted to login, the client would simply hang indefinitely. This PR replaces this with a generic error. Admittedly, this is not much better, but it sets us up for a future ticket where we can replace the generic error with a error with proper wording (TBD by product and UX).

For reference, we are not planning to support these flows directly in the client -- for the stub accounts, security considerations require the user to go through their email to set their password, and for SSO, we are planning to ask users to set a password in the FxA dashboard in the same way that they currently have to do to use Firefox Sync. This itself is a holdover until such time as we can totally rework authentication in the client (i.e. revert to in-browser auth).

## Reference

https://mozilla-hub.atlassian.net/browse/VPN-5899

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [ ] ~I have commented my code PARTICULARLY in hard to understand areas~ (N/A)
- [x] I have added thorough tests where needed
