### PR TITLE
Update release notes script

### DIFF
--- a/scripts/utils/generate_release_notes.sh
+++ b/scripts/utils/generate_release_notes.sh
@@ -62,12 +62,45 @@ do
         LANGUAGE_CODE="it-IT"
     elif [ "$ORIGINAL_LANGUAGE_CODE" == "nl" ]; then
         LANGUAGE_CODE="nl-NL"
+    elif [ "$ORIGINAL_LANGUAGE_CODE" == "cs" ]; then
+        LANGUAGE_CODE="cs-CZ"
+    elif [ "$ORIGINAL_LANGUAGE_CODE" == "da" ]; then
+        LANGUAGE_CODE="da-DK"
+    elif [ "$ORIGINAL_LANGUAGE_CODE" == "el" ]; then
+        LANGUAGE_CODE="el-GR"
+    elif [ "$ORIGINAL_LANGUAGE_CODE" == "fi" ]; then
+        LANGUAGE_CODE="fi-FI"
+    elif [ "$ORIGINAL_LANGUAGE_CODE" == "hu" ]; then
+        LANGUAGE_CODE="hu-HU"
+    elif [ "$ORIGINAL_LANGUAGE_CODE" == "id" ]; then
+        LANGUAGE_CODE="id"
+    elif [ "$ORIGINAL_LANGUAGE_CODE" == "ko" ]; then
+        LANGUAGE_CODE="ko-KR"
+    elif [ "$ORIGINAL_LANGUAGE_CODE" == "pt_BR" ]; then
+        LANGUAGE_CODE="pt-BR"
+    elif [ "$ORIGINAL_LANGUAGE_CODE" == "pt_PT" ]; then
+        LANGUAGE_CODE="pt-PT"
+    elif [ "$ORIGINAL_LANGUAGE_CODE" == "sk" ]; then
+        LANGUAGE_CODE="sk"
+    elif [ "$ORIGINAL_LANGUAGE_CODE" == "sl" ]; then
+        LANGUAGE_CODE="sl"
+    elif [ "$ORIGINAL_LANGUAGE_CODE" == "sv_SE" ]; then
+        LANGUAGE_CODE="sv-SE"
+    elif [ "$ORIGINAL_LANGUAGE_CODE" == "tr" ]; then
+        LANGUAGE_CODE="tr-TR"
+    elif [ "$ORIGINAL_LANGUAGE_CODE" == "uk" ]; then
+        LANGUAGE_CODE="uk"
+    elif [ "$ORIGINAL_LANGUAGE_CODE" == "vi" ]; then
+        LANGUAGE_CODE="vi"
+    elif [ "$ORIGINAL_LANGUAGE_CODE" == "zh_TW" ]; then
+        LANGUAGE_CODE="zh-TW"
     else
         # Play stores don't ask for the other languages.
         continue;
     fi
 
     # Must do this as a for loop rather than a `contains` with multiple clauses to get the proper ordering.
+    MISSING_TRANSLATION=false
     TRANSLATED_TEXT=""
     if [ "$LANGUAGE_CODE" == "en-US" ]; then
         for BLOCK_ID in "${BLOCK_IDS[@]}"
@@ -87,11 +120,16 @@ do
           if [[ ($BLOCK_ID == *"bullet"* || $BLOCK_ID == *"Bullet"*) && $BLOCK_ID != *"generalUpdateBulletIntro"* ]]; then
             TRANSLATED_TEXT+="- "
           fi
-          TRANSLATED_TEXT+=$(xmlstarlet sel \
+          POTENTIAL_TRANSLATION=$(xmlstarlet sel \
                   -N x="urn:oasis:names:tc:xliff:document:1.2" \
                   -t -m "/x:xliff/x:file/x:body/x:trans-unit[$BLOCK_ID]" \
                   -v "concat(x:target, '\n')" -n \
                   "$XLIFF_FILE")
+          if [[ "$POTENTIAL_TRANSLATION" == "\n" ]]; then
+              MISSING_TRANSLATION=true
+          else
+              TRANSLATED_TEXT+=$POTENTIAL_TRANSLATION
+          fi
         done
     fi
 
@@ -100,7 +138,7 @@ do
     TRANSLATED_TEXT="${TRANSLATED_TEXT:0:$TRANSLATED_TEXT_LENGTH-2}"
 
     # Check if the output is not empty
-    if [ -n "$TRANSLATED_TEXT" ]; then
+    if [ $MISSING_TRANSLATION == false ]; then
         if [ "$LANGUAGE_CODE" == "es-ES" ]; then
             ES_FOUND=true
             echo "✅ Release note translations found for: $LANGUAGE_CODE (using $ORIGINAL_LANGUAGE_CODE)"
@@ -112,7 +150,7 @@ do
         echo -e $TRANSLATED_TEXT >> $RELEASE_NOTES_FILE
         echo "</$LANGUAGE_CODE>" >> $RELEASE_NOTES_FILE
     else
-        echo "❌ No release note translations found for: $LANGUAGE_CODE ($ORIGINAL_LANGUAGE_CODE)"
+        echo "❌ Release note translations missing for: $LANGUAGE_CODE ($ORIGINAL_LANGUAGE_CODE)"
     fi
 done
 


### PR DESCRIPTION
## Description

Now that we're using 22 languages (instead of 6), I wanted to update the script to be able to use it. (6 languages were okay to do manually, 22 is annoying.)

Updated the bash script to use the updated file for shared strings. Also added the additional languages. As part of that:
- I had to change to a for loop to get the strings in order. (Otherwise it takes them in the order of the `strings.xliff` file - which for 2.25, gives an incorrect output order due to how `strings.xliff` is sorted.)
- I updated how we decide if a language is missing a translation, as it wasn't working for Greek (which has a missing string for the 2.25 release).

## Reference

N/A

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
