### PR TITLE
VPN-5769: Ignore Error dialog's empty text field for accessibility

### DIFF
--- a/src/ui/sharedViews/ViewErrorFullScreen.qml
+++ b/src/ui/sharedViews/ViewErrorFullScreen.qml
@@ -109,7 +109,7 @@ MZFlickable {
                     lineHeight: 22
                     text: errorMessage2
                     // If empty, keep the white space for better layout, but ignore for Accessibility.
-                    Accessible.ignored: text.length === 0
+                    Accessible.ignored: (text.length === 0) || !visible
                 }
 
                 MZLinkButton {

--- a/src/ui/sharedViews/ViewErrorFullScreen.qml
+++ b/src/ui/sharedViews/ViewErrorFullScreen.qml
@@ -108,6 +108,8 @@ MZFlickable {
                     font.pixelSize: MZTheme.theme.fontSize
                     lineHeight: 22
                     text: errorMessage2
+                    // If empty, keep the white space for better layout, but ignore for Accessibility.
+                    Accessible.ignored: text.length === 0
                 }
 
                 MZLinkButton {


### PR DESCRIPTION
## Description

On some platforms, the empty text field in the Error dialog was being read. Ignore it for accessibility.

## Reference
[VPN-5769](https://mozilla-hub.atlassian.net/browse/VPN-5769), [Github 8394](https://github.com/mozilla-mobile/mozilla-vpn-client/issues/8394)**

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-5769]: https://mozilla-hub.atlassian.net/browse/VPN-5769?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ