### PR TITLE
VPN-5797 - Do not automerge i18n updates on release branch

### DIFF
--- a/.github/workflows/i18n_update.yaml
+++ b/.github/workflows/i18n_update.yaml
@@ -36,7 +36,7 @@ jobs:
           branch: i18n_automation
           delete-branch: true
           title: "[Bot] Update i18n"
-          token: ${{ secrets.WIKI_TOKEN }}         
+          token: ${{ secrets.WIKI_TOKEN }}
       - name: Approve l10n_branch.
         run: gh pr review --approve "$PR_URL"
         env:
@@ -49,7 +49,7 @@ jobs:
         env:
           PR_URL: ${{ steps.cpr.outputs.pull-request-url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  get_release_branches: 
+  get_release_branches:
     name: Get Unreleased Branches
     runs-on: ubuntu-latest
     outputs:
@@ -97,13 +97,6 @@ jobs:
           token: ${{ secrets.WIKI_TOKEN }}
       - name: Approve l10n_branch.
         run: gh pr review --approve "$PR_URL"
-        env:
-          PR_URL: ${{ steps.cpr.outputs.pull-request-url }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      # Finally, this sets the PR to allow auto-merging for patch and minor
-      # updates if all checks pass
-      - name: Enable auto-merge the i18n PR
-        run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ steps.cpr.outputs.pull-request-url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Auto-merge is not ideal for release branches, because they can make it confusing to understand what exactly is state of a given RC.

Instead I have changed this to create the i18n update PR for the release branch, BUT NOT MERGE IT. 

Whenever a Release Manager is about to cut a new RC they should be responsible for merging any outsating PRs.

Note: this doesn't mean multiple PRs will be created for relase branches. If the previous PR is not merged it will just keep being updated untill it is time to merge.