### PR TITLE
VPN-5095: Fix help sheet button tooltip text

### DIFF
--- a/src/ui/screens/devices/ViewDevices.qml
+++ b/src/ui/screens/devices/ViewDevices.qml
@@ -62,7 +62,7 @@ MZViewBase {
                 sourceComponent: MZIconButton {
                     onClicked: helpSheetLoader.active = true
 
-                    accessibleName: MZI18n.GlobalHelp
+                    accessibleName: MZI18n.GetHelpLinkTitle
 
                     Image {
                         anchors.centerIn: parent

--- a/src/ui/screens/home/ViewServers.qml
+++ b/src/ui/screens/home/ViewServers.qml
@@ -34,7 +34,7 @@ Item {
                 sourceComponent: MZIconButton {
                     onClicked: helpSheetLoader.active = true
 
-                    accessibleName: MZI18n.GlobalHelp
+                    accessibleName: MZI18n.GetHelpLinkTitle
 
                     Image {
                         anchors.centerIn: parent

--- a/src/ui/screens/settings/ViewDNSSettings.qml
+++ b/src/ui/screens/settings/ViewDNSSettings.qml
@@ -27,7 +27,7 @@ MZViewBase {
             sourceComponent: MZIconButton {
                 onClicked: helpSheetLoader.active = true
 
-                accessibleName: MZI18n.GlobalHelp
+                accessibleName: MZI18n.GetHelpLinkTitle
 
                 Image {
                     anchors.centerIn: parent

--- a/src/ui/screens/settings/appPermissions/ViewAppPermissions.qml
+++ b/src/ui/screens/settings/appPermissions/ViewAppPermissions.qml
@@ -29,7 +29,7 @@ MZViewBase {
             sourceComponent: MZIconButton {
                 onClicked: helpSheetLoader.active = true
 
-                accessibleName: MZI18n.GlobalHelp
+                accessibleName: MZI18n.GetHelpLinkTitle
 
                 Image {
                     anchors.centerIn: parent

--- a/src/ui/screens/settings/privacy/ViewPrivacy.qml
+++ b/src/ui/screens/settings/privacy/ViewPrivacy.qml
@@ -22,7 +22,8 @@ MZViewBase {
             sourceComponent: MZIconButton {
                 onClicked: helpSheetLoader.active = true
 
-                accessibleName: MZI18n.GlobalHelp
+                accessibleName: MZI18n.GetHelpLinkTitle
+
                 Image {
                     anchors.centerIn: parent
 


### PR DESCRIPTION
## Description

- Updates the tooltip text for icon buttons that open help sheets from "Help" to "Get help"

## Reference

[VPN-5095: Implement Accessibility requirements](https://mozilla-hub.atlassian.net/browse/VPN-5095)
