### PR TITLE
FXVPN-383 (?) Proxy: Enable TCP Keepalive

### DIFF
--- a/extension/socks5proxy/src/socks5.cpp
+++ b/extension/socks5proxy/src/socks5.cpp
@@ -32,6 +32,10 @@ void Socks5::newConnection(T* server) {
     if (!socket) {
       return;
     }
+    if constexpr (std::is_same_v<T, QTcpSocket>) {
+      socket->setSocketOption(QAbstractSocket::LowDelayOption, 1);
+      socket->setSocketOption(QAbstractSocket::KeepAliveOption, 1);
+    }
 
     auto const con = new Socks5Connection(socket);
     connect(con, &QObject::destroyed, this, [this, server]() {

--- a/extension/socks5proxy/src/socks5connection.cpp
+++ b/extension/socks5proxy/src/socks5connection.cpp
@@ -458,7 +458,7 @@ void Socks5Connection::configureOutSocket(quint16 port) {
   m_hostLookupStack.append(m_destAddress.toString());
   m_outSocket = new QTcpSocket(this);
   emit setupOutSocket(m_outSocket, m_destAddress);
-
+  m_outSocket->setSocketOption(QAbstractSocket::KeepAliveOption, 1);
   m_outSocket->connectToHost(m_destAddress, port);
 
   connect(m_outSocket, &QTcpSocket::connected, this, [this]() {


### PR DESCRIPTION
## Description

When Excluding youtube i noticed quite a bit of buffering, as in the background fetching just stalls. Yt is loading this via http 1.1 so it is going to be holding a bunch of tcp connections open to re-use. The devtools list a lot of fetches aborting with "NS_BINDING_ABORTED". 
So i tried enabling keepalive and this problem goes away :) 
