### PR TITLE
Pin the qt version inside the packed conda env

### DIFF
--- a/taskcluster/scripts/toolchain/conda_pack_android.sh
+++ b/taskcluster/scripts/toolchain/conda_pack_android.sh
@@ -3,7 +3,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
-set -e
+
 
 echo pwd 
 ls 
@@ -13,6 +13,7 @@ ls
 /opt/conda/bin/conda install conda-pack -y
 
 /opt/conda/bin/conda env create -f env.yml -n vpn
+bash -l -c "conda activate vpn && conda env config vars set QT_VERSION=${QT_VERSION}"
 bash -l -c "conda activate vpn && ./scripts/android/conda_setup_sdk.sh"
 bash -l -c "conda activate vpn && ./scripts/android/conda_setup_qt.sh"
 bash -l -c "conda activate vpn && ./scripts/android/conda_trim.sh"

--- a/taskcluster/scripts/toolchain/conda_pack_android.sh
+++ b/taskcluster/scripts/toolchain/conda_pack_android.sh
@@ -3,7 +3,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
+set -e
 
 echo pwd 
 ls 


### PR DESCRIPTION
## Description
We override the QT_VERSION env variable in the toolchain-task using the env argument. 
The created env however still uses QT_VERSION used in env.yml. 
So the build runner will be using the conda-env version, therefore we need to set that in the conda-env, so it's properly pased on. 