### PR TITLE
CI: Have Flatpack build the branch rather a merge commit

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -33,7 +33,7 @@ jobs:
         run: |
           python -m yq -yi 'del(.modules[-1].sources[0].branch)' org.mozilla.vpn.yml
           python -m yq -yi ".modules[-1].sources[0].url = \"https://github.com/${{ github.repository }}\"" org.mozilla.vpn.yml
-          python -m yq -yi ".modules[-1].sources[0].commit = \"${{ github.sha }}\"" org.mozilla.vpn.yml
+          python -m yq -yi ".modules[-1].sources[0].commit = \"${{ github.head_ref }}\"" org.mozilla.vpn.yml
           cat org.mozilla.vpn.yml
 
       - name: Add Appstream metainfo


### PR DESCRIPTION
## Description

So i noticed that sometimes the flatpack builds fail i.e 
https://github.com/mozilla-mobile/mozilla-vpn-client/actions/runs/14845508171/job/41712574160?pr=10478 

```
========================================================================
Building module mozillavpn in /__w/mozilla-vpn-client/mozilla-vpn-client/.flatpak-builder/build/mozillavpn-1
========================================================================
Updated Git hooks.
Git LFS initialized.
fatal: unable to read tree (cd92b367c45901b0bc742d1018c5c0c8f87b8c97)
Error: module mozillavpn: Child process exited with code 128
```

What put me off is that the commit `cd92` it fails to load is not part of the pr: https://github.com/mozilla-mobile/mozilla-vpn-client/pull/10478

It seems that the `${github.sha}` points to: 
> Note that GITHUB_SHA for this event is the last merge commit of the pull request merge branch. 

So that is not the branch itself but rather "how do things look if merged into main". 

Given that the flatpack builder again clones the repo, maybe it's not getting that commit 100% of the time?
So let's point it to the actual commit that triggered the workflow, which is more in line with what we do on the other checks. 


