### PR TITLE
VPN-6580 change 'App Exclusions' to 'Excluded Apps'

### DIFF
--- a/docs/rfcs/0005-suggested-excluded-apps-tech-spec.md
+++ b/docs/rfcs/0005-suggested-excluded-apps-tech-spec.md
@@ -6,7 +6,7 @@ Epic: [VPN-4412: Suggest Apps to Exclude from VPN Protection](https://mozilla-hu
 Context / Problem Statement
 ---------------------------
 
-We're looking to create tools that prompt the user in ways that help them stay more secure. Split tunneling (called 'App Exclusion' to users) is a feature that can reduce the need to turn off the VPN entirely by excluding traffic in specific apps from the VPN tunnel, but many users don't know about it. The current feature is in settings, and provides an alphabetical checklist of installed apps:
+We're looking to create tools that prompt the user in ways that help them stay more secure. Split tunneling (called 'Excluded Apps' to users) is a feature that can reduce the need to turn off the VPN entirely by excluding traffic in specific apps from the VPN tunnel, but many users don't know about it. The current feature is in settings, and provides an alphabetical checklist of installed apps:
 
 <img src="./images/0005-01.png" height="500" />
 
@@ -47,12 +47,12 @@ This work is broken into four sections, with the bulk of code coming in the midd
         -   The precise methods to determine whether an app belongs on the list is described in the [epic](https://mozilla-hub.atlassian.net/browse/VPN-4412).
     -   From Santiago (this is a reminder to review these later): https://github.com/citizenlab/test-lists/tree/master/lists, https://ooni.org/ for Android https://docs.google.com/spreadsheets/d/1j2REPQkcdPg5bNW5B3T-L8dnlNPPwAms1WlBiYvVwoc/edit#gid=0
 -   (5-8 points) Deep linking into app for notification to work ([VPN-5034](https://mozilla-hub.atlassian.net/browse/VPN-5034)): This may be even fewer points, based on the scope (in ticket).
--   (2-5 points) Create initial list of recommended app exclusions, from work done by Product.
+-   (2-5 points) Create initial list of recommended excluded apps, from work done by Product.
 
 ### Create daily task in app (12-16 points total)
 <img src="./images/0005-02.png" width="800" alt="New daily task" />
 
--   (3-5 points) Daily task at noon (local) to check for suggested apps that are installed on the device (after one week from first install) and not already excluded, halt task if don't have notification permissions or if the platform doesn't have app exclusions feature.
+-   (3-5 points) Daily task at noon (local) to check for suggested apps that are installed on the device (after one week from first install) and not already excluded, halt task if don't have notification permissions or if the platform doesn't have excluded apps feature.
     -   This will be run by the app for desktop, and in the daemon on Android. (iOS does not have split tunnel.)
         -   After running the job, we will create timer for noon the following day to run the job next. Additionally, we'll record the time for this job as a setting, and we'll check this timestamp on app/daemon launch - if the deadline has passed we'll immediately run the task.
         -   We're not concerned if the user's clock shifts. The vast majority of these daily checks will not result in any notification to the user (except in the rare case that the user consistently adds new apps daily that happen to be on the suggested list). The worst case scenario would be that a user gets two notifications in a 24 hour period. This isn't the planned user interaction, but given the low likelihood (neither clock changes nor the installation of new suggested apps is a common event) it's not worth building a system that considers this.
@@ -71,7 +71,7 @@ This work is broken into four sections, with the bulk of code coming in the midd
 ### Improve existing split tunnel screen (11-17 points total)
 [Figma mocks](https://www.figma.com/file/UZYzma7hlcfE5ke3z8jGbN/App-exclusions-suggestions?type=design&node-id=196-6366&mode=design&t=RL1hdfBQLMS1rKVa-0)
 
-<img src="./images/0005-03.png" width="500" alt="Updated flow for existing App Exclusion screen" />
+<img src="./images/0005-03.png" width="500" alt="Updated flow for existing Excluded Apps screen" />
 
 -   (2 points) Run the task on the launch of screen
     -   Update the "have seen these apps" settings list with all suggested apps. (If a new suggested app is installed and the Settings screen is opened by a user before the daily job runs to send a notification, we thus never send a notification. This behavior was confirmed by Santiago.)
@@ -140,7 +140,7 @@ Metrics
 
 We will create several metrics as part of this work; they are described in the appropriate spots in the "Implementation" section.
 
-We'd expect the `apps_excluded` metric to increase after this is implemented on platforms which have app exclusions. Both the number of people with more than 0 apps excluded and the average count of apps excluded should increase.
+We'd expect the `apps_excluded` metric to increase after this is implemented on platforms which have "excluded apps". Both the number of people with more than 0 apps excluded and the average count of apps excluded should increase.
 
 We will use Nimbus to roll out the test of this feature.
 
@@ -154,7 +154,7 @@ The excluded apps list will likely live in the client repo. There are ways to we
 Considerations for roll out
 ----------------------
 
-While the reworked app exclusion page will affect all platforms that support split tunneling, notifications will only be shown to users who have already allowed our app to send them. On mobile, we show the "approve notifications" screen immediately upon launching the app for the first time, which likely depresses approval rates. We may want to re-consider how we show this as part of onboarding.
+While the reworked exclulded apps page will affect all platforms that support split tunneling, notifications will only be shown to users who have already allowed our app to send them. On mobile, we show the "approve notifications" screen immediately upon launching the app for the first time, which likely depresses approval rates. We may want to re-consider how we show this as part of onboarding.
 
 Test Plan
 ---------

--- a/docs/rfcs/0005-suggested-excluded-apps-tech-spec.md
+++ b/docs/rfcs/0005-suggested-excluded-apps-tech-spec.md
@@ -154,7 +154,7 @@ The excluded apps list will likely live in the client repo. There are ways to we
 Considerations for roll out
 ----------------------
 
-While the reworked exclulded apps page will affect all platforms that support split tunneling, notifications will only be shown to users who have already allowed our app to send them. On mobile, we show the "approve notifications" screen immediately upon launching the app for the first time, which likely depresses approval rates. We may want to re-consider how we show this as part of onboarding.
+While the reworked excluded apps page will affect all platforms that support split tunneling, notifications will only be shown to users who have already allowed our app to send them. On mobile, we show the "approve notifications" screen immediately upon launching the app for the first time, which likely depresses approval rates. We may want to re-consider how we show this as part of onboarding.
 
 Test Plan
 ---------

--- a/src/telemetry/impression_metrics.yaml
+++ b/src/telemetry/impression_metrics.yaml
@@ -437,7 +437,7 @@ impression:
     send_in_pings:
       - main
     description: |
-      The user has just moved on to the app exclusions screen 
+      The user has just moved on to the Excluded Apps screen
     bugs:
       - https://mozilla-hub.atlassian.net/browse/VPN-5363
     data_reviews:
@@ -473,7 +473,7 @@ impression:
     send_in_pings:
       - main
     description: |
-      The user has opened the app exclusions help sheet
+      The user has opened the Excluded Apps help sheet
     bugs:
       - https://mozilla-hub.atlassian.net/browse/VPN-5092
     data_reviews:

--- a/src/telemetry/interaction_metrics.yaml
+++ b/src/telemetry/interaction_metrics.yaml
@@ -962,7 +962,7 @@ interaction:
       - main
     description: |
       The user has clicked the button that opens
-      the app exclusions modal
+      the Excluded Apps modal
     bugs:
       - https://mozilla-hub.atlassian.net/browse/VPN-5363
     data_reviews:
@@ -980,7 +980,7 @@ interaction:
     send_in_pings:
       - main
     description: |
-      The user has clicked on Clear all to clear all App Exclusions
+      The user has clicked on Clear all to clear all Excluded Apps
     bugs:
       - https://mozilla-hub.atlassian.net/browse/VPN-5363
     data_reviews:
@@ -998,7 +998,7 @@ interaction:
     send_in_pings:
       - main
     description: |
-      The user has clicked on Add application in App Exclusions
+      The user has clicked on Add application in Excluded Apps
     bugs:
       - https://mozilla-hub.atlassian.net/browse/VPN-5363
     data_reviews:
@@ -1016,7 +1016,7 @@ interaction:
     send_in_pings:
       - main
     description: |
-      The user has clicked on the search field in app exclusions
+      The user has clicked on the search field in Excluded Apps
     bugs:
       - https://mozilla-hub.atlassian.net/browse/VPN-5363
     data_reviews:

--- a/src/translations/strings.yaml
+++ b/src/translations/strings.yaml
@@ -146,15 +146,10 @@ splittunnel:
       - Success! You added “%1” to this list.
     comment:
       - Displayed in notification after the user added a missing app to the split-tunnel List; %1 is the name of the added application
-  infoText2:
-    value:
-      - For any questions about setting app exclusions, we’ve provided some helpful tips on our website.
-    comment:
-      - This displays as informational text below split tunneling settings. The link directs to a sumo article which will help certain users who are having network issues using this feature.
   infoLinkText: Learn more
-  infoCardDescription:
-    value: VPN must be off to edit App exclusions
-    comment: Displays inside the information card at the top of the app exclusions screen when the VPN is on
+  infoCardDescription2:
+    value: VPN must be off to edit Excluded apps
+    comment: Displays inside the information card at the top of the Excluded apps screen when the VPN is on
 
 multiHopFeature:
   singleHopToggleCTA: Single-hop
@@ -323,7 +318,7 @@ systray:
 
 settings:
   privacySettings: Privacy features
-  appExclusionSettings: App exclusions
+  appExclusionTitle: Excluded apps
   dnsSettings: DNS settings
   preferencesSettings: Preferences
   shareTechnicalDataDescription: Help improve Mozilla VPN by sharing crash reports, diagnostics, and product usage data.

--- a/src/translations/strings.yaml
+++ b/src/translations/strings.yaml
@@ -147,7 +147,7 @@ splittunnel:
     comment:
       - Displayed in notification after the user added a missing app to the split-tunnel List; %1 is the name of the added application
   infoLinkText: Learn more
-  infoCardDescription:
+  infoCardDescription2:
     value: VPN must be off to edit Excluded apps
     comment: Displays inside the information card at the top of the Excluded apps screen when the VPN is on
 
@@ -318,7 +318,7 @@ systray:
 
 settings:
   privacySettings: Privacy features
-  appExclusionSettings: Excluded apps
+  appExclusionTitle: Excluded apps
   dnsSettings: DNS settings
   preferencesSettings: Preferences
   shareTechnicalDataDescription: Help improve Mozilla VPN by sharing crash reports, diagnostics, and product usage data.

--- a/src/translations/strings.yaml
+++ b/src/translations/strings.yaml
@@ -147,7 +147,7 @@ splittunnel:
     comment:
       - Displayed in notification after the user added a missing app to the split-tunnel List; %1 is the name of the added application
   infoLinkText: Learn more
-  infoCardDescription2:
+  infoCardDescription:
     value: VPN must be off to edit Excluded apps
     comment: Displays inside the information card at the top of the Excluded apps screen when the VPN is on
 
@@ -318,7 +318,7 @@ systray:
 
 settings:
   privacySettings: Privacy features
-  appExclusionTitle: Excluded apps
+  appExclusionSettings: Excluded apps
   dnsSettings: DNS settings
   preferencesSettings: Preferences
   shareTechnicalDataDescription: Help improve Mozilla VPN by sharing crash reports, diagnostics, and product usage data.

--- a/src/ui/screens/settings/ViewReset.qml
+++ b/src/ui/screens/settings/ViewReset.qml
@@ -68,13 +68,13 @@ ViewFullScreen {
             Layout.topMargin: 12
             Layout.fillWidth: true
 
-            text: "<ul style='margin-left: -20px;'><li>%1</li></ul>".arg(MZI18n.SettingsAppExclusionSettings)
+            text: "<ul style='margin-left: -20px;'><li>%1</li></ul>".arg(MZI18n.SettingsAppExclusionTitle)
             textFormat: Text.RichText
             color: MZTheme.theme.fontColor
             horizontalAlignment: Text.AlignLeft
             visible: MZFeatureList.get("splitTunnel").isSupported
 
-            Accessible.name: MZI18n.SettingsAppExclusionSettings
+            Accessible.name: MZI18n.SettingsAppExclusionTitle
         }
 
         MZInterLabel {

--- a/src/ui/screens/settings/ViewReset.qml
+++ b/src/ui/screens/settings/ViewReset.qml
@@ -68,13 +68,13 @@ ViewFullScreen {
             Layout.topMargin: 12
             Layout.fillWidth: true
 
-            text: "<ul style='margin-left: -20px;'><li>%1</li></ul>".arg(MZI18n.SettingsAppExclusionTitle)
+            text: "<ul style='margin-left: -20px;'><li>%1</li></ul>".arg(MZI18n.SettingsAppExclusionSettings)
             textFormat: Text.RichText
             color: MZTheme.theme.fontColor
             horizontalAlignment: Text.AlignLeft
             visible: MZFeatureList.get("splitTunnel").isSupported
 
-            Accessible.name: MZI18n.SettingsAppExclusionTitle
+            Accessible.name: MZI18n.SettingsAppExclusionSettings
         }
 
         MZInterLabel {

--- a/src/ui/screens/settings/ViewSettingsMenu.qml
+++ b/src/ui/screens/settings/ViewSettingsMenu.qml
@@ -64,7 +64,7 @@ MZViewBase {
 
             MZSettingsItem {
                 objectName: "appExclusionSettings"
-                settingTitle: MZI18n.SettingsAppExclusionSettings
+                settingTitle: MZI18n.SettingsAppExclusionTitle
                 imageLeftSrc: "qrc:/ui/resources/settings/apppermissions.svg"
                 imageRightSrc: "qrc:/nebula/resources/chevron.svg"
                 imageRightMirror: MZLocalizer.isRightToLeft

--- a/src/ui/screens/settings/ViewSettingsMenu.qml
+++ b/src/ui/screens/settings/ViewSettingsMenu.qml
@@ -64,7 +64,7 @@ MZViewBase {
 
             MZSettingsItem {
                 objectName: "appExclusionSettings"
-                settingTitle: MZI18n.SettingsAppExclusionTitle
+                settingTitle: MZI18n.SettingsAppExclusionSettings
                 imageLeftSrc: "qrc:/ui/resources/settings/apppermissions.svg"
                 imageRightSrc: "qrc:/nebula/resources/chevron.svg"
                 imageRightMirror: MZLocalizer.isRightToLeft

--- a/src/ui/screens/settings/appPermissions/AppPermissionsList.qml
+++ b/src/ui/screens/settings/appPermissions/AppPermissionsList.qml
@@ -64,7 +64,7 @@ ColumnLayout {
                             id: textBlock
                             Layout.fillWidth: true
 
-                            text: MZI18n.SplittunnelInfoCardDescription2
+                            text: MZI18n.SplittunnelInfoCardDescription
                             verticalAlignment: Text.AlignVCenter
                         }
                     }

--- a/src/ui/screens/settings/appPermissions/AppPermissionsList.qml
+++ b/src/ui/screens/settings/appPermissions/AppPermissionsList.qml
@@ -64,7 +64,7 @@ ColumnLayout {
                             id: textBlock
                             Layout.fillWidth: true
 
-                            text: MZI18n.SplittunnelInfoCardDescription
+                            text: MZI18n.SplittunnelInfoCardDescription2
                             verticalAlignment: Text.AlignVCenter
                         }
                     }

--- a/src/ui/screens/settings/appPermissions/ViewAppPermissions.qml
+++ b/src/ui/screens/settings/appPermissions/ViewAppPermissions.qml
@@ -55,7 +55,7 @@ MZViewBase {
         }
     }
 
-    _menuTitle: MZI18n.SettingsAppExclusionSettings
+    _menuTitle: MZI18n.SettingsAppExclusionTitle
     _viewContentData: ColumnLayout {
         AppPermissionsList {
             id: enabledList

--- a/src/ui/screens/settings/appPermissions/ViewAppPermissions.qml
+++ b/src/ui/screens/settings/appPermissions/ViewAppPermissions.qml
@@ -55,7 +55,7 @@ MZViewBase {
         }
     }
 
-    _menuTitle: MZI18n.SettingsAppExclusionTitle
+    _menuTitle: MZI18n.SettingsAppExclusionSettings
     _viewContentData: ColumnLayout {
         AppPermissionsList {
             id: enabledList

--- a/tests/functional/testAppExclusions.js
+++ b/tests/functional/testAppExclusions.js
@@ -90,7 +90,7 @@ describe('Settings', function() {
     await vpn.waitForQuery(queries.screenSettings.STACKVIEW.ready());
     await vpn.waitForQuery(queries.screenSettings.privacyView.VIEW.visible());
 
-    //Go back to the app exclusions view
+    // Go back to the Excluded Apps view
     await vpn.waitForQueryAndClick(queries.screenSettings.BACK.visible());
     await vpn.waitForQuery(queries.screenSettings.STACKVIEW.ready());
 
@@ -105,7 +105,7 @@ describe('Settings', function() {
     await vpn.waitForQueryAndClick(queries.screenSettings.appExclusionsView.HELP_SHEET_CLOSE_BUTTON.visible());
   });
 
-  describe('Checking app exclusions screen telemetry', function () {
+  describe('Checking Excluded Apps screen telemetry', function() {
     // No Glean on WASM.
     if(vpn.runningOnWasm()) {
       return;
@@ -113,7 +113,7 @@ describe('Settings', function() {
 
     const appExclusionsTelemetryScreenId = "app_exclusions"
 
-    it('Record telemetry when user clicks on App Exclusions', async () => {
+    it('Record telemetry when user clicks on Excluded Apps', async () => {
       await vpn.waitForQueryAndClick(queries.navBar.SETTINGS.visible());
       await vpn.waitForQuery(queries.screenSettings.STACKVIEW.ready());
       await vpn.waitForQueryAndClick(queries.screenSettings.APP_EXCLUSIONS.visible());
@@ -125,7 +125,7 @@ describe('Settings', function() {
       assert.equal(element.extra.screen, "settings");
     });
 
-    it('Checking app exclusions screen impression telemetry', async () => {
+    it('Checking Excluded Apps screen impression telemetry', async () => {
       const appExclusionsSreenEvents = await vpn.gleanTestGetValue("impression", "appExclusionsScreen", "main");
       assert.equal(appExclusionsSreenEvents.length, 1);
       const appExclusionsSreenEventsExtras = appExclusionsSreenEvents[0].extra;


### PR DESCRIPTION
## Description

A quick string change.

- I also changed dev-only strings (test descriptions and some markdown docs) for consistency for future maintainers of the app.
- I couldn't find a spot where we still use `infoText2`, so I removed that string.
- The help info sheet for the feature already used the "excluded apps" nomenclature, so there was nothing to update there.

## Reference

VPN-6580

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
