### PR TITLE
VPN-6227: Use correct theme variable in AppPermissionsList.qml

### DIFF
--- a/src/ui/screens/settings/appPermissions/AppPermissionsList.qml
+++ b/src/ui/screens/settings/appPermissions/AppPermissionsList.qml
@@ -366,9 +366,12 @@ ColumnLayout {
                     iconComponent: Component {
                         MZIcon {
                             source: "qrc:/nebula/resources/plus.svg"
-                            sourceSize.height: MZTheme.theme.iconSmallSize
-                            sourceSize.width: MZTheme.theme.iconSmallSize
-                            anchors.verticalCenter: parent.verticalCenter
+                            sourceSize.height: MZTheme.theme.iconSizeSmall
+                            sourceSize.width: MZTheme.theme.iconSizeSmall
+                            anchors.bottom: parent.bottom
+                            anchors.right: parent.right
+                            anchors.rightMargin: -2
+                            anchors.bottomMargin: 1
                         }
                     }
                 }


### PR DESCRIPTION
## Description

This fixes the unusually large "+" icon in the '+ Add application' button in AppPermissionsList.qml.

After:
<img width="344" alt="Screenshot 2024-05-16 at 9 37 37 AM" src="https://github.com/mozilla-mobile/mozilla-vpn-client/assets/22355127/b59ffb53-a72e-4f45-8741-7efb454865b5">

## Reference

VPN-6227

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
