### PR TITLE
VPN-6671 Add a warning for qt 6.8.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,6 +138,7 @@ find_package(Qt6 COMPONENTS
     Xml
     Svg
 )
+include("scripts/cmake/check_qt_breakage.cmake")
 
 if(NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Emscripten" AND
    NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Android")

--- a/scripts/cmake/check_qt_breakage.cmake
+++ b/scripts/cmake/check_qt_breakage.cmake
@@ -1,0 +1,16 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# This File Prints a warning if someone tries to compile Qt with a version
+# that we know the VPN will break with. 
+
+if( ${Qt6_VERSION} VERSION_EQUAL 6.8.0)
+    message(AUTHOR_WARNING 
+        "*******************  WARNING  ********************** \n"
+        "Qt 6.8.0 is known to be broken and will fail to load Mozila VPN \n"
+        "Please consider upgrading to at least Qt 6.8.1 \n"
+        "See: https://bugreports.qt.io/browse/QTBUG-129500 \n"
+        "****************************************************"
+    )
+endif()


### PR DESCRIPTION
## Description
As seen in those issues: 
https://github.com/mozilla-mobile/mozilla-vpn-client/issues/9989
https://github.com/mozilla-mobile/mozilla-vpn-client/issues/9966

We do know it's broken, it's not our fault. 
All we can do here is throw a warning for folks to use 6.8.1 instead :) 



