### PR TITLE
VPN-6050: Change checkboxes to toggles

### DIFF
--- a/nebula/ui/components/CMakeLists.txt
+++ b/nebula/ui/components/CMakeLists.txt
@@ -88,6 +88,7 @@ qt_add_qml_module(components
          MZStepProgressBar.qml
          MZStepProgressBarDelegate.qml
          MZStepNavigation.qml
+         MZToggleRow.qml
          navigationBar/MZBottomNavigationBar.qml
          navigationBar/MZBottomNavigationBarButton.qml
          navigator/MZNavigatorLoader.qml

--- a/nebula/ui/components/MZSettingsToggle.qml
+++ b/nebula/ui/components/MZSettingsToggle.qml
@@ -24,8 +24,8 @@ CheckBox {
     // Prevents 'TypeError: Property 'styleFont' of object MZUIStates_QMLTYPE_14(0x600002d582a0) is not a function' 
     font.pixelSize: undefined
 
-    height: MZTheme.theme.vSpacing
-    width: 45
+    implicitHeight: MZTheme.theme.toggleHeight
+    implicitWidth: MZTheme.theme.toggleWidth
     states: [
         State {
             when: checked
@@ -57,12 +57,6 @@ CheckBox {
             }
         }
     ]
-
-    MZToolTip {
-        id: toolTip
-        text: accessibleName
-    }
-
 
     transitions: [
         Transition {
@@ -178,5 +172,6 @@ CheckBox {
         colorScheme: toggleColor
         radius: height / 2
         showFocusRings: false
+        startingState: checked ? MZTheme.theme.vpnToggleConnected.defaultColor : MZTheme.theme.vpnToggleDisconnected.defaultColor
     }
 }

--- a/nebula/ui/components/MZSettingsToggle.qml
+++ b/nebula/ui/components/MZSettingsToggle.qml
@@ -14,10 +14,8 @@ CheckBox {
     property var toggleColor: MZTheme.theme.vpnToggleConnected
     property var uiState: MZTheme.theme.uiState
     property alias forceFocus: vpnSettingsToggle.focus
-    property var toolTipTitle
     property string accessibleName
 
-    onClicked: toolTip.hide()
     onActiveFocusChanged: if(activeFocus) MZUiUtils.scrollToComponent(vpnSettingsToggle)
 
     // Workaround for https://bugreports.qt.io/browse/QTBUG-101026
@@ -141,12 +139,12 @@ CheckBox {
     focusPolicy: Qt.StrongFocus
 
     Keys.onReleased: event => {
-        if (event.key === Qt.Key_Return)
+        if (event.key === Qt.Key_Return || event.key === Qt.Key_Space)
             uiPlaceholder.state = uiState.stateDefault;
     }
 
     Keys.onPressed: event => {
-        if (event.key === Qt.Key_Return || event.key === Qt.Key_Space)
+        if (event.key === Qt.Key_Return)
             uiPlaceholder.state = uiState.statePressed;
     }
 

--- a/nebula/ui/components/MZToggleCard.qml
+++ b/nebula/ui/components/MZToggleCard.qml
@@ -13,7 +13,6 @@ Item {
     property alias sublabelText: sublabel.text
     property alias toggleEnabled: toggle.enabled
     property alias toggleChecked: toggle.checked
-    property alias toolTipTitleText: toggle.toolTipTitle
     property alias toggleObjectName: toggle.objectName
 
     MZDropShadowWithStates {

--- a/nebula/ui/components/MZToggleRow.qml
+++ b/nebula/ui/components/MZToggleRow.qml
@@ -61,6 +61,7 @@ RowLayout {
 
     MZSettingsToggle {
         id: toggle
+        objectName: "toggle"
 
         Layout.alignment: Qt.AlignTop
 

--- a/nebula/ui/components/MZToggleRow.qml
+++ b/nebula/ui/components/MZToggleRow.qml
@@ -1,0 +1,71 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import QtQuick 2.5
+import QtQuick.Layouts 1.14
+
+import Mozilla.Shared 1.0
+
+RowLayout {
+    id: toggleRow
+
+    property alias labelText: label.text
+    property alias subLabelText: subLabel.text
+    property alias checked: toggle.checked
+    property alias showDivider: divider.visible
+    property int dividerTopMargin
+
+    signal clicked()
+
+    spacing: 16
+
+    ColumnLayout {
+        Layout.fillWidth: true
+        Layout.alignment: Qt.AlignTop
+
+        spacing: 0
+
+        MZInterLabel {
+            id: label
+
+            Layout.fillWidth: true
+
+            text: labelText
+            color: MZTheme.theme.fontColorDark
+            horizontalAlignment: Text.AlignLeft
+            visible: !!text.length
+        }
+
+        MZTextBlock {
+            id: subLabel
+
+            Layout.fillWidth: true
+
+            font.pixelSize: MZTheme.theme.fontSizeSmall
+            visible: !!text.length
+            wrapMode: Text.Wrap
+            verticalAlignment: Text.AlignVCenter
+        }
+
+        Rectangle {
+            id: divider
+
+            Layout.topMargin: dividerTopMargin
+            Layout.fillWidth: true
+            Layout.preferredHeight: 1
+
+            color: MZTheme.colors.grey10
+        }
+    }
+
+    MZSettingsToggle {
+        id: toggle
+
+        Layout.alignment: Qt.AlignTop
+
+        onClicked: toggleRow.clicked()
+
+        accessibleName: labelText
+    }
+}

--- a/nebula/ui/themes/main/theme.js
+++ b/nebula/ui/themes/main/theme.js
@@ -120,6 +120,7 @@ theme.maxZLevel = 10
 
 theme.toggleHeight = 24
 theme.toggleWidth = 45
+theme.toggleRowDividerSpacing = 16
 
 
 theme.onBoardingGradient = {

--- a/nebula/ui/themes/main/theme.js
+++ b/nebula/ui/themes/main/theme.js
@@ -118,6 +118,9 @@ theme.lightFocusBorder = '#d5d3e0';
 
 theme.maxZLevel = 10
 
+theme.toggleHeight = 24
+theme.toggleWidth = 45
+
 
 theme.onBoardingGradient = {
   'start': '#472C87',

--- a/src/translations/strings.yaml
+++ b/src/translations/strings.yaml
@@ -572,10 +572,10 @@ onboarding:
   progressBarAccessibilityStepIncomplete2:
     value: "Onboarding step “%1” (%2 of %3)"
     comment: Accessibility read out for incomplete future steps in the step progress bar. %1 is the name of the step. %2 is the index of the current step. %3 is the total number of steps.
-  dataSlideHeader: Data collection and use
-  dataSlideBody: We strive to provide you with choices and collect only the technical data we need to improve Mozilla VPN. Sharing data with Mozilla is optional.
-  dataSlideCheckboxLabel: Mozilla may collect technical data about my use of Mozilla VPN.
-  dataSlideLearnMoreCaption: Learn more about what data Mozilla collects and how it’s used
+  dataSlideHeader2: Data collection
+  dataSlideBody2: Help us improve Mozilla VPN by sharing crash reports, diagnostics, and product usage data. We never collect data about your online activity while using the VPN.
+  dataSlideToggleLabel: Share technical data
+  dataSlideLearnMoreCaption2: Learn more about data collection
   dataSlidePrivacyLinkLabel: Mozilla VPN Privacy Notice
   privacySlideHeader: Get more privacy
   privacySlideBody: Use these features for more protection. They may cause issues on some sites, so you can turn them off anytime in settings.

--- a/src/ui/screens/onboarding/OnboardingDataSlide.qml
+++ b/src/ui/screens/onboarding/OnboardingDataSlide.qml
@@ -58,8 +58,6 @@ ColumnLayout {
         MZSettingsToggle {
             objectName: "dataCollectionToggle"
 
-            implicitHeight: 24
-            implicitWidth: 45
             checked: MZSettings.onboardingDataCollectionEnabled
             onClicked: MZSettings.onboardingDataCollectionEnabled = !MZSettings.onboardingDataCollectionEnabled
             accessibleName: shareDataLabel.text

--- a/src/ui/screens/onboarding/OnboardingDataSlide.qml
+++ b/src/ui/screens/onboarding/OnboardingDataSlide.qml
@@ -56,7 +56,7 @@ ColumnLayout {
         }
 
         MZSettingsToggle {
-            //        objectName: "dataCollectionCheckBox"
+            objectName: "dataCollectionToggle"
 
             implicitHeight: 24
             implicitWidth: 45

--- a/src/ui/screens/onboarding/OnboardingDataSlide.qml
+++ b/src/ui/screens/onboarding/OnboardingDataSlide.qml
@@ -21,39 +21,49 @@ ColumnLayout {
 
     MZHeadline {
         Layout.topMargin: MZTheme.theme.vSpacing
-        Layout.leftMargin: MZTheme.theme.windowMargin * 2
-        Layout.rightMargin: MZTheme.theme.windowMargin * 2
+        Layout.leftMargin: MZTheme.theme.windowMargin * 1.5
+        Layout.rightMargin: MZTheme.theme.windowMargin * 1.5
         Layout.fillWidth: true
 
-        text: MZI18n.OnboardingDataSlideHeader
+        text: MZI18n.OnboardingDataSlideHeader2
         horizontalAlignment: Text.AlignLeft
     }
 
     MZInterLabel {
         Layout.topMargin: 8
-        Layout.leftMargin: MZTheme.theme.windowMargin * 2
-        Layout.rightMargin: MZTheme.theme.windowMargin * 2
+        Layout.leftMargin: MZTheme.theme.windowMargin * 1.5
+        Layout.rightMargin: MZTheme.theme.windowMargin * 1.5
         Layout.fillWidth: true
 
-        text: MZI18n.OnboardingDataSlideBody
+        text: MZI18n.OnboardingDataSlideBody2
         horizontalAlignment: Text.AlignLeft
         color: MZTheme.theme.fontColor
    }
 
-    MZCheckBoxRow {
-        objectName: "dataCollectionCheckBox"
-
-        Layout.topMargin: MZUiUtils.isMobile() ? MZTheme.theme.vSpacing * 1.5 : MZTheme.theme.vSpacing
-        Layout.leftMargin: MZTheme.theme.windowMargin * 2
-        Layout.rightMargin: MZTheme.theme.windowMargin * 2
+    RowLayout {
+        Layout.topMargin: MZTheme.theme.vSpacingSmall
+        Layout.leftMargin: MZTheme.theme.windowMargin * 1.5
+        Layout.rightMargin: MZTheme.theme.windowMargin * 1.5
         Layout.fillWidth: true
 
-        leftMargin: 0
-        subLabelText: MZI18n.OnboardingDataSlideCheckboxLabel
-        showDivider: false
-        isChecked: MZSettings.onboardingDataCollectionEnabled
+        MZBoldInterLabel {
+            id: shareDataLabel
+            Layout.fillWidth: true
 
-        onClicked: MZSettings.onboardingDataCollectionEnabled = !MZSettings.onboardingDataCollectionEnabled
+            text: MZI18n.OnboardingDataSlideToggleLabel
+            font.pixelSize: MZTheme.theme.fontSize
+            lineHeight: MZTheme.theme.labelLineHeight
+        }
+
+        MZSettingsToggle {
+            //        objectName: "dataCollectionCheckBox"
+
+            implicitHeight: 24
+            implicitWidth: 45
+            checked: MZSettings.onboardingDataCollectionEnabled
+            onClicked: MZSettings.onboardingDataCollectionEnabled = !MZSettings.onboardingDataCollectionEnabled
+            accessibleName: shareDataLabel.text
+        }
     }
 
     Item {
@@ -95,7 +105,7 @@ ColumnLayout {
         Layout.rightMargin: MZTheme.theme.windowMargin * 2
         Layout.fillWidth: true
 
-        text: MZI18n.OnboardingDataSlideLearnMoreCaption
+        text: MZI18n.OnboardingDataSlideLearnMoreCaption2
         color: MZTheme.theme.fontColor
    }
 

--- a/src/ui/screens/onboarding/OnboardingDevicesSlide.qml
+++ b/src/ui/screens/onboarding/OnboardingDevicesSlide.qml
@@ -23,8 +23,8 @@ ColumnLayout {
 
     MZHeadline {
         Layout.topMargin: MZTheme.theme.windowMargin * 1.5
-        Layout.leftMargin: MZTheme.theme.windowMargin * 2
-        Layout.rightMargin: MZTheme.theme.windowMargin * 2
+        Layout.leftMargin: MZTheme.theme.windowMargin * 1.5
+        Layout.rightMargin: MZTheme.theme.windowMargin * 1.5
 
         Layout.fillWidth: true
 
@@ -34,8 +34,8 @@ ColumnLayout {
 
     MZInterLabel {
         Layout.topMargin: 8
-        Layout.leftMargin: MZTheme.theme.windowMargin * 2
-        Layout.rightMargin: MZTheme.theme.windowMargin * 2
+        Layout.leftMargin: MZTheme.theme.windowMargin * 1.5
+        Layout.rightMargin: MZTheme.theme.windowMargin * 1.5
         Layout.fillWidth: true
 
         text: MZUiUtils.isMobile() ? MZI18n.OnboardingDevicesSlideBodyMobile : MZI18n.OnboardingDevicesSlideBody2
@@ -44,9 +44,9 @@ ColumnLayout {
     }
 
     RowLayout {
-        Layout.topMargin: 16
-        Layout.leftMargin: MZTheme.theme.windowMargin * 2
-        Layout.rightMargin: MZTheme.theme.windowMargin * 2
+        Layout.topMargin: MZTheme.theme.vSpacingSmall
+        Layout.leftMargin: MZTheme.theme.windowMargin * 1.5
+        Layout.rightMargin: MZTheme.theme.windowMargin * 1.5
 
         MZBoldInterLabel {
             Layout.alignment: Qt.AlignVCenter

--- a/src/ui/screens/onboarding/OnboardingPrivacySlide.qml
+++ b/src/ui/screens/onboarding/OnboardingPrivacySlide.qml
@@ -23,8 +23,8 @@ ColumnLayout {
 
     MZHeadline {
         Layout.topMargin: MZTheme.theme.windowMargin * 1.5
-        Layout.leftMargin: MZTheme.theme.windowMargin * 2
-        Layout.rightMargin: MZTheme.theme.windowMargin * 2
+        Layout.leftMargin: MZTheme.theme.windowMargin * 1.5
+        Layout.rightMargin: MZTheme.theme.windowMargin * 1.5
 
         Layout.fillWidth: true
 
@@ -34,8 +34,8 @@ ColumnLayout {
 
     MZInterLabel {
         Layout.topMargin: 8
-        Layout.leftMargin: MZTheme.theme.windowMargin * 2
-        Layout.rightMargin: MZTheme.theme.windowMargin * 2
+        Layout.leftMargin: MZTheme.theme.windowMargin * 1.5
+        Layout.rightMargin: MZTheme.theme.windowMargin * 1.5
         Layout.fillWidth: true
 
         text: MZI18n.OnboardingPrivacySlideBody
@@ -44,12 +44,13 @@ ColumnLayout {
     }
 
     PrivacyFeaturesList {
-        Layout.topMargin: MZUiUtils.isMobile() ? MZTheme.theme.vSpacing * 1.5 : MZTheme.theme.vSpacing
-        Layout.leftMargin: 32
-        Layout.rightMargin: 32
+        Layout.topMargin: MZTheme.theme.vSpacing
+        Layout.leftMargin: MZTheme.theme.windowMargin * 1.5
+        Layout.rightMargin: MZTheme.theme.windowMargin * 1.5
         Layout.fillWidth: true
 
         isOnboarding: true
+        dividerSpacing: 8
         telemetryScreenId: root.telemetryScreenId
     }
 

--- a/src/ui/screens/onboarding/OnboardingStartSlideDesktop.qml
+++ b/src/ui/screens/onboarding/OnboardingStartSlideDesktop.qml
@@ -23,8 +23,8 @@ ColumnLayout {
 
     MZHeadline {
         Layout.topMargin: MZTheme.theme.windowMargin * 1.5
-        Layout.leftMargin: MZTheme.theme.windowMargin * 2
-        Layout.rightMargin: MZTheme.theme.windowMargin * 2
+        Layout.leftMargin: MZTheme.theme.windowMargin * 1.5
+        Layout.rightMargin: MZTheme.theme.windowMargin * 1.5
 
         Layout.fillWidth: true
 
@@ -34,8 +34,8 @@ ColumnLayout {
 
     MZInterLabel {
         Layout.topMargin: 8
-        Layout.leftMargin: MZTheme.theme.windowMargin * 2
-        Layout.rightMargin: MZTheme.theme.windowMargin * 2
+        Layout.leftMargin: MZTheme.theme.windowMargin * 1.5
+        Layout.rightMargin: MZTheme.theme.windowMargin * 1.5
         Layout.fillWidth: true
 
         text: MZI18n.OnboardingStartSlideBody
@@ -43,31 +43,43 @@ ColumnLayout {
         color: MZTheme.theme.fontColor
     }
 
-    MZCheckBoxRow {
-        objectName: "startAtBootCheckBox"
-
-        Layout.topMargin: MZTheme.theme.vSpacing
-        Layout.leftMargin: MZTheme.theme.windowMargin * 2
-        Layout.rightMargin: MZTheme.theme.windowMargin * 2
+    RowLayout {
+        Layout.topMargin: MZTheme.theme.vSpacingSmall
+        Layout.leftMargin: MZTheme.theme.windowMargin * 1.5
+        Layout.rightMargin: MZTheme.theme.windowMargin * 1.5
         Layout.fillWidth: true
 
-        subLabelText: MZI18n.SettingsStartAtBootTitle
-        leftMargin: 0
-        isChecked: MZSettings.startAtBoot
-        showDivider: false
-        onClicked: {
-            MZSettings.startAtBoot = !MZSettings.startAtBoot
+        MZBoldInterLabel {
+            id: connectOnStartupLabel
+            Layout.fillWidth: true
 
-            if (MZSettings.startAtBoot) {
-                Glean.interaction.connectOnStartupEnabled.record({
-                    screen: root.telemetryScreenId,
-                });
+            text: MZI18n.SettingsStartAtBootTitle
+            font.pixelSize: MZTheme.theme.fontSize
+            lineHeight: MZTheme.theme.labelLineHeight
+        }
+
+        MZSettingsToggle {
+//            objectName: "startAtBootCheckBox"
+
+            implicitHeight: 24
+            implicitWidth: 45
+            checked: MZSettings.startAtBoot
+            onClicked: {
+                MZSettings.startAtBoot = !MZSettings.startAtBoot
+
+                if (MZSettings.startAtBoot) {
+                    Glean.interaction.connectOnStartupEnabled.record({
+                        screen: root.telemetryScreenId,
+                    });
+                }
+                else {
+                    Glean.interaction.connectOnStartupDisabled.record({
+                        screen: root.telemetryScreenId,
+                    });
+                }
             }
-            else {
-                Glean.interaction.connectOnStartupDisabled.record({
-                    screen: root.telemetryScreenId,
-                });
-            }
+
+            accessibleName: connectOnStartupLabel.text
         }
     }
 

--- a/src/ui/screens/onboarding/OnboardingStartSlideDesktop.qml
+++ b/src/ui/screens/onboarding/OnboardingStartSlideDesktop.qml
@@ -61,8 +61,6 @@ ColumnLayout {
         MZSettingsToggle {
             objectName: "startAtBootToggle"
 
-            implicitHeight: 24
-            implicitWidth: 45
             checked: MZSettings.startAtBoot
             onClicked: {
                 MZSettings.startAtBoot = !MZSettings.startAtBoot

--- a/src/ui/screens/onboarding/OnboardingStartSlideDesktop.qml
+++ b/src/ui/screens/onboarding/OnboardingStartSlideDesktop.qml
@@ -59,7 +59,7 @@ ColumnLayout {
         }
 
         MZSettingsToggle {
-//            objectName: "startAtBootCheckBox"
+            objectName: "startAtBootToggle"
 
             implicitHeight: 24
             implicitWidth: 45

--- a/src/ui/screens/onboarding/OnboardingStartSlideMobile.qml
+++ b/src/ui/screens/onboarding/OnboardingStartSlideMobile.qml
@@ -22,8 +22,8 @@ ColumnLayout {
 
     MZHeadline {
         Layout.topMargin: MZTheme.theme.windowMargin * 1.5
-        Layout.leftMargin: MZTheme.theme.windowMargin * 2
-        Layout.rightMargin: MZTheme.theme.windowMargin * 2
+        Layout.leftMargin: MZTheme.theme.windowMargin * 1.5
+        Layout.rightMargin: MZTheme.theme.windowMargin * 1.5
 
         Layout.fillWidth: true
 
@@ -33,8 +33,8 @@ ColumnLayout {
 
     MZInterLabel {
         Layout.topMargin: 8
-        Layout.leftMargin: MZTheme.theme.windowMargin * 2
-        Layout.rightMargin: MZTheme.theme.windowMargin * 2
+        Layout.leftMargin: MZTheme.theme.windowMargin * 1.5
+        Layout.rightMargin: MZTheme.theme.windowMargin * 1.5
         Layout.fillWidth: true
 
         text: MZI18n.OnboardingStartSlideMobileBody

--- a/src/ui/screens/settings/ViewNotifications.qml
+++ b/src/ui/screens/settings/ViewNotifications.qml
@@ -19,87 +19,73 @@ MZViewBase {
 
     _viewContentData: ColumnLayout {
         spacing: MZTheme.theme.windowMargin * 1.5
+        Layout.leftMargin: MZTheme.theme.windowMargin
+        Layout.rightMargin: MZTheme.theme.windowMargin
 
-        MZCheckBoxRow {
-            id: captivePortalAlert
+        MZToggleRow {
             objectName: "settingCaptivePortalAlert"
-            visible: MZFeatureList.get("captivePortal").isSupported
+
             //% "Guest Wi-Fi portal alert"
             labelText: qsTrId("vpn.settings.guestWifiAlert")
             //% "Get notified if a guest Wi-Fi portal is blocked due to VPN connection"
             subLabelText: qsTrId("vpn.settings.guestWifiAlert.description")
-            isChecked: (MZSettings.captivePortalAlert)
-            showDivider: false
-            onClicked: {
-                MZSettings.captivePortalAlert = !MZSettings.captivePortalAlert
-            }
-            Layout.rightMargin: MZTheme.theme.windowMargin
+            checked: MZSettings.captivePortalAlert
+            visible: MZFeatureList.get("captivePortal").isSupported
+            dividerTopMargin: MZTheme.theme.toggleRowDividerSpacing
+            onClicked: MZSettings.captivePortalAlert = !MZSettings.captivePortalAlert
         }
 
-        MZCheckBoxRow {
-            id: unsecuredNetworkAlert
+        MZToggleRow {
             objectName: "settingUnsecuredNetworkAlert"
-            visible: MZFeatureList.get("unsecuredNetworkNotification").isSupported
+
             //% "Unsecured network alert"
             labelText: qsTrId("vpn.settings.unsecuredNetworkAlert")
             //% "Get notified if you connect to an unsecured Wi-Fi network"
             subLabelText: qsTrId("vpn.settings.unsecuredNetworkAlert.description")
-            isChecked: (MZSettings.unsecuredNetworkAlert)
-            enabled: true
-            showDivider: !enabled
-            onClicked: {
-                MZSettings.unsecuredNetworkAlert = !MZSettings.unsecuredNetworkAlert
-            }
-            Layout.rightMargin: MZTheme.theme.windowMargin
+            checked: MZSettings.unsecuredNetworkAlert
+            visible: MZFeatureList.get("unsecuredNetworkNotification").isSupported
+            dividerTopMargin: MZTheme.theme.toggleRowDividerSpacing
+            onClicked: MZSettings.unsecuredNetworkAlert = !MZSettings.unsecuredNetworkAlert
         }
 
-        MZCheckBoxRow {
-            id: switchServersAlert
+        MZToggleRow {
             objectName: "switchServersAlert"
-            visible: MZFeatureList.get("notificationControl").isSupported
+
             //% "Server switching notification"
             labelText: qsTrId("vpn.settings.notification.serverSwitch2")
             //% "Get notified when you successfully switched servers"
             subLabelText: qsTrId("vpn.settings.notification.serverSwitch.description")
-            isChecked: (MZSettings.serverSwitchNotification)
-            showDivider: false
-            onClicked: {
-                MZSettings.serverSwitchNotification = !MZSettings.serverSwitchNotification
-            }
-            Layout.rightMargin: MZTheme.theme.windowMargin
+            checked: MZSettings.serverSwitchNotification
+            visible: MZFeatureList.get("notificationControl").isSupported
+            dividerTopMargin: MZTheme.theme.toggleRowDividerSpacing
+            onClicked: MZSettings.serverSwitchNotification = !MZSettings.serverSwitchNotification
         }
 
-        MZCheckBoxRow {
-            id: connectionChangeAlert
+        MZToggleRow {
             objectName: "connectionChangeAlert"
-            visible: MZFeatureList.get("notificationControl").isSupported
 
             //% "Connection change notification"
             labelText: qsTrId("vpn.settings.notification.connectionChange2")
             //% "Get notified when the connection status changes"
             subLabelText: qsTrId("vpn.settings.notification.connectionChange.description")
-            isChecked: (MZSettings.connectionChangeNotification)
-            showDivider: false
-            onClicked: {
-                MZSettings.connectionChangeNotification = !MZSettings.connectionChangeNotification
-            }
-            Layout.rightMargin: MZTheme.theme.windowMargin
+            checked: MZSettings.connectionChangeNotification
+            visible: MZFeatureList.get("notificationControl").isSupported
+            dividerTopMargin: MZTheme.theme.toggleRowDividerSpacing
+            onClicked: MZSettings.connectionChangeNotification = !MZSettings.connectionChangeNotification
         }
 
-        MZCheckBoxRow {
-            id: serverUnavailableNotification
+        MZToggleRow {
             objectName: "serverUnavailableNotification"
-            visible: MZFeatureList.get("serverUnavailableNotification").isSupported
+
             labelText: MZI18n.ServerUnavailableNotificationPreferencesLabel
             subLabelText: MZI18n.ServerUnavailableNotificationPreferencesSubLabel
-            isChecked: (MZSettings.serverUnavailableNotification)
-            showDivider: false
-            onClicked: {
-                MZSettings.serverUnavailableNotification = !MZSettings.serverUnavailableNotification
-            }
-            Layout.rightMargin: MZTheme.theme.windowMargin
+            checked: MZSettings.serverUnavailableNotification
+            visible: MZFeatureList.get("serverUnavailableNotification").isSupported
+            dividerTopMargin: MZTheme.theme.toggleRowDividerSpacing
+            onClicked: MZSettings.serverUnavailableNotification = !MZSettings.serverUnavailableNotification
         }
     }
+
     Component.onCompleted: {
         Glean.sample.notificationsViewOpened.record();
     }

--- a/src/ui/screens/settings/ViewPreferences.qml
+++ b/src/ui/screens/settings/ViewPreferences.qml
@@ -26,14 +26,19 @@ MZViewBase {
         Layout.fillWidth: true
         Layout.alignment: Qt.AlignHCenter
 
-        MZCheckBoxRow {
-            id: startAtBootCheckBox
-            objectName: "settingStartAtBoot"
+        MZToggleRow {
+            objectName: "startAtBootToogle"
+
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.leftMargin: MZTheme.theme.windowMargin
+            anchors.rightMargin: MZTheme.theme.windowMargin
 
             labelText: _startAtBootTitle
             subLabelText: MZI18n.SettingsStartAtBootSubtitle
-            isChecked: MZSettings.startAtBoot
-            showDivider: false
+            checked: MZSettings.startAtBoot
+            visible: MZFeatureList.get("startOnBoot").isSupported
+            dividerTopMargin: MZTheme.theme.toggleRowDividerSpacing
             onClicked: {
                 MZSettings.startAtBoot = !MZSettings.startAtBoot
                 if (MZSettings.startAtBoot)
@@ -45,28 +50,20 @@ MZViewBase {
                     Glean.interaction.vpnOnStartupDisabled.record({screen:telemetryScreenId})
                 }
             }
-            visible: MZFeatureList.get("startOnBoot").isSupported
-            anchors {
-                right: parent.right
-                left: parent.left
-                rightMargin: MZTheme.theme.windowMargin
-            }
         }
 
-        MZCheckBoxRow {
-            id: dataCollection
-            objectName: "dataCollection"
-            width: parent.width - MZTheme.theme.windowMargin
-            anchors {
-                right: parent.right
-                left: parent.left
-                rightMargin: MZTheme.theme.windowMargin
-            }
+        MZToggleRow {
+            objectName: "dataCollectionToggle"
 
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.leftMargin: MZTheme.theme.windowMargin
+            anchors.rightMargin: MZTheme.theme.windowMargin
 
             labelText: MZI18n.TelemetryPolicyViewDataCollectionAndUse
             subLabelText: MZI18n.SettingsDataCollectionDescription
-            isChecked: MZSettings.gleanEnabled
+            checked: MZSettings.gleanEnabled
+            dividerTopMargin: MZTheme.theme.toggleRowDividerSpacing
             onClicked: MZSettings.gleanEnabled = !MZSettings.gleanEnabled
         }
 

--- a/src/ui/screens/settings/privacy/PrivacyFeaturesList.qml
+++ b/src/ui/screens/settings/privacy/PrivacyFeaturesList.qml
@@ -13,7 +13,8 @@ ColumnLayout {
 
     property bool isOnboarding: false
     property string telemetryScreenId
-    property int dividerSpacing: 16
+    property int dividerSpacing: MZTheme.theme.toggleRowDividerSpacing
+
 
     signal settingClicked(dnsProviderFlags: int, active: bool)
 

--- a/src/ui/screens/settings/privacy/PrivacyFeaturesList.qml
+++ b/src/ui/screens/settings/privacy/PrivacyFeaturesList.qml
@@ -13,10 +13,11 @@ ColumnLayout {
 
     property bool isOnboarding: false
     property string telemetryScreenId
+    property int dividerSpacing: 16
 
     signal settingClicked(dnsProviderFlags: int, active: bool)
 
-    spacing: MZTheme.theme.vSpacingSmall
+    spacing: dividerSpacing
 
     Repeater {
         id: repeater
@@ -40,15 +41,15 @@ ColumnLayout {
             }
         ];
 
-        delegate: MZCheckBoxRow {
+        delegate: MZToggleRow {
             objectName: modelData.objectName
-
-            leftMargin: 0
 
             labelText: modelData.settingTitle
             subLabelText: modelData.settingDescription
-            isChecked: MZSettings.dnsProviderFlags & modelData.settingValue
-            showDivider: false
+            checked: MZSettings.dnsProviderFlags & modelData.settingValue
+            dividerTopMargin: dividerSpacing
+            showDivider: !isOnboarding || index + 1 !== repeater.model.length
+
             onClicked: {
                 let dnsProviderFlags = MZSettings.dnsProviderFlags;
                 dnsProviderFlags &= ~MZSettings.Custom;

--- a/tests/functional/queries.js
+++ b/tests/functional/queries.js
@@ -290,12 +290,9 @@ const screenSettings = {
 
   privacyView: {
     VIEW: new QmlQueryComposer('//privacySettingsView'),
-    BLOCK_ADS: new QmlQueryComposer('//blockAds'),
-    BLOCK_ADS_CHECKBOX: new QmlQueryComposer('//blockAds//checkbox'),
-    BLOCK_TRACKERS: new QmlQueryComposer('//blockTrackers'),
-    BLOCK_TRACKERS_CHECKBOX: new QmlQueryComposer('//blockTrackers//checkbox'),
-    BLOCK_MALWARE: new QmlQueryComposer('//blockMalware'),
-    BLOCK_MALWARE_CHECKBOX: new QmlQueryComposer('//blockMalware//checkbox'),
+    BLOCK_ADS_TOGGLE: new QmlQueryComposer('//blockAds/toggle'),
+    BLOCK_TRACKERS_TOGGLE: new QmlQueryComposer('//blockTrackers/toggle'),
+    BLOCK_MALWARE_TOGGLE: new QmlQueryComposer('//blockMalware/toggle'),
 
     INFORMATION_CARD:
         new QmlQueryComposer('//privacySettingsViewInformationCard'),
@@ -353,8 +350,8 @@ const screenSettings = {
   },
 
   appPreferencesView: {
-    START_AT_BOOT: new QmlQueryComposer('//settingStartAtBoot'),
-    DATA_COLLECTION: new QmlQueryComposer('//dataCollection'),
+    START_AT_BOOT_TOGGLE: new QmlQueryComposer('//startAtBootToogle'),
+    DATA_COLLECTION_TOGGLE: new QmlQueryComposer('//dataCollectionToggle'),
     LANGUAGE: new QmlQueryComposer('//settingsLanguages'),
     NOTIFICATIONS: new QmlQueryComposer('//settingsNotifications'),
     DNS_SETTINGS: new QmlQueryComposer('//dnsSettings'),
@@ -519,15 +516,14 @@ const screenOnboarding = {
   STEP_PROG_BAR_PRIVACY_BUTTON: new QmlQueryComposer('//progressBarRow/privacy'),
   STEP_PROG_BAR_DEVICES_BUTTON: new QmlQueryComposer('//progressBarRow/devices'),
   DATA_SLIDE: new QmlQueryComposer('//onboardingDataSlide'),
-  DATA_CHECKBOX_ROW: new QmlQueryComposer('//dataCollectionCheckBox'),
-  DATA_CHECKBOX: new QmlQueryComposer('//dataCollectionCheckBox/checkbox'),
+  DATA_TOGGLE: new QmlQueryComposer('//dataCollectionToggle'),
   DATA_PRIVACY_LINK: new QmlQueryComposer('//dataPrivacyLink'),
   DATA_NEXT_BUTTON: new QmlQueryComposer('//dataNextButton'),
   PRIVACY_SLIDE: new QmlQueryComposer('//onboardingPrivacySlide'),
   PRIVACY_NEXT_BUTTON: new QmlQueryComposer('//privacyNextButton'),
-  PRIVACY_BLOCK_ADS_CHECKBOX: new QmlQueryComposer('//blockAds//checkbox'),
-  PRIVACY_BLOCK_TRACKERS_CHECKBOX: new QmlQueryComposer('//blockTrackers//checkbox'),
-  PRIVACY_BLOCK_MALWARE_CHECKBOX: new QmlQueryComposer('//blockMalware//checkbox'),
+  PRIVACY_BLOCK_ADS_TOGGLE: new QmlQueryComposer('//blockAds/toggle'),
+  PRIVACY_BLOCK_TRACKERS_TOGGLE: new QmlQueryComposer('//blockTrackers/toggle'),
+  PRIVACY_BLOCK_MALWARE_TOGGLE: new QmlQueryComposer('//blockMalware/toggle'),
   PRIVACY_BACK_BUTTON: new QmlQueryComposer('//privacyBackButton'),
   DEVICES_SLIDE: new QmlQueryComposer('//onboardingDevicesSlide'),
   DEVICES_TOGGLE_BTN_ANDROID: new QmlQueryComposer('//segmentedToggleBtnLayout/tabAndroid'),
@@ -538,7 +534,7 @@ const screenOnboarding = {
   DEVICES_NEXT_BUTTON: new QmlQueryComposer('//devicesNextButton'),
   DEVICES_BACK_BUTTON: new QmlQueryComposer('//devicesBackButton'),
   START_SLIDE: new QmlQueryComposer('//onboardingStartSlide'),
-  START_START_AT_BOOT_CHECKBOX: new QmlQueryComposer('//startAtBootCheckBox//checkbox'),
+  START_START_AT_BOOT_TOGGLE: new QmlQueryComposer('//startAtBootToggle'),
   START_NEXT_BUTTON: new QmlQueryComposer('//startNextButton'),
   START_BACK_BUTTON: new QmlQueryComposer('//startBackButton'),
 };

--- a/tests/functional/testOnboarding.js
+++ b/tests/functional/testOnboarding.js
@@ -69,12 +69,12 @@ describe('Onboarding', function() {
     await vpn.waitForQuery(queries.screenOnboarding.DATA_SLIDE.visible());
     assert.equal(await vpn.getQueryProperty(queries.screenOnboarding.ONBOARDING_VIEW, 'currentIndex'), 0);
     assert.equal(await vpn.getSetting('onboardingStep'), 0);
-    assert.equal(await vpn.getQueryProperty(queries.screenOnboarding.DATA_CHECKBOX_ROW, 'isChecked'), 'false');
+    assert.equal(await vpn.getQueryProperty(queries.screenOnboarding.DATA_TOGGLE, 'checked'), 'false');
     assert.equal(await vpn.getSetting('gleanEnabled'), true);
 
-    //Check data collection checkbox
-    await vpn.waitForQueryAndClick(queries.screenOnboarding.DATA_CHECKBOX.visible());
-    assert.equal(await vpn.getQueryProperty(queries.screenOnboarding.DATA_CHECKBOX_ROW, 'isChecked'), 'true');
+    //Check data collection toggle
+    await vpn.waitForQueryAndClick(queries.screenOnboarding.DATA_TOGGLE.visible());
+    assert.equal(await vpn.getQueryProperty(queries.screenOnboarding.DATA_TOGGLE, 'checked'), 'true');
 
     //Check privacy link
     await vpn.waitForQueryAndClick(queries.screenOnboarding.DATA_PRIVACY_LINK.visible());
@@ -93,24 +93,24 @@ describe('Onboarding', function() {
     await vpn.waitForQuery(queries.screenOnboarding.PRIVACY_SLIDE.visible());
     assert.equal(await vpn.getQueryProperty(queries.screenOnboarding.ONBOARDING_VIEW, 'currentIndex'), 1);
     assert.equal(await vpn.getSetting('onboardingStep'), 1);
-    assert.equal(await vpn.getQueryProperty(queries.screenOnboarding.PRIVACY_BLOCK_ADS_CHECKBOX, 'checked'), 'false');
-    assert.equal(await vpn.getQueryProperty(queries.screenOnboarding.PRIVACY_BLOCK_TRACKERS_CHECKBOX, 'checked'), 'false');
-    assert.equal(await vpn.getQueryProperty(queries.screenOnboarding.PRIVACY_BLOCK_MALWARE_CHECKBOX, 'checked'), 'false');
+    assert.equal(await vpn.getQueryProperty(queries.screenOnboarding.PRIVACY_BLOCK_ADS_TOGGLE, 'checked'), 'false');
+    assert.equal(await vpn.getQueryProperty(queries.screenOnboarding.PRIVACY_BLOCK_TRACKERS_TOGGLE, 'checked'), 'false');
+    assert.equal(await vpn.getQueryProperty(queries.screenOnboarding.PRIVACY_BLOCK_MALWARE_TOGGLE, 'checked'), 'false');
     assert.equal(await vpn.getSetting('dnsProviderFlags'), 0);
 
-    //Clicks block ads checkbox
-    await vpn.waitForQueryAndClick(queries.screenOnboarding.PRIVACY_BLOCK_ADS_CHECKBOX.visible());
-    assert.equal(await vpn.getQueryProperty(queries.screenOnboarding.PRIVACY_BLOCK_ADS_CHECKBOX, 'checked'), 'true');
+    //Clicks block ads toggle
+    await vpn.waitForQueryAndClick(queries.screenOnboarding.PRIVACY_BLOCK_ADS_TOGGLE.visible());
+    assert.equal(await vpn.getQueryProperty(queries.screenOnboarding.PRIVACY_BLOCK_ADS_TOGGLE, 'checked'), 'true');
     assert.equal(await vpn.getSetting('dnsProviderFlags'), 2);
 
-    //Clicks block trackers checkbox
-    await vpn.waitForQueryAndClick(queries.screenOnboarding.PRIVACY_BLOCK_TRACKERS_CHECKBOX.visible());
-    assert.equal(await vpn.getQueryProperty(queries.screenOnboarding.PRIVACY_BLOCK_TRACKERS_CHECKBOX, 'checked'), 'true');
+    //Clicks block trackers toggle
+    await vpn.waitForQueryAndClick(queries.screenOnboarding.PRIVACY_BLOCK_TRACKERS_TOGGLE.visible());
+    assert.equal(await vpn.getQueryProperty(queries.screenOnboarding.PRIVACY_BLOCK_TRACKERS_TOGGLE, 'checked'), 'true');
     assert.equal(await vpn.getSetting('dnsProviderFlags'), 6);
 
-    //Clicks block trackers checkbox
-    await vpn.waitForQueryAndClick(queries.screenOnboarding.PRIVACY_BLOCK_MALWARE_CHECKBOX.visible());
-    assert.equal(await vpn.getQueryProperty(queries.screenOnboarding.PRIVACY_BLOCK_MALWARE_CHECKBOX, 'checked'), 'true');
+    //Clicks block trackers toggle
+    await vpn.waitForQueryAndClick(queries.screenOnboarding.PRIVACY_BLOCK_MALWARE_TOGGLE.visible());
+    assert.equal(await vpn.getQueryProperty(queries.screenOnboarding.PRIVACY_BLOCK_MALWARE_TOGGLE, 'checked'), 'true');
     //dnsProviderFlags is a bitfield mapping of hex flags that can handle bitwise operations to combine multiple flags
     //here, we combine blockAds (0x02), blockTrackers (0x04), and blockMalware (0x08) which totals to 0xE or 14 in decimal
     assert.equal(await vpn.getSetting('dnsProviderFlags'), 14);
@@ -122,7 +122,7 @@ describe('Onboarding', function() {
     assert.equal(await vpn.getQueryProperty(queries.screenOnboarding.ONBOARDING_VIEW, 'currentIndex'), 0);
 
     //Ensure all selections on previous slide are saved
-    assert.equal(await vpn.getQueryProperty(queries.screenOnboarding.DATA_CHECKBOX_ROW, 'isChecked'), 'true');
+    assert.equal(await vpn.getQueryProperty(queries.screenOnboarding.DATA_TOGGLE, 'checked'), 'true');
 
     //Return to privacy slide
     await vpn.waitForQueryAndClick(queries.screenOnboarding.DATA_NEXT_BUTTON.visible());
@@ -168,9 +168,9 @@ describe('Onboarding', function() {
     assert.equal(await vpn.getQueryProperty(queries.screenOnboarding.ONBOARDING_VIEW, 'currentIndex'), 1);
 
     //Ensure all selections on previous slide are saved
-    assert.equal(await vpn.getQueryProperty(queries.screenOnboarding.PRIVACY_BLOCK_ADS_CHECKBOX, 'checked'), 'true');
-    assert.equal(await vpn.getQueryProperty(queries.screenOnboarding.PRIVACY_BLOCK_TRACKERS_CHECKBOX, 'checked'), 'true');
-    assert.equal(await vpn.getQueryProperty(queries.screenOnboarding.PRIVACY_BLOCK_MALWARE_CHECKBOX, 'checked'), 'true');
+    assert.equal(await vpn.getQueryProperty(queries.screenOnboarding.PRIVACY_BLOCK_ADS_TOGGLE, 'checked'), 'true');
+    assert.equal(await vpn.getQueryProperty(queries.screenOnboarding.PRIVACY_BLOCK_TRACKERS_TOGGLE, 'checked'), 'true');
+    assert.equal(await vpn.getQueryProperty(queries.screenOnboarding.PRIVACY_BLOCK_MALWARE_TOGGLE, 'checked'), 'true');
 
     //Return to devices slide
     await vpn.waitForQueryAndClick(queries.screenOnboarding.PRIVACY_NEXT_BUTTON.visible());
@@ -192,12 +192,12 @@ describe('Onboarding', function() {
     await vpn.waitForQuery(queries.screenOnboarding.START_SLIDE.visible());
     assert.equal(await vpn.getQueryProperty(queries.screenOnboarding.ONBOARDING_VIEW, 'currentIndex'), 3);
     assert.equal(await vpn.getSetting('onboardingStep'), 3);
-    assert.equal(await vpn.getQueryProperty(queries.screenOnboarding.START_START_AT_BOOT_CHECKBOX, 'checked'), 'false');
+    assert.equal(await vpn.getQueryProperty(queries.screenOnboarding.START_START_AT_BOOT_TOGGLE, 'checked'), 'false');
     assert.equal(await vpn.getSetting('startAtBoot'), false);
 
-    //Check start at boot checkbox
-    await vpn.waitForQueryAndClick(queries.screenOnboarding.START_START_AT_BOOT_CHECKBOX.visible());
-    assert.equal(await vpn.getQueryProperty(queries.screenOnboarding.START_START_AT_BOOT_CHECKBOX, 'checked'), 'true');
+    //Check start at boot toggle
+    await vpn.waitForQueryAndClick(queries.screenOnboarding.START_START_AT_BOOT_TOGGLE.visible());
+    assert.equal(await vpn.getQueryProperty(queries.screenOnboarding.START_START_AT_BOOT_TOGGLE, 'checked'), 'true');
     assert.equal(await vpn.getSetting('startAtBoot'), true);
 
     //Test back button
@@ -211,7 +211,7 @@ describe('Onboarding', function() {
     await vpn.waitForQuery(queries.screenOnboarding.STEP_NAV_STACK_VIEW.ready());
 
     //Ensure all selections on start slide are saved
-    assert.equal(await vpn.getQueryProperty(queries.screenOnboarding.START_START_AT_BOOT_CHECKBOX, 'checked'), 'true');
+    assert.equal(await vpn.getQueryProperty(queries.screenOnboarding.START_START_AT_BOOT_TOGGLE, 'checked'), 'true');
     assert.equal(await vpn.getSetting('startAtBoot'), true);
 
     //Test going back one slide via progress bar
@@ -243,18 +243,18 @@ describe('Onboarding', function() {
 
     //Check privacy settings
     await vpn.waitForQueryAndClick(queries.screenSettings.PRIVACY.visible());
-    assert.equal(await vpn.getQueryProperty(queries.screenSettings.privacyView.BLOCK_ADS_CHECKBOX, 'checked'), 'true');
-    assert.equal(await vpn.getQueryProperty(queries.screenSettings.privacyView.BLOCK_TRACKERS_CHECKBOX, 'checked'), 'true');
-    assert.equal(await vpn.getQueryProperty(queries.screenSettings.privacyView.BLOCK_MALWARE_CHECKBOX, 'checked'), 'true');
+    assert.equal(await vpn.getQueryProperty(queries.screenSettings.privacyView.BLOCK_ADS_TOGGLE, 'checked'), 'true');
+    assert.equal(await vpn.getQueryProperty(queries.screenSettings.privacyView.BLOCK_TRACKERS_TOGGLE, 'checked'), 'true');
+    assert.equal(await vpn.getQueryProperty(queries.screenSettings.privacyView.BLOCK_MALWARE_TOGGLE, 'checked'), 'true');
     assert.equal(await vpn.getSetting('dnsProviderFlags'), 14);
     await vpn.waitForQueryAndClick(queries.screenSettings.BACK.visible());
     await vpn.waitForQuery(queries.screenSettings.STACKVIEW.ready());
 
     //Check data collection and start at boot
     await vpn.waitForQueryAndClick(queries.screenSettings.APP_PREFERENCES.visible());
-    assert.equal(await vpn.getQueryProperty(queries.screenSettings.appPreferencesView.DATA_COLLECTION, 'isChecked'), 'true');
+    assert.equal(await vpn.getQueryProperty(queries.screenSettings.appPreferencesView.DATA_COLLECTION_TOGGLE, 'checked'), 'true');
     assert.equal(await vpn.getSetting('gleanEnabled'), true);
-    assert.equal(await vpn.getQueryProperty(queries.screenSettings.appPreferencesView.START_AT_BOOT, 'isChecked'), 'true');
+    assert.equal(await vpn.getQueryProperty(queries.screenSettings.appPreferencesView.START_AT_BOOT_TOGGLE, 'checked'), 'true');
     assert.equal(await vpn.getSetting('startAtBoot'), true);
 
   });
@@ -331,9 +331,9 @@ describe('Onboarding', function() {
     //Ensure we are in onboarding
     await vpn.waitForQuery(queries.screenOnboarding.DATA_SLIDE.visible());
 
-    //Ensure that the data collection checkbox state is bound to onboardingDataCollectionEnabled, which defaults to false
-    //and that this checkboxes state does not affect gleanEnabled
-    assert.equal(await vpn.getQueryProperty(queries.screenOnboarding.DATA_CHECKBOX_ROW, 'isChecked'), 'false');
+    //Ensure that the data collection toggle state is bound to onboardingDataCollectionEnabled, which defaults to false
+    //and that this toggles state does not affect gleanEnabled
+    assert.equal(await vpn.getQueryProperty(queries.screenOnboarding.DATA_TOGGLE, 'checked'), 'false');
     assert.equal(await vpn.getSetting('onboardingDataCollectionEnabled'), false);
     assert.equal(await vpn.getSetting('gleanEnabled'), true);
 
@@ -349,10 +349,10 @@ describe('Onboarding', function() {
     //Ensure we are in onboarding
     await vpn.waitForQuery(queries.screenOnboarding.DATA_SLIDE.visible());
 
-    //Ensure that the data collection checkbox state remains bound to onboardingDataCollectionEnabled when clicked
-    //and that this checkboxes state does not affect gleanEnabled
-    await vpn.waitForQueryAndClick(queries.screenOnboarding.DATA_CHECKBOX.visible());
-    assert.equal(await vpn.getQueryProperty(queries.screenOnboarding.DATA_CHECKBOX_ROW, 'isChecked'), 'true');
+    //Ensure that the data collection toggle state remains bound to onboardingDataCollectionEnabled when clicked
+    //and that this toggles state does not affect gleanEnabled
+    await vpn.waitForQueryAndClick(queries.screenOnboarding.DATA_TOGGLE.visible());
+    assert.equal(await vpn.getQueryProperty(queries.screenOnboarding.DATA_TOGGLE, 'checked'), 'true');
     assert.equal(await vpn.getSetting('onboardingDataCollectionEnabled'), true);
     assert.equal(await vpn.getSetting('gleanEnabled'), true);
 
@@ -363,7 +363,7 @@ describe('Onboarding', function() {
     assert.equal(await vpn.getSetting('gleanEnabled'), true);
   });
 
-  it('Data collection checkbox state persists across app sessions', async () => {
+  it('Data collection toggle state persists across app sessions', async () => {
     // Skip WASM because this test involves quitting and relaunching
     if (this.ctx.wasm) {
       return;
@@ -371,8 +371,8 @@ describe('Onboarding', function() {
     //Ensure we are in onboarding
     await vpn.waitForQuery(queries.screenOnboarding.DATA_SLIDE.visible());
 
-    //Click the data collection checkbox to set onboardingDataCollectionEnabled to true
-    await vpn.waitForQueryAndClick(queries.screenOnboarding.DATA_CHECKBOX.visible());
+    //Click the data collection toggle to set onboardingDataCollectionEnabled to true
+    await vpn.waitForQueryAndClick(queries.screenOnboarding.DATA_TOGGLE.visible());
 
     //Quit and relaunch the app
     await vpn.quit();
@@ -381,14 +381,14 @@ describe('Onboarding', function() {
     //Ensure we are still in onboarding
     await vpn.waitForQuery(queries.screenOnboarding.DATA_SLIDE.visible());
 
-    //Ensure that the data collection checkbox state remains bound to onboardingDataCollectionEnabled upon relaunch
-    //and that this checkboxes state does not affect gleanEnabled
-    assert.equal(await vpn.getQueryProperty(queries.screenOnboarding.DATA_CHECKBOX_ROW, 'isChecked'), 'true');
+    //Ensure that the data collection toggle state remains bound to onboardingDataCollectionEnabled upon relaunch
+    //and that this toggles state does not affect gleanEnabled
+    assert.equal(await vpn.getQueryProperty(queries.screenOnboarding.DATA_TOGGLE, 'checked'), 'true');
     assert.equal(await vpn.getSetting('onboardingDataCollectionEnabled'), true);
     assert.equal(await vpn.getSetting('gleanEnabled'), true);
 
-    //Ensure the data collection checkbox is checked and onboardingDataCollectionEnabled is set to true
-    assert.equal(await vpn.getQueryProperty(queries.screenOnboarding.DATA_CHECKBOX_ROW, 'isChecked'), 'true');
+    //Ensure the data collection toggle is checked and onboardingDataCollectionEnabled is set to true
+    assert.equal(await vpn.getQueryProperty(queries.screenOnboarding.DATA_TOGGLE, 'checked'), 'true');
     assert.equal(await vpn.getSetting('onboardingDataCollectionEnabled'), true);
   });
 
@@ -581,42 +581,42 @@ describe('Onboarding', function() {
       await vpn.waitForQuery(queries.screenOnboarding.PRIVACY_SLIDE.visible());
 
       //Verify that blockAdsEnabled event is recorded
-      await vpn.waitForQueryAndClick(queries.screenOnboarding.PRIVACY_BLOCK_ADS_CHECKBOX.visible());
+      await vpn.waitForQueryAndClick(queries.screenOnboarding.PRIVACY_BLOCK_ADS_TOGGLE.visible());
       const blockAdsEnabledEvents = await vpn.gleanTestGetValue("interaction", "blockAdsEnabled", "main");
       assert.equal(blockAdsEnabledEvents.length, 1);
       const blockAdsEnabledEventsExtras = blockAdsEnabledEvents[0].extra;
       assert.equal(privacyScreenTelemetryId, blockAdsEnabledEventsExtras.screen);
 
       //Verify that blockAdsDisabled event is recorded
-      await vpn.waitForQueryAndClick(queries.screenOnboarding.PRIVACY_BLOCK_ADS_CHECKBOX.visible());
+      await vpn.waitForQueryAndClick(queries.screenOnboarding.PRIVACY_BLOCK_ADS_TOGGLE.visible());
       const blockAdsDisabledEvents = await vpn.gleanTestGetValue("interaction", "blockAdsDisabled", "main");
       assert.equal(blockAdsDisabledEvents.length, 1);
       const blockAdsDisabledEventsExtras = blockAdsDisabledEvents[0].extra;
       assert.equal(privacyScreenTelemetryId, blockAdsDisabledEventsExtras.screen);
 
       //Verify that blockTrackersEnabled event is recorded
-      await vpn.waitForQueryAndClick(queries.screenOnboarding.PRIVACY_BLOCK_TRACKERS_CHECKBOX.visible());
+      await vpn.waitForQueryAndClick(queries.screenOnboarding.PRIVACY_BLOCK_TRACKERS_TOGGLE.visible());
       const blockTrackersEnabledEvents = await vpn.gleanTestGetValue("interaction", "blockTrackersEnabled", "main");
       assert.equal(blockTrackersEnabledEvents.length, 1);
       const blockTrackersEnabledEventsExtras = blockTrackersEnabledEvents[0].extra;
       assert.equal(privacyScreenTelemetryId, blockTrackersEnabledEventsExtras.screen);
 
       //Verify that blockTrackersDisabled event is recorded
-      await vpn.waitForQueryAndClick(queries.screenOnboarding.PRIVACY_BLOCK_TRACKERS_CHECKBOX.visible());
+      await vpn.waitForQueryAndClick(queries.screenOnboarding.PRIVACY_BLOCK_TRACKERS_TOGGLE.visible());
       const blockTrackersDisabledEvents = await vpn.gleanTestGetValue("interaction", "blockTrackersDisabled", "main");
       assert.equal(blockTrackersDisabledEvents.length, 1);
       const blockTrackersDisabledEventsExtras = blockTrackersDisabledEvents[0].extra;
       assert.equal(privacyScreenTelemetryId, blockTrackersDisabledEventsExtras.screen);
 
       //Verify that blockMalwareEnabled event is recorded
-      await vpn.waitForQueryAndClick(queries.screenOnboarding.PRIVACY_BLOCK_MALWARE_CHECKBOX.visible());
+      await vpn.waitForQueryAndClick(queries.screenOnboarding.PRIVACY_BLOCK_MALWARE_TOGGLE.visible());
       const blockMalwareEnabledEvents = await vpn.gleanTestGetValue("interaction", "blockMalwareEnabled", "main");
       assert.equal(blockMalwareEnabledEvents.length, 1);
       const blockMalwareEnabledEventsExtras = blockMalwareEnabledEvents[0].extra;
       assert.equal(privacyScreenTelemetryId, blockMalwareEnabledEventsExtras.screen);
 
       //Verify that blockMalwareDisabled event is recorded
-      await vpn.waitForQueryAndClick(queries.screenOnboarding.PRIVACY_BLOCK_MALWARE_CHECKBOX.visible());
+      await vpn.waitForQueryAndClick(queries.screenOnboarding.PRIVACY_BLOCK_MALWARE_TOGGLE.visible());
       const blockMalwareDisabledEvents = await vpn.gleanTestGetValue("interaction", "blockMalwareDisabled", "main");
       assert.equal(blockMalwareDisabledEvents.length, 1);
       const blockMalwareDisabledEventsExtras = blockMalwareDisabledEvents[0].extra;
@@ -709,14 +709,14 @@ describe('Onboarding', function() {
       await vpn.waitForQuery(queries.screenOnboarding.START_SLIDE.visible());
 
       //Verify that connectOnStartupEnabled event is recorded
-      await vpn.waitForQueryAndClick(queries.screenOnboarding.START_START_AT_BOOT_CHECKBOX.visible());
+      await vpn.waitForQueryAndClick(queries.screenOnboarding.START_START_AT_BOOT_TOGGLE.visible());
       const connectOnStartupEnabledEvents = await vpn.gleanTestGetValue("interaction", "connectOnStartupEnabled", "main");
       assert.equal(connectOnStartupEnabledEvents.length, 1);
       const connectOnStartupEnabledEventsExtras = connectOnStartupEnabledEvents[0].extra;
       assert.equal(startScreenTelemetryId, connectOnStartupEnabledEventsExtras.screen);
 
       //Verify that connectOnStartupDisabled event is recorded
-      await vpn.waitForQueryAndClick(queries.screenOnboarding.START_START_AT_BOOT_CHECKBOX.visible());
+      await vpn.waitForQueryAndClick(queries.screenOnboarding.START_START_AT_BOOT_TOGGLE.visible());
       const connectOnStartupDisabledEvents = await vpn.gleanTestGetValue("interaction", "connectOnStartupDisabled", "main");
       assert.equal(connectOnStartupDisabledEvents.length, 1);
       const connectOnStartupDisabledEventsExtras = connectOnStartupDisabledEvents[0].extra;

--- a/tests/functional/testSettings.js
+++ b/tests/functional/testSettings.js
@@ -22,16 +22,16 @@ describe('Settings', function() {
   async function checkSetting(query, settingKey) {
     await vpn.waitForQuery(query.visible());
     assert.equal(
-        (await vpn.getQueryProperty(query, 'isChecked') === 'true'),
+        (await vpn.getQueryProperty(query, 'checked') === 'true'),
         await vpn.getSetting(settingKey));
 
     await vpn.setSetting(settingKey, true);
     assert.equal((await vpn.getSetting(settingKey)), true);
-    assert.equal((await vpn.getQueryProperty(query, 'isChecked')), 'true');
+    assert.equal((await vpn.getQueryProperty(query, 'checked')), 'true');
 
     await vpn.setSetting(settingKey, false);
     assert.equal((await vpn.getSetting(settingKey)), false);
-    assert.equal((await vpn.getQueryProperty(query, 'isChecked')), 'false');
+    assert.equal((await vpn.getQueryProperty(query, 'checked')), 'false');
   }
 
   async function getToGetHelpView() {
@@ -122,112 +122,112 @@ describe('Settings', function() {
       // Checking if the checkboxes are correctly set based on the settings prop
       await vpn.setSetting('dnsProviderFlags', 0);
       await vpn.waitForQuery(
-          queries.screenSettings.privacyView.BLOCK_ADS.visible().prop(
-              'isChecked', false));
+          queries.screenSettings.privacyView.BLOCK_ADS_TOGGLE.visible().prop(
+              'checked', false));
       await vpn.waitForQuery(
-          queries.screenSettings.privacyView.BLOCK_TRACKERS.visible().prop(
-              'isChecked', false));
+          queries.screenSettings.privacyView.BLOCK_TRACKERS_TOGGLE.visible().prop(
+              'checked', false));
       await vpn.waitForQuery(
-          queries.screenSettings.privacyView.BLOCK_MALWARE.visible().prop(
-              'isChecked', false));
+          queries.screenSettings.privacyView.BLOCK_MALWARE_TOGGLE.visible().prop(
+              'checked', false));
   
       await vpn.setSetting('dnsProviderFlags', 2);
       await vpn.waitForQuery(
-          queries.screenSettings.privacyView.BLOCK_ADS.visible().prop(
-              'isChecked', true));
+          queries.screenSettings.privacyView.BLOCK_ADS_TOGGLE.visible().prop(
+              'checked', true));
       await vpn.waitForQuery(
-          queries.screenSettings.privacyView.BLOCK_TRACKERS.visible().prop(
-              'isChecked', false));
+          queries.screenSettings.privacyView.BLOCK_TRACKERS_TOGGLE.visible().prop(
+              'checked', false));
       await vpn.waitForQuery(
-          queries.screenSettings.privacyView.BLOCK_MALWARE.visible().prop(
-              'isChecked', false));
+          queries.screenSettings.privacyView.BLOCK_MALWARE_TOGGLE.visible().prop(
+              'checked', false));
   
       await vpn.setSetting('dnsProviderFlags', 4);
       await vpn.waitForQuery(
-          queries.screenSettings.privacyView.BLOCK_ADS.visible().prop(
-              'isChecked', false));
+          queries.screenSettings.privacyView.BLOCK_ADS_TOGGLE.visible().prop(
+              'checked', false));
       await vpn.waitForQuery(
-          queries.screenSettings.privacyView.BLOCK_TRACKERS.visible().prop(
-              'isChecked', true));
+          queries.screenSettings.privacyView.BLOCK_TRACKERS_TOGGLE.visible().prop(
+              'checked', true));
       await vpn.waitForQuery(
-          queries.screenSettings.privacyView.BLOCK_MALWARE.visible().prop(
-              'isChecked', false));
+          queries.screenSettings.privacyView.BLOCK_MALWARE_TOGGLE.visible().prop(
+              'checked', false));
   
       await vpn.setSetting('dnsProviderFlags', 6);
       await vpn.waitForQuery(
-          queries.screenSettings.privacyView.BLOCK_ADS.visible().prop(
-              'isChecked', true));
+          queries.screenSettings.privacyView.BLOCK_ADS_TOGGLE.visible().prop(
+              'checked', true));
       await vpn.waitForQuery(
-          queries.screenSettings.privacyView.BLOCK_TRACKERS.visible().prop(
-              'isChecked', true));
+          queries.screenSettings.privacyView.BLOCK_TRACKERS_TOGGLE.visible().prop(
+              'checked', true));
       await vpn.waitForQuery(
-          queries.screenSettings.privacyView.BLOCK_MALWARE.visible().prop(
-              'isChecked', false));
+          queries.screenSettings.privacyView.BLOCK_MALWARE_TOGGLE.visible().prop(
+              'checked', false));
   
       await vpn.setSetting('dnsProviderFlags', 8);
       await vpn.waitForQuery(
-          queries.screenSettings.privacyView.BLOCK_ADS.visible().prop(
-              'isChecked', false));
+          queries.screenSettings.privacyView.BLOCK_ADS_TOGGLE.visible().prop(
+              'checked', false));
       await vpn.waitForQuery(
-          queries.screenSettings.privacyView.BLOCK_TRACKERS.visible().prop(
-              'isChecked', false));
+          queries.screenSettings.privacyView.BLOCK_TRACKERS_TOGGLE.visible().prop(
+              'checked', false));
       await vpn.waitForQuery(
-          queries.screenSettings.privacyView.BLOCK_MALWARE.visible().prop(
-              'isChecked', true));
+          queries.screenSettings.privacyView.BLOCK_MALWARE_TOGGLE.visible().prop(
+              'checked', true));
   
       await vpn.setSetting('dnsProviderFlags', 10);
       await vpn.waitForQuery(
-          queries.screenSettings.privacyView.BLOCK_ADS.visible().prop(
-              'isChecked', true));
+          queries.screenSettings.privacyView.BLOCK_ADS_TOGGLE.visible().prop(
+              'checked', true));
       await vpn.waitForQuery(
-          queries.screenSettings.privacyView.BLOCK_TRACKERS.visible().prop(
-              'isChecked', false));
+          queries.screenSettings.privacyView.BLOCK_TRACKERS_TOGGLE.visible().prop(
+              'checked', false));
       await vpn.waitForQuery(
-          queries.screenSettings.privacyView.BLOCK_MALWARE.visible().prop(
-              'isChecked', true));
+          queries.screenSettings.privacyView.BLOCK_MALWARE_TOGGLE.visible().prop(
+              'checked', true));
   
       await vpn.setSetting('dnsProviderFlags', 12);
       await vpn.waitForQuery(
-          queries.screenSettings.privacyView.BLOCK_ADS.visible().prop(
-              'isChecked', false));
+          queries.screenSettings.privacyView.BLOCK_ADS_TOGGLE.visible().prop(
+              'checked', false));
       await vpn.waitForQuery(
-          queries.screenSettings.privacyView.BLOCK_TRACKERS.visible().prop(
-              'isChecked', true));
+          queries.screenSettings.privacyView.BLOCK_TRACKERS_TOGGLE.visible().prop(
+              'checked', true));
       await vpn.waitForQuery(
-          queries.screenSettings.privacyView.BLOCK_MALWARE.visible().prop(
-              'isChecked', true));
+          queries.screenSettings.privacyView.BLOCK_MALWARE_TOGGLE.visible().prop(
+              'checked', true));
   
       await vpn.setSetting('dnsProviderFlags', 14);
       await vpn.waitForQuery(
-          queries.screenSettings.privacyView.BLOCK_ADS.visible().prop(
-              'isChecked', true));
+          queries.screenSettings.privacyView.BLOCK_ADS_TOGGLE.visible().prop(
+              'checked', true));
       await vpn.waitForQuery(
-          queries.screenSettings.privacyView.BLOCK_TRACKERS.visible().prop(
-              'isChecked', true));
+          queries.screenSettings.privacyView.BLOCK_TRACKERS_TOGGLE.visible().prop(
+              'checked', true));
       await vpn.waitForQuery(
-          queries.screenSettings.privacyView.BLOCK_MALWARE.visible().prop(
-              'isChecked', true));
+          queries.screenSettings.privacyView.BLOCK_MALWARE_TOGGLE.visible().prop(
+              'checked', true));
   
       // Tests the clicks
       await vpn.setSetting('dnsProviderFlags', 0);
       await vpn.waitForQueryAndClick(
-          queries.screenSettings.privacyView.BLOCK_ADS_CHECKBOX.visible());
+          queries.screenSettings.privacyView.BLOCK_ADS_TOGGLE.visible());
       assert.equal(await vpn.getSetting('dnsProviderFlags'), 2);
   
       await vpn.setSetting('dnsProviderFlags', 0);
       await vpn.waitForQueryAndClick(
-          queries.screenSettings.privacyView.BLOCK_TRACKERS_CHECKBOX.visible());
+          queries.screenSettings.privacyView.BLOCK_TRACKERS_TOGGLE.visible());
       assert.equal(await vpn.getSetting('dnsProviderFlags'), 4);
   
       await vpn.setSetting('dnsProviderFlags', 0);
       await vpn.waitForQueryAndClick(
-          queries.screenSettings.privacyView.BLOCK_MALWARE_CHECKBOX.visible());
+          queries.screenSettings.privacyView.BLOCK_MALWARE_TOGGLE.visible());
       assert.equal(await vpn.getSetting('dnsProviderFlags'), 8);
   
       // Let's test the modal
       await vpn.setSetting('dnsProviderFlags', 1);
       await vpn.waitForQueryAndClick(
-          queries.screenSettings.privacyView.BLOCK_ADS_CHECKBOX.visible());
+          queries.screenSettings.privacyView.BLOCK_ADS_TOGGLE.visible());
       assert.equal(await vpn.getSetting('dnsProviderFlags'), 1);
       await vpn.waitForQueryAndClick(
           queries.screenSettings.privacyView.MODAL_SECONDARY_BUTTON.visible());
@@ -235,7 +235,7 @@ describe('Settings', function() {
           queries.screenSettings.privacyView.MODAL_LOADER.prop('active', false));
       assert.equal(await vpn.getSetting('dnsProviderFlags'), 1);
       await vpn.waitForQueryAndClick(
-          queries.screenSettings.privacyView.BLOCK_ADS_CHECKBOX.visible());
+          queries.screenSettings.privacyView.BLOCK_ADS_TOGGLE.visible());
       assert.equal(await vpn.getSetting('dnsProviderFlags'), 1);
       await vpn.waitForQueryAndClick(
           queries.screenSettings.privacyView.MODAL_CLOSE_BUTTON.visible());
@@ -243,7 +243,7 @@ describe('Settings', function() {
           queries.screenSettings.privacyView.MODAL_LOADER.prop('active', false));
       assert.equal(await vpn.getSetting('dnsProviderFlags'), 1);
       await vpn.waitForQueryAndClick(
-          queries.screenSettings.privacyView.BLOCK_ADS_CHECKBOX.visible());
+          queries.screenSettings.privacyView.BLOCK_ADS_TOGGLE.visible());
       assert.equal(await vpn.getSetting('dnsProviderFlags'), 1);
       await vpn.waitForQueryAndClick(
           queries.screenSettings.privacyView.MODAL_PRIMARY_BUTTON.visible());
@@ -253,7 +253,7 @@ describe('Settings', function() {
   
       await vpn.setSetting('dnsProviderFlags', 1);
       await vpn.waitForQueryAndClick(
-          queries.screenSettings.privacyView.BLOCK_TRACKERS_CHECKBOX.visible());
+          queries.screenSettings.privacyView.BLOCK_TRACKERS_TOGGLE.visible());
       assert.equal(await vpn.getSetting('dnsProviderFlags'), 1);
       await vpn.waitForQueryAndClick(
           queries.screenSettings.privacyView.MODAL_SECONDARY_BUTTON.visible());
@@ -261,7 +261,7 @@ describe('Settings', function() {
           queries.screenSettings.privacyView.MODAL_LOADER.prop('active', false));
       assert.equal(await vpn.getSetting('dnsProviderFlags'), 1);
       await vpn.waitForQueryAndClick(
-          queries.screenSettings.privacyView.BLOCK_TRACKERS_CHECKBOX.visible());
+          queries.screenSettings.privacyView.BLOCK_TRACKERS_TOGGLE.visible());
       assert.equal(await vpn.getSetting('dnsProviderFlags'), 1);
       await vpn.waitForQueryAndClick(
           queries.screenSettings.privacyView.MODAL_CLOSE_BUTTON.visible());
@@ -269,7 +269,7 @@ describe('Settings', function() {
           queries.screenSettings.privacyView.MODAL_LOADER.prop('active', false));
       assert.equal(await vpn.getSetting('dnsProviderFlags'), 1);
       await vpn.waitForQueryAndClick(
-          queries.screenSettings.privacyView.BLOCK_TRACKERS_CHECKBOX.visible());
+          queries.screenSettings.privacyView.BLOCK_TRACKERS_TOGGLE.visible());
       assert.equal(await vpn.getSetting('dnsProviderFlags'), 1);
       await vpn.waitForQueryAndClick(
           queries.screenSettings.privacyView.MODAL_PRIMARY_BUTTON.visible());
@@ -279,7 +279,7 @@ describe('Settings', function() {
   
       await vpn.setSetting('dnsProviderFlags', 1);
       await vpn.waitForQueryAndClick(
-          queries.screenSettings.privacyView.BLOCK_MALWARE_CHECKBOX.visible());
+          queries.screenSettings.privacyView.BLOCK_MALWARE_TOGGLE.visible());
       assert.equal(await vpn.getSetting('dnsProviderFlags'), 1);
       await vpn.waitForQueryAndClick(
           queries.screenSettings.privacyView.MODAL_SECONDARY_BUTTON.visible());
@@ -287,7 +287,7 @@ describe('Settings', function() {
           queries.screenSettings.privacyView.MODAL_LOADER.prop('active', false));
       assert.equal(await vpn.getSetting('dnsProviderFlags'), 1);
       await vpn.waitForQueryAndClick(
-          queries.screenSettings.privacyView.BLOCK_MALWARE_CHECKBOX.visible());
+          queries.screenSettings.privacyView.BLOCK_MALWARE_TOGGLE.visible());
       assert.equal(await vpn.getSetting('dnsProviderFlags'), 1);
       await vpn.waitForQueryAndClick(
           queries.screenSettings.privacyView.MODAL_CLOSE_BUTTON.visible());
@@ -295,7 +295,7 @@ describe('Settings', function() {
           queries.screenSettings.privacyView.MODAL_LOADER.prop('active', false));
       assert.equal(await vpn.getSetting('dnsProviderFlags'), 1);
       await vpn.waitForQueryAndClick(
-          queries.screenSettings.privacyView.BLOCK_MALWARE_CHECKBOX.visible());
+          queries.screenSettings.privacyView.BLOCK_MALWARE_TOGGLE.visible());
       assert.equal(await vpn.getSetting('dnsProviderFlags'), 1);
       await vpn.waitForQueryAndClick(
           queries.screenSettings.privacyView.MODAL_PRIMARY_BUTTON.visible());
@@ -886,10 +886,10 @@ describe('Settings', function() {
     await vpn.clickOnQuery(queries.screenSettings.APP_PREFERENCES.visible());
 
     await checkSetting(
-        queries.screenSettings.appPreferencesView.START_AT_BOOT, 'startAtBoot');
+        queries.screenSettings.appPreferencesView.START_AT_BOOT_TOGGLE, 'startAtBoot');
 
     await checkSetting(
-        queries.screenSettings.appPreferencesView.DATA_COLLECTION,
+        queries.screenSettings.appPreferencesView.DATA_COLLECTION_TOGGLE,
         'gleanEnabled');
 
     await vpn.waitForQuery(


### PR DESCRIPTION
## Description

- Add `MZToggleRow` component (for toggles with labels, similar to [MZCheckBoxRow](https://github.com/mozilla-mobile/mozilla-vpn-client/blob/main/nebula/ui/components/MZCheckBoxRow.qml)
- Replaces checkboxes with toggles on 
  - Onboarding data slide
  - Onboarding privacy slide
  - Onboarding start slide (desktop)
  - Privacy feature settings
  - App preferences
  - Notification settings
- Add dividers to
  - Privacy feature list (onboarding and settings)
  - App preferences
  - Notification settings

## Reference

[VPN-6050: UX Improvement: Switch checkboxes to toggles](https://mozilla-hub.atlassian.net/browse/VPN-6050)