### PR TITLE
[DRAFT] VPN-5715 “Captive portal detected” screen not shown when user deactivates the VPN

### DIFF
--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -21,6 +21,7 @@
 #include "models/servercountrymodel.h"
 #include "mozillavpn.h"
 #include "networkrequest.h"
+#include "networkwatcher.h"
 #include "rfc/rfc1112.h"
 #include "rfc/rfc1918.h"
 #include "rfc/rfc4193.h"
@@ -32,6 +33,8 @@
 #include "tasks/function/taskfunction.h"
 #include "tasks/heartbeat/taskheartbeat.h"
 #include "taskscheduler.h"
+
+#include <QNetworkInformation>
 
 #if defined(MZ_LINUX)
 #  include "platforms/linux/linuxcontroller.h"
@@ -998,11 +1001,15 @@ bool Controller::deactivate() {
   // captive portal, they will experience "No Signal". Upon deactivating the VPN
   // a "Captive Portal Detected" screen will be presented to inform the user of
   // the underlying issue.
-  if (m_portalDetected) {
+//  if (m_portalDetected) {
+//  if (MozillaVPN::instance()->networkWatcher()->getIsBehindCaptivePortal()) {
+  auto instance = QNetworkInformation::instance();
+  Q_UNUSED(instance);
+  if (QNetworkInformation::instance() && QNetworkInformation::instance()->isBehindCaptivePortal())
+  {
     emit activationBlockedForCaptivePortal();
     Navigator::instance()->requestScreen(MozillaVPN::ScreenCaptivePortal);
-
-    m_portalDetected = false;
+//    m_portalDetected = false;
   }
 
   if (m_state == StateOn || m_state == StateConfirming ||

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -1005,6 +1005,7 @@ bool Controller::deactivate() {
 //  if (MozillaVPN::instance()->networkWatcher()->getIsBehindCaptivePortal()) {
   auto instance = QNetworkInformation::instance();
   Q_UNUSED(instance);
+
   if (QNetworkInformation::instance() && QNetworkInformation::instance()->isBehindCaptivePortal())
   {
     emit activationBlockedForCaptivePortal();

--- a/src/networkwatcher.cpp
+++ b/src/networkwatcher.cpp
@@ -175,3 +175,10 @@ QNetworkInformation::Reachability NetworkWatcher::getReachability() {
   }
   return QNetworkInformation::Reachability::Unknown;
 }
+
+bool NetworkWatcher::getIsBehindCaptivePortal() {
+  if (QNetworkInformation::instance()) {
+    return QNetworkInformation::instance()->isBehindCaptivePortal();
+  }
+  return false;
+}

--- a/src/networkwatcher.cpp
+++ b/src/networkwatcher.cpp
@@ -86,6 +86,8 @@ void NetworkWatcher::initialize() {
   if (m_active) {
     m_impl->start();
   }
+  
+  QNetworkInformation::loadDefaultBackend();
 
   connect(settingsHolder, &SettingsHolder::unsecuredNetworkAlertChanged, this,
           &NetworkWatcher::settingsChanged);

--- a/src/networkwatcher.h
+++ b/src/networkwatcher.h
@@ -28,6 +28,7 @@ class NetworkWatcher final : public QObject {
   void unsecuredNetwork(const QString& networkName, const QString& networkId);
 
   QNetworkInformation::Reachability getReachability();
+  bool getIsBehindCaptivePortal();
 
  signals:
   void networkChange();


### PR DESCRIPTION
## Description

use isBehindCaptivePortal from Qt to check if user needs to authenticate through the captive portal before going online.

## Reference

    https://mozilla-hub.atlassian.net/browse/VPN-5715

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
