### PR TITLE
VPN-6763: Do not include shared translations when importing addon-specific ts files

### DIFF
--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Generate updated .ts files and check for l10n errors
         run: |
-          ./scripts/utils/generate_ts.sh
+          ./scripts/utils/generate_ts.sh -a
           python .github/l10n/check_l10n_issues.py
 
       - name: Check for QRC errors

--- a/.github/workflows/translations.yaml
+++ b/.github/workflows/translations.yaml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Generating translations
         run: |
-          ./scripts/utils/generate_ts.sh
+          ./scripts/utils/generate_ts.sh -a
 
       - name: Uploading
         uses: actions/upload-artifact@v4

--- a/scripts/utils/generate_ts.sh
+++ b/scripts/utils/generate_ts.sh
@@ -12,8 +12,7 @@ print N ""
 cd $(dirname $0)/../.. || die
 
 printn Y "Branch name: "
-BRANCHNAME="$(git symbolic-ref HEAD 2>/dev/null)"
-BRANCHNAME=${BRANCHNAME##refs/heads/}
+BRANCHNAME="$(git rev-parse --abbrev-ref HEAD 2>/dev/null)"
 print G "$BRANCHNAME"
 
 printn Y "Caching the dep scripts... "

--- a/scripts/utils/generate_ts.sh
+++ b/scripts/utils/generate_ts.sh
@@ -9,6 +9,22 @@
 print N "This script generates 'ts' files for the Mozilla VPN app."
 print N ""
 
+# When the `-a`/`--all` flag is present, .ts files are created
+# for every addon.
+# Without an argument of `-a` or `--all`, .ts files will NOT
+# be created for addons that use the shared strings file.
+KEEP_ALL_TS_FILES=0
+# Parse Script arguments
+while [[ $# -gt 0 ]]; do
+  key="$1"
+  case $key in
+        (-a | --all)
+        KEEP_ALL_TS_FILES=1
+        shift
+        ;;
+    esac
+done
+
 cd $(dirname $0)/../.. || die
 
 printn Y "Branch name: "
@@ -115,17 +131,16 @@ done
 # When creating translation files for l10n repo, remove any addon-specific files that use
 # shared strings, as they are translated via `strings.yaml`, which is set up for translation in
 # `build.py` (which like the addon ts files, is created above when addon's cmake calls `build.py`)"
-if [ true ]; then
+if [ $KEEP_ALL_TS_FILES == 0 ]; then
   print Y "Checking for .ts files using shared strings"
   for ts_file in ./addon_ts/*
   do
     if grep vpn.commonString $ts_file > /dev/null; then
-      print Y "Deleting file because found shared strings: $ts_file"
+      print G "Deleting file because found shared strings: $ts_file"
       rm $ts_file
     fi
   done
 fi
-# DO AWFUL HACKY THINGS HERE AND LOG THE HECK OUT OF IT
 
 if [ "$BRANCHNAME" ]; then
   printn Y "Go back to the initial branch... "

--- a/scripts/utils/generate_ts.sh
+++ b/scripts/utils/generate_ts.sh
@@ -113,6 +113,21 @@ for branch in $(git branch -r | grep origin/releases); do
   done
 done
 
+# When creating translation files for l10n repo, remove any addon-specific files that use
+# shared strings, as they are translated via `strings.yaml`, which is set up for translation in
+# `build.py` (which like the addon ts files, is created above when addon's cmake calls `build.py`)"
+if [ true ]; then
+  print Y "Checking for .ts files using shared strings"
+  for ts_file in ./addon_ts/*
+  do
+    if grep vpn.commonString $ts_file > /dev/null; then
+      print Y "Deleting file because found shared strings: $ts_file"
+      rm $ts_file
+    fi
+  done
+fi
+# DO AWFUL HACKY THINGS HERE AND LOG THE HECK OUT OF IT
+
 if [ "$BRANCHNAME" ]; then
   printn Y "Go back to the initial branch... "
   git checkout "$BRANCHNAME" &>/dev/null || die

--- a/scripts/utils/generate_ts.sh
+++ b/scripts/utils/generate_ts.sh
@@ -135,9 +135,16 @@ if [ $KEEP_ALL_TS_FILES == 0 ]; then
   print Y "Checking for .ts files using shared strings"
   for ts_file in ./addon_ts/*
   do
-    if grep vpn.commonString $ts_file > /dev/null; then
-      print G "Deleting file because found shared strings: $ts_file"
-      rm $ts_file
+    # Use the addon name from the .ts file to build a path to the manifest
+    manifest_file="./addons/$(basename $ts_file .ts)/manifest.json"
+    if [[ -f $manifest_file ]]; then
+      uses_shared_strings=$(jq '.message.usesSharedStrings // false' < $manifest_file)
+      if [[ "$uses_shared_strings" == "true" ]]; then
+        print G "Deleting file because the addon uses shared strings: $ts_file"
+        rm $ts_file
+      fi
+    else
+      die "Manifest file not found: $manifest_file"
     fi
   done
 fi


### PR DESCRIPTION
## Description

_When testing, I found that the git branch wasn't properly picked up by this script, and I fixed that. That one line is *not* part of this bug, but is a fix I included in this PR._

This is 100% egg on my face. While we did extensive testing of the addons shared string work to ensure it extracts shared strings, builds the app with shared strings, and uses those shared strings, I neglected to consider that *additionally* we do not want those shared strings to be duplicated for translation within the addons that they're utilized in. I take full responsibility for this, with a giant caveat that our use of GitHub actions makes true end-to-end testing of this pipeline extremely difficult.

The duplicated addon translations come from this path: 
1. Within the `mozilla-vpn-client-l10n` repo, the `update.yaml` github action runs `generate_ts.sh`
1. `generate_ts.sh` runs cmake for addons (lines 70-71).
1. `/addons/CMakeLists.txt` calls `./scripts/cmake/addons.cmake`
1. `./scripts/cmake/addons.cmake` calls `build.py` (in lines 64 and 74, depending on which forking logic path is used)
1. `build.py` ultimately creates the *.ts files for each addon's translations, in addition to the .ts file for the shared strings for addons. Thus, translations for shared strings are duplicated within the addons they're used for.

While `generate_ts.sh` starts this, we can't just make changes. We need to be cognizant that it is called from 3 places, from what I can tell:
1. `update.yaml` in the l10n repo (the culprit here)
2. `linters.yaml` in the client repo
3. `translations.yaml` in the client repo

In the last two situations, we *need* the .ts files to be created for all addons, including ones that use shared strings - these are what are used when creating the addons, and they will have the shared strings swapped out for real strings appropriately. (Side note: We need all of this work to be done in scripts and cmake and such - as it currently is - and not the client so that older client versions still properly show an "update your client" addon that happens to use shared strings.)

However in the first situation, we *need* to skip .ts files for addons that use the shared strings file - otherwise we'll send the strings out for translations too many times - once with the shared string file, and then once again for every addon that those strings are used in.

So, we need some sort of flag to decide whether or not to include .ts files for addons that use shared strings.
- We could take a flag for `generate_ts.sh`, and pass it down through the entire chain of scripts (see the first list in this PR) until we pass that flag into `build.py`. This seems very fragile, very brittle, and prone to breakage.
- Alternatively, we could hack something into`generate_ts.sh` to remove the unneeded ts files. 

Given these tradeoffs, I went with the latter option. I also made the inclusion of the flag mean that we'll keep all addon .ts files (rather than lack of flag means keep all addons, and including flag means remove the shared addon ones), which has the benefit of not requiring any updates to the translation repo, just our client one.

Of course, both of these options are messy, and our translation pipeline is a `giant house of cards | dumpster fire` (pick your favorite metaphor). That said, rewriting the entire translation pipeline is a large project, and right now we just need a fix.

And, ultimately, GitHub actions are no easier to test than they were last week. So while I've tested this locally, I can't be quite as confident in this fix as I'd like to be. 🤞🏻 

## Reference

VPN-6763

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
