### PR TITLE
Adjust fixes for Android client: add a network conf, change how token is passed to gradle

### DIFF
--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -28,7 +28,7 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
         android:extractNativeLibs="true"
         android:theme="@style/AppTheme"
         android:icon="@mipmap/vpnicon"
-        android:usesCleartextTraffic="false">  <!-- Set this to "true" if you need to use http, i.e. for a local guardian instance -->
+        android:networkSecurityConfig="@xml/network_security_config">  
         <activity
             android:configChanges="orientation|uiMode|screenLayout|screenSize|smallestScreenSize|layoutDirection|locale|fontScale|keyboard|keyboardHidden|navigation|mcc|mnc|density"
             android:name="org.mozilla.firefox.vpn.qt.VPNActivity"

--- a/android/adjust/build.gradle
+++ b/android/adjust/build.gradle
@@ -10,8 +10,8 @@ android {
     defaultConfig {
         minSdkVersion Config.minSdkVersion
         targetSdkVersion Config.targetSdkVersion
-        
-        buildConfigField "String", "ADJUST_SDK_TOKEN", '"' + System.getenv("ADJUST_SDK_TOKEN") + '"'
+
+        buildConfigField  "String", "ADJUST_SDK_TOKEN" ,  '"' + (project.properties["adjusttoken"] ?: "no_token_found") +  '"'
     }
     sourceSets {
         main {

--- a/android/common/build.gradle
+++ b/android/common/build.gradle
@@ -16,7 +16,7 @@ android {
         Config.targetSdkVersion
         buildConfigField  "String", "VERSIONCODE" ,  '"' +System.getenv("VERSIONCODE") + '"'
         buildConfigField  "String", "SHORTVERSION" ,  '"' + System.getenv("SHORTVERSION") +  '"'
-        buildConfigField  "String", "ADJUST_SDK_TOKEN" ,  '"' + System.getenv("ADJUST_SDK_TOKEN") +  '"'
+        buildConfigField  "String", "ADJUST_SDK_TOKEN" ,  '"' + (project.properties["adjusttoken"] ?: "no_token_found") +  '"'
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }

--- a/android/common/src/main/java/org/mozilla/firefox/qt/common/CoreApplication.kt
+++ b/android/common/src/main/java/org/mozilla/firefox/qt/common/CoreApplication.kt
@@ -32,6 +32,7 @@ class CoreApplication : org.qtproject.qt.android.bindings.QtApplication(), Confi
     private var adjustActive = false
 
     companion object {
+        private val tag = "CoreApplicationAdjust"
         lateinit var instance: CoreApplication
             private set
 
@@ -43,6 +44,7 @@ class CoreApplication : org.qtproject.qt.android.bindings.QtApplication(), Confi
          */
         @JvmStatic
         fun initializeAdjust(inProduction: Boolean, proxyPort: Int) {
+            Log.i(tag, "Initializing Adjust")
             val appToken: String = BuildConfig.ADJUST_SDK_TOKEN
             val environment: String =
                 if (inProduction) AdjustConfig.ENVIRONMENT_PRODUCTION else AdjustConfig.ENVIRONMENT_SANDBOX

--- a/android/daemon/build.gradle
+++ b/android/daemon/build.gradle
@@ -54,7 +54,7 @@ android {
 
         buildConfigField  "String", "VERSIONCODE" ,  '"' +System.getenv("VERSIONCODE") + '"'
         buildConfigField  "String", "SHORTVERSION" ,  '"' + System.getenv("SHORTVERSION") +  '"'
-        buildConfigField  "String", "ADJUST_SDK_TOKEN" ,  '"' + System.getenv("ADJUST_SDK_TOKEN") +  '"'
+        buildConfigField  "String", "ADJUST_SDK_TOKEN" ,  '"' + (project.properties["adjusttoken"] ?: "no_token_found") +  '"'
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/android/resources/all/xml/network_security_config.xml
+++ b/android/resources/all/xml/network_security_config.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <base-config cleartextTrafficPermitted="true">
+        <trust-anchors>
+            <certificates src="system" />
+        </trust-anchors>
+    </base-config>
+    <domain-config cleartextTrafficPermitted="false">
+        <domain includeSubdomains="true">mozilla.org</domain>
+        <domain includeSubdomains="true">firefox.com</domain>
+        <domain includeSubdomains="true">mozgcp.net</domain>
+        <domain includeSubdomains="true">sentry.io</domain>
+        <domain includeSubdomains="true">apple.com</domain>
+        <domain includeSubdomains="true">google.com</domain>
+        <domain includeSubdomains="true">github.io</domain> 
+        <trust-anchors>
+            <certificates src="system" />
+        </trust-anchors>
+    </domain-config>
+</network-security-config>

--- a/android/resources/all/xml/network_security_config.xml
+++ b/android/resources/all/xml/network_security_config.xml
@@ -12,7 +12,9 @@
         <domain includeSubdomains="true">sentry.io</domain>
         <domain includeSubdomains="true">apple.com</domain>
         <domain includeSubdomains="true">google.com</domain>
-        <domain includeSubdomains="true">github.io</domain> 
+        <domain includeSubdomains="true">github.io</domain>
+        <domain includeSubdomains="true">allizom.org</domain>
+        <domain includeSubdomains="true">mozaws.net</domain>
         <trust-anchors>
             <certificates src="system" />
         </trust-anchors>

--- a/scripts/android/cmake.sh
+++ b/scripts/android/cmake.sh
@@ -125,13 +125,6 @@ export ADJUST_SDK_TOKEN=$ADJUST_SDK_TOKEN # Export it even if it is not set to o
 FULLVERSION=$SHORTVERSION.$(date +"%Y%m%d%H%M")
 print G "$SHORTVERSION - $FULLVERSION - $VERSIONCODE"
 print Y "Configuring the android build"
-if [[ "$ADJUST_SDK_TOKEN" ]]; then
-  print Y "Use adjust config"
-  ADJUST="CONFIG+=adjust"
-else
-  print Y "No adjust token found."
-  ADJUST="CONFIG-=adjust"
-fi
 
 # Warning: this is hacky.
 #
@@ -190,7 +183,7 @@ cd .tmp/src/android-build/
 if [[ "$RELEASE" ]]; then
   print Y "Generating Release APK..."
   ./gradlew compileReleaseSources
-  ./gradlew assemble || die
+  ./gradlew assemble -Padjusttoken=$ADJUST_SDK_TOKEN || die
 
   print G "Done 🎉"
   print G "Your Release APK is under .tmp/src/android-build/build/outputs/apk/release/"


### PR DESCRIPTION
A write up of the issues on hand is in the ticket: https://mozilla-hub.atlassian.net/browse/VPN-5822?focusedCommentId=809828

## Description

Instead of a bool, let's enforce https for all known domains the client can talk to.