### PR TITLE
No ticket - Add sample Nimbus features file

### DIFF
--- a/src/experimentation/nimbus.yaml
+++ b/src/experimentation/nimbus.yaml
@@ -1,0 +1,26 @@
+about:
+  description: Nimbus Feature Manifest for Monitor Web testing
+channels:
+  - staging
+  - production
+features:
+  example-feature:
+    description: An example feature
+    variables:
+      enabled:
+        description: If the feature is enabled
+        type: Boolean
+        default: false
+      something:
+        description: Another variable
+        type: Option<String>
+        default: null
+    defaults:
+      - channel: staging
+        value: { "enabled": true }
+      - channel: production
+        value: { "something": "wicked" }
+
+types:
+  objects: {}
+  enums: {}

--- a/src/experimentation/nimbus.yaml
+++ b/src/experimentation/nimbus.yaml
@@ -1,5 +1,5 @@
 about:
-  description: Nimbus Feature Manifest for Monitor Web testing
+  description: Nimbus Feature Manifest for Mozilla VPN testing
 channels:
   - vpn
 features:

--- a/src/experimentation/nimbus.yaml
+++ b/src/experimentation/nimbus.yaml
@@ -1,8 +1,7 @@
 about:
   description: Nimbus Feature Manifest for Monitor Web testing
 channels:
-  - staging
-  - production
+  - vpn
 features:
   example-feature:
     description: An example feature
@@ -16,10 +15,8 @@ features:
         type: Option<String>
         default: null
     defaults:
-      - channel: staging
+      - channel: vpn
         value: { "enabled": true }
-      - channel: production
-        value: { "something": "wicked" }
 
 types:
   objects: {}


### PR DESCRIPTION
Adding this in now, because we will need the path for this file to finish setup of the sidecar container.

This feature is copy pasted from https://github.com/mozilla/blurts-server/blob/4331ae752d797eb1f88c4bf6e75fcd4a833a411d/config/nimbus.yaml