### PR TITLE
extend metric, add extra

### DIFF
--- a/src/platforms/ios/ConnectionHealth.swift
+++ b/src/platforms/ios/ConnectionHealth.swift
@@ -72,10 +72,10 @@ class ConnectionHealth {
         }
 
         logger.info(message: "Creating PingAnalyzer")
-        let _ = PingAnalyzer(pingAddress: pingAddress) { (connectivity) in
+        let _ = PingAnalyzer(pingAddress: pingAddress) { (connectivity, error) in
             guard let connectivity = connectivity else {
                 self.logger.error(message: "PingAnalyzer returned error")
-                GleanMetrics.ConnectionHealth.pingAnalyzerError.record()
+                GleanMetrics.ConnectionHealth.pingAnalyzerError.record(PingAnalyzerErrorExtra(errorMessage: error.localizedDescription))
                 return
             }
 

--- a/src/platforms/ios/PingAnalyzer.swift
+++ b/src/platforms/ios/PingAnalyzer.swift
@@ -55,7 +55,7 @@ class PingAnalyzer {
             timer = Timer.scheduledTimer(timeInterval: TimeInterval(checkTime), target: self, selector: #selector(calculateStability), userInfo: nil, repeats: false)
         } catch {
             logger.error(message: "Error when sending pings: \(error)")
-            callback(nil)
+            callback(nil, error)
         }
     }
 
@@ -68,11 +68,11 @@ class PingAnalyzer {
 
         // If any pings take too long to return or
         if (packetLossPercent >= pingLossNoSignalThreshold) {
-            callback(.noSignal)
+            callback(.noSignal, nil)
         } else if (packetLossPercent >= pingLossUnstableThreshold) {
-            callback(.unstable)
+            callback(.unstable, nil)
         } else {
-            callback(.stable)
+            callback(.stable, nil)
         }
     }
 }

--- a/src/telemetry/metrics.yaml
+++ b/src/telemetry/metrics.yaml
@@ -1050,10 +1050,15 @@ connection_health:
     bugs:
       - https://mozilla-hub.atlassian.net/browse/VPN-6406
     data_reviews:
-      - TBA
+      - https://github.com/mozilla-mobile/mozilla-vpn-client/pull/9593#issuecomment-2159109154
     data_sensitivity:
       - technical
     notification_emails:
       - mcleinman@mozilla.com
       - vpn-telemetry@mozilla.com
-    expires: 2024-12-31
+    expires: 2025-06-30
+    extra_keys:
+      error_message:
+        description: |
+          Error type
+        type: string

--- a/src/translations/extras/extras.xliff
+++ b/src/translations/extras/extras.xliff
@@ -119,6 +119,9 @@
       <trans-unit id="languages.sv_SE" xml:space="preserve">
         <source>Swedish</source>
       </trans-unit>
+      <trans-unit id="languages.th" xml:space="preserve">
+        <source>Thai</source>
+      </trans-unit>
       <trans-unit id="languages.tr" xml:space="preserve">
         <source>Turkish</source>
       </trans-unit>


### PR DESCRIPTION
## Description

This metric is expiring, and it seems like there are [more errors being logged](https://mozilla.cloud.looker.com/explore/mozilla_vpn/event_counts?qid=hDrw9dQlABqE7xcvV1cRmx&toggle=fil,vis) than I'd expect. It's happening on about 10% of iOS user's devices (though it should have no user-facing impact), and I'd like to know why an error is being thrown. 

Thus, I've extended the expiration and added an extra bit to learn which error is being thrown.

This will require data review.

## Reference

N/A

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
