### PR TITLE
VPN-5849 - Set locale for Glean pings on desktop platforms

### DIFF
--- a/qtglean/src/lib.rs
+++ b/qtglean/src/lib.rs
@@ -29,7 +29,7 @@ pub extern "C" fn glean_register_log_handler(message_handler: extern fn(i32, *mu
 }
 
 #[no_mangle]
-pub extern "C" fn glean_initialize(is_telemetry_enabled: bool, data_path: FfiStr, channel: FfiStr) {
+pub extern "C" fn glean_initialize(is_telemetry_enabled: bool, data_path: FfiStr, channel: FfiStr, locale: FfiStr) {
     let cfg = Configuration {
         data_path: data_path
             .to_string_fallible()
@@ -58,7 +58,7 @@ pub extern "C" fn glean_initialize(is_telemetry_enabled: bool, data_path: FfiStr
         app_build: env!("BUILD_ID").to_string(),
         app_display_version: env!("APP_VERSION").to_string(),
         channel: channel.to_string_fallible().ok(),
-        locale: None,
+        locale: locale.to_string_fallible().ok(),
     };
 
     register_pings();
@@ -86,7 +86,7 @@ pub extern "C" fn glean_shutdown() {
 }
 
 #[no_mangle]
-pub extern "C" fn glean_test_reset_glean(is_telemetry_enabled: bool, data_path: FfiStr) {
+pub extern "C" fn glean_test_reset_glean(is_telemetry_enabled: bool, data_path: FfiStr, locale: FfiStr) {
     let cfg = Configuration {
         data_path: data_path
             .to_string_fallible()
@@ -117,7 +117,7 @@ pub extern "C" fn glean_test_reset_glean(is_telemetry_enabled: bool, data_path: 
         app_build: env!("BUILD_ID").to_string(),
         app_display_version: env!("APP_VERSION").to_string(),
         channel: Some("testing".to_string()),
-        locale: None,
+        locale: locale.to_string_fallible().ok(),
     };
 
     glean::test_reset_glean(cfg, client_info, true);

--- a/src/glean/mzglean.cpp
+++ b/src/glean/mzglean.cpp
@@ -104,7 +104,8 @@ void MZGlean::initialize() {
     return;
 #elif defined(UNIT_TEST) || defined(MZ_DUMMY)
     glean_test_reset_glean(SettingsHolder::instance()->gleanEnabled(),
-                           gleanDirectory.absolutePath().toUtf8());
+                           gleanDirectory.absolutePath().toUtf8(),
+                           QLocale::system().name().toUtf8());
 #elif defined(MZ_IOS)
     new IOSGleanBridge(SettingsHolder::instance()->gleanEnabled(),
                        Constants::inProduction() ? "production" : "staging");
@@ -118,7 +119,8 @@ void MZGlean::initialize() {
 
     glean_initialize(SettingsHolder::instance()->gleanEnabled(),
                      gleanDirectory.absolutePath().toUtf8(),
-                     Constants::inProduction() ? "production" : "staging");
+                     Constants::inProduction() ? "production" : "staging",
+                     QLocale::system().name().toUtf8());
 
     setLogPings(settingsHolder->gleanLogPings());
     if (settingsHolder->gleanDebugTagActive()) {


### PR DESCRIPTION
Note this get's the system locale *not the VPN locale*. This is how Glean works in other platforms, so this is just for completion sake. We are not trying to understand what is the user chosen chosen locale in the app, but just adding a metric to desktop that we collect on mobile platforms.
