### PR TITLE
Update builds for Ubuntu/24.04 Noble Numbat

### DIFF
--- a/.github/workflows/ppa-automation.yaml
+++ b/.github/workflows/ppa-automation.yaml
@@ -61,7 +61,7 @@ jobs:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
           GNUPGHOME: ${{ runner.temp }}/gnupg-data
-          PPA_TARGET_DISTS: focal jammy lunar mantic
+          PPA_TARGET_DISTS: focal jammy mantic noble
           PPA_URL: ${{ steps.gen-source.outputs.ppa-url }}
         run: |
           mkdir -m700 $GNUPGHOME

--- a/taskcluster/kinds/build/linux.yml
+++ b/taskcluster/kinds/build/linux.yml
@@ -45,16 +45,6 @@ linux/jammy:
         name: linux-jammy
         type: build
 
-linux/lunar:
-    description: "Linux Build (Ubuntu/Lunar)"
-    treeherder:
-        platform: linux/lunar
-    worker:
-        docker-image: {in-tree: linux-build-lunar}
-    add-index-routes:
-        name: linux-lunar
-        type: build
-
 linux/mantic:
     description: "Linux Build (Ubuntu/Mantic)"
     treeherder:
@@ -63,6 +53,16 @@ linux/mantic:
         docker-image: {in-tree: linux-build-mantic}
     add-index-routes:
         name: linux-mantic
+        type: build
+
+linux/noble:
+    description: "Linux Build (Ubuntu/Noble)"
+    treeherder:
+        platform: linux/noble
+    worker:
+        docker-image: {in-tree: linux-build-noble}
+    add-index-routes:
+        name: linux-noble
         type: build
 
 linux/fedora-fc37:

--- a/taskcluster/kinds/docker-image/kind.yml
+++ b/taskcluster/kinds/docker-image/kind.yml
@@ -52,16 +52,17 @@ tasks:
         definition: linux-dpkg-build
         args:
             DOCKER_BASE_IMAGE: ubuntu:jammy
-    linux-build-lunar:
-        symbol: I(linux-lunar)
-        definition: linux-dpkg-build
-        args:
-            DOCKER_BASE_IMAGE: ubuntu:lunar
     linux-build-mantic:
         symbol: I(linux-mantic)
         definition: linux-dpkg-build
         args:
             DOCKER_BASE_IMAGE: ubuntu:mantic
+    linux-build-noble:
+        symbol: I(linux-noble)
+        definition: linux-dpkg-build
+        cache: false ## Disable caching while Ubuntu/Noble is in beta.
+        args:
+            DOCKER_BASE_IMAGE: ubuntu:noble
     linux-build-fedora-fc37:
         symbol: I(linux-fedora-fc37)
         definition: linux-rpm-build


### PR DESCRIPTION

## Description

Ubuntu 23.04 went EOL on January 25th, so let's update the builds to pick up the next LTS release which is currently in beta.

## Reference
Ubuntu/23.04 EOL [announcement](https://lists.ubuntu.com/archives/ubuntu-announce/2024-January/000298.html)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
