### PR TITLE
No ticket: Fix QML console warnings

### DIFF
--- a/nebula/ui/components/MZCheckBox.qml
+++ b/nebula/ui/components/MZCheckBox.qml
@@ -6,6 +6,9 @@ import QtQuick 2.5
 import QtQuick.Controls 2.14
 import QtQuick.Layouts 1.14
 
+// https://bugreports.qt.io/browse/QTBUG-109438
+import QtQuick.Controls.Basic
+
 import Mozilla.Shared 1.0
 import "qrc:/nebula/utils/MZUiUtils.js" as MZUiUtils
 

--- a/nebula/ui/components/MZSettingsToggle.qml
+++ b/nebula/ui/components/MZSettingsToggle.qml
@@ -5,6 +5,9 @@
 import QtQuick 2.0
 import QtQuick.Controls 2.5
 
+// Workaround for https://bugreports.qt.io/browse/QTBUG-109438
+import QtQuick.Controls.Basic
+
 import Mozilla.Shared 1.0
 import "qrc:/nebula/utils/MZUiUtils.js" as MZUiUtils
 

--- a/nebula/ui/components/forms/MZComboBox.qml
+++ b/nebula/ui/components/forms/MZComboBox.qml
@@ -6,6 +6,9 @@ import QtQuick 2.5
 import QtQuick.Controls 2.14
 import QtQuick.Layouts 1.14
 
+// https://bugreports.qt.io/browse/QTBUG-109438
+import QtQuick.Controls.Basic
+
 import Mozilla.Shared 1.0
 import compat 0.1
 import components 0.1

--- a/nebula/ui/components/forms/MZInputBackground.qml
+++ b/nebula/ui/components/forms/MZInputBackground.qml
@@ -4,6 +4,9 @@
 
 import QtQuick 2.5
 
+// https://bugreports.qt.io/browse/QTBUG-109438
+import QtQuick.Controls.Basic
+
 import Mozilla.Shared 1.0
 import components 0.1
 

--- a/nebula/ui/components/forms/MZTextArea.qml
+++ b/nebula/ui/components/forms/MZTextArea.qml
@@ -6,6 +6,9 @@ import QtQuick 2.0
 import QtQuick.Controls 2.14
 import QtQuick.Layouts 1.14
 
+// https://bugreports.qt.io/browse/QTBUG-109438
+import QtQuick.Controls.Basic
+
 import Mozilla.Shared 1.0
 import components 0.1
 import "qrc:/nebula/utils/MZUiUtils.js" as MZUiUtils

--- a/nebula/ui/components/forms/MZTextField.qml
+++ b/nebula/ui/components/forms/MZTextField.qml
@@ -6,6 +6,9 @@ import QtQuick 2.15
 import QtQuick.Controls 2.14
 import QtQuick.Layouts 1.14
 
+// https://bugreports.qt.io/browse/QTBUG-109438
+import QtQuick.Controls.Basic
+
 import Mozilla.Shared 1.0
 import components 0.1
 import "qrc:/nebula/utils/MZUiUtils.js" as MZUiUtils


### PR DESCRIPTION
## Description

While investigating what has ruffled our Android build's proverbial feathers in v2.21, I noticed the console complaining loudly over every appearance of an MZSettingsToggle {}. 
This PR fixes `Warning: qrc:/nebula/components/MZSettingsToggle.qml:172:17: QML MZUIStates: The current style does not support customization of this control (property: "indicator" item: MZUIStates_QMLTYPE_9(0x60000330ebc0, parent=0x0, geometry=0,0 0x0, z=-1)). Please customize a non-native style (such as Basic, Fusion, Material, etc).` and `Warning: qrc:/nebula/components/MZSettingsToggle.qml:24:5: Unable to assign [undefined] to int (MZSettingsToggle.qml:24)`. 

🪐 **UPDATE:**  After more clicking around I realized these warnings are triggered other input components as well. Second commit addresses these as well. 

Related Qt bug: https://bugreports.qt.io/browse/QTBUG-109438

 

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
