### PR TITLE
VPN-6570/VPN-6583: Fix logout race condition when VPN is active

### DIFF
--- a/nebula/ui/components/MZSignOut.qml
+++ b/nebula/ui/components/MZSignOut.qml
@@ -31,6 +31,6 @@ MZFooterLink {
 
     onClicked: () => {
         preLogoutCallback();
-        VPNController.logout();
+        VPN.logout();
     }
 }

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -372,23 +372,6 @@ void Controller::updateRequired() {
   }
 }
 
-void Controller::logout() {
-  logger.debug() << "Logout";
-
-  MozillaVPN::instance()->logout();
-
-  if (m_state == StateOff) {
-    return;
-  }
-
-  m_nextStep = Disconnect;
-
-  if (m_state == StateOn || m_state == StateOnPartial) {
-    deactivate();
-    return;
-  }
-}
-
 void Controller::activateInternal(
     DNSPortPolicy dnsPort,
     ServerSelectionPolicy serverSelectionPolicy = RandomizeServerSelection,

--- a/src/controller.h
+++ b/src/controller.h
@@ -84,7 +84,6 @@ class Controller : public QObject, public LogSerializer {
 
   int connectionRetry() const { return m_connectionRetry; }
   State state() const;
-  Q_INVOKABLE void logout();
   bool silentServerSwitchingSupported() const;
   void cleanupBackendLogs();
 

--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -767,6 +767,8 @@ void MozillaVPN::logout() {
 
   ErrorHandler::instance()->requestAlert(ErrorHandler::LogoutAlert);
 
+  deactivate();
+
   TaskScheduler::deleteTasks();
 
   // Schedule the removal of our device and let it run in the background.

--- a/src/mozillavpn.h
+++ b/src/mozillavpn.h
@@ -167,7 +167,7 @@ class MozillaVPN final : public App {
 
   Q_INVOKABLE void silentSwitch();
 
-  void logout();
+  Q_INVOKABLE void logout();
 
   bool startMinimized() const { return m_startMinimized; }
 

--- a/src/ui/main.qml
+++ b/src/ui/main.qml
@@ -155,7 +155,7 @@ Window {
     Connections {
         target: VPN
         function onAccountDeleted() {
-            VPNController.logout();
+            VPN.logout();
         }
     }
 

--- a/src/ui/screens/ScreenSubscriptionInUseError.qml
+++ b/src/ui/screens/ScreenSubscriptionInUseError.qml
@@ -27,7 +27,7 @@ MZStackView {
            primaryButtonText: MZI18n.GlobalSignOut,
            primaryButtonObjectName: "errorSignOutButton",
            primaryButtonOnClick: () => {
-               VPNController.logout();
+               VPN.logout();
                stackView.pop();
            },
            secondaryButtonIsSignOff: false,

--- a/src/ui/screens/devices/ViewDeviceLimit.qml
+++ b/src/ui/screens/devices/ViewDeviceLimit.qml
@@ -86,7 +86,7 @@ MZViewBase {
             labelText: MZI18n.GlobalSignOut
             fontName: MZTheme.theme.fontBoldFamily
             linkColor: MZTheme.theme.redLinkButton
-            onClicked: VPNController.logout();
+            onClicked: VPN.logout();
         }
     }
 

--- a/tests/qml/moccontroller.cpp
+++ b/tests/qml/moccontroller.cpp
@@ -39,8 +39,6 @@ void Controller::disconnected() {}
 
 void Controller::timerTimeout() {}
 
-void Controller::logout() {}
-
 bool Controller::processNextStep() { return false; }
 
 void Controller::setState(State) {}

--- a/tests/unit/moccontroller.cpp
+++ b/tests/unit/moccontroller.cpp
@@ -43,8 +43,6 @@ void Controller::disconnected() {}
 
 void Controller::timerTimeout() {}
 
-void Controller::logout() {}
-
 bool Controller::processNextStep() { return false; }
 
 void Controller::setState(State) {}


### PR DESCRIPTION
## Description
We have something of a race condition in the handling of the logout proceedure whenever the VPN is active. This seems to be due to some spaghetti code around this proceedure and being a bit too overzealous in our efforts to deactivate the VPN. 

The race condition goes something like this:
1. The user clicks a `Sign Out` button somewhere in the QML, which invokes `Controller::logout()`
2. `Controller::logout()` then calls `MozillaVPN::logout()` to clear out state and log out:
    - Schedules a task to remove the device's public key.
    - Schedules a task to deactivate the VPN.
    - Flush out the application state, erase settings, and reset.
3.  `MozillaVPN::logout()` returns, and execution continues in `Controller::logout()` which then immediately deactivates the VPN.
4. The device removal task scheduled above gets abruptly disconnected before completing. This leaves it ambiguous if the device actually got removed on Guardian and Mullvad.
    - On Linux the `QNetworkRequest` never connects and hangs forever, resulting in a deadlocked task queue that prevents any future actions (such as logging back in).
    - On MacOS/Windows, the `QNetworkRequest` terminates immediately with an error, resulting in a bunch of spurious error banners on logout.

To resolve this, I think we should refactor the logout a bit. In particular:
1. Remove `Controller::logout()`. The QML should call `MozillaVPN::logout()` instead to do this job.
2. Do not perform an immediate deactivation upon logout, rely on the task queue to do it.
3. Perform the VPN deactivation first, and do the device removal second. This minimizes the time window during which the VPN can be active while the user is logged out. 

## Reference
JIRA Issue: [VPN-6570](https://mozilla-hub.atlassian.net/browse/VPN-6570)
JIRA Issue: [VPN-6583](https://mozilla-hub.atlassian.net/browse/VPN-6583)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-6570]: https://mozilla-hub.atlassian.net/browse/VPN-6570?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ