### PR TITLE
VPN-4228: MacOS daemon recovery on crash

### DIFF
--- a/nebula/ui/components/MZSystemAlert.qml
+++ b/nebula/ui/components/MZSystemAlert.qml
@@ -72,13 +72,7 @@ MZAlert {
                     target: alertBox
                     //% "Background service error"
                     alertText: qsTrId("vpn.alert.backendServiceError")
-                    //% "Restore"
-                    //: Restore a service in case of error.
-                    alertActionText: qsTrId("vpn.alert.restore")
                     visible: true
-                    onActionPressed: ()=>{
-                        VPN.backendServiceRestore();
-                    }
                 }
             },
             State {

--- a/nebula/ui/components/MZSystemAlert.qml
+++ b/nebula/ui/components/MZSystemAlert.qml
@@ -81,9 +81,6 @@ MZAlert {
                     target: alertBox
                     alertText: qsTrId("vpn.alert.backendServiceError")
                     visible: true
-                    onActionPressed: ()=>{
-                        VPN.backendServiceRestore();
-                    }
                 }
             },
             State {
@@ -93,9 +90,6 @@ MZAlert {
                     //% "Remote service error"
                     alertText: qsTrId("vpn.alert.remoteServiceError")
                     visible: true
-                    onActionPressed: ()=>{
-                        VPN.backendServiceRestore();
-                    }
                 }
             },
             State {

--- a/src/cmake/macos.cmake
+++ b/src/cmake/macos.cmake
@@ -59,6 +59,8 @@ target_sources(mozillavpn PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/platforms/macos/daemon/macosdaemon.h
     ${CMAKE_CURRENT_SOURCE_DIR}/platforms/macos/daemon/macosdaemonserver.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/platforms/macos/daemon/macosdaemonserver.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/platforms/macos/daemon/macosdnsmanager.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/platforms/macos/daemon/macosdnsmanager.h
     ${CMAKE_CURRENT_SOURCE_DIR}/platforms/macos/daemon/macosroutemonitor.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/platforms/macos/daemon/macosroutemonitor.h
     ${CMAKE_CURRENT_SOURCE_DIR}/platforms/macos/daemon/wireguardutilsmacos.cpp

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -231,9 +231,9 @@ void Controller::quit() {
   }
 }
 
-void Controller::testDaemonCrash() {
+void Controller::forceDaemonCrash() {
   if (m_impl) {
-    m_impl->testDaemonCrash();
+    m_impl->forceDaemonCrash();
   }
 }
 

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -231,6 +231,12 @@ void Controller::quit() {
   }
 }
 
+void Controller::testDaemonCrash() {
+  if (m_impl) {
+    m_impl->testDaemonCrash();
+  }
+}
+
 void Controller::deleteOSTunnelConfig() {
   if (m_impl) {
     m_impl->deleteOSTunnelConfig();

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -164,8 +164,6 @@ void Controller::implInitialized(bool status, bool a_connected,
                  << "connected:" << a_connected
                  << "connectionDate:" << connectionDate.toString();
 
-  Q_ASSERT(m_state == Controller::StateInitializing);
-
   if (!status) {
     REPORTERROR(ErrorHandler::ControllerError, "controller");
     setState(StateOff);

--- a/src/controller.h
+++ b/src/controller.h
@@ -98,7 +98,7 @@ class Controller : public QObject, public LogSerializer {
   bool deactivate();
 
   Q_INVOKABLE void quit();
-  Q_INVOKABLE void testDaemonCrash();
+  Q_INVOKABLE void forceDaemonCrash();
 
  private:
   Q_PROPERTY(State state READ state NOTIFY stateChanged)

--- a/src/controller.h
+++ b/src/controller.h
@@ -98,6 +98,7 @@ class Controller : public QObject, public LogSerializer {
   bool deactivate();
 
   Q_INVOKABLE void quit();
+  Q_INVOKABLE void testDaemonCrash();
 
  private:
   Q_PROPERTY(State state READ state NOTIFY stateChanged)

--- a/src/controllerimpl.h
+++ b/src/controllerimpl.h
@@ -51,6 +51,8 @@ class ControllerImpl : public QObject {
   // tunnel cannot be reactivated in system settings.
   virtual void deleteOSTunnelConfig(){};
 
+  virtual void testDaemonCrash() { /* not implemented */ }
+
   // This method is used to retrieve the VPN tunnel status (mainly the number
   // of bytes sent and received). It's called always when the VPN tunnel is
   // active.

--- a/src/controllerimpl.h
+++ b/src/controllerimpl.h
@@ -53,7 +53,7 @@ class ControllerImpl : public QObject {
 
   // This method attempts to force the daemon to crash, and is used for
   // testing the ability of the VPN to recover from a backend error.
-  virtual void testDaemonCrash() {}
+  virtual void forceDaemonCrash() {}
 
   // This method is used to retrieve the VPN tunnel status (mainly the number
   // of bytes sent and received). It's called always when the VPN tunnel is

--- a/src/controllerimpl.h
+++ b/src/controllerimpl.h
@@ -51,7 +51,7 @@ class ControllerImpl : public QObject {
   // tunnel cannot be reactivated in system settings.
   virtual void deleteOSTunnelConfig(){};
 
-  virtual void testDaemonCrash() { /* not implemented */ }
+  virtual void testDaemonCrash(){}
 
   // This method is used to retrieve the VPN tunnel status (mainly the number
   // of bytes sent and received). It's called always when the VPN tunnel is

--- a/src/controllerimpl.h
+++ b/src/controllerimpl.h
@@ -51,7 +51,9 @@ class ControllerImpl : public QObject {
   // tunnel cannot be reactivated in system settings.
   virtual void deleteOSTunnelConfig(){};
 
-  virtual void testDaemonCrash(){}
+  // This method attempts to force the daemon to crash, and is used for
+  // testing the ability of the VPN to recover from a backend error.
+  virtual void testDaemonCrash() {}
 
   // This method is used to retrieve the VPN tunnel status (mainly the number
   // of bytes sent and received). It's called always when the VPN tunnel is

--- a/src/localsocketcontroller.cpp
+++ b/src/localsocketcontroller.cpp
@@ -4,23 +4,14 @@
 
 #include "localsocketcontroller.h"
 
-#include <QDir>
 #include <QFileInfo>
-#include <QHostAddress>
-#include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QJsonValue>
-#include <QStandardPaths>
 
 #include "errorhandler.h"
-#include "ipaddress.h"
 #include "leakdetector.h"
 #include "logger.h"
-#include "models/device.h"
-#include "models/keys.h"
-#include "models/server.h"
-#include "settingsholder.h"
 
 // When the daemon is unreachable, we will retry indefinitely using an
 // exponential backoff algorithm. The interval between retries starts at

--- a/src/localsocketcontroller.cpp
+++ b/src/localsocketcontroller.cpp
@@ -404,7 +404,7 @@ void LocalSocketController::clearAllTimeouts() {
   }
 }
 
-void LocalSocketController::testDaemonCrash() {
+void LocalSocketController::forceDaemonCrash() {
 #ifdef MZ_MACOS
   pid_t pid;
   socklen_t len = sizeof(pid);

--- a/src/localsocketcontroller.cpp
+++ b/src/localsocketcontroller.cpp
@@ -384,6 +384,9 @@ void LocalSocketController::write(const QJsonObject& message,
 }
 
 void LocalSocketController::clearTimeout(const QString& responseType) {
+  // We assume that responses arrive in the same order, the local socket
+  // API has no mechanism to detect out-of-order responses, and any change
+  // here to add such a mechanism would risk a compatibility issue.
   for (QTimer* t : m_responseTimeouts) {
     QVariant timerResponseType = t->property("responseType");
     if (timerResponseType.type() != QVariant::String) {

--- a/src/localsocketcontroller.cpp
+++ b/src/localsocketcontroller.cpp
@@ -359,7 +359,7 @@ void LocalSocketController::write(const QJsonObject& json,
   // throw an error if that response fails to arrive in a timely manner. This
   // is used to detect a crash or failure of the daemon.
   if (!expect.isEmpty()) {
-    QTimer *t = new QTimer(this);
+    QTimer* t = new QTimer(this);
     connect(t, &QTimer::timeout, this,
             [&] { this->errorOccurred(QLocalSocket::SocketTimeoutError); });
 

--- a/src/localsocketcontroller.cpp
+++ b/src/localsocketcontroller.cpp
@@ -20,8 +20,8 @@
 //
 // This means that if the daemon never starts, the steady-state behaviour will
 // have client to retry every 16 seconds indefinitely.
-constexpr int CONNECTION_RETRY_INITIAL_MSEC = 500; // 0.5 seconds
-constexpr int CONNECTION_RETRY_MAXIMUM_MSEC = 16000; // 16 seconds
+constexpr int CONNECTION_RETRY_INITIAL_MSEC = 500;    // 0.5 seconds
+constexpr int CONNECTION_RETRY_MAXIMUM_MSEC = 16000;  // 16 seconds
 
 namespace {
 Logger logger("LocalSocketController");

--- a/src/localsocketcontroller.cpp
+++ b/src/localsocketcontroller.cpp
@@ -14,15 +14,15 @@
 #include "logger.h"
 
 #ifdef MZ_MACOS
-#include <Security/Authorization.h>
-#include <Security/AuthorizationTags.h>
-#include <signal.h>
-#include <sys/socket.h>
-#include <sys/un.h>
-#include <unistd.h>
+#  include <Security/Authorization.h>
+#  include <Security/AuthorizationTags.h>
+#  include <signal.h>
+#  include <sys/socket.h>
+#  include <sys/un.h>
+#  include <unistd.h>
 
-#include <QProcess>
-#include <QScopeGuard>
+#  include <QProcess>
+#  include <QScopeGuard>
 #endif
 
 // When the daemon is unreachable, we will retry indefinitely using an
@@ -420,7 +420,7 @@ void LocalSocketController::testDaemonCrash() {
   AuthorizationRef authRef;
   AuthorizationFlags authFlags =
       kAuthorizationFlagDefaults | kAuthorizationFlagInteractionAllowed |
-      kAuthorizationFlagPreAuthorize | kAuthorizationFlagExtendRights; 
+      kAuthorizationFlagPreAuthorize | kAuthorizationFlagExtendRights;
   OSStatus status = AuthorizationCreate(nullptr, kAuthorizationEmptyEnvironment,
                                         authFlags, &authRef);
   if (status != errAuthorizationSuccess) {

--- a/src/localsocketcontroller.cpp
+++ b/src/localsocketcontroller.cpp
@@ -375,7 +375,7 @@ void LocalSocketController::write(const QJsonObject& message,
     t->setSingleShot(true);
     t->start(timeout);
 
-    m_expectedResponses.append(t);
+    m_responseTimeouts.append(t);
   }
 
   Q_ASSERT(m_socket);
@@ -384,7 +384,7 @@ void LocalSocketController::write(const QJsonObject& message,
 }
 
 void LocalSocketController::clearTimeout(const QString& responseType) {
-  for (QTimer* t : m_expectedResponses) {
+  for (QTimer* t : m_responseTimeouts) {
     QVariant qv = t->property("responseType");
     if (qv.type() != QVariant::String) {
       continue;
@@ -392,14 +392,14 @@ void LocalSocketController::clearTimeout(const QString& responseType) {
     if (qv.toString() != responseType) {
       continue;
     }
-    m_expectedResponses.removeOne(t);
+    m_responseTimeouts.removeOne(t);
     delete t;
   }
 }
 
 void LocalSocketController::clearAllTimeouts() {
-  while (!m_expectedResponses.isEmpty()) {
-    QTimer* t = m_expectedResponses.takeFirst();
+  while (!m_responseTimeouts.isEmpty()) {
+    QTimer* t = m_responseTimeouts.takeFirst();
     delete t;
   }
 }

--- a/src/localsocketcontroller.cpp
+++ b/src/localsocketcontroller.cpp
@@ -31,7 +31,7 @@
 // with time between each retry clamped to the maximum value.
 //
 // This means that if the daemon never starts, the steady-state behaviour will
-// have client to retry every 16 seconds indefinitely.
+// have the client retry every 16 seconds indefinitely.
 constexpr int CONNECTION_RETRY_INITIAL_MSEC = 500;    // 0.5 seconds
 constexpr int CONNECTION_RETRY_MAXIMUM_MSEC = 16000;  // 16 seconds
 
@@ -385,11 +385,11 @@ void LocalSocketController::write(const QJsonObject& message,
 
 void LocalSocketController::clearTimeout(const QString& responseType) {
   for (QTimer* t : m_responseTimeouts) {
-    QVariant qv = t->property("responseType");
-    if (qv.type() != QVariant::String) {
+    QVariant timerResponseType = t->property("responseType");
+    if (timerResponseType.type() != QVariant::String) {
       continue;
     }
-    if (qv.toString() != responseType) {
+    if (timerResponseType.toString() != responseType) {
       continue;
     }
     m_responseTimeouts.removeOne(t);

--- a/src/localsocketcontroller.cpp
+++ b/src/localsocketcontroller.cpp
@@ -61,7 +61,7 @@ LocalSocketController::~LocalSocketController() {
 
 void LocalSocketController::errorOccurred(
     QLocalSocket::LocalSocketError error) {
-  logger.error() << "Error occurred:" << m_socket->errorString();
+  logger.error() << "Error occurred:" << error;
 
   if (m_daemonState != eInitializing) {
     REPORTERROR(ErrorHandler::ControllerError, "controller");
@@ -109,6 +109,7 @@ void LocalSocketController::initializeInternal() {
 #endif
 
   logger.debug() << "Connecting to:" << path;
+  m_socket->disconnectFromServer();
   m_socket->connectToServer(path);
 }
 

--- a/src/localsocketcontroller.cpp
+++ b/src/localsocketcontroller.cpp
@@ -17,8 +17,11 @@
 // exponential backoff algorithm. The interval between retries starts at
 // the initial value, and doubles after each failed connection attempt,
 // with time between each retry clamped to the maximum value.
-constexpr int CONNECTION_RETRY_INITIAL_MSEC = 500;
-constexpr int CONNECTION_RETRY_MAXIMUM_MSEC = 16000;
+//
+// This means that if the daemon never starts, the steady-state behaviour will
+// have client to retry every 16 seconds indefinitely.
+constexpr int CONNECTION_RETRY_INITIAL_MSEC = 500; // 0.5 seconds
+constexpr int CONNECTION_RETRY_MAXIMUM_MSEC = 16000; // 16 seconds
 
 namespace {
 Logger logger("LocalSocketController");

--- a/src/localsocketcontroller.cpp
+++ b/src/localsocketcontroller.cpp
@@ -50,9 +50,8 @@ LocalSocketController::LocalSocketController() {
           &LocalSocketController::initializeInternal);
 
   m_messageTimeout.setSingleShot(true);
-  connect(&m_messageTimeout, &QTimer::timeout, this, [&] {
-    this->errorOccurred(QLocalSocket::SocketTimeoutError);
-  });
+  connect(&m_messageTimeout, &QTimer::timeout, this,
+          [&] { this->errorOccurred(QLocalSocket::SocketTimeoutError); });
 }
 
 LocalSocketController::~LocalSocketController() {

--- a/src/localsocketcontroller.h
+++ b/src/localsocketcontroller.h
@@ -11,8 +11,6 @@
 
 #include "controllerimpl.h"
 
-
-
 class QJsonObject;
 
 class LocalSocketController final : public ControllerImpl {

--- a/src/localsocketcontroller.h
+++ b/src/localsocketcontroller.h
@@ -40,6 +40,8 @@ class LocalSocketController final : public ControllerImpl {
 
   bool multihopSupported() override { return true; }
 
+  void testDaemonCrash() override;
+
  private:
   void initializeInternal();
   void disconnectInternal();

--- a/src/localsocketcontroller.h
+++ b/src/localsocketcontroller.h
@@ -35,7 +35,7 @@ class LocalSocketController final : public ControllerImpl {
 
   bool multihopSupported() override { return true; }
 
-  void testDaemonCrash() override;
+  void forceDaemonCrash() override;
 
  private:
   // For messages that are expected to generate a synchronous response, this

--- a/src/localsocketcontroller.h
+++ b/src/localsocketcontroller.h
@@ -85,7 +85,7 @@ class LocalSocketController final : public ControllerImpl {
 
   // When a message to the daemon expects an immediate response, these
   // are used to trigger a timeout error if the response never arrives.
-  QList<QTimer*> m_expectedResponses;
+  QList<QTimer*> m_responseTimeouts;
 };
 
 #endif  // LOCALSOCKETCONTROLLER_H

--- a/src/localsocketcontroller.h
+++ b/src/localsocketcontroller.h
@@ -45,7 +45,7 @@ class LocalSocketController final : public ControllerImpl {
   void readData();
   void parseCommand(const QByteArray& command);
 
-  void write(const QJsonObject& json);
+  void write(const QJsonObject& json, const QString& expect = QString());
 
  private:
   enum {
@@ -62,7 +62,10 @@ class LocalSocketController final : public ControllerImpl {
   std::function<void(const QString&)> m_logCallback = nullptr;
 
   QTimer m_initializingTimer;
-  uint32_t m_initializingRetry = 0;
+  uint32_t m_initializingInterval;
+
+  QTimer m_messageTimeout;
+  QString m_messageExpected;
 };
 
 #endif  // LOCALSOCKETCONTROLLER_H

--- a/src/localsocketcontroller.h
+++ b/src/localsocketcontroller.h
@@ -49,6 +49,8 @@ class LocalSocketController final : public ControllerImpl {
   void errorOccurred(QLocalSocket::LocalSocketError socketError);
   void readData();
   void parseCommand(const QByteArray& command);
+  void disarmTimeout(const QString& responseType);
+  void clearAllTimeouts();
 
   /**
    * @brief Write a JSON message to the socket, sending it to the daemon.
@@ -80,8 +82,7 @@ class LocalSocketController final : public ControllerImpl {
 
   // When a message to the daemon expects an immediate response, these
   // are used to trigger a timeout error if the response never arrives.
-  QTimer m_responseTimeout;
-  QString m_responseExpected;
+  QList<QTimer*> m_expectedResponses;
 };
 
 #endif  // LOCALSOCKETCONTROLLER_H

--- a/src/localsocketcontroller.h
+++ b/src/localsocketcontroller.h
@@ -11,10 +11,7 @@
 
 #include "controllerimpl.h"
 
-// For messages that are expected to generate a synchronous response, this
-// defines the default time that we will wait before assuming an error in
-// the daemon has occured.
-constexpr int CONNECTION_RESPONSE_TIMEOUT_MSEC = 500;
+
 
 class QJsonObject;
 
@@ -43,6 +40,11 @@ class LocalSocketController final : public ControllerImpl {
   void testDaemonCrash() override;
 
  private:
+  // For messages that are expected to generate a synchronous response, this
+  // defines the default time that we will wait before assuming an error in
+  // the daemon has occured.
+  static constexpr int CONNECTION_RESPONSE_TIMEOUT_MSEC = 500;
+
   void initializeInternal();
   void disconnectInternal();
 
@@ -50,18 +52,20 @@ class LocalSocketController final : public ControllerImpl {
   void errorOccurred(QLocalSocket::LocalSocketError socketError);
   void readData();
   void parseCommand(const QByteArray& command);
-  void disarmTimeout(const QString& responseType);
+  void clearTimeout(const QString& responseType);
   void clearAllTimeouts();
 
   /**
    * @brief Write a JSON message to the socket, sending it to the daemon.
    *
-   * @param json - A JSON object describing the message to be sent.
-   * @param expect - An optional message type that we expect as a response.
+   * @param message - A JSON object describing the message to be sent.
+   * @param expectedResponseType - An optional message type that we expect as
+   *                               a response.
    * @param timeout - The timeout, in milliseconds, to wait for the response.
    * @return * void
    */
-  void write(const QJsonObject& json, const QString& expect = QString(),
+  void write(const QJsonObject& message,
+             const QString& expectedResponseType = QString(),
              int timeout = CONNECTION_RESPONSE_TIMEOUT_MSEC);
 
  private:

--- a/src/localsocketcontroller.h
+++ b/src/localsocketcontroller.h
@@ -5,7 +5,6 @@
 #ifndef LOCALSOCKETCONTROLLER_H
 #define LOCALSOCKETCONTROLLER_H
 
-#include <QHostAddress>
 #include <QLocalSocket>
 #include <QTimer>
 #include <functional>
@@ -78,7 +77,7 @@ class LocalSocketController final : public ControllerImpl {
   std::function<void(const QString&)> m_logCallback = nullptr;
 
   QTimer m_initializingTimer;
-  uint32_t m_initializingInterval;
+  uint32_t m_initializingInterval = 0;
 
   // When a message to the daemon expects an immediate response, these
   // are used to trigger a timeout error if the response never arrives.

--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -2160,6 +2160,15 @@ void MozillaVPN::registerInspectorCommands() {
         }
         return QJsonObject();
       });
+  
+#ifdef MZ_MACOS
+  InspectorHandler::registerCommand(
+      "force_daemon_crash", "Force the VPN daemon to crash", 0,
+      [](InspectorHandler*, const QList<QByteArray>&) {
+        MozillaVPN::instance()->controller()->testDaemonCrash();
+        return QJsonObject();
+      });
+#endif
 }
 
 // static

--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -2165,7 +2165,7 @@ void MozillaVPN::registerInspectorCommands() {
   InspectorHandler::registerCommand(
       "force_daemon_crash", "Force the VPN daemon to crash", 0,
       [](InspectorHandler*, const QList<QByteArray>&) {
-        MozillaVPN::instance()->controller()->testDaemonCrash();
+        MozillaVPN::instance()->controller()->forceDaemonCrash();
         return QJsonObject();
       });
 #endif

--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -2160,7 +2160,7 @@ void MozillaVPN::registerInspectorCommands() {
         }
         return QJsonObject();
       });
-  
+
 #ifdef MZ_MACOS
   InspectorHandler::registerCommand(
       "force_daemon_crash", "Force the VPN daemon to crash", 0,

--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -1165,11 +1165,6 @@ void MozillaVPN::controllerStateChanged() {
   NetworkManager::instance()->clearCache();
 }
 
-void MozillaVPN::backendServiceRestore() {
-  logger.debug() << "Background service restore request";
-  // TODO
-}
-
 void MozillaVPN::heartbeatCompleted(bool success) {
   logger.debug() << "Server-side check done:" << success;
 

--- a/src/mozillavpn.h
+++ b/src/mozillavpn.h
@@ -110,7 +110,6 @@ class MozillaVPN final : public App {
   Q_INVOKABLE void deactivate(bool block = false);
   Q_INVOKABLE void refreshDevices();
   Q_INVOKABLE void update();
-  Q_INVOKABLE void backendServiceRestore();
   Q_INVOKABLE void triggerHeartbeat();
   Q_INVOKABLE void createSupportTicket(const QString& email,
                                        const QString& subject,

--- a/src/platforms/macos/daemon/dnsutilsmacos.cpp
+++ b/src/platforms/macos/daemon/dnsutilsmacos.cpp
@@ -4,10 +4,8 @@
 
 #include "dnsutilsmacos.h"
 
-#include <systemconfiguration/scdynamicstore.h>
-#include <systemconfiguration/scpreferences.h>
-
-#include <QScopeGuard>
+#include <QCoreApplication>
+#include <QProcess>
 
 #include "leakdetector.h"
 #include "logger.h"
@@ -19,294 +17,52 @@ Logger logger("DnsUtilsMacos");
 DnsUtilsMacos::DnsUtilsMacos(QObject* parent) : DnsUtils(parent) {
   MZ_COUNT_CTOR(DnsUtilsMacos);
 
-  m_scStore = SCDynamicStoreCreate(kCFAllocatorSystemDefault,
-                                   CFSTR("mozillavpn"), nullptr, nullptr);
-  if (m_scStore == nullptr) {
-    logger.error() << "Failed to create system configuration store ref";
-  }
+  m_dnsManager.setProcessChannelMode(QProcess::MergedChannels);
+  connect(&m_dnsManager, SIGNAL(readyReadStandardOutput()), this,
+          SLOT(dnsManagerStdoutReady()));
 
   logger.debug() << "DnsUtilsMacos created.";
 }
 
 DnsUtilsMacos::~DnsUtilsMacos() {
   MZ_COUNT_DTOR(DnsUtilsMacos);
-  restoreResolvers();
+  if (!restoreResolvers()) {
+    m_dnsManager.kill();
+  }
   logger.debug() << "DnsUtilsMacos destroyed.";
 }
 
-static QString cfParseString(CFTypeRef ref) {
-  if (CFGetTypeID(ref) != CFStringGetTypeID()) {
-    return QString();
+void DnsUtilsMacos::dnsManagerStdoutReady() {
+  for (;;) {
+    QByteArray line = m_dnsManager.readLine();
+    if (line.length() <= 0) {
+      break;
+    }
+    logger.debug() << QString::fromUtf8(line);
   }
-
-  CFStringRef stringref = (CFStringRef)ref;
-  CFRange range;
-  range.location = 0;
-  range.length = CFStringGetLength(stringref);
-  if (range.length <= 0) {
-    return QString();
-  }
-
-  UniChar* buf = (UniChar*)malloc(range.length * sizeof(UniChar));
-  if (!buf) {
-    return QString();
-  }
-  auto guard = qScopeGuard([&] { free(buf); });
-
-  CFStringGetCharacters(stringref, range, buf);
-  return QString::fromUtf16(buf, range.length);
-}
-
-static QStringList cfParseStringList(CFTypeRef ref) {
-  if (CFGetTypeID(ref) != CFArrayGetTypeID()) {
-    return QStringList();
-  }
-
-  CFArrayRef array = (CFArrayRef)ref;
-  QStringList result;
-  for (CFIndex i = 0; i < CFArrayGetCount(array); i++) {
-    CFTypeRef value = CFArrayGetValueAtIndex(array, i);
-    result.append(cfParseString(value));
-  }
-
-  return result;
-}
-
-static void cfDictSetString(CFMutableDictionaryRef dict, CFStringRef name,
-                            const QString& value) {
-  if (value.isNull()) {
-    return;
-  }
-  CFStringRef cfValue = CFStringCreateWithCString(
-      kCFAllocatorSystemDefault, qUtf8Printable(value), kCFStringEncodingUTF8);
-  CFDictionarySetValue(dict, name, cfValue);
-  CFRelease(cfValue);
-}
-
-static void cfDictSetStringList(CFMutableDictionaryRef dict, CFStringRef name,
-                                const QStringList& valueList) {
-  if (valueList.isEmpty()) {
-    return;
-  }
-
-  CFMutableArrayRef array;
-  array = CFArrayCreateMutable(kCFAllocatorSystemDefault, 0,
-                               &kCFTypeArrayCallBacks);
-  if (array == nullptr) {
-    return;
-  }
-
-  for (const QString& rstring : valueList) {
-    CFStringRef cfAddr = CFStringCreateWithCString(kCFAllocatorSystemDefault,
-                                                   qUtf8Printable(rstring),
-                                                   kCFStringEncodingUTF8);
-    CFArrayAppendValue(array, cfAddr);
-    CFRelease(cfAddr);
-  }
-  CFDictionarySetValue(dict, name, array);
-  CFRelease(array);
 }
 
 bool DnsUtilsMacos::updateResolvers(const QString& ifname,
                                     const QList<QHostAddress>& resolvers) {
   Q_UNUSED(ifname);
 
-  // Prepare the DNS configuration.
-  CFMutableDictionaryRef dnsConfig = CFDictionaryCreateMutable(
-      kCFAllocatorSystemDefault, 0, &kCFCopyStringDictionaryKeyCallBacks,
-      &kCFTypeDictionaryValueCallBacks);
-  auto configGuard = qScopeGuard([&] { CFRelease(dnsConfig); });
-  QStringList list;
+  // Prepare the process arguments.
+  QStringList args;
+  args.append("macosdnsmanager");
   for (const QHostAddress& addr : resolvers) {
-    list.append(addr.toString());
-  }
-  cfDictSetStringList(dnsConfig, kSCPropNetDNSServerAddresses, list);
-  cfDictSetString(dnsConfig, kSCPropNetDNSDomainName, "lan");
-
-  // Take a snapshot of the DNS services, and start a process to restore it.
-  if (m_dnsSnapshotPid < 0) {
-    if (!takeDnsSnapshot()) {
-      return false;
-    }
+    args.append(addr.toString());
   }
 
-  // Get the list of current network services.
-  CFArrayRef netServices = SCDynamicStoreCopyKeyList(
-      m_scStore, CFSTR("Setup:/Network/Service/[0-9A-F-]+"));
-  if (netServices == nullptr) {
-    return false;
-  }
-  auto serviceGuard = qScopeGuard([&] { CFRelease(netServices); });
-
-  // Configure each network service to use our DNS.
-  for (CFIndex i = 0; i < CFArrayGetCount(netServices); i++) {
-    QString service = cfParseString(CFArrayGetValueAtIndex(netServices, i));
-    QString uuid = service.section('/', 3, 3);
-    if (uuid.isEmpty()) {
-      continue;
-    }
-
-    logger.debug() << "Setting DNS config for" << uuid;
-    CFStringRef dnsPath = CFStringCreateWithFormat(
-        kCFAllocatorSystemDefault, nullptr,
-        CFSTR("Setup:/Network/Service/%s/DNS"), qPrintable(uuid));
-    if (!dnsPath) {
-      continue;
-    }
-    SCDynamicStoreSetValue(m_scStore, dnsPath, dnsConfig);
-    CFRelease(dnsPath);
-  }
-
-  return true;
+  // Launch the DNS manager process.
+  m_dnsManager.start(qApp->applicationFilePath(), args);
+  return m_dnsManager.waitForStarted();
 }
 
 bool DnsUtilsMacos::restoreResolvers() {
-  if (m_dnsSnapshotPid < 0) {
-    logger.debug() << "No DNS resolvers to restore";
-    return false;
-  }
-
-  // Kill the DNS watchdog to restore the resolver configuration.
-  auto guard = qScopeGuard([&] { m_dnsSnapshotPid = -1; });
-  if (kill(m_dnsSnapshotPid, SIGINT) < 0) {
-    logger.debug() << "Failed to signal DNS restorer";
-    return false;
-  }
-
-  // Wait for the process to exit, and gather it's status.
-  int status = 0;
-  if (waitpid(m_dnsSnapshotPid, &status, 0) < 0) {
-    logger.debug() << "Failed to receive child status";
-  } else if (!WIFEXITED(status)) {
-    logger.error() << "Failed to terminate DNS restorer";
-  } else {
-    logger.info() << "DNS restorer completed:" << strerror(WEXITSTATUS(status));
-  }
-  return true;
-}
-
-DnsUtilsMacos::DnsBackup DnsUtilsMacos::backupService(const QString& uuid) {
-  DnsBackup backup;
-  CFStringRef path = CFStringCreateWithFormat(
-      kCFAllocatorSystemDefault, nullptr,
-      CFSTR("Setup:/Network/Service/%s/DNS"), qPrintable(uuid));
-  CFDictionaryRef config =
-      (CFDictionaryRef)SCDynamicStoreCopyValue(m_scStore, path);
-  auto serviceGuard = qScopeGuard([&] {
-    if (config) {
-      CFRelease(config);
-    }
-    CFRelease(path);
-  });
-
-  // Parse the DNS protocol entry and save it for later.
-  if (config) {
-    CFTypeRef value;
-    value = CFDictionaryGetValue(config, kSCPropNetDNSDomainName);
-    if (value) {
-      backup.m_domain = cfParseString(value);
-    }
-    value = CFDictionaryGetValue(config, kSCPropNetDNSServerAddresses);
-    if (value) {
-      backup.m_servers = cfParseStringList(value);
-    }
-    value = CFDictionaryGetValue(config, kSCPropNetDNSSearchDomains);
-    if (value) {
-      backup.m_search = cfParseStringList(value);
-    }
-    value = CFDictionaryGetValue(config, kSCPropNetDNSSortList);
-    if (value) {
-      backup.m_sortlist = cfParseStringList(value);
-    }
-  }
-
-  return backup;
-}
-
-// Fork a child process to handle restoration of the DNS configuration.
-// This ensures that we always cleanup after ourselves, even if the
-// daemon happens to crash.
-bool DnsUtilsMacos::takeDnsSnapshot(void) {
-  // Get the list of current network services.
-  CFArrayRef netServices = SCDynamicStoreCopyKeyList(
-      m_scStore, CFSTR("Setup:/Network/Service/[0-9A-F-]+"));
-  if (netServices == nullptr) {
-    return false;
-  }
-
-  // Take a snapshot of the DNS configuration.
-  QMap<QString, DnsBackup> snapshot;
-  for (CFIndex i = 0; i < CFArrayGetCount(netServices); i++) {
-    QString service = cfParseString(CFArrayGetValueAtIndex(netServices, i));
-    QString uuid = service.section('/', 3, 3);
-    if (uuid.isEmpty()) {
-      continue;
-    }
-    snapshot[uuid] = backupService(uuid);
-  }
-  CFRelease(netServices);
-
-  // Fork the process. The parent/daemon continues on doing daemon stuff.
-  int pid = fork();
-  if (pid < 0) {
-    logger.error() << "Failed to start DNS restoration watchdog";
-    return false;
-  }
-  if (pid > 0) {
-    m_dnsSnapshotPid = pid;
+  if (m_dnsManager.state() == QProcess::NotRunning) {
     return true;
   }
 
-  // If we get here, we are the child. Do nothing until the interface goes down.
-  int sig;
-  sigset_t set;
-  sigemptyset(&set);
-  sigaddset(&set, SIGINT);
-  sigaddset(&set, SIGTERM);
-  sigaddset(&set, SIGHUP);
-  signal(SIGINT, [](int s) { Q_UNUSED(s); });
-  signal(SIGTERM, [](int s) { Q_UNUSED(s); });
-  signal(SIGHUP, [](int s) { Q_UNUSED(s); });
-  if (sigwait(&set, &sig) != 0) {
-    // Something went horribly wrong.
-    exit(errno);
-  }
-  // If we receive a SIGHUP, then exit without restoring anything.
-  if (sig == SIGHUP) {
-    exit(0);
-  }
-
-  // Restore the snapshot of the DNS configuration.
-  SCDynamicStoreRef store =
-      SCDynamicStoreCreate(kCFAllocatorSystemDefault,
-                           CFSTR("mozillavpn-restorer"), nullptr, nullptr);
-
-  for (const QString& uuid : snapshot.keys()) {
-    CFStringRef path = CFStringCreateWithFormat(
-        kCFAllocatorSystemDefault, nullptr,
-        CFSTR("Setup:/Network/Service/%s/DNS"), qPrintable(uuid));
-
-    const DnsBackup& entry = snapshot[uuid];
-    if (entry.isValid()) {
-      CFMutableDictionaryRef config;
-      config = CFDictionaryCreateMutable(kCFAllocatorSystemDefault, 0,
-                                         &kCFCopyStringDictionaryKeyCallBacks,
-                                         &kCFTypeDictionaryValueCallBacks);
-
-      cfDictSetString(config, kSCPropNetDNSDomainName, entry.m_domain);
-      cfDictSetStringList(config, kSCPropNetDNSSearchDomains, entry.m_search);
-      cfDictSetStringList(config, kSCPropNetDNSServerAddresses,
-                          entry.m_servers);
-      cfDictSetStringList(config, kSCPropNetDNSSortList, entry.m_sortlist);
-      SCDynamicStoreSetValue(store, path, config);
-      CFRelease(config);
-    } else {
-      SCDynamicStoreRemoveValue(store, path);
-    }
-    CFRelease(path);
-  }
-
-  // Job is done.
-  exit(0);
-  return false;
+  m_dnsManager.terminate();
+  return m_dnsManager.waitForFinished();
 }

--- a/src/platforms/macos/daemon/dnsutilsmacos.cpp
+++ b/src/platforms/macos/daemon/dnsutilsmacos.cpp
@@ -13,7 +13,7 @@
 namespace {
 Logger logger("DnsUtilsMacos");
 Logger dnsManagerLogger("MacosDnsManager");
-}
+}  // namespace
 
 DnsUtilsMacos::DnsUtilsMacos(QObject* parent) : DnsUtils(parent) {
   MZ_COUNT_CTOR(DnsUtilsMacos);
@@ -70,6 +70,6 @@ bool DnsUtilsMacos::restoreResolvers() {
   }
 
   // Terminate the process gracefully with SIGTERM.
-  m_dnsManager.terminate(); 
+  m_dnsManager.terminate();
   return m_dnsManager.waitForFinished();
 }

--- a/src/platforms/macos/daemon/dnsutilsmacos.cpp
+++ b/src/platforms/macos/daemon/dnsutilsmacos.cpp
@@ -123,7 +123,7 @@ bool DnsUtilsMacos::updateResolvers(const QString& ifname,
   cfDictSetStringList(dnsConfig, kSCPropNetDNSServerAddresses, list);
   cfDictSetString(dnsConfig, kSCPropNetDNSDomainName, "lan");
 
-  // Take a snapshot of the DNS services, and start a watchdog process to restore it.
+  // Take a snapshot of the DNS services, and start a process to restore it.
   if (m_dnsSnapshotPid < 0) {
     if (!takeDnsSnapshot()) {
       return false;
@@ -246,7 +246,7 @@ bool DnsUtilsMacos::takeDnsSnapshot(void) {
   }
   CFRelease(netServices);
 
-  // Fork the process. The parent/daemon continues to live on doing daemon stuff.
+  // Fork the process. The parent/daemon continues on doing daemon stuff.
   int pid = fork();
   if (pid < 0) {
     logger.error() << "Failed to start DNS restoration watchdog";
@@ -264,9 +264,9 @@ bool DnsUtilsMacos::takeDnsSnapshot(void) {
   sigaddset(&set, SIGINT);
   sigaddset(&set, SIGTERM);
   sigaddset(&set, SIGHUP);
-  signal(SIGINT, [](int s){ Q_UNUSED(s); });
-  signal(SIGTERM, [](int s){ Q_UNUSED(s); });
-  signal(SIGHUP, [](int s){ Q_UNUSED(s); });
+  signal(SIGINT, [](int s) { Q_UNUSED(s); });
+  signal(SIGTERM, [](int s) { Q_UNUSED(s); });
+  signal(SIGHUP, [](int s) { Q_UNUSED(s); });
   if (sigwait(&set, &sig) != 0) {
     // Something went horribly wrong.
     exit(errno);
@@ -277,9 +277,9 @@ bool DnsUtilsMacos::takeDnsSnapshot(void) {
   }
 
   // Restore the snapshot of the DNS configuration.
-  SCDynamicStoreRef store = SCDynamicStoreCreate(kCFAllocatorSystemDefault,
-                                                 CFSTR("mozillavpn-restorer"),
-                                                 nullptr, nullptr);
+  SCDynamicStoreRef store =
+      SCDynamicStoreCreate(kCFAllocatorSystemDefault,
+                           CFSTR("mozillavpn-restorer"), nullptr, nullptr);
 
   for (const QString& uuid : snapshot.keys()) {
     CFStringRef path = CFStringCreateWithFormat(

--- a/src/platforms/macos/daemon/dnsutilsmacos.h
+++ b/src/platforms/macos/daemon/dnsutilsmacos.h
@@ -5,11 +5,8 @@
 #ifndef DNSUTILSMACOS_H
 #define DNSUTILSMACOS_H
 
-#include <systemconfiguration/scdynamicstore.h>
-#include <systemconfiguration/systemconfiguration.h>
-
 #include <QHostAddress>
-#include <QMap>
+#include <QProcess>
 #include <QString>
 
 #include "daemon/dnsutils.h"
@@ -25,27 +22,11 @@ class DnsUtilsMacos final : public DnsUtils {
                        const QList<QHostAddress>& resolvers) override;
   bool restoreResolvers() override;
 
- private:
-  class DnsBackup {
-   public:
-    DnsBackup() {}
-    bool isValid() const {
-      return !m_domain.isEmpty() || !m_search.isEmpty() ||
-             !m_servers.isEmpty() || !m_sortlist.isEmpty();
-    }
-
-    QString m_domain;
-    QStringList m_search;
-    QStringList m_servers;
-    QStringList m_sortlist;
-  };
-
-  SCDynamicStoreRef m_scStore = nullptr;
-  int m_dnsSnapshotPid = -1;
+ private slots:
+  void dnsManagerStdoutReady();
 
  private:
-  bool takeDnsSnapshot(void);
-  DnsBackup backupService(const QString& uuid);
+  QProcess m_dnsManager;
 };
 
 #endif  // DNSUTILSMACOS_H

--- a/src/platforms/macos/daemon/dnsutilsmacos.h
+++ b/src/platforms/macos/daemon/dnsutilsmacos.h
@@ -26,7 +26,7 @@ class DnsUtilsMacos final : public DnsUtils {
   void dnsManagerStdoutReady();
 
  private:
-  QProcess m_dnsManager;
+  QProcess m_dnsManagerProcess;
 };
 
 #endif  // DNSUTILSMACOS_H

--- a/src/platforms/macos/daemon/dnsutilsmacos.h
+++ b/src/platforms/macos/daemon/dnsutilsmacos.h
@@ -26,10 +26,6 @@ class DnsUtilsMacos final : public DnsUtils {
   bool restoreResolvers() override;
 
  private:
-  void backupResolvers();
-  void backupService(const QString& uuid);
-
- private:
   class DnsBackup {
    public:
     DnsBackup() {}
@@ -45,7 +41,11 @@ class DnsUtilsMacos final : public DnsUtils {
   };
 
   SCDynamicStoreRef m_scStore = nullptr;
-  QMap<QString, DnsBackup> m_prevServices;
+  int m_dnsSnapshotPid = -1;
+
+ private:
+  bool takeDnsSnapshot(void);
+  DnsBackup backupService(const QString& uuid);
 };
 
 #endif  // DNSUTILSMACOS_H

--- a/src/platforms/macos/daemon/macosdnsmanager.cpp
+++ b/src/platforms/macos/daemon/macosdnsmanager.cpp
@@ -35,7 +35,7 @@ MacOSDnsManager::~MacOSDnsManager() {
 
 int MacOSDnsManager::run(QStringList& tokens) {
   Q_ASSERT(!tokens.isEmpty());
-  QString appName = tokens[0];
+  const QString appName = tokens[0];
 
   QCoreApplication app(CommandLineParser::argc(), CommandLineParser::argv());
 
@@ -51,7 +51,7 @@ int MacOSDnsManager::run(QStringList& tokens) {
   }
 
   // Ensure that the DNS addresses we received are valid.
-  QStringList dnsAddrList = tokens.mid(1);
+  const QStringList dnsAddrList = tokens.mid(1);
   for (const QString& addr : dnsAddrList) {
     QHostAddress host = QHostAddress(addr);
     if (host.isNull()) {
@@ -66,11 +66,11 @@ int MacOSDnsManager::run(QStringList& tokens) {
   }
 
   // Prepare the updated DNS configuration.
-  CFMutableDictionaryRef dnsConfig = CFDictionaryCreateMutable(
+  const CFMutableDictionaryRef dnsConfig = CFDictionaryCreateMutable(
       kCFAllocatorSystemDefault, 0, &kCFCopyStringDictionaryKeyCallBacks,
       &kCFTypeDictionaryValueCallBacks);
   auto configGuard = qScopeGuard([&] { CFRelease(dnsConfig); });
-  cfDictSetStringList(dnsConfig, kSCPropNetDNSServerAddresses, tokens.mid(1));
+  cfDictSetStringList(dnsConfig, kSCPropNetDNSServerAddresses, dnsAddrList);
   cfDictSetString(dnsConfig, kSCPropNetDNSDomainName, "lan");
 
   // Open the system configuration store.
@@ -249,9 +249,8 @@ void MacOSDnsManager::cfDictSetStringList(CFMutableDictionaryRef dict,
     return;
   }
 
-  CFMutableArrayRef array;
-  array = CFArrayCreateMutable(kCFAllocatorSystemDefault, 0,
-                               &kCFTypeArrayCallBacks);
+  CFMutableArrayRef array = CFArrayCreateMutable(kCFAllocatorSystemDefault, 0,
+                                                 &kCFTypeArrayCallBacks);
   if (array == nullptr) {
     return;
   }

--- a/src/platforms/macos/daemon/macosdnsmanager.cpp
+++ b/src/platforms/macos/daemon/macosdnsmanager.cpp
@@ -237,9 +237,11 @@ int MacOSDnsManager::waitForTermination(void) {
   sigaddset(&set, SIGINT);
   sigaddset(&set, SIGTERM);
   sigaddset(&set, SIGHUP);
+  sigaddset(&set, SIGPIPE);
   signal(SIGINT, [](int s) { Q_UNUSED(s); });
   signal(SIGTERM, [](int s) { Q_UNUSED(s); });
   signal(SIGHUP, [](int s) { Q_UNUSED(s); });
+  signal(SIGPIPE, [](int s) { Q_UNUSED(s); });
   if (sigwait(&set, &sig) != 0) {
     // Something went horribly wrong.
     return SIGKILL;

--- a/src/platforms/macos/daemon/macosdnsmanager.cpp
+++ b/src/platforms/macos/daemon/macosdnsmanager.cpp
@@ -19,7 +19,8 @@
 #include "signalhandler.h"
 
 MacOSDnsManager::MacOSDnsManager(QObject* parent)
-    : Command(parent, "macosdnsmanager", "Update the DNS settings while the VPN is active") {
+    : Command(parent, "macosdnsmanager",
+              "Update the DNS settings while the VPN is active") {
   MZ_COUNT_CTOR(MacOSDnsManager);
 }
 
@@ -132,7 +133,7 @@ int MacOSDnsManager::run(QStringList& tokens) {
 
   // Open the system configuration store.
   m_scStore = SCDynamicStoreCreate(kCFAllocatorSystemDefault,
-                                  CFSTR("mozillavpn"), nullptr, nullptr);
+                                   CFSTR("mozillavpn"), nullptr, nullptr);
   if (m_scStore == nullptr) {
     stream << "Failed to open system configuration:" << scErrorMessage()
            << Qt::endl;

--- a/src/platforms/macos/daemon/macosdnsmanager.cpp
+++ b/src/platforms/macos/daemon/macosdnsmanager.cpp
@@ -175,7 +175,7 @@ int MacOSDnsManager::run(QStringList& tokens) {
 
 QStringList MacOSDnsManager::enumerateNetServices() {
   CFArrayRef netServices = SCDynamicStoreCopyKeyList(
-      m_scStore, CFSTR("Setup:/Network/Service/[0-9A-F-]+"));
+      m_scStore, CFSTR("Setup:/Network/Service/[0-9A-Fa-f-]+"));
   if (netServices == nullptr) {
     return QStringList();
   }

--- a/src/platforms/macos/daemon/macosdnsmanager.cpp
+++ b/src/platforms/macos/daemon/macosdnsmanager.cpp
@@ -1,0 +1,250 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "macosdnsmanager.h"
+
+#include <systemconfiguration/scdynamicstore.h>
+#include <systemconfiguration/scpreferences.h>
+#include <systemconfiguration/systemconfiguration.h>
+
+#include <QCoreApplication>
+#include <QHostAddress>
+#include <QScopeGuard>
+#include <QTextStream>
+
+#include "commandlineparser.h"
+#include "constants.h"
+#include "leakdetector.h"
+#include "signalhandler.h"
+
+MacOSDnsManager::MacOSDnsManager(QObject* parent)
+    : Command(parent, "macosdnsmanager", "Update the DNS settings while the VPN is active") {
+  MZ_COUNT_CTOR(MacOSDnsManager);
+}
+
+MacOSDnsManager::~MacOSDnsManager() {
+  if (m_scStore != nullptr) {
+    restoreSnapshot();
+    CFRelease(m_scStore);
+  }
+  MZ_COUNT_DTOR(MacOSDnsManager);
+}
+
+static QString cfParseString(CFTypeRef ref) {
+  if (CFGetTypeID(ref) != CFStringGetTypeID()) {
+    return QString();
+  }
+
+  CFStringRef stringref = (CFStringRef)ref;
+  CFRange range;
+  range.location = 0;
+  range.length = CFStringGetLength(stringref);
+  if (range.length <= 0) {
+    return QString();
+  }
+
+  UniChar* buf = (UniChar*)malloc(range.length * sizeof(UniChar));
+  if (!buf) {
+    return QString();
+  }
+  auto guard = qScopeGuard([&] { free(buf); });
+
+  CFStringGetCharacters(stringref, range, buf);
+  return QString::fromUtf16(buf, range.length);
+}
+
+static void cfDictSetString(CFMutableDictionaryRef dict, CFStringRef name,
+                            const QString& value) {
+  if (value.isNull()) {
+    return;
+  }
+  CFStringRef cfValue = CFStringCreateWithCString(
+      kCFAllocatorSystemDefault, qUtf8Printable(value), kCFStringEncodingUTF8);
+  CFDictionarySetValue(dict, name, cfValue);
+  CFRelease(cfValue);
+}
+
+static void cfDictSetStringList(CFMutableDictionaryRef dict, CFStringRef name,
+                                const QStringList& valueList) {
+  if (valueList.isEmpty()) {
+    return;
+  }
+
+  CFMutableArrayRef array;
+  array = CFArrayCreateMutable(kCFAllocatorSystemDefault, 0,
+                               &kCFTypeArrayCallBacks);
+  if (array == nullptr) {
+    return;
+  }
+
+  for (const QString& rstring : valueList) {
+    CFStringRef cfAddr = CFStringCreateWithCString(kCFAllocatorSystemDefault,
+                                                   qUtf8Printable(rstring),
+                                                   kCFStringEncodingUTF8);
+    CFArrayAppendValue(array, cfAddr);
+    CFRelease(cfAddr);
+  }
+  CFDictionarySetValue(dict, name, array);
+  CFRelease(array);
+}
+
+int MacOSDnsManager::run(QStringList& tokens) {
+  Q_ASSERT(!tokens.isEmpty());
+  QString appName = tokens[0];
+
+  QCoreApplication app(CommandLineParser::argc(), CommandLineParser::argv());
+
+  QCoreApplication::setApplicationName("Mozilla VPN DNS Manager");
+  QCoreApplication::setApplicationVersion(Constants::versionString());
+  QTextStream stream(stderr);
+
+  if (tokens.length() <= 1) {
+    stream << "Error: At least one DNS server address is required." << Qt::endl;
+    stream << Qt::endl;
+    stream << "Usage: [options] ADDR [ADDR ...]" << Qt::endl;
+    return 1;
+  }
+
+  // Ensure that the DNS addresses we received are valid.
+  QStringList dnsAddrList = tokens.mid(1);
+  for (const QString& addr : dnsAddrList) {
+    QHostAddress host = QHostAddress(addr);
+    if (host.isNull()) {
+      stream << "Error: DNS Server \'" << addr << "\' is invalid." << Qt::endl;
+      return 1;
+    }
+    if (host.isBroadcast() || host.isMulticast()) {
+      stream << "Error: DNS Server \'" << addr << "\' is a multicast address."
+             << Qt::endl;
+      return 1;
+    }
+    // TODO: Should we prohibit the loopback address?
+  }
+
+  // Prepare the updated DNS configuration.
+  CFMutableDictionaryRef dnsConfig = CFDictionaryCreateMutable(
+      kCFAllocatorSystemDefault, 0, &kCFCopyStringDictionaryKeyCallBacks,
+      &kCFTypeDictionaryValueCallBacks);
+  auto configGuard = qScopeGuard([&] { CFRelease(dnsConfig); });
+  cfDictSetStringList(dnsConfig, kSCPropNetDNSServerAddresses, tokens.mid(1));
+  cfDictSetString(dnsConfig, kSCPropNetDNSDomainName, "lan");
+
+  // Open the system configuration store.
+  m_scStore = SCDynamicStoreCreate(kCFAllocatorSystemDefault,
+                                  CFSTR("mozillavpn"), nullptr, nullptr);
+  if (m_scStore == nullptr) {
+    stream << "Failed to open system configuration:" << scErrorMessage()
+           << Qt::endl;
+    return 1;
+  }
+
+  // Get the list of current network services and take a snapshot.
+  for (const QString& uuid : enumerateNetServices()) {
+    stream << "Found network service: " << uuid << Qt::endl;
+    CFStringRef dnsPath = CFStringCreateWithFormat(
+        kCFAllocatorSystemDefault, nullptr,
+        CFSTR("Setup:/Network/Service/%s/DNS"), qPrintable(uuid));
+    auto pathGuard = qScopeGuard([&] { CFRelease(dnsPath); });
+
+    // Take a snapshot of the existing configuration.
+    m_snapshot[uuid] =
+        (CFDictionaryRef)SCDynamicStoreCopyValue(m_scStore, dnsPath);
+
+    // Install the updated configuration.
+    if (!SCDynamicStoreSetValue(m_scStore, dnsPath, dnsConfig)) {
+      stream << "Failed to update configuration for " << uuid << Qt::endl;
+      stream << "Error: " << scErrorMessage() << Qt::endl;
+      return 1;
+    }
+  }
+
+  // Block this process and wait for a termination signal.
+  stream << "Waiting for termination signal." << Qt::endl;
+  int sig = waitForTermination();
+  stream << "Caught signal " << sig << ". Preparing to exit." << Qt::endl;
+
+  // If we exit on SIGHUP, leave the DNS configuration in-place.
+  if (sig == SIGHUP) {
+    clearSnapshot();
+  }
+
+  // The DNS configuration should be resored by the destructor.
+  return 0;
+}
+
+QStringList MacOSDnsManager::enumerateNetServices() {
+  CFArrayRef netServices = SCDynamicStoreCopyKeyList(
+      m_scStore, CFSTR("Setup:/Network/Service/[0-9A-F-]+"));
+  if (netServices == nullptr) {
+    return QStringList();
+  }
+  auto serviceGuard = qScopeGuard([&] { CFRelease(netServices); });
+
+  QStringList result;
+  for (CFIndex i = 0; i < CFArrayGetCount(netServices); i++) {
+    QString service = cfParseString(CFArrayGetValueAtIndex(netServices, i));
+    QString uuid = service.section('/', 3, 3);
+    if (!uuid.isEmpty()) {
+      result.append(uuid);
+    }
+  }
+
+  return result;
+}
+
+QString MacOSDnsManager::scErrorMessage() {
+  int error = SCError();
+  return QString(SCErrorString(error));
+}
+
+void MacOSDnsManager::restoreSnapshot(void) {
+  Q_ASSERT(m_scStore != nullptr);
+
+  for (const QString& uuid : m_snapshot.keys()) {
+    CFStringRef dnsPath = CFStringCreateWithFormat(
+        kCFAllocatorSystemDefault, nullptr,
+        CFSTR("Setup:/Network/Service/%s/DNS"), qPrintable(uuid));
+
+    // Restore the snapshotted DNS configuration for this service.
+    CFDictionaryRef dnsConfig = m_snapshot.take(uuid);
+    if (dnsConfig) {
+      SCDynamicStoreSetValue(m_scStore, dnsPath, dnsConfig);
+      CFRelease(dnsConfig);
+    } else {
+      SCDynamicStoreRemoveValue(m_scStore, dnsPath);
+    }
+    CFRelease(dnsPath);
+  }
+}
+
+// Clear the DNS snapshot without doing anything.
+void MacOSDnsManager::clearSnapshot(void) {
+  for (CFDictionaryRef dnsConfig : m_snapshot) {
+    if (dnsConfig) {
+      CFRelease(dnsConfig);
+    }
+  }
+  m_snapshot.clear();
+}
+
+// Block the process and wait for a termination signal.
+// TODO: Also check for exit of the parent process.
+int MacOSDnsManager::waitForTermination(void) {
+  int sig;
+  sigset_t set;
+  sigemptyset(&set);
+  sigaddset(&set, SIGINT);
+  sigaddset(&set, SIGTERM);
+  sigaddset(&set, SIGHUP);
+  signal(SIGINT, [](int s) { Q_UNUSED(s); });
+  signal(SIGTERM, [](int s) { Q_UNUSED(s); });
+  signal(SIGHUP, [](int s) { Q_UNUSED(s); });
+  if (sigwait(&set, &sig) != 0) {
+    // Something went horribly wrong.
+    return SIGKILL;
+  }
+  return sig;
+}
+
+static Command::RegistrationProxy<MacOSDnsManager> s_commandMacOSDaemon;

--- a/src/platforms/macos/daemon/macosdnsmanager.cpp
+++ b/src/platforms/macos/daemon/macosdnsmanager.cpp
@@ -107,7 +107,8 @@ int MacOSDnsManager::run(QStringList& tokens) {
   int sig = waitForTermination();
   stream << "Caught signal " << sig << ". Preparing to exit." << Qt::endl;
 
-  // If we exit on SIGHUP, leave the DNS configuration in-place.
+  // SIGHUP is typically used to inform processes of a configuration change.
+  // Handle this for now by exiting without restoring the DNS resolver config.
   if (sig == SIGHUP) {
     clearSnapshot();
   }

--- a/src/platforms/macos/daemon/macosdnsmanager.cpp
+++ b/src/platforms/macos/daemon/macosdnsmanager.cpp
@@ -63,7 +63,6 @@ int MacOSDnsManager::run(QStringList& tokens) {
              << Qt::endl;
       return 1;
     }
-    // TODO: Should we prohibit the loopback address?
   }
 
   // Prepare the updated DNS configuration.

--- a/src/platforms/macos/daemon/macosdnsmanager.h
+++ b/src/platforms/macos/daemon/macosdnsmanager.h
@@ -11,6 +11,21 @@
 
 #include "command.h"
 
+// This class adds a command to the Mozilla VPN that overwrites the system
+// DNS configuration, and restores it upon program exit. This provides a
+// watchdog mechansim to ensure that no matter how the daemon termanates
+// (or crashes!) we always do our best to clean up.
+//
+// This command accepts DNS server addresses as positional arguments to be
+// applied to the system. For example:
+//   Mozilla\ VPN macosdnsmanager 8.8.8.8
+//
+// This program will exit upon the normal POSIX termination signals (eg:
+// SIGINT, SIGTERM and so on), or when it detects that the parent process
+// has exited via kqueue().
+//
+// To exit without restoring the DNS configuration, this program can be
+// sent the hang-up signal (SIGHUP).
 class MacOSDnsManager final : public Command {
  public:
   explicit MacOSDnsManager(QObject* parent);

--- a/src/platforms/macos/daemon/macosdnsmanager.h
+++ b/src/platforms/macos/daemon/macosdnsmanager.h
@@ -5,11 +5,11 @@
 #ifndef MACOSDNSMANAGER_H
 #define MACOSDNSMANAGER_H
 
-#include "command.h"
-
 #include <systemconfiguration/scdynamicstore.h>
 
 #include <QMap>
+
+#include "command.h"
 
 class MacOSDnsManager final : public Command {
  public:

--- a/src/platforms/macos/daemon/macosdnsmanager.h
+++ b/src/platforms/macos/daemon/macosdnsmanager.h
@@ -25,6 +25,13 @@ class MacOSDnsManager final : public Command {
   void clearSnapshot();
   int waitForTermination();
 
+  // Core foundation type handling helpers.
+  static QString cfParseString(CFTypeRef ref);
+  static void cfDictSetString(CFMutableDictionaryRef dict, CFStringRef name,
+                              const QString& value);
+  static void cfDictSetStringList(CFMutableDictionaryRef dict, CFStringRef name,
+                                  const QStringList& valueList);
+
  private:
   SCDynamicStoreRef m_scStore = nullptr;
   QMap<QString, CFDictionaryRef> m_snapshot;

--- a/src/platforms/macos/daemon/macosdnsmanager.h
+++ b/src/platforms/macos/daemon/macosdnsmanager.h
@@ -12,20 +12,20 @@
 #include "command.h"
 
 // This class adds a command to the Mozilla VPN that overwrites the system
-// DNS configuration, and restores it upon program exit. This provides a
-// watchdog mechansim to ensure that no matter how the daemon termanates
-// (or crashes!) we always do our best to clean up.
+// DNS configuration, and restores it upon program exit. When run in a separate
+// process, this provides a watchdog mechanism to ensure that no matter how the
+// daemon terminates (or crashes!) we always do our best to clean up.
 //
 // This command accepts DNS server addresses as positional arguments to be
 // applied to the system. For example:
 //   Mozilla\ VPN macosdnsmanager 8.8.8.8
 //
-// This program will exit upon the normal POSIX termination signals (eg:
-// SIGINT, SIGTERM and so on), or when it detects that the parent process
-// has exited via kqueue().
+// This program will exit upon the normal POSIX termination signals (eg: SIGINT
+// SIGTERM, and so on), or when it detects that the parent process has exited
+// via kqueue().
 //
-// To exit without restoring the DNS configuration, this program can be
-// sent the hang-up signal (SIGHUP).
+// To exit without restoring the DNS configuration, this program can be sent
+// the hang-up signal (SIGHUP).
 class MacOSDnsManager final : public Command {
  public:
   explicit MacOSDnsManager(QObject* parent);

--- a/src/platforms/macos/daemon/macosdnsmanager.h
+++ b/src/platforms/macos/daemon/macosdnsmanager.h
@@ -1,0 +1,33 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef MACOSDNSMANAGER_H
+#define MACOSDNSMANAGER_H
+
+#include "command.h"
+
+#include <systemconfiguration/scdynamicstore.h>
+
+#include <QMap>
+
+class MacOSDnsManager final : public Command {
+ public:
+  explicit MacOSDnsManager(QObject* parent);
+  ~MacOSDnsManager();
+
+  int run(QStringList& tokens) override;
+
+ private:
+  QStringList enumerateNetServices();
+  static QString scErrorMessage();
+  void restoreSnapshot();
+  void clearSnapshot();
+  int waitForTermination();
+
+ private:
+  SCDynamicStoreRef m_scStore = nullptr;
+  QMap<QString, CFDictionaryRef> m_snapshot;
+};
+
+#endif  // MACOSDNSMANAGER_H

--- a/tests/auth_tests/mocmozillavpn.cpp
+++ b/tests/auth_tests/mocmozillavpn.cpp
@@ -93,8 +93,6 @@ void MozillaVPN::setUpdating(bool) {}
 
 void MozillaVPN::controllerStateChanged() {}
 
-void MozillaVPN::backendServiceRestore() {}
-
 void MozillaVPN::heartbeatCompleted(bool) {}
 
 void MozillaVPN::triggerHeartbeat() {}

--- a/tests/qml/moccontroller.cpp
+++ b/tests/qml/moccontroller.cpp
@@ -88,3 +88,5 @@ QString Controller::currentServerString() const { return QString("42"); }
 
 void Controller::serializeLogs(
     std::function<void(const QString& name, const QString& logs)>&&) {}
+
+void Controller::forceDaemonCrash() {}

--- a/tests/qml/mocmozillavpn.cpp
+++ b/tests/qml/mocmozillavpn.cpp
@@ -109,8 +109,6 @@ void MozillaVPN::setUpdating(bool) {}
 
 void MozillaVPN::controllerStateChanged() {}
 
-void MozillaVPN::backendServiceRestore() {}
-
 void MozillaVPN::heartbeatCompleted(bool) {}
 
 void MozillaVPN::triggerHeartbeat() {}

--- a/tests/unit/moccontroller.cpp
+++ b/tests/unit/moccontroller.cpp
@@ -91,3 +91,5 @@ QString Controller::currentServerString() const { return QString("42"); }
 
 void Controller::serializeLogs(
     std::function<void(const QString& name, const QString& logs)>&&) {}
+
+void Controller::forceDaemonCrash() {}

--- a/tests/unit/mocmozillavpn.cpp
+++ b/tests/unit/mocmozillavpn.cpp
@@ -122,8 +122,6 @@ void MozillaVPN::setUpdating(bool) {}
 
 void MozillaVPN::controllerStateChanged() {}
 
-void MozillaVPN::backendServiceRestore() {}
-
 void MozillaVPN::heartbeatCompleted(bool) {}
 
 void MozillaVPN::triggerHeartbeat() {}

--- a/tests/unit_tests/mocmozillavpn.cpp
+++ b/tests/unit_tests/mocmozillavpn.cpp
@@ -94,8 +94,6 @@ void MozillaVPN::setUpdating(bool) {}
 
 void MozillaVPN::controllerStateChanged() {}
 
-void MozillaVPN::backendServiceRestore() {}
-
 void MozillaVPN::heartbeatCompleted(bool) {}
 
 void MozillaVPN::triggerHeartbeat() {}


### PR DESCRIPTION
## Description
In this PR we attempt to make the VPN client and daemon on MacOS more resilient to abnormal exit conditions in the VPN tunnel or daemon. To accomplish this goal, we made a few changes and tweaks:
- Check for and handle errors in the UNIX socket, and re-initialize of the socket closes on us.
- Remove the "try again" link in the backend failure banner, it doesn't do anything, and it never did anything.
- Permit the controller to re-initialize itself after a backend failure.
- Add optional timeouts on `LocalSocketController::write()` to catch cases where the daemon is hung.

This alone was sufficient to get the client to recover from a crash of the daemon. But there was still a problem: if the daemon crashes while the tunnel is active this will bring the tunnel down, but we don't get to run any cleanup code. This potentially results in leaving the user's DNS configuration in a broken state. To address this, the `DnsUtilsMacos` class was written to fork itself and handle this cleanup from a separate process.

While I was investigating this, I also had a look at converting the MacOS daemon into an on-demand startup mode, as supported by the `Sockets` dictionary in the Launchd [plist](https://www.manpagez.com/man/5/launchd.plist/). However, this would require moving the control socket path, which could bring with it potential compatibility issues and breakage. For this reason, I opted to leave the daemon's startup and keepalive behaviour as-is.

## Reference
Github issue #7988 ([VPN-4228](https://mozilla-hub.atlassian.net/browse/VPN-4228))
Github issue #8665 ([VPN-5931](https://mozilla-hub.atlassian.net/browse/VPN-5931))

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-4228]: https://mozilla-hub.atlassian.net/browse/VPN-4228?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ