### PR TITLE
Bump minimum cmake to 3.20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.20)
 
 message("Configuring for ${CMAKE_GENERATOR}")
 get_property(IS_MULTI_CONFIG GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)

--- a/linux/debian/control
+++ b/linux/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: mozilla <vpn@mozilla.com>
 Build-Depends: debhelper (>= 11.2),
                cdbs,
-               cmake (>= 3.18~),
+               cmake (>= 3.20~),
                flex,
                gcc (>=4:8.0.0~),
                g++ (>=4:8.0.0~),

--- a/scripts/cmake/addons.cmake
+++ b/scripts/cmake/addons.cmake
@@ -18,9 +18,7 @@ function(add_addon_target NAME)
 
     # Fix Ninja dependency tracking when dealing with absolute paths. 
     cmake_policy(PUSH)
-    if(${CMAKE_VERSION} VERSION_GREATER_EQUAL 3.20)
-        cmake_policy(SET CMP0116 NEW)
-    endif()
+    cmake_policy(SET CMP0116 NEW)
 
     if(NOT ADDON_OUTPUT_DIR)
         set(ADDON_OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR})
@@ -57,8 +55,7 @@ function(add_addon_target NAME)
         execute_process(OUTPUT_VARIABLE ADDON_ID OUTPUT_STRIP_TRAILING_WHITESPACE
             COMMAND ${PYTHON_EXECUTABLE} -c "import json; print(json.load(open('${MANIFEST_FILE}', encoding='utf-8'))['id'])")
 
-        if((CMAKE_GENERATOR MATCHES "Ninja") OR
-           (CMAKE_GENERATOR MATCHES "Makefiles" AND (CMAKE_VERSION VERSION_GREATER_EQUAL 3.20)))
+        if((CMAKE_GENERATOR MATCHES "Ninja") OR (CMAKE_GENERATOR MATCHES "Makefiles"))
             ## Depfiles are great, but they only work for some generators.
             file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${NAME}_deps)
             add_custom_command(

--- a/scripts/cmake/rustlang.cmake
+++ b/scripts/cmake/rustlang.cmake
@@ -124,19 +124,16 @@ function(build_rust_archives)
         list(APPEND RUST_BUILD_CARGO_ENV LD=${ANDROID_TOOLCHAIN_ROOT_BIN}/lld)
     endif()
 
-    if(CMAKE_GENERATOR MATCHES "Ninja")
+    if((CMAKE_GENERATOR MATCHES "Ninja") OR (CMAKE_GENERATOR MATCHES "Makefiles"))
         ## If we are building with Ninja, then we can improve build times by
         # specifying a DEPFILE to let CMake know when the library needs
         # building and when we can skip it.
-        #
-        # TODO: Since CMake 3.20 can also set a DEPFILE for Unix Makefiles too.
         set(RUST_BUILD_DEPENDENCY_FILE
             ${CMAKE_STATIC_LIBRARY_PREFIX}${RUST_BUILD_CRATE_NAME}.d
         )
         cmake_policy(PUSH)
-        if(${CMAKE_VERSION} VERSION_GREATER_EQUAL 3.20)
-            cmake_policy(SET CMP0116 NEW)
-        endif()
+        cmake_policy(SET CMP0116 NEW)
+
         ## Outputs for the release build
         add_custom_command(
             OUTPUT ${RUST_BUILD_BINARY_DIR}/${ARCH}/release/${RUST_LIBRARY_FILENAME}

--- a/tests/functional/addons/CMakeLists.txt
+++ b/tests/functional/addons/CMakeLists.txt
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.20)
 
 project(testing_addons VERSION 1.0.0 LANGUAGES CXX
         DESCRIPTION "Mozilla VPN Addons for Functional Testing"


### PR DESCRIPTION
## Description
The upcoming `mz_add_new_module()` work initially required a minimum CMake version of 3.20 to cleanup dependency handling when building the VPN code as modules. But unfortunately this broke on Ubuntu 20.04/Focal which our PPA only provided version 3.18.

Well, I went and updated the PPA to provide a backport of the Ubuntu 22.04/Jammy cmake package which should now give us access to CMake version 3.22. So, let's use it and cleanup some of our outstanding hacky workarounds for older CMakes.

## Reference
Github PR: #9090
Discussion: [here](https://github.com/mozilla-mobile/mozilla-vpn-client/pull/9090#discussion_r1480622632)
Backporting: https://github.com/oskirby/qt6-packaging/commit/db3b19117a337a20eef31734be98f08be522298c

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
