### PR TITLE
VPN-6487: Remove "reset and quit" from dev menu

### DIFF
--- a/src/ui/screens/getHelp/developerMenu/ViewDeveloperMenu.qml
+++ b/src/ui/screens/getHelp/developerMenu/ViewDeveloperMenu.qml
@@ -275,27 +275,10 @@ MZViewBase {
             }
         }
 
-        MZButton {
-            id: resetAndQuit
-            objectName: "resetAndQuitButton"
-            property int clickNeeded: 5
-
-            text: "Reset and Quit"
-            onClicked: {
-                if (clickNeeded) {
-                    text = "Reset and Quit (" + clickNeeded + ")";
-                    --clickNeeded;
-                    return;
-                }
-
-                VPN.hardResetAndQuit()
-            }
-        }
-
         ColumnLayout {
             Layout.alignment: Qt.AlignHCenter
             Layout.fillWidth: true
-            Layout.maximumWidth: resetAndQuit.width
+            Layout.maximumWidth: unstableNetworkExtension.width
             Layout.topMargin: MZTheme.theme.vSpacingSmall
 
             MZTextBlock {

--- a/tests/functional/queries.js
+++ b/tests/functional/queries.js
@@ -265,8 +265,7 @@ const screenGetHelp = {
 };
 
 const screenDeveloperMenu = {
-  SCREEN: new QmlQueryComposer('//developerScreen-flickable'),
-  RESET_AND_QUIT_BUTTON: new QmlQueryComposer('//resetAndQuitButton'),
+  SCREEN: new QmlQueryComposer('//developerScreen-flickable')
 };
 
 const screenSettings = {

--- a/tests/functional/testSettings.js
+++ b/tests/functional/testSettings.js
@@ -915,55 +915,6 @@ describe('Settings', function() {
     await vpn.waitForQuery(queries.screenSettings.USER_PROFILE.visible());
   });
 
-  it('Checking Developer Menu Reset and Quit', async () => {
-    // WASM is failing at relaunching the app, so skip this test on WASM
-    if (this.ctx.wasm) {
-      return;
-    }
-
-    // magically unlock dev menu
-    await vpn.setSetting('developerUnlock', 'true');
-
-    // navigate to Developer Menu
-    await getToGetHelpView();
-    await vpn.waitForQueryAndClick(
-        queries.screenGetHelp.DEVELOPER_MENU.visible());
-
-    // click "reset and quit" 6 times, test will fail if app quits early
-    await vpn.waitForQuery(
-        queries.screenDeveloperMenu.RESET_AND_QUIT_BUTTON.visible());
-    await vpn.scrollToQuery(
-        queries.screenDeveloperMenu.SCREEN,
-        queries.screenDeveloperMenu.RESET_AND_QUIT_BUTTON);
-    await vpn.waitForQueryAndClick(
-        queries.screenDeveloperMenu.RESET_AND_QUIT_BUTTON.visible());
-    await vpn.waitForQueryAndClick(
-        queries.screenDeveloperMenu.RESET_AND_QUIT_BUTTON.visible());
-    await vpn.waitForQueryAndClick(
-        queries.screenDeveloperMenu.RESET_AND_QUIT_BUTTON.visible());
-    await vpn.waitForQueryAndClick(
-        queries.screenDeveloperMenu.RESET_AND_QUIT_BUTTON.visible());
-    await vpn.waitForQueryAndClick(
-        queries.screenDeveloperMenu.RESET_AND_QUIT_BUTTON.visible());
-    // can't use waitForQueryAndClick for final click because it returns an
-    // error - as expected, we crashed the app - but that causes test to fail
-    await vpn.clickOnQueryAndAcceptAnyResults(
-        queries.screenDeveloperMenu.RESET_AND_QUIT_BUTTON.visible());
-
-    // Confirm the app quit
-    assert.equal(setup.vpnIsInactive(), true);
-
-    // relaunch app
-    await setup.startAndConnect();
-    await vpn.setSetting('localhostRequestsOnly', 'true');
-    await vpn.authenticateInApp();
-    await vpn.setGleanAutomationHeader();
-
-    // turn on VPN
-    await vpn.activateViaToggle();
-    await vpn.awaitSuccessfulConnection();
-  });
-
   describe('telemetry in the settings menu', function () {
     this.ctx.authenticationNeeded = true;
 


### PR DESCRIPTION
## Description

Now that this is a public feature, we're removing it from the dev menu.

<img width="154" alt="Screenshot 13" src="https://github.com/mozilla-mobile/mozilla-vpn-client/assets/9295855/87f82678-d3f9-4226-80d8-a39868b6ffd3">

I also removed the test. I kept the currently-unused developer screen menu in `tests/.../queries.js` in case we want to use it in the future. Happy to remove it if y'all think it would be cleaner.

## Reference

VPN-6487

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
