### PR TITLE
Dry run sentry upload

### DIFF
--- a/taskcluster/kinds/build/windows.yml
+++ b/taskcluster/kinds/build/windows.yml
@@ -33,10 +33,7 @@ task-defaults:
     release-artifacts:
         - unsigned.zip
     scopes:
-        by-level:
-            "3":
-                - secrets:get:project/mozillavpn/tokens
-            default: []
+        - secrets:get:project/mozillavpn/level-1/sentry
     run:
         using: run-task
         cwd: '{checkout}'

--- a/taskcluster/scripts/build/windows_clang_cl.ps1
+++ b/taskcluster/scripts/build/windows_clang_cl.ps1
@@ -92,12 +92,17 @@ Get-ChildItem -Path $TASK_WORKDIR/artifacts
 Get-command python
 python  $SOURCE_DIR/taskcluster/scripts/get-secret.py -s project/mozillavpn/level-1/sentry -k sentry_debug_file_upload_key -f sentry_debug_file_upload_key
 $env:SENTRY_AUTH_TOKEN=$(Get-Content sentry_debug_file_upload_key)
+# Are we logged in?
+sentry-cli-Windows-x86_64.exe info 
 
 # This will ask sentry to scan all files in there and upload
 # missing debug info, for symbolification
+
 sentry-cli-Windows-x86_64.exe debug-files check "$BUILD_DIR\src\Mozilla VPN.pdb"
 Get-ChildItem $TASK_WORKDIR/unsigned/
 if ($env:MOZ_SCM_LEVEL -eq "3") {
     sentry-cli-Windows-x86_64.exe debug-files upload --org mozilla -p vpn-client --include-sources $BUILD_DIR
+} else{
+    sentry-cli-Windows-x86_64.exe --log-level info debug-files upload --org mozilla -p vpn-client --include-sources --no-upload $BUILD_DIR
 }
 

--- a/taskcluster/scripts/build/windows_clang_cl.ps1
+++ b/taskcluster/scripts/build/windows_clang_cl.ps1
@@ -88,12 +88,18 @@ Compress-Archive -Path $TASK_WORKDIR/unsigned/* -Destination $ARTIFACTS_PATH/uns
 Write-Output "Artifacts Location:$TASK_WORKDIR/artifacts"
 Get-ChildItem -Path $TASK_WORKDIR/artifacts
 
+
+Get-command python
+python  $SOURCE_DIR/taskcluster/scripts/get-secret.py -s project/mozillavpn/level-1/sentry -k sentry_debug_file_upload_key -f sentry_debug_file_upload_key
+sentry-cli-Windows-x86_64.exe login --auth-token $(Get-Content sentry_debug_file_upload_key)
+# This will ask sentry to scan all files in there and upload
+# missing debug info, for symbolification
+sentry-cli-Windows-x86_64.exed debug-files check $TASK_WORKDIR/unsigned/
+Get-ChildItem $TASK_WORKDIR/unsigned/
 if ($env:MOZ_SCM_LEVEL -eq "3") {
-    Get-command python
-    python  $SOURCE_DIR/taskcluster/scripts/get-secret.py -s project/mozillavpn/tokens -k sentry_debug_file_upload_key -f sentry_debug_file_upload_key
-    sentry-cli-Windows-x86_64.exe login --auth-token $(Get-Content sentry_debug_file_upload_key)
-    # This will ask sentry to scan all files in there and upload
-    # missing debug info, for symbolification
-    sentry-cli-Windows-x86_64.exe debug-files upload --org mozilla -p vpn-client $TASK_WORKDIR/unsigned/Mozilla\ VPN.pdb
+    sentry-cli-Windows-x86_64.exe debug-files upload --org mozilla -p vpn-client --include-sources $TASK_WORKDIR/unsigned/
+}else {
+    # Do a Dry run for non Main/Release branch builds
+    sentry-cli-Windows-x86_64.exed debug-files upload --org mozilla -p vpn-client --include-sources --no-upload $TASK_WORKDIR/unsigned/
 }
 

--- a/taskcluster/scripts/build/windows_clang_cl.ps1
+++ b/taskcluster/scripts/build/windows_clang_cl.ps1
@@ -91,15 +91,13 @@ Get-ChildItem -Path $TASK_WORKDIR/artifacts
 
 Get-command python
 python  $SOURCE_DIR/taskcluster/scripts/get-secret.py -s project/mozillavpn/level-1/sentry -k sentry_debug_file_upload_key -f sentry_debug_file_upload_key
-sentry-cli-Windows-x86_64.exe login --auth-token $(Get-Content sentry_debug_file_upload_key)
+$env:SENTRY_AUTH_TOKEN=$(Get-Content sentry_debug_file_upload_key)
+
 # This will ask sentry to scan all files in there and upload
 # missing debug info, for symbolification
-sentry-cli-Windows-x86_64.exe debug-files check $TASK_WORKDIR/unsigned/
+sentry-cli-Windows-x86_64.exe debug-files check "$BUILD_DIR\src\Mozilla VPN.pdb"
 Get-ChildItem $TASK_WORKDIR/unsigned/
 if ($env:MOZ_SCM_LEVEL -eq "3") {
-    sentry-cli-Windows-x86_64.exe debug-files upload --org mozilla -p vpn-client --include-sources $TASK_WORKDIR/unsigned/
-}else {
-    # Do a Dry run for non Main/Release branch builds
-    sentry-cli-Windows-x86_64.exe debug-files upload --org mozilla -p vpn-client --include-sources --no-upload $TASK_WORKDIR/unsigned/
+    sentry-cli-Windows-x86_64.exe debug-files upload --org mozilla -p vpn-client --include-sources $BUILD_DIR
 }
 

--- a/taskcluster/scripts/build/windows_clang_cl.ps1
+++ b/taskcluster/scripts/build/windows_clang_cl.ps1
@@ -94,12 +94,12 @@ python  $SOURCE_DIR/taskcluster/scripts/get-secret.py -s project/mozillavpn/leve
 sentry-cli-Windows-x86_64.exe login --auth-token $(Get-Content sentry_debug_file_upload_key)
 # This will ask sentry to scan all files in there and upload
 # missing debug info, for symbolification
-sentry-cli-Windows-x86_64.exed debug-files check $TASK_WORKDIR/unsigned/
+sentry-cli-Windows-x86_64.exe debug-files check $TASK_WORKDIR/unsigned/
 Get-ChildItem $TASK_WORKDIR/unsigned/
 if ($env:MOZ_SCM_LEVEL -eq "3") {
     sentry-cli-Windows-x86_64.exe debug-files upload --org mozilla -p vpn-client --include-sources $TASK_WORKDIR/unsigned/
 }else {
     # Do a Dry run for non Main/Release branch builds
-    sentry-cli-Windows-x86_64.exed debug-files upload --org mozilla -p vpn-client --include-sources --no-upload $TASK_WORKDIR/unsigned/
+    sentry-cli-Windows-x86_64.exe debug-files upload --org mozilla -p vpn-client --include-sources --no-upload $TASK_WORKDIR/unsigned/
 }
 


### PR DESCRIPTION
## Description

Currently i can only test sentry uploading on main. I've moved the upload key to level-1 which allows me to have a dry-run on pull requests.
