### PR TITLE
Run Clang-Tidy on taskcluster

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -4,16 +4,18 @@
 # Everything marked under Checks will be warnings
 # WarningAsErrors bump them to a CI error. 
 Checks: >  
-  misc-include-cleaner,
-  misc-const-correctness,
   clang-diagnostic-*,
   clang-analyzer-*,
-#  modernize-*,
-#  -modernize-use-trailing-return-type,
-#  cppcoreguidelines-*,
+  performance*
+  cppcoreguidelines-*,
+  -cppcoreguidelines-owning-memory,
+  modernize*,
+  -modernize-use-trailing-return-type,
+  misc*,
+  -misc-no-recursion
 WarningsAsErrors: >
   clang-analyzer-security.*
-HeaderFilterRegex: ''
+HeaderFilterRegex: '^q.*\.h$' # Any qHeader, so we don't get warnings for qt thigns.
 AnalyzeTemporaryDtors: false
 # Use our .clang-format file when applying fixes.
 FormatStyle: file

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -15,7 +15,6 @@ Checks: >
   -misc-no-recursion
 WarningsAsErrors: >
   clang-analyzer-security.*
-HeaderFilterRegex: '^q.*\.h$' # Any qHeader, so we don't get warnings for qt thigns.
 AnalyzeTemporaryDtors: false
 # Use our .clang-format file when applying fixes.
 FormatStyle: file

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,12 +1,19 @@
+# For a list of checks and what they do see
+# https://clang.llvm.org/extra/clang-tidy/checks/list.html
+#
+# Everything marked under Checks will be warnings
+# WarningAsErrors bump them to a CI error. 
 Checks: >  
-  clang-diagnostic-*
+  misc-include-cleaner,
+  misc-const-correctness,
+  clang-diagnostic-*,
   clang-analyzer-*,
-  -modernize-use-trailing-return-type,
-  modernize-*,
+#  modernize-*,
+#  -modernize-use-trailing-return-type,
 #  cppcoreguidelines-*,
 WarningsAsErrors: >
   clang-analyzer-security.*
 HeaderFilterRegex: ''
 AnalyzeTemporaryDtors: false
-# Use our Clang Format
+# Use our .clang-format file when applying fixes.
 FormatStyle: file

--- a/.dictionary
+++ b/.dictionary
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 246 utf-8
+personal_ws-1.1 en 245 utf-8
 ADRs
 APIs
 Adblock
@@ -14,6 +14,7 @@ CTest
 Changelog
 Conda
 ConnectionDiagnostics
+DBUILD
 DNS
 DevOps
 Docusaurus

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,18 +158,19 @@ add_subdirectory(addons)
 if(NOT CMAKE_CROSSCOMPILING)
     # Extra rustlang libraries
     add_subdirectory(extension)
+    if(BUILD_TESTS)
+        # Unit Tests
+        add_subdirectory(tests/nativemessaging EXCLUDE_FROM_ALL)
+        add_subdirectory(tests/unit EXCLUDE_FROM_ALL)
+        add_subdirectory(tests/qml EXCLUDE_FROM_ALL)
+        add_subdirectory(tests/unit_tests EXCLUDE_FROM_ALL)
 
-    # Unit Tests
-    add_subdirectory(tests/nativemessaging EXCLUDE_FROM_ALL)
-    add_subdirectory(tests/unit EXCLUDE_FROM_ALL)
-    add_subdirectory(tests/qml EXCLUDE_FROM_ALL)
-    add_subdirectory(tests/unit_tests EXCLUDE_FROM_ALL)
+        # E2E Tests
+        add_subdirectory(tests/auth_tests EXCLUDE_FROM_ALL)
 
-    # E2E Tests
-    add_subdirectory(tests/auth_tests EXCLUDE_FROM_ALL)
-
-    # Dummy Testing Client
-    add_subdirectory(tests/dummyvpn EXCLUDE_FROM_ALL)
+        # Dummy Testing Client
+        add_subdirectory(tests/dummyvpn EXCLUDE_FROM_ALL)
+    endif()
 endif()
 
 # Extra platform targets

--- a/docs/Checks/clang-tidy.md
+++ b/docs/Checks/clang-tidy.md
@@ -42,14 +42,10 @@ Some checks can be fixed automatically. You can use `clang-apply-replacements` t
 ### Error: error: 'some.h' file not found [clang-diagnostic-error]
 Make sure that either all targets (including tests) are built or try configuring with -DBUILD_TESTS=OFF. 
 
-This might happen clang-tidy reads the compilation database for each file i.e `a.cpp`, if there are 2 objects build from `a.cpp` i.e:
+This might happen clang-tidy reads the compilation database for each file i.e `a.cpp`, if there are 2 object files built from `a.cpp` i.e:
 ```cmake
 add_library(lib_a a.cpp)
-add_library(lib_b b.cpp)
+add_library(lib_b a.cpp)
 ```
-it will pick one, so either make sure only one lib is configured or even better break the double build if possible :) 
-```
-add_library(a a.cpp)
-add_target_dependencies(lib_a a)
-add_target_dependencies(lib_b a)
-```
+it will pick one, so either make sure only one lib is configured, all possible dependencies for `a.cpp` are attached to the lint target or create a smaller target.
+

--- a/docs/Checks/clang-tidy.md
+++ b/docs/Checks/clang-tidy.md
@@ -34,3 +34,22 @@ Some checks can be fixed automatically. You can use `clang-apply-replacements` t
     # Apply all suggestions: 
     clang-apply-replacements <build_dir>/clang-tidy/
 ```
+
+
+## Help 
+
+
+### Error: error: 'some.h' file not found [clang-diagnostic-error]
+Make sure that either all targets (including tests) are built or try configuring with -DBUILD_TESTS=OFF. 
+
+This might happen clang-tidy reads the compilation database for each file i.e `a.cpp`, if there are 2 objects build from `a.cpp` i.e:
+```cmake
+add_library(lib_a a.cpp)
+add_library(lib_b b.cpp)
+```
+it will pick one, so either make sure only one lib is configured or even better break the double build if possible :) 
+```
+add_library(a a.cpp)
+add_target_dependencies(lib_a a)
+add_target_dependencies(lib_b a)
+```

--- a/scripts/cmake/clang_tidy.cmake
+++ b/scripts/cmake/clang_tidy.cmake
@@ -76,7 +76,7 @@ function(mz_add_clang_tidy aTarget)
     # Otherwise we might have files from MOC there. 
     list(FILTER aTarget_SOURCE_FILES INCLUDE REGEX ".*\\.cpp$")
     list(FILTER aTarget_SOURCE_FILES EXCLUDE REGEX "${CMAKE_BINARY_DIR}/.*")
-   
+
     if(WIN32)
         # on windows we need to pass \\ to clang tidy
         # cmake by default uses / as delemiter so let's replace that. 

--- a/scripts/cmake/clang_tidy.cmake
+++ b/scripts/cmake/clang_tidy.cmake
@@ -49,7 +49,7 @@ if(NOT CLANG_TIDY_EXECUTABLE)
 endif()
 # Check if the flag is set
 if(NOT CMAKE_EXPORT_COMPILE_COMMANDS)
-    message(STATUS "clang-tidy: The -DEXPORT_COMPILE_COMMANDS=ON flag is not set. Linting will be skipped.")
+    message(STATUS "clang-tidy: The -DCMAKE_EXPORT_COMPILE_COMMANDS=ON flag is not set. Linting will be skipped.")
     function(mz_add_clang_tidy dummyArgument)
     endfunction() 
     return()

--- a/scripts/cmake/clang_tidy.cmake
+++ b/scripts/cmake/clang_tidy.cmake
@@ -76,7 +76,7 @@ function(mz_add_clang_tidy aTarget)
     # Otherwise we might have files from MOC there. 
     list(FILTER aTarget_SOURCE_FILES INCLUDE REGEX ".*\\.cpp$")
     list(FILTER aTarget_SOURCE_FILES EXCLUDE REGEX "${CMAKE_BINARY_DIR}/.*")
-    
+   
     if(WIN32)
         # on windows we need to pass \\ to clang tidy
         # cmake by default uses / as delemiter so let's replace that. 

--- a/scripts/cmake/generate_translations_target.cmake
+++ b/scripts/cmake/generate_translations_target.cmake
@@ -42,10 +42,10 @@ function(generate_translations_target TARGET_NAME TRANSLATIONS_DIRECTORY)
 
     target_sources(${TARGET_NAME} PRIVATE
         ${GENERATED_DIR}/i18nstrings_p.cpp
+        ${GENERATED_DIR}/i18nstrings.h
         ${GENERATED_DIR}/translations.qrc
         ${CMAKE_SOURCE_DIR}/translations/i18nstrings.cpp
     )
-
 
     ## Generate the string database (language agnostic)
     add_custom_command(

--- a/scripts/cmake/generate_translations_target.cmake
+++ b/scripts/cmake/generate_translations_target.cmake
@@ -39,12 +39,15 @@ function(generate_translations_target TARGET_NAME TRANSLATIONS_DIRECTORY)
 
     file(MAKE_DIRECTORY ${GENERATED_DIR})
     target_include_directories(${TARGET_NAME} PUBLIC ${GENERATED_DIR})
+    target_include_directories(${TARGET_NAME} INTERFACE ${GENERATED_DIR})
 
     target_sources(${TARGET_NAME} PRIVATE
         ${GENERATED_DIR}/i18nstrings_p.cpp
-        ${GENERATED_DIR}/i18nstrings.h
         ${GENERATED_DIR}/translations.qrc
         ${CMAKE_SOURCE_DIR}/translations/i18nstrings.cpp
+    )
+    target_sources(${TARGET_NAME} INTERFACE
+        ${GENERATED_DIR}/i18nstrings.h
     )
 
     ## Generate the string database (language agnostic)

--- a/scripts/cmake/generate_translations_target.cmake
+++ b/scripts/cmake/generate_translations_target.cmake
@@ -39,16 +39,13 @@ function(generate_translations_target TARGET_NAME TRANSLATIONS_DIRECTORY)
 
     file(MAKE_DIRECTORY ${GENERATED_DIR})
     target_include_directories(${TARGET_NAME} PUBLIC ${GENERATED_DIR})
-    target_include_directories(${TARGET_NAME} INTERFACE ${GENERATED_DIR})
 
     target_sources(${TARGET_NAME} PRIVATE
         ${GENERATED_DIR}/i18nstrings_p.cpp
         ${GENERATED_DIR}/translations.qrc
         ${CMAKE_SOURCE_DIR}/translations/i18nstrings.cpp
     )
-    target_sources(${TARGET_NAME} INTERFACE
-        ${GENERATED_DIR}/i18nstrings.h
-    )
+
 
     ## Generate the string database (language agnostic)
     add_custom_command(

--- a/src/cmake/shared-sources.cmake
+++ b/src/cmake/shared-sources.cmake
@@ -247,3 +247,8 @@ include(${CMAKE_SOURCE_DIR}/src/platforms/${MZ_PLATFORM_NAME}/sources.cmake)
 include(${CMAKE_SOURCE_DIR}/src/cmake/sentry.cmake)
 
 mz_add_clang_tidy(shared-sources)
+if(TARGET shared-sources_clang_tidy_report)
+    add_dependencies(shared-sources_clang_tidy_report
+        qtglean
+    )
+endif()

--- a/src/cmake/shared-sources.cmake
+++ b/src/cmake/shared-sources.cmake
@@ -250,5 +250,6 @@ mz_add_clang_tidy(shared-sources)
 if(TARGET shared-sources_clang_tidy_report)
     add_dependencies(shared-sources_clang_tidy_report
         qtglean
+        translations
     )
 endif()

--- a/src/cmake/shared-sources.cmake
+++ b/src/cmake/shared-sources.cmake
@@ -246,6 +246,8 @@ endif()
 include(${CMAKE_SOURCE_DIR}/src/platforms/${MZ_PLATFORM_NAME}/sources.cmake)
 include(${CMAKE_SOURCE_DIR}/src/cmake/sentry.cmake)
 
+add_dependencies(shared-sources translations)
+
 mz_add_clang_tidy(shared-sources)
 if(TARGET shared-sources_clang_tidy_report)
     add_dependencies(shared-sources_clang_tidy_report

--- a/src/cmake/shared-sources.cmake
+++ b/src/cmake/shared-sources.cmake
@@ -249,7 +249,7 @@ include(${CMAKE_SOURCE_DIR}/src/cmake/sentry.cmake)
 mz_add_clang_tidy(shared-sources)
 if(TARGET shared-sources_clang_tidy_report)
     add_dependencies(shared-sources_clang_tidy_report
-        qtglean
         translations
+        qtglean
     )
 endif()

--- a/taskcluster/kinds/source-test/clang.yml
+++ b/taskcluster/kinds/source-test/clang.yml
@@ -4,7 +4,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 ---
 task-defaults:
-    description: "Clang-tidy "
+    description: "Clang-tidy"
     treeherder:
         symbol: lint(tidy)
         kind: other
@@ -75,3 +75,37 @@ clang-tidy-windows:
     run:
       exec-with: powershell
       command: taskcluster/scripts/source-test/clang-tidy.ps1
+
+
+
+# clang-tidy-macos:
+#     treeherder:
+#             platform: macos/universal
+#     worker-type: b-macos
+#     fetches:
+#         toolchain:
+#             - conda-macos
+#             - qt-macos-6.6
+#     run:
+#         using: run-task
+#         use-caches: false
+#         cwd: '{checkout}'
+#         command: >-
+#           export TASK_HOME=$(dirname "${MOZ_FETCHES_DIR}" )
+#           rm -rf "${TASK_HOME}/artifacts" &&
+#           mkdir -p "${TASK_HOME}/artifacts" &&
+#           source ${TASK_WORKDIR}/fetches/bin/activate && 
+#           conda-unpack && 
+#           export SDKROOT=$(xcrun --sdk macosx --show-sdk-path) && 
+#           git submodule update --init --recursive && 
+
+#           cmake -S . -B ${TASK_HOME}/build -GNinja \
+#             -DCMAKE_PREFIX_PATH=${MOZ_FETCHES_DIR}/qt_dist/lib/cmake \
+#             -DBUILD_TESTS=OFF \
+#             -DCMAKE_EXPORT_COMPILE_COMMANDS=ON &&
+#           cmake --build ${TASK_HOME}/build --target clang_tidy_report &&
+#           rm -rf ${TASK_HOME}/build
+
+
+
+        

--- a/taskcluster/kinds/source-test/clang.yml
+++ b/taskcluster/kinds/source-test/clang.yml
@@ -1,0 +1,60 @@
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+---
+task-defaults:
+    description: "Clang-tidy "
+    treeherder:
+        symbol: lint(tidy)
+        kind: other
+        tier: 2
+    run:
+        using: run-task
+    when:
+        files-changed:
+            - '**/*.c'
+            - '**/*.cpp'
+            - '**/*.cc'
+            - '**/*.cxx'
+            - '**/*.m'
+            - '**/*.mm'
+
+
+clang-tidy-android:
+    treeherder:
+            tier: 1
+            platform: android/arm64-v8a
+    worker-type: b-linux-large
+    fetches:
+      toolchain: 
+        - conda-android-arm64-6.6.0
+    worker:
+          max-run-time: 3600
+          chain-of-trust: true
+          docker-image: {in-tree: conda-base}
+          artifacts:
+            - type: directory
+              name: public/build/
+              path: /builds/worker/artifacts/
+    run:
+      using: run-task
+      use-caches: true
+      cwd: '{checkout}'
+      command: >-
+        source $TASK_WORKDIR/fetches/bin/activate &&
+        conda-unpack &&
+        $QTPATH/bin/qt-cmake \
+          -DQT_HOST_PATH=$QT_HOST_PATH \
+          -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+          -DANDROID_NDK_ROOT=$ANDROID_NDK_ROOT \
+          -DANDROID_SDK_ROOT=$ANDROID_SDK_ROOT \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DADJUST_TOKEN=AAAAAAA \
+          -DBUILD_TESTS=OFF \
+          -GNinja \
+          -S . -B .tmp/ &&
+        cmake --build .tmp --target clang_tidy_report &&
+        mkdir -p /builds/worker/artifacts/ &&
+        cp .tmp/clang-tidy/* /builds/worker/artifacts/
+        

--- a/taskcluster/kinds/source-test/clang.yml
+++ b/taskcluster/kinds/source-test/clang.yml
@@ -10,7 +10,12 @@ task-defaults:
         kind: other
         tier: 2
     run:
-        using: run-task
+      using: run-task
+      use-caches: true
+      cwd: '{checkout}'
+    worker:
+        max-run-time: 3600
+        chain-of-trust: true
     when:
         files-changed:
             - '**/*.c'
@@ -23,24 +28,18 @@ task-defaults:
 
 clang-tidy-android:
     treeherder:
-            tier: 1
             platform: android/arm64-v8a
     worker-type: b-linux-large
     fetches:
       toolchain: 
         - conda-android-arm64-6.6.0
     worker:
-          max-run-time: 3600
-          chain-of-trust: true
           docker-image: {in-tree: conda-base}
           artifacts:
             - type: directory
               name: public/build/
               path: /builds/worker/artifacts/
     run:
-      using: run-task
-      use-caches: true
-      cwd: '{checkout}'
       command: >-
         source $TASK_WORKDIR/fetches/bin/activate &&
         conda-unpack &&
@@ -56,10 +55,36 @@ clang-tidy-android:
           -GNinja \
           -S . -B .tmp/ &&
         unset CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER && 
-        cmake --build .tmp --target sentry &&
-        cmake --build .tmp --target translations &&
-        cmake --build .tmp --target qtglean &&
         cmake --build .tmp --target clang_tidy_report &&
         mkdir -p /builds/worker/artifacts/ &&
         cp .tmp/clang-tidy/* /builds/worker/artifacts/
         
+clang-tidy-windows:
+    treeherder:
+            platform: windows/x86_64
+    worker-type: b-windows
+    fetches:
+      toolchain: 
+        - qt-windows-x86_64-6.6.0
+        - conda-windows-x86_64
+    worker:
+          artifacts:
+            - type: directory
+              name: public/build/
+              path: /builds/worker/artifacts/
+    run:
+      command: >-
+        source $TASK_WORKDIR/fetches/bin/activate &&
+        conda-unpack &&
+        git submodule update --init --recursive && 
+        cmake -s . -b .tmp \
+          -GNinja \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DPYTHON_EXECUTABLE="$CONDA_PREFIX\python.exe" \
+          -DGOLANG_BUILD_TOOL="$CONDA_PREFIX\bin\go.exe" \
+          -DWINTUN_FOLDER="$FETCHES_PATH\wintun" \
+          -DCMAKE_PREFIX_PATH="$QTPATH/lib/cmake" \
+          -DBUILD_TESTS=OFF &&
+        cmake --build .tmp --target clang_tidy_report &&
+        mkdir -p /builds/worker/artifacts/ &&
+        cp .tmp/clang-tidy/* /builds/worker/artifacts/

--- a/taskcluster/kinds/source-test/clang.yml
+++ b/taskcluster/kinds/source-test/clang.yml
@@ -71,7 +71,7 @@ clang-tidy-windows:
           artifacts:
             - type: directory
               name: public/build/
-              path: /builds/worker/artifacts/
+              path: artifacts/
     run:
       exec-with: powershell
       command: taskcluster/scripts/source-test/clang-tidy.ps1

--- a/taskcluster/kinds/source-test/clang.yml
+++ b/taskcluster/kinds/source-test/clang.yml
@@ -44,6 +44,7 @@ clang-tidy-android:
       command: >-
         source $TASK_WORKDIR/fetches/bin/activate &&
         conda-unpack &&
+        git submodule update --init --recursive && 
         $QTPATH/bin/qt-cmake \
           -DQT_HOST_PATH=$QT_HOST_PATH \
           -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
@@ -54,6 +55,10 @@ clang-tidy-android:
           -DBUILD_TESTS=OFF \
           -GNinja \
           -S . -B .tmp/ &&
+        unset CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER && 
+        cmake --build .tmp --target sentry &&
+        cmake --build .tmp --target translations &&
+        cmake --build .tmp --target qtglean &&
         cmake --build .tmp --target clang_tidy_report &&
         mkdir -p /builds/worker/artifacts/ &&
         cp .tmp/clang-tidy/* /builds/worker/artifacts/

--- a/taskcluster/kinds/source-test/clang.yml
+++ b/taskcluster/kinds/source-test/clang.yml
@@ -73,4 +73,5 @@ clang-tidy-windows:
               name: public/build/
               path: /builds/worker/artifacts/
     run:
+      exec-with: powershell
       command: taskcluster/scripts/source-test/clang-tidy.ps1

--- a/taskcluster/kinds/source-test/clang.yml
+++ b/taskcluster/kinds/source-test/clang.yml
@@ -76,35 +76,33 @@ clang-tidy-windows:
       exec-with: powershell
       command: taskcluster/scripts/source-test/clang-tidy.ps1
 
+clang-tidy-macos:
+    treeherder:
+            platform: macos/universal
+    worker-type: b-macos
+    fetches:
+        toolchain:
+            - conda-macos
+            - qt-macos-6.6
+    run:
+        using: run-task
+        use-caches: false
+        cwd: '{checkout}'
+        command: >-
+          export TASK_HOME=$(dirname "${MOZ_FETCHES_DIR}" )
+          rm -rf "${TASK_HOME}/artifacts" &&
+          mkdir -p "${TASK_HOME}/artifacts" &&
+          source ${TASK_WORKDIR}/fetches/bin/activate && 
+          conda-unpack && 
+          export SDKROOT=$(xcrun --sdk macosx --show-sdk-path) && 
+          git submodule update --init --recursive && 
 
-
-# clang-tidy-macos:
-#     treeherder:
-#             platform: macos/universal
-#     worker-type: b-macos
-#     fetches:
-#         toolchain:
-#             - conda-macos
-#             - qt-macos-6.6
-#     run:
-#         using: run-task
-#         use-caches: false
-#         cwd: '{checkout}'
-#         command: >-
-#           export TASK_HOME=$(dirname "${MOZ_FETCHES_DIR}" )
-#           rm -rf "${TASK_HOME}/artifacts" &&
-#           mkdir -p "${TASK_HOME}/artifacts" &&
-#           source ${TASK_WORKDIR}/fetches/bin/activate && 
-#           conda-unpack && 
-#           export SDKROOT=$(xcrun --sdk macosx --show-sdk-path) && 
-#           git submodule update --init --recursive && 
-
-#           cmake -S . -B ${TASK_HOME}/build -GNinja \
-#             -DCMAKE_PREFIX_PATH=${MOZ_FETCHES_DIR}/qt_dist/lib/cmake \
-#             -DBUILD_TESTS=OFF \
-#             -DCMAKE_EXPORT_COMPILE_COMMANDS=ON &&
-#           cmake --build ${TASK_HOME}/build --target clang_tidy_report &&
-#           rm -rf ${TASK_HOME}/build
+          cmake -S . -B ${TASK_HOME}/build -GNinja \
+            -DCMAKE_PREFIX_PATH=${MOZ_FETCHES_DIR}/qt_dist/lib/cmake \
+            -DBUILD_TESTS=OFF \
+            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON &&
+          cmake --build ${TASK_HOME}/build --target clang_tidy_report &&
+          rm -rf ${TASK_HOME}/build
 
 
 

--- a/taskcluster/kinds/source-test/clang.yml
+++ b/taskcluster/kinds/source-test/clang.yml
@@ -73,18 +73,4 @@ clang-tidy-windows:
               name: public/build/
               path: /builds/worker/artifacts/
     run:
-      command: >-
-        source $TASK_WORKDIR/fetches/bin/activate &&
-        conda-unpack &&
-        git submodule update --init --recursive && 
-        cmake -s . -b .tmp \
-          -GNinja \
-          -DCMAKE_BUILD_TYPE=Release \
-          -DPYTHON_EXECUTABLE="$CONDA_PREFIX\python.exe" \
-          -DGOLANG_BUILD_TOOL="$CONDA_PREFIX\bin\go.exe" \
-          -DWINTUN_FOLDER="$FETCHES_PATH\wintun" \
-          -DCMAKE_PREFIX_PATH="$QTPATH/lib/cmake" \
-          -DBUILD_TESTS=OFF &&
-        cmake --build .tmp --target clang_tidy_report &&
-        mkdir -p /builds/worker/artifacts/ &&
-        cp .tmp/clang-tidy/* /builds/worker/artifacts/
+      command: taskcluster/scripts/source-test/clang-tidy.ps1

--- a/taskcluster/kinds/source-test/clang.yml
+++ b/taskcluster/kinds/source-test/clang.yml
@@ -89,7 +89,7 @@ clang-tidy-macos:
         use-caches: false
         cwd: '{checkout}'
         command: >-
-          export TASK_HOME=$(dirname "${MOZ_FETCHES_DIR}" )
+          export TASK_HOME=$(dirname "${MOZ_FETCHES_DIR}" ) &&
           rm -rf "${TASK_HOME}/artifacts" &&
           mkdir -p "${TASK_HOME}/artifacts" &&
           source ${TASK_WORKDIR}/fetches/bin/activate && 

--- a/taskcluster/kinds/source-test/clang.yml
+++ b/taskcluster/kinds/source-test/clang.yml
@@ -62,7 +62,7 @@ clang-tidy-android:
 clang-tidy-windows:
     treeherder:
             platform: windows/x86_64
-    worker-type: b-windows
+    worker-type: b-win2022
     fetches:
       toolchain: 
         - qt-windows-x86_64-6.6.0

--- a/taskcluster/kinds/source-test/kind.yml
+++ b/taskcluster/kinds/source-test/kind.yml
@@ -1,0 +1,17 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+---
+
+loader: taskgraph.loader.transform:loader
+
+transforms:
+    - taskgraph.transforms.run:transforms
+    - taskgraph.transforms.task:transforms
+
+kind-dependencies:
+    - toolchain
+    - build
+
+tasks-from:
+    - clang.yml

--- a/taskcluster/scripts/source-test/clang-tidy.ps1
+++ b/taskcluster/scripts/source-test/clang-tidy.ps1
@@ -1,0 +1,41 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+$REPO_ROOT_PATH =resolve-path "$PSScriptRoot/../../../"
+$TASK_WORKDIR =resolve-path "$REPO_ROOT_PATH/../../"
+$FETCHES_PATH =resolve-path "$TASK_WORKDIR/fetches"
+$QTPATH =resolve-path "$FETCHES_PATH/QT_OUT/"
+
+# Prep Env:
+# Switch to the work dir, configure qt
+Set-Location -Path $TASK_WORKDIR
+. "$FETCHES_PATH/QT_OUT/configure_qt.ps1"
+
+## Setup the conda environment
+. $SOURCE_DIR/scripts/utils/call_bat.ps1  $FETCHES_PATH/Scripts/activate.bat
+conda-unpack
+
+# Conda Pack excpets to be run under cmd. therefore it will
+# (unlike conda) ignore activate.d powershell scripts.
+# So let's manually run the activation scripts.
+#
+$CONDA_PREFIX = $env:CONDA_PREFIX
+$env:PATH="$CONDA_PREFIX\bin;$env:Path"
+# 
+$ACTIVATION_SCRIPTS = Get-ChildItem -Path "$CONDA_PREFIX\etc\conda\activate.d" -Filter "*.ps1"
+foreach ($script in  $ACTIVATION_SCRIPTS)  {
+    Write-Output "Activating: $CONDA_PREFIX\etc\conda\activate.d\$script"
+    . "$CONDA_PREFIX\etc\conda\activate.d\$script"
+}
+
+mkdir $TASK_WORKDIR/cmake_build
+$BUILD_DIR =resolve-path "$TASK_WORKDIR/cmake_build"
+
+cmake -S $SOURCE_DIR -B $BUILD_DIR -GNinja `
+        -DCMAKE_BUILD_TYPE=Release `
+        -DPYTHON_EXECUTABLE="$CONDA_PREFIX\python.exe" `
+        -DGOLANG_BUILD_TOOL="$CONDA_PREFIX\bin\go.exe" `
+        -DCMAKE_PREFIX_PATH="$QTPATH/lib/cmake" `
+
+cmake --build $BUILD_DIR --target clang_tidy_report

--- a/taskcluster/scripts/source-test/clang-tidy.ps1
+++ b/taskcluster/scripts/source-test/clang-tidy.ps1
@@ -43,4 +43,5 @@ cmake -S $SOURCE_DIR -B $BUILD_DIR -GNinja `
         -DCMAKE_EXPORT_COMPILE_COMMANDS=ON `
         -DCMAKE_PREFIX_PATH="$QTPATH/lib/cmake" `
 
+cmake --build $BUILD_DIR --target translations
 cmake --build $BUILD_DIR --target clang_tidy_report

--- a/taskcluster/scripts/source-test/clang-tidy.ps1
+++ b/taskcluster/scripts/source-test/clang-tidy.ps1
@@ -52,3 +52,6 @@ Write-Output "GENERATED FOLDER"
 
 cat $BUILD_DIR/compile_commands.json
 cmake --build $BUILD_DIR --target clang_tidy_report
+
+New-Item -ItemType Directory -Path "$TASK_WORKDIR/artifacts" -Force
+Copy-Item -Path $BUILD_DIR/clang-tidy/* -Destination $TASK_WORKDIR/artifacts

--- a/taskcluster/scripts/source-test/clang-tidy.ps1
+++ b/taskcluster/scripts/source-test/clang-tidy.ps1
@@ -5,6 +5,8 @@
 $REPO_ROOT_PATH =resolve-path "$PSScriptRoot/../../../"
 $TASK_WORKDIR =resolve-path "$REPO_ROOT_PATH/../../"
 $FETCHES_PATH =resolve-path "$TASK_WORKDIR/fetches"
+$SOURCE_DIR = resolve-path "."
+
 $QTPATH =resolve-path "$FETCHES_PATH/QT_OUT/"
 
 # Prep Env:
@@ -24,6 +26,7 @@ $CONDA_PREFIX = $env:CONDA_PREFIX
 $env:PATH="$CONDA_PREFIX\bin;$env:Path"
 # 
 $ACTIVATION_SCRIPTS = Get-ChildItem -Path "$CONDA_PREFIX\etc\conda\activate.d" -Filter "*.ps1"
+
 foreach ($script in  $ACTIVATION_SCRIPTS)  {
     Write-Output "Activating: $CONDA_PREFIX\etc\conda\activate.d\$script"
     . "$CONDA_PREFIX\etc\conda\activate.d\$script"

--- a/taskcluster/scripts/source-test/clang-tidy.ps1
+++ b/taskcluster/scripts/source-test/clang-tidy.ps1
@@ -45,4 +45,9 @@ cmake -S $SOURCE_DIR -B $BUILD_DIR -GNinja `
         -DCMAKE_PREFIX_PATH="$QTPATH/lib/cmake" `
 
 cmake --build $BUILD_DIR --target translations
+Write-Output "GENERATED FOLDER"
+ls $BUILD_DIR/translations/generated
+Write-Output "GENERATED FOLDER"
+
+cat $BUILD_DIR/compile_commands.json
 cmake --build $BUILD_DIR --target clang_tidy_report

--- a/taskcluster/scripts/source-test/clang-tidy.ps1
+++ b/taskcluster/scripts/source-test/clang-tidy.ps1
@@ -41,6 +41,7 @@ cmake -S $SOURCE_DIR -B $BUILD_DIR -GNinja `
         -DPYTHON_EXECUTABLE="$CONDA_PREFIX\python.exe" `
         -DGOLANG_BUILD_TOOL="$CONDA_PREFIX\bin\go.exe" `
         -DCMAKE_EXPORT_COMPILE_COMMANDS=ON `
+        -DWINTUN_FOLDER="not-existing" `
         -DCMAKE_PREFIX_PATH="$QTPATH/lib/cmake" `
 
 cmake --build $BUILD_DIR --target translations

--- a/taskcluster/scripts/source-test/clang-tidy.ps1
+++ b/taskcluster/scripts/source-test/clang-tidy.ps1
@@ -39,7 +39,7 @@ cmake -S $SOURCE_DIR -B $BUILD_DIR -GNinja `
         -DCMAKE_BUILD_TYPE=Release `
         -DPYTHON_EXECUTABLE="$CONDA_PREFIX\python.exe" `
         -DGOLANG_BUILD_TOOL="$CONDA_PREFIX\bin\go.exe" `
-        -DEXPORT_COMPILE_COMMANDS=ON `
+        -DCMAKE_EXPORT_COMPILE_COMMANDS=ON `
         -DCMAKE_PREFIX_PATH="$QTPATH/lib/cmake" `
 
 cmake --build $BUILD_DIR --target clang_tidy_report

--- a/taskcluster/scripts/source-test/clang-tidy.ps1
+++ b/taskcluster/scripts/source-test/clang-tidy.ps1
@@ -1,6 +1,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+git submodule update --init --recursive
 
 $REPO_ROOT_PATH = resolve-path "$PSScriptRoot/../../../"
 $TASK_WORKDIR = resolve-path "$REPO_ROOT_PATH/../../"

--- a/taskcluster/scripts/source-test/clang-tidy.ps1
+++ b/taskcluster/scripts/source-test/clang-tidy.ps1
@@ -39,6 +39,7 @@ cmake -S $SOURCE_DIR -B $BUILD_DIR -GNinja `
         -DCMAKE_BUILD_TYPE=Release `
         -DPYTHON_EXECUTABLE="$CONDA_PREFIX\python.exe" `
         -DGOLANG_BUILD_TOOL="$CONDA_PREFIX\bin\go.exe" `
+        -DEXPORT_COMPILE_COMMANDS=ON `
         -DCMAKE_PREFIX_PATH="$QTPATH/lib/cmake" `
 
 cmake --build $BUILD_DIR --target clang_tidy_report

--- a/taskcluster/scripts/source-test/clang-tidy.ps1
+++ b/taskcluster/scripts/source-test/clang-tidy.ps1
@@ -2,9 +2,9 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-$REPO_ROOT_PATH =resolve-path "$PSScriptRoot/../../../"
-$TASK_WORKDIR =resolve-path "$REPO_ROOT_PATH/../../"
-$FETCHES_PATH =resolve-path "$TASK_WORKDIR/fetches"
+$REPO_ROOT_PATH = resolve-path "$PSScriptRoot/../../../"
+$TASK_WORKDIR = resolve-path "$REPO_ROOT_PATH/../../"
+$FETCHES_PATH = resolve-path "$TASK_WORKDIR/fetches"
 $SOURCE_DIR = resolve-path "."
 
 $QTPATH =resolve-path "$FETCHES_PATH/QT_OUT/"

--- a/taskcluster/scripts/source-test/clang-tidy.ps1
+++ b/taskcluster/scripts/source-test/clang-tidy.ps1
@@ -41,6 +41,7 @@ cmake -S $SOURCE_DIR -B $BUILD_DIR -GNinja `
         -DPYTHON_EXECUTABLE="$CONDA_PREFIX\python.exe" `
         -DGOLANG_BUILD_TOOL="$CONDA_PREFIX\bin\go.exe" `
         -DCMAKE_EXPORT_COMPILE_COMMANDS=ON `
+        -DBUILD_TESTS=OFF `
         -DWINTUN_FOLDER="not-existing" `
         -DCMAKE_PREFIX_PATH="$QTPATH/lib/cmake" `
 


### PR DESCRIPTION
This PR adds taskcluster jobs to run clang-tidy. Given we have diffrent c++ source files for each plattform i did create Tasks covering Android,Windows,Macos which should cover most users. 

iOS and Linux should be easy to add, but given this pr is already 27 commit's this will be a Followup. 

I also touched the clang-tidy file, adding a few checks, however only `clang-analyzer-security.*` will produce errors, therefore can block merging, for now :) 
