### PR TITLE
No ticket - Nit: Fix wasm canvas container

### DIFF
--- a/wasm/main.css
+++ b/wasm/main.css
@@ -182,11 +182,9 @@ canvas {
 .canvas-bg {
 	box-shadow: var(--boxShadow);
 	border-radius: 2rem;
-	overflow: hidden;
 	background-color: rgba(14, 13, 26, 0.05);
-	min-width: 400px;
-	height: 70vh;
-	max-height: 760px;
+	width: fit-content;
+	height: fit-content;
 }
 
 .wasm-loaded .canvas-bg {


### PR DESCRIPTION
I recently changed the dimensos of the wasm canvas, because turns out that can cause testing issues.

Why? Because in order to click on something for tests it needs to be in screen, if it's below or above the fold the click is unsuccessful. Yes, we could have special cased WASM clicks and so on, but that sounds excessive, instead I changed the WASM canvas to always have the same dimensions as the Desktop client. (When we run these tests on mobile devices this may come back to bite us, but then we can come up with a more elegant solution e.g. always scroll to element before a click).

Anyways, that made the WASM client look weird. Just go to https://mozilla-mobile.github.io/mozilla-vpn-client/?branch=main and see for yourself. With this change it will look like this:

<img width="1356" alt="Screenshot 2023-11-07 at 17 39 02" src="https://github.com/mozilla-mobile/mozilla-vpn-client/assets/25176023/182de4de-4f76-4fd7-b6e6-e1663654e964">

A little bit better 👀 