### PR TITLE
Nit: Make ProxyController a featureflag

### DIFF
--- a/src/feature/featurelist.h
+++ b/src/feature/featurelist.h
@@ -227,5 +227,5 @@ FEATURE(localProxy,                      // Feature ID
         "LocalProxy",                    // Feature name
         FeatureCallback_proxyCanTurnOn,  // Can be flipped on
         FeatureCallback_true,            // Can be flipped off
-        QStringList(),                   // feature dependencies
+        QStringList("splitTunnel"),      // feature dependencies
         FeatureCallback_inStaging)

--- a/src/feature/featurelist.h
+++ b/src/feature/featurelist.h
@@ -222,3 +222,10 @@ FEATURE(webPurchase,           // Feature ID
         FeatureCallback_true,  // Can be flipped off
         QStringList(),         // feature dependencies
         FeatureCallback_webPurchase)
+
+FEATURE(localProxy,                      // Feature ID
+        "LocalProxy",                    // Feature name
+        FeatureCallback_proxyCanTurnOn,  // Can be flipped on
+        FeatureCallback_true,            // Can be flipped off
+        QStringList(),                   // feature dependencies
+        FeatureCallback_inStaging)

--- a/src/feature/featurelistcallback.h
+++ b/src/feature/featurelistcallback.h
@@ -194,4 +194,12 @@ bool FeatureCallback_hasBalrog() {
 #endif
 }
 
+bool FeatureCallback_proxyCanTurnOn() {
+#if defined(MZ_WINDOWS) || defined(MZ_LINUX)
+  return true;
+#else
+  return false;
+#endif
+}
+
 #endif  // FEATURELISTCALLBACK_H


### PR DESCRIPTION
## Description
The local proxy currently is a bit hard to enable: 
-> You need to be in stage mode 
-> you need split tunnel 
-> you need to have the binary in a certain place. 

And if one of those fails, we silently fail. 
Let's make it a featureflag, with the precondition of "is windows | linux" and use the featureflag mechanism to allow it to turn it on, make it default on in stage :) 

This also makes it look on "Debug" builds inside the build dir instead of an "install" like folder, making setup better. 

Also add logs if things fail so people can self troubleshoot. 


