### PR TITLE
Cache Wireguard-NT for windows unit tests

### DIFF
--- a/.github/workflows/test_unit.yaml
+++ b/.github/workflows/test_unit.yaml
@@ -153,6 +153,7 @@ jobs:
 
       - name: Download Wireguard NT
         if: steps.cache-wireguard-nt.outputs.cache-hit != 'true'
+        shell: bash
         run: |
           WIREGUARD_NT_URL=$(grep -Eo 'DOWNLOAD[[:space:]].*' windows/wireguard_nt/CMakeLists.txt | awk '{print $2}')
           mkdir -p 3rdparty/wireguard-nt

--- a/.github/workflows/test_unit.yaml
+++ b/.github/workflows/test_unit.yaml
@@ -149,7 +149,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: 3rdparty/wireguard-nt
-          key: wireguard-nt-${{ hashFiles(windows/wireguard_nt/CMakeLists.txt) }}
+          key: wireguard-nt-${{ hashFiles('windows/wireguard_nt/CMakeLists.txt') }}
 
       - name: Download Wireguard NT
         if: steps.cache-wireguard-nt.outputs.cache-hit != 'true'

--- a/.github/workflows/test_unit.yaml
+++ b/.github/workflows/test_unit.yaml
@@ -156,8 +156,8 @@ jobs:
         shell: bash
         run: |
           WIREGUARD_NT_URL=$(grep -Eo 'DOWNLOAD[[:space:]].*' windows/wireguard_nt/CMakeLists.txt | awk '{print $2}')
-          mkdir -p 3rdparty/wireguard-nt
-          curl -sSL -o 3rdparty/wireguard-nt/$(basename $WIREGUARD_NT_URL) $WIREGUARD_NT_URL
+          curl -sSL -o wireguard-nt.zip $WIREGUARD_NT_URL
+          unzip -d 3rdparty/ wireguard-nt.zip
 
       - name: Building tests
         run: |

--- a/.github/workflows/test_unit.yaml
+++ b/.github/workflows/test_unit.yaml
@@ -144,10 +144,24 @@ jobs:
           cache: "pip"
       - run: pip install -r requirements.txt
 
+      - name: Cache Wireguard NT
+        id: cache-wireguard-nt
+        uses: actions/cache@v4
+        with:
+          path: 3rdparty/wireguard-nt
+          key: wireguard-nt-${{ hashFiles(windows/wireguard_nt/CMakeLists.txt) }}
+
+      - name: Download Wireguard NT
+        if: steps.cache-wireguard-nt.outputs.cache-hit != 'true'
+        run: |
+          WIREGUARD_NT_URL=$(grep -Eo 'DOWNLOAD[[:space:]].*' windows/wireguard_nt/CMakeLists.txt | awk '{print $2}')
+          mkdir -p 3rdparty/wireguard-nt
+          curl -sSL -o 3rdparty/wireguard-nt/$(basename $WIREGUARD_NT_URL) $WIREGUARD_NT_URL
+
       - name: Building tests
         run: |
           mkdir ./build
-          cmake -S . -B ./build -GNinja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH="C:\MozillaVPNBuild\lib\cmake" -DWINTUN_FOLDER="not-existing"
+          cmake -S . -B ./build -GNinja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH="C:\MozillaVPNBuild\lib\cmake" -DWIREGUARD_FOLDER="3rdparty/wireguard-nt"
           cmake --build ./build --target build_tests
 
       - name: Running native messaging tests


### PR DESCRIPTION
## Description
The Windows unit tests have been extremely brittle lately, and they frequently fail to download the Wireguard NT driver. Let's see if we can stabilize this by using a cache to save this artifact between builds.

## Reference

    i.e Jira or Github issue URL

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
