### PR TITLE
Fix addon cache keying

### DIFF
--- a/.github/workflows/build_addons.yaml
+++ b/.github/workflows/build_addons.yaml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: build-addons/
-          key: test-addons-${{ hashFiles('addons/', 'test/functional/addons/') }}
+          key: test-addons-${{ hashFiles('addons/**', 'test/functional/addons/**', 'scripts/addons/*.py', 'scripts/cmake/addons.cmake') }}
 
       - name: Install build dependencies
         if: steps.addons-cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
## Description
It looks like the attempted caching of addons for functional testing didn't work as expected. In particular I think that calling `hashFiles('addons/')` doesn't recursively scan the directory, which means that it doesn't react to changes in the addon content. Maybe using a `hashFiles('addons/**') with a globstar instead will do the trick.

While we're at it, let's throw the addons build tooling into the hash too.

## Reference

    i.e Jira or Github issue URL

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
