### PR TITLE
VPN-7010 follow up - make spacing better

### DIFF
--- a/src/ui/screens/settings/ViewAppearance.qml
+++ b/src/ui/screens/settings/ViewAppearance.qml
@@ -57,15 +57,6 @@ MZViewBase {
                 Layout.rightMargin: MZTheme.theme.windowMargin / 2
                 visible: isVisible(radioButtonName)
 
-                MZMouseArea {
-                    anchors.fill: parent
-
-                    enabled: radioButtonId.enabled
-                    width: Math.min(parent.implicitWidth, parent.width)
-                    propagateClickToParent: false
-                    onClicked: wasClicked(radioButtonName)
-                }
-
                 MZRadioButton {
                     objectName: radioButtonName
 
@@ -95,6 +86,15 @@ MZViewBase {
                         Layout.fillWidth: true
                         visible: radioButtonName === "automaticAppearanceRadioButton"
                     }
+                }
+
+                MZMouseArea {
+                    anchors.fill: parent
+
+                    enabled: radioButtonId.enabled
+                    width: Math.min(parent.implicitWidth, parent.width)
+                    propagateClickToParent: false
+                    onClicked: wasClicked(radioButtonName)
                 }
             }
         }

--- a/src/ui/screens/settings/ViewDNSSettings.qml
+++ b/src/ui/screens/settings/ViewDNSSettings.qml
@@ -143,15 +143,6 @@ MZViewBase {
             spacing: MZTheme.theme.windowMargin
             Layout.rightMargin: MZTheme.theme.windowMargin / 2
 
-            MZMouseArea {
-                anchors.fill: parent
-
-                enabled: gatewayRadioButton.enabled
-                width: Math.min(parent.implicitWidth, parent.width)
-                propagateClickToParent: false
-                onClicked: applyFrontendChanges(MZSettings.Gateway);
-            }
-
             MZRadioButton {
                 objectName: "dnsStandard"
 
@@ -181,20 +172,20 @@ MZViewBase {
                     Layout.fillWidth: true
                 }
             }
+
+            MZMouseArea {
+                anchors.fill: parent
+
+                enabled: gatewayRadioButton.enabled
+                width: Math.min(parent.implicitWidth, parent.width)
+                propagateClickToParent: false
+                onClicked: applyFrontendChanges(MZSettings.Gateway);
+            }
         }
 
         RowLayout {
             Layout.fillWidth: true
             spacing: MZTheme.theme.windowMargin
-
-            MZMouseArea {
-                anchors.fill: parent
-
-                enabled: customRadioButton.enabled
-                width: Math.min(parent.implicitWidth, parent.width)
-                propagateClickToParent: false
-                onClicked: applyFrontendChanges(MZSettings.Custom);
-            }
 
             MZRadioButton {
                 objectName: "dnsCustom"
@@ -280,6 +271,15 @@ MZViewBase {
                         }
                     ]
                 }
+            }
+
+            MZMouseArea {
+                anchors.fill: parent
+
+                enabled: customRadioButton.enabled
+                width: Math.min(parent.implicitWidth, parent.width)
+                propagateClickToParent: false
+                onClicked: applyFrontendChanges(MZSettings.Custom);
             }
         }
     }

--- a/src/ui/screens/settings/appPermissions/AppPermissionsList.qml
+++ b/src/ui/screens/settings/appPermissions/AppPermissionsList.qml
@@ -181,14 +181,6 @@ ColumnLayout {
                     VPNAppPermissions.flip(appID)
                 }
 
-                MZMouseArea {
-                    anchors.fill: parent
-                    width: parent.implicitWidth
-                    height: parent.implicitHeight
-                    propagateClickToParent: false
-                    onClicked: () => appRow.handleClick()
-                }
-
                 MZCheckBox {
                     id: checkBox
                     objectName: "checkbox"
@@ -268,6 +260,14 @@ ColumnLayout {
                     text: appName
                     color: MZTheme.colors.fontColorDark
                     horizontalAlignment: Text.AlignLeft
+                }
+
+                MZMouseArea {
+                    anchors.fill: parent
+                    width: parent.implicitWidth
+                    height: parent.implicitHeight
+                    propagateClickToParent: false
+                    onClicked: () => appRow.handleClick()
                 }
             }
         }


### PR DESCRIPTION
## Description

This is a follow up to https://github.com/mozilla-mobile/mozilla-vpn-client/pull/10443, thanks to something QA found.

For reasons I don't fully understand, `MZMouseArea` results in 16 points of horizontal space being used - causing the regression described by QA. (You can confirm this by moving `MZMouseArea` in between the radio button and the text label - and that area will grow too large.) 

I'm not sure why this happens, but we can hide this extra space (while keeping the functionality) by moving it to the end of the row.

It's now fixed:
<img width="162" alt="Screenshot 44" src="https://github.com/user-attachments/assets/10085ac5-6b8d-4dea-b1b0-0b49e053b09c" /><img width="163" alt="Screenshot 43" src="https://github.com/user-attachments/assets/737cf089-6c6d-4022-a6d1-3b29c417a59a" /><img width="168" alt="Screenshot 42" src="https://github.com/user-attachments/assets/da79caf0-d770-4cb7-985b-187d63a4fbb2" />

## Reference

VPN-7010

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
