### PR TITLE
Update RPM build to Fedora 40

### DIFF
--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -91,7 +91,7 @@ jobs:
     needs: source-bundle
     runs-on: ubuntu-latest
     container:
-      image: fedora:39
+      image: fedora:40
 
     steps:
       - name: Download Source Package

--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -101,6 +101,7 @@ jobs:
 
       - name: Install Build Dependencies
         run: |
+          dnf -y update
           dnf -y install rpmdevtools 'dnf-command(builddep)'
           dnf -y builddep mozillavpn.spec
 


### PR DESCRIPTION
Fedora 40 was released on 2024-04-23,
cf. https://discussion.fedoraproject.org/t/announcing-fedora-linux-40/114034

Current builds (tried `mozillavpn-2.23.0~build20240425-1.x86_64`
downloaded from https://github.com/mozilla-mobile/mozilla-vpn-client/actions/runs/8833883299)
depend upon `libQt6Qml.so.6(Qt_6.6_PRIVATE_API)(64bit)` but since
Fedora 40 is on Qt 6.7 no current package provides that symbol.