### PR TITLE
VPN-5900: Do not send pings for server switch

### DIFF
--- a/docs/controller.md
+++ b/docs/controller.md
@@ -29,7 +29,7 @@ sequenceDiagram
     Controller->>Controller: m_nextServerData = Yc
     Controller->>Controller: Connected
     Controller->>Controller: deactivate...
-    Controller->>Controller: ativate(m_nextServerData)
+    Controller->>Controller: activate(m_nextServerData)
     Controller->>Controller: m_serverData = m_nextServerData
     deactivate Controller
 ```

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -659,7 +659,12 @@ void Controller::connected(const QString& pubkey,
   // We have succesfully completed all pending connections.
   logger.debug() << "Connected from state:" << m_state;
   setState(StateOn);
-  emit newConnectionSucceeded();
+
+  logger.debug() << "Connection happened due to server switch:"
+                 << isActivatingFromSwitch;
+  if (!isActivatingFromSwitch) {
+    emit newConnectionSucceeded();
+  }
 
   // In case the Controller provided a valid timestamp that
   // should be used.
@@ -900,6 +905,10 @@ bool Controller::activate(const ServerData& serverData,
     logger.debug() << "Already connected";
     return false;
   }
+
+  isActivatingFromSwitch = (m_state == Controller::StateSwitching ||
+                            m_state == Controller::StateSilentSwitching);
+  logger.debug() << "Set isActivatingFromSwitch to" << isActivatingFromSwitch;
 
   m_serverData = serverData;
 

--- a/src/controller.h
+++ b/src/controller.h
@@ -221,6 +221,7 @@ class Controller : public QObject, public LogSerializer {
   // Please, do not use MozillaVPN::serverData() in the controller!
   ServerData m_serverData;
   ServerData m_nextServerData;
+  bool isActivatingFromSwitch;
 
   PingHelper m_pingCanary;
   bool m_pingReceived = false;


### PR DESCRIPTION
## Description

We want to prevent sending the pings if its due to a server switch. We can take advantage of the fact that all VPN activations come through Controller::activate, and at that point the current state informs us *why* we're switching. I have notes on the ticket that show my work for why I believe these are the only paths.

This isn't pretty, but is better than the alternatives that a couple of us could come up with.

Credit to @Gela for this approach.

## Reference

VPN-5900

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
