### PR TITLE
VPN-6738: Statically link socksproxy to OpenSSL for Static Qt

### DIFF
--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   source-bundle:
     name: Source Bundle
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -35,9 +35,7 @@ jobs:
 
       - name: Build source bundle
         shell: bash
-        env:
-          GITREF: ${{github.ref}}
-        run: ./scripts/linux/script.sh --source --gitref ${GITREF}
+        run: ./scripts/linux/script.sh --source --gitref ${{github.ref}}
 
       - name: Upload source bundle
         uses: actions/upload-artifact@v4

--- a/extension/socks5proxy/bin/CMakeLists.txt
+++ b/extension/socks5proxy/bin/CMakeLists.txt
@@ -14,6 +14,13 @@ target_link_libraries(socksproxy PUBLIC
     libSocks5proxy
 )
 
+# If Qt is statically linked to OpenSSL, we need to link to it manually.
+if(QT_FEATURE_static AND QT_FEATURE_openssl AND QT_FEATURE_openssl_linked)
+    set(OPENSSL_USE_STATIC_LIBS TRUE)
+    find_package(OpenSSL REQUIRED)
+    target_link_libraries(mozillavpn PRIVATE ${OPENSSL_SSL_LIBRARY} ${OPENSSL_CRYPTO_LIBRARY})
+endif()
+
 if(WIN32)
     target_compile_definitions(socksproxy PRIVATE PROXY_OS_WIN)
     target_sources(socksproxy PRIVATE

--- a/extension/socks5proxy/bin/CMakeLists.txt
+++ b/extension/socks5proxy/bin/CMakeLists.txt
@@ -14,13 +14,6 @@ target_link_libraries(socksproxy PUBLIC
     libSocks5proxy
 )
 
-# If Qt is statically linked to OpenSSL, we need to link to it manually.
-if(QT_FEATURE_static AND QT_FEATURE_openssl AND QT_FEATURE_openssl_linked)
-    set(OPENSSL_USE_STATIC_LIBS TRUE)
-    find_package(OpenSSL REQUIRED)
-    target_link_libraries(mozillavpn PRIVATE ${OPENSSL_SSL_LIBRARY} ${OPENSSL_CRYPTO_LIBRARY})
-endif()
-
 if(WIN32)
     target_compile_definitions(socksproxy PRIVATE PROXY_OS_WIN)
     target_sources(socksproxy PRIVATE

--- a/linux/debian/rules
+++ b/linux/debian/rules
@@ -11,13 +11,20 @@ ifneq (ok,$(shell dpkg --compare-versions $(GOLANG_NATIVE_VERSION) ge 2:1.18 && 
 	export PATH := $(GODIR)/bin:$(PATH)
 endif
 
+# Check Qt features.
+QT_INSTALL_HEADERS := $(shell qmake -query QT_INSTALL_HEADERS)
+qtfeatures = $(shell printf "#include <QtCore/qconfig.h>\n%s" $(1) | gcc -I $(QT_INSTALL_HEADERS) -E - | grep -v '^#' | tr -d '[:space:]')
+ifeq (1,$(call qtfeatures,QT_FEATURE_static && QT_FEATURE_openssl && QT_FEATURE_openssl_linked))
+	OPENSSL_BUILD_ARGS := -DOPENSSL_USE_STATIC_LIBS
+endif
+
 CMAKE_BUILD_DIR := build-$(DEB_HOST_MULTIARCH)
 
 %:
 	dh $@ --with=systemd --buildsystem=cmake+ninja --builddirectory=$(CMAKE_BUILD_DIR) --warn-missing
 
 override_dh_auto_configure:
-	dh_auto_configure -- -DWEBEXT_INSTALL_LIBDIR=/lib -DBUILD_ID=$(DEB_VERSION) -DBUILD_TESTS=OFF
+	dh_auto_configure -- -DWEBEXT_INSTALL_LIBDIR=/lib -DBUILD_ID=$(DEB_VERSION) -DBUILD_TESTS=OFF ${OPENSSL_BUILD_ARGS}
 
 override_dh_auto_test:
 

--- a/linux/debian/rules
+++ b/linux/debian/rules
@@ -13,7 +13,7 @@ endif
 
 # Check Qt features.
 QT_INSTALL_HEADERS := $(shell pkg-config --variable=includedir Qt6Core || qmake6 -query QT_INSTALL_HEADERS || true)
-qtfeature = $(shell test -d "$(QT_INSTALL_HEADERS)" && printf "#include <QtCore/qconfig.h>\n%s" "$(1)" | gcc -I "$(QT_INSTALL_HEADERS)" -E - | grep -e '^[^#\s]')
+qtfeature = $(shell test -d "$(QT_INSTALL_HEADERS)" && echo "$(1)" | gcc -I "$(QT_INSTALL_HEADERS)" -include QtCore/qconfig.h -E - | grep -e '^[^#\s]')
 ifeq (1,$(call qtfeature,QT_FEATURE_static))
 ifeq (1,$(call qtfeature,QT_FEATURE_openssl_linked))
 	OPENSSL_BUILD_ARGS := -DOPENSSL_USE_STATIC_LIBS=ON

--- a/linux/debian/rules
+++ b/linux/debian/rules
@@ -13,7 +13,7 @@ endif
 
 # Check Qt features.
 QT_INSTALL_HEADERS := $(shell pkg-config --variable=includedir Qt6Core || qmake6 -query QT_INSTALL_HEADERS || true)
-qtfeature = $(shell test -d "$(QT_INSTALL_HEADERS)" && echo "$(1)" | gcc -I "$(QT_INSTALL_HEADERS)" -include QtCore/qconfig.h -E - | grep -e '^[^#\s]')
+qtfeature = $(shell test -d "$(QT_INSTALL_HEADERS)" && echo "$(1)" | gcc -I "$(QT_INSTALL_HEADERS)" -include QtCore/qconfig.h -E - | grep -e '^[[:alnum:]_-]')
 ifeq (1,$(call qtfeature,QT_FEATURE_static))
 ifeq (1,$(call qtfeature,QT_FEATURE_openssl_linked))
 	OPENSSL_BUILD_ARGS := -DOPENSSL_USE_STATIC_LIBS=ON

--- a/linux/debian/rules
+++ b/linux/debian/rules
@@ -12,8 +12,8 @@ ifneq (ok,$(shell dpkg --compare-versions $(GOLANG_NATIVE_VERSION) ge 2:1.18 && 
 endif
 
 # Check Qt features.
-QT_INSTALL_HEADERS := $(shell pkg-config --variable=includedir Qt6Core || qmake -query QT_INSTALL_HEADERS)
-qtfeature = $(shell printf "#include <QtCore/qconfig.h>\n%s" "$(1)" | gcc -I "$(QT_INSTALL_HEADERS)" -E - | grep -v '^#' | tr -d '[:space:]')
+QT_INSTALL_HEADERS := $(shell pkg-config --variable=includedir Qt6Core || qmake6 -query QT_INSTALL_HEADERS || true)
+qtfeature = $(shell test -d "$(QT_INSTALL_HEADERS)" && printf "#include <QtCore/qconfig.h>\n%s" "$(1)" | gcc -I "$(QT_INSTALL_HEADERS)" -E - | grep -e '^[^#\s]')
 ifeq (1,$(call qtfeature,QT_FEATURE_static))
 ifeq (1,$(call qtfeature,QT_FEATURE_openssl_linked))
 	OPENSSL_BUILD_ARGS := -DOPENSSL_USE_STATIC_LIBS=ON

--- a/linux/debian/rules
+++ b/linux/debian/rules
@@ -12,11 +12,11 @@ ifneq (ok,$(shell dpkg --compare-versions $(GOLANG_NATIVE_VERSION) ge 2:1.18 && 
 endif
 
 # Check Qt features.
-QT_INSTALL_HEADERS := $(shell qmake6 -query QT_INSTALL_HEADERS)
-qtfeature = $(shell printf "#include <QtCore/qconfig.h>\n%s" "$(1)" | gcc -I $(QT_INSTALL_HEADERS) -E - | grep -v '^#' | tr -d '[:space:]')
+QT_INSTALL_HEADERS := $(shell pkg-config --variable=includedir Qt6Core || qmake -query QT_INSTALL_HEADERS)
+qtfeature = $(shell printf "#include <QtCore/qconfig.h>\n%s" "$(1)" | gcc -I "$(QT_INSTALL_HEADERS)" -E - | grep -v '^#' | tr -d '[:space:]')
 ifeq (1,$(call qtfeature,QT_FEATURE_static))
 ifeq (1,$(call qtfeature,QT_FEATURE_openssl_linked))
-	OPENSSL_BUILD_ARGS := -DOPENSSL_USE_STATIC_LIBS
+	OPENSSL_BUILD_ARGS := -DOPENSSL_USE_STATIC_LIBS=ON
 endif
 endif
 

--- a/linux/debian/rules
+++ b/linux/debian/rules
@@ -12,10 +12,12 @@ ifneq (ok,$(shell dpkg --compare-versions $(GOLANG_NATIVE_VERSION) ge 2:1.18 && 
 endif
 
 # Check Qt features.
-QT_INSTALL_HEADERS := $(shell qmake -query QT_INSTALL_HEADERS)
-qtfeatures = $(shell printf "#include <QtCore/qconfig.h>\n%s" $(1) | gcc -I $(QT_INSTALL_HEADERS) -E - | grep -v '^#' | tr -d '[:space:]')
-ifeq (1,$(call qtfeatures,QT_FEATURE_static && QT_FEATURE_openssl && QT_FEATURE_openssl_linked))
+QT_INSTALL_HEADERS := $(shell qmake6 -query QT_INSTALL_HEADERS)
+qtfeature = $(shell printf "#include <QtCore/qconfig.h>\n%s" "$(1)" | gcc -I $(QT_INSTALL_HEADERS) -E - | grep -v '^#' | tr -d '[:space:]')
+ifeq (1,$(call qtfeature,QT_FEATURE_static))
+ifeq (1,$(call qtfeature,QT_FEATURE_openssl_linked))
 	OPENSSL_BUILD_ARGS := -DOPENSSL_USE_STATIC_LIBS
+endif
 endif
 
 CMAKE_BUILD_DIR := build-$(DEB_HOST_MULTIARCH)


### PR DESCRIPTION
## Description
The socksproxy binary, when built with static Qt, fails to start on Linux as follows:

```
/usr/bin/socksproxy: error while loading shared libraries: libssl.so.1.1: cannot open shared object file: No such file or directory
```

This works in the main VPN binary because OpenSSL gets statically linked in through glean, but there is no glean in the socks proxy so it reverts to the default behaviour of Qt. In order to guide Qt (or really CMake in general) to choose static linking for OpenSSL we need to set the `OPENSSL_USE_STATIC_LIBS` variable. This best done at the project configuration stage.

However, there is a minor wrinkle. We have to set it before `find_package(Qt)`, which means we can't use CMake to check the Qt feature flags. To workaround this, we add some magic to the `debian/rules` file to detect the Qt feature flags and set the `-DOPENSSL_USE_STATIC_LIBS=ON` configuration variable if it finds that Qt is statically linked.

## Reference
Jira Issue: [VPN-6738](https://mozilla-hub.atlassian.net/browse/VPN-6738)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-6738]: https://mozilla-hub.atlassian.net/browse/VPN-6738?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ