### PR TITLE
Clang-Tidy: Enforce modernize-use-auto

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -14,6 +14,7 @@ Checks: >
   misc*,
   -misc-no-recursion
 WarningsAsErrors: >
+  modernize-use-auto,
   clang-analyzer-security.*
 AnalyzeTemporaryDtors: false
 # Use our .clang-format file when applying fixes.

--- a/src/addons/addon.cpp
+++ b/src/addons/addon.cpp
@@ -684,7 +684,7 @@ void Addon::maybeLoadLanguageFallback(const QString& code) {
 }
 
 bool Addon::createTranslator(const QLocale& locale) {
-  QTranslator* translator = new QTranslator(this);
+  auto translator = new QTranslator(this);
   m_translators.append(translator);
   QCoreApplication::installTranslator(translator);
 

--- a/src/addons/addonapi.cpp
+++ b/src/addons/addonapi.cpp
@@ -146,7 +146,7 @@ void AddonApi::connectSignal(QObject* obj, const QString& signalName,
     return;
   }
 
-  AddonApiCallbackWrapper* cw = new AddonApiCallbackWrapper(this, callback);
+  auto cw = new AddonApiCallbackWrapper(this, callback);
 
   QMetaMethod slot =
       cw->metaObject()->method(cw->metaObject()->indexOfSlot("run()"));

--- a/src/addons/addonmessage.cpp
+++ b/src/addons/addonmessage.cpp
@@ -34,7 +34,7 @@ Addon* AddonMessage::create(QObject* parent, const QString& manifestFileName,
     return nullptr;
   }
 
-  AddonMessage* message = new AddonMessage(parent, manifestFileName, id, name);
+  auto message = new AddonMessage(parent, manifestFileName, id, name);
   auto guard = qScopeGuard([&] { message->deleteLater(); });
 
   MessageStatus messageStatus = message->loadMessageStatus(id);

--- a/src/addons/addonreplacer.cpp
+++ b/src/addons/addonreplacer.cpp
@@ -44,7 +44,7 @@ Addon* AddonReplacer::create(QObject* parent, const QString& manifestFileName,
     return nullptr;
   }
 
-  AddonReplacer* replacer =
+  auto replacer =
       new AddonReplacer(parent, manifestFileName, id, name);
   auto guard = qScopeGuard([&] { replacer->deleteLater(); });
 

--- a/src/authenticationinapp/authenticationinappsession.cpp
+++ b/src/authenticationinapp/authenticationinappsession.cpp
@@ -34,7 +34,7 @@ NetworkRequest* fxaHawkPostRequest(Task* parent, const QString& path,
   QByteArray hawkHeader =
       hawk.generate(url, "POST", "application/json", payload).toUtf8();
 
-  NetworkRequest* request = new NetworkRequest(parent, 200);
+  auto* request = new NetworkRequest(parent, 200);
   request->requestInternal().setRawHeader("Authorization", hawkHeader);
   request->post(url, payload);
 
@@ -59,7 +59,7 @@ void AuthenticationInAppSession::terminate() {
     return;
   }
 
-  NetworkRequest* request = fxaHawkPostRequest(m_task, "/v1/session/destroy",
+  auto* request = fxaHawkPostRequest(m_task, "/v1/session/destroy",
                                                m_sessionToken, QJsonObject());
 
   connect(request, &NetworkRequest::requestFailed, this,
@@ -90,7 +90,7 @@ void AuthenticationInAppSession::start(Task* task, const QString& codeChallenge,
   QUrl url(AuthenticationListener::createAuthenticationUrl(
       codeChallenge, codeChallengeMethod, emailAddress));
 
-  NetworkRequest* request = new NetworkRequest(task);
+  auto* request = new NetworkRequest(task);
   request->get(url);
 
   connect(request, &NetworkRequest::requestCompleted, this,
@@ -173,7 +173,7 @@ void AuthenticationInAppSession::checkAccount(const QString& emailAddress) {
   aia->requestEmailAddressChange(this);
   aia->requestState(AuthenticationInApp::StateCheckingAccount, this);
 
-  NetworkRequest* request = new NetworkRequest(m_task, 200);
+  auto* request = new NetworkRequest(m_task, 200);
   request->post(QString("%1/v1/account/status").arg(Constants::fxaApiBaseUrl()),
                 QJsonObject{
                     {"email", m_emailAddress},
@@ -300,7 +300,7 @@ void AuthenticationInAppSession::signInInternal(const QString& unblockCode) {
     obj.insert("unblockCode", unblockCode);
   }
 
-  NetworkRequest* request = new NetworkRequest(m_task, 200);
+  auto* request = new NetworkRequest(m_task, 200);
   request->post(QString("%1/v1/account/login").arg(Constants::fxaApiBaseUrl()),
                 obj);
 
@@ -378,7 +378,7 @@ void AuthenticationInAppSession::signUp() {
   AuthenticationInApp::instance()->requestState(
       AuthenticationInApp::StateSigningUp, this);
 
-  NetworkRequest* request = new NetworkRequest(m_task, 200);
+  auto* request = new NetworkRequest(m_task, 200);
   request->post(QString("%1/v1/account/create").arg(Constants::fxaApiBaseUrl()),
                 QJsonObject{
                     {
@@ -439,7 +439,7 @@ void AuthenticationInAppSession::sendUnblockCodeEmail() {
   logger.debug() << "Resend unblock code";
   Q_ASSERT(m_sessionToken.isEmpty());
 
-  NetworkRequest* request = new NetworkRequest(m_task, 200);
+  auto* request = new NetworkRequest(m_task, 200);
   request->post(QString("%1/v1/account/login/send_unblock_code")
                     .arg(Constants::fxaApiBaseUrl()),
                 QJsonObject{{"email", m_emailAddressCaseFix}});
@@ -475,7 +475,7 @@ void AuthenticationInAppSession::verifySessionEmailCode(const QString& code) {
     scopes.append(parsedScope);
   }
 
-  NetworkRequest* request =
+  auto* request =
       fxaHawkPostRequest(m_task, "/v1/session/verify_code", m_sessionToken,
                          QJsonObject{{"code", code},
                                      {"service", m_fxaParams.m_clientId},
@@ -513,7 +513,7 @@ void AuthenticationInAppSession::resendVerificationSessionCodeEmail() {
   logger.debug() << "Resend verification code";
   Q_ASSERT(!m_sessionToken.isEmpty());
 
-  NetworkRequest* request = fxaHawkPostRequest(
+  auto* request = fxaHawkPostRequest(
       m_task, "/v1/session/resend_code", m_sessionToken, QJsonObject());
 
   connect(request, &NetworkRequest::requestFailed, this,
@@ -535,7 +535,7 @@ void AuthenticationInAppSession::verifySessionTotpCode(const QString& code) {
   AuthenticationInApp::instance()->requestState(
       AuthenticationInApp::StateVerifyingSessionTotpCode, this);
 
-  NetworkRequest* request = fxaHawkPostRequest(
+  auto* request = fxaHawkPostRequest(
       m_task, "/v1/session/verify/totp", m_sessionToken,
       QJsonObject{{"code", code},
                   {"service", m_fxaParams.m_clientId},
@@ -624,7 +624,7 @@ void AuthenticationInAppSession::signInOrUpCompleted(
 
 #ifdef UNIT_TEST
 void AuthenticationInAppSession::createTotpCodes() {
-  NetworkRequest* request = fxaHawkPostRequest(m_task, "/v1/totp/create",
+  auto* request = fxaHawkPostRequest(m_task, "/v1/totp/create",
                                                m_sessionToken, QJsonObject());
 
   connect(request, &NetworkRequest::requestFailed, this,
@@ -654,7 +654,7 @@ void AuthenticationInAppSession::startAccountDeletionFlow() {
   HawkAuth hawk = HawkAuth(m_sessionToken);
   QByteArray hawkHeader = hawk.generate(url, "GET", "", "").toUtf8();
 
-  NetworkRequest* request = new NetworkRequest(m_task, 200);
+  auto* request = new NetworkRequest(m_task, 200);
   request->requestInternal().setRawHeader("Authorization", hawkHeader);
   request->get(url);
 
@@ -708,7 +708,7 @@ void AuthenticationInAppSession::startAccountDeletionFlow() {
 }
 
 void AuthenticationInAppSession::deleteAccount() {
-  NetworkRequest* request = fxaHawkPostRequest(
+  auto* request = fxaHawkPostRequest(
       m_task, "/v1/account/destroy", m_sessionToken,
       QJsonObject{{"email", m_emailAddress},
                   {"authPW", QString(generateAuthPw().toHex())}});
@@ -742,7 +742,7 @@ void AuthenticationInAppSession::finalizeSignInOrUp() {
   }
 #endif
 
-  NetworkRequest* request = fxaHawkPostRequest(
+  auto* request = fxaHawkPostRequest(
       m_task, "/v1/oauth/authorization", m_sessionToken,
       QJsonObject{{"client_id", m_fxaParams.m_clientId},
                   {"state", m_fxaParams.m_state},
@@ -787,7 +787,7 @@ void AuthenticationInAppSession::finalizeSignInOrUp() {
           return;
         }
 
-        NetworkRequest* request = new NetworkRequest(m_task, 200);
+        auto* request = new NetworkRequest(m_task, 200);
         request->requestInternal().setAttribute(
             QNetworkRequest::RedirectPolicyAttribute,
             QNetworkRequest::NoLessSafeRedirectPolicy);

--- a/src/captiveportal/captiveportaldetectionimpl.cpp
+++ b/src/captiveportal/captiveportaldetectionimpl.cpp
@@ -24,7 +24,7 @@ CaptivePortalDetectionImpl::~CaptivePortalDetectionImpl() {
 void CaptivePortalDetectionImpl::start() {
   logger.debug() << "Captive portal detection started";
 
-  CaptivePortalRequestTask* task = new CaptivePortalRequestTask();
+  auto* task = new CaptivePortalRequestTask();
   connect(task, &CaptivePortalRequestTask::operationCompleted, this,
           [this](CaptivePortalRequest::CaptivePortalResult detected) {
             logger.debug() << "Captive portal detection:" << detected;

--- a/src/captiveportal/captiveportalrequest.cpp
+++ b/src/captiveportal/captiveportalrequest.cpp
@@ -56,7 +56,7 @@ void CaptivePortalRequest::run() {
 void CaptivePortalRequest::createRequest(const QUrl& url) {
   logger.debug() << "request:" << url.toString();
 
-  NetworkRequest* request = new NetworkRequest(static_cast<Task*>(parent()));
+  auto* request = new NetworkRequest(static_cast<Task*>(parent()));
 
   // This enables the QNetworkReply::redirected for every type of redirect.
   request->requestInternal().setAttribute(

--- a/src/captiveportal/captiveportalrequesttask.cpp
+++ b/src/captiveportal/captiveportalrequesttask.cpp
@@ -39,7 +39,7 @@ void CaptivePortalRequestTask::run() {
 
 void CaptivePortalRequestTask::createRequest() {
   NetworkManager::instance()->clearCache();
-  CaptivePortalRequest* request = new CaptivePortalRequest(this);
+  auto* request = new CaptivePortalRequest(this);
   connect(request, &CaptivePortalRequest::completed, this,
           [this](CaptivePortalRequest::CaptivePortalResult detected) {
             logger.debug() << "Captive portal detection:" << detected;

--- a/src/commands/commandui.cpp
+++ b/src/commands/commandui.cpp
@@ -225,7 +225,7 @@ int CommandUI::run(QStringList& tokens) {
     }
 #endif
     // This object _must_ live longer than MozillaVPN to avoid shutdown crashes.
-    QQmlApplicationEngine* engine = new QQmlApplicationEngine();
+    auto* engine = new QQmlApplicationEngine();
     QmlEngineHolder engineHolder(engine);
 
     // TODO pending #3398

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -987,8 +987,8 @@ bool Controller::activate(const ServerData& serverData,
     // Set up a network request to check the subscription status.
     // "task" is an empty task function which is being used to
     // replicate the behavior of a TaskAccount.
-    TaskFunction* task = new TaskFunction([]() {});
-    NetworkRequest* request = new NetworkRequest(task, 200);
+    auto* task = new TaskFunction([]() {});
+    auto* request = new NetworkRequest(task, 200);
     request->auth();
     request->get(Constants::apiUrl(Constants::Account));
 

--- a/src/daemon/daemonlocalserver.cpp
+++ b/src/daemon/daemonlocalserver.cpp
@@ -56,7 +56,7 @@ bool DaemonLocalServer::initialize() {
     QLocalSocket* socket = m_server.nextPendingConnection();
     Q_ASSERT(socket);
 
-    DaemonLocalServerConnection* connection =
+    auto* connection =
         new DaemonLocalServerConnection(&m_server, socket);
     connect(socket, &QLocalSocket::disconnected, connection,
             &DaemonLocalServerConnection::deleteLater);

--- a/src/dnspingsender.cpp
+++ b/src/dnspingsender.cpp
@@ -144,7 +144,7 @@ void DnsPingSender::readData() {
     memcpy(&header, payload.constData(), sizeof(header));
 
     // Perfom some checks to ensure this is the reply we were expecting.
-    quint16 flags = qFromBigEndian<quint16>(header.flags);
+    auto flags = qFromBigEndian<quint16>(header.flags);
     if ((flags & DNS_FLAG_QR) == 0) {
       logger.debug() << "Received bogus DNS reply: QR == query";
       continue;

--- a/src/env.cpp
+++ b/src/env.cpp
@@ -44,7 +44,7 @@ QString Env::devVersion() {
 
 // static
 QString Env::graphicsApi() {
-  QQuickWindow* window =
+  auto* window =
       qobject_cast<QQuickWindow*>(QmlEngineHolder::instance()->window());
   if (!window) {
     // In unit-tests we do not have a window.

--- a/src/eventlistener.cpp
+++ b/src/eventlistener.cpp
@@ -66,7 +66,7 @@ EventListener::EventListener() {
 
 void EventListener::socketReadyRead() {
   QObject* obj = QObject::sender();
-  QLocalSocket* socket = qobject_cast<QLocalSocket*>(obj);
+  auto* socket = qobject_cast<QLocalSocket*>(obj);
   if (socket == nullptr) {
     logger.warning() << "Signal sender is not a socket!";
     return;

--- a/src/feature/taskgetfeaturelist.cpp
+++ b/src/feature/taskgetfeaturelist.cpp
@@ -27,7 +27,7 @@ TaskGetFeatureList::TaskGetFeatureList() : Task("TaskGetFeatureList") {
 TaskGetFeatureList::~TaskGetFeatureList() { MZ_COUNT_DTOR(TaskGetFeatureList); }
 
 void TaskGetFeatureList::run() {
-  NetworkRequest* request = new NetworkRequest(this, 200);
+  auto* request = new NetworkRequest(this, 200);
 
   QJsonObject body;
   if (SettingsHolder::instance()->token().isEmpty()) {

--- a/src/frontend/navigator.cpp
+++ b/src/frontend/navigator.cpp
@@ -107,7 +107,7 @@ QList<ScreenData*> computeScreens(int* requestedScreen) {
 
 void maybeGenerateComponent(Navigator* navigator, ScreenData* screen) {
   if (!screen->m_qmlComponent) {
-    QQmlComponent* qmlComponent = new QQmlComponent(
+    auto* qmlComponent = new QQmlComponent(
         QmlEngineHolder::instance()->engine(), screen->m_qmlComponentUrl,
         QQmlComponent::Asynchronous, navigator);
 

--- a/src/inspector/inspectorhandler.cpp
+++ b/src/inspector/inspectorhandler.cpp
@@ -304,9 +304,9 @@ static QList<InspectorCommand> s_commands{
           int id = qmlTypeId(qPrintable(arguments[1]), 1, 0,
                              qPrintable(arguments[2]));
 
-          QQmlApplicationEngine* engine = qobject_cast<QQmlApplicationEngine*>(
+          auto* engine = qobject_cast<QQmlApplicationEngine*>(
               QmlEngineHolder::instance()->engine());
-          QObject* item = engine->singletonInstance<QObject*>(id);
+          auto* item = engine->singletonInstance<QObject*>(id);
           if (!item) {
             obj["error"] = "Object not found";
             return obj;
@@ -330,9 +330,9 @@ static QList<InspectorCommand> s_commands{
           int id = qmlTypeId(qPrintable(arguments[1]), 1, 0,
                              qPrintable(arguments[2]));
 
-          QQmlApplicationEngine* engine = qobject_cast<QQmlApplicationEngine*>(
+          auto* engine = qobject_cast<QQmlApplicationEngine*>(
               QmlEngineHolder::instance()->engine());
-          QObject* item = engine->singletonInstance<QObject*>(id);
+          auto* item = engine->singletonInstance<QObject*>(id);
           if (!item) {
             obj["error"] = "Object not found";
             return obj;
@@ -361,7 +361,7 @@ static QList<InspectorCommand> s_commands{
     InspectorCommand{"click", "Click on an object", 1,
                      [](InspectorHandler*, const QList<QByteArray>& arguments) {
                        QJsonObject obj;
-                       QQuickWindow* window = qobject_cast<QQuickWindow*>(
+                       auto* window = qobject_cast<QQuickWindow*>(
                            QmlEngineHolder::instance()->window());
 
 #if QT_CONFIG(thread)
@@ -765,7 +765,7 @@ void InspectorHandler::initialize() {
   WasmInspector::instance();
 #else
   if (!Constants::inProduction()) {
-    InspectorWebSocketServer* inspectWebSocketServer =
+    auto* inspectWebSocketServer =
         new InspectorWebSocketServer(qApp);
     QObject::connect(qApp, &QCoreApplication::aboutToQuit,
                      inspectWebSocketServer, &InspectorWebSocketServer::close);
@@ -902,7 +902,7 @@ QJsonObject InspectorHandler::getViewTree() {
   QJsonObject out;
   out["type"] = "qml_tree";
 
-  QQmlApplicationEngine* engine = qobject_cast<QQmlApplicationEngine*>(
+  auto* engine = qobject_cast<QQmlApplicationEngine*>(
       QmlEngineHolder::instance()->engine());
   if (!engine) {
     return out;
@@ -910,7 +910,7 @@ QJsonObject InspectorHandler::getViewTree() {
 
   QJsonArray viewRoots;
   for (auto& root : engine->rootObjects()) {
-    QQuickWindow* window = qobject_cast<QQuickWindow*>(root);
+    auto* window = qobject_cast<QQuickWindow*>(root);
     if (window == nullptr) {
       continue;
     }

--- a/src/inspector/inspectorhotreloader.cpp
+++ b/src/inspector/inspectorhotreloader.cpp
@@ -80,8 +80,8 @@ void InspectorHotreloader::fetchAndAnnounce(const QUrl& path) {
     logger.error() << "Unexpected File Scheme in: " << path.toString();
     return;
   }
-  TaskFunction* dummy_task = new TaskFunction([]() {});
-  NetworkRequest* request = new NetworkRequest(dummy_task, 200);
+  auto* dummy_task = new TaskFunction([]() {});
+  auto* request = new NetworkRequest(dummy_task, 200);
   request->get(path.toString());
 
   QObject::connect(
@@ -129,7 +129,7 @@ void InspectorHotreloader::resetAllFiles() {
 
 void InspectorHotreloader::reloadWindow() {
   auto engineHolder = QmlEngineHolder::instance();
-  QQmlApplicationEngine* engine =
+  auto* engine =
       static_cast<QQmlApplicationEngine*>(engineHolder->engine());
   // Here is the main QML file.
   if (!engineHolder->hasWindow()) {

--- a/src/inspector/inspectorutils.cpp
+++ b/src/inspector/inspectorutils.cpp
@@ -16,7 +16,7 @@ QObject* InspectorUtils::findObject(const QString& name) {
   Q_ASSERT(!parts.isEmpty());
 
   QQuickItem* parent = nullptr;
-  QQmlApplicationEngine* engine = qobject_cast<QQmlApplicationEngine*>(
+  auto* engine = qobject_cast<QQmlApplicationEngine*>(
       QmlEngineHolder::instance()->engine());
   if (!engine) {
     return nullptr;
@@ -54,7 +54,7 @@ QObject* InspectorUtils::findObject(const QString& name) {
     }
 
     if (!found) {
-      QQuickItem* contentItem =
+      auto* contentItem =
           parent->property("contentItem").value<QQuickItem*>();
       if (!contentItem) {
         return nullptr;
@@ -85,7 +85,7 @@ QObject* InspectorUtils::queryObject(const QString& path) {
     return nullptr;
   }
 
-  QQmlApplicationEngine* engine = qobject_cast<QQmlApplicationEngine*>(
+  auto* engine = qobject_cast<QQmlApplicationEngine*>(
       QmlEngineHolder::instance()->engine());
   if (!engine) {
     return nullptr;

--- a/src/inspector/inspectorwebsocketserver.cpp
+++ b/src/inspector/inspectorwebsocketserver.cpp
@@ -54,7 +54,7 @@ void InspectorWebSocketServer::newConnectionReceived() {
   }
 #endif
 
-  InspectorWebSocketConnection* connection =
+  auto* connection =
       new InspectorWebSocketConnection(this, child);
   connect(child, &QWebSocket::disconnected, connection, &QObject::deleteLater);
 }

--- a/src/ipaddresslookup.cpp
+++ b/src/ipaddresslookup.cpp
@@ -60,7 +60,7 @@ void IpAddressLookup::updateIpAddress() {
   }
   m_state = StateUpdating;
 
-  TaskIPFinder* ipfinder = new TaskIPFinder();
+  auto* ipfinder = new TaskIPFinder();
   connect(
       ipfinder, &TaskIPFinder::operationCompleted, this,
       [this](const QString& ipv4, const QString& ipv6, const QString& country) {

--- a/src/itempicker.cpp
+++ b/src/itempicker.cpp
@@ -44,7 +44,7 @@ bool ItemPicker::eventFilterInternal(QObject* obj, QEvent* event) {
 
   QQuickItem* item = qobject_cast<QQuickItem*>(obj);
   if (!item) {
-    QQuickWindow* window = qobject_cast<QQuickWindow*>(obj);
+    auto* window = qobject_cast<QQuickWindow*>(obj);
     if (window) {
       item = window->contentItem();
     }
@@ -92,7 +92,7 @@ QList<QQuickItem*> ItemPicker::pickItem(QMouseEvent* event, QQuickItem* item) {
     list.append(pickItem(event, child));
   }
 
-  QQuickItem* contentItem = item->property("contentItem").value<QQuickItem*>();
+  auto* contentItem = item->property("contentItem").value<QQuickItem*>();
   if (contentItem) {
     for (QQuickItem* child : contentItem->childItems()) {
       if (!child->isVisible() || !child->isEnabled()) {
@@ -136,7 +136,7 @@ QList<QQuickItem*> ItemPicker::pickItem(QTouchEvent* event, QQuickItem* item) {
     list.append(pickItem(event, child));
   }
 
-  QQuickItem* contentItem = item->property("contentItem").value<QQuickItem*>();
+  auto* contentItem = item->property("contentItem").value<QQuickItem*>();
   if (contentItem) {
     for (QQuickItem* child : contentItem->childItems()) {
       if (!child->isVisible() || !child->isEnabled()) {

--- a/src/localizer.cpp
+++ b/src/localizer.cpp
@@ -364,7 +364,7 @@ bool Localizer::loadLanguage(const QString& requestedLocalCode) {
 }
 
 bool Localizer::createTranslator(const QLocale& locale) {
-  QTranslator* translator = new QTranslator(this);
+  auto* translator = new QTranslator(this);
   m_translators.append(translator);
   QCoreApplication::installTranslator(translator);
 

--- a/src/loghandler.cpp
+++ b/src/loghandler.cpp
@@ -469,8 +469,8 @@ void LogHandler::requestViewLogs() {
 void LogHandler::retrieveLogs() {
   logger.debug() << "Retrieve logs";
 
-  QString* buffer = new QString();
-  QTextStream* out = new QTextStream(buffer);
+  auto* buffer = new QString();
+  auto* out = new QTextStream(buffer);
 
   serializeLogs(out, [this, buffer, out]() {
     Q_ASSERT(out);
@@ -490,7 +490,7 @@ void LogHandler::serializeLogs(QTextStream* out,
 
   LogHandler::writeLogs(*out);
 
-  LogSerializeHelper* lsh = new LogSerializeHelper(out, m_logSerializers,
+  auto* lsh = new LogSerializeHelper(out, m_logSerializers,
                                                    std::move(finalizeCallback));
   lsh->run();
 }
@@ -544,14 +544,14 @@ bool LogHandler::writeLogsToLocation(
 
   logger.debug() << "Writing logs.";
 
-  QFile* file = new QFile(logFile);
+  auto* file = new QFile(logFile);
   if (!file->open(QIODevice::WriteOnly | QIODevice::Text)) {
     logger.error() << "Failed to open the logfile";
     delete file;
     return false;
   }
 
-  QTextStream* out = new QTextStream(file);
+  auto* out = new QTextStream(file);
   serializeLogs(out, [callback = std::move(callback), logFile, file, out]() {
     Q_ASSERT(out);
     Q_ASSERT(file);

--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -465,7 +465,7 @@ void MozillaVPN::authenticateWithType(
     // is a bug elsewhere.
     Q_ASSERT(userState() == UserLoggingOut);
 
-    LogoutObserver* lo = new LogoutObserver(this);
+    auto* lo = new LogoutObserver(this);
     // Let's use QueuedConnection to avoid nested tasks executions.
     connect(
         lo, &LogoutObserver::ready, this,
@@ -478,7 +478,7 @@ void MozillaVPN::authenticateWithType(
 
   TaskScheduler::scheduleTask(new TaskHeartbeat());
 
-  TaskAuthenticate* taskAuthenticate = new TaskAuthenticate(authenticationType);
+  auto* taskAuthenticate = new TaskAuthenticate(authenticationType);
   connect(taskAuthenticate, &TaskAuthenticate::authenticationAborted, this,
           &MozillaVPN::abortAuthentication);
   connect(taskAuthenticate, &TaskAuthenticate::authenticationCompleted, this,
@@ -687,8 +687,8 @@ void MozillaVPN::createSupportTicket(const QString& email,
                                      const QString& category) {
   logger.debug() << "Create support ticket";
 
-  QString* buffer = new QString();
-  QTextStream* out = new QTextStream(buffer);
+  auto* buffer = new QString();
+  auto* out = new QTextStream(buffer);
 
   LogHandler::instance()->serializeLogs(
       out, [out, buffer, email, subject, issueText, category] {
@@ -1246,7 +1246,7 @@ void MozillaVPN::requestDeleteAccount() {
   logger.debug() << "delete account";
   Q_ASSERT(Feature::get(Feature::Feature_accountDeletion)->isSupported());
 
-  TaskDeleteAccount* task = new TaskDeleteAccount(m_private->m_user.email());
+  auto* task = new TaskDeleteAccount(m_private->m_user.email());
   connect(task, &TaskDeleteAccount::accountDeleted, this,
           &MozillaVPN::accountDeleted);
 
@@ -1769,7 +1769,7 @@ void MozillaVPN::registerNavigationBarButtons() {
       "qrc:/nebula/resources/navbar/home.svg",
       "qrc:/nebula/resources/navbar/home-selected.svg"));
 
-  NavigationBarButton* messageIcon = new NavigationBarButton(
+  auto* messageIcon = new NavigationBarButton(
       nbm, "navButton-messages", "NavBarMessagesTab",
       MozillaVPN::ScreenMessaging, "qrc:/nebula/resources/navbar/messages.svg",
       "qrc:/nebula/resources/navbar/messages-selected.svg",

--- a/src/notificationhandler.cpp
+++ b/src/notificationhandler.cpp
@@ -384,7 +384,7 @@ void NotificationHandler::addonCreated(Addon* addon) {
 void NotificationHandler::maybeAddonNotification(Addon* addon) {
   Q_ASSERT(addon->type() == "message");
 
-  AddonMessage* addonMessage = qobject_cast<AddonMessage*>(addon);
+  auto* addonMessage = qobject_cast<AddonMessage*>(addon);
   if (addonMessage->isReceived()) {
     newInAppMessageNotification(addon->property("title").toString(),
                                 addon->property("subtitle").toString());

--- a/src/platforms/windows/daemon/windowsdaemonserver.cpp
+++ b/src/platforms/windows/daemon/windowsdaemonserver.cpp
@@ -72,7 +72,7 @@ int WindowsDaemonServer::run(QStringList& tokens) {
                                             false);
   }
 
-  ServiceThread* st = new ServiceThread();
+  auto* st = new ServiceThread();
   st->start();
 
   WindowsDaemon daemon;

--- a/src/profileflow.cpp
+++ b/src/profileflow.cpp
@@ -52,7 +52,7 @@ void ProfileFlow::start() {
 
   setState(StateLoading);
 
-  TaskGetSubscriptionDetails* task = new TaskGetSubscriptionDetails(
+  auto* task = new TaskGetSubscriptionDetails(
       m_forceReauthFlow
           ? TaskGetSubscriptionDetails::ForceAuthenticationFlow
           : TaskGetSubscriptionDetails::RunAuthenticationFlowIfNeeded,

--- a/src/purchasewebhandler.cpp
+++ b/src/purchasewebhandler.cpp
@@ -38,7 +38,7 @@ void PurchaseWebHandler::startSubscription(const QString&) {
   // user to login on the browser (rather than the client) in order to complete
   // the subscription platform flow elegantly. If/when guardian adds endpoints
   // that seperate these concerns we can use them.
-  TaskAuthenticate* taskAuthenticate =
+  auto* taskAuthenticate =
       new TaskAuthenticate(AuthenticationListener::AuthenticationInBrowser);
   connect(taskAuthenticate, &TaskAuthenticate::authenticationAborted, vpn,
           &MozillaVPN::abortAuthentication);

--- a/src/qmlengineholder.cpp
+++ b/src/qmlengineholder.cpp
@@ -111,7 +111,7 @@ void QmlEngineHolder::clearCacheInternal() {
 }
 
 QWindow* QmlEngineHolder::window() const {
-  QQmlApplicationEngine* engine =
+  auto* engine =
       qobject_cast<QQmlApplicationEngine*>(m_engine);
   if (!engine) return nullptr;
 

--- a/src/qmlpath.cpp
+++ b/src/qmlpath.cpp
@@ -214,7 +214,7 @@ QList<QQuickItem*> QmlPath::collectChildItems(QQuickItem* item) {
   Q_ASSERT(item);
   QList<QQuickItem*> list = item->childItems();
 
-  QQuickItem* contentItem = item->property("contentItem").value<QQuickItem*>();
+  auto* contentItem = item->property("contentItem").value<QQuickItem*>();
   if (contentItem) {
     list.append(collectChildItems(contentItem));
   }

--- a/src/releasemonitor.cpp
+++ b/src/releasemonitor.cpp
@@ -33,7 +33,7 @@ void ReleaseMonitor::runSoon(
   logger.debug() << "Scheduling a release-check task";
 
   QTimer::singleShot(0, this, [this, errorPropagationPolicy] {
-    TaskRelease* task =
+    auto* task =
         new TaskRelease(TaskRelease::Check, errorPropagationPolicy);
 
     connect(task, &TaskRelease::updateRequired, this,
@@ -63,7 +63,7 @@ void ReleaseMonitor::updateSoon() {
   logger.debug() << "Scheduling a release-update task";
 
   QTimer::singleShot(0, this, [] {
-    TaskRelease* task =
+    auto* task =
         new TaskRelease(TaskRelease::Update, ErrorHandler::PropagateError);
     // The updater, in download mode, is not destroyed. So, if this happens,
     // probably something went wrong.

--- a/src/tasks/account/taskaccount.cpp
+++ b/src/tasks/account/taskaccount.cpp
@@ -23,7 +23,7 @@ TaskAccount::TaskAccount(
 TaskAccount::~TaskAccount() { MZ_COUNT_DTOR(TaskAccount); }
 
 void TaskAccount::run() {
-  NetworkRequest* request = new NetworkRequest(this, 200);
+  auto* request = new NetworkRequest(this, 200);
   request->auth();
   request->get(Constants::apiUrl(Constants::Account));
 

--- a/src/tasks/adddevice/taskadddevice.cpp
+++ b/src/tasks/adddevice/taskadddevice.cpp
@@ -52,7 +52,7 @@ void TaskAddDevice::run() {
   logger.debug() << "Private key: " << logger.sensitive(privateKey);
   logger.debug() << "Public key: " << logger.sensitive(publicKey);
 
-  NetworkRequest* request = new NetworkRequest(this, 201);
+  auto* request = new NetworkRequest(this, 201);
   request->auth();
   request->post(Constants::apiUrl(Constants::Device),
                 QJsonObject{{"name", m_deviceName},

--- a/src/tasks/addon/taskaddon.cpp
+++ b/src/tasks/addon/taskaddon.cpp
@@ -21,7 +21,7 @@ TaskAddon::TaskAddon(const QString& addonId, const QByteArray& sha256)
 TaskAddon::~TaskAddon() { MZ_COUNT_DTOR(TaskAddon); }
 
 void TaskAddon::run() {
-  NetworkRequest* request = new NetworkRequest(this, 200);
+  auto* request = new NetworkRequest(this, 200);
   request->get(
       QString("%1%2.rcc").arg(AddonManager::addonServerAddress(), m_addonId));
 

--- a/src/tasks/addonindex/taskaddonindex.cpp
+++ b/src/tasks/addonindex/taskaddonindex.cpp
@@ -26,7 +26,7 @@ void TaskAddonIndex::run() {
         QString("%1manifest.json").arg(AddonManager::addonServerAddress());
     logger.debug() << "Download manifest URL:" << manifestUrl;
 
-    NetworkRequest* request = new NetworkRequest(this, 200);
+    auto* request = new NetworkRequest(this, 200);
     request->get(manifestUrl);
 
     connect(request, &NetworkRequest::requestFailed, this,
@@ -51,7 +51,7 @@ void TaskAddonIndex::run() {
         QString("%1manifest.json.sig").arg(AddonManager::addonServerAddress());
     logger.debug() << "Download manifest signature URL:" << manifestSigUrl;
 
-    NetworkRequest* request = new NetworkRequest(this, 200);
+    auto* request = new NetworkRequest(this, 200);
     request->get(manifestSigUrl);
 
     connect(request, &NetworkRequest::requestFailed, this,

--- a/src/tasks/authenticate/taskauthenticate.cpp
+++ b/src/tasks/authenticate/taskauthenticate.cpp
@@ -52,7 +52,7 @@ void TaskAuthenticate::run() {
             logger.debug() << "Authentication completed with code:"
                            << logger.sensitive(pkceCodeSuccess);
 
-            NetworkRequest* request = new NetworkRequest(this, 200);
+            auto* request = new NetworkRequest(this, 200);
             request->post(
                 AuthenticationListener::createLoginVerifyUrl(),
                 QJsonObject{{"code", pkceCodeSuccess},

--- a/src/tasks/captiveportallookup/taskcaptiveportallookup.cpp
+++ b/src/tasks/captiveportallookup/taskcaptiveportallookup.cpp
@@ -29,7 +29,7 @@ TaskCaptivePortalLookup::~TaskCaptivePortalLookup() {
 void TaskCaptivePortalLookup::run() {
   logger.debug() << "Resolving the captive portal detector URL";
 
-  NetworkRequest* request = new NetworkRequest(this, 200);
+  auto* request = new NetworkRequest(this, 200);
   request->auth();
   request->get(Constants::apiUrl(Constants::DNSDetectPortal));
 

--- a/src/tasks/createsupportticket/taskcreatesupportticket.cpp
+++ b/src/tasks/createsupportticket/taskcreatesupportticket.cpp
@@ -48,7 +48,7 @@ TaskCreateSupportTicket::~TaskCreateSupportTicket() {
 void TaskCreateSupportTicket::run() {
   logger.debug() << "Sending the support ticket";
 
-  NetworkRequest* request = new NetworkRequest(this, 201);
+  auto* request = new NetworkRequest(this, 201);
   if (App::isUserAuthenticated()) {
     request->auth();
   }

--- a/src/tasks/deleteaccount/taskdeleteaccount.cpp
+++ b/src/tasks/deleteaccount/taskdeleteaccount.cpp
@@ -49,7 +49,7 @@ void TaskDeleteAccount::run() {
         logger.debug() << "Authentication completed with code:"
                        << logger.sensitive(pkceCodeSuccess);
 
-        NetworkRequest* request = new NetworkRequest(this, 200);
+        auto* request = new NetworkRequest(this, 200);
         request->post(
             AuthenticationListener::createLoginVerifyUrl(),
             QJsonObject{{"code", pkceCodeSuccess},

--- a/src/tasks/getlocation/taskgetlocation.cpp
+++ b/src/tasks/getlocation/taskgetlocation.cpp
@@ -32,7 +32,7 @@ void TaskGetLocation::run() {
   QUrl url(Constants::apiUrl(Constants::IPInfo));
   QString host = url.host();
 
-  NetworkRequest* request = new NetworkRequest(this, 200);
+  auto* request = new NetworkRequest(this, 200);
   request->auth();
   request->requestInternal().setRawHeader("Host", host.toLocal8Bit());
   request->requestInternal().setPeerVerifyName(host);

--- a/src/tasks/getsubscriptiondetails/taskgetsubscriptiondetails.cpp
+++ b/src/tasks/getsubscriptiondetails/taskgetsubscriptiondetails.cpp
@@ -49,7 +49,7 @@ void TaskGetSubscriptionDetails::run() {
 }
 
 void TaskGetSubscriptionDetails::runInternal() {
-  NetworkRequest* request = new NetworkRequest(this, 200);
+  auto* request = new NetworkRequest(this, 200);
   request->auth();
   request->get(Constants::apiUrl(Constants::SubscriptionDetails));
 
@@ -145,7 +145,7 @@ void TaskGetSubscriptionDetails::initAuthentication() {
             logger.debug() << "Authentication completed with code:"
                            << logger.sensitive(pkceCodeSuccess);
 
-            NetworkRequest* request = new NetworkRequest(this, 200);
+            auto* request = new NetworkRequest(this, 200);
             request->post(
                 Constants::apiUrl(Constants::LoginVerify),
                 QJsonObject{{"code", pkceCodeSuccess},

--- a/src/tasks/heartbeat/taskheartbeat.cpp
+++ b/src/tasks/heartbeat/taskheartbeat.cpp
@@ -24,7 +24,7 @@ TaskHeartbeat::TaskHeartbeat() : Task("TaskHeartbeat") {
 TaskHeartbeat::~TaskHeartbeat() { MZ_COUNT_DTOR(TaskHeartbeat); }
 
 void TaskHeartbeat::run() {
-  NetworkRequest* request = new NetworkRequest(this, 200);
+  auto* request = new NetworkRequest(this, 200);
   request->get(Constants::apiUrl(Constants::Heartbeat));
 
   connect(request, &NetworkRequest::requestFailed, this,

--- a/src/tasks/ipfinder/taskipfinder.cpp
+++ b/src/tasks/ipfinder/taskipfinder.cpp
@@ -101,7 +101,7 @@ void TaskIPFinder::createRequest(const QHostAddress& address, bool ipv6) {
 
   url.setPath("/api/v1/vpn/ipinfo");
 
-  NetworkRequest* request = new NetworkRequest(this, 200);
+  auto* request = new NetworkRequest(this, 200);
   request->auth();
   request->requestInternal().setRawHeader("Host", host.toLocal8Bit());
   request->requestInternal().setPeerVerifyName(host);

--- a/src/tasks/products/taskproducts.cpp
+++ b/src/tasks/products/taskproducts.cpp
@@ -23,7 +23,7 @@ TaskProducts::TaskProducts() : Task("TaskProducts") {
 TaskProducts::~TaskProducts() { MZ_COUNT_DTOR(TaskProducts); }
 
 void TaskProducts::run() {
-  NetworkRequest* request = new NetworkRequest(this, 200);
+  auto* request = new NetworkRequest(this, 200);
   request->get(QString("%1/v1/oauth/subscriptions/iap/plans/%2")
                    .arg(Constants::fxaApiBaseUrl(), Constants::IAP_PLANS));
 

--- a/src/tasks/removedevice/taskremovedevice.cpp
+++ b/src/tasks/removedevice/taskremovedevice.cpp
@@ -43,7 +43,7 @@ void TaskRemoveDevice::run() {
   logger.debug() << "Removing the device with public key"
                  << logger.keys(m_publicKey);
 
-  NetworkRequest* request = new NetworkRequest(this, 204);
+  auto* request = new NetworkRequest(this, 204);
   request->auth(m_authHeader);
   request->deleteResource(
       Constants::apiUrl(Constants::DeviceWithPublicKeyArgument)

--- a/src/tasks/sentry/tasksentry.cpp
+++ b/src/tasks/sentry/tasksentry.cpp
@@ -88,7 +88,7 @@ void TaskSentry::sendRequest() {
     emit completed();
     return;
   }
-  NetworkRequest* request = new NetworkRequest(this, 200);
+  auto* request = new NetworkRequest(this, 200);
   QUrl target_endpoint(endpoint, QUrl::StrictMode);
   if (!target_endpoint.isValid()) {
     logger.error() << "Invalid URL for Sentry provided: " << endpoint;

--- a/src/tasks/sentryconfig/tasksentryconfig.cpp
+++ b/src/tasks/sentryconfig/tasksentryconfig.cpp
@@ -27,7 +27,7 @@ TaskSentryConfig::TaskSentryConfig() : Task("TaskSentryConfig") {
 TaskSentryConfig::~TaskSentryConfig() { MZ_COUNT_DTOR(TaskSentryConfig); }
 
 void TaskSentryConfig::run() {
-  NetworkRequest* request = new NetworkRequest(this, 200);
+  auto* request = new NetworkRequest(this, 200);
 
   QUrl url(Constants::apiBaseUrl());
   url.setPath("/api/v1/vpn/crashreporting");

--- a/src/tasks/servers/taskservers.cpp
+++ b/src/tasks/servers/taskservers.cpp
@@ -24,7 +24,7 @@ TaskServers::TaskServers(
 TaskServers::~TaskServers() { MZ_COUNT_DTOR(TaskServers); }
 
 void TaskServers::run() {
-  NetworkRequest* request = new NetworkRequest(this, 200);
+  auto* request = new NetworkRequest(this, 200);
   request->auth();
   request->get(Constants::apiUrl(Constants::Servers));
 

--- a/src/tcppingsender.cpp
+++ b/src/tcppingsender.cpp
@@ -17,7 +17,7 @@ TcpPingSender::TcpPingSender(const QHostAddress& source, quint16 port,
 TcpPingSender::~TcpPingSender() { MZ_COUNT_DTOR(TcpPingSender); }
 
 void TcpPingSender::sendPing(const QHostAddress& dest, quint16 sequence) {
-  QTcpSocket* socket = new QTcpSocket(this);
+  auto* socket = new QTcpSocket(this);
   if (!m_source.isNull()) {
     socket->bind(m_source);
   }

--- a/src/theme.cpp
+++ b/src/theme.cpp
@@ -117,7 +117,7 @@ void Theme::parseTheme(QJSEngine* engine, const QString& themeName) {
     }
   }
 
-  ThemeData* data = new ThemeData();
+  auto* data = new ThemeData();
   data->theme = themeValue;
   data->colors = colorsValue;
   m_themes.insert(themeName, data);

--- a/src/update/versionapi.cpp
+++ b/src/update/versionapi.cpp
@@ -29,7 +29,7 @@ VersionApi::~VersionApi() {
 }
 
 void VersionApi::start(Task* task) {
-  NetworkRequest* request = new NetworkRequest(task, 200);
+  auto* request = new NetworkRequest(task, 200);
   request->get(Constants::apiUrl(Constants::Versions));
 
   connect(request, &NetworkRequest::requestFailed, request,

--- a/src/webextension/connection.cpp
+++ b/src/webextension/connection.cpp
@@ -80,7 +80,7 @@ void Connection::writeMessage(QJsonObject& data) {
 }
 
 void Connection::writeData(const QByteArray& data) {
-  uint32_t length = (uint32_t)data.length();
+  auto length = (uint32_t)data.length();
   char* rawLength = reinterpret_cast<char*>(&length);
 
   if (m_connection->write(rawLength, sizeof(uint32_t)) != sizeof(uint32_t) ||

--- a/src/webextension/server.cpp
+++ b/src/webextension/server.cpp
@@ -48,7 +48,7 @@ void Server::newConnectionReceived() {
     return;
   }
 
-  Connection* connection = new Connection(this, child);
+  auto* connection = new Connection(this, child);
   connect(child, &QTcpSocket::disconnected, connection, &QObject::deleteLater);
   connect(connection, &Connection::onMessageReceived, m_adapter,
           &BaseAdapter::onMessage);

--- a/src/webextension/tests/testconnection.cpp
+++ b/src/webextension/tests/testconnection.cpp
@@ -98,7 +98,7 @@ void TestConnection::testInvalidJSONEmitsInvalid() {
 }
 
 void TestConnection::writeTo(const QByteArray& data, QIODevice* target) {
-  uint32_t length = (uint32_t)data.length();
+  auto length = (uint32_t)data.length();
   writeTo(data, length, target);
 }
 

--- a/src/webextensionadapter.cpp
+++ b/src/webextensionadapter.cpp
@@ -107,13 +107,13 @@ QJsonObject WebExtensionAdapter::serializeStatus() {
   {
     int stateValue = vpn->state();
     if (stateValue > App::StateCustom) {
-      MozillaVPN::CustomState state =
+      auto state =
           static_cast<MozillaVPN::CustomState>(stateValue);
       const QMetaObject* meta = qt_getEnumMetaObject(state);
       int index = meta->indexOfEnumerator(qt_getEnumName(state));
       obj["app"] = meta->enumerator(index).valueToKey(state);
     } else {
-      App::State state = static_cast<App::State>(stateValue);
+      auto state = static_cast<App::State>(stateValue);
       const QMetaObject* meta = qt_getEnumMetaObject(state);
       int index = meta->indexOfEnumerator(qt_getEnumName(state));
       obj["app"] = meta->enumerator(index).valueToKey(state);


### PR DESCRIPTION
## Description
We currently have clang-tidy but no enforced rules :) 

use auto is simple, instead of writing the Type twice: 
```
NetworkRequest* request = new NetworkRequest(static_cast<Task*>(parent()));
```
just auto deduct 
```
auto* request = new NetworkRequest(static_cast<Task*>(parent()));
```