### PR TITLE
VPN-5291: Tab button's selection state was not being read in 'Select Server' screen

### DIFF
--- a/nebula/ui/components/MZSegmentedToggle.qml
+++ b/nebula/ui/components/MZSegmentedToggle.qml
@@ -154,7 +154,7 @@ Rectangle {
                         elide: Qt.platform.os === "android" ? Text.ElideNone : Text.ElideRight
                         font.family: MZTheme.theme.fontBoldFamily
                         font.pixelSize: MZTheme.theme.fontSize
-                        // Ignore because the segment MZButtonBase provides accessibility
+                        // Ignore because the parent MZButtonBase provides accessibility
                         Accessible.ignored: true
                         color: {
                             if (root.selectedIndex === index) {

--- a/nebula/ui/components/MZSegmentedToggle.qml
+++ b/nebula/ui/components/MZSegmentedToggle.qml
@@ -154,7 +154,8 @@ Rectangle {
                         elide: Qt.platform.os === "android" ? Text.ElideNone : Text.ElideRight
                         font.family: MZTheme.theme.fontBoldFamily
                         font.pixelSize: MZTheme.theme.fontSize
-                        Accessible.ignored: !visible
+                        // Ignore because the segment MZButtonBase provides accessibility
+                        Accessible.ignored: true
                         color: {
                             if (root.selectedIndex === index) {
                                 return MZTheme.colors.purple70

--- a/nebula/ui/components/MZTabNavigation.qml
+++ b/nebula/ui/components/MZTabNavigation.qml
@@ -49,6 +49,7 @@ Item {
                 height: bar.contentHeight
                 Accessible.name: MZI18n[tabLabelStringId]
                 Accessible.ignored: !visible
+                Accessible.onPressAction: handleTabClick(btn)
 
                 onClicked: handleTabClick(btn)
 

--- a/nebula/ui/components/MZTabNavigation.qml
+++ b/nebula/ui/components/MZTabNavigation.qml
@@ -20,9 +20,9 @@ Item {
         bar.setCurrentIndex(idx);
     }
 
-    function selectTab(tabButton){
+    function selectTab(tabButton) {
         bar.currentIndex = tabButton.TabBar.index;
-        // Emit clicked signal to call handleTabClick, which processes selection change
+        // Emit the clicked signal to invoke handleTabClick, which handles the selection change
         tabButton.clicked();
     }
 

--- a/nebula/ui/components/MZTabNavigation.qml
+++ b/nebula/ui/components/MZTabNavigation.qml
@@ -20,6 +20,11 @@ Item {
         bar.setCurrentIndex(idx);
     }
 
+    function handleSelection(btn){
+        bar.currentIndex = btn.TabBar.index;
+        btn.clicked();
+    }
+
     Rectangle {
         // grey divider
         anchors.bottom: bar.bottom
@@ -49,7 +54,9 @@ Item {
                 height: bar.contentHeight
                 Accessible.name: MZI18n[tabLabelStringId]
                 Accessible.ignored: !visible
-                Accessible.onPressAction: handleTabClick(btn)
+                Accessible.onPressAction: handleSelection(btn)
+                Keys.onReturnPressed: handleSelection(btn)
+                Keys.onSpacePressed: handleSelection(btn)
 
                 onClicked: handleTabClick(btn)
 

--- a/nebula/ui/components/MZTabNavigation.qml
+++ b/nebula/ui/components/MZTabNavigation.qml
@@ -20,9 +20,10 @@ Item {
         bar.setCurrentIndex(idx);
     }
 
-    function handleSelection(btn){
-        bar.currentIndex = btn.TabBar.index;
-        btn.clicked();
+    function selectTab(tabButton){
+        bar.currentIndex = tabButton.TabBar.index;
+        // Emit clicked signal to call handleTabClick, which processes selection change
+        tabButton.clicked();
     }
 
     Rectangle {
@@ -52,11 +53,12 @@ Item {
                 id: btn
                 objectName: tabButtonId
                 height: bar.contentHeight
-                Accessible.name: MZI18n[tabLabelStringId]
+                // Use selected state in the accessibility name, because Qt doesn't correctly provide it for a selected tab.
+                Accessible.name: (bar.currentIndex === btn.TabBar.index) ? (MZI18n.AccessibilitySelectedAndItemName.arg(MZI18n[tabLabelStringId])) : MZI18n[tabLabelStringId]
                 Accessible.ignored: !visible
-                Accessible.onPressAction: handleSelection(btn)
-                Keys.onReturnPressed: handleSelection(btn)
-                Keys.onSpacePressed: handleSelection(btn)
+                Accessible.onPressAction: selectTab(btn)
+                Keys.onReturnPressed: selectTab(btn)
+                Keys.onSpacePressed: selectTab(btn)
 
                 onClicked: handleTabClick(btn)
 

--- a/nebula/ui/components/MZTabNavigation.qml
+++ b/nebula/ui/components/MZTabNavigation.qml
@@ -53,8 +53,8 @@ Item {
                 id: btn
                 objectName: tabButtonId
                 height: bar.contentHeight
-                // Use selected state in the accessibility name, because Qt doesn't correctly provide it for a selected tab.
-                Accessible.name: (bar.currentIndex === btn.TabBar.index) ? (MZI18n.AccessibilitySelectedAndItemName.arg(MZI18n[tabLabelStringId])) : MZI18n[tabLabelStringId]
+                // Qt doesn't correctly provide the selected state for a tab on Windows, so include the selected state in the accessibility name.
+                Accessible.name: ((Qt.platform.os === "windows") && (bar.currentIndex === btn.TabBar.index)) ? (MZI18n.AccessibilitySelectedAndItemName.arg(MZI18n[tabLabelStringId])) : MZI18n[tabLabelStringId]
                 Accessible.ignored: !visible
                 Accessible.onPressAction: selectTab(btn)
                 Keys.onReturnPressed: selectTab(btn)


### PR DESCRIPTION
## Description

Tab button's selection state was not being read by the Screen Reader. Add selection state in Tab button's Accessibility name.
Also fixed:
1. Selection of a tab button using keyboard or screen reader shortcut was previously  not supported.
2. The text inside the button could be navigated to using a screen reader shortcut, which was redundant. Remove this.

## Reference

[VPN-5291](https://mozilla-hub.atlassian.net/browse/VPN-5291), [GitHub 7629](https://github.com/mozilla-mobile/mozilla-vpn-client/issues/7629)

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-5291]: https://mozilla-hub.atlassian.net/browse/VPN-5291?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ