### PR TITLE
VPN-6523: Fix Android LAN exclusions

### DIFF
--- a/src/platforms/android/androidcontroller.cpp
+++ b/src/platforms/android/androidcontroller.cpp
@@ -170,13 +170,13 @@ void AndroidController::activate(const InterfaceConfig& config,
     if (item.prefixLength() > 0) {
       jAllowedIPs.append(QJsonValue(item.toString()));
     } else if (item.type() == QAbstractSocket::IPv4Protocol) {
-      QList<IPAddress> routeV4 = {item};
-      foreach(auto prefix, IPAddress::excludeAddresses(routeV4, lanRoutes.v4)) {
+      QList<IPAddress> list = {item};
+      foreach (auto prefix, IPAddress::excludeAddresses(list, lanRoutes.v4)) {
         jAllowedIPs.append(QJsonValue(prefix.toString()));
       }
     } else if (item.type() == QAbstractSocket::IPv6Protocol) {
-      QList<IPAddress> routeV6 = {item};
-      foreach(auto prefix, IPAddress::excludeAddresses(routeV6, lanRoutes.v6)) {
+      QList<IPAddress> list = {item};
+      foreach (auto prefix, IPAddress::excludeAddresses(list, lanRoutes.v6)) {
         jAllowedIPs.append(QJsonValue(prefix.toString()));
       }
     }


### PR DESCRIPTION
## Description
In PR #9674 we tried to improve the LAN exclusion implementation for Windows and Linux. However, this introduced a bug in Android where the LAN exclusion calculation would cause routes to the internal Mulvad network to get lost. This causes the VPN's connectivity checks to fail, and results in the client entering the `No Signal` state shortly after connecting.

The cause of the bug is that `IPAddress::excludeAddresses()` doesn't handle routes nested inside an excluded route. For example, `excludeAddresses({"0.0.0.0/0", "10.64.0.1/32"},{"10.0.0.0/8"})` will ignore the route to `10.64.0.1` because it is excluded by `10.0.0.0/8` despite having a longer prefix length.  

## Reference
JIRA issue: [VPN-6523](https://mozilla-hub.atlassian.net/browse/VPN-6523)
Previous PR: #9674

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-6523]: https://mozilla-hub.atlassian.net/browse/VPN-6523?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ