### PR TITLE
VPN-5841 basti/fix sentry upload

### DIFF
--- a/taskcluster/scripts/build/windows_clang_cl.ps1
+++ b/taskcluster/scripts/build/windows_clang_cl.ps1
@@ -89,7 +89,7 @@ Write-Output "Artifacts Location:$TASK_WORKDIR/artifacts"
 Get-ChildItem -Path $TASK_WORKDIR/artifacts
 
 if ($env:MOZ_SCM_LEVEL -eq "3") {
-    python3  $SOURCE_DIR/taskcluster/scripts/get-secret.py -s project/mozillavpn/tokens -k sentry_debug_file_upload_key -f sentry_debug_file_upload_key
+    $CONDA_PREFIX\python.exe  $SOURCE_DIR/taskcluster/scripts/get-secret.py -s project/mozillavpn/tokens -k sentry_debug_file_upload_key -f sentry_debug_file_upload_key
     sentry-cli-Windows-x86_64.exe login --auth-token $(Get-Content sentry_debug_file_upload_key)
     # This will ask sentry to scan all files in there and upload
     # missing debug info, for symbolification

--- a/taskcluster/scripts/build/windows_clang_cl.ps1
+++ b/taskcluster/scripts/build/windows_clang_cl.ps1
@@ -89,7 +89,8 @@ Write-Output "Artifacts Location:$TASK_WORKDIR/artifacts"
 Get-ChildItem -Path $TASK_WORKDIR/artifacts
 
 if ($env:MOZ_SCM_LEVEL -eq "3") {
-    $CONDA_PREFIX\python.exe  $SOURCE_DIR/taskcluster/scripts/get-secret.py -s project/mozillavpn/tokens -k sentry_debug_file_upload_key -f sentry_debug_file_upload_key
+    Get-command python
+    python  $SOURCE_DIR/taskcluster/scripts/get-secret.py -s project/mozillavpn/tokens -k sentry_debug_file_upload_key -f sentry_debug_file_upload_key
     sentry-cli-Windows-x86_64.exe login --auth-token $(Get-Content sentry_debug_file_upload_key)
     # This will ask sentry to scan all files in there and upload
     # missing debug info, for symbolification


### PR DESCRIPTION
## Description
Codna on windows only has `python.exe` not `python3.exe`  therefore when we called get-secret.py we did not use our conda env where we have all the dep's for that already loaded. And fail like this: 

```
[22 Uhr](https://mozilla.slack.com/archives/D02CSN2APFA/p1702473729781509)
[task 2023-12-11T19:10:56.463Z]   File "D:\task_170232135405499\mozillavpn-2.19.1~rc20231211184139\taskcluster\scripts\get-secret.py", line 12, in <module>
[task 2023-12-11T19:10:56.510Z]     import taskcluster
[task 2023-12-11T19:10:56.510Z] ModuleNotFoundError: No module named 'taskcluster'
```

As we did not fetch the secret to upload sentry secrets, we failed in uploading them too. 
