### PR TITLE
VPN-6402: fix timer

### DIFF
--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -625,13 +625,12 @@ bool Controller::silentSwitchServers(
       return false;
     }
 
-    isSwitchingServer = true;
-
     MozillaVPN::instance()->serverLatency()->setCooldown(
         m_serverData.exitServerPublicKey(),
         Constants::SERVER_UNRESPONSIVE_COOLDOWN_SEC);
   }
 
+  isSwitchingServer = true;
   m_nextServerData = m_serverData;
   m_nextServerSelectionPolicy = serverCoolDownPolicy == eServerCoolDownNeeded
                                     ? RandomizeServerSelection


### PR DESCRIPTION
## Description

In VPN-5266, I put this line in the wrong spot. We want to set this variable to true every time we do a silent switch. But I put it in a block such that it only got set for `eServerCoolDownNeeded`. When changing DNS, this wasn't updated, and thus the timer was stuck on 0:00:00.

## Reference

VPN-6402

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
