### PR TITLE
VPN-4653: Use name of app, instead of the path, as Accessible.name in app exclusions list 

### DIFF
--- a/src/ui/screens/settings/appPermissions/AppPermissionsList.qml
+++ b/src/ui/screens/settings/appPermissions/AppPermissionsList.qml
@@ -190,41 +190,6 @@ ColumnLayout {
                     checkBoxActiveFocusOnTab: false
                     Layout.alignment: Qt.AlignVCenter
                     Accessible.name: appName
-                    focus: true
-
-                    // Change list selection on focus change
-                    onActiveFocusChanged: {
-                        if (activeFocus) { 
-                            listView.currentIndex = index;
-                        };
-                    }
-
-                    function handleTabPressed() {
-                        if (listView.currentIndex < (listView.count - 1)) {
-                            // Move selection & focus to next item
-                            listView.incrementCurrentIndex();
-                            listView.currentItem.forceActiveFocus(Qt.TabFocusReason);
-                        }
-                        else {
-                            // Currently at end of list. Move focus to footer
-                            listView.footerItem.forceActiveFocus(Qt.TabFocusReason);
-                        }
-                    }
-
-                    function handleBacktabPressed() {
-                        if (listView.currentIndex > 0) {
-                            // Move selection & focus to previous item
-                            listView.decrementCurrentIndex();
-                            listView.currentItem.forceActiveFocus(Qt.BacktabFocusReason);
-                        }
-                        else {
-                            // Currently at top of list. Move focus to header
-                            listView.headerItem.forceActiveFocus(Qt.BacktabFocusReason);
-                        }
-                    }
-
-                    Keys.onTabPressed: handleTabPressed()
-                    Keys.onBacktabPressed: handleBacktabPressed()
                 }
 
                 Rectangle {


### PR DESCRIPTION
## Description

In the app exclusions list, we currently feed screen readers the app's path (appID), instead of the name of the app (appName). This PR updates the app exclusions list so that we provide screen readers with `appName` instead. 

## Reference

VPN-4653

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
