### PR TITLE
Revert to taskcluster 60.3.5

### DIFF
--- a/taskcluster/scripts/requirements.in
+++ b/taskcluster/scripts/requirements.in
@@ -1,3 +1,3 @@
 multidict >= 5.0.0 
 yarl>=1.6.0
-taskcluster==60.4.2
+taskcluster==60.3.5

--- a/taskcluster/scripts/requirements.txt
+++ b/taskcluster/scripts/requirements.txt
@@ -362,9 +362,9 @@ slugid==2.0.0 \
     --hash=sha256:a950d98b72691178bdd4d6c52743c4a2aa039207cf7a97d71060a111ff9ba297 \
     --hash=sha256:aec8b0e01c4ad32e38e12d609eab3ec912fd129aaf6b2ded0199b56a5f8fd67c
     # via taskcluster
-taskcluster==60.4.2 \
-    --hash=sha256:5217073dd3c6642d976ab4a3f5861308b18bba533cd246d378a095d85e39597c \
-    --hash=sha256:9cacf06e790e81535a019c0623e5cdf284a7ecefce7f02de8f2802cdad161077
+taskcluster==60.3.5 \
+    --hash=sha256:096996c6c5bdb81cc2e7c3083728b5a68ec908e5712ec7cebc043d627baf2662 \
+    --hash=sha256:9ff456216cec2a6018192a007689f9f36178ebf553fad00cedd0ab4639d9134c
     # via -r scripts/requirements.in
 taskcluster-urls==13.0.1 \
     --hash=sha256:5e25e7e6818e8877178b175ff43d2e6548afad72694aa125f404a7329ece0973 \


### PR DESCRIPTION
## Description
Some recent pull requests have attempted to bump the taskcluster version, but this has resulted in build failures on our production MacOS workers due to a stricter pip environment that prohibits fetching packages from the network. Let's revert these changes for now to keep the builds building until we can get the MacOS workers updated appropriately.

## Reference
Github PR: #9178
Github PR: #9202

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
