### PR TITLE
Linux: Drop CAP_NET_RAW capability from binary

### DIFF
--- a/docs/Building/linux.md
+++ b/docs/Building/linux.md
@@ -22,7 +22,7 @@ Install all of Qt version 6.2.4 and you'll have everything you need.
 On Ubuntu, apt install the following dependencies
 
 * libsecret-1 (>=0.18)
-* libcap2-bin (>=1:2.32)
+* libcap-dev (>=1:2.32)
 * wireguard (>=1.0.20200319)
 * wireguard-tools (>=1.0.20200319)
 

--- a/linux/debian/control
+++ b/linux/debian/control
@@ -41,8 +41,7 @@ Vcs-Git: https://github.com/mozilla-mobile/mozilla-vpn-client
 
 Package: mozillavpn
 Architecture: any
-Depends: libcap2-bin (>=1:2.32),
-         wireguard (>=1.0.20200319),
+Depends: wireguard (>=1.0.20200319),
          wireguard-tools (>=1.0.20200319),
          libsecret-1-0,
          libfreetype6,

--- a/linux/debian/mozillavpn.postinst
+++ b/linux/debian/mozillavpn.postinst
@@ -1,9 +1,0 @@
-#!/bin/sh
-set -e
-
-action="$1"
-if [ "$action" = "configure" ]; then
-    setcap cap_net_raw+ep /usr/bin/mozillavpn
-fi
-
-#DEBHELPER#

--- a/scripts/linux/postinst.cmake
+++ b/scripts/linux/postinst.cmake
@@ -26,12 +26,3 @@ if(SYSTEMCTL_EXECUTABLE)
         COMMAND ${SYSTEMCTL_EXECUTABLE} restart mozillavpn
     )
 endif()
-
-# If we can, run setcap on the installed VPN binary.
-find_program(SETCAP_EXECUTABLE setcap)
-if(SETCAP_EXECUTABLE)
-    execute_process(
-        COMMAND ${SETCAP_EXECUTABLE} cap_net_raw+ep ${CMAKE_INSTALL_PREFIX}/bin/mozillavpn
-    )
-endif()
-


### PR DESCRIPTION
## Description

I have been fighting with the `XdgCryptoSettings` on my Fedora machine which fails to retrieve the secret. The XDG Desktop portal throws an error because the clients procfs entry is root-owned. It turns out this is because the process image has elevated capabilities and we need to drop them before XDG will let us read secrets.

So, why do we have `CAP_NET_RAW` granted at all? Well, it was added to enable the client to send ICMP pings using a raw socket if the kernel doesn't allow us to use ICMP sockets. However, we now have workarounds that use TCP for connection health monitoring too, so it's not really needed anymore.

## Reference
JIRA Issue [VPN-6422](https://mozilla-hub.atlassian.net/browse/VPN-6422)
Introduced by: #9922

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-6422]: https://mozilla-hub.atlassian.net/browse/VPN-6422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ