### PR TITLE
VPN-6422: Migrate to XDG Secrets Portal

### DIFF
--- a/linux/mozillavpn.spec
+++ b/linux/mozillavpn.spec
@@ -56,7 +56,6 @@ install %{_srcdir}/LICENSE.md %{buildroot}/%{_licensedir}/%{name}/
 %license %{_licensedir}/%{name}/LICENSE.md
 %{_sysconfdir}/chromium/native-messaging-hosts/mozillavpn.json
 %{_sysconfdir}/opt/chrome/native-messaging-hosts/mozillavpn.json
-%{_sysconfdir}/xdg/autostart/org.mozilla.vpn-startup.desktop
 %{_unitdir}/mozillavpn.service
 %{_bindir}/mozillavpn
 %{_prefix}/lib/mozillavpn/mozillavpnnp

--- a/src/cmake/linux.cmake
+++ b/src/cmake/linux.cmake
@@ -25,7 +25,18 @@ target_sources(mozillavpn PRIVATE
     ${CMAKE_SOURCE_DIR}/src/platforms/linux/linuxpingsender.h
     ${CMAKE_SOURCE_DIR}/src/platforms/linux/linuxsystemtraynotificationhandler.cpp
     ${CMAKE_SOURCE_DIR}/src/platforms/linux/linuxsystemtraynotificationhandler.h
+    ${CMAKE_SOURCE_DIR}/src/platforms/linux/xdgcryptosettings.cpp
+    ${CMAKE_SOURCE_DIR}/src/platforms/linux/xdgcryptosettings.h
+    ${CMAKE_SOURCE_DIR}/src/platforms/linux/xdgportal.cpp
+    ${CMAKE_SOURCE_DIR}/src/platforms/linux/xdgportal.h
 )
+
+# Resolving the parent window handle for the XDG desktop portal on Wayland
+# needs the Gui internal header files on Qt 6.5.0 and later. Otherwise it
+# only works for X11.
+if(Qt6_VERSION VERSION_GREATER_EQUAL 6.5.0)
+    target_link_libraries(mozillavpn PRIVATE Qt6::GuiPrivate)
+endif()
 
 if(NOT BUILD_FLATPAK)
     # Link to libcap and libsecret
@@ -88,13 +99,6 @@ else()
     # Linux source files for sandboxed builds
     target_compile_definitions(mozillavpn PRIVATE MZ_FLATPAK)
 
-    # Resolving the parent window handle for the XDG desktop portal on Wayland
-    # needs the Gui internal header files on Qt 6.5.0 and later. Otherwise it
-    # only works for X11.
-    if(Qt6_VERSION VERSION_GREATER_EQUAL 6.5.0)
-        target_link_libraries(mozillavpn PRIVATE Qt6::GuiPrivate)
-    endif()
-
     # Network Manager controller - experimental
     pkg_check_modules(libnm REQUIRED IMPORTED_TARGET libnm)
     target_link_libraries(mozillavpn PRIVATE PkgConfig::libnm)
@@ -103,10 +107,6 @@ else()
         ${CMAKE_SOURCE_DIR}/src/platforms/linux/networkmanagerconnection.cpp
         ${CMAKE_SOURCE_DIR}/src/platforms/linux/networkmanagercontroller.h
         ${CMAKE_SOURCE_DIR}/src/platforms/linux/networkmanagercontroller.cpp
-        ${CMAKE_SOURCE_DIR}/src/platforms/linux/xdgcryptosettings.cpp
-        ${CMAKE_SOURCE_DIR}/src/platforms/linux/xdgcryptosettings.h
-        ${CMAKE_SOURCE_DIR}/src/platforms/linux/xdgportal.cpp
-        ${CMAKE_SOURCE_DIR}/src/platforms/linux/xdgportal.h
         ${CMAKE_SOURCE_DIR}/src/platforms/linux/xdgstartatbootwatcher.h
         ${CMAKE_SOURCE_DIR}/src/platforms/linux/xdgstartatbootwatcher.cpp
     )

--- a/src/cmake/linux.cmake
+++ b/src/cmake/linux.cmake
@@ -29,6 +29,8 @@ target_sources(mozillavpn PRIVATE
     ${CMAKE_SOURCE_DIR}/src/platforms/linux/xdgcryptosettings.h
     ${CMAKE_SOURCE_DIR}/src/platforms/linux/xdgportal.cpp
     ${CMAKE_SOURCE_DIR}/src/platforms/linux/xdgportal.h
+    ${CMAKE_SOURCE_DIR}/src/platforms/linux/xdgstartatbootwatcher.h
+    ${CMAKE_SOURCE_DIR}/src/platforms/linux/xdgstartatbootwatcher.cpp
 )
 
 # Resolving the parent window handle for the XDG desktop portal on Wayland
@@ -107,8 +109,6 @@ else()
         ${CMAKE_SOURCE_DIR}/src/platforms/linux/networkmanagerconnection.cpp
         ${CMAKE_SOURCE_DIR}/src/platforms/linux/networkmanagercontroller.h
         ${CMAKE_SOURCE_DIR}/src/platforms/linux/networkmanagercontroller.cpp
-        ${CMAKE_SOURCE_DIR}/src/platforms/linux/xdgstartatbootwatcher.h
-        ${CMAKE_SOURCE_DIR}/src/platforms/linux/xdgstartatbootwatcher.cpp
     )
 endif()
 include(GNUInstallDirs)
@@ -135,11 +135,6 @@ install(FILES ${CMAKE_SOURCE_DIR}/linux/extra/icons/128x128/org.mozilla.vpn.png
     DESTINATION ${CMAKE_INSTALL_DATADIR}/icons/hicolor/128x128/apps)
 
 if(NOT BUILD_FLATPAK)
-    configure_file(${CMAKE_SOURCE_DIR}/linux/extra/org.mozilla.vpn-startup.desktop.in
-        ${CMAKE_CURRENT_BINARY_DIR}/org.mozilla.vpn-startup.desktop)
-    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/org.mozilla.vpn-startup.desktop
-        DESTINATION /etc/xdg/autostart)
-
     install(FILES ${CMAKE_SOURCE_DIR}/src/platforms/linux/daemon/org.mozilla.vpn.conf
         DESTINATION /usr/share/dbus-1/system.d)
 

--- a/src/commands/commandui.cpp
+++ b/src/commands/commandui.cpp
@@ -58,10 +58,6 @@
 
 #ifdef MZ_LINUX
 #  include "eventlistener.h"
-#  include "platforms/linux/linuxdependencies.h"
-#endif
-
-#ifdef MZ_FLATPAK
 #  include "platforms/linux/xdgstartatbootwatcher.h"
 #endif
 
@@ -305,7 +301,7 @@ int CommandUI::run(QStringList& tokens) {
     WindowsStartAtBootWatcher startAtBootWatcher;
 #endif
 
-#ifdef MZ_FLATPAK
+#ifdef MZ_LINUX
     XdgStartAtBootWatcher startAtBootWatcher;
 #endif
 

--- a/src/cryptosettings.cpp
+++ b/src/cryptosettings.cpp
@@ -229,7 +229,7 @@ bool CryptoSettings::writeFile(QIODevice& device,
                                const QSettings::SettingsMap& map) {
   logger.debug() << "Writing the settings file";
 
-  // Without a SryptoSettings we can only write plaintext settings.
+  // Without a CryptoSettings we can only write plaintext settings.
   if (s_instance == nullptr) {
     return writeJsonFile(device, map);
   }
@@ -332,7 +332,7 @@ bool CryptoSettings::writeEncryptedChachaPolyFile(
     header.append(1, metadata.length() & 0xff);
     header.append(1, (metadata.length() >> 8) & 0xff);
     header.append(metadata);
-  } else if (fileVersion != EncryptionChachaPolyV1) {
+  } else {
     logger.error() << "Unsupported encrypted file version:" << header[0];
     return false;
   }

--- a/src/cryptosettings.cpp
+++ b/src/cryptosettings.cpp
@@ -186,7 +186,7 @@ bool CryptoSettings::readEncryptedChachaPolyFile(Version fileVersion,
     return false;
   }
 
-  QByteArray key = getKey(metadata);
+  QByteArray key = getKey(fileVersion, metadata);
   if (key.isEmpty()) {
     logger.error() << "Something went wrong reading the key";
     return false;
@@ -228,13 +228,13 @@ bool CryptoSettings::readEncryptedChachaPolyFile(Version fileVersion,
 bool CryptoSettings::writeFile(QIODevice& device,
                                const QSettings::SettingsMap& map) {
   logger.debug() << "Writing the settings file";
-  CryptoSettings::Version version = NoEncryption;
 
-  if (s_instance) {
-    version = s_instance->getSupportedVersion();
+  // Without a SryptoSettings we can only write plaintext settings.
+  if (s_instance == nullptr) {
+    return writeJsonFile(device, map);
   }
 
-  switch (version) {
+  switch (s_instance->getPreferredVersion()) {
     case NoEncryption:
       return writeJsonFile(device, map);
     case EncryptionChachaPolyV1:
@@ -299,7 +299,8 @@ bool CryptoSettings::writeEncryptedChachaPolyFile(
   QByteArray nonce(NONCE_SIZE, 0x00);
   memcpy(nonce.data(), &m_lastNonce, sizeof(m_lastNonce));
 
-  QByteArray key = getKey(QByteArray());
+  Version fileVersion = getPreferredVersion();
+  QByteArray key = getKey(fileVersion, QByteArray());
   if (key.isEmpty()) {
     logger.error() << "Something went wrong reading the key";
     return false;
@@ -310,24 +311,29 @@ bool CryptoSettings::writeEncryptedChachaPolyFile(
   }
 
   QByteArray header;
-  QByteArray metadata = getMetaData();
-  if (metadata.isEmpty()) {
+  if (fileVersion == CryptoSettings::EncryptionChachaPolyV1) {
     // Encrypted V1 Header: Just the version.
-    header.append(1, CryptoSettings::EncryptionChachaPolyV1);
-  } else if (metadata.length() <= UINT16_MAX) {
+    header.append(1, fileVersion);
+  } else if (fileVersion == CryptoSettings::EncryptionChachaPolyV2) {
+    QByteArray metadata = getMetaData();
+    if (metadata.length() > UINT16_MAX) {
+      logger.error() << "Failed to write encrypted file header: too long";
+      return false;
+    }
+
     // Encrypted V2 Header:
     // +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
     // | Version | Reserved  | Metadata Length | Metadata  |
     // |  8-bit  |   8-bit   |     16-bit      | variable  |
     // +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
     header.reserve(ENCRYPTED_V2_HEADER_SIZE + metadata.length());
-    header.append(1, CryptoSettings::EncryptionChachaPolyV2);
+    header.append(1, fileVersion);
     header.append(1, 0);
     header.append(1, metadata.length() & 0xff);
     header.append(1, (metadata.length() >> 8) & 0xff);
     header.append(metadata);
-  } else {
-    logger.error() << "Failed to write encrypted file header: too long";
+  } else if (fileVersion != EncryptionChachaPolyV1) {
+    logger.error() << "Unsupported encrypted file version:" << header[0];
     return false;
   }
 

--- a/src/cryptosettings.h
+++ b/src/cryptosettings.h
@@ -33,9 +33,9 @@ class CryptoSettings {
 
   // Implementations must provide these methods to retrieve keys.
   virtual void resetKey() = 0;
-  virtual QByteArray getKey(const QByteArray& metadata) = 0;
+  virtual QByteArray getKey(Version version, const QByteArray& metadata) = 0;
   virtual QByteArray getMetaData() { return QByteArray(); }
-  virtual Version getSupportedVersion() = 0;
+  virtual Version getPreferredVersion() = 0;
 
  private:
   // Plantext file implementation

--- a/src/platforms/android/androidcryptosettings.cpp
+++ b/src/platforms/android/androidcryptosettings.cpp
@@ -81,7 +81,7 @@ QByteArray AndroidCryptoSettings::getKey(CryptoSettings::Version version,
 }
 
 CryptoSettings::Version AndroidCryptoSettings::getPreferredVersion() {
-  if (getKey(QByteArray()).isEmpty()) {
+  if (getKey(CryptoSettings::EncryptionChachaPolyV1, QByteArray()).isEmpty()) {
     logger.warning() << "No encryption";
     return CryptoSettings::NoEncryption;
   }

--- a/src/platforms/android/androidcryptosettings.cpp
+++ b/src/platforms/android/androidcryptosettings.cpp
@@ -61,7 +61,9 @@ void AndroidCryptoSettings::resetKey() {
   m_initialized = false;
 }
 
-QByteArray AndroidCryptoSettings::getKey(const QByteArray& metadata) {
+QByteArray AndroidCryptoSettings::getKey(CryptoSettings::Version version,
+                                         const QByteArray& metadata) {
+  Q_UNUSED(version);
   Q_UNUSED(metadata);
 
   if (m_initialized) {
@@ -78,7 +80,7 @@ QByteArray AndroidCryptoSettings::getKey(const QByteArray& metadata) {
   return jni_getKey();
 }
 
-CryptoSettings::Version AndroidCryptoSettings::getSupportedVersion() {
+CryptoSettings::Version AndroidCryptoSettings::getPreferredVersion() {
   if (getKey(QByteArray()).isEmpty()) {
     logger.warning() << "No encryption";
     return CryptoSettings::NoEncryption;

--- a/src/platforms/android/androidcryptosettings.h
+++ b/src/platforms/android/androidcryptosettings.h
@@ -15,8 +15,9 @@ class AndroidCryptoSettings final : public CryptoSettings {
   virtual ~AndroidCryptoSettings() = default;
 
   void resetKey() override;
-  QByteArray getKey(const QByteArray& metadata) override;
-  CryptoSettings::Version getSupportedVersion() override;
+  QByteArray getKey(CryptoSettings::Version version,
+                    const QByteArray& metadata) override;
+  CryptoSettings::Version getPreferredVersion() override;
 
  private:
   bool m_initialized = false;

--- a/src/platforms/dummy/dummycryptosettings.h
+++ b/src/platforms/dummy/dummycryptosettings.h
@@ -14,12 +14,14 @@ class DummyCryptoSettings final : public CryptoSettings {
   virtual ~DummyCryptoSettings() = default;
 
   virtual void resetKey() override { m_fakeKeyValue++; };
-  virtual QByteArray getKey(const QByteArray& metadata) override {
+  virtual QByteArray getKey(CryptoSettings::Version version,
+                            const QByteArray& metadata) override {
     Q_UNUSED(metadata);
+    Q_UNUSED(version);
     return QByteArray(CRYPTO_SETTINGS_KEY_SIZE, m_fakeKeyValue);
   };
   virtual QByteArray getMetaData() override { return m_metadata; };
-  virtual Version getSupportedVersion() override { return m_keyVersion; };
+  virtual Version getPreferredVersion() override { return m_keyVersion; };
 
  private:
   char m_fakeKeyValue = 'A';

--- a/src/platforms/linux/linuxcryptosettings.cpp
+++ b/src/platforms/linux/linuxcryptosettings.cpp
@@ -94,7 +94,8 @@ void LinuxCryptoSettings::resetKey() {
   XdgCryptoSettings::resetKey();
 }
 
-QByteArray LinuxCryptoSettings::getKey(Version version, const QByteArray& metadata) {
+QByteArray LinuxCryptoSettings::getKey(Version version,
+                                       const QByteArray& metadata) {
   if (version == EncryptionChachaPolyV1) {
     // A legacy key is being requested - get it from the libsecrets API.
     return m_legacyKey;

--- a/src/platforms/linux/linuxcryptosettings.cpp
+++ b/src/platforms/linux/linuxcryptosettings.cpp
@@ -7,7 +7,6 @@
 #include <QtDBus/QtDBus>
 
 #include "constants.h"
-#include "cryptosettings.h"
 #include "logger.h"
 #include "xdgcryptosettings.h"
 
@@ -63,6 +62,7 @@ LinuxCryptoSettings::LinuxCryptoSettings() : XdgCryptoSettings() {
   auto schema = cryptosettings_get_schema();
   gchar* password = secret_password_lookup_sync(schema, nullptr, &err, nullptr);
   if (err != nullptr) {
+    logger.info() << "Error while fetching legacy key:" << err->message;
     g_error_free(err);
     return;
   } else if (password != nullptr) {

--- a/src/platforms/linux/linuxcryptosettings.cpp
+++ b/src/platforms/linux/linuxcryptosettings.cpp
@@ -29,9 +29,17 @@ static const SecretSchema* cryptosettings_get_schema(void) {
   return &cryptosettings_schema;
 }
 
-LinuxCryptoSettings::LinuxCryptoSettings() {
-  m_xdg = new XdgCryptoSettings();
-
+/* The XDG Secrets portal is the preferred way to retrieve secrets from
+ * the desktop session, and we should use that whenever possible. However,
+ * we keep the LinuxCryptoSettings class around to allow users to migrate
+ * from the older libsecrets implementation to the XDG Portal.
+ *
+ * This class wraps the XdgCryptoSettings implementation, but provides a
+ * fallback to fetch a key from libsecret when attempting to decrypt a file
+ * using the EncryptionChachaPolyV1 format. For all other cases, we just call
+ * through to the XDG implementation.
+ */
+LinuxCryptoSettings::LinuxCryptoSettings() : XdgCryptoSettings() {
   // Check if "org.freedesktop.secrets" has been taken on the session D-Bus.
   QDBusConnection bus = QDBusConnection::sessionBus();
   QDBusMessage hasOwnerCall = QDBusMessage::createMethodCall(
@@ -47,41 +55,43 @@ LinuxCryptoSettings::LinuxCryptoSettings() {
     return;
   }
 
-  // Try to lookup the encryption key this can fail for a variety of reasons.
-  // It's also not reliable, which is why we want to move users onto the XDG
-  // Secrets portal for managing their encrypted settings.
-  GError* error = nullptr;
-  gchar* password = secret_password_lookup_sync(cryptosettings_get_schema(),
-                                                nullptr, &error, nullptr);
-  if (error != nullptr) {
-    logger.error() << "Key lookup failed:" << error->message;
-    g_error_free(error);
-    error = nullptr;
-    // fall-through to try creating the password anyways
-  } if (password != nullptr) {
+  /* Try to lookup the encryption key. This can fail for a variety of reasons.
+   * It's also not reliable, which is why we want to move users onto the XDG
+   * Secrets portal for managing their encrypted settings.
+   */
+  GError* err = nullptr;
+  auto schema = cryptosettings_get_schema();
+  gchar* password = secret_password_lookup_sync(schema, nullptr, &err, nullptr);
+  if (err != nullptr) {
+    g_error_free(err);
+    return;
+  } else if (password != nullptr) {
     // We successfully retrieved a key from libsecret.
-    QString b64key(password);
-    m_legacyKey = QByteArray::fromBase64(b64key.toUtf8());
+    logger.info() << "Legacy encryption key found:" << password;
+    m_legacyKey = QByteArray::fromBase64(QByteArray(password, -1));
     secret_password_free(password);
   }
 }
 
-void LinuxCryptoSettings::resetKey() {
-  // Reset the key in the XDG secrets portal.
-  m_xdg->resetKey();
-
-  logger.debug() << "Reset the key in the keychain";
+void LinuxCryptoSettings::clearLegacyKey() {
+  if (m_legacyKey.isEmpty()) {
+    return;
+  }
+  logger.debug() << "Removing legacy keys from the keychain";
+  m_legacyKey.clear();
 
   GError* error = nullptr;
   auto schema = cryptosettings_get_schema();
-  gboolean ok = secret_password_clear_sync(schema, nullptr, &error, nullptr);
-  if (!ok) {
-    Q_ASSERT(error);
+  secret_password_clear_sync(schema, nullptr, &error, nullptr);
+  if (error != nullptr) {
     logger.error() << "Key reset failed:" << error->message;
     g_error_free(error);
   }
+}
 
-  m_legacyKey.clear();
+void LinuxCryptoSettings::resetKey() {
+  clearLegacyKey();
+  XdgCryptoSettings::resetKey();
 }
 
 QByteArray LinuxCryptoSettings::getKey(Version version, const QByteArray& metadata) {
@@ -90,14 +100,8 @@ QByteArray LinuxCryptoSettings::getKey(Version version, const QByteArray& metada
     return m_legacyKey;
   } else {
     // Otherwise, use the XDG secrets portal for all new files and keys.
-    return m_xdg->getKey(version, metadata);
+    // Clear the legacy key once an attempt has been made to write a new file.
+    clearLegacyKey();
+    return XdgCryptoSettings::getKey(version, metadata);
   }
-}
-
-CryptoSettings::Version LinuxCryptoSettings::getPreferredVersion() {
-  return m_xdg->getPreferredVersion();
-}
-
-QByteArray LinuxCryptoSettings::getMetaData() {
-  return m_xdg->getMetaData();
 }

--- a/src/platforms/linux/linuxcryptosettings.cpp
+++ b/src/platforms/linux/linuxcryptosettings.cpp
@@ -16,7 +16,7 @@
 #include <libsecret/secret.h>
 
 namespace {
-Logger logger("CryptoSettings");
+Logger logger("LinuxCryptoSettings");
 }  // namespace
 
 static const SecretSchema* cryptosettings_get_schema(void) {
@@ -67,7 +67,7 @@ LinuxCryptoSettings::LinuxCryptoSettings() : XdgCryptoSettings() {
     return;
   } else if (password != nullptr) {
     // We successfully retrieved a key from libsecret.
-    logger.info() << "Legacy encryption key found:" << password;
+    logger.info() << "Legacy encryption key found";
     m_legacyKey = QByteArray::fromBase64(QByteArray(password, -1));
     secret_password_free(password);
   }

--- a/src/platforms/linux/linuxcryptosettings.h
+++ b/src/platforms/linux/linuxcryptosettings.h
@@ -6,10 +6,9 @@
 #define LINUXCRYPTOSETTINGS_H
 
 #include "cryptosettings.h"
+#include "xdgcryptosettings.h"
 
-class XdgCryptoSettings;
-
-class LinuxCryptoSettings final : public CryptoSettings {
+class LinuxCryptoSettings final : public XdgCryptoSettings {
  public:
   LinuxCryptoSettings();
   virtual ~LinuxCryptoSettings() = default;
@@ -17,15 +16,12 @@ class LinuxCryptoSettings final : public CryptoSettings {
   void resetKey() override;
   QByteArray getKey(CryptoSettings::Version version,
                     const QByteArray& metadata) override;
-  QByteArray getMetaData() override;
-  CryptoSettings::Version getPreferredVersion() override;
 
  private:
+  void clearLegacyKey();
+
   // Holds a legeacy encryption key, if we could find one.
   QByteArray m_legacyKey;
-
-  // The real cryptosettings implementation.
-  XdgCryptoSettings* m_xdg = nullptr;
 };
 
 #endif  // LINUXCRYPTOSETTINGS_H

--- a/src/platforms/linux/linuxcryptosettings.h
+++ b/src/platforms/linux/linuxcryptosettings.h
@@ -7,19 +7,25 @@
 
 #include "cryptosettings.h"
 
+class XdgCryptoSettings;
+
 class LinuxCryptoSettings final : public CryptoSettings {
  public:
   LinuxCryptoSettings();
   virtual ~LinuxCryptoSettings() = default;
 
   void resetKey() override;
-  QByteArray getKey(const QByteArray& metadata) override;
-  CryptoSettings::Version getSupportedVersion() override;
+  QByteArray getKey(CryptoSettings::Version version,
+                    const QByteArray& metadata) override;
+  QByteArray getMetaData() override;
+  CryptoSettings::Version getPreferredVersion() override;
 
  private:
-  CryptoSettings::Version m_keyVersion = CryptoSettings::NoEncryption;
-  bool m_initialized = false;
-  QByteArray m_key;
+  // Holds a legeacy encryption key, if we could find one.
+  QByteArray m_legacyKey;
+
+  // The real cryptosettings implementation.
+  XdgCryptoSettings* m_xdg = nullptr;
 };
 
 #endif  // LINUXCRYPTOSETTINGS_H

--- a/src/platforms/linux/xdgcryptosettings.cpp
+++ b/src/platforms/linux/xdgcryptosettings.cpp
@@ -85,7 +85,13 @@ QByteArray XdgCryptoSettings::xdgReadSecretFile(int fd) {
   return data;
 }
 
-QByteArray XdgCryptoSettings::getKey(const QByteArray& metadata) {
+QByteArray XdgCryptoSettings::getKey(CryptoSettings::Version version,
+                                     const QByteArray& metadata) {
+  if (version != CryptoSettings::EncryptionChachaPolyV2) {
+    // This version is not supported.
+    return QByteArray();
+  }
+
   // Retrieve the key if we don't already have a copy.
   if (m_key.isEmpty()) {
     QJsonObject obj = QJsonDocument::fromJson(metadata).object();

--- a/src/platforms/linux/xdgcryptosettings.cpp
+++ b/src/platforms/linux/xdgcryptosettings.cpp
@@ -120,7 +120,7 @@ QByteArray XdgCryptoSettings::getKey(CryptoSettings::Version version,
       return QByteArray();
     } else {
       // We need to rebind our signals if the reply path changed.
-      const QVariant& qv = reply.arguments().constFirst();
+      QVariant qv = reply.arguments().value(0);
       setReplyPath(qv.value<QDBusObjectPath>().path());
     }
 

--- a/src/platforms/linux/xdgcryptosettings.h
+++ b/src/platforms/linux/xdgcryptosettings.h
@@ -10,7 +10,7 @@
 #include "cryptosettings.h"
 #include "xdgportal.h"
 
-class XdgCryptoSettings final : public CryptoSettings, public XdgPortal {
+class XdgCryptoSettings : public CryptoSettings, public XdgPortal {
  public:
   XdgCryptoSettings();
   virtual ~XdgCryptoSettings() = default;

--- a/src/platforms/linux/xdgcryptosettings.h
+++ b/src/platforms/linux/xdgcryptosettings.h
@@ -16,9 +16,10 @@ class XdgCryptoSettings final : public CryptoSettings, public XdgPortal {
   virtual ~XdgCryptoSettings() = default;
 
   void resetKey() override;
-  QByteArray getKey(const QByteArray& metadata) override;
+  QByteArray getKey(CryptoSettings::Version version,
+                    const QByteArray& metadata) override;
   QByteArray getMetaData() override;
-  CryptoSettings::Version getSupportedVersion() override { return m_version; };
+  CryptoSettings::Version getPreferredVersion() override { return m_version; };
 
  private slots:
   void handleResponse(uint code, QVariantMap results);

--- a/src/platforms/linux/xdgportal.cpp
+++ b/src/platforms/linux/xdgportal.cpp
@@ -14,6 +14,7 @@
 #  include <qpa/qplatformintegration.h>
 #else
 #  include <QGuiApplication>
+#  include <QWindow>
 #endif
 
 #include "leakdetector.h"

--- a/src/platforms/macos/macoscryptosettings.h
+++ b/src/platforms/macos/macoscryptosettings.h
@@ -13,8 +13,9 @@ class MacOSCryptoSettings final : public CryptoSettings {
   virtual ~MacOSCryptoSettings() = default;
 
   void resetKey() override;
-  QByteArray getKey(const QByteArray& metadata) override;
-  CryptoSettings::Version getSupportedVersion() override {
+  QByteArray getKey(CryptoSettings::Version version,
+                    const QByteArray& metadata) override;
+  CryptoSettings::Version getPreferredVersion() override {
     return m_keyVersion;
   }
 

--- a/src/platforms/macos/macoscryptosettings.mm
+++ b/src/platforms/macos/macoscryptosettings.mm
@@ -58,7 +58,9 @@ void MacOSCryptoSettings::resetKey() {
   m_initialized = false;
 }
 
-QByteArray MacOSCryptoSettings::getKey(const QByteArray& metadata) {
+QByteArray MacOSCryptoSettings::getKey(CryptoSettings::Version version,
+                                       const QByteArray& metadata) {
+  Q_UNUSED(version);
   Q_UNUSED(metadata);
 
   if (!m_initialized) {

--- a/src/platforms/windows/windowscryptosettings.cpp
+++ b/src/platforms/windows/windowscryptosettings.cpp
@@ -24,7 +24,9 @@ void WindowsCryptoSettings::resetKey() {
   }
 }
 
-QByteArray WindowsCryptoSettings::getKey(const QByteArray& metadata) {
+QByteArray WindowsCryptoSettings::getKey(CryptoSettings::Version version,
+                                         const QByteArray& metadata) {
+  Q_UNUSED(version);
   Q_UNUSED(metadata);
 
   if (!m_initialized) {
@@ -69,6 +71,6 @@ QByteArray WindowsCryptoSettings::getKey(const QByteArray& metadata) {
   return m_key;
 }
 
-CryptoSettings::Version WindowsCryptoSettings::getSupportedVersion() {
+CryptoSettings::Version WindowsCryptoSettings::getPreferredVersion() {
   return CryptoSettings::EncryptionChachaPolyV1;
 }

--- a/src/platforms/windows/windowscryptosettings.h
+++ b/src/platforms/windows/windowscryptosettings.h
@@ -13,8 +13,9 @@ class WindowsCryptoSettings final : public CryptoSettings {
   virtual ~WindowsCryptoSettings() = default;
 
   void resetKey() override;
-  QByteArray getKey(const QByteArray& metadata) override;
-  CryptoSettings::Version getSupportedVersion() override;
+  QByteArray getKey(CryptoSettings::Version version,
+                    const QByteArray& metadata) override;
+  CryptoSettings::Version getPreferredVersion() override;
 
  private:
   bool m_initialized = false;

--- a/src/settingslist.h
+++ b/src/settingslist.h
@@ -748,7 +748,9 @@ SETTING_STRING(tunnelUuid,        // getter
                false,             // remove when reset
                true               // sensitive (do not log)
 )
+#endif
 
+#if defined(MZ_LINUX)
 SETTING_STRING(xdgSecretToken,        // getter
                setXdgSecretToken,     // setter
                removeXdgSecretToken,  // remover

--- a/taskcluster/kinds/build/linux.yml
+++ b/taskcluster/kinds/build/linux.yml
@@ -55,24 +55,24 @@ linux/noble:
         name: linux-noble
         type: build
 
-linux/fedora-fc37:
-    description: "Linux Build (Fedora/37)"
+linux/fedora-fc39:
+    description: "Linux Build (Fedora/39)"
     treeherder:
-        platform: linux/fedora-fc37
+        platform: linux/fedora-fc39
     worker:
-        docker-image: {in-tree: linux-build-fedora-fc37}
+        docker-image: {in-tree: linux-build-fedora-fc39}
     add-index-routes:
-        name: linux-fedora-fc37
+        name: linux-fedora-fc39
         type: build
 
-linux/fedora-fc38:
-    description: "Linux Build (Fedora/38)"
+linux/fedora-fc40:
+    description: "Linux Build (Fedora/40)"
     treeherder:
-        platform: linux/fedora-fc38
+        platform: linux/fedora-fc40
     worker:
-        docker-image: {in-tree: linux-build-fedora-fc38}
+        docker-image: {in-tree: linux-build-fedora-fc40}
     add-index-routes:
-        name: linux-fedora-fc38
+        name: linux-fedora-fc40
         type: build
 
 linux64/release-deb:

--- a/taskcluster/kinds/docker-image/kind.yml
+++ b/taskcluster/kinds/docker-image/kind.yml
@@ -57,13 +57,13 @@ tasks:
         definition: linux-dpkg-build
         args:
             DOCKER_BASE_IMAGE: ubuntu:noble
-    linux-build-fedora-fc37:
-        symbol: I(linux-fedora-fc37)
+    linux-build-fedora-fc39:
+        symbol: I(linux-fedora-fc39)
         definition: linux-rpm-build
         args:
-            DOCKER_BASE_IMAGE: fedora:37
-    linux-build-fedora-fc38:
-        symbol: I(linux-fedora-fc38)
+            DOCKER_BASE_IMAGE: fedora:39
+    linux-build-fedora-fc40:
+        symbol: I(linux-fedora-fc40)
         definition: linux-rpm-build
         args:
-            DOCKER_BASE_IMAGE: fedora:38
+            DOCKER_BASE_IMAGE: fedora:40

--- a/tests/unit/testcryptosettings.h
+++ b/tests/unit/testcryptosettings.h
@@ -38,7 +38,7 @@ class TestCryptoSettings final : public TestHelper {
   void readFailsWithMacError();
 
   // Tests for the encrypted v2 format.
-  void writeV1andReadV2();
+  void writeV1readV2upgrade();
   void writeV2WithMetaData();
   void readFailsWithMetaDataError();
 };


### PR DESCRIPTION
## Description
We have a steady stream of users reporting that their Linux clients are frequently loosing their settings across reboot. This looks and smells like a failure in the `LinuxCryptoSettings` class to retrieve the settings encryption keys from the `libsecret` API. We have seen this before, and it typically results from the user's keyring being locked at the time that they launch the VPN client.

Fortunately, there is a better way to generate an application encryption key using the XDG [Secrets Portal](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.Secret.html), and we already have it implemented for Flatpaks. This PR attempts to provide a migration strategy for users who have settings encrypted with `libsecret` to switch over to the XDG secrets instead.

We accomplish this by doing the following:
1. Extend the `CryptoSettings::getKey()` method to pass in the encrypted settings file version. This lets us distinguish if a file was encrypted with `libsecret` or the XDG portal.
2. Replace `LinuxCryptoSettings` with a wrapper that checks for a key in `libsecret` to use as a fallback if a V1 file is found, otherwise it just wraps `XdgCryptoSettings` instead.
3. Add some code to delete the keys in `libsecret` once the user attempts to write a file with an XDG secret.

Along the way, we found a bug (or quirk?). When the application is launched via the old `/etc/xdg/autostart` handlers, this results in the application being unassociated with a systemd scope. This means that any attempt to use an XDG portal results in the portals being unable to figure out the application ID. This can result in the application getting a different set of keys than when launched via the `.desktop` file. Different keys results in a failure to read the settings files, which results in an apparent loss of settings. Luckily for us, this can be addressed by using the XDG [Background Portal](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.Background.html) for launching at boot... which we also have implemented as a part of the Flatpak work.

There is a potential bug in here though, or maybe a just a developer annoyance. Because the XDG secrets portal is sensitive to the application ID (which in turn is derived from the systemd scopes it is launched in). We wind up with different encryption keys if we launch it via the application menu (which winds up with the proper scopes and app IDs) vs. when we start it manually on the command line (which gets no scope).

And there seems to be something odd in the RPM build world that breaks when trying to include the Qt6 private GUI libraries (for the XDG Portal helpers). This doesn't seem to cause problems on Fedora 39 or later, so we have also included an update to the Fedora build images here as well (they were long overdue for an update anyways as the old versions have been EOL for a number of months).

## Reference
JIRA Issue: [VPN-6422](https://mozilla-hub.atlassian.net/browse/VPN-6422)
User bug reports:
- #9624
- #6607
- #6150 

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-6422]: https://mozilla-hub.atlassian.net/browse/VPN-6422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ