### PR TITLE
VPN-6632: Fix split tunnel when IPv6 unreachable

### DIFF
--- a/src/platforms/windows/daemon/windowsdaemon.cpp
+++ b/src/platforms/windows/daemon/windowsdaemon.cpp
@@ -51,7 +51,8 @@ WindowsDaemon::~WindowsDaemon() {
 
 void WindowsDaemon::prepareActivation(const InterfaceConfig& config) {
   // Before creating the interface we need to check which adapter
-  // routes to the server endpoint
+  // routes to the server endpoint. This will be selected as the outgoing
+  // interface for split-tunnelled traffic.
   auto serveraddr = QHostAddress(config.m_serverIpv4AddrIn);
   m_inetAdapterIndex = WindowsCommons::AdapterIndexTo(serveraddr);
 }

--- a/src/platforms/windows/daemon/windowsfirewall.cpp
+++ b/src/platforms/windows/daemon/windowsfirewall.cpp
@@ -183,10 +183,6 @@ bool WindowsFirewall::enableInterface(int vpnAdapterIndex) {
   if (!allowTrafficForAppOnAll(getCurrentPath(), MAX_WEIGHT, msg)) {
     return false;
   }
-  msg = "Allow all for socksproxy.exe";
-  if (!allowTrafficForAppOnAll(getProxyPath(), MAX_WEIGHT, msg)) {
-    return false;
-  }
   if (!blockTrafficOnPort(53, MED_WEIGHT, "Block all DNS")) {
     return false;
   }
@@ -828,15 +824,6 @@ QString WindowsFirewall::getCurrentPath() {
   }
 
   return QString::fromLocal8Bit(buffer);
-}
-
-QString WindowsFirewall::getProxyPath() {
-  QString execPath = getCurrentPath();
-  if (execPath.isEmpty()) {
-    return "";
-  }
-
-  return QFileInfo(execPath).dir().absoluteFilePath("socksproxy.exe");
 }
 
 void WindowsFirewall::importAddress(const QHostAddress& addr,

--- a/src/platforms/windows/daemon/windowsfirewall.h
+++ b/src/platforms/windows/daemon/windowsfirewall.h
@@ -71,7 +71,6 @@ class WindowsFirewall final : public QObject {
 
   // Utils
   QString getCurrentPath();
-  QString getProxyPath();
   void importAddress(const QHostAddress& addr, OUT FWP_VALUE0_& value,
                      OUT QByteArray* v6DataBuffer);
   void importAddress(const QHostAddress& addr, OUT FWP_CONDITION_VALUE0_& value,

--- a/src/platforms/windows/daemon/windowssplittunnel.cpp
+++ b/src/platforms/windows/daemon/windowssplittunnel.cpp
@@ -481,8 +481,6 @@ bool WindowsSplitTunnel::getAddress(int adapterIndex, IN_ADDR* out_ipv4,
   }
   auto guard = qScopeGuard([table]() { FreeMibTable(table); });
 
-  logger.debug() << "Examining addresses for interface:" << adapterIndex;
-
   // Find the best unicast addresses on this interface.
   const MIB_UNICASTIPADDRESS_ROW* bestIpv4 = nullptr;
   const MIB_UNICASTIPADDRESS_ROW* bestIpv6 = nullptr;
@@ -499,23 +497,18 @@ bool WindowsSplitTunnel::getAddress(int adapterIndex, IN_ADDR* out_ipv4,
       // Check IPv4 addresses
       quint32 rawAddr = row->Address.Ipv4.sin_addr.s_addr;
       QHostAddress addr(qFromBigEndian<quint32>(rawAddr));
-      logger.debug() << "Examining IPv4 address:" << addr.toString();
       if (!addr.isGlobal()) {
-        logger.debug() << "Yeeting IPv4 address:" << addr.toString();
         continue;
       }
       // Prefer the address with the highest DAD state.
       if ((bestIpv4 != nullptr) && (bestIpv4->DadState >= row->DadState)) {
-        logger.debug() << "Yeeting DadState" << row->DadState;
         continue;
       }
       bestIpv4 = row;
     } else if (row->Address.si_family == AF_INET6) {
       QHostAddress addr(row->Address.Ipv6.sin6_addr.s6_addr);
-      logger.debug() << "Examining IPv6 address:" << addr.toString();
       // Check IPv6 addresses
       if (!addr.isGlobal()) {
-        logger.debug() << "Yeeting IPv6 non-global:" << addr.toString();
         continue;
       }
 

--- a/src/platforms/windows/daemon/windowssplittunnel.cpp
+++ b/src/platforms/windows/daemon/windowssplittunnel.cpp
@@ -10,8 +10,6 @@
 #include <winsock2.h>
 #include <ws2ipdef.h>
 
-#include <qassert.h>
-
 #include <memory>
 
 #include "../windowscommons.h"
@@ -23,7 +21,6 @@
 #include "windowsfirewall.h"
 
 #define PSAPI_VERSION 2
-#include <Windows.h>
 #include <psapi.h>
 
 #include <QCoreApplication>
@@ -513,8 +510,7 @@ bool WindowsSplitTunnel::getAddress(int adapterIndex, IN_ADDR* out_ipv4,
         continue;
       }
       bestIpv4 = row;
-    }
-    else if (row->Address.si_family == AF_INET6) {
+    } else if (row->Address.si_family == AF_INET6) {
       QHostAddress addr(row->Address.Ipv6.sin6_addr.s6_addr);
       logger.debug() << "Examining IPv6 address:" << addr.toString();
       // Check IPv6 addresses

--- a/src/platforms/windows/windowscommons.cpp
+++ b/src/platforms/windows/windowscommons.cpp
@@ -115,18 +115,15 @@ QString WindowsCommons::getTunnelLogFilePath() {
 int WindowsCommons::AdapterIndexTo(const QHostAddress& dst) {
   logger.debug() << "Getting Current Internet Adapter that routes to"
                  << logger.sensitive(dst.toString());
-  quint32_be ipBigEndian;
-  quint32 ip = dst.toIPv4Address();
-  qToBigEndian(ip, &ipBigEndian);
-  _MIB_IPFORWARDROW routeInfo;
-  auto result = GetBestRoute(ipBigEndian, 0, &routeInfo);
+  quint32 ipv4be = qToBigEndian<quint32>(dst.toIPv4Address());
+  DWORD index = 0;
+  DWORD result = GetBestInterface(ipv4be, &index);
   if (result != NO_ERROR) {
+    WindowsUtils::windowsLog("Interface lookup failed");
     return -1;
   }
-  auto adapter =
-      QNetworkInterface::interfaceFromIndex(routeInfo.dwForwardIfIndex);
-  logger.debug() << "Internet Adapter:" << adapter.name();
-  return routeInfo.dwForwardIfIndex;
+  logger.debug() << "Internet Adapter:" << index;
+  return index;
 }
 
 // static


### PR DESCRIPTION
## Description
We have a bit of a bug in our handling of split-tunnelling when there is no IPv6 connectivity. In particular, if there are no IPv6 routers on the LAN then the network interface will only have link-local addresses, which cannot be used to enable the split tunneling driver. To ensure that split tunneling works on such networks, we need to take care when selecting addresses to avoid link-local addresses.

This PR rewrites ` WindowsSplitTunnel::getAddress()` so that we rank IPv6 addresses to select the address which is most likely to route to the internet, while also ignoring explicitly unroutable addresses such as link-local and loopback.

While we are at it, we also identified an endian conversion bug in the interface selection logic that would also sometimes result in invalid split tunneling configuration, and removed an unused firewall rule.

## Reference
Heavily inspired by #10001 
JIRA Issue: [VPN-6632](https://mozilla-hub.atlassian.net/browse/VPN-6632)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-6632]: https://mozilla-hub.atlassian.net/browse/VPN-6632?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ