### PR TITLE
VPN-5816: Better position progress bar delegate labels

### DIFF
--- a/nebula/ui/components/MZStepProgressBar.qml
+++ b/nebula/ui/components/MZStepProgressBar.qml
@@ -61,8 +61,8 @@ Item {
                 objectName: model.objectName
 
                 iconSource: model.iconSource
-                labelText: MZI18n[model.labelText]
-                labelWidth: progressBar.width / progressBar.model.count
+                label.text: MZI18n[model.labelText]
+                label.visible: index === progressBar.activeIndex
                 currentState: {
                     if (index === activeIndex) {
                         MZStepProgressBarDelegate.State.Active

--- a/nebula/ui/components/MZStepProgressBarDelegate.qml
+++ b/nebula/ui/components/MZStepProgressBarDelegate.qml
@@ -15,7 +15,7 @@ Column {
     property alias label: label
     property string accessibleName: ""
     property int currentState: MZStepProgressBarDelegate.State.Incomplete
-    property var dontExtendPastComponent: window.contentItem //Component that the label should never extend past
+    property var clippingContainer: window.contentItem //Component that the label should never extend past
 
     signal clicked
 
@@ -137,25 +137,34 @@ Column {
             running: true
             interval: 1
             onTriggered: {
-                if (label.mapToItem(dontExtendPastComponent, 0, 0).x < 0) {
+                //Reset anchors
+                label.anchors.left = undefined
+                label.anchors.leftMargin = undefined
+                label.anchors.right = undefined
+                label.anchors.rightMargin = undefined
+                label.anchors.horizontalCenter = undefined
+
+                //When the label extends horizontally past the clippingContainer on the leading edge, mapToItem tells us how far past
+                //the leading edge the label is (eg -24px) and we use margin to set the X to the leading edge of the clippingContainer
+                //using the absolute value of the offset
+                if (label.mapToItem(clippingContainer, 0, 0).x < 0) {
                     label.anchors.left = delegate.left
-                    label.anchors.leftMargin = label.mapToItem(dontExtendPastComponent, 0, 0).x * -1
-                    label.anchors.right = undefined
-                    label.anchors.rightMargin = undefined
-                    label.anchors.horizontalCenter = undefined
+                    label.anchors.leftMargin = label.mapToItem(clippingContainer, 0, 0).x * -1
                 }
-                else if (label.mapToItem(dontExtendPastComponent, 0, 0).x + label.implicitWidth > dontExtendPastComponent.width) {
-                    label.anchors.horizontalCenter = undefined
-                    label.anchors.left = undefined
-                    label.anchors.leftMargin = undefined
+                //When the label extends horizontally past the clippingContainer on the trailing edge, we find how far past it extends
+                //by locating the X of the end of the label (label.mapToItem(clippingContainer, 0, 0).x - label.implicitWidth) and
+                //subtracting that from the clippingContainers width
+                //Eg clippingContainer width is 360px, but the X of the end of the label is 384. rightMargin = |360-384| or 24
+
+                //mapToItem tells us how far past
+                //the trailing edge the label is (eg -24px) and we use margin to set the X to the trailing edge of the clippingContainer
+                //using the absolute value of the offset
+                else if (label.mapToItem(clippingContainer, 0, 0).x + label.implicitWidth > clippingContainer.width) {
                     label.anchors.right = delegate.right
-                    label.anchors.rightMargin = (dontExtendPastComponent.width - label.mapToItem(dontExtendPastComponent, 0, 0).x - label.implicitWidth) * -1
+                    label.anchors.rightMargin = (clippingContainer.width - label.mapToItem(clippingContainer, 0, 0).x - label.implicitWidth) * -1
                 }
+                //When the label does not extend past the clippingContainer on either edge , horizontally center it with it's parent
                 else {
-                    label.anchors.left = undefined
-                    label.anchors.leftMargin = undefined
-                    label.anchors.right = undefined
-                    label.anchors.rightMargin = undefined
                     label.anchors.horizontalCenter = delegate.horizontalCenter
                 }
 

--- a/nebula/ui/components/MZStepProgressBarDelegate.qml
+++ b/nebula/ui/components/MZStepProgressBarDelegate.qml
@@ -26,7 +26,7 @@ Column {
     }
 
     //Width is set to the size of the button, so the label exceeds bounds
-    width: button.width
+    width: button.implicitWidth
 
     spacing: 8
 
@@ -140,17 +140,23 @@ Column {
             onTriggered: {
                 if (label.mapToItem(dontExtendPastComponent, 0, 0).x < 0) {
                     label.anchors.left = delegate.left
+                    label.anchors.leftMargin = label.mapToItem(dontExtendPastComponent, 0, 0).x * -1
                     label.anchors.right = undefined
+                    label.anchors.rightMargin = undefined
                     label.anchors.horizontalCenter = undefined
                 }
                 else if (label.mapToItem(dontExtendPastComponent, 0, 0).x + label.implicitWidth > dontExtendPastComponent.width) {
-                    label.anchors.left = undefined
-                    label.anchors.right = delegate.right
                     label.anchors.horizontalCenter = undefined
+                    label.anchors.left = undefined
+                    label.anchors.leftMargin = undefined
+                    label.anchors.right = delegate.right
+                    label.anchors.rightMargin = (dontExtendPastComponent.width - label.mapToItem(dontExtendPastComponent, 0, 0).x - label.implicitWidth) * -1
                 }
                 else {
                     label.anchors.left = undefined
+                    label.anchors.leftMargin = undefined
                     label.anchors.right = undefined
+                    label.anchors.rightMargin = undefined
                     label.anchors.horizontalCenter = delegate.horizontalCenter
                 }
 

--- a/nebula/ui/components/MZStepProgressBarDelegate.qml
+++ b/nebula/ui/components/MZStepProgressBarDelegate.qml
@@ -120,7 +120,6 @@ Column {
 
         anchors.horizontalCenter: delegate.horizontalCenter
 
-        elide: Text.ElideNone
         maximumLineCount: 1
         font.pixelSize: MZTheme.theme.fontSizeSmallest
         lineHeightMode: Text.FixedHeight

--- a/nebula/ui/components/MZStepProgressBarDelegate.qml
+++ b/nebula/ui/components/MZStepProgressBarDelegate.qml
@@ -129,7 +129,7 @@ Column {
 
         Accessible.ignored: true
 
-        onTextChanged: labelRepositionTimer.start
+        onTextChanged: labelRepositionTimer.start()
 
         //Hacky workaround to reposition label based on its global x coordinate (so it is not clipped by the window)
         //For some reason, label.mapToItem(window.contentItem, 0, 0).x returns 0 if done inside component.onCompleted, hence the timer


### PR DESCRIPTION
## Description

Previously, long progress bar delegate labels would wrap if they impeded on a neighboring progress bar label. To resolve this, we:

- Hide the labels of non-active progress bar delegates
- Allow the label to take as much horizontal space as it needs (no wrapping, no eliding)
- If the label is so long, that it would extend past a component that it shouldn't (usually the application window) in the leading or trailing direction, then anchor the label horizontally to the leading or trailing edge, respectively, of the bound that it is not supposed to extend past

https://github.com/mozilla-mobile/mozilla-vpn-client/assets/15353801/77789b3d-9d56-4d9a-97ca-ac62761fa1a9

This video demonstrates the resolution to the original issue where the wrapping of a couple of letters would look unappealing. We no longer wrap the label and let it take as much room as it needs by hiding the labels of past and future steps


https://github.com/mozilla-mobile/mozilla-vpn-client/assets/15353801/c0522723-b60f-456d-a3bb-b225aa740f8d

This video demonstrates what we would do with long leading / trailing labels that could go outside a specified bounds (usually the application window) 

## Reference

[VPN-5816: [l10n] New on-boarding progress bar names are not wrapped in some languages](https://mozilla-hub.atlassian.net/browse/VPN-5816)
