### PR TITLE
VPN-4979 part 3: Add telemetry to iOS health checks

### DIFF
--- a/src/telemetry/metrics.yaml
+++ b/src/telemetry/metrics.yaml
@@ -1597,9 +1597,7 @@ connection_health:
 
       This event is recorded in both main application and daemon.
       The logic and cadence of health checks for each of these
-      is not the same. On the daemon this checks are only
-      done on the Android daemon and not on the iOS network extension.
-      To be done on iOS: https://mozilla-hub.atlassian.net/browse/VPN-4979
+      is not the same.
 
       A no signal event happens when the connection is showing issues,
       and a silent switch will not address the issue. Or when the connection
@@ -1629,9 +1627,7 @@ connection_health:
 
       This event is recorded in both main application and daemon.
       The logic and cadence of health checks for each of these
-      is not the same. On the daemon this checks are only
-      done on the Android daemon and not on the iOS network extension.
-      To be done on iOS: https://mozilla-hub.atlassian.net/browse/VPN-4979
+      is not the same.
 
       An unstable event happens when the connection is showing issues,
       but silent switches may still address the issue.
@@ -1659,9 +1655,7 @@ connection_health:
 
       This event is recorded in both main application and daemon.
       The logic and cadence of health checks for each of these
-      is not the same. On the daemon this checks are only
-      done on the Android daemon and not on the iOS network extension.
-      To be done on iOS: https://mozilla-hub.atlassian.net/browse/VPN-4979
+      is not the same.
 
       Stable status is when the app is not in a no signal or unstable
       connection state.
@@ -1767,8 +1761,7 @@ connection_health:
 
       Only collected on desktop for vpnsession, as mobile apps
       frequently are relaunched during VPN sessions. It is
-      collected in daemonsession, currently only on Android.
-      To be done on iOS: https://mozilla-hub.atlassian.net/browse/VPN-4979
+      collected in daemonsession for mobile clients.
     bugs:
       - https://mozilla-hub.atlassian.net/browse/VPN-5860
     data_reviews:
@@ -1791,8 +1784,7 @@ connection_health:
 
       Only collected on desktop for vpnsession, as mobile apps
       frequently are relaunched during VPN sessions. It is
-      collected in daemonsession, currently only on Android.
-      To be done on iOS: https://mozilla-hub.atlassian.net/browse/VPN-4979
+      collected in daemonsession for mobile clients.
     bugs:
       - https://mozilla-hub.atlassian.net/browse/VPN-5860
     data_reviews:
@@ -1815,8 +1807,7 @@ connection_health:
 
       Only collected on desktop for vpnsession, as mobile apps
       frequently are relaunched during VPN sessions. It is
-      collected in daemonsession, currently only on Android.
-      To be done on iOS: https://mozilla-hub.atlassian.net/browse/VPN-4979
+      collected in daemonsession for mobile clients.
     bugs:
       - https://mozilla-hub.atlassian.net/browse/VPN-5860
     data_reviews:


### PR DESCRIPTION
## Description

Adding telemetry to iOS health checks in the network extension. Similar work was done for Android in https://github.com/mozilla-mobile/mozilla-vpn-client/pull/9057.

## Reference

VPN-4979

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
