### PR TITLE
Chore: Enable taskcluster docker cache for Ubuntu/noble

### DIFF
--- a/taskcluster/kinds/docker-image/kind.yml
+++ b/taskcluster/kinds/docker-image/kind.yml
@@ -60,7 +60,6 @@ tasks:
     linux-build-noble:
         symbol: I(linux-noble)
         definition: linux-dpkg-build
-        cache: false ## Disable caching while Ubuntu/Noble is in beta.
         args:
             DOCKER_BASE_IMAGE: ubuntu:noble
     linux-build-fedora-fc37:


### PR DESCRIPTION
## Description
Ubuntu 24.04 Noble Numbat was officially released on April 25th and can now be considered stable. We should enable the docker image cache for this build.

## Reference
None

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
