### PR TITLE
Allow the extension to trigger a minimized start

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,7 @@ __pycache__
 lottie.mjs
 qml_lint_result.txt
 .qmlls.ini
-release_notes.txts
+release_notes.txt
 
 # Translation pipeline
 addon_ts/

--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,8 @@ linux/netfilter/vendor/
 __pycache__
 lottie.mjs
 qml_lint_result.txt
-release_notes.txt
+.qmlls.ini
+release_notes.txts
 
 # Translation pipeline
 addon_ts/

--- a/extension/bridge/src/commands.rs
+++ b/extension/bridge/src/commands.rs
@@ -107,7 +107,7 @@ mod launcher {
 #[cfg(not(target_os = "windows"))]
 mod launcher {
     use serde_json::json;
-    pub fn start_vpn() -> serde_json::Value{
+    pub fn start_vpn(_minimized: bool) -> serde_json::Value{
         json!("{error:'start_unsupported!'}")
     }
 }

--- a/extension/bridge/src/commands.rs
+++ b/extension/bridge/src/commands.rs
@@ -31,7 +31,13 @@
              Ok(true)
          }
          "start" =>{
-            let out = launcher::start_vpn();
+            let mut minimized = false;
+            if obj.contains_key("minimized") {
+                let val = obj.get_key_value("minimized").ok_or("Null minimized");
+                minimized = val?.1.as_bool().unwrap_or(false);
+            }
+
+            let out = launcher::start_vpn(minimized);
             crate::io::write_output(std::io::stdout(),&out)
                 .expect("Unable to Write to STDOUT?");
             Ok(true)
@@ -78,9 +84,14 @@ mod launcher {
     const CREATE_NEW_PROCESS_GROUP: u32 = 0x200; // CREATE_NEW_PROCESS_GROUP
     const DETACHED_PROCESS: u32 = 0x00000008;    // DETACHED_PROCESS
 
-    pub fn start_vpn() -> serde_json::Value{
+    pub fn start_vpn(minimized: bool) -> serde_json::Value{
+        let mut args: Vec<&str>= vec!["ui"];
+        if minimized{
+            args.push("--minimized");
+        }
+
         let result = Command::new(CLIENT_PATH)
-            .args(["ui"])
+            .args(args)
             .creation_flags(CREATE_NEW_PROCESS_GROUP | DETACHED_PROCESS)
             .spawn();
 


### PR DESCRIPTION
## Description
I'm currently hacking on the extension's "let's start the vpn when entering PBM". 
Given we switch to on-partial mode, nothing visually happens in the client when we activate the extension. 

So it's a bit off-putting that if you then open a private browsing mode a vpn windows appears in the center of your screen, empty, deactivated. Like it's judging you to activate it. 


![image](https://github.com/user-attachments/assets/d4c78865-f149-440a-86ab-c0cdbade792b)

But we actually already did this the moment you see the screen, so let's just allow the extension to start the vpn in the background 🥳 