### PR TITLE
Fix broken build instructions link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Here are some useful links to start:
 
 ## Building the Client
 
-Moved here -> [Dev-Setup](./docs/dev-setup/index.md)
+Moved here -> [Dev-Setup](./docs/Building/index.md)
 
 ### Pre-commit formatting hook
 


### PR DESCRIPTION
## Description

    Found a broken link in the README.md when looking for build instructions. Fixed the path; looks like a small oversight when some files were moved in #8922. 

## Reference

    N/A

## Checklist
    
- [ X ] My code follows the style guidelines for this project
- [ X ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ X ] I have performed a self review of my own code
- [ X ] I have commented my code PARTICULARLY in hard to understand areas
- [ X ] I have added thorough tests where needed
