### PR TITLE
MSVC: Disable warning 5105 to fix error in winbase.h

### DIFF
--- a/src/cmake/msvc.cmake
+++ b/src/cmake/msvc.cmake
@@ -12,7 +12,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang$")
 else()
     # /MP -> Compile Files Paraell
     # /Zc:preprocessor -> Enable Modern Macros, needed for settingsholder
-    set(CMAKE_CXX_FLAGS  "/MP /Zc:preprocessor")
+    set(CMAKE_CXX_FLAGS  "/MP /Zc:preprocessor /wd5105")
     # Enable "edit and continue" when using msvc + debug build
     set(CMAKE_CXX_FLAGS_DEBUG  "/MTd /ZI /Ob0 /Od /RTC1")
     set(CMAKE_CXX_FLAGS_DEBUG  "/MTd /ZI /Ob0 /Od /RTC1")


### PR DESCRIPTION
## Description
When compiling with MSVC (VisualStudio 2019), the compilation fails with on a warning in `winbase.h` due to macro expansion rules:
```
C:\Program Files (x86)\Windows Kits\10\Include\10.0.19041.0\um\winbase.h(9461,5): warning C5105: macro expansion producing 'defined' has undefined behavior
```

## Reference

    i.e Jira or Github issue URL

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
