### PR TITLE
VPN-6954 - remove most metrics, extend others

### DIFF
--- a/src/connectionhealth.h
+++ b/src/connectionhealth.h
@@ -92,14 +92,7 @@ class ConnectionHealth final : public QObject {
   QString m_currentGateway;
   QString m_deviceAddress;
 
-#ifndef MZ_MOBILE
-  qint64 m_metricsTimerId = -1;
-#endif
-
-  void startTimingDistributionMetric(ConnectionStability stability);
-  void stopTimingDistributionMetric(ConnectionStability stability);
-  void recordMetrics(ConnectionStability oldStability,
-                     ConnectionStability newStability);
+  void recordMetrics(ConnectionStability stability);
 
 #ifdef UNIT_TEST
   friend class TestConnectionHealth;

--- a/src/platforms/ios/ConnectionHealth.swift
+++ b/src/platforms/ios/ConnectionHealth.swift
@@ -71,7 +71,7 @@ class ConnectionHealth {
         logger.info(message: "Creating PingAnalyzer")
         let _ = PingAnalyzer(pingAddress: pingAddress) { (connectivity, error) in
             guard let connectivity = connectivity else {
-                self.logger.error(message: "PingAnalyzer returned error: " + error?.localizedDescription ?? "no error returned")
+                self.logger.error(message: "PingAnalyzer returned error: " + (error?.localizedDescription ?? "no error returned"))
                 return
             }
 

--- a/src/telemetry/metrics.yaml
+++ b/src/telemetry/metrics.yaml
@@ -738,115 +738,6 @@ connection_health:
     unit: bytes
     histogram_type: exponential
 
-  changed_to_no_signal:
-    type: event
-    lifetime: ping
-    send_in_pings:
-      - vpnsession
-      - daemonsession
-    description: |
-      The connection status changed to no signal.
-
-      This event is recorded in both main application and daemon.
-      The logic and cadence of health checks for each of these
-      is not the same.
-
-      A no signal event happens when the connection is showing issues,
-      and a silent switch will not address the issue. Or when the connection
-      is showing issues and there have been previous silent switches which
-      did not address the issue.
-    bugs:
-      - https://bugzilla.mozilla.org/show_bug.cgi?id=1711123
-      - https://mozilla-hub.atlassian.net/browse/VPN-5860
-    data_reviews:
-      - https://bugzilla.mozilla.org/show_bug.cgi?id=1711123#c1
-      - https://github.com/mozilla-mobile/mozilla-vpn-client/pull/9057#pullrequestreview-1868746289
-    data_sensitivity:
-      - technical
-    notification_emails:
-      - mcleinman@mozilla.com
-      - vpn-telemetry@mozilla.com
-    expires: 2025-04-15
-
-  changed_to_unstable:
-    type: event
-    lifetime: ping
-    send_in_pings:
-      - vpnsession
-      - daemonsession
-    description: |
-      The connection status changed to unstable.
-
-      This event is recorded in both main application and daemon.
-      The logic and cadence of health checks for each of these
-      is not the same.
-
-      An unstable event happens when the connection is showing issues,
-      but silent switches may still address the issue.
-    bugs:
-      - https://bugzilla.mozilla.org/show_bug.cgi?id=1711123
-      - https://mozilla-hub.atlassian.net/browse/VPN-5860
-    data_reviews:
-      - https://bugzilla.mozilla.org/show_bug.cgi?id=1711123#c1
-      - https://github.com/mozilla-mobile/mozilla-vpn-client/pull/9057#pullrequestreview-1868746289
-    data_sensitivity:
-      - technical
-    notification_emails:
-      - mcleinman@mozilla.com
-      - vpn-telemetry@mozilla.com
-    expires: 2025-04-15
-
-  changed_to_stable:
-    type: event
-    lifetime: ping
-    send_in_pings:
-      - vpnsession
-      - daemonsession
-    description: |
-      The connection status changed to stable.
-
-      This event is recorded in both main application and daemon.
-      The logic and cadence of health checks for each of these
-      is not the same.
-
-      Stable status is when the app is not in a no signal or unstable
-      connection state.
-    bugs:
-      - https://bugzilla.mozilla.org/show_bug.cgi?id=1711123
-      - https://mozilla-hub.atlassian.net/browse/VPN-5860
-    data_reviews:
-      - https://bugzilla.mozilla.org/show_bug.cgi?id=1711123#c1
-      - https://github.com/mozilla-mobile/mozilla-vpn-client/pull/9057#pullrequestreview-1868746289
-    data_sensitivity:
-      - technical
-    notification_emails:
-      - mcleinman@mozilla.com
-      - vpn-telemetry@mozilla.com
-    expires: 2025-04-15
-
-  changed_to_pending:
-    type: event
-    lifetime: ping
-    send_in_pings:
-      - daemonsession
-    description: |
-      (iOS only) The connection status changed to pending.
-
-      This event is recorded in daemon.
-
-      Pending status is when the app is first started or when there is
-      no internet.
-    bugs:
-      - https://mozilla-hub.atlassian.net/browse/VPN-6406
-    data_reviews:
-      - https://github.com/mozilla-mobile/mozilla-vpn-client/pull/9593#issuecomment-2159109154
-    data_sensitivity:
-      - technical
-    notification_emails:
-      - mcleinman@mozilla.com
-      - vpn-telemetry@mozilla.com
-    expires: 2025-04-15
-
   no_signal_count:
     type: counter
     lifetime: ping
@@ -872,7 +763,7 @@ connection_health:
     notification_emails:
       - mcleinman@mozilla.com
       - vpn-telemetry@mozilla.com
-    expires: 2025-04-15
+    expires: never
 
   unstable_count:
     type: counter
@@ -899,7 +790,7 @@ connection_health:
     notification_emails:
       - mcleinman@mozilla.com
       - vpn-telemetry@mozilla.com
-    expires: 2025-04-15
+    expires: never
 
   stable_count:
     type: counter
@@ -926,7 +817,7 @@ connection_health:
     notification_emails:
       - mcleinman@mozilla.com
       - vpn-telemetry@mozilla.com
-    expires: 2025-04-15
+    expires: never
 
   pending_count:
     type: counter
@@ -951,117 +842,7 @@ connection_health:
     notification_emails:
       - mcleinman@mozilla.com
       - vpn-telemetry@mozilla.com
-    expires: 2025-04-15
-
-  no_signal_time:
-    type: timing_distribution
-    lifetime: ping
-    send_in_pings:
-      - vpnsession
-      - daemonsession
-    description: |
-      Time spent in no signal state.
-
-      Only collected on desktop for vpnsession, as mobile apps
-      frequently are relaunched during VPN sessions. It is
-      collected in daemonsession for mobile clients.
-    bugs:
-      - https://mozilla-hub.atlassian.net/browse/VPN-5860
-    data_reviews:
-      - https://github.com/mozilla-mobile/mozilla-vpn-client/pull/9057#pullrequestreview-1868746289
-    data_sensitivity:
-      - technical
-    notification_emails:
-      - mcleinman@mozilla.com
-      - vpn-telemetry@mozilla.com
-    expires: 2025-04-15
-
-  unstable_time:
-    type: timing_distribution
-    lifetime: ping
-    send_in_pings:
-      - vpnsession
-      - daemonsession
-    description: |
-      Time spent in unstable state.
-
-      Only collected on desktop for vpnsession, as mobile apps
-      frequently are relaunched during VPN sessions. It is
-      collected in daemonsession for mobile clients.
-    bugs:
-      - https://mozilla-hub.atlassian.net/browse/VPN-5860
-    data_reviews:
-      - https://github.com/mozilla-mobile/mozilla-vpn-client/pull/9057#pullrequestreview-1868746289
-    data_sensitivity:
-      - technical
-    notification_emails:
-      - mcleinman@mozilla.com
-      - vpn-telemetry@mozilla.com
-    expires: 2025-04-15
-
-  stable_time:
-    type: timing_distribution
-    lifetime: ping
-    send_in_pings:
-      - vpnsession
-      - daemonsession
-    description: |
-      Time spent in stable state.
-
-      Only collected on desktop for vpnsession, as mobile apps
-      frequently are relaunched during VPN sessions. It is
-      collected in daemonsession for mobile clients.
-    bugs:
-      - https://mozilla-hub.atlassian.net/browse/VPN-5860
-    data_reviews:
-      - https://github.com/mozilla-mobile/mozilla-vpn-client/pull/9057#pullrequestreview-1868746289
-    data_sensitivity:
-      - technical
-    notification_emails:
-      - mcleinman@mozilla.com
-      - vpn-telemetry@mozilla.com
-    expires: 2025-04-15
-
-  pending_time:
-    type: timing_distribution
-    lifetime: ping
-    send_in_pings:
-      - daemonsession
-    description: |
-      (iOS only) Time spent in pending state.
-    bugs:
-      - https://mozilla-hub.atlassian.net/browse/VPN-6406
-    data_reviews:
-      - https://github.com/mozilla-mobile/mozilla-vpn-client/pull/9593#issuecomment-2159109154
-    data_sensitivity:
-      - technical
-    notification_emails:
-      - mcleinman@mozilla.com
-      - vpn-telemetry@mozilla.com
-    expires: 2025-04-15
-
-  ping_analyzer_error:
-    type: event
-    lifetime: ping
-    send_in_pings:
-      - daemonsession
-    description: |
-      The iOS PingAnalyzer returned an error.
-    bugs:
-      - https://mozilla-hub.atlassian.net/browse/VPN-6406
-    data_reviews:
-      - https://github.com/mozilla-mobile/mozilla-vpn-client/pull/9593#issuecomment-2159109154
-    data_sensitivity:
-      - technical
-    notification_emails:
-      - mcleinman@mozilla.com
-      - vpn-telemetry@mozilla.com
-    expires: 2025-06-30
-    extra_keys:
-      error_message:
-        description: |
-          Error type
-        type: string
+    expires: never
 
 web_authentication:
   started:

--- a/tests/unit/testconnectionhealth.cpp
+++ b/tests/unit/testconnectionhealth.cpp
@@ -92,16 +92,12 @@ void TestConnectionHealth::testTelemetry() {
   ConnectionHealth connectionHealth;
 
   // Nothing recorded at start.
-  metricsTestErrorAndChange(0, 0, 0);
   metricsTestCount(0, 0, 0);
-  metricsTestTimespan(0, 0, 0);
 
   // Shouldn't do anything if controller state isn't on.
   connectionHealth.startActive("", "");
   connectionHealth.stop();
-  metricsTestErrorAndChange(0, 0, 0);
   metricsTestCount(0, 0, 0);
-  metricsTestTimespan(0, 0, 0);
 
   // Activate controller, which allows recording
   TestHelper::controllerState = Controller::StateOn;
@@ -109,77 +105,20 @@ void TestConnectionHealth::testTelemetry() {
   // Currently unstable connection
   connectionHealth.setStability(ConnectionHealth::Unstable);
   connectionHealth.startActive("", "");
-  metricsTestErrorAndChange(0, 1, 0);
   metricsTestCount(0, 1, 0);
-  metricsTestTimespan(0, 0, 0);
 
   // Connections changes to stable
   connectionHealth.setStability(ConnectionHealth::ConnectionStability::Stable);
-  metricsTestErrorAndChange(1, 1, 0);
   metricsTestCount(1, 1, 0);
-  metricsTestTimespan(0, 1, 0);
 
   // Connections changes to no signal
   connectionHealth.setStability(
       ConnectionHealth::ConnectionStability::NoSignal);
-  metricsTestErrorAndChange(1, 1, 1);
   metricsTestCount(1, 1, 1);
-  metricsTestTimespan(1, 1, 0);
 
   // Stops (stopping resets status to stable)
   connectionHealth.stop();
-  metricsTestErrorAndChange(1, 1, 1);
   metricsTestCount(1, 1, 1);
-  metricsTestTimespan(1, 1, 1);
-}
-
-void TestConnectionHealth::metricsTestTimespan(int expectedStablePeriods,
-                                               int expectedUnstablePeriods,
-                                               int expectedNoSignalPeriods) {
-  // test the 3 timespans
-  // Expect one timespan for each period except the current one.
-  QCOMPARE(getTimingDistCount(
-               mozilla::glean::connection_health::stable_time.testGetValue()),
-           expectedStablePeriods);
-  QCOMPARE(getTimingDistCount(
-               mozilla::glean::connection_health::unstable_time.testGetValue()),
-           expectedUnstablePeriods);
-  QCOMPARE(
-      getTimingDistCount(
-          mozilla::glean::connection_health::no_signal_time.testGetValue()),
-      expectedNoSignalPeriods);
-}
-
-void TestConnectionHealth::metricsTestErrorAndChange(
-    int expectedStablePeriods, int expectedUnstablePeriods,
-    int expectedNoSignalPeriods) {
-  // test for no errors
-  QCOMPARE(
-      mozilla::glean::connection_health::stable_time.testGetNumRecordedErrors(
-          ErrorType::InvalidState),
-      0);
-  QCOMPARE(
-      mozilla::glean::connection_health::unstable_time.testGetNumRecordedErrors(
-          ErrorType::InvalidState),
-      0);
-  QCOMPARE(mozilla::glean::connection_health::no_signal_time
-               .testGetNumRecordedErrors(ErrorType::InvalidState),
-           0);
-
-  // test the 3 events
-  // Expect a "change to" event for each period
-  auto changeToStableEvents =
-      mozilla::glean::connection_health::changed_to_stable.testGetValue();
-  auto changeToUnstableEvents =
-      mozilla::glean::connection_health::changed_to_unstable.testGetValue();
-  auto changeToNoSignalEvents =
-      mozilla::glean::connection_health::changed_to_no_signal.testGetValue();
-  QCOMPARE(changeToStableEvents.isArray(), true);
-  QCOMPARE(changeToStableEvents.toArray().count(), expectedStablePeriods);
-  QCOMPARE(changeToUnstableEvents.isArray(), true);
-  QCOMPARE(changeToUnstableEvents.toArray().count(), expectedUnstablePeriods);
-  QCOMPARE(changeToNoSignalEvents.isArray(), true);
-  QCOMPARE(changeToNoSignalEvents.toArray().count(), expectedNoSignalPeriods);
 }
 
 void TestConnectionHealth::metricsTestCount(int expectedStablePeriods,
@@ -199,21 +138,6 @@ void TestConnectionHealth::metricsTestCount(int expectedStablePeriods,
   QCOMPARE(unstableCount.toInt(), expectedUnstablePeriods);
   QCOMPARE(noSignalCount.isDouble(), true);
   QCOMPARE(noSignalCount.toInt(), expectedNoSignalPeriods);
-}
-
-// Count the number of timing distribution samples that were recorded.
-int TestConnectionHealth::getTimingDistCount(const QJsonValue& metric) {
-  QJsonObject values = metric["values"].toObject();
-  int count = 0;
-  for (auto i = values.constBegin(); i != values.constEnd(); ++i) {
-    bool okay = false;
-    qlonglong key = i.key().toLongLong(&okay, 10);
-    if (!okay) {
-      continue;
-    }
-    count += i.value().toInt();
-  }
-  return count;
 }
 
 static TestConnectionHealth s_testConnectionHealth;

--- a/tests/unit/testconnectionhealth.h
+++ b/tests/unit/testconnectionhealth.h
@@ -40,13 +40,6 @@ class TestConnectionHealth final : public TestHelper {
 
  private:
   SettingsHolder* m_settingsHolder = nullptr;
-  int getTimingDistCount(const QJsonValue& metric);
-  void metricsTestErrorAndChange(int expectedStablePeriods,
-                                 int expectedUnstablePeriods,
-                                 int expectedNoSignalPeriods);
   void metricsTestCount(int expectedStablePeriods, int expectedUnstablePeriods,
                         int expectedNoSignalPeriods);
-  void metricsTestTimespan(int expectedStablePeriods,
-                           int expectedUnstablePeriods,
-                           int expectedNoSignalPeriods);
 };


### PR DESCRIPTION
## Description

We created a range of connection health metrics as we weren't sure which ones would be most useful. At this point, they've expired, and we know which ones we want to extend: the connection health counts.

This PR removes a bunch of metrics, and extends the others.

I looked at the count metrics, and they seem solid explainer of health. I'll be updating our dashboards to use them as part of VPN-5991. The [pinganalyzer error](https://mozilla.cloud.looker.com/x/H8X3cZDDdn7sRqjVy6PFnH) affects about 150 people per day, which isn't enough to worry about at the moment.

## Reference

VPN-6954

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
