### PR TITLE
VPN-3511 Remove: GetTransportType Code

### DIFF
--- a/src/networkwatcher.cpp
+++ b/src/networkwatcher.cpp
@@ -5,6 +5,7 @@
 #include "networkwatcher.h"
 
 #include <QMetaEnum>
+#include <QNetworkInformation>
 
 #include "controller.h"
 #include "leakdetector.h"
@@ -168,9 +169,6 @@ void NetworkWatcher::notificationClicked(NotificationHandler::Message message) {
   }
 }
 
-QString NetworkWatcher::getCurrentTransport() {
-  auto type = m_impl->getTransportType();
-  QMetaEnum metaEnum = QMetaEnum::fromType<NetworkWatcherImpl::TransportType>();
-  return QString(metaEnum.valueToKey(type))
-      .remove("TransportType_", Qt::CaseSensitive);
+QNetworkInformation::Reachability NetworkWatcher::getReachability() {
+  return QNetworkInformation::instance()->reachability();
 }

--- a/src/networkwatcher.h
+++ b/src/networkwatcher.h
@@ -7,6 +7,7 @@
 
 #include <QElapsedTimer>
 #include <QMap>
+#include <QNetworkInformation>
 
 #include "notificationhandler.h"
 
@@ -26,7 +27,8 @@ class NetworkWatcher final : public QObject {
   // public for the inspector.
   void unsecuredNetwork(const QString& networkName, const QString& networkId);
 
-  QString getCurrentTransport();
+  // QString getCurrentTransport();
+  QNetworkInformation::Reachability getReachability();
 
  signals:
   void networkChange();

--- a/src/networkwatcher.h
+++ b/src/networkwatcher.h
@@ -27,7 +27,6 @@ class NetworkWatcher final : public QObject {
   // public for the inspector.
   void unsecuredNetwork(const QString& networkName, const QString& networkId);
 
-  // QString getCurrentTransport();
   QNetworkInformation::Reachability getReachability();
 
  signals:

--- a/src/networkwatcherimpl.h
+++ b/src/networkwatcherimpl.h
@@ -5,6 +5,7 @@
 #ifndef NETWORKWATCHERIMPL_H
 #define NETWORKWATCHERIMPL_H
 
+#include <QNetworkInformation>
 #include <QObject>
 
 class NetworkWatcherImpl : public QObject {
@@ -23,6 +24,7 @@ class NetworkWatcherImpl : public QObject {
 
   bool isActive() const { return m_active; }
 
+  ///@TODO should this be removed too?
   enum TransportType {
     TransportType_Unknown = 0,
     TransportType_Ethernet = 1,
@@ -34,7 +36,7 @@ class NetworkWatcherImpl : public QObject {
   Q_ENUM(TransportType);
 
   // Returns the current type of Network Connection
-  virtual TransportType getTransportType() = 0;
+  virtual QNetworkInformation::Reachability getReachability() = 0;
 
  signals:
   // Fires when the Device Connects to an unsecured Network
@@ -45,7 +47,7 @@ class NetworkWatcherImpl : public QObject {
   void networkChanged(QString newBSSID);
 
   // Fired when the Device changed the Type of Transport
-  void transportChanged(NetworkWatcherImpl::TransportType transportType);
+  //  void transportChanged(NetworkWatcherImpl::TransportType transportType);
 
  private:
   bool m_active = false;

--- a/src/networkwatcherimpl.h
+++ b/src/networkwatcherimpl.h
@@ -46,9 +46,6 @@ class NetworkWatcherImpl : public QObject {
   // too.
   void networkChanged(QString newBSSID);
 
-  // Fired when the Device changed the Type of Transport
-  //  void transportChanged(NetworkWatcherImpl::TransportType transportType);
-
  private:
   bool m_active = false;
 };

--- a/src/networkwatcherimpl.h
+++ b/src/networkwatcherimpl.h
@@ -24,7 +24,6 @@ class NetworkWatcherImpl : public QObject {
 
   bool isActive() const { return m_active; }
 
-  ///@TODO should this be removed too?
   enum TransportType {
     TransportType_Unknown = 0,
     TransportType_Ethernet = 1,

--- a/src/platforms/android/androidnetworkwatcher.cpp
+++ b/src/platforms/android/androidnetworkwatcher.cpp
@@ -16,9 +16,6 @@
 
 namespace {
 Logger logger("AndroidNetworkWatcher");
-
-// constexpr auto VPNNetworkWatcher_CLASS =
-//     "org/mozilla/firefox/vpn/qt/VPNNetworkWatcher";
 }  // namespace
 
 AndroidNetworkWatcher::AndroidNetworkWatcher(QObject* parent)

--- a/src/platforms/android/androidnetworkwatcher.cpp
+++ b/src/platforms/android/androidnetworkwatcher.cpp
@@ -19,7 +19,7 @@ Logger logger("AndroidNetworkWatcher");
 
 // constexpr auto VPNNetworkWatcher_CLASS =
 //     "org/mozilla/firefox/vpn/qt/VPNNetworkWatcher";
-// }  // namespace
+}  // namespace
 
 AndroidNetworkWatcher::AndroidNetworkWatcher(QObject* parent)
     : NetworkWatcherImpl(parent) {

--- a/src/platforms/android/androidnetworkwatcher.cpp
+++ b/src/platforms/android/androidnetworkwatcher.cpp
@@ -7,6 +7,7 @@
 #include <QApplication>
 #include <QJniEnvironment>
 #include <QJniObject>
+#include <QNetworkInformation>
 
 #include "leakdetector.h"
 #include "logger.h"
@@ -31,11 +32,6 @@ AndroidNetworkWatcher::~AndroidNetworkWatcher() {
 
 void AndroidNetworkWatcher::initialize() {}
 
-NetworkWatcherImpl::TransportType AndroidNetworkWatcher::getTransportType() {
-  QJniEnvironment env;
-  QJniObject activity = AndroidCommons::getActivity();
-  int type = QJniObject::callStaticMethod<int>(
-      VPNNetworkWatcher_CLASS, "getTransportType",
-      "(Landroid/content/Context;)I", activity.object());
-  return (NetworkWatcherImpl::TransportType)type;
-};
+QNetworkInformation::Reachability AndroidNetworkWatcher::getReachability() {
+  return QNetworkInformation::instance()->reachability();
+}

--- a/src/platforms/android/androidnetworkwatcher.cpp
+++ b/src/platforms/android/androidnetworkwatcher.cpp
@@ -17,9 +17,9 @@
 namespace {
 Logger logger("AndroidNetworkWatcher");
 
-constexpr auto VPNNetworkWatcher_CLASS =
-    "org/mozilla/firefox/vpn/qt/VPNNetworkWatcher";
-}  // namespace
+// constexpr auto VPNNetworkWatcher_CLASS =
+//     "org/mozilla/firefox/vpn/qt/VPNNetworkWatcher";
+// }  // namespace
 
 AndroidNetworkWatcher::AndroidNetworkWatcher(QObject* parent)
     : NetworkWatcherImpl(parent) {

--- a/src/platforms/android/androidnetworkwatcher.h
+++ b/src/platforms/android/androidnetworkwatcher.h
@@ -14,7 +14,7 @@ class AndroidNetworkWatcher final : public NetworkWatcherImpl {
 
   void initialize() override;
 
-  NetworkWatcherImpl::TransportType getTransportType() override;
+  QNetworkInformation::Reachability getReachability() override;
 };
 
 #endif  // ANDROIDNETWORKWATCHER_H

--- a/src/platforms/dummy/dummynetworkwatcher.h
+++ b/src/platforms/dummy/dummynetworkwatcher.h
@@ -14,9 +14,9 @@ class DummyNetworkWatcher final : public NetworkWatcherImpl {
 
   void initialize() override;
 
-  NetworkWatcherImpl::TransportType getTransportType() override {
-    return TransportType_Other;
-  };
+  QNetworkInformation::Reachability getReachability() override {
+    return QNetworkInformation::instance()->reachability();
+  }
 };
 
 #endif  // DUMMYNETWORKWATCHER_H

--- a/src/platforms/ios/iosnetworkwatcher.h
+++ b/src/platforms/ios/iosnetworkwatcher.h
@@ -15,7 +15,7 @@ class IOSNetworkWatcher : public NetworkWatcherImpl {
   ~IOSNetworkWatcher();
 
   void initialize() override;
-  NetworkWatcherImpl::TransportType getTransportType() override;
+  QNetworkInformation::Reachability getReachability() override;
 
  private:
   NetworkWatcherImpl::TransportType toTransportType(nw_path_t path);

--- a/src/platforms/ios/iosnetworkwatcher.mm
+++ b/src/platforms/ios/iosnetworkwatcher.mm
@@ -40,18 +40,9 @@ void IOSNetworkWatcher::initialize() {
           &IOSNetworkWatcher::controllerStateChanged);
 }
 
-NetworkWatcherImpl::TransportType IOSNetworkWatcher::getTransportType() {
-  if (MozillaVPN::instance()->controller()->state() != Controller::StateOn) {
-    // If we're not in stateON, the result from the Observer is fine, as
-    // the default-route-transport  is not the vpn-tunnel
-    return m_currentDefaultTransport;
+  QNetworkInformation::Reachability IOSNetworkWatcher::getReachability() {
+    return QNetworkInformation::instance()->reachability();
   }
-  if (m_observableConnection != nil) {
-    return m_currentVPNTransport;
-  }
-  // If we don't have an open tunnel-observer, m_currentVPNTransport is probably wrong.
-  return NetworkWatcherImpl::TransportType_Unknown;
-}
 
 NetworkWatcherImpl::TransportType IOSNetworkWatcher::toTransportType(nw_path_t path) {
   if (path == nil) {

--- a/src/platforms/linux/linuxnetworkwatcher.h
+++ b/src/platforms/linux/linuxnetworkwatcher.h
@@ -22,10 +22,9 @@ class LinuxNetworkWatcher final : public NetworkWatcherImpl {
 
   void start() override;
 
-  NetworkWatcherImpl::TransportType getTransportType() {
-    // TODO: Find out how to do that on linux generally. (VPN-2382)
-    return NetworkWatcherImpl::TransportType_Unknown;
-  };
+  QNetworkInformation::Reachability WindowsNetworkWatcher::getReachability() {
+    return QNetworkInformation::instance()->reachability();
+  }
 
  signals:
   void checkDevicesInThread();

--- a/src/platforms/linux/linuxnetworkwatcher.h
+++ b/src/platforms/linux/linuxnetworkwatcher.h
@@ -22,7 +22,7 @@ class LinuxNetworkWatcher final : public NetworkWatcherImpl {
 
   void start() override;
 
-  QNetworkInformation::Reachability WindowsNetworkWatcher::getReachability() {
+  QNetworkInformation::Reachability getReachability() {
     return QNetworkInformation::instance()->reachability();
   }
 

--- a/src/platforms/wasm/wasmnetworkwatcher.h
+++ b/src/platforms/wasm/wasmnetworkwatcher.h
@@ -20,7 +20,7 @@ class WasmNetworkWatcher final : public NetworkWatcherImpl {
 
   void start() override;
 
-  QNetworkInformation::Reachability WasmNetworkWatcher::getReachability()
+  QNetworkInformation::Reachability getReachability()
       override {
     return QNetworkInformation::instance()->reachability();
   }

--- a/src/platforms/wasm/wasmnetworkwatcher.h
+++ b/src/platforms/wasm/wasmnetworkwatcher.h
@@ -5,6 +5,8 @@
 #ifndef WASMNETWORKWATCHER_H
 #define WASMNETWORKWATCHER_H
 
+#include <QNetworkInformation>
+
 #include "networkwatcherimpl.h"
 
 class WasmNetworkWatcher final : public NetworkWatcherImpl {
@@ -18,9 +20,10 @@ class WasmNetworkWatcher final : public NetworkWatcherImpl {
 
   void start() override;
 
-  NetworkWatcherImpl::TransportType getTransportType() override {
-    return TransportType_Other;
-  };
+  QNetworkInformation::Reachability WasmNetworkWatcher::getReachability()
+      override {
+    return QNetworkInformation::instance()->reachability();
+  }
 };
 
 #endif  // WASMNETWORKWATCHER_H

--- a/src/platforms/wasm/wasmnetworkwatcher.h
+++ b/src/platforms/wasm/wasmnetworkwatcher.h
@@ -20,8 +20,7 @@ class WasmNetworkWatcher final : public NetworkWatcherImpl {
 
   void start() override;
 
-  QNetworkInformation::Reachability getReachability()
-      override {
+  QNetworkInformation::Reachability getReachability() override {
     return QNetworkInformation::instance()->reachability();
   }
 };

--- a/src/platforms/windows/windowsnetworkwatcher.cpp
+++ b/src/platforms/windows/windowsnetworkwatcher.cpp
@@ -4,6 +4,7 @@
 
 #include "windowsnetworkwatcher.h"
 
+#include <QNetworkInformation>
 #include <QScopeGuard>
 
 #include "leakdetector.h"
@@ -138,7 +139,6 @@ void WindowsNetworkWatcher::processWlan(PWLAN_NOTIFICATION_DATA data) {
   emit unsecuredNetwork(ssid, bssid);
 }
 
-NetworkWatcherImpl::TransportType WindowsNetworkWatcher::getTransportType() {
-  // TODO: Implement this once we update to Qt6.3 (VPN-3511)
-  return TransportType_Other;
+QNetworkInformation::Reachability WindowsNetworkWatcher::getReachability() {
+  return QNetworkInformation::instance()->reachability();
 }

--- a/src/platforms/windows/windowsnetworkwatcher.h
+++ b/src/platforms/windows/windowsnetworkwatcher.h
@@ -17,7 +17,7 @@ class WindowsNetworkWatcher final : public NetworkWatcherImpl {
 
   void initialize() override;
 
-  QNetworkInformation::Reachability NetworkWatcher::getReachability() override;
+  QNetworkInformation::Reachability getReachability() override;
 
  private:
   static void wlanCallback(PWLAN_NOTIFICATION_DATA data, PVOID context);

--- a/src/platforms/windows/windowsnetworkwatcher.h
+++ b/src/platforms/windows/windowsnetworkwatcher.h
@@ -17,7 +17,7 @@ class WindowsNetworkWatcher final : public NetworkWatcherImpl {
 
   void initialize() override;
 
-  NetworkWatcherImpl::TransportType getTransportType() override;
+  QNetworkInformation::Reachability NetworkWatcher::getReachability() override;
 
  private:
   static void wlanCallback(PWLAN_NOTIFICATION_DATA data, PVOID context);

--- a/src/telemetry.cpp
+++ b/src/telemetry.cpp
@@ -124,18 +124,6 @@ void Telemetry::initialize() {
       controller, &Controller::handshakeFailed, this,
       [](const QString& publicKey) {
         logger.info() << "Send a handshake failure event";
-
-        //            // Get reachability status
-        //            QNetworkInformation::Reachability reachabilityStatus =
-        //            networkWatcher->getReachability();
-        //            // Convert to QVariant
-        //            QVariant variantValue =
-        //            QVariant::fromValue(static_cast<int>(reachabilityStatus));
-        //            // Set the reachability status in the extra
-        //            extra._transport = variantValue;
-        //            // Record the data
-        //            mozilla::glean::sample::connectivity_handshake_timeout.record(extra);
-
         mozilla::glean::sample::connectivity_handshake_timeout.record(
             mozilla::glean::sample::ConnectivityHandshakeTimeoutExtra{
                 ._server = publicKey,

--- a/src/telemetry.cpp
+++ b/src/telemetry.cpp
@@ -120,17 +120,29 @@ void Telemetry::initialize() {
           this, &Telemetry::onDaemonStatus);
 #endif
 
-  connect(controller, &Controller::handshakeFailed, this,
-          [](const QString& publicKey) {
-            logger.info() << "Send a handshake failure event";
+  connect(
+      controller, &Controller::handshakeFailed, this,
+      [](const QString& publicKey) {
+        logger.info() << "Send a handshake failure event";
 
-            mozilla::glean::sample::connectivity_handshake_timeout.record(
-                mozilla::glean::sample::ConnectivityHandshakeTimeoutExtra{
-                    ._server = publicKey,
-                    ._transport = MozillaVPN::instance()
-                                      ->networkWatcher()
-                                      ->getCurrentTransport()});
-          });
+        //            // Get reachability status
+        //            QNetworkInformation::Reachability reachabilityStatus =
+        //            networkWatcher->getReachability();
+        //            // Convert to QVariant
+        //            QVariant variantValue =
+        //            QVariant::fromValue(static_cast<int>(reachabilityStatus));
+        //            // Set the reachability status in the extra
+        //            extra._transport = variantValue;
+        //            // Record the data
+        //            mozilla::glean::sample::connectivity_handshake_timeout.record(extra);
+
+        mozilla::glean::sample::connectivity_handshake_timeout.record(
+            mozilla::glean::sample::ConnectivityHandshakeTimeoutExtra{
+                ._server = publicKey,
+                ._transport = QVariant::fromValue(MozillaVPN::instance()
+                                                      ->networkWatcher()
+                                                      ->getReachability())});
+      });
 
   connect(controller, &Controller::stateChanged, this, [this]() {
     MozillaVPN* vpn = MozillaVPN::instance();
@@ -258,7 +270,8 @@ void Telemetry::connectionStabilityEvent() {
           ._loss = QString::number(vpn->connectionHealth()->loss()),
           ._server = vpn->controller()->currentServer().exitServerPublicKey(),
           ._stddev = QString::number(vpn->connectionHealth()->stddev()),
-          ._transport = vpn->networkWatcher()->getCurrentTransport()});
+          ._transport =
+              QVariant::fromValue(vpn->networkWatcher()->getReachability())});
 }
 
 void Telemetry::vpnSessionPingTimeout() {

--- a/src/telemetry/metrics.yaml
+++ b/src/telemetry/metrics.yaml
@@ -1112,7 +1112,7 @@ sample:
         type: string
       transport:
         description: The Host network type (i.e wifi or 4g). Possible values are Unknown, Disconnected, Local, Site, Online
-        type: QNetworkInformation::Reachability
+        type: string
 
   connectivity_stable:
     type: event
@@ -1148,8 +1148,10 @@ sample:
         description: Standard deviation of the ping responses
         type: string
       transport:
-        description: The Host network type (i.e wifi or 4g). Possible values are Unknown, Disconnected, Local, Site, Online
-        type: QNetworkInformation::Reachability
+        description: |
+             The Host network type (i.e wifi or 4g). 
+             Possible values are Unknown, Disconnected, Local, Site, Online
+        type: string
 
   server_unavailable_error:
     type: event

--- a/src/telemetry/metrics.yaml
+++ b/src/telemetry/metrics.yaml
@@ -1111,8 +1111,8 @@ sample:
           loss, stddev.
         type: string
       transport:
-        description: The Host network type (i.e wifi or 4g)
-        type: string
+        description: The Host network type (i.e wifi or 4g). Possible values are Unknown, Disconnected, Local, Site, Online
+        type: QNetworkInformation::Reachability
 
   connectivity_stable:
     type: event
@@ -1148,8 +1148,8 @@ sample:
         description: Standard deviation of the ping responses
         type: string
       transport:
-        description: The Host network type (i.e wifi or 4g)
-        type: string
+        description: The Host network type (i.e wifi or 4g). Possible values are Unknown, Disconnected, Local, Site, Online
+        type: QNetworkInformation::Reachability
 
   server_unavailable_error:
     type: event


### PR DESCRIPTION
## Description

Remove `GetTransportTypeCode` and replace with `getReachability()` instead. GetTransportTypeCode became obsolete with Qt 6.3.

## Reference

    https://mozilla-hub.atlassian.net/browse/VPN-3511

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
