### PR TITLE
VPN-5844: Re-enable Sentry on production iOS

### DIFF
--- a/src/feature/featurelist.h
+++ b/src/feature/featurelist.h
@@ -165,7 +165,7 @@ FEATURE(sentry,                     // Feature ID
         FeatureCallback_true,       // Can be flipped on
         FeatureCallback_true,       // Can be flipped off
         QStringList(),              // feature dependencies
-        FeatureCallback_sentry)
+        FeatureCallback_true)
 
 FEATURE(serverUnavailableNotification,      // Feature ID
         "Server unavailable notification",  // Feature name

--- a/src/feature/featurelistcallback.h
+++ b/src/feature/featurelistcallback.h
@@ -47,14 +47,6 @@ bool FeatureCallback_annualUpgrade() {
   return true;
 }
 
-bool FeatureCallback_sentry() {
-#if defined(MZ_IOS)
-  return FeatureCallback_inStaging();
-#else
-  return true;
-#endif
-}
-
 bool FeatureCallback_captivePortal() {
 #if defined(MZ_LINUX) || defined(MZ_MACOS) || defined(MZ_WINDOWS) || \
     defined(MZ_DUMMY) || defined(MZ_WASM)


### PR DESCRIPTION
## Description

This PR re-enables Sentry on production iOS (VPN-5844).

