### PR TITLE
VPN-5439: Improve focus management when screens are loaded/shown

### DIFF
--- a/nebula/ui/components/MZScreenBase.qml
+++ b/nebula/ui/components/MZScreenBase.qml
@@ -57,7 +57,8 @@ Item {
             Layout.alignment: Qt.AlignTop
             onCurrentItemChanged: {
                 menu.title = Qt.binding(() => currentItem._menuTitle || "");
-                menu._menuOnBackClicked = currentItem._menuOnBackClicked ? currentItem._menuOnBackClicked : () => menu.maybeRequestPreviousScreen()
+                menu._menuOnBackClicked = currentItem._menuOnBackClicked ? currentItem._menuOnBackClicked : () => menu.maybeRequestPreviousScreen();
+                currentItem.forceActiveFocus();
             }
 
             Connections {

--- a/nebula/ui/components/MZViewBase.qml
+++ b/nebula/ui/components/MZViewBase.qml
@@ -20,6 +20,7 @@ Item {
    property alias _contentHeight: vpnFlickable.contentHeight
 
    Accessible.name: (_menuTitle.length > 0) ? _menuTitle : _accessibleName
+   Accessible.role: Accessible.Grouping
 
    anchors {
        top: if (parent) parent.top

--- a/nebula/ui/components/MZViewBase.qml
+++ b/nebula/ui/components/MZViewBase.qml
@@ -13,12 +13,13 @@ Item {
    id: root
 
    property string _menuTitle: ""
+   property string accessibleName: ""
    property var _menuOnBackClicked
    property alias _viewContentData: viewContent.data
    property alias _interactive: vpnFlickable.interactive
    property alias _contentHeight: vpnFlickable.contentHeight
 
-   Accessible.name: _menuTitle
+   Accessible.name: (_menuTitle.length > 0) ? _menuTitle : accessibleName
    Accessible.role: Accessible.PopupMenu
 
    anchors {

--- a/nebula/ui/components/MZViewBase.qml
+++ b/nebula/ui/components/MZViewBase.qml
@@ -18,6 +18,9 @@ Item {
    property alias _interactive: vpnFlickable.interactive
    property alias _contentHeight: vpnFlickable.contentHeight
 
+   Accessible.name: _menuTitle
+   Accessible.role: Accessible.PopupMenu
+
    anchors {
        top: if (parent) parent.top
    }
@@ -44,6 +47,14 @@ Item {
                 topMargin: MZTheme.theme.viewBaseTopMargin
                 bottomMargin: navbar.visible ? 0 : MZTheme.theme.rowHeight
             }
+        }
+    }
+
+    onVisibleChanged: {
+        // Screens with LoadPersistently policy have their visiblity turned on when they become the
+        // current screen. Reset focus to the root to clear the previous focus.
+        if (visible) {
+            root.forceActiveFocus();
         }
     }
 

--- a/nebula/ui/components/MZViewBase.qml
+++ b/nebula/ui/components/MZViewBase.qml
@@ -13,14 +13,13 @@ Item {
    id: root
 
    property string _menuTitle: ""
-   property string accessibleName: ""
+   property string _accessibleName: ""
    property var _menuOnBackClicked
    property alias _viewContentData: viewContent.data
    property alias _interactive: vpnFlickable.interactive
    property alias _contentHeight: vpnFlickable.contentHeight
 
-   Accessible.name: (_menuTitle.length > 0) ? _menuTitle : accessibleName
-   Accessible.role: Accessible.PopupMenu
+   Accessible.name: (_menuTitle.length > 0) ? _menuTitle : _accessibleName
 
    anchors {
        top: if (parent) parent.top

--- a/nebula/ui/components/navigator/MZNavigatorLoader.qml
+++ b/nebula/ui/components/navigator/MZNavigatorLoader.qml
@@ -60,20 +60,23 @@ StackView {
 
       for (let i = 0; i < stackView.screens.length; ++i) {
         stackView.get(i+1).visible = i === pos;
-        // I really don't know why.
-        // Follow up bug for proper fixing: https://mozilla-hub.atlassian.net/browse/VPN-2813
-        // For some reason, once we navigate away the loader of the component
-        // on android will get the opacity and X value set to garbage. 
-        // This will cause the page broken, once we re-navigate here. 
-        // So in case we're on android and this is the component we want to show
-        // Let's reset those 2 values.
-        if(i === pos){
+
+        if (i === pos) {
+          // I really don't know why.
+          // Follow up bug for proper fixing: https://mozilla-hub.atlassian.net/browse/VPN-2813
+          // For some reason, once we navigate away the loader of the component
+          // on android will get the opacity and X value set to garbage. 
+          // This will cause the page broken, once we re-navigate here. 
+          // So in case we're on android and this is the component we want to show
+          // Let's reset those 2 values.
           stackView.get(i+1).opacity = 1;
-          stackView.get(i+1).x = 0; 
+          stackView.get(i+1).x = 0;
+
+          // Set focus to current component
+          stackView.get(i+1).forceActiveFocus();
         }
       }
   }
-
 
   Connections {
     target: MZNavigator
@@ -94,5 +97,9 @@ StackView {
       stackView.push(initialScreen);
 
       showCurrentComponent()
+  }
+
+  onCurrentItemChanged: {
+    currentItem.forceActiveFocus();
   }
 }

--- a/src/ui/screens/ScreenGetHelp.qml
+++ b/src/ui/screens/ScreenGetHelp.qml
@@ -68,7 +68,8 @@ Item {
             onCurrentItemChanged: {
                 menu.title = Qt.binding(() => currentItem._menuTitle || "");
                 menu.visible = Qt.binding(() => menu.title !== "");
-                menu._menuOnBackClicked = currentItem._menuOnBackClicked ? currentItem._menuOnBackClicked : () => getHelpStackView.pop()
+                menu._menuOnBackClicked = currentItem._menuOnBackClicked ? currentItem._menuOnBackClicked : () => getHelpStackView.pop();
+                currentItem.forceActiveFocus();
             }
         }
     }

--- a/src/ui/screens/ScreenHome.qml
+++ b/src/ui/screens/ScreenHome.qml
@@ -11,6 +11,10 @@ import components 0.1
 
 MZScreenBase {
     objectName: "screenHome"
+    id: screenHome
+    Accessible.name: MZI18n.ProductName
+    Accessible.role: Accessible.Client
+
     Component.onCompleted: () => {
         MZNavigator.addStackView(VPN.ScreenHome, getStack())
         getStack().push("qrc:/ui/screens/home/ViewHome.qml")
@@ -30,6 +34,14 @@ MZScreenBase {
 
             // push server view
             getStack().push("qrc:/ui/screens/home/ViewServers.qml", StackView.Immediate);
+        }
+    }
+
+    onVisibleChanged: {
+        // Screens with LoadPersistently policy have their visiblity turned on when they become the
+        // current screen. Reset focus to the root to clear the previous focus.
+        if (visible) {
+            screenHome.forceActiveFocus();
         }
     }
 }

--- a/src/ui/screens/home/ViewServers.qml
+++ b/src/ui/screens/home/ViewServers.qml
@@ -17,6 +17,7 @@ Item {
     id: root
     objectName: "viewServers"
     Accessible.name: qsTrId("vpn.servers.selectLocation")
+    Accessible.role: Accessible.Grouping
     Accessible.ignored: !visible
 
     MZMenu {

--- a/src/ui/screens/home/ViewServers.qml
+++ b/src/ui/screens/home/ViewServers.qml
@@ -17,6 +17,7 @@ Item {
     id: root
     objectName: "viewServers"
     Accessible.name: qsTrId("vpn.servers.selectLocation")
+    Accessible.role: Accessible.PopupMenu
     Accessible.ignored: !visible
 
     MZMenu {

--- a/src/ui/screens/home/ViewServers.qml
+++ b/src/ui/screens/home/ViewServers.qml
@@ -17,7 +17,6 @@ Item {
     id: root
     objectName: "viewServers"
     Accessible.name: qsTrId("vpn.servers.selectLocation")
-    Accessible.role: Accessible.PopupMenu
     Accessible.ignored: !visible
 
     MZMenu {

--- a/src/ui/screens/messaging/ViewMessagesInbox.qml
+++ b/src/ui/screens/messaging/ViewMessagesInbox.qml
@@ -14,7 +14,6 @@ import components.forms 0.1
 MZViewBase {
     id: vpnFlickable
     objectName: "messageInboxView"
-    visible: false
 
     property bool isEmptyState
     property bool isEditing: false
@@ -346,9 +345,5 @@ MZViewBase {
         Component.onCompleted: {
             vpnFlickable.isEmptyState = Qt.binding(() => { return messagesModel.count === 0} )
         }
-    }
-
-    Component.onCompleted: {
-        vpnFlickable.visible = true;
     }
 }

--- a/src/ui/screens/messaging/ViewMessagesInbox.qml
+++ b/src/ui/screens/messaging/ViewMessagesInbox.qml
@@ -14,6 +14,7 @@ import components.forms 0.1
 MZViewBase {
     id: vpnFlickable
     objectName: "messageInboxView"
+    visible: false
 
     property bool isEmptyState
     property bool isEditing: false
@@ -345,5 +346,9 @@ MZViewBase {
         Component.onCompleted: {
             vpnFlickable.isEmptyState = Qt.binding(() => { return messagesModel.count === 0} )
         }
+    }
+
+    Component.onCompleted: {
+        vpnFlickable.visible = true;
     }
 }

--- a/src/ui/screens/settings/ViewSettingsMenu.qml
+++ b/src/ui/screens/settings/ViewSettingsMenu.qml
@@ -14,6 +14,7 @@ MZViewBase {
     id: vpnFlickable
     objectName: "settingsView"
     _menuTitle: MZI18n.NavBarSettingsTab
+    visible: false
 
     _viewContentData: ColumnLayout {
         spacing: MZTheme.theme.windowMargin
@@ -193,6 +194,7 @@ MZViewBase {
         }
     }
     Component.onCompleted: {
+        vpnFlickable.visible = true;
         Glean.sample.settingsViewOpened.record();
     }
 }

--- a/src/ui/screens/settings/ViewSettingsMenu.qml
+++ b/src/ui/screens/settings/ViewSettingsMenu.qml
@@ -13,7 +13,7 @@ import components 0.1
 MZViewBase {
     id: vpnFlickable
     objectName: "settingsView"
-    _menuTitle: MZI18n.NavBarSettingsTab
+    accessibleName: MZI18n.NavBarSettingsTab
 
     _viewContentData: ColumnLayout {
         spacing: MZTheme.theme.windowMargin

--- a/src/ui/screens/settings/ViewSettingsMenu.qml
+++ b/src/ui/screens/settings/ViewSettingsMenu.qml
@@ -14,7 +14,6 @@ MZViewBase {
     id: vpnFlickable
     objectName: "settingsView"
     _menuTitle: MZI18n.NavBarSettingsTab
-    visible: false
 
     _viewContentData: ColumnLayout {
         spacing: MZTheme.theme.windowMargin
@@ -194,7 +193,6 @@ MZViewBase {
         }
     }
     Component.onCompleted: {
-        vpnFlickable.visible = true;
         Glean.sample.settingsViewOpened.record();
     }
 }

--- a/src/ui/screens/settings/ViewSettingsMenu.qml
+++ b/src/ui/screens/settings/ViewSettingsMenu.qml
@@ -13,6 +13,7 @@ import components 0.1
 MZViewBase {
     id: vpnFlickable
     objectName: "settingsView"
+    _menuTitle: MZI18n.NavBarSettingsTab
 
     _viewContentData: ColumnLayout {
         spacing: MZTheme.theme.windowMargin

--- a/src/ui/screens/settings/ViewSettingsMenu.qml
+++ b/src/ui/screens/settings/ViewSettingsMenu.qml
@@ -13,7 +13,7 @@ import components 0.1
 MZViewBase {
     id: vpnFlickable
     objectName: "settingsView"
-    accessibleName: MZI18n.NavBarSettingsTab
+    _accessibleName: MZI18n.NavBarSettingsTab
 
     _viewContentData: ColumnLayout {
         spacing: MZTheme.theme.windowMargin


### PR DESCRIPTION
## Description

The tracking bug is an investigation into slow performance of the TalkBack screen reader on Android in starting to read a newly loaded screen in VPN. When a screen is loaded, TalkBack can take several seconds to start reading it.

The root cause is that the Qt framework sends a large number of TYPE_WINDOW_CONTENT_CHANGED accessibility events while a QML component is loading, because each geometry change triggers this event. This makes TalkBack slow to starting reading a QML component, because the flood of events need to be processed before TalkBack can start reading.  https://bugreports.qt.io/browse/QTBUG-119612 has been opened to report this Qt issue. The length of the delay increases with the the number of elements in the screen, because more elements cause more geometry changes.

While investigating this, it was noticed that many VPN screens do not correctly gain focus when they are loaded or shown. This made the perceived screen reading delay worse, because the focus was not on the screen and user would not get indication that the screen loading had completed.

The additional perceived delay has been fixed by properly transferring focus to a screen when it is loaded and when a previously loaded screen (with LoadPersistently policy) is shown again.

Also fixed:
1. Role of menus and Home screen, so the screen reader reads the role.
2. Accessibility name of Home screen and Settings menu.

## Reference
[VPN-5439](https://mozilla-hub.atlassian.net/browse/VPN-5439)


## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-4830]: https://mozilla-hub.atlassian.net/browse/VPN-4830?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[VPN-5439]: https://mozilla-hub.atlassian.net/browse/VPN-5439?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ