### PR TITLE
Nit: Update asn1-rs crate and friends

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,9 +145,9 @@ checksum = "619743e34b5ba4e9703bba34deac3427c72507c7159f5fd030aea8cac0cfe341"
 
 [[package]]
 name = "asn1-rs"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
+checksum = "607495ec7113b178fbba7a6166a27f99e774359ef4823adbefd756b5b81d7970"
 dependencies = [
  "asn1-rs-derive",
  "asn1-rs-impl",
@@ -155,15 +155,15 @@ dependencies = [
  "nom",
  "num-traits",
  "rusticata-macros",
- "thiserror 1.0.69",
+ "thiserror 2.0.11",
  "time 0.3.36",
 ]
 
 [[package]]
 name = "asn1-rs-derive"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7378575ff571966e99a744addeff0bff98b8ada0dedf1956d59e634db95eaac1"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -438,9 +438,9 @@ checksum = "0e60eed09d8c01d3cee5b7d30acb059b76614c918fa0f992e0dd6eeb10daad6f"
 
 [[package]]
 name = "der-parser"
-version = "9.0.0"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
 dependencies = [
  "asn1-rs",
  "displaydoc",
@@ -1189,9 +1189,9 @@ dependencies = [
 
 [[package]]
 name = "oid-registry"
-version = "0.7.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d8034d9489cdaf79228eb9f6a3b8d7bb32ba00d6645ebd48eef4077ceb5bd9"
+checksum = "264c56d1492c13e769662197fb6b94e0a52abe52d27efac374615799a4bf453d"
 dependencies = [
  "asn1-rs",
 ]
@@ -2655,9 +2655,9 @@ dependencies = [
 
 [[package]]
 name = "x509-parser"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69"
+checksum = "4569f339c0c402346d4a75a9e39cf8dad310e287eef1ff56d4c68e5067f53460"
 dependencies = [
  "asn1-rs",
  "data-encoding",
@@ -2667,7 +2667,7 @@ dependencies = [
  "oid-registry",
  "ring",
  "rusticata-macros",
- "thiserror 1.0.69",
+ "thiserror 2.0.11",
  "time 0.3.36",
 ]
 

--- a/linux/flatpak/flatpak-vpn-crates.json
+++ b/linux/flatpak/flatpak-vpn-crates.json
@@ -210,27 +210,27 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/asn1-rs/asn1-rs-0.6.2.crate",
-        "sha256": "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048",
-        "dest": "cargo/vendor/asn1-rs-0.6.2"
+        "url": "https://static.crates.io/crates/asn1-rs/asn1-rs-0.7.0.crate",
+        "sha256": "607495ec7113b178fbba7a6166a27f99e774359ef4823adbefd756b5b81d7970",
+        "dest": "cargo/vendor/asn1-rs-0.7.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048\", \"files\": {}}",
-        "dest": "cargo/vendor/asn1-rs-0.6.2",
+        "contents": "{\"package\": \"607495ec7113b178fbba7a6166a27f99e774359ef4823adbefd756b5b81d7970\", \"files\": {}}",
+        "dest": "cargo/vendor/asn1-rs-0.7.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/asn1-rs-derive/asn1-rs-derive-0.5.0.crate",
-        "sha256": "7378575ff571966e99a744addeff0bff98b8ada0dedf1956d59e634db95eaac1",
-        "dest": "cargo/vendor/asn1-rs-derive-0.5.0"
+        "url": "https://static.crates.io/crates/asn1-rs-derive/asn1-rs-derive-0.6.0.crate",
+        "sha256": "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c",
+        "dest": "cargo/vendor/asn1-rs-derive-0.6.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"7378575ff571966e99a744addeff0bff98b8ada0dedf1956d59e634db95eaac1\", \"files\": {}}",
-        "dest": "cargo/vendor/asn1-rs-derive-0.5.0",
+        "contents": "{\"package\": \"3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c\", \"files\": {}}",
+        "dest": "cargo/vendor/asn1-rs-derive-0.6.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -626,14 +626,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/der-parser/der-parser-9.0.0.crate",
-        "sha256": "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553",
-        "dest": "cargo/vendor/der-parser-9.0.0"
+        "url": "https://static.crates.io/crates/der-parser/der-parser-10.0.0.crate",
+        "sha256": "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6",
+        "dest": "cargo/vendor/der-parser-10.0.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553\", \"files\": {}}",
-        "dest": "cargo/vendor/der-parser-9.0.0",
+        "contents": "{\"package\": \"07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6\", \"files\": {}}",
+        "dest": "cargo/vendor/der-parser-10.0.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -1588,14 +1588,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/oid-registry/oid-registry-0.7.1.crate",
-        "sha256": "a8d8034d9489cdaf79228eb9f6a3b8d7bb32ba00d6645ebd48eef4077ceb5bd9",
-        "dest": "cargo/vendor/oid-registry-0.7.1"
+        "url": "https://static.crates.io/crates/oid-registry/oid-registry-0.8.0.crate",
+        "sha256": "264c56d1492c13e769662197fb6b94e0a52abe52d27efac374615799a4bf453d",
+        "dest": "cargo/vendor/oid-registry-0.8.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"a8d8034d9489cdaf79228eb9f6a3b8d7bb32ba00d6645ebd48eef4077ceb5bd9\", \"files\": {}}",
-        "dest": "cargo/vendor/oid-registry-0.7.1",
+        "contents": "{\"package\": \"264c56d1492c13e769662197fb6b94e0a52abe52d27efac374615799a4bf453d\", \"files\": {}}",
+        "dest": "cargo/vendor/oid-registry-0.8.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -3564,14 +3564,14 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/x509-parser/x509-parser-0.16.0.crate",
-        "sha256": "fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69",
-        "dest": "cargo/vendor/x509-parser-0.16.0"
+        "url": "https://static.crates.io/crates/x509-parser/x509-parser-0.17.0.crate",
+        "sha256": "4569f339c0c402346d4a75a9e39cf8dad310e287eef1ff56d4c68e5067f53460",
+        "dest": "cargo/vendor/x509-parser-0.17.0"
     },
     {
         "type": "inline",
-        "contents": "{\"package\": \"fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69\", \"files\": {}}",
-        "dest": "cargo/vendor/x509-parser-0.16.0",
+        "contents": "{\"package\": \"4569f339c0c402346d4a75a9e39cf8dad310e287eef1ff56d4c68e5067f53460\", \"files\": {}}",
+        "dest": "cargo/vendor/x509-parser-0.17.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {

--- a/signature/Cargo.toml
+++ b/signature/Cargo.toml
@@ -4,14 +4,14 @@ version = "0.2.0"
 edition = "2021"
 
 [dependencies]
-asn1-rs = { version = "0.6.2", features=["datetime"] }
-oid-registry = "0.7"
+asn1-rs = { version = "0.7.0", features=["datetime"] }
+oid-registry = "0.8"
 data-encoding = "2.7.0"
 ffi-support = "0.4.4"
 thiserror = "2.0.11"
 hex = "0.4"
 ring = "0.17.8"
-x509-parser = { version = "0.16.0", features = ["verify", "validate"] }
+x509-parser = { version = "0.17.0", features = ["verify", "validate"] }
 
 [lib]
 name = "signature"


### PR DESCRIPTION
## Description
It looks like we have a bit of a dependency tangle that dependabot isn't able to resolve. In particular it seems like the `asn1-rs`, `oid-registry` and `x509-parser` crates all need to be updated together to cross some kind of API change. So, let's update these dependencies manually so that we can group them together into the same PR.

## Reference
Conflicting dependabot PRs:
- #10251
- #10222
- #10200

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
