### PR TITLE
VPN-4846: FPN trial subscription expiring message

### DIFF
--- a/addons/message_fpn_trial_subscription_expiring/getHelp.js
+++ b/addons/message_fpn_trial_subscription_expiring/getHelp.js
@@ -1,0 +1,25 @@
+(function(api) {
+  function versionCompare(a, b) {
+    for (let i = 0; i < 3; ++i) {
+      if (a[i] != b[i]) {
+        return a[i] > b[i] ? -1 : 1;
+      }
+    }
+    return 0;
+  }
+
+  const parts = api.env.versionString.split('.');
+
+  const version = parts.map(a => parseInt(a, 10));
+
+  //Post 2.16 API
+  if (versionCompare([2, 16, 0], version) >= 0) {
+	api.navigator.requestScreen(api.vpn.ScreenGetHelp);
+    return;
+  }
+  //Pre 2.16 API
+  else {
+  	api.navigator.requestScreen(api.navigator.ScreenGetHelp);
+  	return;
+  }
+})

--- a/addons/message_fpn_trial_subscription_expiring/isFpnTrial.js
+++ b/addons/message_fpn_trial_subscription_expiring/isFpnTrial.js
@@ -1,0 +1,8 @@
+(function(api, condition) {
+  //Enable message for users on the FPN 6 month trial plan only
+  const fpnPlanId = "price_1MzNRCJNcmPzuWtRMCwUWADu"
+  const subscriptionDataJson = JSON.parse(api.settings.subscriptionData)
+  const subscriptionPlanId = subscriptionDataJson["plan_id"]
+
+  subscriptionPlanId === fpnPlanId ? condition.enable() : condition.disable()
+});

--- a/addons/message_fpn_trial_subscription_expiring/manifest.json
+++ b/addons/message_fpn_trial_subscription_expiring/manifest.json
@@ -1,0 +1,35 @@
+{
+  "api_version": "0.1",
+  "id": "message_fpn_trial_subscription_expiring",
+  "name": "FPN trial subscription expiring",
+  "type": "message",
+  "conditions": {
+    "javascript": "isFpnTrial.js"
+  },
+  "message": {
+    "id": "message_fpn_trial_subscription_expiring",
+    "date": 1699470000,
+    "title": "Don’t lose your protection – get 20% off an annual plan",
+    "subtitle": "We hope you’ve been enjoying your 6-month free trial of Mozilla VPN. Your free trial is coming to an end on November 15, 2023.",
+    "badge": "warning",
+    "blocks": [
+      {
+        "id": "c_1",
+        "type": "text",
+        "content": "Want to keep protecting your privacy online? Look for a coupon code to get 20% off an annual plan, coming to your inbox Nov 15th."
+      },
+      {
+        "id": "c_2",
+        "type": "text",
+        "content": "Thanks for using Mozilla VPN!"
+      },
+      {
+        "id": "c_3",
+        "type": "button",
+        "style": "link",
+        "content": "Get help",
+        "javascript": "getHelp.js"
+      }
+    ]
+  }
+}

--- a/addons/message_fpn_trial_subscription_expiring/manifest.json
+++ b/addons/message_fpn_trial_subscription_expiring/manifest.json
@@ -2,6 +2,7 @@
   "api_version": "0.1",
   "id": "message_fpn_trial_subscription_expiring",
   "name": "FPN trial subscription expiring",
+  "translatable": false,
   "type": "message",
   "conditions": {
     "javascript": "isFpnTrial.js"

--- a/addons/message_fpn_trial_subscription_expiring/manifest.json
+++ b/addons/message_fpn_trial_subscription_expiring/manifest.json
@@ -5,14 +5,15 @@
   "translatable": false,
   "type": "message",
   "conditions": {
-    "javascript": "isFpnTrial.js"
+    "javascript": "isFpnTrial.js",
+    "locales": [ "en" ]
   },
   "message": {
     "id": "message_fpn_trial_subscription_expiring",
-    "date": 1699470000,
+    "date": 1699473600,
     "title": "Don’t lose your protection – get 20% off an annual plan",
     "subtitle": "We hope you’ve been enjoying your 6-month free trial of Mozilla VPN. Your free trial is coming to an end on November 15, 2023.",
-    "badge": "warning",
+    "badge": "new_update",
     "blocks": [
       {
         "id": "c_1",


### PR DESCRIPTION
## Description

- Message that will be sent to FPN users who were given a 6 month free trial
- Does not need translations
  - FPN was US-only so we're restricting this message to users who have there language set to english
- Timestamp is set to 20:00 GMT as we anticipate this message going out at that time or a little later

## Reference

[VPN-4846: Phase 3: Implement and release the in-app message for the free VPN users](https://mozilla-hub.atlassian.net/browse/VPN-4846)