### PR TITLE
Fix typo in ppa-automation workflow

### DIFF
--- a/.github/workflows/ppa-automation.yaml
+++ b/.github/workflows/ppa-automation.yaml
@@ -39,7 +39,7 @@ jobs:
           GITREF: ${{github.ref}}
         run: |
           git clone --depth 1 -b ubuntu/devel git://git.launchpad.net/ubuntu/+source/distro-info-data
-          echo -n "releases" >> $GITHUB_OUTPUT
+          echo -n "releases=" >> $GITHUB_OUTPUT
           tail -n+2 distro-info-data/ubuntu.csv | while read -r line; do
             IFS=',' read -ra data <<< "$line"
             now=$(date +%s)


### PR DESCRIPTION
## Description
In my last round of PPA automation hacking, I attempted to auto-generate the list of current Ubuntu distributions by fetching the distro-info-data repository and parsing the Ubuntu release data for EOL and release date.

Unfortunately, I left a typo in the file that led to a corrupted github outputs. Shame on me!

The workflow ends with an error message like the following:

```
Error: Unable to process file command 'output' successfully.
Error: Invalid format 'releasesfocal jammy noble oracular '
```

## Reference
PR Introducing the issue: #9828

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
