### PR TITLE
VPN-6318 follow up - better resetting of state

### DIFF
--- a/src/profileflow.cpp
+++ b/src/profileflow.cpp
@@ -116,6 +116,11 @@ void ProfileFlow::reset() {
     Q_ASSERT(vpn);
     vpn->cancelReauthentication();
 
+    // Clear out TaskAuthenticate if present. (Without this next line,
+    // TaskAuthentication hangs around forever and can affect future auth
+    // checks.)
+    TaskScheduler::deleteTasks();
+
     m_currentTask = nullptr;
     setState(StateInitial);
   }

--- a/src/ui/screens/settings/ViewSettingsMenu.qml
+++ b/src/ui/screens/settings/ViewSettingsMenu.qml
@@ -212,6 +212,11 @@ MZViewBase {
             }
         ]
 
+        onOpened: {
+          loader.state = "inactive";
+          reauthButton.enabled = true;
+        }
+
         onClosed: {
           VPNProfileFlow.reset();
         }


### PR DESCRIPTION
## Description

This comes from QA's latest checks on VPN-6318. The issues were that the pop up wasn't resetting, and TaskAuthenticate was left hanging. This fixes both of those.

After this gets merged into `main`, it will need to be uplifted into the release branch.

## Reference

VPN-6318

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
