### PR TITLE
Reconnect VPN when rebooting or process is killed

### DIFF
--- a/src/commands/commandui.cpp
+++ b/src/commands/commandui.cpp
@@ -403,7 +403,7 @@ int CommandUI::run(QStringList& tokens) {
       Navigator::instance()->requestDeepLink(url);
     }
     // Whenever the Client is re-opened with a new url
-    // pass that to the navigaot
+    // pass that to the navigator
     QObject::connect(
         AndroidVPNActivity::instance(), &AndroidVPNActivity::onOpenedWithUrl,
         [](QUrl url) { Navigator::instance()->requestDeepLink(url); });


### PR DESCRIPTION
## Description

To reactivate the network extension process, we set up a rule to always use the VPN. We must remove this rule when the user disconnects the VPN via the app.

This means that auto-connect on reboot is active for iOS, with no user option to turn it off. (If the VPN is off when rebooting it will remain off when the phone reboots.)

The user can access both the VPN toggle and "Connect On Demand" in iOS system settings. If a user toggles off the VPN from system settings without toggling "Connect On Demand", the VPN will immediately reconnect. I don't believe there is any way to move the auto connect logic into the system extension (turning it off somewhere in `stopTunnel`), so I think there is no way around this. Once the PR is merged, I'll let our support colleagues know (in the rare case people write in about this).

This PR is similar to https://github.com/mozilla-mobile/mozilla-vpn-client/pull/4897/, though this one is far simpler because there is no user option to disable this functionality. (To ensure it reconnects when the process is ended, we need to always force this to be true - hence the lack of user option.)

## Reference

VPN-6065, VPN-3113, VPN-4230

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
