### PR TITLE
Window Polish on Windows

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,6 +9,8 @@ qt_add_executable(mozillavpn MANUAL_FINALIZATION)
 
 mz_target_handle_warnings(mozillavpn)
 
+find_package(Qt6 REQUIRED COMPONENTS Svg)
+
 target_link_libraries(mozillavpn PRIVATE
     Qt6::Quick
     Qt6::Test

--- a/src/commands/commandui.cpp
+++ b/src/commands/commandui.cpp
@@ -322,13 +322,13 @@ int CommandUI::run(QStringList& tokens) {
     }
 #ifdef MZ_WINDOWS
     auto const updateWindowDecoration = [&engineHolder]() {
-      Theme::instance()->setStatusBarTextColor(
-          Theme::instance()->isThemeDark() ? Theme::StatusBarTextColorDark
-                                           : Theme::StatusBarTextColorLight);
-      WindowsUtils::setDockIcon(engineHolder.window(),
-                                QImage(":/ui/resources/logo-dock.png"));
-      WindowsUtils::setTitleBarIcon(engineHolder.window(),
+      auto const window = engineHolder.window();
+      WindowsUtils::updateTitleBarColor(window,
+                                        Theme::instance()->isThemeDark());
+      WindowsUtils::setDockIcon(window, QImage(":/ui/resources/logo-dock.png"));
+      WindowsUtils::setTitleBarIcon(window,
                                     Theme::instance()->getTitleBarIcon());
+      WindowsUtils::forceWindowRedraw(window)
     };
     QObject::connect(Theme::instance(), &Theme::changed,
                      updateWindowDecoration);

--- a/src/commands/commandui.cpp
+++ b/src/commands/commandui.cpp
@@ -328,7 +328,7 @@ int CommandUI::run(QStringList& tokens) {
       WindowsUtils::setDockIcon(window, QImage(":/ui/resources/logo-dock.png"));
       WindowsUtils::setTitleBarIcon(window,
                                     Theme::instance()->getTitleBarIcon());
-      WindowsUtils::forceWindowRedraw(window)
+      WindowsUtils::forceWindowRedraw(window);
     };
     QObject::connect(Theme::instance(), &Theme::changed,
                      updateWindowDecoration);

--- a/src/commands/commandui.cpp
+++ b/src/commands/commandui.cpp
@@ -9,6 +9,7 @@
 
 #include <QQmlApplicationEngine>
 #include <QQmlContext>
+#include <QWindow>
 
 #include "accessiblenotification.h"
 #include "addons/manager/addonmanager.h"
@@ -64,6 +65,8 @@
 
 #  include "eventlistener.h"
 #  include "platforms/windows/windowsstartatbootwatcher.h"
+#  include "platforms/windows/windowsutils.h"
+#  include "theme.h"
 #endif
 
 #ifdef MZ_WASM
@@ -317,6 +320,20 @@ int CommandUI::run(QStringList& tokens) {
       logger.error() << "Failed to load " << url.toString();
       return -1;
     }
+#ifdef MZ_WINDOWS
+    auto const updateWindowDecoration = [&engineHolder]() {
+      Theme::instance()->setStatusBarTextColor(
+          Theme::instance()->isThemeDark() ? Theme::StatusBarTextColorDark
+                                           : Theme::StatusBarTextColorLight);
+      WindowsUtils::setDockIcon(engineHolder.window(),
+                                QImage(":/ui/resources/logo-dock.png"));
+      WindowsUtils::setTitleBarIcon(engineHolder.window(),
+                                    Theme::instance()->getTitleBarIcon());
+    };
+    QObject::connect(Theme::instance(), &Theme::changed,
+                     updateWindowDecoration);
+    updateWindowDecoration();
+#endif
 
     NotificationHandler* notificationHandler =
         NotificationHandler::create(&engineHolder);

--- a/src/platforms/windows/windowsutils.cpp
+++ b/src/platforms/windows/windowsutils.cpp
@@ -5,13 +5,18 @@
 #include "windowsutils.h"
 
 #include <Windows.h>
+#include <dwmapi.h>
 #include <errhandlingapi.h>
+#include <qwindow.h>
 #include <winsvc.h>
 
 #include <QImage>
 #include <QSettings>
 #include <QSysInfo>
 #include <QWindow>
+
+#include "platforms/windows/daemon/wireguardutilswindows.h"
+#pragma comment(lib, "dwmapi.lib")
 
 #include "logger.h"
 
@@ -86,13 +91,60 @@ void WindowsUtils::setTitleBarIcon(QWindow* window, const QImage& icon) {
   auto const windowHandle = (HWND)window->winId();
   HICON hIcon = icon.toHICON();
   SendMessage(windowHandle, WM_SETICON, ICON_SMALL, (LPARAM)hIcon);
-  ShowWindow(windowHandle, SW_MINIMIZE);
-  ShowWindow(windowHandle, SW_RESTORE);
 }
 void WindowsUtils::setDockIcon(QWindow* window, const QImage& icon) {
   auto const windowHandle = (HWND)window->winId();
   HICON hIcon = icon.toHICON();
   SendMessage(windowHandle, WM_SETICON, ICON_BIG, (LPARAM)hIcon);
+}
+
+// constexpr to Help do color things in compile time.
+//
+namespace ColorUtils {
+constexpr uint8_t hexToByte(char c) {
+  if (c >= '0' && c <= '9') return c - '0';
+  if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+  if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+  throw std::invalid_argument("Invalid hex character");
+}
+
+constexpr uint8_t parseHexByte(const char* hex) {
+  return (hexToByte(hex[0]) << 4) | hexToByte(hex[1]);
+}
+/**
+ * @brief converts a hex RGBA to AGBR represented as DWORD
+ * Binary format is 0x00BBGGRR
+ */
+constexpr uint32_t toCOLORREF(const char* color) {
+  // Ensure it's a valid format
+  if (color[0] != '#' || color[7] != '\0') {
+    throw std::invalid_argument("Invalid color format. Expected '#RRGGBB'.");
+  }
+
+  // Extract and convert R, G, B
+  uint8_t r = parseHexByte(&color[1]);
+  uint8_t g = parseHexByte(&color[3]);
+  uint8_t b = parseHexByte(&color[5]);
+
+  // Construct and return the COLORREF value in 0x00BBGGRR format
+  return (b << 16) | (g << 8) | r;
+}
+}  // namespace ColorUtils
+
+void WindowsUtils::updateTitleBarColor(QWindow* window, bool darkMode) {
+  // TODO: Fetch that from the theme data.
+  const COLORREF defaultColor = darkMode ? ColorUtils::toCOLORREF("#0C0C0D")
+                                         : ColorUtils::toCOLORREF("#F9F9FA");
+
+  auto const windowHandle = (HWND)window->winId();
+  auto const ok = SUCCEEDED(DwmSetWindowAttribute(
+      windowHandle, DWMWINDOWATTRIBUTE::DWMWA_CAPTION_COLOR, &defaultColor,
+      sizeof(defaultColor)));
+  Q_ASSERT(ok);
+}
+
+void WindowsUtils::forceWindowRedraw(QWindow* w) {
+  auto const windowHandle = (HWND)w->winId();
   ShowWindow(windowHandle, SW_MINIMIZE);
   ShowWindow(windowHandle, SW_RESTORE);
 }

--- a/src/platforms/windows/windowsutils.cpp
+++ b/src/platforms/windows/windowsutils.cpp
@@ -15,7 +15,6 @@
 #include <QSysInfo>
 #include <QWindow>
 
-#include "platforms/windows/daemon/wireguardutilswindows.h"
 #pragma comment(lib, "dwmapi.lib")
 
 #include "logger.h"

--- a/src/platforms/windows/windowsutils.cpp
+++ b/src/platforms/windows/windowsutils.cpp
@@ -8,8 +8,10 @@
 #include <errhandlingapi.h>
 #include <winsvc.h>
 
+#include <QImage>
 #include <QSettings>
 #include <QSysInfo>
+#include <QWindow>
 
 #include "logger.h"
 
@@ -78,4 +80,19 @@ bool WindowsUtils::getServiceStatus(const QString& name) {
     return false;
   }
   return (status.dwCurrentState == SERVICE_RUNNING);
+}
+
+void WindowsUtils::setTitleBarIcon(QWindow* window, const QImage& icon) {
+  auto const windowHandle = (HWND)window->winId();
+  HICON hIcon = icon.toHICON();
+  SendMessage(windowHandle, WM_SETICON, ICON_SMALL, (LPARAM)hIcon);
+  ShowWindow(windowHandle, SW_MINIMIZE);
+  ShowWindow(windowHandle, SW_RESTORE);
+}
+void WindowsUtils::setDockIcon(QWindow* window, const QImage& icon) {
+  auto const windowHandle = (HWND)window->winId();
+  HICON hIcon = icon.toHICON();
+  SendMessage(windowHandle, WM_SETICON, ICON_BIG, (LPARAM)hIcon);
+  ShowWindow(windowHandle, SW_MINIMIZE);
+  ShowWindow(windowHandle, SW_RESTORE);
 }

--- a/src/platforms/windows/windowsutils.h
+++ b/src/platforms/windows/windowsutils.h
@@ -7,6 +7,9 @@
 
 #include <QString>
 
+class QWindow;
+class QImage;
+
 class WindowsUtils final {
  public:
   static QString getErrorMessage();
@@ -20,6 +23,9 @@ class WindowsUtils final {
 
   // Force an application crash for testing
   static void forceCrash();
+
+  static void setTitleBarIcon(QWindow* window, const QImage& icon);
+  static void setDockIcon(QWindow* window, const QImage& icon);
 };
 
 #endif  // WINDOWSUTILS_H

--- a/src/platforms/windows/windowsutils.h
+++ b/src/platforms/windows/windowsutils.h
@@ -26,6 +26,14 @@ class WindowsUtils final {
 
   static void setTitleBarIcon(QWindow* window, const QImage& icon);
   static void setDockIcon(QWindow* window, const QImage& icon);
+  static void forceWindowRedraw(QWindow* w);
+  /**
+   *
+   * @brief Set the Color for the titlebar, the color of the current theme
+   * will be used. This only has impact on windows.
+   *
+   */
+  static void updateTitleBarColor(QWindow* window, bool darkMode);
 };
 
 #endif  // WINDOWSUTILS_H

--- a/src/theme.cpp
+++ b/src/theme.cpp
@@ -22,45 +22,13 @@
 #endif
 
 #include <QCoreApplication>
+#include <QPainter>
 #include <QQmlEngine>
+#include <QSvgRenderer>
 
 namespace {
 Logger logger("Theme");
 }
-
-#ifdef MZ_WINDOWS
-// constexpr to Help do color things in compile time.
-namespace ColorUtils {
-constexpr uint8_t hexToByte(char c) {
-  if (c >= '0' && c <= '9') return c - '0';
-  if (c >= 'A' && c <= 'F') return c - 'A' + 10;
-  if (c >= 'a' && c <= 'f') return c - 'a' + 10;
-  throw std::invalid_argument("Invalid hex character");
-}
-
-constexpr uint8_t parseHexByte(const char* hex) {
-  return (hexToByte(hex[0]) << 4) | hexToByte(hex[1]);
-}
-/**
- * @brief converts a hex RGBA to AGBR represented as DWORD
- * Binary format is 0x00BBGGRR
- */
-consteval uint32_t toCOLORREF(const char* color) {
-  // Ensure it's a valid format
-  if (color[0] != '#' || color[7] != '\0') {
-    throw std::invalid_argument("Invalid color format. Expected '#RRGGBB'.");
-  }
-
-  // Extract and convert R, G, B
-  uint8_t r = parseHexByte(&color[1]);
-  uint8_t g = parseHexByte(&color[3]);
-  uint8_t b = parseHexByte(&color[5]);
-
-  // Construct and return the COLORREF value in 0x00BBGGRR format
-  return (b << 16) | (g << 8) | r;
-}
-}  // namespace ColorUtils
-#endif
 
 Theme::Theme(QObject* parent) : QAbstractListModel(parent) {
   MZ_COUNT_CTOR(Theme);
@@ -235,28 +203,6 @@ Qt::ColorScheme Theme::currentSystemTheme() {
 #endif
 
 void Theme::setStatusBarTextColor([[maybe_unused]] StatusBarTextColor color) {
-#ifdef MZ_WINDOWS
-  if (!QmlEngineHolder::instance()->hasWindow()) {
-    return;
-  }
-  // ITS -> ABGR <- format
-
-  QmlEngineHolder::instance()->window();
-  auto const windowHandle =
-      (HWND)QmlEngineHolder::instance()->window()->winId();
-  using namespace ColorUtils;
-  const COLORREF hexColor = color == StatusBarTextColorLight
-                                ? toCOLORREF("#F9F9FA")
-                                : toCOLORREF("#0C0C0D");
-
-  // COLORREF DARK_COLOR = 0x00505050;
-  BOOL SET_CAPTION_COLOR = SUCCEEDED(DwmSetWindowAttribute(
-      windowHandle, DWMWINDOWATTRIBUTE::DWMWA_CAPTION_COLOR, &hexColor,
-      sizeof(hexColor)));
-  Q_ASSERT(SET_CAPTION_COLOR);
-  ShowWindow(windowHandle, SW_MINIMIZE);
-  ShowWindow(windowHandle, SW_RESTORE);
-#endif
 #ifdef MZ_IOS
   IOSCommons::setStatusBarTextColor(color);
 #endif

--- a/src/theme.cpp
+++ b/src/theme.cpp
@@ -24,7 +24,6 @@
 #include <QCoreApplication>
 #include <QPainter>
 #include <QQmlEngine>
-#include <QSvgRenderer>
 
 namespace {
 Logger logger("Theme");

--- a/src/theme.h
+++ b/src/theme.h
@@ -7,6 +7,7 @@
 
 #include <QAbstractListModel>
 #include <QHash>
+#include <QIcon>
 #include <QJSValue>
 
 class QJSEngine;
@@ -34,6 +35,11 @@ class Theme final : public QAbstractListModel {
   const QJSValue& readColors() const;
 
   const QString& currentTheme() const { return m_currentTheme; }
+
+  // Todo: Add a thing for themes to define, if they are using dark or light
+  // resources.
+  bool isThemeDark() { return m_currentTheme != "main"; }
+
   void setCurrentTheme(const QString& themeName);
 
   void initialize(QJSEngine* engine);
@@ -58,6 +64,8 @@ class Theme final : public QAbstractListModel {
   Q_INVOKABLE void setStatusBarTextColor(Theme::StatusBarTextColor color);
 
   bool usesDarkModeAssets() const;
+  // Returns an Icon matching the current colorscheme
+  QImage getTitleBarIcon();
 
  private:
   void parseTheme(QJSEngine* engine, const QString& themeName);

--- a/tests/auth_tests/CMakeLists.txt
+++ b/tests/auth_tests/CMakeLists.txt
@@ -42,6 +42,7 @@ target_link_libraries(app_auth_tests PRIVATE
     Qt6::Test
     Qt6::WebSockets
     Qt6::Widgets
+    Qt6::Svg
 )
 
 if(NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Emscripten"

--- a/tests/qml/CMakeLists.txt
+++ b/tests/qml/CMakeLists.txt
@@ -29,6 +29,7 @@ target_link_libraries(qml_tests PRIVATE
     Qt6::Qml
     Qt6::Quick
     Qt6::QuickTest
+    Qt6::Svg
 )
 
 target_link_libraries(qml_tests PRIVATE qtglean lottie nebula translations)

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -32,6 +32,7 @@ target_link_libraries(unit_tests PRIVATE
     Qt6::Gui
     Qt6::Qml
     Qt6::Quick
+    Qt6::Svg
 )
 
 target_compile_definitions(unit_tests PRIVATE UNIT_TEST)

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -40,6 +40,7 @@ target_link_libraries(app_unit_tests PRIVATE
     Qt6::WebSockets
     Qt6::Widgets
     Qt6::Network
+    Qt6::Svg
 )
 
 if(NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Emscripten"


### PR DESCRIPTION
The Designers aren't looking quick lets change some things. 

IMHO RN our Window on Windows has multiple issues: 

| Dark  | Light |
|-------|-------|
| ![old_dark](https://github.com/user-attachments/assets/3d0d6d88-41fe-4019-9626-c53507620429) | ![old_light](https://github.com/user-attachments/assets/8d8e0bee-9ff1-4199-8b27-80166a71bbd1) 

❌ The Titlebar shows a very pixelated icon
❌ The Icon is not the one in our [figma windows "window"](https://www.figma.com/design/lHbmTJ5xaTFWhI8MMYyLVH/Key-screen---Windows?node-id=0-1&node-type=canvas&m=dev)
❌ The Titlebar is not responsive to neither theme / sys prefrence
❌ The Titlebar is not using the same background as the client app

Whenever this opens on windows it looks ... cheap, especially the title bar not beeing part of the client space, looks outdated. It's giving cross plattform electron app.  
So today i needed a fun break. 



| Dark  | Light |
|-------|-------|
|  ![new_dark](https://github.com/user-attachments/assets/54858aad-2334-4673-9644-c0553eb49090)  | ![new_light](https://github.com/user-attachments/assets/6a45b05f-e40c-4430-a494-1dc037825b92) | 

So this pr adds a theme listener, that: 
✅  Updates the Titlebar to the Themes BG color 
✅  Render icon from the SVG, respecting the coloscheme
✅  Set that icon for the window only. 





