### PR TITLE
basti/nativeMessaging

### DIFF
--- a/extension/bridge/src/commands.rs
+++ b/extension/bridge/src/commands.rs
@@ -26,17 +26,17 @@
          "bridge_ping" =>{
              crate::io::write_output(std::io::stdout(),&json!({"status": "bridge_pong"}))
                  .expect("Unable to Write to STDOUT?");
-             return Ok(true);
+             Ok(true)
          }
          "start" =>{
             let out = launcher::start_vpn();
             crate::io::write_output(std::io::stdout(),&out)
                 .expect("Unable to Write to STDOUT?");
-            return Ok(true);
+            Ok(true)
         }
          _ =>{
              // We did not handle this.
-             return Ok(false);
+             Ok(false)
          }
      }
  }

--- a/extension/bridge/src/commands.rs
+++ b/extension/bridge/src/commands.rs
@@ -1,0 +1,37 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+
+
+ use std::error::Error;
+ use serde_json::{Value, json};
+ 
+ /**
+  * Handles commands that are sent from
+  * [Extension] === > [NativeMessagingBridge]
+  * 
+  * Returns true if the command was handled, in which case it should
+  * *not* be forwarded to the VPN Client. 
+  * 
+  * Will attempt to print to STDOUT in case a command needs a response. 
+  *  
+  */
+ pub fn handle(val:&Value)-> Result<bool,Box<dyn Error>>{
+     let obj = val.as_object().ok_or("Not an object")?;
+     // Type of command is in {t:'doThing'}
+     let cmd = obj.get_key_value("t").ok_or("Missing obj.t")?;
+ 
+     match cmd.1.as_str().ok_or("T is not a string")? {
+         "bridge_pong" =>{
+             crate::io::write_output(std::io::stdout(),&json!({"status": "bridge_pong"}))
+                 .expect("Unable to Write to STDOUT?");
+             return Ok(true);
+         }
+         _ =>{
+             // We did not handle this.
+             return Ok(false);
+         }
+     }
+ }
+ 

--- a/extension/bridge/src/commands.rs
+++ b/extension/bridge/src/commands.rs
@@ -71,6 +71,7 @@ mod launcher {
 
 #[cfg(not(target_os = "windows"))]
 mod launcher {
+    use serde_json::json;
     pub fn start_vpn() -> serde_json::Value{
         json!("{error:'start_unsupported!'}")
     }

--- a/extension/bridge/src/io.rs
+++ b/extension/bridge/src/io.rs
@@ -1,0 +1,127 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+ use byteorder::{NativeEndian, ReadBytesExt, WriteBytesExt};
+ use mio::net::TcpStream;
+ use mio::{Events, Interest, Poll, Token, Waker};
+ use serde_json::{json, Value};
+ use std::io::{Cursor, Read, Write};
+ use std::mem::size_of;
+ use std::sync::mpsc::channel;
+ use std::sync::Arc;
+ use std::{thread, time};
+ use std::env;
+ 
+
+
+#[derive(PartialEq)]
+enum ReaderState {
+    ReadingLength,
+    ReadingBuffer,
+}
+
+pub struct Reader {
+    state: ReaderState,
+    buffer: Vec<u8>,
+    length: usize,
+}
+
+impl Reader {
+    pub fn new() -> Reader {
+        Reader {
+            state: ReaderState::ReadingLength,
+            buffer: Vec::new(),
+            length: 0,
+        }
+    }
+
+    pub fn read_input<R: Read>(&mut self, mut input: R) -> Option<Value> {
+        // Until we are able to read things from the stream...
+        loop {
+            if self.state == ReaderState::ReadingLength {
+                assert!(self.buffer.len() < size_of::<u32>());
+
+                let mut buffer = vec![0; size_of::<u32>() - self.buffer.len()];
+                match input.read(&mut buffer) {
+                    Ok(size) => {
+                        // Maybe we have read just part of the buffer. Let's append
+                        // only what we have been read.
+                        buffer.truncate(size);
+                        self.buffer.append(&mut buffer);
+
+                        // Not enough data yet.
+                        if self.buffer.len() < size_of::<u32>() {
+                            continue;
+                        }
+
+                        // Let's convert our buffer into a u32.
+                        let mut rdr = Cursor::new(&self.buffer);
+                        self.length = rdr.read_u32::<NativeEndian>().unwrap() as usize;
+                        if self.length == 0 {
+                            continue;
+                        }
+
+                        self.state = ReaderState::ReadingBuffer;
+                        self.buffer = Vec::with_capacity(self.length);
+                    }
+                    _ => return None,
+                }
+            }
+
+            if self.state == ReaderState::ReadingBuffer {
+                assert!(self.length > 0);
+                assert!(self.buffer.len() < self.length);
+
+                let mut buffer = vec![0; self.length - self.buffer.len()];
+                match input.read(&mut buffer) {
+                    Ok(size) => {
+                        // Maybe we have read just part of the buffer. Let's append
+                        // only what we have been read.
+                        buffer.truncate(size);
+                        self.buffer.append(&mut buffer);
+
+                        // Not enough data yet.
+                        if self.buffer.len() < self.length {
+                            continue;
+                        }
+
+                        match serde_json::from_slice(&self.buffer) {
+                            Ok(value) => {
+                                self.buffer.clear();
+                                self.state = ReaderState::ReadingLength;
+                                return Some(value);
+                            }
+                            _ => {
+                                self.buffer.clear();
+                                self.state = ReaderState::ReadingLength;
+                                continue;
+                            }
+                        }
+                    }
+                    _ => return None,
+                }
+            }
+        }
+    }
+}
+
+pub fn write_output<W: Write>(mut output: W, value: &Value) -> Result<(), std::io::Error> {
+    let msg = serde_json::to_string(value)?;
+    let len = msg.len();
+    output.write_u32::<NativeEndian>(len as u32)?;
+    output.write_all(msg.as_bytes())?;
+    output.flush()?;
+    Ok(())
+}
+
+pub fn write_vpn_down(error: bool) {
+    let field = if error { "error" } else { "status" };
+    let value = json!({field: "vpn-client-down"});
+    write_output(std::io::stdout(), &value).expect("Unable to write to STDOUT");
+}
+
+pub fn write_vpn_up() {
+    let value = json!({"status": "vpn-client-up"});
+    write_output(std::io::stdout(), &value).expect("Unable to write to STDOUT");
+}

--- a/extension/bridge/src/io.rs
+++ b/extension/bridge/src/io.rs
@@ -3,15 +3,15 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
  use byteorder::{NativeEndian, ReadBytesExt, WriteBytesExt};
- use mio::net::TcpStream;
- use mio::{Events, Interest, Poll, Token, Waker};
+ 
+ 
  use serde_json::{json, Value};
  use std::io::{Cursor, Read, Write};
  use std::mem::size_of;
- use std::sync::mpsc::channel;
- use std::sync::Arc;
- use std::{thread, time};
- use std::env;
+ 
+ 
+ 
+ 
  
 
 

--- a/extension/bridge/src/main.rs
+++ b/extension/bridge/src/main.rs
@@ -2,12 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use byteorder::{NativeEndian, ReadBytesExt, WriteBytesExt};
 use mio::net::TcpStream;
 use mio::{Events, Interest, Poll, Token, Waker};
-use serde_json::{json, Value};
-use std::io::{Cursor, Read, Write};
-use std::mem::size_of;
 use std::sync::mpsc::channel;
 use std::sync::Arc;
 use std::{thread, time};

--- a/tests/nativemessaging/testbridge.cpp
+++ b/tests/nativemessaging/testbridge.cpp
@@ -4,7 +4,7 @@
 
 #include "testbridge.h"
 
-#include <QJSONDocument>
+#include <QJsonDocument>
 
 #include "helperserver.h"
 

--- a/tests/nativemessaging/testbridge.cpp
+++ b/tests/nativemessaging/testbridge.cpp
@@ -4,17 +4,17 @@
 
 #include "testbridge.h"
 
-#include "helperserver.h"
 #include <QJSONDocument>
+
+#include "helperserver.h"
 
 void TestBridge::bridge_ping() {
   QVERIFY(s_nativeMessagingProcess);
 
-  
   // A simple ping/pong.
   QVERIFY(write(R"({"t": "bridge_ping"})"));
   auto const json = QJsonDocument::fromJson(readIgnoringStatus());
-  QCOMPARE(json["status"].toString(),"bridge_pong");
+  QCOMPARE(json["status"].toString(), "bridge_pong");
 }
 
 void TestBridge::app_ping_failure() {


### PR DESCRIPTION
## Description

This PR "fixes" "the "bridge_pong" - the extension and client only expect that we pass json-objects through this impl, the native messaging part however expected a raw string. - This now gives nm the ability to handle commands similar to the client. 

Then i add a start command that launches on windows the client. Feedback welcome if there is a "standard" way to that on linux os'es too. 
