### PR TITLE
Addons: Fix fallback languages

### DIFF
--- a/scripts/addon/build.py
+++ b/scripts/addon/build.py
@@ -416,7 +416,7 @@ with open(args.source, "r", encoding="utf-8") as file:
                     # The fallback translations are computed in reverse order.
                     # First "en" where we have 100% of translations by default.
                     xliff_path_en = os.path.join(args.i18npath, "en", "addons", manifest["id"], "strings.xliff")
-                    locale_file_en = os.path.join(tmp_path, "i18n", f"locale_{locale}.ts")
+                    locale_file_en = os.path.join(tmp_path, "i18n", "locale_en_fallback.ts")
                     os.system(f"{lconvert} -if xlf -i {xliff_path_en} -o {locale_file_en}")
 
                     # Then the fallback languages

--- a/scripts/addon/build.py
+++ b/scripts/addon/build.py
@@ -420,16 +420,18 @@ with open(args.source, "r", encoding="utf-8") as file:
                     os.system(f"{lconvert} -if xlf -i {xliff_path_en} -o {locale_file_en}")
 
                     # Then the fallback languages
+                    locale_file_fallbacks = []
                     for fallback in translations_fallback[locale]:
                         xliff_path_fallback = os.path.join(args.i18npath, fallback, "addons", manifest["id"], "strings.xliff")
-                        locale_file_fallback = os.path.join(tmp_path, "i18n", f"locale_{locale}.ts")
+                        locale_file_fallback = os.path.join(tmp_path, "i18n", f"locale_{fallback}.ts")
+                        locale_file_fallbacks.append(locale_file_fallback)
                         os.system(f"{lconvert} -if xlf -i {xliff_path_fallback} -no-untranslated -o {locale_file_fallback}")
 
                     # Finally, the current language
                     os.system(f"{lconvert} -if xlf -i {xliff_path} -no-untranslated -o {locale_file}")
 
                     # All is unified in reverse order.
-                    os.system(f"{lconvert} -i {locale_file_en} {' '.join(translations_fallback[locale])} {locale_file} -o {locale_file}")
+                    os.system(f"{lconvert} -i {locale_file_en} {' '.join(locale_file_fallbacks)} {locale_file} -o {locale_file}")
                 else:
                     os.system(f"{lconvert} -if xlf -i {xliff_path} -o {locale_file}")
 


### PR DESCRIPTION
## Description

When coming up to speed on addon translations as part of VPN-5478, I noticed this quirk. I can't find a reason why it would exist (other than an error), so I'm putting up this patch.

`locale_file_fallback` is the file for a given fallback language's translations (`ts` file type), built from `translations_fallback[locale]`. However, we never do anything with `locale_file_fallback` after creating it - however we again use the `translations_fallback[locale]` in creating the final translation pack. (Additionally, for languages with multiple fallback languages, we overwrite `locale_file_fallback` each time, as we use the source language's abbreviation in creating the filename, not the fallback language - so it ends up overwritten if there are 2 fallback languages.) This all seems like an error.

That said, I can't find user-facing impact in my (limited) testing. `lconvert` is smart enough to be able to use many different file extension types, and it seems to be working as expected - that last line I updated here is combining different file types as it does its work, rather than multiple `ts` files as (I believe) we expected it to. The one thing we're losing is the `-no-untranslated` flag in the interim step. And so that makes this PR seem worthwhile, in my opinion.

## Reference

None

## Checklist
  
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
