### PR TITLE
Cherry pick to 2.24: extend ping_analyzer_error expiration date

### DIFF
--- a/src/telemetry/metrics.yaml
+++ b/src/telemetry/metrics.yaml
@@ -994,4 +994,4 @@ connection_health:
     notification_emails:
       - mcleinman@mozilla.com
       - vpn-telemetry@mozilla.com
-    expires: 2024-08-15
+    expires: 2024-12-31


### PR DESCRIPTION
Cherry pick https://github.com/mozilla-mobile/mozilla-vpn-client/pull/9773