### PR TITLE
VPN-6318 follow up: Fix for testing

### DIFF
--- a/src/profileflow.cpp
+++ b/src/profileflow.cpp
@@ -101,6 +101,7 @@ void ProfileFlow::reauthenticateViaWeb() {
       taskAuthenticate, &TaskAuthenticate::authenticationCompleted, this,
       [this]() {
         logger.debug() << "Authentication succeeded, restarting profile flow";
+        m_forceReauthFlow = false;
         ProfileFlow::start();
       });
 


### PR DESCRIPTION
## Description

https://github.com/mozilla-mobile/mozilla-vpn-client/pull/10141/ had a testing bug. This set of tasks results in being hung on the new "reauth" popup:
        - Reset app
        - Launch app - in debug menu use staging server, flip InAppAuth on (so that it is on for staging)
        - Relaunch app, sign in (via in app auth)
        - In Debug menu turn InAppAuth pref off
        - In inspector, give `force_subscription_management_reauthentication` command
        - Tap into the "Account" screen in settings

This was because we re-run profile flow after the reauth, but weren't clearing out the flag to force reauth before the second run. (In testing before putting up the original PR, I was testing via a different path.)

## Reference

VPN-6318

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
