### PR TITLE
Experiment: Try using b-linux-large workers for Taskcluster build tasks

### DIFF
--- a/taskcluster/kinds/build/linux.yml
+++ b/taskcluster/kinds/build/linux.yml
@@ -22,6 +22,7 @@ task-defaults:
               path: /builds/worker/artifacts
     run:
         using: run-task
+        checkout: false
         use-caches: true
         command: /builds/worker/builder.sh
 

--- a/taskcluster/kinds/build/linux.yml
+++ b/taskcluster/kinds/build/linux.yml
@@ -12,7 +12,7 @@ task-defaults:
             - artifact: mozillavpn-sources.tar.gz
     dependencies:
         build: build-source/vpn
-    worker-type: b-linux
+    worker-type: b-linux-large
     worker:
         max-run-time: 3600
         chain-of-trust: true

--- a/taskcluster/kinds/build/wasm.yml
+++ b/taskcluster/kinds/build/wasm.yml
@@ -10,7 +10,7 @@ wasm/opt:
         kind: build
         tier: 1
         platform: web/opt
-    worker-type: b-linux
+    worker-type: b-linux-large
     worker:
         docker-image: {in-tree: wasm}
         max-run-time: 3600

--- a/taskcluster/kinds/toolchain/qt.yml
+++ b/taskcluster/kinds/toolchain/qt.yml
@@ -94,7 +94,7 @@ qt-linux:
         toolchain-artifact: public/build/qt6_linux.tar.xz
     treeherder:
         symbol: TL(qt-linux)
-    worker-type: b-linux
+    worker-type: b-linux-large
     worker:
         docker-image: {in-tree: linux-qt6-build}
 
@@ -111,6 +111,6 @@ qt-linux-6.6.0:
         toolchain-artifact: public/build/qt6_linux.tar.xz
     treeherder:
         symbol: TL(qt-linux-6.6)
-    worker-type: b-linux
+    worker-type: b-linux-large
     worker:
         docker-image: {in-tree: linux-qt6-build}


### PR DESCRIPTION
## Description
We have a larger GCP worker available to us on Taskcluster. While we aren't frequently blocked by taskcluster jobs, it might be nice to get an idea of how much faster they could be. Especially if we have dreams of doing more testing in taskcluster.

## Reference
None.

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
