### PR TITLE
Update RPM build to Fedora 39

### DIFF
--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -46,7 +46,7 @@ jobs:
     needs: source-bundle
     runs-on: ubuntu-latest
     container:
-      image: fedora:37
+      image: fedora:39
 
     steps:
       - name: Download Source Package
@@ -56,8 +56,8 @@ jobs:
 
       - name: Install Build Dependencies
         run: |
-          yum -y install rpm-build rpmdevtools yum-utils
-          yum-builddep -y mozillavpn.spec
+          dnf -y install rpmdevtools
+          dnf -y builddep mozillavpn.spec
 
       - name: Building package
         shell: bash

--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Install Build Dependencies
         run: |
-          dnf -y install rpmdevtools
+          dnf -y install rpmdevtools 'dnf-command(builddep)'
           dnf -y builddep mozillavpn.spec
 
       - name: Building package


### PR DESCRIPTION
Fedora 37 is EOL since 2023-12-05 (cf. https://docs.fedoraproject.org/en-US/releases/eol/).

Current builds (tried e.g. `mozillavpn-2.20.0~build20240125-1.x86_64`
downloaded from https://github.com/mozilla-mobile/mozilla-vpn-client/actions/runs/7661282763)
depends upon `libQt6Network.so.6(Qt_6.5_PRIVATE_API)(64bit)` but since
Fedora 39 is on Qt 6.6 no current package provides that symbol.

Also update from YUM to DNF:
* https://fedoraproject.org/wiki/Yum_to_DNF_Cheatsheet
* https://www.redhat.com/sysadmin/create-rpm-package