### PR TITLE
Bump to rust 1.75.0 for static QT builds too

### DIFF
--- a/taskcluster/docker/linux-qt6-build/Dockerfile
+++ b/taskcluster/docker/linux-qt6-build/Dockerfile
@@ -71,7 +71,7 @@ RUN apt-get -y install -t bullseye-backports cmake
 
 ## Install Rust
 RUN mkdir -p /tmp/rust
-RUN curl https://static.rust-lang.org/dist/rust-1.69.0-x86_64-unknown-linux-gnu.tar.gz  -o /tmp/rust/rust-static.tar.gz
+RUN curl https://static.rust-lang.org/dist/rust-1.75.0-x86_64-unknown-linux-gnu.tar.gz -o /tmp/rust/rust-static.tar.gz
 RUN tar -C /tmp/rust -xf /tmp/rust/rust-static.tar.gz
 RUN $(find /tmp/rust -name 'install.sh')
 RUN rm -rf /tmp/rust


### PR DESCRIPTION
## Description
In the last change to the Rust version, we missed a spot and left the Static QT Docker image on version 1.69 while the rest of our project moved onto version 1.75. To fix this, I think we just need to bump the version in the rust download URL during the docker container setup.

This is causing dependabot to fail when trying to update dependencies to versions that no longer build cleanly on 1.69 (such as #9792)

## Reference
Introduced by #9935