### PR TITLE
NIT: Fix Sentry Compile when using link.exe

### DIFF
--- a/src/cmake/sentry.cmake
+++ b/src/cmake/sentry.cmake
@@ -68,6 +68,7 @@ if( ${_SUPPORTED} GREATER -1 )
         target_link_libraries(shared-sources INTERFACE sentry.lib)
         target_link_libraries(shared-sources INTERFACE breakpad_client.lib)
         target_link_libraries(shared-sources INTERFACE dbghelp.lib)
+        target_link_libraries(shared-sources INTERFACE version.lib)
         SET(SENTRY_ARGS -DSENTRY_BACKEND=breakpad -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} )
     endif()
 


### PR DESCRIPTION
## Description
When compiling with vs-studio and therefore using link.exe, linking sentry fails. 
So we need to pass all libs manually, lld seems to just find this 😅 