### PR TITLE
Nit: don't download wintun for each build

### DIFF
--- a/taskcluster/ci/build/windows.yml
+++ b/taskcluster/ci/build/windows.yml
@@ -20,6 +20,7 @@ task-defaults:
             - win-perl
             - win-sentry-cli
             - win-conda
+            - wintun
         build:
             - artifact: mozillavpn-sources.tar.gz
         toolchain:

--- a/taskcluster/ci/fetch/kind.yml
+++ b/taskcluster/ci/fetch/kind.yml
@@ -71,6 +71,13 @@ tasks:
             sha256: d4517212c8ac44fd8b5ccc2d4d9f38c2dd924c77a81c2be92c3a72e70dd3e907
             artifact-name: miniconda_installer.exe
             size: 55780192
+    wintun:
+        description: Wintun Driver
+        fetch: 
+            type: static-url 
+            url: https://www.wintun.net/builds/wintun-0.12.zip
+            sha256: eba90e26686ed86595ae0a6d4d3f4f022924b1758f5148a32a91c60cc6e604df
+            size: 1192872
     macos-miniconda:
         description: MiniConda3 osx-x86 Python 3.10 
         fetch:

--- a/taskcluster/scripts/build/windows_clang_cl.ps1
+++ b/taskcluster/scripts/build/windows_clang_cl.ps1
@@ -80,6 +80,7 @@ if ($env:MOZ_SCM_LEVEL -eq "3") {
         -DCMAKE_BUILD_TYPE=Release `
         -DPYTHON_EXECUTABLE="$CONDA_PREFIX\python.exe" `
         -DGOLANG_BUILD_TOOL="$CONDA_PREFIX\bin\go.exe" `
+        -DWINTUN_FOLDER="$FETCHES_PATH\wintun" `
         -DCMAKE_PREFIX_PATH="$QTPATH/lib/cmake"
 }
 cmake --build $BUILD_DIR

--- a/windows/tunnel/CMakeLists.txt
+++ b/windows/tunnel/CMakeLists.txt
@@ -3,11 +3,19 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 ## Download and extract wintun.dll and friends.
-file(DOWNLOAD https://www.wintun.net/builds/wintun-0.12.zip
-    ${CMAKE_CURRENT_BINARY_DIR}/.deps/wintun.zip
-    EXPECTED_HASH SHA256=eba90e26686ed86595ae0a6d4d3f4f022924b1758f5148a32a91c60cc6e604df)
 
-file(ARCHIVE_EXTRACT INPUT ${CMAKE_CURRENT_BINARY_DIR}/.deps/wintun.zip DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/.deps)
+set(WINTUN_FOLDER $ENV{WINTUN_FOLDER} CACHE STRING "Path to Extracted Wintun Folder")
+
+if(NOT WINTUN_FOLDER)
+    message("Downloading Wintun, as WINTUN_FOLDER is unset")
+    file(DOWNLOAD https://www.wintun.net/builds/wintun-0.12.zip
+        ${CMAKE_CURRENT_BINARY_DIR}/.deps/wintun.zip
+        EXPECTED_HASH SHA256=eba90e26686ed86595ae0a6d4d3f4f022924b1758f5148a32a91c60cc6e604df
+    )
+    file(ARCHIVE_EXTRACT INPUT ${CMAKE_CURRENT_BINARY_DIR}/.deps/wintun.zip DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/.deps)
+
+    set(WINTUN_FOLDER ${CMAKE_CURRENT_BINARY_DIR}/.deps/wintun) 
+endif()
 
 ## Build the tunnel DLL
 add_custom_target(tunneldll ALL
@@ -25,6 +33,6 @@ set_directory_properties(PROPERTIES ADDITIONAL_MAKE_CLEAN_FILES ${CMAKE_BINARY_D
 
 install(FILES
     ${CMAKE_CURRENT_BINARY_DIR}/tunnel.dll
-    ${CMAKE_CURRENT_BINARY_DIR}/.deps/wintun/bin/${CMAKE_SYSTEM_PROCESSOR}/wintun.dll
+    ${WINTUN_FOLDER}/bin/${CMAKE_SYSTEM_PROCESSOR}/wintun.dll
     DESTINATION .
 )


### PR DESCRIPTION
## Description
We're currently downloading wintun on every init of the build folder from the interwebs. 
Now today that has been flaky, so let's have taskcluster fetch it and use that instead, so we don't hit the server everytime ,__,