### PR TITLE
VPN-6953: Force MSI reinstallation when in maintenence mode

### DIFF
--- a/windows/installer/MozillaVPN.wxs
+++ b/windows/installer/MozillaVPN.wxs
@@ -179,5 +179,15 @@
     <InstallExecuteSequence>
       <Custom Action="CloseApplication" After="StopServices" />
     </InstallExecuteSequence>
+
+    <!--
+      Force reinstall of components when running in maintenence mode.
+    -->
+    <CustomAction Id="ForceReinstall" Property="REINSTALL" Value="MozillaVPNFeature"/>
+    <InstallExecuteSequence>
+      <Custom Action="ForceReinstall" Before="CostInitialize">
+        Installed AND NOT (REMOVE="ALL") and NOT REINSTALL
+      </Custom>
+    </InstallExecuteSequence>
   </Product>
 </Wix>


### PR DESCRIPTION
## Description
We have a bit of an obnoxious bug in our Windows MSI installer, when running the installer multiple times the installer is started in maintenence mode which attempts to minimize the changes to the system by leaving unmodified files in place. Unfortunately, this causes the installer to behave inconsistently depending on whether it is running in upgrade or maintenence mode.

To fix this, we make an attempt to detect this situation (using the Wix condition `Installed and NOT (REMOVE="ALL") AND NOT REINSTALL`) and then force the re-installation of the VPN client by setting the `REINSTALL` property. This condition checks that:
 - `Installed` is true, which means that an existing VPN installation was found on the system.
 - `NOT (REMOVE="ALL")` means that the MSI was not invoked for uninstallation.
 - `NOT REINSTALL` means that the user has not explicitly requested the reinstallation of some component - so we ought to do what the user asked for instead.

## Reference
JIRA Issue: [VPN-6593](https://mozilla-hub.atlassian.net/browse/VPN-6593)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-6593]: https://mozilla-hub.atlassian.net/browse/VPN-6593?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ