### PR TITLE
FXVPN-213: Fix timer wonkiness in extension

### DIFF
--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -344,7 +344,12 @@ qint64 Controller::connectionTimestamp() const {
     case Controller::State::StateSilentSwitching:
       [[fallthrough]];
     case Controller::State::StateSwitching:
-      return m_connectedTimeInUTC.toMSecsSinceEpoch();
+      if (m_connectedTimeInUTC.isValid()) {
+        return m_connectedTimeInUTC.toMSecsSinceEpoch();
+      }
+      const QDateTime& initialTimeStampForExtension =
+          QDateTime::currentDateTimeUtc();
+      return initialTimeStampForExtension.toMSecsSinceEpoch();
   }
   Q_UNREACHABLE();
 }


### PR DESCRIPTION
## Description
Occasionally, when starting the VPN from the extension, the client sends an invalid initial `connectedSince` value to the extension resulting in the extension timer erroneously reporting that the extension has been connected for > 480,000 hours. This PR checks that `m_connectedTimeInUTC` is valid before converting it to milliseconds and sending it to the extension and creates a new `timStampForExtension` if it isn't. 

## Reference

FXVPN-213
## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
