### PR TITLE
VPN-6267 Respect Errors of DNSPingsender

### DIFF
--- a/src/connectionhealth.cpp
+++ b/src/connectionhealth.cpp
@@ -42,6 +42,10 @@ ConnectionHealth::ConnectionHealth() : m_dnsPingSender(QHostAddress()) {
 
   connect(&m_dnsPingSender, &DnsPingSender::recvPing, this,
           &ConnectionHealth::dnsPingReceived, Qt::QueuedConnection);
+  connect(&m_dnsPingSender, &DnsPingSender::criticalPingError, this, [this]() {
+    m_dnsPingInitialized = false;
+    m_dnsPingTimer.stop();
+  });
 
   connect(&m_dnsPingTimer, &QTimer::timeout, this, [this]() {
     m_dnsPingSequence++;
@@ -103,14 +107,13 @@ void ConnectionHealth::startIdle() {
   m_dnsPingInitialized = false;
   m_dnsPingLatency = PING_TIME_UNSTABLE_SEC * 1000;
 
-  m_dnsPingSender.start();
-  m_dnsPingTimer.start(PING_INTERVAL_IDLE_SEC * 1000);
-
-  // Send an initial ping right away.
-  m_dnsPingTimestamp = QDateTime::currentMSecsSinceEpoch();
-  m_dnsPingSender.sendPing(QHostAddress(PING_WELL_KNOWN_ANYCAST_DNS),
-                           m_dnsPingSequence);
-
+  if (m_dnsPingSender.start()) {
+    m_dnsPingTimer.start(PING_INTERVAL_IDLE_SEC * 1000);
+    // Send an initial ping right away.
+    m_dnsPingTimestamp = QDateTime::currentMSecsSinceEpoch();
+    m_dnsPingSender.sendPing(QHostAddress(PING_WELL_KNOWN_ANYCAST_DNS),
+                             m_dnsPingSequence);
+  }
   stopTimingDistributionMetric(m_stability);
 }
 

--- a/src/dnspingsender.cpp
+++ b/src/dnspingsender.cpp
@@ -59,13 +59,13 @@ DnsPingSender::DnsPingSender(const QHostAddress& source, QObject* parent)
 
 DnsPingSender::~DnsPingSender() { MZ_COUNT_DTOR(DnsPingSender); }
 
-void DnsPingSender::start() {
+bool DnsPingSender::start() {
   auto state = m_socket.state();
-  if (state != QAbstractSocket::UnconnectedState) {
+  if (true) {
     logger.info()
         << "Attempted to start UDP socket, but it's in an invalid state:"
         << state;
-    return;
+    return false;
   }
 
   bool bindResult = false;
@@ -77,22 +77,24 @@ void DnsPingSender::start() {
 
   if (!bindResult) {
     logger.error() << "Unable to bind UDP socket. Socket state:" << state;
-    return;
+    return false;
   }
 
   logger.debug() << "UDP socket bound to:"
                  << m_socket.localAddress().toString();
-  return;
+  return false;
 }
 
 void DnsPingSender::sendPing(const QHostAddress& dest, quint16 sequence) {
   if (dest.isNull()) {
+    emit criticalPingError();
     logger.error() << "Attempted to send DNS ping to invalid destination:"
                    << dest.toString() << "Ignoring.";
     return;
   }
 
   if (!m_socket.isValid()) {
+    emit criticalPingError();
     logger.error() << "Attempted to send DNS ping, but socket is invalid.";
     return;
   }

--- a/src/dnspingsender.cpp
+++ b/src/dnspingsender.cpp
@@ -61,7 +61,7 @@ DnsPingSender::~DnsPingSender() { MZ_COUNT_DTOR(DnsPingSender); }
 
 bool DnsPingSender::start() {
   auto state = m_socket.state();
-  if (true) {
+  if (state != QAbstractSocket::UnconnectedState) {
     logger.info()
         << "Attempted to start UDP socket, but it's in an invalid state:"
         << state;

--- a/src/dnspingsender.cpp
+++ b/src/dnspingsender.cpp
@@ -82,7 +82,7 @@ bool DnsPingSender::start() {
 
   logger.debug() << "UDP socket bound to:"
                  << m_socket.localAddress().toString();
-  return false;
+  return true;
 }
 
 void DnsPingSender::sendPing(const QHostAddress& dest, quint16 sequence) {

--- a/src/dnspingsender.h
+++ b/src/dnspingsender.h
@@ -19,7 +19,11 @@ class DnsPingSender final : public PingSender {
 
   void sendPing(const QHostAddress& dest, quint16 sequence) override;
 
-  void start();
+  /**
+   * Starts the Underlying socket, returns true
+   * if the PingSender is now ready to be used.
+   */
+  [[nodiscard]] bool start();
   void stop() { m_socket.close(); }
 
  private:


### PR DESCRIPTION
## Description

In the logs we see errors, however they are currently unhandled. 
So let's assume start as failable. Also we can now abort whenever something is wierd. 