### PR TITLE
Fix GNUPGHOME variable in PPA automation workflow

### DIFF
--- a/.github/workflows/ppa-automation.yaml
+++ b/.github/workflows/ppa-automation.yaml
@@ -17,7 +17,6 @@ jobs:
     env:
       DEBEMAIL: ${{ github.actor }}@users.noreply.github.com
       DEBFULLNAME: ${{ github.actor }}
-      GNUPGHOME: ${{ runner.temp }}/gnupg-data
       GITREF: ${{ github.ref }}
     steps:
       - name: Checkout sources
@@ -79,6 +78,7 @@ jobs:
         env:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
           GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
+          GNUPGHOME: ${{ runner.temp }}/gnupg-data
         run: |
           mkdir -m700 $GNUPGHOME
           echo "allow-preset-passphrase" > $GNUPGHOME/gpg-agent.conf
@@ -99,6 +99,7 @@ jobs:
           KEYID: ${{ steps.keys.outputs.keyid }}
           PPA_TARGET_DISTS: ${{ steps.decision.outputs.releases }}
           PPA_URL: ${{ steps.decision.outputs.ppa-url }}
+          GNUPGHOME: ${{ runner.temp }}/gnupg-data
         run: |
           JOB_EXIT_CODE=0
           PACKAGE_DSC_FILE=$(find . -name '*.dsc')
@@ -126,6 +127,7 @@ jobs:
           KEYID: ${{ steps.keys.outputs.keyid }}
           PPA_TARGET_DISTS: ${{ steps.decision.outputs.releases }}
           PPA_URL: ${{ steps.decision.outputs.ppa-url }}
+          GNUPGHOME: ${{ runner.temp }}/gnupg-data
         run: |
           JOB_EXIT_CODE=0
           for dist in ${PPA_TARGET_DISTS}; do


### PR DESCRIPTION
## Description
In the change to the PPA automation workflow, we did a bit of refactoring to submit a second package, the `mozilla-vpn-keying`, to the testing PPAs. However, we missed that the github `runner` context isn't defined at the job level which means we can't set the `GNUPGHOME` variable globally like we can all the others.

## Reference
Introduced by #9839

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
