### PR TITLE
Nit: Suppress Balrog network errors

### DIFF
--- a/src/networkrequest.cpp
+++ b/src/networkrequest.cpp
@@ -68,8 +68,7 @@ void NetworkRequest::resetRequestHandler() {
 }
 #endif
 
-NetworkRequest::NetworkRequest(Task* parent, int status)
-    : QObject(parent) {
+NetworkRequest::NetworkRequest(Task* parent, int status) : QObject(parent) {
   MZ_COUNT_CTOR(NetworkRequest);
   logger.debug() << "Network request created by" << parent->name();
 
@@ -296,8 +295,8 @@ void NetworkRequest::processData(QNetworkReply::NetworkError error,
     return;
   }
 
-  // Otherwise, if we get this far and an expected response code was provided, but
-  // but not found. Then handle this as an error.
+  // Otherwise, if we get this far and an expected response code was provided,
+  // but not found. Handle this as an error.
   if (!m_expectedStatusCodes.isEmpty()) {
     // If the status was found, it should be handled earlier in this function.
     Q_ASSERT(!m_expectedStatusCodes.contains(status));

--- a/src/networkrequest.cpp
+++ b/src/networkrequest.cpp
@@ -69,9 +69,13 @@ void NetworkRequest::resetRequestHandler() {
 #endif
 
 NetworkRequest::NetworkRequest(Task* parent, int status)
-    : QObject(parent), m_expectedStatusCode(status) {
+    : QObject(parent) {
   MZ_COUNT_CTOR(NetworkRequest);
   logger.debug() << "Network request created by" << parent->name();
+
+  if (status != 0) {
+    addExpectedStatus(status);
+  }
 
   m_request.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
   m_request.setAttribute(QNetworkRequest::Http2AllowedAttribute, false);
@@ -187,6 +191,22 @@ void NetworkRequest::deleteResource(const QUrl& url) {
   m_timer.start(REQUEST_TIMEOUT);
 }
 
+// Debug helper: format the expected status codes into a string for logging.
+QString NetworkRequest::expectStatusString() const {
+  if (m_expectedStatusCodes.isEmpty()) {
+    return "any";
+  } else if (m_expectedStatusCodes.count() == 1) {
+    return QString::number(m_expectedStatusCodes.first());
+  }
+
+  // Otherwise, format an array of codes.
+  QStringList list;
+  for (int code : m_expectedStatusCodes) {
+    list.append(QString::number(code));
+  }
+  return QString("[%1]").arg(list.join(","));
+}
+
 void NetworkRequest::replyFinished() {
   Q_ASSERT(m_reply);
   Q_ASSERT(m_reply->isFinished());
@@ -228,11 +248,8 @@ void NetworkRequest::replyFinished() {
 #endif
 
   int status = statusCode();
-
-  QString expect =
-      m_expectedStatusCode ? QString::number(m_expectedStatusCode) : "any";
   logger.debug() << "Network reply received - status:" << status
-                 << "- expected:" << expect;
+                 << "- expected:" << expectStatusString();
 
   m_replyData.append(m_reply->readAll());
   processData(m_reply->error(), m_reply->errorString(), status, m_replyData);
@@ -247,6 +264,14 @@ void NetworkRequest::processData(QNetworkReply::NetworkError error,
 #ifdef MZ_WASM
   m_finalStatusCode = status;
 #endif
+
+  // Check for expected HTTP reponse statuses. This can distinguish successful
+  // responses (eg: 200 vs. 201), but it allows for expected error conditions
+  // (eg: 404 when it's okay for the resource not to exist).
+  if ((status != 0) && m_expectedStatusCodes.contains(status)) {
+    emit requestCompleted(data);
+    return;
+  }
 
   if (error != QNetworkReply::NoError) {
     QUrl::FormattingOptions options = QUrl::RemoveQuery | QUrl::RemoveUserInfo;
@@ -271,11 +296,13 @@ void NetworkRequest::processData(QNetworkReply::NetworkError error,
     return;
   }
 
-  // This is an extra check for succeeded requests (status code 200 vs 201, for
-  // instance). The real network status check is done in the previous if-stmt.
-  if (m_expectedStatusCode && status != m_expectedStatusCode) {
+  // Otherwise, if we get this far and an expected response code was provided, but
+  // but not found. Then handle this as an error.
+  if (!m_expectedStatusCodes.isEmpty()) {
+    // If the status was found, it should be handled earlier in this function.
+    Q_ASSERT(!m_expectedStatusCodes.contains(status));
     logger.error() << "Status code unexpected - status code:" << status
-                   << "- expected:" << m_expectedStatusCode;
+                   << "- expected:" << expectStatusString();
     emit requestFailed(QNetworkReply::ConnectionRefusedError, data);
     return;
   }

--- a/src/networkrequest.h
+++ b/src/networkrequest.h
@@ -36,6 +36,8 @@ class NetworkRequest final : public QObject {
       std::function<bool(NetworkRequest*, QIODevice*)>&&
           postResourceIODeviceCallback);
 
+  void addExpectedStatus(int code) { m_expectedStatusCodes.append(code); }
+
 #ifdef UNIT_TEST
   static void resetRequestHandler();
 #endif
@@ -84,6 +86,8 @@ class NetworkRequest final : public QObject {
   bool isRedirect() const;
 
   void maybeDeleteLater();
+  QString expectStatusString() const;
+
 
  private slots:
   void replyFinished();
@@ -119,7 +123,8 @@ class NetworkRequest final : public QObject {
 
   QNetworkReply* m_reply = nullptr;
   QByteArray m_replyData;
-  int m_expectedStatusCode = 0;
+  QList<int> m_expectedStatusCodes;
+
 #ifdef MZ_WASM
   // In wasm network request, m_reply is null. So we need to store the "status
   // code" in a variable member.

--- a/src/networkrequest.h
+++ b/src/networkrequest.h
@@ -88,7 +88,6 @@ class NetworkRequest final : public QObject {
   void maybeDeleteLater();
   QString expectStatusString() const;
 
-
  private slots:
   void replyFinished();
   void timeout();

--- a/src/update/balrog.cpp
+++ b/src/update/balrog.cpp
@@ -86,6 +86,7 @@ void Balrog::start(Task* task) {
   logger.debug() << "URL:" << url;
 
   NetworkRequest* request = new NetworkRequest(task, 200);
+  request->addExpectedStatus(404);
   request->get(url);
 
   connect(request, &NetworkRequest::requestFailed, this,
@@ -98,7 +99,10 @@ void Balrog::start(Task* task) {
           [this, task, request](const QByteArray& data) {
             logger.debug() << "Request completed";
 
-            if (!fetchSignature(task, request, data)) {
+            if (request->statusCode() != 200) {
+              logger.info() << "No updates available.";
+              deleteLater();
+            } else if (!fetchSignature(task, request, data)) {
               logger.warning() << "Ignore failure.";
               deleteLater();
             }


### PR DESCRIPTION
## Description
The update check task has been fairly noisy in the logs which is due to Balrog returning a 404 status code whenever there are no updates available and the `NetworkRequest` task handles this as an error when it is really the expected the response in this case.

To suppress some of the noise in the logs, let's extend the `NetworkRequest` class so that it can accept more than one expected status code, and let's not treat it as an error when we happen to receive one of the expected status codes.

After this change, the log messages for a typical run of Balrog, when no updates are available, now looks like this:
```
[17.09.2024 10:44:32.700] (Updater) Debug: Updater created
[17.09.2024 10:44:32.701] (Balrog) Debug: Balrog created
[17.09.2024 10:44:32.701] (Balrog) Debug: URL: https://aus5.mozilla.org/json/2/FirefoxVPN/2.25.0/Darwin_x86/release-cdntest/14.6/update.json
[17.09.2024 10:44:32.701] (NetworkRequest) Debug: Network request created by TaskRelease
[17.09.2024 10:44:32.770] (NetworkRequest) Debug: Network header received
[17.09.2024 10:44:32.770] (NetworkRequest) Debug: Network reply received - status: 404 - expected: [200,404]
[17.09.2024 10:44:32.770] (Balrog) Debug: Request completed
[17.09.2024 10:44:32.770] (Balrog) Info: No updates available.
[17.09.2024 10:44:32.770] (Balrog) Debug: Balrog released
[17.09.2024 10:44:32.770] (Updater) Debug: Updater released
```

## Reference

    i.e Jira or Github issue URL

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
