### PR TITLE
SplitTunnel 02: remove dupe code in generateIPConfiguration

### DIFF
--- a/src/platforms/windows/daemon/windowsdaemon.cpp
+++ b/src/platforms/windows/daemon/windowsdaemon.cpp
@@ -5,6 +5,7 @@
 #include "windowsdaemon.h"
 
 #include <Windows.h>
+#include <qassert.h>
 
 #include <QCoreApplication>
 #include <QJsonDocument>
@@ -18,24 +19,28 @@
 #include "dnsutilswindows.h"
 #include "leakdetector.h"
 #include "logger.h"
+#include "platforms/windows/daemon/windowsfirewall.h"
+#include "platforms/windows/daemon/windowssplittunnel.h"
 #include "platforms/windows/windowscommons.h"
-#include "platforms/windows/windowsservicemanager.h"
 #include "windowsfirewall.h"
 
 namespace {
 Logger logger("WindowsDaemon");
 }
 
-WindowsDaemon::WindowsDaemon() : Daemon(nullptr), m_splitTunnelManager(this) {
+WindowsDaemon::WindowsDaemon() : Daemon(nullptr) {
   MZ_COUNT_CTOR(WindowsDaemon);
+  m_firewallManager = WindowsFirewall::create(this);
+  Q_ASSERT(m_firewallManager != nullptr);
 
-  m_wgutils = WireguardUtilsWindows::create(this);
+  m_wgutils = WireguardUtilsWindows::create(m_firewallManager, this);
   m_dnsutils = new DnsUtilsWindows(this);
+  m_splitTunnelManager = WindowsSplitTunnel::create(m_firewallManager);
 
   connect(m_wgutils.get(), &WireguardUtilsWindows::backendFailure, this,
           &WindowsDaemon::monitorBackendFailure);
   connect(this, &WindowsDaemon::activationFailure,
-          []() { WindowsFirewall::instance()->disableKillSwitch(); });
+          [this]() { m_firewallManager->disableKillSwitch(); });
 }
 
 WindowsDaemon::~WindowsDaemon() {
@@ -51,24 +56,19 @@ void WindowsDaemon::prepareActivation(const InterfaceConfig& config) {
 }
 
 bool WindowsDaemon::run(Op op, const InterfaceConfig& config) {
-  if (op == Down) {
-    m_splitTunnelManager.stop();
+  if (!m_splitTunnelManager) {
     return true;
   }
 
-  if (op == Up) {
-    logger.debug() << "Tunnel UP, Starting SplitTunneling";
-    if (!WindowsSplitTunnel::isInstalled()) {
-      logger.warning() << "Split Tunnel Driver not Installed yet, fixing this.";
-      WindowsSplitTunnel::installDriver();
-    }
+  if (op == Down) {
+    m_splitTunnelManager->stop();
+    return true;
   }
-
   if (config.m_vpnDisabledApps.length() > 0) {
-    m_splitTunnelManager.start(m_inetAdapterIndex);
-    m_splitTunnelManager.setRules(config.m_vpnDisabledApps);
+    m_splitTunnelManager->start(m_inetAdapterIndex);
+    m_splitTunnelManager->setRules(config.m_vpnDisabledApps);
   } else {
-    m_splitTunnelManager.stop();
+    m_splitTunnelManager->stop();
   }
   return true;
 }

--- a/src/platforms/windows/daemon/windowsdaemon.h
+++ b/src/platforms/windows/daemon/windowsdaemon.h
@@ -5,8 +5,11 @@
 #ifndef WINDOWSDAEMON_H
 #define WINDOWSDAEMON_H
 
+#include <qpointer.h>
+
 #include "daemon/daemon.h"
 #include "dnsutilswindows.h"
+#include "windowsfirewall.h"
 #include "windowssplittunnel.h"
 #include "wireguardutilswindows.h"
 
@@ -39,7 +42,8 @@ class WindowsDaemon final : public Daemon {
 
   std::unique_ptr<WireguardUtilsWindows> m_wgutils;
   DnsUtilsWindows* m_dnsutils = nullptr;
-  WindowsSplitTunnel m_splitTunnelManager;
+  std::unique_ptr<WindowsSplitTunnel> m_splitTunnelManager;
+  QPointer<WindowsFirewall> m_firewallManager;
 };
 
 #endif  // WINDOWSDAEMON_H

--- a/src/platforms/windows/daemon/windowsfirewall.h
+++ b/src/platforms/windows/daemon/windowsfirewall.h
@@ -26,10 +26,17 @@ struct FWP_CONDITION_VALUE0_;
 
 class WindowsFirewall final : public QObject {
  public:
-  ~WindowsFirewall();
-
-  static WindowsFirewall* instance();
-  bool init();
+  /**
+   * @brief Opens the Windows Filtering Platform, initializes the session,
+   * sublayer. Returns a WindowsFirewall object if successful, otherwise
+   * nullptr. If there is already a WindowsFirewall object, it will be returned.
+   *
+   * @param parent - parent QObject
+   * @return WindowsFirewall* - nullptr if failed to open the Windows Filtering
+   * Platform.
+   */
+  static WindowsFirewall* create(QObject* parent);
+  ~WindowsFirewall() override;
 
   bool enableInterface(int vpnAdapterIndex);
   bool enableLanBypass(const QList<IPAddress>& ranges);
@@ -38,7 +45,8 @@ class WindowsFirewall final : public QObject {
   bool disableKillSwitch();
 
  private:
-  WindowsFirewall(QObject* parent);
+  static bool initSublayer();
+  WindowsFirewall(HANDLE session, QObject* parent);
   HANDLE m_sessionHandle;
   bool m_init = false;
   QList<uint64_t> m_activeRules;

--- a/src/platforms/windows/daemon/windowssplittunnel.h
+++ b/src/platforms/windows/daemon/windowssplittunnel.h
@@ -84,10 +84,11 @@ class WindowsSplitTunnel final {
   // Generates a Configuration for Each APP
   std::vector<uint8_t> generateAppConfiguration(const QStringList& appPaths);
   // Generates a Configuration which IP's are VPN and which network
-  std::vector<uint8_t> generateIPConfiguration(int inetAdapterIndex);
+  std::vector<std::byte> generateIPConfiguration(int inetAdapterIndex);
   std::vector<uint8_t> generateProcessBlob();
 
-  void getAddress(int adapterIndex, IN_ADDR* out_ipv4, IN6_ADDR* out_ipv6);
+  [[nodiscard]] bool getAddress(int adapterIndex, IN_ADDR* out_ipv4,
+                                IN6_ADDR* out_ipv6);
   // Collects info about an Opened Process
 
   // Converts a path to a Dos Path:

--- a/src/platforms/windows/daemon/wireguardutilswindows.h
+++ b/src/platforms/windows/daemon/wireguardutilswindows.h
@@ -11,6 +11,7 @@
 #include "daemon/wireguardutils.h"
 #include "wireguard.h"
 
+class WindowsFirewall;
 class WindowsRouteMonitor;
 struct WireGuardAPI;
 
@@ -20,7 +21,8 @@ class WireguardUtilsWindows final : public WireguardUtils {
  public:
   // Creates a WireguardUtilsWindows instance, may fail due to i.e
   // wireguard-nt failing to initialize, returns nullptr in that case.
-  static std::unique_ptr<WireguardUtilsWindows> create(QObject* parent);
+  static std::unique_ptr<WireguardUtilsWindows> create(WindowsFirewall* fw,
+                                                       QObject* parent);
   ~WireguardUtilsWindows();
 
   bool interfaceExists() override;
@@ -43,7 +45,7 @@ class WireguardUtilsWindows final : public WireguardUtils {
   void backendFailure();
 
  private:
-  WireguardUtilsWindows(QObject* parent,
+  WireguardUtilsWindows(QObject* parent, WindowsFirewall* fw,
                         std::unique_ptr<WireGuardAPI> wireguard_api);
   void buildMibForwardRow(const IPAddress& prefix, void* row);
 
@@ -52,6 +54,7 @@ class WireguardUtilsWindows final : public WireguardUtils {
   ulong m_deviceIpv4_Handle = 0;
 
   QPointer<WindowsRouteMonitor> m_routeMonitor;
+  QPointer<WindowsFirewall> m_firewall;
   WIREGUARD_ADAPTER_HANDLE m_adapter = NULL;
 };
 


### PR DESCRIPTION
Stacked PRs:
 * #9892
 * #9891
 * __->__#9890
 * #9889


--- --- ---

### SplitTunnel 02: remove dupe code in generateIPConfiguration


Inline Lambdas are cool, let's use them to reduce dupecode and lets
give this function a failstate to bubble that up later to the client.
