### PR TITLE
Experiment: Attempt to automate PPA release selection

### DIFF
--- a/.github/workflows/ppa-automation.yaml
+++ b/.github/workflows/ppa-automation.yaml
@@ -7,16 +7,13 @@ on:
       - "v[0-9]+.[0-9a-z]+.[0-9a-z]+"
   schedule:
     - cron: "0 5 * * *"
-  pull_request:
-    branches:
-      - main
 
 jobs:
   ppa-release-candidate:
     name: PPA Releases
     if: github.repository == 'mozilla-mobile/mozilla-vpn-client'
     runs-on: ubuntu-latest
-    #environment: PPA Automation
+    environment: PPA Automation
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -42,7 +39,7 @@ jobs:
           GITREF: ${{github.ref}}
         run: |
           git clone --depth 1 -b ubuntu/devel git://git.launchpad.net/ubuntu/+source/distro-info-data
-          echo "releases<<EOF" >> $GITHUB_OUTPUT
+          echo -n "releases" >> $GITHUB_OUTPUT
           tail -n+2 distro-info-data/ubuntu.csv | while read -r line; do
             IFS=',' read -ra data <<< "$line"
             now=$(date +%s)
@@ -54,10 +51,10 @@ jobs:
               echo "Ignoring release ${data[2]} -> unreleased ${data[4]}"
               continue # Ignore releases more than 60 days in the future
             fi
-            echo "Accepting release ${data[2]}"
-            echo "${data[2]}" >> $GITHUB_OUTPUT
+            echo "Targeting release ${data[2]}"
+            echo -n "${data[2]} " >> $GITHUB_OUTPUT
           done
-          echo "EOF" >> $GITHUB_OUTPUT
+          echo "" >> $GITHUB_OUTPUT
 
           if [[ "$GITREF" == "refs/heads/main" ]]; then
             echo "ppa-url=ppa:okirby/mozilla-vpn-nightly" >> $GITHUB_OUTPUT
@@ -81,8 +78,8 @@ jobs:
         env:
           DEBEMAIL: ${{ github.actor }}@users.noreply.github.com
           DEBFULLNAME: ${{ github.actor }}
-          #GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-          #GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
           GNUPGHOME: ${{ runner.temp }}/gnupg-data
           PPA_TARGET_DISTS: ${{ steps.decision.outputs.releases }}
           PPA_URL: ${{ steps.decision.outputs.ppa-url }}
@@ -91,10 +88,10 @@ jobs:
           echo "allow-preset-passphrase" > $GNUPGHOME/gpg-agent.conf
           gpgconf --kill gpg-agent
 
-          # echo "$GPG_PRIVATE_KEY" | gpg --import --batch
-          # KEYID=$(gpg --with-colons --list-keys | grep -m1 '^fpr:' | tr -d [fpr:])
-          # KEYGRIP=$(gpg --with-colons --with-keygrip --list-keys | grep -m1 '^grp:' | tr -d [grp:])
-          # echo "$GPG_PASSWORD" | /lib/gnupg2/gpg-preset-passphrase --preset $KEYGRIP
+          echo "$GPG_PRIVATE_KEY" | gpg --import --batch
+          KEYID=$(gpg --with-colons --list-keys | grep -m1 '^fpr:' | tr -d [fpr:])
+          KEYGRIP=$(gpg --with-colons --with-keygrip --list-keys | grep -m1 '^grp:' | tr -d [grp:])
+          echo "$GPG_PASSWORD" | /lib/gnupg2/gpg-preset-passphrase --preset $KEYGRIP
 
           JOB_EXIT_CODE=0
           PACKAGE_DSC_FILE=$(find . -name '*.dsc')
@@ -106,9 +103,9 @@ jobs:
             PACKAGE_DIST_VERSION=${PACKAGE_BASE_VERSION}-${dist}1
 
             dch -c $(pwd)/mozillavpn-source/debian/changelog -v ${PACKAGE_DIST_VERSION} -D ${dist}  "Release for ${dist}"
-            #(cd mozillavpn-source && dpkg-buildpackage --build=source --sign-key=$KEYID -sa --no-check-builddeps)
+            (cd mozillavpn-source && dpkg-buildpackage --build=source --sign-key=$KEYID -sa --no-check-builddeps)
 
-            #dput $PPA_URL ${PACKAGE_SOURCE_NAME}_${PACKAGE_DIST_VERSION}_source.changes || JOB_EXIT_CODE=1
+            dput $PPA_URL ${PACKAGE_SOURCE_NAME}_${PACKAGE_DIST_VERSION}_source.changes || JOB_EXIT_CODE=1
             rm -rf $(pwd)/mozillavpn-source
           done
 

--- a/.github/workflows/ppa-automation.yaml
+++ b/.github/workflows/ppa-automation.yaml
@@ -7,13 +7,16 @@ on:
       - "v[0-9]+.[0-9a-z]+.[0-9a-z]+"
   schedule:
     - cron: "0 5 * * *"
+  pull_request:
+    branches:
+      - main
 
 jobs:
   ppa-release-candidate:
     name: PPA Releases
     if: github.repository == 'mozilla-mobile/mozilla-vpn-client'
     runs-on: ubuntu-latest
-    environment: PPA Automation
+    #environment: PPA Automation
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -32,13 +35,29 @@ jobs:
           sudo apt-get update
           sudo apt-get install golang debhelper devscripts dput-ng -y
 
-      - name: Build source bundle
-        id: gen-source
+      - name: Decision
+        id: decision
         shell: bash
         env:
           GITREF: ${{github.ref}}
         run: |
-          ./scripts/linux/script.sh --source --gitref ${GITREF}
+          git clone --depth 1 -b ubuntu/devel git://git.launchpad.net/ubuntu/+source/distro-info-data
+          echo "releases<<EOF" >> $GITHUB_OUTPUT
+          tail -n+2 distro-info-data/ubuntu.csv | while read -r line; do
+            IFS=',' read -ra data <<< "$line"
+            now=$(date +%s)
+            if [ $(date -d "${data[5]}" +%s) -lt $now ]; then
+              echo "Ignoring release ${data[2]} -> eol ${data[5]}"
+              continue # Ignore EOL releases
+            fi
+            if [ $(date -d "${data[4]}" +%s) -gt $((now + 5184000)) ]; then
+              echo "Ignoring release ${data[2]} -> unreleased ${data[4]}"
+              continue # Ignore releases more than 60 days in the future
+            fi
+            echo "Accepting release ${data[2]}"
+            echo "${data[2]}" >> $GITHUB_OUTPUT
+          done
+          echo "EOF" >> $GITHUB_OUTPUT
 
           if [[ "$GITREF" == "refs/heads/main" ]]; then
             echo "ppa-url=ppa:okirby/mozilla-vpn-nightly" >> $GITHUB_OUTPUT
@@ -50,27 +69,32 @@ jobs:
             echo "submit-changes=true" >> $GITHUB_OUTPUT
           fi
 
+      - name: Build source bundle
+        id: gen-source
+        shell: bash
+        run: ./scripts/linux/script.sh --source --gitref ${{github.ref}}
+
       - name: Push to Launchpad PPA
         shell: bash
         working-directory: .tmp
-        if: ${{ steps.gen-source.outputs.submit-changes == 'true' }}
+        if: ${{ steps.decision.outputs.submit-changes == 'true' }}
         env:
           DEBEMAIL: ${{ github.actor }}@users.noreply.github.com
           DEBFULLNAME: ${{ github.actor }}
-          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-          GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
+          #GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          #GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
           GNUPGHOME: ${{ runner.temp }}/gnupg-data
-          PPA_TARGET_DISTS: focal jammy noble
-          PPA_URL: ${{ steps.gen-source.outputs.ppa-url }}
+          PPA_TARGET_DISTS: ${{ steps.decision.outputs.releases }}
+          PPA_URL: ${{ steps.decision.outputs.ppa-url }}
         run: |
           mkdir -m700 $GNUPGHOME
           echo "allow-preset-passphrase" > $GNUPGHOME/gpg-agent.conf
           gpgconf --kill gpg-agent
 
-          echo "$GPG_PRIVATE_KEY" | gpg --import --batch
-          KEYID=$(gpg --with-colons --list-keys | grep -m1 '^fpr:' | tr -d [fpr:])
-          KEYGRIP=$(gpg --with-colons --with-keygrip --list-keys | grep -m1 '^grp:' | tr -d [grp:])
-          echo "$GPG_PASSWORD" | /lib/gnupg2/gpg-preset-passphrase --preset $KEYGRIP
+          # echo "$GPG_PRIVATE_KEY" | gpg --import --batch
+          # KEYID=$(gpg --with-colons --list-keys | grep -m1 '^fpr:' | tr -d [fpr:])
+          # KEYGRIP=$(gpg --with-colons --with-keygrip --list-keys | grep -m1 '^grp:' | tr -d [grp:])
+          # echo "$GPG_PASSWORD" | /lib/gnupg2/gpg-preset-passphrase --preset $KEYGRIP
 
           JOB_EXIT_CODE=0
           PACKAGE_DSC_FILE=$(find . -name '*.dsc')
@@ -82,9 +106,9 @@ jobs:
             PACKAGE_DIST_VERSION=${PACKAGE_BASE_VERSION}-${dist}1
 
             dch -c $(pwd)/mozillavpn-source/debian/changelog -v ${PACKAGE_DIST_VERSION} -D ${dist}  "Release for ${dist}"
-            (cd mozillavpn-source && dpkg-buildpackage --build=source --sign-key=$KEYID -sa --no-check-builddeps)
+            #(cd mozillavpn-source && dpkg-buildpackage --build=source --sign-key=$KEYID -sa --no-check-builddeps)
 
-            dput $PPA_URL ${PACKAGE_SOURCE_NAME}_${PACKAGE_DIST_VERSION}_source.changes || JOB_EXIT_CODE=1
+            #dput $PPA_URL ${PACKAGE_SOURCE_NAME}_${PACKAGE_DIST_VERSION}_source.changes || JOB_EXIT_CODE=1
             rm -rf $(pwd)/mozillavpn-source
           done
 


### PR DESCRIPTION
## Description
It is a little bit annoying to have to manually update the list of current Ubuntu releases everytime something new comes along or a release goes EOL. So why not automate it by pulling the release data directly from the [distro-info-data](https://launchpad.net/ubuntu/+source/distro-info-data) repository and computing which releases are active.

## Reference

    i.e Jira or Github issue URL

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
