### PR TITLE
Nit: Fix reqwest/libglean dependencies on MacOS

### DIFF
--- a/qtglean/CMakeLists.txt
+++ b/qtglean/CMakeLists.txt
@@ -37,6 +37,12 @@ add_library(qtglean STATIC
 
 )
 
+# The reqwest library depends on SystemConfiguration for MacOS.
+if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+    find_library(FW_SYSTEMCONFIG SystemConfiguration)
+    target_link_libraries(qtglean PRIVATE ${FW_SYSTEMCONFIG})
+endif()
+
 mz_target_handle_warnings(qtglean)
 
 target_include_directories(qtglean PUBLIC


### PR DESCRIPTION
## Description
Recently, I have found myself unable to build tests on MacOS, which ends with the following linker error:

```
Undefined symbols for architecture arm64:
  "_SCDynamicStoreCopyProxies", referenced from:
      system_configuration::dynamic_store::SCDynamicStore::get_proxies::h7cf43ef2a47c43d1 in libqtglean.a(system_configuration-5a1250e520b516c2.system_configuration.6155de0b-cgu.4.rcgu.o)
  "_SCDynamicStoreCreateWithOptions", referenced from:
      system_configuration::dynamic_store::SCDynamicStore::create::hcb281992b6c549d9 in libqtglean.a(system_configuration-5a1250e520b516c2.system_configuration.6155de0b-cgu.4.rcgu.o)
  "_kSCDynamicStoreUseSessionKeys", referenced from:
      system_configuration::dynamic_store::SCDynamicStoreBuilder$LT$T$GT$::create_store_options::h5b5370c6a1f89759 in libqtglean.a(reqwest-9dc02ba4186b92ce.reqwest.1f28d153-cgu.14.rcgu.o)
  "_kSCPropNetProxiesHTTPEnable", referenced from:
      reqwest::proxy::get_from_platform_impl::hcfacbaabd683ec97 in libqtglean.a(reqwest-9dc02ba4186b92ce.reqwest.1f28d153-cgu.1.rcgu.o)
  "_kSCPropNetProxiesHTTPPort", referenced from:
      reqwest::proxy::get_from_platform_impl::hcfacbaabd683ec97 in libqtglean.a(reqwest-9dc02ba4186b92ce.reqwest.1f28d153-cgu.1.rcgu.o)
  "_kSCPropNetProxiesHTTPProxy", referenced from:
      reqwest::proxy::get_from_platform_impl::hcfacbaabd683ec97 in libqtglean.a(reqwest-9dc02ba4186b92ce.reqwest.1f28d153-cgu.1.rcgu.o)
  "_kSCPropNetProxiesHTTPSEnable", referenced from:
      reqwest::proxy::get_from_platform_impl::hcfacbaabd683ec97 in libqtglean.a(reqwest-9dc02ba4186b92ce.reqwest.1f28d153-cgu.1.rcgu.o)
  "_kSCPropNetProxiesHTTPSPort", referenced from:
      reqwest::proxy::get_from_platform_impl::hcfacbaabd683ec97 in libqtglean.a(reqwest-9dc02ba4186b92ce.reqwest.1f28d153-cgu.1.rcgu.o)
  "_kSCPropNetProxiesHTTPSProxy", referenced from:
      reqwest::proxy::get_from_platform_impl::hcfacbaabd683ec97 in libqtglean.a(reqwest-9dc02ba4186b92ce.reqwest.1f28d153-cgu.1.rcgu.o)
ld: symbol(s) not found for architecture arm64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

This seems to have been introduced by commit 5e8f9d1439560ea6e3d277df373db89dcaf29268 which bumped the version of [reqwest](https://github.com/seanmonstar/reqwest) used by Glean, which now depends on the `SystemConfiguration` framework in order to pull HTTP proxy configuration from MacOS. We don't notice this in our app builds because we already use `SystemConfiguration` elsewhere in the VPN app, but it's not presently used anywhere for tests.

## Reference

    i.e Jira or Github issue URL

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
