### PR TITLE
Nit: Cleanup "BackendFailures" in controller.cpp

### DIFF
--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -940,7 +940,6 @@ bool Controller::switchServers(const ServerData& serverData) {
   return true;
 }
 
-
 QString Controller::currentServerString() const {
   return QString("%1-%2-%3-%4")
       .arg(m_serverData.exitCountryCode(), m_serverData.exitCityName(),

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -817,12 +817,6 @@ bool Controller::processNextStep() {
     emit readyToUpdate();
     return true;
   }
-
-  if (nextStep == BackendFailure) {
-    emit readyToBackendFailure();
-    return true;
-  }
-
   return false;
 }
 
@@ -946,23 +940,6 @@ bool Controller::switchServers(const ServerData& serverData) {
   return true;
 }
 
-void Controller::backendFailure() {
-  logger.error() << "backend failure";
-
-  if (m_state == StateInitializing || m_state == StateOff) {
-    emit readyToBackendFailure();
-    return;
-  }
-
-  m_nextStep = BackendFailure;
-
-  if (m_state == StateOn || m_state == StateOnPartial ||
-      m_state == StateSwitching || m_state == StateSilentSwitching ||
-      m_state == StateConnecting || m_state == StateConfirming) {
-    deactivate();
-    return;
-  }
-}
 
 QString Controller::currentServerString() const {
   return QString("%1-%2-%3-%4")

--- a/src/controller.h
+++ b/src/controller.h
@@ -65,7 +65,6 @@ class Controller : public QObject, public LogSerializer {
   void captivePortalPresent();
   void captivePortalGone();
   bool switchServers(const ServerData& serverData);
-  void backendFailure();
   void updateRequired();
   void deleteOSTunnelConfig();
   void startHandshakeTimer();
@@ -148,7 +147,6 @@ class Controller : public QObject, public LogSerializer {
   void recordDataTransferTelemetry();
   void readyToQuit();
   void readyToUpdate();
-  void readyToBackendFailure();
   void readyToServerUnavailable(bool pingReceived);
   void activationBlockedForCaptivePortal();
   void isDeviceConnectedChanged();
@@ -191,7 +189,6 @@ class Controller : public QObject, public LogSerializer {
     Quit,
     Update,
     Disconnect,
-    BackendFailure,
   };
 
   NextStep m_nextStep = None;

--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -166,13 +166,6 @@ MozillaVPN::MozillaVPN() : App(nullptr), m_private(new MozillaVPNPrivate()) {
 
   connect(&m_private->m_controller, &Controller::readyToUpdate, this,
           [this]() { setState(StateUpdateRequired); });
-
-  connect(&m_private->m_controller, &Controller::readyToBackendFailure, this,
-          [this]() {
-            TaskScheduler::deleteTasks();
-            setState(StateBackendFailure);
-          });
-
   connect(&m_private->m_controller, &Controller::readyToServerUnavailable, this,
           [](bool pingReceived) {
             NotificationHandler::instance()->serverUnavailableNotification(
@@ -920,6 +913,10 @@ void MozillaVPN::activate() {
 void MozillaVPN::deactivate(bool block) {
   logger.debug() << "VPN tunnel deactivation";
 
+  if()
+
+
+
   TaskScheduler::deleteTasks();
   Task* task = new TaskControllerAction(TaskControllerAction::eDeactivate);
   if (block) {
@@ -1148,7 +1145,8 @@ void MozillaVPN::heartbeatCompleted(bool success) {
   // for the user to do and it may not affect the connectivity at all so it is
   // not necessary to take additional actions.
   if (!success && state() == StateAuthenticating) {
-    m_private->m_controller.backendFailure();
+    TaskScheduler::deleteTasks();
+    setState(StateBackendFailure);
     return;
   }
 

--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -913,10 +913,6 @@ void MozillaVPN::activate() {
 void MozillaVPN::deactivate(bool block) {
   logger.debug() << "VPN tunnel deactivation";
 
-  if()
-
-
-
   TaskScheduler::deleteTasks();
   Task* task = new TaskControllerAction(TaskControllerAction::eDeactivate);
   if (block) {
@@ -1146,11 +1142,11 @@ void MozillaVPN::heartbeatCompleted(bool success) {
   // not necessary to take additional actions.
   if (!success && state() == StateAuthenticating) {
     TaskScheduler::deleteTasks();
-    setState(StateBackendFailure);
+    setState(StateHeartbeatFailure);
     return;
   }
 
-  if (state() != StateBackendFailure) {
+  if (state() != StateHeartbeatFailure) {
     return;
   }
 
@@ -1445,9 +1441,10 @@ void MozillaVPN::registerNavigatorScreens() {
       });
 
   Navigator::registerScreen(
-      MozillaVPN::ScreenBackendFailure, Navigator::LoadPolicy::LoadTemporarily,
+      MozillaVPN::ScreenHeartbeatFailure,
+      Navigator::LoadPolicy::LoadTemporarily,
       "qrc:/qt/qml/Mozilla/VPN/screens/ScreenBackendFailure.qml",
-      QVector<int>{MozillaVPN::StateBackendFailure},
+      QVector<int>{MozillaVPN::StateHeartbeatFailure},
       [](int*) -> int8_t { return 0; }, []() -> bool { return false; });
 
   Navigator::registerScreen(
@@ -1878,14 +1875,6 @@ void MozillaVPN::registerInspectorCommands() {
         AddonManager::instance()->fetch();
         return QJsonObject();
       });
-
-  InspectorHandler::registerCommand(
-      "force_backend_failure", "Force a backend failure", 0,
-      [](InspectorHandler*, const QList<QByteArray>&) {
-        MozillaVPN::instance()->controller()->backendFailure();
-        return QJsonObject();
-      });
-
   InspectorHandler::registerCommand(
       "force_captive_portal_check", "Force a captive portal check", 0,
       [](InspectorHandler*, const QList<QByteArray>&) {

--- a/src/mozillavpn.h
+++ b/src/mozillavpn.h
@@ -46,7 +46,7 @@ class MozillaVPN final : public App {
  public:
   enum CustomState {
     StateDeviceLimit = StateCustom + 1,
-    StateBackendFailure,
+    StateHeartbeatFailure,
     StateUpdateRequired,
   };
   Q_ENUM(CustomState);
@@ -54,7 +54,7 @@ class MozillaVPN final : public App {
   enum CustomScreen {
     ScreenAuthenticating = Navigator::ScreenCustom + 1,
     ScreenAuthenticationInApp,
-    ScreenBackendFailure,
+    ScreenHeartbeatFailure,
     ScreenBillingNotAvailable,
     ScreenCaptivePortal,
     ScreenCrashReporting,

--- a/src/ui/screens/ScreenBackendFailure.qml
+++ b/src/ui/screens/ScreenBackendFailure.qml
@@ -9,6 +9,12 @@ import Mozilla.Shared 1.0
 import Mozilla.VPN 1.0
 import components 0.1
 
+/**
+* This screen is an error that should be triggered
+* whenever we have a hearbeatfailure. 
+* Note: we did not rename the file as that would nuke 
+* translations at this point in time. 
+**/
 MZStackView {
     id: stackview
 

--- a/tests/qml/moccontroller.cpp
+++ b/tests/qml/moccontroller.cpp
@@ -70,8 +70,6 @@ void Controller::getStatus(
 
 void Controller::quit() {}
 
-void Controller::backendFailure() {}
-
 void Controller::captivePortalPresent() {}
 
 void Controller::captivePortalGone() {}

--- a/tests/unit/moccontroller.cpp
+++ b/tests/unit/moccontroller.cpp
@@ -76,8 +76,6 @@ void Controller::getStatus(
 
 void Controller::quit() {}
 
-void Controller::backendFailure() {}
-
 void Controller::captivePortalPresent() {}
 
 void Controller::captivePortalGone() {}


### PR DESCRIPTION
Time for some cleanup.
![](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExZ2tibGtyaW5iYjU0eHc5dG5icHg0bnk1Y203ZGdqNnByc295czhvNSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/4ZtzzqkAahINGZoUxo/giphy-downsized.gif)

## Description
This was the old hearbeat check
```c++
void MozillaVPN::heartbeatCompleted(bool success) {
  logger.debug() << "Server-side check done:" << success;

  if (!success) {
    m_private->m_controller.backendFailure();
    return;
  }

  if (m_state != StateBackendFailure) {
    return;
  }

  if (!modelsInitialized() || m_userState != UserAuthenticated) {
    setState(StateInitialize);
    return;
  }

  maybeStateMain();
}
```
So there we actually needed the controller to deativate and come back later. 
Nowadays we only care during auth for heartbeat, we so vpn can't be activated anymore. So let's remove the controller code and rename all the screens to heartbeat failure, as otherwise a confused engineer might think this could have something to do with the daemon :) 



