### PR TITLE
VPN-6529: Do not show update message for any Android or any iOS or macOS 10.x.

### DIFF
--- a/addons/message_update_v2.24/osCheck.js
+++ b/addons/message_update_v2.24/osCheck.js
@@ -1,23 +1,32 @@
-// Disable on iOS 13 and earlier
+// Disable on iOS 13 and earlier, all Android versions, and all macOS versions before 11
 (function(api, condition) {
-  // First check for iOS...
+  // First check for Android...
+  const isAndroid = (api.env.platform === "android");
+  if (isAndroid) {
+    condition.disable();
+    return;
+  }
+
+  // Then check for iOS or macOS...
   const isIOS = (api.env.platform === "ios");
-  if (!isIOS) {
-    condition.enable();
-    return;
+  const isMacOS = (api.env.platform === "macos");
+  if (isIOS || isMacOS) {
+    // ...then check for the minimum version - minimum is 14 for iOS, 11 for macOS
+    const minVersion = isIOS ? 14 : 11;
+    const osVersion = api.env.osVersion;
+    if (!osVersion || (typeof osVersion !== "string") || osVersion.length === 0) {
+      // Something unexpected happened. Enable on failure.
+      condition.enable();
+      return;
+    }
+    const majorVersionString = osVersion.split(".", 1)[0];
+    const majorVersion = Number(majorVersionString);
+
+    majorVersion >= minVersion ? condition.enable() : condition.disable();
   }
 
-  // ...then check for iOS 14 or later
-  const minVersion = 14;
-  const osVersion = api.env.osVersion;
-  if (!osVersion || (typeof osVersion !== "string") || osVersion.length === 0) {
-    // Something unexpected happened. Enable on failure.
-    condition.enable();
-    return;
-  }
-  const majorVersionString = osVersion.split(".", 1)[0];
-  const majorVersion = Number(majorVersionString);
-
-  majorVersion >= minVersion ? condition.enable() : condition.disable();
+  // For all other platforms, enable the addon.
+  condition.enable();
+  return;
 });
   

--- a/addons/message_update_v2.24/osCheck.js
+++ b/addons/message_update_v2.24/osCheck.js
@@ -1,18 +1,18 @@
-// Disable on iOS 13 and earlier, all Android versions, and all macOS versions before 11
+// Disable all Android and iOS versions, and all macOS versions before 11
 (function(api, condition) {
   // First check for Android...
   const isAndroid = (api.env.platform === "android");
-  if (isAndroid) {
+  const isIOS = (api.env.platform === "ios");
+  if (isAndroid || isIOS) {
     condition.disable();
     return;
   }
 
-  // Then check for iOS or macOS...
-  const isIOS = (api.env.platform === "ios");
+  // Then check for macOS...
   const isMacOS = (api.env.platform === "macos");
-  if (isIOS || isMacOS) {
-    // ...then check for the minimum version - minimum is 14 for iOS, 11 for macOS
-    const minVersion = isIOS ? 14 : 11;
+  if (isMacOS) {
+    // ...then check for the minimum version - minimum is 11 for macOS
+    const minVersion = 11;
     const osVersion = api.env.osVersion;
     if (!osVersion || (typeof osVersion !== "string") || osVersion.length === 0) {
       // Something unexpected happened. Enable on failure.


### PR DESCRIPTION
## Description

Update criteria for showing the "update to latest version" addon message. We don't want to show it on Android or iOS (most mobile users get automatic updates), and we do not want to show it on macOS versions less than 11.0 (our current minimum requirement).

## Reference

VPN-6529

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
