### PR TITLE
VPN-5101: cleanup logs after they are exported for iOS and desktop

### DIFF
--- a/src/loghandler.cpp
+++ b/src/loghandler.cpp
@@ -449,15 +449,10 @@ bool LogHandler::viewLogs() {
   return ok;
 #endif
 
-  if (writeAndShowLogs(QStandardPaths::DesktopLocation)) {
-    return true;
-  }
-
-  if (writeAndShowLogs(QStandardPaths::HomeLocation)) {
-    return true;
-  }
-
-  if (writeAndShowLogs(QStandardPaths::TempLocation)) {
+  if (writeAndShowLogs(QStandardPaths::DesktopLocation) ||
+      writeAndShowLogs(QStandardPaths::HomeLocation) ||
+      writeAndShowLogs(QStandardPaths::TempLocation)) {
+    flushLogs();
     return true;
   }
 

--- a/src/platforms/ios/ioscommons.mm
+++ b/src/platforms/ios/ioscommons.mm
@@ -5,6 +5,7 @@
 #include "ioscommons.h"
 #include "constants.h"
 #include "logger.h"
+#include "loghandler.h"
 #include "qmlengineholder.h"
 
 #include <QtGui/qpa/qplatformnativeinterface.h>
@@ -102,6 +103,15 @@ void IOSCommons::shareLogs(const QString& logs) {
     activityViewController.popoverPresentationController.sourceRect =
         CGRectMake(view.bounds.size.width / 2, view.bounds.size.height, 0, 0);
   }
+  activityViewController.completionWithItemsHandler =
+      ^(NSString* activityType, BOOL completed, NSArray* returnedItems, NSError* activityError) {
+        if (completed) {
+          logger.info() << "Clearing logs.";
+          LogHandler::instance()->flushLogs();
+        } else {
+          logger.info() << "No need to clear logs.";
+        }
+      };
   [qtController presentViewController:activityViewController animated:YES completion:nil];
   [activityViewController release];
 }


### PR DESCRIPTION
## Description

While we had the code to cleanup logs, we weren't using it. While this ticket was about iOS, I also added relevant code for all non-Android platforms.

Reason for not implementing on Android:
- On desktop platforms, we save the log file, so it can always be found.
- On iOS, we only clear logs if we get a positive signal that the user did something with the logs. (If they cancel out of the share sheet screen, the logs are not cleared.)
- On Android, we don't have a way to discover whether the user did something with the share sheet - and thus they could have canceled out without sharing the logs anywhere. In those cases, we don't want to clear the logs. And since we can't tell which type of case we're in, I'm being conservative and keeping the logs for Android.

## Reference

VPN-5101

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
