### PR TITLE
VPN-6715 and VPN-6716 - fix layout issues

### DIFF
--- a/nebula/ui/components/MZFlickable.qml
+++ b/nebula/ui/components/MZFlickable.qml
@@ -11,7 +11,7 @@ import Mozilla.VPN 1.0
 Flickable {
     id: vpnFlickable
 
-    property var flickContentHeight
+    property var flickContentHeight: 0
     property bool contentExceedsHeight: height < contentHeight
     property bool hideScollBarOnStackTransition: false
     property bool addNavbarHeightOffset: navbar.visible

--- a/nebula/ui/components/MZHelpSheet.qml
+++ b/nebula/ui/components/MZHelpSheet.qml
@@ -150,11 +150,10 @@ MZBottomSheet {
                 id: flickable
 
                 readonly property int maxheight: bottomSheet.maxSheetHeight - headerLayout.implicitHeight - headerLayout.Layout.topMargin
+                flickContentHeight: layout.implicitHeight + layout.anchors.topMargin + layout.anchors.bottomMargin
 
                 Layout.fillWidth: true
-                Layout.preferredHeight: Math.min(layout.implicitHeight + layout.anchors.topMargin + layout.anchors.bottomMargin, maxheight)
-
-                flickContentHeight: layout.implicitHeight + layout.anchors.topMargin + layout.anchors.bottomMargin
+                implicitHeight: Math.min(flickContentHeight, maxheight)
 
                 addNavbarHeightOffset: false
 


### PR DESCRIPTION
## Description

From a bisect, it was this commit that introduced both issues: https://github.com/mozilla-mobile/mozilla-vpn-client/commit/874ffe4b5f2bf437f5b4cf9f354f51b8b9e02d84

For the "blank reset screen" issue - Within `recalculateContentHeight`, `vpnFlickable.contentHeight = flickContentHeight` was having an issue because we were setting an undefined variable. Giving a default value of 0 to `flickContentHeight` fixes this.

For the "drawers are too small" issue - The warning in the logs was: `Warning: qrc:/nebula/components/MZBottomSheet.qml:51:22: QML Drawer: Binding loop detected for property "implicitHeight" (MZBottomSheet.qml:51)` I did a bunch of research, and found a bunch of ways to fix the bug... that still resulted in the warning in the logs. (Presumably the first layout pass produced the warning, but it fixed itself on further passes.) Changing `Layout.preferredHeight` to `implicitHeight` seemingly fixes the bug without ever giving the same warning in the logs. (While I was in that area of the code, I also changed the `min` statement to be more legible and use the variable name.)

## Reference

VPN-6715 and VPN-6716

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
