### PR TITLE
VPN-6941: Update OSX permission required screen to use SUMO link

### DIFF
--- a/src/constants.h
+++ b/src/constants.h
@@ -216,7 +216,7 @@ constexpr const char* SUMO_ALWAYS_ON_ANDROID =
     "https://support.mozilla.org/kb/how-enable-always-vpn-android";
 
 constexpr const char* SUMO_ALLOW_BACKGROUND_MACOS =
-    "https://support.mozilla.org/en-US/kb/allow-vpn-run-background-macos";
+    "https://support.mozilla.org/kb/allow-vpn-run-background-macos";
 
 PRODBETAEXPR(QString, contactSupportUrl, "https://accounts.firefox.com/support",
              "https://accounts.stage.mozaws.net/support")

--- a/src/constants.h
+++ b/src/constants.h
@@ -215,6 +215,9 @@ constexpr const char* SUMO_MULTIHOP =
 constexpr const char* SUMO_ALWAYS_ON_ANDROID =
     "https://support.mozilla.org/kb/how-enable-always-vpn-android";
 
+constexpr const char* SUMO_ALLOW_BACKGROUND_MACOS =
+    "https://support.mozilla.org/en-US/kb/allow-vpn-run-background-macos";
+
 PRODBETAEXPR(QString, contactSupportUrl, "https://accounts.firefox.com/support",
              "https://accounts.stage.mozaws.net/support")
 

--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -1355,6 +1355,10 @@ void MozillaVPN::registerUrlOpenerLabels() {
   uo->registerUrlLabel("sumoAlwaysOnAndroid", []() -> QString {
     return Constants::SUMO_ALWAYS_ON_ANDROID;
   });
+
+  uo->registerUrlLabel("sumoAllowBackgroundMacos", []() -> QString {
+    return Constants::SUMO_ALLOW_BACKGROUND_MACOS;
+  });
 }
 
 void MozillaVPN::errorHandled() {

--- a/src/ui/sharedViews/ViewPermissionRequiredOSX.qml
+++ b/src/ui/sharedViews/ViewPermissionRequiredOSX.qml
@@ -11,25 +11,15 @@ import components 0.1
 import "qrc:/nebula/utils/MZAssetLookup.js" as MZAssetLookup
 
 MZFlickable {
-    id: vpnFlickable
-
-    property var primaryButtonObjectName
+    id: osxPermissionRequired
 
     width: parent.width
-    flickContentHeight: headerLink.implicitHeight + col.implicitHeight + col.anchors.topMargin
-
-    MZHeaderLink {
-        id: headerLink
-        objectName: "getHelpLink"
-
-        labelText: MZI18n.GetHelpLinkText
-        onClicked: MZNavigator.requestScreen(VPN.ScreenGetHelp)
-    }
+    flickContentHeight: col.implicitHeight + col.anchors.topMargin
 
     ColumnLayout {
         id: col
 
-        anchors.top: headerLink.bottom
+        anchors.top: parent.top
         anchors.left: parent.left
         anchors.right: parent.right
         spacing: MZTheme.theme.vSpacingSmall
@@ -84,13 +74,21 @@ MZFlickable {
         }
 
         MZButton {
-            id: primaryButton
+            id: openSettingsButton
 
-            objectName: primaryButtonObjectName
             text: MZI18n.PermissionMacosOpenSettingsButtonLabel
             Layout.preferredHeight: MZTheme.theme.rowHeight
             loaderVisible: false
             onClicked: VPNMacOSUtils.openSystemSettingsLoginItems()
+        }
+
+        MZLinkButton {
+            id: learnMoreLink
+
+            labelText:  MZI18n.GlobalLearnMore
+            Layout.preferredHeight: MZTheme.theme.rowHeight
+            Layout.alignment: Qt.AlignHCenter
+            onClicked: MZUrlOpener.openUrlLabel("sumoAllowBackgroundMacos")
         }
 
         MZSignOut {


### PR DESCRIPTION
## Description
The new OSX permission required screen doesn't match the Figma designs, in particular the `Help` link is in the wrong place and is inteded to open a SUMO article instead of opening the help screen. This should move the link and add a URL to SUMO as expected.

The updated screen is as follows:
<img width="472" alt="Screenshot 2025-05-07 at 10 12 00 AM" src="https://github.com/user-attachments/assets/1c16e56f-696f-4998-aace-70b14a98a4fc" />


## Reference
JIRA Issue: [VPN-6941](https://mozilla-hub.atlassian.net/browse/VPN-6941)
Figma Design: [link](https://www.figma.com/design/aqZq6eYrgAthI6BU3Soasr/macOS-Permissions-Update?node-id=97-157)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-6941]: https://mozilla-hub.atlassian.net/browse/VPN-6941?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ