### PR TITLE
VPN-6706: fix timer after server unavailable

### DIFF
--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -526,6 +526,12 @@ void Controller::activateInternal(
   activateNext();
 }
 
+void Controller::startTimerIfInactive() {
+  if (m_connectedTimeInUTC == QDateTime()) {
+    m_connectedTimeInUTC = QDateTime::currentDateTimeUtc();
+  }
+}
+
 void Controller::clearConnectedTime() {
   if (!isSwitchingServer) {
     m_connectedTimeInUTC = QDateTime();
@@ -921,6 +927,13 @@ bool Controller::switchServers(const ServerData& serverData) {
     logger.debug() << "Server data changed but we are off";
     return false;
   }
+
+  // This next line fixes VPN-6706. Without this, the connection clock will
+  // never have started when the server switch comes after the "server
+  // unavailable" modal is shown. In that case, the server switch will have come
+  // before the initial server was fully connected, and thus before the timer
+  // was ever started. Hence, we start the timer here before we continue.
+  startTimerIfInactive();
 
   isSwitchingServer = true;
   m_nextServerData = serverData;

--- a/src/controller.h
+++ b/src/controller.h
@@ -199,6 +199,7 @@ class Controller : public QObject, public LogSerializer {
                         ServerSelectionPolicy serverSelectionPolicy,
                         ActivationPrincipal);
 
+  void startTimerIfInactive();
   void clearConnectedTime();
   void clearRetryCounter();
   void activateNext();

--- a/src/ui/popups/ServerUnavailablePopup.qml
+++ b/src/ui/popups/ServerUnavailablePopup.qml
@@ -24,6 +24,7 @@ MZSimplePopup {
     buttons: [
         MZButton {
             text: MZI18n.ServerUnavailableModalButtonLabel
+            objectName: "serverUnavailablePopup-button"
             Layout.fillWidth: true
             onClicked: {
                 MZNavigator.requestScreen(VPN.ScreenHome)

--- a/tests/functional/queries.js
+++ b/tests/functional/queries.js
@@ -90,6 +90,8 @@ const screenHome = {
   SERVER_LIST_BUTTON_LABEL:
       new QmlQueryComposer('//serverListButton-label-label'),
   SERVER_LIST_BUTTON: new QmlQueryComposer('//serverListButton-btn'),
+  SERVER_UNAVAILABLE_POPUP_BUTTON:
+      new QmlQueryComposer('//serverUnavailablePopup-button'),
   STACKVIEW: new QmlQueryComposer('//screenHome-stackView'),
 
   serverListView: {

--- a/tests/functional/servers/guardian_endpoints.js
+++ b/tests/functional/servers/guardian_endpoints.js
@@ -123,13 +123,13 @@ exports.endpoints = {
                   'ipv6_addr_in': '::1',
                   'weight': 3,
                   'include_in_country': true,
-                  'public_key': 'public-key',
+                  'public_key': 'public-key1',
                   'port_ranges':
                       [[53, 53], [4000, 33433], [33565, 51820], [52000, 60000]],
                   'ipv4_gateway': '127.0.0.1',
                   'ipv6_gateway': '::1'
                 }],
-                'public_key': 'public-key',
+                'public_key': 'public-key2',
                 'ipv4_gateway': '127.0.0.1',
                 'ipv6_gateway': '::1',
                 'ipv4_addr_in': '127.0.0.1',
@@ -147,7 +147,7 @@ exports.endpoints = {
                     'ipv6_addr_in': '::1',
                     'weight': 100,
                     'include_in_country': true,
-                    'public_key': 'public-key',
+                    'public_key': 'public-key3',
                     'port_ranges': [
                       [53, 53], [4000, 33433], [33565, 51820], [52000, 60000]
                     ],
@@ -155,7 +155,7 @@ exports.endpoints = {
                     'ipv6_gateway': '::1'
                   },
                 ],
-                'public_key': 'public-key',
+                'public_key': 'public-key4',
                 'ipv4_gateway': '127.0.0.1',
                 'ipv6_gateway': '::1',
                 'ipv4_addr_in': '127.0.0.1',
@@ -178,14 +178,14 @@ exports.endpoints = {
                   'ipv6_addr_in': '::1',
                   'weight': 100,
                   'include_in_country': true,
-                  'public_key': 'public-key',
+                  'public_key': 'public-key5',
                   'port_ranges':
                       [[53, 53], [4000, 33433], [33565, 51820], [52000, 60000]],
                   'ipv4_gateway': '127.0.0.1',
                   'ipv6_gateway': '::1'
                 },
               ],
-              'public_key': 'public-key',
+              'public_key': 'public-key6',
               'ipv4_gateway': '127.0.0.1',
               'ipv6_gateway': '::1',
               'ipv4_addr_in': '127.0.0.1',
@@ -207,14 +207,14 @@ exports.endpoints = {
                   'ipv6_addr_in': '::1',
                   'weight': 100,
                   'include_in_country': true,
-                  'public_key': 'public-key',
+                  'public_key': 'public-key7',
                   'port_ranges':
                       [[53, 53], [4000, 33433], [33565, 51820], [52000, 60000]],
                   'ipv4_gateway': '127.0.0.1',
                   'ipv6_gateway': '::1'
                 },
               ],
-              'public_key': 'public-key',
+              'public_key': 'public-key8',
               'ipv4_gateway': '127.0.0.1',
               'ipv6_gateway': '::1',
               'ipv4_addr_in': '127.0.0.1',
@@ -260,10 +260,7 @@ exports.endpoints = {
     '/api/v2/vpn/featurelist': {
       status: 200,
       body: {
-        featuresOverwrite: {
-          'enableUpdateServer': false,
-          'splitTunnel': true
-        },
+        featuresOverwrite: {'enableUpdateServer': false, 'splitTunnel': true},
         experimentalFeatures: {}
       }
     },


### PR DESCRIPTION
## Description

If a connection attempt results in a "server unavailable" modal, the user is encouraged to select a new server. However, that results in the timer being stuck at 0:00:00:
1) Since the first server never fully connected, the timer is never started
2) Since the second server is technically a server switch, the timer isn't touched when switching servers

Since this could be fragile, I added a test to make sure this doesn't break in the future. While writing that test:
- `forceServerUnavailable` got some parameters added to it, as the CLI command requires parameters (previously, this testing command was unused)
- I changed the stub server response to have different "public keys". We gray out unavailable servers based on their public key - so when we marked a server unavailable in our test, *all* servers were being marked unavailable because they shared a public key.
- I created a new helper function to prevent code duplication.

## Reference

VPN-6706

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
