### PR TITLE
NIT: Update Compiler for macosTests

### DIFF
--- a/.github/workflows/macos_tests.yaml
+++ b/.github/workflows/macos_tests.yaml
@@ -45,7 +45,10 @@ jobs:
         run: |
           wget https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/mozillavpn.v2.mozillavpn.cache.level-3.toolchains.v3.qt-mac.latest/artifacts/public%2Fbuild%2Fqt6_mac.zip -O qt6_mac.zip
           unzip -a -d ${{ github.workspace }} qt6_mac.zip
-
+      # Change Xcode?
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest
       - name: Compile test client
         run: |
           conda info --envs

--- a/.github/workflows/macos_tests.yaml
+++ b/.github/workflows/macos_tests.yaml
@@ -57,8 +57,8 @@ jobs:
           mkdir -p build/cmake
           cmake -S $(pwd) -B build/cmake -GNinja \
             -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-            -DCC=$CONDA_PREFIX/bin/clang \
-            -DCXX=$CONDA_PREFIX/bin/clang \
+            -DCMAKE_C_COMPILER=$CONDA_PREFIX/bin/clang \
+            -DCMAKE_CXX_COMPILER=$CONDA_PREFIX/bin/clang++ \
             -DCMAKE_PREFIX_PATH=${{ github.workspace }}/qt_dist/lib/cmake
 
           cmake --build build/cmake -j$(nproc) --target dummyvpn

--- a/.github/workflows/macos_tests.yaml
+++ b/.github/workflows/macos_tests.yaml
@@ -55,7 +55,7 @@ jobs:
           echo "!!!!!!!!!!"
 
           mkdir -p build/cmake
-          cmake -S $(pwd) -B build/cmake -GNinja 
+          cmake -S $(pwd) -B build/cmake -GNinja \
             -DCMAKE_BUILD_TYPE=RelWithDebInfo \
             -DCC=$CONDA_PREFIX/bin/clang \
             -DCXX=$CONDA_PREFIX/bin/clang \

--- a/.github/workflows/macos_tests.yaml
+++ b/.github/workflows/macos_tests.yaml
@@ -7,7 +7,7 @@ on:
   pull_request:
     branches:
       - main
-      - "releases/**"
+      - "**"
 
 # Restrict tests to the most recent commit.
 concurrency:

--- a/.github/workflows/macos_tests.yaml
+++ b/.github/workflows/macos_tests.yaml
@@ -55,8 +55,12 @@ jobs:
           echo "!!!!!!!!!!"
 
           mkdir -p build/cmake
-          cmake -S $(pwd) -B build/cmake -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+          cmake -S $(pwd) -B build/cmake -GNinja 
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DCC=$CONDA_PREFIX/bin/clang \
+            -DCXX=$CONDA_PREFIX/bin/clang \
             -DCMAKE_PREFIX_PATH=${{ github.workspace }}/qt_dist/lib/cmake
+
           cmake --build build/cmake -j$(nproc) --target dummyvpn
           cp ./build/cmake/tests/dummyvpn/dummyvpn build/
           cp -r ./build/cmake/tests/dummyvpn/addons build/addons

--- a/taskcluster/kinds/source-test/clang.yml
+++ b/taskcluster/kinds/source-test/clang.yml
@@ -43,6 +43,7 @@ clang-tidy-android:
       command: >-
         source $TASK_WORKDIR/fetches/bin/activate &&
         conda-unpack &&
+        unset CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER && 
         git submodule update --init --recursive && 
         $QTPATH/bin/qt-cmake \
           -DQT_HOST_PATH=$QT_HOST_PATH \
@@ -54,7 +55,6 @@ clang-tidy-android:
           -DBUILD_TESTS=OFF \
           -GNinja \
           -S . -B .tmp/ &&
-        unset CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER && 
         cmake --build .tmp --target clang_tidy_report &&
         mkdir -p /builds/worker/artifacts/ &&
         cp .tmp/clang-tidy/* /builds/worker/artifacts/


### PR DESCRIPTION
## Description

Looking at #9351 - it seems only gh actions on macos is failing to link this binary now with modules 🤔 - Also it is using an older version of apple-clang than we use on taskcluster. Ofc, i'd prefer it to use clang from the conda env, so we can update it in one place :) 
