### PR TITLE
Update Mac and Windows builds to 6.6.3

### DIFF
--- a/.github/workflows/translations.yaml
+++ b/.github/workflows/translations.yaml
@@ -20,7 +20,7 @@ jobs:
     name: Translations
     runs-on: ubuntu-22.04
     env:
-      QTVERSION: 6.2.4
+      QTVERSION: 6.6.3
 
     steps:
       - name: Clone repository

--- a/README.md
+++ b/README.md
@@ -98,8 +98,8 @@ export MVPN_BIN=$(pwd)/build/tests/dummyvpn/dummyvpn
  * `ARTIFACT_DIR` - optional (directory to put screenshots from test failures)
  * Sample .env file:
   ```
-  export PATH=$PATH:~/Qt/6.2.4/macos/bin:$PATH
-  export QT_MACOS_BIN=~/Qt/6.2.4/macos/bin
+  export PATH=$PATH:~/Qt/6.6.3/macos/bin:$PATH
+  export QT_MACOS_BIN=~/Qt/6.6.3/macos/bin
   MVPN_API_BASE_URL=http://localhost:5000
   MVPN_BIN=dummybuild/src/mozillavpn
   ARTIFACT_DIR=tests/artifact

--- a/docs/Building/macos.md
+++ b/docs/Building/macos.md
@@ -48,7 +48,7 @@ When you next want to start building the VPN, all you need to do is activate you
 
 Get a static build of Qt made built in our CI.
 
-https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/mozillavpn.v2.mozillavpn.cache.level-3.toolchains.v3.qt-mac.latest/artifacts/public%2Fbuild%2Fqt6_mac.zip
+https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/mozillavpn.v2.mozillavpn.cache.level-3.toolchains.v3.qt-macos-6.6.latest/artifacts/public%2Fbuild%2Fqt6_mac.zip
 
 Unzip the folder and remember the location for the configure step.
 

--- a/docs/Building/windows.md
+++ b/docs/Building/windows.md
@@ -4,7 +4,7 @@
 
 Get a static build of Qt made built in our CI.
 
-https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/mozillavpn.v2.mozillavpn.cache.level-3.toolchains.v3.qt-win.latest/artifacts/public%2Fbuild%2Fqt6_win.zip
+https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/mozillavpn.v2.mozillavpn.cache.level-3.toolchains.v3.qt-windows-x86_64-6.6.latest/artifacts/public%2Fbuild%2Fqt6_win.zip
 
 Unzip the folder and remember the location for the configure step.
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -138,8 +138,8 @@ export MVPN_BIN=$(pwd)/build/tests/dummyvpn/dummyvpn
  * `ARTIFACT_DIR` - optional (directory to put screenshots from test failures)
  * Sample .env file:
   ```
-  export PATH=$PATH:~/Qt/6.2.4/macos/bin:$PATH
-  export QT_MACOS_BIN=~/Qt/6.2.4/macos/bin
+  export PATH=$PATH:~/Qt/6.6.3/macos/bin:$PATH
+  export QT_MACOS_BIN=~/Qt/6.6.3/macos/bin
   MVPN_API_BASE_URL=http://localhost:5000
   MVPN_BIN=dummybuild/src/mozillavpn
   ARTIFACT_DIR=tests/artifact

--- a/env.yml
+++ b/env.yml
@@ -26,4 +26,4 @@ dependencies:
       - -r requirements.txt
       - -r taskcluster/scripts/requirements.txt
 variables:
-  QT_VERSION: 6.2.4
+  QT_VERSION: 6.6.3

--- a/taskcluster/kinds/build/ios.yml
+++ b/taskcluster/kinds/build/ios.yml
@@ -25,18 +25,10 @@ task-defaults:
         cwd: '{checkout}'
         command: ./taskcluster/scripts/build/ios_build_debug.sh
 
-ios-arm64-qt-next/debug:
-    description: "IOS Debug Build using Qt-Next"
-    treeherder:
-        symbol: NEXT
-    fetches:
-        toolchain:
-            - conda-ios-6.6.0
-
 ios-arm64/debug:
     description: "IOS Debug Build using Qt-Next"
     treeherder:
         symbol: BD
     fetches:
         toolchain:
-            - conda-ios-6.2.4
+            - conda-ios-6.6.0

--- a/taskcluster/kinds/build/ios.yml
+++ b/taskcluster/kinds/build/ios.yml
@@ -26,7 +26,7 @@ task-defaults:
         command: ./taskcluster/scripts/build/ios_build_debug.sh
 
 ios-arm64/debug:
-    description: "IOS Debug Build using Qt-Next"
+    description: "IOS Debug Build"
     treeherder:
         symbol: BD
     fetches:

--- a/taskcluster/kinds/build/macos.yml
+++ b/taskcluster/kinds/build/macos.yml
@@ -26,23 +26,14 @@ task-defaults:
         cwd: '{checkout}'
         command: ./taskcluster/scripts/build/macos_build.sh
 
-macos/pr:
-    fetches:
-        fetch:
-            - qt-hotfix
-    description: "Mac Build"
-    treeherder:
-        symbol: BD
-    run:
-        command: ./taskcluster/scripts/build/macos_build.sh -d
 
-macos/next:
+macos/pr:
     fetches:
         toolchain:
             - qt-macos-6.6
     description: "Mac Build"
     treeherder:
-        symbol: NEXT
+        symbol: BD
     run:
         command: ./taskcluster/scripts/build/macos_build.sh -d
 
@@ -50,7 +41,7 @@ macos/next:
 macos/opt:
     fetches:
         fetch:
-            - qt-hotfix
+            - qt-macos-6.6
     description: "Mac Build"
     treeherder:
         symbol: B

--- a/taskcluster/kinds/build/macos.yml
+++ b/taskcluster/kinds/build/macos.yml
@@ -40,7 +40,7 @@ macos/pr:
 
 macos/opt:
     fetches:
-        fetch:
+        toolchain:
             - qt-macos-6.6
     description: "Mac Build"
     treeherder:

--- a/taskcluster/kinds/build/macos.yml
+++ b/taskcluster/kinds/build/macos.yml
@@ -45,6 +45,8 @@ macos/opt:
     description: "Mac Build"
     treeherder:
         symbol: B
+    run:
+        command: ./taskcluster/scripts/build/macos_build.sh -d
     requires-level: 3 
     scopes:
         - secrets:get:project/mozillavpn/level-1/sentry

--- a/taskcluster/kinds/build/windows.yml
+++ b/taskcluster/kinds/build/windows.yml
@@ -43,16 +43,8 @@ task-defaults:
 windows/opt:
     fetches:
         toolchain:
-            - qt-windows-x86_64-6.2.4
+            - qt-windows-x86_64-6.6
     description: "Windows Build"
     treeherder:
         symbol: B
-
-windows/next:
-    fetches:
-        toolchain:
-            - qt-windows-x86_64-6.6
-    description: "Windows Build for Next Version of QT"
-    treeherder:
-        symbol: NEXT
 

--- a/taskcluster/kinds/fetch/kind.yml
+++ b/taskcluster/kinds/fetch/kind.yml
@@ -86,11 +86,3 @@ tasks:
             url: https://download.qt.io/archive/qt/6.6/6.6.3/single/qt-everywhere-src-6.6.3.tar.xz
             sha256: 69d0348fef415da98aa890a34651e9cfb232f1bffcee289b7b4e21386bf36104
             size: 801192112
-    qt-hotfix:
-        description: Qt 6.2.4 Static build
-        fetch:
-            type: static-url
-            url: https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/ZswGg-syTMWyn2UTOaMVQg/runs/0/artifacts/public%2Fbuild%2Fqt6_mac.zip
-            size: 446046644
-            sha256: 68ec769ed98206784234c1c8dfae7ebb3f1be869cddfca984bb81104542a6721
-            artifact-name: qt.zip

--- a/taskcluster/kinds/toolchain/conda_osx.yml
+++ b/taskcluster/kinds/toolchain/conda_osx.yml
@@ -10,7 +10,7 @@ task-defaults:
     worker:
         max-run-time: 14400
         env:
-            QT_VERSION: "6.2.4"
+            QT_VERSION: "6.6.3"
     worker-type: b-macos
     run:
         script: conda_pack_ios.sh
@@ -21,15 +21,6 @@ task-defaults:
             - scripts/macos/conda_install_extras.sh
             - scripts/macos/conda_setup_qt.sh
 
-conda-ios-x86_64-6.2.4:
-        treeherder:
-            symbol: "conda-ios-6.2"
-        worker:
-            env:
-                QT_VERSION: "6.2.4"
-        run:
-            toolchain-alias: conda-ios-6.2.4
-            toolchain-artifact: public/build/conda-ios.tar.gz
 
 conda-ios-x86_64-6.6.0:
         treeherder:

--- a/taskcluster/kinds/toolchain/qt.yml
+++ b/taskcluster/kinds/toolchain/qt.yml
@@ -5,8 +5,8 @@
 task-defaults:
     worker:
         env:
-            QT_VERSION: "6.2.4"
-            QT_MAJOR: "6.2"
+            QT_VERSION: "6.6.3"
+            QT_MAJOR: "6.6"
         max-run-time: 14400
 
 qt-macos-6.6:
@@ -26,27 +26,6 @@ qt-macos-6.6:
         symbol: TL(qt-mac-6.6)
     worker-type: b-macos
 
-qt-windows-x86_64-6.2.4:
-    description: "Windows QT compile Task"
-    fetches:
-        fetch:
-            - win-dev-env
-        openssl:
-            - artifact: open_ssl_win.zip
-              extract: false  # For some reason unzip exits with 1 even tho the file is okay
-    dependencies:
-        openssl: toolchain-openssl-win
-    run:
-        script: compile_qt_6.ps1
-        resources:
-            - taskcluster/scripts/toolchain/configure_qt.ps1
-        toolchain-alias: qt-win-x86_64-6.2.4
-        toolchain-artifact: public/build/qt6_win.zip
-    treeherder:
-        symbol: TL(qt-win)
-        platform: windows/x86_64
-    worker-type: b-win2022
-
 qt-windows-x86_64-6.6:
     description: "Windows QT compile Task"
     fetches:
@@ -62,10 +41,6 @@ qt-windows-x86_64-6.6:
         symbol: TL(qt-win-6.6)
         platform: windows/x86_64
     worker-type: b-win2022
-    worker:
-        env:
-            QT_VERSION: "6.6.3"
-            QT_MAJOR: "6.6"
 
 qt-ios:
     description: "QT ios bundle Task"
@@ -80,6 +55,9 @@ qt-ios:
     worker-type: b-linux
     worker:
         docker-image: {in-tree: base}
+        env:
+            QT_VERSION: "6.2.4"
+            QT_MAJOR: "6.2"
 
 qt-linux:
     description: "Linux QT compile Task"
@@ -97,6 +75,9 @@ qt-linux:
     worker-type: b-linux-large
     worker:
         docker-image: {in-tree: linux-qt6-build}
+        env:
+            QT_VERSION: "6.2.4"
+            QT_MAJOR: "6.2"
 
 qt-linux-6.6.0:
     description: "Linux QT compile Task"
@@ -114,3 +95,6 @@ qt-linux-6.6.0:
     worker-type: b-linux-large
     worker:
         docker-image: {in-tree: linux-qt6-build}
+        env:
+            QT_VERSION: "6.6.0"
+            QT_MAJOR: "6.6"


### PR DESCRIPTION
## Description
This PR: 
- Removes Mac and Windows next builds and bumps release and pr builds to 6.6.3
- Removes qt-hotfix and qt-windows-x86_64-6.2.4 toolchains
- Removes ios TC next build, and bumps ios-arm64/debug to 6.6.0
- Updates QT_VERSION in env.yml to 6.6.3
- Updates static links and references to 6.2.4 in Mac and Windows build docs

## Reference

VPN-6384, VPN-6382, VPN-5563

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
