### PR TITLE
Remove releng as CODEOWNERS of build / addons scripts

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -7,3 +7,5 @@
 .cron.yml @mozilla-mobile/releng
 .taskcluster.yml @mozilla-mobile/releng
 taskcluster @mozilla-mobile/releng
+taskcluster/scripts/addons
+taskcluster/scripts/build


### PR DESCRIPTION
## Description

Releng doesn't have much involvement with the build / addons scripts so we shouldn't be CODEOWNERS here. 

Btw, if VPN folks would like us to be CODEOWNERS of fewer things, let us know! We're mostly here to help catch potential problems early and are happy to remain. But if we're just holding things up we can revisit.

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
