### PR TITLE
Use a different token for dependabot PRs

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -111,7 +111,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
-          token: ${{ secrets.WIKI_TOKEN }}
+          token: ${{ secrets.DEPENDABOT_TOKEN }}
 
       - name: Install pip tools
         shell: bash


### PR DESCRIPTION
## Description
In PR #9915 we tried to add a github workflow to keep the flatpak crates updated whenever dependabot tries to apply an update. And this worked great in PRs, but it failed as soon as dependabot tried to update a crate for real. The root of the issue is that dependabot pull requsts are explicitly prohibited from accessing repository secrets, where the `WIKI_TOKEN` was set.

We can work around the issue by creating a separate token just for dependabot and installing it into the "Dependabot secrets" instead. I have created a new token for this purpose, and named it `DEPENDABOT_TOKEN` so in theory we just need to update the workflow to use this secret and it should start working again.

## Reference
Flatpak crate update PR #9915

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
