### PR TITLE
VPN-5948 - Abort controller activation when there is no current device

### DIFF
--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -350,6 +350,11 @@ void Controller::activateInternal(DNSPortPolicy dnsPort,
 
   MozillaVPN* vpn = MozillaVPN::instance();
   const Device* device = vpn->deviceModel()->currentDevice(vpn->keys());
+  if (!device) {
+    logger.warning() << "No current device. Aborting activation.";
+    m_nextStep = Disconnect;
+    return;
+  }
   SettingsHolder* settingsHolder = SettingsHolder::instance();
 
   // Prepare the exit server's connection data.


### PR DESCRIPTION
The issue here is quite simple: we do not handle the case when there is no current device available when activating the controller. That was the cause of VPN-5948.

This can happen if a device is removed and immediatelly an activation is enqueued. 

A better option might be to just stop the task that is activating the VPN, this is a bit less drastic and maybe less risky?
