### PR TITLE
VPN-5911: Verify MacOS code signatures during installation.

### DIFF
--- a/macos/pkg/CMakeLists.txt
+++ b/macos/pkg/CMakeLists.txt
@@ -44,7 +44,15 @@ foreach(LOCALE ${I18N_LOCALES})
     set_target_properties(pkg_resources_${LOCALE} PROPERTIES FOLDER "Installer")
 endforeach()
 
-## Stage 1: Create the staging directory, and populate it with the app.
+## Stage 1: Preprocess the installation scripts.
+file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/scripts)
+configure_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/scripts/postinstall.in
+    ${CMAKE_CURRENT_BINARY_DIR}/scripts/postinstall
+    @ONLY
+)
+
+## Stage 2: Create the staging directory, and populate it with the app.
 add_custom_command(
     OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/staging/MozillaVPN.pkg
     BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/installer.plist
@@ -56,12 +64,12 @@ add_custom_command(
     COMMAND pkgbuild --analyze --root ${CMAKE_CURRENT_BINARY_DIR}/staging ${CMAKE_CURRENT_BINARY_DIR}/installer.plist
     COMMAND plutil -replace 0.BundleIsRelocatable -bool NO ${CMAKE_CURRENT_BINARY_DIR}/installer.plist
     COMMAND pkgbuild --identifier "$<TARGET_PROPERTY:mozillavpn,MACOSX_BUNDLE_GUI_IDENTIFIER>" --version "2.0"
-        --scripts ${CMAKE_CURRENT_SOURCE_DIR}/scripts --root ${CMAKE_CURRENT_BINARY_DIR}/staging
+        --scripts ${CMAKE_CURRENT_BINARY_DIR}/scripts --root ${CMAKE_CURRENT_BINARY_DIR}/staging
         --component-plist ${CMAKE_CURRENT_BINARY_DIR}/installer.plist
         ${CMAKE_CURRENT_BINARY_DIR}/staging/MozillaVPN.pkg
 )
 
-## Stage 2: Run productbuild to inject the distribution files.
+## Stage 3: Run productbuild to inject the distribution files.
 add_custom_command(
     OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/MozillaVPN-unsigned.pkg
     DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/staging/MozillaVPN.pkg pkg_resources
@@ -71,7 +79,7 @@ add_custom_command(
         MozillaVPN-unsigned.pkg
 )
 
-## Stage 3 (optional): Sign the installer package
+## Stage 4 (optional): Sign the installer package
 if(INSTALLER_SIGN_IDENTITY)
     add_custom_command(
         COMMENT "Building Signed MacOS Installer Package"

--- a/macos/pkg/CMakeLists.txt
+++ b/macos/pkg/CMakeLists.txt
@@ -47,13 +47,17 @@ endforeach()
 ## Stage 1: Create the staging directory, and populate it with the app.
 add_custom_command(
     OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/staging/MozillaVPN.pkg
+    BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/installer.plist
     DEPENDS mozillavpn
     COMMAND ${CMAKE_COMMAND} -E remove_directory -f ${CMAKE_CURRENT_BINARY_DIR}/staging
     COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/staging
     COMMAND ${CMAKE_COMMAND} -E copy_directory $<TARGET_BUNDLE_DIR:mozillavpn>
        ${CMAKE_CURRENT_BINARY_DIR}/staging/Applications/$<TARGET_PROPERTY:mozillavpn,OUTPUT_NAME>.app/
+    COMMAND pkgbuild --analyze --root ${CMAKE_CURRENT_BINARY_DIR}/staging ${CMAKE_CURRENT_BINARY_DIR}/installer.plist
+    COMMAND plutil -replace 0.BundleIsRelocatable -bool NO ${CMAKE_CURRENT_BINARY_DIR}/installer.plist
     COMMAND pkgbuild --identifier "$<TARGET_PROPERTY:mozillavpn,MACOSX_BUNDLE_GUI_IDENTIFIER>" --version "2.0"
         --scripts ${CMAKE_CURRENT_SOURCE_DIR}/scripts --root ${CMAKE_CURRENT_BINARY_DIR}/staging
+        --component-plist ${CMAKE_CURRENT_BINARY_DIR}/installer.plist
         ${CMAKE_CURRENT_BINARY_DIR}/staging/MozillaVPN.pkg
 )
 

--- a/macos/pkg/scripts/postinstall.in
+++ b/macos/pkg/scripts/postinstall.in
@@ -6,14 +6,20 @@
 
 set -eu
 
+APP_DIR="$2/Mozilla VPN.app"
 LOG_DIR=/var/log/mozillavpn
+
+CODESIGN_APP_IDENTIFIER="@BUILD_OSX_APP_IDENTIFIER@"
+CODESIGN_TEAM_IDENTIFIER="@BUILD_VPN_DEVELOPMENT_TEAM@"
+CODESIGN_CERT_SUBJECT="Developer ID Application: Mozilla Corporation (${CODESIGN_TEAM_IDENTIFIER})"
 
 mkdir -p $LOG_DIR
 exec 2>&1 > $LOG_DIR/postinstall.log
 
 echo "Running postinstall at $(date)"
+echo "Installing Mozilla VPN to ${APP_DIR}"
 
-DAEMON_PLIST_PATH="/Library/LaunchDaemons/org.mozilla.macos.FirefoxVPN.daemon.plist"
+DAEMON_PLIST_PATH="/Library/LaunchDaemons/${CODESIGN_APP_IDENTIFIER}.daemon.plist"
 
 DAEMON_PLIST=$(cat <<-EOM
 <?xml version="1.0" encoding="UTF-8"?>
@@ -21,10 +27,10 @@ DAEMON_PLIST=$(cat <<-EOM
 <plist version="1.0">
         <dict>
                 <key>Label</key>
-                <string>org.mozilla.macos.FirefoxVPN.daemon</string>
+                <string>${CODESIGN_APP_IDENTIFIER}.daemon</string>
                 <key>ProgramArguments</key>
                 <array>
-                        <string>/Applications/Mozilla VPN.app/Contents/MacOS/Mozilla VPN</string>
+                        <string>${APP_DIR}/Contents/MacOS/Mozilla VPN</string>
                         <string>macosdaemon</string>
                 </array>
                 <key>UserName</key>
@@ -48,6 +54,22 @@ EOM
 pkill -x "Mozilla VPN" || echo "Unable to kill GUI, not running?"
 sleep 1
 
+## Before MacOS 13, take extra care to prevent tampering with the app.
+echo "Restrict App file permissions..."
+chown -R root "$APP_DIR"
+chmod -R go-w "$APP_DIR"
+
+echo "Validate application codesign..."
+CODESIGN_REQS="anchor apple generic"
+CODESIGN_REQS+=" and certificate leaf[subject.OU] = \"${CODESIGN_TEAM_IDENTIFIER}\""
+CODESIGN_REQS+=" and certificate leaf[subject.CN] = \"${CODESIGN_CERT_SUBJECT}\""
+if ! codesign -v --verbose=4 -R="${CODESIGN_REQS}" "$APP_DIR"; then
+  echo "Codesign failed! Aborting."
+  rm -rf "$APP_DIR"
+  exit 1
+fi
+echo "Codesign successful!"
+
 UPDATING=
 if [ -f "$DAEMON_PLIST_PATH" ]; then
   UPDATING=1
@@ -60,24 +82,24 @@ echo "$DAEMON_PLIST" > $DAEMON_PLIST_PATH
 echo "Loading the Daemon at $DAEMON_PLIST_PATH"
 launchctl load -w $DAEMON_PLIST_PATH
 
-if [ -f "/Applications/Mozilla VPN.app/Contents/Resources/utils/mozillavpn.json" ]; then
+if [ -f "${APP_DIR}/Contents/Resources/utils/mozillavpn.json" ]; then
   echo "Install the firefox native messaging manifest"
   mkdir -p "/Library/Application Support/Mozilla/NativeMessagingHosts"
-  cp -f "/Applications/Mozilla VPN.app/Contents/Resources/utils/mozillavpn.json" "/Library/Application Support/Mozilla/NativeMessagingHosts/mozillavpn.json"
+  cp -f "${APP_DIR}/Contents/Resources/utils/mozillavpn.json" "/Library/Application Support/Mozilla/NativeMessagingHosts/mozillavpn.json"
 
   echo "Install the chrome native messaging manifest"
   mkdir -p "/Library/Google/Chrome/NativeMessagingHosts"
-  cp -f "/Applications/Mozilla VPN.app/Contents/Resources/utils/mozillavpn.json" "/Library/Google/Chrome/NativeMessagingHosts/mozillavpn.json"
+  cp -f "${APP_DIR}/Contents/Resources/utils/mozillavpn.json" "/Library/Google/Chrome/NativeMessagingHosts/mozillavpn.json"
 
   echo "Install the chromium native messaging manifest"
   mkdir -p "/Library/Application Support/Chromium/NativeMessagingHosts"
-  cp -f "/Applications/Mozilla VPN.app/Contents/Resources/utils/mozillavpn.json" "/Library/Application Support/Chromium/NativeMessagingHosts/mozillavpn.json"
+  cp -f "${APP_DIR}/Contents/Resources/utils/mozillavpn.json" "/Library/Application Support/Chromium/NativeMessagingHosts/mozillavpn.json"
 fi
 
 echo "Install Complete Run the app"
 if [ "$UPDATING" ]; then
-  open -a "/Applications/Mozilla VPN.app" --args ui --updated
+  open -a "$APP_DIR" --args ui --updated
 else
-  open -a "/Applications/Mozilla VPN.app"
+  open -a "$APP_DIR"
 fi
 exit 0

--- a/taskcluster/scripts/build/macos_build.sh
+++ b/taskcluster/scripts/build/macos_build.sh
@@ -132,7 +132,7 @@ fi
 
 cp -r ${TASK_HOME}/build/src/Mozilla\ VPN.app tmp || die
 cp -r ${TASK_HOME}/build/macos/pkg/Resources tmp || die
-cp -r ./macos/pkg/scripts tmp || die
+cp -r ${TASK_HOME}/build/macos/pkg/scripts tmp || die
 cp -r ./macos/pkg/Distribution tmp || die
 
 print Y "Compressing the build artifacts..."


### PR DESCRIPTION
## Description
In order to prevent tampering with the VPN application, we should take steps to verify the application code signature during installation. This can be done as some additional steps in the `postinstall` script.

While at it, I also figured out the fix for VPN-3443, which is that we need to configure the application bundle to deny relocation by PackageKit.

## Reference
Github issue #5137 ([VPN-3443](https://mozilla-hub.atlassian.net/browse/VPN-3443))
JIRA issue ([VPN-5911](https://mozilla-hub.atlassian.net/browse/VPN-5911))

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-3443]: https://mozilla-hub.atlassian.net/browse/VPN-3443?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[VPN-5911]: https://mozilla-hub.atlassian.net/browse/VPN-5911?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ