### PR TITLE
Fix build errors from deprecated `QByteArray::count()`, `QVariant::type()`, `QEventPoint::pos()`

### DIFF
--- a/src/inspector/inspectorhandler.cpp
+++ b/src/inspector/inspectorhandler.cpp
@@ -287,7 +287,7 @@ static QList<InspectorCommand> s_commands{
           Q_ASSERT(property.isValid());
 
           QVariant value = QVariant::fromValue(arguments[3]);
-          if (!value.canConvert(property.type())) {
+          if (!value.canConvert(property.metaType())) {
             obj["error"] = "Property value is invalid";
             return obj;
           }
@@ -349,7 +349,7 @@ static QList<InspectorCommand> s_commands{
           Q_ASSERT(property.isValid());
 
           QVariant value = QVariant::fromValue(arguments[4]);
-          if (!value.canConvert(property.type())) {
+          if (!value.canConvert(property.metaType())) {
             obj["error"] = "Property value is invalid";
             return obj;
           }
@@ -500,13 +500,13 @@ static QList<InspectorCommand> s_commands{
           Q_ASSERT(property.isValid());
 
           QVariant value = QVariant::fromValue(arguments[2]);
-          if (value.canConvert(property.type())) {
+          if (value.canConvert(property.metaType())) {
             property.write(settingsHolder, value);
             return obj;
           }
 
           obj["error"] = QString("Property %1 has a non-supported type: %2")
-                             .arg(arguments[1], property.type());
+                             .arg(arguments[1], property.typeName());
           return obj;
         }},
 
@@ -546,7 +546,7 @@ static QList<InspectorCommand> s_commands{
           }
 
           obj["error"] = QString("Property %1 has a non-supported type: %2")
-                             .arg(arguments[1], property.type());
+                             .arg(arguments[1], property.typeName());
           return obj;
         }},
 

--- a/src/itempicker.cpp
+++ b/src/itempicker.cpp
@@ -84,7 +84,7 @@ QList<QQuickItem*> ItemPicker::pickItem(QMouseEvent* event, QQuickItem* item) {
       continue;
     }
 
-    QPointF gpos = child->mapFromGlobal(event->globalPos());
+    QPointF gpos = child->mapFromGlobal(event->globalPosition());
     if (!child->contains(gpos)) {
       continue;
     }
@@ -99,7 +99,7 @@ QList<QQuickItem*> ItemPicker::pickItem(QMouseEvent* event, QQuickItem* item) {
         continue;
       }
 
-      QPointF gpos = child->mapFromGlobal(event->globalPos());
+      QPointF gpos = child->mapFromGlobal(event->globalPosition());
       if (!child->contains(gpos)) {
         continue;
       }
@@ -114,14 +114,14 @@ QList<QQuickItem*> ItemPicker::pickItem(QMouseEvent* event, QQuickItem* item) {
 QList<QQuickItem*> ItemPicker::pickItem(QTouchEvent* event, QQuickItem* item) {
   QList<QQuickItem*> list;
 
-  if (event->touchPoints().length() != 1) {
+  if (event->pointCount() != 1) {
     return list;
   }
 
   list.append(item);
 
-  QTouchEvent::TouchPoint point = event->touchPoints()[0];
-  QPointF pos = point.pos();
+  QTouchEvent::TouchPoint point = event->point(0);
+  QPointF pos = point.position();
 
   for (QQuickItem* child : item->childItems()) {
     if (!child->isVisible() || !child->isEnabled()) {

--- a/src/localsocketcontroller.cpp
+++ b/src/localsocketcontroller.cpp
@@ -9,6 +9,7 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QJsonValue>
+#include <QMetaType>
 
 #include "daemon/daemonerrors.h"
 #include "errorhandler.h"
@@ -380,7 +381,7 @@ void LocalSocketController::clearTimeout(const QString& responseType) {
   // here to add such a mechanism would risk a compatibility issue.
   for (QTimer* t : m_responseTimeouts) {
     QVariant timerResponseType = t->property("responseType");
-    if (timerResponseType.type() != QVariant::String) {
+    if (timerResponseType.typeId() != QMetaType::QString) {
       continue;
     }
     if (timerResponseType.toString() != responseType) {

--- a/src/networkrequest.cpp
+++ b/src/networkrequest.cpp
@@ -310,7 +310,7 @@ void NetworkRequest::processData(QNetworkReply::NetworkError error,
 }
 
 qint64 NetworkRequest::discardData() {
-  qint64 bytes = m_replyData.count();
+  qint64 bytes = m_replyData.size();
   if (m_reply != nullptr) {
     bytes += m_reply->skip(m_reply->bytesAvailable());
   }

--- a/src/platforms/linux/daemon/apptracker.cpp
+++ b/src/platforms/linux/daemon/apptracker.cpp
@@ -8,6 +8,7 @@
 
 #include <QDBusConnection>
 #include <QDBusInterface>
+#include <QMetaType>
 #include <QScopeGuard>
 #include <QtDBus/QtDBus>
 
@@ -70,7 +71,7 @@ void AppTracker::userCreated(uint userid, const QString& xdgRuntimePath) {
       new QDBusInterface(DBUS_SYSTEMD_SERVICE, DBUS_SYSTEMD_PATH,
                          DBUS_SYSTEMD_MANAGER, connection, this);
   QVariant qv = m_systemdInterface->property("ControlGroup");
-  if (!m_cgroupMount.isEmpty() && qv.type() == QVariant::String) {
+  if (!m_cgroupMount.isEmpty() && qv.typeId() == QMetaType::QString) {
     QString userCgroupPath = m_cgroupMount + qv.toString();
     logger.debug() << "Monitoring Control Groups v2 at:" << userCgroupPath;
 

--- a/src/platforms/linux/daemon/dbustypeslinux.h
+++ b/src/platforms/linux/daemon/dbustypeslinux.h
@@ -46,7 +46,7 @@ class DnsResolver : public QHostAddress {
     args.endStructure();
     if (family == AF_INET6) {
       ip.setAddress(data.constData());
-    } else if (data.count() >= 4) {
+    } else if (data.size() >= 4) {
       quint32 addrv4 = 0;
       addrv4 |= (data[0] << 24);
       addrv4 |= (data[1] << 16);

--- a/src/settings/setting.cpp
+++ b/src/settings/setting.cpp
@@ -4,6 +4,8 @@
 
 #include "settings/setting.h"
 
+#include <QMetaType>
+
 #include "leakdetector.h"
 #include "settingsmanager.h"
 
@@ -70,9 +72,9 @@ QString Setting::log() const {
     logLine.append(QString("%1 -> ").arg(m_key));
     QVariant value = get();
     switch (value.typeId()) {
-      case QVariant::List:
+      case QMetaType::QVariantList:
         [[fallthrough]];
-      case QVariant::StringList:
+      case QMetaType::QStringList:
         logLine.append(QString("[%1]").arg(value.toStringList().join(",")));
         break;
       default:

--- a/tests/unit/testmodels.cpp
+++ b/tests/unit/testmodels.cpp
@@ -7,6 +7,7 @@
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
+#include <QMetaType>
 
 #include "constants.h"
 #include "helper.h"
@@ -1632,9 +1633,9 @@ void TestModels::serverCountryModelFromJson() {
         QCOMPARE(m.data(index, ServerCountryModel::CodeRole), code);
 
         QFETCH(QVariant, cities);
-        Q_ASSERT(cities.typeId() == QVariant::List);
+        Q_ASSERT(cities.typeId() == QMetaType::QVariantList);
         QVariant cityData = m.data(index, ServerCountryModel::CitiesRole);
-        QCOMPARE(cityData.typeId(), QVariant::List);
+        QCOMPARE(cityData.typeId(), QMetaType::QVariantList);
         QCOMPARE(cities.toList().length(), cityData.toList().length());
         for (int i = 0; i < cities.toList().length(); i++) {
           QVERIFY(cityData.toList().at(0).canConvert<ServerCity*>());
@@ -1687,7 +1688,7 @@ void TestModels::serverCountryModelFromJson() {
 
         QFETCH(QVariant, cities);
         QVariant cityData = m.data(index, ServerCountryModel::CitiesRole);
-        QCOMPARE(cityData.typeId(), QVariant::List);
+        QCOMPARE(cityData.typeId(), QMetaType::QVariantList);
         QCOMPARE(cities.toList().length(), cityData.toList().length());
         for (int i = 0; i < cities.toList().length(); i++) {
           QVERIFY(cityData.toList().at(0).canConvert<ServerCity*>());


### PR DESCRIPTION
## Description

- Fixes #9966.

```
In file included from /build/source/build/src/mozillavpn_autogen/UM7GZO45JR/../../../../src/platforms/linux/daemon/dnsutilslinux.h:12,
                 from /build/source/build/src/mozillavpn_autogen/UM7GZO45JR/../../../../src/platforms/linux/daemon/dbusservice.h:13,
                 from /build/source/build/src/mozillavpn_autogen/UM7GZO45JR/moc_dbusservice.cpp:9,
                 from /build/source/build/src/mozillavpn_autogen/mocs_compilation.cpp:88:
/build/source/build/src/mozillavpn_autogen/UM7GZO45JR/../../../../src/platforms/linux/daemon/dbustypeslinux.h: In function 'const QDBusArgument& operator>>(const QDBusArgument&, DnsResolver&)':
/build/source/build/src/mozillavpn_autogen/UM7GZO45JR/../../../../src/platforms/linux/daemon/dbustypeslinux.h:49:26: error: 'qsizetype QByteArray::count() const' is deprecated: Use size() or length() instead. [-Werror=deprecated-declarations]
   49 |     } else if (data.count() >= 4) {
      |                ~~~~~~~~~~^~
In file included from /nix/store/bgfalfi93kbn8j1wfwz0x0dnk1wx9wdp-qtbase-6.8.0/include/QtCore/qstringview.h:10,
                 from /nix/store/bgfalfi93kbn8j1wfwz0x0dnk1wx9wdp-qtbase-6.8.0/include/QtCore/qchar.h:660,
                 from /nix/store/bgfalfi93kbn8j1wfwz0x0dnk1wx9wdp-qtbase-6.8.0/include/QtCore/qstring.h:14,
                 from /nix/store/bgfalfi93kbn8j1wfwz0x0dnk1wx9wdp-qtbase-6.8.0/include/QtCore/qcoreapplication.h:8,
                 from /nix/store/bgfalfi93kbn8j1wfwz0x0dnk1wx9wdp-qtbase-6.8.0/include/QtGui/qaccessible.h:17,
                 from /nix/store/bgfalfi93kbn8j1wfwz0x0dnk1wx9wdp-qtbase-6.8.0/include/QtGui/QAccessible:1,
                 from /build/source/build/src/mozillavpn_autogen/EWIEGA46WW/../../../../src/accessiblenotification.h:8,
                 from /build/source/build/src/mozillavpn_autogen/EWIEGA46WW/moc_accessiblenotification.cpp:9,
                 from /build/source/build/src/mozillavpn_autogen/mocs_compilation.cpp:2:
/nix/store/bgfalfi93kbn8j1wfwz0x0dnk1wx9wdp-qtbase-6.8.0/include/QtCore/qbytearray.h:501:22: note: declared here
  501 |     inline qsizetype count() const noexcept { return size(); }
      |                      ^~~~~
```

```
/build/source/src/platforms/linux/daemon/apptracker.cpp: In member function 'void AppTracker::userCreated(uint, const QString&)':
/build/source/src/platforms/linux/daemon/apptracker.cpp:73:42: error: 'QVariant::Type QVariant::type() const' is deprecated: Use typeId() or metaType(). [-Werror=deprecated-declarations]
   73 |   if (!m_cgroupMount.isEmpty() && qv.type() == QVariant::String) {
      |                                   ~~~~~~~^~
In file included from /nix/store/bgfalfi93kbn8j1wfwz0x0dnk1wx9wdp-qtbase-6.8.0/include/QtDBus/qtdbusglobal.h:9,
                 from /nix/store/bgfalfi93kbn8j1wfwz0x0dnk1wx9wdp-qtbase-6.8.0/include/QtDBus/qdbusconnection.h:8,
                 from /nix/store/bgfalfi93kbn8j1wfwz0x0dnk1wx9wdp-qtbase-6.8.0/include/QtDBus/QDBusConnection:1,
                 from /build/source/src/platforms/linux/daemon/apptracker.cpp:9:
/nix/store/bgfalfi93kbn8j1wfwz0x0dnk1wx9wdp-qtbase-6.8.0/include/QtCore/qvariant.h:433:10: note: declared here
  433 |     Type type() const
      |          ^~~~
```

```
/build/source/src/itempicker.cpp: In member function 'QList<QQuickItem*> ItemPicker::pickItem(QMouseEvent*, QQuickItem*)':
/build/source/src/itempicker.cpp:87:57: error: 'QPoint QMouseEvent::globalPos() const' is deprecated: Use globalPosition() [8;;https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wdeprecated-declarations-Werror=deprecated-declarations8;;]
   87 |     QPointF gpos = child->mapFromGlobal(event->globalPos());
      |                                         ~~~~~~~~~~~~~~~~^~
In file included from /nix/store/bgfalfi93kbn8j1wfwz0x0dnk1wx9wdp-qtbase-6.8.0/include/QtGui/QMouseEvent:1,
                 from /build/source/src/itempicker.cpp:9:
/nix/store/bgfalfi93kbn8j1wfwz0x0dnk1wx9wdp-qtbase-6.8.0/include/QtGui/qevent.h:224:19: note: declared here
  224 |     inline QPoint globalPos() const { return globalPosition().toPoint(); }
      |                   ^~~~~~~~~
/build/source/src/itempicker.cpp:102:59: error: 'QPoint QMouseEvent::globalPos() const' is deprecated: Use globalPosition() [8;;https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wdeprecated-declarations-Werror=deprecated-declarations8;;]
  102 |       QPointF gpos = child->mapFromGlobal(event->globalPos());
      |                                           ~~~~~~~~~~~~~~~~^~
/nix/store/bgfalfi93kbn8j1wfwz0x0dnk1wx9wdp-qtbase-6.8.0/include/QtGui/qevent.h:224:19: note: declared here
  224 |     inline QPoint globalPos() const { return globalPosition().toPoint(); }
      |                   ^~~~~~~~~
/build/source/src/itempicker.cpp: In member function 'QList<QQuickItem*> ItemPicker::pickItem(QTouchEvent*, QQuickItem*)':
/build/source/src/itempicker.cpp:117:25: error: 'const QList<QEventPoint>& QTouchEvent::touchPoints() const' is deprecated: Use points() [8;;https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wdeprecated-declarations-Werror=deprecated-declarations8;;]
  117 |   if (event->touchPoints().length() != 1) {
      |       ~~~~~~~~~~~~~~~~~~^~
/nix/store/bgfalfi93kbn8j1wfwz0x0dnk1wx9wdp-qtbase-6.8.0/include/QtGui/qevent.h:939:31: note: declared here
  939 |     const QList<QEventPoint> &touchPoints() const { return points(); }
      |                               ^~~~~~~~~~~
/build/source/src/itempicker.cpp:123:53: error: 'const QList<QEventPoint>& QTouchEvent::touchPoints() const' is deprecated: Use points() [8;;https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wdeprecated-declarations-Werror=deprecated-declarations8;;]
  123 |   QTouchEvent::TouchPoint point = event->touchPoints()[0];
      |                                   ~~~~~~~~~~~~~~~~~~^~
/nix/store/bgfalfi93kbn8j1wfwz0x0dnk1wx9wdp-qtbase-6.8.0/include/QtGui/qevent.h:939:31: note: declared here
  939 |     const QList<QEventPoint> &touchPoints() const { return points(); }
      |                               ^~~~~~~~~~~
/build/source/src/itempicker.cpp:124:26: error: 'QPointF QEventPoint::pos() const' is deprecated: Use position() [8;;https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wdeprecated-declarations-Werror=deprecated-declarations8;;]
  124 |   QPointF pos = point.pos();
      |                 ~~~~~~~~~^~
In file included from /nix/store/bgfalfi93kbn8j1wfwz0x0dnk1wx9wdp-qtbase-6.8.0/include/QtGui/qevent.h:20:
/nix/store/bgfalfi93kbn8j1wfwz0x0dnk1wx9wdp-qtbase-6.8.0/include/QtGui/qeventpoint.h:87:13: note: declared here
   87 |     QPointF pos() const { return position(); }
      |             ^~~
```

## Reference

https://code.qt.io/cgit/qt/qtbase.git/commit?id=65859635830b1476ce5c3e22f86438a08d4894cf
https://code.qt.io/cgit/qt/qtbase.git/commit/?id=11bad6109606794091adc3b8a14070ac09707f45
https://code.qt.io/cgit/qt/qtbase.git/commit/?id=24e52c10deedbaef833c0e2c3ee7bee03eacc4f5
https://code.qt.io/cgit/qt/qtbase.git/commit/?id=2692237bb1b0c0f50b7cc5d920eb8ab065063d47

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
