### PR TITLE
VPN-6399: Add Linux Qt build dependencies for accessibility

### DIFF
--- a/taskcluster/docker/linux-qt6-build/Dockerfile
+++ b/taskcluster/docker/linux-qt6-build/Dockerfile
@@ -39,7 +39,9 @@ RUN apt-get -y install build-essential \
 
 ## Install Qt6/X11 build dependencies
 ## From: https://doc.qt.io/qt-6/linux-requirements.html
-RUN apt-get -y install libfontconfig1-dev \
+RUN apt-get -y install libatspi2.0-dev \
+                       libdbus-1-dev \
+                       libfontconfig1-dev \
                        libfreetype6-dev \
                        libssl-dev \
                        libx11-dev \


### PR DESCRIPTION
## Description
The smoking gun in the Qt build logs seems to be this:

```
Note: Disabling X11 Accessibility Bridge: D-Bus or AT-SPI is missing.
```

To enable X11 accesibility support, I think we just need to make sure that Qt is built with the development libraries `libdbus-1-dev` and `libatspi2.0-dev` installed.

## Reference
JIRA Issue: [VPN-6399](https://mozilla-hub.atlassian.net/browse/VPN-6399)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-6399]: https://mozilla-hub.atlassian.net/browse/VPN-6399?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ