### PR TITLE
VPN-5156 - Do not fallback to English on language name map

### DIFF
--- a/scripts/utils/generate_language_names_map.py
+++ b/scripts/utils/generate_language_names_map.py
@@ -42,7 +42,7 @@ def generate_cpp_header(language_strings, output_file):
         f.write('namespace LanguageStrings {\n')
         f.write('const QMap<QString, QString> NATIVE_LANGUAGE_NAMES = {\n')
         for lang_code, strings in language_strings.items():
-            f.write('    {"' + lang_code + '", "' + strings.get(lang_code, strings.get("en", "")) + '"},\n')
+            f.write('    {"' + lang_code + '", "' + strings.get(lang_code, "") + '"},\n')
         f.write('};\n}\n\n#endif\n')
 
 if __name__ == "__main__":


### PR DESCRIPTION
For some reason I thought it would be a good idea to fallback to the translation for "English" in whatever language if the translation for the actual language name was not present. So, say the translation for `es_CL` is missing for `es_CL` we would instead get the translation for `en` ("Inglés") instead of leaving it blank and letting Qt do the translation... 🤦‍♀️ 