### PR TITLE
Fix matrix evaluation for wasm functional tests

### DIFF
--- a/.github/workflows/wasm_tests.yaml
+++ b/.github/workflows/wasm_tests.yaml
@@ -25,7 +25,7 @@ jobs:
     name: Wasm Qt6
     runs-on: ubuntu-20.04
     outputs:
-      matrix: ${{ steps.testGen.outputs.tests }}
+      matrix: ${{ steps.enumerate.outputs.tests }}
     env:
       QTVERSION: 6.2.4
 
@@ -76,7 +76,7 @@ jobs:
             !build/cmake/
 
       - name: Generate tasklist
-        id: testGen
+        id: enumerate
         shell: bash
         run: |
           echo -n "tests=" >> $GITHUB_OUTPUT
@@ -87,7 +87,7 @@ jobs:
       - name: Check tests
         shell: bash
         env:
-          TEST_LIST: ${{ steps.testGen.outputs.tests }}
+          TEST_LIST: ${{ steps.enumerate.outputs.tests }}
         run: |
           echo $TEST_LIST | jq
 
@@ -101,7 +101,7 @@ jobs:
     strategy:
       fail-fast: false # Don't cancel other jobs if a test fails
       matrix:
-        test: ${{ fromJson(needs.wasmQt6.outputs.matrix) }}
+        test: ${{ fromJson(needs.build_test_app.outputs.matrix) }}
     env:
       QTVERSION: 6.2.4
 


### PR DESCRIPTION
## Description
I think this was introduced by #10053 which made an error in how we pass the generated test list to the functional test jobs. This should fix it and make the wasm job consistent with Linux and MacOS.

## Reference
Introduced by #10053

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
