### PR TITLE
Nit: Compiler Warnings as Errors when using MSVC

### DIFF
--- a/scripts/cmake/utilities.cmake
+++ b/scripts/cmake/utilities.cmake
@@ -5,7 +5,7 @@
 # Sets Defaults like `-Wall -Werror` if we know it will not
 # explode on that target + compiler
 function(mz_target_handle_warnings MZ_TARGET)
-    if(MSVC OR IOS)
+    if(IOS)
         return()
     endif()
     # Just don't for wasm
@@ -20,7 +20,11 @@ function(mz_target_handle_warnings MZ_TARGET)
         set(scope "PRIVATE")
     endif()
 
-    target_compile_options( ${MZ_TARGET} ${scope} -Wall -Werror -Wno-conversion)
+    if(MSVC)
+        target_compile_options( ${MZ_TARGET} ${scope} /W3 /WX)
+    else()
+        target_compile_options( ${MZ_TARGET} ${scope} -Wall -Werror -Wno-conversion)
+    endif()
 endfunction()
 
 # MZ_ADD_NEW_MODULE: A utility function for adding a new module to this project.

--- a/src/hacl-star/kremlin/minimal/fstar_uint128_msvc.h
+++ b/src/hacl-star/kremlin/minimal/fstar_uint128_msvc.h
@@ -9,7 +9,7 @@
  */
 
 #pragma once
-#pragma warning(disable : C4554)
+#pragma warning(disable:4554)
 
 #include "kremlin/internal/types.h"
 #include "FStar_UInt128.h"

--- a/src/hacl-star/kremlin/minimal/fstar_uint128_msvc.h
+++ b/src/hacl-star/kremlin/minimal/fstar_uint128_msvc.h
@@ -9,6 +9,7 @@
  */
 
 #pragma once
+#pragma warning(disable : C4554)
 
 #include "kremlin/internal/types.h"
 #include "FStar_UInt128.h"

--- a/src/platforms/windows/daemon/windowsdaemon.h
+++ b/src/platforms/windows/daemon/windowsdaemon.h
@@ -36,7 +36,6 @@ class WindowsDaemon final : public Daemon {
     Inactive,
   };
 
-  State m_state = Inactive;
   int m_inetAdapterIndex = -1;
 
   WireguardUtilsWindows* m_wgutils = nullptr;

--- a/src/platforms/windows/daemon/windowsfirewall.cpp
+++ b/src/platforms/windows/daemon/windowsfirewall.cpp
@@ -670,7 +670,7 @@ bool WindowsFirewall::blockTrafficTo(const IPAddress& addr, uint8_t weight,
   filter.weight.uint8 = weight;
   filter.subLayerKey = ST_FW_WINFW_BASELINE_SUBLAYER_KEY;
 
-  FWPM_FILTER_CONDITION0 cond[1] = {0};
+  FWPM_FILTER_CONDITION0 cond[1] = {};
   FWP_RANGE0 ipRange;
   QByteArray lowIpV6Buffer;
   QByteArray highIpV6Buffer;

--- a/src/platforms/windows/daemon/windowsroutemonitor.cpp
+++ b/src/platforms/windows/daemon/windowsroutemonitor.cpp
@@ -114,7 +114,7 @@ void WindowsRouteMonitor::updateValidInterfaces(int family) {
 void WindowsRouteMonitor::updateExclusionRoute(MIB_IPFORWARD_ROW2* data,
                                                void* ptable) {
   PMIB_IPFORWARD_TABLE2 table = reinterpret_cast<PMIB_IPFORWARD_TABLE2>(ptable);
-  SOCKADDR_INET nexthop = {0};
+  SOCKADDR_INET nexthop = {};
   quint64 bestLuid = 0;
   int bestMatch = -1;
   ULONG bestMetric = ULONG_MAX;

--- a/src/platforms/windows/daemon/windowstunnellogger.cpp
+++ b/src/platforms/windows/daemon/windowstunnellogger.cpp
@@ -39,7 +39,7 @@ Logger logger("tunnel.dll");
 
 WindowsTunnelLogger::WindowsTunnelLogger(const QString& filename,
                                          QObject* parent)
-    : QObject(parent), m_logfile(filename, this), m_timer(this) {
+    : QObject(parent), m_timer(this), m_logfile(filename, this) {
   MZ_COUNT_CTOR(WindowsTunnelLogger);
 
   m_startTime = QDateTime::currentMSecsSinceEpoch() * 1000000;

--- a/src/platforms/windows/daemon/windowstunnelservice.cpp
+++ b/src/platforms/windows/daemon/windowstunnelservice.cpp
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#include "WindowsTunnelService.h"
+#include "windowstunnelservice.h"
 
 #include <Windows.h>
 


### PR DESCRIPTION
## Description
For clang& gcc we set `-Wall -Werror -Wno-conversion`
for windows we skip this. I just noticed a warning and thought, let's fix them all :) 