### PR TITLE
VPN-6968 - dark mode touch ups

### DIFF
--- a/nebula/ui/components/MZTextBlock.qml
+++ b/nebula/ui/components/MZTextBlock.qml
@@ -12,6 +12,7 @@ Text {
     color: MZTheme.colors.fontColor
     font.family: MZTheme.theme.fontInterFamily
     font.pixelSize: MZTheme.theme.fontSizeSmall
+    linkColor: MZTheme.colors.normalButtonDefault
     lineHeightMode: Text.FixedHeight
     lineHeight: 21
     wrapMode: Text.Wrap

--- a/src/ui/screens/settings/ViewAppearance.qml
+++ b/src/ui/screens/settings/ViewAppearance.qml
@@ -93,7 +93,7 @@ MZViewBase {
                     MZTextBlock {
                         text: MZI18n.SettingsAppearanceAutomaticDescription
                         Layout.fillWidth: true
-                        visible: radioButtonName === "automatic"
+                        visible: radioButtonName === "automaticAppearanceRadioButton"
                     }
                 }
             }


### PR DESCRIPTION
## Description

Fixes two bugs described in the ticket.

#### Link color (and doesn't mess up light mode)
<img width="159" alt="Screenshot 16" src="https://github.com/user-attachments/assets/2deb2f5c-ea6b-433e-8ee0-326964ec661c" /><img width="164" alt="Screenshot 15" src="https://github.com/user-attachments/assets/42b6837b-0629-47a1-b6a7-d25f8d14cb2e" />

I confirmed it doesn't mess up the other place we use `linkColor` on a `Text` element (the underlined links here):
<img width="159" alt="Screenshot 14" src="https://github.com/user-attachments/assets/976e206f-ff1a-484d-be23-cd4aa2b9a510" /><img width="157" alt="Screenshot 13" src="https://github.com/user-attachments/assets/b4f5ce2e-18aa-4db8-8de4-8adeca7afe37" />

#### Missing text on theme selection screen
(I changed the object names fairly last minute, and I missed updating one spot.)
<img width="159" alt="Screenshot 18" src="https://github.com/user-attachments/assets/e4cd32b1-d534-4f5c-82b8-d12210d80acf" /><img width="157" alt="Screenshot 17" src="https://github.com/user-attachments/assets/90a59170-92fb-49de-bb1f-1ec302667bfd" />


## Reference

VPN-6968

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
