### PR TITLE
Nit: Enable node and pip cache in Github actions

### DIFF
--- a/.github/workflows/gh_pages.yaml
+++ b/.github/workflows/gh_pages.yaml
@@ -144,10 +144,10 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.9'
+          cache: 'pip'
       - name: Install python dependencies
         shell: bash
-        run: |
-          pip install -r requirements.txt
+        run: pip install -r requirements.txt
 
       - name: Generating addons
         shell: bash

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -104,11 +104,14 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: 'true'
+
       - uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: 18
+          cache: 'npm'
+      - run: npm install
+
       - name: Run languagelocalizer
         run: |
           cd tools/languagelocalizer
-          npm install 
           node languageLocalizer.js --check

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -24,6 +24,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y aspell aspell-en $(./scripts/linux/getdeps.py -b linux/debian/control)
+
       - uses: actions/setup-python@v4
         with:
           python-version: '3.9'

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -27,7 +27,9 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.9'
+          cache: 'pip'
       - run: pip install -r requirements.txt
+
       - name: Importing translation files
         shell: bash
         run: |

--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -20,14 +20,17 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
+
       - uses: actions/setup-python@v4
         with:
           python-version: '3.9'
+          cache: 'pip'
+      - run: pip install -r requirements.txt
+
       - name: Install source dependencies
         shell: bash
         run: |
           sudo apt-get install golang debhelper -y
-          pip install -r requirements.txt
 
       - name: Build source bundle
         shell: bash

--- a/.github/workflows/linux_tests.yaml
+++ b/.github/workflows/linux_tests.yaml
@@ -28,13 +28,15 @@ jobs:
       - run: |
           sudo apt-get update
           sudo apt-get install -y $(./scripts/linux/getdeps.py -a linux/debian/control)
+
       - uses: actions/setup-python@v4
         with:
           python-version: '3.9'
+          cache: 'pip'
+
       - name: Install build dependencies
         shell: bash
-        run: |
-          pip install -r requirements.txt
+        run: pip install -r requirements.txt
           
       - name: Cache grcov
         id: cache-grcov

--- a/.github/workflows/linux_tests.yaml
+++ b/.github/workflows/linux_tests.yaml
@@ -114,11 +114,18 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y $(./scripts/linux/getdeps.py -r linux/debian/control)
           sudo apt install --no-upgrade firefox xvfb -y
-          npm install
+
       - uses: actions/setup-python@v4
         with:
           python-version: '3.9'
       - run: pip install -r requirements.txt
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: 'npm'
+      -run: npm install
+
       - name: Cache grcov
         id: cache-grcov
         uses: actions/cache@v3

--- a/.github/workflows/linux_tests.yaml
+++ b/.github/workflows/linux_tests.yaml
@@ -33,10 +33,7 @@ jobs:
         with:
           python-version: '3.9'
           cache: 'pip'
-
-      - name: Install build dependencies
-        shell: bash
-        run: pip install -r requirements.txt
+      - run: pip install -r requirements.txt
           
       - name: Cache grcov
         id: cache-grcov
@@ -118,6 +115,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.9'
+          cache: 'pip'
       - run: pip install -r requirements.txt
 
       - uses: actions/setup-node@v4

--- a/.github/workflows/linux_tests.yaml
+++ b/.github/workflows/linux_tests.yaml
@@ -124,7 +124,7 @@ jobs:
         with:
           node-version: 18
           cache: 'npm'
-      -run: npm install
+      - run: npm install
 
       - name: Cache grcov
         id: cache-grcov

--- a/.github/workflows/macos_tests.yaml
+++ b/.github/workflows/macos_tests.yaml
@@ -105,11 +105,13 @@ jobs:
         with:
           python-version: '3.9'
           cache: 'pip'
+      - run: pip install -r requirements.txt
 
-      - name: Install test dependecies
-        run: |
-          pip install -r requirements.txt
-          npm install
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: 'npm'
+      -run: npm install
 
       - name: Check build
         shell: bash

--- a/.github/workflows/macos_tests.yaml
+++ b/.github/workflows/macos_tests.yaml
@@ -100,9 +100,12 @@ jobs:
         with:
           name: test-client-${{ github.sha }}
           path: build/
+
       - uses: actions/setup-python@v4
         with:
           python-version: '3.9'
+          cache: 'pip'
+
       - name: Install test dependecies
         run: |
           pip install -r requirements.txt

--- a/.github/workflows/macos_tests.yaml
+++ b/.github/workflows/macos_tests.yaml
@@ -111,7 +111,7 @@ jobs:
         with:
           node-version: 18
           cache: 'npm'
-      -run: npm install
+      - run: npm install
 
       - name: Check build
         shell: bash

--- a/.github/workflows/ppa-automation.yaml
+++ b/.github/workflows/ppa-automation.yaml
@@ -23,7 +23,9 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.9'
+          cache: 'pip'
       - run: pip install -r requirements.txt
+
       - name: Install dependencies
         shell: bash
         run: |

--- a/.github/workflows/test_unit.yaml
+++ b/.github/workflows/test_unit.yaml
@@ -27,9 +27,11 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y $(./scripts/linux/getdeps.py -a linux/debian/control)
+
       - uses: actions/setup-python@v4
         with:
           python-version: '3.9'
+          cache: 'pip'
       - run: pip install -r requirements.txt
 
       - name: Cache grcov
@@ -214,6 +216,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.9'
+          cache: 'pip'
       - run: pip install -r requirements.txt
 
       - name: Building tests

--- a/.github/workflows/translations.yaml
+++ b/.github/workflows/translations.yaml
@@ -36,8 +36,7 @@ jobs:
         with:
           python-version: '3.9'
           cache: 'pip'
-      - name: Install python dependencies
-        run: pip install -r requirements.txt
+      - run: pip install -r requirements.txt
 
       - name: Generating translations
         run: |

--- a/.github/workflows/translations.yaml
+++ b/.github/workflows/translations.yaml
@@ -31,12 +31,13 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y $(./scripts/linux/getdeps.py -a linux/debian/control)
+
       - uses: actions/setup-python@v4
         with:
           python-version: '3.9'
+          cache: 'pip'
       - name: Install python dependencies
-        run: |
-          pip install -r requirements.txt
+        run: pip install -r requirements.txt
 
       - name: Generating translations
         run: |

--- a/.github/workflows/wasm_tests.yaml
+++ b/.github/workflows/wasm_tests.yaml
@@ -116,10 +116,15 @@ jobs:
           cache: 'pip'
       - run: pip install -r requirements.txt
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: 'npm'
+      -run: npm install
+
       - name: Install test dependecies
         run: |
           sudo apt install --no-upgrade firefox xvfb -y
-          npm install
 
       - name: Running ${{ matrix.test.name }} Tests
         id: runTests

--- a/.github/workflows/wasm_tests.yaml
+++ b/.github/workflows/wasm_tests.yaml
@@ -120,7 +120,7 @@ jobs:
         with:
           node-version: 18
           cache: 'npm'
-      -run: npm install
+      - run: npm install
 
       - name: Install test dependecies
         run: |

--- a/.github/workflows/wasm_tests.yaml
+++ b/.github/workflows/wasm_tests.yaml
@@ -31,10 +31,10 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.9'
+          cache: 'pip'
       - name: Install build dependencies
         shell: bash
-        run: |
-          pip install -r requirements.txt
+        run: pip install -r requirements.txt
 
       - name: Install Qt6
         shell: bash
@@ -109,10 +109,13 @@ jobs:
         with:
           name: WebAssembly Build Qt6
           path: build/
+
       - uses: actions/setup-python@v4
         with:
           python-version: '3.9'
+          cache: 'pip'
       - run: pip install -r requirements.txt
+
       - name: Install test dependecies
         run: |
           sudo apt install --no-upgrade firefox xvfb -y

--- a/.github/workflows/wasm_tests.yaml
+++ b/.github/workflows/wasm_tests.yaml
@@ -28,13 +28,12 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: 'true'
+
       - uses: actions/setup-python@v4
         with:
           python-version: '3.9'
           cache: 'pip'
-      - name: Install build dependencies
-        shell: bash
-        run: pip install -r requirements.txt
+      - run: pip install -r requirements.txt
 
       - name: Install Qt6
         shell: bash


### PR DESCRIPTION
## Description
We are getting a lot of spurious test failures due to connection errors when installing python and node packages, so let's see if we can stabilize the tests a bit by caching these packages between test runs. Fortunately, this is something supported by the `actions/setup-node@v4` and `actions/setup-python@v4` actions, we just have to turn it on.

## Reference
Github [actions/setup-node@v4](https://github.com/actions/setup-node#caching-global-packages-data) docs.
Github [actions/setup-python@v4](https://github.com/actions/setup-python#caching-packages-dependencies) docs

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
