### PR TITLE
VPN-5098: add telemetry id to onboarding start screen

### DIFF
--- a/src/ui/screens/onboarding/OnboardingStartSlideMobile.qml
+++ b/src/ui/screens/onboarding/OnboardingStartSlideMobile.qml
@@ -13,6 +13,8 @@ import "qrc:/nebula/utils/MZUiUtils.js" as MZUiUtils
 ColumnLayout {
     id: root
 
+    property string telemetryScreenId: "network_permissions"
+
     signal nextClicked()
     signal backClicked()
 


### PR DESCRIPTION
## Description

- Somehow forgot the `telemetryScreenId` for the network permissions onboarding slide (mobile-only), which caused all telemetry impression/interaction events with the `screen:network_permissions` extra key to not be recorded 

## Reference

[VPN-5098: Improvement: Implement onboarding telemetry](https://mozilla-hub.atlassian.net/browse/VPN-5098)