### PR TITLE
Nit: Fix Android-Armv7 builds

### DIFF
--- a/scripts/android/conda_setup_qt.sh
+++ b/scripts/android/conda_setup_qt.sh
@@ -38,6 +38,7 @@ if ! python -m aqt install-qt --outputdir $QT_DIR $HOST android ${QT_VERSION} ${
 fi
 
 echo "$QT_DIR/$QT_VERSION/$ANDROID_ARCH/bin/qt-cmake"
+chmod +x $QT_DIR/$QT_VERSION/$ANDROID_ARCH/bin/qt-cmake
 
 
 ## Generate activation/deactivation scripts, so stuff stays portable.


### PR DESCRIPTION
## Description
This is the error: https://firefox-ci-tc.services.mozilla.com/tasks/Wi-gr5dLRval_TEDLPp8OQ/runs/0/logs/public/logs/live.log
```
Use release config./scripts/android/cmake.sh: line 134: /builds/worker/fetches/Qt/6.6.3/android_armv7/bin/qt-cmake: Permission denied
```
Looking at the packed conda env, it seems the exectutable bit was not set on this file, so let's manually do that.