### PR TITLE
VPN-6236: Re-introduce Balrog staging as a feature

### DIFF
--- a/signature/Cargo.lock
+++ b/signature/Cargo.lock
@@ -305,7 +305,7 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "asn1-rs",
  "data-encoding",

--- a/signature/Cargo.lock
+++ b/signature/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "asn1-rs"
-version = "0.5.2"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f6fd5ddaf0351dff5b8da21b2fb4ff8e08ddd02857f0bf69c47639106c0fff0"
+checksum = "22ad1373757efa0f70ec53939aabc7152e1591cb485208052993070ac8d2429d"
 dependencies = [
  "asn1-rs-derive",
  "asn1-rs-impl",
@@ -20,25 +20,25 @@ dependencies = [
 
 [[package]]
 name = "asn1-rs-derive"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "726535892e8eae7e70657b4c8ea93d26b8553afb1ce617caee529ef96d7dee6c"
+checksum = "7378575ff571966e99a744addeff0bff98b8ada0dedf1956d59e634db95eaac1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
  "synstructure",
 ]
 
 [[package]]
 name = "asn1-rs-impl"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2777730b2039ac0f95f093556e61b6d26cebed5393ca6f152717777cec3a42ed"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -46,12 +46,6 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
-
-[[package]]
-name = "bumpalo"
-version = "3.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
 
 [[package]]
 name = "cc"
@@ -76,9 +70,9 @@ checksum = "7e962a19be5cfc3f3bf6dd8f61eb50107f356ad6270fbb3ed41476571db78be5"
 
 [[package]]
 name = "der-parser"
-version = "8.2.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbd676fbbab537128ef0278adb5576cf363cff6aa22a7b24effe97347cfab61e"
+checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
 dependencies = [
  "asn1-rs",
  "displaydoc",
@@ -96,7 +90,7 @@ checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn",
 ]
 
 [[package]]
@@ -131,15 +125,6 @@ name = "itoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
-
-[[package]]
-name = "js-sys"
-version = "0.3.64"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
-dependencies = [
- "wasm-bindgen",
-]
 
 [[package]]
 name = "lazy_static"
@@ -213,18 +198,12 @@ dependencies = [
 
 [[package]]
 name = "oid-registry"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bedf36ffb6ba96c2eb7144ef6270557b52e54b20c0a8e1eb2ff99a6c6959bff"
+checksum = "1c958dd45046245b9c3c2547369bb634eb461670b2e7e0de552905801a648d1d"
 dependencies = [
  "asn1-rs",
 ]
-
-[[package]]
-name = "once_cell"
-version = "1.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "proc-macro2"
@@ -246,21 +225,6 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.16.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
-dependencies = [
- "cc",
- "libc",
- "once_cell",
- "spin 0.5.2",
- "untrusted 0.7.1",
- "web-sys",
- "winapi",
-]
-
-[[package]]
-name = "ring"
 version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
@@ -269,8 +233,8 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "libc",
- "spin 0.9.8",
- "untrusted 0.9.0",
+ "spin",
+ "untrusted",
  "windows-sys",
 ]
 
@@ -300,7 +264,7 @@ checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn",
 ]
 
 [[package]]
@@ -312,33 +276,16 @@ dependencies = [
  "ffi-support",
  "hex",
  "oid-registry",
- "ring 0.17.8",
+ "ring",
  "thiserror",
  "x509-parser",
 ]
 
 [[package]]
 name = "spin"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
-
-[[package]]
-name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
 
 [[package]]
 name = "syn"
@@ -353,14 +300,13 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.12.6"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
+checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
- "unicode-xid",
+ "syn",
 ]
 
 [[package]]
@@ -380,7 +326,7 @@ checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn",
 ]
 
 [[package]]
@@ -417,18 +363,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
-
-[[package]]
-name = "untrusted"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
-
-[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -439,92 +373,6 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
-
-[[package]]
-name = "wasm-bindgen"
-version = "0.2.87"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
-dependencies = [
- "cfg-if",
- "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.87"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
-dependencies = [
- "bumpalo",
- "log",
- "once_cell",
- "proc-macro2",
- "quote",
- "syn 2.0.48",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.87"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
-dependencies = [
- "quote",
- "wasm-bindgen-macro-support",
-]
-
-[[package]]
-name = "wasm-bindgen-macro-support"
-version = "0.2.87"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.48",
- "wasm-bindgen-backend",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-shared"
-version = "0.2.87"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
-
-[[package]]
-name = "web-sys"
-version = "0.3.64"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
@@ -594,9 +442,9 @@ checksum = "9e440c60457f84b0bee09208e62acc7ade264b38c4453f6312b8c9ab1613e73c"
 
 [[package]]
 name = "x509-parser"
-version = "0.15.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7069fba5b66b9193bd2c5d3d4ff12b839118f6bcbef5328efafafb5395cf63da"
+checksum = "fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69"
 dependencies = [
  "asn1-rs",
  "data-encoding",
@@ -604,7 +452,7 @@ dependencies = [
  "lazy_static",
  "nom",
  "oid-registry",
- "ring 0.16.20",
+ "ring",
  "rusticata-macros",
  "thiserror",
  "time",

--- a/signature/Cargo.toml
+++ b/signature/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "signature"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [dependencies]

--- a/signature/Cargo.toml
+++ b/signature/Cargo.toml
@@ -4,14 +4,14 @@ version = "0.2.0"
 edition = "2021"
 
 [dependencies]
-asn1-rs = { version = "0.5", features=["datetime"] }
-oid-registry = "0.6"
+asn1-rs = { version = "0.6.1", features=["datetime"] }
+oid-registry = "0.7"
 data-encoding = "2.5.0"
 ffi-support = "0.4.4"
 thiserror = "1.0.57"
 hex = "0.4"
 ring = "0.17.8"
-x509-parser = { version = "0.15.1", features = ["verify", "validate"] }
+x509-parser = { version = "0.16.0", features = ["verify", "validate"] }
 
 [lib]
 name = "signature"

--- a/signature/src/balrog.rs
+++ b/signature/src/balrog.rs
@@ -317,7 +317,9 @@ impl<'a> Balrog<'_> {
         )?)
     }
 
-    /* Wrapper function to verify everything at once. */
+    /* Wrapper function to verify the certificate chain, signer subject name,
+     * and content signature all at once.
+     */
     pub fn verify(
         &self,
         input: &[u8],

--- a/signature/src/balrog.rs
+++ b/signature/src/balrog.rs
@@ -98,9 +98,7 @@ impl<'a> Balrog<'_> {
             parsed.push(x509);
         }
 
-        Ok(Balrog {
-            chain: parsed,
-        })
+        Ok(Balrog { chain: parsed })
     }
 
     /* Ensure that the certificate chain is valid. */
@@ -331,7 +329,7 @@ impl<'a> Balrog<'_> {
         self.verify_chain(current_time)?;
         self.verify_leaf_hostname(leaf_subject)?;
         self.verify_content_signature(input, signature)?;
-    
+
         /* Success */
         Ok(())
     }
@@ -623,9 +621,7 @@ culpa qui officia deserunt mollit anim id est laborum.";
 
     #[test]
     fn test_everything_fails_without_init() {
-        let b = Balrog {
-            chain: Vec::new(),
-        };
+        let b = Balrog { chain: Vec::new() };
 
         let r = b.verify_chain(VALID_TIMESTAMP);
         assert_eq!(r, Err(BalrogError::CertificateNotFound));

--- a/signature/src/lib.rs
+++ b/signature/src/lib.rs
@@ -297,21 +297,23 @@ mod test {
             PROD_CERT_CHAIN.as_ptr(),
             PROD_CERT_CHAIN.len(),
             hash_result.as_mut_ptr(),
-            hash_result.len());
-        
+            hash_result.len(),
+        );
+
         assert!(r, "Root hash computation failed");
         assert_eq!(hash_result, expect.as_slice());
     }
 
     #[test]
     fn test_compute_root_hash_invalid_length() {
-        let mut hash_result = [0u8; digest::SHA256_OUTPUT_LEN-1];
+        let mut hash_result = [0u8; digest::SHA256_OUTPUT_LEN - 1];
 
         let r = compute_root_certificate_hash(
             PROD_CERT_CHAIN.as_ptr(),
             PROD_CERT_CHAIN.len(),
             hash_result.as_mut_ptr(),
-            hash_result.len());
+            hash_result.len(),
+        );
 
         assert!(!r, "Root hash computation failed to check buffer size");
     }

--- a/src/constants.h
+++ b/src/constants.h
@@ -238,9 +238,9 @@ constexpr const char* AUTOGRAPH_PROD_FINGERPRINTS =
 constexpr const char* BALROG_STAGE_HOSTNAME =
     "stage.balrog.nonprod.cloudops.mozgcp.net";
 constexpr const char* AUTOGRAPH_STAGE_FINGERPRINTS =
-    "c0f05d59b1fde25780854c32fae8faba8481c233b4c1d390cca5f2cea81930ee\n"   // cas-new 2024-03-12
-    "45c37f3a09a6d70e0fa321fb29753ba7998f1259b32772768f23ccdc24836798\n"   // cas-cur 2024-03-12
-    "3c01446abe9036cea9a09acaa3a520ac628f20a7ae32ce861cb2efb70fa0c745\n";  // test.addons.signing.root.ca 2021-02-11
+    "c0f05d59b1fde25780854c32fae8faba8481c233b4c1d390cca5f2cea81930ee\n"   // cas-new-2024-03-12
+    "45c37f3a09a6d70e0fa321fb29753ba7998f1259b32772768f23ccdc24836798\n"   // cas-cur-2024-03-12
+    "3c01446abe9036cea9a09acaa3a520ac628f20a7ae32ce861cb2efb70fa0c745\n";  // test.addons.signing.root.ca-2021-02-11
 
 PRODBETAEXPR(qint64, keyRegeneratorTimeSec, 604800, 300);
 

--- a/src/constants.h
+++ b/src/constants.h
@@ -232,15 +232,19 @@ PRODBETAEXPR(QString, captivePortalUrl, "http://%1/success.txt",
                                      "http://%1/success.txt"));
 
 constexpr const char* BALROG_PROD_HOSTNAME = "aus5.mozilla.org";
-constexpr const char* AUTOGRAPH_PROD_FINGERPRINTS =
-    "97e8ba9cf12fb3de53cc42a4e6577ed64df493c247b414fea036818d3823560e";
+constexpr const char* AUTOGRAPH_PROD_FINGERPRINTS[] = {
+    "97e8ba9cf12fb3de53cc42a4e6577ed64df493c247b414fea036818d3823560e",
+    nullptr  // list termination
+};
 
 constexpr const char* BALROG_STAGE_HOSTNAME =
     "stage.balrog.nonprod.cloudops.mozgcp.net";
-constexpr const char* AUTOGRAPH_STAGE_FINGERPRINTS =
-    "c0f05d59b1fde25780854c32fae8faba8481c233b4c1d390cca5f2cea81930ee\n"  // cas-new-2024-03-12
-    "45c37f3a09a6d70e0fa321fb29753ba7998f1259b32772768f23ccdc24836798\n"  // cas-cur-2024-03-12
-    "3c01446abe9036cea9a09acaa3a520ac628f20a7ae32ce861cb2efb70fa0c745\n";  // test.addons.signing.root.ca-2021-02-11
+constexpr const char* AUTOGRAPH_STAGE_FINGERPRINTS[] = {
+    "c0f05d59b1fde25780854c32fae8faba8481c233b4c1d390cca5f2cea81930ee",  // cas-new-2024-03-12
+    "45c37f3a09a6d70e0fa321fb29753ba7998f1259b32772768f23ccdc24836798",  // cas-cur-2024-03-12
+    "3c01446abe9036cea9a09acaa3a520ac628f20a7ae32ce861cb2efb70fa0c745",  // test.addons.signing.root.ca-2021-02-11
+    nullptr  // list termination
+};
 
 PRODBETAEXPR(qint64, keyRegeneratorTimeSec, 604800, 300);
 

--- a/src/constants.h
+++ b/src/constants.h
@@ -232,15 +232,15 @@ PRODBETAEXPR(QString, captivePortalUrl, "http://%1/success.txt",
                                      "http://%1/success.txt"));
 
 constexpr const char* BALROG_PROD_HOSTNAME = "aus5.mozilla.org";
-constexpr const char* AUTOGRAPH_ROOT_CERT_FINGERPRINT =
+constexpr const char* AUTOGRAPH_PROD_FINGERPRINTS =
     "97e8ba9cf12fb3de53cc42a4e6577ed64df493c247b414fea036818d3823560e";
 
 constexpr const char* BALROG_STAGE_HOSTNAME =
     "stage.balrog.nonprod.cloudops.mozgcp.net";
-constexpr const char* AUTOGRAPH_STAGE_CURRENT_FINGERPRINT =
-    "45c37f3a09a6d70e0fa321fb29753ba7998f1259b32772768f23ccdc24836798";
-constexpr const char* AUTOGRAPH_STAGE_NEXT_FINGERPRINT =
-    "c0f05d59b1fde25780854c32fae8faba8481c233b4c1d390cca5f2cea81930ee";
+constexpr const char* AUTOGRAPH_STAGE_FINGERPRINTS =
+    "c0f05d59b1fde25780854c32fae8faba8481c233b4c1d390cca5f2cea81930ee\n"   // cas-new 2024-03-12
+    "45c37f3a09a6d70e0fa321fb29753ba7998f1259b32772768f23ccdc24836798\n"   // cas-cur 2024-03-12
+    "3c01446abe9036cea9a09acaa3a520ac628f20a7ae32ce861cb2efb70fa0c745\n";  // test.addons.signing.root.ca 2021-02-11
 
 PRODBETAEXPR(qint64, keyRegeneratorTimeSec, 604800, 300);
 

--- a/src/constants.h
+++ b/src/constants.h
@@ -240,9 +240,12 @@ constexpr const char* AUTOGRAPH_PROD_FINGERPRINTS[] = {
 constexpr const char* BALROG_STAGE_HOSTNAME =
     "stage.balrog.nonprod.cloudops.mozgcp.net";
 constexpr const char* AUTOGRAPH_STAGE_FINGERPRINTS[] = {
-    "c0f05d59b1fde25780854c32fae8faba8481c233b4c1d390cca5f2cea81930ee",  // cas-new-2024-03-12
-    "45c37f3a09a6d70e0fa321fb29753ba7998f1259b32772768f23ccdc24836798",  // cas-cur-2024-03-12
-    "3c01446abe9036cea9a09acaa3a520ac628f20a7ae32ce861cb2efb70fa0c745",  // test.addons.signing.root.ca-2021-02-11
+    // cas-new-2024-03-12
+    "c0f05d59b1fde25780854c32fae8faba8481c233b4c1d390cca5f2cea81930ee",
+    // cas-cur-2024-03-12
+    "45c37f3a09a6d70e0fa321fb29753ba7998f1259b32772768f23ccdc24836798",
+    // test.addons.signing.root.ca-2021-02-11
+    "3c01446abe9036cea9a09acaa3a520ac628f20a7ae32ce861cb2efb70fa0c745",
     nullptr  // list termination
 };
 

--- a/src/constants.h
+++ b/src/constants.h
@@ -231,17 +231,12 @@ PRODBETAEXPR(QString, captivePortalUrl, "http://%1/success.txt",
              Constants::envOrDefault("MZ_CAPTIVE_PORTAL_URL",
                                      "http://%1/success.txt"));
 
-PRODBETAEXPR(
-    const char*, balrogUrl,
-    "https://aus5.mozilla.org/json/1/FirefoxVPN/%1/%2/release/update.json",
-    "https://aus5.mozilla.org/json/1/FirefoxVPN/%1/%2/release-cdntest/"
-    "update.json");
+constexpr const char* BALROG_PROD_HOSTNAME = "aus5.mozilla.org";
 constexpr const char* AUTOGRAPH_ROOT_CERT_FINGERPRINT =
     "97e8ba9cf12fb3de53cc42a4e6577ed64df493c247b414fea036818d3823560e";
 
-constexpr const char* BALROG_STAGE_URL =
-    "https://stage.balrog.nonprod.cloudops.mozgcp.net/json/1/FirefoxVPN/%1/%2/"
-    "release-cdntest/update.json";
+constexpr const char* BALROG_STAGE_HOSTNAME =
+    "stage.balrog.nonprod.cloudops.mozgcp.net";
 constexpr const char* AUTOGRAPH_STAGE_CURRENT_FINGERPRINT =
     "45c37f3a09a6d70e0fa321fb29753ba7998f1259b32772768f23ccdc24836798";
 constexpr const char* AUTOGRAPH_STAGE_NEXT_FINGERPRINT =

--- a/src/constants.h
+++ b/src/constants.h
@@ -239,6 +239,14 @@ PRODBETAEXPR(
 constexpr const char* AUTOGRAPH_ROOT_CERT_FINGERPRINT =
     "97e8ba9cf12fb3de53cc42a4e6577ed64df493c247b414fea036818d3823560e";
 
+constexpr const char* BALROG_STAGE_URL =
+    "https://stage.balrog.nonprod.cloudops.mozgcp.net/json/1/FirefoxVPN/%1/%2/"
+    "release-cdntest/update.json";
+constexpr const char* AUTOGRAPH_STAGE_CURRENT_FINGERPRINT =
+    "45c37f3a09a6d70e0fa321fb29753ba7998f1259b32772768f23ccdc24836798";
+constexpr const char* AUTOGRAPH_STAGE_NEXT_FINGERPRINT =
+    "c0f05d59b1fde25780854c32fae8faba8481c233b4c1d390cca5f2cea81930ee";
+
 PRODBETAEXPR(qint64, keyRegeneratorTimeSec, 604800, 300);
 
 PRODBETAEXPR(QString, upgradeToAnnualUrl,

--- a/src/constants.h
+++ b/src/constants.h
@@ -238,8 +238,8 @@ constexpr const char* AUTOGRAPH_PROD_FINGERPRINTS =
 constexpr const char* BALROG_STAGE_HOSTNAME =
     "stage.balrog.nonprod.cloudops.mozgcp.net";
 constexpr const char* AUTOGRAPH_STAGE_FINGERPRINTS =
-    "c0f05d59b1fde25780854c32fae8faba8481c233b4c1d390cca5f2cea81930ee\n"   // cas-new-2024-03-12
-    "45c37f3a09a6d70e0fa321fb29753ba7998f1259b32772768f23ccdc24836798\n"   // cas-cur-2024-03-12
+    "c0f05d59b1fde25780854c32fae8faba8481c233b4c1d390cca5f2cea81930ee\n"  // cas-new-2024-03-12
+    "45c37f3a09a6d70e0fa321fb29753ba7998f1259b32772768f23ccdc24836798\n"  // cas-cur-2024-03-12
     "3c01446abe9036cea9a09acaa3a520ac628f20a7ae32ce861cb2efb70fa0c745\n";  // test.addons.signing.root.ca-2021-02-11
 
 PRODBETAEXPR(qint64, keyRegeneratorTimeSec, 604800, 300);

--- a/src/feature/featurelist.h
+++ b/src/feature/featurelist.h
@@ -202,6 +202,13 @@ FEATURE(startOnBoot,            // Feature ID
         QStringList(),          // feature dependencies
         FeatureCallback_startOnBoot)
 
+FEATURE(stagingUpdateServer,        // Feature ID
+        "Staging Update Server",    // Feature name
+        FeatureCallback_hasBalrog,  // Can be flipped on
+        FeatureCallback_false,      // Can be flipped off
+        QStringList(),              // feature dependencies
+        FeatureCallback_false)
+
 FEATURE(subscriptionManagement,     // Feature ID
         "Subscription management",  // Feature name
         FeatureCallback_true,       // Can be flipped on

--- a/src/feature/featurelistcallback.h
+++ b/src/feature/featurelistcallback.h
@@ -174,4 +174,12 @@ bool FeatureCallback_webPurchase() {
 #endif
 }
 
+bool FeatureCallback_hasBalrog() {
+#if defined(MVPN_BALROG)
+  return true;
+#else
+  return false;
+#endif
+}
+
 #endif  // FEATURELISTCALLBACK_H

--- a/src/update/balrog.cpp
+++ b/src/update/balrog.cpp
@@ -14,6 +14,7 @@
 
 #include "constants.h"
 #include "errorhandler.h"
+#include "feature/feature.h"
 #include "glean/generated/metrics.h"
 #include "leakdetector.h"
 #include "logger.h"
@@ -79,8 +80,7 @@ void Balrog::start(Task* task) {
             ._state = QVariant::fromValue(UpdateProcessStarted).toString()});
   }
 
-  QString url =
-      QString(Constants::balrogUrl()).arg(appVersion()).arg(userAgent());
+  QString url = balrogUrl();
   logger.debug() << "URL:" << url;
 
   NetworkRequest* request = new NetworkRequest(task, 200);
@@ -460,4 +460,15 @@ void Balrog::propagateError(NetworkRequest* request,
   }
 
   REPORTNETWORKERROR(error, m_errorPropagationPolicy, "balrog");
+}
+
+//static
+QString Balrog::balrogUrl() {
+  const QString version = appVersion();
+  const QString agent = userAgent();
+  if (Feature::get(Feature::Feature_stagingUpdateServer)->isSupported()) {
+    return QString(Constants::BALROG_STAGE_URL).arg(version).arg(agent);
+  } else {
+    return QString(Constants::balrogUrl()).arg(version).arg(agent);
+  }
 }

--- a/src/update/balrog.cpp
+++ b/src/update/balrog.cpp
@@ -510,9 +510,16 @@ QString Balrog::balrogUrl() {
 
 // static
 QStringList Balrog::rootCertHashes() {
+  QStringList result;
   if (Feature::get(Feature::Feature_stagingUpdateServer)->isSupported()) {
-    return QString(Constants::AUTOGRAPH_STAGE_FINGERPRINTS).split('\n');
+    for (int i = 0; Constants::AUTOGRAPH_STAGE_FINGERPRINTS[i] != nullptr; i++) {
+      result.append(Constants::AUTOGRAPH_STAGE_FINGERPRINTS[i]);
+    }
   } else {
-    return QString(Constants::AUTOGRAPH_PROD_FINGERPRINTS).split('\n');
+    for (int i = 0; Constants::AUTOGRAPH_PROD_FINGERPRINTS[i] != nullptr; i++) {
+      result.append(Constants::AUTOGRAPH_PROD_FINGERPRINTS[i]);
+    }
   }
+
+  return result;
 }

--- a/src/update/balrog.cpp
+++ b/src/update/balrog.cpp
@@ -512,7 +512,8 @@ QString Balrog::balrogUrl() {
 QStringList Balrog::rootCertHashes() {
   QStringList result;
   if (Feature::get(Feature::Feature_stagingUpdateServer)->isSupported()) {
-    for (int i = 0; Constants::AUTOGRAPH_STAGE_FINGERPRINTS[i] != nullptr; i++) {
+    for (int i = 0; Constants::AUTOGRAPH_STAGE_FINGERPRINTS[i] != nullptr;
+         i++) {
       result.append(Constants::AUTOGRAPH_STAGE_FINGERPRINTS[i]);
     }
   } else {

--- a/src/update/balrog.cpp
+++ b/src/update/balrog.cpp
@@ -464,11 +464,22 @@ void Balrog::propagateError(NetworkRequest* request,
 
 //static
 QString Balrog::balrogUrl() {
-  const QString version = appVersion();
-  const QString agent = userAgent();
+  const QString product = "FirefoxVPN";
+  QString hostname = Constants::BALROG_PROD_HOSTNAME;
+  QString channel = "release";
+
   if (Feature::get(Feature::Feature_stagingUpdateServer)->isSupported()) {
-    return QString(Constants::BALROG_STAGE_URL).arg(version).arg(agent);
-  } else {
-    return QString(Constants::balrogUrl()).arg(version).arg(agent);
+    hostname = Constants::BALROG_STAGE_HOSTNAME;
+    channel = "release-cdntest";
+  } else if (!Constants::inProduction()) {
+    channel = "release-cdntest";
   }
+
+  QStringList path =
+      {"json", "1", product, appVersion(), userAgent(), channel, "update.json"};
+  QUrl url;
+  url.setScheme("https");
+  url.setHost(hostname);
+  url.setPath(QString("/") + path.join("/"));
+  return url.toString();
 }

--- a/src/update/balrog.cpp
+++ b/src/update/balrog.cpp
@@ -486,7 +486,7 @@ void Balrog::propagateError(NetworkRequest* request,
   REPORTNETWORKERROR(error, m_errorPropagationPolicy, "balrog");
 }
 
-//static
+// static
 QString Balrog::balrogUrl() {
   const QString product = "FirefoxVPN";
   QString hostname = Constants::BALROG_PROD_HOSTNAME;
@@ -499,8 +499,8 @@ QString Balrog::balrogUrl() {
     channel = "release-cdntest";
   }
 
-  QStringList path =
-      {"json", "1", product, appVersion(), userAgent(), channel, "update.json"};
+  QStringList path = {"json",      "1",     product,      appVersion(),
+                      userAgent(), channel, "update.json"};
   QUrl url;
   url.setScheme("https");
   url.setHost(hostname);

--- a/src/update/balrog.h
+++ b/src/update/balrog.h
@@ -44,6 +44,7 @@ class Balrog final : public Updater {
                       QNetworkReply::NetworkError error);
 
  private:
+  static QString balrogUrl();
   TemporaryDir m_tmpDir;
   bool m_downloadAndInstall;
   ErrorHandler::ErrorPropagationPolicy m_errorPropagationPolicy =

--- a/src/update/balrog.h
+++ b/src/update/balrog.h
@@ -45,6 +45,7 @@ class Balrog final : public Updater {
 
  private:
   static QString balrogUrl();
+  static QStringList rootCertHashes();
   TemporaryDir m_tmpDir;
   bool m_downloadAndInstall;
   ErrorHandler::ErrorPropagationPolicy m_errorPropagationPolicy =


### PR DESCRIPTION
## Description
We need to do some testing against Balrog staging over the next few months. We used to use Balrog stage for QA testing, but this resulted in a lot of manual work for SRE, and our QA channel was moved to Balrog prod in #4741 in order to better automate our release and QA process. We are basically adding this back, but putting it behind a feature flag.

However, the content signing root CA for Balrog staging is up for renewal, so it is also important to implement a little more flexibility when handling the root hash pinning when switching to Balrog stage. In order to do this, we have refactored the API to the `signature` crate in order to migrate the root hash verification job into the Qt/C++ world.

## Reference
Github PR removing balrog stage: #4741
Bugzilla staging CA rotation: [1882192](https://bugzilla.mozilla.org/show_bug.cgi?id=1882192)
JIRA ticket: [VPN-6236](https://mozilla-hub.atlassian.net/browse/VPN-6236)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-6236]: https://mozilla-hub.atlassian.net/browse/VPN-6236?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ