### PR TITLE
VPN-4040: Fix CLI assert due to missing ServerData init

### DIFF
--- a/src/command.cpp
+++ b/src/command.cpp
@@ -79,8 +79,6 @@ bool Command::loadModels() {
     return false;
   }
 
-  vpn->serverData()->initialize();
-
   if (!vpn->deviceModel()->fromSettings(vpn->keys()) ||
       !vpn->serverCountryModel()->fromSettings() ||
       !vpn->user()->fromSettings() || !vpn->serverData()->fromSettings() ||

--- a/src/models/serverdata.cpp
+++ b/src/models/serverdata.cpp
@@ -27,7 +27,12 @@ namespace {
 Logger logger("ServerData");
 }
 
-ServerData::ServerData() { MZ_COUNT_CTOR(ServerData); }
+ServerData::ServerData() {
+  MZ_COUNT_CTOR(ServerData);
+
+  connect(SettingsHolder::instance(), &SettingsHolder::serverDataChanged, this,
+          &ServerData::settingsChanged);
+}
 
 ServerData::ServerData(const ServerData& other) {
   MZ_COUNT_CTOR(ServerData);
@@ -37,7 +42,6 @@ ServerData::ServerData(const ServerData& other) {
 ServerData::~ServerData() { MZ_COUNT_DTOR(ServerData); }
 
 ServerData& ServerData::operator=(const ServerData& other) {
-  m_initialized = other.m_initialized;
   m_exitCountryCode = other.m_exitCountryCode;
   m_exitCityName = other.m_exitCityName;
   m_entryCountryCode = other.m_entryCountryCode;
@@ -50,16 +54,7 @@ ServerData& ServerData::operator=(const ServerData& other) {
   return *this;
 }
 
-void ServerData::initialize() {
-  m_initialized = true;
-
-  connect(SettingsHolder::instance(), &SettingsHolder::serverDataChanged, this,
-          &ServerData::settingsChanged);
-}
-
 bool ServerData::fromSettings() {
-  Q_ASSERT(m_initialized);
-
   SettingsHolder* settingsHolder = SettingsHolder::instance();
   Q_ASSERT(settingsHolder);
 
@@ -88,8 +83,6 @@ void ServerData::update(const QString& exitCountryCode,
                         const QString& exitCityName,
                         const QString& entryCountryCode,
                         const QString& entryCityName) {
-  Q_ASSERT(m_initialized);
-
   m_previousExitCountryCode = m_exitCountryCode;
   m_previousExitCountryName =
       MozillaVPN::instance()->serverCountryModel()->countryName(
@@ -117,8 +110,6 @@ void ServerData::update(const QString& exitCountryCode,
 }
 
 bool ServerData::settingsChanged() {
-  Q_ASSERT(m_initialized);
-
   SettingsHolder* settingsHolder = SettingsHolder::instance();
   Q_ASSERT(settingsHolder);
 
@@ -163,37 +154,31 @@ bool ServerData::settingsChanged() {
 }
 
 QString ServerData::localizedExitCityName() const {
-  Q_ASSERT(m_initialized);
   return ServerI18N::instance()->translateCityName(m_exitCountryCode,
                                                    m_exitCityName);
 }
 
 QString ServerData::localizedEntryCityName() const {
-  Q_ASSERT(m_initialized);
   return ServerI18N::instance()->translateCityName(m_entryCountryCode,
                                                    m_entryCityName);
 }
 
 QString ServerData::localizedPreviousExitCountryName() const {
-  Q_ASSERT(m_initialized);
   return ServerI18N::instance()->translateCityName(m_previousExitCountryCode,
                                                    m_previousExitCountryName);
 }
 
 QString ServerData::localizedPreviousExitCityName() const {
-  Q_ASSERT(m_initialized);
   return ServerI18N::instance()->translateCityName(m_previousExitCountryCode,
                                                    m_previousExitCityName);
 }
 
 QString ServerData::localizedEntryCountryName() const {
-  Q_ASSERT(m_initialized);
   return ServerI18N::instance()->translateCountryName(m_entryCountryCode,
                                                       m_entryCountryName);
 }
 
 QString ServerData::localizedExitCountryName() const {
-  Q_ASSERT(m_initialized);
   return ServerI18N::instance()->translateCountryName(m_exitCountryCode,
                                                       m_exitCountryName);
 }
@@ -244,8 +229,6 @@ void ServerData::changeServer(const QString& countryCode,
 }
 
 void ServerData::forget() {
-  Q_ASSERT(m_initialized);
-
   m_exitCountryCode.clear();
   m_exitCityName.clear();
   m_exitCountryName.clear();

--- a/src/models/serverdata.h
+++ b/src/models/serverdata.h
@@ -47,8 +47,6 @@ class ServerData final : public QObject {
 
   ServerData& operator=(const ServerData& other);
 
-  void initialize();
-
   [[nodiscard]] bool fromSettings();
 
   Q_INVOKABLE void changeServer(const QString& countryCode,
@@ -105,8 +103,6 @@ class ServerData final : public QObject {
                                      const QString& cityName);
 
  private:
-  bool m_initialized = false;
-
   QString m_exitCountryCode;
   QString m_exitCountryName;
   QString m_exitCityName;

--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -258,8 +258,6 @@ void MozillaVPN::initialize() {
 
   m_private->m_serverLatency.initialize();
 
-  m_private->m_serverData.initialize();
-
   AddonManager::instance();
 
   RecentConnections::instance()->initialize();

--- a/tests/unit/testmodels.cpp
+++ b/tests/unit/testmodels.cpp
@@ -565,8 +565,6 @@ void TestModels::recentConnectionBasic() {
   QVERIFY(rcMultiHop->isEmpty());
   QCOMPARE(rcMultiHop->rowCount(QModelIndex()), 0);
 
-  MozillaVPN::instance()->serverData()->initialize();
-
   // First entry (single hop)
   {
     MozillaVPN::instance()->serverData()->changeServer("a", "b");
@@ -874,8 +872,6 @@ void TestModels::recentConnectionSaveAndRestore() {
 
   QCOMPARE(rcMultiHop->rowCount(QModelIndex()), 0);
   QVERIFY(rcMultiHop->isEmpty());
-
-  MozillaVPN::instance()->serverData()->initialize();
 
   // Let's populate the models
   {
@@ -1662,9 +1658,7 @@ void TestModels::serverCountryModelPick() {
 
 void TestModels::serverDataBasic() {
   SettingsHolder settingsHolder;
-
   ServerData sd;
-  sd.initialize();
 
   QSignalSpy spy(&sd, &ServerData::changed);
 
@@ -1707,7 +1701,6 @@ void TestModels::serverDataBasic() {
 
     {
       ServerData sd2;
-      sd2.initialize();
 
       QVERIFY(sd2.fromSettings());
       QVERIFY(sd2.hasServerData());
@@ -1780,8 +1773,6 @@ void TestModels::serverDataMigrate() {
     settingsHolder.setCurrentServerCityDeprecated("bar");
 
     ServerData sd;
-    sd.initialize();
-
     QVERIFY(sd.fromSettings());
 
     QCOMPARE(sd.exitCountryCode(), "foo");
@@ -1797,8 +1788,6 @@ void TestModels::serverDataMigrate() {
     QVERIFY(!settingsHolder.hasEntryServerCityDeprecated());
 
     ServerData sd2;
-    sd2.initialize();
-
     QVERIFY(sd2.fromSettings());
 
     QCOMPARE(sd2.exitCountryCode(), "foo");
@@ -1822,8 +1811,6 @@ void TestModels::serverDataMigrate() {
     settingsHolder.setEntryServerCityDeprecated("bb");
 
     ServerData sd;
-    sd.initialize();
-
     QVERIFY(sd.fromSettings());
 
     QCOMPARE(sd.exitCountryCode(), "foo");
@@ -1839,8 +1826,6 @@ void TestModels::serverDataMigrate() {
     QVERIFY(!settingsHolder.hasEntryServerCityDeprecated());
 
     ServerData sd2;
-    sd2.initialize();
-
     QVERIFY(sd2.fromSettings());
 
     QCOMPARE(sd2.exitCountryCode(), "foo");


### PR DESCRIPTION
## Description
When compiled for debug, the CLI commands terminate with an assert due to a skipped initialization of the `ServerData` model, but the init doesn't really do anything other than connect a signal which we can just do from the constructor instead.

## Reference
Github issue #5816 ([VPN-4040](https://mozilla-hub.atlassian.net/browse/VPN-4040))

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-4040]: https://mozilla-hub.atlassian.net/browse/VPN-4040?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ