### PR TITLE
Add `ad id` permission for Android, because Adjust

### DIFF
--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -12,6 +12,7 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES"/>
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
+    <uses-permission android:name="com.google.android.gms.permission.AD_ID"/>
 
     <!-- The following comment will be replaced upon deployment with default features based on the dependencies of the application.
          Remove the comment if you do not require these default features. -->


### PR DESCRIPTION
## Description

This essentially reverts https://github.com/mozilla-mobile/mozilla-vpn-client/pull/7822/. It's needed to use the Adjust SDK again.

This will be uplifted to 2.19.1 release branch after it hits `main`.

## Reference

N/A

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
