### PR TITLE
VPN-7017: improved dark mode toggle

### DIFF
--- a/nebula/ui/themes/color-themes/dark-mode.js
+++ b/nebula/ui/themes/color-themes/dark-mode.js
@@ -80,6 +80,7 @@ color.stepProgressBarCompleteText = color.purple20;
 color.stepProgressIconIncomplete = mixColors(color.bgColor, color.white, 0.8);
 color.stepProgressIconComplete = mixColors(color.bgColor, color.white, 0.8);
 
+// Toggle
 color.vpnToggleConnected = {
   defaultColor: color.blue20,
   buttonHovered: mixColors(color.blue20, color.black, 0.2),
@@ -88,7 +89,19 @@ color.vpnToggleConnected = {
   focusBorder: color.focusBorder,
 };
 
-// Toggle
+color.vpnToggleDisconnected = {
+  defaultColor: color.grey30,
+  buttonHovered: mixColors(color.grey30, color.black, 0.2),
+  buttonPressed: mixColors(color.grey30, color.black, 0.3),
+  buttonDisabled: mixColors(color.grey30, color.white, 0.3),
+  focusOutline: mixColors(color.grey30, color.white, 0.3),
+  focusBorder: color.focusBorder,
+};
+
+color.vpnToggleDisconnectedBorder = color.grey30;
+
+color.connectedToggle = color.grey50;
+color.disconnectedToggle = color.grey30;
 color.connectingToggle = color.dullPurple;
 color.connectingToggleBackground =
     mixColors(color.vpnToggleConnected.defaultColor, color.primary, 0.4);
@@ -106,25 +119,16 @@ color.destructiveButton = {
 
 color.successAlert = {
   defaultColor: color.green80,
-  buttonHovered: mixColors(
-      color.green80, color.black, 0.3),  // NEED confirmation - matt draft
-  buttonPressed: mixColors(
-      color.green80, color.black, 0.5),  // NEED confirmation - matt draft
-  focusOutline:
-      addTransparency(color.green80, 0.4),  // NEED confirmation - matt draft
-  focusBorder:
-      color.green80,  // or main button color? // NEED confirmation - matt draft
+  buttonHovered: mixColors(color.green80, color.black, 0.3),
+  buttonPressed: mixColors(color.green80, color.black, 0.5),
+  focusOutline: addTransparency(color.green80, 0.4),
+  focusBorder: color.green80,
 };
 color.warningAlert = {
-  buttonHovered: mixColors(
-      color.yellow70, color.black, 0.3),  // NEED confirmation - matt draft
-  buttonPressed: mixColors(
-      color.yellow70, color.black, 0.5),  // NEED confirmation - matt draft
-  focusOutline:
-      addTransparency(color.yellow70, 0.4),  // NEED confirmation - matt draft
-  focusBorder:
-      color
-          .yellow70,  // or main button color? // NEED confirmation - matt draft
+  buttonHovered: mixColors(color.yellow70, color.black, 0.3),
+  buttonPressed: mixColors(color.yellow70, color.black, 0.5),
+  focusOutline: addTransparency(color.yellow70, 0.4),
+  focusBorder: color.yellow70,
 };
 
 color.textLink = {
@@ -138,13 +142,4 @@ color.onBoardingGradient = {
   start: color.lighterOnboardingPurple,
   middle: color.mediumOnboardingPurple,
   end: color.darkerOnboardingPurple,
-};
-
-color.vpnToggleDisconnected = {
-  defaultColor: color.grey30,
-  buttonHovered: mixColors(color.grey30, color.black, 0.2),
-  buttonPressed: mixColors(color.grey30, color.black, 0.3),
-  buttonDisabled: mixColors(color.grey30, color.black, 0.3),
-  focusOutline: color.transparent,
-  focusBorder: color.focusBorder,
 };

--- a/nebula/ui/themes/color-themes/main.js
+++ b/nebula/ui/themes/color-themes/main.js
@@ -80,6 +80,27 @@ color.stepProgressIconIncomplete = color.white;
 color.stepProgressIconComplete = color.successAccent;
 
 // Toggle
+color.vpnToggleConnected = {
+  defaultColor: color.green50,
+  buttonHovered: color.green60,
+  buttonPressed: color.green70,
+  focusOutline: addTransparency(color.bgColor, 0.3),
+  focusBorder: color.focusBorder,
+};
+
+color.vpnToggleDisconnected = {
+  defaultColor: color.grey30,
+  buttonHovered: color.fontColor,
+  buttonPressed: color.fontColorDark,
+  buttonDisabled: color.disabledButtonColor,
+  focusOutline: color.transparent,
+  focusBorder: color.focusBorder,
+};
+
+color.vpnToggleDisconnectedBorder = color.transparent;
+
+color.connectedToggle = color.white;
+color.disconnectedToggle = color.white;
 color.connectingToggle = color.dullPurple;
 color.connectingToggleBackground = color.dullGreen;
 
@@ -119,21 +140,4 @@ color.onBoardingGradient = {
   start: color.lighterOnboardingPurple,
   middle: color.mediumOnboardingPurple,
   end: color.darkerOnboardingPurple,
-};
-
-color.vpnToggleConnected = {
-  defaultColor: color.green50,
-  buttonHovered: color.green60,
-  buttonPressed: color.green70,
-  focusOutline: addTransparency(color.bgColor, 0.3),
-  focusBorder: color.focusBorder,
-};
-
-color.vpnToggleDisconnected = {
-  defaultColor: color.grey30,
-  buttonHovered: color.fontColor,
-  buttonPressed: color.fontColorDark,
-  buttonDisabled: color.disabledButtonColor,
-  focusOutline: color.transparent,
-  focusBorder: color.focusBorder,
 };

--- a/nebula/ui/themes/theme-derived.js
+++ b/nebula/ui/themes/theme-derived.js
@@ -13,6 +13,18 @@
 
 color.bgColorTransparent = addTransparency(color.bgColor, 0.0);
 
+color.vpnToggleDisconnectedMainSwitch = {
+  defaultColor:
+      (color.vpnToggleDisconnectedBorder === color.transparent ?
+           color.vpnToggleDisconnected.defaultColor :
+           color.bgColorStronger),
+  buttonHovered: color.vpnToggleDisconnected.buttonHovered,
+  buttonPressed: color.vpnToggleDisconnected.buttonPressed,
+  buttonDisabled: color.vpnToggleDisconnected.buttonDisabled,
+  focusOutline: color.vpnToggleDisconnected.focusOutline,
+  focusBorder: color.vpnToggleDisconnected.focusBorder,
+};
+
 // pressed/disabled goes darker on light theme, goes lighter on dark theme
 color.normalButton = {
   defaultColor: color.normalButtonDefault,

--- a/src/ui/screens/home/controller/VPNToggle.qml
+++ b/src/ui/screens/home/controller/VPNToggle.qml
@@ -50,6 +50,7 @@ MZButtonBase {
             PropertyChanges {
                 target: cursor
                 anchors.leftMargin: 4
+                color: MZTheme.colors.disconnectedToggle
             }
 
             PropertyChanges {
@@ -60,7 +61,12 @@ MZButtonBase {
 
             PropertyChanges {
                 target: toggleButton
-                toggleColor: MZTheme.colors.vpnToggleDisconnected
+                toggleColor: MZTheme.colors.vpnToggleDisconnectedMainSwitch
+            }
+
+            PropertyChanges {
+                target: disconnectedOutline
+                opacity: 1
             }
 
         },
@@ -70,6 +76,7 @@ MZButtonBase {
             PropertyChanges {
                 target: cursor
                 anchors.leftMargin: 4
+                color: MZTheme.colors.disconnectedToggle
             }
 
             PropertyChanges {
@@ -82,7 +89,12 @@ MZButtonBase {
                 target: toggleButton
                 //% "Turn VPN on"
                 toolTipTitle: qsTrId("vpn.toggle.on")
-                toggleColor: MZTheme.colors.vpnToggleDisconnected
+                toggleColor: MZTheme.colors.vpnToggleDisconnectedMainSwitch
+            }
+
+            PropertyChanges {
+                target: disconnectedOutline
+                opacity: 1
             }
 
         },
@@ -92,6 +104,7 @@ MZButtonBase {
             PropertyChanges {
                 target: cursor
                 anchors.leftMargin: 4
+                color: MZTheme.colors.disconnectedToggle
             }
 
             PropertyChanges {
@@ -104,7 +117,12 @@ MZButtonBase {
                 target: toggleButton
                 //% "Turn VPN on"
                 toolTipTitle: qsTrId("vpn.toggle.on")
-                toggleColor: MZTheme.colors.vpnToggleDisconnected
+                toggleColor: MZTheme.colors.vpnToggleDisconnectedMainSwitch
+            }
+
+            PropertyChanges {
+                target: disconnectedOutline
+                opacity: 1
             }
         },
 
@@ -131,6 +149,11 @@ MZButtonBase {
                 toggleColor: MZTheme.colors.vpnToggleConnected
             }
 
+            PropertyChanges {
+                target: disconnectedOutline
+                opacity: 0
+            }
+
         },
         State {
             name: VPNController.StateConfirming
@@ -154,6 +177,11 @@ MZButtonBase {
                 toggleColor: MZTheme.colors.vpnToggleConnected
             }
 
+            PropertyChanges {
+                target: disconnectedOutline
+                opacity: 0
+            }
+
         },
         State {
             name: VPNController.StateOn
@@ -161,6 +189,7 @@ MZButtonBase {
             PropertyChanges {
                 target: cursor
                 anchors.leftMargin: 32
+                color: MZTheme.colors.connectedToggle
             }
 
             PropertyChanges {
@@ -173,6 +202,11 @@ MZButtonBase {
                 target: toggleButton
                 toolTipTitle: qsTrId("vpn.toggle.off")
                 toggleColor: MZTheme.colors.vpnToggleConnected
+            }
+
+            PropertyChanges {
+                target: disconnectedOutline
+                opacity: 0
             }
         },
 
@@ -182,6 +216,7 @@ MZButtonBase {
             PropertyChanges {
                 target: cursor
                 anchors.leftMargin: 32
+                color: MZTheme.colors.connectedToggle
             }
 
             PropertyChanges {
@@ -195,6 +230,11 @@ MZButtonBase {
                 toolTipTitle: qsTrId("vpn.toggle.off")
                 toggleColor: MZTheme.colors.vpnToggleConnected
             }
+
+            PropertyChanges {
+                target: disconnectedOutline
+                opacity: 0
+            }
         },
         State {
             name: VPNController.StateDisconnecting
@@ -202,6 +242,7 @@ MZButtonBase {
             PropertyChanges {
                 target: cursor
                 anchors.leftMargin: 4
+                color: MZTheme.colors.disconnectedToggle
             }
 
             PropertyChanges {
@@ -216,6 +257,10 @@ MZButtonBase {
                 toggleColor: MZTheme.colors.vpnToggleDisconnected
             }
 
+            PropertyChanges {
+                target: disconnectedOutline
+                opacity: 1
+            }
         },
         State {
             name: VPNController.StateSwitching
@@ -257,6 +302,18 @@ MZButtonBase {
 
         }
     ]
+
+    // Using MZFocusBorder as the outline for dark mode's disconnected state
+    MZFocusBorder {
+        id: disconnectedOutline
+
+        anchors.fill: toggle
+        anchors.margins: -2
+        radius: height / 2
+        border.color: MZTheme.colors.vpnToggleDisconnectedBorder
+        color: MZTheme.colors.transparent
+        opacity: 1
+    }
 
     // Focus rings
     MZFocusBorder {
@@ -302,7 +359,7 @@ MZButtonBase {
         z: -1
         anchors.fill: toggle
         radius: height / 2
-        anchors.margins: -5
+        anchors.margins: -7
 
         PropertyAnimation on opacity {
             duration: 200
@@ -339,6 +396,7 @@ MZButtonBase {
         }
     }
 
+    // Circle within the toggle
     Rectangle {
         id: cursor
 


### PR DESCRIPTION
## Description

Updated the disconnected switch to have an outline on dark mode (with a main color identical to the background). Also tweaked colors of the toggle's circle.

Also made that hover glow slightly larger, as this border is outside the toggle - so that glow looked too thin with a couple points being taken up by this new outline.

Video shows dark mode and light mode - both using the mouse, then using the keyboard, then finally showing what the default toggles look like (they do not change in this PR): https://github.com/user-attachments/assets/c780c317-9ba9-4cab-ae05-a43c0dd29622

## Reference

VPN-7017

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
