### PR TITLE
VPN-4852: Implement MZBottomSheet and MZHelpSheet

### DIFF
--- a/nebula/ui/components/CMakeLists.txt
+++ b/nebula/ui/components/CMakeLists.txt
@@ -13,6 +13,7 @@ qt_add_qml_module(components
          MZAvatar.qml
          MZBoldInterLabel.qml
          MZBoldLabel.qml
+         MZBottomSheet.qml
          MZButtonBase.qml
          MZButtonLoader.qml
          MZButton.qml
@@ -34,6 +35,7 @@ qt_add_qml_module(components
          MZGuideCard.qml
          MZHeaderLink.qml
          MZHeadline.qml
+         MZHelpSheet.qml
          MZLottieAnimation.qml
          MZIconAndLabel.qml
          MZIconButton.qml

--- a/nebula/ui/components/MZBottomSheet.qml
+++ b/nebula/ui/components/MZBottomSheet.qml
@@ -9,6 +9,23 @@ import QtQuick.Layouts 1.14
 import components 0.1
 import Mozilla.Shared 1.0
 
+//SUMMARY: MZBottomSheet opens a drawer from the bottom of the screen showing it's contentItem
+
+//USAGE:
+/*
+  MZBottomSheet {
+      contentItem: ColumnLayout {
+          Rectangle {
+              anchors.left: parent.left
+              anchors. right: parent.right
+              height: 20
+              color: "green"
+
+          }
+      }
+  }
+*/
+
 Drawer {
     id: drawer
 

--- a/nebula/ui/components/MZBottomSheet.qml
+++ b/nebula/ui/components/MZBottomSheet.qml
@@ -8,7 +8,7 @@ import Mozilla.Shared 1.0
 Drawer {
     id: drawer
 
-    readonly property int maxHeight: parent.height - MZTheme.theme.sheetTopMargin //parent is the overlay
+    readonly property int maxHeight: window.height - MZTheme.theme.sheetTopMargin //parent is the overlay
 
     implicitWidth: window.width
     implicitHeight: maxHeight

--- a/nebula/ui/components/MZBottomSheet.qml
+++ b/nebula/ui/components/MZBottomSheet.qml
@@ -8,7 +8,7 @@ import Mozilla.Shared 1.0
 Drawer {
     id: drawer
 
-    readonly property int maxHeight: window.height - MZTheme.theme.sheetTopMargin //parent is the overlay
+    readonly property int maxHeight: (Qt.platform.os === "ios" ? window.safeContentHeight : window.height) -  MZTheme.theme.sheetTopMargin
 
     implicitWidth: window.width
     implicitHeight: maxHeight

--- a/nebula/ui/components/MZBottomSheet.qml
+++ b/nebula/ui/components/MZBottomSheet.qml
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import QtQuick 2.15
 import QtQuick.Controls 2.14
 import QtQuick.Layouts 1.14

--- a/nebula/ui/components/MZBottomSheet.qml
+++ b/nebula/ui/components/MZBottomSheet.qml
@@ -8,7 +8,7 @@ import Mozilla.Shared 1.0
 Drawer {
     id: drawer
 
-    readonly property int maxHeight: window.height - 32
+    readonly property int maxHeight: parent.height - MZTheme.theme.sheetTopMargin //parent is the overlay
 
     implicitWidth: window.width
     implicitHeight: maxHeight

--- a/nebula/ui/components/MZBottomSheet.qml
+++ b/nebula/ui/components/MZBottomSheet.qml
@@ -1,0 +1,36 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.14
+import QtQuick.Layouts 1.14
+
+import components 0.1
+import Mozilla.Shared 1.0
+
+Drawer {
+    id: drawer
+
+    readonly property int maxHeight: window.height - 32
+
+    implicitWidth: window.width
+    implicitHeight: maxHeight
+
+    topPadding: 0
+
+    dragMargin: 0
+    edge: Qt.BottomEdge
+    background: Rectangle {
+
+        radius: 8
+        color: MZTheme.theme.bgColor
+
+        Rectangle {
+            color: parent.color
+            anchors.bottom: parent.bottom
+            width: parent.width
+            height: parent.radius
+        }
+    }
+
+    Overlay.modal: Rectangle {
+        color: MZTheme.theme.overlayBackground
+    }
+}

--- a/nebula/ui/components/MZFlickable.qml
+++ b/nebula/ui/components/MZFlickable.qml
@@ -14,7 +14,7 @@ Flickable {
     property var flickContentHeight
     property bool contentExceedsHeight: height < contentHeight
     property bool hideScollBarOnStackTransition: false
-    property bool navbarVisible: navbar.visible
+    property bool addNavbarHeightOffset: navbar.visible
 
     //This property should be true if the flickable appears behind the main navbar
     interactive: contentHeight > height || contentY > 0
@@ -95,13 +95,13 @@ Flickable {
 
         const isItemBehindNavbar = item.mapToItem(window.contentItem, 0, 0).y + item.height > window.height - MZTheme.theme.navBarHeightWithMargins
         const isItemOffScreen = item.mapToItem(window.contentItem, 0, 0).y + item.height > window.height
-        const buffer = vpnFlickable.navbarVisible && isItemBehindNavbar ? MZTheme.theme.navBarHeightWithMargins : MZTheme.theme.contentBottomMargin
+        const buffer = vpnFlickable.addNavbarHeightOffset && isItemBehindNavbar ? MZTheme.theme.navBarHeightWithMargins : MZTheme.theme.contentBottomMargin
         const itemHeight = Math.max(item.height, MZTheme.theme.rowHeight) + buffer
         let destinationY
 
         //When focusing on an item either behind the navbar and/or that is partially or fully off screen in the downward direction
         //scroll to it so that it is visible
-        if((vpnFlickable.navbarVisible && isItemBehindNavbar) || (!vpnFlickable.navbarVisible && isItemOffScreen)) {
+        if((vpnFlickable.addNavbarHeightOffset && isItemBehindNavbar) || (!vpnFlickable.addNavbarHeightOffset && isItemOffScreen)) {
             const scrollDistance = item.mapToItem(window.contentItem, 0, 0).y + item.height - (window.height - buffer)
 
             destinationY = contentY + scrollDistance
@@ -130,7 +130,7 @@ Flickable {
         //Checks if the flickable AND it's content interferes with the navbar area (bottom 146px for iOS, bottom 128px for other platforms)
         //If it does, we pad the flickable's contentHeight with whatever bottom padding is needed so that there is always 48px (aka theme.navBarTopMargin)
         //between the bottom of the flickable's content and the navbar
-        if (vpnFlickable.navbarVisible && absoluteYPosition + height >= contentSpace
+        if (vpnFlickable.addNavbarHeightOffset && absoluteYPosition + height >= contentSpace
                 && flickContentHeight + absoluteYPosition >= contentSpace) {
             vpnFlickable.contentHeight = flickContentHeight + (flickContentHeight >= height ? MZTheme.theme.navBarHeightWithMargins : (absoluteYPosition + flickContentHeight) - contentSpace + (height - flickContentHeight))
         }

--- a/nebula/ui/components/MZFlickable.qml
+++ b/nebula/ui/components/MZFlickable.qml
@@ -14,6 +14,8 @@ Flickable {
     property var flickContentHeight
     property bool contentExceedsHeight: height < contentHeight
     property bool hideScollBarOnStackTransition: false
+    property bool navbarVisible: navbar.visible
+
     //This property should be true if the flickable appears behind the main navbar
     interactive: contentHeight > height || contentY > 0
     clip: true
@@ -93,13 +95,13 @@ Flickable {
 
         const isItemBehindNavbar = item.mapToItem(window.contentItem, 0, 0).y + item.height > window.height - MZTheme.theme.navBarHeightWithMargins
         const isItemOffScreen = item.mapToItem(window.contentItem, 0, 0).y + item.height > window.height
-        const buffer = navbar.visible && isItemBehindNavbar ? MZTheme.theme.navBarHeightWithMargins : MZTheme.theme.contentBottomMargin
+        const buffer = vpnFlickable.navbarVisible && isItemBehindNavbar ? MZTheme.theme.navBarHeightWithMargins : MZTheme.theme.contentBottomMargin
         const itemHeight = Math.max(item.height, MZTheme.theme.rowHeight) + buffer
         let destinationY
 
         //When focusing on an item either behind the navbar and/or that is partially or fully off screen in the downward direction
         //scroll to it so that it is visible
-        if((navbar.visible && isItemBehindNavbar) || (!navbar.visible && isItemOffScreen)) {
+        if((vpnFlickable.navbarVisible && isItemBehindNavbar) || (!vpnFlickable.navbarVisible && isItemOffScreen)) {
             const scrollDistance = item.mapToItem(window.contentItem, 0, 0).y + item.height - (window.height - buffer)
 
             destinationY = contentY + scrollDistance
@@ -128,7 +130,7 @@ Flickable {
         //Checks if the flickable AND it's content interferes with the navbar area (bottom 146px for iOS, bottom 128px for other platforms)
         //If it does, we pad the flickable's contentHeight with whatever bottom padding is needed so that there is always 48px (aka theme.navBarTopMargin)
         //between the bottom of the flickable's content and the navbar
-        if (navbar.visible && absoluteYPosition + height >= contentSpace
+        if (vpnFlickable.navbarVisible && absoluteYPosition + height >= contentSpace
                 && flickContentHeight + absoluteYPosition >= contentSpace) {
             vpnFlickable.contentHeight = flickContentHeight + (flickContentHeight >= height ? MZTheme.theme.navBarHeightWithMargins : (absoluteYPosition + flickContentHeight) - contentSpace + (height - flickContentHeight))
         }

--- a/nebula/ui/components/MZHelpSheet.qml
+++ b/nebula/ui/components/MZHelpSheet.qml
@@ -6,6 +6,11 @@ import components 0.1
 import Mozilla.Shared 1.0
 
 //Usage: pass a list of blocks into the model
+//Fields:
+//"type": MZHelpSheet.BlockType (eg MZHelpSheet.BlockType.PrimaryButton)
+//"text": label or button text (eg "Hello world")
+//"action": action performed on button click - only applicable when type is MZHelpSheet.BlockType.PrimaryButton or MZHelpSheet.BlockType.LinkButton
+//(eg () => { MZUrlOpener.openUrl("https://mozilla.org") })
 /*
   MZHelpSheet {
       title: "MZHelpSheet"
@@ -123,14 +128,13 @@ MZBottomSheet {
             }
         }
 
-
         MZFlickable {
             id: flickable
 
             readonly property int maxheight: bottomSheet.maxHeight - headerLayout.implicitHeight - headerLayout.Layout.topMargin
 
             Layout.fillWidth: true
-            Layout.preferredHeight: Math.min(layout.implicitHeight + layout.anchors.topMargin + layout.anchors.bottomMargin, flickable.maxheight)
+            Layout.preferredHeight: Math.min(layout.implicitHeight + layout.anchors.topMargin + layout.anchors.bottomMargin, maxheight)
 
             flickContentHeight: layout.implicitHeight + layout.anchors.topMargin + layout.anchors.bottomMargin
 
@@ -177,9 +181,8 @@ MZBottomSheet {
 
                                 text: loader.composerBlock.text
                                 font.pixelSize: MZTheme.theme.fontSize
-                                lineHeight: MZTheme.theme.labelLineHeight
+                                lineHeight: 24
                                 verticalAlignment: Text.AlignVCenter
-                                wrapMode: Text.Wrap
                             }
                         }
 
@@ -191,6 +194,7 @@ MZBottomSheet {
                                 text: loader.composerBlock.text
                                 font.pixelSize: MZTheme.theme.fontSizeSmall
                                 color: MZTheme.theme.fontColor
+                                lineHeight: 21
                                 horizontalAlignment: Text.AlignLeft
                             }
                         }

--- a/nebula/ui/components/MZHelpSheet.qml
+++ b/nebula/ui/components/MZHelpSheet.qml
@@ -1,0 +1,122 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.14
+import QtQuick.Layouts 1.14
+
+import components 0.1
+import Mozilla.Shared 1.0
+
+MZBottomSheet {
+    id: bottomSheet
+
+    property alias iconSource: icon.source
+    property alias title: title.text
+    property alias content: layout.data
+
+    implicitHeight: Math.min(contentItem.implicitHeight, maxHeight)
+
+    contentItem: ColumnLayout {
+        spacing: 0
+
+        ColumnLayout {
+            id: headerLayout
+
+            Layout.topMargin: 8
+
+            spacing: 0
+
+            RowLayout {
+                spacing: 0
+
+                Item {
+                    Layout.topMargin: MZTheme.theme.windowMargin / 2
+                    Layout.leftMargin: MZTheme.theme.windowMargin
+                    Layout.preferredHeight: 24
+                    Layout.preferredWidth: 24
+                    Layout.alignment: Qt.AlignTop
+
+                    Image {
+                        id: icon
+                        anchors.centerIn: parent
+
+                        sourceSize.width: MZTheme.theme.iconSize
+
+                        mirror: MZLocalizer.isRightToLeft
+                        fillMode: Image.PreserveAspectFit
+                    }
+                }
+
+
+                MZBoldLabel {
+                    id: title
+
+                    Layout.topMargin: MZTheme.theme.windowMargin / 2
+                    Layout.leftMargin: 8
+                    Layout.alignment: Qt.AlignTop
+
+                    verticalAlignment: Text.AlignVCenter
+                    lineHeightMode: Text.FixedHeight
+                    lineHeight: 24
+                }
+
+                Item {
+                    Layout.fillWidth: true
+                }
+
+                MZIconButton {
+                    id: iconButton
+
+                    Layout.rightMargin: MZTheme.theme.windowMargin / 2
+
+                    Layout.preferredHeight: MZTheme.theme.rowHeight
+                    Layout.preferredWidth: MZTheme.theme.rowHeight
+
+                    //                skipEnsureVisible: true // prevents scrolling of lists when this is focused
+
+                    onClicked: bottomSheet.close()
+
+                    accessibleName: MZI18n.GlobalClose
+                    Accessible.ignored: !visible
+
+                    Image {
+                        anchors.centerIn: parent
+
+                        sourceSize.height: MZTheme.theme.iconSize
+                        sourceSize.width: MZTheme.theme.iconSize
+
+                        source: "qrc:/nebula/resources/close-dark.svg"
+                        fillMode: Image.PreserveAspectFit
+                    }
+                }
+            }
+
+            Rectangle {
+                Layout.topMargin: 8
+                Layout.preferredHeight: 1
+                Layout.preferredWidth: parent.width
+
+                color: MZTheme.colors.grey10
+            }
+        }
+
+
+        MZFlickable {
+            id: flickable
+
+            readonly property int maxheight: bottomSheet.maxHeight - headerLayout.implicitHeight - headerLayout.Layout.topMargin
+
+            Layout.fillWidth: true
+            Layout.preferredHeight: Math.min(layout.implicitHeight + layout.anchors.topMargin + layout.anchors.bottomMargin, flickable.maxheight)
+
+            flickContentHeight: layout.implicitHeight + layout.anchors.topMargin + layout.anchors.bottomMargin
+
+            navbarVisible: false
+
+            ColumnLayout {
+                id: layout
+                anchors.fill: parent
+                anchors.margins: MZTheme.theme.windowMargin * 1.5
+            }
+        }
+    }
+
+}

--- a/nebula/ui/components/MZHelpSheet.qml
+++ b/nebula/ui/components/MZHelpSheet.qml
@@ -53,7 +53,13 @@ MZBottomSheet {
     implicitHeight: Math.min(contentItem.implicitHeight, maxHeight)
 
     contentItem: ColumnLayout {
+
         spacing: 0
+
+        Accessible.role: Accessible.Grouping
+        Accessible.name: bottomSheet.title
+
+        Component.onCompleted: forceActiveFocus()
 
         ColumnLayout {
             id: headerLayout

--- a/nebula/ui/components/MZHelpSheet.qml
+++ b/nebula/ui/components/MZHelpSheet.qml
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 import QtQuick 2.15
 import QtQuick.Controls 2.14
 import QtQuick.Layouts 1.14

--- a/nebula/ui/components/MZHelpSheet.qml
+++ b/nebula/ui/components/MZHelpSheet.qml
@@ -9,7 +9,11 @@ import QtQuick.Layouts 1.14
 import components 0.1
 import Mozilla.Shared 1.0
 
-//Usage: pass a list of blocks into the model to instantiate components
+//SUMMARY: MZHelpSheet is a component derived from MZBottomSheet that opens a drawer from the bottom of the screen who's content
+//is always laid out in a consistnet way by passing in a model with the correct schema, and sizes to fit the content it contains
+
+//USAGE: pass a list of blocks into the model to instantiate components as follows:
+
 //Fields:
 //"type": MZHelpSheet.BlockType (eg MZHelpSheet.BlockType.PrimaryButton)
 //"text": label or button text (eg "Hello world")
@@ -37,8 +41,7 @@ MZBottomSheet {
 
     property alias iconSource: icon.source
     property alias title: title.text
-    property var model
-
+    required property var model
 
     enum BlockType {
         Title,
@@ -65,8 +68,8 @@ MZBottomSheet {
                 Item {
                     Layout.topMargin: MZTheme.theme.windowMargin / 2
                     Layout.leftMargin: MZTheme.theme.windowMargin
-                    Layout.preferredHeight: 24
-                    Layout.preferredWidth: 24
+                    Layout.preferredHeight: MZTheme.theme.iconSize * 1.5
+                    Layout.preferredWidth: MZTheme.theme.iconSize * 1.5
                     Layout.alignment: Qt.AlignTop
 
                     Image {
@@ -105,12 +108,9 @@ MZBottomSheet {
                     Layout.preferredHeight: MZTheme.theme.rowHeight
                     Layout.preferredWidth: MZTheme.theme.rowHeight
 
-                    //                skipEnsureVisible: true // prevents scrolling of lists when this is focused
-
                     onClicked: bottomSheet.close()
 
                     accessibleName: MZI18n.GlobalClose
-                    Accessible.ignored: !visible
 
                     Image {
                         anchors.centerIn: parent
@@ -126,7 +126,7 @@ MZBottomSheet {
 
             Rectangle {
                 Layout.topMargin: 8
-                Layout.preferredHeight: 1
+                Layout.preferredHeight: MZTheme.theme.dividerHeight
                 Layout.preferredWidth: parent.width
 
                 color: MZTheme.colors.grey10
@@ -143,7 +143,7 @@ MZBottomSheet {
 
             flickContentHeight: layout.implicitHeight + layout.anchors.topMargin + layout.anchors.bottomMargin
 
-            navbarVisible: false
+            addNavbarHeightOffset: false
 
             ColumnLayout {
                 id: layout

--- a/nebula/ui/components/MZHelpSheet.qml
+++ b/nebula/ui/components/MZHelpSheet.qml
@@ -5,10 +5,11 @@ import QtQuick.Layouts 1.14
 import components 0.1
 import Mozilla.Shared 1.0
 
-//Usage: pass a list of blocks into the model
+//Usage: pass a list of blocks into the model to instantiate components
 //Fields:
 //"type": MZHelpSheet.BlockType (eg MZHelpSheet.BlockType.PrimaryButton)
 //"text": label or button text (eg "Hello world")
+//"margin": top margin above the component (eg 16)
 //"action": action performed on button click - only applicable when type is MZHelpSheet.BlockType.PrimaryButton or MZHelpSheet.BlockType.LinkButton
 //(eg () => { MZUrlOpener.openUrl("https://mozilla.org") })
 /*
@@ -18,11 +19,11 @@ import Mozilla.Shared 1.0
 
       model: [
           {type: MZHelpSheet.BlockType.Title, text: "title"},
-          {type: MZHelpSheet.BlockType.Text, text: "text"},
-          {type: MZHelpSheet.BlockType.Text, text: "text"},
-          {type: MZHelpSheet.BlockType.Text, text: "text"},
-          {type: MZHelpSheet.BlockType.PrimaryButton, text: "Primary", action: () => { sheet.close(); MZNavigator.requestScreen(VPN.ScreenGetHelp) } },
-          {type: MZHelpSheet.BlockType.LinkButton, text: "Link", action: () => { MZUrlOpener.openUrl("https://mozilla.org") } }
+          {type: MZHelpSheet.BlockType.Text, margin: 8, text: "text"},
+          {type: MZHelpSheet.BlockType.Text, margin: 16, text: "text"},
+          {type: MZHelpSheet.BlockType.Text, margin: 16, text: "text"},
+          {type: MZHelpSheet.BlockType.PrimaryButton, text: "Primary", margin: 16, action: () => { sheet.close(); MZNavigator.requestScreen(VPN.ScreenGetHelp) } },
+          {type: MZHelpSheet.BlockType.LinkButton, text: "Link", margin: 8, action: () => { MZUrlOpener.openUrl("https://mozilla.org") } }
       ]
     }
 */
@@ -170,6 +171,7 @@ MZBottomSheet {
 
                         Layout.fillWidth: true
                         Layout.preferredHeight: item.implicitHeight
+                        Layout.topMargin: composerBlock.margin
 
                         sourceComponent: getSourceComponent()
 

--- a/nebula/ui/components/qmldir
+++ b/nebula/ui/components/qmldir
@@ -75,5 +75,4 @@ MZVerticalSpacer 0.1 MZVerticalSpacer.qml
 MZViewBase 0.1 MZViewBase.qml
 MZGuideList 0.1 MZGuideList.qml
 MZTipsAndTricksSection 0.1 MZTipsAndTricksSection.qml
-MZHelpSheet 0.1 helpSheet/MZHelpSheet
-MZHelpSheetComposer 0.1 helpSheet/MZHelpSheetComposer
+MZHelpSheet 0.1 MZHelpSheet

--- a/nebula/ui/components/qmldir
+++ b/nebula/ui/components/qmldir
@@ -75,3 +75,5 @@ MZVerticalSpacer 0.1 MZVerticalSpacer.qml
 MZViewBase 0.1 MZViewBase.qml
 MZGuideList 0.1 MZGuideList.qml
 MZTipsAndTricksSection 0.1 MZTipsAndTricksSection.qml
+MZHelpSheet 0.1 helpSheet/MZHelpSheet
+MZHelpSheetComposer 0.1 helpSheet/MZHelpSheetComposer

--- a/nebula/ui/themes/main/theme.js
+++ b/nebula/ui/themes/main/theme.js
@@ -75,6 +75,7 @@ theme.listSpacing = 8;
 theme.maxTextWidth = 296;
 theme.windowMargin = 16;
 theme.popupMargin = 24;
+theme.sheetTopMargin = 32
 theme.desktopAppHeight = 640;
 theme.desktopAppWidth = 360;
 theme.tabletMinimumWidth = 600;

--- a/nebula/ui/themes/main/theme.js
+++ b/nebula/ui/themes/main/theme.js
@@ -83,6 +83,7 @@ theme.largePhoneHeight = 852
 theme.menuHeight = 56;
 theme.viewBaseTopMargin = 16;
 theme.checkBoxRowSubLabelTopMargin = 2;
+theme.dividerHeight = 1
 
 theme.guideCardHeight = 172
 


### PR DESCRIPTION
## Description

- Create `MZBottomSheet`, a generic, reusable drawer/sheet component
- Create `MZHelpSheet`, based off of `MZBottomSheet`, but specifically tailored for our [educational content](https://mozilla-hub.atlassian.net/browse/VPN-4681)
- Notes about `MZHelpSheet`:
  - Resizes to fit it's content, up to a maximum size, then scrolls
  - Supports titles, text, primary buttons, and link buttons

Examples: 

https://github.com/mozilla-mobile/mozilla-vpn-client/assets/15353801/735a2be2-860c-4bf4-b018-3b6e0f222d25

https://github.com/mozilla-mobile/mozilla-vpn-client/assets/15353801/d60c5af8-f22e-4243-b2a6-8ccb66b3b57d

## Reference

[VPN-4852: Create new "MZSheet" Nebula component to support new guides](https://mozilla-hub.atlassian.net/browse/VPN-4852)