### PR TITLE
VPN-6581: disable adjust

### DIFF
--- a/src/platforms/android/sources.cmake
+++ b/src/platforms/android/sources.cmake
@@ -9,30 +9,31 @@ target_sources(shared-sources INTERFACE
      ${CMAKE_CURRENT_SOURCE_DIR}/platforms/android/androidcommons.h
 )
 
-if(ADJUST_TOKEN)
-    message("Adjust SDK enabled")
-    # SDK Token present, let's enable that.
-    target_compile_definitions(mozillavpn PUBLIC MZ_ADJUST)
+# Disabling Adjust per VPN-6581
+# if(ADJUST_TOKEN)
+#     message("Adjust SDK enabled")
+#     # SDK Token present, let's enable that.
+#     target_compile_definitions(mozillavpn PUBLIC MZ_ADJUST)
 
-    target_sources(shared-sources INTERFACE
-        ${CMAKE_CURRENT_SOURCE_DIR}/adjust/adjustfiltering.cpp
-        ${CMAKE_CURRENT_SOURCE_DIR}/adjust/adjustfiltering.h
-        ${CMAKE_CURRENT_SOURCE_DIR}/adjust/adjusthandler.cpp
-        ${CMAKE_CURRENT_SOURCE_DIR}/adjust/adjusthandler.h
-        ${CMAKE_CURRENT_SOURCE_DIR}/adjust/adjustproxy.cpp
-        ${CMAKE_CURRENT_SOURCE_DIR}/adjust/adjustproxy.h
-        ${CMAKE_CURRENT_SOURCE_DIR}/adjust/adjustproxyconnection.cpp
-        ${CMAKE_CURRENT_SOURCE_DIR}/adjust/adjustproxyconnection.h
-        ${CMAKE_CURRENT_SOURCE_DIR}/adjust/adjustproxypackagehandler.cpp
-        ${CMAKE_CURRENT_SOURCE_DIR}/adjust/adjustproxypackagehandler.h
-        ${CMAKE_CURRENT_SOURCE_DIR}/adjust/adjusttasksubmission.cpp
-        ${CMAKE_CURRENT_SOURCE_DIR}/adjust/adjusttasksubmission.h
-    )
-else()
-    if (${CMAKE_BUILD_TYPE} STREQUAL "Release")
-        message(${CMAKE_BUILD_TYPE})
-        message( FATAL_ERROR "Adjust token cannot be empty for release builds")
-    endif()
-endif()
+#     target_sources(shared-sources INTERFACE
+#         ${CMAKE_CURRENT_SOURCE_DIR}/adjust/adjustfiltering.cpp
+#         ${CMAKE_CURRENT_SOURCE_DIR}/adjust/adjustfiltering.h
+#         ${CMAKE_CURRENT_SOURCE_DIR}/adjust/adjusthandler.cpp
+#         ${CMAKE_CURRENT_SOURCE_DIR}/adjust/adjusthandler.h
+#         ${CMAKE_CURRENT_SOURCE_DIR}/adjust/adjustproxy.cpp
+#         ${CMAKE_CURRENT_SOURCE_DIR}/adjust/adjustproxy.h
+#         ${CMAKE_CURRENT_SOURCE_DIR}/adjust/adjustproxyconnection.cpp
+#         ${CMAKE_CURRENT_SOURCE_DIR}/adjust/adjustproxyconnection.h
+#         ${CMAKE_CURRENT_SOURCE_DIR}/adjust/adjustproxypackagehandler.cpp
+#         ${CMAKE_CURRENT_SOURCE_DIR}/adjust/adjustproxypackagehandler.h
+#         ${CMAKE_CURRENT_SOURCE_DIR}/adjust/adjusttasksubmission.cpp
+#         ${CMAKE_CURRENT_SOURCE_DIR}/adjust/adjusttasksubmission.h
+#     )
+# else()
+#     if (${CMAKE_BUILD_TYPE} STREQUAL "Release")
+#         message(${CMAKE_BUILD_TYPE})
+#         message( FATAL_ERROR "Adjust token cannot be empty for release builds")
+#     endif()
+# endif()
 
 target_link_libraries(shared-sources INTERFACE -ljnigraphics)

--- a/src/platforms/ios/sources.cmake
+++ b/src/platforms/ios/sources.cmake
@@ -8,23 +8,24 @@ target_sources(shared-sources INTERFACE
 )
 
 # Include the Adjust SDK
-if(BUILD_ADJUST_SDK_TOKEN)
-    target_compile_definitions(mozillavpn PUBLIC MZ_ADJUST)
-    target_sources(shared-sources INTERFACE
-        ${CMAKE_CURRENT_SOURCE_DIR}/adjust/adjustfiltering.cpp
-        ${CMAKE_CURRENT_SOURCE_DIR}/adjust/adjustfiltering.h
-        ${CMAKE_CURRENT_SOURCE_DIR}/adjust/adjusthandler.cpp
-        ${CMAKE_CURRENT_SOURCE_DIR}/adjust/adjusthandler.h
-        ${CMAKE_CURRENT_SOURCE_DIR}/adjust/adjustproxy.cpp
-        ${CMAKE_CURRENT_SOURCE_DIR}/adjust/adjustproxy.h
-        ${CMAKE_CURRENT_SOURCE_DIR}/adjust/adjustproxyconnection.cpp
-        ${CMAKE_CURRENT_SOURCE_DIR}/adjust/adjustproxyconnection.h
-        ${CMAKE_CURRENT_SOURCE_DIR}/adjust/adjustproxypackagehandler.cpp
-        ${CMAKE_CURRENT_SOURCE_DIR}/adjust/adjustproxypackagehandler.h
-        ${CMAKE_CURRENT_SOURCE_DIR}/adjust/adjusttasksubmission.cpp
-        ${CMAKE_CURRENT_SOURCE_DIR}/adjust/adjusttasksubmission.h
-        ${CMAKE_CURRENT_SOURCE_DIR}/platforms/ios/iosadjusthelper.mm
-        ${CMAKE_CURRENT_SOURCE_DIR}/platforms/ios/iosadjusthelper.h
-    )
-    target_link_libraries(shared-sources INTERFACE adjust)
-endif()
+# Disabling Adjust per VPN-6581
+# if(BUILD_ADJUST_SDK_TOKEN)
+#     target_compile_definitions(mozillavpn PUBLIC MZ_ADJUST)
+#     target_sources(shared-sources INTERFACE
+#         ${CMAKE_CURRENT_SOURCE_DIR}/adjust/adjustfiltering.cpp
+#         ${CMAKE_CURRENT_SOURCE_DIR}/adjust/adjustfiltering.h
+#         ${CMAKE_CURRENT_SOURCE_DIR}/adjust/adjusthandler.cpp
+#         ${CMAKE_CURRENT_SOURCE_DIR}/adjust/adjusthandler.h
+#         ${CMAKE_CURRENT_SOURCE_DIR}/adjust/adjustproxy.cpp
+#         ${CMAKE_CURRENT_SOURCE_DIR}/adjust/adjustproxy.h
+#         ${CMAKE_CURRENT_SOURCE_DIR}/adjust/adjustproxyconnection.cpp
+#         ${CMAKE_CURRENT_SOURCE_DIR}/adjust/adjustproxyconnection.h
+#         ${CMAKE_CURRENT_SOURCE_DIR}/adjust/adjustproxypackagehandler.cpp
+#         ${CMAKE_CURRENT_SOURCE_DIR}/adjust/adjustproxypackagehandler.h
+#         ${CMAKE_CURRENT_SOURCE_DIR}/adjust/adjusttasksubmission.cpp
+#         ${CMAKE_CURRENT_SOURCE_DIR}/adjust/adjusttasksubmission.h
+#         ${CMAKE_CURRENT_SOURCE_DIR}/platforms/ios/iosadjusthelper.mm
+#         ${CMAKE_CURRENT_SOURCE_DIR}/platforms/ios/iosadjusthelper.h
+#     )
+#     target_link_libraries(shared-sources INTERFACE adjust)
+# endif()


### PR DESCRIPTION
## Description

We want to disable adjust, but in a way that we can re-enable it if we later decide to. Commenting out this section removes the `MZ_ADJUST` flag in the builds, which disables adjust.

You can verify that Adjust is not running by finding the log line `Debug: Adjust not included in build.` shortly after the app initializes, rather than `Debug: Adjust included in build.`. (Build with a placeholder Adjust token when testing this; without one, Adjust will never be included in the build whether that section is commented out or not.)

## Reference

VPN-6581

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
