### PR TITLE
VPN-6813 fix translation in install string

### DIFF
--- a/macos/pkg/conclusion.html.in
+++ b/macos/pkg/conclusion.html.in
@@ -9,7 +9,7 @@
       <p style="margin: 5px;">@MACOSINSTALLER_CONCLUSION_MESSAGE1_V2@</p>
     <br />
     <p style="margin: 5px;">@MACOSINSTALLER_CONCLUSION_MESSAGE2@
-    <a rel="noopener noreferrer" href="https://support.mozilla.org/products/firefox-private-network-vpn?utm_source=mozilla-vpn&utm_medium=mozilla-vpn-installer&utm_campaign=mac-installer" style="color: #0a84ff;">@MACOSINSTALLER_CONCLUSION_MESSAGE3@</a>
+    <a rel="noopener noreferrer" href="https://support.mozilla.org/products/firefox-private-network-vpn?utm_source=mozilla-vpn&utm_medium=mozilla-vpn-installer&utm_campaign=mac-installer" style="color: #0a84ff;">@MACOSINSTALLER_CONCLUSION_MESSAGE31@</a>
     </p>
   </body>
 </html>


### PR DESCRIPTION
## Description

[See diagnosis on the ticket](https://mozilla-hub.atlassian.net/browse/VPN-6813). I'm the one who broke this in https://github.com/mozilla-mobile/mozilla-vpn-client/pull/9641.


## Reference

VPN-6813

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
