### PR TITLE
Set Inspector to nosignal/stable or stable for UI purposes

### DIFF
--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -2171,6 +2171,17 @@ void MozillaVPN::registerInspectorCommands() {
         bool forceDisconnection = byteArray.contains("true");
         MozillaVPN::instance()->networkWatcher()->simulateDisconnection(
             forceDisconnection);
+        if (forceDisconnection) {
+          MozillaVPN::instance()
+              ->connectionHealth()
+              ->overwriteStabilityForInspector(
+                  ConnectionHealth::ConnectionStability::NoSignal);
+        } else {
+          MozillaVPN::instance()
+              ->connectionHealth()
+              ->overwriteStabilityForInspector(
+                  ConnectionHealth::ConnectionStability::Stable);
+        }
         return QJsonObject();
       });
 


### PR DESCRIPTION
## Description

The existing logic simulates disconnection under the hood by returning "Disconnected" as the reachability value but doesn't seem to reflect in the Inspector UI that we are in NoSignal. The reachability code seems to work as expected otherwise so I think this is a Inspector limitation and we need to specifically set the Connection Health value.

## Reference

n/a

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
