### PR TITLE
Fix GH pages workflow (update deploy action)

### DIFF
--- a/.github/workflows/gh_pages.yaml
+++ b/.github/workflows/gh_pages.yaml
@@ -234,4 +234,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
There is a step in this workflow that only runs for pushes on main, so I missed it.

Not completely sure that updating the actio version will fix it, but it seemed to work on my fork.