### PR TITLE
VPN-6974: status bar color when logging in on dark mode

### DIFF
--- a/nebula/ui/components/MZMobileStatusBarModifier.qml
+++ b/nebula/ui/components/MZMobileStatusBarModifier.qml
@@ -18,7 +18,11 @@ QtObject {
     }
 
     function resetDefaults() {
+      if (MZTheme.isThemeDark()) {
+        statusBarTextColor = MZTheme.StatusBarTextColorLight;
+      } else {
         statusBarTextColor = MZTheme.StatusBarTextColorDark;
+      }
     }
 
     Component.onCompleted: applyChanges()

--- a/src/theme.h
+++ b/src/theme.h
@@ -43,7 +43,7 @@ class Theme final : public QAbstractListModel {
 
   // Todo: Add a thing for themes to define, if they are using dark or light
   // resources. `useDarkAssets` is available, add this to ThemeData and connect.
-  bool isThemeDark() { return m_currentTheme != "main"; }
+  Q_INVOKABLE bool isThemeDark() { return m_currentTheme != "main"; }
 
   void setCurrentTheme(const QString& themeName);
 


### PR DESCRIPTION
## Description

We could remove a whole lot of the code for status bar and it would *almost* all work as expected - but logging in on light mode on iOS 16 (and possibly iOS 15) would end up with an incorrect color for the email/password/etc. screens. I [wrote up code for this](https://github.com/mozilla-mobile/mozilla-vpn-client/compare/vpn-6974-fix-status-bar-color?expand=1), and tested it out. Though we have few users on iOS 15 and iOS 16, this PR's solution works for iOS 15-18. However, once we cut off iOS 16 in a couple years, we'll be able to get rid of a bunch of this code.

I tested this on iOS 15, iOS 16, iOS 17, and iOS 18 (all the major versions we support) - both dark mode and light mode, on the log in flow and in the main app. For all these scenarios, I tested both a cold launch, and switching back in from another app.

## Reference

VPN-6974

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
