### PR TITLE
VPN-6945: Fix crash in MacOSController

### DIFF
--- a/src/platforms/macos/macoscontroller.h
+++ b/src/platforms/macos/macoscontroller.h
@@ -13,7 +13,6 @@ class MacOSController final : public LocalSocketController {
 
  public:
   MacOSController();
-  ~MacOSController();
 
   void initialize(const Device* device, const Keys* keys) override;
 
@@ -21,7 +20,8 @@ class MacOSController final : public LocalSocketController {
   void checkServiceStatus();
 
  private:
-  void* m_service = nullptr;
+  QString plistName() const;
+
   int m_smAppStatus;
   QTimer m_regTimer;
 };


### PR DESCRIPTION
## Description
In PR #10358 we introduced a new mechanism for registering the VPN daemon, but due to my inexperience with Obj-C and how it handles object lifecycles - I inadvertently left a use-after-free bug in the `MacOSController` class.

This crash would only manifest in release builds, and it basically comes down to the fact that the `SMAppService` object is automatically released at the end of the function scope, so attempting to retain it as a class member causes the use-after-free bug. The most straightforward fix is to simply recreate the object in each call to `checkServiceStatus()`

## Reference
Bug introduced by #10358 
JIRA Issue: [VPN-6945](https://mozilla-hub.atlassian.net/browse/VPN-6945)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
