### PR TITLE
Update CODEOWNERS per the new addon shared strings

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
-/addons/**/manifest.json @flodolo
+/addons/strings.yaml @flodolo
 /src/translations/strings.yaml @flodolo
 /src/translations/extras @flodolo
 


### PR DESCRIPTION
## Description

Strings should no longer be in the manifest files, but will be in the shared strings file - let's make sure that @flodolo reveiws those.

## Reference

VPN-6838

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
