### PR TITLE
fix: use proper signing format for authenticode

### DIFF
--- a/taskcluster/kinds/signing/kind.yml
+++ b/taskcluster/kinds/signing/kind.yml
@@ -38,7 +38,7 @@ tasks:
             by-build-type:
                 android.*: gcp_prod_autograph_apk
                 macos.*: macapp
-                windows/opt: gcp_prod_autograph_authenticode_202404
+                windows/opt: gcp_prod_autograph_authenticode_202412
                 addons/opt: gcp_prod_autograph_rsa
         treeherder:
             job-symbol:


### PR DESCRIPTION
I typo'ed this one in https://github.com/mozilla-mobile/mozilla-vpn-client/pull/10198 =\