### PR TITLE
VPN-6805: Add timestamp to socksproxy logfile

### DIFF
--- a/extension/socks5proxy/bin/sockslogger.cpp
+++ b/extension/socks5proxy/bin/sockslogger.cpp
@@ -211,8 +211,9 @@ void SocksLogger::logfileHandler(QtMsgType type, const QMessageLogContext& ctx,
                                  const QString& msg) {
   QMutexLocker lock(&m_logFileMutex);
   if (m_logFileDevice) {
-    // Write the line into the logfile.
-    m_logFileDevice->write(msg.toUtf8() + '\n');
+    QDateTime now = QDateTime::currentDateTime();
+    QString line = now.toString("[dd.MM.yyyy hh:mm:ss.zzz] ") + msg + '\n';
+    m_logFileDevice->write(line.toUtf8());
     m_logFileDevice->flush();
   }
 }


### PR DESCRIPTION
## Description
While trying to take a look at the log files for [FXVPN-323](https://mozilla-hub.atlassian.net/browse/FXVPN-323), it seems that the logs weren't particularly helpful due to a lack of timing information. This PR attempts to add a timestamp to the start of each line as we write it to the logfile.

## Reference
JIRA Issue: [VPN-6805](https://mozilla-hub.atlassian.net/browse/VPN-6805)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[FXVPN-323]: https://mozilla-hub.atlassian.net/browse/FXVPN-323?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[VPN-6805]: https://mozilla-hub.atlassian.net/browse/VPN-6805?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ