### PR TITLE
VPN-6622: Fix broken device language for Chinese

### DIFF
--- a/src/localizer.cpp
+++ b/src/localizer.cpp
@@ -79,8 +79,14 @@ QList<QPair<QString, QString>> Localizer::parseBCP47Languages(
 
     // Chinese is often reported as `zh-Hant-HK`, and we want the middle
     // section.
-    QString country = parts[1];
-    if (country.length() == 2 || country == "Hans" || country == "Hant") {
+    QString script = parts[1];
+    if (script == "Hans" || script == "Hant") {
+      codes.append(QPair<QString, QString>{parts[0], script});
+      continue;
+    }
+
+    QString country = parts.last();
+    if (country.length() == 2) {
       codes.append(QPair<QString, QString>{parts[0], country});
       continue;
     }

--- a/src/localizer.cpp
+++ b/src/localizer.cpp
@@ -77,7 +77,8 @@ QList<QPair<QString, QString>> Localizer::parseBCP47Languages(
       continue;
     }
 
-    // Chinese is often reported as `zh-Hant-HK`, and we want the middle section.
+    // Chinese is often reported as `zh-Hant-HK`, and we want the middle
+    // section.
     QString country = parts[1];
     if (country.length() == 2 || country == "Hans" || country == "Hant") {
       codes.append(QPair<QString, QString>{parts[0], country});
@@ -100,14 +101,17 @@ QList<QPair<QString, QString>> Localizer::parseIOSLanguages(
     // The language code comes in the format <language>-<country> or
     // <language>-<script>-<country>.
     // For an iOS device set to these 6 languages: Chinese Traditional (Macao),
-    // Chinese Traditional, Chinese Simplified, English, Mexican Spanish, Spanish
-    // ...we get these language codes: [zh-Hant-MO,zh-Hant-US,zh-Hans-US,en-US,es-MX,es-US]
-    // iOS shows the 2 part versions for nearly all languages, and shows the 3 part version
-    // only when there is a script - like for Chinese variants.
-    // Thus, we can pull the second chunk of the locale string in all cases to get the
-    // translations flow required by our app. That second chunk gives the country for all
-    // languages except Chinese, where it gives the script - and in both these
-    // situations, this is what we want (script for Chinese, country for all others).
+    // Chinese Traditional, Chinese Simplified, English, Mexican Spanish,
+    // Spanish
+    // ...we get these language codes:
+    // [zh-Hant-MO,zh-Hant-US,zh-Hans-US,en-US,es-MX,es-US]
+    // iOS shows the 2 part versions for nearly all languages, and shows the
+    // 3 part version only when there is a script - like for Chinese variants.
+    // Thus, we can pull the second chunk of the locale string in all cases to
+    // get the translations flow required by our app. That second chunk gives
+    // the country for all languages except Chinese, where it gives the script -
+    // and in both these situations, this is what we want (script for Chinese,
+    // country for all others).
     QString countryCode;
 
     QStringList parts = language.split('-');

--- a/src/localizer.cpp
+++ b/src/localizer.cpp
@@ -97,8 +97,17 @@ QList<QPair<QString, QString>> Localizer::parseIOSLanguages(
   QList<QPair<QString, QString>> codes;
 
   for (const QString& language : languages) {
-    // By documentation, the language code should be in the format
-    // <language>-<script>_<country>. And we don't care about the script.
+    // The language code comes in the format <language>-<country> or
+    // <language>-<script>-<country>.
+    // For an iOS device set to these 6 languages: Chinese Traditional (Macao),
+    // Chinese Traditional, Chinese Simplified, English, Mexican Spanish, Spanish
+    // ...we get these language codes: [zh-Hant-MO,zh-Hant-US,zh-Hans-US,en-US,es-MX,es-US]
+    // iOS shows the 2 part versions for nearly all languages, and shows the 3 part version
+    // only when there is a script - like for Chinese variants.
+    // Thus, we can pull the second chunk of the locale string in all cases to get the
+    // translations flow required by our app. That second chunk gives the country for all
+    // languages except Chinese, where it gives the script - and in both these
+    // situations, this is what we want (script for Chinese, country for all others).
     QString countryCode;
 
     QStringList parts = language.split('-');

--- a/src/localizer.cpp
+++ b/src/localizer.cpp
@@ -100,11 +100,28 @@ QList<QPair<QString, QString>> Localizer::parseIOSLanguages(
     // <language>-<script>_<country>. And we don't care about the script.
     QString countryCode;
 
-    QStringList parts = language.split('_');
+    QStringList parts = language.split('-');
     if (parts.length() > 1) {
       countryCode = parts[1];
     }
 
+    QString language = parts[0].split('-')[0];
+
+    // iOS reports Chinese as "zh-Hans" and "zh-Hant". However the app uses
+    // "zh_CN" and "zh-TW". We need to manually adjust these. More info:
+    // https://stackoverflow.com/questions/4892372/language-codes-for-simplified-chinese-and-traditional-chinese
+    // (For country-specific variants, it reports it as "zh-Hant-MO", etc. Since
+    // the app only looks at the strings before the 1st and 2nd dashes, we
+    // ignore the country - which is what we want to do, as we don't have
+    // translations for Chinese beyond simplified and traditional.)
+    if (language == "zh") {
+      if (countryCode == "Hans") {
+        countryCode = "CN";
+      }
+      if (countryCode == "Hant") {
+        countryCode = "TW";
+      }
+    }
     codes.append(QPair<QString, QString>{parts[0].split('-')[0], countryCode});
   }
 

--- a/src/localizer.cpp
+++ b/src/localizer.cpp
@@ -105,23 +105,6 @@ QList<QPair<QString, QString>> Localizer::parseIOSLanguages(
       countryCode = parts[1];
     }
 
-    QString language = parts[0].split('-')[0];
-
-    // iOS reports Chinese as "zh-Hans" and "zh-Hant". However the app uses
-    // "zh_CN" and "zh-TW". We need to manually adjust these. More info:
-    // https://stackoverflow.com/questions/4892372/language-codes-for-simplified-chinese-and-traditional-chinese
-    // (For country-specific variants, it reports it as "zh-Hant-MO", etc. Since
-    // the app only looks at the strings before the 1st and 2nd dashes, we
-    // ignore the country - which is what we want to do, as we don't have
-    // translations for Chinese beyond simplified and traditional.)
-    if (language == "zh") {
-      if (countryCode == "Hans") {
-        countryCode = "CN";
-      }
-      if (countryCode == "Hant") {
-        countryCode = "TW";
-      }
-    }
     codes.append(QPair<QString, QString>{parts[0].split('-')[0], countryCode});
   }
 
@@ -142,8 +125,27 @@ QString Localizer::systemLanguageCode() const {
 #endif
 
   for (const QPair<QString, QString>& language : uiLanguages) {
-    QString selectedLanguage =
-        findLanguageCode(language.first, language.second);
+    QString language = language.first;
+    QString locale = language.second;
+
+    // iOS reports Chinese as "zh-Hans" and "zh-Hant". Android reports
+    // them as "zh-CN" and "zh-Hans". However the app uses "zh-CN" and
+    // "zh-TW". We need to manually adjust these. More info:
+    // https://stackoverflow.com/questions/4892372/language-codes-for-simplified-chinese-and-traditional-chinese
+    // (For country-specific variants, it reports it as "zh-Hant-MO", etc. Since
+    // the app only looks at the strings before the 1st and 2nd dashes, we
+    // ignore the country - which is what we want to do, as we don't have
+    // translations for Chinese beyond simplified and traditional.)
+    if (language == "zh") {
+      if (locale == "Hans") {
+        locale = "CN";
+      }
+      if (locale == "Hant") {
+        locale = "TW";
+      }
+    }
+
+    QString selectedLanguage = findLanguageCode(language, locale);
     if (!selectedLanguage.isEmpty()) {
       return selectedLanguage;
     }

--- a/tests/unit_tests/testlocalizer.cpp
+++ b/tests/unit_tests/testlocalizer.cpp
@@ -158,17 +158,17 @@ void TestLocalizer::parseIOSLanguages_data() {
   {
     LanguageList a;
     a.append(QPair<QString, QString>{"aa", "bb"});
-    QTest::addRow("language_country") << QStringList("aa_bb") << a;
+    QTest::addRow("language-country") << QStringList("aa-bb") << a;
   }
   {
     LanguageList a;
-    a.append(QPair<QString, QString>{"aa", ""});
+    a.append(QPair<QString, QString>{"aa", "cc"});
     QTest::addRow("language-script") << QStringList("aa-cc") << a;
   }
   {
     LanguageList a;
-    a.append(QPair<QString, QString>{"aa", "bb"});
-    QTest::addRow("language-script_country") << QStringList("aa-cc_bb") << a;
+    a.append(QPair<QString, QString>{"aa", "cc"});
+    QTest::addRow("language-script-country") << QStringList("aa-cc-bb") << a;
   }
 }
 


### PR DESCRIPTION
## Description

On iOS, I believe all device locales were broken - we were just pulling the major language, regardless of the country.

3 things were preventing properly reporting the device locale:
1) iOS: We were breaking it on the wrong character within `parseIOSLanguages`. This resulted in never getting the country. Instead, that function was returning `es` instead of `es` and `MX`, etc. (I've added some comments to this method as well.)
2) iOS and Android: Chinese was reporting in as Hans and Hant, when consider it TW and CN. I've added some hacky code manually adjusting this.
3) Android: We were ignoring anything that wasn't 2 letters for a country/script. I've adjusted this to also accept "Hans" and "Hant".

## Reference

VPN-6622

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
