### PR TITLE
Update RPM build to Fedora 41

### DIFF
--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -51,7 +51,7 @@ jobs:
     needs: source-bundle
     runs-on: ubuntu-latest
     container:
-      image: fedora:40
+      image: fedora:41
 
     steps:
       - name: Download Source Package

--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -62,7 +62,7 @@ jobs:
       - name: Install Build Dependencies
         run: |
           dnf -y update
-          dnf -y install rpmdevtools 'dnf-command(builddep)'
+          dnf -y install gdb rpmdevtools 'dnf-command(builddep)'
           dnf -y builddep mozillavpn.spec
 
       - name: Building package


### PR DESCRIPTION
Fedora 41 was released on 2024-10-29, cf. https://discussion.fedoraproject.org/t/fedora-linux-41-is-here/134766.

Current builds (tried `mozillavpn-2.25.0~build20241108-1.x86_64` downloaded from https://github.com/mozilla-mobile/mozilla-vpn-client/actions/runs/11733374458) depend upon `libQt6Core.so.6(Qt_6.7_PRIVATE_API)(64bit)` but since Fedora 41 is on Qt 6.8 no current package provides that symbol.

See-also: https://github.com/mozilla-mobile/mozilla-vpn-client/issues/9966