### PR TITLE
VPN-6783: detect system theme changes

### DIFF
--- a/src/theme.cpp
+++ b/src/theme.cpp
@@ -37,6 +37,12 @@ Theme::Theme(QObject* parent) : QAbstractListModel(parent) {
             m_themes.clear();
             initialize(QmlEngineHolder::instance()->engine());
           });
+
+  connect(QGuiApplication::styleHints(), &QStyleHints::colorSchemeChanged, this,
+          []() {
+            // In VPN-6178, add code here to update the theme when the system
+            // theme changes (if the user has "system theme" selected).
+          });
 }
 
 Theme::~Theme() { MZ_COUNT_DTOR(Theme); }

--- a/src/theme.cpp
+++ b/src/theme.cpp
@@ -38,13 +38,16 @@ Theme::Theme(QObject* parent) : QAbstractListModel(parent) {
             initialize(QmlEngineHolder::instance()->engine());
           });
 
-#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
-  connect(QGuiApplication::styleHints(), &QStyleHints::colorSchemeChanged, this,
-          []() {
-            // In VPN-6178, add code here to update the theme when the system
-            // theme changes (if the user has "system theme" selected).
-          });
-#endif
+  // In VPN-6178, uncomment these next few lines and add code.
+  // #if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
+  //   connect(QGuiApplication::styleHints(), &QStyleHints::colorSchemeChanged,
+  //   this,
+  //           []() {
+  // Code gets added here. Code must update the theme when the system
+  // theme changes (if the user has "system theme" selected for their VPN
+  // theme).
+  //           });
+  // #endif
 }
 
 Theme::~Theme() { MZ_COUNT_DTOR(Theme); }

--- a/src/theme.cpp
+++ b/src/theme.cpp
@@ -38,11 +38,13 @@ Theme::Theme(QObject* parent) : QAbstractListModel(parent) {
             initialize(QmlEngineHolder::instance()->engine());
           });
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
   connect(QGuiApplication::styleHints(), &QStyleHints::colorSchemeChanged, this,
           []() {
             // In VPN-6178, add code here to update the theme when the system
             // theme changes (if the user has "system theme" selected).
           });
+#endif
 }
 
 Theme::~Theme() { MZ_COUNT_DTOR(Theme); }


### PR DESCRIPTION
## Description

Detect when the system theme changes. VPN-6178 will add the code that actually exposes this to the user.

This will not work on Qt version <6.5, to keep it in line with the [prior system color work](https://github.com/mozilla-mobile/mozilla-vpn-client/pull/10131).

## Reference

VPN-6783

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
