### PR TITLE
VPN-4689: Hide "Tips and tricks" settings menu when help sheets are enabled

### DIFF
--- a/src/ui/screens/settings/ViewSettingsMenu.qml
+++ b/src/ui/screens/settings/ViewSettingsMenu.qml
@@ -92,15 +92,29 @@ MZViewBase {
                 visible: MZFeatureList.get("splitTunnel").isSupported
             }
 
-            MZSettingsItem {
-                objectName: "settingsTipsAndTricks"
-                settingTitle: MZI18n.SettingsTipsAndTricksSettings
-                imageLeftSrc: "qrc:/ui/resources/settings/tipsandtrickssettings.svg"
-                imageRightSrc: "qrc:/nebula/resources/chevron.svg"
-                imageRightMirror: MZLocalizer.isRightToLeft
-                onClicked: {
-                    Glean.interaction.tipsAndTricksSelected.record({screen:telemetryScreenId})
-                    MZNavigator.requestScreen(VPN.ScreenTipsAndTricks);
+            Loader {
+                Layout.preferredHeight: item.Layout.preferredHeight
+                Layout.fillWidth: item.Layout.fillWidth
+
+                visible: active
+                active: !MZFeatureList.get("helpSheets").isSupported
+
+                sourceComponent: MZSettingsItem {
+                    objectName: "settingsTipsAndTricks"
+
+                    anchors.right: parent.right
+                    anchors.left: parent.left
+                    anchors.leftMargin: 0
+                    anchors.rightMargin: 0
+
+                    settingTitle: MZI18n.SettingsTipsAndTricksSettings
+                    imageLeftSrc: "qrc:/ui/resources/settings/tipsandtrickssettings.svg"
+                    imageRightSrc: "qrc:/nebula/resources/chevron.svg"
+                    imageRightMirror: MZLocalizer.isRightToLeft
+                    onClicked: {
+                        Glean.interaction.tipsAndTricksSelected.record({screen:telemetryScreenId})
+                        MZNavigator.requestScreen(VPN.ScreenTipsAndTricks);
+                    }
                 }
             }
 


### PR DESCRIPTION
## Description

- Make "Tips and tricks" inaccessible by hiding it in the settings menu when the help sheets feature flag is enabled

## Reference

[VPN-4689: Remove the `Tips and Tricks` section from the app](https://mozilla-hub.atlassian.net/browse/VPN-4689)
