### PR TITLE
FXVPN-319: Change extensionTelemetry to true by default

### DIFF
--- a/src/settingslist.h
+++ b/src/settingslist.h
@@ -789,7 +789,7 @@ SETTING_BOOL(extensionTelemetryEnabled,        // getter
              removeExtensionTelemetryEnabled,  // remover
              hasExtensionTelemetryEnabled,     // has
              "extensionTelemetryEnabled",      // key
-             false,                            // default value
+             true,                             // default value
              true,                             // remove when reset
              false                             // sensitive (do not log)
 )


### PR DESCRIPTION
## Description

Telemetry on the VPN extension is opt-out. This PR changes the default value of our `extensionTelemetryEnabled` setting to true by default. 

## Reference

FXVPN-319

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
