### PR TITLE
bug 1942364: switch to autograph gcp production for signing

### DIFF
--- a/taskcluster/kinds/repackage-signing/kind.yml
+++ b/taskcluster/kinds/repackage-signing/kind.yml
@@ -29,7 +29,7 @@ tasks:
         add-index-routes:
             name: windows
             type: build
-        signing-format: autograph_authenticode_202404
+        signing-format: gcp_prod_autograph_authenticode_202412
         treeherder:
             job-symbol: Bs
             kind: build

--- a/taskcluster/kinds/signing/kind.yml
+++ b/taskcluster/kinds/signing/kind.yml
@@ -26,7 +26,6 @@ tasks:
                     - android-x86/release
                     - android-arm64/release
                     - android-armv7/release
-                    # - linux/opt
                     - macos/opt
                     - windows/opt
                     - addons/opt
@@ -37,11 +36,10 @@ tasks:
                 default: build
         signing-format:
             by-build-type:
-                android.*: autograph_apk
-                linux.*: autograph_debsign
+                android.*: gcp_prod_autograph_apk
                 macos.*: macapp
-                windows/opt: autograph_authenticode_202404
-                addons/opt: autograph_rsa
+                windows/opt: gcp_prod_autograph_authenticode_202404
+                addons/opt: gcp_prod_autograph_rsa
         treeherder:
             job-symbol:
                 by-build-type:


### PR DESCRIPTION
And while I'm in here, remove the `linux` entries that are long unused.

This needs to wait for https://github.com/mozilla-releng/scriptworker-scripts/pull/1123 to be deployed before it can.