### PR TITLE
Add setuptools to requirements.in

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -2,6 +2,7 @@ aqtinstall==3.2.0
 glean-parser==13.0.0
 oathtool==2.3.2
 pyrsistent==0.20.0
+setuptools==80.0.0
 yamllint==1.37.0
 
 # Windows-only dependency included via glean-parser.


### PR DESCRIPTION
## Description

The glean parser script uses `pkg_resources`, and running the glean parser script fails. 

According to the release notes for Python 3.12[^1], `setuptools` is not included in a virtual environment by default any more and should be explicitly included.

I don't know what would be the appropriate version, the latest version worked for me.  So I used that.

[^1]: https://docs.python.org/3/whatsnew/3.12.html

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
