### PR TITLE
VPN-5986 Add openssl-3 on Qt 6.4+

### DIFF
--- a/src/cmake/android.cmake
+++ b/src/cmake/android.cmake
@@ -60,3 +60,11 @@ set_property(TARGET mozillavpn PROPERTY QT_ANDROID_EXTRA_LIBS
     ${OPENSSL_LIBS_DIR}/libssl_1_1.so
     ${QTGLEAN_LIB_LOCATION}
     APPEND)
+
+
+if( ${Qt6_VERSION} VERSION_GREATER_EQUAL 6.4.0)
+    set_property(TARGET mozillavpn PROPERTY QT_ANDROID_EXTRA_LIBS
+        ${OPENSSL_LIBS_DIR}/libcrypto_3.so
+        ${OPENSSL_LIBS_DIR}/libssl_3.so
+    APPEND)
+endif()

--- a/src/cmake/android_openssl.cmake
+++ b/src/cmake/android_openssl.cmake
@@ -7,7 +7,6 @@
 
 include(ExternalProject)
 
-
 ExternalProject_Add(ndk_openssl
   URL https://maven.google.com/com/android/ndk/thirdparty/openssl/1.1.1q-beta-1/openssl-1.1.1q-beta-1.aar
   URL_HASH SHA256=a5b05c4b362d35c022238ef9b2e4e2196248adea3bac9dd683845ee75a3a8d66
@@ -69,7 +68,7 @@ include(FetchContent)
     android_openssl
     DOWNLOAD_EXTRACT_TIMESTAMP true
     URL      https://github.com/KDAB/android_openssl/archive/refs/heads/master.zip
-  #      URL_HASH MD5=c97d6ad774fab16be63b0ab40f78d945 #optional
+    URL_HASH MD5=c97d6ad774fab16be63b0ab40f78d945
   )
   FetchContent_MakeAvailable(android_openssl)
   add_custom_command(

--- a/src/cmake/android_openssl.cmake
+++ b/src/cmake/android_openssl.cmake
@@ -6,6 +6,8 @@
 # Publishes builds of openSSL for android on maven. 
 
 include(ExternalProject)
+
+
 ExternalProject_Add(ndk_openssl
   URL https://maven.google.com/com/android/ndk/thirdparty/openssl/1.1.1q-beta-1/openssl-1.1.1q-beta-1.aar
   URL_HASH SHA256=a5b05c4b362d35c022238ef9b2e4e2196248adea3bac9dd683845ee75a3a8d66
@@ -54,6 +56,26 @@ add_custom_command(
         COMMAND ${CMAKE_COMMAND} -E copy ${_OPENSSL_CRYPTO_MODULE}/libs/android.${ANDROID_ABI}/libcrypto.so ${_OPENSSL_LIBS}/libcrypto.so)
 
 
-get_property(crypto_module GLOBAL PROPERTY OPENSSL_CRYPTO_MODULE)
-get_property(ssl_module GLOBAL PROPERTY OPENSSL_SSL_MODULE)
-get_property(openssl_libs GLOBAL PROPERTY OPENSSL_LIBS)
+# In case of newer versions of QT, for QtSLL we need to 
+# have 3.x.x bundled alongside.
+# Some rust crates seem to need 1.x? so ugh. both i guess. 
+# This piece just add's the _3.so libs into the merged folder.
+find_package(Qt6 COMPONENTS Core)
+if( ${Qt6_VERSION} VERSION_GREATER_EQUAL 6.4.0)
+include(FetchContent)
+# Google does not provide openssl v 3.0
+# so let's use the builds from kdab
+  FetchContent_Declare(
+    android_openssl
+    DOWNLOAD_EXTRACT_TIMESTAMP true
+    URL      https://github.com/KDAB/android_openssl/archive/refs/heads/master.zip
+  #      URL_HASH MD5=c97d6ad774fab16be63b0ab40f78d945 #optional
+  )
+  FetchContent_MakeAvailable(android_openssl)
+  add_custom_command(
+    TARGET ndk_openssl_merged
+    COMMAND ${CMAKE_COMMAND} -E copy ${android_openssl_SOURCE_DIR}/ssl_3/${ANDROID_ABI}/libssl_3.so ${_OPENSSL_LIBS}/libssl_3.so
+    COMMAND ${CMAKE_COMMAND} -E copy ${android_openssl_SOURCE_DIR}/ssl_3/${ANDROID_ABI}/libcrypto_3.so ${_OPENSSL_LIBS}/libcrypto_3.so
+  )
+endif()
+

--- a/src/cmake/android_openssl.cmake
+++ b/src/cmake/android_openssl.cmake
@@ -68,7 +68,7 @@ include(FetchContent)
     android_openssl
     DOWNLOAD_EXTRACT_TIMESTAMP true
     URL      https://github.com/KDAB/android_openssl/archive/refs/heads/master.zip
-    URL_HASH MD5=c97d6ad774fab16be63b0ab40f78d945
+    URL_HASH MD5=7c0736e84fc21d0d767ffc13876e5491
   )
   FetchContent_MakeAvailable(android_openssl)
   add_custom_command(

--- a/src/platforms/android/sources.cmake
+++ b/src/platforms/android/sources.cmake
@@ -34,14 +34,4 @@ else()
     endif()
 endif()
 
-add_dependencies(shared-sources ndk_openssl_merged)
-
-get_property(crypto_module GLOBAL PROPERTY OPENSSL_CRYPTO_MODULE)
-get_property(ssl_module GLOBAL PROPERTY OPENSSL_SSL_MODULE)
-
-target_include_directories(shared-sources INTERFACE ${ssl_module}/include)
-
-target_link_directories(shared-sources INTERFACE ${openssl_libs})
-target_link_libraries(shared-sources INTERFACE libcrypto.so)
-target_link_libraries(shared-sources INTERFACE libssl.so)
 target_link_libraries(shared-sources INTERFACE -ljnigraphics)


### PR DESCRIPTION
## Description

So from Qt 6.4 we need to also bundle openssl 3.x.x. As before, i'm going to use kdab :) 
We're keeping the 1.x, as our rust builds seem to rely on those q_q 

![Screenshot (02 01](https://github.com/mozilla-mobile/mozilla-vpn-client/assets/9611612/20c4f9ac-56cc-4b78-b770-2cf9708cb840)

