### PR TITLE
Fix iOS toolchain generation

### DIFF
--- a/scripts/macos/conda_setup_qt.sh
+++ b/scripts/macos/conda_setup_qt.sh
@@ -16,6 +16,7 @@ else
 fi
 
 export QT_DIR=$CONDA_PREFIX/Qt
+set -e
 # QT_Host Tools
 python -m aqt install-qt --outputdir $QT_DIR $HOST_TARGET -m all
 # QT Android Tools


### PR DESCRIPTION
## Description

if `scripts/macos/conda_setup_qt.sh` fails due to a network error we still continue and cache that. 
This butched the iOS conda toolchain. So let's fix that, and let it fail so tc can resheudle.. 
