### PR TITLE
Update cargo deps for "time" 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,7 +107,7 @@ dependencies = [
  "num-traits",
  "rusticata-macros",
  "thiserror",
- "time 0.3.23",
+ "time 0.3.36",
 ]
 
 [[package]]
@@ -401,6 +401,15 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "rusticata-macros",
+]
+
+[[package]]
+name = "deranged"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+dependencies = [
+ "powerfmt",
 ]
 
 [[package]]
@@ -1106,6 +1115,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "num-integer"
 version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1280,6 +1295,12 @@ name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "proc-macro2"
@@ -1807,11 +1828,14 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.23"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59e399c068f43a5d116fedaf73b203fa4f9c519f17e2b34f63221d3792f81446"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
+ "deranged",
  "itoa",
+ "num-conv",
+ "powerfmt",
  "serde",
  "time-core",
  "time-macros",
@@ -1819,16 +1843,17 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.10"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96ba15a897f3c86766b757e5ac7221554c6750054d74d5b28844fce5fb36a6c4"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
+ "num-conv",
  "time-core",
 ]
 
@@ -2540,7 +2565,7 @@ dependencies = [
  "ring",
  "rusticata-macros",
  "thiserror",
- "time 0.3.23",
+ "time 0.3.36",
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

```
linux-build/src/ui/mozillavpn-ui_autogen/LWZFM5XUEJ/moc_VPNServerCountryModel.cpp /__w/mozilla-vpn-client/mozilla-vpn-client/BUILD/mozillavpn-2.24.0~build20240802/src/ui/singletons/VPNServerCountryModel.h
2024-08-02T16:21:41.0873817Z error[E0282]: type annotations needed for `Box<_>`
2024-08-02T16:21:41.0883588Z   --> /__w/mozilla-vpn-client/mozilla-vpn-client/BUILD/mozillavpn-2.24.0~build20240802/signature/vendor/time/src/format_description/parse/mod.rs:83:9
2024-08-02T16:21:41.0892295Z    |
2024-08-02T16:21:41.0904521Z 83 |     let items = format_items
2024-08-02T16:21:41.0914971Z    |         ^^^^^
2024-08-02T16:21:41.0921127Z ...
2024-08-02T16:21:41.0940724Z 86 |     Ok(items.into())
2024-08-02T16:21:41.0941497Z    |              ---- type must be known at this point
2024-08-02T16:21:41.0942121Z    |
2024-08-02T16:21:41.0942854Z help: consider giving `items` an explicit type, where the placeholders `_` are specified
2024-08-02T16:21:41.0943756Z    |
2024-08-02T16:21:41.0944145Z 83 |     let items: Box<_> = format_items
2024-08-02T16:21:41.0944698Z    |              ++++++++
2024-08-02T16:21:41.0944987Z 
2024-08-02T16:21:41.1982752Z AutoMoc: Reading dependencies from "SRC:/redhat-linux-build/src/ui/mozillavpn-ui_autogen/LWZFM5XUEJ/moc_VPNReleaseMonitor.cpp.d"
2024-08-02T16:21:41.2002672Z AutoMoc: Generating "SRC:/redhat-linux-build/src/ui/mozillavpn-ui_autogen/LWZFM5XUEJ/moc_VPNServerLatency.cpp", because it doesn't exist, from "SRC:/src/ui/singletons/VPNServerLatency.h"
2024-08-02T16:21:41.2022852Z

```
Gh CI seems busted. Let's see if `cargo update` helps :) 