### PR TITLE
Fix log truncation in Wasm tests

### DIFF
--- a/tests/functional/setupWasm.js
+++ b/tests/functional/setupWasm.js
@@ -35,6 +35,7 @@ const stdout = path.join(tmpdir(), "wasm-stdout.txt");
 let driver;
 let url;
 let logServer;
+let logSocket;
 
 exports.mochaHooks = {
   async beforeAll() {
@@ -63,7 +64,7 @@ exports.mochaHooks = {
       fs.rmSync(pipePath, {'force': true});
     });
 
-    let logSocket = net.createConnection(pipePath);
+    logSocket = net.createConnection(pipePath);
     logSocket.on('close', () => {
       logSocket.destroy();
     });
@@ -118,6 +119,7 @@ exports.mochaHooks = {
 
     await driver.quit();
 
+    logSocket.destroy();
     logServer.close();
   },
 


### PR DESCRIPTION
## Description
Sometimes, when a Wasm functional test fails and gets rerun, the log files are mangled and a closer examination shows that they are full of null characters. This seems to be due to a bug in how we handle the lot output from the Firefox webdriver, which doesn't really truncate the logs correctly.

A synopsis of how this bug occurs:
1. The `beforeAll()` hook spawns the webdriver and tells it to write Firefox's `stdout` to a file.
2. The `afterEach()` hook checks for the results of the test, dumps the log file to the test runner's console, and then truncates the log file.
3. However! Because the file descriptor passed to Firefox is still open, it is still pointing at some offset way into the file.
4. The next time firefox writes anything the write occurs at an offset, and Linux does a sparse allocation to fill the preceeding bytes of the file with zeroes.
5. Therefore, because Firefox's file descriptor never seeks back to zero, the file grows with each test, and the initial contents of the file are just zeroes.

Normally, we don't notice the issue as the null bytes just get eaten by the console on each attempt but eventually the log file can get large enough that Github starts to choke on the output.

Because we can't perform a seek on Firefox's file descriptor, the solution to this problem is to create some kind of log handler in the test runner which can flush the logs between test runs. We make use of a UNIX domain socket (provided by  the node.js [net](https://nodejs.org/api/net.html) module) to receive and handle log messages from Firefox.

## Reference
Example test failures: [seen here](https://github.com/mozilla-mobile/mozilla-vpn-client/actions/runs/9766509732/job/26960173267)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
