### PR TITLE
VPN-6981: only require 1 argument (string) in release notes script

### DIFF
--- a/scripts/utils/generate_release_notes.sh
+++ b/scripts/utils/generate_release_notes.sh
@@ -7,7 +7,7 @@ if ! command -v xmlstarlet &> /dev/null; then
 fi
 
 # Check for the correct number of command-line arguments
-if [ "$#" -lt 2 ]; then
+if [ "$#" -lt 1 ]; then
   echo ""
   echo "Usage: $0 stringId1 [stringId2 stringId3 ... stringIdN]"
   echo "The blocks are the ids of the addon blocks we want to extract strings from."


### PR DESCRIPTION
## Description

It errored on producing the release notes for this month - because there was only one string.

## Reference

VPN-6981

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
