### PR TITLE
VPN-6700: fix color

### DIFF
--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -1,4 +1,4 @@
-name: Linters (clang, l10n)
+name: Linters (clang, l10n, colors)
 on:
   # Triggers the workflow on pull request events but only for the main branch
   pull_request:

--- a/README.md
+++ b/README.md
@@ -201,6 +201,6 @@ If you don't know the answers to these questions, reach out to Sarah Bird or the
 
 [![Unit Tests](https://github.com/mozilla-mobile/mozilla-vpn-client/actions/workflows/test_unit.yaml/badge.svg)](https://github.com/mozilla-mobile/mozilla-vpn-client/actions/workflows/test_unit.yaml)
 [![Lottie Tests](https://github.com/mozilla-mobile/mozilla-vpn-client/actions/workflows/test_lottie.yaml/badge.svg)](https://github.com/mozilla-mobile/mozilla-vpn-client/actions/workflows/test_lottie.yaml)
-[![Linters (clang, l10n)](https://github.com/mozilla-mobile/mozilla-vpn-client/actions/workflows/linters.yaml/badge.svg)](https://github.com/mozilla-mobile/mozilla-vpn-client/actions/workflows/linters.yaml)
+[![Linters (clang, l10n, colors)](https://github.com/mozilla-mobile/mozilla-vpn-client/actions/workflows/linters.yaml/badge.svg)](https://github.com/mozilla-mobile/mozilla-vpn-client/actions/workflows/linters.yaml)
 [![Linux Packages](https://github.com/mozilla-mobile/mozilla-vpn-client/actions/workflows/linux.yaml/badge.svg)](https://github.com/mozilla-mobile/mozilla-vpn-client/actions/workflows/linux.yaml)
 [![WebAssembly](https://github.com/mozilla-mobile/mozilla-vpn-client/actions/workflows/wasm.yaml/badge.svg)](https://github.com/mozilla-mobile/mozilla-vpn-client/actions/workflows/wasm.yaml)

--- a/nebula/ui/components/MZAlert.qml
+++ b/nebula/ui/components/MZAlert.qml
@@ -129,7 +129,7 @@ Rectangle {
             name: stateNames.warning
             PropertyChanges {
                 target: focusIndicators
-                colorScheme: MZTheme.theme.warningAlert
+                colorScheme: MZTheme.colors.warningAlert
             }
 
             PropertyChanges {

--- a/nebula/ui/components/MZPopupButton.qml
+++ b/nebula/ui/components/MZPopupButton.qml
@@ -12,7 +12,7 @@ MZButtonBase {
 
     property alias buttonText: buttonText.text
     property alias buttonTextColor: buttonText.color
-    property var colorScheme
+    property var colorScheme: MZTheme.colors.normalButton
     property var uiState:MZTheme.theme.uiState
     property bool isCancelBtn
 

--- a/nebula/ui/themes/main/theme.js
+++ b/nebula/ui/themes/main/theme.js
@@ -22,7 +22,7 @@ color.primaryPressed = color.dullPurple;
 color.bgColor = color.grey5;
 color.bgColorTransparent = addTransparency(color.bgColor, 0.0);
 color.bgColorStronger = color.white;
-color.overlayBackground = addTransparency(color.black, 0.0);
+color.overlayBackground = addTransparency(color.black, 0.3);
 
 // Fonts
 color.fontColor = color.grey40;

--- a/nebula/ui/themes/not-designer-approved/theme.js
+++ b/nebula/ui/themes/not-designer-approved/theme.js
@@ -22,7 +22,7 @@ color.primaryPressed = color.purple90;
 color.bgColor = color.grey60;
 color.bgColorTransparent = addTransparency(color.bgColor, 0.0);
 color.bgColorStronger = color.black;
-color.overlayBackground = addTransparency(color.white, 0.0);
+color.overlayBackground = addTransparency(color.white, 0.3);
 
 // Fonts
 color.fontColor = color.grey40;

--- a/nebula/ui/themes/theme-derived.js
+++ b/nebula/ui/themes/theme-derived.js
@@ -51,7 +51,7 @@ color.iconButtonDarkBackground = {
   buttonHovered: color.primaryHovered,
   buttonPressed: color.primaryPressed,
   buttonDisabled: addTransparency(color.primary, 0.0),
-  focusOutline: color.transparent,
+  focusOutline: addTransparency(color.primaryHovered, 0.0),
   focusBorder: color.lightFocusBorder,
 };
 


### PR DESCRIPTION
## Description

I introduced this bug [right here](https://github.com/mozilla-mobile/mozilla-vpn-client/pull/10015/files#diff-9fc531023123071c2001a81ad0ff768a4408ea77e9b30a28cef024c3074f087eL183), by replacing `color.overlayBackground = '#4D000000';` with `color.overlayBackground = addTransparency(color.black, 0.0);`. Of course, 4D is 30%, not 0%. 

I went through and audited every other use of 0.0 transparency, to make sure I didn't have any other copy/paste errors. I found just one other spot that used 0.0 but the wrong color, and updated it as part of this PR. (Not all #00xxxxx colors are identical. While they look identical on screen, in transitions or with opacity changes they may look different. Changing all `addTransparency(color.[anything], 0.0)` to `color.transparency` will cause UI bugs.)

I also snuck two other things in here - a fix for a color name that needed to be updated, and a default `colorScheme` that suppresses some log warnings.

This color was used beneath overlays and above the help drawers. As expected, this PR fixes both spots (before photos are in the Jira ticket):
<img width="161" alt="Screenshot 22" src="https://github.com/user-attachments/assets/40e18a39-bab6-4a16-8dfc-cb54475edccd"><img width="168" alt="Screenshot 21" src="https://github.com/user-attachments/assets/fb140eec-10f8-4d7a-95a8-cbdc994d1257">

## Reference

VPN-6700

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
