### PR TITLE
VPN-4798: Linux cgroup application matching heuristics

### DIFF
--- a/src/platforms/linux/daemon/apptracker.cpp
+++ b/src/platforms/linux/daemon/apptracker.cpp
@@ -125,7 +125,7 @@ QString AppTracker::decodeUnicodeEscape(const QString& str) {
 //
 // However, at some point the separator between the app and UUID was
 // swapped from a dot to a dash. Which makes the parsing a bit of a pain.
-// 
+//
 // See: https://github.com/snapcore/snapd/blob/master/sandbox/cgroup/scanning.go
 QString AppTracker::snapDesktopId(const QString& scope) {
   static const QRegularExpression snapuuid(

--- a/src/platforms/linux/daemon/apptracker.cpp
+++ b/src/platforms/linux/daemon/apptracker.cpp
@@ -107,7 +107,7 @@ QString AppTracker::decodeUnicodeEscape(const QString& str) {
     bool okay;
     qsizetype start = match.capturedStart(0);
     QChar code = match.captured(0).mid(2).toUShort(&okay, 16);
-    if (okay) {
+    if (okay && (code != 0)) {
       result.replace(start, match.capturedLength(0), QString(code));
       offset = start + 1;
     } else {

--- a/src/platforms/linux/daemon/apptracker.cpp
+++ b/src/platforms/linux/daemon/apptracker.cpp
@@ -235,24 +235,3 @@ void AppTracker::cgroupsChanged(const QString& directory) {
     }
   }
 }
-
-QList<int> AppTracker::pids(const QString& cgroup) const {
-  QList<int> results;
-  QFile cgroupProcs(m_cgroupMount + cgroup + "/cgroup.procs");
-
-  if (cgroupProcs.open(QIODevice::ReadOnly | QIODevice::Text)) {
-    while (true) {
-      QString line = QString::fromLocal8Bit(cgroupProcs.readLine());
-      if (line.isEmpty()) {
-        break;
-      }
-      int pid = line.trimmed().toInt();
-      if (pid != 0) {
-        results.append(pid);
-      }
-    }
-    cgroupProcs.close();
-  }
-
-  return results;
-}

--- a/src/platforms/linux/daemon/apptracker.cpp
+++ b/src/platforms/linux/daemon/apptracker.cpp
@@ -128,7 +128,9 @@ QString AppTracker::decodeUnicodeEscape(const QString& str) {
 // 
 // See: https://github.com/snapcore/snapd/blob/master/sandbox/cgroup/scanning.go
 QString AppTracker::snapDesktopId(const QString& scope) {
-  static const QRegularExpression snapuuid("[-.][0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}");
+  static const QRegularExpression snapuuid(
+      "[-.][0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}"
+      "\\b-[0-9a-fA-F]{12}");
 
   // Strip the UUID out of the scope name
   QString stripped(scope);

--- a/src/platforms/linux/daemon/apptracker.cpp
+++ b/src/platforms/linux/daemon/apptracker.cpp
@@ -116,7 +116,7 @@ void AppTracker::gtkLaunchEvent(const QByteArray& appid, const QString& display,
     appIdName.chop(1);
   }
   if (!appIdName.isEmpty()) {
-    m_lastLaunchName = appIdName;
+    m_lastLaunchName = LinuxDependencies::desktopFileId(appIdName);
     m_lastLaunchPid = pid;
   }
 }
@@ -127,7 +127,7 @@ void AppTracker::appHeuristicMatch(AppData* data) {
   for (int pid : data->pids()) {
     if ((pid != 0) && (pid == m_lastLaunchPid)) {
       logger.debug() << data->cgroup << "matches app:" << m_lastLaunchName;
-      data->appId = m_lastLaunchName;
+      data->desktopId = m_lastLaunchName;
       data->rootpid = m_lastLaunchPid;
       break;
     }
@@ -144,7 +144,7 @@ void AppTracker::appHeuristicMatch(AppData* data) {
                            this);
   QString source = interface.property("SourcePath").toString();
   if (!source.isEmpty() && source.endsWith(".desktop")) {
-    data->appId = source;
+    data->desktopId = LinuxDependencies::desktopFileId(source);
   }
 
   // TODO: Some comparison between the .desktop file and the directory name
@@ -177,7 +177,7 @@ void AppTracker::cgroupsChanged(const QString& directory) {
       m_runningApps[path] = data;
       appHeuristicMatch(data);
 
-      emit appLaunched(data->cgroup, data->appId, data->rootpid);
+      emit appLaunched(data->cgroup, data->desktopId);
     }
   }
 
@@ -189,7 +189,7 @@ void AppTracker::cgroupsChanged(const QString& directory) {
       Q_ASSERT(m_runningApps.contains(scope));
       AppData* data = m_runningApps.take(scope);
 
-      emit appTerminated(data->cgroup, data->appId);
+      emit appTerminated(data->cgroup, data->desktopId);
       delete data;
     }
   }

--- a/src/platforms/linux/daemon/apptracker.cpp
+++ b/src/platforms/linux/daemon/apptracker.cpp
@@ -131,7 +131,7 @@ QString AppTracker::findDesktopId(const QString& cgroup) {
     }
   }
 
-  QString gnomeLaunchdPrefix("gnome-launchd-");
+  QString gnomeLaunchdPrefix("gnome-launched-");
   if (scopeName.startsWith(gnomeLaunchdPrefix)) {
     qsizetype start = gnomeLaunchdPrefix.length();
     qsizetype end = scopeName.lastIndexOf('-');

--- a/src/platforms/linux/daemon/apptracker.h
+++ b/src/platforms/linux/daemon/apptracker.h
@@ -16,25 +16,28 @@ class QDBusInterface;
 // Applications on Linux can be a bit vague and hard to define at runtime, so
 // we need to make some assumptions to try and tackle the problem.
 //
-// The first concept, comes from the Freedesktop specification, which makes use
-// of desktop entry files to populate entities in the applications menu. The
-// path to these files are used to generate identifiers, known as Desktop File
-// IDs. This means that we can only track applications which are launched by
-// the applications menu.
+// First off, we try to identify applications based on the application menu
+// entries. According to the Freedesktop specification, these are described by
+// the `*.desktop` files found under the user's XDG_DATA_DIRS environment
+// variable. The Freedesktop specification also defines that the path to this
+// file can be converted into a Desktop File ID, which we will use as the
+// identifier of the application.
 //
-// The second contept are control groups, or cgroups, which are used to group
-// process IDs together for the purpose of establishing shared resource
-// contstraints. We use these control groups in the Linux netfilter subsystem
-// to apply the split tunnelling traffic manipulation.
+// However, the `*.desktop` files only describe how to launch an application.
+// Once an application has started, there is no definitive way to track the
+// processes of that application. For this, we rely on Linux control groups,
+// or cgroups, which are used to group processes together for the purpose of
+// establishing shared resource constraints and containerization.
 //
 // It just so happens that many modern desktop environments will group their
 // processes forked from the application launchers into cgroups for resource
 // management and containerization. This class attempts to track those cgroups
 // and match them to the destop file ID from which they originated.
 //
-// This means that we also only support desktop environments which make us of
-// control groups for application containerization. This more or less limits us
-// to Gnome, KDE, Flatpaks and Snaps.
+// This means that we only support application environments which make use of
+// control groups for application containerization, and apps which can be
+// launched via the applications menu. This limits us to Gnome, KDE, Flatpaks,
+// and Snaps.
 class AppTracker final : public QObject {
   Q_OBJECT
   Q_DISABLE_COPY_MOVE(AppTracker)

--- a/src/platforms/linux/daemon/apptracker.h
+++ b/src/platforms/linux/daemon/apptracker.h
@@ -41,8 +41,7 @@ class AppTracker final : public QObject {
 
  private:
   QString findDesktopId(const QString& cgroup);
-  QString snapDesktopId(const QString& cgroup);
-  QList<int> pids(const QString& cgroup) const;
+  static QString snapDesktopId(const QString& cgroup);
   static QString decodeUnicodeEscape(const QString& str);
 
  private:

--- a/src/platforms/linux/daemon/apptracker.h
+++ b/src/platforms/linux/daemon/apptracker.h
@@ -21,7 +21,7 @@ class AppData {
   QList<int> pids() const;
 
   const QString cgroup;
-  QString appId;
+  QString desktopId;
   int rootpid = 0;
 };
 
@@ -41,8 +41,8 @@ class AppTracker final : public QObject {
   AppData* find(const QString& cgroup) { return m_runningApps.value(cgroup); }
 
  signals:
-  void appLaunched(const QString& cgroup, const QString& appId, int rootpid);
-  void appTerminated(const QString& cgroup, const QString& appId);
+  void appLaunched(const QString& cgroup, const QString& desktopId);
+  void appTerminated(const QString& cgroup, const QString& desktopId);
 
  private slots:
   void gtkLaunchEvent(const QByteArray& appid, const QString& display,

--- a/src/platforms/linux/daemon/apptracker.h
+++ b/src/platforms/linux/daemon/apptracker.h
@@ -41,6 +41,7 @@ class AppTracker final : public QObject {
 
  private:
   QString findDesktopId(const QString& cgroup);
+  QString snapDesktopId(const QString& cgroup);
   QList<int> pids(const QString& cgroup) const;
   static QString decodeUnicodeEscape(const QString& str);
 

--- a/src/platforms/linux/daemon/apptracker.h
+++ b/src/platforms/linux/daemon/apptracker.h
@@ -13,6 +13,28 @@
 
 class QDBusInterface;
 
+// Applications on Linux can be a bit vague and hard to define at runtime, so
+// we need to make some assumptions to try and tackle the problem.
+//
+// The first concept, comes from the Freedesktop specification, which makes use
+// of desktop entry files to populate entities in the applications menu. The
+// path to these files are used to generate identifiers, known as Desktop File
+// IDs. This means that we can only track applications which are launched by
+// the applications menu.
+//
+// The second contept are control groups, or cgroups, which are used to group
+// process IDs together for the purpose of establishing shared resource
+// contstraints. We use these control groups in the Linux netfilter subsystem
+// to apply the split tunnelling traffic manipulation.
+//
+// It just so happens that many modern desktop environments will group their
+// processes forked from the application launchers into cgroups for resource
+// management and containerization. This class attempts to track those cgroups
+// and match them to the destop file ID from which they originated.
+//
+// This means that we also only support desktop environments which make us of
+// control groups for application containerization. This more or less limits us
+// to Gnome, KDE, Flatpaks and Snaps.
 class AppTracker final : public QObject {
   Q_OBJECT
   Q_DISABLE_COPY_MOVE(AppTracker)
@@ -21,27 +43,43 @@ class AppTracker final : public QObject {
   explicit AppTracker(QObject* parent = nullptr);
   ~AppTracker();
 
+  /**
+   * @brief Track a new user session for control group scopes where applications
+   *        may be running.
+   *
+   * @param userid Unix User identifier.
+   * @param xdgRuntimePath 
+   */
   void userCreated(uint userid, const QString& xdgRuntimePath);
+
+  /**
+   * @brief Terminate tracking of a user session.
+   *
+   * @param userid Unix User identifier.
+   */
   void userRemoved(uint userid);
 
-  QStringList getRunningApps() const { return m_runningApps.keys(); }
-  QString getDesktopId(const QString& cgroup) const {
-    return m_runningApps.value(cgroup);
-  }
-  QStringList findByDesktopId(const QString& desktopId) const {
-    return m_runningApps.keys(desktopId);
+  /**
+   * @brief Return a list of control groups matching a given desktop file ID.
+   *
+   * @param desktopFileId desktop file ID to match.
+   *
+   * @returns a list control group scopes.
+   */
+  QStringList findByDesktopFileId(const QString& desktopFileId) const {
+    return m_runningCgroups.keys(desktopFileId);
   }
 
  signals:
-  void appLaunched(const QString& cgroup, const QString& desktopId);
-  void appTerminated(const QString& cgroup, const QString& desktopId);
+  void appLaunched(const QString& cgroup, const QString& desktopFileId);
+  void appTerminated(const QString& cgroup, const QString& desktopFileId);
 
  private slots:
   void cgroupsChanged(const QString& directory);
 
  private:
-  QString findDesktopId(const QString& cgroup);
-  static QString snapDesktopId(const QString& cgroup);
+  QString findDesktopFileId(const QString& cgroup);
+  static QString snapDesktopFileId(const QString& cgroup);
   static QString decodeUnicodeEscape(const QString& str);
 
  private:
@@ -50,10 +88,11 @@ class AppTracker final : public QObject {
   QFileSystemWatcher m_cgroupWatcher;
   QDBusInterface* m_systemdInterface = nullptr;
 
-  // The set of applications that we have tracked.
-  //  - key is the cgroup path.
-  //  - value is the desktopId, or an empty QString if unknown.
-  QHash<QString, QString> m_runningApps;
+  // The set of control groups that are currently running, and the desktop file
+  // IDs to which we have mapped them. The key to this QHash is the control
+  // group path, and the value is the mapped desktop file ID, or an empty
+  // QString if unknown.
+  QHash<QString, QString> m_runningCgroups;
 };
 
 #endif  // APPTRACKER_H

--- a/src/platforms/linux/daemon/apptracker.h
+++ b/src/platforms/linux/daemon/apptracker.h
@@ -42,10 +42,6 @@ class AppTracker final : public QObject {
   void appTerminated(const QString& cgroup, const QString& desktopId);
 
  private slots:
-  void gtkLaunchEvent(const QByteArray& appid, const QString& display,
-                      qlonglong pid, const QStringList& uris,
-                      const QVariantMap& extra);
-
   void cgroupsChanged(const QString& directory);
 
  private:
@@ -61,8 +57,6 @@ class AppTracker final : public QObject {
 
   // The set of applications that we have tracked.
   QHash<QString, AppData*> m_runningApps;
-  QString m_lastLaunchName;
-  int m_lastLaunchPid;
 };
 
 #endif  // APPTRACKER_H

--- a/src/platforms/linux/daemon/apptracker.h
+++ b/src/platforms/linux/daemon/apptracker.h
@@ -48,7 +48,7 @@ class AppTracker final : public QObject {
    *        may be running.
    *
    * @param userid Unix User identifier.
-   * @param xdgRuntimePath 
+   * @param xdgRuntimePath User's runtime path (eg: "/run/user/<uid>").
    */
   void userCreated(uint userid, const QString& xdgRuntimePath);
 

--- a/src/platforms/linux/daemon/apptracker.h
+++ b/src/platforms/linux/daemon/apptracker.h
@@ -53,6 +53,7 @@ class AppTracker final : public QObject {
 
  private:
   void appHeuristicMatch(AppData* data);
+  static QString decodeUnicodeEscape(const QString& str);
 
  private:
   // Monitoring of the user's control groups.

--- a/src/platforms/linux/daemon/apptracker.h
+++ b/src/platforms/linux/daemon/apptracker.h
@@ -18,11 +18,8 @@ class AppData {
   AppData(const QString& path) : cgroup(path) { MZ_COUNT_CTOR(AppData); }
   ~AppData() { MZ_COUNT_DTOR(AppData); }
 
-  QList<int> pids() const;
-
   const QString cgroup;
   QString desktopId;
-  int rootpid = 0;
 };
 
 class AppTracker final : public QObject {
@@ -53,6 +50,7 @@ class AppTracker final : public QObject {
 
  private:
   void appHeuristicMatch(AppData* data);
+  QList<int> pids(const QString& cgroup) const;
   static QString decodeUnicodeEscape(const QString& str);
 
  private:

--- a/src/platforms/linux/daemon/dbusservice.cpp
+++ b/src/platforms/linux/daemon/dbusservice.cpp
@@ -225,8 +225,7 @@ void DBusService::userRemoved(uint uid, const QDBusObjectPath& path) {
   m_appTracker->userRemoved(uid);
 }
 
-void DBusService::appLaunched(const QString& cgroup,
-                              const QString& desktopId) {
+void DBusService::appLaunched(const QString& cgroup, const QString& desktopId) {
   logger.debug() << "tracking:" << cgroup << "id:" << desktopId;
 
   // HACK: Quick and dirty split tunnelling.

--- a/src/platforms/linux/daemon/dbusservice.cpp
+++ b/src/platforms/linux/daemon/dbusservice.cpp
@@ -254,7 +254,8 @@ void DBusService::setAppState(const QString& desktopFileId, AppState state) {
   // When the App is "Active" there is no special manipulation to do.
   if (state == Active) {
     m_excludedApps.remove(desktopFileId);
-    for (const QString& cgroup : m_appTracker->findByDesktopFileId(desktopFileId)) {
+    for (const QString& cgroup :
+         m_appTracker->findByDesktopFileId(desktopFileId)) {
       m_wgutils->resetCgroup(cgroup);
     }
     return;
@@ -262,7 +263,8 @@ void DBusService::setAppState(const QString& desktopFileId, AppState state) {
 
   // Otherwise, apply special handling to any matching control groups.
   m_excludedApps[desktopFileId] = state;
-  for (const QString& cgroup : m_appTracker->findByDesktopFileId(desktopFileId)) {
+  for (const QString& cgroup :
+       m_appTracker->findByDesktopFileId(desktopFileId)) {
     if (m_excludedCgroups.contains(cgroup)) {
       m_wgutils->resetCgroup(cgroup);
     }

--- a/src/platforms/linux/daemon/dbusservice.cpp
+++ b/src/platforms/linux/daemon/dbusservice.cpp
@@ -286,8 +286,8 @@ void DBusService::setAppState(const QString& desktopId, AppState state) {
     }
     m_excludedCgroups[cgroup] = state;
     if (state == Excluded) {
-      // Excluded control groups are given special netfilter rules to direct their
-      // traffic outside of the VPN tunnel.
+      // Excluded control groups are given special netfilter rules to direct
+      // their traffic outside of the VPN tunnel.
       m_wgutils->excludeCgroup(cgroup);
     }
   }

--- a/src/platforms/linux/daemon/dbusservice.cpp
+++ b/src/platforms/linux/daemon/dbusservice.cpp
@@ -45,8 +45,8 @@ DBusService::DBusService(QObject* parent) : Daemon(parent) {
   }
 
   m_appTracker = new AppTracker(this);
-  connect(m_appTracker, SIGNAL(appLaunched(QString, QString, int)), this,
-          SLOT(appLaunched(QString, QString, int)));
+  connect(m_appTracker, SIGNAL(appLaunched(QString, QString)), this,
+          SLOT(appLaunched(QString, QString)));
   connect(m_appTracker, SIGNAL(appTerminated(QString, QString)), this,
           SLOT(appTerminated(QString, QString)));
 
@@ -226,9 +226,8 @@ void DBusService::userRemoved(uint uid, const QDBusObjectPath& path) {
 }
 
 void DBusService::appLaunched(const QString& cgroup,
-                              const QString& desktopId, int rootpid) {
-  logger.debug() << "tracking:" << cgroup << "id:" << desktopId
-                 << "PID:" << rootpid;
+                              const QString& desktopId) {
+  logger.debug() << "tracking:" << cgroup << "id:" << desktopId;
 
   // HACK: Quick and dirty split tunnelling.
   // TODO: Apply filtering to currently-running apps too.
@@ -255,16 +254,9 @@ QString DBusService::runningApps() {
   for (auto i = m_appTracker->begin(); i != m_appTracker->end(); i++) {
     const AppData* data = *i;
     QJsonObject appObject;
-    QJsonArray pidList;
     appObject.insert("id", QJsonValue(data->desktopId));
     appObject.insert("cgroup", QJsonValue(data->cgroup));
-    appObject.insert("rootpid", QJsonValue(data->rootpid));
 
-    for (int pid : data->pids()) {
-      pidList.append(QJsonValue(pid));
-    }
-
-    appObject.insert("pids", pidList);
     result.append(appObject);
   }
 

--- a/src/platforms/linux/daemon/dbusservice.h
+++ b/src/platforms/linux/daemon/dbusservice.h
@@ -25,11 +25,10 @@ class DBusService final : public Daemon, protected QDBusContext {
   DBusService(QObject* parent);
   ~DBusService();
 
-  enum AppState { Active, Excluded, Blocked };
+  enum AppState { Active, Excluded };
   Q_ENUM(AppState)
 
   void setAdaptor(DbusAdaptor* adaptor);
-  void setAppState(const QString& desktopId, AppState state);
 
   using Daemon::activate;
 
@@ -43,11 +42,6 @@ class DBusService final : public Daemon, protected QDBusContext {
   QString getLogs();
   void cleanupLogs() { cleanLogs(); }
 
-  QString runningApps();
-  bool firewallApp(const QString& appName, const QString& state);
-  bool firewallPid(int rootpid, const QString& state);
-  bool firewallClear();
-
  protected:
   WireguardUtils* wgutils() const override { return m_wgutils; }
   bool supportIPUtils() const override { return true; }
@@ -59,6 +53,9 @@ class DBusService final : public Daemon, protected QDBusContext {
   bool removeInterfaceIfExists();
   bool isCallerAuthorized();
   void dropRootPermissions();
+
+  void setAppState(const QString& desktopId, AppState state);
+  void clearAppStates();
 
  private slots:
   void appLaunched(const QString& cgroup, const QString& desktopId);

--- a/src/platforms/linux/daemon/dbusservice.h
+++ b/src/platforms/linux/daemon/dbusservice.h
@@ -56,7 +56,7 @@ class DBusService final : public Daemon, protected QDBusContext {
   void dropRootPermissions();
 
  private slots:
-  void appLaunched(const QString& cgroup, const QString& desktopId, int rootpid);
+  void appLaunched(const QString& cgroup, const QString& desktopId);
   void appTerminated(const QString& cgroup, const QString& desktopId);
 
   void userListCompleted(QDBusPendingCallWatcher* call);

--- a/src/platforms/linux/daemon/dbusservice.h
+++ b/src/platforms/linux/daemon/dbusservice.h
@@ -6,6 +6,7 @@
 #define DBUSSERVICE_H
 
 #include <QDBusContext>
+#include <QHash>
 
 #include "apptracker.h"
 #include "daemon/daemon.h"
@@ -24,7 +25,11 @@ class DBusService final : public Daemon, protected QDBusContext {
   DBusService(QObject* parent);
   ~DBusService();
 
+  enum AppState { Active, Excluded, Blocked };
+  Q_ENUM(AppState)
+
   void setAdaptor(DbusAdaptor* adaptor);
+  void setAppState(const QString& desktopId, AppState state);
 
   using Daemon::activate;
 
@@ -70,7 +75,8 @@ class DBusService final : public Daemon, protected QDBusContext {
   DnsUtilsLinux* m_dnsutils = nullptr;
 
   AppTracker* m_appTracker = nullptr;
-  QList<QString> m_excludedApps;
+  QHash<QString, AppState> m_excludedApps;
+  QHash<QString, AppState> m_excludedCgroups;
 
   uint m_sessionUid = 0;
 };

--- a/src/platforms/linux/daemon/dbusservice.h
+++ b/src/platforms/linux/daemon/dbusservice.h
@@ -56,8 +56,8 @@ class DBusService final : public Daemon, protected QDBusContext {
   void dropRootPermissions();
 
  private slots:
-  void appLaunched(const QString& cgroup, const QString& appId, int rootpid);
-  void appTerminated(const QString& cgroup, const QString& appId);
+  void appLaunched(const QString& cgroup, const QString& desktopId, int rootpid);
+  void appTerminated(const QString& cgroup, const QString& desktopId);
 
   void userListCompleted(QDBusPendingCallWatcher* call);
   void userCreated(uint uid, const QDBusObjectPath& path);

--- a/src/platforms/linux/daemon/dbusservice.h
+++ b/src/platforms/linux/daemon/dbusservice.h
@@ -54,12 +54,12 @@ class DBusService final : public Daemon, protected QDBusContext {
   bool isCallerAuthorized();
   void dropRootPermissions();
 
-  void setAppState(const QString& desktopId, AppState state);
+  void setAppState(const QString& desktopFileId, AppState state);
   void clearAppStates();
 
  private slots:
-  void appLaunched(const QString& cgroup, const QString& desktopId);
-  void appTerminated(const QString& cgroup, const QString& desktopId);
+  void appLaunched(const QString& cgroup, const QString& desktopFileId);
+  void appTerminated(const QString& cgroup, const QString& desktopFileId);
 
   void userListCompleted(QDBusPendingCallWatcher* call);
   void userCreated(uint uid, const QDBusObjectPath& path);

--- a/src/platforms/linux/daemon/org.mozilla.vpn.dbus.xml
+++ b/src/platforms/linux/daemon/org.mozilla.vpn.dbus.xml
@@ -14,22 +14,6 @@
     <method name="status">
       <arg name="jsonStatus" type="s" direction="out"/>
     </method>
-    <method name="runningApps">
-      <arg type="s" direction="out"/>
-    </method>
-    <method name="firewallApp">
-      <arg type="b" direction="out"/>
-      <arg name="appName" type="s" direction="in"/>
-      <arg name="state" type="s" direction="in"/>
-    </method>
-    <method name="firewallPid">
-      <arg type="b" direction="out"/>
-      <arg name="rootpid" type="i" direction="in"/>
-      <arg name="state" type="s" direction="in"/>
-    </method>
-    <method name="firewallClear">
-      <arg type="b" direction="out"/>
-    </method>
     <method name="getLogs">
       <arg name="logs" type="s" direction="out"/>
     </method>

--- a/src/platforms/linux/linuxdependencies.cpp
+++ b/src/platforms/linux/linuxdependencies.cpp
@@ -156,3 +156,31 @@ QString LinuxDependencies::kdeFrameworkVersion() {
 
   return QString();
 }
+
+// static
+QString LinuxDependencies::desktopFileId(const QString& path) {
+  // Given the path to a .desktop file, return its Desktop File ID as per
+  // the freedesktop.org's Desktop Entry Spec. See:
+  // https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#desktop-file-id
+  //
+  // To determine the ID of a desktop file, make its full path relative to the
+  // $XDG_DATA_DIRS component in which the desktop file is installed, remove the
+  // "applications/" prefix, and turn '/' into '-'.
+
+  // If the path contains no slashes, assume this conversion is already done.
+  if (!path.contains('/')) {
+    return path;
+  }
+
+  // Find the application dir in the path.
+  const QString dirComponent("/applications/");
+  qsizetype index = path.lastIndexOf(dirComponent);
+  if (index >= 0) {
+    index += dirComponent.length();
+  } else if (index < 0) {
+    index = 0;
+  }
+
+  // Convert it.
+  return path.mid(index).replace('/', '-');
+}

--- a/src/platforms/linux/linuxdependencies.cpp
+++ b/src/platforms/linux/linuxdependencies.cpp
@@ -178,7 +178,9 @@ QString LinuxDependencies::desktopFileId(const QString& path) {
   if (index >= 0) {
     index += dirComponent.length();
   } else if (index < 0) {
-    index = 0;
+    // If no applications dir was found, let's just use the filename.
+    index = path.lastIndexOf('/') + 1;
+    Q_ASSERT(index > 0);
   }
 
   // Convert it.

--- a/src/platforms/linux/linuxdependencies.h
+++ b/src/platforms/linux/linuxdependencies.h
@@ -14,6 +14,7 @@ class LinuxDependencies final {
   static QString findCgroup2Path();
   static QString gnomeShellVersion();
   static QString kdeFrameworkVersion();
+  static QString desktopFileId(const QString& path);
 
  private:
   LinuxDependencies() = default;


### PR DESCRIPTION
## Description
App exclusions on Linux mostly make use of the GTK `Launched` signal over D-Bus to kick off application detection by connecting a `*.desktop` file and a control group, and this has worked okay-ish for the most part, but it leaves a lot of edge cases where applications can fall through the cracks if the PID that we get from the GTK launch event dies before the following control group is created. And it just so happens that this has become the case for Snap-packaged applications as of Ubuntu/23.04 Lunar.

To fix this, I think it's finally time that we get off our butts and do some proper heuristic matching between the control group name and typical launcher commands used for Linux desktop environments. To make this work, we first convert the `*.desktop` file into a desktop file ID and then try to parse a matching desktop file ID out of the cgroup path name.

So far this supports applications launched via the Gnome shell launcher, Snaps and Flatpaks. Perhaps with works with more desktop environments too? Only testing will tell!

Platforms tested thus far:
- Ubuntu 20.04 native apps
- Ubuntu 20.04 snaps
- Ubuntu 23.04 native apps
- Ubuntu 23.04 snaps
- Ubuntu 23.04 flatpaks
- Debian 12 native apps on Gnome shell
- Debian 12 native apps on KDE Plasma
- Fedora 38 native apps
- Fedora 38 flatpaks

## Reference
Github issue #6917 ([VPN-4798](https://mozilla-hub.atlassian.net/browse/VPN-4798))
Github issue #8016 ([VPN-5535](https://mozilla-hub.atlassian.net/browse/VPN-5535))
Freedesktop spec: https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#desktop-file-id

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-4798]: https://mozilla-hub.atlassian.net/browse/VPN-4798?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ