### PR TITLE
VPN-6152 - Allow WebExt to talk to VPN

### DIFF
--- a/extension/bridge/src/main.rs
+++ b/extension/bridge/src/main.rs
@@ -17,7 +17,7 @@ const SERVER_AND_PORT: &str = "127.0.0.1:8754";
 
 const ALLOW_LISTED_WEBEXTENSIONS: [&str;2] = [
     "@testpilot-containers",
-    "vpn@mozilla.org"
+    "vpn@mozilla.com"
 ];
 
 #[derive(PartialEq)]

--- a/extension/bridge/src/main.rs
+++ b/extension/bridge/src/main.rs
@@ -15,8 +15,9 @@ use std::env;
 
 const SERVER_AND_PORT: &str = "127.0.0.1:8754";
 
-const ALLOW_LISTED_WEBEXTENSIONS: [&str;1] = [
-    "@testpilot-containers"
+const ALLOW_LISTED_WEBEXTENSIONS: [&str;2] = [
+    "@testpilot-containers",
+    "vpn@mozilla.org"
 ];
 
 #[derive(PartialEq)]

--- a/extension/manifests/linux/mozillavpn.json.in
+++ b/extension/manifests/linux/mozillavpn.json.in
@@ -3,5 +3,5 @@
   "description": "A fast, secure and easy to use VPN. Built by the makers of Firefox. ",
   "path": "@WEBEXT_INSTALL_LIBDIR@/mozillavpn/mozillavpnnp",
   "type": "stdio",
-  "allowed_extensions": [ "vpn@mozilla.org", "@testpilot-containers" ]
+  "allowed_extensions": [ "vpn@mozilla.com", "@testpilot-containers" ]
 }

--- a/extension/manifests/macos/mozillavpn.json
+++ b/extension/manifests/macos/mozillavpn.json
@@ -3,6 +3,6 @@
   "description": "A fast, secure and easy to use VPN. Built by the makers of Firefox. ",
   "path": "/Applications/Mozilla VPN.app/Contents/Resources/utils/mozillavpnnp",
   "type": "stdio",
-  "allowed_extensions": [ "vpn@mozilla.org", "@testpilot-containers" ]
+  "allowed_extensions": [ "vpn@mozilla.com", "@testpilot-containers" ]
 }
 

--- a/extension/manifests/windows/mozillavpn.json
+++ b/extension/manifests/windows/mozillavpn.json
@@ -3,5 +3,5 @@
   "description": "A fast, secure and easy to use VPN. Built by the makers of Firefox. ",
   "path": "mozillavpnnp.exe",
   "type": "stdio",
-  "allowed_extensions": [ "vpn@mozilla.org", "@testpilot-containers" ]
+  "allowed_extensions": [ "vpn@mozilla.com", "@testpilot-containers" ]
 }


### PR DESCRIPTION
## Description

To let the extension allow talking to the client, we need to make sure the right id is there c:
Looking at:
https://github.com/mozilla-extensions/mozilla-vpn-extension/blob/main/src/manifest.json#L8

we chose mozilla.com instead of .org