### PR TITLE
slow staging checks

### DIFF
--- a/src/constants.h
+++ b/src/constants.h
@@ -160,11 +160,11 @@ namespace Timers {
 #endif
 using namespace std::chrono_literals;
 // How often we check for updates
-TIMEREXPR(releaseMonitor, 6h, 4s, 0s)
+TIMEREXPR(releaseMonitor, 6h, 30s, 0s)
 // How often should we do periodic things (i.e update Serverlist)
 TIMEREXPR(schedulePeriodicTask, 60min, 5min, 0ms)
 // How often we should check for a Captive portal
-TIMEREXPR(captivePortalRequest, 10s, 4s, 0ms)
+TIMEREXPR(captivePortalRequest, 10s, 30s, 0ms)
 // How fast the animated icon should move
 TIMEREXPR(statusIconAnimation, 200ms, 200ms, 0ms)
 // How often glean pings are sent


### PR DESCRIPTION
## Description

Slow down some of the staging checks. I couldn't find any other super-frequent ones that are more frequent than they are on prod. (There are some "once per second" checks, but they're that way on both staging and prod.)

## Reference

N/A

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
