### PR TITLE
VPN-6540: Add missing return to addons condition

### DIFF
--- a/addons/message_update_v2.24/osCheck.js
+++ b/addons/message_update_v2.24/osCheck.js
@@ -23,6 +23,7 @@
     const majorVersion = Number(majorVersionString);
 
     majorVersion >= minVersion ? condition.enable() : condition.disable();
+    return;
   }
 
   // For all other platforms, enable the addon.


### PR DESCRIPTION
## Description

Egg on my face from VPN-6529: I missed an early return, and that meant the check kept evaluating. On line 29/30, we `enable` the addon in all cases - so when the macOS check was disabling the addon, it was being re-enabled a few lines later.

## Reference

VPN-6540

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
