### PR TITLE
Android Deep Linking Bits 

### DIFF
--- a/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/NotificationUtil.kt
+++ b/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/NotificationUtil.kt
@@ -2,182 +2,200 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package org.mozilla.firefox.vpn.daemon
+ package org.mozilla.firefox.vpn.daemon
 
-import android.app.NotificationChannel
-import android.app.NotificationManager
-import android.app.PendingIntent
-import android.app.Service
-import android.content.Context
-import android.content.Intent
-import android.content.pm.PackageManager
-import android.os.Build
-import androidx.core.app.NotificationCompat
-import kotlinx.serialization.Serializable
-import org.json.JSONObject
-import org.mozilla.firefox.qt.common.Prefs
-
-class NotificationUtil(ctx: Service) {
-    private val HAS_ASKED_FOR_PUSH_PERMISSION = "com.mozilla.vpnNotification.didAskForPermission"
-    private val NOTIFICATION_CHANNEL_ID = "com.mozilla.vpnNotification"
-    private val CONNECTED_NOTIFICATION_ID = 1337
-    private val context: Service = ctx
-    private val mNotificationBuilder: NotificationCompat.Builder by lazy {
-        NotificationCompat.Builder(ctx, NOTIFICATION_CHANNEL_ID)
-    }
-    private val mNotificationManager: NotificationManager by lazy {
-        ctx.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-    }
-    private val mainActivityName = "org.mozilla.firefox.vpn.qt.VPNActivity"
-
-    /**
-     * Creates a new Notification using the {CannedNotification}
-     * Will bring the service into the foreground using that.
-     */
-    fun show(message: CannedNotification) {
-        updateNotificationChannel()
-        // Create the Intent that Should be Fired if the User Clicks the notification
-        val activity = Class.forName(mainActivityName)
-        val intent = Intent(context, activity)
-        val pendingIntent =
-            PendingIntent.getActivity(context, 0, intent, PendingIntent.FLAG_IMMUTABLE)
-        // Build our notification
-        mNotificationBuilder
-            .setSmallIcon(R.drawable.icon_mozillavpn_notifiaction)
-            .setContentTitle(message.connectedMessage.header)
-            .setContentText(message.connectedMessage.body)
-            .setOnlyAlertOnce(true)
-            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
-            .setContentIntent(pendingIntent)
-        context.startForeground(CONNECTED_NOTIFICATION_ID, mNotificationBuilder.build())
-    }
-
-    /**
-     * Updates the Notification
-     * in case there is no notification currently,
-     * this is a no-op.
-     */
-    fun setNotificationText(msg: ClientNotification?) {
-        if (msg == null) {
-            return
-        }
-        mNotificationBuilder.let {
-            it.setContentTitle(msg.header)
-            it.setContentText(msg.body)
-            mNotificationManager.notify(CONNECTED_NOTIFICATION_ID, it.build())
-        }
-    }
-
-    /**
-     * Should be called whenever a session is ended.
-     * Will upadte the notification to show the Disconnected Message
-     */
-    fun hide(message: CannedNotification) {
-        // Switch the notification to "Disconnected" / or translated version
-        // If the VPN-Client is alive, it will override this instantly
-        // If not, this fallback is shown.
-        setNotificationText(message.disconnectedMessage)
-    }
-
-    // Creates / Updates the notification channel we will be using to post
-    // the notification to.
-    private fun updateNotificationChannel(name: String = "General", descriptionText: String = "") {
-        // From Oreo on we need to have a "notification channel" to post to.
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
-            return
-        }
-        val importance = NotificationManager.IMPORTANCE_LOW
-        val channel = NotificationChannel(NOTIFICATION_CHANNEL_ID, name, importance).apply {
-            description = descriptionText
-        }
-        // Register the channel with the system
-        mNotificationManager.createNotificationChannel(channel)
-    }
-
-    /**
-     * Returns true if the permission "android.permission.POST_NOTIFICATIONS"
-     * needs to be requested before this class will be functional.
-     */
-    fun needsNotificationPermission(): Boolean {
-        // Android 13
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
-            Log.i("NotificationUtil", "No need to request permissionf for ${Build.VERSION.SDK_INT}")
-            // Below android 13, we will request permissions on
-            // implicit due to us being a foreground service
-            return false
-        }
-        val res = context.checkSelfPermission("android.permission.POST_NOTIFICATIONS")
-        if (res == PackageManager.PERMISSION_GRANTED) {
-            Log.i("NotificationUtil", "Permission Granted")
-            // We have the permission, all good
-            return false
-        }
-        // We would need permissions but only ask the user once.
-        val prefs = Prefs.get(context)
-        if (prefs.getBoolean(HAS_ASKED_FOR_PUSH_PERMISSION, false)) {
-            Log.i("NotificationUtil", "We already asked for push permission, not doing again")
-            return false
-        }
-        Log.i("NotificationUtil", "Need to ask for Notificaiton Permission")
-        return true
-    }
-
-    /**
-     * Should be fired once the user has been asked about their notification
-     * preference, so we will only ask once.
-     */
-    fun onNotificationPermissionPromptFired() {
-        val prefs = Prefs.get(context)
-        prefs.edit().putBoolean(HAS_ASKED_FOR_PUSH_PERMISSION, true).apply()
-    }
-}
-
- /*
-  * ClientNotification
-  * Message sent from the client manually.
-  */
-@Serializable
-data class ClientNotification(val header: String, val body: String)
-
- /*
-  * A "Canned" Notification contains all strings needed for the "(dis-)/connected" flow
-  * and is provided by the controller when asking for a connection.
-  */
-@Serializable
-data class CannedNotification(
+ import android.app.NotificationChannel
+ import android.app.NotificationManager
+ import android.app.PendingIntent
+ import android.app.Service
+ import android.content.Context
+ import android.content.Intent
+ import android.content.pm.PackageManager
+ import android.net.Uri
+ import android.os.Build
+ import androidx.core.app.NotificationCompat
+ import kotlinx.serialization.Serializable
+ import org.json.JSONObject
+ import org.mozilla.firefox.qt.common.Prefs
+ 
+ class NotificationUtil(ctx: Service) {
+     private val HAS_ASKED_FOR_PUSH_PERMISSION = "com.mozilla.vpnNotification.didAskForPermission"
+     private val NOTIFICATION_CHANNEL_ID = "com.mozilla.vpnNotification"
+     private val CONNECTED_NOTIFICATION_ID = 1337
+     private val context: Service = ctx
+     private val mNotificationBuilder: NotificationCompat.Builder by lazy {
+         NotificationCompat.Builder(ctx, NOTIFICATION_CHANNEL_ID)
+     }
+     private val mNotificationManager: NotificationManager by lazy {
+         ctx.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+     }
+     private val mainActivityName = "org.mozilla.firefox.vpn.qt.VPNActivity"
+ 
+     /**
+      * Creates a new Notification using the {CannedNotification}
+      * Will bring the service into the foreground using that.
+      */
+     fun show(message: CannedNotification) {
+         updateNotificationChannel()
+         // Create the Intent that Should be Fired if the User Clicks the notification
+         val activity = Class.forName(mainActivityName)
+         val intent = Intent(context, activity)
+         try {
+            message.requestedScreen.let{
+                intent.data = Uri.parse(message.requestedScreen)
+            }
+         }catch(ex:Exception){
+            // Uuuh let's just put a default one?
+            intent.data = Uri.parse("mozilla-vpn://home");
+         }
+ 
+         val pendingIntent =
+             PendingIntent.getActivity(context, 0, intent, PendingIntent.FLAG_IMMUTABLE)
+ 
+         // Build our notification
+         mNotificationBuilder
+             .setSmallIcon(R.drawable.icon_mozillavpn_notifiaction)
+             .setContentTitle(message.connectedMessage.header)
+             .setContentText(message.connectedMessage.body)
+             .setOnlyAlertOnce(true)
+             .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+             .setContentIntent(pendingIntent)
+         context.startForeground(CONNECTED_NOTIFICATION_ID, mNotificationBuilder.build())
+     }
+ 
+     /**
+      * Updates the Notification
+      * in case there is no notification currently,
+      * this is a no-op.
+      */
+     fun setNotificationText(msg: ClientNotification?) {
+         if (msg == null) {
+             return
+         }
+         mNotificationBuilder.let {
+             it.setContentTitle(msg.header)
+             it.setContentText(msg.body)
+             mNotificationManager.notify(CONNECTED_NOTIFICATION_ID, it.build())
+         }
+     }
+ 
+     /**
+      * Should be called whenever a session is ended.
+      * Will upadte the notification to show the Disconnected Message
+      */
+     fun hide(message: CannedNotification) {
+         // Switch the notification to "Disconnected" / or translated version
+         // If the VPN-Client is alive, it will override this instantly
+         // If not, this fallback is shown.
+         setNotificationText(message.disconnectedMessage)
+     }
+ 
+     // Creates / Updates the notification channel we will be using to post
+     // the notification to.
+     private fun updateNotificationChannel(name: String = "General", descriptionText: String = "") {
+         // From Oreo on we need to have a "notification channel" to post to.
+         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+             return
+         }
+         val importance = NotificationManager.IMPORTANCE_LOW
+         val channel = NotificationChannel(NOTIFICATION_CHANNEL_ID, name, importance).apply {
+             description = descriptionText
+         }
+         // Register the channel with the system
+         mNotificationManager.createNotificationChannel(channel)
+     }
+ 
+     /**
+      * Returns true if the permission "android.permission.POST_NOTIFICATIONS"
+      * needs to be requested before this class will be functional.
+      */
+     fun needsNotificationPermission(): Boolean {
+         // Android 13
+         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+             Log.i("NotificationUtil", "No need to request permissionf for ${Build.VERSION.SDK_INT}")
+             // Below android 13, we will request permissions on
+             // implicit due to us being a foreground service
+             return false
+         }
+         val res = context.checkSelfPermission("android.permission.POST_NOTIFICATIONS")
+         if (res == PackageManager.PERMISSION_GRANTED) {
+             Log.i("NotificationUtil", "Permission Granted")
+             // We have the permission, all good
+             return false
+         }
+         // We would need permissions but only ask the user once.
+         val prefs = Prefs.get(context)
+         if (prefs.getBoolean(HAS_ASKED_FOR_PUSH_PERMISSION, false)) {
+             Log.i("NotificationUtil", "We already asked for push permission, not doing again")
+             return false
+         }
+         Log.i("NotificationUtil", "Need to ask for Notificaiton Permission")
+         return true
+     }
+ 
+     /**
+      * Should be fired once the user has been asked about their notification
+      * preference, so we will only ask once.
+      */
+     fun onNotificationPermissionPromptFired() {
+         val prefs = Prefs.get(context)
+         prefs.edit().putBoolean(HAS_ASKED_FOR_PUSH_PERMISSION, true).apply()
+     }
+ }
+ 
+  /*
+   * ClientNotification
+   * Message sent from the client manually.
+   */
+ @Serializable
+ data class ClientNotification(
+    val header: String, 
+    val body: String,
+ )
+ 
+  /*
+   * A "Canned" Notification contains all strings needed for the "(dis-)/connected" flow
+   * and is provided by the controller when asking for a connection.
+   */
+ @Serializable
+ data class CannedNotification(
     // Message to be shown when the Client connects
     val connectedMessage: ClientNotification,
     // Message to be shown when the client disconnects
     val disconnectedMessage: ClientNotification,
     // Product-Name -> Will be used as the Notification Header
     val productName: String,
-) {
-    companion object {
-        /**
-         * CannedNotification(json) -> Creates a Canned notification
-         * out of a VPN-Client JSON config.
-         */
-        operator fun invoke(value: JSONObject?): CannedNotification? {
-            if (value == null) {
-                return null
-            }
-            val messages = value.getJSONObject("messages")
-            return try {
-                CannedNotification(
-                    ClientNotification(
-                        messages.getString("connectedHeader"),
-                        messages.getString("connectedBody"),
-                    ),
-                    ClientNotification(
-                        messages.getString("disconnectedHeader"),
-                        messages.getString("disconnectedBody"),
-                    ),
-                    messages.getString("productName"),
-                )
-            } catch (e: Exception) {
-                Log.e("NotificationUtil", "Failed to Parse Notification Object $value")
-                null
-            }
-        }
-    }
-}
+    // requestedScreen: a url -> mozilla-vpn://<my-string>
+    val requestedScreen: String?,
+ ) {
+     companion object {
+         /**
+          * CannedNotification(json) -> Creates a Canned notification
+          * out of a VPN-Client JSON config.
+          */
+         operator fun invoke(value: JSONObject?): CannedNotification? {
+             if (value == null) {
+                 return null
+             }
+             val messages = value.getJSONObject("messages")
+             return try {
+                 CannedNotification(
+                     ClientNotification(
+                         messages.getString("connectedHeader"),
+                         messages.getString("connectedBody"),
+                     ),
+                     ClientNotification(
+                         messages.getString("disconnectedHeader"),
+                         messages.getString("disconnectedBody"),
+                     ),
+                     messages.getString("productName"),
+                     messages.getString("requestedScreen"),
+                 )
+             } catch (e: Exception) {
+                 Log.e("NotificationUtil", "Failed to Parse Notification Object $value")
+                 null
+             }
+         }
+     }
+ }
+ 

--- a/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/NotificationUtil.kt
+++ b/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/NotificationUtil.kt
@@ -2,163 +2,163 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
- package org.mozilla.firefox.vpn.daemon
+package org.mozilla.firefox.vpn.daemon
 
- import android.app.NotificationChannel
- import android.app.NotificationManager
- import android.app.PendingIntent
- import android.app.Service
- import android.content.Context
- import android.content.Intent
- import android.content.pm.PackageManager
- import android.net.Uri
- import android.os.Build
- import androidx.core.app.NotificationCompat
- import kotlinx.serialization.Serializable
- import org.json.JSONObject
- import org.mozilla.firefox.qt.common.Prefs
- 
- class NotificationUtil(ctx: Service) {
-     private val HAS_ASKED_FOR_PUSH_PERMISSION = "com.mozilla.vpnNotification.didAskForPermission"
-     private val NOTIFICATION_CHANNEL_ID = "com.mozilla.vpnNotification"
-     private val CONNECTED_NOTIFICATION_ID = 1337
-     private val context: Service = ctx
-     private val mNotificationBuilder: NotificationCompat.Builder by lazy {
-         NotificationCompat.Builder(ctx, NOTIFICATION_CHANNEL_ID)
-     }
-     private val mNotificationManager: NotificationManager by lazy {
-         ctx.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-     }
-     private val mainActivityName = "org.mozilla.firefox.vpn.qt.VPNActivity"
- 
-     /**
-      * Creates a new Notification using the {CannedNotification}
-      * Will bring the service into the foreground using that.
-      */
-     fun show(message: CannedNotification) {
-         updateNotificationChannel()
-         // Create the Intent that Should be Fired if the User Clicks the notification
-         val activity = Class.forName(mainActivityName)
-         val intent = Intent(context, activity)
-         try {
-            message.requestedScreen.let{
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.net.Uri
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import kotlinx.serialization.Serializable
+import org.json.JSONObject
+import org.mozilla.firefox.qt.common.Prefs
+
+class NotificationUtil(ctx: Service) {
+    private val HAS_ASKED_FOR_PUSH_PERMISSION = "com.mozilla.vpnNotification.didAskForPermission"
+    private val NOTIFICATION_CHANNEL_ID = "com.mozilla.vpnNotification"
+    private val CONNECTED_NOTIFICATION_ID = 1337
+    private val context: Service = ctx
+    private val mNotificationBuilder: NotificationCompat.Builder by lazy {
+        NotificationCompat.Builder(ctx, NOTIFICATION_CHANNEL_ID)
+    }
+    private val mNotificationManager: NotificationManager by lazy {
+        ctx.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+    }
+    private val mainActivityName = "org.mozilla.firefox.vpn.qt.VPNActivity"
+
+    /**
+     * Creates a new Notification using the {CannedNotification}
+     * Will bring the service into the foreground using that.
+     */
+    fun show(message: CannedNotification) {
+        updateNotificationChannel()
+        // Create the Intent that Should be Fired if the User Clicks the notification
+        val activity = Class.forName(mainActivityName)
+        val intent = Intent(context, activity)
+        try {
+            message.requestedScreen.let {
                 intent.data = Uri.parse(message.requestedScreen)
             }
-         }catch(ex:Exception){
+        } catch (ex: Exception) {
             // Uuuh let's just put a default one?
-            intent.data = Uri.parse("mozilla-vpn://home");
-         }
- 
-         val pendingIntent =
-             PendingIntent.getActivity(context, 0, intent, PendingIntent.FLAG_IMMUTABLE)
- 
-         // Build our notification
-         mNotificationBuilder
-             .setSmallIcon(R.drawable.icon_mozillavpn_notifiaction)
-             .setContentTitle(message.connectedMessage.header)
-             .setContentText(message.connectedMessage.body)
-             .setOnlyAlertOnce(true)
-             .setPriority(NotificationCompat.PRIORITY_DEFAULT)
-             .setContentIntent(pendingIntent)
-         context.startForeground(CONNECTED_NOTIFICATION_ID, mNotificationBuilder.build())
-     }
- 
-     /**
-      * Updates the Notification
-      * in case there is no notification currently,
-      * this is a no-op.
-      */
-     fun setNotificationText(msg: ClientNotification?) {
-         if (msg == null) {
-             return
-         }
-         mNotificationBuilder.let {
-             it.setContentTitle(msg.header)
-             it.setContentText(msg.body)
-             mNotificationManager.notify(CONNECTED_NOTIFICATION_ID, it.build())
-         }
-     }
- 
-     /**
-      * Should be called whenever a session is ended.
-      * Will upadte the notification to show the Disconnected Message
-      */
-     fun hide(message: CannedNotification) {
-         // Switch the notification to "Disconnected" / or translated version
-         // If the VPN-Client is alive, it will override this instantly
-         // If not, this fallback is shown.
-         setNotificationText(message.disconnectedMessage)
-     }
- 
-     // Creates / Updates the notification channel we will be using to post
-     // the notification to.
-     private fun updateNotificationChannel(name: String = "General", descriptionText: String = "") {
-         // From Oreo on we need to have a "notification channel" to post to.
-         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
-             return
-         }
-         val importance = NotificationManager.IMPORTANCE_LOW
-         val channel = NotificationChannel(NOTIFICATION_CHANNEL_ID, name, importance).apply {
-             description = descriptionText
-         }
-         // Register the channel with the system
-         mNotificationManager.createNotificationChannel(channel)
-     }
- 
-     /**
-      * Returns true if the permission "android.permission.POST_NOTIFICATIONS"
-      * needs to be requested before this class will be functional.
-      */
-     fun needsNotificationPermission(): Boolean {
-         // Android 13
-         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
-             Log.i("NotificationUtil", "No need to request permissionf for ${Build.VERSION.SDK_INT}")
-             // Below android 13, we will request permissions on
-             // implicit due to us being a foreground service
-             return false
-         }
-         val res = context.checkSelfPermission("android.permission.POST_NOTIFICATIONS")
-         if (res == PackageManager.PERMISSION_GRANTED) {
-             Log.i("NotificationUtil", "Permission Granted")
-             // We have the permission, all good
-             return false
-         }
-         // We would need permissions but only ask the user once.
-         val prefs = Prefs.get(context)
-         if (prefs.getBoolean(HAS_ASKED_FOR_PUSH_PERMISSION, false)) {
-             Log.i("NotificationUtil", "We already asked for push permission, not doing again")
-             return false
-         }
-         Log.i("NotificationUtil", "Need to ask for Notificaiton Permission")
-         return true
-     }
- 
-     /**
-      * Should be fired once the user has been asked about their notification
-      * preference, so we will only ask once.
-      */
-     fun onNotificationPermissionPromptFired() {
-         val prefs = Prefs.get(context)
-         prefs.edit().putBoolean(HAS_ASKED_FOR_PUSH_PERMISSION, true).apply()
-     }
- }
- 
+            intent.data = Uri.parse("mozilla-vpn://home")
+        }
+
+        val pendingIntent =
+            PendingIntent.getActivity(context, 0, intent, PendingIntent.FLAG_IMMUTABLE)
+
+        // Build our notification
+        mNotificationBuilder
+            .setSmallIcon(R.drawable.icon_mozillavpn_notifiaction)
+            .setContentTitle(message.connectedMessage.header)
+            .setContentText(message.connectedMessage.body)
+            .setOnlyAlertOnce(true)
+            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+            .setContentIntent(pendingIntent)
+        context.startForeground(CONNECTED_NOTIFICATION_ID, mNotificationBuilder.build())
+    }
+
+    /**
+     * Updates the Notification
+     * in case there is no notification currently,
+     * this is a no-op.
+     */
+    fun setNotificationText(msg: ClientNotification?) {
+        if (msg == null) {
+            return
+        }
+        mNotificationBuilder.let {
+            it.setContentTitle(msg.header)
+            it.setContentText(msg.body)
+            mNotificationManager.notify(CONNECTED_NOTIFICATION_ID, it.build())
+        }
+    }
+
+    /**
+     * Should be called whenever a session is ended.
+     * Will upadte the notification to show the Disconnected Message
+     */
+    fun hide(message: CannedNotification) {
+        // Switch the notification to "Disconnected" / or translated version
+        // If the VPN-Client is alive, it will override this instantly
+        // If not, this fallback is shown.
+        setNotificationText(message.disconnectedMessage)
+    }
+
+    // Creates / Updates the notification channel we will be using to post
+    // the notification to.
+    private fun updateNotificationChannel(name: String = "General", descriptionText: String = "") {
+        // From Oreo on we need to have a "notification channel" to post to.
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+            return
+        }
+        val importance = NotificationManager.IMPORTANCE_LOW
+        val channel = NotificationChannel(NOTIFICATION_CHANNEL_ID, name, importance).apply {
+            description = descriptionText
+        }
+        // Register the channel with the system
+        mNotificationManager.createNotificationChannel(channel)
+    }
+
+    /**
+     * Returns true if the permission "android.permission.POST_NOTIFICATIONS"
+     * needs to be requested before this class will be functional.
+     */
+    fun needsNotificationPermission(): Boolean {
+        // Android 13
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+            Log.i("NotificationUtil", "No need to request permissionf for ${Build.VERSION.SDK_INT}")
+            // Below android 13, we will request permissions on
+            // implicit due to us being a foreground service
+            return false
+        }
+        val res = context.checkSelfPermission("android.permission.POST_NOTIFICATIONS")
+        if (res == PackageManager.PERMISSION_GRANTED) {
+            Log.i("NotificationUtil", "Permission Granted")
+            // We have the permission, all good
+            return false
+        }
+        // We would need permissions but only ask the user once.
+        val prefs = Prefs.get(context)
+        if (prefs.getBoolean(HAS_ASKED_FOR_PUSH_PERMISSION, false)) {
+            Log.i("NotificationUtil", "We already asked for push permission, not doing again")
+            return false
+        }
+        Log.i("NotificationUtil", "Need to ask for Notificaiton Permission")
+        return true
+    }
+
+    /**
+     * Should be fired once the user has been asked about their notification
+     * preference, so we will only ask once.
+     */
+    fun onNotificationPermissionPromptFired() {
+        val prefs = Prefs.get(context)
+        prefs.edit().putBoolean(HAS_ASKED_FOR_PUSH_PERMISSION, true).apply()
+    }
+}
+
   /*
    * ClientNotification
    * Message sent from the client manually.
    */
- @Serializable
- data class ClientNotification(
-    val header: String, 
+@Serializable
+data class ClientNotification(
+    val header: String,
     val body: String,
- )
- 
+)
+
   /*
    * A "Canned" Notification contains all strings needed for the "(dis-)/connected" flow
    * and is provided by the controller when asking for a connection.
    */
- @Serializable
- data class CannedNotification(
+@Serializable
+data class CannedNotification(
     // Message to be shown when the Client connects
     val connectedMessage: ClientNotification,
     // Message to be shown when the client disconnects
@@ -167,35 +167,34 @@
     val productName: String,
     // requestedScreen: a url -> mozilla-vpn://<my-string>
     val requestedScreen: String?,
- ) {
-     companion object {
-         /**
-          * CannedNotification(json) -> Creates a Canned notification
-          * out of a VPN-Client JSON config.
-          */
-         operator fun invoke(value: JSONObject?): CannedNotification? {
-             if (value == null) {
-                 return null
-             }
-             val messages = value.getJSONObject("messages")
-             return try {
-                 CannedNotification(
-                     ClientNotification(
-                         messages.getString("connectedHeader"),
-                         messages.getString("connectedBody"),
-                     ),
-                     ClientNotification(
-                         messages.getString("disconnectedHeader"),
-                         messages.getString("disconnectedBody"),
-                     ),
-                     messages.getString("productName"),
-                     messages.getString("requestedScreen"),
-                 )
-             } catch (e: Exception) {
-                 Log.e("NotificationUtil", "Failed to Parse Notification Object $value")
-                 null
-             }
-         }
-     }
- }
- 
+) {
+    companion object {
+        /**
+         * CannedNotification(json) -> Creates a Canned notification
+         * out of a VPN-Client JSON config.
+         */
+        operator fun invoke(value: JSONObject?): CannedNotification? {
+            if (value == null) {
+                return null
+            }
+            val messages = value.getJSONObject("messages")
+            return try {
+                CannedNotification(
+                    ClientNotification(
+                        messages.getString("connectedHeader"),
+                        messages.getString("connectedBody"),
+                    ),
+                    ClientNotification(
+                        messages.getString("disconnectedHeader"),
+                        messages.getString("disconnectedBody"),
+                    ),
+                    messages.getString("productName"),
+                    messages.getString("requestedScreen"),
+                )
+            } catch (e: Exception) {
+                Log.e("NotificationUtil", "Failed to Parse Notification Object $value")
+                null
+            }
+        }
+    }
+}

--- a/src/commands/commandui.cpp
+++ b/src/commands/commandui.cpp
@@ -468,7 +468,7 @@ int CommandUI::run(QStringList& tokens) {
     QObject::connect(
         AndroidVPNActivity::instance(), &AndroidVPNActivity::onOpenedWithUrl,
         [](QUrl url) { Navigator::instance()->requestDeepLink(url); });
-#else 
+#else
     // If there happen to be navigation URLs, send them to the navigator class.
     for (const QString& value : tokens) {
       QUrl url(value);

--- a/src/commands/commandui.cpp
+++ b/src/commands/commandui.cpp
@@ -70,6 +70,7 @@
 #ifdef MZ_ANDROID
 #  include "platforms/android/androidcommons.h"
 #  include "platforms/android/androidutils.h"
+#  include "platforms/android/androidvpnactivity.h"
 #endif
 
 #ifndef Q_OS_WIN
@@ -454,6 +455,20 @@ int CommandUI::run(QStringList& tokens) {
                      &ServerHandler::close);
 #endif
 
+#ifdef MZ_ANDROID
+    // If we are created with an url intent, auto pass that.
+    QUrl maybeURL = AndroidVPNActivity::getOpenerURL();
+    if (!maybeURL.isValid()) {
+      logger.error() << "Error in deep-link:" << maybeURL.toString();
+    } else {
+      Navigator::instance()->requestDeepLink(url);
+    }
+    // Whenever the Client is re-opened with a new url
+    // pass that to the navigaot
+    QObject::connect(
+        AndroidVPNActivity::instance(), &AndroidVPNActivity::onOpenedWithUrl,
+        [](QUrl url) { Navigator::instance()->requestDeepLink(url); });
+#else 
     // If there happen to be navigation URLs, send them to the navigator class.
     for (const QString& value : tokens) {
       QUrl url(value);
@@ -463,6 +478,7 @@ int CommandUI::run(QStringList& tokens) {
         Navigator::instance()->requestDeepLink(url);
       }
     }
+#endif
 
     KeyRegenerator keyRegenerator;
     // Let's go.

--- a/src/loghandler.cpp
+++ b/src/loghandler.cpp
@@ -261,12 +261,20 @@ void LogHandler::addLog(const Log& log,
   emit logEntryAdded(buffer);
 
 #if defined(MZ_ANDROID)
+#  ifdef MZ_DEBUG
+  const char* str = buffer.constData();
+  if (str) {
+    __android_log_write(ANDROID_LOG_DEBUG, Constants::ANDROID_LOG_NAME, str);
+  }
+#  else
   if (!Constants::inProduction()) {
     const char* str = buffer.constData();
     if (str) {
       __android_log_write(ANDROID_LOG_DEBUG, Constants::ANDROID_LOG_NAME, str);
     }
   }
+#  endif
+
 #endif
 }
 

--- a/src/platforms/android/androidvpnactivity.h
+++ b/src/platforms/android/androidvpnactivity.h
@@ -117,7 +117,6 @@ class AndroidVPNActivity : public QObject {
   AndroidVPNActivity();
   void startAtBootChanged();
   void onLogout();
-  void applicationStateChanged(Qt::ApplicationState state);
 
   static void onServiceMessage(JNIEnv* env, jobject thiz, jint messageType,
                                jstring body);
@@ -128,7 +127,6 @@ class AndroidVPNActivity : public QObject {
   static void onIntentInternal(JNIEnv* env, jobject thiz);
   void handleServiceMessage(int code, const QString& data);
 
-  bool m_suspended = false;
 };
 
 #endif  // ANDROIDVPNACTIVITY_H

--- a/src/platforms/android/androidvpnactivity.h
+++ b/src/platforms/android/androidvpnactivity.h
@@ -91,11 +91,11 @@ class AndroidVPNActivity : public QObject {
   static void sendToService(ServiceAction type, const QString& data = "");
   static void connectService();
   /**
-   * @brief Checks if the Intent that opened the Activiy 
+   * @brief Checks if the Intent that opened the Activiy
    * Contains a `mozilla-vpn://<something>` url
    * returns an Empty url if none is found
-   * 
-   * @return QUrl 
+   *
+   * @return QUrl
    */
   static QUrl getOpenerURL();
   void onAppStateChange();
@@ -126,7 +126,6 @@ class AndroidVPNActivity : public QObject {
   // We got a new Intent
   static void onIntentInternal(JNIEnv* env, jobject thiz);
   void handleServiceMessage(int code, const QString& data);
-
 };
 
 #endif  // ANDROIDVPNACTIVITY_H

--- a/src/platforms/android/androidvpnactivity.h
+++ b/src/platforms/android/androidvpnactivity.h
@@ -90,6 +90,14 @@ class AndroidVPNActivity : public QObject {
   static bool handleBackButton(JNIEnv* env, jobject thiz);
   static void sendToService(ServiceAction type, const QString& data = "");
   static void connectService();
+  /**
+   * @brief Checks if the Intent that opened the Activiy 
+   * Contains a `mozilla-vpn://<something>` url
+   * returns an Empty url if none is found
+   * 
+   * @return QUrl 
+   */
+  static QUrl getOpenerURL();
   void onAppStateChange();
 
  signals:
@@ -103,17 +111,24 @@ class AndroidVPNActivity : public QObject {
   void eventOnboardingCompleted();
   void eventVpnConfigPermissionResponse(bool granted);
   void eventRequestGleanUploadEnabledState();
+  void onOpenedWithUrl(const QUrl& data);
 
  private:
   AndroidVPNActivity();
   void startAtBootChanged();
   void onLogout();
+  void applicationStateChanged(Qt::ApplicationState state);
 
   static void onServiceMessage(JNIEnv* env, jobject thiz, jint messageType,
                                jstring body);
   static void onServiceConnected(JNIEnv* env, jobject thiz);
   static void onServiceDisconnected(JNIEnv* env, jobject thiz);
+
+  // We got a new Intent
+  static void onIntentInternal(JNIEnv* env, jobject thiz);
   void handleServiceMessage(int code, const QString& data);
+
+  bool m_suspended = false;
 };
 
 #endif  // ANDROIDVPNACTIVITY_H


### PR DESCRIPTION
## Description

This add's a few new primitives to help others build cool deeplinking things. 

- Added `AndroidVPNActivity::getOpenerURL` to get the current `mozilla-vpn://` url 
- Added `Q_SIGNAL(AndroidVPNActivity::onOpenedWithUrl)` to get notifications whenever the app is alive but got forgrounded with a new url
- Added the ability to add URL's in `NotificationUtil`

Did a little WIP demo thing to tie that together - given we registered handling  `mozilla-vpn://` urls back in 2.0 we can just test them from a browser and ` <a href="mozilla-vpn://nav/gethelp"> Open HELP Page</a> ` :) 

https://github.com/mozilla-mobile/mozilla-vpn-client/assets/9611612/2d847e01-c225-4220-8e05-6f8c02e2beb9

--- 
There are some wierdnesses when doing a cold-start using that an url. However the url is correctly passed to the navigator as seen in the logs, therefore i consider this outside of this PR :)  


