### PR TITLE
VPN-6854: fix data throughput Glean issues

### DIFF
--- a/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/VPNService.kt
+++ b/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/VPNService.kt
@@ -54,6 +54,7 @@ class VPNService : android.net.VpnService() {
             var wasTimerJustStarted = (millisUntilFinished == mBackgroundPingTimerMSec)
             if (!wasTimerJustStarted && isUsingShortTimerSessionPing && shouldRecordTimerAndEndMetrics) {
                 Log.i(tag, "Sending daemon_timer ping (on short timer debug schedule)")
+                recordDataTransferMetrics()
                 Pings.daemonsession.submit(
                     Pings.daemonsessionReasonCodes.daemonTimer,
                 )

--- a/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/VPNService.kt
+++ b/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/VPNService.kt
@@ -322,7 +322,7 @@ class VPNService : android.net.VpnService() {
                 // Record data transfer metrics, as we're switching servers/configs and this data will get reset
                 // Data metrics must be recorded prior to wgTurnOff, or we can't get data from the config
                 if (isSuperDooperMetricsActive) {
-                  recordDataTransferMetrics()
+                    recordDataTransferMetrics()
                 }
 
                 wgTurnOff(currentTunnelHandle)
@@ -368,13 +368,13 @@ class VPNService : android.net.VpnService() {
 
         // If changing server, connection health is still running
         if (!isChangingServers) {
-          mConnectionHealth.start(
-              jServer.getString("ipv4AddrIn"),
-              jServer.getString("ipv4Gateway"),
-              json.getString("dns"),
-              fallbackIpv4,
-              isSuperDooperMetricsActive,
-          )
+            mConnectionHealth.start(
+                jServer.getString("ipv4AddrIn"),
+                jServer.getString("ipv4Gateway"),
+                json.getString("dns"),
+                fallbackIpv4,
+                isSuperDooperMetricsActive,
+            )
         }
 
         // For `isGleanDebugTagActive` and `isSuperDooperMetricsActive` to work,
@@ -409,7 +409,7 @@ class VPNService : android.net.VpnService() {
                 Pings.daemonsessionReasonCodes.daemonStart,
             )
         } else {
-          Log.v(tag, "Skipping recording of start telemetry")
+            Log.v(tag, "Skipping recording of start telemetry")
         }
         mMetricsTimer.cancel() // if this is a server switch, time is already running and must be reset
         mMetricsTimer.start()
@@ -465,7 +465,7 @@ class VPNService : android.net.VpnService() {
 
     fun turnOff() {
         Log.v(tag, "Try to disable tunnel")
-        // turnOff is not called when switching locations, doing a silent server switch from app, or doing a silent server switch from daemon... 
+        // turnOff is not called when switching locations, doing a silent server switch from app, or doing a silent server switch from daemon...
         // Thus we always want to record end-of-session metrics here, and send the ping below.
         if (isSuperDooperMetricsActive) {
             // Data metrics must be recorded prior to wgTurnOff, or we can't get data from the config
@@ -497,7 +497,7 @@ class VPNService : android.net.VpnService() {
             // metrics.
             Session.daemonSessionId.generateAndSet()
         } else {
-          Log.v(tag, "Skipping ending metrics")
+            Log.v(tag, "Skipping ending metrics")
         }
         mMetricsTimer.cancel()
     }

--- a/src/connectionhealth.cpp
+++ b/src/connectionhealth.cpp
@@ -45,23 +45,6 @@ constexpr const char* PING_WELL_KNOWN_ANYCAST_DNS = "194.242.2.2";
 ConnectionHealth::ConnectionHealth() : m_dnsPingSender(QHostAddress()) {
   MZ_COUNT_CTOR(ConnectionHealth);
 
-// On mobile, these metrics are recorded in the daemon process.
-#ifndef MZ_MOBILE
-  m_metricsTimer.setSingleShot(false);
-
-  if (SettingsHolder::instance()->shortTimerSessionPing()) {
-    m_metricsTimer.setInterval(
-        std::chrono::duration_cast<std::chrono::minutes>(3min));
-  } else {
-    m_metricsTimer.setInterval(
-        std::chrono::duration_cast<std::chrono::hours>(3h));
-  }
-  connect(&m_metricsTimer, &QTimer::timeout, this, []() {
-    emit MozillaVPN::instance()->controller()->recordDataTransferTelemetry();
-  });
-  m_metricsTimer.start();
-#endif
-
   m_noSignalTimer.setSingleShot(true);
 
   m_settlingTimer.setSingleShot(true);

--- a/src/connectionhealth.h
+++ b/src/connectionhealth.h
@@ -78,7 +78,6 @@ class ConnectionHealth final : public QObject {
   QTimer m_settlingTimer;
   QTimer m_noSignalTimer;
   QTimer m_healthCheckTimer;
-  QTimer m_metricsTimer;
 
   PingHelper m_pingHelper;
 


### PR DESCRIPTION
## Description

We record the data transfer telemetry from wireguard. This wireguard data only resets every time there is a new peer (VPN activation, silent server switch, location switch, etc.). We were sending it in every timer ping - which means we were counting data multiple times, as the subsequent timer/end ping would report the cumulative data since the user connected to the peer.

While there are probably ways to make fancy data science dashboards that only use the latest one reported, it seems easiest to fix this by only reporting data transfer when the peer is changed (or the VPN is turned off). (This also has a benefit of allowing adhoc metrics to be run more easily.)

Desktop - We just need to remove the data transfer metrics from the timer ping.

Android - This one was a bit harder, as there were some underlying data issues I noticed (also fixed in this PR):
1) First, same as desktop - needed to stop recording data transfer metrics on the timer ping.
2) On debug timer, we sometimes had an extra Timer ping right after activation. I added a 1 second grace period to `wasTimerJustStarted` to fix this.
3) We were sometimes missing end and timer metrics: This was because `shouldRecordTimerAndEndMetrics` was very, very wrong. On every activation in Android (from app, location switch, silent server switch from app, silent server switch from daemon) we run through `turnOn`. However, `turnOff` is only hit when the actual VPN is coming down - not when doing a silent server switch or location switch. Thus, we always want to record ending metrics in `turnOff`, and we want to skip start metrics in `turnOn` if it's a silent server switch or location switch. Ultimately I removed the `shouldRecordTimerAndEndMetrics`, as it was no longer useful.
4) We weren't recording data metrics when switching locations or doing a silent server switch - and so we needed to capture that data.

iOS - we do not record this data on iOS, so nothing to do here.

I've run through a bunch of tests on macOS and Android -
1) Turn on, download some data / visit a webpage, turn off.
1) Turn on, download some data, wait for timer ping, download some data / visit a webpage, wait for another timer ping, turn off.
1) Turn on, download some data, wait for timer ping, location switch, download some data / visit a webpage, wait for another timer ping, turn off.
1) Turn on, download some data, wait for timer ping, silent server switch via app, download some data / visit a webpage, wait for another timer ping, turn off.
1) (Android only) Turn on, download some data, wait for timer ping, silent server switch via daemon, download some data / visit a webpage, wait for another timer ping, turn off.

If there are any other scenarios to consider, please let me know.

## Reference

VPN-6854

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
