### PR TITLE
Let Conda-Pack on Macos use Pypi

### DIFF
--- a/taskcluster/scripts/toolchain/conda_pack_ios.sh
+++ b/taskcluster/scripts/toolchain/conda_pack_ios.sh
@@ -20,7 +20,7 @@ source bin/activate
 env 
 whereis pip
 whereis python3
-
+pip config debug
 
 
 conda env create -f env.yml -n vpn

--- a/taskcluster/scripts/toolchain/conda_pack_ios.sh
+++ b/taskcluster/scripts/toolchain/conda_pack_ios.sh
@@ -20,8 +20,11 @@ chmod +x ${MOZ_FETCHES_DIR}/miniconda.sh
 bash ${MOZ_FETCHES_DIR}/miniconda.sh -b -u -p .
 source bin/activate
 
-# Hack, let's disable the Mozilla Pip repo
-# as we do have all things pinned down. 
+# Normally pip is locked down to only 
+# allow download from moz-pip mirror. 
+# The packages are firefox only and everything
+# we're going to fetch is pinned down, so 
+# let's remove that restriction for the current task. 
 rm -f ~/.config/pip/pip.conf
 pip config --user set install.no-index 0 
 pip config debug
@@ -50,4 +53,6 @@ find ../../public/build/ -mindepth 1 -delete
 
 conda-pack -p envs/vpn -o conda-ios.tar.gz
 mv conda-ios.tar.gz  ../../public/build
+
+# remove our Pip conf, so the restrictions are back. 
 rm -f ~/.config/pip/pip.conf

--- a/taskcluster/scripts/toolchain/conda_pack_ios.sh
+++ b/taskcluster/scripts/toolchain/conda_pack_ios.sh
@@ -9,6 +9,14 @@ echo pwd
 ls 
 cd vcs
 ls 
+
+# Hack, let's disable the Mozilla Pip repo
+# as we do have all things pinned down. 
+rm -f ~/.config/pip/pip.conf
+pip config --user set install.no-index 0 
+pip config debug
+
+
 # save the passed QT_Version
 # as that will be overwritten once 
 # we enable the env.yml
@@ -16,14 +24,6 @@ BACKUP_QT_VERSION=${QT_VERSION}
 chmod +x ${MOZ_FETCHES_DIR}/miniconda.sh
 bash ${MOZ_FETCHES_DIR}/miniconda.sh -b -u -p .
 source bin/activate
-
-env 
-whereis pip
-whereis python3
-pip config debug
-pip config --user set install.no-index 0 || true
-pip config debug
-
 
 conda env create -f env.yml -n vpn
 conda activate vpn
@@ -49,3 +49,4 @@ find ../../public/build/ -mindepth 1 -delete
 
 conda-pack -p envs/vpn -o conda-ios.tar.gz
 mv conda-ios.tar.gz  ../../public/build
+rm -f ~/.config/pip/pip.conf

--- a/taskcluster/scripts/toolchain/conda_pack_ios.sh
+++ b/taskcluster/scripts/toolchain/conda_pack_ios.sh
@@ -17,6 +17,12 @@ chmod +x ${MOZ_FETCHES_DIR}/miniconda.sh
 bash ${MOZ_FETCHES_DIR}/miniconda.sh -b -u -p .
 source bin/activate
 
+env 
+whereis pip
+whereis python3
+
+
+
 conda env create -f env.yml -n vpn
 conda activate vpn
 echo "SETTING QT_VERSION=${BACKUP_QT_VERSION}"

--- a/taskcluster/scripts/toolchain/conda_pack_ios.sh
+++ b/taskcluster/scripts/toolchain/conda_pack_ios.sh
@@ -21,6 +21,8 @@ env
 whereis pip
 whereis python3
 pip config debug
+pip config --user set install.no-index: false
+pip config debug
 
 
 conda env create -f env.yml -n vpn

--- a/taskcluster/scripts/toolchain/conda_pack_ios.sh
+++ b/taskcluster/scripts/toolchain/conda_pack_ios.sh
@@ -21,7 +21,7 @@ env
 whereis pip
 whereis python3
 pip config debug
-pip config --user set install.no-index False || true
+pip config --user set install.no-index 0 || true
 pip config debug
 
 

--- a/taskcluster/scripts/toolchain/conda_pack_ios.sh
+++ b/taskcluster/scripts/toolchain/conda_pack_ios.sh
@@ -21,7 +21,7 @@ env
 whereis pip
 whereis python3
 pip config debug
-pip config --user set install.no-index: false
+pip config --user set install.no-index False || true
 pip config debug
 
 

--- a/taskcluster/scripts/toolchain/conda_pack_ios.sh
+++ b/taskcluster/scripts/toolchain/conda_pack_ios.sh
@@ -10,11 +10,6 @@ ls
 cd vcs
 ls 
 
-# Hack, let's disable the Mozilla Pip repo
-# as we do have all things pinned down. 
-rm -f ~/.config/pip/pip.conf
-pip config --user set install.no-index 0 
-pip config debug
 
 
 # save the passed QT_Version
@@ -24,6 +19,12 @@ BACKUP_QT_VERSION=${QT_VERSION}
 chmod +x ${MOZ_FETCHES_DIR}/miniconda.sh
 bash ${MOZ_FETCHES_DIR}/miniconda.sh -b -u -p .
 source bin/activate
+
+# Hack, let's disable the Mozilla Pip repo
+# as we do have all things pinned down. 
+rm -f ~/.config/pip/pip.conf
+pip config --user set install.no-index 0 
+pip config debug
 
 conda env create -f env.yml -n vpn
 conda activate vpn

--- a/taskcluster/scripts/toolchain/conda_pack_macos.sh
+++ b/taskcluster/scripts/toolchain/conda_pack_macos.sh
@@ -16,6 +16,16 @@ chmod +x ${MOZ_FETCHES_DIR}/miniconda.sh
 bash ${MOZ_FETCHES_DIR}/miniconda.sh -b -p ${TASK_WORKDIR}/miniconda
 source ${TASK_WORKDIR}/miniconda/bin/activate
 
+
+# Normally pip is locked down to only 
+# allow download from moz-pip mirror. 
+# The packages are firefox only and everything
+# we're going to fetch is pinned down, so 
+# let's remove that restriction for the current task. 
+rm -f ~/.config/pip/pip.conf
+pip config --user set install.no-index 0 
+pip config debug
+
 echo "Installing provided conda env..."
 conda env create -f ${VCS_PATH}/env.yml
 conda activate VPN
@@ -34,3 +44,6 @@ mkdir -p ${TASK_WORKDIR}/public/build
 conda-pack -p ${TASK_WORKDIR}/miniconda/envs/vpn -o ${TASK_WORKDIR}/public/build/conda-macos.tar.gz
 
 echo "Done."
+
+# remove our Pip conf, so the restrictions are back. 
+rm -f ~/.config/pip/pip.conf


### PR DESCRIPTION
## Description
It seems our machines now have recieved a global pip config restricting download from the moz-pip mirror.
```
ask 2024-04-15T16:32:39.715Z] env_var:
[task 2024-04-15T16:32:39.715Z] env:
[task 2024-04-15T16:32:39.715Z] global:
[task 2024-04-15T16:32:39.716Z]   /Library/Application Support/pip/pip.conf, exists: True
[task 2024-04-15T16:32:39.716Z]     install.no-index: true
[task 2024-04-15T16:32:39.716Z]     install.disable-pip-version-check: true
[task 2024-04-15T16:32:39.716Z]     install.find-links: 
[task 2024-04-15T16:32:39.716Z]     https://pypi.pub.build.mozilla.org/pub/
[task 2024-04-15T16:32:39.716Z]     install.trusted-host: 
[task 2024-04-15T16:32:39.716Z]     pypi.pub.build.mozilla.org
[task 2024-04-15T16:32:39.716Z]     global.disable-pip-version-check: true
[task 2024-04-15T16:32:39.717Z] site:
[task 2024-04-15T16:32:39.717Z]   /opt/worker/tasks/task_171210470794485/checkouts/vcs/pip.conf, exists: False
[task 2024-04-15T16:32:39.717Z] user:
[task 2024-04-15T16:32:39.717Z]   /Users/task_171210470794485/.pip/pip.conf, exists: False
[task 2024-04-15T16:32:39.717Z]   /Users/task_171210470794485/.config/pip/pip.conf, exists: True
[task 2024-04-15T16:32:39.717Z]     install.no-index: 0

```
Mac builds are failing but dependabot too. ` https://pypi.pub.build.mozilla.org/pub/`  see:https://firefox-ci-tc.services.mozilla.com/tasks/cdf3mYcsTz-Vh2_KNj2ntg/runs/0/logs/public/logs/live.log


The problem is, most of our dependencies are not on the internal pypi mirror. 
see: https://github.com/mozilla-mobile/mozilla-vpn-client/pull/9340
 
So whenever we would want to update the env, it will fail. 
Given we have pinned all our deps and download & cache them once in a packed-conda env, let's disable this for those tasks :) 

