### PR TITLE
Nit: fix inspector paths

### DIFF
--- a/.github/workflows/gh_pages.yaml
+++ b/.github/workflows/gh_pages.yaml
@@ -97,15 +97,14 @@ jobs:
       - name: Building
         shell: bash
         run: |
-          cd tools/inspector
           npm install
-          npm run build
+          npm run inspector:build
 
       - name: Uploading
         uses: actions/upload-artifact@v3
         with:
             name: Inspector Build
-            path: tools/inspector/dist
+            path: tools/inspector/dist/app
 
   translationsreport:
     name: Add Translations Report

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "languages:update": "cd ./tools/languagelocalizer/ && node languageLocalizer.js",
     "translationsreport:start": "cd ./tools/translationsreport/app && npm run start",
     "translationsreport:build": "cd ./tools/translationsreport/app && npm run build",
+    "inspector:start": "npm run start -w ./tools/inspector/",
+    "inspector:build": "npm run build -w ./tools/inspector/",
     "docs:serve": "npm install && npm run start -w tools/mozillavpn.dev",
     "docs:build": "npm install && npm run build -w tools/mozillavpn.dev"
   },

--- a/tools/inspector/package.json
+++ b/tools/inspector/package.json
@@ -22,6 +22,7 @@
     }
   },
   "scripts": {
+    "start": "parcel index.html",
     "dev": "parcel index.html",
     "build": "parcel build",
     "lint": "eslint **/*.js"


### PR DESCRIPTION
## Description
We recently changed so that the inspector can be build as a library and the standalone client. 
Therefore we also need to update the path  as we now have`/dist/lib ; /dist/app`
