### PR TITLE
Reduce keyring debhelper compat to 12

### DIFF
--- a/linux/keyring/Makefile
+++ b/linux/keyring/Makefile
@@ -10,5 +10,8 @@ install:
 	install -d $(DESTDIR)/etc/apt/preferences.d
 	install -m 644 mozilla-vpn.pref $(DESTDIR)/etc/apt/preferences.d/
 
-.PHONY: build install
+deb:
+	dpkg-buildpackage -b -us -uc
+
+.PHONY: build install deb
 

--- a/linux/keyring/debian/control
+++ b/linux/keyring/debian/control
@@ -2,7 +2,7 @@ Source: mozilla-vpn-keyring
 Section: misc
 Priority: important
 Maintainer: Mozilla VPN Team <vpn@mozilla.com>
-Build-Depends: debhelper-compat (= 13)
+Build-Depends: debhelper-compat (= 12)
 Standards-Version: 4.6.0
 Homepage: https://vpn.mozilla.org/
 #Vcs-Git: https://github.com/mozilla-mobile/mozilla-vpn-client.git


### PR DESCRIPTION
## Description
The `mozilla-vpn-keyring` package isn't building on Ubuntu/Focal because we set the `debhelper-compat` package version to 13. Unfurtunately, that is too new of a debhelper version for Focal which only supports up to version 12.

I also added a phony target of `deb` to do the package build, because I forgot the commands to do so and felt silly having to look it up.

## Reference
JIRA Issue: [VPN-6365](https://mozilla-hub.atlassian.net/browse/VPN-6365)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-6365]: https://mozilla-hub.atlassian.net/browse/VPN-6365?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ