### PR TITLE
Nit: Enable the pip cache for auth tests

### DIFF
--- a/.github/workflows/auth_tests.yml
+++ b/.github/workflows/auth_tests.yml
@@ -25,7 +25,12 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y $(./scripts/linux/getdeps.py -a linux/debian/control)
-          pip3 install -r requirements.txt
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+          cache: 'pip'
+      - run: pip install -r requirements.txt
 
       - name: Building tests
         shell: bash
@@ -54,9 +59,13 @@ jobs:
 
       - name: Install dependencies
         shell: bash
-        run: |
-          pip3 install -r requirements.txt
-          brew install ninja
+        run: brew install ninja
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+          cache: 'pip'
+      - run: pip install -r requirements.txt
 
       - name: Install Qt6
         shell: bash
@@ -111,10 +120,11 @@ jobs:
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v1.1
 
-      - name: Install depedencies
-        shell: bash
-        run: |
-          pip3 install -r requirements.txt
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+          cache: 'pip'
+      - run: pip install -r requirements.txt
 
       - name: Building tests
         run: |

--- a/.github/workflows/auth_tests.yml
+++ b/.github/workflows/auth_tests.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
       - "releases/**"
+  pull_request:
+    branches:
+      - main
+      - "releases/**"
 
 # Restrict tests to the most recent commit.
 concurrency:


### PR DESCRIPTION
## Description
In PR #9095 I enabled the PIP package cache in CI to try and stabilize the functional tests due to package download errors, and it seems to have improved things by quite a bit. However, I missed a spot and forgot the use of `pip3` which appears in the Auth tests. So let's add that too.

I wonder if adding the `actions/setup-python@v4` action will fix the sporadic python errors noted in PR #8722

## Reference
Github PR #9095

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
