### PR TITLE
Nit: Stop downloading wintun for Unit-Tests

### DIFF
--- a/.github/workflows/test_unit.yaml
+++ b/.github/workflows/test_unit.yaml
@@ -222,7 +222,7 @@ jobs:
       - name: Building tests
         run: |
           mkdir ./build
-          cmake -S . -B ./build -GNinja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH="C:\MozillaVPNBuild\lib\cmake"
+          cmake -S . -B ./build -GNinja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH="C:\MozillaVPNBuild\lib\cmake" -DWINTUN_FOLDER="not-existing" 
           cmake --build ./build --target build_tests
 
       - name: Running native messaging tests


### PR DESCRIPTION
## Description

Windows unit tests are flaky with 
```

 Downloading Wintun, as WINTUN_FOLDER is unset
CMake Error at windows/tunnel/CMakeLists.txt:11 (file):
  file DOWNLOAD cannot compute hash on failed download

    status: [22;"HTTP response code said error"]


-- Configuring incomplete, errors occurred!
ninja: error: loading 'build.ninja': The system cannot find the file specified.

```


We only care about wintun when buulding the client, so providing a nonexistent path still stops the download and
 should make it less flaky