### PR TITLE
VPN-6976: update 2.27 messages to default text

### DIFF
--- a/addons/message_update_v2.27/manifest.json
+++ b/addons/message_update_v2.27/manifest.json
@@ -22,17 +22,7 @@
       {
         "id": "c_1",
         "type": "text",
-        "content": "vpn.commonStrings.generalUpdateBulletIntro"
-      },
-      {
-        "id": "c_2",
-        "type": "ulist",
-        "content": [
-          {
-            "id": "l_1",
-            "content": "vpn.227updateMessage.bullet1"
-          }
-        ]
+        "content": "vpn.commonStrings.generalUpdateContent"
       },
       {
         "id": "c_3",

--- a/addons/message_whats_new_v2.27/manifest.json
+++ b/addons/message_whats_new_v2.27/manifest.json
@@ -23,17 +23,7 @@
       {
         "id": "c_1",
         "type": "text",
-        "content": "vpn.commonStrings.generalUpdateBulletIntro"
-      },
-      {
-        "id": "c_2",
-        "type": "ulist",
-        "content": [
-          {
-            "id": "l_1",
-            "content": "vpn.227updateMessage.bullet1"
-          }
-        ]
+        "content": "vpn.commonStrings.generalUpdateContent"
       },
       {
         "id": "c_3",


### PR DESCRIPTION
## Description

Dark mode isn't coming until 2.28 - so we need to update the addon text to reflect this

## Reference

VPN-6976

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
