### PR TITLE
VPN-5855 - Part 1 - Parse experimentalFeatures property returned from featurelist Guardian endpoint

### DIFF
--- a/src/addons/manager/addonmanager.cpp
+++ b/src/addons/manager/addonmanager.cpp
@@ -434,7 +434,6 @@ void AddonManager::reinstateMessages() const {
 
   // Group containing all the message settings.
   // It only needs to live for the scope of this function.
-  QObject parent;
   SettingGroup* messageSettingGroup =
       SettingsManager::instance()->createSettingGroup(
           ADDON_MESSAGE_SETTINGS_GROUP);

--- a/src/feature/feature.cpp
+++ b/src/feature/feature.cpp
@@ -21,6 +21,25 @@ QList<Feature*>* s_featuresList = nullptr;
 }  // namespace
 
 // static
+#ifdef UNIT_TEST
+void Feature::testReset() {
+  if (!s_featuresList) {
+    return;
+  }
+
+  // We can't use qDeleteAll. There are nullptrs in the list sometimes.
+  foreach (Feature* feature, *s_featuresList) {
+    if (feature) {
+      delete feature;
+    }
+  }
+
+  s_featuresHashtable = nullptr;
+  s_featuresList = nullptr;
+}
+#endif
+
+// static
 void Feature::maybeInitialize() {
   if (!s_featuresHashtable) {
     s_featuresHashtable = new QMap<QString, Feature*>();

--- a/src/feature/feature.cpp
+++ b/src/feature/feature.cpp
@@ -10,6 +10,7 @@
 #include "constants.h"
 #include "featurelistcallback.h"
 #include "logger.h"
+#include "settings/settinggroup.h"
 #include "settingsholder.h"
 #include "versionutils.h"
 
@@ -36,7 +37,8 @@ void Feature::maybeInitialize() {
 
 #define EXPERIMENTAL_FEATURE(id, name, ...)                          \
   new Feature(#id, name, FeatureCallback_true, FeatureCallback_true, \
-              QStringList(), FeatureCallback_false);
+              QStringList(), FeatureCallback_false,                  \
+              SettingsHolder::instance()->id());
 #include "experimentalfeaturelist.h"
 #undef EXPERIMENTAL_FEATURE
   }
@@ -46,14 +48,15 @@ Feature::Feature(const QString& id, const QString& name,
                  std::function<bool()>&& flippableOn,
                  std::function<bool()>&& flippableOff,
                  const QStringList& featureDependencies,
-                 std::function<bool()>&& callback)
+                 std::function<bool()>&& callback, SettingGroup* settingGroup)
     : QObject(qApp),
       m_id(id),
       m_name(name),
       m_flippableOn(std::move(flippableOn)),
       m_flippableOff(std::move(flippableOff)),
       m_featureDependencies(featureDependencies),
-      m_callback(std::move(callback)) {
+      m_callback(std::move(callback)),
+      m_settingGroup(settingGroup) {
   logger.debug() << "Initializing feature" << id;
 
   Q_ASSERT(s_featuresHashtable);

--- a/src/feature/feature.h
+++ b/src/feature/feature.h
@@ -8,6 +8,8 @@
 #include <QApplication>
 #include <QObject>
 
+class SettingGroup;
+
 class Feature : public QObject {
   Q_OBJECT
 
@@ -37,7 +39,8 @@ class Feature : public QObject {
           std::function<bool()>&& flippableOn,
           std::function<bool()>&& flippableOff,
           const QStringList& otherFeatureDependencies,
-          std::function<bool()>&& callback);
+          std::function<bool()>&& callback,
+          SettingGroup* settingGroup = nullptr);
   ~Feature();
 
  public:
@@ -65,6 +68,19 @@ class Feature : public QObject {
   bool isToggleable() const;
 
   QString id() const { return m_id; }
+
+  /**
+   * @brief Returns the group of settings related to this feature.
+   *
+   * Currently only experimental features have this. Other features will return
+   * a nullptr here.
+   *
+   * @return SettingGroup*
+   */
+  SettingGroup* settingGroup() const {
+    Q_ASSERT(m_settingGroup);
+    return m_settingGroup;
+  }
 
  signals:
   // This signal is emitted if the underlying factors for support changed e.g
@@ -112,6 +128,9 @@ class Feature : public QObject {
     FlippedOff,
   };
   State m_state = DefaultValue;
+
+  // Features may have a group of settings related to them.
+  SettingGroup* m_settingGroup = nullptr;
 
 #ifdef UNIT_TEST
   friend class TestAddonIndex;

--- a/src/feature/feature.h
+++ b/src/feature/feature.h
@@ -78,9 +78,17 @@ class Feature : public QObject {
    * @return SettingGroup*
    */
   SettingGroup* settingGroup() const {
+    maybeInitialize();
+
     Q_ASSERT(m_settingGroup);
     return m_settingGroup;
   }
+
+#ifdef UNIT_TEST
+  static void testReset();
+#endif
+
+  static void maybeInitialize();
 
  signals:
   // This signal is emitted if the underlying factors for support changed e.g
@@ -89,7 +97,6 @@ class Feature : public QObject {
   void supportedChanged();
 
  private:
-  static void maybeInitialize();
   void maybeFlipOnOrOff();
 
   // Returns true if this feature is flipped on via settings

--- a/src/feature/featuremodel.cpp
+++ b/src/feature/featuremodel.cpp
@@ -67,6 +67,12 @@ void featureToggleOn(const QString& feature, bool add_to_on) {
   }
 }
 
+// Comprehensive list of experimental feature ids.
+//
+// This is required due to the format of the object parsed by
+// FeatureModel::parseExperimentalFeatures. The object only contains the
+// features that must be enabled. Feature not in the object must be disabled,
+// this list is used to check what is not in the list.
 QStringList experimentalFeatureIds({
 #define EXPERIMENTAL_FEATURE(id, ...) #id,
 #include "experimentalfeaturelist.h"
@@ -225,6 +231,9 @@ QPair<QStringList, QStringList> FeatureModel::parseExperimentalFeatures(
   QJsonObject experimentalFeaturesObj = experimentalFeatures.toObject();
 
   QStringList experimentalFeaturesToToggleOn = experimentalFeaturesObj.keys();
+
+  // Starts with all features. As experimentalFeaturesToToggleOn are parsed,
+  // they are removed from this list.
   QStringList experimentalFeaturesToToggleOff = experimentalFeatureIds;
 
   for (const QString& key : experimentalFeaturesToToggleOn) {
@@ -292,7 +301,6 @@ void FeatureModel::updateFeatureList(const QByteArray& data) {
     auto experimentalFeaturesToToggleOff = parsedExperimentalFeatures.second;
 
     // Disable features that should be toggled off.
-    qDebug() << experimentalFeaturesToToggleOff;
     foreach (const QString& feature, featuresToToggleOn) {
       if (experimentalFeaturesToToggleOff.contains(feature)) {
         featuresToToggleOn.removeAll(feature);

--- a/src/feature/featuremodel.cpp
+++ b/src/feature/featuremodel.cpp
@@ -158,19 +158,19 @@ QObject* FeatureModel::get(const QString& feature) {
 }
 
 // static
-void FeatureModel::updateFeatures(QJsonValue featuresOverwrite) {
+void FeatureModel::updateFeatures(const QJsonValue& features) {
   SettingsHolder* settingsHolder = SettingsHolder::instance();
   Q_ASSERT(settingsHolder);
 
-  if (!featuresOverwrite.isObject()) {
-    logger.error() << "Error in the featuresOverwrite json format";
+  if (!features.isObject()) {
+    logger.error() << "Error in the features json format";
     return;
   }
 
   QStringList featuresFlippedOn;
   QStringList featuresFlippedOff;
 
-  QJsonObject featuresObj = featuresOverwrite.toObject();
+  QJsonObject featuresObj = features.toObject();
   for (const QString& key : featuresObj.keys()) {
     QJsonValue value = featuresObj.value(key);
     if (!value.isBool()) {
@@ -206,7 +206,8 @@ void FeatureModel::updateFeatures(QJsonValue featuresOverwrite) {
 }
 
 // static
-void FeatureModel::updateExperimentalFeatures(QJsonValue experimentalFeatures) {
+void FeatureModel::updateExperimentalFeatures(
+    const QJsonValue& experimentalFeatures) {
   if (!experimentalFeatures.isObject()) {
     logger.error() << "Error in the json format: experimentalFeatures is"
                       "not an object.";
@@ -251,12 +252,12 @@ void FeatureModel::updateExperimentalFeatures(QJsonValue experimentalFeatures) {
   }
 }
 
-void FeatureModel::parseRemoteFeatureList(const QByteArray& data) {
+void FeatureModel::parseFeatureList(const QByteArray& data) {
   QJsonObject json = QJsonDocument::fromJson(data).object();
 
   if (json.contains("featuresOverwrite")) {
-    QJsonValue featuresValue = json["featuresOverwrite"];
-    updateFeatures(featuresValue);
+    QJsonValue features = json["featuresOverwrite"];
+    updateFeatures(features);
   }
 
   if (json.contains("experimentalFeatures")) {

--- a/src/feature/featuremodel.cpp
+++ b/src/feature/featuremodel.cpp
@@ -157,193 +157,110 @@ QObject* FeatureModel::get(const QString& feature) {
   return obj;
 }
 
-void FeatureModel::updateFeatureList(const QByteArray& data) {
+// static
+void FeatureModel::updateFeatures(QJsonValue featuresOverwrite) {
   SettingsHolder* settingsHolder = SettingsHolder::instance();
   Q_ASSERT(settingsHolder);
 
-  QJsonObject json = QJsonDocument::fromJson(data).object();
-  if (json.contains("featuresOverwrite")) {
-    QJsonValue featuresValue = json["featuresOverwrite"];
-    if (!featuresValue.isObject()) {
-      logger.error() << "Error in the json format";
+  if (!featuresOverwrite.isObject()) {
+    logger.error() << "Error in the featuresOverwrite json format";
+    return;
+  }
+
+  QStringList featuresFlippedOn;
+  QStringList featuresFlippedOff;
+
+  QJsonObject featuresObj = featuresOverwrite.toObject();
+  for (const QString& key : featuresObj.keys()) {
+    QJsonValue value = featuresObj.value(key);
+    if (!value.isBool()) {
+      logger.error() << "Error in parsing feature enabling:" << key;
+      continue;
+    }
+
+    const Feature* feature = Feature::getOrNull(key);
+    if (!feature) {
+      logger.error() << "No feature named" << key;
+      continue;
+    }
+
+    if (value.toBool()) {
+      if (!feature->isFlippableOn()) {
+        logger.error() << "Feature" << key << "cannot be flipped on";
+        continue;
+      }
+
+      featuresFlippedOn.append(key);
+    } else {
+      if (!feature->isFlippableOff()) {
+        logger.error() << "Feature" << key << "cannot be flipped off";
+        continue;
+      }
+
+      featuresFlippedOff.append(key);
+    }
+  }
+
+  settingsHolder->setFeaturesFlippedOn(featuresFlippedOn);
+  settingsHolder->setFeaturesFlippedOff(featuresFlippedOff);
+}
+
+// static
+void FeatureModel::updateExperimentalFeatures(QJsonValue experimentalFeatures) {
+  if (!experimentalFeatures.isObject()) {
+    logger.error() << "Error in the json format: experimentalFeatures is"
+                      "not an object.";
+    return;
+  }
+
+  QJsonObject experimentalFeaturesObj = experimentalFeatures.toObject();
+  logger.debug() << experimentalFeaturesObj.keys();
+  for (const QString& key : experimentalFeaturesObj.keys()) {
+    const Feature* experimentalFeature = Feature::getOrNull(key);
+    if (!experimentalFeature) {
+      logger.warning() << "Got" << key
+                       << "but experimental feature doesn't exist. Ignoring.";
+      continue;
+    }
+
+    QJsonValue experimentalFeatureSettings = experimentalFeaturesObj[key];
+    if (!experimentalFeatureSettings.isObject()) {
+      logger.error() << "Error in the json format: experimentalFeature" << key
+                     << "is not an object.";
       return;
     }
 
-    QStringList featuresFlippedOn;
-    QStringList featuresFlippedOff;
-
-    QJsonObject featuresObj = featuresValue.toObject();
-    for (const QString& key : featuresObj.keys()) {
-      QJsonValue value = featuresObj.value(key);
-      if (!value.isBool()) {
-        logger.error() << "Error in parsing feature enabling:" << key;
+    QJsonObject experimentalFeatureSettingsObj =
+        experimentalFeatureSettings.toObject();
+    for (const QString& settingKey : experimentalFeatureSettingsObj.keys()) {
+      auto value = experimentalFeatureSettingsObj[settingKey].toVariant();
+      if (value.isNull()) {
+        logger.warning()
+            << "Received null value for experimental feature setting"
+            << settingKey;
         continue;
       }
 
-      const Feature* feature = Feature::getOrNull(key);
-      if (!feature) {
-        logger.error() << "No feature named" << key;
-        continue;
-      }
+      logger.debug() << "Setting experimental feature setting" << settingKey;
 
-      if (value.toBool()) {
-        if (!feature->isFlippableOn()) {
-          logger.error() << "Feature" << key << "cannot be flipped on";
-          continue;
-        }
-
-        featuresFlippedOn.append(key);
-      } else {
-        if (!feature->isFlippableOff()) {
-          logger.error() << "Feature" << key << "cannot be flipped off";
-          continue;
-        }
-
-        featuresFlippedOff.append(key);
-      }
+      experimentalFeature->settingGroup()->set(settingKey, value);
     }
 
-    settingsHolder->setFeaturesFlippedOn(featuresFlippedOn);
-    settingsHolder->setFeaturesFlippedOff(featuresFlippedOff);
+    logger.debug() << "Toggling experimental feature" << key << "on.";
+    featureToggleOn(key, true);
+  }
+}
+
+void FeatureModel::parseRemoteFeatureList(const QByteArray& data) {
+  QJsonObject json = QJsonDocument::fromJson(data).object();
+
+  if (json.contains("featuresOverwrite")) {
+    QJsonValue featuresValue = json["featuresOverwrite"];
+    updateFeatures(featuresValue);
   }
 
   if (json.contains("experimentalFeatures")) {
-    logger.debug() << "Attempting to parse experimental features.";
-
     QJsonValue experimentalFeatures = json["experimentalFeatures"];
-
-    if (!experimentalFeatures.isObject()) {
-      logger.error() << "Error in the json format: experimentalFeatures is"
-                        "not an object.";
-      return;
-    }
-
-    QJsonObject experimentalFeaturesObj = experimentalFeatures.toObject();
-    logger.debug() << experimentalFeaturesObj.keys();
-    for (const QString& key : experimentalFeaturesObj.keys()) {
-      const Feature* experimentalFeature = Feature::getOrNull(key);
-      if (!experimentalFeature) {
-        logger.warning() << "Got" << key
-                         << "but experimental feature doesn't exist. Ignoring.";
-        continue;
-      }
-
-      QJsonValue experimentalFeatureSettings = experimentalFeaturesObj[key];
-      if (!experimentalFeatureSettings.isObject()) {
-        logger.error() << "Error in the json format: experimentalFeature" << key
-                       << "is not an object.";
-        return;
-      }
-
-      QJsonObject experimentalFeatureSettingsObj =
-          experimentalFeatureSettings.toObject();
-      for (const QString& settingKey : experimentalFeatureSettingsObj.keys()) {
-        auto value = experimentalFeatureSettingsObj[settingKey].toVariant();
-        if (value.isNull()) {
-          logger.warning()
-              << "Received null value for experimental feature setting"
-              << settingKey;
-          continue;
-        }
-
-        logger.debug() << "Setting experimental feature setting" << settingKey;
-
-        experimentalFeature->settingGroup()->set(settingKey, value);
-      }
-
-      logger.debug() << "Toggling experimental feature" << key << "on.";
-      featureToggleOn(key, true);
-    }
+    updateExperimentalFeatures(experimentalFeatures);
   }
-
-#ifdef MZ_ADJUST
-  QJsonValue adjustFieldsValue = json["adjustFields"];
-  if (adjustFieldsValue.isUndefined()) {
-    logger.debug() << "No adjust fields found in feature list";
-    return;
-  }
-
-  if (!adjustFieldsValue.isObject()) {
-    logger.error()
-        << "Error in the json format; adjust fields is not an object";
-    return;
-  }
-
-  QJsonValue allowParameterValue = adjustFieldsValue["allowParameters"];
-  if (!allowParameterValue.isArray()) {
-    logger.error()
-        << "Error in the json format; allow parameters are not an array";
-    return;
-  }
-
-  QJsonArray allowParametersArray = allowParameterValue.toArray();
-  for (const QJsonValue& param : allowParametersArray) {
-    if (!param.isString()) {
-      logger.error()
-          << "Error in the json format; allowlist parameter is not a string";
-      continue;
-    }
-    AdjustFiltering::instance()->allowField(param.toString());
-  }
-
-  QJsonValue denyParameterValue = adjustFieldsValue["denyParameters"];
-  if (!denyParameterValue.isObject()) {
-    logger.error()
-        << "Error in the json format; deny parameters in not an object";
-    return;
-  }
-
-  QJsonObject denyParameterObject = denyParameterValue.toObject();
-  for (const QString& key : denyParameterObject.keys()) {
-    QJsonValue value = denyParameterObject.value(key);
-    if (!value.isString()) {
-      logger.error()
-          << "Error in the json format; deny list parameter is not a string";
-      continue;
-    }
-
-    AdjustFiltering::instance()->denyField(key, value.toString());
-  }
-
-  QJsonValue mirrorParameterValue = adjustFieldsValue["mirrorParameters"];
-  if (!mirrorParameterValue.isObject()) {
-    logger.error()
-        << "Error in the json format; mirror parameters are not an object";
-    return;
-  }
-
-  QJsonObject mirrorParameterObject = mirrorParameterValue.toObject();
-  for (const QString& key : mirrorParameterObject.keys()) {
-    QJsonValue values = mirrorParameterObject.value(key);
-    if (!values.isArray()) {
-      logger.error() << "Error in the json format; mirror parameters value is "
-                        "not an array";
-      continue;
-    }
-
-    QJsonArray valuesArray = values.toArray();
-    if (valuesArray.size() != 2) {
-      logger.error()
-          << "Error in the json format; mirror value is not an array";
-      continue;
-    }
-
-    QJsonValue mirrorParamValue = valuesArray.first();
-    if (!mirrorParamValue.isString()) {
-      logger.error()
-          << "Error in the json format; mirroring field is not a string";
-      continue;
-    }
-
-    QJsonValue defaultValue = valuesArray.last();
-    if (!defaultValue.isString()) {
-      logger.error()
-          << "Error in the json format; mirror default value is not a string";
-      continue;
-    }
-
-    AdjustFiltering::instance()->mirrorField(
-        key, {mirrorParamValue.toString(), defaultValue.toString()});
-  }
-#endif
 }

--- a/src/feature/featuremodel.cpp
+++ b/src/feature/featuremodel.cpp
@@ -238,7 +238,7 @@ void FeatureModel::updateExperimentalFeatures(
         experimentalFeatureSettings.toObject();
     for (const QString& settingKey : experimentalFeatureSettingsObj.keys()) {
       auto value = experimentalFeatureSettingsObj[settingKey].toVariant();
-      if (value.isNull()) {
+      if (!value.isValid() || value.isNull()) {
         logger.warning()
             << "Received null value for experimental feature setting"
             << settingKey;

--- a/src/feature/featuremodel.h
+++ b/src/feature/featuremodel.h
@@ -7,6 +7,7 @@
 
 #include <QAbstractListModel>
 #include <QObject>
+#include <QPair>
 
 class Feature;
 
@@ -24,7 +25,7 @@ class FeatureModel final : public QAbstractListModel {
 
   static FeatureModel* instance();
 
-  void parseFeatureList(const QByteArray& data);
+  void updateFeatureList(const QByteArray& data);
 
   // QAbstractListModel methods
   QHash<int, QByteArray> roleNames() const override;
@@ -35,8 +36,9 @@ class FeatureModel final : public QAbstractListModel {
   Q_INVOKABLE QObject* get(const QString& feature);
 
  private:
-  static void updateFeatures(const QJsonValue& featuresOverwrite);
-  static void updateExperimentalFeatures(
+  static QPair<QStringList, QStringList> parseFeatures(
+      const QJsonValue& features);
+  static QPair<QStringList, QStringList> parseExperimentalFeatures(
       const QJsonValue& experimentalFeatures);
 };
 

--- a/src/feature/featuremodel.h
+++ b/src/feature/featuremodel.h
@@ -36,8 +36,51 @@ class FeatureModel final : public QAbstractListModel {
   Q_INVOKABLE QObject* get(const QString& feature);
 
  private:
+  /**
+   * @brief Parses an object with a list of features to enable / disable.
+   *
+   * The expected format of the object is:
+   *
+   * ```json
+   * {
+   *   "featureToEnable": true,
+   *   "featureToDisable": false,
+   * }
+   * ```
+   *
+   * Features _not_ in the object are ignored by this function.
+   *
+   * @param features
+   * @return QPair<QStringList, QStringList> Returns the a list of the feature
+   * to enabled and disable respectively.
+   */
   static QPair<QStringList, QStringList> parseFeatures(
       const QJsonValue& features);
+
+  /**
+   * @brief Parses an object with a list of experimental features to enable /
+   * disable and the values of related experimental feature settings.
+   *
+   * The expected format of the object is:
+   *
+   * ```json
+   * {
+   *   "experimentalFeatureToEnable": {
+   *      "aFeatureSetting": "aha!"
+   *   },
+   *   "anotherExperimentalFeatureToEnable": {
+   *      "anotherFeatureSetting": 42
+   *   },
+   * }
+   * ```
+   *
+   * Experimental features _not_ in the object are disabled.
+   *
+   *
+   * @param features
+   * @return QPair<QStringList, QStringList> Returns the a list of the feature
+   * to enabled and disable respectively.
+   */
   static QPair<QStringList, QStringList> parseExperimentalFeatures(
       const QJsonValue& experimentalFeatures);
 };

--- a/src/feature/featuremodel.h
+++ b/src/feature/featuremodel.h
@@ -24,7 +24,7 @@ class FeatureModel final : public QAbstractListModel {
 
   static FeatureModel* instance();
 
-  void parseRemoteFeatureList(const QByteArray& data);
+  void parseFeatureList(const QByteArray& data);
 
   // QAbstractListModel methods
   QHash<int, QByteArray> roleNames() const override;
@@ -35,8 +35,9 @@ class FeatureModel final : public QAbstractListModel {
   Q_INVOKABLE QObject* get(const QString& feature);
 
  private:
-  static void updateFeatures(QJsonValue featuresOverwrite);
-  static void updateExperimentalFeatures(QJsonValue experimentalFeatures);
+  static void updateFeatures(const QJsonValue& featuresOverwrite);
+  static void updateExperimentalFeatures(
+      const QJsonValue& experimentalFeatures);
 };
 
 #endif  // FEATUREMODEL_H

--- a/src/feature/featuremodel.h
+++ b/src/feature/featuremodel.h
@@ -78,7 +78,7 @@ class FeatureModel final : public QAbstractListModel {
    *
    *
    * @param features
-   * @return QPair<QStringList, QStringList> Returns the a list of the feature
+   * @return QPair<QStringList, QStringList> Returns a list of the feature
    * to enabled and disable respectively.
    */
   static QPair<QStringList, QStringList> parseExperimentalFeatures(

--- a/src/feature/featuremodel.h
+++ b/src/feature/featuremodel.h
@@ -24,7 +24,7 @@ class FeatureModel final : public QAbstractListModel {
 
   static FeatureModel* instance();
 
-  void updateFeatureList(const QByteArray& data);
+  void parseRemoteFeatureList(const QByteArray& data);
 
   // QAbstractListModel methods
   QHash<int, QByteArray> roleNames() const override;
@@ -33,6 +33,10 @@ class FeatureModel final : public QAbstractListModel {
 
   Q_INVOKABLE void toggle(const QString& feature);
   Q_INVOKABLE QObject* get(const QString& feature);
+
+ private:
+  static void updateFeatures(QJsonValue featuresOverwrite);
+  static void updateExperimentalFeatures(QJsonValue experimentalFeatures);
 };
 
 #endif  // FEATUREMODEL_H

--- a/src/settings/settinggroup.cpp
+++ b/src/settings/settinggroup.cpp
@@ -18,7 +18,7 @@ SettingGroup::SettingGroup(QObject* parent,
       m_removeWhenReset(removeWhenReset),
       m_acceptedKeys(acceptedKeys),
       m_settingsConnector(settingsConnector) {
-  MZ_COUNT_CTOR(Setting);
+  MZ_COUNT_CTOR(SettingGroup);
 
   // Group settings are dynamic, therefore we need to load from memory all
   // settings that exist under this group prefix in order to emit change signals
@@ -28,7 +28,7 @@ SettingGroup::SettingGroup(QObject* parent,
   }
 }
 
-SettingGroup::~SettingGroup() { MZ_COUNT_DTOR(Setting); }
+SettingGroup::~SettingGroup() { MZ_COUNT_DTOR(SettingGroup); }
 
 void SettingGroup::addSetting(const QString& key) {
   auto settingKey = buildSettingKeyWithGroupPrefix(key);
@@ -37,7 +37,7 @@ void SettingGroup::addSetting(const QString& key) {
       m_sensitiveSetting);
 
   // Emit the group change signal for this group when the setting is changed.
-  connect(setting, &Setting::changed, this, [this]() { emit changed(); });
+  connect(setting, &Setting::changed, this, [&]() { emit changed(); });
 }
 
 bool SettingGroup::isAcceptedKey(const QString& key) {

--- a/src/settings/settinggroup.cpp
+++ b/src/settings/settinggroup.cpp
@@ -37,7 +37,7 @@ void SettingGroup::addSetting(const QString& key) {
       m_sensitiveSetting);
 
   // Emit the group change signal for this group when the setting is changed.
-  connect(setting, &Setting::changed, this, [&]() { emit changed(); });
+  connect(setting, &Setting::changed, this, [this]() { emit changed(); });
 }
 
 bool SettingGroup::isAcceptedKey(const QString& key) {

--- a/src/tasks/getfeaturelist/taskgetfeaturelist.cpp
+++ b/src/tasks/getfeaturelist/taskgetfeaturelist.cpp
@@ -36,7 +36,7 @@ void TaskGetFeatureList::run() {
   connect(request, &NetworkRequest::requestCompleted, this,
           [this](const QByteArray& data) {
             logger.debug() << "Get feature list is completed" << data;
-            FeatureModel::instance()->parseRemoteFeatureList(data);
+            FeatureModel::instance()->parseFeatureList(data);
             emit completed();
           });
 }

--- a/src/tasks/getfeaturelist/taskgetfeaturelist.cpp
+++ b/src/tasks/getfeaturelist/taskgetfeaturelist.cpp
@@ -36,7 +36,7 @@ void TaskGetFeatureList::run() {
   connect(request, &NetworkRequest::requestCompleted, this,
           [this](const QByteArray& data) {
             logger.debug() << "Get feature list is completed" << data;
-            FeatureModel::instance()->updateFeatureList(data);
+            FeatureModel::instance()->parseRemoteFeatureList(data);
             emit completed();
           });
 }

--- a/src/tasks/getfeaturelist/taskgetfeaturelist.cpp
+++ b/src/tasks/getfeaturelist/taskgetfeaturelist.cpp
@@ -36,7 +36,7 @@ void TaskGetFeatureList::run() {
   connect(request, &NetworkRequest::requestCompleted, this,
           [this](const QByteArray& data) {
             logger.debug() << "Get feature list is completed" << data;
-            FeatureModel::instance()->parseFeatureList(data);
+            FeatureModel::instance()->updateFeatureList(data);
             emit completed();
           });
 }

--- a/tests/unit_tests/feature/testfeaturemodel.cpp
+++ b/tests/unit_tests/feature/testfeaturemodel.cpp
@@ -133,8 +133,7 @@ void TestFeatureModel::parseFeatureListOverwriteFeatures() {
   QJsonObject json;
   json["featuresOverwrite"] = obj;
 
-  FeatureModel::instance()->parseRemoteFeatureList(
-      QJsonDocument(json).toJson());
+  FeatureModel::instance()->parseFeatureList(QJsonDocument(json).toJson());
   QVERIFY(settingsHolder.featuresFlippedOn().contains("testFeatureA"));
   QVERIFY(settingsHolder.featuresFlippedOn().contains("testFeatureB"));
   QVERIFY(!settingsHolder.featuresFlippedOn().contains("testFeatureC"));
@@ -150,8 +149,7 @@ void TestFeatureModel::parseFeatureListOverwriteFeatures() {
   obj["testFeatureC"] = false;
   json["featuresOverwrite"] = obj;
 
-  FeatureModel::instance()->parseRemoteFeatureList(
-      QJsonDocument(json).toJson());
+  FeatureModel::instance()->parseFeatureList(QJsonDocument(json).toJson());
   QVERIFY(!settingsHolder.featuresFlippedOn().contains("testFeatureA"));
   QVERIFY(!settingsHolder.featuresFlippedOn().contains("testFeatureB"));
   QVERIFY(!settingsHolder.featuresFlippedOn().contains("testFeatureC"));
@@ -177,7 +175,7 @@ void TestFeatureModel::parseFeatureListExperimentalFeaturesEmpty() {
   // Empty object ¯\_(ツ)_/¯
   QJsonObject experimentalFeatures;
   obj["experimentalFeatures"] = experimentalFeatures;
-  FeatureModel::instance()->parseRemoteFeatureList(QJsonDocument(obj).toJson());
+  FeatureModel::instance()->parseFeatureList(QJsonDocument(obj).toJson());
 
   // Nothing happened, because we got an empty object
   QCOMPARE(initialFeaturesOnState.count(),
@@ -198,7 +196,7 @@ void TestFeatureModel::parseFeatureListExperimentalFeaturesNotObject() {
 
   QJsonObject obj;
   obj["experimentalFeatures"] = "notanobject";
-  FeatureModel::instance()->parseRemoteFeatureList(QJsonDocument(obj).toJson());
+  FeatureModel::instance()->parseFeatureList(QJsonDocument(obj).toJson());
 
   // Nothing happened, because we got misformatted input
   QCOMPARE(initialFeaturesOnState.count(),
@@ -223,7 +221,7 @@ void TestFeatureModel::parseFeatureListExperimentalFeaturesUnknownExperiment() {
   experimentalFeatures["unknownExperiment"] = unknownExperiment;
   obj["experimentalFeatures"] = experimentalFeatures;
 
-  FeatureModel::instance()->parseRemoteFeatureList(QJsonDocument(obj).toJson());
+  FeatureModel::instance()->parseFeatureList(QJsonDocument(obj).toJson());
 
   // Nothing happened, because we got an unknown feature
   QCOMPARE(initialFeaturesOnState.count(),
@@ -248,7 +246,7 @@ void TestFeatureModel::
   experimentalFeatures["unknownExperiment"] = "notanobject";
   obj["experimentalFeatures"] = experimentalFeatures;
 
-  FeatureModel::instance()->parseRemoteFeatureList(QJsonDocument(obj).toJson());
+  FeatureModel::instance()->parseFeatureList(QJsonDocument(obj).toJson());
 
   // Nothing happened, because we got a misconfigured feature
   QCOMPARE(initialFeaturesOnState.count(),
@@ -273,7 +271,7 @@ void TestFeatureModel::parseFeatureListExperimentalFeaturesNoSettings() {
   experimentalFeatures["myExperimentalFeature"] = myExperimentalFeature;
   obj["experimentalFeatures"] = experimentalFeatures;
 
-  FeatureModel::instance()->parseRemoteFeatureList(QJsonDocument(obj).toJson());
+  FeatureModel::instance()->parseFeatureList(QJsonDocument(obj).toJson());
 
   // Finally, it is flipped on!
   QCOMPARE(initialFeaturesOnState.count() + 1,
@@ -307,7 +305,7 @@ void TestFeatureModel::parseFeatureListExperimentalFeaturesInvalidSettings() {
   experimentalFeatures["myExperimentalFeature"] = myExperimentalFeature;
   obj["experimentalFeatures"] = experimentalFeatures;
 
-  FeatureModel::instance()->parseRemoteFeatureList(QJsonDocument(obj).toJson());
+  FeatureModel::instance()->parseFeatureList(QJsonDocument(obj).toJson());
 
   // It is flipped on!
   QCOMPARE(initialFeaturesOnState.count() + 1,
@@ -339,7 +337,7 @@ void TestFeatureModel::parseFeatureListExperimentalFeaturesValidSettings() {
   experimentalFeatures["myExperimentalFeature"] = myExperimentalFeature;
   obj["experimentalFeatures"] = experimentalFeatures;
 
-  FeatureModel::instance()->parseRemoteFeatureList(QJsonDocument(obj).toJson());
+  FeatureModel::instance()->parseFeatureList(QJsonDocument(obj).toJson());
 
   // It is flipped on!
   QCOMPARE(initialFeaturesOnState.count() + 1,

--- a/tests/unit_tests/feature/testfeaturemodel.cpp
+++ b/tests/unit_tests/feature/testfeaturemodel.cpp
@@ -10,16 +10,29 @@
 #include "helper.h"
 #include "settingsholder.h"
 
-void TestFeatureModel::flipOnOff() {
-  SettingsHolder settingsHolder;
+namespace {
+SettingsHolder* s_settingsHolder = nullptr;
+}
 
+void TestFeatureModel::init() {
+  s_settingsHolder = new SettingsHolder();
+
+  Feature::maybeInitialize();
+}
+
+void TestFeatureModel::cleanup() {
+  delete s_settingsHolder;
+  Feature::testReset();
+}
+
+void TestFeatureModel::flipOnOff() {
   // Fresh settings!
-  QVERIFY(!settingsHolder.featuresFlippedOn().contains("testFeatureA"));
-  QVERIFY(!settingsHolder.featuresFlippedOn().contains("testFeatureB"));
-  QVERIFY(!settingsHolder.featuresFlippedOn().contains("testFeatureC"));
-  QVERIFY(!settingsHolder.featuresFlippedOff().contains("testFeatureA"));
-  QVERIFY(!settingsHolder.featuresFlippedOff().contains("testFeatureB"));
-  QVERIFY(!settingsHolder.featuresFlippedOff().contains("testFeatureC"));
+  QVERIFY(!s_settingsHolder->featuresFlippedOn().contains("testFeatureA"));
+  QVERIFY(!s_settingsHolder->featuresFlippedOn().contains("testFeatureB"));
+  QVERIFY(!s_settingsHolder->featuresFlippedOn().contains("testFeatureC"));
+  QVERIFY(!s_settingsHolder->featuresFlippedOff().contains("testFeatureA"));
+  QVERIFY(!s_settingsHolder->featuresFlippedOff().contains("testFeatureB"));
+  QVERIFY(!s_settingsHolder->featuresFlippedOff().contains("testFeatureC"));
 
   // Let's create a few features
 
@@ -57,44 +70,43 @@ void TestFeatureModel::flipOnOff() {
 
   // On -> On(+flip off)
   fm->toggle("testFeatureA");
-  QVERIFY(!settingsHolder.featuresFlippedOn().contains("testFeatureA"));
-  QVERIFY(settingsHolder.featuresFlippedOff().contains("testFeatureA"));
+  QVERIFY(!s_settingsHolder->featuresFlippedOn().contains("testFeatureA"));
+  QVERIFY(s_settingsHolder->featuresFlippedOff().contains("testFeatureA"));
   QVERIFY(!Feature::get("testFeatureA")->isSupported());
 
   // On(+flip off) -> On
   fm->toggle("testFeatureA");
-  QVERIFY(!settingsHolder.featuresFlippedOn().contains("testFeatureA"));
-  QVERIFY(!settingsHolder.featuresFlippedOff().contains("testFeatureA"));
+  QVERIFY(!s_settingsHolder->featuresFlippedOn().contains("testFeatureA"));
+  QVERIFY(!s_settingsHolder->featuresFlippedOff().contains("testFeatureA"));
   QVERIFY(Feature::get("testFeatureA")->isSupported());
 
   // Off -> Off(+flip on)
   fm->toggle("testFeatureB");
-  QVERIFY(settingsHolder.featuresFlippedOn().contains("testFeatureB"));
-  QVERIFY(!settingsHolder.featuresFlippedOff().contains("testFeatureB"));
+  QVERIFY(s_settingsHolder->featuresFlippedOn().contains("testFeatureB"));
+  QVERIFY(!s_settingsHolder->featuresFlippedOff().contains("testFeatureB"));
   QVERIFY(Feature::get("testFeatureB")->isSupported());
 
   // Off(+flip on) -> Off
   fm->toggle("testFeatureB");
-  QVERIFY(!settingsHolder.featuresFlippedOn().contains("testFeatureB"));
-  QVERIFY(!settingsHolder.featuresFlippedOff().contains("testFeatureB"));
+  QVERIFY(!s_settingsHolder->featuresFlippedOn().contains("testFeatureB"));
+  QVERIFY(!s_settingsHolder->featuresFlippedOff().contains("testFeatureB"));
   QVERIFY(!Feature::get("testFeatureB")->isSupported());
 
   // Flipping on an unflippable feature doesn't produce changes.
   fm->toggle("testFeatureC");
-  QVERIFY(!settingsHolder.featuresFlippedOn().contains("testFeatureC"));
-  QVERIFY(!settingsHolder.featuresFlippedOff().contains("testFeatureC"));
+  QVERIFY(!s_settingsHolder->featuresFlippedOn().contains("testFeatureC"));
+  QVERIFY(!s_settingsHolder->featuresFlippedOff().contains("testFeatureC"));
   QVERIFY(!Feature::get("testFeatureC")->isSupported());
 }
 
 void TestFeatureModel::updateFeatureListOverwriteFeatures() {
-  SettingsHolder settingsHolder;
-  // Fresh settings!
-  QVERIFY(!settingsHolder.featuresFlippedOn().contains("testFeatureA"));
-  QVERIFY(!settingsHolder.featuresFlippedOn().contains("testFeatureB"));
-  QVERIFY(!settingsHolder.featuresFlippedOn().contains("testFeatureC"));
-  QVERIFY(!settingsHolder.featuresFlippedOff().contains("testFeatureA"));
-  QVERIFY(!settingsHolder.featuresFlippedOff().contains("testFeatureB"));
-  QVERIFY(!settingsHolder.featuresFlippedOff().contains("testFeatureC"));
+  // Fresh settings
+  QVERIFY(!s_settingsHolder->featuresFlippedOn().contains("testFeatureA"));
+  QVERIFY(!s_settingsHolder->featuresFlippedOn().contains("testFeatureB"));
+  QVERIFY(!s_settingsHolder->featuresFlippedOn().contains("testFeatureC"));
+  QVERIFY(!s_settingsHolder->featuresFlippedOff().contains("testFeatureA"));
+  QVERIFY(!s_settingsHolder->featuresFlippedOff().contains("testFeatureB"));
+  QVERIFY(!s_settingsHolder->featuresFlippedOff().contains("testFeatureC"));
 
   // Let's create a few features
 
@@ -134,12 +146,12 @@ void TestFeatureModel::updateFeatureListOverwriteFeatures() {
   json["featuresOverwrite"] = obj;
 
   FeatureModel::instance()->updateFeatureList(QJsonDocument(json).toJson());
-  QVERIFY(settingsHolder.featuresFlippedOn().contains("testFeatureA"));
-  QVERIFY(settingsHolder.featuresFlippedOn().contains("testFeatureB"));
-  QVERIFY(!settingsHolder.featuresFlippedOn().contains("testFeatureC"));
-  QVERIFY(!settingsHolder.featuresFlippedOff().contains("testFeatureA"));
-  QVERIFY(!settingsHolder.featuresFlippedOff().contains("testFeatureB"));
-  QVERIFY(!settingsHolder.featuresFlippedOff().contains("testFeatureC"));
+  QVERIFY(s_settingsHolder->featuresFlippedOn().contains("testFeatureA"));
+  QVERIFY(s_settingsHolder->featuresFlippedOn().contains("testFeatureB"));
+  QVERIFY(!s_settingsHolder->featuresFlippedOn().contains("testFeatureC"));
+  QVERIFY(!s_settingsHolder->featuresFlippedOff().contains("testFeatureA"));
+  QVERIFY(!s_settingsHolder->featuresFlippedOff().contains("testFeatureB"));
+  QVERIFY(!s_settingsHolder->featuresFlippedOff().contains("testFeatureC"));
   QVERIFY(Feature::get("testFeatureA")->isSupported());
   QVERIFY(Feature::get("testFeatureB")->isSupported());
   QVERIFY(!Feature::get("testFeatureC")->isSupported());
@@ -150,24 +162,22 @@ void TestFeatureModel::updateFeatureListOverwriteFeatures() {
   json["featuresOverwrite"] = obj;
 
   FeatureModel::instance()->updateFeatureList(QJsonDocument(json).toJson());
-  QVERIFY(!settingsHolder.featuresFlippedOn().contains("testFeatureA"));
-  QVERIFY(!settingsHolder.featuresFlippedOn().contains("testFeatureB"));
-  QVERIFY(!settingsHolder.featuresFlippedOn().contains("testFeatureC"));
-  QVERIFY(settingsHolder.featuresFlippedOff().contains("testFeatureA"));
-  QVERIFY(settingsHolder.featuresFlippedOff().contains("testFeatureB"));
-  QVERIFY(!settingsHolder.featuresFlippedOff().contains("testFeatureC"));
+  QVERIFY(!s_settingsHolder->featuresFlippedOn().contains("testFeatureA"));
+  QVERIFY(!s_settingsHolder->featuresFlippedOn().contains("testFeatureB"));
+  QVERIFY(!s_settingsHolder->featuresFlippedOn().contains("testFeatureC"));
+  QVERIFY(s_settingsHolder->featuresFlippedOff().contains("testFeatureA"));
+  QVERIFY(s_settingsHolder->featuresFlippedOff().contains("testFeatureB"));
+  QVERIFY(!s_settingsHolder->featuresFlippedOff().contains("testFeatureC"));
   QVERIFY(!Feature::get("testFeatureA")->isSupported());
   QVERIFY(!Feature::get("testFeatureB")->isSupported());
   QVERIFY(!Feature::get("testFeatureC")->isSupported());
 }
 
 void TestFeatureModel::updateFeatureListExperimentalFeaturesEmpty() {
-  SettingsHolder settingsHolder;
-
   // Clean up the features state.
-  settingsHolder.setFeaturesFlippedOn({});
+  s_settingsHolder->setFeaturesFlippedOn({});
 
-  auto initialFeaturesOnState = settingsHolder.featuresFlippedOn();
+  auto initialFeaturesOnState = s_settingsHolder->featuresFlippedOn();
 
   QJsonObject obj;
   // Empty object ¯\_(ツ)_/¯
@@ -177,16 +187,14 @@ void TestFeatureModel::updateFeatureListExperimentalFeaturesEmpty() {
 
   // Nothing happened, because we got an empty object
   QCOMPARE(initialFeaturesOnState.count(),
-           settingsHolder.featuresFlippedOn().count());
+           s_settingsHolder->featuresFlippedOn().count());
 }
 
 void TestFeatureModel::updateFeatureListExperimentalFeaturesNotObject() {
-  SettingsHolder settingsHolder;
-
   // Clean up the features state.
-  settingsHolder.setFeaturesFlippedOn({});
+  s_settingsHolder->setFeaturesFlippedOn({});
 
-  auto initialFeaturesOnState = settingsHolder.featuresFlippedOn();
+  auto initialFeaturesOnState = s_settingsHolder->featuresFlippedOn();
 
   QJsonObject obj;
   obj["experimentalFeatures"] = "notanobject";
@@ -194,17 +202,15 @@ void TestFeatureModel::updateFeatureListExperimentalFeaturesNotObject() {
 
   // Nothing happened, because we got misformatted input
   QCOMPARE(initialFeaturesOnState.count(),
-           settingsHolder.featuresFlippedOn().count());
+           s_settingsHolder->featuresFlippedOn().count());
 }
 
 void TestFeatureModel::
     updateFeatureListExperimentalFeaturesUnknownExperiment() {
-  SettingsHolder settingsHolder;
-
   // Clean up the features state.
-  settingsHolder.setFeaturesFlippedOn({});
+  s_settingsHolder->setFeaturesFlippedOn({});
 
-  auto initialFeaturesOnState = settingsHolder.featuresFlippedOn();
+  auto initialFeaturesOnState = s_settingsHolder->featuresFlippedOn();
 
   QJsonObject obj;
   QJsonObject experimentalFeatures;
@@ -216,17 +222,15 @@ void TestFeatureModel::
 
   // Nothing happened, because we got an unknown feature
   QCOMPARE(initialFeaturesOnState.count(),
-           settingsHolder.featuresFlippedOn().count());
+           s_settingsHolder->featuresFlippedOn().count());
 }
 
 void TestFeatureModel::
     updateFeatureListExperimentalFeaturesNonObjectExperiment() {
-  SettingsHolder settingsHolder;
-
   // Clean up the features state.
-  settingsHolder.setFeaturesFlippedOn({});
+  s_settingsHolder->setFeaturesFlippedOn({});
 
-  auto initialFeaturesOnState = settingsHolder.featuresFlippedOn();
+  auto initialFeaturesOnState = s_settingsHolder->featuresFlippedOn();
 
   QJsonObject obj;
   QJsonObject experimentalFeatures;
@@ -237,16 +241,14 @@ void TestFeatureModel::
 
   // Nothing happened, because we got a misconfigured feature
   QCOMPARE(initialFeaturesOnState.count(),
-           settingsHolder.featuresFlippedOn().count());
+           s_settingsHolder->featuresFlippedOn().count());
 }
 
 void TestFeatureModel::updateFeatureListExperimentalFeaturesNoSettings() {
-  SettingsHolder settingsHolder;
-
   // Clean up the features state.
-  settingsHolder.setFeaturesFlippedOn({});
+  s_settingsHolder->setFeaturesFlippedOn({});
 
-  auto initialFeaturesOnState = settingsHolder.featuresFlippedOn();
+  auto initialFeaturesOnState = s_settingsHolder->featuresFlippedOn();
 
   QJsonObject obj;
   QJsonObject experimentalFeatures;
@@ -258,22 +260,21 @@ void TestFeatureModel::updateFeatureListExperimentalFeaturesNoSettings() {
 
   // Finally, it is flipped on!
   QCOMPARE(initialFeaturesOnState.count() + 1,
-           settingsHolder.featuresFlippedOn().count());
-  QVERIFY(settingsHolder.featuresFlippedOn().contains("myExperimentalFeature"));
+           s_settingsHolder->featuresFlippedOn().count());
+  QVERIFY(
+      s_settingsHolder->featuresFlippedOn().contains("myExperimentalFeature"));
 
   // No settings were set though, settings were empty.
-  QVERIFY(!settingsHolder.myExperimentalFeature()->get("one").isValid());
-  QVERIFY(!settingsHolder.myExperimentalFeature()->get("two").isValid());
-  QVERIFY(!settingsHolder.myExperimentalFeature()->get("three").isValid());
+  QVERIFY(!s_settingsHolder->myExperimentalFeature()->get("one").isValid());
+  QVERIFY(!s_settingsHolder->myExperimentalFeature()->get("two").isValid());
+  QVERIFY(!s_settingsHolder->myExperimentalFeature()->get("three").isValid());
 }
 
 void TestFeatureModel::updateFeatureListExperimentalFeaturesInvalidSettings() {
-  SettingsHolder settingsHolder;
-
   // Clean up the features state.
-  settingsHolder.setFeaturesFlippedOn({});
+  s_settingsHolder->setFeaturesFlippedOn({});
 
-  auto initialFeaturesOnState = settingsHolder.featuresFlippedOn();
+  auto initialFeaturesOnState = s_settingsHolder->featuresFlippedOn();
 
   QJsonObject obj;
   QJsonObject experimentalFeatures;
@@ -288,22 +289,21 @@ void TestFeatureModel::updateFeatureListExperimentalFeaturesInvalidSettings() {
 
   // It is flipped on!
   QCOMPARE(initialFeaturesOnState.count() + 1,
-           settingsHolder.featuresFlippedOn().count());
-  QVERIFY(settingsHolder.featuresFlippedOn().contains("myExperimentalFeature"));
+           s_settingsHolder->featuresFlippedOn().count());
+  QVERIFY(
+      s_settingsHolder->featuresFlippedOn().contains("myExperimentalFeature"));
 
   // No settings were set though, settings had invalid values
-  QVERIFY(!settingsHolder.myExperimentalFeature()->get("one").isValid());
-  QVERIFY(!settingsHolder.myExperimentalFeature()->get("two").isValid());
-  QVERIFY(!settingsHolder.myExperimentalFeature()->get("three").isValid());
+  QVERIFY(!s_settingsHolder->myExperimentalFeature()->get("one").isValid());
+  QVERIFY(!s_settingsHolder->myExperimentalFeature()->get("two").isValid());
+  QVERIFY(!s_settingsHolder->myExperimentalFeature()->get("three").isValid());
 }
 
 void TestFeatureModel::updateFeatureListExperimentalFeaturesValidSettings() {
-  SettingsHolder settingsHolder;
-
   // Clean up the features state.
-  settingsHolder.setFeaturesFlippedOn({});
+  s_settingsHolder->setFeaturesFlippedOn({});
 
-  auto initialFeaturesOnState = settingsHolder.featuresFlippedOn();
+  auto initialFeaturesOnState = s_settingsHolder->featuresFlippedOn();
 
   QJsonObject obj;
   QJsonObject experimentalFeatures;
@@ -318,25 +318,25 @@ void TestFeatureModel::updateFeatureListExperimentalFeaturesValidSettings() {
 
   // It is flipped on!
   QCOMPARE(initialFeaturesOnState.count() + 1,
-           settingsHolder.featuresFlippedOn().count());
-  QVERIFY(settingsHolder.featuresFlippedOn().contains("myExperimentalFeature"));
+           s_settingsHolder->featuresFlippedOn().count());
+  QVERIFY(
+      s_settingsHolder->featuresFlippedOn().contains("myExperimentalFeature"));
 
   // And finally, the settings were set!
-  QCOMPARE(settingsHolder.myExperimentalFeature()->get("one").toString(),
+  QCOMPARE(s_settingsHolder->myExperimentalFeature()->get("one").toString(),
            "one");
-  QCOMPARE(settingsHolder.myExperimentalFeature()->get("two").toString(),
+  QCOMPARE(s_settingsHolder->myExperimentalFeature()->get("two").toString(),
            "two");
-  QCOMPARE(settingsHolder.myExperimentalFeature()->get("three").toString(),
+  QCOMPARE(s_settingsHolder->myExperimentalFeature()->get("three").toString(),
            "three");
 }
 
 void TestFeatureModel::updateFeatureListExperimentalFeaturesToggleOnOff() {
-  SettingsHolder settingsHolder;
+  // Setup the initial feature state with some random features that shouldn't be
+  // messed with by meddling with the experimental features.
+  s_settingsHolder->setFeaturesFlippedOn({"some", "random", "feature"});
 
-  // Clean up the features state.
-  settingsHolder.setFeaturesFlippedOn({});
-
-  auto initialFeaturesOnState = settingsHolder.featuresFlippedOn();
+  auto initialFeaturesOnState = s_settingsHolder->featuresFlippedOn();
 
   QJsonObject obj;
   QJsonObject experimentalFeatures;
@@ -348,8 +348,12 @@ void TestFeatureModel::updateFeatureListExperimentalFeaturesToggleOnOff() {
 
   // It is flipped on!
   QCOMPARE(initialFeaturesOnState.count() + 1,
-           settingsHolder.featuresFlippedOn().count());
-  QVERIFY(settingsHolder.featuresFlippedOn().contains("myExperimentalFeature"));
+           s_settingsHolder->featuresFlippedOn().count());
+  QVERIFY(
+      s_settingsHolder->featuresFlippedOn().contains("myExperimentalFeature"));
+  QVERIFY(s_settingsHolder->featuresFlippedOn().contains("some"));
+  QVERIFY(s_settingsHolder->featuresFlippedOn().contains("random"));
+  QVERIFY(s_settingsHolder->featuresFlippedOn().contains("feature"));
 
   QJsonObject emptyObj;
   obj["experimentalFeatures"] = emptyObj;
@@ -357,9 +361,12 @@ void TestFeatureModel::updateFeatureListExperimentalFeaturesToggleOnOff() {
 
   // It is flipped off!
   QCOMPARE(initialFeaturesOnState.count(),
-           settingsHolder.featuresFlippedOn().count());
+           s_settingsHolder->featuresFlippedOn().count());
   QVERIFY(
-      !settingsHolder.featuresFlippedOn().contains("myExperimentalFeature"));
+      !s_settingsHolder->featuresFlippedOn().contains("myExperimentalFeature"));
+  QVERIFY(s_settingsHolder->featuresFlippedOn().contains("some"));
+  QVERIFY(s_settingsHolder->featuresFlippedOn().contains("random"));
+  QVERIFY(s_settingsHolder->featuresFlippedOn().contains("feature"));
 }
 
 static TestFeatureModel s_testFeature;

--- a/tests/unit_tests/feature/testfeaturemodel.cpp
+++ b/tests/unit_tests/feature/testfeaturemodel.cpp
@@ -86,7 +86,7 @@ void TestFeatureModel::flipOnOff() {
   QVERIFY(!Feature::get("testFeatureC")->isSupported());
 }
 
-void TestFeatureModel::updateFeatureListOverwriteFeatures() {
+void TestFeatureModel::parseFeatureListOverwriteFeatures() {
   SettingsHolder settingsHolder;
   // Fresh settings!
   QVERIFY(!settingsHolder.featuresFlippedOn().contains("testFeatureA"));
@@ -133,7 +133,8 @@ void TestFeatureModel::updateFeatureListOverwriteFeatures() {
   QJsonObject json;
   json["featuresOverwrite"] = obj;
 
-  FeatureModel::instance()->updateFeatureList(QJsonDocument(json).toJson());
+  FeatureModel::instance()->parseRemoteFeatureList(
+      QJsonDocument(json).toJson());
   QVERIFY(settingsHolder.featuresFlippedOn().contains("testFeatureA"));
   QVERIFY(settingsHolder.featuresFlippedOn().contains("testFeatureB"));
   QVERIFY(!settingsHolder.featuresFlippedOn().contains("testFeatureC"));
@@ -149,7 +150,8 @@ void TestFeatureModel::updateFeatureListOverwriteFeatures() {
   obj["testFeatureC"] = false;
   json["featuresOverwrite"] = obj;
 
-  FeatureModel::instance()->updateFeatureList(QJsonDocument(json).toJson());
+  FeatureModel::instance()->parseRemoteFeatureList(
+      QJsonDocument(json).toJson());
   QVERIFY(!settingsHolder.featuresFlippedOn().contains("testFeatureA"));
   QVERIFY(!settingsHolder.featuresFlippedOn().contains("testFeatureB"));
   QVERIFY(!settingsHolder.featuresFlippedOn().contains("testFeatureC"));
@@ -159,33 +161,9 @@ void TestFeatureModel::updateFeatureListOverwriteFeatures() {
   QVERIFY(!Feature::get("testFeatureA")->isSupported());
   QVERIFY(!Feature::get("testFeatureB")->isSupported());
   QVERIFY(!Feature::get("testFeatureC")->isSupported());
-
-  obj["allowParameters"] = QJsonArray{"allowTest"};
-
-  QJsonObject deny;
-  deny["denyTest"] = "test";
-  obj["denyParameters"] = deny;
-
-  QJsonObject mirror;
-  mirror["mirrorTest"] = QJsonArray{"test", "testValue"};
-  obj["mirrorParameters"] = mirror;
-
-  json["adjustFields"] = obj;
-
-  FeatureModel::instance()->updateFeatureList(QJsonDocument(json).toJson());
-  QVERIFY(AdjustFiltering::instance()->allowList.contains("allowTest"));
-  QVERIFY(AdjustFiltering::instance()->denyList.contains("denyTest"));
-  QVERIFY(AdjustFiltering::instance()->denyList.value("denyTest") == "test");
-  QVERIFY(AdjustFiltering::instance()->mirrorList.contains("mirrorTest"));
-  QVERIFY(AdjustFiltering::instance()
-              ->mirrorList.value("mirrorTest")
-              .m_mirrorParamName == "test");
-  QVERIFY(AdjustFiltering::instance()
-              ->mirrorList.value("mirrorTest")
-              .m_defaultValue == "testValue");
 }
 
-void TestFeatureModel::updateFeatureListExperimentalFeaturesEmpty() {
+void TestFeatureModel::parseFeatureListExperimentalFeaturesEmpty() {
   SettingsHolder settingsHolder;
 
   // Clean up the features state.
@@ -199,7 +177,7 @@ void TestFeatureModel::updateFeatureListExperimentalFeaturesEmpty() {
   // Empty object ¯\_(ツ)_/¯
   QJsonObject experimentalFeatures;
   obj["experimentalFeatures"] = experimentalFeatures;
-  FeatureModel::instance()->updateFeatureList(QJsonDocument(obj).toJson());
+  FeatureModel::instance()->parseRemoteFeatureList(QJsonDocument(obj).toJson());
 
   // Nothing happened, because we got an empty object
   QCOMPARE(initialFeaturesOnState.count(),
@@ -208,7 +186,7 @@ void TestFeatureModel::updateFeatureListExperimentalFeaturesEmpty() {
            settingsHolder.featuresFlippedOff().count());
 }
 
-void TestFeatureModel::updateFeatureListExperimentalFeaturesNotObject() {
+void TestFeatureModel::parseFeatureListExperimentalFeaturesNotObject() {
   SettingsHolder settingsHolder;
 
   // Clean up the features state.
@@ -220,7 +198,7 @@ void TestFeatureModel::updateFeatureListExperimentalFeaturesNotObject() {
 
   QJsonObject obj;
   obj["experimentalFeatures"] = "notanobject";
-  FeatureModel::instance()->updateFeatureList(QJsonDocument(obj).toJson());
+  FeatureModel::instance()->parseRemoteFeatureList(QJsonDocument(obj).toJson());
 
   // Nothing happened, because we got misformatted input
   QCOMPARE(initialFeaturesOnState.count(),
@@ -229,8 +207,7 @@ void TestFeatureModel::updateFeatureListExperimentalFeaturesNotObject() {
            settingsHolder.featuresFlippedOff().count());
 }
 
-void TestFeatureModel::
-    updateFeatureListExperimentalFeaturesUnknownExperiment() {
+void TestFeatureModel::parseFeatureListExperimentalFeaturesUnknownExperiment() {
   SettingsHolder settingsHolder;
 
   // Clean up the features state.
@@ -246,7 +223,7 @@ void TestFeatureModel::
   experimentalFeatures["unknownExperiment"] = unknownExperiment;
   obj["experimentalFeatures"] = experimentalFeatures;
 
-  FeatureModel::instance()->updateFeatureList(QJsonDocument(obj).toJson());
+  FeatureModel::instance()->parseRemoteFeatureList(QJsonDocument(obj).toJson());
 
   // Nothing happened, because we got an unknown feature
   QCOMPARE(initialFeaturesOnState.count(),
@@ -256,7 +233,7 @@ void TestFeatureModel::
 }
 
 void TestFeatureModel::
-    updateFeatureListExperimentalFeaturesNonObjectExperiment() {
+    parseFeatureListExperimentalFeaturesNonObjectExperiment() {
   SettingsHolder settingsHolder;
 
   // Clean up the features state.
@@ -271,7 +248,7 @@ void TestFeatureModel::
   experimentalFeatures["unknownExperiment"] = "notanobject";
   obj["experimentalFeatures"] = experimentalFeatures;
 
-  FeatureModel::instance()->updateFeatureList(QJsonDocument(obj).toJson());
+  FeatureModel::instance()->parseRemoteFeatureList(QJsonDocument(obj).toJson());
 
   // Nothing happened, because we got a misconfigured feature
   QCOMPARE(initialFeaturesOnState.count(),
@@ -280,7 +257,7 @@ void TestFeatureModel::
            settingsHolder.featuresFlippedOff().count());
 }
 
-void TestFeatureModel::updateFeatureListExperimentalFeaturesNoSettings() {
+void TestFeatureModel::parseFeatureListExperimentalFeaturesNoSettings() {
   SettingsHolder settingsHolder;
 
   // Clean up the features state.
@@ -296,7 +273,7 @@ void TestFeatureModel::updateFeatureListExperimentalFeaturesNoSettings() {
   experimentalFeatures["myExperimentalFeature"] = myExperimentalFeature;
   obj["experimentalFeatures"] = experimentalFeatures;
 
-  FeatureModel::instance()->updateFeatureList(QJsonDocument(obj).toJson());
+  FeatureModel::instance()->parseRemoteFeatureList(QJsonDocument(obj).toJson());
 
   // Finally, it is flipped on!
   QCOMPARE(initialFeaturesOnState.count() + 1,
@@ -311,7 +288,7 @@ void TestFeatureModel::updateFeatureListExperimentalFeaturesNoSettings() {
   QVERIFY(!settingsHolder.myExperimentalFeature()->get("three").isValid());
 }
 
-void TestFeatureModel::updateFeatureListExperimentalFeaturesInvalidSettings() {
+void TestFeatureModel::parseFeatureListExperimentalFeaturesInvalidSettings() {
   SettingsHolder settingsHolder;
 
   // Clean up the features state.
@@ -330,7 +307,7 @@ void TestFeatureModel::updateFeatureListExperimentalFeaturesInvalidSettings() {
   experimentalFeatures["myExperimentalFeature"] = myExperimentalFeature;
   obj["experimentalFeatures"] = experimentalFeatures;
 
-  FeatureModel::instance()->updateFeatureList(QJsonDocument(obj).toJson());
+  FeatureModel::instance()->parseRemoteFeatureList(QJsonDocument(obj).toJson());
 
   // It is flipped on!
   QCOMPARE(initialFeaturesOnState.count() + 1,
@@ -343,7 +320,7 @@ void TestFeatureModel::updateFeatureListExperimentalFeaturesInvalidSettings() {
   QVERIFY(!settingsHolder.myExperimentalFeature()->get("three").isValid());
 }
 
-void TestFeatureModel::updateFeatureListExperimentalFeaturesValidSettings() {
+void TestFeatureModel::parseFeatureListExperimentalFeaturesValidSettings() {
   SettingsHolder settingsHolder;
 
   // Clean up the features state.
@@ -362,7 +339,7 @@ void TestFeatureModel::updateFeatureListExperimentalFeaturesValidSettings() {
   experimentalFeatures["myExperimentalFeature"] = myExperimentalFeature;
   obj["experimentalFeatures"] = experimentalFeatures;
 
-  FeatureModel::instance()->updateFeatureList(QJsonDocument(obj).toJson());
+  FeatureModel::instance()->parseRemoteFeatureList(QJsonDocument(obj).toJson());
 
   // It is flipped on!
   QCOMPARE(initialFeaturesOnState.count() + 1,

--- a/tests/unit_tests/feature/testfeaturemodel.cpp
+++ b/tests/unit_tests/feature/testfeaturemodel.cpp
@@ -166,10 +166,8 @@ void TestFeatureModel::parseFeatureListExperimentalFeaturesEmpty() {
 
   // Clean up the features state.
   settingsHolder.setFeaturesFlippedOn({});
-  settingsHolder.setFeaturesFlippedOff({});
 
   auto initialFeaturesOnState = settingsHolder.featuresFlippedOn();
-  auto initialFeaturesOffState = settingsHolder.featuresFlippedOff();
 
   QJsonObject obj;
   // Empty object ¯\_(ツ)_/¯
@@ -180,8 +178,6 @@ void TestFeatureModel::parseFeatureListExperimentalFeaturesEmpty() {
   // Nothing happened, because we got an empty object
   QCOMPARE(initialFeaturesOnState.count(),
            settingsHolder.featuresFlippedOn().count());
-  QCOMPARE(initialFeaturesOffState.count(),
-           settingsHolder.featuresFlippedOff().count());
 }
 
 void TestFeatureModel::parseFeatureListExperimentalFeaturesNotObject() {
@@ -189,10 +185,8 @@ void TestFeatureModel::parseFeatureListExperimentalFeaturesNotObject() {
 
   // Clean up the features state.
   settingsHolder.setFeaturesFlippedOn({});
-  settingsHolder.setFeaturesFlippedOff({});
 
   auto initialFeaturesOnState = settingsHolder.featuresFlippedOn();
-  auto initialFeaturesOffState = settingsHolder.featuresFlippedOff();
 
   QJsonObject obj;
   obj["experimentalFeatures"] = "notanobject";
@@ -201,8 +195,6 @@ void TestFeatureModel::parseFeatureListExperimentalFeaturesNotObject() {
   // Nothing happened, because we got misformatted input
   QCOMPARE(initialFeaturesOnState.count(),
            settingsHolder.featuresFlippedOn().count());
-  QCOMPARE(initialFeaturesOffState.count(),
-           settingsHolder.featuresFlippedOff().count());
 }
 
 void TestFeatureModel::parseFeatureListExperimentalFeaturesUnknownExperiment() {
@@ -210,10 +202,8 @@ void TestFeatureModel::parseFeatureListExperimentalFeaturesUnknownExperiment() {
 
   // Clean up the features state.
   settingsHolder.setFeaturesFlippedOn({});
-  settingsHolder.setFeaturesFlippedOff({});
 
   auto initialFeaturesOnState = settingsHolder.featuresFlippedOn();
-  auto initialFeaturesOffState = settingsHolder.featuresFlippedOff();
 
   QJsonObject obj;
   QJsonObject experimentalFeatures;
@@ -226,8 +216,6 @@ void TestFeatureModel::parseFeatureListExperimentalFeaturesUnknownExperiment() {
   // Nothing happened, because we got an unknown feature
   QCOMPARE(initialFeaturesOnState.count(),
            settingsHolder.featuresFlippedOn().count());
-  QCOMPARE(initialFeaturesOffState.count(),
-           settingsHolder.featuresFlippedOff().count());
 }
 
 void TestFeatureModel::
@@ -236,14 +224,12 @@ void TestFeatureModel::
 
   // Clean up the features state.
   settingsHolder.setFeaturesFlippedOn({});
-  settingsHolder.setFeaturesFlippedOff({});
 
   auto initialFeaturesOnState = settingsHolder.featuresFlippedOn();
-  auto initialFeaturesOffState = settingsHolder.featuresFlippedOff();
 
   QJsonObject obj;
   QJsonObject experimentalFeatures;
-  experimentalFeatures["unknownExperiment"] = "notanobject";
+  experimentalFeatures["myExperimentalFeature"] = "notanobject";
   obj["experimentalFeatures"] = experimentalFeatures;
 
   FeatureModel::instance()->parseFeatureList(QJsonDocument(obj).toJson());
@@ -251,8 +237,6 @@ void TestFeatureModel::
   // Nothing happened, because we got a misconfigured feature
   QCOMPARE(initialFeaturesOnState.count(),
            settingsHolder.featuresFlippedOn().count());
-  QCOMPARE(initialFeaturesOffState.count(),
-           settingsHolder.featuresFlippedOff().count());
 }
 
 void TestFeatureModel::parseFeatureListExperimentalFeaturesNoSettings() {
@@ -260,10 +244,8 @@ void TestFeatureModel::parseFeatureListExperimentalFeaturesNoSettings() {
 
   // Clean up the features state.
   settingsHolder.setFeaturesFlippedOn({});
-  settingsHolder.setFeaturesFlippedOff({});
 
   auto initialFeaturesOnState = settingsHolder.featuresFlippedOn();
-  auto initialFeaturesOffState = settingsHolder.featuresFlippedOff();
 
   QJsonObject obj;
   QJsonObject experimentalFeatures;
@@ -277,8 +259,6 @@ void TestFeatureModel::parseFeatureListExperimentalFeaturesNoSettings() {
   QCOMPARE(initialFeaturesOnState.count() + 1,
            settingsHolder.featuresFlippedOn().count());
   QVERIFY(settingsHolder.featuresFlippedOn().contains("myExperimentalFeature"));
-  QCOMPARE(initialFeaturesOffState.count(),
-           settingsHolder.featuresFlippedOff().count());
 
   // No settings were set though, settings were empty.
   QVERIFY(!settingsHolder.myExperimentalFeature()->get("one").isValid());
@@ -291,10 +271,8 @@ void TestFeatureModel::parseFeatureListExperimentalFeaturesInvalidSettings() {
 
   // Clean up the features state.
   settingsHolder.setFeaturesFlippedOn({});
-  settingsHolder.setFeaturesFlippedOff({});
 
   auto initialFeaturesOnState = settingsHolder.featuresFlippedOn();
-  auto initialFeaturesOffState = settingsHolder.featuresFlippedOff();
 
   QJsonObject obj;
   QJsonObject experimentalFeatures;
@@ -323,10 +301,8 @@ void TestFeatureModel::parseFeatureListExperimentalFeaturesValidSettings() {
 
   // Clean up the features state.
   settingsHolder.setFeaturesFlippedOn({});
-  settingsHolder.setFeaturesFlippedOff({});
 
   auto initialFeaturesOnState = settingsHolder.featuresFlippedOn();
-  auto initialFeaturesOffState = settingsHolder.featuresFlippedOff();
 
   QJsonObject obj;
   QJsonObject experimentalFeatures;
@@ -351,6 +327,38 @@ void TestFeatureModel::parseFeatureListExperimentalFeaturesValidSettings() {
            "two");
   QCOMPARE(settingsHolder.myExperimentalFeature()->get("three").toString(),
            "three");
+}
+
+void TestFeatureModel::parseFeatureListExperimentalFeaturesToggleOnOff() {
+  SettingsHolder settingsHolder;
+
+  // Clean up the features state.
+  settingsHolder.setFeaturesFlippedOn({});
+
+  auto initialFeaturesOnState = settingsHolder.featuresFlippedOn();
+
+  QJsonObject obj;
+  QJsonObject experimentalFeatures;
+  QJsonObject myExperimentalFeature;
+  experimentalFeatures["myExperimentalFeature"] = myExperimentalFeature;
+  obj["experimentalFeatures"] = experimentalFeatures;
+
+  FeatureModel::instance()->parseFeatureList(QJsonDocument(obj).toJson());
+
+  // It is flipped on!
+  QCOMPARE(initialFeaturesOnState.count() + 1,
+           settingsHolder.featuresFlippedOn().count());
+  QVERIFY(settingsHolder.featuresFlippedOn().contains("myExperimentalFeature"));
+
+  QJsonObject emptyObj;
+  obj["experimentalFeatures"] = emptyObj;
+  FeatureModel::instance()->parseFeatureList(QJsonDocument(obj).toJson());
+
+  // It is flipped off!
+  QCOMPARE(initialFeaturesOnState.count(),
+           settingsHolder.featuresFlippedOn().count());
+  QVERIFY(
+      !settingsHolder.featuresFlippedOn().contains("myExperimentalFeature"));
 }
 
 static TestFeatureModel s_testFeature;

--- a/tests/unit_tests/feature/testfeaturemodel.cpp
+++ b/tests/unit_tests/feature/testfeaturemodel.cpp
@@ -86,7 +86,7 @@ void TestFeatureModel::flipOnOff() {
   QVERIFY(!Feature::get("testFeatureC")->isSupported());
 }
 
-void TestFeatureModel::parseFeatureListOverwriteFeatures() {
+void TestFeatureModel::updateFeatureListOverwriteFeatures() {
   SettingsHolder settingsHolder;
   // Fresh settings!
   QVERIFY(!settingsHolder.featuresFlippedOn().contains("testFeatureA"));
@@ -133,7 +133,7 @@ void TestFeatureModel::parseFeatureListOverwriteFeatures() {
   QJsonObject json;
   json["featuresOverwrite"] = obj;
 
-  FeatureModel::instance()->parseFeatureList(QJsonDocument(json).toJson());
+  FeatureModel::instance()->updateFeatureList(QJsonDocument(json).toJson());
   QVERIFY(settingsHolder.featuresFlippedOn().contains("testFeatureA"));
   QVERIFY(settingsHolder.featuresFlippedOn().contains("testFeatureB"));
   QVERIFY(!settingsHolder.featuresFlippedOn().contains("testFeatureC"));
@@ -149,7 +149,7 @@ void TestFeatureModel::parseFeatureListOverwriteFeatures() {
   obj["testFeatureC"] = false;
   json["featuresOverwrite"] = obj;
 
-  FeatureModel::instance()->parseFeatureList(QJsonDocument(json).toJson());
+  FeatureModel::instance()->updateFeatureList(QJsonDocument(json).toJson());
   QVERIFY(!settingsHolder.featuresFlippedOn().contains("testFeatureA"));
   QVERIFY(!settingsHolder.featuresFlippedOn().contains("testFeatureB"));
   QVERIFY(!settingsHolder.featuresFlippedOn().contains("testFeatureC"));
@@ -161,7 +161,7 @@ void TestFeatureModel::parseFeatureListOverwriteFeatures() {
   QVERIFY(!Feature::get("testFeatureC")->isSupported());
 }
 
-void TestFeatureModel::parseFeatureListExperimentalFeaturesEmpty() {
+void TestFeatureModel::updateFeatureListExperimentalFeaturesEmpty() {
   SettingsHolder settingsHolder;
 
   // Clean up the features state.
@@ -173,14 +173,14 @@ void TestFeatureModel::parseFeatureListExperimentalFeaturesEmpty() {
   // Empty object ¯\_(ツ)_/¯
   QJsonObject experimentalFeatures;
   obj["experimentalFeatures"] = experimentalFeatures;
-  FeatureModel::instance()->parseFeatureList(QJsonDocument(obj).toJson());
+  FeatureModel::instance()->updateFeatureList(QJsonDocument(obj).toJson());
 
   // Nothing happened, because we got an empty object
   QCOMPARE(initialFeaturesOnState.count(),
            settingsHolder.featuresFlippedOn().count());
 }
 
-void TestFeatureModel::parseFeatureListExperimentalFeaturesNotObject() {
+void TestFeatureModel::updateFeatureListExperimentalFeaturesNotObject() {
   SettingsHolder settingsHolder;
 
   // Clean up the features state.
@@ -190,14 +190,15 @@ void TestFeatureModel::parseFeatureListExperimentalFeaturesNotObject() {
 
   QJsonObject obj;
   obj["experimentalFeatures"] = "notanobject";
-  FeatureModel::instance()->parseFeatureList(QJsonDocument(obj).toJson());
+  FeatureModel::instance()->updateFeatureList(QJsonDocument(obj).toJson());
 
   // Nothing happened, because we got misformatted input
   QCOMPARE(initialFeaturesOnState.count(),
            settingsHolder.featuresFlippedOn().count());
 }
 
-void TestFeatureModel::parseFeatureListExperimentalFeaturesUnknownExperiment() {
+void TestFeatureModel::
+    updateFeatureListExperimentalFeaturesUnknownExperiment() {
   SettingsHolder settingsHolder;
 
   // Clean up the features state.
@@ -211,7 +212,7 @@ void TestFeatureModel::parseFeatureListExperimentalFeaturesUnknownExperiment() {
   experimentalFeatures["unknownExperiment"] = unknownExperiment;
   obj["experimentalFeatures"] = experimentalFeatures;
 
-  FeatureModel::instance()->parseFeatureList(QJsonDocument(obj).toJson());
+  FeatureModel::instance()->updateFeatureList(QJsonDocument(obj).toJson());
 
   // Nothing happened, because we got an unknown feature
   QCOMPARE(initialFeaturesOnState.count(),
@@ -219,7 +220,7 @@ void TestFeatureModel::parseFeatureListExperimentalFeaturesUnknownExperiment() {
 }
 
 void TestFeatureModel::
-    parseFeatureListExperimentalFeaturesNonObjectExperiment() {
+    updateFeatureListExperimentalFeaturesNonObjectExperiment() {
   SettingsHolder settingsHolder;
 
   // Clean up the features state.
@@ -232,14 +233,14 @@ void TestFeatureModel::
   experimentalFeatures["myExperimentalFeature"] = "notanobject";
   obj["experimentalFeatures"] = experimentalFeatures;
 
-  FeatureModel::instance()->parseFeatureList(QJsonDocument(obj).toJson());
+  FeatureModel::instance()->updateFeatureList(QJsonDocument(obj).toJson());
 
   // Nothing happened, because we got a misconfigured feature
   QCOMPARE(initialFeaturesOnState.count(),
            settingsHolder.featuresFlippedOn().count());
 }
 
-void TestFeatureModel::parseFeatureListExperimentalFeaturesNoSettings() {
+void TestFeatureModel::updateFeatureListExperimentalFeaturesNoSettings() {
   SettingsHolder settingsHolder;
 
   // Clean up the features state.
@@ -253,7 +254,7 @@ void TestFeatureModel::parseFeatureListExperimentalFeaturesNoSettings() {
   experimentalFeatures["myExperimentalFeature"] = myExperimentalFeature;
   obj["experimentalFeatures"] = experimentalFeatures;
 
-  FeatureModel::instance()->parseFeatureList(QJsonDocument(obj).toJson());
+  FeatureModel::instance()->updateFeatureList(QJsonDocument(obj).toJson());
 
   // Finally, it is flipped on!
   QCOMPARE(initialFeaturesOnState.count() + 1,
@@ -266,7 +267,7 @@ void TestFeatureModel::parseFeatureListExperimentalFeaturesNoSettings() {
   QVERIFY(!settingsHolder.myExperimentalFeature()->get("three").isValid());
 }
 
-void TestFeatureModel::parseFeatureListExperimentalFeaturesInvalidSettings() {
+void TestFeatureModel::updateFeatureListExperimentalFeaturesInvalidSettings() {
   SettingsHolder settingsHolder;
 
   // Clean up the features state.
@@ -283,7 +284,7 @@ void TestFeatureModel::parseFeatureListExperimentalFeaturesInvalidSettings() {
   experimentalFeatures["myExperimentalFeature"] = myExperimentalFeature;
   obj["experimentalFeatures"] = experimentalFeatures;
 
-  FeatureModel::instance()->parseFeatureList(QJsonDocument(obj).toJson());
+  FeatureModel::instance()->updateFeatureList(QJsonDocument(obj).toJson());
 
   // It is flipped on!
   QCOMPARE(initialFeaturesOnState.count() + 1,
@@ -296,7 +297,7 @@ void TestFeatureModel::parseFeatureListExperimentalFeaturesInvalidSettings() {
   QVERIFY(!settingsHolder.myExperimentalFeature()->get("three").isValid());
 }
 
-void TestFeatureModel::parseFeatureListExperimentalFeaturesValidSettings() {
+void TestFeatureModel::updateFeatureListExperimentalFeaturesValidSettings() {
   SettingsHolder settingsHolder;
 
   // Clean up the features state.
@@ -313,7 +314,7 @@ void TestFeatureModel::parseFeatureListExperimentalFeaturesValidSettings() {
   experimentalFeatures["myExperimentalFeature"] = myExperimentalFeature;
   obj["experimentalFeatures"] = experimentalFeatures;
 
-  FeatureModel::instance()->parseFeatureList(QJsonDocument(obj).toJson());
+  FeatureModel::instance()->updateFeatureList(QJsonDocument(obj).toJson());
 
   // It is flipped on!
   QCOMPARE(initialFeaturesOnState.count() + 1,
@@ -329,7 +330,7 @@ void TestFeatureModel::parseFeatureListExperimentalFeaturesValidSettings() {
            "three");
 }
 
-void TestFeatureModel::parseFeatureListExperimentalFeaturesToggleOnOff() {
+void TestFeatureModel::updateFeatureListExperimentalFeaturesToggleOnOff() {
   SettingsHolder settingsHolder;
 
   // Clean up the features state.
@@ -343,7 +344,7 @@ void TestFeatureModel::parseFeatureListExperimentalFeaturesToggleOnOff() {
   experimentalFeatures["myExperimentalFeature"] = myExperimentalFeature;
   obj["experimentalFeatures"] = experimentalFeatures;
 
-  FeatureModel::instance()->parseFeatureList(QJsonDocument(obj).toJson());
+  FeatureModel::instance()->updateFeatureList(QJsonDocument(obj).toJson());
 
   // It is flipped on!
   QCOMPARE(initialFeaturesOnState.count() + 1,
@@ -352,7 +353,7 @@ void TestFeatureModel::parseFeatureListExperimentalFeaturesToggleOnOff() {
 
   QJsonObject emptyObj;
   obj["experimentalFeatures"] = emptyObj;
-  FeatureModel::instance()->parseFeatureList(QJsonDocument(obj).toJson());
+  FeatureModel::instance()->updateFeatureList(QJsonDocument(obj).toJson());
 
   // It is flipped off!
   QCOMPARE(initialFeaturesOnState.count(),

--- a/tests/unit_tests/feature/testfeaturemodel.h
+++ b/tests/unit_tests/feature/testfeaturemodel.h
@@ -8,6 +8,9 @@ class TestFeatureModel final : public TestHelper {
   Q_OBJECT
 
  private slots:
+  void init();
+  void cleanup();
+
   void flipOnOff();
 
   void updateFeatureListOverwriteFeatures();

--- a/tests/unit_tests/feature/testfeaturemodel.h
+++ b/tests/unit_tests/feature/testfeaturemodel.h
@@ -10,13 +10,13 @@ class TestFeatureModel final : public TestHelper {
  private slots:
   void flipOnOff();
 
-  void updateFeatureListOverwriteFeatures();
+  void parseFeatureListOverwriteFeatures();
 
-  void updateFeatureListExperimentalFeaturesEmpty();
-  void updateFeatureListExperimentalFeaturesNotObject();
-  void updateFeatureListExperimentalFeaturesUnknownExperiment();
-  void updateFeatureListExperimentalFeaturesNonObjectExperiment();
-  void updateFeatureListExperimentalFeaturesNoSettings();
-  void updateFeatureListExperimentalFeaturesInvalidSettings();
-  void updateFeatureListExperimentalFeaturesValidSettings();
+  void parseFeatureListExperimentalFeaturesEmpty();
+  void parseFeatureListExperimentalFeaturesNotObject();
+  void parseFeatureListExperimentalFeaturesUnknownExperiment();
+  void parseFeatureListExperimentalFeaturesNonObjectExperiment();
+  void parseFeatureListExperimentalFeaturesNoSettings();
+  void parseFeatureListExperimentalFeaturesInvalidSettings();
+  void parseFeatureListExperimentalFeaturesValidSettings();
 };

--- a/tests/unit_tests/feature/testfeaturemodel.h
+++ b/tests/unit_tests/feature/testfeaturemodel.h
@@ -19,4 +19,5 @@ class TestFeatureModel final : public TestHelper {
   void parseFeatureListExperimentalFeaturesNoSettings();
   void parseFeatureListExperimentalFeaturesInvalidSettings();
   void parseFeatureListExperimentalFeaturesValidSettings();
+  void parseFeatureListExperimentalFeaturesToggleOnOff();
 };

--- a/tests/unit_tests/feature/testfeaturemodel.h
+++ b/tests/unit_tests/feature/testfeaturemodel.h
@@ -10,14 +10,14 @@ class TestFeatureModel final : public TestHelper {
  private slots:
   void flipOnOff();
 
-  void parseFeatureListOverwriteFeatures();
+  void updateFeatureListOverwriteFeatures();
 
-  void parseFeatureListExperimentalFeaturesEmpty();
-  void parseFeatureListExperimentalFeaturesNotObject();
-  void parseFeatureListExperimentalFeaturesUnknownExperiment();
-  void parseFeatureListExperimentalFeaturesNonObjectExperiment();
-  void parseFeatureListExperimentalFeaturesNoSettings();
-  void parseFeatureListExperimentalFeaturesInvalidSettings();
-  void parseFeatureListExperimentalFeaturesValidSettings();
-  void parseFeatureListExperimentalFeaturesToggleOnOff();
+  void updateFeatureListExperimentalFeaturesEmpty();
+  void updateFeatureListExperimentalFeaturesNotObject();
+  void updateFeatureListExperimentalFeaturesUnknownExperiment();
+  void updateFeatureListExperimentalFeaturesNonObjectExperiment();
+  void updateFeatureListExperimentalFeaturesNoSettings();
+  void updateFeatureListExperimentalFeaturesInvalidSettings();
+  void updateFeatureListExperimentalFeaturesValidSettings();
+  void updateFeatureListExperimentalFeaturesToggleOnOff();
 };

--- a/tests/unit_tests/feature/testfeaturemodel.h
+++ b/tests/unit_tests/feature/testfeaturemodel.h
@@ -9,5 +9,14 @@ class TestFeatureModel final : public TestHelper {
 
  private slots:
   void flipOnOff();
-  void enableByAPI();
+
+  void updateFeatureListOverwriteFeatures();
+
+  void updateFeatureListExperimentalFeaturesEmpty();
+  void updateFeatureListExperimentalFeaturesNotObject();
+  void updateFeatureListExperimentalFeaturesUnknownExperiment();
+  void updateFeatureListExperimentalFeaturesNonObjectExperiment();
+  void updateFeatureListExperimentalFeaturesNoSettings();
+  void updateFeatureListExperimentalFeaturesInvalidSettings();
+  void updateFeatureListExperimentalFeaturesValidSettings();
 };

--- a/tests/unit_tests/testsettingsholder.cpp
+++ b/tests/unit_tests/testsettingsholder.cpp
@@ -8,6 +8,7 @@
                 ...)                                                           \
   void TestSettingsHolder::testGetSetCheckRemove_##getter() {                  \
     SettingsHolder settingsHolder;                                             \
+    SettingsManager::instance()->hardReset();                                  \
                                                                                \
     QSignalSpy spy(&settingsHolder, &SettingsHolder::getter##Changed);         \
                                                                                \
@@ -119,14 +120,16 @@
 
 #define EXPERIMENTAL_FEATURE(experimentId, experimentDescription, \
                              experimentSettings)                  \
-  void testGetSet_##experimentId() {                              \
+  void TestSettingsHolder::testGetSet_##experimentId() {          \
     SettingsHolder settingsHolder;                                \
     auto group = settingsHolder.experimentId();                   \
                                                                   \
     QSignalSpy spy(group, &SettingGroup::changed);                \
                                                                   \
-    group->set(experimentSettings[0], QVariant("hey"));           \
-    QCOMPARE(spy.count(), 1);                                     \
+    if (experimentSettings.count() > 0) {                         \
+      group->set(experimentSettings[0], QVariant("hey"));         \
+      QCOMPARE(spy.count(), 1);                                   \
+    }                                                             \
                                                                   \
     group->set("disalowedkey", QVariant("hey"));                  \
     QCOMPARE(spy.count(), 1);                                     \

--- a/tests/unit_tests/testsettingsholder.h
+++ b/tests/unit_tests/testsettingsholder.h
@@ -8,7 +8,6 @@
 class TestSettingsHolder final : public TestHelper {
   Q_OBJECT
 
- private slots:
 #define SETTING(type, toType, getter, setter, remover, has, ...) \
   void testGetSetCheckRemove_##getter();
 
@@ -20,4 +19,21 @@ class TestSettingsHolder final : public TestHelper {
 
 #include "feature/experimentalfeaturelist.h"
 #undef EXPERIMENTAL_FEATURE
+
+ private slots:
+  void runAllTests() {
+#define SETTING(type, toType, getter, setter, remover, has, ...) \
+  qDebug() << "Testing setting" << #getter;                      \
+  testGetSetCheckRemove_##getter();
+
+#include "settingslist.h"
+#undef SETTING
+
+#define EXPERIMENTAL_FEATURE(experimentId, ...)                      \
+  qDebug() << "Testing experimental setting group" << #experimentId; \
+  testGetSet_##experimentId();
+
+#include "feature/experimentalfeaturelist.h"
+#undef EXPERIMENTAL_FEATURE
+  }
 };


### PR DESCRIPTION
This is part one as there are a bunch of changes still required to actually get Guardian to send the experimental features. 

This part of the ticket got a bit big, because I also did some cleanup here -- removed some unused code and separated a big function into smaller functions. 

**Anyways, what this PR aims to do is parse the `experimentalFeatures` property that will be returned from Guardian once the Guardian PR is merged and deployed.**

The Guardian companion PR is: https://github.com/mozilla-services/guardian-website/pull/1688

> Note: I reccomend reviewing this commit by commit as there are some clean up changes that might get in the way.