### PR TITLE
Attempt to auto-update flatpak crates

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -118,8 +118,7 @@ jobs:
   dependabot-cargo:
     name: "Update flatpak crates"
     runs-on: ubuntu-latest
-    #if: ${{ github.event_name == 'pull_request'}} && startsWith(gitub.head_ref, 'dependabot/cargo/')
-    if: ${{ github.event_name == 'pull_request'}}
+    if: ${{ startsWith(github.head_ref, 'dependabot/cargo/') && github.event_name == 'pull_request' }}
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4

--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -103,7 +103,7 @@ jobs:
           cache-key: flatpak-builder-${{ github.sha }}
 
   dependabot-cargo:
-    name: "Update flatpak crates"
+    name: "Update Crates"
     runs-on: ubuntu-latest
     if: ${{ startsWith(github.head_ref, 'dependabot/cargo/') && github.event_name == 'pull_request' }}
     steps:
@@ -115,9 +115,9 @@ jobs:
 
       - name: Install pip tools
         shell: bash
-        run: pip install requirements-parser PyYAML toml aiohttp yq
+        run: pip install requirements-parser PyYAML toml aiohttp
 
-      # Don't continue if there are changes to the flatpak directory.
+      # Do not continue if there are changes to the flatpak directory.
       - name: Inspect pull request
         id: inspect
         shell: bash

--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -114,3 +114,39 @@ jobs:
           bundle: mozillavpn.flatpak
           manifest-path: manifest/org.mozilla.vpn.yml
           cache-key: flatpak-builder-${{ github.sha }}
+
+  dependabot-cargo:
+    name: "Update flatpak crates"
+    runs-on: ubuntu-latest
+    #if: ${{ github.event_name == 'pull_request'}} && startsWith('dependabot/cargo/', gitub.head_ref)
+    if: ${{ github.event_name == 'pull_request'}}
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.WIKI_TOKEN }}
+
+      - name: Install pip tools
+        shell: bash
+        run: pip install requirements-parser PyYAML toml aiohttp yq
+
+      - name: Update flatpak rust crates
+        id: update
+        shell: bash
+        run: |
+          ./linux/flatpak/flatpak-update-crates.sh ./Cargo.lock
+          echo -n "changed-files=" >> $GITHUB_OUTPUT
+          git diff --name-only | grep '^linux/flatpak/flatpak-vpn-crates.json' >> $GITHUB_OUTPUT
+
+      - name: Commit the changes
+        shell: bash
+        if: ${{ steps.update.outputs.changed-files }}
+        run: |
+          git add ${{ steps.update.outputs.changed-files }}
+          git config user.name "${GITHUB_ACTOR}"
+          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+          git commit -m "[dependabot skip] Update ${{ steps.update.outputs.changed-files }}"
+          # TODO: I am scared. Let's check this first...
+          # git push
+          git format-patch --stdout HEAD~1

--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -21,28 +21,15 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v4
         with:
-          path: src
-          sparse-checkout: |
-            linux/flatpak/
-            Cargo.lock
-
-      - name: Checkout tools
-        uses: actions/checkout@v4
-        with:
-          repository: flatpak/flatpak-builder-tools
-          path: tools
+          sparse-checkout: linux/flatpak/
 
       - name: Install pip tools
         shell: bash
-        run: pip install requirements-parser PyYAML toml aiohttp yq
-
-      - name: Update Cargo dependencies
-        shell: bash
-        run: src/linux/flatpak/flatpak-update-crates.sh src/Cargo.lock
+        run: pip install PyYAML yq
 
       - name: Update git reference
         shell: bash
-        working-directory: src/linux/flatpak
+        working-directory: linux/flatpak
         run: |
           python -m yq -yi 'del(.modules[-1].sources[0].branch)' org.mozilla.vpn.yml
           python -m yq -yi ".modules[-1].sources[0].url = \"https://github.com/${{ github.repository }}\"" org.mozilla.vpn.yml
@@ -51,7 +38,7 @@ jobs:
 
       - name: Add Appstream metainfo
         shell: bash
-        working-directory: src/linux/flatpak
+        working-directory: linux/flatpak
         run: |
           curl -sSL -o org.mozilla.vpn.releases.xml \
             https://mozilla.github.io/mozillavpn-product-details/org.mozilla.vpn.releases.xml
@@ -61,7 +48,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: mozillavpn-manifest
-          path: src/linux/flatpak
+          path: linux/flatpak
 
   linter:
     name: "Linters"

--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -118,7 +118,7 @@ jobs:
   dependabot-cargo:
     name: "Update flatpak crates"
     runs-on: ubuntu-latest
-    #if: ${{ github.event_name == 'pull_request'}} && startsWith('dependabot/cargo/', gitub.head_ref)
+    #if: ${{ github.event_name == 'pull_request'}} && startsWith(gitub.head_ref, 'dependabot/cargo/')
     if: ${{ github.event_name == 'pull_request'}}
     steps:
       - name: Checkout sources
@@ -132,20 +132,17 @@ jobs:
         run: pip install requirements-parser PyYAML toml aiohttp yq
 
       - name: Update flatpak rust crates
-        id: update
         shell: bash
-        run: |
-          ./linux/flatpak/flatpak-update-crates.sh ./Cargo.lock
-          echo -n "changed-files=" >> $GITHUB_OUTPUT
-          git diff --name-only | grep '^linux/flatpak/flatpak-vpn-crates.json' >> $GITHUB_OUTPUT
+        run: ./linux/flatpak/flatpak-update-crates.sh ./Cargo.lock
 
       - name: Commit the changes
         shell: bash
-        if: ${{ steps.update.outputs.changed-files }}
         run: |
-          git add ${{ steps.update.outputs.changed-files }}
-          git config user.name "${GITHUB_ACTOR}"
-          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
-          git commit -m "[dependabot skip] Update ${{ steps.update.outputs.changed-files }}"
-          git format-patch --stdout HEAD~1
-          git push
+          if git diff --name-only | grep -q '^linux/flatpak/flatpak-vpn-crates.json'; then
+            git add linux/flatpak/flatpak-vpn-crates.json
+            git config user.name "${GITHUB_ACTOR}"
+            git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+            git commit -m "[dependabot skip] Update linux/flatpak/flatpak-vpn-crates.json"
+            git format-patch --stdout HEAD~1
+            git push
+          fi

--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -147,6 +147,5 @@ jobs:
           git config user.name "${GITHUB_ACTOR}"
           git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
           git commit -m "[dependabot skip] Update ${{ steps.update.outputs.changed-files }}"
-          # TODO: I am scared. Let's check this first...
-          # git push
           git format-patch --stdout HEAD~1
+          git push

--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -131,12 +131,23 @@ jobs:
         shell: bash
         run: pip install requirements-parser PyYAML toml aiohttp yq
 
+      # Don't continue if there are changes to the flatpak directory.
+      - name: Inspect pull request
+        id: inspect
+        shell: bash
+        run: |
+          git fetch origin "${{ github.base_ref }}" --depth=1
+          echo -n "flatpak-changes=" >> $GITHUB_OUTPUT
+          git diff --name-only --relative=linux/flatpak "origin/${{ github.base_ref }}" | wc -l >> $GITHUB_OUTPUT
+
       - name: Update flatpak rust crates
         shell: bash
+        if: ${{ steps.inspect.outputs.flatpak-changes == 0 }}
         run: ./linux/flatpak/flatpak-update-crates.sh ./Cargo.lock
 
       - name: Commit the changes
         shell: bash
+        if: ${{ steps.inspect.outputs.flatpak-changes == 0 }}
         run: |
           if git diff --name-only | grep -q '^linux/flatpak/flatpak-vpn-crates.json'; then
             git add linux/flatpak/flatpak-vpn-crates.json

--- a/linux/flatpak/flatpak-vpn-crates.json
+++ b/linux/flatpak/flatpak-vpn-crates.json
@@ -1536,14 +1536,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/once_cell/once_cell-1.19.0.crate",
-        "sha256": "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92",
-        "dest": "cargo/vendor/once_cell-1.19.0"
+        "url": "https://static.crates.io/crates/once_cell/once_cell-1.20.0.crate",
+        "sha256": "33ea5043e58958ee56f3e15a90aee535795cd7dfd319846288d93c5b57d85cbe",
+        "dest": "cargo/vendor/once_cell-1.20.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92\", \"files\": {}}",
-        "dest": "cargo/vendor/once_cell-1.19.0",
+        "contents": "{\"package\": \"33ea5043e58958ee56f3e15a90aee535795cd7dfd319846288d93c5b57d85cbe\", \"files\": {}}",
+        "dest": "cargo/vendor/once_cell-1.20.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2043,40 +2043,40 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/serde/serde-1.0.209.crate",
-        "sha256": "99fce0ffe7310761ca6bf9faf5115afbc19688edd00171d81b1bb1b116c63e09",
-        "dest": "cargo/vendor/serde-1.0.209"
+        "url": "https://static.crates.io/crates/serde/serde-1.0.210.crate",
+        "sha256": "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a",
+        "dest": "cargo/vendor/serde-1.0.210"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"99fce0ffe7310761ca6bf9faf5115afbc19688edd00171d81b1bb1b116c63e09\", \"files\": {}}",
-        "dest": "cargo/vendor/serde-1.0.209",
+        "contents": "{\"package\": \"c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a\", \"files\": {}}",
+        "dest": "cargo/vendor/serde-1.0.210",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/serde_derive/serde_derive-1.0.209.crate",
-        "sha256": "a5831b979fd7b5439637af1752d535ff49f4860c0f341d1baeb6faf0f4242170",
-        "dest": "cargo/vendor/serde_derive-1.0.209"
+        "url": "https://static.crates.io/crates/serde_derive/serde_derive-1.0.210.crate",
+        "sha256": "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f",
+        "dest": "cargo/vendor/serde_derive-1.0.210"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"a5831b979fd7b5439637af1752d535ff49f4860c0f341d1baeb6faf0f4242170\", \"files\": {}}",
-        "dest": "cargo/vendor/serde_derive-1.0.209",
+        "contents": "{\"package\": \"243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f\", \"files\": {}}",
+        "dest": "cargo/vendor/serde_derive-1.0.210",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/serde_json/serde_json-1.0.127.crate",
-        "sha256": "8043c06d9f82bd7271361ed64f415fe5e12a77fdb52e573e7f06a516dea329ad",
-        "dest": "cargo/vendor/serde_json-1.0.127"
+        "url": "https://static.crates.io/crates/serde_json/serde_json-1.0.128.crate",
+        "sha256": "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8",
+        "dest": "cargo/vendor/serde_json-1.0.128"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"8043c06d9f82bd7271361ed64f415fe5e12a77fdb52e573e7f06a516dea329ad\", \"files\": {}}",
-        "dest": "cargo/vendor/serde_json-1.0.127",
+        "contents": "{\"package\": \"6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8\", \"files\": {}}",
+        "dest": "cargo/vendor/serde_json-1.0.128",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -2342,27 +2342,27 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/thiserror/thiserror-1.0.63.crate",
-        "sha256": "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724",
-        "dest": "cargo/vendor/thiserror-1.0.63"
+        "url": "https://static.crates.io/crates/thiserror/thiserror-1.0.64.crate",
+        "sha256": "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84",
+        "dest": "cargo/vendor/thiserror-1.0.64"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724\", \"files\": {}}",
-        "dest": "cargo/vendor/thiserror-1.0.63",
+        "contents": "{\"package\": \"d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84\", \"files\": {}}",
+        "dest": "cargo/vendor/thiserror-1.0.64",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/thiserror-impl/thiserror-impl-1.0.63.crate",
-        "sha256": "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261",
-        "dest": "cargo/vendor/thiserror-impl-1.0.63"
+        "url": "https://static.crates.io/crates/thiserror-impl/thiserror-impl-1.0.64.crate",
+        "sha256": "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3",
+        "dest": "cargo/vendor/thiserror-impl-1.0.64"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261\", \"files\": {}}",
-        "dest": "cargo/vendor/thiserror-impl-1.0.63",
+        "contents": "{\"package\": \"08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3\", \"files\": {}}",
+        "dest": "cargo/vendor/thiserror-impl-1.0.64",
         "dest-filename": ".cargo-checksum.json"
     },
     {


### PR DESCRIPTION
## Description
After my last messing around with the Flatpak manifests, it turns out that it wasn't a good idea to check in a static version of `flatpak-vpn-crates.json` since our `Cargo.lock` is updated automatically by Dependabot and the two files will quickly fall out of sync. Let's make another attempt to write some automation to ensure it's updated.

The last time I tried this, it got stuck because Github prevents workflows from retriggering themselves (this runs the risk of creating an infinite loop). So we would wind up with a PR that would automatically update the flatpak manifests, but then none of the required checks wound run, leaving the PR in an un-mergeable state. However, there are some [recommended workarounds](https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs) that we can use.

To try and mitigate the risk of an infinite loop, we set up this workflow so that it only runs on dependabot PRs, and only when there are no changes to the `linux/flatpak` directory.

## Reference
Github issue #9895 
My last attempt: #9616

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
