### PR TITLE
VPN-6829: add 2 missing imports

### DIFF
--- a/nebula/ui/components/inAppAuth/MZInAppAuthenticationPasswordCondition.qml
+++ b/nebula/ui/components/inAppAuth/MZInAppAuthenticationPasswordCondition.qml
@@ -8,6 +8,7 @@ import QtQuick.Layouts 1.14
 import Mozilla.Shared 1.0
 import components 0.1
 import components.forms 0.1
+import "qrc:/nebula/utils/MZAssetLookup.js" as MZAssetLookup
 
 RowLayout {
     id: root

--- a/src/ui/authenticationInApp/ViewAuthenticationVerificationSessionByEmailNeeded.qml
+++ b/src/ui/authenticationInApp/ViewAuthenticationVerificationSessionByEmailNeeded.qml
@@ -9,6 +9,7 @@ import Mozilla.Shared 1.0
 import Mozilla.VPN 1.0
 import components 0.1
 import components.inAppAuth 0.1
+import "qrc:/nebula/utils/MZAssetLookup.js" as MZAssetLookup
 
 MZInAppAuthenticationBase {
     id: authSignUp


### PR DESCRIPTION
## Description

I saw a warning in the logs for one of these, then audited [the PR that changed how we handle images](https://github.com/mozilla-mobile/mozilla-vpn-client/pull/10170/files) to confirm there were no other omissions - and I found one more.

## Reference

VPN-6829 (I just created this ticket for tracking purposes)

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
