### PR TITLE
Cherry-pick VPN-6333: Bump Android billinglib to v5.2.1

### DIFF
--- a/android/vpnClient/build.gradle
+++ b/android/vpnClient/build.gradle
@@ -91,7 +91,7 @@ dependencies {
 
     implementation SharedDependencies.androidx_core
     implementation "com.android.installreferrer:installreferrer:2.2"
-    implementation "com.android.billingclient:billing-ktx:5.2.0"
+    implementation "com.android.billingclient:billing-ktx:5.2.1"
     implementation "com.google.android.gms:play-services-ads-identifier:17.0.1"
     implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.4.1"
 


### PR DESCRIPTION
## Description
Cherry-pick of PR #9424 to the `releases/2.22.0` branch in order to unblock release candidate uploads to Google Play.

## Reference
JIRA issue: [VPN-6333](https://mozilla-hub.atlassian.net/browse/VPN-6333)
Github PR #9424

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-6333]: https://mozilla-hub.atlassian.net/browse/VPN-6333?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ