### PR TITLE
VPN-6021: Improve "App Exculsions" screen load time by switching from Repeater to ListView

### DIFF
--- a/nebula/ui/components/MZCheckBox.qml
+++ b/nebula/ui/components/MZCheckBox.qml
@@ -12,6 +12,7 @@ import "qrc:/nebula/utils/MZUiUtils.js" as MZUiUtils
 CheckBox {
     property var uiState: MZTheme.theme.uiState
     property string accessibleName
+    property alias checkBoxActiveFocusOnTab: checkBox.activeFocusOnTab
 
     id: checkBox
 

--- a/nebula/ui/components/MZList.qml
+++ b/nebula/ui/components/MZList.qml
@@ -7,6 +7,9 @@ import QtQuick.Controls
 
 import Mozilla.Shared 1.0
 
+// ListView with scroll bar and a ensureVisible() method that scrolls an item into the
+// ListView's visible viewport. (ensureVisible() is used by scrollToComponent())
+
 ListView {
     id: list
 

--- a/nebula/ui/components/MZList.qml
+++ b/nebula/ui/components/MZList.qml
@@ -18,7 +18,6 @@ ListView {
     Accessible.ignored: !visible
     boundsBehavior: Flickable.StopAtBounds
     highlightFollowsCurrentItem: true
-    clip: true
     Keys.onDownPressed: list.incrementCurrentIndex()
     Keys.onUpPressed: list.decrementCurrentIndex()
 

--- a/nebula/ui/components/MZList.qml
+++ b/nebula/ui/components/MZList.qml
@@ -7,7 +7,7 @@ import QtQuick.Controls
 
 import Mozilla.Shared 1.0
 
-// ListView with scroll bar and a ensureVisible() method that scrolls an item into the
+// ListView with scroll bar and an ensureVisible() method that scrolls an item into the
 // ListView's visible viewport. (ensureVisible() is used by scrollToComponent())
 
 ListView {
@@ -69,7 +69,7 @@ ListView {
         }
     }
 
-    // Scroll item into ListView's visible viewport region if necessary
+    // Scroll item into ListView's visible viewport region, if necessary
     function ensureVisible(item) {
         if(ensureVisAnimation.running) {
             ensureVisAnimation.stop();

--- a/nebula/ui/components/MZList.qml
+++ b/nebula/ui/components/MZList.qml
@@ -11,13 +11,11 @@ ListView {
     id: list
 
     property var accessibleName: ""
-    property alias listActiveFocusOnTab : list.activeFocusOnTab
 
     height:contentHeight
     Accessible.role: Accessible.List
     Accessible.name: accessibleName
     Accessible.ignored: !visible
-    activeFocusOnTab: true
     boundsBehavior: Flickable.StopAtBounds
     highlightFollowsCurrentItem: true
     clip: true
@@ -87,15 +85,15 @@ ListView {
         const itemHeight = item.height + bottomMargin;
         let scrollY;
 
-        // Scroll down to bring item into view. Occurs if the item is beyond the navbar's top (with a visible navbar) or beyond
-        // the window height (without a visible navbar).
+        // Scroll the item upwards into view. Occurs if the item is beyond the navbar's top while navbar is visible. Or if the
+        // item is beyond the window height while navbar is not visible.
         if((navbar.visible && isItemBeyondNavBarTop) || (!navbar.visible && isItemBeyondWindowHeight)) {
             const scrollDistance = item.mapToItem(window.contentItem, 0, 0).y + item.height - (window.height - bottomMargin);
 
             scrollY = list.contentY + scrollDistance;
         }
         else {
-            // Scroll up to bring item into view
+            // Scroll the item downwards into view
             if (itemY < list.contentY) {
                 scrollY = itemY - bottomMargin;
             }

--- a/nebula/ui/components/MZList.qml
+++ b/nebula/ui/components/MZList.qml
@@ -13,11 +13,11 @@ import Mozilla.Shared 1.0
 ListView {
     id: list
 
-    property var accessibleName: ""
+    property var _accessibleName: ""
 
     height:contentHeight
     Accessible.role: Accessible.List
-    Accessible.name: accessibleName
+    Accessible.name: _accessibleName
     Accessible.ignored: !visible
     boundsBehavior: Flickable.StopAtBounds
     highlightFollowsCurrentItem: true

--- a/nebula/ui/components/MZList.qml
+++ b/nebula/ui/components/MZList.qml
@@ -3,19 +3,117 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import QtQuick 2.5
+import QtQuick.Controls
+
+import Mozilla.Shared 1.0
 
 ListView {
     id: list
 
-    property var listName
+    property var accessibleName: ""
+    property alias listActiveFocusOnTab : list.activeFocusOnTab
+
     height:contentHeight
     Accessible.role: Accessible.List
-    Accessible.name: listName
+    Accessible.name: accessibleName
     Accessible.ignored: !visible
     activeFocusOnTab: true
-    interactive: false // disable scrolling on list since the entire window is scrollable
     boundsBehavior: Flickable.StopAtBounds
     highlightFollowsCurrentItem: true
+    clip: true
     Keys.onDownPressed: list.incrementCurrentIndex()
     Keys.onUpPressed: list.decrementCurrentIndex()
+
+    ScrollBar.vertical: ScrollBar {
+        readonly property real scrollBarWidth: Qt.platform.os === "osx" ? 6 : 10
+        id: scrollBar
+
+        Accessible.ignored: true
+        hoverEnabled: true
+        anchors.top: parent.top
+        anchors.bottom: parent.bottom
+        anchors.right: parent.right
+        anchors.rightMargin: Qt.platform.os === "osx" ? 2 : 0
+
+        background: Rectangle {
+            color: MZTheme.theme.transparent
+            anchors.fill: parent
+        }
+
+        contentItem: Rectangle {
+            color: MZTheme.colors.grey40
+            width: scrollBar.scrollBarWidth
+            implicitWidth: scrollBar.scrollBarWidth
+            radius: scrollBar.scrollBarWidth
+
+            opacity: scrollBar.pressed ? 0.5 :
+                   scrollBar.interactive && scrollBar.hovered ? 0.4 : 0.3
+            Behavior on opacity {
+                PropertyAnimation {
+                    duration: 100
+                }
+            }
+        }
+
+        font.pixelSize: 0 // QTBUG-96733 workaround
+        implicitWidth: scrollBarWidth
+        width: scrollBarWidth
+        minimumSize: 0
+
+        visible: list.interactive
+
+        Behavior on opacity {
+            PropertyAnimation {
+                duration: 100
+            }
+        }
+    }
+
+    // Scroll item into ListView's visible viewport region if necessary
+    function ensureVisible(item) {
+        if(ensureVisAnimation.running) {
+            ensureVisAnimation.stop();
+        }
+
+        const itemY = item.mapToItem(list.contentItem, 0, 0).y;
+
+        if (item.skipEnsureVisible || itemY < list.originY) {
+            return;
+        }
+
+        const isItemBeyondNavBarTop = (item.mapToItem(window.contentItem, 0, 0).y + item.height) > (window.height - MZTheme.theme.navBarHeightWithMargins);
+        const isItemBeyondWindowHeight = (item.mapToItem(window.contentItem, 0, 0).y + item.height) > window.height;
+        const bottomMargin = (navbar.visible && isItemBeyondNavBarTop) ? MZTheme.theme.navBarHeightWithMargins : MZTheme.theme.contentBottomMargin;
+        const itemHeight = item.height + bottomMargin;
+        let scrollY;
+
+        // Scroll down to bring item into view. Occurs if the item is beyond the navbar's top (with a visible navbar) or beyond
+        // the window height (without a visible navbar).
+        if((navbar.visible && isItemBeyondNavBarTop) || (!navbar.visible && isItemBeyondWindowHeight)) {
+            const scrollDistance = item.mapToItem(window.contentItem, 0, 0).y + item.height - (window.height - bottomMargin);
+
+            scrollY = list.contentY + scrollDistance;
+        }
+        else {
+            // Scroll up to bring item into view
+            if (itemY < list.contentY) {
+                scrollY = itemY - bottomMargin;
+            }
+        }
+
+        if (typeof(scrollY) === "undefined") {
+            return;
+        }
+
+        // Animate scroll to destination
+        ensureVisAnimation.to = scrollY;
+        ensureVisAnimation.start();
+    }
+
+    NumberAnimation on contentY {
+        id: ensureVisAnimation
+
+        duration: 300
+        easing.type: Easing.OutQuad
+    }
 }

--- a/nebula/ui/components/MZViewBase.qml
+++ b/nebula/ui/components/MZViewBase.qml
@@ -45,7 +45,7 @@ Item {
                 top: parent.top
                 left: parent.left
                 right: parent.right
-                topMargin: MZTheme.theme.viewBaseTopMargin
+                topMargin: vpnFlickable.interactive ? MZTheme.theme.viewBaseTopMargin : 0
                 bottomMargin: navbar.visible ? 0 : MZTheme.theme.rowHeight
             }
         }

--- a/nebula/ui/components/MZViewBase.qml
+++ b/nebula/ui/components/MZViewBase.qml
@@ -15,6 +15,7 @@ Item {
    property string _menuTitle: ""
    property string _accessibleName: ""
    property var _menuOnBackClicked
+   property bool _useTopMargin: true
    property alias _viewContentData: viewContent.data
    property alias _interactive: vpnFlickable.interactive
    property alias _contentHeight: vpnFlickable.contentHeight
@@ -45,7 +46,7 @@ Item {
                 top: parent.top
                 left: parent.left
                 right: parent.right
-                topMargin: vpnFlickable.interactive ? MZTheme.theme.viewBaseTopMargin : 0
+                topMargin: _useTopMargin ? MZTheme.theme.viewBaseTopMargin : 0
                 bottomMargin: navbar.visible ? 0 : MZTheme.theme.rowHeight
             }
         }

--- a/nebula/ui/components/MZViewBase.qml
+++ b/nebula/ui/components/MZViewBase.qml
@@ -15,7 +15,7 @@ Item {
    property string _menuTitle: ""
    property string _accessibleName: ""
    property var _menuOnBackClicked
-   property bool _useTopMargin: true
+   property bool _useMargins: true
    property alias _viewContentData: viewContent.data
    property alias _interactive: vpnFlickable.interactive
    property alias _contentHeight: vpnFlickable.contentHeight
@@ -46,8 +46,8 @@ Item {
                 top: parent.top
                 left: parent.left
                 right: parent.right
-                topMargin: _useTopMargin ? MZTheme.theme.viewBaseTopMargin : 0
-                bottomMargin: navbar.visible ? 0 : MZTheme.theme.rowHeight
+                topMargin: _useMargins ? MZTheme.theme.viewBaseTopMargin : 0
+                bottomMargin: (_useMargins && !navbar.visible) ? MZTheme.theme.rowHeight : 0
             }
         }
     }

--- a/nebula/ui/components/forms/MZSearchBar.qml
+++ b/nebula/ui/components/forms/MZSearchBar.qml
@@ -10,7 +10,7 @@ import Mozilla.VPN 1.0
 import components 0.1
 import components.forms 0.1
 
-ColumnLayout {
+FocusScope {
     property var _filterProxyCallback: () => {}
     property var _sortProxyCallback: () => {}
     property var _editCallback: () => {}
@@ -19,62 +19,71 @@ ColumnLayout {
     property bool _searchBarHasError: false
     readonly property bool isEmpty: searchBar.length === 0
 
-    spacing: MZTheme.theme.windowMargin / 2
+    implicitHeight: searchBarColumn.implicitHeight
+    implicitWidth: searchBarColumn.implicitWidth
 
-    MZTextField {
-        id: searchBar
-        objectName: "searchBarTextField"
+    ColumnLayout {
+        id: searchBarColumn
 
-        Accessible.editable: false
-        Accessible.searchEdit: true
-        Layout.fillWidth: true
+        anchors.fill: parent
+        spacing: MZTheme.theme.windowMargin / 2
 
-        background: MZInputBackground {}
-        leftInset: MZTheme.theme.windowMargin * 3
-        leftPadding: MZTheme.theme.windowMargin * 3
-        rightPadding: MZTheme.theme.windowMargin * 3
-        rightInset: MZTheme.theme.windowMargin * 3
-        hasError: _searchBarHasError
+        MZTextField {
+            id: searchBar
+            objectName: "searchBarTextField"
 
-        onLengthChanged: text => model.invalidate()
-        onTextChanged: {
-            if (focus) {
-                _editCallback();
+            Accessible.editable: false
+            Accessible.searchEdit: true
+            Layout.fillWidth: true
+            focus: true
+
+            background: MZInputBackground {}
+            leftInset: MZTheme.theme.windowMargin * 3
+            leftPadding: MZTheme.theme.windowMargin * 3
+            rightPadding: MZTheme.theme.windowMargin * 3
+            rightInset: MZTheme.theme.windowMargin * 3
+            hasError: _searchBarHasError
+
+            onLengthChanged: text => model.invalidate()
+            onTextChanged: {
+                if (activeFocus) {
+                    _editCallback();
+                }
+            }
+
+            MZIcon {
+                anchors {
+                    left: parent.left
+                    leftMargin: MZTheme.theme.hSpacing
+                    verticalCenter: parent.verticalCenter
+                }
+                source: "qrc:/nebula/resources/search.svg"
+                sourceSize.height: MZTheme.theme.windowMargin
+                sourceSize.width: MZTheme.theme.windowMargin
+                opacity: parent.focus ? 1 : 0.8
             }
         }
 
-        MZIcon {
-            anchors {
-                left: parent.left
-                leftMargin: MZTheme.theme.hSpacing
-                verticalCenter: parent.verticalCenter
-            }
-            source: "qrc:/nebula/resources/search.svg"
-            sourceSize.height: MZTheme.theme.windowMargin
-            sourceSize.width: MZTheme.theme.windowMargin
-            opacity: parent.focus ? 1 : 0.8
+        MZContextualAlerts {
+            id: searchWarning
+            objectName: "searchBarError"
+            Layout.fillWidth: true
+            visible: _searchBarHasError
+
+            messages: [
+                {
+                    type: "error",
+                    message: MZI18n.ServersViewSearchNoResultsLabel,
+                    visible: searchBar.hasError
+                }
+            ]
         }
-    }
 
-    MZContextualAlerts {
-        id: searchWarning
-        objectName: "searchBarError"
-        Layout.fillWidth: true
-        visible: _searchBarHasError
-
-        messages: [
-            {
-                type: "error",
-                message: MZI18n.ServersViewSearchNoResultsLabel,
-                visible: searchBar.hasError
-            }
-        ]
-    }
-
-    MZFilterProxyModel {
-        id: model
-        filterCallback: _filterProxyCallback
-        sortCallback: _sortProxyCallback
+        MZFilterProxyModel {
+            id: model
+            filterCallback: _filterProxyCallback
+            sortCallback: _sortProxyCallback
+        }
     }
 
     function getProxyModel() {

--- a/nebula/ui/components/forms/MZSearchBar.qml
+++ b/nebula/ui/components/forms/MZSearchBar.qml
@@ -18,6 +18,7 @@ FocusScope {
     property alias _searchBarPlaceholderText: searchBar._placeholderText
     property bool _searchBarHasError: false
     readonly property bool isEmpty: searchBar.length === 0
+    property var _getNextTabItem: () => { return null; }
 
     implicitHeight: searchBarColumn.implicitHeight
     implicitWidth: searchBarColumn.implicitWidth
@@ -50,6 +51,16 @@ FocusScope {
                     _editCallback();
                 }
             }
+
+            function handleTabPressed() {
+                let nextTabItem = _getNextTabItem();
+                if (!nextTabItem) {
+                    nextTabItem = searchBar.nextItemInFocusChain();
+                }
+                nextTabItem.forceActiveFocus(Qt.TabFocusReason);
+            }
+
+            Keys.onTabPressed: handleTabPressed()
 
             MZIcon {
                 anchors {

--- a/src/ui/screens/settings/appPermissions/AppPermissionsList.qml
+++ b/src/ui/screens/settings/appPermissions/AppPermissionsList.qml
@@ -277,7 +277,7 @@ ColumnLayout {
             // a delay to allow for layout to complete.
             scrollTimer.setTimeout(function() {
                 appList.positionViewAtBeginning();
-                }, 300);
+                }, 10);
         }
 
         // Restore scroll position, selected item and focus when the model changes

--- a/src/ui/screens/settings/appPermissions/AppPermissionsList.qml
+++ b/src/ui/screens/settings/appPermissions/AppPermissionsList.qml
@@ -12,6 +12,11 @@ import Mozilla.VPN 1.0
 import components.forms 0.1
 import components 0.1
 
+// AppPermissionsList displays the list of installed applications, allowing users to exclude applications from VPN tunneling
+// (split tunneling). It uses a ListView (MZList) for better performance, because that control supports lazy loading of list items.
+// The ListView header contains controls preceding the list items, such as the Search Bar and Clear All buttons. The  footer
+// contains controls appearing after the list items, such as the Add Application button.
+
 ColumnLayout {
     id: appListContainer
     objectName: "appListContainer"
@@ -19,9 +24,7 @@ ColumnLayout {
     readonly property string telemetryScreenId : "app_exclusions"
     property int availableHeight: 0;
 
-    spacing: MZTheme.theme.vSpacing
-    Layout.preferredWidth: parent.width
-
+    // ListView Header
     Component {
         id: appListHeader
 
@@ -38,8 +41,31 @@ ColumnLayout {
                 id: appListHeaderColumn
 
                 spacing: MZTheme.theme.vSpacingSmall
-                width: listView.width - (3 * MZTheme.theme.windowMargin)
-                // 'Layout.preferredWidth: parent.width' was too small. It seemed to use implicit width, which is smaller.
+                width: listView.width - MZTheme.theme.vSpacing
+
+                Loader {
+                    Layout.fillWidth: true
+
+                    active: Qt.platform.os === "linux" && VPNController.state !== VPNController.StateOff
+                    visible: active
+
+                    sourceComponent: MZInformationCard {
+                        width: parent.width
+                        implicitHeight: textBlock.height + MZTheme.theme.windowMargin * 2
+                        _infoContent: MZTextBlock {
+                            id: textBlock
+                            Layout.fillWidth: true
+
+
+                            text: MZI18n.SplittunnelInfoCardDescription
+                            verticalAlignment: Text.AlignVCenter
+                        }
+                    }
+                }
+
+                MZVerticalSpacer {
+                    height: MZTheme.theme.dividerHeight
+                }
 
                 MZSearchBar {
                     property bool sorted: false;
@@ -121,19 +147,9 @@ ColumnLayout {
 
         objectName: "appList"
         model: headerItem.getProxyModel()
-        height: availableHeight // $TODO: Can this be replaced by layout values in https://doc.qt.io/qt-6/qml-qtquick-layouts-columnlayout.html#details
-        width: 250
-        //Layout.preferredWidth: parent.width
-        //contentWidth: parent.width
-        // Layout.fillWidth: true
-        //Layout.fillHeight: true
-        // anchors.fill: parent
+        height: availableHeight
+        Layout.fillWidth: true
         spacing: MZTheme.theme.windowMargin
-        // Using the following may cause a jiggle when checkbox is selected and model is changed
-        //highlightRangeMode: ListView.ApplyRange
-        //preferredHighlightBegin: height * 0.4
-        //preferredHighlightEnd: height - (height * 0.4)
-        //cacheBuffer: 4000 // Pixel size taken by all items. (Otherwise delegates will be removed causing tab order changes)
 
         delegate: FocusScope {
             id: appRowFocusScope
@@ -231,7 +247,6 @@ ColumnLayout {
                     id: label
                     Layout.alignment: Qt.AlignLeft | Qt.AlignVCenter
                     Layout.fillWidth: true
-                    // TODO: The text doesn't wrap as before
                     text: appName
                     color: MZTheme.theme.fontColorDark
                     horizontalAlignment: Text.AlignLeft
@@ -254,6 +269,7 @@ ColumnLayout {
             appList.positionViewAtBeginning();
         }
 
+        // Restore scroll position, selected item and focus when the model changes
         Connections {
             target: appList.model
 
@@ -281,6 +297,7 @@ ColumnLayout {
         }
     }
 
+    // Footer
     Component {
         id: appListFooter
 
@@ -297,7 +314,7 @@ ColumnLayout {
                 readonly property ListView listView: ListView.view
 
                 spacing: MZTheme.theme.vSpacingSmall
-                width: listView.width - (3 * MZTheme.theme.windowMargin)
+                width: listView.width - MZTheme.theme.vSpacing
 
                 MZVerticalSpacer {
                     height: MZTheme.theme.dividerHeight

--- a/src/ui/screens/settings/appPermissions/AppPermissionsList.qml
+++ b/src/ui/screens/settings/appPermissions/AppPermissionsList.qml
@@ -14,8 +14,12 @@ import components 0.1
 
 // AppPermissionsList displays the list of installed applications, allowing users to exclude applications from VPN tunneling
 // (split tunneling). It uses a ListView (MZList) for better performance, because that control supports lazy loading of list items.
-// The ListView header contains controls preceding the list items, such as the Search Bar and Clear All buttons. The  footer
-// contains controls appearing after the list items, such as the Add Application button.
+// The ListView header contains controls preceding the list items, such as the Search Bar and 'Clear All' buttons. The  ooter
+// contains controls appearing after the list items, such as the 'Add Application' button. 
+//
+// The ListView lazily generates list items when they come into view, so the order of creation is unpredictable. To handle this,
+// activeFocusOnTab is disabled on the list item checkbox, and tabbing between list items is implemented by making
+// Tab and Backtab to navigate by list item index.
 
 ColumnLayout {
     id: appListContainer
@@ -178,7 +182,7 @@ ColumnLayout {
                     onClicked: () => appRow.handleClick()
                     checked: !appIsEnabled
                     // Disable activeFocusOnTab as it relies on the order of element creation. The ListView lazily generates
-                    // list items when they come into view, so the order of creation is unpredicatable. Instead, this
+                    // list items when they come into view, so the order of creation is unpredictable. Instead, this
                     // checkbox manages Tab/Backtab to navigate by list item index.
                     checkBoxActiveFocusOnTab: false
                     Layout.alignment: Qt.AlignVCenter

--- a/src/ui/screens/settings/appPermissions/AppPermissionsList.qml
+++ b/src/ui/screens/settings/appPermissions/AppPermissionsList.qml
@@ -17,6 +17,7 @@ ColumnLayout {
     objectName: "appListContainer"
     property string searchBarPlaceholder: ""
     readonly property string telemetryScreenId : "app_exclusions"
+    property int availableHeight: 0;
 
     spacing: MZTheme.theme.vSpacing
 
@@ -67,13 +68,18 @@ ColumnLayout {
             }
             enabled: MZSettings.vpnDisabledApps.length > 0
             visible: applist.count > 0
+            width: parent.width
         }
 
-        Repeater {
+        ListView {
             id: applist
 
             objectName: "appList"
             model: searchBarWrapper.getProxyModel()
+            height: availableHeight - itemSpacer.height - addApp.height
+            width: parent.width
+            interactive: true
+            spacing: MZTheme.theme.windowMargin
             delegate: RowLayout {
                 property string appIdForFunctionalTests: appID
                 id: appRow
@@ -127,6 +133,7 @@ ColumnLayout {
                     text: appName
                     color: MZTheme.theme.fontColorDark
                     horizontalAlignment: Text.AlignLeft
+                    width: parent.width
 
                     MZMouseArea {
                         anchors.fill: undefined
@@ -139,8 +146,15 @@ ColumnLayout {
             }
         }
 
+        Item {
+            id: itemSpacer
+            height: MZTheme.theme.vSpacing
+            width: parent.width
+        }
+
         MZLinkButton {
             objectName: "addApplication"
+            id: addApp
             labelText: addApplication
             textAlignment: Text.AlignLeft
             fontSize: MZTheme.theme.fontSize

--- a/src/ui/screens/settings/appPermissions/AppPermissionsList.qml
+++ b/src/ui/screens/settings/appPermissions/AppPermissionsList.qml
@@ -56,10 +56,12 @@ ColumnLayout {
                     sourceComponent: MZInformationCard {
                         width: parent.width
                         implicitHeight: textBlock.height + MZTheme.theme.windowMargin * 2
+                        anchors.top: parent.top
+                        anchors.topMargin: MZTheme.theme.viewBaseTopMargin
+
                         _infoContent: MZTextBlock {
                             id: textBlock
                             Layout.fillWidth: true
-
 
                             text: MZI18n.SplittunnelInfoCardDescription
                             verticalAlignment: Text.AlignVCenter
@@ -84,8 +86,8 @@ ColumnLayout {
                         // from the SearchBar to the selected list item.
                         listView.currentIndex = -1; 
                     }
+                    // Return next item to be tabbed to
                     _getNextTabItem: () => {
-                        // Return next item to be tabbed to
                         if (clearAllButton.enabled) {
                             return clearAllButton;
                         } else if (listView.count > 0) {

--- a/src/ui/screens/settings/appPermissions/AppPermissionsList.qml
+++ b/src/ui/screens/settings/appPermissions/AppPermissionsList.qml
@@ -26,6 +26,7 @@ ColumnLayout {
         id: appListHeader
 
         FocusScope {
+            id: appListHeaderFocusScope
             readonly property ListView listView: ListView.view
             readonly property var getProxyModel: searchBarWrapper.getProxyModel
 
@@ -142,113 +143,111 @@ ColumnLayout {
             implicitWidth: appRow.implicitWidth
 
             RowLayout {
-            id: appRow
+                id: appRow
 
+                objectName: `app-${index}`
+                spacing: MZTheme.theme.windowMargin
+                opacity: enabled ? 1.0 : 0.5
+                Layout.preferredHeight: MZTheme.theme.navBarTopMargin
 
-
-            objectName: `app-${index}`
-            spacing: MZTheme.theme.windowMargin
-            opacity: enabled ? 1.0 : 0.5
-            Layout.preferredHeight: MZTheme.theme.navBarTopMargin
-
-            function handleClick() {
-                //appList.currentIndex = index;
-                //checkBox.forceActiveFocus();
-                VPNAppPermissions.flip(appID)
-            }
-
-            MZCheckBox {
-                id: checkBox
-                objectName: "checkbox"
-                onClicked: () => appRow.handleClick()
-                checked: !appIsEnabled
-                Layout.alignment: Qt.AlignVCenter
-                Accessible.name: appName
-                focus: true
-
-                // Change list selection on focus change
-                onActiveFocusChanged: {
-                    if (activeFocus) { 
-                        listView.currentIndex = index;
-                    };
+                function handleClick() {
+                    //appList.currentIndex = index;
+                    //checkBox.forceActiveFocus();
+                    VPNAppPermissions.flip(appID)
                 }
 
-                function handleTabPressed() {
-                    if (listView.currentIndex < (listView.count - 1)) {
-                        // Move selection & focus to next item
-                        listView.incrementCurrentIndex();
-                        listView.currentItem.forceActiveFocus(Qt.TabFocusReason);
-                    }
-                    else {
-                        // Currently at end of list. Move focus to footer
-                        listView.footerItem.forceActiveFocus(Qt.TabFocusReason);
-                    }
-                }
+                MZCheckBox {
+                    id: checkBox
+                    objectName: "checkbox"
+                    onClicked: () => appRow.handleClick()
+                    checked: !appIsEnabled
+                    Layout.alignment: Qt.AlignVCenter
+                    Accessible.name: appName
+                    focus: true
 
-                function handleBacktabPressed() {
-                    if (listView.currentIndex > 0) {
-                        // Move selection & focus to previous item and bring it into view if necessary
-                        listView.decrementCurrentIndex();
-                        listView.currentItem.forceActiveFocus(Qt.BacktabFocusReason);
+                    // Change list selection on focus change
+                    onActiveFocusChanged: {
+                        if (activeFocus) { 
+                            listView.currentIndex = index;
+                        };
                     }
-                    else {
-                        listView.headerItem.forceActiveFocus(Qt.BacktabFocusReason);
-                    }
-                }
 
-                Keys.onTabPressed: handleTabPressed()
-                Keys.onBacktabPressed: handleBacktabPressed()
-            }
-
-            Rectangle {
-                Layout.preferredWidth: MZTheme.theme.windowMargin * 2
-                Layout.preferredHeight: MZTheme.theme.windowMargin * 2
-                Layout.maximumHeight: MZTheme.theme.windowMargin * 2
-                Layout.maximumWidth: MZTheme.theme.windowMargin * 2
-                Layout.alignment: Qt.AlignVCenter
-                color: MZTheme.theme.transparent
-
-                Image {
-                    height: MZTheme.theme.windowMargin * 2
-                    width: MZTheme.theme.windowMargin * 2
-                    sourceSize.width: MZTheme.theme.windowMargin * 2
-                    sourceSize.height: MZTheme.theme.windowMargin * 2
-                    anchors.centerIn: parent
-                    fillMode:  Image.PreserveAspectFit
-                    Component.onCompleted: {
-                        if (appID !== "") {
-                            source = "image://app/"+appID
+                    function handleTabPressed() {
+                        if (listView.currentIndex < (listView.count - 1)) {
+                            // Move selection & focus to next item
+                            listView.incrementCurrentIndex();
+                            listView.currentItem.forceActiveFocus(Qt.TabFocusReason);
+                        }
+                        else {
+                            // Currently at end of list. Move focus to footer
+                            listView.footerItem.forceActiveFocus(Qt.TabFocusReason);
                         }
                     }
-                    
+
+                    function handleBacktabPressed() {
+                        if (listView.currentIndex > 0) {
+                            // Move selection & focus to previous item and bring it into view if necessary
+                            listView.decrementCurrentIndex();
+                            listView.currentItem.forceActiveFocus(Qt.BacktabFocusReason);
+                        }
+                        else {
+                            listView.headerItem.forceActiveFocus(Qt.BacktabFocusReason);
+                        }
+                    }
+
+                    Keys.onTabPressed: handleTabPressed()
+                    Keys.onBacktabPressed: handleBacktabPressed()
                 }
 
-                Component.onCompleted: {
-                    //console.log("vc: ListView delegate component completed " + index);
+                Rectangle {
+                    Layout.preferredWidth: MZTheme.theme.windowMargin * 2
+                    Layout.preferredHeight: MZTheme.theme.windowMargin * 2
+                    Layout.maximumHeight: MZTheme.theme.windowMargin * 2
+                    Layout.maximumWidth: MZTheme.theme.windowMargin * 2
+                    Layout.alignment: Qt.AlignVCenter
+                    color: MZTheme.theme.transparent
+
+                    Image {
+                        height: MZTheme.theme.windowMargin * 2
+                        width: MZTheme.theme.windowMargin * 2
+                        sourceSize.width: MZTheme.theme.windowMargin * 2
+                        sourceSize.height: MZTheme.theme.windowMargin * 2
+                        anchors.centerIn: parent
+                        fillMode:  Image.PreserveAspectFit
+                        Component.onCompleted: {
+                            if (appID !== "") {
+                                source = "image://app/"+appID
+                            }
+                        }
+                        
+                    }
+
+                    Component.onCompleted: {
+                        //console.log("vc: ListView delegate component completed " + index);
+                    }
+
+                    Component.onDestruction: {
+                        //console.log("vc: ListView delegate component destroyed " + index);
+                    }
                 }
 
-                Component.onDestruction: {
-                    //console.log("vc: ListView delegate component destroyed " + index);
-                }
-            }
+                MZInterLabel {
+                    id: label
+                    Layout.alignment: Qt.AlignLeft | Qt.AlignVCenter
+                    Layout.fillWidth: true
+                    // TODO: The text doesn't wrap as before
+                    text: appName
+                    color: MZTheme.theme.fontColorDark
+                    horizontalAlignment: Text.AlignLeft
 
-            MZInterLabel {
-                id: label
-                Layout.alignment: Qt.AlignLeft | Qt.AlignVCenter
-                Layout.fillWidth: true
-                // TODO: The text doesn't wrap as before
-                text: appName
-                color: MZTheme.theme.fontColorDark
-                horizontalAlignment: Text.AlignLeft
-
-                MZMouseArea {
-                    anchors.fill: undefined
-                    width: parent.implicitWidth
-                    height: parent.implicitHeight
-                    propagateClickToParent: false
-                    onClicked: () => appRow.handleClick()
+                    MZMouseArea {
+                        anchors.fill: undefined
+                        width: parent.implicitWidth
+                        height: parent.implicitHeight
+                        propagateClickToParent: false
+                        onClicked: () => appRow.handleClick()
+                    }
                 }
-            }
             }
         }
 
@@ -260,7 +259,7 @@ ColumnLayout {
         }
 
         Connections {
-            target: model
+            target: appList.model
 
             property Item previousFocusItem: null
             property int previousIndex: -1

--- a/src/ui/screens/settings/appPermissions/AppPermissionsList.qml
+++ b/src/ui/screens/settings/appPermissions/AppPermissionsList.qml
@@ -14,8 +14,8 @@ import components 0.1
 
 // AppPermissionsList displays the list of installed applications, allowing users to exclude applications from VPN tunneling
 // (split tunneling). It uses a ListView (MZList) for better performance, because that control supports lazy loading of list items.
-// The ListView header contains controls preceding the list items, such as the Search Bar and 'Clear All' buttons. The  ooter
-// contains controls appearing after the list items, such as the 'Add Application' button. 
+// The ListView header contains controls preceding the list items, such as the Search Bar and 'Clear All' buttons. The footer
+// contains controls appearing after the list items, such as the 'Add Application' button.
 //
 // The ListView lazily generates list items when they come into view, so the order of creation is unpredictable. To handle this,
 // activeFocusOnTab is disabled on the list item checkbox, and tabbing between list items is implemented by making
@@ -211,11 +211,12 @@ ColumnLayout {
 
                     function handleBacktabPressed() {
                         if (listView.currentIndex > 0) {
-                            // Move selection & focus to previous item and bring it into view if necessary
+                            // Move selection & focus to previous item
                             listView.decrementCurrentIndex();
                             listView.currentItem.forceActiveFocus(Qt.BacktabFocusReason);
                         }
                         else {
+                            // Currently at top of list. Move focus to header
                             listView.headerItem.forceActiveFocus(Qt.BacktabFocusReason);
                         }
                     }
@@ -308,7 +309,7 @@ ColumnLayout {
         }
     }
 
-    // Footer
+    // ListView Footer
     Component {
         id: appListFooter
 
@@ -322,7 +323,6 @@ ColumnLayout {
 
             ColumnLayout {
                 id: appListFooterColumn
-                readonly property ListView listView: ListView.view
 
                 spacing: MZTheme.theme.vSpacingSmall
                 width: listView.width - MZTheme.theme.vSpacing
@@ -345,6 +345,7 @@ ColumnLayout {
                     }
 
                     function handleBacktabPressed() {
+                        // Move focus back to last item in list
                         if (listView.count > 0) {
                             listView.currentIndex = listView.count - 1;
                             listView.currentItem.forceActiveFocus(Qt.BacktabFocusReason);

--- a/src/ui/screens/settings/appPermissions/AppPermissionsList.qml
+++ b/src/ui/screens/settings/appPermissions/AppPermissionsList.qml
@@ -158,7 +158,6 @@ ColumnLayout {
         delegate: FocusScope {
             id: appRowFocusScope
 
-            property string appIdForFunctionalTests: appID
             readonly property ListView listView: ListView.view
 
             implicitHeight: appRow.implicitHeight
@@ -166,6 +165,8 @@ ColumnLayout {
 
             RowLayout {
                 id: appRow
+
+                property string appIdForFunctionalTests: appID
 
                 objectName: `app-${index}`
                 spacing: MZTheme.theme.windowMargin
@@ -271,6 +272,12 @@ ColumnLayout {
 
         Component.onCompleted: {
             appList.positionViewAtBeginning();
+
+            // Sometimes appList is not scrolled to the beginning despite the previous request. Try again after
+            // a delay to allow for layout to complete.
+            scrollTimer.setTimeout(function() {
+                appList.positionViewAtBeginning();
+                }, 300);
         }
 
         // Restore scroll position, selected item and focus when the model changes
@@ -368,5 +375,9 @@ ColumnLayout {
                 }
             }
         }
+    }
+
+    MZTimer {
+        id: scrollTimer
     }
 }

--- a/src/ui/screens/settings/appPermissions/AppPermissionsList.qml
+++ b/src/ui/screens/settings/appPermissions/AppPermissionsList.qml
@@ -25,11 +25,12 @@ ColumnLayout {
     Component {
         id: appListHeader
 
-        ColumnLayout {
-            id: col2
+    ColumnLayout {
+            id: appListHeaderColumn
             property var getProxyModel: searchBarWrapper.getProxyModel
 
-            Layout.preferredWidth: parent.width
+            spacing: MZTheme.theme.vSpacingSmall
+            width: applist.width - (3 * MZTheme.theme.windowMargin)
 
             MZSearchBar {
                 property bool sorted: false;
@@ -67,7 +68,10 @@ ColumnLayout {
                 }
                 enabled: MZSettings.vpnDisabledApps.length > 0
                 visible: applist.count > 0
-                width: parent.width
+            }
+
+            MZVerticalSpacer {
+                height: MZTheme.theme.dividerHeight
             }
         }
     }
@@ -78,7 +82,7 @@ ColumnLayout {
         objectName: "appList"
         model: headerItem.getProxyModel()
         height: availableHeight // $TODO: Can this be replaced by layout values in https://doc.qt.io/qt-6/qml-qtquick-layouts-columnlayout.html#details
-        Layout.fillWidth: true
+        Layout.preferredWidth: parent.width
         spacing: MZTheme.theme.windowMargin
         delegate: RowLayout {
             property string appIdForFunctionalTests: appID
@@ -133,7 +137,6 @@ ColumnLayout {
                 text: appName
                 color: MZTheme.theme.fontColorDark
                 horizontalAlignment: Text.AlignLeft
-                width: parent.width
 
                 MZMouseArea {
                     anchors.fill: undefined
@@ -151,29 +154,40 @@ ColumnLayout {
     Component {
         id: appListFooter
 
-        MZLinkButton {
-            objectName: "addApplication"
-            id: addApp
-            labelText: addApplication
-            textAlignment: Text.AlignLeft
-            fontSize: MZTheme.theme.fontSize
-            fontName: MZTheme.theme.fontInterSemiBoldFamily
-            onClicked: {
-                Glean.interaction.addApplicationSelected.record({screen:telemetryScreenId});
-                VPNAppPermissions.openFilePicker()
+        ColumnLayout {
+            id: appListFooterColumn
+
+            spacing: MZTheme.theme.vSpacingSmall
+            width: applist.width - (3 * MZTheme.theme.windowMargin)
+
+            MZVerticalSpacer {
+                height: MZTheme.theme.dividerHeight
             }
 
-            // Hack to horizontally align the "+" sign with the
-            // column of checkboxes
-            Layout.leftMargin: -1
+            MZLinkButton {
+                objectName: "addApplication"
+                id: addApp
+                labelText: addApplication
+                textAlignment: Text.AlignLeft
+                fontSize: MZTheme.theme.fontSize
+                fontName: MZTheme.theme.fontInterSemiBoldFamily
+                onClicked: {
+                    Glean.interaction.addApplicationSelected.record({screen:telemetryScreenId});
+                    VPNAppPermissions.openFilePicker()
+                }
 
-            visible: Qt.platform.os === "windows"
-            iconComponent: Component {
-                MZIcon {
-                    source: "qrc:/nebula/resources/plus.svg"
-                    sourceSize.height: MZTheme.theme.iconSmallSize
-                    sourceSize.width: MZTheme.theme.iconSmallSize
-                    anchors.verticalCenter: parent.verticalCenter
+                // Hack to horizontally align the "+" sign with the
+                // column of checkboxes
+                Layout.leftMargin: -1
+
+                visible: Qt.platform.os === "windows"
+                iconComponent: Component {
+                    MZIcon {
+                        source: "qrc:/nebula/resources/plus.svg"
+                        sourceSize.height: MZTheme.theme.iconSmallSize
+                        sourceSize.width: MZTheme.theme.iconSmallSize
+                        anchors.verticalCenter: parent.verticalCenter
+                    }
                 }
             }
         }

--- a/src/ui/screens/settings/appPermissions/AppPermissionsList.qml
+++ b/src/ui/screens/settings/appPermissions/AppPermissionsList.qml
@@ -66,6 +66,7 @@ ColumnLayout {
                     Glean.interaction.clearAppExclusionsSelected.record({screen:telemetryScreenId});
                     VPNAppPermissions.protectAll();
                 }
+                Keys.onTabPressed: applist.itemAtIndex(0).children[0].forceActiveFocus(Qt.TabFocusReason)
                 enabled: MZSettings.vpnDisabledApps.length > 0
                 visible: applist.count > 0
             }
@@ -104,6 +105,33 @@ ColumnLayout {
                 checked: !appIsEnabled
                 Layout.alignment: Qt.AlignVCenter
                 Accessible.name: appID
+
+                function handleTabPressed() {
+                    applist.positionViewAtIndex(applist.currentIndex + 1, ListView.Visible);
+
+                    if (applist.itemAtIndex(applist.currentIndex + 1)) {
+                        applist.currentIndex++;
+                        nextItemInFocusChain().forceActiveFocus(Qt.TabFocusReason);
+                    }
+                    else {
+                        applist.footerItem.forceActiveFocus(Qt.TabFocusReason);
+                    }
+                }
+
+                function handleBacktabPressed() {
+                    applist.positionViewAtIndex(applist.currentIndex - 1, ListView.Visible);
+
+                    if (applist.itemAtIndex(applist.currentIndex - 1)) {
+                        applist.currentIndex--;
+                        nextItemInFocusChain(false).forceActiveFocus(Qt.BacktabFocusReason);
+                    }
+                    else {
+                        applist.headerItem.forceActiveFocus(Qt.BacktabFocusReason);
+                    }
+                }
+
+                Keys.onTabPressed: handleTabPressed()
+                Keys.onBacktabPressed: handleBacktabPressed()
             }
 
             Rectangle {

--- a/src/ui/screens/settings/appPermissions/ViewAppPermissions.qml
+++ b/src/ui/screens/settings/appPermissions/ViewAppPermissions.qml
@@ -14,8 +14,10 @@ import components.forms 0.1
 MZViewBase {
     id: vpnFlickable
     objectName: "appPermissions"
-    // The ListView in AppPermissionsList is flickable, so this one need not be.
+    // The ListView Flickable in AppPermissionsList is interactive, so prevent conflict by turning off this one
      _interactive: false
+    // Turn off top margin because ListView in AppPermissionsList fills the content area, so additional margin is unecessary
+    _useTopMargin: false
 
     readonly property string telemetryScreenId : "app_exclusions"
 

--- a/src/ui/screens/settings/appPermissions/ViewAppPermissions.qml
+++ b/src/ui/screens/settings/appPermissions/ViewAppPermissions.qml
@@ -14,6 +14,8 @@ import components.forms 0.1
 MZViewBase {
     id: vpnFlickable
     objectName: "appPermissions"
+    // The ListView in AppPermissionsList is flickable, so this one need not be.
+     _interactive: false
 
     readonly property string telemetryScreenId : "app_exclusions"
 
@@ -81,6 +83,8 @@ MZViewBase {
 
         AppPermissionsList {
             id: enabledList
+            // The list provides its own code to ensure visibility of a child item
+            // property bool skipEnsureVisible: true
 
             Layout.fillWidth: true
             Layout.fillHeight: false
@@ -89,7 +93,13 @@ MZViewBase {
 
             searchBarPlaceholder: searchApps
             enabled: Qt.platform.os === "linux" ? VPNController.state === VPNController.StateOff : true
-            availableHeight: window.height - vpnFlickable.y; 
+            availableHeight: {
+                const yPosition = enabledList.mapToItem(null, 0, 0).y;
+                console.log("appList yPosition = ", yPosition);
+                //return window.height - yPosition;
+                return 584;
+            }
+            //anchors.fill: parent
         }
     }
 

--- a/src/ui/screens/settings/appPermissions/ViewAppPermissions.qml
+++ b/src/ui/screens/settings/appPermissions/ViewAppPermissions.qml
@@ -88,11 +88,10 @@ MZViewBase {
         Layout.fillHeight: false
         Layout.leftMargin: MZTheme.theme.vSpacing
         Layout.rightMargin: MZTheme.theme.vSpacing
-        width: parent.width
 
         searchBarPlaceholder: searchApps
         enabled: Qt.platform.os === "linux" ? VPNController.state === VPNController.StateOff : true
-        availableHeight: navbar.mapToItem(null, 0, 0).y - vpnFlickable.mapToItem(null, 0, 0).y - 200 // This needs to be fixed.
+        availableHeight: window.height - MZTheme.theme.navBarHeight // This needs to be fixed.
     }
 
 

--- a/src/ui/screens/settings/appPermissions/ViewAppPermissions.qml
+++ b/src/ui/screens/settings/appPermissions/ViewAppPermissions.qml
@@ -55,54 +55,18 @@ MZViewBase {
 
     _menuTitle: MZI18n.SettingsAppExclusionSettings
     _viewContentData: ColumnLayout {
-
-        Layout.preferredWidth: parent.width
-
-        Loader {
-            Layout.leftMargin: MZTheme.theme.windowMargin
-            Layout.rightMargin: MZTheme.theme.windowMargin
-            Layout.bottomMargin: 24
-            Layout.fillWidth: true
-
-            active: Qt.platform.os === "linux" && VPNController.state !== VPNController.StateOff
-            visible: active
-
-            sourceComponent: MZInformationCard {
-                width: parent.width
-                implicitHeight: textBlock.height + MZTheme.theme.windowMargin * 2
-                _infoContent: MZTextBlock {
-                    id: textBlock
-                    Layout.fillWidth: true
-
-
-                    text: MZI18n.SplittunnelInfoCardDescription
-                    verticalAlignment: Text.AlignVCenter
-                }
-            }
-        }
-
         AppPermissionsList {
             id: enabledList
-            // The list provides its own code to ensure visibility of a child item
-            // property bool skipEnsureVisible: true
 
             Layout.fillWidth: true
             Layout.fillHeight: false
             Layout.leftMargin: MZTheme.theme.vSpacing
-            Layout.rightMargin: MZTheme.theme.vSpacing
 
             searchBarPlaceholder: searchApps
             enabled: Qt.platform.os === "linux" ? VPNController.state === VPNController.StateOff : true
-            availableHeight: {
-                const yPosition = enabledList.mapToItem(null, 0, 0).y;
-                console.log("appList yPosition = ", yPosition);
-                //return window.height - yPosition;
-                return 584;
-            }
-            //anchors.fill: parent
+            availableHeight: window.height - MZTheme.theme.menuHeight
         }
     }
-
 
     MZHelpSheet {
         id: helpSheet

--- a/src/ui/screens/settings/appPermissions/ViewAppPermissions.qml
+++ b/src/ui/screens/settings/appPermissions/ViewAppPermissions.qml
@@ -78,18 +78,21 @@ MZViewBase {
                 }
             }
         }
+    }
+    _contentHeight: _viewContentData.height;
 
-        AppPermissionsList {
-            id: enabledList
+    AppPermissionsList {
+        id: enabledList
 
-            Layout.fillWidth: true
-            Layout.fillHeight: false
-            Layout.leftMargin: MZTheme.theme.vSpacing
-            Layout.rightMargin: MZTheme.theme.vSpacing
+        Layout.fillWidth: true
+        Layout.fillHeight: false
+        Layout.leftMargin: MZTheme.theme.vSpacing
+        Layout.rightMargin: MZTheme.theme.vSpacing
+        width: parent.width
 
-            searchBarPlaceholder: searchApps
-            enabled: Qt.platform.os === "linux" ? VPNController.state === VPNController.StateOff : true
-        }
+        searchBarPlaceholder: searchApps
+        enabled: Qt.platform.os === "linux" ? VPNController.state === VPNController.StateOff : true
+        availableHeight: navbar.mapToItem(null, 0, 0).y - vpnFlickable.mapToItem(null, 0, 0).y - 200 // This needs to be fixed.
     }
 
 

--- a/src/ui/screens/settings/appPermissions/ViewAppPermissions.qml
+++ b/src/ui/screens/settings/appPermissions/ViewAppPermissions.qml
@@ -16,8 +16,8 @@ MZViewBase {
     objectName: "appPermissions"
     // The ListView Flickable in AppPermissionsList is interactive, so prevent conflict by turning off this one
      _interactive: false
-    // Turn off top margin because ListView in AppPermissionsList fills the content area, so additional margin is unecessary
-    _useTopMargin: false
+    // Turn off top & bottom margins because ListView in AppPermissionsList fills the vertical content area, so additional margins are unecessary
+    _useMargins: false
 
     readonly property string telemetryScreenId : "app_exclusions"
 

--- a/src/ui/screens/settings/appPermissions/ViewAppPermissions.qml
+++ b/src/ui/screens/settings/appPermissions/ViewAppPermissions.qml
@@ -78,20 +78,19 @@ MZViewBase {
                 }
             }
         }
-    }
-    _contentHeight: _viewContentData.height;
 
-    AppPermissionsList {
-        id: enabledList
+        AppPermissionsList {
+            id: enabledList
 
-        Layout.fillWidth: true
-        Layout.fillHeight: false
-        Layout.leftMargin: MZTheme.theme.vSpacing
-        Layout.rightMargin: MZTheme.theme.vSpacing
+            Layout.fillWidth: true
+            Layout.fillHeight: false
+            Layout.leftMargin: MZTheme.theme.vSpacing
+            Layout.rightMargin: MZTheme.theme.vSpacing
 
-        searchBarPlaceholder: searchApps
-        enabled: Qt.platform.os === "linux" ? VPNController.state === VPNController.StateOff : true
-        availableHeight: window.height - MZTheme.theme.navBarHeight // This needs to be fixed.
+            searchBarPlaceholder: searchApps
+            enabled: Qt.platform.os === "linux" ? VPNController.state === VPNController.StateOff : true
+            availableHeight: window.height - vpnFlickable.y; 
+        }
     }
 
 


### PR DESCRIPTION
## Description

The "App Exclusions" screen used a Repeater for the list items, which required all application names and their icons to be obtained when the screen was loaded. Obtaining icons is expensive, and slowed screen load. Switch this to ListView, which lazily loads list items as they become visible in the viewport. This allows icons to be obtained only when needed and improves screen load time.

The following additional changes were required to switch to ListView:
1. The MZViewBase parent is a flickable and ListView is also a flickable. To prevent conflicts, the MZViewBase has been marked interactive:false. 
2. The ListView is implemented in MZList, with its own ensureVisible() which is used to scroll an item in the flickable into the visible part of the viewport.
3. The controls before and after the list are moved into the ListView's header and footer, to allow the ListView flickable to scroll through all of them.
4. Tab and Backtab navigation have been customized in places to account for the lazy loading of list items. The creation order of list items can no longer be depended upon for standard tabbing and this customization allows items to be navigated to by list index.

## Reference

  [VPN-6021](https://mozilla-hub.atlassian.net/browse/VPN-6021)

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-6021]: https://mozilla-hub.atlassian.net/browse/VPN-6021?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ