### PR TITLE
Nit: Only try to unbound the Daemon if it exists

### DIFF
--- a/android/vpnClient/src/main/java/org/mozilla/firefox/vpn/qt/VPNActivity.java
+++ b/android/vpnClient/src/main/java/org/mozilla/firefox/vpn/qt/VPNActivity.java
@@ -214,7 +214,9 @@ public class VPNActivity extends org.qtproject.qt.android.bindings.QtActivity {
 
   @Override
   protected void onDestroy() {
-    unbindService(mConnection);
+    if(bound){
+      unbindService(mConnection);
+    }
     super.onDestroy();
   }
 


### PR DESCRIPTION
## Description
In case we kill the activity before the serviceconnection is valid, for example when writing speedy integration tests, 
this will cause a crash :) 
