### PR TITLE
Fix iOS build failures on Taskcluster

### DIFF
--- a/taskcluster/scripts/build/ios_build_debug.sh
+++ b/taskcluster/scripts/build/ios_build_debug.sh
@@ -25,7 +25,6 @@ export LC_ALL=en_US.utf-8
 export LANG=en_US.utf-8
 export PYTHONIOENCODING="UTF-8"
 
-
 print Y "Installing conda"
 # We need to call bash with a login shell, so that conda is intitialized
 source $TASK_WORKDIR/fetches/bin/activate
@@ -45,6 +44,7 @@ if [ -d ${TASK_HOME}/build ]; then
 fi
 mkdir ${TASK_HOME}/build
 
+unset SDKROOT
 env
 whereis qt-cmake
 cat $TASK_WORKDIR/fetches/bin/qt-cmake

--- a/taskcluster/scripts/build/ios_build_debug.sh
+++ b/taskcluster/scripts/build/ios_build_debug.sh
@@ -44,12 +44,11 @@ if [ -d ${TASK_HOME}/build ]; then
 fi
 mkdir ${TASK_HOME}/build
 
+# Clear the SDKROOT and rely on CMake to figure it out. Otherwise, if this
+# is set to the host SDK it will break the iOS toolchain detection.
 unset SDKROOT
-env
-whereis qt-cmake
-cat $TASK_WORKDIR/fetches/bin/qt-cmake
 
-qt-cmake -S . -B ${TASK_HOME}/build \
+$TASK_WORKDIR/fetches/bin/qt-cmake -S . -B ${TASK_HOME}/build \
   -DCMAKE_OSX_ARCHITECTURES="arm64" \
   -DCMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY="" \
   -DCMAKE_XCODE_ATTRIBUTE_CODE_SIGNING_REQUIRED="NO" \


### PR DESCRIPTION
## Description
The iOS builds have been failing on Taskcluster for a while now, and it seems like the problem is related to the `SDKROOT` environment being set. I am guessing this is due to a change on the MacOS worker machines. To fix it, we basically just need to unset the environment variable and let CMake do its thing.

## Reference

    i.e Jira or Github issue URL

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
