### PR TITLE
VPN-6344 Add missing permission

### DIFF
--- a/android/daemon/src/main/AndroidManifest.xml
+++ b/android/daemon/src/main/AndroidManifest.xml
@@ -3,6 +3,8 @@
     package="org.mozilla.firefox.vpn.daemon">
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SYSTEM_EXEMPTED" />
+   
     <application>
         <service android:name=".VPNService"
             android:permission="android.permission.BIND_VPN_SERVICE"


### PR DESCRIPTION
## Description

> Declare new permission to use foreground service types
If apps that target Android 14 use a foreground service, they must declare a specific permission, based on the foreground service type, that Android 14 introduces. 

https://developer.android.com/about/versions/14/changes/fgs-types-required#permission-for-fgs-type

We did add a type here 
https://github.com/mozilla-mobile/mozilla-vpn-client/blob/main/android/daemon/src/main/AndroidManifest.xml#L9 
We did not add the permission, so the connection fails
