### PR TITLE
VPN-2876: Stop loading screens persistently

### DIFF
--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -1507,7 +1507,7 @@ void MozillaVPN::registerNavigatorScreens() {
       });
 
   Navigator::registerScreen(
-      MozillaVPN::ScreenHome, Navigator::LoadPolicy::LoadPersistently,
+      MozillaVPN::ScreenHome, Navigator::LoadPolicy::LoadTemporarily,
       "qrc:/qt/qml/Mozilla/VPN/screens/ScreenHome.qml",
       QVector<int>{App::StateMain}, [](int*) -> int8_t { return 99; },
       []() -> bool { return false; });

--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -1519,7 +1519,7 @@ void MozillaVPN::registerNavigatorScreens() {
       []() -> bool { return false; });
 
   Navigator::registerScreen(
-      MozillaVPN::ScreenMessaging, Navigator::LoadPolicy::LoadPersistently,
+      MozillaVPN::ScreenMessaging, Navigator::LoadPolicy::LoadTemporarily,
       "qrc:/qt/qml/Mozilla/VPN/screens/ScreenMessaging.qml",
       QVector<int>{App::StateMain}, [](int*) -> int8_t { return 0; },
       []() -> bool {
@@ -1543,7 +1543,7 @@ void MozillaVPN::registerNavigatorScreens() {
       []() -> bool { return false; });
 
   Navigator::registerScreen(
-      MozillaVPN::ScreenSettings, Navigator::LoadPolicy::LoadPersistently,
+      MozillaVPN::ScreenSettings, Navigator::LoadPolicy::LoadTemporarily,
       "qrc:/qt/qml/Mozilla/VPN/screens/ScreenSettings.qml",
       QVector<int>{App::StateMain}, [](int*) -> int8_t { return 0; },
       []() -> bool {

--- a/src/ui/screens/home/controller/ControllerImage.qml
+++ b/src/ui/screens/home/controller/ControllerImage.qml
@@ -15,11 +15,10 @@ Rectangle {
 
     color: MZTheme.theme.transparent
     opacity: 1
+    state: VPNController.state
     states: [
         State {
-            name: "stateConnecting"
-            when: (VPNController.state === VPNController.StateConnecting)
-
+            name: VPNController.StateConnecting
             PropertyChanges {
                 target: logo
                 opacity: 0.6
@@ -36,8 +35,7 @@ Rectangle {
             }
         },
         State {
-            name: "stateConfirming"
-            when: VPNController.state === VPNController.StateConfirming
+            name: VPNController.StateConfirming
 
             PropertyChanges {
                 target: logo
@@ -56,8 +54,7 @@ Rectangle {
 
         },
         State {
-            name: "stateDisconnecting"
-            when: VPNController.state === VPNController.StateDisconnecting
+            name: VPNController.StateDisconnecting
 
             PropertyChanges {
                 target: logo
@@ -74,11 +71,9 @@ Rectangle {
                 source: "qrc:/ui/resources/shield-off.svg"
                 opacity: 1
             }
-
         },
         State {
-            name: "stateSwitching"
-            when: VPNController.state === VPNController.StateSwitching
+            name: VPNController.StateSwitching
 
             PropertyChanges {
                 target: logo
@@ -99,10 +94,19 @@ Rectangle {
             }
         },
         State {
-            name: "stateOff"
-            when: VPNController.state === VPNController.StateOff ||
-                  VPNController.state === VPNController.StateOnPartial
-
+            name: VPNController.StateOff
+            PropertyChanges {
+                target: insetCircle
+                color: MZTheme.colors.error.default
+            }
+            PropertyChanges {
+                target: insetIcon
+                source: "qrc:/ui/resources/shield-off.svg"
+                opacity: 1
+            }
+        },
+        State {
+            name: VPNController.StateOnPartial
             PropertyChanges {
                 target: insetCircle
                 color: MZTheme.colors.error.default
@@ -115,8 +119,7 @@ Rectangle {
 
         },
         State {
-            name: "stateInitializing"
-            when: VPNController.state === VPNController.StateInitializing
+            name: VPNController.StateInitializing
 
             PropertyChanges {
                 target: logo
@@ -134,11 +137,7 @@ Rectangle {
             }
         },
         State {
-            name: "stateOn"
-            when: (VPNController.state === VPNController.StateOn ||
-                   VPNController.state === VPNController.StateSilentSwitching) &&
-                VPNConnectionHealth.stability === VPNConnectionHealth.Stable
-
+            name: VPNController.StateOn
             PropertyChanges {
                 target: logo
                 showVPNOnIcon: true
@@ -152,48 +151,6 @@ Rectangle {
                 source: "qrc:/ui/resources/shield-on.svg"
                 opacity: 1
             }
-        },
-        State {
-            name: "unstableOn"
-            when: (VPNController.state === VPNController.StateOn ||
-                   VPNController.state === VPNController.StateSilentSwitching) &&
-                VPNConnectionHealth.stability === VPNConnectionHealth.Unstable
-
-            PropertyChanges {
-                target: logo
-                showVPNOnIcon: true
-                opacity: 1
-            }
-            PropertyChanges {
-                target: insetCircle
-                color: MZTheme.colors.warning.default
-            }
-            PropertyChanges {
-                target: insetIcon
-                source: "qrc:/ui/resources/shield-on.svg"
-                opacity: 1
-            }
-        },
-        State {
-            name: "noSignalOn"
-            when: (VPNController.state === VPNController.StateOn ||
-                   VPNController.state === VPNController.StateSilentSwitching) &&
-                VPNConnectionHealth.stability === VPNConnectionHealth.NoSignal
-
-            PropertyChanges {
-                target: logo
-                showVPNOnIcon: true
-                opacity: 1
-            }
-            PropertyChanges {
-                target: insetCircle
-                color: MZTheme.colors.error.default
-            }
-            PropertyChanges {
-                target: insetIcon
-                source: "qrc:/ui/resources/shield-off.svg"
-                opacity: 1
-            }
         }
     ]
     transitions: [
@@ -205,18 +162,17 @@ Rectangle {
                     property: "color"
                     duration: 100
                 }
-
                 PropertyAnimation {
                     target: logo
                     property: "opacity"
-                    duration: 200
+                    duration: 100
                 }
 
                 PropertyAnimation {
                     target: insetCircle
                     property: "scale"
                     to: 0.9
-                    duration: 200
+                    duration: 100
                     easing.type: Easing.Linear
                 }
             }
@@ -224,11 +180,24 @@ Rectangle {
         Transition {
             to: VPNController.StateConfirming
             ParallelAnimation {
+                PropertyAnimation {
+                    target: insetCircle
+                    property: "color"
+                    duration: 100
+                }
 
                 PropertyAnimation {
-                    target: insetIcon
+                    target: logo
                     property: "opacity"
                     duration: 100
+                }
+
+                PropertyAnimation {
+                    target: insetCircle
+                    property: "scale"
+                    to: 0.9
+                    duration: 100
+                    easing.type: Easing.Linear
                 }
             }
 
@@ -250,8 +219,8 @@ Rectangle {
                 PropertyAnimation {
                     target: insetCircle
                     property: "scale"
-                    to: 0.9
-                    duration: 150
+                    to: 0.85
+                    duration: 200
                     easing.type: Easing.Linear
                 }
             }
@@ -265,7 +234,6 @@ Rectangle {
                     property: "opacity"
                     duration: 100
                 }
-
                 PropertyAnimation {
                     target: insetCircle
                     property: "scale"
@@ -282,7 +250,7 @@ Rectangle {
                     target: insetCircle
                     property: "scale"
                     to: 0.9
-                    duration: 200
+                    duration: 100
                     easing.type: Easing.Linear
                 }
 
@@ -329,6 +297,29 @@ Rectangle {
             }
         }
     ]
+
+
+    Connections{
+        target: VPNConnectionHealth
+        function onStabilityChanged() {
+            switch(VPNConnectionHealth.stability) {
+                case(VPNConnectionHealth.NoSignal):
+                    insetCircle.color = MZTheme.colors.error.default;
+                    insetIcon.source = "qrc:/ui/resources/shield-off.svg";
+                    break;
+            
+                case(VPNConnectionHealth.Stable):
+                    insetCircle.color = MZTheme.colors.success.default;
+                    insetIcon.source = "qrc:/ui/resources/shield-on.svg";
+                    break;
+            
+                case(VPNConnectionHealth.Unstable):
+                    insetCircle.color = MZTheme.colors.warning.default;
+                    break;
+            
+            }
+        }
+    }
 
     Rectangle {
         // green or red circle in upper right hand area of

--- a/src/ui/screens/home/controller/VPNToggle.qml
+++ b/src/ui/screens/home/controller/VPNToggle.qml
@@ -13,7 +13,7 @@ MZButtonBase {
 
     property var connectionRetryOverX: VPNController.connectionRetry > 1
     property var enableDisconnectInConfirming: VPNController.enableDisconnectInConfirming
-    property var toggleColor: MZTheme.theme.vpnToggleDisconnected
+    property var toggleColor: {}
     property var toolTipTitle: ""
     Accessible.name: toolTipTitle
 

--- a/src/ui/screens/home/controller/VPNToggle.qml
+++ b/src/ui/screens/home/controller/VPNToggle.qml
@@ -45,8 +45,7 @@ MZButtonBase {
 
     states: [
         State {
-            name: "stateInitializing"
-            when: VPNController.state === VPNController.StateInitializing
+            name: VPNController.StateInitializing
 
             PropertyChanges {
                 target: cursor
@@ -66,9 +65,7 @@ MZButtonBase {
 
         },
         State {
-            name: "stateOff"
-            when: VPNController.state === VPNController.StateOff ||
-                  VPNController.state === VPNController.StateOnPartial
+            name: VPNController.StateOff
 
             PropertyChanges {
                 target: cursor
@@ -85,12 +82,34 @@ MZButtonBase {
                 target: toggleButton
                 //% "Turn VPN on"
                 toolTipTitle: qsTrId("vpn.toggle.on")
+                toggleColor: MZTheme.theme.vpnToggleDisconnected
             }
 
         },
+
         State {
-            name: "stateConnecting"
-            when: (VPNController.state === VPNController.StateConnecting)
+            name: VPNController.StateOnPartial
+            PropertyChanges {
+                target: cursor
+                anchors.leftMargin: 4
+            }
+
+            PropertyChanges {
+                target: toggle
+                color: "#9E9E9E"
+                border.color: MZTheme.theme.white
+            }
+
+            PropertyChanges {
+                target: toggleButton
+                //% "Turn VPN on"
+                toolTipTitle: qsTrId("vpn.toggle.on")
+            }
+        },
+
+
+        State {
+            name: VPNController.StateConnecting
 
             PropertyChanges {
                 target: cursor
@@ -113,8 +132,7 @@ MZButtonBase {
 
         },
         State {
-            name: "stateConfirming"
-            when: VPNController.state === VPNController.StateConfirming
+            name: VPNController.StateConfirming
 
             PropertyChanges {
                 target: cursor
@@ -137,9 +155,7 @@ MZButtonBase {
 
         },
         State {
-            name: "stateOn"
-            when: (VPNController.state === VPNController.StateOn ||
-                   VPNController.state === VPNController.StateSilentSwitching)
+            name: VPNController.StateOn
 
             PropertyChanges {
                 target: cursor
@@ -157,11 +173,30 @@ MZButtonBase {
                 toolTipTitle: qsTrId("vpn.toggle.off")
                 toggleColor: MZTheme.theme.vpnToggleConnected
             }
+        },
 
+        State {
+            name: VPNController.StateSilentSwitching
+
+            PropertyChanges {
+                target: cursor
+                anchors.leftMargin: 32
+            }
+
+            PropertyChanges {
+                target: toggle
+                color: "#3FE1B0"
+                border.color: MZTheme.theme.ink
+            }
+
+            PropertyChanges {
+                target: toggleButton
+                toolTipTitle: qsTrId("vpn.toggle.off")
+                toggleColor: MZTheme.theme.vpnToggleConnected
+            }
         },
         State {
-            name: "stateDisconnecting"
-            when: VPNController.state === VPNController.StateDisconnecting
+            name: VPNController.StateDisconnecting
 
             PropertyChanges {
                 target: cursor
@@ -182,8 +217,7 @@ MZButtonBase {
 
         },
         State {
-            name: "stateSwitching"
-            when: VPNController.state === VPNController.StateSwitching
+            name: VPNController.StateSwitching
 
             PropertyChanges {
                 target: cursor
@@ -340,7 +374,7 @@ MZButtonBase {
 
         Behavior on color {
             ColorAnimation {
-                duration: 200
+                duration: 100
             }
 
         }

--- a/tests/functional/helper.js
+++ b/tests/functional/helper.js
@@ -66,7 +66,7 @@ module.exports = {
   async activateViaToggle() {
     await this.waitForQueryAndClick(
         queries.screenHome.CONTROLLER_TOGGLE.visible().prop(
-            'state', 'stateOff'));
+            'toolTipTitle', 'Turn VPN on'));
   },
 
   async activate(awaitConnectionOkay = false) {

--- a/tests/functional/testSettings.js
+++ b/tests/functional/testSettings.js
@@ -359,6 +359,14 @@ describe('Settings', function() {
       await vpn.waitForQueryAndClick(queries.navBar.SETTINGS.visible());
       await vpn.waitForQuery(queries.global.SCREEN_LOADER.ready());
 
+      await vpn.waitForQueryAndClick(
+          queries.screenSettings.APP_PREFERENCES.visible());
+      await vpn.waitForQuery(queries.screenSettings.STACKVIEW.ready());
+
+      await vpn.waitForQueryAndClick(
+          queries.screenSettings.appPreferencesView.DNS_SETTINGS.visible());
+      await vpn.waitForQuery(queries.screenSettings.STACKVIEW.ready());
+
       await vpn.waitForQuery(
           queries.screenSettings.appPreferencesView.dnsSettingsView.STANDARD_DNS
               .visible()
@@ -407,6 +415,14 @@ describe('Settings', function() {
       await vpn.waitForQuery(queries.global.SCREEN_LOADER.ready());
 
       await vpn.waitForQueryAndClick(
+          queries.screenSettings.APP_PREFERENCES.visible());
+      await vpn.waitForQuery(queries.screenSettings.STACKVIEW.ready());
+
+      await vpn.waitForQueryAndClick(
+          queries.screenSettings.appPreferencesView.DNS_SETTINGS.visible());
+      await vpn.waitForQuery(queries.screenSettings.STACKVIEW.ready());
+
+      await vpn.waitForQueryAndClick(
           queries.screenSettings.appPreferencesView.dnsSettingsView.CUSTOM_DNS
               .visible()
               .prop('checked', false));
@@ -426,6 +442,16 @@ describe('Settings', function() {
 
       await vpn.waitForQueryAndClick(queries.navBar.SETTINGS.visible());
       await vpn.waitForQuery(queries.global.SCREEN_LOADER.ready());
+
+      await vpn.waitForQueryAndClick(
+          queries.screenSettings.APP_PREFERENCES.visible());
+      await vpn.waitForQuery(queries.screenSettings.STACKVIEW.ready());
+
+
+      await vpn.waitForQueryAndClick(
+          queries.screenSettings.appPreferencesView.DNS_SETTINGS.visible());
+      await vpn.waitForQuery(queries.screenSettings.STACKVIEW.ready());
+
 
       await vpn.waitForQuery(
           queries.screenSettings.appPreferencesView.dnsSettingsView.STANDARD_DNS


### PR DESCRIPTION
## Description

Here we:
- Stop loading the Home, Settings, and Messages screens "Persistently" in favor of loading them "Temporarily"
- Fix UI flickering in ScreenHome when the Screen loads and which becomes much more noticeable when the view is loaded every time the home button is clicked.  
  - Annoyingly: I can't say with 100% confidence _why_ these changes, mostly to how we name states and assign property changes, fixes the flicker but I suspect that assigning state changes conditionally with `when: someConditionIsTrue` was causing the FOUC.  
  - Also annoyingly: The main toggle still fades in somewhat noticeably. This is fixable but less trivial to fix and, given the a11y wins we gain by doing this, is I think acceptable. 


<table>
<th>Before flicker fixes <br>(Note the toggle wiggliness)</th><th>After flicker fixes</th>
<tr>
<td>

https://github.com/user-attachments/assets/7ec22884-41ca-48b2-9b9b-d6a4785e4d9c

</td>
<td>

https://github.com/user-attachments/assets/c88e2991-dd39-4aca-a1fc-a0293ae7d7e1

</td>
</tr>
</table>

## Reference

VPN-2876

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
