### PR TITLE
VPN-6320: change authentication default for macOS and Linux

### DIFF
--- a/src/feature/featurelistcallback.h
+++ b/src/feature/featurelistcallback.h
@@ -94,16 +94,13 @@ bool FeatureCallback_captivePortal() {
 }
 
 bool FeatureCallback_inAppAuthentication() {
-#if defined(MZ_WASM)
+#if defined(MZ_WINDOWS)
+  // Windows: InAppAuth for prod, web auth for staging
+  return Constants::inProduction();
+#elif defined(MZ_ANDROID) || defined(MZ_IOS) || defined(MZ_WASM)
   return true;
 #else
-  if (Constants::inProduction() || byPlatform({
-                                       .android = true,
-                                       .ios = true,
-                                   })()) {
-    return true;
-  }
-
+  // macOS and Linux
   return false;
 #endif
 }


### PR DESCRIPTION
## Description

Changes Linux and macOS to use web-based auth in prod. Rewrites this area a little to (hopefully) be clearer.

## Reference

VPN-6320

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
