### PR TITLE
VPN-6067: Null check navigator screen layers

### DIFF
--- a/src/frontend/navigator.cpp
+++ b/src/frontend/navigator.cpp
@@ -181,17 +181,19 @@ void Navigator::requestScreenFromBottomBar(
   // screens stack view, which would be the view currently being displayed
   for (ScreenData& screen : s_screens) {
     if (screen.m_screen == m_currentScreen) {
-      auto layers = screen.m_layers;
+      // Make sure the screen has a layer (stack or view added via
+      // Navigator::addView() or Navigator::addStackView())
+      if (screen.m_layers.isEmpty()) {
+        break;
+      }
 
-      QString telemetryScreenId =
-          layers.last().m_layer->property("telemetryScreenId").toString();
+      QString telemetryScreenId = screen.m_layers.last()
+                                      .m_layer->property("telemetryScreenId")
+                                      .toString();
 
-      // Make sure the screen has a view (and it has been added to the layers
-      // via Navigator::addView(), and that view has a non-empty
-      // "telemetryScreenId" property
-      // TODO in VPN-6039 - support screens as well (not just views on top of
-      // screens)
-      if (layers.length() < 1 || telemetryScreenId.isEmpty()) {
+      // Make sure the layer has a "telemetryScreenId" property
+      // If it doesn't, telemetryScreenId will be an empty string
+      if (telemetryScreenId.isEmpty()) {
         break;
       }
 

--- a/tests/unit_tests/testnavigator.cpp
+++ b/tests/unit_tests/testnavigator.cpp
@@ -14,6 +14,7 @@
 #include "localizer.h"
 #include "mozillavpn.h"
 #include "qmlengineholder.h"
+#include "qmlpath.h"
 #include "settingsholder.h"
 
 void TestNavigator::init() {
@@ -193,6 +194,15 @@ void TestNavigator::testNavbarButtonTelemetry() {
       mozilla::glean::interaction::settings_selected.testGetNumRecordedErrors(
           ErrorType::InvalidOverflow),
       0);
+
+  // Delete the stack view from the settings screen (such that ScreenSettings
+  // has no layers added to it) and ensure the application does not crash when
+  // switching screens and generating nav bar button telemetry from a screen
+  // containing no layers
+  QmlPath qmlPath("//settings-stackView");
+  QCOMPARE(qmlPath.isValid(), true);
+  qmlPath.evaluate(&engine)->deleteLater();
+  Navigator::instance()->requestScreenFromBottomBar(MozillaVPN::ScreenHome);
 }
 
 static TestNavigator s_testNavigator;

--- a/tests/unit_tests/testnavigator.h
+++ b/tests/unit_tests/testnavigator.h
@@ -11,8 +11,10 @@ class TestNavigator final : public TestHelper {
 
  private slots:
   void init();
+  void cleanup();
 
   void testNavbarButtonTelemetry();
+  void testNavbarButtonTelemetryNoLayers();
 
  private:
   SettingsHolder* m_settingsHolder = nullptr;


### PR DESCRIPTION
## Description

- Make sure the screen that is being navigated away from (on nav bar button click) has at least one layer (stack or view) before attempting to get it's `telemetryScreenId` property

## Reference

[VPN-6067: [Intermittent] [macOS] Mozilla VPN is crashing without clear steps while the VPN is OFF](https://mozilla-hub.atlassian.net/browse/VPN-6067)
