### PR TITLE
VPN-5994 Add inspector command to mock network connection being down

### DIFF
--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -1959,6 +1959,13 @@ void MozillaVPN::registerInspectorCommands() {
       });
 
   InspectorHandler::registerCommand(
+      "force_no_network", "Force a network connection failure", 0,
+      [](InspectorHandler*, const QList<QByteArray>&) {
+        MozillaVPN::instance()->networkWatcher()->setTransportTypeToNone();
+        return QJsonObject();
+      });
+
+  InspectorHandler::registerCommand(
       "force_server_unavailable",
       "Timeout all servers in a city using force_server_unavailable "
       "{countryCode} "

--- a/src/networkwatcher.h
+++ b/src/networkwatcher.h
@@ -8,6 +8,7 @@
 #include <QElapsedTimer>
 #include <QMap>
 
+#include "networkwatcherimpl.h"
 #include "notificationhandler.h"
 
 class NetworkWatcherImpl;
@@ -25,6 +26,12 @@ class NetworkWatcher final : public QObject {
 
   // public for the inspector.
   void unsecuredNetwork(const QString& networkName, const QString& networkId);
+
+  // public for the inspector, only used to set the transport
+  // type to None to mock internet connection being down.
+  NetworkWatcherImpl::TransportType setTransportTypeToNone() /*override*/ {
+    return NetworkWatcherImpl::TransportType_None;
+  };
 
   QString getCurrentTransport();
 


### PR DESCRIPTION
## Description

Add inspector command `force_no_network` to mock network connection being down.

## Reference

    https://mozilla-hub.atlassian.net/browse/VPN-5994

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
