### PR TITLE
Fix android build script

### DIFF
--- a/scripts/android/cmake.sh
+++ b/scripts/android/cmake.sh
@@ -110,7 +110,7 @@ print Y "Patch Adjust files..."
 
 # If not provided - use the current time.
 if [ -z "$BUILD_TIMESTAMP" ]; then
-  BUILD_TIMESTAMP=$(date +s)
+  BUILD_TIMESTAMP=$(date +%s)
 fi
 
 printn Y "Computing the version... "


### PR DESCRIPTION
## Description

I believe we missed a character in https://github.com/mozilla-mobile/mozilla-vpn-client/pull/9510/. Build timestamp was being set to the string `s`, and thus it was failing downstream.

## Reference

VPN-6390

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
