### PR TITLE
VPN-7021: Improve colors by moving them into Nebula objects

### DIFF
--- a/nebula/ui/components/MZBadge.qml
+++ b/nebula/ui/components/MZBadge.qml
@@ -7,19 +7,50 @@ import QtQuick 2.0
 import Mozilla.Shared 1.0
 
 Rectangle {
+    enum BadgeType {
+        Success,
+        Normal,
+        Warning,
+        Error
+    }
+
     id: root
 
-    //A type is a JS object containing the badgeText and badgeBackgroundColor and badgeTextColor
-    property var badgeType
+    // Private property, will be changed depending on badgeType
+    QtObject {
+        id: style
+        property var backgroundColor: {
+          switch (root.badgeType) {
+            case MZBadge.BadgeType.Success:
+              return MZTheme.colors.successBackground
+            case MZBadge.BadgeType.Normal:
+              return MZTheme.colors.normalLevelBackground
+            case MZBadge.BadgeType.Warning:
+              return MZTheme.colors.warningBackground
+            case MZBadge.BadgeType.Error:
+              return MZTheme.colors.errorBackground
+          }
+        }
 
-    //Alternatively to setting the badgeType, you can set it's properties manually
-    property alias backgroundColor: root.color
+        property var textColor: {
+          switch (root.badgeType) {
+            case MZBadge.BadgeType.Success:
+              return MZTheme.colors.successText
+            case MZBadge.BadgeType.Normal:
+              return MZTheme.colors.normalLevelText
+            case MZBadge.BadgeType.Warning:
+              return MZTheme.colors.warningText
+            case MZBadge.BadgeType.Error:
+              return MZTheme.colors.errorText
+          }
+        }
+    }
+
+    property var badgeType: MZBadge.BadgeType.Normal
     property alias text: badgeLabel.text
-    property alias textColor: badgeLabel.color
-
     property alias badgeLabel: badgeLabel
 
-    color: badgeType.badgeBackgroundColor
+    color: style.backgroundColor
     height: badgeLabel.height
     width: badgeLabel.width
     radius: 4
@@ -29,7 +60,7 @@ Rectangle {
         id: badgeLabel
 
         text: badgeType.badgeText
-        color: badgeType.badgeTextColor
+        color: style.textColor
         verticalAlignment: Text.AlignVCenter
         topPadding: MZTheme.theme.badgeVerticalPadding
         leftPadding: MZTheme.theme.badgeHorizontalPadding

--- a/nebula/ui/components/MZComposerView.qml
+++ b/nebula/ui/components/MZComposerView.qml
@@ -94,7 +94,6 @@ ColumnLayout {
 
                     text: loader.composerBlock.text
                     font.pixelSize: MZTheme.theme.fontSizeSmall
-                    color: MZTheme.colors.fontColor
                     horizontalAlignment: Text.AlignLeft
                 }
             }
@@ -112,7 +111,6 @@ ColumnLayout {
                     text: `<${listType} style='margin-left: -24px;-qt-list-indent:1;'>%1</${listType}>`.arg(tagsList.join(""))
                     textFormat: Text.RichText
                     font.pixelSize: MZTheme.theme.fontSizeSmall
-                    color: MZTheme.colors.fontColor
                     horizontalAlignment: Text.AlignLeft
                     Accessible.name: tagsList.join(".\n").replace(repeater.indentTagRegex, "")
                     lineHeight: 20

--- a/nebula/ui/components/MZHelpSheet.qml
+++ b/nebula/ui/components/MZHelpSheet.qml
@@ -214,7 +214,6 @@ MZBottomSheet {
 
                                     text: loader.composerBlock.text
                                     font.pixelSize: MZTheme.theme.fontSizeSmall
-                                    color: MZTheme.colors.fontColor
                                     lineHeight: 21
                                     horizontalAlignment: Text.AlignLeft
                                 }

--- a/nebula/ui/components/MZInterLabel.qml
+++ b/nebula/ui/components/MZInterLabel.qml
@@ -15,7 +15,7 @@ Text {
     lineHeightMode: Text.FixedHeight
     lineHeight: MZTheme.theme.labelLineHeight
     wrapMode: Text.Wrap
-    color: MZTheme.colors.fontColorDark
+    color: MZTheme.colors.fontColor
 
     Accessible.role: Accessible.StaticText
     Accessible.name: text

--- a/nebula/ui/components/MZMetropolisLabel.qml
+++ b/nebula/ui/components/MZMetropolisLabel.qml
@@ -15,6 +15,7 @@ Text {
     lineHeightMode: Text.FixedHeight
     lineHeight: MZTheme.theme.labelLineHeight
     wrapMode: Text.Wrap
+    color: MZTheme.colors.fontColorDark
 
     Accessible.role: Accessible.StaticText
     Accessible.name: text

--- a/nebula/ui/components/MZPaymentMethod.qml
+++ b/nebula/ui/components/MZPaymentMethod.qml
@@ -19,6 +19,7 @@ RowLayout {
         id: label
         objectName: "paymentLabel"
 
+        color: MZTheme.colors.fontColorDark
         horizontalAlignment: Text.AlignLeft
         font.pixelSize: MZTheme.theme.fontSizeSmall
         text: selectedPaymentMethod.name

--- a/nebula/ui/components/MZPopupButton.qml
+++ b/nebula/ui/components/MZPopupButton.qml
@@ -42,7 +42,6 @@ MZButtonBase {
     contentItem: MZInterLabel {
         id: buttonText
 
-        color: style.colorScheme.fontColor
         font.family: isCancelBtn ? MZTheme.theme.fontInterFamily : MZTheme.theme.fontBoldFamily
         lineHeight: 15
         horizontalAlignment: Text.AlignHCenter

--- a/nebula/ui/components/MZSimplePopup.qml
+++ b/nebula/ui/components/MZSimplePopup.qml
@@ -37,7 +37,6 @@ MZPopup {
             Layout.topMargin: MZTheme.theme.vSpacingSmall
             Layout.fillWidth: true
 
-            color: MZTheme.colors.fontColorDark
             font.pixelSize: MZTheme.theme.fontSizeLarge
             lineHeight: MZTheme.theme.vSpacingSmall * 2
 

--- a/nebula/ui/components/MZSimplePopup.qml
+++ b/nebula/ui/components/MZSimplePopup.qml
@@ -48,8 +48,6 @@ MZPopup {
 
             Layout.topMargin: MZTheme.theme.vSpacingSmall / 2
             Layout.fillWidth: true
-
-            color: MZTheme.colors.fontColor
         }
 
         ColumnLayout {

--- a/src/ui/screens/devices/VPNDeviceListItem.qml
+++ b/src/ui/screens/devices/VPNDeviceListItem.qml
@@ -78,6 +78,7 @@ MZSwipeDelegate {
                 MZInterLabel {
                     Layout.fillWidth: true
 
+                    color: MZTheme.colors.fontColorDark
                     text: name
                     maximumLineCount: 1
                     elide: Text.ElideRight

--- a/src/ui/screens/devices/ViewDevices.qml
+++ b/src/ui/screens/devices/ViewDevices.qml
@@ -56,7 +56,6 @@ MZViewBase {
                 Layout.maximumWidth: vpnFlickable.width - parent.Layout.leftMargin - parent.Layout.rightMargin - parent.spacing - helpIconButtonLoader.implicitWidth
 
                 horizontalAlignment: Text.AlignLeft
-                color: MZTheme.colors.fontColor
                 text: MZI18n.DevicesCountLabel.arg(VPNDeviceModel.activeDevices).arg(VPNUser.maxDevices)
             }
 

--- a/src/ui/screens/getHelp/developerMenu/ViewColorObjects.qml
+++ b/src/ui/screens/getHelp/developerMenu/ViewColorObjects.qml
@@ -138,38 +138,26 @@ MZViewBase {
 
           MZBadge {
               badgeLabel.width: badgeLabel.implicitWidth
-              badgeType: {
-                      'badgeText': "Error badge",
-                      'badgeTextColor': MZTheme.colors.errorText,
-                      'badgeBackgroundColor': MZTheme.colors.errorBackground
-                  };
+              text: "Error badge"
+              badgeType: MZBadge.BadgeType.Error
           }
 
           MZBadge {
               badgeLabel.width: badgeLabel.implicitWidth
-              badgeType: {
-                      'badgeText': "Warning badge",
-                      'badgeTextColor': MZTheme.colors.warningText,
-                      'badgeBackgroundColor': MZTheme.colors.warningBackground
-                  };
+              text: "Warning badge"
+              badgeType: MZBadge.BadgeType.Warning
           }
 
           MZBadge {
               badgeLabel.width: badgeLabel.implicitWidth
-              badgeType: {
-                      'badgeText': "Success badge",
-                      'badgeTextColor': MZTheme.colors.successText,
-                      'badgeBackgroundColor': MZTheme.colors.successBackground
-                  };
+              text: "Success badge"
+              badgeType: MZBadge.BadgeType.Success
           }
 
           MZBadge {
               badgeLabel.width: badgeLabel.implicitWidth
-              badgeType: {
-                      'badgeText': "Normal badge",
-                      'badgeTextColor': MZTheme.colors.normalLevelText,
-                      'badgeBackgroundColor': MZTheme.colors.normalLevelBackground
-                  };
+              text: "Normal badge"
+              badgeType: MZBadge.BadgeType.Normal
           }
 
           Rectangle {

--- a/src/ui/screens/getHelp/developerMenu/ViewImagesPlayground.qml
+++ b/src/ui/screens/getHelp/developerMenu/ViewImagesPlayground.qml
@@ -38,7 +38,6 @@ Item {
             text: "No image selected"
             anchors.horizontalCenter: parent.horizontalCenter
             anchors.verticalCenter: parent.verticalCenter
-            color: MZTheme.colors.fontColor
             visible: imageSelect.currentIndex < 0
         }
         

--- a/src/ui/screens/getHelp/developerMenu/ViewUiTesting.qml
+++ b/src/ui/screens/getHelp/developerMenu/ViewUiTesting.qml
@@ -121,7 +121,6 @@ MZViewBase {
 
                             text: "Use these features for more protection. They may cause issues on some sites, so you can turn them off anytime in settings."
                             horizontalAlignment: Text.AlignLeft
-                            color: MZTheme.colors.fontColor
                         }
 
                         MZCheckBoxRow {

--- a/src/ui/screens/home/controller/ConnectionStability.qml
+++ b/src/ui/screens/home/controller/ConnectionStability.qml
@@ -138,6 +138,7 @@ Item {
                                                         "vpn.connectionStability.noSignal")
 
                 id: stabilityLabel
+                color: MZTheme.colors.fontColorDark
                 lineHeight: MZTheme.theme.controllerInterLineHeight
                 onPaintedWidthChanged: stability.setColumns()
                 text: VPNConnectionHealth.stability

--- a/src/ui/screens/home/controller/ControllerView.qml
+++ b/src/ui/screens/home/controller/ControllerView.qml
@@ -523,6 +523,7 @@ Item {
             id: logoSubtitle
             objectName: "controllerSubTitle"
 
+            color: MZTheme.colors.fontColorDark
             lineHeight: MZTheme.theme.controllerInterLineHeight
             width: parent.width - MZTheme.theme.windowMargin
             anchors.horizontalCenter: parent.horizontalCenter

--- a/src/ui/screens/home/servers/ServerList.qml
+++ b/src/ui/screens/home/servers/ServerList.qml
@@ -200,7 +200,6 @@ FocusScope {
                                 Layout.preferredWidth: parent.width
                                 Layout.maximumWidth: parent.width
 
-                                color: MZTheme.colors.fontColor
                                 horizontalAlignment: Text.AlignLeft
                                 // TODO: Replace placeholder strings and generate
                                 // values that will be set instead of `%1`

--- a/src/ui/screens/messaging/ViewMessage.qml
+++ b/src/ui/screens/messaging/ViewMessage.qml
@@ -158,7 +158,6 @@ MZViewBase {
                 Layout.alignment: Qt.AlignRight
 
                 text: message.formattedDate
-                color: MZTheme.colors.fontColor
                 font.pixelSize: MZTheme.theme.fontSizeSmall
                 lineHeight: 21
                 horizontalAlignment: Text.AlignRight
@@ -192,7 +191,6 @@ MZViewBase {
 
                 text: message.subtitle
                 font.pixelSize: MZTheme.theme.fontSizeSmall
-                color: MZTheme.colors.fontColor
                 horizontalAlignment: Text.AlignLeft
             }
 

--- a/src/ui/screens/messaging/ViewMessage.qml
+++ b/src/ui/screens/messaging/ViewMessage.qml
@@ -93,60 +93,39 @@ MZViewBase {
                     badgeType: {
                         switch(message.badge) {
                         case MZAddonMessage.Warning:
-                            return badgeInfo.warningBadge
+                            return MZBadge.BadgeType.Warning
                         case MZAddonMessage.Critical:
-                            return badgeInfo.criticalBadge
+                            return MZBadge.BadgeType.Error
                         case MZAddonMessage.NewUpdate:
-                            return badgeInfo.newUpdateBadge
+                            return MZBadge.BadgeType.Success
                         case MZAddonMessage.WhatsNew:
-                            return badgeInfo.whatsNewBadge
+                            return MZBadge.BadgeType.Normal
                         case MZAddonMessage.Survey:
-                            return badgeInfo.surveyBadge
+                            return MZBadge.BadgeType.Normal
                         case MZAddonMessage.Subscription:
-                            return badgeInfo.subscriptionBadge
+                            return MZBadge.BadgeType.Normal
                         case MZAddonMessage.Extension:
-                            return badgeInfo.extensionBadge
+                            return MZBadge.BadgeType.Normal
                         }
                     }
 
-                    QtObject {
-                        id: badgeInfo
-
-                        property var warningBadge: {
-                            'badgeText': MZI18n.InAppMessagingWarningBadge,
-                            'badgeTextColor': MZTheme.colors.warningText,
-                            'badgeBackgroundColor': MZTheme.colors.warningBackground
-                        };
-                        property var criticalBadge: {
-                            'badgeText': MZI18n.InAppMessagingCriticalBadge,
-                            'badgeTextColor': MZTheme.colors.errorText,
-                            'badgeBackgroundColor': MZTheme.colors.errorBackground
-                        };
-                        property var newUpdateBadge: {
-                            'badgeText': MZI18n.InAppMessagingNewUpdateBadge,
-                            'badgeTextColor': MZTheme.colors.successText,
-                            'badgeBackgroundColor': MZTheme.colors.successBackground
-                        };
-                        property var whatsNewBadge: {
-                            'badgeText': MZI18n.InAppMessagingWhatsNewBadge,
-                            'badgeTextColor': MZTheme.colors.normalLevelText,
-                            'badgeBackgroundColor': MZTheme.colors.normalLevelBackground
-                        };
-                        property var surveyBadge: {
-                            'badgeText': MZI18n.InAppMessagingSurveyBadge,
-                            'badgeTextColor': MZTheme.colors.normalLevelText,
-                            'badgeBackgroundColor': MZTheme.colors.normalLevelBackground
-                        };
-                        property var subscriptionBadge: {
-                            'badgeText': MZI18n.InAppMessagingSubscriptionBadge,
-                            'badgeTextColor': MZTheme.colors.normalLevelText,
-                            'badgeBackgroundColor': MZTheme.colors.normalLevelBackground
-                        };
-                        property var extensionBadge: {
-                            'badgeText': MZI18n.InAppMessagingExtensionBadge,
-                            'badgeTextColor': MZTheme.colors.normalLevelText,
-                            'badgeBackgroundColor': MZTheme.colors.normalLevelBackground
-                        };
+                    text: {
+                        switch(message.badge) {
+                        case MZAddonMessage.Warning:
+                            return MZI18n.InAppMessagingWarningBadge
+                        case MZAddonMessage.Critical:
+                            return MZI18n.InAppMessagingCriticalBadge
+                        case MZAddonMessage.NewUpdate:
+                            return MZI18n.InAppMessagingNewUpdateBadge
+                        case MZAddonMessage.WhatsNew:
+                            return MZI18n.InAppMessagingWhatsNewBadge
+                        case MZAddonMessage.Survey:
+                            return MZI18n.InAppMessagingSurveyBadge
+                        case MZAddonMessage.Subscription:
+                            return MZI18n.InAppMessagingSubscriptionBadge
+                        case MZAddonMessage.Extension:
+                            return MZI18n.InAppMessagingExtensionBadge
+                        }
                     }
                 }
             }

--- a/src/ui/screens/messaging/ViewMessagesInbox.qml
+++ b/src/ui/screens/messaging/ViewMessagesInbox.qml
@@ -110,7 +110,6 @@ MZViewBase {
 
             text: MZI18n.InAppMessagingEmptyStateDescription
             visible: vpnFlickable.isEmptyState
-            color: MZTheme.colors.fontColor
         }
 
         ListView {
@@ -272,7 +271,6 @@ MZViewBase {
                                 text: swipeDelegate.formattedDate
                                 font.pixelSize: MZTheme.theme.fontSizeSmall
                                 lineHeight: 21
-                                color: MZTheme.colors.fontColor
                                 horizontalAlignment: Text.AlignRight
                             }
                         }
@@ -285,7 +283,6 @@ MZViewBase {
                             text: swipeDelegate.subtitle
                             font.pixelSize: MZTheme.theme.fontSizeSmall
                             lineHeight: 21
-                            color: MZTheme.colors.fontColor
                             horizontalAlignment: Text.AlignLeft
                             elide: Text.ElideRight
                             maximumLineCount: 1

--- a/src/ui/screens/onboarding/OnboardingDataSlide.qml
+++ b/src/ui/screens/onboarding/OnboardingDataSlide.qml
@@ -38,7 +38,6 @@ ColumnLayout {
 
         text: MZI18n.OnboardingDataSlideBody2
         horizontalAlignment: Text.AlignLeft
-        color: MZTheme.colors.fontColor
    }
 
     RowLayout {
@@ -105,7 +104,6 @@ ColumnLayout {
         Layout.fillWidth: true
 
         text: MZI18n.OnboardingDataSlideLearnMoreCaption2
-        color: MZTheme.colors.fontColor
    }
 
     MZLinkButton {

--- a/src/ui/screens/onboarding/OnboardingDevicesSlide.qml
+++ b/src/ui/screens/onboarding/OnboardingDevicesSlide.qml
@@ -41,7 +41,6 @@ ColumnLayout {
 
         text: MZUiUtils.isMobile() ? MZI18n.OnboardingDevicesSlideBodyMobile : MZI18n.OnboardingDevicesSlideBody2
         horizontalAlignment: Text.AlignLeft
-        color: MZTheme.colors.fontColor
     }
 
     RowLayout {

--- a/src/ui/screens/onboarding/OnboardingPrivacySlide.qml
+++ b/src/ui/screens/onboarding/OnboardingPrivacySlide.qml
@@ -40,7 +40,6 @@ ColumnLayout {
 
         text: MZI18n.OnboardingPrivacySlideBody
         horizontalAlignment: Text.AlignLeft
-        color: MZTheme.colors.fontColor
     }
 
     PrivacyFeaturesList {

--- a/src/ui/screens/onboarding/OnboardingStartSlideDesktop.qml
+++ b/src/ui/screens/onboarding/OnboardingStartSlideDesktop.qml
@@ -44,7 +44,6 @@ ColumnLayout {
 
         text: MZI18n.OnboardingStartSlideBody2
         horizontalAlignment: Text.AlignLeft
-        color: MZTheme.colors.fontColor
     }
 
     RowLayout {

--- a/src/ui/screens/onboarding/OnboardingStartSlideMobile.qml
+++ b/src/ui/screens/onboarding/OnboardingStartSlideMobile.qml
@@ -40,7 +40,6 @@ ColumnLayout {
 
         text: MZI18n.OnboardingStartSlideMobileBody
         horizontalAlignment: Text.AlignLeft
-        color: MZTheme.colors.fontColor
     }
 
     Item {

--- a/src/ui/screens/settings/ViewAppearance.qml
+++ b/src/ui/screens/settings/ViewAppearance.qml
@@ -85,6 +85,7 @@ MZViewBase {
                     MZInterLabel {
                         Layout.fillWidth: true
 
+                        color: MZTheme.colors.fontColorDark
                         text: MZI18n[textName]
                         wrapMode: Text.WordWrap
                         horizontalAlignment: Text.AlignLeft

--- a/src/ui/screens/settings/ViewDNSSettings.qml
+++ b/src/ui/screens/settings/ViewDNSSettings.qml
@@ -171,6 +171,7 @@ MZViewBase {
                 MZInterLabel {
                     Layout.fillWidth: true
 
+                    color: MZTheme.colors.fontColorDark
                     text: MZI18n.SettingsDnsSettingsStandardDNSTitle
                     wrapMode: Text.WordWrap
                     horizontalAlignment: Text.AlignLeft
@@ -216,6 +217,7 @@ MZViewBase {
                 MZInterLabel {
                     Layout.fillWidth: true
 
+                    color: MZTheme.colors.fontColorDark
                     text: MZI18n.SettingsDnsSettingsCustomDNSTitle
                     wrapMode: Text.WordWrap
                     horizontalAlignment: Text.AlignLeft

--- a/src/ui/screens/settings/ViewFirefoxExtensionInfo.qml
+++ b/src/ui/screens/settings/ViewFirefoxExtensionInfo.qml
@@ -34,6 +34,7 @@ MZViewBase {
         }
 
         MZInterLabel {
+            color: MZTheme.colors.fontColorDark
             text: MZI18n.SettingsFirefoxExtensionIntro
             horizontalAlignment: Text.AlignLeft
             Layout.preferredWidth: parent.width
@@ -52,6 +53,7 @@ MZViewBase {
           }
 
           MZInterLabel {
+            color: MZTheme.colors.fontColorDark
             text: MZI18n.SettingsFirefoxExtensionFirstParagraphMain
             horizontalAlignment: Text.AlignLeft
             Layout.preferredWidth: parent.width
@@ -71,6 +73,7 @@ MZViewBase {
           }
 
           MZInterLabel {
+            color: MZTheme.colors.fontColorDark
             text: MZI18n.SettingsFirefoxExtensionSecondParagraphMain
             horizontalAlignment: Text.AlignLeft
             Layout.preferredWidth: parent.width

--- a/src/ui/screens/settings/ViewReset.qml
+++ b/src/ui/screens/settings/ViewReset.qml
@@ -49,7 +49,6 @@ ViewFullScreen {
             Layout.fillWidth: true
 
             text: MZI18n.ResetSettingsBody1
-            color: MZTheme.colors.fontColor
             horizontalAlignment: Text.AlignLeft
         }
 
@@ -59,7 +58,6 @@ ViewFullScreen {
 
             text: "<ul style='margin-left: -20px;'><li>%1</li></ul>".arg(MZI18n.HelpSheetsPrivacyTitle)
             textFormat: Text.RichText
-            color: MZTheme.colors.fontColor
             horizontalAlignment: Text.AlignLeft
 
             Accessible.name: MZI18n.HelpSheetsPrivacyTitle
@@ -71,7 +69,6 @@ ViewFullScreen {
 
             text: "<ul style='margin-left: -20px;'><li>%1</li></ul>".arg(MZI18n.SettingsAppExclusionTitle)
             textFormat: Text.RichText
-            color: MZTheme.colors.fontColor
             horizontalAlignment: Text.AlignLeft
             visible: MZFeatureList.get("splitTunnel").isSupported
 
@@ -84,7 +81,6 @@ ViewFullScreen {
 
             text: "<ul style='margin-left: -20px;'><li>%1</li></ul>".arg(MZI18n.MultiHopFeatureMultiHopConnectionsHeader)
             textFormat: Text.RichText
-            color: MZTheme.colors.fontColor
             horizontalAlignment: Text.AlignLeft
 
             Accessible.name: MZI18n.MultiHopFeatureMultiHopConnectionsHeader
@@ -96,7 +92,6 @@ ViewFullScreen {
 
             text: "<ul style='margin-left: -20px;'><li>%1</li></ul>".arg(MZI18n.ResetSettingsListItemPreferences)
             textFormat: Text.RichText
-            color: MZTheme.colors.fontColor
             horizontalAlignment: Text.AlignLeft
 
             Accessible.name: MZI18n.ResetSettingsListItemPreferences
@@ -107,7 +102,6 @@ ViewFullScreen {
             Layout.fillWidth: true
 
             text: MZI18n.ResetSettingsBody2
-            color: MZTheme.colors.fontColor
             horizontalAlignment: Text.AlignLeft
         }
     }

--- a/src/ui/screens/settings/ViewSubscriptionManagement/SubscriptionManagementItem.qml
+++ b/src/ui/screens/settings/ViewSubscriptionManagement/SubscriptionManagementItem.qml
@@ -104,6 +104,7 @@ ColumnLayout {
             visible: !paymentMethod.visible
             text: labelText
             wrapMode: Text.WordWrap
+            color: MZTheme.colors.fontColorDark
 
             Layout.alignment: Qt.AlignLeft
         }

--- a/src/ui/screens/settings/ViewSubscriptionManagement/ViewSubscriptionManagement.qml
+++ b/src/ui/screens/settings/ViewSubscriptionManagement/ViewSubscriptionManagement.qml
@@ -59,7 +59,6 @@ MZViewBase {
 
 
             MZMetropolisLabel {
-                color: MZTheme.colors.fontColorDark
                 horizontalAlignment: Text.AlignLeft
                 font.family: MZTheme.theme.fontBoldFamily
                 text: MZI18n.SubscriptionManagementSummaryHeadline
@@ -81,7 +80,6 @@ MZViewBase {
             }
 
             MZMetropolisLabel {
-                color: MZTheme.colors.fontColorDark
                 horizontalAlignment: Text.AlignLeft
                 font.family: MZTheme.theme.fontBoldFamily
                 text: MZI18n.SubscriptionManagementPaymentHeadline

--- a/src/ui/sharedViews/ViewPermissionRequiredOSX.qml
+++ b/src/ui/sharedViews/ViewPermissionRequiredOSX.qml
@@ -67,7 +67,6 @@ MZFlickable {
                 Layout.fillWidth: true
 
                 text: MZI18n.PermissionMacosBody
-                color: MZTheme.colors.fontColor
                 horizontalAlignment: Text.AlignLeft
             }
 
@@ -76,7 +75,6 @@ MZFlickable {
                 Layout.fillWidth: true
 
                 text: MZI18n.PermissionMacosInstructions
-                color: MZTheme.colors.fontColor
                 horizontalAlignment: Text.AlignLeft
             }
         }


### PR DESCRIPTION
## Description

In an ideal world, all `MZTheme.colors.*` are only in Nebula objects, and the objects have a type that can be set to pull up the proper color scheme. This gets us a tiny bit closer to that:
1) It reworks `MZBadge` to this style
2) All `MZMetropolisLabel`s have the same font color, so it is now set on that label
3) I updated the default `MZLabel` font color to be the most frequently used one (and changed others to the old default)

## Reference

VPN-7021

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
