### PR TITLE
VPN-6145 Remove deactivate() when not needed

### DIFF
--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -263,11 +263,6 @@ void Controller::handshakeTimeout() {
 
   emit handshakeFailed(hop.m_serverPublicKey);
 
-  if (m_nextStep != None) {
-    deactivate();
-    return;
-  }
-
   // Try again, again if there are sufficient retries left.
   ++m_connectionRetry;
   emit connectionRetryChanged();
@@ -695,11 +690,6 @@ void Controller::connected(const QString& pubkey,
     m_timer.start(TIMER_MSEC);
   } else {
     resetConnectedTime();
-  }
-
-  if (m_nextStep != None) {
-    deactivate();
-    return;
   }
 }
 


### PR DESCRIPTION
## Description

As a result of auditing all calls to deactivate() in the client code, the following 2 calls to `deactivate()` are flagged to be removed since they can disable the VPN without the user explicitly being aware of this.

- [controller.cpp#701](https://searchfox.org/mozilla-vpn-client/source/src/controller.cpp#701): we’re calling deactivate() Controller::connected(...) if there are no next steps. We should not be deactivating here. 
- [controller.cpp#267](https://searchfox.org/mozilla-vpn-client/source/src/controller.cpp#267): gets called in `controller::handshakeTimeout()`. We can end up in handshake timeout for example if in a multihop connection there are issues connecting to the entry or exit server, but we don’t know and can’t tell why it failed and we shouldn’t just automatically deactivate.

To view the complete audit list, please view [Google Doc](https://docs.google.com/document/d/1NZ10hVaxLhKf8b_FoSjI59wDsNUBNjodsf47HzAWepI/edit).
## Reference

    https://mozilla-hub.atlassian.net/browse/VPN-6145


