### PR TITLE
Move unit tests for linux to taskcluster?

### DIFF
--- a/taskcluster/ci/config.yml
+++ b/taskcluster/ci/config.yml
@@ -10,6 +10,7 @@ treeherder:
         'lint': 'Linting tasks'
         'Fetch': 'Fetching Tasks'
         'TL': 'Toolchain Tasks'
+        'T': 'Testing Tasks'
         'rpk': 'Re-Package Tasks'
         'BM': 'Beetmover Tasks'
 

--- a/taskcluster/ci/test/kind.yml
+++ b/taskcluster/ci/test/kind.yml
@@ -9,25 +9,12 @@ transforms:
     - taskgraph.transforms.job:transforms
     - taskgraph.transforms.task:transforms
 
-tasks:
-    taskgraph-definition:
-        worker-type: b-linux
-        worker:
-            docker-image: {in-tree: base}
-            max-run-time: 3600
-        description: "Test the full `mozilla_vpn_taskgraph` to validate the latest changes"
-        treeherder:
-            symbol: test-taskgraph-definition
-            kind: test
-            platform: tests/opt
-            tier: 1
-        run:
-            using: run-task
-            use-caches: true
-            cwd: '{checkout}'
-            command: >-
-                pip3 install -r taskcluster/requirements.txt &&
-                for param in `ls taskcluster/test/params`; do
-                    taskgraph full -p taskcluster/test/params/$param
-                done &&
-                taskgraph full
+kind-dependencies:
+    - fetch
+    - toolchain
+    - build
+
+tasks-from: 
+    - taskcluster.yml
+    - unit.yml
+

--- a/taskcluster/ci/test/taskcluster.yml
+++ b/taskcluster/ci/test/taskcluster.yml
@@ -1,0 +1,25 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+taskgraph-definition:
+  worker-type: b-linux
+  worker:
+      docker-image: {in-tree: base}
+      max-run-time: 3600
+  description: "Test the full `mozilla_vpn_taskgraph` to validate the latest changes"
+  treeherder:
+      symbol: test-taskgraph-definition
+      kind: test
+      platform: tests/opt
+      tier: 1
+  run:
+      using: run-task
+      use-caches: true
+      cwd: '{checkout}'
+      command: >-
+          pip3 install -r taskcluster/requirements.txt &&
+          for param in `ls taskcluster/test/params`; do
+              taskgraph full -p taskcluster/test/params/$param
+          done &&
+          taskgraph full

--- a/taskcluster/ci/test/unit.yml
+++ b/taskcluster/ci/test/unit.yml
@@ -21,14 +21,14 @@ ctest-linux:
             - qt-linux
     worker-type: b-linux
     worker:
-        docker-image: {in-tree: linux-qt6-build}
+        docker-image: {in-tree: linux-build-focal}
     run:
         cwd: '{checkout}'
         command: >-
             pip install -r requirements.txt &&
             cmake -S . -B build -GNinja -DCMAKE_PREFIX_PATH=${MOZ_FETCHES_DIR}/qt_dist/lib/cmake -DCMAKE_BUILD_TYPE=Debug &&
             cmake --build build/ --target build_tests &&
-            ctest  --test-dir .\build\vpn\ 
+            ctest  --test-dir ./build/vpn
 
 
 

--- a/taskcluster/ci/test/unit.yml
+++ b/taskcluster/ci/test/unit.yml
@@ -25,7 +25,7 @@ ctest-linux:
     run:
         cwd: '{checkout}'
         command: >-
-            cmake -S . -B build -GNinja -DCMAKE_PREFIX_PATH=${MOZ_FETCHES_DIR}/lib/cmake -DCMAKE_BUILD_TYPE=Debug &&
+            cmake -S . -B build -GNinja -DCMAKE_PREFIX_PATH=${MOZ_FETCHES_DIR}/qt_dist/lib/cmake -DCMAKE_BUILD_TYPE=Debug &&
             cmake --build build/ --target build_tests &&
             ctest  --test-dir .\build\vpn\ 
 

--- a/taskcluster/ci/test/unit.yml
+++ b/taskcluster/ci/test/unit.yml
@@ -25,6 +25,7 @@ ctest-linux:
     run:
         cwd: '{checkout}'
         command: >-
+            pip install -r requirements.txt &&
             cmake -S . -B build -GNinja -DCMAKE_PREFIX_PATH=${MOZ_FETCHES_DIR}/qt_dist/lib/cmake -DCMAKE_BUILD_TYPE=Debug &&
             cmake --build build/ --target build_tests &&
             ctest  --test-dir .\build\vpn\ 

--- a/taskcluster/ci/test/unit.yml
+++ b/taskcluster/ci/test/unit.yml
@@ -1,0 +1,38 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+---
+task-defaults:
+    treeherder:
+        symbol: T(unit)
+        kind: test
+        tier: 1
+    worker:
+        max-run-time: 3600
+        chain-of-trust: true
+    run:
+        using: run-task
+        use-caches: true
+
+ctest-linux:
+    description: "Run full C-Test"
+    fetches:
+        toolchain:
+            - qt-linux
+    worker-type: b-linux
+    worker:
+        docker-image: {in-tree: linux-qt6-build}
+    run:
+        cwd: '{checkout}'
+        command: >-
+            cmake -S . -B build -GNinja -DCMAKE_PREFIX_PATH=${MOZ_FETCHES_DIR}/lib/cmake -DCMAKE_BUILD_TYPE=Debug &&
+            cmake --build build/ --target build_tests &&
+            ctest  --test-dir .\build\vpn\ 
+
+
+
+
+
+
+
+

--- a/taskcluster/docker/linux-qt6-build/Dockerfile
+++ b/taskcluster/docker/linux-qt6-build/Dockerfile
@@ -20,6 +20,7 @@ RUN apt-get -y install build-essential \
                        locales \
                        ninja-build \
                        patchelf \
+                       libsecret-1-dev \
                        sudo
 
 ## Install Qt6/X11 build dependencies

--- a/taskcluster/docker/linux-qt6-build/Dockerfile
+++ b/taskcluster/docker/linux-qt6-build/Dockerfile
@@ -20,7 +20,6 @@ RUN apt-get -y install build-essential \
                        locales \
                        ninja-build \
                        patchelf \
-                       libsecret-1-dev \
                        sudo
 
 ## Install Qt6/X11 build dependencies


### PR DESCRIPTION
## Description
Currently to build tests, we pull our 3rdparty deps from the taskcluster index, pointing at main. 
This introduces a race between i.e updating qt in a pr and having the tests horribly fail due to that. 

Therefore they should live inside taskcluster, so they properly get the correct dependencies. 