### PR TITLE
VPN-6966: Exclude DNS traffic from socksproxy

### DIFF
--- a/extension/socks5proxy/bin/linuxbypass.h
+++ b/extension/socks5proxy/bin/linuxbypass.h
@@ -19,7 +19,7 @@ class LinuxBypass final : public QObject {
   ~LinuxBypass() = default;
 
  private slots:
-  void outgoingConnection(QAbstractSocket* s, const QHostAddress& dest);
+  void outgoingConnection(qintptr sd, const QHostAddress& dest);
 };
 
 #endif  // LINUXBYPASS_H

--- a/extension/socks5proxy/bin/windowsbypass.cpp
+++ b/extension/socks5proxy/bin/windowsbypass.cpp
@@ -124,8 +124,7 @@ void WindowsBypass::outgoingConnection(qintptr sd, const QHostAddress& dest) {
   }
 
   // Bind the socket to force its traffic to use a specific interface.
-  int result =
-      bind(sd, reinterpret_cast<sockaddr*>(&source), sizeof(source));
+  int result = bind(sd, reinterpret_cast<sockaddr*>(&source), sizeof(source));
   if (result != 0) {
     qWarning() << "socket bind failed:" << WSAGetLastError();
   }

--- a/extension/socks5proxy/bin/windowsbypass.h
+++ b/extension/socks5proxy/bin/windowsbypass.h
@@ -30,7 +30,7 @@ class WindowsBypass final : public QObject {
   const struct _MIB_IPFORWARD_ROW2* lookupRoute(const QHostAddress& dest) const;
 
  private slots:
-  void outgoingConnection(QAbstractSocket* s, const QHostAddress& dest);
+  void outgoingConnection(qintptr sd, const QHostAddress& dest);
   void interfaceChanged(quint64 luid);
   void refreshRoutes(int family);
   void refreshAddresses();

--- a/extension/socks5proxy/src/dnsresolver.cpp
+++ b/extension/socks5proxy/src/dnsresolver.cpp
@@ -9,7 +9,7 @@
 #else
 #  include <fcntl.h>
 #  include <net/if.h>
-#  include <sys/socket.h>
+#  include <unistd.h>
 #endif
 
 #include <QCoreApplication>

--- a/extension/socks5proxy/src/dnsresolver.cpp
+++ b/extension/socks5proxy/src/dnsresolver.cpp
@@ -4,12 +4,12 @@
 #include <ares.h>
 
 #ifdef Q_OS_WIN
-# include <netioapi.h>
-# include <winsock2.h>
+#  include <netioapi.h>
+#  include <winsock2.h>
 #else
-# include <fcntl.h>
-# include <net/if.h>
-# include <sys/socket.h>
+#  include <fcntl.h>
+#  include <net/if.h>
+#  include <sys/socket.h>
 #endif
 
 #include <QCoreApplication>
@@ -42,14 +42,14 @@ DNSResolver::DNSResolver() {
   static auto cbClose = [](ares_socket_t sd, void* ctx) -> int {
     return static_cast<DNSResolver*>(ctx)->aresClose(sd);
   };
-  static auto cbConnect = [](ares_socket_t sd, const struct sockaddr *sa,
+  static auto cbConnect = [](ares_socket_t sd, const struct sockaddr* sa,
                              ares_socklen_t socklen, unsigned int flags,
                              void* ctx) -> int {
     return static_cast<DNSResolver*>(ctx)->aresConnect(sd, sa, socklen, flags);
   };
   static auto cbSetsockopt = [](ares_socket_t sd, ares_socket_opt_t opt,
-                                const void *val, ares_socklen_t vlen,
-                                void *ctx) -> int {
+                                const void* val, ares_socklen_t vlen,
+                                void* ctx) -> int {
     DNSResolver* dns = static_cast<DNSResolver*>(ctx);
     return dns->aresSetsockopt(sd, opt, val, vlen);
   };
@@ -73,18 +73,18 @@ DNSResolver::DNSResolver() {
 
   // Register callback methods for the sockets.
   static struct ares_socket_functions_ex s_functions = {
-    .version = 1,
-    .flags = ARES_SOCKFUNC_FLAG_NONBLOCKING,
-    .asocket = cbSocket,
-    .aclose = cbClose,
-    .asetsockopt = cbSetsockopt,
-    .aconnect = cbConnect,
-    .arecvfrom = cbRecvfrom,
-    .asendto = cbSendto,
-    .agetsockname = cbGetsockname,
-    .abind = nullptr,
-    .aif_nametoindex = aresNametoindex,
-    .aif_indextoname = aresIndextoname,
+      .version = 1,
+      .flags = ARES_SOCKFUNC_FLAG_NONBLOCKING,
+      .asocket = cbSocket,
+      .aclose = cbClose,
+      .asetsockopt = cbSetsockopt,
+      .aconnect = cbConnect,
+      .arecvfrom = cbRecvfrom,
+      .asendto = cbSendto,
+      .agetsockname = cbGetsockname,
+      .abind = nullptr,
+      .aif_nametoindex = aresNametoindex,
+      .aif_indextoname = aresIndextoname,
   };
   ares_set_socket_functions_ex(m_channel, &s_functions, this);
 
@@ -180,7 +180,7 @@ void DNSResolver::resolveAsync(const QString& hostname, QObject* parent) {
 void DNSResolver::setNameserver(const QList<QHostAddress>& dnsList) {
   QString buffer{};
 
-  for(const QHostAddress& dns : dnsList) {
+  for (const QHostAddress& dns : dnsList) {
     if (dns.isNull()) {
       continue;
     }
@@ -195,7 +195,7 @@ void DNSResolver::setNameserver(const QList<QHostAddress>& dnsList) {
 
 void DNSResolver::socketAcivated(QSocketDescriptor sd,
                                  QSocketNotifier::Type type) {
-  ares_fd_events_t ev = { .fd = static_cast<ares_socket_t>(sd) };
+  ares_fd_events_t ev = {.fd = static_cast<ares_socket_t>(sd)};
   if (type == QSocketNotifier::Read) {
     ev.events = ARES_FD_EVENT_READ;
   }
@@ -254,7 +254,7 @@ int DNSResolver::aresClose(qintptr sd) {
   return closesocket(sd);
 }
 
-int DNSResolver::aresConnect(qintptr sd, const struct sockaddr *sa,
+int DNSResolver::aresConnect(qintptr sd, const struct sockaddr* sa,
                              ares_socklen_t salen, unsigned int flags) {
   Q_UNUSED(flags);
   emit setupDnsSocket(sd, QHostAddress(sa));
@@ -276,20 +276,18 @@ int DNSResolver::aresSetsockopt(qintptr sd, int opt, const void* val,
   }
 }
 
-int DNSResolver::aresRecvfrom(qintptr sd, void* data, size_t len,
-                              int flags, struct sockaddr* sa,
-                              socklen_t* socklen) {
+int DNSResolver::aresRecvfrom(qintptr sd, void* data, size_t len, int flags,
+                              struct sockaddr* sa, socklen_t* socklen) {
   return recvfrom(sd, static_cast<char*>(data), len, flags, sa, socklen);
 }
 
-int DNSResolver::aresSendto(qintptr sd, const void* data, size_t len,
-                           int flags, const struct sockaddr* sa,
-                           socklen_t socklen) {
+int DNSResolver::aresSendto(qintptr sd, const void* data, size_t len, int flags,
+                            const struct sockaddr* sa, socklen_t socklen) {
   return sendto(sd, static_cast<const char*>(data), len, flags, sa, socklen);
 }
 
 int DNSResolver::aresGetsockname(qintptr sd, struct sockaddr* sa,
-                                 socklen_t *socklen) {
+                                 socklen_t* socklen) {
   return getsockname(sd, sa, socklen);
 }
 
@@ -301,7 +299,7 @@ unsigned int DNSResolver::aresNametoindex(const char* ifname, void* user_data) {
 const char* DNSResolver::aresIndextoname(unsigned int ifindex, char* buf,
                                          size_t len, void* user_data) {
   Q_UNUSED(user_data);
-  char tmp[IF_NAMESIZE+1];
+  char tmp[IF_NAMESIZE + 1];
   if (!if_indextoname(ifindex, buf)) {
     return nullptr;
   }

--- a/extension/socks5proxy/src/dnsresolver.cpp
+++ b/extension/socks5proxy/src/dnsresolver.cpp
@@ -229,7 +229,7 @@ int DNSResolver::aresSocket(int domain, int type, int proto) {
   return sd;
 }
 
-int DNSResolver::aresClose(QSocketDescriptor sd) {
+int DNSResolver::aresClose(qintptr sd) {
   QSocketNotifier* n = m_notifiers.take(sd);
   if (n) {
     delete n;
@@ -237,13 +237,14 @@ int DNSResolver::aresClose(QSocketDescriptor sd) {
   return close(sd);
 }
 
-int DNSResolver::aresConnect(QSocketDescriptor sd, const struct sockaddr *sa,
+int DNSResolver::aresConnect(qintptr sd, const struct sockaddr *sa,
                              ares_socklen_t salen, unsigned int flags) {
   Q_UNUSED(flags);
+  emit setupDnsSocket(sd, QHostAddress(sa));
   return ::connect(sd, sa, salen);
 }
 
-int DNSResolver::aresSetsockopt(QSocketDescriptor sd, int opt, const void* val,
+int DNSResolver::aresSetsockopt(qintptr sd, int opt, const void* val,
                                 int vlen) {
   switch (opt) {
     case ARES_SOCKET_OPT_SENDBUF_SIZE:
@@ -257,13 +258,13 @@ int DNSResolver::aresSetsockopt(QSocketDescriptor sd, int opt, const void* val,
   }
 }
 
-int DNSResolver::aresRecvfrom(QSocketDescriptor sd, void* data, size_t len,
+int DNSResolver::aresRecvfrom(qintptr sd, void* data, size_t len,
                               int flags, struct sockaddr* sa,
                               socklen_t* socklen) {
   return recvfrom(sd, data, len, flags, sa, socklen);
 }
 
-int DNSResolver::aresSendto(QSocketDescriptor sd, const void* data, size_t len,
+int DNSResolver::aresSendto(qintptr sd, const void* data, size_t len,
                            int flags, const struct sockaddr* sa,
                            socklen_t socklen) {
   return sendto(sd, data, len, flags, sa, socklen);

--- a/extension/socks5proxy/src/dnsresolver.cpp
+++ b/extension/socks5proxy/src/dnsresolver.cpp
@@ -251,7 +251,11 @@ int DNSResolver::aresClose(qintptr sd) {
   if (n) {
     delete n;
   }
+#ifdef Q_OS_WIN
   return closesocket(sd);
+#else
+  return close(sd);
+#endif
 }
 
 int DNSResolver::aresConnect(qintptr sd, const struct sockaddr* sa,
@@ -298,13 +302,8 @@ unsigned int DNSResolver::aresNametoindex(const char* ifname, void* user_data) {
 
 const char* DNSResolver::aresIndextoname(unsigned int ifindex, char* buf,
                                          size_t len, void* user_data) {
-  Q_UNUSED(user_data);
-  char tmp[IF_NAMESIZE + 1];
-  if (!if_indextoname(ifindex, buf)) {
+  if (len < IF_NAMESIZE) {
     return nullptr;
   }
-  if (strncpy_s(buf, len, tmp, sizeof(tmp)) != 0) {
-    return nullptr;
-  }
-  return buf;
+  return if_indextoname(ifindex, buf);
 }

--- a/extension/socks5proxy/src/dnsresolver.h
+++ b/extension/socks5proxy/src/dnsresolver.h
@@ -17,7 +17,7 @@ class ares_addrinfo;
 class Socks5Connection;
 
 #ifdef Q_OS_WIN
-# include <ws2tcpip.h>
+#  include <ws2tcpip.h>
 #endif
 
 class DNSResolver : public QObject {

--- a/extension/socks5proxy/src/dnsresolver.h
+++ b/extension/socks5proxy/src/dnsresolver.h
@@ -9,6 +9,8 @@
 #include <QHostAddress>
 #include <QMutex>
 #include <QObject>
+#include <QSocketNotifier>
+#include <QTimer>
 
 struct ares_channeldata;
 class ares_addrinfo;
@@ -36,14 +38,37 @@ class DNSResolver : public QObject {
 
  private slots:
   void requestDestroyed();
+  void socketAcivated(QSocketDescriptor sd, QSocketNotifier::Type type);
+  void aresTimeout();
 
  private:
   void addressInfoCallback(QObject* ctx, int status, int timeouts,
                            struct ares_addrinfo* result);
   void shutdownAres();
+  void updateTimeout();
+
+  // C-Ares Socket callback methods.
+  int aresSocket(int domain, int type, int proto);
+  int aresClose(QSocketDescriptor sd);
+  int aresConnect(QSocketDescriptor sd, const struct sockaddr* sa,
+                  socklen_t socklen, unsigned int flags);
+  int aresSetsockopt(QSocketDescriptor sd, int opt, const void* val, int vlen);
+  int aresRecvfrom(QSocketDescriptor sd, void* data, size_t len, int flags,
+                   struct sockaddr* sa, socklen_t* socklen);
+  int aresSendto(QSocketDescriptor sd, const void* data, size_t len, int flags,
+                 const struct sockaddr* sa, socklen_t socklen);
+
+  static int aresGetsockname(int sd, struct sockaddr* sa, socklen_t* socklen,
+                             void* user_data);
+  static unsigned int aresNametoindex(const char* ifname, void* user_data);
+  static const char* aresIndextoname(unsigned int ifindex, char* buf,
+                                     size_t len, void* user_data);
 
   QHash<QObject*, QString> m_requests;
   QMutex m_requestLock;
 
-  ares_channeldata* mChannel = nullptr;
+  QHash<int, QSocketNotifier*> m_notifiers;
+  QTimer m_timer;
+
+  ares_channeldata* m_channel = nullptr;
 };

--- a/extension/socks5proxy/src/dnsresolver.h
+++ b/extension/socks5proxy/src/dnsresolver.h
@@ -16,6 +16,10 @@ struct ares_channeldata;
 class ares_addrinfo;
 class Socks5Connection;
 
+#ifdef Q_OS_WIN
+# include <ws2tcpip.h>
+#endif
+
 class DNSResolver : public QObject {
   Q_OBJECT
 
@@ -51,7 +55,7 @@ class DNSResolver : public QObject {
   void updateTimeout();
 
   // C-Ares Socket callback methods.
-  int aresSocket(int domain, int type, int proto);
+  qintptr aresSocket(int domain, int type, int proto);
   int aresClose(qintptr sd);
   int aresConnect(qintptr sd, const struct sockaddr* sa, socklen_t socklen,
                   unsigned int flags);
@@ -60,9 +64,8 @@ class DNSResolver : public QObject {
                    struct sockaddr* sa, socklen_t* socklen);
   int aresSendto(qintptr sd, const void* data, size_t len, int flags,
                  const struct sockaddr* sa, socklen_t socklen);
+  int aresGetsockname(qintptr sd, struct sockaddr* sa, socklen_t* socklen);
 
-  static int aresGetsockname(int sd, struct sockaddr* sa, socklen_t* socklen,
-                             void* user_data);
   static unsigned int aresNametoindex(const char* ifname, void* user_data);
   static const char* aresIndextoname(unsigned int ifindex, char* buf,
                                      size_t len, void* user_data);

--- a/extension/socks5proxy/src/dnsresolver.h
+++ b/extension/socks5proxy/src/dnsresolver.h
@@ -18,6 +18,8 @@ class Socks5Connection;
 
 #ifdef Q_OS_WIN
 #  include <ws2tcpip.h>
+#else
+#  include <sys/socket.h>
 #endif
 
 class DNSResolver : public QObject {

--- a/extension/socks5proxy/src/dnsresolver.h
+++ b/extension/socks5proxy/src/dnsresolver.h
@@ -36,6 +36,9 @@ class DNSResolver : public QObject {
 
   void setNameserver(const QList<QHostAddress>& addr);
 
+ signals:
+  void setupDnsSocket(qintptr sd, const QHostAddress& dest);
+
  private slots:
   void requestDestroyed();
   void socketAcivated(QSocketDescriptor sd, QSocketNotifier::Type type);
@@ -49,13 +52,13 @@ class DNSResolver : public QObject {
 
   // C-Ares Socket callback methods.
   int aresSocket(int domain, int type, int proto);
-  int aresClose(QSocketDescriptor sd);
-  int aresConnect(QSocketDescriptor sd, const struct sockaddr* sa,
-                  socklen_t socklen, unsigned int flags);
-  int aresSetsockopt(QSocketDescriptor sd, int opt, const void* val, int vlen);
-  int aresRecvfrom(QSocketDescriptor sd, void* data, size_t len, int flags,
+  int aresClose(qintptr sd);
+  int aresConnect(qintptr sd, const struct sockaddr* sa, socklen_t socklen,
+                  unsigned int flags);
+  int aresSetsockopt(qintptr sd, int opt, const void* val, int vlen);
+  int aresRecvfrom(qintptr sd, void* data, size_t len, int flags,
                    struct sockaddr* sa, socklen_t* socklen);
-  int aresSendto(QSocketDescriptor sd, const void* data, size_t len, int flags,
+  int aresSendto(qintptr sd, const void* data, size_t len, int flags,
                  const struct sockaddr* sa, socklen_t socklen);
 
   static int aresGetsockname(int sd, struct sockaddr* sa, socklen_t* socklen,

--- a/extension/socks5proxy/src/socks5.cpp
+++ b/extension/socks5proxy/src/socks5.cpp
@@ -44,8 +44,8 @@ void Socks5::newConnection(T* server) {
     });
 
     connect(con, &Socks5Connection::setupOutSocket, this,
-            [this](QAbstractSocket* s, const QHostAddress& dest) {
-              emit outgoingConnection(s, dest);
+            [this](qintptr sd, const QHostAddress& dest) {
+              emit outgoingConnection(sd, dest);
             });
 
     ++m_clientCount;

--- a/extension/socks5proxy/src/socks5.h
+++ b/extension/socks5proxy/src/socks5.h
@@ -10,7 +10,6 @@
 #include "dnsresolver.h"
 #include "socks5connection.h"
 
-class QAbstractSocket;
 class QHostAddress;
 class QLocalServer;
 class QTcpServer;
@@ -29,7 +28,7 @@ class Socks5 final : public QObject {
  signals:
   void connectionsChanged();
   void incomingConnection(Socks5Connection* connection);
-  void outgoingConnection(QAbstractSocket* socket, const QHostAddress& dest);
+  void outgoingConnection(qintptr sd, const QHostAddress& dest);
 
  private:
   void clientDismissed();

--- a/extension/socks5proxy/src/socks5connection.cpp
+++ b/extension/socks5proxy/src/socks5connection.cpp
@@ -10,6 +10,7 @@
 #ifdef Q_OS_WIN
 #  include <winsock2.h>
 #  include <ws2ipdef.h>
+
 #  include "winutils.h"
 #else
 #  include <arpa/inet.h>

--- a/extension/socks5proxy/src/socks5connection.h
+++ b/extension/socks5proxy/src/socks5connection.h
@@ -86,7 +86,7 @@ class Socks5Connection final : public QObject {
   const QString& errorString() const { return m_errorString; }
 
  signals:
-  void setupOutSocket(QAbstractSocket* socket, const QHostAddress& dest);
+  void setupOutSocket(qintptr sd, const QHostAddress& dest);
   void dataSentReceived(qint64 sent, qint64 received);
   void stateChanged();
 


### PR DESCRIPTION
## Description
The `socksproxy` tool is capable of generating DNS queries on behalf of the browser, but at present we don't take any explicit steps to exclude those DNS queries from the VPN tunnel. Normally this isn't a big deal as the DNS server is typically on the user's LAN, but if they happen to be using a DNS server on the public internet then this can result in incorrectly routed DNS queries.

To fix this, we need to use the `c-ares` socket functions in order to provide a hook on socket creation/connection where we can insert the VPN bypass code. As a side effect, we must also disable the `c-ares` thread and integrate it with the Qt event loop in order for these hooks to work.

This should resolve the case where some users are unable to exclude websites due to their ISP's DNS servers rejecting traffic from outside the ISP's network.

## Reference
JIRA issue [VPN-6966](https://mozilla-hub.atlassian.net/browse/VPN-6966)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-6966]: https://mozilla-hub.atlassian.net/browse/VPN-6966?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ