### PR TITLE
VPN-5597: Fix a11y issues when Speed Test and IP Info panels are opened

### DIFF
--- a/src/translations/strings.yaml
+++ b/src/translations/strings.yaml
@@ -500,6 +500,9 @@ connectionInfo:
   connectionInformation:
     value: Connection information
     comment: Accessible label for the button that shows the IP info panel when clicked.
+  restartSpeedTest:
+    value: Restart speed test
+    comment: Accessible label for the button to restart the speed test upon its completion.
 
 crashreporter:
   mainTitle:

--- a/src/ui/screens/home/controller/ControllerNav.qml
+++ b/src/ui/screens/home/controller/ControllerNav.qml
@@ -23,6 +23,7 @@ ColumnLayout {
         text: titleText
         Layout.leftMargin: MZTheme.theme.windowMargin
         opacity: disableRowWhen ?  .7 : 1
+        Accessible.ignored: disableRowWhen || !visible
 
         Behavior on opacity {
             PropertyAnimation {

--- a/src/ui/screens/home/controller/ControllerView.qml
+++ b/src/ui/screens/home/controller/ControllerView.qml
@@ -471,7 +471,7 @@ Item {
             topMargin: MZTheme.theme.windowMargin / 2
         }
         accessibleName: box.connectionInfoScreenVisible ? connectionInfoCloseText : MZI18n.ConnectionInfoStartSpeedTest
-        Accessible.ignored: !visible
+        Accessible.ignored: !enabled || !visible
         buttonColorScheme: MZTheme.theme.iconButtonDarkBackground
         enabled: visible && !ipInfoPanel.isOpen
         opacity: visible ? 1 : 0
@@ -558,7 +558,7 @@ Item {
             objectName: "controllerTitle"
             lineHeight: 22
             font.pixelSize: 22
-            Accessible.ignored: connectionInfoScreenVisible || !visible
+            Accessible.ignored: connectionInfoScreenVisible || ipInfoPanel.isOpen || !visible
             Accessible.description: logoSubtitle.text
             width: parent.width
             onPaintedHeightChanged: if (visible) col.handleMultilineText()
@@ -596,6 +596,7 @@ Item {
 
             color: MZTheme.theme.white
             lineHeight: MZTheme.theme.controllerInterLineHeight
+            Accessible.ignored: connectionInfoScreenVisible || ipInfoPanel.isOpen || !visible
 
             //% "Secure and private"
             //: This refers to the user’s internet connection.

--- a/src/ui/screens/home/controller/connectionInfo/ConnectionInfoScreen.qml
+++ b/src/ui/screens/home/controller/connectionInfo/ConnectionInfoScreen.qml
@@ -167,8 +167,8 @@ Rectangle {
             topMargin: MZTheme.theme.windowMargin / 2
             rightMargin: MZTheme.theme.windowMargin / 2
         }
-        // TODO: Replace with localized string
-        accessibleName: "Restart speed test"
+
+        accessibleName: MZI18n.ConnectionInfoRestartSpeedTest
         buttonColorScheme: MZTheme.theme.iconButtonDarkBackground
         enabled: visible
         z: 1


### PR DESCRIPTION
## Description

When the Speed Test's Connection Info panel or the IP Info panel was opened, some elements in the Home screen that are under those panels ("Secure and Private", "Select location") were read by the screen reader. Fixed by ignoring them for Accessibility in this state.

Also fixed the following issues:
1. The Speed Test panel's connectionInfoToggleButton was being read when the IPInfoPanel was open.
2. The "Restart speed test" button label was not  localized.

## Reference

[VPN-5597](https://mozilla-hub.atlassian.net/browse/VPN-5597), [GitHub 8125](https://github.com/mozilla-mobile/mozilla-vpn-client/issues/8125)

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-5597]: https://mozilla-hub.atlassian.net/browse/VPN-5597?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ