### PR TITLE
Nit: Put Decision Tasks for branches on the TC index

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -175,7 +175,8 @@ tasks:
                       - index.mozillavpn.v2.${project}.branch.${head_branch}.latest.taskgraph.decision-${cron.job_name}
                       - index.mozillavpn.v2.${project}.branch.${head_branch}.revision.${head_sha}.taskgraph.decision-${cron.job_name}
                       - index.mozillavpn.v2.${project}.branch.${head_branch}.revision.${head_sha}.taskgraph.cron.${ownTaskId}
-
+                else:
+                  - index.mozillavpn.v2.${project}.branch.${short_head_branch}.latest.taskgraph.decision
           scopes:
             $if: 'tasks_for == "github-push"'
             then:

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -176,7 +176,7 @@ tasks:
                       - index.mozillavpn.v2.${project}.branch.${head_branch}.revision.${head_sha}.taskgraph.decision-${cron.job_name}
                       - index.mozillavpn.v2.${project}.branch.${head_branch}.revision.${head_sha}.taskgraph.cron.${ownTaskId}
                 else:
-                  - index.mozillavpn.v2.${project}.branch.${short_head_branch}.latest.taskgraph.decision
+                  - index.mozillavpn.v2.${project}.branch.${head_branch}.latest.taskgraph.decision
           scopes:
             $if: 'tasks_for == "github-push"'
             then:


### PR DESCRIPTION
## Description

We have a bit of tooling that tries to pull specific taskcluster jobs by branch. i.e https://mozilla-mobile.github.io/mozilla-vpn-client/
However it's a bit more complex right now then it need's to. It pulls on the gh api the branches, the runs from each branch and from there tries to find the task group. From that it pulls the wasm task and renders it's result. 

We could simplify that and announce the latest pr decision task on the index, which would allow me to instantly get the taskgroup of a certain branch 😅 
 