### PR TITLE
VPN-5439: Use 'Pane' for a11y role instead of 'Grouping'

### DIFF
--- a/nebula/ui/components/MZViewBase.qml
+++ b/nebula/ui/components/MZViewBase.qml
@@ -20,7 +20,7 @@ Item {
    property alias _contentHeight: vpnFlickable.contentHeight
 
    Accessible.name: (_menuTitle.length > 0) ? _menuTitle : _accessibleName
-   Accessible.role: Accessible.Grouping
+   Accessible.role: Accessible.Pane
 
    anchors {
        top: if (parent) parent.top

--- a/src/ui/screens/home/ViewServers.qml
+++ b/src/ui/screens/home/ViewServers.qml
@@ -17,7 +17,7 @@ Item {
     id: root
     objectName: "viewServers"
     Accessible.name: qsTrId("vpn.servers.selectLocation")
-    Accessible.role: Accessible.Grouping
+    Accessible.role: Accessible.Pane
     Accessible.ignored: !visible
 
     MZMenu {


### PR DESCRIPTION
## Description

Use 'Pane' for a11y role in a view because 'Grouping' caused VoiceOver ScreenReader quick-nav problems in macOS

## Reference

[VPN-5439](https://mozilla-hub.atlassian.net/browse/VPN-5439), [GitHub 8751](https://github.com/mozilla-mobile/mozilla-vpn-client/issues/8751)

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-5439]: https://mozilla-hub.atlassian.net/browse/VPN-5439?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ