### PR TITLE
VPN-6676 Include dns traffic in stateOnPartial

### DIFF
--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -592,7 +592,7 @@ QList<IPAddress> Controller::getAllowedIPAddressRanges(
 QList<IPAddress> Controller::getExtensionProxyAddressRanges(
     const Server& exitServer) {
   auto const dns = DNSHelper::getDNSDetails(exitServer.ipv4Gateway());
-  if (dns.dnsType == "Custom") {
+  if (dns.dnsType == "Custom" || dns.dnsType == "Default") {
     return {IPAddress(QHostAddress(exitServer.ipv4Gateway()), 32),
             IPAddress(QHostAddress(exitServer.ipv6Gateway()), 128),
             IPAddress(QHostAddress{MULLVAD_PROXY_RANGE},

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -592,7 +592,7 @@ QList<IPAddress> Controller::getAllowedIPAddressRanges(
 QList<IPAddress> Controller::getExtensionProxyAddressRanges(
     const Server& exitServer) {
   auto const dns = DNSHelper::getDNSDetails(exitServer.ipv4Gateway());
-  if (dns.dnsType == "Custom" || dns.dnsType == "Default") {
+  if (dns.dnsType == "Default" || dns.dnsType == "Custom") {
     return {IPAddress(QHostAddress(exitServer.ipv4Gateway()), 32),
             IPAddress(QHostAddress(exitServer.ipv6Gateway()), 128),
             IPAddress(QHostAddress{MULLVAD_PROXY_RANGE},

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -591,10 +591,19 @@ QList<IPAddress> Controller::getAllowedIPAddressRanges(
 // static
 QList<IPAddress> Controller::getExtensionProxyAddressRanges(
     const Server& exitServer) {
+  auto const dns = DNSHelper::getDNSDetails(exitServer.ipv4Gateway());
+  if (dns.dnsType == "Custom") {
+    return {IPAddress(QHostAddress(exitServer.ipv4Gateway()), 32),
+            IPAddress(QHostAddress(exitServer.ipv6Gateway()), 128),
+            IPAddress(QHostAddress{MULLVAD_PROXY_RANGE},
+                      MULLVAD_PROXY_RANGE_LENGTH)};
+  }
   return {
       IPAddress(QHostAddress(exitServer.ipv4Gateway()), 32),
       IPAddress(QHostAddress(exitServer.ipv6Gateway()), 128),
-      IPAddress(QHostAddress{MULLVAD_PROXY_RANGE}, MULLVAD_PROXY_RANGE_LENGTH)};
+      IPAddress(QHostAddress{MULLVAD_PROXY_RANGE}, MULLVAD_PROXY_RANGE_LENGTH),
+      IPAddress(QHostAddress(dns.ipAddress), 32),
+  };
 }
 
 void Controller::activateNext() {


### PR DESCRIPTION
## Description

In State on partial we allow wireguard to only route to a subset of ip adresses.
The default dns is the exit server, however if a privacy value is added, we currently dont add that private ip adress to the routes -> it's unreachable blocking stuff. 
