### PR TITLE
Chore: Fix flaky subscription test

### DIFF
--- a/tests/functional/testSubscription.js
+++ b/tests/functional/testSubscription.js
@@ -1397,6 +1397,7 @@ describe('Subscription view', function() {
     await vpn.waitForQueryAndClick(
         queries.screenSettings.USER_PROFILE.visible());
     await vpn.waitForQuery(queries.screenSettings.subscriptionView.SCREEN.visible());
+    await vpn.waitForQuery(queries.screenSettings.STACKVIEW.ready());
   }
 
   it('Shows annual upgrade UI based on billing interval and purchase type',


### PR DESCRIPTION
## Description
We have been seeing a bunch of flaky test failures in the `testSubscription.js` functional test. This seems to occur when checking the subscription management links, and the logs appear to show the test failing to register a click of the various subscription management buttons. I suspect that the cause of the failure is clicking too soon after opening the subscription management view, so we try to work around it by waiting for the stackview to finish its transition.

## Reference

    i.e Jira or Github issue URL

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
