### PR TITLE
VPN-4604 - Add utm params to subscription url

### DIFF
--- a/src/tasks/authenticate/desktopauthenticationlistener.cpp
+++ b/src/tasks/authenticate/desktopauthenticationlistener.cpp
@@ -66,6 +66,8 @@ void DesktopAuthenticationListener::start(Task* task,
 
   QUrlQuery query(url.query());
   query.addQueryItem("port", QString::number(m_server->port()));
+  query.addQueryItem("utm_medium", "vpn-client");
+  query.addQueryItem("utm_source", "desktop-signup-flow");
   url.setQuery(query);
 
   UrlOpener::instance()->openUrl(url);


### PR DESCRIPTION
The params are added to the login URL and are passed on to the subscription purchase page.
