### PR TITLE
VPN-5766 - Fix CountdownTimer generation timing

### DIFF
--- a/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/VPNService.kt
+++ b/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/VPNService.kt
@@ -39,7 +39,7 @@ class VPNService : android.net.VpnService() {
     private var mCityname = ""
     private var mBackgroundPingTimerMSec: Long = 3 * 60 * 60 * 1000 // 3 hours, in milliseconds
     private var mShortTimerBackgroundPingMSec: Long = 3 * 60 * 1000 // 3 minutes, in milliseconds
-    private val mMetricsTimer: CountDownTimer  = object : CountDownTimer(
+    private val mMetricsTimer: CountDownTimer = object : CountDownTimer(
         if (isUsingShortTimerSessionPing) mShortTimerBackgroundPingMSec else mBackgroundPingTimerMSec,
         if (isUsingShortTimerSessionPing) mShortTimerBackgroundPingMSec / 4 else mBackgroundPingTimerMSec / 4,
     ) {

--- a/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/VPNService.kt
+++ b/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/VPNService.kt
@@ -39,21 +39,19 @@ class VPNService : android.net.VpnService() {
     private var mCityname = ""
     private var mBackgroundPingTimerMSec: Long = 3 * 60 * 60 * 1000 // 3 hours, in milliseconds
     private var mShortTimerBackgroundPingMSec: Long = 3 * 60 * 1000 // 3 minutes, in milliseconds
-    private val mMetricsTimer: CountDownTimer by lazy {
-        object : CountDownTimer(
-            if (isUsingShortTimerSessionPing) mShortTimerBackgroundPingMSec else mBackgroundPingTimerMSec,
-            if (isUsingShortTimerSessionPing) mShortTimerBackgroundPingMSec / 4 else mBackgroundPingTimerMSec / 4,
-        ) {
-            override fun onTick(millisUntilFinished: Long) {}
-            override fun onFinish() {
-                Log.i(tag, "Sending daemon_timer ping")
-                if (isSuperDooperMetricsActive) {
-                    Pings.daemonsession.submit(
-                        Pings.daemonsessionReasonCodes.daemonTimer,
-                    )
-                }
-                this.start()
+    private val mMetricsTimer: CountDownTimer  = object : CountDownTimer(
+        if (isUsingShortTimerSessionPing) mShortTimerBackgroundPingMSec else mBackgroundPingTimerMSec,
+        if (isUsingShortTimerSessionPing) mShortTimerBackgroundPingMSec / 4 else mBackgroundPingTimerMSec / 4,
+    ) {
+        override fun onTick(millisUntilFinished: Long) {}
+        override fun onFinish() {
+            Log.i(tag, "Sending daemon_timer ping")
+            if (isSuperDooperMetricsActive) {
+                Pings.daemonsession.submit(
+                    Pings.daemonsessionReasonCodes.daemonTimer,
+                )
             }
+            this.start()
         }
     }
 


### PR DESCRIPTION
When the generation of this object was changed to be lazy, it would be created inside the `VPNService.turnOn` method. That method is called in a thread that is not equipped to create timers causing a crash and thus the issue described on VPN-5766. 