### PR TITLE
VPN-5407: Start DnsPingSender

### DIFF
--- a/src/connectionhealth.cpp
+++ b/src/connectionhealth.cpp
@@ -128,7 +128,7 @@ void ConnectionHealth::startIdle() {
   m_dnsPingInitialized = false;
   m_dnsPingLatency = PING_TIME_UNSTABLE.count();
 
-  if (m_dnsPingSender.start()) {
+  if (m_dnsPingSender.isValid()) {
     m_dnsPingTimer.start(PING_INTERVAL_IDLE);
     // Send an initial ping right away.
     m_dnsPingTimestamp = QDateTime::currentMSecsSinceEpoch();

--- a/src/dnspingsender.cpp
+++ b/src/dnspingsender.cpp
@@ -55,17 +55,13 @@ DnsPingSender::DnsPingSender(const QHostAddress& source, QObject* parent)
   m_source = source;
 
   connect(&m_socket, &QUdpSocket::readyRead, this, &DnsPingSender::readData);
-}
 
-DnsPingSender::~DnsPingSender() { MZ_COUNT_DTOR(DnsPingSender); }
-
-bool DnsPingSender::start() {
   auto state = m_socket.state();
   if (state != QAbstractSocket::UnconnectedState) {
     logger.info()
         << "Attempted to start UDP socket, but it's in an invalid state:"
         << state;
-    return false;
+    m_socket.abort();
   }
 
   bool bindResult = false;
@@ -77,13 +73,14 @@ bool DnsPingSender::start() {
 
   if (!bindResult) {
     logger.error() << "Unable to bind UDP socket. Socket state:" << state;
-    return false;
+    m_socket.abort();
   }
 
   logger.debug() << "UDP socket bound to:"
                  << m_socket.localAddress().toString();
-  return true;
 }
+
+DnsPingSender::~DnsPingSender() { MZ_COUNT_DTOR(DnsPingSender); }
 
 void DnsPingSender::sendPing(const QHostAddress& dest, quint16 sequence) {
   if (dest.isNull()) {

--- a/src/dnspingsender.h
+++ b/src/dnspingsender.h
@@ -17,13 +17,10 @@ class DnsPingSender final : public PingSender {
   DnsPingSender(const QHostAddress& source, QObject* parent = nullptr);
   ~DnsPingSender();
 
+  bool isValid() override { return m_socket.isValid(); };
+
   void sendPing(const QHostAddress& dest, quint16 sequence) override;
 
-  /**
-   * Starts the Underlying socket, returns true
-   * if the PingSender is now ready to be used.
-   */
-  [[nodiscard]] bool start();
   void stop() { m_socket.close(); }
 
  private:

--- a/src/pinghelper.cpp
+++ b/src/pinghelper.cpp
@@ -12,6 +12,7 @@
 #include "logger.h"
 #include "pingsender.h"
 #include "pingsenderfactory.h"
+#include "platforms/dummy/dummypingsender.h"
 
 // Maximum window size for ping statistics.
 constexpr int PING_STATS_WINDOW = 32;
@@ -47,10 +48,14 @@ void PingHelper::start(const QString& serverIpv4Gateway,
   // we happen to be on one of these unlucky devices, create a DnsPingSender
   // instead.
   if (!m_pingSender->isValid()) {
+    logger.warning() << "PingSenderFactory is not valid, trying DnsPingSender.";
     m_pingSender->deleteLater();
     m_pingSender = new DnsPingSender(m_source, this);
-    if (!((DnsPingSender*)m_pingSender)->start()) {
-      logger.error() << "Unable to start DNSPingSender.";
+    if (!m_pingSender->isValid()) {
+      logger.error()
+          << "DnsPingSender is also not valid, using DummyPingSender.";
+      m_pingSender->deleteLater();
+      m_pingSender = new DummyPingSender(m_source, this);
     }
   }
 

--- a/src/pinghelper.cpp
+++ b/src/pinghelper.cpp
@@ -49,6 +49,9 @@ void PingHelper::start(const QString& serverIpv4Gateway,
   if (!m_pingSender->isValid()) {
     m_pingSender->deleteLater();
     m_pingSender = new DnsPingSender(m_source, this);
+    if (!((DnsPingSender*)m_pingSender)->start()) {
+      logger.error() << "Unable to start DNSPingSender.";
+    }
   }
 
   connect(m_pingSender, &PingSender::recvPing, this, &PingHelper::pingReceived,

--- a/src/platforms/macos/macospingsender.cpp
+++ b/src/platforms/macos/macospingsender.cpp
@@ -52,6 +52,8 @@ MacOSPingSender::MacOSPingSender(const QHostAddress& source, QObject* parent)
   addr.sin_addr.s_addr = qToBigEndian<quint32>(ipv4addr);
 
   if (bind(m_socket, (struct sockaddr*)&addr, sizeof(addr)) != 0) {
+    close(m_socket);
+    m_socket = -1;
     logger.error() << "bind error:" << strerror(errno);
     return;
   }

--- a/src/platforms/macos/macospingsender.h
+++ b/src/platforms/macos/macospingsender.h
@@ -17,6 +17,8 @@ class MacOSPingSender final : public PingSender {
   MacOSPingSender(const QHostAddress& source, QObject* parent = nullptr);
   ~MacOSPingSender();
 
+  bool isValid() override { return (m_socket >= 0); };
+
   void sendPing(const QHostAddress& dest, quint16 sequence) override;
 
  private slots:


### PR DESCRIPTION
## Description

In PingHelper.cpp, we have this block:
```
m_pingSender = PingSenderFactory::create(m_source, this);

// Some platforms require root access to send and receive ICMP pings. If
// we happen to be on one of these unlucky devices, create a DnsPingSender
// instead.
 if (!m_pingSender->isValid()) {
    m_pingSender->deleteLater();
    m_pingSender = new DnsPingSender(m_source, this);
} 
```

If you comment out this entire snippet except `m_pingSender = new DnsPingSender(m_source, this);` (that is, pretend we need root access), this bug reliably repros a few seconds after turning the VPN on, as well as when doing a cold launch of the app when the VPN is active.

`DnnsPingSender` has a `start` method. This should be called before `sendPing` it seems. (That is how it works in `ConnectionHealth`, the only other part of the code that uses `DnsPingSender`.) However in `PingHelper`, we initialize `DnsPingSender` but we never call `start`. But we do call `sendPing`.

To provide some more evidence that this likely the root issue: It makes sense why this bug is only on certain platforms - it's the rare platforms that enter the if block in the snippet above.

For the fix, we're removing the entire `start` method and incorporating it into the initializer. We're also fixing up a related piece on the mac ping sender.

## Reference

VPN-5407

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
