### PR TITLE
Add Webext Feature flag

### DIFF
--- a/src/feature/featurelist.h
+++ b/src/feature/featurelist.h
@@ -41,11 +41,8 @@ FEATURE(annualUpgrade,         // Feature ID
         FeatureCallback_true,  // Can be flipped on
         FeatureCallback_true,  // Can be flipped off
         QStringList(),         // feature dependencies
-        byPlatform({
-            .windows = true,
-            .macos = true,
-            .gnu_linux = true,
-        }))
+        byPlatform(
+            {.windows = true, .macos = true, .gnu_linux = true, .wasm = true}))
 
 FEATURE(appReview,              // Feature ID
         "App Review",           // Feature name

--- a/src/feature/featurelist.h
+++ b/src/feature/featurelist.h
@@ -17,7 +17,7 @@ FEATURE(accountDeletion,        // Feature ID
         FeatureCallback_true,   // Can be flipped on
         FeatureCallback_false,  // Can be flipped off
         QStringList(),          // feature dependencies
-        enableForPlatform({
+        byPlatform({
             .android = true,
             .ios = true,
         }))
@@ -41,7 +41,7 @@ FEATURE(annualUpgrade,         // Feature ID
         FeatureCallback_true,  // Can be flipped on
         FeatureCallback_true,  // Can be flipped off
         QStringList(),         // feature dependencies
-        enableForPlatform({
+        byPlatform({
             .windows = true,
             .macos = true,
             .gnu_linux = true,
@@ -52,7 +52,7 @@ FEATURE(appReview,              // Feature ID
         FeatureCallback_false,  // Can be flipped on
         FeatureCallback_false,  // Can be flipped off
         QStringList(),          // feature dependencies
-        enableForPlatform({
+        byPlatform({
             .android = true,
             .ios = true,
         }))
@@ -196,7 +196,7 @@ FEATURE(startOnBoot,            // Feature ID
         FeatureCallback_true,   // Can be flipped on
         FeatureCallback_false,  // Can be flipped off
         QStringList(),          // feature dependencies
-        enableForPlatform(
+        byPlatform(
             {.windows = true, .macos = true, .gnu_linux = true, .wasm = true}))
 
 FEATURE(stagingUpdateServer,        // Feature ID
@@ -225,7 +225,7 @@ FEATURE(unsecuredNetworkNotification,      // Feature ID
         FeatureCallback_true,              // Can be flipped on
         FeatureCallback_false,             // Can be flipped off
         QStringList(),                     // feature dependencies
-        enableForPlatform(
+        byPlatform(
             {.windows = true, .macos = true, .gnu_linux = true, .wasm = true}))
 
 FEATURE(webPurchase,           // Feature ID
@@ -233,7 +233,7 @@ FEATURE(webPurchase,           // Feature ID
         FeatureCallback_true,  // Can be flipped on
         FeatureCallback_true,  // Can be flipped off
         QStringList(),         // feature dependencies
-        enableForPlatform({
+        byPlatform({
             .windows = true,
             .macos = true,
             .gnu_linux = true,
@@ -241,7 +241,7 @@ FEATURE(webPurchase,           // Feature ID
 
 FEATURE(localProxy,    // Feature ID
         "LocalProxy",  // Feature name
-        enableForPlatform({
+        byPlatform({
             .windows = true,
             .gnu_linux = true,
         }),                          // Can be flipped on
@@ -249,13 +249,13 @@ FEATURE(localProxy,    // Feature ID
         QStringList("splitTunnel"),  // feature dependencies
         FeatureCallback_inStaging)
 
-FEATURE(webExtension,      // Feature ID
-        "webExtension",    // Feature name
-        enableForPlatform({// Can be flipped on
-                           .windows = true,
-                           .macos = true,
-                           .gnu_linux = true}),
+FEATURE(webExtension,    // Feature ID
+        "webExtension",  // Feature name
+        byPlatform({     // Can be flipped on
+                    .windows = true,
+                    .macos = true,
+                    .gnu_linux = true}),
         FeatureCallback_true,  // Can be flipped off
         QStringList(),         // feature dependencies
-        enableForPlatform({    // default value
-                           .windows = true}))
+        byPlatform({           // default value
+                    .windows = true}))

--- a/src/feature/featurelist.h
+++ b/src/feature/featurelist.h
@@ -44,7 +44,7 @@ FEATURE(annualUpgrade,         // Feature ID
         enableForPlatform({
             .windows = true,
             .macos = true,
-            .linux = true,
+            .gnu_linux = true,
         }))
 
 FEATURE(appReview,              // Feature ID
@@ -197,7 +197,7 @@ FEATURE(startOnBoot,            // Feature ID
         FeatureCallback_false,  // Can be flipped off
         QStringList(),          // feature dependencies
         enableForPlatform(
-            {.windows = true, .macos = true, .linux = true, .wasm = true}))
+            {.windows = true, .macos = true, .gnu_linux = true, .wasm = true}))
 
 FEATURE(stagingUpdateServer,        // Feature ID
         "Staging Update Server",    // Feature name
@@ -226,7 +226,7 @@ FEATURE(unsecuredNetworkNotification,      // Feature ID
         FeatureCallback_false,             // Can be flipped off
         QStringList(),                     // feature dependencies
         enableForPlatform(
-            {.windows = true, .macos = true, .linux = true, .wasm = true}))
+            {.windows = true, .macos = true, .gnu_linux = true, .wasm = true}))
 
 FEATURE(webPurchase,           // Feature ID
         "Web Purchase",        // Feature name
@@ -236,14 +236,14 @@ FEATURE(webPurchase,           // Feature ID
         enableForPlatform({
             .windows = true,
             .macos = true,
-            .linux = true,
+            .gnu_linux = true,
         }))
 
 FEATURE(localProxy,    // Feature ID
         "LocalProxy",  // Feature name
         enableForPlatform({
             .windows = true,
-            .linux = true,
+            .gnu_linux = true,
         }),                          // Can be flipped on
         FeatureCallback_true,        // Can be flipped off
         QStringList("splitTunnel"),  // feature dependencies
@@ -254,7 +254,7 @@ FEATURE(webExtension,      // Feature ID
         enableForPlatform({// Can be flipped on
                            .windows = true,
                            .macos = true,
-                           .linux = true}),
+                           .gnu_linux = true}),
         FeatureCallback_true,  // Can be flipped off
         QStringList(),         // feature dependencies
         enableForPlatform({    // default value

--- a/src/feature/featurelist.h
+++ b/src/feature/featurelist.h
@@ -17,7 +17,10 @@ FEATURE(accountDeletion,        // Feature ID
         FeatureCallback_true,   // Can be flipped on
         FeatureCallback_false,  // Can be flipped off
         QStringList(),          // feature dependencies
-        FeatureCallback_iosOrAndroid)
+        enableForPlatform({
+            .android = true,
+            .ios = true,
+        }))
 
 FEATURE(addonSignature,             // Feature ID
         "Addons Signature",         // Feature name
@@ -38,14 +41,21 @@ FEATURE(annualUpgrade,         // Feature ID
         FeatureCallback_true,  // Can be flipped on
         FeatureCallback_true,  // Can be flipped off
         QStringList(),         // feature dependencies
-        FeatureCallback_annualUpgrade)
+        enableForPlatform({
+            .windows = true,
+            .macos = true,
+            .linux = true,
+        }))
 
 FEATURE(appReview,              // Feature ID
         "App Review",           // Feature name
         FeatureCallback_false,  // Can be flipped on
         FeatureCallback_false,  // Can be flipped off
         QStringList(),          // feature dependencies
-        FeatureCallback_iosOrAndroid)
+        enableForPlatform({
+            .android = true,
+            .ios = true,
+        }))
 
 FEATURE(captivePortal,          // Feature ID
         "Captive Portal",       // Feature name
@@ -186,7 +196,8 @@ FEATURE(startOnBoot,            // Feature ID
         FeatureCallback_true,   // Can be flipped on
         FeatureCallback_false,  // Can be flipped off
         QStringList(),          // feature dependencies
-        FeatureCallback_startOnBoot)
+        enableForPlatform(
+            {.windows = true, .macos = true, .linux = true, .wasm = true}))
 
 FEATURE(stagingUpdateServer,        // Feature ID
         "Staging Update Server",    // Feature name
@@ -214,18 +225,37 @@ FEATURE(unsecuredNetworkNotification,      // Feature ID
         FeatureCallback_true,              // Can be flipped on
         FeatureCallback_false,             // Can be flipped off
         QStringList(),                     // feature dependencies
-        FeatureCallback_unsecuredNetworkNotification)
+        enableForPlatform(
+            {.windows = true, .macos = true, .linux = true, .wasm = true}))
 
 FEATURE(webPurchase,           // Feature ID
         "Web Purchase",        // Feature name
         FeatureCallback_true,  // Can be flipped on
         FeatureCallback_true,  // Can be flipped off
         QStringList(),         // feature dependencies
-        FeatureCallback_webPurchase)
+        enableForPlatform({
+            .windows = true,
+            .macos = true,
+            .linux = true,
+        }))
 
-FEATURE(localProxy,                      // Feature ID
-        "LocalProxy",                    // Feature name
-        FeatureCallback_proxyCanTurnOn,  // Can be flipped on
-        FeatureCallback_true,            // Can be flipped off
-        QStringList("splitTunnel"),      // feature dependencies
+FEATURE(localProxy,    // Feature ID
+        "LocalProxy",  // Feature name
+        enableForPlatform({
+            .windows = true,
+            .linux = true,
+        }),                          // Can be flipped on
+        FeatureCallback_true,        // Can be flipped off
+        QStringList("splitTunnel"),  // feature dependencies
         FeatureCallback_inStaging)
+
+FEATURE(webExtension,      // Feature ID
+        "webExtension",    // Feature name
+        enableForPlatform({// Can be flipped on
+                           .windows = true,
+                           .macos = true,
+                           .linux = true}),
+        FeatureCallback_true,  // Can be flipped off
+        QStringList(),         // feature dependencies
+        enableForPlatform({    // default value
+                           .windows = true}))

--- a/src/feature/featurelistcallback.h
+++ b/src/feature/featurelistcallback.h
@@ -39,22 +39,23 @@ struct FeatureSupportedPlatforms {
 };
 
 consteval auto enableForPlatform(FeatureSupportedPlatforms support) {
+  return [support]() constexpr {
 #if defined(MZ_WINDOWS)
-  auto value = support.windows;
+    return support.windows;
 #elif defined(MZ_MACOS)
-  auto value = support.macos;
+    return support.macos;
 #elif defined(MZ_LINUX)
-  auto value = support.linux;
+    return support.linux;
 #elif defined(MZ_ANDROID)
-  auto value = support.android;
+    return support.android;
 #elif defined(MZ_IOS)
-  auto value = support.ios;
+    return support.ios;
 #elif defined(MZ_WASM)
-  auto value = support.wasm;
+    return support.wasm;
 #else
-  auto value = false;
+    return false;
 #endif
-  return [value]() { return value; };
+  };
 }
 
 // Custom callback functions

--- a/src/feature/featurelistcallback.h
+++ b/src/feature/featurelistcallback.h
@@ -62,7 +62,7 @@ constIshExpr auto byPlatform(FeatureSupportedPlatforms support) {
 #elif defined(MZ_WASM)
     return support.wasm;
 #else
-#  error Undefined MZ_Platform ?
+    return false;
 #endif
   };
 }

--- a/src/feature/featurelistcallback.h
+++ b/src/feature/featurelistcallback.h
@@ -32,7 +32,7 @@ bool FeatureCallback_inStaging() { return !Constants::inProduction(); }
 struct FeatureSupportedPlatforms {
   bool windows = false;
   bool macos = false;
-  bool linux = false;
+  bool gnu_linux = false;  // TIL, "linux" is reserved keyword on gcc.
   bool android = false;
   bool ios = false;
   bool wasm = false;
@@ -45,7 +45,7 @@ consteval auto enableForPlatform(FeatureSupportedPlatforms support) {
 #elif defined(MZ_MACOS)
     return support.macos;
 #elif defined(MZ_LINUX)
-    return support.linux;
+    return support.gnu_linux;
 #elif defined(MZ_ANDROID)
     return support.android;
 #elif defined(MZ_IOS)

--- a/src/feature/featurelistcallback.h
+++ b/src/feature/featurelistcallback.h
@@ -51,18 +51,18 @@ constIshExpr auto byPlatform(FeatureSupportedPlatforms support) {
   return [support]() constexpr {
 #if defined(MZ_WINDOWS)
     return support.windows;
-#elif defined(MZ_MACOS)
-    return support.macos;
-#elif defined(MZ_LINUX)
-    return support.gnu_linux;
 #elif defined(MZ_ANDROID)
     return support.android;
 #elif defined(MZ_IOS)
     return support.ios;
+#elif defined(MZ_MACOS)
+    return support.macos;
+#elif defined(MZ_LINUX)
+    return support.gnu_linux;
 #elif defined(MZ_WASM)
     return support.wasm;
 #else
-    return false;
+#  error Undefined MZ_Platform ?
 #endif
   };
 }

--- a/src/feature/featurelistcallback.h
+++ b/src/feature/featurelistcallback.h
@@ -47,7 +47,7 @@ struct FeatureSupportedPlatforms {
 #  define constIshExpr constexpr
 #endif
 
-constIshExpr auto enableForPlatform(FeatureSupportedPlatforms support) {
+constIshExpr auto byPlatform(FeatureSupportedPlatforms support) {
   return [support]() constexpr {
 #if defined(MZ_WINDOWS)
     return support.windows;
@@ -97,7 +97,7 @@ bool FeatureCallback_inAppAuthentication() {
 #if defined(MZ_WASM)
   return true;
 #else
-  if (Constants::inProduction() || enableForPlatform({
+  if (Constants::inProduction() || byPlatform({
                                        .android = true,
                                        .ios = true,
                                    })()) {

--- a/src/feature/featurelistcallback.h
+++ b/src/feature/featurelistcallback.h
@@ -38,7 +38,16 @@ struct FeatureSupportedPlatforms {
   bool wasm = false;
 };
 
-consteval auto enableForPlatform(FeatureSupportedPlatforms support) {
+// TODO : Remove once focal support is removed
+// as that is that is the only distro we support
+// that does not have consteval q_q
+#if defined(__cpp_consteval)  // If consteval is supported
+#  define constIshExpr consteval
+#else  // Fallback to constexpr
+#  define constIshExpr constexpr
+#endif
+
+constIshExpr auto enableForPlatform(FeatureSupportedPlatforms support) {
   return [support]() constexpr {
 #if defined(MZ_WINDOWS)
     return support.windows;
@@ -57,6 +66,7 @@ consteval auto enableForPlatform(FeatureSupportedPlatforms support) {
 #endif
   };
 }
+#undef constIshExpr
 
 // Custom callback functions
 // -------------------------

--- a/src/webextensionadapter.cpp
+++ b/src/webextensionadapter.cpp
@@ -207,6 +207,8 @@ QJsonObject WebExtensionAdapter::serializeStatus() {
 
 QJsonObject WebExtensionAdapter::serializeFeaturelist() {
   auto out = QJsonObject();
+  out["webExtension"] =
+      Feature::get(Feature::Feature_webExtension)->isSupported();
   out["localProxy"] = Feature::get(Feature::Feature_localProxy)->isSupported();
   return out;
 }


### PR DESCRIPTION
## Description

The Extension itself cannot know on which plattform it is on, and if that is supported. 
So let's have the client send a signal whether it supports "webextension" 


Also while at it, i consolidated a few `FeatureListCallback_X` with a consteval func, so in the end the compiler will evaluate to a simple `()=>true|false` lambda same as before but i think it looks neat to not change to a diffrent file to check when a feature is enabled 😅 

