### PR TITLE
No ticket: Fix layout related console warnings in ViewPreferences.qml

### DIFF
--- a/src/ui/screens/settings/ViewPreferences.qml
+++ b/src/ui/screens/settings/ViewPreferences.qml
@@ -110,11 +110,12 @@ MZViewBase {
 
         ColumnLayout {
             spacing: MZTheme.theme.windowMargin / 2
-            width: parent.width
+            Layout.alignment: Qt.AlignHCenter
+            Layout.leftMargin: MZTheme.theme.windowMargin / 2
+            Layout.rightMargin: MZTheme.theme.windowMargin / 2
+
             MZSettingsItem {
                 objectName: "settingsNotifications"
-                anchors.left: parent.left
-                anchors.right: parent.right
 
                 settingTitle: _notificationsTitle
                 imageLeftSrc: "qrc:/ui/resources/settings/notifications.svg"
@@ -129,14 +130,10 @@ MZViewBase {
                     stackview.push("qrc:/ui/screens/settings/ViewNotifications.qml")
                 }
                 visible: MZFeatureList.get("captivePortal").isSupported || MZFeatureList.get("unsecuredNetworkNotification").isSupported || MZFeatureList.get("notificationControl").isSupported
-                width: parent.width - MZTheme.theme.windowMargin
             }
 
             MZSettingsItem {
                 objectName: "settingsLanguages"
-
-                anchors.left: parent.left
-                anchors.right: parent.right
 
                 settingTitle: _languageTitle
                 imageLeftSrc: "qrc:/ui/resources/settings/language.svg"
@@ -147,14 +144,10 @@ MZViewBase {
                     stackview.push("qrc:/ui/screens/settings/ViewLanguage.qml")
                 }
                 visible: MZLocalizer.hasLanguages
-                width: parent.width - MZTheme.theme.windowMargin
             }
 
             MZSettingsItem {
                 objectName: "dnsSettings"
-
-                anchors.left: parent.left
-                anchors.right: parent.right
 
                 settingTitle: MZI18n.SettingsDnsSettings
                 imageLeftSrc: "qrc:/ui/resources/settings/dnssettings.svg"
@@ -164,7 +157,6 @@ MZViewBase {
                     Glean.interaction.dnsSettingsSelected.record({screen:telemetryScreenId})
                     stackview.push("qrc:/ui/screens/settings/ViewDNSSettings.qml")
                 }
-                width: parent.width - MZTheme.theme.windowMargin
             }
         }
     }


### PR DESCRIPTION
## Description

This PR addresses the following QML warnings in ViewPreferences.qml

```
[22.04.2024 16:46:57.653] Warning: qrc:/ui/screens/settings/ViewPreferences.qml:114:13: QML MZSettingsItem: Detected anchors on an item that is managed by a layout. This is undefined behavior; use Layout.alignment instead. (ViewPreferences.qml:114)
[22.04.2024 16:46:57.653] Warning: qrc:/ui/screens/settings/ViewPreferences.qml:135:13: QML MZSettingsItem: Detected anchors on an item that is managed by a layout. This is undefined behavior; use Layout.alignment instead. (ViewPreferences.qml:135)
[22.04.2024 16:46:57.653] Warning: qrc:/ui/screens/settings/ViewPreferences.qml:153:13: QML MZSettingsItem: Detected anchors on an item that is managed by a layout. This is undefined behavior; use Layout.alignment instead. (ViewPreferences.qml:153)
[22.04.2024 16:46:57.655] Warning: qrc:/nebula/components/forms/MZContextualAlert.qml:20:5: Unable to assign [undefined] to bool (MZContextualAlert.qml:20)
```
These warnings were caused by anchor properties assigned to children (in this case, MZSettingsItem) of a ColumnLayout. Children of Layouts need to use [specific properties](https://doc.qt.io/qt-6/qml-qtquick-layouts-layout.html) (and not anchors) to position themselves within a Layout or face unexpected behavior and console complaints.

VPN-6388 
## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
