### PR TITLE
Maybe fix testWebExtensionApi.js

### DIFF
--- a/tests/functional/testWebExtensionApi.js
+++ b/tests/functional/testWebExtensionApi.js
@@ -94,7 +94,7 @@ describe('WebExtension API', function() {
   it('A Webextension can get a Subset of the Featurelist', async () => {
     const sock = await connectExtension();
     const messagePipe = getMessageStream(sock);
-    const isProxyEnabled = await this.isFeatureEnabled('localProxy');
+    const isProxyEnabled = await vpn.isFeatureEnabled('localProxy');
 
 
     const response = readResponseOfType('featurelist', messagePipe);


### PR DESCRIPTION
## Description
I have noticed that the `tetWebExtensionApi.js` has been failing, and the test ends with

```
     4 passing (22s)
    1 failing
  
    1) WebExtension API
         A Webextension can get a Subset of the Featurelist:
       TypeError: this.isFeatureEnabled is not a function
        at Context.<anonymous> (tests/functional/testWebExtensionApi.js:97:39)
```

I think this was a simple typo. The test was calling `this.isFeatureEnabled()` when it ought to have called `vpn.isFeatureEnabled()`.

## Reference

    i.e Jira or Github issue URL

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
