### PR TITLE
VPN-3112: read title for a11y link

### DIFF
--- a/nebula/ui/components/MZLinkRow.qml
+++ b/nebula/ui/components/MZLinkRow.qml
@@ -15,12 +15,11 @@ RowLayout {
     Layout.leftMargin: MZTheme.theme.windowMargin
     property alias title: label.text
     property alias subLabelText: subLabel.text
-    property var accessibleName: ""
 
     signal clicked()
 
     spacing: 16
-    Accessible.name: accessibleName
+    Accessible.name: title
 
     ColumnLayout {
         Layout.fillWidth: true
@@ -66,6 +65,7 @@ RowLayout {
         Layout.preferredHeight: 50
         Layout.preferredWidth: 50
         buttonColorScheme: MZTheme.theme.clickableRowBlue
+        accessibleName: title
         MZIcon {
             source: "qrc:/nebula/resources/externalLink.svg"
             anchors.centerIn: parent

--- a/src/ui/screens/settings/ViewPreferences.qml
+++ b/src/ui/screens/settings/ViewPreferences.qml
@@ -34,7 +34,6 @@ MZViewBase {
         MZLinkRow {
             objectName: "androidStartAtBootLink"
 
-            accessibleName: _startAtBootTitle
             title: _startAtBootTitle
             subLabelText: MZI18n.SettingsStartAtBootSubtitle
             visible: Qt.platform.os === "android"


### PR DESCRIPTION
## Description

QA caught that we're missing accessibility text for the button; it was reading as "unlabeled".

## Reference

VPN-3112

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
