### PR TITLE
VPN-6921: Logout upon launch w/ in app purchase

### DIFF
--- a/src/platforms/ios/iosiaphandler.swift
+++ b/src/platforms/ios/iosiaphandler.swift
@@ -174,12 +174,12 @@ import StoreKit
     InAppPurchaseHandler.logger.info(message: "Creating transaction listener")
       return Task(priority: .background) {
           for await verificationResult in Transaction.updates {
-              self.handle(updatedTransaction: verificationResult)
+              await self.handle(updatedTransaction: verificationResult)
           }
       }
   }
 
-  private func handle(updatedTransaction verificationResult: VerificationResult<Transaction>) {
+  private func handle(updatedTransaction verificationResult: VerificationResult<Transaction>) async {
     guard case .verified(let transaction) = verificationResult else {
         InAppPurchaseHandler.logger.info(message: "Unverified transaction returend")
         return
@@ -193,17 +193,16 @@ import StoreKit
       // Expirations handled by server
       InAppPurchaseHandler.logger.info(message: "Transaction has expired")
       errorCallback(false)
-        return
     } else if transaction.isUpgraded {
         // Do nothing, there is an active transaction
         // for a higher level of service.
       InAppPurchaseHandler.logger.info(message: "Transaction was upgraded")
       errorCallback(false)
-        return
     } else {
       InAppPurchaseHandler.logger.info(message: "New successful transaction returned")
       let originalTransactionIdentifier: String = "\(transaction.originalID)"
       successCallback(NSString(string: transaction.productID), NSString(string: originalTransactionIdentifier))
+      await transaction.finish()
     }
   }
 }

--- a/src/purchaseiaphandler.cpp
+++ b/src/purchaseiaphandler.cpp
@@ -52,5 +52,10 @@ void PurchaseIAPHandler::startSubscription(const QString& productIdentifier) {
 
 void PurchaseIAPHandler::startRestoreSubscription() {
   logger.debug() << "Starting the restore of the subscription";
+  if (m_subscriptionState != eInactive) {
+    logger.warning() << "No multiple IAP!";
+    return;
+  }
+  m_subscriptionState = eActive;
   nativeRestoreSubscription();
 }


### PR DESCRIPTION
## Description

I believe adding `transaction.finish()` fixes the bug, likely completely. The rest of this code is mostly to make things more defensive in case similar edge cases pop up - we only try to complete transactions if we're actually in the process of doing a transaction in the UI.

I'm not 100% sure if we need to call `transaction.finish()` on the expired/upgraded/revoked code paths. The documentation is silent on this, and there are a variety of opinions in forums. Ultimately, with the defensive work done it shouldn't matter for these code paths whether we finish them or not.

### What is happening
- Pretty quickly, I identified via the client logs that we were running `TaskAddDevice` more than we should, and that sometimes we didn't think the current device was in the account. This led me down an unfruitful rabbit hole thinking it was about the keys on the device changing or going missing, that Guardian was randomly removing a device, and other similar thoughts. As part of this, I spent a long while in our Guardian logs online.
- I then noticed that client logs have `Subscription completed with StoreKit2. User not signed in.` repeatedly, which was the tip off.
- I eventually realized that while we're `finish`ing the transaction in the happiest code path, there was another code path where we weren't - and thus when iOS sent an `update` on the transaction (seemingly when device rebooted?), we were treating it like a new transaction. And while one code path from here was confirming we were actively in a "subscribing" screen before continuing on, several others were not - and those paths could cause the range of outcomes we were experiencing.
- The user was logged out when the app though the user wasn't authenticated. But why was `App::instance()->userAuthenticated()` false, causing this issue?
    -  I didn’t expect this code to be run on app launch. It’s running this before the App has moved itself out of `StateInitialized`. So `userAuthenticated` (which is `return (m_state > StateAuthenticating) && holder->hasToken();`) doesn’t have a state higher than `StateAuthenticating`, and returns false.

I've tested this using [Apple's guidance](https://developer.apple.com/documentation/storekit/testing-purchases-made-outside-your-app) on testing purchases made outside the app, as that also comes through via `update`.

## Reference

VPN-6921

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
