### PR TITLE
ci: Don't run beetmover-apt tasks as part of relpro yet

### DIFF
--- a/taskcluster/mozillavpn_taskgraph/transforms/beetmover_apt.py
+++ b/taskcluster/mozillavpn_taskgraph/transforms/beetmover_apt.py
@@ -51,14 +51,10 @@ ALLOWED_SHIPPING_PHASES = [
 def filter_shipping(config, tasks):
     shipping_phase = config.params.get("shipping_phase", "")
     for task in tasks:
-        if not shipping_phase in ALLOWED_SHIPPING_PHASES:
+        if shipping_phase not in ALLOWED_SHIPPING_PHASES:
             continue
-        attributes = {
-            **task["attributes"],
-            "shipping-phase": shipping_phase,
-        } 
-        task["attributes"]=attributes   
         yield task
+
 
 @transforms.add
 def beetmover_apt(config, tasks):
@@ -76,6 +72,7 @@ def beetmover_apt(config, tasks):
             and config.params.get("shipping_phase", "") == "ship-client"
             and config.params["tasks_for"] in task["run-on-tasks-for"]
         )
+
         bucket = "release" if is_production else "dep"
         project_name = "mozillavpn" if is_production else "mozillavpn:releng"
 


### PR DESCRIPTION

## Description

The scopes aren't set up properly and there's some oddities (like using the `dep` bucket in production relpro). It seems these tasks aren't quite ready to run in production releases, and they are holding up release candidates. So let's disable them there for now.

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
