### PR TITLE
VPN-3362: Annual upgrade plan message fixes 

### DIFF
--- a/addons/message_upgrade_to_annual_plan/conditions.js
+++ b/addons/message_upgrade_to_annual_plan/conditions.js
@@ -25,7 +25,7 @@
     let fourteenDaysAfterSubscriptionStarted = api.subscriptionData.createdAt + 1000 * 60 * 60 * 24 * 14
     let eightySevenDaysAfterSubscriptionStarted = api.subscriptionData.createdAt + 1000 * 60 * 60 * 24 * 87
 
-    if (isMonthlyWebPlan) {
+    if (isMonthlyWebPlan()) {
       //Less than 14 days into the subscription, don't show message
       if (now < fourteenDaysAfterSubscriptionStarted) {
         api.setTimedCallback(fourteenDaysAfterSubscriptionStarted - now, () => computeCondition());

--- a/addons/message_upgrade_to_annual_plan/manifest.json
+++ b/addons/message_upgrade_to_annual_plan/manifest.json
@@ -4,7 +4,7 @@
   "name": "Upgrade to annual plan",
   "type": "message",
   "conditions": {
-    "platforms": ["macos, windows, linux"],
+    "platforms": ["macos", "windows", "linux"],
     "javascript": "conditions.js"
   },
   "message": {

--- a/addons/message_upgrade_to_annual_plan/manifest.json
+++ b/addons/message_upgrade_to_annual_plan/manifest.json
@@ -4,7 +4,7 @@
   "name": "Upgrade to annual plan",
   "type": "message",
   "conditions": {
-    "env": "staging",
+    "platforms": ["macos, windows, linux"],
     "javascript": "conditions.js"
   },
   "message": {

--- a/src/addons/addon.cpp
+++ b/src/addons/addon.cpp
@@ -87,6 +87,11 @@ QList<ConditionCallback> s_conditionCallbacks{
     {"platforms",
      [](const QJsonValue& value) -> bool {
        QStringList platforms;
+
+       // always add "dummy" to the list of supported platforms so addons can be
+       // tested by functional tests
+       platforms.append("dummy");
+
        QJsonArray platformArray = value.toArray();
        for (const QJsonValue& platform : platformArray) {
          platforms.append(platform.toString());

--- a/src/notificationhandler.cpp
+++ b/src/notificationhandler.cpp
@@ -366,7 +366,11 @@ void NotificationHandler::addonCreated(Addon* addon) {
     return;
   }
 
-  if (addon->enabled() && qobject_cast<AddonMessage*>(addon)->shouldNotify()) {
+  if (!qobject_cast<AddonMessage*>(addon)->shouldNotify()) {
+    return;
+  }
+
+  if (addon->enabled()) {
     maybeAddonNotification(addon);
   }
 


### PR DESCRIPTION
## Description

- Re-enable (removing `staging` condition) the message
- Add condition to only enable on desktop platforms
- Fix push notification not being suppressed on condition changes when set to not notify
- Fix conditional in condition.js that was always evaluating to true
- Allows functional tests to run on addons that only support certain platforms (automatically include `dummy` in list of supported platforms)

## Reference

[VPN-3362: Release a "Plan Upgrade" in-app message to monthly-plan non-IAP subscribers](https://mozilla-hub.atlassian.net/browse/VPN-3362)
[VPN-3044: Release support for In-App Messages to generate (or not) an OS notification](https://mozilla-hub.atlassian.net/browse/VPN-3044)