### PR TITLE
VPN-6224: Prevent default checkboxes from appearing on hover 

### DIFF
--- a/nebula/ui/components/MZSettingsToggle.qml
+++ b/nebula/ui/components/MZSettingsToggle.qml
@@ -24,6 +24,11 @@ CheckBox {
 
     implicitHeight: MZTheme.theme.toggleHeight
     implicitWidth: MZTheme.theme.toggleWidth
+
+    // Hack-around for https://bugreports.qt.io/browse/QTBUG-99692
+    // Prevents the default Qt checkbox from appearing when hovering the toggle on Windows
+    hoverEnabled: false
+
     states: [
         State {
             when: checked


### PR DESCRIPTION
## Description
This is a hack to prevent default checkboxes from appearing over our stylized toggles on Windows. We do  the same thing [here ](https://github.com/mozilla-mobile/mozilla-vpn-client/blob/d9aca561a638cf2985ac9d60ed56502844cd6b85/nebula/ui/components/MZCheckBox.qml#L25)in MZCheckbox. 

Here is a crummy video taken with my iPhone since screen casting on Windows seems (at least at current energy level) non-trivial. 



https://github.com/mozilla-mobile/mozilla-vpn-client/assets/22355127/3023bd79-d10f-4149-81fd-4ef6cff13443




## Reference

VPN-6224

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
