### PR TITLE
Fix flaky AuthenticationInAppAccountCreationNav tests

### DIFF
--- a/src/authenticationinapp/authenticationinapp.h
+++ b/src/authenticationinapp/authenticationinapp.h
@@ -20,6 +20,7 @@ class AuthenticationInApp final : public QObject {
   Q_PROPERTY(QString emailAddress READ emailAddress NOTIFY emailAddressChanged);
   Q_PROPERTY(QStringList attachedClients READ attachedClients NOTIFY
                  attachedClientsChanged);
+  Q_PROPERTY(State state READ state NOTIFY stateChanged)
 
  public:
   enum State {
@@ -88,8 +89,6 @@ class AuthenticationInApp final : public QObject {
   };
   Q_ENUM(ErrorType);
 
- private:
-  Q_PROPERTY(State state READ state NOTIFY stateChanged)
 
  public:
   static AuthenticationInApp* instance();

--- a/src/authenticationinapp/authenticationinapp.h
+++ b/src/authenticationinapp/authenticationinapp.h
@@ -89,7 +89,6 @@ class AuthenticationInApp final : public QObject {
   };
   Q_ENUM(ErrorType);
 
-
  public:
   static AuthenticationInApp* instance();
 

--- a/tests/functional/testAuthenticationInAppAccountCreationNav.js
+++ b/tests/functional/testAuthenticationInAppAccountCreationNav.js
@@ -40,7 +40,7 @@ describe('User authentication', function() {
       // Step 1: main -> start -> main
       await vpn.waitForInitialView();
       await vpn.clickOnQuery(queries.screenInitialize.SIGN_UP_BUTTON.visible());
-      await vpn.waitForQuery(queries.global.SCREEN_LOADER.ready());
+      await vpn.waitForQuery(queries.screenAuthenticationInApp.AUTH_LOADER.ready());
       await vpn.waitForQueryAndClick(
           queries.screenAuthenticationInApp.AUTH_START_BACK_BUTTON.visible());
       await vpn.waitForInitialView();
@@ -53,7 +53,7 @@ describe('User authentication', function() {
           queries.screenAuthenticationInApp.AUTH_START_GET_HELP_LINK.visible());
       await vpn.waitForQuery(queries.screenGetHelp.STACKVIEW.ready());
       await vpn.waitForQueryAndClick(queries.screenGetHelp.BACK_BUTTON.visible());
-      await vpn.waitForQuery(queries.global.SCREEN_LOADER.ready());
+      await vpn.waitForQuery(queries.screenAuthenticationInApp.AUTH_LOADER.ready());
       await vpn.waitForQuery(
           queries.screenAuthenticationInApp.AUTH_START_TEXT_INPUT.visible());
 
@@ -77,7 +77,7 @@ describe('User authentication', function() {
                                          .AUTH_SIGNUP_GET_HELP_LINK.visible());
       await vpn.waitForQuery(queries.screenGetHelp.STACKVIEW.ready());
       await vpn.waitForQueryAndClick(queries.screenGetHelp.BACK_BUTTON.visible());
-      await vpn.waitForQuery(queries.global.SCREEN_LOADER.ready());
+      await vpn.waitForQuery(queries.screenAuthenticationInApp.AUTH_LOADER.ready());
       await vpn.waitForQuery(
           queries.screenAuthenticationInApp.AUTH_SIGNUP_BACK_BUTTON.visible());
 
@@ -99,12 +99,15 @@ describe('User authentication', function() {
       await vpn.waitForQueryAndClick(
           queries.screenAuthenticationInApp.AUTH_START_BUTTON.visible()
               .enabled());
+      await vpn.waitForMozillaProperty(
+          'Mozilla.Shared', 'MZAuthInApp', 'state', 'StateSignIn');
+      await vpn.waitForQuery(queries.screenAuthenticationInApp.AUTH_LOADER.ready());
 
       await vpn.waitForQueryAndClick(queries.screenAuthenticationInApp
                                          .AUTH_SIGNIN_GET_HELP_LINK.visible());
       await vpn.waitForQuery(queries.screenGetHelp.STACKVIEW.ready());
       await vpn.waitForQueryAndClick(queries.screenGetHelp.BACK_BUTTON.visible());
-      await vpn.waitForQuery(queries.global.SCREEN_LOADER.ready());
+      await vpn.waitForQuery(queries.screenAuthenticationInApp.AUTH_LOADER.ready());
       await vpn.waitForQuery(
           queries.screenAuthenticationInApp.AUTH_SIGNIN_BACK_BUTTON.visible());
 
@@ -147,7 +150,7 @@ describe('User authentication', function() {
               .visible());
       await vpn.waitForQuery(queries.screenGetHelp.STACKVIEW.ready());
       await vpn.waitForQueryAndClick(queries.screenGetHelp.BACK_BUTTON.visible());
-      await vpn.waitForQuery(queries.global.SCREEN_LOADER.ready());
+      await vpn.waitForQuery(queries.screenAuthenticationInApp.AUTH_LOADER.ready());
 
       // Step 8: email verification -> start
       await vpn.waitForQueryAndClick(
@@ -187,7 +190,7 @@ describe('User authentication', function() {
           queries.screenAuthenticationInApp.AUTH_TOTP_GET_HELP_LINK.visible());
       await vpn.waitForQuery(queries.screenGetHelp.STACKVIEW.ready());
       await vpn.waitForQueryAndClick(queries.screenGetHelp.BACK_BUTTON.visible());
-      await vpn.waitForQuery(queries.global.SCREEN_LOADER.ready());
+      await vpn.waitForQuery(queries.screenAuthenticationInApp.AUTH_LOADER.ready());
       await vpn.waitForQuery(
           queries.screenAuthenticationInApp.AUTH_TOTP_CANCEL_BUTTON.visible());
 
@@ -231,7 +234,7 @@ describe('User authentication', function() {
               .visible());
       await vpn.waitForQuery(queries.screenGetHelp.STACKVIEW.ready());
       await vpn.waitForQueryAndClick(queries.screenGetHelp.BACK_BUTTON.visible());
-      await vpn.waitForQuery(queries.global.SCREEN_LOADER.ready());
+      await vpn.waitForQuery(queries.screenAuthenticationInApp.AUTH_LOADER.ready());
       await vpn.waitForQuery(queries.screenAuthenticationInApp
                                  .AUTH_UNBLOCKCODE_BACK_BUTTON.visible());
 

--- a/tests/functional/testAuthenticationInAppAccountCreationNav.js
+++ b/tests/functional/testAuthenticationInAppAccountCreationNav.js
@@ -69,7 +69,9 @@ describe('User authentication', function() {
       await vpn.waitForQueryAndClick(
           queries.screenAuthenticationInApp.AUTH_START_BUTTON.visible()
               .enabled());
-      await vpn.waitForQuery(queries.global.SCREEN_LOADER.ready());
+      await vpn.waitForMozillaProperty(
+          'Mozilla.Shared', 'MZAuthInApp', 'state', 'StateSignUp');
+      await vpn.waitForQuery(queries.screenAuthenticationInApp.AUTH_LOADER.ready());
 
       await vpn.waitForQueryAndClick(queries.screenAuthenticationInApp
                                          .AUTH_SIGNUP_GET_HELP_LINK.visible());


### PR DESCRIPTION
## Description
At last, my cup runneth over with frustration when it comes to the `AuthenticationInAppAccountCreationNav` tests, and it's time to figure out why they are flaky. It seems the problem has to do with the fact that we have multiple QML loaders at play in the authentication screens, and for the most part we want to be waiting on the Authentication screen's loader to finish rather than the global loader.

We should also be checking the auth state as well to ensure we get the correct state transitions.

I should probably look at the Addons tests too at some point, but those are scary.

## Reference
So, so many test retries. Arggggggghhhhh

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
