### PR TITLE
Let the extension query relevant featureflags

### DIFF
--- a/src/webextensionadapter.cpp
+++ b/src/webextensionadapter.cpp
@@ -13,6 +13,7 @@
 #include <functional>
 
 #include "controller.h"
+#include "feature/feature.h"
 #include "leakdetector.h"
 #include "localizer.h"
 #include "logger.h"
@@ -96,6 +97,12 @@ WebExtensionAdapter::WebExtensionAdapter(QObject* parent)
 
                     QJsonObject obj;
                     obj["disabled_apps"] = apps;
+                    return obj;
+                  }},
+      RequestType{"featurelist",
+                  [this](const QJsonObject&) {
+                    QJsonObject obj;
+                    obj["featurelist"] = serializeFeaturelist();
                     return obj;
                   }},
 
@@ -185,6 +192,12 @@ QJsonObject WebExtensionAdapter::serializeStatus() {
 #endif
 
   return obj;
+}
+
+QJsonObject WebExtensionAdapter::serializeFeaturelist() {
+  auto out = QJsonObject();
+  out["localProxy"] = Feature::get(Feature::Feature_localProxy)->isSupported();
+  return out;
 }
 
 void WebExtensionAdapter::serializeServerCountry(ServerCountryModel* model,

--- a/src/webextensionadapter.h
+++ b/src/webextensionadapter.h
@@ -27,6 +27,7 @@ class WebExtensionAdapter : public WebExtension::BaseAdapter {
  private:
   void writeState();
   QJsonObject serializeStatus();
+  QJsonObject serializeFeaturelist();
   void serializeServerCountry(ServerCountryModel* model, QJsonObject& obj);
   QPropertyObserver mProxyStateChanged;
 };

--- a/tests/functional/testWebExtensionApi.js
+++ b/tests/functional/testWebExtensionApi.js
@@ -87,6 +87,20 @@ describe('WebExtension API', function() {
        }, 500, 'VPN should still report StateOn');
        sock.destroy();
      });
+
+  it('A Webextension can get a Subset of the Featurelist', async () => {
+    const sock = await connectExtension();
+    const messagePipe = getMessageStream(sock);
+    const isProxyEnabled = await this.isFeatureEnabled('localProxy');
+
+
+    const response = readResponseOfType('featurelist', messagePipe);
+    sentToClient(new ExtensionMessage('featurelist'), sock);
+    const msg = await response;
+    assert(msg.featurelist.localProxy === isProxyEnabled);
+
+    sock.destroy();
+  });
 });
 
 }


### PR DESCRIPTION
## Description

We cannot stop people from installing the extension if "localProxy" is not a thing. So let's have the extension be able to query feature flags that are relevant for it. 
This can allow the webextension to work, simply without that functionality if the client does not support that. 