### PR TITLE
VPN-6641: Send connection health info to ext in StateOnPartial

### DIFF
--- a/src/connectionhealth.cpp
+++ b/src/connectionhealth.cpp
@@ -99,8 +99,10 @@ void ConnectionHealth::startActive(const QString& serverIpv4Gateway,
                                    const QString& deviceIpv4Address) {
   logger.debug() << "ConnectionHealth active started";
 
-  bool isNotOnOrOnPartial = MozillaVPN::instance()->controller()->state() != Controller::StateOn &&
-    MozillaVPN::instance()->controller()->state() != Controller::StateOnPartial;
+  bool isNotOnOrOnPartial =
+      MozillaVPN::instance()->controller()->state() != Controller::StateOn &&
+      MozillaVPN::instance()->controller()->state() !=
+          Controller::StateOnPartial;
 
   if (serverIpv4Gateway.isEmpty() || isNotOnOrOnPartial) {
     logger.info() << "ConnectionHealth not starting because no connection";
@@ -155,7 +157,8 @@ void ConnectionHealth::setStability(ConnectionStability stability) {
   // setStability. Do not record count metrics in these cases.
   Controller::State state = MozillaVPN::instance()->controller()->state();
   if (state == Controller::StateOn || state == Controller::StateSwitching ||
-      state == Controller::StateSilentSwitching || state == Controller::StateOnPartial) {
+      state == Controller::StateSilentSwitching ||
+      state == Controller::StateOnPartial) {
     recordMetrics(m_stability, stability);
   }
 

--- a/src/connectionhealth.cpp
+++ b/src/connectionhealth.cpp
@@ -99,8 +99,10 @@ void ConnectionHealth::startActive(const QString& serverIpv4Gateway,
                                    const QString& deviceIpv4Address) {
   logger.debug() << "ConnectionHealth active started";
 
-  if (serverIpv4Gateway.isEmpty() ||
-      MozillaVPN::instance()->controller()->state() != Controller::StateOn) {
+  bool isNotOnOrOnPartial = MozillaVPN::instance()->controller()->state() != Controller::StateOn &&
+    MozillaVPN::instance()->controller()->state() != Controller::StateOnPartial;
+
+  if (serverIpv4Gateway.isEmpty() || isNotOnOrOnPartial) {
     logger.info() << "ConnectionHealth not starting because no connection";
     return;
   }
@@ -153,11 +155,11 @@ void ConnectionHealth::setStability(ConnectionStability stability) {
   // setStability. Do not record count metrics in these cases.
   Controller::State state = MozillaVPN::instance()->controller()->state();
   if (state == Controller::StateOn || state == Controller::StateSwitching ||
-      state == Controller::StateSilentSwitching) {
+      state == Controller::StateSilentSwitching || state == Controller::StateOnPartial) {
     recordMetrics(m_stability, stability);
   }
 
-  if (stability == Unstable) {
+  if (state != Controller::StateOnPartial && stability == Unstable) {
     MozillaVPN::instance()->silentSwitch();
   }
 
@@ -180,6 +182,7 @@ void ConnectionHealth::connectionStateChanged() {
   }
 
   switch (state) {
+    case Controller::StateOnPartial:
     case Controller::StateOn:
       MozillaVPN::instance()->controller()->getStatus(
           [this](const QString& serverIpv4Gateway,

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -867,7 +867,8 @@ void Controller::getStatus(
                      uint64_t rxBytes)>
       callback = std::move(a_callback);
 
-  if (m_state != StateOn && m_state != StateConfirming && m_state != StateOnPartial) {
+  if (m_state != StateOn && m_state != StateConfirming &&
+      m_state != StateOnPartial) {
     callback(QString(), QString(), 0, 0);
     return;
   }

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -867,7 +867,7 @@ void Controller::getStatus(
                      uint64_t rxBytes)>
       callback = std::move(a_callback);
 
-  if (m_state != StateOn && m_state != StateConfirming) {
+  if (m_state != StateOn && m_state != StateConfirming && m_state != StateOnPartial) {
     callback(QString(), QString(), 0, 0);
     return;
   }

--- a/src/ui/screens/home/controller/ConnectionStability.qml
+++ b/src/ui/screens/home/controller/ConnectionStability.qml
@@ -69,7 +69,7 @@ Item {
 
                 PropertyChanges {
                     target: stability
-                    visible: true
+                    visible: (VPNController.state !== VPNController.StateOnPartial)
                     opacity: 1
                 }
                 PropertyChanges {
@@ -89,6 +89,10 @@ Item {
             State {
                 name: VPNConnectionHealth.NoSignal
                 extend: VPNConnectionHealth.Unstable
+                PropertyChanges {
+                    target: stability
+                    visible: (VPNController.state !== VPNController.StateOnPartial)
+                }
                 PropertyChanges {
                     target: stabilityLabel
                     color: MZTheme.theme.red

--- a/src/ui/screens/home/controller/ControllerImage.qml
+++ b/src/ui/screens/home/controller/ControllerImage.qml
@@ -302,6 +302,9 @@ Rectangle {
     Connections{
         target: VPNConnectionHealth
         function onStabilityChanged() {
+            if (VPNController.state === VPNController.StateOnPartial) {
+                return;
+            }
             switch(VPNConnectionHealth.stability) {
                 case(VPNConnectionHealth.NoSignal):
                     insetCircle.color = MZTheme.colors.error.default;


### PR DESCRIPTION
## Description

Here we make adjustments to the UI and to ConnectionHealth to provide connection stability updates to the extension when the client is in StateOnPartial. This allows the extension to surface "No Signal" / "Unstable" UI in the tool bar icon and popup. The UI changes are to prevent connection stability UI changes in the VPN client when in StateOnPartial.

## Reference

VPN-6641

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
