### PR TITLE
Nit: Unify setting target_compile_options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,9 @@ set_target_properties(build_tests PROPERTIES
         FOLDER "Tests"
 )
 
+# Include Global Helper functions
+include(scripts/cmake/utilities.cmake)
+
 ## Some workarounds for platform build quirks
 if(WIN32)
     ## CMake v3.20 has problems with race conditions in dependency generation.

--- a/ios/adjust/CMakeLists.txt
+++ b/ios/adjust/CMakeLists.txt
@@ -4,9 +4,7 @@
 
 add_library(adjust STATIC)
 
-if(NOT MSVC AND NOT IOS)
-  target_compile_options(adjust-sources PRIVATE -Wall -Werror -Wno-conversion)
-endif()
+mz_target_handle_warnings(adjust-sources)
 
 set_target_properties(adjust PROPERTIES FOLDER "Libs")
 

--- a/lottie/CMakeLists.txt
+++ b/lottie/CMakeLists.txt
@@ -17,9 +17,7 @@ endif()
 
 add_library(lottie STATIC)
 
-if(NOT MSVC AND NOT IOS)
-  target_compile_options(lottie PRIVATE -Wall -Werror -Wno-conversion)
-endif()
+mz_target_handle_warnings(lottie)
 
 find_package(Qt6 REQUIRED COMPONENTS Core Qml Qml Quick QuickTest Test)
 target_link_libraries(lottie PUBLIC Qt6::Core Qt6::Qml)

--- a/qtglean/CMakeLists.txt
+++ b/qtglean/CMakeLists.txt
@@ -37,9 +37,7 @@ add_library(qtglean STATIC
 
 )
 
-if(NOT MSVC AND NOT IOS)
-  target_compile_options(qtglean PRIVATE -Wall -Werror -Wno-conversion)
-endif()
+mz_target_handle_warnings(qtglean)
 
 target_include_directories(qtglean PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/include

--- a/scripts/cmake/generate_translations_target.cmake
+++ b/scripts/cmake/generate_translations_target.cmake
@@ -32,9 +32,7 @@ function(generate_translations_target TARGET_NAME TRANSLATIONS_DIRECTORY)
     message("Creating library ${TARGET_NAME} from ${TRANSLATIONS_DIRECTORY}")
     add_library(${TARGET_NAME} STATIC)
 
-    if(NOT MSVC)
-        target_compile_options(${TARGET_NAME} PRIVATE -Wall -Werror -Wno-conversion)
-    endif()
+    mz_target_handle_warnings(${TARGET_NAME})
 
     set_target_properties(${TARGET_NAME} PROPERTIES FOLDER "Libs")
     target_link_libraries(${TARGET_NAME} PRIVATE Qt6::Core Qt6::Qml)

--- a/scripts/cmake/utilities.cmake
+++ b/scripts/cmake/utilities.cmake
@@ -1,0 +1,21 @@
+
+# Set's Defaults like `-Wall -Werror` if we know it will not 
+# explode on that target + compiler
+function(mz_target_handle_warnings MZ_TARGET)
+    if(MSVC OR IOS)
+        return()
+    endif()
+    # Just don't for wasm
+    if( ${CMAKE_SYSTEM_NAME} STREQUAL "Emscripten")
+        return()
+    endif()
+    # Check if the target is an interface lib
+    get_target_property(target_type ${MZ_TARGET} TYPE)
+    if (${target_type} STREQUAL "INTERFACE_LIBRARY")
+        set(scope "INTERFACE")
+    else()
+        set(scope "PRIVATE")
+    endif()
+
+    target_compile_options( ${MZ_TARGET} ${scope} -Wall -Werror -Wno-conversion)
+endfunction()

--- a/scripts/cmake/utilities.cmake
+++ b/scripts/cmake/utilities.cmake
@@ -1,5 +1,5 @@
 
-# Set's Defaults like `-Wall -Werror` if we know it will not 
+# Sets Defaults like `-Wall -Werror` if we know it will not 
 # explode on that target + compiler
 function(mz_target_handle_warnings MZ_TARGET)
     if(MSVC OR IOS)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,9 +7,7 @@
 # statically.
 qt_add_executable(mozillavpn MANUAL_FINALIZATION)
 
-if(NOT MSVC AND NOT IOS)
-  target_compile_options(mozillavpn PRIVATE -Wall -Werror -Wno-conversion)
-endif()
+mz_target_handle_warnings(mozillavpn)
 
 target_link_libraries(mozillavpn PRIVATE
     Qt6::Quick

--- a/src/cmake/shared-sources.cmake
+++ b/src/cmake/shared-sources.cmake
@@ -5,9 +5,7 @@
 # Library of sources shared between app and tests
 add_library(shared-sources INTERFACE)
 
-if(NOT MSVC AND NOT IOS)
-  target_compile_options(shared-sources INTERFACE -Wall -Werror -Wno-conversion)
-endif()
+mz_target_handle_warnings(shared-sources)
 
 # Generated version header file
 configure_file(version.h.in ${CMAKE_CURRENT_BINARY_DIR}/version.h)

--- a/src/cmake/sources.cmake
+++ b/src/cmake/sources.cmake
@@ -6,9 +6,7 @@
 # This allows us to pull them into multiple builds like the dummy client.
 add_library(mozillavpn-sources INTERFACE)
 
-if(NOT MSVC AND NOT IOS)
-  target_compile_options(mozillavpn-sources INTERFACE -Wall -Werror -Wno-conversion)
-endif()
+mz_target_handle_warnings(mozillavpn-sources)
 
 # VPN client include paths
 set_property(TARGET mozillavpn-sources PROPERTY INTERFACE_INCLUDE_DIRECTORIES


### PR DESCRIPTION
## Description
We set `-werror` in multiple places with conditions. I wanted to add wasm to that. So let's have that condition in one place only. 
