### PR TITLE
VPN-6129: Android Daemon - skip telemetry on silent server switch

### DIFF
--- a/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/VPNService.kt
+++ b/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/VPNService.kt
@@ -269,7 +269,7 @@ class VPNService : android.net.VpnService() {
         return intent
     }
 
-    fun turnOn(json: JSONObject?, useFallbackServer: Boolean = false, source: String? = null, shouldSkipMetricsBecauseReconnect = false) {
+    fun turnOn(json: JSONObject?, useFallbackServer: Boolean = false, source: String? = null, shouldSkipMetricsBecauseReconnect: Boolean = false) {
         if (json == null) {
             throw Error("no json config provided")
         }


### PR DESCRIPTION
## Description

In investigating VPN-6129, I noticed that there were far fewer `end` pings as `start` pings for android daemon telemetry. (Over 10x difference. This was not true for iOS.) 

I believe this is due to silent server switch recording start telemetry but not end telemetry. (When the silent switch comes from the app, telemetry is not currently recorded - but when it comes from the daemon, it is.) This disconnect between when start and end pings are recorded causes this difference. This PR skips telemetry for reconnects from silent server switches.

While we could do a hacky change to the config to take advantage of the existing `shouldRecordMetrics`, I'm not sure how that state gets wiped/updated, and am reluctant to introduce hacky changes to something so core to the experience.

## Reference

https://mozilla-hub.atlassian.net/browse/VPN-6129

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
