### PR TITLE
Add flatpak sandbox config to run on 'KDE Fedora 40'

### DIFF
--- a/linux/flatpak/org.mozilla.vpn.yml
+++ b/linux/flatpak/org.mozilla.vpn.yml
@@ -10,6 +10,7 @@ finish-args:
   - "--share=network"
   - "--socket=fallback-x11"
   - "--socket=wayland"
+  - "--device=dri"
   - "--talk-name=org.kde.StatusNotifierWatcher"
   - "--system-talk-name=org.freedesktop.NetworkManager"
   - "--env=QML2_IMPORT_PATH=/app/lib64/qml:/app/lib/qml:/app/qml"

--- a/linux/flatpak/org.mozilla.vpn.yml
+++ b/linux/flatpak/org.mozilla.vpn.yml
@@ -8,7 +8,9 @@ command: mozillavpn
 finish-args:
   - "--share=ipc"
   - "--share=network"
-  - "--socket=x11"
+  - "--socket=fallback-x11"
+  - "--socket=wayland"
+  - "--talk-name=org.kde.StatusNotifierWatcher"
   - "--system-talk-name=org.freedesktop.NetworkManager"
   - "--env=QML2_IMPORT_PATH=/app/lib64/qml:/app/lib/qml:/app/qml"
 build-options:


### PR DESCRIPTION
## Description
  
Update flatpak finish args. I am testing on KDE Fedora 40. 

-  "--socket=fallback-x11" seems to be best practice
- "--socket=wayland" is required to get the app to start at all
- "--talk-name=org.kde.StatusNotifierWatcher" is required to see the app in the systray
- "--device=dri" Optional, but required for graphics accel

## Reference

    i.e Jira or Github issue URL

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
