### PR TITLE
ci: split 'beetmover-apt' into promote and ship tasks

### DIFF
--- a/taskcluster/kinds/beetmover-apt/kind.yml
+++ b/taskcluster/kinds/beetmover-apt/kind.yml
@@ -12,19 +12,24 @@ transforms:
 kind-dependencies:
     - beetmover-promote
 
-tasks:
-    push-to-gcr:
-        from-deps:
-            with-attributes:
-                build-type:
-                    - linux64/release-deb
-        run-on-tasks-for: [action]
-        description: description
-        worker-type: beetmover-apt
-        worker:
-            product: vpn
-            max-run-time: 1800
-            gcs-sources: [] # Set from Transform beetmover_apt
-        
+task-defaults:
+    description: Import .deb package into Google Artifact Registry
+    run-on-tasks-for: [action]
+    from-deps:
+        with-attributes:
+            build-type:
+                - linux64/release-deb
+        set-name: false
+    worker-type: beetmover-apt
+    worker:
+        product: vpn
+        max-run-time: 1800
 
-      
+tasks:
+    promote-linux64-deb:
+        attributes:
+            shipping-phase: promote-client
+
+    ship-linux64-deb:
+        attributes:
+            shipping-phase: ship-client


### PR DESCRIPTION
## Description

We want to have two tasks, one for promote and one for ship. The bucket / scopes that gets used should depend only on which of these tasks is running, and the tasks should then get filtered out at the target phase.

We also remove the 'filter_shipping' transforms because these tasks will get filtered at the target phase. The generation (aka full) phase doesn't need to be doing any pre-filtering of its own.

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
