### PR TITLE
VPN-6475: Parse and log Guardian errors

### DIFF
--- a/src/cmake/sources.cmake
+++ b/src/cmake/sources.cmake
@@ -110,6 +110,8 @@ target_sources(mozillavpn-sources INTERFACE
     ${CMAKE_CURRENT_SOURCE_DIR}/localsocketcontroller.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/localsocketcontroller.h
     ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/models/apierror.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/models/apierror.h
     ${CMAKE_CURRENT_SOURCE_DIR}/models/device.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/models/device.h
     ${CMAKE_CURRENT_SOURCE_DIR}/models/devicemodel.cpp

--- a/src/models/apierror.cpp
+++ b/src/models/apierror.cpp
@@ -1,0 +1,49 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "apierror.h"
+
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonValue>
+
+ApiError::ApiError(const ApiError& other) {
+  *this = other;
+}
+
+ApiError& ApiError::operator=(const ApiError& other) {
+  if (this == &other) return *this;
+
+  m_code = other.m_code;
+  m_errnum = other.m_errnum;
+  m_message = other.m_message;
+
+  return *this;
+}
+
+bool ApiError::fromJson(const QByteArray& json) {
+  QJsonDocument doc = QJsonDocument::fromJson(json);
+  if (!doc.isObject()) {
+    return false;
+  }
+  QJsonObject obj = doc.object();
+
+  QJsonValue code = obj.value("code");
+  if (!code.isDouble()) {
+    return false;
+  }
+  QJsonValue errnum = obj.value("errno");
+  if (!errnum.isDouble()) {
+    return false;
+  }
+  QJsonValue message = obj.value("error");
+  if (!message.isString()) {
+    return false;
+  }
+
+  m_code = code.toInt();
+  m_errnum = errnum.toInt();
+  m_message = message.toString();
+  return true;
+}

--- a/src/models/apierror.h
+++ b/src/models/apierror.h
@@ -1,0 +1,78 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef APIERROR_H
+#define APIERROR_H
+
+#include <QString>
+#include <QObject>
+
+class QByteArray;
+
+class ApiError final {
+  Q_GADGET
+
+ public:
+  ApiError() {};
+  ApiError(const ApiError& other);
+  ApiError& operator=(const ApiError& other);
+
+  // Error codes transcribed from guardian-website/server/lib/errors.ts
+  enum ErrorNumbers : int {
+    NoError = 0,
+
+    MissingPubkeyError = 100,
+    MissingNameError = 101,
+    InvalidPubkeyError = 102,
+    PubkeyAlreadyUsed = 103,
+    KeyLimitReachedError = 104,
+    PubkeyNotFound = 105,
+    SecretKeyNotFound = 106,
+
+    FxaUnauthorizedForRouteError = 110,
+
+    InvalidToken = 120,
+    UserNotFound = 121,
+    DeviceNotFound = 122,
+    NoActiveSubsription = 123,
+    MissingAuthCodeError = 127,
+    MissingAuthCodeVerifierError = 128,
+    AuthCodeExpiredError = 129,
+    InvalidAuthCodeVerifierError = 130,
+    MissingReceiptError = 141,
+    UserAlreadyHasActiveSubscription = 143,
+    ReceiptIsBeingUsed = 145,
+    InvalidTokenError = 147,
+    InvalidSkuError = 148,
+    MissingTokenError = 149,
+    MissingSkuError = 150,
+    FxaTokenValidationError = 151,
+    FxaPlansError = 152,
+    FxaSupportTicketError = 153,
+    FxaSupportTicketNotReturned = 154,
+    SupportTicketIssueTextSizeError = 155,
+    SupportTicketMissingLogsError = 157,
+    MissingAccessToken = 159,
+    AdjustMissingOrInvalidHeaders = 161,
+    AdjustMissingOrInvalidPath = 162,
+    FxaScopesNotAllowedError = 163,
+    MissingOriginalTransactionIdError = 164,
+    MissingExperimenterIdOrAuthHeader = 165,
+  };
+  Q_ENUM(ErrorNumbers);
+
+  bool fromJson(const QByteArray& json);
+
+  int code() const { return m_code; }
+  int errnum() const { return m_errnum; }
+  const QString& message() const { return m_message; }
+  const QString& error() const { return m_message; }
+
+ private:
+  int m_code = 0;
+  int m_errnum = 0;
+  QString m_message;
+};
+
+#endif  // APIERROR_H

--- a/src/networkrequest.cpp
+++ b/src/networkrequest.cpp
@@ -15,6 +15,7 @@
 
 #include "leakdetector.h"
 #include "logger.h"
+#include "models/apierror.h"
 #include "networkmanager.h"
 #include "settingsholder.h"
 #include "task.h"
@@ -253,6 +254,15 @@ void NetworkRequest::processData(QNetworkReply::NetworkError error,
                    << "status code:" << status
                    << "- body:" << logger.sensitive(data);
     logger.error() << "Failed to access:" << m_request.url().toString(options);
+
+    ApiError err;
+    QString contentType =
+        m_reply->header(QNetworkRequest::ContentTypeHeader).toString();
+    if (contentType.contains("json") && err.fromJson(data)) {
+      logger.error() << "Remote API error" << err.errnum()
+                     << "-" << err.message();
+    }
+
     emit requestFailed(error, data);
     return;
   }


### PR DESCRIPTION
## Description
Sometimes it can be difficult to diagnose the cause of an error caused by an interaction with Guardian, or any other Mozilla web service. This is made extra tricky when the error handling in the `NetworkRequest` class treats the response body as sensitive and scrubs it from the logs.

To try and make diagnosis a little better, let's make an attempt to parse the error responses and log them if they happen to be parseable as such. To my knowledge, there are no API errors we get back from Guardian which contain sensitive information.

The format of these errors ought to match the [ApiErrorJson](https://github.com/mozilla-services/guardian-website/blob/2eb7ad4188db6bd5d4f48a15dd2768f89c143bc6/server/lib/errors.ts#L77-L82) type in the Guardian website:
```ts
interface ApiErrorJson {
  code: number;
  errno: number;
  error: string;
}
```

## Reference
JIRA Issue: [VPN-6475](https://mozilla-hub.atlassian.net/browse/VPN-6475)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
