### PR TITLE
Do not deactivate if the VPN is on and server becomes unavailable

### DIFF
--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -290,8 +290,7 @@ void Controller::serverUnavailable() {
 
   m_nextStep = ServerUnavailable;
 
-  if (m_state == StateOn || m_state == StateSwitching ||
-      m_state == StateSilentSwitching || m_state == StateConnecting ||
+  if (m_state == StateSwitching || m_state == StateConnecting ||
       m_state == StateConfirming || m_state == StateCheckSubscription) {
     deactivate();
     return;


### PR DESCRIPTION
## Description

Do not deactivate if the VPN is in StateOn or SilentSwitch and the server location becomes unavailable. Because this the user can miss that the VPN was deactivated which will leave them unprotected. Instead stay in kill switch mode until the issue is resolved. 

Follow up issue to write a functional test for this: https://mozilla-hub.atlassian.net/browse/VPN-6117

## Reference

https://mozilla-hub.atlassian.net/browse/VPN-6033

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
