### PR TITLE
VPN-6333 Bump BillingLib from 5.2.0 to 5.2.1 

### DIFF
--- a/android/vpnClient/build.gradle
+++ b/android/vpnClient/build.gradle
@@ -91,7 +91,7 @@ dependencies {
 
     implementation SharedDependencies.androidx_core
     implementation "com.android.installreferrer:installreferrer:2.2"
-    implementation "com.android.billingclient:billing-ktx:5.2.0"
+    implementation "com.android.billingclient:billing-ktx:5.2.1"
     implementation "com.google.android.gms:play-services-ads-identifier:17.0.1"
     implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.4.1"
 


### PR DESCRIPTION
## Description
We reverted to 5.2.0 due to a crash. 
>I tried to add the desugar_jdk_libs with the right version as dependecy to the vpnClient project, but then I get the error "Execution failed for DexingNoClasspathTransform". 

Well now those deps have been upgraded to the latest one (thanks @brizental ) , i just tired bumping the version, iAP works fine now :) 
