### PR TITLE
VPN-6351 Improve visibility of ViewReset elems

### DIFF
--- a/src/ui/sharedViews/ViewFullScreen.qml
+++ b/src/ui/sharedViews/ViewFullScreen.qml
@@ -6,7 +6,11 @@ import QtQuick 2.5
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
 
+
+import Mozilla.Shared 1.0
+import Mozilla.VPN 1.0
 import components 0.1
+
 import "qrc:/nebula/utils/MZUiUtils.js" as MZUiUtils
 
 //View that spaces out content to take up the entire screen, but scrolls if necessary (typically on smaller devices)
@@ -39,7 +43,6 @@ MZFlickable {
 
     //Weirdly get a "parent is null" warning when popping of a stackview without checking if parent is null
     implicitHeight: parent ? parent.height : 0
-    flickContentHeight: layout.implicitHeight + layout.anchors.topMargin
 
     ColumnLayout {
         id: layout
@@ -47,7 +50,7 @@ MZFlickable {
         anchors.top: parent.top
         anchors.left: parent.left
         anchors.right: parent.right
-        anchors.topMargin: flickable.isMobile ? 0 : 48
+        anchors.topMargin: flickable.isMobile ? 0 : 24
         anchors.leftMargin: 24
         anchors.rightMargin: 24
 
@@ -80,8 +83,12 @@ MZFlickable {
 
             Layout.topMargin: flickable.isMobile ? 0 : 40
             Layout.bottomMargin: flickable.isMobile ? 36 : 48 //58 for iPhones with safe area
-
             spacing: 0
+        }
+
+         Item {
+            visible: flickable.isMobile && VPN.UserAuthenticated
+            Layout.minimumHeight: MZTheme.theme.navBarBottomMargin + MZTheme.theme.navBarHeight
         }
 
         Item {


### PR DESCRIPTION
## Description

Small UI tweaks to improve the visibility of factory reset view elements on mobile. 
<table>
<tr>
<td>
<img width="200" alt="Screenshot 2024-05-06 at 4 23 37 PM" src="https://github.com/mozilla-mobile/mozilla-vpn-client/assets/22355127/97f3eaff-f1f9-4833-9d5a-db9564e613af">
</td>
<td>
<img width="100" alt="Screenshot 2024-05-06 at 4 14 23 PM" src="https://github.com/mozilla-mobile/mozilla-vpn-client/assets/22355127/ad1b1092-97ca-43d6-847f-933927a47d26">
</td>
<td>
<img width="100" alt="Screenshot 2024-05-06 at 11 12 54 AM" src="https://github.com/mozilla-mobile/mozilla-vpn-client/assets/22355127/b934440f-c4a5-4983-b473-25c1d0e44221">

</td>
</tr>
</table>

## Reference

VPN-6351

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
