### PR TITLE
VPN-7027: Fix main switch for transitions and when there is no daemon

### DIFF
--- a/src/controller.h
+++ b/src/controller.h
@@ -69,7 +69,7 @@ class Controller : public QObject, public LogSerializer {
   void startHandshakeTimer();
   bool isDeviceConnected() const { return m_isDeviceConnected; }
   bool isInitialized() const { return m_state >= StateOff; }
-  bool isActive() const { return m_state > StateOff; }
+  Q_INVOKABLE bool isActive() const { return m_state > StateOff; }
 
   const ServerData& currentServer() const { return m_serverData; }
 

--- a/src/ui/screens/home/controller/ControllerImage.qml
+++ b/src/ui/screens/home/controller/ControllerImage.qml
@@ -128,7 +128,7 @@ Rectangle {
             }
             PropertyChanges {
                 target: insetCircle
-                color: MZTheme.colors.successAlert.defaultColor
+                color: MZTheme.colors.errorAccentLight
             }
             PropertyChanges {
                 target: insetIcon
@@ -145,7 +145,7 @@ Rectangle {
             }
             PropertyChanges {
                 target: insetCircle
-                color: MZTheme.colors.successAlert.defaultColor
+                color: MZTheme.colors.errorAccentLight
             }
             PropertyChanges {
                 target: insetIcon

--- a/src/ui/screens/home/controller/VPNToggle.qml
+++ b/src/ui/screens/home/controller/VPNToggle.qml
@@ -13,7 +13,8 @@ MZButtonBase {
 
     property var connectionRetryOverX: VPNController.connectionRetry > 1
     property var enableDisconnectInConfirming: VPNController.enableDisconnectInConfirming
-    property var toggleColor: {}
+    // Without a default for toggleColor, there is a flicker on dark mode when tapping into the main screen while VPN is disconnected
+    property var toggleColor: (VPNController.isActive() ? MZTheme.colors.vpnToggleConnected : MZTheme.colors.vpnToggleDisconnectedMainSwitch)
     property var toolTipTitle: ""
     Accessible.name: toolTipTitle
 
@@ -55,7 +56,7 @@ MZButtonBase {
 
             PropertyChanges {
                 target: toggle
-                color: MZTheme.colors.vpnToggleDisconnected.defaultColor
+                color: MZTheme.colors.vpnToggleDisconnectedMainSwitch.defaultColor
                 border.color: MZTheme.colors.bgColorStronger
             }
 
@@ -68,7 +69,6 @@ MZButtonBase {
                 target: disconnectedOutline
                 opacity: 1
             }
-
         },
         State {
             name: VPNController.StatePermissionRequired
@@ -80,13 +80,18 @@ MZButtonBase {
 
             PropertyChanges {
                 target: toggle
-                color: MZTheme.colors.vpnToggleDisconnected.defaultColor
+                color: MZTheme.colors.vpnToggleDisconnectedMainSwitch.defaultColor
                 border.color: MZTheme.colors.bgColorStronger
             }
 
             PropertyChanges {
                 target: toggleButton
-                toggleColor: MZTheme.colors.vpnToggleDisconnected
+                toggleColor: MZTheme.colors.vpnToggleDisconnectedMainSwitch
+            }
+
+            PropertyChanges {
+                target: disconnectedOutline
+                opacity: 1
             }
         },
         State {
@@ -100,7 +105,7 @@ MZButtonBase {
 
             PropertyChanges {
                 target: toggle
-                color: MZTheme.colors.vpnToggleDisconnected.defaultColor
+                color: MZTheme.colors.vpnToggleDisconnectedMainSwitch.defaultColor
                 border.color: MZTheme.colors.bgColorStronger
             }
 
@@ -128,7 +133,7 @@ MZButtonBase {
 
             PropertyChanges {
                 target: toggle
-                color: MZTheme.colors.vpnToggleDisconnected.defaultColor
+                color: MZTheme.colors.vpnToggleDisconnectedMainSwitch.defaultColor
                 border.color: MZTheme.colors.bgColorStronger
             }
 
@@ -266,14 +271,14 @@ MZButtonBase {
 
             PropertyChanges {
                 target: toggle
-                color: MZTheme.colors.vpnToggleDisconnected.buttonDisabled
+                color: MZTheme.colors.vpnToggleDisconnectedMainSwitch.buttonDisabled
                 border.color: MZTheme.colors.bgColorStronger
             }
 
             PropertyChanges {
                 target: toggleButton
                 toolTipTitle: qsTrId("vpn.toggle.on")
-                toggleColor: MZTheme.colors.vpnToggleDisconnected
+                toggleColor: MZTheme.colors.vpnToggleDisconnectedMainSwitch
             }
 
             PropertyChanges {


### PR DESCRIPTION
## Description

A few things to make this smoother:

- Fix the `insetCircle` color on initialization. This fixes the "inset circle is green when there is no daemon found" problem.
- Give the `toggleColor` a default value. This fixes the "there is a flicker on dark mode when moving to this screen while the switch is off" problem.
- Change all the remaining `vpnToggleDisconnected` to `vpnToggleDisconnectedMainSwitch`. This fixes the "when no daemon, the switch shows as solid gray on dark mode" problem.
- Update `StatePermissionRequired` to show the proper outline border.

## Reference

VPN-7027

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
