### PR TITLE
VPN-4307 Use registerAndReturnError to replace deprecated API for managing LoginItems

### DIFF
--- a/src/platforms/macos/macosutils.mm
+++ b/src/platforms/macos/macosutils.mm
@@ -38,33 +38,38 @@ QString MacOSUtils::computerName() {
 void MacOSUtils::enableLoginItem(bool startAtBoot) {
   logger.debug() << "Enabling login-item";
 
-  NSString* appId = MacOSUtils::appId();
+  NSString * appId = MacOSUtils::appId();
   Q_ASSERT(appId);
 
-  NSString* loginItemAppId =
+  NSString * loginItemAppId =
     QString("%1.login-item").arg(QString::fromNSString(appId)).toNSString();
-  
+
   // For macOS 13 and beyond, register() and unregister() methods
   // are used for managing login items since SMLoginItemSetEnabled() is deprecated.
   // For versions prior to macOS 13, SMLoginItemSetEnabled() is used.
-    if (@available(macOS 13, *)) {
-      // Use register() or unregister() based on the startAtBoot flag
-      NSError *error = nil;
-      if (startAtBoot) {
-        if (![[SMAppService mainAppService] registerAndReturnError:&error]) {
-          logger.error() << "Failed to register Mozilla VPN LoginItem: " << error.localizedDescription;
-        } else {
-          logger.debug() << "Mozilla VPN LoginItem registered successfully.";
-        }
+  if (@available(macOS 13, *)) {
+    // Use register() or unregister() based on the startAtBoot flag
+    NSError * error = nil;
+
+    if (startAtBoot) {
+      if (![
+          [SMAppService mainAppService] registerAndReturnError: & error
+        ]) {
+        logger.error() << "Failed to register Mozilla VPN LoginItem: " << error.localizedDescription;
       } else {
-        if (![[SMAppService mainAppService] unregisterAndReturnError:&error]) {
-          logger.error() << "Failed to unregister Mozilla VPN LoginItem: " << error.localizedDescription;
-        } else {
-          logger.debug() << "LoginItem unregistered successfully.";
-        }
+        logger.debug() << "Mozilla VPN LoginItem registered successfully.";
       }
     } else {
-    CFStringRef cfs = (__bridge CFStringRef)loginItemAppId;
+      if (![
+          [SMAppService mainAppService] unregisterAndReturnError: & error
+        ]) {
+        logger.error() << "Failed to unregister Mozilla VPN LoginItem: " << error.localizedDescription;
+      } else {
+        logger.debug() << "LoginItem unregistered successfully.";
+      }
+    }
+  } else {
+    CFStringRef cfs = (__bridge CFStringRef) loginItemAppId;
     Boolean ok = SMLoginItemSetEnabled(cfs, startAtBoot ? YES : NO);
     logger.debug() << "Result: " << ok;
   }

--- a/src/platforms/macos/macosutils.mm
+++ b/src/platforms/macos/macosutils.mm
@@ -11,8 +11,6 @@
 
 #import <Cocoa/Cocoa.h>
 #import <ServiceManagement/ServiceManagement.h>
-#import <ServiceManagement/SMAppService.h>
-#import <ServiceManagement/SMLoginItem.h>
 
 namespace {
 Logger logger("MacOSUtils");

--- a/src/platforms/macos/macosutils.mm
+++ b/src/platforms/macos/macosutils.mm
@@ -11,6 +11,8 @@
 
 #import <Cocoa/Cocoa.h>
 #import <ServiceManagement/ServiceManagement.h>
+#import <ServiceManagement/SMAppService.h>
+#import <ServiceManagement/SMLoginItem.h>
 
 namespace {
 Logger logger("MacOSUtils");
@@ -42,11 +44,35 @@ void MacOSUtils::enableLoginItem(bool startAtBoot) {
   Q_ASSERT(appId);
 
   NSString* loginItemAppId =
-      QString("%1.login-item").arg(QString::fromNSString(appId)).toNSString();
-  CFStringRef cfs = (__bridge CFStringRef)loginItemAppId;
-
-  Boolean ok = SMLoginItemSetEnabled(cfs, startAtBoot ? YES : NO);
-  logger.debug() << "Result: " << ok;
+    QString("%1.login-item").arg(QString::fromNSString(appId)).toNSString();
+  
+  // For macOS 13 and beyond, register() and unregister() methods
+  // are used for managing login items since SMLoginItemSetEnabled() is deprecated.
+  // For versions prior to macOS 13, SMLoginItemSetEnabled() is used.
+  #if defined(__MAC_13_0) && (__MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_13_0)
+    if (@available(macOS 13, *)) {
+      // Use register() or unregister() based on the startAtBoot flag
+      NSError *error = nil;
+      if (startAtBoot) {
+        if (![[SMAppService mainAppService] registerAndReturnError:&error]) {
+          logger.error() << "Failed to register Mozilla VPN LoginItem: " << error.localizedDescription;
+        } else {
+          logger.debug() << "Mozilla VPN LoginItem registered successfully.";
+        }
+      } else {
+        if (![[SMAppService mainAppService] unregisterAndReturnError:&error]) {
+          logger.error() << "Failed to unregister Mozilla VPN LoginItem: " << error.localizedDescription;
+        } else {
+          logger.debug() << "LoginItem unregistered successfully.";
+        }
+      }
+    } else
+  #endif
+  {
+    CFStringRef cfs = (__bridge CFStringRef)loginItemAppId;
+    Boolean ok = SMLoginItemSetEnabled(cfs, startAtBoot ? YES : NO);
+    logger.debug() << "Result: " << ok;
+  }
 }
 
 namespace {

--- a/src/platforms/macos/macosutils.mm
+++ b/src/platforms/macos/macosutils.mm
@@ -38,10 +38,10 @@ QString MacOSUtils::computerName() {
 void MacOSUtils::enableLoginItem(bool startAtBoot) {
   logger.debug() << "Enabling login-item";
 
-  NSString * appId = MacOSUtils::appId();
+  NSString* appId = MacOSUtils::appId();
   Q_ASSERT(appId);
 
-  NSString * loginItemAppId =
+  NSString* loginItemAppId =
     QString("%1.login-item").arg(QString::fromNSString(appId)).toNSString();
 
   // For macOS 13 and beyond, register() and unregister() methods
@@ -49,20 +49,16 @@ void MacOSUtils::enableLoginItem(bool startAtBoot) {
   // For versions prior to macOS 13, SMLoginItemSetEnabled() is used.
   if (@available(macOS 13, *)) {
     // Use register() or unregister() based on the startAtBoot flag
-    NSError * error = nil;
+    NSError* error = nil;
 
     if (startAtBoot) {
-      if (![
-          [SMAppService mainAppService] registerAndReturnError: & error
-        ]) {
+      if (![[SMAppService mainAppService] registerAndReturnError: & error]) {
         logger.error() << "Failed to register Mozilla VPN LoginItem: " << error.localizedDescription;
       } else {
         logger.debug() << "Mozilla VPN LoginItem registered successfully.";
       }
     } else {
-      if (![
-          [SMAppService mainAppService] unregisterAndReturnError: & error
-        ]) {
+      if (![[SMAppService mainAppService] unregisterAndReturnError: & error]) {
         logger.error() << "Failed to unregister Mozilla VPN LoginItem: " << error.localizedDescription;
       } else {
         logger.debug() << "LoginItem unregistered successfully.";

--- a/src/platforms/macos/macosutils.mm
+++ b/src/platforms/macos/macosutils.mm
@@ -49,7 +49,6 @@ void MacOSUtils::enableLoginItem(bool startAtBoot) {
   // For macOS 13 and beyond, register() and unregister() methods
   // are used for managing login items since SMLoginItemSetEnabled() is deprecated.
   // For versions prior to macOS 13, SMLoginItemSetEnabled() is used.
-  #if defined(__MAC_13_0) && (__MAC_OS_X_VERSION_MAX_ALLOWED >= __MAC_13_0)
     if (@available(macOS 13, *)) {
       // Use register() or unregister() based on the startAtBoot flag
       NSError *error = nil;
@@ -66,9 +65,7 @@ void MacOSUtils::enableLoginItem(bool startAtBoot) {
           logger.debug() << "LoginItem unregistered successfully.";
         }
       }
-    } else
-  #endif
-  {
+    } else {
     CFStringRef cfs = (__bridge CFStringRef)loginItemAppId;
     Boolean ok = SMLoginItemSetEnabled(cfs, startAtBoot ? YES : NO);
     logger.debug() << "Result: " << ok;


### PR DESCRIPTION
## Description

Update the API we use to manage loginItems and startAtBoot. What we were using(`SMLoginItemSetEnabled()`) is deprecated on MacOS 13 and beyond and is replaced by `registerAndReturnError` and `unregisterAndReturnError`. To continue backwards compatibility, if the OS is older than MacOS 13 we still fall back to the old way of managing login items.

## Reference

https://mozilla-hub.atlassian.net/browse/VPN-4126
https://mozilla-hub.atlassian.net/browse/VPN-4307

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
