### PR TITLE
VPN-6124: Help sheet improvements

### DIFF
--- a/nebula/ui/components/MZBottomSheet.qml
+++ b/nebula/ui/components/MZBottomSheet.qml
@@ -32,7 +32,7 @@ Loader {
     readonly property int maxSheetHeight: (Qt.platform.os === "ios" ? window.safeContentHeight : window.height) -  MZTheme.theme.sheetTopMargin
     required default property var contentItem
     property bool sizeToContent: false
-    property bool opened: item.opened
+    property bool opened: active ? item.opened : null
 
     signal close
 

--- a/nebula/ui/components/MZBottomSheet.qml
+++ b/nebula/ui/components/MZBottomSheet.qml
@@ -29,8 +29,9 @@ import Mozilla.Shared 1.0
 Loader {
     id: root
 
-    readonly property int maxHeight: (Qt.platform.os === "ios" ? window.safeContentHeight : window.height) -  MZTheme.theme.sheetTopMargin
+    readonly property int maxSheetHeight: (Qt.platform.os === "ios" ? window.safeContentHeight : window.height) -  MZTheme.theme.sheetTopMargin
     required default property var contentItem
+    property bool sizeToContent: false
 
     signal close
 
@@ -40,7 +41,7 @@ Loader {
 
     sourceComponent: Drawer {
         implicitWidth: window.width
-        implicitHeight: Math.min(contentItem.implicitHeight, maxHeight)
+        implicitHeight: root.sizeToContent ? Math.min(contentItem.implicitHeight, maxSheetHeight) : maxSheetHeight
 
         topPadding: 0
 

--- a/nebula/ui/components/MZBottomSheet.qml
+++ b/nebula/ui/components/MZBottomSheet.qml
@@ -67,9 +67,6 @@ Loader {
         Overlay.modal: Rectangle {
             color: MZTheme.theme.overlayBackground
         }
-
-        Component.onCompleted: console.log("Created XXX")
-        Component.onDestruction: console.log("Destroyed XXX")
     }
 }
 

--- a/nebula/ui/components/MZBottomSheet.qml
+++ b/nebula/ui/components/MZBottomSheet.qml
@@ -26,32 +26,49 @@ import Mozilla.Shared 1.0
   }
 */
 
-Drawer {
-    id: drawer
+Loader {
+    id: root
 
     readonly property int maxHeight: (Qt.platform.os === "ios" ? window.safeContentHeight : window.height) -  MZTheme.theme.sheetTopMargin
+    required default property var contentItem
 
-    implicitWidth: window.width
-    implicitHeight: maxHeight
+    signal close
 
-    topPadding: 0
+    active: false
 
-    dragMargin: 0
-    edge: Qt.BottomEdge
-    background: Rectangle {
+    onClose: item.close()
 
-        radius: 8
-        color: MZTheme.theme.bgColor
+    sourceComponent: Drawer {
+        implicitWidth: window.width
+        implicitHeight: Math.min(contentItem.implicitHeight, maxHeight)
 
-        Rectangle {
-            color: parent.color
-            anchors.bottom: parent.bottom
-            width: parent.width
-            height: parent.radius
+        topPadding: 0
+
+        dragMargin: 0
+        edge: Qt.BottomEdge
+        contentItem: root.contentItem
+
+        onClosed: root.active = false
+
+        background: Rectangle {
+
+            radius: 8
+            color: MZTheme.theme.bgColor
+
+            Rectangle {
+                color: parent.color
+                anchors.bottom: parent.bottom
+                width: parent.width
+                height: parent.radius
+            }
         }
-    }
 
-    Overlay.modal: Rectangle {
-        color: MZTheme.theme.overlayBackground
+        Overlay.modal: Rectangle {
+            color: MZTheme.theme.overlayBackground
+        }
+
+        Component.onCompleted: console.log("Created XXX")
+        Component.onDestruction: console.log("Destroyed XXX")
     }
 }
+

--- a/nebula/ui/components/MZBottomSheet.qml
+++ b/nebula/ui/components/MZBottomSheet.qml
@@ -32,6 +32,7 @@ Loader {
     readonly property int maxSheetHeight: (Qt.platform.os === "ios" ? window.safeContentHeight : window.height) -  MZTheme.theme.sheetTopMargin
     required default property var contentItem
     property bool sizeToContent: false
+    property bool opened: item.opened
 
     signal close
 

--- a/nebula/ui/components/MZHelpSheet.qml
+++ b/nebula/ui/components/MZHelpSheet.qml
@@ -223,6 +223,8 @@ MZBottomSheet {
                                 id: buttonBlock
 
                                 MZButton {
+                                    objectName: typeof loader.composerBlock.objectName !== "undefined" ? loader.composerBlock.objectName : null
+
                                     anchors.left: parent.left
                                     anchors.right: parent.right
 
@@ -238,6 +240,8 @@ MZBottomSheet {
                                 id: linkButtonBlock
 
                                 MZLinkButton {
+                                    objectName: typeof loader.composerBlock.objectName !== "undefined" ? loader.composerBlock.objectName : null
+
                                     anchors.left: parent.left
                                     anchors.right: parent.right
 

--- a/nebula/ui/components/MZHelpSheet.qml
+++ b/nebula/ui/components/MZHelpSheet.qml
@@ -38,7 +38,7 @@ import Mozilla.Shared 1.0
 MZBottomSheet {
     id: bottomSheet
 
-    property alias title: title.text
+    property string title
     required property var model
 
     enum BlockType {
@@ -50,192 +50,201 @@ MZBottomSheet {
 
     sizeToContent: true
 
-    contentItem: ColumnLayout {
+    //Only load the content if the drawer itself is loaded
+    contentItem: Loader {
 
-        spacing: 0
-
-        Accessible.role: Accessible.Grouping
-        Accessible.name: bottomSheet.title
-
-        Component.onCompleted: forceActiveFocus()
-
-        ColumnLayout {
-            id: headerLayout
-
-            Layout.topMargin: 8
-            Layout.preferredWidth: parent.width
+        active: bottomSheet.active
+        sourceComponent: ColumnLayout {
 
             spacing: 0
 
-            RowLayout {
-                spacing: 0
+            Accessible.role: Accessible.Grouping
+            Accessible.name: bottomSheet.title
 
-                Item {
-                    Layout.topMargin: MZTheme.theme.windowMargin / 2
-                    Layout.leftMargin: MZTheme.theme.windowMargin
-                    Layout.preferredHeight: MZTheme.theme.iconSize * 1.5
-                    Layout.preferredWidth: MZTheme.theme.iconSize * 1.5
-                    Layout.alignment: Qt.AlignTop
-
-                    Image {
-                        id: icon
-                        anchors.centerIn: parent
-
-                        source: "qrc:/nebula/resources/tip-filled.svg"
-                        sourceSize.width: MZTheme.theme.iconSize * 1.5
-
-                        mirror: MZLocalizer.isRightToLeft
-                        fillMode: Image.PreserveAspectFit
-                    }
-                }
-
-
-                MZBoldLabel {
-                    id: title
-
-                    Layout.topMargin: MZTheme.theme.windowMargin / 2
-                    Layout.leftMargin: 8
-                    Layout.alignment: Qt.AlignTop
-                    Layout.fillWidth: true
-
-                    verticalAlignment: Text.AlignVCenter
-                    lineHeightMode: Text.FixedHeight
-                    lineHeight: 24
-                    elide: Text.ElideRight
-                }
-
-                Item {
-                    Layout.fillWidth: true
-                }
-
-                MZIconButton {
-                    Layout.rightMargin: MZTheme.theme.windowMargin / 2
-
-                    Layout.preferredHeight: MZTheme.theme.rowHeight
-                    Layout.preferredWidth: MZTheme.theme.rowHeight
-
-                    onClicked: bottomSheet.close()
-
-                    accessibleName: MZI18n.GlobalClose
-
-                    Image {
-                        anchors.centerIn: parent
-
-                        sourceSize.height: MZTheme.theme.iconSize
-                        sourceSize.width: MZTheme.theme.iconSize
-
-                        source: "qrc:/nebula/resources/close-dark.svg"
-                        fillMode: Image.PreserveAspectFit
-                    }
-                }
-            }
-
-            Rectangle {
-                Layout.topMargin: 8
-                Layout.preferredHeight: MZTheme.theme.dividerHeight
-                Layout.fillWidth: true
-
-                color: MZTheme.colors.grey10
-            }
-        }
-
-        MZFlickable {
-            id: flickable
-
-            readonly property int maxheight: bottomSheet.maxSheetHeight - headerLayout.implicitHeight - headerLayout.Layout.topMargin
-
-            Layout.fillWidth: true
-            Layout.preferredHeight: Math.min(layout.implicitHeight + layout.anchors.topMargin + layout.anchors.bottomMargin, maxheight)
-
-            flickContentHeight: layout.implicitHeight + layout.anchors.topMargin + layout.anchors.bottomMargin
-
-            addNavbarHeightOffset: false
+            Component.onCompleted: forceActiveFocus()
 
             ColumnLayout {
-                id: layout
-                anchors.fill: parent
-                anchors.margins: MZTheme.theme.windowMargin * 1.5
+                id: headerLayout
 
-                Repeater {
-                    model: bottomSheet.model
-                    delegate: Loader {
-                        id: loader
+                Layout.topMargin: 8
+                Layout.preferredWidth: parent.width
 
-                        property var composerBlock: bottomSheet.model[index]
+                spacing: 0
 
-                        function getSourceComponent() {
-                            switch (composerBlock.type) {
-                            case MZHelpSheet.BlockType.Title:
-                                return titleBlock
-                            case MZHelpSheet.BlockType.Text:
-                                return textBlock
-                            case MZHelpSheet.BlockType.PrimaryButton:
-                                return buttonBlock
-                            case MZHelpSheet.BlockType.LinkButton:
-                                return linkButtonBlock
-                            default:
-                                return console.error("Unable to create view for composer block of type: " + modelData)
-                            }
+                RowLayout {
+                    spacing: 0
 
+                    Item {
+                        Layout.topMargin: MZTheme.theme.windowMargin / 2
+                        Layout.leftMargin: MZTheme.theme.windowMargin
+                        Layout.preferredHeight: MZTheme.theme.iconSize * 1.5
+                        Layout.preferredWidth: MZTheme.theme.iconSize * 1.5
+                        Layout.alignment: Qt.AlignTop
+
+                        Image {
+                            anchors.centerIn: parent
+
+                            source: "qrc:/nebula/resources/tip-filled.svg"
+                            sourceSize.width: MZTheme.theme.iconSize * 1.5
+
+                            mirror: MZLocalizer.isRightToLeft
+                            fillMode: Image.PreserveAspectFit
                         }
+                    }
 
+
+                    MZBoldLabel {
+                        id: title
+
+                        Layout.topMargin: MZTheme.theme.windowMargin / 2
+                        Layout.leftMargin: 8
+                        Layout.alignment: Qt.AlignTop
                         Layout.fillWidth: true
-                        Layout.preferredHeight: item.implicitHeight
-                        Layout.topMargin: composerBlock.margin
 
-                        sourceComponent: getSourceComponent()
+                        text: bottomSheet.title
+                        verticalAlignment: Text.AlignVCenter
+                        lineHeightMode: Text.FixedHeight
+                        lineHeight: 24
+                        elide: Text.ElideRight
+                    }
 
-                        Component {
-                            id: titleBlock
+                    Item {
+                        Layout.fillWidth: true
+                    }
 
-                            MZBoldInterLabel {
-                                Layout.fillWidth: true
+                    MZIconButton {
+                        objectName: bottomSheet.objectName + "-closeButton"
 
-                                text: loader.composerBlock.text
-                                font.pixelSize: MZTheme.theme.fontSize
-                                lineHeight: 24
-                                verticalAlignment: Text.AlignVCenter
-                            }
+                        Layout.rightMargin: MZTheme.theme.windowMargin / 2
+
+                        Layout.preferredHeight: MZTheme.theme.rowHeight
+                        Layout.preferredWidth: MZTheme.theme.rowHeight
+
+                        onClicked: bottomSheet.close()
+
+                        accessibleName: MZI18n.GlobalClose
+
+                        Image {
+                            anchors.centerIn: parent
+
+                            sourceSize.height: MZTheme.theme.iconSize
+                            sourceSize.width: MZTheme.theme.iconSize
+
+                            source: "qrc:/nebula/resources/close-dark.svg"
+                            fillMode: Image.PreserveAspectFit
                         }
+                    }
+                }
 
-                        Component {
-                            id: textBlock
+                Rectangle {
+                    Layout.topMargin: 8
+                    Layout.preferredHeight: MZTheme.theme.dividerHeight
+                    Layout.fillWidth: true
 
-                            MZInterLabel {
+                    color: MZTheme.colors.grey10
+                }
+            }
 
-                                text: loader.composerBlock.text
-                                font.pixelSize: MZTheme.theme.fontSizeSmall
-                                color: MZTheme.theme.fontColor
-                                lineHeight: 21
-                                horizontalAlignment: Text.AlignLeft
+            MZFlickable {
+                id: flickable
+
+                readonly property int maxheight: bottomSheet.maxSheetHeight - headerLayout.implicitHeight - headerLayout.Layout.topMargin
+
+                Layout.fillWidth: true
+                Layout.preferredHeight: Math.min(layout.implicitHeight + layout.anchors.topMargin + layout.anchors.bottomMargin, maxheight)
+
+                flickContentHeight: layout.implicitHeight + layout.anchors.topMargin + layout.anchors.bottomMargin
+
+                addNavbarHeightOffset: false
+
+                ColumnLayout {
+                    id: layout
+
+                    anchors.fill: parent
+                    anchors.margins: MZTheme.theme.windowMargin * 1.5
+
+                    Repeater {
+                        model: bottomSheet.model
+                        delegate: Loader {
+                            id: loader
+                            objectName: "helpSheetContentLoader"
+
+                            property var composerBlock: bottomSheet.model[index]
+
+                            function getSourceComponent() {
+                                switch (composerBlock.type) {
+                                case MZHelpSheet.BlockType.Title:
+                                    return titleBlock
+                                case MZHelpSheet.BlockType.Text:
+                                    return textBlock
+                                case MZHelpSheet.BlockType.PrimaryButton:
+                                    return buttonBlock
+                                case MZHelpSheet.BlockType.LinkButton:
+                                    return linkButtonBlock
+                                default:
+                                    return console.error("Unable to create view for composer block of type: " + modelData)
+                                }
+
                             }
-                        }
 
-                        Component {
-                            id: buttonBlock
+                            Layout.fillWidth: true
+                            Layout.preferredHeight: item.implicitHeight
+                            Layout.topMargin: composerBlock.margin
 
-                            MZButton {
-                                anchors.left: parent.left
-                                anchors.right: parent.right
+                            sourceComponent: getSourceComponent()
 
-                                implicitHeight: MZTheme.theme.rowHeight
+                            Component {
+                                id: titleBlock
 
-                                text: loader.composerBlock.text
+                                MZBoldInterLabel {
+                                    Layout.fillWidth: true
 
-                                onClicked: loader.composerBlock.action()
+                                    text: loader.composerBlock.text
+                                    font.pixelSize: MZTheme.theme.fontSize
+                                    lineHeight: 24
+                                    verticalAlignment: Text.AlignVCenter
+                                }
                             }
-                        }
 
-                        Component {
-                            id: linkButtonBlock
+                            Component {
+                                id: textBlock
 
-                            MZLinkButton {
-                                anchors.left: parent.left
-                                anchors.right: parent.right
+                                MZInterLabel {
 
-                                labelText: loader.composerBlock.text
+                                    text: loader.composerBlock.text
+                                    font.pixelSize: MZTheme.theme.fontSizeSmall
+                                    color: MZTheme.theme.fontColor
+                                    lineHeight: 21
+                                    horizontalAlignment: Text.AlignLeft
+                                }
+                            }
 
-                                onClicked: loader.composerBlock.action()
+                            Component {
+                                id: buttonBlock
+
+                                MZButton {
+                                    anchors.left: parent.left
+                                    anchors.right: parent.right
+
+                                    implicitHeight: MZTheme.theme.rowHeight
+
+                                    text: loader.composerBlock.text
+
+                                    onClicked: loader.composerBlock.action()
+                                }
+                            }
+
+                            Component {
+                                id: linkButtonBlock
+
+                                MZLinkButton {
+                                    anchors.left: parent.left
+                                    anchors.right: parent.right
+
+                                    labelText: loader.composerBlock.text
+
+                                    onClicked: loader.composerBlock.action()
+                                }
                             }
                         }
                     }

--- a/nebula/ui/components/MZHelpSheet.qml
+++ b/nebula/ui/components/MZHelpSheet.qml
@@ -48,6 +48,8 @@ MZBottomSheet {
         LinkButton
     }
 
+    sizeToContent: true
+
     contentItem: ColumnLayout {
 
         spacing: 0
@@ -140,7 +142,7 @@ MZBottomSheet {
         MZFlickable {
             id: flickable
 
-            readonly property int maxheight: bottomSheet.maxHeight - headerLayout.implicitHeight - headerLayout.Layout.topMargin
+            readonly property int maxheight: bottomSheet.maxSheetHeight - headerLayout.implicitHeight - headerLayout.Layout.topMargin
 
             Layout.fillWidth: true
             Layout.preferredHeight: Math.min(layout.implicitHeight + layout.anchors.topMargin + layout.anchors.bottomMargin, maxheight)

--- a/nebula/ui/components/MZHelpSheet.qml
+++ b/nebula/ui/components/MZHelpSheet.qml
@@ -48,8 +48,6 @@ MZBottomSheet {
         LinkButton
     }
 
-    implicitHeight: Math.min(contentItem.implicitHeight, maxHeight)
-
     contentItem: ColumnLayout {
 
         spacing: 0
@@ -113,13 +111,6 @@ MZBottomSheet {
 
                     Layout.preferredHeight: MZTheme.theme.rowHeight
                     Layout.preferredWidth: MZTheme.theme.rowHeight
-
-                    //Hacky workaround because for some reason, when opening a sheet via
-                    //the right menu button in MZMenu, this close button is in a
-                    //"Hovered" state, even though it wasn't hovered
-                    //Likely something to do with both icon buttons being in the same position
-                    //Relative to their parent (top right corner)
-                    mouseArea.hoverEnabled: bottomSheet.opened
 
                     onClicked: bottomSheet.close()
 

--- a/nebula/ui/themes/main/theme.js
+++ b/nebula/ui/themes/main/theme.js
@@ -87,6 +87,11 @@ theme.dividerHeight = 1
 
 theme.guideCardHeight = 172
 
+theme.helpSheetTitleBodySpacing = 8
+theme.helpSheetBodySpacing = 16
+theme.helpSheetBodyButtonSpacing = 16
+theme.helpSheetSecondaryButtonSpacing = 8
+
 theme.navBarHeight = 64;
 theme.navBarMaxWidth = 608;
 theme.navBarTopMargin = 48;

--- a/src/ui/screens/devices/ViewDevices.qml
+++ b/src/ui/screens/devices/ViewDevices.qml
@@ -12,6 +12,8 @@ import components 0.1
 
 MZViewBase {
     id: vpnFlickable
+    objectName: "devicesSettingsView"
+
     property var isModalDialogOpened: removePopup.visible
     property var wasmView
     property string deviceCountLabelText: ""
@@ -60,6 +62,8 @@ MZViewBase {
                 id: helpIconButtonLoader
                 active: MZFeatureList.get("helpSheets").isSupported
                 sourceComponent: MZIconButton {
+                    objectName: "devicesHelpButton"
+
                     onClicked: helpSheet.active = true
 
                     accessibleName: MZI18n.GlobalHelp
@@ -101,13 +105,15 @@ MZViewBase {
 
     MZHelpSheet {
         id: helpSheet
+        objectName: "devicesHelpSheet"
+
         title: MZI18n.HelpSheetsDevicesTitle
 
         model: [
             {type: MZHelpSheet.BlockType.Title, text: MZI18n.HelpSheetsDevicesHeader},
             {type: MZHelpSheet.BlockType.Text, text: MZI18n.HelpSheetsDevicesBody1, margin: MZTheme.theme.helpSheetTitleBodySpacing},
             {type: MZHelpSheet.BlockType.Text, text: MZI18n.HelpSheetsDevicesBody2, margin: MZTheme.theme.helpSheetBodySpacing},
-            {type: MZHelpSheet.BlockType.LinkButton, text: MZI18n.GlobalLearnMore, margin: MZTheme.theme.helpSheetBodyButtonSpacing, action: () => { MZUrlOpener.openUrlLabel("sumoDevices") }},
+            {type: MZHelpSheet.BlockType.LinkButton, text: MZI18n.GlobalLearnMore, margin: MZTheme.theme.helpSheetBodyButtonSpacing, action: () => { MZUrlOpener.openUrlLabel("sumoDevices") }, objectName: "learnMoreLink"},
         ]
 
         onActiveChanged: if (active) item.open()

--- a/src/ui/screens/devices/ViewDevices.qml
+++ b/src/ui/screens/devices/ViewDevices.qml
@@ -111,9 +111,9 @@ MZViewBase {
 
             model: [
                 {type: MZHelpSheet.BlockType.Title, text: MZI18n.HelpSheetsDevicesHeader},
-                {type: MZHelpSheet.BlockType.Text, text: MZI18n.HelpSheetsDevicesBody1, margin: 8},
-                {type: MZHelpSheet.BlockType.Text, text:MZI18n.HelpSheetsDevicesBody2, margin: 16},
-                {type: MZHelpSheet.BlockType.LinkButton, text: MZI18n.GlobalLearnMore, margin: 16, action: () => { MZUrlOpener.openUrlLabel("sumoDevices") } },
+                {type: MZHelpSheet.BlockType.Text, text: MZI18n.HelpSheetsDevicesBody1, margin: MZTheme.theme.helpSheetTitleBodySpacing},
+                {type: MZHelpSheet.BlockType.Text, text: MZI18n.HelpSheetsDevicesBody2, margin: MZTheme.theme.helpSheetBodySpacing},
+                {type: MZHelpSheet.BlockType.LinkButton, text: MZI18n.GlobalLearnMore, margin: MZTheme.theme.helpSheetBodyButtonSpacing, action: () => { MZUrlOpener.openUrlLabel("sumoDevices") }},
             ]
 
             onClosed: helpSheetLoader.active = false

--- a/src/ui/screens/devices/ViewDevices.qml
+++ b/src/ui/screens/devices/ViewDevices.qml
@@ -60,7 +60,7 @@ MZViewBase {
                 id: helpIconButtonLoader
                 active: MZFeatureList.get("helpSheets").isSupported
                 sourceComponent: MZIconButton {
-                    onClicked: helpSheetLoader.active = true
+                    onClicked: helpSheet.active = true
 
                     accessibleName: MZI18n.GlobalHelp
 
@@ -99,26 +99,20 @@ MZViewBase {
         }
     }
 
-    Loader {
-        id: helpSheetLoader
+    MZHelpSheet {
+        id: helpSheet
+        title: MZI18n.HelpSheetsDevicesTitle
 
-        active: false
+        model: [
+            {type: MZHelpSheet.BlockType.Title, text: MZI18n.HelpSheetsDevicesHeader},
+            {type: MZHelpSheet.BlockType.Text, text: MZI18n.HelpSheetsDevicesBody1, margin: MZTheme.theme.helpSheetTitleBodySpacing},
+            {type: MZHelpSheet.BlockType.Text, text: MZI18n.HelpSheetsDevicesBody2, margin: MZTheme.theme.helpSheetBodySpacing},
+            {type: MZHelpSheet.BlockType.LinkButton, text: MZI18n.GlobalLearnMore, margin: MZTheme.theme.helpSheetBodyButtonSpacing, action: () => { MZUrlOpener.openUrlLabel("sumoDevices") }},
+        ]
 
         onActiveChanged: if (active) item.open()
-
-        sourceComponent: MZHelpSheet {
-            title: MZI18n.HelpSheetsDevicesTitle
-
-            model: [
-                {type: MZHelpSheet.BlockType.Title, text: MZI18n.HelpSheetsDevicesHeader},
-                {type: MZHelpSheet.BlockType.Text, text: MZI18n.HelpSheetsDevicesBody1, margin: MZTheme.theme.helpSheetTitleBodySpacing},
-                {type: MZHelpSheet.BlockType.Text, text: MZI18n.HelpSheetsDevicesBody2, margin: MZTheme.theme.helpSheetBodySpacing},
-                {type: MZHelpSheet.BlockType.LinkButton, text: MZI18n.GlobalLearnMore, margin: MZTheme.theme.helpSheetBodyButtonSpacing, action: () => { MZUrlOpener.openUrlLabel("sumoDevices") }},
-            ]
-
-            onClosed: helpSheetLoader.active = false
-        }
     }
+
 
     Connections {
         target: deviceList

--- a/src/ui/screens/home/ViewServers.qml
+++ b/src/ui/screens/home/ViewServers.qml
@@ -32,6 +32,8 @@ Item {
             Loader {
                 active: MZFeatureList.get("helpSheets").isSupported
                 sourceComponent: MZIconButton {
+                    objectName: "serverHelpButton"
+
                     onClicked: helpSheet.active = true
 
                     accessibleName: MZI18n.GlobalHelp
@@ -152,6 +154,7 @@ Item {
 
     MZHelpSheet {
         id: helpSheet
+        objectName: "serverHelpSheet"
 
         title: MZI18n.HelpSheetsLocationTitle
 
@@ -159,7 +162,7 @@ Item {
             {type: MZHelpSheet.BlockType.Title, text: MZI18n.HelpSheetsLocationHeader},
             {type: MZHelpSheet.BlockType.Text, text: MZI18n.HelpSheetsLocationBody1, margin: MZTheme.theme.helpSheetTitleBodySpacing},
             {type: MZHelpSheet.BlockType.Text, text: MZI18n.HelpSheetsLocationBody2, margin: MZTheme.theme.helpSheetBodySpacing},
-            {type: MZHelpSheet.BlockType.LinkButton, text: MZI18n.GlobalLearnMore, margin: MZTheme.theme.helpSheetBodyButtonSpacing, action: () => { MZUrlOpener.openUrlLabel("sumoMultihop") }},
+            {type: MZHelpSheet.BlockType.LinkButton, text: MZI18n.GlobalLearnMore, margin: MZTheme.theme.helpSheetBodyButtonSpacing, action: () => { MZUrlOpener.openUrlLabel("sumoMultihop") }, objectName: "learnMoreLink"},
         ]
 
         onActiveChanged: if (active) item.open()

--- a/src/ui/screens/home/ViewServers.qml
+++ b/src/ui/screens/home/ViewServers.qml
@@ -161,9 +161,9 @@ Item {
 
             model: [
                 {type: MZHelpSheet.BlockType.Title, text: MZI18n.HelpSheetsLocationHeader},
-                {type: MZHelpSheet.BlockType.Text, text: MZI18n.HelpSheetsLocationBody1, margin: 8},
-                {type: MZHelpSheet.BlockType.Text, text:MZI18n.HelpSheetsLocationBody2, margin: 16},
-                {type: MZHelpSheet.BlockType.LinkButton, text: MZI18n.GlobalLearnMore, margin: 16, action: () => { MZUrlOpener.openUrlLabel("sumoMultihop") } },
+                {type: MZHelpSheet.BlockType.Text, text: MZI18n.HelpSheetsLocationBody1, margin: MZTheme.theme.helpSheetTitleBodySpacing},
+                {type: MZHelpSheet.BlockType.Text, text: MZI18n.HelpSheetsLocationBody2, margin: MZTheme.theme.helpSheetBodySpacing},
+                {type: MZHelpSheet.BlockType.LinkButton, text: MZI18n.GlobalLearnMore, margin: MZTheme.theme.helpSheetBodyButtonSpacing, action: () => { MZUrlOpener.openUrlLabel("sumoMultihop") }},
             ]
 
             onClosed: helpSheetLoader.active = false

--- a/src/ui/screens/home/ViewServers.qml
+++ b/src/ui/screens/home/ViewServers.qml
@@ -32,7 +32,7 @@ Item {
             Loader {
                 active: MZFeatureList.get("helpSheets").isSupported
                 sourceComponent: MZIconButton {
-                    onClicked: helpSheetLoader.active = true
+                    onClicked: helpSheet.active = true
 
                     accessibleName: MZI18n.GlobalHelp
 
@@ -149,25 +149,20 @@ Item {
         }
     }
 
-    Loader {
-        id: helpSheetLoader
 
-        active: false
+    MZHelpSheet {
+        id: helpSheet
+
+        title: MZI18n.HelpSheetsLocationTitle
+
+        model: [
+            {type: MZHelpSheet.BlockType.Title, text: MZI18n.HelpSheetsLocationHeader},
+            {type: MZHelpSheet.BlockType.Text, text: MZI18n.HelpSheetsLocationBody1, margin: MZTheme.theme.helpSheetTitleBodySpacing},
+            {type: MZHelpSheet.BlockType.Text, text: MZI18n.HelpSheetsLocationBody2, margin: MZTheme.theme.helpSheetBodySpacing},
+            {type: MZHelpSheet.BlockType.LinkButton, text: MZI18n.GlobalLearnMore, margin: MZTheme.theme.helpSheetBodyButtonSpacing, action: () => { MZUrlOpener.openUrlLabel("sumoMultihop") }},
+        ]
 
         onActiveChanged: if (active) item.open()
-
-        sourceComponent: MZHelpSheet {
-            title: MZI18n.HelpSheetsLocationTitle
-
-            model: [
-                {type: MZHelpSheet.BlockType.Title, text: MZI18n.HelpSheetsLocationHeader},
-                {type: MZHelpSheet.BlockType.Text, text: MZI18n.HelpSheetsLocationBody1, margin: MZTheme.theme.helpSheetTitleBodySpacing},
-                {type: MZHelpSheet.BlockType.Text, text: MZI18n.HelpSheetsLocationBody2, margin: MZTheme.theme.helpSheetBodySpacing},
-                {type: MZHelpSheet.BlockType.LinkButton, text: MZI18n.GlobalLearnMore, margin: MZTheme.theme.helpSheetBodyButtonSpacing, action: () => { MZUrlOpener.openUrlLabel("sumoMultihop") }},
-            ]
-
-            onClosed: helpSheetLoader.active = false
-        }
     }
 
     Component.onCompleted: {

--- a/src/ui/screens/settings/ViewDNSSettings.qml
+++ b/src/ui/screens/settings/ViewDNSSettings.qml
@@ -25,7 +25,7 @@ MZViewBase {
         Loader {
             active: MZFeatureList.get("helpSheets").isSupported
             sourceComponent: MZIconButton {
-                onClicked: helpSheetLoader.active = true
+                onClicked: helpSheet.active = true
 
                 accessibleName: MZI18n.GlobalHelp
 
@@ -334,25 +334,18 @@ MZViewBase {
         onActiveChanged: if (active) { item.open() }
     }
 
-    Loader {
-        id: helpSheetLoader
+    MZHelpSheet {
+        id: helpSheet
+        title: MZI18n.HelpSheetsDnsTitle
 
-        active: false
+        model: [
+            {type: MZHelpSheet.BlockType.Title, text: MZI18n.HelpSheetsDnsHeader},
+            {type: MZHelpSheet.BlockType.Text, text: MZI18n.HelpSheetsDnsBody1, margin: MZTheme.theme.helpSheetTitleBodySpacing},
+            {type: MZHelpSheet.BlockType.Text, text: MZI18n.HelpSheetsDnsBody2, margin: MZTheme.theme.helpSheetBodySpacing},
+            {type: MZHelpSheet.BlockType.LinkButton, text: MZI18n.GlobalLearnMore, margin: MZTheme.theme.helpSheetBodyButtonSpacing, action: () => { MZUrlOpener.openUrlLabel("sumoDns") }},
+        ]
 
         onActiveChanged: if (active) item.open()
-
-        sourceComponent: MZHelpSheet {
-            title: MZI18n.HelpSheetsDnsTitle
-
-            model: [
-                {type: MZHelpSheet.BlockType.Title, text: MZI18n.HelpSheetsDnsHeader},
-                {type: MZHelpSheet.BlockType.Text, text: MZI18n.HelpSheetsDnsBody1, margin: MZTheme.theme.helpSheetTitleBodySpacing},
-                {type: MZHelpSheet.BlockType.Text, text: MZI18n.HelpSheetsDnsBody2, margin: MZTheme.theme.helpSheetBodySpacing},
-                {type: MZHelpSheet.BlockType.LinkButton, text: MZI18n.GlobalLearnMore, margin: MZTheme.theme.helpSheetBodyButtonSpacing, action: () => { MZUrlOpener.openUrlLabel("sumoDns") }},
-            ]
-
-            onClosed: helpSheetLoader.active = false
-        }
     }
 }
 

--- a/src/ui/screens/settings/ViewDNSSettings.qml
+++ b/src/ui/screens/settings/ViewDNSSettings.qml
@@ -25,6 +25,8 @@ MZViewBase {
         Loader {
             active: MZFeatureList.get("helpSheets").isSupported
             sourceComponent: MZIconButton {
+                objectName: "dnsHelpButton"
+
                 onClicked: helpSheet.active = true
 
                 accessibleName: MZI18n.GlobalHelp
@@ -336,13 +338,15 @@ MZViewBase {
 
     MZHelpSheet {
         id: helpSheet
+        objectName: "dnsHelpSheet"
+
         title: MZI18n.HelpSheetsDnsTitle
 
         model: [
             {type: MZHelpSheet.BlockType.Title, text: MZI18n.HelpSheetsDnsHeader},
             {type: MZHelpSheet.BlockType.Text, text: MZI18n.HelpSheetsDnsBody1, margin: MZTheme.theme.helpSheetTitleBodySpacing},
             {type: MZHelpSheet.BlockType.Text, text: MZI18n.HelpSheetsDnsBody2, margin: MZTheme.theme.helpSheetBodySpacing},
-            {type: MZHelpSheet.BlockType.LinkButton, text: MZI18n.GlobalLearnMore, margin: MZTheme.theme.helpSheetBodyButtonSpacing, action: () => { MZUrlOpener.openUrlLabel("sumoDns") }},
+            {type: MZHelpSheet.BlockType.LinkButton, text: MZI18n.GlobalLearnMore, margin: MZTheme.theme.helpSheetBodyButtonSpacing, action: () => { MZUrlOpener.openUrlLabel("sumoDns") }, objectName: "learnMoreLink"},
         ]
 
         onActiveChanged: if (active) item.open()

--- a/src/ui/screens/settings/ViewDNSSettings.qml
+++ b/src/ui/screens/settings/ViewDNSSettings.qml
@@ -346,9 +346,9 @@ MZViewBase {
 
             model: [
                 {type: MZHelpSheet.BlockType.Title, text: MZI18n.HelpSheetsDnsHeader},
-                {type: MZHelpSheet.BlockType.Text, text: MZI18n.HelpSheetsDnsBody1, margin: 8},
-                {type: MZHelpSheet.BlockType.Text, text:MZI18n.HelpSheetsDnsBody2, margin: 16},
-                {type: MZHelpSheet.BlockType.LinkButton, text: MZI18n.GlobalLearnMore, margin: 16, action: () => { MZUrlOpener.openUrlLabel("sumoDns") } },
+                {type: MZHelpSheet.BlockType.Text, text: MZI18n.HelpSheetsDnsBody1, margin: MZTheme.theme.helpSheetTitleBodySpacing},
+                {type: MZHelpSheet.BlockType.Text, text: MZI18n.HelpSheetsDnsBody2, margin: MZTheme.theme.helpSheetBodySpacing},
+                {type: MZHelpSheet.BlockType.LinkButton, text: MZI18n.GlobalLearnMore, margin: MZTheme.theme.helpSheetBodyButtonSpacing, action: () => { MZUrlOpener.openUrlLabel("sumoDns") }},
             ]
 
             onClosed: helpSheetLoader.active = false

--- a/src/ui/screens/settings/appPermissions/ViewAppPermissions.qml
+++ b/src/ui/screens/settings/appPermissions/ViewAppPermissions.qml
@@ -27,7 +27,7 @@ MZViewBase {
         Loader {
             active: MZFeatureList.get("helpSheets").isSupported
             sourceComponent: MZIconButton {
-                onClicked: helpSheetLoader.active = true
+                onClicked: helpSheet.active = true
 
                 accessibleName: MZI18n.GlobalHelp
 
@@ -82,30 +82,25 @@ MZViewBase {
         }
     }
 
-    Loader {
-        id: helpSheetLoader
 
-        active: false
+    MZHelpSheet {
+        id: helpSheet
+
+        title: MZI18n.HelpSheetsExcludedAppsTitle
+
+        model: [
+            {type: MZHelpSheet.BlockType.Title, text: MZI18n.HelpSheetsExcludedAppsHeader},
+            {type: MZHelpSheet.BlockType.Text, text: MZI18n.HelpSheetsExcludedAppsBody1, margin: MZTheme.theme.helpSheetTitleBodySpacing},
+            {type: MZHelpSheet.BlockType.Text, text: MZI18n.HelpSheetsExcludedAppsBody2, margin: MZTheme.theme.helpSheetBodySpacing},
+            {type: MZHelpSheet.BlockType.Text, text: MZI18n.HelpSheetsExcludedAppsBody3, margin: MZTheme.theme.helpSheetBodySpacing},
+            {type: MZHelpSheet.BlockType.PrimaryButton, text: MZI18n.HelpSheetsExcludedAppsCTA, margin: MZTheme.theme.helpSheetBodyButtonSpacing, action: () => {
+                    close()
+                    getStack().push("qrc:/ui/screens/settings/privacy/ViewPrivacy.qml")
+                }},
+            {type: MZHelpSheet.BlockType.LinkButton, text: MZI18n.GlobalLearnMore, margin: MZTheme.theme.helpSheetSecondaryButtonSpacing, action: () => { MZUrlOpener.openUrlLabel("sumoExcludedApps") } },
+        ]
 
         onActiveChanged: if (active) item.open()
-
-        sourceComponent: MZHelpSheet {
-            title: MZI18n.HelpSheetsExcludedAppsTitle
-
-            model: [
-                {type: MZHelpSheet.BlockType.Title, text: MZI18n.HelpSheetsExcludedAppsHeader},
-                {type: MZHelpSheet.BlockType.Text, text: MZI18n.HelpSheetsExcludedAppsBody1, margin: MZTheme.theme.helpSheetTitleBodySpacing},
-                {type: MZHelpSheet.BlockType.Text, text: MZI18n.HelpSheetsExcludedAppsBody2, margin: MZTheme.theme.helpSheetBodySpacing},
-                {type: MZHelpSheet.BlockType.Text, text: MZI18n.HelpSheetsExcludedAppsBody3, margin: MZTheme.theme.helpSheetBodySpacing},
-                {type: MZHelpSheet.BlockType.PrimaryButton, text: MZI18n.HelpSheetsExcludedAppsCTA, margin: MZTheme.theme.helpSheetBodyButtonSpacing, action: () => {
-                        close()
-                        getStack().push("qrc:/ui/screens/settings/privacy/ViewPrivacy.qml")
-                    }},
-                {type: MZHelpSheet.BlockType.LinkButton, text: MZI18n.GlobalLearnMore, margin: MZTheme.theme.helpSheetSecondaryButtonSpacing, action: () => { MZUrlOpener.openUrlLabel("sumoExcludedApps") } },
-            ]
-
-            onClosed: helpSheetLoader.active = false
-        }
     }
 
     Component.onCompleted: {
@@ -113,5 +108,4 @@ MZViewBase {
         VPNAppPermissions.requestApplist();
         Glean.sample.appPermissionsViewOpened.record();
     }
-
 }

--- a/src/ui/screens/settings/appPermissions/ViewAppPermissions.qml
+++ b/src/ui/screens/settings/appPermissions/ViewAppPermissions.qml
@@ -27,6 +27,8 @@ MZViewBase {
         Loader {
             active: MZFeatureList.get("helpSheets").isSupported
             sourceComponent: MZIconButton {
+                objectName: "excludedAppsHelpButton"
+
                 onClicked: helpSheet.active = true
 
                 accessibleName: MZI18n.GlobalHelp
@@ -85,6 +87,7 @@ MZViewBase {
 
     MZHelpSheet {
         id: helpSheet
+        objectName: "excludedAppsHelpSheet"
 
         title: MZI18n.HelpSheetsExcludedAppsTitle
 
@@ -96,8 +99,8 @@ MZViewBase {
             {type: MZHelpSheet.BlockType.PrimaryButton, text: MZI18n.HelpSheetsExcludedAppsCTA, margin: MZTheme.theme.helpSheetBodyButtonSpacing, action: () => {
                     close()
                     getStack().push("qrc:/ui/screens/settings/privacy/ViewPrivacy.qml")
-                }},
-            {type: MZHelpSheet.BlockType.LinkButton, text: MZI18n.GlobalLearnMore, margin: MZTheme.theme.helpSheetSecondaryButtonSpacing, action: () => { MZUrlOpener.openUrlLabel("sumoExcludedApps") } },
+                }, objectName: "openPrivacyFeaturesButton"},
+            {type: MZHelpSheet.BlockType.LinkButton, text: MZI18n.GlobalLearnMore, margin: MZTheme.theme.helpSheetSecondaryButtonSpacing, action: () => { MZUrlOpener.openUrlLabel("sumoExcludedApps") }, objectName: "learnMoreLink"},
         ]
 
         onActiveChanged: if (active) item.open()

--- a/src/ui/screens/settings/appPermissions/ViewAppPermissions.qml
+++ b/src/ui/screens/settings/appPermissions/ViewAppPermissions.qml
@@ -94,14 +94,14 @@ MZViewBase {
 
             model: [
                 {type: MZHelpSheet.BlockType.Title, text: MZI18n.HelpSheetsExcludedAppsHeader},
-                {type: MZHelpSheet.BlockType.Text, text: MZI18n.HelpSheetsExcludedAppsBody1, margin: 8},
-                {type: MZHelpSheet.BlockType.Text, text: MZI18n.HelpSheetsExcludedAppsBody2, margin: 16},
-                {type: MZHelpSheet.BlockType.Text, text: MZI18n.HelpSheetsExcludedAppsBody3, margin: 16},
-                {type: MZHelpSheet.BlockType.PrimaryButton, text: MZI18n.HelpSheetsExcludedAppsCTA, margin: 16, action: () => {
+                {type: MZHelpSheet.BlockType.Text, text: MZI18n.HelpSheetsExcludedAppsBody1, margin: MZTheme.theme.helpSheetTitleBodySpacing},
+                {type: MZHelpSheet.BlockType.Text, text: MZI18n.HelpSheetsExcludedAppsBody2, margin: MZTheme.theme.helpSheetBodySpacing},
+                {type: MZHelpSheet.BlockType.Text, text: MZI18n.HelpSheetsExcludedAppsBody3, margin: MZTheme.theme.helpSheetBodySpacing},
+                {type: MZHelpSheet.BlockType.PrimaryButton, text: MZI18n.HelpSheetsExcludedAppsCTA, margin: MZTheme.theme.helpSheetBodyButtonSpacing, action: () => {
                         close()
                         getStack().push("qrc:/ui/screens/settings/privacy/ViewPrivacy.qml")
                     }},
-                {type: MZHelpSheet.BlockType.LinkButton, text: MZI18n.GlobalLearnMore, margin: 8, action: () => { MZUrlOpener.openUrlLabel("sumoExcludedApps") } },
+                {type: MZHelpSheet.BlockType.LinkButton, text: MZI18n.GlobalLearnMore, margin: MZTheme.theme.helpSheetSecondaryButtonSpacing, action: () => { MZUrlOpener.openUrlLabel("sumoExcludedApps") } },
             ]
 
             onClosed: helpSheetLoader.active = false

--- a/src/ui/screens/settings/privacy/ViewPrivacy.qml
+++ b/src/ui/screens/settings/privacy/ViewPrivacy.qml
@@ -20,6 +20,8 @@ MZViewBase {
         Loader {
             active: MZFeatureList.get("helpSheets").isSupported
             sourceComponent: MZIconButton {
+                objectName: "privacyHelpButton"
+
                 onClicked: helpSheet.active = true
 
                 accessibleName: MZI18n.GlobalHelp
@@ -126,6 +128,7 @@ MZViewBase {
 
     MZHelpSheet {
         id: helpSheet
+        objectName: "privacyHelpSheet"
 
         title: MZI18n.HelpSheetsPrivacyTitle
 
@@ -133,7 +136,7 @@ MZViewBase {
             {type: MZHelpSheet.BlockType.Title, text: MZI18n.HelpSheetsPrivacyHeader},
             {type: MZHelpSheet.BlockType.Text, text: MZI18n.HelpSheetsPrivacyBody1, margin: MZTheme.theme.helpSheetTitleBodySpacing},
             {type: MZHelpSheet.BlockType.Text, text: MZI18n.HelpSheetsPrivacyBody2, margin: MZTheme.theme.helpSheetBodySpacing},
-            {type: MZHelpSheet.BlockType.LinkButton, text: MZI18n.GlobalLearnMore, margin: MZTheme.theme.helpSheetBodyButtonSpacing, action: () => { MZUrlOpener.openUrlLabel("sumoPrivacy") }},
+            {type: MZHelpSheet.BlockType.LinkButton, text: MZI18n.GlobalLearnMore, margin: MZTheme.theme.helpSheetBodyButtonSpacing, action: () => { MZUrlOpener.openUrlLabel("sumoPrivacy") }, objectName: "learnMoreLink"},
         ]
 
         onActiveChanged: if (active) item.open()

--- a/src/ui/screens/settings/privacy/ViewPrivacy.qml
+++ b/src/ui/screens/settings/privacy/ViewPrivacy.qml
@@ -20,7 +20,7 @@ MZViewBase {
         Loader {
             active: MZFeatureList.get("helpSheets").isSupported
             sourceComponent: MZIconButton {
-                onClicked: helpSheetLoader.active = true
+                onClicked: helpSheet.active = true
 
                 accessibleName: MZI18n.GlobalHelp
                 Image {
@@ -124,25 +124,19 @@ MZViewBase {
         onActiveChanged: if (active) { item.open() }
     }
 
-    Loader {
-        id: helpSheetLoader
+    MZHelpSheet {
+        id: helpSheet
 
-        active: false
+        title: MZI18n.HelpSheetsPrivacyTitle
+
+        model: [
+            {type: MZHelpSheet.BlockType.Title, text: MZI18n.HelpSheetsPrivacyHeader},
+            {type: MZHelpSheet.BlockType.Text, text: MZI18n.HelpSheetsPrivacyBody1, margin: MZTheme.theme.helpSheetTitleBodySpacing},
+            {type: MZHelpSheet.BlockType.Text, text: MZI18n.HelpSheetsPrivacyBody2, margin: MZTheme.theme.helpSheetBodySpacing},
+            {type: MZHelpSheet.BlockType.LinkButton, text: MZI18n.GlobalLearnMore, margin: MZTheme.theme.helpSheetBodyButtonSpacing, action: () => { MZUrlOpener.openUrlLabel("sumoPrivacy") }},
+        ]
 
         onActiveChanged: if (active) item.open()
-
-        sourceComponent: MZHelpSheet {
-            title: MZI18n.HelpSheetsPrivacyTitle
-
-            model: [
-                {type: MZHelpSheet.BlockType.Title, text: MZI18n.HelpSheetsPrivacyHeader},
-                {type: MZHelpSheet.BlockType.Text, text: MZI18n.HelpSheetsPrivacyBody1, margin: MZTheme.theme.helpSheetTitleBodySpacing},
-                {type: MZHelpSheet.BlockType.Text, text: MZI18n.HelpSheetsPrivacyBody2, margin: MZTheme.theme.helpSheetBodySpacing},
-                {type: MZHelpSheet.BlockType.LinkButton, text: MZI18n.GlobalLearnMore, margin: MZTheme.theme.helpSheetBodyButtonSpacing, action: () => { MZUrlOpener.openUrlLabel("sumoPrivacy") }},
-            ]
-
-            onClosed: helpSheetLoader.active = false
-        }
     }
 }
 

--- a/src/ui/screens/settings/privacy/ViewPrivacy.qml
+++ b/src/ui/screens/settings/privacy/ViewPrivacy.qml
@@ -136,9 +136,9 @@ MZViewBase {
 
             model: [
                 {type: MZHelpSheet.BlockType.Title, text: MZI18n.HelpSheetsPrivacyHeader},
-                {type: MZHelpSheet.BlockType.Text, text: MZI18n.HelpSheetsPrivacyBody1, margin: 8},
-                {type: MZHelpSheet.BlockType.Text, text:MZI18n.HelpSheetsPrivacyBody2, margin: 16},
-                {type: MZHelpSheet.BlockType.LinkButton, text: MZI18n.GlobalLearnMore, margin: 16, action: () => { MZUrlOpener.openUrlLabel("sumoPrivacy") } },
+                {type: MZHelpSheet.BlockType.Text, text: MZI18n.HelpSheetsPrivacyBody1, margin: MZTheme.theme.helpSheetTitleBodySpacing},
+                {type: MZHelpSheet.BlockType.Text, text: MZI18n.HelpSheetsPrivacyBody2, margin: MZTheme.theme.helpSheetBodySpacing},
+                {type: MZHelpSheet.BlockType.LinkButton, text: MZI18n.GlobalLearnMore, margin: MZTheme.theme.helpSheetBodyButtonSpacing, action: () => { MZUrlOpener.openUrlLabel("sumoPrivacy") }},
             ]
 
             onClosed: helpSheetLoader.active = false

--- a/tests/functional/queries.js
+++ b/tests/functional/queries.js
@@ -110,9 +110,9 @@ const screenHome = {
 
     BACK_BUTTON: new QmlQueryComposer('//serverListBackButton'),
     HELP_BUTTON: new QmlQueryComposer('//serverHelpButton'),
-    SERVER_HELP_SHEET: new QmlQueryComposer('//serverHelpSheet'),
-    SERVER_HELP_SHEET_CLOSE_BUTTON: new QmlQueryComposer('//serverHelpSheet-closeButton'),
-    SERVER_HELP_SHEET_LEARN_MORE_BUTTON: new QmlQueryComposer('//helpSheetContentLoader/learnMoreLink'),
+    HELP_SHEET: new QmlQueryComposer('//serverHelpSheet'),
+    HELP_SHEET_CLOSE_BUTTON: new QmlQueryComposer('//serverHelpSheet-closeButton'),
+    HELP_SHEET_LEARN_MORE_BUTTON: new QmlQueryComposer('//helpSheetContentLoader/learnMoreLink'),
     COUNTRY_VIEW: new QmlQueryComposer('//serverCountryView'),
     ENTRY_BUTTON: new QmlQueryComposer('//buttonSelectEntry'),
     EXIT_BUTTON: new QmlQueryComposer('//buttonSelectExit'),
@@ -309,9 +309,9 @@ const screenSettings = {
     VIEW_PRIVACY_WARNING: new QmlQueryComposer('//viewPrivacyWarning'),
 
     HELP_BUTTON: new QmlQueryComposer('//privacyHelpButton'),
-    PRIVACY_HELP_SHEET: new QmlQueryComposer('//privacyHelpSheet'),
-    PRIVACY_HELP_SHEET_CLOSE_BUTTON: new QmlQueryComposer('//privacyHelpSheet-closeButton'),
-    PRIVACY_HELP_SHEET_LEARN_MORE_BUTTON: new QmlQueryComposer('//helpSheetContentLoader/learnMoreLink'),
+    HELP_SHEET: new QmlQueryComposer('//privacyHelpSheet'),
+    HELP_SHEET_CLOSE_BUTTON: new QmlQueryComposer('//privacyHelpSheet-closeButton'),
+    HELP_SHEET_LEARN_MORE_BUTTON: new QmlQueryComposer('//helpSheetContentLoader/learnMoreLink'),
   },
 
   appExclusionsView: {
@@ -340,9 +340,9 @@ const screenSettings = {
         '//deviceList/deviceListLayout/device-device_1/swipeActionLoader/swipeActionDelete'),
 
     HELP_BUTTON: new QmlQueryComposer('//devicesHelpButton'),
-    DEVICES_HELP_SHEET: new QmlQueryComposer('//devicesHelpSheet'),
-    DEVICES_HELP_SHEET_CLOSE_BUTTON: new QmlQueryComposer('//devicesHelpSheet-closeButton'),
-    DEVICES_HELP_SHEET_LEARN_MORE_BUTTON: new QmlQueryComposer('//helpSheetContentLoader/learnMoreLink'),
+    HELP_SHEET: new QmlQueryComposer('//devicesHelpSheet'),
+    HELP_SHEET_CLOSE_BUTTON: new QmlQueryComposer('//devicesHelpSheet-closeButton'),
+    HELP_SHEET_LEARN_MORE_BUTTON: new QmlQueryComposer('//helpSheetContentLoader/learnMoreLink'),
   },
 
   tipsAndTricksView: {
@@ -376,9 +376,9 @@ const screenSettings = {
           new QmlQueryComposer('//dnsOverwritePopupGoBackButton'),
 
       HELP_BUTTON: new QmlQueryComposer('//dnsHelpButton'),
-      PRIVACY_HELP_SHEET: new QmlQueryComposer('//dnsHelpSheet'),
-      PRIVACY_HELP_SHEET_CLOSE_BUTTON: new QmlQueryComposer('//dnsHelpSheet-closeButton'),
-      PRIVACY_HELP_SHEET_LEARN_MORE_BUTTON: new QmlQueryComposer('//helpSheetContentLoader/learnMoreLink'),
+      HELP_SHEET: new QmlQueryComposer('//dnsHelpSheet'),
+      HELP_SHEET_CLOSE_BUTTON: new QmlQueryComposer('//dnsHelpSheet-closeButton'),
+      HELP_SHEET_LEARN_MORE_BUTTON: new QmlQueryComposer('//helpSheetContentLoader/learnMoreLink'),
     },
 
     languageSettingsView: {

--- a/tests/functional/queries.js
+++ b/tests/functional/queries.js
@@ -100,6 +100,10 @@ const screenHome = {
     },
 
     BACK_BUTTON: new QmlQueryComposer('//serverListBackButton'),
+    HELP_BUTTON: new QmlQueryComposer('//serverHelpButton'),
+    SERVER_HELP_SHEET: new QmlQueryComposer('//serverHelpSheet'),
+    SERVER_HELP_SHEET_CLOSE_BUTTON: new QmlQueryComposer('//serverHelpSheet-closeButton'),
+    SERVER_HELP_SHEET_LEARN_MORE_BUTTON: new QmlQueryComposer('//helpSheetContentLoader/learnMoreLink'),
     COUNTRY_VIEW: new QmlQueryComposer('//serverCountryView'),
     ENTRY_BUTTON: new QmlQueryComposer('//buttonSelectEntry'),
     EXIT_BUTTON: new QmlQueryComposer('//buttonSelectExit'),

--- a/tests/functional/queries.js
+++ b/tests/functional/queries.js
@@ -319,6 +319,7 @@ const screenSettings = {
   },
 
   myDevicesView: {
+    DEVICES_VIEW: new QmlQueryComposer('//devicesSettingsView'),
     BACK: new QmlQueryComposer('//deviceList-back'),
     CONFIRM_REMOVAL_BUTTON: new QmlQueryComposer('//confirmRemoveDeviceButton'),
     DEVICE_LIST: new QmlQueryComposer('//deviceList'),
@@ -326,6 +327,10 @@ const screenSettings = {
     REMOVE_DEVICE_BUTTON: new QmlQueryComposer(
         '//deviceList/deviceListLayout/device-device_1/swipeActionLoader/swipeActionDelete'),
 
+    HELP_BUTTON: new QmlQueryComposer('//devicesHelpButton'),
+    DEVICES_HELP_SHEET: new QmlQueryComposer('//devicesHelpSheet'),
+    DEVICES_HELP_SHEET_CLOSE_BUTTON: new QmlQueryComposer('//devicesHelpSheet-closeButton'),
+    DEVICES_HELP_SHEET_LEARN_MORE_BUTTON: new QmlQueryComposer('//helpSheetContentLoader/learnMoreLink'),
   },
 
   tipsAndTricksView: {

--- a/tests/functional/queries.js
+++ b/tests/functional/queries.js
@@ -54,6 +54,10 @@ class QmlQueryComposer {
     return this.prop('busy', false);
   }
 
+  opened() {
+    return this.prop('opened', true);
+  }
+
   prop(propName, propValue = undefined) {
     if (propValue === undefined) {
       return new QmlQueryComposer(`${this.path}{${propName}}`);
@@ -306,7 +310,12 @@ const screenSettings = {
     MODAL_SECONDARY_BUTTON:
         new QmlQueryComposer('//privacyOverwritePopupGoBackButton'),
 
-    VIEW_PRIVACY_WARNING: new QmlQueryComposer('//viewPrivacyWarning')
+    VIEW_PRIVACY_WARNING: new QmlQueryComposer('//viewPrivacyWarning'),
+
+    HELP_BUTTON: new QmlQueryComposer('//privacyHelpButton'),
+    PRIVACY_HELP_SHEET: new QmlQueryComposer('//privacyHelpSheet'),
+    PRIVACY_HELP_SHEET_CLOSE_BUTTON: new QmlQueryComposer('//privacyHelpSheet-closeButton'),
+    PRIVACY_HELP_SHEET_LEARN_MORE_BUTTON: new QmlQueryComposer('//helpSheetContentLoader/learnMoreLink'),
   },
 
   myDevicesView: {

--- a/tests/functional/queries.js
+++ b/tests/functional/queries.js
@@ -357,6 +357,11 @@ const screenSettings = {
           new QmlQueryComposer('//dnsOverwritePopupDiscoverNowButton'),
       MODAL_SECONDARY_BUTTON:
           new QmlQueryComposer('//dnsOverwritePopupGoBackButton'),
+
+      HELP_BUTTON: new QmlQueryComposer('//dnsHelpButton'),
+      PRIVACY_HELP_SHEET: new QmlQueryComposer('//dnsHelpSheet'),
+      PRIVACY_HELP_SHEET_CLOSE_BUTTON: new QmlQueryComposer('//dnsHelpSheet-closeButton'),
+      PRIVACY_HELP_SHEET_LEARN_MORE_BUTTON: new QmlQueryComposer('//helpSheetContentLoader/learnMoreLink'),
     },
 
     languageSettingsView: {

--- a/tests/functional/queries.js
+++ b/tests/functional/queries.js
@@ -58,6 +58,11 @@ class QmlQueryComposer {
     return this.prop('opened', true);
   }
 
+  closed() {
+    return this.prop('opened', false);
+  }
+
+
   prop(propName, propValue = undefined) {
     if (propValue === undefined) {
       return new QmlQueryComposer(`${this.path}{${propName}}`);
@@ -262,16 +267,6 @@ const screenDeveloperMenu = {
   RESET_AND_QUIT_BUTTON: new QmlQueryComposer('//resetAndQuitButton'),
 };
 
-const appExclusionsView = {
-  ADD_APPLICATION_BUTTON: new QmlQueryComposer('//addApplication'),
-  APP_LIST: new QmlQueryComposer('//appList'),
-  APP_ROW1: new QmlQueryComposer('//app-0'),
-  CHECKBOX1: new QmlQueryComposer('//app-0/checkbox'),
-  CHECKBOX2: new QmlQueryComposer('//app-1/checkbox'),
-  CLEAR_ALL: new QmlQueryComposer('//clearAll'),
-  SCREEN: new QmlQueryComposer('//appPermissions')
-};
-
 const screenSettings = {
   ABOUT_US: new QmlQueryComposer('//settingsAboutUs'),
   BACK: new QmlQueryComposer('//settings-back'),
@@ -292,6 +287,7 @@ const screenSettings = {
       new QmlQueryComposer('//settingsUserProfile-emailAddress'),
 
   privacyView: {
+    VIEW: new QmlQueryComposer('//privacySettingsView'),
     BLOCK_ADS: new QmlQueryComposer('//blockAds'),
     BLOCK_ADS_CHECKBOX: new QmlQueryComposer('//blockAds//checkbox'),
     BLOCK_TRACKERS: new QmlQueryComposer('//blockTrackers'),
@@ -316,6 +312,22 @@ const screenSettings = {
     PRIVACY_HELP_SHEET: new QmlQueryComposer('//privacyHelpSheet'),
     PRIVACY_HELP_SHEET_CLOSE_BUTTON: new QmlQueryComposer('//privacyHelpSheet-closeButton'),
     PRIVACY_HELP_SHEET_LEARN_MORE_BUTTON: new QmlQueryComposer('//helpSheetContentLoader/learnMoreLink'),
+  },
+
+  appExclusionsView: {
+    ADD_APPLICATION_BUTTON: new QmlQueryComposer('//addApplication'),
+    APP_LIST: new QmlQueryComposer('//appList'),
+    APP_ROW1: new QmlQueryComposer('//app-0'),
+    CHECKBOX1: new QmlQueryComposer('//app-0/checkbox'),
+    CHECKBOX2: new QmlQueryComposer('//app-1/checkbox'),
+    CLEAR_ALL: new QmlQueryComposer('//clearAll'),
+    SCREEN: new QmlQueryComposer('//appPermissions'),
+  
+    HELP_BUTTON: new QmlQueryComposer('//excludedAppsHelpButton'),
+    HELP_SHEET: new QmlQueryComposer('//excludedAppsHelpSheet'),
+    HELP_SHEET_CLOSE_BUTTON: new QmlQueryComposer('//excludedAppsHelpSheet-closeButton'),
+    HELP_SHEET_LEARN_MORE_BUTTON: new QmlQueryComposer('//helpSheetContentLoader/learnMoreLink'),
+    HELP_SHEET_OPEN_PRIVACY_FEATURES_BUTTON: new QmlQueryComposer('//helpSheetContentLoader/openPrivacyFeaturesButton'),
   },
 
   myDevicesView: {
@@ -540,7 +552,6 @@ const global = {
 };
 
 module.exports = {
-  appExclusionsView,
   screenHome,
   screenInitialize,
   screenPostAuthentication,

--- a/tests/functional/testAppExclusions.js
+++ b/tests/functional/testAppExclusions.js
@@ -81,7 +81,7 @@ describe('Settings', function() {
     await vpn.waitForQueryAndClick(queries.screenSettings.APP_EXCLUSIONS.visible());
   });
 
-  it.only('Checking the excluded apps help sheet', async () => {
+  it('Checking the excluded apps help sheet', async () => {
     if (!(await vpn.isFeatureFlippedOn('helpSheets'))) {
       await vpn.flipFeatureOn('helpSheets');
     }

--- a/tests/functional/testAppExclusions.js
+++ b/tests/functional/testAppExclusions.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 const assert = require('assert');
-const {appExclusionsView, navBar, screenSettings} = require('./queries.js');
+const queries = require('./queries.js');
 const vpn = require('./helper.js');
 const {appendFile} = require('fs');
 
@@ -12,10 +12,10 @@ describe('Settings', function() {
   this.ctx.authenticationNeeded = true;
 
   beforeEach(async () => {
-    await vpn.waitForQueryAndClick(navBar.SETTINGS.visible());
-    await vpn.waitForQuery(screenSettings.STACKVIEW.ready());
-    await vpn.waitForQueryAndClick(screenSettings.APP_EXCLUSIONS.visible());
-    await vpn.waitForQuery(screenSettings.STACKVIEW.ready());
+    await vpn.waitForQueryAndClick(queries.navBar.SETTINGS.visible());
+    await vpn.waitForQuery(queries.screenSettings.STACKVIEW.ready());
+    await vpn.waitForQueryAndClick(queries.screenSettings.APP_EXCLUSIONS.visible());
+    await vpn.waitForQuery(queries.screenSettings.STACKVIEW.ready());
   });
 
   const getNumDisabledApps =
@@ -28,15 +28,15 @@ describe('Settings', function() {
      async () => {
        // Clear all button is correctly disabled when there are no disabled apps
        await vpn.waitForQuery(
-           appExclusionsView.CLEAR_ALL.visible().prop('enabled', 'false'));
-       await vpn.waitForQuery(screenSettings.STACKVIEW.ready());
-       await vpn.waitForQueryAndClick(appExclusionsView.CHECKBOX1.visible());
-       await vpn.waitForQuery(screenSettings.STACKVIEW.ready());
+           queries.screenSettings.appExclusionsView.CLEAR_ALL.visible().prop('enabled', 'false'));
+       await vpn.waitForQuery(queries.screenSettings.STACKVIEW.ready());
+       await vpn.waitForQueryAndClick(queries.screenSettings.appExclusionsView.CHECKBOX1.visible());
+       await vpn.waitForQuery(queries.screenSettings.STACKVIEW.ready());
 
        // Clear all button is enabled when disabledAppsList.length > 0
        await vpn.waitForQuery(
-           appExclusionsView.CLEAR_ALL.visible().prop('enabled', 'true'));
-       await vpn.waitForQueryAndClick(appExclusionsView.CHECKBOX1);
+           queries.screenSettings.appExclusionsView.CLEAR_ALL.visible().prop('enabled', 'true'));
+       await vpn.waitForQueryAndClick(queries.screenSettings.appExclusionsView.CHECKBOX1);
        assert(await getNumDisabledApps() == '0');
      });
 
@@ -46,14 +46,14 @@ describe('Settings', function() {
       return;
     }
     
-    await vpn.waitForQueryAndClick(appExclusionsView.CHECKBOX1.visible());
-    await vpn.waitForQueryAndClick(appExclusionsView.CHECKBOX2.visible());
-    await vpn.waitForQuery(screenSettings.STACKVIEW.ready());
+    await vpn.waitForQueryAndClick(queries.screenSettings.appExclusionsView.CHECKBOX1.visible());
+    await vpn.waitForQueryAndClick(queries.screenSettings.appExclusionsView.CHECKBOX2.visible());
+    await vpn.waitForQuery(queries.screenSettings.STACKVIEW.ready());
 
     assert(await getNumDisabledApps() == '2');
 
-    await vpn.waitForQueryAndClick(appExclusionsView.CLEAR_ALL.visible());
-    await vpn.waitForQuery(screenSettings.STACKVIEW.ready());
+    await vpn.waitForQueryAndClick(queries.screenSettings.appExclusionsView.CLEAR_ALL.visible());
+    await vpn.waitForQuery(queries.screenSettings.STACKVIEW.ready());
     assert(await getNumDisabledApps() == '0');
 
     // Check that we collect telemetry
@@ -64,21 +64,51 @@ describe('Settings', function() {
   });
 
   it('Excluded apps are at the top of the list on initial load', async () => {
-    await vpn.waitForQueryAndClick(appExclusionsView.CHECKBOX2);
-    await vpn.waitForQueryAndClick(screenSettings.BACK.visible());
-    await vpn.waitForQuery(screenSettings.STACKVIEW.ready());
+    await vpn.waitForQueryAndClick(queries.screenSettings.appExclusionsView.CHECKBOX2);
+    await vpn.waitForQueryAndClick(queries.screenSettings.BACK.visible());
+    await vpn.waitForQuery(queries.screenSettings.STACKVIEW.ready());
     
-    await vpn.waitForQueryAndClick(screenSettings.APP_EXCLUSIONS.visible());
-    await vpn.waitForQuery(screenSettings.STACKVIEW.ready());
+    await vpn.waitForQueryAndClick(queries.screenSettings.APP_EXCLUSIONS.visible());
+    await vpn.waitForQuery(queries.screenSettings.STACKVIEW.ready());
     
-    await vpn.waitForQuery(appExclusionsView.APP_ROW1.visible().prop(
+    await vpn.waitForQuery(queries.screenSettings.appExclusionsView.APP_ROW1.visible().prop(
         'appIdForFunctionalTests', 'com.example.two'));
   });
 
   it('Back button works', async () => {
-    await vpn.waitForQueryAndClick(screenSettings.BACK.visible());
-    await vpn.waitForQuery(screenSettings.STACKVIEW.ready());
-    await vpn.waitForQueryAndClick(screenSettings.APP_EXCLUSIONS.visible());
+    await vpn.waitForQueryAndClick(queries.screenSettings.BACK.visible());
+    await vpn.waitForQuery(queries.screenSettings.STACKVIEW.ready());
+    await vpn.waitForQueryAndClick(queries.screenSettings.APP_EXCLUSIONS.visible());
+  });
+
+  it.only('Checking the excluded apps help sheet', async () => {
+    if (!(await vpn.isFeatureFlippedOn('helpSheets'))) {
+      await vpn.flipFeatureOn('helpSheets');
+    }
+
+    //Test the "Open privacy features" button
+    await vpn.waitForQueryAndClick(queries.screenSettings.appExclusionsView.HELP_BUTTON.visible());
+    await vpn.waitForQuery(queries.screenSettings.appExclusionsView.HELP_SHEET.visible());
+    await vpn.waitForQuery(queries.screenSettings.appExclusionsView.HELP_SHEET.opened());
+    await vpn.waitForQueryAndClick(queries.screenSettings.appExclusionsView.HELP_SHEET_OPEN_PRIVACY_FEATURES_BUTTON.visible());
+    await vpn.waitForQuery(queries.screenSettings.appExclusionsView.HELP_SHEET.closed());
+    await vpn.waitForQuery(queries.screenSettings.STACKVIEW.ready());
+    await vpn.waitForQuery(queries.screenSettings.privacyView.VIEW.visible());
+
+    //Go back to the app exclusions view
+    await vpn.waitForQueryAndClick(queries.screenSettings.BACK.visible());
+    await vpn.waitForQuery(queries.screenSettings.STACKVIEW.ready());
+
+    //Test the "Learn more" link
+    await vpn.waitForQueryAndClick(queries.screenSettings.appExclusionsView.HELP_BUTTON.visible());
+    await vpn.waitForQuery(queries.screenSettings.appExclusionsView.HELP_SHEET.visible());
+    await vpn.waitForQuery(queries.screenSettings.appExclusionsView.HELP_SHEET.opened());
+    await vpn.waitForQueryAndClick(queries.screenSettings.appExclusionsView.HELP_SHEET_LEARN_MORE_BUTTON.visible());
+    await vpn.waitForCondition(async () => {
+        const url = await vpn.getLastUrl();
+        return url === 'https://support.mozilla.org/kb/split-tunneling-app-permissions';
+    });
+    await vpn.waitForQueryAndClick(queries.screenSettings.appExclusionsView.HELP_SHEET_CLOSE_BUTTON.visible());
   });
 
   // Dummy VPN does not have the Add Application button so we cannot currently test this.
@@ -98,10 +128,10 @@ describe('Settings', function() {
       // This test cannot run in wasm
       return;
     }
-    await vpn.waitForQueryAndClick(navBar.SETTINGS.visible());
-    await vpn.waitForQuery(screenSettings.STACKVIEW.ready());
-    await vpn.waitForQueryAndClick(screenSettings.APP_EXCLUSIONS.visible());
-    await vpn.waitForQuery(screenSettings.STACKVIEW.ready());
+    await vpn.waitForQueryAndClick(queries.navBar.SETTINGS.visible());
+    await vpn.waitForQuery(queries.screenSettings.STACKVIEW.ready());
+    await vpn.waitForQueryAndClick(queries.screenSettings.APP_EXCLUSIONS.visible());
+    await vpn.waitForQuery(queries.screenSettings.STACKVIEW.ready());
 
     // Check that we collect telemetry
     const events = await vpn.gleanTestGetValue("interaction", "appExclusionsSelected", "main");

--- a/tests/functional/testDevices.js
+++ b/tests/functional/testDevices.js
@@ -23,14 +23,15 @@ describe('Devices', function() {
       }
   
       await vpn.waitForQueryAndClick(queries.screenSettings.myDevicesView.HELP_BUTTON.visible());
-      await vpn.waitForQuery(queries.screenSettings.myDevicesView.DEVICES_HELP_SHEET.visible());
-      await vpn.waitForQuery(queries.screenSettings.myDevicesView.DEVICES_HELP_SHEET.opened());
-      await vpn.waitForQueryAndClick(queries.screenSettings.myDevicesView.DEVICES_HELP_SHEET_LEARN_MORE_BUTTON.visible());
+      await vpn.waitForQuery(queries.screenSettings.myDevicesView.HELP_SHEET.visible());
+      await vpn.waitForQuery(queries.screenSettings.myDevicesView.HELP_SHEET.opened());
+      await vpn.waitForQueryAndClick(queries.screenSettings.myDevicesView.HELP_SHEET_LEARN_MORE_BUTTON.visible());
       await vpn.waitForCondition(async () => {
           const url = await vpn.getLastUrl();
           return url === 'https://support.mozilla.org/kb/how-add-devices-your-mozilla-vpn-subscription';
       });
-      await vpn.waitForQueryAndClick(queries.screenSettings.myDevicesView.DEVICES_HELP_SHEET_CLOSE_BUTTON.visible());
+      await vpn.waitForQueryAndClick(queries.screenSettings.myDevicesView.HELP_SHEET_CLOSE_BUTTON.visible());
+      await vpn.waitForQuery(queries.screenSettings.myDevicesView.HELP_SHEET.closed());
     });
   });
 

--- a/tests/functional/testDevices.js
+++ b/tests/functional/testDevices.js
@@ -7,6 +7,33 @@ const vpn = require('./helper.js');
 const guardianEndpoints = require('./servers/guardian_endpoints.js')
 
 describe('Devices', function() {
+  describe('My devices tests', function() {
+    this.ctx.authenticationNeeded = true;
+
+    beforeEach(async () => {
+      await vpn.waitForQueryAndClick(queries.navBar.SETTINGS.visible());
+      await vpn.waitForQueryAndClick(queries.screenSettings.MY_DEVICES.visible());
+      await vpn.waitForQuery(queries.screenSettings.STACKVIEW.ready());
+      await vpn.waitForQuery(queries.screenSettings.myDevicesView.DEVICES_VIEW.visible());
+    });
+
+    it('Checking the devices help sheet', async () => {
+      if (!(await vpn.isFeatureFlippedOn('helpSheets'))) {
+        await vpn.flipFeatureOn('helpSheets');
+      }
+  
+      await vpn.waitForQueryAndClick(queries.screenSettings.myDevicesView.HELP_BUTTON.visible());
+      await vpn.waitForQuery(queries.screenSettings.myDevicesView.DEVICES_HELP_SHEET.visible());
+      await vpn.waitForQuery(queries.screenSettings.myDevicesView.DEVICES_HELP_SHEET.opened());
+      await vpn.waitForQueryAndClick(queries.screenSettings.myDevicesView.DEVICES_HELP_SHEET_LEARN_MORE_BUTTON.visible());
+      await vpn.waitForCondition(async () => {
+          const url = await vpn.getLastUrl();
+          return url === 'https://support.mozilla.org/kb/how-add-devices-your-mozilla-vpn-subscription';
+      });
+      await vpn.waitForQueryAndClick(queries.screenSettings.myDevicesView.DEVICES_HELP_SHEET_CLOSE_BUTTON.visible());
+    });
+  });
+
   describe('Device limit', function() {
     this.ctx.authenticationNeeded = true;
 

--- a/tests/functional/testServers.js
+++ b/tests/functional/testServers.js
@@ -273,14 +273,15 @@ describe('Server list', function() {
     }
 
     await vpn.waitForQueryAndClick(queries.screenHome.serverListView.HELP_BUTTON.visible());
-    await vpn.waitForQuery(queries.screenHome.serverListView.SERVER_HELP_SHEET.visible());
-    await vpn.waitForQuery(queries.screenHome.serverListView.SERVER_HELP_SHEET.opened());
-    await vpn.waitForQueryAndClick(queries.screenHome.serverListView.SERVER_HELP_SHEET_LEARN_MORE_BUTTON.visible());
+    await vpn.waitForQuery(queries.screenHome.serverListView.HELP_SHEET.visible());
+    await vpn.waitForQuery(queries.screenHome.serverListView.HELP_SHEET.opened());
+    await vpn.waitForQueryAndClick(queries.screenHome.serverListView.HELP_SHEET_LEARN_MORE_BUTTON.visible());
     await vpn.waitForCondition(async () => {
         const url = await vpn.getLastUrl();
         return url === 'https://support.mozilla.org/kb/multi-hop-encrypt-your-data-twice-enhanced-security';
     });
-    await vpn.waitForQueryAndClick(queries.screenHome.serverListView.SERVER_HELP_SHEET_CLOSE_BUTTON.visible());
+    await vpn.waitForQueryAndClick(queries.screenHome.serverListView.HELP_SHEET_CLOSE_BUTTON.visible());
+    await vpn.waitForQuery(queries.screenHome.serverListView.HELP_SHEET.closed());
   });
 
   // TODO: server list disabled when reached the device limit

--- a/tests/functional/testServers.js
+++ b/tests/functional/testServers.js
@@ -274,6 +274,7 @@ describe('Server list', function() {
 
     await vpn.waitForQueryAndClick(queries.screenHome.serverListView.HELP_BUTTON.visible());
     await vpn.waitForQuery(queries.screenHome.serverListView.SERVER_HELP_SHEET.visible());
+    await vpn.waitForQuery(queries.screenHome.serverListView.SERVER_HELP_SHEET.opened());
     await vpn.waitForQueryAndClick(queries.screenHome.serverListView.SERVER_HELP_SHEET_LEARN_MORE_BUTTON.visible());
     await vpn.waitForCondition(async () => {
         const url = await vpn.getLastUrl();

--- a/tests/functional/testServers.js
+++ b/tests/functional/testServers.js
@@ -267,7 +267,7 @@ describe('Server list', function() {
         queries.screenHome.serverListView.SEARCH_BAR_ERROR.hidden());
   });
 
-  it.only('check the help sheet', async () => {
+  it('check the help sheet', async () => {
     if (!(await vpn.isFeatureFlippedOn('helpSheets'))) {
       await vpn.flipFeatureOn('helpSheets');
     }

--- a/tests/functional/testServers.js
+++ b/tests/functional/testServers.js
@@ -267,6 +267,21 @@ describe('Server list', function() {
         queries.screenHome.serverListView.SEARCH_BAR_ERROR.hidden());
   });
 
+  it.only('check the help sheet', async () => {
+    if (!(await vpn.isFeatureFlippedOn('helpSheets'))) {
+      await vpn.flipFeatureOn('helpSheets');
+    }
+
+    await vpn.waitForQueryAndClick(queries.screenHome.serverListView.HELP_BUTTON.visible());
+    await vpn.waitForQuery(queries.screenHome.serverListView.SERVER_HELP_SHEET.visible());
+    await vpn.waitForQueryAndClick(queries.screenHome.serverListView.SERVER_HELP_SHEET_LEARN_MORE_BUTTON.visible());
+    await vpn.waitForCondition(async () => {
+        const url = await vpn.getLastUrl();
+        return url === 'https://support.mozilla.org/kb/multi-hop-encrypt-your-data-twice-enhanced-security';
+    });
+    await vpn.waitForQueryAndClick(queries.screenHome.serverListView.SERVER_HELP_SHEET_CLOSE_BUTTON.visible());
+  });
+
   // TODO: server list disabled when reached the device limit
 
 });

--- a/tests/functional/testSettings.js
+++ b/tests/functional/testSettings.js
@@ -572,7 +572,7 @@ describe('Settings', function() {
       assert.equal(await vpn.getSetting('dnsProviderFlags'), 1);
     });
 
-    it.only('Checking the dns help sheet', async () => {
+    it('Checking the dns help sheet', async () => {
       if (!(await vpn.isFeatureFlippedOn('helpSheets'))) {
         await vpn.flipFeatureOn('helpSheets');
       }

--- a/tests/functional/testSettings.js
+++ b/tests/functional/testSettings.js
@@ -103,211 +103,233 @@ describe('Settings', function() {
     await vpn.waitForQuery(queries.screenSettings.USER_PROFILE.visible());
   });
 
-  it('Checking the privacy settings', async () => {
-    await vpn.waitForQuery(queries.screenSettings.PRIVACY.visible());
+  describe('Privacy settings tests', function () {
 
-    await vpn.scrollToQuery(
-        queries.screenSettings.SCREEN, queries.screenSettings.PRIVACY);
+    beforeEach(async () => {
+      await vpn.waitForQuery(queries.screenSettings.PRIVACY.visible());
+  
+      await vpn.scrollToQuery(
+          queries.screenSettings.SCREEN, queries.screenSettings.PRIVACY);
+  
+      await vpn.clickOnQuery(queries.screenSettings.PRIVACY.visible());
+      await vpn.waitForQuery(queries.screenSettings.STACKVIEW.ready());
+  });
+  
+    it('Checking the privacy settings', async () => {
+      // Checking that the `These changes may affect...` warning is visible
+      await vpn.waitForQuery(
+          queries.screenSettings.privacyView.INFORMATION_CARD.visible());
+  
+      // Checking if the checkboxes are correctly set based on the settings prop
+      await vpn.setSetting('dnsProviderFlags', 0);
+      await vpn.waitForQuery(
+          queries.screenSettings.privacyView.BLOCK_ADS.visible().prop(
+              'isChecked', false));
+      await vpn.waitForQuery(
+          queries.screenSettings.privacyView.BLOCK_TRACKERS.visible().prop(
+              'isChecked', false));
+      await vpn.waitForQuery(
+          queries.screenSettings.privacyView.BLOCK_MALWARE.visible().prop(
+              'isChecked', false));
+  
+      await vpn.setSetting('dnsProviderFlags', 2);
+      await vpn.waitForQuery(
+          queries.screenSettings.privacyView.BLOCK_ADS.visible().prop(
+              'isChecked', true));
+      await vpn.waitForQuery(
+          queries.screenSettings.privacyView.BLOCK_TRACKERS.visible().prop(
+              'isChecked', false));
+      await vpn.waitForQuery(
+          queries.screenSettings.privacyView.BLOCK_MALWARE.visible().prop(
+              'isChecked', false));
+  
+      await vpn.setSetting('dnsProviderFlags', 4);
+      await vpn.waitForQuery(
+          queries.screenSettings.privacyView.BLOCK_ADS.visible().prop(
+              'isChecked', false));
+      await vpn.waitForQuery(
+          queries.screenSettings.privacyView.BLOCK_TRACKERS.visible().prop(
+              'isChecked', true));
+      await vpn.waitForQuery(
+          queries.screenSettings.privacyView.BLOCK_MALWARE.visible().prop(
+              'isChecked', false));
+  
+      await vpn.setSetting('dnsProviderFlags', 6);
+      await vpn.waitForQuery(
+          queries.screenSettings.privacyView.BLOCK_ADS.visible().prop(
+              'isChecked', true));
+      await vpn.waitForQuery(
+          queries.screenSettings.privacyView.BLOCK_TRACKERS.visible().prop(
+              'isChecked', true));
+      await vpn.waitForQuery(
+          queries.screenSettings.privacyView.BLOCK_MALWARE.visible().prop(
+              'isChecked', false));
+  
+      await vpn.setSetting('dnsProviderFlags', 8);
+      await vpn.waitForQuery(
+          queries.screenSettings.privacyView.BLOCK_ADS.visible().prop(
+              'isChecked', false));
+      await vpn.waitForQuery(
+          queries.screenSettings.privacyView.BLOCK_TRACKERS.visible().prop(
+              'isChecked', false));
+      await vpn.waitForQuery(
+          queries.screenSettings.privacyView.BLOCK_MALWARE.visible().prop(
+              'isChecked', true));
+  
+      await vpn.setSetting('dnsProviderFlags', 10);
+      await vpn.waitForQuery(
+          queries.screenSettings.privacyView.BLOCK_ADS.visible().prop(
+              'isChecked', true));
+      await vpn.waitForQuery(
+          queries.screenSettings.privacyView.BLOCK_TRACKERS.visible().prop(
+              'isChecked', false));
+      await vpn.waitForQuery(
+          queries.screenSettings.privacyView.BLOCK_MALWARE.visible().prop(
+              'isChecked', true));
+  
+      await vpn.setSetting('dnsProviderFlags', 12);
+      await vpn.waitForQuery(
+          queries.screenSettings.privacyView.BLOCK_ADS.visible().prop(
+              'isChecked', false));
+      await vpn.waitForQuery(
+          queries.screenSettings.privacyView.BLOCK_TRACKERS.visible().prop(
+              'isChecked', true));
+      await vpn.waitForQuery(
+          queries.screenSettings.privacyView.BLOCK_MALWARE.visible().prop(
+              'isChecked', true));
+  
+      await vpn.setSetting('dnsProviderFlags', 14);
+      await vpn.waitForQuery(
+          queries.screenSettings.privacyView.BLOCK_ADS.visible().prop(
+              'isChecked', true));
+      await vpn.waitForQuery(
+          queries.screenSettings.privacyView.BLOCK_TRACKERS.visible().prop(
+              'isChecked', true));
+      await vpn.waitForQuery(
+          queries.screenSettings.privacyView.BLOCK_MALWARE.visible().prop(
+              'isChecked', true));
+  
+      // Tests the clicks
+      await vpn.setSetting('dnsProviderFlags', 0);
+      await vpn.waitForQueryAndClick(
+          queries.screenSettings.privacyView.BLOCK_ADS_CHECKBOX.visible());
+      assert.equal(await vpn.getSetting('dnsProviderFlags'), 2);
+  
+      await vpn.setSetting('dnsProviderFlags', 0);
+      await vpn.waitForQueryAndClick(
+          queries.screenSettings.privacyView.BLOCK_TRACKERS_CHECKBOX.visible());
+      assert.equal(await vpn.getSetting('dnsProviderFlags'), 4);
+  
+      await vpn.setSetting('dnsProviderFlags', 0);
+      await vpn.waitForQueryAndClick(
+          queries.screenSettings.privacyView.BLOCK_MALWARE_CHECKBOX.visible());
+      assert.equal(await vpn.getSetting('dnsProviderFlags'), 8);
+  
+      // Let's test the modal
+      await vpn.setSetting('dnsProviderFlags', 1);
+      await vpn.waitForQueryAndClick(
+          queries.screenSettings.privacyView.BLOCK_ADS_CHECKBOX.visible());
+      assert.equal(await vpn.getSetting('dnsProviderFlags'), 1);
+      await vpn.waitForQueryAndClick(
+          queries.screenSettings.privacyView.MODAL_SECONDARY_BUTTON.visible());
+      await vpn.waitForQuery(
+          queries.screenSettings.privacyView.MODAL_LOADER.prop('active', false));
+      assert.equal(await vpn.getSetting('dnsProviderFlags'), 1);
+      await vpn.waitForQueryAndClick(
+          queries.screenSettings.privacyView.BLOCK_ADS_CHECKBOX.visible());
+      assert.equal(await vpn.getSetting('dnsProviderFlags'), 1);
+      await vpn.waitForQueryAndClick(
+          queries.screenSettings.privacyView.MODAL_CLOSE_BUTTON.visible());
+      await vpn.waitForQuery(
+          queries.screenSettings.privacyView.MODAL_LOADER.prop('active', false));
+      assert.equal(await vpn.getSetting('dnsProviderFlags'), 1);
+      await vpn.waitForQueryAndClick(
+          queries.screenSettings.privacyView.BLOCK_ADS_CHECKBOX.visible());
+      assert.equal(await vpn.getSetting('dnsProviderFlags'), 1);
+      await vpn.waitForQueryAndClick(
+          queries.screenSettings.privacyView.MODAL_PRIMARY_BUTTON.visible());
+      await vpn.waitForQuery(
+          queries.screenSettings.privacyView.MODAL_LOADER.prop('active', false));
+      assert.equal(await vpn.getSetting('dnsProviderFlags'), 2);
+  
+      await vpn.setSetting('dnsProviderFlags', 1);
+      await vpn.waitForQueryAndClick(
+          queries.screenSettings.privacyView.BLOCK_TRACKERS_CHECKBOX.visible());
+      assert.equal(await vpn.getSetting('dnsProviderFlags'), 1);
+      await vpn.waitForQueryAndClick(
+          queries.screenSettings.privacyView.MODAL_SECONDARY_BUTTON.visible());
+      await vpn.waitForQuery(
+          queries.screenSettings.privacyView.MODAL_LOADER.prop('active', false));
+      assert.equal(await vpn.getSetting('dnsProviderFlags'), 1);
+      await vpn.waitForQueryAndClick(
+          queries.screenSettings.privacyView.BLOCK_TRACKERS_CHECKBOX.visible());
+      assert.equal(await vpn.getSetting('dnsProviderFlags'), 1);
+      await vpn.waitForQueryAndClick(
+          queries.screenSettings.privacyView.MODAL_CLOSE_BUTTON.visible());
+      await vpn.waitForQuery(
+          queries.screenSettings.privacyView.MODAL_LOADER.prop('active', false));
+      assert.equal(await vpn.getSetting('dnsProviderFlags'), 1);
+      await vpn.waitForQueryAndClick(
+          queries.screenSettings.privacyView.BLOCK_TRACKERS_CHECKBOX.visible());
+      assert.equal(await vpn.getSetting('dnsProviderFlags'), 1);
+      await vpn.waitForQueryAndClick(
+          queries.screenSettings.privacyView.MODAL_PRIMARY_BUTTON.visible());
+      await vpn.waitForQuery(
+          queries.screenSettings.privacyView.MODAL_LOADER.prop('active', false));
+      assert.equal(await vpn.getSetting('dnsProviderFlags'), 4);
+  
+      await vpn.setSetting('dnsProviderFlags', 1);
+      await vpn.waitForQueryAndClick(
+          queries.screenSettings.privacyView.BLOCK_MALWARE_CHECKBOX.visible());
+      assert.equal(await vpn.getSetting('dnsProviderFlags'), 1);
+      await vpn.waitForQueryAndClick(
+          queries.screenSettings.privacyView.MODAL_SECONDARY_BUTTON.visible());
+      await vpn.waitForQuery(
+          queries.screenSettings.privacyView.MODAL_LOADER.prop('active', false));
+      assert.equal(await vpn.getSetting('dnsProviderFlags'), 1);
+      await vpn.waitForQueryAndClick(
+          queries.screenSettings.privacyView.BLOCK_MALWARE_CHECKBOX.visible());
+      assert.equal(await vpn.getSetting('dnsProviderFlags'), 1);
+      await vpn.waitForQueryAndClick(
+          queries.screenSettings.privacyView.MODAL_CLOSE_BUTTON.visible());
+      await vpn.waitForQuery(
+          queries.screenSettings.privacyView.MODAL_LOADER.prop('active', false));
+      assert.equal(await vpn.getSetting('dnsProviderFlags'), 1);
+      await vpn.waitForQueryAndClick(
+          queries.screenSettings.privacyView.BLOCK_MALWARE_CHECKBOX.visible());
+      assert.equal(await vpn.getSetting('dnsProviderFlags'), 1);
+      await vpn.waitForQueryAndClick(
+          queries.screenSettings.privacyView.MODAL_PRIMARY_BUTTON.visible());
+      await vpn.waitForQuery(
+          queries.screenSettings.privacyView.MODAL_LOADER.prop('active', false));
+      assert.equal(await vpn.getSetting('dnsProviderFlags'), 8);
+  
+      // Let's go back
+      await vpn.waitForQueryAndClick(queries.screenSettings.BACK.visible());
+      await vpn.waitForQuery(queries.screenSettings.STACKVIEW.ready());
+  
+      await vpn.waitForQuery(queries.screenSettings.USER_PROFILE.visible());
+  
+      // Reset
+      await vpn.setSetting('dnsProviderFlags', 0);
+    });
+  
+    it('Checking the privacy help sheet', async () => {
+      if (!(await vpn.isFeatureFlippedOn('helpSheets'))) {
+        await vpn.flipFeatureOn('helpSheets');
+      }
+  
+      await vpn.waitForQueryAndClick(queries.screenSettings.privacyView.HELP_BUTTON.visible());
+      await vpn.waitForQuery(queries.screenSettings.privacyView.PRIVACY_HELP_SHEET.visible());
+      await vpn.waitForQuery(queries.screenSettings.privacyView.PRIVACY_HELP_SHEET.opened());
+      await vpn.waitForQueryAndClick(queries.screenSettings.privacyView.PRIVACY_HELP_SHEET_LEARN_MORE_BUTTON.visible());
+      await vpn.waitForCondition(async () => {
+          const url = await vpn.getLastUrl();
+          return url === 'https://support.mozilla.org/kb/how-do-i-change-my-privacy-features';
+      });
+      await vpn.waitForQueryAndClick(queries.screenSettings.privacyView.PRIVACY_HELP_SHEET_CLOSE_BUTTON.visible());
+    });
 
-    await vpn.clickOnQuery(queries.screenSettings.PRIVACY.visible());
-    await vpn.waitForQuery(queries.screenSettings.STACKVIEW.ready());
-
-    // Checking that the `These changes may affect...` warning is visible
-    await vpn.waitForQuery(
-        queries.screenSettings.privacyView.INFORMATION_CARD.visible());
-
-    // Checking if the checkboxes are correctly set based on the settings prop
-    await vpn.setSetting('dnsProviderFlags', 0);
-    await vpn.waitForQuery(
-        queries.screenSettings.privacyView.BLOCK_ADS.visible().prop(
-            'isChecked', false));
-    await vpn.waitForQuery(
-        queries.screenSettings.privacyView.BLOCK_TRACKERS.visible().prop(
-            'isChecked', false));
-    await vpn.waitForQuery(
-        queries.screenSettings.privacyView.BLOCK_MALWARE.visible().prop(
-            'isChecked', false));
-
-    await vpn.setSetting('dnsProviderFlags', 2);
-    await vpn.waitForQuery(
-        queries.screenSettings.privacyView.BLOCK_ADS.visible().prop(
-            'isChecked', true));
-    await vpn.waitForQuery(
-        queries.screenSettings.privacyView.BLOCK_TRACKERS.visible().prop(
-            'isChecked', false));
-    await vpn.waitForQuery(
-        queries.screenSettings.privacyView.BLOCK_MALWARE.visible().prop(
-            'isChecked', false));
-
-    await vpn.setSetting('dnsProviderFlags', 4);
-    await vpn.waitForQuery(
-        queries.screenSettings.privacyView.BLOCK_ADS.visible().prop(
-            'isChecked', false));
-    await vpn.waitForQuery(
-        queries.screenSettings.privacyView.BLOCK_TRACKERS.visible().prop(
-            'isChecked', true));
-    await vpn.waitForQuery(
-        queries.screenSettings.privacyView.BLOCK_MALWARE.visible().prop(
-            'isChecked', false));
-
-    await vpn.setSetting('dnsProviderFlags', 6);
-    await vpn.waitForQuery(
-        queries.screenSettings.privacyView.BLOCK_ADS.visible().prop(
-            'isChecked', true));
-    await vpn.waitForQuery(
-        queries.screenSettings.privacyView.BLOCK_TRACKERS.visible().prop(
-            'isChecked', true));
-    await vpn.waitForQuery(
-        queries.screenSettings.privacyView.BLOCK_MALWARE.visible().prop(
-            'isChecked', false));
-
-    await vpn.setSetting('dnsProviderFlags', 8);
-    await vpn.waitForQuery(
-        queries.screenSettings.privacyView.BLOCK_ADS.visible().prop(
-            'isChecked', false));
-    await vpn.waitForQuery(
-        queries.screenSettings.privacyView.BLOCK_TRACKERS.visible().prop(
-            'isChecked', false));
-    await vpn.waitForQuery(
-        queries.screenSettings.privacyView.BLOCK_MALWARE.visible().prop(
-            'isChecked', true));
-
-    await vpn.setSetting('dnsProviderFlags', 10);
-    await vpn.waitForQuery(
-        queries.screenSettings.privacyView.BLOCK_ADS.visible().prop(
-            'isChecked', true));
-    await vpn.waitForQuery(
-        queries.screenSettings.privacyView.BLOCK_TRACKERS.visible().prop(
-            'isChecked', false));
-    await vpn.waitForQuery(
-        queries.screenSettings.privacyView.BLOCK_MALWARE.visible().prop(
-            'isChecked', true));
-
-    await vpn.setSetting('dnsProviderFlags', 12);
-    await vpn.waitForQuery(
-        queries.screenSettings.privacyView.BLOCK_ADS.visible().prop(
-            'isChecked', false));
-    await vpn.waitForQuery(
-        queries.screenSettings.privacyView.BLOCK_TRACKERS.visible().prop(
-            'isChecked', true));
-    await vpn.waitForQuery(
-        queries.screenSettings.privacyView.BLOCK_MALWARE.visible().prop(
-            'isChecked', true));
-
-    await vpn.setSetting('dnsProviderFlags', 14);
-    await vpn.waitForQuery(
-        queries.screenSettings.privacyView.BLOCK_ADS.visible().prop(
-            'isChecked', true));
-    await vpn.waitForQuery(
-        queries.screenSettings.privacyView.BLOCK_TRACKERS.visible().prop(
-            'isChecked', true));
-    await vpn.waitForQuery(
-        queries.screenSettings.privacyView.BLOCK_MALWARE.visible().prop(
-            'isChecked', true));
-
-    // Tests the clicks
-    await vpn.setSetting('dnsProviderFlags', 0);
-    await vpn.waitForQueryAndClick(
-        queries.screenSettings.privacyView.BLOCK_ADS_CHECKBOX.visible());
-    assert.equal(await vpn.getSetting('dnsProviderFlags'), 2);
-
-    await vpn.setSetting('dnsProviderFlags', 0);
-    await vpn.waitForQueryAndClick(
-        queries.screenSettings.privacyView.BLOCK_TRACKERS_CHECKBOX.visible());
-    assert.equal(await vpn.getSetting('dnsProviderFlags'), 4);
-
-    await vpn.setSetting('dnsProviderFlags', 0);
-    await vpn.waitForQueryAndClick(
-        queries.screenSettings.privacyView.BLOCK_MALWARE_CHECKBOX.visible());
-    assert.equal(await vpn.getSetting('dnsProviderFlags'), 8);
-
-    // Let's test the modal
-    await vpn.setSetting('dnsProviderFlags', 1);
-    await vpn.waitForQueryAndClick(
-        queries.screenSettings.privacyView.BLOCK_ADS_CHECKBOX.visible());
-    assert.equal(await vpn.getSetting('dnsProviderFlags'), 1);
-    await vpn.waitForQueryAndClick(
-        queries.screenSettings.privacyView.MODAL_SECONDARY_BUTTON.visible());
-    await vpn.waitForQuery(
-        queries.screenSettings.privacyView.MODAL_LOADER.prop('active', false));
-    assert.equal(await vpn.getSetting('dnsProviderFlags'), 1);
-    await vpn.waitForQueryAndClick(
-        queries.screenSettings.privacyView.BLOCK_ADS_CHECKBOX.visible());
-    assert.equal(await vpn.getSetting('dnsProviderFlags'), 1);
-    await vpn.waitForQueryAndClick(
-        queries.screenSettings.privacyView.MODAL_CLOSE_BUTTON.visible());
-    await vpn.waitForQuery(
-        queries.screenSettings.privacyView.MODAL_LOADER.prop('active', false));
-    assert.equal(await vpn.getSetting('dnsProviderFlags'), 1);
-    await vpn.waitForQueryAndClick(
-        queries.screenSettings.privacyView.BLOCK_ADS_CHECKBOX.visible());
-    assert.equal(await vpn.getSetting('dnsProviderFlags'), 1);
-    await vpn.waitForQueryAndClick(
-        queries.screenSettings.privacyView.MODAL_PRIMARY_BUTTON.visible());
-    await vpn.waitForQuery(
-        queries.screenSettings.privacyView.MODAL_LOADER.prop('active', false));
-    assert.equal(await vpn.getSetting('dnsProviderFlags'), 2);
-
-    await vpn.setSetting('dnsProviderFlags', 1);
-    await vpn.waitForQueryAndClick(
-        queries.screenSettings.privacyView.BLOCK_TRACKERS_CHECKBOX.visible());
-    assert.equal(await vpn.getSetting('dnsProviderFlags'), 1);
-    await vpn.waitForQueryAndClick(
-        queries.screenSettings.privacyView.MODAL_SECONDARY_BUTTON.visible());
-    await vpn.waitForQuery(
-        queries.screenSettings.privacyView.MODAL_LOADER.prop('active', false));
-    assert.equal(await vpn.getSetting('dnsProviderFlags'), 1);
-    await vpn.waitForQueryAndClick(
-        queries.screenSettings.privacyView.BLOCK_TRACKERS_CHECKBOX.visible());
-    assert.equal(await vpn.getSetting('dnsProviderFlags'), 1);
-    await vpn.waitForQueryAndClick(
-        queries.screenSettings.privacyView.MODAL_CLOSE_BUTTON.visible());
-    await vpn.waitForQuery(
-        queries.screenSettings.privacyView.MODAL_LOADER.prop('active', false));
-    assert.equal(await vpn.getSetting('dnsProviderFlags'), 1);
-    await vpn.waitForQueryAndClick(
-        queries.screenSettings.privacyView.BLOCK_TRACKERS_CHECKBOX.visible());
-    assert.equal(await vpn.getSetting('dnsProviderFlags'), 1);
-    await vpn.waitForQueryAndClick(
-        queries.screenSettings.privacyView.MODAL_PRIMARY_BUTTON.visible());
-    await vpn.waitForQuery(
-        queries.screenSettings.privacyView.MODAL_LOADER.prop('active', false));
-    assert.equal(await vpn.getSetting('dnsProviderFlags'), 4);
-
-    await vpn.setSetting('dnsProviderFlags', 1);
-    await vpn.waitForQueryAndClick(
-        queries.screenSettings.privacyView.BLOCK_MALWARE_CHECKBOX.visible());
-    assert.equal(await vpn.getSetting('dnsProviderFlags'), 1);
-    await vpn.waitForQueryAndClick(
-        queries.screenSettings.privacyView.MODAL_SECONDARY_BUTTON.visible());
-    await vpn.waitForQuery(
-        queries.screenSettings.privacyView.MODAL_LOADER.prop('active', false));
-    assert.equal(await vpn.getSetting('dnsProviderFlags'), 1);
-    await vpn.waitForQueryAndClick(
-        queries.screenSettings.privacyView.BLOCK_MALWARE_CHECKBOX.visible());
-    assert.equal(await vpn.getSetting('dnsProviderFlags'), 1);
-    await vpn.waitForQueryAndClick(
-        queries.screenSettings.privacyView.MODAL_CLOSE_BUTTON.visible());
-    await vpn.waitForQuery(
-        queries.screenSettings.privacyView.MODAL_LOADER.prop('active', false));
-    assert.equal(await vpn.getSetting('dnsProviderFlags'), 1);
-    await vpn.waitForQueryAndClick(
-        queries.screenSettings.privacyView.BLOCK_MALWARE_CHECKBOX.visible());
-    assert.equal(await vpn.getSetting('dnsProviderFlags'), 1);
-    await vpn.waitForQueryAndClick(
-        queries.screenSettings.privacyView.MODAL_PRIMARY_BUTTON.visible());
-    await vpn.waitForQuery(
-        queries.screenSettings.privacyView.MODAL_LOADER.prop('active', false));
-    assert.equal(await vpn.getSetting('dnsProviderFlags'), 8);
-
-    // Let's go back
-    await vpn.waitForQueryAndClick(queries.screenSettings.BACK.visible());
-    await vpn.waitForQuery(queries.screenSettings.STACKVIEW.ready());
-
-    await vpn.waitForQuery(queries.screenSettings.USER_PROFILE.visible());
-
-    // Reset
-    await vpn.setSetting('dnsProviderFlags', 0);
   });
 
   it('Checking the DNS settings', async () => {

--- a/tests/functional/testSettings.js
+++ b/tests/functional/testSettings.js
@@ -319,14 +319,15 @@ describe('Settings', function() {
       }
   
       await vpn.waitForQueryAndClick(queries.screenSettings.privacyView.HELP_BUTTON.visible());
-      await vpn.waitForQuery(queries.screenSettings.privacyView.PRIVACY_HELP_SHEET.visible());
-      await vpn.waitForQuery(queries.screenSettings.privacyView.PRIVACY_HELP_SHEET.opened());
-      await vpn.waitForQueryAndClick(queries.screenSettings.privacyView.PRIVACY_HELP_SHEET_LEARN_MORE_BUTTON.visible());
+      await vpn.waitForQuery(queries.screenSettings.privacyView.HELP_SHEET.visible());
+      await vpn.waitForQuery(queries.screenSettings.privacyView.HELP_SHEET.opened());
+      await vpn.waitForQueryAndClick(queries.screenSettings.privacyView.HELP_SHEET_LEARN_MORE_BUTTON.visible());
       await vpn.waitForCondition(async () => {
           const url = await vpn.getLastUrl();
           return url === 'https://support.mozilla.org/kb/how-do-i-change-my-privacy-features';
       });
-      await vpn.waitForQueryAndClick(queries.screenSettings.privacyView.PRIVACY_HELP_SHEET_CLOSE_BUTTON.visible());
+      await vpn.waitForQueryAndClick(queries.screenSettings.privacyView.HELP_SHEET_CLOSE_BUTTON.visible());
+      await vpn.waitForQuery(queries.screenSettings.privacyView.HELP_SHEET.closed());
     });
   });
 
@@ -578,14 +579,15 @@ describe('Settings', function() {
       }
   
       await vpn.waitForQueryAndClick(queries.screenSettings.appPreferencesView.dnsSettingsView.HELP_BUTTON.visible());
-      await vpn.waitForQuery(queries.screenSettings.appPreferencesView.dnsSettingsView.PRIVACY_HELP_SHEET.visible());
-      await vpn.waitForQuery(queries.screenSettings.appPreferencesView.dnsSettingsView.PRIVACY_HELP_SHEET.opened());
-      await vpn.waitForQueryAndClick(queries.screenSettings.appPreferencesView.dnsSettingsView.PRIVACY_HELP_SHEET_LEARN_MORE_BUTTON.visible());
+      await vpn.waitForQuery(queries.screenSettings.appPreferencesView.dnsSettingsView.HELP_SHEET.visible());
+      await vpn.waitForQuery(queries.screenSettings.appPreferencesView.dnsSettingsView.HELP_SHEET.opened());
+      await vpn.waitForQueryAndClick(queries.screenSettings.appPreferencesView.dnsSettingsView.HELP_SHEET_LEARN_MORE_BUTTON.visible());
       await vpn.waitForCondition(async () => {
           const url = await vpn.getLastUrl();
           return url === 'https://support.mozilla.org/kb/how-do-i-change-my-dns-settings';
       });
-      await vpn.waitForQueryAndClick(queries.screenSettings.appPreferencesView.dnsSettingsView.PRIVACY_HELP_SHEET_CLOSE_BUTTON.visible());
+      await vpn.waitForQueryAndClick(queries.screenSettings.appPreferencesView.dnsSettingsView.HELP_SHEET_CLOSE_BUTTON.visible());
+      await vpn.waitForQuery(queries.screenSettings.appPreferencesView.dnsSettingsView.HELP_SHEET.closed());
     });
   });
 

--- a/tests/functional/testSettings.js
+++ b/tests/functional/testSettings.js
@@ -104,7 +104,6 @@ describe('Settings', function() {
   });
 
   describe('Privacy settings tests', function () {
-
     beforeEach(async () => {
       await vpn.waitForQuery(queries.screenSettings.PRIVACY.visible());
   
@@ -329,258 +328,267 @@ describe('Settings', function() {
       });
       await vpn.waitForQueryAndClick(queries.screenSettings.privacyView.PRIVACY_HELP_SHEET_CLOSE_BUTTON.visible());
     });
-
   });
 
-  it('Checking the DNS settings', async () => {
-    await vpn.setSetting('userDNS', '');
-    await vpn.setSetting('dnsProviderFlags', 0);
+  describe('DNS settings tests', function () {
+    beforeEach(async () => {
+      await vpn.setSetting('userDNS', '');
+      await vpn.setSetting('dnsProviderFlags', 0);
+  
+      await vpn.waitForQueryAndClick(
+          queries.screenSettings.APP_PREFERENCES.visible());
+      await vpn.waitForQuery(queries.screenSettings.STACKVIEW.ready());
+  
+      await vpn.waitForQueryAndClick(
+          queries.screenSettings.appPreferencesView.DNS_SETTINGS.visible());
+      await vpn.waitForQuery(queries.screenSettings.STACKVIEW.ready());
+    });
 
-    await vpn.waitForQueryAndClick(
-        queries.screenSettings.APP_PREFERENCES.visible());
-    await vpn.waitForQuery(queries.screenSettings.STACKVIEW.ready());
+    it('Checking the DNS settings', async () => {
+      // Checking if the checkboxes are correctly set based on the settings prop
+      await vpn.waitForQuery(
+          queries.screenSettings.appPreferencesView.dnsSettingsView.STANDARD_DNS
+              .visible()
+              .prop('checked', true));
+      await vpn.waitForQuery(
+          queries.screenSettings.appPreferencesView.dnsSettingsView.CUSTOM_DNS
+              .visible()
+              .prop('checked', false));
+  
+      await vpn.waitForQueryAndClick(queries.navBar.HOME.visible());
+      await vpn.waitForQuery(queries.global.SCREEN_LOADER.ready());
+  
+      await vpn.setSetting('dnsProviderFlags', 1);
+  
+      await vpn.waitForQueryAndClick(queries.navBar.SETTINGS.visible());
+      await vpn.waitForQuery(queries.global.SCREEN_LOADER.ready());
+  
+      await vpn.waitForQuery(
+          queries.screenSettings.appPreferencesView.dnsSettingsView.STANDARD_DNS
+              .visible()
+              .prop('checked', false));
+      await vpn.waitForQuery(
+          queries.screenSettings.appPreferencesView.dnsSettingsView.CUSTOM_DNS
+              .visible()
+              .prop('checked', true));
+      await vpn.waitForQuery(queries.screenSettings.appPreferencesView
+                                 .dnsSettingsView.CUSTOM_DNS_INPUT.visible()
+                                 .prop('hasError', false));
+      await vpn.setQueryProperty(
+          queries.screenSettings.appPreferencesView.dnsSettingsView
+              .CUSTOM_DNS_INPUT.visible(),
+          'text', 'wow');
+      await vpn.waitForQuery(queries.screenSettings.appPreferencesView
+                                 .dnsSettingsView.CUSTOM_DNS_INPUT.visible()
+                                 .prop('hasError', true));
+      await vpn.setQueryProperty(
+          queries.screenSettings.appPreferencesView.dnsSettingsView
+              .CUSTOM_DNS_INPUT.visible(),
+          'text', '1.2.3.4');
+      await vpn.waitForQuery(queries.screenSettings.appPreferencesView
+                                 .dnsSettingsView.CUSTOM_DNS_INPUT.visible()
+                                 .prop('hasError', false));
+  
+      // Check the warning message
+      assert.equal(
+          await vpn.getQueryProperty(
+              queries.screenSettings.appPreferencesView.dnsSettingsView
+                  .INFORMATION_CARD_LOADER,
+              'active'), 'false');
+  
+      // Check the click
+      await vpn.waitForQueryAndClick(
+          queries.screenSettings.appPreferencesView.dnsSettingsView.STANDARD_DNS
+              .visible()
+              .prop('checked', false));
+  
+      await vpn.waitForQueryAndClick(queries.navBar.HOME.visible());
+      await vpn.waitForQuery(queries.global.SCREEN_LOADER.ready());
+  
+      assert.equal(await vpn.getSetting('dnsProviderFlags'), 0);
+  
+      await vpn.waitForQueryAndClick(queries.navBar.SETTINGS.visible());
+      await vpn.waitForQuery(queries.global.SCREEN_LOADER.ready());
+  
+      await vpn.waitForQueryAndClick(
+          queries.screenSettings.appPreferencesView.dnsSettingsView.CUSTOM_DNS
+              .visible()
+              .prop('checked', false));
+  
+      await vpn.waitForQueryAndClick(queries.navBar.HOME.visible());
+      await vpn.waitForQuery(queries.global.SCREEN_LOADER.ready());
+  
+      assert.equal(await vpn.getSetting('dnsProviderFlags'), 1);
+  
+      // Check the modal
+      await vpn.setSetting('dnsProviderFlags', 2);
+  
+      await vpn.waitForQueryAndClick(queries.navBar.SETTINGS.visible());
+      await vpn.waitForQuery(queries.global.SCREEN_LOADER.ready());
+  
+      await vpn.waitForQuery(
+          queries.screenSettings.appPreferencesView.dnsSettingsView.STANDARD_DNS
+              .visible()
+              .prop('checked', true));
+  
+      await vpn.waitForQueryAndClick(
+          queries.screenSettings.appPreferencesView.dnsSettingsView.CUSTOM_DNS
+              .visible()
+              .prop('checked', false));
+  
+      await vpn.waitForQueryAndClick(
+          queries.screenSettings.appPreferencesView.dnsSettingsView
+              .MODAL_SECONDARY_BUTTON.visible());
+      await vpn.waitForQuery(
+          queries.screenSettings.appPreferencesView.dnsSettingsView
+              .MODAL_LOADER.prop('active', false));
+  
+      await vpn.waitForQueryAndClick(queries.screenSettings.appPreferencesView
+                                         .dnsSettingsView.CUSTOM_DNS.visible());
+  
+      await vpn.waitForQueryAndClick(
+          queries.screenSettings.appPreferencesView.dnsSettingsView
+              .MODAL_CLOSE_BUTTON.visible());
+      await vpn.waitForQuery(
+          queries.screenSettings.appPreferencesView.dnsSettingsView
+              .MODAL_LOADER.prop('active', false));
+  
+      await vpn.waitForQueryAndClick(queries.screenSettings.appPreferencesView
+                                         .dnsSettingsView.CUSTOM_DNS.visible());
+  
+      await vpn.waitForQueryAndClick(
+          queries.screenSettings.appPreferencesView.dnsSettingsView
+              .MODAL_PRIMARY_BUTTON.visible());
+      await vpn.waitForQuery(
+          queries.screenSettings.appPreferencesView.dnsSettingsView
+              .MODAL_LOADER.prop('active', false));
+  
+      await vpn.setQueryProperty(
+          queries.screenSettings.appPreferencesView.dnsSettingsView
+              .CUSTOM_DNS_INPUT.visible(),
+          'text', '1.2.3.4');
+  
+      await vpn.waitForQueryAndClick(queries.screenSettings.BACK.visible());
+      await vpn.waitForQuery(queries.screenSettings.STACKVIEW.ready());
+  
+      assert.equal(await vpn.getSetting('dnsProviderFlags'), 1);
+  
+      await vpn.waitForQueryAndClick(queries.screenSettings.BACK.visible());
+      await vpn.waitForQuery(queries.screenSettings.STACKVIEW.ready());
+  
+      await vpn.waitForQuery(queries.screenSettings.USER_PROFILE.visible());
+    });
+  
+    it('Checking the DNS settings reset', async () => {
+      // Checking if the checkboxes are correctly set based on the settings prop
+      await vpn.waitForQuery(
+          queries.screenSettings.appPreferencesView.dnsSettingsView.STANDARD_DNS
+              .visible()
+              .prop('checked', true));
+      await vpn.waitForQuery(
+          queries.screenSettings.appPreferencesView.dnsSettingsView.CUSTOM_DNS
+              .visible()
+              .prop('checked', false));
+  
+      // Click on "Custom DNS" but leaving the input field empty.
+      await vpn.waitForQueryAndClick(
+          queries.screenSettings.appPreferencesView.dnsSettingsView.CUSTOM_DNS
+              .visible()
+              .prop('checked', false));
+  
+      await vpn.setQueryProperty(
+          queries.screenSettings.appPreferencesView.dnsSettingsView
+              .CUSTOM_DNS_INPUT.visible(),
+          'text', '');
+  
+      // Going back...
+      await vpn.waitForQueryAndClick(queries.screenSettings.BACK.visible());
+      await vpn.waitForQuery(queries.screenSettings.STACKVIEW.ready());
+  
+      // .. the DNS setting is reset to the default value.
+      assert.equal(await vpn.getSetting('dnsProviderFlags'), 0);
+  
+      // Same test as before...
+      await vpn.waitForQueryAndClick(
+          queries.screenSettings.appPreferencesView.DNS_SETTINGS.visible());
+      await vpn.waitForQuery(queries.screenSettings.STACKVIEW.ready());
+  
+      await vpn.waitForQuery(
+          queries.screenSettings.appPreferencesView.dnsSettingsView.STANDARD_DNS
+              .visible()
+              .prop('checked', true));
+      await vpn.waitForQuery(
+          queries.screenSettings.appPreferencesView.dnsSettingsView.CUSTOM_DNS
+              .visible()
+              .prop('checked', false));
+  
+      await vpn.waitForQueryAndClick(
+          queries.screenSettings.appPreferencesView.dnsSettingsView.CUSTOM_DNS
+              .visible()
+              .prop('checked', false));
+  
+      // But with a valid DNS value...
+      await vpn.setQueryProperty(
+          queries.screenSettings.appPreferencesView.dnsSettingsView
+              .CUSTOM_DNS_INPUT.visible(),
+          'text', '1.2.3.4');
+  
+      await vpn.waitForQueryAndClick(queries.screenSettings.BACK.visible());
+      await vpn.waitForQuery(queries.screenSettings.STACKVIEW.ready());
+  
+      // We keep the custom DNS.
+      assert.equal(await vpn.getSetting('dnsProviderFlags'), 1);
+  
+      // Write something invalid...
+      await vpn.waitForQueryAndClick(
+          queries.screenSettings.appPreferencesView.DNS_SETTINGS.visible());
+      await vpn.waitForQuery(queries.screenSettings.STACKVIEW.ready());
+  
+      await vpn.waitForQuery(
+          queries.screenSettings.appPreferencesView.dnsSettingsView.STANDARD_DNS
+              .visible()
+              .prop('checked', false));
+      await vpn.waitForQuery(
+          queries.screenSettings.appPreferencesView.dnsSettingsView.CUSTOM_DNS
+              .visible()
+              .prop('checked', true));
+  
+      assert.equal(
+          await vpn.getQueryProperty(
+              queries.screenSettings.appPreferencesView.dnsSettingsView
+                  .CUSTOM_DNS_INPUT.visible(),
+              'text'),
+          '1.2.3.4');
+  
+      await vpn.setQueryProperty(
+          queries.screenSettings.appPreferencesView.dnsSettingsView
+              .CUSTOM_DNS_INPUT.visible(),
+          'text', '1.2.3.4aabbcc');
+  
+      await vpn.waitForQueryAndClick(queries.screenSettings.BACK.visible());
+      await vpn.waitForQuery(queries.screenSettings.STACKVIEW.ready());
+  
+      // We keep the custom DNS.
+      assert.equal(await vpn.getSetting('dnsProviderFlags'), 1);
+    });
 
-    await vpn.waitForQueryAndClick(
-        queries.screenSettings.appPreferencesView.DNS_SETTINGS.visible());
-    await vpn.waitForQuery(queries.screenSettings.STACKVIEW.ready());
-
-    // Checking if the checkboxes are correctly set based on the settings prop
-    await vpn.waitForQuery(
-        queries.screenSettings.appPreferencesView.dnsSettingsView.STANDARD_DNS
-            .visible()
-            .prop('checked', true));
-    await vpn.waitForQuery(
-        queries.screenSettings.appPreferencesView.dnsSettingsView.CUSTOM_DNS
-            .visible()
-            .prop('checked', false));
-
-    await vpn.waitForQueryAndClick(queries.navBar.HOME.visible());
-    await vpn.waitForQuery(queries.global.SCREEN_LOADER.ready());
-
-    await vpn.setSetting('dnsProviderFlags', 1);
-
-    await vpn.waitForQueryAndClick(queries.navBar.SETTINGS.visible());
-    await vpn.waitForQuery(queries.global.SCREEN_LOADER.ready());
-
-    await vpn.waitForQuery(
-        queries.screenSettings.appPreferencesView.dnsSettingsView.STANDARD_DNS
-            .visible()
-            .prop('checked', false));
-    await vpn.waitForQuery(
-        queries.screenSettings.appPreferencesView.dnsSettingsView.CUSTOM_DNS
-            .visible()
-            .prop('checked', true));
-    await vpn.waitForQuery(queries.screenSettings.appPreferencesView
-                               .dnsSettingsView.CUSTOM_DNS_INPUT.visible()
-                               .prop('hasError', false));
-    await vpn.setQueryProperty(
-        queries.screenSettings.appPreferencesView.dnsSettingsView
-            .CUSTOM_DNS_INPUT.visible(),
-        'text', 'wow');
-    await vpn.waitForQuery(queries.screenSettings.appPreferencesView
-                               .dnsSettingsView.CUSTOM_DNS_INPUT.visible()
-                               .prop('hasError', true));
-    await vpn.setQueryProperty(
-        queries.screenSettings.appPreferencesView.dnsSettingsView
-            .CUSTOM_DNS_INPUT.visible(),
-        'text', '1.2.3.4');
-    await vpn.waitForQuery(queries.screenSettings.appPreferencesView
-                               .dnsSettingsView.CUSTOM_DNS_INPUT.visible()
-                               .prop('hasError', false));
-
-    // Check the warning message
-    assert.equal(
-        await vpn.getQueryProperty(
-            queries.screenSettings.appPreferencesView.dnsSettingsView
-                .INFORMATION_CARD_LOADER,
-            'active'), 'false');
-
-    // Check the click
-    await vpn.waitForQueryAndClick(
-        queries.screenSettings.appPreferencesView.dnsSettingsView.STANDARD_DNS
-            .visible()
-            .prop('checked', false));
-
-    await vpn.waitForQueryAndClick(queries.navBar.HOME.visible());
-    await vpn.waitForQuery(queries.global.SCREEN_LOADER.ready());
-
-    assert.equal(await vpn.getSetting('dnsProviderFlags'), 0);
-
-    await vpn.waitForQueryAndClick(queries.navBar.SETTINGS.visible());
-    await vpn.waitForQuery(queries.global.SCREEN_LOADER.ready());
-
-    await vpn.waitForQueryAndClick(
-        queries.screenSettings.appPreferencesView.dnsSettingsView.CUSTOM_DNS
-            .visible()
-            .prop('checked', false));
-
-    await vpn.waitForQueryAndClick(queries.navBar.HOME.visible());
-    await vpn.waitForQuery(queries.global.SCREEN_LOADER.ready());
-
-    assert.equal(await vpn.getSetting('dnsProviderFlags'), 1);
-
-    // Check the modal
-    await vpn.setSetting('dnsProviderFlags', 2);
-
-    await vpn.waitForQueryAndClick(queries.navBar.SETTINGS.visible());
-    await vpn.waitForQuery(queries.global.SCREEN_LOADER.ready());
-
-    await vpn.waitForQuery(
-        queries.screenSettings.appPreferencesView.dnsSettingsView.STANDARD_DNS
-            .visible()
-            .prop('checked', true));
-
-    await vpn.waitForQueryAndClick(
-        queries.screenSettings.appPreferencesView.dnsSettingsView.CUSTOM_DNS
-            .visible()
-            .prop('checked', false));
-
-    await vpn.waitForQueryAndClick(
-        queries.screenSettings.appPreferencesView.dnsSettingsView
-            .MODAL_SECONDARY_BUTTON.visible());
-    await vpn.waitForQuery(
-        queries.screenSettings.appPreferencesView.dnsSettingsView
-            .MODAL_LOADER.prop('active', false));
-
-    await vpn.waitForQueryAndClick(queries.screenSettings.appPreferencesView
-                                       .dnsSettingsView.CUSTOM_DNS.visible());
-
-    await vpn.waitForQueryAndClick(
-        queries.screenSettings.appPreferencesView.dnsSettingsView
-            .MODAL_CLOSE_BUTTON.visible());
-    await vpn.waitForQuery(
-        queries.screenSettings.appPreferencesView.dnsSettingsView
-            .MODAL_LOADER.prop('active', false));
-
-    await vpn.waitForQueryAndClick(queries.screenSettings.appPreferencesView
-                                       .dnsSettingsView.CUSTOM_DNS.visible());
-
-    await vpn.waitForQueryAndClick(
-        queries.screenSettings.appPreferencesView.dnsSettingsView
-            .MODAL_PRIMARY_BUTTON.visible());
-    await vpn.waitForQuery(
-        queries.screenSettings.appPreferencesView.dnsSettingsView
-            .MODAL_LOADER.prop('active', false));
-
-    await vpn.setQueryProperty(
-        queries.screenSettings.appPreferencesView.dnsSettingsView
-            .CUSTOM_DNS_INPUT.visible(),
-        'text', '1.2.3.4');
-
-    await vpn.waitForQueryAndClick(queries.screenSettings.BACK.visible());
-    await vpn.waitForQuery(queries.screenSettings.STACKVIEW.ready());
-
-    assert.equal(await vpn.getSetting('dnsProviderFlags'), 1);
-
-    await vpn.waitForQueryAndClick(queries.screenSettings.BACK.visible());
-    await vpn.waitForQuery(queries.screenSettings.STACKVIEW.ready());
-
-    await vpn.waitForQuery(queries.screenSettings.USER_PROFILE.visible());
+    it.only('Checking the dns help sheet', async () => {
+      if (!(await vpn.isFeatureFlippedOn('helpSheets'))) {
+        await vpn.flipFeatureOn('helpSheets');
+      }
+  
+      await vpn.waitForQueryAndClick(queries.screenSettings.appPreferencesView.dnsSettingsView.HELP_BUTTON.visible());
+      await vpn.waitForQuery(queries.screenSettings.appPreferencesView.dnsSettingsView.PRIVACY_HELP_SHEET.visible());
+      await vpn.waitForQuery(queries.screenSettings.appPreferencesView.dnsSettingsView.PRIVACY_HELP_SHEET.opened());
+      await vpn.waitForQueryAndClick(queries.screenSettings.appPreferencesView.dnsSettingsView.PRIVACY_HELP_SHEET_LEARN_MORE_BUTTON.visible());
+      await vpn.waitForCondition(async () => {
+          const url = await vpn.getLastUrl();
+          return url === 'https://support.mozilla.org/kb/how-do-i-change-my-dns-settings';
+      });
+      await vpn.waitForQueryAndClick(queries.screenSettings.appPreferencesView.dnsSettingsView.PRIVACY_HELP_SHEET_CLOSE_BUTTON.visible());
+    });
   });
 
-  it('Checking the DNS settings reset', async () => {
-    await vpn.setSetting('dnsProviderFlags', 0);
-    await vpn.setSetting('userDNS', '');
-
-    await vpn.waitForQueryAndClick(
-        queries.screenSettings.APP_PREFERENCES.visible());
-    await vpn.waitForQuery(queries.screenSettings.STACKVIEW.ready());
-
-    await vpn.waitForQueryAndClick(
-        queries.screenSettings.appPreferencesView.DNS_SETTINGS.visible());
-    await vpn.waitForQuery(queries.screenSettings.STACKVIEW.ready());
-
-    // Checking if the checkboxes are correctly set based on the settings prop
-    await vpn.waitForQuery(
-        queries.screenSettings.appPreferencesView.dnsSettingsView.STANDARD_DNS
-            .visible()
-            .prop('checked', true));
-    await vpn.waitForQuery(
-        queries.screenSettings.appPreferencesView.dnsSettingsView.CUSTOM_DNS
-            .visible()
-            .prop('checked', false));
-
-    // Click on "Custom DNS" but leaving the input field empty.
-    await vpn.waitForQueryAndClick(
-        queries.screenSettings.appPreferencesView.dnsSettingsView.CUSTOM_DNS
-            .visible()
-            .prop('checked', false));
-
-    await vpn.setQueryProperty(
-        queries.screenSettings.appPreferencesView.dnsSettingsView
-            .CUSTOM_DNS_INPUT.visible(),
-        'text', '');
-
-    // Going back...
-    await vpn.waitForQueryAndClick(queries.screenSettings.BACK.visible());
-    await vpn.waitForQuery(queries.screenSettings.STACKVIEW.ready());
-
-    // .. the DNS setting is reset to the default value.
-    assert.equal(await vpn.getSetting('dnsProviderFlags'), 0);
-
-    // Same test as before...
-    await vpn.waitForQueryAndClick(
-        queries.screenSettings.appPreferencesView.DNS_SETTINGS.visible());
-    await vpn.waitForQuery(queries.screenSettings.STACKVIEW.ready());
-
-    await vpn.waitForQuery(
-        queries.screenSettings.appPreferencesView.dnsSettingsView.STANDARD_DNS
-            .visible()
-            .prop('checked', true));
-    await vpn.waitForQuery(
-        queries.screenSettings.appPreferencesView.dnsSettingsView.CUSTOM_DNS
-            .visible()
-            .prop('checked', false));
-
-    await vpn.waitForQueryAndClick(
-        queries.screenSettings.appPreferencesView.dnsSettingsView.CUSTOM_DNS
-            .visible()
-            .prop('checked', false));
-
-    // But with a valid DNS value...
-    await vpn.setQueryProperty(
-        queries.screenSettings.appPreferencesView.dnsSettingsView
-            .CUSTOM_DNS_INPUT.visible(),
-        'text', '1.2.3.4');
-
-    await vpn.waitForQueryAndClick(queries.screenSettings.BACK.visible());
-    await vpn.waitForQuery(queries.screenSettings.STACKVIEW.ready());
-
-    // We keep the custom DNS.
-    assert.equal(await vpn.getSetting('dnsProviderFlags'), 1);
-
-    // Write something invalid...
-    await vpn.waitForQueryAndClick(
-        queries.screenSettings.appPreferencesView.DNS_SETTINGS.visible());
-    await vpn.waitForQuery(queries.screenSettings.STACKVIEW.ready());
-
-    await vpn.waitForQuery(
-        queries.screenSettings.appPreferencesView.dnsSettingsView.STANDARD_DNS
-            .visible()
-            .prop('checked', false));
-    await vpn.waitForQuery(
-        queries.screenSettings.appPreferencesView.dnsSettingsView.CUSTOM_DNS
-            .visible()
-            .prop('checked', true));
-
-    assert.equal(
-        await vpn.getQueryProperty(
-            queries.screenSettings.appPreferencesView.dnsSettingsView
-                .CUSTOM_DNS_INPUT.visible(),
-            'text'),
-        '1.2.3.4');
-
-    await vpn.setQueryProperty(
-        queries.screenSettings.appPreferencesView.dnsSettingsView
-            .CUSTOM_DNS_INPUT.visible(),
-        'text', '1.2.3.4aabbcc');
-
-    await vpn.waitForQueryAndClick(queries.screenSettings.BACK.visible());
-    await vpn.waitForQuery(queries.screenSettings.STACKVIEW.ready());
-
-    // We keep the custom DNS.
-    assert.equal(await vpn.getSetting('dnsProviderFlags'), 1);
-  });
 
   it('Checking the languages settings', async () => {
     await vpn.setSetting('languageCode', '');


### PR DESCRIPTION
## Description

- Change `MZBottomSheet` root to be a loader so that we don't always need to remember to put it in a loader during usage
  - Make `MZHelpSheet`'s `contentItem` a loader so that it's content is only loaded when opened and destroyed when closed (before this, content was loaded regardless of whether the drawer was loaded/opened)
- Add help sheet margins to `theme.js
- Add functional tests for all of the help sheets
  - Refactor `testAppExclusions` to be consistent with the other functional tests

*Note: A lot of the changes are caused by indentation / slight refactoring

## Reference

[VPN-6124: Help sheet functional tests](https://mozilla-hub.atlassian.net/browse/VPN-6124)