### PR TITLE
VPN-6407: 15 minutes between daemon server switches

### DIFF
--- a/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/ConnectionHealth.kt
+++ b/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/ConnectionHealth.kt
@@ -11,8 +11,8 @@ import android.net.NetworkCapabilities
 import android.net.NetworkRequest
 import android.os.Build
 import android.os.CountDownTimer
-import mozilla.telemetry.glean.GleanTimerId
 import java.time.LocalDateTime
+import mozilla.telemetry.glean.GleanTimerId
 import org.mozilla.firefox.vpn.daemon.GleanMetrics.ConnectionHealth
 import org.mozilla.firefox.vpn.daemon.GleanMetrics.Session
 import java.util.concurrent.ExecutorService

--- a/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/ConnectionHealth.kt
+++ b/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/ConnectionHealth.kt
@@ -253,7 +253,7 @@ class ConnectionHealth(service: VPNService) {
                 }
 
                 Log.i(TAG, "Switch to fallback VPN server")
-                // We the server is online but the connection broke up, let's rest it
+                // The server is online but the connection broke up, let's reconnect to a new server.
                 mService.mainLooper.run {
                     // Silent server switch to a different server in same geo
                     Session.daemonSilentServerSwitch.record()

--- a/src/platforms/ios/ConnectionHealth.swift
+++ b/src/platforms/ios/ConnectionHealth.swift
@@ -30,7 +30,7 @@ class ConnectionHealth {
     private let toleranceTime = 1.0 // 1 seconds
     private var timer: Timer?
     private var nextPossibleServerSwitch = Date()
-    private let serverSwitchCooldownMinutes: TimeInterval = 60*5 // 5 minutes
+    private let serverSwitchCooldownMinutes: TimeInterval = 60*15 // 15 minutes
 
     private var lastHealthStatus: ConnectionStability = .pending
     private var connectionHealthTimerId: GleanTimerId? = nil


### PR DESCRIPTION
## Description

Based on the data coming back from this ticket, we decided to do server switches from the mobile daemons at most once every 15 minutes. On iOS this is simply changing a variable (we had previously done one at most every 5 minutes), and on Android we had to build some new logic in.

## Reference

VPN-6407

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
