### PR TITLE
VPN-6495: fix iOS server switching bug

### DIFF
--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -1096,9 +1096,17 @@ bool Controller::activate(const ServerData& serverData,
     connect(request, &QObject::destroyed, task, &QObject::deleteLater);
     return true;
   }
+
+  // The next few lines are not run on iOS to prevent a bad bug.
+  // These 3 lines were added in
+  // https://github.com/mozilla-mobile/mozilla-vpn-client/pull/9639, and caused
+  // a bug on iOS where server switches stopped working. See more details in
+  // VPN-6495.
+#ifndef MZ_IOS
   if (initiator != ExtensionUser) {
     setState(StateConnecting);
   }
+#endif
 
   clearRetryCounter();
   activateInternal(DoNotForceDNSPort, serverSelectionPolicy, initiator);


### PR DESCRIPTION
## Description

A few lines were added in https://github.com/mozilla-mobile/mozilla-vpn-client/pull/9639, and they broke server switching on iOS. (Notably, it works on macOS - this seems to be iOS-specific.) While I'm deeply curious why an additional time setting the state to Connecting would cause this behavior (and would love to dig deeper to understand *why* this caused the behavior), the most time-judicious fix seems to be wrapping this new code in a platform flag to not run it on iOS.

## Reference

VPN-6495

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
