### PR TITLE
VPN-5865 - Move a few rules from ip rules to the firewall

### DIFF
--- a/linux/netfilter/netfilter.go
+++ b/linux/netfilter/netfilter.go
@@ -260,6 +260,22 @@ func (ctx *nftCtx) nftRestrictTraffic(ifname string) {
 				SetName:        ctx.addrset.Name,
 				SetID:          ctx.addrset.ID,
 			},
+		},
+	})
+
+	ctx.conn.AddRule(&nftables.Rule{
+		Table: ctx.table_inet,
+		Chain: ctx.input,
+		Exprs: []expr.Any{
+			&expr.Meta{
+				Key:      expr.MetaKeyMARK,
+				Register: 1,
+			},
+			&expr.Cmp{
+				Op:       expr.CmpOpEq,
+				Register: 1,
+				Data:     binaryutil.NativeEndian.PutUint32(ctx.fwmark),
+			},
 			&expr.Verdict{
 				Kind: expr.VerdictAccept,
 			},
@@ -341,6 +357,25 @@ func (ctx *nftCtx) nftRestrictTraffic(ifname string) {
 				SourceRegister: 1,
 				SetName:        ctx.addrset.Name,
 				SetID:          ctx.addrset.ID,
+			},
+			&expr.Verdict{
+				Kind: expr.VerdictAccept,
+			},
+		},
+	})
+
+	ctx.conn.AddRule(&nftables.Rule{
+		Table: ctx.table_inet,
+		Chain: ctx.output,
+		Exprs: []expr.Any{
+			&expr.Meta{
+				Key:      expr.MetaKeyMARK,
+				Register: 1,
+			},
+			&expr.Cmp{
+				Op:       expr.CmpOpEq,
+				Register: 1,
+				Data:     binaryutil.NativeEndian.PutUint32(ctx.fwmark),
 			},
 			&expr.Verdict{
 				Kind: expr.VerdictAccept,

--- a/linux/netfilter/netfilter.go
+++ b/linux/netfilter/netfilter.go
@@ -14,74 +14,74 @@ package main
 import "C"
 
 import (
-  "log"
-  "net"
-  "bytes"
-  "errors"
-  "unsafe"
+	"bytes"
+	"errors"
+	"log"
+	"net"
+	"unsafe"
 
-  "C"
+	"C"
 
-  "github.com/google/nftables"
-  "github.com/google/nftables/alignedbuff"
-  "github.com/google/nftables/binaryutil"
-  "github.com/google/nftables/expr"
-  "github.com/google/nftables/xt"
-  linux "golang.org/x/sys/unix"
+	"github.com/google/nftables"
+	"github.com/google/nftables/alignedbuff"
+	"github.com/google/nftables/binaryutil"
+	"github.com/google/nftables/expr"
+	"github.com/google/nftables/xt"
+	linux "golang.org/x/sys/unix"
 )
 
 type CLogger struct {
-  level C.int
-  function unsafe.Pointer
+	level    C.int
+	function unsafe.Pointer
 }
 
 func (l *CLogger) Write(p []byte) (int, error) {
-  if uintptr(l.function) == 0 {
-    return 0, errors.New("No logger initialized")
-  }
-  message := C.CString(string(p))
-  C.callLogger(l.function, l.level, message)
-  C.free(unsafe.Pointer(message))
-  return len(p), nil
+	if uintptr(l.function) == 0 {
+		return 0, errors.New("No logger initialized")
+	}
+	message := C.CString(string(p))
+	C.callLogger(l.function, l.level, message)
+	C.free(unsafe.Pointer(message))
+	return len(p), nil
 }
 
 //export NetfilterSetLogger
 func NetfilterSetLogger(loggerFn uintptr) {
-  log.SetOutput(&CLogger{
-    level: 0,
-    function: unsafe.Pointer(loggerFn),
-  })
-  log.SetPrefix("")
-  log.SetFlags(0)
+	log.SetOutput(&CLogger{
+		level:    0,
+		function: unsafe.Pointer(loggerFn),
+	})
+	log.SetPrefix("")
+	log.SetFlags(0)
 }
 
 type nftCtx struct {
-  table_inet  *nftables.Table
-  table_v6    *nftables.Table
-  mangle      *nftables.Chain
-  nat         *nftables.Chain
-  conntrack   *nftables.Chain
-  preroute    *nftables.Chain
-  preroute_v6 *nftables.Chain
-  addrset     *nftables.Set
-  fwmark      uint32
-  conn        nftables.Conn
+	table_inet  *nftables.Table
+	table_v6    *nftables.Table
+	mangle      *nftables.Chain
+	nat         *nftables.Chain
+	conntrack   *nftables.Chain
+	preroute    *nftables.Chain
+	preroute_v6 *nftables.Chain
+	addrset     *nftables.Set
+	fwmark      uint32
+	conn        nftables.Conn
 }
 
 var mozvpn_ctx = nftCtx{}
 
-func (ctx* nftCtx) nftCommit() int32 {
-  if err := ctx.conn.Flush(); err != nil {
-    log.Println("Netfiler commit failed:", err)
-    return -1
-  }
-  return 0
+func (ctx *nftCtx) nftCommit() int32 {
+	if err := ctx.conn.Flush(); err != nil {
+		log.Println("Netfiler commit failed:", err)
+		return -1
+	}
+	return 0
 }
 
 func nftIfname(n string) []byte {
-  b := make([]byte, 16)
-  copy(b, []byte(n+"\x00"))
-  return b
+	b := make([]byte, 16)
+	copy(b, []byte(n+"\x00"))
+	return b
 }
 
 // A Conntrack zone used for traffic excluded from the VPN tunnel.
@@ -89,519 +89,519 @@ func nftIfname(n string) []byte {
 // and non-zero.
 const ctzone_external = 0x9e4c
 
-func (ctx* nftCtx) nftIfup(ifname string) {
-  var immctzone = expr.Immediate{
-    Register:   1,
-    Data:       binaryutil.NativeEndian.PutUint32(ctzone_external),
-  }
-  var setctzone = expr.Ct{
-    Key:        expr.CtKeyZONE,
-    Register:   1,
-    SourceRegister: true,
-  }
+func (ctx *nftCtx) nftIfup(ifname string) {
+	var immctzone = expr.Immediate{
+		Register: 1,
+		Data:     binaryutil.NativeEndian.PutUint32(ctzone_external),
+	}
+	var setctzone = expr.Ct{
+		Key:            expr.CtKeyZONE,
+		Register:       1,
+		SourceRegister: true,
+	}
 
-  // Move all marked packets into their own conntrack zone
-  ctx.conn.AddRule(&nftables.Rule{
-    Table: ctx.table_inet,
-    Chain: ctx.conntrack,
-    Exprs: []expr.Any{
-      // Match marked packets
-      &expr.Meta{
-        Key:        expr.MetaKeyMARK,
-        Register:   1,
-      },
-      &expr.Cmp{
-        Op:         expr.CmpOpEq,
-        Register:   1,
-        Data:       binaryutil.NativeEndian.PutUint32(ctx.fwmark),
-      },
-      // Set the conntrack zone
-      &immctzone,
-      &setctzone,
-    },
-  })
+	// Move all marked packets into their own conntrack zone
+	ctx.conn.AddRule(&nftables.Rule{
+		Table: ctx.table_inet,
+		Chain: ctx.conntrack,
+		Exprs: []expr.Any{
+			// Match marked packets
+			&expr.Meta{
+				Key:      expr.MetaKeyMARK,
+				Register: 1,
+			},
+			&expr.Cmp{
+				Op:       expr.CmpOpEq,
+				Register: 1,
+				Data:     binaryutil.NativeEndian.PutUint32(ctx.fwmark),
+			},
+			// Set the conntrack zone
+			&immctzone,
+			&setctzone,
+		},
+	})
 
-  // Inbound packets from wireguard servers should be marked for RPF
-  // and moved into the external conntrack zone.
-  ctx.conn.AddRule(&nftables.Rule{
-    Table: ctx.table_inet,
-    Chain: ctx.preroute,
-    Exprs: []expr.Any{
-      // For now, we only support IPv4 in this check.
-      // TODO: Support IPv6.
-      &expr.Meta{
-        Key:            expr.MetaKeyPROTOCOL,
-        Register:       1,
-      },
-      &expr.Cmp{
-        Op:             expr.CmpOpEq,
-        Register:       1,
-        Data:           binaryutil.BigEndian.PutUint16(linux.ETH_P_IP),
-      },
-      // Match UDP packets
-      &expr.Meta{
-        Key:            expr.MetaKeyL4PROTO,
-        Register:       1,
-      },
-      &expr.Cmp{
-        Op:             expr.CmpOpEq,
-        Register:       1,
-	Data:           []byte{linux.IPPROTO_UDP},
-      },
-      // Lookup the IPv4 source address.
-      &expr.Payload{
-        DestRegister:   1,
-	Base:           expr.PayloadBaseNetworkHeader,
-        Offset:         uint32(12),
-        Len:            uint32(4),
-      },
-      &expr.Lookup{
-        SourceRegister: 1,
-        SetName:        ctx.addrset.Name,
-        SetID:          ctx.addrset.ID,
-      },
-      // Set the firewall mark.
-      &expr.Immediate{
-        Register:       1,
-        Data:           binaryutil.NativeEndian.PutUint32(ctx.fwmark),
-      },
-      &expr.Meta{
-        Key:            expr.MetaKeyMARK,
-        Register:       1,
-        SourceRegister: true,
-      },
-      // Set the conntrack zone.
-      &immctzone,
-      &setctzone,
-    },
-  })
+	// Inbound packets from wireguard servers should be marked for RPF
+	// and moved into the external conntrack zone.
+	ctx.conn.AddRule(&nftables.Rule{
+		Table: ctx.table_inet,
+		Chain: ctx.preroute,
+		Exprs: []expr.Any{
+			// For now, we only support IPv4 in this check.
+			// TODO: Support IPv6.
+			&expr.Meta{
+				Key:      expr.MetaKeyPROTOCOL,
+				Register: 1,
+			},
+			&expr.Cmp{
+				Op:       expr.CmpOpEq,
+				Register: 1,
+				Data:     binaryutil.BigEndian.PutUint16(linux.ETH_P_IP),
+			},
+			// Match UDP packets
+			&expr.Meta{
+				Key:      expr.MetaKeyL4PROTO,
+				Register: 1,
+			},
+			&expr.Cmp{
+				Op:       expr.CmpOpEq,
+				Register: 1,
+				Data:     []byte{linux.IPPROTO_UDP},
+			},
+			// Lookup the IPv4 source address.
+			&expr.Payload{
+				DestRegister: 1,
+				Base:         expr.PayloadBaseNetworkHeader,
+				Offset:       uint32(12),
+				Len:          uint32(4),
+			},
+			&expr.Lookup{
+				SourceRegister: 1,
+				SetName:        ctx.addrset.Name,
+				SetID:          ctx.addrset.ID,
+			},
+			// Set the firewall mark.
+			&expr.Immediate{
+				Register: 1,
+				Data:     binaryutil.NativeEndian.PutUint32(ctx.fwmark),
+			},
+			&expr.Meta{
+				Key:            expr.MetaKeyMARK,
+				Register:       1,
+				SourceRegister: true,
+			},
+			// Set the conntrack zone.
+			&immctzone,
+			&setctzone,
+		},
+	})
 }
 
 func nftXtCgroupMatch(cgroup string) expr.Match {
-  // struct xt_cgroup_info_v2 only supports a maximum path of 512 bytes
-  if len(cgroup) >= 512 {
-    cgroup = cgroup[:511]
-  }
+	// struct xt_cgroup_info_v2 only supports a maximum path of 512 bytes
+	if len(cgroup) >= 512 {
+		cgroup = cgroup[:511]
+	}
 
-  // Build struct xt_cgroup_info_v2 to match the cgroup path.
-  xtcgroup := alignedbuff.New()
-  xtcgroup.PutUint8(1) // has_path
-  xtcgroup.PutUint8(0) // has_classid
-  xtcgroup.PutUint8(0) // invert_path
-  xtcgroup.PutUint8(0) // invert_classid
-  xtcgroup.PutBytesAligned32([]byte(cgroup + "\x00"), 512) // Cgroup path.
-  xtcgroup.PutUint64(0) // kernel padding
-  var xtinfo = xt.Unknown(xtcgroup.Data())
+	// Build struct xt_cgroup_info_v2 to match the cgroup path.
+	xtcgroup := alignedbuff.New()
+	xtcgroup.PutUint8(1)                                   // has_path
+	xtcgroup.PutUint8(0)                                   // has_classid
+	xtcgroup.PutUint8(0)                                   // invert_path
+	xtcgroup.PutUint8(0)                                   // invert_classid
+	xtcgroup.PutBytesAligned32([]byte(cgroup+"\x00"), 512) // Cgroup path.
+	xtcgroup.PutUint64(0)                                  // kernel padding
+	var xtinfo = xt.Unknown(xtcgroup.Data())
 
-  return expr.Match{
-    Name:     "cgroup",
-    Rev:      2,
-    Info:     &xtinfo,
-  }
+	return expr.Match{
+		Name: "cgroup",
+		Rev:  2,
+		Info: &xtinfo,
+	}
 }
 
-func (ctx* nftCtx) nftMarkCgroup2xt(cgroup string) {
-  xtmatch := nftXtCgroupMatch(cgroup)
+func (ctx *nftCtx) nftMarkCgroup2xt(cgroup string) {
+	xtmatch := nftXtCgroupMatch(cgroup)
 
-  ctx.conn.AddRule(&nftables.Rule{
-    Table: ctx.table_inet,
-    Chain: ctx.mangle,
-    Exprs: []expr.Any{
-      // Match the cgroup v2 path for originated packets.
-      &xtmatch,
-      // Match packets that have not already been marked
-      &expr.Meta{
-        Key:        expr.MetaKeyMARK,
-        Register:   1,
-      },
-      &expr.Cmp{
-        Op:         expr.CmpOpEq,
-        Register:   1,
-        Data:       binaryutil.NativeEndian.PutUint32(0),
-      },
-      // Do not match packets sent to localhost interfaces
-      &expr.Meta{
-        Key:      expr.MetaKeyOIFTYPE,
-        Register: 1,
-      },
-      &expr.Cmp{
-        Op:       expr.CmpOpNeq,
-        Register: 1,
-        Data:     binaryutil.NativeEndian.PutUint16(linux.ARPHRD_LOOPBACK),
-      },
-      // Set the firewall mark to request NAT
-      &expr.Immediate{
-        Register:   1,
-        Data:       binaryutil.NativeEndian.PutUint32(ctx.fwmark),
-      },
-      &expr.Meta{
-        Key:        expr.MetaKeyMARK,
-        Register:   1,
-        SourceRegister: true,
-      },
-    },
-  })
+	ctx.conn.AddRule(&nftables.Rule{
+		Table: ctx.table_inet,
+		Chain: ctx.mangle,
+		Exprs: []expr.Any{
+			// Match the cgroup v2 path for originated packets.
+			&xtmatch,
+			// Match packets that have not already been marked
+			&expr.Meta{
+				Key:      expr.MetaKeyMARK,
+				Register: 1,
+			},
+			&expr.Cmp{
+				Op:       expr.CmpOpEq,
+				Register: 1,
+				Data:     binaryutil.NativeEndian.PutUint32(0),
+			},
+			// Do not match packets sent to localhost interfaces
+			&expr.Meta{
+				Key:      expr.MetaKeyOIFTYPE,
+				Register: 1,
+			},
+			&expr.Cmp{
+				Op:       expr.CmpOpNeq,
+				Register: 1,
+				Data:     binaryutil.NativeEndian.PutUint16(linux.ARPHRD_LOOPBACK),
+			},
+			// Set the firewall mark to request NAT
+			&expr.Immediate{
+				Register: 1,
+				Data:     binaryutil.NativeEndian.PutUint32(ctx.fwmark),
+			},
+			&expr.Meta{
+				Key:            expr.MetaKeyMARK,
+				Register:       1,
+				SourceRegister: true,
+			},
+		},
+	})
 
-  // Masquerade outgoing packets from split tunnelling to trigger rerouting.
-  ctx.conn.AddRule(&nftables.Rule{
-    Table: ctx.table_inet,
-    Chain: ctx.nat,
-    Exprs: []expr.Any{
-      &xtmatch,
-      // Match marked packets
-      &expr.Meta{
-        Key:        expr.MetaKeyMARK,
-        Register:   1,
-      },
-      &expr.Cmp{
-        Op:         expr.CmpOpEq,
-        Register:   1,
-        Data:       binaryutil.NativeEndian.PutUint32(ctx.fwmark),
-      },
-      // Masquerade
-      &expr.Masq{},
-    },
-  })
+	// Masquerade outgoing packets from split tunnelling to trigger rerouting.
+	ctx.conn.AddRule(&nftables.Rule{
+		Table: ctx.table_inet,
+		Chain: ctx.nat,
+		Exprs: []expr.Any{
+			&xtmatch,
+			// Match marked packets
+			&expr.Meta{
+				Key:      expr.MetaKeyMARK,
+				Register: 1,
+			},
+			&expr.Cmp{
+				Op:       expr.CmpOpEq,
+				Register: 1,
+				Data:     binaryutil.NativeEndian.PutUint32(ctx.fwmark),
+			},
+			// Masquerade
+			&expr.Masq{},
+		},
+	})
 }
 
-func (ctx* nftCtx) nftDelCgroup2xt(rules []*nftables.Rule, xtmatch *expr.Match) {
-  cgdata, _ := xt.Marshal(0, xtmatch.Rev, xtmatch.Info)
+func (ctx *nftCtx) nftDelCgroup2xt(rules []*nftables.Rule, xtmatch *expr.Match) {
+	cgdata, _ := xt.Marshal(0, xtmatch.Rev, xtmatch.Info)
 
-  for _, r := range rules {
-    rr := r.Exprs[0].(*expr.Match)
-    if rr.Name != xtmatch.Name || rr.Rev != xtmatch.Rev {
-      continue
-    }
-    rrdata, err := xt.Marshal(0, rr.Rev, rr.Info)
-    if err != nil {
-      continue
-    }
-    if bytes.Compare(rrdata, cgdata) == 0 {
-      log.Println("Deleting", r.Chain.Name, "rule handle", r.Handle)
-      ctx.conn.DelRule(r);
-    }
-  }
+	for _, r := range rules {
+		rr := r.Exprs[0].(*expr.Match)
+		if rr.Name != xtmatch.Name || rr.Rev != xtmatch.Rev {
+			continue
+		}
+		rrdata, err := xt.Marshal(0, rr.Rev, rr.Info)
+		if err != nil {
+			continue
+		}
+		if bytes.Compare(rrdata, cgdata) == 0 {
+			log.Println("Deleting", r.Chain.Name, "rule handle", r.Handle)
+			ctx.conn.DelRule(r)
+		}
+	}
 }
 
-func (ctx* nftCtx) nftMarkCgroup1netcls(cgroup uint32) {
-  // Match packets originating from the cgroup/net_cls
-  var loadcgroup = expr.Meta{
-    Key:      expr.MetaKeyCGROUP,
-    Register: 1,
-  }
-  var matchcgroup = expr.Cmp{
-    Op:       expr.CmpOpEq,
-    Register: 1,
-    Data:     binaryutil.NativeEndian.PutUint32(cgroup),
-  }
+func (ctx *nftCtx) nftMarkCgroup1netcls(cgroup uint32) {
+	// Match packets originating from the cgroup/net_cls
+	var loadcgroup = expr.Meta{
+		Key:      expr.MetaKeyCGROUP,
+		Register: 1,
+	}
+	var matchcgroup = expr.Cmp{
+		Op:       expr.CmpOpEq,
+		Register: 1,
+		Data:     binaryutil.NativeEndian.PutUint32(cgroup),
+	}
 
-  ctx.conn.AddRule(&nftables.Rule{
-    Table: ctx.table_inet,
-    Chain: ctx.mangle,
-    Exprs: []expr.Any{
-      &loadcgroup,
-      &matchcgroup,
-      // Do not match packets sent to localhost interfaces
-      &expr.Meta{
-        Key:      expr.MetaKeyOIFTYPE,
-        Register: 1,
-      },
-      &expr.Cmp{
-        Op:       expr.CmpOpNeq,
-        Register: 1,
-        Data:     binaryutil.NativeEndian.PutUint16(linux.ARPHRD_LOOPBACK),
-      },
-      // Set the firewall mark
-      &expr.Immediate{
-        Register:   1,
-        Data:       binaryutil.NativeEndian.PutUint32(ctx.fwmark),
-      },
-      &expr.Meta{
-        Key:        expr.MetaKeyMARK,
-        Register:   1,
-        SourceRegister: true,
-      },
-    },
-  })
+	ctx.conn.AddRule(&nftables.Rule{
+		Table: ctx.table_inet,
+		Chain: ctx.mangle,
+		Exprs: []expr.Any{
+			&loadcgroup,
+			&matchcgroup,
+			// Do not match packets sent to localhost interfaces
+			&expr.Meta{
+				Key:      expr.MetaKeyOIFTYPE,
+				Register: 1,
+			},
+			&expr.Cmp{
+				Op:       expr.CmpOpNeq,
+				Register: 1,
+				Data:     binaryutil.NativeEndian.PutUint16(linux.ARPHRD_LOOPBACK),
+			},
+			// Set the firewall mark
+			&expr.Immediate{
+				Register: 1,
+				Data:     binaryutil.NativeEndian.PutUint32(ctx.fwmark),
+			},
+			&expr.Meta{
+				Key:            expr.MetaKeyMARK,
+				Register:       1,
+				SourceRegister: true,
+			},
+		},
+	})
 
-  // Masquerade outgoing packets from split tunnelling to trigger rerouting.
-  ctx.conn.AddRule(&nftables.Rule{
-    Table: ctx.table_inet,
-    Chain: ctx.nat,
-    Exprs: []expr.Any{
-      &loadcgroup,
-      &matchcgroup,
-      // Match marked packets
-      &expr.Meta{
-        Key:        expr.MetaKeyMARK,
-        Register:   1,
-      },
-      &expr.Cmp{
-        Op:         expr.CmpOpEq,
-        Register:   1,
-        Data:       binaryutil.NativeEndian.PutUint32(ctx.fwmark),
-      },
-      // Masquerade
-      &expr.Masq{},
-    },
-  })
+	// Masquerade outgoing packets from split tunnelling to trigger rerouting.
+	ctx.conn.AddRule(&nftables.Rule{
+		Table: ctx.table_inet,
+		Chain: ctx.nat,
+		Exprs: []expr.Any{
+			&loadcgroup,
+			&matchcgroup,
+			// Match marked packets
+			&expr.Meta{
+				Key:      expr.MetaKeyMARK,
+				Register: 1,
+			},
+			&expr.Cmp{
+				Op:       expr.CmpOpEq,
+				Register: 1,
+				Data:     binaryutil.NativeEndian.PutUint32(ctx.fwmark),
+			},
+			// Masquerade
+			&expr.Masq{},
+		},
+	})
 }
 
-func (ctx* nftCtx) nftBlockCgroup(cgroup uint32) {
-  ctx.conn.AddRule(&nftables.Rule{
-    Table: ctx.table_inet,
-    Chain: ctx.mangle,
-    Exprs: []expr.Any{
-      // Match packets from the cgroup
-      &expr.Meta{
-        Key:        expr.MetaKeyCGROUP,
-        Register:   1,
-      },
-      &expr.Cmp{
-        Op:         expr.CmpOpEq,
-        Register:   1,
-        Data:       binaryutil.NativeEndian.PutUint32(cgroup),
-      },
-      // Do not match packets sent to localhost interfaces
-      &expr.Meta{
-        Key:      expr.MetaKeyOIFTYPE,
-        Register: 1,
-      },
-      &expr.Cmp{
-        Op:       expr.CmpOpNeq,
-        Register: 1,
-        Data:     binaryutil.NativeEndian.PutUint16(linux.ARPHRD_LOOPBACK),
-      },
-      // Drop the packets
-      &expr.Verdict{
-        Kind:       expr.VerdictDrop,
-      },
-    },
-  })
+func (ctx *nftCtx) nftBlockCgroup(cgroup uint32) {
+	ctx.conn.AddRule(&nftables.Rule{
+		Table: ctx.table_inet,
+		Chain: ctx.mangle,
+		Exprs: []expr.Any{
+			// Match packets from the cgroup
+			&expr.Meta{
+				Key:      expr.MetaKeyCGROUP,
+				Register: 1,
+			},
+			&expr.Cmp{
+				Op:       expr.CmpOpEq,
+				Register: 1,
+				Data:     binaryutil.NativeEndian.PutUint32(cgroup),
+			},
+			// Do not match packets sent to localhost interfaces
+			&expr.Meta{
+				Key:      expr.MetaKeyOIFTYPE,
+				Register: 1,
+			},
+			&expr.Cmp{
+				Op:       expr.CmpOpNeq,
+				Register: 1,
+				Data:     binaryutil.NativeEndian.PutUint16(linux.ARPHRD_LOOPBACK),
+			},
+			// Drop the packets
+			&expr.Verdict{
+				Kind: expr.VerdictDrop,
+			},
+		},
+	})
 }
 
 //export NetfilterCreateTables
 func NetfilterCreateTables() int32 {
-  mozvpn_ctx.table_inet = mozvpn_ctx.conn.AddTable(&nftables.Table{
-    Family: nftables.TableFamilyINet,
-    Name: "mozvpn-inet",
-  })
-  mozvpn_ctx.mangle = mozvpn_ctx.conn.AddChain(&nftables.Chain{
-    Name:       "mozvpn-mangle",
-    Table:      mozvpn_ctx.table_inet,
-    Type:       nftables.ChainTypeRoute,
-    Hooknum:    nftables.ChainHookOutput,
-    Priority:   nftables.ChainPriorityMangle,
-  })
-  mozvpn_ctx.nat = mozvpn_ctx.conn.AddChain(&nftables.Chain{
-    Name:       "mozvpn-nat",
-    Table:      mozvpn_ctx.table_inet,
-    Type:       nftables.ChainTypeNAT,
-    Hooknum:    nftables.ChainHookPostrouting,
-    Priority:   nftables.ChainPriorityNATSource,
-  })
-  mozvpn_ctx.conntrack = mozvpn_ctx.conn.AddChain(&nftables.Chain{
-    Name:       "mozvpn-conntrack",
-    Table:      mozvpn_ctx.table_inet,
-    Type:       nftables.ChainTypeRoute,
-    Hooknum:    nftables.ChainHookOutput,
-    Priority:   nftables.ChainPriorityConntrack-1,
-  })
-  mozvpn_ctx.preroute = mozvpn_ctx.conn.AddChain(&nftables.Chain{
-    Name:       "mozvpn-preroute",
-    Table:      mozvpn_ctx.table_inet,
-    Type:       nftables.ChainTypeFilter,
-    Hooknum:    nftables.ChainHookPrerouting,
-    Priority:   nftables.ChainPriorityRaw,
-  })
+	mozvpn_ctx.table_inet = mozvpn_ctx.conn.AddTable(&nftables.Table{
+		Family: nftables.TableFamilyINet,
+		Name:   "mozvpn-inet",
+	})
+	mozvpn_ctx.mangle = mozvpn_ctx.conn.AddChain(&nftables.Chain{
+		Name:     "mozvpn-mangle",
+		Table:    mozvpn_ctx.table_inet,
+		Type:     nftables.ChainTypeRoute,
+		Hooknum:  nftables.ChainHookOutput,
+		Priority: nftables.ChainPriorityMangle,
+	})
+	mozvpn_ctx.nat = mozvpn_ctx.conn.AddChain(&nftables.Chain{
+		Name:     "mozvpn-nat",
+		Table:    mozvpn_ctx.table_inet,
+		Type:     nftables.ChainTypeNAT,
+		Hooknum:  nftables.ChainHookPostrouting,
+		Priority: nftables.ChainPriorityNATSource,
+	})
+	mozvpn_ctx.conntrack = mozvpn_ctx.conn.AddChain(&nftables.Chain{
+		Name:     "mozvpn-conntrack",
+		Table:    mozvpn_ctx.table_inet,
+		Type:     nftables.ChainTypeRoute,
+		Hooknum:  nftables.ChainHookOutput,
+		Priority: nftables.ChainPriorityConntrack - 1,
+	})
+	mozvpn_ctx.preroute = mozvpn_ctx.conn.AddChain(&nftables.Chain{
+		Name:     "mozvpn-preroute",
+		Table:    mozvpn_ctx.table_inet,
+		Type:     nftables.ChainTypeFilter,
+		Hooknum:  nftables.ChainHookPrerouting,
+		Priority: nftables.ChainPriorityRaw,
+	})
 
-  mozvpn_ctx.table_v6 = mozvpn_ctx.conn.AddTable(&nftables.Table{
-    Family: nftables.TableFamilyIPv6,
-    Name: "mozvpn-v6",
-  })
-  mozvpn_ctx.preroute_v6 = mozvpn_ctx.conn.AddChain(&nftables.Chain{
-    Name:       "mozvpn-preroute-v6",
-    Table:      mozvpn_ctx.table_v6,
-    Type:       nftables.ChainTypeFilter,
-    Hooknum:    nftables.ChainHookPrerouting,
-    Priority:   nftables.ChainPriorityRaw,
-  })
+	mozvpn_ctx.table_v6 = mozvpn_ctx.conn.AddTable(&nftables.Table{
+		Family: nftables.TableFamilyIPv6,
+		Name:   "mozvpn-v6",
+	})
+	mozvpn_ctx.preroute_v6 = mozvpn_ctx.conn.AddChain(&nftables.Chain{
+		Name:     "mozvpn-preroute-v6",
+		Table:    mozvpn_ctx.table_v6,
+		Type:     nftables.ChainTypeFilter,
+		Hooknum:  nftables.ChainHookPrerouting,
+		Priority: nftables.ChainPriorityRaw,
+	})
 
-  mozvpn_ctx.addrset = &nftables.Set{
-    Table:      mozvpn_ctx.table_inet,
-    Name:       "mozvpn-addrset",
-    KeyType:    nftables.TypeIPAddr,
-  }
-  mozvpn_ctx.conn.AddSet(mozvpn_ctx.addrset, nil)
+	mozvpn_ctx.addrset = &nftables.Set{
+		Table:   mozvpn_ctx.table_inet,
+		Name:    "mozvpn-addrset",
+		KeyType: nftables.TypeIPAddr,
+	}
+	mozvpn_ctx.conn.AddSet(mozvpn_ctx.addrset, nil)
 
-  log.Println("Creating netfilter tables")
-  return mozvpn_ctx.nftCommit()
+	log.Println("Creating netfilter tables")
+	return mozvpn_ctx.nftCommit()
 }
 
 //export NetfilterRemoveTables
 func NetfilterRemoveTables() int32 {
-  mozvpn_ctx.conn.DelTable(mozvpn_ctx.table_inet)
-  mozvpn_ctx.conn.DelTable(mozvpn_ctx.table_v6)
+	mozvpn_ctx.conn.DelTable(mozvpn_ctx.table_inet)
+	mozvpn_ctx.conn.DelTable(mozvpn_ctx.table_v6)
 
-  log.Println("Removing netfilter tables")
-  return mozvpn_ctx.nftCommit()
+	log.Println("Removing netfilter tables")
+	return mozvpn_ctx.nftCommit()
 }
 
 //export NetfilterClearTables
 func NetfilterClearTables() int32 {
-  mozvpn_ctx.fwmark = 0
-  mozvpn_ctx.conn.FlushChain(mozvpn_ctx.mangle)
-  mozvpn_ctx.conn.FlushChain(mozvpn_ctx.nat)
-  mozvpn_ctx.conn.FlushChain(mozvpn_ctx.conntrack)
-  mozvpn_ctx.conn.FlushChain(mozvpn_ctx.preroute)
-  mozvpn_ctx.conn.FlushChain(mozvpn_ctx.preroute_v6)
-  mozvpn_ctx.conn.FlushSet(mozvpn_ctx.addrset)
+	mozvpn_ctx.fwmark = 0
+	mozvpn_ctx.conn.FlushChain(mozvpn_ctx.mangle)
+	mozvpn_ctx.conn.FlushChain(mozvpn_ctx.nat)
+	mozvpn_ctx.conn.FlushChain(mozvpn_ctx.conntrack)
+	mozvpn_ctx.conn.FlushChain(mozvpn_ctx.preroute)
+	mozvpn_ctx.conn.FlushChain(mozvpn_ctx.preroute_v6)
+	mozvpn_ctx.conn.FlushSet(mozvpn_ctx.addrset)
 
-  log.Println("Clearing netfilter tables")
-  return mozvpn_ctx.nftCommit()
+	log.Println("Clearing netfilter tables")
+	return mozvpn_ctx.nftCommit()
 }
 
 //export NetfilterIfup
 func NetfilterIfup(ifname string, fwmark uint32) int32 {
-  mozvpn_ctx.fwmark = fwmark
-  if fwmark != 0 {
-    mozvpn_ctx.nftIfup(ifname)
-  }
+	mozvpn_ctx.fwmark = fwmark
+	if fwmark != 0 {
+		mozvpn_ctx.nftIfup(ifname)
+	}
 
-  log.Println("Starting netfilter tables for", ifname)
-  return mozvpn_ctx.nftCommit()
+	log.Println("Starting netfilter tables for", ifname)
+	return mozvpn_ctx.nftCommit()
 }
 
 //export NetfilterMarkInbound
 func NetfilterMarkInbound(ipaddr string, port uint32) int32 {
-  element := []nftables.SetElement{
-    { Key: net.ParseIP(ipaddr).To4(), },
-  }
- 
-  mozvpn_ctx.conn.SetAddElements(mozvpn_ctx.addrset, element)
+	element := []nftables.SetElement{
+		{Key: net.ParseIP(ipaddr).To4()},
+	}
 
-  log.Println("Marking inbound traffic from server")
-  return mozvpn_ctx.nftCommit()
+	mozvpn_ctx.conn.SetAddElements(mozvpn_ctx.addrset, element)
+
+	log.Println("Marking inbound traffic from server")
+	return mozvpn_ctx.nftCommit()
 }
 
 //export NetfilterClearInbound
 func NetfilterClearInbound(ipaddr string) int32 {
-  element := []nftables.SetElement{
-    { Key: net.ParseIP(ipaddr).To4(), },
-  }
+	element := []nftables.SetElement{
+		{Key: net.ParseIP(ipaddr).To4()},
+	}
 
-  mozvpn_ctx.conn.SetDeleteElements(mozvpn_ctx.addrset, element)
-  log.Println("Clearing traffic marks for server")
-  return mozvpn_ctx.nftCommit()
+	mozvpn_ctx.conn.SetDeleteElements(mozvpn_ctx.addrset, element)
+	log.Println("Clearing traffic marks for server")
+	return mozvpn_ctx.nftCommit()
 }
 
 //export NetfilterIsolateIpv6
 func NetfilterIsolateIpv6(ifname string, ipv6addr string) int32 {
-  // Inbound packets from any interface other than the tunnel should
-  // be dropped if they are routed to an address assigned to the tunnel.
-  mozvpn_ctx.conn.AddRule(&nftables.Rule{
-    Table: mozvpn_ctx.table_v6,
-    Chain: mozvpn_ctx.preroute_v6,
-    Exprs: []expr.Any{
-      // Match packets arriving from outside the tunnel
-      &expr.Meta{
-        Key:      expr.MetaKeyIIFNAME,
-        Register: 1,
-      },
-      &expr.Cmp{
-        Op:       expr.CmpOpNeq,
-        Register: 1,
-        Data:     nftIfname(ifname),
-      },
-      // Match packets sent from non-local addresses.
-      &expr.Fib{
-        Register: 1,
-        ResultADDRTYPE: true,
-        FlagSADDR: true,
-      },
-      &expr.Cmp{
-        Op:       expr.CmpOpNeq,
-        Register: 1,
-        Data:     binaryutil.NativeEndian.PutUint32(linux.RTN_LOCAL),
-      },
-      // Match packets sent to the IPv6 address
-      &expr.Payload{
-        DestRegister: 1,
-        Base:     expr.PayloadBaseNetworkHeader,
-        Offset:   24,
-        Len:      16,
-      },
-      &expr.Cmp{
-        Op:       expr.CmpOpEq,
-        Register: 1,
-        Data:     net.ParseIP(ipv6addr).To16(),
-      },
-      // Drop the packets
-      &expr.Verdict{
-        Kind:     expr.VerdictDrop,
-      },
-    },
-  })
+	// Inbound packets from any interface other than the tunnel should
+	// be dropped if they are routed to an address assigned to the tunnel.
+	mozvpn_ctx.conn.AddRule(&nftables.Rule{
+		Table: mozvpn_ctx.table_v6,
+		Chain: mozvpn_ctx.preroute_v6,
+		Exprs: []expr.Any{
+			// Match packets arriving from outside the tunnel
+			&expr.Meta{
+				Key:      expr.MetaKeyIIFNAME,
+				Register: 1,
+			},
+			&expr.Cmp{
+				Op:       expr.CmpOpNeq,
+				Register: 1,
+				Data:     nftIfname(ifname),
+			},
+			// Match packets sent from non-local addresses.
+			&expr.Fib{
+				Register:       1,
+				ResultADDRTYPE: true,
+				FlagSADDR:      true,
+			},
+			&expr.Cmp{
+				Op:       expr.CmpOpNeq,
+				Register: 1,
+				Data:     binaryutil.NativeEndian.PutUint32(linux.RTN_LOCAL),
+			},
+			// Match packets sent to the IPv6 address
+			&expr.Payload{
+				DestRegister: 1,
+				Base:         expr.PayloadBaseNetworkHeader,
+				Offset:       24,
+				Len:          16,
+			},
+			&expr.Cmp{
+				Op:       expr.CmpOpEq,
+				Register: 1,
+				Data:     net.ParseIP(ipv6addr).To16(),
+			},
+			// Drop the packets
+			&expr.Verdict{
+				Kind: expr.VerdictDrop,
+			},
+		},
+	})
 
-  log.Println("Isolating tunnel address", ipv6addr)
-  return mozvpn_ctx.nftCommit()
+	log.Println("Isolating tunnel address", ipv6addr)
+	return mozvpn_ctx.nftCommit()
 }
 
 //export NetfilterMarkCgroupV1
 func NetfilterMarkCgroupV1(cgroup uint32) int32 {
-  if mozvpn_ctx.fwmark == 0 {
-    log.Println("Unable to mark traffic: no fwmark")
-    return -1
-  }
+	if mozvpn_ctx.fwmark == 0 {
+		log.Println("Unable to mark traffic: no fwmark")
+		return -1
+	}
 
-  mozvpn_ctx.nftMarkCgroup1netcls(cgroup)
+	mozvpn_ctx.nftMarkCgroup1netcls(cgroup)
 
-  log.Println("Marking traffic from cgroup", cgroup)
-  return mozvpn_ctx.nftCommit()
+	log.Println("Marking traffic from cgroup", cgroup)
+	return mozvpn_ctx.nftCommit()
 }
 
 //export NetfilterMarkCgroupV2
 func NetfilterMarkCgroupV2(cgroup string) int32 {
-  if mozvpn_ctx.fwmark == 0 {
-    log.Println("Unable to mark traffic: no fwmark")
-    return -1
-  }
+	if mozvpn_ctx.fwmark == 0 {
+		log.Println("Unable to mark traffic: no fwmark")
+		return -1
+	}
 
-  log.Println("Marking traffic from cgroup", cgroup)
-  mozvpn_ctx.nftMarkCgroup2xt(cgroup)
+	log.Println("Marking traffic from cgroup", cgroup)
+	mozvpn_ctx.nftMarkCgroup2xt(cgroup)
 
-  return mozvpn_ctx.nftCommit()
+	return mozvpn_ctx.nftCommit()
 }
 
 //export NetfilterResetCgroupV2
 func NetfilterResetCgroupV2(cgroup string) int32 {
-  xtcgroup := nftXtCgroupMatch(cgroup)
+	xtcgroup := nftXtCgroupMatch(cgroup)
 
-  // Delete all mangle rules matching against the cgroup.
-  rules, err := mozvpn_ctx.conn.GetRules(mozvpn_ctx.table_inet, mozvpn_ctx.mangle)
-  if err != nil {
-    log.Println("Failed to inspect inet/mangle rules", err)
-  } else {
-    mozvpn_ctx.nftDelCgroup2xt(rules, &xtcgroup)
-  }
+	// Delete all mangle rules matching against the cgroup.
+	rules, err := mozvpn_ctx.conn.GetRules(mozvpn_ctx.table_inet, mozvpn_ctx.mangle)
+	if err != nil {
+		log.Println("Failed to inspect inet/mangle rules", err)
+	} else {
+		mozvpn_ctx.nftDelCgroup2xt(rules, &xtcgroup)
+	}
 
-  // Delete all NAT rules matching against the cgroup.
-  rules, err = mozvpn_ctx.conn.GetRules(mozvpn_ctx.table_inet, mozvpn_ctx.nat)
-  if err != nil {
-    log.Println("Failed to inspect inet/nat rules", err)
-  } else {
-    mozvpn_ctx.nftDelCgroup2xt(rules, &xtcgroup)
-  }
-  
-  return mozvpn_ctx.nftCommit()
+	// Delete all NAT rules matching against the cgroup.
+	rules, err = mozvpn_ctx.conn.GetRules(mozvpn_ctx.table_inet, mozvpn_ctx.nat)
+	if err != nil {
+		log.Println("Failed to inspect inet/nat rules", err)
+	} else {
+		mozvpn_ctx.nftDelCgroup2xt(rules, &xtcgroup)
+	}
+
+	return mozvpn_ctx.nftCommit()
 }
 
 //export NetfilterResetAllCgroupsV2
 func NetfilterResetAllCgroupsV2() int32 {
-  log.Println("Clearing all cgroup traffic marks")
-  mozvpn_ctx.conn.FlushChain(mozvpn_ctx.mangle)
-  mozvpn_ctx.conn.FlushChain(mozvpn_ctx.nat)
-  return mozvpn_ctx.nftCommit()
+	log.Println("Clearing all cgroup traffic marks")
+	mozvpn_ctx.conn.FlushChain(mozvpn_ctx.mangle)
+	mozvpn_ctx.conn.FlushChain(mozvpn_ctx.nat)
+	return mozvpn_ctx.nftCommit()
 }
 
 func main() {}

--- a/src/cmake/linux.cmake
+++ b/src/cmake/linux.cmake
@@ -75,6 +75,8 @@ if(NOT BUILD_FLATPAK)
         ${CMAKE_SOURCE_DIR}/src/platforms/linux/daemon/iputilslinux.cpp
         ${CMAKE_SOURCE_DIR}/src/platforms/linux/daemon/iputilslinux.h
         ${CMAKE_SOURCE_DIR}/src/platforms/linux/daemon/linuxdaemon.cpp
+        ${CMAKE_SOURCE_DIR}/src/platforms/linux/daemon/linuxfirewall.cpp
+        ${CMAKE_SOURCE_DIR}/src/platforms/linux/daemon/linuxfirewall.h
         ${CMAKE_SOURCE_DIR}/src/platforms/linux/daemon/wireguardutilslinux.cpp
         ${CMAKE_SOURCE_DIR}/src/platforms/linux/daemon/wireguardutilslinux.h
     )

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -864,7 +864,7 @@ void Controller::statusUpdated(const QString& serverIpv4Gateway,
 
   list.swap(m_getStatusCallbacks);
   for (const std::function<void(
-           const QString&serverIpv4Gateway, const QString&deviceIpv4Address,
+           const QString& serverIpv4Gateway, const QString& deviceIpv4Address,
            uint64_t txBytes, uint64_t rxBytes)>&func : list) {
     func(serverIpv4Gateway, deviceIpv4Address, txBytes, rxBytes);
   }

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -513,8 +513,9 @@ Controller::IPAddressList Controller::getExcludedIPAddressRanges() {
   logger.debug() << "Filtering out the local area networks (rfc 1918)";
   excludeIPv4s.append(RFC1918::ipv4());
 
-  logger.debug() << "Filtering out the local area networks (rfc 4193)";
+  logger.debug() << "Filtering out the local area networks";
   excludeIPv6s.append(RFC4193::ipv6());
+  excludeIPv6s.append(RFC4291::ipv6LinkLocalAddressBlock());
 
   logger.debug() << "Filtering out multicast addresses";
   excludeIPv4s.append(RFC1112::ipv4MulticastAddressBlock());

--- a/src/controller.h
+++ b/src/controller.h
@@ -155,6 +155,19 @@ class Controller : public QObject, public LogSerializer {
   ~Controller();
 
   void initialize();
+
+  struct IPAddressList {
+    QList<IPAddress> v6;
+    QList<IPAddress> v4;
+
+    QList<IPAddress> flatten() {
+      QList<IPAddress> list;
+      list.append(v6);
+      list.append(v4);
+      return list;
+    }
+  };
+  static IPAddressList getExcludedIPAddressRanges();
   static QList<IPAddress> getAllowedIPAddressRanges(const Server& server);
 
   enum ServerCoolDownPolicyForSilentSwitch {

--- a/src/daemon/wireguardutils.h
+++ b/src/daemon/wireguardutils.h
@@ -41,11 +41,23 @@ class WireguardUtils : public QObject {
   virtual bool deletePeer(const InterfaceConfig& config) = 0;
   virtual QList<PeerStatus> getPeerStatus() = 0;
 
-  virtual bool updateRoutePrefix(const IPAddress& prefix) = 0;
-  virtual bool deleteRoutePrefix(const IPAddress& prefix) = 0;
+  virtual bool updateRoutePrefix(const IPAddress& prefix) {
+    Q_UNUSED(prefix);
+    return true;
+  }
+  virtual bool deleteRoutePrefix(const IPAddress& prefix) {
+    Q_UNUSED(prefix);
+    return true;
+  }
 
-  virtual bool addExclusionRoute(const IPAddress& prefix) = 0;
-  virtual bool deleteExclusionRoute(const IPAddress& prefix) = 0;
+  virtual bool addExclusionRoute(const IPAddress& prefix) {
+    Q_UNUSED(prefix);
+    return true;
+  }
+  virtual bool deleteExclusionRoute(const IPAddress& prefix) {
+    Q_UNUSED(prefix);
+    return true;
+  }
 };
 
 #endif  // WIREGUARDUTILS_H

--- a/src/platforms/linux/daemon/linuxfirewall.cpp
+++ b/src/platforms/linux/daemon/linuxfirewall.cpp
@@ -109,6 +109,10 @@ bool LinuxFirewall::up(const QString& ifname, uint32_t fwmark,
     return false;
   }
 
+  if (NetfilterAllowNDP() != 0) {
+    return false;
+  }
+
   if (NetfilterBlockDNS() != 0) {
     return false;
   }

--- a/src/platforms/linux/daemon/linuxfirewall.cpp
+++ b/src/platforms/linux/daemon/linuxfirewall.cpp
@@ -1,0 +1,185 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "linuxfirewall.h"
+
+#include "controller.h"
+#include "leakdetector.h"
+#include "logger.h"
+
+// Import Netfilter.go headers
+#if defined(__cplusplus)
+extern "C" {
+#endif
+#include "netfilter.h"
+#if defined(__cplusplus)
+}
+#endif
+
+namespace {
+Logger netfilterLogger("NetfilterGo");
+Logger logger("LinuxFirewall");
+
+void NetfilterLogger(int level, const char* msg) {
+  // https:// pkg.go.dev/github.com/tusharsoni/copper/clogger#pkg-constants
+  //
+  // LevelDebug = Level(iota + 1)
+  // LevelInfo
+  // LevelWarn
+  // LevelError
+
+  switch (level) {
+    case 2:
+      netfilterLogger.info() << msg;
+    case 3:
+      netfilterLogger.warning() << msg;
+    case 4:
+      netfilterLogger.error() << msg;
+    default:
+      netfilterLogger.debug() << msg;
+  }
+}
+
+// Using a macro instead of a function here,
+// because we want the QByteArray to have the same lifetime as the caller.
+#define MAKE_GO_STRING(identifier, str)                   \
+  QByteArray b_##identifier = str.toLocal8Bit();          \
+  GoString identifier = {.p = b_##identifier.constData(), \
+                         .n = (ptrdiff_t)b_##identifier.length()};
+
+}  // namespace
+
+LinuxFirewall::LinuxFirewall(QObject* parent) : QObject(parent) {
+  MZ_COUNT_CTOR(LinuxFirewall);
+
+  NetfilterSetLogger((GoUintptr)&NetfilterLogger);
+}
+
+LinuxFirewall::~LinuxFirewall() {
+  MZ_COUNT_DTOR(LinuxFirewall);
+
+  down();
+}
+
+bool LinuxFirewall::up(const QString& ifname, uint32_t fwmark,
+                       const QString& deviceIpv6Address) {
+  logger.debug() << "Starting firewall";
+
+  if (NetfilterCreateTables() != 0) {
+    return false;
+  }
+
+  // Once tables exist there is something to clean up, therefore we are up.
+  m_isUp = true;
+  // TODO: We should have a better solution for this once VPN-6256 is addressed.
+  auto cleanup = qScopeGuard([this] {
+    logger.error() << "Error attempting to setup firewall.";
+    down();
+  });
+
+  if (NetfilterApplyFwMark(fwmark) != 0) {
+    return false;
+  }
+
+  MAKE_GO_STRING(goIfname, ifname);
+  if (NetfilterRestrictTraffic(goIfname) != 0) {
+    return false;
+  }
+
+  int slashPos = deviceIpv6Address.indexOf('/');
+  MAKE_GO_STRING(goIpv6Address, deviceIpv6Address);
+  if (slashPos != -1) {
+    goIpv6Address.n = slashPos;
+  }
+
+  if (NetfilterIsolateIpv6(goIfname, goIpv6Address)) {
+    return false;
+  }
+
+  for (const IPAddress& prefix :
+       Controller::getExcludedIPAddressRanges().flatten()) {
+    MAKE_GO_STRING(goPrefix, prefix.toString());
+    if (NetfilterAllowPrefix(goPrefix) != 0) {
+      return false;
+    }
+  }
+
+  cleanup.dismiss();
+  return true;
+}
+
+bool LinuxFirewall::down() {
+  logger.debug() << "Disabling firewall";
+
+  if (m_isUp && NetfilterRemoveTables() != 0) {
+    // TODO(VPN-6265): Should we retry?
+    logger.error() << "Error attempting to disable firewall.";
+    return false;
+  }
+
+  return true;
+}
+
+bool LinuxFirewall::markInbound(const QString& serverIpv4AddrIn) {
+  MAKE_GO_STRING(goAddress, serverIpv4AddrIn);
+  if (NetfilterMarkInbound(goAddress) != 0) {
+    logger.error() << "Error attempting to mark inbound traffic from"
+                   << serverIpv4AddrIn;
+    return false;
+  }
+
+  return true;
+}
+
+bool LinuxFirewall::clearInbound(const QString& serverIpv4AddrIn) {
+  MAKE_GO_STRING(goAddress, serverIpv4AddrIn);
+  if (NetfilterClearInbound(goAddress) != 0) {
+    logger.error() << "Error attempting to clear inbound traffic from"
+                   << serverIpv4AddrIn;
+    return false;
+  }
+
+  return true;
+}
+
+bool LinuxFirewall::markCgroupV1(uint32_t cgroup) {
+  if (NetfilterMarkCgroupV1(cgroup) != 0) {
+    logger.error() << "Error attempting to mark cgroupv1 traffic for cgroup"
+                   << cgroup;
+    return false;
+  }
+
+  return true;
+}
+
+bool LinuxFirewall::markCgroupV2(const QString& cgroup) {
+  MAKE_GO_STRING(goCgroup, cgroup);
+  if (NetfilterMarkCgroupV2(goCgroup) != 0) {
+    logger.error() << "Error attempting to mark cgroupv2 traffic for cgroup"
+                   << cgroup;
+    return false;
+  }
+
+  return true;
+}
+
+bool LinuxFirewall::clearCgroupV2(const QString& cgroup) {
+  MAKE_GO_STRING(goCgroup, cgroup);
+  if (NetfilterResetCgroupV2(goCgroup) != 0) {
+    logger.error() << "Error attempting to clear cgroupv2 traffic for cgroup"
+                   << cgroup;
+    return false;
+  }
+
+  return true;
+}
+
+bool LinuxFirewall::clearAllCgroupsV2() {
+  if (NetfilterResetAllCgroupsV2() != 0) {
+    logger.error() << "Error attempting to clear all cgroupv2 traffic";
+    return false;
+  }
+
+  return true;
+}

--- a/src/platforms/linux/daemon/linuxfirewall.cpp
+++ b/src/platforms/linux/daemon/linuxfirewall.cpp
@@ -105,6 +105,10 @@ bool LinuxFirewall::up(const QString& ifname, uint32_t fwmark,
     }
   }
 
+  if (NetfilterAllowDHCP() != 0) {
+    return false;
+  }
+
   cleanup.dismiss();
   return true;
 }

--- a/src/platforms/linux/daemon/linuxfirewall.cpp
+++ b/src/platforms/linux/daemon/linuxfirewall.cpp
@@ -109,6 +109,10 @@ bool LinuxFirewall::up(const QString& ifname, uint32_t fwmark,
     return false;
   }
 
+  if (NetfilterBlockDNS() != 0) {
+    return false;
+  }
+
   cleanup.dismiss();
   return true;
 }

--- a/src/platforms/linux/daemon/linuxfirewall.h
+++ b/src/platforms/linux/daemon/linuxfirewall.h
@@ -1,0 +1,33 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef LINUXFIREWALL_H
+#define LINUXFIREWALL_H
+
+#include <QObject>
+
+class LinuxFirewall final : public QObject {
+  Q_DISABLE_COPY_MOVE(LinuxFirewall)
+
+ public:
+  ~LinuxFirewall();
+  LinuxFirewall(QObject* parent);
+
+  bool up(const QString& ifname, uint32_t fwmark,
+          const QString& deviceIpv6Address);
+  bool down();
+
+  bool markInbound(const QString& serverIpv4AddrIn);
+  bool clearInbound(const QString& serverIpv4AddrIn);
+
+  bool markCgroupV1(uint32_t cgroup);
+  bool markCgroupV2(const QString& cgroup);
+  bool clearCgroupV2(const QString& cgroup);
+  bool clearAllCgroupsV2();
+
+ private:
+  bool m_isUp = false;
+};
+
+#endif  // LINUXFIREWALL_H

--- a/src/platforms/linux/daemon/wireguardutilslinux.cpp
+++ b/src/platforms/linux/daemon/wireguardutilslinux.cpp
@@ -631,12 +631,12 @@ void WireguardUtilsLinux::nlsockReady() {
     switch (nlmsg->nlmsg_type) {
       case NLMSG_DONE:
         return;
-      
+
       case NLMSG_NOOP:
         // Ignore noops - typically used for message padding.
         continue;
-      
-      case NLMSG_ERROR:{
+
+      case NLMSG_ERROR: {
         struct nlmsgerr* err = static_cast<struct nlmsgerr*>(NLMSG_DATA(nlmsg));
         if (err->error != 0) {
           logger.debug() << "Netlink request failed:" << strerror(-err->error);
@@ -647,7 +647,7 @@ void WireguardUtilsLinux::nlsockReady() {
       case RTM_NEWLINK:
         nlsockHandleNewlink(nlmsg);
         break;
-      
+
       case RTM_DELLINK:
         nlsockHandleDellink(nlmsg);
         break;
@@ -661,7 +661,7 @@ void WireguardUtilsLinux::nlsockReady() {
 }
 
 void WireguardUtilsLinux::nlsockHandleNewlink(struct nlmsghdr* nlmsg) {
-  struct ifinfomsg *msg = static_cast<struct ifinfomsg*>(NLMSG_DATA(nlmsg));
+  struct ifinfomsg* msg = static_cast<struct ifinfomsg*>(NLMSG_DATA(nlmsg));
 
   // Ignore messages unless they pertain to the wireguard interface.
   if (msg->ifi_index != static_cast<int>(m_ifindex)) {
@@ -679,11 +679,12 @@ void WireguardUtilsLinux::nlsockHandleNewlink(struct nlmsghdr* nlmsg) {
     setupWireguardRoutingTable(AF_INET6);
   }
 
-  logger.debug() << "RTM_NEWLINK flags:" << "0x" + QString::number(msg->ifi_flags, 16);
+  logger.debug() << "RTM_NEWLINK flags:"
+                 << "0x" + QString::number(msg->ifi_flags, 16);
 }
 
 void WireguardUtilsLinux::nlsockHandleDellink(struct nlmsghdr* nlmsg) {
-  struct ifinfomsg *msg = static_cast<struct ifinfomsg*>(NLMSG_DATA(nlmsg));
+  struct ifinfomsg* msg = static_cast<struct ifinfomsg*>(NLMSG_DATA(nlmsg));
 
   // Ignore messages unless they pertain to the wireguard interface.
   if (msg->ifi_index != static_cast<int>(m_ifindex)) {
@@ -693,7 +694,8 @@ void WireguardUtilsLinux::nlsockHandleDellink(struct nlmsghdr* nlmsg) {
   // Interface is down!
   m_ifindex = 0;
   m_ifflags = 0;
-  logger.debug() << "RTM_DELLINK flags:" << "0x" + QString::number(msg->ifi_flags, 16);
+  logger.debug() << "RTM_DELLINK flags:"
+                 << "0x" + QString::number(msg->ifi_flags, 16);
 }
 
 // static

--- a/src/platforms/linux/daemon/wireguardutilslinux.h
+++ b/src/platforms/linux/daemon/wireguardutilslinux.h
@@ -26,12 +26,6 @@ class WireguardUtilsLinux final : public WireguardUtils {
   bool deletePeer(const InterfaceConfig& config) override;
   QList<PeerStatus> getPeerStatus() override;
 
-  bool updateRoutePrefix(const IPAddress& prefix) override;
-  bool deleteRoutePrefix(const IPAddress& prefix) override;
-
-  bool addExclusionRoute(const IPAddress& prefix) override;
-  bool deleteExclusionRoute(const IPAddress& prefix) override;
-
   void excludeCgroup(const QString& cgroup);
   void resetCgroup(const QString& cgroup);
   void resetAllCgroups();
@@ -41,7 +35,17 @@ class WireguardUtilsLinux final : public WireguardUtils {
   bool setPeerEndpoint(struct sockaddr* sa, const QString& address, int port);
   bool addPeerPrefix(struct wg_peer* peer, const IPAddress& prefix);
   bool rtmSendRule(int action, int flags, int addrfamily);
-  bool rtmSendRoute(int action, int flags, int type, const IPAddress& prefix);
+  /**
+   * This table is made up of a single routing rule:
+   *    default dev moz0 proto static scope link
+   *
+   * This rule simply states that all packets that make it here,
+   * just go through the moz0 interface.
+   *
+   * Packets that make it to this table must go through the Wireguard interface.
+   * Firewall rules and ip rules are responsible for making sure of that.
+   */
+  bool setupWireguardRoutingTable();
   bool rtmIncludePeer(int action, int flags, const IPAddress& prefix);
   static bool setupCgroupClass(const QString& path, unsigned long classid);
   static bool moveCgroupProcs(const QString& src, const QString& dest);

--- a/src/platforms/linux/daemon/wireguardutilslinux.h
+++ b/src/platforms/linux/daemon/wireguardutilslinux.h
@@ -11,6 +11,7 @@
 #include <QStringList>
 
 #include "daemon/wireguardutils.h"
+#include "linuxfirewall.h"
 
 class WireguardUtilsLinux final : public WireguardUtils {
   Q_OBJECT
@@ -58,6 +59,8 @@ class WireguardUtilsLinux final : public WireguardUtils {
   int m_cgroupVersion = 0;
   QString m_cgroupNetClass;
   QString m_cgroupUnified;
+
+  LinuxFirewall m_firewall;
 
  private slots:
   void nlsockReady();

--- a/src/rfc/rfc4291.cpp
+++ b/src/rfc/rfc4291.cpp
@@ -9,3 +9,6 @@ IPAddress RFC4291::ipv6LoopbackAddressBlock() { return IPAddress("::1/128"); }
 
 // static
 IPAddress RFC4291::ipv6MulticastAddressBlock() { return IPAddress("ff00::/8"); }
+
+// static
+IPAddress RFC4291::ipv6LinkLocalAddressBlock() { return IPAddress("fe80::/10"); }

--- a/src/rfc/rfc4291.cpp
+++ b/src/rfc/rfc4291.cpp
@@ -11,4 +11,6 @@ IPAddress RFC4291::ipv6LoopbackAddressBlock() { return IPAddress("::1/128"); }
 IPAddress RFC4291::ipv6MulticastAddressBlock() { return IPAddress("ff00::/8"); }
 
 // static
-IPAddress RFC4291::ipv6LinkLocalAddressBlock() { return IPAddress("fe80::/10"); }
+IPAddress RFC4291::ipv6LinkLocalAddressBlock() {
+  return IPAddress("fe80::/10");
+}

--- a/src/rfc/rfc4291.h
+++ b/src/rfc/rfc4291.h
@@ -13,6 +13,7 @@ class RFC4291 final {
  public:
   static IPAddress ipv6LoopbackAddressBlock();
   static IPAddress ipv6MulticastAddressBlock();
+  static IPAddress ipv6LinkLocalAddressBlock();
 };
 
 #endif  // RFC4291_H


### PR DESCRIPTION
The approach for these firewall rules is "deny by default". I have added two new chains to our Linux firewall configuration:

```
chain mozvpn-input {
		type filter hook input priority filter; policy drop;
# Allow traffic to the loopback interface
		meta iiftype loopback accept
# Allow traffic to the VPN interface
		iifname "moz0" accept
# Allow udp traffic to the VPN servers
		meta protocol ip meta l4proto udp @nh,96,32 @mozvpn-addrset accept
# Allow LAN traffic and any other exclusision the user might have set up
		ip6 saddr fc00::/7 accept
		ip6 saddr ff00::/8 accept
		ip saddr 10.0.0.0/8 accept
		ip saddr 172.16.0.0/12 accept
		ip saddr 192.168.0.0/16 accept
		ip saddr 224.0.0.0/4 accept
# Allow DHCP
		udp sport 68 ip daddr 255.255.255.255 udp dport 67 accept
		udp sport 68 udp dport 67 accept
	}

	chain mozvpn-output {
		type filter hook output priority filter; policy drop;
# Allow traffic from the loopback interface
		meta oiftype loopback accept
# Allow traffic from the VPN interface
		oifname "moz0" accept
# Allow udp traffic from the VPN servers
		meta protocol ip meta l4proto udp @nh,128,32 @mozvpn-addrset accept
# Allow LAN traffic and any other exclusision the user might have set up
		ip6 daddr fc00::/7 accept
		ip6 daddr ff00::/8 accept
		ip daddr 10.0.0.0/8 accept
		ip daddr 172.16.0.0/12 accept
		ip daddr 192.168.0.0/16 accept
		ip daddr 224.0.0.0/4 accept
# Allow DHCPv4 (no v6... can add it, but on Windows we don't have it for the longest time and all is fine)
		udp sport 68 ip daddr 255.255.255.255 udp dport 67 accept
		udp sport 67 udp dport 68 accept
# Stop any DNS queries going outside of the tunnel
		udp dport 53 reject
		tcp dport 53 reject with tcp reset
	}
```

~On the Windows firewall we also add rules to allow DHCP packets to bypass the VPN tunnel, which I want to add here as well before we merge.~ Done.

Notice the default policy for all input and output packets is to drop, unless the packet matches any of the rules in this table.

By moving these rules to the firewall I was able to clean up the routing table in the ip rules to:

```
$ ip route show table 51820
default dev moz0 proto static scope link 
```

No routing is required, when packets get here they have already been "routed".

---

I have also done a bit of refactoring and moved the firewall out of the WireguardUtils class.

> Note: I am sorry for the reformatting of `netfilter.go` I only noticed that when I opened this PR. I can undo it if you all hate it too much... But that would not be to ostright forward. I reccomend reviewing commit by commit, because fortunately the reformatting is all concentrated in the first commit -- where there are no real changed to that file :woman_facepalming: 