### PR TITLE
VPN-6512: Update Apple in app purchase to use StoreKit2

### DIFF
--- a/src/cmake/ios.cmake
+++ b/src/cmake/ios.cmake
@@ -98,6 +98,7 @@ target_sources(mozillavpn PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/platforms/macos/macospingsender.h
     ${CMAKE_CURRENT_SOURCE_DIR}/tasks/purchase/taskpurchase.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/tasks/purchase/taskpurchase.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/platforms/ios/iosiaphandler.swift
     ${CMAKE_CURRENT_SOURCE_DIR}/platforms/ios/iosiaphandler.mm
     ${CMAKE_CURRENT_SOURCE_DIR}/platforms/ios/iosiaphandler.h
     ${CMAKE_CURRENT_SOURCE_DIR}/platforms/ios/ioscontroller.mm

--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -94,6 +94,7 @@ QString Constants::apiUrl(ApiEndpoint endpoint) {
 #endif
 #ifdef MZ_IOS
       {ApiEndpoint::PurchasesIOS, "/api/v1/vpn/purchases/ios"},
+      {ApiEndpoint::PurchasesIOSv2, "/api/v2/vpn/purchases/ios"},
 #endif
 #ifdef MZ_WASM
       {ApiEndpoint::PurchasesWasm, "/api/v1/vpn/purchases/wasm"},

--- a/src/constants.h
+++ b/src/constants.h
@@ -35,6 +35,7 @@ enum ApiEndpoint {
 #endif
 #ifdef MZ_IOS
   PurchasesIOS,
+  PurchasesIOSv2,
 #endif
 #ifdef MZ_WASM
   PurchasesWasm,

--- a/src/platforms/ios/iosiaphandler.h
+++ b/src/platforms/ios/iosiaphandler.h
@@ -5,6 +5,7 @@
 #ifndef IOSIAPHANDLER_H
 #define IOSIAPHANDLER_H
 
+#include "Mozilla-Swift.h"
 #include "purchaseiaphandler.h"
 
 class IOSIAPHandler final : public PurchaseIAPHandler {
@@ -18,7 +19,8 @@ class IOSIAPHandler final : public PurchaseIAPHandler {
 
  public slots:
   void productRegistered(void* product);
-  void processCompletedTransactions(const QStringList& ids);
+  void processCompletedTransactions(const QStringList& ids,
+                                    const QString transactionIdentifier);
   void noSubscriptionFoundError();
 
  protected:
@@ -28,6 +30,12 @@ class IOSIAPHandler final : public PurchaseIAPHandler {
  private:
   void* m_delegate = nullptr;
   int discountToDays(void* discount);
+  // This is a void (and cast to InAppPurchaseHandler as needed) as the
+  // InAppPurchaseHandler needs to store Product, which is only available in iOS
+  // 15+. So the entire class must be marked as only available in iOS 15. But we
+  // can't mark this variable as only available in iOS 15+ here. Hence, we have
+  // this variable as a `void`, and cast it to InAppPurchaseHandler as needed.
+  void* swiftIAPHandler;
 };
 
 #endif  // IOSIAPHANDLER_H

--- a/src/platforms/ios/iosiaphandler.h
+++ b/src/platforms/ios/iosiaphandler.h
@@ -19,6 +19,7 @@ class IOSIAPHandler final : public PurchaseIAPHandler {
 
  public slots:
   void productRegistered(void* product);
+  void processCompletedTransactions(const QStringList& ids);
   void processCompletedTransactions(const QStringList& ids,
                                     const QString transactionIdentifier);
   void noSubscriptionFoundError();

--- a/src/platforms/ios/iosiaphandler.h
+++ b/src/platforms/ios/iosiaphandler.h
@@ -36,7 +36,7 @@ class IOSIAPHandler final : public PurchaseIAPHandler {
   // 15+. So the entire class must be marked as only available in iOS 15. But we
   // can't mark this variable as only available in iOS 15+ here. Hence, we have
   // this variable as a `void`, and cast it to InAppPurchaseHandler as needed.
-  void* swiftIAPHandler;
+  void* swiftIAPHandler = nullptr;
 };
 
 #endif  // IOSIAPHANDLER_H

--- a/src/platforms/ios/iosiaphandler.mm
+++ b/src/platforms/ios/iosiaphandler.mm
@@ -248,10 +248,9 @@ void IOSIAPHandler::nativeRegisterProducts() {
     productIdentifiers = [productIdentifiers setByAddingObject:product.m_name.toNSString()];
   }
 
-  logger.debug() << "We are about to register" << [productIdentifiers count] << "products...";
-
   if (@available(iOS 15, *)) {
-    logger.debug() << "...using StoreKit2 API.";
+    logger.debug() << "Registering" << [productIdentifiers count]
+                   << "products using StoreKit2 API.";
     [(InAppPurchaseHandler*)swiftIAPHandler getProductsWith:productIdentifiers
         productRegistrationCallback:^(NSString* productIdentifier, NSString* currencyCode,
                                       NSString* totalPrice, NSString* monthlyPrice,
@@ -289,7 +288,7 @@ void IOSIAPHandler::nativeRegisterProducts() {
         completionHandler:^{
         }];
   } else {
-    logger.debug() << "...using legacy StoreKit API.";
+    logger.debug() << "Registering" << [productIdentifiers count] << "using legacy StoreKit API.";
     SKProductsRequest* productsRequest =
         [[SKProductsRequest alloc] initWithProductIdentifiers:productIdentifiers];
 

--- a/src/platforms/ios/iosiaphandler.mm
+++ b/src/platforms/ios/iosiaphandler.mm
@@ -398,6 +398,18 @@ void IOSIAPHandler::productRegistered(void* a_product) {
   productData->m_extra = product;
 }
 
+// Called directly when using StoreKit1
+void IOSIAPHandler::processCompletedTransactions(const QStringList& ids) {
+  if (@available(iOS 15, *)) {
+    logger.error() << "This block should never be hit.";
+    assert(NO);
+  } else {
+    // For StoreKit1, we don't need a transaction identifier, so giving it some garbage.
+    processCompletedTransactions(ids, "this should never be seen");
+  }
+}
+
+// Called directly when using StoreKit2
 void IOSIAPHandler::processCompletedTransactions(const QStringList& ids, const QString transactionIdentifier) {
   logger.debug() << "process completed transactions";
 

--- a/src/platforms/ios/iosiaphandler.mm
+++ b/src/platforms/ios/iosiaphandler.mm
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "platforms/ios/iosiaphandler.h"
+#include "Mozilla-Swift.h"
 
 #include "app.h"
 #include "errorhandler.h"
@@ -137,7 +138,7 @@ bool s_transactionsProcessed = false;
         logger.debug() << "transaction deferred";
         break;
       default:
-        logger.warning() << "transaction unknwon state";
+        logger.warning() << "transaction unknown state";
         break;
     }
   }
@@ -201,9 +202,13 @@ bool s_transactionsProcessed = false;
 IOSIAPHandler::IOSIAPHandler(QObject* parent) : PurchaseIAPHandler(parent) {
   MZ_COUNT_CTOR(IOSIAPHandler);
 
-  m_delegate = [[IOSIAPHandlerDelegate alloc] initWithObject:this];
-  [[SKPaymentQueue defaultQueue]
-      addTransactionObserver:static_cast<IOSIAPHandlerDelegate*>(m_delegate)];
+  if (@available(iOS 15, *)) {
+    swiftIAPHandler = [[InAppPurchaseHandler alloc] init];
+  } else {
+    m_delegate = [[IOSIAPHandlerDelegate alloc] initWithObject:this];
+    [[SKPaymentQueue defaultQueue]
+        addTransactionObserver:static_cast<IOSIAPHandlerDelegate*>(m_delegate)];
+  }
 }
 
 IOSIAPHandler::~IOSIAPHandler() {
@@ -214,6 +219,9 @@ IOSIAPHandler::~IOSIAPHandler() {
 
   [delegate dealloc];
   m_delegate = nullptr;
+  if (@available(iOS 15, *)) {
+    swiftIAPHandler = nullptr;
+  }
 }
 
 void IOSIAPHandler::nativeRegisterProducts() {
@@ -222,21 +230,88 @@ void IOSIAPHandler::nativeRegisterProducts() {
     productIdentifiers = [productIdentifiers setByAddingObject:product.m_name.toNSString()];
   }
 
-  logger.debug() << "We are about to register" << [productIdentifiers count] << "products";
+  logger.debug() << "We are about to register" << [productIdentifiers count] << "products...";
 
-  SKProductsRequest* productsRequest =
-      [[SKProductsRequest alloc] initWithProductIdentifiers:productIdentifiers];
+  if (@available(iOS 15, *)) {
+    logger.debug() << "...using StoreKit2 API.";
+    [(InAppPurchaseHandler*)swiftIAPHandler getProductsWith:productIdentifiers
+        productRegistrationCallback:^(NSString* productIdentifier, NSString* currencyCode,
+                                      NSString* totalPrice, NSString* monthlyPrice,
+                                      double monthlyPriceNumber, NSInteger freeTrialDays) {
+          ProductsHandler* productsHandler = ProductsHandler::instance();
+          Q_ASSERT(productsHandler->isRegistering());
+          logger.debug() << "Product registered";
+          ProductsHandler::Product* productData =
+              productsHandler->findProduct(QString::fromNSString(productIdentifier));
+          Q_ASSERT(productData);
+          productData->m_price = QString::fromNSString(totalPrice);
+          productData->m_trialDays = (int)freeTrialDays;
+          productData->m_monthlyPrice = QString::fromNSString(monthlyPrice);
+          productData->m_nonLocalizedMonthlyPrice = monthlyPriceNumber;
+          productData->m_currencyCode = QString::fromNSString(currencyCode);
 
-  IOSIAPHandlerDelegate* delegate = static_cast<IOSIAPHandlerDelegate*>(m_delegate);
-  productsRequest.delegate = delegate;
-  [productsRequest start];
+          logger.debug() << "Id:" << QString::fromNSString(productIdentifier);
+          logger.debug() << "Price:" << productData->m_price;
+          logger.debug() << "Monthly price:" << productData->m_monthlyPrice;
+        }
+        registrationCompleteCallback:^(void) {
+          ProductsHandler* productsHandler = ProductsHandler::instance();
+          QMetaObject::invokeMethod(productsHandler, "productsRegistrationCompleted",
+                                    Qt::QueuedConnection);
+        }
+        registrationFailureCallback:^{
+          logger.error() << "Registration failure";
+          ProductsHandler* productsHandler = ProductsHandler::instance();
+          NSArray* productIdentifiersArray = [productIdentifiers allObjects];
+          for (unsigned long i = 0, count = [productIdentifiersArray count]; i < count; ++i) {
+            NSString* identifier = [productIdentifiersArray objectAtIndex:i];
+            productsHandler->unknownProductRegistered(QString::fromNSString(identifier));
+          }
+        }
+        completionHandler:^{
+        }];
+  } else {
+    logger.debug() << "...using legacy StoreKit API.";
+    SKProductsRequest* productsRequest =
+        [[SKProductsRequest alloc] initWithProductIdentifiers:productIdentifiers];
+
+    IOSIAPHandlerDelegate* delegate = static_cast<IOSIAPHandlerDelegate*>(m_delegate);
+    productsRequest.delegate = delegate;
+    [productsRequest start];
+  }
 }
 
 void IOSIAPHandler::nativeStartSubscription(ProductsHandler::Product* product) {
-  Q_ASSERT(product->m_extra);
-  SKProduct* skProduct = static_cast<SKProduct*>(product->m_extra);
-  SKPayment* payment = [SKPayment paymentWithProduct:skProduct];
-  [[SKPaymentQueue defaultQueue] addPayment:payment];
+  if (@available(iOS 15, *)) {
+    logger.debug() << "Using StoreKit2 APIs";
+    NSString* productId = product->m_name.toNSString();
+    [(InAppPurchaseHandler*)swiftIAPHandler startSubscriptionFor:productId
+        errorCallback:^(void) {
+          logger.debug() << "Subscription error with StoreKit2.";
+          QMetaObject::invokeMethod(this, "stopSubscription", Qt::QueuedConnection);
+          QMetaObject::invokeMethod(this, "subscriptionCanceled", Qt::QueuedConnection);
+        }
+        successCallback:^(NSString* transactionIdentifier) {
+          if (App::instance()->userAuthenticated()) {
+            logger.debug() << "Subscription completed with StoreKit2. Starting validation.";
+            QMetaObject::invokeMethod(this, "processCompletedTransactions", Qt::QueuedConnection,
+                                      Q_ARG(QStringList, {QString::fromNSString(productId)}),
+                                      Q_ARG(QString, QString::fromNSString(transactionIdentifier)));
+          } else {
+            logger.debug() << "Subscription completed with StoreKit2. User not signed in.";
+            QMetaObject::invokeMethod(this, "stopSubscription", Qt::QueuedConnection);
+            QMetaObject::invokeMethod(this, "subscriptionCanceled", Qt::QueuedConnection);
+          }
+        }
+        completionHandler:^{
+        }];
+  } else {
+    logger.debug() << "Using legacy StoreKit API.";
+    Q_ASSERT(product->m_extra);
+    SKProduct* skProduct = static_cast<SKProduct*>(product->m_extra);
+    SKPayment* payment = [SKPayment paymentWithProduct:skProduct];
+    [[SKPaymentQueue defaultQueue] addPayment:payment];
+  }
 }
 
 void IOSIAPHandler::nativeRestoreSubscription() {
@@ -317,21 +392,26 @@ void IOSIAPHandler::productRegistered(void* a_product) {
   productData->m_extra = product;
 }
 
-void IOSIAPHandler::processCompletedTransactions(const QStringList& ids) {
+void IOSIAPHandler::processCompletedTransactions(const QStringList& ids, const QString transactionIdentifier) {
   logger.debug() << "process completed transactions";
 
   if (m_subscriptionState != eActive) {
     logger.warning() << "Completing transaction out of subscription process!";
   }
 
-  QString receipt = IOSUtils::IAPReceipt();
-  if (receipt.isEmpty()) {
-    logger.warning() << "Empty receipt found";
-    emit subscriptionFailed();
-    return;
+  TaskPurchase* purchase;
+  if (@available(iOS 15, *)) {
+    purchase = TaskPurchase::createForIOS(transactionIdentifier, false);
+  } else {
+    QString receipt = IOSUtils::IAPReceipt();
+    if (receipt.isEmpty()) {
+      logger.warning() << "Empty receipt found";
+      emit subscriptionFailed();
+      return;
+    }
+    purchase = TaskPurchase::createForIOS(receipt, true);
   }
 
-  TaskPurchase* purchase = TaskPurchase::createForIOS(receipt);
   Q_ASSERT(purchase);
 
   connect(

--- a/src/platforms/ios/iosiaphandler.swift
+++ b/src/platforms/ios/iosiaphandler.swift
@@ -112,20 +112,16 @@ import StoreKit
       case .unverified(_, let verificationError):
         InAppPurchaseHandler.logger.info(message: "StoreKit subscription returned success, but unverified: \(verificationError.localizedDescription)")
         errorCallback()
-        break
       }
     case .pending:
       InAppPurchaseHandler.logger.info(message: "StoreKit subscription returned pending")
       // do not call error nor success - wait for further updates via `Transaction.updates`
-      break
     case .userCancelled:
       InAppPurchaseHandler.logger.info(message: "StoreKit subscription returned userCancelled")
       errorCallback()
-      break
     @unknown default:
       InAppPurchaseHandler.logger.error(message: "purchaseResult using a new enum")
       errorCallback()
-      break
     }
   }
 

--- a/src/platforms/ios/iosiaphandler.swift
+++ b/src/platforms/ios/iosiaphandler.swift
@@ -1,0 +1,134 @@
+import Foundation
+import StoreKit
+
+@available(iOS 15, *)
+@objc class InAppPurchaseHandler: NSObject {
+  private static let logger = IOSLoggerImpl(tag: "InAppPurchaseHandler")
+
+  // Saving the product list in this class is awful, but we're in a tough spot here.
+  // The older StoreKit API used both ObjC and Swift, and we could save the ObjC object
+  // as part of the ProductsHandler class, which is written in C++.
+  // The new StoreKit API is Swift-only. We'd have to write a bunch of wrapper code to save
+  // the object in C++, marshalling the object into and out of Swift. Given how brittle that is,
+  // we instead having a shadow product cache in this Swift class, which we use if the user wants
+  // to subscribe.
+  private var productList: [Product] = []
+
+  @objc func getProducts(with productIdentifiers: Set<String>, productRegistrationCallback: @escaping ((NSString, NSString, NSString, NSString, Double, Int) -> Void), registrationCompleteCallback: @escaping (() ->Void), registrationFailureCallback: @escaping (() ->Void)) async {
+      do {
+        productList = try await Product.products(for: Array(productIdentifiers))
+        InAppPurchaseHandler.logger.info(message: "Saved \(productList.count) products")
+
+        for product in productList {
+
+          let productIdentifier = product.id
+          InAppPurchaseHandler.logger.debug (message: "\(productIdentifier): \(product.displayName)")
+          InAppPurchaseHandler.logger.debug (message: product.description)
+
+          guard let subscription = product.subscription else {
+            InAppPurchaseHandler.logger.error(message: "Product does not include subscription: \(product.id)")
+            assertionFailure()
+            continue
+          }
+
+          let trialDays: Int
+          if await subscription.isEligibleForIntroOffer, let offerType = subscription.introductoryOffer?.type, offerType == .introductory, let introOfferPeriod = subscription.introductoryOffer?.period {
+            trialDays = daysInTrial(for: introOfferPeriod.unit, with: introOfferPeriod.value)
+          } else {
+            trialDays = 0
+          }
+
+          let price = product.displayPrice
+          let currencyCode = product.priceFormatStyle.currencyCode
+
+          let numberOfMonthsInSubscription = monthsInSubscription(for: subscription.subscriptionPeriod.unit, with: subscription.subscriptionPeriod.value)
+          let monthlyPrice: Double = (product.price as NSDecimalNumber).doubleValue / Double(numberOfMonthsInSubscription)
+
+          let numberFormatter = NumberFormatter()
+          numberFormatter.numberStyle = .currency
+          numberFormatter.locale = product.priceFormatStyle.locale
+          guard let monthlyPriceString = numberFormatter.string(from: NSNumber(floatLiteral: monthlyPrice)) else {
+            InAppPurchaseHandler.logger.error(message: "Monthly price could not be converted to a string with numberFormatter: \(monthlyPrice)")
+            assertionFailure()
+            continue
+          }
+
+          productRegistrationCallback(NSString(string: productIdentifier), NSString(string: currencyCode), NSString(string: price), NSString(string: monthlyPriceString), monthlyPrice, trialDays)
+        }
+
+        registrationCompleteCallback()
+
+        } catch {
+          InAppPurchaseHandler.logger.error(message: "Failed product request from the App Store server. \(error)")
+          registrationFailureCallback()
+          assertionFailure()
+        }
+    }
+
+  @objc func startSubscription(for productIdentifier: String, errorCallback: @escaping (() -> Void), successCallback: @escaping ((NSString) -> Void)) async {
+    guard let product = productList.first(where: {$0.id == productIdentifier}) else {
+      InAppPurchaseHandler.logger.error(message: "Could not find a product with ID \(productIdentifier)")
+      errorCallback()
+      assertionFailure()
+      return
+    }
+
+    do {
+      let purchaseResult = try await product.purchase()
+      switch purchaseResult {
+      case .success(let verificationResult):
+        switch verificationResult {
+        case .verified(let transaction):
+          InAppPurchaseHandler.logger.error(message: "StoreKit subscription returned success and verified")
+          let originalTransactionIdentifier: String = "\(transaction.originalID)"
+          successCallback(NSString(string: originalTransactionIdentifier))
+          await transaction.finish()
+        case .unverified(_, let verificationError):
+          InAppPurchaseHandler.logger.error(message: "StoreKit subscription returned success, but unverified: \(verificationError.localizedDescription)")
+          errorCallback()
+          break
+        }
+      case .pending:
+        InAppPurchaseHandler.logger.error(message: "StoreKit subscription returned pending")
+        // do not call error nor success - wait for further updates via `Transaction.updates`
+        break
+      case .userCancelled:
+        InAppPurchaseHandler.logger.error(message: "StoreKit subscription returned userCancelled")
+        errorCallback()
+        break
+      @unknown default:
+        InAppPurchaseHandler.logger.error(message: "purchaseResult using a new enum")
+        errorCallback()
+        break
+      }
+    } catch {
+      InAppPurchaseHandler.logger.error(message: "Error purchasing product: \(error.localizedDescription)")
+      errorCallback()
+      assertionFailure()
+    }
+  }
+
+  private func monthsInSubscription(for unit: Product.SubscriptionPeriod.Unit, with length: Int) -> Int {
+    switch unit {
+    case .day: return length / 30 // using 30 days per month - should never get this subscription unit
+    case .week: return length / 4 // using 4 weeks per month - should never get this subscription unit
+    case .month: return length // this one is easy!
+    case .year: return length * 12 // 12 months per year
+    @unknown default:
+      InAppPurchaseHandler.logger.error(message: "unit using a new enum")
+      return length
+    }
+  }
+
+  private func daysInTrial(for unit: Product.SubscriptionPeriod.Unit, with length: Int) -> Int {
+    switch unit {
+    case .day: return length
+    case .week: return length * 7 // 7 days per week
+    case .month: return length * 30 // using 30 days per month
+    case .year: return length * 365 // sorry leap years!
+    @unknown default:
+      InAppPurchaseHandler.logger.error(message: "unit using a new enum")
+      return length
+    }
+  }
+}

--- a/src/tasks/purchase/taskpurchase.cpp
+++ b/src/tasks/purchase/taskpurchase.cpp
@@ -26,7 +26,7 @@ TaskPurchase* TaskPurchase::createForIOS(const QString& receipt,
                                          bool isOlderOS) {
   TaskPurchase* task = new TaskPurchase(IOS);
   task->m_iOSData = receipt;
-  task->isOlderOS = isOlderOS;
+  task->m_isOlderOS = isOlderOS;
   return task;
 }
 #endif
@@ -61,7 +61,7 @@ void TaskPurchase::run() {
 #ifdef MZ_IOS
   // APIv2 returns 200, APIv1 returns 201
   int expectedStatusCode;
-  if (isOlderOS) {
+  if (m_isOlderOS) {
     expectedStatusCode = 201;
   } else {
     expectedStatusCode = 200;
@@ -81,7 +81,7 @@ void TaskPurchase::run() {
     case IOS:
       Constants::ApiEndpoint endpoint;
       QJsonObject body;
-      if (isOlderOS) {
+      if (m_isOlderOS) {
         endpoint = Constants::PurchasesIOS;
         body = QJsonObject{{"receipt", m_iOSData},
                            {"appId", QString::fromNSString(IOSUtils::appId())}};

--- a/src/tasks/purchase/taskpurchase.h
+++ b/src/tasks/purchase/taskpurchase.h
@@ -57,7 +57,7 @@ class TaskPurchase final : public Task {
   QString m_iOSData;
   // `@available(iOS 15, *)` is not available in C++, so this value must be
   // passed in and saved
-  bool isOlderOS;
+  bool m_isOlderOS;
 #endif
 #ifdef MZ_ANDROID
   QString m_androidSku;

--- a/src/tasks/purchase/taskpurchase.h
+++ b/src/tasks/purchase/taskpurchase.h
@@ -16,7 +16,7 @@ class TaskPurchase final : public Task {
 
  public:
 #ifdef MZ_IOS
-  static TaskPurchase* createForIOS(const QString& receipt);
+  static TaskPurchase* createForIOS(const QString& receipt, bool isOlderOS);
 #endif
 #ifdef MZ_ANDROID
   static TaskPurchase* createForAndroid(const QString& sku,
@@ -52,7 +52,12 @@ class TaskPurchase final : public Task {
  private:
   Op m_op;
 #ifdef MZ_IOS
-  QString m_iOSReceipt;
+  // m_iOSData is the originalTransactionId for iOS 15+, and the receipt for
+  // earlier versions of iOS
+  QString m_iOSData;
+  // `@available(iOS 15, *)` is not available in C++, so this value must be
+  // passed in and saved
+  bool isOlderOS;
 #endif
 #ifdef MZ_ANDROID
   QString m_androidSku;


### PR DESCRIPTION
## Description

StoreKit (formerly called StoreKit2)  has been the modern way to build In App Purchase for a few years now. And Apple has announced Original StoreKit is deprecated after iOS 18.0. We needed to update the library we use, which is done in this PR. 

StoreKit2 is only available on iOS 15 and greater. Since it was trivial to maintain support for iOS 14 and earlier by using the original StoreKit APIs, there is forking logic all over this.

For a swift-only app, StoreKit2 is fairly straightforward. However, that doesn't work for our app. This is a mix of Objective C++ and Swift:
- Callbacks into our Qt code shared across platforms cannot be written in Swift, so those need to be in C++ or Objective C++.
- StoreKit2 is a Swift-only API, so code that interacts with it must be written in Swift. (StoreKit1 was available both in Swift and Objective-C, and given our app's architecture we use the Obj-C APIs.)
  
## Testing

I've tested:
- The happy path (subscribe in app)
- Cancelling the transaction when the IAP sheet comes up, rather than completing the purchase
- An interrupted transaction (interrupted by new App Store rules that the user must agree to)
- Restoring an Apple IAP subscription purchased outside the app
- The old, StoreKit1 happy path
- probably a few more things I'm not remembering

## Reference

VPN-6512

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
