### PR TITLE
Bug 1927890 - Hardcode beetmover-apt-promote task to level 1 worker

### DIFF
--- a/taskcluster/config.yml
+++ b/taskcluster/config.yml
@@ -105,6 +105,14 @@ workers:
             implementation: beetmover-import-from-gcs-to-artifact-registry
             os: scriptworker
             worker-type: 'mozillavpn-{level}-beetmover'
+        # For now the `beetmover-apt-promote` task is importing to the staging
+        # apt repository. To do this it needs to run on a level 1 worker,
+        # despite running in an L3 release graph. See bug 1927890.
+        beetmover-apt-stage:
+            provisioner: scriptworker-k8s
+            implementation: beetmover-import-from-gcs-to-artifact-registry
+            os: scriptworker
+            worker-type: 'mozillavpn-1-beetmover'
         shipit:
             provisioner: scriptworker-k8s
             implementation: scriptworker-shipit

--- a/taskcluster/kinds/beetmover-apt/kind.yml
+++ b/taskcluster/kinds/beetmover-apt/kind.yml
@@ -20,16 +20,17 @@ task-defaults:
             build-type:
                 - linux64/release-deb
         set-name: null
-    worker-type: beetmover-apt
     worker:
         product: vpn
         max-run-time: 1800
 
 tasks:
     promote-linux64-deb:
+        worker-type: beetmover-apt-stage
         attributes:
             shipping-phase: promote-client
 
     ship-linux64-deb:
+        worker-type: beetmover-apt
         attributes:
             shipping-phase: ship-client


### PR DESCRIPTION
For now there isn't a good place for us to import the candidate package during the promote phase for QA to be able to test. So we use the "staging" apt repo. However, this lives in the non production GCP project, so we have to use the level 1 workers.

In the future we'll want to either:
1. Create a second apt repo in the production GCP project that we can use for QA prior to shipping.
2. Import the package into the main `mozillavpn` production apt repo but with a different name (e.g include `rc###` or similar). Then add a repackage task that renames it to the proper name during the ship phase.

## Description

    Describe your changes

## Reference

    i.e Jira or Github issue URL

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
