### PR TITLE
FXVPN-218: Fix busted split tunneling on Linux

### DIFF
--- a/linux/netfilter/netfilter.go
+++ b/linux/netfilter/netfilter.go
@@ -642,7 +642,7 @@ func NetfilterCreateTables() int32 {
 		Table:    mozvpn_ctx.table,
 		Type:     nftables.ChainTypeFilter,
 		Hooknum:  nftables.ChainHookPrerouting,
-		Priority: nftables.ChainPriorityRaw,
+		Priority: nftables.ChainPriorityMangle,
 	})
 
 	dropPolicy := nftables.ChainPolicyDrop


### PR DESCRIPTION
## Description
In PR #9906 I messed around a bit with the firewall rules to get IPv6 traffic to split tunnel correctly when originating with a firewall mark (eg: `sudo ping6 -m 51820 <dest>`) by making better use of connection tracking to re-set the firewall mark upon packet reception.

However, I goofed up during the rebase and I forgot the most important part of that change: the firewall mark has to be applied *after* connection tracking, and unfortunately a raw hook happens before connection tracking. The result of that error is that split tunneling just doesn't work on some machines because the inbound packets loose their firewall mark and get rejected by RPF.

To fix this, we just need to adjust the priority of the `preroute` chain from `ChainPriorityRaw` to `ChainPriorityMangle` so that it happens after connection tracking. 

## Reference
Bug introduced by #9906
Related JIRA Issue: [FXVPN-218](https://mozilla-hub.atlassian.net/browse/FXVPN-218)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[FXVPN-218]: https://mozilla-hub.atlassian.net/browse/FXVPN-218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ