### PR TITLE
VPN-7024: Remove legacy daemon plist during package install

### DIFF
--- a/macos/pkg/scripts/postinstall.in
+++ b/macos/pkg/scripts/postinstall.in
@@ -59,12 +59,15 @@ if ! codesign -v --verbose=4 -R="${CODESIGN_REQS}" "$APP_DIR"; then
 fi
 echo "Codesign successful!"
 
+# Unload the daemon
 UPDATING=
-if [ -f "$DAEMON_PLIST_PATH" ]; then
+if launchctl bootout system/${CODESIGN_APP_IDENTIFIER}.daemon 2>/dev/null; then
+  echo "Update detected"
   UPDATING=1
-  # Load the daemon
-  echo "Update detected - Unloading the Daemon"
-  launchctl unload -w $DAEMON_PLIST_PATH
+fi
+if [ -f "$DAEMON_PLIST_PATH" ]; then
+  echo "Removing legacy daemon plist"
+  rm -f ${DAEMON_PLIST_PATH}
 fi
 
 # For legacy MacOS versions - a privileged helper tool is required to run


### PR DESCRIPTION
## Description
When users attempt to upgrade from 2.27 to the latest and greatest. The installer package would leave the `/Library/LaunchDaemons/org.mozilla.macos.FirefoxVPN.daemon.plist` file on disk. This would cause problems when trying to install the daemon service using `SMAppService` which gets confused and thinks the daemon already exists.

To ensure that the daemon can be cleanly installed, we need to make sure to clean that file up at package installation.

## Reference
JIRA Issue: [VPN-7024](https://mozilla-hub.atlassian.net/browse/VPN-7024)
JIRA Issue: [VPN-6945](https://mozilla-hub.atlassian.net/browse/VPN-6945)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-7024]: https://mozilla-hub.atlassian.net/browse/VPN-7024?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[VPN-6945]: https://mozilla-hub.atlassian.net/browse/VPN-6945?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ