### PR TITLE
Nit: [Sentry] - Pass version using semver

### DIFF
--- a/src/sentry/sentryadapter.cpp
+++ b/src/sentry/sentryadapter.cpp
@@ -72,8 +72,9 @@ void SentryAdapter::init() {
   sentry_options_set_dsn(options, dsn.toLocal8Bit().constData());
   sentry_options_set_environment(
       options, Constants::inProduction() ? "production" : "stage");
-  sentry_options_set_release(
-      options, Constants::versionString().toLocal8Bit().constData());
+  auto semver_release =
+      QString("mozilla-vpn@%0").arg(Constants::versionString());
+  sentry_options_set_release(options, semver_release.toLocal8Bit().constData());
   sentry_options_set_database_path(options,
                                    sentryFolder.toLocal8Bit().constData());
   sentry_options_set_on_crash(options, &SentryAdapter::onCrash, NULL);


### PR DESCRIPTION
## Description
One annoying thing right now is that sentry does not parse our versions. So if we mark something fixed on 2.23 (which is on stage) but we push a 2.22.1 hotfix still with that bug, the bug will be re-opened until a newer release is created. 

That is because sentry currently goes by "when was this release first seen" vs "what does the number say". 

For that we need to pass that string formatted using semver. 
With that pr i created a test crash: see semver is now "yes" for 2.23.
https://mozilla.sentry.io/releases/mozilla-vpn%402.23.0/?project=4504197915607040
