### PR TITLE
VPN-6041 iOS: Swift logging doesn't save to VPN log stream

### DIFF
--- a/src/platforms/ios/ioscontroller.swift
+++ b/src/platforms/ios/ioscontroller.swift
@@ -60,19 +60,19 @@ public class IOSControllerImpl : NSObject {
 
         switch session.status {
         case .connected:
-            IOSControllerImpl.logger.debug(message: "STATE CHANGED: connected")
+            IOSControllerImpl.logger.debug(message: "(IOSSwiftController) Debug: STATE CHANGED: connected")
         case .connecting:
-            IOSControllerImpl.logger.debug(message: "STATE CHANGED: connecting")
+            IOSControllerImpl.logger.debug(message: "(IOSSwiftController) Debug: STATE CHANGED: connecting")
         case .disconnected:
-            IOSControllerImpl.logger.debug(message: "STATE CHANGED: disconnected")
+            IOSControllerImpl.logger.debug(message: "(IOSSwiftController) Debug: STATE CHANGED: disconnected")
         case .disconnecting:
-            IOSControllerImpl.logger.debug(message: "STATE CHANGED: disconnecting")
+            IOSControllerImpl.logger.debug(message: "(IOSSwiftController) Debug: STATE CHANGED: disconnecting")
         case .invalid:
-            IOSControllerImpl.logger.debug(message: "STATE CHANGED: invalid")
+            IOSControllerImpl.logger.debug(message: "(IOSSwiftController) Debug: STATE CHANGED: invalid")
         case .reasserting:
-            IOSControllerImpl.logger.debug(message: "STATE CHANGED: reasserting")
+            IOSControllerImpl.logger.debug(message: "(IOSSwiftController) Debug: STATE CHANGED: reasserting")
         default:
-            IOSControllerImpl.logger.debug(message: "STATE CHANGED: unknown status")
+            IOSControllerImpl.logger.debug(message: "(IOSSwiftController) Debug: STATE CHANGED: unknown status")
         }
 
         // We care about "unknown" state changes.
@@ -117,7 +117,7 @@ public class IOSControllerImpl : NSObject {
     }
 
     @objc func connect(dnsServer: String, serverIpv6Gateway: String, serverPublicKey: String, serverIpv4AddrIn: String, serverPort: Int,  allowedIPAddressRanges: Array<VPNIPAddressRange>, reason: Int, gleanDebugTag: String, isSuperDooperFeatureActive: Bool, installationId: String, disconnectOnErrorCallback: @escaping () -> Void, onboardingCompletedCallback: @escaping () -> Void, vpnConfigPermissionResponseCallback: @escaping (Bool) -> Void) {
-        IOSControllerImpl.logger.debug(message: "Connecting")
+        IOSControllerImpl.logger.debug(message: "(IOSSwiftController) Debug: Connecting")
 
         TunnelManager.withTunnel { tunnel in
             // Let's remove the previous config if it exists.
@@ -164,7 +164,7 @@ public class IOSControllerImpl : NSObject {
             proto!.serverAddress = serverName;
 
             if #available(iOS 15.1, *) {
-                IOSControllerImpl.logger.debug(message: "Activating includeAllNetworks")
+                IOSControllerImpl.logger.debug(message: "(IOSSwiftController) Debug: Activating includeAllNetworks")
                 proto!.includeAllNetworks = true
                 proto!.excludeLocalNetworks = true
 
@@ -191,27 +191,27 @@ public class IOSControllerImpl : NSObject {
                 vpnConfigPermissionResponseCallback(saveError == nil)
                 
                 if let error = saveError {
-                    IOSControllerImpl.logger.error(message: "Connect Tunnel Save Error: \(error)")
+                    IOSControllerImpl.logger.error(message: "(IOSSwiftController) Debug: Connect Tunnel Save Error: \(error)")
                     disconnectOnErrorCallback()
                     return
                 }
 
-               IOSControllerImpl.logger.info(message: "Saving the tunnel succeeded")
+               IOSControllerImpl.logger.info(message: "(IOSSwiftController) Debug: Saving the tunnel succeeded")
 
                tunnel.loadFromPreferences { error in
                     if let error = error {
-                        IOSControllerImpl.logger.error(message: "Connect Tunnel Load Error: \(error)")
+                        IOSControllerImpl.logger.error(message: "(IOSSwiftController) Debug: Connect Tunnel Load Error: \(error)")
                         disconnectOnErrorCallback()
                         return
                     }
 
-                    IOSControllerImpl.logger.info(message: "Loading the tunnel succeeded")
+                    IOSControllerImpl.logger.info(message: "(IOSSwiftController) Debug: Loading the tunnel succeeded")
 
                     do {
                         if (reason == 1 /* ReasonSwitching */) {
                             let settings = config.asWgQuickConfig()
                             let message = TunnelMessage.configurationSwitch(settings)
-                            IOSControllerImpl.logger.info(message: "Sending new message \(message)")
+                            IOSControllerImpl.logger.info(message: "(IOSSwiftController) Debug: Sending new message \(message)")
                             try TunnelManager.session?.sendProviderMessage(message.encode()) {_ in return}
                         } else {
                             try TunnelManager.session?.startTunnel(options: ["source":"app"])
@@ -219,7 +219,7 @@ public class IOSControllerImpl : NSObject {
                         // If `try` didn't throw, run onboarding callback. This callback only matters when onboarding.
                         onboardingCompletedCallback()
                     } catch let error {
-                        IOSControllerImpl.logger.error(message: "Something went wrong: \(error)")
+                        IOSControllerImpl.logger.error(message: "(IOSSwiftController) Debug: Something went wrong: \(error)")
                         disconnectOnErrorCallback()
                         return
                     }
@@ -229,23 +229,23 @@ public class IOSControllerImpl : NSObject {
     }
 
     @objc func disconnect() {
-        IOSControllerImpl.logger.info(message: "Disconnecting")
+        IOSControllerImpl.logger.info(message: "(IOSSwiftController) Debug: Disconnecting")
         TunnelManager.session?.stopTunnel()
     }
 
     @objc func deleteOSTunnelConfig() {
-      IOSControllerImpl.logger.info(message: "Removing tunnel from iOS System Preferences")
+      IOSControllerImpl.logger.info(message: "(IOSSwiftController) Debug: Removing tunnel from iOS System Preferences")
       TunnelManager.withTunnel { tunnel in
         tunnel.removeFromPreferences(completionHandler: { error in
           if let error = error {
-            IOSControllerImpl.logger.info(message: "Error when removing tunnel \(error.localizedDescription)")
+            IOSControllerImpl.logger.info(message: "(IOSSwiftController) Debug: Error when removing tunnel \(error.localizedDescription)")
           }
         })
       }
     }
 
     @objc func checkStatus(callback: @escaping (String, String, String) -> Void) {
-        IOSControllerImpl.logger.info(message: "Check status")
+        IOSControllerImpl.logger.info(message: "(IOSSwiftController) Debug: Check status")
         
         TunnelManager.withTunnel { tunnel in
             let proto = tunnel.protocolConfiguration as? NETunnelProviderProtocol
@@ -280,12 +280,12 @@ public class IOSControllerImpl : NSObject {
 
             do {
                 let message = TunnelMessage.getRuntimeConfiguration;
-                IOSControllerImpl.logger.info(message: "Sending new message \(message)");
+                IOSControllerImpl.logger.info(message: "(IOSSwiftController) Debug: Sending new message \(message)");
                 try session.sendProviderMessage(message.encode()) { [callback] data in
                     guard let data = data,
                           let configString = String(data: data, encoding: .utf8)
                     else {
-                        IOSControllerImpl.logger.error(message: "Failed to convert data to string")
+                        IOSControllerImpl.logger.error(message: "(IOSSwiftController) Debug: Failed to convert data to string")
                         callback("", "", "")
                         return
                     }
@@ -293,7 +293,7 @@ public class IOSControllerImpl : NSObject {
                     callback("\(serverIpv4Gateway!)", "\(deviceIpv4Address!)", configString)
                 }
             } catch {
-                IOSControllerImpl.logger.error(message: "Failed to retrieve data from session. \(error)")
+                IOSControllerImpl.logger.error(message: "(IOSSwiftController) Debug: Failed to retrieve data from session. \(error)")
                 callback("", "", "")
             }
             

--- a/src/platforms/ios/ioslogger.swift
+++ b/src/platforms/ios/ioslogger.swift
@@ -50,7 +50,7 @@ public class IOSLoggerImpl : NSObject {
     func log(_ message: String, type: OSLogType) {
         os_log("%{public}@", log: self.log, type: type, message)
         
-        if (Bundle.main.bundlePath.hasSuffix(".appex")) {
+      if (Bundle.main.bundlePath.hasSuffix(".appex") || message.contains("(IOSSwiftController)")) {
             let currentDate = Date()
             let formattedDateString = dateFormatter.string(from: currentDate)
 


### PR DESCRIPTION
…troller

## Description

We are dropping all swift client side logs messages that are not in the network extension. This is problematic because we use the iOS logs to determine issues for the clients, and not seeing vital information such as VPN connection state for example could make it harder/impossible to effectively draw conclusions from the iOS logs.

Because in iOSLogger we were filtering the messages by only logging what's coming from `.appex` previously, we were missing this data. Simply removing the if statement `if (Bundle.main.bundlePath.hasSuffix(".appex")` doesn't resolve this because now we end up with some duplicate logs coming from the main app. 

The simplest fix I could think of which doesn't involves rewriting the logging code is to append the class name to the log messages coming from the swift controller, and expanding the if statement check to allow messages coming from `IOSSwiftController`. I would argue that this is a good practice in general because otherwise with the log statement we can't even tell where they're coming from. For example just seeing "Connecting" in logs gives no context as to where it's coming from. 

## Reference

    https://mozilla-hub.atlassian.net/browse/VPN-6041

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
