### PR TITLE
VPN-6598: Update taskcluster Qt jobs to 6.6.3

### DIFF
--- a/taskcluster/kinds/build/linux.yml
+++ b/taskcluster/kinds/build/linux.yml
@@ -97,7 +97,7 @@ linux64/next-deb:
         platform: linux/x86_64
     fetches:
         toolchain:
-            - qt-linux-6.6
+            - qt-linux-next
     worker:
         docker-image: {in-tree: linux-qt6-build}
     run:

--- a/taskcluster/kinds/fetch/kind.yml
+++ b/taskcluster/kinds/fetch/kind.yml
@@ -66,23 +66,16 @@ tasks:
             size: 106401416
         fetch-alias: miniconda-osx
     qt-source-tarball:
-        description: Qt 6.2.4 Source Tarball
-        fetch:
-            type: static-url
-            url: https://download.qt.io/archive/qt/6.2/6.2.4/single/qt-everywhere-src-6.2.4.tar.xz
-            sha256: cfe41905b6bde3712c65b102ea3d46fc80a44c9d1487669f14e4a6ee82ebb8fd
-            size: 661663792
-    qt-source-tarball-6.6.0:
-        description: Qt 6.6.0 Source Tarball
-        fetch:
-            type: static-url
-            url: https://download.qt.io/archive/qt/6.6/6.6.0/single/qt-everywhere-src-6.6.0.tar.xz
-            sha256: 652538fcb5d175d8f8176c84c847b79177c87847b7273dccaec1897d80b50002
-            size: 812361632
-    qt-source-tarball-6.6.3:
         description: Qt 6.6.3 Source Tarball
         fetch:
             type: static-url
             url: https://download.qt.io/archive/qt/6.6/6.6.3/single/qt-everywhere-src-6.6.3.tar.xz
             sha256: 69d0348fef415da98aa890a34651e9cfb232f1bffcee289b7b4e21386bf36104
             size: 801192112
+    qt-source-tarball-next:
+        description: Qt 6.7.2 Source Tarball
+        fetch:
+            type: static-url
+            url: https://download.qt.io/archive/qt/6.7/6.7.2/single/qt-everywhere-src-6.7.2.tar.xz
+            sha256: 0aaea247db870193c260e8453ae692ca12abc1bd841faa1a6e6c99459968ca8a
+            size: 935696876

--- a/taskcluster/kinds/toolchain/qt.yml
+++ b/taskcluster/kinds/toolchain/qt.yml
@@ -13,7 +13,7 @@ qt-macos-6.6:
     description: "Mac QT compile Task"
     fetches:
         fetch:
-            - qt-source-tarball-6.6.3
+            - qt-source-tarball
             - miniconda-osx
     run:
         use-caches: false
@@ -75,26 +75,20 @@ qt-linux:
     worker-type: b-linux-large
     worker:
         docker-image: {in-tree: linux-qt6-build}
-        env:
-            QT_VERSION: "6.2.4"
-            QT_MAJOR: "6.2"
 
-qt-linux-6.6.0:
+qt-linux-next:
     description: "Linux QT compile Task"
     fetches:
         fetch:
-            - qt-source-tarball-6.6.0
+            - qt-source-tarball-next
     run:
         script: compile_qt_6_linux.sh
         resources:
             - scripts/utils/qt6_compile.sh
-        toolchain-alias: qt-linux-6.6
+        toolchain-alias: qt-linux-next
         toolchain-artifact: public/build/qt6_linux.tar.xz
     treeherder:
-        symbol: TL(qt-linux-6.6)
+        symbol: TL(qt-linux-next)
     worker-type: b-linux-large
     worker:
         docker-image: {in-tree: linux-qt6-build}
-        env:
-            QT_VERSION: "6.6.0"
-            QT_MAJOR: "6.6"


### PR DESCRIPTION
## Description
Doing a bit of an update cycle to our Qt taskclusters jobs. This should settle on Qt 6.6.3 for all of the release targets, and then upgrades the Qt/next targets to version 6.7.2 (the latest release as of today).

Most notably, this should upgrade the Linux static builds to 6.6.3 from 6.2.4, which was the last straggler on 6.2.x (excluding the PPA packaged builds, which we don't have any real control over).

As a minor annoyance, I wish we didn't have the Qt version number in the artifact URL for the Windows and MacOS builds, but we can't really change those because they are relied on externally via the Github CI jobs.

## Reference
JIRA Issue: [VPN-6598](https://mozilla-hub.atlassian.net/browse/VPN-6598)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-6598]: https://mozilla-hub.atlassian.net/browse/VPN-6598?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ