### PR TITLE
Remove Obsolete Import of GraphicalEffects

### DIFF
--- a/src/ui/qt6winhack.qml
+++ b/src/ui/qt6winhack.qml
@@ -5,7 +5,6 @@
 // See https://mozilla-hub.atlassian.net/browse/VPN-1894
 
 import Qt5Compat.GraphicalEffects
-import QtGraphicalEffects 1.0
 import Qt.labs.qmlmodels 1.0
 
 Item {}

--- a/tests/dummyvpn/qml/qt6winhack.qml
+++ b/tests/dummyvpn/qml/qt6winhack.qml
@@ -12,7 +12,6 @@ import QtQuick.Controls 2.15
 import QtQuick.Layout 1.14
 import QtQuick.Windows 2.12
 import Qt5Compat.GraphicalEffects
-import QtGraphicalEffects 1.0
 import Qt.labs.qmlmodels 1.0
 
 Item {}

--- a/tests/qml/qt6winhack.qml
+++ b/tests/qml/qt6winhack.qml
@@ -10,7 +10,6 @@ import QtQuick.Controls 2.15
 import QtQuick.Layout 1.14
 import QtQuick.Windows 2.12
 import Qt5Compat.GraphicalEffects
-import QtGraphicalEffects 1.0
 import Qt.labs.qmlmodels 1.0
 
 Item {}


### PR DESCRIPTION
## Description
```
import QtGraphicalEffects 1.0
```
Was removed while switching from Qt5 ->Qt6, i think we kept this as we supported both 5 and 6. 
Graphical effects are now provided through the qt5compat thing. 




Closes #9762
