### PR TITLE
VPN-6971: Implement theme detection fallback on Linux via XDG portal

### DIFF
--- a/src/cmake/linux.cmake
+++ b/src/cmake/linux.cmake
@@ -26,6 +26,8 @@ target_sources(mozillavpn PRIVATE
     ${CMAKE_SOURCE_DIR}/src/platforms/linux/linuxsystemtraynotificationhandler.h
     ${CMAKE_SOURCE_DIR}/src/platforms/linux/linuxutils.cpp
     ${CMAKE_SOURCE_DIR}/src/platforms/linux/linuxutils.h
+    ${CMAKE_SOURCE_DIR}/src/platforms/linux/xdgappearance.cpp
+    ${CMAKE_SOURCE_DIR}/src/platforms/linux/xdgappearance.h
     ${CMAKE_SOURCE_DIR}/src/platforms/linux/xdgcryptosettings.cpp
     ${CMAKE_SOURCE_DIR}/src/platforms/linux/xdgcryptosettings.h
     ${CMAKE_SOURCE_DIR}/src/platforms/linux/xdgportal.cpp

--- a/src/feature/featurelistcallback.h
+++ b/src/feature/featurelistcallback.h
@@ -191,7 +191,9 @@ bool FeatureCallback_proxyCanTurnOn() {
 }
 
 bool FeatureCallback_themeSelectionIncludesAutomatic() {
-#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
+#if defined(MZ_LINUX)
+  return true;
+#elif QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
   return true;
 #else
   // The API we're using isn't available below Qt 6.5, so this feature will not

--- a/src/platforms/linux/xdgappearance.cpp
+++ b/src/platforms/linux/xdgappearance.cpp
@@ -4,10 +4,10 @@
 
 #include "xdgappearance.h"
 
+#include <QDBusReply>
+
 #include "leakdetector.h"
 #include "logger.h"
-
-#include <QDBusReply>
 
 constexpr const char* XDG_NAMESPACE_APPEARANCE = "org.freedesktop.appearance";
 
@@ -23,9 +23,7 @@ XdgAppearance::XdgAppearance(QObject* parent)
           this, SLOT(xdgSettingChanged(QString, QString, QDBusVariant)));
 }
 
-XdgAppearance::~XdgAppearance() {
-  MZ_COUNT_DTOR(XdgAppearance);
-}
+XdgAppearance::~XdgAppearance() { MZ_COUNT_DTOR(XdgAppearance); }
 
 uint XdgAppearance::colorScheme() { return readValueUint("color-scheme"); }
 
@@ -54,7 +52,7 @@ void XdgAppearance::xdgSettingChanged(const QString& ns, const QString& key,
     return;
   }
   QVariant qv = value.variant();
-  logger.debug() << "Appearance changed" <<key << "->" << qv.toString();
+  logger.debug() << "Appearance changed:" << key << "->" << qv.toString();
   if (key == "color-scheme") {
     emit colorSchemeChanged();
   } else if (key == "accent-color") {

--- a/src/platforms/linux/xdgappearance.cpp
+++ b/src/platforms/linux/xdgappearance.cpp
@@ -1,0 +1,65 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "xdgappearance.h"
+
+#include "leakdetector.h"
+#include "logger.h"
+
+#include <QDBusReply>
+
+constexpr const char* XDG_NAMESPACE_APPEARANCE = "org.freedesktop.appearance";
+
+namespace {
+Logger logger("XdgAppearance");
+}  // namespace
+
+XdgAppearance::XdgAppearance(QObject* parent)
+    : XdgPortal(XDG_PORTAL_SETTINGS, parent) {
+  MZ_COUNT_CTOR(XdgAppearance);
+
+  connect(&m_portal, SIGNAL(SettingChanged(QString, QString, QDBusVariant)),
+          this, SLOT(xdgSettingChanged(QString, QString, QDBusVariant)));
+}
+
+XdgAppearance::~XdgAppearance() {
+  MZ_COUNT_DTOR(XdgAppearance);
+}
+
+uint XdgAppearance::colorScheme() { return readValueUint("color-scheme"); }
+
+uint XdgAppearance::accentColor() { return readValueUint("accent-color"); }
+
+uint XdgAppearance::contrast() { return readValueUint("contrast"); }
+
+uint XdgAppearance::readValueUint(const QString& name) {
+  QList<QVariant> args;
+  args.append(QVariant(XDG_NAMESPACE_APPEARANCE));
+  args.append(QVariant(name));
+  QDBusReply<QDBusVariant> reply =
+      m_portal.callWithArgumentList(QDBus::Block, "Read", args);
+  if (!reply.isValid()) {
+    logger.error() << "Failed to read" << name << reply.error().message();
+    return 0;
+  }
+
+  QDBusVariant result = qvariant_cast<QDBusVariant>(reply.value().variant());
+  return result.variant().toUInt();
+}
+
+void XdgAppearance::xdgSettingChanged(const QString& ns, const QString& key,
+                                      const QDBusVariant& value) {
+  if (ns != XDG_NAMESPACE_APPEARANCE) {
+    return;
+  }
+  QVariant qv = value.variant();
+  logger.debug() << "Appearance changed" <<key << "->" << qv.toString();
+  if (key == "color-scheme") {
+    emit colorSchemeChanged();
+  } else if (key == "accent-color") {
+    emit accentColorChanged();
+  } else if (key == "contrast") {
+    emit contrastChanged();
+  }
+}

--- a/src/platforms/linux/xdgappearance.h
+++ b/src/platforms/linux/xdgappearance.h
@@ -1,0 +1,43 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef XDGAPPEARANCE_H
+#define XDGAPPEARANCE_H
+
+#include <QObject>
+
+#include "xdgportal.h"
+
+class QDBusPendingCallWatcher;
+
+class XdgAppearance final : public XdgPortal {
+  Q_OBJECT
+  Q_DISABLE_COPY_MOVE(XdgAppearance)
+
+  Q_PROPERTY(uint colorScheme READ colorScheme NOTIFY colorSchemeChanged)
+  Q_PROPERTY(uint accentColor READ accentColor NOTIFY accentColorChanged)
+  Q_PROPERTY(uint contrast READ contrast NOTIFY contrastChanged)
+
+ public:
+  explicit XdgAppearance(QObject* parent = nullptr);
+  ~XdgAppearance();
+
+  uint colorScheme();
+  uint accentColor();
+  uint contrast();
+
+ signals:
+  void colorSchemeChanged();
+  void accentColorChanged();
+  void contrastChanged();
+
+ private slots:
+  void xdgSettingChanged(const QString& ns, const QString& key,
+                         const QDBusVariant& value);
+
+ private:
+  uint readValueUint(const QString& name);
+};
+
+#endif  // XDGAPPEARANCE_H

--- a/src/platforms/linux/xdgportal.cpp
+++ b/src/platforms/linux/xdgportal.cpp
@@ -29,7 +29,8 @@ namespace {
 Logger logger("XdgPortal");
 }
 
-XdgPortal::XdgPortal(QObject* parent) : QObject(parent) {
+XdgPortal::XdgPortal(const QString& iface, QObject* parent)
+    : QObject(parent), m_portal(XDG_PORTAL_SERVICE, XDG_PORTAL_PATH, iface) {
   MZ_COUNT_CTOR(XdgPortal);
 
   // Generate a unique token
@@ -47,10 +48,8 @@ XdgPortal::XdgPortal(QObject* parent) : QObject(parent) {
 
 XdgPortal::~XdgPortal() { MZ_COUNT_DTOR(XdgPortal); }
 
-// static
-uint XdgPortal::getVersion(const QString& interface) {
-  QDBusInterface portal(XDG_PORTAL_SERVICE, XDG_PORTAL_PATH, interface);
-  QVariant qv = portal.property("version");
+uint XdgPortal::getVersion() {
+  QVariant qv = m_portal.property("version");
   if (qv.typeId() == QMetaType::UInt) {
     return qv.toUInt();
   }

--- a/src/platforms/linux/xdgportal.h
+++ b/src/platforms/linux/xdgportal.h
@@ -5,6 +5,7 @@
 #ifndef XDGPORTAL_H
 #define XDGPORTAL_H
 
+#include <QDBusInterface>
 #include <QObject>
 
 constexpr const char* XDG_PORTAL_SERVICE = "org.freedesktop.portal.Desktop";
@@ -14,6 +15,7 @@ constexpr const char* XDG_PORTAL_BACKGROUND =
     "org.freedesktop.portal.Background";
 constexpr const char* XDG_PORTAL_REQUEST = "org.freedesktop.portal.Request";
 constexpr const char* XDG_PORTAL_SECRET = "org.freedesktop.portal.Secret";
+constexpr const char* XDG_PORTAL_SETTINGS = "org.freedesktop.portal.Settings";
 
 // XDG Portals allow sandboxed applications to interact with the host operating
 // system in a secure way via D-Bus APIs. This class implements some common
@@ -27,13 +29,13 @@ class XdgPortal : public QObject {
   Q_DISABLE_COPY_MOVE(XdgPortal)
 
  public:
-  explicit XdgPortal(QObject* parent = nullptr);
+  explicit XdgPortal(const QString& interface, QObject* parent = nullptr);
   ~XdgPortal();
 
   const QString& token() const { return m_token; }
   const QString& replyPath() const { return m_replyPath; }
   void setReplyPath(const QString& path);
-  static uint getVersion(const QString& interface);
+  uint getVersion();
   static void setupAppScope(const QString& appid);
 
  signals:
@@ -47,6 +49,8 @@ class XdgPortal : public QObject {
 
   QString m_replyPath;
   QString m_token;
+
+  QDBusInterface m_portal;
 };
 
 #endif  // XDGPORTAL_H

--- a/src/platforms/linux/xdgstartatbootwatcher.cpp
+++ b/src/platforms/linux/xdgstartatbootwatcher.cpp
@@ -20,7 +20,8 @@ namespace {
 Logger logger("XdgStartAtBootWatcher");
 }
 
-XdgStartAtBootWatcher::XdgStartAtBootWatcher() : XdgPortal() {
+XdgStartAtBootWatcher::XdgStartAtBootWatcher()
+    : XdgPortal(XDG_PORTAL_BACKGROUND) {
   MZ_COUNT_CTOR(XdgStartAtBootWatcher);
 
   logger.debug() << "StartAtBoot watcher";

--- a/src/settingslist.h
+++ b/src/settingslist.h
@@ -562,7 +562,9 @@ SETTING_STRING(theme,          // getter
 // Below Qt 6.5, this option won't be available.
 // Without this, the Apperance screen will
 // initially show no radio button selected.
-#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
+#if defined(MZ_LINUX)
+#  define USING_SYSTEM_THEME_DEFAULT_VALUE true
+#elif QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
 #  define USING_SYSTEM_THEME_DEFAULT_VALUE true
 #else
 #  define USING_SYSTEM_THEME_DEFAULT_VALUE false

--- a/src/settingslist.h
+++ b/src/settingslist.h
@@ -559,9 +559,9 @@ SETTING_STRING(theme,          // getter
                false           // sensitive (do not log)
 )
 
-// Below Qt 6.5, this option won't be available.
-// Without this, the Apperance screen will
-// initially show no radio button selected.
+// This option is only supported for Qt 6.5 or later, with a special fallback
+// for Linux users via the XDG settings portal.
+// Without this, the Apperance screen will initially show no theme selected.
 #if defined(MZ_LINUX)
 #  define USING_SYSTEM_THEME_DEFAULT_VALUE true
 #elif QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)

--- a/src/theme.cpp
+++ b/src/theme.cpp
@@ -20,7 +20,7 @@
 #  include "platforms/ios/ioscommons.h"
 #endif
 
-#ifdef MZ_LINUX
+#if defined(MZ_LINUX) && !defined(UNIT_TEST)
 #  include "platforms/linux/xdgappearance.h"
 #endif
 
@@ -41,12 +41,12 @@ Theme::Theme(QObject* parent) : QAbstractListModel(parent) {
             initialize(QmlEngineHolder::instance()->engine());
           });
 
-#ifdef MZ_LINUX
+#if defined(MZ_LINUX) && !defined(UNIT_TEST)
   m_xdg = new XdgAppearance(this);
   connect(m_xdg, &XdgAppearance::colorSchemeChanged, this, [this]() {
     if (SettingsHolder::instance()->usingSystemTheme()) {
       setToSystemTheme();
-     }
+    }
   });
 #elif QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
   connect(QGuiApplication::styleHints(), &QStyleHints::colorSchemeChanged, this,
@@ -245,7 +245,7 @@ QVariant Theme::data(const QModelIndex& index, int role) const {
 }
 
 QString Theme::currentSystemTheme() {
-#ifdef MZ_LINUX
+#if defined(MZ_LINUX) && !defined(UNIT_TEST)
   if (m_xdg->colorScheme() != 1) {
     return "main";
   } else {
@@ -258,6 +258,9 @@ QString Theme::currentSystemTheme() {
   } else {
     return "dark-mode";
   }
+#else
+  // Otherwise, we have no way to detect the system theme.
+  return "main";
 #endif
 }
 

--- a/src/theme.cpp
+++ b/src/theme.cpp
@@ -43,12 +43,11 @@ Theme::Theme(QObject* parent) : QAbstractListModel(parent) {
 
 #ifdef MZ_LINUX
   m_xdg = new XdgAppearance(this);
-  connect(m_xdg, &XdgAppearance::colorSchemeChanged, this,
-          [this]() {
-            if (SettingsHolder::instance()->usingSystemTheme()) {
-              setToSystemTheme();
-            }
-          });
+  connect(m_xdg, &XdgAppearance::colorSchemeChanged, this, [this]() {
+    if (SettingsHolder::instance()->usingSystemTheme()) {
+      setToSystemTheme();
+     }
+  });
 #elif QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
   connect(QGuiApplication::styleHints(), &QStyleHints::colorSchemeChanged, this,
           [this]() {

--- a/src/theme.cpp
+++ b/src/theme.cpp
@@ -181,7 +181,8 @@ void Theme::setUsingSystemTheme(const bool usingSystemTheme) {
 }
 
 void Theme::setToSystemTheme() {
-  if (!Feature::get(Feature::Feature_themeSelection)->isSupported()) {
+  if (!Feature::get(Feature::Feature_themeSelection)->isSupported() ||
+      !Feature::get(Feature::Feature_themeSelectionIncludesAutomatic)) {
     logger.debug()
         << "Not setting to system theme because feature is not supported.";
     return;

--- a/src/theme.cpp
+++ b/src/theme.cpp
@@ -20,6 +20,10 @@
 #  include "platforms/ios/ioscommons.h"
 #endif
 
+#ifdef MZ_LINUX
+#  include "platforms/linux/xdgappearance.h"
+#endif
+
 #include <QCoreApplication>
 #include <QPainter>
 #include <QQmlEngine>
@@ -37,7 +41,15 @@ Theme::Theme(QObject* parent) : QAbstractListModel(parent) {
             initialize(QmlEngineHolder::instance()->engine());
           });
 
-#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
+#ifdef MZ_LINUX
+  m_xdg = new XdgAppearance(this);
+  connect(m_xdg, &XdgAppearance::colorSchemeChanged, this,
+          [this]() {
+            if (SettingsHolder::instance()->usingSystemTheme()) {
+              setToSystemTheme();
+            }
+          });
+#elif QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
   connect(QGuiApplication::styleHints(), &QStyleHints::colorSchemeChanged, this,
           [this]() {
             if (SettingsHolder::instance()->usingSystemTheme()) {
@@ -164,14 +176,11 @@ void Theme::setCurrentTheme(const QString& themeName) {
 void Theme::setUsingSystemTheme(const bool usingSystemTheme) {
   SettingsHolder::instance()->setUsingSystemTheme(usingSystemTheme);
 
-#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
   if (usingSystemTheme) {
     setToSystemTheme();
   }
-#endif
 }
 
-#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
 void Theme::setToSystemTheme() {
   if (!Feature::get(Feature::Feature_themeSelection)->isSupported()) {
     logger.debug()
@@ -179,13 +188,7 @@ void Theme::setToSystemTheme() {
     return;
   }
 
-  QString themeImpliedBySystemTheme;
-  if (currentSystemTheme() != Qt::ColorScheme::Dark) {
-    themeImpliedBySystemTheme = "main";
-  } else {
-    themeImpliedBySystemTheme = "dark-mode";
-  }
-
+  QString themeImpliedBySystemTheme = currentSystemTheme();
   logger.debug() << "Using system theme. Associated VPN theme is"
                  << themeImpliedBySystemTheme;
 
@@ -200,7 +203,6 @@ void Theme::setToSystemTheme() {
     emit changed();
   }
 }
-#endif
 
 bool Theme::loadTheme(const QString& themeName) {
   if (!m_themes.contains(themeName)) return false;
@@ -243,14 +245,23 @@ QVariant Theme::data(const QModelIndex& index, int role) const {
   }
 }
 
-#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
-Qt::ColorScheme Theme::currentSystemTheme() {
+QString Theme::currentSystemTheme() {
+#ifdef MZ_LINUX
+  if (m_xdg->colorScheme() != 1) {
+    return "main";
+  } else {
+    return "dark-mode";
+  }
+#elif QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
   QStyleHints* styleHints = QGuiApplication::styleHints();
-  Qt::ColorScheme currentColorScheme = styleHints->colorScheme();
-  logger.debug() << "Current system theme: " << currentColorScheme;
-  return currentColorScheme;
-}
+  if (styleHints->colorScheme() != Qt::ColorScheme::Dark) {
+    return "main";
+  } else {
+    return "dark-mode";
+  }
 #endif
+}
+
 #ifdef MZ_WINDOWS
 #  include <dwmapi.h>
 

--- a/src/theme.h
+++ b/src/theme.h
@@ -13,6 +13,7 @@
 #include "settingsholder.h"
 
 class QJSEngine;
+class XdgAppearance;
 
 class Theme final : public QAbstractListModel {
   Q_OBJECT
@@ -58,9 +59,7 @@ class Theme final : public QAbstractListModel {
 
   QVariant data(const QModelIndex& index, int role) const override;
 
-#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
-  Qt::ColorScheme currentSystemTheme();
-#endif
+  QString currentSystemTheme();
 
   enum StatusBarTextColor {
     StatusBarTextColorLight,
@@ -77,9 +76,7 @@ class Theme final : public QAbstractListModel {
   void parseTheme(QJSEngine* engine, const QString& themeFilename);
   bool loadTheme(const QString& themeName);
   void parseSizing(QJSEngine* engine);
-#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
   void setToSystemTheme();
-#endif
 
  signals:
   void changed();
@@ -89,6 +86,10 @@ class Theme final : public QAbstractListModel {
   QHash<QString, QJSValue> m_themes;
   QString m_currentTheme;
   QJSValue m_sizing;
+
+#if defined(MZ_LINUX)
+  XdgAppearance* m_xdg = nullptr;
+#endif
 };
 
 #endif  // THEME_H


### PR DESCRIPTION
## Description
It's been reported that Linux doesn't correctly detect the system theme on some Qt versions, and some have reported it broken altogether. So, let's throw together a quick workaround by pulling the theme information from the [XDG Settings portal](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.Settings.html).


## Reference
JIRA issue: [VPN-6971](https://mozilla-hub.atlassian.net/browse/VPN-6971)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-6971]: https://mozilla-hub.atlassian.net/browse/VPN-6971?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ