### PR TITLE
Test: Build for iOS-aarch64 Simulator

### DIFF
--- a/env.yml
+++ b/env.yml
@@ -14,6 +14,7 @@ dependencies:
   - rust-std-x86_64-apple-darwin=1.75
   - rust-std-aarch64-apple-ios=1.75
   - rust-std-x86_64-apple-ios=1.75
+  - rust-std-aarch64-apple-ios-sim=1.75
   - rust-std-armv7-linux-androideabi=1.75
   - rust-std-x86_64-linux-android=1.75
   - rust-std-i686-linux-android=1.75

--- a/qtglean/CMakeLists.txt
+++ b/qtglean/CMakeLists.txt
@@ -75,16 +75,16 @@ if(NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Emscripten")
     if(IOS)
         set(RUST_ARCH "")
         if("arm64" IN_LIST CMAKE_OSX_ARCHITECTURES)
-            list(APPEND RUST_ARCH aarch64-apple-ios)
+            list(APPEND RUST_ARCH aarch64-apple-ios aarch64-apple-ios-sim)
         endif()
 
         if("x86_64" IN_LIST CMAKE_OSX_ARCHITECTURES)
-            list(APPEND RUST_ARCH x86_64-apple-ios)
+            list(APPEND RUST_ARCH x86_64-apple-ios x86_64-apple-ios-sim)
         endif()
 
         # If no architecure is defined, just do all of them.
         if (RUST_ARCH STREQUAL "")
-            set(RUST_ARCH aarch64-apple-ios x86_64-apple-ios)
+            set(RUST_ARCH aarch64-apple-ios x86_64-apple-ios x86_64-apple-ios-sim aarch64-apple-ios-sim)
         endif()
 
         # On iOS we will build a dynamic lib,

--- a/qtglean/CMakeLists.txt
+++ b/qtglean/CMakeLists.txt
@@ -79,7 +79,7 @@ if(NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Emscripten")
         endif()
 
         if("x86_64" IN_LIST CMAKE_OSX_ARCHITECTURES)
-            list(APPEND RUST_ARCH x86_64-apple-ios x86_64-apple-ios-sim)
+            list(APPEND RUST_ARCH x86_64-apple-ios)
         endif()
 
         # If no architecure is defined, just do all of them.


### PR DESCRIPTION
## Description
Currently trying to build for simulator on bitrise, it uses an m1 instead of x86 like taskcluster. So the compilation of glean fails. 
