### PR TITLE
Add Thai to extras.xliff

### DIFF
--- a/src/translations/extras/extras.xliff
+++ b/src/translations/extras/extras.xliff
@@ -119,6 +119,9 @@
       <trans-unit id="languages.sv_SE" xml:space="preserve">
         <source>Swedish</source>
       </trans-unit>
+      <trans-unit id="languages.th" xml:space="preserve">
+        <source>Thai</source>
+      </trans-unit>
       <trans-unit id="languages.tr" xml:space="preserve">
         <source>Turkish</source>
       </trans-unit>


### PR DESCRIPTION
## Description

[New language in Pontoon](https://pontoon.mozilla.org/th/mozilla-vpn-client/mozillavpn.xliff/?string=276710) - Thai!

Our linter fails when there is a new language that is not yet in `extras.xliff`, as you can see in a recent run of "merge in the most recent translations": https://github.com/mozilla-mobile/mozilla-vpn-client/actions/runs/12336343269/job/34428760557?pr=10125

This PR gets everything moving again.

## Reference

N/A

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
