### PR TITLE
Nit: Clean iOS build folder, if not empty

### DIFF
--- a/taskcluster/scripts/build/ios_build_no_adjust_cmake.sh
+++ b/taskcluster/scripts/build/ios_build_no_adjust_cmake.sh
@@ -46,6 +46,16 @@ print G "done."
 
 print Y "Configuring the build..."
 QTVERSION=$(ls ${MOZ_FETCHES_DIR}/qt_ios)
+
+
+if [ -d ${TASK_HOME}/build ]; then
+    echo "Found old build-folder, wierd!"
+    echo "Removing it..."
+    rm -r ${TASK_HOME}/build
+fi
+ mkdir ${TASK_HOME}/build
+
+
 mkdir ${TASK_HOME}/build
 
 $MOZ_FETCHES_DIR/qt_ios/$QTVERSION/ios/bin/qt-cmake -S . -B ${TASK_HOME}/build -GXcode \
@@ -55,8 +65,6 @@ $MOZ_FETCHES_DIR/qt_ios/$QTVERSION/ios/bin/qt-cmake -S . -B ${TASK_HOME}/build -
   -DCMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY="" \
   -DCMAKE_XCODE_ATTRIBUTE_CODE_SIGNING_REQUIRED="NO" \
   -DCMAKE_XCODE_ATTRIBUTE_CODE_SIGNING_ALLOWED="NO" \
-  -DSENTRY_DSN="dummy" \
-  -DSENTRY_ENVELOPE_ENDPOINT="dummy" \
   -DCMAKE_BUILD_TYPE=Release
 
 print Y "Building the client..."

--- a/taskcluster/scripts/build/ios_build_no_adjust_cmake.sh
+++ b/taskcluster/scripts/build/ios_build_no_adjust_cmake.sh
@@ -49,7 +49,7 @@ QTVERSION=$(ls ${MOZ_FETCHES_DIR}/qt_ios)
 
 
 if [ -d ${TASK_HOME}/build ]; then
-    echo "Found old build-folder, wierd!"
+    echo "Found old build-folder, weird!"
     echo "Removing it..."
     rm -r ${TASK_HOME}/build
 fi

--- a/taskcluster/scripts/build/ios_build_no_adjust_cmake.sh
+++ b/taskcluster/scripts/build/ios_build_no_adjust_cmake.sh
@@ -53,10 +53,9 @@ if [ -d ${TASK_HOME}/build ]; then
     echo "Removing it..."
     rm -r ${TASK_HOME}/build
 fi
- mkdir ${TASK_HOME}/build
-
-
 mkdir ${TASK_HOME}/build
+
+
 
 $MOZ_FETCHES_DIR/qt_ios/$QTVERSION/ios/bin/qt-cmake -S . -B ${TASK_HOME}/build -GXcode \
   -DQT_HOST_PATH="$MOZ_FETCHES_DIR/qt_ios/$QTVERSION/macos" \

--- a/taskcluster/scripts/build/macos_build.sh
+++ b/taskcluster/scripts/build/macos_build.sh
@@ -92,7 +92,7 @@ fi
 
 print Y "Configuring the build..."
 if [ -d ${TASK_HOME}/build ]; then
-    echo "Found old build-folder, wierd!"
+    echo "Found old build-folder, weird!"
     echo "Removing it..."
     rm -r ${TASK_HOME}/build
 fi

--- a/taskcluster/scripts/build/macos_build.sh
+++ b/taskcluster/scripts/build/macos_build.sh
@@ -96,7 +96,7 @@ if [ -d ${TASK_HOME}/build ]; then
     echo "Removing it..."
     rm -r ${TASK_HOME}/build
 fi
- mkdir ${TASK_HOME}/build
+mkdir ${TASK_HOME}/build
 
 cmake -S . -B ${TASK_HOME}/build -GNinja \
         -DCMAKE_PREFIX_PATH=${MOZ_FETCHES_DIR}/qt_dist/lib/cmake \

--- a/taskcluster/scripts/build/macos_build.sh
+++ b/taskcluster/scripts/build/macos_build.sh
@@ -91,7 +91,12 @@ then
 fi
 
 print Y "Configuring the build..."
-mkdir ${TASK_HOME}/build
+if [ -d ${TASK_HOME}/build ]; then
+    echo "Found old build-folder, wierd!"
+    echo "Removing it..."
+    rm -r ${TASK_HOME}/build
+fi
+ mkdir ${TASK_HOME}/build
 
 cmake -S . -B ${TASK_HOME}/build -GNinja \
         -DCMAKE_PREFIX_PATH=${MOZ_FETCHES_DIR}/qt_dist/lib/cmake \


### PR DESCRIPTION
## Description

See: https://github.com/mozilla-mobile/mozilla-vpn-client/pull/8541/checks?check_run_id=18627540446 
This has now been happening too often 😅 
Are we re-using task-id's again? 



