### PR TITLE
VPN-6005: strip out log names

### DIFF
--- a/src/addons/manager/addonmanager.cpp
+++ b/src/addons/manager/addonmanager.cpp
@@ -272,7 +272,7 @@ bool AddonManager::validateAndLoad(const QString& addonId,
 
     if (QCryptographicHash::hash(addonFileContents,
                                  QCryptographicHash::Sha256) != sha256) {
-      logger.warning() << "Addon hash does not match" << addonFilePath;
+      logger.warning() << "Addon hash does not match" << addonId;
       return false;
     }
   }
@@ -281,7 +281,7 @@ bool AddonManager::validateAndLoad(const QString& addonId,
   QString addonMountPath = mountPath(addonId);
 
   if (!QResource::registerResource(addonFilePath, addonMountPath)) {
-    logger.warning() << "Unable to load resource from file" << addonFilePath;
+    logger.warning() << "Unable to load resource from file" << addonId;
     return false;
   }
 

--- a/src/loghandler.cpp
+++ b/src/loghandler.cpp
@@ -398,8 +398,10 @@ void LogHandler::openLogFile(const QMutexLocker<QMutex>& proofOfLock) {
 
   m_output = new QTextStream(m_logFile);
 
+#ifdef MZ_DEBUG
   addLog(Log(Debug, "LogHandler", QString("Log file: %1").arg(logFileName)),
          proofOfLock);
+#endif
 }
 
 void LogHandler::closeLogFile(const QMutexLocker<QMutex>& proofOfLock) {
@@ -501,7 +503,11 @@ void LogHandler::serializeLogs(QTextStream* out,
 bool LogHandler::writeLogsToLocation(
     QStandardPaths::StandardLocation location,
     std::function<void(const QString& filename)>&& a_callback) {
+#ifdef MZ_DEBUG
   logger.debug() << "Trying to save logs in:" << location;
+#else
+  logger.debug() << "Trying to save logs.";
+#endif
 
   std::function<void(const QString& filename)> callback = std::move(a_callback);
 
@@ -522,7 +528,11 @@ bool LogHandler::writeLogsToLocation(
   QString logFile = logDir.filePath(filename);
 
   if (QFileInfo::exists(logFile)) {
+#ifdef MZ_DEBUG
     logger.warning() << logFile << "exists. Let's try a new filename";
+#else
+    logger.warning() << "Logfile exists. Let's try a new filename";
+#endif
 
     for (uint32_t i = 1;; ++i) {
       QString filename;
@@ -537,7 +547,7 @@ bool LogHandler::writeLogsToLocation(
     }
   }
 
-  logger.debug() << "Writing logs into: " << logFile;
+  logger.debug() << "Writing logs.";
 
   QFile* file = new QFile(logFile);
   if (!file->open(QIODevice::WriteOnly | QIODevice::Text)) {
@@ -561,7 +571,7 @@ bool LogHandler::writeLogsToLocation(
 
 bool LogHandler::writeAndShowLogs(QStandardPaths::StandardLocation location) {
   return writeLogsToLocation(location, [](const QString& filename) {
-    logger.debug() << "Opening the logFile somehow:" << filename;
+    logger.debug() << "Opening the logFile somehow.";
     UrlOpener::instance()->openUrl(QUrl::fromLocalFile(filename));
   });
 }


### PR DESCRIPTION
## Description

Per ticket, we don't need the full file names in the logs. This PR handles the existing ones in 3 ways:
- Removes the file locations from the log line, as the same locations/names are covered by earlier logs lines.
- Uses the PII-ish log lines only when on a debug build, otherwise uses a version without the actual filename.
- In one case, only uses a log line when on a debug build, as it has limited utility otherwise.

## Reference

VPN-6005

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
