### PR TITLE
Maybe fix flatpak build checkout failures

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -30,10 +30,12 @@ jobs:
       - name: Update git reference
         shell: bash
         working-directory: linux/flatpak
+        env:
+          HEAD_COMMIT_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
         run: |
           python -m yq -yi 'del(.modules[-1].sources[0].branch)' org.mozilla.vpn.yml
           python -m yq -yi ".modules[-1].sources[0].url = \"https://github.com/${{ github.repository }}\"" org.mozilla.vpn.yml
-          python -m yq -yi ".modules[-1].sources[0].commit = \"${{ github.sha }}\"" org.mozilla.vpn.yml
+          python -m yq -yi ".modules[-1].sources[0].commit = \"${HEAD_COMMIT_SHA}\"" org.mozilla.vpn.yml
           cat org.mozilla.vpn.yml
 
       - name: Add Appstream metainfo


### PR DESCRIPTION
## Description
I have noticed a lot of Flatpak build failures lately, which seem to end with a failure to checkout the Mozilla VPN sources, but the build never seems to fail on the `main` branch. I suspect that this is due to an inability to find the merge commit SHA in whatever build worker is running the build. We might have better luck using `github.event.pull_request.head.sha` instead, which is the latest commit on the PR branch rather than the merge commit.

## Reference

    i.e Jira or Github issue URL

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
