### PR TITLE
VPN-5971 - Use Conda environment on MacOS auth tests

### DIFF
--- a/.github/workflows/auth_tests.yml
+++ b/.github/workflows/auth_tests.yml
@@ -72,21 +72,12 @@ jobs:
           wget https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/mozillavpn.v2.mozillavpn.cache.level-3.toolchains.v3.qt-mac.latest/artifacts/public%2Fbuild%2Fqt6_mac.zip -O qt6_mac.zip
           unzip -a -d ${{ github.workspace }} qt6_mac.zip
 
-      - name: Install Grcov
-        if: steps.cache-grcov.outputs.cache-hit != 'true'
-        shell: bash
+      - name: Compile test client
         run: |
-          cargo install grcov --root ${{github.workspace}}/grcov-build --version 0.8.13
-
-      - name: Building tests
-        shell: bash
-        run: |
-          export PATH=/opt/qt_dist/bin:${{github.workspace}}/grcov-build/bin:$PATH
-          mkdir -p build
-          cmake -S . -B $(pwd)/build -GNinja \
-            -DCMAKE_PREFIX_PATH=${{ github.workspace }}/qt_dist/lib/cmake \
-            -DCMAKE_CXX_FLAGS=--coverage -DCMAKE_EXE_LINKER_FLAGS=--coverage
-          cmake --build $(pwd)/build --target app_auth_tests
+          mkdir -p build/cmake
+          cmake -S $(pwd) -B build/cmake -GNinja \
+            -DCMAKE_PREFIX_PATH=${{ github.workspace }}/qt_dist/lib/cmake
+          cmake --build build/cmake -j$(nproc) --target app_auth_tests
 
       - name: Running tests
         shell: bash

--- a/.github/workflows/auth_tests.yml
+++ b/.github/workflows/auth_tests.yml
@@ -81,6 +81,7 @@ jobs:
           export PATH=/opt/qt_dist/bin:${{github.workspace}}/grcov-build/bin:$PATH
           mkdir -p build
           cmake -S . -B $(pwd)/build -GNinja \
+            -DCMAKE_PREFIX_PATH=${{ github.workspace }}/qt_dist/lib/cmake \
             -DCMAKE_CXX_FLAGS=--coverage -DCMAKE_EXE_LINKER_FLAGS=--coverage
           cmake --build $(pwd)/build --target app_auth_tests
 

--- a/.github/workflows/auth_tests.yml
+++ b/.github/workflows/auth_tests.yml
@@ -52,19 +52,22 @@ jobs:
         with:
           submodules: "recursive"
 
-      - name: Install dependencies
-        shell: bash
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          miniconda-version: "latest"
+          environment-file: env.yml
+          activate-environment: vpn
+
+      - name: Install build dependencies
         run: |
-          pip3 install -r requirements.txt
+          ./scripts/macos/conda_install_extras.sh
+          export SDKROOT=$(xcrun --sdk macosx --show-sdk-path)
           brew install ninja
 
       - name: Install Qt6
-        shell: bash
         run: |
-          wget https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/mozillavpn.v2.mozillavpn.cache.level-3.toolchains.v3.qt-mac.latest/artifacts/public%2Fbuild%2Fqt6_mac.zip -O mac.zip
-          unzip -a mac.zip
-          sudo mv qt_dist /opt
-          cd ..
+          wget https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/mozillavpn.v2.mozillavpn.cache.level-3.toolchains.v3.qt-mac.latest/artifacts/public%2Fbuild%2Fqt6_mac.zip -O qt6_mac.zip
+          unzip -a -d ${{ github.workspace }} qt6_mac.zip
 
       - name: Install Grcov
         if: steps.cache-grcov.outputs.cache-hit != 'true'

--- a/.github/workflows/auth_tests.yml
+++ b/.github/workflows/auth_tests.yml
@@ -83,6 +83,7 @@ jobs:
         shell: bash
         working-directory: ./build/cmake/tests/auth_tests
         run: |
+          python3 -m oathtool
           ctest --output-on-failure
 
   windows-unit-tests:

--- a/.github/workflows/auth_tests.yml
+++ b/.github/workflows/auth_tests.yml
@@ -82,7 +82,6 @@ jobs:
       - name: Running tests
         working-directory: ./build/cmake/tests/auth_tests
         run: |
-          python3 -m oathtool
           ctest --output-on-failure
 
   windows-unit-tests:

--- a/.github/workflows/auth_tests.yml
+++ b/.github/workflows/auth_tests.yml
@@ -44,6 +44,9 @@ jobs:
 
   macos-unit-tests:
     runs-on: macos-latest
+    defaults:
+      run:
+        shell: bash -el {0}
     name: Run auth tests on MacOS
 
     steps:

--- a/.github/workflows/auth_tests.yml
+++ b/.github/workflows/auth_tests.yml
@@ -80,7 +80,6 @@ jobs:
           cmake --build build/cmake -j$(nproc) --target app_auth_tests
 
       - name: Running tests
-        shell: bash
         working-directory: ./build/cmake/tests/auth_tests
         run: |
           python3 -m oathtool

--- a/.github/workflows/auth_tests.yml
+++ b/.github/workflows/auth_tests.yml
@@ -81,9 +81,8 @@ jobs:
 
       - name: Running tests
         shell: bash
-        working-directory: ./build/tests/auth_tests
+        working-directory: ./build/cmake/tests/auth_tests
         run: |
-          export PATH=/opt/qt_dist/bin:${{github.workspace}}/grcov-build/bin:$PATH
           ctest --output-on-failure
 
   windows-unit-tests:

--- a/.github/workflows/macos_tests.yaml
+++ b/.github/workflows/macos_tests.yaml
@@ -48,12 +48,6 @@ jobs:
 
       - name: Compile test client
         run: |
-          conda info --envs
-          which python
-          which python3
-
-          echo "!!!!!!!!!!"
-
           mkdir -p build/cmake
           cmake -S $(pwd) -B build/cmake -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo \
             -DCMAKE_PREFIX_PATH=${{ github.workspace }}/qt_dist/lib/cmake


### PR DESCRIPTION
The auth tests are currently broken for MacOS, this is probably going on for a long time.

The issue is the same we had and fixed for MacOS functional tests, so this is very stright forward.

We should monitor this failures more closely though.