### PR TITLE
VPN-7034: add new iPhone sizes to fix layout issue

### DIFF
--- a/src/ui/main.qml
+++ b/src/ui/main.qml
@@ -34,6 +34,7 @@ Window {
             return 0;
         }
         switch(window.height * Screen.devicePixelRatio) {
+        // Notch (natch)
         case 1624: // iPhone_XR (Qt Provided Physical Resolution)
         case 1792: // iPhone_XR
 
@@ -44,10 +45,14 @@ Window {
         case 2778: // iPhone_12_Pro_Max
         case 2340: // iPhone_12_mini
             return 34;
-        case 2556: // iPhone_14_Pro
+
+        // Dynamic island
+        case 2556: // iPhone_14_Pro, 15, 15 Pro, 16
+        case 2622: // iPhone 16, 16 Pro
+        case 2796: // iPhone_14_Pro_Max, 15 Plus, 15 Pro Max, 16 Plus
+        case 2868: // iPhone 16 Pro Max
             return 48;
-        case 2796: // iPhone_14_Pro_Max
-            return 48;
+
         default:
             return 20;
         }


### PR DESCRIPTION
## Description

Adding newer iPhone sizes. I didn't realize we manually set this; I've added a reminder for myself to update this (if needed) when new iOS devices come out. I checked these sizes against a [couple](https://www.ios-resolution.com/) [spots](https://www.practicallynetworked.com/iphone-size-comparison-chart/), and confirmed against [Apple's docs](https://www.apple.com/iphone-16-pro/specs/) for the 16 Pros.

(Unnecessary grumble grumble... a native app is typically setup to handle this automatically by default, at this point only something like Qt needs manual updates to keep this working when new devices sizes come out... shakes fist at sky.)

## Reference

VPN-7034

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
