### PR TITLE
VPN-4987 [Part 1] - Check for internet connectivity upon activation + VPN-5994 - Inspector command

### DIFF
--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -940,7 +940,7 @@ bool Controller::activate(const ServerData& serverData,
       logger.debug() << "Internet probe failed during controller activation. "
                         "Device has no network connectivity.";
       m_isDeviceConnected = false;
-      emit isDeviceConnectedFailed();
+      emit isDeviceConnectedChanged();
       return false;
     }
     m_isDeviceConnected = true;

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -943,7 +943,10 @@ bool Controller::activate(const ServerData& serverData,
       emit isDeviceConnectedChanged();
       return false;
     }
-    m_isDeviceConnected = true;
+    if (!m_isDeviceConnected) {
+      m_isDeviceConnected = true;
+      emit isDeviceConnectedChanged();
+    }
 
     // Before attempting to enable VPN connection we should check that the
     // subscription is active.

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -934,18 +934,21 @@ bool Controller::activate(const ServerData& serverData,
       return true;
     }
 
-    // Ensure that the device is connected to the Internet.
-    if (MozillaVPN::instance()->networkWatcher()->getReachability() ==
-        QNetworkInformation::Reachability::Disconnected) {
-      logger.debug() << "Internet probe failed during controller activation. "
-                        "Device has no network connectivity.";
-      m_isDeviceConnected = false;
-      emit isDeviceConnectedChanged();
-      return false;
-    }
-    if (!m_isDeviceConnected) {
-      m_isDeviceConnected = true;
-      emit isDeviceConnectedChanged();
+    if (Feature::get(Feature::Feature_checkConnectivityOnActivation)
+            ->isSupported()) {
+      // Ensure that the device is connected to the Internet.
+      if (MozillaVPN::instance()->networkWatcher()->getReachability() ==
+          QNetworkInformation::Reachability::Disconnected) {
+        logger.debug() << "Internet probe failed during controller activation. "
+                          "Device has no network connectivity.";
+        m_isDeviceConnected = false;
+        emit isDeviceConnectedChanged();
+        return false;
+      }
+      if (!m_isDeviceConnected) {
+        m_isDeviceConnected = true;
+        emit isDeviceConnectedChanged();
+      }
     }
 
     // Before attempting to enable VPN connection we should check that the

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -939,10 +939,11 @@ bool Controller::activate(const ServerData& serverData,
         QNetworkInformation::Reachability::Disconnected) {
       logger.debug() << "Internet probe failed during controller activation. "
                         "Device has no network connectivity.";
-      m_deviceNetworkConnectivity = false;
-      emit deviceNetworkConnectivityFailed();
+      m_isDeviceConnected = false;
+      emit isDeviceConnectedFailed();
       return false;
     }
+    m_isDeviceConnected = true;
 
     // Before attempting to enable VPN connection we should check that the
     // subscription is active.

--- a/src/controller.h
+++ b/src/controller.h
@@ -57,6 +57,7 @@ class Controller : public QObject, public LogSerializer {
   void updateRequired();
   void deleteOSTunnelConfig();
   void startHandshakeTimer();
+  bool deviceNetworkConnectivity() const { return m_deviceNetworkConnectivity; }
 
   const ServerData& currentServer() const { return m_serverData; }
 
@@ -109,6 +110,8 @@ class Controller : public QObject, public LogSerializer {
                  NOTIFY enableDisconnectInConfirmingChanged);
   Q_PROPERTY(bool silentServerSwitchingSupported READ
                  silentServerSwitchingSupported CONSTANT);
+  Q_PROPERTY(bool deviceNetworkConnectivity READ deviceNetworkConnectivity
+                 NOTIFY deviceNetworkConnectivityFailed);
 
 #ifdef MZ_DUMMY
   // This is just for testing purposes. Not exposed in prod.
@@ -141,6 +144,7 @@ class Controller : public QObject, public LogSerializer {
   void readyToBackendFailure();
   void readyToServerUnavailable(bool pingReceived);
   void activationBlockedForCaptivePortal();
+  void deviceNetworkConnectivityFailed();
 
 #ifdef MZ_DUMMY
   void currentServerChanged();
@@ -204,6 +208,7 @@ class Controller : public QObject, public LogSerializer {
 
   QScopedPointer<ControllerImpl> m_impl;
   bool m_portalDetected = false;
+  bool m_deviceNetworkConnectivity = true;
 
   // Server data can change while the controller is busy completing an
   // activation or a server switch because they are managed by the

--- a/src/controller.h
+++ b/src/controller.h
@@ -111,7 +111,7 @@ class Controller : public QObject, public LogSerializer {
   Q_PROPERTY(bool silentServerSwitchingSupported READ
                  silentServerSwitchingSupported CONSTANT);
   Q_PROPERTY(bool isDeviceConnected READ isDeviceConnected NOTIFY
-             isDeviceConnectedChanged);
+                 isDeviceConnectedChanged);
 
 #ifdef MZ_DUMMY
   // This is just for testing purposes. Not exposed in prod.

--- a/src/controller.h
+++ b/src/controller.h
@@ -57,7 +57,7 @@ class Controller : public QObject, public LogSerializer {
   void updateRequired();
   void deleteOSTunnelConfig();
   void startHandshakeTimer();
-  bool deviceNetworkConnectivity() const { return m_deviceNetworkConnectivity; }
+  bool isDeviceConnected() const { return m_isDeviceConnected; }
 
   const ServerData& currentServer() const { return m_serverData; }
 
@@ -110,8 +110,8 @@ class Controller : public QObject, public LogSerializer {
                  NOTIFY enableDisconnectInConfirmingChanged);
   Q_PROPERTY(bool silentServerSwitchingSupported READ
                  silentServerSwitchingSupported CONSTANT);
-  Q_PROPERTY(bool deviceNetworkConnectivity READ deviceNetworkConnectivity
-                 NOTIFY deviceNetworkConnectivityFailed);
+  Q_PROPERTY(bool isDeviceConnected READ isDeviceConnected NOTIFY
+                 isDeviceConnectedFailed);
 
 #ifdef MZ_DUMMY
   // This is just for testing purposes. Not exposed in prod.
@@ -144,7 +144,7 @@ class Controller : public QObject, public LogSerializer {
   void readyToBackendFailure();
   void readyToServerUnavailable(bool pingReceived);
   void activationBlockedForCaptivePortal();
-  void deviceNetworkConnectivityFailed();
+  void isDeviceConnectedFailed();
 
 #ifdef MZ_DUMMY
   void currentServerChanged();
@@ -208,7 +208,7 @@ class Controller : public QObject, public LogSerializer {
 
   QScopedPointer<ControllerImpl> m_impl;
   bool m_portalDetected = false;
-  bool m_deviceNetworkConnectivity = true;
+  bool m_isDeviceConnected = true;
 
   // Server data can change while the controller is busy completing an
   // activation or a server switch because they are managed by the

--- a/src/controller.h
+++ b/src/controller.h
@@ -111,7 +111,7 @@ class Controller : public QObject, public LogSerializer {
   Q_PROPERTY(bool silentServerSwitchingSupported READ
                  silentServerSwitchingSupported CONSTANT);
   Q_PROPERTY(bool isDeviceConnected READ isDeviceConnected NOTIFY
-                 isDeviceConnectedFailed);
+             isDeviceConnectedChanged);
 
 #ifdef MZ_DUMMY
   // This is just for testing purposes. Not exposed in prod.
@@ -144,7 +144,7 @@ class Controller : public QObject, public LogSerializer {
   void readyToBackendFailure();
   void readyToServerUnavailable(bool pingReceived);
   void activationBlockedForCaptivePortal();
-  void isDeviceConnectedFailed();
+  void isDeviceConnectedChanged();
 
 #ifdef MZ_DUMMY
   void currentServerChanged();

--- a/src/feature/featurelist.h
+++ b/src/feature/featurelist.h
@@ -68,6 +68,13 @@ FEATURE(captivePortal,          // Feature ID
         QStringList(),          // feature dependencies
         FeatureCallback_captivePortal)
 
+FEATURE(checkConnectivityOnActivation,       // Feature ID
+        "Check Connectivity On Activation",  // Feature name
+        FeatureCallback_true,                // Can be flipped on
+        FeatureCallback_true,                // Can be flipped off
+        QStringList(),                       // feature dependencies
+        FeatureCallback_false)
+
 FEATURE(customDNS,              // Feature ID
         "Custom DNS",           // Feature name
         FeatureCallback_true,   // Can be flipped on

--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -2147,6 +2147,20 @@ void MozillaVPN::registerInspectorCommands() {
       });
 
   InspectorHandler::registerCommand(
+      "force_no_network",
+      "Mock the internet connection being down by passing true, pass false to "
+      "restore",
+      1, [](InspectorHandler*, const QList<QByteArray>& arguments) {
+        QJsonObject obj;
+        QByteArray byteArray = arguments[1].toLower();
+        // Check if the byte array contains the string "true"
+        bool forceDisconnection = byteArray.contains("true");
+        MozillaVPN::instance()->networkWatcher()->simulateDisconnection(
+            forceDisconnection);
+        return QJsonObject();
+      });
+
+  InspectorHandler::registerCommand(
       "force_connection_health",
       "Force VPN connection health stability. Possible values are: stable, "
       "unstable, nosignal",

--- a/src/networkwatcher.cpp
+++ b/src/networkwatcher.cpp
@@ -5,7 +5,11 @@
 #include "networkwatcher.h"
 
 #include <QMetaEnum>
+<<<<<<< HEAD
 #include <QNetworkInformation>
+    =======
+// #include <QNetworkInformation>
+>>>>>>> 4b51530eb (Reachability)
 
 #include "controller.h"
 #include "leakdetector.h"
@@ -40,7 +44,7 @@
 
 // How often we notify the same unsecured network
 #ifndef UNIT_TEST
-constexpr uint32_t NETWORK_WATCHER_TIMER_MSEC = 20000;
+    constexpr uint32_t NETWORK_WATCHER_TIMER_MSEC = 20000;
 #endif
 
 namespace {
@@ -170,8 +174,14 @@ void NetworkWatcher::notificationClicked(NotificationHandler::Message message) {
 }
 
 QNetworkInformation::Reachability NetworkWatcher::getReachability() {
-  if (QNetworkInformation::instance()) {
+  if (m_simulatedDisconnection) {
+    return QNetworkInformation::Reachability::Disconnected;
+  } else if (QNetworkInformation::instance()) {
     return QNetworkInformation::instance()->reachability();
   }
   return QNetworkInformation::Reachability::Unknown;
+}
+
+void NetworkWatcher::simulateDisconnection(bool simulatedDisconnection) {
+  m_simulatedDisconnection = simulatedDisconnection;
 }

--- a/src/networkwatcher.cpp
+++ b/src/networkwatcher.cpp
@@ -40,7 +40,7 @@
 
 // How often we notify the same unsecured network
 #ifndef UNIT_TEST
-    constexpr uint32_t NETWORK_WATCHER_TIMER_MSEC = 20000;
+constexpr uint32_t NETWORK_WATCHER_TIMER_MSEC = 20000;
 #endif
 
 namespace {
@@ -86,6 +86,11 @@ void NetworkWatcher::initialize() {
   if (m_active) {
     m_impl->start();
   }
+
+  // This call creates an instance of QNetworkInformation which can be used
+  // later on to check other network related attributes such as network type, or
+  // whether or not the network is behind captive portal.
+  QNetworkInformation::loadDefaultBackend();
 
   connect(settingsHolder, &SettingsHolder::unsecuredNetworkAlertChanged, this,
           &NetworkWatcher::settingsChanged);

--- a/src/networkwatcher.cpp
+++ b/src/networkwatcher.cpp
@@ -5,11 +5,7 @@
 #include "networkwatcher.h"
 
 #include <QMetaEnum>
-<<<<<<< HEAD
 #include <QNetworkInformation>
-    =======
-// #include <QNetworkInformation>
->>>>>>> 4b51530eb (Reachability)
 
 #include "controller.h"
 #include "leakdetector.h"

--- a/src/networkwatcher.cpp
+++ b/src/networkwatcher.cpp
@@ -6,6 +6,7 @@
 
 #include <QMetaEnum>
 #include <QNetworkInformation>
+#include <QtGlobal>
 
 #include "controller.h"
 #include "leakdetector.h"
@@ -87,10 +88,12 @@ void NetworkWatcher::initialize() {
     m_impl->start();
   }
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 4, 0)
   // This call creates an instance of QNetworkInformation which can be used
   // later on to check other network related attributes such as network type, or
   // whether or not the network is behind captive portal.
   QNetworkInformation::loadDefaultBackend();
+#endif
 
   connect(settingsHolder, &SettingsHolder::unsecuredNetworkAlertChanged, this,
           &NetworkWatcher::settingsChanged);

--- a/src/networkwatcher.h
+++ b/src/networkwatcher.h
@@ -54,8 +54,6 @@ class NetworkWatcher final : public QObject {
 
   // Used to simulate network disconnection in the Inspector
   bool m_simulatedDisconnection = false;
-  QNetworkInformation::Reachability m_currentReachability =
-      QNetworkInformation::Reachability::Online;
 };
 
 #endif  // NETWORKWATCHER_H

--- a/src/networkwatcher.h
+++ b/src/networkwatcher.h
@@ -24,8 +24,11 @@ class NetworkWatcher final : public QObject {
 
   void initialize();
 
-  // public for the inspector.
+  // Public for the Inspector.
   void unsecuredNetwork(const QString& networkName, const QString& networkId);
+  // Used for the Inspector. simulateOffline = true to mock being disconnected,
+  // false to restore.
+  void simulateDisconnection(bool simulatedDisconnection);
 
   QNetworkInformation::Reachability getReachability();
 
@@ -48,6 +51,11 @@ class NetworkWatcher final : public QObject {
 
   // This is used to connect NotificationHandler lazily.
   bool m_firstNotification = true;
+
+  // Used to simulate network disconnection in the Inspector
+  bool m_simulatedDisconnection = false;
+  QNetworkInformation::Reachability m_currentReachability =
+      QNetworkInformation::Reachability::Online;
 };
 
 #endif  // NETWORKWATCHER_H


### PR DESCRIPTION
## Description

This PR does 2 things:
1. Check for internet connection upon activation. This is the backend code only, [frontend](https://mozilla-hub.atlassian.net/browse/VPN-3711) will be completed in a later sprint
2. Add inspector command force_connection_down to mock network connection being down.

Please note that functional tests cannot be added until the front end work is done.

## Reference

    https://mozilla-hub.atlassian.net/browse/VPN-5994
    https://mozilla-hub.atlassian.net/browse/VPN-4987


## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
