### PR TITLE
VPN-6129 - Create daemon-specific metrics

### DIFF
--- a/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/ConnectionHealth.kt
+++ b/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/ConnectionHealth.kt
@@ -189,7 +189,7 @@ class ConnectionHealth(service: VPNService) {
             val canReachGateway = vpnNetwork.getByName(gateway).isReachable(PING_TIMEOUT)
             val canReachDNS = vpnNetwork.getByName(dns).isReachable(PING_TIMEOUT)
             if (canReachGateway && canReachDNS) {
-                Session.daemonConnectionHealthStableCount.add()
+                Session.daemonConnHealthStable.add()
 
                 // Internet should be fine :)
                 mResetUsed = false
@@ -210,7 +210,7 @@ class ConnectionHealth(service: VPNService) {
                 it.getByName(endpoint).isReachable(PING_TIMEOUT)
             } != null
             if (anyNetworkCanConnect && canReachDNS && !mResetUsed) {
-                Session.daemonConnectionHealthUnstable.record()
+                Session.daemonConnHealthUnstable.record()
 
                 // The server seems to be online but the connection broke,
                 // Let's just try to force a reconnect ... but only once.
@@ -228,7 +228,7 @@ class ConnectionHealth(service: VPNService) {
                 it.getByName(fallbackEndpoint).isReachable(PING_TIMEOUT)
             } != null
             if (fallbackServerIsReachable) {
-                Session.daemonConnectionHealthUnstable.record()
+                Session.daemonConnHealthUnstable.record()
 
                 Log.i(TAG, "Switch to fallback VPN server")
                 // We the server is online but the connection broke up, let's rest it
@@ -244,7 +244,7 @@ class ConnectionHealth(service: VPNService) {
             // Nothing we can do here to help.
             Log.e(TAG, "Both Server / Serverfallback seem to be unreachable.")
 
-            Session.daemonConnectionHealthNoSignal.record()
+            Session.daemonConnHealthNoSignal.record()
             mPanicStateReached = true
             taskDone()
         }

--- a/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/ConnectionHealth.kt
+++ b/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/ConnectionHealth.kt
@@ -11,7 +11,6 @@ import android.net.NetworkCapabilities
 import android.net.NetworkRequest
 import android.os.Build
 import android.os.CountDownTimer
-import org.mozilla.firefox.vpn.daemon.GleanMetrics.Sample
 import org.mozilla.firefox.vpn.daemon.GleanMetrics.Session
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors

--- a/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/ConnectionHealth.kt
+++ b/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/ConnectionHealth.kt
@@ -190,7 +190,7 @@ class ConnectionHealth(service: VPNService) {
             val canReachGateway = vpnNetwork.getByName(gateway).isReachable(PING_TIMEOUT)
             val canReachDNS = vpnNetwork.getByName(dns).isReachable(PING_TIMEOUT)
             if (canReachGateway && canReachDNS) {
-                Session.connectionHealthStableCount.add()
+                Session.daemonConnectionHealthStableCount.add()
 
                 // Internet should be fine :)
                 mResetUsed = false
@@ -211,7 +211,7 @@ class ConnectionHealth(service: VPNService) {
                 it.getByName(endpoint).isReachable(PING_TIMEOUT)
             } != null
             if (anyNetworkCanConnect && canReachDNS && !mResetUsed) {
-                Sample.connectionHealthUnstable.record()
+                Session.daemonConnectionHealthUnstable.record()
 
                 // The server seems to be online but the connection broke,
                 // Let's just try to force a reconnect ... but only once.
@@ -229,7 +229,7 @@ class ConnectionHealth(service: VPNService) {
                 it.getByName(fallbackEndpoint).isReachable(PING_TIMEOUT)
             } != null
             if (fallbackServerIsReachable) {
-                Sample.connectionHealthUnstable.record()
+                Session.daemonConnectionHealthUnstable.record()
 
                 Log.i(TAG, "Switch to fallback VPN server")
                 // We the server is online but the connection broke up, let's rest it
@@ -245,7 +245,7 @@ class ConnectionHealth(service: VPNService) {
             // Nothing we can do here to help.
             Log.e(TAG, "Both Server / Serverfallback seem to be unreachable.")
 
-            Sample.connectionHealthNoSignal.record()
+            Session.daemonConnectionHealthNoSignal.record()
             mPanicStateReached = true
             taskDone()
         }

--- a/src/telemetry/metrics.yaml
+++ b/src/telemetry/metrics.yaml
@@ -1762,7 +1762,7 @@ session:
       - vpn-telemetry@mozilla.com
     expires: never
 
-  daemon_connection_health_no_signal:
+  daemon_conn_health_no_signal:
     type: event
     lifetime: ping
     send_in_pings:
@@ -1788,7 +1788,7 @@ session:
       - vpn-telemetry@mozilla.com
     expires: never
 
-  daemon_connection_health_unstable:
+  daemon_conn_health_unstable:
     type: event
     lifetime: ping
     send_in_pings:
@@ -1813,7 +1813,7 @@ session:
       - vpn-telemetry@mozilla.com
     expires: never
 
-  daemmon_connection_health_stable_count:
+  daemon_conn_health_stable:
     type: counter
     lifetime: ping
     send_in_pings:

--- a/src/telemetry/metrics.yaml
+++ b/src/telemetry/metrics.yaml
@@ -740,14 +740,8 @@ sample:
     send_in_pings:
       - main
       - vpnsession
-      - daemonsession
     description: |
       The connection has no signal.
-
-      This event is recorded in both main application and daemon.
-      The logic and cadence of health checks for each of these
-      is not the same. On the daemon this checks are only
-      done on the Android daemon and not on the iOS network extension.
 
       A no signal event event happens when the connection is showing issues,
       and a silent switch will not address the issue. On when the connection
@@ -770,14 +764,8 @@ sample:
     send_in_pings:
       - main
       - vpnsession
-      - daemonsession
     description: |
       The connection is unstable.
-
-      This event is recorded in both main application and daemon.
-      The logic and cadence of health checks for each of these
-      is not the same. On the daemon this checks are only
-      done on the Android daemon and not on the iOS network extension.
 
       An unstable event happens when the connection is showing issues,
       but a silent switch may still address the issue and no previous
@@ -1688,7 +1676,6 @@ session:
     lifetime: ping
     send_in_pings:
       - vpnsession
-      - daemonsession
     description: |
       Count of times that the connection health check succeeds.
       Collected only on mobile apps.
@@ -1772,6 +1759,76 @@ session:
       - daemonsession
     data_sensitivity:
       - interaction
+    notification_emails:
+      - mcleinman@mozilla.com
+      - vpn-telemetry@mozilla.com
+    expires: never
+
+  daemon_connection_health_no_signal:
+    type: event
+    lifetime: ping
+    send_in_pings:
+      - daemonsession
+    description: |
+      The connection has no signal.
+
+      These checks are only done on the Android daemon and not on the iOS
+      network extension.
+
+      A no signal event event happens when the connection is showing issues,
+      and a silent switch will not address the issue. On when the connection
+      is showing issues and there have been previous silent switches which
+      did not address the issue.
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/VPN-6129
+    data_reviews:
+      - TBD
+    data_sensitivity:
+      - technical
+    notification_emails:
+      - mcleinman@mozilla.com
+      - vpn-telemetry@mozilla.com
+    expires: never
+
+  daemon_connection_health_unstable:
+    type: event
+    lifetime: ping
+    send_in_pings:
+      - daemonsession
+    description: |
+      The connection is unstable.
+
+      These checks are only done on the Android daemon and not on the
+      iOS network extension.
+
+      An unstable event happens when the connection is showing issues,
+      but a silent switch may still address the issue and no previous
+      silent switches have happened yet.
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/VPN-6129
+    data_reviews:
+      - TBD
+    data_sensitivity:
+      - technical
+    notification_emails:
+      - mcleinman@mozilla.com
+      - vpn-telemetry@mozilla.com
+    expires: never
+
+  daemmon_connection_health_stable_count:
+    type: counter
+    lifetime: ping
+    send_in_pings:
+      - daemonsession
+    description: |
+      Count of times that the connection health check succeeds.
+      Collected only on mobile apps.
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/VPN-6129
+    data_reviews:
+      - TBD
+    data_sensitivity:
+      - technical
     notification_emails:
       - mcleinman@mozilla.com
       - vpn-telemetry@mozilla.com

--- a/src/telemetry/metrics.yaml
+++ b/src/telemetry/metrics.yaml
@@ -738,7 +738,6 @@ sample:
     type: event
     lifetime: ping
     send_in_pings:
-      - main
       - vpnsession
     description: |
       The connection has no signal.
@@ -762,7 +761,6 @@ sample:
     type: event
     lifetime: ping
     send_in_pings:
-      - main
       - vpnsession
     description: |
       The connection is unstable.


### PR DESCRIPTION
## Description

The connection health metrics all have a ping lifetime. However, in [this PR](https://github.com/mozilla-mobile/mozilla-vpn-client/pull/7124/) they were added to the daemon ping - and previously, two of them were already on both `main` and `session` pings. Thus, they're being misreported - for example, we increment one metric (`connection_health_stable_count`) for both Android daemon and app session health checks - and clear it whenever either ping is sent.

This PR adds new variables for the daemon, and removes the existing metrics from `main` and `daemon` pings.

## Reference

https://mozilla-hub.atlassian.net/browse/VPN-6129

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
