### PR TITLE
Revert cherry pick of VPN-6593

### DIFF
--- a/src/ui/screens/onboarding/OnboardingStartSlideDesktop.qml
+++ b/src/ui/screens/onboarding/OnboardingStartSlideDesktop.qml
@@ -15,9 +15,6 @@ ColumnLayout {
     objectName: "onboardingStartSlide"
 
     property string telemetryScreenId: "connect_on_startup"
-    // `startAtBootCheckbox` was added to change the default `startAtBoot` setting to true. We  couldn't simply change the `startAtBoot` default in `settingslist.h`
-    // without affecting older VPN clients. See https://github.com/mozilla-mobile/mozilla-vpn-client/pull/9878
-    property bool startAtBootCheckbox: true
 
     signal nextClicked()
     signal backClicked()
@@ -64,11 +61,11 @@ ColumnLayout {
         MZSettingsToggle {
             objectName: "startAtBootToggle"
 
-            checked: startAtBootCheckbox
+            checked: MZSettings.startAtBoot
             onClicked: {
-                startAtBootCheckbox = !startAtBootCheckbox
+                MZSettings.startAtBoot = !MZSettings.startAtBoot
 
-                if (startAtBootCheckbox) {
+                if (MZSettings.startAtBoot) {
                     Glean.interaction.connectOnStartupEnabled.record({
                         screen: root.telemetryScreenId,
                     });
@@ -112,8 +109,6 @@ ColumnLayout {
         text: MZI18n.GlobalGetStarted
 
         onClicked: {
-            MZSettings.startAtBoot = startAtBootCheckbox
-
             Glean.interaction.getStartedSelected.record({
                 screen: root.telemetryScreenId,
             });

--- a/tests/functional/testOnboarding.js
+++ b/tests/functional/testOnboarding.js
@@ -170,18 +170,13 @@ describe('Onboarding', function() {
     await vpn.waitForQuery(queries.screenOnboarding.START_SLIDE.visible());
     assert.equal(await vpn.getQueryProperty(queries.screenOnboarding.ONBOARDING_VIEW, 'currentIndex'), 3);
     assert.equal(await vpn.getSetting('onboardingStep'), 3);
-    assert.equal(
-        await vpn.getQueryProperty(
-            queries.screenOnboarding.START_START_AT_BOOT_TOGGLE, 'checked'),
-        'true');
+    assert.equal(await vpn.getQueryProperty(queries.screenOnboarding.START_START_AT_BOOT_TOGGLE, 'checked'), 'false');
     assert.equal(await vpn.getSetting('startAtBoot'), false);
 
     //Check start at boot toggle
     await vpn.waitForQueryAndClick(queries.screenOnboarding.START_START_AT_BOOT_TOGGLE.visible());
-    assert.equal(
-        await vpn.getQueryProperty(
-            queries.screenOnboarding.START_START_AT_BOOT_TOGGLE, 'checked'),
-        'false');
+    assert.equal(await vpn.getQueryProperty(queries.screenOnboarding.START_START_AT_BOOT_TOGGLE, 'checked'), 'true');
+    assert.equal(await vpn.getSetting('startAtBoot'), true);
 
     //Test back button
     await vpn.waitForQueryAndClick(queries.screenOnboarding.START_BACK_BUTTON.visible());
@@ -194,18 +189,8 @@ describe('Onboarding', function() {
     await vpn.waitForQuery(queries.screenOnboarding.STEP_NAV_STACK_VIEW.ready());
 
     //Ensure all selections on start slide are saved
-    assert.equal(
-        await vpn.getQueryProperty(
-            queries.screenOnboarding.START_START_AT_BOOT_TOGGLE, 'checked'),
-        'false');
-
-    // Then click it again
-    await vpn.waitForQueryAndClick(
-        queries.screenOnboarding.START_START_AT_BOOT_TOGGLE.visible());
-    assert.equal(
-        await vpn.getQueryProperty(
-            queries.screenOnboarding.START_START_AT_BOOT_TOGGLE, 'checked'),
-        'true');
+    assert.equal(await vpn.getQueryProperty(queries.screenOnboarding.START_START_AT_BOOT_TOGGLE, 'checked'), 'true');
+    assert.equal(await vpn.getSetting('startAtBoot'), true);
 
     //Test going back one slide via progress bar
     await vpn.waitForQueryAndClick(queries.screenOnboarding.STEP_PROG_BAR_DEVICES_BUTTON.visible());
@@ -703,16 +688,14 @@ describe('Onboarding', function() {
 
       //Verify that connectOnStartupEnabled event is recorded
       await vpn.waitForQueryAndClick(queries.screenOnboarding.START_START_AT_BOOT_TOGGLE.visible());
-      const connectOnStartupEnabledEvents = await vpn.waitForGleanValue(
-          'interaction', 'connectOnStartupDisabled', 'main');
+      const connectOnStartupEnabledEvents = await vpn.waitForGleanValue("interaction", "connectOnStartupEnabled", "main");
       assert.equal(connectOnStartupEnabledEvents.length, 1);
       const connectOnStartupEnabledEventsExtras = connectOnStartupEnabledEvents[0].extra;
       assert.equal(startScreenTelemetryId, connectOnStartupEnabledEventsExtras.screen);
 
       //Verify that connectOnStartupDisabled event is recorded
       await vpn.waitForQueryAndClick(queries.screenOnboarding.START_START_AT_BOOT_TOGGLE.visible());
-      const connectOnStartupDisabledEvents = await vpn.waitForGleanValue(
-          'interaction', 'connectOnStartupEnabled', 'main');
+      const connectOnStartupDisabledEvents = await vpn.waitForGleanValue("interaction", "connectOnStartupDisabled", "main");
       assert.equal(connectOnStartupDisabledEvents.length, 1);
       const connectOnStartupDisabledEventsExtras = connectOnStartupDisabledEvents[0].extra;
       assert.equal(startScreenTelemetryId, connectOnStartupDisabledEventsExtras.screen);


### PR DESCRIPTION
This reverts commit 7a16aa76aefa8c68e1215032e5de52e74ed4d301 from the 2.24.0 release branch. It came in yesterday as https://github.com/mozilla-mobile/mozilla-vpn-client/pull/9880

It was intended to fix a blocking bug, but did not. Thus, we're backing it out to increase confidence in the release.

Note: This code remains on `main` branch.

