### PR TITLE
Add missing language names (Korean, Vietnamese)

### DIFF
--- a/src/translations/extras/extras.xliff
+++ b/src/translations/extras/extras.xliff
@@ -83,6 +83,9 @@
       <trans-unit id="languages.lo" xml:space="preserve">
         <source>Lao</source>
       </trans-unit>
+      <trans-unit id="languages.ko" xml:space="preserve">
+        <source>Korean</source>
+      </trans-unit>
       <trans-unit id="languages.nl" xml:space="preserve">
         <source>Dutch</source>
       </trans-unit>
@@ -121,6 +124,9 @@
       </trans-unit>
       <trans-unit id="languages.uk" xml:space="preserve">
         <source>Ukrainian</source>
+      </trans-unit>
+      <trans-unit id="languages.vi" xml:space="preserve">
+        <source>Vietnamese</source>
       </trans-unit>
       <trans-unit id="languages.zh_CN" xml:space="preserve">
         <source>Simplified Chinese</source>


### PR DESCRIPTION
https://github.com/mozilla-mobile/mozilla-vpn-client/pull/9885

Looks like import is failing because of missing language names

> Languages ['ko', 'vi'] found in the i18n submodule do not have language names strings in extras.xliff!