### PR TITLE
VPN-5932: Change where we save a new device model

### DIFF
--- a/src/models/devicemodel.cpp
+++ b/src/models/devicemodel.cpp
@@ -51,6 +51,7 @@ bool DeviceModel::fromJson(const Keys* keys, const QByteArray& s) {
   }
 
   m_rawJson = s;
+  writeSettings();
   return true;
 }
 

--- a/src/models/devicemodel.cpp
+++ b/src/models/devicemodel.cpp
@@ -51,7 +51,9 @@ bool DeviceModel::fromJson(const Keys* keys, const QByteArray& s) {
   }
 
   m_rawJson = s;
+#if !defined(UNIT_TEST)
   writeSettings();
+#endif
   return true;
 }
 

--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -535,7 +535,6 @@ void MozillaVPN::completeAuthentication(const QByteArray& json,
   }
 
   m_private->m_user.writeSettings();
-  m_private->m_deviceModel.writeSettings();
 
   SettingsHolder::instance()->setToken(token);
   setUserState(UserAuthenticated);
@@ -751,7 +750,6 @@ void MozillaVPN::accountChecked(const QByteArray& json) {
   }
 
   m_private->m_user.writeSettings();
-  m_private->m_deviceModel.writeSettings();
 
   if (m_private->m_user.subscriptionNeeded() && state() == StateMain) {
     NotificationHandler::instance()->subscriptionNotFoundNotification();


### PR DESCRIPTION
## Description

This bug existed for the following situation:
- Have an account with five devices.
- Sign in on a new device
- Remove a device from the account as part of the sign in flow
- End up on main screen
- Force kill app
- Reopen it
- Note that you need to sign in again - not what we expected

The list of valid devices comes from the Guardian, and is saved in local settings (as the device list JSON). Upon launch, we check if the current device is in those devices, and if not, we ask the user to sign in again.

When we sign into the app when an account already has max devices, we retrieve the device list from Guardian twice - once upon initial launch, and a second time after we remove a device and add our current one. *However, we were only saving it to settings after that first retrieval.* Thus, on subsequent launch, the current device wasn't in the saved list, signing the user out.

I updated where we save the device JSON to local settings - It's now in the function where we process the new device list from Guardian. This fixes the bug, and hopefully prevents future iterations of this bug.

Note that we save the user data in the same spot, but I am not updating it as part of this bug. Arguably, we should save it to disk in the function where we process the server response, as we're changing devices here. However, there are no known issues with it currently and I'm trying to keep this patch as small as possible.

## Reference

VPN-5932

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
