### PR TITLE
VPN-6856: Fix QML hot reloader tools

### DIFF
--- a/src/inspector/inspectorhotreloader.cpp
+++ b/src/inspector/inspectorhotreloader.cpp
@@ -26,21 +26,6 @@ InspectorHotreloader::InspectorHotreloader(QQmlEngine* target)
     : m_target(target) {
   m_target->addUrlInterceptor(this);
   new NavigatorReloader(qApp);
-  QDir dataDir(
-      QStandardPaths::writableLocation(QStandardPaths::AppLocalDataLocation));
-  m_qml_folder = dataDir.absoluteFilePath("hot_reload");
-
-  QDir dir(m_qml_folder);
-  if (!dir.exists()) {
-    dir.mkpath(".");
-  }
-  // On shutdown cleanup all things.
-  QObject::connect(qApp, &QCoreApplication::aboutToQuit, [this] {
-    QDir dir(m_qml_folder);
-    if (dir.exists()) {
-      dir.removeRecursively();
-    }
-  });
 }
 
 QUrl InspectorHotreloader::intercept(
@@ -58,70 +43,20 @@ void InspectorHotreloader::annonceReplacedFile(const QUrl& path) {
   logger.debug() << "Announced redirect! : " << path.fileName() << " as ->"
                  << path.toString();
 
-  if (path.scheme() != "http" && path.scheme() != "file" &&
-      path.scheme() != "qrc") {
+  if (path.scheme() != "file" && path.scheme() != "qrc") {
     logger.error() << "Unexpected File Scheme in: " << path.toString();
     return;
   }
-  if (path.scheme() == "file" || path.scheme() == "qrc") {
-    // If it's a file, just load it!
-    m_target->clearComponentCache();
-    m_announced_files.insert(path.fileName(), path);
-    Navigator::instance()->reloadCurrentScreen();
-    return;
-  }
-  // If it is a remote file, download to a temp file and then come back to
-  // announce it!
-  fetchAndAnnounce(path);
-}
-
-void InspectorHotreloader::fetchAndAnnounce(const QUrl& path) {
-  if (path.scheme() != "http") {
-    logger.error() << "Unexpected File Scheme in: " << path.toString();
-    return;
-  }
-  TaskFunction* dummy_task = new TaskFunction([]() {});
-  NetworkRequest* request = new NetworkRequest(dummy_task, 200);
-  request->get(path.toString());
-
-  QObject::connect(
-      request, &NetworkRequest::requestFailed,
-      [dummy_task](QNetworkReply::NetworkError error, const QByteArray&) {
-        dummy_task->deleteLater();
-        logger.error() << "Get qml content failed" << error;
-      });
-
-  QObject::connect(
-      request, &NetworkRequest::requestCompleted,
-      [this, path, dummy_task](const QByteArray& data) {
-        dummy_task->deleteLater();
-        auto temp_path = QString("%1/%2").arg(m_qml_folder, path.fileName());
-        auto temp_file = new QFile(temp_path);
-        temp_file->open(QIODevice::WriteOnly);
-        if (!temp_file->write(data)) {
-          logger.warning() << "Unable to write to file:"
-                           << temp_file->fileName();
-          return;
-        }
-        if (!temp_file->flush()) {
-          logger.warning() << "Unable to flush to file:"
-                           << temp_file->fileName();
-          return;
-        }
-        temp_file->close();
-        QFileInfo info(temp_path);
-        annonceReplacedFile(QUrl::fromLocalFile(info.absoluteFilePath()));
-      });
+  // If it's a file, just load it!
+  m_target->clearComponentCache();
+  m_announced_files.insert(path.fileName(), path);
+  Navigator::instance()->reloadCurrentScreen();
+  return;
 }
 
 void InspectorHotreloader::resetAllFiles() {
   logger.debug() << "Resetting hot reloaded files";
 
-  QDir dir(m_qml_folder);
-  if (dir.exists()) {
-    logger.debug() << "Removing hot reloaded files from disk";
-    dir.removeRecursively();
-  }
   m_target->clearComponentCache();
   m_announced_files.clear();
   Navigator::instance()->reloadCurrentScreen();

--- a/src/inspector/inspectorhotreloader.h
+++ b/src/inspector/inspectorhotreloader.h
@@ -22,7 +22,7 @@ class InspectorHotreloader : public QQmlAbstractUrlInterceptor {
    * Will redirect all requests that match path.filename
    * to that URL
    *
-   * supported schemes: qrc://, file://, http://
+   * supported schemes: qrc://, file://
    *
    * @param path - The Replacement Path
    */
@@ -34,15 +34,6 @@ class InspectorHotreloader : public QQmlAbstractUrlInterceptor {
   void resetAllFiles();
 
   /**
-   * @brief Announces a qml replacement path is available
-   * Will download a file, store it in a temp directory and
-   * redirect all matching files to that.
-   *
-   * @param path - The Replacement Path
-   */
-  void fetchAndAnnounce(const QUrl& path);
-
-  /**
    * @brief Closes and re-opens the QML window
    * forcing a refresh of all components.
    *
@@ -52,7 +43,6 @@ class InspectorHotreloader : public QQmlAbstractUrlInterceptor {
  private:
   QQmlEngine* m_target = nullptr;
   QMap<QString, QUrl> m_announced_files;
-  QString m_qml_folder;
 };
 
 #endif  // MOZILLA_VPN_INSPECTORHOTRELOADER_H


### PR DESCRIPTION
## Description
I've been trying to get the QML hot reloader working on my Linux machine, and I ran into a couple of difficulties. First the HTTP transport wasn't working outside of localhost, which kind of defeats the point of using HTTP at all, and secondly, we have too many files in the git tree for the `chokidar` library to handle, so we need to restrict the watch list to just QML content.

## Reference
JIRA issue [VPN-6856](https://mozilla-hub.atlassian.net/browse/VPN-6856)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-6856]: https://mozilla-hub.atlassian.net/browse/VPN-6856?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ