### PR TITLE
VPN-5816: Elide step progress bar delegate labels

### DIFF
--- a/nebula/ui/components/MZStepProgressBarDelegate.qml
+++ b/nebula/ui/components/MZStepProgressBarDelegate.qml
@@ -121,7 +121,7 @@ Column {
         anchors.horizontalCenter: parent.horizontalCenter
 
         elide: Text.ElideRight
-        maximumLineCount: 2
+        maximumLineCount: 1
         font.pixelSize: MZTheme.theme.fontSizeSmallest
         lineHeightMode: Text.FixedHeight
         lineHeight: MZTheme.theme.controllerInterLineHeight


### PR DESCRIPTION
## Description

Previously, long progress bar delegate labels would wrap if they impeded on a neighboring progress bar label. To resolve this, we will now right elide long labels 

| Before  | After |
| ------------- | ------------- |
| <img width="428" alt="Screenshot 2023-12-04 at 11 08 45 AM" src="https://github.com/mozilla-mobile/mozilla-vpn-client/assets/15353801/020a74ee-1680-4aff-bb46-1c7deb46c109"> | <img width="428" alt="Screenshot 2023-12-04 at 11 08 31 AM" src="https://github.com/mozilla-mobile/mozilla-vpn-client/assets/15353801/51d5d2fd-2186-4c7f-b51c-987553c66d52"> |

## Reference

[VPN-5816: [l10n] New on-boarding progress bar names are not wrapped in some languages](https://mozilla-hub.atlassian.net/browse/VPN-5816)
