### PR TITLE
VPN-5802: Onboarding - prevent buttons overlapping qr code

### DIFF
--- a/src/ui/screens/onboarding/OnboardingDevicesSlide.qml
+++ b/src/ui/screens/onboarding/OnboardingDevicesSlide.qml
@@ -133,6 +133,8 @@ ColumnLayout {
 
         Layout.maximumHeight: qrcodeSize
         Layout.maximumWidth: qrcodeSize
+        Layout.minimumHeight: qrcodeSize
+        Layout.minimumWidth: qrcodeSize
         Layout.alignment: Qt.AlignHCenter
 
         currentIndex: deviceTypeToggle.selectedIndex


### PR DESCRIPTION
## Description

- On devices with shorter screens, the "Next" and "Go back" buttons wouldn't respect the size of the QR code and would overlap it. Setting a minimum size on the QR codes layout resolves the issue

| Beforer  | After |
| ------------- | ------------- |
| <img width="472" alt="Screenshot 2023-11-09 at 12 30 31 PM" src="https://github.com/mozilla-mobile/mozilla-vpn-client/assets/15353801/b107b5fd-edaf-49f4-9780-4b553cb984fd"> | <img width="472" alt="Screenshot 2023-11-09 at 12 31 03 PM" src="https://github.com/mozilla-mobile/mozilla-vpn-client/assets/15353801/448181bc-b599-4d62-b31e-8bc44b268246"> |

## Reference

[VPN-5802: UI issues in the Devices screen while on small screens mobile devices](https://mozilla-hub.atlassian.net/browse/VPN-5802)
