### PR TITLE
ci: Remove unused fetch-open-ssl task

### DIFF
--- a/taskcluster/ci/fetch/kind.yml
+++ b/taskcluster/ci/fetch/kind.yml
@@ -34,14 +34,6 @@ tasks:
             size: 158837368
         #artifact-prefix: vpn/win-perl
         fetch-alias: win-perl
-    open-ssl:
-        description: Open SSL Source
-        fetch:
-            type: static-url
-            url: https://github.com/openssl/openssl/archive/refs/tags/OpenSSL_1_1_1m.zip
-            artifact-name: open-ssl-src.zip
-            sha256: aeb973da474f14210d3e1a1f942dcf779e2ae7e71e4c535e6c53ebabe632cc98
-            size: 158837368
     win-rustup:
         description: Rustup for Windows v1.25.2
         fetch:


### PR DESCRIPTION
The `fetch-open-ssl` task [is failing](https://firefox-ci-tc.services.mozilla.com/tasks/J9O4fWO3T2-Nn6mT6Sq_Hw/runs/0/logs/public/logs/live.log) after rebuilding cached tasks for a CoT key rotation. To be clear, the failure has nothing to do with the rotation, the rotation is just surfacing a latent error that would have popped up sooner or later anyway.

In this case I can confirm that downloading the file at the requested url yields the same hash / size that the error is complaining about... But I'm confused why the new file is so much smaller than the old one. Something seems suspicious here.