### PR TITLE
Follow up to VPN-5969 - fix final 2 strings

### DIFF
--- a/src/extrastrings.h
+++ b/src/extrastrings.h
@@ -41,8 +41,8 @@ void macOSInstallerStrings() {
   //% "Trouble with this installation?"
   qtTrId("macosinstaller.conclusion.message2");
 
-  //% "Help."
-  qtTrId("macosinstaller.conclusion.message3");
+  //% "Help"
+  qtTrId("macosinstaller.conclusion.message31");
 }
 
 };  // namespace ExtraStrings

--- a/src/ui/screens/devices/ViewDeviceLimit.qml
+++ b/src/ui/screens/devices/ViewDeviceLimit.qml
@@ -28,7 +28,7 @@ MZViewBase {
     }
 
     //% "Devices"
-    _menuTitle: qsTrId("vpn.devices.myDevices")
+    _menuTitle: MZI18n.DevicesSectionTitle
 
     _viewContentData: ColumnLayout {
         spacing: MZTheme.theme.vSpacingSmall


### PR DESCRIPTION
## Description

@flodolo [pointed out](https://github.com/mozilla-mobile/mozilla-vpn-client/pull/9484#discussion_r1626396386) that I missed a couple strings in #9484 that were being done the old way.

For the macOS installer string (in `extrastrings.h`), I've maintained the old way of doing translations as we have little translation work in the C++ layer. In part for quickness of a fix (to not have to learn how to pass a variable from new translation system via C++ to our mac installer - and that mac installer is an area of our codebase I'm not familiar with at all), I'm suggesting we keep using the old translation system in this one case.

## Reference

N/A

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
