### PR TITLE
VPN-6753: Reset menu title after location selection

### DIFF
--- a/src/ui/screens/home/servers/ServerList.qml
+++ b/src/ui/screens/home/servers/ServerList.qml
@@ -30,6 +30,7 @@ FocusScope {
         }
 
         segmentedNav[currentServer.whichHop] = [countryCode, cityName, localizedCityName];
+        menu.title = qsTrId("vpn.servers.selectLocation");
         multiHopStackView.pop();
     }
 


### PR DESCRIPTION
## Description

The menu title text is [manually set when pushing in](https://github.com/mozilla-mobile/mozilla-vpn-client/blob/main/src/ui/screens/home/ViewMultiHop.qml#L62), but wasn't being touched when popping back out. This adds "setting the menu title" to every pop after a multihop server was selected.

[Video of fix](https://github.com/user-attachments/assets/983f1b92-f976-4b6a-a7f9-274af31ed1ae)

## Reference

VPN-6753

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
