### PR TITLE
VPN-5992 Allow extensions to request Access to the Proxy Network

### DIFF
--- a/nebula/ui/components/MZDropShadowWithStates.qml
+++ b/nebula/ui/components/MZDropShadowWithStates.qml
@@ -24,8 +24,7 @@ MZDropShadow {
                    state === VPNController.StateConfirming ||
                    state === VPNController.StateOn ||
                    state === VPNController.StateSilentSwitching ||
-                   state === VPNController.StateSwitching ||
-                   state == VPNController.StateCheckSubscription)
+                   state === VPNController.StateSwitching)
             PropertyChanges {
                 target: dropShadow
                 opacity: .3

--- a/src/captiveportal/captiveportaldetection.cpp
+++ b/src/captiveportal/captiveportaldetection.cpp
@@ -51,7 +51,6 @@ void CaptivePortalDetection::networkChanged() {
 
   Controller::State state = vpn->controller()->state();
   if (state != Controller::StateOn && state != Controller::StateConnecting &&
-      state != Controller::StateCheckSubscription &&
       state != Controller::StateConfirming) {
     // Network Changed but we're not connected, no need to test for captive
     // portal
@@ -80,7 +79,6 @@ void CaptivePortalDetection::stateChanged() {
   if ((state != Controller::StateOn ||
        vpn->connectionHealth()->stability() == ConnectionHealth::Stable) &&
       state != Controller::StateConnecting &&
-      state != Controller::StateCheckSubscription &&
       state != Controller::StateConfirming) {
     logger.warning() << "No captive portal detection required";
     m_impl.reset();

--- a/src/commands/commandstatus.cpp
+++ b/src/commands/commandstatus.cpp
@@ -135,11 +135,6 @@ int CommandStatus::run(QStringList& tokens) {
       case Controller::StateOff:
         stream << "off";
         break;
-
-      case Controller::StateCheckSubscription:
-        stream << "check subscription";
-        break;
-
       case Controller::StateConnecting:
         stream << "connecting";
         break;

--- a/src/commands/commandstatus.cpp
+++ b/src/commands/commandstatus.cpp
@@ -150,6 +150,8 @@ int CommandStatus::run(QStringList& tokens) {
 
       case Controller::StateOn:
         [[fallthrough]];
+      case Controller::StateOnPartial:
+        [[fallthrough]];
       case Controller::StateSilentSwitching:
         stream << "on";
         break;

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -281,10 +281,10 @@ void Controller::handshakeTimeout() {
     logger.info() << "Connection Attempt: Using Port 53 Option this time.";
     // On the first retry, opportunisticly try again using the port 53
     // option enabled, if that feature is disabled.
-    activateInternal(ForceDNSPort, RandomizeServerSelection, m_iniator);
+    activateInternal(ForceDNSPort, RandomizeServerSelection, m_initiator);
     return;
   } else if (m_connectionRetry < CONNECTION_MAX_RETRY) {
-    activateInternal(DoNotForceDNSPort, RandomizeServerSelection, m_iniator);
+    activateInternal(DoNotForceDNSPort, RandomizeServerSelection, m_initiator);
     return;
   }
 
@@ -357,7 +357,7 @@ void Controller::activateInternal(
     ActivationPrincipal initiator = ClientUser) {
   logger.debug() << "Activation internal";
   Q_ASSERT(m_impl);
-  m_iniator = initiator;
+  m_initiator = initiator;
 
   clearConnectedTime();
   m_handshakeTimer.stop();
@@ -722,7 +722,7 @@ void Controller::connected(const QString& pubkey) {
 
   // We have succesfully completed all pending connections.
   logger.debug() << "Connected from state:" << m_state;
-  if (m_iniator == ExtensionUser) {
+  if (m_initiator == ExtensionUser) {
     setState(StateOnPartial);
   } else {
     setState(StateOn);
@@ -773,7 +773,7 @@ void Controller::disconnected() {
     // Else move the iniator to Client User
     // as the extension cannot switch servers.
     auto target_iniator = m_state == StateSilentSwitching
-                              ? m_iniator
+                              ? m_initiator
                               : ActivationPrincipal::ClientUser;
     activate(m_nextServerData, target_iniator, m_nextServerSelectionPolicy);
     return;
@@ -784,7 +784,7 @@ void Controller::disconnected() {
   if (m_state != StateConfirming) {
     emit recordConnectionEndTelemetry();
   }
-  m_iniator = Null;
+  m_initiator = Null;
   setState(StateOff);
 }
 
@@ -1079,7 +1079,7 @@ bool Controller::activate(const ServerData& serverData,
 
 bool Controller::deactivate(ActivationPrincipal user) {
   logger.debug() << "Deactivation" << m_state;
-  if (m_iniator > user) {
+  if (m_initiator > user) {
     // i.e the Firefox Extension cannot deativate the
     // vpn if we are in full device protection.
     logger.warning()

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -397,6 +397,7 @@ void Controller::activateInternal(
   exitConfig.m_serverPublicKey = exitServer.publicKey();
   exitConfig.m_serverIpv4AddrIn = exitServer.ipv4AddrIn();
   exitConfig.m_serverIpv6AddrIn = exitServer.ipv6AddrIn();
+  exitConfig.m_serverPort = exitServer.choosePort();
   exitConfig.m_allowedIPAddressRanges = allowedIPList;
   exitConfig.m_dnsServer = DNSHelper::getDNS(exitServer.ipv4Gateway());
 #if defined(MZ_ANDROID) || defined(MZ_IOS)

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -49,13 +49,11 @@
 #  include "platforms/dummy/dummycontroller.h"
 #endif
 
-#ifndef MZ_IOS
 // The Mullvad proxy services are located at internal IPv4 addresses in the
 // 10.124.0.0/20 address range, which is a subset of the 10.0.0.0/8 Class-A
 // private address range.
 constexpr const char* MULLVAD_PROXY_RANGE = "10.124.0.0";
 constexpr const int MULLVAD_PROXY_RANGE_LENGTH = 20;
-#endif
 
 namespace {
 Logger logger("Controller");

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -230,7 +230,7 @@ void Controller::quit() {
 
   if (m_state == StateOn || m_state == StateOnPartial ||
       m_state == StateSwitching || m_state == StateSilentSwitching ||
-      m_state == StateConnecting || m_state == StateCheckSubscription) {
+      m_state == StateConnecting) {
     deactivate();
     return;
   }
@@ -308,7 +308,7 @@ void Controller::serverUnavailable() {
   m_nextStep = ServerUnavailable;
 
   if (m_state == StateSwitching || m_state == StateConnecting ||
-      m_state == StateConfirming || m_state == StateCheckSubscription) {
+      m_state == StateConfirming) {
     logger.info() << "Server location is unavailable and we are not in "
                      "StateOn. Deactivate!";
     deactivate();
@@ -957,8 +957,7 @@ void Controller::backendFailure() {
 
   if (m_state == StateOn || m_state == StateOnPartial ||
       m_state == StateSwitching || m_state == StateSilentSwitching ||
-      m_state == StateConnecting || m_state == StateCheckSubscription ||
-      m_state == StateConfirming) {
+      m_state == StateConnecting || m_state == StateConfirming) {
     deactivate();
     return;
   }
@@ -1020,12 +1019,6 @@ bool Controller::activate(const ServerData& serverData,
         m_isDeviceConnected = true;
         emit isDeviceConnectedChanged();
       }
-    }
-
-    // Before attempting to enable VPN connection we should check that the
-    // subscription is active.
-    if (initiator != ExtensionUser) {
-      setState(StateCheckSubscription);
     }
 
     // Set up a network request to check the subscription status.
@@ -1099,8 +1092,7 @@ bool Controller::deactivate(ActivationPrincipal user) {
 
   if (m_state != StateOn && m_state != StateOnPartial &&
       m_state != StateSwitching && m_state != StateSilentSwitching &&
-      m_state != StateConfirming && m_state != StateConnecting &&
-      m_state != StateCheckSubscription) {
+      m_state != StateConfirming && m_state != StateConnecting) {
     logger.warning() << "Already disconnected";
     return false;
   }
@@ -1117,8 +1109,7 @@ bool Controller::deactivate(ActivationPrincipal user) {
   }
 
   if (m_state == StateOn || m_state == StateOnPartial ||
-      m_state == StateConfirming || m_state == StateConnecting ||
-      m_state == StateCheckSubscription) {
+      m_state == StateConfirming || m_state == StateConnecting) {
     setState(StateDisconnecting);
   }
 

--- a/src/controller.h
+++ b/src/controller.h
@@ -48,8 +48,8 @@ class Controller : public QObject, public LogSerializer {
     ReasonConfirming,
   };
   /**
-   * @brief Who asked the Connection 
-   * to be Iniated? A Webextension 
+   * @brief Who asked the Connection
+   * to be Iniated? A Webextension
    * or a User Interaction inside the Client?
    */
   enum ActivationPrincipal {
@@ -230,7 +230,7 @@ class Controller : public QObject, public LogSerializer {
   QDateTime m_connectedTimeInUTC;
 
   State m_state = StateInitializing;
-  ActivationPrincipal m_iniator = Null;
+  ActivationPrincipal m_initiator = Null;
   bool m_enableDisconnectInConfirming = false;
   QList<InterfaceConfig> m_activationQueue;
   int m_connectionRetry = 0;

--- a/src/controller.h
+++ b/src/controller.h
@@ -48,7 +48,7 @@ class Controller : public QObject, public LogSerializer {
   };
   /**
    * @brief Who asked the Connection
-   * to be Iniated? A Webextension
+   * to be Initiated? A Webextension
    * or a User Interaction inside the Client?
    */
   enum ActivationPrincipal {

--- a/src/controller.h
+++ b/src/controller.h
@@ -31,7 +31,6 @@ class Controller : public QObject, public LogSerializer {
   enum State {
     StateInitializing,
     StateOff,
-    StateCheckSubscription,
     StateConnecting,
     StateConfirming,
     StateOn,

--- a/src/controller.h
+++ b/src/controller.h
@@ -46,6 +46,16 @@ class Controller : public QObject, public LogSerializer {
     ReasonSwitching,
     ReasonConfirming,
   };
+  /**
+   * @brief Who asked the Connection 
+   * to be Iniated? A Webextension 
+   * or a User Interaction inside the Client?
+   */
+  enum ActivationInitiator {
+    Null = 0,
+    ExtensionUser = 1,
+    ClientUser = 2,
+  };
 
  public:
   qint64 time() const;
@@ -95,6 +105,7 @@ class Controller : public QObject, public LogSerializer {
   // be emitted at the end of the operation.
   bool activate(
       const ServerData& serverData,
+      ActivationInitiator = ClientUser, 
       ServerSelectionPolicy serverSelectionPolicy = RandomizeServerSelection);
   bool deactivate();
 
@@ -169,6 +180,7 @@ class Controller : public QObject, public LogSerializer {
   };
   static IPAddressList getExcludedIPAddressRanges();
   static QList<IPAddress> getAllowedIPAddressRanges(const Server& server);
+  static QList<IPAddress> getExtensionProxyAddressRanges();
 
   enum ServerCoolDownPolicyForSilentSwitch {
     eServerCoolDownNeeded,
@@ -196,6 +208,7 @@ class Controller : public QObject, public LogSerializer {
   };
 
   void activateInternal(DNSPortPolicy dnsPort,
+                        std::optional<QList<IPAddress>> allowedIPList, 
                         ServerSelectionPolicy serverSelectionPolicy);
 
   void clearConnectedTime();
@@ -215,6 +228,7 @@ class Controller : public QObject, public LogSerializer {
   QDateTime m_connectedTimeInUTC;
 
   State m_state = StateInitializing;
+  ActivationInitiator m_iniator = Null;
   bool m_enableDisconnectInConfirming = false;
   QList<InterfaceConfig> m_activationQueue;
   int m_connectionRetry = 0;

--- a/src/inspector/inspectorhandler.cpp
+++ b/src/inspector/inspectorhandler.cpp
@@ -764,7 +764,7 @@ void InspectorHandler::initialize() {
 #ifdef MZ_WASM
   WasmInspector::instance();
 #else
-  if (true) {
+  if (!Constants::inProduction()) {
     InspectorWebSocketServer* inspectWebSocketServer =
         new InspectorWebSocketServer(qApp);
     QObject::connect(qApp, &QCoreApplication::aboutToQuit,

--- a/src/inspector/inspectorhandler.cpp
+++ b/src/inspector/inspectorhandler.cpp
@@ -764,7 +764,7 @@ void InspectorHandler::initialize() {
 #ifdef MZ_WASM
   WasmInspector::instance();
 #else
-  if (!Constants::inProduction()) {
+  if (true) {
     InspectorWebSocketServer* inspectWebSocketServer =
         new InspectorWebSocketServer(qApp);
     QObject::connect(qApp, &QCoreApplication::aboutToQuit,

--- a/src/networkwatcher.cpp
+++ b/src/networkwatcher.cpp
@@ -138,7 +138,6 @@ void NetworkWatcher::unsecuredNetwork(const QString& networkName,
 
   Controller::State state = vpn->controller()->state();
   if (state == Controller::StateOn || state == Controller::StateConnecting ||
-      state == Controller::StateCheckSubscription ||
       state == Controller::StateSwitching ||
       state == Controller::StateSilentSwitching) {
     logger.debug() << "VPN on. Ignoring unsecured network";

--- a/src/statusicon.cpp
+++ b/src/statusicon.cpp
@@ -104,8 +104,6 @@ const QString StatusIcon::iconString() {
       [[fallthrough]];
     case Controller::StateConnecting:
       [[fallthrough]];
-    case Controller::StateCheckSubscription:
-      [[fallthrough]];
     case Controller::StateConfirming:
       [[fallthrough]];
     case Controller::StateDisconnecting:

--- a/src/statusicon.cpp
+++ b/src/statusicon.cpp
@@ -73,8 +73,6 @@ void StatusIcon::activateAnimation() {
 }
 
 void StatusIcon::animateIcon() {
-  logger.debug() << "Animate icon";
-
   Q_ASSERT(m_animatedIconIndex < ANIMATED_LOGO_STEPS.size());
   m_animatedIconIndex++;
   if (m_animatedIconIndex == ANIMATED_LOGO_STEPS.size()) {
@@ -84,8 +82,6 @@ void StatusIcon::animateIcon() {
 }
 
 const QString StatusIcon::iconString() {
-  logger.debug() << "Icon string" << m_animatedIconIndex;
-
   MozillaVPN* vpn = MozillaVPN::instance();
 
   // If we are in a non-main state, we don't need to show special icons.
@@ -149,8 +145,6 @@ const QColor StatusIcon::indicatorColor() const {
 }
 
 void StatusIcon::refreshNeeded() {
-  logger.debug() << "Refresh needed";
-
   if (!m_icon.isNull()) {
     m_icon = QIcon();
   }
@@ -158,8 +152,6 @@ void StatusIcon::refreshNeeded() {
 }
 
 QIcon StatusIcon::drawStatusIndicator() {
-  logger.debug() << "Get icon from URL";
-
   // Create pixmap so that we can paint on the original resource.
   QPixmap iconPixmap = QPixmap(iconString());
 

--- a/src/systemtraynotificationhandler.cpp
+++ b/src/systemtraynotificationhandler.cpp
@@ -223,8 +223,6 @@ void SystemTrayNotificationHandler::updateContextMenu() {
 }
 
 void SystemTrayNotificationHandler::updateIcon() {
-  logger.debug() << "Update icon";
-
 #if defined(MZ_LINUX) || defined(MZ_WINDOWS)
   MozillaVPN* vpn = MozillaVPN::instance();
   m_systemTrayIcon->setIcon(vpn->statusIcon()->icon());

--- a/src/systemtraynotificationhandler.cpp
+++ b/src/systemtraynotificationhandler.cpp
@@ -185,8 +185,6 @@ void SystemTrayNotificationHandler::updateContextMenu() {
       [[fallthrough]];
     case Controller::StateConnecting:
       [[fallthrough]];
-    case Controller::StateCheckSubscription:
-      [[fallthrough]];
     case Controller::StateConfirming:
       statusLabel = i18nStrings->t(I18nStrings::SystrayStatusConnectingTo);
       break;

--- a/src/tasks/controlleraction/taskcontrolleraction.cpp
+++ b/src/tasks/controlleraction/taskcontrolleraction.cpp
@@ -53,7 +53,8 @@ void TaskControllerAction::run() {
       expectSignal = controller->activate(m_serverData);
       break;
     case eActivateForExtension:
-      expectSignal = controller->activate(m_serverData, Controller::ExtensionUser);
+      expectSignal =
+          controller->activate(m_serverData, Controller::ExtensionUser);
       break;
     case eDeactivate:
       expectSignal = controller->deactivate();

--- a/src/tasks/controlleraction/taskcontrolleraction.cpp
+++ b/src/tasks/controlleraction/taskcontrolleraction.cpp
@@ -52,15 +52,15 @@ void TaskControllerAction::run() {
     case eActivate:
       expectSignal = controller->activate(m_serverData);
       break;
-
+    case eActivateForExtension:
+      expectSignal = controller->activate(m_serverData, Controller::ExtensionUser);
+      break;
     case eDeactivate:
       expectSignal = controller->deactivate();
       break;
-
     case eSilentSwitch:
       expectSignal = controller->silentSwitchServers(m_serverCoolDownPolicy);
       break;
-
     case eSwitch:
       expectSignal = controller->switchServers(m_serverData);
       break;

--- a/src/tasks/controlleraction/taskcontrolleraction.cpp
+++ b/src/tasks/controlleraction/taskcontrolleraction.cpp
@@ -58,6 +58,9 @@ void TaskControllerAction::run() {
     case eDeactivate:
       expectSignal = controller->deactivate();
       break;
+    case eDeactivateForExtension:
+      expectSignal = controller->deactivate(Controller::ExtensionUser);
+      break;
     case eSilentSwitch:
       expectSignal = controller->silentSwitchServers(m_serverCoolDownPolicy);
       break;

--- a/src/tasks/controlleraction/taskcontrolleraction.h
+++ b/src/tasks/controlleraction/taskcontrolleraction.h
@@ -23,6 +23,7 @@ class TaskControllerAction final : public Task {
     eActivate,
     eActivateForExtension,
     eDeactivate,
+    eDeactivateForExtension,
     eSilentSwitch,
     eSwitch,
   };

--- a/src/tasks/controlleraction/taskcontrolleraction.h
+++ b/src/tasks/controlleraction/taskcontrolleraction.h
@@ -21,6 +21,7 @@ class TaskControllerAction final : public Task {
  public:
   enum TaskAction {
     eActivate,
+    eActivateForExtension,
     eDeactivate,
     eSilentSwitch,
     eSwitch,

--- a/src/ui/screens/home/controller/ControllerImage.qml
+++ b/src/ui/screens/home/controller/ControllerImage.qml
@@ -18,8 +18,7 @@ Rectangle {
     states: [
         State {
             name: "stateConnecting"
-            when: (VPNController.state === VPNController.StateConnecting ||
-                   VPNController.state === VPNController.StateCheckSubscription)
+            when: (VPNController.state === VPNController.StateConnecting)
 
             PropertyChanges {
                 target: logo

--- a/src/ui/screens/home/controller/ControllerImage.qml
+++ b/src/ui/screens/home/controller/ControllerImage.qml
@@ -101,7 +101,8 @@ Rectangle {
         },
         State {
             name: "stateOff"
-            when: VPNController.state === VPNController.StateOff
+            when: VPNController.state === VPNController.StateOff ||
+                  VPNController.state === VPNController.StateOnPartial
 
             PropertyChanges {
                 target: insetCircle

--- a/src/ui/screens/home/controller/ControllerView.qml
+++ b/src/ui/screens/home/controller/ControllerView.qml
@@ -143,8 +143,7 @@ Item {
         },
         State {
             name: "stateConnecting"
-            when: (VPNController.state === VPNController.StateConnecting ||
-                   VPNController.state === VPNController.StateCheckSubscription)
+            when: (VPNController.state === VPNController.StateConnecting)
 
             PropertyChanges {
                 target: boxBackground

--- a/src/ui/screens/home/controller/ControllerView.qml
+++ b/src/ui/screens/home/controller/ControllerView.qml
@@ -103,7 +103,8 @@ Item {
         },
         State {
             name: "stateOff"
-            when: VPNController.state === VPNController.StateOff
+            when: VPNController.state === VPNController.StateOff ||
+                  VPNController.state === VPNController.StateOnPartial
 
             PropertyChanges {
                 target: boxBackground

--- a/src/ui/screens/home/controller/VPNToggle.qml
+++ b/src/ui/screens/home/controller/VPNToggle.qml
@@ -90,8 +90,7 @@ MZButtonBase {
         },
         State {
             name: "stateConnecting"
-            when: (VPNController.state === VPNController.StateConnecting ||
-                   VPNController.state === VPNController.StateCheckSubscription)
+            when: (VPNController.state === VPNController.StateConnecting)
 
             PropertyChanges {
                 target: cursor

--- a/src/ui/screens/home/controller/VPNToggle.qml
+++ b/src/ui/screens/home/controller/VPNToggle.qml
@@ -19,7 +19,8 @@ MZButtonBase {
 
     function handleClick() {
         toolTip.close();
-        if (VPNController.state !== VPNController.StateOff) {
+        if (VPNController.state !== VPNController.StateOff &&
+            VPNController.state !== VPNController.StateOnPartial) {
             return VPN.deactivate();
         }
 
@@ -66,7 +67,8 @@ MZButtonBase {
         },
         State {
             name: "stateOff"
-            when: VPNController.state === VPNController.StateOff
+            when: VPNController.state === VPNController.StateOff ||
+                  VPNController.state === VPNController.StateOnPartial
 
             PropertyChanges {
                 target: cursor
@@ -277,6 +279,7 @@ MZButtonBase {
     function toggleClickable() {
         return VPN.state === VPN.StateMain &&
                (VPNController.state === VPNController.StateOn ||
+               VPNController.state === VPNController.StateOnPartial ||
                 VPNController.state === VPNController.StateSilentSwitching ||
                 VPNController.state === VPNController.StateOff ||
                 (VPNController.state === VPNController.StateConfirming &&

--- a/src/webextensionadapter.cpp
+++ b/src/webextensionadapter.cpp
@@ -21,9 +21,9 @@
 #include "models/serverdata.h"
 #include "mozillavpn.h"
 #include "settingsholder.h"
-#include "webextensionadapter.h"
-#include "taskscheduler.h"
 #include "tasks/controlleraction/taskcontrolleraction.h"
+#include "taskscheduler.h"
+#include "webextensionadapter.h"
 
 namespace {
 
@@ -46,7 +46,7 @@ WebExtensionAdapter::WebExtensionAdapter(QObject* parent)
       RequestType{"activate",
                   [](const QJsonObject&) {
                     auto t = new TaskControllerAction(
-                      TaskControllerAction::eActivateForExtension);
+                        TaskControllerAction::eActivateForExtension);
                     TaskScheduler::scheduleTask(t);
                     QJsonObject obj;
                     obj["ok"] = true;

--- a/src/webextensionadapter.cpp
+++ b/src/webextensionadapter.cpp
@@ -22,6 +22,8 @@
 #include "mozillavpn.h"
 #include "settingsholder.h"
 #include "webextensionadapter.h"
+#include "taskscheduler.h"
+#include "tasks/controlleraction/taskcontrolleraction.h"
 
 namespace {
 
@@ -43,10 +45,13 @@ WebExtensionAdapter::WebExtensionAdapter(QObject* parent)
   m_commands = QList<RequestType>({
       RequestType{"activate",
                   [](const QJsonObject&) {
-                    MozillaVPN::instance()->activate();
+                    auto t = new TaskControllerAction(
+                      TaskControllerAction::eActivateForExtension);
+                    TaskScheduler::scheduleTask(t);
+                    QJsonObject obj;
+                    obj["ok"] = true;
                     return QJsonObject();
                   }},
-
       RequestType{"servers",
                   [this](const QJsonObject&) {
                     QJsonObject servers;

--- a/src/webextensionadapter.cpp
+++ b/src/webextensionadapter.cpp
@@ -52,6 +52,15 @@ WebExtensionAdapter::WebExtensionAdapter(QObject* parent)
                     obj["ok"] = true;
                     return QJsonObject();
                   }},
+      RequestType{"deactivate",
+                  [](const QJsonObject&) {
+                    auto t = new TaskControllerAction(
+                        TaskControllerAction::eDeactivateForExtension);
+                    TaskScheduler::scheduleTask(t);
+                    QJsonObject obj;
+                    obj["ok"] = true;
+                    return QJsonObject();
+                  }},
       RequestType{"servers",
                   [this](const QJsonObject&) {
                     QJsonObject servers;
@@ -127,6 +136,10 @@ QJsonObject WebExtensionAdapter::serializeStatus() {
 
   {
     Controller::State state = vpn->controller()->state();
+    if (state == Controller::StateOnPartial) {
+      state = Controller::StateOn;  // Old extensions like MAC dont know and
+                                    // dont need to know about this state.
+    }
     const QMetaObject* meta = qt_getEnumMetaObject(state);
     int index = meta->indexOfEnumerator(qt_getEnumName(state));
     obj["vpn"] = meta->enumerator(index).valueToKey(state);

--- a/src/webextensionadapter.cpp
+++ b/src/webextensionadapter.cpp
@@ -99,7 +99,8 @@ WebExtensionAdapter::~WebExtensionAdapter() {
 }
 
 void WebExtensionAdapter::writeState() {
-  QJsonObject obj = serializeStatus();
+  QJsonObject obj;
+  obj["status"] = serializeStatus();
   obj["t"] = "status";
 
   emit onOutgoingMessage(obj);

--- a/tests/functional/helper.js
+++ b/tests/functional/helper.js
@@ -352,18 +352,33 @@ module.exports = {
     return await this.getMozillaProperty(
         'Mozilla.Shared', 'MZUrlOpener', 'lastUrl');
   },
-
-  async waitForCondition(condition, waitTimeInMilliSecs = 500) {
+  /**
+   * Calls condition() every waitTimeInMilliSecs, promise resolves
+   * if condition returns true.
+   *
+   * @param {()=> Promise<Boolean>} condition -  A Callable Function, returning
+   *     true if the Condition is fulfulledbcondition
+   * @param {*} waitTimeInMilliSecs -
+   * @param {string} description - Description of the Condition to debug
+   *     Failures
+   * @returns {Promise<void>}
+   */
+  async waitForCondition(
+      condition, waitTimeInMilliSecs = 500, description = '') {
     // If the condition takes longer than 15 seconds, give up.
     let active = true;
     let timeout = setTimeout(() => { active = false }, 15000);
     while (true) {
       if (await condition()) {
+        if (description != '') {
+          // If there is a description mark the assert
+          assert(true, 'Condition passed: ' + description);
+        }
         clearTimeout(timeout)
         return;
       }
       // Asserting here produces a more useful backtrace for diagnosing tests.
-      assert(active, "Condition timed out");
+      assert(active, 'Condition timed out: ' + description);
       await new Promise(resolve => setTimeout(resolve, waitTimeInMilliSecs));
     }
   },
@@ -473,31 +488,38 @@ module.exports = {
   },
 
   async completeTelemetryPolicy() {
-      await this.waitForQuery(queries.screenTelemetry.BUTTON.visible());
-      await this.clickOnQuery(queries.screenTelemetry.BUTTON.visible());
-      await this.waitForQuery(queries.screenHome.CONTROLLER_TITLE.visible());
+    await this.waitForQuery(queries.screenTelemetry.BUTTON.visible());
+    await this.clickOnQuery(queries.screenTelemetry.BUTTON.visible());
+    await this.waitForQuery(queries.screenHome.CONTROLLER_TITLE.visible());
   },
 
   async completeOnboarding() {
     await this.waitForQuery(queries.screenOnboarding.STEP_NAV_STACK_VIEW.ready());
     switch(await this.getSetting('onboardingStep')) {
-    case 0:
-      await this.waitForQueryAndClick(queries.screenOnboarding.DATA_NEXT_BUTTON.visible());
-      await this.waitForQuery(queries.screenOnboarding.STEP_NAV_STACK_VIEW.ready());
-    case 1:
-      await this.waitForQueryAndClick(queries.screenOnboarding.PRIVACY_NEXT_BUTTON.visible());
-      await this.waitForQuery(queries.screenOnboarding.STEP_NAV_STACK_VIEW.ready());
-    case 2:
-      await this.waitForQueryAndClick(queries.screenOnboarding.DEVICES_NEXT_BUTTON.visible());
-      await this.waitForQuery(queries.screenOnboarding.STEP_NAV_STACK_VIEW.ready());
-    case 3:
-      await this.waitForQueryAndClick(queries.screenOnboarding.START_NEXT_BUTTON.visible());
-      await this.waitForQuery(queries.screenHome.SCREEN.visible());
-      assert.equal(await this.getSetting('onboardingCompleted'), true);
-    default:
-      break;
+      case 0:
+        await this.waitForQueryAndClick(
+            queries.screenOnboarding.DATA_NEXT_BUTTON.visible());
+        await this.waitForQuery(
+            queries.screenOnboarding.STEP_NAV_STACK_VIEW.ready());
+      case 1:
+        await this.waitForQueryAndClick(
+            queries.screenOnboarding.PRIVACY_NEXT_BUTTON.visible());
+        await this.waitForQuery(
+            queries.screenOnboarding.STEP_NAV_STACK_VIEW.ready());
+      case 2:
+        await this.waitForQueryAndClick(
+            queries.screenOnboarding.DEVICES_NEXT_BUTTON.visible());
+        await this.waitForQuery(
+            queries.screenOnboarding.STEP_NAV_STACK_VIEW.ready());
+      case 3:
+        await this.waitForQueryAndClick(
+            queries.screenOnboarding.START_NEXT_BUTTON.visible());
+        await this.waitForQuery(queries.screenHome.SCREEN.visible());
+        assert.equal(await this.getSetting('onboardingCompleted'), true);
+      default:
+        break;
     }
- },
+  },
 
   async logout() {
     const json = await this._writeCommand('logout');
@@ -686,14 +708,17 @@ module.exports = {
 
   // By default gets the last recorded event.
   // `offset` can be used to change that, it adds the offset from the last.
-  // So, for example, if we want the next to last event we give it an `offset` of 1.
-  async getOneEventOfType({
-    eventCategory,
-    eventName,
-    // When expectedEventCount is provided it will be asserted on.
-    // When it's not provided the last event will be tested.
-    expectedEventCount
-  }, offset = 0) {
+  // So, for example, if we want the next to last event we give it an `offset`
+  // of 1.
+  async getOneEventOfType(
+      {
+        eventCategory,
+        eventName,
+        // When expectedEventCount is provided it will be asserted on.
+        // When it's not provided the last event will be tested.
+        expectedEventCount
+      },
+      offset = 0) {
     let events;
     await this.waitForCondition(async () => {
       events = await this.gleanTestGetValue(eventCategory, eventName, "main");
@@ -710,7 +735,7 @@ module.exports = {
     return events[computedEventCount - (1 + offset)];
   },
 
-  async testLastInteractionEvent (options) {
+  async testLastInteractionEvent(options) {
     const defaults = { eventCategory: "interaction", action: "select" };
     const optionsWithDefaults = { ...defaults, ...options };
 

--- a/tests/functional/helper.js
+++ b/tests/functional/helper.js
@@ -357,7 +357,7 @@ module.exports = {
    * if condition returns true.
    *
    * @param {()=> Promise<Boolean>} condition -  A Callable Function, returning
-   *     true if the Condition is fulfulledbcondition
+   *     true if the Condition is fulfilledbycondition
    * @param {*} waitTimeInMilliSecs -
    * @param {string} description - Description of the Condition to debug
    *     Failures

--- a/tests/functional/testWebExtensionApi.js
+++ b/tests/functional/testWebExtensionApi.js
@@ -14,6 +14,7 @@ const {
   readResponseOfType
 } = require('./utils/webextension.js')
 
+if(!vpn.runningOnWasm()) {
 
 describe('WebExtension API', function() {
   this.timeout(60000);
@@ -87,3 +88,5 @@ describe('WebExtension API', function() {
        sock.destroy();
      });
 });
+
+}

--- a/tests/functional/testWebExtensionApi.js
+++ b/tests/functional/testWebExtensionApi.js
@@ -1,0 +1,89 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const assert = require('assert');
+const vpn = require('./helper.js');
+const queries = require('./queries.js');
+
+const {
+  sentToClient,
+  connectExtension,
+  getMessageStream,
+  ExtensionMessage,
+  readResponseOfType
+} = require('./utils/webextension.js')
+
+
+describe('WebExtension API', function() {
+  this.timeout(60000);
+  this.ctx.authenticationNeeded = true;
+
+  it('A Webextension can query the Status of the VPN', async () => {
+    const sock = await connectExtension();
+    const messagePipe = getMessageStream(sock);
+    sentToClient(new ExtensionMessage('status'), sock);
+    await readResponseOfType('status', messagePipe);
+    sock.destroy();
+  });
+  it('A Webextension can activate the VPN', async () => {
+    const sock = await connectExtension();
+    const messagePipe = getMessageStream(sock);
+    sentToClient(new ExtensionMessage('activate'), sock);
+
+    await vpn.waitForCondition(async () => {
+      sentToClient(new ExtensionMessage('status'), sock);
+      const msg = await readResponseOfType('status', messagePipe);
+      return msg.status.vpn === 'StateOn';
+    });
+    const currentstate =
+        await vpn.getMozillaProperty('Mozilla.VPN', 'VPNController', 'state');
+    assert(currentstate === 'StateOnPartial')
+    sock.destroy();
+  });
+  it('A Webextension can deactivate the VPN if it Self Activated', async () => {
+    const sock = await connectExtension();
+    const messagePipe = getMessageStream(sock);
+    sentToClient(new ExtensionMessage('activate'), sock);
+    await readResponseOfType('activate', messagePipe);
+    await vpn.waitForCondition(async () => {
+      sentToClient(new ExtensionMessage('status'), sock);
+      const msg = await readResponseOfType('status', messagePipe);
+      return msg.status.vpn === 'StateOn';
+    });
+    sentToClient(new ExtensionMessage('deactivate'), sock);
+    await vpn.waitForCondition(async () => {
+      sentToClient(new ExtensionMessage('status'), sock);
+      const msg = await readResponseOfType('status', messagePipe);
+      return msg.status.vpn === 'StateOff';
+    });
+    sock.destroy();
+  });
+
+  it('A Webextension can NOT deactivate the VPN if it was activated in Client',
+     async () => {
+       /**
+        * We currently do not want to allow the extension to Disable the
+        * Connection unless the extension was the reason for the current
+        * connection
+        */
+       await vpn.activate();
+       const sock = await connectExtension();
+       const messagePipe = getMessageStream(sock);
+
+       await vpn.waitForCondition(async () => {
+         sentToClient(new ExtensionMessage('status'), sock);
+         const msg = await readResponseOfType('status', messagePipe);
+         return msg.status.vpn === 'StateOn';
+       }, 500, 'VPN should report StateOn');
+       sentToClient(new ExtensionMessage('deactivate'), sock);
+       await vpn.wait(200);
+
+       await vpn.waitForCondition(async () => {
+         sentToClient(new ExtensionMessage('status'), sock);
+         const msg = await readResponseOfType('status', messagePipe);
+         return msg.status.vpn === 'StateOn';
+       }, 500, 'VPN should still report StateOn');
+       sock.destroy();
+     });
+});

--- a/tests/functional/utils/webextension.js
+++ b/tests/functional/utils/webextension.js
@@ -1,0 +1,101 @@
+const net = require('node:net');
+const {Buffer} = require('node:buffer');
+
+
+const SERVER_PORT = 8754;
+
+
+function ExtensionMessage(aT) {
+  if (!aT) {
+    this.t = 'help'
+    return;
+  }
+  this.t = aT
+};
+
+/**
+ * Connects to the Client's default WebExtension
+ * API Socket
+ *
+ * @returns {Promise<net.Socket>} a node:net Socket with an established
+ *     connection
+ */
+async function connectExtension() {
+  const sock = new net.Socket();
+  await new Promise(r => sock.connect(8754, '127.0.0.1', r));
+  return sock;
+};
+
+/**
+ * Encodes and sends a Message to the Client
+ * @param {ExtensionMessage} message - Message :)
+ * @param {net.Socket} socket - Socket
+ *
+ */
+function sentToClient(message, sock) {
+  const resEncodedMessage = new TextEncoder().encode(JSON.stringify(message))
+  const b = new Uint32Array([resEncodedMessage.length]);
+  const header = new Uint8Array(b.buffer);
+
+
+  var raw_message = new Uint8Array([...header, ...resEncodedMessage]);
+  sock.write(raw_message);
+}
+
+/**
+ * Returns a generator Yieling Messages from the Webextension
+ * The Generator is valid as long as the socket is open
+ * @param {*} sock - an Open Socket
+ * @returns {ReadableStream<Message>}- A ReadableStream yieling Messages
+ */
+function getMessageStream(sock = new net.Socket) {
+  return new ReadableStream({
+    start(cntrl) {
+      sock.on('data', (buff) => {
+        let data = buff;
+        // Pop out the first X bytes
+        // from data and return them
+        const nom = (len) => {
+          const out = data.slice(0, len)
+          data = data.slice(len)
+          return out;
+        } while (data.length != 0) {
+          const header = nom(4)
+          const len = header.readUint32LE(0);
+          const payload = nom(len);
+          const text = new TextDecoder().decode(payload)
+          const blob = JSON.parse(text);
+          cntrl.enqueue(blob);
+        }
+      });
+    }
+  });
+}
+
+
+/**
+ * Returns a Promise that Resolves if a Message of the
+ * provided type is returned
+ * @param {String} type
+ * @param {ReadableStream<Message>} messagePipe
+ *
+ * @returns {Promise<ExtensionMessage>} - The Message
+ */
+async function readResponseOfType(type = '', messagePipe) {
+  const reader = messagePipe.getReader();
+  while (true) {
+    const {value} = await reader.read();
+    if (value.t == type) {
+      reader.releaseLock()
+      return value
+    }
+  }
+}
+
+module.exports = {
+  getMessageStream,
+  sentToClient,
+  connectExtension,
+  ExtensionMessage,
+  readResponseOfType
+}

--- a/tests/functional/utils/webextension.js
+++ b/tests/functional/utils/webextension.js
@@ -59,7 +59,8 @@ function getMessageStream(sock = new net.Socket) {
           const out = data.slice(0, len)
           data = data.slice(len)
           return out;
-        } while (data.length != 0) {
+        };
+        while (data.length != 0) {
           const header = nom(4)
           const len = header.readUint32LE(0);
           const payload = nom(len);

--- a/tests/qml/moccontroller.cpp
+++ b/tests/qml/moccontroller.cpp
@@ -15,7 +15,8 @@ void Controller::initialize() {}
 
 void Controller::implInitialized(bool, bool, const QDateTime&) {}
 
-bool Controller::activate(const ServerData&, ServerSelectionPolicy) {
+bool Controller::activate(const ServerData&, ActivationPrincipal user,
+                          ServerSelectionPolicy) {
   return false;
 }
 
@@ -27,9 +28,10 @@ bool Controller::silentSwitchServers(ServerCoolDownPolicyForSilentSwitch) {
 
 bool Controller::silentServerSwitchingSupported() const { return false; }
 
-void Controller::activateInternal(DNSPortPolicy, ServerSelectionPolicy) {}
+void Controller::activateInternal(DNSPortPolicy, ServerSelectionPolicy,
+                                  ActivationPrincipal user) {}
 
-bool Controller::deactivate() { return false; }
+bool Controller::deactivate(ActivationPrincipal user) { return false; }
 
 void Controller::connected(const QString& pubkey) { Q_UNUSED(pubkey); }
 

--- a/tests/unit/moccontroller.cpp
+++ b/tests/unit/moccontroller.cpp
@@ -16,7 +16,8 @@ void Controller::initialize() {}
 
 void Controller::implInitialized(bool, bool, const QDateTime&) {}
 
-bool Controller::activate(const ServerData&, ServerSelectionPolicy) {
+bool Controller::activate(const ServerData&, ActivationPrincipal user,
+                          ServerSelectionPolicy) {
   return false;
 }
 
@@ -28,9 +29,13 @@ bool Controller::silentSwitchServers(ServerCoolDownPolicyForSilentSwitch) {
 
 bool Controller::silentServerSwitchingSupported() const { return false; }
 
-void Controller::activateInternal(DNSPortPolicy, ServerSelectionPolicy) {}
+void Controller::activateInternal(DNSPortPolicy, ServerSelectionPolicy,
+                                  ActivationPrincipal user) {}
 
-bool Controller::deactivate() { return false; }
+bool Controller::deactivate(ActivationPrincipal user) {
+  Q_UNUSED(user);
+  return false;
+}
 
 void Controller::connected(const QString& pubkey) { Q_UNUSED(pubkey); }
 


### PR DESCRIPTION
This pull request introduces support for a new StateOnPartial state in the controller, enhancing the VPN's state management. It also adds an ActivationPrincipal enum to track whether a connection was initiated by a user or an extension, along with corresponding permission checks for deactivation. Additionally, this update includes several new methods and refines existing ones to handle the new state and activation principal, ensuring improved VPN control and security.