### PR TITLE
Nit: Add postinstall hook for Linux development

### DIFF
--- a/scripts/linux/postinst.cmake
+++ b/scripts/linux/postinst.cmake
@@ -1,0 +1,37 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# If DESTDIR is set, we are probably not installing on a real system
+# and this is just for packaging. We should do nothing here.
+if(DEFINED ENV{DESTDIR})
+  return()
+endif()
+
+# If we are not root - do nothing.
+execute_process(
+    COMMAND id -u
+    OUTPUT_VARIABLE CURRENT_UID
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+if(NOT "${CURRENT_UID}" STREQUAL "0")
+  return()
+endif()
+
+# If systemctl exists then reload the service files and restart the daemon.
+find_program(SYSTEMCTL_EXECUTABLE systemctl)
+if(SYSTEMCTL_EXECUTABLE)
+    execute_process(
+        COMMAND ${SYSTEMCTL_EXECUTABLE} daemon-reload
+        COMMAND ${SYSTEMCTL_EXECUTABLE} restart mozillavpn
+    )
+endif()
+
+# If we can, run setcap on the installed VPN binary.
+find_program(SETCAP_EXECUTABLE setcap)
+if(SETCAP_EXECUTABLE)
+    execute_process(
+        COMMAND ${SETCAP_EXECUTABLE} cap_net_raw+ep ${CMAKE_INSTALL_PREFIX}/bin/mozillavpn
+    )
+endif()
+

--- a/src/cmake/linux.cmake
+++ b/src/cmake/linux.cmake
@@ -158,4 +158,6 @@ if(NOT BUILD_FLATPAK)
         ${CMAKE_CURRENT_BINARY_DIR}/mozillavpn.service)
     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/mozillavpn.service
         DESTINATION ${SYSTEMD_UNIT_DIR})
+
+    install(SCRIPT ${CMAKE_SOURCE_DIR}/scripts/linux/postinst.cmake)
 endif()


### PR DESCRIPTION
## Description
This just automates things a little better when doing daemon debugging. We add a script that runs on `cmake --install` for Linux. A quick synopsis of what this script does:
1. Check that `DESTDIR` is unset, indicating that we are installing onto the host system, and we are not doing some packaging thing.
2. Check that we have root permissions (eg: run with `sudo`).
3. Reload and restart the Systemd services.
4. Grant the `CAP_NET_RAW` capability to the `mozillavpn` binary.

This is only needed for local development. These tasks are normally handled by the `linux/debian/mozillavpn.postinst` script when installed via a Debian package.

## Reference

    i.e Jira or Github issue URL

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
