### PR TITLE
Disable broken wasm test

### DIFF
--- a/tests/functional/testSettings.js
+++ b/tests/functional/testSettings.js
@@ -655,6 +655,11 @@ describe('Settings', function() {
 
 
   it('Checking the languages settings', async () => {
+    if (this.ctx.wasm) {
+        // That page is currently broken see: VPN-6798
+        return;
+    }
+
     await vpn.setSetting('languageCode', '');
 
     await vpn.waitForQueryAndClick(


### PR DESCRIPTION
## Description

For reasons i don't know the language page causes a dlopen , which is not supported. Sadly emscripten does not want to tell WHAT is trying to load :( so for now let's disable the test on wasm, given we have coverage from the other plattforms