### PR TITLE
VPN-5547: Implement subscription management telemetry

### DIFF
--- a/nebula/ui/components/MZUserProfile.qml
+++ b/nebula/ui/components/MZUserProfile.qml
@@ -91,7 +91,6 @@ MZClickableRow {
 
         Rectangle {
             id: iconButton
-            objectName: _objNameBase + "-manageAccountButton"
             Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
             Layout.preferredHeight: MZTheme.theme.rowHeight
             Layout.preferredWidth: MZTheme.theme.rowHeight

--- a/src/frontend/navigator.cpp
+++ b/src/frontend/navigator.cpp
@@ -186,6 +186,8 @@ void Navigator::requestScreenFromBottomBar(
       // Make sure the screen has a view (and it has been added to the layers
       // via Navigator::addView(), and that view has a non-empty
       // "telemetryScreenId" property
+      // TODO in VPN-6039 - support screens as well (not just views on top of
+      // screens)
       if (layers.length() < 1 || layers.last()
                                      .m_layer->property("telemetryScreenId")
                                      .toString()

--- a/src/frontend/navigator.cpp
+++ b/src/frontend/navigator.cpp
@@ -206,13 +206,13 @@ void Navigator::requestScreenFromBottomBar(
           break;
         case MozillaVPN::ScreenMessaging:
           mozilla::glean::interaction::messages_selected.record(
-              mozilla::glean::interaction::HomeSelectedExtra{
+              mozilla::glean::interaction::MessagesSelectedExtra{
                   ._screen = telemetryScreenId,
               });
           break;
         case MozillaVPN::ScreenSettings:
           mozilla::glean::interaction::settings_selected.record(
-              mozilla::glean::interaction::HomeSelectedExtra{
+              mozilla::glean::interaction::SettingsSelectedExtra{
                   ._screen = telemetryScreenId,
               });
           break;

--- a/src/frontend/navigator.cpp
+++ b/src/frontend/navigator.cpp
@@ -189,8 +189,9 @@ void Navigator::requestScreenFromBottomBar(
       if (layers.length() < 1 || layers.last()
                                      .m_layer->property("telemetryScreenId")
                                      .toString()
-                                     .isEmpty())
+                                     .isEmpty()) {
         break;
+      }
 
       QString telemetryScreenId =
           layers.last().m_layer->property("telemetryScreenId").toString();

--- a/src/frontend/navigator.cpp
+++ b/src/frontend/navigator.cpp
@@ -183,20 +183,17 @@ void Navigator::requestScreenFromBottomBar(
     if (screen.m_screen == m_currentScreen) {
       auto layers = screen.m_layers;
 
+      QString telemetryScreenId =
+          layers.last().m_layer->property("telemetryScreenId").toString();
+
       // Make sure the screen has a view (and it has been added to the layers
       // via Navigator::addView(), and that view has a non-empty
       // "telemetryScreenId" property
       // TODO in VPN-6039 - support screens as well (not just views on top of
       // screens)
-      if (layers.length() < 1 || layers.last()
-                                     .m_layer->property("telemetryScreenId")
-                                     .toString()
-                                     .isEmpty()) {
+      if (layers.length() < 1 || telemetryScreenId.isEmpty()) {
         break;
       }
-
-      QString telemetryScreenId =
-          layers.last().m_layer->property("telemetryScreenId").toString();
 
       // Record telemetry based on which screen was requested (aka which navbar
       // button pressed)
@@ -218,6 +215,10 @@ void Navigator::requestScreenFromBottomBar(
               mozilla::glean::interaction::SettingsSelectedExtra{
                   ._screen = telemetryScreenId,
               });
+          break;
+        default:
+          logger.warning() << "Requested screen" << requestedScreen
+                           << "is not a screen from the navbar";
           break;
       }
     }

--- a/src/frontend/navigator.cpp
+++ b/src/frontend/navigator.cpp
@@ -168,10 +168,57 @@ void Navigator::computeComponent() {
 void Navigator::requestScreenFromBottomBar(
     int requestedScreen, Navigator::LoadingFlags loadingFlags) {
   // Exists so we can add glean metric for screen changes only from bottom bar
+  // "bar_button" extra key denotes destination screen
   mozilla::glean::sample::bottom_navigation_bar_click.record(
       mozilla::glean::sample::BottomNavigationBarClickExtra{
           ._barButton = QVariant::fromValue(
               static_cast<MozillaVPN::CustomScreen>(requestedScreen))});
+
+  // Record navbar button interaction telemetry with "screen" extra key which
+  // denotes the source view
+  // This is done by finding the screen we are currently on, and getting the
+  // "telemetryScreenId" QML property of the top (layers.last()) layer of this
+  // screens stack view, which would be the view currently being displayed
+  for (ScreenData& screen : s_screens) {
+    if (screen.m_screen == m_currentScreen) {
+      auto layers = screen.m_layers;
+
+      // Make sure the screen has a view (and it has been added to the layers
+      // via Navigator::addView(), and that view has a non-empty
+      // "telemetryScreenId" property
+      if (layers.length() < 1 || layers.last()
+                                     .m_layer->property("telemetryScreenId")
+                                     .toString()
+                                     .isEmpty())
+        break;
+
+      QString telemetryScreenId =
+          layers.last().m_layer->property("telemetryScreenId").toString();
+
+      // Record telemetry based on which screen was requested (aka which navbar
+      // button pressed)
+      switch (requestedScreen) {
+        case MozillaVPN::ScreenHome:
+          mozilla::glean::interaction::home_selected.record(
+              mozilla::glean::interaction::HomeSelectedExtra{
+                  ._screen = telemetryScreenId,
+              });
+          break;
+        case MozillaVPN::ScreenMessaging:
+          mozilla::glean::interaction::messages_selected.record(
+              mozilla::glean::interaction::HomeSelectedExtra{
+                  ._screen = telemetryScreenId,
+              });
+          break;
+        case MozillaVPN::ScreenSettings:
+          mozilla::glean::interaction::settings_selected.record(
+              mozilla::glean::interaction::HomeSelectedExtra{
+                  ._screen = telemetryScreenId,
+              });
+          break;
+      }
+    }
+  }
 
   requestScreen(requestedScreen, loadingFlags);
 }

--- a/src/telemetry/impression_metrics.yaml
+++ b/src/telemetry/impression_metrics.yaml
@@ -522,7 +522,7 @@ impression:
     bugs:
       - https://mozilla-hub.atlassian.net/browse/VPN-5547
     data_reviews:
-      - https://github.com/mozilla-mobile/mozilla-vpn-client/pull/8838#issuecomment-1862135964
+      - https://github.com/mozilla-mobile/mozilla-vpn-client/pull/8838#pullrequestreview-1789303235
     data_sensitivity:
       - interaction
     notification_emails:

--- a/src/telemetry/impression_metrics.yaml
+++ b/src/telemetry/impression_metrics.yaml
@@ -522,7 +522,7 @@ impression:
     bugs:
       - https://mozilla-hub.atlassian.net/browse/VPN-5547
     data_reviews:
-      - TODO
+      - https://github.com/mozilla-mobile/mozilla-vpn-client/pull/8838#issuecomment-1862135964
     data_sensitivity:
       - interaction
     notification_emails:

--- a/src/telemetry/impression_metrics.yaml
+++ b/src/telemetry/impression_metrics.yaml
@@ -511,4 +511,22 @@ impression:
       - gela@mozilla.com
       - vpn-telemetry@mozilla.com
     expires: never
-    extra_keys: *impression_extra_keys  
+    extra_keys: *impression_extra_keys
+  account_screen:
+    type: event
+    lifetime: ping
+    send_in_pings:
+      - main
+    description: |
+      The user has viewed the subscription management screen
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/VPN-5547
+    data_reviews:
+      - TODO
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - mlichtenstein@mozilla.com
+      - vpn-telemetry@mozilla.com
+    expires: never
+    extra_keys: *impression_extra_keys   

--- a/src/telemetry/interaction_metrics.yaml
+++ b/src/telemetry/interaction_metrics.yaml
@@ -1086,4 +1086,40 @@ interaction:
       - gela@mozilla.com
       - vpn-telemetry@mozilla.com
     expires: never
-    extra_keys: *interaction_extra_keys  
+    extra_keys: *interaction_extra_keys 
+  edit_selected:
+    type: event
+    lifetime: ping
+    send_in_pings:
+      - main
+    description: |
+      The user has clicked the `edit account` button
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/VPN-5547
+    data_reviews:
+      - TODO
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - vpn-telemetry@mozilla.com
+      - mlichtenstein@mozilla.com
+    expires: never 
+    extra_keys: *interaction_extra_keys
+  manage_subscription_selected:
+    type: event
+    lifetime: ping
+    send_in_pings:
+      - main
+    description: |
+      The user has clicked the “manage subscription” button from the subscription management view.
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/VPN-5547
+    data_reviews:
+      - TODO
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - mlichtenstein@mozilla.com
+      - vpn-telemetry@mozilla.com
+    expires: never
+    extra_keys: *interaction_extra_keys

--- a/src/telemetry/interaction_metrics.yaml
+++ b/src/telemetry/interaction_metrics.yaml
@@ -1097,7 +1097,7 @@ interaction:
     bugs:
       - https://mozilla-hub.atlassian.net/browse/VPN-5547
     data_reviews:
-      - https://github.com/mozilla-mobile/mozilla-vpn-client/pull/8838#issuecomment-1862135964
+      - https://github.com/mozilla-mobile/mozilla-vpn-client/pull/8838#pullrequestreview-1789303235
     data_sensitivity:
       - interaction
     notification_emails:
@@ -1115,7 +1115,7 @@ interaction:
     bugs:
       - https://mozilla-hub.atlassian.net/browse/VPN-5547
     data_reviews:
-      - https://github.com/mozilla-mobile/mozilla-vpn-client/pull/8838#issuecomment-1862135964
+      - https://github.com/mozilla-mobile/mozilla-vpn-client/pull/8838#pullrequestreview-1789303235
     data_sensitivity:
       - interaction
     notification_emails:
@@ -1133,7 +1133,7 @@ interaction:
     bugs:
       - https://mozilla-hub.atlassian.net/browse/VPN-5547
     data_reviews:
-      - https://github.com/mozilla-mobile/mozilla-vpn-client/pull/8838#issuecomment-1862135964
+      - https://github.com/mozilla-mobile/mozilla-vpn-client/pull/8838#pullrequestreview-1789303235
     data_sensitivity:
       - interaction
     notification_emails:

--- a/src/telemetry/interaction_metrics.yaml
+++ b/src/telemetry/interaction_metrics.yaml
@@ -1123,3 +1123,21 @@ interaction:
       - vpn-telemetry@mozilla.com
     expires: never
     extra_keys: *interaction_extra_keys
+  change_plan_selected:
+    type: event
+    lifetime: ping
+    send_in_pings:
+      - main
+    description: |
+      The user has clicked the “change plan” button from the subscription management view (monthly web plan).
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/VPN-5547
+    data_reviews:
+      - TODO
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - mlichtenstein@mozilla.com
+      - vpn-telemetry@mozilla.com
+    expires: never
+    extra_keys: *interaction_extra_keys

--- a/src/telemetry/interaction_metrics.yaml
+++ b/src/telemetry/interaction_metrics.yaml
@@ -1093,11 +1093,11 @@ interaction:
     send_in_pings:
       - main
     description: |
-      The user has clicked the `edit account` button
+      The user has clicked the "edit account" button
     bugs:
       - https://mozilla-hub.atlassian.net/browse/VPN-5547
     data_reviews:
-      - TODO
+      - https://github.com/mozilla-mobile/mozilla-vpn-client/pull/8838#issuecomment-1862135964
     data_sensitivity:
       - interaction
     notification_emails:
@@ -1111,11 +1111,11 @@ interaction:
     send_in_pings:
       - main
     description: |
-      The user has clicked the “manage subscription” button from the subscription management view.
+      The user has clicked the “manage subscription” button from the subscription management view
     bugs:
       - https://mozilla-hub.atlassian.net/browse/VPN-5547
     data_reviews:
-      - TODO
+      - https://github.com/mozilla-mobile/mozilla-vpn-client/pull/8838#issuecomment-1862135964
     data_sensitivity:
       - interaction
     notification_emails:
@@ -1129,11 +1129,11 @@ interaction:
     send_in_pings:
       - main
     description: |
-      The user has clicked the “change plan” button from the subscription management view (monthly web plan).
+      The user has clicked the “change plan” button from the subscription management view (monthly web plan)
     bugs:
       - https://mozilla-hub.atlassian.net/browse/VPN-5547
     data_reviews:
-      - TODO
+      - https://github.com/mozilla-mobile/mozilla-vpn-client/pull/8838#issuecomment-1862135964
     data_sensitivity:
       - interaction
     notification_emails:

--- a/src/telemetry/metrics.yaml
+++ b/src/telemetry/metrics.yaml
@@ -811,6 +811,24 @@ sample:
       - vpn-telemetry@mozilla.com
     expires: never
 
+  manage_account_clicked:
+    type: event
+    lifetime: ping
+    send_in_pings:
+      - main
+    description: |
+      The user has clicked the `manage account` button
+    bugs:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1711123
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1711123#c1
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - amarchesini@mozilla.com
+      - vpn-telemetry@mozilla.com
+    expires: never
+
   max_device_reached:
     type: event
     lifetime: ping

--- a/src/telemetry/metrics.yaml
+++ b/src/telemetry/metrics.yaml
@@ -811,24 +811,6 @@ sample:
       - vpn-telemetry@mozilla.com
     expires: never
 
-  manage_account_clicked:
-    type: event
-    lifetime: ping
-    send_in_pings:
-      - main
-    description: |
-      The user has clicked the `manage account` button
-    bugs:
-      - https://bugzilla.mozilla.org/show_bug.cgi?id=1711123
-    data_reviews:
-      - https://bugzilla.mozilla.org/show_bug.cgi?id=1711123#c1
-    data_sensitivity:
-      - interaction
-    notification_emails:
-      - amarchesini@mozilla.com
-      - vpn-telemetry@mozilla.com
-    expires: never
-
   max_device_reached:
     type: event
     lifetime: ping
@@ -1333,25 +1315,6 @@ sample:
           The name of the profile flow state. The list of states can be found in
           `profileflow.h`.
         type: string
-
-  manage_subscription_clicked:
-    type: event
-    lifetime: ping
-    send_in_pings:
-      - main
-    description: |
-      The user has clicked the “manage subscription” button from the
-      profile view.
-    bugs:
-      - https://github.com/mozilla-mobile/mozilla-vpn-client/issues/3627
-    data_reviews:
-      - https://bugzilla.mozilla.org/show_bug.cgi?id=1774568
-    data_sensitivity:
-      - interaction
-    notification_emails:
-      - amarchesini@mozilla.com
-      - vpn-telemetry@mozilla.com
-    expires: never
 
   delete_account_requested:
     type: event

--- a/src/ui/screens/settings/ViewSubscriptionManagement/SubscriptionManagementItem.qml
+++ b/src/ui/screens/settings/ViewSubscriptionManagement/SubscriptionManagementItem.qml
@@ -14,6 +14,8 @@ ColumnLayout {
     id: root
     objectName: _objectName + "-parent"
 
+    property string telemetryScreenId
+
     spacing: 0
 
     states: [
@@ -178,7 +180,12 @@ ColumnLayout {
         MZButton {
             objectName: _objectName + "-upgradeToAnnualSub-upgradeButton"
             
-            onClicked: MZUrlOpener.openUrlLabel("upgradeToAnnualUrl");
+            onClicked: {
+                Glean.interaction.changePlanSelected.record({
+                    screen: root.telemetryScreenId,
+                });
+                MZUrlOpener.openUrlLabel("upgradeToAnnualUrl");
+            }
             text: MZI18n.SubscriptionManagementUpgradeToAnnualButton// "Change plan"
             fontSize: MZTheme.theme.fontSizeSmall
             Layout.alignment: Qt.AlignRight | Qt.AlignVCenter

--- a/src/ui/screens/settings/ViewSubscriptionManagement/ViewSubscriptionManagement.qml
+++ b/src/ui/screens/settings/ViewSubscriptionManagement/ViewSubscriptionManagement.qml
@@ -73,7 +73,9 @@ MZViewBase {
                 delegate: Loader {
                     objectName: _objectName
                     Layout.fillWidth: true
-                    source: "qrc:/ui/screens/settings/ViewSubscriptionManagement/SubscriptionManagementItem.qml"
+                    sourceComponent: SubscriptionManagementItem {
+                        telemetryScreenId: vpnFlickable.telemetryScreenId
+                    }
                 }
             }
 

--- a/src/ui/screens/settings/ViewSubscriptionManagement/ViewSubscriptionManagement.qml
+++ b/src/ui/screens/settings/ViewSubscriptionManagement/ViewSubscriptionManagement.qml
@@ -14,6 +14,8 @@ MZViewBase {
     id: vpnFlickable
     objectName: "subscriptionManagmentView"
 
+    property string telemetryScreenId: isAnnualUpgradeAvailable() && VPNSubscriptionData.type === VPNSubscriptionData.SubscriptionWeb ? "account_with_change_plan" : "account"
+
     Component.onDestruction: () => VPNProfileFlow.reset()
 
     _menuTitle: MZI18n.SubscriptionManagementMenuTitle
@@ -34,12 +36,13 @@ MZViewBase {
             Layout.leftMargin: MZTheme.theme.windowMargin / 2
             Layout.rightMargin: MZTheme.theme.windowMargin / 2
 
-            objectName: "subscriptionUserProfile"
             _objNameBase: "subscriptionUserProfile"
 
             _iconSource: "qrc:/nebula/resources/open-in-new.svg"
             _buttonOnClicked: () => {
-                Glean.sample.manageAccountClicked.record();
+                Glean.interaction.editSelected.record({
+                    screen: vpnFlickable.telemetryScreenId,
+                });
                 MZUrlOpener.openUrlLabel("account");
             }
         }
@@ -138,7 +141,9 @@ MZViewBase {
                 MZUrlOpener.openUrlLabel("account");
         }
 
-        Glean.sample.manageSubscriptionClicked.record();
+        Glean.interaction.manageSubscriptionSelected.record({
+            screen: vpnFlickable.telemetryScreenId,
+        });
     }
 
     function isAnnualUpgradeAvailable() {
@@ -299,5 +304,9 @@ MZViewBase {
 
     Component.onCompleted: {
         populateListModels();
+        MZNavigator.addView(VPN.ScreenSettings, vpnFlickable)
+        Glean.impression.accountScreen.record({
+            screen: telemetryScreenId,
+        });
     }
 }

--- a/tests/functional/queries.js
+++ b/tests/functional/queries.js
@@ -398,8 +398,6 @@ const screenSettings = {
     PAYMENT_METHOD_LABEL: new QmlQueryComposer(
         '//subscriptionItem/subscriptionItem-payment/subscriptionItem-payment-parent/subscriptionItem-payment-container/subscriptionItem-payment-paymentMethod/paymentLabel'),
 
-    SUBSCRIPTION_USER_PROFILE:
-        new QmlQueryComposer('//subscriptionUserProfile'),
     SUBSCRIPTION_USER_PROFILE_DISPLAY_NAME:
         new QmlQueryComposer('//subscriptionUserProfile-displayName'),
     SUBSCRIPTION_USER_PROFILE_EMAIL_ADDRESS:

--- a/tests/functional/queries.js
+++ b/tests/functional/queries.js
@@ -376,6 +376,8 @@ const screenSettings = {
     ACCOUNT_DELETION: new QmlQueryComposer('//accountDeletionButton'),
     ANNUAL_UPGRADE: new QmlQueryComposer(
         '//subscriptionItem/subscriptionItem-plan/subscriptionItem-plan-parent/subscriptionItem-plan-upgradeToAnnualSub-layout'),
+    ANNUAL_UPGRADE_BUTTON: new QmlQueryComposer(
+        '//subscriptionItem/subscriptionItem-plan/subscriptionItem-plan-parent/subscriptionItem-plan-upgradeToAnnualSub-layout/subscriptionItem-plan-upgradeToAnnualSub-upgradeButton'),
     PLAN: new QmlQueryComposer('//subscriptionItem-plan-valueText'),
     SCREEN: new QmlQueryComposer('//subscriptionManagmentView'),
     FLICKABLE: new QmlQueryComposer('//subscriptionManagmentView-flickable'),

--- a/tests/functional/queries.js
+++ b/tests/functional/queries.js
@@ -270,14 +270,11 @@ const screenSettings = {
   APP_PREFERENCES: new QmlQueryComposer('//settingsPreferences'),
   TIPS_AND_TRICKS: new QmlQueryComposer('//settingsTipsAndTricks'),
   USER_PROFILE:
-      new QmlQueryComposer('//settingsUserProfile-manageAccountButton'),
+      new QmlQueryComposer('//settingsUserProfile'),
   USER_PROFILE_DISPLAY_NAME:
       new QmlQueryComposer('//settingsUserProfile-displayName'),
   USER_PROFILE_EMAIL_ADDRESS:
       new QmlQueryComposer('//settingsUserProfile-emailAddress'),
-
-  SUBSCRIPTION_MANAGMENT_VIEW:
-      new QmlQueryComposer('//subscriptionManagmentView'),
 
   privacyView: {
     BLOCK_ADS: new QmlQueryComposer('//blockAds'),
@@ -380,7 +377,8 @@ const screenSettings = {
     ANNUAL_UPGRADE: new QmlQueryComposer(
         '//subscriptionItem/subscriptionItem-plan/subscriptionItem-plan-parent/subscriptionItem-plan-upgradeToAnnualSub-layout'),
     PLAN: new QmlQueryComposer('//subscriptionItem-plan-valueText'),
-    SCREEN: new QmlQueryComposer('//subscriptionManagmentView-flickable'),
+    SCREEN: new QmlQueryComposer('//subscriptionManagmentView'),
+    FLICKABLE: new QmlQueryComposer('//subscriptionManagmentView-flickable'),
     STATUS_PILL: new QmlQueryComposer('//subscriptionItem-status-pill'),
 
     ACTIVATED: new QmlQueryComposer(

--- a/tests/functional/testAddons.js
+++ b/tests/functional/testAddons.js
@@ -368,7 +368,7 @@ describe('Addons', function() {
     afterEach(() => setNextSubscriptionStarted(this.ctx));
 
     testCases.forEach(([createdAtTimestamp, expectedTimeFormat, shouldBeAvailable, testCase]) => {
-      it.only(`message display is correct when subscription started at ${testCase}`, async () => {
+      it(`message display is correct when subscription started at ${testCase}`, async () => {
         await vpn.resetAddons('prod');
 
         //Load messages

--- a/tests/functional/testAddons.js
+++ b/tests/functional/testAddons.js
@@ -255,7 +255,7 @@ describe('Addons', function() {
            await vpn.waitForQuery(queries.screenSettings.STACKVIEW.ready());
 
            await vpn.waitForQuery(
-               queries.screenSettings.SUBSCRIPTION_MANAGMENT_VIEW.visible());
+               queries.screenSettings.subscriptionView.SCREEN.visible());
 
            // TODO: Uncomment the assertion below once we re-enable
            // "Subscription expiring" message

--- a/tests/functional/testSubscription.js
+++ b/tests/functional/testSubscription.js
@@ -1568,34 +1568,6 @@ describe('Subscription view', function() {
           const manageSubscriptionSelectedEventsExtras = manageSubscriptionSelectedEvents[0].extra;
           assert.equal(subscriptionManagementScreenTelemetryId, manageSubscriptionSelectedEventsExtras.screen);
         });
-
-        it('homeSelected interaction event is recorded with correct screen', async () => {
-          //Click the home navbar button and record homeSelected telemetry
-          await vpn.waitForQueryAndClick(queries.navBar.HOME.visible());
-          const homeSelectedEvents = await vpn.gleanTestGetValue("interaction", "homeSelected", "main");
-          assert.equal(homeSelectedEvents.length, 1);
-          const homeSelectedEventsExtras = homeSelectedEvents[0].extra;
-          assert.equal(subscriptionManagementScreenTelemetryId, homeSelectedEventsExtras.screen);
-        });
-
-        it('messagesSelected interaction event is recorded with correct screen', async () => {
-          //Click the messages navbar button and record messagesSelected telemetry
-          await vpn.waitForQueryAndClick(queries.navBar.MESSAGES.visible());
-          const messagesSelectedEvents = await vpn.gleanTestGetValue("interaction", "messagesSelected", "main");
-          assert.equal(messagesSelectedEvents.length, 1);
-          const messagesSelectedEventsExtras = messagesSelectedEvents[0].extra;
-          assert.equal(subscriptionManagementScreenTelemetryId, messagesSelectedEventsExtras.screen);
-
-        });
-
-        it('settingsSelected interaction event is recorded with correct screen', async () => {
-          //Click the settings navbar button and record settingsSelected telemetry
-          await vpn.waitForQueryAndClick(queries.navBar.SETTINGS.visible());
-          const settingselectedEvents = await vpn.gleanTestGetValue("interaction", "settingsSelected", "main");
-          assert.equal(settingselectedEvents.length, 1);
-          const settingselectedEventsExtras = settingselectedEvents[0].extra;
-          assert.equal(subscriptionManagementScreenTelemetryId, settingselectedEventsExtras.screen);
-        });
       });
     });
   });

--- a/tests/functional/testSubscription.js
+++ b/tests/functional/testSubscription.js
@@ -421,7 +421,7 @@ describe('Subscription view', function() {
             .enabled());
 
     await vpn.waitForQuery(
-        queries.screenSettings.SUBSCRIPTION_MANAGMENT_VIEW.visible());
+        queries.screenSettings.subscriptionView.SCREEN.visible());
   });
 
   it('Authentication needed - totp', async () => {
@@ -498,7 +498,7 @@ describe('Subscription view', function() {
         queries.screenAuthenticationInApp.AUTH_TOTP_BUTTON.visible().enabled());
 
     await vpn.waitForQuery(
-        queries.screenSettings.SUBSCRIPTION_MANAGMENT_VIEW.visible());
+        queries.screenSettings.subscriptionView.SCREEN.visible());
   });
 
   it('Playing with the subscription view', async () => {
@@ -982,7 +982,7 @@ describe('Subscription view', function() {
       await vpn.waitForQuery(queries.screenSettings.STACKVIEW.ready());
 
       await vpn.waitForQuery(
-          queries.screenSettings.SUBSCRIPTION_MANAGMENT_VIEW.visible());
+          queries.screenSettings.subscriptionView.SCREEN.visible());
 
       if (data.subscription.expected.status) {
         assert.equal(
@@ -1090,7 +1090,7 @@ describe('Subscription view', function() {
             queries.screenSettings.subscriptionView
                 .SUBSCRIPTION_USER_PROFILE_BUTTON_SUB.visible());
         await vpn.scrollToQuery(
-            queries.screenSettings.subscriptionView.SCREEN,
+            queries.screenSettings.subscriptionView.FLICKABLE,
             queries.screenSettings.subscriptionView
                 .SUBSCRIPTION_USER_PROFILE_BUTTON_SUB.visible());
         await vpn.waitForQueryAndClick(
@@ -1144,7 +1144,7 @@ describe('Subscription view', function() {
         queries.screenSettings.USER_PROFILE.visible());
 
     await vpn.waitForQuery(
-        queries.screenSettings.SUBSCRIPTION_MANAGMENT_VIEW.visible());
+        queries.screenSettings.subscriptionView.SCREEN.visible());
 
     await vpn.waitForQuery(
         queries.screenSettings.subscriptionView.ACCOUNT_DELETION.hidden());
@@ -1153,7 +1153,7 @@ describe('Subscription view', function() {
         queries.screenSettings.subscriptionView.ACCOUNT_DELETION.visible());
 
     await vpn.scrollToQuery(
-        queries.screenSettings.subscriptionView.SCREEN,
+        queries.screenSettings.subscriptionView.FLICKABLE,
         queries.screenSettings.subscriptionView.ACCOUNT_DELETION.visible());
 
     await vpn.waitForQueryAndClick(
@@ -1273,7 +1273,7 @@ describe('Subscription view', function() {
         queries.screenSettings.USER_PROFILE.visible());
 
     await vpn.waitForQuery(
-        queries.screenSettings.SUBSCRIPTION_MANAGMENT_VIEW.visible());
+        queries.screenSettings.subscriptionView.SCREEN.visible());
 
     await vpn.waitForQuery(
         queries.screenSettings.subscriptionView.ACCOUNT_DELETION.hidden());
@@ -1282,7 +1282,7 @@ describe('Subscription view', function() {
         queries.screenSettings.subscriptionView.ACCOUNT_DELETION.visible());
 
     await vpn.scrollToQuery(
-        queries.screenSettings.subscriptionView.SCREEN,
+        queries.screenSettings.subscriptionView.FLICKABLE,
         queries.screenSettings.subscriptionView.ACCOUNT_DELETION.visible());
 
     await vpn.waitForQueryAndClick(
@@ -1391,13 +1391,12 @@ describe('Subscription view', function() {
         queries.screenInitialize.ALREADY_A_SUBSCRIBER_LINK.visible());
   });
 
-  async function clickSettingsIcon() {
+  async function openSubscriptionManagement() {
     await vpn.waitForQueryAndClick(queries.navBar.SETTINGS.visible());
     await vpn.waitForQuery(queries.global.SCREEN_LOADER.ready());
-  }
-  async function openSubscriptionManagement() {
     await vpn.waitForQueryAndClick(
         queries.screenSettings.USER_PROFILE.visible());
+    await vpn.waitForQuery(queries.screenSettings.subscriptionView.SCREEN.visible());
   }
 
   it('Shows annual upgrade UI based on billing interval and purchase type',
@@ -1425,7 +1424,6 @@ describe('Subscription view', function() {
          await vpn.flipFeatureOn('annualUpgrade');
        }
 
-       await clickSettingsIcon();
        await openSubscriptionManagement();
 
        await vpn.waitForQuery(
@@ -1456,7 +1454,6 @@ describe('Subscription view', function() {
          await vpn.flipFeatureOn('annualUpgrade');
        }
 
-       await clickSettingsIcon();
        await openSubscriptionManagement();
 
        await vpn.waitForQuery(
@@ -1486,10 +1483,81 @@ describe('Subscription view', function() {
              .body = SUBSCRIPTION_DETAILS;
        };
 
-       await clickSettingsIcon();
        await openSubscriptionManagement();
 
        await vpn.waitForQuery(
            queries.screenSettings.subscriptionView.ANNUAL_UPGRADE.hidden());
      });
+
+  describe('Subscription management telemetry tests', () => {
+
+      beforeEach(async () => {
+        await openSubscriptionManagement();
+      });
+
+    describe('Subscription management view events are recorded (annual plan)', () => {
+      const subscriptionManagementScreenTelemetryId = "account";
+
+      it('accountScreen impression event is recorded', async () => {
+
+        //Open the subscription management view and record accountScreen telemetry
+        const accountScreenEvents = await vpn.gleanTestGetValue("impression", "accountScreen", "main");
+        assert.equal(accountScreenEvents.length, 1);
+        const accountScreenEventExtras = accountScreenEvents[0].extra;
+        assert.equal(subscriptionManagementScreenTelemetryId, accountScreenEventExtras.screen);
+      });
+
+      it('editSelected interaction event is recorded', async () => {
+
+        //Click the user profile button and record editSelected telemetry
+        await vpn.waitForQueryAndClick(queries.screenSettings.subscriptionView.SUBSCRIPTION_USER_PROFILE_BUTTON_ACCOUNT.visible());
+        const editSelectedEvents = await vpn.gleanTestGetValue("interaction", "editSelected", "main");
+        assert.equal(editSelectedEvents.length, 1);
+        const editSelectedEventsExtras = editSelectedEvents[0].extra;
+        assert.equal(subscriptionManagementScreenTelemetryId, editSelectedEventsExtras.screen);
+      });
+
+      it('manageSubscriptionSelected interaction event is recorded', async () => {
+
+        //Click the manage subscription button and record manageSubscriptionSelected telemetry
+        await vpn.scrollToQuery(queries.screenSettings.subscriptionView.FLICKABLE, queries.screenSettings.subscriptionView.SUBSCRIPTION_USER_PROFILE_BUTTON_SUB.visible());
+        await vpn.waitForQueryAndClick(queries.screenSettings.subscriptionView.SUBSCRIPTION_USER_PROFILE_BUTTON_SUB.visible());
+        const manageSubscriptionSelectedEvents = await vpn.gleanTestGetValue("interaction", "manageSubscriptionSelected", "main");
+        assert.equal(manageSubscriptionSelectedEvents.length, 1);
+        const manageSubscriptionSelectedEventsExtras = manageSubscriptionSelectedEvents[0].extra;
+        assert.equal(subscriptionManagementScreenTelemetryId, manageSubscriptionSelectedEventsExtras.screen);
+      });
+
+      it('homeSelected interaction event is recorded with correct screen', async () => {
+
+        //Click the home navbar button and record homeSelected telemetry
+        await vpn.waitForQueryAndClick(queries.navBar.HOME.visible());
+        const homeSelectedEvents = await vpn.gleanTestGetValue("interaction", "homeSelected", "main");
+        assert.equal(homeSelectedEvents.length, 1);
+        const homeSelectedEventsExtras = homeSelectedEvents[0].extra;
+        assert.equal(subscriptionManagementScreenTelemetryId, homeSelectedEventsExtras.screen);
+      });
+
+      it('messagesSelected interaction event is recorded with correct screen', async () => {
+
+        //Click the messages navbar button and record homeSelected telemetry
+        await vpn.waitForQueryAndClick(queries.navBar.MESSAGES.visible());
+        const messagesSelectedEvents = await vpn.gleanTestGetValue("interaction", "messagesSelected", "main");
+        assert.equal(messagesSelectedEvents.length, 1);
+        const messagesSelectedEventsExtras = messagesSelectedEvents[0].extra;
+        assert.equal(subscriptionManagementScreenTelemetryId, messagesSelectedEventsExtras.screen);
+
+      });
+
+      it('settingsSelected interaction event is recorded with correct screen', async () => {
+
+        //Click the settings navbar button and record homeSelected telemetry
+        await vpn.waitForQueryAndClick(queries.navBar.SETTINGS.visible());
+        const settingselectedEvents = await vpn.gleanTestGetValue("interaction", "settingsSelected", "main");
+        assert.equal(settingselectedEvents.length, 1);
+        const settingselectedEventsExtras = settingselectedEvents[0].extra;
+        assert.equal(subscriptionManagementScreenTelemetryId, settingselectedEventsExtras.screen);
+      });
+    });
+  });
 });

--- a/tests/functional/testSubscription.js
+++ b/tests/functional/testSubscription.js
@@ -501,7 +501,7 @@ describe('Subscription view', function() {
         queries.screenSettings.subscriptionView.SCREEN.visible());
   });
 
-  it('Playing with the subscription view', async () => {
+  it.only('Playing with the subscription view', async () => {
     this.ctx.fxaLoginCallback = (req) => {
       this.ctx.fxaOverrideEndpoints.POSTs['/v1/account/login'].body = {
         sessionToken: 'session',
@@ -1066,7 +1066,7 @@ describe('Subscription view', function() {
       }
 
       await vpn.waitForQuery(queries.screenSettings.subscriptionView
-                                 .SUBSCRIPTION_USER_PROFILE.visible());
+                                 .SUBSCRIPTION_USER_PROFILE_BUTTON_ACCOUNT.visible());
       await vpn.waitForQuery(
           queries.screenSettings.subscriptionView
               .SUBSCRIPTION_USER_PROFILE_DISPLAY_NAME.visible()

--- a/tests/functional/testSubscription.js
+++ b/tests/functional/testSubscription.js
@@ -1490,13 +1490,15 @@ describe('Subscription view', function() {
      });
 
   describe('Subscription management telemetry tests', () => {
+    // No Glean on WASM.
+    if(vpn.runningOnWasm()) {
+      return;
+    }
 
     const testCases = [["annual plan", "account"], ["monthly plan", "account_with_change_plan"]];
 
     testCases.forEach(([testCase, subscriptionManagementScreenTelemetryId]) => {
-      
       describe(`Subscription management view events are recorded (${testCase})`, () => {
-
         const isMonthlyPlanTest = testCase === "monthly plan"
 
         //Check if we are testing the monthly plan so we can mock the guardian response
@@ -1530,7 +1532,6 @@ describe('Subscription view', function() {
        });
 
         it('accountScreen impression event is recorded', async () => {
-
           //Open the subscription management view and record accountScreen telemetry
           const accountScreenEvents = await vpn.gleanTestGetValue("impression", "accountScreen", "main");
           assert.equal(accountScreenEvents.length, 1);
@@ -1539,7 +1540,6 @@ describe('Subscription view', function() {
         });
 
         it('editSelected interaction event is recorded', async () => {
-
           //Click the user profile button and record editSelected telemetry
           await vpn.waitForQueryAndClick(queries.screenSettings.subscriptionView.SUBSCRIPTION_USER_PROFILE_BUTTON_ACCOUNT.visible());
           const editSelectedEvents = await vpn.gleanTestGetValue("interaction", "editSelected", "main");
@@ -1550,7 +1550,6 @@ describe('Subscription view', function() {
 
         if (isMonthlyPlanTest) {
           it('changePlanSelected interaction event is recorded with correct screen', async () => {
-
             //Click the change plan button and record changePlanSelected telemetry
             await vpn.waitForQueryAndClick(queries.screenSettings.subscriptionView.ANNUAL_UPGRADE_BUTTON.visible());
             const changePlanSelectedEvents = await vpn.gleanTestGetValue("interaction", "changePlanSelected", "main");
@@ -1561,7 +1560,6 @@ describe('Subscription view', function() {
         }
 
         it('manageSubscriptionSelected interaction event is recorded', async () => {
-
           //Click the manage subscription button and record manageSubscriptionSelected telemetry
           await vpn.scrollToQuery(queries.screenSettings.subscriptionView.FLICKABLE, queries.screenSettings.subscriptionView.SUBSCRIPTION_USER_PROFILE_BUTTON_SUB.visible());
           await vpn.waitForQueryAndClick(queries.screenSettings.subscriptionView.SUBSCRIPTION_USER_PROFILE_BUTTON_SUB.visible());
@@ -1572,7 +1570,6 @@ describe('Subscription view', function() {
         });
 
         it('homeSelected interaction event is recorded with correct screen', async () => {
-
           //Click the home navbar button and record homeSelected telemetry
           await vpn.waitForQueryAndClick(queries.navBar.HOME.visible());
           const homeSelectedEvents = await vpn.gleanTestGetValue("interaction", "homeSelected", "main");
@@ -1582,7 +1579,6 @@ describe('Subscription view', function() {
         });
 
         it('messagesSelected interaction event is recorded with correct screen', async () => {
-
           //Click the messages navbar button and record messagesSelected telemetry
           await vpn.waitForQueryAndClick(queries.navBar.MESSAGES.visible());
           const messagesSelectedEvents = await vpn.gleanTestGetValue("interaction", "messagesSelected", "main");
@@ -1593,7 +1589,6 @@ describe('Subscription view', function() {
         });
 
         it('settingsSelected interaction event is recorded with correct screen', async () => {
-
           //Click the settings navbar button and record settingsSelected telemetry
           await vpn.waitForQueryAndClick(queries.navBar.SETTINGS.visible());
           const settingselectedEvents = await vpn.gleanTestGetValue("interaction", "settingsSelected", "main");

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -107,6 +107,8 @@ target_sources(app_unit_tests PRIVATE
     testlocalizer.h
     testlogger.cpp
     testlogger.h
+    testnavigator.cpp
+    testnavigator.h
     testnetworkmanager.cpp
     testnetworkmanager.h
     testqmlpath.cpp

--- a/tests/unit_tests/testnavigator.cpp
+++ b/tests/unit_tests/testnavigator.cpp
@@ -1,0 +1,180 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "testnavigator.h"
+
+#include <QQmlApplicationEngine>
+#include <QQuickItem>
+
+#include "frontend/navigator.h"
+#include "glean/generated/metrics.h"
+#include "glean/mzglean.h"
+#include "helper.h"
+#include "localizer.h"
+#include "mozillavpn.h"
+#include "qmlengineholder.h"
+#include "settingsholder.h"
+
+void TestNavigator::init() {
+  m_settingsHolder = new SettingsHolder();
+
+  // Glean needs to be initialized for every test because this test suite
+  // includes telemetry tests.
+  //
+  // Glean operations are queued and applied once Glean is initialized.
+  // If we only initialize it in the test that actually tests telemetry all
+  // of the Glean operations from previous tests will be applied and mess with
+  // the status of the test that actually is testing telemetry.
+  //
+  // Note: on tests Glean::initialize clears Glean's storage.
+  MZGlean::initialize();
+}
+
+void TestNavigator::navbar_button_telemetry() {
+  // Initialize
+  Navigator* navigator = Navigator::instance();
+  Localizer l;
+  QQmlApplicationEngine engine;
+  QmlEngineHolder qml(&engine);
+
+  // Register screens
+  Navigator::registerScreen(
+      MozillaVPN::ScreenHome, Navigator::LoadPolicy::LoadPersistently,
+      "qrc:/ui/screens/ScreenHome.qml", QVector<int>{},
+      [](int*) -> int8_t { return 99; }, []() -> bool { return false; });
+
+  Navigator::registerScreen(
+      MozillaVPN::ScreenMessaging, Navigator::LoadPolicy::LoadPersistently,
+      "qrc:/ui/screens/ScreenMessaging.qml", QVector<int>{},
+      [](int*) -> int8_t { return 0; },
+      []() -> bool {
+        Navigator::instance()->requestScreen(MozillaVPN::ScreenHome,
+                                             Navigator::ForceReload);
+        return true;
+      });
+
+  Navigator::registerScreen(
+      MozillaVPN::ScreenSettings, Navigator::LoadPolicy::LoadPersistently,
+      "qrc:/ui/screens/ScreenSettings.qml", QVector<int>{},
+      [](int*) -> int8_t { return 0; },
+      []() -> bool {
+        Navigator::instance()->requestScreen(MozillaVPN::ScreenHome,
+                                             Navigator::ForceReload);
+        return true;
+      });
+
+  // Setup UI - doesn't really matter what view we start in
+  navigator->requestScreen(MozillaVPN::ScreenHome);
+
+  QString telemetryScreenId = "test-screen-id";
+
+  // Create QQuickItem and add as a mock view on top of the current screen with
+  // telemetryScreenId property that will be used as the events extra key
+  QQuickItem* item = new QQuickItem;
+  item->setProperty("telemetryScreenId", telemetryScreenId);
+
+  navigator->addView(MozillaVPN::ScreenHome, QVariant::fromValue(item));
+
+  // Test homeSelected event
+  // Verify number of events is 0 before the test
+  auto homeSelectedEvents =
+      mozilla::glean::interaction::home_selected.testGetValue();
+
+  QCOMPARE(homeSelectedEvents.length(), 0);
+
+  // Click the navbar home button
+  Navigator::instance()->requestScreenFromBottomBar(MozillaVPN::ScreenHome);
+
+  homeSelectedEvents =
+      mozilla::glean::interaction::home_selected.testGetValue();
+
+  // Verify number of events and event extras after test
+  QCOMPARE(homeSelectedEvents.length(), 1);
+
+  auto homeSelectedEventsExtras = homeSelectedEvents[0]["extra"].toObject();
+
+  QCOMPARE(homeSelectedEventsExtras["screen"].toString(), telemetryScreenId);
+
+  QCOMPARE(mozilla::glean::interaction::home_selected.testGetNumRecordedErrors(
+               ErrorType::InvalidValue),
+           0);
+
+  QCOMPARE(mozilla::glean::interaction::home_selected.testGetNumRecordedErrors(
+               ErrorType::InvalidOverflow),
+           0);
+
+  // No need to go back to ScreenHome here because we did that as part of the
+  // home button telemetry test above
+
+  // Test messagesSelected event
+  // Verify number of events is 0 before the test
+  auto messagesSelectedEvents =
+      mozilla::glean::interaction::messages_selected.testGetValue();
+
+  QCOMPARE(messagesSelectedEvents.length(), 0);
+
+  // Click the navbar messages button
+  Navigator::instance()->requestScreenFromBottomBar(
+      MozillaVPN::ScreenMessaging);
+
+  messagesSelectedEvents =
+      mozilla::glean::interaction::messages_selected.testGetValue();
+
+  // Verify number of events and event extras after test
+  QCOMPARE(messagesSelectedEvents.length(), 1);
+
+  auto messagesSelectedEventsExtras =
+      messagesSelectedEvents[0]["extra"].toObject();
+
+  QCOMPARE(messagesSelectedEventsExtras["screen"].toString(),
+           telemetryScreenId);
+
+  QCOMPARE(
+      mozilla::glean::interaction::messages_selected.testGetNumRecordedErrors(
+          ErrorType::InvalidValue),
+      0);
+
+  QCOMPARE(
+      mozilla::glean::interaction::messages_selected.testGetNumRecordedErrors(
+          ErrorType::InvalidOverflow),
+      0);
+
+  // Go back to ScreenHome which has the mock view stacked on top of it before
+  // starting the next test
+  navigator->requestScreen(MozillaVPN::ScreenHome);
+
+  // Test settingsSelected event
+  // Verify number of events is 0 before the test
+  auto settingsSelectedEvents =
+      mozilla::glean::interaction::settings_selected.testGetValue();
+
+  QCOMPARE(settingsSelectedEvents.length(), 0);
+
+  // Click the navbar settings button
+  Navigator::instance()->requestScreenFromBottomBar(MozillaVPN::ScreenSettings);
+
+  settingsSelectedEvents =
+      mozilla::glean::interaction::settings_selected.testGetValue();
+
+  // Verify number of events and event extras after test
+  QCOMPARE(settingsSelectedEvents.length(), 1);
+
+  auto settingsSelectedEventsExtras =
+      settingsSelectedEvents[0]["extra"].toObject();
+
+  QCOMPARE(settingsSelectedEventsExtras["screen"].toString(),
+           telemetryScreenId);
+
+  QCOMPARE(
+      mozilla::glean::interaction::settings_selected.testGetNumRecordedErrors(
+          ErrorType::InvalidValue),
+      0);
+
+  QCOMPARE(
+      mozilla::glean::interaction::settings_selected.testGetNumRecordedErrors(
+          ErrorType::InvalidOverflow),
+      0);
+}
+
+static TestNavigator s_testNavigator;

--- a/tests/unit_tests/testnavigator.h
+++ b/tests/unit_tests/testnavigator.h
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "helper.h"
+
+class SettingsHolder;
+
+class TestNavigator final : public TestHelper {
+  Q_OBJECT
+
+ private slots:
+  void init();
+
+  void navbar_button_telemetry();
+
+ private:
+  SettingsHolder* m_settingsHolder = nullptr;
+};

--- a/tests/unit_tests/testnavigator.h
+++ b/tests/unit_tests/testnavigator.h
@@ -12,7 +12,7 @@ class TestNavigator final : public TestHelper {
  private slots:
   void init();
 
-  void navbar_button_telemetry();
+  void testNavbarButtonTelemetry();
 
  private:
   SettingsHolder* m_settingsHolder = nullptr;


### PR DESCRIPTION
## Description

- Add impression telemetry for the subscription management view
- Replace old manage account and manage subscription telemetry with new interaction format
- Add new telemetry for navbar button presses (that records source view as extra key)
  - Source views need to be added to the screen via [Navigator::addView](https://github.com/mozilla-mobile/mozilla-vpn-client/pull/8838/files#diff-bf5452c5d9bf001e7b2cf467b8ef9ea5d752617491b1aeaf711f7e5a674e25d6R333)
  - Source views need a [telemetryScreenId property](https://github.com/mozilla-mobile/mozilla-vpn-client/pull/8838/files#diff-801f8102a46fbdeea68eacfcedafcc467b5a247655c88dfa7f4c963ed9612424R17)
  - Left [old navbar button press telemetry](https://github.com/mozilla-mobile/mozilla-vpn-client/pull/8838/files#diff-bf5452c5d9bf001e7b2cf467b8ef9ea5d752617491b1aeaf711f7e5a674e25d6R172-R175) in tact as we transition to the new telemetry for more views
- Add functional tests for subscription management view telemetry
- Add unit tests for navbar telemetry

## Reference

[VPN-5547: Implement Telemetry](https://mozilla-hub.atlassian.net/browse/VPN-5547)
[[Telemetry] Miro board](https://miro.com/app/board/uXjVNfZs_pQ=/)
