### PR TITLE
Bugzilla 1882147: Add fingerprint for new AMO production root CA to Balrog

### DIFF
--- a/src/constants.h
+++ b/src/constants.h
@@ -233,7 +233,10 @@ PRODBETAEXPR(QString, captivePortalUrl, "http://%1/success.txt",
 
 constexpr const char* BALROG_PROD_HOSTNAME = "aus5.mozilla.org";
 constexpr const char* AUTOGRAPH_PROD_FINGERPRINTS[] = {
+    // root-ca-production-amo 2015-03-17
     "97e8ba9cf12fb3de53cc42a4e6577ed64df493c247b414fea036818d3823560e",
+    // root-ca-production-amo 2024-02-01
+    "c8a80e9afaef4e219b6fb5d7a71d0f101223bac5001ac28f9b0d43dc59a106db",
     nullptr  // list termination
 };
 

--- a/src/constants.h
+++ b/src/constants.h
@@ -236,6 +236,7 @@ constexpr const char* AUTOGRAPH_PROD_FINGERPRINTS[] = {
     // root-ca-production-amo 2015-03-17
     "97e8ba9cf12fb3de53cc42a4e6577ed64df493c247b414fea036818d3823560e",
     // root-ca-production-amo 2024-02-01
+    // https://bugzilla.mozilla.org/show_bug.cgi?id=1882147
     "c8a80e9afaef4e219b6fb5d7a71d0f101223bac5001ac28f9b0d43dc59a106db",
     nullptr  // list termination
 };


### PR DESCRIPTION
## Description
The root CA for signing Balrog update messages is due to expire in 2025, and a new root certificate has been prepared for prod. Let's add the fingerprint of the new root to Balrog so that the CA transition can be handled smoothly.

## Reference
Bugzilla [1882147](https://bugzilla.mozilla.org/show_bug.cgi?id=1882147)

## Checklist
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
