### PR TITLE
Fix QML paths for Qt6.5+

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,7 +139,7 @@ if(NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Emscripten" AND
 endif()
 
 if(QT_KNOWN_POLICY_QTP0001)
-    qt_policy(SET QTP0001 NEW)
+    qt_policy(SET QTP0001 OLD)
 endif()
 
 message("Using Qt version ${Qt6_VERSION}")


### PR DESCRIPTION
## Description
In https://github.com/mozilla-mobile/mozilla-vpn-client/pull/9400/
we switched to qml_modules and the paths were updated. On my Mac with Qt 6.6.3 the app no longer finds main.qml.
In Qt6.5+ the way qml_modules path works have been changed https://doc.qt.io/qt-6/qt-cmake-policy-qtp0001.html. 

```
The OLD behavior of this policy is that, the RESOURCE_PREFIX argument for qt_add_qml_module() defaults to ":/".

The NEW behavior of this policy is that the RESOURCE_PREFIX argument for qt_add_qml_module() defaults to ":/qt/qml/". The new behavior ensures that modules are put into the [QML Import Path](https://doc.qt.io/qt-6/qtqml-syntax-imports.html#qml-import-path) and can be found without further setup.
```

Looking at 
```
const QUrl url(QStringLiteral("qrc:/Mozilla/VPN/main.qml"));
  engine->load(url);
```

We actually assume the "OLD" behavior, so let's enable that :) 
