### PR TITLE
VPN-6370: Try to set a consistent build timestamp for APK build ordering.

### DIFF
--- a/scripts/android/cmake.sh
+++ b/scripts/android/cmake.sh
@@ -115,7 +115,7 @@ fi
 
 printn Y "Computing the version... "
 export SHORTVERSION=$(cat version.txt) # Export so gradle can pick it up
-export VERSIONCODE=$(echo $BUILD_TIMESTAMP | sed 's/.\{3\}$//' )"0" #Remove the last 3 digits of the timestamp, so we only get every ~16m a new versioncode
+export VERSIONCODE=$(echo "$BUILD_TIMESTAMP" | sed 's/.\{2\}$//' ) #Remove the last 2 digits of the timestamp, should give us a new version every 100 seconds.
 export ADJUST_SDK_TOKEN=$ADJUST_SDK_TOKEN # Export it even if it is not set to override system env variables
 FULLVERSION=$SHORTVERSION.$(date +"%Y%m%d%H%M")
 print G "$SHORTVERSION - $FULLVERSION - $VERSIONCODE"

--- a/scripts/android/cmake.sh
+++ b/scripts/android/cmake.sh
@@ -108,9 +108,14 @@ mkdir -p .tmp || die "Failed to create the temporary directory"
 print Y "Patch Adjust files..."
 ./scripts/android/patch_adjust.sh
 
+# If not provided - use the current time.
+if [ -z "$BUILD_TIMESTAMP" ]; then
+  BUILD_TIMESTAMP=$(date +s)
+fi
+
 printn Y "Computing the version... "
 export SHORTVERSION=$(cat version.txt) # Export so gradle can pick it up
-export VERSIONCODE=$(date +%s | sed 's/.\{3\}$//' )"0" #Remove the last 3 digits of the timestamp, so we only get every ~16m a new versioncode
+export VERSIONCODE=$(echo $BUILD_TIMESTAMP | sed 's/.\{3\}$//' )"0" #Remove the last 3 digits of the timestamp, so we only get every ~16m a new versioncode
 export ADJUST_SDK_TOKEN=$ADJUST_SDK_TOKEN # Export it even if it is not set to override system env variables
 FULLVERSION=$SHORTVERSION.$(date +"%Y%m%d%H%M")
 print G "$SHORTVERSION - $FULLVERSION - $VERSIONCODE"

--- a/taskcluster/mozillavpn_taskgraph/transforms/build.py
+++ b/taskcluster/mozillavpn_taskgraph/transforms/build.py
@@ -83,7 +83,7 @@ def add_build_metadata(config, tasks):
             })
         if config.params["build_date"]:
             task["worker"]["env"].update({
-                "BUILD_TIMESTAMP": config.params["build_date"]
+                "BUILD_TIMESTAMP": str(config.params["build_date"])
             })
 
         yield task

--- a/taskcluster/mozillavpn_taskgraph/transforms/build.py
+++ b/taskcluster/mozillavpn_taskgraph/transforms/build.py
@@ -81,5 +81,9 @@ def add_build_metadata(config, tasks):
             task["worker"]["env"].update({
                 "TASK_OWNER": config.params["owner"]
             })
+        if config.params["build_date"]:
+            task["worker"]["env"].update({
+                "BUILD_TIMESTAMP": config.params["build_date"]
+            })
 
         yield task


### PR DESCRIPTION
## Description
It is important for Android building that the version code orders the build APKs by architecture, with the 32-bit architectures first, and the 64-bit architectures having higher versions. Failing to do so will result in rejection by Google Play because they will incorrectly assume that we fail to support 64-bit.

To correct this, we need to share a consistent timestamp (which is used to generate the version code) across all the tasks, regardless of when they actually start. I think we can do this by grabbing the `build_date` taskgraph config and setting it as an environment variable in the build jobs.

The current strategy here simply truncates the current time to try and get a similar number, which works-ish, but leaves us with a race condition when the truncated value rolls over and can potentially result in mis-ordered builds.

## Reference
JIRA issue: [VPN-6370](https://mozilla-hub.atlassian.net/browse/VPN-6370)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-6370]: https://mozilla-hub.atlassian.net/browse/VPN-6370?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ