### PR TITLE
Set include-hidden-files in the Linux/Source workflow

### DIFF
--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -44,6 +44,7 @@ jobs:
         with:
           name: Sources
           path: .tmp
+          include-hidden-files: true
 
   flatpak:
     name: Flatpak Packages

--- a/.github/workflows/ppa-automation.yaml
+++ b/.github/workflows/ppa-automation.yaml
@@ -96,3 +96,4 @@ jobs:
         with:
           name: Sources
           path: .tmp
+          include-hidden-files: true


### PR DESCRIPTION
## Description
Starting September 2nd, Github workflows now exclude all hidden files and directories from the `actions/upload-artifact` workflows by default. This is intended as a security measure to make it harder to accidentally export and upload credential files.

However, this breaks our `Linux/Source` workflow which stages the sources in `.tmp` before passing them onto another task, and it has been the reason the Linux workflow has been failing ever since.

## Reference
See: https://github.blog/changelog/2024-08-19-notice-of-upcoming-deprecations-and-breaking-changes-in-github-actions-runners/

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
