### PR TITLE
Fix script for getting unreleased branches when there are none

### DIFF
--- a/.github/scripts/get_unreleased_branches.ps1
+++ b/.github/scripts/get_unreleased_branches.ps1
@@ -1,10 +1,10 @@
 #
 # This script fetches all remote branches
-# And filteres out branches that have a github release connected to that. 
-# Draft releases will count too. 
+# And filteres out branches that have a GitHub release connected to that.
+# Draft releases will count too.
 # It Writes a key=value expression
-# Where value: JSONArray<version> 
-# to STDOUT, for easy use in Github workflows
+# Where value: JSONArray<version>
+# to STDOUT, for easy use in GitHub workflows
 # use: ./.github/scripts/get_unreleased_branches.ps1  >> $env:GITHUB_OUTPUT
 
 git fetch
@@ -12,7 +12,6 @@ $REMOTE_RELEASE_BRANCHES = $(git branch -r).Split([Environment]::NewLine) `
                 | ForEach-Object{ $_.Trim() } `
                 | Where-Object {$_.startsWith('origin/releases/')} `
                 | ForEach-Object{ $_.Replace("origin/releases/","") } `
-                    
 
 # Output of gh releases
 # v2.15.1 Latest  v2.15.1 2023-06-28T21:38:04Z
@@ -20,23 +19,23 @@ $REMOTE_RELEASE_BRANCHES = $(git branch -r).Split([Environment]::NewLine) `
 # v2.15.0         v2.15.0 2023-05-30T16:15:58Z
 # v2.14.1         v2.14.1 2023-03-30T16:09:25Z
 $releases_on_github  = @()
-$(gh release list).Split([Environment]::NewLine) | ForEach-Object{ 
+$(gh release list).Split([Environment]::NewLine) | ForEach-Object{
     # $_ is now one line "v2.15.1 Latest  v2.15.1 2023-06-28T21:38:04Z"
     $tag = $_.Split([char]9)[0]
     $releases_on_github += $tag.Replace("v","")
 } `
-# Now we have 2 Lists. 
+# Now we have 2 Lists.
 
-$UNRELEASED_BRANCHES = $REMOTE_RELEASE_BRANCHES | Where-Object { !($releases_on_github -contains $_) } 
+$UNRELEASED_BRANCHES = $REMOTE_RELEASE_BRANCHES | Where-Object { !($releases_on_github -contains $_) }
 
-# If we only have one Branch this will be a string, so let's json pack it. 
+# If we only have one Branch this will be a string, so let's json pack it.
 # If not this is a list and we can just use ConvertTo-Json
-if ( $UNRELEASED_BRANCHES.GetType() -Eq [string] ){
+if ($UNRELEASED_BRANCHES -eq $null) {
+    $json_value = "[]"
+} elseif ($UNRELEASED_BRANCHES -is [string]) {
     $json_value = "[ '$UNRELEASED_BRANCHES' ]"
-}else{
-    $json_value = ConvertTo-Json $UNRELEASED_BRANCHES -Compress 
+} else {
+    $json_value = ConvertTo-Json $UNRELEASED_BRANCHES -Compress
 }
-
-
 
 Write-Output "branches=$json_value"


### PR DESCRIPTION
## Description

`i18n_update.yml` has been [failing for over a week](https://github.com/mozilla-mobile/mozilla-vpn-client/actions/workflows/i18n_update.yaml) (the PR goes through to `main`, it's just the next step failing). The reason is that there are no unreleased branches.

I think this should fix, but hard to tell considering there are no unreleased branches at the moment.

```
InvalidOperation: /home/runner/work/mozilla-vpn-client/mozilla-vpn-client/.github/scripts/get_unreleased_branches.ps1:34
Line |
  34 |  if ( $UNRELEASED_BRANCHES.GetType() -Eq [string] ){
     |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | You cannot call a method on a null-valued expression.
Error: Process completed with exit code 1.
```
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
