### PR TITLE
Chore: Fix race in AuthenticationInApp functional test

### DIFF
--- a/tests/functional/testAuthenticationInApp.js
+++ b/tests/functional/testAuthenticationInApp.js
@@ -639,7 +639,7 @@ describe('User authentication', function() {
             await goToPasswordScreen(false);
         });
 
-        it("impression event is are recorded", async () => {
+        it("impression event is recorded", async () => {
             const  enterPasswordViewEvent = await vpn.gleanTestGetValue("impression", "enterPasswordScreen", "main");
             assert.strictEqual(enterPasswordViewEvent.length, 1)
             const enterPasswordViewEventExtras = enterPasswordViewEvent[0].extra;
@@ -910,6 +910,8 @@ describe('User authentication', function() {
                 eventName: "verifySelected",
                 screen
             });
+            // Give the authentication APIs a moment to finish.
+            await vpn.wait();
 
             // Now the successfull outcome
             const successOutcomeEvent = await vpn.gleanTestGetValue("outcome", "twoFaVerificationSucceeded", "main");
@@ -1200,6 +1202,8 @@ describe('User authentication', function() {
                 eventName: "verifySelected",
                 screen
             });
+            // Give the authentication APIs a moment to finish.
+            await vpn.wait();
 
             // Now the successfull outcome
             const successOutcomeEvent = await vpn.gleanTestGetValue("outcome", "twoFaVerificationSucceeded", "main");
@@ -1350,6 +1354,8 @@ describe('User authentication', function() {
                 eventName: "verifySelected",
                 screen
             });
+            // Give the authentication APIs a moment to finish.
+            await vpn.wait();
 
             // Now the successfull outcome
             const successOutcomeEvent = await vpn.gleanTestGetValue("outcome", "twoFaVerificationSucceeded", "main");


### PR DESCRIPTION
## Description
The `testAuthenticationInApp.js` functional test has recently started to fail on Linux, and this appears to be due to a race between the functional test and the asynchronous handling of the 2FA network request. In particular, the tests click on the verification button and then immediately check the glean telemetry for the expected events, but those events are set only once the 2FA network requests are completed. This leaves a race condition where the tests fail to wait for the telemetry to be set.

To resolve the problem, I just added a few waits before checking telemetry on a successful 2FA verification.

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
