### PR TITLE
No ticket nit fix to better position central icon

### DIFF
--- a/src/ui/screens/home/controller/ControllerImage.qml
+++ b/src/ui/screens/home/controller/ControllerImage.qml
@@ -338,8 +338,8 @@ Rectangle {
         height: 32
         width: 32
         radius: 16
-        x: 43
-        y: 5
+        x: 44
+        y: 4
         antialiasing: true
         smooth: true
 


### PR DESCRIPTION
## Description

This PR addresses a personal nit of mine I noticed while debugging something else: The status icon and background circle in `ControllerImage.qml` are off-center (see picture for reference). Here we adjust the positioning of said icon and circle to bring us back into alignment. 

<table>
<tr>
<th>Before</th><th>After</th>
</tr>
<tr>
<td>
<img width="348" alt="Screenshot 2024-02-02 at 1 28 39 PM" src="https://github.com/mozilla-mobile/mozilla-vpn-client/assets/22355127/59daeae0-e06a-415c-a471-94f3150d910b"><br />
Note the red circle is just the tiniest bit too low and too far left.
</td>
<td>
<img width="363" alt="Screenshot 2024-02-02 at 1 27 51 PM" src="https://github.com/mozilla-mobile/mozilla-vpn-client/assets/22355127/9f75a653-d298-4375-bf5f-43bfef458c01">

</td>
</tr>
</table>
VPN-6171