### PR TITLE
MacOS: Fix a bunch of codesign issues when building outside Xcode

### DIFF
--- a/.dictionary
+++ b/.dictionary
@@ -133,6 +133,7 @@ cldr
 cloudops
 cmake
 codebase
+codesigning
 colima
 conda
 config

--- a/docs/Building/macos.md
+++ b/docs/Building/macos.md
@@ -56,41 +56,53 @@ Unzip the folder and remember the location for the configure step.
 
 Make the build directory
 
-    mkdir build-mac
+    mkdir build-macos
 
 Configure
 
-    cmake -S . -B build-mac -DCMAKE_PREFIX_PATH=(Qt unzipped path)/macos/lib/cmake/
+    cmake -S . -B build-macos -GNinja -DCMAKE_PREFIX_PATH=(Qt unzipped path)/macos/lib/cmake/
 
 Compile
 
-    cmake --build build-mac -j (number of processes to use e.g. 8)
+    cmake --build build-macos -j (number of processes to use e.g. 8)
 
 # Run
 
 After building, you can run the app with
 
-    open ./build-mac/src/Mozilla\ VPN.app
+    open ./build-macos/src/Mozilla\ VPN.app
 
 However, opening as above will not give you log output and will not let you
 connect to the VPN.
 To overcome this, run two terminals.
 In the first, run
 
-    sudo ./build-mac/src/Mozilla\ VPN.app/Contents/MacOS/Mozilla\ VPN macosdaemon
+    sudo ./build-macos/src/Mozilla\ VPN.app/Contents/MacOS/Mozilla\ VPN macosdaemon
 
 In the second, run
 
-    ./build-mac/src/Mozilla\ VPN.app/Contents/MacOS/Mozilla\ VPN
+    ./build-macos/src/Mozilla\ VPN.app/Contents/MacOS/Mozilla\ VPN
 
 For most dev tasks (everything except working on the macosdaemon), you can leave the first terminal with the `macosdaemon` running and rebuild your client in the second with your new changes and test them.
+
+## Codesigning
+
+Many features of the Mozilla VPN project depend on having a valid code signature. To determine the codesigning identities available to you, you can use the `security` tool on the command line as follows:
+
+```
+user@example ~ % security find-identity -v -p codesigning                
+  1) AAAABBBBCCCCDDDDEEEEFFFFAAAABBBBCCCCDDDD "Apple Development: Jane Doe (XXXXXXXXXX)"
+     1 valid identities found
+```
+
+Thus, to configure the project to use the above codesigning identity, we can provide the argument `-DCODE_SIGN_IDENTITY=AAAABBBBCCCCDDDDEEEEFFFFAAAABBBBCCCCDDDD`
 
 # Building the installer
 
 Use the `--target pkg` to build the MacOS installer.
 
-This will produce an unsigned installer package at `build-mac/macos/pkg/MozillaVPN-unsigned.pkg`
-and a signed installer at `build-mac/macos/pkg/MozillaVPN-signed.pkg` if a valid installer
+This will produce an unsigned installer package at `build-macos/macos/pkg/MozillaVPN-unsigned.pkg`
+and a signed installer at `build-macos/macos/pkg/MozillaVPN-signed.pkg` if a valid installer
 signing identity was provided in the `INSTALLER_SIGN_IDENTITIY` [variable at configuration time](./index.md).
 
 # Building with Xcode
@@ -121,12 +133,12 @@ This step needs to be repeated each time Xcode updates.
 
 Use the same configure command above and add `-GXcode`:
 
-    cmake -S . -B build-mac -DCMAKE_PREFIX_PATH=(Qt unzipped path)/macos/lib/cmake/ -GXcode
+    cmake -S . -B build-macos -DCMAKE_PREFIX_PATH=(Qt unzipped path)/macos/lib/cmake/ -GXcode
 
-This will generate an Xcode project file at `build-mac/Mozilla VPN.xcodeproj` which can be opened
+This will generate an Xcode project file at `build-macos/Mozilla VPN.xcodeproj` which can be opened
 by Xcode:
 
-    open build-mac/Mozilla\ VPN.xcodeproj
+    open build-macos/Mozilla\ VPN.xcodeproj
 
 Once Xcode has opened the project, select the `mozillavpn` target and start the build.
 

--- a/macos/pkg/CMakeLists.txt
+++ b/macos/pkg/CMakeLists.txt
@@ -52,30 +52,32 @@ configure_file(
     @ONLY
 )
 
-## Stage 2: Create the staging directory, and populate it with the app.
+## Stage 2: Create the staging directory and build the component package.
 add_custom_command(
-    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/staging/MozillaVPN.pkg
+    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/components/MozillaVPN.pkg
     BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/installer.plist
     DEPENDS mozillavpn
     COMMAND ${CMAKE_COMMAND} -E remove_directory -f ${CMAKE_CURRENT_BINARY_DIR}/staging
     COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/staging
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/components
     COMMAND ${CMAKE_COMMAND} -E copy_directory $<TARGET_BUNDLE_DIR:mozillavpn>
-       ${CMAKE_CURRENT_BINARY_DIR}/staging/Applications/$<TARGET_PROPERTY:mozillavpn,OUTPUT_NAME>.app/
+       ${CMAKE_CURRENT_BINARY_DIR}/staging/$<TARGET_PROPERTY:mozillavpn,OUTPUT_NAME>.app/
     COMMAND pkgbuild --analyze --root ${CMAKE_CURRENT_BINARY_DIR}/staging ${CMAKE_CURRENT_BINARY_DIR}/installer.plist
     COMMAND plutil -replace 0.BundleIsRelocatable -bool NO ${CMAKE_CURRENT_BINARY_DIR}/installer.plist
-    COMMAND pkgbuild --identifier "$<TARGET_PROPERTY:mozillavpn,MACOSX_BUNDLE_GUI_IDENTIFIER>" --version "2.0"
+    COMMAND pkgbuild --identifier "$<TARGET_PROPERTY:mozillavpn,XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER>" 
+        --version "2.0" --install-location "/Applications"
         --scripts ${CMAKE_CURRENT_BINARY_DIR}/scripts --root ${CMAKE_CURRENT_BINARY_DIR}/staging
         --component-plist ${CMAKE_CURRENT_BINARY_DIR}/installer.plist
-        ${CMAKE_CURRENT_BINARY_DIR}/staging/MozillaVPN.pkg
+        ${CMAKE_CURRENT_BINARY_DIR}/components/MozillaVPN.pkg
 )
 
-## Stage 3: Run productbuild to inject the distribution files.
+## Stage 3: Run productbuild to inject the distribution files and build the installer package.
 add_custom_command(
     OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/MozillaVPN-unsigned.pkg
-    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/staging/MozillaVPN.pkg pkg_resources
+    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/components/MozillaVPN.pkg pkg_resources
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     COMMAND productbuild --distribution ${CMAKE_CURRENT_SOURCE_DIR}/Distribution
-        --resources ${CMAKE_CURRENT_BINARY_DIR}/Resources --package-path staging
+        --resources ${CMAKE_CURRENT_BINARY_DIR}/Resources --package-path ${CMAKE_CURRENT_BINARY_DIR}/components
         MozillaVPN-unsigned.pkg
 )
 

--- a/scripts/cmake/osxtools.cmake
+++ b/scripts/cmake/osxtools.cmake
@@ -135,7 +135,7 @@ function(osx_codesign_target TARGET)
             add_custom_command(TARGET ${TARGET} POST_BUILD
                 COMMAND ${CMAKE_SOURCE_DIR}/scripts/utils/make_template.py ${CODESIGN_ENTITLEMENTS}
                     -k PRODUCT_BUNDLE_IDENTIFIER=$<TARGET_PROPERTY:${TARGET},XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER>
-                    -k DEVELOPMENT_TEAM=$<TARGET_PROPERTY:${TARGET},XCODE_ATTRIBUTE_DEVELOPMENT_TEAM>
+                    -k DEVELOPMENT_TEAM=${CMAKE_XCODE_ATTRIBUTE_DEVELOPMENT_TEAM}
                     -o ${CMAKE_CURRENT_BINARY_DIR}/${TARGET}_codesign.entitlements
             )
             list(APPEND CODESIGN_ARGS --entitlements ${CMAKE_CURRENT_BINARY_DIR}/${TARGET}_codesign.entitlements)

--- a/scripts/cmake/osxtools.cmake
+++ b/scripts/cmake/osxtools.cmake
@@ -154,3 +154,70 @@ function(osx_codesign_target TARGET)
         endforeach()
     endif()
 endfunction()
+
+function(osx_embed_provision_profile TARGET)
+    ## Xcode should perform manage this for us.
+    if(XCODE)
+        return()
+    endif()
+
+    # Enumerate the provioning profiles managed by Xcode
+    set(XCODE_PROVISION_PROFILES_DIR "$ENV{HOME}/Library/Developer/Xcode/UserData/Provisioning\ Profiles")
+    execute_process(
+        OUTPUT_VARIABLE XCODE_PROVISION_PROFILES_RAW
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        COMMAND find ${XCODE_PROVISION_PROFILES_DIR} -type f -name "*.provisionprofile"
+    )
+    string(REGEX MATCHALL "[^\n\r]+" XCODE_PROVISION_PROFILES ${XCODE_PROVISION_PROFILES_RAW})
+
+    # Find the profile which matches our team identifier and has the most recent creation date.
+    set(BEST_TIMESTAMP 0)
+    set(BEST_PROFILE "")
+    foreach(FILENAME ${XCODE_PROVISION_PROFILES})
+        # Compare the file creation dates.
+        # TODO: Technically, we should look at the CreationDate field in the profile's plist.
+        file(TIMESTAMP ${FILENAME} FILE_TIMESTAMP "%s" UTC)
+        if(FILE_TIMESTAMP LESS BEST_TIMESTAMP)
+            continue()
+        endif()
+
+        # Check if this provision profile can be used by our development team.
+        set(TEAM_IDENTIFIER_INDEX 0)
+        while(TRUE)
+            execute_process(
+                OUTPUT_VARIABLE TEAM_IDENTIFIER
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+                RESULT_VARIABLE PLUTIL_RETURN_CODE
+                COMMAND security cms -D -i ${FILENAME}
+                COMMAND plutil -extract TeamIdentifier.${TEAM_IDENTIFIER_INDEX} raw -
+            )
+            if(NOT PLUTIL_RETURN_CODE EQUAL 0)
+                break()
+            endif()
+            if(TEAM_IDENTIFIER STREQUAL CMAKE_XCODE_ATTRIBUTE_DEVELOPMENT_TEAM)
+                set(BEST_TIMESTAMP ${FILE_TIMESTAMP})
+                set(BEST_PROFILE ${FILENAME})
+                break()
+            endif()
+            math(EXPR TEAM_IDENTIFIER_INDEX "${TEAM_IDENTIFIER_INDEX}+1")
+        endwhile()
+    endforeach()
+
+    # If a provisioning profile was found - embed it into the bundle
+    if(BEST_PROFILE)
+        # For diagnostic assistance, print the provisioning profile name.
+        execute_process(
+            OUTPUT_VARIABLE PROFILE_NAME
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+            COMMAND security cms -D -i ${BEST_PROFILE}
+            COMMAND plutil -extract Name raw -
+        )
+        message("Using provisioning profile: ${PROFILE_NAME}")
+
+        add_custom_command(TARGET ${TARGET} POST_BUILD
+            COMMAND_EXPAND_LISTS
+            COMMAND ${COMMENT_ECHO_COMMAND} "Bundling embedded.provisionprofile"
+            COMMAND ${CMAKE_COMMAND} -E copy ${BEST_PROFILE} $<TARGET_BUNDLE_CONTENT_DIR:${TARGET}>/embedded.provisionprofile
+        )
+    endif()
+endfunction()

--- a/src/cmake/macos.cmake
+++ b/src/cmake/macos.cmake
@@ -189,4 +189,5 @@ add_custom_command(TARGET mozillavpn POST_BUILD
 osx_bundle_assetcatalog(mozillavpn CATALOG ${CMAKE_SOURCE_DIR}/macos/app/Images.xcassets)
 
 # Perform codesigning.
+osx_embed_provision_profile(mozillavpn)
 osx_codesign_target(mozillavpn FORCE)


### PR DESCRIPTION
## Description
While working away on #10358 it was necessary to be able to build and sign both the Mozilla VPN bundle as well as the MacOS installer package. But unfortunately this has been rather broken outside of Xcode for a while now. So while working on that PR, I have collected a bunch of fixes to get codesigning working again outside of Xcode.

## Reference

    i.e Jira or Github issue URL

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
