### PR TITLE
VPN-5887: Fix tab and segmented toggle focus states

### DIFF
--- a/nebula/ui/components/MZSegmentedToggle.qml
+++ b/nebula/ui/components/MZSegmentedToggle.qml
@@ -110,15 +110,6 @@ Rectangle {
 
                 Accessible.name: (root.selectedIndex === index ? MZI18n.AccessibilitySelectedAndItemName.arg(MZI18n[segmentLabelStringId]) : MZI18n[segmentLabelStringId]) + MZI18n.AccessibilityCurrentIndexFocusedOfTotalItemsInGroup.arg(index + 1).arg(options.count)
 
-                Rectangle {
-                    anchors.fill: parent
-                    border.width: MZTheme.theme.focusBorderWidth
-                    border.color: MZTheme.theme.fontColor
-                    color: MZTheme.theme.transparent
-                    visible: parent.focus
-                    radius: root.radius
-                }
-
                 onFocusChanged: {
                     if(!root.anySegmentFocused()) root.focusedViaClick = false
                 }

--- a/nebula/ui/components/MZTabNavigation.qml
+++ b/nebula/ui/components/MZTabNavigation.qml
@@ -79,16 +79,6 @@ Item {
                     // Accessibility provided by btn's Accessible properties
                     Accessible.ignored: true
 
-                    Rectangle {
-                        anchors.fill: parent
-                        anchors.margins: 2
-                        border.width: MZTheme.theme.focusBorderWidth
-                        border.color: MZTheme.theme.fontColor
-                        color: MZTheme.theme.transparent
-                        visible: btn.activeFocus
-                        radius: 4
-                    }
-
                     Behavior on color {
                         PropertyAnimation {
                             duration: 100


### PR DESCRIPTION
## Description

- Restore focus states of `MZTabNavigation` buttons and `MZSegmentedToggle`'s to how they were prior to tutorial removal. We only used these outlines for focusing on these components during tutorials, so lets remove them

## Reference

[VPN-5887: Text elements of the tabbed bars from Select location screen are bordered when being pressed ](https://mozilla-hub.atlassian.net/browse/VPN-5887)
