### PR TITLE
Maybe fix test race in authentication helpers

### DIFF
--- a/src/ui/screens/authenticationInApp/ViewAuthenticationInApp.qml
+++ b/src/ui/screens/authenticationInApp/ViewAuthenticationInApp.qml
@@ -15,7 +15,9 @@ Item {
 
     Loader {
         id: loader
+        objectName: "authLoader"
         property bool isReauthFlow: false
+        property bool ready: status === Loader.Ready
 
         // This is only necessary to fix a text layout bug in Qt 6.4,
         // which can sometimes be pulled in on Linux. Remove this once we move

--- a/tests/functional/helper.js
+++ b/tests/functional/helper.js
@@ -466,6 +466,9 @@ module.exports = {
 
     // Click on get started and wait for authenticating view
     await this.clickOnQuery(queries.screenInitialize.SIGN_UP_BUTTON.visible());
+    // Wait for the authentication view to finish loading.
+    await this.waitForQuery(queries.screenAuthenticationInApp.AUTH_LOADER.ready());
+
     await this.waitForQuery(
         queries.screenAuthenticationInApp.AUTH_START_TEXT_INPUT.visible());
     await this.setQueryProperty(

--- a/tests/functional/queries.js
+++ b/tests/functional/queries.js
@@ -151,6 +151,7 @@ const screenTelemetry = {
 const screenAuthenticationInApp = {
   AUTH_TERMS_OF_SERVICE: new QmlQueryComposer('//termsOfService'),
   AUTH_PRIVACY_NOTICE: new QmlQueryComposer('//privacyPolicy'),
+  AUTH_LOADER: new QmlQueryComposer('//authLoader'),
 
   AUTH_START_TEXT_INPUT: new QmlQueryComposer('//authStart-textInput'),
   AUTH_START_BUTTON: new QmlQueryComposer('//authStart-button'),


### PR DESCRIPTION
## Description
There seems to be a race in the authentication helpers during functional testing. This results in a hang during the login (often breaking a test in the `beforeEach` step), and it tends to fall over as the authentication view fails to receive a click event after setting the user email.

I suspect this is caused by the asynchronous QML loader used in `ViewAuthenticationInApp.qml` which means that the QML is being loaded in a background task, making it somewhat uncertain what happens if we try to interact with the screen. I think that by adding a `ready` property we can wait for the loading to finish before proceeding with the authentication steps.

## Reference

    i.e Jira or Github issue URL

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
