### PR TITLE
VPN-6330: Fix focus ring alignment in MZLinkButton

### DIFF
--- a/nebula/ui/components/MZLinkButton.qml
+++ b/nebula/ui/components/MZLinkButton.qml
@@ -115,7 +115,7 @@ MZButtonBase {
     }
 
     contentItem: RowLayout {
-        spacing: MZTheme.theme.windowMargin / 2
+        spacing: iconLoader.active?  MZTheme.theme.windowMargin / 2 : 0
 
         Loader {
             id: iconLoader


### PR DESCRIPTION
## Description

This PR fixes the alignment of the focus indicator in MZLinkButton {}. 

<table>
<tr>
<th colspan="3">After</th>
</tr>
<tr>
<td>
<img width="200" alt="Screenshot 2024-04-29 at 1 58 41 PM" src="https://github.com/mozilla-mobile/mozilla-vpn-client/assets/22355127/5595486b-a969-4719-a13b-d1731d196c16">
</td>
<td>
<img width="200" alt="Screenshot 2024-04-29 at 1 58 27 PM" src="https://github.com/mozilla-mobile/mozilla-vpn-client/assets/22355127/33fd3aec-ea82-4fc5-8ac1-4a17427d4934">
</td>
<td>
<img width="200" alt="Screenshot 2024-04-29 at 1 58 22 PM" src="https://github.com/mozilla-mobile/mozilla-vpn-client/assets/22355127/7d78a4fb-9b4d-4ca8-b0fe-868285a41ede">
</td>
</tr>
</td>
</table>

## Reference
VPN-6330

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
