### PR TITLE
Qt 6.9 compat:  Remove Qt.labls.qmlmodels usage

### DIFF
--- a/nebula/ui/components/forms/MZContextualAlert.qml
+++ b/nebula/ui/components/forms/MZContextualAlert.qml
@@ -7,13 +7,25 @@ import QtQuick.Layouts 1.14
 
 import Mozilla.Shared 1.0
 import components 0.1
+import "qrc:/nebula/utils/MZAssetLookup.js" as MZAssetLookup
+
 
 RowLayout {
     id: messageItem
 
-    property string iconSrc
-    property string fontColor
+    enum AlertType {
+        Warning,
+        Error
+    }
+    property var messageString: ""
+    property var alertType: MZContextualAlert.AlertType.Warning
 
+    property string iconSrc: (alertType == MZContextualAlert.AlertType.Warning) 
+                                ? MZAssetLookup.getImageSource("WarningDarkOrange") :
+                                  MZAssetLookup.getImageSource("WarningRed")
+    property string fontColor: (alertType == MZContextualAlert.AlertType.Warning) ? 
+                                  MZTheme.colors.fontColorWarningForBackground :
+                                  MZTheme.colors.errorAccentLight
     Layout.preferredWidth: parent.width
     Layout.fillWidth: true
     spacing: 0
@@ -82,7 +94,7 @@ RowLayout {
         Accessible.role: Accessible.StaticText
 
         color: fontColor
-        text: modelData.message
+        text: messageString
         wrapMode: Text.WordWrap
         width: undefined
         Layout.fillWidth: true

--- a/nebula/ui/components/forms/MZContextualAlerts.qml
+++ b/nebula/ui/components/forms/MZContextualAlerts.qml
@@ -4,11 +4,9 @@
 
 import QtQuick 2.6
 import QtQuick.Layouts 1.14
-import Qt.labs.qmlmodels 1.0
 
 import Mozilla.Shared 1.0
 import components.forms 0.1
-import "qrc:/nebula/utils/MZAssetLookup.js" as MZAssetLookup
 
 ColumnLayout {
     id: messagesContainer
@@ -16,29 +14,13 @@ ColumnLayout {
 
     spacing: MZTheme.theme.listSpacing / 4
 
-    DelegateChooser {
-        id: messagesChooser
-        role: "type"
-
-        DelegateChoice {
-            roleValue: "warning"
-            delegate: MZContextualAlert {
-                fontColor: MZTheme.colors.fontColorWarningForBackground
-                iconSrc: MZAssetLookup.getImageSource("WarningDarkOrange")
-            }
-        }
-        DelegateChoice {
-            roleValue: "error"
-            delegate: MZContextualAlert {
-                fontColor: MZTheme.colors.errorAccentLight
-                iconSrc: MZAssetLookup.getImageSource("WarningRed")
-            }
-        }
-    }
-
     Repeater {
         id: messagesRepeater
-        delegate: messagesChooser
+        delegate: MZContextualAlert {
+                alertType: modelData.type
+                messageString: modelData.message
+                visible: modelData.visible
+            }
         model: messages
     }
 }

--- a/nebula/ui/components/forms/MZSearchBar.qml
+++ b/nebula/ui/components/forms/MZSearchBar.qml
@@ -84,7 +84,7 @@ FocusScope {
 
             messages: [
                 {
-                    type: "error",
+                    type: MZContextualAlert.AlertType.Error,
                     message: MZI18n.ServersViewSearchNoResultsLabel,
                     visible: searchBar.hasError
                 }

--- a/nebula/ui/components/inAppAuth/MZInAppAuthenticationInputs.qml
+++ b/nebula/ui/components/inAppAuth/MZInAppAuthenticationInputs.qml
@@ -178,7 +178,7 @@ ColumnLayout {
 
             messages: [
                 {
-                    type: "error",
+                    type: MZContextualAlert.AlertType.Error,
                     message: base._inputErrorMessage,
                     visible: activeInput().hasError
                 }

--- a/src/ui/screens/getHelp/developerMenu/ViewDeveloperMenu.qml
+++ b/src/ui/screens/getHelp/developerMenu/ViewDeveloperMenu.qml
@@ -201,7 +201,7 @@ MZViewBase {
 
             messages: [
                 {
-                    type: "warning",
+                    type: MZContextualAlert.AlertType.Warning,
                     message: MZI18n.SettingsDevRestartRequired,
                     visible: isVisible
                 }

--- a/src/ui/screens/settings/ViewDNSSettings.qml
+++ b/src/ui/screens/settings/ViewDNSSettings.qml
@@ -274,7 +274,7 @@ MZViewBase {
 
                     messages: [
                         {
-                            type: "error",
+                            type: MZContextualAlert.AlertType.Error,
                             message: ipInput.error,
                             visible: ipInput.valueInvalid && ipInput.visible
                         }


### PR DESCRIPTION
## Description
While fixing https://github.com/mozilla-mobile/mozilla-vpn-client/issues/10375 - i noticed anothing thing beeing utterly broken by qt 6.9.0. 

qmllmodels moved from qt.labs to the qt namespace but i could not see a way to conditionally do an `import` if we're on 6.9.+ - 
Now given all that did was switch colors of the button i'm taking your tricks using enums and just remove that dependency. 
