### PR TITLE
VPN-5578: Work around lack of built-in RadioButton selection a11y support on Windows

### DIFF
--- a/nebula/ui/components/MZAlert.qml
+++ b/nebula/ui/components/MZAlert.qml
@@ -355,7 +355,8 @@ Rectangle {
     }
 
     function onShowCompleted() {
-        MZAccessibleNotification.notify(label, alertBox.alertText + ". " + alertBox.alertActionText);
+        if (!label.Accessible.ignored)
+            MZAccessibleNotification.notify(label, alertBox.alertText + ". " + alertBox.alertActionText);
     }
 
     function remove() {

--- a/nebula/ui/components/MZRadioDelegate.qml
+++ b/nebula/ui/components/MZRadioDelegate.qml
@@ -12,7 +12,7 @@ RadioDelegate {
 
     property bool isHoverable: true
     property var radioButtonLabelText
-    property string accessibleName
+    property string accessibleName: ""
     property bool isRadioButtonLabelAccessible: true
     property var uiState: MZTheme.theme.uiState
     readonly property int labelX: radioButton.anchors.margins + radioButton.implicitWidth + radioButtonLabel.anchors.leftMargin
@@ -44,8 +44,23 @@ RadioDelegate {
             radioControl.clicked();
     }
 
+    function handleAccessiblePressAction() {
+        let prevAccessibleName = radioControl.Accessible.name;
+
+        clicked();
+
+        // Currently, Qt doesn't have built-in accessibility support for screen readers to announce the selection of a radio button through
+        // PressAction. A workaround on Windows is to manually raise the "Selected" state as an Accessible Notification.
+        // Don't do this if the selection also changes focus, as the screen reader will read the newly focused control. Also, don't do this
+        // if the selection changes the Accessible Name, as the screen reader will read the new name and state, making the extra "Selected"
+        // notification redundant.
+        if (radioControl.checked && !radioControl.Accessible.ignored 
+                && radioControl.activeFocus && radioControl.Accessible.name === prevAccessibleName)
+            MZAccessibleNotification.notify(radioControl, MZI18n.AccessibilitySelected);
+    }
+
     Accessible.name: accessibleName
-    Accessible.onPressAction: clicked()
+    Accessible.onPressAction: handleAccessiblePressAction()
     Accessible.focusable: true
     Accessible.ignored: !visible
 

--- a/nebula/ui/components/forms/MZContextualAlert.qml
+++ b/nebula/ui/components/forms/MZContextualAlert.qml
@@ -56,7 +56,8 @@ RowLayout {
     ]
 
     function onShowCompleted() {
-        MZAccessibleNotification.notify(messageText, messageText.text);
+        if (!messageText.Accessible.ignored)
+            MZAccessibleNotification.notify(messageText, messageText.text);
     }
 
     MZIcon {

--- a/nebula/ui/components/forms/MZRadioButton.qml
+++ b/nebula/ui/components/forms/MZRadioButton.qml
@@ -41,8 +41,23 @@ RadioDelegate {
             radioControl.clicked();
     }
 
+    function handleAccessiblePressAction() {
+        let prevAccessibleName = radioControl.Accessible.name;
+
+        clicked();
+
+        // Currently, Qt doesn't have built-in accessibility support for screen readers to announce the selection of a radio button through
+        // PressAction. A workaround on Windows is to manually raise the "Selected" state as an Accessible Notification.
+        // Don't do this if the selection also changes focus, as the screen reader will read the newly focused control. Also, don't do this
+        // if the selection changes the Accessible Name, as the screen reader will read the new name and state, making the extra "Selected"
+        // notification redundant.
+        if (radioControl.checked && !radioControl.Accessible.ignored
+                && radioControl.activeFocus && radioControl.Accessible.name === prevAccessibleName)
+            MZAccessibleNotification.notify(radioControl, MZI18n.AccessibilitySelected);
+    }
+
     Accessible.name: accessibleName
-    Accessible.onPressAction: clicked()
+    Accessible.onPressAction: handleAccessiblePressAction()
     Accessible.focusable: true
     Accessible.ignored: !visible
 

--- a/src/localizer.cpp
+++ b/src/localizer.cpp
@@ -326,9 +326,6 @@ void Localizer::settingsChanged() {
   mozilla::glean::settings::using_system_language.set(code.isEmpty());
 
   m_code = code;
-
-  beginResetModel();
-  endResetModel();
 }
 
 bool Localizer::loadLanguage(const QString& requestedLocalCode) {

--- a/src/translations/strings.yaml
+++ b/src/translations/strings.yaml
@@ -737,6 +737,9 @@ accessibility:
       - Used by screen readers to denote that a particular item is currently selected.
       - For example, given a segmented control with 2 items, where the first item is currently selected. We want the screen reader to read out "Selected, <item name>".
       - The %1 represents the name of the selected item.
+  selected:
+    value: "Selected"
+    comment: Used by screen reader to indicate that a user action selected an item.
 
 freeTrials:
   startYourFreeTrial:

--- a/src/translations/strings.yaml
+++ b/src/translations/strings.yaml
@@ -738,7 +738,7 @@ accessibility:
       - For example, given a segmented control with 2 items, where the first item is currently selected. We want the screen reader to read out "Selected, <item name>".
       - The %1 represents the name of the selected item.
   selected:
-    value: "Selected"
+    value: Selected
     comment: Used by screen reader to indicate that a user action selected an item.
 
 freeTrials:

--- a/src/ui/screens/home/controller/ConnectionStability.qml
+++ b/src/ui/screens/home/controller/ConnectionStability.qml
@@ -30,8 +30,11 @@ Item {
         }
 
         // Notify accessibility client of connection health problems
-        let notificationText = stabilityLabel.text + ". " + stabilityLabelInstruction.text;
-        MZAccessibleNotification.notify(stabilityLabel, notificationText);
+        if (!stabilityLabel.Accessible.ignored)
+        {
+            let notificationText = stabilityLabel.text + ". " + stabilityLabelInstruction.text;
+            MZAccessibleNotification.notify(stabilityLabel, notificationText);
+        }
     }
 
     GridLayout {

--- a/src/ui/screens/home/controller/ControllerView.qml
+++ b/src/ui/screens/home/controller/ControllerView.qml
@@ -21,13 +21,15 @@ Item {
 
     function handleConnectionStateChange() {
         // Notify accessibility client of connection state
-        let notificationText = (logoTitle.text + '. ');
-        if (logoSubtitle.visible)
-            notificationText += (logoSubtitle.text + '. ');
-        if (connectedStateDescription.visible)
-            notificationText += (connectedStateDescription.text + '. ');
+        if (!logoTitle.Accessible.ignored) {
+            let notificationText = (logoTitle.text + '. ');
+            if (logoSubtitle.visible)
+                notificationText += (logoSubtitle.text + '. ');
+            if (connectedStateDescription.visible)
+                notificationText += (connectedStateDescription.text + '. ');
 
-        MZAccessibleNotification.notify(logoTitle, notificationText);
+            MZAccessibleNotification.notify(logoTitle, notificationText);
+        }
     }
 
     Layout.preferredHeight: 318

--- a/src/ui/screens/settings/ViewLanguage.qml
+++ b/src/ui/screens/settings/ViewLanguage.qml
@@ -70,7 +70,7 @@ MZViewBase {
         ColumnLayout {
             spacing: 0
             visible: searchBar.isEmpty
-
+            
             MZRadioDelegate {
                 id: systemLanguageRadioButton
                 objectName: "systemLanguageRadioButton"
@@ -109,7 +109,7 @@ MZViewBase {
                 Layout.leftMargin: 18.5
                 Layout.rightMargin: 18.5
 
-                color: "#E7E7E7"
+                color: MZTheme.theme.input.highlight
             }
         }
 


### PR DESCRIPTION
## Description

The selected state of a Radio Button is not read by the screen reader on Windows  when activated through the Accessibility PressAction command. This is a Qt limitation. Worked around by raising a "Selected" accessible notification. Accessible notifications currently are supported only in Windows by Qt. 

This workaround excludes the following scenarios, as explained in the code comment, to prevent a redundant notification:
1. When the radio button's selection causes focus to change, as seen in the DNS Settings screen, when custom DNS is selected.
2. When the radio button's selection causes the Accessible name to change, as seen in the Languages screen, when an unrelated new language is chosen.

Also, fixed the following:
1. Improved performance in the Languages screen by removing the unnecessary resetting of the model in  `Localizer::settingsChanged` when a new language is selected.  The model reset also broke the screen reading experience on Windows because the old radio item that raised the  focus notification was no longer present after the model reset, since it was replaced by a new radio button.
2. Handled hidden screens in the StackView when raising accessible notifications for elements with changed text due to a new language selection. This ensures that only elements with `Accessible.ignored == false` raise these notifications, preventing unnecessary notifications from hidden text elements (where `Accessible.ignored == true`), when the language is changed.
3. Used the highlight color from the themes file instead of hard coding, in the Languages screen

## Reference
[VPN-5578](https://mozilla-hub.atlassian.net/browse/VPN-5578), [GitHub 8097](https://github.com/mozilla-mobile/mozilla-vpn-client/issues/8097)

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-5578]: https://mozilla-hub.atlassian.net/browse/VPN-5578?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ