### PR TITLE
Nit: No more npm updates from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -68,10 +68,10 @@ updates:
     labels:
       - "dependencies"
   # Functional Tests etc
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: "weekly"
+  #- package-ecosystem: "npm"
+  #  directory: "/"
+  #  schedule:
+  #    interval: "weekly"
   # Inspector
   #- package-ecosystem: "npm"
   #  directory: "/tools/inspector"


### PR DESCRIPTION
## Description
None of our node code is shipped to users. 
All of that is internal dev tools, the testing suite or our docs page. 

Therefore imho dependabot is more noise then useful. 

WDYT?