### PR TITLE
Avoid Start loops for localproxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ linux/netfilter/vendor/
 .tmp
 .env
 .venv
+.cache/clangd
 __pycache__
 lottie.mjs
 qml_lint_result.txt

--- a/src/proxycontroller.cpp
+++ b/src/proxycontroller.cpp
@@ -5,8 +5,6 @@
 
 #include "proxycontroller.h"
 
-#include <QObject.h>
-
 #include <QDir>
 #include <QFileInfo>
 #include <QJsonDocument>

--- a/src/proxycontroller.h
+++ b/src/proxycontroller.h
@@ -5,11 +5,11 @@
 
 #pragma once
 
-#include <QObject>
 #include <QPointer>
-#include <QProcess>
 #include <QProperty>
 #include <QUrl>
+
+class QProcess;
 
 class ProxyController {
  public:
@@ -29,7 +29,7 @@ class ProxyController {
   // Returns true if the proxy is alive
   State state() { return m_state.value(); }
   // Returns a bindable in case state changes.
-  QBindable<State> stateBindable() { return QBindable<State>(&m_state); }
+  QBindable<State> stateBindable() { return {&m_state}; }
 
   /**
    * @brief Returns the Path of the Binary to Exclude

--- a/src/proxycontroller.h
+++ b/src/proxycontroller.h
@@ -62,5 +62,6 @@ class ProxyController {
   QProperty<State> m_state;
   QPointer<QProcess> mCurrentProcess;
   QMetaObject::Connection mCrashSignal;
+  QMetaObject::Connection mErrorSignal;
   std::optional<bool> m_canActivate;
 };


### PR DESCRIPTION
Ohno who wrote all that? 
![4207562-spider-point](https://github.com/user-attachments/assets/686bd816-b045-4f0a-84e6-5b5069a4498f)

## Description
The biggest culprit for an endless loop is this
```c++
mCrashSignal = QObject::connect(
      mCurrentProcess, &QProcess::finished, [this](){ ..., start()}
```

So whenever the proxy would exit, we would try to reboot it, which sounds sensible. *IN THEORY* 

Except that i did forget to remove that listener when we actually want to stop it. i.e we switch servers or disconnect, or extra fun in `QObject::connect(mCurrentProcess, &QProcess::errorOccurred,`. 

This means on any error we call  
```
QProcess::errorOccurred -> calls stop() -> triggers QProcess::finished -> calls start() -> which given we have a m_process calls kill() -> WHICH TRIGGERS QProcess::errorOccurred  -> which calls stop() -> ....
```

- so stop now actually removes signals from the about to be killed process. No loops. 
- The unexpected kill check `&QProcess::finished` schedules the start by putting an event on the loop, which means qt will (as its then marked with delete later) cleanup the old process first. 



