### PR TITLE
VPN-6892: Fix "reinstate messages" debug option

### DIFF
--- a/src/addons/manager/addonmanager.cpp
+++ b/src/addons/manager/addonmanager.cpp
@@ -419,6 +419,7 @@ QJSValue AddonManager::reduce(QJSValue callback, QJSValue initialValue) const {
 
 // Undismisses any dismissed messages and marks all messages as unread
 void AddonManager::reinstateMessages() const {
+  logger.debug() << "Reinstating all messages";
   SettingsHolder* settingsHolder = SettingsHolder::instance();
   Q_ASSERT(settingsHolder);
 
@@ -426,7 +427,12 @@ void AddonManager::reinstateMessages() const {
   // It only needs to live for the scope of this function.
   SettingGroup* messageSettingGroup =
       SettingsManager::instance()->createSettingGroup(
-          ADDON_MESSAGE_SETTINGS_GROUP);
+          QString("%1/%2")
+              .arg(Constants::ADDONS_SETTINGS_GROUP)
+              .arg(ADDON_MESSAGE_SETTINGS_GROUP),
+          true,  // remove when reset
+          false  // sensitive setting
+      );
   messageSettingGroup->remove();
 }
 

--- a/src/ui/screens/getHelp/developerMenu/ViewDeveloperMenu.qml
+++ b/src/ui/screens/getHelp/developerMenu/ViewDeveloperMenu.qml
@@ -230,6 +230,7 @@ MZViewBase {
             text: "Reinstate messages"
             onClicked: {
                 MZAddonManager.reinstateMessages()
+                restartRequired.isVisible = true
             }
         }
 


### PR DESCRIPTION
## Description

The "reinstate messages" button wasn't working. We were using a different style of creating the setting group than in other places - once this was updated the modern method, it worked.

Also, the user must relaunch the client after pressing the "reinstate messages" button, so clicking the button now shows the pre-existing "restart required" component.

Also added a tiny bit of logging.

## Reference

VPN-6892

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
