### PR TITLE
Remove legacy XDG autostart files

### DIFF
--- a/linux/debian/mozillavpn.postinst
+++ b/linux/debian/mozillavpn.postinst
@@ -1,0 +1,9 @@
+#!/bin/sh
+action="$1"
+if [ "$action" = "configure" ]; then
+  # Remove the legacy XDG autostart start-on-boot configuration
+  rm -f /etc/xdg/autostart/mozillavpn-startup.desktop
+  rm -f /etc/xdg/autostart/org.mozilla.vpn-startup.desktop
+fi
+
+#DEBHELPER#


### PR DESCRIPTION
## Description
When upgrading from 2.24.x to 2.25, we removed the legacy autostart scripts and switched to the XDG desktop portal instead for handling start-on-boot. However, because the autostart scripts are installed under `/etc` they don't get removed on package upgrade, meaning that we can wind up launching the VPN application twice.

The second launch can have a malformed application ID, which can also lead to the corruption of the settings file.

To fix this, we need to make sure that these autostart files are removed.

## Reference
JIRA issue: [VPN-6804](https://mozilla-hub.atlassian.net/browse/VPN-6804)
Autostart scripts removed by #9922

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-6804]: https://mozilla-hub.atlassian.net/browse/VPN-6804?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ