### PR TITLE
VPN-6145 Only deactivate if next step is update, quit or disconnect

### DIFF
--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -263,6 +263,11 @@ void Controller::handshakeTimeout() {
 
   emit handshakeFailed(hop.m_serverPublicKey);
 
+  if (m_nextStep == Quit || m_nextStep == Disconnect || m_nextStep == Update) {
+    deactivate();
+    return;
+  }
+
   // Try again, again if there are sufficient retries left.
   ++m_connectionRetry;
   emit connectionRetryChanged();
@@ -690,6 +695,11 @@ void Controller::connected(const QString& pubkey,
     m_timer.start(TIMER_MSEC);
   } else {
     resetConnectedTime();
+  }
+
+  if (m_nextStep == Quit || m_nextStep == Disconnect || m_nextStep == Update) {
+    deactivate();
+    return;
   }
 }
 


### PR DESCRIPTION
## Description

This is a follow up on [this PR](https://github.com/mozilla-mobile/mozilla-vpn-client/pull/9056). Rather than removing the call to `deactivate()` entirely, we should check and still continue to deactivate if the next step is quit, update or disconnect. 

## Reference

    https://mozilla-hub.atlassian.net/browse/VPN-6145

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
