### PR TITLE
Nit: Support Apple native string types in Logger

### DIFF
--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -54,6 +54,13 @@ Logger::Log& Logger::Log::operator<<(QTextStreamFunction t) {
   return *this;
 }
 
+#ifdef Q_OS_APPLE
+Logger::Log& Logger::Log::operator<<(const NSString* t) {
+  m_data->m_ts << QString::fromNSString(t);
+  return *this;
+}
+#endif
+
 QString Logger::sensitive(const QString& input) {
 #ifdef MZ_DEBUG
   return input;

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -59,6 +59,10 @@ Logger::Log& Logger::Log::operator<<(const NSString* t) {
   m_data->m_ts << QString::fromNSString(t);
   return *this;
 }
+Logger::Log& Logger::Log::operator<<(CFStringRef t) {
+  m_data->m_ts << QString::fromNSString(reinterpret_cast<const NSString*>(t));
+  return *this;
+}
 #endif
 
 QString Logger::sensitive(const QString& input) {

--- a/src/logger.h
+++ b/src/logger.h
@@ -35,6 +35,7 @@ class Logger {
     Log& operator<<(const void* t);
 #ifdef Q_OS_APPLE
     Log& operator<<(const NSString* t);
+    Log& operator<<(CFStringRef t);
 #endif
 
     // Q_ENUM

--- a/src/logger.h
+++ b/src/logger.h
@@ -33,6 +33,9 @@ class Logger {
     Log& operator<<(const QJsonObject& t);
     Log& operator<<(QTextStreamFunction t);
     Log& operator<<(const void* t);
+#ifdef Q_OS_APPLE
+    Log& operator<<(const NSString* t);
+#endif
 
     // Q_ENUM
     template <typename T>

--- a/src/platforms/ios/ioscontroller.mm
+++ b/src/platforms/ios/ioscontroller.mm
@@ -275,8 +275,8 @@ void IOSController::checkStatus() {
       }
     }
 
-    logger.debug() << "ServerIpv4Gateway:" << QString::fromNSString(serverIpv4Gateway)
-                   << "DeviceIpv4Address:" << QString::fromNSString(deviceIpv4Address)
+    logger.debug() << "ServerIpv4Gateway:" << serverIpv4Gateway
+                   << "DeviceIpv4Address:" << deviceIpv4Address
                    << "RxBytes:" << rxBytes << "TxBytes:" << txBytes;
     emit statusUpdated(QString::fromNSString(serverIpv4Gateway),
                        QString::fromNSString(deviceIpv4Address), txBytes, rxBytes);

--- a/src/platforms/ios/iosiaphandler.mm
+++ b/src/platforms/ios/iosiaphandler.mm
@@ -83,7 +83,7 @@ void IOSIAPHandler::nativeRegisterProducts() {
         productData->m_nonLocalizedMonthlyPrice = monthlyPriceNumber;
         productData->m_currencyCode = QString::fromNSString(currencyCode);
 
-        logger.debug() << "Id:" << QString::fromNSString(productIdentifier);
+        logger.debug() << "Id:" << productIdentifier;
         logger.debug() << "Price:" << productData->m_price;
         logger.debug() << "Monthly price:" << productData->m_monthlyPrice;
       }

--- a/src/platforms/ios/iosutils.mm
+++ b/src/platforms/ios/iosutils.mm
@@ -45,7 +45,7 @@ QString IOSUtils::IAPReceipt() {
   NSString* path = [receiptURL path];
   Q_ASSERT(path);
 
-  logger.debug() << "Receipt URL:" << QString::fromNSString(path);
+  logger.debug() << "Receipt URL:" << path;
 
   NSFileManager* fileManager = [NSFileManager defaultManager];
   Q_ASSERT(fileManager);
@@ -59,7 +59,7 @@ QString IOSUtils::IAPReceipt() {
 
     NSString* fileOwner = [fileAttributes objectForKey:NSFileOwnerAccountName];
     if (fileOwner) {
-      logger.debug() << "Owner:" << QString::fromNSString(fileOwner);
+      logger.debug() << "Owner:" << fileOwner;
     }
 
     NSDate* fileModDate = [fileAttributes objectForKey:NSFileModificationDate];

--- a/src/platforms/macos/daemon/macosdnsmanager.cpp
+++ b/src/platforms/macos/daemon/macosdnsmanager.cpp
@@ -210,7 +210,7 @@ QString MacOSDnsManager::cfParseString(CFTypeRef ref) {
   if (CFGetTypeID(ref) != CFStringGetTypeID()) {
     return QString();
   }
-  return QString::fromNSString(static_cast<NSString*>(ref));
+  return QString::fromNSString(static_cast<const NSString*>(ref));
 }
 
 // static

--- a/src/platforms/macos/daemon/macosdnsmanager.cpp
+++ b/src/platforms/macos/daemon/macosdnsmanager.cpp
@@ -210,23 +210,7 @@ QString MacOSDnsManager::cfParseString(CFTypeRef ref) {
   if (CFGetTypeID(ref) != CFStringGetTypeID()) {
     return QString();
   }
-
-  CFStringRef stringref = (CFStringRef)ref;
-  CFRange range;
-  range.location = 0;
-  range.length = CFStringGetLength(stringref);
-  if (range.length <= 0) {
-    return QString();
-  }
-
-  UniChar* buf = (UniChar*)malloc(range.length * sizeof(UniChar));
-  if (!buf) {
-    return QString();
-  }
-  auto guard = qScopeGuard([&] { free(buf); });
-
-  CFStringGetCharacters(stringref, range, buf);
-  return QString::fromUtf16(buf, range.length);
+  return QString::fromNSString(static_cast<NSString*>(ref));
 }
 
 // static

--- a/src/platforms/macos/macoscontroller.mm
+++ b/src/platforms/macos/macoscontroller.mm
@@ -58,7 +58,7 @@ void MacOSController::initialize(const Device* device, const Keys* keys) {
       // Otherwise, we encountered some other error. Most likely the user
       // needs to approve the daemon to run. Which will be handled below.
       logger.error() << "Unable to register Mozilla VPN daemon:"
-                     << QString::fromNSString(error.localizedDescription);
+                     << error.localizedDescription;
     }
 
     // Check the service status for how to proceed.

--- a/src/platforms/macos/macoscryptosettings.mm
+++ b/src/platforms/macos/macoscryptosettings.mm
@@ -126,8 +126,7 @@ bool MacOSCryptoSettings::checkCodesign() {
   CFStringRef signer = SecTaskCopySigningIdentifier(task, nullptr);
   CFRelease(task);
   if (signer != nullptr) {
-    logger.debug() << "Got signature from:"
-                   << QString::fromNSString(static_cast<NSString*>(signer));
+    logger.debug() << "Got signature from:" << signer;
     CFRelease(signer);
     return true;
   }
@@ -158,8 +157,7 @@ bool MacOSCryptoSettings::checkEntitlement(const QString& name) {
   CFTypeRef result = SecTaskCopyValueForEntitlement(task, cfName, &error);
   if (error != nullptr) {
     CFStringRef desc = CFErrorCopyDescription(error);
-    logger.error() << "Failed to check entitlements:"
-                   << QString::fromNSString(static_cast<NSString*>(desc));
+    logger.error() << "Failed to check entitlements:" << desc;
     CFRelease(desc);
     CFRelease(error);
   }

--- a/src/platforms/macos/macosnetworkwatcher.mm
+++ b/src/platforms/macos/macosnetworkwatcher.mm
@@ -30,7 +30,7 @@ Logger logger("MacOSNetworkWatcher");
 }
 
 - (void)bssidDidChangeForWiFiInterfaceWithName:(NSString*)interfaceName {
-  logger.debug() << "BSSID changed!" << QString::fromNSString(interfaceName);
+  logger.debug() << "BSSID changed!" << interfaceName;
 
   if (m_watcher) {
     m_watcher->checkInterface();


### PR DESCRIPTION
## Description
This adds Apple's native string types (`NSString*` for objective-C and it's C equivalent `CFStringRef`) to the `Logger` class so that they can be logged without needing to cast and convert them around. And while we're at it, use the new logger methods to cleanup a bunch of iOS and macOS code.

I keep find myself cherry-picking this patch between PRs. So maybe its probably time to split this into its own PR.

## Reference

    i.e Jira or Github issue URL

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
