### PR TITLE
VPN-4227: Windows daemon recovery on crash

### DIFF
--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -79,7 +79,7 @@ bool Daemon::activate(const InterfaceConfig& config) {
         return false;
       }
 
-      if (supportDnsUtils() && !dnsutils()->restoreResolvers()) {
+      if (!dnsutils()->restoreResolvers()) {
         return false;
       }
 
@@ -161,10 +161,6 @@ bool Daemon::activate(const InterfaceConfig& config) {
 }
 
 bool Daemon::maybeUpdateResolvers(const InterfaceConfig& config) {
-  if (!supportDnsUtils()) {
-    return true;
-  }
-
   if ((config.m_hopType == InterfaceConfig::MultiHopExit) ||
       (config.m_hopType == InterfaceConfig::SingleHop)) {
     QList<QHostAddress> resolvers;
@@ -348,7 +344,7 @@ bool Daemon::deactivate(bool emitSignals) {
   }
 
   // Cleanup DNS
-  if (supportDnsUtils() && !dnsutils()->restoreResolvers()) {
+  if (!dnsutils()->restoreResolvers()) {
     return false;
   }
 

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -345,12 +345,7 @@ bool Daemon::deactivate(bool emitSignals) {
 
   // Cleanup DNS
   if (!dnsutils()->restoreResolvers()) {
-    return false;
-  }
-
-  if (!wgutils()->interfaceExists()) {
-    logger.warning() << "Wireguard interface does not exist.";
-    return false;
+    logger.warning() << "Failed to restore DNS resolvers.";
   }
 
   // Cleanup peers and routing
@@ -362,14 +357,10 @@ bool Daemon::deactivate(bool emitSignals) {
     }
     wgutils()->deletePeer(config);
   }
+  m_connections.clear();
 
   // Delete the interface
-  if (!wgutils()->deleteInterface()) {
-    return false;
-  }
-
-  m_connections.clear();
-  return true;
+  return wgutils()->deleteInterface();
 }
 
 QString Daemon::logs() {

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -65,7 +65,6 @@ class Daemon : public QObject {
   virtual WireguardUtils* wgutils() const = 0;
   virtual bool supportIPUtils() const { return false; }
   virtual IPUtils* iputils() { return nullptr; }
-  virtual bool supportDnsUtils() const { return false; }
   virtual DnsUtils* dnsutils() { return nullptr; }
 
   static bool parseStringList(const QJsonObject& obj, const QString& name,

--- a/src/localsocketcontroller.cpp
+++ b/src/localsocketcontroller.cpp
@@ -46,7 +46,7 @@ LocalSocketController::LocalSocketController() {
   connect(m_socket, &QLocalSocket::connected, this,
           &LocalSocketController::daemonConnected);
   connect(m_socket, &QLocalSocket::disconnected, this,
-          &LocalSocketController::disconnected);
+          [&] { errorOccurred(QLocalSocket::PeerClosedError); });
   connect(m_socket, &QLocalSocket::errorOccurred, this,
           &LocalSocketController::errorOccurred);
   connect(m_socket, &QLocalSocket::readyRead, this,

--- a/src/platforms/linux/daemon/dbusservice.h
+++ b/src/platforms/linux/daemon/dbusservice.h
@@ -46,7 +46,6 @@ class DBusService final : public Daemon, protected QDBusContext {
   WireguardUtils* wgutils() const override { return m_wgutils; }
   bool supportIPUtils() const override { return true; }
   IPUtils* iputils() override;
-  bool supportDnsUtils() const override { return true; }
   DnsUtils* dnsutils() override;
 
  private:

--- a/src/platforms/macos/daemon/macosdaemon.h
+++ b/src/platforms/macos/daemon/macosdaemon.h
@@ -21,7 +21,6 @@ class MacOSDaemon final : public Daemon {
 
  protected:
   WireguardUtils* wgutils() const override { return m_wgutils; }
-  bool supportDnsUtils() const override { return true; }
   DnsUtils* dnsutils() override { return m_dnsutils; }
   bool supportIPUtils() const override { return true; }
   IPUtils* iputils() override { return m_iputils; }

--- a/src/platforms/windows/daemon/dnsutilswindows.h
+++ b/src/platforms/windows/daemon/dnsutilswindows.h
@@ -27,8 +27,8 @@ class DnsUtilsWindows final : public DnsUtils {
   quint64 m_luid = 0;
   DWORD (*m_setInterfaceDnsSettingsProcAddr)(GUID, const void*) = nullptr;
 
-  bool updateResolversWin32(const QList<QHostAddress>& resolvers);
-  bool updateResolversNetsh(const QList<QHostAddress>& resolvers);
+  bool updateResolversWin32(GUID, const QList<QHostAddress>& resolvers);
+  bool updateResolversNetsh(int ifindex, const QList<QHostAddress>& resolvers);
 };
 
 #endif  // DNSUTILSWINDOWS_H

--- a/src/platforms/windows/daemon/windowsdaemon.h
+++ b/src/platforms/windows/daemon/windowsdaemon.h
@@ -25,7 +25,6 @@ class WindowsDaemon final : public Daemon {
  protected:
   bool run(Op op, const InterfaceConfig& config) override;
   WireguardUtils* wgutils() const override { return m_wgutils; }
-  bool supportDnsUtils() const override { return true; }
   DnsUtils* dnsutils() override { return m_dnsutils; }
 
  private:

--- a/src/platforms/windows/daemon/windowstunnelservice.cpp
+++ b/src/platforms/windows/daemon/windowstunnelservice.cpp
@@ -38,8 +38,8 @@ WindowsTunnelService::WindowsTunnelService(QObject* parent) : QObject(parent) {
   }
 
   // Is the service already running? Terminate it.
-  SC_HANDLE service = OpenService((SC_HANDLE)m_scm, TUNNEL_SERVICE_NAME,
-                                  SERVICE_ALL_ACCESS);
+  SC_HANDLE service =
+      OpenService((SC_HANDLE)m_scm, TUNNEL_SERVICE_NAME, SERVICE_ALL_ACCESS);
   if (service != nullptr) {
     logger.info() << "Tunnel already exists. Terminating it.";
     stopAndDeleteTunnelService(service);

--- a/src/platforms/windows/daemon/windowstunnelservice.cpp
+++ b/src/platforms/windows/daemon/windowstunnelservice.cpp
@@ -30,10 +30,20 @@ static bool waitForServiceStatus(SC_HANDLE service, DWORD expectedStatus);
 
 WindowsTunnelService::WindowsTunnelService(QObject* parent) : QObject(parent) {
   MZ_COUNT_CTOR(WindowsTunnelService);
+  logger.debug() << "WindowsTunnelService created.";
 
   m_scm = OpenSCManager(nullptr, nullptr, SC_MANAGER_ALL_ACCESS);
   if (m_scm == nullptr) {
     WindowsUtils::windowsLog("Failed to open SCManager");
+  }
+
+  // Is the service already running? Terminate it.
+  SC_HANDLE service = OpenService((SC_HANDLE)m_scm, TUNNEL_SERVICE_NAME,
+                                  SERVICE_ALL_ACCESS);
+  if (service != nullptr) {
+    logger.info() << "Tunnel already exists. Terminating it.";
+    stopAndDeleteTunnelService(service);
+    CloseServiceHandle(service);
   }
 
   connect(&m_timer, &QTimer::timeout, this, &WindowsTunnelService::timeout);

--- a/src/platforms/windows/windowscommons.cpp
+++ b/src/platforms/windows/windowscommons.cpp
@@ -20,8 +20,6 @@
 #include "logger.h"
 #include "platforms/windows/windowsutils.h"
 
-#define TUNNEL_SERVICE_NAME L"WireGuardTunnel$mozvpn"
-
 constexpr const char* VPN_NAME = "MozillaVPN";
 constexpr const char* WIREGUARD_DIR = "WireGuard";
 constexpr const char* DATA_DIR = "Data";


### PR DESCRIPTION
## Description
In order to add a bit more robustness to the VPN client, we should ensure we can recovery gracefully in the event of a crash of the daemon. This adds some handling of unexpected daemon termination and takes steps to ensure that the system remains in a usable state even if a crash occurs.

## Reference
Github issue #7986 ([VPN-4227](https://mozilla-hub.atlassian.net/browse/VPN-4227))
Github issue #7987 ([VPN-4231](https://mozilla-hub.atlassian.net/browse/VPN-4231))

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-4227]: https://mozilla-hub.atlassian.net/browse/VPN-4227?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[VPN-4231]: https://mozilla-hub.atlassian.net/browse/VPN-4231?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ