### PR TITLE
VPN-5588 Add OS Version to balrog requests

### DIFF
--- a/src/platforms/windows/windowsutils.cpp
+++ b/src/platforms/windows/windowsutils.cpp
@@ -16,9 +16,6 @@ namespace {
 Logger logger("WindowsUtils");
 }  // namespace
 
-constexpr const int WINDOWS_11_BUILD =
-    22000;  // Build Number of the first release win 11 iso
-
 QString WindowsUtils::getErrorMessage(quint32 code) {
   LPSTR messageBuffer = nullptr;
   size_t size = FormatMessageA(
@@ -45,15 +42,11 @@ void WindowsUtils::windowsLog(const QString& msg) {
 
 // Static
 QString WindowsUtils::windowsVersion() {
-  QSettings regCurrentVersion(
+    QSettings regCurrentVersion(
       "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion",
       QSettings::NativeFormat);
 
-  int buildNr = regCurrentVersion.value("CurrentBuild").toInt();
-  if (buildNr >= WINDOWS_11_BUILD) {
-    return "11";
-  }
-  return QSysInfo::productVersion();
+  return regCurrentVersion.value("CurrentBuild");
 }
 
 // static

--- a/src/platforms/windows/windowsutils.cpp
+++ b/src/platforms/windows/windowsutils.cpp
@@ -42,7 +42,7 @@ void WindowsUtils::windowsLog(const QString& msg) {
 
 // Static
 QString WindowsUtils::windowsVersion() {
-    QSettings regCurrentVersion(
+  QSettings regCurrentVersion(
       "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion",
       QSettings::NativeFormat);
 

--- a/src/platforms/windows/windowsutils.cpp
+++ b/src/platforms/windows/windowsutils.cpp
@@ -46,7 +46,7 @@ QString WindowsUtils::windowsVersion() {
       "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion",
       QSettings::NativeFormat);
 
-  return regCurrentVersion.value("CurrentBuild");
+  return regCurrentVersion.value("CurrentBuild").toString();
 }
 
 // static

--- a/src/update/balrog.cpp
+++ b/src/update/balrog.cpp
@@ -14,6 +14,7 @@
 #include <QSslKey>
 
 #include "constants.h"
+#include "env.h"
 #include "errorhandler.h"
 #include "feature/feature.h"
 #include "glean/generated/metrics.h"
@@ -38,9 +39,9 @@ bool verify_content_signature(const char* x5u_ptr, size_t x5u_length,
 }
 
 #if defined(MZ_WINDOWS)
-constexpr const char* BALROG_WINDOWS_UA = "WINNT_x86_64";
+constexpr const char* BALROG_WINDOWS_BUILD_TARGET = "WINNT_x86_64";
 #elif defined(MZ_MACOS)
-constexpr const char* BALROG_MACOS_UA = "Darwin_x86";
+constexpr const char* BALROG_MACOS_BUILD_TARGET = "Darwin_x86";
 #else
 #  error Platform not supported yet
 #endif
@@ -70,13 +71,13 @@ Balrog::~Balrog() {
 }
 
 // static
-QString Balrog::userAgent() {
+QString Balrog::buildTarget() {
 #if defined(MZ_WINDOWS)
-  return BALROG_WINDOWS_UA;
+  return BALROG_WINDOWS_BUILD_TARGET;
 #elif defined(MZ_MACOS)
-  return BALROG_MACOS_UA;
+  return BALROG_MACOS_BUILD_TARGET;
 #else
-#  error Unsupported platform
+#  error Balrog: Unsupported platform
 #endif
 }
 
@@ -502,8 +503,8 @@ QString Balrog::balrogUrl() {
     channel = "release-cdntest";
   }
 
-  QStringList path = {"json",      "1",     product,      appVersion(),
-                      userAgent(), channel, "update.json"};
+  QStringList path = {"json",        "2",     product,          appVersion(),
+                      buildTarget(), channel, Env::osVersion(), "update.json"};
   QUrl url;
   url.setScheme("https");
   url.setHost(hostname);

--- a/src/update/balrog.h
+++ b/src/update/balrog.h
@@ -25,8 +25,6 @@ class Balrog final : public Updater {
   void start(Task* task) override;
 
  private:
-  static QString userAgent();
-
   bool processData(Task* task, const QByteArray& data);
   bool fetchSignature(Task* task, NetworkRequest* request,
                       const QByteArray& data);
@@ -44,6 +42,7 @@ class Balrog final : public Updater {
                       QNetworkReply::NetworkError error);
 
  private:
+  static QString buildTarget();
   static QString balrogUrl();
   static QStringList rootCertHashes();
   TemporaryDir m_tmpDir;


### PR DESCRIPTION
## Description
Thanks to -> https://github.com/mozilla-releng/balrog/issues/3071 
We can now add the OS version to balrog requests to depricate specific versions. 

This PR adds the env::Osversion into that request. Also we change the behavior of windows detection, we just report build number. Otherwise we can only select for "Windows 11 or Windows 10" vs windows 11-22-H1.  
Just see how many builds there are 💀 
https://learn.microsoft.com/en-us/windows/release-health/windows11-release-information
https://learn.microsoft.com/en-us/windows/release-health/release-information

