### PR TITLE
VPN-4846: Add subscriptionDataChanged watcher to FPN message

### DIFF
--- a/addons/message_fpn_trial_subscription_expiring/isFpnTrial.js
+++ b/addons/message_fpn_trial_subscription_expiring/isFpnTrial.js
@@ -1,8 +1,15 @@
 (function(api, condition) {
-  //Enable message for users on the FPN 6 month trial plan only
-  const fpnPlanId = "price_1MzNRCJNcmPzuWtRMCwUWADu"
-  const subscriptionDataJson = JSON.parse(api.settings.subscriptionData)
-  const subscriptionPlanId = subscriptionDataJson["plan_id"]
+  function computeCondition() {
 
-  subscriptionPlanId === fpnPlanId ? condition.enable() : condition.disable()
+    //Enable message for users on the FPN 6 month trial plan only
+    const fpnPlanId = "price_1MzNRCJNcmPzuWtRMCwUWADu"
+    const subscriptionDataJson = JSON.parse(api.settings.subscriptionData)
+    const subscriptionPlanId = subscriptionDataJson["plan_id"]
+
+    subscriptionPlanId === fpnPlanId ? condition.enable() : condition.disable()
+  }
+
+  api.connectSignal(api.settings.subscriptionData, 'changed', () => computeCondition());
+
+  computeCondition();
 });


### PR DESCRIPTION
## Description

- Fast follow to #8510 addressing [this comment](https://github.com/mozilla-mobile/mozilla-vpn-client/pull/8510#discussion_r1387270769) regarding adding a watcher for a change in `subscriptionData` to re-evaluate the conditions for the message

- Although the scenarios are unlikely and very edge case-y, this will:
  - Prevent users who switch from an FPN subscription account to a non-FPN subscription account from seeing the message (without an app relaunch)
  - Allow users switching from a non-FPN subscription account to an FPN subscription account to see the message ((without an app relaunch)
  - Allow unauthenticated users who are signing in to an FPN subscription account to see the message (without an app relaunch)

*Note: "FPN subscription account" means an account that was in a 6-month free trial for being an FPN subscriber when it was sunset

## Reference

[VPN-4846: Phase 3: Implement and release the in-app message for the free VPN users](https://mozilla-hub.atlassian.net/browse/VPN-4846)