### PR TITLE
VPN-7040: fix flatpaks tests?

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -33,7 +33,7 @@ jobs:
         run: |
           python -m yq -yi 'del(.modules[-1].sources[0].branch)' org.mozilla.vpn.yml
           python -m yq -yi ".modules[-1].sources[0].url = \"https://github.com/${{ github.repository }}\"" org.mozilla.vpn.yml
-          python -m yq -yi ".modules[-1].sources[0].commit = \"${{ github.head_ref }}\"" org.mozilla.vpn.yml
+          python -m yq -yi ".modules[-1].sources[0].commit = \"${{ github.ref }}\"" org.mozilla.vpn.yml
           cat org.mozilla.vpn.yml
 
       - name: Add Appstream metainfo


### PR DESCRIPTION
## Description

From [docs](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs) on `head-ref`: `The head_ref or source branch of the pull request in a workflow run. This property is only available when the event that triggers a workflow run is either pull_request or pull_request_target.`

So by definition, it’s expected this would fail when running tests on `main`, as we've observed. But it’s succeeding on PRs. (And this changed [in a recent PR](https://github.com/mozilla-mobile/mozilla-vpn-client/pull/10480/files).)

Looking at [documentation](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs), maybe `ref` is what we want?

## Reference

VPN-7040

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
