### PR TITLE
VPN-6945: Fix SMAppService registration bugs

### DIFF
--- a/src/platforms/macos/macoscontroller.h
+++ b/src/platforms/macos/macoscontroller.h
@@ -13,15 +13,15 @@ class MacOSController final : public LocalSocketController {
 
  public:
   MacOSController();
-  ~MacOSController();
 
   void initialize(const Device* device, const Keys* keys) override;
 
  private slots:
-  void checkServiceStatus();
+  void checkServiceEnabled();
 
  private:
-  void* m_service = nullptr;
+  QString plistName() const;
+
   int m_smAppStatus;
   QTimer m_regTimer;
 };

--- a/src/ui/screens/ScreenPermissionRequired.qml
+++ b/src/ui/screens/ScreenPermissionRequired.qml
@@ -16,7 +16,7 @@ MZScreenBase {
     _menuIconVisibility: false
 
     Component.onCompleted: () => {
-        MZNavigator.addStackView(VPN.ScreenDeviceLimit, getStack())
+        MZNavigator.addStackView(VPN.ScreenPermissionRequired, getStack())
         if(Qt.platform.os === "osx"){
             getStack().push("qrc:/qt/qml/Mozilla/VPN/sharedViews/ViewPermissionRequiredOSX.qml")
             return;


### PR DESCRIPTION
## Description
In PR #10358 we tried to add a new mechnaism to register the macOS daemon using the `SMAppService` API, but unfortunately I missed an edge case and mis-handled the Obj-C object lifecycle leading to a possible crash when compiled for release.

First off, the crash was being caused by saving the `SMAppService` object reference in the `MacOSController` class. It seems that Obj-C will automatically garbage collect the references at the end of the function scope, leading to a use-after-free bug that could crash the application. For whatever reason, this crash was only observed once compiled for release. To fix this, we stop saving the `SMAppService` object and we just created it anew whenever we need it.

The second issue occurs when upgrading the daemon. In this scenario we attempt to get the `SMAppService` object and it reports that the status is `Enabled` because it's been enabled from a previous run and carry on through the state checks in `checkServiceStatus()`, assume the daemon is running and return without doing nothing. However, in this scenario the correct thing to do is call `[service registerAndReturnError]` again which should replace the old daemon with the new one. To address this bug, we reorganize the registration a bit so that we always attempt to register the daemon upon controller initialization.

## Reference
Introduced by: #10358
Jira issue: [VPN-6945](https://mozilla-hub.atlassian.net/browse/VPN-6945)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-6945]: https://mozilla-hub.atlassian.net/browse/VPN-6945?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ