### PR TITLE
VPN-6640: Fix crash on reset and quit

### DIFF
--- a/src/platforms/ios/iosiaphandler.mm
+++ b/src/platforms/ios/iosiaphandler.mm
@@ -200,8 +200,6 @@ bool s_transactionsProcessed = false;
 @end
 
 IOSIAPHandler::IOSIAPHandler(QObject* parent) : PurchaseIAPHandler(parent) {
-  MZ_COUNT_CTOR(IOSIAPHandler);
-
   if (@available(iOS 15, *)) {
     swiftIAPHandler = [[InAppPurchaseHandler alloc]
         initWithErrorCallback:^(void) {
@@ -223,6 +221,7 @@ IOSIAPHandler::IOSIAPHandler(QObject* parent) : PurchaseIAPHandler(parent) {
           }
         }];
   } else {
+    MZ_COUNT_CTOR(IOSIAPHandler);
     m_delegate = [[IOSIAPHandlerDelegate alloc] initWithObject:this];
     [[SKPaymentQueue defaultQueue]
         addTransactionObserver:static_cast<IOSIAPHandlerDelegate*>(m_delegate)];
@@ -230,15 +229,15 @@ IOSIAPHandler::IOSIAPHandler(QObject* parent) : PurchaseIAPHandler(parent) {
 }
 
 IOSIAPHandler::~IOSIAPHandler() {
-  MZ_COUNT_DTOR(IOSIAPHandler);
-
-  IOSIAPHandlerDelegate* delegate = static_cast<IOSIAPHandlerDelegate*>(m_delegate);
-  [[SKPaymentQueue defaultQueue] removeTransactionObserver:delegate];
-
-  [delegate dealloc];
-  m_delegate = nullptr;
   if (@available(iOS 15, *)) {
     swiftIAPHandler = nullptr;
+  } else {
+    MZ_COUNT_DTOR(IOSIAPHandler);
+    IOSIAPHandlerDelegate* delegate = static_cast<IOSIAPHandlerDelegate*>(m_delegate);
+    [[SKPaymentQueue defaultQueue] removeTransactionObserver:delegate];
+
+    [delegate dealloc];
+    m_delegate = nullptr;
   }
 }
 

--- a/src/platforms/ios/iosiaphandler.mm
+++ b/src/platforms/ios/iosiaphandler.mm
@@ -200,6 +200,8 @@ bool s_transactionsProcessed = false;
 @end
 
 IOSIAPHandler::IOSIAPHandler(QObject* parent) : PurchaseIAPHandler(parent) {
+  MZ_COUNT_CTOR(IOSIAPHandler);
+
   if (@available(iOS 15, *)) {
     swiftIAPHandler = [[InAppPurchaseHandler alloc]
         initWithErrorCallback:^(void) {
@@ -221,7 +223,6 @@ IOSIAPHandler::IOSIAPHandler(QObject* parent) : PurchaseIAPHandler(parent) {
           }
         }];
   } else {
-    MZ_COUNT_CTOR(IOSIAPHandler);
     m_delegate = [[IOSIAPHandlerDelegate alloc] initWithObject:this];
     [[SKPaymentQueue defaultQueue]
         addTransactionObserver:static_cast<IOSIAPHandlerDelegate*>(m_delegate)];
@@ -229,10 +230,11 @@ IOSIAPHandler::IOSIAPHandler(QObject* parent) : PurchaseIAPHandler(parent) {
 }
 
 IOSIAPHandler::~IOSIAPHandler() {
+  MZ_COUNT_DTOR(IOSIAPHandler);
+
   if (@available(iOS 15, *)) {
     swiftIAPHandler = nullptr;
   } else {
-    MZ_COUNT_DTOR(IOSIAPHandler);
     IOSIAPHandlerDelegate* delegate = static_cast<IOSIAPHandlerDelegate*>(m_delegate);
     [[SKPaymentQueue defaultQueue] removeTransactionObserver:delegate];
 


### PR DESCRIPTION
## Description

Reset and quit was crashing the app, caused by #9873.

Something that made this take a lot longer: There is a pre-existing issue that when on a debug build, reset and quit doesn't work (at least when the VPN is active). That predates #9873, and is not fixed here. But you must build a release build to have this work.

I tested for both the iOS 15+ code path and the iOS 14 code path:
- reset before logged in
- reset when logged in, VPN on
- reset when logged in, VPN off

## Reference

VPN-6640

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
