### PR TITLE
VPN-6569: Compute balrog installer hashes as QByteArrays

### DIFF
--- a/src/update/balrog.cpp
+++ b/src/update/balrog.cpp
@@ -292,7 +292,8 @@ bool Balrog::processData(Task* task, const QByteArray& data) {
     return false;
   }
 
-  QString hashValue = obj.value("hashValue").toString();
+  QString hashString = obj.value("hashValue").toString();
+  QByteArray hashValue = QByteArray::fromHex(hashString.toUtf8());
   if (hashValue.isEmpty()) {
     logger.error() << "No hashValue item";
     return false;
@@ -326,20 +327,17 @@ bool Balrog::processData(Task* task, const QByteArray& data) {
 }
 
 bool Balrog::computeHash(const QString& url, const QByteArray& data,
-                         const QString& hashValue,
-                         const QString& hashFunction) {
+                         const QByteArray& expect, const QString& algorithm) {
   logger.debug() << "Compute the hash";
 
-  if (hashFunction != "sha512") {
+  if (algorithm != "sha512") {
     logger.error() << "Invalid hash function";
     return false;
   }
 
   QCryptographicHash hash(QCryptographicHash::Sha512);
   hash.addData(data);
-  QByteArray hashHex = hash.result().toHex();
-
-  if (hashHex != hashValue) {
+  if (hash.result() != expect) {
     logger.error() << "Hash doesn't match";
     return false;
   }

--- a/src/update/balrog.h
+++ b/src/update/balrog.h
@@ -35,7 +35,7 @@ class Balrog final : public Updater {
                          const QByteArray& updateData,
                          const QByteArray& signatureBlob);
   bool computeHash(const QString& url, const QByteArray& data,
-                   const QString& hashValue, const QString& hashFunction);
+                   const QByteArray& expect, const QString& algorithm);
   bool saveFileAndInstall(const QString& url, const QByteArray& data);
   bool install(const QString& filePath);
   void propagateError(NetworkRequest* request,


### PR DESCRIPTION
## Description
Balrog computes its file hashes by converting the hash to a hex string and then comparing it to the hash string received from Balrog. While this works, it is sloppy and it means that hash comparisons can fail depending on case sensitivity. The better approach is to compare hashes as a `QByteArray` so that the string case doesn't matter.

## Reference
JIRA issue: [VPN-6569](https://mozilla-hub.atlassian.net/browse/VPN-6569)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-6569]: https://mozilla-hub.atlassian.net/browse/VPN-6569?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ