### PR TITLE
Turn off Sentry for wasm

### DIFF
--- a/src/feature/featurelist.h
+++ b/src/feature/featurelist.h
@@ -158,7 +158,12 @@ FEATURE(sentry,                     // Feature ID
         FeatureCallback_true,       // Can be flipped on
         FeatureCallback_true,       // Can be flipped off
         QStringList(),              // feature dependencies
-        FeatureCallback_true)
+        byPlatform({.windows = true,
+                    .macos = true,
+                    .gnu_linux = true,
+                    .android = true,
+                    .ios = true,
+                    .wasm = false}))
 
 FEATURE(serverUnavailableNotification,      // Feature ID
         "Server unavailable notification",  // Feature name

--- a/src/localizer.cpp
+++ b/src/localizer.cpp
@@ -273,6 +273,9 @@ void Localizer::loadLanguagesFromI18n() {
       locale = QLocale::system();
     }
 
+    if (code == "en-US") {
+      code = "en";
+    }
     Language language{code, codeParts[0],
                       codeParts.length() > 1 ? codeParts[1] : QString(),
                       nativeLanguageName(locale, code),

--- a/src/ui/screens/settings/ViewLanguage.qml
+++ b/src/ui/screens/settings/ViewLanguage.qml
@@ -151,31 +151,31 @@ MZViewBase {
 
                 MZRadioDelegate {
                     id: delRadio
-                    objectName: "language-" + code
+                    objectName: "language-" + code // can I do something here to change the code if needed from en-US
 
                     Layout.fillWidth: true
                     Layout.leftMargin: MZTheme.theme.windowMargin
                     Layout.rightMargin: MZTheme.theme.windowMargin
 
                     radioButtonLabelText: nativeLanguageName // "Taking out text" 
-                    checked: false // MZSettings.languageCode === code
+                    checked:  MZSettings.languageCode === code // false //
                     activeFocusOnTab: true
                     onClicked: {
                         MZSettings.languageCode = code;
                     }
 
-                    // Keys.onDownPressed: if(repeater.itemAt(index + 1)) repeater.itemAt(index + 1).pushFocusToRadio()
-                    // Keys.onUpPressed: {
-                    //     if(repeater.itemAt(index - 1)) repeater.itemAt(index - 1).pushFocusToRadio()
-                    //     else systemLanguageRadioButton.forceActiveFocus()
-                    // }
+                    Keys.onDownPressed: if(repeater.itemAt(index + 1)) repeater.itemAt(index + 1).pushFocusToRadio()
+                    Keys.onUpPressed: {
+                        if(repeater.itemAt(index - 1)) repeater.itemAt(index - 1).pushFocusToRadio()
+                        else systemLanguageRadioButton.forceActiveFocus()
+                    }
 
                     //% "%1 %2"
                     //: This string is read by accessibility tools.
                     //: %1 is the language name, %2 is the localized language name.
-                    // accessibleName: qsTrId("vpn.settings.languageAccessibleName")
-                    // .arg(nativeLanguageName)
-                    // .arg(localizedLanguageName)
+                    accessibleName: qsTrId("vpn.settings.languageAccessibleName")
+                    .arg(nativeLanguageName)
+                    .arg(localizedLanguageName)
                 }
 
                 MZTextBlock {

--- a/src/ui/screens/settings/ViewLanguage.qml
+++ b/src/ui/screens/settings/ViewLanguage.qml
@@ -157,7 +157,7 @@ MZViewBase {
                     Layout.leftMargin: MZTheme.theme.windowMargin
                     Layout.rightMargin: MZTheme.theme.windowMargin
 
-                    radioButtonLabelText: "Taking out text" //nativeLanguageName
+                    radioButtonLabelText: nativeLanguageName // "Taking out text" 
                     checked: false // MZSettings.languageCode === code
                     activeFocusOnTab: true
                     onClicked: {

--- a/src/ui/screens/settings/ViewLanguage.qml
+++ b/src/ui/screens/settings/ViewLanguage.qml
@@ -15,12 +15,17 @@ MZViewBase {
     objectName: "settingsLanguagesView"
     readonly property string telemetryScreenId : "language"
 
-    Component.onCompleted: Glean.impression.languageScreen.record({screen:telemetryScreenId})
+    Component.onCompleted: {
+      console.log("Completed loading ViewLanguage");
+      Glean.impression.languageScreen.record({screen:telemetryScreenId});
+      console.log("And recorded telemetry");
+    }
 
     //% "Language"
     _menuTitle :  qsTrId("vpn.settings.language")
 
     function centerSelectedLanguage() {
+        console.log("Centering selected language")
         for (let idx = 0; idx < repeater.count; idx++) {
             const langItem = repeater.itemAt(idx);
             if (langItem.isSelectedLanguage) {
@@ -86,6 +91,7 @@ MZViewBase {
                 checked: MZSettings.languageCode === ""
                 activeFocusOnTab: true
                 onClicked: {
+                    console.log("Radio button clicked")
                     MZSettings.languageCode = ""
                 }
 
@@ -121,7 +127,10 @@ MZViewBase {
 
             model: searchBar.getProxyModel()
 
-            Component.onCompleted: vpnFlickable.centerSelectedLanguage()
+            Component.onCompleted: {
+              console.log("Completed loading repeater");
+              vpnFlickable.centerSelectedLanguage();
+            }
 
             delegate: ColumnLayout {
                 id: del
@@ -130,6 +139,7 @@ MZViewBase {
                 property bool isSelectedLanguage: delRadio.checked
 
                 function pushFocusToRadio() {
+                    console.log("Pushing focus to radio");
                     delRadio.forceActiveFocus();
                 }
 

--- a/src/ui/screens/settings/ViewLanguage.qml
+++ b/src/ui/screens/settings/ViewLanguage.qml
@@ -157,25 +157,25 @@ MZViewBase {
                     Layout.leftMargin: MZTheme.theme.windowMargin
                     Layout.rightMargin: MZTheme.theme.windowMargin
 
-                    radioButtonLabelText: nativeLanguageName
-                    checked: MZSettings.languageCode === code
+                    radioButtonLabelText: "Taking out text" //nativeLanguageName
+                    checked: false // MZSettings.languageCode === code
                     activeFocusOnTab: true
                     onClicked: {
                         MZSettings.languageCode = code;
                     }
 
-                    Keys.onDownPressed: if(repeater.itemAt(index + 1)) repeater.itemAt(index + 1).pushFocusToRadio()
-                    Keys.onUpPressed: {
-                        if(repeater.itemAt(index - 1)) repeater.itemAt(index - 1).pushFocusToRadio()
-                        else systemLanguageRadioButton.forceActiveFocus()
-                    }
+                    // Keys.onDownPressed: if(repeater.itemAt(index + 1)) repeater.itemAt(index + 1).pushFocusToRadio()
+                    // Keys.onUpPressed: {
+                    //     if(repeater.itemAt(index - 1)) repeater.itemAt(index - 1).pushFocusToRadio()
+                    //     else systemLanguageRadioButton.forceActiveFocus()
+                    // }
 
                     //% "%1 %2"
                     //: This string is read by accessibility tools.
                     //: %1 is the language name, %2 is the localized language name.
-                    accessibleName: qsTrId("vpn.settings.languageAccessibleName")
-                    .arg(nativeLanguageName)
-                    .arg(localizedLanguageName)
+                    // accessibleName: qsTrId("vpn.settings.languageAccessibleName")
+                    // .arg(nativeLanguageName)
+                    // .arg(localizedLanguageName)
                 }
 
                 MZTextBlock {
@@ -184,7 +184,7 @@ MZViewBase {
                     Layout.rightMargin: MZTheme.theme.windowMargin
                     Layout.fillWidth: true
 
-                    text: localizedLanguageName
+                    text: "Taking out text" //localizedLanguageName
                 }
             }
         }

--- a/src/ui/screens/settings/ViewPreferences.qml
+++ b/src/ui/screens/settings/ViewPreferences.qml
@@ -134,8 +134,11 @@ MZViewBase {
                 imageRightSrc: "qrc:/nebula/resources/chevron.svg"
                 imageRightMirror: MZLocalizer.isRightToLeft
                 onClicked: {
+                    console.log("Opening language settings")
                     Glean.interaction.languageSelected.record({screen:telemetryScreenId})
+                    console.log("Telemetry recorded")
                     stackview.push("qrc:/qt/qml/Mozilla/VPN/screens/settings/ViewLanguage.qml")
+                    console.log("Screen pushed")
                 }
                 visible: MZLocalizer.hasLanguages
             }


### PR DESCRIPTION
## Description

Sentry makes extensive use of `dlopen`, which is not supported by WASM (according to a comment in `TaskIPFinder::run()`, where we fake something for WASM). We're seeing a `dlopen` crash on WASM... maybe it's Sentry itself crashing?

I'm putting up this PR to get a WASM build. Once we see the output of that WASM build, we'll decide whether this is something we actually want to merge.

## Reference

N/A

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
