### PR TITLE
CMAKE: Add an option to disable sentry

### DIFF
--- a/.github/workflows/auth_tests.yml
+++ b/.github/workflows/auth_tests.yml
@@ -31,7 +31,7 @@ jobs:
         shell: bash
         run: |
           mkdir -p build
-          cmake -S . -B $(pwd)/build -GNinja
+          cmake -S . -B $(pwd)/build -GNinja -DBUILD_CRASHREPORTING=OFF
           cmake --build $(pwd)/build --target app_auth_tests
 
       - name: Running tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,8 @@ cmake_minimum_required(VERSION 3.20)
 cmake_policy(SET CMP0118 NEW)
 
 option(BUILD_TESTS "Whether or not to build test targets" ON)
+option(BUILD_CRASHREPORTING "Whether or not Sentry-Crash Reporting will be built" ON)
+
 
 message("Configuring for ${CMAKE_GENERATOR}")
 get_property(IS_MULTI_CONFIG GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)

--- a/docs/Building/index.md
+++ b/docs/Building/index.md
@@ -77,6 +77,7 @@ cmake flags:
 * `CMAKE_OSX_ARCHITECTURES`: set to "arm64;x86_64" to build a universal build
 
 other flags:
+* `BUILD_CRASHREPORTING=OFF`: Can be set to skip compilation of sentry-native. Makes sense for non-mozilla builds as without symbols sent to sentry, the reports are less insightful.
 * `BUILD_TESTING=ON`: can be set to build, and execute the unit tests using `CTest`
 * `BUILD_ID=<string>`: sets the build identifier that will be embedded into the project. If
   left unset, this will generate a timestamp when configuring the Makefiles.

--- a/src/cmake/sentry.cmake
+++ b/src/cmake/sentry.cmake
@@ -4,7 +4,10 @@
 
 
 # This CMAKE File will Integrate Sentry into MZ
-
+if(NOT BUILD_CRASHREPORTING)
+    message("Sentry disabled by commandline")
+    return()
+endif()
 
 # Defines which OS builds can include sentry. Check src/cmake Lists for all values of MZ_PLATFORM_NAME
 set(SENTRY_SUPPORTED_OS  "Windows" "Darwin" "Android" "iOS" "Linux")


### PR DESCRIPTION
- **Let the people disable sentry**
- **the auth tests do not need that**

## Description

    Describe your changes

## Reference

    i.e Jira or Github issue URL

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
