### PR TITLE
VPN-6215 : Fix navbar visibility after viewing reset options

### DIFF
--- a/src/ui/screens/settings/ViewReset.qml
+++ b/src/ui/screens/settings/ViewReset.qml
@@ -16,13 +16,7 @@ ViewFullScreen {
     property string _menuTitle: MZI18n.ResetSettingsResetLabel
     property var _menuOnBackClicked:  () => {
                                           getHelpStackView.pop();
-                                          if (internal.wasNavbarVisible) navbar.visible = true
                                       }
-    //Internal properies
-    QtObject {
-      id: internal
-      property bool wasNavbarVisible: false
-    }
 
     content: ColumnLayout {
         spacing : 0
@@ -139,7 +133,6 @@ ViewFullScreen {
 
             onClicked: {
                 getHelpStackView.pop();
-                if (internal.wasNavbarVisible) navbar.visible = true
             }
         }
     }
@@ -188,12 +181,5 @@ ViewFullScreen {
         }
 
         onActiveChanged: if (active) { item.open() }
-    }
-
-    Component.onCompleted: {
-        if(navbar.visible) {
-            internal.wasNavbarVisible = true
-            navbar.visible = false
-        }
     }
 }


### PR DESCRIPTION
## Description

This PR removes `property bool wasNavbarVisible` from ViewReset.qml to fix VPN-6215 because:
- `wasNavbarVisible` overwrites the [default navbar visibility handling](https://github.com/mozilla-mobile/mozilla-vpn-client/blob/162e1b947fcd83252d73dbbe4340f72010d160ca/src/ui/main.qml#L179-L190) which causes the navbar to erroneously stay visible after logout. 
- The `wasNavBarVisible` property is not needed given navbar visibilit is handled in the above code chunk, even when on the Get help menu and Get help sub pages.

## Reference

VPN-6215

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
