### PR TITLE
VPN-5098: Remove telemetry for data collection checkbox

### DIFF
--- a/src/telemetry/interaction_metrics.yaml
+++ b/src/telemetry/interaction_metrics.yaml
@@ -492,44 +492,6 @@ interaction:
         description: |
           The screen where the interaction happened
         type: string
-  data_collection_enabled:
-    type: event
-    lifetime: ping
-    send_in_pings:
-        - main
-    description: |
-        The user has checked the data collection checkbox
-    bugs:
-        - https://mozilla-hub.atlassian.net/browse/VPN-5098
-    data_reviews:
-        - https://github.com/mozilla-mobile/mozilla-vpn-client/pull/8493#issuecomment-1799126384
-    data_sensitivity:
-        - interaction
-    notification_emails:
-      - vpn-telemetry@mozilla.com
-      - mlichtenstein@mozilla.com
-    expires: never
-    extra_keys: *interaction_extra_keys
-  data_collection_disabled:
-    type: event
-    lifetime: ping
-    send_in_pings:
-        - main
-    description: |
-        The user has unchecked the data collection checkbox. 
-        If in onboarding (denoted by screen:data_collection), 
-        this does not actually disable data collection until onboarding is completed
-    bugs:
-        - https://mozilla-hub.atlassian.net/browse/VPN-5098
-    data_reviews:
-        - https://github.com/mozilla-mobile/mozilla-vpn-client/pull/8493#issuecomment-1799126384
-    data_sensitivity:
-        - interaction
-    notification_emails:
-      - vpn-telemetry@mozilla.com
-      - mlichtenstein@mozilla.com
-    expires: never
-    extra_keys: *interaction_extra_keys
   block_ads_enabled:
     type: event
     lifetime: ping

--- a/src/ui/screens/onboarding/OnboardingDataSlide.qml
+++ b/src/ui/screens/onboarding/OnboardingDataSlide.qml
@@ -53,20 +53,7 @@ ColumnLayout {
         showDivider: false
         isChecked: MZSettings.onboardingDataCollectionEnabled
 
-        onClicked: {
-            MZSettings.onboardingDataCollectionEnabled = !MZSettings.onboardingDataCollectionEnabled
-
-            if (MZSettings.onboardingDataCollectionEnabled) {
-                Glean.interaction.dataCollectionEnabled.record({
-                    screen: root.telemetryScreenId,
-                });
-            }
-            else {
-                Glean.interaction.dataCollectionDisabled.record({
-                    screen: root.telemetryScreenId,
-                });
-            }
-        }
+        onClicked: MZSettings.onboardingDataCollectionEnabled = !MZSettings.onboardingDataCollectionEnabled
     }
 
     Item {

--- a/tests/functional/testOnboarding.js
+++ b/tests/functional/testOnboarding.js
@@ -556,20 +556,6 @@ describe('Onboarding', function() {
     it('Data slide events are recorded', async () => {
       await vpn.waitForQuery(queries.screenOnboarding.DATA_SLIDE.visible());
 
-      //Verify that dataCollectionEnabled event is recorded
-      await vpn.waitForQueryAndClick(queries.screenOnboarding.DATA_CHECKBOX.visible());
-      const dataCollectionEnabledEvents = await vpn.gleanTestGetValue("interaction", "dataCollectionEnabled", "main");
-      assert.equal(dataCollectionEnabledEvents.length, 1);
-      const dataCollectionEnabledExtras = dataCollectionEnabledEvents[0].extra;
-      assert.equal(dataScreenTelemetryId, dataCollectionEnabledExtras.screen);
-
-      //Verify that dataCollectionDisabled event is recorded
-      await vpn.waitForQueryAndClick(queries.screenOnboarding.DATA_CHECKBOX.visible());
-      const dataCollectionDisabledEvents = await vpn.gleanTestGetValue("interaction", "dataCollectionDisabled", "main");
-      assert.equal(dataCollectionDisabledEvents.length, 1);
-      const dataCollectionDisabledExtras = dataCollectionDisabledEvents[0].extra;
-      assert.equal(dataScreenTelemetryId, dataCollectionDisabledExtras.screen);
-
       //Verify that privacyNoticedSelected event is recorded
       await vpn.waitForQueryAndClick(queries.screenOnboarding.DATA_PRIVACY_LINK.visible());
       const privacyNoticeSelectedEvents = await vpn.gleanTestGetValue("interaction", "privacyNoticeSelected", "main");


### PR DESCRIPTION
## Description

- Remove telemetry for data collection checkbox in onboarding, as it is not deemed to be userful

## Reference

[VPN-5098: Improvement: Implement onboarding telemetry](https://mozilla-hub.atlassian.net/browse/VPN-5098)