### PR TITLE
VPN-6042 Check QNetworkInformation::instance() exists first

### DIFF
--- a/src/networkwatcher.cpp
+++ b/src/networkwatcher.cpp
@@ -170,5 +170,8 @@ void NetworkWatcher::notificationClicked(NotificationHandler::Message message) {
 }
 
 QNetworkInformation::Reachability NetworkWatcher::getReachability() {
-  return QNetworkInformation::instance()->reachability();
+  if (QNetworkInformation::instance()) {
+    return QNetworkInformation::instance()->reachability();
+  }
+  return QNetworkInformation::Reachability::Unknown;
 }

--- a/src/networkwatcherimpl.h
+++ b/src/networkwatcherimpl.h
@@ -34,9 +34,6 @@ class NetworkWatcherImpl : public QObject {
   };
   Q_ENUM(TransportType);
 
-  // Returns the current type of Network Connection
-  virtual QNetworkInformation::Reachability getReachability() = 0;
-
  signals:
   // Fires when the Device Connects to an unsecured Network
   void unsecuredNetwork(const QString& networkName, const QString& networkId);

--- a/src/platforms/android/androidnetworkwatcher.cpp
+++ b/src/platforms/android/androidnetworkwatcher.cpp
@@ -28,10 +28,3 @@ AndroidNetworkWatcher::~AndroidNetworkWatcher() {
 }
 
 void AndroidNetworkWatcher::initialize() {}
-
-QNetworkInformation::Reachability AndroidNetworkWatcher::getReachability() {
-  if (QNetworkInformation::instance()) {
-    return QNetworkInformation::instance()->reachability();
-  }
-  return QNetworkInformation::Reachability::Unknown;
-}

--- a/src/platforms/android/androidnetworkwatcher.cpp
+++ b/src/platforms/android/androidnetworkwatcher.cpp
@@ -30,5 +30,8 @@ AndroidNetworkWatcher::~AndroidNetworkWatcher() {
 void AndroidNetworkWatcher::initialize() {}
 
 QNetworkInformation::Reachability AndroidNetworkWatcher::getReachability() {
-  return QNetworkInformation::instance()->reachability();
+  if (QNetworkInformation::instance()) {
+    return QNetworkInformation::instance()->reachability();
+  }
+  return QNetworkInformation::Reachability::Unknown;
 }

--- a/src/platforms/android/androidnetworkwatcher.h
+++ b/src/platforms/android/androidnetworkwatcher.h
@@ -13,8 +13,6 @@ class AndroidNetworkWatcher final : public NetworkWatcherImpl {
   ~AndroidNetworkWatcher();
 
   void initialize() override;
-
-  QNetworkInformation::Reachability getReachability() override;
 };
 
 #endif  // ANDROIDNETWORKWATCHER_H

--- a/src/platforms/dummy/dummynetworkwatcher.h
+++ b/src/platforms/dummy/dummynetworkwatcher.h
@@ -15,7 +15,10 @@ class DummyNetworkWatcher final : public NetworkWatcherImpl {
   void initialize() override;
 
   QNetworkInformation::Reachability getReachability() override {
-    return QNetworkInformation::instance()->reachability();
+    if (QNetworkInformation::instance()) {
+      return QNetworkInformation::instance()->reachability();
+    }
+    return QNetworkInformation::Reachability::Unknown;
   }
 };
 

--- a/src/platforms/dummy/dummynetworkwatcher.h
+++ b/src/platforms/dummy/dummynetworkwatcher.h
@@ -13,13 +13,6 @@ class DummyNetworkWatcher final : public NetworkWatcherImpl {
   ~DummyNetworkWatcher();
 
   void initialize() override;
-
-  QNetworkInformation::Reachability getReachability() override {
-    if (QNetworkInformation::instance()) {
-      return QNetworkInformation::instance()->reachability();
-    }
-    return QNetworkInformation::Reachability::Unknown;
-  }
 };
 
 #endif  // DUMMYNETWORKWATCHER_H

--- a/src/platforms/ios/iosnetworkwatcher.h
+++ b/src/platforms/ios/iosnetworkwatcher.h
@@ -15,7 +15,6 @@ class IOSNetworkWatcher : public NetworkWatcherImpl {
   ~IOSNetworkWatcher();
 
   void initialize() override;
-  QNetworkInformation::Reachability getReachability() override;
 
  private:
   NetworkWatcherImpl::TransportType toTransportType(nw_path_t path);

--- a/src/platforms/ios/iosnetworkwatcher.mm
+++ b/src/platforms/ios/iosnetworkwatcher.mm
@@ -40,13 +40,6 @@ void IOSNetworkWatcher::initialize() {
           &IOSNetworkWatcher::controllerStateChanged);
 }
 
-  QNetworkInformation::Reachability IOSNetworkWatcher::getReachability() {
-    if (QNetworkInformation::instance()) {
-    return QNetworkInformation::instance()->reachability();
-    }
-    return QNetworkInformation::Reachability::Unknown;
-  }
-
 NetworkWatcherImpl::TransportType IOSNetworkWatcher::toTransportType(nw_path_t path) {
   if (path == nil) {
     return NetworkWatcherImpl::TransportType_Unknown;

--- a/src/platforms/ios/iosnetworkwatcher.mm
+++ b/src/platforms/ios/iosnetworkwatcher.mm
@@ -41,7 +41,10 @@ void IOSNetworkWatcher::initialize() {
 }
 
   QNetworkInformation::Reachability IOSNetworkWatcher::getReachability() {
+    if (QNetworkInformation::instance()) {
     return QNetworkInformation::instance()->reachability();
+    }
+    return QNetworkInformation::Reachability::Unknown;
   }
 
 NetworkWatcherImpl::TransportType IOSNetworkWatcher::toTransportType(nw_path_t path) {

--- a/src/platforms/linux/linuxnetworkwatcher.h
+++ b/src/platforms/linux/linuxnetworkwatcher.h
@@ -23,7 +23,10 @@ class LinuxNetworkWatcher final : public NetworkWatcherImpl {
   void start() override;
 
   QNetworkInformation::Reachability getReachability() {
-    return QNetworkInformation::instance()->reachability();
+    if (QNetworkInformation::instance()) {
+      return QNetworkInformation::instance()->reachability();
+    }
+    return QNetworkInformation::Reachability::Unknown;
   }
 
  signals:

--- a/src/platforms/linux/linuxnetworkwatcher.h
+++ b/src/platforms/linux/linuxnetworkwatcher.h
@@ -22,13 +22,6 @@ class LinuxNetworkWatcher final : public NetworkWatcherImpl {
 
   void start() override;
 
-  QNetworkInformation::Reachability getReachability() {
-    if (QNetworkInformation::instance()) {
-      return QNetworkInformation::instance()->reachability();
-    }
-    return QNetworkInformation::Reachability::Unknown;
-  }
-
  signals:
   void checkDevicesInThread();
 

--- a/src/platforms/wasm/wasmnetworkwatcher.h
+++ b/src/platforms/wasm/wasmnetworkwatcher.h
@@ -21,7 +21,10 @@ class WasmNetworkWatcher final : public NetworkWatcherImpl {
   void start() override;
 
   QNetworkInformation::Reachability getReachability() override {
-    return QNetworkInformation::instance()->reachability();
+    if (QNetworkInformation::instance()) {
+      return QNetworkInformation::instance()->reachability();
+    }
+    return QNetworkInformation::Reachability::Unknown;
   }
 };
 

--- a/src/platforms/wasm/wasmnetworkwatcher.h
+++ b/src/platforms/wasm/wasmnetworkwatcher.h
@@ -19,13 +19,6 @@ class WasmNetworkWatcher final : public NetworkWatcherImpl {
   void initialize() override;
 
   void start() override;
-
-  QNetworkInformation::Reachability getReachability() override {
-    if (QNetworkInformation::instance()) {
-      return QNetworkInformation::instance()->reachability();
-    }
-    return QNetworkInformation::Reachability::Unknown;
-  }
 };
 
 #endif  // WASMNETWORKWATCHER_H

--- a/src/platforms/windows/windowsnetworkwatcher.cpp
+++ b/src/platforms/windows/windowsnetworkwatcher.cpp
@@ -138,10 +138,3 @@ void WindowsNetworkWatcher::processWlan(PWLAN_NOTIFICATION_DATA data) {
                  << "id:" << logger.sensitive(bssid);
   emit unsecuredNetwork(ssid, bssid);
 }
-
-QNetworkInformation::Reachability WindowsNetworkWatcher::getReachability() {
-  if (QNetworkInformation::instance()) {
-    return QNetworkInformation::instance()->reachability();
-  }
-  return QNetworkInformation::Reachability::Unknown;
-}

--- a/src/platforms/windows/windowsnetworkwatcher.cpp
+++ b/src/platforms/windows/windowsnetworkwatcher.cpp
@@ -140,5 +140,8 @@ void WindowsNetworkWatcher::processWlan(PWLAN_NOTIFICATION_DATA data) {
 }
 
 QNetworkInformation::Reachability WindowsNetworkWatcher::getReachability() {
-  return QNetworkInformation::instance()->reachability();
+  if (QNetworkInformation::instance()) {
+    return QNetworkInformation::instance()->reachability();
+  }
+  return QNetworkInformation::Reachability::Unknown;
 }

--- a/src/platforms/windows/windowsnetworkwatcher.h
+++ b/src/platforms/windows/windowsnetworkwatcher.h
@@ -17,8 +17,6 @@ class WindowsNetworkWatcher final : public NetworkWatcherImpl {
 
   void initialize() override;
 
-  QNetworkInformation::Reachability getReachability() override;
-
  private:
   static void wlanCallback(PWLAN_NOTIFICATION_DATA data, PVOID context);
 


### PR DESCRIPTION
## Description

Check QNetworkInformation::instance() exists first before attempting to access its reachability. If it doesn't exist, return reachability::unknown.

## Reference

   https://mozilla-hub.atlassian.net/browse/VPN-6042

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
