### PR TITLE
FXVPN-32 follow up: Add extension badge for addons

### DIFF
--- a/addons/message_try_firefox_extension/manifest.json
+++ b/addons/message_try_firefox_extension/manifest.json
@@ -15,7 +15,7 @@
     "id": "message_try_firefox_extension.24",
     "title": "vpn.tryFirefoxExtension.title",
     "subtitle": "vpn.tryFirefoxExtension.subtitle",
-    "badge": "new_update",
+    "badge": "extension",
     "blocks": [
       {
         "id": "c_1",

--- a/src/addons/addonmessage.cpp
+++ b/src/addons/addonmessage.cpp
@@ -241,6 +241,8 @@ void AddonMessage::setBadge(const QString& badge) {
     m_badge = Survey;
   } else if (badge == "subscription") {
     m_badge = Subscription;
+  } else if (badge == "extension") {
+    m_badge = Extension;
   } else {
     logger.error() << "Unsupported badge type" << badge;
   }

--- a/src/addons/addonmessage.h
+++ b/src/addons/addonmessage.h
@@ -42,7 +42,8 @@ class AddonMessage final : public Addon {
     NewUpdate,
     WhatsNew,
     Survey,
-    Subscription
+    Subscription,
+    Extension
   };
   Q_ENUM(Badge)
 

--- a/src/translations/strings.yaml
+++ b/src/translations/strings.yaml
@@ -884,6 +884,9 @@ inAppMessaging:
   subscriptionBadge:
     value: Subscription
     comment: A badge shown in a message signifying that this message contains information about the user's subscription
+  extensionBadge:
+    value: Extension
+    comment: A badge shown in a message signifying that this message contains information about a Firefox browser extension
 
 devices:
   countLabel:

--- a/src/ui/screens/messaging/ViewMessage.qml
+++ b/src/ui/screens/messaging/ViewMessage.qml
@@ -103,6 +103,8 @@ MZViewBase {
                             return badgeInfo.surveyBadge
                         case MZAddonMessage.Subscription:
                             return badgeInfo.subscriptionBadge
+                        case MZAddonMessage.Extension:
+                            return badgeInfo.subscriptionBadge
                         }
                     }
 
@@ -135,6 +137,11 @@ MZViewBase {
                             'badgeBackgroundColor': MZTheme.colors.normalLevelBackground
                         };
                         property var subscriptionBadge: {
+                            'badgeText': MZI18n.InAppMessagingSubscriptionBadge,
+                            'badgeTextColor': MZTheme.colors.normalLevelMain,
+                            'badgeBackgroundColor': MZTheme.colors.normalLevelBackground
+                        };
+                        property var extensionBadge: {
                             'badgeText': MZI18n.InAppMessagingSubscriptionBadge,
                             'badgeTextColor': MZTheme.colors.normalLevelMain,
                             'badgeBackgroundColor': MZTheme.colors.normalLevelBackground


### PR DESCRIPTION
## Description

New badge type for addons. (I missed this when initially implementing the spec for the message.) Since this addon message will only be shown to users on the latest version of the client (2.25.0), we can be assured that all users who see this message will have a client that can actually show this badge.

<img width="200" alt="Screenshot 2" src="https://github.com/user-attachments/assets/7ad258b3-4c3b-4000-8304-949b0db23b8c" />

## Reference

FXVPN-32

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
