### PR TITLE
VPN-6307: Fix update message to match Figma

### DIFF
--- a/addons/message_update_v2.22/manifest.json
+++ b/addons/message_update_v2.22/manifest.json
@@ -11,15 +11,38 @@
   },
   "message": {
     "date": 1713466835,
-    "id": "message_update_v2.22",
+    "id": "message_update_v2.22-0",
     "title": "Update to Mozilla VPN 2.22",
-    "subtitle": "We’ve released an updated version of Mozilla VPN! Update to the latest version for the best possible Mozilla VPN experience.",
+    "subtitle": "We’ve released an updated version of Mozilla VPN! Update to the latest version for the best possible Mozilla VPN experience. This update includes minor bug fixes, UI adjustments and other performance improvements.",
     "badge": "new_update",
     "blocks": [
       {
-        "id": "c_1-1",
+        "id": "c_1-2",
         "type": "text",
-        "content": "This update includes a new factory reset feature, in addition to minor bug fixes, UI adjustments and other performance improvements."
+        "content": "It also introduces a new option to reset Mozilla VPN to its default settings. This can be helpful if you’re experiencing instability or crashes with the application, and other troubleshooting steps haven’t resolved the issue."
+      },
+      {
+        "id": "c_1-3",
+        "type": "text",
+        "content": "How to reset Mozilla VPN:"
+      },
+      {
+        "id": "c_2",
+        "type": "olist",
+        "content": [
+          {
+            "id": "l_1",
+            "content": "Click or tap on the gear icon to access Settings."
+          },
+          {
+            "id": "l_2",
+            "content": "Navigate to the Get help section."
+          },
+          {
+            "id": "l_3",
+            "content": "Look for the new Reset VPN option and follow the on-screen instructions."
+          }
+        ]
       },
       {
         "id": "c_3",


### PR DESCRIPTION
## Description
In my haste to get the "Update" addon messages out the door, I neglected to check my work against the Figma file, and I must shamefully admit that I got the content of the strings completely wrong. This PR attempts to update the strings accordingly to match the design documents. 

There is a small discrepancy in that we have a paragraph separating `How to reset Mozilla VPN:` and the ordered list which follows, as I don't think we can create a text block that includes an ordered list, so they wound up as separate blocks.

## Reference
JIRA issue: [VPN-6307](https://mozilla-hub.atlassian.net/browse/VPN-6307)
Figma designs: [here](https://www.figma.com/file/Disx2dX7tw81NQIN39BrYo/In-app-Messaging?type=design&node-id=2979-430&mode=design&t=RqBsLawIkiVWea7c-0)
Previous attempt: #9396

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-6307]: https://mozilla-hub.atlassian.net/browse/VPN-6307?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ