### PR TITLE
VPN-5363 Update our App Exclusions Telemetry

### DIFF
--- a/src/telemetry/impression_metrics.yaml
+++ b/src/telemetry/impression_metrics.yaml
@@ -476,3 +476,39 @@ impression:
       - gela@mozilla.com
     expires: never
     extra_keys: *impression_extra_keys
+  settings_screen:
+    type: event
+    lifetime: ping
+    send_in_pings:
+      - main
+    description: |
+      The user has just moved on to the settings screen 
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/VPN-5363
+    data_reviews:
+      - https://github.com/mozilla-mobile/mozilla-vpn-client/pull/8440#issuecomment-1791474783
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - gela@mozilla.com
+      - vpn-telemetry@mozilla.com
+    expires: never
+    extra_keys: *impression_extra_keys  
+  app_exclusions_screen:
+    type: event
+    lifetime: ping
+    send_in_pings:
+      - main
+    description: |
+      The user has just moved on to the app exclusions screen 
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/VPN-5363
+    data_reviews:
+      - https://github.com/mozilla-mobile/mozilla-vpn-client/pull/8440#issuecomment-1791474783
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - gela@mozilla.com
+      - vpn-telemetry@mozilla.com
+    expires: never
+    extra_keys: *impression_extra_keys  

--- a/src/telemetry/interaction_metrics.yaml
+++ b/src/telemetry/interaction_metrics.yaml
@@ -1014,3 +1014,76 @@ interaction:
       - gela@mozilla.com
     expires: never
     extra_keys: *interaction_extra_keys
+  app_exclusions_selected:
+    type: event
+    lifetime: ping
+    send_in_pings:
+      - main
+    description: |
+      The user has clicked the button that opens
+      the app exclusions modal
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/VPN-5363
+    data_reviews:
+      - https://github.com/mozilla-mobile/mozilla-vpn-client/pull/8440#issuecomment-1791474783
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - gela@mozilla.com
+      - vpn-telemetry@mozilla.com
+    expires: never
+    extra_keys: *interaction_extra_keys
+  clear_app_exclusions_selected:
+    type: event
+    lifetime: ping
+    send_in_pings:
+      - main
+    description: |
+      The user has clicked on Clear all to clear all App Exclusions
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/VPN-5363
+    data_reviews:
+      - https://github.com/mozilla-mobile/mozilla-vpn-client/pull/8440#issuecomment-1791474783
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - gela@mozilla.com
+      - vpn-telemetry@mozilla.com
+    expires: never
+    extra_keys: *interaction_extra_keys
+  add_application_selected:
+    type: event
+    lifetime: ping
+    send_in_pings:
+      - main
+    description: |
+      The user has clicked on Add application in App Exclusions
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/VPN-5363
+    data_reviews:
+      - https://github.com/mozilla-mobile/mozilla-vpn-client/pull/8440#issuecomment-1791474783
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - gela@mozilla.com
+      - vpn-telemetry@mozilla.com
+    expires: never
+    extra_keys: *interaction_extra_keys
+  search_selected:
+    type: event
+    lifetime: ping
+    send_in_pings:
+      - main
+    description: |
+      The user has clicked on the search field in app exclusions
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/VPN-5363
+    data_reviews:
+      - https://github.com/mozilla-mobile/mozilla-vpn-client/pull/8440#issuecomment-1791474783
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - gela@mozilla.com
+      - vpn-telemetry@mozilla.com
+    expires: never
+    extra_keys: *interaction_extra_keys  

--- a/src/ui/screens/settings/ViewSettingsMenu.qml
+++ b/src/ui/screens/settings/ViewSettingsMenu.qml
@@ -210,6 +210,6 @@ MZViewBase {
         }
     }
     Component.onCompleted: {
-        Glean.sample.settingsViewOpened.record();
+        Glean.impression.settingsScreen.record({screen:telemetryScreenId});
     }
 }

--- a/src/ui/screens/settings/ViewSettingsMenu.qml
+++ b/src/ui/screens/settings/ViewSettingsMenu.qml
@@ -84,7 +84,10 @@ MZViewBase {
                 imageLeftSrc: "qrc:/ui/resources/settings/apppermissions.svg"
                 imageRightSrc: "qrc:/nebula/resources/chevron.svg"
                 imageRightMirror: MZLocalizer.isRightToLeft
-                onClicked: stackview.push("qrc:/ui/screens/settings/appPermissions/ViewAppPermissions.qml")
+                onClicked: {
+                    Glean.interaction.appExclusionsSelected.record({screen:telemetryScreenId});
+                    stackview.push("qrc:/ui/screens/settings/appPermissions/ViewAppPermissions.qml")
+                }
                 visible: MZFeatureList.get("splitTunnel").isSupported
             }
 

--- a/src/ui/screens/settings/appPermissions/AppPermissionsList.qml
+++ b/src/ui/screens/settings/appPermissions/AppPermissionsList.qml
@@ -17,6 +17,7 @@ ColumnLayout {
     id: appListContainer
     objectName: "appListContainer"
     property string searchBarPlaceholder: ""
+    readonly property string telemetryScreenId : "app_exclusions"
 
     spacing: MZTheme.theme.vSpacing
 
@@ -61,7 +62,10 @@ ColumnLayout {
             fontSize: MZTheme.theme.fontSize
             fontName: MZTheme.theme.fontInterSemiBoldFamily
 
-            onClicked: VPNAppPermissions.protectAll();
+            onClicked: {
+                Glean.interaction.clearAppExclusionsSelected.record({screen:telemetryScreenId});
+                VPNAppPermissions.protectAll();
+            }
             enabled: MZSettings.vpnDisabledApps.length > 0
             visible: applist.count > 0
         }

--- a/src/ui/screens/settings/appPermissions/AppPermissionsList.qml
+++ b/src/ui/screens/settings/appPermissions/AppPermissionsList.qml
@@ -146,7 +146,10 @@ ColumnLayout {
             textAlignment: Text.AlignLeft
             fontSize: MZTheme.theme.fontSize
             fontName: MZTheme.theme.fontInterSemiBoldFamily
-            onClicked: VPNAppPermissions.openFilePicker()
+            onClicked: {
+                Glean.interaction.addApplicationSelected.record({screen:telemetryScreenId});
+                VPNAppPermissions.openFilePicker()
+            }
 
             // Hack to horizontally align the "+" sign with the
             // column of checkboxes

--- a/tests/functional/testAppExclusions.js
+++ b/tests/functional/testAppExclusions.js
@@ -75,4 +75,16 @@ describe('Settings', function() {
     await vpn.waitForQuery(screenSettings.STACKVIEW.ready());
     await vpn.waitForQueryAndClick(screenSettings.APP_EXCLUSIONS.visible());
   });
+
+  // Dummy VPN does not have the Add Application button so we cannot currently test this.
+  // Jira issue: https://mozilla-hub.atlassian.net/browse/VPN-5974
+  it('Record telemetry when users clicks on Add application', async () => {
+    // await vpn.waitForQueryAndClick(appExclusionsView.ADD_APPLICATION_BUTTON.visible());
+    // await vpn.waitForQuery(appExclusionsView.STACKVIEW.ready());
+
+    // const events = await vpn.gleanTestGetValue("interaction", "addApplicationSelected", "main")
+    // assert.equal(events.length, 1);
+    // var element = events[0];
+    // assert.equal(element.extra.screen, "app_exclusions");
+  });
 });

--- a/tests/functional/testAppExclusions.js
+++ b/tests/functional/testAppExclusions.js
@@ -41,6 +41,11 @@ describe('Settings', function() {
      });
 
   it('Clear all button removes all apps from exclusion list and records telemetry', async () => {
+    if (this.ctx.wasm) {
+      // This test cannot run in wasm
+      return;
+    }
+    
     await vpn.waitForQueryAndClick(appExclusionsView.CHECKBOX1.visible());
     await vpn.waitForQueryAndClick(appExclusionsView.CHECKBOX2.visible());
     await vpn.waitForQuery(screenSettings.STACKVIEW.ready());
@@ -89,6 +94,10 @@ describe('Settings', function() {
   });
 
   it('Record telemetry when user clicks on App Exclusions', async () => {
+    if (this.ctx.wasm) {
+      // This test cannot run in wasm
+      return;
+    }
     await vpn.waitForQueryAndClick(navBar.SETTINGS.visible());
     await vpn.waitForQuery(screenSettings.STACKVIEW.ready());
     await vpn.waitForQueryAndClick(screenSettings.APP_EXCLUSIONS.visible());

--- a/tests/functional/testAppExclusions.js
+++ b/tests/functional/testAppExclusions.js
@@ -40,7 +40,7 @@ describe('Settings', function() {
        assert(await getNumDisabledApps() == '0');
      });
 
-  it('Clear all button removes all apps from exclusion list', async () => {
+  it('Clear all button removes all apps from exclusion list and records telemetry', async () => {
     await vpn.waitForQueryAndClick(appExclusionsView.CHECKBOX1.visible());
     await vpn.waitForQueryAndClick(appExclusionsView.CHECKBOX2.visible());
     await vpn.waitForQuery(screenSettings.STACKVIEW.ready());
@@ -50,6 +50,12 @@ describe('Settings', function() {
     await vpn.waitForQueryAndClick(appExclusionsView.CLEAR_ALL.visible());
     await vpn.waitForQuery(screenSettings.STACKVIEW.ready());
     assert(await getNumDisabledApps() == '0');
+
+    // Check that we collect telemetry
+    const events = await vpn.gleanTestGetValue("interaction", "clearAppExclusionsSelected", "main");
+    assert.equal(events.length, 1);
+    var element = events[0];
+    assert.equal(element.extra.screen, "app_exclusions");
   });
 
   it('Excluded apps are at the top of the list on initial load', async () => {

--- a/tests/functional/testAppExclusions.js
+++ b/tests/functional/testAppExclusions.js
@@ -78,7 +78,7 @@ describe('Settings', function() {
 
   // Dummy VPN does not have the Add Application button so we cannot currently test this.
   // Jira issue: https://mozilla-hub.atlassian.net/browse/VPN-5974
-  it('Record telemetry when users clicks on Add application', async () => {
+  it('Record telemetry when user clicks on Add application', async () => {
     // await vpn.waitForQueryAndClick(appExclusionsView.ADD_APPLICATION_BUTTON.visible());
     // await vpn.waitForQuery(appExclusionsView.STACKVIEW.ready());
 
@@ -86,5 +86,17 @@ describe('Settings', function() {
     // assert.equal(events.length, 1);
     // var element = events[0];
     // assert.equal(element.extra.screen, "app_exclusions");
+  });
+
+  it('Record telemetry when user clicks on App Exclusions', async () => {
+    await vpn.waitForQueryAndClick(navBar.SETTINGS.visible());
+    await vpn.waitForQuery(screenSettings.STACKVIEW.ready());
+    await vpn.waitForQueryAndClick(screenSettings.APP_EXCLUSIONS.visible());
+    await vpn.waitForQuery(screenSettings.STACKVIEW.ready());
+
+    // Check that we collect telemetry
+    const events = await vpn.gleanTestGetValue("interaction", "appExclusionsSelected", "main");
+    var element = events[0];
+    assert.equal(element.extra.screen, "settings");
   });
 });

--- a/tests/functional/testSettings.js
+++ b/tests/functional/testSettings.js
@@ -977,5 +977,13 @@ describe('Settings', function() {
         var element = events[0];
         assert.equal(element.extra.screen, "settings");
     });
+
+    it("record telemetry when user goes to the Settings screen", async () => {
+        await vpn.waitForQueryAndClick(queries.navBar.SETTINGS.visible());
+
+        const settingsScreenEvent = await vpn.gleanTestGetValue("impression", "settingsScreen", "main");
+        const settingsScreenEventExtras = settingsScreenEvent[0].extra;
+        assert.strictEqual("settings", settingsScreenEventExtras.screen);
+    });
   });
 });

--- a/tests/functional/testSettings.js
+++ b/tests/functional/testSettings.js
@@ -979,6 +979,11 @@ describe('Settings', function() {
     });
 
     it("record telemetry when user goes to the Settings screen", async () => {
+        if (this.ctx.wasm) {
+            // This test cannot run in wasm
+            return;
+        }
+        
         await vpn.waitForQueryAndClick(queries.navBar.SETTINGS.visible());
 
         const settingsScreenEvent = await vpn.gleanTestGetValue("impression", "settingsScreen", "main");


### PR DESCRIPTION
Please note that this PR is essentially a duplicate of https://github.com/mozilla-mobile/mozilla-vpn-client/pull/8440 but I was getting some mysterious test failures and it was more straightforward to cherry pick the changes over to this PR than to try and get the original PR to work again. Sorry! For data and PR review please refer back to the original.

## Description

Add telemetry to the buttons and screens pertaining to app exclusions in the VPN setting (and corresponding functional tests to ensure we are correctly tracking these interactions). These new additions attempt to answer the following question:

- What’s the level of interest for “App Exclusions”? (views of the “App Exclusions” screen and %age of devices)
- How often do people use search to find the apps they want to exclude? (# clicks on the search function / # views of the “App Exclusions” screen)
- How often do people add custom Apps? (# clicks on the “Add application” button / # views of the “App Exclusions” screen)
- What’s the actual usage of App Exclusions? (# and %age of total active sessions that have at least 1 App opted out of protection)
- What’s the intensity of usage of App Exclusions? (avg. # of apps excluded in sessions that have had at least 1 app excluded)

## Reference

**Ticket:** https://mozilla-hub.atlassian.net/browse/VPN-5363

**Miro board:** https://miro.com/app/board/uXjVMAXDiYc=/

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
