### PR TITLE
VPN-5532: Prevent persistent VPN config system prompt

### DIFF
--- a/android/vpnClient/src/main/java/org/mozilla/firefox/vpn/qt/VPNActivity.java
+++ b/android/vpnClient/src/main/java/org/mozilla/firefox/vpn/qt/VPNActivity.java
@@ -163,6 +163,7 @@ public class VPNActivity extends org.qtproject.qt.android.bindings.QtActivity {
   private final int EVENT_PERMISSION_REQURED = 6;
   private final int EVENT_DISCONNECTED = 2;
   private final int EVENT_ONBOARDING_COMPLETED = 9;
+  private final int EVENT_ALLOW_VPN_CONFIG_OPTION_SELECTED = 10;
 
   public void onPermissionRequest(int code, Parcel data) {
     if(code != EVENT_PERMISSION_REQURED){
@@ -183,6 +184,10 @@ public class VPNActivity extends org.qtproject.qt.android.bindings.QtActivity {
   protected void onActivityResult(int requestCode, int resultCode, Intent data) {
     if(requestCode == PERMISSION_TRANSACTION){
       // THATS US!
+
+      // User made a selection, at this point it is safe to run retries via
+      // ConnectionManager::startHandshakeTimer()      
+      onServiceMessage(EVENT_ALLOW_VPN_CONFIG_OPTION_SELECTED,"");
       if( resultCode == RESULT_OK ){
         // Prompt accepted, tell service to retry.
         dispatchParcel(ACTION_RESUME_ACTIVATE,"");

--- a/android/vpnClient/src/main/java/org/mozilla/firefox/vpn/qt/VPNActivity.java
+++ b/android/vpnClient/src/main/java/org/mozilla/firefox/vpn/qt/VPNActivity.java
@@ -163,7 +163,7 @@ public class VPNActivity extends org.qtproject.qt.android.bindings.QtActivity {
   private final int EVENT_PERMISSION_REQURED = 6;
   private final int EVENT_DISCONNECTED = 2;
   private final int EVENT_ONBOARDING_COMPLETED = 9;
-  private final int EVENT_ALLOW_VPN_CONFIG_OPTION_SELECTED = 10;
+  private final int EVENT_VPN_CONFIG_PERMISSION_RESPONSE = 10;
 
   public void onPermissionRequest(int code, Parcel data) {
     if(code != EVENT_PERMISSION_REQURED){
@@ -185,9 +185,10 @@ public class VPNActivity extends org.qtproject.qt.android.bindings.QtActivity {
     if(requestCode == PERMISSION_TRANSACTION){
       // THATS US!
 
-      // User made a selection, at this point it is safe to run retries via
-      // ConnectionManager::startHandshakeTimer()      
-      onServiceMessage(EVENT_ALLOW_VPN_CONFIG_OPTION_SELECTED,"");
+      // At this point, the user has made a selection on the system config permission modal to either allow or not allow
+      // the vpn configuration to be created, so it is safe to run activation retries via ConnectionManager::startHandshakeTimer()
+      // without the possibility or re-prompting (flickering) the modal while it is currently being displayed  
+      onServiceMessage(EVENT_VPN_CONFIG_PERMISSION_RESPONSE,"");
       if( resultCode == RESULT_OK ){
         // Prompt accepted, tell service to retry.
         dispatchParcel(ACTION_RESUME_ACTIVATE,"");

--- a/src/connectionmanager.h
+++ b/src/connectionmanager.h
@@ -78,6 +78,7 @@ class ConnectionManager : public QObject, public LogSerializer {
   void backendFailure();
   void updateRequired();
   void deleteOSTunnelConfig();
+  void startHandshakeTimer();
 
   const ServerData& currentServer() const { return m_serverData; }
 

--- a/src/platforms/android/androidcontroller.cpp
+++ b/src/platforms/android/androidcontroller.cpp
@@ -14,6 +14,7 @@
 
 #include "androidutils.h"
 #include "androidvpnactivity.h"
+#include "connectionmanager.h"
 #include "errorhandler.h"
 #include "feature.h"
 #include "i18nstrings.h"
@@ -108,6 +109,15 @@ AndroidController::AndroidController() {
           vpn->onboardingCompleted();
           emit disconnected();
         }
+      },
+      Qt::QueuedConnection);
+  connect(
+      activity, &AndroidVPNActivity::eventAllowVpnConfigOptionSelected, this,
+      []() {
+        ConnectionManager* connectionManager =
+            MozillaVPN::instance()->connectionManager();
+        Q_ASSERT(connectionManager);
+        connectionManager->startHandshakeTimer();
       },
       Qt::QueuedConnection);
 }

--- a/src/platforms/android/androidcontroller.cpp
+++ b/src/platforms/android/androidcontroller.cpp
@@ -112,11 +112,10 @@ AndroidController::AndroidController() {
       },
       Qt::QueuedConnection);
   connect(
-      activity, &AndroidVPNActivity::eventAllowVpnConfigOptionSelected, this,
+      activity, &AndroidVPNActivity::eventVpnConfigPermissionResponse, this,
       []() {
         ConnectionManager* connectionManager =
             MozillaVPN::instance()->connectionManager();
-        Q_ASSERT(connectionManager);
         connectionManager->startHandshakeTimer();
       },
       Qt::QueuedConnection);

--- a/src/platforms/android/androidvpnactivity.cpp
+++ b/src/platforms/android/androidvpnactivity.cpp
@@ -142,6 +142,9 @@ void AndroidVPNActivity::handleServiceMessage(int code, const QString& data) {
     case ServiceEvents::EVENT_ONBOARDING_COMPLETED:
       emit eventOnboardingCompleted();
       break;
+    case ServiceEvents::EVENT_ALLOW_VPN_CONFIG_OPTION_SELECTED:
+      emit eventAllowVpnConfigOptionSelected();
+      break;
     default:
       Q_ASSERT(false);
   }

--- a/src/platforms/android/androidvpnactivity.cpp
+++ b/src/platforms/android/androidvpnactivity.cpp
@@ -142,8 +142,8 @@ void AndroidVPNActivity::handleServiceMessage(int code, const QString& data) {
     case ServiceEvents::EVENT_ONBOARDING_COMPLETED:
       emit eventOnboardingCompleted();
       break;
-    case ServiceEvents::EVENT_ALLOW_VPN_CONFIG_OPTION_SELECTED:
-      emit eventAllowVpnConfigOptionSelected();
+    case ServiceEvents::EVENT_VPN_CONFIG_PERMISSION_RESPONSE:
+      emit eventVpnConfigPermissionResponse();
       break;
     default:
       Q_ASSERT(false);

--- a/src/platforms/android/androidvpnactivity.h
+++ b/src/platforms/android/androidvpnactivity.h
@@ -72,8 +72,12 @@ enum ServiceEvents {
   // The Daemon need's the app to ask for notification
   // permissions, to show the "you're connected" messages.
   EVENT_REQUEST_NOTIFICATION_PERMISSION = 8,
+  // Signals MozillaVPN that we have completed onboarding
   EVENT_ONBOARDING_COMPLETED = 9,
-  EVENT_ALLOW_VPN_CONFIG_OPTION_SELECTED = 10,
+  // Signals the ConnectionManager that it may now allow 
+  // activation retries now that the system vpn config modal
+  // has been responded to
+  EVENT_VPN_CONFIG_PERMISSION_RESPONSE = 10,
 };
 typedef enum ServiceEvents ServiceEvents;
 
@@ -97,7 +101,7 @@ class AndroidVPNActivity : public QObject {
   void eventStatisticUpdate(const QString& data);
   void eventActivationError(const QString& data);
   void eventOnboardingCompleted();
-  void eventAllowVpnConfigOptionSelected();
+  void eventVpnConfigPermissionResponse();
   void eventRequestGleanUploadEnabledState();
 
  private:

--- a/src/platforms/android/androidvpnactivity.h
+++ b/src/platforms/android/androidvpnactivity.h
@@ -74,7 +74,7 @@ enum ServiceEvents {
   EVENT_REQUEST_NOTIFICATION_PERMISSION = 8,
   // Signals MozillaVPN that we have completed onboarding
   EVENT_ONBOARDING_COMPLETED = 9,
-  // Signals the ConnectionManager that it may now allow 
+  // Signals the ConnectionManager that it may now allow
   // activation retries now that the system vpn config modal
   // has been responded to
   EVENT_VPN_CONFIG_PERMISSION_RESPONSE = 10,

--- a/src/platforms/android/androidvpnactivity.h
+++ b/src/platforms/android/androidvpnactivity.h
@@ -73,6 +73,7 @@ enum ServiceEvents {
   // permissions, to show the "you're connected" messages.
   EVENT_REQUEST_NOTIFICATION_PERMISSION = 8,
   EVENT_ONBOARDING_COMPLETED = 9,
+  EVENT_ALLOW_VPN_CONFIG_OPTION_SELECTED = 10,
 };
 typedef enum ServiceEvents ServiceEvents;
 
@@ -96,6 +97,7 @@ class AndroidVPNActivity : public QObject {
   void eventStatisticUpdate(const QString& data);
   void eventActivationError(const QString& data);
   void eventOnboardingCompleted();
+  void eventAllowVpnConfigOptionSelected();
   void eventRequestGleanUploadEnabledState();
 
  private:

--- a/src/platforms/ios/ioscontroller.mm
+++ b/src/platforms/ios/ioscontroller.mm
@@ -160,6 +160,11 @@ void IOSController::activate(const InterfaceConfig& config, ConnectionManager::R
       }
       onboardingCompletedCallback:^() {
         MozillaVPN::instance()->onboardingCompleted();
+      }
+      allowVpnConfigOptionSelectedCallback:^() {
+        ConnectionManager* connectionManager = MozillaVPN::instance()->connectionManager();
+        Q_ASSERT(connectionManager);
+        connectionManager->startHandshakeTimer();
       }];
 }
 

--- a/src/platforms/ios/ioscontroller.mm
+++ b/src/platforms/ios/ioscontroller.mm
@@ -161,9 +161,8 @@ void IOSController::activate(const InterfaceConfig& config, ConnectionManager::R
       onboardingCompletedCallback:^() {
         MozillaVPN::instance()->onboardingCompleted();
       }
-      allowVpnConfigOptionSelectedCallback:^() {
+      vpnConfigPermissionResponseCallback:^() {
         ConnectionManager* connectionManager = MozillaVPN::instance()->connectionManager();
-        Q_ASSERT(connectionManager);
         connectionManager->startHandshakeTimer();
       }];
 }

--- a/src/platforms/ios/ioscontroller.swift
+++ b/src/platforms/ios/ioscontroller.swift
@@ -116,7 +116,7 @@ public class IOSControllerImpl : NSObject {
         }
     }
 
-    @objc func connect(dnsServer: String, serverIpv6Gateway: String, serverPublicKey: String, serverIpv4AddrIn: String, serverPort: Int,  allowedIPAddressRanges: Array<VPNIPAddressRange>, reason: Int, gleanDebugTag: String, isSuperDooperFeatureActive: Bool, installationId: String, isOnboarding: Bool, disconnectCallback: @escaping () -> Void, onboardingCompletedCallback: @escaping () -> Void) {
+    @objc func connect(dnsServer: String, serverIpv6Gateway: String, serverPublicKey: String, serverIpv4AddrIn: String, serverPort: Int,  allowedIPAddressRanges: Array<VPNIPAddressRange>, reason: Int, gleanDebugTag: String, isSuperDooperFeatureActive: Bool, installationId: String, isOnboarding: Bool, disconnectCallback: @escaping () -> Void, onboardingCompletedCallback: @escaping () -> Void, allowVpnConfigOptionSelectedCallback: @escaping () -> Void) {
         IOSControllerImpl.logger.debug(message: "Connecting")
 
         TunnelManager.withTunnel { tunnel in
@@ -152,11 +152,11 @@ public class IOSControllerImpl : NSObject {
 
             let config = TunnelConfiguration(name: VPN_NAME, interface: interface, peers: peerConfigurations)
 
-            return self.configureTunnel(config: config, reason: reason, serverName: serverIpv4AddrIn + ":\(serverPort )", gleanDebugTag: gleanDebugTag, isSuperDooperFeatureActive: isSuperDooperFeatureActive, installationId: installationId, isOnboarding: isOnboarding, disconnectCallback: disconnectCallback, onboardingCompletedCallback: onboardingCompletedCallback)
+            return self.configureTunnel(config: config, reason: reason, serverName: serverIpv4AddrIn + ":\(serverPort )", gleanDebugTag: gleanDebugTag, isSuperDooperFeatureActive: isSuperDooperFeatureActive, installationId: installationId, isOnboarding: isOnboarding, disconnectCallback: disconnectCallback, onboardingCompletedCallback: onboardingCompletedCallback, allowVpnConfigOptionSelectedCallback: allowVpnConfigOptionSelectedCallback)
         }
     }
 
-    func configureTunnel(config: TunnelConfiguration, reason: Int, serverName: String, gleanDebugTag: String, isSuperDooperFeatureActive: Bool, installationId: String, isOnboarding: Bool, disconnectCallback: @escaping () -> Void, onboardingCompletedCallback: @escaping () -> Void) {
+    func configureTunnel(config: TunnelConfiguration, reason: Int, serverName: String, gleanDebugTag: String, isSuperDooperFeatureActive: Bool, installationId: String, isOnboarding: Bool, disconnectCallback: @escaping () -> Void, onboardingCompletedCallback: @escaping () -> Void, allowVpnConfigOptionSelectedCallback: @escaping () -> Void) {
         TunnelManager.withTunnel { tunnel in
             let proto = NETunnelProviderProtocol(tunnelConfiguration: config)
             proto!.providerBundleIdentifier = TunnelManager.vpnBundleId
@@ -185,6 +185,10 @@ public class IOSControllerImpl : NSObject {
             tunnel.isEnabled = true
 
             return tunnel.saveToPreferences { saveError in
+                // User made a selection, at this point it is safe to run retries via
+                // ConnectionManager::startHandshakeTimer()
+                allowVpnConfigOptionSelectedCallback()
+
                 if let error = saveError {
                     IOSControllerImpl.logger.error(message: "Connect Tunnel Save Error: \(error)")
                     disconnectCallback()


### PR DESCRIPTION
## Description

- Prevents the VPN config system prompt from repeatedly showing when no selection (neither "Allow" or "Don't allow") has been made by the user.
  - This was due to the handshake timer that begins upon an activation request and retries to activate the VPN every 15 seconds, and is only stopped once a connection either succeeds or fails. In this case, the connection success/failure was delayed due to a required response by the user to either allow or not allow the vpn configuration to be made by the OS.
  - This caused onboarding to be automatically completed after the system prompt appears, ignoring it, and waiting 15 seconds 
- Repeatedly showing the VPN config system prompt when selecting "Don't allow" was resolved as part of #8328

## Reference

[VPN-5532](https://mozilla-hub.atlassian.net/browse/VPN-5532)

[VPN-5532]: https://mozilla-hub.atlassian.net/browse/VPN-5532?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ