### PR TITLE
Refine flatpak/dependabot conditions

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -105,7 +105,10 @@ jobs:
   dependabot-cargo:
     name: "Update Crates"
     runs-on: ubuntu-latest
-    if: ${{ startsWith(github.head_ref, 'dependabot/cargo/') && github.event_name == 'pull_request' }}
+    if: |
+      startsWith(github.head_ref, 'dependabot/cargo/') &&
+      github.actor ==  'dependabot[bot]' &&
+      github.event_name == 'pull_request'
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4


### PR DESCRIPTION
## Description
A while back in #9915 and #9930 we added some automation to keep the flatpak manifests in sync as dependabot tries to update the rust crates, and for the most part it has been working great! However, we find that after the action runs and commits the flatpak manifest the job runs again and ends with an error.

The error itself is harmless, but it means the CI is red and that makes me unhappy. So let's try to refine the workflow conditions a bit more so the job only runs once. To do this, we need to make it conditional on running with the dependabot actor too.

## Reference
Introduced by #9915 and #9930

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
