### PR TITLE
VPN-6020: null check telemetryScreenId in MZSignOut

### DIFF
--- a/nebula/ui/components/MZSignOut.qml
+++ b/nebula/ui/components/MZSignOut.qml
@@ -14,7 +14,7 @@ MZFooterLink {
 
     onClicked: () => {
         preLogoutCallback();
-        Glean.interaction.signOutSelected.record({screen:telemetryScreenId})
+        Glean.interaction.signOutSelected.record({screen: typeof telemetryScreenId !== "undefined" ? telemetryScreenId : "" })
         VPNController.logout();
     }
 }

--- a/nebula/ui/components/MZSignOut.qml
+++ b/nebula/ui/components/MZSignOut.qml
@@ -14,7 +14,6 @@ MZFooterLink {
 
     onClicked: () => {
         preLogoutCallback();
-        Glean.interaction.signOutSelected.record({screen: typeof telemetryScreenId !== "undefined" ? telemetryScreenId : "" })
         VPNController.logout();
     }
 }

--- a/src/ui/screens/settings/ViewSettingsMenu.qml
+++ b/src/ui/screens/settings/ViewSettingsMenu.qml
@@ -171,6 +171,12 @@ MZViewBase {
                 }
                 Layout.alignment: Qt.AlignHCenter | Qt.AlignBottom
                 Layout.topMargin: MZTheme.theme.vSpacingSmall - parent.spacing
+
+                preLogoutCallback: () => {
+                    Glean.interaction.signOutSelected.record({
+                        screen: vpnFlickable.telemetryScreenId,
+                    });
+                }
             }
 
         }


### PR DESCRIPTION
## Description

- Only record `signOutSelected` events from the settings menu, instead of from all sign out buttons app-wide
- Fixes broken sign out button (button did not do anything) on other screens (subscription not found, subscription is linked with another account, update view) caused by referencing an undefined variable

## Reference

[VPN-6020: [iOS] “Sign out” button from “Problem confirming subscription” error screens is not working](https://mozilla-hub.atlassian.net/browse/VPN-6020)