### PR TITLE
VPN-6340 Remove Multithreading Footgun

### DIFF
--- a/src/platforms/android/androidcommons.cpp
+++ b/src/platforms/android/androidcommons.cpp
@@ -73,21 +73,15 @@ void AndroidCommons::initializeGlean(bool isTelemetryEnabled,
                               ? settingsHolder->gleanDebugTag()
                               : "";
 
-  runOnAndroidThreadSync([isTelemetryEnabled, channel, gleanDebugTag]() {
-    QJniObject::callStaticMethod<void>(
-        COMMON_UTILS_CLASS, "initializeGlean",
-        "(Landroid/content/Context;ZLjava/lang/String;Ljava/lang/String;)V",
-        getActivity().object(), (jboolean)isTelemetryEnabled,
-        QJniObject::fromString(channel).object(),
-        QJniObject::fromString(gleanDebugTag).object());
-  });
-}
-
-// static
-void AndroidCommons::runOnAndroidThreadSync(
-    const std::function<void()> runnable) {
-  QNativeInterface::QAndroidApplication::runOnAndroidMainThread(runnable)
-      .waitForFinished();
+  QNativeInterface::QAndroidApplication::runOnAndroidMainThread(
+      [isTelemetryEnabled, channel, gleanDebugTag]() {
+        QJniObject::callStaticMethod<void>(
+            COMMON_UTILS_CLASS, "initializeGlean",
+            "(Landroid/content/Context;ZLjava/lang/String;Ljava/lang/String;)V",
+            getActivity().object(), (jboolean)isTelemetryEnabled,
+            QJniObject::fromString(channel).object(),
+            QJniObject::fromString(gleanDebugTag).object());
+      });
 }
 
 // static

--- a/src/platforms/android/androidcommons.h
+++ b/src/platforms/android/androidcommons.h
@@ -30,8 +30,6 @@ class AndroidCommons final : public QObject {
 
   static void initializeGlean(bool isTelemetryEnabled, const QString& channel);
 
-  static void runOnAndroidThreadSync(const std::function<void()> runnable);
-
   static void dispatchToMainThread(std::function<void()> callback);
 };
 

--- a/src/platforms/android/androidiaphandler.cpp
+++ b/src/platforms/android/androidiaphandler.cpp
@@ -4,6 +4,7 @@
 
 #include "androidiaphandler.h"
 
+#include <QCoreApplication>
 #include <QJniEnvironment>
 #include <QJniObject>
 #include <QJsonArray>
@@ -56,7 +57,7 @@ void AndroidIAPHandler::maybeInit() {
                                      appContext.object());
 
   // Hook together implementations for functions called by native code
-  AndroidCommons::runOnAndroidThreadSync([]() {
+  QNativeInterface::QAndroidApplication::runOnAndroidMainThread([]() {
     JNINativeMethod methods[]{
         // Failures
         {"onBillingNotAvailable", "(Ljava/lang/String;)V",
@@ -83,8 +84,7 @@ void AndroidIAPHandler::maybeInit() {
     }
     env->RegisterNatives(objectClass, methods,
                          sizeof(methods) / sizeof(methods[0]));
-  });
-  m_init = true;
+  }).then([this]() { m_init = true; });
 }
 
 void AndroidIAPHandler::nativeRegisterProducts() {

--- a/src/platforms/android/androidvpnactivity.cpp
+++ b/src/platforms/android/androidvpnactivity.cpp
@@ -28,7 +28,7 @@ Logger logger("AndroidVPNActivity");
 }  // namespace
 
 AndroidVPNActivity::AndroidVPNActivity() {
-  AndroidCommons::runOnAndroidThreadSync([]() {
+  QNativeInterface::QAndroidApplication::runOnAndroidMainThread([]() {
     // Hook in the native implementation for startActivityForResult into the JNI
     JNINativeMethod methods[]{
         {"handleBackButton", "()Z", reinterpret_cast<bool*>(handleBackButton)},
@@ -188,10 +188,11 @@ void AndroidVPNActivity::onAppStateChange() {
   // those screens.
   auto state = MozillaVPN::instance()->state();
   bool isSensitive = state == App::StateAuthenticating;
-  AndroidCommons::runOnAndroidThreadSync([isSensitive]() {
-    QJniObject::callStaticMethod<void>(CLASSNAME, "setScreenSensitivity",
-                                       "(Z)V", isSensitive);
-  });
+  QNativeInterface::QAndroidApplication::runOnAndroidMainThread(
+      [isSensitive]() {
+        QJniObject::callStaticMethod<void>(CLASSNAME, "setScreenSensitivity",
+                                           "(Z)V", isSensitive);
+      });
 }
 
 QUrl AndroidVPNActivity::getOpenerURL() {


### PR DESCRIPTION
## Description

`runOnAndroidThreadSync` was a thing in Qt5, so obviously when upgrading we just replaced it with `AndroidCommons::runOnAndroidThreadSync`. 

This obviously can lead to deadlocks, i.e if we're waiting to run a task on the main thread but i.e an Accessbility Service is trying to read the screen info from the Qt Thread. 
None of the callsites actually require the code to be run in sync, so it's better for the callsites to use the QFuture returned and decide what to do :) 

