### PR TITLE
VPN-6893 part 2 - fix WASM’s UnsecuredNetworkAlert functional test

### DIFF
--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -254,7 +254,7 @@ void Controller::quit() {
 
   if (m_state == StateOn || m_state == StateOnPartial ||
       m_state == StateSwitching || m_state == StateSilentSwitching ||
-      m_state == StateConnecting) {
+      m_state == StateConnecting || m_state == StateConfirming) {
     deactivate();
     return;
   }


### PR DESCRIPTION
## Description

For the last long while, the WASM UnsecuredNetworkAlert functional test has been flaky. It mostly passes, but fails maybe 20% of the time. A rerun typically fixes it. 

It errors out on a timeout in `afterEach`. I isolated the issue to [this line](https://github.com/mozilla-mobile/mozilla-vpn-client/blob/main/tests/functional/setupWasm.js#L167). While you can see it is wrapped in a try/catch, the timeout for `afterEach` doesn't seem to throw. And wrapping that block in a `Promise.race` didn't fix it either.

Digging in to the controller's quit function, it doesn't seem to handle the `confirming` state. Given that at the end of this test, we're usually in some state of connecting, it makes sense that this could be the reason for inconsistent failures. I haven't been able to get a run to confirm this, however - and so for now, I'm putting this PR up. If for some reason this doesn't fix the issue, I'll spend more time on this soon - but for now, I think I've sunk an appropriate amount of time into it.

## Reference

VPN-6893

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
