### PR TITLE
VPN-4226: Linux firewall cleanup upon crash/restart

### DIFF
--- a/linux/netfilter/netfilter.go
+++ b/linux/netfilter/netfilter.go
@@ -678,7 +678,7 @@ func NetfilterRemoveTables() int32 {
 	for _, table := range tables {
 		if table.Name == "mozvpn-inet" {
 			log.Println("Removing netfilter table")
-			mozvpn_ctx.conn.DelTable(mozvpn_ctx.table)
+			mozvpn_ctx.conn.DelTable(table)
 		}
 	}
 

--- a/src/platforms/linux/daemon/linuxfirewall.cpp
+++ b/src/platforms/linux/daemon/linuxfirewall.cpp
@@ -54,6 +54,7 @@ LinuxFirewall::LinuxFirewall(QObject* parent) : QObject(parent) {
   MZ_COUNT_CTOR(LinuxFirewall);
 
   NetfilterSetLogger((GoUintptr)&NetfilterLogger);
+  NetfilterRemoveTables();
 }
 
 LinuxFirewall::~LinuxFirewall() {


### PR DESCRIPTION
## Description
The killswitch code on Linux doesn't handle crashes very well, and can be left in place after the daemon crashes. Unfortunately, the kill switch gets in the way of the recovery by preventing the client from re-establishing a connection after restart. To try and clean this up, we do two things:

1. Combine the firewall tables into one to make manual recovery easier (eg: `sudo nft delete table inet mozvpn-inet`), and
2. Delete any existing tables in the `LinuxFirewall` constructor to get back to a known state after recovery.

## Reference
Linux daemon recovery issue: [VPN-4226](https://mozilla-hub.atlassian.net/browse/VPN-4226)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-4226]: https://mozilla-hub.atlassian.net/browse/VPN-4226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ