### PR TITLE
VPN-6983: exclude Google Fi

### DIFF
--- a/android/vpnClient/src/main/java/org/mozilla/firefox/vpn/qt/PackageManagerHelper.kt
+++ b/android/vpnClient/src/main/java/org/mozilla/firefox/vpn/qt/PackageManagerHelper.kt
@@ -92,6 +92,7 @@ object PackageManagerHelper {
 
     private val ALLOWLISTED_APPS = arrayOf(
         "com.google.android.projection.gearhead",
+        "com.google.android.apps.tycho",
     )
 
     internal fun isAllowListed(packageName: ApplicationId): Boolean {

--- a/src/settingslist.h
+++ b/src/settingslist.h
@@ -651,16 +651,20 @@ SETTING_BOOL(userSubscriptionNeeded,        // getter
 )
 
 #ifdef MZ_ANDROID
-
-SETTING_STRINGLIST(vpnDisabledApps,        // getter
-                   setVpnDisabledApps,     // setter
-                   removeVpnDisabledApps,  // remover
-                   hasVpnDisabledApps,     // has
-                   "vpnDisabledApps",      // key
-                   QStringList{            // Android Auto
-                               "com.google.android.projection.gearhead"},
-                   false,  // remove when reset
-                   false   // sensitive (do not log)
+// If a system app, may also need to add to PackageManagerHelper.kt's
+// ALLOWLISTED_APPS before it is visible in Excluded Apps screen
+SETTING_STRINGLIST(
+    vpnDisabledApps,        // getter
+    setVpnDisabledApps,     // setter
+    removeVpnDisabledApps,  // remover
+    hasVpnDisabledApps,     // has
+    "vpnDisabledApps",      // key
+    QStringList({
+        "com.google.android.projection.gearhead",  // Android Auto
+        "com.google.android.apps.tycho"            // Google Fi
+    }),
+    false,  // remove when reset
+    false   // sensitive (do not log)
 )
 
 #else


### PR DESCRIPTION
## Description

Make [Google Fi](https://play.google.com/store/apps/details?id=com.google.android.apps.tycho) show up on the list, and exclude it by default.

While I can confirm that the app shows up on the list and is excluded by default, I do not have a Google Fi cell plan and thus cannot check if this rectifies the calling issue.

I've also left a comment to make the secondary allow list more obvious to find in the future.

## Reference

VPN-6983

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
