### PR TITLE
Check isBehindCaptivePortal() on activation

### DIFF
--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -4,6 +4,8 @@
 
 #include "controller.h"
 
+#include <QNetworkInformation>
+
 #include "app.h"
 #include "apppermission.h"
 #include "captiveportal/captiveportal.h"
@@ -899,9 +901,6 @@ QString Controller::currentServerString() const {
 }
 #endif
 
-// These will eventually go back to the controller but to get the code working
-// for now they will reside here
-
 bool Controller::activate(const ServerData& serverData,
                           ServerSelectionPolicy serverSelectionPolicy) {
   logger.debug() << "Activation" << m_state;
@@ -923,7 +922,7 @@ bool Controller::activate(const ServerData& serverData,
 #endif
 
   if (m_state == Controller::StateOff) {
-    if (m_portalDetected) {
+    if (QNetworkInformation::instance()->isBehindCaptivePortal()) {
       emit activationBlockedForCaptivePortal();
       Navigator::instance()->requestScreen(MozillaVPN::ScreenCaptivePortal);
 

--- a/src/networkwatcher.cpp
+++ b/src/networkwatcher.cpp
@@ -87,6 +87,11 @@ void NetworkWatcher::initialize() {
     m_impl->start();
   }
 
+  // This call creates an instance of QNetworkInformation which can be used
+  // later on to check other network related attributes such as network type, or
+  // whether or not the network is behind captive portal.
+  QNetworkInformation::loadDefaultBackend();
+
   connect(settingsHolder, &SettingsHolder::unsecuredNetworkAlertChanged, this,
           &NetworkWatcher::settingsChanged);
   connect(settingsHolder, &SettingsHolder::captivePortalAlertChanged, this,


### PR DESCRIPTION
## Description

use isBehindCaptivePortal from Qt upon VPN activation.

## Reference

    https://mozilla-hub.atlassian.net/browse/VPN-4618

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
