### PR TITLE
Nit: Combine App::state and App::userState to fix test races

### DIFF
--- a/src/app.cpp
+++ b/src/app.cpp
@@ -40,7 +40,7 @@ void App::setState(int state) {
   logger.debug() << "Set state:" << state;
 
   m_state = state;
-  emit userAuthenticationChanged();
+  emit userAuthenticationMaybeChanged();
   emit stateChanged();
 }
 

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -36,8 +36,6 @@ App::~App() { MZ_COUNT_DTOR(App); }
 
 int App::state() const { return m_state; }
 
-App::UserState App::userState() const { return m_userState; }
-
 void App::setState(int state) {
   logger.debug() << "Set state:" << state;
 

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -30,9 +30,6 @@ App::App(QObject* parent) : QObject(parent) {
                                     WasmNetworkRequest::postResource,
                                     WasmNetworkRequest::postResourceIODevice);
 #endif
-
-  connect(SettingsHolder::instance(), &SettingsHolder::tokenChanged, this,
-          [this]() { emit userAuthenticationChanged(); });
 }
 
 App::~App() { MZ_COUNT_DTOR(App); }

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -30,6 +30,9 @@ App::App(QObject* parent) : QObject(parent) {
                                     WasmNetworkRequest::postResource,
                                     WasmNetworkRequest::postResourceIODevice);
 #endif
+
+  connect(SettingsHolder::instance(), &SettingsHolder::tokenChanged, this,
+          [this]() { emit userAuthenticationChanged(); });
 }
 
 App::~App() { MZ_COUNT_DTOR(App); }
@@ -40,15 +43,8 @@ void App::setState(int state) {
   logger.debug() << "Set state:" << state;
 
   m_state = state;
+  emit userAuthenticationChanged();
   emit stateChanged();
-}
-
-void App::setUserState(UserState state) {
-  logger.debug() << "User authentication state:" << state;
-  if (m_userState != state) {
-    m_userState = state;
-    emit userStateChanged();
-  }
 }
 
 void App::quit() {
@@ -64,4 +60,9 @@ void App::quit() {
 #endif
 
   qApp->quit();
+}
+
+bool App::userAuthenticated() const {
+  auto holder = SettingsHolder::instance();
+  return (m_state > StateAuthenticating) && holder->hasToken();
 }

--- a/src/app.h
+++ b/src/app.h
@@ -12,6 +12,7 @@ class App : public QObject {
   Q_DISABLE_COPY_MOVE(App)
 
   Q_PROPERTY(UserState userState READ userState NOTIFY userStateChanged)
+  Q_PROPERTY(bool userAuthenticated READ userAuthenticated NOTIFY userStateChanged)
   Q_PROPERTY(int state READ state NOTIFY stateChanged)
 
  public:
@@ -82,9 +83,8 @@ class App : public QObject {
   UserState userState() const;
   void setUserState(UserState userState);
 
-  static bool isUserAuthenticated() {
-    return App::instance()->userState() == App::UserAuthenticated;
-  }
+  bool userAuthenticated() const { return m_userState == UserAuthenticated; };
+  static bool isUserAuthenticated() { return instance()->userAuthenticated(); };
 
   static QByteArray authorizationHeader();
 

--- a/src/app.h
+++ b/src/app.h
@@ -12,7 +12,7 @@ class App : public QObject {
   Q_DISABLE_COPY_MOVE(App)
 
   Q_PROPERTY(bool userAuthenticated READ userAuthenticated NOTIFY
-                 userAuthenticationChanged)
+                 userAuthenticationMaybeChanged)
   Q_PROPERTY(int state READ state NOTIFY stateChanged)
 
  public:
@@ -70,7 +70,7 @@ class App : public QObject {
   void quit();
 
  signals:
-  void userAuthenticationChanged();
+  void userAuthenticationMaybeChanged();
   void stateChanged();
 
  protected:

--- a/src/app.h
+++ b/src/app.h
@@ -12,7 +12,7 @@ class App : public QObject {
   Q_DISABLE_COPY_MOVE(App)
 
   Q_PROPERTY(bool userAuthenticated READ userAuthenticated NOTIFY
-             userAuthenticationChanged)
+                 userAuthenticationChanged)
   Q_PROPERTY(int state READ state NOTIFY stateChanged)
 
  public:

--- a/src/app.h
+++ b/src/app.h
@@ -11,7 +11,8 @@ class App : public QObject {
   Q_OBJECT
   Q_DISABLE_COPY_MOVE(App)
 
-  Q_PROPERTY(bool userAuthenticated READ userAuthenticated NOTIFY stateChanged)
+  Q_PROPERTY(bool userAuthenticated READ userAuthenticated NOTIFY
+             userAuthenticationChanged)
   Q_PROPERTY(int state READ state NOTIFY stateChanged)
 
  public:
@@ -19,11 +20,6 @@ class App : public QObject {
     // This is the first state when the app starts. During the initialization,
     // the app can move to a different state
     StateInitialize = 0,
-
-    // We are logging out the user. There are a few steps to run in order to
-    // complete the logout. In the meantime, the user should be considered as
-    // not-authenticated. The next state will be `StateInitialize`.
-    StateLoggingOut,
 
     // The authentication flow has started.
     StateAuthenticating,
@@ -66,7 +62,7 @@ class App : public QObject {
   int state() const;
   void setState(int state);
 
-  bool userAuthenticated() const { return m_state > StateAuthenticating; };
+  bool userAuthenticated() const;
   static bool isUserAuthenticated() { return instance()->userAuthenticated(); };
 
   static QByteArray authorizationHeader();
@@ -74,6 +70,7 @@ class App : public QObject {
   void quit();
 
  signals:
+  void userAuthenticationChanged();
   void stateChanged();
 
  protected:

--- a/src/logoutobserver.cpp
+++ b/src/logoutobserver.cpp
@@ -10,14 +10,14 @@
 LogoutObserver::LogoutObserver(QObject* parent) : QObject(parent) {
   MZ_COUNT_CTOR(LogoutObserver);
 
-  connect(App::instance(), &App::userStateChanged, this,
-          &LogoutObserver::userStateChanged);
+  connect(App::instance(), &App::stateChanged, this,
+          &LogoutObserver::stateChanged);
 }
 
 LogoutObserver::~LogoutObserver() { MZ_COUNT_DTOR(LogoutObserver); }
 
-void LogoutObserver::userStateChanged() {
-  if (App::instance()->userState() == App::UserNotAuthenticated) {
+void LogoutObserver::stateChanged() {
+  if (App::instance()->state() == App::StateInitialize) {
     emit ready();
     deleteLater();
   }

--- a/src/logoutobserver.cpp
+++ b/src/logoutobserver.cpp
@@ -10,14 +10,14 @@
 LogoutObserver::LogoutObserver(QObject* parent) : QObject(parent) {
   MZ_COUNT_CTOR(LogoutObserver);
 
-  connect(App::instance(), &App::stateChanged, this,
+  connect(App::instance(), &App::userAuthenticationChanged, this,
           &LogoutObserver::stateChanged);
 }
 
 LogoutObserver::~LogoutObserver() { MZ_COUNT_DTOR(LogoutObserver); }
 
 void LogoutObserver::stateChanged() {
-  if (App::instance()->state() == App::StateInitialize) {
+  if (!App::instance()->userAuthenticated()) {
     emit ready();
     deleteLater();
   }

--- a/src/logoutobserver.cpp
+++ b/src/logoutobserver.cpp
@@ -10,7 +10,7 @@
 LogoutObserver::LogoutObserver(QObject* parent) : QObject(parent) {
   MZ_COUNT_CTOR(LogoutObserver);
 
-  connect(App::instance(), &App::userAuthenticationChanged, this,
+  connect(App::instance(), &App::userAuthenticationMaybeChanged, this,
           &LogoutObserver::stateChanged);
 }
 

--- a/src/logoutobserver.h
+++ b/src/logoutobserver.h
@@ -25,7 +25,7 @@ class LogoutObserver final : public QObject {
   void ready();
 
  private slots:
-  void userStateChanged();
+  void stateChanged();
 };
 
 #endif  // LOGOUTOBSERVER_H

--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -221,13 +221,6 @@ MozillaVPN::MozillaVPN() : App(nullptr), m_private(new MozillaVPNPrivate()) {
   connect(ErrorHandler::instance(), &ErrorHandler::errorHandled, this,
           &MozillaVPN::errorHandled);
 
-  connect(&m_private->m_user, &User::changed, this,
-          [&]() { emit modelsChanged(); });
-  connect(&m_private->m_serverCountryModel, &ServerCountryModel::changed, this,
-          [&]() { emit modelsChanged(); });
-  connect(&m_private->m_deviceModel, &DeviceModel::changed, this,
-          [&]() { emit modelsChanged(); });
-
   ensureApplicationIdExists();
 }
 

--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -221,6 +221,13 @@ MozillaVPN::MozillaVPN() : App(nullptr), m_private(new MozillaVPNPrivate()) {
   connect(ErrorHandler::instance(), &ErrorHandler::errorHandled, this,
           &MozillaVPN::errorHandled);
 
+  connect(&m_private->m_user, &User::changed, this,
+          [&]() { emit modelsChanged(); });
+  connect(&m_private->m_serverCountryModel, &ServerCountryModel::changed, this,
+          [&]() { emit modelsChanged(); });
+  connect(&m_private->m_deviceModel, &DeviceModel::changed, this,
+          [&]() { emit modelsChanged(); });
+
   ensureApplicationIdExists();
 }
 

--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -792,6 +792,9 @@ void MozillaVPN::reset(bool forceInitialState) {
 
   if (forceInitialState) {
     setState(StateInitialize);
+  } else {
+    // Manually emit an auth change if we are not changing state.
+    emit userAuthenticationChanged();
   }
 }
 

--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -793,8 +793,8 @@ void MozillaVPN::reset(bool forceInitialState) {
   if (forceInitialState) {
     setState(StateInitialize);
   } else {
-    // Manually emit an auth change if we are not changing state.
-    emit userAuthenticationChanged();
+    // Manually emit a potential auth change if we are not changing state.
+    emit userAuthenticationMaybeChanged();
   }
 }
 

--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -1189,7 +1189,7 @@ void MozillaVPN::maybeRegenerateDeviceKey() {
     if (!modelsInitialized()) {
       logger.error() << "Failed to complete the key regeneration";
       REPORTERROR(ErrorHandler::RemoteServiceError, "vpn");
-      setState(StateInitialize); // TODO: or maybe logging out?
+      setState(StateInitialize);
       return;
     }
   }));

--- a/src/mozillavpn.h
+++ b/src/mozillavpn.h
@@ -82,6 +82,7 @@ class MozillaVPN final : public App {
  private:
   Q_PROPERTY(bool startMinimized READ startMinimized CONSTANT)
   Q_PROPERTY(bool updating READ updating NOTIFY updatingChanged)
+  Q_PROPERTY(bool modelsInitialized READ modelsInitialized NOTIFY modelsChanged)
 
  public:
   MozillaVPN();
@@ -247,6 +248,7 @@ class MozillaVPN final : public App {
   void deviceRemoving(const QString& publicKey);
   void deviceRemoved(const QString& source);
   void aboutNeeded();
+  void modelsChanged();
   void updatingChanged();
   void accountDeleted();
 

--- a/src/mozillavpn.h
+++ b/src/mozillavpn.h
@@ -82,7 +82,6 @@ class MozillaVPN final : public App {
  private:
   Q_PROPERTY(bool startMinimized READ startMinimized CONSTANT)
   Q_PROPERTY(bool updating READ updating NOTIFY updatingChanged)
-  Q_PROPERTY(bool modelsInitialized READ modelsInitialized NOTIFY modelsChanged)
 
  public:
   MozillaVPN();
@@ -248,7 +247,6 @@ class MozillaVPN final : public App {
   void deviceRemoving(const QString& publicKey);
   void deviceRemoved(const QString& source);
   void aboutNeeded();
-  void modelsChanged();
   void updatingChanged();
   void accountDeleted();
 

--- a/src/platforms/ios/iosiaphandler.mm
+++ b/src/platforms/ios/iosiaphandler.mm
@@ -160,7 +160,7 @@ bool s_transactionsProcessed = false;
     logger.debug() << "Subscription completed - but all the transactions are known";
     QMetaObject::invokeMethod(m_handler, "stopSubscription", Qt::QueuedConnection);
     QMetaObject::invokeMethod(m_handler, "subscriptionCanceled", Qt::QueuedConnection);
-  } else if (App::instance()->userState() == App::UserAuthenticated) {
+  } else if (App::instance()->userAuthenticated()) {
     Q_ASSERT(completedTransactions);
     logger.debug() << "Subscription completed. Let's start the validation";
     QMetaObject::invokeMethod(m_handler, "processCompletedTransactions", Qt::QueuedConnection,

--- a/src/ui/main.qml
+++ b/src/ui/main.qml
@@ -185,7 +185,6 @@ Window {
         ]
 
         visible: showNavigationBar.includes(MZNavigator.screen) &&
-                 VPN.userState === VPN.UserAuthenticated &&
                  VPN.state === VPN.StateMain
     }
 

--- a/src/ui/screens/getHelp/contactUs/ViewContactUsForm.qml
+++ b/src/ui/screens/getHelp/contactUs/ViewContactUsForm.qml
@@ -67,7 +67,7 @@ MZViewBase {
             ColumnLayout {
                 objectName: "contactUs-unauthedUserInputs"
                 spacing: 24
-                visible: VPN.userState !== VPN.UserAuthenticated
+                visible: !VPN.userAuthenticated
                 Layout.alignment: Qt.AlignHCenter
 
                 ColumnLayout {
@@ -109,7 +109,7 @@ MZViewBase {
                 objectName: "contactUs-userInfo"
                 enabled: false
                 Layout.fillWidth: true
-                visible: VPN.userState === VPN.UserAuthenticated
+                visible: VPN.userAuthenticated
                 Layout.topMargin: -MZTheme.theme.windowMargin / 2
                 Layout.bottomMargin: -MZTheme.theme.windowMargin / 2
                 Layout.leftMargin: undefined
@@ -199,11 +199,11 @@ MZViewBase {
                     text: MZI18n.InAppSupportWorkflowSupportPrimaryButtonText
                     onClicked: {
                       Glean.sample.supportCaseSubmitted.record();
-                      contactUsRoot._emailAddress = (VPN.userState === VPN.UserAuthenticated ? VPNUser.email : emailInput.text);
+                      contactUsRoot._emailAddress = (VPN.userAuthenticated ? VPNUser.email : emailInput.text);
                       contactUsRoot.createSupportTicket(contactUsRoot._emailAddress, subjectInput.text, textArea.userEntry, dropDown.currentValue);
                     }
                     enabled: dropDown.currentValue != null && textArea.userEntry != "" &&
-                             (VPN.userState === VPN.UserAuthenticated ? true :
+                             (VPN.userAuthenticated  ? true :
                                 (MZAuthInApp.validateEmailAddress(emailInput.text) && emailInput.text == confirmEmailInput.text)
                              )
                     opacity: enabled ? 1 : .5

--- a/src/ui/sharedViews/ViewUpdate.qml
+++ b/src/ui/sharedViews/ViewUpdate.qml
@@ -55,7 +55,7 @@ MZFlickable {
 
             PropertyChanges {
                 target: signOff
-                visible: VPN.userState === VPN.UserAuthenticated
+                visible: VPN.userAuthenticated
             }
 
             PropertyChanges {

--- a/tests/functional/helper.js
+++ b/tests/functional/helper.js
@@ -431,11 +431,7 @@ module.exports = {
 
     // Wait for VPN client screen to move from spinning wheel to next screen
     await this.waitForMozillaProperty(
-        'Mozilla.VPN', 'VPN', 'userState', 'UserAuthenticated');
-
-    // Wait for model init to finish to ensure keys and devices are synchronized.
-    await this.waitForMozillaProperty(
-        'Mozilla.VPN', 'VPN', 'modelsInitialized', 'true');
+        'Mozilla.VPN', 'VPN', 'userAuthenticated', 'true');
   },
 
   async authenticateInApp(skipOnboarding = true) {
@@ -469,11 +465,7 @@ module.exports = {
 
     // Wait for VPN client screen to move from spinning wheel to next screen
     await this.waitForMozillaProperty(
-        'Mozilla.VPN', 'VPN', 'userState', 'UserAuthenticated');
-
-    // Wait for model init to finish to ensure keys and devices are synchronized.
-    await this.waitForMozillaProperty(
-        'Mozilla.VPN', 'VPN', 'modelsInitialized', 'true');
+        'Mozilla.VPN', 'VPN', 'userAuthenticated', 'true');
   },
 
   async skipOnboarding() {

--- a/tests/functional/helper.js
+++ b/tests/functional/helper.js
@@ -432,6 +432,10 @@ module.exports = {
     // Wait for VPN client screen to move from spinning wheel to next screen
     await this.waitForMozillaProperty(
         'Mozilla.VPN', 'VPN', 'userState', 'UserAuthenticated');
+
+    // Wait for model init to finish to ensure keys and devices are synchronized.
+    await vpn.waitForMozillaProperty(
+        'Mozilla.VPN', 'VPN', 'modelsInitialized', 'true');
   },
 
   async authenticateInApp(skipOnboarding = true) {
@@ -466,6 +470,10 @@ module.exports = {
     // Wait for VPN client screen to move from spinning wheel to next screen
     await this.waitForMozillaProperty(
         'Mozilla.VPN', 'VPN', 'userState', 'UserAuthenticated');
+
+    // Wait for model init to finish to ensure keys and devices are synchronized.
+    await vpn.waitForMozillaProperty(
+        'Mozilla.VPN', 'VPN', 'modelsInitialized', 'true');
   },
 
   async skipOnboarding() {

--- a/tests/functional/helper.js
+++ b/tests/functional/helper.js
@@ -434,7 +434,7 @@ module.exports = {
         'Mozilla.VPN', 'VPN', 'userState', 'UserAuthenticated');
 
     // Wait for model init to finish to ensure keys and devices are synchronized.
-    await vpn.waitForMozillaProperty(
+    await this.waitForMozillaProperty(
         'Mozilla.VPN', 'VPN', 'modelsInitialized', 'true');
   },
 
@@ -472,7 +472,7 @@ module.exports = {
         'Mozilla.VPN', 'VPN', 'userState', 'UserAuthenticated');
 
     // Wait for model init to finish to ensure keys and devices are synchronized.
-    await vpn.waitForMozillaProperty(
+    await this.waitForMozillaProperty(
         'Mozilla.VPN', 'VPN', 'modelsInitialized', 'true');
   },
 

--- a/tests/functional/testAuthenticationInApp.js
+++ b/tests/functional/testAuthenticationInApp.js
@@ -145,7 +145,7 @@ describe('User authentication', function() {
               .enabled());
 
       await vpn.waitForMozillaProperty(
-          'Mozilla.VPN', 'VPN', 'userState', 'UserAuthenticated');
+          'Mozilla.VPN', 'VPN', 'userAuthenticated', 'true');
 
       await vpn.waitForQuery(queries.global.SCREEN_LOADER.ready());
 
@@ -252,7 +252,7 @@ describe('User authentication', function() {
               .enabled());
 
       await vpn.waitForMozillaProperty(
-          'Mozilla.VPN', 'VPN', 'userState', 'UserAuthenticated');
+          'Mozilla.VPN', 'VPN', 'userAuthenticated', 'true');
 
       await vpn.waitForQuery(queries.global.SCREEN_LOADER.ready());
 
@@ -360,7 +360,7 @@ describe('User authentication', function() {
               .enabled());
 
       await vpn.waitForMozillaProperty(
-          'Mozilla.VPN', 'VPN', 'userState', 'UserAuthenticated');
+          'Mozilla.VPN', 'VPN', 'userAuthenticated', 'true');
 
       await vpn.waitForQuery(queries.global.SCREEN_LOADER.ready());
 
@@ -437,7 +437,7 @@ describe('User authentication', function() {
               .enabled());
 
       await vpn.waitForMozillaProperty(
-          'Mozilla.VPN', 'VPN', 'userState', 'UserAuthenticated');
+          'Mozilla.VPN', 'VPN', 'userAuthenticated', 'true');
 
       await vpn.waitForQuery(queries.global.SCREEN_LOADER.ready());
 
@@ -756,7 +756,7 @@ describe('User authentication', function() {
             assert.strictEqual(startedOutcomeEvent.length, 1);
 
             await vpn.waitForMozillaProperty(
-                'Mozilla.VPN', 'VPN', 'userState', 'UserAuthenticated');
+                'Mozilla.VPN', 'VPN', 'userAuthenticated', 'true');
 
             const endedOutcomeEvent = await vpn.gleanTestGetValue("outcome", "loginEnded", "main");
             assert.strictEqual(endedOutcomeEvent.length, 1);
@@ -1044,7 +1044,7 @@ describe('User authentication', function() {
             assert.strictEqual(startedEvent.length, 1);
 
             await vpn.waitForMozillaProperty(
-                'Mozilla.VPN', 'VPN', 'userState', 'UserAuthenticated');
+                'Mozilla.VPN', 'VPN', 'userAuthenticated', 'true');
 
             const completedOutcomeEvent = await vpn.gleanTestGetValue("outcome", "registrationCompleted", "main");
             assert.strictEqual(completedOutcomeEvent.length, 1);

--- a/tests/functional/testDevices.js
+++ b/tests/functional/testDevices.js
@@ -209,7 +209,7 @@ describe('Devices', function() {
 
       // Wait for VPN client screen to move from spinning wheel to next screen
       await vpn.waitForMozillaProperty(
-          'Mozilla.VPN', 'VPN', 'userState', 'UserAuthenticated');
+          'Mozilla.VPN', 'VPN', 'userAuthenticated', 'true');
 
       await vpn.waitForQuery(
           queries.screenSettings.myDevicesView.DEVICE_LIST.visible());
@@ -342,7 +342,7 @@ describe('Devices', function() {
 
       // Wait for VPN client screen to move from spinning wheel to next screen
       await vpn.waitForMozillaProperty(
-          'Mozilla.VPN', 'VPN', 'userState', 'UserAuthenticated');
+          'Mozilla.VPN', 'VPN', 'userAuthenticated', 'true');
 
       await vpn.waitForQuery(
         queries.screenSettings.myDevicesView.DEVICE_LIST.visible());
@@ -468,7 +468,7 @@ describe('Devices', function() {
 
       // Wait for VPN client screen to move from spinning wheel to next screen
       await vpn.waitForMozillaProperty(
-          'Mozilla.VPN', 'VPN', 'userState', 'UserAuthenticated');
+          'Mozilla.VPN', 'VPN', 'userAuthenticated', 'true');
 
       await vpn.waitForQuery(
           queries.screenSettings.myDevicesView.DEVICE_LIST.visible());

--- a/tests/functional/testFactoryReset.js
+++ b/tests/functional/testFactoryReset.js
@@ -80,7 +80,7 @@ describe('Factory Reset', function() {
   	await vpn.waitForQuery(queries.screenInitialize.SCREEN.visible());
 
   	//Check that the user is logged out
-  	await vpn.waitForMozillaProperty('Mozilla.VPN', 'VPN', 'userState', 'UserNotAuthenticated');
+  	await vpn.waitForMozillaProperty('Mozilla.VPN', 'VPN', 'userAuthenticated', 'false');
 
 	//Check that settings were reset to factory
 	assert.equal(await vpn.getSetting('dnsProviderFlags'), 0);

--- a/tests/functional/testSubscription.js
+++ b/tests/functional/testSubscription.js
@@ -392,7 +392,7 @@ describe('Subscription view', function() {
     await vpn.waitForQueryAndClick(
         queries.screenSettings.USER_PROFILE.visible());
 
-    await vpn.waitForQuery(queries.global.SCREEN_LOADER.ready());
+    await vpn.waitForQuery(queries.screenSettings.STACKVIEW.ready());
 
     await vpn.waitForQuery(
         queries.screenAuthenticationInApp.AUTH_SIGNIN_PASSWORD_INPUT.visible());
@@ -433,7 +433,7 @@ describe('Subscription view', function() {
     await vpn.waitForQueryAndClick(
         queries.screenSettings.USER_PROFILE.visible());
 
-    await vpn.waitForQuery(queries.global.SCREEN_LOADER.ready());
+    await vpn.waitForQuery(queries.screenSettings.STACKVIEW.ready());
 
     await vpn.waitForQuery(
         queries.screenAuthenticationInApp.AUTH_SIGNIN_PASSWORD_INPUT.visible());

--- a/tests/functional/testSubscription.js
+++ b/tests/functional/testSubscription.js
@@ -224,6 +224,10 @@ describe('Subscription manager', function() {
 
          await vpn.authenticateInApp();
 
+         // Wait for model init to finish before mocking guardian errors.
+         await vpn.waitForMozillaProperty(
+             'Mozilla.VPN', 'VPN', 'modelsInitialized', 'true');
+
          // Step 1: Override the Guardian endpoint to mock an expired
          // subscription. Set the error status to 500.
          this.ctx.guardianOverrideEndpoints.GETs['/api/v1/vpn/account'].body =

--- a/tests/functional/testSubscription.js
+++ b/tests/functional/testSubscription.js
@@ -224,10 +224,6 @@ describe('Subscription manager', function() {
 
          await vpn.authenticateInApp();
 
-         // Wait for model init to finish before mocking guardian errors.
-         await vpn.waitForMozillaProperty(
-             'Mozilla.VPN', 'VPN', 'modelsInitialized', 'true');
-
          // Step 1: Override the Guardian endpoint to mock an expired
          // subscription. Set the error status to 500.
          this.ctx.guardianOverrideEndpoints.GETs['/api/v1/vpn/account'].body =

--- a/tests/unit/testaddon.cpp
+++ b/tests/unit/testaddon.cpp
@@ -77,7 +77,8 @@ void TestAddon::message_notification_data() {
 
   // Mock a user login.
   TestHelper::resetLastSystemNotification();
-  App::instance()->setUserState(App::UserAuthenticated);
+  settingsHolder.setToken("Hello World");
+  App::instance()->setState(App::StateMain);
   // A login should not trigger any messages either.
   QTest::addRow("login") << QString() << QString()
                          << TestHelper::lastSystemNotification.title
@@ -138,7 +139,7 @@ void TestAddon::message_notification_data() {
       << TestHelper::lastSystemNotification.message;
 
   TestHelper::resetLastSystemNotification();
-  // Message is created but due to it"s conditions it"s not enabled
+  // Message is created but due to its conditions it's not enabled
   AddonMessage* disabledMessage = static_cast<AddonMessage*>(
       Addon::create(&parent, ":/addons_test/message4.json"));
   emit AddonManager::instance()->addonCreated(disabledMessage);
@@ -155,7 +156,7 @@ void TestAddon::message_notification_data() {
       << TestHelper::lastSystemNotification.title
       << TestHelper::lastSystemNotification.message;
 
-  App::instance()->setUserState(App::UserNotAuthenticated);
+  App::instance()->setState(App::StateInitialize);
 }
 
 void TestAddon::message_notification() {

--- a/wasm/presets.js
+++ b/wasm/presets.js
@@ -126,7 +126,7 @@ const MVPNPresets = [
       await controller.clickOnQuery('//signUpButton');
 
       await controller.waitForMozillaProperty(
-          'Mozilla.VPN', 'VPN', 'userState', 'UserAuthenticated');
+          'Mozilla.VPN', 'VPN', 'userAuthenticated', 'true');
       await controller.wait();
       await controller.waitForQuery('//screenLoader{busy=false}');
 
@@ -277,7 +277,7 @@ const MVPNPresets = [
       await controller.clickOnQuery('//signUpButton');
 
       await controller.waitForMozillaProperty(
-          'Mozilla.VPN', 'VPN', 'userState', 'UserAuthenticated');
+          'Mozilla.VPN', 'VPN', 'userAuthenticated', 'true');
       await controller.wait();
 
       await controller.waitForQuery('//screenLoader{busy=false}');
@@ -330,7 +330,7 @@ const MVPNPresets = [
       await controller.clickOnQuery('//signUpButton');
 
       await controller.waitForMozillaProperty(
-          'Mozilla.VPN', 'VPN', 'userState', 'UserAuthenticated');
+          'Mozilla.VPN', 'VPN', 'userAuthenticated', 'true');
       await controller.waitForQuery('//screenLoader{busy=false}');
 
       await controller.waitForQueryAndClick('//telemetryPolicyButton');


### PR DESCRIPTION
## Description
Spotted in the wild: a flaky [testSubscription.js](https://github.com/mozilla-mobile/mozilla-vpn-client/actions/runs/9281903149/job/25539154427?pr=9617).

This was hauntingly familliar to a bug I fixed in one of my experimental hackathons in which `vpn.authenticateInApp()` returns success as soon as we get to the `UserAuthenticated` state but the model initialization is still waiting on a bunch of tasks to finish. If this happens during the initial test setup, and we quit before those jobs finish -  we are left with a settings file that is incomplete (the token is set but no keys are) and all the subsequent test jobs fail to load.

To fix this properly, I think the best approach is to combine the `App::state` and `App::userState` states together to eliminate potential race conditions between them, and to add a new `userAuthenticated` property that returns `true` once the auth is completed.

## Reference
Cherry-picking a bunch of stuff from PR #9584
Flaky test run: [testSubscription.js](https://github.com/mozilla-mobile/mozilla-vpn-client/actions/runs/9281903149/job/25539154427?pr=9617)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
