### PR TITLE
VPN-6423: Fix TestQmlPath on Qt 6.6.0 and later

### DIFF
--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -169,6 +169,10 @@ if(NOT BUILD_ADJUST_SDK_TOKEN)
     )
 endif()
 
+if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+    list(APPEND UNIT_TEST_ARGS -platform offscreen)
+endif()
+
 ## Add the tests to be run, one for each test class.
 get_target_property(UTEST_SOURCES app_unit_tests SOURCES)
 list(FILTER UTEST_SOURCES INCLUDE REGEX "test.*.h$")
@@ -181,7 +185,7 @@ foreach(filename ${UTEST_SOURCES})
     )
 
     foreach(UTEST_CLASS ${UTEST_CLASS_LIST})
-        add_test(NAME ${UTEST_CLASS} COMMAND app_unit_tests ${UTEST_CLASS})
+        add_test(NAME ${UTEST_CLASS} COMMAND app_unit_tests ${UNIT_TEST_ARGS} ${UTEST_CLASS})
         set_property(TEST ${UTEST_CLASS} PROPERTY ENVIRONMENT LANG="en" LANGUAGE="en")
     endforeach()
 endforeach()

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -34,6 +34,7 @@ target_compile_definitions(app_unit_tests PRIVATE UNIT_TEST "MZ_$<UPPER_CASE:${M
 target_compile_definitions(app_unit_tests PRIVATE MZ_ADJUST)
 
 target_link_libraries(app_unit_tests PRIVATE
+    Qt6::Gui
     Qt6::Quick
     Qt6::Test
     Qt6::WebSockets

--- a/tests/unit_tests/main.cpp
+++ b/tests/unit_tests/main.cpp
@@ -52,7 +52,7 @@ int main(int argc, char* argv[]) {
   pe.insert("LANG", "en");
   pe.insert("LANGUAGE", "en");
 
-  QCoreApplication app(argc, argv);
+  QGuiApplication app(argc, argv);
 
   I18nStrings::initialize();
 

--- a/tests/unit_tests/qml/a.qml
+++ b/tests/unit_tests/qml/a.qml
@@ -73,13 +73,6 @@ Item {
     }
   }
 
-/*   
-
-  This PathView breaks testqmlpath when run with statically compiled
-  Qt6.6.3 on mac. 
-  
-  See: https://mozilla-hub.atlassian.net/browse/VPN-6423
-
   PathView {
      objectName: "list"
      model: vegetableModel
@@ -87,9 +80,6 @@ Item {
        objectName: name
      }
   }
-
-*/
-
 
   Item {
     objectName: "rangeA"

--- a/tests/unit_tests/testqmlpath.cpp
+++ b/tests/unit_tests/testqmlpath.cpp
@@ -106,22 +106,13 @@ void TestQmlPath::evaluate_data() {
       << "/abc/apple" << true << "apple";
   QTest::addRow("search for apple in repeater") << "//apple" << true << "apple";
 
-  /*
-
-    These tests break when run with statically compiled
-    Qt6.6.3 on mac.
-
-    See: https://mozilla-hub.atlassian.net/browse/VPN-6423
-
-    // objects with contentItem property (lists)
-    QTest::addRow("select item in lists")
-        << "/abc/list/artichoke" << true << "artichoke";
-    QTest::addRow("search for item a lists")
-        << "//artichoke" << true << "artichoke";
-    QTest::addRow("search for list, then item")
-        << "//list/artichoke" << true << "artichoke";
-
-  */
+  // objects with contentItem property (lists)
+  QTest::addRow("select item in lists")
+      << "/abc/list/artichoke" << true << "artichoke";
+  QTest::addRow("search for item a lists")
+      << "//artichoke" << true << "artichoke";
+  QTest::addRow("search for list, then item")
+      << "//list/artichoke" << true << "artichoke";
 
   // Indexing
   QTest::addRow("root index") << "/[0]" << true << "abc";


### PR DESCRIPTION
## Description
The `TestQmlPath` test has been failing for me on Qt 6.6.0 and later, and after a bit digging I traced the crash down into the depths of Qt, which was failing at `qquickpathview.cpp:68:75` with the expression `QGuiApplicationPrivate::platformIntegration()` returning a null pointer. This occurs because the app unit tests are invoked as `QCoreApplication` instead of a `QGuiApplication` so the platform integration plugins are never initialized, leading to the segmentation fault in the QML engine.

There are two reasonable ways to fix this issue:
1. We move this test case into the QML Tests, which does initialize the Gui and QML engine, or
2. We just convert the app unit tests into a GUI application.

I have gone with option 2 here.

## Reference
JIRA issue: [VPN-6423](https://mozilla-hub.atlassian.net/browse/VPN-6423)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-6423]: https://mozilla-hub.atlassian.net/browse/VPN-6423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ