### PR TITLE
Introduce mz_add_new_module CMake utility

### DIFF
--- a/.dictionary
+++ b/.dictionary
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 232 utf-8
+personal_ws-1.1 en 246 utf-8
 ADRs
 APIs
 Adblock
@@ -10,14 +10,14 @@ CLI
 CMU
 CMake
 CSV
+CTest
 Changelog
 Conda
 ConnectionDiagnostics
-Docusaurus
 DNS
 DevOps
+Docusaurus
 FFI
-ffi
 FeatureList
 Figma
 FreeDesktop
@@ -59,13 +59,11 @@ Qt's
 QtLottie
 RCC
 README
-readme
 RSA
 Replacer
 Rizental
 Rustup
 SDKs
-sdks
 SHA
 Serde
 SettingsHolder
@@ -77,7 +75,6 @@ TOTP
 TP
 TaskGetFeatureList
 UniFFI
-uniffi
 WebAssembly
 WebSockets
 WiX
@@ -137,6 +134,7 @@ experimentalfeaturelist
 facto
 featurelist
 featuresOverride
+ffi
 frontend
 getters
 gobject
@@ -166,6 +164,7 @@ macosdaemon
 makefiles
 md
 miniconda
+modularization
 mozilla
 mozillavpn
 mozillavpnbionic
@@ -192,6 +191,7 @@ qml
 qmldir
 qrc
 rdparty
+readme
 reftag
 relink
 relinking
@@ -201,9 +201,10 @@ resolvconf
 rlottie
 runtime
 rustup
+sarah's
 scalable
 sdk
-sarah's
+sdks
 serverData
 settingHolder
 shader
@@ -221,6 +222,7 @@ tooltip
 ui
 ulist
 unenrolled
+uniffi
 uploader
 urls
 utils

--- a/.github/workflows/wasm_tests.yaml
+++ b/.github/workflows/wasm_tests.yaml
@@ -27,12 +27,12 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v3
         with:
-          submodules: 'true'
+          submodules: "true"
 
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
-          cache: 'pip'
+          python-version: "3.9"
+          cache: "pip"
       - run: pip install -r requirements.txt
 
       - name: Install Qt6
@@ -52,7 +52,8 @@ jobs:
           mkdir -p build/cmake
           /opt/$QTVERSION/wasm_32/bin/qt-cmake -S $(pwd) -B build/cmake -DCMAKE_BUILD_TYPE=Release \
             -DQT_HOST_PATH_CMAKE_DIR=/opt/$QTVERSION/gcc_64/lib/cmake \
-            -DQT_HOST_PATH=/opt/$QTVERSION/gcc_64
+            -DQT_HOST_PATH=/opt/$QTVERSION/gcc_64 \
+            -DBUILD_TESTS=OFF
           cmake --build build/cmake -j4
           cp -r build/cmake/wasm_build build/wasm_build
 
@@ -111,14 +112,14 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
-          cache: 'pip'
+          python-version: "3.9"
+          cache: "pip"
       - run: pip install -r requirements.txt
 
       - uses: actions/setup-node@v4
         with:
           node-version: 18
-          cache: 'npm'
+          cache: "npm"
       - run: npm install
 
       - name: Install test dependecies

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,9 +2,10 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.20)
 
-option(BUILD_TESTS "Whether or not to build test targets" ON)
+# The source file GENERATED property is visible from all directory scopes when set.
+cmake_policy(SET CMP0118 NEW)
 
 message("Configuring for ${CMAKE_GENERATOR}")
 get_property(IS_MULTI_CONFIG GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
@@ -25,7 +26,7 @@ project("Mozilla VPN" VERSION ${APP_VERSION} LANGUAGES C CXX
 include(CTest)
 add_custom_target(build_tests)
 set_target_properties(build_tests PROPERTIES
-        EXCLUDE_FROM_ALL ${BUILD_TESTS}
+        EXCLUDE_FROM_ALL TRUE
         FOLDER "Tests"
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,10 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-cmake_minimum_required(VERSION 3.20)
-
-# The source file GENERATED property is visible from all directory scopes when set.
-cmake_policy(SET CMP0118 NEW)
+cmake_minimum_required(VERSION 3.18)
 
 message("Configuring for ${CMAKE_GENERATOR}")
 get_property(IS_MULTI_CONFIG GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,8 @@
 
 cmake_minimum_required(VERSION 3.18)
 
+option(BUILD_TESTS "Whether or not to build test targets" ON)
+
 message("Configuring for ${CMAKE_GENERATOR}")
 get_property(IS_MULTI_CONFIG GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
 if(NOT (IS_MULTI_CONFIG OR DEFINED CMAKE_BUILD_TYPE))
@@ -23,7 +25,7 @@ project("Mozilla VPN" VERSION ${APP_VERSION} LANGUAGES C CXX
 include(CTest)
 add_custom_target(build_tests)
 set_target_properties(build_tests PROPERTIES
-        EXCLUDE_FROM_ALL TRUE
+        EXCLUDE_FROM_ALL ${BUILD_TESTS}
         FOLDER "Tests"
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,8 @@ cmake_minimum_required(VERSION 3.20)
 # The source file GENERATED property is visible from all directory scopes when set.
 cmake_policy(SET CMP0118 NEW)
 
+option(BUILD_TESTS "Whether or not to build test targets" ON)
+
 message("Configuring for ${CMAKE_GENERATOR}")
 get_property(IS_MULTI_CONFIG GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
 if(NOT (IS_MULTI_CONFIG OR DEFINED CMAKE_BUILD_TYPE))

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,9 @@
 
 cmake_minimum_required(VERSION 3.20)
 
+# The source file GENERATED property is visible from all directory scopes when set.
+cmake_policy(SET CMP0118 NEW)
+
 message("Configuring for ${CMAKE_GENERATOR}")
 get_property(IS_MULTI_CONFIG GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
 if(NOT (IS_MULTI_CONFIG OR DEFINED CMAKE_BUILD_TYPE))

--- a/docs/Building/cmake.md
+++ b/docs/Building/cmake.md
@@ -72,7 +72,7 @@ mz_add_new_module(
     - **`QT_DEPENDENCIES`**: Qt-specific dependencies. The `Qt::` prefix should be skipped from target names added to this list e.g. `Qt::Core`, becomes `Core`.
     - **`MZ_DEPENDENCIES`**: Other modules the current module depends on.
     - **`<PLATFORM>_DEPENDENCIES`**: Platform specific dependencies.
-    - **`TEST_DEPENDENCIES`**: Test specific dependencies. If the target name startes with `replace-<dep>`, test executables will replace `<dep>` with it.
+    - **`TEST_DEPENDENCIES`**: Test specific dependencies. If the target name starts with `replace-<dep>`, test executables will replace `<dep>` with it.
     - **`RUST_DEPENDENCIES`**: Rust crates the current module depends on. This expects the path to the directory that contains the crate's `Cargo.toml` file. `mz_add_new_module` will add steps to build and link to this crate automatically.
     - **`EXTRA_DEPENDENCIES`**: Any other dependency that doesn't fit in one of the above types.
 

--- a/docs/Building/cmake.md
+++ b/docs/Building/cmake.md
@@ -1,0 +1,157 @@
+# CMake Project Structure
+
+CMake is the main tool used to generate build configurations for the Mozilla VPN.
+
+> **Note**: The following document, apart from the above sentence, is about where we would like to be, not about where we are right now.
+> The modularization of the codebase is currently _ongoing_.
+
+# Modules
+
+The Mozilla VPN codebase is separated into modules and the main application.
+
+Each module is as a CMake target representing a static library. The main application,
+on the other hand, is also a CMake target but it represents an executable.
+
+These modules operate as self-contained entities. Upon linking, a module integrates all
+necessary dependencies, sources, include directories, compile definitions, and any other essential
+components required for its proper functioning.
+
+### Deciding when to create a module
+
+Creating a new module is a appropriate adding new features to the application.
+
+Modules come in handy when these new features need to be accessed by multiple other modules
+of the codebase or by both the main application and other modules.
+
+If the new functionality is only needed by one other module and not directly by the main application,
+it's usually simpler to just add it to that module instead of creating a whole new one.
+
+### Module structure
+
+Each module has it's own folder under the `src/` directory.
+
+Only source files that are part of the module should be inside it's directory.
+
+Unit test files for the module live under the `tests/` directory of the module.
+
+```
+    src/
+        mymodule/
+            CMakeLists.txt
+            modulefile1.cpp
+            modulefile1.h
+            modulefile2.cpp
+            modulefile2.g
+            tests/
+                test1.cpp
+                test1.h
+                test2.cpp
+                test2.h
+```
+
+### Creating the module
+
+Each module is created using the `mz_add_new_module` utility function.
+
+```
+mz_add_new_module(
+    TARGET_NAME mz_mymodule
+    INCLUDE_DIRECTORIES ${CMAKE_CURRENT_SOURCE_DIR}/include
+    SOURCES src/file1.cpp src/file2.cpp
+    TEST_SOURCES tests/test_file.cpp
+    MZ_DEPENDENCIES mz_module
+)
+```
+
+#### Arguments
+
+- **`TARGET_NAME` (required)**: The name of the CMake target containing this module. All target names should start with the prefix `mz_`.
+- **`INCLUDE_DIRECTORIES` (optional)**: List of include directories for this module.
+- **`SOURCES`, `<PLATFORM>_SOURCES`, `TEST_SOURCES` (optional)**: List of source files. When prefixed with `<PLATFORM>_` the source file is only included when building for a specific platform. See more about the test sources under "Testing the module".
+- **`<TYPE>_DEPENDENCIES` (optional)**: List of CMake targets the module depends on.
+    - **`QT_DEPENDENCIES`**: Qt-specific dependencies. The `Qt::` prefix should be skipped from target names added to this list e.g. `Qt::Core`, becomes `Core`.
+    - **`MZ_DEPENDENCIES`**: Other modules the current module depends on.
+    - **`<PLATFORM>_DEPENDENCIES`**: Platform specific dependencies.
+    - **`TEST_DEPENDENCIES`**: Test specific dependencies. If the target name startes with `replace-<dep>`, test executables will replace `<dep>` with it.
+    - **`RUST_DEPENDENCIES`**: Rust crates the current module depends on. This expects the path to the directory that contains the crate's `Cargo.toml` file. `mz_add_new_module` will add steps to build and link to this crate automatically.
+    - **`EXTRA_DEPENDENCIES`**: Any other dependency that doesn't fit in one of the above types.
+
+### Importing the module on the main project
+
+Upon creating a new module, it's necessary to reference it within the main CMake project.
+
+To achieve this, do `add_subdirectory(<path>/<to>/mymodule)` within the root `src/CMakeLists.txt` file, for example.
+
+Once this step is completed, executing `cmake -S . -B build` will automatically generate build rules for the new module.
+
+Subsequently, the module can be linked to the main project by referencing it appropriately:
+
+```
+target_link_libraries(mozillavpn PRIVATE mz_mymodule)
+```
+
+Or built by itself:
+
+```
+cmake --build build -j${nproc} --target mz_mymodule
+```
+
+### Testing the module
+
+Each pair of `.cpp` and `.h` files added to the `TEST_SOURCES` list of a module will become a test executable.
+
+Each test executable can be built by itself. For example:
+
+```
+    src/
+        mymodule/
+            ...
+            tests/
+                test1.cpp
+                test1.h
+                test2.cpp
+                test2.h
+```
+
+`mz_add_new_module` will create a separate CMake target for `test1` and `test2`, which can be built in isolation.
+
+Test targets are named, `<modulename>-<testfilename>`. Therefore in this case, two new targets are created:
+`mz_mymodule-test1` and `mz_mymodule-test2`. These can be built by themselves like so:
+
+```
+cmake --build build -j${nproc} --target mz_mymodule-test1
+cmake --build build -j${nproc} --target mz_mymodule-test2
+```
+
+In order to run these executables, we can use CTest or just run them directly:
+
+```
+ctest --test-dir build -R mz_mymodule-test1 --output-on-failure --verbose
+ctest --test-dir build -R mz_mymodule-test2 --output-on-failure --verbose
+```
+
+or
+
+```
+build/src/mz_mymodule/tests/mz_mymodule-test1
+build/src/mz_mymodule/tests/mz_mymodule-test2
+```
+
+For convenience, a CMake target that include all tests under a module is also created:
+
+```
+cmake --build build -j${nproc} --target mz_mymodule-alltests
+```
+
+Finally, this target is also added as a dependency to the `build_tests` target. So that these tests
+are also built when building all tests for the project.
+
+```mermaid
+graph TD;
+    build_tests -->|Builds all tests| module1-alltests;
+    build_tests -->|Builds all tests| module2-alltests;
+    module1-alltests -->|Includes all tests| module1-test1;
+    module1-alltests -->|Includes all tests| module1-test2;
+    module2-alltests -->|Includes all tests| module2-test1;
+    module2-alltests -->|Includes all tests| module2-test2;
+```

--- a/docs/Components/cmake-project-structure.md
+++ b/docs/Components/cmake-project-structure.md
@@ -148,10 +148,10 @@ are also built when building all tests for the project.
 
 ```mermaid
 graph TD;
-    build_tests -->|Builds all tests| module1-alltests;
-    build_tests -->|Builds all tests| module2-alltests;
-    module1-alltests -->|Includes all tests| module1-test1;
-    module1-alltests -->|Includes all tests| module1-test2;
-    module2-alltests -->|Includes all tests| module2-test1;
-    module2-alltests -->|Includes all tests| module2-test2;
+    build_tests -->|depends on| module1-alltests;
+    build_tests -->|depends on| module2-alltests;
+    module1-alltests -->|depends on| module1-test1;
+    module1-alltests -->|depends on| module1-test2;
+    module2-alltests -->|depends on| module2-test1;
+    module2-alltests -->|depends on| module2-test2;
 ```

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -25,7 +25,7 @@ export const Grid = ({children}) => (
     {children}
   </span>
 );
-export const Preview = ({children}) =>(<iframe 
+export const Preview = ({children}) =>(<iframe
     src="https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/mozillavpn.v2.mozilla-vpn-client.branch.main.latest.build.wasm/artifacts/public%2Fbuild%2Fembedded.html"
     style={{
       width: "390px",
@@ -102,10 +102,10 @@ to manually installed. (For example, using Homebrew on macOS:
 When built for any one of the desktop platforms, this project will also generate
 a suite of unit tests.
 
-The tests are built manually specifying the `build_tests` target.
+The tests are built by default.
 
 ```bash
-cmake --build build --target build_tests -j $(nproc)
+cmake --build build -j $(nproc)
 ```
 
 Once built, you can run them with `ctest` as follows:

--- a/linux/debian/rules
+++ b/linux/debian/rules
@@ -15,7 +15,7 @@ endif
 	dh $@ --with=systemd --buildsystem=cmake+ninja --warn-missing
 
 override_dh_auto_configure:
-	dh_auto_configure -- -DWEBEXT_INSTALL_LIBDIR=/lib -DBUILD_ID=$(DEB_VERSION) -DBUILD_TESTING=OFF
+	dh_auto_configure -- -DWEBEXT_INSTALL_LIBDIR=/lib -DBUILD_ID=$(DEB_VERSION) -DBUILD_TESTS=OFF
 
 override_dh_auto_test:
 

--- a/scripts/android/cmake.sh
+++ b/scripts/android/cmake.sh
@@ -138,6 +138,7 @@ if [[ "$RELEASE" ]]; then
     -DANDROID_SDK_ROOT=$ANDROID_SDK_ROOT \
     -DCMAKE_BUILD_TYPE=Release \
     -DADJUST_TOKEN=$ADJUST_SDK_TOKEN \
+    -DBUILD_TESTS=OFF \
     -GNinja \
     -S . -B .tmp/
 else
@@ -149,6 +150,7 @@ else
     -DANDROID_NDK_ROOT=$ANDROID_NDK_ROOT \
     -DANDROID_SDK_ROOT=$ANDROID_SDK_ROOT \
     -DCMAKE_BUILD_TYPE=Debug \
+    -DBUILD_TESTS=OFF \
     -GNinja \
     -S . -B .tmp/
 
@@ -156,7 +158,7 @@ fi
 
 print Y "Compiling apk_install_target in .tmp/"
 # This compiles the client and generates a mozillavpn.so
-cmake --build .tmp -j$JOBS -DBUILD_TESTS=OFF
+cmake --build .tmp -j$JOBS
 
 # Generate a valid gradle project and pre-compile it.
 print Y "Generate Android Project"

--- a/scripts/android/cmake.sh
+++ b/scripts/android/cmake.sh
@@ -156,7 +156,7 @@ fi
 
 print Y "Compiling apk_install_target in .tmp/"
 # This compiles the client and generates a mozillavpn.so
-cmake --build .tmp -j$JOBS
+cmake --build .tmp -j$JOBS -DBUILD_TESTS=OFF
 
 # Generate a valid gradle project and pre-compile it.
 print Y "Generate Android Project"

--- a/scripts/cmake/utilities.cmake
+++ b/scripts/cmake/utilities.cmake
@@ -96,7 +96,29 @@ function(mz_add_new_module)
         MZ_ADD_NEW_MODULE # prefix
         "" # options
         "" # single-value args
-        "TARGET_NAME;INCLUDE_DIRECTORIES;SOURCES;IOS_SOURCES;ANDROID_SOURCES;MACOS_SOURCES;LINUX_SOURCES;WINDOWS_SOURCES;WASM_SOURCES;DUMMY_SOURCES;TEST_SOURCES;QT_DEPENDENCIES;MZ_DEPENDENCIES;RUST_DEPENDENCIES;EXTRA_DEPENDENCIES;TEST_DEPENDENCIES;IOS_DEPENDENCIES;ANDROID_DEPENDENCIES;MACOS_DEPENDENCIES;LINUX_DEPENDENCIES;WINDOWS_DEPENDENCIES;WASM_DEPENDENCIES;DUMMY_DEPENDENCIES" # multi-value args
+        "TARGET_NAME;
+         INCLUDE_DIRECTORIES;
+         SOURCES;
+         IOS_SOURCES;
+         ANDROID_SOURCES;
+         MACOS_SOURCES;
+         LINUX_SOURCES;
+         WINDOWS_SOURCES;
+         WASM_SOURCES;
+         DUMMY_SOURCES;
+         TEST_SOURCES;
+         QT_DEPENDENCIES;
+         MZ_DEPENDENCIES;
+         RUST_DEPENDENCIES;
+         EXTRA_DEPENDENCIES;
+         TEST_DEPENDENCIES;
+         IOS_DEPENDENCIES;
+         ANDROID_DEPENDENCIES;
+         MACOS_DEPENDENCIES;
+         LINUX_DEPENDENCIES;
+         WINDOWS_DEPENDENCIES;
+         WASM_DEPENDENCIES;
+         DUMMY_DEPENDENCIES" # multi-value args
         ${ARGN})
 
 
@@ -167,9 +189,9 @@ function(mz_add_new_module)
         add_dependencies(build_tests ${MZ_ADD_NEW_MODULE_TARGET_NAME}-alltests)
 
         set(CPP_TEST_FILES ${MZ_ADD_NEW_MODULE_TEST_SOURCES})
-        list(FILTER CPP_TEST_FILES INCLUDE REGEX "(.*)\\c\\p\\p$")
+        list(FILTER CPP_TEST_FILES INCLUDE REGEX "\.cpp$")
         set(QRC_TEST_FILES ${MZ_ADD_NEW_MODULE_TEST_SOURCES})
-        list(FILTER QRC_TEST_FILES INCLUDE REGEX "(.*)\\q\\r\\c$")
+        list(FILTER QRC_TEST_FILES INCLUDE REGEX "\.qrc$")
 
         foreach(TEST_FILE ${CPP_TEST_FILES})
             # The test executable name will be the name of the test file
@@ -192,8 +214,10 @@ function(mz_add_new_module)
                     ${TEST_LINK_LIBRARIES}
             )
 
+            add_dependencies(${MZ_ADD_NEW_MODULE_TARGET_NAME}-alltests ${TEST_TARGET_NAME})
+
             # Check if the corresponding header file exists
-            string(REGEX REPLACE ".cpp$" ".h" HEADER_FILE ${TEST_FILE})
+            string(REGEX REPLACE "\.cpp$" ".h" HEADER_FILE ${TEST_FILE})
             if(EXISTS ${HEADER_FILE})
                 # Add the header file to the executable if it exists.
                 target_sources(${TEST_TARGET_NAME} PRIVATE ${TEST_FILE})
@@ -237,6 +261,7 @@ function(mz_add_test_target)
     set_target_properties(${MZ_ADD_TEST_TARGET_NAME} PROPERTIES
         EXCLUDE_FROM_ALL TRUE
     )
+
 
     add_test(
         NAME ${MZ_ADD_TEST_TARGET_NAME}
@@ -335,7 +360,7 @@ function(mz_generate_link_libraries)
 
     # Replace dependencies for test dependencies that start with `replace-`
     set(REPLACER_DEPENDENCIES ${MZ_GENERATE_LINK_LIBRARIES_TEST_DEPENDENCIES})
-    list(FILTER REPLACER_DEPENDENCIES INCLUDE REGEX "^\\r\\e\\p\\l\\a\\c\\e\\-")
+    list(FILTER REPLACER_DEPENDENCIES INCLUDE REGEX "^replace-")
     foreach(REPLACER_DEPENDENCY ${REPLACER_DEPENDENCIES})
         # Get the name of the original dependency
         string(REPLACE "replace-" "" ORIGINAL_DEPENDENCY ${REPLACER_DEPENDENCY})
@@ -393,13 +418,13 @@ function(mz_generate_sources_list)
     # 2. Separate out Swift and ObjC sources
 
     set(SWIFT_SOURCES ${LOCAL_ALL_SOURCES})
-    list(FILTER SWIFT_SOURCES INCLUDE REGEX "(.*)\\s\\w\\i\\f\\t$")
+    list(FILTER SWIFT_SOURCES INCLUDE REGEX "\.swift$")
 
     set(OBJC_SOURCES ${LOCAL_ALL_SOURCES})
-    list(FILTER OBJC_SOURCES INCLUDE REGEX "(.*)\\m\\m$")
+    list(FILTER OBJC_SOURCES INCLUDE REGEX "\.mm$")
 
-    list(FILTER LOCAL_ALL_SOURCES EXCLUDE REGEX "(.*)\\s\\w\\i\\f\\t$")
-    list(FILTER LOCAL_ALL_SOURCES EXCLUDE REGEX "(.*)\\m\\m$")
+    list(FILTER LOCAL_ALL_SOURCES EXCLUDE REGEX "\.swift$")
+    list(FILTER LOCAL_ALL_SOURCES EXCLUDE REGEX "\.mm$")
 
     set(APPLE_SOURCES ${SWIFT_SOURCES} ${OBJC_SOURCES} PARENT_SCOPE)
 

--- a/scripts/cmake/utilities.cmake
+++ b/scripts/cmake/utilities.cmake
@@ -87,7 +87,6 @@ endfunction()
 # MZ_ADD_NEW_MODULE(
 #     TARGET_NAME MyModule
 #     INCLUDE_DIRECTORIES ${CMAKE_CURRENT_SOURCE_DIR}/include
-#     GENERATED_SOURCES ${CMAKE_CURRENT_BINARY_DIR}/generated_sources.cpp
 #     SOURCES src/file1.cpp src/file2.cpp
 #     TEST_SOURCES tests/test_file.cpp
 #     MZ_DEPENDENCIES mz_module

--- a/scripts/cmake/utilities.cmake
+++ b/scripts/cmake/utilities.cmake
@@ -1,5 +1,8 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-# Sets Defaults like `-Wall -Werror` if we know it will not 
+# Sets Defaults like `-Wall -Werror` if we know it will not
 # explode on that target + compiler
 function(mz_target_handle_warnings MZ_TARGET)
     if(MSVC OR IOS)
@@ -18,4 +21,439 @@ function(mz_target_handle_warnings MZ_TARGET)
     endif()
 
     target_compile_options( ${MZ_TARGET} ${scope} -Wall -Werror -Wno-conversion)
+endfunction()
+
+# MZ_ADD_NEW_MODULE: A utility function for adding a new module to this project.
+#
+# Targets added:
+# - TARGET_NAME
+# - <TARGET_NAME>-alltests -- Builds all tests for this target
+# - <TARGET_NAME>-<TESTFILENAME> -- Builds one specific test
+#
+# Usage:
+# MZ_ADD_NEW_MODULE(
+#     TARGET_NAME <target_name>
+#     [INCLUDE_DIRECTORIES <include_directories>]
+#     [SOURCES <sources>]
+#     [IOS_SOURCES <ios_sources>]
+#     [ANDROID_SOURCES <android_sources>]
+#     [MACOS_SOURCES <macos_sources>]
+#     [LINUX_SOURCES <linux_sources>]
+#     [WINDOWS_SOURCES <windows_sources>]
+#     [WASM_SOURCES <wasm_sources>]
+#     [DUMMY_SOURCES <dummy_sources>]
+#     [TEST_SOURCES <test_sources>]
+#     [QT_DEPENDENCIES <qt_dependencies>]
+#     [MZ_DEPENDENCIES <mz_dependencies>]
+#     [RUST_DEPENDENCIES <rust_dependencies>]
+#     [EXTRA_DEPENDENCIES <extra_dependencies>]
+#     [TEST_DEPENDENCIES <test_dependencies>]
+#     [ANDROID_DEPENDENCIES <android_dependencies>]
+#     [MACOS_DEPENDENCIES <macos_dependencies>]
+#     [LINUX_DEPENDENCIES <linux_dependencies>]
+#     [WINDOWS_DEPENDENCIES <windows_dependencies>]
+#     [WASM_DEPENDENCIES <wasm_dependencies>]
+#     [DUMMY_DEPENDENCIES <dummy_dependencies>]
+# )
+#
+# Parameters:
+# - TARGET_NAME: The name of the target module.
+# - INCLUDE_DIRECTORIES: (Optional) List of additional include directories for the module.
+# - SOURCES: (Optional) List of source files for the module.
+# - IOS_SOURCES: (Optional) List of iOS-specific source files for the module.
+# - ANDROID_SOURCES: (Optional) List of Android-specific source files for the module.
+# - MACOS_SOURCES: (Optional) List of macOS-specific source files for the module.
+# - LINUX_SOURCES: (Optional) List of Linux-specific source files for the module.
+# - WINDOWS_SOURCES: (Optional) List of Windows-specific source files for the module.
+# - WASM_SOURCES: (Optional) List of WebAssembly-specific source files for the module.
+# - DUMMY_SOURCES: (Optional) List of dummy sources for the module.
+# - TEST_SOURCES: (Optional) List of test source files for the module.
+# - QT_DEPENDENCIES: (Optional) List of Qt dependencies for the module.
+# - MZ_DEPENDENCIES: (Optional) List of custom module dependencies for the module.
+# - RUST_DEPENDENCIES: (Optional) List of Rust dependencies for the module.
+# - EXTRA_DEPENDENCIES: (Optional) List of additional dependencies for the module.
+# - TEST_DEPENDENCIES: (Optional) List of test-only dependencies.
+#   If the name of the dependency starts with `replace-<targetname>`
+#   it will replace <targetname> dependency for tests.
+# - IOS_DEPENDENCIES: (Optional) List of iOS-specific dependencies for the module.
+# - ANDROID_DEPENDENCIES: (Optional) List of Android-specific dependencies for the module.
+# - MACOS_DEPENDENCIES: (Optional) List of macOS-specific dependencies for the module.
+# - LINUX_DEPENDENCIES: (Optional) List of Linux-specific dependencies for the module.
+# - WINDOWS_DEPENDENCIES: (Optional) List of Windows-specific dependencies for the module.
+# - WASM_DEPENDENCIES: (Optional) List of WebAssembly-specific dependencies for the module.
+# - DUMMY_DEPENDENCIES: (Optional) List of dummy dependencies for the module.
+#
+# Example:
+# MZ_ADD_NEW_MODULE(
+#     TARGET_NAME MyModule
+#     INCLUDE_DIRECTORIES ${CMAKE_CURRENT_SOURCE_DIR}/include
+#     GENERATED_SOURCES ${CMAKE_CURRENT_BINARY_DIR}/generated_sources.cpp
+#     SOURCES src/file1.cpp src/file2.cpp
+#     TEST_SOURCES tests/test_file.cpp
+#     MZ_DEPENDENCIES mz_module
+# )
+function(mz_add_new_module)
+    cmake_parse_arguments(
+        MZ_ADD_NEW_MODULE # prefix
+        "" # options
+        "" # single-value args
+        "TARGET_NAME;INCLUDE_DIRECTORIES;SOURCES;IOS_SOURCES;ANDROID_SOURCES;MACOS_SOURCES;LINUX_SOURCES;WINDOWS_SOURCES;WASM_SOURCES;DUMMY_SOURCES;TEST_SOURCES;QT_DEPENDENCIES;MZ_DEPENDENCIES;RUST_DEPENDENCIES;EXTRA_DEPENDENCIES;TEST_DEPENDENCIES;IOS_DEPENDENCIES;ANDROID_DEPENDENCIES;MACOS_DEPENDENCIES;LINUX_DEPENDENCIES;WINDOWS_DEPENDENCIES;WASM_DEPENDENCIES;DUMMY_DEPENDENCIES" # multi-value args
+        ${ARGN})
+
+
+    # Create a static lib for the new module.
+    mz_add_library(
+        NAME ${MZ_ADD_NEW_MODULE_TARGET_NAME}
+        TYPE STATIC
+    )
+
+    # Generate sources lists
+    mz_generate_sources_list(
+        SOURCES ${MZ_ADD_NEW_MODULE_SOURCES}
+        IOS_SOURCES ${MZ_ADD_NEW_MODULE_IOS_SOURCES}
+        ANDROID_SOURCES ${MZ_ADD_NEW_MODULE_ANDROID_SOURCES}
+        MACOS_SOURCES ${MZ_ADD_NEW_MODULE_MACOS_SOURCES}
+        LINUX_SOURCES ${MZ_ADD_NEW_MODULE_LINUX_SOURCES}
+        WINDOWS_SOURCES ${MZ_ADD_NEW_MODULE_WINDOWS_SOURCES}
+        WASM_SOURCES ${MZ_ADD_NEW_MODULE_WASM_SOURCES}
+        DUMMY_SOURCES ${MZ_ADD_NEW_MODULE_DUMMY_SOURCES}
+    )
+    target_sources(${MZ_ADD_NEW_MODULE_TARGET_NAME} PRIVATE ${ALL_SOURCES})
+
+    # Generate dependencies lists
+    mz_generate_link_libraries(
+        QT_DEPENDENCIES  ${MZ_ADD_NEW_MODULE_QT_DEPENDENCIES}
+        MZ_DEPENDENCIES ${MZ_ADD_NEW_MODULE_MZ_DEPENDENCIES}
+        RUST_DEPENDENCIES ${MZ_ADD_NEW_MODULE_RUST_DEPENDENCIES}
+        EXTRA_DEPENDENCIES ${MZ_ADD_NEW_MODULE_EXTRA_DEPENDENCIES}
+        TEST_DEPENDENCIES ${MZ_ADD_NEW_MODULE_TEST_DEPENDENCIES}
+        IOS_DEPENDENCIES ${MZ_ADD_NEW_MODULE_IOS_DEPENDENCIES}
+        ANDROID_DEPENDENCIES ${MZ_ADD_NEW_MODULE_ANDROID_DEPENDENCIES}
+        MACOS_DEPENDENCIES ${MZ_ADD_NEW_MODULE_MACOS_DEPENDENCIES}
+        LINUX_DEPENDENCIES ${MZ_ADD_NEW_MODULE_LINUX_DEPENDENCIES}
+        WINDOWS_DEPENDENCIES ${MZ_ADD_NEW_MODULE_WINDOWS_DEPENDENCIES}
+        WASM_DEPENDENCIES ${MZ_ADD_NEW_MODULE_WASM_DEPENDENCIES}
+        DUMMY_DEPENDENCIES ${MZ_ADD_NEW_MODULE_DUMMY_DEPENDENCIES}
+    )
+    target_link_libraries(${MZ_ADD_NEW_MODULE_TARGET_NAME} PUBLIC ${LINK_LIBRARIES})
+
+    # Define include directories
+    target_include_directories(${MZ_ADD_NEW_MODULE_TARGET_NAME} PUBLIC
+        ${MZ_ADD_NEW_MODULE_INCLUDE_DIRECTORIES}
+    )
+
+    # Swift sources are added to a separate target.
+    if(APPLE_SOURCES)
+        mz_add_the_apple_stuff(
+            TARGET_NAME
+                ${MZ_ADD_NEW_MODULE_TARGET_NAME}
+            SOURCES
+                ${APPLE_SOURCES}
+            DEPENDENCIES
+                ${LINK_LIBRARIES}
+            INCLUDE_DIRECTORIES
+                ${MZ_ADD_NEW_MODULE_INCLUDE_DIRECTORIES}
+        )
+    endif()
+
+    # Create separate targets for each test,
+    # one target that builds all tests from this module
+    # and finally add this module's tests to the build_tests target which builds all tests.
+    if(MZ_ADD_NEW_MODULE_TEST_SOURCES)
+        add_custom_target(${MZ_ADD_NEW_MODULE_TARGET_NAME}-alltests)
+        set_target_properties(${MZ_ADD_NEW_MODULE_TARGET_NAME}-alltests PROPERTIES
+            EXCLUDE_FROM_ALL TRUE
+        )
+
+        add_dependencies(build_tests ${MZ_ADD_NEW_MODULE_TARGET_NAME}-alltests)
+
+        set(CPP_TEST_FILES ${MZ_ADD_NEW_MODULE_TEST_SOURCES})
+        list(FILTER CPP_TEST_FILES INCLUDE REGEX "(.*)\\c\\p\\p$")
+        set(QRC_TEST_FILES ${MZ_ADD_NEW_MODULE_TEST_SOURCES})
+        list(FILTER QRC_TEST_FILES INCLUDE REGEX "(.*)\\q\\r\\c$")
+
+        foreach(TEST_FILE ${CPP_TEST_FILES})
+            # The test executable name will be the name of the test file
+            # + the name of the parent target as a prefix.
+            get_filename_component(TEST_NAME ${TEST_FILE} NAME_WE)
+            set(TEST_TARGET_NAME "${MZ_ADD_NEW_MODULE_TARGET_NAME}-${TEST_NAME}")
+
+            mz_add_test_target(
+                TARGET_NAME
+                    ${TEST_TARGET_NAME}
+                TEST_COMMAND
+                    ${TEST_TARGET_NAME}
+                PARENT_TARGET
+                    ${MZ_ADD_NEW_MODULE_TARGET_NAME}
+                SOURCES
+                    ${TEST_FILE}
+                    ${QRC_TEST_FILES}
+                    ${ALL_SOURCES}
+                DEPENDENCIES
+                    ${TEST_LINK_LIBRARIES}
+            )
+
+            # Check if the corresponding header file exists
+            string(REGEX REPLACE ".cpp$" ".h" HEADER_FILE ${TEST_FILE})
+            if(EXISTS ${HEADER_FILE})
+                # Add the header file to the executable if it exists.
+                target_sources(${TEST_TARGET_NAME} PRIVATE ${TEST_FILE})
+            endif()
+        endforeach()
+    endif()
+endfunction()
+
+function(mz_add_library)
+    cmake_parse_arguments(
+        MZ_ADD_LIBRARY # prefix
+        "" # options
+        "" # single-value args
+        "NAME;TYPE" # multi-value args
+        ${ARGN})
+
+    add_library(${MZ_ADD_LIBRARY_NAME} ${MZ_ADD_LIBRARY_TYPE})
+    mz_target_handle_warnings(${MZ_ADD_LIBRARY_NAME})
+    target_compile_definitions(${MZ_ADD_LIBRARY_NAME} PUBLIC
+        "MZ_$<UPPER_CASE:${MZ_PLATFORM_NAME}>"
+        "$<$<CONFIG:Debug>:MZ_DEBUG>"
+    )
+    target_include_directories(${MZ_ADD_LIBRARY_NAME} PRIVATE
+        ${CMAKE_SOURCE_DIR}/src
+        ${CMAKE_CURRENT_SOURCE_DIR}
+    )
+endfunction()
+
+function(mz_add_test_target)
+    cmake_parse_arguments(
+        MZ_ADD_TEST # prefix
+        "" # options
+        "" # single-value args
+        "TARGET_NAME;TEST_COMMAND;PARENT_TARGET;SOURCES;DEPENDENCIES" # multi-value args
+        ${ARGN})
+
+    # Test targets are executable targets.
+    qt_add_executable(${MZ_ADD_TEST_TARGET_NAME}
+        ${MZ_ADD_TEST_SOURCES}
+    )
+    set_target_properties(${MZ_ADD_TEST_TARGET_NAME} PROPERTIES
+        EXCLUDE_FROM_ALL TRUE
+    )
+
+    add_test(
+        NAME ${MZ_ADD_TEST_TARGET_NAME}
+        COMMAND ${MZ_ADD_TEST_TEST_COMMAND}
+    )
+
+    target_compile_definitions(${MZ_ADD_TEST_TARGET_NAME} PRIVATE
+        UNIT_TEST
+        "MZ_$<UPPER_CASE:${MZ_PLATFORM_NAME}>"
+        "$<$<CONFIG:Debug>:MZ_DEBUG>"
+    )
+
+    target_link_libraries(${MZ_ADD_TEST_TARGET_NAME} PRIVATE Qt6::Test)
+    target_link_libraries(${MZ_ADD_TEST_TARGET_NAME} PUBLIC
+        ${MZ_ADD_TEST_PARENT_TARGET}
+        ${MZ_ADD_TEST_DEPENDENCIES}
+    )
+
+    target_include_directories(${TEST_TARGET_NAME} PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}
+        ${CMAKE_CURRENT_BINARY_DIR}
+        ${CMAKE_SOURCE_DIR}/src
+    )
+endfunction()
+
+# Sets the following new variables in the parent scope:
+#
+# LINK_LIBRARIES
+# TEST_LINK_LIBRARIES
+function(mz_generate_link_libraries)
+    cmake_parse_arguments(
+        MZ_GENERATE_LINK_LIBRARIES # prefix
+        "" # options
+        "" # single-value args
+        "QT_DEPENDENCIES;MZ_DEPENDENCIES;RUST_DEPENDENCIES;EXTRA_DEPENDENCIES;TEST_DEPENDENCIES;IOS_DEPENDENCIES;ANDROID_DEPENDENCIES;MACOS_DEPENDENCIES;LINUX_DEPENDENCIES;WINDOWS_DEPENDENCIES;WASM_DEPENDENCIES;DUMMY_DEPENDENCIES" # multi-value args
+        ${ARGN})
+
+    set(LOCAL_LINK_LIBRARIES)
+
+    # 1. Qt dependencies handling
+
+    # Get list of required Qt dependencies
+    find_package(Qt6 REQUIRED COMPONENTS ${MZ_GENERATE_LINK_LIBRARIES_QT_DEPENDENCIES})
+    foreach(QT_DEPENDENCY ${MZ_GENERATE_LINK_LIBRARIES_QT_DEPENDENCIES})
+        list(APPEND LOCAL_LINK_LIBRARIES "Qt6::${QT_DEPENDENCY}")
+    endforeach()
+
+    # 2. MZ dependencies handling
+
+    list(APPEND LOCAL_LINK_LIBRARIES ${MZ_GENERATE_LINK_LIBRARIES_MZ_DEPENDENCIES})
+
+    # 3. Rust dependencies handling
+
+    # Build Rust creates and add to list of linkd targets.
+    foreach(RUST_CRATE_PATH ${MZ_GENERATE_LINK_LIBRARIES_RUST_DEPENDENCIES})
+        # The name of the crate target is expected to be the name of the crate folder
+        get_filename_component(CRATE_NAME ${RUST_CRATE_PATH} NAME)
+
+        include(${CMAKE_SOURCE_DIR}/scripts/cmake/rustlang.cmake)
+        add_rust_library(${CRATE_NAME}
+            PACKAGE_DIR ${RUST_CRATE_PATH}
+            BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}
+            CRATE_NAME ${CRATE_NAME}
+        )
+
+        list(APPEND LOCAL_LINK_LIBRARIES ${CRATE_NAME})
+    endforeach()
+
+    # 4. Platform specific dependencies handling
+
+    if(${MZ_PLATFORM_NAME} STREQUAL "ios")
+        list(APPEND LOCAL_LINK_LIBRARIES ${MZ_GENERATE_LINK_LIBRARIES_IOS_DEPENDENCIES})
+    elseif(${MZ_PLATFORM_NAME} STREQUAL "android")
+        list(APPEND LOCAL_LINK_LIBRARIES ${MZ_GENERATE_LINK_LIBRARIES_ANDROID_DEPENDENCIES})
+    elseif(${MZ_PLATFORM_NAME} STREQUAL "macos")
+        list(APPEND LOCAL_LINK_LIBRARIES ${MZ_GENERATE_LINK_LIBRARIES_MACOS_DEPENDENCIES})
+    elseif(${MZ_PLATFORM_NAME} STREQUAL "linux")
+        list(APPEND LOCAL_LINK_LIBRARIES ${MZ_GENERATE_LINK_LIBRARIES_LINUX_DEPENDENCIES})
+    elseif(${MZ_PLATFORM_NAME} STREQUAL "windows")
+        list(APPEND LOCAL_LINK_LIBRARIES ${MZ_GENERATE_LINK_LIBRARIES_WINDOWS_DEPENDENCIES})
+    elseif(${MZ_PLATFORM_NAME} STREQUAL "wasm")
+        list(APPEND LOCAL_LINK_LIBRARIES ${MZ_GENERATE_LINK_LIBRARIES_WASM_DEPENDENCIES})
+    elseif(${MZ_PLATFORM_NAME} STREQUAL "dummy")
+        list(APPEND LOCAL_LINK_LIBRARIES ${MZ_GENERATE_LINK_LIBRARIES_DUMMY_DEPENDENCIES})
+    else()
+        message(FATAL_ERROR "MZ_PLATFORM_NAME must be set before creating modules.")
+    endif()
+
+    # 5. Finalize the list of all dependencies
+
+    list(APPEND LOCAL_LINK_LIBRARIES ${MZ_GENERATE_LINK_LIBRARIES_EXTRA_DEPENDENCIES})
+
+    # 6. Test dependency handling
+
+    set(LOCAL_TEST_LINK_LIBRARIES ${LOCAL_LINK_LIBRARIES})
+
+    # Replace dependencies for test dependencies that start with `replace-`
+    set(REPLACER_DEPENDENCIES ${MZ_GENERATE_LINK_LIBRARIES_TEST_DEPENDENCIES})
+    list(FILTER REPLACER_DEPENDENCIES INCLUDE REGEX "^\\r\\e\\p\\l\\a\\c\\e\\-")
+    foreach(REPLACER_DEPENDENCY ${REPLACER_DEPENDENCIES})
+        # Get the name of the original dependency
+        string(REPLACE "replace-" "" ORIGINAL_DEPENDENCY ${REPLACER_DEPENDENCY})
+        # Remove it  from the list
+        list(REMOVE_ITEM LOCAL_TEST_LINK_LIBRARIES ${ORIGINAL_DEPENDENCY})
+    endforeach()
+
+    # Tests always need Qt6::Test
+    find_package(Qt6 REQUIRED COMPONENTS Test)
+    list(APPEND LOCAL_TEST_LINK_LIBRARIES Qt6::Test)
+
+    # Finalize the list of test dependencies.
+    list(APPEND LOCAL_TEST_LINK_LIBRARIES ${MZ_GENERATE_LINK_LIBRARIES_TEST_DEPENDENCIES})
+
+    # 7. Set the lists in the parent scope.
+
+    set(LINK_LIBRARIES ${LOCAL_LINK_LIBRARIES} PARENT_SCOPE)
+    set(TEST_LINK_LIBRARIES ${LOCAL_TEST_LINK_LIBRARIES} PARENT_SCOPE)
+endfunction()
+
+# Sets the following new variables in the parent scope:
+#
+# ALL_SOURCES
+# APPLE_SOURCES -- These are no included in ALL_SOURCES.
+function(mz_generate_sources_list)
+    cmake_parse_arguments(
+        MZ_GENERATE_SOURCES_LIST # prefix
+        "" # options
+        "" # single-value args
+        "SOURCES;IOS_SOURCES;ANDROID_SOURCES;MACOS_SOURCES;LINUX_SOURCES;WINDOWS_SOURCES;WASM_SOURCES;DUMMY_SOURCES" # multi-value args
+        ${ARGN})
+
+    set(LOCAL_ALL_SOURCES ${MZ_GENERATE_SOURCES_LIST_SOURCES})
+
+    # 1. Handle platform specific sources
+
+    if(${MZ_PLATFORM_NAME} STREQUAL "ios")
+        list(APPEND LOCAL_ALL_SOURCES ${MZ_GENERATE_SOURCES_LIST_IOS_SOURCES})
+    elseif(${MZ_PLATFORM_NAME} STREQUAL "android")
+        list(APPEND LOCAL_ALL_SOURCES ${MZ_GENERATE_SOURCES_LIST_ANDROID_SOURCES})
+    elseif(${MZ_PLATFORM_NAME} STREQUAL "macos")
+        list(APPEND LOCAL_ALL_SOURCES ${MZ_GENERATE_SOURCES_LIST_MACOS_SOURCES})
+    elseif(${MZ_PLATFORM_NAME} STREQUAL "linux")
+        list(APPEND LOCAL_ALL_SOURCES ${MZ_GENERATE_SOURCES_LIST_LINUX_SOURCES})
+    elseif(${MZ_PLATFORM_NAME} STREQUAL "windows")
+        list(APPEND LOCAL_ALL_SOURCES ${MZ_GENERATE_SOURCES_LIST_WINDOWS_SOURCES})
+    elseif(${MZ_PLATFORM_NAME} STREQUAL "wasm")
+        list(APPEND LOCAL_ALL_SOURCES ${MZ_GENERATE_SOURCES_LIST_WASM_SOURCES})
+    elseif(${MZ_PLATFORM_NAME} STREQUAL "dummy")
+        list(APPEND LOCAL_ALL_SOURCES ${MZ_GENERATE_SOURCES_LIST_DUMMY_SOURCES})
+    else()
+        message(FATAL_ERROR "MZ_PLATFORM_NAME must be set before creating modules.")
+    endif()
+
+    # 2. Separate out Swift and ObjC sources
+
+    set(SWIFT_SOURCES ${LOCAL_ALL_SOURCES})
+    list(FILTER SWIFT_SOURCES INCLUDE REGEX "(.*)\\s\\w\\i\\f\\t$")
+
+    set(OBJC_SOURCES ${LOCAL_ALL_SOURCES})
+    list(FILTER OBJC_SOURCES INCLUDE REGEX "(.*)\\m\\m$")
+
+    list(FILTER LOCAL_ALL_SOURCES EXCLUDE REGEX "(.*)\\s\\w\\i\\f\\t$")
+    list(FILTER LOCAL_ALL_SOURCES EXCLUDE REGEX "(.*)\\m\\m$")
+
+    set(APPLE_SOURCES ${SWIFT_SOURCES} ${OBJC_SOURCES} PARENT_SCOPE)
+
+    # 3. Set the list in the parent scope.
+
+    set(ALL_SOURCES ${LOCAL_ALL_SOURCES} PARENT_SCOPE)
+endfunction()
+
+# Swift and Obj-C files are all added to a separate target that includes
+# all apple stuff and the Obj-C bridging header.
+#
+# I (Bea) could not figure out how to make a static lib into an
+# importable swift module, so this was easier. The ObjC stuff was added here as well,
+# because otherwise ObjC files don't find the brdiging header. Hacky include directories
+# shenanigans were considered, but we decided it was too hacky.
+set(APPLE_SPECIFIC_TARGET_NAME mz_apple_stuff)
+function(mz_add_the_apple_stuff)
+    cmake_parse_arguments(
+        MZ_ADD_APPLE_STUFF # prefix
+        "" # options
+        "" # single-value args
+        "TARGET_NAME;SOURCES;DEPENDENCIES;INCLUDE_DIRECTORIES" # multi-value args
+        ${ARGN})
+
+    # Create the Swift target if it doesn't exist.
+    if(NOT TARGET ${APPLE_SPECIFIC_TARGET_NAME})
+        mz_add_library(
+            NAME ${APPLE_SPECIFIC_TARGET_NAME}
+            TYPE STATIC
+        )
+        set_target_properties(${APPLE_SPECIFIC_TARGET_NAME} PROPERTIES
+            XCODE_ATTRIBUTE_SWIFT_VERSION "5.0"
+            XCODE_ATTRIBUTE_CLANG_ENABLE_MODULES "YES"
+            XCODE_ATTRIBUTE_SWIFT_OBJC_INTERFACE_HEADER_NAME "MozillaVPN-Swift.h"
+            # Do not strip debug symbols on copy
+            XCODE_ATTRIBUTE_COPY_PHASE_STRIP "NO"
+            XCODE_ATTRIBUTE_STRIP_INSTALLED_PRODUCT "NO"
+            XCODE_ATTRIBUTE_SKIP_INSTALL "YES"
+        )
+    endif()
+
+    target_sources(${APPLE_SPECIFIC_TARGET_NAME} PUBLIC
+        ${MZ_ADD_APPLE_STUFF_SOURCES}
+    )
+    target_include_directories(${APPLE_SPECIFIC_TARGET_NAME} PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}
+        ${MZ_ADD_APPLE_STUFF_INCLUDE_DIRECTORIES}
+    )
+    target_link_libraries(${APPLE_SPECIFIC_TARGET_NAME} PRIVATE
+        ${MZ_ADD_APPLE_STUFF_DEPENDENCIES}
+    )
+
+    target_link_libraries(${MZ_ADD_APPLE_STUFF_TARGET_NAME} PUBLIC
+        ${APPLE_SPECIFIC_TARGET_NAME}
+    )
 endfunction()

--- a/scripts/cmake/utilities.cmake
+++ b/scripts/cmake/utilities.cmake
@@ -182,9 +182,6 @@ function(mz_add_new_module)
     # and finally add this module's tests to the build_tests target which builds all tests.
     if(MZ_ADD_NEW_MODULE_TEST_SOURCES)
         add_custom_target(${MZ_ADD_NEW_MODULE_TARGET_NAME}-alltests)
-        set_target_properties(${MZ_ADD_NEW_MODULE_TARGET_NAME}-alltests PROPERTIES
-            EXCLUDE_FROM_ALL TRUE
-        )
 
         add_dependencies(build_tests ${MZ_ADD_NEW_MODULE_TARGET_NAME}-alltests)
 
@@ -258,10 +255,6 @@ function(mz_add_test_target)
     qt_add_executable(${MZ_ADD_TEST_TARGET_NAME}
         ${MZ_ADD_TEST_SOURCES}
     )
-    set_target_properties(${MZ_ADD_TEST_TARGET_NAME} PROPERTIES
-        EXCLUDE_FROM_ALL TRUE
-    )
-
 
     add_test(
         NAME ${MZ_ADD_TEST_TARGET_NAME}

--- a/scripts/cmake/utilities.cmake
+++ b/scripts/cmake/utilities.cmake
@@ -84,8 +84,8 @@ endfunction()
 # - DUMMY_DEPENDENCIES: (Optional) List of dummy dependencies for the module.
 #
 # Example:
-# MZ_ADD_NEW_MODULE(
-#     TARGET_NAME MyModule
+# mz_add_new_module(
+#     TARGET_NAME mz_mymodule
 #     INCLUDE_DIRECTORIES ${CMAKE_CURRENT_SOURCE_DIR}/include
 #     SOURCES src/file1.cpp src/file2.cpp
 #     TEST_SOURCES tests/test_file.cpp

--- a/taskcluster/scripts/build/ios_build_debug.sh
+++ b/taskcluster/scripts/build/ios_build_debug.sh
@@ -54,7 +54,8 @@ qt-cmake -S . -B ${TASK_HOME}/build \
   -DCMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY="" \
   -DCMAKE_XCODE_ATTRIBUTE_CODE_SIGNING_REQUIRED="NO" \
   -DCMAKE_XCODE_ATTRIBUTE_CODE_SIGNING_ALLOWED="NO" \
-  -DCMAKE_BUILD_TYPE=Release
+  -DCMAKE_BUILD_TYPE=Release \
+  -DBUILD_TESTS=OFF
 
 print Y "Building the client..."
 cmake --build ${TASK_HOME}/build --config Release || die

--- a/taskcluster/scripts/build/macos_build.sh
+++ b/taskcluster/scripts/build/macos_build.sh
@@ -38,8 +38,17 @@ export LANG=en_US.utf-8
 export PYTHONIOENCODING="UTF-8"
 
 print Y "Installing conda"
-source ${TASK_WORKDIR}/fetches/bin/activate
-conda-unpack
+chmod +x ${MOZ_FETCHES_DIR}/miniconda.sh
+bash ${MOZ_FETCHES_DIR}/miniconda.sh -b -u -p ${TASK_HOME}/miniconda
+source ${TASK_HOME}/miniconda/bin/activate
+
+
+print Y "Installing provided conda env..."
+# TODO: Check why --force is needed if we install into TASK_HOME?
+conda env create --force -f env.yml
+conda activate VPN
+./scripts/macos/conda_install_extras.sh
+conda info
 
 # Conda Cannot know installed MacOS SDK'S
 # and as we use conda'provided clang/llvm
@@ -84,7 +93,8 @@ mkdir ${TASK_HOME}/build
 cmake -S . -B ${TASK_HOME}/build -GNinja \
         -DCMAKE_PREFIX_PATH=${MOZ_FETCHES_DIR}/qt_dist/lib/cmake \
         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-        -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64"
+        -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64" \
+        -DBUILD_TESTS=OFF
 
 print Y "Building the client..."
 cmake --build ${TASK_HOME}/build

--- a/taskcluster/scripts/build/wasm.sh
+++ b/taskcluster/scripts/build/wasm.sh
@@ -19,7 +19,8 @@ mkdir build
 $QTPATH/wasm_32/bin/qt-cmake -S . -B build \
     -DCMAKE_BUILD_TYPE=MinSizeRel \
     -DQT_HOST_PATH=/$QTPATH/gcc_64 \
-    -DQT_HOST_PATH_CMAKE_DIR=/$QTPATH/gcc_64/lib/cmake
+    -DQT_HOST_PATH_CMAKE_DIR=/$QTPATH/gcc_64/lib/cmake \
+    -DBUILD_TESTS=OFF
 cmake --build build -j8
 
 # Artifacts should be placed here!

--- a/tests/auth_tests/CMakeLists.txt
+++ b/tests/auth_tests/CMakeLists.txt
@@ -28,7 +28,11 @@ include_directories(${MZ_SOURCE_DIR}/hacl-star/kremlin/minimal)
 include_directories(${MZ_SOURCE_DIR}/ui/composer)
 include_directories(${CMAKE_SOURCE_DIR}/tests/auth_tests)
 
-qt_add_executable(app_auth_tests EXCLUDE_FROM_ALL MANUAL_FINALIZATION)
+qt_add_executable(app_auth_tests MANUAL_FINALIZATION)
+set_target_properties(app_auth_tests PROPERTIES
+    EXCLUDE_FROM_ALL ${BUILD_TESTS}
+    FOLDER "Tests"
+)
 add_dependencies(build_tests app_auth_tests)
 target_compile_definitions(app_auth_tests PRIVATE UNIT_TEST "MZ_$<UPPER_CASE:${MZ_PLATFORM_NAME}>")
 

--- a/tests/nativemessaging/CMakeLists.txt
+++ b/tests/nativemessaging/CMakeLists.txt
@@ -2,8 +2,11 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-qt_add_executable(nativemessaging_tests EXCLUDE_FROM_ALL)
-set_target_properties(nativemessaging_tests PROPERTIES FOLDER "Tests")
+qt_add_executable(nativemessaging_tests)
+set_target_properties(nativemessaging_tests PROPERTIES
+    EXCLUDE_FROM_ALL ${BUILD_TESTS}
+    FOLDER "Tests"
+)
 add_dependencies(build_tests nativemessaging_tests)
 
 target_link_libraries(nativemessaging_tests PRIVATE

--- a/tests/qml/CMakeLists.txt
+++ b/tests/qml/CMakeLists.txt
@@ -14,8 +14,11 @@ include_directories(${MZ_SOURCE_DIR}/hacl-star/kremlin/minimal)
 include_directories(${MZ_SOURCE_DIR}/ui/composer)
 include_directories(${CMAKE_SOURCE_DIR}/glean)
 
-qt_add_executable(qml_tests EXCLUDE_FROM_ALL)
-set_target_properties(qml_tests PROPERTIES FOLDER "Tests")
+qt_add_executable(qml_tests)
+set_target_properties(qml_tests PROPERTIES
+    EXCLUDE_FROM_ALL ${BUILD_TESTS}
+    FOLDER "Tests"
+)
 add_dependencies(build_tests qml_tests)
 
 target_link_libraries(qml_tests PRIVATE

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -15,8 +15,11 @@ include_directories(${MZ_SOURCE_DIR}/hacl-star/kremlin/minimal)
 include_directories(${MZ_SOURCE_DIR}/ui/composer)
 include_directories(${CMAKE_SOURCE_DIR}/tests/unit)
 
-qt_add_executable(unit_tests EXCLUDE_FROM_ALL)
-set_target_properties(unit_tests PROPERTIES FOLDER "Tests")
+qt_add_executable(unit_tests)
+set_target_properties(unit_tests PROPERTIES
+    EXCLUDE_FROM_ALL ${BUILD_TESTS}
+    FOLDER "Tests"
+)
 add_dependencies(build_tests unit_tests)
 target_link_libraries(unit_tests PRIVATE
     Qt6::Core


### PR DESCRIPTION
This is extracted from my YOLO sprint PR: https://github.com/mozilla-mobile/mozilla-vpn-client/pull/8961

The modularization itself is a lot of code, but maybe we can sneakly introduce the utility to create modules and if we happen to create a new module (please raise your hand now @strseb 👀 ) we can create it in this format?

Usage examples can be found all over that PR:

- https://github.com/mozilla-mobile/mozilla-vpn-client/pull/8961/files#diff-2660e919af9eddfb4d2b5933f6a0166edde95992e5813193b6f7eec51978a4da
- https://github.com/mozilla-mobile/mozilla-vpn-client/pull/8961/files#diff-76a02f3395033bf965cc8168ee9e36408f914cd1b6a4f57960998abc979e087d
- https://github.com/mozilla-mobile/mozilla-vpn-client/pull/8961/files#diff-b4e86c3c2ea7c1aa8ff606965604a64b8d68866dea660318e35e2543f37372b7
- https://github.com/mozilla-mobile/mozilla-vpn-client/pull/8961/files#diff-383906385b56894602bbb61b1d5968470b4eb5324959949af41c74449342f027
- https://github.com/mozilla-mobile/mozilla-vpn-client/pull/8961/files#diff-55ffab2043edfdc5b4edc06e31a6016365d051aa221a5d08004a793114589cc9
- https://github.com/mozilla-mobile/mozilla-vpn-client/pull/8961/files#diff-4b4dca15b7841d4d947d55cecf910e76f6c3dba6e2e01548a13ef2686f74839e
- https://github.com/mozilla-mobile/mozilla-vpn-client/pull/8961/files#diff-e27c8e325de5fa1be8ed0bd037301e77ba8c3bb756768837972f1fb79f1a2570
- https://github.com/mozilla-mobile/mozilla-vpn-client/pull/8961/files#diff-daa941ca76de1dba7afdcf49665d0cc636faacb747eb37c114add8282e3c5e8b
- https://github.com/mozilla-mobile/mozilla-vpn-client/pull/8961/files#diff-aca153d79dfeafc1bdc6c942f55b024cd97b8b2ee211fcdc833d44195fe64c88

---

One strong principle I used when desinging the module was that they were self contained. Meaning the module defines and contains all of it's dependencies, source files, test files, include directories, compile definitions and so on.

Targets that depend of the module just link to it and don't need to do anything else.