### PR TITLE
(Windows) Add manifest for accurate OS version detection

### DIFF
--- a/src/models/devicemodel.cpp
+++ b/src/models/devicemodel.cpp
@@ -294,10 +294,10 @@ void DeviceModel::logSerialize(QIODevice* device) {
   out << "Machine arch -> " << QSysInfo::currentCpuArchitecture() << Qt::endl;
   out << "OS -> " << QSysInfo::productType() << Qt::endl;
 #ifdef MZ_WINDOWS
-  out << "OS Version -> " << WindowsUtils::windowsVersion() << Qt::endl;
-#else
-  out << "OS Version -> " << QSysInfo::productVersion() << Qt::endl;
+  out << "OS Version (Reg) -> " << WindowsUtils::windowsVersion() << Qt::endl;
 #endif
+  out << "OS Version -> " << QSysInfo::productVersion() << Qt::endl;
+
 #ifdef MZ_ANDROID
   out << "SDK Version -> " << AndroidCommons::getSDKVersion() << Qt::endl;
   out << "Manufacturer -> " << AndroidCommons::GetManufacturer() << Qt::endl;

--- a/windows/version.rc.in
+++ b/windows/version.rc.in
@@ -12,6 +12,9 @@
 
 IDI_ICON1       ICON "@CMAKE_SOURCE_DIR@/src/ui/resources/logo.ico"
 
+// Embed application manifest as resource (ID 1 is standard for app manifests)
+1 RT_MANIFEST "@CMAKE_SOURCE_DIR@/windows/vpn.manifest"
+
 // See https://docs.microsoft.com/en-us/windows/win32/menurc/versioninfo-resource
 // for a list of all the neat metadata we can set in this file.
 VS_VERSION_INFO VERSIONINFO

--- a/windows/vpn.manifest
+++ b/windows/vpn.manifest
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0"
+          xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
+
+  <trustInfo>
+    <security>
+      <requestedPrivileges>
+        <requestedExecutionLevel level="asInvoker" uiAccess="false"/>
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+      <application>
+         <!-- Max Tested: Windows 11 24H2 -->
+         <maxversiontested Id="10.0.26100.0"/>
+         <!-- Supports Windows 10 and Windows 11 -->
+         <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+      </application>
+   </compatibility>
+
+  <asmv3:application>
+    <asmv3:windowsSettings xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">
+      <dpiAwareness>PerMonitorV2</dpiAwareness>
+    </asmv3:windowsSettings>
+  </asmv3:application>
+
+</assembly>


### PR DESCRIPTION
Windows lies about the OS version to applications for compatibility
unless weexplicitly declare tested versions via manifest. Without
maxversiontested, we get fake version numbers.

#### Before: 
<img width="1052" alt="before" src="https://github.com/user-attachments/assets/487be76c-1590-4152-934a-0d963aa85aa9" />

#### After: 
<img width="1048" alt="after" src="https://github.com/user-attachments/assets/501f821b-6b22-4893-b756-2360afd52f01" />

