### PR TITLE
socksproxy: Fix localhost DNS and use-after-free crash

### DIFF
--- a/extension/socks5proxy/bin/windowsbypass.cpp
+++ b/extension/socks5proxy/bin/windowsbypass.cpp
@@ -305,8 +305,8 @@ void WindowsBypass::updateNameserver() {
     }
   }
   // Sort the nameservers by it's metric smallest first
-  std::ranges::sort(dnsNameservers,
-                    [](auto a, auto b) { return a.metric < b.metric; });
+  std::sort(dnsNameservers.begin(), dnsNameservers.end(),
+            [](auto a, auto b) { return a.metric < b.metric; });
   QList<QHostAddress> selectedNameServers(dnsNameservers.length());
   for (const auto& sortedDNSServer : qAsConst(dnsNameservers)) {
     selectedNameServers.append(sortedDNSServer.addr);

--- a/extension/socks5proxy/bin/windowsbypass.cpp
+++ b/extension/socks5proxy/bin/windowsbypass.cpp
@@ -8,9 +8,6 @@
 #include <fwpmu.h>
 #include <iphlpapi.h>
 #include <netioapi.h>
-#include <qforeach.h>
-#include <qhostaddress.h>
-#include <qttypetraits.h>
 #include <windows.h>
 #include <winsock2.h>
 

--- a/extension/socks5proxy/bin/windowsbypass.cpp
+++ b/extension/socks5proxy/bin/windowsbypass.cpp
@@ -18,6 +18,7 @@
 #include <QSettings>
 #include <QUuid>
 #include <algorithm>
+#include <ranges>
 
 #include "socks5.h"
 #include "winutils.h"

--- a/extension/socks5proxy/bin/windowsbypass.h
+++ b/extension/socks5proxy/bin/windowsbypass.h
@@ -45,7 +45,6 @@ class WindowsBypass final : public QObject {
     unsigned long ipv6metric;
     QHostAddress ipv4addr;
     QHostAddress ipv6addr;
-    QList<QHostAddress> dnsAddr;
   };
 
   QHash<quint64, InterfaceData> m_interfaceData;

--- a/extension/socks5proxy/bin/windowsbypass.h
+++ b/extension/socks5proxy/bin/windowsbypass.h
@@ -45,7 +45,7 @@ class WindowsBypass final : public QObject {
     unsigned long ipv6metric;
     QHostAddress ipv4addr;
     QHostAddress ipv6addr;
-    QHostAddress dnsAddr;
+    QList<QHostAddress> dnsAddr;
   };
 
   QHash<quint64, InterfaceData> m_interfaceData;

--- a/extension/socks5proxy/src/dnsresolver.cpp
+++ b/extension/socks5proxy/src/dnsresolver.cpp
@@ -100,12 +100,12 @@ void DNSResolver::resolveAsync(const QString& hostname, QObject* parent) {
   m_requests.insert(parent, hostname);
   m_requestLock.unlock();
 
-  auto callback =
-      [](void *arg, int status, int timeouts, struct ares_addrinfo *results) {
-        QObject* ctx = static_cast<QObject*>(arg);
-        auto instance = DNSResolver::instance();
-        instance->addressInfoCallback(ctx, status, timeouts, results);
-      };
+  auto callback = [](void* arg, int status, int timeouts,
+                     struct ares_addrinfo* results) {
+    QObject* ctx = static_cast<QObject*>(arg);
+    auto instance = DNSResolver::instance();
+    instance->addressInfoCallback(ctx, status, timeouts, results);
+  };
 
   auto name = hostname.toStdString();
   struct ares_addrinfo_hints hints;

--- a/extension/socks5proxy/src/dnsresolver.cpp
+++ b/extension/socks5proxy/src/dnsresolver.cpp
@@ -2,8 +2,7 @@
 #include "dnsresolver.h"
 
 #include <ares.h>
-#include <qforeach.h>
-#include <qhostaddress.h>
+#include <qttypetraits.h>
 
 #include <QCoreApplication>
 #include <QObject>
@@ -94,7 +93,7 @@ void DNSResolver::resolveAsync(const QString& hostname,
 void DNSResolver::setNameserver(const QList<QHostAddress>& dnsList) {
   QString buffer{};
 
-  foreach (const QHostAddress& dns, dnsList) {
+  foreach (const QHostAddress& dns, qAsConst(dnsList)) {
     if (dns.isNull()) {
       continue;
     }

--- a/extension/socks5proxy/src/dnsresolver.cpp
+++ b/extension/socks5proxy/src/dnsresolver.cpp
@@ -2,7 +2,6 @@
 #include "dnsresolver.h"
 
 #include <ares.h>
-#include <qttypetraits.h>
 
 #include <QCoreApplication>
 #include <QObject>

--- a/extension/socks5proxy/src/dnsresolver.h
+++ b/extension/socks5proxy/src/dnsresolver.h
@@ -28,7 +28,7 @@ class DNSResolver {
    */
   void resolveAsync(const QString& hostname, Socks5Connection* parent);
 
-  void setNameserver(const QHostAddress& addr);
+  void setNameserver(const QList<QHostAddress>& addr);
 
  private:
   static void addressInfoCallback(void* arg, int status, int timeouts,
@@ -36,6 +36,4 @@ class DNSResolver {
   void shutdownAres();
 
   ares_channeldata* mChannel = nullptr;
-
-  QHostAddress m_nameserver;
 };

--- a/extension/socks5proxy/src/dnsresolver.h
+++ b/extension/socks5proxy/src/dnsresolver.h
@@ -42,7 +42,7 @@ class DNSResolver : public QObject {
                            struct ares_addrinfo* result);
   void shutdownAres();
 
-  QHash<QObject*,QString> m_requests;
+  QHash<QObject*, QString> m_requests;
   QMutex m_requestLock;
 
   ares_channeldata* mChannel = nullptr;

--- a/extension/socks5proxy/src/dnsresolver.h
+++ b/extension/socks5proxy/src/dnsresolver.h
@@ -5,14 +5,18 @@
 #pragma once
 
 #include <QGlobalStatic>
+#include <QHash>
 #include <QHostAddress>
-#include <mutex>
+#include <QMutex>
+#include <QObject>
 
 struct ares_channeldata;
 class ares_addrinfo;
 class Socks5Connection;
 
-class DNSResolver {
+class DNSResolver : public QObject {
+  Q_OBJECT
+
  public:
   DNSResolver();
   ~DNSResolver();
@@ -23,17 +27,23 @@ class DNSResolver {
    * @brief Queues up a DNS Query to get Resolved.
    *
    * @param hostname - The requested Hostname
-   * @param parent - The Socks5Connection to notify. Will call
-   * Socks5Connection::onHostnameResolved(QHostAddress) when done.
+   * @param parent - The QObject to notify. Will call the
+   * onHostnameResolved(QHostAddress) method when done.
    */
-  void resolveAsync(const QString& hostname, Socks5Connection* parent);
+  void resolveAsync(const QString& hostname, QObject* parent);
 
   void setNameserver(const QList<QHostAddress>& addr);
 
+ private slots:
+  void requestDestroyed();
+
  private:
-  static void addressInfoCallback(void* arg, int status, int timeouts,
-                                  struct ares_addrinfo* result);
+  void addressInfoCallback(QObject* ctx, int status, int timeouts,
+                           struct ares_addrinfo* result);
   void shutdownAres();
+
+  QHash<QObject*,QString> m_requests;
+  QMutex m_requestLock;
 
   ares_channeldata* mChannel = nullptr;
 };


### PR DESCRIPTION
## Description
In continuing my testing with the socksproxy and the DNS resolution woes, I came across a couple of bugs that can lead to breakage.

The first issue is that when selecting DNS servers, when the first choice is a link-local IPv6 address, we don't set a scope ID in the address, which can prevent `c-ares` from being able to connect to it. We can fix this just by calling `QHostAddress::setScopeId()` when building the list of DNS servers. While implementing this, I also performed a bit of cleanup by moving the DNS server selection into `WindowsBypass::updateNamserver()`

The second issue, which was a bit trickier to track down, is that we have a use-after-free bug in the socks proxy that can occur between the `c-ares` resolver thread and the Qt thread. This happens when the `Socks5Connection` is closed before DNS resolution finishes, in which case the `arg` provided to the c-ares callback points to freed memory. To resolve this, we need to verify that the `QObject` is valid before invoking the `onResolutionFinished()` method. We add a `QHash` map to store the objects that requested resolution, and use the `QObject::destroyed()` signal to track when they are garabge collected. 

## Reference
Based upon PR #10317 by @strseb
JIRA Issues:
- [VPN-6891](https://mozilla-hub.atlassian.net/browse/VPN-6891)
- [VPN-6890](https://mozilla-hub.atlassian.net/browse/VPN-6890)
- [VPN-6874](https://mozilla-hub.atlassian.net/browse/VPN-6874)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-6891]: https://mozilla-hub.atlassian.net/browse/VPN-6891?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[VPN-6890]: https://mozilla-hub.atlassian.net/browse/VPN-6890?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[VPN-6874]: https://mozilla-hub.atlassian.net/browse/VPN-6874?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ