### PR TITLE
VPN-6356: Fix assert in QTest::mouseEvent()

### DIFF
--- a/.github/workflows/wasm_tests.yaml
+++ b/.github/workflows/wasm_tests.yaml
@@ -38,12 +38,17 @@ jobs:
       - name: Install Qt6
         shell: bash
         run: |
-          # qt6.2.3 for wasm needs the desktop linux installation
+          # qt6.2.4 for wasm needs the desktop linux installation
           python -m aqt install-qt -O /opt linux desktop $QTVERSION
           python -m aqt install-qt -O /opt linux desktop $QTVERSION wasm_32 -m qtcharts qtwebsockets qt5compat
 
       - name: Setup emsdk
         uses: mymindstorm/setup-emsdk@v7
+        with:
+          # Emscripten does not guarantee ABI compatibility, we should use the
+          # same version used to build Qt. See:
+          # https://doc.qt.io/qt-6/wasm.html#installing-emscripten
+          version: 2.0.14
 
       - name: Compile test client
         shell: bash

--- a/nebula/ui/components/inAppAuth/MZInAppAuthenticationBase.qml
+++ b/nebula/ui/components/inAppAuth/MZInAppAuthenticationBase.qml
@@ -16,7 +16,6 @@ MZFlickable {
     property bool _changeEmailLinkVisible: false
     property bool _disclaimersVisible: true
     property bool _backButtonVisible: true
-    property string _viewObjectName: ""
 
     property alias _menuButtonImageSource: menuButtonImage.source
     property alias _menuButtonImageMirror: menuButtonImage.mirror
@@ -57,7 +56,7 @@ MZFlickable {
 
             MZIconButton {
                 id: menuButton
-                objectName: _viewObjectName + "-backButton"
+                objectName: authBase.objectName + "-backButton"
                 onClicked: _menuButtonOnClick()
                 Layout.preferredHeight: MZTheme.theme.rowHeight
                 Layout.preferredWidth: MZTheme.theme.rowHeight
@@ -74,7 +73,7 @@ MZFlickable {
 
             MZLinkButton {
                 id: headerLink
-                objectName: _viewObjectName + "-getHelpLink"
+                objectName: authBase.objectName + "-getHelpLink"
                 Layout.preferredHeight: menuButton.height
                 Layout.alignment: Qt.AlignRight
                 Layout.rightMargin: MZTheme.theme.windowMargin
@@ -142,7 +141,7 @@ MZFlickable {
                 }
 
                 Loader {
-                    objectName: _viewObjectName + "-changeEmail"
+                    objectName: authBase.objectName + "-changeEmail"
                     Layout.alignment: Qt.AlignHCenter
                     active: _changeEmailLinkVisible
                     visible: _changeEmailLinkVisible

--- a/nebula/ui/components/inAppAuth/MZInAppAuthenticationInputs.qml
+++ b/nebula/ui/components/inAppAuth/MZInAppAuthenticationInputs.qml
@@ -13,6 +13,7 @@ import components.forms 0.1
 
 ColumnLayout {
     id: base
+    property string _viewObjectName: ""
     property string _telemetryScreenId
     property string _telemetryButtonEventName
     property string _inputPlaceholderText: ""
@@ -55,7 +56,7 @@ ColumnLayout {
 
             MZTextField {
                 id: textInput
-                objectName: base.objectName + "-textInput"
+                objectName: base._viewObjectName + "-textInput"
                 width: base.width - (inputPasteButton.visible ? inputPasteButton.width - parent.spacing : 0)
                 height: MZTheme.theme.rowHeight
                 _placeholderText: _inputPlaceholderText
@@ -65,7 +66,7 @@ ColumnLayout {
 
             MZPasswordInput {
                 id: passwordInput
-                objectName: base.objectName + "-passwordInput"
+                objectName: base._viewObjectName + "-passwordInput"
                 _placeholderText: _inputPlaceholderText
                 Keys.onReturnPressed: col.submitInfo(passwordInput)
                 width: base.width - inputPasteButton.width - parent.spacing
@@ -75,7 +76,7 @@ ColumnLayout {
 
             MZPasteButton {
                 id: inputPasteButton
-                objectName: base.objectName + "-inputPasteButton"
+                objectName: base._viewObjectName + "-inputPasteButton"
                 width: MZTheme.theme.rowHeight
                 height: MZTheme.theme.rowHeight
                 onClicked: {
@@ -145,20 +146,20 @@ ColumnLayout {
 
                 MZInAppAuthenticationPasswordCondition {
                     id: passwordLength
-                    objectName: base.objectName + "-passwordConditionLength"
+                    objectName: base._viewObjectName + "-passwordConditionLength"
                     _iconVisible: true
                     _passwordConditionIsSatisfied: toolTip._isSignUp && MZAuthInApp.validatePasswordLength(passwordInput.text)
                     _passwordConditionDescription: MZI18n.InAppAuthPasswordHintCharacterLength
                 }
                 MZInAppAuthenticationPasswordCondition {
-                    objectName: base.objectName + "-passwordConditionEmailAddress"
+                    objectName: base._viewObjectName + "-passwordConditionEmailAddress"
                     _iconVisible: passwordLength._passwordConditionIsSatisfied
                     _passwordConditionIsSatisfied: toolTip._isSignUp && passwordLength._passwordConditionIsSatisfied && MZAuthInApp.validatePasswordEmail(passwordInput.text)
                     _passwordConditionDescription: MZI18n.InAppAuthPasswordHintEmailAddressAsPassword
                     opacity: passwordLength._passwordConditionIsSatisfied ? 1 : .5
                 }
                 MZInAppAuthenticationPasswordCondition {
-                    objectName: base.objectName + "-passwordConditionCommon"
+                    objectName: base._viewObjectName + "-passwordConditionCommon"
                     _iconVisible:  passwordLength._passwordConditionIsSatisfied
                     _passwordConditionIsSatisfied: toolTip._isSignUp && passwordLength._passwordConditionIsSatisfied && MZAuthInApp.validatePasswordCommons(passwordInput.text)
                     _passwordConditionDescription: MZI18n.InAppAuthPasswordHintCommonPassword
@@ -233,7 +234,7 @@ ColumnLayout {
 
     MZButton {
         id: btn
-        objectName: base.objectName + "-button"
+        objectName: base._viewObjectName + "-button"
         Layout.fillWidth: true
         loaderVisible:  MZAuthInApp.state === MZAuthInApp.StateCheckingAccount ||
                         MZAuthInApp.state === MZAuthInApp.StateSigningIn ||

--- a/nebula/ui/components/inAppAuth/MZInAppAuthenticationThirdParty.qml
+++ b/nebula/ui/components/inAppAuth/MZInAppAuthenticationThirdParty.qml
@@ -13,7 +13,6 @@ import components.forms 0.1
 MZFlickable {
     id: authThirdParty
 
-    property string _viewObjectName
     property string _telemetryScreenId
 
     property alias _imgSource: img.source
@@ -39,7 +38,7 @@ MZFlickable {
 
             MZLinkButton {
                 id: headerLink
-                objectName: _viewObjectName + "-getHelpLink"
+                objectName: authThirdParty.objectName + "-getHelpLink"
                 Layout.alignment: Qt.AlignRight
                 Layout.rightMargin: MZTheme.theme.windowMargin
                 labelText: MZI18n.GetHelpLinkTitle
@@ -74,7 +73,7 @@ MZFlickable {
 
             MZHeadline {
                 id: headline
-                objectName: _viewObjectName + "-headline"
+                objectName: authThirdParty.objectName + "-headline"
                 width: undefined
                 Layout.fillWidth: true
             }
@@ -100,7 +99,7 @@ MZFlickable {
             spacing: 24
 
             MZButton {
-                objectName: _viewObjectName + "-buttonSignIn"
+                objectName: authThirdParty.objectName + "-buttonSignIn"
                 text: MZI18n.InAppAuthContinueToSignIn
                 Layout.fillWidth: true
                 onClicked: {
@@ -109,7 +108,7 @@ MZFlickable {
             }
 
             MZCancelButton {
-                objectName: _viewObjectName + "-cancel"
+                objectName: authThirdParty.objectName + "-cancel"
                 Layout.alignment: Qt.AlignHCenter
                 onClicked: {
                     VPN.cancelAuthentication();

--- a/src/frontend/navigator.cpp
+++ b/src/frontend/navigator.cpp
@@ -298,7 +298,7 @@ void Navigator::requestPreviousScreen() {
 void Navigator::loadScreen(int screen, LoadPolicy loadPolicy,
                            QQmlComponent* component,
                            LoadingFlags loadingFlags) {
-  logger.debug() << "Loading screen" << screen;
+  logger.debug() << "Loading screen" << component->url().toString();
 
   if (screen == m_currentScreen) {
     logger.debug()

--- a/src/inspector/inspectorhandler.cpp
+++ b/src/inspector/inspectorhandler.cpp
@@ -358,17 +358,18 @@ static QList<InspectorCommand> s_commands{
                      [](InspectorHandler*, const QList<QByteArray>& arguments) {
                        QJsonObject obj;
 
+#ifndef MZ_WASM
                        // Ensure window rendering is finished.
                        QQuickWindow* window = qobject_cast<QQuickWindow*>(
-                          QmlEngineHolder::instance()->window());
+                           QmlEngineHolder::instance()->window());
                        QSignalSpy spy(window, &QQuickWindow::afterFrameEnd);
                        window->update();
                        if (!spy.isValid()) {
                          logger.debug() << "QSignalSpy is invalid";
+                       } else if (!spy.wait(150)) {
+                         logger.debug() << "Never got an afterFrameEnd signal";
                        }
-                       if (!spy.wait(150)) {
-                        logger.debug() << "Never got an afterFrameEnd signal";
-                       }
+#endif
 
                        QObject* qmlobj =
                            InspectorUtils::queryObject(arguments[1]);

--- a/src/inspector/inspectorhandler.cpp
+++ b/src/inspector/inspectorhandler.cpp
@@ -391,71 +391,70 @@ static QList<InspectorCommand> s_commands{
                        return obj;
                      }},
 
-    InspectorCommand{"scrollview", "Scroll a view until an item is centered", 2,
-                     [](InspectorHandler*, const QList<QByteArray>& arguments) {
-                       QJsonObject result;
+    InspectorCommand{
+        "scrollview", "Scroll a view until an item is centered", 2,
+        [](InspectorHandler*, const QList<QByteArray>& arguments) {
+          QJsonObject result;
 
-                       QObject* viewobj =
-                           InspectorUtils::queryObject(arguments[1]);
-                       if (!viewobj) {
-                         logger.error() << "Did not find view object";
-                         result["error"] = "Object not found";
-                         return result;
-                       }
-                       QQuickItem* view = qobject_cast<QQuickItem*>(viewobj);
-                       if (!view) {
-                         logger.error() << "View is not a QQuickItem object";
-                         result["error"] = "Object not found";
-                         return result;
-                       }
-                       const QMetaObject* viewMeta = view->metaObject();
-                       int scrollPropId = viewMeta->indexOfProperty("contentY");
-                       if (scrollPropId < 0) {
-                         logger.error() << "View is not scrollable";
-                         result["error"] = "View is not scrollable";
-                         return result;
-                       }
+          QObject* viewobj = InspectorUtils::queryObject(arguments[1]);
+          if (!viewobj) {
+            logger.error() << "Did not find view object";
+            result["error"] = "Object not found";
+            return result;
+          }
+          QQuickItem* view = qobject_cast<QQuickItem*>(viewobj);
+          if (!view) {
+            logger.error() << "View is not a QQuickItem object";
+            result["error"] = "Object not found";
+            return result;
+          }
+          const QMetaObject* viewMeta = view->metaObject();
+          int scrollPropId = viewMeta->indexOfProperty("contentY");
+          if (scrollPropId < 0) {
+            logger.error() << "View is not scrollable";
+            result["error"] = "View is not scrollable";
+            return result;
+          }
 
-                       QObject* targetobj =
-                           InspectorUtils::queryObject(arguments[2]);
-                       if (!targetobj) {
-                         logger.error() << "Did not find target object";
-                         result["error"] = "Object not found";
-                         return result;
-                       }
-                       QQuickItem* target = qobject_cast<QQuickItem*>(targetobj);
-                       if (!target) {
-                         logger.error() << "View is not a QQuickItem object";
-                         result["error"] = "Object not found";
-                         return result;
-                       }
+          QObject* targetobj = InspectorUtils::queryObject(arguments[2]);
+          if (!targetobj) {
+            logger.error() << "Did not find target object";
+            result["error"] = "Object not found";
+            return result;
+          }
+          QQuickItem* target = qobject_cast<QQuickItem*>(targetobj);
+          if (!target) {
+            logger.error() << "Target is not a QQuickItem object";
+            result["error"] = "Object not found";
+            return result;
+          }
 
-                       // Get the size of the view and calculate scroll limits.
-                       qreal current = view->property("contentY").toReal();
-                       qreal content = view->property("contentHeight").toReal();
-                       qreal height = view->property("height").toReal();
-                       qreal limit = (content > height) ? content - height : 0;
+          // Get the size of the view and calculate scroll limits.
+          qreal current = view->property("contentY").toReal();
+          qreal content = view->property("contentHeight").toReal();
+          qreal height = view->property("height").toReal();
+          qreal limit = (content > height) ? content - height : 0;
 
-                       // Get the vertical position, in the view's coordinates.
-                       QPointF center = target->boundingRect().center();
-                       qreal offset = target->mapToItem(view, center).y();
+          // Get the vertical position, in the view's coordinates.
+          QPointF center = target->boundingRect().center();
+          qreal offset = target->mapToItem(view, center).y();
 
-                       // Figure out how much to scroll to center the target.
-                       qreal contentY = current + offset - (height / 2);
-                       if (contentY < 0) contentY = 0;
-                       if (contentY > limit) contentY = limit;
+          // Figure out how much to scroll to center the target.
+          qreal contentY = current + offset - (height / 2);
+          if (contentY < 0) contentY = 0;
+          if (contentY > limit) contentY = limit;
 
-                       // Scroll the view.
-                       QMetaProperty prop = viewMeta->property(scrollPropId);
-                       Q_ASSERT(prop.isValid());
-                       if (!prop.write(view, QVariant::fromValue(contentY))) {
-                         logger.error() << "Could not write property contentY";
-                         result["error"] = "Could not write property contentY";
-                         return result;
-                       }
+          // Scroll the view.
+          QMetaProperty prop = viewMeta->property(scrollPropId);
+          Q_ASSERT(prop.isValid());
+          if (!prop.write(view, QVariant::fromValue(contentY))) {
+            logger.error() << "Could not write property contentY";
+            result["error"] = "Could not write property contentY";
+            return result;
+          }
 
-                       return result;
-                     }},
+          return result;
+        }},
 
     InspectorCommand{
         "stealurls",

--- a/src/inspector/inspectorhandler.cpp
+++ b/src/inspector/inspectorhandler.cpp
@@ -371,28 +371,10 @@ static QList<InspectorCommand> s_commands{
                          return obj;
                        }
 
-                       // It seems that in QT/QML there is a race-condition bug
-                       // between the rendering thread and the main one when
-                       // simulating clicks using QTest. At this point, all the
-                       // properties are synchronized, the animation is
-                       // probably already completed (otherwise it's a bug in
-                       // the test!) but it could be that he following
-                       // `mouse`Click` is ignored.
-                       // The horrible/temporary solution is to wait a bit more
-                       // and to add a delay (VPN-3697)
-                       QTest::qWait(150);
-
-                       // Post a mouse click and the release.
-                       QPointF point(item->width()/2, item->height()/2);
-                       QCoreApplication::postEvent(item, new QMouseEvent(
-                          QEvent::MouseButtonPress, point,
-                          item->mapToGlobal(point), Qt::LeftButton,
-                          Qt::LeftButton, Qt::NoModifier));
-                       QCoreApplication::postEvent(item, new QMouseEvent(
-                          QEvent::MouseButtonRelease, point,
-                          item->mapToGlobal(point), Qt::LeftButton,
-                          Qt::LeftButton, Qt::NoModifier));
-
+                       QWindow* window = QmlEngineHolder::instance()->window();
+                       QPointF center = item->boundingRect().center();
+                       QTest::mouseClick(window, Qt::LeftButton, Qt::NoModifier,
+                                         item->mapToScene(center).toPoint());
                        return obj;
                      }},
 

--- a/src/inspector/inspectorhandler.cpp
+++ b/src/inspector/inspectorhandler.cpp
@@ -382,11 +382,16 @@ static QList<InspectorCommand> s_commands{
                        // and to add a delay (VPN-3697)
                        QTest::qWait(150);
 
-                       QPointF pointF = item->mapToScene(QPoint(0, 0));
-                       QPoint point = pointF.toPoint();
-
-                       QTest::mouseClick(item->window(), Qt::LeftButton,
-                                         Qt::NoModifier, point);
+                       // Post a mouse click and the release.
+                       QPointF point(item->width()/2, item->height()/2);
+                       QCoreApplication::postEvent(item, new QMouseEvent(
+                          QEvent::MouseButtonPress, point,
+                          item->mapToGlobal(point), Qt::LeftButton,
+                          Qt::LeftButton, Qt::NoModifier));
+                       QCoreApplication::postEvent(item, new QMouseEvent(
+                          QEvent::MouseButtonRelease, point,
+                          item->mapToGlobal(point), Qt::LeftButton,
+                          Qt::LeftButton, Qt::NoModifier));
 
                        return obj;
                      }},

--- a/src/inspector/inspectorhandler.cpp
+++ b/src/inspector/inspectorhandler.cpp
@@ -361,10 +361,13 @@ static QList<InspectorCommand> s_commands{
                        // Ensure window rendering is finished.
                        QQuickWindow* window = qobject_cast<QQuickWindow*>(
                           QmlEngineHolder::instance()->window());
-                       QSignalSpy spy(window, SIGNAL(afterRendering()));
+                       QSignalSpy spy(window, &QQuickWindow::afterFrameEnd);
                        window->update();
+                       if (!spy.isValid()) {
+                         logger.debug() << "QSignalSpy is invalid";
+                       }
                        if (!spy.wait(150)) {
-                        logger.debug() << "Never got an afterRendering signal";
+                        logger.debug() << "Never got an afterFrameEnd signal";
                        }
 
                        QObject* qmlobj =

--- a/src/inspector/inspectorhandler.cpp
+++ b/src/inspector/inspectorhandler.cpp
@@ -391,6 +391,72 @@ static QList<InspectorCommand> s_commands{
                        return obj;
                      }},
 
+    InspectorCommand{"scrollview", "Scroll a view until an item is centered", 2,
+                     [](InspectorHandler*, const QList<QByteArray>& arguments) {
+                       QJsonObject result;
+
+                       QObject* viewobj =
+                           InspectorUtils::queryObject(arguments[1]);
+                       if (!viewobj) {
+                         logger.error() << "Did not find view object";
+                         result["error"] = "Object not found";
+                         return result;
+                       }
+                       QQuickItem* view = qobject_cast<QQuickItem*>(viewobj);
+                       if (!view) {
+                         logger.error() << "View is not a QQuickItem object";
+                         result["error"] = "Object not found";
+                         return result;
+                       }
+                       const QMetaObject* viewMeta = view->metaObject();
+                       int scrollPropId = viewMeta->indexOfProperty("contentY");
+                       if (scrollPropId < 0) {
+                         logger.error() << "View is not scrollable";
+                         result["error"] = "View is not scrollable";
+                         return result;
+                       }
+
+                       QObject* targetobj =
+                           InspectorUtils::queryObject(arguments[2]);
+                       if (!targetobj) {
+                         logger.error() << "Did not find target object";
+                         result["error"] = "Object not found";
+                         return result;
+                       }
+                       QQuickItem* target = qobject_cast<QQuickItem*>(targetobj);
+                       if (!target) {
+                         logger.error() << "View is not a QQuickItem object";
+                         result["error"] = "Object not found";
+                         return result;
+                       }
+
+                       // Get the size of the view and calculate scroll limits.
+                       qreal current = view->property("contentY").toReal();
+                       qreal content = view->property("contentHeight").toReal();
+                       qreal height = view->property("height").toReal();
+                       qreal limit = (content > height) ? content - height : 0;
+
+                       // Get the vertical position, in the view's coordinates.
+                       QPointF center = target->boundingRect().center();
+                       qreal offset = target->mapToItem(view, center).y();
+
+                       // Figure out how much to scroll to center the target.
+                       qreal contentY = current + offset - (height / 2);
+                       if (contentY < 0) contentY = 0;
+                       if (contentY > limit) contentY = limit;
+
+                       // Scroll the view.
+                       QMetaProperty prop = viewMeta->property(scrollPropId);
+                       Q_ASSERT(prop.isValid());
+                       if (!prop.write(view, QVariant::fromValue(contentY))) {
+                         logger.error() << "Could not write property contentY";
+                         result["error"] = "Could not write property contentY";
+                         return result;
+                       }
+
+                       return result;
+                     }},
+
     InspectorCommand{
         "stealurls",
         "Do not open the URLs in browser and expose them via inspector", 0,

--- a/src/inspector/inspectorhandler.cpp
+++ b/src/inspector/inspectorhandler.cpp
@@ -358,10 +358,10 @@ static QList<InspectorCommand> s_commands{
                      [](InspectorHandler*, const QList<QByteArray>& arguments) {
                        QJsonObject obj;
 
-#ifndef MZ_WASM
-                       // Ensure window rendering is finished.
                        QQuickWindow* window = qobject_cast<QQuickWindow*>(
                            QmlEngineHolder::instance()->window());
+#ifndef MZ_WASM
+                       // Ensure window rendering is finished.
                        QSignalSpy spy(window, &QQuickWindow::afterFrameEnd);
                        window->update();
                        if (!spy.isValid()) {

--- a/src/ui/authenticationInApp/ViewAuthenticationSignIn.qml
+++ b/src/ui/authenticationInApp/ViewAuthenticationSignIn.qml
@@ -12,6 +12,7 @@ import components.inAppAuth 0.1
 
 MZInAppAuthenticationBase {
     id: authSignIn
+    objectName: "authSignIn"
 
     _telemetryScreenId: "enter_password"
 
@@ -41,7 +42,6 @@ MZInAppAuthenticationBase {
     ]
 
     _changeEmailLinkVisible: true
-    _viewObjectName: "authSignIn"
     _menuButtonImageSource: "qrc:/nebula/resources/back.svg"
     _menuButtonImageMirror: MZLocalizer.isRightToLeft
     _menuButtonOnClick: () => {
@@ -65,8 +65,8 @@ MZInAppAuthenticationBase {
     _inputLabel: MZI18n.InAppAuthPasswordInputLabel
 
     _inputs: MZInAppAuthenticationInputs {
-        objectName: "authSignIn"
         id: authInputs
+        _viewObjectName: authSignIn.objectName
 
         _telemetryScreenId: authSignIn._telemetryScreenId
         _telemetryButtonEventName: "signInSelected"
@@ -99,7 +99,7 @@ MZInAppAuthenticationBase {
         spacing: MZTheme.theme.windowMargin
 
         MZLinkButton {
-            objectName: _viewObjectName + "-forgotPassword"
+            objectName: authSignIn.objectName + "-forgotPassword"
             labelText: MZI18n.InAppAuthForgotPasswordLink
             anchors.horizontalCenter: parent.horizontalCenter
             onClicked: {
@@ -112,7 +112,7 @@ MZInAppAuthenticationBase {
         }
 
         MZCancelButton {
-            objectName: _viewObjectName + "-cancel"
+            objectName: authSignIn.objectName + "-cancel"
             anchors.horizontalCenter: parent.horizontalCenter
             onClicked: {
                 Glean.interaction.cancelSelected.record({

--- a/src/ui/authenticationInApp/ViewAuthenticationSignUp.qml
+++ b/src/ui/authenticationInApp/ViewAuthenticationSignUp.qml
@@ -14,9 +14,10 @@ import components.inAppAuth 0.1
 
 MZInAppAuthenticationBase {
     id: authSignUp
+    objectName: "authSignUp"
+
     _changeEmailLinkVisible: true
     _telemetryScreenId: "create_password"
-    _viewObjectName: "authSignUp"
     _menuButtonImageSource: "qrc:/nebula/resources/back.svg"
     _menuButtonImageMirror: MZLocalizer.isRightToLeft
     _menuButtonOnClick: () => {
@@ -32,7 +33,7 @@ MZInAppAuthenticationBase {
     _inputLabel: MZI18n.InAppAuthCreatePasswordLabel
 
     _inputs: MZInAppAuthenticationInputs {
-        objectName: "authSignUp"
+        _viewObjectName: authSignUp.objectName
 
         _telemetryScreenId: authSignUp._telemetryScreenId
         _telemetryButtonEventName: "createAccountSelected"
@@ -62,7 +63,7 @@ MZInAppAuthenticationBase {
         Layout.alignment: Qt.AlignHCenter
 
         MZCancelButton {
-            objectName: _viewObjectName + "-cancel"
+            objectName: authSignUp.objectName + "-cancel"
             anchors.horizontalCenter: parent.horizontalCenter
             onClicked: {
                 Glean.interaction.cancelSelected.record({

--- a/src/ui/authenticationInApp/ViewAuthenticationSsoAccount.qml
+++ b/src/ui/authenticationInApp/ViewAuthenticationSsoAccount.qml
@@ -12,9 +12,9 @@ import components.inAppAuth 0.1
 
 MZInAppAuthenticationThirdParty {
     id: authSsoAccount
+    objectName: "authSsoAccount"
 
     _telemetryScreenId: "authentication_sso_account"
-    _viewObjectName: "authSsoAccount"
     _imgSource: "qrc:/ui/resources/create-password.svg"
     _headlineText: MZI18n.InAppAuthSsoInstructionHeader
 

--- a/src/ui/authenticationInApp/ViewAuthenticationStart.qml
+++ b/src/ui/authenticationInApp/ViewAuthenticationStart.qml
@@ -12,7 +12,8 @@ import components.inAppAuth 0.1
 
 MZInAppAuthenticationBase {
     id: authStart
-    _viewObjectName: "authStart"
+    objectName: "authStart"
+
     _telemetryScreenId: "enter_email"
     _menuButtonOnClick: () => {
         Glean.interaction.backSelected.record({
@@ -30,7 +31,7 @@ MZInAppAuthenticationBase {
     _inputLabel: MZI18n.InAppAuthEmailInputPlaceholder
 
     _inputs: MZInAppAuthenticationInputs {
-        objectName: "authStart"
+        _viewObjectName: authStart.objectName
         _telemetryScreenId: authStart._telemetryScreenId
         _telemetryButtonEventName: "continueSelected"
         _buttonEnabled: MZAuthInApp.state === MZAuthInApp.StateStart && activeInput().text.length !== 0 && !activeInput().hasError && MZAuthInApp.validateEmailAddress(activeInput().text)

--- a/src/ui/authenticationInApp/ViewAuthenticationStubAccount.qml
+++ b/src/ui/authenticationInApp/ViewAuthenticationStubAccount.qml
@@ -12,9 +12,9 @@ import components.inAppAuth 0.1
 
 MZInAppAuthenticationThirdParty {
     id: authStubAccount
+    objectName: "authStubAccount"
 
     _telemetryScreenId: "authentication_stub_account"
-    _viewObjectName: "authStubAccount"
     _imgSource: "qrc:/ui/resources/check-email.svg"
     _headlineText: MZI18n.InAppAuthStubAccountVerificationHeader
 

--- a/src/ui/authenticationInApp/ViewAuthenticationUnblockCodeNeeded.qml
+++ b/src/ui/authenticationInApp/ViewAuthenticationUnblockCodeNeeded.qml
@@ -13,9 +13,9 @@ import components.inAppAuth 0.1
 
 MZInAppAuthenticationBase {
     id: authUnblockCodeNeeded
+    objectName: "authUnblockCodeNeeded"
 
     _telemetryScreenId: "enter_unblock_code"
-    _viewObjectName: "authUnblockCodeNeeded"
     _menuButtonImageSource: "qrc:/nebula/resources/close-dark.svg"
     _menuButtonOnClick: () => {
         if (isReauthFlow) {
@@ -37,7 +37,7 @@ MZInAppAuthenticationBase {
     _imgSource: "qrc:/nebula/resources/verification-code.svg"
 
     _inputs: MZInAppAuthenticationInputs {
-        objectName: "authUnblockCodeNeeded"
+        _viewObjectName: authUnblockCodeNeeded.objectName
         _telemetryScreenId: authUnblockCodeNeeded._telemetryScreenId
         _telemetryButtonEventName: "verifySelected"
         _buttonEnabled: MZAuthInApp.state === MZAuthInApp.StateUnblockCodeNeeded && activeInput().text.length === MZAuthInApp.unblockCodeLength && !activeInput().hasError
@@ -52,7 +52,7 @@ MZInAppAuthenticationBase {
         spacing: MZTheme.theme.windowMargin
 
         MZLinkButton {
-            objectName: _viewObjectName + "-resendCode"
+            objectName: authUnblockCodeNeeded.objectName + "-resendCode"
             labelText: MZI18n.InAppAuthResendCodeLink
             anchors.horizontalCenter: parent.horizontalCenter
             onClicked: {
@@ -66,7 +66,7 @@ MZInAppAuthenticationBase {
             }
         }
         MZCancelButton {
-            objectName: _viewObjectName + "-cancel"
+            objectName: authUnblockCodeNeeded.objectName + "-cancel"
             anchors.horizontalCenter: parent.horizontalCenter
             onClicked: {
                 Glean.interaction.cancelSelected.record({

--- a/src/ui/authenticationInApp/ViewAuthenticationVerificationSessionByEmailNeeded.qml
+++ b/src/ui/authenticationInApp/ViewAuthenticationVerificationSessionByEmailNeeded.qml
@@ -12,16 +12,16 @@ import components.inAppAuth 0.1
 
 MZInAppAuthenticationBase {
     id: authSignUp
+    objectName: "authVerificationSessionByEmailNeeded"
 
     _telemetryScreenId: "enter_verification_code"
-    _viewObjectName: "authVerificationSessionByEmailNeeded"
     _headlineText: MZI18n.InAppAuthVerificationCodeTitle
     _subtitleText: MZI18n.InAppAuthEmailVerificationDescription
     _imgSource: "qrc:/nebula/resources/verification-code.svg"
     _backButtonVisible: false
 
     _inputs: MZInAppAuthenticationInputs {
-        objectName: "authVerificationSessionByEmailNeeded"
+        _viewObjectName: authSignUp.objectName
         _telemetryScreenId: authSignUp._telemetryScreenId
         _telemetryButtonEventName: "verifySelected"
         _buttonEnabled: MZAuthInApp.state === MZAuthInApp.StateVerificationSessionByEmailNeeded && activeInput().text && activeInput().text.length === MZAuthInApp.sessionEmailCodeLength && !activeInput().hasError
@@ -36,7 +36,7 @@ MZInAppAuthenticationBase {
         spacing: MZTheme.theme.windowMargin
 
         MZLinkButton {
-            objectName: _viewObjectName + "-resendCode"
+            objectName: authSignUp.objectName + "-resendCode"
             labelText: MZI18n.InAppAuthResendCodeLink
             anchors.horizontalCenter: parent.horizontalCenter
             onClicked: {
@@ -50,7 +50,7 @@ MZInAppAuthenticationBase {
         }
 
         MZCancelButton {
-            objectName: _viewObjectName + "-cancel"
+            objectName: authSignUp.objectName + "-cancel"
             anchors.horizontalCenter: parent.horizontalCenter
             onClicked: {
                 Glean.interaction.cancelSelected.record({

--- a/src/ui/authenticationInApp/ViewAuthenticationVerificationSessionByTotpNeeded.qml
+++ b/src/ui/authenticationInApp/ViewAuthenticationVerificationSessionByTotpNeeded.qml
@@ -12,10 +12,10 @@ import components.inAppAuth 0.1
 
 MZInAppAuthenticationBase {
     id: authVerificationSessionByTotpNeeded
+    objectName: "authVerificationSessionByTotpNeeded"
 
     _telemetryScreenId: "enter_security_code"
 
-    _viewObjectName: "authVerificationSessionByTotpNeeded"
     _menuButtonImageSource: "qrc:/nebula/resources/close-dark.svg"
     _menuButtonOnClick: () => {
         if (isReauthFlow) {
@@ -39,7 +39,7 @@ MZInAppAuthenticationBase {
     _backButtonVisible: false
 
     _inputs: MZInAppAuthenticationInputs {
-        objectName: "authVerificationSessionByTotpNeeded"
+        _viewObjectName: authVerificationSessionByTotpNeeded.objectName
 
         _telemetryScreenId: authVerificationSessionByTotpNeeded._telemetryScreenId
         _telemetryButtonEventName: "verifySelected"
@@ -55,7 +55,7 @@ MZInAppAuthenticationBase {
         Layout.preferredWidth: parent.width
 
         MZCancelButton {
-            objectName: _viewObjectName + "-cancel"
+            objectName: authVerificationSessionByTotpNeeded.objectName + "-cancel"
             anchors.horizontalCenter: parent.horizontalCenter
             onClicked: {
                 Glean.interaction.cancelSelected.record({

--- a/src/ui/deleteAccount/ViewDeleteAccountRequest.qml
+++ b/src/ui/deleteAccount/ViewDeleteAccountRequest.qml
@@ -40,7 +40,6 @@ MZInAppAuthenticationBase {
 
     _changeEmailLinkVisible: false
     _disclaimersVisible: false
-    _viewObjectName: "authDeleteAccountRequest"
     _menuButtonAccessibleName: MZI18n.GlobalGoBack
     _menuButtonImageSource: "qrc:/nebula/resources/back.svg"
     _menuButtonImageMirror: MZLocalizer.isRightToLeft

--- a/src/ui/screens/home/controller/ip/IPInfoPanel.qml
+++ b/src/ui/screens/home/controller/ip/IPInfoPanel.qml
@@ -11,6 +11,7 @@ import components 0.1
 
 Rectangle {
     property bool isOpen: false
+    property bool busy: opacityAnimation.running
 
     anchors.fill: parent
     color: MZTheme.colors.primary
@@ -74,6 +75,7 @@ Rectangle {
 
     Behavior on opacity {
         NumberAnimation {
+            id: opacityAnimation
             duration: 300
         }
     }

--- a/src/ui/screens/home/servers/ServerCountry.qml
+++ b/src/ui/screens/home/servers/ServerCountry.qml
@@ -22,7 +22,7 @@ MZClickableRow {
     property var currentCityIndex
     property alias serverCountryName: countryName.text
     property var cityList: cityListVisible ? cityLoader.item : cityLoader
-    property var busy: cityListVisible ? scrollAnimation.running : false
+    property var busy: cityListVisible && (scrollAnimation.running || listOpenTransition.running || listClosedTransition.running)
 
     Component.onCompleted:{
        cityLoader.active = cityListVisible
@@ -100,6 +100,7 @@ MZClickableRow {
 
     transitions: [
         Transition {
+            id: listClosedTransition
             to: "listClosed"
                 SequentialAnimation{
                     ParallelAnimation {
@@ -122,9 +123,9 @@ MZClickableRow {
                         }
                     }
                 }
-                
         },
         Transition {
+            id: listOpenTransition
             to: "listOpen"               
                     PropertyAnimation {
                         target: serverCountry

--- a/src/ui/screens/home/servers/ServerList.qml
+++ b/src/ui/screens/home/servers/ServerList.qml
@@ -290,6 +290,7 @@ FocusScope {
         MZFlickable {
             objectName: "serverCountryView"
             property alias countries: countriesRepeater
+            property bool busy: scrollAnimation.running
             id: vpnFlickable
 
             flickContentHeight: serverList.implicitHeight

--- a/src/ui/screens/settings/ViewReset.qml
+++ b/src/ui/screens/settings/ViewReset.qml
@@ -14,6 +14,7 @@ import "qrc:/Mozilla/VPN/sharedViews"
 
 ViewFullScreen {
     id: root
+    objectName: "resetVpnView"
 
     property string telemetryScreenId: "reset_vpn"
     property string _menuTitle: MZI18n.ResetSettingsResetLabel

--- a/tests/functional/helper.js
+++ b/tests/functional/helper.js
@@ -239,6 +239,18 @@ module.exports = {
     await this.wait();
   },
 
+  async scrollToBottom(view) {
+    assert(await this.query(view), 'Scrolling on an non-existing view?!?');
+
+    const contentHeight =
+        parseInt(await this.getQueryProperty(view, 'contentHeight'));
+    const height = parseInt(await this.getQueryProperty(view, 'height'));
+    let maxScroll = (contentHeight > height) ? contentHeight - height : 0;
+
+    await this.setQueryProperty(view, 'contentY', maxScroll);
+    await this.wait();
+  },
+
   async getMozillaProperty(namespace, id, property) {
     const json =
         await this._writeCommand(`property ${encodeURIComponent(namespace)} ${

--- a/tests/functional/queries.js
+++ b/tests/functional/queries.js
@@ -254,6 +254,7 @@ const screenGetHelp = {
   },
 
   resetView: {
+    VIEW: new QmlQueryComposer('//resetVpnView'),
     RESET_BUTTON: new QmlQueryComposer('//resetVpnButton'),
     BACK_BUTTON: new QmlQueryComposer('//goBackButton'),
     POPUP_LOADER: new QmlQueryComposer('//confirmResetPopupLoader'),

--- a/tests/functional/testAuthenticationInApp.js
+++ b/tests/functional/testAuthenticationInApp.js
@@ -708,7 +708,8 @@ describe('User authentication', function() {
         it("cancel event is recorded", async () => {
             // Click the "Cancel" button
             await vpn.waitForQuery(queries.screenAuthenticationInApp.AUTH_SIGNIN_CANCEL_BUTTON.visible());
-            await vpn.scrollToBottom(queries.screenAuthenticationInApp.AUTH_SIGNIN_SCREEN);
+            await vpn.scrollToQuery(queries.screenAuthenticationInApp.AUTH_SIGNIN_SCREEN,
+                queries.screenAuthenticationInApp.AUTH_SIGNIN_CANCEL_BUTTON);
             await vpn.clickOnQuery(queries.screenAuthenticationInApp.AUTH_SIGNIN_CANCEL_BUTTON);
             await vpn.testLastInteractionEvent({
                 eventName: "cancelSelected",

--- a/tests/functional/testAuthenticationInApp.js
+++ b/tests/functional/testAuthenticationInApp.js
@@ -570,6 +570,7 @@ describe('User authentication', function() {
         await vpn.setQueryProperty(
             queries.screenAuthenticationInApp.AUTH_START_TEXT_INPUT.visible(),
             'text', 'test@test.com');
+
         await vpn.waitForQueryAndClick(
             queries.screenAuthenticationInApp.AUTH_START_BUTTON.visible()
                 .enabled());
@@ -706,7 +707,9 @@ describe('User authentication', function() {
 
         it("cancel event is recorded", async () => {
             // Click the "Cancel" button
-            await vpn.waitForQueryAndClick(queries.screenAuthenticationInApp.AUTH_SIGNIN_CANCEL_BUTTON.visible());
+            await vpn.waitForQuery(queries.screenAuthenticationInApp.AUTH_SIGNIN_CANCEL_BUTTON.visible());
+            await vpn.scrollToBottom(queries.screenAuthenticationInApp.AUTH_SIGNIN_SCREEN);
+            await vpn.clickOnQuery(queries.screenAuthenticationInApp.AUTH_SIGNIN_CANCEL_BUTTON);
             await vpn.testLastInteractionEvent({
                 eventName: "cancelSelected",
                 screen

--- a/tests/functional/testAuthenticationInAppErrors.js
+++ b/tests/functional/testAuthenticationInAppErrors.js
@@ -235,6 +235,7 @@ describe('User authentication', function() {
       await vpn.waitForQueryAndClick(
           queries.screenAuthenticationInApp.AUTH_EMAILVER_CANCEL_BUTTON
               .visible());
+      await vpn.waitForInitialView();
       await vpn.clickOnQuery(queries.screenInitialize.SIGN_UP_BUTTON.visible());
       await vpn.waitForQuery(
           queries.screenAuthenticationInApp.AUTH_START_TEXT_INPUT.visible());

--- a/tests/functional/testAuthenticationInAppErrors.js
+++ b/tests/functional/testAuthenticationInAppErrors.js
@@ -84,9 +84,13 @@ describe('User authentication', function() {
 
         await vpn.waitForQueryAndClick(queries.screenAuthenticationInApp
                                            .AUTH_ERROR_POPUP_BUTTON.visible());
-        await vpn.waitForQueryAndClick(
-            queries.screenAuthenticationInApp.AUTH_START_BUTTON.visible()
-                .disabled());
+        await vpn.waitForCondition(async () => {
+          const vis = await vpn.query(queries.screenAuthenticationInApp
+                                          .AUTH_ERROR_POPUP_BUTTON.visible());
+          return vis === false;
+        });
+        await vpn.waitForQuery(queries.screenAuthenticationInApp
+                                   .AUTH_START_BUTTON.visible().disabled());
       }
 
       // Step 2: start -> email error
@@ -162,6 +166,11 @@ describe('User authentication', function() {
 
       await vpn.waitForQueryAndClick(
           queries.screenAuthenticationInApp.AUTH_ERROR_POPUP_BUTTON.visible());
+      await vpn.waitForCondition(async () => {
+        const vis = await vpn.query(queries.screenAuthenticationInApp
+                                       .AUTH_ERROR_POPUP_BUTTON.visible());
+        return vis === false;
+      });
       await vpn.waitForQuery(
           queries.screenAuthenticationInApp.AUTH_SIGNIN_BUTTON.visible()
               .disabled());

--- a/tests/functional/testDevices.js
+++ b/tests/functional/testDevices.js
@@ -221,6 +221,7 @@ describe('Devices', function() {
       // Let's remove a device
       await vpn.waitForQueryAndClick(
           queries.screenSettings.myDevicesView.REMOVE_DEVICE_BUTTON.visible());
+      await vpn.wait(); // Wait for popup animation
 
       await vpn.waitForQueryAndClick(queries.screenSettings.myDevicesView
                                          .CONFIRM_REMOVAL_BUTTON.visible());
@@ -483,6 +484,8 @@ describe('Devices', function() {
       // Let's remove a device by clicking the button
       await vpn.waitForQueryAndClick(
           queries.screenSettings.myDevicesView.REMOVE_DEVICE_BUTTON.visible());
+      await vpn.wait(); // Wait for popup animation
+
       await vpn.waitForQueryAndClick(queries.screenSettings.myDevicesView
                                          .CONFIRM_REMOVAL_BUTTON.visible());
 

--- a/tests/functional/testFactoryReset.js
+++ b/tests/functional/testFactoryReset.js
@@ -33,7 +33,8 @@ describe('Factory Reset', function() {
   	await vpn.waitForQueryAndClick(queries.screenGetHelp.RESET.visible());
 
   	await vpn.waitForQueryAndClick(queries.screenGetHelp.STACKVIEW.ready());
-	await vpn.scrollToBottom(queries.screenGetHelp.resetView.VIEW);
+	await vpn.scrollToQuery(queries.screenGetHelp.resetView.VIEW,
+		queries.screenGetHelp.resetView.BACK_BUTTON);
   	await vpn.waitForQueryAndClick(queries.screenGetHelp.resetView.BACK_BUTTON.visible());
 
   	await vpn.waitForQueryAndClick(queries.screenGetHelp.STACKVIEW.ready());

--- a/tests/functional/testFactoryReset.js
+++ b/tests/functional/testFactoryReset.js
@@ -33,6 +33,7 @@ describe('Factory Reset', function() {
   	await vpn.waitForQueryAndClick(queries.screenGetHelp.RESET.visible());
 
   	await vpn.waitForQueryAndClick(queries.screenGetHelp.STACKVIEW.ready());
+	await vpn.scrollToBottom(queries.screenGetHelp.resetView.VIEW);
   	await vpn.waitForQueryAndClick(queries.screenGetHelp.resetView.BACK_BUTTON.visible());
 
   	await vpn.waitForQueryAndClick(queries.screenGetHelp.STACKVIEW.ready());

--- a/tests/functional/testIpInfo.js
+++ b/tests/functional/testIpInfo.js
@@ -15,7 +15,7 @@ describe('IP info', function() {
 
     // Open IP info panel
     await vpn.waitForQueryAndClick(queries.screenHome.IP_INFO_TOGGLE.visible());
-    await vpn.waitForQuery(queries.screenHome.IP_INFO_PANEL.visible());
+    await vpn.waitForQuery(queries.screenHome.IP_INFO_PANEL.ready());
     assert.equal(
         await vpn.getQueryProperty(
             queries.screenHome.IP_INFO_PANEL, 'isOpen'), 'true');
@@ -33,7 +33,7 @@ describe('IP info', function() {
 
     // Open IP info panel
     await vpn.waitForQueryAndClick(queries.screenHome.IP_INFO_TOGGLE.visible());
-    await vpn.waitForQuery(queries.screenHome.IP_INFO_PANEL.visible());
+    await vpn.waitForQuery(queries.screenHome.IP_INFO_PANEL.ready());
     assert.equal(
         await vpn.getQueryProperty(
             queries.screenHome.IP_INFO_PANEL, 'isOpen'), 'true');
@@ -64,7 +64,7 @@ describe('IP info', function() {
 
       // Open IP info panel
       await vpn.waitForQueryAndClick(queries.screenHome.IP_INFO_TOGGLE.visible());
-      await vpn.waitForQuery(queries.screenHome.IP_INFO_PANEL.visible());
+      await vpn.waitForQuery(queries.screenHome.IP_INFO_PANEL.ready());
       assert.equal(
           await vpn.getQueryProperty(
               queries.screenHome.IP_INFO_PANEL, 'isOpen'), 'true');

--- a/tests/functional/testMultihop.js
+++ b/tests/functional/testMultihop.js
@@ -7,10 +7,8 @@ const queries = require('./queries.js');
 const vpn = require('./helper.js');
 
 async function selectCityFromList(cityId, countryId) {
-  await vpn.scrollView(
-      queries.screenHome.serverListView.COUNTRY_VIEW,
-      parseInt(await vpn.getQueryProperty(cityId, 'y')) +
-          parseInt(await vpn.getQueryProperty(countryId, 'y')));
+  await vpn.scrollToQuery(
+      queries.screenHome.serverListView.COUNTRY_VIEW, cityId);
 }
 
 async function selectCountryFromList(countryId) {

--- a/tests/functional/testMultihop.js
+++ b/tests/functional/testMultihop.js
@@ -172,6 +172,7 @@ describe('Server list', function() {
 
     if (await vpn.getQueryProperty(countryId, 'cityListVisible') === 'false') {
       await vpn.clickOnQuery(countryId);
+      await vpn.waitForQuery(countryId.ready());
     }
     let [city] = server.cities
     const cityId_query =

--- a/tests/functional/testMultihop.js
+++ b/tests/functional/testMultihop.js
@@ -7,8 +7,8 @@ const queries = require('./queries.js');
 const vpn = require('./helper.js');
 
 async function selectCityFromList(cityId, countryId) {
-  await vpn.setQueryProperty(
-      queries.screenHome.serverListView.COUNTRY_VIEW, 'contentY',
+  await vpn.scrollView(
+      queries.screenHome.serverListView.COUNTRY_VIEW,
       parseInt(await vpn.getQueryProperty(cityId, 'y')) +
           parseInt(await vpn.getQueryProperty(countryId, 'y')));
 }
@@ -73,19 +73,7 @@ describe('Server list', function() {
       // Scope country_query to be inside multiHopStackView
       // make sure we are querying the correct list :)
       const countryId = multiHopStackView.query(country_query);
-      await vpn.waitForQuery(countryId.visible());
-
-      await vpn.setQueryProperty(
-          queries.screenHome.serverListView.COUNTRY_VIEW, 'contentY',
-          parseInt(await vpn.getQueryProperty(countryId, 'y')));
-
-      await vpn.wait();
-
-
-      if (await vpn.getQueryProperty(countryId, 'cityListVisible') ===
-          'false') {
-        await vpn.clickOnQuery(countryId);
-      }
+      await vpn.navServerList(countryId);
 
       for (let city of server.cities) {
         const cityId_query = queries.screenHome.serverListView.generateCityId(
@@ -166,21 +154,16 @@ describe('Server list', function() {
     let country =
         queries.screenHome.serverListView.generateCountryId(server.code);
     let countryId = multiHopStackView.query(country);
-    await vpn.waitForQuery(countryId.visible());
-    await selectCountryFromList(countryId);
-    await vpn.wait();
 
-    if (await vpn.getQueryProperty(countryId, 'cityListVisible') === 'false') {
-      await vpn.clickOnQuery(countryId);
-      await vpn.waitForQuery(countryId.ready());
-    }
     let [city] = server.cities
     const cityId_query =
         queries.screenHome.serverListView.generateCityId(country, city.name);
     const cityId = multiHopStackView.query(cityId_query);
 
-    await vpn.waitForQuery(cityId);
-    await vpn.clickOnQuery(cityId);
+    // Navigate the server list and click the city.
+    await vpn.navServerList(countryId, cityId);
+    await vpn.waitForQueryAndClick(cityId.visible());
+
     // We should now be back on the overview
     await vpn.waitForQuery(
         queries.screenHome.serverListView.ENTRY_BUTTON.visible());

--- a/tests/functional/testServerSearch.js
+++ b/tests/functional/testServerSearch.js
@@ -74,9 +74,9 @@ describe("Server list", function () {
       (await vpn.getQueryProperty(countryId, "cityListVisible")) === "false"
     ) {
       await vpn.waitForQueryAndClick(countryId.visible());
+      await vpn.waitForQuery(countryId.visible().prop("cityListVisible", true));
     }
-
-    await vpn.waitForQuery(countryId.visible().prop("cityListVisible", true));
+    await vpn.waitForQuery(countryId.ready());
 
     const city = server.cities[0]
     console.log("Start test for city:", city);
@@ -92,9 +92,9 @@ describe("Server list", function () {
       parseInt(await vpn.getQueryProperty(cityId, "y")) +
         parseInt(await vpn.getQueryProperty(countryId, "y"))
     );
-    await vpn.waitForQuery(cityId.visible());
 
-    await vpn.waitForQueryAndClick(cityId.visible());
+    await vpn.wait(150); // I cannot figure out why we need this delay.
+    await vpn.waitForQueryAndClick(cityId.visible().enabled());
     await vpn.waitForQuery(queries.screenHome.STACKVIEW.ready());
 
     // navigate back to connection view
@@ -145,8 +145,9 @@ describe("Server list", function () {
       (await vpn.getQueryProperty(countryId, "cityListVisible")) === "false"
     ) {
       await vpn.waitForQueryAndClick(countryId.visible());
+      await vpn.waitForQuery(countryId.visible().prop("cityListVisible", true));
     }
-    await vpn.waitForQuery(countryId.visible().prop("cityListVisible", true));
+    await vpn.waitForQuery(countryId.ready());
 
     console.log("Start test for city:", server.cities[0]);
     const cityId = queries.screenHome.serverListView.generateCityId(

--- a/tests/functional/testServerSearch.js
+++ b/tests/functional/testServerSearch.js
@@ -61,39 +61,17 @@ describe("Server list", function () {
       server.name
     );
 
+    const city = server.cities[0]
+    console.log("Start test for city:", city);
     const countryId = queries.screenHome.serverListView.generateCountryId(
       server.code
     );
-    await vpn.waitForQuery(countryId.visible());
-    await vpn.scrollToQuery(
-      queries.screenHome.serverListView.COUNTRY_VIEW,
-      countryId
-    );
-
-    if (
-      (await vpn.getQueryProperty(countryId, "cityListVisible")) === "false"
-    ) {
-      await vpn.waitForQueryAndClick(countryId.visible());
-      await vpn.waitForQuery(countryId.visible().prop("cityListVisible", true));
-    }
-    await vpn.waitForQuery(countryId.ready());
-
-    const city = server.cities[0]
-    console.log("Start test for city:", city);
     const cityId = queries.screenHome.serverListView.generateCityId(
       countryId,
       city.name
     );
-    await vpn.waitForQuery(cityId.visible());
+    await vpn.navServerList(countryId, cityId);
 
-    await vpn.setQueryProperty(
-      queries.screenHome.serverListView.COUNTRY_VIEW,
-      "contentY",
-      parseInt(await vpn.getQueryProperty(cityId, "y")) +
-        parseInt(await vpn.getQueryProperty(countryId, "y"))
-    );
-
-    await vpn.wait(150); // I cannot figure out why we need this delay.
     await vpn.waitForQueryAndClick(cityId.visible().enabled());
     await vpn.waitForQuery(queries.screenHome.STACKVIEW.ready());
 
@@ -132,37 +110,15 @@ describe("Server list", function () {
       server.name
     );
 
+    console.log("Start test for city:", server.cities[0]);
     const countryId = queries.screenHome.serverListView.generateCountryId(
       server.code
     );
-    await vpn.waitForQuery(countryId.visible());
-    await vpn.scrollToQuery(
-      queries.screenHome.serverListView.COUNTRY_VIEW,
-      countryId
-    );
-
-    if (
-      (await vpn.getQueryProperty(countryId, "cityListVisible")) === "false"
-    ) {
-      await vpn.waitForQueryAndClick(countryId.visible());
-      await vpn.waitForQuery(countryId.visible().prop("cityListVisible", true));
-    }
-    await vpn.waitForQuery(countryId.ready());
-
-    console.log("Start test for city:", server.cities[0]);
     const cityId = queries.screenHome.serverListView.generateCityId(
       countryId,
       server.cities[0].name
     );
-    await vpn.waitForQuery(cityId.visible());
-
-    await vpn.setQueryProperty(
-      queries.screenHome.serverListView.COUNTRY_VIEW,
-      "contentY",
-      parseInt(await vpn.getQueryProperty(cityId, "y")) +
-        parseInt(await vpn.getQueryProperty(countryId, "y"))
-    );
-    await vpn.waitForQuery(cityId.visible());
+    await vpn.navServerList(countryId, cityId);
 
     await vpn.waitForQueryAndClick(cityId.visible());
     await vpn.waitForQuery(queries.screenHome.STACKVIEW.ready());

--- a/tests/functional/testServers.js
+++ b/tests/functional/testServers.js
@@ -80,9 +80,8 @@ describe('Server', function() {
               countryId, city.name);
           await vpn.waitForQuery(cityId);
 
-          await vpn.scrollView(
-              queries.screenHome.serverListView.COUNTRY_VIEW,
-              parseInt(await vpn.getQueryProperty(cityId, 'y')) + countryY);
+          await vpn.scrollToQuery(
+              queries.screenHome.serverListView.COUNTRY_VIEW, cityId);
           await vpn.waitForQuery(cityId.visible());
 
           const cityName =

--- a/tests/functional/testServers.js
+++ b/tests/functional/testServers.js
@@ -52,21 +52,7 @@ describe('Server', function() {
       for (let server of servers) {
         const countryId =
             queries.screenHome.serverListView.generateCountryId(server.code);
-        await vpn.waitForQuery(countryId.visible());
-
-        await vpn.scrollToQuery(
-            queries.screenHome.serverListView.COUNTRY_VIEW, countryId);
-
-        if (currentCountryCode === server.code) {
-          assert.equal(
-              await vpn.getQueryProperty(countryId, 'cityListVisible'),
-              'true');
-        }
-
-        if (await vpn.getQueryProperty(countryId, 'cityListVisible') ===
-            'false') {
-          await vpn.clickOnQuery(countryId);
-        }
+        await vpn.navServerList(countryId);
 
         for (let city of server.cities) {
           const cityId = queries.screenHome.serverListView.generateCityId(
@@ -85,29 +71,18 @@ describe('Server', function() {
       for (let server of servers) {
         const countryId =
             queries.screenHome.serverListView.generateCountryId(server.code);
-        await vpn.waitForQuery(countryId.visible());
+        await vpn.navServerList(countryId);
 
-        await vpn.scrollToQuery(
-            queries.screenHome.serverListView.COUNTRY_VIEW, countryId);
-
-        if (await vpn.getQueryProperty(countryId, 'cityListVisible') ===
-            'false') {
-          await vpn.clickOnQuery(countryId);
-          await vpn.waitForQuery(countryId.ready());
-        }
-
-        await vpn.waitForQuery(countryId.prop('cityListVisible', true));
-
+        let countryY = parseInt(await vpn.getQueryProperty(countryId, 'y'));
         for (let city of server.cities) {
           console.log('  Start test for city:', city);
           const cityId = queries.screenHome.serverListView.generateCityId(
               countryId, city.name);
           await vpn.waitForQuery(cityId);
 
-          await vpn.setQueryProperty(
-              queries.screenHome.serverListView.COUNTRY_VIEW, 'contentY',
-              parseInt(await vpn.getQueryProperty(cityId, 'y')) +
-                  parseInt(await vpn.getQueryProperty(countryId, 'y')));
+          await vpn.scrollView(
+              queries.screenHome.serverListView.COUNTRY_VIEW,
+              parseInt(await vpn.getQueryProperty(cityId, 'y')) + countryY);
           await vpn.waitForQuery(cityId.visible());
 
           const cityName =
@@ -186,24 +161,12 @@ describe('Server', function() {
 
       const countryId =
           queries.screenHome.serverListView.generateCountryId(server.code);
-      await vpn.waitForQuery(countryId.visible());
-
-      await vpn.scrollToQuery(
-          queries.screenHome.serverListView.COUNTRY_VIEW, countryId);
-      await vpn.clickOnQuery(countryId);
-
       let city = server.cities[Math.floor(Math.random() * server.cities.length)];
       const cityId =
           queries.screenHome.serverListView.generateCityId(countryId, city.name);
-      await vpn.waitForQuery(cityId.visible());
+      await vpn.navServerList(countryId, cityId);
 
-      await vpn.setQueryProperty(
-          queries.screenHome.serverListView.COUNTRY_VIEW, 'contentY',
-          parseInt(await vpn.getQueryProperty(cityId, 'y')) +
-              parseInt(await vpn.getQueryProperty(countryId, 'y')));
-      await vpn.wait();
-
-      await vpn.clickOnQuery(cityId);
+      await vpn.waitForQueryAndClick(cityId.visible());
       await vpn.waitForQuery(queries.screenHome.STACKVIEW.ready());
 
       const previousCountry = currentCountry;

--- a/tests/functional/testSubscription.js
+++ b/tests/functional/testSubscription.js
@@ -979,10 +979,10 @@ describe('Subscription view', function() {
               'text', 'test@mozilla.com'));
       await vpn.waitForQueryAndClick(
           queries.screenSettings.USER_PROFILE.visible());
-      await vpn.waitForQuery(queries.screenSettings.STACKVIEW.ready());
 
       await vpn.waitForQuery(
           queries.screenSettings.subscriptionView.SCREEN.visible());
+      await vpn.waitForQuery(queries.screenSettings.STACKVIEW.ready());
 
       if (data.subscription.expected.status) {
         assert.equal(
@@ -1149,6 +1149,8 @@ describe('Subscription view', function() {
     await vpn.waitForQuery(
         queries.screenSettings.subscriptionView.ACCOUNT_DELETION.hidden());
     await vpn.flipFeatureOn('accountDeletion');
+    await vpn.wait();
+
     await vpn.waitForQuery(
         queries.screenSettings.subscriptionView.ACCOUNT_DELETION.visible());
 
@@ -1271,6 +1273,8 @@ describe('Subscription view', function() {
     await vpn.waitForQuery(
         queries.screenSettings.subscriptionView.ACCOUNT_DELETION.hidden());
     await vpn.flipFeatureOn('accountDeletion');
+    await vpn.wait();
+  
     await vpn.waitForQuery(
         queries.screenSettings.subscriptionView.ACCOUNT_DELETION.visible());
 

--- a/tests/functional/testSubscription.js
+++ b/tests/functional/testSubscription.js
@@ -1174,10 +1174,8 @@ describe('Subscription view', function() {
         queries.screenDeleteAccount.BUTTON.visible().disabled());
     await vpn.waitForQuery(queries.screenDeleteAccount.LABEL.visible());
 
-    await vpn.setQueryProperty(
-        queries.screenDeleteAccount.SCREEN, 'contentY',
-        parseInt(await vpn.getQueryProperty(
-            queries.screenDeleteAccount.CHECKBOX1, 'y')));
+    await vpn.scrollToQuery(queries.screenDeleteAccount.SCREEN,
+        queries.screenDeleteAccount.CHECKBOX1);
     await vpn.waitForQuery(queries.screenDeleteAccount.CHECKBOX1.visible().prop(
         'isChecked', false));
     await vpn.waitForQueryAndClick(
@@ -1187,10 +1185,8 @@ describe('Subscription view', function() {
     await vpn.waitForQuery(
         queries.screenDeleteAccount.BUTTON.visible().disabled());
 
-    await vpn.setQueryProperty(
-        queries.screenDeleteAccount.SCREEN, 'contentY',
-        parseInt(await vpn.getQueryProperty(
-            queries.screenDeleteAccount.CHECKBOX2, 'y')));
+    await vpn.scrollToQuery(queries.screenDeleteAccount.SCREEN,
+        queries.screenDeleteAccount.CHECKBOX2);
     await vpn.waitForQuery(queries.screenDeleteAccount.CHECKBOX2.visible().prop(
         'isChecked', false));
     await vpn.waitForQueryAndClick(
@@ -1200,10 +1196,8 @@ describe('Subscription view', function() {
     await vpn.waitForQuery(
         queries.screenDeleteAccount.BUTTON.visible().disabled());
 
-    await vpn.setQueryProperty(
-        queries.screenDeleteAccount.SCREEN, 'contentY',
-        parseInt(await vpn.getQueryProperty(
-            queries.screenDeleteAccount.CHECKBOX3, 'y')));
+    await vpn.scrollToQuery(queries.screenDeleteAccount.SCREEN,
+        queries.screenDeleteAccount.CHECKBOX3);
     await vpn.waitForQuery(queries.screenDeleteAccount.CHECKBOX3.visible().prop(
         'isChecked', false));
     await vpn.waitForQueryAndClick(
@@ -1213,10 +1207,8 @@ describe('Subscription view', function() {
     await vpn.waitForQuery(
         queries.screenDeleteAccount.BUTTON.visible().disabled());
 
-    await vpn.setQueryProperty(
-        queries.screenDeleteAccount.SCREEN, 'contentY',
-        parseInt(await vpn.getQueryProperty(
-            queries.screenDeleteAccount.CHECKBOX3, 'y')));
+    await vpn.scrollToQuery(queries.screenDeleteAccount.SCREEN,
+        queries.screenDeleteAccount.CHECKBOX3);
     await vpn.waitForQuery(queries.screenDeleteAccount.CHECKBOX4.visible().prop(
         'isChecked', false));
     await vpn.waitForQueryAndClick(
@@ -1323,10 +1315,9 @@ describe('Subscription view', function() {
         queries.screenDeleteAccount.BUTTON.visible().disabled());
     await vpn.waitForQuery(queries.screenDeleteAccount.LABEL.visible());
 
-    await vpn.setQueryProperty(
-        queries.screenDeleteAccount.SCREEN, 'contentY',
-        parseInt(await vpn.getQueryProperty(
-            queries.screenDeleteAccount.CHECKBOX1, 'y')));
+    await vpn.scrollToQuery(
+        queries.screenDeleteAccount.SCREEN,
+        queries.screenDeleteAccount.CHECKBOX1);
     await vpn.waitForQuery(queries.screenDeleteAccount.CHECKBOX1.visible().prop(
         'isChecked', false));
     await vpn.waitForQueryAndClick(
@@ -1336,10 +1327,9 @@ describe('Subscription view', function() {
     await vpn.waitForQuery(
         queries.screenDeleteAccount.BUTTON.visible().disabled());
 
-    await vpn.setQueryProperty(
-        queries.screenDeleteAccount.SCREEN, 'contentY',
-        parseInt(await vpn.getQueryProperty(
-            queries.screenDeleteAccount.CHECKBOX2, 'y')));
+    await vpn.scrollToQuery(
+        queries.screenDeleteAccount.SCREEN,
+        queries.screenDeleteAccount.CHECKBOX2);
     await vpn.waitForQuery(queries.screenDeleteAccount.CHECKBOX2.visible().prop(
         'isChecked', false));
     await vpn.waitForQueryAndClick(
@@ -1349,10 +1339,9 @@ describe('Subscription view', function() {
     await vpn.waitForQuery(
         queries.screenDeleteAccount.BUTTON.visible().disabled());
 
-    await vpn.setQueryProperty(
-        queries.screenDeleteAccount.SCREEN, 'contentY',
-        parseInt(await vpn.getQueryProperty(
-            queries.screenDeleteAccount.CHECKBOX3, 'y')));
+    await vpn.scrollToQuery(
+        queries.screenDeleteAccount.SCREEN,
+        queries.screenDeleteAccount.CHECKBOX3);
     await vpn.waitForQuery(queries.screenDeleteAccount.CHECKBOX3.visible().prop(
         'isChecked', false));
     await vpn.waitForQueryAndClick(
@@ -1362,10 +1351,9 @@ describe('Subscription view', function() {
     await vpn.waitForQuery(
         queries.screenDeleteAccount.BUTTON.visible().disabled());
 
-    await vpn.setQueryProperty(
-        queries.screenDeleteAccount.SCREEN, 'contentY',
-        parseInt(await vpn.getQueryProperty(
-            queries.screenDeleteAccount.CHECKBOX3, 'y')));
+    await vpn.scrollToQuery(
+        queries.screenDeleteAccount.SCREEN,
+        queries.screenDeleteAccount.CHECKBOX3);
     await vpn.waitForQuery(queries.screenDeleteAccount.CHECKBOX4.visible().prop(
         'isChecked', false));
     await vpn.waitForQueryAndClick(

--- a/tests/functional/testSubscription.js
+++ b/tests/functional/testSubscription.js
@@ -1208,7 +1208,7 @@ describe('Subscription view', function() {
         queries.screenDeleteAccount.BUTTON.visible().disabled());
 
     await vpn.scrollToQuery(queries.screenDeleteAccount.SCREEN,
-        queries.screenDeleteAccount.CHECKBOX3);
+        queries.screenDeleteAccount.CHECKBOX4);
     await vpn.waitForQuery(queries.screenDeleteAccount.CHECKBOX4.visible().prop(
         'isChecked', false));
     await vpn.waitForQueryAndClick(
@@ -1223,7 +1223,8 @@ describe('Subscription view', function() {
       this.ctx.fxaOverrideEndpoints.POSTs['/v1/account/destroy'].body = {}
     };
 
-    await vpn.wait();
+    await vpn.scrollToQuery(queries.screenDeleteAccount.SCREEN,
+      queries.screenDeleteAccount.BUTTON);
 
     await vpn.waitForQueryAndClick(
         queries.screenDeleteAccount.BUTTON.visible().enabled());
@@ -1368,8 +1369,8 @@ describe('Subscription view', function() {
       this.ctx.fxaOverrideEndpoints.POSTs['/v1/account/destroy'].body = {}
     };
 
-    await vpn.wait();
-
+    await vpn.scrollToQuery(queries.screenDeleteAccount.SCREEN,
+      queries.screenDeleteAccount.BUTTON);
     await vpn.waitForQueryAndClick(
         queries.screenDeleteAccount.BUTTON.visible().enabled());
 


### PR DESCRIPTION
## Description
I have been seeing a bunch of auth functional tests failing in CI due to an assert in `QTest::mouseEvent()` due to a null `QWindow` pointer. After some digging, I think this is really a consequence of the bug noted by [VPN-3697](https://mozilla-hub.atlassian.net/browse/VPN-3697), where we encounter a race condition between the rendering thread and the GUI thread.

To resolve this, we should poke the rendering thread and wait for the frame draw to finish before submitting the click to the window. This should ensure that the QML scene graph is synchronized with the QML content before we process the click event.

Some subtle changes that revealed some bugs:
- Sending the click to `item->window()` can actually click things that are offscreen, and sending the click to the root window revealed a handful of test bugs.
- There were a lot of test bugs that were being hidden by the `QTest::qWait()` workaround.

## Reference
JIRA issue: [VPN-3697](https://mozilla-hub.atlassian.net/browse/VPN-3697)
JIRA issue: [VPN-6356](https://mozilla-hub.atlassian.net/browse/VPN-6356)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-3697]: https://mozilla-hub.atlassian.net/browse/VPN-3697?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[VPN-3697]: https://mozilla-hub.atlassian.net/browse/VPN-3697?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[VPN-6356]: https://mozilla-hub.atlassian.net/browse/VPN-6356?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ