### PR TITLE
VPN-4685: Add device management help sheet

### DIFF
--- a/src/constants.h
+++ b/src/constants.h
@@ -214,6 +214,10 @@ constexpr const char* MOZILLA_VPN_SUMO_URL =
 constexpr const char* SUMO_DNS =
     "https://support.mozilla.org/kb/how-do-i-change-my-dns-settings";
 
+constexpr const char* SUMO_DEVICES =
+    "https://support.mozilla.org/kb/"
+    "how-add-devices-your-mozilla-vpn-subscription";
+
 PRODBETAEXPR(QString, contactSupportUrl, "https://accounts.firefox.com/support",
              "https://accounts.stage.mozaws.net/support")
 

--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -1384,6 +1384,11 @@ void MozillaVPN::registerUrlOpenerLabels() {
 
   uo->registerUrlLabel("sumoDns",
                        []() -> QString { return Constants::SUMO_DNS; });
+
+    uo->registerUrlLabel("sumoDevices", []() -> QString {
+    return "https://support.mozilla.org/en-US/kb/"
+           "how-add-devices-your-mozilla-vpn-subscription";
+  });
 }
 
 void MozillaVPN::errorHandled() {

--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -1385,10 +1385,8 @@ void MozillaVPN::registerUrlOpenerLabels() {
   uo->registerUrlLabel("sumoDns",
                        []() -> QString { return Constants::SUMO_DNS; });
 
-    uo->registerUrlLabel("sumoDevices", []() -> QString {
-    return "https://support.mozilla.org/en-US/kb/"
-           "how-add-devices-your-mozilla-vpn-subscription";
-  });
+  uo->registerUrlLabel("sumoDevices",
+                       []() -> QString { return Constants::SUMO_DEVICES; });
 }
 
 void MozillaVPN::errorHandled() {

--- a/src/translations/strings.yaml
+++ b/src/translations/strings.yaml
@@ -966,6 +966,18 @@ helpSheets:
   dnsBody2:
     value: Mozilla VPN allows you to choose a custom DNS server if you prefer. If you use one, you won’t be able to use other privacy features in the VPN like tracker blocking.
     comment: Body text for the custom dns help sheet
+  devicesTitle:
+    value: Device management
+    comment: Title label for the devices help sheet
+  devicesHeader:
+    value: Adding and removing devices
+    comment: Header label for the devices help sheet
+  devicesBody1: 
+    value: "Adding a new device to your subscription is easy: just download and log in to Mozilla VPN on that device."
+    comment: Body label for the devices help sheet
+  devicesBody2:
+    value: To remove one of your added devices, select “Edit” on this screen and use the trash icon to remove the device you no longer want to use Mozilla VPN on.
+    comment: Body label for the devices help sheet
 
 global:
   expand:

--- a/src/ui/screens/devices/ViewDevices.qml
+++ b/src/ui/screens/devices/ViewDevices.qml
@@ -40,15 +40,39 @@ MZViewBase {
 
         spacing: 0
 
-        MZInterLabel {
-            Layout.topMargin: -8
+
+        RowLayout {
+            Layout.topMargin: -8 //Because we are in a MZViewBase with default 16px top margin
             Layout.leftMargin: MZTheme.theme.windowMargin * 1.5
             Layout.rightMargin: MZTheme.theme.windowMargin * 1.5
-            Layout.fillWidth: true
 
-            horizontalAlignment: Text.AlignLeft
-            color: MZTheme.theme.fontColor
-            text: MZI18n.DevicesCountLabel.arg(VPNDeviceModel.activeDevices).arg(VPNUser.maxDevices)
+            spacing: 4
+
+            MZInterLabel {
+                Layout.maximumWidth: vpnFlickable.width - parent.Layout.leftMargin - parent.Layout.rightMargin - parent.spacing - helpIconButtonLoader.implicitWidth
+
+                horizontalAlignment: Text.AlignLeft
+                color: MZTheme.theme.fontColor
+                text: MZI18n.DevicesCountLabel.arg(VPNDeviceModel.activeDevices).arg(VPNUser.maxDevices)
+            }
+
+            Loader {
+                id: helpIconButtonLoader
+                active: MZFeatureList.get("helpSheets").isSupported
+                sourceComponent: MZIconButton {
+                    onClicked: helpSheetLoader.active = true
+
+                    accessibleName: MZI18n.GlobalHelp
+                    Accessible.ignored: !visible
+
+                    Image {
+                        anchors.centerIn: parent
+
+                        source: "qrc:/nebula/resources/question.svg"
+                        fillMode: Image.PreserveAspectFit
+                    }
+                }
+            }
         }
 
         Rectangle {
@@ -73,6 +97,27 @@ MZViewBase {
             removePopup.deviceName = name;
             removePopup.devicePublicKey = publicKey;
             removePopup.open();
+        }
+    }
+
+    Loader {
+        id: helpSheetLoader
+
+        active: false
+
+        onActiveChanged: if (active) item.open()
+
+        sourceComponent: MZHelpSheet {
+            title: MZI18n.HelpSheetsDevicesTitle
+
+            model: [
+                {type: MZHelpSheet.BlockType.Title, text: MZI18n.HelpSheetsDevicesHeader},
+                {type: MZHelpSheet.BlockType.Text, text: MZI18n.HelpSheetsDevicesBody1, margin: 8},
+                {type: MZHelpSheet.BlockType.Text, text:MZI18n.HelpSheetsDevicesBody2, margin: 16},
+                {type: MZHelpSheet.BlockType.LinkButton, text: MZI18n.GlobalLearnMore, margin: 16, action: () => { MZUrlOpener.openUrlLabel("sumoDevices") } },
+            ]
+
+            onClosed: helpSheetLoader.active = false
         }
     }
 

--- a/src/ui/screens/devices/ViewDevices.qml
+++ b/src/ui/screens/devices/ViewDevices.qml
@@ -63,7 +63,6 @@ MZViewBase {
                     onClicked: helpSheetLoader.active = true
 
                     accessibleName: MZI18n.GlobalHelp
-                    Accessible.ignored: !visible
 
                     Image {
                         anchors.centerIn: parent


### PR DESCRIPTION
## Description

**NOTE: Depends on [#8864: VPN-4687: Add DNS settings help sheet](https://github.com/mozilla-mobile/mozilla-vpn-client/pull/8864)**

- Implement help sheet for device management

https://github.com/mozilla-mobile/mozilla-vpn-client/assets/15353801/ae55c2ec-09bf-492e-8ae0-7d5931410604

## Reference

[VPN-4685: Implement the 'Device Management' in-product help sheet](https://mozilla-hub.atlassian.net/browse/VPN-4685)
