### PR TITLE
VPN-6121: Reinstate recommended/multiphop collapsible cards (#8983)

### DIFF
--- a/src/ui/screens/home/ViewMultiHop.qml
+++ b/src/ui/screens/home/ViewMultiHop.qml
@@ -44,6 +44,20 @@ StackView {
             anchors.rightMargin: MZTheme.theme.windowMargin / 2
             spacing: MZTheme.theme.vSpacing
 
+            MZCollapsibleCard {
+                title: MZI18n.MultiHopFeatureMultiHopCardHeader
+
+                iconSrc: "qrc:/ui/resources/tip.svg"
+                contentItem: MZTextBlock {
+                    text: MZI18n.MultiHopFeatureMultiHopCardBody
+                    textFormat: Text.StyledText
+                    Layout.fillWidth: true
+                }
+                Layout.alignment: Qt.AlignHCenter
+                Layout.preferredWidth: parent.width - MZTheme.theme.windowMargin
+                visible: !MZFeatureList.get("helpSheets").isSupported
+            }
+
             RecentConnections {
                 Layout.fillWidth: true
                 showMultiHopRecentConnections: true

--- a/src/ui/screens/home/servers/ServerList.qml
+++ b/src/ui/screens/home/servers/ServerList.qml
@@ -156,6 +156,20 @@ FocusScope {
                         right: parent.right
                     }
 
+                    MZCollapsibleCard {
+                        anchors.horizontalCenter: parent.horizontalCenter
+
+                        iconSrc: "qrc:/ui/resources/tip.svg"
+                        contentItem: MZTextBlock {
+                            text: MZI18n.ServersViewRecommendedCardBody
+                            textFormat: Text.StyledText
+                            Layout.fillWidth: true
+                        }
+                        title: MZI18n.ServersViewRecommendedCardTitle
+                        width: parent.width - MZTheme.theme.windowMargin * 2
+                        visible: !MZFeatureList.get("helpSheets").isSupported
+                    }
+
                     // Status component
                     // TODO: Refresh server list and handle states
                     MZClickableRow {

--- a/tests/functional/queries.js
+++ b/tests/functional/queries.js
@@ -112,6 +112,8 @@ const screenHome = {
         '//segmentedNavToggle/segmentedToggleBtnLayout/tabMultiHop'),
     MULTIHOP_VIEW: new QmlQueryComposer('//multiHopStackView'),
     ALL_SERVERS_TAB: new QmlQueryComposer('//tabAllServers'),
+    VPN_MULTHOP_CHEVRON: new QmlQueryComposer('//vpnCollapsibleCardChevron'),
+    VPN_COLLAPSIBLE_CARD: new QmlQueryComposer('//vpnCollapsibleCard'),
   }
 };
 

--- a/tests/functional/testMultihop.js
+++ b/tests/functional/testMultihop.js
@@ -55,12 +55,24 @@ describe('Server list', function() {
   it('opening the entry and exit server list', async () => {
     await vpn.waitForQueryAndClick(
         queries.screenHome.serverListView.MULTIHOP_SELECTOR_TAB.visible());
+    await vpn.waitForQuery(
+        queries.screenHome.serverListView.VPN_COLLAPSIBLE_CARD.visible());
+
+    assert(
+        await vpn.getQueryProperty(
+            queries.screenHome.serverListView.VPN_COLLAPSIBLE_CARD,
+            'expanded') === 'false');
 
     await vpn.waitForQuery(
         queries.screenHome.serverListView.ENTRY_BUTTON.visible());
 
     await vpn.waitForQuery(
         queries.screenHome.serverListView.EXIT_BUTTON.visible());
+
+    await vpn.waitForQueryAndClick(
+        queries.screenHome.serverListView.VPN_MULTHOP_CHEVRON.visible())
+    assert(await vpn.getQueryProperty(
+        queries.screenHome.serverListView.VPN_COLLAPSIBLE_CARD, 'expanded'))
   });
 
   it('check the countries and cities for multihop entries', async () => {


### PR DESCRIPTION
## Description

- Uplift #8983

## Reference

[VPN-6121: Expandable tooltips from Select location screens are not displayed when the “Help sheets” feature flag is disabled](https://mozilla-hub.atlassian.net/browse/VPN-6121)

