### PR TITLE
Update RPM build to Fedora 41

### DIFF
--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -51,7 +51,7 @@ jobs:
     needs: source-bundle
     runs-on: ubuntu-latest
     container:
-      image: fedora:40
+      image: fedora:41
 
     steps:
       - name: Download Source Package


### PR DESCRIPTION
Akin to https://github.com/mozilla-mobile/mozilla-vpn-client/pull/9028/commits 

Current builds (tried e.g. mozillavpn-2.24.3~rc20241030191255-1.x86_64.rpm package downloaded from https://github.com/mozilla-mobile/mozilla-vpn-client/actions/runs/11600067264/job/32299824195) depends upon `libQt6Core.so.6(Qt_6.6_PRIVATE_API)(64bit)` and `libQt6Qml.so.6(Qt_6.6_PRIVATE_API)(64bit)` but since Fedora 41 is on Qt 6.8 no current package provides that symbol.

Trying to install via `dnf` yields the error:

```
Problem: conflicting requests
  - nothing provides libQt6Core.so.6(Qt_6.6_PRIVATE_API)(64bit) needed by mozillavpn-2.24.3~rc20241030191255-1.x86_64 from @commandline
  - nothing provides libQt6Qml.so.6(Qt_6.6_PRIVATE_API)(64bit) needed by mozillavpn-2.24.3~rc20241030191255-1.x86_64 from @commandline
```

## Description

    Describe your changes

## Reference

    i.e Jira or Github issue URL

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
