### PR TITLE
Adding logging to investigate VPN-5766

### DIFF
--- a/ConnectionHealth.swift
+++ b/ConnectionHealth.swift
@@ -1,0 +1,8 @@
+//
+//  ConnectionHealth.swift
+//  compat
+//
+//  Created by Matt Cleinman on 2/2/24.
+//
+
+import Foundation

--- a/src/platforms/macos/macospingsender.cpp
+++ b/src/platforms/macos/macospingsender.cpp
@@ -69,6 +69,7 @@ MacOSPingSender::~MacOSPingSender() {
 }
 
 void MacOSPingSender::sendPing(const QHostAddress& dest, quint16 sequence) {
+  logger.debug() << "Creating address";
   quint32 ipv4dest = dest.toIPv4Address();
   struct sockaddr_in addr;
   bzero(&addr, sizeof(addr));
@@ -76,6 +77,7 @@ void MacOSPingSender::sendPing(const QHostAddress& dest, quint16 sequence) {
   addr.sin_len = sizeof(addr);
   addr.sin_addr.s_addr = qToBigEndian<quint32>(ipv4dest);
 
+  logger.debug() << "Creating packet";
   struct icmp packet;
   bzero(&packet, sizeof packet);
   packet.icmp_type = ICMP_ECHO;
@@ -83,6 +85,7 @@ void MacOSPingSender::sendPing(const QHostAddress& dest, quint16 sequence) {
   packet.icmp_seq = htons(sequence);
   packet.icmp_cksum = inetChecksum(&packet, sizeof(packet));
 
+  logger.debug() << "Sending ping";
   if (sendto(m_socket, (char*)&packet, sizeof(packet), 0,
              (struct sockaddr*)&addr, sizeof(addr)) != sizeof(packet)) {
     logger.error() << "ping sending failed:" << strerror(errno);

--- a/src/platforms/macos/macospingsender.cpp
+++ b/src/platforms/macos/macospingsender.cpp
@@ -112,7 +112,7 @@ void MacOSPingSender::socketReady() {
 
   ssize_t rc = recvmsg(m_socket, &msg, MSG_DONTWAIT);
   if (rc <= 0) {
-    logger.error() << "Recvmsg failed";
+    logger.error() << "Recvmsg failed:" << rc;
     return;
   }
 


### PR DESCRIPTION
## Description

From prior and current investigation, iOS is crashing somewhere in this function. We don't have solid repro steps, though it's happening often enough to know we'll get a few samples a week from QA. These log lines are to start narrowing in on where the issue is. After we get crash logs from QA, we'll remove these log lines (and possibly add more logging in to figure out exactly where the problem lies). Then we'll fix it.

## Reference

VPN-5766 (sorta)

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
