### PR TITLE
Nit: Remove Sentry config from CI

### DIFF
--- a/scripts/android/cmake.sh
+++ b/scripts/android/cmake.sh
@@ -55,16 +55,6 @@ while [[ $# -gt 0 ]]; do
     RELEASE=
     shift
     ;;
-  --sentrydsn)
-    SENTRY_DSN="$2"
-    shift
-    shift
-    ;;
-  --sentryendpoint)
-    SENTRY_ENVELOPE_ENDPOINT="$2"
-    shift
-    shift
-    ;;
   -h | --help)
     helpFunction
     ;;
@@ -148,8 +138,6 @@ if [[ "$RELEASE" ]]; then
     -DANDROID_SDK_ROOT=$ANDROID_SDK_ROOT \
     -DCMAKE_BUILD_TYPE=Release \
     -DADJUST_TOKEN=$ADJUST_SDK_TOKEN \
-    -DSENTRY_DSN=$SENTRY_DSN \
-    -DSENTRY_ENVELOPE_ENDPOINT=$SENTRY_ENVELOPE_ENDPOINT \
     -GNinja \
     -S . -B .tmp/
 else
@@ -161,8 +149,6 @@ else
     -DANDROID_NDK_ROOT=$ANDROID_NDK_ROOT \
     -DANDROID_SDK_ROOT=$ANDROID_SDK_ROOT \
     -DCMAKE_BUILD_TYPE=Debug \
-    -DSENTRY_DSN=$SENTRY_DSN \
-    -DSENTRY_ENVELOPE_ENDPOINT=$SENTRY_ENVELOPE_ENDPOINT \
     -GNinja \
     -S . -B .tmp/
 

--- a/taskcluster/scripts/build/android_build_release.sh
+++ b/taskcluster/scripts/build/android_build_release.sh
@@ -22,14 +22,10 @@ env
 if [[ "$MOZ_SCM_LEVEL" == "3" ]]; then
   echo "Fetching Tokens!"
   ./taskcluster/scripts/get-secret.py -s project/mozillavpn/tokens -k adjust -f adjust_token
-  ./taskcluster/scripts/get-secret.py -s project/mozillavpn/tokens -k sentry_dsn -f sentry_dsn
-  ./taskcluster/scripts/get-secret.py -s project/mozillavpn/tokens -k sentry_envelope_endpoint -f sentry_envelope_endpoint
   ./taskcluster/scripts/get-secret.py -s project/mozillavpn/tokens -k sentry_debug_file_upload_key -f sentry_debug_file_upload_key
 else
     echo "Using dummy Tokens!"
     # write a dummy value in the files, so that we still compile sentry c:
-    echo "dummy" > sentry_dsn
-    echo "dummy" > sentry_envelope_endpoint
     echo "dummy" > sentry_debug_file_upload_key
     echo "dummy" > adjust_token
 fi
@@ -46,11 +42,10 @@ mkdir -p /builds/worker/artifacts/
 # aqt-name "x86"         -> qmake-name: "x86"
 # aqt-name "x86_64"      -> qmake-name: "x86_64"
 
-./scripts/android/cmake.sh $QTPATH -A $1 -a $(cat adjust_token) --sentrydsn $(cat sentry_dsn) --sentryendpoint $(cat sentry_envelope_endpoint)
-
-npm install -g @sentry/cli
+./scripts/android/cmake.sh $QTPATH -A $1 -a $(cat adjust_token)
 
 if [[ "$MOZ_SCM_LEVEL" == "3" ]]; then
+  npm install -g @sentry/cli
   sentry-cli login --auth-token $(cat sentry_debug_file_upload_key)
   # This will ask sentry to scan all files in there and upload
   # missing debug info, for symbolification

--- a/taskcluster/scripts/build/macos_build.sh
+++ b/taskcluster/scripts/build/macos_build.sh
@@ -72,18 +72,11 @@ python3 -m pip install -r taskcluster/scripts/requirements.txt
 print Y "Fetching tokens..."
 # Only on a release build we have access to those secrects.
 if [[ "$RELEASE" ]]; then
-   ./taskcluster/scripts/get-secret.py -s project/mozillavpn/level-1/sentry -k sentry_dsn -f sentry_dsn
-   ./taskcluster/scripts/get-secret.py -s project/mozillavpn/level-1/sentry -k sentry_envelope_endpoint -f sentry_envelope_endpoint
-   ./taskcluster/scripts/get-secret.py -s project/mozillavpn/level-1/sentry -k sentry_debug_file_upload_key -f sentry_debug_file_upload_key
+    ./taskcluster/scripts/get-secret.py -s project/mozillavpn/level-1/sentry -k sentry_debug_file_upload_key -f sentry_debug_file_upload_key
 else
-    # write a dummy value in the files, so that we still compile sentry c:
-    echo "dummy" > sentry_dsn
-    echo "dummy" > sentry_envelope_endpoint
     echo "dummy" > sentry_debug_file_upload_key
 fi
 
-export SENTRY_ENVELOPE_ENDPOINT=$(cat sentry_envelope_endpoint)
-export SENTRY_DSN=$(cat sentry_dsn)
 #Install Sentry CLI, if' not already installed from previous run.
 if ! command -v sentry-cli &> /dev/null
 then
@@ -100,8 +93,6 @@ mkdir ${TASK_HOME}/build
 
 cmake -S . -B ${TASK_HOME}/build -GNinja \
         -DCMAKE_PREFIX_PATH=${MOZ_FETCHES_DIR}/qt_dist/lib/cmake \
-        -DSENTRY_DSN=$SENTRY_DSN \
-        -DSENTRY_ENVELOPE_ENDPOINT=$SENTRY_ENVELOPE_ENDPOINT \
         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
         -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64"
 


### PR DESCRIPTION
## Description
We fetch sentry info from guardian, no need to pass it as cmake args anymore. 


Should fix: 
```
[task 2024-01-02T14:35:35.776Z] Fetching tokens...
[task 2024-01-02T14:35:36.323Z] Outputting secret to: /opt/worker/tasks/task_169453793109859/checkouts/vcs/sentry_dsn
[task 2024-01-02T14:35:36.323Z] Traceback (most recent call last):
[task 2024-01-02T14:35:36.323Z]   File "/opt/worker/tasks/task_169453793109859/checkouts/vcs/./taskcluster/scripts/get-secret.py", line 106, in <module>
[task 2024-01-02T14:35:36.323Z]     main()
[task 2024-01-02T14:35:36.323Z]   File "/opt/worker/tasks/task_169453793109859/checkouts/vcs/./taskcluster/scripts/get-secret.py", line 94, in main
[task 2024-01-02T14:35:36.324Z]     write_secret_to_file(
[task 2024-01-02T14:35:36.324Z]   File "/opt/worker/tasks/task_169453793109859/checkouts/vcs/./taskcluster/scripts/get-secret.py", line 23, in write_secret_to_file
[task 2024-01-02T14:35:36.324Z]     value = data["secret"][key]
[task 2024-01-02T14:35:36.324Z] KeyError: 'sentry_dsn'

```
