### PR TITLE
qtglean bindings must match min version

### DIFF
--- a/scripts/cmake/Info.plist.QtGleanBindings
+++ b/scripts/cmake/Info.plist.QtGleanBindings
@@ -17,6 +17,6 @@
     <key>CFBundleVersion</key>
     <string>1</string>
     <key>MinimumOSVersion</key>
-    <string>14.0</string>
+    <string>15.0</string>
 </dict>
 </plist>


### PR DESCRIPTION
## Description

After https://github.com/mozilla-mobile/mozilla-vpn-client/pull/10078 was merged in, Xcode Cloud reported failures because `ITMS-90208: Invalid Bundle - The bundle MozillaVPN.app/Frameworks/QtGleanBindings.framework does not support the minimum OS Version specified in the Info.plist.`

Updating the minimum version to match.

## Reference

VPN-6742 follow up

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
