### PR TITLE
Remove code coverage from github actions.

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,1 +1,0 @@
-comment: false

--- a/.github/workflows/auth_tests.yml
+++ b/.github/workflows/auth_tests.yml
@@ -31,14 +31,13 @@ jobs:
         shell: bash
         run: |
           mkdir -p build
-          cmake -S . -B $(pwd)/build
-          cmake --build $(pwd)/build --target app_auth_tests -j$(nproc)
+          cmake -S . -B $(pwd)/build -GNinja
+          cmake --build $(pwd)/build --target app_auth_tests
 
       - name: Running tests
         shell: bash
         working-directory: ./build/tests/auth_tests
         run: |
-          export PATH=${{github.workspace}}/grcov-build/bin:$PATH
           ctest --output-on-failure
 
   macos-unit-tests:
@@ -76,7 +75,7 @@ jobs:
           mkdir -p build/cmake
           cmake -S $(pwd) -B build/cmake -GNinja \
             -DCMAKE_PREFIX_PATH=${{ github.workspace }}/qt_dist/lib/cmake
-          cmake --build build/cmake -j$(nproc) --target app_auth_tests
+          cmake --build build/cmake --target app_auth_tests
 
       - name: Running tests
         working-directory: ./build/cmake/tests/auth_tests

--- a/.github/workflows/auth_tests.yml
+++ b/.github/workflows/auth_tests.yml
@@ -31,8 +31,7 @@ jobs:
         shell: bash
         run: |
           mkdir -p build
-          cmake -S . -B $(pwd)/build \
-            -DCMAKE_CXX_FLAGS=--coverage -DCMAKE_EXE_LINKER_FLAGS=--coverage
+          cmake -S . -B $(pwd)/build
           cmake --build $(pwd)/build --target app_auth_tests -j$(nproc)
 
       - name: Running tests

--- a/.github/workflows/linux_tests.yaml
+++ b/.github/workflows/linux_tests.yaml
@@ -35,27 +35,12 @@ jobs:
           cache: "pip"
       - run: pip install -r requirements.txt
 
-      - name: Cache grcov
-        id: cache-grcov
-        uses: actions/cache@v4
-        with:
-          path: grcov-build/
-          key: ${{ runner.os }}-grcov-v0.8.13
-
-      - name: Install Grcov
-        if: steps.cache-grcov.outputs.cache-hit != 'true'
-        shell: bash
-        run: |
-          cargo install grcov --root ${{ github.workspace }}/grcov-build --version 0.8.13
-
       - name: Compile test client
         shell: bash
         run: |
           mkdir -p build/cmake
           mkdir -p build/profile
-          cmake -S $(pwd) -B build/cmake \
-              -DCMAKE_CXX_FLAGS="--coverage -fprofile-generate=$(pwd)/build/profile" \
-              -DCMAKE_EXE_LINKER_FLAGS="--coverage -fprofile-generate=$(pwd)/build/profile"
+          cmake -S $(pwd) -B build/cmake
           cmake --build build/cmake -j$(nproc) --target dummyvpn
 
           mkdir -p build/profile
@@ -124,21 +109,11 @@ jobs:
           cache: "npm"
       - run: npm install
 
-      - name: Cache grcov
-        id: cache-grcov
-        uses: actions/cache@v4
-        with:
-          path: grcov-build/
-          key: ${{ runner.os }}-grcov-v0.8.13
-
       - name: Check build
         shell: bash
         run: |
           chmod +x ./build/dummyvpn
           ./build/dummyvpn -v
-
-          chmod +x ${{ github.workspace }}/grcov-build/bin/grcov
-          ${{ github.workspace }}/grcov-build/bin/grcov --version
 
       - name: Running ${{ matrix.test.name }} Tests
         id: runTests
@@ -155,28 +130,6 @@ jobs:
         env:
           ARTIFACT_DIR: ${{ runner.temp }}/artifacts
           MVPN_BIN: ./build/dummyvpn
-
-      - name: Generating grcov reports
-        id: generateGrcov
-        continue-on-error: true # Ignore GRCOV parsing errors, see github.com/mozilla/grcov/issues/570
-        timeout-minutes: 1 # Give GRCOV a short timeout in case it hangs after a panic
-        run: |
-          export PATH=${{ github.workspace }}/grcov-build/bin:$PATH
-          grcov build/profile \
-              -s src -t lcov --branch --ignore-not-existing \
-              -o ${{ runner.temp }}/artifacts/functional_lcov.info
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
-        if: steps.generateGrcov.outcome == 'success'
-        with:
-          directory: .
-          flags: functional_tests
-          name: codecov-poc
-          files: ${{ runner.temp }}/artifacts/functional_lcov.info
-          verbose: true
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Uploading artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/linux_tests.yaml
+++ b/.github/workflows/linux_tests.yaml
@@ -40,8 +40,8 @@ jobs:
         run: |
           mkdir -p build/cmake
           mkdir -p build/profile
-          cmake -S $(pwd) -B build/cmake
-          cmake --build build/cmake -j$(nproc) --target dummyvpn
+          cmake -S $(pwd) -B build/cmake -GNinja
+          cmake --build build/cmake --target dummyvpn
 
           mkdir -p build/profile
           rsync -a --include '*/' --include '*.gcno' --exclude '*' \

--- a/.github/workflows/macos_tests.yaml
+++ b/.github/workflows/macos_tests.yaml
@@ -51,7 +51,7 @@ jobs:
           mkdir -p build/cmake
           cmake -S $(pwd) -B build/cmake -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo \
             -DCMAKE_PREFIX_PATH=${{ github.workspace }}/qt_dist/lib/cmake
-          cmake --build build/cmake -j$(nproc) --target dummyvpn
+          cmake --build build/cmake --target dummyvpn
           cp ./build/cmake/tests/dummyvpn/dummyvpn build/
           cp -r ./build/cmake/tests/dummyvpn/addons build/addons
 

--- a/.github/workflows/test_unit.yaml
+++ b/.github/workflows/test_unit.yaml
@@ -38,8 +38,8 @@ jobs:
         shell: bash
         run: |
           mkdir -p build
-          cmake -S . -B $(pwd)/build
-          cmake --build $(pwd)/build --target build_tests -j$(nproc)
+          cmake -S . -B $(pwd)/build -GNinja
+          cmake --build $(pwd)/build --target build_tests
 
       - name: Running native messaging tests
         shell: bash

--- a/.github/workflows/test_unit.yaml
+++ b/.github/workflows/test_unit.yaml
@@ -34,71 +34,31 @@ jobs:
           cache: "pip"
       - run: pip install -r requirements.txt
 
-      - name: Cache grcov
-        id: cache-grcov
-        uses: actions/cache@v4
-        with:
-          path: grcov-build/
-          key: ${{runner.os}}-grcov-v0.8.13
-
-      - name: Install Grcov
-        if: steps.cache-grcov.outputs.cache-hit != 'true'
-        shell: bash
-        run: |
-          cargo install grcov --root ${{github.workspace}}/grcov-build --version 0.8.13
-
       - name: Building tests
         shell: bash
         run: |
           mkdir -p build
-          cmake -S . -B $(pwd)/build \
-            -DCMAKE_CXX_FLAGS=--coverage -DCMAKE_EXE_LINKER_FLAGS=--coverage
+          cmake -S . -B $(pwd)/build
           cmake --build $(pwd)/build --target build_tests -j$(nproc)
 
       - name: Running native messaging tests
         shell: bash
         working-directory: ./build/tests/nativemessaging
         run: |
-          export PATH=${{github.workspace}}/grcov-build/bin:$PATH
           ctest --output-on-failure
-
-          grcov $(pwd)/CMakeFiles/nativemessaging_tests.dir -s ${{github.workspace}} \
-              -t lcov --branch --ignore-not-existing > ${{github.workspace}}/nativemessaging_lcov.info
 
       - name: Running QML tests
         shell: bash
         working-directory: ./build/tests/qml
         run: |
-          export PATH=${{github.workspace}}/grcov-build/bin:$PATH
           ctest --output-on-failure
-
-          grcov $(pwd)/CMakeFiles/qml_tests.dir -s ${{github.workspace}} \
-              -t lcov --branch --ignore-not-existing > ${{github.workspace}}/qml_lcov.info
 
       - name: Running unit tests
         shell: bash
         working-directory: ./build/tests
         run: |
-          export PATH=${{github.workspace}}/grcov-build/bin:$PATH
           ctest --test-dir unit --output-on-failure
           ctest --test-dir unit_tests --output-on-failure
-
-          grcov $(pwd)/unit/CMakeFiles/unit_tests.dir -s ${{github.workspace}} \
-              -t lcov --branch --ignore-not-existing > ${{github.workspace}}/unit_lcov.info
-
-          grcov $(pwd)/unit_tests/CMakeFiles/app_unit_tests.dir -s ${{github.workspace}} \
-              -t lcov --branch --ignore-not-existing > ${{github.workspace}}/unitapp_lcov.info
-
-      - name: Upload coverage for linux unit tests to Codecov
-        uses: codecov/codecov-action@v4
-        with:
-          directory: .
-          flags: linux_unit_tests
-          name: codecov-poc
-          files: nativemessaging_lcov.info,qml_lcov.info,unit_lcov.info,unitapp_lcov.info
-          verbose: true
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   macos-unit-tests:
     runs-on: macos-latest
@@ -132,67 +92,28 @@ jobs:
           sudo mv qt_dist /opt
           cd ..
 
-      - name: Cache grcov
-        id: cache-grcov
-        uses: actions/cache@v4
-        with:
-          path: grcov-build/
-          key: ${{runner.os}}-grcov-v0.8.13
-
-      - name: Install Grcov
-        if: steps.cache-grcov.outputs.cache-hit != 'true'
-        run: |
-          cargo install grcov --root ${{github.workspace}}/grcov-build --version 0.8.13
-
       - name: Building tests
         run: |
-          export PATH=/opt/qt_dist/bin:${{github.workspace}}/grcov-build/bin:$PATH
+          export PATH=/opt/qt_dist/bin:$PATH
           mkdir -p build
-          cmake -S . -B $(pwd)/build -GNinja \
-            -DCMAKE_CXX_FLAGS=--coverage -DCMAKE_EXE_LINKER_FLAGS=--coverage
+          cmake -S . -B $(pwd)/build -GNinja
           cmake --build $(pwd)/build --target build_tests
 
       - name: Running native messaging tests
         working-directory: ./build/tests/nativemessaging
         run: |
-          export PATH=${{github.workspace}}/grcov-build/bin:$PATH
           ctest --output-on-failure
-
-          grcov $(pwd)/CMakeFiles/nativemessaging_tests.dir -s ${{github.workspace}} \
-              -t lcov --branch --ignore-not-existing > ${{github.workspace}}/nativemessaging_lcov.info
 
       - name: Running QML tests
         working-directory: ./build/tests/qml
         run: |
-          export PATH=${{github.workspace}}/grcov-build/bin:$PATH
           ctest --output-on-failure
-
-          grcov $(pwd)/CMakeFiles/qml_tests.dir -s ${{github.workspace}} \
-              -t lcov --branch --ignore-not-existing > ${{github.workspace}}/qml_lcov.info
 
       - name: Running unit tests
         working-directory: ./build/tests
         run: |
-          export PATH=${{github.workspace}}/grcov-build/bin:$PATH
           ctest --test-dir unit --output-on-failure
           ctest --test-dir unit_tests --output-on-failure
-
-          grcov $(pwd)/unit/CMakeFiles/unit_tests.dir -s ${{github.workspace}} \
-              -t lcov --branch --ignore-not-existing > ${{github.workspace}}/unit_lcov.info
-
-          grcov $(pwd)/unit_tests/CMakeFiles/app_unit_tests.dir -s ${{github.workspace}} \
-              -t lcov --branch --ignore-not-existing > ${{github.workspace}}/unitapp_lcov.info
-
-      - name: Upload coverage for macos unit tests to Codecov
-        uses: codecov/codecov-action@v4
-        with:
-          directory: .
-          flags: macos_unit_tests
-          name: codecov-poc
-          files: auth_lcov.info,nativemessaging_lcov.info,qml_lcov.info,unit_lcov.info,unitapp_lcov.info
-          verbose: true
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   windows-unit-tests:
     name: Run Unit tests on Windows
@@ -233,21 +154,18 @@ jobs:
         shell: bash
         working-directory: ./build/tests/nativemessaging
         run: |
-          export PATH=${{github.workspace}}/grcov-build/bin:$PATH
           ctest --output-on-failure
 
       - name: Running QML tests
         shell: bash
         working-directory: ./build/tests/qml
         run: |
-          export PATH=${{github.workspace}}/grcov-build/bin:$PATH
           ctest --output-on-failure
 
       - name: Running unit tests
         shell: bash
         working-directory: ./build/tests
         run: |
-          export PATH=${{github.workspace}}/grcov-build/bin:$PATH
           ctest --test-dir unit --output-on-failure
           ctest --test-dir unit_tests --output-on-failure
 


### PR DESCRIPTION
## Description
Codecov has never really worked all that great, and hasn't had someone to maintain it since @mozrokafor left the team. So in the interest of cutting down on needless work and maintenence burden, we should just remove it from our CI jobs.

## Reference
None

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
