### PR TITLE
VPN-6828 - Remove uneeded Window destruction

### DIFF
--- a/src/commands/commandui.cpp
+++ b/src/commands/commandui.cpp
@@ -301,7 +301,7 @@ int CommandUI::run(QStringList& tokens) {
       // just sent).
       MZGlean::shutdown();
 
-      emit MozillaVPN::instance()->aboutToQuit();
+      MozillaVPN::instance()->aboutToQuit();
     });
 #endif
 
@@ -328,7 +328,6 @@ int CommandUI::run(QStringList& tokens) {
       WindowsUtils::setDockIcon(window, QImage(":/ui/resources/logo-dock.png"));
       WindowsUtils::setTitleBarIcon(window,
                                     Theme::instance()->getTitleBarIcon());
-      WindowsUtils::forceWindowRedraw(window);
     };
     QObject::connect(Theme::instance(), &Theme::changed,
                      updateWindowDecoration);

--- a/src/platforms/windows/windowsutils.cpp
+++ b/src/platforms/windows/windowsutils.cpp
@@ -141,9 +141,3 @@ void WindowsUtils::updateTitleBarColor(QWindow* window, bool darkMode) {
       sizeof(defaultColor)));
   Q_ASSERT(ok);
 }
-
-void WindowsUtils::forceWindowRedraw(QWindow* w) {
-  auto const windowHandle = (HWND)w->winId();
-  ShowWindow(windowHandle, SW_MINIMIZE);
-  ShowWindow(windowHandle, SW_RESTORE);
-}

--- a/src/platforms/windows/windowsutils.h
+++ b/src/platforms/windows/windowsutils.h
@@ -26,7 +26,6 @@ class WindowsUtils final {
 
   static void setTitleBarIcon(QWindow* window, const QImage& icon);
   static void setDockIcon(QWindow* window, const QImage& icon);
-  static void forceWindowRedraw(QWindow* w);
   /**
    *
    * @brief Set the Color for the titlebar, the color of the current theme


### PR DESCRIPTION
## Description
Hiding and Re-rendering the window can cause the flicker seen in the issue. The best thing, that was completly unneeded. 



![output](https://github.com/user-attachments/assets/1f24b190-19cc-40af-8734-1e8eccf68c63)
