### PR TITLE
Qt 6.9 compat: Provide default args for LottieStatus::changed so moc can call it

### DIFF
--- a/lottie/lib/lottiestatus.h
+++ b/lottie/lib/lottiestatus.h
@@ -53,8 +53,8 @@ class LottieStatus final : public QObject {
   }
 
  signals:
-  void changed(bool playing, double currentTime, int totalTime, bool error,
-               const QString& errorString);
+  void changed(bool playing = false, double currentTime = 0, int totalTime = 0,
+               bool error = false, const QString& errorString = "");
 
  private:
   bool m_playing = false;


### PR DESCRIPTION
Looking at: https://github.com/mozilla-mobile/mozilla-vpn-client/issues/10375

it seems moc generates a function call that tries to call it without arguments. Given all our callsites are providing one, we can just add defaults so moc can happily compile :) 