### PR TITLE
VPN-6330: More Linux static packaging fixes

### DIFF
--- a/linux/debian/control
+++ b/linux/debian/control
@@ -44,6 +44,7 @@ Architecture: any
 Depends: libcap2-bin (>=1:2.32),
          wireguard (>=1.0.20200319),
          wireguard-tools (>=1.0.20200319),
+         libxcb-cursor0,
          libqt6quick6 (>=6.2.0~),
          libqt6widgets6 (>=6.2.0~),
          libqt6gui6 (>=6.2.0~),

--- a/scripts/utils/qt6_compile.sh
+++ b/scripts/utils/qt6_compile.sh
@@ -74,6 +74,7 @@ LINUX="
   -opengl es2 \
   -no-icu \
   -no-linuxfb \
+  -system-freetype \
   -fontconfig \
   -bundled-xcb-xinput \
   -feature-qdbus \
@@ -87,6 +88,7 @@ MACOS="
   -no-feature-quickcontrols2-ios \
   -no-feature-quickcontrols2-macos \
   -no-feature-qdbus \
+  -qt-freetype \
   -appstore-compliant \
   -feature-texthtmlparser \ 
   -- \
@@ -189,7 +191,6 @@ mkdir -p $BUILDDIR
   -qt-libpng \
   -qt-zlib \
   -qt-pcre \
-  -qt-freetype \
   $PLATFORM) || die "Configuration error."
 
 print Y "Compiling..."

--- a/scripts/utils/qt6_compile.sh
+++ b/scripts/utils/qt6_compile.sh
@@ -116,7 +116,7 @@ fi
 
 # Create the installation prefix, and convert to an absolute path.
 mkdir -p $PREFIX
-PREFIX=(cd $PREFIX && pwd)
+PREFIX=$(cd $PREFIX && pwd)
 
 print Y "Wait..."
 mkdir -p $BUILDDIR

--- a/scripts/utils/qt6_compile.sh
+++ b/scripts/utils/qt6_compile.sh
@@ -74,6 +74,7 @@ LINUX="
   -opengl es2 \
   -no-icu \
   -no-linuxfb \
+  -fontconfig \
   -bundled-xcb-xinput \
   -feature-qdbus \
   -xcb \

--- a/taskcluster/kinds/toolchain/qt.yml
+++ b/taskcluster/kinds/toolchain/qt.yml
@@ -14,6 +14,7 @@ qt-macos-6.6:
     fetches:
         fetch:
             - qt-source-tarball-6.6.0
+            - miniconda-osx
     run:
         use-caches: false
         script: compile_qt_6_mac.sh

--- a/taskcluster/kinds/toolchain/qt.yml
+++ b/taskcluster/kinds/toolchain/qt.yml
@@ -94,7 +94,7 @@ qt-linux:
         toolchain-artifact: public/build/qt6_linux.tar.xz
     treeherder:
         symbol: TL(qt-linux)
-    worker-type: b-linux
+    worker-type: b-linux-large
     worker:
         docker-image: {in-tree: linux-qt6-build}
 
@@ -111,6 +111,6 @@ qt-linux-6.6.0:
         toolchain-artifact: public/build/qt6_linux.tar.xz
     treeherder:
         symbol: TL(qt-linux-6.6)
-    worker-type: b-linux
+    worker-type: b-linux-large
     worker:
         docker-image: {in-tree: linux-qt6-build}

--- a/taskcluster/scripts/toolchain/compile_qt_6_mac.sh
+++ b/taskcluster/scripts/toolchain/compile_qt_6_mac.sh
@@ -29,4 +29,4 @@ $VCS_PATH/scripts/utils/qt6_compile.sh $QT_SOURCE_DIR ${TASK_WORKDIR}/qt_dist -b
 
 echo "Creating Qt dist artifact"
 mkdir -p ${TASK_WORKDIR}/public/build
-zip -qr ${TASK_WORKDIR}/public/build/qt6_mac.zip ${TASK_WORKDIR}/qt_dist/*
+(cd ${TASK_WORKDIR} && zip -qr ./public/build/qt6_mac.zip qt_dist/*)

--- a/taskcluster/scripts/toolchain/compile_qt_6_mac.sh
+++ b/taskcluster/scripts/toolchain/compile_qt_6_mac.sh
@@ -24,7 +24,7 @@ conda install -y -c conda-forge cmake=3.26.3 ninja=1.11.0
 
 QT_SOURCE_DIR=$(find $MOZ_FETCHES_DIR -maxdepth 1 -type d -name 'qt-everywhere-src-*' | head -1)
 echo "Building $(basename $QT_SOURCE_DIR)"
-$VCS_PATH/scripts/utils/qt6_compile.sh $QT_SOURCE_DIR ${TASK_WORKDIR}/qt_dist
+$VCS_PATH/scripts/utils/qt6_compile.sh $QT_SOURCE_DIR ${TASK_WORKDIR}/qt_dist -b ${TASK_WORKDIR}/qt_build
 
 echo "Creating Qt dist artifact"
 mkdir -p ${TASK_WORKDIR}/public/build

--- a/taskcluster/scripts/toolchain/compile_qt_6_mac.sh
+++ b/taskcluster/scripts/toolchain/compile_qt_6_mac.sh
@@ -24,6 +24,7 @@ conda install -y -c conda-forge cmake=3.26.3 ninja=1.11.0
 
 QT_SOURCE_DIR=$(find $MOZ_FETCHES_DIR -maxdepth 1 -type d -name 'qt-everywhere-src-*' | head -1)
 echo "Building $(basename $QT_SOURCE_DIR)"
+rm -rf ${TASK_WORKDIR}/qt_dist ${TASK_WORKDIR}/qt_build
 $VCS_PATH/scripts/utils/qt6_compile.sh $QT_SOURCE_DIR ${TASK_WORKDIR}/qt_dist -b ${TASK_WORKDIR}/qt_build
 
 echo "Creating Qt dist artifact"

--- a/taskcluster/scripts/toolchain/compile_qt_6_mac.sh
+++ b/taskcluster/scripts/toolchain/compile_qt_6_mac.sh
@@ -4,21 +4,28 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+set -e
+cd ${TASK_WORKDIR}
 
-pushd vcs
-mkdir homebrew && curl -L https://github.com/Homebrew/brew/tarball/master | tar xz --strip 1 -C homebrew
-export PATH=$PWD/homebrew/bin:$PATH
+if [ -e ${TASK_WORKDIR}/miniconda ]; then
+    echo "Conda already exist? Remove it."
+    rm -rf ${TASK_WORKDIR}/miniconda
+fi
 
-mkdir qt_dist
-mkdir artifacts
+echo "Installing conda"
+chmod +x ${MOZ_FETCHES_DIR}/miniconda.sh
+bash ${MOZ_FETCHES_DIR}/miniconda.sh -b -p ${TASK_WORKDIR}/miniconda
+source ${TASK_WORKDIR}/miniconda/bin/activate
 
-brew install cmake
-brew install ninja
+echo "Installing provided conda env..."
+conda create -y -n qt
+conda activate qt
+conda install -y -c conda-forge cmake=3.26.3 ninja=1.11.0
 
 QT_SOURCE_DIR=$(find $MOZ_FETCHES_DIR -maxdepth 1 -type d -name 'qt-everywhere-src-*' | head -1)
 echo "Building $(basename $QT_SOURCE_DIR)"
-./scripts/utils/qt6_compile.sh $QT_SOURCE_DIR $(pwd)/qt_dist
+$VCS_PATH/scripts/utils/qt6_compile.sh $QT_SOURCE_DIR ${TASK_WORKDIR}/qt_dist
 
 echo "Creating Qt dist artifact"
-mkdir -p ../../public/build
-zip -qr ../../public/build/qt6_mac.zip qt_dist/*
+mkdir -p ${TASK_WORKDIR}/public/build
+zip -qr ${TASK_WORKDIR}/public/build/qt6_mac.zip ${TASK_WORKDIR}/qt_dist/*


### PR DESCRIPTION
## Description
To fix the missing fonts for Qt static builds, we need to rebuild Qt with fontconfig support (which also requires `-system-freetype`) and we patch up a missing `libxcb-cursor0` dependency too while we are at it.

However! Because this just so happened to touch the Qt build scripts, we also needed to address some breakage in MacOS due to a busted homebrew install. In this case, I opted to just ditch homebrew and use conda because it's already a part of our build tooling anyways. 

## Reference
JIRA issue: [VPN-6330](https://mozilla-hub.atlassian.net/browse/VPN-6330)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-6330]: https://mozilla-hub.atlassian.net/browse/VPN-6330?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ