### PR TITLE
VPN-5920: Display the "Annual upgrade" in-app message in staging only

### DIFF
--- a/addons/message_upgrade_to_annual_plan/manifest.json
+++ b/addons/message_upgrade_to_annual_plan/manifest.json
@@ -4,6 +4,7 @@
   "name": "Upgrade to annual plan",
   "type": "message",
   "conditions": {
+    "env": "staging",
     "javascript": "conditions.js"
   },
   "message": {


### PR DESCRIPTION
## Description

- Prevent the "annual upgrade" in-app message from displaying in production

Note: this should be removed as a part of [VPN-5637: Turn the VPN plan upgrades feature ON](https://mozilla-hub.atlassian.net/browse/VPN-5637)

## Reference

[VPN-5920: Upgrade to annual plan message is displayed when using Addons RC in production](https://mozilla-hub.atlassian.net/browse/VPN-5920)