### PR TITLE
VPN-5841 Fix sentry upload round 2

### DIFF
--- a/taskcluster/scripts/build/windows_clang_cl.ps1
+++ b/taskcluster/scripts/build/windows_clang_cl.ps1
@@ -94,6 +94,6 @@ if ($env:MOZ_SCM_LEVEL -eq "3") {
     sentry-cli-Windows-x86_64.exe login --auth-token $(Get-Content sentry_debug_file_upload_key)
     # This will ask sentry to scan all files in there and upload
     # missing debug info, for symbolification
-    sentry-cli-Windows-x86_64.exe debug-files upload --org mozilla -p vpn-client $BUILD_DIR/src/CMakeFiles/mozillavpn.dir/vc140.pdb
+    sentry-cli-Windows-x86_64.exe debug-files upload --org mozilla -p vpn-client $TASK_WORKDIR/unsigned/Mozilla\ VPN.pdb
 }
 


### PR DESCRIPTION
## Description
It seems to now fetch the correct secret. but tries to upload the wrong file. 
```
[task 2023-12-13T17:02:10.876Z] Stored token in C:\Users\task_170248645540156\.sentryclirc
[task 2023-12-13T17:02:11.146Z] > Found 0 debug information files
[task 2023-12-13T17:02:11.146Z] > No debug information files found
[task 2023-12-13T17:02:11.287Z] 
[task 2023-12-13T17:02:11.287Z] 

```


In the Unsinged DIR we have the PDB file we want, so let's upload that! :) 
```
[task 2023-12-13T17:02:03.457Z] -- Installing: D:\task_170248645540156\/unsigned/./Mozilla VPN.exe
[task 2023-12-13T17:02:03.537Z] -- Installing: D:\task_170248645540156\/unsigned/./Mozilla VPN.pdb
[task 2023-12-13T17:02:03.694Z] D:\task_170248645540156\cmake_build\src\Mozilla VPN.exe 64 bit, release executable
[task 2023-12-13T17:02:03.694Z] D:\task_170248645540156\cmake_build\src\Mozilla VPN.exe does not seem to be a Qt executable.
[task 2023-12-13T17:02:03.709Z] -- Installing: D:\task_170248645540156\/unsigned/./Microsoft_CRT_x64.msm
[task 2023-12-13T17:02:03.710Z] -- Installing: D:\task_170248645540156\/unsigned/./logo.ico
[task 2023-12-13T17:02:03.714Z] -- Installing: D:\task_170248645540156\/unsigned/./mozillavpnnp.exe
[task 2023-12-13T17:02:03.715Z] -- Installing: D:\task_170248645540156\/unsigned/./mozillavpn.json
[task 2023-12-13T17:02:03.716Z] -- Installing: D:\task_170248645540156\/unsigned/./mullvad-split-tunnel.cat
[task 2023-12-13T17:02:03.716Z] -- Installing: D:\task_170248645540156\/unsigned/./mullvad-split-tunnel.inf
[task 2023-12-13T17:02:03.717Z] -- Installing: D:\task_170248645540156\/unsigned/./mullvad-split-tunnel.sys
[task 2023-12-13T17:02:03.717Z] -- Installing: D:\task_170248645540156\/unsigned/./WdfCoinstaller01011.dll
```
