### PR TITLE
VPN-6228: Don't deactivate during silent server switches

### DIFF
--- a/src/connectionhealth.cpp
+++ b/src/connectionhealth.cpp
@@ -93,7 +93,6 @@ void ConnectionHealth::stop() {
   m_dnsPingTimer.stop();
 
   stopTimingDistributionMetric(m_stability);
-  setStability(Stable);
 }
 
 void ConnectionHealth::startActive(const QString& serverIpv4Gateway,
@@ -343,8 +342,6 @@ void ConnectionHealth::stopTimingDistributionMetric(
       mozilla::glean::connection_health::stable_time.stopAndAccumulate(
           m_metricsTimerId);
   }
-  m_metricsTimerId = -1;  // used as a signal to prevent turning it off twice
-                          // when ConnectionHealth moves between idle and stop.
 #endif
 }
 

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -290,24 +290,9 @@ void Controller::handshakeTimeout() {
 }
 
 void Controller::serverUnavailable() {
-  logger.error() << "server unavailable";
+  logger.info() << "Server Unavailable - Ping succeeded: " << m_pingReceived;
 
-  // If VPN is already active and server location becomes unavailable we do not
-  // deactivate the VPN or proceed with next steps. We specifically do not want
-  // to deactivate the VPN in the case of server location becoming unavailable
-  // because the user may not notice that they are no longer protected which can
-  // cause the traffic to leak outside the tunnel without their knowledge.
-  if (m_state == StateOn || m_state == StateSilentSwitching || m_state == StateOnPartial) {
-    logger.info() << "Server location is unavailable in StateOn or "
-                     "StateSilentSwitching. Do not deactivate.";
-    return;
-  }
-
-  logger.info() << "Server location is unavailable and we are not in StateOn "
-                   "or StateSilentSwitching. Deactivate.";
-
-  m_nextStep = ServerUnavailable;
-  deactivate();
+  emit readyToServerUnavailable(m_pingReceived);
   return;
 }
 
@@ -804,13 +789,6 @@ bool Controller::processNextStep() {
 
   if (nextStep == BackendFailure) {
     emit readyToBackendFailure();
-    return true;
-  }
-
-  if (nextStep == ServerUnavailable) {
-    logger.info() << "Server Unavailable - Ping succeeded: " << m_pingReceived;
-
-    emit readyToServerUnavailable(m_pingReceived);
     return true;
   }
 

--- a/src/controller.h
+++ b/src/controller.h
@@ -197,7 +197,6 @@ class Controller : public QObject, public LogSerializer {
     Update,
     Disconnect,
     BackendFailure,
-    ServerUnavailable,
   };
 
   NextStep m_nextStep = None;

--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -2118,6 +2118,13 @@ void MozillaVPN::registerInspectorCommands() {
         return QJsonObject();
       });
 
+  InspectorHandler::registerCommand(
+      "force_silent_switch", "Force the VPN to silently switch servers", 0,
+      [](InspectorHandler*, const QList<QByteArray>&) {
+        MozillaVPN::instance()->silentSwitch();
+        return QJsonObject();
+      });
+
 #ifdef MZ_MACOS
   InspectorHandler::registerCommand(
       "force_daemon_crash", "Force the VPN daemon to crash", 0,

--- a/src/ui/main.qml
+++ b/src/ui/main.qml
@@ -172,6 +172,16 @@ Window {
             serverUnavailablePopup.receivedPing = receivedPing
             serverUnavailablePopup.open();
         }
+
+        function onStateChanged() {
+            if (VPNController.state !== VPNController.StateOn) {
+                return
+            }
+            if (serverUnavailablePopup.opened) {
+                serverUnavailablePopup.close();
+                console.log("Connection stabilized and server unavailable popup visible. Closing server unavailable popup");
+            }
+        }
     }
 
     MZBottomNavigationBar {

--- a/tests/unit/testconnectionhealth.cpp
+++ b/tests/unit/testconnectionhealth.cpp
@@ -128,8 +128,8 @@ void TestConnectionHealth::testTelemetry() {
 
   // Stops (stopping resets status to stable)
   connectionHealth.stop();
-  metricsTestErrorAndChange(2, 1, 1);
-  metricsTestCount(2, 1, 1);
+  metricsTestErrorAndChange(1, 1, 1);
+  metricsTestCount(1, 1, 1);
   metricsTestTimespan(1, 1, 1);
 }
 


### PR DESCRIPTION
## Description

In #8826 and #9174 a subscriber reports occasionally getting erroneously disconnected from the VPN (through no action of their own) and seeing the 'Server Unavailable' modal upon reopening the client. 

We hypothesize this is caused by the subscriber's connection becoming `Unstable`, whereupon we go into a silent server switch which fails sending us into the server unavailable routine and eventual disconnection. 

#8978 attempted to resolve this by adding logic to the server unavailable routine to check if the state is `StateSilentSwitching` or `StateOn` and bypassing the call the deactivate if so. This treatment was insufficient because, by the time we get to `ServerUnavailable`, the user is either in `StateConfirming` or `StateConnecting`. 

In this PR we remove the call to deactivate from the server unavailable routine entirely. This is in keeping with behavior outlined in this [PRD](https://mozilla-hub.atlassian.net/wiki/spaces/PXI/pages/130809909/Improve+our+handling+of+network+connectivity+issues) reiterating that we should never tear down the tunnel for any reason other than the subscriber has specifically clicked a button, or taken some action, to knowingly do so. 

Changed behavior:
- If we fail to connect, or reconnect after a silent server switch, we show the `ServerUnavailable` modal but do not deactivate the VPN. We stay in `NoSignal` and continue attempting to reestablish the connection.
- If the connection eventually succeeds and we move out of `NoSignal`, the `ServerUnavailable` modal will be hidden. 

There is a drawback: We could show the server unavailable modal when the failure is actually caused by something else (a lack of internet for example). But this is actually already the case. This PR is meant as a stop-gap ahead of future work to untangle the Controller and improve connection failure communication to the subscriber ([PRD](https://mozilla-hub.atlassian.net/wiki/spaces/PXI/pages/130809909/Improve+our+handling+of+network+connectivity+issues)).

VPN-6228

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
