### PR TITLE
FXVPN-218: Socks Proxy bypass without split tunneling

### DIFF
--- a/extension/socks5proxy/bin/CMakeLists.txt
+++ b/extension/socks5proxy/bin/CMakeLists.txt
@@ -25,6 +25,10 @@ elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
         linuxbypass.cpp
         linuxbypass.h)
 
+    find_package(PkgConfig REQUIRED)
+    pkg_check_modules(LIBCAP REQUIRED IMPORTED_TARGET libcap)
+    target_link_libraries(socksproxy PRIVATE PkgConfig::LIBCAP)
+
     # TODO: not install that yet.
     #install(FILES ${CMAKE_CURRENT_BINARY_DIR}/socksproxy
     #    DESTINATION ${CMAKE_INSTALL_DATADIR}/socksproxy)

--- a/extension/socks5proxy/bin/CMakeLists.txt
+++ b/extension/socks5proxy/bin/CMakeLists.txt
@@ -13,6 +13,10 @@ target_link_libraries(socksproxy PUBLIC
 )
 
 if(WIN32)
+    target_sources(socksproxy PRIVATE
+        windowsbypass.cpp
+        windowsbypass.h)
+
     install(FILES
         ${CMAKE_CURRENT_BINARY_DIR}/socksproxy.exe
         DESTINATION .)

--- a/extension/socks5proxy/bin/CMakeLists.txt
+++ b/extension/socks5proxy/bin/CMakeLists.txt
@@ -4,6 +4,8 @@
 
 qt_add_executable(socksproxy 
     main.cpp
+    verboselogger.cpp
+    verboselogger.h
 )
 
 target_link_libraries(socksproxy PUBLIC 

--- a/extension/socks5proxy/bin/CMakeLists.txt
+++ b/extension/socks5proxy/bin/CMakeLists.txt
@@ -16,7 +16,11 @@ if(WIN32)
     install(FILES
         ${CMAKE_CURRENT_BINARY_DIR}/socksproxy.exe
         DESTINATION .)
-elseif(LINUX)
+elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+    target_sources(socksproxy PRIVATE
+        linuxbypass.cpp
+        linuxbypass.h)
+
     # TODO: not install that yet.
     #install(FILES ${CMAKE_CURRENT_BINARY_DIR}/socksproxy
     #    DESTINATION ${CMAKE_INSTALL_DATADIR}/socksproxy)

--- a/extension/socks5proxy/bin/linuxbypass.cpp
+++ b/extension/socks5proxy/bin/linuxbypass.cpp
@@ -1,0 +1,34 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include <QAbstractSocket>
+#include <QHostAddress>
+
+#include <errno.h>
+#include <sys/socket.h>
+
+void setupLinuxBypass(QAbstractSocket* s, const QHostAddress& dest) {
+  constexpr const int vpn_firewall_mark = 51820;
+  int af = AF_INET;
+
+  if (dest.protocol() == QAbstractSocket::IPv6Protocol) {
+    af = AF_INET6;
+  }
+
+  // Create a socket and set its firewall mark.
+  int newsock = socket(af, SOCK_STREAM, 0);
+  if (newsock < 0) {
+    qWarning() << "socket() failed:" << strerror(errno);
+    return;
+  }
+
+  int err = setsockopt(newsock, SOL_SOCKET, SO_MARK, &vpn_firewall_mark,
+                       sizeof(vpn_firewall_mark));
+  if (err != 0) {
+    qWarning() << "setsockopt(SO_MARK) failed:" << strerror(errno);
+    close(newsock);
+  } else if (!s->setSocketDescriptor(newsock, QAbstractSocket::UnconnectedState)) {
+    qWarning() << "setSocketDescriptor() failed:" << s->errorString();
+  }
+}

--- a/extension/socks5proxy/bin/linuxbypass.cpp
+++ b/extension/socks5proxy/bin/linuxbypass.cpp
@@ -10,6 +10,8 @@
 #include <QAbstractSocket>
 #include <QHostAddress>
 
+#include "socks5.h"
+
 LinuxBypass::LinuxBypass(Socks5* proxy) : QObject(proxy) {
   connect(proxy, &Socks5::outgoingConnection, this,
           &LinuxBypass::outgoingConnection);

--- a/extension/socks5proxy/bin/linuxbypass.cpp
+++ b/extension/socks5proxy/bin/linuxbypass.cpp
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#include "linuxbypass.h"
+
 #include <QAbstractSocket>
 #include <QHostAddress>
 

--- a/extension/socks5proxy/bin/linuxbypass.cpp
+++ b/extension/socks5proxy/bin/linuxbypass.cpp
@@ -8,7 +8,12 @@
 #include <errno.h>
 #include <sys/socket.h>
 
-void setupLinuxBypass(QAbstractSocket* s, const QHostAddress& dest) {
+LinuxBypass::LinuxBypass(Socks5* proxy) : QObject(proxy) {
+  connect(proxy, &Socks5::outgoingConnection, this,
+          &LinuxBypass::outgoingConnection);
+}
+
+void LinuxBypass::outgoingConnection(QAbstractSocket* s, const QHostAddress& dest) {
   constexpr const int vpn_firewall_mark = 51820;
   int af = AF_INET;
 

--- a/extension/socks5proxy/bin/linuxbypass.cpp
+++ b/extension/socks5proxy/bin/linuxbypass.cpp
@@ -27,6 +27,7 @@ LinuxBypass::LinuxBypass(Socks5* proxy) : QObject(proxy) {
   cap_value_t newcaps[] = {CAP_NET_RAW};
   const int numcaps = sizeof(newcaps) / sizeof(cap_value_t);
   cap_set_flag(caps, CAP_EFFECTIVE, numcaps, newcaps, CAP_SET);
+  cap_set_flag(caps, CAP_PERMITTED, numcaps, newcaps, CAP_SET);
   if (cap_set_proc(caps) != 0) {
     qWarning() << "Failed to set CAP_NET_RAW: disabling split tunnel";
     cap_clear(caps);

--- a/extension/socks5proxy/bin/linuxbypass.cpp
+++ b/extension/socks5proxy/bin/linuxbypass.cpp
@@ -6,6 +6,7 @@
 
 #include <errno.h>
 #include <sys/socket.h>
+#include <unistd.h>
 
 #include <QAbstractSocket>
 #include <QHostAddress>

--- a/extension/socks5proxy/bin/linuxbypass.cpp
+++ b/extension/socks5proxy/bin/linuxbypass.cpp
@@ -4,18 +4,19 @@
 
 #include "linuxbypass.h"
 
-#include <QAbstractSocket>
-#include <QHostAddress>
-
 #include <errno.h>
 #include <sys/socket.h>
+
+#include <QAbstractSocket>
+#include <QHostAddress>
 
 LinuxBypass::LinuxBypass(Socks5* proxy) : QObject(proxy) {
   connect(proxy, &Socks5::outgoingConnection, this,
           &LinuxBypass::outgoingConnection);
 }
 
-void LinuxBypass::outgoingConnection(QAbstractSocket* s, const QHostAddress& dest) {
+void LinuxBypass::outgoingConnection(QAbstractSocket* s,
+                                     const QHostAddress& dest) {
   constexpr const int vpn_firewall_mark = 51820;
   int af = AF_INET;
 
@@ -35,7 +36,8 @@ void LinuxBypass::outgoingConnection(QAbstractSocket* s, const QHostAddress& des
   if (err != 0) {
     qWarning() << "setsockopt(SO_MARK) failed:" << strerror(errno);
     close(newsock);
-  } else if (!s->setSocketDescriptor(newsock, QAbstractSocket::UnconnectedState)) {
+  } else if (!s->setSocketDescriptor(newsock,
+                                     QAbstractSocket::UnconnectedState)) {
     qWarning() << "setSocketDescriptor() failed:" << s->errorString();
   }
 }

--- a/extension/socks5proxy/bin/linuxbypass.cpp
+++ b/extension/socks5proxy/bin/linuxbypass.cpp
@@ -5,15 +5,36 @@
 #include "linuxbypass.h"
 
 #include <errno.h>
+#include <sys/capability.h>
 #include <sys/socket.h>
 #include <unistd.h>
 
 #include <QAbstractSocket>
 #include <QHostAddress>
+#include <QScopeGuard>
 
 #include "socks5.h"
 
 LinuxBypass::LinuxBypass(Socks5* proxy) : QObject(proxy) {
+  cap_t caps = cap_init();
+  if (caps == nullptr) {
+    qWarning() << "Failed to init process capabilities";
+    return;
+  }
+  auto guard = qScopeGuard([&] { cap_free(caps); });
+
+  // Try to acquire CAP_NET_RAW in order to set the firewall mark.
+  cap_value_t newcaps[] = {CAP_NET_RAW};
+  const int numcaps = sizeof(newcaps) / sizeof(cap_value_t);
+  cap_set_flag(caps, CAP_EFFECTIVE, numcaps, newcaps, CAP_SET);
+  if (cap_set_proc(caps) != 0) {
+    qWarning() << "Failed to set CAP_NET_RAW: disabling split tunnel";
+    cap_clear(caps);
+    cap_set_proc(caps);
+    return;
+  }
+
+  // If we get this far - we can perform split tunneling.
   connect(proxy, &Socks5::outgoingConnection, this,
           &LinuxBypass::outgoingConnection);
 }

--- a/extension/socks5proxy/bin/linuxbypass.h
+++ b/extension/socks5proxy/bin/linuxbypass.h
@@ -5,9 +5,21 @@
 #ifndef LINUXBYPASS_H
 #define LINUXBYPASS_H
 
+#include <QObject>
+
+class Socks5;
 class QAbstractSocket;
 class QHostAddress;
 
-void setupLinuxBypass(QAbstractSocket* s, const QHostAddress& dest);
+class LinuxBypass : public QObject {
+  Q_OBJECT
+
+ public:
+  LinuxBypass(Socks5* proxy);
+  ~LinuxBypass() = default;
+
+ private slots:
+  void outgoingConnection(QAbstractSocket* s, const QHostAddress& dest);
+};
 
 #endif  // LINUXBYPASS_H

--- a/extension/socks5proxy/bin/linuxbypass.h
+++ b/extension/socks5proxy/bin/linuxbypass.h
@@ -1,0 +1,13 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef LINUXBYPASS_H
+#define LINUXBYPASS_H
+
+class QAbstractSocket;
+class QHostAddress;
+
+void setupLinuxBypass(QAbstractSocket* s, const QHostAddress& dest);
+
+#endif  // LINUXBYPASS_H

--- a/extension/socks5proxy/bin/linuxbypass.h
+++ b/extension/socks5proxy/bin/linuxbypass.h
@@ -11,11 +11,11 @@ class Socks5;
 class QAbstractSocket;
 class QHostAddress;
 
-class LinuxBypass : public QObject {
+class LinuxBypass final : public QObject {
   Q_OBJECT
 
  public:
-  LinuxBypass(Socks5* proxy);
+  explicit LinuxBypass(Socks5* proxy);
   ~LinuxBypass() = default;
 
  private slots:

--- a/extension/socks5proxy/bin/main.cpp
+++ b/extension/socks5proxy/bin/main.cpp
@@ -126,11 +126,6 @@ int main(int argc, char** argv) {
     new VerboseLogger(socks5);
   }
 
-  QObject::connect(socks5, &Socks5::incomingConnection,
-                   [](Socks5Connection* conn) {
-                     qDebug() << "Connection from peer" << conn->clientName();
-                   });
-
 #ifdef __linux__
   new LinuxBypass(socks5);
 #elif defined(WIN32) || defined(_WIN32) || defined(__WIN32__) || defined(__NT__)

--- a/extension/socks5proxy/bin/main.cpp
+++ b/extension/socks5proxy/bin/main.cpp
@@ -14,6 +14,9 @@
 #ifdef __linux__
 #  include "linuxbypass.h"
 #endif
+#if defined(WIN32) || defined(_WIN32) || defined(__WIN32__) || defined(__NT__)
+#  include "windowsbypass.h"
+#endif
 
 struct Event {
   QString m_newConnection;
@@ -189,7 +192,9 @@ int main(int argc, char** argv) {
                    });
 
 #ifdef __linux__
-  QObject::connect(socks5, &Socks5::outgoingConnection, &setupLinuxBypass);
+  LinuxBypass* bypass = new LinuxBypass(socks5);
+#elif defined(WIN32) || defined(_WIN32) || defined(__WIN32__) || defined(__NT__)
+  WindowsBypass* bypass = new WindowsBypass(socks5);
 #endif
 
   return app.exec();

--- a/extension/socks5proxy/bin/main.cpp
+++ b/extension/socks5proxy/bin/main.cpp
@@ -154,8 +154,8 @@ static void startVerboseCLI(const Socks5* socks5) {
   QObject::connect(
       socks5, &Socks5::incomingConnection,
       [printStatus](Socks5Connection* conn) {
-        s_events.append(
-            Event{conn->clientName(), 0, 0, QDateTime::currentMSecsSinceEpoch()});
+        s_events.append(Event{conn->clientName(), 0, 0,
+                              QDateTime::currentMSecsSinceEpoch()});
         printStatus();
       });
 
@@ -197,7 +197,8 @@ int main(int argc, char** argv) {
                server->listen(config.localSocketName)) {
       qDebug() << "(Re)starting on local socket" << server->fullServerName();
     } else {
-      qWarning() << "Unable to listen to the local socket" << config.localSocketName;
+      qWarning() << "Unable to listen to the local socket"
+                 << config.localSocketName;
       qWarning() << "Listen failed:" << server->errorString();
       return 1;
     }

--- a/extension/socks5proxy/bin/main.cpp
+++ b/extension/socks5proxy/bin/main.cpp
@@ -145,7 +145,7 @@ static void startVerboseCLI(const Socks5* socks5) {
                    [printStatus]() { printStatus(); });
   QObject::connect(
       socks5, &Socks5::incomingConnection,
-      [printStatus](QAbstractSocket*s, const QHostAddress& peer) {
+      [printStatus](QAbstractSocket* s, const QHostAddress& peer) {
         Q_UNUSED(s);
         s_events.append(
             Event{peer.toString(), 0, 0, QDateTime::currentMSecsSinceEpoch()});

--- a/extension/socks5proxy/bin/main.cpp
+++ b/extension/socks5proxy/bin/main.cpp
@@ -203,7 +203,7 @@ int main(int argc, char** argv) {
       return 1;
     }
   } else {
-    QTcpServer* server = new QTcpServer(socks5);
+    QTcpServer* server = new QTcpServer();
     socks5 = new Socks5(server);
     if (server->listen(config.addr, config.port)) {
       qDebug() << "Starting on port" << config.port;

--- a/extension/socks5proxy/bin/main.cpp
+++ b/extension/socks5proxy/bin/main.cpp
@@ -223,9 +223,9 @@ int main(int argc, char** argv) {
                    });
 
 #ifdef __linux__
-  LinuxBypass* bypass = new LinuxBypass(socks5);
+  new LinuxBypass(socks5);
 #elif defined(WIN32) || defined(_WIN32) || defined(__WIN32__) || defined(__NT__)
-  WindowsBypass* bypass = new WindowsBypass(socks5);
+  new WindowsBypass(socks5);
 #endif
 
   return app.exec();

--- a/extension/socks5proxy/bin/verboselogger.cpp
+++ b/extension/socks5proxy/bin/verboselogger.cpp
@@ -1,0 +1,111 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "verboselogger.h"
+
+#include <QDateTime>
+#include <QLoggingCategory>
+
+#include "socks5.h"
+
+// static
+QString VerboseLogger::bytesToString(qint64 bytes) {
+  if (bytes < 1024) {
+    return QString("%1b").arg(bytes);
+  }
+
+  if (bytes < 1024 * 1024) {
+    return QString("%1Kb").arg(bytes / 1024);
+  }
+
+  if (bytes < 1024 * 1024 * 1024) {
+    return QString("%1Mb").arg(bytes / (1024 * 1024));
+  }
+
+  return QString("%1Gb").arg(bytes / (1024 * 1024 * 1024));
+}
+
+VerboseLogger::VerboseLogger(Socks5* socks5)
+    : QObject(socks5), m_socks(socks5) {
+  connect(&m_timer, &QTimer::timeout, this, &VerboseLogger::tick);
+  m_timer.setSingleShot(false);
+  m_timer.start(1000);
+
+  connect(socks5, &Socks5::connectionsChanged, this,
+          &VerboseLogger::printStatus);
+
+  connect(socks5, &Socks5::dataSentReceived, this,
+      [this](qint64 sent, qint64 received) {
+        m_tx_bytes.addSample(sent);
+        m_rx_bytes.addSample(received);
+      });
+
+  connect(socks5, &Socks5::incomingConnection, this,
+      [this](Socks5Connection* conn) {
+        m_events.append(Event{conn->clientName(),
+                              QDateTime::currentMSecsSinceEpoch()});
+        printStatus();
+      });
+
+  // Install a custom log handler that plays nicely with the status.
+  QLoggingCategory::defaultCategory()->setEnabled(QtMsgType::QtDebugMsg, true);
+  qInstallMessageHandler(logHandler);
+}
+
+void VerboseLogger::tick() {
+  // Update the boxcar average.
+  m_tx_bytes.advance();
+  m_rx_bytes.advance();
+
+  // Drop entries from the event queue.
+  qint64 now = QDateTime::currentMSecsSinceEpoch();
+  QMutableListIterator<Event> i(m_events);
+  while (i.hasNext()) {
+    if ((now - i.next().m_when) > 1000) {
+      i.remove();
+    }
+  }
+
+  // Update the status.
+  printStatus();
+}
+
+QString VerboseLogger::s_lastStatus;
+
+void VerboseLogger::printStatus() {
+  QString output;
+  {
+    QTextStream out(&output);
+    out << "Connections: " << m_socks->connections();
+
+    QStringList addresses;
+    for (const Event& event : m_events) {
+      if (!event.m_newConnection.isEmpty() &&
+          !addresses.contains(event.m_newConnection)) {
+          addresses.append(event.m_newConnection);
+      }
+    }
+    out << " [" << addresses.join(", ") << "]";
+    out << " Up: " << bytesToString(m_tx_bytes.average()) << "/s";
+    out << " Down: " << bytesToString(m_rx_bytes.average()) << "/s";
+  }
+
+  output.truncate(80);
+  while (output.length() < 80) output.append(' ');
+  QTextStream out(stdout);
+  out << output << '\r';
+
+  s_lastStatus = output;
+}
+
+// static
+void VerboseLogger::logHandler(QtMsgType type, const QMessageLogContext& ctx,
+                               const QString& msg) {
+  // A message logger that plays nicely with the status output.
+  // Clears the current line - prints the log message - reprints the status.
+  QTextStream out(stdout);
+  out << QString(80, ' ') << '\r';
+  out << msg << "\r\n";
+  out << s_lastStatus << '\r';
+}

--- a/extension/socks5proxy/bin/verboselogger.cpp
+++ b/extension/socks5proxy/bin/verboselogger.cpp
@@ -36,16 +36,16 @@ VerboseLogger::VerboseLogger(Socks5* socks5)
           &VerboseLogger::printStatus);
 
   connect(socks5, &Socks5::incomingConnection, this,
-      [this](Socks5Connection* conn) {
-        connect(conn, &Socks5Connection::dataSentReceived, this,
-                &VerboseLogger::dataSentReceived);
-        connect(conn, &Socks5Connection::stateChanged, this,
-                &VerboseLogger::connectionStateChanged);
+          [this](Socks5Connection* conn) {
+            connect(conn, &Socks5Connection::dataSentReceived, this,
+                    &VerboseLogger::dataSentReceived);
+            connect(conn, &Socks5Connection::stateChanged, this,
+                    &VerboseLogger::connectionStateChanged);
 
-        m_events.append(Event{conn->clientName(),
-                              QDateTime::currentMSecsSinceEpoch()});
-        printStatus();
-      });
+            m_events.append(
+                Event{conn->clientName(), QDateTime::currentMSecsSinceEpoch()});
+            printStatus();
+          });
 
   // Install a custom log handler that plays nicely with the status.
   QLoggingCategory::defaultCategory()->setEnabled(QtMsgType::QtDebugMsg, true);
@@ -82,7 +82,7 @@ void VerboseLogger::printStatus() {
     for (const Event& event : m_events) {
       if (!event.m_newConnection.isEmpty() &&
           !addresses.contains(event.m_newConnection)) {
-          addresses.append(event.m_newConnection);
+        addresses.append(event.m_newConnection);
       }
     }
     out << " [" << addresses.join(", ") << "]";

--- a/extension/socks5proxy/bin/verboselogger.h
+++ b/extension/socks5proxy/bin/verboselogger.h
@@ -6,8 +6,8 @@
 #define VERBOSELOGGER_H
 
 #include <QObject>
-#include <QTimer>
 #include <QString>
+#include <QTimer>
 #include <QVector>
 
 class Socks5;
@@ -19,25 +19,23 @@ class BoxcarAverage final {
   BoxcarAverage(int buckets = 8) : m_buckets(buckets) { advance(); }
 
   // Increment the data in the current bucket.
-  void addSample(qint64 sample) {
-   m_data[0] += sample;
-  }
+  void addSample(qint64 sample) { m_data[0] += sample; }
 
   // Advance the boxcar average to the next bucket.
   void advance() {
-   if (m_data.length() >= m_buckets) {
-     m_data.resize(m_buckets - 1);
-   }
-   m_data.push_front(0);
+    if (m_data.length() >= m_buckets) {
+      m_data.resize(m_buckets - 1);
+    }
+    m_data.push_front(0);
   }
 
   // Calculate the average value over the buckets.
   qint64 average() const {
-   qint64 sum = 0;
-   for (auto x : m_data) {
-     sum += x;
-   }
-   return m_data.isEmpty() ? 0 : sum / m_data.length();
+    qint64 sum = 0;
+    for (auto x : m_data) {
+      sum += x;
+    }
+    return m_data.isEmpty() ? 0 : sum / m_data.length();
   }
 
  private:

--- a/extension/socks5proxy/bin/verboselogger.h
+++ b/extension/socks5proxy/bin/verboselogger.h
@@ -11,6 +11,7 @@
 #include <QVector>
 
 class Socks5;
+class Socks5Connection;
 
 // Calculates a boxcar average
 class BoxcarAverage final {
@@ -58,6 +59,8 @@ class VerboseLogger final : public QObject {
  private:
   static void logHandler(QtMsgType type, const QMessageLogContext& ctx,
                          const QString& msg);
+  void dataSentReceived(qint64 sent, qint64 received);
+  void connectionStateChanged();
   void tick();
 
  private:

--- a/extension/socks5proxy/bin/verboselogger.h
+++ b/extension/socks5proxy/bin/verboselogger.h
@@ -1,0 +1,79 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef VERBOSELOGGER_H
+#define VERBOSELOGGER_H
+
+#include <QObject>
+#include <QTimer>
+#include <QString>
+#include <QVector>
+
+class Socks5;
+
+// Calculates a boxcar average
+class BoxcarAverage final {
+ public:
+  BoxcarAverage(int buckets = 8) : m_buckets(buckets) { advance(); }
+
+  // Increment the data in the current bucket.
+  void addSample(qint64 sample) {
+   m_data[0] += sample;
+  }
+
+  // Advance the boxcar average to the next bucket.
+  void advance() {
+   if (m_data.length() >= m_buckets) {
+     m_data.resize(m_buckets - 1);
+   }
+   m_data.push_front(0);
+  }
+
+  // Calculate the average value over the buckets.
+  qint64 average() const {
+   qint64 sum = 0;
+   for (auto x : m_data) {
+     sum += x;
+   }
+   return m_data.isEmpty() ? 0 : sum / m_data.length();
+  }
+
+ private:
+  const int m_buckets;
+  QVector<qint64> m_data;
+};
+
+class VerboseLogger final : public QObject {
+  Q_OBJECT
+
+ public:
+  explicit VerboseLogger(Socks5* proxy);
+  ~VerboseLogger() = default;
+
+  static QString bytesToString(qint64 value);
+
+  void printStatus();
+
+ private:
+  static void logHandler(QtMsgType type, const QMessageLogContext& ctx,
+                         const QString& msg);
+  void tick();
+
+ private:
+  Socks5* m_socks = nullptr;
+
+  struct Event {
+    QString m_newConnection;
+    qint64 m_when;
+  };
+  QList<Event> m_events;
+
+  QTimer m_timer;
+  static QString s_lastStatus;
+
+  BoxcarAverage m_rx_bytes;
+  BoxcarAverage m_tx_bytes;
+};
+
+#endif  // VERBOSELOGGER_H

--- a/extension/socks5proxy/bin/windowsbypass.cpp
+++ b/extension/socks5proxy/bin/windowsbypass.cpp
@@ -1,0 +1,239 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "windowsbypass.h"
+
+#include <WS2tcpip.h>
+#include <windows.h>
+#include <winsock2.h>
+#include <netioapi.h>
+
+#include <QAbstractSocket>
+#include <QHostAddress>
+#include <QScopeGuard>
+#include <QUuid>
+
+#include "socks5.h"
+
+// Fixed GUID of the Wireguard NT driver.
+constexpr const QUuid WIREGUARD_NT_GUID(0xf64063ab, 0xbfee, 0x4881, 0xbf, 0x79, 0x36, 0x6e, 0x4c, 0xc7, 0xba, 0x75);
+
+// Called by the kernel on network interface changes.
+// Runs in some unknown thread, so invoke a Qt signal to do the real work.
+static void netChangeCallback(PVOID context, PMIB_IPINTERFACE_ROW row,
+                              MIB_NOTIFICATION_TYPE type) {
+  WindowsBypass* bypass = static_cast<WindowsBypass*>(context);
+  Q_UNUSED(type);
+
+  // Invoke the route changed signal to do the real work in Qt.
+  QMetaObject::invokeMethod(bypass, "refreshInterfaces", Qt::QueuedConnection);
+}
+
+// Called by the kernel on route changes.
+// Runs in some unknown thread, so invoke a Qt signal to do the real work.
+static void routeChangeCallback(PVOID context, PMIB_IPFORWARD_ROW2 row,
+                                MIB_NOTIFICATION_TYPE type) {
+  WindowsBypass* bypass = static_cast<WindowsBypass*>(context);
+  Q_UNUSED(type);
+
+  // Ignore routing changes into the Wireguard tunnel.
+  int family = AF_UNSPEC;
+  if (row) {
+    GUID rowGuid;
+    if (ConvertInterfaceLuidToGuid(&row->InterfaceLuid, &rowGuid) != NO_ERROR) {
+      return;
+    }
+    if (QUuid(rowGuid) == WIREGUARD_NT_GUID) {
+      return;
+    }
+    family = row->DestinationPrefix.Prefix.si_family;
+  }
+
+  // Invoke the route changed signal to do the real work in Qt.
+  QMetaObject::invokeMethod(bypass, "refreshRoutes", Qt::QueuedConnection,
+                            Q_ARG(int, family));
+}
+
+WindowsBypass::WindowsBypass(Socks5* proxy) : QObject(proxy) {
+  connect(proxy, &Socks5::outgoingConnection, this,
+          &WindowsBypass::outgoingConnection);
+
+  NotifyIpInterfaceChange(AF_UNSPEC, netChangeCallback, this, true,
+                          &m_netChangeHandle);
+  NotifyRouteChange2(AF_UNSPEC, routeChangeCallback, this, true,
+                     &m_routeChangeHandle);
+}
+
+WindowsBypass::~WindowsBypass() {
+  CancelMibChangeNotify2(m_netChangeHandle);
+  CancelMibChangeNotify2(m_routeChangeHandle);
+}
+
+void WindowsBypass::outgoingConnection(QAbstractSocket* s, const QHostAddress& dest) {
+  const MIB_IPFORWARD_ROW2* route = lookupRoute(dest);
+  if (route == nullptr) {
+    // No routing exclusions to apply.
+    return;
+  }
+
+  char buffer[NDIS_IF_MAX_STRING_SIZE+1];
+  ConvertInterfaceLuidToNameA(&route->InterfaceLuid, buffer, sizeof(buffer));
+  
+  qDebug() << "Routing" << dest.toString() << "via" << buffer;
+
+  // TODO: Interface binding shenanigans.
+  // The magic goes here.
+  return;
+}
+
+// static
+QString WindowsBypass::win32strerror(unsigned long code) {
+  LPWSTR buffer = nullptr;
+  DWORD flags = FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS;
+  DWORD size = FormatMessageW(flags, nullptr, code,
+                              MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+                              (LPWSTR)&buffer, 0, nullptr);
+  QString result = QString::fromWCharArray(buffer, size);
+  LocalFree(buffer);
+  return result;
+}
+
+// Refresh our understanding of the current interfaces, and identify the VPN
+// tunnel, if running.
+void WindowsBypass::refreshInterfaces() {
+  // Fetch the interface table.
+  MIB_IPINTERFACE_TABLE* table;
+  DWORD result = GetIpInterfaceTable(AF_UNSPEC, &table);
+  if (result != NO_ERROR) {
+    qWarning() << "GetIpInterfaceTable() failed:" << win32strerror(result);
+    return;
+  }
+  auto guard = qScopeGuard([table]() { FreeMibTable(table); });
+
+  m_vpnInterfaceIndex = -1;
+  for (ULONG i = 0; i < table->NumEntries; i++) {
+    const MIB_IPINTERFACE_ROW* row = &table->Table[i];
+    GUID rowGuid;
+    if (ConvertInterfaceLuidToGuid(&row->InterfaceLuid, &rowGuid) != NO_ERROR) {
+      continue;
+    }
+
+    if (QUuid(rowGuid) == WIREGUARD_NT_GUID) {
+      m_vpnInterfaceIndex = row->InterfaceIndex;
+    }
+  }
+
+  if (m_vpnInterfaceIndex > 0) {
+    qInfo() << "VPN tunnel is up:" << m_vpnInterfaceIndex;
+  } else {
+    qInfo() << "VPN tunnel is down";
+  }
+}
+
+// In this function, we basically try our best to re-implement the Windows
+// lookup algorithm, but instead we use our own local copy of the table.
+// This returns the best route to the destination, or a null pointer if
+// we can't find a matching route.
+const MIB_IPFORWARD_ROW2* WindowsBypass::lookupRoute(const QHostAddress& dest) const {
+  int bestLength = -1;
+  ULONG bestMetric = ULONG_MAX;
+  const MIB_IPFORWARD_ROW2* bestMatch = nullptr;
+  const QVector<MIB_IPFORWARD_ROW2>* table;
+  int family;
+
+  if (dest.protocol() == QAbstractSocket::IPv4Protocol) {
+    family = AF_INET;
+    table = &m_routeTableIpv4;
+  } else {
+    family = AF_INET6;
+    table = &m_routeTableIpv6;
+  }
+
+  for (qsizetype i = 0; i < table->count(); i++) {
+    const MIB_IPFORWARD_ROW2& row = table->at(i);
+    if (Q_UNLIKELY(row.DestinationPrefix.Prefix.si_family != family)) {
+      continue;
+    }
+    if (row.DestinationPrefix.PrefixLength < bestLength) {
+      continue;
+    }
+
+    // Find the route with the longest prefix match and lowest matric.
+    QHostAddress prefix;
+    if (family == AF_INET) {
+      prefix.setAddress(row.DestinationPrefix.Prefix.Ipv4.sin_addr.s_addr);
+    } else {
+      prefix.setAddress(row.DestinationPrefix.Prefix.Ipv6.sin6_addr.s6_addr);
+    }
+    if (!dest.isInSubnet(prefix, row.DestinationPrefix.PrefixLength)) {
+      continue;
+    }
+    // TODO: Need to check interface metrics too for proper tiebreaking.
+    if ((row.DestinationPrefix.PrefixLength == bestLength) && (row.Metric < bestMetric)) {
+      continue;
+    }
+    
+    // This is the best route so far.
+    bestLength = row.DestinationPrefix.PrefixLength;
+    bestMetric = row.Metric;
+    bestMatch = &row;
+  }
+
+  return bestMatch;
+}
+
+void WindowsBypass::updateTable(QVector<MIB_IPFORWARD_ROW2>& table, int family) {
+  // Get the LUID of the wireguard interface, if it's up.
+  NET_LUID vpnInterfaceLuid;
+  GUID vpnInterfaceGuid = WIREGUARD_NT_GUID;
+  if (ConvertInterfaceGuidToLuid(&vpnInterfaceGuid, &vpnInterfaceLuid) != NO_ERROR) {
+    // If the interface is not up, then don't have to do any manipulation.
+    table.clear();
+    return;
+  }
+
+  // Fetch the routing table.
+  MIB_IPFORWARD_TABLE2* mib;
+  DWORD result = GetIpForwardTable2(family, &mib);
+  if (result != NO_ERROR) {
+    qWarning() << "GetIpForwardTable2() failed:" << win32strerror(result);
+    table.clear();
+    return;
+  }
+  auto guard = qScopeGuard([mib] { FreeMibTable(mib); });
+
+  // First pass: iterate over the table and estimate the size to allocate.
+  ULONG tableSize = 0;
+  for (ULONG i = 0; i < mib->NumEntries; i++) {
+    if (mib->Table[i].InterfaceLuid.Value != vpnInterfaceLuid.Value) {
+      tableSize++;
+    }
+  }
+  // If there were no routes to exclude, then we disable routing exclusions.
+  if (tableSize == mib->NumEntries) {
+    table.clear();
+    return;
+  }
+
+  // Allocate memory for the table populate it with the entries which do not
+  // route into the VPN.
+  table.clear();
+  table.reserve(tableSize);
+  for (ULONG i = 0; i < mib->NumEntries; i++) {
+    if (mib->Table[i].InterfaceLuid.Value != vpnInterfaceLuid.Value) {
+      table.append(mib->Table[i]);
+    }
+  }
+}
+
+void WindowsBypass::refreshRoutes(int family) {
+  if (family == AF_UNSPEC) {
+    updateTable(m_routeTableIpv4, AF_INET);
+    updateTable(m_routeTableIpv6, AF_INET6);
+  } else if (family == AF_INET) {
+    updateTable(m_routeTableIpv4, AF_INET);
+  } else if (family == AF_INET6) {
+    updateTable(m_routeTableIpv6, AF_INET6);
+  }
+}

--- a/extension/socks5proxy/bin/windowsbypass.cpp
+++ b/extension/socks5proxy/bin/windowsbypass.cpp
@@ -33,7 +33,7 @@ static void netChangeCallback(PVOID context, PMIB_IPINTERFACE_ROW row,
 
 // Called by the kernel on network interface changes.
 // Runs in some unknown thread, so invoke a Qt signal to do the real work.
-static void addrChangeCallback(PVOID context, PMIB_UNICASTIPADDRESS_ROW  row,
+static void addrChangeCallback(PVOID context, PMIB_UNICASTIPADDRESS_ROW row,
                                MIB_NOTIFICATION_TYPE type) {
   WindowsBypass* bypass = static_cast<WindowsBypass*>(context);
   Q_UNUSED(type);
@@ -107,7 +107,7 @@ void WindowsBypass::outgoingConnection(QAbstractSocket* s,
     source.Ipv6.sin6_family = AF_INET6;
     source.Ipv6.sin6_port = 0;
     source.Ipv6.sin6_flowinfo = 0;
-    source.Ipv6.sin6_scope_id = 0; // TODO: Do we need to provide a scope?
+    source.Ipv6.sin6_scope_id = 0;  // TODO: Do we need to provide a scope?
     memcpy(&source.Ipv6.sin6_addr.s6_addr, &v6addr, 16);
     qDebug() << "Routing" << dest.toString() << "via"
              << data.ipv6addr.toString();
@@ -124,8 +124,8 @@ void WindowsBypass::outgoingConnection(QAbstractSocket* s,
   }
 
   // Bind it to force its traffic to use a specific interface.
-  int result = bind(newsock, reinterpret_cast<sockaddr*>(&source),
-                    sizeof(source)); 
+  int result =
+      bind(newsock, reinterpret_cast<sockaddr*>(&source), sizeof(source));
   if (result != 0) {
     qWarning() << "socket bind failed:" << WSAGetLastError();
     closesocket(newsock);

--- a/extension/socks5proxy/bin/windowsbypass.cpp
+++ b/extension/socks5proxy/bin/windowsbypass.cpp
@@ -269,9 +269,12 @@ const MIB_IPFORWARD_ROW2* WindowsBypass::lookupRoute(
   if (dest.protocol() == QAbstractSocket::IPv4Protocol) {
     family = AF_INET;
     table = &m_routeTableIpv4;
-  } else {
+  } else if (dest.protocol() == QAbstractSocket::IPv6Protocol) {
     family = AF_INET6;
     table = &m_routeTableIpv6;
+  } else {
+    // This address is not routable.
+    return nullptr;
   }
 
   for (qsizetype i = 0; i < table->count(); i++) {

--- a/extension/socks5proxy/bin/windowsbypass.cpp
+++ b/extension/socks5proxy/bin/windowsbypass.cpp
@@ -222,7 +222,7 @@ void WindowsBypass::refreshAddresses() {
   }
 
   // Fetch the interface metrics too.
-  for(auto i = data.begin(); i != data.end(); i++) {
+  for (auto i = data.begin(); i != data.end(); i++) {
     MIB_IPINTERFACE_ROW row = {0};
     row.InterfaceLuid.Value = i.key();
     if (GetIpInterfaceEntry(&row) == NO_ERROR) {
@@ -330,7 +330,8 @@ const MIB_IPFORWARD_ROW2* WindowsBypass::lookupRoute(
   return bestMatch;
 }
 
-void WindowsBypass::updateTable(QVector<MIB_IPFORWARD_ROW2> &table, int family) {
+void WindowsBypass::updateTable(QVector<MIB_IPFORWARD_ROW2>& table,
+                                int family) {
   // Update the output table on exit.
   QVector<MIB_IPFORWARD_ROW2> update;
   auto swapGuard = qScopeGuard([&] { table.swap(update); });

--- a/extension/socks5proxy/bin/windowsbypass.h
+++ b/extension/socks5proxy/bin/windowsbypass.h
@@ -1,0 +1,43 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef WINDOWSBYPASS_H
+#define WINDOWSBYPASS_H
+
+#include <QObject>
+#include <QVector>
+
+class Socks5;
+class QAbstractSocket;
+class QHostAddress;
+
+struct _MIB_IPFORWARD_ROW2;
+
+class WindowsBypass : public QObject {
+  Q_OBJECT
+
+ public:
+  WindowsBypass(Socks5* proxy);
+  ~WindowsBypass();
+
+ private:
+  static QString win32strerror(unsigned long code);
+  void updateTable(QVector<struct _MIB_IPFORWARD_ROW2> &table, int family);
+  const struct _MIB_IPFORWARD_ROW2* lookupRoute(const QHostAddress& dest) const;
+
+ private slots:
+  void outgoingConnection(QAbstractSocket* s, const QHostAddress& dest);
+  void refreshRoutes(int family);
+  void refreshInterfaces();
+
+ private:
+  void* m_netChangeHandle = nullptr;
+  void* m_routeChangeHandle = nullptr;
+  int m_vpnInterfaceIndex = -1;
+
+  QVector<struct _MIB_IPFORWARD_ROW2> m_routeTableIpv4;
+  QVector<struct _MIB_IPFORWARD_ROW2> m_routeTableIpv6;
+};
+
+#endif  // WINDOWSBYPASS_H

--- a/extension/socks5proxy/bin/windowsbypass.h
+++ b/extension/socks5proxy/bin/windowsbypass.h
@@ -25,7 +25,7 @@ class WindowsBypass : public QObject {
 
  private:
   static QString win32strerror(unsigned long code);
-  void updateTable(QVector<struct _MIB_IPFORWARD_ROW2> &table, int family);
+  void updateTable(QVector<struct _MIB_IPFORWARD_ROW2>& table, int family);
   quint64 getVpnLuid() const;
   const struct _MIB_IPFORWARD_ROW2* lookupRoute(const QHostAddress& dest) const;
 

--- a/extension/socks5proxy/bin/windowsbypass.h
+++ b/extension/socks5proxy/bin/windowsbypass.h
@@ -25,8 +25,8 @@ class WindowsBypass final : public QObject {
 
  private:
   static QString win32strerror(unsigned long code);
-  void updateTable(QVector<struct _MIB_IPFORWARD_ROW2>& table, int family);
   quint64 getVpnLuid() const;
+  void updateTable(QVector<struct _MIB_IPFORWARD_ROW2> &table, int family);
   const struct _MIB_IPFORWARD_ROW2* lookupRoute(const QHostAddress& dest) const;
 
  private slots:

--- a/extension/socks5proxy/bin/windowsbypass.h
+++ b/extension/socks5proxy/bin/windowsbypass.h
@@ -5,6 +5,8 @@
 #ifndef WINDOWSBYPASS_H
 #define WINDOWSBYPASS_H
 
+#include <QHash>
+#include <QHostAddress>
 #include <QObject>
 #include <QVector>
 
@@ -24,18 +26,27 @@ class WindowsBypass : public QObject {
  private:
   static QString win32strerror(unsigned long code);
   void updateTable(QVector<struct _MIB_IPFORWARD_ROW2> &table, int family);
+  quint64 getVpnLuid() const;
   const struct _MIB_IPFORWARD_ROW2* lookupRoute(const QHostAddress& dest) const;
 
  private slots:
   void outgoingConnection(QAbstractSocket* s, const QHostAddress& dest);
   void refreshRoutes(int family);
-  void refreshInterfaces();
+  void refreshIfMetrics();
+  void refreshAddresses();
 
  private:
+  void* m_addrChangeHandle = nullptr;
   void* m_netChangeHandle = nullptr;
   void* m_routeChangeHandle = nullptr;
-  int m_vpnInterfaceIndex = -1;
 
+  struct InterfaceData {
+    unsigned long metric;
+    QHostAddress ipv4addr;
+    QHostAddress ipv6addr;
+  };
+
+  QHash<quint64, InterfaceData> m_interfaceData;
   QVector<struct _MIB_IPFORWARD_ROW2> m_routeTableIpv4;
   QVector<struct _MIB_IPFORWARD_ROW2> m_routeTableIpv6;
 };

--- a/extension/socks5proxy/bin/windowsbypass.h
+++ b/extension/socks5proxy/bin/windowsbypass.h
@@ -16,11 +16,11 @@ class QHostAddress;
 
 struct _MIB_IPFORWARD_ROW2;
 
-class WindowsBypass : public QObject {
+class WindowsBypass final : public QObject {
   Q_OBJECT
 
  public:
-  WindowsBypass(Socks5* proxy);
+  explicit WindowsBypass(Socks5* proxy);
   ~WindowsBypass();
 
  private:

--- a/extension/socks5proxy/bin/windowsbypass.h
+++ b/extension/socks5proxy/bin/windowsbypass.h
@@ -31,8 +31,8 @@ class WindowsBypass final : public QObject {
 
  private slots:
   void outgoingConnection(QAbstractSocket* s, const QHostAddress& dest);
+  void interfaceChanged(quint64 luid);
   void refreshRoutes(int family);
-  void refreshIfMetrics();
   void refreshAddresses();
 
  private:

--- a/extension/socks5proxy/bin/windowsbypass.h
+++ b/extension/socks5proxy/bin/windowsbypass.h
@@ -26,7 +26,7 @@ class WindowsBypass final : public QObject {
  private:
   static QString win32strerror(unsigned long code);
   quint64 getVpnLuid() const;
-  void updateTable(QVector<struct _MIB_IPFORWARD_ROW2> &table, int family);
+  void updateTable(QVector<struct _MIB_IPFORWARD_ROW2>& table, int family);
   const struct _MIB_IPFORWARD_ROW2* lookupRoute(const QHostAddress& dest) const;
 
  private slots:

--- a/extension/socks5proxy/src/CMakeLists.txt
+++ b/extension/socks5proxy/src/CMakeLists.txt
@@ -13,7 +13,6 @@ target_sources(libSocks5proxy PRIVATE
     socks5connection.h
 )
 
-
 target_include_directories(libSocks5proxy PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}
 )

--- a/extension/socks5proxy/src/CMakeLists.txt
+++ b/extension/socks5proxy/src/CMakeLists.txt
@@ -13,6 +13,12 @@ target_sources(libSocks5proxy PRIVATE
     socks5connection.h
 )
 
+if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+    target_sources(libSocks5proxy PRIVATE socks5local_linux.cpp)
+else()
+    target_sources(libSocks5proxy PRIVATE socks5local_default.cpp)
+endif()
+
 target_include_directories(libSocks5proxy PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}
 )

--- a/extension/socks5proxy/src/socks5.cpp
+++ b/extension/socks5proxy/src/socks5.cpp
@@ -34,7 +34,7 @@ void Socks5::newConnection(T* server) {
     }
 
     auto const con = new Socks5Connection(socket);
-    connect(con, &QObject::destroyed, this, [&]() {
+    connect(con, &QObject::destroyed, this, [this, server]() {
       clientDismissed();
       newConnection(server);
     });

--- a/extension/socks5proxy/src/socks5.cpp
+++ b/extension/socks5proxy/src/socks5.cpp
@@ -38,10 +38,6 @@ void Socks5::newConnection(T* server) {
       clientDismissed();
       newConnection(server);
     });
-    connect(con, &Socks5Connection::dataSentReceived,
-            [this](qint64 sent, qint64 received) {
-              emit dataSentReceived(sent, received);
-            });
 
     connect(con, &Socks5Connection::setupOutSocket, this,
             [this](QAbstractSocket* s, const QHostAddress& dest) {

--- a/extension/socks5proxy/src/socks5.cpp
+++ b/extension/socks5proxy/src/socks5.cpp
@@ -25,7 +25,8 @@ Socks5::Socks5(QTcpServer* server) : QObject(server) {
 
 Socks5::~Socks5() { m_shuttingDown = true; }
 
-template <typename T> void Socks5::newConnection(T* server) {
+template <typename T>
+void Socks5::newConnection(T* server) {
   while (server->hasPendingConnections() && (m_clientCount < MAX_CLIENTS)) {
     auto* socket = server->nextPendingConnection();
     if (!socket) {
@@ -33,11 +34,10 @@ template <typename T> void Socks5::newConnection(T* server) {
     }
 
     auto const con = new Socks5Connection(socket);
-    connect(con, &QObject::destroyed, this,
-            [&]() {
-              clientDismissed();
-              newConnection(server);
-            });
+    connect(con, &QObject::destroyed, this, [&]() {
+      clientDismissed();
+      newConnection(server);
+    });
     connect(con, &Socks5Connection::dataSentReceived,
             [this](qint64 sent, qint64 received) {
               emit dataSentReceived(sent, received);

--- a/extension/socks5proxy/src/socks5.cpp
+++ b/extension/socks5proxy/src/socks5.cpp
@@ -28,13 +28,18 @@ void Socks5::newConnection() {
       return;
     }
 
-    emit incomingConnection(socket->peerAddress().toString());
+    emit incomingConnection(socket, socket->peerAddress());
 
     auto const con = new Socks5Connection(socket, m_server.serverPort());
     connect(con, &QObject::destroyed, this, &Socks5::clientDismissed);
     connect(con, &Socks5Connection::dataSentReceived,
             [this](qint64 sent, qint64 received) {
               emit dataSentReceived(sent, received);
+            });
+
+    connect(con, &Socks5Connection::setupOutSocket, this,
+            [this](QAbstractSocket* s, const QHostAddress& dest) {
+              emit outgoingConnection(s, dest);
             });
 
     ++m_clientCount;

--- a/extension/socks5proxy/src/socks5.cpp
+++ b/extension/socks5proxy/src/socks5.cpp
@@ -4,34 +4,40 @@
 
 #include "socks5.h"
 
+#include <QLocalServer>
+#include <QLocalSocket>
+#include <QTcpServer>
+#include <QTcpSocket>
+
 #include "socks5connection.h"
 
 #define MAX_CLIENTS 1024
 
-Socks5::Socks5(uint16_t port, QHostAddress listenAddress = QHostAddress::Any,
-               QObject* parent = nullptr)
-    : QObject(parent) {
-  connect(&m_server, &QTcpServer::newConnection, this, &Socks5::newConnection);
-  qDebug() << "port" << port;
-  if (!m_server.listen(listenAddress, port)) {
-    qDebug() << "Unable to listen to the proxy port" << port;
-    return;
-  }
+Socks5::Socks5(QLocalServer* server) : QObject(server) {
+  connect(server, &QLocalServer::newConnection, this,
+          [this, server]() { newConnection(server); });
+}
+
+Socks5::Socks5(QTcpServer* server) : QObject(server) {
+  connect(server, &QTcpServer::newConnection, this,
+          [this, server]() { newConnection(server); });
 }
 
 Socks5::~Socks5() { m_shuttingDown = true; }
 
-void Socks5::newConnection() {
-  while (m_server.hasPendingConnections() && m_clientCount < MAX_CLIENTS) {
-    QTcpSocket* socket = m_server.nextPendingConnection();
+template <typename T> void Socks5::newConnection(T* server) {
+  while (server->hasPendingConnections() && (m_clientCount < MAX_CLIENTS)) {
+    auto* socket = server->nextPendingConnection();
     if (!socket) {
       return;
     }
 
-    emit incomingConnection(socket, socket->peerAddress());
-
-    auto const con = new Socks5Connection(socket, m_server.serverPort());
-    connect(con, &QObject::destroyed, this, &Socks5::clientDismissed);
+    auto const con = new Socks5Connection(socket);
+    connect(con, &QObject::destroyed, this,
+            [&]() {
+              clientDismissed();
+              newConnection(server);
+            });
     connect(con, &Socks5Connection::dataSentReceived,
             [this](qint64 sent, qint64 received) {
               emit dataSentReceived(sent, received);
@@ -43,6 +49,7 @@ void Socks5::newConnection() {
             });
 
     ++m_clientCount;
+    emit incomingConnection(con);
     emit connectionsChanged();
   }
 }
@@ -53,9 +60,5 @@ void Socks5::clientDismissed() {
   if (!m_shuttingDown) {
     --m_clientCount;
     emit connectionsChanged();
-
-    newConnection();
   }
 }
-
-int Socks5::port() const { return m_server.serverPort(); }

--- a/extension/socks5proxy/src/socks5.h
+++ b/extension/socks5proxy/src/socks5.h
@@ -8,6 +8,9 @@
 #include <QObject>
 #include <QTcpServer>
 
+class QAbstractSocket;
+class QHostAddress;
+
 class Socks5 final : public QObject {
   Q_OBJECT
   Q_PROPERTY(uint16_t connections READ connections NOTIFY connectionsChanged);
@@ -24,7 +27,8 @@ class Socks5 final : public QObject {
 
  signals:
   void connectionsChanged();
-  void incomingConnection(const QString& peerAddress);
+  void incomingConnection(QAbstractSocket* socket, const QHostAddress& peer);
+  void outgoingConnection(QAbstractSocket* socket, const QHostAddress& dest);
   void dataSentReceived(qint64 sent, qint64 received);
 
  private:

--- a/extension/socks5proxy/src/socks5.h
+++ b/extension/socks5proxy/src/socks5.h
@@ -29,7 +29,6 @@ class Socks5 final : public QObject {
   void connectionsChanged();
   void incomingConnection(Socks5Connection* connection);
   void outgoingConnection(QAbstractSocket* socket, const QHostAddress& dest);
-  void dataSentReceived(qint64 sent, qint64 received);
 
  private:
   void clientDismissed();

--- a/extension/socks5proxy/src/socks5.h
+++ b/extension/socks5proxy/src/socks5.h
@@ -6,36 +6,35 @@
 #define SOCKS5_H
 
 #include <QObject>
-#include <QTcpServer>
+
+#include "socks5connection.h"
 
 class QAbstractSocket;
 class QHostAddress;
+class QLocalServer;
+class QTcpServer;
 
 class Socks5 final : public QObject {
   Q_OBJECT
   Q_PROPERTY(uint16_t connections READ connections NOTIFY connectionsChanged);
 
  public:
-  explicit Socks5(uint16_t port, QHostAddress listenAddress, QObject* parent);
+  explicit Socks5(QLocalServer* server);
+  explicit Socks5(QTcpServer* server);
   ~Socks5();
-
-  void clientDismissed();
-
-  int port() const;
 
   uint16_t connections() const { return m_clientCount; }
 
  signals:
   void connectionsChanged();
-  void incomingConnection(QAbstractSocket* socket, const QHostAddress& peer);
+  void incomingConnection(Socks5Connection* connection);
   void outgoingConnection(QAbstractSocket* socket, const QHostAddress& dest);
   void dataSentReceived(qint64 sent, qint64 received);
 
  private:
-  void newConnection();
+  void clientDismissed();
+  template <typename T> void newConnection(T* server);
 
- private:
-  QTcpServer m_server;
   uint16_t m_clientCount = 0;
   bool m_shuttingDown = false;
 };

--- a/extension/socks5proxy/src/socks5.h
+++ b/extension/socks5proxy/src/socks5.h
@@ -33,7 +33,8 @@ class Socks5 final : public QObject {
 
  private:
   void clientDismissed();
-  template <typename T> void newConnection(T* server);
+  template <typename T>
+  void newConnection(T* server);
 
   uint16_t m_clientCount = 0;
   bool m_shuttingDown = false;

--- a/extension/socks5proxy/src/socks5connection.cpp
+++ b/extension/socks5proxy/src/socks5connection.cpp
@@ -327,6 +327,7 @@ void Socks5Connection::dnsResolutionFinished(quint16 port) {
 void Socks5Connection::configureOutSocket(const QHostAddress& dest,
                                           quint16 port) {
   m_outSocket = new QTcpSocket();
+  emit setupOutSocket(m_outSocket, dest);
 
   m_outSocket->connectToHost(dest, port);
 

--- a/extension/socks5proxy/src/socks5connection.cpp
+++ b/extension/socks5proxy/src/socks5connection.cpp
@@ -88,7 +88,7 @@ Socks5Connection::Socks5Connection(QTcpSocket* socket)
 Socks5Connection::Socks5Connection(QLocalSocket* socket) {
   connect(m_inSocket, &QIODevice::readyRead, this,
           &Socks5Connection::readyRead);
-  
+
   m_socksPort = 0;
   // TODO: Some magic may be required here to resolve the entity of which app
   // tried to connect. Some breadcrumbs:

--- a/extension/socks5proxy/src/socks5connection.cpp
+++ b/extension/socks5proxy/src/socks5connection.cpp
@@ -375,7 +375,7 @@ void Socks5Connection::dnsResolutionFinished(quint16 port) {
 
 void Socks5Connection::configureOutSocket(quint16 port) {
   Q_ASSERT(!m_destAddress.isNull());
-  m_outSocket = new QTcpSocket();
+  m_outSocket = new QTcpSocket(this);
   emit setupOutSocket(m_outSocket, m_destAddress);
 
   m_outSocket->connectToHost(m_destAddress, port);

--- a/extension/socks5proxy/src/socks5connection.cpp
+++ b/extension/socks5proxy/src/socks5connection.cpp
@@ -80,6 +80,8 @@ Socks5Connection::Socks5Connection(QTcpSocket* socket)
   connect(m_inSocket, &QIODevice::readyRead, this,
           &Socks5Connection::readyRead);
 
+  connect(socket, &QTcpSocket::disconnected, this, &QObject::deleteLater);
+
   m_socksPort = socket->localPort();
   m_clientName = socket->peerAddress().toString();
   readyRead();
@@ -88,6 +90,8 @@ Socks5Connection::Socks5Connection(QTcpSocket* socket)
 Socks5Connection::Socks5Connection(QLocalSocket* socket) {
   connect(m_inSocket, &QIODevice::readyRead, this,
           &Socks5Connection::readyRead);
+
+  connect(socket, &QLocalSocket::disconnected, this, &QObject::deleteLater);
 
   m_socksPort = 0;
   // TODO: Some magic may be required here to resolve the entity of which client

--- a/extension/socks5proxy/src/socks5connection.cpp
+++ b/extension/socks5proxy/src/socks5connection.cpp
@@ -90,7 +90,7 @@ Socks5Connection::Socks5Connection(QLocalSocket* socket) {
           &Socks5Connection::readyRead);
 
   m_socksPort = 0;
-  // TODO: Some magic may be required here to resolve the entity of which app
+  // TODO: Some magic may be required here to resolve the entity of which client
   // tried to connect. Some breadcrumbs:
   //   - Linux: SO_PEERCRED can get us the cllient PID, from which we can get
   //            the cgroup name, systemd scope and parse out the application ID.

--- a/extension/socks5proxy/src/socks5connection.cpp
+++ b/extension/socks5proxy/src/socks5connection.cpp
@@ -196,7 +196,7 @@ void Socks5Connection::readyRead() {
         m_dnsLookupAttempts = MAX_DNS_LOOKUP_ATTEMPTS;
         QDnsLookup* lookup = new QDnsLookup(QDnsLookup::ANY, hostname, this);
         connect(lookup, &QDnsLookup::finished, this,
-                [this, port](){ dnsResolutionFinished(htons(port)); });
+                [this, port]() { dnsResolutionFinished(htons(port)); });
 
         lookup->lookup();
       }
@@ -264,9 +264,9 @@ void Socks5Connection::dnsResolutionFinished(quint16 port) {
   // Garbage collect the lookup when we're finished.
   m_dnsLookupAttempts--;
   auto guard = qScopeGuard([lookup]() {
-                           if (lookup->isFinished()) {
-                             lookup->deleteLater();
-                           }});
+    if (lookup->isFinished()) {
+      lookup->deleteLater();
+  }});
 
   qDebug() << "Finished lookup for:" << lookup->name();
 
@@ -318,8 +318,7 @@ void Socks5Connection::dnsResolutionFinished(quint16 port) {
   }
 
   // Otherwise, no such host was found.
-  ServerResponsePacket packet(
-      createServerResponsePacket(ErrorHostUnreachable));
+  ServerResponsePacket packet(createServerResponsePacket(ErrorHostUnreachable));
   m_inSocket->write((char*)&packet, sizeof(ServerResponsePacket));
   m_inSocket->close();
 }

--- a/extension/socks5proxy/src/socks5connection.cpp
+++ b/extension/socks5proxy/src/socks5connection.cpp
@@ -93,6 +93,7 @@ Socks5Connection::Socks5Connection(QTcpSocket* socket)
 
 Socks5Connection::Socks5Connection(QLocalSocket* socket)
     : Socks5Connection(static_cast<QIODevice*>(socket)) {
+
   connect(socket, &QLocalSocket::disconnected, this, &QObject::deleteLater);
 
   // TODO: Some magic may be required here to resolve the entity of which client
@@ -104,7 +105,7 @@ Socks5Connection::Socks5Connection(QLocalSocket* socket)
   //   - MacOS: SecTaskCopySigningIdentifier() can be used to grab information
   //            about processes and their code signatures. Somewhere in there
   //            I would expect to find the application ID too.
-  m_clientName = "TODO";
+  m_clientName = localClientName(socket);
 }
 
 void Socks5Connection::setState(Socks5State newstate) {

--- a/extension/socks5proxy/src/socks5connection.cpp
+++ b/extension/socks5proxy/src/socks5connection.cpp
@@ -266,7 +266,8 @@ void Socks5Connection::dnsResolutionFinished(quint16 port) {
   auto guard = qScopeGuard([lookup]() {
     if (lookup->isFinished()) {
       lookup->deleteLater();
-  }});
+    }
+  });
 
   qDebug() << "Finished lookup for:" << lookup->name();
 

--- a/extension/socks5proxy/src/socks5connection.cpp
+++ b/extension/socks5proxy/src/socks5connection.cpp
@@ -84,7 +84,6 @@ Socks5Connection::Socks5Connection(QIODevice* socket)
 
 Socks5Connection::Socks5Connection(QTcpSocket* socket)
     : Socks5Connection(static_cast<QIODevice*>(socket)) {
-
   connect(socket, &QTcpSocket::disconnected, this, &QObject::deleteLater);
 
   m_socksPort = socket->localPort();
@@ -93,7 +92,6 @@ Socks5Connection::Socks5Connection(QTcpSocket* socket)
 
 Socks5Connection::Socks5Connection(QLocalSocket* socket)
     : Socks5Connection(static_cast<QIODevice*>(socket)) {
-
   connect(socket, &QLocalSocket::disconnected, this, &QObject::deleteLater);
 
   // TODO: Some magic may be required here to resolve the entity of which client

--- a/extension/socks5proxy/src/socks5connection.h
+++ b/extension/socks5proxy/src/socks5connection.h
@@ -15,8 +15,8 @@ class Socks5Connection final : public QObject {
   Q_OBJECT
 
  public:
-  Socks5Connection(QTcpSocket* socket);
-  Socks5Connection(QLocalSocket* socket);
+  explicit Socks5Connection(QTcpSocket* socket);
+  explicit Socks5Connection(QLocalSocket* socket);
   ~Socks5Connection() = default;
 
   /**

--- a/extension/socks5proxy/src/socks5connection.h
+++ b/extension/socks5proxy/src/socks5connection.h
@@ -90,6 +90,9 @@ class Socks5Connection final : public QObject {
   void dnsResolutionFinished(quint16 port);
   void readyRead();
 
+  // Implemented by platform-specific code in socks5local_<platform>.cpp
+  static QString localClientName(QLocalSocket* s);
+
   Socks5State m_state = ClientGreeting;
 
   uint8_t m_authNumber = 0;

--- a/extension/socks5proxy/src/socks5connection.h
+++ b/extension/socks5proxy/src/socks5connection.h
@@ -7,8 +7,8 @@
 
 #include <QByteArray>
 #include <QIODevice>
-#include <QObject>
 #include <QLocalSocket>
+#include <QObject>
 #include <QTcpSocket>
 
 class Socks5Connection final : public QObject {

--- a/extension/socks5proxy/src/socks5connection.h
+++ b/extension/socks5proxy/src/socks5connection.h
@@ -15,8 +15,6 @@ class Socks5Connection final : public QObject {
   Socks5Connection(QTcpSocket* socket, uint16_t port);
   ~Socks5Connection() = default;
 
-  void configureOutSocket();
-
   /**
    * @brief Copies incoming bytes to another QIODevice
    *
@@ -58,10 +56,13 @@ class Socks5Connection final : public QObject {
    */
   template <typename T>
   static std::optional<T> readPacket(QIODevice* connection);
+
  signals:
   void dataSentReceived(qint64 sent, qint64 received);
 
  private:
+  void configureOutSocket(const QHostAddress& dest, quint16 port);
+  void dnsResolutionFinished(quint16 port);
   void readyRead();
 
   enum {
@@ -79,6 +80,8 @@ class Socks5Connection final : public QObject {
   uint16_t m_socksPort = 0;
 
   uint8_t m_addressType = 0;
+
+  int m_dnsLookupAttempts = 0;
 };
 
 #endif  // Socks5Connection_H

--- a/extension/socks5proxy/src/socks5connection.h
+++ b/extension/socks5proxy/src/socks5connection.h
@@ -58,6 +58,7 @@ class Socks5Connection final : public QObject {
   static std::optional<T> readPacket(QIODevice* connection);
 
  signals:
+  void setupOutSocket(QAbstractSocket* socket, const QHostAddress& dest);
   void dataSentReceived(qint64 sent, qint64 received);
 
  private:

--- a/extension/socks5proxy/src/socks5connection.h
+++ b/extension/socks5proxy/src/socks5connection.h
@@ -5,14 +5,18 @@
 #ifndef Socks5Connection_H
 #define Socks5Connection_H
 
+#include <QByteArray>
+#include <QIODevice>
 #include <QObject>
+#include <QLocalSocket>
 #include <QTcpSocket>
 
 class Socks5Connection final : public QObject {
   Q_OBJECT
 
  public:
-  Socks5Connection(QTcpSocket* socket, uint16_t port);
+  Socks5Connection(QTcpSocket* socket);
+  Socks5Connection(QLocalSocket* socket);
   ~Socks5Connection() = default;
 
   /**
@@ -57,6 +61,8 @@ class Socks5Connection final : public QObject {
   template <typename T>
   static std::optional<T> readPacket(QIODevice* connection);
 
+  const QString& clientName() const { return m_clientName; }
+
  signals:
   void setupOutSocket(QAbstractSocket* socket, const QHostAddress& dest);
   void dataSentReceived(qint64 sent, qint64 received);
@@ -75,9 +81,10 @@ class Socks5Connection final : public QObject {
   } m_state = ClientGreeting;
 
   uint8_t m_authNumber = 0;
-  QTcpSocket* m_inSocket = nullptr;
+  QIODevice* m_inSocket = nullptr;
   QTcpSocket* m_outSocket = nullptr;
 
+  QString m_clientName;
   uint16_t m_socksPort = 0;
 
   uint8_t m_addressType = 0;

--- a/extension/socks5proxy/src/socks5local_default.cpp
+++ b/extension/socks5proxy/src/socks5local_default.cpp
@@ -1,0 +1,11 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "socks5connection.h"
+
+// static
+QString Socks5Connection::localClientName(QLocalSocket* s) {
+  Q_UNUSED(s);
+  return QString();
+}

--- a/extension/socks5proxy/src/socks5local_linux.cpp
+++ b/extension/socks5proxy/src/socks5local_linux.cpp
@@ -2,17 +2,18 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#include "socks5connection.h"
-
 #include <sys/socket.h>
 
-#include <QLocalSocket>
 #include <QFile>
+#include <QLocalSocket>
+
+#include "socks5connection.h"
 
 // Read /proc/<pid>/cgroup and parse out the cgroupv2 control group path.
 static QString lookupCgroupForPid(pid_t pid) {
   QFile cgfile(QString("/proc/%1/cgroup").arg(pid));
-  if (!cgfile.exists() || !cgfile.open(QIODeviceBase::ReadOnly | QIODeviceBase::Text)) {
+  if (!cgfile.exists() ||
+      !cgfile.open(QIODeviceBase::ReadOnly | QIODeviceBase::Text)) {
     return QString();
   }
   while (true) {
@@ -40,7 +41,6 @@ QString Socks5Connection::localClientName(QLocalSocket* s) {
   if (!peer.pid) {
     return QString();
   }
-
 
   QString cgscope;
   for (const QString& segment : lookupCgroupForPid(peer.pid).split("/")) {

--- a/extension/socks5proxy/src/socks5local_linux.cpp
+++ b/extension/socks5proxy/src/socks5local_linux.cpp
@@ -1,0 +1,52 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "socks5connection.h"
+
+#include <sys/socket.h>
+
+#include <QLocalSocket>
+#include <QFile>
+
+// Read /proc/<pid>/cgroup and parse out the cgroupv2 control group path.
+static QString lookupCgroupForPid(pid_t pid) {
+  QFile cgfile(QString("/proc/%1/cgroup").arg(pid));
+  if (!cgfile.exists() || !cgfile.open(QIODeviceBase::ReadOnly | QIODeviceBase::Text)) {
+    return QString();
+  }
+  while (true) {
+    QString line = QString::fromUtf8(cgfile.readLine());
+    if (line.isEmpty()) {
+      return QString();
+    }
+    if (line.startsWith("0::")) {
+      return line.mid(3);
+    }
+  }
+  return QString();
+}
+
+// static
+// Return the systemd scope of the process at the other end of the local socket.
+QString Socks5Connection::localClientName(QLocalSocket* s) {
+  struct ucred peer;
+  socklen_t len = sizeof(peer);
+  int sd = s->socketDescriptor();
+  if (getsockopt(sd, SOL_SOCKET, SO_PEERCRED, &peer, &len) != 0) {
+    return QString();
+  }
+  // Don't believe anyone who tells us they are PID zero.
+  if (!peer.pid) {
+    return QString();
+  }
+
+
+  QString cgscope;
+  for (const QString& segment : lookupCgroupForPid(peer.pid).split("/")) {
+    if (segment.endsWith(".scope")) {
+      cgscope = segment;
+    }
+  }
+  return cgscope;
+}

--- a/extension/socks5proxy/tests/testsocks5.cpp
+++ b/extension/socks5proxy/tests/testsocks5.cpp
@@ -106,10 +106,9 @@ void TestSocks5::proxyTCP() {
   auto const connectionToServer = connectTo(serverPort, proxyPort);
 
   QString proxyClientName;
-  QObject::connect(&proxy, &Socks5::incomingConnection,
-                   [&](Socks5Connection* conn) {
-                     proxyClientName = conn->clientName();
-                   });
+  QObject::connect(
+      &proxy, &Socks5::incomingConnection,
+      [&](Socks5Connection* conn) { proxyClientName = conn->clientName(); });
 
   while (!connectionToServer.isFinished()) {
     QTest::qWait(250);

--- a/extension/socks5proxy/tests/testsocks5.cpp
+++ b/extension/socks5proxy/tests/testsocks5.cpp
@@ -112,7 +112,7 @@ void TestSocks5::proxyTCP() {
   // Data Sent should be 10.
   QCOMPARE(std::get<1>(proxyHadData.result()), qsizetype(10));
   // The Proxy server should have gotten a connection
-  QCOMPARE(QHostAddress{proxyHadConnection.result()}, QHostAddress::LocalHost);
+  QCOMPARE(std::get<1>(proxyHadConnection.result()), QHostAddress::LocalHost);
   // We should have gotten the correct string
   QCOMPARE(connectionToServer.result(), QByteArray{testData});
 }

--- a/extension/socks5proxy/tests/testsocks5.cpp
+++ b/extension/socks5proxy/tests/testsocks5.cpp
@@ -95,12 +95,21 @@ void TestSocks5::proxyTCP() {
   auto const proxyPort = rollPort();
   auto const serverPort = rollPort();
   auto const serverHadConnection = makeServer(serverPort);
-  Socks5 proxy{proxyPort, QHostAddress::LocalHost, nullptr};
-  auto const proxyHadConnection =
-      QtFuture::connect(&proxy, &Socks5::incomingConnection);
+
+  // Create a TCP Server and connect the proxy to it.
+  QTcpServer proxyServer;
+  Socks5 proxy(&proxyServer);
+  proxyServer.listen(QHostAddress::LocalHost, proxyPort);
+
   auto const proxyHadData =
       QtFuture::connect(&proxy, &Socks5::dataSentReceived);
   auto const connectionToServer = connectTo(serverPort, proxyPort);
+
+  QString proxyClientName;
+  QObject::connect(&proxy, &Socks5::incomingConnection,
+                   [&](Socks5Connection* conn) {
+                     proxyClientName = conn->clientName();
+                   });
 
   while (!connectionToServer.isFinished()) {
     QTest::qWait(250);
@@ -112,7 +121,7 @@ void TestSocks5::proxyTCP() {
   // Data Sent should be 10.
   QCOMPARE(std::get<1>(proxyHadData.result()), qsizetype(10));
   // The Proxy server should have gotten a connection
-  QCOMPARE(std::get<1>(proxyHadConnection.result()), QHostAddress::LocalHost);
+  QCOMPARE(proxyClientName, "127.0.0.1");
   // We should have gotten the correct string
   QCOMPARE(connectionToServer.result(), QByteArray{testData});
 }

--- a/extension/socks5proxy/tests/testsocks5.cpp
+++ b/extension/socks5proxy/tests/testsocks5.cpp
@@ -101,13 +101,12 @@ void TestSocks5::proxyTCP() {
   Socks5 proxy(&proxyServer);
   proxyServer.listen(QHostAddress::LocalHost, proxyPort);
 
-  QFuture<std::tuple<qint64,qint64>> proxyHadData;
+  QFuture<std::tuple<qint64, qint64>> proxyHadData;
   auto const connectionToServer = connectTo(serverPort, proxyPort);
 
   QString proxyClientName;
   QObject::connect(
-      &proxy, &Socks5::incomingConnection,
-      [&](Socks5Connection* conn) {
+      &proxy, &Socks5::incomingConnection, [&](Socks5Connection* conn) {
         proxyClientName = conn->clientName();
         proxyHadData =
             QtFuture::connect(conn, &Socks5Connection::dataSentReceived);

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -429,12 +429,6 @@ void Controller::activateInternal(
   // Splittunnel-feature could have been disabled due to a driver conflict.
   if (Feature::get(Feature::Feature_splitTunnel)->isSupported()) {
     exitConfig.m_vpnDisabledApps = settingsHolder->vpnDisabledApps();
-// Add the Proxy to the excluded list, if activateable
-#if defined MZ_PROXY_ENABLED
-    if (vpn->proxyController()->canActivate()) {
-      exitConfig.m_vpnDisabledApps.append(vpn->proxyController()->binaryPath());
-    }
-#endif
   }
   if (Feature::get(Feature::Feature_alwaysPort53)->isSupported()) {
     dnsPort = ForceDNSPort;

--- a/src/platforms/windows/daemon/windowsfirewall.cpp
+++ b/src/platforms/windows/daemon/windowsfirewall.cpp
@@ -353,6 +353,8 @@ bool WindowsFirewall::allowTrafficForAppOnAll(const QString& exePath,
     WindowsUtils::windowsLog("FwpmGetAppIdFromFileName0 failure");
     return false;
   }
+  auto guard = qScopeGuard([appID]() { FwpmFreeMemory0((void**)&appID); });
+
   // Condition: Request must come from the .exe
   FWPM_FILTER_CONDITION0 conds;
   conds.fieldKey = FWPM_CONDITION_ALE_APP_ID;
@@ -373,21 +375,29 @@ bool WindowsFirewall::allowTrafficForAppOnAll(const QString& exePath,
                                                        // only blockable by veto
   // Build and add the Filters
   // #1 Permit outbound IPv4 traffic.
-  {
-    QString desc("Permit (out) IPv4 Traffic of: " + appName);
-    filter.layerKey = FWPM_LAYER_ALE_AUTH_CONNECT_V4;
-    if (!enableFilter(&filter, title, desc)) {
-      return false;
-    }
+  filter.layerKey = FWPM_LAYER_ALE_AUTH_CONNECT_V4;
+  if (!enableFilter(&filter, title, "Permit out IPv4 Traffic of: " + appName)) {
+    return false;
   }
+
   // #2 Permit inbound IPv4 traffic.
-  {
-    QString desc("Permit (in) IPv4 Traffic of: " + appName);
-    filter.layerKey = FWPM_LAYER_ALE_AUTH_RECV_ACCEPT_V4;
-    if (!enableFilter(&filter, title, desc)) {
-      return false;
-    }
+  filter.layerKey = FWPM_LAYER_ALE_AUTH_RECV_ACCEPT_V4;
+  if (!enableFilter(&filter, title, "Permit in IPv4 Traffic of: " + appName)) {
+    return false;
   }
+
+  // #3 Permit outbound IPv6 traffic.
+  filter.layerKey = FWPM_LAYER_ALE_AUTH_CONNECT_V6;
+  if (!enableFilter(&filter, title, "Permit out IPv6 Traffic of: " + appName)) {
+    return false;
+  }
+
+  // #4 Permit inbound IPv6 traffic.
+  filter.layerKey = FWPM_LAYER_ALE_AUTH_RECV_ACCEPT_V6;
+  if (!enableFilter(&filter, title, "Permit in IPv6 Traffic of: " + appName)) {
+    return false;
+  }
+
   return true;
 }
 

--- a/src/platforms/windows/daemon/windowsfirewall.cpp
+++ b/src/platforms/windows/daemon/windowsfirewall.cpp
@@ -15,6 +15,7 @@
 #include <windows.h>
 
 #include <QApplication>
+#include <QDir>
 #include <QFileInfo>
 #include <QHostAddress>
 #include <QNetworkInterface>
@@ -186,6 +187,8 @@ bool WindowsFirewall::enableInterface(int vpnAdapterIndex) {
   FW_OK(allowHyperVTraffic(MED_WEIGHT, "Allow Hyper-V Traffic"));
   FW_OK(allowTrafficForAppOnAll(getCurrentPath(), MAX_WEIGHT,
                                 "Allow all for Mozilla VPN.exe"));
+  FW_OK(allowTrafficForAppOnAll(getProxyPath(), MAX_WEIGHT,
+                                "Allow all for socksproxy.exe"));
   FW_OK(blockTrafficOnPort(53, MED_WEIGHT, "Block all DNS"));
   FW_OK(
       allowLoopbackTraffic(MED_WEIGHT, "Allow Loopback traffic on device %1"));
@@ -804,6 +807,15 @@ QString WindowsFirewall::getCurrentPath() {
   }
 
   return QString::fromLocal8Bit(buffer);
+}
+
+QString WindowsFirewall::getProxyPath() {
+  QString execPath = getCurrentPath();
+  if (execPath.isEmpty()) {
+    return "";
+  }
+
+  return QFileInfo(execPath).dir().absoluteFilePath("socksproxy.exe");
 }
 
 void WindowsFirewall::importAddress(const QHostAddress& addr,

--- a/src/platforms/windows/daemon/windowsfirewall.h
+++ b/src/platforms/windows/daemon/windowsfirewall.h
@@ -71,6 +71,7 @@ class WindowsFirewall final : public QObject {
 
   // Utils
   QString getCurrentPath();
+  QString getProxyPath();
   void importAddress(const QHostAddress& addr, OUT FWP_VALUE0_& value,
                      OUT QByteArray* v6DataBuffer);
   void importAddress(const QHostAddress& addr, OUT FWP_CONDITION_VALUE0_& value,


### PR DESCRIPTION
## Description
A couple months ago, I made an attempt to get the firefox extension working on MacOS by binding the proxy connections to an interface with `IP_BOUND_IF` to try and get them to bypass the VPN connection. Unfortunately, this work never got anywhere so the MacOS implementation was abandoned.

However, when some of our devs started to experience some difficulty in getting their split tunneling drivers working on Windows, I figured it might be worth revisiting this work by doing the same thing on Windows. This should allow us to implement firefox extension in a way that doesn't require the split tunneling driver at all.

Along the way, we also implemented it for Linux, mostly because it was the easiest way to test out all the connection handling changes (it's easy there because we just need a way to set `SO_MARK` and we don't have to mess around with the routing table and firewall).

## Reference
JIRA Issue: [FXVPN-218](https://mozilla-hub.atlassian.net/browse/FXVPN-218)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[FXVPN-218]: https://mozilla-hub.atlassian.net/browse/FXVPN-218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ