### PR TITLE
Extend `ping_analyzer_error` expiration date

### DIFF
--- a/src/telemetry/metrics.yaml
+++ b/src/telemetry/metrics.yaml
@@ -994,4 +994,4 @@ connection_health:
     notification_emails:
       - mcleinman@mozilla.com
       - vpn-telemetry@mozilla.com
-    expires: 2024-08-15
+    expires: 2024-12-31


### PR DESCRIPTION

## Description

In https://github.com/mozilla-mobile/mozilla-vpn-client/pull/9057/, we added several new metrics to measure connection health. I wanted `ping_analyzer_error` to be a short term metric used as a gut check to make sure nothing was erroring out around here. When the original PR was put up on May 23rd, I was far too optimistic that it would be approved and released with at least a few weeks to go before July 15th (the metric expiration date). 

At this point, 2.24 (the release this metric is first part of) is not yet out, and the metric is already expired - we've gathered no data from it. (Even worse, when we extended several of the expiration dates a few weeks ago in https://github.com/mozilla-mobile/mozilla-vpn-client/pull/9710, I mistakenly thought we had data from `ping_analyzer_error` from the 2.23 release, and didn't extend it at that time.)

This PR extends the date through the end of the year. I'd hope we can pull the metric in mid-fall once we confirm this part of the code is working as expected, but wanted to give a little bit of a buffer so we don't find ourselves in this same position a few months down the line.

## Reference

N/A

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
