### PR TITLE
VPN-6517: Fix contention between LAN bypass and DNS killswitch on Windows

### DIFF
--- a/src/platforms/windows/daemon/windowsfirewall.cpp
+++ b/src/platforms/windows/daemon/windowsfirewall.cpp
@@ -213,7 +213,7 @@ bool WindowsFirewall::enableLanBypass(const QList<IPAddress>& ranges) {
 
   // Blocking unprotected traffic
   for (const IPAddress& prefix : ranges) {
-    if (!allowTrafficTo(prefix, LOW_WEIGHT+1, "Allow LAN bypass traffic")) {
+    if (!allowTrafficTo(prefix, LOW_WEIGHT + 1, "Allow LAN bypass traffic")) {
       return false;
     }
   }

--- a/src/platforms/windows/daemon/windowsfirewall.cpp
+++ b/src/platforms/windows/daemon/windowsfirewall.cpp
@@ -212,9 +212,8 @@ bool WindowsFirewall::enableLanBypass(const QList<IPAddress>& ranges) {
   });
 
   // Blocking unprotected traffic
-  logger.info() << "Blocking unprotected traffic";
   for (const IPAddress& prefix : ranges) {
-    if (!allowTrafficTo(prefix, MED_WEIGHT, "Allow LAN bypass traffic")) {
+    if (!allowTrafficTo(prefix, LOW_WEIGHT+1, "Allow LAN bypass traffic")) {
       return false;
     }
   }


### PR DESCRIPTION
## Description
Previously, on the LAN bypass saga, our heros sought to make LAN bypass better by utilizing route cloning to direct traffic outside of the VPN tunnel, which required the addition of a new method `WindowsFirewall::enableLanBypass()` to specifically permit LAN traffic through the firewall that would be otherwise blocked by the "Block internet" rule.

Unfortunately, this filter rule shared the same weight as the DNS killswitch rule in `WindowsFirewall::enableInterface()` which makes it unclear which firewall rule will apply to DNS traffic sent to the LAN. This means that a web browser might start before the VPN and decide that the user's LAN should be used for DNS, fail to detect that the VPN has changed DNS configuration, and then merrily continue to use the LAN for its DNS resolution so long the traffic keeps flowing.

To resolve this, we need to reorder things slightly. In order from lowest to highest weight:
- Traffic to the internet sent outside the VPN is blocked.
- Traffic to the LAN is permitted.
- The DNS killswitch and other protocol-specific rules are applied.
- Traffic into the VPN is permitted.
- Traffic to DNS servers configured by the VPN is permitted.

## Reference
JIRA Issue: [VPN-6517](https://mozilla-hub.atlassian.net/browse/VPN-6517)
Bug introduced by: #9674

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-6517]: https://mozilla-hub.atlassian.net/browse/VPN-6517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ