### PR TITLE
VPN-5385 - register callback to make Android back work

### DIFF
--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -2281,6 +2281,8 @@ void MozillaVPN::registerExternalOperations() {
         new TaskControllerAction(TaskControllerAction::eDeactivate));
   });
 
+  eoh->registerExternalOperation(ExternalOpHandler::OpCloseEvent, []() {});
+
   eoh->registerExternalOperation(OpNotificationClicked, []() {});
 
   eoh->registerExternalOperation(


### PR DESCRIPTION
## Description

The intended flow of a back button press:
- `handleBackButton` is called
- Which calls `Navigator::instance()->eventHandled()`
- One of the first lines of that function is `if (!ExternalOpHandler::instance()->request(
          ExternalOpHandler::OpCloseEvent))`... 
- ... and in the middle of that function lies these two lines: `Q_ASSERT(m_ops.contains(op));` and `if (!m_ops.contains(op))`.
- Since we weren't registering this event, it was failing the assert (or on release, always returning `false` due to this if statement).

My guess is this bug was introduced in flattening the app (or making it a multi-app repo), but I didn't do the research to confirm this.

## Reference

https://mozilla-hub.atlassian.net/browse/VPN-5385

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
