### PR TITLE
VPN-6151: Fix vertical alignment of text in controller view

### DIFF
--- a/src/ui/screens/home/controller/ControllerView.qml
+++ b/src/ui/screens/home/controller/ControllerView.qml
@@ -548,6 +548,8 @@ Item {
             //% "Secure and private"
             //: This refers to the user’s internet connection.
             text: qsTrId("vpn.controller.active") + " • "
+            onPaintedHeightChanged: if (visible) col.handleMultilineText()
+            onVisibleChanged: if (visible) col.handleMultilineText()
           }
 
           ConnectionTimer {


### PR DESCRIPTION
## Description

Short story: This PR makes a two line tweak to the controller view to fix VPN-6151. 

Longer story: Depending on the locale, text in the controller view occasionally changes from a single line to multiple lines when connecting/disconnecting and requires 'special handling' to maintain evenly distributed vertical space without repositioning the vpn toggle button and changing the overall size of the containing purple background square. At some point in quasi-recent history, that handling was dropped for the controller subtitle text (but only when the VPN is on). This PR restores that handling so that the subtitle text can reposition itself correctly. 

## Reference

VPN-6151

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
