### PR TITLE
Remove .gitmodules entry for dead 3rdparty/openSSL submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,10 +6,6 @@
 	path = 3rdparty/wireguard-apple
 	url = https://github.com/WireGuard/wireguard-apple
 	shallow = true
-[submodule "3rdparty/openSSL"]
-	path = 3rdparty/openSSL
-	url = https://github.com/KDAB/android_openssl
-	shallow = true
 [submodule "3rdparty/wireguard-go"]
 	path = 3rdparty/wireguard-go
 	url = https://github.com/WireGuard/wireguard-go


### PR DESCRIPTION
Commit 37793a9617e4797a8218c2bc495cf507b6b6c300 (#5198) incompletely deleted this submodule: it removed the gitlink without removing the .gitmodules entry.

- https://github.com/mozilla-mobile/mozilla-vpn-client/issues/1014#issuecomment-2561945273