### PR TITLE
set max client version to 2.19.9

### DIFF
--- a/addons/message_update_v2.20/manifest.json
+++ b/addons/message_update_v2.20/manifest.json
@@ -4,7 +4,7 @@
   "name": "Update to Mozilla VPN 2.20",
   "type": "message",
   "conditions": {
-    "max_client_version": "2.18.9"
+    "max_client_version": "2.19.9"
   },
   "javascript": {
     "enable": "enable.js"


### PR DESCRIPTION
Fix an oversight from [this PR](https://github.com/mozilla-mobile/mozilla-vpn-client/pull/8910) to fix the max client version

Issue:
https://mozilla-hub.atlassian.net/browse/VPN-5914