### PR TITLE
VPN-6893: part 1 - fix servers test

### DIFF
--- a/tests/functional/testServers.js
+++ b/tests/functional/testServers.js
@@ -197,6 +197,7 @@ describe('Server', function() {
 
       await vpn.forceServerUnavailable('at', 'vie');
       await vpn.activate();
+      await vpn.setSetting('recommendedServerSelected', 'false');
 
       // click the button
       await vpn.waitForQueryAndClick(


### PR DESCRIPTION
## Description

I'm going to put each test fix up as a separate PR. This fixes the Servers functional test. 

[I created this test](https://github.com/mozilla-mobile/mozilla-vpn-client/pull/10238/files#diff-ecac75875a7bfd126997889026cef83ea780e46d4c1f0e985db256eabe718c14) a while back.
![image](https://github.com/user-attachments/assets/e9e23075-6410-4f97-8f1f-b2ff49137aea)

There is some sort of inconsistent race condition. For some reason, this line doesn't work:
` await this.waitForQueryAndClick(queries.screenHome.serverListView.ALL_SERVERS_TAB.visible());`

The test sometimes passes this line before the all servers tab is selected. I tried a few different ways to get around this - and the best thing I could find is this awful hack here.


## Reference

VPN-6893

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
