### PR TITLE
Fix split tunnel on ipv4 only networks

### DIFF
--- a/src/platforms/windows/daemon/windowssplittunnel.cpp
+++ b/src/platforms/windows/daemon/windowssplittunnel.cpp
@@ -484,6 +484,9 @@ bool WindowsSplitTunnel::getAddress(int adapterIndex, IN_ADDR* out_ipv4,
     logger.debug() << "Ipv4 Conversation error" << WSAGetLastError();
     return false;
   }
+  if (ipv6.empty()) {
+    return true;
+  }
   if (InetPtonW(AF_INET6, ipv6.c_str(), out_ipv6) != 1) {
     logger.debug() << "Ipv6 Conversation error" << WSAGetLastError();
     return false;

--- a/src/platforms/windows/daemon/windowssplittunnel.cpp
+++ b/src/platforms/windows/daemon/windowssplittunnel.cpp
@@ -485,6 +485,7 @@ bool WindowsSplitTunnel::getAddress(int adapterIndex, IN_ADDR* out_ipv4,
     return false;
   }
   if (ipv6.empty()) {
+    std::memset(out_ipv6, 0x00, sizeof(IN6_ADDR));
     return true;
   }
   if (InetPtonW(AF_INET6, ipv6.c_str(), out_ipv6) != 1) {


### PR DESCRIPTION
## Description
Valentina notes on some "hotspot" networks split tunnel breaks. 
From valentinas logs: 
``` 
[23.10.2024 17:53:21.923] (WindowsSplitTunnel) Debug: Getting adapter info for: MozillaVPN
[23.10.2024 17:53:21.930] (WindowsSplitTunnel) Debug: Getting adapter info for: Wi-Fi
[23.10.2024 17:53:21.930] (WindowsSplitTunnel) Debug: Ipv6 Conversation error 0
[23.10.2024 17:53:21.930] (WindowsSplitTunnel) Error: Failed to set Network Config
[23.10.2024 17:53:21.930] (WindowsSplitTunnel) Debug: Pushing new Ruleset for Split-Tunnel  3
[23.10.2024 17:53:21.930] (WindowsSplitTunnel) Debug: \Device\HarddiskVolume4\Program Files\Mozilla Firefox\firefox.exe
[23.10.2024 17:53:21.934] (WindowsSplitTunnel) Debug: New Configuration applied:  STATE_RUNNING
```

Currently we assume the local network adapter contains an ipv6. If not we bubble the error up the stack: 
-> if not `InetPtonW(AF_INET6,..)` will return false
-> `WindowsSplitTunnel::getAddress` will return false 
-> `WindowsSplitTunnel::generateIPConfiguration` will return {} so 0 bytes
-> this will cause the driver call `DeviceIoControl(m_driver, IOCTL_REGISTER_IP_ADDRESSES,..)` to error as we don't send a valid blob 
-> this will cause this error message `logger.error() << "Failed to set Network Config";` 

So let's bail the ipv6 conversation if there is none and send the info we have to the driver. 

