### PR TITLE
VPN-6965: missing navbar background on dark mode

### DIFF
--- a/nebula/ui/components/navigationBar/MZBottomNavigationBarButton.qml
+++ b/nebula/ui/components/navigationBar/MZBottomNavigationBarButton.qml
@@ -38,8 +38,7 @@ MZIconButton {
         anchors.fill: parent
         visible: checked
         radius: parent.height / 2
-        opacity: .2
-        color: MZTheme.colors.bgColorStronger
+        color: MZTheme.colors.primaryHovered
     }
 
     Image {


### PR DESCRIPTION
## Description

The opacity was killing the button background effect on dark mode. I replaced it with an equivalent color, so light mode has no perceptible changes.

#### Before
<img width="161" alt="Screenshot 1" src="https://github.com/user-attachments/assets/8bf7d8ba-d805-49cc-994d-6b66a1b63fdb" /><img width="156" alt="Screenshot 2" src="https://github.com/user-attachments/assets/97bc35d5-23bc-4eea-b19d-00155088ad12" />

#### After
<img width="160" alt="Screenshot 7" src="https://github.com/user-attachments/assets/dc9d2be3-73ac-4f07-912b-877263d773ff" /><img width="160" alt="Screenshot 6" src="https://github.com/user-attachments/assets/f97828d4-2d8c-4508-a507-0b42637c652c" />


## Reference

VPN-6965

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
