### PR TITLE
VPN-2367: Save iOS start time

### DIFF
--- a/src/platforms/ios/iostunnelmessage.swift
+++ b/src/platforms/ios/iostunnelmessage.swift
@@ -10,6 +10,9 @@ public enum TunnelMessage: Codable, CustomStringConvertible {
     /// Request for the current runtime configuration
     case getRuntimeConfiguration
 
+    /// Request for the original connection timestamp
+    case getConnectionTimestamp
+
     /// Switch tunnel configuration
     case configurationSwitch(String)
 
@@ -23,6 +26,8 @@ public enum TunnelMessage: Codable, CustomStringConvertible {
         switch self {
         case .getRuntimeConfiguration:
             return "getRuntimeConfiguration"
+        case .getConnectionTimestamp:
+            return "getConnectionTimestamp"
         case .configurationSwitch(let newConfig):
             // We do not want to log the configuration itself.
             // It contains private information.


### PR DESCRIPTION
## Description

iOS connection time has a bug when following these steps:
1. Start the VPN
2. Wait 10 seconds or so
3. Switch servers (timer will not reset)
4. Hard quit the app
5. Relaunch the app. The timer should still be counting up from the original connection time, but instead it's jumped back 10 seconds - to when the server switched.
 
This is because when the app starts up use the iOS network extension's timestamp as the connection start time (which the count up timer comes from). The iOS network extension's timestamp is the last time we connected to any server, which is a different definition of session start than we're using. (We do not want to turn off the timer until the user turns off the VPN - user-generated or silent server switches should result in the timer continuing to increment without a reset.)

This PR manually saves the timestamp on a new connection, and creates a new message between the network extension and the app to provide that timestamp when initializing the app.

## Reference

VPN-2367

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
