### PR TITLE
VPN-2656 Support Windows CLI 

### DIFF
--- a/src/commands/commandui.cpp
+++ b/src/commands/commandui.cpp
@@ -187,20 +187,6 @@ int CommandUI::run(QStringList& tokens) {
     EventListener eventListener;
 #endif
 
-#ifdef MZ_WINDOWS
-#  ifdef MZ_DEBUG
-    // Allocate a console to view log output in debug mode on windows
-    if (AllocConsole()) {
-      FILE* unusedFile;
-      freopen_s(&unusedFile, "CONOUT$", "w", stdout);
-      freopen_s(&unusedFile, "CONOUT$", "w", stderr);
-      std::cout.clear();
-      std::clog.clear();
-      std::cerr.clear();
-    }
-#  endif
-#endif
-
 #ifdef MZ_DEBUG
     // This enables the qt-creator qml debugger on debug builds.:
     // Go to QtCreator: Debug->Start Debugging-> Attach to QML port

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,11 +4,31 @@
 
 #include "commandlineparser.h"
 #include "leakdetector.h"
+#include "stdio.h"
+#ifdef MZ_WINDOWS
+
+#  include <windows.h>
+
+#  include <iostream>
+
+#endif
 
 Q_DECL_EXPORT int main(int argc, char* argv[]) {
 #ifdef MZ_DEBUG
   LeakDetector leakDetector;
   Q_UNUSED(leakDetector);
+#endif
+
+#ifdef MZ_WINDOWS
+  if (AttachConsole(ATTACH_PARENT_PROCESS) != 0) {
+    FILE* unusedFile;
+    // Swap to the new out/err streams
+    freopen_s(&unusedFile, "CONOUT$", "w", stdout);
+    freopen_s(&unusedFile, "CONOUT$", "w", stderr);
+    std::cout.clear();
+    std::clog.clear();
+    std::cerr.clear();
+  }
 #endif
 
   CommandLineParser clp;


### PR DESCRIPTION
## Description
So far when building in MZ_DEBUG we allocated a console instead of using the perfectly fine ones in my IDE >:( 
This pr changes so that we attach to a parent console if it exists, so the client behaves the same way like we do on MacOS. (just as broken lmao) 

This also enables use to use the cli. 
![image](https://github.com/mozilla-mobile/mozilla-vpn-client/assets/9611612/3e9b6a0f-7d69-45ea-b6ee-f5ac683b7ca7)


## Reference


https://mozilla-hub.atlassian.net/browse/VPN-2656