### PR TITLE
VPN-6473: check for OS in addons

### DIFF
--- a/addons/message_update_v2.23/manifest.json
+++ b/addons/message_update_v2.23/manifest.json
@@ -4,7 +4,8 @@
   "name": "Update to Mozilla VPN 2.23",
   "type": "message",
   "conditions": {
-    "max_client_version": "2.22.9"
+    "max_client_version": "2.22.9",
+    "javascript": "osCheck.js"
   },
   "javascript": {
     "enable": "enable.js"

--- a/addons/message_update_v2.23/osCheck.js
+++ b/addons/message_update_v2.23/osCheck.js
@@ -1,0 +1,23 @@
+// Disable on iOS 13 and earlier
+(function(api, condition) {
+  // First check for iOS...
+  const isIOS = (api.env.platform === "ios");
+  if (!isIOS) {
+    condition.enable();
+    return;
+  }
+
+  // ...then check for iOS 14 or later
+  const minVersion = 14;
+  const osVersion = api.env.osVersion;
+  if (!osVersion || (typeof osVersion !== "string") || osVersion.length === 0) {
+    // Something unexpected happened. Enable on failure.
+    condition.enable();
+    return;
+  }
+  const majorVersionString = osVersion.split(".", 1)[0];
+  const majorVersion = Number(majorVersionString);
+
+  majorVersion >= minVersion ? condition.enable() : condition.disable();
+});
+  


### PR DESCRIPTION
## Description

Checking OS via a JS condition.

I don't believe this adds any translations, but perhaps those strings did something weird? I'm not sure why @flodolo got auto-added to this PR.

This PR overrides https://github.com/mozilla-mobile/mozilla-vpn-client/pull/9686. However, I'm keeping that one open for now - I asked whether we want to modify that to add the condition in, so that we can use it in the future once enough users are on a version that include that condition.

Also, I might be doing over-defensive code with this check: `if (!osVersion || (typeof osVersion !== "string") || osVersion.length === 0)`. I don't write JS often; please let me know if there is a better way to do this.

## Reference

VPN-6473

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
