### PR TITLE
VPN-5293: Add missing a11y names in "Contact Support" screen

### DIFF
--- a/nebula/ui/components/forms/MZComboBox.qml
+++ b/nebula/ui/components/forms/MZComboBox.qml
@@ -11,7 +11,7 @@ import compat 0.1
 import components 0.1
 
 ComboBox {
-    property string placeholderText
+    property string placeholderText: ""
     property bool showInteractionStates: true
     textRole: "name"
     valueRole: "value"
@@ -20,6 +20,7 @@ ComboBox {
     Layout.preferredHeight: MZTheme.theme.rowHeight
     currentIndex: -1
     activeFocusOnTab: true
+    Accessible.name: contentItem.text
     background: MZInputBackground {
         z: -1
     }

--- a/nebula/ui/components/forms/MZTextArea.qml
+++ b/nebula/ui/components/forms/MZTextArea.qml
@@ -47,6 +47,7 @@ Item {
             id: textArea
 
             Accessible.focused: textArea.focus
+            Accessible.name: formattedPlaceholderText.visible ? formattedPlaceholderText.text : textArea.text
             background: MZInputBackground {
                 itemToFocus: textArea
                 z: -1
@@ -68,6 +69,8 @@ Item {
             wrapMode: Text.WrapAtWordBoundaryOrAnywhere
 
             Keys.onTabPressed: nextItemInFocusChain().forceActiveFocus(Qt.TabFocusReason)
+            Keys.onBacktabPressed: nextItemInFocusChain(false).forceActiveFocus(Qt.BacktabFocusReason)
+
             onTextChanged: {
                 handleOnTextChanged(textArea.text);
 

--- a/src/ui/screens/home/controller/ControllerView.qml
+++ b/src/ui/screens/home/controller/ControllerView.qml
@@ -619,7 +619,6 @@ Item {
             lineHeight: 22
             font.pixelSize: 22
             Accessible.ignored: connectionInfoScreenVisible || ipInfoPanel.isOpen || !visible
-            Accessible.description: logoSubtitle.text
             width: parent.width
             onPaintedHeightChanged: if (visible) col.handleMultilineText()
             onTextChanged: handleConnectionStateChange()
@@ -635,7 +634,6 @@ Item {
             objectName: "controllerSubTitle"
 
             lineHeight: MZTheme.theme.controllerInterLineHeight
-            Accessible.ignored: true
             width: parent.width - MZTheme.theme.windowMargin
             anchors.horizontalCenter: parent.horizontalCenter
             onPaintedHeightChanged: if (visible) col.handleMultilineText()


### PR DESCRIPTION
## Description

"Contact Support" screen's ComboBox and "Describe Issue" TextArea did not have a11y names, so were not read by the screen reader.

Also fixed:
1. Shift+Tab in the  "Describe Issue" TextArea was being input into the TextArea instead of moving to the previous control.
2. Subtitle in Home screen was not accessible.

## Reference
[VPN-5293](https://mozilla-hub.atlassian.net/browse/VPN-5293), [GitHub 7631](https://github.com/mozilla-mobile/mozilla-vpn-client/issues/7631)

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-5293]: https://mozilla-hub.atlassian.net/browse/VPN-5293?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ