### PR TITLE
Remove addon condition for testing

### DIFF
--- a/addons/message_try_firefox_extension/manifest.json
+++ b/addons/message_try_firefox_extension/manifest.json
@@ -5,7 +5,6 @@
   "type": "message",
   "conditions": {
     "min_client_version": "2.25.0",
-    "trigger_time": 1209600,
     "env": "staging",
     "platforms": ["windows"]
   },


### PR DESCRIPTION
## Description

QA requested removal of the timing condition to make testing easier: https://mozilla-hub.atlassian.net/browse/FXVPN-32?focusedCommentId=974354

I've included "adding this back in" in the ticket to finalize this addon: https://mozilla-hub.atlassian.net/browse/FXVPN-280

## Reference

https://mozilla-hub.atlassian.net/browse/FXVPN-32?focusedCommentId=974354

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
