### PR TITLE
VPN-5771 - Fix UI issues with long app names in app exclusions (#8396)

### DIFF
--- a/src/ui/screens/settings/appPermissions/AppPermissionsList.qml
+++ b/src/ui/screens/settings/appPermissions/AppPermissionsList.qml
@@ -40,7 +40,7 @@ ColumnLayout {
         id: col2
         objectName: "appExclusionsList"
 
-        spacing: MZTheme.theme.windowMargin / 2
+        spacing: MZTheme.theme.vSpacing
 
         Layout.preferredWidth: parent.width
 
@@ -82,7 +82,6 @@ ColumnLayout {
                 objectName: `app-${index}`
                 spacing: MZTheme.theme.windowMargin
                 opacity: enabled ? 1.0 : 0.5
-                Layout.preferredHeight: MZTheme.theme.navBarTopMargin
 
                 function handleClick() {
                     VPNAppPermissions.flip(appID)


### PR DESCRIPTION
# Description

When adding an app with a long app name, the UI causes problems with overlapping text. Removing the fixed height solves this. I could not use Windows for testing, so I used the `dummyapplistprovider.cpp`.

# Reference

* https://mozilla-hub.atlassian.net/browse/VPN-5771
* #8396

# Screenshot

![screenshot-vpn-5771](https://github.com/mozilla-mobile/mozilla-vpn-client/assets/1068037/f0037624-c0db-4c6a-beb9-629beb448d3b)