### PR TITLE
VPN-6220: Fix systemd installation on Ubuntu/noble

### DIFF
--- a/linux/debian/rules
+++ b/linux/debian/rules
@@ -11,8 +11,10 @@ ifneq (ok,$(shell dpkg --compare-versions $(GOLANG_NATIVE_VERSION) ge 2:1.18 && 
 	export PATH := $(GODIR)/bin:$(PATH)
 endif
 
+CMAKE_BUILD_DIR := build-$(DEB_HOST_MULTIARCH)
+
 %:
-	dh $@ --with=systemd --buildsystem=cmake+ninja --warn-missing
+	dh $@ --with=systemd --buildsystem=cmake+ninja --builddirectory=$(CMAKE_BUILD_DIR) --warn-missing
 
 override_dh_auto_configure:
 	dh_auto_configure -- -DWEBEXT_INSTALL_LIBDIR=/lib -DBUILD_ID=$(DEB_VERSION) -DBUILD_TESTS=OFF
@@ -24,10 +26,10 @@ override_dh_installdocs:
 override_dh_installinfo:
 
 override_dh_installsystemd:
-	dh_installsystemd debian/mozillavpn/lib/systemd/system/mozillavpn.service
+	dh_installsystemd $(CMAKE_BUILD_DIR)/src/mozillavpn.service
 
 override_dh_systemd_start:
-	dh_systemd_start debian/mozillavpn/lib/systemd/system/mozillavpn.service
+	dh_systemd_start $(CMAKE_BUILD_DIR)/src/mozillavpn.service
 
 override_dh_systemd_enable:
-	dh_systemd_enable debian/mozillavpn/lib/systemd/system/mozillavpn.service
+	dh_systemd_enable $(CMAKE_BUILD_DIR)/src/mozillavpn.service

--- a/scripts/utils/xlifftool.py
+++ b/scripts/utils/xlifftool.py
@@ -78,9 +78,9 @@ class xliff_language:
     # Perform variable substitution and return the transformed text.
     def transform(self, text):
         start = 0
-        ac_regex = re.compile('@[\w.]+@') ## Autoconf style match: @VARNAME@
-        cm_regex = re.compile('\${[\w.]+}')  ## CMake style match: ${VARNAME}
-        qt_regex = re.compile('qtTrId("[\w.]+")') ## Qt match: qtTrId("VARNAME")
+        ac_regex = re.compile('@[\\w.]+@') ## Autoconf style match: @VARNAME@
+        cm_regex = re.compile('\\${[\\w.]+}')  ## CMake style match: ${VARNAME}
+        qt_regex = re.compile('qtTrId\\("[\\w.]+"\\)') ## Qt match: qtTrId("VARNAME")
 
         while start < len(text):
             ## Search for the first thing that we can translate
@@ -99,7 +99,7 @@ class xliff_language:
                 match = cm_match
                 trid = cm_match.group(0)[2:-1]
             elif qt_match and (qt_start < ac_start) and (qt_start < cm_start):
-                match = cm_match
+                match = qt_match
                 trid = qt_match.group(0)[8:-2] ## TODO: Won't handle whitespace well.
             else:
                 break


### PR DESCRIPTION
## Description
Recently the VPN builds have been failing on Ubuntu/Noble. It seems like the problem is caused by change in the installation path of the Systemd service files. Because these files are generated, we wind up trying to use the installed files for `dh_systemd_install` but this is a little bit janky. So let's instead try to run `dh_systemd_install` using the generated files in the build dir instead.

Also, starting with Ubuntu/noble, we have been getting a bunch of warnings when trying to compile regex in the `xlifftool.py` script, so I figured it would be a good opportunity to fix those at the same time.

## Reference
Github issue: #9166 ([VPN-6220](https://mozilla-hub.atlassian.net/browse/VPN-6220))

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-6220]: https://mozilla-hub.atlassian.net/browse/VPN-6220?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ