### PR TITLE
Assorted fixes for Xcode 16

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,7 +4,7 @@
 	shallow = true
 [submodule "3rdparty/wireguard-apple"]
 	path = 3rdparty/wireguard-apple
-	url = https://github.com/WireGuard/wireguard-apple
+	url = https://github.com/mozilla/wireguard-apple.git
 	shallow = true
 [submodule "3rdparty/openSSL"]
 	path = 3rdparty/openSSL

--- a/docs/Building/ios.md
+++ b/docs/Building/ios.md
@@ -56,4 +56,5 @@ Once Xcode has opened the project, select the `mozillavpn` target and start the 
 
 Tips:
 * If you can't see a simulator target in the Xcode interface, look at Product -> Destination -> Destination Architectures -> Show Both
-* Due to lack of low level networking support, it is not possible to turn on the VPN from the iOS simulator in Xcode.
+* Simulator builds can only be run on Rosetta versions of simulators. Simulator builds use the mocked VPN controller.
+* When switching between building for Simulator and building for a device, the build folder must be completely removed.

--- a/docs/Building/macos.md
+++ b/docs/Building/macos.md
@@ -18,30 +18,6 @@ Install extra conda packages
 
     ./scripts/macos/conda_install_extras.sh
 
-Your Xcode install comes with a copy of the MacOS-SDK.
-We need to tell the conda environment where to find it.
-
-Find the sdk path
-
-    xcrun --sdk macosx --show-sdk-path
-
-If xcrun didn't work, default paths where you probably find your SDK:
- * Default Xcode-command-line tool path: `/Library/Developer/CommandLineTools/SDKs/MacOSX.<VersionNumber>.sdk`
- * Default Xcode.app path: `/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk`
-
-Add it to the conda env
-
-    conda env config vars set SDKROOT=$SDK_PATH
-
-Reactivate your conda env
-
-    conda activate vpn
-
-You can view your set variables
-
-    conda env config vars list
-
-The variable config step only needs to be done once.
 When you next want to start building the VPN, all you need to do is activate your conda environment (`conda activate vpn`).
 
 ## Get Qt

--- a/env.yml
+++ b/env.yml
@@ -18,7 +18,7 @@ dependencies:
   - rust-std-x86_64-linux-android=1.75
   - rust-std-i686-linux-android=1.75
   - rust-std-aarch64-linux-android=1.75
-  - go=1.18
+  - go=1.22
   - compiler-rt
   - cmake=3.26.3
   - ninja=1.11.0

--- a/ios/networkextension/CMakeLists.txt
+++ b/ios/networkextension/CMakeLists.txt
@@ -140,3 +140,16 @@ set_source_files_properties(
 target_sources(networkextension PRIVATE
     ${CMAKE_BINARY_DIR}/src/generated/VPNMetrics.swift
 )
+
+# The IOSGlean framework is built under the src directory, so we'll need to
+# explicitly add it to the framework search paths. However, this gets messy
+# in Xcode because the actual path is somewhat somewhat buried in
+# subdirectories.
+if(XCODE)
+    # Xcode is a multi-config generator, so technically we need to do this for
+    # each supported config too.
+    foreach(CONFIG ${CMAKE_CONFIGURATION_TYPES})
+        set_target_properties(networkextension PROPERTIES
+            "XCODE_ATTRIBUTE_FRAMEWORK_SEARCH_PATHS[variant=${CONFIG}]" "${CMAKE_BINARY_DIR}/src/${CONFIG}$(EFFECTIVE_PLATFORM_NAME)")
+    endforeach()
+endif()

--- a/scripts/cmake/rustlang.cmake
+++ b/scripts/cmake/rustlang.cmake
@@ -381,11 +381,4 @@ function(add_rust_library TARGET_NAME)
 
     add_dependencies(${TARGET_NAME} ${TARGET_NAME}_builder)
     set_property(TARGET ${TARGET_NAME} APPEND PROPERTY INTERFACE_LINK_LIBRARIES ${CMAKE_DL_LIBS})
-
-    ## When including multiple rust staticlibs, we often wind up with duplicate
-    ## symbols from the rust runtime. Work around it by permitting duplicates
-    ## during linking.
-    set_property(TARGET ${TARGET_NAME} APPEND PROPERTY INTERFACE_LINK_OPTIONS
-        $<$<C_COMPILER_ID:AppleClang>:-Xlink=-force:multiple>
-    )
 endfunction()

--- a/src/cmake/ios.cmake
+++ b/src/cmake/ios.cmake
@@ -29,7 +29,6 @@ target_sources(mozillavpn PRIVATE
     ${CMAKE_SOURCE_DIR}/src/platforms/ios/iosgleanbridge.h
 )
 
-
 ## Install the Network Extension into the bundle.
 add_dependencies(mozillavpn networkextension)
 
@@ -74,6 +73,10 @@ set_target_properties(mozillavpn PROPERTIES
     # Do not strip debug symbols on copy
     XCODE_ATTRIBUTE_COPY_PHASE_STRIP "NO"
     XCODE_ATTRIBUTE_STRIP_INSTALLED_PRODUCT "NO"
+    # Do not build with debug dylibs - it breaks the Qt/ios entrypoint.
+    # This can be fixed by rolling out own entrypoint and invoking
+    # UIApplicationMain() ourselves.
+    XCODE_ATTRIBUTE_ENABLE_DEBUG_DYLIB "NO"
 )
 target_include_directories(mozillavpn PRIVATE ${CMAKE_SOURCE_DIR})
 

--- a/src/commands/commandstatus.cpp
+++ b/src/commands/commandstatus.cpp
@@ -158,6 +158,10 @@ int CommandStatus::run(QStringList& tokens) {
       case Controller::StateSwitching:
         stream << "switching";
         break;
+
+      case Controller::State::StateOnboarding:
+        stream << "onboarding";
+        break;
     }
 
     stream << Qt::endl;

--- a/src/commands/commandui.cpp
+++ b/src/commands/commandui.cpp
@@ -165,15 +165,11 @@ int CommandUI::run(QStringList& tokens) {
       qputenv("MVPN_CONTROL_SOCKET", daemon->socketPath().toLocal8Bit());
     }
 #ifdef MZ_IOS
-    else {
-      QString simDeviceName = QString(qgetenv("SIMULATOR_DEVICE_NAME"));
-      if (!simDeviceName.isEmpty()) {
-        // The network extension doesn't actually start when running in the
-        // simulator - use a mocked daemon instead.
-        logger.debug() << "Mocking daemon for:" << simDeviceName;
-        MockDaemon* daemon = new MockDaemon(qApp);
-        qputenv("MVPN_CONTROL_SOCKET", daemon->socketPath().toLocal8Bit());
-      }
+    else if (!qEnvironmentVariable("SIMULATOR_DEVICE_NAME").isEmpty()) {
+      // If we are running in the iOS device simulator, the network extension
+      // is not supported in this environment - use a mocked daemon instead.
+      MockDaemon* daemon = new MockDaemon(qApp);
+      qputenv("MVPN_CONTROL_SOCKET", daemon->socketPath().toLocal8Bit());
     }
 #endif
 

--- a/src/commands/commandui.cpp
+++ b/src/commands/commandui.cpp
@@ -164,6 +164,18 @@ int CommandUI::run(QStringList& tokens) {
       MockDaemon* daemon = new MockDaemon(qApp);
       qputenv("MVPN_CONTROL_SOCKET", daemon->socketPath().toLocal8Bit());
     }
+#ifdef MZ_IOS
+    else {
+      QString simDeviceName = QString(qgetenv("SIMULATOR_DEVICE_NAME"));
+      if (!simDeviceName.isEmpty()) {
+        // The network extension doesn't actually start when running in the
+        // simulator - use a mocked daemon instead.
+        logger.debug() << "Mocking daemon for:" << simDeviceName;
+        MockDaemon* daemon = new MockDaemon(qApp);
+        qputenv("MVPN_CONTROL_SOCKET", daemon->socketPath().toLocal8Bit());
+      }
+    }
+#endif
 
     MozillaVPN vpn;
     logger.info() << "MozillaVPN" << Constants::versionString();

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -124,8 +124,8 @@ QString Controller::useLocalSocketPath() const {
   return Constants::WINDOWS_DAEMON_PATH;
 #elif defined(MZ_IOS)
   // The IOS simulator also uses a mocked daemon.
-  QString simulatorName = qEnvironmentVariable("SIMULATOR_DEVICE_NAME");
-  if (!simulatorName.isEmpty() && !path.isEmpty()) {
+  bool isSimDevice = !qEnvironmentVariable("SIMULATOR_DEVICE_NAME").isEmpty();
+  if (isSimDevice && !path.isEmpty()) {
     return path;
   }
 #endif

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -122,6 +122,12 @@ QString Controller::useLocalSocketPath() const {
   }
 #elif defined(MZ_WINDOWS)
   return Constants::WINDOWS_DAEMON_PATH;
+#elif defined(MZ_IOS)
+  // The IOS simulator also uses a mocked daemon.
+  QString simulatorName = qEnvironmentVariable("SIMULATOR_DEVICE_NAME");
+  if (!simulatorName.isEmpty() && !path.isEmpty()) {
+    return path;
+  }
 #endif
 
   // Otherwise, we will need some other controller.

--- a/src/controller.h
+++ b/src/controller.h
@@ -38,6 +38,7 @@ class Controller : public QObject, public LogSerializer {
     StateDisconnecting,
     StateSilentSwitching,
     StateSwitching,
+    StateOnboarding,
   };
   Q_ENUM(State)
 
@@ -45,7 +46,10 @@ class Controller : public QObject, public LogSerializer {
     ReasonNone = 0,
     ReasonSwitching,
     ReasonConfirming,
+    ReasonOnboarding,
   };
+  Q_ENUM(Reason)
+
   /**
    * @brief Who asked the Connection
    * to be Initiated? A Webextension

--- a/src/daemon/daemonlocalserverconnection.cpp
+++ b/src/daemon/daemonlocalserverconnection.cpp
@@ -122,6 +122,17 @@ void DaemonLocalServerConnection::parseCommand(const QByteArray& data) {
       return;
     }
 
+    // If this connection is being made for onboading. Don't actually connect,
+    // just emit a disconnected signal to confirm.
+    QString reason = obj.value("reason").toString();
+    if (!reason.isEmpty()) {
+      logger.error() << "Connection reason:" << reason;
+    }
+    if (reason == "onboarding") {
+      emit disconnected();
+      return;
+    }
+
     if (!m_daemon->activate(config)) {
       logger.error() << "Failed to activate the interface";
       emit disconnected();

--- a/src/daemon/mock/mockdaemon.cpp
+++ b/src/daemon/mock/mockdaemon.cpp
@@ -28,6 +28,15 @@ MockDaemon::MockDaemon(const QString& name, QObject* parent)
 
   logger.debug() << "Mock daemon created";
 
+#ifdef MZ_IOS
+  // We have to go out of our way to keep the path length under sizeof(sun_path)
+  // for iOS because the QDir::tempPath() used by QLocalServer winds up being
+  // way too long.
+  if (!m_socketName.startsWith('/')) {
+    m_socketName.prepend("/tmp/");
+  }
+#endif
+
 #ifndef MZ_WASM
   m_server.setSocketOptions(QLocalServer::UserAccessOption);
   if (!m_server.listen(m_socketName)) {

--- a/src/localsocketcontroller.cpp
+++ b/src/localsocketcontroller.cpp
@@ -128,10 +128,14 @@ void LocalSocketController::daemonConnected() {
 
 void LocalSocketController::activate(const InterfaceConfig& config,
                                      Controller::Reason reason) {
-  Q_UNUSED(reason);
-
   QJsonObject json = config.toJson();
   json.insert("type", "activate");
+
+  if (reason != Controller::ReasonNone) {
+    QMetaEnum metaEnum = QMetaEnum::fromType<Controller::Reason>();
+    QString reasonString = metaEnum.valueToKey(reason);
+    json.insert("reason", reasonString.toLower().mid(6));
+  }
 
   write(json);
 }

--- a/src/localsocketcontroller.cpp
+++ b/src/localsocketcontroller.cpp
@@ -50,7 +50,11 @@ LocalSocketController::LocalSocketController(const QString& path)
   connect(m_socket, &QLocalSocket::connected, this,
           &LocalSocketController::daemonConnected);
   connect(m_socket, &QLocalSocket::disconnected, this,
-          [&] { errorOccurred(QLocalSocket::PeerClosedError); });
+          [&] {
+            if (m_daemonState != eInitializing) {
+              errorOccurred(QLocalSocket::PeerClosedError);
+            }
+          });
   connect(m_socket, &QLocalSocket::errorOccurred, this,
           &LocalSocketController::errorOccurred);
   connect(m_socket, &QLocalSocket::readyRead, this,

--- a/src/localsocketcontroller.cpp
+++ b/src/localsocketcontroller.cpp
@@ -49,12 +49,11 @@ LocalSocketController::LocalSocketController(const QString& path)
   m_socket = new QLocalSocket(this);
   connect(m_socket, &QLocalSocket::connected, this,
           &LocalSocketController::daemonConnected);
-  connect(m_socket, &QLocalSocket::disconnected, this,
-          [&] {
-            if (m_daemonState != eInitializing) {
-              errorOccurred(QLocalSocket::PeerClosedError);
-            }
-          });
+  connect(m_socket, &QLocalSocket::disconnected, this, [&] {
+    if (m_daemonState != eInitializing) {
+      errorOccurred(QLocalSocket::PeerClosedError);
+    }
+  });
   connect(m_socket, &QLocalSocket::errorOccurred, this,
           &LocalSocketController::errorOccurred);
   connect(m_socket, &QLocalSocket::readyRead, this,

--- a/src/localsocketcontroller.cpp
+++ b/src/localsocketcontroller.cpp
@@ -10,6 +10,7 @@
 #include <QJsonObject>
 #include <QJsonValue>
 #include <QMetaType>
+#include <QMetaEnum>
 
 #include "daemon/daemonerrors.h"
 #include "errorhandler.h"

--- a/src/models/devicemodel.cpp
+++ b/src/models/devicemodel.cpp
@@ -78,7 +78,7 @@ bool sortCallback(const Device& a, const Device& b) {
 }  // anonymous namespace
 
 // Check if the current device exists, and if so move it to to the front.
-void  DeviceModel::moveCurrentDevice(const Keys* keys) {
+void DeviceModel::moveCurrentDevice(const Keys* keys) {
   for (qsizetype index = 0; index < m_devices.length(); index++) {
     if (m_devices.at(index).isCurrentDevice(keys)) {
       m_devices.move(index, 0);

--- a/src/models/devicemodel.h
+++ b/src/models/devicemodel.h
@@ -74,6 +74,7 @@ class DeviceModel final : public QAbstractListModel, public LogSerializer {
  private:
   [[nodiscard]] bool fromJsonInternal(const Keys* keys, const QByteArray& json);
 
+  void moveCurrentDevice(const Keys* keys);
   bool removeRows(int row, int count,
                   const QModelIndex& parent = QModelIndex()) override;
 

--- a/src/platforms/android/androidcontroller.cpp
+++ b/src/platforms/android/androidcontroller.cpp
@@ -100,8 +100,7 @@ AndroidController::AndroidController() {
       Qt::QueuedConnection);
   connect(
       activity, &AndroidVPNActivity::eventOnboardingCompleted, this,
-      [this]() { emit disconnected(); },
-      Qt::QueuedConnection);
+      [this]() { emit disconnected(); }, Qt::QueuedConnection);
   connect(
       activity, &AndroidVPNActivity::eventVpnConfigPermissionResponse, this,
       [](bool granted) {

--- a/src/platforms/android/androidcontroller.cpp
+++ b/src/platforms/android/androidcontroller.cpp
@@ -100,13 +100,7 @@ AndroidController::AndroidController() {
       Qt::QueuedConnection);
   connect(
       activity, &AndroidVPNActivity::eventOnboardingCompleted, this,
-      [this]() {
-        auto vpn = MozillaVPN::instance();
-        if (vpn->state() == App::StateOnboarding) {
-          vpn->onboardingCompleted();
-          emit disconnected();
-        }
-      },
+      [this]() { emit disconnected(); },
       Qt::QueuedConnection);
   connect(
       activity, &AndroidVPNActivity::eventVpnConfigPermissionResponse, this,
@@ -251,8 +245,7 @@ void AndroidController::activate(const InterfaceConfig& config,
   args["isUsingShortTimerSessionPing"] =
       settingsHolder->shortTimerSessionPing();
 
-  args["isOnboarding"] =
-      MozillaVPN::instance()->state() == App::StateOnboarding;
+  args["isOnboarding"] = reason == Controller::ReasonOnboarding;
 
   QJsonDocument doc(args);
   AndroidVPNActivity::sendToService(ServiceAction::ACTION_ACTIVATE,

--- a/src/platforms/ios/ioscontroller.mm
+++ b/src/platforms/ios/ioscontroller.mm
@@ -187,12 +187,9 @@ void IOSController::activate(const InterfaceConfig& config, Controller::Reason r
         }
       }
       onboardingCompletedCallback:^() {
-        BOOL isOnboarding = MozillaVPN::instance()->state() == App::StateOnboarding;
-        if (isOnboarding) {
+        if (reason == Controller::ReasonOnboarding) {
           logger.debug() << "Onboarding completed";
-          MozillaVPN::instance()->onboardingCompleted();
-        } else {
-          logger.debug() << "Not onboarding";
+          emit disconnected();
         }
       }
       vpnConfigPermissionResponseCallback:^(BOOL granted) {

--- a/src/platforms/ios/ioscontroller.mm
+++ b/src/platforms/ios/ioscontroller.mm
@@ -115,13 +115,6 @@ void IOSController::activate(const InterfaceConfig& config, Controller::Reason r
   if (!impl) {
     logger.error() << "Controller not correctly initialized";
 
-#if TARGET_OS_SIMULATOR
-    if (MozillaVPN::instance()->state() == App::StateOnboarding) {
-      logger.debug() << "Cannot activate VPN on a simulator. Completing onboarding.";
-      MozillaVPN::instance()->onboardingCompleted();
-    }
-#endif
-
     emit disconnected();
     return;
   }

--- a/src/ui/screens/home/controller/ControllerImage.qml
+++ b/src/ui/screens/home/controller/ControllerImage.qml
@@ -137,6 +137,24 @@ Rectangle {
             }
         },
         State {
+            name: VPNController.StateOnboarding
+
+            PropertyChanges {
+                target: logo
+                showVPNOnIcon: false
+                opacity: 0.55
+            }
+            PropertyChanges {
+                target: insetCircle
+                color: MZTheme.colors.successAccent
+            }
+            PropertyChanges {
+                target: insetIcon
+                source: "qrc:/ui/resources/shield-off.svg"
+                opacity: 1
+            }
+        },
+        State {
             name: VPNController.StateOn
             PropertyChanges {
                 target: logo

--- a/src/ui/screens/home/controller/ControllerView.qml
+++ b/src/ui/screens/home/controller/ControllerView.qml
@@ -63,7 +63,8 @@ Item {
     states: [
         State {
             name: "stateInitializing"
-            when: VPNController.state === VPNController.StateInitializing
+            when: VPNController.state === VPNController.StateInitializing ||
+                  VPNController.state === VPNController.StateOnboarding
 
             PropertyChanges {
                 target: boxBackground

--- a/src/ui/screens/home/controller/VPNToggle.qml
+++ b/src/ui/screens/home/controller/VPNToggle.qml
@@ -237,6 +237,26 @@ MZButtonBase {
                 toggleColor: MZTheme.colors.vpnToggleConnected
             }
 
+        },
+        State {
+            name: VPNController.StateOnboarding
+
+            PropertyChanges {
+                target: cursor
+                anchors.leftMargin: 4
+            }
+
+            PropertyChanges {
+                target: toggle
+                color: MZTheme.colors.vpnToggleDisconnected.defaultColor
+                border.color: MZTheme.colors.bgColorStronger
+            }
+
+            PropertyChanges {
+                target: toggleButton
+                toggleColor: MZTheme.colors.vpnToggleDisconnected
+            }
+
         }
     ]
     transitions: [


### PR DESCRIPTION
## Description
I've been trying to get my iOS development environment working again after the latest round of updates from Apple. Here's the fixes I've had to apply in order to get going.

The simulator even works too, but switching from device to simulator (and vice versa) is broken and requires a complete rebuild. Looks to be something to do with how sentry/breakpad gets built that bakes in the platform config. That probably needs to be turned into a fat binary or framework or something.

## Reference

    i.e Jira or Github issue URL

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
