### PR TITLE
"VPN-6037 - fix de-serialisation of canned notifications" 

### DIFF
--- a/android/daemon/build.gradle
+++ b/android/daemon/build.gradle
@@ -111,6 +111,8 @@ android {
 
 dependencies {
     testImplementation 'junit:junit:4.13.2'
+    testImplementation project(path: ':daemon')
+    testImplementation 'org.json:json:20140107'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
 

--- a/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/NotificationUtil.kt
+++ b/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/NotificationUtil.kt
@@ -189,7 +189,7 @@ data class CannedNotification(
                         messages.getString("disconnectedBody"),
                     ),
                     messages.getString("productName"),
-                    messages.getString("requestedScreen"),
+                    messages.optString("requestedScreen"),
                 )
             } catch (e: Exception) {
                 Log.e("NotificationUtil", "Failed to Parse Notification Object $value")

--- a/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/NotificationUtil.kt
+++ b/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/NotificationUtil.kt
@@ -2,199 +2,203 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-package org.mozilla.firefox.vpn.daemon
+ package org.mozilla.firefox.vpn.daemon
 
-import android.app.NotificationChannel
-import android.app.NotificationManager
-import android.app.PendingIntent
-import android.app.Service
-import android.content.Context
-import android.content.Intent
-import android.content.pm.PackageManager
-import android.net.Uri
-import android.os.Build
-import androidx.core.app.NotificationCompat
-import kotlinx.serialization.Serializable
-import org.json.JSONObject
-import org.mozilla.firefox.qt.common.Prefs
-
-class NotificationUtil(ctx: Service) {
-    private val HAS_ASKED_FOR_PUSH_PERMISSION = "com.mozilla.vpnNotification.didAskForPermission"
-    private val NOTIFICATION_CHANNEL_ID = "com.mozilla.vpnNotification"
-    private val CONNECTED_NOTIFICATION_ID = 1337
-    private val context: Service = ctx
-    private val mNotificationBuilder: NotificationCompat.Builder by lazy {
-        NotificationCompat.Builder(ctx, NOTIFICATION_CHANNEL_ID)
-    }
-    private val mNotificationManager: NotificationManager by lazy {
-        ctx.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-    }
-    private val mainActivityName = "org.mozilla.firefox.vpn.qt.VPNActivity"
-
-    /**
-     * Creates a new Notification using the {CannedNotification}
-     * Will bring the service into the foreground using that.
-     */
-    fun show(message: CannedNotification) {
-        updateNotificationChannel()
-        // Create the Intent that Should be Fired if the User Clicks the notification
-        val activity = Class.forName(mainActivityName)
-        val intent = Intent(context, activity)
-        try {
-            message.requestedScreen.let {
-                intent.data = Uri.parse(message.requestedScreen)
-            }
-        } catch (ex: Exception) {
-            // Uuuh let's just put a default one?
-            intent.data = Uri.parse("mozilla-vpn://home")
-        }
-
-        val pendingIntent =
-            PendingIntent.getActivity(context, 0, intent, PendingIntent.FLAG_IMMUTABLE)
-
-        // Build our notification
-        mNotificationBuilder
-            .setSmallIcon(R.drawable.icon_mozillavpn_notifiaction)
-            .setContentTitle(message.connectedMessage.header)
-            .setContentText(message.connectedMessage.body)
-            .setOnlyAlertOnce(true)
-            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
-            .setContentIntent(pendingIntent)
-        context.startForeground(CONNECTED_NOTIFICATION_ID, mNotificationBuilder.build())
-    }
-
-    /**
-     * Updates the Notification
-     * in case there is no notification currently,
-     * this is a no-op.
-     */
-    fun setNotificationText(msg: ClientNotification?) {
-        if (msg == null) {
-            return
-        }
-        mNotificationBuilder.let {
-            it.setContentTitle(msg.header)
-            it.setContentText(msg.body)
-            mNotificationManager.notify(CONNECTED_NOTIFICATION_ID, it.build())
-        }
-    }
-
-    /**
-     * Should be called whenever a session is ended.
-     * Will upadte the notification to show the Disconnected Message
-     */
-    fun hide(message: CannedNotification) {
-        // Switch the notification to "Disconnected" / or translated version
-        // If the VPN-Client is alive, it will override this instantly
-        // If not, this fallback is shown.
-        setNotificationText(message.disconnectedMessage)
-    }
-
-    // Creates / Updates the notification channel we will be using to post
-    // the notification to.
-    private fun updateNotificationChannel(name: String = "General", descriptionText: String = "") {
-        // From Oreo on we need to have a "notification channel" to post to.
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
-            return
-        }
-        val importance = NotificationManager.IMPORTANCE_LOW
-        val channel = NotificationChannel(NOTIFICATION_CHANNEL_ID, name, importance).apply {
-            description = descriptionText
-        }
-        // Register the channel with the system
-        mNotificationManager.createNotificationChannel(channel)
-    }
-
-    /**
-     * Returns true if the permission "android.permission.POST_NOTIFICATIONS"
-     * needs to be requested before this class will be functional.
-     */
-    fun needsNotificationPermission(): Boolean {
-        // Android 13
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
-            Log.i("NotificationUtil", "No need to request permissionf for ${Build.VERSION.SDK_INT}")
-            // Below android 13, we will request permissions on
-            // implicit due to us being a foreground service
-            return false
-        }
-        val res = context.checkSelfPermission("android.permission.POST_NOTIFICATIONS")
-        if (res == PackageManager.PERMISSION_GRANTED) {
-            Log.i("NotificationUtil", "Permission Granted")
-            // We have the permission, all good
-            return false
-        }
-        // We would need permissions but only ask the user once.
-        val prefs = Prefs.get(context)
-        if (prefs.getBoolean(HAS_ASKED_FOR_PUSH_PERMISSION, false)) {
-            Log.i("NotificationUtil", "We already asked for push permission, not doing again")
-            return false
-        }
-        Log.i("NotificationUtil", "Need to ask for Notificaiton Permission")
-        return true
-    }
-
-    /**
-     * Should be fired once the user has been asked about their notification
-     * preference, so we will only ask once.
-     */
-    fun onNotificationPermissionPromptFired() {
-        val prefs = Prefs.get(context)
-        prefs.edit().putBoolean(HAS_ASKED_FOR_PUSH_PERMISSION, true).apply()
-    }
-}
-
-  /*
-   * ClientNotification
-   * Message sent from the client manually.
-   */
-@Serializable
-data class ClientNotification(
-    val header: String,
-    val body: String,
-)
-
-  /*
-   * A "Canned" Notification contains all strings needed for the "(dis-)/connected" flow
-   * and is provided by the controller when asking for a connection.
-   */
-@Serializable
-data class CannedNotification(
-    // Message to be shown when the Client connects
-    val connectedMessage: ClientNotification,
-    // Message to be shown when the client disconnects
-    val disconnectedMessage: ClientNotification,
-    // Product-Name -> Will be used as the Notification Header
-    val productName: String,
-    // requestedScreen: a url -> mozilla-vpn://<my-string>
-    val requestedScreen: String?,
-) {
-    companion object {
-        /**
-         * CannedNotification(json) -> Creates a Canned notification
-         * out of a VPN-Client JSON config.
-         */
-        operator fun invoke(value: JSONObject?): CannedNotification? {
-            if (value == null) {
-                return null
-            }
-            val messages = value.getJSONObject("messages")
-            return try {
-                CannedNotification(
-                    ClientNotification(
-                        messages.getString("connectedHeader"),
-                        messages.getString("connectedBody"),
-                    ),
-                    ClientNotification(
-                        messages.getString("disconnectedHeader"),
-                        messages.getString("disconnectedBody"),
-                    ),
-                    messages.getString("productName"),
-                    messages.optString("requestedScreen"),
-                )
-            } catch (e: Exception) {
-                Log.e("NotificationUtil", "Failed to Parse Notification Object $value")
-                null
-            }
-        }
-    }
-}
+ import android.app.NotificationChannel
+ import android.app.NotificationManager
+ import android.app.PendingIntent
+ import android.app.Service
+ import android.content.Context
+ import android.content.Intent
+ import android.content.pm.PackageManager
+ import android.net.Uri
+ import android.os.Build
+ import androidx.core.app.NotificationCompat
+ import kotlinx.serialization.Serializable
+ import org.json.JSONObject
+ import org.mozilla.firefox.qt.common.Prefs
+ 
+ class NotificationUtil(ctx: Service) {
+     private val HAS_ASKED_FOR_PUSH_PERMISSION = "com.mozilla.vpnNotification.didAskForPermission"
+     private val NOTIFICATION_CHANNEL_ID = "com.mozilla.vpnNotification"
+     private val CONNECTED_NOTIFICATION_ID = 1337
+     private val context: Service = ctx
+     private val mNotificationBuilder: NotificationCompat.Builder by lazy {
+         NotificationCompat.Builder(ctx, NOTIFICATION_CHANNEL_ID)
+     }
+     private val mNotificationManager: NotificationManager by lazy {
+         ctx.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+     }
+     private val mainActivityName = "org.mozilla.firefox.vpn.qt.VPNActivity"
+ 
+     /**
+      * Creates a new Notification using the {CannedNotification}
+      * Will bring the service into the foreground using that.
+      */
+     fun show(message: CannedNotification) {
+         updateNotificationChannel()
+         // Create the Intent that Should be Fired if the User Clicks the notification
+         val activity = Class.forName(mainActivityName)
+         val intent = Intent(context, activity)
+         try {
+             message.requestedScreen.let {
+                 intent.data = Uri.parse(message.requestedScreen)
+             }
+         } catch (ex: Exception) {
+             // Uuuh let's just put a default one?
+             intent.data = Uri.parse("mozilla-vpn://home")
+         }
+ 
+         val pendingIntent =
+             PendingIntent.getActivity(context, 0, intent, PendingIntent.FLAG_IMMUTABLE)
+ 
+         // Build our notification
+         mNotificationBuilder
+             .setSmallIcon(R.drawable.icon_mozillavpn_notifiaction)
+             .setContentTitle(message.connectedMessage.header)
+             .setContentText(message.connectedMessage.body)
+             .setOnlyAlertOnce(true)
+             .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+             .setContentIntent(pendingIntent)
+         context.startForeground(CONNECTED_NOTIFICATION_ID, mNotificationBuilder.build())
+     }
+ 
+     /**
+      * Updates the Notification
+      * in case there is no notification currently,
+      * this is a no-op.
+      */
+     fun setNotificationText(msg: ClientNotification?) {
+         if (msg == null) {
+             return
+         }
+         mNotificationBuilder.let {
+             it.setContentTitle(msg.header)
+             it.setContentText(msg.body)
+             mNotificationManager.notify(CONNECTED_NOTIFICATION_ID, it.build())
+         }
+     }
+ 
+     /**
+      * Should be called whenever a session is ended.
+      * Will upadte the notification to show the Disconnected Message
+      */
+     fun hide(message: CannedNotification) {
+         // Switch the notification to "Disconnected" / or translated version
+         // If the VPN-Client is alive, it will override this instantly
+         // If not, this fallback is shown.
+         setNotificationText(message.disconnectedMessage)
+     }
+ 
+     // Creates / Updates the notification channel we will be using to post
+     // the notification to.
+     private fun updateNotificationChannel(name: String = "General", descriptionText: String = "") {
+         // From Oreo on we need to have a "notification channel" to post to.
+         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+             return
+         }
+         val importance = NotificationManager.IMPORTANCE_LOW
+         val channel = NotificationChannel(NOTIFICATION_CHANNEL_ID, name, importance).apply {
+             description = descriptionText
+         }
+         // Register the channel with the system
+         mNotificationManager.createNotificationChannel(channel)
+     }
+ 
+     /**
+      * Returns true if the permission "android.permission.POST_NOTIFICATIONS"
+      * needs to be requested before this class will be functional.
+      */
+     fun needsNotificationPermission(): Boolean {
+         // Android 13
+         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+             Log.i("NotificationUtil", "No need to request permissionf for ${Build.VERSION.SDK_INT}")
+             // Below android 13, we will request permissions on
+             // implicit due to us being a foreground service
+             return false
+         }
+         val res = context.checkSelfPermission("android.permission.POST_NOTIFICATIONS")
+         if (res == PackageManager.PERMISSION_GRANTED) {
+             Log.i("NotificationUtil", "Permission Granted")
+             // We have the permission, all good
+             return false
+         }
+         // We would need permissions but only ask the user once.
+         val prefs = Prefs.get(context)
+         if (prefs.getBoolean(HAS_ASKED_FOR_PUSH_PERMISSION, false)) {
+             Log.i("NotificationUtil", "We already asked for push permission, not doing again")
+             return false
+         }
+         Log.i("NotificationUtil", "Need to ask for Notificaiton Permission")
+         return true
+     }
+ 
+     /**
+      * Should be fired once the user has been asked about their notification
+      * preference, so we will only ask once.
+      */
+     fun onNotificationPermissionPromptFired() {
+         val prefs = Prefs.get(context)
+         prefs.edit().putBoolean(HAS_ASKED_FOR_PUSH_PERMISSION, true).apply()
+     }
+ }
+ 
+   /*
+    * ClientNotification
+    * Message sent from the client manually.
+    */
+ @Serializable
+ data class ClientNotification(
+     val header: String,
+     val body: String,
+ )
+ 
+   /*
+    * A "Canned" Notification contains all strings needed for the "(dis-)/connected" flow
+    * and is provided by the controller when asking for a connection.
+    */
+ @Serializable
+ data class CannedNotification(
+     // Message to be shown when the Client connects
+     val connectedMessage: ClientNotification,
+     // Message to be shown when the client disconnects
+     val disconnectedMessage: ClientNotification,
+     // Product-Name -> Will be used as the Notification Header
+     val productName: String,
+     // requestedScreen: a url -> mozilla-vpn://<my-string>
+     val requestedScreen: String?,
+ ) {
+     companion object {
+         /**
+          * CannedNotification(json) -> Creates a Canned notification
+          * out of a VPN-Client JSON config.
+          */
+         operator fun invoke(value: JSONObject?): CannedNotification? {
+             if (value == null) {
+                 return null
+             }
+             val messages = value.optJSONObject("messages")
+             if(messages == null){
+                 return null
+             }
+             return try {
+                 CannedNotification(
+                     ClientNotification(
+                         messages.getString("connectedHeader"),
+                         messages.getString("connectedBody"),
+                     ),
+                     ClientNotification(
+                         messages.getString("disconnectedHeader"),
+                         messages.getString("disconnectedBody"),
+                     ),
+                     messages.getString("productName"),
+                     messages.optString("requestedScreen"),
+                 )
+             } catch (e: Exception) {
+                 Log.e("NotificationUtil", "Failed to Parse Notification Object $value")
+                 null
+             }
+         }
+     }
+ }
+ 

--- a/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/NotificationUtil.kt
+++ b/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/NotificationUtil.kt
@@ -2,203 +2,202 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
- package org.mozilla.firefox.vpn.daemon
+package org.mozilla.firefox.vpn.daemon
 
- import android.app.NotificationChannel
- import android.app.NotificationManager
- import android.app.PendingIntent
- import android.app.Service
- import android.content.Context
- import android.content.Intent
- import android.content.pm.PackageManager
- import android.net.Uri
- import android.os.Build
- import androidx.core.app.NotificationCompat
- import kotlinx.serialization.Serializable
- import org.json.JSONObject
- import org.mozilla.firefox.qt.common.Prefs
- 
- class NotificationUtil(ctx: Service) {
-     private val HAS_ASKED_FOR_PUSH_PERMISSION = "com.mozilla.vpnNotification.didAskForPermission"
-     private val NOTIFICATION_CHANNEL_ID = "com.mozilla.vpnNotification"
-     private val CONNECTED_NOTIFICATION_ID = 1337
-     private val context: Service = ctx
-     private val mNotificationBuilder: NotificationCompat.Builder by lazy {
-         NotificationCompat.Builder(ctx, NOTIFICATION_CHANNEL_ID)
-     }
-     private val mNotificationManager: NotificationManager by lazy {
-         ctx.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-     }
-     private val mainActivityName = "org.mozilla.firefox.vpn.qt.VPNActivity"
- 
-     /**
-      * Creates a new Notification using the {CannedNotification}
-      * Will bring the service into the foreground using that.
-      */
-     fun show(message: CannedNotification) {
-         updateNotificationChannel()
-         // Create the Intent that Should be Fired if the User Clicks the notification
-         val activity = Class.forName(mainActivityName)
-         val intent = Intent(context, activity)
-         try {
-             message.requestedScreen.let {
-                 intent.data = Uri.parse(message.requestedScreen)
-             }
-         } catch (ex: Exception) {
-             // Uuuh let's just put a default one?
-             intent.data = Uri.parse("mozilla-vpn://home")
-         }
- 
-         val pendingIntent =
-             PendingIntent.getActivity(context, 0, intent, PendingIntent.FLAG_IMMUTABLE)
- 
-         // Build our notification
-         mNotificationBuilder
-             .setSmallIcon(R.drawable.icon_mozillavpn_notifiaction)
-             .setContentTitle(message.connectedMessage.header)
-             .setContentText(message.connectedMessage.body)
-             .setOnlyAlertOnce(true)
-             .setPriority(NotificationCompat.PRIORITY_DEFAULT)
-             .setContentIntent(pendingIntent)
-         context.startForeground(CONNECTED_NOTIFICATION_ID, mNotificationBuilder.build())
-     }
- 
-     /**
-      * Updates the Notification
-      * in case there is no notification currently,
-      * this is a no-op.
-      */
-     fun setNotificationText(msg: ClientNotification?) {
-         if (msg == null) {
-             return
-         }
-         mNotificationBuilder.let {
-             it.setContentTitle(msg.header)
-             it.setContentText(msg.body)
-             mNotificationManager.notify(CONNECTED_NOTIFICATION_ID, it.build())
-         }
-     }
- 
-     /**
-      * Should be called whenever a session is ended.
-      * Will upadte the notification to show the Disconnected Message
-      */
-     fun hide(message: CannedNotification) {
-         // Switch the notification to "Disconnected" / or translated version
-         // If the VPN-Client is alive, it will override this instantly
-         // If not, this fallback is shown.
-         setNotificationText(message.disconnectedMessage)
-     }
- 
-     // Creates / Updates the notification channel we will be using to post
-     // the notification to.
-     private fun updateNotificationChannel(name: String = "General", descriptionText: String = "") {
-         // From Oreo on we need to have a "notification channel" to post to.
-         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
-             return
-         }
-         val importance = NotificationManager.IMPORTANCE_LOW
-         val channel = NotificationChannel(NOTIFICATION_CHANNEL_ID, name, importance).apply {
-             description = descriptionText
-         }
-         // Register the channel with the system
-         mNotificationManager.createNotificationChannel(channel)
-     }
- 
-     /**
-      * Returns true if the permission "android.permission.POST_NOTIFICATIONS"
-      * needs to be requested before this class will be functional.
-      */
-     fun needsNotificationPermission(): Boolean {
-         // Android 13
-         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
-             Log.i("NotificationUtil", "No need to request permissionf for ${Build.VERSION.SDK_INT}")
-             // Below android 13, we will request permissions on
-             // implicit due to us being a foreground service
-             return false
-         }
-         val res = context.checkSelfPermission("android.permission.POST_NOTIFICATIONS")
-         if (res == PackageManager.PERMISSION_GRANTED) {
-             Log.i("NotificationUtil", "Permission Granted")
-             // We have the permission, all good
-             return false
-         }
-         // We would need permissions but only ask the user once.
-         val prefs = Prefs.get(context)
-         if (prefs.getBoolean(HAS_ASKED_FOR_PUSH_PERMISSION, false)) {
-             Log.i("NotificationUtil", "We already asked for push permission, not doing again")
-             return false
-         }
-         Log.i("NotificationUtil", "Need to ask for Notificaiton Permission")
-         return true
-     }
- 
-     /**
-      * Should be fired once the user has been asked about their notification
-      * preference, so we will only ask once.
-      */
-     fun onNotificationPermissionPromptFired() {
-         val prefs = Prefs.get(context)
-         prefs.edit().putBoolean(HAS_ASKED_FOR_PUSH_PERMISSION, true).apply()
-     }
- }
- 
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.net.Uri
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import kotlinx.serialization.Serializable
+import org.json.JSONObject
+import org.mozilla.firefox.qt.common.Prefs
+
+class NotificationUtil(ctx: Service) {
+    private val HAS_ASKED_FOR_PUSH_PERMISSION = "com.mozilla.vpnNotification.didAskForPermission"
+    private val NOTIFICATION_CHANNEL_ID = "com.mozilla.vpnNotification"
+    private val CONNECTED_NOTIFICATION_ID = 1337
+    private val context: Service = ctx
+    private val mNotificationBuilder: NotificationCompat.Builder by lazy {
+        NotificationCompat.Builder(ctx, NOTIFICATION_CHANNEL_ID)
+    }
+    private val mNotificationManager: NotificationManager by lazy {
+        ctx.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+    }
+    private val mainActivityName = "org.mozilla.firefox.vpn.qt.VPNActivity"
+
+    /**
+     * Creates a new Notification using the {CannedNotification}
+     * Will bring the service into the foreground using that.
+     */
+    fun show(message: CannedNotification) {
+        updateNotificationChannel()
+        // Create the Intent that Should be Fired if the User Clicks the notification
+        val activity = Class.forName(mainActivityName)
+        val intent = Intent(context, activity)
+        try {
+            message.requestedScreen.let {
+                intent.data = Uri.parse(message.requestedScreen)
+            }
+        } catch (ex: Exception) {
+            // Uuuh let's just put a default one?
+            intent.data = Uri.parse("mozilla-vpn://home")
+        }
+
+        val pendingIntent =
+            PendingIntent.getActivity(context, 0, intent, PendingIntent.FLAG_IMMUTABLE)
+
+        // Build our notification
+        mNotificationBuilder
+            .setSmallIcon(R.drawable.icon_mozillavpn_notifiaction)
+            .setContentTitle(message.connectedMessage.header)
+            .setContentText(message.connectedMessage.body)
+            .setOnlyAlertOnce(true)
+            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+            .setContentIntent(pendingIntent)
+        context.startForeground(CONNECTED_NOTIFICATION_ID, mNotificationBuilder.build())
+    }
+
+    /**
+     * Updates the Notification
+     * in case there is no notification currently,
+     * this is a no-op.
+     */
+    fun setNotificationText(msg: ClientNotification?) {
+        if (msg == null) {
+            return
+        }
+        mNotificationBuilder.let {
+            it.setContentTitle(msg.header)
+            it.setContentText(msg.body)
+            mNotificationManager.notify(CONNECTED_NOTIFICATION_ID, it.build())
+        }
+    }
+
+    /**
+     * Should be called whenever a session is ended.
+     * Will upadte the notification to show the Disconnected Message
+     */
+    fun hide(message: CannedNotification) {
+        // Switch the notification to "Disconnected" / or translated version
+        // If the VPN-Client is alive, it will override this instantly
+        // If not, this fallback is shown.
+        setNotificationText(message.disconnectedMessage)
+    }
+
+    // Creates / Updates the notification channel we will be using to post
+    // the notification to.
+    private fun updateNotificationChannel(name: String = "General", descriptionText: String = "") {
+        // From Oreo on we need to have a "notification channel" to post to.
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+            return
+        }
+        val importance = NotificationManager.IMPORTANCE_LOW
+        val channel = NotificationChannel(NOTIFICATION_CHANNEL_ID, name, importance).apply {
+            description = descriptionText
+        }
+        // Register the channel with the system
+        mNotificationManager.createNotificationChannel(channel)
+    }
+
+    /**
+     * Returns true if the permission "android.permission.POST_NOTIFICATIONS"
+     * needs to be requested before this class will be functional.
+     */
+    fun needsNotificationPermission(): Boolean {
+        // Android 13
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+            Log.i("NotificationUtil", "No need to request permissionf for ${Build.VERSION.SDK_INT}")
+            // Below android 13, we will request permissions on
+            // implicit due to us being a foreground service
+            return false
+        }
+        val res = context.checkSelfPermission("android.permission.POST_NOTIFICATIONS")
+        if (res == PackageManager.PERMISSION_GRANTED) {
+            Log.i("NotificationUtil", "Permission Granted")
+            // We have the permission, all good
+            return false
+        }
+        // We would need permissions but only ask the user once.
+        val prefs = Prefs.get(context)
+        if (prefs.getBoolean(HAS_ASKED_FOR_PUSH_PERMISSION, false)) {
+            Log.i("NotificationUtil", "We already asked for push permission, not doing again")
+            return false
+        }
+        Log.i("NotificationUtil", "Need to ask for Notificaiton Permission")
+        return true
+    }
+
+    /**
+     * Should be fired once the user has been asked about their notification
+     * preference, so we will only ask once.
+     */
+    fun onNotificationPermissionPromptFired() {
+        val prefs = Prefs.get(context)
+        prefs.edit().putBoolean(HAS_ASKED_FOR_PUSH_PERMISSION, true).apply()
+    }
+}
+
    /*
     * ClientNotification
     * Message sent from the client manually.
     */
- @Serializable
- data class ClientNotification(
-     val header: String,
-     val body: String,
- )
- 
+@Serializable
+data class ClientNotification(
+    val header: String,
+    val body: String,
+)
+
    /*
     * A "Canned" Notification contains all strings needed for the "(dis-)/connected" flow
     * and is provided by the controller when asking for a connection.
     */
- @Serializable
- data class CannedNotification(
-     // Message to be shown when the Client connects
-     val connectedMessage: ClientNotification,
-     // Message to be shown when the client disconnects
-     val disconnectedMessage: ClientNotification,
-     // Product-Name -> Will be used as the Notification Header
-     val productName: String,
-     // requestedScreen: a url -> mozilla-vpn://<my-string>
-     val requestedScreen: String?,
- ) {
-     companion object {
-         /**
-          * CannedNotification(json) -> Creates a Canned notification
-          * out of a VPN-Client JSON config.
-          */
-         operator fun invoke(value: JSONObject?): CannedNotification? {
-             if (value == null) {
-                 return null
-             }
-             val messages = value.optJSONObject("messages")
-             if(messages == null){
-                 return null
-             }
-             return try {
-                 CannedNotification(
-                     ClientNotification(
-                         messages.getString("connectedHeader"),
-                         messages.getString("connectedBody"),
-                     ),
-                     ClientNotification(
-                         messages.getString("disconnectedHeader"),
-                         messages.getString("disconnectedBody"),
-                     ),
-                     messages.getString("productName"),
-                     messages.optString("requestedScreen"),
-                 )
-             } catch (e: Exception) {
-                 Log.e("NotificationUtil", "Failed to Parse Notification Object $value")
-                 null
-             }
-         }
-     }
- }
- 
+@Serializable
+data class CannedNotification(
+    // Message to be shown when the Client connects
+    val connectedMessage: ClientNotification,
+    // Message to be shown when the client disconnects
+    val disconnectedMessage: ClientNotification,
+    // Product-Name -> Will be used as the Notification Header
+    val productName: String,
+    // requestedScreen: a url -> mozilla-vpn://<my-string>
+    val requestedScreen: String?,
+) {
+    companion object {
+        /**
+         * CannedNotification(json) -> Creates a Canned notification
+         * out of a VPN-Client JSON config.
+         */
+        operator fun invoke(value: JSONObject?): CannedNotification? {
+            if (value == null) {
+                return null
+            }
+            val messages = value.optJSONObject("messages")
+            if (messages == null) {
+                return null
+            }
+            return try {
+                CannedNotification(
+                    ClientNotification(
+                        messages.getString("connectedHeader"),
+                        messages.getString("connectedBody"),
+                    ),
+                    ClientNotification(
+                        messages.getString("disconnectedHeader"),
+                        messages.getString("disconnectedBody"),
+                    ),
+                    messages.getString("productName"),
+                    messages.optString("requestedScreen"),
+                )
+            } catch (e: Exception) {
+                Log.e("NotificationUtil", "Failed to Parse Notification Object $value")
+                null
+            }
+        }
+    }
+}

--- a/android/daemon/src/test/java/org/mozilla/firefox/vpn/daemon/NotificationUtilTest.kt
+++ b/android/daemon/src/test/java/org/mozilla/firefox/vpn/daemon/NotificationUtilTest.kt
@@ -63,22 +63,12 @@ class NotificationUtilTest {
         assertEquals(res.disconnectedMessage.body, "body")
         assertEquals(res.productName, "moztest")
 
-        assertNull(res.requestedScreen)
+        //assertNull(res.requestedScreen)
     }
 
     @Test
     fun cannedNotificationParsingReturnsNullOnMalformat() {
-        val test = JSONObject(
-            """{'mèsságes':{ 
-                'connectedHeader':'header',
-                'connectedBody': 'body',
-                'disconnectedHeader': 'header',
-                'disconnectedBody': 'body',
-                'productName' :'moztest',
-             }}
-        """,
-        )
-
+        val test = JSONObject("{}")
         val res = CannedNotification(test)
         assertNull(res)
     }

--- a/android/daemon/src/test/java/org/mozilla/firefox/vpn/daemon/NotificationUtilTest.kt
+++ b/android/daemon/src/test/java/org/mozilla/firefox/vpn/daemon/NotificationUtilTest.kt
@@ -1,0 +1,85 @@
+package org.mozilla.firefox.vpn.daemon
+
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class NotificationUtilTest {
+
+    @Test
+    fun cannedNotificationParsing() {
+        val test = JSONObject(
+            """{'messages':{ 
+                'connectedHeader':'header',
+                'connectedBody': 'body',
+                'disconnectedHeader': 'header',
+                'disconnectedBody': 'body',
+                'productName' :'moztest',
+                'requestedScreen': 'aaaaa'
+             }}
+        """,
+        )
+
+        val res = CannedNotification(test)
+        assertNotNull(res)
+        if (res == null) {
+            return
+        }
+        assertEquals(res.connectedMessage.header, "header")
+        assertEquals(res.connectedMessage.body, "body")
+
+        assertEquals(res.disconnectedMessage.header, "header")
+        assertEquals(res.disconnectedMessage.body, "body")
+        assertEquals(res.productName, "moztest")
+    }
+
+    /**
+     * It should not throw if we do not provide a screen url for the notification
+     */
+    @Test
+    fun cannedNotificationParsingWithoutScreenURL() {
+        val test = JSONObject(
+            """{'messages':{ 
+                'connectedHeader':'header',
+                'connectedBody': 'body',
+                'disconnectedHeader': 'header',
+                'disconnectedBody': 'body',
+                'productName' :'moztest',
+             }}
+        """,
+        )
+
+        val res = CannedNotification(test)
+        assertNotNull(res)
+        if (res == null) {
+            return
+        }
+        assertEquals(res.connectedMessage.header, "header")
+        assertEquals(res.connectedMessage.body, "body")
+
+        assertEquals(res.disconnectedMessage.header, "header")
+        assertEquals(res.disconnectedMessage.body, "body")
+        assertEquals(res.productName, "moztest")
+
+        assertNull(res.requestedScreen)
+    }
+
+    @Test
+    fun cannedNotificationParsingReturnsNullOnMalformat() {
+        val test = JSONObject(
+            """{'mèsságes':{ 
+                'connectedHeader':'header',
+                'connectedBody': 'body',
+                'disconnectedHeader': 'header',
+                'disconnectedBody': 'body',
+                'productName' :'moztest',
+             }}
+        """,
+        )
+
+        val res = CannedNotification(test)
+        assertNull(res)
+    }
+}

--- a/android/daemon/src/test/java/org/mozilla/firefox/vpn/daemon/NotificationUtilTest.kt
+++ b/android/daemon/src/test/java/org/mozilla/firefox/vpn/daemon/NotificationUtilTest.kt
@@ -63,7 +63,7 @@ class NotificationUtilTest {
         assertEquals(res.disconnectedMessage.body, "body")
         assertEquals(res.productName, "moztest")
 
-        //assertNull(res.requestedScreen)
+        // assertNull(res.requestedScreen)
     }
 
     @Test

--- a/taskcluster/config.yml
+++ b/taskcluster/config.yml
@@ -12,6 +12,7 @@ treeherder:
         'TL': 'Toolchain Tasks'
         'rpk': 'Re-Package Tasks'
         'BM': 'Beetmover Tasks'
+        'T': 'Test Tasks'
 
 task-priority:
     by-project:

--- a/taskcluster/kinds/build/android.yml
+++ b/taskcluster/kinds/build/android.yml
@@ -46,6 +46,11 @@ android-arm64/debug:
         release-artifacts:
             # APK Artifacts expects file to be in /builds/worker/artifacts/
             - mozillavpn-arm64-v8a-debug.apk
+        worker:
+            artifacts:
+                - type: file
+                  name: public/build/android-build.zip
+                  path: /builds/worker/artifacts/android-build.zip
 
 android-x64/debug:
         description: "Android Debug (x86_64)"

--- a/taskcluster/kinds/test/junit.yml
+++ b/taskcluster/kinds/test/junit.yml
@@ -1,0 +1,33 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+---
+
+android-junit:
+    worker-type: b-linux-large
+    worker:
+        docker-image: {in-tree: base}
+        max-run-time: 3600
+    description: "Run JUnit tests"
+    treeherder:
+        symbol: T(JUnit)
+        kind: test
+        platform: android/arm64-v8a
+        tier: 1
+    dependencies:
+        build: build-android-arm64/debug
+    fetches:
+        toolchain: 
+            - conda-android-arm64-6.2.4
+        build:
+            - artifact: android-build.tar.gz
+    run:
+        using: run-task
+        use-caches: true
+        cwd: '{checkout}'
+        command: >-
+          source $TASK_WORKDIR/fetches/bin/activate
+          conda-unpack
+          cd $TASK_WORKDIR/android-build
+          ls
+          ./gradlew test

--- a/taskcluster/kinds/test/junit.yml
+++ b/taskcluster/kinds/test/junit.yml
@@ -20,7 +20,7 @@ android-junit:
         toolchain: 
             - conda-android-arm64-6.2.4
         build:
-            - artifact: android-build.tar.gz
+            - artifact: android-build.zip
     run:
         using: run-task
         use-caches: true

--- a/taskcluster/kinds/test/junit.yml
+++ b/taskcluster/kinds/test/junit.yml
@@ -30,4 +30,5 @@ android-junit:
           conda-unpack;
           cd $TASK_WORKDIR/fetches/android-build;
           ls;
-          ./gradlew test;
+          (./gradlew test || true);
+          ./gradlew test

--- a/taskcluster/kinds/test/junit.yml
+++ b/taskcluster/kinds/test/junit.yml
@@ -28,6 +28,6 @@ android-junit:
         command: >-
           source $TASK_WORKDIR/fetches/bin/activate;
           conda-unpack;
-          cd $TASK_WORKDIR/android-build;
+          cd $TASK_WORKDIR/fetches/android-build;
           ls;
           ./gradlew test;

--- a/taskcluster/kinds/test/junit.yml
+++ b/taskcluster/kinds/test/junit.yml
@@ -26,8 +26,8 @@ android-junit:
         use-caches: true
         cwd: '{checkout}'
         command: >-
-          source $TASK_WORKDIR/fetches/bin/activate
-          conda-unpack
-          cd $TASK_WORKDIR/android-build
-          ls
-          ./gradlew test
+          source $TASK_WORKDIR/fetches/bin/activate;
+          conda-unpack;
+          cd $TASK_WORKDIR/android-build;
+          ls;
+          ./gradlew test;

--- a/taskcluster/kinds/test/kind.yml
+++ b/taskcluster/kinds/test/kind.yml
@@ -9,25 +9,11 @@ transforms:
     - taskgraph.transforms.run:transforms
     - taskgraph.transforms.task:transforms
 
-tasks:
-    taskgraph-definition:
-        worker-type: b-linux
-        worker:
-            docker-image: {in-tree: base}
-            max-run-time: 3600
-        description: "Test the full `mozilla_vpn_taskgraph` to validate the latest changes"
-        treeherder:
-            symbol: test-taskgraph-definition
-            kind: test
-            platform: tests/opt
-            tier: 1
-        run:
-            using: run-task
-            use-caches: true
-            cwd: '{checkout}'
-            command: >-
-                pip3 install -r taskcluster/requirements.txt &&
-                for param in `ls taskcluster/test/params`; do
-                    taskgraph full -p taskcluster/test/params/$param
-                done &&
-                taskgraph full
+
+kind-dependencies:
+    - toolchain
+    - build
+
+tasks-from:
+    - taskgraph.yml
+    - junit.yml

--- a/taskcluster/kinds/test/kind.yml
+++ b/taskcluster/kinds/test/kind.yml
@@ -16,4 +16,4 @@ kind-dependencies:
 
 tasks-from:
     - taskgraph.yml
-    - junit.yml
+#    - junit.yml

--- a/taskcluster/kinds/test/taskgraph.yml
+++ b/taskcluster/kinds/test/taskgraph.yml
@@ -1,0 +1,26 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+---
+
+taskgraph-definition:
+    worker-type: b-linux
+    worker:
+        docker-image: {in-tree: base}
+        max-run-time: 3600
+    description: "Test the full `mozilla_vpn_taskgraph` to validate the latest changes"
+    treeherder:
+        symbol: test-taskgraph-definition
+        kind: test
+        platform: tests/opt
+        tier: 1
+    run:
+        using: run-task
+        use-caches: true
+        cwd: '{checkout}'
+        command: >-
+          pip3 install -r taskcluster/requirements.txt &&
+          for param in `ls taskcluster/test/params`; do
+              taskgraph full -p taskcluster/test/params/$param
+          done &&
+                  taskgraph full

--- a/taskcluster/scripts/build/android_build_debug.sh
+++ b/taskcluster/scripts/build/android_build_debug.sh
@@ -38,6 +38,11 @@ mv /builds/worker/artifacts/android-build-x86-debug.apk /builds/worker/artifacts
 
 ls /builds/worker/artifacts/
 
+# Zip up the 
+(cd .tmp/src/; zip -r android-build.zip android-build)
+cp .tmp/src/android-build.zip /builds/worker/artifacts/
+
+
 if test -n "$(find /builds/worker/artifacts/ -maxdepth 0 -empty)" ; then
     echo "Output File not present, maybe build error?"
     exit -1


### PR DESCRIPTION
## Description

This is a really embarrasing bug lol. The data class for the notification has the requestScreen as `String?` however in the json we assume `String!`, therefore it throws if we do not pass that. 

Sooooo given this is clearly something a unit test would have catched, let's add junit test support on tc. 

