### PR TITLE
Chore: Add homepage key to translations report package.json

### DIFF
--- a/tools/translationsreport/app/package.json
+++ b/tools/translationsreport/app/package.json
@@ -2,6 +2,7 @@
   "name": "app",
   "version": "0.1.0",
   "private": true,
+  "homepage": "https://mozilla-mobile.github.io/mozilla-vpn-client/translationsreport/",
   "dependencies": {
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",


### PR DESCRIPTION
Without it it's unable to find the static assets. See console errors: https://mozilla-mobile.github.io/mozilla-vpn-client/translationsreport/
