### PR TITLE
[VPN-6080] Fix regression to beetmover-promote-windows task

### DIFF
--- a/taskcluster/mozillavpn_taskgraph/transforms/beetmover.py
+++ b/taskcluster/mozillavpn_taskgraph/transforms/beetmover.py
@@ -103,7 +103,7 @@ def add_beetmover_worker_config(config, tasks):
 
         upstream_artifacts = []
         for dep in task["dependencies"]:
-            if dep not in ("build", "signing"):
+            if dep not in ("build", "repackage-signing", "signing"):
                 continue
             upstream_artifacts.append(
                 {


### PR DESCRIPTION
## Description

This fixes a regression from #8931 to the Windows beetmover task.

## Reference

Issue: #8919

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
