### PR TITLE
Deprecate Ubuntu/23.10 Mantic Minotaur

### DIFF
--- a/.github/workflows/ppa-automation.yaml
+++ b/.github/workflows/ppa-automation.yaml
@@ -60,7 +60,7 @@ jobs:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
           GNUPGHOME: ${{ runner.temp }}/gnupg-data
-          PPA_TARGET_DISTS: focal jammy mantic noble
+          PPA_TARGET_DISTS: focal jammy noble
           PPA_URL: ${{ steps.gen-source.outputs.ppa-url }}
         run: |
           mkdir -m700 $GNUPGHOME

--- a/taskcluster/kinds/build/linux.yml
+++ b/taskcluster/kinds/build/linux.yml
@@ -45,16 +45,6 @@ linux/jammy:
         name: linux-jammy
         type: build
 
-linux/mantic:
-    description: "Linux Build (Ubuntu/Mantic)"
-    treeherder:
-        platform: linux/mantic
-    worker:
-        docker-image: {in-tree: linux-build-mantic}
-    add-index-routes:
-        name: linux-mantic
-        type: build
-
 linux/noble:
     description: "Linux Build (Ubuntu/Noble)"
     treeherder:

--- a/taskcluster/kinds/docker-image/kind.yml
+++ b/taskcluster/kinds/docker-image/kind.yml
@@ -55,11 +55,6 @@ tasks:
         definition: linux-dpkg-build
         args:
             DOCKER_BASE_IMAGE: ubuntu:jammy
-    linux-build-mantic:
-        symbol: I(linux-mantic)
-        definition: linux-dpkg-build
-        args:
-            DOCKER_BASE_IMAGE: ubuntu:mantic
     linux-build-noble:
         symbol: I(linux-noble)
         definition: linux-dpkg-build


### PR DESCRIPTION
## Description
Ubuntu/23.10 Mantic Minotaur has reached EOL status as of June 11th this year, and as such we should no longer be attempting to build it.

## Reference
EOL Announcement: https://lists.ubuntu.com/archives/ubuntu-announce/2024-June/000302.html

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
