### PR TITLE
Reduce warnings in GitHub workflows

### DIFF
--- a/.github/workflows/auth_tests.yml
+++ b/.github/workflows/auth_tests.yml
@@ -55,7 +55,7 @@ jobs:
         with:
           submodules: "recursive"
 
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v3
         with:
           miniconda-version: "latest"
           environment-file: env.yml
@@ -105,9 +105,9 @@ jobs:
         uses: ilammy/msvc-dev-cmd@v1
 
       - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v1.1
+        uses: microsoft/setup-msbuild@v2
 
-      - name: Install depedencies
+      - name: Install dependencies
         shell: bash
         run: |
           pip3 install -r requirements.txt

--- a/.github/workflows/cloudflare_pages.yml
+++ b/.github/workflows/cloudflare_pages.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
       # Run a build step here if your project requires
       - name: Building
         shell: bash

--- a/.github/workflows/gh_pages.yaml
+++ b/.github/workflows/gh_pages.yaml
@@ -43,7 +43,7 @@ jobs:
           cd tools/wasm_chrome
           deno run --allow-all generate_branch_file.ts -T ${{ secrets.GITHUB_TOKEN }}
       - name: Uploading
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Wasm-Chrome
           path: tools/wasm_chrome
@@ -55,7 +55,7 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v4
       - name: Uploading
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Logviewer
           path: tools/logviewer
@@ -66,7 +66,7 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v4
       - name: Uploading
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: AddonStats
           path: tools/addonstats
@@ -78,11 +78,11 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Cache conda Packages
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/conda_pkgs_dir
           key: ${{ runner.os }}-conda-packages
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v3
         with:
           activate-environment: vpn
           environment-file: env.yml
@@ -94,7 +94,7 @@ jobs:
           npm run inspector:build
 
       - name: Uploading
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Inspector Build
           path: tools/inspector/dist/app
@@ -106,7 +106,7 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: "16"
 
@@ -118,7 +118,7 @@ jobs:
           npm run build
 
       - name: Uploading
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Translations Report
           path: tools/translationsreport/app/build
@@ -134,7 +134,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y $(./scripts/linux/getdeps.py -a linux/debian/control)
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.9"
           cache: "pip"
@@ -162,7 +162,7 @@ jobs:
           rm addon_private_key.pem
 
       - name: Uploading
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Addons
           path: |
@@ -185,43 +185,43 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Download Wasm-chrome
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: Wasm-Chrome
           # Destination path
           path: _site
       - name: Download a Addons Artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: Addons
           path: _site/addons
 
       - name: Download the Logviewer Artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: Logviewer
           path: _site/logviewer
 
       - name: Download the AddonStats Artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: AddonStats
           path: _site/addonstats
 
       - name: Download a Inspector Artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: Inspector Build
           path: _site/inspector
 
       - name: Download the Translations Report artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: Translations Report
           path: _site/translationsreport
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
 
   deploy:
     name: Deploy Github Page

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -25,7 +25,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y aspell aspell-en $(./scripts/linux/getdeps.py -b linux/debian/control)
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.9"
           cache: "pip"
@@ -78,7 +78,7 @@ jobs:
         with:
           fetch-depth: 1
       - name: Cache conda Packages
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/conda_pkgs_dir
           key: ${{ runner.os }}-conda-packages
@@ -86,7 +86,7 @@ jobs:
       - name: Fetch glean submodules
         run: |
           git submodule update --init 3rdparty/glean
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v3
         with:
           activate-environment: vpn
           environment-file: env.yml

--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.9"
           cache: "pip"
@@ -40,7 +40,7 @@ jobs:
         run: ./scripts/linux/script.sh --source --gitref ${GITREF}
 
       - name: Upload source bundle
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Sources
           path: .tmp
@@ -52,7 +52,7 @@ jobs:
 
     steps:
       - name: Download Source Package
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: Sources
 
@@ -81,7 +81,7 @@ jobs:
           flatpak build-bundle fp-export-dir mozillavpn.flatpak org.mozilla.vpn
 
       - name: Uploading
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Flatpak Build
           path: mozillavpn.flatpak
@@ -95,7 +95,7 @@ jobs:
 
     steps:
       - name: Download Source Package
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: Sources
 
@@ -109,7 +109,7 @@ jobs:
         run: rpmbuild -D "_topdir $(pwd)" -D "_sourcedir $(pwd)" -ba mozillavpn.spec
 
       - name: Uploading
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: RPM Build
           path: |

--- a/.github/workflows/linux_tests.yaml
+++ b/.github/workflows/linux_tests.yaml
@@ -29,7 +29,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y $(./scripts/linux/getdeps.py -a linux/debian/control)
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.9"
           cache: "pip"
@@ -37,7 +37,7 @@ jobs:
 
       - name: Cache grcov
         id: cache-grcov
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: grcov-build/
           key: ${{ runner.os }}-grcov-v0.8.13
@@ -64,7 +64,7 @@ jobs:
           cp ./build/cmake/tests/dummyvpn/dummyvpn build/
           cp -r ./build/cmake/tests/dummyvpn/addons build/addons
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: test-client-${{ github.sha }}
           path: |
@@ -101,7 +101,7 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v4
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: test-client-${{ github.sha }}
           path: build/
@@ -112,7 +112,7 @@ jobs:
           sudo apt-get install -y $(./scripts/linux/getdeps.py -r linux/debian/control)
           sudo apt install --no-upgrade firefox xvfb -y
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.9"
           cache: "pip"
@@ -126,7 +126,7 @@ jobs:
 
       - name: Cache grcov
         id: cache-grcov
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: grcov-build/
           key: ${{ runner.os }}-grcov-v0.8.13
@@ -142,7 +142,7 @@ jobs:
 
       - name: Running ${{ matrix.test.name }} Tests
         id: runTests
-        uses: nick-invision/retry@v2
+        uses: nick-invision/retry@v3
         with:
           timeout_minutes: 15
           max_attempts: 3
@@ -167,7 +167,7 @@ jobs:
               -o ${{ runner.temp }}/artifacts/functional_lcov.info
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         if: steps.generateGrcov.outcome == 'success'
         with:
           directory: .
@@ -175,9 +175,11 @@ jobs:
           name: codecov-poc
           files: ${{ runner.temp }}/artifacts/functional_lcov.info
           verbose: true
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Uploading artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ always() }}
         with:
           name: ${{ matrix.test.name }} Logs

--- a/.github/workflows/macos_tests.yaml
+++ b/.github/workflows/macos_tests.yaml
@@ -29,7 +29,7 @@ jobs:
         with:
           submodules: "recursive"
 
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v3
         with:
           miniconda-version: "latest"
           environment-file: env.yml
@@ -55,7 +55,7 @@ jobs:
           cp ./build/cmake/tests/dummyvpn/dummyvpn build/
           cp -r ./build/cmake/tests/dummyvpn/addons build/addons
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: test-client-${{ github.sha }}
           path: |
@@ -90,12 +90,14 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v4
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: test-client-${{ github.sha }}
           path: build/
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
+        env:
+          PIP_DISABLE_PIP_VERSION_CHECK: 1
         with:
           python-version: "3.9"
           cache: "pip"
@@ -115,7 +117,7 @@ jobs:
 
       - name: Running ${{ matrix.test.name }} Tests
         id: runTests
-        uses: nick-invision/retry@v2
+        uses: nick-invision/retry@v3
         with:
           timeout_minutes: 15
           max_attempts: 3
@@ -130,8 +132,9 @@ jobs:
           MVPN_BIN: ./build/dummyvpn
 
       - name: Uploading artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ always() }}
         with:
           name: ${{ matrix.test.name }} Logs
           path: ${{ runner.temp }}/artifacts
+          if-no-files-found: ignore

--- a/.github/workflows/ppa-automation.yaml
+++ b/.github/workflows/ppa-automation.yaml
@@ -20,7 +20,7 @@ jobs:
         with:
           submodules: "recursive"
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.9"
           cache: "pip"
@@ -91,7 +91,7 @@ jobs:
           exit $JOB_EXIT_CODE
 
       - name: Uploading sources
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: Sources

--- a/.github/workflows/test_unit.yaml
+++ b/.github/workflows/test_unit.yaml
@@ -28,7 +28,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y $(./scripts/linux/getdeps.py -a linux/debian/control)
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.9"
           cache: "pip"
@@ -36,7 +36,7 @@ jobs:
 
       - name: Cache grcov
         id: cache-grcov
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: grcov-build/
           key: ${{runner.os}}-grcov-v0.8.13
@@ -90,13 +90,15 @@ jobs:
               -t lcov --branch --ignore-not-existing > ${{github.workspace}}/unitapp_lcov.info
 
       - name: Upload coverage for linux unit tests to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           directory: .
           flags: linux_unit_tests
           name: codecov-poc
           files: nativemessaging_lcov.info,qml_lcov.info,unit_lcov.info,unitapp_lcov.info
           verbose: true
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   macos-unit-tests:
     runs-on: macos-latest
@@ -111,7 +113,7 @@ jobs:
         with:
           submodules: "recursive"
 
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v3
         with:
           miniconda-version: "latest"
           environment-file: env.yml
@@ -132,7 +134,7 @@ jobs:
 
       - name: Cache grcov
         id: cache-grcov
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: grcov-build/
           key: ${{runner.os}}-grcov-v0.8.13
@@ -182,13 +184,15 @@ jobs:
               -t lcov --branch --ignore-not-existing > ${{github.workspace}}/unitapp_lcov.info
 
       - name: Upload coverage for macos unit tests to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           directory: .
           flags: macos_unit_tests
           name: codecov-poc
           files: auth_lcov.info,nativemessaging_lcov.info,qml_lcov.info,unit_lcov.info,unitapp_lcov.info
           verbose: true
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   windows-unit-tests:
     name: Run Unit tests on Windows
@@ -211,9 +215,9 @@ jobs:
         uses: ilammy/msvc-dev-cmd@v1
 
       - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v1.1
+        uses: microsoft/setup-msbuild@v2
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.9"
           cache: "pip"

--- a/.github/workflows/translations.yaml
+++ b/.github/workflows/translations.yaml
@@ -32,7 +32,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y $(./scripts/linux/getdeps.py -a linux/debian/control)
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.9"
           cache: "pip"
@@ -43,7 +43,7 @@ jobs:
           ./scripts/utils/generate_ts.sh
 
       - name: Uploading
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Translation files
           path: |

--- a/.github/workflows/wasm_tests.yaml
+++ b/.github/workflows/wasm_tests.yaml
@@ -29,7 +29,7 @@ jobs:
         with:
           submodules: "true"
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.9"
           cache: "pip"
@@ -43,7 +43,7 @@ jobs:
           python -m aqt install-qt -O /opt linux desktop $QTVERSION wasm_32 -m qtcharts qtwebsockets qt5compat
 
       - name: Setup emsdk
-        uses: mymindstorm/setup-emsdk@v7
+        uses: mymindstorm/setup-emsdk@v14
         with:
           # Emscripten does not guarantee ABI compatibility, we should use the
           # same version used to build Qt. See:
@@ -70,7 +70,7 @@ jobs:
             -DCMAKE_PREFIX_PATH=/opt/$QTVERSION/gcc_64/lib/cmake
           cmake --build build/addons
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: WebAssembly Build Qt6
           path: |
@@ -110,12 +110,12 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v4
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: WebAssembly Build Qt6
           path: build/
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.9"
           cache: "pip"
@@ -133,7 +133,7 @@ jobs:
 
       - name: Running ${{ matrix.test.name }} Tests
         id: runTests
-        uses: nick-invision/retry@v2
+        uses: nick-invision/retry@v3
         with:
           timeout_minutes: 15
           max_attempts: 3


### PR DESCRIPTION
There are currently over 100 warnings in checks, mostly due to obsolete GitHub actions.