### PR TITLE
Try to pick a better flatpak cache key

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -100,7 +100,7 @@ jobs:
         with:
           bundle: mozillavpn.flatpak
           manifest-path: manifest/org.mozilla.vpn.yml
-          cache-key: flatpak-builder-${{ github.sha }}
+          cache-key: flatpak-builder-${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.sha }}
 
   dependabot-cargo:
     name: "Update Crates"


### PR DESCRIPTION
## Description
Since I am up to my eyeballs in getting the CI working better, the Flatpak build jobs are taking far too long for my liking.
It seems that the github action they are built with has support for caching, but we include the `${{ github.sha }}` in it, which basically means the cache will never hit.

If we change that to `${{ github.event.pull_request.base.sha }}` then at least pull requests will build off the cached build from `main`.

## Reference

    i.e Jira or Github issue URL

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
