### PR TITLE
VPN-5251 - Address QA feedback

### DIFF
--- a/nebula/ui/components/inAppAuth/MZInAppAuthenticationLegalDisclaimer.qml
+++ b/nebula/ui/components/inAppAuth/MZInAppAuthenticationLegalDisclaimer.qml
@@ -34,8 +34,6 @@ ColumnLayout {
 
             Glean.interaction.privacyNoticeSelected.record({
                 screen: _telemetryScreenId,
-                action: "select",
-                element_id: "privacy_notice",
             });
 
             MZUrlOpener.openUrlLabel("privacyNotice");

--- a/src/ui/authenticationInApp/ViewAuthenticationSignIn.qml
+++ b/src/ui/authenticationInApp/ViewAuthenticationSignIn.qml
@@ -84,7 +84,13 @@ MZInAppAuthenticationBase {
         id: disclaimersLoader
 
         Layout.alignment: Qt.AlignHCenter
-        source: "qrc:/nebula/components/inAppAuth/MZInAppAuthenticationLegalDisclaimer.qml"
+
+        Component.onCompleted: {
+            disclaimersLoader.setSource(
+                "qrc:/nebula/components/inAppAuth/MZInAppAuthenticationLegalDisclaimer.qml",
+                { "_telemetryScreenId": authSignIn._telemetryScreenId }
+            );
+        }
     }
 
     _footerContent: Column {

--- a/src/ui/authenticationInApp/ViewAuthenticationSignUp.qml
+++ b/src/ui/authenticationInApp/ViewAuthenticationSignUp.qml
@@ -54,7 +54,7 @@ MZInAppAuthenticationBase {
     _disclaimers: Column {
         Layout.alignment: Qt.AlignHCenter
         MZInAppAuthenticationLegalDisclaimer {
-            _telemetryScreenId: _telemetryScreenId
+            _telemetryScreenId: authSignUp._telemetryScreenId
         }
     }
 

--- a/tests/functional/testAuthenticationInApp.js
+++ b/tests/functional/testAuthenticationInApp.js
@@ -668,7 +668,7 @@ describe('User authentication', function() {
             const endedOutcomeEvent = await vpn.gleanTestGetValue("outcome", "loginEnded", "main");
             assert.strictEqual(endedOutcomeEvent.length, 1);
 
-            // Make sure no 2fa outcome event was recorded
+            // Make sure no 2fa outcome event was NOT recorded
             const unwantedEvents = [
                 ...(await vpn.gleanTestGetValue("outcome", "twoFaVerificationFailed", "main")),
                 ...(await vpn.gleanTestGetValue("outcome", "twoFaVerificationSucceeded", "main"))

--- a/tests/functional/testAuthenticationInApp.js
+++ b/tests/functional/testAuthenticationInApp.js
@@ -667,6 +667,13 @@ describe('User authentication', function() {
 
             const endedOutcomeEvent = await vpn.gleanTestGetValue("outcome", "loginEnded", "main");
             assert.strictEqual(endedOutcomeEvent.length, 1);
+
+            // Make sure no 2fa outcome event was recorded
+            const unwantedEvents = [
+                ...(await vpn.gleanTestGetValue("outcome", "twoFaVerificationFailed", "main")),
+                ...(await vpn.gleanTestGetValue("outcome", "twoFaVerificationSucceeded", "main"))
+            ];
+            assert.strictEqual(unwantedEvents.length, 0);
         });
     });
 
@@ -946,6 +953,13 @@ describe('User authentication', function() {
 
             const completedOutcomeEvent = await vpn.gleanTestGetValue("outcome", "registrationCompleted", "main");
             assert.strictEqual(completedOutcomeEvent.length, 1);
+
+             // Make sure no 2fa outcome event was NOT recorded
+             const unwantedEvents = [
+                ...(await vpn.gleanTestGetValue("outcome", "twoFaVerificationFailed", "main")),
+                ...(await vpn.gleanTestGetValue("outcome", "twoFaVerificationSucceeded", "main"))
+            ];
+            assert.strictEqual(unwantedEvents.length, 0);
         });
     });
 

--- a/tests/functional/testAuthenticationInApp.js
+++ b/tests/functional/testAuthenticationInApp.js
@@ -668,7 +668,7 @@ describe('User authentication', function() {
             const endedOutcomeEvent = await vpn.gleanTestGetValue("outcome", "loginEnded", "main");
             assert.strictEqual(endedOutcomeEvent.length, 1);
 
-            // Make sure no 2fa outcome event was NOT recorded
+            // Make sure 2fa outcome event were NOT recorded
             const unwantedEvents = [
                 ...(await vpn.gleanTestGetValue("outcome", "twoFaVerificationFailed", "main")),
                 ...(await vpn.gleanTestGetValue("outcome", "twoFaVerificationSucceeded", "main"))


### PR DESCRIPTION
The two issues found by QA were:

1. Privacy notice and terms of service interaction events were not being recorded correctly. 
2. 2fa outcome events were being recorded for users that didn't go through 2fa. I have not been able to reproduce this, but I added test cases for it just in case (the tests pass).
