### PR TITLE
VPN-7035: Add background log fallback when daemon is not running

### DIFF
--- a/macos/pkg/scripts/postinstall.in
+++ b/macos/pkg/scripts/postinstall.in
@@ -29,6 +29,7 @@ APPLE_OID_EXT_CA_INTERMEDIATE="1.2.840.113635.100.6.2.6"
 #APPLE_OID_EXT_CA_INTERMEDIATE="1.2.840.113635.100.6.2.1"
 
 mkdir -p $LOG_DIR
+chmod 755 $LOG_DIR
 exec 2>&1 > $LOG_DIR/postinstall.log
 
 echo "Running postinstall at $(date)"

--- a/src/localsocketcontroller.h
+++ b/src/localsocketcontroller.h
@@ -66,7 +66,7 @@ class LocalSocketController : public ControllerImpl {
              const QString& expectedResponseType = QString(),
              int timeout = CONNECTION_RESPONSE_TIMEOUT_MSEC);
 
- private:
+ protected:
   enum {
     eUnknown,
     eInitializing,
@@ -74,6 +74,7 @@ class LocalSocketController : public ControllerImpl {
     eDisconnected,
   } m_daemonState = eUnknown;
 
+ private:
   const QString m_path;
   QLocalSocket* m_socket = nullptr;
 

--- a/src/platforms/linux/backendlogsobserver.cpp
+++ b/src/platforms/linux/backendlogsobserver.cpp
@@ -27,7 +27,6 @@ BackendLogsObserver::~BackendLogsObserver() {
 
 void BackendLogsObserver::completed(QDBusPendingCallWatcher* call) {
   QDBusPendingReply<QString> reply = *call;
-  
   if (!reply.isError()) {
     QString status = reply.argumentAt<0>();
     m_callback(status);

--- a/src/platforms/macos/daemon/macosdaemonserver.h
+++ b/src/platforms/macos/daemon/macosdaemonserver.h
@@ -18,6 +18,7 @@ class MacOSDaemonServer final : public Command {
 
  private:
   static bool makeRuntimeDir(const QDir& dir);
+  static void setupLogDir();
 };
 
 #endif  // MACOSDAEMONSERVER_H

--- a/src/platforms/macos/macoscontroller.h
+++ b/src/platforms/macos/macoscontroller.h
@@ -16,6 +16,8 @@ class MacOSController final : public LocalSocketController {
 
   void initialize(const Device* device, const Keys* keys) override;
 
+  void getBackendLogs(std::function<void(const QString&)>&& callback) override;
+
  private slots:
   void checkServiceEnabled();
 


### PR DESCRIPTION
## Description
Sometimes we get support tickets from users where the daemon is offline for one reason or another, and we find ourselves having to guide users through manually fetching the logs off disk. This is a pain in the butt and in many cases we can automate this with some platform-specific code in the controller to access the log files.

This implements the fallback for macOS and Linux. I don't think it's feasible to do the same on Windows as the log file is written to a protected directory.

## Reference
JIRA Issue [VPN-7035](https://mozilla-hub.atlassian.net/browse/VPN-7035)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-7035]: https://mozilla-hub.atlassian.net/browse/VPN-7035?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ