### PR TITLE
Refactor beetmover tasks to be distinct to each shipping phase

### DIFF
--- a/taskcluster/kinds/beetmover-promote/kind.yml
+++ b/taskcluster/kinds/beetmover-promote/kind.yml
@@ -18,6 +18,7 @@ kind-dependencies:
     - repackage-signing
 
 task-defaults:
+    beetmover-action: "push-to-candidates"
     run-on-tasks-for: [action]
     worker-type: beetmover
 

--- a/taskcluster/kinds/beetmover-ship/kind.yml
+++ b/taskcluster/kinds/beetmover-ship/kind.yml
@@ -1,0 +1,70 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+---
+loader: taskgraph.loader.transform:loader
+
+transforms:
+    - taskgraph.transforms.from_deps
+    - mozilla_taskgraph.transforms.scriptworker.release_artifacts
+    - mozillavpn_taskgraph.transforms.beetmover
+    - taskgraph.transforms.task
+
+kind-dependencies:
+    - beetmover-promote
+    - build
+    - signing
+
+task-defaults:
+    from-deps:
+        kinds: [beetmover-promote]
+        group-by: all
+        set-name: false
+        unique-kinds: false
+    worker-type: beetmover
+    worker:
+        chain-of-trust: true
+        max-run-time: 1800
+    run-on-tasks-for: [action]
+
+tasks:
+    client:
+        beetmover-action: "push-to-releases"
+        from-deps:
+            copy-attributes: true
+            with-attributes:
+                shipping-phase: promote-client
+
+    # Beetmoverscript doesn't support the `push-to-release` action for VPN
+    # addons yet, as they use a slightly different directory structure on
+    # archive.mozilla.org.
+    #
+    # For that reason, we need to use the `direct-push-to-bucket` action to
+    # re-upload the build artifacts rather than copying them over from the
+    # candidates dir. This means we need to depend on the build dependencies
+    # even in the `ship` phase. We also depend on the `beetmover-promote` tasks
+    # just to ensure we don't skip uploading to the candidates dir.
+    addons-bundle:
+        beetmover-action: "direct-push-to-bucket"
+        attributes:
+            build-type: "addons/opt"
+        from-deps:
+            with-attributes:
+                shipping-phase: promote-addons
+        dependencies:
+            build: build-addons-bundle
+        # The addons-bundle release-artifacts are dynamically generated in the beetmover transform
+        release-artifacts: []
+
+    addons-manifest:
+        beetmover-action: "direct-push-to-bucket"
+        attributes:
+            build-type: "addons/opt"
+        from-deps:
+            with-attributes:
+                shipping-phase: promote-addons
+        dependencies:
+            signing: signing-addons-bundle
+        release-artifacts:
+            - manifest.json
+            - manifest.json.sig

--- a/taskcluster/kinds/beetmover/kind.yml
+++ b/taskcluster/kinds/beetmover/kind.yml
@@ -17,11 +17,13 @@ kind-dependencies:
     - mac-notarization
     - repackage-signing
 
+task-defaults:
+    run-on-tasks-for: [action]
+    worker-type: beetmover
+
 tasks:
     android-arm64:
         requires-level: 3
-        worker-type: beetmover
-        run-on-tasks-for: [action]
         release-artifacts: [mozillavpn-arm64-v8a-release.apk]
         dependencies:
             signing: signing-android-arm64/release
@@ -29,8 +31,6 @@ tasks:
             build-type: android/arm64-v8a
     android-armv7:
         requires-level: 3
-        worker-type: beetmover
-        run-on-tasks-for: [action]
         release-artifacts: [mozillavpn-armeabi-v7a-release.apk]
         dependencies:
             signing: signing-android-armv7/release
@@ -38,8 +38,6 @@ tasks:
             build-type: android/armv7
     android-x86:
         requires-level: 3
-        worker-type: beetmover
-        run-on-tasks-for: [action]
         release-artifacts: [mozillavpn-x86-release.apk]
         dependencies:
             signing: signing-android-x86/release
@@ -47,8 +45,6 @@ tasks:
             build-type: android/x86
     android-x64:
         requires-level: 3
-        worker-type: beetmover
-        run-on-tasks-for: [action]
         release-artifacts: [mozillavpn-x86_64-release.apk]
         dependencies:
             signing: signing-android-x64/release
@@ -56,8 +52,6 @@ tasks:
             build-type: android/x64
     macos:
         requires-level: 3
-        worker-type: beetmover
-        run-on-tasks-for: [action]
         release-artifacts: [MozillaVPN.pkg]
         dependencies:
             signing: signing-macos/opt
@@ -65,16 +59,12 @@ tasks:
         attributes:
             build-type: macos/opt
     windows:
-        worker-type: beetmover
-        run-on-tasks-for: [action]
         release-artifacts: [MozillaVPN.msi]
         dependencies:
             repackage-signing: repackage-signing-msi
         attributes:
             build-type: windows/opt
     addons-bundle:
-        worker-type: beetmover
-        run-on-tasks-for: [action]
         # The addons-bundle release-artifacts are dynamically generated in the beetmover transform
         release-artifacts: []
         dependencies:
@@ -82,8 +72,6 @@ tasks:
         attributes:
             build-type: addons/opt
     addons-manifest:
-        worker-type: beetmover
-        run-on-tasks-for: [action]
         release-artifacts:
             - manifest.json
             - manifest.json.sig

--- a/taskcluster/kinds/beetmover/kind.yml
+++ b/taskcluster/kinds/beetmover/kind.yml
@@ -21,145 +21,73 @@ tasks:
     android-arm64:
         requires-level: 3
         worker-type: beetmover
-        worker:
-            chain-of-trust: true
-            max-run-time: 1800
         run-on-tasks-for: [action]
         release-artifacts: [mozillavpn-arm64-v8a-release.apk]
         dependencies:
             signing: signing-android-arm64/release
-        if-dependencies: [signing]
         attributes:
             build-type: android/arm64-v8a
-        treeherder:
-            symbol: BM(android)
-            kind: build
-            tier: 1
-            platform: android/arm64-v8a
     android-armv7:
         requires-level: 3
         worker-type: beetmover
-        worker:
-            chain-of-trust: true
-            max-run-time: 1800
         run-on-tasks-for: [action]
         release-artifacts: [mozillavpn-armeabi-v7a-release.apk]
         dependencies:
             signing: signing-android-armv7/release
-        if-dependencies: [signing]
         attributes:
             build-type: android/armv7
-        treeherder:
-            symbol: BM(android)
-            kind: build
-            tier: 1
-            platform: android/armv7
     android-x86:
         requires-level: 3
         worker-type: beetmover
-        worker:
-            chain-of-trust: true
-            max-run-time: 1800
         run-on-tasks-for: [action]
         release-artifacts: [mozillavpn-x86-release.apk]
         dependencies:
             signing: signing-android-x86/release
-        if-dependencies: [signing]
         attributes:
             build-type: android/x86
-        treeherder:
-            symbol: BM(android)
-            kind: build
-            tier: 1
-            platform: android/x86
     android-x64:
         requires-level: 3
         worker-type: beetmover
-        worker:
-            chain-of-trust: true
-            max-run-time: 1800
         run-on-tasks-for: [action]
         release-artifacts: [mozillavpn-x86_64-release.apk]
         dependencies:
             signing: signing-android-x64/release
-        if-dependencies: [signing]
         attributes:
             build-type: android/x64
-        treeherder:
-            symbol: BM(android)
-            kind: build
-            tier: 1
-            platform: android/x64
     macos:
         requires-level: 3
         worker-type: beetmover
-        worker:
-            chain-of-trust: true
-            max-run-time: 1800
         run-on-tasks-for: [action]
         release-artifacts: [MozillaVPN.pkg]
         dependencies:
             signing: signing-macos/opt
             mac-notarization: mac-notarization-macos/opt
-        if-dependencies: [signing]
         attributes:
             build-type: macos/opt
-        treeherder:
-            symbol: BM(macos)
-            kind: build
-            tier: 1
-            platform: macos/opt
     windows:
         worker-type: beetmover
-        worker:
-            chain-of-trust: true
-            max-run-time: 1800
         run-on-tasks-for: [action]
         release-artifacts: [MozillaVPN.msi]
         dependencies:
             repackage-signing: repackage-signing-msi
-        if-dependencies: [repackage-signing]
         attributes:
             build-type: windows/opt
-        treeherder:
-            symbol: BM(windows)
-            kind: build
-            tier: 1
-            platform: windows/x86_64
     addons-bundle:
         worker-type: beetmover
-        worker:
-            chain-of-trust: true
-            max-run-time: 1800
         run-on-tasks-for: [action]
         # The addons-bundle release-artifacts are dynamically generated in the beetmover transform
         release-artifacts: []
         dependencies:
             build: build-addons-bundle
-        if-dependencies: [build]
         attributes:
             build-type: addons/opt
-        treeherder:
-            symbol: BM(addons-bundle)
-            kind: build
-            tier: 1
-            platform: addons/opt
     addons-manifest:
         worker-type: beetmover
-        worker:
-            chain-of-trust: true
-            max-run-time: 1800
         run-on-tasks-for: [action]
         release-artifacts:
             - manifest.json
             - manifest.json.sig
         dependencies:
             signing: signing-addons-bundle
-        if-dependencies: [signing]
         attributes:
             build-type: addons/opt
-        treeherder:
-            symbol: BM(addons-manifest)
-            kind: build
-            tier: 1
-            platform: addons/opt

--- a/taskcluster/kinds/release-notify/kind.yml
+++ b/taskcluster/kinds/release-notify/kind.yml
@@ -10,7 +10,8 @@ transforms:
     - taskgraph.transforms.task:transforms
 
 kind-dependencies:
-    - beetmover
+    - beetmover-promote
+    - beetmover-ship
 
 task-defaults:
     description: "Sends notifications to #mozilla-vpn-release in Slack"

--- a/taskcluster/mozillavpn_taskgraph/transforms/beetmover.py
+++ b/taskcluster/mozillavpn_taskgraph/transforms/beetmover.py
@@ -15,6 +15,7 @@ transforms = TransformSequence()
 
 beetmover_schema = Schema(
     {
+        Required("beetmover-action"): str,
         Required("attributes"): {
             Required("build-type"): str,
             Required("release-artifacts"): [dict],
@@ -92,60 +93,18 @@ def add_beetmover_worker_config(config, tasks):
     archive_url = (
         "https://ftp.mozilla.org/" if is_production else "https://ftp.stage.mozaws.net/"
     )
+    short_phase = config.kind[len("beetmover-"):]
 
     for task in tasks:
         worker_type = task["worker-type"]
         build_type = task["attributes"]["build-type"]
         build_os = build_type_os.get(build_type)
-        shipping_phase = config.params.get("shipping_phase", "")
-
-        destination_paths = []
-
-        if build_type == "addons/opt":
-            destination_paths.append(
-                os.path.join(
-                    "pub",
-                    "vpn",
-                    "addons",
-                    "releases" if shipping_phase.startswith("ship") else "candidates",
-                    build_id,
-                )
-            )
-        elif shipping_phase == "promote-client":
-            destination_paths.append(
-                os.path.join(
-                    "pub",
-                    "vpn",
-                    "candidates",
-                    f"{app_version}-candidates",
-                    f"build{build_id}",
-                    build_os,
-                )
-            )
-        elif shipping_phase == "ship-client":
-            destination_paths.append(
-                os.path.join(
-                    "pub",
-                    "vpn",
-                    "releases",
-                    app_version,
-                    build_os,
-                )
-            )
-
-        if shipping_phase == "ship-addons":
-            destination_paths.append(
-                os.path.join(
-                    "pub",
-                    "vpn",
-                    "addons",
-                    "releases",
-                    "latest",
-                )
-            )
+        phase = f"{short_phase}-{'addons' if task['name'].startswith('addons') else 'client'}"
 
         upstream_artifacts = []
         for dep in task["dependencies"]:
+            if dep not in ("build", "signing"):
+                continue
             upstream_artifacts.append(
                 {
                     "taskId": {"task-reference": f"<{dep}>"},
@@ -157,9 +116,69 @@ def add_beetmover_worker_config(config, tasks):
                 }
             )
 
-        artifact_map = []
+        worker = {
+            "action": task["beetmover-action"],
+            "artifact-map": [],
+            "bucket": bucket,
+            "build-number": int(build_id),
+            "release-properties": {
+                "app-name": "vpn",
+                "app-version": app_version,
+                "branch": config.params["head_ref"],
+                "build-id": build_id,
+                "platform": build_type,
+            },
+            "upstream-artifacts": upstream_artifacts
+        }
+
+        destination_paths = []
+
+        if task["name"].startswith("addons"):
+            destination_paths.append(
+                os.path.join(
+                    "pub",
+                    "vpn",
+                    "addons",
+                    "releases" if short_phase == "ship" else "candidates",
+                    build_id,
+                )
+            )
+            if phase == "ship-addons":
+                destination_paths.append(
+                    os.path.join(
+                        "pub",
+                        "vpn",
+                        "addons",
+                        "releases",
+                        "latest",
+                    )
+                )
+        elif phase == "promote-client":
+            assert build_os
+            destination_paths.append(
+                os.path.join(
+                    "pub",
+                    "vpn",
+                    "candidates",
+                    f"{app_version}-candidates",
+                    f"build{build_id}",
+                    build_os,
+                )
+            )
+        elif phase == "ship-client":
+            assert build_os
+            destination_paths.append(
+                os.path.join(
+                    "pub",
+                    "vpn",
+                    "releases",
+                    app_version,
+                    build_os,
+                )
+            )
+
         for artifact in upstream_artifacts:
-            artifact_map.append(
+            worker["artifact-map"].append(
                 {
                     "taskId": artifact["taskId"],
                     "paths": {
@@ -179,48 +198,27 @@ def add_beetmover_worker_config(config, tasks):
 
         attributes = {
             **task["attributes"],
-            "shipping-phase": shipping_phase,
+            "shipping-phase": phase,
         }
 
         dest = (
-            f"{archive_url}{destination_paths[0]}" if destination_paths else archive_url
+            f"{archive_url}{destination_paths[0]}"
+            if destination_paths
+            else archive_url
         )
         if build_type == "addons/opt":
             task_description = (
                 f"This {worker_type} task will upload the {task['name']} to {dest}/"
             )
-        elif shipping_phase == "ship-client":
+        elif phase == "ship-client":
             task_description = f"This {worker_type} task will copy the v{app_version} build {build_id} candidate to releases"
         else:
             task_description = f"This {worker_type} task will upload a {build_os} release candidate for v{app_version} to {dest}/"
-
-        if not shipping_phase or shipping_phase.startswith("promote"):
-            action = "push-to-candidates"
-        elif shipping_phase == "ship-addons":
-            action = "direct-push-to-bucket"
-        elif shipping_phase == "ship-client":
-            action = "push-to-releases"
-        else:
-            raise Exception(f"Invalid shipping_phase `{shipping_phase}`")
 
         extra = {
             "release_destinations": [
                 f"{archive_url}{dest}/" for dest in destination_paths
             ]
-        }
-        worker = {
-            "upstream-artifacts": upstream_artifacts,
-            "bucket": bucket,
-            "action": action,
-            "release-properties": {
-                "app-name": "vpn",
-                "app-version": app_version,
-                "branch": config.params["head_ref"],
-                "build-id": build_id,
-                "platform": build_type,
-            },
-            "artifact-map": artifact_map,
-            "build-number": int(build_id),
         }
         task_def = {
             "name": task["name"],

--- a/taskcluster/mozillavpn_taskgraph/transforms/beetmover.py
+++ b/taskcluster/mozillavpn_taskgraph/transforms/beetmover.py
@@ -158,7 +158,7 @@ def add_beetmover_worker_config(config, tasks):
                 f"This {worker_type} task will upload the {task['name']} to {dest}/"
             )
         elif shipping_phase == "ship-client":
-            task_description = f"This {worker_type} task will copy build {build_id} from candidates to releases"
+            task_description = f"This {worker_type} task will copy the v{app_version} build {build_id} candidate to releases"
         else:
             task_description = f"This {worker_type} task will upload a {build_os} release candidate for v{app_version} to {dest}/"
 

--- a/taskcluster/mozillavpn_taskgraph/transforms/release_notify.py
+++ b/taskcluster/mozillavpn_taskgraph/transforms/release_notify.py
@@ -131,7 +131,7 @@ def format_message(config, tasks):
 
         dirs = set()
         for label, dep_task in config.kind_dependencies_tasks.items():
-            if label not in task["dependencies"] or dep_task.kind != "beetmover":
+            if label not in task["dependencies"] or not dep_task.kind.startswith("beetmover"):
                 continue
 
             platform = dep_task.attributes["build-type"].rsplit("/")[0]


### PR DESCRIPTION
## Description

The way the beetmover tasks/transforms are currently defined means the task definitions change based on the shipping_phase parameter. This breaks expectations, and should be changed so that there are separate push-to-candidates and copy-to-releases tasks in the full graph, with the selection of which one(s) to run happening as part of targeting.

## Reference

Jira: https://mozilla-hub.atlassian.net/browse/VPN-6080
Issue: https://github.com/mozilla-mobile/mozilla-vpn-client/issues/8919

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
