### PR TITLE
VPN-6408 and VPN-6678: Turn daemon server switches into round robin of servers, and fix DNS bug

### DIFF
--- a/android/common/src/main/java/org/mozilla/firefox/qt/common/CoreBinder.kt
+++ b/android/common/src/main/java/org/mozilla/firefox/qt/common/CoreBinder.kt
@@ -19,6 +19,7 @@ open class CoreBinder : Binder() {
         const val clearStorage = 17
         const val setGleanUploadEnabled = 18
         const val notificationPermissionFired = 19
+        const val silentServerSwitch = 20
     }
 
     /** The codes we Are Using in case of [dispatchEvent] */

--- a/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/ConnectionHealth.kt
+++ b/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/ConnectionHealth.kt
@@ -203,7 +203,8 @@ class ConnectionHealth(service: VPNService) {
 
             // Step 2: Are both the VPN-Gateway and the DNS reachable? (i.e is internet working?)
             val canReachGateway = vpnNetwork.getByName(gateway).isReachable(PING_TIMEOUT)
-            val canReachDNS = vpnNetwork.getByName(dns).isReachable(PING_TIMEOUT)
+            // For DNS, we check both the main DNS (gateway) and the specific value (which could be user-input DNS or privacy DNS, or may be gateway)
+            val canReachDNS = vpnNetwork.getByName(dns).isReachable(PING_TIMEOUT) || vpnNetwork.getByName(endpoint).isReachable(PING_TIMEOUT)
             if (canReachGateway && canReachDNS) {
                 recordMetrics(ConnectionStability.Stable)
 

--- a/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/ConnectionHealth.kt
+++ b/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/ConnectionHealth.kt
@@ -11,7 +11,6 @@ import android.net.NetworkCapabilities
 import android.net.NetworkRequest
 import android.os.Build
 import android.os.CountDownTimer
-import java.time.LocalDateTime
 import mozilla.telemetry.glean.GleanTimerId
 import org.mozilla.firefox.vpn.daemon.GleanMetrics.ConnectionHealth
 import org.mozilla.firefox.vpn.daemon.GleanMetrics.Session

--- a/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/VPNService.kt
+++ b/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/VPNService.kt
@@ -291,7 +291,7 @@ class VPNService : android.net.VpnService() {
             throw Error("no json config provided")
         }
         Log.sensitive(tag, json.toString())
-        val jServer: JSONObject = getServerConfig(json, useFallbackServer)
+        val jServer: JSONObject = getNextServerConfig(json, useFallbackServer)
         val wireguard_conf = buildWireguardConfig(jServer, json)
         val wgConfig: String = wireguard_conf.toWgUserspaceString()
         if (wgConfig.isEmpty()) {
@@ -589,10 +589,11 @@ class VPNService : android.net.VpnService() {
         return confBuilder.build()
     }
 
-    private fun getServerConfig(obj: JSONObject, useFallbackServer: Boolean): JSONObject {
+    private fun getNextServerConfig(obj: JSONObject, useFallbackServer: Boolean): JSONObject {
         if (!useFallbackServer) {
             currentServerConfig = 0
         } else {
+            // Potential future work: Use server weights when selecting next server here and in iOS.
             val numServers = obj.getJSONArray("servers").length()
             currentServerConfig = (currentServerConfig + 1) % numServers
         }

--- a/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/VPNService.kt
+++ b/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/VPNService.kt
@@ -291,7 +291,7 @@ class VPNService : android.net.VpnService() {
             throw Error("no json config provided")
         }
         Log.sensitive(tag, json.toString())
-        val jServer: JSONObject =  getServerConfig(json, useFallbackServer)
+        val jServer: JSONObject = getServerConfig(json, useFallbackServer)
         val wireguard_conf = buildWireguardConfig(jServer, json)
         val wgConfig: String = wireguard_conf.toWgUserspaceString()
         if (wgConfig.isEmpty()) {

--- a/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/VPNService.kt
+++ b/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/VPNService.kt
@@ -40,6 +40,8 @@ class VPNService : android.net.VpnService() {
     private var mBackgroundPingTimerMSec: Long = 3 * 60 * 60 * 1000 // 3 hours, in milliseconds
     private var mShortTimerBackgroundPingMSec: Long = 3 * 60 * 1000 // 3 minutes, in milliseconds
 
+    private var currentServerConfig = 0
+
     // `isUsingShortTimerSessionPing` is not reliable until mConfig has been set, so it cannot be set upon
     // class initialization (VPN-6629). And this cannot be a lazy var, as that caused a crash (PR #8555)
     // Thus, the interval ticks are for the debug timer mode (but `isUsingShortTimerSessionPing` determines
@@ -287,7 +289,8 @@ class VPNService : android.net.VpnService() {
             throw Error("no json config provided")
         }
         Log.sensitive(tag, json.toString())
-        val wireguard_conf = buildWireguardConfig(json, useFallbackServer)
+        val jServer: JSONObject =  getServerConfig(json, useFallbackServer)
+        val wireguard_conf = buildWireguardConfig(jServer, json)
         val wgConfig: String = wireguard_conf.toWgUserspaceString()
         if (wgConfig.isEmpty()) {
             throw Error("WG_Userspace config is empty, can't continue")
@@ -343,27 +346,23 @@ class VPNService : android.net.VpnService() {
         // Go foreground
         CannedNotification(mConfig)?.let { mNotificationHandler.show(it) }
 
-        if (useFallbackServer) {
-            mConnectionHealth.start(
-                json.getJSONObject("serverFallback").getString("ipv4AddrIn"),
-                json.getJSONObject("serverFallback").getString("ipv4Gateway"),
-                json.getJSONObject("serverFallback").getString("ipv4Gateway"),
-                json.getJSONObject("server").getString("ipv4AddrIn"),
-                shouldRecordStartTelemetry,
-            )
-        } else {
-            var fallbackIpv4 = ""
-            if (json.has("serverFallback")) {
-                fallbackIpv4 = json.getJSONObject("serverFallback").getString("ipv4AddrIn")
+        // Select a fallback IP address to use for connection health checks. If not on first server,
+        // use the first server. If on first server and another server exists, use the second server.
+        var fallbackIpv4 = ""
+        if (currentServerConfig == 0) {
+            if (json.getJSONArray("servers").length() >= 2) {
+                fallbackIpv4 = json.getJSONArray("servers").getJSONObject(1).getString("ipv4AddrIn")
             }
-            mConnectionHealth.start(
-                json.getJSONObject("server").getString("ipv4AddrIn"),
-                json.getJSONObject("server").getString("ipv4Gateway"),
-                json.getString("dns"),
-                fallbackIpv4,
-                shouldRecordStartTelemetry,
-            )
+        } else {
+            fallbackIpv4 = json.getJSONArray("servers").getJSONObject(0).getString("ipv4AddrIn")
         }
+        mConnectionHealth.start(
+            jServer.getString("ipv4AddrIn"),
+            jServer.getString("ipv4Gateway"),
+            json.getString("dns"),
+            fallbackIpv4,
+            shouldRecordStartTelemetry,
+        )
 
         // For `isGleanDebugTagActive` and `isSuperDooperMetricsActive` to work,
         // this must be after the mConfig is set to the latest data.
@@ -528,14 +527,8 @@ class VPNService : android.net.VpnService() {
      * Create a Wireguard [Config] from a [json] string - The [json] will be created in
      * AndroidController.cpp
      */
-    private fun buildWireguardConfig(obj: JSONObject, useFallbackServer: Boolean = false): Config {
+    private fun buildWireguardConfig(jServer: JSONObject, obj: JSONObject): Config {
         val confBuilder = Config.Builder()
-        val jServer: JSONObject =
-            if (useFallbackServer) {
-                obj.getJSONObject("serverFallback")
-            } else {
-                obj.getJSONObject("server")
-            }
 
         val peerBuilder = Peer.Builder()
         val ep =
@@ -565,11 +558,19 @@ class VPNService : android.net.VpnService() {
         ifaceBuilder.parsePrivateKey(privateKey)
         ifaceBuilder.addAddress(InetNetwork.parse(jDevice.getString("ipv4Address")))
         ifaceBuilder.addAddress(InetNetwork.parse(jDevice.getString("ipv6Address")))
-        ifaceBuilder.addDnsServer(InetNetwork.parse(obj.getString("dns")).address)
-        if (useFallbackServer) {
-            // In case we have to use the fallback, add the default dns as fallback as well.
-            ifaceBuilder.addDnsServer(InetNetwork.parse(jServer.getString("ipv4Gateway")).address)
+
+        // Select the best DNS - if user is using a special privacy or user-specified DNS, use that.
+        // Otherwise, use the gateway for this server.
+        val mainGatewayAddress = obj.getJSONArray("servers").getJSONObject(0).getString("ipv4AddrIn")
+        val mainDnsAddress = obj.getString("dns")
+        val isSpecialDNS = mainGatewayAddress != mainDnsAddress
+        val dnsAddress = if (isSpecialDNS) {
+            mainDnsAddress
+        } else {
+            jServer.getString("ipv4Gateway")
         }
+        ifaceBuilder.addDnsServer(InetNetwork.parse(dnsAddress).address)
+
         val jExcludedApplication = obj.getJSONArray("excludedApps")
         (0 until jExcludedApplication.length()).toList().forEach {
             val appName = jExcludedApplication.get(it).toString()
@@ -577,6 +578,16 @@ class VPNService : android.net.VpnService() {
         }
         confBuilder.setInterface(ifaceBuilder.build())
         return confBuilder.build()
+    }
+
+    private fun getServerConfig(obj: JSONObject, useFallbackServer: Boolean): JSONObject {
+        if (!useFallbackServer) {
+            currentServerConfig = 0
+        } else {
+            val numServers = obj.getJSONArray("servers").length()
+            currentServerConfig = (currentServerConfig + 1) % numServers
+        }
+        return obj.getJSONArray("servers").getJSONObject(currentServerConfig)
     }
 
     fun setGleanUploadEnabled(uploadEnabled: Boolean) {

--- a/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/VPNServiceBinder.kt
+++ b/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/VPNServiceBinder.kt
@@ -167,6 +167,9 @@ class VPNServiceBinder(service: VPNService) : CoreBinder() {
                 mService.mNotificationHandler.onNotificationPermissionPromptFired()
                 return true
             }
+            ACTIONS.silentServerSwitch -> {
+                this.mService.reconnect(true)
+            }
             IBinder.LAST_CALL_TRANSACTION -> {
                 Log.e(tag, "The OS Requested to shut down the VPN")
                 this.mService.turnOff()

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -1127,16 +1127,16 @@ bool Controller::deactivate(ActivationPrincipal user) {
 }
 
 void Controller::forceDaemonSilentServerSwitch() {
-#ifdef MZ_IOS
+#ifdef MZ_MOBILE
   if (m_impl) {
-    logger.debug() << "Sending server switch message to iOS Network Extension";
+    logger.debug() << "Sending server switch message to mobile daemon";
     m_impl->forceDaemonSilentServerSwitch();
   } else {
-    logger.error() << "No server switch message sent to iOS Network Extension "
+    logger.error() << "No server switch message sent to mobile daemon "
                       "- no controller found";
   }
 #else
-  logger.debug() << "Server switch debug feature only available for iOS. Not "
-                    "sending message.";
+  logger.debug() << "Server switch debug feature only available for iOS "
+                    "and Android. Not sending message.";
 #endif
 }

--- a/src/models/serverdata.cpp
+++ b/src/models/serverdata.cpp
@@ -295,12 +295,18 @@ void ServerData::setExitServerPublicKey(const QString& publicKey) {
   m_exitServerPublicKey = publicKey;
 }
 
-const Server ServerData::backupServer(const QString& currentPublicKey) const {
+const QList<Server> ServerData::backupServers(
+    const QString& currentPublicKey) const {
   const QList<Server> serverList = exitServers();
+  const int ADDITIONAL_BACKUP_SERVERS = 3;  // kept in sync w/ iostunnel.swift
+  QList<Server> backupServers;
   foreach (auto item, serverList) {
     if (item.publicKey() != currentPublicKey) {
-      return item;
+      backupServers.append(item);
+      if (backupServers.size() >= ADDITIONAL_BACKUP_SERVERS) {
+        break;
+      }
     }
   }
-  return Server();
+  return backupServers;
 }

--- a/src/models/serverdata.cpp
+++ b/src/models/serverdata.cpp
@@ -298,7 +298,7 @@ void ServerData::setExitServerPublicKey(const QString& publicKey) {
 const QList<Server> ServerData::backupServers(
     const QString& currentPublicKey) const {
   const QList<Server> serverList = exitServers();
-  const int ADDITIONAL_BACKUP_SERVERS = 3;  // kept in sync w/ iostunnel.swift
+  const int ADDITIONAL_BACKUP_SERVERS = 3;
   QList<Server> backupServers;
   foreach (auto item, serverList) {
     if (item.publicKey() != currentPublicKey) {

--- a/src/models/serverdata.h
+++ b/src/models/serverdata.h
@@ -64,7 +64,7 @@ class ServerData final : public QObject {
   const QString& exitCityName() const { return m_exitCityName; }
   QString localizedExitCountryName() const;
   QString localizedExitCityName() const;
-  const Server backupServer(const QString& currentPublicKey) const;
+  const QList<Server> backupServers(const QString& currentPublicKey) const;
 
   bool multihop() const {
     return !m_entryCountryCode.isEmpty() && !m_entryCityName.isEmpty();

--- a/src/platforms/android/androidcontroller.h
+++ b/src/platforms/android/androidcontroller.h
@@ -30,6 +30,8 @@ class AndroidController final : public ControllerImpl {
 
   void cleanupBackendLogs() override;
 
+  void forceDaemonSilentServerSwitch() override;
+
  private:
   bool m_init = false;
   QString m_deviceName;

--- a/src/platforms/android/androidvpnactivity.h
+++ b/src/platforms/android/androidvpnactivity.h
@@ -46,6 +46,8 @@ enum ServiceAction {
   ACTION_CLEAR_STORAGE = 17,
   // Broadcast a change in telemetry preferences
   ACTION_SET_GLEAN_UPLOAD_ENABLED = 18,
+  // Daemon-based silent server switch
+  ACTION_SILENT_SERVER_SWITCH = 20,
 
 };
 typedef enum ServiceAction ServiceAction;

--- a/src/platforms/ios/ConnectionHealth.swift
+++ b/src/platforms/ios/ConnectionHealth.swift
@@ -30,7 +30,7 @@ class ConnectionHealth {
     private let toleranceTime = 1.0 // 1 seconds
     private var timer: Timer?
     private var nextPossibleServerSwitch = Date()
-    private let serverSwitchCooldownMinutes: TimeInterval = 60*5 // 5 minutes
+    private let serverSwitchCooldownMinutes: TimeInterval = 60*15 // 15 minutes
 
     private var lastHealthStatus: ConnectionStability = .pending
     private var connectionHealthTimerId: GleanTimerId? = nil

--- a/src/platforms/ios/ioscontroller.swift
+++ b/src/platforms/ios/ioscontroller.swift
@@ -161,7 +161,10 @@ public class IOSControllerImpl: NSObject {
         }
     }
 
-    @objc func connect(serverData: [VPNServerData], excludeLocalNetworks: Bool, allowedIPAddressRanges: [VPNIPAddressRange], reason: Int, gleanDebugTag: String, isSuperDooperFeatureActive: Bool, installationId: String, disconnectOnErrorCallback: @escaping () -> Void, onboardingCompletedCallback: @escaping () -> Void, vpnConfigPermissionResponseCallback: @escaping (Bool) -> Void) {
+    @objc func connect(serverData: [VPNServerData], excludeLocalNetworks: Bool, allowedIPAddressRanges: [VPNIPAddressRange], reason: Int,
+            gleanDebugTag: String, isSuperDooperFeatureActive: Bool, installationId: String,
+            disconnectOnErrorCallback: @escaping () -> Void, onboardingCompletedCallback: @escaping () -> Void,
+            vpnConfigPermissionResponseCallback: @escaping (Bool) -> Void) {
         IOSControllerImpl.logger.debug(message: "Connecting")
 
         TunnelManager.withTunnel { tunnel in
@@ -178,7 +181,10 @@ public class IOSControllerImpl: NSObject {
         }
     }
 
-    func configureTunnel(configs: [TunnelConfiguration], reason: Int, serverName: String, excludeLocalNetworks: Bool, gleanDebugTag: String, isSuperDooperFeatureActive: Bool, installationId: String, disconnectOnErrorCallback: @escaping () -> Void, onboardingCompletedCallback: @escaping () -> Void, vpnConfigPermissionResponseCallback: @escaping (Bool) -> Void) {
+    func configureTunnel(configs: [TunnelConfiguration], reason: Int, serverName: String, excludeLocalNetworks: Bool,
+            gleanDebugTag: String, isSuperDooperFeatureActive: Bool, installationId: String,
+            disconnectOnErrorCallback: @escaping () -> Void, onboardingCompletedCallback: @escaping () -> Void,
+            vpnConfigPermissionResponseCallback: @escaping (Bool) -> Void) {
         TunnelManager.withTunnel { tunnel in
             guard let config = configs.first else {
               IOSControllerImpl.logger.error(message: "No VPN config found")

--- a/src/platforms/ios/ioscontroller.swift
+++ b/src/platforms/ios/ioscontroller.swift
@@ -205,10 +205,7 @@ public class IOSControllerImpl: NSObject {
             customConfig["isSuperDooperFeatureActive"] = isSuperDooperFeatureActive
             customConfig["gleanDebugTag"] = gleanDebugTag
             customConfig["installationId"] = installationId
-
-            for i in 0..<configs.count {
-                customConfig["config\(i)"] = configs[i].asWgQuickConfig()
-            }
+            customConfig["configs"] = configs.map({ $0.asWgQuickConfig() })
             proto?.providerConfiguration = customConfig
 
             tunnel.protocolConfiguration = proto

--- a/src/platforms/ios/ioscontroller.swift
+++ b/src/platforms/ios/ioscontroller.swift
@@ -161,27 +161,30 @@ public class IOSControllerImpl: NSObject {
         }
     }
 
-    @objc func connect(serverData: VPNServerData, fallbackServer: VPNServerData?, excludeLocalNetworks: Bool, allowedIPAddressRanges: [VPNIPAddressRange], reason: Int, gleanDebugTag: String, isSuperDooperFeatureActive: Bool, installationId: String, disconnectOnErrorCallback: @escaping () -> Void, onboardingCompletedCallback: @escaping () -> Void, vpnConfigPermissionResponseCallback: @escaping (Bool) -> Void) {
+    @objc func connect(serverData: [VPNServerData], excludeLocalNetworks: Bool, allowedIPAddressRanges: [VPNIPAddressRange], reason: Int, gleanDebugTag: String, isSuperDooperFeatureActive: Bool, installationId: String, disconnectOnErrorCallback: @escaping () -> Void, onboardingCompletedCallback: @escaping () -> Void, vpnConfigPermissionResponseCallback: @escaping (Bool) -> Void) {
         IOSControllerImpl.logger.debug(message: "Connecting")
 
         TunnelManager.withTunnel { tunnel in
             // Let's remove the previous config if it exists.
             (tunnel.protocolConfiguration as? NETunnelProviderProtocol)?.destroyConfigurationReference()
+            let configs: [TunnelConfiguration] = serverData.map({createConfig(for: $0, allowedIPAddressRanges: allowedIPAddressRanges)})
 
-            let config = createConfig(for: serverData, allowedIPAddressRanges: allowedIPAddressRanges)
-            let fallbackConfig: TunnelConfiguration?
-            if let fallbackServer = fallbackServer {
-                fallbackConfig = createConfig(for: fallbackServer, allowedIPAddressRanges: allowedIPAddressRanges)
-            } else {
-                fallbackConfig = nil
+            guard let serverName = serverData.first?.serverWithPort else {
+              IOSControllerImpl.logger.error(message: "No VPN server data found")
+              disconnectOnErrorCallback()
+              return
             }
-
-            return self.configureTunnel(config: config, reason: reason, serverName: serverData.serverWithPort, fallbackConfig: fallbackConfig, excludeLocalNetworks: excludeLocalNetworks, gleanDebugTag: gleanDebugTag, isSuperDooperFeatureActive: isSuperDooperFeatureActive, installationId: installationId, disconnectOnErrorCallback: disconnectOnErrorCallback, onboardingCompletedCallback: onboardingCompletedCallback, vpnConfigPermissionResponseCallback: vpnConfigPermissionResponseCallback)
+            return self.configureTunnel(configs: configs, reason: reason, serverName: serverName, excludeLocalNetworks: excludeLocalNetworks, gleanDebugTag: gleanDebugTag, isSuperDooperFeatureActive: isSuperDooperFeatureActive, installationId: installationId, disconnectOnErrorCallback: disconnectOnErrorCallback, onboardingCompletedCallback: onboardingCompletedCallback, vpnConfigPermissionResponseCallback: vpnConfigPermissionResponseCallback)
         }
     }
 
-    func configureTunnel(config: TunnelConfiguration, reason: Int, serverName: String, fallbackConfig: TunnelConfiguration?, excludeLocalNetworks: Bool, gleanDebugTag: String, isSuperDooperFeatureActive: Bool, installationId: String, disconnectOnErrorCallback: @escaping () -> Void, onboardingCompletedCallback: @escaping () -> Void, vpnConfigPermissionResponseCallback: @escaping (Bool) -> Void) {
+    func configureTunnel(configs: [TunnelConfiguration], reason: Int, serverName: String, excludeLocalNetworks: Bool, gleanDebugTag: String, isSuperDooperFeatureActive: Bool, installationId: String, disconnectOnErrorCallback: @escaping () -> Void, onboardingCompletedCallback: @escaping () -> Void, vpnConfigPermissionResponseCallback: @escaping (Bool) -> Void) {
         TunnelManager.withTunnel { tunnel in
+            guard let config = configs.first else {
+              IOSControllerImpl.logger.error(message: "No VPN config found")
+              disconnectOnErrorCallback()
+              return
+            }
             let proto = NETunnelProviderProtocol(tunnelConfiguration: config)
             proto!.providerBundleIdentifier = TunnelManager.vpnBundleId
             proto!.disconnectOnSleep = false
@@ -203,7 +206,9 @@ public class IOSControllerImpl: NSObject {
             customConfig["gleanDebugTag"] = gleanDebugTag
             customConfig["installationId"] = installationId
 
-            customConfig["fallbackConfig"] = fallbackConfig?.asWgQuickConfig() ?? ""
+            for i in 0..<configs.count {
+                customConfig["config\(i)"] = configs[i].asWgQuickConfig()
+            }
             proto?.providerConfiguration = customConfig
 
             tunnel.protocolConfiguration = proto

--- a/src/platforms/ios/iostunnel.swift
+++ b/src/platforms/ios/iostunnel.swift
@@ -263,6 +263,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider, SilentServerSwitching {
             logger.error(message: "No protocol config found")
             return nil
         }
+        // Potential future work: Use server weights when selecting next server here and in iOS.
         let numberOfServers = serverConfigs.count
         currentServerConfig = (currentServerConfig + 1) % numberOfServers
         return serverConfigs[currentServerConfig]

--- a/src/platforms/ios/iostunnel.swift
+++ b/src/platforms/ios/iostunnel.swift
@@ -258,7 +258,6 @@ class PacketTunnelProvider: NEPacketTunnelProvider, SilentServerSwitching {
 
     private func nextValidServerConfig() -> String? {
         let startConfig = currentServerConfig
-        var nextConfig = startConfig
         let additionalBackupServers = 3 // kept in sync w/ serverdata.cpp
         let maxNumberOfServers = 1 + additionalBackupServers // main server + backup servers
 
@@ -267,10 +266,9 @@ class PacketTunnelProvider: NEPacketTunnelProvider, SilentServerSwitching {
         // This should never hit the `while` condition (which returns `nil`), but an unexpected config could allow for it. To be
         // defensive against a potential inifinite loop, we set up the failsafe of the `while` check.
         repeat {
-            nextConfig = (nextConfig + 1) % maxNumberOfServers
-            if let nextServerConfig = ((protocolConfiguration as? NETunnelProviderProtocol)?.providerConfiguration?["config\(nextConfig)"] as? String), !nextServerConfig.isEmpty {
-                currentServerConfig = nextConfig
-                return nextServerConfig
+            currentServerConfig = (currentServerConfig + 1) % maxNumberOfServers
+            if let nextServerConfigData = ((protocolConfiguration as? NETunnelProviderProtocol)?.providerConfiguration?["config\(currentServerConfig)"] as? String), !nextServerConfigData.isEmpty {
+                return nextServerConfigData
             }
         } while (nextConfig != startConfig)
       return nil

--- a/src/ui/screens/getHelp/developerMenu/ViewDeveloperMenu.qml
+++ b/src/ui/screens/getHelp/developerMenu/ViewDeveloperMenu.qml
@@ -267,9 +267,9 @@ MZViewBase {
 
         MZButton {
             id: unstableNetworkExtension
-            visible: Qt.platform.os === "ios"
+            visible: Qt.platform.os === "ios" || Qt.platform.os === "android"
 
-            text: "iOS daemon: Silent server switch"
+            text: "Silent server switch (from daemon)"
             onClicked: {
                 VPNController.forceDaemonSilentServerSwitch();
             }


### PR DESCRIPTION
## Description

There are a few things in this PR, apologies. If you'd like them broken out into separate PRs, please let me know and I'll happily restructure.
1) (no ticket) Adding a developer debug option for daemon silent switching on Android. This exists on iOS already, and this was extended for Android as well. (This was necessary to test other work in this PR.)
2) (VPN-6408) Currently daemon silent server switches (which exist only on mobile, as on desktop the client is always running) will attempt a single switch to a new server. Once they've used their backup server, they never again try to switch until the VPN is again activated from the client. This updates it to use up to 4 servers, and rotate between them.
3) (VPN-6678) In looking at the code and testing my work, I discovered a bug - Special DNS (custom or privacy DNS) isn't maintained when moving to the backup server - it falls back to using the main Mullvad DNS. (This currently exists in prod, though it doesn't look like there was a ticket for it before I filed one today.) I've fixed this bug by looking at whether the main DNS is used on the main server, and setting DNS for the fallback servers appropriately.

## Reference

VPN-6408 and VPN-6678

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
