### PR TITLE
VPN-6213 (part 1): Remove explicit colors

### DIFF
--- a/nebula/ui/components/MZAlert.qml
+++ b/nebula/ui/components/MZAlert.qml
@@ -53,10 +53,10 @@ Rectangle {
         id: style
         readonly property string darkCloseIcon: "qrc:/nebula/resources/close-dark.svg"
         readonly property string whiteCloseIcon: "qrc:/nebula/resources/close-white.svg"
-        property var alertColor: "black";
-        property var alertHoverColor: "gray";
-        property var alertClickColor: "white";
-        property var fontColor: "yellow"
+        property var alertColor: MZTheme.colors.black
+        property var alertHoverColor: MZTheme.colors.grey30
+        property var alertClickColor: MZTheme.colors.white
+        property var fontColor: MZTheme.colors.yellow10
         property var fontSize: 13
         property var lineHeight: 21
         property var borderRadius: 4
@@ -88,7 +88,7 @@ Rectangle {
                 alertColor: MZTheme.theme.blue
                 alertHoverColor: MZTheme.theme.blueHovered
                 alertClickColor: MZTheme.theme.bluePressed
-                fontColor: "#FFFFFF"
+                fontcolor: MZTheme.colors.white
                 closeIcon: whiteCloseIcon
             }
         },
@@ -121,7 +121,7 @@ Rectangle {
                 alertColor: MZTheme.theme.red
                 alertHoverColor: MZTheme.theme.redHovered
                 alertClickColor: MZTheme.theme.redPressed
-                fontColor: "#FFFFFF"
+                fontcolor: MZTheme.colors.white
                 closeIcon: whiteCloseIcon
             }
         },
@@ -163,7 +163,7 @@ Rectangle {
         horizontalOffset: 1
         verticalOffset: 1
         radius: 5.5
-        color: "#0C0C0D"
+        color: MZTheme.colors.grey60
    }
 
     MZButtonBase {

--- a/nebula/ui/components/MZBottomSheet.qml
+++ b/nebula/ui/components/MZBottomSheet.qml
@@ -19,7 +19,7 @@ import Mozilla.Shared 1.0
               anchors.left: parent.left
               anchors.right: parent.right
               height: 20
-              color: "green"
+              color: MZTheme.colors.green90
 
           }
       }

--- a/nebula/ui/components/MZDropShadowWithStates.qml
+++ b/nebula/ui/components/MZDropShadowWithStates.qml
@@ -13,7 +13,7 @@ MZDropShadow {
     horizontalOffset: 1
     verticalOffset: 1
     radius: 5.5
-    color: "#0C0C0D"
+    color: MZTheme.colors.grey60
     opacity: .1
     state: VPNController.state
 

--- a/nebula/ui/components/MZSettingsToggle.qml
+++ b/nebula/ui/components/MZSettingsToggle.qml
@@ -104,7 +104,7 @@ CheckBox {
     Rectangle {
         id: hoverPressHandler
 
-        color: "#C2C2C2"
+        color: MZTheme.colors.grey20
         opacity: 0
         z: -1
         anchors.fill: uiPlaceholder

--- a/nebula/ui/components/MZSubscriptionOption.qml
+++ b/nebula/ui/components/MZSubscriptionOption.qml
@@ -32,7 +32,7 @@ RadioDelegate {
             anchors.fill: bg
             glowRadius: radioDelegate.checked ? 8 : 1
             spread: radioDelegate.checked ? 0.1 : 0
-            color: "#4D0C0C0D"
+            color: MZTheme.colors.grey30
             cornerRadius: rect.radius + glowRadius
         }
 

--- a/nebula/ui/components/MZToolTip.qml
+++ b/nebula/ui/components/MZToolTip.qml
@@ -65,7 +65,7 @@ ToolTip {
             anchors.fill: glowClippingPath
             glowRadius: 2
             spread: 0.5
-            color: "#0C0C0D"
+            color: MZTheme.colors.grey60
             cornerRadius: glowClippingPath.radius + glowRadius
             opacity: 0.1
             z: -2

--- a/nebula/ui/components/forms/MZComboBox.qml
+++ b/nebula/ui/components/forms/MZComboBox.qml
@@ -120,7 +120,7 @@ ComboBox {
                 anchors.fill: shadowMask
                 transparentBorder: true
                 radius: 7.5
-                color: "#0C0C0D"
+                color: MZTheme.colors.grey60
                 z: -1
                 opacity: .1
                 cached: true

--- a/nebula/ui/themes/main/colors.js
+++ b/nebula/ui/themes/main/colors.js
@@ -118,6 +118,10 @@ color.pink20 = '#FF8AC5';
 color.pink10 = '#FFB4DB';
 color.pink5 = '#FFDEF0';
 
+// Dull colors
+color.dullPurple = '#387E8A';
+color.dullGreen = '#998DB2';
+
 /**
  * Helper functions
  */

--- a/src/ui/screens/ScreenViewLogs.qml
+++ b/src/ui/screens/ScreenViewLogs.qml
@@ -112,7 +112,7 @@ Item {
             height: 1
             width: parent.width
             anchors.bottom: parent.bottom
-            color: "#0C0C0D0A"
+            color: MZTheme.colors.grey10
         }
 
     }

--- a/src/ui/screens/getHelp/developerMenu/ViewDeveloperMenu.qml
+++ b/src/ui/screens/getHelp/developerMenu/ViewDeveloperMenu.qml
@@ -134,7 +134,7 @@ MZViewBase {
             Layout.topMargin: MZTheme.theme.windowMargin / 2
             Layout.leftMargin: MZTheme.theme.windowMargin * 3
             Layout.rightMargin: MZTheme.theme.windowMargin
-            color: "#E7E7E7"
+            color: MZTheme.colors.grey10
         }
 
         Repeater {

--- a/src/ui/screens/getHelp/developerMenu/ViewTelemetryDebugging.qml
+++ b/src/ui/screens/getHelp/developerMenu/ViewTelemetryDebugging.qml
@@ -93,7 +93,7 @@ MZViewBase {
             Layout.topMargin: MZTheme.theme.windowMargin / 2
             Layout.leftMargin: MZTheme.theme.windowMargin * 3
             Layout.rightMargin: MZTheme.theme.windowMargin
-            color: "#E7E7E7"
+            color: MZTheme.colors.grey10
         }
 
         MZButton {

--- a/src/ui/screens/getHelp/developerMenu/ViewUiTesting.qml
+++ b/src/ui/screens/getHelp/developerMenu/ViewUiTesting.qml
@@ -93,7 +93,7 @@ MZViewBase {
 
                             text: "Use these features for more protection. They may cause issues on some sites, so you can turn them off anytime in settings."
                             horizontalAlignment: Text.AlignLeft
-                            color: "#6D6D6E"
+                            color: MZTheme.colors.grey40
                         }
 
                         MZCheckBoxRow {

--- a/src/ui/screens/home/ViewHome.qml
+++ b/src/ui/screens/home/ViewHome.qml
@@ -72,7 +72,7 @@ MZFlickable {
             MZBoldLabel {
                 //% "Mozilla VPN"
                 text: qsTrId("MozillaVPN")
-                color: "#000000"
+                color: MZTheme.colors.black
                 Layout.alignment: Qt.AlignVCenter
             }
         }

--- a/src/ui/screens/home/controller/ConnectionStability.qml
+++ b/src/ui/screens/home/controller/ConnectionStability.qml
@@ -146,7 +146,7 @@ Item {
         }
 
         Rectangle {
-            color: "#FFFFFF"
+            color: MZTheme.colors.white
             opacity: 0.8
             radius: 3
             height: 4
@@ -160,7 +160,7 @@ Item {
             //: Message displayed to the user when the connection is unstable or
             //: missing, asking them to check their connection.
             text: qsTrId("vpn.connectionStability.checkConnection")
-            color: "#FFFFFF"
+            color: MZTheme.colors.white
             opacity: 0.8
             Layout.alignment: Qt.AlignCenter
             onPaintedWidthChanged: stability.setColumns()

--- a/src/ui/screens/home/controller/ControllerView.qml
+++ b/src/ui/screens/home/controller/ControllerView.qml
@@ -67,7 +67,7 @@ Item {
 
             PropertyChanges {
                 target: boxBackground
-                color: "#FFFFFF"
+                color: MZTheme.colors.white
             }
 
             PropertyChanges {
@@ -108,7 +108,7 @@ Item {
 
             PropertyChanges {
                 target: boxBackground
-                color: "#FFFFFF"
+                color: MZTheme.colors.white
             }
 
             PropertyChanges {
@@ -154,14 +154,14 @@ Item {
                 target: logoTitle
                 //% "Connecting…"
                 text: qsTrId("vpn.controller.connectingState")
-                color: "#FFFFFF"
+                color: MZTheme.colors.white
             }
 
             PropertyChanges {
                 target: logoSubtitle
                 //% "Masking connection and location"
                 text: qsTrId("vpn.controller.activating")
-                color: "#FFFFFF"
+                color: MZTheme.colors.white
                 opacity: 0.8
                 visible: true
             }
@@ -194,7 +194,7 @@ Item {
             PropertyChanges {
                 target: logoTitle
                 text: qsTrId("vpn.controller.connectingState")
-                color: "#FFFFFF"
+                color: MZTheme.colors.white
             }
 
             PropertyChanges {
@@ -203,7 +203,7 @@ Item {
                           //% "Attempting to confirm connection"
                           qsTrId("vpn.controller.attemptingToConfirm") :
                           qsTrId("vpn.controller.activating")
-                color: "#FFFFFF"
+                color: MZTheme.colors.white
                 opacity: 0.8
                 visible: true
             }
@@ -238,7 +238,7 @@ Item {
                 target: logoTitle
                 //% "VPN is on"
                 text: qsTrId("vpn.controller.activated")
-                color: "#FFFFFF"
+                color: MZTheme.colors.white
             }
 
             PropertyChanges {
@@ -264,7 +264,7 @@ Item {
 
             PropertyChanges {
                 target: boxBackground
-                color: "#FFFFFF"
+                color: MZTheme.colors.white
             }
 
             PropertyChanges {
@@ -311,7 +311,7 @@ Item {
                 target: logoTitle
                 //% "Switching…"
                 text: qsTrId("vpn.controller.switching")
-                color: "#FFFFFF"
+                color: MZTheme.colors.white
             }
 
             PropertyChanges {
@@ -319,7 +319,7 @@ Item {
                 //% "From %1 to %2"
                 //: Switches from location 1 to location 2
                 text: qsTrId("vpn.controller.switchingDetail").arg(VPNCurrentServer.localizedPreviousExitCityName).arg(VPNCurrentServer.localizedExitCityName)
-                color: "#FFFFFF"
+                color: MZTheme.colors.white
                 opacity: 0.8
                 visible: true
             }

--- a/src/ui/screens/home/controller/VPNToggle.qml
+++ b/src/ui/screens/home/controller/VPNToggle.qml
@@ -54,7 +54,7 @@ MZButtonBase {
 
             PropertyChanges {
                 target: toggle
-                color: "#9E9E9E"
+                color: MZTheme.colors.grey30
                 border.color: MZTheme.theme.white
             }
 
@@ -74,7 +74,7 @@ MZButtonBase {
 
             PropertyChanges {
                 target: toggle
-                color: "#9E9E9E"
+                color: MZTheme.colors.grey30
                 border.color: MZTheme.theme.white
             }
 
@@ -96,7 +96,7 @@ MZButtonBase {
 
             PropertyChanges {
                 target: toggle
-                color: "#9E9E9E"
+                color: MZTheme.colors.grey30
                 border.color: MZTheme.theme.white
             }
 
@@ -115,12 +115,12 @@ MZButtonBase {
             PropertyChanges {
                 target: cursor
                 anchors.leftMargin: 32
-                color: "#998DB2"
+                color: MZTheme.theme.dullGreen
             }
 
             PropertyChanges {
                 target: toggle
-                color: "#387E8A"
+                color: MZTheme.theme.dullPurple
                 border.color: MZTheme.theme.ink
             }
 
@@ -138,12 +138,12 @@ MZButtonBase {
             PropertyChanges {
                 target: cursor
                 anchors.leftMargin: 32
-                color: connectionRetryOverX ? "#FFFFFF" : "#998DB2"
+                color: connectionRetryOverX ? MZTheme.theme.white : MZTheme.theme.dullGreen
             }
 
             PropertyChanges {
                 target: toggle
-                color: "#387E8A"
+                color: MZTheme.theme.dullPurple
                 border.color: MZTheme.theme.ink
             }
 
@@ -165,7 +165,7 @@ MZButtonBase {
 
             PropertyChanges {
                 target: toggle
-                color: "#3FE1B0"
+                color: MZTheme.colors.green50
                 border.color: MZTheme.theme.ink
             }
 
@@ -186,7 +186,7 @@ MZButtonBase {
 
             PropertyChanges {
                 target: toggle
-                color: "#3FE1B0"
+                color: MZTheme.colors.green50
                 border.color: MZTheme.theme.ink
             }
 
@@ -206,7 +206,7 @@ MZButtonBase {
 
             PropertyChanges {
                 target: toggle
-                color: "#CECECE"
+                color: MZTheme.colors.grey20
                 border.color: MZTheme.theme.white
             }
 
@@ -223,12 +223,12 @@ MZButtonBase {
             PropertyChanges {
                 target: cursor
                 anchors.leftMargin: 32
-                color: "#998DB2"
+                color: MZTheme.theme.dullGreen
             }
 
             PropertyChanges {
                 target: toggle
-                color: "#387E8A"
+                color: MZTheme.theme.dullPurple
                 border.color: MZTheme.theme.ink
             }
 
@@ -288,7 +288,7 @@ MZButtonBase {
     Rectangle {
         id: hoverPressHandler
 
-        color: "#C2C2C2"
+        color: MZTheme.colors.grey20
         state: toggle.state
         opacity: {
             if (state === uiState.stateHovered)

--- a/src/ui/screens/messaging/ViewMessage.qml
+++ b/src/ui/screens/messaging/ViewMessage.qml
@@ -34,7 +34,7 @@ MZViewBase {
 
             MZBoldLabel {
                 text: qsTrId("MozillaVPN")
-                color: "#000000"
+                color: MZTheme.colors.black
                 horizontalAlignment: Text.AlignHCenter
                 verticalAlignment: Text.AlignVCenter
                 elide: Text.ElideRight

--- a/src/ui/screens/settings/ViewAboutUs.qml
+++ b/src/ui/screens/settings/ViewAboutUs.qml
@@ -96,7 +96,7 @@ MZViewBase {
 
                 Layout.preferredHeight: 1
                 Layout.fillWidth: true
-                color: "#0C0C0D0A"
+                color: MZTheme.colors.grey10
             }
         }
 


### PR DESCRIPTION
## Description

VPN-6213 is to refactor main theme to separate layout/spacing from the colors, and while we're at it remove explicit colors from the code.

This is going to be done as 3 PRs, stacked on top of one another:
1) Change explicit colors to variable colors (this PR)
2) Change use of variable colors in the code to named variables, and set them to colors (to make them easy to swap out for other themes) - so instead of a border being `grey20` it's a new variable `borderColor`, and `borderColor` is set to `grey20`.
3) Pull colors out from the rest of theming, so it's easy to swap in new color schemes as desired

For this PR - some of these color choices are pretty straightforward (looking at you, #FFFFFF and #000000), but some were slight judgement calls. I tried to match QT explicit colors (in MZAlert and another place or two) the best I could to our color scheme. The oddest looking one is on MZSubscriptionOption, the glow color. I spent a while testing different options, and think grey30 is best. The image on the left is how it currently looks in the app, the one on the right is grey30:
<img width=200 src="https://github.com/user-attachments/assets/24fa229a-9b44-424a-ac5a-21c5a5d583c8"><img width=200 src="https://github.com/user-attachments/assets/4482b2e7-30d6-4b82-bb5e-8b22edf65db2">

Additionally, I only focused on client colors for this PR. Areas I found that still have some explicit color:
- images/animations/etc.
- app icons, notification icons, mobile launcher screens, etc
- documentation including mozillapvn.dev
- inspector
- translation report
- linux flatpak webpage
- macOS setup screen
- WASM's chrome

I'm going to ensure we have tickets filed for these first two (update: this has been filed as VPN-6681), but the final 6 are items that I don't think we need to make generalizable (so they may never get a dark mode).

## Reference

VPN-6213

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
