### PR TITLE
VPN-6392: Allow promote-client to stage repository for beetmover-apt

### DIFF
--- a/taskcluster/mozillavpn_taskgraph/transforms/beetmover_apt.py
+++ b/taskcluster/mozillavpn_taskgraph/transforms/beetmover_apt.py
@@ -44,7 +44,7 @@ def get_gcs_sources(dependent_task):
 
 ALLOWED_SHIPPING_PHASES = [
     "ship-client",
-#    "promote-client" - candidates are not setup yet.
+    "promote-client"
 ]
 
 @transforms.add
@@ -70,12 +70,14 @@ def beetmover_apt(config, tasks):
             # We do have nothing to ship, skip this task
             continue
         task["worker"]["gcs-sources"] = gcs_sources
-        is_relpro = (
+
+        is_production = (
             config.params["level"] == "3"
+            and config.params.get("shipping_phase", "") == "ship-client"
             and config.params["tasks_for"] in task["run-on-tasks-for"]
         )
-        bucket = "release" if is_relpro else "dep"
-        project_name = "mozillavpn" if is_relpro else "mozillavpn:releng"
+        bucket = "release" if is_production else "dep"
+        project_name = "mozillavpn" if is_production else "mozillavpn:releng"
 
         task["scopes"] = [
             f"project:{project_name}:beetmover:apt-repo:{bucket}",
@@ -83,6 +85,3 @@ def beetmover_apt(config, tasks):
         ]
 
         yield task
-
-
-


### PR DESCRIPTION
## Description
For the 2.23 release, we would like to automate the promotion of static linux builds to the stage APT repository for QA and internal testing. To do so, I think we need to check the `shipping_phase` config option and direct releases to the `release` bucket and non-releases to the `dep` bucket.

## Reference
JIRA issue [VPN-6392](https://mozilla-hub.atlassian.net/browse/VPN-6392)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-6392]: https://mozilla-hub.atlassian.net/browse/VPN-6392?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ