### PR TITLE
Bug 1894209 - use new certificate for windows code signing

### DIFF
--- a/taskcluster/kinds/repackage-signing/kind.yml
+++ b/taskcluster/kinds/repackage-signing/kind.yml
@@ -29,7 +29,7 @@ tasks:
         add-index-routes:
             name: windows
             type: build
-        signing-format: autograph_authenticode_sha2
+        signing-format: autograph_authenticode_202404
         treeherder:
             job-symbol: Bs
             kind: build

--- a/taskcluster/kinds/signing/kind.yml
+++ b/taskcluster/kinds/signing/kind.yml
@@ -40,7 +40,7 @@ tasks:
                 android.*: autograph_apk
                 linux.*: autograph_debsign
                 macos.*: macapp
-                windows/opt: autograph_authenticode_sha2
+                windows/opt: autograph_authenticode_202404
                 addons/opt: autograph_rsa
         treeherder:
             job-symbol:


### PR DESCRIPTION
The old cert expires June 19, 2024.

## Description

    Describe your changes

## Reference

https://bugzilla.mozilla.org/show_bug.cgi?id=1894209

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
