### PR TITLE
VPN-6593: Improve start on boot

### DIFF
--- a/src/settingslist.h
+++ b/src/settingslist.h
@@ -506,19 +506,14 @@ SETTING_BOOL(stagingServer,                 // getter
              false                          // sensitive (do not log)
 )
 
-#if defined(MZ_LINUX) || defined(MZ_WINDOWS) || defined(MZ_MACOS)
-#  define START_AT_BOOT_DEFAULT_VALUE true
-#else
-#  define START_AT_BOOT_DEFAULT_VALUE false
-#endif
-SETTING_BOOL(startAtBoot,                  // getter
-             setStartAtBoot,               // setter
-             removeStartAtBoot,            // remover
-             hasStartAtBoot,               // has
-             "startAtBoot",                // key
-             START_AT_BOOT_DEFAULT_VALUE,  // default value
-             false,                        // remove when reset
-             false                         // sensitive (do not log)
+SETTING_BOOL(startAtBoot,        // getter
+             setStartAtBoot,     // setter
+             removeStartAtBoot,  // remover
+             hasStartAtBoot,     // has
+             "startAtBoot",      // key
+             false,              // default value
+             false,              // remove when reset
+             false               // sensitive (do not log)
 )
 #undef START_AT_BOOT_DEFAULT_VALUE
 

--- a/src/ui/screens/onboarding/OnboardingStartSlideDesktop.qml
+++ b/src/ui/screens/onboarding/OnboardingStartSlideDesktop.qml
@@ -15,6 +15,8 @@ ColumnLayout {
     objectName: "onboardingStartSlide"
 
     property string telemetryScreenId: "connect_on_startup"
+    // `startAtBootCheckbox` was added to change the default `startAtBoot` setting to true. We  couldn't simply change the `startAtBoot` default in `settingslist.h`
+    // without affecting older VPN clients. See https://github.com/mozilla-mobile/mozilla-vpn-client/pull/9878
     property bool startAtBootCheckbox: true
 
     signal nextClicked()

--- a/src/ui/screens/onboarding/OnboardingStartSlideDesktop.qml
+++ b/src/ui/screens/onboarding/OnboardingStartSlideDesktop.qml
@@ -15,6 +15,7 @@ ColumnLayout {
     objectName: "onboardingStartSlide"
 
     property string telemetryScreenId: "connect_on_startup"
+    property bool startAtBootCheckbox: true
 
     signal nextClicked()
     signal backClicked()
@@ -61,11 +62,11 @@ ColumnLayout {
         MZSettingsToggle {
             objectName: "startAtBootToggle"
 
-            checked: MZSettings.startAtBoot
+            checked: startAtBootCheckbox
             onClicked: {
-                MZSettings.startAtBoot = !MZSettings.startAtBoot
+                startAtBootCheckbox = !startAtBootCheckbox
 
-                if (MZSettings.startAtBoot) {
+                if (startAtBootCheckbox) {
                     Glean.interaction.connectOnStartupEnabled.record({
                         screen: root.telemetryScreenId,
                     });
@@ -109,6 +110,8 @@ ColumnLayout {
         text: MZI18n.GlobalGetStarted
 
         onClicked: {
+            MZSettings.startAtBoot = startAtBootCheckbox
+
             Glean.interaction.getStartedSelected.record({
                 screen: root.telemetryScreenId,
             });

--- a/tests/functional/testOnboarding.js
+++ b/tests/functional/testOnboarding.js
@@ -170,13 +170,18 @@ describe('Onboarding', function() {
     await vpn.waitForQuery(queries.screenOnboarding.START_SLIDE.visible());
     assert.equal(await vpn.getQueryProperty(queries.screenOnboarding.ONBOARDING_VIEW, 'currentIndex'), 3);
     assert.equal(await vpn.getSetting('onboardingStep'), 3);
-    assert.equal(await vpn.getQueryProperty(queries.screenOnboarding.START_START_AT_BOOT_TOGGLE, 'checked'), 'false');
+    assert.equal(
+        await vpn.getQueryProperty(
+            queries.screenOnboarding.START_START_AT_BOOT_TOGGLE, 'checked'),
+        'true');
     assert.equal(await vpn.getSetting('startAtBoot'), false);
 
     //Check start at boot toggle
     await vpn.waitForQueryAndClick(queries.screenOnboarding.START_START_AT_BOOT_TOGGLE.visible());
-    assert.equal(await vpn.getQueryProperty(queries.screenOnboarding.START_START_AT_BOOT_TOGGLE, 'checked'), 'true');
-    assert.equal(await vpn.getSetting('startAtBoot'), true);
+    assert.equal(
+        await vpn.getQueryProperty(
+            queries.screenOnboarding.START_START_AT_BOOT_TOGGLE, 'checked'),
+        'false');
 
     //Test back button
     await vpn.waitForQueryAndClick(queries.screenOnboarding.START_BACK_BUTTON.visible());
@@ -189,8 +194,18 @@ describe('Onboarding', function() {
     await vpn.waitForQuery(queries.screenOnboarding.STEP_NAV_STACK_VIEW.ready());
 
     //Ensure all selections on start slide are saved
-    assert.equal(await vpn.getQueryProperty(queries.screenOnboarding.START_START_AT_BOOT_TOGGLE, 'checked'), 'true');
-    assert.equal(await vpn.getSetting('startAtBoot'), true);
+    assert.equal(
+        await vpn.getQueryProperty(
+            queries.screenOnboarding.START_START_AT_BOOT_TOGGLE, 'checked'),
+        'false');
+
+    // Then click it again
+    await vpn.waitForQueryAndClick(
+        queries.screenOnboarding.START_START_AT_BOOT_TOGGLE.visible());
+    assert.equal(
+        await vpn.getQueryProperty(
+            queries.screenOnboarding.START_START_AT_BOOT_TOGGLE, 'checked'),
+        'true');
 
     //Test going back one slide via progress bar
     await vpn.waitForQueryAndClick(queries.screenOnboarding.STEP_PROG_BAR_DEVICES_BUTTON.visible());

--- a/tests/functional/testOnboarding.js
+++ b/tests/functional/testOnboarding.js
@@ -703,14 +703,16 @@ describe('Onboarding', function() {
 
       //Verify that connectOnStartupEnabled event is recorded
       await vpn.waitForQueryAndClick(queries.screenOnboarding.START_START_AT_BOOT_TOGGLE.visible());
-      const connectOnStartupEnabledEvents = await vpn.waitForGleanValue("interaction", "connectOnStartupEnabled", "main");
+      const connectOnStartupEnabledEvents = await vpn.waitForGleanValue(
+          'interaction', 'connectOnStartupDisabled', 'main');
       assert.equal(connectOnStartupEnabledEvents.length, 1);
       const connectOnStartupEnabledEventsExtras = connectOnStartupEnabledEvents[0].extra;
       assert.equal(startScreenTelemetryId, connectOnStartupEnabledEventsExtras.screen);
 
       //Verify that connectOnStartupDisabled event is recorded
       await vpn.waitForQueryAndClick(queries.screenOnboarding.START_START_AT_BOOT_TOGGLE.visible());
-      const connectOnStartupDisabledEvents = await vpn.waitForGleanValue("interaction", "connectOnStartupDisabled", "main");
+      const connectOnStartupDisabledEvents = await vpn.waitForGleanValue(
+          'interaction', 'connectOnStartupEnabled', 'main');
       assert.equal(connectOnStartupDisabledEvents.length, 1);
       const connectOnStartupDisabledEventsExtras = connectOnStartupDisabledEvents[0].extra;
       assert.equal(startScreenTelemetryId, connectOnStartupDisabledEventsExtras.screen);


### PR DESCRIPTION
## Description

https://github.com/mozilla-mobile/mozilla-vpn-client/pull/9818/ introduced a couple issues (in order of importance):
1) When upgrading to 2.24, users who have never changed their "start on boot" preference got updated from false to true. (Today I learned that the default setting is not written in local storage - Updates to a settings are written to local storage, and otherwise we use the default. So changing the default affects existing users.)
2) The VPN was turned on at the end of onboarding (this is only expected for iOS), with a session timer that is not 0:00 (as it got turned on during the user's onboarding).

This PR fixes this by creating a temporarily boolean used during onboarding, and sets the "start on boot" setting to that temporary boolean as the user passes the onboarding screen.

## Reference

VPN-6593 and VPN-6588

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
