### PR TITLE
VPN-5594 Use a diffrent Settings File for testing and running the client!

### DIFF
--- a/src/constants.h
+++ b/src/constants.h
@@ -68,7 +68,6 @@ QString versionString();
 QString buildNumber();
 QString envOrDefault(const QString& name, const QString& defaultValue);
 
-
 // The prefix for the user-agent requests
 constexpr const char* NETWORK_USERAGENT_PREFIX = "MozillaVPN";
 

--- a/src/constants.h
+++ b/src/constants.h
@@ -68,8 +68,6 @@ QString versionString();
 QString buildNumber();
 QString envOrDefault(const QString& name, const QString& defaultValue);
 
-// This is used by SettingsHolder to configure the QSetting file.
-constexpr const char* SETTINGS_APP_NAME = "vpn";
 
 // The prefix for the user-agent requests
 constexpr const char* NETWORK_USERAGENT_PREFIX = "MozillaVPN";

--- a/src/settings/settingsmanager.cpp
+++ b/src/settings/settingsmanager.cpp
@@ -27,13 +27,12 @@ constexpr const char* SETTINGS_ORGANIZATION_NAME = "mozilla_testing";
 #endif
 
 #if defined UNIT_TEST
-  constexpr const char* SETTINGS_APP_NAME = "vpn_unit";
+constexpr const char* SETTINGS_APP_NAME = "vpn_unit";
 #elif defined MZ_DUMMY
-  constexpr const char* SETTINGS_APP_NAME = "vpn_dummy";
-#else 
-  constexpr const char* SETTINGS_APP_NAME = "vpn";
+constexpr const char* SETTINGS_APP_NAME = "vpn_dummy";
+#else
+constexpr const char* SETTINGS_APP_NAME = "vpn";
 #endif
-
 
 const QSettings::Format MozFormat = QSettings::registerFormat(
     "moz", CryptoSettings::readFile, CryptoSettings::writeFile);

--- a/src/settings/settingsmanager.cpp
+++ b/src/settings/settingsmanager.cpp
@@ -10,7 +10,6 @@
 #include <QSettings>
 #include <QStandardPaths>
 
-#include "constants.h"
 #include "cryptosettings.h"
 #include "leakdetector.h"
 #include "logger.h"
@@ -26,6 +25,15 @@ constexpr const char* SETTINGS_ORGANIZATION_NAME = "mozilla";
 #else
 constexpr const char* SETTINGS_ORGANIZATION_NAME = "mozilla_testing";
 #endif
+
+#if defined UNIT_TEST
+  constexpr const char* SETTINGS_APP_NAME = "vpn_unit";
+#elif defined MZ_DUMMY
+  constexpr const char* SETTINGS_APP_NAME = "vpn_dummy";
+#else 
+  constexpr const char* SETTINGS_APP_NAME = "vpn";
+#endif
+
 
 const QSettings::Format MozFormat = QSettings::registerFormat(
     "moz", CryptoSettings::readFile, CryptoSettings::writeFile);
@@ -52,7 +60,7 @@ void SettingsManager::testCleanup() {
 SettingsManager::SettingsManager(QObject* parent)
     : QObject(parent),
       m_settings(MozFormat, QSettings::UserScope, SETTINGS_ORGANIZATION_NAME,
-                 Constants::SETTINGS_APP_NAME),
+                 SETTINGS_APP_NAME),
       m_settingsConnector(this, &m_settings) {
   MZ_COUNT_CTOR(SettingsManager);
 


### PR DESCRIPTION
## Description

The Functional tests are using the same Settings file as the normal vpn client. 
This set's settings like "only use localhost requests" which means i always need to nuke that file after running tests. 
Let's have this file per-test suite. 
