### PR TITLE
VPN-6220: Fix MacOS Taskcluster jobs after bad squash/merge

### DIFF
--- a/taskcluster/scripts/build/macos_build.sh
+++ b/taskcluster/scripts/build/macos_build.sh
@@ -38,17 +38,8 @@ export LANG=en_US.utf-8
 export PYTHONIOENCODING="UTF-8"
 
 print Y "Installing conda"
-chmod +x ${MOZ_FETCHES_DIR}/miniconda.sh
-bash ${MOZ_FETCHES_DIR}/miniconda.sh -b -u -p ${TASK_HOME}/miniconda
-source ${TASK_HOME}/miniconda/bin/activate
-
-
-print Y "Installing provided conda env..."
-# TODO: Check why --force is needed if we install into TASK_HOME?
-conda env create --force -f env.yml
-conda activate VPN
-./scripts/macos/conda_install_extras.sh
-conda info
+source ${TASK_WORKDIR}/fetches/bin/activate
+conda-unpack
 
 # Conda Cannot know installed MacOS SDK'S
 # and as we use conda'provided clang/llvm


### PR DESCRIPTION
## Description
We recently updated the Taskcluster jobs for MacOS to use `conda-pack` for the build environment to resolve some flaky build tasks, but it seems that this change got partially reverted by a squash/merge of PR #9090, and it no longer works because of a missing fetch dependency. This should put the use of `conda-pack` back.

## Reference
Github issue: #9166 ([VPN-6220](https://mozilla-hub.atlassian.net/browse/VPN-6220))
Github PR: #9090

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-6220]: https://mozilla-hub.atlassian.net/browse/VPN-6220?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ