### PR TITLE
VPN-4690: Add excluded apps help sheet

### DIFF
--- a/src/constants.h
+++ b/src/constants.h
@@ -214,6 +214,9 @@ constexpr const char* MOZILLA_VPN_SUMO_URL =
 constexpr const char* SUMO_DNS =
     "https://support.mozilla.org/kb/how-do-i-change-my-dns-settings";
 
+constexpr const char* SUMO_EXCLUDED_APPS =
+    "https://support.mozilla.org/kb/split-tunneling-app-permissions";
+
 PRODBETAEXPR(QString, contactSupportUrl, "https://accounts.firefox.com/support",
              "https://accounts.stage.mozaws.net/support")
 

--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -1384,6 +1384,11 @@ void MozillaVPN::registerUrlOpenerLabels() {
 
   uo->registerUrlLabel("sumoDns",
                        []() -> QString { return Constants::SUMO_DNS; });
+
+  uo->registerUrlLabel("sumoExcludedApps", []() -> QString {
+    return "https://support.mozilla.org/en-US/kb/"
+           "split-tunneling-app-permissions";
+  });
 }
 
 void MozillaVPN::errorHandled() {

--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -1386,8 +1386,7 @@ void MozillaVPN::registerUrlOpenerLabels() {
                        []() -> QString { return Constants::SUMO_DNS; });
 
   uo->registerUrlLabel("sumoExcludedApps", []() -> QString {
-    return "https://support.mozilla.org/en-US/kb/"
-           "split-tunneling-app-permissions";
+    return Constants::SUMO_EXCLUDED_APPS;
   });
 }
 

--- a/src/translations/strings.yaml
+++ b/src/translations/strings.yaml
@@ -966,6 +966,24 @@ helpSheets:
   dnsBody2:
     value: Mozilla VPN allows you to choose a custom DNS server if you prefer. If you use one, you won’t be able to use other privacy features in the VPN like tracker blocking.
     comment: Body text for the custom dns help sheet
+  excludedAppsTitle:
+    value: Excluded apps
+    comment: Title label for the excluded apps help sheet
+  excludedAppsHeader:
+    value: What are excluded apps? 
+    comment: Header label for the excluded apps help sheet
+  excludedAppsBody1:
+    value: Excluded apps let you turn off VPN protection for specific apps, without turning off your device’s VPN protection.
+    comment: Body label for the excluded apps help sheet
+  excludedAppsBody2:
+    value: When you exclude an app, your IP address and approximate location will be exposed to it.
+    comment: Body label for the excluded apps help sheet
+  excludedAppsBody3:
+    value: You can use the settings under Settings > Privacy features to block ads, block trackers, and block malware, even on excluded apps.
+    comment: Body label for the excluded apps help sheet
+  excludedAppsCTA:
+    value: Open “Privacy features”
+    comment: Label for button that opens the "Privacy features" view from the excluded apps help sheet
 
 global:
   expand:

--- a/src/translations/strings.yaml
+++ b/src/translations/strings.yaml
@@ -973,10 +973,10 @@ helpSheets:
     value: What are excluded apps? 
     comment: Header label for the excluded apps help sheet
   excludedAppsBody1:
-    value: Excluded apps let you turn off VPN protection for specific apps, without turning off your device’s VPN protection.
+    value: Excluded apps let you turn off VPN protection for specific apps, without turning off VPN protection for your entire device.
     comment: Body label for the excluded apps help sheet
   excludedAppsBody2:
-    value: When you exclude an app, your IP address and approximate location will be exposed to it.
+    value: When you exclude an app, it will have access to your IP address and approximate location.
     comment: Body label for the excluded apps help sheet
   excludedAppsBody3:
     value: You can use the settings under Settings > Privacy features to block ads, block trackers, and block malware, even on excluded apps.

--- a/src/ui/screens/settings/appPermissions/ViewAppPermissions.qml
+++ b/src/ui/screens/settings/appPermissions/ViewAppPermissions.qml
@@ -30,7 +30,6 @@ MZViewBase {
                 onClicked: helpSheetLoader.active = true
 
                 accessibleName: MZI18n.GlobalHelp
-                Accessible.ignored: !visible
 
                 Image {
                     anchors.centerIn: parent
@@ -96,8 +95,8 @@ MZViewBase {
             model: [
                 {type: MZHelpSheet.BlockType.Title, text: MZI18n.HelpSheetsExcludedAppsHeader},
                 {type: MZHelpSheet.BlockType.Text, text: MZI18n.HelpSheetsExcludedAppsBody1, margin: 8},
-                {type: MZHelpSheet.BlockType.Text, text:MZI18n.HelpSheetsExcludedAppsBody2, margin: 16},
-                {type: MZHelpSheet.BlockType.Text, text:MZI18n.HelpSheetsExcludedAppsBody3, margin: 16},
+                {type: MZHelpSheet.BlockType.Text, text: MZI18n.HelpSheetsExcludedAppsBody2, margin: 16},
+                {type: MZHelpSheet.BlockType.Text, text: MZI18n.HelpSheetsExcludedAppsBody3, margin: 16},
                 {type: MZHelpSheet.BlockType.PrimaryButton, text: MZI18n.HelpSheetsExcludedAppsCTA, margin: 16, action: () => {
                         close()
                         getStack().push("qrc:/ui/screens/settings/privacy/ViewPrivacy.qml")

--- a/src/ui/screens/settings/appPermissions/ViewAppPermissions.qml
+++ b/src/ui/screens/settings/appPermissions/ViewAppPermissions.qml
@@ -12,6 +12,9 @@ import components 0.1
 import components.forms 0.1
 
 MZViewBase {
+    id: vpnFlickable
+    objectName: "appPermissions"
+
     //% "Search apps"
     //: Search bar placeholder text
     property string searchApps: qsTrId("vpn.protectSelectedApps.searchApps")
@@ -20,8 +23,24 @@ MZViewBase {
     //: Button label
     property string addApplication: qsTrId("vpn.protectSelectedApps.addApplication")
 
-    id: vpnFlickable
-    objectName: "appPermissions"
+    property Component rightMenuButton: Component {
+        Loader {
+            active: MZFeatureList.get("helpSheets").isSupported
+            sourceComponent: MZIconButton {
+                onClicked: helpSheetLoader.active = true
+
+                accessibleName: MZI18n.GlobalHelp
+                Accessible.ignored: !visible
+
+                Image {
+                    anchors.centerIn: parent
+
+                    source: "qrc:/nebula/resources/question.svg"
+                    fillMode: Image.PreserveAspectFit
+                }
+            }
+        }
+    }
 
     _menuTitle: MZI18n.SettingsAppExclusionSettings
     _viewContentData: ColumnLayout {
@@ -61,6 +80,32 @@ MZViewBase {
 
             searchBarPlaceholder: searchApps
             enabled: Qt.platform.os === "linux" ? VPNController.state === VPNController.StateOff : true
+        }
+    }
+
+    Loader {
+        id: helpSheetLoader
+
+        active: false
+
+        onActiveChanged: if (active) item.open()
+
+        sourceComponent: MZHelpSheet {
+            title: MZI18n.HelpSheetsExcludedAppsTitle
+
+            model: [
+                {type: MZHelpSheet.BlockType.Title, text: MZI18n.HelpSheetsExcludedAppsHeader},
+                {type: MZHelpSheet.BlockType.Text, text: MZI18n.HelpSheetsExcludedAppsBody1, margin: 8},
+                {type: MZHelpSheet.BlockType.Text, text:MZI18n.HelpSheetsExcludedAppsBody2, margin: 16},
+                {type: MZHelpSheet.BlockType.Text, text:MZI18n.HelpSheetsExcludedAppsBody3, margin: 16},
+                {type: MZHelpSheet.BlockType.PrimaryButton, text: MZI18n.HelpSheetsExcludedAppsCTA, margin: 16, action: () => {
+                        close()
+                        getStack().push("qrc:/ui/screens/settings/privacy/ViewPrivacy.qml")
+                    }},
+                {type: MZHelpSheet.BlockType.LinkButton, text: MZI18n.GlobalLearnMore, margin: 8, action: () => { MZUrlOpener.openUrlLabel("sumoExcludedApps") } },
+            ]
+
+            onClosed: helpSheetLoader.active = false
         }
     }
 


### PR DESCRIPTION
## Description

**NOTE: Depends on [#8864: VPN-4687: Add DNS settings help sheet](https://github.com/mozilla-mobile/mozilla-vpn-client/pull/8864)**

- Implement help sheet for excluded apps

https://github.com/mozilla-mobile/mozilla-vpn-client/assets/15353801/bfde51ba-a118-4824-ad77-edccd191f8da

## Reference

[VPN-4690: Implement the 'App Exclusions' in-product help sheet](https://mozilla-hub.atlassian.net/browse/VPN-4690)