### PR TITLE
VPN-5766: Fix iOS crash

### DIFF
--- a/src/sentry/sentryadapter.cpp
+++ b/src/sentry/sentryadapter.cpp
@@ -132,7 +132,7 @@ void SentryAdapter::onLoglineAdded(const QByteArray& line) {
 
 sentry_value_t SentryAdapter::onCrash(const sentry_ucontext_t* uctx,
                                       sentry_value_t event, void* closure) {
-  logger.info() << "Sentry ON CRASH";
+  logger.info() << "Sentry ON CRASH:" << uctx->siginfo->si_signo;
   captureQMLStacktrace("Client Crashed, Current QML Stack:");
   return event;
 }

--- a/src/sentry/sentryadapter.cpp
+++ b/src/sentry/sentryadapter.cpp
@@ -132,7 +132,11 @@ void SentryAdapter::onLoglineAdded(const QByteArray& line) {
 
 sentry_value_t SentryAdapter::onCrash(const sentry_ucontext_t* uctx,
                                       sentry_value_t event, void* closure) {
+#ifdef MZ_IOS
   logger.info() << "Sentry ON CRASH:" << uctx->siginfo->si_signo;
+#else
+  logger.info() << "Sentry ON CRASH";
+#endif
   captureQMLStacktrace("Client Crashed, Current QML Stack:");
   return event;
 }

--- a/src/serverlatency.cpp
+++ b/src/serverlatency.cpp
@@ -65,6 +65,9 @@ void ServerLatency::initialize() {
   if (feature->isSupported()) {
     m_refreshTimer.start(SERVER_LATENCY_INITIAL_MSEC);
   }
+
+  connect(qApp, &QApplication::applicationStateChanged, this,
+          &ServerLatency::applicationStateChanged);
 }
 
 void ServerLatency::start() {
@@ -249,6 +252,26 @@ void ServerLatency::stateChanged() {
     // If the VPN has been deactivated, start a refresh if desired.
     start();
   }
+}
+
+// iOS kills the socket shortly after the device is turned off, and possibly if
+// the app is backgrounded. This was causing a crash when the device was turned
+// back on. By only refreshing the server list when the app is active, we
+// prevent this crash. More details in VPN-5766.
+void ServerLatency::applicationStateChanged() {
+#ifdef MZ_IOS
+  if (QGuiApplication::applicationState() !=
+      Qt::ApplicationState::ApplicationActive) {
+    if (m_pingSender != nullptr) {
+      m_wantRefresh = true;
+      stop();
+    }
+  } else {
+    if (m_wantRefresh) {
+      refresh();
+    }
+  }
+#endif
 }
 
 void ServerLatency::recvPing(quint16 sequence) {

--- a/src/serverlatency.h
+++ b/src/serverlatency.h
@@ -96,6 +96,7 @@ class ServerLatency final : public QObject {
 
  private slots:
   void stateChanged();
+  void applicationStateChanged();
   void recvPing(quint16 sequence);
   void criticalPingError();
 };


### PR DESCRIPTION
## Description

Big credit to @oskirby for coming up with the fix after the source of the problem was identified.

iOS is closing sockets when the device is closed (and probably while the app is backgrounded), causing this crash when the device is turned back on. This makes sense as to why QA is running into this the most - as they are more likely to launch the app and immediately background it.

To reproduce:
1. Ensure VPN is off
2. Cold launch of app
3. In about a second or two, press power button to turn screen off
4. In 5-10 seconds, unlock phone (this part seemed inconsistent - the crash doesn’t happen if it’s only a couple seconds)
5. Crash happens

This PR does 3 things:
- Improves logging (removes some logging we added to diagnose the problem, adds some better logging for any future issues)
- Adds the `MSG_NOSIGNAL` flag to the socket. (Big thanks to Naomi for this.)
- If server latency checks are running when the app state changes to non-foreground, it stops the checks and sets it up to refresh the server list on the next launch. (FWIW, we already had similar code for health checks - the other place that uses sockets.) 

(This third piece - My first attempt at this functionality was to essentially pause the running check. In `ServerLatency::maybeSendPings`, I checked if we were on iOS and not foregrounded, and if so did an early return while setting a timer to check again in a few seconds. For reasons I don't quite understand, when we came back to foreground the latency checks were *very very slow*, and so I went with this current approach. It's not the best - as it restarts the entire check - but given that in most cases a server check isn't interrupted by backgrounding the app, it seems like an okay tradeoff.)

## Reference

VPN-5766

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
