### PR TITLE
Chore: Fix out-of-order apt-get update in Linux tests

### DIFF
--- a/.github/workflows/test_unit.yaml
+++ b/.github/workflows/test_unit.yaml
@@ -25,8 +25,8 @@ jobs:
           submodules: "recursive"
       - name: Install dependences
         run: |
-          sudo apt-get install -y $(./scripts/linux/getdeps.py -a linux/debian/control)
           sudo apt-get update
+          sudo apt-get install -y $(./scripts/linux/getdeps.py -a linux/debian/control)
       - uses: actions/setup-python@v4
         with:
           python-version: '3.9'


### PR DESCRIPTION
## Description
The Linux unit tests have recently started to fail, and this is due to installing dependencies before doing an `apt-get update`. This causes the worker to try and fetch outdated packages from the APT repository. We were already doing and update of the repository data, it was just in the wrong order.

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
