### PR TITLE
Nits for mordor

### DIFF
--- a/src/platforms/windows/daemon/windowssplittunnel.cpp
+++ b/src/platforms/windows/daemon/windowssplittunnel.cpp
@@ -340,6 +340,10 @@ bool WindowsSplitTunnel::start(int inetAdapterIndex) {
   logger.debug() << "Driver is  ready || new State:" << stateString();
 
   auto config = generateIPConfiguration(inetAdapterIndex);
+  if(config.empty()){
+     logger.error() << "Failed to set Network Config";
+    return false;
+  }
   auto ok = DeviceIoControl(m_driver, IOCTL_REGISTER_IP_ADDRESSES, &config[0],
                             (DWORD)config.size(), nullptr, 0, &bytesReturned,
                             nullptr);

--- a/src/platforms/windows/daemon/windowssplittunnel.cpp
+++ b/src/platforms/windows/daemon/windowssplittunnel.cpp
@@ -340,8 +340,8 @@ bool WindowsSplitTunnel::start(int inetAdapterIndex) {
   logger.debug() << "Driver is  ready || new State:" << stateString();
 
   auto config = generateIPConfiguration(inetAdapterIndex);
-  if(config.empty()){
-     logger.error() << "Failed to set Network Config";
+  if (config.empty()) {
+    logger.error() << "Failed to set Network Config";
     return false;
   }
   auto ok = DeviceIoControl(m_driver, IOCTL_REGISTER_IP_ADDRESSES, &config[0],

--- a/src/platforms/windows/daemon/wireguardutilswindows.cpp
+++ b/src/platforms/windows/daemon/wireguardutilswindows.cpp
@@ -410,7 +410,7 @@ bool WireguardUtilsWindows::updatePeer(const InterfaceConfig& config) {
   // Exclude the server address, except for multihop exit servers.
   if (m_routeMonitor && (config.m_hopType != InterfaceConfig::MultiHopExit)) {
     m_routeMonitor->addExclusionRoute(IPAddress(config.m_serverIpv4AddrIn));
-    if(!config.m_serverIpv6AddrIn.isEmpty()){
+    if (!config.m_serverIpv6AddrIn.isEmpty()) {
       m_routeMonitor->addExclusionRoute(IPAddress(config.m_serverIpv6AddrIn));
     }
   }

--- a/src/platforms/windows/daemon/wireguardutilswindows.cpp
+++ b/src/platforms/windows/daemon/wireguardutilswindows.cpp
@@ -377,7 +377,7 @@ bool WireguardUtilsWindows::updatePeer(const InterfaceConfig& config) {
   // we need to make sure this is the right decision.
   wgnt_conf.peer.Endpoint.si_family = AF_INET;
   wgnt_conf.peer.Endpoint.Ipv4.sin_family = AF_INET;
-  wgnt_conf.peer.Endpoint.Ipv4.sin_port = config.m_serverPort;
+  wgnt_conf.peer.Endpoint.Ipv4.sin_port = htons(config.m_serverPort);
 
   if (!inet_pton(AF_INET, qPrintable(config.m_serverIpv4AddrIn),
                  &wgnt_conf.peer.Endpoint.Ipv4.sin_addr)) {
@@ -411,7 +411,7 @@ bool WireguardUtilsWindows::updatePeer(const InterfaceConfig& config) {
   if (m_routeMonitor && (config.m_hopType != InterfaceConfig::MultiHopExit)) {
     m_routeMonitor->addExclusionRoute(IPAddress(config.m_serverIpv4AddrIn));
     if(!config.m_serverIpv6AddrIn.isEmpty()){
-    m_routeMonitor->addExclusionRoute(IPAddress(config.m_serverIpv6AddrIn));
+      m_routeMonitor->addExclusionRoute(IPAddress(config.m_serverIpv6AddrIn));
     }
   }
   return true;

--- a/src/platforms/windows/daemon/wireguardutilswindows.cpp
+++ b/src/platforms/windows/daemon/wireguardutilswindows.cpp
@@ -410,7 +410,9 @@ bool WireguardUtilsWindows::updatePeer(const InterfaceConfig& config) {
   // Exclude the server address, except for multihop exit servers.
   if (m_routeMonitor && (config.m_hopType != InterfaceConfig::MultiHopExit)) {
     m_routeMonitor->addExclusionRoute(IPAddress(config.m_serverIpv4AddrIn));
+    if(!config.m_serverIpv6AddrIn.isEmpty()){
     m_routeMonitor->addExclusionRoute(IPAddress(config.m_serverIpv6AddrIn));
+    }
   }
   return true;
 }


### PR DESCRIPTION
Some things found while we played with the config files: 
- **Dont try to give a pointer to an unallocated vector**
- **Dont try to create an address from an empty string**
- **Use correct byteorder for wireguard**
