### PR TITLE
VPN-6327: Remove server list info cards and associated strings

### DIFF
--- a/src/translations/strings.yaml
+++ b/src/translations/strings.yaml
@@ -73,12 +73,6 @@
 #
 
 serversView:
-  recommendedCardTitle:
-    value: Why are these locations recommended?
-    comment: Title of an expandable info card on the recommended servers list.
-  recommendedCardBody:
-    value: These locations are sorted by expected performance.
-    comment: Body text of an expandable info card on the recommended servers list.
   recommendedRefreshLabel:
     value: Refresh list
     comment: Accessible label for the button that triggers a refresh of the recommended servers list.
@@ -165,8 +159,6 @@ splittunnel:
 multiHopFeature:
   singleHopToggleCTA: Single-hop
   multiHopToggleCTA: Multi-hop
-  multiHopCardHeader: What is multi-hop VPN?
-  multiHopCardBody: Multi-hop VPN routes your traffic through two servers instead of one for extra security and privacy. This may slow down your connection.
   multiHopEntryLocationHeader: Select entry location
   multiHopExitLocationHeader: Select exit location
   multiHopInfoText: Exit location represents your main VPN server.

--- a/src/ui/screens/home/ViewMultiHop.qml
+++ b/src/ui/screens/home/ViewMultiHop.qml
@@ -44,20 +44,6 @@ StackView {
             anchors.rightMargin: MZTheme.theme.windowMargin / 2
             spacing: MZTheme.theme.vSpacing
 
-            MZCollapsibleCard {
-                title: MZI18n.MultiHopFeatureMultiHopCardHeader
-
-                iconSrc: "qrc:/ui/resources/tip.svg"
-                contentItem: MZTextBlock {
-                    text: MZI18n.MultiHopFeatureMultiHopCardBody
-                    textFormat: Text.StyledText
-                    Layout.fillWidth: true
-                }
-                Layout.alignment: Qt.AlignHCenter
-                Layout.preferredWidth: parent.width - MZTheme.theme.windowMargin
-                visible: !MZFeatureList.get("helpSheets").isSupported
-            }
-
             RecentConnections {
                 Layout.fillWidth: true
                 showMultiHopRecentConnections: true

--- a/src/ui/screens/home/servers/ServerList.qml
+++ b/src/ui/screens/home/servers/ServerList.qml
@@ -156,20 +156,6 @@ FocusScope {
                         right: parent.right
                     }
 
-                    MZCollapsibleCard {
-                        anchors.horizontalCenter: parent.horizontalCenter
-
-                        iconSrc: "qrc:/ui/resources/tip.svg"
-                        contentItem: MZTextBlock {
-                            text: MZI18n.ServersViewRecommendedCardBody
-                            textFormat: Text.StyledText
-                            Layout.fillWidth: true
-                        }
-                        title: MZI18n.ServersViewRecommendedCardTitle
-                        width: parent.width - MZTheme.theme.windowMargin * 2
-                        visible: !MZFeatureList.get("helpSheets").isSupported
-                    }
-
                     // Status component
                     // TODO: Refresh server list and handle states
                     MZClickableRow {


### PR DESCRIPTION
## Description

The collapsible info cards in the server lists are a thing of the past now that we have help sheets. This PR removes them from the server list views.

## Reference

VPN-6327

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
