### PR TITLE
Fix workflow to update server names

### DIFF
--- a/.github/workflows/i18n_server_list_update.yaml
+++ b/.github/workflows/i18n_server_list_update.yaml
@@ -1,4 +1,4 @@
-name: i18n Updater
+name: i18n Update Servers
 # This Workflow will periodically go in:
 # 1. Update extras.xliff with any new servers names Mullvad may have added
 # 2. File a pr with the changes to extras.xliff
@@ -21,6 +21,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: "true"
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.9"
+          cache: "pip"
+      - run: pip install -r requirements.txt
       - name: Update server name strings
         run: |
           scripts/ci/update_server_names.py


### PR DESCRIPTION
Workflow is currently broken (missing deps), and has the same name of another workflow.