### PR TITLE
Extend metric expiration date

### DIFF
--- a/src/telemetry/metrics.yaml
+++ b/src/telemetry/metrics.yaml
@@ -704,7 +704,7 @@ connection_health:
     notification_emails:
       - mcleinman@mozilla.com
       - vpn-telemetry@mozilla.com
-    expires: 2024-07-15
+    expires: 2025-04-15
 
   changed_to_unstable:
     type: event
@@ -732,7 +732,7 @@ connection_health:
     notification_emails:
       - mcleinman@mozilla.com
       - vpn-telemetry@mozilla.com
-    expires: 2024-07-15
+    expires: 2025-04-15
 
   changed_to_stable:
     type: event
@@ -760,7 +760,7 @@ connection_health:
     notification_emails:
       - mcleinman@mozilla.com
       - vpn-telemetry@mozilla.com
-    expires: 2024-07-15
+    expires: 2025-04-15
 
   changed_to_pending:
     type: event
@@ -783,7 +783,7 @@ connection_health:
     notification_emails:
       - mcleinman@mozilla.com
       - vpn-telemetry@mozilla.com
-    expires: 2024-07-15
+    expires: 2025-04-15
 
   no_signal_count:
     type: counter
@@ -810,7 +810,7 @@ connection_health:
     notification_emails:
       - mcleinman@mozilla.com
       - vpn-telemetry@mozilla.com
-    expires: 2024-07-15
+    expires: 2025-04-15
 
   unstable_count:
     type: counter
@@ -837,7 +837,7 @@ connection_health:
     notification_emails:
       - mcleinman@mozilla.com
       - vpn-telemetry@mozilla.com
-    expires: 2024-07-15
+    expires: 2025-04-15
 
   stable_count:
     type: counter
@@ -864,7 +864,7 @@ connection_health:
     notification_emails:
       - mcleinman@mozilla.com
       - vpn-telemetry@mozilla.com
-    expires: 2024-07-15
+    expires: 2025-04-15
 
   pending_count:
     type: counter
@@ -889,7 +889,7 @@ connection_health:
     notification_emails:
       - mcleinman@mozilla.com
       - vpn-telemetry@mozilla.com
-    expires: 2024-07-15
+    expires: 2025-04-15
 
   no_signal_time:
     type: timing_distribution
@@ -912,7 +912,7 @@ connection_health:
     notification_emails:
       - mcleinman@mozilla.com
       - vpn-telemetry@mozilla.com
-    expires: 2024-07-15
+    expires: 2025-04-15
 
   unstable_time:
     type: timing_distribution
@@ -935,7 +935,7 @@ connection_health:
     notification_emails:
       - mcleinman@mozilla.com
       - vpn-telemetry@mozilla.com
-    expires: 2024-07-15
+    expires: 2025-04-15
 
   stable_time:
     type: timing_distribution
@@ -958,7 +958,7 @@ connection_health:
     notification_emails:
       - mcleinman@mozilla.com
       - vpn-telemetry@mozilla.com
-    expires: 2024-07-15
+    expires: 2025-04-15
 
   pending_time:
     type: timing_distribution
@@ -976,7 +976,7 @@ connection_health:
     notification_emails:
       - mcleinman@mozilla.com
       - vpn-telemetry@mozilla.com
-    expires: 2024-07-15
+    expires: 2025-04-15
 
   ping_analyzer_error:
     type: event


### PR DESCRIPTION
# On draft until data review is complete
---

## Description

In https://github.com/mozilla-mobile/mozilla-vpn-client/pull/9057/, we added several new metrics to measure connection health. From that PR: `We're adding 9 new metrics, and removing a bunch as well. We think that some subset of these 9 will be most useful, but aren't quite sure. Thus, these metrics all will live for about 6 months, and we'll then evaluate the data and decide which ones to keep in perpetuity.`

Unfortunately, according to our Product Manager, we're still figuring out how to best analyze this new data in Looker, and these metrics expire in 2 weeks. This PR adds another 9 months to continue the experiment of figuring out which subset should get an expiration of "never", and which should be removed.

## Reference

N/A

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
