### PR TITLE
VPN-5092: Help sheet telemetry

### DIFF
--- a/nebula/ui/components/MZBottomSheet.qml
+++ b/nebula/ui/components/MZBottomSheet.qml
@@ -32,13 +32,21 @@ Loader {
     readonly property int maxSheetHeight: (Qt.platform.os === "ios" ? window.safeContentHeight : window.height) -  MZTheme.theme.sheetTopMargin
     required default property var contentItem
     property bool sizeToContent: false
-    property bool opened: active ? item.opened : null
+    property bool isOpen: active ? item.opened : null
 
-    signal close
+    signal opened
+    signal closed
+
+    function open() {
+        active = true
+        item.open()
+    }
+
+    function close() {
+        item.close()
+    }
 
     active: false
-
-    onClose: item.close()
 
     sourceComponent: Drawer {
         implicitWidth: window.width
@@ -50,7 +58,12 @@ Loader {
         edge: Qt.BottomEdge
         contentItem: root.contentItem
 
-        onClosed: root.active = false
+        onOpened:  root.opened()
+
+        onClosed: {
+            root.closed()
+            root.active = false
+        }
 
         background: Rectangle {
 

--- a/nebula/ui/components/MZHelpSheet.qml
+++ b/nebula/ui/components/MZHelpSheet.qml
@@ -18,6 +18,7 @@ import Mozilla.Shared 1.0
 //"type": MZHelpSheet.BlockType (eg MZHelpSheet.BlockType.PrimaryButton)
 //"text": label or button text (eg "Hello world")
 //"margin": top margin above the component (eg 16)
+//"objectName": objectName for the component (used for functional tests)
 //"action": action performed on button click - only applicable when type is MZHelpSheet.BlockType.PrimaryButton or MZHelpSheet.BlockType.LinkButton
 //(eg () => { MZUrlOpener.openUrl("https://mozilla.org") })
 /*
@@ -30,7 +31,7 @@ import Mozilla.Shared 1.0
           {type: MZHelpSheet.BlockType.Text, margin: 16, text: "text"},
           {type: MZHelpSheet.BlockType.Text, margin: 16, text: "text"},
           {type: MZHelpSheet.BlockType.PrimaryButton, text: "Primary", margin: 16, action: () => { sheet.close(); MZNavigator.requestScreen(VPN.ScreenGetHelp) } },
-          {type: MZHelpSheet.BlockType.LinkButton, text: "Link", margin: 8, action: () => { MZUrlOpener.openUrl("https://mozilla.org") } }
+          {type: MZHelpSheet.BlockType.LinkButton, text: "Link", margin: 8, objectName: "learnMoreLink", action: () => { MZUrlOpener.openUrl("https://mozilla.org") }}
       ]
     }
 */

--- a/src/telemetry/impression_metrics.yaml
+++ b/src/telemetry/impression_metrics.yaml
@@ -663,6 +663,13 @@ impression:
       - main
     description: |
       The user has opened to the multihop screen
+
+      Note: When recorded, the `screen` extra key may have the value 
+      `unexpected`. That value is used if this event is recorded 
+      when an unexpected segment is clicked (not singlehop or multihop)
+      Although that is theoretically not possible, the code path for
+      such a situation exists. Large number of this event with this
+      value for the `screen` extra key would mean a bug in the code.
     bugs:
       - https://mozilla-hub.atlassian.net/browse/VPN-5092
     data_reviews:

--- a/src/telemetry/impression_metrics.yaml
+++ b/src/telemetry/impression_metrics.yaml
@@ -540,7 +540,7 @@ impression:
     bugs:
       - https://mozilla-hub.atlassian.net/browse/VPN-5092
     data_reviews:
-      - TODO
+      - https://github.com/mozilla-mobile/mozilla-vpn-client/pull/9023#pullrequestreview-1848707594
     data_sensitivity:
       - interaction
     notification_emails:
@@ -558,7 +558,7 @@ impression:
     bugs:
       - https://mozilla-hub.atlassian.net/browse/VPN-5092
     data_reviews:
-      - TODO
+      - https://github.com/mozilla-mobile/mozilla-vpn-client/pull/9023#pullrequestreview-1848707594
     data_sensitivity:
       - interaction
     notification_emails:
@@ -576,7 +576,7 @@ impression:
     bugs:
       - https://mozilla-hub.atlassian.net/browse/VPN-5092
     data_reviews:
-      - TODO
+      - https://github.com/mozilla-mobile/mozilla-vpn-client/pull/9023#pullrequestreview-1848707594
     data_sensitivity:
       - interaction
     notification_emails:
@@ -594,7 +594,7 @@ impression:
     bugs:
       - https://mozilla-hub.atlassian.net/browse/VPN-5092
     data_reviews:
-      - TODO
+      - https://github.com/mozilla-mobile/mozilla-vpn-client/pull/9023#pullrequestreview-1848707594
     data_sensitivity:
       - interaction
     notification_emails:
@@ -612,7 +612,7 @@ impression:
     bugs:
       - https://mozilla-hub.atlassian.net/browse/VPN-5092
     data_reviews:
-      - TODO
+      - https://github.com/mozilla-mobile/mozilla-vpn-client/pull/9023#pullrequestreview-1848707594
     data_sensitivity:
       - interaction
     notification_emails:
@@ -630,7 +630,7 @@ impression:
     bugs:
       - https://mozilla-hub.atlassian.net/browse/VPN-5092
     data_reviews:
-      - TODO
+      - https://github.com/mozilla-mobile/mozilla-vpn-client/pull/9023#pullrequestreview-1848707594
     data_sensitivity:
       - interaction
     notification_emails:
@@ -648,7 +648,7 @@ impression:
     bugs:
       - https://mozilla-hub.atlassian.net/browse/VPN-5092
     data_reviews:
-      - TODO
+      - https://github.com/mozilla-mobile/mozilla-vpn-client/pull/9023#pullrequestreview-1848707594
     data_sensitivity:
       - interaction
     notification_emails:
@@ -673,7 +673,7 @@ impression:
     bugs:
       - https://mozilla-hub.atlassian.net/browse/VPN-5092
     data_reviews:
-      - TODO
+      - https://github.com/mozilla-mobile/mozilla-vpn-client/pull/9023#pullrequestreview-1848707594
     data_sensitivity:
       - interaction
     notification_emails:
@@ -691,7 +691,7 @@ impression:
     bugs:
       - https://mozilla-hub.atlassian.net/browse/VPN-5092
     data_reviews:
-      - TODO
+      - https://github.com/mozilla-mobile/mozilla-vpn-client/pull/9023#pullrequestreview-1848707594
     data_sensitivity:
       - interaction
     notification_emails:

--- a/src/telemetry/impression_metrics.yaml
+++ b/src/telemetry/impression_metrics.yaml
@@ -638,7 +638,7 @@ impression:
       - vpn-telemetry@mozilla.com
     expires: never
     extra_keys: *impression_extra_keys
-  select_location_singlehop_screen:
+  location_singlehop_screen:
     type: event
     lifetime: ping
     send_in_pings:
@@ -656,7 +656,7 @@ impression:
       - vpn-telemetry@mozilla.com
     expires: never
     extra_keys: *impression_extra_keys
-  select_location_multihop_screen:
+  location_multihop_screen:
     type: event
     lifetime: ping
     send_in_pings:
@@ -674,13 +674,13 @@ impression:
       - vpn-telemetry@mozilla.com
     expires: never
     extra_keys: *impression_extra_keys
-  select_location_info_screen:
+  location_info_screen:
     type: event
     lifetime: ping
     send_in_pings:
       - main
     description: |
-      The user has opened the selection location help sheet
+      The user has opened the select location help sheet
     bugs:
       - https://mozilla-hub.atlassian.net/browse/VPN-5092
     data_reviews:

--- a/src/telemetry/impression_metrics.yaml
+++ b/src/telemetry/impression_metrics.yaml
@@ -638,3 +638,57 @@ impression:
       - vpn-telemetry@mozilla.com
     expires: never
     extra_keys: *impression_extra_keys
+  select_location_singlehop_screen:
+    type: event
+    lifetime: ping
+    send_in_pings:
+      - main
+    description: |
+      The user has opened to the singlehop screen
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/VPN-5092
+    data_reviews:
+      - TODO
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - mlichtenstein@mozilla.com
+      - vpn-telemetry@mozilla.com
+    expires: never
+    extra_keys: *impression_extra_keys
+  select_location_multihop_screen:
+    type: event
+    lifetime: ping
+    send_in_pings:
+      - main
+    description: |
+      The user has opened to the multihop screen
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/VPN-5092
+    data_reviews:
+      - TODO
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - mlichtenstein@mozilla.com
+      - vpn-telemetry@mozilla.com
+    expires: never
+    extra_keys: *impression_extra_keys
+  select_location_info_screen:
+    type: event
+    lifetime: ping
+    send_in_pings:
+      - main
+    description: |
+      The user has opened the selection location help sheet
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/VPN-5092
+    data_reviews:
+      - TODO
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - mlichtenstein@mozilla.com
+      - vpn-telemetry@mozilla.com
+    expires: never
+    extra_keys: *impression_extra_keys

--- a/src/telemetry/impression_metrics.yaml
+++ b/src/telemetry/impression_metrics.yaml
@@ -530,3 +530,111 @@ impression:
       - vpn-telemetry@mozilla.com
     expires: never
     extra_keys: *impression_extra_keys   
+  app_exclusions_info_screen:
+    type: event
+    lifetime: ping
+    send_in_pings:
+      - main
+    description: |
+      The user has opened the app exclusions help sheet
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/VPN-5092
+    data_reviews:
+      - TODO
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - mlichtenstein@mozilla.com
+      - vpn-telemetry@mozilla.com
+    expires: never
+    extra_keys: *impression_extra_keys
+  dns_settings_info_screen:
+    type: event
+    lifetime: ping
+    send_in_pings:
+      - main
+    description: |
+      The user has opened the dns settings help sheet
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/VPN-5092
+    data_reviews:
+      - TODO
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - mlichtenstein@mozilla.com
+      - vpn-telemetry@mozilla.com
+    expires: never
+    extra_keys: *impression_extra_keys
+  my_devices_screen:
+    type: event
+    lifetime: ping
+    send_in_pings:
+      - main
+    description: |
+      The user has opened the devices settings 
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/VPN-5092
+    data_reviews:
+      - TODO
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - mlichtenstein@mozilla.com
+      - vpn-telemetry@mozilla.com
+    expires: never
+    extra_keys: *impression_extra_keys
+  my_devices_info_screen:
+    type: event
+    lifetime: ping
+    send_in_pings:
+      - main
+    description: |
+      The user has opened the devices help sheet
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/VPN-5092
+    data_reviews:
+      - TODO
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - mlichtenstein@mozilla.com
+      - vpn-telemetry@mozilla.com
+    expires: never
+    extra_keys: *impression_extra_keys
+  privacy_features_screen:
+    type: event
+    lifetime: ping
+    send_in_pings:
+      - main
+    description: |
+      The user has opened the privacy features settings 
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/VPN-5092
+    data_reviews:
+      - TODO
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - mlichtenstein@mozilla.com
+      - vpn-telemetry@mozilla.com
+    expires: never
+    extra_keys: *impression_extra_keys
+  privacy_features_info_screen:
+    type: event
+    lifetime: ping
+    send_in_pings:
+      - main
+    description: |
+      The user has opened the privacy features help sheet
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/VPN-5092
+    data_reviews:
+      - TODO
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - mlichtenstein@mozilla.com
+      - vpn-telemetry@mozilla.com
+    expires: never
+    extra_keys: *impression_extra_keys

--- a/src/telemetry/interaction_metrics.yaml
+++ b/src/telemetry/interaction_metrics.yaml
@@ -1141,3 +1141,48 @@ interaction:
       - vpn-telemetry@mozilla.com
     expires: never
     extra_keys: *interaction_extra_keys
+  help_tooltip_selected:
+    type: event
+    lifetime: ping
+    send_in_pings:
+      - main
+    description: |
+      The user has clicked a help tooltip button
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/VPN-5092
+    data_reviews:
+      - TODO
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - mlichtenstein@mozilla.com
+      - vpn-telemetry@mozilla.com
+    expires: never
+    extra_keys: *interaction_extra_keys
+  learn_more_clicked:
+    type: event
+    lifetime: ping
+    send_in_pings:
+      - main
+    description: |
+      The user has clicked a learn more link
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/VPN-5092
+    data_reviews:
+      - TODO
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - mlichtenstein@mozilla.com
+      - vpn-telemetry@mozilla.com
+    expires: never
+    extra_keys:
+      screen:
+        description: The screen where the interaction happened
+        type: string
+      action:
+        description: TODO
+        type: string
+      element_id:
+        description: TODO
+        type: string

--- a/src/telemetry/interaction_metrics.yaml
+++ b/src/telemetry/interaction_metrics.yaml
@@ -1176,13 +1176,4 @@ interaction:
       - mlichtenstein@mozilla.com
       - vpn-telemetry@mozilla.com
     expires: never
-    extra_keys:
-      screen:
-        description: The screen where the interaction happened
-        type: string
-      action:
-        description: TODO
-        type: string
-      element_id:
-        description: TODO
-        type: string
+    extra_keys: *interaction_extra_keys

--- a/src/telemetry/interaction_metrics.yaml
+++ b/src/telemetry/interaction_metrics.yaml
@@ -1159,7 +1159,7 @@ interaction:
       - vpn-telemetry@mozilla.com
     expires: never
     extra_keys: *interaction_extra_keys
-  learn_more_clicked:
+  learn_more_selected:
     type: event
     lifetime: ping
     send_in_pings:

--- a/src/telemetry/interaction_metrics.yaml
+++ b/src/telemetry/interaction_metrics.yaml
@@ -1151,7 +1151,7 @@ interaction:
     bugs:
       - https://mozilla-hub.atlassian.net/browse/VPN-5092
     data_reviews:
-      - TODO
+      - https://github.com/mozilla-mobile/mozilla-vpn-client/pull/9023#pullrequestreview-1848707594
     data_sensitivity:
       - interaction
     notification_emails:
@@ -1169,7 +1169,7 @@ interaction:
     bugs:
       - https://mozilla-hub.atlassian.net/browse/VPN-5092
     data_reviews:
-      - TODO
+      - https://github.com/mozilla-mobile/mozilla-vpn-client/pull/9023#pullrequestreview-1848707594
     data_sensitivity:
       - interaction
     notification_emails:

--- a/src/ui/screens/devices/ViewDevices.qml
+++ b/src/ui/screens/devices/ViewDevices.qml
@@ -69,7 +69,7 @@ MZViewBase {
                         helpSheet.open()
 
                         Glean.interaction.helpTooltipSelected.record({
-                            screen: telemetryScreenId,
+                            screen: vpnFlickable.telemetryScreenId,
                         });
                     }
 
@@ -124,10 +124,8 @@ MZViewBase {
             {type: MZHelpSheet.BlockType.Text, text: MZI18n.HelpSheetsDevicesBody2, margin: MZTheme.theme.helpSheetBodySpacing},
             {type: MZHelpSheet.BlockType.LinkButton, text: MZI18n.GlobalLearnMore, margin: MZTheme.theme.helpSheetBodyButtonSpacing, objectName: "learnMoreLink", action: () => {
                     MZUrlOpener.openUrlLabel("sumoDevices")
-                    Glean.interaction.learnMoreClicked.record({
-                        screen: telemetryScreenId,
-                        action: "select",
-                        element_id: "learn_more"
+                    Glean.interaction.learnMoreSelected.record({
+                        screen: telemetryScreenId
                     });
                 }}
         ]

--- a/src/ui/screens/devices/ViewDevices.qml
+++ b/src/ui/screens/devices/ViewDevices.qml
@@ -14,6 +14,7 @@ MZViewBase {
     id: vpnFlickable
     objectName: "devicesSettingsView"
 
+    readonly property string telemetryScreenId : "my_devices"
     property var isModalDialogOpened: removePopup.visible
     property var wasmView
     property string deviceCountLabelText: ""
@@ -64,7 +65,13 @@ MZViewBase {
                 sourceComponent: MZIconButton {
                     objectName: "devicesHelpButton"
 
-                    onClicked: helpSheet.active = true
+                    onClicked: {
+                        helpSheet.open()
+
+                        Glean.interaction.helpTooltipSelected.record({
+                            screen: telemetryScreenId,
+                        });
+                    }
 
                     accessibleName: MZI18n.GetHelpLinkTitle
 
@@ -107,18 +114,30 @@ MZViewBase {
         id: helpSheet
         objectName: "devicesHelpSheet"
 
+        property string telemetryScreenId: "my_devices_info"
+
         title: MZI18n.HelpSheetsDevicesTitle
 
         model: [
             {type: MZHelpSheet.BlockType.Title, text: MZI18n.HelpSheetsDevicesHeader},
             {type: MZHelpSheet.BlockType.Text, text: MZI18n.HelpSheetsDevicesBody1, margin: MZTheme.theme.helpSheetTitleBodySpacing},
             {type: MZHelpSheet.BlockType.Text, text: MZI18n.HelpSheetsDevicesBody2, margin: MZTheme.theme.helpSheetBodySpacing},
-            {type: MZHelpSheet.BlockType.LinkButton, text: MZI18n.GlobalLearnMore, margin: MZTheme.theme.helpSheetBodyButtonSpacing, action: () => { MZUrlOpener.openUrlLabel("sumoDevices") }, objectName: "learnMoreLink"},
+            {type: MZHelpSheet.BlockType.LinkButton, text: MZI18n.GlobalLearnMore, margin: MZTheme.theme.helpSheetBodyButtonSpacing, objectName: "learnMoreLink", action: () => {
+                    MZUrlOpener.openUrlLabel("sumoDevices")
+                    Glean.interaction.learnMoreClicked.record({
+                        screen: telemetryScreenId,
+                        action: "select",
+                        element_id: "learn_more"
+                    });
+                }}
         ]
 
-        onActiveChanged: if (active) item.open()
+        onOpened: {
+            Glean.impression.myDevicesInfoScreen.record({
+                screen: telemetryScreenId,
+            });
+        }
     }
-
 
     Connections {
         target: deviceList
@@ -129,5 +148,9 @@ MZViewBase {
 
     Component.onCompleted: {
         VPN.refreshDevices()
+
+        Glean.impression.myDevicesScreen.record({
+            screen: telemetryScreenId,
+        });
     }
 }

--- a/src/ui/screens/home/ViewServers.qml
+++ b/src/ui/screens/home/ViewServers.qml
@@ -168,7 +168,7 @@ Item {
                 });
                 break
             default:
-                Glean.impression.locationSinglehopScreen.record({
+                Glean.impression.locationMultihopScreen.record({
                     screen: "unexpected",
                 });
                 break

--- a/src/ui/screens/home/ViewServers.qml
+++ b/src/ui/screens/home/ViewServers.qml
@@ -168,7 +168,9 @@ Item {
                 });
                 break
             default:
-                console.log("Unrecognized selected segment")
+                Glean.impression.locationSinglehopScreen.record({
+                    screen: "unexpected",
+                });
                 break
             }
         }

--- a/src/ui/screens/home/ViewServers.qml
+++ b/src/ui/screens/home/ViewServers.qml
@@ -16,6 +16,7 @@ import compat 0.1
 Item {
     id: root
     objectName: "viewServers"
+
     Accessible.name: qsTrId("vpn.servers.selectLocation")
     Accessible.role: Accessible.Pane
     Accessible.ignored: !visible
@@ -34,7 +35,7 @@ Item {
                 sourceComponent: MZIconButton {
                     objectName: "serverHelpButton"
 
-                    onClicked: helpSheet.active = true
+                    onClicked: helpSheet.open()
 
                     accessibleName: MZI18n.GetHelpLinkTitle
 
@@ -162,7 +163,7 @@ Item {
             {type: MZHelpSheet.BlockType.Title, text: MZI18n.HelpSheetsLocationHeader},
             {type: MZHelpSheet.BlockType.Text, text: MZI18n.HelpSheetsLocationBody1, margin: MZTheme.theme.helpSheetTitleBodySpacing},
             {type: MZHelpSheet.BlockType.Text, text: MZI18n.HelpSheetsLocationBody2, margin: MZTheme.theme.helpSheetBodySpacing},
-            {type: MZHelpSheet.BlockType.LinkButton, text: MZI18n.GlobalLearnMore, margin: MZTheme.theme.helpSheetBodyButtonSpacing, action: () => { MZUrlOpener.openUrlLabel("sumoMultihop") }, objectName: "learnMoreLink"},
+            {type: MZHelpSheet.BlockType.LinkButton, text: MZI18n.GlobalLearnMore, margin: MZTheme.theme.helpSheetBodyButtonSpacing, objectName: "learnMoreLink", action: () => { MZUrlOpener.openUrlLabel("sumoMultihop") }}
         ]
 
         onActiveChanged: if (active) item.open()

--- a/src/ui/screens/home/ViewServers.qml
+++ b/src/ui/screens/home/ViewServers.qml
@@ -154,16 +154,16 @@ Item {
                         }
 
         onSelectedSegmentChanged: {
-            root.telemetryScreenId = segmentedNav.selectedSegment.objectName === "tabSingleHop" ? "select_location_singlehop" : "select_location_multihop"
+            root.telemetryScreenId = segmentedNav.selectedSegment.objectName === "tabSingleHop" ? "location_singlehop" : "location_multihop"
 
             switch (segmentedNav.selectedSegment.objectName) {
             case "tabSingleHop":
-                Glean.impression.selectLocationSinglehopScreen.record({
+                Glean.impression.locationSinglehopScreen.record({
                     screen: root.telemetryScreenId,
                 });
                 break
             case "tabMultiHop":
-                Glean.impression.selectLocationMultihopScreen.record({
+                Glean.impression.locationMultihopScreen.record({
                     screen: root.telemetryScreenId,
                 });
                 break
@@ -184,7 +184,7 @@ Item {
         id: helpSheet
         objectName: "serverHelpSheet"
 
-        property string telemetryScreenId: "selection_location_info"
+        property string telemetryScreenId: "location_info"
 
         title: MZI18n.HelpSheetsLocationTitle
 
@@ -201,7 +201,7 @@ Item {
         ]
 
         onOpened: {
-            Glean.impression.selectLocationInfoScreen.record({
+            Glean.impression.locationInfoScreen.record({
                 screen: telemetryScreenId,
             });
         }

--- a/src/ui/screens/settings/ViewDNSSettings.qml
+++ b/src/ui/screens/settings/ViewDNSSettings.qml
@@ -31,7 +31,7 @@ MZViewBase {
                     helpSheet.open()
 
                     Glean.interaction.helpTooltipSelected.record({
-                        screen: telemetryScreenId,
+                        screen: root.telemetryScreenId,
                     });
                 }
 
@@ -356,10 +356,8 @@ MZViewBase {
             {type: MZHelpSheet.BlockType.Text, text: MZI18n.HelpSheetsDnsBody2, margin: MZTheme.theme.helpSheetBodySpacing},
             {type: MZHelpSheet.BlockType.LinkButton, text: MZI18n.GlobalLearnMore, margin: MZTheme.theme.helpSheetBodyButtonSpacing, objectName: "learnMoreLink", action: () => {
                     MZUrlOpener.openUrlLabel("sumoDns")
-                    Glean.interaction.learnMoreClicked.record({
-                        screen: telemetryScreenId,
-                        action: "select",
-                        element_id: "learn_more"
+                    Glean.interaction.learnMoreSelected.record({
+                        screen: telemetryScreenId
                     });
                 }}
         ]

--- a/src/ui/screens/settings/ViewDNSSettings.qml
+++ b/src/ui/screens/settings/ViewDNSSettings.qml
@@ -17,17 +17,23 @@ MZViewBase {
 
     _menuTitle: MZI18n.SettingsDnsSettings
 
+    readonly property string telemetryScreenId : "dns_settings"
     property bool customDNS: false
     property bool privacyDialogNeeded: true
     property bool dnsSelectionChanged: false
-    readonly property string telemetryScreenId : "dns_settings"
     property Component rightMenuButton: Component {
         Loader {
             active: MZFeatureList.get("helpSheets").isSupported
             sourceComponent: MZIconButton {
                 objectName: "dnsHelpButton"
 
-                onClicked: helpSheet.active = true
+                onClicked: {
+                    helpSheet.open()
+
+                    Glean.interaction.helpTooltipSelected.record({
+                        screen: telemetryScreenId,
+                    });
+                }
 
                 accessibleName: MZI18n.GetHelpLinkTitle
 
@@ -278,8 +284,8 @@ MZViewBase {
 
     Component.onCompleted: {
         Glean.impression.dnsSettingsScreen.record({
-                                                      screen: telemetryScreenId,
-                                                  });
+            screen: telemetryScreenId,
+        });
         reset();
     }
 
@@ -340,16 +346,29 @@ MZViewBase {
         id: helpSheet
         objectName: "dnsHelpSheet"
 
+        property string telemetryScreenId: "dns_settings_info"
+
         title: MZI18n.HelpSheetsDnsTitle
 
         model: [
             {type: MZHelpSheet.BlockType.Title, text: MZI18n.HelpSheetsDnsHeader},
             {type: MZHelpSheet.BlockType.Text, text: MZI18n.HelpSheetsDnsBody1, margin: MZTheme.theme.helpSheetTitleBodySpacing},
             {type: MZHelpSheet.BlockType.Text, text: MZI18n.HelpSheetsDnsBody2, margin: MZTheme.theme.helpSheetBodySpacing},
-            {type: MZHelpSheet.BlockType.LinkButton, text: MZI18n.GlobalLearnMore, margin: MZTheme.theme.helpSheetBodyButtonSpacing, action: () => { MZUrlOpener.openUrlLabel("sumoDns") }, objectName: "learnMoreLink"},
+            {type: MZHelpSheet.BlockType.LinkButton, text: MZI18n.GlobalLearnMore, margin: MZTheme.theme.helpSheetBodyButtonSpacing, objectName: "learnMoreLink", action: () => {
+                    MZUrlOpener.openUrlLabel("sumoDns")
+                    Glean.interaction.learnMoreClicked.record({
+                        screen: telemetryScreenId,
+                        action: "select",
+                        element_id: "learn_more"
+                    });
+                }}
         ]
 
-        onActiveChanged: if (active) item.open()
+        onOpened: {
+            Glean.impression.dnsSettingsInfoScreen.record({
+                screen: telemetryScreenId,
+            });
+        }
     }
 }
 

--- a/src/ui/screens/settings/ViewSettingsMenu.qml
+++ b/src/ui/screens/settings/ViewSettingsMenu.qml
@@ -93,8 +93,8 @@ MZViewBase {
             }
 
             Loader {
-                Layout.preferredHeight: item.Layout.preferredHeight
-                Layout.fillWidth: item.Layout.fillWidth
+                Layout.preferredHeight: active ? item.Layout.preferredHeight : 0
+                Layout.fillWidth: active ? item.Layout.fillWidth : false
 
                 visible: active
                 active: !MZFeatureList.get("helpSheets").isSupported

--- a/src/ui/screens/settings/appPermissions/ViewAppPermissions.qml
+++ b/src/ui/screens/settings/appPermissions/ViewAppPermissions.qml
@@ -35,7 +35,7 @@ MZViewBase {
                     helpSheet.open()
 
                     Glean.interaction.helpTooltipSelected.record({
-                        screen: telemetryScreenId,
+                        screen: vpnFlickable.telemetryScreenId,
                     });
                 }
 
@@ -112,10 +112,8 @@ MZViewBase {
                 }},
             {type: MZHelpSheet.BlockType.LinkButton, text: MZI18n.GlobalLearnMore, margin: MZTheme.theme.helpSheetSecondaryButtonSpacing, objectName: "learnMoreLink", action: () => {
                     MZUrlOpener.openUrlLabel("sumoExcludedApps")
-                    Glean.interaction.learnMoreClicked.record({
-                        screen: telemetryScreenId,
-                        action: "select",
-                        element_id: "learn_more"
+                    Glean.interaction.learnMoreSelected.record({
+                        screen: telemetryScreenId
                     });
                 }}
         ]

--- a/src/ui/screens/settings/appPermissions/ViewAppPermissions.qml
+++ b/src/ui/screens/settings/appPermissions/ViewAppPermissions.qml
@@ -15,6 +15,8 @@ MZViewBase {
     id: vpnFlickable
     objectName: "appPermissions"
 
+    readonly property string telemetryScreenId : "app_exclusions"
+
     //% "Search apps"
     //: Search bar placeholder text
     property string searchApps: qsTrId("vpn.protectSelectedApps.searchApps")
@@ -29,7 +31,13 @@ MZViewBase {
             sourceComponent: MZIconButton {
                 objectName: "excludedAppsHelpButton"
 
-                onClicked: helpSheet.active = true
+                onClicked: {
+                    helpSheet.open()
+
+                    Glean.interaction.helpTooltipSelected.record({
+                        screen: telemetryScreenId,
+                    });
+                }
 
                 accessibleName: MZI18n.GetHelpLinkTitle
 
@@ -89,6 +97,8 @@ MZViewBase {
         id: helpSheet
         objectName: "excludedAppsHelpSheet"
 
+        property string telemetryScreenId: "app_exclusions_info"
+
         title: MZI18n.HelpSheetsExcludedAppsTitle
 
         model: [
@@ -96,19 +106,31 @@ MZViewBase {
             {type: MZHelpSheet.BlockType.Text, text: MZI18n.HelpSheetsExcludedAppsBody1, margin: MZTheme.theme.helpSheetTitleBodySpacing},
             {type: MZHelpSheet.BlockType.Text, text: MZI18n.HelpSheetsExcludedAppsBody2, margin: MZTheme.theme.helpSheetBodySpacing},
             {type: MZHelpSheet.BlockType.Text, text: MZI18n.HelpSheetsExcludedAppsBody3, margin: MZTheme.theme.helpSheetBodySpacing},
-            {type: MZHelpSheet.BlockType.PrimaryButton, text: MZI18n.HelpSheetsExcludedAppsCTA, margin: MZTheme.theme.helpSheetBodyButtonSpacing, action: () => {
+            {type: MZHelpSheet.BlockType.PrimaryButton, text: MZI18n.HelpSheetsExcludedAppsCTA, margin: MZTheme.theme.helpSheetBodyButtonSpacing, objectName: "openPrivacyFeaturesButton", action: () => {
                     close()
                     getStack().push("qrc:/ui/screens/settings/privacy/ViewPrivacy.qml")
-                }, objectName: "openPrivacyFeaturesButton"},
-            {type: MZHelpSheet.BlockType.LinkButton, text: MZI18n.GlobalLearnMore, margin: MZTheme.theme.helpSheetSecondaryButtonSpacing, action: () => { MZUrlOpener.openUrlLabel("sumoExcludedApps") }, objectName: "learnMoreLink"},
+                }},
+            {type: MZHelpSheet.BlockType.LinkButton, text: MZI18n.GlobalLearnMore, margin: MZTheme.theme.helpSheetSecondaryButtonSpacing, objectName: "learnMoreLink", action: () => {
+                    MZUrlOpener.openUrlLabel("sumoExcludedApps")
+                    Glean.interaction.learnMoreClicked.record({
+                        screen: telemetryScreenId,
+                        action: "select",
+                        element_id: "learn_more"
+                    });
+                }}
         ]
 
-        onActiveChanged: if (active) item.open()
+        onOpened: {
+            Glean.impression.appExclusionsInfoScreen.record({
+                screen: telemetryScreenId,
+            });
+        }
     }
 
     Component.onCompleted: {
-        console.log("Component ready");
         VPNAppPermissions.requestApplist();
-        Glean.sample.appPermissionsViewOpened.record();
+        Glean.impression.appExclusionsScreen.record({
+            screen: telemetryScreenId,
+        });
     }
 }

--- a/src/ui/screens/settings/privacy/ViewPrivacy.qml
+++ b/src/ui/screens/settings/privacy/ViewPrivacy.qml
@@ -16,13 +16,20 @@ MZViewBase {
     id: root
     objectName: "privacySettingsView"
 
+    readonly property string telemetryScreenId : "privacy_features"
     property Component rightMenuButton: Component {
         Loader {
             active: MZFeatureList.get("helpSheets").isSupported
             sourceComponent: MZIconButton {
                 objectName: "privacyHelpButton"
 
-                onClicked: helpSheet.active = true
+                onClicked: {
+                    helpSheet.open()
+
+                    Glean.interaction.helpTooltipSelected.record({
+                        screen: telemetryScreenId,
+                    });
+                }
 
                 accessibleName: MZI18n.GetHelpLinkTitle
 
@@ -34,6 +41,12 @@ MZViewBase {
                 }
             }
         }
+    }
+
+    Component.onCompleted: {
+        Glean.impression.privacyFeaturesScreen.record({
+            screen: telemetryScreenId,
+        });
     }
 
     _menuTitle: MZI18n.SettingsPrivacySettings
@@ -131,16 +144,29 @@ MZViewBase {
         id: helpSheet
         objectName: "privacyHelpSheet"
 
+        property string telemetryScreenId: "privacy_features_info"
+
         title: MZI18n.HelpSheetsPrivacyTitle
 
         model: [
             {type: MZHelpSheet.BlockType.Title, text: MZI18n.HelpSheetsPrivacyHeader},
             {type: MZHelpSheet.BlockType.Text, text: MZI18n.HelpSheetsPrivacyBody1, margin: MZTheme.theme.helpSheetTitleBodySpacing},
             {type: MZHelpSheet.BlockType.Text, text: MZI18n.HelpSheetsPrivacyBody2, margin: MZTheme.theme.helpSheetBodySpacing},
-            {type: MZHelpSheet.BlockType.LinkButton, text: MZI18n.GlobalLearnMore, margin: MZTheme.theme.helpSheetBodyButtonSpacing, action: () => { MZUrlOpener.openUrlLabel("sumoPrivacy") }, objectName: "learnMoreLink"},
+            {type: MZHelpSheet.BlockType.LinkButton, text: MZI18n.GlobalLearnMore, margin: MZTheme.theme.helpSheetBodyButtonSpacing, objectName: "learnMoreLink", action: () => {
+                    MZUrlOpener.openUrlLabel("sumoPrivacy")
+                    Glean.interaction.learnMoreClicked.record({
+                        screen: telemetryScreenId,
+                        action: "select",
+                        element_id: "learn_more"
+                    });
+                }}
         ]
 
-        onActiveChanged: if (active) item.open()
+        onOpened: {
+            Glean.impression.privacyFeaturesInfoScreen.record({
+                screen: telemetryScreenId,
+            });
+        }
     }
 }
 

--- a/src/ui/screens/settings/privacy/ViewPrivacy.qml
+++ b/src/ui/screens/settings/privacy/ViewPrivacy.qml
@@ -27,7 +27,7 @@ MZViewBase {
                     helpSheet.open()
 
                     Glean.interaction.helpTooltipSelected.record({
-                        screen: telemetryScreenId,
+                        screen: root.telemetryScreenId,
                     });
                 }
 
@@ -154,10 +154,8 @@ MZViewBase {
             {type: MZHelpSheet.BlockType.Text, text: MZI18n.HelpSheetsPrivacyBody2, margin: MZTheme.theme.helpSheetBodySpacing},
             {type: MZHelpSheet.BlockType.LinkButton, text: MZI18n.GlobalLearnMore, margin: MZTheme.theme.helpSheetBodyButtonSpacing, objectName: "learnMoreLink", action: () => {
                     MZUrlOpener.openUrlLabel("sumoPrivacy")
-                    Glean.interaction.learnMoreClicked.record({
-                        screen: telemetryScreenId,
-                        action: "select",
-                        element_id: "learn_more"
+                    Glean.interaction.learnMoreSelected.record({
+                        screen: telemetryScreenId
                     });
                 }}
         ]

--- a/tests/functional/queries.js
+++ b/tests/functional/queries.js
@@ -55,11 +55,11 @@ class QmlQueryComposer {
   }
 
   opened() {
-    return this.prop('opened', true);
+    return this.prop('isOpen', true);
   }
 
   closed() {
-    return this.prop('opened', false);
+    return this.prop('isOpen', false);
   }
 
 

--- a/tests/functional/testAppExclusions.js
+++ b/tests/functional/testAppExclusions.js
@@ -142,8 +142,6 @@ describe('Settings', function() {
       }
 
       const appExclusionsHelpSheetTelemetryScreenId = "app_exclusions_info"
-      const appExclusionsHelpSheetLinkTelemetryActionValue = "select"
-      const appExclusionsHelpSheetLinkTelemetryElementIdValue = "learn_more"
 
       await vpn.waitForQueryAndClick(queries.screenSettings.appExclusionsView.HELP_BUTTON.visible());
 
@@ -161,15 +159,10 @@ describe('Settings', function() {
 
       await vpn.waitForQueryAndClick(queries.screenSettings.appExclusionsView.HELP_SHEET_LEARN_MORE_BUTTON.visible());
 
-      const learnMoreClickedEvents = await vpn.gleanTestGetValue("interaction", "learnMoreClicked", "main");
-      assert.equal(learnMoreClickedEvents.length, 1);
-      const learnMoreClickedEventsExtras = learnMoreClickedEvents[0].extra;
-      assert.equal(appExclusionsHelpSheetTelemetryScreenId, learnMoreClickedEventsExtras.screen);
-      assert.equal(appExclusionsHelpSheetLinkTelemetryActionValue, learnMoreClickedEventsExtras.action);
-      assert.equal(appExclusionsHelpSheetLinkTelemetryElementIdValue, learnMoreClickedEventsExtras.element_id);
-
-      // PLACEHOLDER: IF THIS BUTTON GETS TELEMETRY (OTHERWISE REMOVE)
-      // await vpn.waitForQueryAndClick(queries.screenSettings.appExclusionsView.HELP_SHEET_OPEN_PRIVACY_FEATURES_BUTTON.visible());
+      const learnMoreSelectedEvents = await vpn.gleanTestGetValue("interaction", "learnMoreSelected", "main");
+      assert.equal(learnMoreSelectedEvents.length, 1);
+      const learnMoreSelectedEventsExtras = learnMoreSelectedEvents[0].extra;
+      assert.equal(appExclusionsHelpSheetTelemetryScreenId, learnMoreSelectedEventsExtras.screen);
     });
 
     // Dummy VPN does not have the Add Application button so we cannot currently test this.

--- a/tests/functional/testAppExclusions.js
+++ b/tests/functional/testAppExclusions.js
@@ -88,7 +88,6 @@ describe('Settings', function() {
 
     //Test the "Open privacy features" button
     await vpn.waitForQueryAndClick(queries.screenSettings.appExclusionsView.HELP_BUTTON.visible());
-    await vpn.waitForQuery(queries.screenSettings.appExclusionsView.HELP_SHEET.visible());
     await vpn.waitForQuery(queries.screenSettings.appExclusionsView.HELP_SHEET.opened());
     await vpn.waitForQueryAndClick(queries.screenSettings.appExclusionsView.HELP_SHEET_OPEN_PRIVACY_FEATURES_BUTTON.visible());
     await vpn.waitForQuery(queries.screenSettings.appExclusionsView.HELP_SHEET.closed());
@@ -101,7 +100,6 @@ describe('Settings', function() {
 
     //Test the "Learn more" link
     await vpn.waitForQueryAndClick(queries.screenSettings.appExclusionsView.HELP_BUTTON.visible());
-    await vpn.waitForQuery(queries.screenSettings.appExclusionsView.HELP_SHEET.visible());
     await vpn.waitForQuery(queries.screenSettings.appExclusionsView.HELP_SHEET.opened());
     await vpn.waitForQueryAndClick(queries.screenSettings.appExclusionsView.HELP_SHEET_LEARN_MORE_BUTTON.visible());
     await vpn.waitForCondition(async () => {
@@ -111,9 +109,72 @@ describe('Settings', function() {
     await vpn.waitForQueryAndClick(queries.screenSettings.appExclusionsView.HELP_SHEET_CLOSE_BUTTON.visible());
   });
 
-  // Dummy VPN does not have the Add Application button so we cannot currently test this.
-  // Jira issue: https://mozilla-hub.atlassian.net/browse/VPN-5974
-  it('Record telemetry when user clicks on Add application', async () => {
+  describe('Checking app exclusions screen telemetry', function () {
+    // No Glean on WASM.
+    if(vpn.runningOnWasm()) {
+      return;
+    }
+
+    const appExclusionsTelemetryScreenId = "app_exclusions"
+
+    it('Record telemetry when user clicks on App Exclusions', async () => {
+      await vpn.waitForQueryAndClick(queries.navBar.SETTINGS.visible());
+      await vpn.waitForQuery(queries.screenSettings.STACKVIEW.ready());
+      await vpn.waitForQueryAndClick(queries.screenSettings.APP_EXCLUSIONS.visible());
+      await vpn.waitForQuery(queries.screenSettings.STACKVIEW.ready());
+
+      // Check that we collect telemetry
+      const events = await vpn.gleanTestGetValue("interaction", "appExclusionsSelected", "main");
+      var element = events[0];
+      assert.equal(element.extra.screen, "settings");
+    });
+
+    it('Checking app exclusions screen impression telemetry', async () => {
+      const appExclusionsSreenEvents = await vpn.gleanTestGetValue("impression", "appExclusionsScreen", "main");
+      assert.equal(appExclusionsSreenEvents.length, 1);
+      const appExclusionsSreenEventsExtras = appExclusionsSreenEvents[0].extra;
+      assert.equal(appExclusionsTelemetryScreenId, appExclusionsSreenEventsExtras.screen);
+    });
+
+    it('Checking privacy help sheet telemetry', async () => {
+      if (!(await vpn.isFeatureFlippedOn('helpSheets'))) {
+        await vpn.flipFeatureOn('helpSheets');
+      }
+
+      const appExclusionsHelpSheetTelemetryScreenId = "app_exclusions_info"
+      const appExclusionsHelpSheetLinkTelemetryActionValue = "select"
+      const appExclusionsHelpSheetLinkTelemetryElementIdValue = "learn_more"
+
+      await vpn.waitForQueryAndClick(queries.screenSettings.appExclusionsView.HELP_BUTTON.visible());
+
+      const helpTooltipSelectedEvents = await vpn.gleanTestGetValue("interaction", "helpTooltipSelected", "main");
+      assert.equal(helpTooltipSelectedEvents.length, 1);
+      const helpTooltipSelectedEventsExtras = helpTooltipSelectedEvents[0].extra;
+      assert.equal(appExclusionsTelemetryScreenId, helpTooltipSelectedEventsExtras.screen);
+
+      await vpn.waitForQuery(queries.screenSettings.appExclusionsView.HELP_SHEET.opened());
+
+      const appExclusionsInfoScreenEvents = await vpn.gleanTestGetValue("impression", "appExclusionsInfoScreen", "main");
+      assert.equal(appExclusionsInfoScreenEvents.length, 1);
+      const appExclusionsInfoScreenEventsExtras = appExclusionsInfoScreenEvents[0].extra;
+      assert.equal(appExclusionsHelpSheetTelemetryScreenId, appExclusionsInfoScreenEventsExtras.screen);
+
+      await vpn.waitForQueryAndClick(queries.screenSettings.appExclusionsView.HELP_SHEET_LEARN_MORE_BUTTON.visible());
+
+      const learnMoreClickedEvents = await vpn.gleanTestGetValue("interaction", "learnMoreClicked", "main");
+      assert.equal(learnMoreClickedEvents.length, 1);
+      const learnMoreClickedEventsExtras = learnMoreClickedEvents[0].extra;
+      assert.equal(appExclusionsHelpSheetTelemetryScreenId, learnMoreClickedEventsExtras.screen);
+      assert.equal(appExclusionsHelpSheetLinkTelemetryActionValue, learnMoreClickedEventsExtras.action);
+      assert.equal(appExclusionsHelpSheetLinkTelemetryElementIdValue, learnMoreClickedEventsExtras.element_id);
+
+      // PLACEHOLDER: IF THIS BUTTON GETS TELEMETRY (OTHERWISE REMOVE)
+      // await vpn.waitForQueryAndClick(queries.screenSettings.appExclusionsView.HELP_SHEET_OPEN_PRIVACY_FEATURES_BUTTON.visible());
+    });
+
+    // Dummy VPN does not have the Add Application button so we cannot currently test this.
+    // Jira issue: https://mozilla-hub.atlassian.net/browse/VPN-5974
+    it('Record telemetry when user clicks on Add application', async () => {
     // await vpn.waitForQueryAndClick(appExclusionsView.ADD_APPLICATION_BUTTON.visible());
     // await vpn.waitForQuery(appExclusionsView.STACKVIEW.ready());
 
@@ -121,21 +182,6 @@ describe('Settings', function() {
     // assert.equal(events.length, 1);
     // var element = events[0];
     // assert.equal(element.extra.screen, "app_exclusions");
-  });
-
-  it('Record telemetry when user clicks on App Exclusions', async () => {
-    if (this.ctx.wasm) {
-      // This test cannot run in wasm
-      return;
-    }
-    await vpn.waitForQueryAndClick(queries.navBar.SETTINGS.visible());
-    await vpn.waitForQuery(queries.screenSettings.STACKVIEW.ready());
-    await vpn.waitForQueryAndClick(queries.screenSettings.APP_EXCLUSIONS.visible());
-    await vpn.waitForQuery(queries.screenSettings.STACKVIEW.ready());
-
-    // Check that we collect telemetry
-    const events = await vpn.gleanTestGetValue("interaction", "appExclusionsSelected", "main");
-    var element = events[0];
-    assert.equal(element.extra.screen, "settings");
+    });
   });
 });

--- a/tests/functional/testDevices.js
+++ b/tests/functional/testDevices.js
@@ -55,8 +55,6 @@ describe('Devices', function() {
         }
 
         const devicesHelpSheetTelemetryScreenId = "my_devices_info"
-        const devicesHelpSheetLinkTelemetryActionValue = "select"
-        const devicesHelpSheetLinkTelemetryElementIdValue = "learn_more"
 
         await vpn.waitForQueryAndClick(queries.screenSettings.myDevicesView.HELP_BUTTON.visible());
 
@@ -74,12 +72,10 @@ describe('Devices', function() {
 
         await vpn.waitForQueryAndClick(queries.screenSettings.appPreferencesView.dnsSettingsView.HELP_SHEET_LEARN_MORE_BUTTON.visible());
 
-        const learnMoreClickedEvents = await vpn.gleanTestGetValue("interaction", "learnMoreClicked", "main");
-        assert.equal(learnMoreClickedEvents.length, 1);
-        const learnMoreClickedEventsExtras = learnMoreClickedEvents[0].extra;
-        assert.equal(devicesHelpSheetTelemetryScreenId, learnMoreClickedEventsExtras.screen);
-        assert.equal(devicesHelpSheetLinkTelemetryActionValue, learnMoreClickedEventsExtras.action);
-        assert.equal(devicesHelpSheetLinkTelemetryElementIdValue, learnMoreClickedEventsExtras.element_id);
+        const learnMoreSelectedEvents = await vpn.gleanTestGetValue("interaction", "learnMoreSelected", "main");
+        assert.equal(learnMoreSelectedEvents.length, 1);
+        const learnMoreSelectedEventsExtras = learnMoreSelectedEvents[0].extra;
+        assert.equal(devicesHelpSheetTelemetryScreenId, learnMoreSelectedEventsExtras.screen);
       });
     });
 

--- a/tests/functional/testServers.js
+++ b/tests/functional/testServers.js
@@ -273,7 +273,6 @@ describe('Server list', function() {
     }
 
     await vpn.waitForQueryAndClick(queries.screenHome.serverListView.HELP_BUTTON.visible());
-    await vpn.waitForQuery(queries.screenHome.serverListView.HELP_SHEET.visible());
     await vpn.waitForQuery(queries.screenHome.serverListView.HELP_SHEET.opened());
     await vpn.waitForQueryAndClick(queries.screenHome.serverListView.HELP_SHEET_LEARN_MORE_BUTTON.visible());
     await vpn.waitForCondition(async () => {

--- a/tests/functional/testServers.js
+++ b/tests/functional/testServers.js
@@ -6,281 +6,406 @@ const assert = require('assert');
 const queries = require('./queries.js');
 const vpn = require('./helper.js');
 
-describe('Server list', function() {
-  let servers;
-  let currentCountryCode;
-  let currentCity;
-
+describe('Server', function() {
   this.timeout(240000);
   this.ctx.authenticationNeeded = true;
 
-  beforeEach(async () => {
-    await vpn.waitForQueryAndClick(
-        queries.screenHome.SERVER_LIST_BUTTON.visible());
-    await vpn.waitForQuery(queries.screenHome.STACKVIEW.ready());
-    await vpn.waitForQueryAndClick(queries.screenHome.serverListView.ALL_SERVERS_TAB.visible());
-
-    servers = await vpn.servers();
-    currentCountryCode = await vpn.getMozillaProperty(
-        'Mozilla.VPN', 'VPNCurrentServer', 'exitCountryCode');
-    currentCity = await vpn.getMozillaProperty(
-        'Mozilla.VPN', 'VPNCurrentServer', 'exitCityName');
-
-    for (let server of servers) {
-      if (currentCountryCode === server.code) {
-        for (let city of server.cities) {
-          if (city.name == currentCity) {
-            currentCity = city.localizedName;
-            break;
+  describe('General server list tests', function() {
+    let servers;
+    let currentCountryCode;
+    let currentCity;
+  
+    beforeEach(async () => {
+      await vpn.waitForQueryAndClick(
+          queries.screenHome.SERVER_LIST_BUTTON.visible());
+      await vpn.waitForQuery(queries.screenHome.STACKVIEW.ready());
+      await vpn.waitForQueryAndClick(queries.screenHome.serverListView.ALL_SERVERS_TAB.visible());
+  
+      servers = await vpn.servers();
+      currentCountryCode = await vpn.getMozillaProperty(
+          'Mozilla.VPN', 'VPNCurrentServer', 'exitCountryCode');
+      currentCity = await vpn.getMozillaProperty(
+          'Mozilla.VPN', 'VPNCurrentServer', 'exitCityName');
+  
+      for (let server of servers) {
+        if (currentCountryCode === server.code) {
+          for (let city of server.cities) {
+            if (city.name == currentCity) {
+              currentCity = city.localizedName;
+              break;
+            }
           }
         }
       }
-    }
-    console.log(
-        'Current city (localized):', currentCity,
-        '| Current country code:', currentCountryCode);
-  });
-
-  it('opening the server list', async () => {
-    await vpn.waitForQueryAndClick(
-        queries.screenHome.serverListView.BACK_BUTTON.visible());
-    await vpn.waitForQuery(queries.screenHome.SERVER_LIST_BUTTON.visible());
-  });
-
-  it('check the countries and cities', async () => {
-    for (let server of servers) {
+      console.log(
+          'Current city (localized):', currentCity,
+          '| Current country code:', currentCountryCode);
+    });
+  
+    it('opening the server list', async () => {
+      await vpn.waitForQueryAndClick(
+          queries.screenHome.serverListView.BACK_BUTTON.visible());
+      await vpn.waitForQuery(queries.screenHome.SERVER_LIST_BUTTON.visible());
+    });
+  
+    it('check the countries and cities', async () => {
+      for (let server of servers) {
+        const countryId =
+            queries.screenHome.serverListView.generateCountryId(server.code);
+        await vpn.waitForQuery(countryId.visible());
+  
+        await vpn.scrollToQuery(
+            queries.screenHome.serverListView.COUNTRY_VIEW, countryId);
+  
+        if (currentCountryCode === server.code) {
+          assert.equal(
+              await vpn.getQueryProperty(countryId, 'cityListVisible'),
+              'true');
+        }
+  
+        if (await vpn.getQueryProperty(countryId, 'cityListVisible') ===
+            'false') {
+          await vpn.clickOnQuery(countryId);
+        }
+  
+        for (let city of server.cities) {
+          const cityId = queries.screenHome.serverListView.generateCityId(
+              countryId, city.name);
+          await vpn.waitForQuery(cityId.visible().prop(
+              'checked',
+              currentCountryCode === server.code &&
+                      currentCity === city.localizedName ?
+                  'true' :
+                  'false'));
+        }
+      }
+    });
+  
+    it('Pick cities', async () => {
+      for (let server of servers) {
+        const countryId =
+            queries.screenHome.serverListView.generateCountryId(server.code);
+        await vpn.waitForQuery(countryId.visible());
+  
+        await vpn.scrollToQuery(
+            queries.screenHome.serverListView.COUNTRY_VIEW, countryId);
+  
+        if (await vpn.getQueryProperty(countryId, 'cityListVisible') ===
+            'false') {
+          await vpn.clickOnQuery(countryId);
+          await vpn.waitForQuery(countryId.ready());
+        }
+  
+        await vpn.waitForQuery(countryId.prop('cityListVisible', true));
+  
+        for (let city of server.cities) {
+          console.log('  Start test for city:', city);
+          const cityId = queries.screenHome.serverListView.generateCityId(
+              countryId, city.name);
+          await vpn.waitForQuery(cityId);
+  
+          await vpn.setQueryProperty(
+              queries.screenHome.serverListView.COUNTRY_VIEW, 'contentY',
+              parseInt(await vpn.getQueryProperty(cityId, 'y')) +
+                  parseInt(await vpn.getQueryProperty(countryId, 'y')));
+          await vpn.waitForQuery(cityId.visible());
+  
+          const cityName =
+              await vpn.getQueryProperty(cityId, 'radioButtonLabelText');
+  
+          await vpn.clickOnQuery(cityId);
+          await vpn.waitForQuery(queries.screenHome.STACKVIEW.ready());
+  
+          currentCountryCode = server.code;
+          currentCity = city.localizedName;
+  
+          // Back to the main view.
+  
+          await vpn.waitForQuery(queries.screenHome.SERVER_LIST_BUTTON.visible());
+          await vpn.waitForQuery(
+              queries.screenHome.SERVER_LIST_BUTTON_LABEL.visible().prop(
+                  'text', cityName));
+          await vpn.waitForQueryAndClick(
+              queries.screenHome.SERVER_LIST_BUTTON.visible());
+          await vpn.waitForQuery(queries.screenHome.STACKVIEW.ready());
+          await vpn.waitForQueryAndClick(queries.screenHome.serverListView.ALL_SERVERS_TAB.visible());
+  
+          // One selected
+          await vpn.waitForQuery(queries.screenHome.STACKVIEW.ready());
+          await vpn.waitForQuery(cityId.checked());
+        }
+      }
+    });
+  
+    it('Server switching', async () => {
+      await vpn.setSetting('serverSwitchNotification', 'true');
+      await vpn.setSetting('connectionChangeNotification', 'true');
+  
+      await vpn.waitForQueryAndClick(
+          queries.screenHome.serverListView.BACK_BUTTON.visible());
+  
+      await vpn.activate();
+  
+      await vpn.waitForCondition(async () => {
+        return await vpn.getQueryProperty(
+                   queries.screenHome.CONTROLLER_TITLE.visible(), 'text') ==
+            'VPN is on';
+      });
+  
+      let currentCountry = '';
+      for (let server of servers) {
+        if (server.code === currentCountryCode) {
+          currentCountry = server.localizedName;
+          break;
+        }
+      }
+  
+      assert(currentCountry != '');
+  
+      assert.strictEqual(vpn.lastNotification().title, 'VPN Connected');
+      assert.strictEqual(
+          vpn.lastNotification().message,
+          `Connected through ${currentCity}`);
+  
+      await vpn.waitForQueryAndClick(
+          queries.screenHome.SERVER_LIST_BUTTON.visible());
+      await vpn.waitForQuery(queries.screenHome.STACKVIEW.ready());
+      await vpn.waitForQueryAndClick(queries.screenHome.serverListView.ALL_SERVERS_TAB.visible());
+  
+      let server;
+      while (true) {
+        server = servers[Math.floor(Math.random() * servers.length)];
+        if (server.code != currentCountryCode) break;
+      }
+  
       const countryId =
           queries.screenHome.serverListView.generateCountryId(server.code);
       await vpn.waitForQuery(countryId.visible());
-
+  
       await vpn.scrollToQuery(
           queries.screenHome.serverListView.COUNTRY_VIEW, countryId);
-
-      if (currentCountryCode === server.code) {
-        assert.equal(
-            await vpn.getQueryProperty(countryId, 'cityListVisible'),
-            'true');
-      }
-
-      if (await vpn.getQueryProperty(countryId, 'cityListVisible') ===
-          'false') {
-        await vpn.clickOnQuery(countryId);
-      }
-
-      for (let city of server.cities) {
-        const cityId = queries.screenHome.serverListView.generateCityId(
-            countryId, city.name);
-        await vpn.waitForQuery(cityId.visible().prop(
-            'checked',
-            currentCountryCode === server.code &&
-                    currentCity === city.localizedName ?
-                'true' :
-                'false'));
-      }
-    }
-  });
-
-  it('Pick cities', async () => {
-    for (let server of servers) {
-      const countryId =
-          queries.screenHome.serverListView.generateCountryId(server.code);
-      await vpn.waitForQuery(countryId.visible());
-
-      await vpn.scrollToQuery(
-          queries.screenHome.serverListView.COUNTRY_VIEW, countryId);
-
-      if (await vpn.getQueryProperty(countryId, 'cityListVisible') ===
-          'false') {
-        await vpn.clickOnQuery(countryId);
-        await vpn.waitForQuery(countryId.ready());
-      }
-
-      await vpn.waitForQuery(countryId.prop('cityListVisible', true));
-
-      for (let city of server.cities) {
-        console.log('  Start test for city:', city);
-        const cityId = queries.screenHome.serverListView.generateCityId(
-            countryId, city.name);
-        await vpn.waitForQuery(cityId);
-
-        await vpn.setQueryProperty(
-            queries.screenHome.serverListView.COUNTRY_VIEW, 'contentY',
-            parseInt(await vpn.getQueryProperty(cityId, 'y')) +
-                parseInt(await vpn.getQueryProperty(countryId, 'y')));
-        await vpn.waitForQuery(cityId.visible());
-
-        const cityName =
-            await vpn.getQueryProperty(cityId, 'radioButtonLabelText');
-
-        await vpn.clickOnQuery(cityId);
-        await vpn.waitForQuery(queries.screenHome.STACKVIEW.ready());
-
-        currentCountryCode = server.code;
-        currentCity = city.localizedName;
-
-        // Back to the main view.
-
-        await vpn.waitForQuery(queries.screenHome.SERVER_LIST_BUTTON.visible());
-        await vpn.waitForQuery(
-            queries.screenHome.SERVER_LIST_BUTTON_LABEL.visible().prop(
-                'text', cityName));
-        await vpn.waitForQueryAndClick(
-            queries.screenHome.SERVER_LIST_BUTTON.visible());
-        await vpn.waitForQuery(queries.screenHome.STACKVIEW.ready());
-        await vpn.waitForQueryAndClick(queries.screenHome.serverListView.ALL_SERVERS_TAB.visible());
-
-        // One selected
-        await vpn.waitForQuery(queries.screenHome.STACKVIEW.ready());
-        await vpn.waitForQuery(cityId.checked());
-      }
-    }
-  });
-
-  it('Server switching', async () => {
-    await vpn.setSetting('serverSwitchNotification', 'true');
-    await vpn.setSetting('connectionChangeNotification', 'true');
-
-    await vpn.waitForQueryAndClick(
-        queries.screenHome.serverListView.BACK_BUTTON.visible());
-
-    await vpn.activate();
-
-    await vpn.waitForCondition(async () => {
-      return await vpn.getQueryProperty(
-                 queries.screenHome.CONTROLLER_TITLE.visible(), 'text') ==
-          'VPN is on';
+      await vpn.clickOnQuery(countryId);
+  
+      let city = server.cities[Math.floor(Math.random() * server.cities.length)];
+      const cityId =
+          queries.screenHome.serverListView.generateCityId(countryId, city.name);
+      await vpn.waitForQuery(cityId.visible());
+  
+      await vpn.setQueryProperty(
+          queries.screenHome.serverListView.COUNTRY_VIEW, 'contentY',
+          parseInt(await vpn.getQueryProperty(cityId, 'y')) +
+              parseInt(await vpn.getQueryProperty(countryId, 'y')));
+      await vpn.wait();
+  
+      await vpn.clickOnQuery(cityId);
+      await vpn.waitForQuery(queries.screenHome.STACKVIEW.ready());
+  
+      const previousCountry = currentCountry;
+      const previousCity = currentCity;
+  
+      currentCountryCode = server.code;
+      currentCountry = server.localizedName;
+      currentCity = city.localizedName;
+  
+      await vpn.waitForQuery(queries.screenHome.CONTROLLER_TITLE.visible());
+  
+      await vpn.waitForCondition(async () => {
+        let connectingMsg = await vpn.getQueryProperty(
+            queries.screenHome.CONTROLLER_TITLE.visible(), 'text');
+        return connectingMsg === 'Switching…' || connectingMsg === 'VPN is on';
+      });
+  
+      // Often the `From ${previousCity} to ${currentCity}` is too fast to be
+      // visible. Let's keep this test.
+  
+      await vpn.waitForCondition(async () => {
+        return await vpn.getQueryProperty(
+                   queries.screenHome.CONTROLLER_TITLE.visible(), 'text') ===
+            'VPN is on';
+      });
+  
+      assert.strictEqual(vpn.lastNotification().title, 'VPN Switched Servers');
+      assert.strictEqual(
+          vpn.lastNotification().message,
+          `Switched from ${previousCity} to ${currentCity}`);
     });
-
-    let currentCountry = '';
-    for (let server of servers) {
-      if (server.code === currentCountryCode) {
-        currentCountry = server.localizedName;
-        break;
+  
+    it('ensuring search message appears appropriately', async () => {
+      // open it up
+      await vpn.waitForQueryAndClick(
+          queries.screenHome.serverListView.SEARCH_BAR.visible());
+  
+      // ensure no message visible
+      await vpn.waitForQuery(
+          queries.screenHome.serverListView.SEARCH_BAR_ERROR.hidden());
+      // search down to one item - need to modify text within it
+      await vpn.setQueryProperty(
+          queries.screenHome.serverListView.SEARCH_BAR_TEXT_FIELD, 'text',
+          'Austra');
+      // ensure no message visible
+      await vpn.waitForQuery(
+          queries.screenHome.serverListView.SEARCH_BAR_ERROR.hidden());
+      // search to zero items
+      await vpn.setQueryProperty(
+          queries.screenHome.serverListView.SEARCH_BAR_TEXT_FIELD, 'text',
+          'Austraz');
+      // ensure message is visible
+      await vpn.waitForQuery(
+          queries.screenHome.serverListView.SEARCH_BAR_ERROR.visible());
+      // add another character
+      await vpn.setQueryProperty(
+          queries.screenHome.serverListView.SEARCH_BAR_TEXT_FIELD, 'text',
+          'Austrazz');
+      // ensure message
+      await vpn.waitForQuery(
+          queries.screenHome.serverListView.SEARCH_BAR_ERROR.visible());
+      // delete a couple characters
+      await vpn.setQueryProperty(
+          queries.screenHome.serverListView.SEARCH_BAR_TEXT_FIELD, 'text',
+          'Austra');
+      // ensure message disappears
+      await vpn.waitForQuery(
+          queries.screenHome.serverListView.SEARCH_BAR_ERROR.hidden());
+    });
+  
+    it('check the selection location help sheet', async () => {
+      if (!(await vpn.isFeatureFlippedOn('helpSheets'))) {
+        await vpn.flipFeatureOn('helpSheets');
       }
-    }
-
-    assert(currentCountry != '');
-
-    assert.strictEqual(vpn.lastNotification().title, 'VPN Connected');
-    assert.strictEqual(
-        vpn.lastNotification().message,
-        `Connected through ${currentCity}`);
-
-    await vpn.waitForQueryAndClick(
-        queries.screenHome.SERVER_LIST_BUTTON.visible());
-    await vpn.waitForQuery(queries.screenHome.STACKVIEW.ready());
-    await vpn.waitForQueryAndClick(queries.screenHome.serverListView.ALL_SERVERS_TAB.visible());
-
-    let server;
-    while (true) {
-      server = servers[Math.floor(Math.random() * servers.length)];
-      if (server.code != currentCountryCode) break;
-    }
-
-    const countryId =
-        queries.screenHome.serverListView.generateCountryId(server.code);
-    await vpn.waitForQuery(countryId.visible());
-
-    await vpn.scrollToQuery(
-        queries.screenHome.serverListView.COUNTRY_VIEW, countryId);
-    await vpn.clickOnQuery(countryId);
-
-    let city = server.cities[Math.floor(Math.random() * server.cities.length)];
-    const cityId =
-        queries.screenHome.serverListView.generateCityId(countryId, city.name);
-    await vpn.waitForQuery(cityId.visible());
-
-    await vpn.setQueryProperty(
-        queries.screenHome.serverListView.COUNTRY_VIEW, 'contentY',
-        parseInt(await vpn.getQueryProperty(cityId, 'y')) +
-            parseInt(await vpn.getQueryProperty(countryId, 'y')));
-    await vpn.wait();
-
-    await vpn.clickOnQuery(cityId);
-    await vpn.waitForQuery(queries.screenHome.STACKVIEW.ready());
-
-    const previousCountry = currentCountry;
-    const previousCity = currentCity;
-
-    currentCountryCode = server.code;
-    currentCountry = server.localizedName;
-    currentCity = city.localizedName;
-
-    await vpn.waitForQuery(queries.screenHome.CONTROLLER_TITLE.visible());
-
-    await vpn.waitForCondition(async () => {
-      let connectingMsg = await vpn.getQueryProperty(
-          queries.screenHome.CONTROLLER_TITLE.visible(), 'text');
-      return connectingMsg === 'Switching…' || connectingMsg === 'VPN is on';
-    });
-
-    // Often the `From ${previousCity} to ${currentCity}` is too fast to be
-    // visible. Let's keep this test.
-
-    await vpn.waitForCondition(async () => {
-      return await vpn.getQueryProperty(
-                 queries.screenHome.CONTROLLER_TITLE.visible(), 'text') ===
-          'VPN is on';
-    });
-
-    assert.strictEqual(vpn.lastNotification().title, 'VPN Switched Servers');
-    assert.strictEqual(
-        vpn.lastNotification().message,
-        `Switched from ${previousCity} to ${currentCity}`);
-  });
-
-  it('ensuring search message appears appropriately', async () => {
-    // open it up
-    await vpn.waitForQueryAndClick(
-        queries.screenHome.serverListView.SEARCH_BAR.visible());
-
-    // ensure no message visible
-    await vpn.waitForQuery(
-        queries.screenHome.serverListView.SEARCH_BAR_ERROR.hidden());
-    // search down to one item - need to modify text within it
-    await vpn.setQueryProperty(
-        queries.screenHome.serverListView.SEARCH_BAR_TEXT_FIELD, 'text',
-        'Austra');
-    // ensure no message visible
-    await vpn.waitForQuery(
-        queries.screenHome.serverListView.SEARCH_BAR_ERROR.hidden());
-    // search to zero items
-    await vpn.setQueryProperty(
-        queries.screenHome.serverListView.SEARCH_BAR_TEXT_FIELD, 'text',
-        'Austraz');
-    // ensure message is visible
-    await vpn.waitForQuery(
-        queries.screenHome.serverListView.SEARCH_BAR_ERROR.visible());
-    // add another character
-    await vpn.setQueryProperty(
-        queries.screenHome.serverListView.SEARCH_BAR_TEXT_FIELD, 'text',
-        'Austrazz');
-    // ensure message
-    await vpn.waitForQuery(
-        queries.screenHome.serverListView.SEARCH_BAR_ERROR.visible());
-    // delete a couple characters
-    await vpn.setQueryProperty(
-        queries.screenHome.serverListView.SEARCH_BAR_TEXT_FIELD, 'text',
-        'Austra');
-    // ensure message disappears
-    await vpn.waitForQuery(
-        queries.screenHome.serverListView.SEARCH_BAR_ERROR.hidden());
-  });
-
-  it('check the help sheet', async () => {
-    if (!(await vpn.isFeatureFlippedOn('helpSheets'))) {
-      await vpn.flipFeatureOn('helpSheets');
-    }
-
-    await vpn.waitForQueryAndClick(queries.screenHome.serverListView.HELP_BUTTON.visible());
-    await vpn.waitForQuery(queries.screenHome.serverListView.HELP_SHEET.opened());
-    await vpn.waitForQueryAndClick(queries.screenHome.serverListView.HELP_SHEET_LEARN_MORE_BUTTON.visible());
-    await vpn.waitForCondition(async () => {
+  
+      await vpn.waitForQueryAndClick(queries.screenHome.serverListView.HELP_BUTTON.visible());
+      await vpn.waitForQuery(queries.screenHome.serverListView.HELP_SHEET.opened());
+      await vpn.waitForQueryAndClick(queries.screenHome.serverListView.HELP_SHEET_LEARN_MORE_BUTTON.visible());
+      await vpn.waitForCondition(async () => {
         const url = await vpn.getLastUrl();
         return url === 'https://support.mozilla.org/kb/multi-hop-encrypt-your-data-twice-enhanced-security';
+      });
+      await vpn.waitForQueryAndClick(queries.screenHome.serverListView.HELP_SHEET_CLOSE_BUTTON.visible());
+      await vpn.waitForQuery(queries.screenHome.serverListView.HELP_SHEET.closed());
     });
-    await vpn.waitForQueryAndClick(queries.screenHome.serverListView.HELP_SHEET_CLOSE_BUTTON.visible());
-    await vpn.waitForQuery(queries.screenHome.serverListView.HELP_SHEET.closed());
+  });
+
+
+  describe('checking select location screen telemetry', function () {
+    // No Glean on WASM.
+    if(vpn.runningOnWasm()) {
+      return;
+    }
+
+    const selectLocationSheetTelemetryScreenId = "selection_location_info"
+
+    // const multiHopTelemetryScreenId = "select_location_multihop"
+
+    describe('checking select location screen telemetry (singlehop)', function () {
+      const singleHopTelemetryScreenId = "select_location_singlehop"
+
+      it('checking select location screen impression telemetry on server view open', async () => {
+        //Ensures the server view opens to multihop
+        await vpn.setSetting('serverData', '{"enter_city_name":"","enter_country_code":"","exit_city_name":"Melbourne","exit_country_code":"au"}');
+        await vpn.waitForQueryAndClick(queries.screenHome.SERVER_LIST_BUTTON.visible());
+        await vpn.waitForQuery(queries.screenHome.STACKVIEW.ready());
+
+        const selectionLocationSinglehopScreenEvents = await vpn.gleanTestGetValue("impression", "selectLocationSinglehopScreen", "main");
+        assert.equal(selectionLocationSinglehopScreenEvents.length, 1);
+        const selectionLocationSinglehopScreenEventsExtras = selectionLocationSinglehopScreenEvents[0].extra;
+        assert.equal(singleHopTelemetryScreenId, selectionLocationSinglehopScreenEventsExtras.screen);
+      });
+
+      it('checking select location screen impression telemetry on segment change', async () => {
+        //Open's the server view to multihop
+        await vpn.setSetting('serverData', '{"enter_city_name":"Atlanta","enter_country_code":"us","exit_city_name":"Melbourne","exit_country_code":"au"}');
+        await vpn.waitForQueryAndClick(queries.screenHome.SERVER_LIST_BUTTON.visible());
+        await vpn.waitForQuery(queries.screenHome.STACKVIEW.ready());
+        await vpn.waitForQueryAndClick(queries.screenHome.serverListView.SINGLEHOP_SELECTOR_TAB.visible());
+
+        const selectionLocationSinglehopScreenEvents = await vpn.gleanTestGetValue("impression", "selectLocationSinglehopScreen", "main");
+        assert.equal(selectionLocationSinglehopScreenEvents.length, 1);
+        const selectionLocationSinglehopScreenEventsExtras = selectionLocationSinglehopScreenEvents[0].extra;
+        assert.equal(singleHopTelemetryScreenId, selectionLocationSinglehopScreenEventsExtras.screen);
+      });
+
+      it('checking select location help tooltip telemetry', async () => {
+        if (!(await vpn.isFeatureFlippedOn('helpSheets'))) {
+          await vpn.flipFeatureOn('helpSheets');
+        }
+
+        await vpn.waitForQueryAndClick(queries.screenHome.SERVER_LIST_BUTTON.visible());
+        await vpn.waitForQuery(queries.screenHome.STACKVIEW.ready());
+
+        await vpn.waitForQueryAndClick(queries.screenHome.serverListView.HELP_BUTTON.visible());
+
+        const helpTooltipSelectedEvents = await vpn.gleanTestGetValue("interaction", "helpTooltipSelected", "main");
+        assert.equal(helpTooltipSelectedEvents.length, 1);
+        const helpTooltipSelectedEventsExtras = helpTooltipSelectedEvents[0].extra;
+        assert.equal(singleHopTelemetryScreenId, helpTooltipSelectedEventsExtras.screen);
+
+        await vpn.waitForQuery(queries.screenHome.serverListView.HELP_SHEET.opened());
+
+        const selectLocationInfoScreenEvents = await vpn.gleanTestGetValue("impression", "selectLocationInfoScreen", "main");
+        assert.equal(selectLocationInfoScreenEvents.length, 1);
+        const selectLocationInfoScreenEventsExtras = selectLocationInfoScreenEvents[0].extra;
+        assert.equal(selectLocationSheetTelemetryScreenId, selectLocationInfoScreenEventsExtras.screen);
+
+        await vpn.waitForQueryAndClick(queries.screenHome.serverListView.HELP_SHEET_LEARN_MORE_BUTTON.visible());
+
+        const learnMoreSelectedEvents = await vpn.gleanTestGetValue("interaction", "learnMoreSelected", "main");
+        assert.equal(learnMoreSelectedEvents.length, 1);
+        const learnMoreSelectedEventsExtras = learnMoreSelectedEvents[0].extra;
+        assert.equal(selectLocationSheetTelemetryScreenId, learnMoreSelectedEventsExtras.screen);
+      });
+    });
+
+    describe('checking select location screen telemetry (multihop)', function () {
+      const multiHopTelemetryScreenId = "select_location_multihop"
+
+      it('checking select location screen impression telemetry on server view open', async () => {
+        //Ensures the server view opens to multihop
+        await vpn.setSetting('serverData', '{"enter_city_name":"Atlanta","enter_country_code":"us","exit_city_name":"Melbourne","exit_country_code":"au"}');
+        await vpn.waitForQueryAndClick(queries.screenHome.SERVER_LIST_BUTTON.visible());
+        await vpn.waitForQuery(queries.screenHome.STACKVIEW.ready());
+
+        const selectionLocationMultihopScreenEvents = await vpn.gleanTestGetValue("impression", "selectLocationMultihopScreen", "main");
+        assert.equal(selectionLocationMultihopScreenEvents.length, 1);
+        const selectionLocationMultihopScreenEventsExtras = selectionLocationMultihopScreenEvents[0].extra;
+        assert.equal(multiHopTelemetryScreenId, selectionLocationMultihopScreenEventsExtras.screen);
+      });
+
+      it('checking select location screen impression telemetry on segment change', async () => {
+        //Open's the server view to singlehop
+        await vpn.setSetting('serverData', '{"enter_city_name":"","enter_country_code":"","exit_city_name":"Melbourne","exit_country_code":"au"}');
+        await vpn.waitForQueryAndClick(queries.screenHome.SERVER_LIST_BUTTON.visible());
+        await vpn.waitForQuery(queries.screenHome.STACKVIEW.ready());
+        await vpn.waitForQueryAndClick(queries.screenHome.serverListView.MULTIHOP_SELECTOR_TAB.visible());
+
+        const selectionLocationMultihopScreenEvents = await vpn.gleanTestGetValue("impression", "selectLocationMultihopScreen", "main");
+        assert.equal(selectionLocationMultihopScreenEvents.length, 1);
+        const selectionLocationMultihopScreenEventsExtras = selectionLocationMultihopScreenEvents[0].extra;
+        assert.equal(multiHopTelemetryScreenId, selectionLocationMultihopScreenEventsExtras.screen);
+      });
+
+      it('checking select location help tooltip telemetry', async () => {
+        if (!(await vpn.isFeatureFlippedOn('helpSheets'))) {
+          await vpn.flipFeatureOn('helpSheets');
+        }
+
+        //Open's the server view to multihop
+        await vpn.setSetting('serverData', '{"enter_city_name":"Atlanta","enter_country_code":"us","exit_city_name":"Melbourne","exit_country_code":"au"}');
+        await vpn.waitForQueryAndClick(queries.screenHome.SERVER_LIST_BUTTON.visible());
+        await vpn.waitForQuery(queries.screenHome.STACKVIEW.ready());
+
+        await vpn.waitForQueryAndClick(queries.screenHome.serverListView.HELP_BUTTON.visible());
+
+        //We only need to test the helpTooltipSelected event as it has a different extra key value (multihop instead of singlehop)
+        //Eventhing else related to the sheet is tested in the singlehop tests
+        const helpTooltipSelectedEvents = await vpn.gleanTestGetValue("interaction", "helpTooltipSelected", "main");
+        assert.equal(helpTooltipSelectedEvents.length, 1);
+        const helpTooltipSelectedEventsExtras = helpTooltipSelectedEvents[0].extra;
+        assert.equal(multiHopTelemetryScreenId, helpTooltipSelectedEventsExtras.screen);
+
+        await vpn.waitForQuery(queries.screenHome.serverListView.HELP_SHEET.opened());
+      });
+    });
+
   });
 
   // TODO: server list disabled when reached the device limit

--- a/tests/functional/testServers.js
+++ b/tests/functional/testServers.js
@@ -268,7 +268,7 @@ describe('Server', function() {
           queries.screenHome.serverListView.SEARCH_BAR_ERROR.hidden());
     });
   
-    it('check the selection location help sheet', async () => {
+    it('check the location help sheet', async () => {
       if (!(await vpn.isFeatureFlippedOn('helpSheets'))) {
         await vpn.flipFeatureOn('helpSheets');
       }
@@ -286,45 +286,43 @@ describe('Server', function() {
   });
 
 
-  describe('checking select location screen telemetry', function () {
+  describe('checking location screen telemetry', function () {
     // No Glean on WASM.
     if(vpn.runningOnWasm()) {
       return;
     }
 
-    const selectLocationSheetTelemetryScreenId = "selection_location_info"
+    const locationSheetTelemetryScreenId = "location_info"
 
-    // const multiHopTelemetryScreenId = "select_location_multihop"
+    describe('checking location screen telemetry (singlehop)', function () {
+      const singleHopTelemetryScreenId = "location_singlehop"
 
-    describe('checking select location screen telemetry (singlehop)', function () {
-      const singleHopTelemetryScreenId = "select_location_singlehop"
-
-      it('checking select location screen impression telemetry on server view open', async () => {
+      it('checking location screen impression telemetry on server view open', async () => {
         //Ensures the server view opens to multihop
         await vpn.setSetting('serverData', '{"enter_city_name":"","enter_country_code":"","exit_city_name":"Melbourne","exit_country_code":"au"}');
         await vpn.waitForQueryAndClick(queries.screenHome.SERVER_LIST_BUTTON.visible());
         await vpn.waitForQuery(queries.screenHome.STACKVIEW.ready());
 
-        const selectionLocationSinglehopScreenEvents = await vpn.gleanTestGetValue("impression", "selectLocationSinglehopScreen", "main");
-        assert.equal(selectionLocationSinglehopScreenEvents.length, 1);
-        const selectionLocationSinglehopScreenEventsExtras = selectionLocationSinglehopScreenEvents[0].extra;
-        assert.equal(singleHopTelemetryScreenId, selectionLocationSinglehopScreenEventsExtras.screen);
+        const locationSinglehopScreenEvents = await vpn.gleanTestGetValue("impression", "locationSinglehopScreen", "main");
+        assert.equal(locationSinglehopScreenEvents.length, 1);
+        const locationSinglehopScreenEventsExtras = locationSinglehopScreenEvents[0].extra;
+        assert.equal(singleHopTelemetryScreenId, locationSinglehopScreenEventsExtras.screen);
       });
 
-      it('checking select location screen impression telemetry on segment change', async () => {
+      it('checking location screen impression telemetry on segment change', async () => {
         //Open's the server view to multihop
         await vpn.setSetting('serverData', '{"enter_city_name":"Atlanta","enter_country_code":"us","exit_city_name":"Melbourne","exit_country_code":"au"}');
         await vpn.waitForQueryAndClick(queries.screenHome.SERVER_LIST_BUTTON.visible());
         await vpn.waitForQuery(queries.screenHome.STACKVIEW.ready());
         await vpn.waitForQueryAndClick(queries.screenHome.serverListView.SINGLEHOP_SELECTOR_TAB.visible());
 
-        const selectionLocationSinglehopScreenEvents = await vpn.gleanTestGetValue("impression", "selectLocationSinglehopScreen", "main");
-        assert.equal(selectionLocationSinglehopScreenEvents.length, 1);
-        const selectionLocationSinglehopScreenEventsExtras = selectionLocationSinglehopScreenEvents[0].extra;
-        assert.equal(singleHopTelemetryScreenId, selectionLocationSinglehopScreenEventsExtras.screen);
+        const locationSinglehopScreenEvents = await vpn.gleanTestGetValue("impression", "locationSinglehopScreen", "main");
+        assert.equal(locationSinglehopScreenEvents.length, 1);
+        const locationSinglehopScreenEventsExtras = locationSinglehopScreenEvents[0].extra;
+        assert.equal(singleHopTelemetryScreenId, locationSinglehopScreenEventsExtras.screen);
       });
 
-      it('checking select location help tooltip telemetry', async () => {
+      it('checking location help tooltip telemetry', async () => {
         if (!(await vpn.isFeatureFlippedOn('helpSheets'))) {
           await vpn.flipFeatureOn('helpSheets');
         }
@@ -341,46 +339,46 @@ describe('Server', function() {
 
         await vpn.waitForQuery(queries.screenHome.serverListView.HELP_SHEET.opened());
 
-        const selectLocationInfoScreenEvents = await vpn.gleanTestGetValue("impression", "selectLocationInfoScreen", "main");
-        assert.equal(selectLocationInfoScreenEvents.length, 1);
-        const selectLocationInfoScreenEventsExtras = selectLocationInfoScreenEvents[0].extra;
-        assert.equal(selectLocationSheetTelemetryScreenId, selectLocationInfoScreenEventsExtras.screen);
+        const locationInfoScreenEvents = await vpn.gleanTestGetValue("impression", "locationInfoScreen", "main");
+        assert.equal(locationInfoScreenEvents.length, 1);
+        const locationInfoScreenEventsExtras = locationInfoScreenEvents[0].extra;
+        assert.equal(locationSheetTelemetryScreenId, locationInfoScreenEventsExtras.screen);
 
         await vpn.waitForQueryAndClick(queries.screenHome.serverListView.HELP_SHEET_LEARN_MORE_BUTTON.visible());
 
         const learnMoreSelectedEvents = await vpn.gleanTestGetValue("interaction", "learnMoreSelected", "main");
         assert.equal(learnMoreSelectedEvents.length, 1);
         const learnMoreSelectedEventsExtras = learnMoreSelectedEvents[0].extra;
-        assert.equal(selectLocationSheetTelemetryScreenId, learnMoreSelectedEventsExtras.screen);
+        assert.equal(locationSheetTelemetryScreenId, learnMoreSelectedEventsExtras.screen);
       });
     });
 
-    describe('checking select location screen telemetry (multihop)', function () {
-      const multiHopTelemetryScreenId = "select_location_multihop"
+    describe('checking location screen telemetry (multihop)', function () {
+      const multiHopTelemetryScreenId = "location_multihop"
 
-      it('checking select location screen impression telemetry on server view open', async () => {
+      it('checking location screen impression telemetry on server view open', async () => {
         //Ensures the server view opens to multihop
         await vpn.setSetting('serverData', '{"enter_city_name":"Atlanta","enter_country_code":"us","exit_city_name":"Melbourne","exit_country_code":"au"}');
         await vpn.waitForQueryAndClick(queries.screenHome.SERVER_LIST_BUTTON.visible());
         await vpn.waitForQuery(queries.screenHome.STACKVIEW.ready());
 
-        const selectionLocationMultihopScreenEvents = await vpn.gleanTestGetValue("impression", "selectLocationMultihopScreen", "main");
-        assert.equal(selectionLocationMultihopScreenEvents.length, 1);
-        const selectionLocationMultihopScreenEventsExtras = selectionLocationMultihopScreenEvents[0].extra;
-        assert.equal(multiHopTelemetryScreenId, selectionLocationMultihopScreenEventsExtras.screen);
+        const locationMultihopScreenEvents = await vpn.gleanTestGetValue("impression", "locationMultihopScreen", "main");
+        assert.equal(locationMultihopScreenEvents.length, 1);
+        const locationMultihopScreenEventsExtras = locationMultihopScreenEvents[0].extra;
+        assert.equal(multiHopTelemetryScreenId, locationMultihopScreenEventsExtras.screen);
       });
 
-      it('checking select location screen impression telemetry on segment change', async () => {
+      it('checking location screen impression telemetry on segment change', async () => {
         //Open's the server view to singlehop
         await vpn.setSetting('serverData', '{"enter_city_name":"","enter_country_code":"","exit_city_name":"Melbourne","exit_country_code":"au"}');
         await vpn.waitForQueryAndClick(queries.screenHome.SERVER_LIST_BUTTON.visible());
         await vpn.waitForQuery(queries.screenHome.STACKVIEW.ready());
         await vpn.waitForQueryAndClick(queries.screenHome.serverListView.MULTIHOP_SELECTOR_TAB.visible());
 
-        const selectionLocationMultihopScreenEvents = await vpn.gleanTestGetValue("impression", "selectLocationMultihopScreen", "main");
-        assert.equal(selectionLocationMultihopScreenEvents.length, 1);
-        const selectionLocationMultihopScreenEventsExtras = selectionLocationMultihopScreenEvents[0].extra;
-        assert.equal(multiHopTelemetryScreenId, selectionLocationMultihopScreenEventsExtras.screen);
+        const locationMultihopScreenEvents = await vpn.gleanTestGetValue("impression", "locationMultihopScreen", "main");
+        assert.equal(locationMultihopScreenEvents.length, 1);
+        const locationMultihopScreenEventsExtras = locationMultihopScreenEvents[0].extra;
+        assert.equal(multiHopTelemetryScreenId, locationMultihopScreenEventsExtras.screen);
       });
 
       it('checking select location help tooltip telemetry', async () => {

--- a/tests/functional/testSettings.js
+++ b/tests/functional/testSettings.js
@@ -350,8 +350,6 @@ describe('Settings', function() {
         }
 
         const privacyHelpSheetTelemetryScreenId = "privacy_features_info"
-        const privacyHelpSheetLinkTelemetryActionValue = "select"
-        const privacyHelpSheetLinkTelemetryElementIdValue = "learn_more"
 
         await vpn.waitForQueryAndClick(queries.screenSettings.privacyView.HELP_BUTTON.visible());
 
@@ -369,12 +367,10 @@ describe('Settings', function() {
 
         await vpn.waitForQueryAndClick(queries.screenSettings.privacyView.HELP_SHEET_LEARN_MORE_BUTTON.visible());
 
-        const learnMoreClickedEvents = await vpn.gleanTestGetValue("interaction", "learnMoreClicked", "main");
-        assert.equal(learnMoreClickedEvents.length, 1);
-        const learnMoreClickedEventsExtras = learnMoreClickedEvents[0].extra;
-        assert.equal(privacyHelpSheetTelemetryScreenId, learnMoreClickedEventsExtras.screen);
-        assert.equal(privacyHelpSheetLinkTelemetryActionValue, learnMoreClickedEventsExtras.action);
-        assert.equal(privacyHelpSheetLinkTelemetryElementIdValue, learnMoreClickedEventsExtras.element_id);
+        const learnMoreSelectedEvents = await vpn.gleanTestGetValue("interaction", "learnMoreSelected", "main");
+        assert.equal(learnMoreSelectedEvents.length, 1);
+        const learnMoreSelectedEventsExtras = learnMoreSelectedEvents[0].extra;
+        assert.equal(privacyHelpSheetTelemetryScreenId, learnMoreSelectedEventsExtras.screen);
       });
     });
   });
@@ -658,8 +654,6 @@ describe('Settings', function() {
         }
 
         const dnsHelpSheetTelemetryScreenId = "dns_settings_info"
-        const dnsHelpSheetLinkTelemetryActionValue = "select"
-        const dnsHelpSheetLinkTelemetryElementIdValue = "learn_more"
 
         await vpn.waitForQueryAndClick(queries.screenSettings.appPreferencesView.dnsSettingsView.HELP_BUTTON.visible());
 
@@ -677,12 +671,10 @@ describe('Settings', function() {
 
         await vpn.waitForQueryAndClick(queries.screenSettings.appPreferencesView.dnsSettingsView.HELP_SHEET_LEARN_MORE_BUTTON.visible());
 
-        const learnMoreClickedEvents = await vpn.gleanTestGetValue("interaction", "learnMoreClicked", "main");
-        assert.equal(learnMoreClickedEvents.length, 1);
-        const learnMoreClickedEventsExtras = learnMoreClickedEvents[0].extra;
-        assert.equal(dnsHelpSheetTelemetryScreenId, learnMoreClickedEventsExtras.screen);
-        assert.equal(dnsHelpSheetLinkTelemetryActionValue, learnMoreClickedEventsExtras.action);
-        assert.equal(dnsHelpSheetLinkTelemetryElementIdValue, learnMoreClickedEventsExtras.element_id);
+        const learnMoreSelectedEvents = await vpn.gleanTestGetValue("interaction", "learnMoreSelected", "main");
+        assert.equal(learnMoreSelectedEvents.length, 1);
+        const learnMoreSelectedEventsExtras = learnMoreSelectedEvents[0].extra;
+        assert.equal(dnsHelpSheetTelemetryScreenId, learnMoreSelectedEventsExtras.screen);
       });
     });
   });

--- a/tests/functional/testSettings.js
+++ b/tests/functional/testSettings.js
@@ -319,7 +319,6 @@ describe('Settings', function() {
       }
   
       await vpn.waitForQueryAndClick(queries.screenSettings.privacyView.HELP_BUTTON.visible());
-      await vpn.waitForQuery(queries.screenSettings.privacyView.HELP_SHEET.visible());
       await vpn.waitForQuery(queries.screenSettings.privacyView.HELP_SHEET.opened());
       await vpn.waitForQueryAndClick(queries.screenSettings.privacyView.HELP_SHEET_LEARN_MORE_BUTTON.visible());
       await vpn.waitForCondition(async () => {
@@ -328,6 +327,55 @@ describe('Settings', function() {
       });
       await vpn.waitForQueryAndClick(queries.screenSettings.privacyView.HELP_SHEET_CLOSE_BUTTON.visible());
       await vpn.waitForQuery(queries.screenSettings.privacyView.HELP_SHEET.closed());
+    });
+    
+    describe('Checking privacy screen telemetry', function () {
+      // No Glean on WASM.
+      if(vpn.runningOnWasm()) {
+        return;
+      }
+
+      const privacyTelemetryScreenId = "privacy_features"
+
+      it('Checking privacy screen impression telemetry', async () => {
+        const privacyFeaturesSreenEvents = await vpn.gleanTestGetValue("impression", "privacyFeaturesScreen", "main");
+        assert.equal(privacyFeaturesSreenEvents.length, 1);
+        const privacyFeaturesSreenEventsExtras = privacyFeaturesSreenEvents[0].extra;
+        assert.equal(privacyTelemetryScreenId, privacyFeaturesSreenEventsExtras.screen);
+      });
+
+      it('Checking privacy help sheet telemetry', async () => {
+        if (!(await vpn.isFeatureFlippedOn('helpSheets'))) {
+          await vpn.flipFeatureOn('helpSheets');
+        }
+
+        const privacyHelpSheetTelemetryScreenId = "privacy_features_info"
+        const privacyHelpSheetLinkTelemetryActionValue = "select"
+        const privacyHelpSheetLinkTelemetryElementIdValue = "learn_more"
+
+        await vpn.waitForQueryAndClick(queries.screenSettings.privacyView.HELP_BUTTON.visible());
+
+        const helpTooltipSelectedEvents = await vpn.gleanTestGetValue("interaction", "helpTooltipSelected", "main");
+        assert.equal(helpTooltipSelectedEvents.length, 1);
+        const helpTooltipSelectedEventsExtras = helpTooltipSelectedEvents[0].extra;
+        assert.equal(privacyTelemetryScreenId, helpTooltipSelectedEventsExtras.screen);
+
+        await vpn.waitForQuery(queries.screenSettings.privacyView.HELP_SHEET.opened());
+
+        const privacyFeaturesInfoScreenEvents = await vpn.gleanTestGetValue("impression", "privacyFeaturesInfoScreen", "main");
+        assert.equal(privacyFeaturesInfoScreenEvents.length, 1);
+        const privacyFeaturesInfoScreenEventsExtras = privacyFeaturesInfoScreenEvents[0].extra;
+        assert.equal(privacyHelpSheetTelemetryScreenId, privacyFeaturesInfoScreenEventsExtras.screen);
+
+        await vpn.waitForQueryAndClick(queries.screenSettings.privacyView.HELP_SHEET_LEARN_MORE_BUTTON.visible());
+
+        const learnMoreClickedEvents = await vpn.gleanTestGetValue("interaction", "learnMoreClicked", "main");
+        assert.equal(learnMoreClickedEvents.length, 1);
+        const learnMoreClickedEventsExtras = learnMoreClickedEvents[0].extra;
+        assert.equal(privacyHelpSheetTelemetryScreenId, learnMoreClickedEventsExtras.screen);
+        assert.equal(privacyHelpSheetLinkTelemetryActionValue, learnMoreClickedEventsExtras.action);
+        assert.equal(privacyHelpSheetLinkTelemetryElementIdValue, learnMoreClickedEventsExtras.element_id);
+      });
     });
   });
 
@@ -579,7 +627,6 @@ describe('Settings', function() {
       }
   
       await vpn.waitForQueryAndClick(queries.screenSettings.appPreferencesView.dnsSettingsView.HELP_BUTTON.visible());
-      await vpn.waitForQuery(queries.screenSettings.appPreferencesView.dnsSettingsView.HELP_SHEET.visible());
       await vpn.waitForQuery(queries.screenSettings.appPreferencesView.dnsSettingsView.HELP_SHEET.opened());
       await vpn.waitForQueryAndClick(queries.screenSettings.appPreferencesView.dnsSettingsView.HELP_SHEET_LEARN_MORE_BUTTON.visible());
       await vpn.waitForCondition(async () => {
@@ -588,6 +635,55 @@ describe('Settings', function() {
       });
       await vpn.waitForQueryAndClick(queries.screenSettings.appPreferencesView.dnsSettingsView.HELP_SHEET_CLOSE_BUTTON.visible());
       await vpn.waitForQuery(queries.screenSettings.appPreferencesView.dnsSettingsView.HELP_SHEET.closed());
+    });
+
+    describe('Checking DNS screen telemetry', function () {
+      // No Glean on WASM.
+      if(vpn.runningOnWasm()) {
+        return;
+      }
+
+      const dnsTelemetryScreenId = "dns_settings"
+
+      it('Checking DNS screen impression telemetry', async () => {
+        const dnsSettingsScreenEvents = await vpn.gleanTestGetValue("impression", "dnsSettingsScreen", "main");
+        assert.equal(dnsSettingsScreenEvents.length, 1);
+        const dnsSettingsScreenEventExtras = dnsSettingsScreenEvents[0].extra;
+        assert.equal(dnsTelemetryScreenId, dnsSettingsScreenEventExtras.screen);
+      });
+
+      it('Checking DNS help sheet telemetry', async () => {
+        if (!(await vpn.isFeatureFlippedOn('helpSheets'))) {
+          await vpn.flipFeatureOn('helpSheets');
+        }
+
+        const dnsHelpSheetTelemetryScreenId = "dns_settings_info"
+        const dnsHelpSheetLinkTelemetryActionValue = "select"
+        const dnsHelpSheetLinkTelemetryElementIdValue = "learn_more"
+
+        await vpn.waitForQueryAndClick(queries.screenSettings.appPreferencesView.dnsSettingsView.HELP_BUTTON.visible());
+
+        const helpTooltipSelectedEvents = await vpn.gleanTestGetValue("interaction", "helpTooltipSelected", "main");
+        assert.equal(helpTooltipSelectedEvents.length, 1);
+        const helpTooltipSelectedEventsExtras = helpTooltipSelectedEvents[0].extra;
+        assert.equal(dnsTelemetryScreenId, helpTooltipSelectedEventsExtras.screen);
+
+        await vpn.waitForQuery(queries.screenSettings.appPreferencesView.dnsSettingsView.HELP_SHEET.opened());
+
+        const dnsSettingsInfoScreenEvents = await vpn.gleanTestGetValue("impression", "dnsSettingsInfoScreen", "main");
+        assert.equal(dnsSettingsInfoScreenEvents.length, 1);
+        const dnsSettingsInfoScreenEventsExtras = dnsSettingsInfoScreenEvents[0].extra;
+        assert.equal(dnsHelpSheetTelemetryScreenId, dnsSettingsInfoScreenEventsExtras.screen);
+
+        await vpn.waitForQueryAndClick(queries.screenSettings.appPreferencesView.dnsSettingsView.HELP_SHEET_LEARN_MORE_BUTTON.visible());
+
+        const learnMoreClickedEvents = await vpn.gleanTestGetValue("interaction", "learnMoreClicked", "main");
+        assert.equal(learnMoreClickedEvents.length, 1);
+        const learnMoreClickedEventsExtras = learnMoreClickedEvents[0].extra;
+        assert.equal(dnsHelpSheetTelemetryScreenId, learnMoreClickedEventsExtras.screen);
+        assert.equal(dnsHelpSheetLinkTelemetryActionValue, learnMoreClickedEventsExtras.action);
+        assert.equal(dnsHelpSheetLinkTelemetryElementIdValue, learnMoreClickedEventsExtras.element_id);
+      });
     });
   });
 


### PR DESCRIPTION
## Description

- Add telemetry for help sheets
- Add impression telemetry for Devices, app exclusions, dns settings, privacy features, and select location screens
- Add functional tests for added telemetry

Miro board reference: https://miro.com/app/board/uXjVMk7nhvA=/

**Needs data review**

## Reference

[VPN-5092: Implement telemetry](https://mozilla-hub.atlassian.net/browse/VPN-5092)