### PR TITLE
Nit: Fix timing jitter in AddonConditionWatcherTriggerTimeSecs

### DIFF
--- a/src/addons/conditionwatchers/addonconditionwatchertriggertimesecs.cpp
+++ b/src/addons/conditionwatchers/addonconditionwatchertriggertimesecs.cpp
@@ -45,19 +45,15 @@ bool AddonConditionWatcherTriggerTimeSecs::conditionApplied() const {
 
 bool AddonConditionWatcherTriggerTimeSecs::maybeStartTimer() {
   QDateTime now = QDateTime::currentDateTime();
-  QDateTime installation = SettingsHolder::instance()->installationTime();
+  QDateTime expire =
+      SettingsHolder::instance()->installationTime().addSecs(m_triggerTimeSecs);
 
-  // Note: triggerTimeSecs is seconds!
-  CheckedInt<int> secs =
-      static_cast<int>(m_triggerTimeSecs - installation.secsTo(now));
-  if (secs.value() <= 0) {
+  if (expire <= now) {
     return true;
   }
 
   m_timer.setSingleShot(true);
-  secs *= 1000;
-  m_timer.start(secs.isValid() ? secs.value()
-                               : std::numeric_limits<int>::max());
+  m_timer.start(now.msecsTo(expire));
 
   return false;
 }


### PR DESCRIPTION
## Description
Have you been experiencing unstable unit tests in the `TestAddon::conditionWatcher_group()` test case? Well we have an exciting, limited time offer for you! A fix to the addon condition time calculation now available for the low LOW price of one r+ to this simple PR!

The gist of the issue is that addon condition times are specified in seconds relative to the installation time, but the installation time is stored in milliseconds. The truncation in handling the expiration calculation can result in a second of jitter around the actual emission of the `conditionChanged()` signal. Sometimes, when the jitter overlaps we can wind up with the conditions going true in reverse order, which is what causes this test to fail.

To fix this, I felt the best approach was to do all the math in milliseconds, which is kind of the native unit of the `QDateTime` class which eliminates the need to do our own timestamp math.
 
To reproduce the issue, build the unit tests and then torture them in the following loop. Without this change it dies after a handful of iterations.
```
while ./tests/unit_tests/app_unit_tests TestAddon; do rm ~/.config/mozilla_testing/vpn_unit.moz; done
```



## Reference
Example test failures: [seen here](https://github.com/mozilla-mobile/mozilla-vpn-client/actions/runs/9766509723/job/26959641876?pr=9674)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
