### PR TITLE
VPN-5521: Enable new onboarding

### DIFF
--- a/src/feature/featurelist.h
+++ b/src/feature/featurelist.h
@@ -144,7 +144,7 @@ FEATURE(newOnboarding,         // Feature ID
         FeatureCallback_true,  // Can be flipped on
         FeatureCallback_true,  // Can be flipped off
         QStringList(),         // feature dependencies
-        FeatureCallback_false)
+        FeatureCallback_true)
 
 FEATURE(notificationControl,     // Feature ID
         "Notification control",  // Feature name

--- a/tests/functional/helper.js
+++ b/tests/functional/helper.js
@@ -415,8 +415,13 @@ module.exports = {
     }
   },
 
-  async authenticateInApp(
-      clickOnPostAuthenticate = false, acceptTelemetry = false) {
+  async authenticateInApp(skipOnboarding = true) {
+    if (skipOnboarding) {
+      await this.setSetting('onboardingCompleted', 'true')
+      await this.setSetting('postAuthenticationShown', 'true')
+      await this.setSetting('telemetryPolicyShown', 'true')
+    }
+    
     // This method must be called when the client is on the "Get Started" view.
     await this.waitForInitialView();
 
@@ -445,13 +450,12 @@ module.exports = {
     await this.waitForMozillaProperty(
         'Mozilla.VPN', 'VPN', 'userState', 'UserAuthenticated');
 
-    if (clickOnPostAuthenticate) {
+    if (!skipOnboarding && !await this.isFeatureEnabled('newOnboarding')) {
       await this.waitForQuery(queries.screenPostAuthentication.BUTTON.visible());
       await this.clickOnQuery(
           queries.screenPostAuthentication.BUTTON.visible());
       await this.wait();
-    }
-    if (acceptTelemetry) {
+
       await this.waitForQuery(queries.screenTelemetry.BUTTON.visible());
       await this.clickOnQuery(queries.screenTelemetry.BUTTON.visible());
       await this.waitForQuery(queries.screenHome.CONTROLLER_TITLE.visible());

--- a/tests/functional/setupVpn.js
+++ b/tests/functional/setupVpn.js
@@ -117,7 +117,7 @@ exports.mochaHooks = {
       await vpn.reset();
       await vpn.setSetting('tipsAndTricksIntroShown', 'true');
       await vpn.setSetting('localhostRequestsOnly', 'true');
-      await vpn.authenticateInApp(true, true);
+      await vpn.authenticateInApp();
 
       const fileName = await vpn.settingsFileName();
 

--- a/tests/functional/setupWasm.js
+++ b/tests/functional/setupWasm.js
@@ -115,7 +115,7 @@ exports.mochaHooks = {
     await vpn.setSetting('tipsAndTricksIntroShown', 'true')
 
     if (this.currentTest.ctx.authenticationNeeded) {
-      await vpn.authenticateInApp(true, true);
+      await vpn.authenticateInApp();
     }
 
     // Add servers to the context so that stub endpoints can be modified in the

--- a/tests/functional/testCaptivePortal.js
+++ b/tests/functional/testCaptivePortal.js
@@ -69,8 +69,13 @@ describe('Captive portal', function() {
     assert.equal(vpn.lastNotification().title, null);
   });
 
-  it('Captive portal in the Telemetry policy view', async () => {
-    await vpn.authenticateInApp(true, false);
+  it('Captive portal in the Telemetry policy view', async function () {
+    //Telemetry policy view does not exist in new onboarding
+    if (await vpn.isFeatureEnabled('newOnboarding')) {
+      this.skip();
+    }
+
+    await vpn.authenticateInApp(false);
     // Setup - end
 
     await vpn.waitForQuery(queries.screenTelemetry.BUTTON.visible());

--- a/tests/functional/testHeartbeat.js
+++ b/tests/functional/testHeartbeat.js
@@ -65,8 +65,13 @@ describe('Backend failure', function() {
     await vpn.waitForQuery(queries.screenPostAuthentication.BUTTON.visible());
   });
 
-  it('BackendFailure in the Telemetry policy view', async () => {
-    await vpn.authenticateInApp(true, false);
+  it('BackendFailure in the Telemetry policy view', async function () {
+    //Telemetry policy view does not exist in new onboarding
+    if (await vpn.isFeatureEnabled('newOnboarding')) {
+      this.skip();
+    }
+
+    await vpn.authenticateInApp(false);
     await vpn.waitForQuery(queries.screenTelemetry.BUTTON.visible());
     await vpn.forceHeartbeatFailure();
     await vpn.waitForQuery(queries.screenTelemetry.BUTTON.visible());

--- a/tests/functional/testNavigation.js
+++ b/tests/functional/testNavigation.js
@@ -56,8 +56,13 @@ describe('Navigation bar', async function() {
   });
 
 
-  it('Is not visible over telemetry screen', async () => {
-    await vpn.authenticateInApp(true, false);
+  it('Is not visible over telemetry screen', async function () {
+    //Telemetry policy view does not exist in new onboarding
+    if (await vpn.isFeatureEnabled('newOnboarding')) {
+      this.skip();
+    }
+
+    await vpn.authenticateInApp(false);
     await vpn.waitForQuery(queries.screenTelemetry.BUTTON.visible());
     assert.equal(await navigationBarVisible(), 'false');
   });

--- a/tests/functional/testOnboarding.js
+++ b/tests/functional/testOnboarding.js
@@ -14,7 +14,7 @@ describe('Onboarding', function() {
     await vpn.flipFeatureOn("newOnboarding");
     assert.equal(await vpn.getSetting('onboardingCompleted'), false);
     assert.equal(await vpn.getSetting('onboardingStep'), 0);
-    await vpn.authenticateInApp();
+    await vpn.authenticateInApp(false);
   });
 
  async function completeOnboarding() {

--- a/tests/functional/testReplacer.js
+++ b/tests/functional/testReplacer.js
@@ -25,7 +25,7 @@ describe('Addon content replacer', function() {
     it('Replace the country/city names', async () => {
       // In this way we disable the 'home-replacement' addon.
       await vpn.setSetting('languageCode', 'it');
-      await vpn.authenticateInApp(true, true);
+      await vpn.authenticateInApp();
 
       await vpn.waitForQueryAndClick(
           queries.screenHome.SERVER_LIST_BUTTON.visible());

--- a/tests/functional/testSettings.js
+++ b/tests/functional/testSettings.js
@@ -1008,7 +1008,7 @@ describe('Settings', function() {
     await setup.startAndConnect();
     await vpn.setSetting('tipsAndTricksIntroShown', 'true');
     await vpn.setSetting('localhostRequestsOnly', 'true');
-    await vpn.authenticateInApp(true, true);
+    await vpn.authenticateInApp();
     await vpn.setGleanAutomationHeader();
 
     // turn on VPN

--- a/tests/functional/testSubscription.js
+++ b/tests/functional/testSubscription.js
@@ -114,7 +114,7 @@ describe('Subscription manager', function() {
          // When they try to turn the VPN on, they get the
          // "Subscribe to Mozilla VPN" screen.
 
-         await vpn.authenticateInApp(true, true);
+         await vpn.authenticateInApp();
 
          // Step 1: Override the Guardian endpoint to mock an expired
          // subscription.
@@ -142,7 +142,7 @@ describe('Subscription manager', function() {
          // redirected back to the controller home screen.
 
          if (!this.ctx.wasm) {
-           await vpn.authenticateInApp(true, true);
+           await vpn.authenticateInApp();
 
            // Mark the user subscription as inactive
            this.ctx.guardianOverrideEndpoints.GETs['/api/v1/vpn/account'].body =
@@ -222,7 +222,7 @@ describe('Subscription manager', function() {
          this.ctx.guardianOverrideEndpoints.GETs['/api/v1/vpn/account'].body =
              userDataActive;
 
-         await vpn.authenticateInApp(true, true);
+         await vpn.authenticateInApp();
 
          // Step 1: Override the Guardian endpoint to mock an expired
          // subscription. Set the error status to 500.
@@ -251,7 +251,7 @@ describe('Subscription manager', function() {
          // They enter No Signal, and once they toggle the VPN off
          // they get the "Subscribe to Mozilla VPN" screen.
 
-         await vpn.authenticateInApp(true, true);
+         await vpn.authenticateInApp();
 
          // toggle on VPN here
          await vpn.waitForQuery(queries.screenHome.CONTROLLER_TITLE.visible());

--- a/tests/functional/testUnsecuredNetworkAlert.js
+++ b/tests/functional/testUnsecuredNetworkAlert.js
@@ -63,8 +63,13 @@ describe('Unsecured network alert', function() {
       await vpn.waitForQuery(queries.screenInitialize.SIGN_UP_BUTTON.visible());
     });
 
-    it('Unsecured network alert in the Post authentication view', async () => {
-      await vpn.authenticateInApp(false, false);
+    it('Unsecured network alert in the Post authentication view', async function () {
+      //Post auth view does not exist in new onboarding
+      if (await vpn.isFeatureEnabled('newOnboarding')) {
+        this.skip();
+      }
+
+      await vpn.authenticateInApp(false);
       await vpn.waitForQuery(queries.screenPostAuthentication.BUTTON.visible());
 
       await vpn.forceUnsecuredNetworkAlert();
@@ -78,8 +83,13 @@ describe('Unsecured network alert', function() {
       await vpn.wait();
     });
 
-    it('Unsecured network alert in the Telemetry policy view', async () => {
-      await vpn.authenticateInApp(true, false);
+    it('Unsecured network alert in the Telemetry policy view', async function () {
+      //Telemetry view does not exist in new onboarding
+      if (await vpn.isFeatureEnabled('newOnboarding')) {
+        this.skip();
+      }
+
+      await vpn.authenticateInApp(false);
       await vpn.waitForQuery(queries.screenTelemetry.BUTTON.visible());
 
       await vpn.forceUnsecuredNetworkAlert();
@@ -93,7 +103,7 @@ describe('Unsecured network alert', function() {
     });
 
     it('Unsecured network alert in the Controller view', async () => {
-      await vpn.authenticateInApp(true, true);
+      await vpn.authenticateInApp();
       await vpn.waitForQuery(queries.screenHome.CONTROLLER_TITLE.visible());
       assert.equal(
           await vpn.getQueryProperty(


### PR DESCRIPTION
## Description

- Enables the New Onboarding feature by default
- Amend functional tests
  - Ensure functional tests pass with both the old and new onboarding
  - Skip old/new onboarding when not specifically being tested

## Reference

[VPN-5521: Turn on the New Onboarding feature flag](https://mozilla-hub.atlassian.net/browse/VPN-5521)
