### PR TITLE
VPN-6842: invalid server fix

### DIFF
--- a/docs/Troubleshooting/inspector.md
+++ b/docs/Troubleshooting/inspector.md
@@ -31,7 +31,6 @@ On desktop, use `ws://localhost:8765`.
     3. Note the iOS device's IP address. (Settings app -> Wi-Fi -> ⓘ by network name. See "IP Address" in "IPv4 Address" section)
 3. On the desktop computer, go to the [inspector page](
 https://mozilla-mobile.github.io/mozilla-vpn-client/inspector/).
-On desktop, use `ws://localhost:8765`.
 4. On the iOS device, hard quit the Mozilla VPN app (if it is running), and relaunch the app from a cold start. (The actual VPN connection should remain off.)
 5. On the Desktop computer, put `ws://[IP addresss]:8765` (example: `ws://192.168.1.131:8765`) in the `Inspector Address` field, click the blue `->` button, and wait for the connection.
 

--- a/src/platforms/ios/ioscontroller.swift
+++ b/src/platforms/ios/ioscontroller.swift
@@ -249,7 +249,7 @@ public class IOSControllerImpl: NSObject {
                     IOSControllerImpl.logger.info(message: "Loading the tunnel succeeded")
 
                     do {
-                        if (reason == 1 /* ReasonSwitching */) {
+                        if (reason == 1 /* ReasonSwitching */ && TunnelManager.session?.status == .connected) {
                             let settings = config.asWgQuickConfig()
                             let message = TunnelMessage.configurationSwitch(settings)
                             IOSControllerImpl.logger.info(message: "Sending new message \(message)")

--- a/src/platforms/ios/iostunnel.swift
+++ b/src/platforms/ios/iostunnel.swift
@@ -152,6 +152,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider, SilentServerSwitching {
 
             case .invalidState:
                 // Must never happen
+                self.logger.error(message: "Starting tunnel failed with invalidState")
                 fatalError()
             }
         }


### PR DESCRIPTION
## Description

Ultimately this is pretty simple - We had been assuming that switching the config only happened when the VPN was active. However, when the server/city wasn't available, the VPN was never activated - and thus switching the server was happening when no VPN was active, and getting us into this terrible state

Unfortunately, I wasn't able to figure out precisely how this is happening. I can confirm that when we send the update message from `iosController` to the `iostunnel`, it eventually sends an `update` message to `WireGuardAdapter` - which immediately returns an `.invalidState` back to `iostunnel` (because the adapter wasn't in a `started` state), which in turn doesn’t do anything for the `ioscontroller`. `Even if we run a `disconnectOnErrorCallback` in this situation it doesn’t fully fix the issue. I am not quite sure how either iOS or Wireguard's non-standard (for iOS) packet filtering is getting activated in this situation - which I think is the source of this issue, that one half (but not the other).  is getting activated.

This behavior - try to turn on VPN, essentially bork the iOS device's network capabilities until rebooting (or removing the VPN in system settings) - has been seen in many similar corner case situations. It's my hope that this fix stamps out this class of bugs.

Added some logging in `iostunnel.swift`. Also a small cleanup in `inspector.md`.

## Reference

VPN-6842

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
