### PR TITLE
VPN-6375 - Fix QML modules import

### DIFF
--- a/nebula/ui/components/MZScreenBase.qml
+++ b/nebula/ui/components/MZScreenBase.qml
@@ -36,8 +36,10 @@ Item {
             _menuIconButtonMirror:  stackview.depth !== 1 && MZLocalizer.isRightToLeft
             _iconButtonAccessibleName: stackview.depth === 1 ? MZI18n.GlobalClose : MZI18n.GlobalGoBack
             _menuOnBackClicked: () => maybeRequestPreviousScreen()
-            titleComponent: stackview.currentItem.titleComponent ? stackview.currentItem.titleComponent : null
-            rightButtonComponent: stackview.currentItem.rightMenuButton ? stackview.currentItem.rightMenuButton : null
+            titleComponent: stackview.currentItem && stackview.currentItem.titleComponent
+                ? stackview.currentItem.titleComponent : null
+            rightButtonComponent: stackview.currentItem && stackview.currentItem.rightMenuButton
+                ? stackview.currentItem.rightMenuButton : null
 
             title: ""
 

--- a/src/ui/CMakeLists.txt
+++ b/src/ui/CMakeLists.txt
@@ -5,6 +5,7 @@
 qt_add_qml_module(mozillavpn-ui
     VERSION 1.0
     URI Mozilla.VPN
+    NO_PLUGIN_OPTIONAL
     STATIC
     OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/Mozilla/VPN
     QML_FILES

--- a/src/ui/screens/messaging/ViewMessage.qml
+++ b/src/ui/screens/messaging/ViewMessage.qml
@@ -186,7 +186,7 @@ MZViewBase {
                 anchors.left: parent.left
                 anchors.right: parent.right
 
-                view: MZComposerView.View.Message
+                view: MZComposerView.View && MZComposerView.View.Message
                 addon: message
             }
         }

--- a/src/ui/screens/messaging/ViewMessagesInbox.qml
+++ b/src/ui/screens/messaging/ViewMessagesInbox.qml
@@ -272,7 +272,7 @@ MZViewBase {
                                 Layout.preferredHeight: 8
                                 Layout.preferredWidth: 8
 
-                                opacity: addon.isRead? 0 : 1
+                                opacity: addon && addon.isRead ? 0 : 1
                                 radius: Layout.preferredHeight / 2
                                 color: MZTheme.theme.blue
                             }


### PR DESCRIPTION
Ok, something funky is happening with the Qt6.6 imports.

Here is the thing, this patch fixes it. But I kinda hate the way it fixes it, makes no sense.

Opening as a draft, as food for thought. It seems sometime Qt6.6 is unable to resolve QML files in the same module???? cc @lesleyjanenorton for QML knowledge.