### PR TITLE
Fix buggy globbing rules in addon build

### DIFF
--- a/scripts/cmake/addons.cmake
+++ b/scripts/cmake/addons.cmake
@@ -34,7 +34,10 @@ function(add_addon_target NAME)
 
     # Scan for addon manifests if a source directory was provided.
     if(ADDON_SOURCE_DIR)
-        file(GLOB_RECURSE SCANNED_MANIFEST_FILES CONFIGURE_DEPENDS ${ADDON_SOURCE_DIR}/manifest.json)
+        file(GLOB_RECURSE SCANNED_MANIFEST_FILES
+            CONFIGURE_DEPENDS
+            ${ADDON_SOURCE_DIR}/*/manifest.json)
+
         foreach(FILENAME ${SCANNED_MANIFEST_FILES})
             if(${FILENAME} MATCHES "generated")
                 continue()
@@ -52,8 +55,8 @@ function(add_addon_target NAME)
     # Add commands to build the addons
     foreach(MANIFEST_FILE ${ADDON_SOURCES})
         # Parse the manifest to get the addon ID.
-        execute_process(OUTPUT_VARIABLE ADDON_ID OUTPUT_STRIP_TRAILING_WHITESPACE
-            COMMAND ${PYTHON_EXECUTABLE} -c "import json; print(json.load(open('${MANIFEST_FILE}', encoding='utf-8'))['id'])")
+        file(READ ${MANIFEST_FILE} MANIFEST_JSON)
+        string(JSON ADDON_ID GET "${MANIFEST_JSON}" "id")
 
         if((CMAKE_GENERATOR MATCHES "Ninja") OR (CMAKE_GENERATOR MATCHES "Makefiles"))
             ## Depfiles are great, but they only work for some generators.

--- a/tests/functional/addons/CMakeLists.txt
+++ b/tests/functional/addons/CMakeLists.txt
@@ -11,21 +11,21 @@ project(testing_addons VERSION 1.0.0 LANGUAGES CXX
 find_program(PYTHON_EXECUTABLE NAMES python3 python)
 find_package(Qt6 REQUIRED COMPONENTS Core Qml)
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../../scripts/cmake/addons.cmake)
+include(${CMAKE_SOURCE_DIR}/scripts/cmake/addons.cmake)
 
 # Build the production addons.
 add_addon_target(prod_addon
-    OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR}/prod/
-    SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../../addons/
-    I18N_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../../3rdparty/i18n
+    OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR}/prod
+    SOURCE_DIR ${CMAKE_SOURCE_DIR}/addons
+    I18N_DIR ${CMAKE_SOURCE_DIR}/3rdparty/i18n
 )
 set_target_properties(prod_addon PROPERTIES EXCLUDE_FROM_ALL FALSE)
 
 # Build the addons for testing.
 add_custom_target(test_01_empty_manifest
     COMMAND ${CMAKE_COMMAND} -E copy_directory
-                ${CMAKE_CURRENT_SOURCE_DIR}/01_empty_manifest/
-                ${CMAKE_CURRENT_BINARY_DIR}/01_empty_manifest/
+                ${CMAKE_CURRENT_SOURCE_DIR}/01_empty_manifest
+                ${CMAKE_CURRENT_BINARY_DIR}/01_empty_manifest
 )
 set_target_properties(test_01_empty_manifest PROPERTIES EXCLUDE_FROM_ALL FALSE)
 
@@ -37,13 +37,13 @@ add_custom_target(test_02_broken_manifest
 set_target_properties(test_02_broken_manifest PROPERTIES EXCLUDE_FROM_ALL FALSE)
 
 add_addon_target(test_03_single_addon
-    OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR}/03_single_addon/
-    SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/03_single_addon/
+    OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR}/03_single_addon
+    SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/03_single_addon
 )
 set_target_properties(test_03_single_addon PROPERTIES EXCLUDE_FROM_ALL FALSE)
 
 add_addon_target(test_08_message_disabled
-    OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR}/08_message_disabled/
-    SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/08_message_disabled/
+    OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR}/08_message_disabled
+    SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/08_message_disabled
 )
 set_target_properties(test_08_message_disabled PROPERTIES EXCLUDE_FROM_ALL FALSE)


### PR DESCRIPTION
## Description
I have noticed that the flatpak builds started failing after merging #10064 due to a failure to build the test addons, which I failed to notice because the flatpak builds were kinda flaky lately anyways. The problem seems to be that we have a buggy use of `GLOB_RECURSE` in addons.cmake that doesn't include any glob patterns and can fail to match any addons when `CMAKE_CURRENT_SOURCE_DIR` and `ADDON_SOURCE_DIR` differ.

While we're at it, we don't need to use inline python to parse the `ADDON_ID`. We have since upgraded to CMake > 2.20 which now includes native support for JSON parsing.

## Reference
Example build failure: https://github.com/mozilla-mobile/mozilla-vpn-client/actions/runs/12019520242/job/33506273223

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
