### PR TITLE
VPN-6749: Fix shared addon ids

### DIFF
--- a/.github/l10n/check_l10n_issues.py
+++ b/.github/l10n/check_l10n_issues.py
@@ -35,7 +35,7 @@ def fileContentsAsJSON(filepath):
 def getSharedStringsInManifest(mainifest_contents):
     shared_string_ids = []
     # If it includes the key “message” and if within "message", there is a “usesSharedStrings” key that is true...
-    if "message" in manifest_contents and "usesSharedStrings" in manifest_contents["message"] and manifest_contents["message"]["usesSharedStrings"]:
+    if manifest_contents.get("message", {}).get("usesSharedStrings", False):
         #...collect all the string IDs
         if "title" in manifest_contents["message"]:
             shared_string_ids.append(manifest_contents["message"]["title"])
@@ -80,7 +80,7 @@ except Exception as e:
     sys.exit(1)
 
 if len(addon_list) == 0:
-    print(f"No themes found")
+    print(f"No addons found")
     sys.exit(1)
 
 shared_string_ids = []

--- a/addons/CMakeLists.txt
+++ b/addons/CMakeLists.txt
@@ -11,14 +11,6 @@ project(addons VERSION 1.0.0 LANGUAGES CXX
 find_program(PYTHON_EXECUTABLE NAMES python3 python)
 find_package(Qt6 REQUIRED COMPONENTS Core Qml)
 
-## In case new shared strings were added to ./addons/strings.yaml, run the generation script so actual strings are shown
-add_custom_command(
-                OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/../3rdparty/i18n/en/addons/strings.xliff
-                DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/strings.yaml
-                COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/../scripts/utils/generate_shared_addon_xliff.py
-                            -i ${CMAKE_CURRENT_SOURCE_DIR}/strings.yaml
-                            -o ${CMAKE_CURRENT_SOURCE_DIR}/../3rdparty/i18n/en/addons/strings.xliff)
-
 ## Create the addons target.
 include(${CMAKE_CURRENT_SOURCE_DIR}/../scripts/cmake/addons.cmake)
 add_addon_target(addons

--- a/addons/CMakeLists.txt
+++ b/addons/CMakeLists.txt
@@ -11,6 +11,14 @@ project(addons VERSION 1.0.0 LANGUAGES CXX
 find_program(PYTHON_EXECUTABLE NAMES python3 python)
 find_package(Qt6 REQUIRED COMPONENTS Core Qml)
 
+## In case new shared strings were added to ./addons/strings.yaml, run the generation script so actual strings are shown
+add_custom_command(
+                OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/../3rdparty/i18n/en/addons/strings.xliff
+                DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/strings.yaml
+                COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/../scripts/utils/generate_shared_addon_xliff.py
+                            -i ${CMAKE_CURRENT_SOURCE_DIR}/strings.yaml
+                            -o ${CMAKE_CURRENT_SOURCE_DIR}/../3rdparty/i18n/en/addons/strings.xliff)
+
 ## Create the addons target.
 include(${CMAKE_CURRENT_SOURCE_DIR}/../scripts/cmake/addons.cmake)
 add_addon_target(addons

--- a/docs/Components/Addons/index.md
+++ b/docs/Components/Addons/index.md
@@ -152,7 +152,13 @@ If you want to implement new add-ons, you need to follow these steps:
 
 1. Create a manifest in a separate folder in the `addons` directory of the mozilla VPN repository.
 2. Read and follow the documentation for the add-on type you want to implement.
-3. If new shared strings were added, process them so that strings are shown in the addon: `python ./scripts/utils/generate_shared_addon_xliff.py -i ./addons/strings.yaml -o ./3rdparty/i18n/en/addons/strings.xliff` (This step is not necessary, strictly speaking. This script is what will be run as new strings are ingested into l10n repo, and once the new strings have done a round trip to the l10n repo and then back to the client repo, the string will show up in the addon as expected. Manually running this script as part of the build process prevents the brand new addon from showing "vpn.newStringCategory.newString" until this round trip happens.)
+3. If new shared strings were added, process them so that strings are shown in the addon:
+`python ./scripts/utils/generate_shared_addon_xliff.py -i ./addons/strings.yaml -o ./3rdparty/i18n/en/addons/strings.xliff`
+(This step is not necessary, strictly speaking. This script is what will be run as new
+strings are ingested into l10n repo, and once the new strings have done a round trip to
+the l10n repo and then back to the client repo, the string will show up in the addon as
+expected. Manually running this script as part of the build process prevents the brand
+new addon from showing "vpn.newStringCategory.newString" until this round trip happens.)
 4. Build the CMake project in the `addons` directory.
 
 ```

--- a/docs/Components/Addons/index.md
+++ b/docs/Components/Addons/index.md
@@ -152,7 +152,8 @@ If you want to implement new add-ons, you need to follow these steps:
 
 1. Create a manifest in a separate folder in the `addons` directory of the mozilla VPN repository.
 2. Read and follow the documentation for the add-on type you want to implement.
-3. Build the CMake project in the `addons` directory.
+3. If new shared strings were added, process them so that strings are shown in the addon: `python ./scripts/utils/generate_shared_addon_xliff.py -i ./addons/strings.yaml -o ./3rdparty/i18n/en/addons/strings.xliff` (This step is not necessary, strictly speaking. This script is what will be run as new strings are ingested into l10n repo, and once the new strings have done a round trip to the l10n repo and then back to the client repo, the string will show up in the addon as expected. Manually running this script as part of the build process prevents the brand new addon from showing "vpn.newStringCategory.newString" until this round trip happens.)
+4. Build the CMake project in the `addons` directory.
 
 ```
 mkdir -p build-addons/
@@ -160,10 +161,10 @@ cmake -S <source>/addons -B build-addons -GNinja
 cmake --build build-addons
 ```
 
-4. Expose the generated build directory through a webservice. For example: `python3 -m http.server --directory build-addons/`
-5. Open the dev-menu from the get-help view and set a custom add-on URL: `http://localhost:8000/`
-6. Scroll down and disable the signature-addon feature from the dev-menu, list of features
-7. Be sure you are doing all of this using a staging environment
+5. Expose the generated build directory through a webservice. For example: `python3 -m http.server --directory build-addons/`
+6. Open the dev-menu from the get-help view and set a custom add-on URL: `http://localhost:8000/`
+7. Scroll down and disable the signature-addon feature from the dev-menu, list of features
+8. Be sure you are doing all of this using a staging environment
 
 If all has done correctly, you can see the app fetching the manifest.json (and
 not! the manifest.json.sig) resource from the webservice.

--- a/scripts/addon/build.py
+++ b/scripts/addon/build.py
@@ -461,7 +461,7 @@ with open(args.source, "r", encoding="utf-8") as file:
         print("Create localization file...")
         os.mkdir(os.path.join(tmp_path, "i18n"))
         template_ts_file = os.path.join(args.dest, f"{manifest['id']}.ts")
-        write_en_language(template_ts_file, strings)
+        write_en_language(template_ts_file, strings, True)
 
         # This will be probably replaced by the en locale if it exists
         en_ts_file = os.path.join(tmp_path, "i18n", "locale_en.ts")

--- a/scripts/shared.py
+++ b/scripts/shared.py
@@ -2,7 +2,7 @@ import os
 import sys
 import xml.etree.ElementTree as ET
 
-def write_en_language(filename, strings):
+def write_en_language(filename, strings, key_as_id):
     ts = ET.Element("TS")
     ts.set("version", "2.1")
     ts.set("language", "en")
@@ -12,7 +12,10 @@ def write_en_language(filename, strings):
 
     for key, value in strings.items():
         message = ET.SubElement(context, "message")
-        message.set("id", key)
+        if key_as_id:
+            message.set("id", key)
+        else:
+            message.set("id", value["string_id"])
 
         location = ET.SubElement(message, "location")
         location.set("filename", "addon.qml")

--- a/scripts/utils/generate_shared_addon_xliff.py
+++ b/scripts/utils/generate_shared_addon_xliff.py
@@ -28,6 +28,16 @@ def prune_lists_to_strings(data):
             sys.exit("Unexpected input")
     return data
 
+def use_proper_id(data):
+    return_data = {}
+    for value in data.values():
+        string_id = value["string_id"]
+        return_data[string_id] = {
+            "value": value["value"],
+            "comments": value["comments"]
+        }
+    return return_data
+
 # Make sure we have all the required things
 # Lookup our required tools for addon generation.
 
@@ -59,6 +69,8 @@ print("Preparing the addons shared string file")
 print("First, pull in the strings from the YAML file")
 translation_strings = parseYAMLTranslationStrings(args.infile)
 translation_strings = prune_lists_to_strings(translation_strings)
+# parseYAMLTranslationStrings gives a different ID than we want to use
+translation_strings = use_proper_id(translation_strings)
 
 print("Then, write the strings to a .ts file")
 tmp_path = tempfile.mkdtemp()

--- a/scripts/utils/generate_shared_addon_xliff.py
+++ b/scripts/utils/generate_shared_addon_xliff.py
@@ -28,16 +28,6 @@ def prune_lists_to_strings(data):
             sys.exit("Unexpected input")
     return data
 
-def use_proper_id(data):
-    return_data = {}
-    for value in data.values():
-        string_id = value["string_id"]
-        return_data[string_id] = {
-            "value": value["value"],
-            "comments": value["comments"]
-        }
-    return return_data
-
 # Make sure we have all the required things
 # Lookup our required tools for addon generation.
 
@@ -69,13 +59,11 @@ print("Preparing the addons shared string file")
 print("First, pull in the strings from the YAML file")
 translation_strings = parseYAMLTranslationStrings(args.infile)
 translation_strings = prune_lists_to_strings(translation_strings)
-# parseYAMLTranslationStrings gives a different ID than we want to use
-translation_strings = use_proper_id(translation_strings)
 
 print("Then, write the strings to a .ts file")
 tmp_path = tempfile.mkdtemp()
 ts_file = os.path.join(tmp_path, "sharedAddonsStrings.ts")
-write_en_language(ts_file, translation_strings)
+write_en_language(ts_file, translation_strings, False)
 
 print("Finally, convert the ts file into an xliff file")
 os.system(f"{lconvert} -if ts -i {ts_file} -of xlf -o {args.outfile}")


### PR DESCRIPTION
## Description

The “shared addons strings” for VPN ([VPN PR](https://github.com/mozilla-mobile/mozilla-vpn-client/pull/9763/), [translations PR](https://github.com/mozilla-l10n/mozilla-vpn-client-l10n/pull/466)) had a bug - the string IDs in pontoon are of the form `CommonStringsSubtitle`, and the intention was `vpn.commonStrings.subtitle`. While this is non-standard (per the rest of our string IDs), it also provides an unlikely-but-real technical issue of a future clash - `update.soonMessage` and `updateSoon.message` from different parts of the YAML file would end up with the same ID of `CommonStringsUpdateSoonMessage`.

This PR does 3 things:
- Fixes the bug in `generate_shared_addons_xliff.py`
- Adds a new test in `check_l10n_issues.py` that probably should have been there from the start - it would have caught this issue. This confirms that all shared strings from addons are present in the processed translation file.
- Adds a note to the documentation. (I tried to automatically do this via cmake, but belatedly learnend that cmake cannot modify source directory files.)

### There is another PR on the l10n repo to update the current translation strings to this id format: https://github.com/mozilla-l10n/mozilla-vpn-client-l10n/pull/494

### The two PRs must be merged at the same time, so that the subsequent ingestion script run doesn't re-introduce the bad IDs and doesn't introduce the good IDs (without translations).

## Reference

VPN-6749

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
