### PR TITLE
Update taskcluster conda to 23.11.0

### DIFF
--- a/taskcluster/kinds/fetch/kind.yml
+++ b/taskcluster/kinds/fetch/kind.yml
@@ -45,10 +45,10 @@ tasks:
         description: Miniconda Installer
         fetch: 
             type: static-url
-            url: https://repo.anaconda.com/miniconda/Miniconda3-py310_23.1.0-1-Windows-x86_64.exe
-            sha256: d4517212c8ac44fd8b5ccc2d4d9f38c2dd924c77a81c2be92c3a72e70dd3e907
+            url: https://repo.anaconda.com/miniconda/Miniconda3-py310_23.11.0-2-Windows-x86_64.exe
+            sha256: f242f98378691496851f78beaf466797fb20251ba5092840c794503594d37726
             artifact-name: miniconda_installer.exe
-            size: 55780192
+            size: 80281312
     wintun:
         description: Wintun Driver
         fetch: 
@@ -60,10 +60,10 @@ tasks:
         description: MiniConda3 osx-x86 Python 3.10 
         fetch:
             type: static-url 
-            url: https://repo.anaconda.com/miniconda/Miniconda3-py310_22.11.1-1-MacOSX-x86_64.sh
-            sha256: 7406579393427eaf9bc0e094dcd3c66d1e1b93ee9db4e7686d0a72ea5d7c0ce5
+            url: https://repo.anaconda.com/miniconda/Miniconda3-py310_23.11.0-2-MacOSX-x86_64.sh
+            sha256: 07a6f46146993510d5d839ee014fc2229f7870d92aa73a52f11dd240833f08fb
             artifact-name: miniconda.sh
-            size: 46574107
+            size: 106401416
         fetch-alias: miniconda-osx
     qt-source-tarball:
         description: Qt 6.2.4 Source Tarball


### PR DESCRIPTION
## Description
I have noticed that we seem to occasionally get download errors when fetching packages in Conda that look something like this:

```
[task 2024-02-07T17:53:39.589Z] Collecting package metadata (repodata.json): ...working... failed
[task 2024-02-07T17:53:39.602Z] 
[task 2024-02-07T17:53:39.602Z] # >>>>>>>>>>>>>>>>>>>>>> ERROR REPORT <<<<<<<<<<<<<<<<<<<<<<
[task 2024-02-07T17:53:39.602Z] 
[task 2024-02-07T17:53:39.602Z]     Traceback (most recent call last):
[task 2024-02-07T17:53:39.602Z]       File "/opt/worker/tasks/task_169453793109859/checkouts/vcs/lib/python3.10/site-packages/urllib3/response.py", line 761, in _update_chunk_length
[task 2024-02-07T17:53:39.602Z]         self.chunk_left = int(line, 16)
[task 2024-02-07T17:53:39.602Z]     ValueError: invalid literal for int() with base 16: b''
[task 2024-02-07T17:53:39.602Z]     
[task 2024-02-07T17:53:39.602Z]     During handling of the above exception, another exception occurred:
[task 2024-02-07T17:53:39.602Z]     
[task 2024-02-07T17:53:39.602Z]     Traceback (most recent call last):
[task 2024-02-07T17:53:39.602Z]       File "/opt/worker/tasks/task_169453793109859/checkouts/vcs/lib/python3.10/site-packages/urllib3/response.py", line 444, in _error_catcher
[task 2024-02-07T17:53:39.602Z]         yield
[task 2024-02-07T17:53:39.602Z]       File "/opt/worker/tasks/task_169453793109859/checkouts/vcs/lib/python3.10/site-packages/urllib3/response.py", line 828, in read_chunked
[task 2024-02-07T17:53:39.602Z]         self._update_chunk_length()
[task 2024-02-07T17:53:39.602Z]       File "/opt/worker/tasks/task_169453793109859/checkouts/vcs/lib/python3.10/site-packages/urllib3/response.py", line 765, in _update_chunk_length
[task 2024-02-07T17:53:39.602Z]         raise InvalidChunkLength(self, line)
[task 2024-02-07T17:53:39.602Z]     urllib3.exceptions.InvalidChunkLength: InvalidChunkLength(got length b'', 0 bytes read)
[task 2024-02-07T17:53:39.602Z]     
```

This is exception isn't properly caught by Conda, which can result in a failure of the toolchain tasks. Hopefully an update to our Conda versions will make things a bit more robust.

## Reference
Conda bugfix: https://github.com/conda/conda/pull/12487
Failed taskcluster job: https://firefox-ci-tc.services.mozilla.com/tasks/bETKG7wrRFSbcntYEhi-xw

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
