### PR TITLE
Use SSL server for Adjust proxy

### DIFF
--- a/src/adjust/adjustproxy.cpp
+++ b/src/adjust/adjustproxy.cpp
@@ -5,7 +5,7 @@
 #include "adjustproxy.h"
 
 #include <QHostAddress>
-#include <QTcpSocket>
+#include <QSslSocket>
 
 #include "adjustproxyconnection.h"
 #include "leakdetector.h"
@@ -15,7 +15,7 @@ namespace {
 Logger logger("AdjustProxy");
 }  // namespace
 
-AdjustProxy::AdjustProxy(QObject* parent) : QTcpServer(parent) {
+AdjustProxy::AdjustProxy(QObject* parent) : QSslServer(parent) {
   MZ_COUNT_CTOR(AdjustProxy);
   logger.debug() << "Creating the AdjustProxy server";
 }
@@ -39,9 +39,9 @@ bool AdjustProxy::initialize(quint16 port) {
 void AdjustProxy::newConnectionReceived() {
   logger.debug() << "New Adjust Proxy connection received";
 
-  QTcpSocket* child = nextPendingConnection();
-  Q_ASSERT(child);
+  QSslSocket* child = new QSslSocket(this);
+  incomingConnection(child->socketDescriptor());
 
   AdjustProxyConnection* connection = new AdjustProxyConnection(this, child);
-  connect(child, &QTcpSocket::disconnected, connection, &QObject::deleteLater);
+  connect(child, &QSslSocket::disconnected, connection, &QObject::deleteLater);
 }

--- a/src/adjust/adjustproxy.h
+++ b/src/adjust/adjustproxy.h
@@ -5,9 +5,9 @@
 #ifndef ADJUSTPROXY_H
 #define ADJUSTPROXY_H
 
-#include <QTcpServer>
+#include <QSslServer>
 
-class AdjustProxy final : public QTcpServer {
+class AdjustProxy final : public QSslServer {
   Q_OBJECT
   Q_DISABLE_COPY_MOVE(AdjustProxy)
 

--- a/src/adjust/adjustproxyconnection.cpp
+++ b/src/adjust/adjustproxyconnection.cpp
@@ -7,7 +7,7 @@
 
 #include "adjustproxyconnection.h"
 
-#include <QTcpSocket>
+#include <QSslSocket>
 #include <QUrl>
 #include <QUrlQuery>
 
@@ -27,14 +27,14 @@ Logger logger("AdjustProxyConnection");
 }  // namespace
 
 AdjustProxyConnection::AdjustProxyConnection(QObject* parent,
-                                             QTcpSocket* connection)
+                                             QSslSocket* connection)
     : QObject(parent), m_connection(connection) {
   MZ_COUNT_CTOR(AdjustProxyConnection);
 
   logger.debug() << "New connection received";
 
   Q_ASSERT(m_connection);
-  connect(m_connection, &QTcpSocket::readyRead, this,
+  connect(m_connection, &QSslSocket::readyRead, this,
           &AdjustProxyConnection::readData);
 }
 

--- a/src/adjust/adjustproxyconnection.h
+++ b/src/adjust/adjustproxyconnection.h
@@ -9,14 +9,14 @@
 
 #include "adjustproxypackagehandler.h"
 
-class QTcpSocket;
+class QSslSocket;
 
 class AdjustProxyConnection final : public QObject {
   Q_OBJECT
   Q_DISABLE_COPY_MOVE(AdjustProxyConnection)
 
  public:
-  AdjustProxyConnection(QObject* parent, QTcpSocket* connection);
+  AdjustProxyConnection(QObject* parent, QSslSocket* connection);
   ~AdjustProxyConnection();
 
  private:
@@ -24,7 +24,7 @@ class AdjustProxyConnection final : public QObject {
   void forwardRequest();
 
  private:
-  QTcpSocket* m_connection = nullptr;
+  QSslSocket* m_connection = nullptr;
   AdjustProxyPackageHandler m_packageHandler;
 };
 


### PR DESCRIPTION
Requests to the adjust proxy fail because it's not using an encrypted connection.

This fixes it.