### PR TITLE
Fix: Taskcluster/MacOS ensure a fresh install of miniconda on each run

### DIFF
--- a/taskcluster/scripts/build/macos_build.sh
+++ b/taskcluster/scripts/build/macos_build.sh
@@ -40,6 +40,9 @@ export PYTHONIOENCODING="UTF-8"
 print Y "Checking conda hash..."
 shasum -a 256 ${MOZ_FETCHES_DIR}/miniconda.sh
 
+print Y "What's in ${TASK_HOME}?"
+ls -al ${TASK_HOME}
+
 if [ -e ${TASK_HOME}/miniconda ]; then
     print Y "Conda already exist?"
 

--- a/taskcluster/scripts/build/macos_build.sh
+++ b/taskcluster/scripts/build/macos_build.sh
@@ -42,7 +42,7 @@ shasum -a 256 ${MOZ_FETCHES_DIR}/miniconda.sh
 
 print Y "Installing conda"
 chmod +x ${MOZ_FETCHES_DIR}/miniconda.sh
-bash ${MOZ_FETCHES_DIR}/miniconda.sh -b -u -p ${TASK_HOME}/miniconda
+bash ${MOZ_FETCHES_DIR}/miniconda.sh -b -p ${TASK_HOME}/miniconda
 source ${TASK_HOME}/miniconda/bin/activate
 
 print Y "Conda version is..."

--- a/taskcluster/scripts/build/macos_build.sh
+++ b/taskcluster/scripts/build/macos_build.sh
@@ -37,12 +37,16 @@ export LC_ALL=en_US.utf-8
 export LANG=en_US.utf-8
 export PYTHONIOENCODING="UTF-8"
 
+print Y "Checking conda hash..."
+shasum -a 256 ${MOZ_FETCHES_DIR}/miniconda.sh
 
 print Y "Installing conda"
 chmod +x ${MOZ_FETCHES_DIR}/miniconda.sh
 bash ${MOZ_FETCHES_DIR}/miniconda.sh -b -u -p ${TASK_HOME}/miniconda
 source ${TASK_HOME}/miniconda/bin/activate
 
+print Y "Conda version is..."
+conda -V
 
 print Y "Installing provided conda env..."
 # TODO: Check why --force is needed if we install into TASK_HOME?

--- a/taskcluster/scripts/build/macos_build.sh
+++ b/taskcluster/scripts/build/macos_build.sh
@@ -53,7 +53,7 @@ if [ -e ${TASK_HOME}/miniconda ]; then
     ls -al ${TASK_HOME}/miniconda/bin
 
     print Y "Remove it."
-    rm -rf ${TAKS_HOME}/miniconda
+    rm -rf ${TASK_HOME}/miniconda
 fi
 
 print Y "Installing conda"

--- a/taskcluster/scripts/build/macos_build.sh
+++ b/taskcluster/scripts/build/macos_build.sh
@@ -40,12 +40,26 @@ export PYTHONIOENCODING="UTF-8"
 print Y "Checking conda hash..."
 shasum -a 256 ${MOZ_FETCHES_DIR}/miniconda.sh
 
+if [ -e ${TASK_HOME}/miniconda ]; then
+    print Y "Conda already exist?"
+
+    print Y "Listing prefix..."
+    ls -al ${TASK_HOME}/miniconda
+
+    print Y "Listing bin..."
+    ls -al ${TASK_HOME}/miniconda/bin
+
+    print Y "Found version..."
+    ${TASK_HOME}/miniconda/bin/conda -V
+fi
+
 print Y "Installing conda"
 chmod +x ${MOZ_FETCHES_DIR}/miniconda.sh
 bash ${MOZ_FETCHES_DIR}/miniconda.sh -b -p ${TASK_HOME}/miniconda
 source ${TASK_HOME}/miniconda/bin/activate
 
 print Y "Conda version is..."
+which conda
 conda -V
 
 print Y "Installing provided conda env..."

--- a/taskcluster/scripts/build/macos_build.sh
+++ b/taskcluster/scripts/build/macos_build.sh
@@ -52,8 +52,8 @@ if [ -e ${TASK_HOME}/miniconda ]; then
     print Y "Listing bin..."
     ls -al ${TASK_HOME}/miniconda/bin
 
-    print Y "Found version..."
-    ${TASK_HOME}/miniconda/bin/conda -V
+    print Y "Remove it."
+    rm -rf ${TAKS_HOME}/miniconda
 fi
 
 print Y "Installing conda"

--- a/taskcluster/scripts/build/macos_build.sh
+++ b/taskcluster/scripts/build/macos_build.sh
@@ -37,21 +37,8 @@ export LC_ALL=en_US.utf-8
 export LANG=en_US.utf-8
 export PYTHONIOENCODING="UTF-8"
 
-print Y "Checking conda hash..."
-shasum -a 256 ${MOZ_FETCHES_DIR}/miniconda.sh
-
-print Y "What's in ${TASK_HOME}?"
-ls -al ${TASK_HOME}
-
 if [ -e ${TASK_HOME}/miniconda ]; then
     print Y "Conda already exist?"
-
-    print Y "Listing prefix..."
-    ls -al ${TASK_HOME}/miniconda
-
-    print Y "Listing bin..."
-    ls -al ${TASK_HOME}/miniconda/bin
-
     print Y "Remove it."
     rm -rf ${TASK_HOME}/miniconda
 fi
@@ -60,10 +47,6 @@ print Y "Installing conda"
 chmod +x ${MOZ_FETCHES_DIR}/miniconda.sh
 bash ${MOZ_FETCHES_DIR}/miniconda.sh -b -p ${TASK_HOME}/miniconda
 source ${TASK_HOME}/miniconda/bin/activate
-
-print Y "Conda version is..."
-which conda
-conda -V
 
 print Y "Installing provided conda env..."
 # TODO: Check why --force is needed if we install into TASK_HOME?


### PR DESCRIPTION
## Description
It seems that the miniconda installation directory gets cached between task runs on our MacOS workers, and we run the installer with the `-u` option (for upgrade), which means that we never really install Conda and are just kind of relying on the cached version to be correct.

Unfortunately, when there are multiple versions of Conda being used by our taskcluster jobs, such as when upgrading packages, this can result in broken packages. To ensure that Conda is correctly installed, we should flush these caches when the job starts and do a fresh install.

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
