### PR TITLE
Android: Remove orientationlock

### DIFF
--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -33,7 +33,6 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
             android:configChanges="orientation|uiMode|screenLayout|screenSize|smallestScreenSize|layoutDirection|locale|fontScale|keyboard|keyboardHidden|navigation|mcc|mnc|density"
             android:name="org.mozilla.firefox.vpn.qt.VPNActivity"
             android:label="Mozilla VPN"
-            android:screenOrientation="portrait"
             android:theme="@style/AppTheme.Splash"
             android:windowSoftInputMode="adjustPan"
             android:exported="true"


### PR DESCRIPTION
## Description

> On [Android 12 (API level 31)](https://developer.android.com/about/versions/12/12L/summary#dev-device-orientation-request) and higher, device manufacturers can configure individual device screens (such as the tablet-sized screen of a foldable) to ignore this suggestion, and instead force an activity to be letterboxed within the user's preferred orientation of the device.
## Checklist

If we look at #10442 we're clearly in that letterboxing case that seems to fuck stuff up. 
My current hypothesis is that while we're letterboxed, qt still assumes the full width+height of the landscape screen
