### PR TITLE
No ticket: Remove en-US from constants urls

### DIFF
--- a/src/constants.h
+++ b/src/constants.h
@@ -194,7 +194,7 @@ constexpr const char* GOOGLE_SUBSCRIPTIONS_URL =
   inline type functionName() { return Constants::inProduction() ? prod : beta; }
 
 constexpr const char* MOZILLA_VPN_SUMO_URL =
-    "https://support.mozilla.org/en-US/products/firefox-private-network-vpn";
+    "https://support.mozilla.org/products/firefox-private-network-vpn";
 
 constexpr const char* SUMO_DNS =
     "https://support.mozilla.org/kb/how-do-i-change-my-dns-settings";
@@ -253,7 +253,7 @@ PRODBETAEXPR(qint64, keyRegeneratorTimeSec, 604800, 300);
 PRODBETAEXPR(QString, upgradeToAnnualUrl,
              "https://www.mozilla.org/products/vpn/"
              "?utm_medium=mozillavpn&utm_source=account#pricing",
-             "https://www-dev.allizom.org/en-US/products/vpn/"
+             "https://www-dev.allizom.org/products/vpn/"
              "?utm_medium=mozillavpn&utm_source=account#pricing")
 
 #undef PRODBETAEXPR


### PR DESCRIPTION
## Description
This PR removes references to 'en-US' from urls in `constants.h` so that folks visiting these pages from the client are presented the page content in the language their browser has been configured to use instead of in english by default. 


## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
