### PR TITLE
Re:#9966 Fix Crash in MZFlickable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,7 +52,7 @@ nebula/nebula_autogen/
 nebula/libnebula.a
 src/mozillavpn_autogen/
 /build-*/
-/build/
+/build*/
 dummybuild
 
 # Node (for functional tests)

--- a/extension/socks5proxy/bin/CMakeLists.txt
+++ b/extension/socks5proxy/bin/CMakeLists.txt
@@ -18,6 +18,7 @@ if(WIN32)
     target_sources(socksproxy PRIVATE
         windowsbypass.cpp
         windowsbypass.h)
+    target_link_libraries(socksproxy PRIVATE Iphlpapi.lib)
 
     install(FILES
         ${CMAKE_CURRENT_BINARY_DIR}/socksproxy.exe

--- a/nebula/ui/components/MZFlickable.qml
+++ b/nebula/ui/components/MZFlickable.qml
@@ -22,15 +22,11 @@ Flickable {
     boundsBehavior: Flickable.StopAtBounds
     opacity: 0
 
-    onFlickContentHeightChanged: {
-        recalculateContentHeight()
-    }
-
-    onHeightChanged: {
-        recalculateContentHeight()
-    }
-
     Component.onCompleted: {
+        recalculateContentHeight()
+        this.onHeightChanged.connect(recalculateContentHeight)
+        this.onFlickContentHeightChanged.connect(recalculateContentHeight)
+    
         opacity = 1;
         if (Qt.platform.os === "windows") {
             maximumFlickVelocity = 700;

--- a/src/commands/commandui.cpp
+++ b/src/commands/commandui.cpp
@@ -207,23 +207,6 @@ int CommandUI::run(QStringList& tokens) {
     EventListener eventListener;
 #endif
 
-#ifdef false
-    // This enables the qt-creator qml debugger on debug builds.:
-    // Go to QtCreator: Debug->Start Debugging-> Attach to QML port
-    // Port is 1234.
-    // Note: Qt creator only will use localhost:port so tunnel any external
-    // device to there i.e on android $adb forward tcp:1234 tcp:1234
-
-    // We need to create the qmldebug server before the engine is created.
-    QQmlDebuggingEnabler enabler;
-    bool ok = enabler.startTcpDebugServer(
-        1234, QQmlDebuggingEnabler::StartMode::DoNotWaitForClient, "0.0.0.0");
-    if (ok) {
-      logger.debug() << "Started QML Debugging server on 0.0.0.0:1234";
-    } else {
-      logger.error() << "Failed to start QML Debugging";
-    }
-#endif
 #ifdef MZ_ANDROID
     // https://bugreports.qt.io/browse/QTBUG-82617
     // Currently there is a crash happening on exit with Huawei devices.

--- a/src/commands/commandui.cpp
+++ b/src/commands/commandui.cpp
@@ -207,7 +207,7 @@ int CommandUI::run(QStringList& tokens) {
     EventListener eventListener;
 #endif
 
-#ifdef MZ_DEBUG
+#ifdef false
     // This enables the qt-creator qml debugger on debug builds.:
     // Go to QtCreator: Debug->Start Debugging-> Attach to QML port
     // Port is 1234.

--- a/src/platforms/windows/daemon/windowsfirewall.cpp
+++ b/src/platforms/windows/daemon/windowsfirewall.cpp
@@ -22,6 +22,7 @@
 #include <QObject>
 #include <QScopeGuard>
 #include <QtEndian>
+#include <utility>
 
 #include "ipaddress.h"
 #include "leakdetector.h"
@@ -320,7 +321,7 @@ bool WindowsFirewall::disableKillSwitch() {
     FwpmFilterDeleteById0(m_sessionHandle, filterID);
   }
 
-  for (const auto& filterID : qAsConst(m_activeRules)) {
+  for (const auto& filterID : std::as_const(m_activeRules)) {
     FwpmFilterDeleteById0(m_sessionHandle, filterID);
   }
 


### PR DESCRIPTION
Soooo i did set up a 6.8 dev build and was able to repro the crash seen in #9966 - this is a fun one. 
In 6.8.0 we get the "onHeightChange" before the window has finished to initialize, so that when we call ` mapToItem(window.contentItem)` we defer a nullptr and crash.