### PR TITLE
VPN-6251: fix backend logs

### DIFF
--- a/src/localsocketcontroller.cpp
+++ b/src/localsocketcontroller.cpp
@@ -194,11 +194,6 @@ void LocalSocketController::getBackendLogs(
 void LocalSocketController::cleanupBackendLogs() {
   logger.debug() << "Cleanup logs";
 
-  if (m_logCallback) {
-    m_logCallback("");
-    m_logCallback = nullptr;
-  }
-
   if (m_daemonState != eReady) {
     return;
   }


### PR DESCRIPTION
## Description

After a bunch of debugging, I realized that the problem went away when we didn't flush the logs.

And I remembered that I recently changed the behavior of log flushing, which would be why this is a recent bug: https://github.com/mozilla-mobile/mozilla-vpn-client/pull/9231 (It's me, hi, I'm the problem it's me)

Digging into *why* flushing logs caused the problem, it was because of a race condition between asking for backend logs and flushing the logs. We reset the `m_logCallback` after we get the daemon's response with backend logs (as we'd expect), but we also clear `m_logCallback` when asking to flush the logs. Since both requests were being made before the daemon returned with the backend logs, `m_logCallback` was null by the time we wanted to use it with the first request.

This chunk of code is in 3 spots in the class, and I don't believe it's necessary here. I can't think of any race issues that could arise from removing this chunk of code, but I'd ask reviewers to think through this and confirm. (I'm also happy to get on a call and talk through the logic together if you want.)

## Reference

VPN-6251

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
