### PR TITLE
try to fix qml imports

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,7 +139,7 @@ if(NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Emscripten" AND
 endif()
 
 if(QT_KNOWN_POLICY_QTP0001)
-    qt_policy(SET QTP0001 OLD)
+    qt_policy(SET QTP0001 NEW)
 endif()
 
 message("Using Qt version ${Qt6_VERSION}")

--- a/src/commands/commandui.cpp
+++ b/src/commands/commandui.cpp
@@ -305,6 +305,7 @@ int CommandUI::run(QStringList& tokens) {
     // Prior to Qt 6.5, there was no default QML import path. We must set one.
 #if QT_VERSION < QT_VERSION_CHECK(6, 5, 0)
     engine->addImportPath("qrc:/");
+    engine->addImportPath("qrc:/qt/qml");
 #endif
 
     QQuickImageProvider* provider = ImageProviderFactory::create(qApp);
@@ -345,7 +346,7 @@ int CommandUI::run(QStringList& tokens) {
                      &App::quit, Qt::QueuedConnection);
 
     // Here is the main QML file.
-    const QUrl url(QStringLiteral("qrc:/Mozilla/VPN/main.qml"));
+    const QUrl url(QStringLiteral("qrc:/qt/qml/Mozilla/VPN/main.qml"));
     engine->load(url);
     if (!engineHolder.hasWindow()) {
       logger.error() << "Failed to load " << url.toString();

--- a/src/inspector/inspectorhotreloader.cpp
+++ b/src/inspector/inspectorhotreloader.cpp
@@ -152,7 +152,7 @@ void InspectorHotreloader::reloadWindow() {
       maybeWindow->close();
     }
   }
-  const QUrl url(QStringLiteral("qrc:/Mozilla/VPN/main.qml"));
+  const QUrl url(QStringLiteral("qrc:/qt/qml/Mozilla/VPN/main.qml"));
   engine->load(url);
   auto newWindow = qobject_cast<QWindow*>(engine->rootObjects().last());
   if (newWindow) {

--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -1433,7 +1433,7 @@ void MozillaVPN::registerErrorHandlers() {
 void MozillaVPN::registerNavigatorScreens() {
   Navigator::registerScreen(
       MozillaVPN::ScreenAuthenticating, Navigator::LoadPolicy::LoadTemporarily,
-      "qrc:/Mozilla/VPN/screens/ScreenAuthenticating.qml",
+      "qrc:/qt/qml/Mozilla/VPN/screens/ScreenAuthenticating.qml",
       QVector<int>{App::StateAuthenticating},
       [](int*) -> int8_t {
         return Feature::get(Feature::Feature_inAppAuthentication)->isSupported()
@@ -1448,7 +1448,7 @@ void MozillaVPN::registerNavigatorScreens() {
   Navigator::registerScreen(
       MozillaVPN::ScreenAuthenticationInApp,
       Navigator::LoadPolicy::LoadTemporarily,
-      "qrc:/Mozilla/VPN/screens/ScreenAuthenticationInApp.qml",
+      "qrc:/qt/qml/Mozilla/VPN/screens/ScreenAuthenticationInApp.qml",
       QVector<int>{App::StateAuthenticating},
       [](int*) -> int8_t {
         return Feature::get(Feature::Feature_inAppAuthentication)->isSupported()
@@ -1462,26 +1462,26 @@ void MozillaVPN::registerNavigatorScreens() {
 
   Navigator::registerScreen(
       MozillaVPN::ScreenBackendFailure, Navigator::LoadPolicy::LoadTemporarily,
-      "qrc:/Mozilla/VPN/screens/ScreenBackendFailure.qml",
+      "qrc:/qt/qml/Mozilla/VPN/screens/ScreenBackendFailure.qml",
       QVector<int>{MozillaVPN::StateBackendFailure},
       [](int*) -> int8_t { return 0; }, []() -> bool { return false; });
 
   Navigator::registerScreen(
       MozillaVPN::ScreenBillingNotAvailable,
       Navigator::LoadPolicy::LoadTemporarily,
-      "qrc:/Mozilla/VPN/screens/ScreenBillingNotAvailable.qml",
+      "qrc:/qt/qml/Mozilla/VPN/screens/ScreenBillingNotAvailable.qml",
       QVector<int>{App::StateBillingNotAvailable},
       [](int*) -> int8_t { return 0; }, []() -> bool { return false; });
 
   Navigator::registerScreen(
       MozillaVPN::ScreenCaptivePortal, Navigator::LoadPolicy::LoadTemporarily,
-      "qrc:/Mozilla/VPN/screens/ScreenCaptivePortal.qml",
+      "qrc:/qt/qml/Mozilla/VPN/screens/ScreenCaptivePortal.qml",
       QVector<int>{App::StateMain}, [](int*) -> int8_t { return 0; },
       []() -> bool { return false; });
 
   Navigator::registerScreen(
       MozillaVPN::ScreenCrashReporting, Navigator::LoadPolicy::LoadTemporarily,
-      "qrc:/Mozilla/VPN/screens/ScreenCrashReporting.qml", QVector<int>{},
+      "qrc:/qt/qml/Mozilla/VPN/screens/ScreenCrashReporting.qml", QVector<int>{},
       [](int* requestedScreen) -> int8_t {
         return (requestedScreen &&
                 *requestedScreen == MozillaVPN::ScreenCrashReporting)
@@ -1492,7 +1492,7 @@ void MozillaVPN::registerNavigatorScreens() {
 
   Navigator::registerScreen(
       MozillaVPN::ScreenDeleteAccount, Navigator::LoadPolicy::LoadTemporarily,
-      "qrc:/Mozilla/VPN/screens/ScreenDeleteAccount.qml",
+      "qrc:/qt/qml/Mozilla/VPN/screens/ScreenDeleteAccount.qml",
       QVector<int>{App::StateMain},
       [](int* requestedScreen) -> int8_t {
         return (requestedScreen &&
@@ -1507,13 +1507,13 @@ void MozillaVPN::registerNavigatorScreens() {
 
   Navigator::registerScreen(
       MozillaVPN::ScreenDeviceLimit, Navigator::LoadPolicy::LoadTemporarily,
-      "qrc:/Mozilla/VPN/screens/ScreenDeviceLimit.qml",
+      "qrc:/qt/qml/Mozilla/VPN/screens/ScreenDeviceLimit.qml",
       QVector<int>{MozillaVPN::StateDeviceLimit},
       [](int*) -> int8_t { return 0; }, []() -> bool { return false; });
 
   Navigator::registerScreen(
       MozillaVPN::ScreenGetHelp, Navigator::LoadPolicy::LoadTemporarily,
-      "qrc:/Mozilla/VPN/screens/ScreenGetHelp.qml", QVector<int>{},
+      "qrc:/qt/qml/Mozilla/VPN/screens/ScreenGetHelp.qml", QVector<int>{},
       [](int* requestedScreen) -> int8_t {
         return (requestedScreen &&
                 *requestedScreen == MozillaVPN::ScreenGetHelp)
@@ -1527,18 +1527,18 @@ void MozillaVPN::registerNavigatorScreens() {
 
   Navigator::registerScreen(
       MozillaVPN::ScreenHome, Navigator::LoadPolicy::LoadPersistently,
-      "qrc:/Mozilla/VPN/screens/ScreenHome.qml", QVector<int>{App::StateMain},
+      "qrc:/qt/qml/Mozilla/VPN/screens/ScreenHome.qml", QVector<int>{App::StateMain},
       [](int*) -> int8_t { return 99; }, []() -> bool { return false; });
 
   Navigator::registerScreen(
       MozillaVPN::ScreenInitialize, Navigator::LoadPolicy::LoadTemporarily,
-      "qrc:/Mozilla/VPN/screens/ScreenInitialize.qml",
+      "qrc:/qt/qml/Mozilla/VPN/screens/ScreenInitialize.qml",
       QVector<int>{App::StateInitialize}, [](int*) -> int8_t { return 0; },
       []() -> bool { return false; });
 
   Navigator::registerScreen(
       MozillaVPN::ScreenMessaging, Navigator::LoadPolicy::LoadPersistently,
-      "qrc:/Mozilla/VPN/screens/ScreenMessaging.qml",
+      "qrc:/qt/qml/Mozilla/VPN/screens/ScreenMessaging.qml",
       QVector<int>{App::StateMain}, [](int*) -> int8_t { return 0; },
       []() -> bool {
         Navigator::instance()->requestScreen(MozillaVPN::ScreenHome,
@@ -1549,7 +1549,7 @@ void MozillaVPN::registerNavigatorScreens() {
   Navigator::registerScreen(
       MozillaVPN::ScreenNoSubscriptionFoundError,
       Navigator::LoadPolicy::LoadTemporarily,
-      "qrc:/Mozilla/VPN/screens/ScreenNoSubscriptionFoundError.qml",
+      "qrc:/qt/qml/Mozilla/VPN/screens/ScreenNoSubscriptionFoundError.qml",
       QVector<int>{App::StateSubscriptionNeeded,
                    App::StateSubscriptionInProgress},
       [](int* requestedScreen) -> int8_t {
@@ -1562,7 +1562,7 @@ void MozillaVPN::registerNavigatorScreens() {
 
   Navigator::registerScreen(
       MozillaVPN::ScreenSettings, Navigator::LoadPolicy::LoadPersistently,
-      "qrc:/Mozilla/VPN/screens/ScreenSettings.qml",
+      "qrc:/qt/qml/Mozilla/VPN/screens/ScreenSettings.qml",
       QVector<int>{App::StateMain}, [](int*) -> int8_t { return 0; },
       []() -> bool {
         Navigator::instance()->requestScreen(MozillaVPN::ScreenHome,
@@ -1573,14 +1573,14 @@ void MozillaVPN::registerNavigatorScreens() {
   Navigator::registerScreen(
       MozillaVPN::ScreenSubscriptionBlocked,
       Navigator::LoadPolicy::LoadTemporarily,
-      "qrc:/Mozilla/VPN/screens/ScreenSubscriptionBlocked.qml",
+      "qrc:/qt/qml/Mozilla/VPN/screens/ScreenSubscriptionBlocked.qml",
       QVector<int>{App::StateSubscriptionBlocked},
       [](int*) -> int8_t { return 0; }, []() -> bool { return false; });
 
   Navigator::registerScreen(
       MozillaVPN::ScreenSubscriptionExpiredError,
       Navigator::LoadPolicy::LoadTemporarily,
-      "qrc:/Mozilla/VPN/screens/ScreenSubscriptionExpiredError.qml",
+      "qrc:/qt/qml/Mozilla/VPN/screens/ScreenSubscriptionExpiredError.qml",
       QVector<int>{App::StateSubscriptionNeeded,
                    App::StateSubscriptionInProgress},
       [](int* requestedScreen) -> int8_t {
@@ -1594,7 +1594,7 @@ void MozillaVPN::registerNavigatorScreens() {
   Navigator::registerScreen(
       MozillaVPN::ScreenSubscriptionGenericError,
       Navigator::LoadPolicy::LoadTemporarily,
-      "qrc:/Mozilla/VPN/screens/ScreenSubscriptionGenericError.qml",
+      "qrc:/qt/qml/Mozilla/VPN/screens/ScreenSubscriptionGenericError.qml",
       QVector<int>{App::StateSubscriptionNeeded,
                    App::StateSubscriptionInProgress},
       [](int* requestedScreen) -> int8_t {
@@ -1608,7 +1608,7 @@ void MozillaVPN::registerNavigatorScreens() {
   Navigator::registerScreen(
       MozillaVPN::ScreenSubscriptionInProgressIAP,
       Navigator::LoadPolicy::LoadTemporarily,
-      "qrc:/Mozilla/VPN/screens/ScreenSubscriptionInProgressIAP.qml",
+      "qrc:/qt/qml/Mozilla/VPN/screens/ScreenSubscriptionInProgressIAP.qml",
       QVector<int>{App::StateSubscriptionInProgress},
       [](int*) -> int8_t {
         return Feature::get(Feature::Feature_webPurchase)->isSupported() ? -1
@@ -1619,7 +1619,7 @@ void MozillaVPN::registerNavigatorScreens() {
   Navigator::registerScreen(
       MozillaVPN::ScreenSubscriptionInProgressWeb,
       Navigator::LoadPolicy::LoadTemporarily,
-      "qrc:/Mozilla/VPN/screens/ScreenSubscriptionInProgressWeb.qml",
+      "qrc:/qt/qml/Mozilla/VPN/screens/ScreenSubscriptionInProgressWeb.qml",
       QVector<int>{App::StateSubscriptionInProgress},
       [](int*) -> int8_t {
         return Feature::get(Feature::Feature_webPurchase)->isSupported() ? 99
@@ -1630,7 +1630,7 @@ void MozillaVPN::registerNavigatorScreens() {
   Navigator::registerScreen(
       MozillaVPN::ScreenSubscriptionInUseError,
       Navigator::LoadPolicy::LoadTemporarily,
-      "qrc:/Mozilla/VPN/screens/ScreenSubscriptionInUseError.qml",
+      "qrc:/qt/qml/Mozilla/VPN/screens/ScreenSubscriptionInUseError.qml",
       QVector<int>{App::StateSubscriptionNeeded,
                    App::StateSubscriptionInProgress},
       [](int* requestedScreen) -> int8_t {
@@ -1644,27 +1644,27 @@ void MozillaVPN::registerNavigatorScreens() {
   Navigator::registerScreen(
       MozillaVPN::ScreenSubscriptionNeeded,
       Navigator::LoadPolicy::LoadTemporarily,
-      "qrc:/Mozilla/VPN/screens/ScreenSubscriptionNeeded.qml",
+      "qrc:/qt/qml/Mozilla/VPN/screens/ScreenSubscriptionNeeded.qml",
       QVector<int>{App::StateSubscriptionNeeded},
       [](int*) -> int8_t { return 0; }, []() -> bool { return false; });
 
   Navigator::registerScreen(
       MozillaVPN::ScreenSubscriptionNotValidated,
       Navigator::LoadPolicy::LoadTemporarily,
-      "qrc:/Mozilla/VPN/screens/ScreenSubscriptionNotValidated.qml",
+      "qrc:/qt/qml/Mozilla/VPN/screens/ScreenSubscriptionNotValidated.qml",
       QVector<int>{App::StateSubscriptionNotValidated},
       [](int*) -> int8_t { return 0; }, []() -> bool { return false; });
 
   Navigator::registerScreen(
       MozillaVPN::ScreenUpdateRequired, Navigator::LoadPolicy::LoadTemporarily,
-      "qrc:/Mozilla/VPN/screens/ScreenUpdateRequired.qml",
+      "qrc:/qt/qml/Mozilla/VPN/screens/ScreenUpdateRequired.qml",
       QVector<int>{MozillaVPN::StateUpdateRequired},
       [](int*) -> int8_t { return 0; }, []() -> bool { return false; });
 
   Navigator::registerScreen(
       MozillaVPN::ScreenUpdateRecommended,
       Navigator::LoadPolicy::LoadTemporarily,
-      "qrc:/Mozilla/VPN/screens/ScreenUpdateRecommended.qml", QVector<int>{},
+      "qrc:/qt/qml/Mozilla/VPN/screens/ScreenUpdateRecommended.qml", QVector<int>{},
       [](int* requestedScreen) -> int8_t {
         return (requestedScreen &&
                 *requestedScreen == MozillaVPN::ScreenUpdateRecommended)
@@ -1678,7 +1678,7 @@ void MozillaVPN::registerNavigatorScreens() {
 
   Navigator::registerScreen(
       MozillaVPN::ScreenViewLogs, Navigator::LoadPolicy::LoadTemporarily,
-      "qrc:/Mozilla/VPN/screens/ScreenViewLogs.qml", QVector<int>{},
+      "qrc:/qt/qml/Mozilla/VPN/screens/ScreenViewLogs.qml", QVector<int>{},
       [](int* requestedScreen) -> int8_t {
         return (requestedScreen &&
                 *requestedScreen == MozillaVPN::ScreenViewLogs)
@@ -1692,7 +1692,7 @@ void MozillaVPN::registerNavigatorScreens() {
 
   Navigator::registerScreen(
       MozillaVPN::ScreenRemovingDevice, Navigator::LoadPolicy::LoadTemporarily,
-      "qrc:/Mozilla/VPN/screens/ScreenRemovingDevice.qml", QVector<int>{},
+      "qrc:/qt/qml/Mozilla/VPN/screens/ScreenRemovingDevice.qml", QVector<int>{},
       [](int* requestedScreen) -> int8_t {
         return (requestedScreen &&
                 *requestedScreen == MozillaVPN::ScreenRemovingDevice)
@@ -1706,7 +1706,7 @@ void MozillaVPN::registerNavigatorScreens() {
 
   Navigator::registerScreen(
       MozillaVPN::ScreenOnboarding, Navigator::LoadPolicy::LoadTemporarily,
-      "qrc:/Mozilla/VPN/screens/ScreenOnboarding.qml",
+      "qrc:/qt/qml/Mozilla/VPN/screens/ScreenOnboarding.qml",
       QVector<int>{App::StateOnboarding}, [](int*) -> int8_t { return 0; },
       []() -> bool { return false; });
 

--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -1481,7 +1481,8 @@ void MozillaVPN::registerNavigatorScreens() {
 
   Navigator::registerScreen(
       MozillaVPN::ScreenCrashReporting, Navigator::LoadPolicy::LoadTemporarily,
-      "qrc:/qt/qml/Mozilla/VPN/screens/ScreenCrashReporting.qml", QVector<int>{},
+      "qrc:/qt/qml/Mozilla/VPN/screens/ScreenCrashReporting.qml",
+      QVector<int>{},
       [](int* requestedScreen) -> int8_t {
         return (requestedScreen &&
                 *requestedScreen == MozillaVPN::ScreenCrashReporting)
@@ -1527,8 +1528,9 @@ void MozillaVPN::registerNavigatorScreens() {
 
   Navigator::registerScreen(
       MozillaVPN::ScreenHome, Navigator::LoadPolicy::LoadPersistently,
-      "qrc:/qt/qml/Mozilla/VPN/screens/ScreenHome.qml", QVector<int>{App::StateMain},
-      [](int*) -> int8_t { return 99; }, []() -> bool { return false; });
+      "qrc:/qt/qml/Mozilla/VPN/screens/ScreenHome.qml",
+      QVector<int>{App::StateMain}, [](int*) -> int8_t { return 99; },
+      []() -> bool { return false; });
 
   Navigator::registerScreen(
       MozillaVPN::ScreenInitialize, Navigator::LoadPolicy::LoadTemporarily,
@@ -1664,7 +1666,8 @@ void MozillaVPN::registerNavigatorScreens() {
   Navigator::registerScreen(
       MozillaVPN::ScreenUpdateRecommended,
       Navigator::LoadPolicy::LoadTemporarily,
-      "qrc:/qt/qml/Mozilla/VPN/screens/ScreenUpdateRecommended.qml", QVector<int>{},
+      "qrc:/qt/qml/Mozilla/VPN/screens/ScreenUpdateRecommended.qml",
+      QVector<int>{},
       [](int* requestedScreen) -> int8_t {
         return (requestedScreen &&
                 *requestedScreen == MozillaVPN::ScreenUpdateRecommended)
@@ -1692,7 +1695,8 @@ void MozillaVPN::registerNavigatorScreens() {
 
   Navigator::registerScreen(
       MozillaVPN::ScreenRemovingDevice, Navigator::LoadPolicy::LoadTemporarily,
-      "qrc:/qt/qml/Mozilla/VPN/screens/ScreenRemovingDevice.qml", QVector<int>{},
+      "qrc:/qt/qml/Mozilla/VPN/screens/ScreenRemovingDevice.qml",
+      QVector<int>{},
       [](int* requestedScreen) -> int8_t {
         return (requestedScreen &&
                 *requestedScreen == MozillaVPN::ScreenRemovingDevice)

--- a/src/ui/CMakeLists.txt
+++ b/src/ui/CMakeLists.txt
@@ -5,7 +5,7 @@
 qt_add_qml_module(mozillavpn-ui
     VERSION 1.0
     URI Mozilla.VPN
-    NO_PLUGIN_OPTIONAL
+    RESOURCE_PREFIX /qt/qml #TODO: Remove this once we only compile with 6.5+
     STATIC
     OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/Mozilla/VPN
     QML_FILES

--- a/src/ui/screens/ScreenAuthenticationInApp.qml
+++ b/src/ui/screens/ScreenAuthenticationInApp.qml
@@ -14,6 +14,6 @@ MZStackView {
 
     Component.onCompleted: function() {
         MZNavigator.addStackView(VPN.ScreenAuthenticationInApp, stackview)
-        stackview.push("qrc:/Mozilla/VPN/screens/authenticationInApp/ViewAuthenticationInApp.qml")
+        stackview.push("qrc:/qt/qml/Mozilla/VPN/screens/authenticationInApp/ViewAuthenticationInApp.qml")
     }
 }

--- a/src/ui/screens/ScreenBackendFailure.qml
+++ b/src/ui/screens/ScreenBackendFailure.qml
@@ -20,7 +20,7 @@ MZStackView {
         MZNavigator.addStackView(VPN.ScreenBackendFailure, stackview)
 
         stackview.push(
-            "qrc:/Mozilla/VPN/sharedViews/ViewErrorFullScreen.qml", {
+            "qrc:/qt/qml/Mozilla/VPN/sharedViews/ViewErrorFullScreen.qml", {
                 //% "Something went wrong…"
                 headlineText: qsTrId("vpn.errors.somethingWentWrong"),
 

--- a/src/ui/screens/ScreenBillingNotAvailable.qml
+++ b/src/ui/screens/ScreenBillingNotAvailable.qml
@@ -19,7 +19,7 @@ MZStackView {
     Component.onCompleted: {
         MZNavigator.addStackView(VPN.ScreenBillingNotAvailable, stackview)
 
-        stackview.push("qrc:/Mozilla/VPN/sharedViews/ViewErrorFullScreen.qml", {
+        stackview.push("qrc:/qt/qml/Mozilla/VPN/sharedViews/ViewErrorFullScreen.qml", {
             // Sign in to Google Account
             headlineText: MZI18n.NotSignedInGoogleGoogleModalHeader,
 

--- a/src/ui/screens/ScreenDeleteAccount.qml
+++ b/src/ui/screens/ScreenDeleteAccount.qml
@@ -16,6 +16,6 @@ MZStackView {
     id: stackview
     Component.onCompleted: () => {
        MZNavigator.addStackView(VPN.ScreenDeleteAccount, stackview)
-       stackview.push("qrc:/Mozilla/VPN/deleteAccount/ViewDeleteAccount.qml")
+       stackview.push("qrc:/qt/qml/Mozilla/VPN/deleteAccount/ViewDeleteAccount.qml")
     }
 }

--- a/src/ui/screens/ScreenDeviceLimit.qml
+++ b/src/ui/screens/ScreenDeviceLimit.qml
@@ -17,6 +17,6 @@ MZScreenBase {
 
     Component.onCompleted: () => {
         MZNavigator.addStackView(VPN.ScreenDeviceLimit, getStack())
-        getStack().push("qrc:/Mozilla/VPN/screens/devices/ViewDeviceLimit.qml")
+        getStack().push("qrc:/qt/qml/Mozilla/VPN/screens/devices/ViewDeviceLimit.qml")
     }
 }

--- a/src/ui/screens/ScreenGetHelp.qml
+++ b/src/ui/screens/ScreenGetHelp.qml
@@ -62,7 +62,7 @@ Item {
 
             Component.onCompleted: function() {
                 MZNavigator.addStackView(VPN.ScreenGetHelp, getHelpStackView)
-                getHelpStackView.push("qrc:/Mozilla/VPN/screens/getHelp/ViewGetHelp.qml")
+                getHelpStackView.push("qrc:/qt/qml/Mozilla/VPN/screens/getHelp/ViewGetHelp.qml")
             }
 
             onCurrentItemChanged: {

--- a/src/ui/screens/ScreenHome.qml
+++ b/src/ui/screens/ScreenHome.qml
@@ -17,7 +17,7 @@ MZScreenBase {
 
     Component.onCompleted: () => {
         MZNavigator.addStackView(VPN.ScreenHome, getStack())
-        getStack().push("qrc:/Mozilla/VPN/screens/home/ViewHome.qml")
+        getStack().push("qrc:/qt/qml/Mozilla/VPN/screens/home/ViewHome.qml")
     }
 
     Connections {
@@ -33,7 +33,7 @@ MZScreenBase {
             getStack().pop(null);
 
             // push server view
-            getStack().push("qrc:/Mozilla/VPN/screens/home/ViewServers.qml", StackView.Immediate);
+            getStack().push("qrc:/qt/qml/Mozilla/VPN/screens/home/ViewServers.qml", StackView.Immediate);
         }
     }
 

--- a/src/ui/screens/ScreenInitialize.qml
+++ b/src/ui/screens/ScreenInitialize.qml
@@ -16,7 +16,7 @@ MZStackView {
     anchors.fill: parent
 
     Component.onCompleted: {
-        stackview.push("qrc:/Mozilla/VPN/screens/initialize/ViewInitialize.qml")
+        stackview.push("qrc:/qt/qml/Mozilla/VPN/screens/initialize/ViewInitialize.qml")
         MZNavigator.addStackView(VPN.ScreenInitialize, stackview)
     }
 }

--- a/src/ui/screens/ScreenMessaging.qml
+++ b/src/ui/screens/ScreenMessaging.qml
@@ -15,6 +15,6 @@ MZScreenBase {
 
     Component.onCompleted: () => {
        MZNavigator.addStackView(VPN.ScreenMessaging, getStack())
-       getStack().push("qrc:/Mozilla/VPN/screens/messaging/ViewMessagesInbox.qml")
+       getStack().push("qrc:/qt/qml/Mozilla/VPN/screens/messaging/ViewMessagesInbox.qml")
    }
 }

--- a/src/ui/screens/ScreenNoSubscriptionFoundError.qml
+++ b/src/ui/screens/ScreenNoSubscriptionFoundError.qml
@@ -15,7 +15,7 @@ MZStackView {
     Component.onCompleted: function() {
        MZNavigator.addStackView(VPN.ScreenNoSubscriptionFoundError, stackView)
 
-       stackView.push("qrc:/Mozilla/VPN/sharedViews/ViewErrorFullScreen.qml", {
+       stackView.push("qrc:/qt/qml/Mozilla/VPN/sharedViews/ViewErrorFullScreen.qml", {
            // Problem confirming subscription...
            headlineText: MZI18n.GenericPurchaseErrorGenericPurchaseErrorHeader,
 

--- a/src/ui/screens/ScreenOnboarding.qml
+++ b/src/ui/screens/ScreenOnboarding.qml
@@ -14,6 +14,6 @@ MZScreenBase {
 
     Component.onCompleted: () => {
         MZNavigator.addStackView(VPN.ScreenOnboarding, getStack())
-        getStack().push("qrc:/Mozilla/VPN/screens/onboarding/ViewOnboarding.qml")
+        getStack().push("qrc:/qt/qml/Mozilla/VPN/screens/onboarding/ViewOnboarding.qml")
     }
 }

--- a/src/ui/screens/ScreenSettings.qml
+++ b/src/ui/screens/ScreenSettings.qml
@@ -16,6 +16,6 @@ MZScreenBase {
 
     Component.onCompleted: () => {
         MZNavigator.addStackView(VPN.ScreenSettings, getStack())
-        getStack().push("qrc:/Mozilla/VPN/screens/settings/ViewSettingsMenu.qml")
+        getStack().push("qrc:/qt/qml/Mozilla/VPN/screens/settings/ViewSettingsMenu.qml")
     }
 }

--- a/src/ui/screens/ScreenSubscriptionBlocked.qml
+++ b/src/ui/screens/ScreenSubscriptionBlocked.qml
@@ -19,7 +19,7 @@ MZStackView {
     Component.onCompleted: {
         MZNavigator.addStackView(VPN.ScreenSubscriptionBlocked, stackview)
 
-        stackview.push("qrc:/Mozilla/VPN/sharedViews/ViewErrorFullScreen.qml", {
+        stackview.push("qrc:/qt/qml/Mozilla/VPN/sharedViews/ViewErrorFullScreen.qml", {
             // "Problem confirming subscription…"
             headlineText: MZI18n.MultiFxaAccountErrorFxaAccountErrorHeader,
 

--- a/src/ui/screens/ScreenSubscriptionExpiredError.qml
+++ b/src/ui/screens/ScreenSubscriptionExpiredError.qml
@@ -15,7 +15,7 @@ MZStackView {
     Component.onCompleted: function(){
        MZNavigator.addStackView(VPN.ScreenSubscriptionExpiredError, stackView)
 
-       stackView.push("qrc:/Mozilla/VPN/sharedViews/ViewErrorFullScreen.qml", {
+       stackView.push("qrc:/qt/qml/Mozilla/VPN/sharedViews/ViewErrorFullScreen.qml", {
            // Problem confirming subscription...
            headlineText: MZI18n.GenericPurchaseErrorGenericPurchaseErrorHeader,
 

--- a/src/ui/screens/ScreenSubscriptionGenericError.qml
+++ b/src/ui/screens/ScreenSubscriptionGenericError.qml
@@ -15,7 +15,7 @@ MZStackView {
     Component.onCompleted: function() {
        MZNavigator.addStackView(VPN.ScreenSubscriptionGenericError, stackView)
 
-       stackView.push("qrc:/Mozilla/VPN/sharedViews/ViewErrorFullScreen.qml", {
+       stackView.push("qrc:/qt/qml/Mozilla/VPN/sharedViews/ViewErrorFullScreen.qml", {
            // Problem confirming subscription...
            headlineText: MZI18n.GenericPurchaseErrorGenericPurchaseErrorHeader,
 

--- a/src/ui/screens/ScreenSubscriptionInUseError.qml
+++ b/src/ui/screens/ScreenSubscriptionInUseError.qml
@@ -15,7 +15,7 @@ MZStackView {
     Component.onCompleted: function(){
        MZNavigator.addStackView(VPN.ScreenSubscriptionInUseError, stackView)
 
-       stackView.push("qrc:/Mozilla/VPN/sharedViews/ViewErrorFullScreen.qml", {
+       stackView.push("qrc:/qt/qml/Mozilla/VPN/sharedViews/ViewErrorFullScreen.qml", {
            // Problem confirming subscription...
            headlineText: MZI18n.GenericPurchaseErrorGenericPurchaseErrorHeader,
 

--- a/src/ui/screens/ScreenSubscriptionNeeded.qml
+++ b/src/ui/screens/ScreenSubscriptionNeeded.qml
@@ -13,6 +13,6 @@ StackView {
 
     Component.onCompleted: function(){
         MZNavigator.addStackView(VPN.ScreenSubscriptionNeeded, stackview)
-        stackview.push("qrc:/Mozilla/VPN/screens/subscriptionNeeded/ViewSubscriptionNeeded.qml")
+        stackview.push("qrc:/qt/qml/Mozilla/VPN/screens/subscriptionNeeded/ViewSubscriptionNeeded.qml")
     }
 }

--- a/src/ui/screens/ScreenSubscriptionNotValidated.qml
+++ b/src/ui/screens/ScreenSubscriptionNotValidated.qml
@@ -19,7 +19,7 @@ MZStackView {
     Component.onCompleted: {
         MZNavigator.addStackView(VPN.ScreenSubscriptionNotValidated, stackview)
 
-        stackview.push("qrc:/Mozilla/VPN/sharedViews/ViewErrorFullScreen.qml", {
+        stackview.push("qrc:/qt/qml/Mozilla/VPN/sharedViews/ViewErrorFullScreen.qml", {
             // "Problem confirming subscription…"
             headlineText: MZI18n.GenericPurchaseErrorGenericPurchaseErrorHeader,
 

--- a/src/ui/screens/ScreenUpdateRecommended.qml
+++ b/src/ui/screens/ScreenUpdateRecommended.qml
@@ -8,6 +8,6 @@ Loader {
     id: loader
 
     Component.onCompleted: function(){
-        loader.source="qrc:/Mozilla/VPN/sharedViews/ViewUpdate.qml"
+        loader.source="qrc:/qt/qml/Mozilla/VPN/sharedViews/ViewUpdate.qml"
     }
 }

--- a/src/ui/screens/ScreenUpdateRequired.qml
+++ b/src/ui/screens/ScreenUpdateRequired.qml
@@ -8,6 +8,6 @@ Loader {
     id: loader
 
     Component.onCompleted: function(){
-        loader.source="qrc:/Mozilla/VPN/sharedViews/ViewUpdate.qml"
+        loader.source="qrc:/qt/qml/Mozilla/VPN/sharedViews/ViewUpdate.qml"
     }
 }

--- a/src/ui/screens/authenticationInApp/ViewAuthenticationInApp.qml
+++ b/src/ui/screens/authenticationInApp/ViewAuthenticationInApp.qml
@@ -36,7 +36,7 @@ Item {
             when: MZAuthInApp.state === MZAuthInApp.StateInitializing || MZAuthInApp.state === MZAuthInApp.StateAuthenticated
             PropertyChanges {
                 target: loader
-                source: "qrc:/Mozilla/VPN/authenticationInApp/ViewAuthenticationInitializing.qml"
+                source: "qrc:/qt/qml/Mozilla/VPN/authenticationInApp/ViewAuthenticationInitializing.qml"
             }
         },
 
@@ -45,7 +45,7 @@ Item {
             when: MZAuthInApp.state === MZAuthInApp.StateStart || MZAuthInApp.state === MZAuthInApp.StateCheckingAccount
             PropertyChanges {
                 target: loader
-                source: "qrc:/Mozilla/VPN/authenticationInApp/ViewAuthenticationStart.qml"
+                source: "qrc:/qt/qml/Mozilla/VPN/authenticationInApp/ViewAuthenticationStart.qml"
             }
         },
 
@@ -54,7 +54,7 @@ Item {
             when: MZAuthInApp.state === MZAuthInApp.StateSignIn || MZAuthInApp.state === MZAuthInApp.StateSigningIn
             PropertyChanges {
                 target: loader
-                source: "qrc:/Mozilla/VPN/authenticationInApp/ViewAuthenticationSignIn.qml"
+                source: "qrc:/qt/qml/Mozilla/VPN/authenticationInApp/ViewAuthenticationSignIn.qml"
             }
         },
 
@@ -62,7 +62,7 @@ Item {
             when: MZAuthInApp.state === MZAuthInApp.StateSignUp || MZAuthInApp.state === MZAuthInApp.StateSigningUp
             PropertyChanges {
                 target: loader
-                source: "qrc:/Mozilla/VPN/authenticationInApp/ViewAuthenticationSignUp.qml"
+                source: "qrc:/qt/qml/Mozilla/VPN/authenticationInApp/ViewAuthenticationSignUp.qml"
             }
         },
 
@@ -71,7 +71,7 @@ Item {
             when: MZAuthInApp.state === MZAuthInApp.StateUnblockCodeNeeded || MZAuthInApp.state === MZAuthInApp.StateVerifyingUnblockCode
             PropertyChanges {
                 target: loader
-                source: "qrc:/Mozilla/VPN/authenticationInApp/ViewAuthenticationUnblockCodeNeeded.qml"
+                source: "qrc:/qt/qml/Mozilla/VPN/authenticationInApp/ViewAuthenticationUnblockCodeNeeded.qml"
             }
         },
 
@@ -80,7 +80,7 @@ Item {
             when: MZAuthInApp.state === MZAuthInApp.StateVerificationSessionByEmailNeeded || MZAuthInApp.state === MZAuthInApp.StateVerifyingSessionEmailCode
             PropertyChanges {
                 target: loader
-                source: "qrc:/Mozilla/VPN/authenticationInApp/ViewAuthenticationVerificationSessionByEmailNeeded.qml"
+                source: "qrc:/qt/qml/Mozilla/VPN/authenticationInApp/ViewAuthenticationVerificationSessionByEmailNeeded.qml"
             }
         },
 
@@ -89,7 +89,7 @@ Item {
             when: MZAuthInApp.state === MZAuthInApp.StateVerificationSessionByTotpNeeded || MZAuthInApp.state === MZAuthInApp.StateVerifyingSessionTotpCode
             PropertyChanges {
                 target: loader
-                source: "qrc:/Mozilla/VPN/authenticationInApp/ViewAuthenticationVerificationSessionByTotpNeeded.qml"
+                source: "qrc:/qt/qml/Mozilla/VPN/authenticationInApp/ViewAuthenticationVerificationSessionByTotpNeeded.qml"
             }
         },
 
@@ -98,7 +98,7 @@ Item {
             when: MZAuthInApp.state === MZAuthInApp.StateIsStubAccount
             PropertyChanges {
                 target: loader
-                source: "qrc:/Mozilla/VPN/authenticationInApp/ViewAuthenticationStubAccount.qml"
+                source: "qrc:/qt/qml/Mozilla/VPN/authenticationInApp/ViewAuthenticationStubAccount.qml"
             }
         },
 
@@ -107,7 +107,7 @@ Item {
             when: MZAuthInApp.state === MZAuthInApp.StateIsSsoAccount
             PropertyChanges {
                 target: loader
-                source: "qrc:/Mozilla/VPN/authenticationInApp/ViewAuthenticationSsoAccount.qml"
+                source: "qrc:/qt/qml/Mozilla/VPN/authenticationInApp/ViewAuthenticationSsoAccount.qml"
             }
         },
 
@@ -116,7 +116,7 @@ Item {
             when: MZAuthInApp.state === MZAuthInApp.StateFallbackInBrowser
             PropertyChanges {
                 target: loader
-                source: "qrc:/Mozilla/VPN/authenticationInApp/ViewAuthenticationFallbackInBrowser.qml"
+                source: "qrc:/qt/qml/Mozilla/VPN/authenticationInApp/ViewAuthenticationFallbackInBrowser.qml"
             }
         }
     ]

--- a/src/ui/screens/getHelp/ViewGetHelp.qml
+++ b/src/ui/screens/getHelp/ViewGetHelp.qml
@@ -52,7 +52,7 @@ MZViewBase {
             width: parent.width - MZTheme.theme.windowMargin
             onClicked: {
                 Glean.sample.helpContactSupportOpened.record();
-                getHelpStackView.push("qrc:/Mozilla/VPN/screens/getHelp/contactUs/ViewContactUsForm.qml");
+                getHelpStackView.push("qrc:/qt/qml/Mozilla/VPN/screens/getHelp/contactUs/ViewContactUsForm.qml");
             }
         }
 
@@ -80,7 +80,7 @@ MZViewBase {
             backgroundColor: MZTheme.theme.iconButtonLightBackground
             visible: MZFeatureList.get("factoryReset").isSupported
 
-            onClicked: getHelpStackView.push("qrc:/Mozilla/VPN/screens/settings/ViewReset.qml");
+            onClicked: getHelpStackView.push("qrc:/qt/qml/Mozilla/VPN/screens/settings/ViewReset.qml");
 
             accessibleName: title
         }
@@ -97,7 +97,7 @@ MZViewBase {
             imageRightSrc: "qrc:/nebula/resources/chevron.svg"
             imageRightMirror: MZLocalizer.isRightToLeft
             visible: MZSettings.developerUnlock
-            onClicked: getHelpStackView.push("qrc:/Mozilla/VPN/screens/getHelp/developerMenu/ViewDeveloperMenu.qml")
+            onClicked: getHelpStackView.push("qrc:/qt/qml/Mozilla/VPN/screens/getHelp/developerMenu/ViewDeveloperMenu.qml")
         }
     }
 }

--- a/src/ui/screens/getHelp/contactUs/ViewContactUsForm.qml
+++ b/src/ui/screens/getHelp/contactUs/ViewContactUsForm.qml
@@ -33,10 +33,10 @@ MZViewBase {
            target: VPN
            function onTicketCreationAnswer(successful) {
                if(successful) {
-                   getHelpStackView.replace("qrc:/Mozilla/VPN/screens/getHelp/contactUs/ViewContactUsThankYou.qml", {_emailAddress: contactUsRoot._emailAddress}, StackView.Immediate);
+                   getHelpStackView.replace("qrc:/qt/qml/Mozilla/VPN/screens/getHelp/contactUs/ViewContactUsThankYou.qml", {_emailAddress: contactUsRoot._emailAddress}, StackView.Immediate);
                } else {
                    // TODO: Navigator.GetTheThing
-                   getHelpStackView.replace("qrc:/Mozilla/VPN/sharedViews/ViewErrorFullScreen.qml", {
+                   getHelpStackView.replace("qrc:/qt/qml/Mozilla/VPN/sharedViews/ViewErrorFullScreen.qml", {
                        headlineText: MZI18n.InAppSupportWorkflowSupportErrorHeader,
                        errorMessage: MZI18n.InAppSupportWorkflowSupportErrorText,
                        primaryButtonText: MZI18n.InAppSupportWorkflowSupportErrorButton,

--- a/src/ui/screens/getHelp/developerMenu/ViewDeveloperMenu.qml
+++ b/src/ui/screens/getHelp/developerMenu/ViewDeveloperMenu.qml
@@ -143,23 +143,23 @@ MZViewBase {
 
                 ListElement {
                     title: "Feature list"
-                    viewQrc: "qrc:/Mozilla/VPN/screens/getHelp/developerMenu/ViewFeatureList.qml"
+                    viewQrc: "qrc:/qt/qml/Mozilla/VPN/screens/getHelp/developerMenu/ViewFeatureList.qml"
                 }
                 ListElement {
                     title: "Theme list"
-                    viewQrc: "qrc:/Mozilla/VPN/screens/getHelp/developerMenu/ViewThemeList.qml"
+                    viewQrc: "qrc:/qt/qml/Mozilla/VPN/screens/getHelp/developerMenu/ViewThemeList.qml"
                 }
                 ListElement {
                     title: "Animations playground"
-                    viewQrc: "qrc:/Mozilla/VPN/screens/getHelp/developerMenu/ViewAnimationsPlayground.qml"
+                    viewQrc: "qrc:/qt/qml/Mozilla/VPN/screens/getHelp/developerMenu/ViewAnimationsPlayground.qml"
                 }
                 ListElement {
                     title: "UI Testing"
-                    viewQrc: "qrc:/Mozilla/VPN/screens/getHelp/developerMenu/ViewUiTesting.qml"
+                    viewQrc: "qrc:/qt/qml/Mozilla/VPN/screens/getHelp/developerMenu/ViewUiTesting.qml"
                 }
                 ListElement {
                     title: "Telemetry Debugging"
-                    viewQrc: "qrc:/Mozilla/VPN/screens/getHelp/developerMenu/ViewTelemetryDebugging.qml"
+                    viewQrc: "qrc:/qt/qml/Mozilla/VPN/screens/getHelp/developerMenu/ViewTelemetryDebugging.qml"
                 }
             }
 

--- a/src/ui/screens/home/ViewMultiHop.qml
+++ b/src/ui/screens/home/ViewMultiHop.qml
@@ -52,7 +52,7 @@ StackView {
             ControllerNav {
                 function handleClick() {
                     multiHopStackView.push(
-                        "qrc:/Mozilla/VPN/screens/home/servers/ServerList.qml",
+                        "qrc:/qt/qml/Mozilla/VPN/screens/home/servers/ServerList.qml",
                         {
                             currentServer: entryLabel.serversList[0],
                             showRecentConnections: false
@@ -86,7 +86,7 @@ StackView {
                 spacing: 8
                 ControllerNav {
                     function handleClick() {
-                        multiHopStackView.push("qrc:/Mozilla/VPN/screens/home/servers/ServerList.qml",
+                        multiHopStackView.push("qrc:/qt/qml/Mozilla/VPN/screens/home/servers/ServerList.qml",
                            {
                                 currentServer:  exitLabel.serversList[0],
                                 showRecentConnections: false

--- a/src/ui/screens/messaging/ViewMessagesInbox.qml
+++ b/src/ui/screens/messaging/ViewMessagesInbox.qml
@@ -208,7 +208,7 @@ MZViewBase {
                         if (vpnFlickable.anySwipesOpen()) vpnFlickable.closeAllSwipes()
                         else {
                             addon.markAsRead()
-                            stackview.push("qrc:/Mozilla/VPN/screens/messaging/ViewMessage.qml", {"message": addon})
+                            stackview.push("qrc:/qt/qml/Mozilla/VPN/screens/messaging/ViewMessage.qml", {"message": addon})
                         }
                     }
 

--- a/src/ui/screens/onboarding/OnboardingPrivacySlide.qml
+++ b/src/ui/screens/onboarding/OnboardingPrivacySlide.qml
@@ -7,7 +7,7 @@ import QtQuick.Layouts 1.15
 
 import Mozilla.Shared 1.0
 import components 0.1
-import "qrc:/Mozilla/VPN/screens/settings/privacy"
+import "qrc:/qt/qml/Mozilla/VPN/screens/settings/privacy"
 import "qrc:/nebula/utils/MZUiUtils.js" as MZUiUtils
 
 ColumnLayout {

--- a/src/ui/screens/settings/ViewAboutUs.qml
+++ b/src/ui/screens/settings/ViewAboutUs.qml
@@ -150,7 +150,7 @@ MZViewBase {
               aboutUsListModel.append({
                    linkId: "license",
                    linkTitleId: "AboutUsLicenses",
-                   openView: "qrc:/Mozilla/VPN/screens/settings/ViewLicenses.qml"
+                   openView: "qrc:/qt/qml/Mozilla/VPN/screens/settings/ViewLicenses.qml"
               });
            }
         }

--- a/src/ui/screens/settings/ViewLicenses.qml
+++ b/src/ui/screens/settings/ViewLicenses.qml
@@ -37,7 +37,7 @@ MZViewBase {
                 title: licenseTitle
                 iconSource: "qrc:/nebula/resources/chevron.svg"
                 iconMirror: MZLocalizer.isRightToLeft
-                onClicked: stackview.push("qrc:/Mozilla/VPN/screens/settings/ViewLicense.qml", { _menuTitle: licenseTitle, licenseContent })
+                onClicked: stackview.push("qrc:/qt/qml/Mozilla/VPN/screens/settings/ViewLicense.qml", { _menuTitle: licenseTitle, licenseContent })
             }
         }
     }

--- a/src/ui/screens/settings/ViewPreferences.qml
+++ b/src/ui/screens/settings/ViewPreferences.qml
@@ -127,7 +127,7 @@ MZViewBase {
                         VPNAndroidUtils.openNotificationSettings();
                         return;
                     }
-                    stackview.push("qrc:/Mozilla/VPN/screens/settings/ViewNotifications.qml")
+                    stackview.push("qrc:/qt/qml/Mozilla/VPN/screens/settings/ViewNotifications.qml")
                 }
                 visible: MZFeatureList.get("captivePortal").isSupported || MZFeatureList.get("unsecuredNetworkNotification").isSupported || MZFeatureList.get("notificationControl").isSupported
             }
@@ -141,7 +141,7 @@ MZViewBase {
                 imageRightMirror: MZLocalizer.isRightToLeft
                 onClicked: {
                     Glean.interaction.languageSelected.record({screen:telemetryScreenId})
-                    stackview.push("qrc:/Mozilla/VPN/screens/settings/ViewLanguage.qml")
+                    stackview.push("qrc:/qt/qml/Mozilla/VPN/screens/settings/ViewLanguage.qml")
                 }
                 visible: MZLocalizer.hasLanguages
             }
@@ -155,7 +155,7 @@ MZViewBase {
                 imageRightMirror: MZLocalizer.isRightToLeft
                 onClicked: {
                     Glean.interaction.dnsSettingsSelected.record({screen:telemetryScreenId})
-                    stackview.push("qrc:/Mozilla/VPN/screens/settings/ViewDNSSettings.qml")
+                    stackview.push("qrc:/qt/qml/Mozilla/VPN/screens/settings/ViewDNSSettings.qml")
                 }
             }
         }

--- a/src/ui/screens/settings/ViewReset.qml
+++ b/src/ui/screens/settings/ViewReset.qml
@@ -10,7 +10,7 @@ import Mozilla.VPN 1.0
 import Mozilla.Shared 1.0
 import components 0.1
 import compat 0.1
-import "qrc:/Mozilla/VPN/sharedViews"
+import "qrc:/qt/qml/Mozilla/VPN/sharedViews"
 
 ViewFullScreen {
     id: root

--- a/src/ui/screens/settings/ViewSettingsMenu.qml
+++ b/src/ui/screens/settings/ViewSettingsMenu.qml
@@ -59,7 +59,7 @@ MZViewBase {
                 imageRightMirror: MZLocalizer.isRightToLeft
                 onClicked: {
                     Glean.interaction.privacyFeaturesSelected.record({screen:telemetryScreenId})
-                    stackview.push("qrc:/Mozilla/VPN/screens/settings/privacy/ViewPrivacy.qml")
+                    stackview.push("qrc:/qt/qml/Mozilla/VPN/screens/settings/privacy/ViewPrivacy.qml")
                 }
             }
 
@@ -71,7 +71,7 @@ MZViewBase {
                 imageRightMirror: MZLocalizer.isRightToLeft
                 onClicked: {
                     Glean.interaction.appExclusionsSelected.record({screen:telemetryScreenId});
-                    stackview.push("qrc:/Mozilla/VPN/screens/settings/appPermissions/ViewAppPermissions.qml")
+                    stackview.push("qrc:/qt/qml/Mozilla/VPN/screens/settings/appPermissions/ViewAppPermissions.qml")
                 }
                 visible: MZFeatureList.get("splitTunnel").isSupported
             }
@@ -86,7 +86,7 @@ MZViewBase {
                 imageRightMirror: MZLocalizer.isRightToLeft
                 onClicked: {
                     Glean.interaction.myDevicesSelected.record({screen:telemetryScreenId})
-                    stackview.push("qrc:/Mozilla/VPN/screens/devices/ViewDevices.qml")
+                    stackview.push("qrc:/qt/qml/Mozilla/VPN/screens/devices/ViewDevices.qml")
                 }
             }
 
@@ -99,7 +99,7 @@ MZViewBase {
                 imageRightMirror: MZLocalizer.isRightToLeft
                 onClicked: {
                     Glean.interaction.appPreferencesSelected.record({screen:telemetryScreenId})
-                    stackview.push("qrc:/Mozilla/VPN/screens/settings/ViewPreferences.qml", {
+                    stackview.push("qrc:/qt/qml/Mozilla/VPN/screens/settings/ViewPreferences.qml", {
                                                     _startAtBootTitle: Qt.binding(() => MZI18n.SettingsStartAtBootTitle),
                                                     _languageTitle:  Qt.binding(() => qsTrId("vpn.settings.language")),
                                                     _notificationsTitle:  Qt.binding(() => qsTrId("vpn.settings.notifications")),
@@ -128,7 +128,7 @@ MZViewBase {
                 imageRightMirror: MZLocalizer.isRightToLeft
                 onClicked: {
                     Glean.interaction.aboutUsSelected.record({screen:telemetryScreenId})
-                    stackview.push("qrc:/Mozilla/VPN/screens/settings/ViewAboutUs.qml")
+                    stackview.push("qrc:/qt/qml/Mozilla/VPN/screens/settings/ViewAboutUs.qml")
                 }
             }
 
@@ -143,14 +143,14 @@ MZViewBase {
                 VPNProfileFlow.state === VPNProfileFlow.StateReady
                 && stackview.currentItem.objectName !== "subscriptionManagmentView"
             ) {
-                return stackview.push("qrc:/Mozilla/VPN/screens/settings/ViewSubscriptionManagement/ViewSubscriptionManagement.qml");
+                return stackview.push("qrc:/qt/qml/Mozilla/VPN/screens/settings/ViewSubscriptionManagement/ViewSubscriptionManagement.qml");
             }
             // Only push the profile view if it’s not already in the stack
             if (
                 VPNProfileFlow.state === VPNProfileFlow.StateAuthenticationNeeded
                 && stackview.currentItem.objectName !== "reauthenticationFlow"
             ) {
-                return stackview.push("qrc:/Mozilla/VPN/screens/settings/ViewSubscriptionManagement/ViewReauthenticationFlow.qml", {
+                return stackview.push("qrc:/qt/qml/Mozilla/VPN/screens/settings/ViewSubscriptionManagement/ViewReauthenticationFlow.qml", {
                     _onClose: () => {
                         VPNProfileFlow.reset();
                         stackview.pop(null, StackView.Immediate);

--- a/src/ui/screens/settings/ViewSubscriptionManagement/ViewReauthenticationFlow.qml
+++ b/src/ui/screens/settings/ViewSubscriptionManagement/ViewReauthenticationFlow.qml
@@ -48,7 +48,7 @@ Item {
             )
             PropertyChanges {
                 target: loader
-                source: "qrc:/Mozilla/VPN/authenticationInApp/ViewAuthenticationInitializing.qml"
+                source: "qrc:/qt/qml/Mozilla/VPN/authenticationInApp/ViewAuthenticationInitializing.qml"
             }
         },
 
@@ -60,7 +60,7 @@ Item {
             )
             PropertyChanges {
                 target: loader
-                source: "qrc:/Mozilla/VPN/authenticationInApp/ViewAuthenticationSignIn.qml"
+                source: "qrc:/qt/qml/Mozilla/VPN/authenticationInApp/ViewAuthenticationSignIn.qml"
             }
         },
 
@@ -72,7 +72,7 @@ Item {
             )
             PropertyChanges {
                 target: loader
-                source: "qrc:/Mozilla/VPN/authenticationInApp/ViewAuthenticationUnblockCodeNeeded.qml"
+                source: "qrc:/qt/qml/Mozilla/VPN/authenticationInApp/ViewAuthenticationUnblockCodeNeeded.qml"
             }
         },
 
@@ -84,7 +84,7 @@ Item {
             )
             PropertyChanges {
                 target: loader
-                source: "qrc:/Mozilla/VPN/authenticationInApp/ViewAuthenticationVerificationSessionByEmailNeeded.qml"
+                source: "qrc:/qt/qml/Mozilla/VPN/authenticationInApp/ViewAuthenticationVerificationSessionByEmailNeeded.qml"
             }
         },
 
@@ -96,7 +96,7 @@ Item {
             )
             PropertyChanges {
                 target: loader
-                source: "qrc:/Mozilla/VPN/authenticationInApp/ViewAuthenticationVerificationSessionByTotpNeeded.qml"
+                source: "qrc:/qt/qml/Mozilla/VPN/authenticationInApp/ViewAuthenticationVerificationSessionByTotpNeeded.qml"
             }
         },
 

--- a/src/ui/screens/settings/ViewSubscriptionManagement/ViewSubscriptionManagement.qml
+++ b/src/ui/screens/settings/ViewSubscriptionManagement/ViewSubscriptionManagement.qml
@@ -95,7 +95,7 @@ MZViewBase {
                 delegate: Loader {
                     Layout.fillWidth: true
                     objectName: _objectName
-                    source: "qrc:/Mozilla/VPN/screens/settings/ViewSubscriptionManagement/SubscriptionManagementItem.qml"
+                    source: "qrc:/qt/qml/Mozilla/VPN/screens/settings/ViewSubscriptionManagement/SubscriptionManagementItem.qml"
                 }
             }
 

--- a/src/ui/screens/settings/appPermissions/ViewAppPermissions.qml
+++ b/src/ui/screens/settings/appPermissions/ViewAppPermissions.qml
@@ -85,7 +85,7 @@ MZViewBase {
             {type: MZHelpSheet.BlockType.Text, text: MZI18n.HelpSheetsExcludedAppsBody3, margin: MZTheme.theme.helpSheetBodySpacing},
             {type: MZHelpSheet.BlockType.PrimaryButton, text: MZI18n.HelpSheetsExcludedAppsCTA, margin: MZTheme.theme.helpSheetBodyButtonSpacing, objectName: "openPrivacyFeaturesButton", action: () => {
                     close()
-                    getStack().push("qrc:/Mozilla/VPN/screens/settings/privacy/ViewPrivacy.qml")
+                    getStack().push("qrc:/qt/qml/Mozilla/VPN/screens/settings/privacy/ViewPrivacy.qml")
                 }},
             {type: MZHelpSheet.BlockType.LinkButton, text: MZI18n.GlobalLearnMore, margin: MZTheme.theme.helpSheetSecondaryButtonSpacing, objectName: "learnMoreLink", action: () => {
                     MZUrlOpener.openUrlLabel("sumoExcludedApps")

--- a/tests/unit_tests/testnavigator.cpp
+++ b/tests/unit_tests/testnavigator.cpp
@@ -44,12 +44,12 @@ void TestNavigator::testNavbarButtonTelemetry() {
   // Register screens
   Navigator::registerScreen(
       MozillaVPN::ScreenHome, Navigator::LoadPolicy::LoadPersistently,
-      "qrc:/Mozilla/VPN/screens/ScreenHome.qml", QVector<int>{},
+      "qrc:/qt/qml/Mozilla/VPN/screens/ScreenHome.qml", QVector<int>{},
       [](int*) -> int8_t { return 99; }, []() -> bool { return false; });
 
   Navigator::registerScreen(
       MozillaVPN::ScreenMessaging, Navigator::LoadPolicy::LoadPersistently,
-      "qrc:/Mozilla/VPN/screens/ScreenMessaging.qml", QVector<int>{},
+      "qrc:/qt/qml/Mozilla/VPN/screens/ScreenMessaging.qml", QVector<int>{},
       [](int*) -> int8_t { return 0; },
       []() -> bool {
         Navigator::instance()->requestScreen(MozillaVPN::ScreenHome,
@@ -59,7 +59,7 @@ void TestNavigator::testNavbarButtonTelemetry() {
 
   Navigator::registerScreen(
       MozillaVPN::ScreenSettings, Navigator::LoadPolicy::LoadPersistently,
-      "qrc:/Mozilla/VPN/screens/ScreenSettings.qml", QVector<int>{},
+      "qrc:/qt/qml/Mozilla/VPN/screens/ScreenSettings.qml", QVector<int>{},
       [](int*) -> int8_t { return 0; },
       []() -> bool {
         Navigator::instance()->requestScreen(MozillaVPN::ScreenHome,
@@ -221,7 +221,7 @@ void TestNavigator::testNavbarButtonTelemetryNoLayers() {
   // Register screen
   Navigator::registerScreen(
       MozillaVPN::ScreenHome, Navigator::LoadPolicy::LoadPersistently,
-      "qrc:/Mozilla/VPN/screens/ScreenHome.qml", QVector<int>{},
+      "qrc:/qt/qml/Mozilla/VPN/screens/ScreenHome.qml", QVector<int>{},
       [](int*) -> int8_t { return 99; }, []() -> bool { return false; });
 
   // Click the home nav bar button to go to ScreenHome again


### PR DESCRIPTION
## Description

i do think setting the policy to OLD broke things, my bad 🙏 . 
```
qt_policy(SET QTP0001 NEW)
```

-> So let's keep it at new and backport the changes of this policy to 6.2.4
->Set the resource prefix `/qt/qml`, it's the default value after 6.5
-> Add `/qt/qml` to the path by default.

This seems to fix everything on Windows (6.2.4/6.6.0) tested. 