### PR TITLE
VPN-6710: fix Android time

### DIFF
--- a/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/VPNService.kt
+++ b/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/VPNService.kt
@@ -108,7 +108,10 @@ class VPNService : android.net.VpnService() {
         set(value: Int) {
             field = value
             if (value > -1) {
-                mConnectionTime = System.currentTimeMillis()
+                if (!isAppChangingServers) {
+                    // Don't reset the timer on a server switch
+                    mConnectionTime = System.currentTimeMillis()
+                }
                 Log.i(tag, "Dispatch Daemon State -> connected")
                 mBinder.dispatchEvent(
                     CoreBinder.EVENTS.connected,

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -1048,7 +1048,9 @@ bool Controller::activate(const ServerData& serverData,
   // https://github.com/mozilla-mobile/mozilla-vpn-client/pull/9639, and caused
   // a bug on iOS where server switches stopped working. See more details in
   // VPN-6495.
-#ifndef MZ_IOS
+  // On Android, we need to skip this so that the client knows it is a
+  // server switch when appropriate.
+#ifndef MZ_MOBILE
   if (initiator != ExtensionUser) {
     setState(StateConnecting);
   }


### PR DESCRIPTION
## Description

This PR fixes the timer when relaunching the Android app after a silent server switch or a server location switch initiated by the user. (In both cases, we want the timer to continue counting up and not reset to zero. While this was working as expected while the app remained open, when the app was quit and re-launched the timer would change.)

There were two parts to this fix:
First - In `VPNService.kt`, do not reset the timer when it is a server switch.

However, that didn't fix the bug. I ended up rabbit holing on this for quite a while. Eventually in the logs I noticed additional controller state changes when doing a server switch on Android that didn't exist in similar server switches on iOS. And then I realized the bug is Android's version of #9733. While the bug on Android isn't as catastrophic as it was on iOS (which is probably why it hung around for a bit longer), it has the same root cause - an [additional state change that was recently added](https://github.com/mozilla-mobile/mozilla-vpn-client/pull/9639/files#diff-53fc727c3acacc0c0b7c531be394c8074b1211826f68cff4e8217b65c536ab8fR1073-R1075) was affecting mobile clients' abilities to determine if an activation was coming from a server switch or not - because we rely on using the current state in `Controller::Reason stateToReason(Controller::State state)` to determine if it's a server switch... but by the time we were getting there, we were in `StateConnecting` and not `StateServerSwitching`.

## Reference

VPN-6710

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
