### PR TITLE
MacOSCryptoSettings: Disable encryption if keychain entitlement is missing

### DIFF
--- a/src/platforms/macos/macoscryptosettings.h
+++ b/src/platforms/macos/macoscryptosettings.h
@@ -14,10 +14,16 @@ class MacOSCryptoSettings final : public CryptoSettings {
 
   void resetKey() override;
   QByteArray getKey(const QByteArray& metadata) override;
-  CryptoSettings::Version getSupportedVersion() override;
+  CryptoSettings::Version getSupportedVersion() override {
+    return m_keyVersion;
+  }
 
  private:
+  static bool checkCodesign();
+  static bool checkEntitlement(const QString& name);
+
   bool m_initialized = false;
+  CryptoSettings::Version m_keyVersion = CryptoSettings::NoEncryption;
   QByteArray m_key;
   QString m_appId;
 };

--- a/src/platforms/macos/macoscryptosettings.mm
+++ b/src/platforms/macos/macoscryptosettings.mm
@@ -9,7 +9,9 @@
 #include "logger.h"
 
 #import <Foundation/Foundation.h>
-#import <Security/SecTask.h>
+#ifdef MZ_MACOS
+#  import <Security/SecTask.h>
+#endif
 
 namespace {
 Logger logger("MacOSCryptoSettings");
@@ -138,7 +140,7 @@ bool MacOSCryptoSettings::checkCodesign() {
 
 // static
 bool MacOSCryptoSettings::checkEntitlement(const QString& name) {
-#ifdef MZ_MACOS  // Convert the entitlement to a string.
+#ifdef MZ_MACOS
   SecTaskRef task = SecTaskCreateFromSelf(kCFAllocatorSystemDefault);
   if (task == nullptr) {
     return false;

--- a/src/platforms/macos/macoscryptosettings.mm
+++ b/src/platforms/macos/macoscryptosettings.mm
@@ -9,12 +9,21 @@
 #include "logger.h"
 
 #import <Foundation/Foundation.h>
+#import <Security/SecTask.h>
 
 namespace {
 Logger logger("MacOSCryptoSettings");
 }  // namespace
 
 MacOSCryptoSettings::MacOSCryptoSettings() : CryptoSettings() {
+  if (checkCodesign() && checkEntitlement("keychain-access-groups")) {
+    // If we are signed and have entitlements - we can use the encryption key.
+    m_keyVersion = CryptoSettings::EncryptionChachaPolyV1;
+  } else {
+    logger.warning() << "Disabling encryption: Codesign is invalid";
+    m_keyVersion = CryptoSettings::NoEncryption;
+  }
+
   NSString* appId = [[NSBundle mainBundle] bundleIdentifier];
   if (appId) {
     m_appId = QString::fromNSString(appId);
@@ -106,13 +115,63 @@ QByteArray MacOSCryptoSettings::getKey(const QByteArray& metadata) {
   return m_key;
 }
 
-CryptoSettings::Version MacOSCryptoSettings::getSupportedVersion() {
-  logger.debug() << "Get supported settings method";
-
-  if (getKey(QByteArray()).isEmpty()) {
-    logger.debug() << "No encryption";
-    return CryptoSettings::NoEncryption;
+// static
+bool MacOSCryptoSettings::checkCodesign() {
+#ifdef MZ_MACOS
+  SecTaskRef task = SecTaskCreateFromSelf(kCFAllocatorSystemDefault);
+  CFStringRef signer = SecTaskCopySigningIdentifier(task, nullptr);
+  CFRelease(task);
+  if (signer != nullptr) {
+    logger.debug() << "Got signature from:"
+                   << QString::fromNSString(static_cast<NSString*>(signer));
+    CFRelease(signer);
+    return true;
   }
-  logger.debug() << "Encryption supported!";
-  return CryptoSettings::EncryptionChachaPolyV1;
+  return false;
+#else
+  // For iOS we probably need to roll our own solution by calling the
+  // csopt syscall directly, as the SecTask framework is only available
+  // for MacOS.
+  return true;
+#endif
+}
+
+// static
+bool MacOSCryptoSettings::checkEntitlement(const QString& name) {
+#ifdef MZ_MACOS  // Convert the entitlement to a string.
+  SecTaskRef task = SecTaskCreateFromSelf(kCFAllocatorSystemDefault);
+  if (task == nullptr) {
+    return false;
+  }
+  CFStringRef cfName = CFStringCreateWithCString(
+      kCFAllocatorSystemDefault, qUtf8Printable(name), kCFStringEncodingUTF8);
+  auto guard = qScopeGuard([&] {
+    CFRelease(task);
+    CFRelease(cfName);
+  });
+
+  CFErrorRef error = nullptr;
+  CFTypeRef result = SecTaskCopyValueForEntitlement(task, cfName, &error);
+  if (error != nullptr) {
+    CFStringRef desc = CFErrorCopyDescription(error);
+    logger.error() << "Failed to check entitlements:"
+                   << QString::fromNSString(static_cast<NSString*>(desc));
+    CFRelease(desc);
+    CFRelease(error);
+  }
+  if (result != nullptr) {
+    CFRelease(result);
+  }
+
+  // Return success if we got anything back from the entitlement.
+  return (result != nullptr);
+#else
+  // For iOS we probably need to roll our own solution by calling the
+  // csopt syscall directly, as the SecTask methods are only available
+  // for MacOS.
+  //
+  // Check out https://github.com/Apple-FOSS-Mirror/security_systemkeychain/
+  // for inspiration, specifically the procinfo() function in src/cs_misc.cpp.
+  return true;
+#endif
 }


### PR DESCRIPTION
## Description
As noted in the discussion of #9584 we have a need to be a bit smarter in how and when we enable cryposettings on MacOS. Traditionally this was done at compile time by doing a no-op for the `getKey()` in the dummy builds, but this should really be done by examining the processes' entitlements to know whether the binary can access the encrypted settings. The entitlement that guards this access is the `keychain-access-group` permission.

Normally, when this entitlement is missing, the user is greeted with a login prompt asking for the user's password before permitting them access to the keychain, which is a minor annoyance for developers. This PR will also make unsigned developer builds fall back to plaintext settings instead of triggering such a prompt.

## Reference
Inciting PR: #9584 
Discussion: [here](https://github.com/mozilla-mobile/mozilla-vpn-client/pull/9584#discussion_r1648168969)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
