### PR TITLE
Fix up for VPN-4979 part 1

### DIFF
--- a/src/platforms/ios/PingAnalyzer.swift
+++ b/src/platforms/ios/PingAnalyzer.swift
@@ -53,7 +53,7 @@ class PingAnalyzer {
             logger.info(message: "Sending pings")
             try ping.startPinging()
         } catch {
-            logger.error(message: "Error when sending pings")
+            logger.error(message: "Error when sending pings: \(error)")
             callback(nil)
         }
         timer = Timer.scheduledTimer(timeInterval: TimeInterval(checkTime), target: self, selector: #selector(calculateStability), userInfo: nil, repeats: false)

--- a/src/platforms/ios/iostunnel.swift
+++ b/src/platforms/ios/iostunnel.swift
@@ -102,8 +102,9 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
                     GleanMetrics.Pings.shared.daemonsession.submit(reason: .daemonStart)
                 }
 
-                let endpointHost = tunnelConfiguration.peers.first?.endpoint?.host
-                if endpointHost == nil {
+                if let endpointHost = tunnelConfiguration.peers.first?.endpoint?.host {
+                    self.connectionHealthMonitor.start(for: String(describing: endpointHost))
+                } else {
                     // Intentionally using an assertion failure here without an early return.
                     // This is new functionality being added for connection health checks.
                     // It would be surprising if this was ever nil (and we hit this block).
@@ -113,8 +114,6 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
                     self.logger.info(message: "Tunnel config is missing endpoint")
                     assertionFailure("Missing endpoint")
                 }
-                let endpointIP = String(describing: endpointHost)
-                self.connectionHealthMonitor.start(for: endpointIP)
 
                 completionHandler(nil)
                 return


### PR DESCRIPTION
## Description

[VPN-4979](https://mozilla-hub.atlassian.net/browse/VPN-4979) was planned to be a set of 3 PRs:

1. Set up connection health monitoring (https://github.com/mozilla-mobile/mozilla-vpn-client/pull/9146)
2. Add silent server switching (https://github.com/mozilla-mobile/mozilla-vpn-client/pull/9288)
3. Add telemetry (to be done after step 2 is merged)

This could be considered 1.5 - it fixes a bug I introduced when making some last minute changes in https://github.com/mozilla-mobile/mozilla-vpn-client/pull/9146. 

I went through a few ways to write this (we don't want to use `guard` here, as that can't fall through, though it's somewhat stylistically appropriate), and I went back and forth. Unfortunately, I left a bug in my final change:
```
let endpointIP = String(describing: endpointHost)
self.connectionHealthMonitor.start(for: endpointIP)
```
Since `endpointHost` is an optional, endpointIP becomes this string: `Optional(104.128.56.65)`. And passing that to the connection health monitor - when it expects a string like `104.128.56.65` - ends up with an error.

## Reference

VPN-4979, part 1.5

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed


[VPN-4979]: https://mozilla-hub.atlassian.net/browse/VPN-4979?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ