### PR TITLE
VPN-6630: Fix disappearing toggle in StateOnPartial

### DIFF
--- a/src/ui/screens/home/controller/VPNToggle.qml
+++ b/src/ui/screens/home/controller/VPNToggle.qml
@@ -104,6 +104,7 @@ MZButtonBase {
                 target: toggleButton
                 //% "Turn VPN on"
                 toolTipTitle: qsTrId("vpn.toggle.on")
+                toggleColor: MZTheme.theme.vpnToggleDisconnected
             }
         },
 
@@ -266,7 +267,7 @@ MZButtonBase {
         radius: height / 2
         border.color: toggleColor.focusBorder
         color: MZTheme.theme.transparent
-        opacity: toggleButton.activeFocus && (VPNController.state === VPNController.StateOn || VPNController.state === VPNController.StateSilentSwitching || VPNController.state === VPNController.StateOff) ? 1 : 0
+        opacity: toggleButton.activeFocus && (VPNController.state === VPNController.StateOn || VPNController.state === VPNController.StateOnPartial || VPNController.state === VPNController.StateSilentSwitching || VPNController.state === VPNController.StateOff) ? 1 : 0
 
         MZFocusOutline {
             id: vpnFocusOutline


### PR DESCRIPTION
## Description

In StateOnPartial, the VPNToggle can easily 'disappear' after navigating to and fro ScreenHome because of a missing custom property in the StateOnPartial state changes. This adds that property and also fixes the toggle's interaction UI on focus/StateOnPartial.

## Reference

    i.e Jira or Github issue URL

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
