### PR TITLE
VPN-7010: make entire rows tap targets

### DIFF
--- a/src/ui/screens/settings/ViewAppearance.qml
+++ b/src/ui/screens/settings/ViewAppearance.qml
@@ -57,6 +57,15 @@ MZViewBase {
                 Layout.rightMargin: MZTheme.theme.windowMargin / 2
                 visible: isVisible(radioButtonName)
 
+                MZMouseArea {
+                    anchors.fill: parent
+
+                    enabled: radioButtonId.enabled
+                    width: Math.min(parent.implicitWidth, parent.width)
+                    propagateClickToParent: false
+                    onClicked: wasClicked(radioButtonName)
+                }
+
                 MZRadioButton {
                     objectName: radioButtonName
 
@@ -79,15 +88,6 @@ MZViewBase {
                         text: MZI18n[textName]
                         wrapMode: Text.WordWrap
                         horizontalAlignment: Text.AlignLeft
-
-                        MZMouseArea {
-                            anchors.fill: parent
-
-                            enabled: radioButtonId.enabled
-                            width: Math.min(parent.implicitWidth, parent.width)
-                            propagateClickToParent: false
-                            onClicked: wasClicked(radioButtonName)
-                        }
                     }
 
                     MZTextBlock {

--- a/src/ui/screens/settings/ViewDNSSettings.qml
+++ b/src/ui/screens/settings/ViewDNSSettings.qml
@@ -143,6 +143,15 @@ MZViewBase {
             spacing: MZTheme.theme.windowMargin
             Layout.rightMargin: MZTheme.theme.windowMargin / 2
 
+            MZMouseArea {
+                anchors.fill: parent
+
+                enabled: gatewayRadioButton.enabled
+                width: Math.min(parent.implicitWidth, parent.width)
+                propagateClickToParent: false
+                onClicked: applyFrontendChanges(MZSettings.Gateway);
+            }
+
             MZRadioButton {
                 objectName: "dnsStandard"
 
@@ -165,15 +174,6 @@ MZViewBase {
                     text: MZI18n.SettingsDnsSettingsStandardDNSTitle
                     wrapMode: Text.WordWrap
                     horizontalAlignment: Text.AlignLeft
-
-                    MZMouseArea {
-                        anchors.fill: parent
-
-                        enabled: gatewayRadioButton.enabled
-                        width: Math.min(parent.implicitWidth, parent.width)
-                        propagateClickToParent: false
-                        onClicked: applyFrontendChanges(MZSettings.Gateway);
-                    }
                 }
 
                 MZTextBlock {
@@ -186,6 +186,15 @@ MZViewBase {
         RowLayout {
             Layout.fillWidth: true
             spacing: MZTheme.theme.windowMargin
+
+            MZMouseArea {
+                anchors.fill: parent
+
+                enabled: customRadioButton.enabled
+                width: Math.min(parent.implicitWidth, parent.width)
+                propagateClickToParent: false
+                onClicked: applyFrontendChanges(MZSettings.Custom);
+            }
 
             MZRadioButton {
                 objectName: "dnsCustom"
@@ -210,15 +219,6 @@ MZViewBase {
                     text: MZI18n.SettingsDnsSettingsCustomDNSTitle
                     wrapMode: Text.WordWrap
                     horizontalAlignment: Text.AlignLeft
-
-                    MZMouseArea {
-                        anchors.fill: parent
-
-                        enabled: customRadioButton.enabled
-                        width: Math.min(parent.implicitWidth, parent.width)
-                        propagateClickToParent: false
-                        onClicked: applyFrontendChanges(MZSettings.Custom);
-                    }
                 }
                 MZTextBlock {
                     text: MZI18n.SettingsDnsSettingsCustomDNSBody

--- a/src/ui/screens/settings/appPermissions/AppPermissionsList.qml
+++ b/src/ui/screens/settings/appPermissions/AppPermissionsList.qml
@@ -181,6 +181,14 @@ ColumnLayout {
                     VPNAppPermissions.flip(appID)
                 }
 
+                MZMouseArea {
+                    anchors.fill: parent
+                    width: parent.implicitWidth
+                    height: parent.implicitHeight
+                    propagateClickToParent: false
+                    onClicked: () => appRow.handleClick()
+                }
+
                 MZCheckBox {
                     id: checkBox
                     objectName: "checkbox"
@@ -260,14 +268,6 @@ ColumnLayout {
                     text: appName
                     color: MZTheme.colors.fontColorDark
                     horizontalAlignment: Text.AlignLeft
-
-                    MZMouseArea {
-                        anchors.fill: undefined
-                        width: parent.implicitWidth
-                        height: parent.implicitHeight
-                        propagateClickToParent: false
-                        onClicked: () => appRow.handleClick()
-                    }
                 }
             }
         }


### PR DESCRIPTION
## Description

From feedback on foxfooding - improve tap targets for the Dark/Light appearance. I went ahead and fixed the few other spots I could find a similar issue.

## Reference

VPN-7010

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
