### PR TITLE
VPN-6445: Bump macos deployment target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,7 +84,7 @@ if(APPLE)
     if(IOS)
         set(CMAKE_OSX_DEPLOYMENT_TARGET 13.0)
     else()
-        set(CMAKE_OSX_DEPLOYMENT_TARGET 10.15)
+        set(CMAKE_OSX_DEPLOYMENT_TARGET 11.0)
     endif()
 endif()
 


### PR DESCRIPTION
## Description

This PR bumps CMAKE_OSX_DEPLOYMENT_TARGET for mac from `10.5` to `11.0`, which is the minimum supported platform for macos in Qt6.6. 

## Reference

VPN-6445

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
