### PR TITLE
Nit: Remove GHA retries for failed tests

### DIFF
--- a/.github/workflows/linux_tests.yaml
+++ b/.github/workflows/linux_tests.yaml
@@ -117,19 +117,16 @@ jobs:
 
       - name: Running ${{ matrix.test.name }} Tests
         id: runTests
-        uses: nick-invision/retry@v3
-        with:
-          timeout_minutes: 15
-          max_attempts: 3
-          command: |
-            export PATH=$GECKOWEBDRIVER:$(npm bin):$PATH
-            export HEADLESS=yes
-            export TZ=Europe/London
-            mkdir -p $ARTIFACT_DIR
-            xvfb-run -a npm run functionalTest --  --retries 3 ${{matrix.test.path}}
+        shell: bash
         env:
+          TZ: Europe/London
+          HEADLESS: yes
           ARTIFACT_DIR: ${{ runner.temp }}/artifacts
           MVPN_BIN: ./build/dummyvpn
+        run: |
+          export PATH=$GECKOWEBDRIVER:$(npm bin):$PATH
+          mkdir -p $ARTIFACT_DIR
+          xvfb-run -a npm run functionalTest --  --retries 3 ${{matrix.test.path}}
 
       - name: Uploading artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/macos_tests.yaml
+++ b/.github/workflows/macos_tests.yaml
@@ -116,20 +116,17 @@ jobs:
           ./build/dummyvpn -v
 
       - name: Running ${{ matrix.test.name }} Tests
+        shell: bash
         id: runTests
-        uses: nick-invision/retry@v3
-        with:
-          timeout_minutes: 15
-          max_attempts: 3
-          command: |
-            export PATH=$GECKOWEBDRIVER:$(npm bin):$PATH
-            export HEADLESS=yes
-            export TZ=Europe/London
-            mkdir -p $ARTIFACT_DIR
-            npm run functionalTest --  --retries 3 ${{ matrix.test.path }}
         env:
+          TZ: Europe/London
+          HEADLESS: yes
           ARTIFACT_DIR: ${{ runner.temp }}/artifacts
           MVPN_BIN: ./build/dummyvpn
+        run: |
+          export PATH=$GECKOWEBDRIVER:$(npm bin):$PATH
+          mkdir -p $ARTIFACT_DIR
+          npm run functionalTest --  --retries 3 ${{ matrix.test.path }}
 
       - name: Uploading artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/wasm_tests.yaml
+++ b/.github/workflows/wasm_tests.yaml
@@ -133,13 +133,10 @@ jobs:
 
       - name: Running ${{ matrix.test.name }} Tests
         id: runTests
-        uses: nick-invision/retry@v3
-        with:
-          timeout_minutes: 15
-          max_attempts: 3
-          command: |
-            export PATH=$GECKOWEBDRIVER:$(npm bin):$PATH
-            export HEADLESS=yes
-            export WASM_BUILD_DIRECTORY=$(pwd)/build/wasm_build
-            export MVPN_ADDONS_PATH=$(pwd)/build/addons
-            xvfb-run -a npm run functionalTestWasm --  --retries 3 ${{ matrix.test.path }}
+        env:
+          HEADLESS: yes
+          WASM_BUILD_DIRECTORY: ${{ github.workspace }}/build/wasm_build
+          MVPN_ADDONS_PATH: ${{ github.workspace }}/build/addons
+        run: |
+          export PATH=$GECKOWEBDRIVER:$(npm bin):$PATH
+          xvfb-run -a npm run functionalTestWasm --  --retries 3 ${{ matrix.test.path }}

--- a/nebula/ui/components/MZStackView.qml
+++ b/nebula/ui/components/MZStackView.qml
@@ -9,6 +9,7 @@ import Mozilla.Shared 1.0
 
 StackView {
     id: stackView
+    property bool ready: !busy && !empty
 
     Component.onCompleted: function(){
         if(!currentItem && initialItem) {

--- a/nebula/ui/components/MZStepNavigation.qml
+++ b/nebula/ui/components/MZStepNavigation.qml
@@ -117,6 +117,8 @@ ColumnLayout {
 
         StackView {
             id: stackView
+            propery bool ready: !busy
+
             objectName: "stepNavStackView"
 
             anchors.top: parent.top

--- a/nebula/ui/components/MZStepNavigation.qml
+++ b/nebula/ui/components/MZStepNavigation.qml
@@ -117,7 +117,7 @@ ColumnLayout {
 
         StackView {
             id: stackView
-            propery bool ready: !busy
+            property bool ready: !busy
 
             objectName: "stepNavStackView"
 

--- a/nebula/ui/components/navigator/MZNavigatorLoader.qml
+++ b/nebula/ui/components/navigator/MZNavigatorLoader.qml
@@ -17,6 +17,7 @@ StackView {
 
   property var screens: []
   property var currentLoadPolicy: null
+  property bool ready: !empty && !busy
 
   function showCurrentComponent() {
       if (stackView.currentLoadPolicy === MZNavigator.LoadTemporarily) {

--- a/src/inspector/inspectorhandler.cpp
+++ b/src/inspector/inspectorhandler.cpp
@@ -818,7 +818,7 @@ void InspectorHandler::recv(const QByteArray& command) {
 
       QJsonObject obj = command.m_callback(this, parts);
       if (obj.contains("error")) {
-        logger.debug() << "command failed:" << obj["error"]; 
+        logger.debug() << "command failed:" << obj["error"].toString(); 
       }
       obj["type"] = command.m_commandName;
       send(QJsonDocument(obj).toJson(QJsonDocument::Compact));

--- a/src/inspector/inspectorhandler.cpp
+++ b/src/inspector/inspectorhandler.cpp
@@ -818,7 +818,7 @@ void InspectorHandler::recv(const QByteArray& command) {
 
       QJsonObject obj = command.m_callback(this, parts);
       if (obj.contains("error")) {
-        logger.debug() << "command failed:" << obj["error"].toString(); 
+        logger.debug() << "command failed:" << obj["error"].toString();
       }
       obj["type"] = command.m_commandName;
       send(QJsonDocument(obj).toJson(QJsonDocument::Compact));

--- a/src/inspector/inspectorhandler.cpp
+++ b/src/inspector/inspectorhandler.cpp
@@ -817,6 +817,9 @@ void InspectorHandler::recv(const QByteArray& command) {
       }
 
       QJsonObject obj = command.m_callback(this, parts);
+      if (obj.contains("error")) {
+        logger.debug() << "command failed:" << obj["error"]; 
+      }
       obj["type"] = command.m_commandName;
       send(QJsonDocument(obj).toJson(QJsonDocument::Compact));
       return;

--- a/src/ui/screens/home/controller/ip/IPInfoPanel.qml
+++ b/src/ui/screens/home/controller/ip/IPInfoPanel.qml
@@ -11,7 +11,7 @@ import components 0.1
 
 Rectangle {
     property bool isOpen: false
-    property bool busy: opacityAnimation.running
+    property bool ready: !opacityAnimation.running
 
     anchors.fill: parent
     color: MZTheme.colors.primary

--- a/src/ui/screens/home/servers/ServerCountry.qml
+++ b/src/ui/screens/home/servers/ServerCountry.qml
@@ -23,7 +23,7 @@ MZClickableRow {
     property alias serverCountryName: countryName.text
     property var cityList: cityListVisible ? cityLoader.item : cityLoader
     property var cityListExpandedHeight: 54 * cities.length
-    property var busy: cityListVisible && (scrollAnimation.running || listOpenTransition.running || listClosedTransition.running)
+    property bool ready: cityListVisible && !(scrollAnimation.running || listOpenTransition.running || listClosedTransition.running)
 
     Component.onCompleted:{
        cityLoader.active = cityListVisible

--- a/src/ui/screens/home/servers/ServerList.qml
+++ b/src/ui/screens/home/servers/ServerList.qml
@@ -290,7 +290,7 @@ FocusScope {
         MZFlickable {
             objectName: "serverCountryView"
             property alias countries: countriesRepeater
-            property bool busy: scrollAnimation.running
+            property bool ready: !scrollAnimation.running
             id: vpnFlickable
 
             flickContentHeight: serverList.implicitHeight

--- a/tests/functional/helper.js
+++ b/tests/functional/helper.js
@@ -338,6 +338,16 @@ module.exports = {
     return json.value || null;
   },
 
+  async waitForGleanValue(metricCategory, metricName, ping, count = 1) {
+    // Wait for at least 'count' pings to be recorded, and return them.
+    let result = null;
+    await this.waitForCondition(async () => {
+      result = await this.gleanTestGetValue(metricCategory, metricName, ping);
+      return result.length >= count;
+    });
+    return result;
+  },
+
   async getLastUrl() {
     return await this.getMozillaProperty(
         'Mozilla.Shared', 'MZUrlOpener', 'lastUrl');

--- a/tests/functional/queries.js
+++ b/tests/functional/queries.js
@@ -51,7 +51,7 @@ class QmlQueryComposer {
   }
 
   ready() {
-    return this.prop('busy', false);
+    return this.prop('ready', true);
   }
 
   opened() {

--- a/tests/functional/setupWasm.js
+++ b/tests/functional/setupWasm.js
@@ -78,8 +78,8 @@ exports.mochaHooks = {
         new firefox.ServiceBuilder()
           .setStdio([
             'ignore',
-            fs.openSync(stdout, 'w'),
-            'ignore',
+            process.stderr,
+            process.stderr,
           ])
       )
       .build();

--- a/tests/functional/setupWasm.js
+++ b/tests/functional/setupWasm.js
@@ -36,6 +36,7 @@ let url;
 
 exports.mochaHooks = {
   async beforeAll() {
+    console.log("DEBUG beforeAll started");
     if (process.env['MZ_WASM_URL']) {
       url = process.env['MZ_WASM_URL'];
     } else {
@@ -43,10 +44,15 @@ exports.mochaHooks = {
       url = wasm.url;
     }
 
+    console.log("DEBUG B");
     await guardian.start(false);
+    console.log("DEBUG C");
     await fxaServer.start(guardian.url, false);
+    console.log("DEBUG D");
     await addonServer.start(false);
+    console.log("DEBUG E");
     await captivePortalServer.start(false);
+    console.log("DEBUG F");
 
     const u = new URL(`${url}/test.html`);
     u.searchParams.set('guardian', guardian.url);
@@ -77,6 +83,8 @@ exports.mochaHooks = {
           ])
       )
       .build();
+
+      console.log("DEBUG beforeAll complete");
   },
 
   async afterAll() {

--- a/tests/functional/setupWasm.js
+++ b/tests/functional/setupWasm.js
@@ -36,6 +36,9 @@ let url;
 
 exports.mochaHooks = {
   async beforeAll() {
+    // The webdriver can take up to 60s to try and connect.
+    this.timeout(90000);
+
     console.log("DEBUG beforeAll started");
     if (process.env['MZ_WASM_URL']) {
       url = process.env['MZ_WASM_URL'];
@@ -44,15 +47,10 @@ exports.mochaHooks = {
       url = wasm.url;
     }
 
-    console.log("DEBUG B");
     await guardian.start(false);
-    console.log("DEBUG C");
     await fxaServer.start(guardian.url, false);
-    console.log("DEBUG D");
     await addonServer.start(false);
-    console.log("DEBUG E");
     await captivePortalServer.start(false);
-    console.log("DEBUG F");
 
     const u = new URL(`${url}/test.html`);
     u.searchParams.set('guardian', guardian.url);

--- a/tests/functional/setupWasm.js
+++ b/tests/functional/setupWasm.js
@@ -36,10 +36,9 @@ let url;
 
 exports.mochaHooks = {
   async beforeAll() {
-    // The webdriver can take up to 60s to try and connect.
+    // Give the webdriver a bit more time to connect
     this.timeout(90000);
 
-    console.log("DEBUG beforeAll started");
     if (process.env['MZ_WASM_URL']) {
       url = process.env['MZ_WASM_URL'];
     } else {
@@ -76,13 +75,11 @@ exports.mochaHooks = {
         new firefox.ServiceBuilder()
           .setStdio([
             'ignore',
-            process.stderr,
-            process.stderr,
+            fs.openSync(stdout, 'w'),
+            'ignore',
           ])
       )
       .build();
-
-      console.log("DEBUG beforeAll complete");
   },
 
   async afterAll() {

--- a/tests/functional/testAuthenticationInApp.js
+++ b/tests/functional/testAuthenticationInApp.js
@@ -1096,7 +1096,7 @@ describe('User authentication', function() {
         });
 
         it('impression event is recorded', async () => {
-          const verificationViewEvent = await vpn.gleanTestGetValue(
+          const verificationViewEvent = await vpn.waitForGleanValue(
               "impression", "enterVerificationCodeScreen", "main");
           assert.strictEqual(verificationViewEvent.length, 1)
           const verificationViewEventExtras = verificationViewEvent[0].extra;
@@ -1181,11 +1181,8 @@ describe('User authentication', function() {
             });
 
             // First a failing outcome
-            let failedOutcomeEvent;
-            await vpn.waitForCondition(async () => {
-                failedOutcomeEvent = await vpn.gleanTestGetValue("outcome", "twoFaVerificationFailed", "main");
-                return failedOutcomeEvent.length == 1;
-            });
+            let failedOutcomeEvent = await vpn.waitForGleanValue("outcome", "twoFaVerificationFailed", "main");
+            assert.strictEqual(failedOutcomeEvent.length, 1);
             const failedOutcomeExtras = failedOutcomeEvent[0].extra;
             assert.strictEqual("email", failedOutcomeExtras.type);
 
@@ -1215,7 +1212,7 @@ describe('User authentication', function() {
             await vpn.wait();
 
             // Now the successfull outcome
-            const successOutcomeEvent = await vpn.gleanTestGetValue("outcome", "twoFaVerificationSucceeded", "main");
+            const successOutcomeEvent = await vpn.waitForGleanValue("outcome", "twoFaVerificationSucceeded", "main");
             assert.strictEqual(successOutcomeEvent.length, 1);
             const successOutcomeExtras = successOutcomeEvent[0].extra;
             assert.strictEqual("email", successOutcomeExtras.type);
@@ -1256,7 +1253,7 @@ describe('User authentication', function() {
         });
 
         it("impression event is recorded", async () => {
-            const  verificationViewEvent = await vpn.gleanTestGetValue("impression", "enterSecurityCodeScreen", "main");
+            const  verificationViewEvent = await vpn.waitForGleanValue("impression", "enterSecurityCodeScreen", "main");
             assert.strictEqual(verificationViewEvent.length, 1)
             const verificationViewEventExtras = verificationViewEvent[0].extra;
             assert.strictEqual(screen, verificationViewEventExtras.screen);
@@ -1331,11 +1328,8 @@ describe('User authentication', function() {
             });
 
             // First a failing outcome
-            let failedOutcomeEvent;
-            await vpn.waitForCondition(async () => {
-                failedOutcomeEvent = await vpn.gleanTestGetValue("outcome", "twoFaVerificationFailed", "main");
-                return failedOutcomeEvent.length == 1;
-            });
+            let failedOutcomeEvent = await vpn.waitForGleanValue("outcome", "twoFaVerificationFailed", "main");
+            assert.strictEqual(failedOutcomeEvent.length, 1)
             const failedOutcomeExtras = failedOutcomeEvent[0].extra;
             assert.strictEqual("totp", failedOutcomeExtras.type);
 
@@ -1367,7 +1361,7 @@ describe('User authentication', function() {
             await vpn.wait();
 
             // Now the successfull outcome
-            const successOutcomeEvent = await vpn.gleanTestGetValue("outcome", "twoFaVerificationSucceeded", "main");
+            const successOutcomeEvent = await vpn.waitForGleanValue("outcome", "twoFaVerificationSucceeded", "main");
             assert.strictEqual(successOutcomeEvent.length, 1);
             const successOutcomeExtras = successOutcomeEvent[0].extra;
             assert.strictEqual("totp", successOutcomeExtras.type);

--- a/tests/functional/testAuthenticationInAppAccountCreationNav.js
+++ b/tests/functional/testAuthenticationInAppAccountCreationNav.js
@@ -51,9 +51,8 @@ describe('User authentication', function() {
           queries.screenAuthenticationInApp.AUTH_START_TEXT_INPUT.visible());
       await vpn.waitForQueryAndClick(
           queries.screenAuthenticationInApp.AUTH_START_GET_HELP_LINK.visible());
-      await vpn.waitForQuery(queries.screenGetHelp.BACK_BUTTON.visible());
-      await vpn.waitForQuery(queries.global.SCREEN_LOADER.ready());
-      await vpn.waitForQueryAndClick(queries.screenGetHelp.BACK_BUTTON);
+      await vpn.waitForQuery(queries.screenGetHelp.STACKVIEW.ready());
+      await vpn.waitForQueryAndClick(queries.screenGetHelp.BACK_BUTTON.visible());
       await vpn.waitForQuery(queries.global.SCREEN_LOADER.ready());
       await vpn.waitForQuery(
           queries.screenAuthenticationInApp.AUTH_START_TEXT_INPUT.visible());
@@ -74,8 +73,8 @@ describe('User authentication', function() {
 
       await vpn.waitForQueryAndClick(queries.screenAuthenticationInApp
                                          .AUTH_SIGNUP_GET_HELP_LINK.visible());
-      await vpn.waitForQuery(queries.global.SCREEN_LOADER.ready());
-      await vpn.waitForQueryAndClick(queries.screenGetHelp.BACK_BUTTON);
+      await vpn.waitForQuery(queries.screenGetHelp.STACKVIEW.ready());
+      await vpn.waitForQueryAndClick(queries.screenGetHelp.BACK_BUTTON.visible());
       await vpn.waitForQuery(queries.global.SCREEN_LOADER.ready());
       await vpn.waitForQuery(
           queries.screenAuthenticationInApp.AUTH_SIGNUP_BACK_BUTTON.visible());
@@ -101,8 +100,8 @@ describe('User authentication', function() {
 
       await vpn.waitForQueryAndClick(queries.screenAuthenticationInApp
                                          .AUTH_SIGNIN_GET_HELP_LINK.visible());
-      await vpn.waitForQuery(queries.global.SCREEN_LOADER.ready());
-      await vpn.waitForQueryAndClick(queries.screenGetHelp.BACK_BUTTON);
+      await vpn.waitForQuery(queries.screenGetHelp.STACKVIEW.ready());
+      await vpn.waitForQueryAndClick(queries.screenGetHelp.BACK_BUTTON.visible());
       await vpn.waitForQuery(queries.global.SCREEN_LOADER.ready());
       await vpn.waitForQuery(
           queries.screenAuthenticationInApp.AUTH_SIGNIN_BACK_BUTTON.visible());
@@ -144,8 +143,8 @@ describe('User authentication', function() {
       await vpn.waitForQueryAndClick(
           queries.screenAuthenticationInApp.AUTH_EMAILVER_GET_HELP_LINK
               .visible());
-      await vpn.waitForQuery(queries.global.SCREEN_LOADER.ready());
-      await vpn.waitForQueryAndClick(queries.screenGetHelp.BACK_BUTTON);
+      await vpn.waitForQuery(queries.screenGetHelp.STACKVIEW.ready());
+      await vpn.waitForQueryAndClick(queries.screenGetHelp.BACK_BUTTON.visible());
       await vpn.waitForQuery(queries.global.SCREEN_LOADER.ready());
 
       // Step 8: email verification -> start
@@ -184,8 +183,8 @@ describe('User authentication', function() {
 
       await vpn.waitForQueryAndClick(
           queries.screenAuthenticationInApp.AUTH_TOTP_GET_HELP_LINK.visible());
-      await vpn.waitForQuery(queries.global.SCREEN_LOADER.ready());
-      await vpn.waitForQueryAndClick(queries.screenGetHelp.BACK_BUTTON);
+      await vpn.waitForQuery(queries.screenGetHelp.STACKVIEW.ready());
+      await vpn.waitForQueryAndClick(queries.screenGetHelp.BACK_BUTTON.visible());
       await vpn.waitForQuery(queries.global.SCREEN_LOADER.ready());
       await vpn.waitForQuery(
           queries.screenAuthenticationInApp.AUTH_TOTP_CANCEL_BUTTON.visible());
@@ -228,8 +227,8 @@ describe('User authentication', function() {
       await vpn.waitForQueryAndClick(
           queries.screenAuthenticationInApp.AUTH_UNBLOCKCODE_GET_HELP_LINK
               .visible());
-      await vpn.waitForQuery(queries.global.SCREEN_LOADER.ready());
-      await vpn.waitForQueryAndClick(queries.screenGetHelp.BACK_BUTTON);
+      await vpn.waitForQuery(queries.screenGetHelp.STACKVIEW.ready());
+      await vpn.waitForQueryAndClick(queries.screenGetHelp.BACK_BUTTON.visible());
       await vpn.waitForQuery(queries.global.SCREEN_LOADER.ready());
       await vpn.waitForQuery(queries.screenAuthenticationInApp
                                  .AUTH_UNBLOCKCODE_BACK_BUTTON.visible());

--- a/tests/functional/testAuthenticationInAppAccountCreationNav.js
+++ b/tests/functional/testAuthenticationInAppAccountCreationNav.js
@@ -51,6 +51,7 @@ describe('User authentication', function() {
           queries.screenAuthenticationInApp.AUTH_START_TEXT_INPUT.visible());
       await vpn.waitForQueryAndClick(
           queries.screenAuthenticationInApp.AUTH_START_GET_HELP_LINK.visible());
+      await vpn.waitForQuery(queries.screenGetHelp.STACKVIEW.prop('empty', false));
       await vpn.waitForQuery(queries.screenGetHelp.STACKVIEW.ready());
       await vpn.waitForQueryAndClick(queries.screenGetHelp.BACK_BUTTON.visible());
       await vpn.waitForQuery(queries.global.SCREEN_LOADER.ready());
@@ -73,6 +74,7 @@ describe('User authentication', function() {
 
       await vpn.waitForQueryAndClick(queries.screenAuthenticationInApp
                                          .AUTH_SIGNUP_GET_HELP_LINK.visible());
+      await vpn.waitForQuery(queries.screenGetHelp.STACKVIEW.prop('empty', false));
       await vpn.waitForQuery(queries.screenGetHelp.STACKVIEW.ready());
       await vpn.waitForQueryAndClick(queries.screenGetHelp.BACK_BUTTON.visible());
       await vpn.waitForQuery(queries.global.SCREEN_LOADER.ready());
@@ -100,6 +102,7 @@ describe('User authentication', function() {
 
       await vpn.waitForQueryAndClick(queries.screenAuthenticationInApp
                                          .AUTH_SIGNIN_GET_HELP_LINK.visible());
+      await vpn.waitForQuery(queries.screenGetHelp.STACKVIEW.prop('empty', false));
       await vpn.waitForQuery(queries.screenGetHelp.STACKVIEW.ready());
       await vpn.waitForQueryAndClick(queries.screenGetHelp.BACK_BUTTON.visible());
       await vpn.waitForQuery(queries.global.SCREEN_LOADER.ready());
@@ -143,6 +146,7 @@ describe('User authentication', function() {
       await vpn.waitForQueryAndClick(
           queries.screenAuthenticationInApp.AUTH_EMAILVER_GET_HELP_LINK
               .visible());
+      await vpn.waitForQuery(queries.screenGetHelp.STACKVIEW.prop('empty', false));
       await vpn.waitForQuery(queries.screenGetHelp.STACKVIEW.ready());
       await vpn.waitForQueryAndClick(queries.screenGetHelp.BACK_BUTTON.visible());
       await vpn.waitForQuery(queries.global.SCREEN_LOADER.ready());
@@ -183,6 +187,7 @@ describe('User authentication', function() {
 
       await vpn.waitForQueryAndClick(
           queries.screenAuthenticationInApp.AUTH_TOTP_GET_HELP_LINK.visible());
+      await vpn.waitForQuery(queries.screenGetHelp.STACKVIEW.prop('empty', false));
       await vpn.waitForQuery(queries.screenGetHelp.STACKVIEW.ready());
       await vpn.waitForQueryAndClick(queries.screenGetHelp.BACK_BUTTON.visible());
       await vpn.waitForQuery(queries.global.SCREEN_LOADER.ready());
@@ -227,6 +232,7 @@ describe('User authentication', function() {
       await vpn.waitForQueryAndClick(
           queries.screenAuthenticationInApp.AUTH_UNBLOCKCODE_GET_HELP_LINK
               .visible());
+      await vpn.waitForQuery(queries.screenGetHelp.STACKVIEW.prop('empty', false));
       await vpn.waitForQuery(queries.screenGetHelp.STACKVIEW.ready());
       await vpn.waitForQueryAndClick(queries.screenGetHelp.BACK_BUTTON.visible());
       await vpn.waitForQuery(queries.global.SCREEN_LOADER.ready());

--- a/tests/functional/testAuthenticationInAppAccountCreationNav.js
+++ b/tests/functional/testAuthenticationInAppAccountCreationNav.js
@@ -51,6 +51,7 @@ describe('User authentication', function() {
           queries.screenAuthenticationInApp.AUTH_START_TEXT_INPUT.visible());
       await vpn.waitForQueryAndClick(
           queries.screenAuthenticationInApp.AUTH_START_GET_HELP_LINK.visible());
+      await vpn.waitForQuery(queries.screenGetHelp.BACK_BUTTON.visible());
       await vpn.waitForQuery(queries.global.SCREEN_LOADER.ready());
       await vpn.waitForQueryAndClick(queries.screenGetHelp.BACK_BUTTON);
       await vpn.waitForQuery(queries.global.SCREEN_LOADER.ready());

--- a/tests/functional/testAuthenticationInAppAccountCreationNav.js
+++ b/tests/functional/testAuthenticationInAppAccountCreationNav.js
@@ -51,7 +51,6 @@ describe('User authentication', function() {
           queries.screenAuthenticationInApp.AUTH_START_TEXT_INPUT.visible());
       await vpn.waitForQueryAndClick(
           queries.screenAuthenticationInApp.AUTH_START_GET_HELP_LINK.visible());
-      await vpn.waitForQuery(queries.screenGetHelp.STACKVIEW.prop('empty', false));
       await vpn.waitForQuery(queries.screenGetHelp.STACKVIEW.ready());
       await vpn.waitForQueryAndClick(queries.screenGetHelp.BACK_BUTTON.visible());
       await vpn.waitForQuery(queries.global.SCREEN_LOADER.ready());
@@ -74,7 +73,6 @@ describe('User authentication', function() {
 
       await vpn.waitForQueryAndClick(queries.screenAuthenticationInApp
                                          .AUTH_SIGNUP_GET_HELP_LINK.visible());
-      await vpn.waitForQuery(queries.screenGetHelp.STACKVIEW.prop('empty', false));
       await vpn.waitForQuery(queries.screenGetHelp.STACKVIEW.ready());
       await vpn.waitForQueryAndClick(queries.screenGetHelp.BACK_BUTTON.visible());
       await vpn.waitForQuery(queries.global.SCREEN_LOADER.ready());
@@ -102,7 +100,6 @@ describe('User authentication', function() {
 
       await vpn.waitForQueryAndClick(queries.screenAuthenticationInApp
                                          .AUTH_SIGNIN_GET_HELP_LINK.visible());
-      await vpn.waitForQuery(queries.screenGetHelp.STACKVIEW.prop('empty', false));
       await vpn.waitForQuery(queries.screenGetHelp.STACKVIEW.ready());
       await vpn.waitForQueryAndClick(queries.screenGetHelp.BACK_BUTTON.visible());
       await vpn.waitForQuery(queries.global.SCREEN_LOADER.ready());
@@ -146,7 +143,6 @@ describe('User authentication', function() {
       await vpn.waitForQueryAndClick(
           queries.screenAuthenticationInApp.AUTH_EMAILVER_GET_HELP_LINK
               .visible());
-      await vpn.waitForQuery(queries.screenGetHelp.STACKVIEW.prop('empty', false));
       await vpn.waitForQuery(queries.screenGetHelp.STACKVIEW.ready());
       await vpn.waitForQueryAndClick(queries.screenGetHelp.BACK_BUTTON.visible());
       await vpn.waitForQuery(queries.global.SCREEN_LOADER.ready());
@@ -187,7 +183,6 @@ describe('User authentication', function() {
 
       await vpn.waitForQueryAndClick(
           queries.screenAuthenticationInApp.AUTH_TOTP_GET_HELP_LINK.visible());
-      await vpn.waitForQuery(queries.screenGetHelp.STACKVIEW.prop('empty', false));
       await vpn.waitForQuery(queries.screenGetHelp.STACKVIEW.ready());
       await vpn.waitForQueryAndClick(queries.screenGetHelp.BACK_BUTTON.visible());
       await vpn.waitForQuery(queries.global.SCREEN_LOADER.ready());
@@ -232,7 +227,6 @@ describe('User authentication', function() {
       await vpn.waitForQueryAndClick(
           queries.screenAuthenticationInApp.AUTH_UNBLOCKCODE_GET_HELP_LINK
               .visible());
-      await vpn.waitForQuery(queries.screenGetHelp.STACKVIEW.prop('empty', false));
       await vpn.waitForQuery(queries.screenGetHelp.STACKVIEW.ready());
       await vpn.waitForQueryAndClick(queries.screenGetHelp.BACK_BUTTON.visible());
       await vpn.waitForQuery(queries.global.SCREEN_LOADER.ready());

--- a/tests/functional/testDevices.js
+++ b/tests/functional/testDevices.js
@@ -39,7 +39,7 @@ describe('Devices', function() {
       const devicesTelemetryScreenId = "my_devices"
 
       it('Checking devices screen impression telemetry', async () => {
-        const myDevicesScreenEvents = await vpn.gleanTestGetValue("impression", "myDevicesScreen", "main");
+        const myDevicesScreenEvents = await vpn.waitForGleanValue("impression", "myDevicesScreen", "main");
         assert.equal(myDevicesScreenEvents.length, 1);
         const myDevicesScreenEventsExtras = myDevicesScreenEvents[0].extra;
         assert.equal(devicesTelemetryScreenId, myDevicesScreenEventsExtras.screen);
@@ -50,21 +50,21 @@ describe('Devices', function() {
 
         await vpn.waitForQueryAndClick(queries.screenSettings.myDevicesView.HELP_BUTTON.visible());
 
-        const helpTooltipSelectedEvents = await vpn.gleanTestGetValue("interaction", "helpTooltipSelected", "main");
+        const helpTooltipSelectedEvents = await vpn.waitForGleanValue("interaction", "helpTooltipSelected", "main");
         assert.equal(helpTooltipSelectedEvents.length, 1);
         const helpTooltipSelectedEventsExtras = helpTooltipSelectedEvents[0].extra;
         assert.equal(devicesTelemetryScreenId, helpTooltipSelectedEventsExtras.screen);
 
         await vpn.waitForQuery(queries.screenSettings.myDevicesView.HELP_SHEET.opened());
 
-        const myDevicesInfoScreenEvents = await vpn.gleanTestGetValue("impression", "myDevicesInfoScreen", "main");
+        const myDevicesInfoScreenEvents = await vpn.waitForGleanValue("impression", "myDevicesInfoScreen", "main");
         assert.equal(myDevicesInfoScreenEvents.length, 1);
         const myDevicesInfoScreenEventsExtras = myDevicesInfoScreenEvents[0].extra;
         assert.equal(devicesHelpSheetTelemetryScreenId, myDevicesInfoScreenEventsExtras.screen);
 
         await vpn.waitForQueryAndClick(queries.screenSettings.appPreferencesView.dnsSettingsView.HELP_SHEET_LEARN_MORE_BUTTON.visible());
 
-        const learnMoreSelectedEvents = await vpn.gleanTestGetValue("interaction", "learnMoreSelected", "main");
+        const learnMoreSelectedEvents = await vpn.waitForGleanValue("interaction", "learnMoreSelected", "main");
         assert.equal(learnMoreSelectedEvents.length, 1);
         const learnMoreSelectedEventsExtras = learnMoreSelectedEvents[0].extra;
         assert.equal(devicesHelpSheetTelemetryScreenId, learnMoreSelectedEventsExtras.screen);

--- a/tests/functional/testInitialize.js
+++ b/tests/functional/testInitialize.js
@@ -101,11 +101,8 @@ describe('Initialize', function() {
       await startAndConnect();
 
       await vpn.waitForQuery(queries.screenInitialize.SIGN_UP_BUTTON.visible());
-      let signupScreenEvents;
-      await vpn.waitForCondition(async () => {
-        signupScreenEvents = await vpn.gleanTestGetValue("impression", "signupScreen", "main");
-        return signupScreenEvents.length === 1;
-      });
+      let signupScreenEvents = await vpn.waitForGleanValue("impression", "signupScreen", "main");
+      assert.strictEqual(signupScreenEvents.length, 1);
       const signupScreenExtras = signupScreenEvents[0].extra;
       assert.strictEqual(telemetryScreenId, signupScreenExtras.screen);
     });
@@ -114,7 +111,7 @@ describe('Initialize', function() {
       // Click on the "Help" link
       await vpn.waitForQueryAndClick(
         queries.screenInitialize.GET_HELP_LINK.visible());
-      const getHelpEvents = await vpn.gleanTestGetValue("interaction", "getHelpSelected", "main");
+      const getHelpEvents = await vpn.waitForGleanValue("interaction", "getHelpSelected", "main");
       assert.strictEqual(getHelpEvents.length, 1);
       const getHelpExtras = getHelpEvents[0].extra;
       assert.strictEqual(telemetryScreenId, getHelpExtras.screen);
@@ -124,7 +121,7 @@ describe('Initialize', function() {
       // Click the "Sign up" button
       await vpn.waitForQueryAndClick(
         queries.screenInitialize.SIGN_UP_BUTTON.visible());
-      const signupButtonEvents = await vpn.gleanTestGetValue("interaction", "signupSelected", "main");
+      const signupButtonEvents = await vpn.waitForGleanValue("interaction", "signupSelected", "main");
       assert.strictEqual(signupButtonEvents.length, 1);
       const signupButtonExtras = signupButtonEvents[0].extra;
       assert.strictEqual(telemetryScreenId, signupButtonExtras.screen);
@@ -134,7 +131,7 @@ describe('Initialize', function() {
       // Click the "Already a subscriber?" button
       await vpn.waitForQueryAndClick(
         queries.screenInitialize.ALREADY_A_SUBSCRIBER_LINK.visible());
-      const alreadyASubscriberButtonEvents = await vpn.gleanTestGetValue("interaction", "alreadyASubscriberSelected", "main");
+      const alreadyASubscriberButtonEvents = await vpn.waitForGleanValue("interaction", "alreadyASubscriberSelected", "main");
       assert.strictEqual(alreadyASubscriberButtonEvents.length, 1);
       const alreadyASubscriberButtonExtras = alreadyASubscriberButtonEvents[0].extra;
       assert.strictEqual(telemetryScreenId, alreadyASubscriberButtonExtras.screen);

--- a/tests/functional/testIpInfo.js
+++ b/tests/functional/testIpInfo.js
@@ -69,7 +69,7 @@ describe('IP info', function() {
           await vpn.getQueryProperty(
               queries.screenHome.IP_INFO_PANEL, 'isOpen'), 'true');
 
-      const openedEventsList = await vpn.gleanTestGetValue("interaction", "openConnectionInfoSelected", "main")
+      const openedEventsList = await vpn.waitForGleanValue("interaction", "openConnectionInfoSelected", "main")
       assert.strictEqual(openedEventsList.length, 1);
       const openedExtras = openedEventsList[0].extra;
       assert.strictEqual("main", openedExtras.screen);
@@ -83,7 +83,7 @@ describe('IP info', function() {
           await vpn.getQueryProperty(
               queries.screenHome.IP_INFO_PANEL, 'isOpen'), 'false');
 
-      const closedEventsList = await vpn.gleanTestGetValue("interaction", "closeSelected", "main")
+      const closedEventsList = await vpn.waitForGleanValue("interaction", "closeSelected", "main")
       assert.strictEqual(closedEventsList.length, 1);
       const closedExtras = closedEventsList[0].extra;
       assert.strictEqual("connection_info", closedExtras.screen);

--- a/tests/functional/testOnboarding.js
+++ b/tests/functional/testOnboarding.js
@@ -383,7 +383,7 @@ describe('Onboarding', function() {
 
     it('Onboarding started event is recorded', async () => {
       await vpn.waitForQuery(queries.screenOnboarding.ONBOARDING_VIEW.visible());
-      let onboardingStartedEvents = await vpn.gleanTestGetValue("outcome", "onboardingStarted", "main");
+      let onboardingStartedEvents = await vpn.waitForGleanValue("outcome", "onboardingStarted", "main");
       assert.equal(onboardingStartedEvents.length, 1);
 
       //Quit and relaunch the app
@@ -403,13 +403,13 @@ describe('Onboarding', function() {
 
       await vpn.completeOnboarding()
 
-      let onboardingCompletedEvents = await vpn.gleanTestGetValue("outcome", "onboardingCompleted", "main");
+      let onboardingCompletedEvents = await vpn.waitForGleanValue("outcome", "onboardingCompleted", "main");
       assert.equal(onboardingCompletedEvents.length, 1);
     });
 
     it('Onboarding slide impression events are recorded', async () => {
       //Verify that dataCollectionScreen event is recorded
-      const dataCollectionScreenEvents = await vpn.gleanTestGetValue("impression", "dataCollectionScreen", "main");
+      const dataCollectionScreenEvents = await vpn.waitForGleanValue("impression", "dataCollectionScreen", "main");
       assert.equal(dataCollectionScreenEvents.length, 1);
       const dataCollectionScreenEventsExtras = dataCollectionScreenEvents[0].extra;
       assert.equal(dataScreenTelemetryId, dataCollectionScreenEventsExtras.screen);
@@ -417,7 +417,7 @@ describe('Onboarding', function() {
       await advanceToSlide(1)
 
       //Verify that getMorePrivacyScreen event is recorded
-      const getMorePrivacyScreenEvents = await vpn.gleanTestGetValue("impression", "getMorePrivacyScreen", "main");
+      const getMorePrivacyScreenEvents = await vpn.waitForGleanValue("impression", "getMorePrivacyScreen", "main");
       assert.equal(getMorePrivacyScreenEvents.length, 1);
       const getMorePrivacyScreenEventsExtras = getMorePrivacyScreenEvents[0].extra;
       assert.equal(privacyScreenTelemetryId, getMorePrivacyScreenEventsExtras.screen);
@@ -425,7 +425,7 @@ describe('Onboarding', function() {
       await advanceToSlide(2)
 
       //Verify that installOn5DevicesScreen event is recorded
-      const installOn5DevicesScreenEvents = await vpn.gleanTestGetValue("impression", "installOn5DevicesScreen", "main");
+      const installOn5DevicesScreenEvents = await vpn.waitForGleanValue("impression", "installOn5DevicesScreen", "main");
       assert.equal(installOn5DevicesScreenEvents.length, 1);
       const installOn5DevicesScreenEventsExtras = installOn5DevicesScreenEvents[0].extra;
       assert.equal(devicesScreenTelemetryId, installOn5DevicesScreenEventsExtras.screen);
@@ -433,7 +433,7 @@ describe('Onboarding', function() {
       await advanceToSlide(3)
 
       //Verify that connectOnStartupScreen event is recorded
-      const connectOnStartupScreenEvents = await vpn.gleanTestGetValue("impression", "connectOnStartupScreen", "main");
+      const connectOnStartupScreenEvents = await vpn.waitForGleanValue("impression", "connectOnStartupScreen", "main");
       assert.equal(connectOnStartupScreenEvents.length, 1);
       const connectOnStartupScreenEventsExtras = connectOnStartupScreenEvents[0].extra;
       assert.equal(startScreenTelemetryId, connectOnStartupScreenEventsExtras.screen);
@@ -504,7 +504,7 @@ describe('Onboarding', function() {
 
       //Ensure addDevicesSelected event is recorded from the start screen
       await vpn.waitForQueryAndClick(queries.screenOnboarding.STEP_PROG_BAR_DEVICES_BUTTON.visible());
-      addDevicesSelectedEvents = await vpn.gleanTestGetValue("interaction", "addDevicesSelected", "main");
+      addDevicesSelectedEvents = await vpn.waitForGleanValue("interaction", "addDevicesSelected", "main");
       assert.equal(addDevicesSelectedEvents.length, 1);
       let addDevicesSelectedEventsExtras = addDevicesSelectedEvents[0].extra;
       assert.equal(startScreenTelemetryId, addDevicesSelectedEventsExtras.screen);
@@ -536,7 +536,7 @@ describe('Onboarding', function() {
 
       //Verify that privacyNoticedSelected event is recorded
       await vpn.waitForQueryAndClick(queries.screenOnboarding.DATA_PRIVACY_LINK.visible());
-      const privacyNoticeSelectedEvents = await vpn.gleanTestGetValue("interaction", "privacyNoticeSelected", "main");
+      const privacyNoticeSelectedEvents = await vpn.waitForGleanValue("interaction", "privacyNoticeSelected", "main");
       assert.equal(privacyNoticeSelectedEvents.length, 1);
       const privacyNoticeSelectedEventsExtras = privacyNoticeSelectedEvents[0].extra;
       assert.equal(dataScreenTelemetryId, privacyNoticeSelectedEventsExtras.screen);
@@ -547,7 +547,7 @@ describe('Onboarding', function() {
 
       //Verify that continueSelected event is recorded
       await vpn.waitForQueryAndClick(queries.screenOnboarding.DATA_NEXT_BUTTON.visible());
-      const continueSelectedEvents = await vpn.gleanTestGetValue("interaction", "continueSelected", "main");
+      const continueSelectedEvents = await vpn.waitForGleanValue("interaction", "continueSelected", "main");
       assert.equal(continueSelectedEvents.length, 1);
       const continueSelectedEventsExtras = continueSelectedEvents[0].extra;
       assert.equal(dataScreenTelemetryId, continueSelectedEventsExtras.screen);
@@ -560,7 +560,7 @@ describe('Onboarding', function() {
 
       //Verify that blockAdsEnabled event is recorded
       await vpn.waitForQueryAndClick(queries.screenOnboarding.PRIVACY_BLOCK_ADS_TOGGLE.visible());
-      const blockAdsEnabledEvents = await vpn.gleanTestGetValue("interaction", "blockAdsEnabled", "main");
+      const blockAdsEnabledEvents = await vpn.waitForGleanValue("interaction", "blockAdsEnabled", "main");
       assert.equal(blockAdsEnabledEvents.length, 1);
       const blockAdsEnabledEventsExtras = blockAdsEnabledEvents[0].extra;
       assert.equal(privacyScreenTelemetryId, blockAdsEnabledEventsExtras.screen);
@@ -574,35 +574,35 @@ describe('Onboarding', function() {
 
       //Verify that blockTrackersEnabled event is recorded
       await vpn.waitForQueryAndClick(queries.screenOnboarding.PRIVACY_BLOCK_TRACKERS_TOGGLE.visible());
-      const blockTrackersEnabledEvents = await vpn.gleanTestGetValue("interaction", "blockTrackersEnabled", "main");
+      const blockTrackersEnabledEvents = await vpn.waitForGleanValue("interaction", "blockTrackersEnabled", "main");
       assert.equal(blockTrackersEnabledEvents.length, 1);
       const blockTrackersEnabledEventsExtras = blockTrackersEnabledEvents[0].extra;
       assert.equal(privacyScreenTelemetryId, blockTrackersEnabledEventsExtras.screen);
 
       //Verify that blockTrackersDisabled event is recorded
       await vpn.waitForQueryAndClick(queries.screenOnboarding.PRIVACY_BLOCK_TRACKERS_TOGGLE.visible());
-      const blockTrackersDisabledEvents = await vpn.gleanTestGetValue("interaction", "blockTrackersDisabled", "main");
+      const blockTrackersDisabledEvents = await vpn.waitForGleanValue("interaction", "blockTrackersDisabled", "main");
       assert.equal(blockTrackersDisabledEvents.length, 1);
       const blockTrackersDisabledEventsExtras = blockTrackersDisabledEvents[0].extra;
       assert.equal(privacyScreenTelemetryId, blockTrackersDisabledEventsExtras.screen);
 
       //Verify that blockMalwareEnabled event is recorded
       await vpn.waitForQueryAndClick(queries.screenOnboarding.PRIVACY_BLOCK_MALWARE_TOGGLE.visible());
-      const blockMalwareEnabledEvents = await vpn.gleanTestGetValue("interaction", "blockMalwareEnabled", "main");
+      const blockMalwareEnabledEvents = await vpn.waitForGleanValue("interaction", "blockMalwareEnabled", "main");
       assert.equal(blockMalwareEnabledEvents.length, 1);
       const blockMalwareEnabledEventsExtras = blockMalwareEnabledEvents[0].extra;
       assert.equal(privacyScreenTelemetryId, blockMalwareEnabledEventsExtras.screen);
 
       //Verify that blockMalwareDisabled event is recorded
       await vpn.waitForQueryAndClick(queries.screenOnboarding.PRIVACY_BLOCK_MALWARE_TOGGLE.visible());
-      const blockMalwareDisabledEvents = await vpn.gleanTestGetValue("interaction", "blockMalwareDisabled", "main");
+      const blockMalwareDisabledEvents = await vpn.waitForGleanValue("interaction", "blockMalwareDisabled", "main");
       assert.equal(blockMalwareDisabledEvents.length, 1);
       const blockMalwareDisabledEventsExtras = blockMalwareDisabledEvents[0].extra;
       assert.equal(privacyScreenTelemetryId, blockMalwareDisabledEventsExtras.screen);
 
       //Verify that goBackSelected event is recorded
       await vpn.waitForQueryAndClick(queries.screenOnboarding.PRIVACY_BACK_BUTTON.visible());
-      const goBackSelectedEvents = await vpn.gleanTestGetValue("interaction", "goBackSelected", "main");
+      const goBackSelectedEvents = await vpn.waitForGleanValue("interaction", "goBackSelected", "main");
       assert.equal(goBackSelectedEvents.length, 1);
       const goBackSelectedEventsExtras = goBackSelectedEvents[0].extra;
       assert.equal(privacyScreenTelemetryId, goBackSelectedEventsExtras.screen);
@@ -615,7 +615,7 @@ describe('Onboarding', function() {
 
       //Verify that continueSelected event is recorded
       await vpn.waitForQueryAndClick(queries.screenOnboarding.PRIVACY_NEXT_BUTTON.visible());
-      const continueSelectedEvents = await vpn.gleanTestGetValue("interaction", "continueSelected", "main");
+      const continueSelectedEvents = await vpn.waitForGleanValue("interaction", "continueSelected", "main");
       assert.equal(continueSelectedEvents.length, 1);
       const continueSelectedEventsExtras = continueSelectedEvents[0].extra;
       assert.equal(privacyScreenTelemetryId, continueSelectedEventsExtras.screen);
@@ -630,14 +630,14 @@ describe('Onboarding', function() {
         //[Android, Windows, Linux] Starting with Android - switch to iOS and back to Android
         //Verify that showIosQrSelected event is recorded
         await vpn.waitForQueryAndClick(queries.screenOnboarding.DEVICES_TOGGLE_BTN_IOS.visible());
-        const showIosQrSelectedEvents = await vpn.gleanTestGetValue("interaction", "showIosQrSelected", "main");
+        const showIosQrSelectedEvents = await vpn.waitForGleanValue("interaction", "showIosQrSelected", "main");
         assert.equal(showIosQrSelectedEvents.length, 1);
         const showIosQrSelectedEventsExtras = showIosQrSelectedEvents[0].extra;
         assert.equal(devicesScreenTelemetryId, showIosQrSelectedEventsExtras.screen);
 
         //Verify that showAndroidQrSelected event is recorded
         await vpn.waitForQueryAndClick(queries.screenOnboarding.DEVICES_TOGGLE_BTN_ANDROID.visible());
-        const showAndroidQrSelectedEvents = await vpn.gleanTestGetValue("interaction", "showAndroidQrSelected", "main");
+        const showAndroidQrSelectedEvents = await vpn.waitForGleanValue("interaction", "showAndroidQrSelected", "main");
         assert.equal(showAndroidQrSelectedEvents.length, 1);
         const showAndroidQrSelectedEventsExtras = showAndroidQrSelectedEvents[0].extra;
         assert.equal(devicesScreenTelemetryId, showAndroidQrSelectedEventsExtras.screen);
@@ -647,14 +647,14 @@ describe('Onboarding', function() {
         //[iOS, macOS] Starting with iOS - switch to Android and back to iOS
         //Verify that showAndroidQrSelected event is recorded
         await vpn.waitForQueryAndClick(queries.screenOnboarding.DEVICES_TOGGLE_BTN_ANDROID.visible());
-        const showAndroidQrSelectedEvents = await vpn.gleanTestGetValue("interaction", "showAndroidQrSelected", "main");
+        const showAndroidQrSelectedEvents = await vpn.waitForGleanValue("interaction", "showAndroidQrSelected", "main");
         assert.equal(showAndroidQrSelectedEvents.length, 1);
         const showAndroidQrSelectedEventsExtras = showAndroidQrSelectedEvents[0].extra;
         assert.equal(devicesScreenTelemetryId, showAndroidQrSelectedEventsExtras.screen);
 
         //Verify that showIosQrSelected event is recorded
         await vpn.waitForQueryAndClick(queries.screenOnboarding.DEVICES_TOGGLE_BTN_IOS.visible());
-        const showIosQrSelectedEvents = await vpn.gleanTestGetValue("interaction", "showIosQrSelected", "main");
+        const showIosQrSelectedEvents = await vpn.waitForGleanValue("interaction", "showIosQrSelected", "main");
         assert.equal(showIosQrSelectedEvents.length, 1);
         const showIosQrSelectedEventsExtras = showIosQrSelectedEvents[0].extra;
         assert.equal(devicesScreenTelemetryId, showIosQrSelectedEventsExtras.screen);
@@ -662,7 +662,7 @@ describe('Onboarding', function() {
 
       //Verify that goBackSelected event is recorded
       await vpn.waitForQueryAndClick(queries.screenOnboarding.DEVICES_BACK_BUTTON.visible());
-      const goBackSelectedEvents = await vpn.gleanTestGetValue("interaction", "goBackSelected", "main");
+      const goBackSelectedEvents = await vpn.waitForGleanValue("interaction", "goBackSelected", "main");
       assert.equal(goBackSelectedEvents.length, 1);
       const goBackSelectedEventsExtras = goBackSelectedEvents[0].extra;
       assert.equal(devicesScreenTelemetryId, goBackSelectedEventsExtras.screen);
@@ -675,7 +675,7 @@ describe('Onboarding', function() {
 
       //Verify that continueSelected event is recorded
       await vpn.waitForQueryAndClick(queries.screenOnboarding.DEVICES_NEXT_BUTTON.visible());
-      const continueSelectedEvents = await vpn.gleanTestGetValue("interaction", "continueSelected", "main");
+      const continueSelectedEvents = await vpn.waitForGleanValue("interaction", "continueSelected", "main");
       assert.equal(continueSelectedEvents.length, 1);
       const continueSelectedEventsExtras = continueSelectedEvents[0].extra;
       assert.equal(devicesScreenTelemetryId, continueSelectedEventsExtras.screen);
@@ -688,21 +688,21 @@ describe('Onboarding', function() {
 
       //Verify that connectOnStartupEnabled event is recorded
       await vpn.waitForQueryAndClick(queries.screenOnboarding.START_START_AT_BOOT_TOGGLE.visible());
-      const connectOnStartupEnabledEvents = await vpn.gleanTestGetValue("interaction", "connectOnStartupEnabled", "main");
+      const connectOnStartupEnabledEvents = await vpn.waitForGleanValue("interaction", "connectOnStartupEnabled", "main");
       assert.equal(connectOnStartupEnabledEvents.length, 1);
       const connectOnStartupEnabledEventsExtras = connectOnStartupEnabledEvents[0].extra;
       assert.equal(startScreenTelemetryId, connectOnStartupEnabledEventsExtras.screen);
 
       //Verify that connectOnStartupDisabled event is recorded
       await vpn.waitForQueryAndClick(queries.screenOnboarding.START_START_AT_BOOT_TOGGLE.visible());
-      const connectOnStartupDisabledEvents = await vpn.gleanTestGetValue("interaction", "connectOnStartupDisabled", "main");
+      const connectOnStartupDisabledEvents = await vpn.waitForGleanValue("interaction", "connectOnStartupDisabled", "main");
       assert.equal(connectOnStartupDisabledEvents.length, 1);
       const connectOnStartupDisabledEventsExtras = connectOnStartupDisabledEvents[0].extra;
       assert.equal(startScreenTelemetryId, connectOnStartupDisabledEventsExtras.screen);
 
       //Verify that goBackSelected event is recorded
       await vpn.waitForQueryAndClick(queries.screenOnboarding.START_BACK_BUTTON.visible());
-      const goBackSelectedEvents = await vpn.gleanTestGetValue("interaction", "goBackSelected", "main");
+      const goBackSelectedEvents = await vpn.waitForGleanValue("interaction", "goBackSelected", "main");
       assert.equal(goBackSelectedEvents.length, 1);
       const goBackSelectedEventsExtras = goBackSelectedEvents[0].extra;
       assert.equal(startScreenTelemetryId, goBackSelectedEventsExtras.screen);
@@ -719,7 +719,7 @@ describe('Onboarding', function() {
 
       //Verify that getStartedSelected event is recorded
       await vpn.waitForQueryAndClick(queries.screenOnboarding.START_NEXT_BUTTON.visible());
-      const getStartedSelectedEvents = await vpn.gleanTestGetValue("interaction", "getStartedSelected", "main");
+      const getStartedSelectedEvents = await vpn.waitForGleanValue("interaction", "getStartedSelected", "main");
       assert.equal(getStartedSelectedEvents.length, 1);
       const getStartedSelectedEventsExtras = getStartedSelectedEvents[0].extra;
       assert.equal(startScreenTelemetryId, getStartedSelectedEventsExtras.screen);

--- a/tests/functional/testServers.js
+++ b/tests/functional/testServers.js
@@ -273,7 +273,7 @@ describe('Server', function() {
         await vpn.waitForQueryAndClick(queries.screenHome.SERVER_LIST_BUTTON.visible());
         await vpn.waitForQuery(queries.screenHome.STACKVIEW.ready());
 
-        const locationSinglehopScreenEvents = await vpn.gleanTestGetValue("impression", "locationSinglehopScreen", "main");
+        const locationSinglehopScreenEvents = await vpn.waitForGleanValue("impression", "locationSinglehopScreen", "main");
         assert.equal(locationSinglehopScreenEvents.length, 1);
         const locationSinglehopScreenEventsExtras = locationSinglehopScreenEvents[0].extra;
         assert.equal(singleHopTelemetryScreenId, locationSinglehopScreenEventsExtras.screen);
@@ -286,7 +286,7 @@ describe('Server', function() {
         await vpn.waitForQuery(queries.screenHome.STACKVIEW.ready());
         await vpn.waitForQueryAndClick(queries.screenHome.serverListView.SINGLEHOP_SELECTOR_TAB.visible());
 
-        const locationSinglehopScreenEvents = await vpn.gleanTestGetValue("impression", "locationSinglehopScreen", "main");
+        const locationSinglehopScreenEvents = await vpn.waitForGleanValue("impression", "locationSinglehopScreen", "main");
         assert.equal(locationSinglehopScreenEvents.length, 1);
         const locationSinglehopScreenEventsExtras = locationSinglehopScreenEvents[0].extra;
         assert.equal(singleHopTelemetryScreenId, locationSinglehopScreenEventsExtras.screen);
@@ -298,21 +298,21 @@ describe('Server', function() {
 
         await vpn.waitForQueryAndClick(queries.screenHome.serverListView.HELP_BUTTON.visible());
 
-        const helpTooltipSelectedEvents = await vpn.gleanTestGetValue("interaction", "helpTooltipSelected", "main");
+        const helpTooltipSelectedEvents = await vpn.waitForGleanValue("interaction", "helpTooltipSelected", "main");
         assert.equal(helpTooltipSelectedEvents.length, 1);
         const helpTooltipSelectedEventsExtras = helpTooltipSelectedEvents[0].extra;
         assert.equal(singleHopTelemetryScreenId, helpTooltipSelectedEventsExtras.screen);
 
         await vpn.waitForQuery(queries.screenHome.serverListView.HELP_SHEET.opened());
 
-        const locationInfoScreenEvents = await vpn.gleanTestGetValue("impression", "locationInfoScreen", "main");
+        const locationInfoScreenEvents = await vpn.waitForGleanValue("impression", "locationInfoScreen", "main");
         assert.equal(locationInfoScreenEvents.length, 1);
         const locationInfoScreenEventsExtras = locationInfoScreenEvents[0].extra;
         assert.equal(locationSheetTelemetryScreenId, locationInfoScreenEventsExtras.screen);
 
         await vpn.waitForQueryAndClick(queries.screenHome.serverListView.HELP_SHEET_LEARN_MORE_BUTTON.visible());
 
-        const learnMoreSelectedEvents = await vpn.gleanTestGetValue("interaction", "learnMoreSelected", "main");
+        const learnMoreSelectedEvents = await vpn.waitForGleanValue("interaction", "learnMoreSelected", "main");
         assert.equal(learnMoreSelectedEvents.length, 1);
         const learnMoreSelectedEventsExtras = learnMoreSelectedEvents[0].extra;
         assert.equal(locationSheetTelemetryScreenId, learnMoreSelectedEventsExtras.screen);
@@ -328,7 +328,7 @@ describe('Server', function() {
         await vpn.waitForQueryAndClick(queries.screenHome.SERVER_LIST_BUTTON.visible());
         await vpn.waitForQuery(queries.screenHome.STACKVIEW.ready());
 
-        const locationMultihopScreenEvents = await vpn.gleanTestGetValue("impression", "locationMultihopScreen", "main");
+        const locationMultihopScreenEvents = await vpn.waitForGleanValue("impression", "locationMultihopScreen", "main");
         assert.equal(locationMultihopScreenEvents.length, 1);
         const locationMultihopScreenEventsExtras = locationMultihopScreenEvents[0].extra;
         assert.equal(multiHopTelemetryScreenId, locationMultihopScreenEventsExtras.screen);
@@ -341,7 +341,7 @@ describe('Server', function() {
         await vpn.waitForQuery(queries.screenHome.STACKVIEW.ready());
         await vpn.waitForQueryAndClick(queries.screenHome.serverListView.MULTIHOP_SELECTOR_TAB.visible());
 
-        const locationMultihopScreenEvents = await vpn.gleanTestGetValue("impression", "locationMultihopScreen", "main");
+        const locationMultihopScreenEvents = await vpn.waitForGleanValue("impression", "locationMultihopScreen", "main");
         assert.equal(locationMultihopScreenEvents.length, 1);
         const locationMultihopScreenEventsExtras = locationMultihopScreenEvents[0].extra;
         assert.equal(multiHopTelemetryScreenId, locationMultihopScreenEventsExtras.screen);
@@ -357,7 +357,7 @@ describe('Server', function() {
 
         //We only need to test the helpTooltipSelected event as it has a different extra key value (multihop instead of singlehop)
         //Eventhing else related to the sheet is tested in the singlehop tests
-        const helpTooltipSelectedEvents = await vpn.gleanTestGetValue("interaction", "helpTooltipSelected", "main");
+        const helpTooltipSelectedEvents = await vpn.waitForGleanValue("interaction", "helpTooltipSelected", "main");
         assert.equal(helpTooltipSelectedEvents.length, 1);
         const helpTooltipSelectedEventsExtras = helpTooltipSelectedEvents[0].extra;
         assert.equal(multiHopTelemetryScreenId, helpTooltipSelectedEventsExtras.screen);

--- a/tests/functional/testSettings.js
+++ b/tests/functional/testSettings.js
@@ -292,7 +292,7 @@ describe('Settings', function() {
       const privacyTelemetryScreenId = "privacy_features"
 
       it('Checking privacy screen impression telemetry', async () => {
-        const privacyFeaturesSreenEvents = await vpn.gleanTestGetValue("impression", "privacyFeaturesScreen", "main");
+        const privacyFeaturesSreenEvents = await vpn.waitForGleanValue("impression", "privacyFeaturesScreen", "main");
         assert.equal(privacyFeaturesSreenEvents.length, 1);
         const privacyFeaturesSreenEventsExtras = privacyFeaturesSreenEvents[0].extra;
         assert.equal(privacyTelemetryScreenId, privacyFeaturesSreenEventsExtras.screen);
@@ -303,21 +303,21 @@ describe('Settings', function() {
 
         await vpn.waitForQueryAndClick(queries.screenSettings.privacyView.HELP_BUTTON.visible());
 
-        const helpTooltipSelectedEvents = await vpn.gleanTestGetValue("interaction", "helpTooltipSelected", "main");
+        const helpTooltipSelectedEvents = await vpn.waitForGleanValue("interaction", "helpTooltipSelected", "main");
         assert.equal(helpTooltipSelectedEvents.length, 1);
         const helpTooltipSelectedEventsExtras = helpTooltipSelectedEvents[0].extra;
         assert.equal(privacyTelemetryScreenId, helpTooltipSelectedEventsExtras.screen);
 
         await vpn.waitForQuery(queries.screenSettings.privacyView.HELP_SHEET.opened());
 
-        const privacyFeaturesInfoScreenEvents = await vpn.gleanTestGetValue("impression", "privacyFeaturesInfoScreen", "main");
+        const privacyFeaturesInfoScreenEvents = await vpn.waitForGleanValue("impression", "privacyFeaturesInfoScreen", "main");
         assert.equal(privacyFeaturesInfoScreenEvents.length, 1);
         const privacyFeaturesInfoScreenEventsExtras = privacyFeaturesInfoScreenEvents[0].extra;
         assert.equal(privacyHelpSheetTelemetryScreenId, privacyFeaturesInfoScreenEventsExtras.screen);
 
         await vpn.waitForQueryAndClick(queries.screenSettings.privacyView.HELP_SHEET_LEARN_MORE_BUTTON.visible());
 
-        const learnMoreSelectedEvents = await vpn.gleanTestGetValue("interaction", "learnMoreSelected", "main");
+        const learnMoreSelectedEvents = await vpn.waitForGleanValue("interaction", "learnMoreSelected", "main");
         assert.equal(learnMoreSelectedEvents.length, 1);
         const learnMoreSelectedEventsExtras = learnMoreSelectedEvents[0].extra;
         assert.equal(privacyHelpSheetTelemetryScreenId, learnMoreSelectedEventsExtras.screen);
@@ -593,7 +593,7 @@ describe('Settings', function() {
       const dnsTelemetryScreenId = "dns_settings"
 
       it('Checking DNS screen impression telemetry', async () => {
-        const dnsSettingsScreenEvents = await vpn.gleanTestGetValue("impression", "dnsSettingsScreen", "main");
+        const dnsSettingsScreenEvents = await vpn.waitForGleanValue("impression", "dnsSettingsScreen", "main");
         assert.equal(dnsSettingsScreenEvents.length, 1);
         const dnsSettingsScreenEventExtras = dnsSettingsScreenEvents[0].extra;
         assert.equal(dnsTelemetryScreenId, dnsSettingsScreenEventExtras.screen);
@@ -604,21 +604,21 @@ describe('Settings', function() {
 
         await vpn.waitForQueryAndClick(queries.screenSettings.appPreferencesView.dnsSettingsView.HELP_BUTTON.visible());
 
-        const helpTooltipSelectedEvents = await vpn.gleanTestGetValue("interaction", "helpTooltipSelected", "main");
+        const helpTooltipSelectedEvents = await vpn.waitForGleanValue("interaction", "helpTooltipSelected", "main");
         assert.equal(helpTooltipSelectedEvents.length, 1);
         const helpTooltipSelectedEventsExtras = helpTooltipSelectedEvents[0].extra;
         assert.equal(dnsTelemetryScreenId, helpTooltipSelectedEventsExtras.screen);
 
         await vpn.waitForQuery(queries.screenSettings.appPreferencesView.dnsSettingsView.HELP_SHEET.opened());
 
-        const dnsSettingsInfoScreenEvents = await vpn.gleanTestGetValue("impression", "dnsSettingsInfoScreen", "main");
+        const dnsSettingsInfoScreenEvents = await vpn.waitForGleanValue("impression", "dnsSettingsInfoScreen", "main");
         assert.equal(dnsSettingsInfoScreenEvents.length, 1);
         const dnsSettingsInfoScreenEventsExtras = dnsSettingsInfoScreenEvents[0].extra;
         assert.equal(dnsHelpSheetTelemetryScreenId, dnsSettingsInfoScreenEventsExtras.screen);
 
         await vpn.waitForQueryAndClick(queries.screenSettings.appPreferencesView.dnsSettingsView.HELP_SHEET_LEARN_MORE_BUTTON.visible());
 
-        const learnMoreSelectedEvents = await vpn.gleanTestGetValue("interaction", "learnMoreSelected", "main");
+        const learnMoreSelectedEvents = await vpn.waitForGleanValue("interaction", "learnMoreSelected", "main");
         assert.equal(learnMoreSelectedEvents.length, 1);
         const learnMoreSelectedEventsExtras = learnMoreSelectedEvents[0].extra;
         assert.equal(dnsHelpSheetTelemetryScreenId, learnMoreSelectedEventsExtras.screen);
@@ -830,7 +830,7 @@ describe('Settings', function() {
     await vpn.waitForQueryAndClick(queries.screenGetHelp.STACKVIEW.ready());
 
     const helpScreenEvents =
-        await vpn.gleanTestGetValue('impression', 'helpScreen', 'main');
+        await vpn.waitForGleanValue('impression', 'helpScreen', 'main');
     assert.equal(helpScreenEvents.length, 1);
     const helpScreenEventsExtras = helpScreenEvents[0].extra;
     assert.equal(getHelpTelemetryScreenId, helpScreenEventsExtras.screen);
@@ -976,7 +976,7 @@ describe('Settings', function() {
             return;
         }
         await vpn.waitForQueryAndClick(queries.screenSettings.USER_PROFILE.visible());
-        const events = await vpn.gleanTestGetValue("interaction", "accountSelected", "main");
+        const events = await vpn.waitForGleanValue("interaction", "accountSelected", "main");
 
         assert.equal(events.length, 1);
         var element = events[0];
@@ -989,7 +989,7 @@ describe('Settings', function() {
             return;
         }
         await vpn.waitForQueryAndClick(queries.screenSettings.PRIVACY.visible());
-        const events = await vpn.gleanTestGetValue("interaction", "privacyFeaturesSelected", "main");
+        const events = await vpn.waitForGleanValue("interaction", "privacyFeaturesSelected", "main");
 
         assert.equal(events.length, 1);
         var element = events[0];
@@ -1003,7 +1003,7 @@ describe('Settings', function() {
       }
       await vpn.waitForQueryAndClick(
           queries.screenSettings.MY_DEVICES.visible());
-      const events = await vpn.gleanTestGetValue(
+      const events = await vpn.waitForGleanValue(
           "interaction", "myDevicesSelected", "main");
 
       assert.equal(events.length, 1);
@@ -1018,7 +1018,7 @@ describe('Settings', function() {
       }
       await vpn.waitForQueryAndClick(
           queries.screenSettings.APP_PREFERENCES.visible());
-      const events = await vpn.gleanTestGetValue(
+      const events = await vpn.waitForGleanValue(
           "interaction", "appPreferencesSelected", "main");
 
       assert.equal(events.length, 1);
@@ -1034,7 +1034,7 @@ describe('Settings', function() {
 
         await vpn.waitForQueryAndClick(queries.navBar.SETTINGS.visible());
 
-        const settingsScreenEvent = await vpn.gleanTestGetValue("impression", "settingsScreen", "main");
+        const settingsScreenEvent = await vpn.waitForGleanValue("impression", "settingsScreen", "main");
         const settingsScreenEventExtras = settingsScreenEvent[0].extra;
         assert.strictEqual("settings", settingsScreenEventExtras.screen);
     });

--- a/tests/functional/testSubscriptionNeeded.js
+++ b/tests/functional/testSubscriptionNeeded.js
@@ -48,7 +48,7 @@ describe("subscription needed tests", function() {
       });
 
       it("impression event is recorded", async () => {
-        const  subNeededImpression = await vpn.gleanTestGetValue("impression", "subscriptionNeededScreen", "main");
+        const  subNeededImpression = await vpn.waitForGleanValue("impression", "subscriptionNeededScreen", "main");
         assert.strictEqual(subNeededImpression.length, 1)
         const enterEmailViewEventExtras = subNeededImpression[0].extra;
         assert.strictEqual(screen, enterEmailViewEventExtras.screen);
@@ -91,7 +91,7 @@ describe("subscription needed tests", function() {
       it("subscribe now button event is recorded", async () => {
         // Click the "Subscribe now" button
         await vpn.waitForQueryAndClick(queries.screenSubscriptionNeeded.SUBSCRIPTION_NEEDED_BUTTON.visible());
-        const subscriptionNeededViewEvents = await vpn.gleanTestGetValue("impression", "subscriptionNeededScreen", "main");
+        const subscriptionNeededViewEvents = await vpn.waitForGleanValue("impression", "subscriptionNeededScreen", "main");
         const subscriptionNeededViewEventExtras = subscriptionNeededViewEvents[0].extra;
         assert.strictEqual(screen, subscriptionNeededViewEventExtras.screen);
       });


### PR DESCRIPTION
## Description
These just seem to make the tests take far longer than necessary and make it harder to spot flaky tests. Besides, we already have the `--retries 3` option passed to mocha when running tests. We shouldn't need retries ontop of our retries.

This revealed the following test instabilities, which will need to be fixed for this to land:
 - [x] Many tests when checking for telemetry.
 - [x] testAuthenticationInAppAccountCreationNav
 - [ ] ~testAuthenticationInBrowser ([linux](https://github.com/mozilla-mobile/mozilla-vpn-client/actions/runs/8989529463/job/24693281153) [macos](https://github.com/mozilla-mobile/mozilla-vpn-client/actions/runs/8989529465/job/24694056498))~ Possibly fixed on `main`
 - [ ] testMultihop ([linux](https://github.com/mozilla-mobile/mozilla-vpn-client/actions/runs/8992364465/job/24702403784))

## Reference
None! Just my own personal annoyance.

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
