### PR TITLE
Enable code-ql scanning on the linux&macos build

### DIFF
--- a/.github/workflows/linux_tests.yaml
+++ b/.github/workflows/linux_tests.yaml
@@ -51,7 +51,7 @@ jobs:
 
       # Set up CodeQL
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@v3
         with:
           languages: 'cpp'
 

--- a/.github/workflows/linux_tests.yaml
+++ b/.github/workflows/linux_tests.yaml
@@ -49,6 +49,12 @@ jobs:
           lookup-only: github.event_name == 'pull_request'
           restore-keys: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.sha }}
 
+      # Set up CodeQL
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v2
+        with:
+          languages: 'cpp'
+
       - name: Compile test client
         shell: bash
         run: |
@@ -56,6 +62,9 @@ jobs:
           cmake -S $(pwd) -B build-${{ runner.os }} -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache
           cmake --build build-${{ runner.os }} --target mozillavpn
+      # Run CodeQL analysis
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v2
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/macos_tests.yaml
+++ b/.github/workflows/macos_tests.yaml
@@ -60,6 +60,12 @@ jobs:
           wget https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/mozillavpn.v2.mozillavpn.cache.level-3.toolchains.v3.qt-macos-6.6.latest/artifacts/public%2Fbuild%2Fqt6_mac.zip -O qt6_mac.zip
           unzip -a -d ${{ github.workspace }} qt6_mac.zip
 
+      # Set up CodeQL
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: 'cpp'
+
       - name: Compile test client
         run: |
           mkdir -p build/cmake
@@ -68,6 +74,10 @@ jobs:
             -DCMAKE_PREFIX_PATH=${{ github.workspace }}/qt_dist/lib/cmake
           cmake --build build/cmake
           cp -r ./build/cmake/src/Mozilla\ VPN.app/ build/Mozilla\ VPN.app
+
+      # Run CodeQL analysis
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v2
 
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Description

Looking back at: https://docs.google.com/document/d/1n2fa1QZhaki8EZC85OzAEp3CpJAj2iOItXT2C2bH1d0/edit?tab=t.0 
this thing seems to be able to find some bugs :) 

We're not building the release-clients anymore on gh but we could run-code-ql on the mozillavpn target we compile for functional testing 
