### PR TITLE
VPN-6649: fix translations for cities with special characters

### DIFF
--- a/scripts/ci/update_server_names.py
+++ b/scripts/ci/update_server_names.py
@@ -61,15 +61,11 @@ if __name__ == "__main__":
     string_map = countries
     for city in cities:
         # Remove state suffix, capitalize each work, remove spaces.
-        baseId = city.split(",")[0].strip().title().replace(" ", "")
+        id = city.split(",")[0].strip().title().replace(" ", "")
         # Remove special characters like the `ö` in `Malmö`
-        allowedIdChars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
-        simpleId = ""
-        for char in baseId:
-            if char in allowedIdChars:
-                simpleId = simpleId + char
+        id = re.sub(r'[^a-zA-Z]+', '', id)
         # Add it to the map
-        string_map[simpleId] = city
+        string_map[id] = city
 
     ###
     # 2. Fetch the list of servers in extras.xliff

--- a/scripts/ci/update_server_names.py
+++ b/scripts/ci/update_server_names.py
@@ -61,8 +61,15 @@ if __name__ == "__main__":
     string_map = countries
     for city in cities:
         # Remove state suffix, capitalize each work, remove spaces.
-        id = city.split(",")[0].strip().title().replace(" ", "")
-        string_map[id] = city
+        baseId = city.split(",")[0].strip().title().replace(" ", "")
+        # Remove special characters like the `ö` in `Malmö`
+        allowedIdChars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+        simpleId = ""
+        for char in baseId:
+            if char in allowedIdChars:
+                simpleId = simpleId + char
+        # Add it to the map
+        string_map[simpleId] = city
 
     ###
     # 2. Fetch the list of servers in extras.xliff

--- a/src/translations/extras/extras.xliff
+++ b/src/translations/extras/extras.xliff
@@ -384,9 +384,6 @@
       <trans-unit id="servers.Gothenburg" xml:space="preserve">
         <source>Gothenburg</source>
       </trans-unit>
-      <trans-unit id="servers.Malmö" xml:space="preserve">
-        <source>Malmö</source>
-      </trans-unit>
       <trans-unit id="servers.Stockholm" xml:space="preserve">
         <source>Stockholm</source>
       </trans-unit>
@@ -530,6 +527,9 @@
       </trans-unit>
       <trans-unit id="servers.Nicosia" xml:space="preserve">
         <source>Nicosia</source>
+      </trans-unit>
+      <trans-unit id="servers.Malm" xml:space="preserve">
+        <source>Malmö</source>
       </trans-unit>
     </body>
   </file>


### PR DESCRIPTION
## Description

Malmö is the only city with special characters in the name. Our build scripts should handle this fine - and we use `Servers.Malm` for the string ID. It builds perfectly on my machine, but was failing on TaskCluster. This failure was due to taskcluster not handling special characters in string IDs in the same way my machine does, apparently. While special characters should be removed from string IDs, they weren't being removed.

This PR adds "cleaning of special characters" on the front end - before we pass the string IDs to the translation repo. Thus, we'll now keep the ID as `servers.Malm` for the round trip journey from our client repo to the translation repo and back. 

VPN-6649 will be fixed as 4 separate PRs, merged in order:
1. A PR on the translation repo to copy all existing translations of Malmö from `servers.Malmö` to `servers.Malm` (https://github.com/mozilla-l10n/mozilla-vpn-client-l10n/pull/488)
2. A fixit PR on the translation repo: https://github.com/mozilla-l10n/mozilla-vpn-client-l10n/pull/490/files
3. This PR, which will update the translation script.
4. Another PR on the translation repo to remove all the legacy `servers.Malmö` translations.

More details from my research:
1. In `Localizer::getTranslatedCityName`, we have the following values on my machine on `main` branch: `cityName  Malmö / parsedCityName  Malm  / i18nCityId  ServersMalm / value  Μάλμε`. On TaskCluster (on `main`), we get the same ones with one exception - value is `Malmö`.
5. Digging deeper into how `value` is created here, this seems to imply it's an issue with the translation that Qt is pulling out.
6. Looking at how we build our translation files, we have this line being build on TaskCluster: `<message id="servers.Malmö">` When building locally, I get the same thing. This is in `build/translations/generated/mozillavpn_el.ts`. This makes sense, as `servers.Malmö` is the string ID used in the translation repo.
7. After the .ts file is created in our build process, we use `lconvert` to convert it to a binary `qm` file. `qm` files are binary, and are somewhat of a black box to us.
8. It seems like somewhere in `lconvert` or loading the files when running the client, special characters should get stripped out from the translation ID. And they are on my machine, but not on TaskCluster. In both cases, what happens at this level is somewhat unknown, as they get deep Qt's handling of translations - it's deeper than our translation scripts (for creating translation files or loading them into the client).

(A different approach to solving this bug was taken in https://github.com/mozilla-mobile/mozilla-vpn-client/pull/9964 - that PR is being closed in favor of this one.)

## Reference

VPN-6649

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
