### PR TITLE
VPN-6318: Add reauth to subscription management flow

### DIFF
--- a/src/profileflow.cpp
+++ b/src/profileflow.cpp
@@ -80,7 +80,7 @@ void ProfileFlow::start() {
   });
 
   connect(task, &TaskGetSubscriptionDetails::mustTransitionAuthToWeb, this,
-          [this]() { setState(StateNeedsWebReauthentication); });
+          [this]() { setState(StateAuthenticationNeeded); });
 
   TaskScheduler::scheduleTask(task);
   m_currentTask = task;

--- a/src/profileflow.cpp
+++ b/src/profileflow.cpp
@@ -97,11 +97,12 @@ void ProfileFlow::reauthenticateViaWeb() {
             setState(StateError);
             ProfileFlow::reset();
           });
-  connect(taskAuthenticate, &TaskAuthenticate::authenticationCompleted, this,
-          [this]() {
-            logger.debug() << "Authentication succeeded, restarting profile flow";
-            ProfileFlow::start();
-          });
+  connect(
+      taskAuthenticate, &TaskAuthenticate::authenticationCompleted, this,
+      [this]() {
+        logger.debug() << "Authentication succeeded, restarting profile flow";
+        ProfileFlow::start();
+      });
 
   TaskScheduler::scheduleTask(taskAuthenticate);
 }

--- a/src/profileflow.cpp
+++ b/src/profileflow.cpp
@@ -92,9 +92,16 @@ void ProfileFlow::reauthenticateViaWeb() {
   TaskAuthenticate* taskAuthenticate =
       new TaskAuthenticate(AuthenticationListener::AuthenticationInBrowser);
   connect(taskAuthenticate, &TaskAuthenticate::authenticationAborted, this,
-          &ProfileFlow::reset);
+          [this]() {
+            logger.debug() << "Authentication failed";
+            setState(StateError);
+            ProfileFlow::reset();
+          });
   connect(taskAuthenticate, &TaskAuthenticate::authenticationCompleted, this,
-          &ProfileFlow::start);  // retry
+          [this]() {
+            logger.debug() << "Authentication succeeded, restarting profile flow";
+            ProfileFlow::start();
+          });
 
   TaskScheduler::scheduleTask(taskAuthenticate);
 }

--- a/src/profileflow.cpp
+++ b/src/profileflow.cpp
@@ -10,6 +10,7 @@
 #include "leakdetector.h"
 #include "logger.h"
 #include "mozillavpn.h"
+#include "tasks/authenticate/taskauthenticate.h"
 #include "tasks/getsubscriptiondetails/taskgetsubscriptiondetails.h"
 #include "taskscheduler.h"
 
@@ -78,8 +79,24 @@ void ProfileFlow::start() {
     }
   });
 
+  connect(task, &TaskGetSubscriptionDetails::mustTransitionAuthToWeb, this,
+          [this]() { setState(StateNeedsWebReauthentication); });
+
   TaskScheduler::scheduleTask(task);
   m_currentTask = task;
+}
+
+void ProfileFlow::reauthenticateViaWeb() {
+  // We need the user to login on the browser (rather than the client),
+  // then we'll try getting the profile again.
+  TaskAuthenticate* taskAuthenticate =
+      new TaskAuthenticate(AuthenticationListener::AuthenticationInBrowser);
+  connect(taskAuthenticate, &TaskAuthenticate::authenticationAborted, this,
+          &ProfileFlow::reset);
+  connect(taskAuthenticate, &TaskAuthenticate::authenticationCompleted, this,
+          &ProfileFlow::start);  // retry
+
+  TaskScheduler::scheduleTask(taskAuthenticate);
 }
 
 void ProfileFlow::reset() {

--- a/src/profileflow.h
+++ b/src/profileflow.h
@@ -28,7 +28,6 @@ class ProfileFlow final : public QObject {
     StateLoading,
     StateAuthenticationNeeded,
     StateNeedsWebReauthentication,
-    StateAuthenticatingViaWeb,
     StateReady,
     StateError,
   };

--- a/src/profileflow.h
+++ b/src/profileflow.h
@@ -20,12 +20,15 @@ class ProfileFlow final : public QObject {
   ~ProfileFlow();
 
   Q_INVOKABLE void start();
+  Q_INVOKABLE void reauthenticateViaWeb();
   Q_INVOKABLE void reset();
 
   enum State {
     StateInitial,
     StateLoading,
     StateAuthenticationNeeded,
+    StateNeedsWebReauthentication,
+    StateAuthenticatingViaWeb,
     StateReady,
     StateError,
   };

--- a/src/profileflow.h
+++ b/src/profileflow.h
@@ -27,7 +27,6 @@ class ProfileFlow final : public QObject {
     StateInitial,
     StateLoading,
     StateAuthenticationNeeded,
-    StateNeedsWebReauthentication,
     StateReady,
     StateError,
   };

--- a/src/tasks/getsubscriptiondetails/taskgetsubscriptiondetails.cpp
+++ b/src/tasks/getsubscriptiondetails/taskgetsubscriptiondetails.cpp
@@ -128,12 +128,14 @@ void TaskGetSubscriptionDetails::initAuthentication() {
   Q_ASSERT(!m_authenticationInAppSession);
 
   // If transitioning from in-app auth to web-based auth, bounce to web-based
+#ifndef MZ_WASM
   if (!Feature::get(Feature::Feature_inAppAuthentication)->isSupported()) {
     logger.info() << "Starting web-based re-authentication.";
     emit mustTransitionAuthToWeb();
     emit completed();
     return;
   }
+#endif
 
   emit needsAuthentication();
 

--- a/src/tasks/getsubscriptiondetails/taskgetsubscriptiondetails.cpp
+++ b/src/tasks/getsubscriptiondetails/taskgetsubscriptiondetails.cpp
@@ -10,6 +10,7 @@
 #include "authenticationinapp/authenticationinappsession.h"
 #include "authenticationlistener.h"
 #include "constants.h"
+#include "feature/feature.h"
 #include "leakdetector.h"
 #include "logger.h"
 #include "models/subscriptiondata.h"
@@ -125,6 +126,14 @@ void TaskGetSubscriptionDetails::maybeComplete(bool status) {
 void TaskGetSubscriptionDetails::initAuthentication() {
   logger.debug() << "Init authentication";
   Q_ASSERT(!m_authenticationInAppSession);
+
+  // If transitioning from in-app auth to web-based auth, bounce to web-based
+  if (!Feature::get(Feature::Feature_inAppAuthentication)->isSupported()) {
+    logger.info() << "Starting web-based re-authentication.";
+    emit mustTransitionAuthToWeb();
+    emit completed();
+    return;
+  }
 
   emit needsAuthentication();
 

--- a/src/tasks/getsubscriptiondetails/taskgetsubscriptiondetails.h
+++ b/src/tasks/getsubscriptiondetails/taskgetsubscriptiondetails.h
@@ -31,6 +31,7 @@ class TaskGetSubscriptionDetails final : public Task {
  signals:
   void operationCompleted(bool status);
   void needsAuthentication();
+  void mustTransitionAuthToWeb();
 
  private:
   void initAuthentication();

--- a/src/translations/strings.yaml
+++ b/src/translations/strings.yaml
@@ -349,7 +349,7 @@ settings:
     value: Clear all
     comment: Button label to clear all apps from the exclusions list
   reauthTitle: Sign In Again
-  reauthDescription: For your security, please sign in again to access your account information. You'll complete this process on Mozilla's website. 
+  reauthDescription: For your security, please sign in again to access your account information. You’ll complete this process on Mozilla’s website.
 
 localNetworkAccess:
   labelTitle: Exclude local network traffic

--- a/src/translations/strings.yaml
+++ b/src/translations/strings.yaml
@@ -348,6 +348,9 @@ settings:
   appExclusionClearAllApps:
     value: Clear all
     comment: Button label to clear all apps from the exclusions list
+  reauthTitle: Reauthentication required
+  reauthDescription: A one-time reauthentication is required to continue to Account information, due to improvements in the security of Mozilla VPN. You will complete signing in on Mozilla's website. 
+  reauthButton: Reauthenticate
 
 localNetworkAccess:
   labelTitle: Exclude local network traffic

--- a/src/translations/strings.yaml
+++ b/src/translations/strings.yaml
@@ -348,9 +348,8 @@ settings:
   appExclusionClearAllApps:
     value: Clear all
     comment: Button label to clear all apps from the exclusions list
-  reauthTitle: Reauthentication required
-  reauthDescription: A one-time reauthentication is required to continue to Account information, due to improvements in the security of Mozilla VPN. You will complete signing in on Mozilla's website. 
-  reauthButton: Reauthenticate
+  reauthTitle: Sign In Again
+  reauthDescription: For your security, please sign in again to access your account information. You'll complete this process on Mozilla's website. 
 
 localNetworkAccess:
   labelTitle: Exclude local network traffic

--- a/src/ui/screens/settings/ViewSettingsMenu.qml
+++ b/src/ui/screens/settings/ViewSettingsMenu.qml
@@ -142,6 +142,7 @@ MZViewBase {
                 VPNProfileFlow.state === VPNProfileFlow.StateReady
                 && stackview.currentItem.objectName !== "subscriptionManagmentView"
             ) {
+                reauthPopup.close();
                 return stackview.push("qrc:/qt/qml/Mozilla/VPN/screens/settings/ViewSubscriptionManagement/ViewSubscriptionManagement.qml");
             }
             // Only push the profile view if it’s not already in the stack
@@ -149,6 +150,7 @@ MZViewBase {
                 VPNProfileFlow.state === VPNProfileFlow.StateAuthenticationNeeded
                 && stackview.currentItem.objectName !== "reauthenticationFlow"
             ) {
+                reauthPopup.close();
                 return stackview.push("qrc:/qt/qml/Mozilla/VPN/screens/settings/ViewSubscriptionManagement/ViewReauthenticationFlow.qml", {
                     _onClose: () => {
                         VPNProfileFlow.reset();
@@ -161,6 +163,7 @@ MZViewBase {
             // to the main settings view.
             const hasError = VPNProfileFlow.state === VPNProfileFlow.StateError;
             if (hasError) {
+                reauthPopup.close();
                 if (stackview.currentItem.objectName === "reauthenticationFlow") {
                   stackview.pop(null, StackView.Immediate);
                 }
@@ -187,7 +190,7 @@ MZViewBase {
         buttons: [
             MZButton {
                 id: reauthButton
-                text: MZI18n.SettingsReauthButton
+                text: MZI18n.InAppAuthContinueToSignIn
                 Layout.fillWidth: true
                 onClicked: {
                   VPNProfileFlow.reauthenticateViaWeb();

--- a/src/ui/screens/settings/ViewSettingsMenu.qml
+++ b/src/ui/screens/settings/ViewSettingsMenu.qml
@@ -146,10 +146,10 @@ MZViewBase {
                 return stackview.push("qrc:/qt/qml/Mozilla/VPN/screens/settings/ViewSubscriptionManagement/ViewSubscriptionManagement.qml");
             }
             // Only push the profile view if it’s not already in the stack
-            if (
-                VPNProfileFlow.state === VPNProfileFlow.StateAuthenticationNeeded
-                && stackview.currentItem.objectName !== "reauthenticationFlow"
-            ) {
+            if (VPNProfileFlow.state === VPNProfileFlow.StateAuthenticationNeeded) {
+              if (!MZFeatureList.get("inAppAuthentication").isSupported) {
+                reauthPopup.open();
+              } else if (stackview.currentItem.objectName !== "reauthenticationFlow") {
                 reauthPopup.close();
                 return stackview.push("qrc:/qt/qml/Mozilla/VPN/screens/settings/ViewSubscriptionManagement/ViewReauthenticationFlow.qml", {
                     _onClose: () => {
@@ -157,6 +157,7 @@ MZViewBase {
                         stackview.pop(null, StackView.Immediate);
                     }
                 });
+              }
             }
 
             // An error occurred during the profile flow. Let’s reset and return
@@ -168,10 +169,6 @@ MZViewBase {
                   stackview.pop(null, StackView.Immediate);
                 }
                 VPNProfileFlow.reset();
-            }
-
-            if (VPNProfileFlow.state == VPNProfileFlow.StateNeedsWebReauthentication) {
-              reauthPopup.open();
             }
         }
     }

--- a/src/ui/screens/settings/ViewSettingsMenu.qml
+++ b/src/ui/screens/settings/ViewSettingsMenu.qml
@@ -166,9 +166,52 @@ MZViewBase {
                 }
                 VPNProfileFlow.reset();
             }
+
+            if (VPNProfileFlow.state == VPNProfileFlow.StateNeedsWebReauthentication) {
+              reauthPopup.open();
+            }
         }
     }
     Component.onCompleted: {
         Glean.impression.settingsScreen.record({screen:telemetryScreenId});
+    }
+
+    MZSimplePopup {
+        id: reauthPopup
+
+        anchors.centerIn: Overlay.overlay
+        imageSrc: "qrc:/nebula/resources/updateStatusUpdateAvailable.svg"
+        imageSize: Qt.size(80, 80)
+        title: MZI18n.SettingsReauthTitle
+        description: MZI18n.SettingsReauthDescription
+        buttons: [
+            MZButton {
+                id: reauthButton
+                text: MZI18n.SettingsReauthButton
+                Layout.fillWidth: true
+                onClicked: {
+                  VPNProfileFlow.reauthenticateViaWeb();
+                  loader.state = "active";
+                  reauthButton.enabled = false;
+                }
+
+                Rectangle {
+                  width: MZTheme.theme.rowHeight
+                  height: MZTheme.theme.rowHeight
+                  anchors.right: parent.right
+                  color: MZTheme.colors.transparent
+
+                  MZButtonLoader {
+                    id: loader
+                    color: MZTheme.colors.transparent
+                    iconUrl: "qrc:/nebula/resources/spinner.svg"
+                  }
+               }
+            }
+        ]
+
+        onClosed: {
+          VPNProfileFlow.reset();
+        }
     }
 }

--- a/src/ui/screens/settings/ViewSettingsMenu.qml
+++ b/src/ui/screens/settings/ViewSettingsMenu.qml
@@ -190,6 +190,7 @@ MZViewBase {
         buttons: [
             MZButton {
                 id: reauthButton
+                objectName: "reauthButton"
                 text: MZI18n.InAppAuthContinueToSignIn
                 Layout.fillWidth: true
                 onClicked: {

--- a/tests/functional/queries.js
+++ b/tests/functional/queries.js
@@ -280,6 +280,7 @@ const screenSettings = {
   STACKVIEW: new QmlQueryComposer('//settings-stackView'),
   APP_PREFERENCES: new QmlQueryComposer('//settingsPreferences'),
   USER_PROFILE: new QmlQueryComposer('//settingsUserProfile'),
+  REAUTH_BUTTON: new QmlQueryComposer('//reauthButton'),
 
   privacyView: {
     VIEW: new QmlQueryComposer('//privacySettingsView'),

--- a/tests/functional/testSubscription.js
+++ b/tests/functional/testSubscription.js
@@ -369,7 +369,7 @@ describe('Subscription view', function() {
     this.ctx.resetCallbacks();
   });
 
-  it('Authentication needed - sample', async () => {
+  it('Authentication needed', async () => {
     this.ctx.fxaLoginCallback = (req) => {
       this.ctx.fxaOverrideEndpoints.POSTs['/v1/account/login'].body = {
         sessionToken: 'session',
@@ -403,77 +403,6 @@ describe('Subscription view', function() {
     await vpn.waitForQueryAndClick(
         queries.screenSettings.REAUTH_BUTTON.visible());
     await vpn.mockInBrowserAuthentication();
-
-    await vpn.waitForQuery(
-        queries.screenSettings.subscriptionView.SCREEN.visible());
-  });
-
-  it('Authentication needed - totp', async () => {
-    this.ctx.guardianSubscriptionDetailsCallback = req => {
-      this.ctx.guardianOverrideEndpoints.GETs['/api/v1/vpn/subscriptionDetails']
-          .status = 401;
-      this.ctx.guardianOverrideEndpoints.GETs['/api/v1/vpn/subscriptionDetails']
-          .body = {}
-    };
-
-    await vpn.waitForQueryAndClick(queries.navBar.SETTINGS.visible());
-    await vpn.waitForQuery(queries.global.SCREEN_LOADER.ready());
-
-    await vpn.waitForQuery(queries.screenSettings.USER_PROFILE.visible());
-    await vpn.waitForQueryAndClick(
-        queries.screenSettings.USER_PROFILE.visible());
-
-    await vpn.waitForQuery(queries.screenSettings.STACKVIEW.ready());
-
-    await vpn.waitForQuery(
-        queries.screenAuthenticationInApp.AUTH_SIGNIN_PASSWORD_INPUT.visible());
-    await vpn.setQueryProperty(
-        queries.screenAuthenticationInApp.AUTH_SIGNIN_PASSWORD_INPUT.visible(),
-        'text', 'P4ssw0rd!!');
-
-    await vpn.waitForQuery(
-        queries.screenAuthenticationInApp.AUTH_SIGNIN_BUTTON.visible()
-            .enabled());
-
-    this.ctx.fxaLoginCallback = (req) => {
-      this.ctx.fxaOverrideEndpoints.POSTs['/v1/account/login'].body = {
-        sessionToken: 'session',
-        verified: false,
-        verificationMethod: 'totp-2fa'
-      };
-      this.ctx.fxaOverrideEndpoints.POSTs['/v1/account/login'].status = 200;
-    };
-
-    await vpn.waitForQueryAndClick(
-        queries.screenAuthenticationInApp.AUTH_SIGNIN_BUTTON.visible()
-            .enabled());
-
-    await vpn.waitForQuery(
-        queries.screenAuthenticationInApp.AUTH_TOTP_TEXT_INPUT.visible());
-    await vpn.waitForQuery(
-        queries.screenAuthenticationInApp.AUTH_TOTP_BUTTON.visible()
-            .disabled());
-    await vpn.setQueryProperty(
-        queries.screenAuthenticationInApp.AUTH_TOTP_TEXT_INPUT.visible(),
-        'text', '123456');
-    await vpn.waitForQuery(
-        queries.screenAuthenticationInApp.AUTH_TOTP_BUTTON.visible().enabled());
-
-    this.ctx.fxaTotpCallback = (req) => {
-      this.ctx.fxaOverrideEndpoints.POSTs['/v1/session/verify/totp'].body = {
-        success: true
-      }
-    };
-
-    this.ctx.guardianSubscriptionDetailsCallback = req => {
-      this.ctx.guardianOverrideEndpoints.GETs['/api/v1/vpn/subscriptionDetails']
-          .status = 200;
-      this.ctx.guardianOverrideEndpoints.GETs['/api/v1/vpn/subscriptionDetails']
-          .body = SUBSCRIPTION_DETAILS;
-    };
-
-    await vpn.waitForQueryAndClick(
-        queries.screenAuthenticationInApp.AUTH_TOTP_BUTTON.visible().enabled());
 
     await vpn.waitForQuery(
         queries.screenSettings.subscriptionView.SCREEN.visible());

--- a/tests/functional/testSubscription.js
+++ b/tests/functional/testSubscription.js
@@ -402,7 +402,9 @@ describe('Subscription view', function() {
     };
     await vpn.waitForQueryAndClick(
         queries.screenSettings.REAUTH_BUTTON.visible());
-    await vpn.mockInBrowserAuthentication();
+    if (!this.ctx.wasm) {
+      await vpn.mockInBrowserAuthentication();
+    }
 
     await vpn.waitForQuery(
         queries.screenSettings.subscriptionView.SCREEN.visible());

--- a/tests/functional/testSubscription.js
+++ b/tests/functional/testSubscription.js
@@ -370,6 +370,10 @@ describe('Subscription view', function() {
   });
 
   it('Authentication needed', async () => {
+    // With moving to in browser auth, this test no longer makes sense for WASM
+    if (this.ctx.wasm) {
+      return;
+    }
     this.ctx.fxaLoginCallback = (req) => {
       this.ctx.fxaOverrideEndpoints.POSTs['/v1/account/login'].body = {
         sessionToken: 'session',
@@ -400,11 +404,9 @@ describe('Subscription view', function() {
       this.ctx.guardianOverrideEndpoints.GETs['/api/v1/vpn/subscriptionDetails']
           .body = SUBSCRIPTION_DETAILS;
     };
-    if (!this.ctx.wasm) {
-      await vpn.waitForQueryAndClick(
-          queries.screenSettings.REAUTH_BUTTON.visible());
-      await vpn.mockInBrowserAuthentication();
-    }
+    await vpn.waitForQueryAndClick(
+        queries.screenSettings.REAUTH_BUTTON.visible());
+    await vpn.mockInBrowserAuthentication();
 
     await vpn.waitForQuery(
         queries.screenSettings.subscriptionView.SCREEN.visible());

--- a/tests/functional/testSubscription.js
+++ b/tests/functional/testSubscription.js
@@ -394,25 +394,15 @@ describe('Subscription view', function() {
 
     await vpn.waitForQuery(queries.screenSettings.STACKVIEW.ready());
 
-    await vpn.waitForQuery(
-        queries.screenAuthenticationInApp.AUTH_SIGNIN_PASSWORD_INPUT.visible());
-    await vpn.setQueryProperty(
-        queries.screenAuthenticationInApp.AUTH_SIGNIN_PASSWORD_INPUT.visible(),
-        'text', 'P4ssw0rd!!');
-    await vpn.waitForQuery(
-        queries.screenAuthenticationInApp.AUTH_SIGNIN_BUTTON.visible()
-            .enabled());
-
     this.ctx.guardianSubscriptionDetailsCallback = req => {
       this.ctx.guardianOverrideEndpoints.GETs['/api/v1/vpn/subscriptionDetails']
           .status = 200;
       this.ctx.guardianOverrideEndpoints.GETs['/api/v1/vpn/subscriptionDetails']
           .body = SUBSCRIPTION_DETAILS;
     };
-
     await vpn.waitForQueryAndClick(
-        queries.screenAuthenticationInApp.AUTH_SIGNIN_BUTTON.visible()
-            .enabled());
+        queries.screenSettings.REAUTH_BUTTON.visible());
+    await vpn.mockInBrowserAuthentication();
 
     await vpn.waitForQuery(
         queries.screenSettings.subscriptionView.SCREEN.visible());

--- a/tests/functional/testSubscription.js
+++ b/tests/functional/testSubscription.js
@@ -400,9 +400,9 @@ describe('Subscription view', function() {
       this.ctx.guardianOverrideEndpoints.GETs['/api/v1/vpn/subscriptionDetails']
           .body = SUBSCRIPTION_DETAILS;
     };
-    await vpn.waitForQueryAndClick(
-        queries.screenSettings.REAUTH_BUTTON.visible());
     if (!this.ctx.wasm) {
+      await vpn.waitForQueryAndClick(
+          queries.screenSettings.REAUTH_BUTTON.visible());
       await vpn.mockInBrowserAuthentication();
     }
 


### PR DESCRIPTION
## Description

My understanding of this ticket is that once we switch from in app auth to web based auth, the call to get subscription details will fail due to insufficient scopes. This PR adds a flow when this call fails - if it fails due to authentication and the user is using web-based authentication, we show a popup prompting the user to reauthenticate on web.

If we ever get a bad response for getting subscription details for the account profile screen and it's a `AuthenticationRequiredError`, this screen will pop up. This is what we want in the transition to web, but if this error pops up other times... it isn't the worst to try to reauthenticate, so I think this is okay. 

## Testing 
Since you need a specific token to trigger this (if I understand the ticket correctly), I hacked together a test setup:
1. Add [this diff](https://github.com/user-attachments/files/18216359/sample.txt) into the codebase. (It will force a reauth when running getsubscriptiondetails - but only once [for each app launch] and only when using web-based auth.)
2. Turn InAppAuthentication on (it defaults to `off` in staging) via Developer->Features menu. 
3. Sign out.
4. Sign back in (via in app authentication)
5. Turn InAppAuthentication back off
6. Hard quit and relaunch the app
7. In Settings, tap the Account row. You should get the reauth experience!

Video of it in process: https://github.com/user-attachments/assets/f213739a-53fe-4190-a9d6-c3245f0fa6b2


## Reference

VPN-6318

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
