### PR TITLE
Xcode 16 simulator fixes

### DIFF
--- a/docs/Building/ios.md
+++ b/docs/Building/ios.md
@@ -56,4 +56,5 @@ Once Xcode has opened the project, select the `mozillavpn` target and start the 
 
 Tips:
 * If you can't see a simulator target in the Xcode interface, look at Product -> Destination -> Destination Architectures -> Show Both
-* Due to lack of low level networking support, it is not possible to turn on the VPN from the iOS simulator in Xcode.
+* Simulator builds can only be run on Rosetta versions of simulators. Simulator builds use the mocked VPN controller.
+* When switching between building for Simulator and building for a device, the build folder must be completely removed.

--- a/docs/Building/macos.md
+++ b/docs/Building/macos.md
@@ -18,30 +18,6 @@ Install extra conda packages
 
     ./scripts/macos/conda_install_extras.sh
 
-Your Xcode install comes with a copy of the MacOS-SDK.
-We need to tell the conda environment where to find it.
-
-Find the sdk path
-
-    xcrun --sdk macosx --show-sdk-path
-
-If xcrun didn't work, default paths where you probably find your SDK:
- * Default Xcode-command-line tool path: `/Library/Developer/CommandLineTools/SDKs/MacOSX.<VersionNumber>.sdk`
- * Default Xcode.app path: `/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk`
-
-Add it to the conda env
-
-    conda env config vars set SDKROOT=$SDK_PATH
-
-Reactivate your conda env
-
-    conda activate vpn
-
-You can view your set variables
-
-    conda env config vars list
-
-The variable config step only needs to be done once.
 When you next want to start building the VPN, all you need to do is activate your conda environment (`conda activate vpn`).
 
 ## Get Qt

--- a/src/commands/commandstatus.cpp
+++ b/src/commands/commandstatus.cpp
@@ -158,6 +158,10 @@ int CommandStatus::run(QStringList& tokens) {
       case Controller::StateSwitching:
         stream << "switching";
         break;
+
+      case Controller::State::StateOnboarding:
+        stream << "onboarding";
+        break;
     }
 
     stream << Qt::endl;

--- a/src/commands/commandui.cpp
+++ b/src/commands/commandui.cpp
@@ -143,6 +143,18 @@ int CommandUI::run(QStringList& tokens) {
       MockDaemon* daemon = new MockDaemon(qApp);
       qputenv("MVPN_CONTROL_SOCKET", daemon->socketPath().toLocal8Bit());
     }
+#ifdef MZ_IOS
+    else {
+      QString simDeviceName = QString(qgetenv("SIMULATOR_DEVICE_NAME"));
+      if (!simDeviceName.isEmpty()) {
+        // The network extension doesn't actually start when running in the
+        // simulator - use a mocked daemon instead.
+        logger.debug() << "Mocking daemon for:" << simDeviceName;
+        MockDaemon* daemon = new MockDaemon(qApp);
+        qputenv("MVPN_CONTROL_SOCKET", daemon->socketPath().toLocal8Bit());
+      }
+    }
+#endif
 
     MozillaVPN vpn;
     logger.info() << "MozillaVPN" << Constants::versionString();

--- a/src/commands/commandui.cpp
+++ b/src/commands/commandui.cpp
@@ -144,15 +144,11 @@ int CommandUI::run(QStringList& tokens) {
       qputenv("MVPN_CONTROL_SOCKET", daemon->socketPath().toLocal8Bit());
     }
 #ifdef MZ_IOS
-    else {
-      QString simDeviceName = QString(qgetenv("SIMULATOR_DEVICE_NAME"));
-      if (!simDeviceName.isEmpty()) {
-        // The network extension doesn't actually start when running in the
-        // simulator - use a mocked daemon instead.
-        logger.debug() << "Mocking daemon for:" << simDeviceName;
-        MockDaemon* daemon = new MockDaemon(qApp);
-        qputenv("MVPN_CONTROL_SOCKET", daemon->socketPath().toLocal8Bit());
-      }
+    else if (!qEnvironmentVariable("SIMULATOR_DEVICE_NAME").isEmpty()) {
+      // If we are running in the iOS device simulator, the network extension
+      // is not supported in this environment - use a mocked daemon instead.
+      MockDaemon* daemon = new MockDaemon(qApp);
+      qputenv("MVPN_CONTROL_SOCKET", daemon->socketPath().toLocal8Bit());
     }
 #endif
 

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -119,6 +119,12 @@ QString Controller::useLocalSocketPath() const {
   }
 #elif defined(MZ_WINDOWS)
   return Constants::WINDOWS_DAEMON_PATH;
+#elif defined(MZ_IOS)
+  // The IOS simulator also uses a mocked daemon.
+  QString simulatorName = qEnvironmentVariable("SIMULATOR_DEVICE_NAME");
+  if (!simulatorName.isEmpty() && !path.isEmpty()) {
+    return path;
+  }
 #endif
 
   // Otherwise, we will need some other controller.

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -72,6 +72,10 @@ Controller::Reason stateToReason(Controller::State state) {
     return Controller::ReasonConfirming;
   }
 
+  if (state == Controller::StateOnboarding) {
+    return Controller::ReasonOnboarding;
+  }
+
   return Controller::ReasonNone;
 }
 }  // namespace
@@ -335,6 +339,8 @@ qint64 Controller::connectionTimestamp() const {
     case Controller::State::StateInitializing:
       [[fallthrough]];
     case Controller::State::StateOff:
+      [[fallthrough]];
+    case Controller::State::StateOnboarding:
       return 0;
     case Controller::State::StateOn:
       [[fallthrough]];
@@ -634,7 +640,7 @@ void Controller::activateNext() {
     return;
   }
 
-  if (m_state != StateSilentSwitching) {
+  if ((m_state != StateSilentSwitching) && (m_state != StateOnboarding)) {
     // Move to the StateConfirming if we are awaiting any connection handshakes
     setState(StateConfirming);
   }
@@ -780,6 +786,12 @@ void Controller::disconnected() {
   clearRetryCounter();
 
   NextStep nextStep = m_nextStep;
+
+  // Mobile onboarding is completed when we receive the disconnected signal.
+  if (m_state == StateOnboarding) {
+    logger.debug() << "Onboarding completed";
+    MozillaVPN::instance()->onboardingCompleted();
+  }
 
   if (processNextStep()) {
     setState(StateOff);
@@ -980,6 +992,16 @@ bool Controller::activate(const ServerData& serverData,
       return true;
     }
 
+    // If we are in the onboarding state, this connection is being made just
+    // to establish system permissions. We don't actually want to connect to
+    // a server.
+    if (App::instance()->state() == App::StateOnboarding) {
+      setState(StateOnboarding);
+      clearRetryCounter();
+      activateInternal(DoNotForceDNSPort, RandomizeServerSelection, ClientUser);
+      return true;
+    }
+
     if (Feature::get(Feature::Feature_checkConnectivityOnActivation)
             ->isSupported()) {
       // Ensure that the device is connected to the Internet.
@@ -1014,11 +1036,8 @@ bool Controller::activate(const ServerData& serverData,
 
               // Check if the error propagation has changed the Mozilla VPN
               // state. Continue only if the user is still authenticated and
-              // subscribed. We can ignore this during onboarding because we are
-              // not actually turning the VPN on (only asking for VPN system
-              // config permissions)
-              if (App::instance()->state() != App::StateMain &&
-                  App::instance()->state() != App::StateOnboarding) {
+              // subscribed.
+              if (App::instance()->state() != App::StateMain) {
                 return;
               }
 

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -121,8 +121,8 @@ QString Controller::useLocalSocketPath() const {
   return Constants::WINDOWS_DAEMON_PATH;
 #elif defined(MZ_IOS)
   // The IOS simulator also uses a mocked daemon.
-  QString simulatorName = qEnvironmentVariable("SIMULATOR_DEVICE_NAME");
-  if (!simulatorName.isEmpty() && !path.isEmpty()) {
+  bool isSimDevice = !qEnvironmentVariable("SIMULATOR_DEVICE_NAME").isEmpty();
+  if (isSimDevice && !path.isEmpty()) {
     return path;
   }
 #endif

--- a/src/controller.h
+++ b/src/controller.h
@@ -35,6 +35,7 @@ class Controller : public QObject, public LogSerializer {
     StateDisconnecting,
     StateSilentSwitching,
     StateSwitching,
+    StateOnboarding,
   };
   Q_ENUM(State)
 
@@ -42,7 +43,10 @@ class Controller : public QObject, public LogSerializer {
     ReasonNone = 0,
     ReasonSwitching,
     ReasonConfirming,
+    ReasonOnboarding,
   };
+  Q_ENUM(Reason)
+
   /**
    * @brief Who asked the Connection
    * to be Initiated? A Webextension

--- a/src/daemon/daemonlocalserverconnection.cpp
+++ b/src/daemon/daemonlocalserverconnection.cpp
@@ -122,6 +122,17 @@ void DaemonLocalServerConnection::parseCommand(const QByteArray& data) {
       return;
     }
 
+    // If this connection is being made for onboading. Don't actually connect,
+    // just emit a disconnected signal to confirm.
+    QString reason = obj.value("reason").toString();
+    if (!reason.isEmpty()) {
+      logger.error() << "Connection reason:" << reason;
+    }
+    if (reason == "onboarding") {
+      emit disconnected();
+      return;
+    }
+
     if (!m_daemon->activate(config)) {
       logger.error() << "Failed to activate the interface";
       emit disconnected();

--- a/src/daemon/mock/mockdaemon.cpp
+++ b/src/daemon/mock/mockdaemon.cpp
@@ -28,6 +28,15 @@ MockDaemon::MockDaemon(const QString& name, QObject* parent)
 
   logger.debug() << "Mock daemon created";
 
+#ifdef MZ_IOS
+  // We have to go out of our way to keep the path length under sizeof(sun_path)
+  // for iOS because the QDir::tempPath() used by QLocalServer winds up being
+  // way too long.
+  if (!m_socketName.startsWith('/')) {
+    m_socketName.prepend("/tmp/");
+  }
+#endif
+
 #ifndef MZ_WASM
   m_server.setSocketOptions(QLocalServer::UserAccessOption);
   if (!m_server.listen(m_socketName)) {

--- a/src/localsocketcontroller.cpp
+++ b/src/localsocketcontroller.cpp
@@ -50,7 +50,11 @@ LocalSocketController::LocalSocketController(const QString& path)
   connect(m_socket, &QLocalSocket::connected, this,
           &LocalSocketController::daemonConnected);
   connect(m_socket, &QLocalSocket::disconnected, this,
-          [&] { errorOccurred(QLocalSocket::PeerClosedError); });
+          [&] {
+            if (m_daemonState != eInitializing) {
+              errorOccurred(QLocalSocket::PeerClosedError);
+            }
+          });
   connect(m_socket, &QLocalSocket::errorOccurred, this,
           &LocalSocketController::errorOccurred);
   connect(m_socket, &QLocalSocket::readyRead, this,

--- a/src/localsocketcontroller.cpp
+++ b/src/localsocketcontroller.cpp
@@ -50,12 +50,11 @@ LocalSocketController::LocalSocketController(const QString& path)
   m_socket = new QLocalSocket(this);
   connect(m_socket, &QLocalSocket::connected, this,
           &LocalSocketController::daemonConnected);
-  connect(m_socket, &QLocalSocket::disconnected, this,
-          [&] {
-            if (m_daemonState != eInitializing) {
-              errorOccurred(QLocalSocket::PeerClosedError);
-            }
-          });
+  connect(m_socket, &QLocalSocket::disconnected, this, [&] {
+    if (m_daemonState != eInitializing) {
+      errorOccurred(QLocalSocket::PeerClosedError);
+    }
+  });
   connect(m_socket, &QLocalSocket::errorOccurred, this,
           &LocalSocketController::errorOccurred);
   connect(m_socket, &QLocalSocket::readyRead, this,

--- a/src/localsocketcontroller.cpp
+++ b/src/localsocketcontroller.cpp
@@ -9,6 +9,7 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QJsonValue>
+#include <QMetaEnum>
 #include <QMetaType>
 
 #include "daemon/daemonerrors.h"
@@ -128,10 +129,14 @@ void LocalSocketController::daemonConnected() {
 
 void LocalSocketController::activate(const InterfaceConfig& config,
                                      Controller::Reason reason) {
-  Q_UNUSED(reason);
-
   QJsonObject json = config.toJson();
   json.insert("type", "activate");
+
+  if (reason != Controller::ReasonNone) {
+    QMetaEnum metaEnum = QMetaEnum::fromType<Controller::Reason>();
+    QString reasonString = metaEnum.valueToKey(reason);
+    json.insert("reason", reasonString.toLower().mid(6));
+  }
 
   write(json);
 }

--- a/src/platforms/android/androidcontroller.cpp
+++ b/src/platforms/android/androidcontroller.cpp
@@ -100,8 +100,7 @@ AndroidController::AndroidController() {
       Qt::QueuedConnection);
   connect(
       activity, &AndroidVPNActivity::eventOnboardingCompleted, this,
-      [this]() { emit disconnected(); },
-      Qt::QueuedConnection);
+      [this]() { emit disconnected(); }, Qt::QueuedConnection);
   connect(
       activity, &AndroidVPNActivity::eventVpnConfigPermissionResponse, this,
       [](bool granted) {

--- a/src/platforms/android/androidcontroller.cpp
+++ b/src/platforms/android/androidcontroller.cpp
@@ -100,13 +100,7 @@ AndroidController::AndroidController() {
       Qt::QueuedConnection);
   connect(
       activity, &AndroidVPNActivity::eventOnboardingCompleted, this,
-      [this]() {
-        auto vpn = MozillaVPN::instance();
-        if (vpn->state() == App::StateOnboarding) {
-          vpn->onboardingCompleted();
-          emit disconnected();
-        }
-      },
+      [this]() { emit disconnected(); },
       Qt::QueuedConnection);
   connect(
       activity, &AndroidVPNActivity::eventVpnConfigPermissionResponse, this,
@@ -251,8 +245,7 @@ void AndroidController::activate(const InterfaceConfig& config,
   args["isUsingShortTimerSessionPing"] =
       settingsHolder->shortTimerSessionPing();
 
-  args["isOnboarding"] =
-      MozillaVPN::instance()->state() == App::StateOnboarding;
+  args["isOnboarding"] = reason == Controller::ReasonOnboarding;
 
   QJsonDocument doc(args);
   AndroidVPNActivity::sendToService(ServiceAction::ACTION_ACTIVATE,

--- a/src/platforms/ios/ioscontroller.mm
+++ b/src/platforms/ios/ioscontroller.mm
@@ -187,12 +187,9 @@ void IOSController::activate(const InterfaceConfig& config, Controller::Reason r
         }
       }
       onboardingCompletedCallback:^() {
-        BOOL isOnboarding = MozillaVPN::instance()->state() == App::StateOnboarding;
-        if (isOnboarding) {
+        if (reason == Controller::ReasonOnboarding) {
           logger.debug() << "Onboarding completed";
-          MozillaVPN::instance()->onboardingCompleted();
-        } else {
-          logger.debug() << "Not onboarding";
+          emit disconnected();
         }
       }
       vpnConfigPermissionResponseCallback:^(BOOL granted) {

--- a/src/platforms/ios/ioscontroller.mm
+++ b/src/platforms/ios/ioscontroller.mm
@@ -115,13 +115,6 @@ void IOSController::activate(const InterfaceConfig& config, Controller::Reason r
   if (!impl) {
     logger.error() << "Controller not correctly initialized";
 
-#if TARGET_OS_SIMULATOR
-    if (MozillaVPN::instance()->state() == App::StateOnboarding) {
-      logger.debug() << "Cannot activate VPN on a simulator. Completing onboarding.";
-      MozillaVPN::instance()->onboardingCompleted();
-    }
-#endif
-
     emit disconnected();
     return;
   }

--- a/src/ui/screens/home/controller/ControllerImage.qml
+++ b/src/ui/screens/home/controller/ControllerImage.qml
@@ -137,6 +137,24 @@ Rectangle {
             }
         },
         State {
+            name: VPNController.StateOnboarding
+
+            PropertyChanges {
+                target: logo
+                showVPNOnIcon: false
+                opacity: 0.55
+            }
+            PropertyChanges {
+                target: insetCircle
+                color: MZTheme.colors.successAccent
+            }
+            PropertyChanges {
+                target: insetIcon
+                source: "qrc:/ui/resources/shield-off.svg"
+                opacity: 1
+            }
+        },
+        State {
             name: VPNController.StateOn
             PropertyChanges {
                 target: logo

--- a/src/ui/screens/home/controller/ControllerView.qml
+++ b/src/ui/screens/home/controller/ControllerView.qml
@@ -63,7 +63,8 @@ Item {
     states: [
         State {
             name: "stateInitializing"
-            when: VPNController.state === VPNController.StateInitializing
+            when: VPNController.state === VPNController.StateInitializing ||
+                  VPNController.state === VPNController.StateOnboarding
 
             PropertyChanges {
                 target: boxBackground

--- a/src/ui/screens/home/controller/VPNToggle.qml
+++ b/src/ui/screens/home/controller/VPNToggle.qml
@@ -237,6 +237,26 @@ MZButtonBase {
                 toggleColor: MZTheme.colors.vpnToggleConnected
             }
 
+        },
+        State {
+            name: VPNController.StateOnboarding
+
+            PropertyChanges {
+                target: cursor
+                anchors.leftMargin: 4
+            }
+
+            PropertyChanges {
+                target: toggle
+                color: MZTheme.colors.vpnToggleDisconnected.defaultColor
+                border.color: MZTheme.colors.bgColorStronger
+            }
+
+            PropertyChanges {
+                target: toggleButton
+                toggleColor: MZTheme.colors.vpnToggleDisconnected
+            }
+
         }
     ]
     transitions: [


### PR DESCRIPTION
## Description
The iOS simulator doesn't currently run because the network extension will fail to start. To work around it, we can make use of the mock daemon as a substitute. However, trying to get this working required a handful of fixes specific for iOS. In particular:
 - Check for the simulation environment and create the mock daemon.
 - Fix a bug in the local socket disconnection handling.
 - Workaround a pathname limitation in iOS UNIX socket creation.
 - Refactor mobile onboarding into a controller state, and then implement it in the Mock daemon.

## Reference
Split from #10092

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
