### PR TITLE
VPN-6830: Fix split tunnel on Windows with multihop

### DIFF
--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -112,8 +112,6 @@ bool Daemon::activate(const InterfaceConfig& config) {
     return false;
   }
 
-  prepareActivation(config);
-
   // Bring up the wireguard interface if not already done.
   if (!wgutils()->interfaceExists()) {
     // Create the interface.

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -36,10 +36,6 @@ class Daemon : public QObject {
   virtual bool deactivate(bool emitSignals = true);
   virtual QJsonObject getStatus();
 
-  // Callback before any Activating measure is done
-  virtual void prepareActivation(const InterfaceConfig& config){
-      Q_UNUSED(config)};
-
   QString logs();
   void cleanLogs();
 

--- a/src/platforms/windows/daemon/windowsdaemon.cpp
+++ b/src/platforms/windows/daemon/windowsdaemon.cpp
@@ -49,14 +49,6 @@ WindowsDaemon::~WindowsDaemon() {
   logger.debug() << "Daemon released";
 }
 
-void WindowsDaemon::prepareActivation(const InterfaceConfig& config) {
-  // Before creating the interface we need to check which adapter
-  // routes to the server endpoint. This will be selected as the outgoing
-  // interface for split-tunnelled traffic.
-  auto serveraddr = QHostAddress(config.m_serverIpv4AddrIn);
-  m_inetAdapterIndex = WindowsCommons::AdapterIndexTo(serveraddr);
-}
-
 bool WindowsDaemon::run(Op op, const InterfaceConfig& config) {
   if (!m_splitTunnelManager) {
     if (config.m_vpnDisabledApps.length() > 0) {
@@ -73,7 +65,25 @@ bool WindowsDaemon::run(Op op, const InterfaceConfig& config) {
     return true;
   }
   if (config.m_vpnDisabledApps.length() > 0) {
-    if (!m_splitTunnelManager->start(m_inetAdapterIndex)) {
+    // Before creating the interface we need to check which adapter routes to
+    // the entry server endpoint. This will be selected as the outgoing
+    // interface for split-tunnelled traffic.
+    QHostAddress entryServerAddr;
+    if (config.m_hopType == InterfaceConfig::HopType::SingleHop) {
+      entryServerAddr.setAddress(config.m_serverIpv4AddrIn);
+    } else if (config.m_hopType == InterfaceConfig::HopType::MultiHopExit) {
+      auto entry = m_connections.value(InterfaceConfig::HopType::MultiHopEntry);
+      entryServerAddr.setAddress(entry.m_config.m_serverIpv4AddrIn);
+    } else {
+      return true;
+    }
+
+    int inetAdapterIndex = WindowsCommons::AdapterIndexTo(entryServerAddr);
+    if (inetAdapterIndex < 0) {
+      emit backendFailure(DaemonError::ERROR_SPLIT_TUNNEL_START_FAILURE);
+    }
+
+    if (!m_splitTunnelManager->start(inetAdapterIndex)) {
       emit backendFailure(DaemonError::ERROR_SPLIT_TUNNEL_START_FAILURE);
     };
     if (!m_splitTunnelManager->excludeApps(config.m_vpnDisabledApps)) {

--- a/src/platforms/windows/daemon/windowsdaemon.h
+++ b/src/platforms/windows/daemon/windowsdaemon.h
@@ -22,8 +22,6 @@ class WindowsDaemon final : public Daemon {
   WindowsDaemon();
   ~WindowsDaemon();
 
-  void prepareActivation(const InterfaceConfig& config) override;
-
  protected:
   bool run(Op op, const InterfaceConfig& config) override;
   WireguardUtils* wgutils() const override { return m_wgutils.get(); }
@@ -37,8 +35,6 @@ class WindowsDaemon final : public Daemon {
     Active,
     Inactive,
   };
-
-  int m_inetAdapterIndex = -1;
 
   std::unique_ptr<WireguardUtilsWindows> m_wgutils;
   DnsUtilsWindows* m_dnsutils = nullptr;

--- a/src/platforms/windows/windowscommons.cpp
+++ b/src/platforms/windows/windowscommons.cpp
@@ -119,7 +119,8 @@ int WindowsCommons::AdapterIndexTo(const QHostAddress& dst) {
   DWORD index = 0;
   DWORD result = GetBestInterface(ipv4be, &index);
   if (result != NO_ERROR) {
-    WindowsUtils::windowsLog("Interface lookup failed");
+    logger.warning() << "Interface lookup failed:"
+                     << WindowsUtils::getErrorMessage(result);
     return -1;
   }
   logger.debug() << "Internet Adapter:" << index;


### PR DESCRIPTION
## Description
It seems that split tunneling on Windows is broken when used in combination with multihop. This seems to be caused by calling `prepareActivation()` upon activation of the exit hop. During this call, we try to lookup the interface that routes to the server address, but this is the VPN interface when examining the exit hop.

To fix this, we need to use the address of the entry server, which can be found in the `Daemon::m_connection` member.

While we're at it, we don't really need to explicitly call this `prepareActivation()` method before bringing up the interface, we can just do this whenever since we use the routing table to exclude Wireguard traffic from re-entering the tunnel.

Oh, and there was also a bug in the error logging in `WindowsCommons::AdapterIndexTo()` that we might as well fix.

## Reference
JIRA Issue [VPN-6830](https://mozilla-hub.atlassian.net/browse/VPN-6830)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-6830]: https://mozilla-hub.atlassian.net/browse/VPN-6830?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ