### PR TITLE
Allow for switches in stateonpartial

### DIFF
--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -782,12 +782,13 @@ void Controller::disconnected() {
 
   if (nextStep == None &&
       (m_state == StateSilentSwitching || m_state == StateSwitching)) {
-    // If we are only silently switching, keep the iniator
+    // If we are only switching, keep the iniator
     // Else move the iniator to Client User
     // as the extension cannot switch servers.
-    auto target_iniator = m_state == StateSilentSwitching
-                              ? m_initiator
-                              : ActivationPrincipal::ClientUser;
+    auto target_iniator =
+        (m_state == StateSilentSwitching || m_state == StateSwitching)
+            ? m_initiator
+            : ActivationPrincipal::ClientUser;
     activate(m_nextServerData, target_iniator, m_nextServerSelectionPolicy);
     return;
   }

--- a/src/ui/screens/home/ViewHome.qml
+++ b/src/ui/screens/home/ViewHome.qml
@@ -106,8 +106,9 @@ MZFlickable {
             descriptionText: qsTrId("vpn.servers.currentLocation").arg(
                                  VPNCurrentServer.localizedExitCityName)
 
-            disableRowWhen: (VPNController.state !== VPNController.StateOn
-                             && VPNController.state !== VPNController.StateOff)
+            disableRowWhen: (VPNController.state !== VPNController.StateOn &&
+                            VPNController.state !== VPNController.StateOnPartial &&
+                            VPNController.state !== VPNController.StateOff)
             Layout.topMargin: 12
             contentChildren: [
 


### PR DESCRIPTION
So far we have removed the option to have show the serverlist in state on partial. 
Let's allow that, and keep the activation principal, so that a server switch in partial will result to stay in stateonpartial after the switch. 
This will cause a gui glitch but our pm specifically said he wants that despite that :) 

![output](https://github.com/user-attachments/assets/803ab5f4-8f78-4a15-93a1-35d4ee4ac93f)
