### PR TITLE
VPN-6790 : Tweak Killer software detection

### DIFF
--- a/src/interventions/killernetwork.cpp
+++ b/src/interventions/killernetwork.cpp
@@ -6,31 +6,16 @@
 
 #include <qobject.h>
 
-<<<<<<< HEAD
-#include <QObject>
-
-#include "platforms/windows/windowsservicemanager.h"
-=======
 #include "platforms/windows/windowsutils.h"
->>>>>>> 9578cbf61 (Format)
 
 namespace Intervention {
 
 const QString KillerNetwork::id = "intel.killernetwork";
 
 bool KillerNetwork::systemAffected() {
-<<<<<<< HEAD
-  std::unique_ptr<WindowsServiceManager> svm =
-      WindowsServiceManager::open("Killer Network Service");
-  if (svm == nullptr) {
-    return false;
-  }
-  return svm->isRunning();
-=======
   const bool isKillerInstalledAndRunning =
       WindowsUtils::getServiceStatus("Killer Network Service");
   return isKillerInstalledAndRunning;
->>>>>>> 9578cbf61 (Format)
 }
 
 }  // namespace Intervention

--- a/src/interventions/killernetwork.cpp
+++ b/src/interventions/killernetwork.cpp
@@ -6,21 +6,31 @@
 
 #include <qobject.h>
 
+<<<<<<< HEAD
 #include <QObject>
 
 #include "platforms/windows/windowsservicemanager.h"
+=======
+#include "platforms/windows/windowsutils.h"
+>>>>>>> 9578cbf61 (Format)
 
 namespace Intervention {
 
 const QString KillerNetwork::id = "intel.killernetwork";
 
 bool KillerNetwork::systemAffected() {
+<<<<<<< HEAD
   std::unique_ptr<WindowsServiceManager> svm =
       WindowsServiceManager::open("Killer Network Service");
   if (svm == nullptr) {
     return false;
   }
   return svm->isRunning();
+=======
+  const bool isKillerInstalledAndRunning =
+      WindowsUtils::getServiceStatus("Killer Network Service");
+  return isKillerInstalledAndRunning;
+>>>>>>> 9578cbf61 (Format)
 }
 
 }  // namespace Intervention


### PR DESCRIPTION
## Description
KillerNetwork::systemAffected() consistently returns `false` due to permissions issues. This PR tweaks the way we detect Killer Networking Software to use `WindowsUtils::getServiceStatus()` instead of ` WindowsServiceManager::open()` to get around this.

## Reference

VPN-6790

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
