### PR TITLE
VPN-6208 Enable Beetmover apt

### DIFF
--- a/taskcluster/kinds/beetmover-apt/kind.yml
+++ b/taskcluster/kinds/beetmover-apt/kind.yml
@@ -10,7 +10,7 @@ transforms:
     - taskgraph.transforms.task:transforms
 
 kind-dependencies:
-    - beetmover
+    - beetmover-promote
 
 tasks:
     push-to-gcr:

--- a/taskcluster/mozillavpn_taskgraph/transforms/beetmover_apt.py
+++ b/taskcluster/mozillavpn_taskgraph/transforms/beetmover_apt.py
@@ -22,13 +22,14 @@ def get_gcs_sources(dependent_task):
     if not destinations:
         return []
     assert len(destinations) == 1 # We only should expect one
+    destination = list(destinations.values())[0]
     # release_artifacts is a list of upstream artifacts 
     # i.e [{'type': 'file', 'name': 'public/build/mozillavpn.deb', 'path': '/builds/worker/artifacts/mozillavpn.deb'}]
     release_artifacts = dependent_task.attributes["release-artifacts"]
     if not release_artifacts:
         return []
 
-    gcs_path_prefix = urlparse(destinations[0]).path
+    gcs_path_prefix = urlparse(destination).path
     if gcs_path_prefix[0] == "/":
         gcs_path_prefix=gcs_path_prefix[1:]
     gcs_paths = []
@@ -42,7 +43,7 @@ def get_gcs_sources(dependent_task):
 
 
 ALLOWED_SHIPPING_PHASES = [
-#    "ship-client", - TODO: Disabled until https://mozilla-hub.atlassian.net/browse/VPN-6208 is resolved
+    "ship-client",
 #    "promote-client" - candidates are not setup yet.
 ]
 


### PR DESCRIPTION
## Description

From our side we have nothing that would block us to publish to the Mozilla APT instead of the PPA. 
So this pr (fixes my failed merge) and also enables beetmover-apt. 