### PR TITLE
VPN-5900 (part 2): Don't send Android daemon metrics when switching server

### DIFF
--- a/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/VPNService.kt
+++ b/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/VPNService.kt
@@ -63,7 +63,7 @@ class VPNService : android.net.VpnService() {
     private val isChangingServers: Boolean
         get() {
             // could be user choosing new server or silent switching
-            return this.mConfig?.optInt("reason") ?: 1
+            return (this.mConfig?.optInt("reason") ?: 0) == 1
         }
 
     private val shouldRecordMetrics: Boolean

--- a/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/VPNService.kt
+++ b/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/VPNService.kt
@@ -46,7 +46,7 @@ class VPNService : android.net.VpnService() {
         override fun onTick(millisUntilFinished: Long) {}
         override fun onFinish() {
             Log.i(tag, "Sending daemon_timer ping")
-            if (isSuperDooperMetricsActive) {
+            if (shouldRecordMetrics) {
                 Pings.daemonsession.submit(
                     Pings.daemonsessionReasonCodes.daemonTimer,
                 )
@@ -58,6 +58,17 @@ class VPNService : android.net.VpnService() {
     private val isSuperDooperMetricsActive: Boolean
         get() {
             return this.mConfig?.optBoolean("isSuperDooperFeatureActive", false) ?: false
+        }
+
+    private val isChangingServers: Boolean
+        get() {
+            // could be user choosing new server or silent switching
+            return this.mConfig?.optInt("reason") ?: 1
+        }
+
+    private val shouldRecordMetrics: Boolean
+        get() {
+            return isSuperDooperMetricsActive && !isChangingServers
         }
 
     private val isUsingShortTimerSessionPing: Boolean
@@ -338,7 +349,7 @@ class VPNService : android.net.VpnService() {
             Log.i(tag, "Setting Glean debug tag for daemon.")
             Glean.setDebugViewTag(gleanTag)
         }
-        if (isSuperDooperMetricsActive) {
+        if (shouldRecordMetrics) {
             val installationIdString = json.getString("installationId")
             installationIdString?.let {
                 try {
@@ -421,7 +432,7 @@ class VPNService : android.net.VpnService() {
         // Clear the notification message, so the content
         // is not "disconnected" in case we connect from a non-client.
         CannedNotification(mConfig)?.let { mNotificationHandler.hide(it) }
-        if (isSuperDooperMetricsActive) {
+        if (shouldRecordMetrics) {
             Session.daemonSessionEnd.set()
             Pings.daemonsession.submit(
                 Pings.daemonsessionReasonCodes.daemonEnd,


### PR DESCRIPTION
## Description

In testing https://github.com/mozilla-mobile/mozilla-vpn-client/pull/8698/, QA noticed that Android sent daemon pings for server switches. iOS has never done this, and so this fixes the behavior on Android.

## Reference

VPN-5900

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
