### PR TITLE
Fix possible test race when restarting the VPN client

### DIFF
--- a/tests/functional/testFactoryReset.js
+++ b/tests/functional/testFactoryReset.js
@@ -71,7 +71,7 @@ describe('Factory Reset', function() {
     await vpn.clickOnQueryAndAcceptAnyResults(queries.screenGetHelp.resetView.CONFIRM_RESET_BUTTON.visible());
 
     // Confirm the app quit
-    assert.equal(setup.vpnIsInactive(), true);
+	await vpn.waitForCondition(() => !setup.vpnIsRunning());
 
     // relaunch app
 	await setup.startAndConnect();


### PR DESCRIPTION
## Description
I think I have managed to figure out a possible race in the functional tests when restarting the VPN client. What we see sometimes is that the client needs to be terminated, and restarted for some reason. The race goes something like this:

1. The client is instructed to quit by sending a `quit` command over the inspector. This does little more than dump a string into a websocket and return.
2. Quitting, for whatever reason, takes a bit of time as destructors run, threads are reaped, telemetry is sent and so on.
3. Meanwhile, the test carries on and a new client is launched via `setup.startAndConnect()`
4. The new client, in `EventListener::checkForInstances()` finds that the UI socket is still alive, because the last client hasn't finished quitting. So the new client sends message over the socket and exits.
5. The test is unaware of this, and attempts to open a websocket connection to the new client, who has just exited.

Because there are two instances of the client running during this race, parsing the logs can be a bit of a challenge, but the smoking gun here is that the `(EventListener) Debug: event listener released` message is found after the new client decides to exit with `(CommandUI) Debug: Terminating the current process` which suggests that the old client is in the process of shutting down as the new client is starting.

The solution here, is that we should wait for the client to exit before starting a new one. We do so by adding a check to `setup.startAndConnect()` to see if the `vpnProcessTerminatePromise` is unresolved, and to await on it before starting a new client.

## Reference
Flaky test example: https://github.com/mozilla-mobile/mozilla-vpn-client/actions/runs/10841772845/attempts/1

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
