### PR TITLE
Update RPM build to Fedora 42

### DIFF
--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -49,7 +49,7 @@ jobs:
     needs: source-bundle
     runs-on: ubuntu-latest
     container:
-      image: fedora:41
+      image: fedora:42
 
     steps:
       - name: Download Source Package


### PR DESCRIPTION
## Description

Fedora 42 was released on 2025-04-15, cf. https://fedoramagazine.org/announcing-fedora-linux-42/

Current builds (tried 2.27.0~rc20250414171010-1 downloaded from https://github.com/mozilla-mobile/mozilla-vpn-client/actions/runs/14451532392) depend upon libQt6Gui.so.6(Qt_6.8_PRIVATE_API)(64bit) but since Fedora 42 is on Qt 6.9 no current package provides that symbol.

## Reference

N/A

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed