### PR TITLE
VPN-3044: Suppress OS notification for "What's new" message

### DIFF
--- a/addons/message_whats_new_v2.20/manifest.json
+++ b/addons/message_whats_new_v2.20/manifest.json
@@ -16,6 +16,7 @@
     "title": "You’ve updated to Mozilla VPN 2.20",
     "subtitle": "You’re using the latest version of Mozilla VPN.",
     "badge": "whats_new",
+    "notify": false,
     "blocks": [
       {
         "id": "c_1-1",


### PR DESCRIPTION
## Description

- Prevent triggering an OS notification when the "What's New" in-app message is received 

## Reference

[VPN-3044: Release support for In-App Messages to generate (or not) an OS notification](https://mozilla-hub.atlassian.net/browse/VPN-3044)
