### PR TITLE
VPN-5589: Add system tray notification for connection failures

### DIFF
--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -1350,6 +1350,11 @@ void MozillaVPN::registerUrlOpenerLabels() {
 void MozillaVPN::errorHandled() {
   ErrorHandler::AlertType alert = ErrorHandler::instance()->alert();
 
+  // Controller errors should trigger a system tray notification.
+  if (alert == ErrorHandler::ControllerErrorAlert) {
+    NotificationHandler::instance()->connectionFailureNotification();
+  }
+
   // Any error in authenticating state sends to the Initial state.
   if (state() == App::StateAuthenticating) {
     if (alert == ErrorHandler::GeoIpRestrictionAlert) {

--- a/src/notificationhandler.cpp
+++ b/src/notificationhandler.cpp
@@ -340,6 +340,21 @@ void NotificationHandler::subscriptionNotFoundNotification() {
                  Constants::DEFAULT_OS_NOTIFICATION_MSEC);
 }
 
+void NotificationHandler::connectionFailureNotification() {
+  logger.debug() << "connection failure notification";
+
+  I18nStrings* i18nStrings = I18nStrings::instance();
+  Q_ASSERT(i18nStrings);
+
+  QString notificationTitle =
+      i18nStrings->t(I18nStrings::NotificationsConnectionFailedTitle);
+  QString notificationBody =
+      i18nStrings->t(I18nStrings::NotificationsConnectionFailedMessage);
+
+  notifyInternal(ConnectionFailure, notificationTitle, notificationBody,
+                 Constants::DEFAULT_OS_NOTIFICATION_MSEC);
+}
+
 void NotificationHandler::notifyInternal(Message type, const QString& title,
                                          const QString& message,
                                          int timerMsec) {

--- a/src/notificationhandler.h
+++ b/src/notificationhandler.h
@@ -27,6 +27,7 @@ class NotificationHandler : public QObject {
     ServerUnavailable,
     NewInAppMessage,
     SubscriptionNotFound,
+    ConnectionFailure,
   };
 
   static NotificationHandler* create(QObject* parent);
@@ -46,6 +47,8 @@ class NotificationHandler : public QObject {
                                    const QString& message);
 
   void subscriptionNotFoundNotification();
+
+  void connectionFailureNotification();
 
   void showNotification();
 

--- a/src/platforms/linux/linuxcontroller.cpp
+++ b/src/platforms/linux/linuxcontroller.cpp
@@ -78,9 +78,18 @@ void LinuxController::initializeCompleted(QDBusPendingCallWatcher* call) {
 void LinuxController::dbusNameOwnerChanged(const QString& name,
                                            const QString& prevOwner,
                                            const QString& newOwner) {
-  // If the daemon stops, or re-starts then we have been disconnected.
-  if (name == m_dbus->serviceName()) {
-    logger.info() << "DBus name" << name << "has changed owner to" << newOwner;
+  if (name != m_dbus->serviceName()) {
+    return;
+  }
+
+  if (prevOwner.isEmpty()) {
+    // The daemon has started.
+    logger.info() << "DBus name" << name << "has owner:" << newOwner;
+    return;
+  } else {
+    // Otherwise, the daemon has stopped or re-started somehow.
+    logger.info() << "DBus name" << name << "has changed owner:" << newOwner;
+    REPORTERROR(ErrorHandler::ControllerError, "controller");
     emit disconnected();
   }
 }

--- a/src/translations/strings.yaml
+++ b/src/translations/strings.yaml
@@ -279,6 +279,8 @@ notifications:
   captivePortalBlockMessage2: The guest Wi-Fi network you’re connected to requires action. Click to turn off VPN to see the portal.
   captivePortalUnblockTitle: Guest Wi-Fi portal detected
   captivePortalUnblockMessage2: The guest Wi-Fi network you’re connected to may not be secure. Click to turn on VPN to secure your device.
+  connectionFailedTitle: Connection failed
+  connectionFailedMessage: Sorry, something went wrong with your VPN connection.
   subscriptionNotFound: Your Mozilla VPN subscription cannot be found. Please open the app to resolve this subscription issue.
   unsecuredNetworkTitle: Unsecured Wi-Fi network detected
   unsecuredNetworkMessage:


### PR DESCRIPTION
## Description
This adds a system tray notification which is triggered upon a connection failure, and connects it to the controller errors.

![Screenshot from 2024-07-11 13-22-46](https://github.com/user-attachments/assets/07e65af1-f3b8-484b-9f52-bc2b91a03cdd)

## Reference
JIRA Issue: [VPN-5589](https://mozilla-hub.atlassian.net/browse/VPN-5589)

## Checklist
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-5589]: https://mozilla-hub.atlassian.net/browse/VPN-5589?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ