### PR TITLE
Add extensionTelemetry

### DIFF
--- a/qtglean/glean_parser_ext/run_glean_parser.py
+++ b/qtglean/glean_parser_ext/run_glean_parser.py
@@ -114,6 +114,7 @@ if __name__ == "__main__":
         ]
         metrics_files = [
             os.path.join(telemetry_path, "metrics.yaml"),
+            os.path.join(telemetry_path, "extension_metrics.yaml"),
             os.path.join(telemetry_path, "interaction_metrics.yaml"),
             os.path.join(telemetry_path, "impression_metrics.yaml"),
             os.path.join(telemetry_path, "outcome_metrics.yaml"),

--- a/src/cmake/sources.cmake
+++ b/src/cmake/sources.cmake
@@ -241,6 +241,8 @@ if(NOT CMAKE_CROSSCOMPILING)
     target_sources(mozillavpn-sources INTERFACE
         ${CMAKE_CURRENT_SOURCE_DIR}/webextensionadapter.h
         ${CMAKE_CURRENT_SOURCE_DIR}/webextensionadapter.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/webextensiontelemetry.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/webextensiontelemetry.cpp
     )
     target_compile_definitions(mozillavpn-sources INTERFACE MVPN_WEBEXTENSION)
 endif()

--- a/src/glean/mzglean.cpp
+++ b/src/glean/mzglean.cpp
@@ -52,7 +52,7 @@ MZGlean::MZGlean(QObject* parent) : QObject(parent) {
   connect(AndroidVPNActivity::instance(),
           &AndroidVPNActivity::eventRequestGleanUploadEnabledState, this,
           [&]() {
-            broadcastUploadEnabledChange(
+            broadcastClientUploadEnabledChange(
                 SettingsHolder::instance()->gleanEnabled());
           });
 #endif
@@ -79,8 +79,14 @@ void MZGlean::initialize(const QString& channel) {
 
       connect(SettingsHolder::instance(), &SettingsHolder::gleanEnabledChanged,
               s_instance, []() {
-                s_instance->setUploadEnabled(
-                    SettingsHolder::instance()->gleanEnabled());
+                updatePingFilter();
+                upadateUploadEnabled();
+              });
+      connect(SettingsHolder::instance(),
+              &SettingsHolder::extensionTelemetryEnabledChanged, s_instance,
+              []() {
+                updatePingFilter();
+                upadateUploadEnabled();
               });
     }
 
@@ -115,10 +121,16 @@ void MZGlean::initialize(const QString& channel) {
 #  else
     SettingsHolder* settingsHolder = SettingsHolder::instance();
     Q_ASSERT(settingsHolder);
+    auto const clientTelemetryEnabled = settingsHolder->gleanEnabled();
+    auto const extensionTelemetryEnabled =
+        settingsHolder->extensionTelemetryEnabled();
 
-    glean_initialize(SettingsHolder::instance()->gleanEnabled(),
-                     gleanDirectory.absolutePath().toUtf8(), channel.toUtf8(),
-                     QLocale::system().name().toUtf8());
+    auto const shouldUpload =
+        extensionTelemetryEnabled | clientTelemetryEnabled;
+
+    updatePingFilter();
+    glean_initialize(shouldUpload, gleanDirectory.absolutePath().toUtf8(),
+                     channel.toUtf8(), QLocale::system().name().toUtf8());
 
     setLogPings(settingsHolder->gleanLogPings());
     if (settingsHolder->gleanDebugTagActive()) {
@@ -130,16 +142,21 @@ void MZGlean::initialize(const QString& channel) {
 }
 
 // static
-void MZGlean::setUploadEnabled(bool isTelemetryEnabled) {
-  logger.debug() << "Changing MZGlean upload status to" << isTelemetryEnabled;
+void MZGlean::upadateUploadEnabled() {
+  auto const settings = SettingsHolder::instance();
+  auto const clientTelemetryEnabled = settings->gleanEnabled();
+  auto const extensionTelemetryEnabled = settings->extensionTelemetryEnabled();
+
+  auto const shouldUpload = extensionTelemetryEnabled | clientTelemetryEnabled;
+  logger.debug() << "Changing MZGlean upload status to" << shouldUpload;
 
 #if not(defined(MZ_WASM))
-  glean_set_upload_enabled(isTelemetryEnabled);
+  glean_set_upload_enabled(shouldUpload);
 #endif
 
-  broadcastUploadEnabledChange(isTelemetryEnabled);
+  broadcastClientUploadEnabledChange(clientTelemetryEnabled);
 
-  if (isTelemetryEnabled) {
+  if (clientTelemetryEnabled) {
 #if defined(MZ_ANDROID) || defined(MZ_IOS)
     // need to reset installation ID, as it would have been cleared
     QString uuid = mozilla::glean::session::installation_id.generateAndSet();
@@ -162,7 +179,7 @@ void MZGlean::setUploadEnabled(bool isTelemetryEnabled) {
 }
 
 // static
-void MZGlean::broadcastUploadEnabledChange(bool isTelemetryEnabled) {
+void MZGlean::broadcastClientUploadEnabledChange(bool isTelemetryEnabled) {
 #if defined(MZ_ANDROID)
   logger.debug() << "Broadcasting MZGlean upload status to Android Daemon.";
 
@@ -219,5 +236,34 @@ void MZGlean::setLogPings(bool flag) {
   settingsHolder->setGleanLogPings(flag);
 #if not(defined(MZ_WASM))
   glean_set_log_pings(flag);
+#endif
+}
+
+void MZGlean::updatePingFilter() {
+#if defined(MZ_WASM)
+  return;
+#else
+  glean_clear_ping_filter();
+  auto settings = SettingsHolder::instance();
+  auto clientTelemetryEnabled = settings->gleanEnabled();
+  auto extensionTelemetryEnabled = settings->extensionTelemetryEnabled();
+
+  // Everything is allowed, only required to clear the filter.
+  if (clientTelemetryEnabled && extensionTelemetryEnabled) {
+    return;
+  }
+  // All extension telemetry is inside the extension session ping
+  // so filter that ping out.
+  if (clientTelemetryEnabled) {
+    glean_push_ping_filter("extensionsession");
+  }
+  // Otherwise, filter the vpn pings out.
+  else if (extensionTelemetryEnabled) {
+    glean_push_ping_filter("daemonsession");
+    glean_push_ping_filter("main");
+    glean_push_ping_filter("vpnsession");
+  }
+  // If neither are enabled, we won't send things anyway.
+
 #endif
 }

--- a/src/glean/mzglean.cpp
+++ b/src/glean/mzglean.cpp
@@ -80,13 +80,13 @@ void MZGlean::initialize(const QString& channel) {
       connect(SettingsHolder::instance(), &SettingsHolder::gleanEnabledChanged,
               s_instance, []() {
                 updatePingFilter();
-                upadateUploadEnabled();
+                updateUploadEnabled();
               });
       connect(SettingsHolder::instance(),
               &SettingsHolder::extensionTelemetryEnabledChanged, s_instance,
               []() {
                 updatePingFilter();
-                upadateUploadEnabled();
+                updateUploadEnabled();
               });
     }
 
@@ -142,7 +142,7 @@ void MZGlean::initialize(const QString& channel) {
 }
 
 // static
-void MZGlean::upadateUploadEnabled() {
+void MZGlean::updateUploadEnabled() {
   auto const settings = SettingsHolder::instance();
   auto const clientTelemetryEnabled = settings->gleanEnabled();
   auto const extensionTelemetryEnabled = settings->extensionTelemetryEnabled();

--- a/src/glean/mzglean.h
+++ b/src/glean/mzglean.h
@@ -16,7 +16,7 @@ class MZGlean final : public QObject {
  private:
   explicit MZGlean(QObject* parent);
 
-  static void upadateUploadEnabled();
+  static void updateUploadEnabled();
 
   /**
    * @brief Broadcast to the mobile VPN daemon instances of Glean,

--- a/src/glean/mzglean.h
+++ b/src/glean/mzglean.h
@@ -16,7 +16,7 @@ class MZGlean final : public QObject {
  private:
   explicit MZGlean(QObject* parent);
 
-  static void setUploadEnabled(bool isTelemetryEnabled);
+  static void upadateUploadEnabled();
 
   /**
    * @brief Broadcast to the mobile VPN daemon instances of Glean,
@@ -24,7 +24,9 @@ class MZGlean final : public QObject {
    *
    * @param isTelemetryEnabled The new upload enabled state.
    */
-  static void broadcastUploadEnabledChange(bool isTelemetryEnabled);
+  static void broadcastClientUploadEnabledChange(bool isTelemetryEnabled);
+
+  static void updatePingFilter();
 
  public:
   ~MZGlean();

--- a/src/settingslist.h
+++ b/src/settingslist.h
@@ -22,6 +22,8 @@
 
 #define SETTING_INT(getter, ...) SETTING(int, toInt, getter, __VA_ARGS__)
 
+#define SETTING_UINT(getter, ...) SETTING(uint32_t, toUInt, getter, __VA_ARGS__)
+
 #define SETTING_INT64(getter, ...) \
   SETTING(qint64, toLongLong, getter, __VA_ARGS__)
 
@@ -783,3 +785,23 @@ SETTING_BOOL(addonApiSetting,        // getter
              false                   // sensitive (do not log)
 )
 #endif
+
+SETTING_UINT(extensionTelemetryFlags,        // getter
+             setExtensionTelemetryFlags,     // setter
+             removeExtensionTelemetryFlags,  // remover
+             hasExtensionTelemetryFlags,     // has
+             "extensionTelemetryFlags",      // key
+             0,                              // default value
+             false,                          // remove when reset
+             true  // sensitive (contains interaction info)
+)
+
+SETTING_BOOL(extensionTelemetryEnabled,        // getter
+             setExtensionTelemetryEnabled,     // setter
+             removeExtensionTelemetryEnabled,  // remover
+             hasExtensionTelemetryEnabled,     // has
+             "extensionTelemetryEnabled",      // key
+             false,                            // default value
+             true,                             // remove when reset
+             false                             // sensitive (do not log)
+)

--- a/src/settingslist.h
+++ b/src/settingslist.h
@@ -22,8 +22,6 @@
 
 #define SETTING_INT(getter, ...) SETTING(int, toInt, getter, __VA_ARGS__)
 
-#define SETTING_UINT(getter, ...) SETTING(uint32_t, toUInt, getter, __VA_ARGS__)
-
 #define SETTING_INT64(getter, ...) \
   SETTING(qint64, toLongLong, getter, __VA_ARGS__)
 
@@ -785,16 +783,6 @@ SETTING_BOOL(addonApiSetting,        // getter
              false                   // sensitive (do not log)
 )
 #endif
-
-SETTING_UINT(extensionTelemetryFlags,        // getter
-             setExtensionTelemetryFlags,     // setter
-             removeExtensionTelemetryFlags,  // remover
-             hasExtensionTelemetryFlags,     // has
-             "extensionTelemetryFlags",      // key
-             0,                              // default value
-             false,                          // remove when reset
-             true  // sensitive (contains interaction info)
-)
 
 SETTING_BOOL(extensionTelemetryEnabled,        // getter
              setExtensionTelemetryEnabled,     // setter

--- a/src/telemetry/extension_metrics.yaml
+++ b/src/telemetry/extension_metrics.yaml
@@ -109,6 +109,7 @@ extension:
           type: string
     used_feature_diable_firefox_protection:
       type: boolean
+      lifetime: user
       description: >
         True if the user has disabled the VPN for firefox
       bugs:
@@ -122,8 +123,9 @@ extension:
         - vpn-telemetry@mozilla.com
       send_in_pings:
         - extensionsession
-      expires: 2025-06-30
+      expires: never
     used_feature_settings_page:
+      lifetime: user
       type: boolean
       description: >
         True if the user has opened the internal settings page. 
@@ -138,9 +140,10 @@ extension:
         - vpn-telemetry@mozilla.com
       send_in_pings:
         - extensionsession
-      expires: 2025-06-30
+      expires: never
     used_feature_page_action_revoke_exclude:
       type: boolean
+      lifetime: user
       description: >
         True if the user has removed a Website Exclusion from the Page action
       bugs:
@@ -154,9 +157,10 @@ extension:
         - vpn-telemetry@mozilla.com
       send_in_pings:
         - extensionsession
-      expires: 2025-06-30
+      expires: never
     used_feature_page_action_revoke_geopref:
       type: boolean
+      lifetime: user
       description: >
         True if the user has removed a Website GeoPrefrence from the Page action
       bugs:
@@ -170,9 +174,10 @@ extension:
         - vpn-telemetry@mozilla.com
       send_in_pings:
         - extensionsession
-      expires: 2025-06-30
+      expires: never
     has_completed_onboarding:
       type: boolean
+      lifetime: user
       description: >
         True if the user has completed onboarding.
       bugs:
@@ -186,7 +191,7 @@ extension:
         - vpn-telemetry@mozilla.com
       send_in_pings:
         - extensionsession
-      expires: 2025-06-30
+      expires: never
     count_excluded:
       type: quantity
       unit: websites

--- a/src/telemetry/extension_metrics.yaml
+++ b/src/telemetry/extension_metrics.yaml
@@ -5,8 +5,6 @@
 ---
 $schema: moz://mozilla.org/schemas/glean/metrics/2-0-0
 
-# "impression" category events, are events where the user has just moved on to page X
-# Events under this category are recorded when a new screen is loaded
 extension:
     main_screen:
       type: event
@@ -26,6 +24,7 @@ extension:
         - sstreich@mozilla.com
         - vpn-telemetry@mozilla.com
       expires: 2025-06-30
+
     error_screen:
       type: event
       lifetime: ping
@@ -68,7 +67,8 @@ extension:
         - sstreich@mozilla.com
         - vpn-telemetry@mozilla.com
       expires: 2025-06-30
-    fx_protection_disenabled:
+
+    fx_protetion_disabled:
       type: event
       lifetime: ping
       send_in_pings:
@@ -85,6 +85,7 @@ extension:
         - sstreich@mozilla.com
         - vpn-telemetry@mozilla.com
       expires: 2025-06-30
+
     fx_protection_mode_changed:
       type: event
       lifetime: ping
@@ -107,7 +108,8 @@ extension:
           description: |
             Full,PartialOn,PartialOff,Off,
           type: string
-    used_feature_diable_firefox_protection:
+
+    used_feature_disable_firefox_protection:
       type: boolean
       lifetime: user
       description: >
@@ -124,6 +126,7 @@ extension:
       send_in_pings:
         - extensionsession
       expires: never
+
     used_feature_settings_page:
       lifetime: user
       type: boolean
@@ -141,6 +144,7 @@ extension:
       send_in_pings:
         - extensionsession
       expires: never
+
     used_feature_page_action_revoke_exclude:
       type: boolean
       lifetime: user
@@ -158,6 +162,7 @@ extension:
       send_in_pings:
         - extensionsession
       expires: never
+
     used_feature_page_action_revoke_geopref:
       type: boolean
       lifetime: user
@@ -175,6 +180,7 @@ extension:
       send_in_pings:
         - extensionsession
       expires: never
+
     has_completed_onboarding:
       type: boolean
       lifetime: user
@@ -192,6 +198,7 @@ extension:
       send_in_pings:
         - extensionsession
       expires: never
+
     count_excluded:
       type: quantity
       unit: websites
@@ -209,6 +216,7 @@ extension:
       send_in_pings:
         - extensionsession
       expires: 2025-06-30
+
     count_geoprefed:
       type: quantity
       unit: websites

--- a/src/telemetry/extension_metrics.yaml
+++ b/src/telemetry/extension_metrics.yaml
@@ -50,6 +50,7 @@ extension:
               subscription_needed, signin_needed, split_tunneled
           type: string
       expires: 2025-06-30
+
     fx_protection_enabled:
       type: event
       lifetime: ping
@@ -68,7 +69,7 @@ extension:
         - vpn-telemetry@mozilla.com
       expires: 2025-06-30
 
-    fx_protetion_disabled:
+    fx_protection_disabled:
       type: event
       lifetime: ping
       send_in_pings:

--- a/src/telemetry/extension_metrics.yaml
+++ b/src/telemetry/extension_metrics.yaml
@@ -1,0 +1,223 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+---
+$schema: moz://mozilla.org/schemas/glean/metrics/2-0-0
+
+# "impression" category events, are events where the user has just moved on to page X
+# Events under this category are recorded when a new screen is loaded
+extension:
+    main_screen:
+      type: event
+      lifetime: ping
+      send_in_pings:
+        - extensionsession
+      description: |
+        The user has just moved on to the main screen
+        i.e. the screen with the VPN toggle button.
+      bugs:
+        - https://mozilla-hub.atlassian.net/browse/VPN-6714
+      data_reviews:
+        - TBD
+      data_sensitivity:
+        - interaction
+      notification_emails:
+        - sstreich@mozilla.com
+        - vpn-telemetry@mozilla.com
+      expires: 2025-06-30
+    error_screen:
+      type: event
+      lifetime: ping
+      send_in_pings:
+        - extensionsession
+      description: |
+        The user has just moved on to the main screen
+        i.e. the screen with the VPN toggle button.
+      bugs:
+        - https://mozilla-hub.atlassian.net/browse/VPN-6714
+      data_reviews:
+        - TBD
+      data_sensitivity:
+        - interaction
+      notification_emails:
+        - sstreich@mozilla.com
+        - vpn-telemetry@mozilla.com
+      extra_keys:
+        error:
+          description: |
+            The Type of Error: 
+              client_too_old, client_not_opened, unsupported_platform, install_needed
+              subscription_needed, signin_needed, split_tunneled
+          type: string
+      expires: 2025-06-30
+    fx_protection_enabled:
+      type: event
+      lifetime: ping
+      send_in_pings:
+        - extensionsession
+      description: |
+        The user has toggled the Fx Protection On
+      bugs:
+        - https://mozilla-hub.atlassian.net/browse/VPN-6714
+      data_reviews:
+        - TBD
+      data_sensitivity:
+        - interaction
+      notification_emails:
+        - sstreich@mozilla.com
+        - vpn-telemetry@mozilla.com
+      expires: 2025-06-30
+    fx_protection_disenabled:
+      type: event
+      lifetime: ping
+      send_in_pings:
+        - extensionsession
+      description: |
+        The user has toggled the Fx Protection Off
+      bugs:
+        - https://mozilla-hub.atlassian.net/browse/VPN-6714
+      data_reviews:
+        - TBD
+      data_sensitivity:
+        - interaction
+      notification_emails:
+        - sstreich@mozilla.com
+        - vpn-telemetry@mozilla.com
+      expires: 2025-06-30
+    fx_protection_mode_changed:
+      type: event
+      lifetime: ping
+      send_in_pings:
+        - extensionsession
+      description: |
+        The Protection Mode Changed
+      bugs:
+        - https://mozilla-hub.atlassian.net/browse/VPN-6714
+      data_reviews:
+        - TBD
+      data_sensitivity:
+        - interaction
+      notification_emails:
+        - sstreich@mozilla.com
+        - vpn-telemetry@mozilla.com
+      expires: 2025-06-30
+      extra_keys:
+        message_state:
+          description: |
+            Full,PartialOn,PartialOff,Off,
+          type: string
+    used_feature_diable_firefox_protection:
+      type: boolean
+      description: >
+        True if the user has disabled the VPN for firefox
+      bugs:
+        - https://mozilla-hub.atlassian.net/browse/VPN-6714
+      data_reviews:
+        - TBD
+      data_sensitivity:
+        - interaction
+      notification_emails:
+        - sstreich@mozilla.com
+        - vpn-telemetry@mozilla.com
+      send_in_pings:
+        - extensionsession
+      expires: 2025-06-30
+    used_feature_settings_page:
+      type: boolean
+      description: >
+        True if the user has opened the internal settings page. 
+      bugs:
+        - https://mozilla-hub.atlassian.net/browse/VPN-6714
+      data_reviews:
+        - TBD
+      data_sensitivity:
+        - interaction
+      notification_emails:
+        - sstreich@mozilla.com
+        - vpn-telemetry@mozilla.com
+      send_in_pings:
+        - extensionsession
+      expires: 2025-06-30
+    used_feature_page_action_revoke_exclude:
+      type: boolean
+      description: >
+        True if the user has removed a Website Exclusion from the Page action
+      bugs:
+        - https://mozilla-hub.atlassian.net/browse/VPN-6714
+      data_reviews:
+        - TBD
+      data_sensitivity:
+        - interaction
+      notification_emails:
+        - sstreich@mozilla.com
+        - vpn-telemetry@mozilla.com
+      send_in_pings:
+        - extensionsession
+      expires: 2025-06-30
+    used_feature_page_action_revoke_geopref:
+      type: boolean
+      description: >
+        True if the user has removed a Website GeoPrefrence from the Page action
+      bugs:
+        - https://mozilla-hub.atlassian.net/browse/VPN-6714
+      data_reviews:
+        - TBD
+      data_sensitivity:
+        - interaction
+      notification_emails:
+        - sstreich@mozilla.com
+        - vpn-telemetry@mozilla.com
+      send_in_pings:
+        - extensionsession
+      expires: 2025-06-30
+    has_completed_onboarding:
+      type: boolean
+      description: >
+        True if the user has completed onboarding.
+      bugs:
+        - https://mozilla-hub.atlassian.net/browse/VPN-6714
+      data_reviews:
+        - TBD
+      data_sensitivity:
+        - interaction
+      notification_emails:
+        - sstreich@mozilla.com
+        - vpn-telemetry@mozilla.com
+      send_in_pings:
+        - extensionsession
+      expires: 2025-06-30
+    count_excluded:
+      type: quantity
+      unit: websites
+      description: >
+        The amount of websites excluded from the VPN 
+      bugs:
+        - https://mozilla-hub.atlassian.net/browse/VPN-6714
+      data_reviews:
+        - TBD
+      data_sensitivity:
+        - interaction
+      notification_emails:
+        - sstreich@mozilla.com
+        - vpn-telemetry@mozilla.com
+      send_in_pings:
+        - extensionsession
+      expires: 2025-06-30
+    count_geoprefed:
+      type: quantity
+      unit: websites
+      description: >
+        The amount of Websites with a GeoPrefrence.
+      bugs:
+        - https://mozilla-hub.atlassian.net/browse/VPN-6714
+      data_reviews:
+        - TBD
+      data_sensitivity:
+        - interaction
+      notification_emails:
+        - sstreich@mozilla.com
+        - vpn-telemetry@mozilla.com
+      send_in_pings:
+        - extensionsession
+      expires: 2025-06-30

--- a/src/telemetry/pings.yaml
+++ b/src/telemetry/pings.yaml
@@ -73,8 +73,6 @@ daemonsession:
       (Android only) Sent every three hours during an active VPN session.
     daemon_end: >
       Sent after as session ending metric is recorded.
-
-
 extensionsession:
   description: |
     Only on desktop. 

--- a/src/telemetry/pings.yaml
+++ b/src/telemetry/pings.yaml
@@ -73,6 +73,7 @@ daemonsession:
       (Android only) Sent every three hours during an active VPN session.
     daemon_end: >
       Sent after as session ending metric is recorded.
+
 extensionsession:
   description: |
     Only on desktop. 

--- a/src/telemetry/pings.yaml
+++ b/src/telemetry/pings.yaml
@@ -82,7 +82,7 @@ extensionsession:
     This ping will record start/end datestamp,
     session-based metrics, etc.
   include_client_id: true
-  send_if_empty: false
+  send_if_empty: true
   bugs:
     - https://mozilla-hub.atlassian.net/browse/VPN-6714
   data_reviews:
@@ -93,5 +93,5 @@ extensionsession:
   reasons:
     extension_start: >
       Sent right after a session start metric is recorded.
-    extension_end: >
+    extension_stop: >
       Sent after as session ending metric is recorded.

--- a/src/telemetry/pings.yaml
+++ b/src/telemetry/pings.yaml
@@ -73,3 +73,25 @@ daemonsession:
       (Android only) Sent every three hours during an active VPN session.
     daemon_end: >
       Sent after as session ending metric is recorded.
+
+
+extensionsession:
+  description: |
+    Only on desktop. 
+    Data for the VPN extension
+    This ping will record start/end datestamp,
+    session-based metrics, etc.
+  include_client_id: true
+  send_if_empty: false
+  bugs:
+    - https://mozilla-hub.atlassian.net/browse/VPN-6714
+  data_reviews:
+    - N/A, will be done for metrics within
+  notification_emails:
+    - vpn-telemetry@mozilla.com
+    - sstreich@mozilla.com
+  reasons:
+    extension_start: >
+      Sent right after a session start metric is recorded.
+    extension_end: >
+      Sent after as session ending metric is recorded.

--- a/src/ui/screens/getHelp/developerMenu/ViewTelemetryDebugging.qml
+++ b/src/ui/screens/getHelp/developerMenu/ViewTelemetryDebugging.qml
@@ -31,6 +31,17 @@ MZViewBase {
                 VPN.gleanSetLogPings(!MZSettings.gleanLogPings)
             }
         }
+        MZCheckBoxRow {
+            Layout.fillWidth: true
+            Layout.rightMargin: MZTheme.theme.windowMargin
+            labelText: "Glean Enable Extension Telemetry"
+            subLabelText: "Enables / Disables Glean Telemetry for the extension"
+            isChecked: MZSettings.extensionTelemetryEnabled
+            showDivider: false
+            onClicked: {
+                MZSettings.extensionTelemetryEnabled = !MZSettings.extensionTelemetryEnabled
+            }
+        }
 
         MZCheckBoxRow {
             id: checkBoxRowGleanDebugTag
@@ -106,6 +117,10 @@ MZViewBase {
             id: submitSessionPing
             text: "Submit the 'vpnsession' ping"
             onClicked: GleanPings.Vpnsession.submit()
+        }
+        MZButton {
+            text: "Submit the 'extensionsession' ping"
+            onClicked: GleanPings.Extensionsession.submit()
         }
     }
 }

--- a/src/webextensionadapter.cpp
+++ b/src/webextensionadapter.cpp
@@ -12,7 +12,6 @@
 #include <QMetaEnum>
 #include <QTcpSocket>
 #include <QWindow>
-#include <functional>
 
 #include "connectionhealth.h"
 #include "controller.h"

--- a/src/webextensionadapter.cpp
+++ b/src/webextensionadapter.cpp
@@ -27,14 +27,13 @@
 #include "settingsholder.h"
 #include "tasks/controlleraction/taskcontrolleraction.h"
 #include "taskscheduler.h"
-#include "webextensionadapter.h"
+#include "webextensiontelemetry.h"
 
 #if defined(MZ_WINDOWS)
 #  include "platforms/windows/windowsutils.h"
 #endif
 
 namespace {
-
 // See https://en.cppreference.com/w/cpp/utility/variant/visit
 template <class... Ts>
 struct match : Ts... {
@@ -135,6 +134,24 @@ WebExtensionAdapter::WebExtensionAdapter(QObject* parent)
                     QJsonObject obj;
                     obj["status"] = serializeStatus();
                     return obj;
+                  }},
+      RequestType{"telemetry",
+                  [](const QJsonObject& data) {
+                    auto info = WebextensionTelemetry::fromJson(data);
+                    if (info.has_value()) {
+                      WebextensionTelemetry::recordTelemetry(info.value());
+                    }
+                    return QJsonObject{};
+                  }},
+      RequestType{"session_start",
+                  [](const QJsonObject& data) {
+                    WebextensionTelemetry::startSession();
+                    return QJsonObject{};
+                  }},
+      RequestType{"session_stop",
+                  [](const QJsonObject& data) {
+                    WebextensionTelemetry::stopSession();
+                    return QJsonObject{};
                   }},
   });
 }

--- a/src/webextensiontelemetry.cpp
+++ b/src/webextensiontelemetry.cpp
@@ -1,0 +1,135 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "webextensiontelemetry.h"
+
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QMetaEnum>
+
+#include "glean/boolean.h"
+#include "glean/event.h"
+#include "glean/generated/metrics.h"
+#include "glean/generated/pings.h"
+#include "glean/quantity.h"
+#include "logger.h"
+#include "settingsholder.h"
+
+namespace {
+Logger logger("WebExtensionTelemetry");
+}  // namespace
+
+namespace WebextensionTelemetry {
+
+std::optional<TelemetryInfo> fromJson(const QJsonObject& obj) {
+  // 1: Needs to have type:"telemetry"
+  if (obj["t"].toString("") != "telemetry") {
+    return {};
+  }
+  // 2: MUST have name
+  TelemetryInfo out{};
+  if (!obj["name"].isString()) {
+    return {};
+  }
+  out.name = obj["name"].toString();
+  // 3: Can have Variant args
+  if (obj["args"].toVariant().isValid()) {
+    out.args = obj["args"].toVariant();
+  }
+  return out;
+}
+// Const functions to create handlers for glean data types.
+namespace handlers {
+// For Events we want to just record it to glean.
+// It will be send out with the next ping
+auto constexpr event(EventMetric* metric) {
+  return [metric](QVariant) { metric->record(); };
+};
+auto constexpr count(QuantityMetric* metric) {
+  return [metric](QVariant args) {
+    bool ok;
+    const auto count = args.toUInt(&ok);
+    if (!ok) {
+      return;
+    }
+    metric->set(count);
+  };
+};
+// For flags, we will flip the flag-bit in the settings to true.
+// We will also record this to glean.
+// Flags will always be sent with the next ping
+template <uint8_t bit>  // The bit in the bitfield to denote
+auto consteval flag(BooleanMetric* metric) {
+  static_assert(bit < 32u,
+                "The Bitfield is a u32, cannout assign a bigger bitfield");
+  return [metric](QVariant) {
+    auto settings = SettingsHolder::instance();
+    uint32_t currentBitFlags = settings->extensionTelemetryFlags();
+    // Flip the bit
+    uint32_t newFlags = currentBitFlags | (1 << bit);
+    if (currentBitFlags != newFlags) {
+      // Avoid disk io.
+      settings->setExtensionTelemetryFlags(currentBitFlags);
+    }
+    metric->set(true);
+  };
+}
+using namespace mozilla::glean;
+const auto map = QMap<QString, std::function<void(QVariant)>>{
+    {"fx_protection_disenabled", event(&extension::fx_protection_disenabled)},
+    {"fx_protection_enabled", event(&extension::fx_protection_enabled)},
+    {"fx_protection_mode_changed",
+     event(&extension::fx_protection_mode_changed)},
+    {"main_screen", event(&extension::main_screen)},
+    {"error_screen", event(&mozilla::glean::extension::error_screen)},
+    {"has_completed_onboarding", flag<0>(&extension::has_completed_onboarding)},
+    {"used_feature_diable_firefox_protection",
+     flag<1>(&extension::used_feature_diable_firefox_protection)},
+    {"used_feature_settings_page",
+     flag<2>(&extension::used_feature_settings_page)},
+    {"used_feature_page_action_revoke_exclude",
+     flag<3>(&extension::used_feature_page_action_revoke_exclude)},
+    {"used_feature_page_action_revoke_geopref",
+     flag<4>(&extension::used_feature_page_action_revoke_geopref)},
+    {"count_excluded", count(&extension::count_excluded)},
+    {"count_geoprefed", count(&extension::count_geoprefed)},
+};
+}  // namespace handlers
+
+bool recordTelemetry(const TelemetryInfo& info) {
+  if (!handlers::map.contains(info.name)) {
+    return false;
+  }
+  auto handler = handlers::map[info.name];
+  handler(info.args);
+  return true;
+}
+
+void recordAllFlags() {
+  auto settings = SettingsHolder::instance();
+  const uint32_t currentBitFlags = settings->extensionTelemetryFlags();
+  auto readFlag = [currentBitFlags](BooleanMetric* metric, uint8_t bit) {
+    // Check if the specified bit is set
+    bool isBitSet = (currentBitFlags & (1 << bit)) != 0;
+    // Set the metric value based on the bit's state
+    metric->set(isBitSet);
+  };
+  using namespace mozilla::glean;
+  readFlag(&extension::has_completed_onboarding, 0);
+  readFlag(&extension::used_feature_diable_firefox_protection, 1);
+  readFlag(&extension::used_feature_settings_page, 2);
+  readFlag(&extension::used_feature_page_action_revoke_exclude, 3);
+  readFlag(&extension::used_feature_page_action_revoke_geopref, 4);
+}
+
+void startSession() {
+  // Read the current bitflags to the ping before we submit it.
+  recordAllFlags();
+  mozilla::glean_pings::Extensionsession.submit("extension_start");
+}
+void stopSession() {
+  mozilla::glean_pings::Extensionsession.submit("extension_stop");
+}
+}  // namespace WebextensionTelemetry

--- a/src/webextensiontelemetry.cpp
+++ b/src/webextensiontelemetry.cpp
@@ -61,13 +61,11 @@ auto constexpr count(QuantityMetric* metric) {
 // We will also record this to glean.
 // Flags will always be sent with the next ping
 auto consteval flag(BooleanMetric* metric) {
-  return [metric](QVariant) {
-    metric->set(true);
-  };
+  return [metric](QVariant) { metric->set(true); };
 }
 using namespace mozilla::glean;
 const auto map = QMap<QString, std::function<void(QVariant)>>{
-    {"fx_protetion_disabled", event(&extension::fx_protetion_disabled)},
+    {"fx_protection_disabled", event(&extension::fx_protection_disabled)},
     {"fx_protection_enabled", event(&extension::fx_protection_enabled)},
     {"fx_protection_mode_changed",
      event(&extension::fx_protection_mode_changed)},

--- a/src/webextensiontelemetry.cpp
+++ b/src/webextensiontelemetry.cpp
@@ -60,7 +60,7 @@ auto constexpr count(QuantityMetric* metric) {
 // For flags, we will flip the flag-bit in the settings to true.
 // We will also record this to glean.
 // Flags will always be sent with the next ping
-auto consteval flag(BooleanMetric* metric) {
+auto constexpr flag(BooleanMetric* metric) {
   return [metric](QVariant) { metric->set(true); };
 }
 using namespace mozilla::glean;

--- a/src/webextensiontelemetry.cpp
+++ b/src/webextensiontelemetry.cpp
@@ -67,15 +67,15 @@ auto consteval flag(BooleanMetric* metric) {
 }
 using namespace mozilla::glean;
 const auto map = QMap<QString, std::function<void(QVariant)>>{
-    {"fx_protection_disenabled", event(&extension::fx_protection_disenabled)},
+    {"fx_protetion_disabled", event(&extension::fx_protetion_disabled)},
     {"fx_protection_enabled", event(&extension::fx_protection_enabled)},
     {"fx_protection_mode_changed",
      event(&extension::fx_protection_mode_changed)},
     {"main_screen", event(&extension::main_screen)},
     {"error_screen", event(&mozilla::glean::extension::error_screen)},
     {"has_completed_onboarding", flag(&extension::has_completed_onboarding)},
-    {"used_feature_diable_firefox_protection",
-     flag(&extension::used_feature_diable_firefox_protection)},
+    {"used_feature_disable_firefox_protection",
+     flag(&extension::used_feature_disable_firefox_protection)},
     {"used_feature_settings_page",
      flag(&extension::used_feature_settings_page)},
     {"used_feature_page_action_revoke_exclude",

--- a/src/webextensiontelemetry.h
+++ b/src/webextensiontelemetry.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include <QJSONObject>
+#include <QJsonObject>
 #include <QString>
 #include <QVariant>
 #include <optional>

--- a/src/webextensiontelemetry.h
+++ b/src/webextensiontelemetry.h
@@ -1,0 +1,35 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#pragma once
+
+#include <QJSONObject>
+#include <QString>
+#include <QVariant>
+#include <optional>
+
+namespace WebextensionTelemetry {
+struct TelemetryInfo {
+  QString name;
+  QVariant args;
+};
+
+/**
+ * @brief Tries to parse a JSON Blob into a telemetry info obj,
+ * @return std::optional<TelemetryInfo> - Nullopt on parse-error.
+ */
+std::optional<TelemetryInfo> fromJson(const QJsonObject& obj);
+/**
+ * @brief Records telemetry to glean
+ *
+ * @param info - The Info to record, create with fromJson();
+ * @return true - info was accepted
+ * @return false - info was rejected
+ */
+bool recordTelemetry(const TelemetryInfo& info);
+
+void startSession();
+void stopSession();
+
+};  // namespace WebextensionTelemetry


### PR DESCRIPTION
## Description

This PR adds commands for the extension to send telemetry to the client. 
It's a bit bigger, therefore i've split this across 3 commits, for easyier reivew. 
1. In : https://github.com/mozilla-mobile/mozilla-vpn-client/pull/10057/commits/d6e1d7782b1f1780a36d494f795f4af65a3b7786
I've only added the metrics, the data review happens in a google doc, i can link that if it's done. 
2. In https://github.com/mozilla-mobile/mozilla-vpn-client/pull/10057/commits/a897f14912442bb1d84cc31e74fb0da6a81e362c
I add 3 commands:  `{t:telemetry, name: metric_name: args: any}` `{t:start_session}` `{t:stop_session}` - Those allow the extension to send any events or counts. For the bools we save them and attach them to the next ping, similar how we do that with our settings related bools. 
3. https://github.com/mozilla-mobile/mozilla-vpn-client/pull/10057/commits/fa836d69596e6d222634581dbb09e3dc82ee378d
I tried the least refactoring solution to allow us to enable telemetry either for the extension or the client. All data is attached to a ping with a name. I've added the ability for glean to filter out on a per `ping_name` basis. I use that to filter the extensions pings if they are not enabled and the client pings if those are disabled. 