### PR TITLE
Fix assert fail in auth tests

### DIFF
--- a/src/settings/settingsmanager.cpp
+++ b/src/settings/settingsmanager.cpp
@@ -54,8 +54,9 @@ QString SettingsManager::getOrganizationName() {
 #ifdef UNIT_TEST
 // static
 void SettingsManager::testCleanup() {
-  Q_ASSERT(s_instance);
-  delete s_instance;
+  if (s_instance) {
+    delete s_instance;
+  }
 }
 #endif
 


### PR DESCRIPTION
## Description
At some point in the past the auth tests were broken due to a bad assert that was causing the test worker to fail if there was no SettingsManager created. Rather than an assert, we should just check to see if the SettingsManager was created and handle the test cleanup accordingly.

There's a 99.999% chance that I am to blame for the failed test, but we just never noticed because we don't run the auth tests in PR.

## Reference

    i.e Jira or Github issue URL

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
