### PR TITLE
VPN-6306: Fix what's new addon message to match Figma

### DIFF
--- a/addons/message_whats_new_v2.22/manifest.json
+++ b/addons/message_whats_new_v2.22/manifest.json
@@ -19,17 +19,17 @@
     "notify": false,
     "blocks": [
       {
-        "id": "c_1-1",
+        "id": "c_1-2",
         "type": "text",
         "content": "This update includes minor bug fixes, UI adjustments and other performance improvements."
       },
       {
-        "id": "c_1-2",
+        "id": "c_1-3",
         "type": "text",
         "content": "It also introduces a new option to reset Mozilla VPN to its default settings. This can be helpful if you’re experiencing instability or crashes with the application, and other troubleshooting steps haven’t resolved the issue."
       },
       {
-        "id": "c_1-3",
+        "id": "c_1-4",
         "type": "text",
         "content": "How to reset Mozilla VPN:"
       },

--- a/addons/message_whats_new_v2.22/manifest.json
+++ b/addons/message_whats_new_v2.22/manifest.json
@@ -26,7 +26,7 @@
       {
         "id": "c_1-2",
         "type": "text",
-        "content": "It also introduces a new option to reset Mozilla VPN to its default settings. This can be helpful if you're experiencing instability or crashes with the application, and other troubleshooting steps haven't resolved the issue."
+        "content": "It also introduces a new option to reset Mozilla VPN to its default settings. This can be helpful if you’re experiencing instability or crashes with the application, and other troubleshooting steps haven’t resolved the issue."
       },
       {
         "id": "c_1-3",

--- a/addons/message_whats_new_v2.22/manifest.json
+++ b/addons/message_whats_new_v2.22/manifest.json
@@ -21,7 +21,35 @@
       {
         "id": "c_1-1",
         "type": "text",
-        "content": "This update includes a new factory reset feature, in addition to minor bug fixes, UI adjustments and other performance improvements."
+        "content": "This update includes minor bug fixes, UI adjustments and other performance improvements."
+      },
+      {
+        "id": "c_1-2",
+        "type": "text",
+        "content": "It also introduces a new option to reset Mozilla VPN to its default settings. This can be helpful if you're experiencing instability or crashes with the application, and other troubleshooting steps haven't resolved the issue."
+      },
+      {
+        "id": "c_1-3",
+        "type": "text",
+        "content": "How to reset Mozilla VPN:"
+      },
+      {
+        "id": "c_2",
+        "type": "olist",
+        "content": [
+          {
+            "id": "l_1",
+            "content": "Click or tap on the gear icon to access Settings."
+          },
+          {
+            "id": "l_2",
+            "content": "Navigate to the Get help section."
+          },
+          {
+            "id": "l_3",
+            "content": "Look for the new Reset VPN option and follow the on-screen instructions."
+          }
+        ]
       },
       {
         "id": "c_3",


### PR DESCRIPTION
## Description
In my last attempt to author a "What's New" addon message, I neglected to check the figma docs and got the strings completely wrong. This should attempt to set the strings right and get us as close to the Figma file as possible.

There is a small discrepancy in that we have a paragraph separating `How to reset Mozilla VPN:` and the ordered list which follows, as I don't think we can create a text block that includes an ordered list, so they wound up as separate blocks.

## Reference
JIRA issue: [VPN-6306](https://mozilla-hub.atlassian.net/browse/VPN-6306)
Figma designs: [here](https://www.figma.com/file/Disx2dX7tw81NQIN39BrYo/In-app-Messaging?type=design&node-id=2979-430&mode=design&t=RqBsLawIkiVWea7c-0)
Previous attempt: #9395

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-6306]: https://mozilla-hub.atlassian.net/browse/VPN-6306?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ