### PR TITLE
VPN-5932: Change where we save device model

### DIFF
--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -746,6 +746,9 @@ void MozillaVPN::accountChecked(const QByteArray& json) {
     return;
   }
 
+  // Must write settings *before* checkCurrentDevice, to prevent a
+  // bug when user already has 5 devices on launch. Details:
+  // https://github.com/mozilla-mobile/mozilla-vpn-client/pull/9011#issuecomment-1915795735
   m_private->m_user.writeSettings();
   m_private->m_deviceModel.writeSettings();
 

--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -746,12 +746,12 @@ void MozillaVPN::accountChecked(const QByteArray& json) {
     return;
   }
 
+  m_private->m_user.writeSettings();
+  m_private->m_deviceModel.writeSettings();
+
   if (!checkCurrentDevice()) {
     return;
   }
-
-  m_private->m_user.writeSettings();
-  m_private->m_deviceModel.writeSettings();
 
   if (m_private->m_user.subscriptionNeeded() && state() == StateMain) {
     NotificationHandler::instance()->subscriptionNotFoundNotification();


### PR DESCRIPTION
## Description

This bug existed for the following situation:
- Have an account with five devices.
- Sign in on a new device
- Remove a device from the account as part of the sign in flow
- End up on main screen
- Force kill app
- Reopen it
- Note that you need to sign in again - not what we expected

The list of valid devices comes from the Guardian, and is saved in local settings (as the device list JSON). Upon launch, we check if the current device is in those devices, and if not, we ask the user to sign in again.

When we sign into the app when an account already has max devices, we retrieve the device list from Guardian twice - once upon initial launch, and a second time after we remove a device and add our current one. *However, we were only saving it to settings after that first retrieval.* Thus, on subsequent launch, the current device wasn't in the saved list, signing the user out.

I updated where we save the device JSON to local settings - It's now before we check the current device. `checkCurrentDevice` returns false here, because the state is `StateDeviceLimit` - but we want to save the new devices anyway.

Note that we save the user data in the same spot, and I moved it as well.

## Reference

VPN-5932

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
