### PR TITLE
VPN-2387: Fix iOS status bar color on iOS 16

### DIFF
--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -80,6 +80,10 @@
 #  include "adjust/adjusthandler.h"
 #endif
 
+#ifdef MZ_IOS
+#  include "platforms/ios/ioscommons.h"
+#endif
+
 #include <QApplication>
 #include <QDir>
 #include <QFileInfo>
@@ -2214,6 +2218,19 @@ void MozillaVPN::ensureApplicationIdExists() {
   if (!settingsHolder->hasInstallationId()) {
     QString uuid = mozilla::glean::session::installation_id.generateAndSet();
     settingsHolder->setInstallationId(uuid);
+  }
+#endif
+}
+
+// There is a bug for iOS 16 and below where the status bar text is the wrong
+// color when app is restored from background. This fixes the bug. More info:
+// VPN-2387 Remove this code when the app's minimum supported iOS version is
+// iOS 17.
+void MozillaVPN::statusBarCheck() {
+#ifdef MZ_IOS
+  if (QGuiApplication::applicationState() ==
+      Qt::ApplicationState::ApplicationActive) {
+    IOSCommons::statusBarUpdateHack();
   }
 #endif
 }

--- a/src/mozillavpn.h
+++ b/src/mozillavpn.h
@@ -115,6 +115,7 @@ class MozillaVPN final : public App {
   Q_INVOKABLE void requestDeleteAccount();
   Q_INVOKABLE void cancelReauthentication();
   Q_INVOKABLE void updateViewShown();
+  Q_INVOKABLE static void statusBarCheck();
 
   Q_INVOKABLE void gleanSetDebugViewTag(QString tag);
   Q_INVOKABLE void gleanSetLogPings(bool flag);

--- a/src/platforms/ios/ioscommons.h
+++ b/src/platforms/ios/ioscommons.h
@@ -14,6 +14,7 @@ class IOSCommons final {
   static int compareStrings(const QString& a, const QString& b);
 
   static void setStatusBarTextColor(Theme::StatusBarTextColor color);
+  static void statusBarUpdateHack();
 
   static QStringList systemLanguageCodes();
 

--- a/src/platforms/ios/ioscommons.mm
+++ b/src/platforms/ios/ioscommons.mm
@@ -63,6 +63,17 @@ void IOSCommons::setStatusBarTextColor(Theme::StatusBarTextColor color) {
   [rootViewController setNeedsStatusBarAppearanceUpdate];
 }
 
+// There is a bug for iOS 16 and below where the status bar text is the wrong color
+// when app is restored from background. This fixes the bug. More info: VPN-2387
+// Remove this code when the app's minimum supported iOS version is iOS 17.
+void IOSCommons::statusBarUpdateHack() {
+  if (@available(iOS 17, *)) {
+    // No need to update status bar color, as works as expected on iOS 17+.
+  } else {
+    setStatusBarTextColor(Theme::StatusBarTextColorLight);
+  }
+}
+
 // static
 bool IOSCommons::verifySignature(const QByteArray& publicKey, const QByteArray& content,
                                  const QByteArray& signature) {

--- a/src/ui/screens/initialize/ViewInitialize.qml
+++ b/src/ui/screens/initialize/ViewInitialize.qml
@@ -412,4 +412,9 @@ Item {
             statusBarModifier.resetDefaults();
         }
     }
+
+    Connections {
+        target: Qt.application
+        onStateChanged: VPN.statusBarCheck()
+    }
 }

--- a/tests/auth_tests/mocmozillavpn.cpp
+++ b/tests/auth_tests/mocmozillavpn.cpp
@@ -128,5 +128,7 @@ void MozillaVPN::gleanSetDebugViewTag(QString tag) {}
 
 void MozillaVPN::gleanSetLogPings(bool flag) {}
 
+void MozillaVPN::statusBarCheck() {}
+
 // static
 QString MozillaVPN::appVersionForUpdate() { return "42"; }

--- a/tests/qml/mocmozillavpn.cpp
+++ b/tests/qml/mocmozillavpn.cpp
@@ -142,5 +142,7 @@ void MozillaVPN::gleanSetDebugViewTag(QString tag) {}
 
 void MozillaVPN::gleanSetLogPings(bool flag) {}
 
+void MozillaVPN::statusBarCheck() {}
+
 // static
 QString MozillaVPN::appVersionForUpdate() { return "42"; }

--- a/tests/unit/mocmozillavpn.cpp
+++ b/tests/unit/mocmozillavpn.cpp
@@ -155,5 +155,7 @@ void MozillaVPN::gleanSetDebugViewTag(QString tag) {}
 
 void MozillaVPN::gleanSetLogPings(bool flag) {}
 
+void MozillaVPN::statusBarCheck() {}
+
 // static
 QString MozillaVPN::appVersionForUpdate() { return "42"; }

--- a/tests/unit_tests/mocmozillavpn.cpp
+++ b/tests/unit_tests/mocmozillavpn.cpp
@@ -129,5 +129,7 @@ void MozillaVPN::gleanSetDebugViewTag(QString tag) {}
 
 void MozillaVPN::gleanSetLogPings(bool flag) {}
 
+void MozillaVPN::statusBarCheck() {}
+
 // static
 QString MozillaVPN::appVersionForUpdate() { return "42"; }


### PR DESCRIPTION
## Description

This ended up being a bug on iOS 16 only, so the fix only affects iOS 16 and below. Somehow the status bar type is getting reset to `default`, causing the issue here. I checked all the places our code resets it to default, and it didn't seem to be happening in any of those spots - so I made this fix.

Once our minimum iOS version is iOS 17, we can remove this code - and I've left notes in the code that remind us of this.

## Reference

VPN-2387

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
