### PR TITLE
VPN-7025: fix button font color

### DIFF
--- a/nebula/ui/components/MZPopupButton.qml
+++ b/nebula/ui/components/MZPopupButton.qml
@@ -43,6 +43,7 @@ MZButtonBase {
         id: buttonText
 
         font.family: isCancelBtn ? MZTheme.theme.fontInterFamily : MZTheme.theme.fontBoldFamily
+        color: style.colorScheme.fontColor
         lineHeight: 15
         horizontalAlignment: Text.AlignHCenter
         verticalAlignment: Text.AlignVCenter


### PR DESCRIPTION
## Description

For reasons unknown, `MZPopupButton` is only used in `VPNRemoveDevicePopup`, so this is the only place with this issue. I introduced this problem in [a recent PR](https://github.com/mozilla-mobile/mozilla-vpn-client/pull/10462/files#diff-ed0c2a194000472763071a0f94554aa7e7b9c74c6bf0dd7cae9e6e044d275d7b), where I changed how button colors were created. I didn't realize that this button was defined differently from the rest, and required the color to be set here.

Screenshots of it fixed:
<img width="158" alt="Screenshot 2" src="https://github.com/user-attachments/assets/0da27628-14fc-495f-b947-d5d953971860" /><img width="165" alt="Screenshot 1" src="https://github.com/user-attachments/assets/b6e18610-f213-4057-9ebc-555f9dd8d1f9" />


## Reference

VPN-7025

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
