### PR TITLE
Experiment: Set codecov upload token

### DIFF
--- a/.github/workflows/linux_tests.yaml
+++ b/.github/workflows/linux_tests.yaml
@@ -164,6 +164,7 @@ jobs:
         if: steps.generateGrcov.outcome == 'success'
         with:
           directory: .
+          token: ${{ secrets.CODECOV_TOKEN }}
           flags: functional_tests
           name: codecov-poc
           files: ${{ runner.temp }}/artifacts/functional_lcov.info

--- a/.github/workflows/test_unit.yaml
+++ b/.github/workflows/test_unit.yaml
@@ -91,6 +91,7 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           directory: .
+          token: ${{ secrets.CODECOV_TOKEN }}
           flags: linux_unit_tests
           name: codecov-poc
           files: nativemessaging_lcov.info,qml_lcov.info,unit_lcov.info,unitapp_lcov.info
@@ -183,6 +184,7 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           directory: .
+          token: ${{ secrets.CODECOV_TOKEN }}
           flags: macos_unit_tests
           name: codecov-poc
           files: auth_lcov.info,nativemessaging_lcov.info,qml_lcov.info,unit_lcov.info,unitapp_lcov.info


### PR DESCRIPTION
## Description
In doing a bit of investigation on code coverage tooling, I took another look at what's going on with codecov, and it seems that we are missing upload data quite often due to rate limiting of the github API. It seems that there is a known workaround for this simply by setting a codecov upload token.

So, let's find out what happens when we set it.

## Reference
[Codecov issue](https://community.codecov.com/t/upload-issues-unable-to-locate-build-via-github-actions-api/3954)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
