### PR TITLE
Use caching to speed up functional tests

### DIFF
--- a/.github/workflows/build_addons.yaml
+++ b/.github/workflows/build_addons.yaml
@@ -1,0 +1,44 @@
+# A reusable workflow to build addons
+on:
+  workflow_call:
+    inputs:
+      test-addons-name:
+        required: true
+        type: string
+
+jobs:
+  build-test-addons:
+    name: Build Test Addons
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+
+      - name: Setup addons cache
+        id: addons-cache
+        uses: actions/cache@v4
+        with:
+          path: build-addons/
+          key: test-addons-${{ hashFiles('addons/', 'test/functional/addons/') }}
+
+      - name: Install build dependencies
+        if: steps.addons-cache.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          git submodule init
+          git submodule update 3rdparty/i18n
+          sudo apt-get update
+          sudo apt-get install -y $(./scripts/linux/getdeps.py -b linux/debian/control)
+
+      - name: Build test addons
+        if: steps.addons-cache.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          mkdir -p build-addons/
+          cmake -S $(pwd)/tests/functional/addons -B build-addons/
+          cmake --build build-addons/
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.test-addons-name }}
+          path: build-addons/

--- a/.github/workflows/linux_tests.yaml
+++ b/.github/workflows/linux_tests.yaml
@@ -15,7 +15,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build_test_adons:
+  build_test_addons:
     runs-on: ubuntu-latest
     steps:
       - name: Clone repository

--- a/.github/workflows/linux_tests.yaml
+++ b/.github/workflows/linux_tests.yaml
@@ -16,39 +16,10 @@ concurrency:
 
 jobs:
   build_test_addons:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v4
-
-      - name: Setup addons cache
-        id: addons-cache
-        uses: actions/cache@v4
-        with:
-          path: build-addons/
-          key: test-addons-${{ hashFiles('addons/', 'test/functional/addons/') }}
-
-      - name: Install build dependencies
-        if: steps.addons-cache.outputs.cache-hit != 'true'
-        shell: bash
-        run: |
-          git submodule init
-          git submodule update 3rdparty/i18n
-          sudo apt-get update
-          sudo apt-get install -y $(./scripts/linux/getdeps.py -b linux/debian/control)
-
-      - name: Build test addons dependencies
-        if: steps.addons-cache.outputs.cache-hit != 'true'
-        shell: bash
-        run: |
-          mkdir -p build-addons/
-          cmake -S $(pwd)/tests/functional/addons -B build-addons/
-          cmake --build build-addons/
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: test-addons-${{ github.sha }}
-          path: build-addons/
+    name: Build Test Addons
+    uses: ./.github/workflows/build_addons.yaml
+    with:
+      test-addons-name: test-addons-${{ github.sha }}
 
   build_test_app:
     name: Build Test Client
@@ -64,9 +35,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y $(./scripts/linux/getdeps.py -a linux/debian/control) ccache
 
-          echo "DEBUG: ccache configuration"
-          ccache -p
-
       - uses: actions/setup-python@v5
         with:
           python-version: "3.9"
@@ -76,7 +44,7 @@ jobs:
       - name: Setup compiler cache
         uses: actions/cache@v4
         with:
-          path: ~/.ccache
+          path: ~/.cache/ccache
           key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.event_name == 'pull_request' && 'pull' || 'sha' }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.sha }}
           restore-keys: |
             ccache-${{ runner.os }}-${{ runner.arch }}-sha-${{ github.event.pull_request.base.sha }}

--- a/.github/workflows/linux_tests.yaml
+++ b/.github/workflows/linux_tests.yaml
@@ -45,9 +45,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/ccache
-          key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.event_name == 'pull_request' && 'pull' || 'sha' }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.sha }}
-          restore-keys: |
-            ccache-${{ runner.os }}-${{ runner.arch }}-sha-${{ github.event.pull_request.base.sha }}
+          key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}
+          lookup-only: github.event_name == 'pull_request'
+          restore-keys: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.sha }}
 
       - name: Compile test client
         shell: bash

--- a/.github/workflows/linux_tests.yaml
+++ b/.github/workflows/linux_tests.yaml
@@ -15,6 +15,41 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  build_test_adons:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+
+      - name: Setup addons cache
+        id: addons-cache
+        uses: actions/cache@v4
+        with:
+          path: build-addons/
+          key: test-addons-${{ hashFiles('addons/', 'test/functional/addons/') }}
+
+      - name: Install build dependencies
+        if: steps.addons-cache.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          git submodule init
+          git submodule update 3rdparty/i18n
+          sudo apt-get update
+          sudo apt-get install -y $(./scripts/linux/getdeps.py -b linux/debian/control)
+
+      - name: Build test addons dependencies
+        if: steps.addons-cache.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          mkdir -p build-addons/
+          cmake -S $(pwd)/tests/functional/addons -B build-addons/
+          cmake --build build-addons/
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: test-addons-${{ github.sha }}
+          path: build-addons/
+
   build_test_app:
     name: Build Test Client
     runs-on: ubuntu-22.04
@@ -28,6 +63,9 @@ jobs:
       - run: |
           sudo apt-get update
           sudo apt-get install -y $(./scripts/linux/getdeps.py -a linux/debian/control) ccache
+
+          echo "DEBUG: ccache configuration"
+          ccache -p
 
       - uses: actions/setup-python@v5
         with:
@@ -51,14 +89,6 @@ jobs:
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache
           cmake --build build/cmake
           cp ./build/cmake/src/mozillavpn build/
-
-      - name: Compile test addons
-        shell: bash
-        run: |
-          mkdir -p build/addons
-          cmake -S $(pwd)/tests/functional/addons -B build/addons \
-            -DCMAKE_PREFIX_PATH=${{ github.workspace }}/qt_dist/lib/cmake
-          cmake --build build/addons
 
       - uses: actions/upload-artifact@v4
         with:
@@ -87,6 +117,7 @@ jobs:
     name: Functional tests
     needs:
       - build_test_app
+      - build_test_addons
     runs-on: ubuntu-22.04
     timeout-minutes: 45
     strategy:
@@ -101,6 +132,11 @@ jobs:
         with:
           name: test-client-${{ github.sha }}
           path: build/
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: test-addons-${{ github.sha }}
+          path: build/addons/
 
       - name: Install test dependecies
         run: |

--- a/.github/workflows/linux_tests.yaml
+++ b/.github/workflows/linux_tests.yaml
@@ -27,7 +27,7 @@ jobs:
           submodules: "recursive"
       - run: |
           sudo apt-get update
-          sudo apt-get install -y $(./scripts/linux/getdeps.py -a linux/debian/control)
+          sudo apt-get install -y $(./scripts/linux/getdeps.py -a linux/debian/control) ccache
 
       - uses: actions/setup-python@v5
         with:
@@ -35,11 +35,20 @@ jobs:
           cache: "pip"
       - run: pip install -r requirements.txt
 
+      - name: Setup compiler cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.ccache
+          key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.event_name == 'pull_request' && 'pull' || 'sha' }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.sha }}
+          restore-keys: |
+            ccache-${{ runner.os }}-${{ runner.arch }}-sha-${{ github.event.pull_request.base.sha }}
+
       - name: Compile test client
         shell: bash
         run: |
           mkdir -p build/cmake
-          cmake -S $(pwd) -B build/cmake -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo
+          cmake -S $(pwd) -B build/cmake -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache
           cmake --build build/cmake
           cp ./build/cmake/src/mozillavpn build/
 

--- a/.github/workflows/macos_tests.yaml
+++ b/.github/workflows/macos_tests.yaml
@@ -64,7 +64,9 @@ jobs:
       - name: Download cargo packages
         if: steps.cargo-vendor.outputs.cache-hit != 'true'
         shell: bash
-        run: cargo vendor --manifest-path Cargo.toml 3rdparty/cargo-vendor > 3rdparty/cargo-vendor/config.toml
+        run: |
+          mkdir -p 3rdparty/cargo-vendor
+          cargo vendor --manifest-path Cargo.toml 3rdparty/cargo-vendor > 3rdparty/cargo-vendor/config.toml
 
       - name: Install build dependencies
         run: |

--- a/.github/workflows/macos_tests.yaml
+++ b/.github/workflows/macos_tests.yaml
@@ -15,6 +15,41 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  build_test_adons:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+
+      - name: Setup addons cache
+        id: addons-cache
+        uses: actions/cache@v4
+        with:
+          path: build-addons/
+          key: test-addons-${{ hashFiles('addons/', 'test/functional/addons/') }}
+
+      - name: Install build dependencies
+        if: steps.addons-cache.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          git submodule init
+          git submodule update 3rdparty/i18n
+          sudo apt-get update
+          sudo apt-get install -y $(./scripts/linux/getdeps.py -b linux/debian/control)
+
+      - name: Build test addons dependencies
+        if: steps.addons-cache.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          mkdir -p build-addons/
+          cmake -S $(pwd)/tests/functional/addons -B build-addons/
+          cmake --build build-addons/
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: test-addons-${{ github.sha }}
+          path: build-addons/
+
   build_test_app:
     name: Build Test Client
     runs-on: macos-latest
@@ -63,13 +98,6 @@ jobs:
           cmake --build build/cmake
           cp -r ./build/cmake/src/Mozilla\ VPN.app/ build/Mozilla\ VPN.app
 
-      - name: Compile test addons
-        run: |
-          mkdir -p build/addons
-          cmake -S $(pwd)/tests/functional/addons -B build/addons \
-            -DCMAKE_PREFIX_PATH=${{ github.workspace }}/qt_dist/lib/cmake
-          cmake --build build/addons
-
       - uses: actions/upload-artifact@v4
         with:
           name: test-client-${{ github.sha }}
@@ -95,6 +123,7 @@ jobs:
     name: Functional tests
     needs:
       - build_test_app
+      - build_test_addons
     runs-on: macos-latest
     timeout-minutes: 45
     strategy:
@@ -109,6 +138,11 @@ jobs:
         with:
           name: test-client-${{ github.sha }}
           path: build/
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: test-addons-${{ github.sha }}
+          path: build/addons/
 
       - uses: actions/setup-python@v5
         env:

--- a/.github/workflows/macos_tests.yaml
+++ b/.github/workflows/macos_tests.yaml
@@ -15,7 +15,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build_test_adons:
+  build_test_addons:
     runs-on: ubuntu-latest
     steps:
       - name: Clone repository

--- a/.github/workflows/macos_tests.yaml
+++ b/.github/workflows/macos_tests.yaml
@@ -45,9 +45,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/Library/Caches/ccache
-          key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.event_name == 'pull_request' && 'pull' || 'sha' }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.sha }}
-          restore-keys: |
-            ccache-${{ runner.os }}-${{ runner.arch }}-sha-${{ github.event.pull_request.base.sha }}
+          key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}
+          lookup-only: github.event_name == 'pull_request'
+          restore-keys: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.sha }}
 
       - name: Install build dependencies
         run: |

--- a/.github/workflows/macos_tests.yaml
+++ b/.github/workflows/macos_tests.yaml
@@ -46,10 +46,18 @@ jobs:
           wget https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/mozillavpn.v2.mozillavpn.cache.level-3.toolchains.v3.qt-macos-6.6.latest/artifacts/public%2Fbuild%2Fqt6_mac.zip -O qt6_mac.zip
           unzip -a -d ${{ github.workspace }} qt6_mac.zip
 
+      - name: Setup compiler cache
+        if: github.event_name == 'pull_request'
+        uses: actions/cache@v4
+        with:
+          path: .ccache
+          key: ${{ runner.os }}-ccache-${{ github.event.pull_request.base.sha }}
+
       - name: Compile test client
         run: |
           mkdir -p build/cmake
           cmake -S $(pwd) -B build/cmake -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -DCMAKE_PREFIX_PATH=${{ github.workspace }}/qt_dist/lib/cmake
           cmake --build build/cmake
           cp -r ./build/cmake/src/Mozilla\ VPN.app/ build/Mozilla\ VPN.app

--- a/.github/workflows/macos_tests.yaml
+++ b/.github/workflows/macos_tests.yaml
@@ -54,12 +54,8 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ env.HOME }}/Library/Caches/ccache
-          key: |
-            github.event_name == 'pull_request' &&
-            ccache-${{ runner.os }}-${{ runner.arch }}-pull-${{ github.event.pull_request.number ||
-            ccache-${{ runner.os }}-${{ runner.arch }}-sha-${{ github.sha }}
+          key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.event_name == 'pull_request' && 'pull' || 'sha' }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.sha }}
           restore-keys: |
-            github.event_name == 'pull_request' &&
             ccache-${{ runner.os }}-${{ runner.arch }}-sha-${{ github.event.pull_request.base.sha }}
 
       - name: Install build dependencies

--- a/.github/workflows/macos_tests.yaml
+++ b/.github/workflows/macos_tests.yaml
@@ -37,23 +37,13 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v3
         with:
           miniconda-version: "latest"
+          environment-file: "env.yml"
           activate-environment: vpn
-      
-      - name: Setup conda cache
-        id: conda-cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ env.CONDA }}/envs
-          key: conda-${{ runner.os }}-${{ runner.arch }}-${{ steps.get-date.outputs.today }}-${{ hashFiles('env.yml', 'requirements.txt') }}
-
-      - name: Setup conda env
-        if: steps.conda-cache.outputs.cache-hit != 'true'
-        run: conda env update -n vpn -f env.yml
 
       - name: Setup compiler cache
         uses: actions/cache@v4
         with:
-          path: ${{ env.HOME }}/Library/Caches/ccache
+          path: /Users/runner/Library/Caches/ccache
           key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.event_name == 'pull_request' && 'pull' || 'sha' }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.sha }}
           restore-keys: |
             ccache-${{ runner.os }}-${{ runner.arch }}-sha-${{ github.event.pull_request.base.sha }}

--- a/.github/workflows/macos_tests.yaml
+++ b/.github/workflows/macos_tests.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: Setup compiler cache
         uses: actions/cache@v4
         with:
-          path: /Users/runner/Library/Caches/ccache
+          path: ~/Library/Caches/ccache
           key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.event_name == 'pull_request' && 'pull' || 'sha' }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.sha }}
           restore-keys: |
             ccache-${{ runner.os }}-${{ runner.arch }}-sha-${{ github.event.pull_request.base.sha }}

--- a/.github/workflows/macos_tests.yaml
+++ b/.github/workflows/macos_tests.yaml
@@ -29,17 +29,6 @@ jobs:
         with:
           submodules: "recursive"
 
-      - name: Get Datestamp
-        id: get-date
-        shell: bash
-        run: echo "today=$(/bin/date -u '+%Y%m%d')" >> $GITHUB_OUTPUT
-
-      - name: Setup conda package cache
-        uses: actions/cache@v4
-        with:
-          path: ~/conda_pkgs_dir
-          key: condapkg-${{ runner.os }}-${{ runner.arch }}-${{ steps.get-date.outputs.today }}-${{ hashFiles('env.yml') }}
-
       - uses: conda-incubator/setup-miniconda@v3
         with:
           miniconda-version: "latest"
@@ -54,20 +43,6 @@ jobs:
           restore-keys: |
             ccache-${{ runner.os }}-${{ runner.arch }}-sha-${{ github.event.pull_request.base.sha }}
 
-      - name: Setup cargo package cache
-        id: cargo-vendor
-        uses: actions/cache@v4
-        with:
-          path: 3rdparty/cargo-vendor
-          key: cargo-vendor-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
-
-      - name: Download cargo packages
-        if: steps.cargo-vendor.outputs.cache-hit != 'true'
-        shell: bash
-        run: |
-          mkdir -p 3rdparty/cargo-vendor
-          cargo vendor --manifest-path Cargo.toml 3rdparty/cargo-vendor > 3rdparty/cargo-vendor/config.toml
-
       - name: Install build dependencies
         run: |
           ./scripts/macos/conda_install_extras.sh
@@ -81,9 +56,6 @@ jobs:
 
       - name: Compile test client
         run: |
-          mkdir -p .cargo
-          cp 3rdparty/cargo-vendor/config.toml .cargo/config.toml
-
           mkdir -p build/cmake
           cmake -S $(pwd) -B build/cmake -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache \

--- a/.github/workflows/macos_tests.yaml
+++ b/.github/workflows/macos_tests.yaml
@@ -16,39 +16,10 @@ concurrency:
 
 jobs:
   build_test_addons:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v4
-
-      - name: Setup addons cache
-        id: addons-cache
-        uses: actions/cache@v4
-        with:
-          path: build-addons/
-          key: test-addons-${{ hashFiles('addons/', 'test/functional/addons/') }}
-
-      - name: Install build dependencies
-        if: steps.addons-cache.outputs.cache-hit != 'true'
-        shell: bash
-        run: |
-          git submodule init
-          git submodule update 3rdparty/i18n
-          sudo apt-get update
-          sudo apt-get install -y $(./scripts/linux/getdeps.py -b linux/debian/control)
-
-      - name: Build test addons dependencies
-        if: steps.addons-cache.outputs.cache-hit != 'true'
-        shell: bash
-        run: |
-          mkdir -p build-addons/
-          cmake -S $(pwd)/tests/functional/addons -B build-addons/
-          cmake --build build-addons/
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: test-addons-${{ github.sha }}
-          path: build-addons/
+    name: Build Test Addons
+    uses: ./.github/workflows/build_addons.yaml
+    with:
+      test-addons-name: test-addons-${{ github.sha }}
 
   build_test_app:
     name: Build Test Client

--- a/.github/workflows/macos_tests.yaml
+++ b/.github/workflows/macos_tests.yaml
@@ -29,11 +29,32 @@ jobs:
         with:
           submodules: "recursive"
 
+      - name: Get Datestamp
+        id: get-date
+        shell: bash
+        run: echo "today=$(/bin/date -u '+%Y%m%d')" >> $GITHUB_OUTPUT
+
       - uses: conda-incubator/setup-miniconda@v3
         with:
           miniconda-version: "latest"
-          environment-file: env.yml
           activate-environment: vpn
+      
+      - name: Setup conda cache
+        id: conda-cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.CONDA }}/envs
+          key: conda-${{ runner.os }}-${{ runner.arch }}-${{ steps.get-date.outputs.today }}-${{ hashFiles('env.yml', 'requirements.txt') }}
+
+      - name: Setup conda env
+        if: steps.conda-cache.outputs.cache-hit != 'true'
+        run: conda env update -n vpn -f env.yml
+
+      - name: Setup compiler cache
+        uses: actions/cache@v4
+        with:
+          path: .ccache
+          key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ steps.get-date.outputs.today }}
 
       - name: Install build dependencies
         run: |
@@ -46,15 +67,12 @@ jobs:
           wget https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/mozillavpn.v2.mozillavpn.cache.level-3.toolchains.v3.qt-macos-6.6.latest/artifacts/public%2Fbuild%2Fqt6_mac.zip -O qt6_mac.zip
           unzip -a -d ${{ github.workspace }} qt6_mac.zip
 
-      - name: Setup compiler cache
-        if: github.event_name == 'pull_request'
-        uses: actions/cache@v4
-        with:
-          path: .ccache
-          key: ${{ runner.os }}-ccache-${{ github.event.pull_request.base.sha }}
-
       - name: Compile test client
         run: |
+          echo "DEBUG: Where is the compiler cache?"
+          ccache -p
+          echo ""
+
           mkdir -p build/cmake
           cmake -S $(pwd) -B build/cmake -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache \

--- a/.github/workflows/macos_tests.yaml
+++ b/.github/workflows/macos_tests.yaml
@@ -53,8 +53,14 @@ jobs:
       - name: Setup compiler cache
         uses: actions/cache@v4
         with:
-          path: .ccache
-          key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ steps.get-date.outputs.today }}
+          path: ${{ env.HOME }}/Library/Caches/ccache
+          key: |
+            github.event_name == 'pull_request' &&
+            ccache-${{ runner.os }}-${{ runner.arch }}-pull-${{ github.event.pull_request.number ||
+            ccache-${{ runner.os }}-${{ runner.arch }}-sha-${{ github.sha }}
+          restore-keys: |
+            github.event_name == 'pull_request' &&
+            ccache-${{ runner.os }}-${{ runner.arch }}-sha-${{ github.event.pull_request.base.sha }}
 
       - name: Install build dependencies
         run: |
@@ -69,10 +75,6 @@ jobs:
 
       - name: Compile test client
         run: |
-          echo "DEBUG: Where is the compiler cache?"
-          ccache -p
-          echo ""
-
           mkdir -p build/cmake
           cmake -S $(pwd) -B build/cmake -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache \

--- a/.github/workflows/macos_tests.yaml
+++ b/.github/workflows/macos_tests.yaml
@@ -54,6 +54,18 @@ jobs:
           restore-keys: |
             ccache-${{ runner.os }}-${{ runner.arch }}-sha-${{ github.event.pull_request.base.sha }}
 
+      - name: Setup cargo package cache
+        id: cargo-vendor
+        uses: actions/cache@v4
+        with:
+          path: 3rdparty/cargo-vendor
+          key: cargo-vendor-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+
+      - name: Download cargo packages
+        if: steps.cargo-vendor.outputs.cache-hit != 'true'
+        shell: bash
+        run: cargo vendor --manifest-path Cargo.toml 3rdparty/cargo-vendor > 3rdparty/cargo-vendor/config.toml
+
       - name: Install build dependencies
         run: |
           ./scripts/macos/conda_install_extras.sh
@@ -67,6 +79,9 @@ jobs:
 
       - name: Compile test client
         run: |
+          mkdir -p .cargo
+          cp 3rdparty/cargo-vendor/config.toml .cargo/config.toml
+
           mkdir -p build/cmake
           cmake -S $(pwd) -B build/cmake -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache \

--- a/.github/workflows/macos_tests.yaml
+++ b/.github/workflows/macos_tests.yaml
@@ -34,6 +34,12 @@ jobs:
         shell: bash
         run: echo "today=$(/bin/date -u '+%Y%m%d')" >> $GITHUB_OUTPUT
 
+      - name: Setup conda package cache
+        uses: actions/cache@v4
+        with:
+          path: ~/conda_pkgs_dir
+          key: condapkg-${{ runner.os }}-${{ runner.arch }}-${{ steps.get-date.outputs.today }}-${{ hashFiles('env.yml') }}
+
       - uses: conda-incubator/setup-miniconda@v3
         with:
           miniconda-version: "latest"

--- a/.github/workflows/wasm_tests.yaml
+++ b/.github/workflows/wasm_tests.yaml
@@ -15,7 +15,13 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  wasmQt6:
+  build_test_addons:
+    name: Build Test Addons
+    uses: ./.github/workflows/build_addons.yaml
+    with:
+      test-addons-name: test-addons-${{ github.sha }}
+
+  build_test_app:
     name: Wasm Qt6
     runs-on: ubuntu-20.04
     outputs:
@@ -62,17 +68,9 @@ jobs:
           cmake --build build/cmake -j4
           cp -r build/cmake/wasm_build build/wasm_build
 
-      - name: Compile test addons
-        shell: bash
-        run: |
-          mkdir -p build/addons
-          cmake -S $(pwd)/tests/functional/addons -B build/addons \
-            -DCMAKE_PREFIX_PATH=/opt/$QTVERSION/gcc_64/lib/cmake
-          cmake --build build/addons
-
       - uses: actions/upload-artifact@v4
         with:
-          name: WebAssembly Build Qt6
+          name: test-wasm-${{ github.sha }}
           path: |
             build/
             !build/cmake/
@@ -96,7 +94,8 @@ jobs:
   functionaltests:
     name: Functional tests
     needs:
-      - wasmQt6
+      - build_test_app
+      - build_test_addons
     runs-on: ubuntu-20.04
     timeout-minutes: 45
     strategy:
@@ -112,8 +111,13 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
-          name: WebAssembly Build Qt6
+          name: test-wasm-${{ github.sha }}
           path: build/
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: test-addons-${{ github.sha }}
+          path: build/addons/
 
       - uses: actions/setup-python@v5
         with:

--- a/env.yml
+++ b/env.yml
@@ -5,6 +5,7 @@ dependencies:
   - clang=16.0.6
   - clang-tools=16.0.6
   - clangxx=16.0.6
+  - ccache=4.10.1
   - python=3.9
   - nodejs=18.16.*
   - pip=22.3.1

--- a/src/dnshelper.h
+++ b/src/dnshelper.h
@@ -11,6 +11,7 @@ struct dnsData {
   QString ipAddress;
   QString dnsType;
 };
+
 class DNSHelper final {
  public:
   static QString getDNS(const QString& fallbackAddress);


### PR DESCRIPTION
## Description
The functional tests are slow, and it sucks. Here are some tweaks to make it go faster:
 - Install `ccache` which we'll use to cache compiled objects.
 - Setup `actions/cache@v4` to save the results of the ccache folder on every `push`
 - Setup `actions/cache@v4` to pull the ccache folder from the PR's base commit.
 - Refactor the test addon build into a reusable workflow and cache the addons since they rarely change.

Some future work to make it go even faster:
 - The rust libraries don't benefit from `ccache` and they are slow to build. However, they don't change very often so maybe we should just cache the generated libs?
 - Miniconda is sloooooow. Unfortunately, caching it is complicated because of how it interracts with pip packages.
 - Miniconda is kinda too big to cache. Github workers tend to have 1-2GB of cache space available and the Miniconda package cache is something like 1.1GB in size.

## Reference

    i.e Jira or Github issue URL

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
