### PR TITLE
VPN-3112: Auto start breadcrumb on Android

### DIFF
--- a/nebula/ui/components/CMakeLists.txt
+++ b/nebula/ui/components/CMakeLists.txt
@@ -36,6 +36,7 @@ qt_add_qml_module(components
          MZHeaderLink.qml
          MZHeadline.qml
          MZHelpSheet.qml
+         MZLinkRow.qml
          MZLottieAnimation.qml
          MZIconAndLabel.qml
          MZIconButton.qml

--- a/nebula/ui/components/MZBottomSheet.qml
+++ b/nebula/ui/components/MZBottomSheet.qml
@@ -17,7 +17,7 @@ import Mozilla.Shared 1.0
       contentItem: ColumnLayout {
           Rectangle {
               anchors.left: parent.left
-              anchors. right: parent.right
+              anchors.right: parent.right
               height: 20
               color: "green"
 

--- a/nebula/ui/components/MZExternalLinkListItem.qml
+++ b/nebula/ui/components/MZExternalLinkListItem.qml
@@ -10,39 +10,18 @@ import Mozilla.Shared 1.0
 // MZExternalLinkListItem
 MZClickableRow {
     property alias title: title.text
-    property alias subLabelText: subLabel.text
     property string iconSource:  "qrc:/nebula/resources/externalLink.svg"
     property alias iconMirror: icon.mirror
 
     backgroundColor: MZTheme.theme.clickableRowBlue
 
     RowLayout {
-        // these next 3 anchors are messing stuff up b/c I'm in a layout
         anchors.fill: parent
         anchors.leftMargin: MZTheme.theme.windowMargin / 2
         anchors.rightMargin: MZTheme.theme.windowMargin / 2
 
-        ColumnLayout {
-            // height: 40 - this seemingly has done nothing
-            Layout.fillWidth: true
-            // Layout.height: 40
-            // implicitHeight
-            // Layout.minimumHeight: 50
-            spacing: 1
-
-            MZBoldLabel {
-                id: title
-                Layout.fillWidth: true
-            }
-
-            MZTextBlock {
-                id: subLabel
-                Layout.fillWidth: true
-
-                font.pixelSize: MZTheme.theme.fontSizeSmall
-                visible: !!text.length
-                wrapMode: Text.Wrap
-            }
+        MZBoldLabel {
+            id: title
         }
 
         Item {

--- a/nebula/ui/components/MZExternalLinkListItem.qml
+++ b/nebula/ui/components/MZExternalLinkListItem.qml
@@ -10,18 +10,39 @@ import Mozilla.Shared 1.0
 // MZExternalLinkListItem
 MZClickableRow {
     property alias title: title.text
+    property alias subLabelText: subLabel.text
     property string iconSource:  "qrc:/nebula/resources/externalLink.svg"
     property alias iconMirror: icon.mirror
 
     backgroundColor: MZTheme.theme.clickableRowBlue
 
     RowLayout {
+        // these next 3 anchors are messing stuff up b/c I'm in a layout
         anchors.fill: parent
         anchors.leftMargin: MZTheme.theme.windowMargin / 2
         anchors.rightMargin: MZTheme.theme.windowMargin / 2
 
-        MZBoldLabel {
-            id: title
+        ColumnLayout {
+            // height: 40 - this seemingly has done nothing
+            Layout.fillWidth: true
+            // Layout.height: 40
+            // implicitHeight
+            // Layout.minimumHeight: 50
+            spacing: 1
+
+            MZBoldLabel {
+                id: title
+                Layout.fillWidth: true
+            }
+
+            MZTextBlock {
+                id: subLabel
+                Layout.fillWidth: true
+
+                font.pixelSize: MZTheme.theme.fontSizeSmall
+                visible: !!text.length
+                wrapMode: Text.Wrap
+            }
         }
 
         Item {

--- a/nebula/ui/components/MZLinkRow.qml
+++ b/nebula/ui/components/MZLinkRow.qml
@@ -9,14 +9,15 @@ import Mozilla.Shared 1.0
         
         
 RowLayout {
-    id: toggleRow
+    id: linkRow
     Layout.fillWidth: true
     Layout.rightMargin: MZTheme.theme.windowMargin
     Layout.leftMargin: MZTheme.theme.windowMargin
-    property string destinationUrl: ""
     property alias title: label.text
     property alias subLabelText: subLabel.text
     property var accessibleName: ""
+
+    signal clicked()
 
     spacing: 16
     Accessible.name: accessibleName
@@ -69,6 +70,6 @@ RowLayout {
             source: "qrc:/nebula/resources/externalLink.svg"
             anchors.centerIn: parent
         }
-        onClicked: MZUrlOpener.openUrl(destinationUrl)
+        onClicked: linkRow.clicked()
     }
 }

--- a/nebula/ui/components/MZLinkRow.qml
+++ b/nebula/ui/components/MZLinkRow.qml
@@ -1,0 +1,74 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import QtQuick 2.5
+import QtQuick.Layouts 1.14
+
+import Mozilla.Shared 1.0        
+        
+        
+RowLayout {
+    id: toggleRow
+    Layout.fillWidth: true
+    Layout.rightMargin: MZTheme.theme.windowMargin
+    Layout.leftMargin: MZTheme.theme.windowMargin
+    property string destinationUrl: ""
+    property alias title: label.text
+    property alias subLabelText: subLabel.text
+    property var accessibleName: ""
+
+    spacing: 16
+    Accessible.name: accessibleName
+
+    ColumnLayout {
+        Layout.fillWidth: true
+        Layout.alignment: Qt.AlignTop
+
+        spacing: 0
+
+        MZInterLabel {
+            id: label
+            Layout.fillWidth: true
+            text: ""
+            color: MZTheme.theme.fontColorDark
+            horizontalAlignment: Text.AlignLeft
+            visible: !!text.length
+            Layout.topMargin: 10
+        }
+
+        MZTextBlock {
+            id: subLabel
+
+            Layout.fillWidth: true
+            text: ""
+            font.pixelSize: MZTheme.theme.fontSizeSmall
+            visible: !!text.length
+            wrapMode: Text.Wrap
+            verticalAlignment: Text.AlignVCenter
+        }
+
+        Rectangle {
+            id: divider
+
+            Layout.topMargin: MZTheme.theme.toggleRowDividerSpacing
+            Layout.fillWidth: true
+            Layout.preferredHeight: 1
+
+            color: MZTheme.colors.grey10
+        }
+    }
+
+    MZIconButton {
+        id: icon
+        Layout.alignment: Qt.AlignTop
+        Layout.preferredHeight: 50
+        Layout.preferredWidth: 50
+        buttonColorScheme: MZTheme.theme.clickableRowBlue
+        MZIcon {
+            source: "qrc:/nebula/resources/externalLink.svg"
+            anchors.centerIn: parent
+        }
+        onClicked: MZUrlOpener.openUrl(destinationUrl)
+    }
+}

--- a/nebula/ui/components/qmldir
+++ b/nebula/ui/components/qmldir
@@ -34,6 +34,7 @@ MZInformationCard 0.1 MZInformationCard.qml
 MZInterLabel 0.1 MZInterLabel.qml
 MZLightLabel 0.1 MZLightLabel.qml
 MZLinkButton 0.1 MZLinkButton.qml
+MZLinkRow 0.1 MZLinkRow.qml
 MZList 0.1 MZList.qml
 MZLoader 0.1 MZLoader.qml
 MZLogsButton 0.1 MZLogsButton.qml

--- a/src/constants.h
+++ b/src/constants.h
@@ -211,6 +211,9 @@ constexpr const char* SUMO_MULTIHOP =
     "https://support.mozilla.org/kb/"
     "multi-hop-encrypt-your-data-twice-enhanced-security";
 
+constexpr const char* SUMO_ALWAYS_ON_ANDROID =
+    "https://support.mozilla.org/kb/how-enable-always-vpn-android";
+
 PRODBETAEXPR(QString, contactSupportUrl, "https://accounts.firefox.com/support",
              "https://accounts.stage.mozaws.net/support")
 

--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -1355,6 +1355,10 @@ void MozillaVPN::registerUrlOpenerLabels() {
 
   uo->registerUrlLabel("sumoMultihop",
                        []() -> QString { return Constants::SUMO_MULTIHOP; });
+
+  uo->registerUrlLabel("sumoAlwaysOnAndroid", []() -> QString {
+    return Constants::SUMO_ALWAYS_ON_ANDROID;
+  });
 }
 
 void MozillaVPN::errorHandled() {

--- a/src/ui/screens/settings/ViewPreferences.qml
+++ b/src/ui/screens/settings/ViewPreferences.qml
@@ -31,6 +31,34 @@ MZViewBase {
 
         spacing: MZTheme.theme.windowMargin
 
+        // MZTextBlock {
+        //     id: subLabel
+        //     Layout.fillWidth: true
+
+        //     text: "HELLO WORLD WE AR EMULTILINE>HELLO WORLD WE AR EMULTILINE>HELLO WORLD WE AR EMULTILINE>HELLO WORLD WE AR EMULTILINE>HELLO WORLD WE AR EMULTILINE>HELLO WORLD WE AR EMULTILINE>HELLO WORLD WE AR EMULTILINE>HELLO WORLD WE AR EMULTILIN"
+        //     font.pixelSize: MZTheme.theme.fontSizeSmall
+        //     visible: !!text.length
+        //     wrapMode: Text.Wrap
+        // }
+
+        MZExternalLinkListItem {
+            objectName: "androidStartAtBootLink"
+
+            // height: 80
+            // canGrowVertical: false
+            accessibleName: _startAtBootTitle
+            title: _startAtBootTitle
+            subLabelText: MZI18n.SettingsStartAtBootSubtitle
+            iconSource: "qrc:/nebula/resources/externalLink.svg"
+            visible: Qt.platform.os === "android"
+            backgroundColor: MZTheme.theme.clickableRowBlue
+            Layout.fillWidth: true
+            Layout.topMargin: MZTheme.theme.toggleRowDividerSpacing
+            Layout.rightMargin: MZTheme.theme.windowMargin
+            Layout.leftMargin: MZTheme.theme.windowMargin
+            onClicked: MZUrlOpener.openUrl("https://support.mozilla.org/kb/how-enable-always-vpn-android")
+        }
+
         MZToggleRow {
             objectName: "startAtBootToogle"
 

--- a/src/ui/screens/settings/ViewPreferences.qml
+++ b/src/ui/screens/settings/ViewPreferences.qml
@@ -31,32 +31,14 @@ MZViewBase {
 
         spacing: MZTheme.theme.windowMargin
 
-        // MZTextBlock {
-        //     id: subLabel
-        //     Layout.fillWidth: true
-
-        //     text: "HELLO WORLD WE AR EMULTILINE>HELLO WORLD WE AR EMULTILINE>HELLO WORLD WE AR EMULTILINE>HELLO WORLD WE AR EMULTILINE>HELLO WORLD WE AR EMULTILINE>HELLO WORLD WE AR EMULTILINE>HELLO WORLD WE AR EMULTILINE>HELLO WORLD WE AR EMULTILIN"
-        //     font.pixelSize: MZTheme.theme.fontSizeSmall
-        //     visible: !!text.length
-        //     wrapMode: Text.Wrap
-        // }
-
-        MZExternalLinkListItem {
+        MZLinkRow {
             objectName: "androidStartAtBootLink"
 
-            // height: 80
-            // canGrowVertical: false
             accessibleName: _startAtBootTitle
             title: _startAtBootTitle
             subLabelText: MZI18n.SettingsStartAtBootSubtitle
-            iconSource: "qrc:/nebula/resources/externalLink.svg"
             visible: Qt.platform.os === "android"
-            backgroundColor: MZTheme.theme.clickableRowBlue
-            Layout.fillWidth: true
-            Layout.topMargin: MZTheme.theme.toggleRowDividerSpacing
-            Layout.rightMargin: MZTheme.theme.windowMargin
-            Layout.leftMargin: MZTheme.theme.windowMargin
-            onClicked: MZUrlOpener.openUrl("https://support.mozilla.org/kb/how-enable-always-vpn-android")
+            destinationUrl: "https://support.mozilla.org/kb/how-enable-always-vpn-android"
         }
 
         MZToggleRow {

--- a/src/ui/screens/settings/ViewPreferences.qml
+++ b/src/ui/screens/settings/ViewPreferences.qml
@@ -38,7 +38,7 @@ MZViewBase {
             title: _startAtBootTitle
             subLabelText: MZI18n.SettingsStartAtBootSubtitle
             visible: Qt.platform.os === "android"
-            destinationUrl: "https://support.mozilla.org/kb/how-enable-always-vpn-android"
+            onClicked: MZUrlOpener.openUrlLabel("sumoAlwaysOnAndroid")
         }
 
         MZToggleRow {


### PR DESCRIPTION
## Description

Adding a row with a link to the help article for Android start on boot. (Users need to set this up from Android Settings themselves.)

While the Figma (attached to the ticket) for this has link icon center justified (along with the toggle), I made this top justified to match what the toggle actually looks like.

While there is a similar looking component on the help screen, it is not a row - and didn't work here. I also tried adjusting another component to make it work as a link row, but ultimately Lesley helped me realize that we needed to create a new component for this situation.

<img width="233" alt="Screenshot 27" src="https://github.com/user-attachments/assets/73e2fac3-2d29-4d3d-9c9d-50d93cb8455a">

## Reference

VPN-3112

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
