### PR TITLE
VPN-7020 (part 1) - remove special icon for dev menu

### DIFF
--- a/nebula/ui/utils/MZAssetLookup.js
+++ b/nebula/ui/utils/MZAssetLookup.js
@@ -124,10 +124,6 @@ var imageLookup = {
     filenameDark: 'qrc:/ui/resources/devices-dark.svg'
   },
   'IconWrench': {
-    filenameLight: 'qrc:/ui/resources/developer.svg',
-    filenameDark: 'qrc:/ui/resources/settings/preferences-dark.svg'
-  },
-  'IconWrenchDarker': {
     filenameLight: 'qrc:/ui/resources/settings/preferences.svg',
     filenameDark: 'qrc:/ui/resources/settings/preferences-dark.svg'
   },

--- a/src/ui/resources.qrc
+++ b/src/ui/resources.qrc
@@ -25,7 +25,6 @@
         <file>resources/devicesLimit-dark.svg</file>
         <file>resources/devicesRemove.svg</file>
         <file>resources/devicesRemove-dark.svg</file>
-        <file>resources/developer.svg</file>
         <file>resources/emptyMessages-DM.svg</file>
         <file>resources/emptyMessages-LM.svg</file>
         <file>resources/emptyServerList-DM.svg</file>

--- a/src/ui/resources/developer.svg
+++ b/src/ui/resources/developer.svg
@@ -1,6 +1,0 @@
-<!-- This Source Code Form is subject to the terms of the Mozilla Public
-   - License, v. 2.0. If a copy of the MPL was not distributed with this
-   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none">
-  <path d="M14.555 3.2l-2.434 2.436a1.243 1.243 0 1 1-1.757-1.757L12.8 1.445A3.956 3.956 0 0 0 11 1a3.976 3.976 0 0 0-3.434 6.02l-6.273 6.273a1 1 0 1 0 1.414 1.414L8.98 8.434A3.96 3.96 0 0 0 11 9a4 4 0 0 0 4-4 3.956 3.956 0 0 0-.445-1.8z" fill="#6D6D6E"/>
-</svg>

--- a/src/ui/screens/settings/ViewSettingsMenu.qml
+++ b/src/ui/screens/settings/ViewSettingsMenu.qml
@@ -107,7 +107,7 @@ MZViewBase {
                 id: preferencesSetting
                 objectName: "settingsPreferences"
                 settingTitle: MZI18n.SettingsPreferencesSettings
-                imageLeftSrc: MZAssetLookup.getImageSource("IconWrenchDarker")
+                imageLeftSrc: MZAssetLookup.getImageSource("IconWrench")
                 imageRightSrc: MZAssetLookup.getImageSource("Chevron")
                 imageRightMirror: MZLocalizer.isRightToLeft
                 onClicked: {


### PR DESCRIPTION
## Description

Some more Friday afternoon cleanup.

This came out of the work for VPN-1468 (theming work). In auditing all assets for VPN-3225, I found that there were a handful of assets that were nearly identical.

In this case, you may note that the only difference between the Preferences menu icon and the Dev menu icon is the color. And in light mode, the Dev menu icon doesn't match the text color (as it should). So let's remove the special icon for the dev menu.

## Reference

VPN-7020

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
