### PR TITLE
VPN-5983: Fix infinite loop bug in Navigator::requestDeepLink()

### DIFF
--- a/src/frontend/navigator.cpp
+++ b/src/frontend/navigator.cpp
@@ -221,7 +221,7 @@ void Navigator::requestDeepLink(const QUrl& url) {
   }
   QString name = QString("Screen%1").arg(topPath);
   const QMetaEnum meta = QMetaEnum::fromType<MozillaVPN::CustomScreen>();
-  for (int index = 0; meta.keyCount(); index++) {
+  for (int index = 0; index < meta.keyCount(); index++) {
     const char* key = meta.key(index);
     if ((key != nullptr) && (name.compare(key, Qt::CaseInsensitive) == 0)) {
       requestScreen(meta.value(index));


### PR DESCRIPTION
## Description
In a recent PR, we added support for navigating to screens using deep linking. But unfortunately, in the implementation we left an infinite loop bug where upon if we fail to find a screen that matches the requested deep link, we iterate forever.

## Reference
Deeplinking PR #8757
Github issue: #8742 ([VPN-5983](https://mozilla-hub.atlassian.net/browse/VPN-5983?focusedCommentId=808646))

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-5983]: https://mozilla-hub.atlassian.net/browse/VPN-5983?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ