### PR TITLE
VPN-6437: stop extra metric recordings

### DIFF
--- a/src/platforms/android/androidcontroller.cpp
+++ b/src/platforms/android/androidcontroller.cpp
@@ -114,13 +114,9 @@ AndroidController::AndroidController() {
         Controller* controller = MozillaVPN::instance()->controller();
         controller->startHandshakeTimer();
 
-        BOOL isOnboarding =
-            MozillaVPN::instance()->state() == App::StateOnboarding;
-        if (isOnboarding) {
-          granted
-              ? mozilla::glean::outcome::onboarding_ntwrk_perm_granted.record()
-              : mozilla::glean::outcome::onboarding_ntwrk_perm_denied.record();
-        }
+        granted
+            ? mozilla::glean::outcome::onboarding_ntwrk_perm_granted.record()
+            : mozilla::glean::outcome::onboarding_ntwrk_perm_denied.record();
       },
       Qt::QueuedConnection);
 }

--- a/src/platforms/android/androidcontroller.cpp
+++ b/src/platforms/android/androidcontroller.cpp
@@ -114,9 +114,13 @@ AndroidController::AndroidController() {
         Controller* controller = MozillaVPN::instance()->controller();
         controller->startHandshakeTimer();
 
-        granted
-            ? mozilla::glean::outcome::onboarding_ntwrk_perm_granted.record()
-            : mozilla::glean::outcome::onboarding_ntwrk_perm_denied.record();
+        BOOL isOnboarding =
+            MozillaVPN::instance()->state() == App::StateOnboarding;
+        if (isOnboarding) {
+          granted
+              ? mozilla::glean::outcome::onboarding_ntwrk_perm_granted.record()
+              : mozilla::glean::outcome::onboarding_ntwrk_perm_denied.record();
+        }
       },
       Qt::QueuedConnection);
 }

--- a/src/platforms/ios/ioscontroller.mm
+++ b/src/platforms/ios/ioscontroller.mm
@@ -206,8 +206,11 @@ void IOSController::activate(const InterfaceConfig& config, Controller::Reason r
         Controller* controller = MozillaVPN::instance()->controller();
         controller->startHandshakeTimer();
 
-        granted ? mozilla::glean::outcome::onboarding_ntwrk_perm_granted.record()
-                : mozilla::glean::outcome::onboarding_ntwrk_perm_denied.record();
+        BOOL isOnboarding = MozillaVPN::instance()->state() == App::StateOnboarding;
+        if (isOnboarding) {
+          granted ? mozilla::glean::outcome::onboarding_ntwrk_perm_granted.record()
+                  : mozilla::glean::outcome::onboarding_ntwrk_perm_denied.record();
+        }
       }];
 }
 


### PR DESCRIPTION
## Description

This callback is being hit on every VPN activation, so it was sending the metric way too often. Wrapping this is an "is it onboarding?" statement fixes the issue.

## Reference

VPN-6437

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
