### PR TITLE
VPN-6473: Add addon condition for OS version

### DIFF
--- a/addons/message_survey_staging_30m/manifest.json
+++ b/addons/message_survey_staging_30m/manifest.json
@@ -6,6 +6,8 @@
   "type": "message",
   "conditions": {
     "env": "staging",
+    "min_os_version": {"ios": "14.0", "macos": "12.4"},
+    "max_os_version": {"ios": "24", "macos": "19.4"},
     "translation_threshold": 0,
     "trigger_time": 1800
   },

--- a/docs/Components/Addons/index.md
+++ b/docs/Components/Addons/index.md
@@ -87,6 +87,8 @@ Add-ons can enable and disable themselves using the `conditions` key in the mani
 | locales | An array of locales to be checked | Array of string | No | Yes |
 | min_client_version | The min client version | String | No | No |
 | max_client_version | The max client version | String | No | No |
+| min_os_version | The max OS version | String | No | No |
+| max_os_version | The max OS version | String | No | No |
 | platforms | An array of platforms to be checked | Array of string | No | No |
 | settings | An array of Condition Setting object. See below | Array of Condition Setting object | No | No |
 | trigger_time | A number identifying the number of seconds from the first execution of the client | Integer |  No | Yes |
@@ -162,7 +164,7 @@ cmake --build build-addons
 
 4. Expose the generated build directory through a webservice. For example: `python3 -m http.server --directory build-addons/`
 5. Open the dev-menu from the get-help view and set a custom add-on URL: `http://localhost:8000/`
-6. Scroll down and disable the signature-addon feature from the dev-menu, list of features
+6. In the dev menu's list of features, disable the addon-signature feature
 7. Be sure you are doing all of this using a staging environment
 
 If all has done correctly, you can see the app fetching the manifest.json (and

--- a/scripts/ci/jsonSchemas/conditions.json
+++ b/scripts/ci/jsonSchemas/conditions.json
@@ -28,11 +28,61 @@
     },
     "min_client_version": {
       "type": "string",
-      "description": "Enable the addon only if the client version is eq or higher than this valie"
+      "description": "Enable the addon only if the client version is eq or higher than this value"
     },
     "max_client_version": {
       "type": "string",
-      "description": "Enable the addon only if the client version is eq or lower than this valie"
+      "description": "Enable the addon only if the client version is eq or lower than this value"
+    },
+    "min_os_version": {
+      "type": "object",
+      "description": "Enable the addon only if the os version is eq or lower than given value. Do not need to list all platforms - Missing platforms will enable the addon (if other conditions match).",
+      "properties": {
+        "macos": {
+          "type": "string",
+          "description": "macos minimum version"
+        },
+        "linux": {
+          "type": "string",
+          "description": "linux minimum version"
+        },
+        "windows": {
+          "type": "string",
+          "description": "windows minimum version"
+        },
+        "ios": {
+          "type": "string",
+          "description": "ios minimum version"
+        },
+        "android": {
+          "type": "string",
+          "description": "android minimum version"
+        }
+    },
+    "max_os_version": {
+      "type": "object",
+      "description": "Enable the addon only if the os version is eq or higher than given value. Do not need to list all platforms - Missing platforms will enable the addon (if other conditions match).",
+      "properties": {
+        "macos": {
+          "type": "string",
+          "description": "macos maximum version"
+        },
+        "linux": {
+          "type": "string",
+          "description": "linux maximum version"
+        },
+        "windows": {
+          "type": "string",
+          "description": "windows maximum version"
+        },
+        "ios": {
+          "type": "string",
+          "description": "ios maximum version"
+        },
+        "android": {
+          "type": "string",
+          "description": "android maximum version"
+        }
     },
     "platforms": {
       "type": "array",

--- a/src/addons/addon.cpp
+++ b/src/addons/addon.cpp
@@ -202,7 +202,7 @@ QList<ConditionCallback> s_conditionCallbacks{
 
        if (!min.isEmpty() &&
            VersionUtils::compareVersions(min, currentVersion) == 1) {
-         logger.info() << "Min version is" << min << " curent"
+         logger.info() << "Min version is" << min << " current"
                        << currentVersion;
          return false;
        }
@@ -221,11 +221,66 @@ QList<ConditionCallback> s_conditionCallbacks{
 
        if (!max.isEmpty() &&
            VersionUtils::compareVersions(max, currentVersion) == -1) {
-         logger.info() << "Max version is" << max << " curent"
+         logger.info() << "Max version is" << max << " current"
                        << currentVersion;
          return false;
        }
 
+       return true;
+     },
+     [](QObject*, const QJsonValue&) -> AddonConditionWatcher* {
+       return nullptr;
+     },
+     nullptr},
+
+    {"min_os_version",
+     [](const QJsonValue& value) -> bool {
+       QJsonObject minOsDictionary = value.toObject();
+
+       QString currentPlatform = Env::platform();
+       if (minOsDictionary.isEmpty()) {
+         return true;
+       }
+
+       for (const QString& key : minOsDictionary.keys()) {
+         if (currentPlatform == key) {
+           QString currentVersion = Env::osVersion();
+           QString minOsVersion = minOsDictionary[key].toString();
+           logger.info() << "Min OS version is" << minOsVersion << " current"
+                         << currentVersion;
+           return (VersionUtils::compareVersions(minOsVersion,
+                                                 currentVersion) <= 0);
+         }
+       }
+
+       logger.info() << "Min OS rule not set for" << currentPlatform;
+       return true;
+     },
+     [](QObject*, const QJsonValue&) -> AddonConditionWatcher* {
+       return nullptr;
+     },
+     nullptr},
+
+    {"max_os_version",
+     [](const QJsonValue& value) -> bool {
+       QJsonObject maxOsDictionary = value.toObject();
+       QString currentPlatform = Env::platform();
+       if (maxOsDictionary.isEmpty()) {
+         return true;
+       }
+
+       for (const QString& key : maxOsDictionary.keys()) {
+         if (currentPlatform == key) {
+           QString currentVersion = Env::osVersion();
+           QString maxOsVersion = maxOsDictionary[key].toString();
+           logger.info() << "Max OS version is" << maxOsVersion << " current"
+                         << currentVersion;
+           return (VersionUtils::compareVersions(maxOsVersion,
+                                                 currentVersion) >= 0);
+         }
+       }
+
+       logger.info() << "Min OS rule not set for" << currentPlatform;
        return true;
      },
      [](QObject*, const QJsonValue&) -> AddonConditionWatcher* {


### PR DESCRIPTION
## Description

New addon conditions that looks at version of OS on a per-OS level.

Not sure what here triggered @flodolo 's review - let me know if I somehow messed with translations.

## Reference

VPN-6473

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
