### PR TITLE
Nit: Fix MSVC warning

### DIFF
--- a/src/platforms/windows/daemon/windowssplittunnel.cpp
+++ b/src/platforms/windows/daemon/windowssplittunnel.cpp
@@ -712,4 +712,5 @@ QString WindowsSplitTunnel::stateString() {
       return "STATE_ZOMBIE";
       break;
   }
+  return {};
 }


### PR DESCRIPTION
## Description
Clang auto infers that all code-paths return a value .... msvc is unable to do so and therefore throws an error :) 