### PR TITLE
Fix TC android builds

### DIFF
--- a/scripts/cmake/utilities.cmake
+++ b/scripts/cmake/utilities.cmake
@@ -478,3 +478,11 @@ function(mz_add_the_apple_stuff)
     )
 endfunction()
 
+# Creates an optional dependency between two CMake targets.
+# If both TARGET_A and TARGET_B exist, a dependency is established
+# where TARGET_A depends on TARGET_B.
+function(mz_optional_dependency TARGET_A TARGET_B)
+   if(TARGET ${TARGET_A} AND TARGET ${TARGET_B})
+      add_dependencies(${TARGET_A} ${TARGET_B})
+   endif()
+endfunction() 

--- a/src/cmake/sources.cmake
+++ b/src/cmake/sources.cmake
@@ -225,10 +225,6 @@ mz_add_clang_tidy(mozillavpn-sources)
 # we need to make sure those are up to date before we build. 
 # Those targets generate code we #include, therefore
 
-if(TARGET mozillavpn-sources_clang_tidy_report)
-    add_dependencies(mozillavpn-sources_clang_tidy_report
-        qtglean
-        sentry
-        translations
-    )
-endif()
+mz_optional_dependency(mozillavpn-sources_clang_tidy_report qtglean)
+mz_optional_dependency(mozillavpn-sources_clang_tidy_report sentry)
+mz_optional_dependency(mozillavpn-sources_clang_tidy_report translations)


### PR DESCRIPTION
## Description

in #9239 i added support for clang tidy, trying to not add dependencies if the clang_tidy target was not created. 
I did not consider that those can depend on targets that are not created for all plattforms i.e sentry is not built on 32bit android.
This caused all 32bit android builds to go bust on main, while the PR was green. 
 
given this, let's add a util that adds dependencies between 2 targets if they both exist, so it's a bit more clean :) 
