### PR TITLE
VPN-6049 Build a fat-bin for vpnnp

### DIFF
--- a/extension/CMakeLists.txt
+++ b/extension/CMakeLists.txt
@@ -5,7 +5,6 @@
 ## Custom target to build the web-extension bridge with Rust/Cargo
 
 if(APPLE AND CMAKE_OSX_ARCHITECTURES)
-
     add_custom_target(cargo_mozillavpnnp_all COMMENT "Build vpnnp for all Architectures")
     # For each requested Arch , create a new target and 
     # make it a dependency for cargo_mozillavpnnp_all

--- a/extension/CMakeLists.txt
+++ b/extension/CMakeLists.txt
@@ -12,10 +12,10 @@ if(APPLE AND CMAKE_OSX_ARCHITECTURES)
     foreach(OSXARCH ${CMAKE_OSX_ARCHITECTURES})
         string(REPLACE "arm64" "aarch64" OSXARCH ${OSXARCH})
         add_custom_target(cargo_mozillavpnnp_${OSXARCH}
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/bridge
-        COMMAND ${CMAKE_COMMAND} -E env CARGO_HOME=${CMAKE_CURRENT_BINARY_DIR}/.cargo_home 
-             cargo build --release --target-dir "${CMAKE_CURRENT_BINARY_DIR}/bridge"
-             --target "${OSXARCH}-apple-darwin"
+            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/bridge
+            COMMAND ${CMAKE_COMMAND} -E env CARGO_HOME=${CMAKE_CURRENT_BINARY_DIR}/.cargo_home 
+                cargo build --release --target-dir "${CMAKE_CURRENT_BINARY_DIR}/bridge"
+                --target "${OSXARCH}-apple-darwin"
         )
         list(APPEND MOZILLAVPNNP_TARGET_OUTPUTS "${CMAKE_CURRENT_BINARY_DIR}/bridge/${OSXARCH}-apple-darwin/release/mozillavpnnp")
         add_dependencies(cargo_mozillavpnnp_all cargo_mozillavpnnp_${OSXARCH})
@@ -27,6 +27,7 @@ if(APPLE AND CMAKE_OSX_ARCHITECTURES)
         DEPENDS cargo_mozillavpnnp_all
         COMMAND lipo -create -output ${CMAKE_CURRENT_BINARY_DIR}/bridge/target/release/mozillavpnnp ${MOZILLAVPNNP_TARGET_OUTPUTS}
     )
+    file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/bridge/target/release/)
 else()
     # Single Plattform 
     add_custom_target(cargo_mozillavpnnp ALL
@@ -35,9 +36,8 @@ else()
         COMMAND ${CMAKE_COMMAND} -E env CARGO_HOME=${CMAKE_CURRENT_BINARY_DIR}/.cargo_home
                 cargo build --release --target-dir ${CMAKE_CURRENT_BINARY_DIR}/bridge/target
     )
+    set_directory_properties(PROPERTIES ADDITIONAL_MAKE_CLEAN_FILES ${CMAKE_CURRENT_BINARY_DIR}/bridge/target)
 endif()
-set_directory_properties(PROPERTIES ADDITIONAL_MAKE_CLEAN_FILES ${CMAKE_CURRENT_BINARY_DIR}/bridge/target)
-
 
 ## Wrap the build artifacts as a CMake target.
 add_executable(mozillavpnnp IMPORTED GLOBAL)

--- a/extension/CMakeLists.txt
+++ b/extension/CMakeLists.txt
@@ -3,13 +3,41 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 ## Custom target to build the web-extension bridge with Rust/Cargo
-add_custom_target(cargo_mozillavpnnp ALL
-    COMMENT "Building web extension crate"
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/bridge
-    COMMAND ${CMAKE_COMMAND} -E env CARGO_HOME=${CMAKE_CURRENT_BINARY_DIR}/.cargo_home
-            cargo build --release --target-dir ${CMAKE_CURRENT_BINARY_DIR}/bridge/target
-)
+
+if(APPLE AND CMAKE_OSX_ARCHITECTURES)
+
+    add_custom_target(cargo_mozillavpnnp_all COMMENT "Build vpnnp for all Architectures")
+    # For each requested Arch , create a new target and 
+    # make it a dependency for cargo_mozillavpnnp_all
+    foreach(OSXARCH ${CMAKE_OSX_ARCHITECTURES})
+        string(REPLACE "arm64" "aarch64" OSXARCH ${OSXARCH})
+        add_custom_target(cargo_mozillavpnnp_${OSXARCH}
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/bridge
+        COMMAND ${CMAKE_COMMAND} -E env CARGO_HOME=${CMAKE_CURRENT_BINARY_DIR}/.cargo_home 
+             cargo build --release --target-dir "${CMAKE_CURRENT_BINARY_DIR}/bridge"
+             --target "${OSXARCH}-apple-darwin"
+        )
+        list(APPEND MOZILLAVPNNP_TARGET_OUTPUTS "${CMAKE_CURRENT_BINARY_DIR}/bridge/${OSXARCH}-apple-darwin/release/mozillavpnnp")
+        add_dependencies(cargo_mozillavpnnp_all cargo_mozillavpnnp_${OSXARCH})
+    endforeach()
+    # Create a target that runs after all-arches have been build 
+    # Create a far binary using all lipo
+    add_custom_target(cargo_mozillavpnnp ALL
+        COMMENT "Create a universal binary for mozillavpnp"
+        DEPENDS cargo_mozillavpnnp_all
+        COMMAND lipo -create -output ${CMAKE_CURRENT_BINARY_DIR}/bridge/release/mozillavpnnp ${MOZILLAVPNNP_TARGET_OUTPUTS}
+    )
+else()
+    # Single Plattform 
+    add_custom_target(cargo_mozillavpnnp ALL
+        COMMENT "Building web extension crate"
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/bridge
+        COMMAND ${CMAKE_COMMAND} -E env CARGO_HOME=${CMAKE_CURRENT_BINARY_DIR}/.cargo_home
+                cargo build --release --target-dir ${CMAKE_CURRENT_BINARY_DIR}/bridge/target
+    )
+endif()
 set_directory_properties(PROPERTIES ADDITIONAL_MAKE_CLEAN_FILES ${CMAKE_CURRENT_BINARY_DIR}/bridge/target)
+
 
 ## Wrap the build artifacts as a CMake target.
 add_executable(mozillavpnnp IMPORTED GLOBAL)

--- a/extension/CMakeLists.txt
+++ b/extension/CMakeLists.txt
@@ -25,7 +25,7 @@ if(APPLE AND CMAKE_OSX_ARCHITECTURES)
     add_custom_target(cargo_mozillavpnnp ALL
         COMMENT "Create a universal binary for mozillavpnp"
         DEPENDS cargo_mozillavpnnp_all
-        COMMAND lipo -create -output ${CMAKE_CURRENT_BINARY_DIR}/bridge/release/mozillavpnnp ${MOZILLAVPNNP_TARGET_OUTPUTS}
+        COMMAND lipo -create -output ${CMAKE_CURRENT_BINARY_DIR}/bridge/target/release/mozillavpnnp ${MOZILLAVPNNP_TARGET_OUTPUTS}
     )
 else()
     # Single Plattform 


### PR DESCRIPTION
## Description
We only invoke cargo for vpnnp, resulting in a binary matching the host arch. 
This Pr changes the logic similar to how be build libs, invoke for every OSX_ARCH and lipo the binaries into one fat :) 
Results in: 
```
 ~/C/mozilla-vpn-client  file build/conda_vpn/extension/bridge/release/mozillavpnnp
build/conda_vpn/extension/bridge/release/mozillavpnnp: Mach-O universal binary with 2 architectures: [x86_64:Mach-O 64-bit executable x86_64] [arm64:Mach-O 64-bit executable arm64]
build/conda_vpn/extension/bridge/release/mozillavpnnp (for architecture x86_64):        Mach-O 64-bit executable x86_64
build/conda_vpn/extension/bridge/release/mozillavpnnp (for architecture arm64): Mach-O 64-bit executable arm64

```


## Reference
closes https://github.com/mozilla-mobile/mozilla-vpn-client/issues/8855

