### PR TITLE
VPN-7041: Use XPC Service for daemon communication

### DIFF
--- a/macos/app/Info.plist.in
+++ b/macos/app/Info.plist.in
@@ -48,5 +48,12 @@
 	<string>NSApplication</string>
 	<key>NSSupportsAutomaticGraphicsSwitching</key>
 	<true/>
+	<key>XPCService</key>
+	<dict>
+		<key>ServiceType</key>
+		<string>Application</string>
+		<key>RunLoopType</key>
+		<string>NSRunLoop</string>
+	</dict>
 </dict>
 </plist>

--- a/macos/app/service.plist.in
+++ b/macos/app/service.plist.in
@@ -13,6 +13,11 @@
                         <string>Mozilla VPN</string>
                         <string>macosdaemon</string>
                 </array>
+                <key>MachServices</key>
+                <dict>
+                        <key>${BUILD_OSX_APP_IDENTIFIER}.daemon</key>
+                        <true/>
+                </dict>
                 <key>UserName</key>
                 <string>root</string>
                 <key>RunAtLoad</key>

--- a/macos/app/service.plist.in
+++ b/macos/app/service.plist.in
@@ -15,7 +15,7 @@
                 </array>
                 <key>MachServices</key>
                 <dict>
-                        <key>${BUILD_OSX_APP_IDENTIFIER}.daemon</key>
+                        <key>${BUILD_OSX_APP_IDENTIFIER}.service</key>
                         <true/>
                 </dict>
                 <key>UserName</key>

--- a/src/cmake/macos.cmake
+++ b/src/cmake/macos.cmake
@@ -52,6 +52,8 @@ target_sources(mozillavpn PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/platforms/macos/daemon/macosroutemonitor.h
     ${CMAKE_CURRENT_SOURCE_DIR}/platforms/macos/daemon/wireguardutilsmacos.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/platforms/macos/daemon/wireguardutilsmacos.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/platforms/macos/daemon/xpcdaemonserver.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/platforms/macos/daemon/xpcdaemonserver.mm
     ${CMAKE_CURRENT_SOURCE_DIR}/platforms/macos/macoscontroller.h
     ${CMAKE_CURRENT_SOURCE_DIR}/platforms/macos/macoscontroller.mm
     ${CMAKE_CURRENT_SOURCE_DIR}/platforms/macos/macoscryptosettings.h
@@ -70,6 +72,7 @@ target_sources(mozillavpn PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/platforms/macos/macosstatusicon.h
     ${CMAKE_CURRENT_SOURCE_DIR}/platforms/macos/macosutils.mm
     ${CMAKE_CURRENT_SOURCE_DIR}/platforms/macos/macosutils.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/platforms/macos/xpcdaemonprotocol.h
     ${CMAKE_CURRENT_SOURCE_DIR}/platforms/ios/iosnetworkwatcher.mm
     ${CMAKE_CURRENT_SOURCE_DIR}/platforms/ios/iosnetworkwatcher.h
 )

--- a/src/controller.h
+++ b/src/controller.h
@@ -45,6 +45,16 @@ class Controller : public QObject, public LogSerializer {
     ReasonSwitching,
     ReasonConfirming,
   };
+
+  enum ErrorCode {
+    ErrorNone = 0,
+    ErrorFatal = 1,
+    ErrorSplitTunnelInit = 2,
+    ErrorSplitTunnelStart = 3,
+    ErrorSplitTunnelExclude = 4,
+  };
+  Q_ENUM(ErrorCode);
+
   /**
    * @brief Who asked the Connection
    * to be Initiated? A Webextension
@@ -137,6 +147,7 @@ class Controller : public QObject, public LogSerializer {
   void implInitialized(bool status, bool connected,
                        const QDateTime& connectionDate);
   void implPermRequired();
+  void handleBackendFailure(ErrorCode code);
 
  signals:
   void stateChanged();

--- a/src/controllerimpl.h
+++ b/src/controllerimpl.h
@@ -108,6 +108,9 @@ class ControllerImpl : public QObject {
   void statusUpdated(const QString& serverIpv4Gateway,
                      const QString& deviceIpv4Address, uint64_t txBytes,
                      uint64_t rxBytes);
+  
+  // This signal is emitted when the implementation encounters an error.
+  void backendFailure(Controller::ErrorCode errorCode);
 };
 
 #endif  // CONTROLLERIMPL_H

--- a/src/controllerimpl.h
+++ b/src/controllerimpl.h
@@ -108,7 +108,7 @@ class ControllerImpl : public QObject {
   void statusUpdated(const QString& serverIpv4Gateway,
                      const QString& deviceIpv4Address, uint64_t txBytes,
                      uint64_t rxBytes);
-  
+
   // This signal is emitted when the implementation encounters an error.
   void backendFailure(Controller::ErrorCode errorCode);
 };

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -516,3 +516,9 @@ void Daemon::checkHandshake() {
     m_handshakeTimer.start(HANDSHAKE_POLL_MSEC);
   }
 }
+
+void Daemon::abortBackendFailure() {
+  logger.warning() << "Backend failure occured - disconnecting";
+  emit backendFailure();
+  deactivate();
+}

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -55,6 +55,16 @@ Daemon* Daemon::instance() {
   return s_daemon;
 }
 
+bool Daemon::activate(const QString& json) {
+  QJsonDocument jsDocument = QJsonDocument::fromJson(json.toUtf8());
+  InterfaceConfig ifConfig;
+
+  if (!Daemon::parseConfig(jsDocument.object(), ifConfig)) {
+    return false;
+  }
+  return activate(ifConfig);
+}
+
 bool Daemon::activate(const InterfaceConfig& config) {
   Q_ASSERT(wgutils() != nullptr);
 

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -33,13 +33,14 @@ class Daemon : public QObject {
   static bool parseConfig(const QJsonObject& obj, InterfaceConfig& config);
 
   virtual bool activate(const InterfaceConfig& config);
+  virtual bool deactivate(bool emitSignals);
 
   QJsonObject getStatus();
   QString logs();
   void cleanLogs();
 
   Q_INVOKABLE bool activate(const QString& json);
-  Q_INVOKABLE bool deactivate(bool emitSignals = true);
+  Q_INVOKABLE bool deactivate() { return deactivate(true); };
 
  signals:
   void connected(const QString& pubkey);

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -33,11 +33,13 @@ class Daemon : public QObject {
   static bool parseConfig(const QJsonObject& obj, InterfaceConfig& config);
 
   virtual bool activate(const InterfaceConfig& config);
-  virtual bool deactivate(bool emitSignals = true);
-  virtual QJsonObject getStatus();
 
+  QJsonObject getStatus();
   QString logs();
   void cleanLogs();
+
+  Q_INVOKABLE bool activate(const QString& json);
+  Q_INVOKABLE bool deactivate(bool emitSignals = true);
 
  signals:
   void connected(const QString& pubkey);

--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -71,6 +71,7 @@ class Daemon : public QObject {
   static bool parseStringList(const QJsonObject& obj, const QString& name,
                               QStringList& list);
 
+  void abortBackendFailure();
   void checkHandshake();
 
   class ConnectionState {

--- a/src/daemon/wireguardutils.h
+++ b/src/daemon/wireguardutils.h
@@ -44,6 +44,9 @@ class WireguardUtils : public QObject {
   virtual bool updateRoutePrefix(const IPAddress& prefix) = 0;
   virtual bool deleteRoutePrefix(const IPAddress& prefix) = 0;
   virtual bool excludeLocalNetworks(const QList<IPAddress>& addresses) = 0;
+
+ signals:
+  void backendFailure();
 };
 
 #endif  // WIREGUARDUTILS_H

--- a/src/localsocketcontroller.cpp
+++ b/src/localsocketcontroller.cpp
@@ -119,7 +119,9 @@ void LocalSocketController::initializeInternal() {
 void LocalSocketController::daemonConnected() {
   logger.debug() << "Daemon connected";
   Q_ASSERT(m_daemonState == eInitializing);
-  checkStatus();
+
+  // HACK: Temporary hack until MacOSController can become its own class.
+  LocalSocketController::checkStatus();
 }
 
 void LocalSocketController::activate(const InterfaceConfig& config,

--- a/src/localsocketcontroller.cpp
+++ b/src/localsocketcontroller.cpp
@@ -16,18 +16,6 @@
 #include "leakdetector.h"
 #include "logger.h"
 
-#ifdef MZ_MACOS
-#  include <Security/Authorization.h>
-#  include <Security/AuthorizationTags.h>
-#  include <signal.h>
-#  include <sys/socket.h>
-#  include <sys/un.h>
-#  include <unistd.h>
-
-#  include <QProcess>
-#  include <QScopeGuard>
-#endif
-
 // When the daemon is unreachable, we will retry indefinitely using an
 // exponential backoff algorithm. The interval between retries starts at
 // the initial value, and doubles after each failed connection attempt,
@@ -400,59 +388,4 @@ void LocalSocketController::clearAllTimeouts() {
     QTimer* t = m_responseTimeouts.takeFirst();
     delete t;
   }
-}
-
-void LocalSocketController::forceDaemonCrash() {
-#ifdef MZ_MACOS
-  pid_t pid;
-  socklen_t len = sizeof(pid);
-  int sd = m_socket->socketDescriptor();
-  if (getsockopt(sd, SOL_LOCAL, LOCAL_PEERPID, &pid, &len) < 0) {
-    return;
-  }
-  if ((pid <= 0) || (pid == getpid())) {
-    return;
-  }
-
-  // Create an authorization session.
-  AuthorizationRef authRef;
-  AuthorizationFlags authFlags =
-      kAuthorizationFlagDefaults | kAuthorizationFlagInteractionAllowed |
-      kAuthorizationFlagPreAuthorize | kAuthorizationFlagExtendRights;
-  OSStatus status = AuthorizationCreate(nullptr, kAuthorizationEmptyEnvironment,
-                                        authFlags, &authRef);
-  if (status != errAuthorizationSuccess) {
-    logger.error() << "Failed to acquire authorization:" << status;
-    return;
-  }
-  auto authGuard = qScopeGuard(
-      [&] { AuthorizationFree(authRef, kAuthorizationFlagDefaults); });
-
-  // Acquire execution permissions.
-  AuthorizationItem authItems = {kAuthorizationRightExecute, 0, nullptr, 0};
-  AuthorizationRights authRights = {1, &authItems};
-  status = AuthorizationCopyRights(authRef, &authRights, nullptr, authFlags,
-                                   nullptr);
-  if (status != errAuthorizationSuccess) {
-    logger.error() << "Failed to copy authorization rights:" << status;
-    return;
-  }
-
-  // Execute 'kill' to terminate the daemon as though it crashed.
-  logger.warning() << "Sending SIGSEGV to:" << pid;
-  QByteArray pidString = QString::number(pid).toUtf8();
-  char killpath[] = "/bin/kill";
-  char killsignal[] = "-SEGV";
-  char* const killargs[] = {killsignal, pidString.data(), nullptr};
-
-#  pragma clang diagnostic push
-#  pragma clang diagnostic ignored "-Wdeprecated-declarations"
-  status = AuthorizationExecuteWithPrivileges(
-      authRef, killpath, kAuthorizationFlagDefaults, killargs, nullptr);
-#  pragma clang diagnostic pop
-  if (status != errAuthorizationSuccess) {
-    logger.error() << "Failed to copy execute tool:" << status;
-    return;
-  }
-#endif
 }

--- a/src/localsocketcontroller.cpp
+++ b/src/localsocketcontroller.cpp
@@ -119,9 +119,7 @@ void LocalSocketController::initializeInternal() {
 void LocalSocketController::daemonConnected() {
   logger.debug() << "Daemon connected";
   Q_ASSERT(m_daemonState == eInitializing);
-
-  // HACK: Temporary hack until MacOSController can become its own class.
-  LocalSocketController::checkStatus();
+  checkStatus();
 }
 
 void LocalSocketController::activate(const InterfaceConfig& config,

--- a/src/localsocketcontroller.h
+++ b/src/localsocketcontroller.h
@@ -35,8 +35,6 @@ class LocalSocketController : public ControllerImpl {
 
   bool multihopSupported() override { return true; }
 
-  void forceDaemonCrash() override;
-
  private:
   // For messages that are expected to generate a synchronous response, this
   // defines the default time that we will wait before assuming an error in

--- a/src/platforms/linux/daemon/dbusservice.h
+++ b/src/platforms/linux/daemon/dbusservice.h
@@ -28,16 +28,13 @@ class DBusService final : public Daemon, protected QDBusContext {
   enum AppState { Active, Excluded };
   Q_ENUM(AppState)
 
-  void setAdaptor(DbusAdaptor* adaptor);
-
   using Daemon::activate;
 
+  virtual bool activate(const InterfaceConfig& config) override;
+  virtual bool deactivate(bool emitSignals = true) override;
+
  public slots:
-  bool activate(const QString& jsonConfig);
-
-  bool deactivate(bool emitSignals = true) override;
   QString status();
-
   QString version();
   QString getLogs();
   void cleanupLogs() { cleanLogs(); }
@@ -65,7 +62,6 @@ class DBusService final : public Daemon, protected QDBusContext {
   void userRemoved(uint uid, const QDBusObjectPath& path);
 
  private:
-  DbusAdaptor* m_adaptor = nullptr;
   WireguardUtilsLinux* m_wgutils = nullptr;
   IPUtilsLinux* m_iputils = nullptr;
   DnsUtilsLinux* m_dnsutils = nullptr;

--- a/src/platforms/linux/daemon/linuxdaemon.cpp
+++ b/src/platforms/linux/daemon/linuxdaemon.cpp
@@ -29,8 +29,7 @@ class CommandLinuxDaemon final : public Command {
 
     return runCommandLineApp([&]() {
       DBusService* dbus = new DBusService(qApp);
-      DbusAdaptor* adaptor = new DbusAdaptor(dbus);
-      dbus->setAdaptor(adaptor);
+      new DbusAdaptor(dbus);
 
       QDBusConnection connection = QDBusConnection::systemBus();
       logger.debug() << "Connecting to DBus...";

--- a/src/platforms/macos/daemon/macosdaemon.cpp
+++ b/src/platforms/macos/daemon/macosdaemon.cpp
@@ -23,7 +23,7 @@ Logger logger("MacOSDaemon");
 MacOSDaemon* s_daemon = nullptr;
 }  // namespace
 
-MacOSDaemon::MacOSDaemon() : Daemon(nullptr) {
+MacOSDaemon::MacOSDaemon(QObject* parent) : Daemon(parent) {
   MZ_COUNT_CTOR(MacOSDaemon);
 
   logger.debug() << "Daemon created";
@@ -31,6 +31,9 @@ MacOSDaemon::MacOSDaemon() : Daemon(nullptr) {
   m_wgutils = new WireguardUtilsMacos(this);
   m_dnsutils = new DnsUtilsMacos(this);
   m_iputils = new IPUtilsMacos(this);
+
+  connect(m_wgutils, &WireguardUtils::backendFailure, this,
+          &MacOSDaemon::abortBackendFailure);
 
   Q_ASSERT(s_daemon == nullptr);
   s_daemon = this;

--- a/src/platforms/macos/daemon/macosdaemon.h
+++ b/src/platforms/macos/daemon/macosdaemon.h
@@ -14,7 +14,7 @@ class MacOSDaemon final : public Daemon {
   friend class IPUtilsMacos;
 
  public:
-  MacOSDaemon();
+  MacOSDaemon(QObject* parent = nullptr);
   ~MacOSDaemon();
 
   static MacOSDaemon* instance();

--- a/src/platforms/macos/daemon/macosdaemonserver.cpp
+++ b/src/platforms/macos/daemon/macosdaemonserver.cpp
@@ -36,10 +36,11 @@ MacOSDaemonServer::~MacOSDaemonServer() { MZ_COUNT_DTOR(MacOSDaemonServer); }
 
 int MacOSDaemonServer::run(QStringList& tokens) {
   Q_ASSERT(!tokens.isEmpty());
+  qputenv("QT_EVENT_DISPATCHER_CORE_FOUNDATION", "1");
   setupLogDir();
+
   QString appName = tokens[0];
   QCoreApplication app(CommandLineParser::argc(), CommandLineParser::argv());
-
   QCoreApplication::setApplicationName("Mozilla VPN Daemon");
   QCoreApplication::setApplicationVersion(Constants::versionString());
 

--- a/src/platforms/macos/daemon/macosdaemonserver.cpp
+++ b/src/platforms/macos/daemon/macosdaemonserver.cpp
@@ -21,6 +21,7 @@
 #include "macosdaemon.h"
 #include "mozillavpn.h"
 #include "signalhandler.h"
+#include "xpcdaemonserver.h"
 
 namespace {
 Logger logger("MacOSDaemonServer");
@@ -75,6 +76,9 @@ int MacOSDaemonServer::run(QStringList& tokens) {
     logger.error() << "Failed to initialize the server";
     return 1;
   }
+
+  // Create an XPC service too.
+  new XpcDaemonServer(&daemon);
 
   // Signal handling for a proper shutdown.
   SignalHandler sh;

--- a/src/platforms/macos/daemon/wireguardutilsmacos.cpp
+++ b/src/platforms/macos/daemon/wireguardutilsmacos.cpp
@@ -33,6 +33,8 @@ WireguardUtilsMacos::WireguardUtilsMacos(QObject* parent)
           SLOT(tunnelStdoutReady()));
   connect(&m_tunnel, SIGNAL(errorOccurred(QProcess::ProcessError)), this,
           SLOT(tunnelErrorOccurred(QProcess::ProcessError)));
+  connect(&m_tunnel, SIGNAL(finished(int, QProcess::ExitStatus)), this,
+          SLOT(tunnelFinished(int, QProcess::ExitStatus)));
 }
 
 WireguardUtilsMacos::~WireguardUtilsMacos() {
@@ -53,6 +55,14 @@ void WireguardUtilsMacos::tunnelStdoutReady() {
 void WireguardUtilsMacos::tunnelErrorOccurred(QProcess::ProcessError error) {
   logger.warning() << "Tunnel process encountered an error:" << error;
   emit backendFailure();
+}
+
+void WireguardUtilsMacos::tunnelFinished(int exitCode,
+                                         QProcess::ExitStatus exitStatus) {
+  if ((exitStatus != QProcess::NormalExit) || (exitCode != 0)) {
+    logger.warning() << "Tunnel process exited with code:" << exitCode;
+    emit backendFailure();
+  }
 }
 
 bool WireguardUtilsMacos::addInterface(const InterfaceConfig& config) {

--- a/src/platforms/macos/daemon/wireguardutilsmacos.h
+++ b/src/platforms/macos/daemon/wireguardutilsmacos.h
@@ -33,12 +33,10 @@ class WireguardUtilsMacos final : public WireguardUtils {
   bool deleteRoutePrefix(const IPAddress& prefix) override;
   bool excludeLocalNetworks(const QList<IPAddress>& lanAddressRanges) override;
 
- signals:
-  void backendFailure();
-
  private slots:
   void tunnelStdoutReady();
   void tunnelErrorOccurred(QProcess::ProcessError error);
+  void tunnelFinished(int exitCode, QProcess::ExitStatus exitStatus);
 
  private:
   QString uapiCommand(const QString& command);

--- a/src/platforms/macos/daemon/xpcdaemonserver.h
+++ b/src/platforms/macos/daemon/xpcdaemonserver.h
@@ -20,6 +20,8 @@ class XpcDaemonServer final : public QObject {
   ~XpcDaemonServer();
 
  private:
+  static QString getTeamIdentifier();
+
   void* m_listener = nullptr;
 };
 

--- a/src/platforms/macos/daemon/xpcdaemonserver.h
+++ b/src/platforms/macos/daemon/xpcdaemonserver.h
@@ -5,6 +5,9 @@
 #ifndef XPCDAEMONSERVER_H
 #define XPCDAEMONSERVER_H
 
+#include <objc/objc-runtime.h>
+
+#include <QAtomicInt>
 #include <QObject>
 
 #include "daemon/daemon.h"
@@ -17,8 +20,26 @@ class XpcDaemonServer final : public QObject {
   ~XpcDaemonServer();
 
  private:
-  QThread* m_thread = nullptr;
   void* m_listener = nullptr;
+};
+
+// And a little helper to manage async responses.
+class XpcDaemonSession final : public QObject {
+  Q_OBJECT
+
+ public:
+  XpcDaemonSession(Daemon* daemon, void* connection);
+
+ public slots:
+  void connected(const QString& pubkey);
+  void disconnected();
+
+ private:
+  void invokeClient(SEL selector);
+  template<typename T> void invokeClient(SEL selector, T arg);
+
+  QAtomicInt m_backlog;
+  void* m_connection = nullptr;
 };
 
 #endif  // XPCDAEMONSERVER_H

--- a/src/platforms/macos/daemon/xpcdaemonserver.h
+++ b/src/platforms/macos/daemon/xpcdaemonserver.h
@@ -33,6 +33,7 @@ class XpcDaemonSession final : public QObject {
  public slots:
   void connected(const QString& pubkey);
   void disconnected();
+  void backendFailure(DaemonError reason);
 
  private:
   void invokeClient(SEL selector);

--- a/src/platforms/macos/daemon/xpcdaemonserver.h
+++ b/src/platforms/macos/daemon/xpcdaemonserver.h
@@ -30,6 +30,9 @@ class XpcDaemonSession final : public QObject {
  public:
   XpcDaemonSession(Daemon* daemon, void* connection);
 
+  template <typename T>
+  T invokeDaemon(T (Daemon::*method)(void));
+
  public slots:
   void connected(const QString& pubkey);
   void disconnected();
@@ -37,7 +40,8 @@ class XpcDaemonSession final : public QObject {
 
  private:
   void invokeClient(SEL selector);
-  template<typename T> void invokeClient(SEL selector, T arg);
+  template <typename T>
+  void invokeClient(SEL selector, T arg);
 
   QAtomicInt m_backlog;
   void* m_connection = nullptr;

--- a/src/platforms/macos/daemon/xpcdaemonserver.h
+++ b/src/platforms/macos/daemon/xpcdaemonserver.h
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef XPCDAEMONSERVER_H
+#define XPCDAEMONSERVER_H
+
+#include <QObject>
+
+#include "daemon/daemon.h"
+
+class XpcDaemonServer final : public QObject {
+  Q_OBJECT
+
+ public:
+  XpcDaemonServer(Daemon* daemon);
+  ~XpcDaemonServer();
+
+ private:
+  QThread* m_thread = nullptr;
+  void* m_listener = nullptr;
+};
+
+#endif  // XPCDAEMONSERVER_H

--- a/src/platforms/macos/daemon/xpcdaemonserver.h
+++ b/src/platforms/macos/daemon/xpcdaemonserver.h
@@ -20,8 +20,6 @@ class XpcDaemonServer final : public QObject {
   ~XpcDaemonServer();
 
  private:
-  static QString getTeamIdentifier();
-
   void* m_listener = nullptr;
 };
 

--- a/src/platforms/macos/daemon/xpcdaemonserver.mm
+++ b/src/platforms/macos/daemon/xpcdaemonserver.mm
@@ -11,6 +11,7 @@
 #include "logger.h"
 #include "platforms/macos/macosutils.h"
 #include "platforms/macos/xpcdaemonprotocol.h"
+#include "version.h"
 
 constexpr const int XPC_SESSION_MAX_BACKLOG = 32;
 
@@ -96,6 +97,10 @@ shouldAcceptNewConnection:(NSXPCConnection *) newConnection {
 
 - (void)deactivate {
   QMetaObject::invokeMethod(self.daemon, "deactivate");
+}
+
+- (void)getVersion: (void (^)(NSString *))reply {
+  reply([NSString stringWithUTF8String:APP_VERSION]);
 }
 
 - (void)getStatus:(void (^)(NSString *))reply {

--- a/src/platforms/macos/daemon/xpcdaemonserver.mm
+++ b/src/platforms/macos/daemon/xpcdaemonserver.mm
@@ -1,0 +1,68 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "xpcdaemonserver.h"
+
+#include "leakdetector.h"
+#include "logger.h"
+#include "platforms/macos/macosutils.h"
+#include "platforms/macos/xpcdaemonprotocol.h"
+
+namespace {
+Logger logger("XpcDaemonServer");
+}  // namespace
+
+@interface XpcDaemonDelegate : NSObject<NSXPCListenerDelegate, XpcDaemonProtocol>
+- (BOOL)         listener:(NSXPCListener *) listener
+shouldAcceptNewConnection:(NSXPCConnection *) newConnection;
+
+- (void) activate:(NSString*) config;
+- (void) deactivate;
+
+@end
+
+XpcDaemonServer::XpcDaemonServer(Daemon* daemon) : QObject(daemon) {
+  MZ_COUNT_CTOR(XpcDaemonServer);
+
+  QString daemonId = MacOSUtils::appId() + ".daemon";
+  logger.debug() << "XpcDaemonServer created:" << daemonId;
+
+  XpcDaemonDelegate* delegate = [XpcDaemonDelegate new];
+
+  NSXPCListener* listener =
+      [[NSXPCListener alloc] initWithMachServiceName:daemonId.toNSString()];
+  listener.delegate = delegate;
+  [listener retain];
+  [listener resume];
+
+  m_listener = listener;
+}
+
+XpcDaemonServer::~XpcDaemonServer() {
+  MZ_COUNT_DTOR(XpcDaemonServer);
+  NSXPCListener* listener = static_cast<NSXPCListener*>(m_listener);
+  logger.debug() << "XpcDaemonServer destroyed.";
+  [listener release];
+}
+
+@implementation XpcDaemonDelegate
+- (BOOL)         listener:(NSXPCListener *) listener
+shouldAcceptNewConnection:(NSXPCConnection *) newConnection {
+  logger.debug() << "XpcDaemonServer new connection";
+  newConnection.exportedObject = listener.delegate;
+  newConnection.exportedInterface =
+      [NSXPCInterface interfaceWithProtocol:@protocol(XpcDaemonProtocol)];
+  [newConnection resume];
+  return true;
+}
+
+- (void)activate:(NSString*) config {
+  logger.debug() << "activate";
+}
+
+- (void)deactivate {
+  logger.debug() << "deactivate";
+}
+
+@end

--- a/src/platforms/macos/daemon/xpcdaemonserver.mm
+++ b/src/platforms/macos/daemon/xpcdaemonserver.mm
@@ -19,9 +19,17 @@ namespace {
 Logger logger("XpcDaemonServer");
 }  // namespace
 
+// This property exists, but it's private. Make it available:
+@interface NSXPCConnection(PrivateAuditToken)
+@property (nonatomic, readonly) audit_token_t auditToken;
+@end
+
 @interface XpcDaemonDelegate : NSObject<NSXPCListenerDelegate>
 @property Daemon* daemon;
+@property (copy) NSString* teamIdentifier;
+
 - (id)initWithObject:(Daemon*)daemon;
++ (NSString*)getTeamIdentifier:(SecTaskRef)task;
 @end
 
 @interface XpcSessionDelegate : NSObject<XpcDaemonProtocol>
@@ -37,9 +45,11 @@ XpcDaemonServer::XpcDaemonServer(Daemon* daemon) : QObject(daemon) {
   QString daemonId = MacOSUtils::appId() + ".daemon";
   logger.debug() << "XpcDaemonServer created:" << daemonId;
 
+  XpcDaemonDelegate* delegate =
+      [[XpcDaemonDelegate alloc] initWithObject:daemon];
   NSXPCListener* listener =
       [[NSXPCListener alloc] initWithMachServiceName:daemonId.toNSString()];
-  listener.delegate = [[XpcDaemonDelegate alloc] initWithObject:daemon];
+  listener.delegate = delegate;
 
   // Connections to the daemon require codesigning
   // TODO: It would be nice if we could turn this off for developers somehow.
@@ -50,7 +60,8 @@ XpcDaemonServer::XpcDaemonServer(Daemon* daemon) : QObject(daemon) {
     constexpr const char* oidExtAppleCaIntermediate =
         "(certificate 1[field.1.2.840.113635.100.6.2.6] or" \
         " certificate 1[field.1.2.840.113635.100.6.2.1])";
-    QString devTeamIdentifier = getTeamIdentifier();
+    QString devTeamIdentifier =
+        QString::fromNSString(delegate.teamIdentifier);
     QString devTeamSubject =
         QString("certificate leaf[subject.OU] = \"%1\"").arg(devTeamIdentifier);
 
@@ -75,12 +86,21 @@ XpcDaemonServer::~XpcDaemonServer() {
   [listener release];
 }
 
-QString XpcDaemonServer::getTeamIdentifier() {
-  SecTaskRef task = SecTaskCreateFromSelf(kCFAllocatorSystemDefault);
-  if (!task) {
-    return QString();
+@implementation XpcDaemonDelegate
+- (id)initWithObject:(Daemon*)daemon {
+  self = [super init];
+  self.daemon = daemon;
+
+  SecTaskRef task = SecTaskCreateFromSelf(kCFAllocatorDefault);
+  if (task) {
+    self.teamIdentifier = [XpcDaemonDelegate getTeamIdentifier:task];
+    CFRelease(task);
   }
 
+  return self;
+}
+
++ (NSString*) getTeamIdentifier:(SecTaskRef)task {
   CFErrorRef error = nullptr;
   CFStringRef cfTeamId = CFSTR("com.apple.developer.team-identifier");
   CFTypeRef result = SecTaskCopyValueForEntitlement(task, cfTeamId, &error);
@@ -89,27 +109,41 @@ QString XpcDaemonServer::getTeamIdentifier() {
     CFRelease(error);
     return nil;
   }
-  auto guard = qScopeGuard([&]() {
-    CFRelease(task);
-    CFRelease(result);
-  });
+  auto guard = qScopeGuard([&]() { CFRelease(result); });
 
   if (CFGetTypeID(result) == CFStringGetTypeID()) {
-    return QString::fromNSString(static_cast<NSString*>(result));
+    return static_cast<NSString*>(result);
   }
-  return QString();
-}
-
-@implementation XpcDaemonDelegate
-- (id)initWithObject:(Daemon*)daemon {
-  self = [super init];
-  self.daemon = daemon;
-  return self;
+  CFRelease(result);
+  return nil;
 }
 
 - (BOOL)         listener:(NSXPCListener *) listener
 shouldAcceptNewConnection:(NSXPCConnection *) newConnection {
   logger.debug() << "new connection";
+
+  if (@available(macOS 13, *)) {
+    // Nothing to do here - this is handled by the listener.
+  } else {
+    // For macOS versions prior to 13.0 we must roll our own connection auth
+    // code. This uses the private auditToken property on the NSXPCConnection
+    // and inspects the caller's entitlements for a matching team identifier.
+    //
+    // Sadly there is no public API to get this information, and doing it via
+    // the caller's PID is vulnerable to race conditions.
+    SecTaskRef task = SecTaskCreateWithAuditToken(kCFAllocatorDefault,
+                                                  newConnection.auditToken);
+    if (!task) {
+      logger.debug() << "rejecting connection: unable to locate calling task";
+      return false;
+    }
+    NSString* clientTeamIdentifier = [XpcDaemonDelegate getTeamIdentifier:task];
+    CFRelease(task);
+    if ([clientTeamIdentifier compare:self.teamIdentifier] != NSOrderedSame) {
+      logger.debug() << "rejecting connection:" << clientTeamIdentifier;
+      return false;
+    }
+  }
 
   XpcSessionDelegate* delegate = [XpcSessionDelegate alloc];
   delegate.bridge = new XpcDaemonSession(self.daemon, newConnection);

--- a/src/platforms/macos/daemon/xpcdaemonserver.mm
+++ b/src/platforms/macos/daemon/xpcdaemonserver.mm
@@ -221,6 +221,8 @@ XpcDaemonSession::XpcDaemonSession(Daemon* daemon, void* connection)
     : QObject(nullptr), m_connection(connection) {
   connect(daemon, &Daemon::connected, this, &XpcDaemonSession::connected);
   connect(daemon, &Daemon::disconnected, this, &XpcDaemonSession::disconnected);
+  connect(daemon, &Daemon::backendFailure, this,
+          &XpcDaemonSession::backendFailure);
 
   // Move this object to the same thread as the daemon, and make it our parent.
   // The XPC connection runs in its own thread, so it lacks a Qt event loop to
@@ -272,4 +274,8 @@ void XpcDaemonSession::connected(const QString& pubkey) {
 
 void XpcDaemonSession::disconnected() {
   invokeClient(@selector(disconnected));
+}
+
+void XpcDaemonSession::backendFailure(DaemonError reason) {
+  invokeClient(@selector(backendFailure:), static_cast<NSUInteger>(reason));
 }

--- a/src/platforms/macos/daemon/xpcdaemonserver.mm
+++ b/src/platforms/macos/daemon/xpcdaemonserver.mm
@@ -54,6 +54,19 @@ XpcDaemonServer::XpcDaemonServer(Daemon* daemon) : QObject(daemon) {
   // Connections to the daemon require codesigning
   // TODO: It would be nice if we could turn this off for developers somehow.
   if (@available(macOS 13, *)) {
+    // These certificate extension OIDs are described in Apple's technical note
+    // TN3127: Inside Code Signing Requirements, and are used to identify
+    // certificates and authorities used by Apple for codesigning.
+    //
+    // The extension identifiers ending in 6.1.13 and 6.2.6 denote a Developer
+    // ID certificate granted by the apple Developer ID CA. This permits release
+    // software signed by our development team to access this service.
+    //
+    // The extension identifiers ending in 6.1.12 and 6.2.1 denote a macOS
+    // developer certificate granted by the Apple WWDR intermediate CA. This
+    // permits development builds signed by our development team to access this
+    // service.
+    //
     constexpr const char* oidExtAppleCodesign =
         "(certificate leaf[field.1.2.840.113635.100.6.1.13] or" \
         " certificate leaf[field.1.2.840.113635.100.6.1.12])";

--- a/src/platforms/macos/daemon/xpcdaemonserver.mm
+++ b/src/platforms/macos/daemon/xpcdaemonserver.mm
@@ -42,13 +42,13 @@ Logger logger("XpcDaemonServer");
 XpcDaemonServer::XpcDaemonServer(Daemon* daemon) : QObject(daemon) {
   MZ_COUNT_CTOR(XpcDaemonServer);
 
-  QString daemonId = MacOSUtils::appId() + ".daemon";
-  logger.debug() << "XpcDaemonServer created:" << daemonId;
+  NSString* machServiceName = MacOSUtils::appId(".service").toNSString();
+  logger.debug() << "XpcDaemonServer created:" << machServiceName;
 
   XpcDaemonDelegate* delegate =
       [[XpcDaemonDelegate alloc] initWithObject:daemon];
   NSXPCListener* listener =
-      [[NSXPCListener alloc] initWithMachServiceName:daemonId.toNSString()];
+      [[NSXPCListener alloc] initWithMachServiceName:machServiceName];
   listener.delegate = delegate;
 
   // Connections to the daemon require codesigning

--- a/src/platforms/macos/daemon/xpcdaemonserver.mm
+++ b/src/platforms/macos/daemon/xpcdaemonserver.mm
@@ -113,6 +113,24 @@ shouldAcceptNewConnection:(NSXPCConnection *) newConnection {
   reply(result);
 }
 
+- (void) getBackendLogs: (void (^)(NSString *))reply {
+  NSString* result = nullptr;
+  NSCondition* cond = [NSCondition new];
+
+  [cond lock];
+  QMetaObject::invokeMethod(self.daemon, [&](){
+    result = self.daemon->logs().toNSString();
+    [cond signal];
+  });
+
+  [cond wait];
+  reply(result);
+}
+
+- (void)cleanupBackendLogs {
+  QMetaObject::invokeMethod(self.daemon, [&]{ self.daemon->cleanLogs(); });
+}
+
 @end
 
 XpcDaemonSession::XpcDaemonSession(Daemon* daemon, void* connection)

--- a/src/platforms/macos/macoscontroller.h
+++ b/src/platforms/macos/macoscontroller.h
@@ -6,9 +6,12 @@
 #define MACOSCONTROLLER_H
 
 #include "controllerimpl.h"
-#include "localsocketcontroller.h"
 
-class MacOSController final : public LocalSocketController {
+#ifdef __OBJC__
+#  include "xpcdaemonprotocol.h"
+#endif
+
+class MacOSController final : public ControllerImpl {
   Q_DISABLE_COPY_MOVE(MacOSController)
 
  public:
@@ -29,13 +32,23 @@ class MacOSController final : public LocalSocketController {
   void cleanupBackendLogs() override;
 
  private slots:
+  void upgradeService();
   void registerService();
+  void connectService();
 
  private:
   NSString* plist() const;
+  NSString* machServiceName() const;
 
+ private:
+  QString plistName() const;
+#ifdef __OBJC__
+  NSObject<XpcDaemonProtocol>* remoteObject();
+#endif
+
+  QTimer m_registerTimer;
+  QTimer m_connectTimer;
   bool m_permissionRequired = false;
-  QTimer m_regTimer;
 
   // NSXPCConnection to the daemon.
   void* m_connection = nullptr;

--- a/src/platforms/macos/macoscontroller.h
+++ b/src/platforms/macos/macoscontroller.h
@@ -26,6 +26,8 @@ class MacOSController final : public LocalSocketController {
 
   void getBackendLogs(QIODevice* device) override;
 
+  void cleanupBackendLogs() override;
+
  private slots:
   void registerService();
 

--- a/src/platforms/macos/macoscontroller.h
+++ b/src/platforms/macos/macoscontroller.h
@@ -20,10 +20,9 @@ class MacOSController final : public ControllerImpl {
 
   void initialize(const Device* device, const Keys* keys) override;
 
-  void activate(const InterfaceConfig& config,
-                Controller::Reason reason) override;
+  void activate(const InterfaceConfig& config, Controller::Reason reason) override;
 
-  void deactivate(Controller::Reason reason) override;;
+  void deactivate(Controller::Reason reason) override;
 
   void checkStatus() override;
 

--- a/src/platforms/macos/macoscontroller.h
+++ b/src/platforms/macos/macoscontroller.h
@@ -22,6 +22,8 @@ class MacOSController final : public LocalSocketController {
 
   void deactivate(Controller::Reason reason) override;;
 
+  void checkStatus() override;
+
   void getBackendLogs(QIODevice* device) override;
 
  private slots:

--- a/src/platforms/macos/macoscontroller.h
+++ b/src/platforms/macos/macoscontroller.h
@@ -13,8 +13,14 @@ class MacOSController final : public LocalSocketController {
 
  public:
   MacOSController();
+  ~MacOSController();
 
   void initialize(const Device* device, const Keys* keys) override;
+
+  void activate(const InterfaceConfig& config,
+                Controller::Reason reason) override;
+
+  void deactivate(Controller::Reason reason) override;;
 
   void getBackendLogs(QIODevice* device) override;
 
@@ -26,6 +32,9 @@ class MacOSController final : public LocalSocketController {
 
   bool m_permissionRequired = false;
   QTimer m_regTimer;
+
+  // NSXPCConnection to the daemon.
+  void* m_connection = nullptr;
 };
 
 #endif  // MACOSCONTROLLER_H

--- a/src/platforms/macos/macoscontroller.h
+++ b/src/platforms/macos/macoscontroller.h
@@ -31,6 +31,8 @@ class MacOSController final : public ControllerImpl {
 
   void cleanupBackendLogs() override;
 
+  void forceDaemonCrash() override;
+
  private slots:
   void upgradeService();
   void registerService();

--- a/src/platforms/macos/macoscontroller.mm
+++ b/src/platforms/macos/macoscontroller.mm
@@ -162,6 +162,14 @@ void MacOSController::deactivate(Controller::Reason reason) {
   [[conn remoteObjectProxy] deactivate];
 }
 
+void MacOSController::checkStatus() {
+  [remoteObject() getStatus:^(NSString* status){
+    QByteArray jsBlob = QString::fromNSString(status).toUtf8();
+    QJsonObject obj = QJsonDocument::fromJson(jsBlob).object();
+    emitStatusFromJson(obj);
+  }];
+}
+
 void MacOSController::getBackendLogs(QIODevice* device) {
   // If the daemon is connected - use the LocalSocketController to fetch logs.
   if (m_daemonState == eReady) {

--- a/src/platforms/macos/macoscontroller.mm
+++ b/src/platforms/macos/macoscontroller.mm
@@ -9,6 +9,7 @@
 #include "constants.h"
 #include "logger.h"
 #include "macosutils.h"
+#include "xpcdaemonprotocol.h"
 
 #import <Cocoa/Cocoa.h>
 #import <ServiceManagement/ServiceManagement.h>

--- a/src/platforms/macos/macoscontroller.mm
+++ b/src/platforms/macos/macoscontroller.mm
@@ -7,11 +7,14 @@
 #include <QFile>
 #include <QJsonDocument>
 #include <QJsonObject>
+#include <QVersionNumber>
 
 #include "constants.h"
+#include "errorhandler.h"
 #include "logger.h"
 #include "macosutils.h"
 #include "xpcdaemonprotocol.h"
+#include "version.h"
 
 #import <Cocoa/Cocoa.h>
 #import <ServiceManagement/ServiceManagement.h>
@@ -20,7 +23,7 @@ namespace {
 Logger logger("MacOSController");
 }  // namespace
 
-constexpr const int SERVICE_REG_POLL_INTERVAL_MSEC = 1000;
+constexpr const int SERVICE_INIT_POLL_INTERVAL_MSEC = 1000;
 
 // A delegate object used to receive async events from the daemon.
 @interface XpcClientDelegate : NSObject<XpcClientProtocol>
@@ -28,42 +31,60 @@ constexpr const int SERVICE_REG_POLL_INTERVAL_MSEC = 1000;
 - (id)initWithObject:(ControllerImpl*)controller;
 @end
 
-MacOSController::MacOSController() :
-   LocalSocketController(Constants::MACOS_DAEMON_PATH) {
-
-  m_regTimer.setSingleShot(true);
-  connect(&m_regTimer, &QTimer::timeout, this,
+MacOSController::MacOSController() : ControllerImpl()  {
+  m_registerTimer.setSingleShot(true);
+  connect(&m_registerTimer, &QTimer::timeout, this,
           &MacOSController::registerService);
-
-  // Create an XPC connection
-  QString daemonId = MacOSUtils::appId() + ".daemon";
-  XpcClientDelegate* delegate = [XpcClientDelegate alloc];
-  NSXPCConnection* conn = [NSXPCConnection alloc];
-  [conn initWithMachServiceName:daemonId.toNSString()
-                        options:NSXPCConnectionPrivileged];
-  conn.exportedObject = [delegate initWithObject:this];
-  conn.exportedInterface =
-      [NSXPCInterface interfaceWithProtocol:@protocol(XpcClientProtocol)];
-  conn.remoteObjectInterface =
-      [NSXPCInterface interfaceWithProtocol:@protocol(XpcDaemonProtocol)];
-
-  // Activate the connection and retain it as a member of this object.
-  [conn activate];
-  [conn retain];
-  m_connection = conn;
+  
+  m_connectTimer.setSingleShot(true);
+  connect(&m_connectTimer, &QTimer::timeout, this,
+          &MacOSController::connectService);
 }
 
 MacOSController::~MacOSController() {
-  [static_cast<NSXPCConnection*>(m_connection) release];
+  if (m_connection != nil) {
+    [static_cast<NSXPCConnection*>(m_connection) release];
+  }
 }
 
 NSString* MacOSController::plist() const {
-  NSString* appId = MacOSUtils::appId();
-  Q_ASSERT(appId);
-  return [NSString stringWithFormat:@"%@.service.plist", appId];
+  return MacOSUtils::appId(".service.plist").toNSString();
+}
+
+NSString* MacOSController::machServiceName() const {
+  return MacOSUtils::appId(".service").toNSString();
 }
 
 void MacOSController::initialize(const Device* device, const Keys* keys) {
+  // Setup a temporary connection to check the daemon version.
+  NSXPCConnection* conn = [NSXPCConnection alloc];
+  [conn initWithMachServiceName:machServiceName()
+                        options:NSXPCConnectionPrivileged];
+  conn.remoteObjectInterface =
+      [NSXPCInterface interfaceWithProtocol:@protocol(XpcDaemonProtocol)];
+  [conn activate];
+
+  // Create the remote object.
+  NSObject<XpcDaemonProtocol>* remote = nullptr;
+  remote = [conn remoteObjectProxyWithErrorHandler:^(NSError* error){
+    logger.debug() << "Initialize daemon failed:" << error.localizedDescription;
+    QMetaObject::invokeMethod(this, &MacOSController::upgradeService);
+  }];
+
+  // Get the daemon version and decide if an upgrade is needed.
+  [remote getVersion:^(NSString* version){
+    logger.debug() << "Initialize daemon version:" << version;
+    QVersionNumber daemonVersion =
+        QVersionNumber::fromString(QString::fromNSString(version));
+    if (daemonVersion < QVersionNumber::fromString(APP_VERSION)) {
+      QMetaObject::invokeMethod(this, &MacOSController::upgradeService);
+    } else {
+      QMetaObject::invokeMethod(this, &MacOSController::connectService);
+    }
+  }];
+}
+
+void MacOSController::upgradeService() {
   // For MacOS 13 and beyond, attempt to register the daemon using the
   // SMAppService interface.
   if (@available(macOS 13, *)) {
@@ -73,25 +94,18 @@ void MacOSController::initialize(const Device* device, const Keys* keys) {
     // exist. We might need to forcibly remove the old daemon and upgrade it.
     // This can occur when upgrading from a legacy launchd-style service to
     // one that is managed by SMAppService.
-    if ((service.status == SMAppServiceStatusEnabled) &&
-         !QFile::exists(Constants::MACOS_DAEMON_PATH)) {
-      [service unregisterWithCompletionHandler:^(NSError* error){
-        if (error != nil) {
-          logger.warning() << "Legacy service removal failed:" << error;
-        } else {
-          logger.info() << "Legacy service removal succeeded";
-        }
-        QMetaObject::invokeMethod(this, &MacOSController::registerService);
-      }];
-      return;
-    }
-
-    // Perform the service installation.
-    return registerService();
+    [service unregisterWithCompletionHandler:^(NSError* error){
+      if (error != nil) {
+        logger.warning() << "Legacy service removal failed:" << error;
+      } else {
+        logger.info() << "Legacy service removal succeeded";
+      }
+      QMetaObject::invokeMethod(this, &MacOSController::registerService);
+    }];
   } else {
     // Otherwise, for legacy Mac users, they will need to install the daemon
     // some other way. This is normally handled by the installer package.
-    return LocalSocketController::initialize(device, keys);
+    return connectService();
   }
 }
 
@@ -102,7 +116,7 @@ void MacOSController::registerService(void) {
     // Attempt to register the service upon initialization. This should be a
     // no-op if the service is already registered.
     NSError* error = nil;
-    if ([service registerAndReturnError: & error]) {
+    if ([service registerAndReturnError: &error]) {
       logger.debug() << "Mozilla VPN daemon registered successfully.";
     } else if (error.code == kSMErrorInvalidSignature) {
       // If the build is unsigned, continue anyways and hope for the best.
@@ -110,7 +124,8 @@ void MacOSController::registerService(void) {
       // of a pre-existing daemon from a signed installation.
       logger.error() << "Unable to register Mozilla VPN daemon:"
                      << "code signature invalid";
-      return LocalSocketController::initialize(nullptr, nullptr);
+      connectService();
+      return;
     } else {
       // Otherwise, we encountered some other error. Most likely the user
       // needs to approve the daemon to run. Which will be handled below.
@@ -122,7 +137,7 @@ void MacOSController::registerService(void) {
     switch ([service status]) {
       case SMAppServiceStatusNotRegistered:
         logger.debug() << "Mozilla VPN daemon not registered.";
-        m_regTimer.start(SERVICE_REG_POLL_INTERVAL_MSEC);
+        m_registerTimer.start(SERVICE_INIT_POLL_INTERVAL_MSEC);
         break;
 
       case SMAppServiceStatusNotFound:
@@ -132,15 +147,16 @@ void MacOSController::registerService(void) {
       case SMAppServiceStatusEnabled:
         logger.debug() << "Mozilla VPN daemon enabled.";
         m_permissionRequired = false;
-        return LocalSocketController::initialize(nullptr, nullptr);
+        connectService();
+        break;
 
       case SMAppServiceStatusRequiresApproval:
         logger.debug() << "Mozilla VPN daemon requires approval.";
         if (!m_permissionRequired) {
           m_permissionRequired = true;
           emit permissionRequired();
-        } 
-        m_regTimer.start(SERVICE_REG_POLL_INTERVAL_MSEC);
+        }
+        m_registerTimer.start(SERVICE_INIT_POLL_INTERVAL_MSEC);
         break;
     }
   } else {
@@ -149,17 +165,61 @@ void MacOSController::registerService(void) {
   }
 }
 
+void MacOSController::connectService(void) {
+  // Create an XPC connection to the daemon.
+  NSXPCConnection* conn = [NSXPCConnection alloc];
+  [conn initWithMachServiceName:machServiceName()
+                        options:NSXPCConnectionPrivileged];
+  conn.remoteObjectInterface =
+      [NSXPCInterface interfaceWithProtocol:@protocol(XpcDaemonProtocol)];
+  [conn activate];
+
+  // Make an XPC request to get the status.
+  // We may need to re-activate the connection here.
+  NSObject<XpcDaemonProtocol>* remote = nullptr;
+  remote = [conn remoteObjectProxyWithErrorHandler:^(NSError* error){
+    logger.debug() << "daemon connection failed:" << error.localizedDescription;
+    QMetaObject::invokeMethod(&m_connectTimer, "start",
+                              Q_ARG(int, SERVICE_INIT_POLL_INTERVAL_MSEC));
+  }];
+
+  // Get the status and report the controller as initialized.
+  [remote getStatus:^(NSString* status){
+    // Save the connection in the controller class for further use.
+    [conn retain];
+    m_connection = conn;
+    m_connectTimer.stop();
+
+    // Export the client object to receive async events.
+    XpcClientDelegate* delegate = [XpcClientDelegate alloc];
+    conn.exportedObject = [delegate initWithObject:this];
+    conn.exportedInterface =
+        [NSXPCInterface interfaceWithProtocol:@protocol(XpcClientProtocol)];
+
+    // Inform the rest of the application that initialization is complete.
+    QByteArray jsBlob = QString::fromNSString(status).toUtf8();
+    QJsonObject jsObj = QJsonDocument::fromJson(jsBlob).object();
+    emit initialized(true, jsObj.value("connected").toBool(),
+                     QDateTime::fromString(jsObj.value("date").toString()));
+  }];
+}
+
+NSObject<XpcDaemonProtocol>* MacOSController::remoteObject() {
+  NSXPCConnection* conn = static_cast<NSXPCConnection*>(m_connection);
+  return [conn remoteObjectProxyWithErrorHandler:^(NSError* error){
+    REPORTERROR(ErrorHandler::ControllerError, "controller");
+    emit disconnected();
+  }];
+}
+
 void MacOSController::activate(const InterfaceConfig& config,
                                Controller::Reason reason) {
   QString json = QString::fromUtf8(QJsonDocument(config.toJson()).toJson());
-  auto conn = static_cast<NSXPCConnection*>(m_connection);
-  NSObject<XpcDaemonProtocol>* obj = [conn remoteObjectProxy];
-  [obj activate:json.toNSString()];
+  [remoteObject() activate:json.toNSString()];
 }
 
 void MacOSController::deactivate(Controller::Reason reason) {
-  auto conn = static_cast<NSXPCConnection*>(m_connection);
-  [[conn remoteObjectProxy] deactivate];
+  [remoteObject() deactivate];
 }
 
 void MacOSController::checkStatus() {
@@ -204,11 +264,12 @@ void MacOSController::cleanupBackendLogs() {
 }
 
 - (void)connected:(NSString*)pubkey {
-  logger.debug() << "connected:" << pubkey;
+  QMetaObject::invokeMethod(self.parent, "connected",
+                            Q_ARG(QString, QString::fromNSString(pubkey)));
 }
 
 - (void)disconnected {
-  logger.debug() << "disconnected";
+  QMetaObject::invokeMethod(self.parent, "disconnected");
 }
 
 @end

--- a/src/platforms/macos/macosutils.h
+++ b/src/platforms/macos/macosutils.h
@@ -19,7 +19,7 @@ class MacOSUtils final : public QObject {
 
   Q_INVOKABLE void openSystemSettingsLoginItems();
 
-  static NSString* appId();
+  static QString appId();
 
   static QString computerName();
 

--- a/src/platforms/macos/macosutils.h
+++ b/src/platforms/macos/macosutils.h
@@ -19,7 +19,7 @@ class MacOSUtils final : public QObject {
 
   Q_INVOKABLE void openSystemSettingsLoginItems();
 
-  static QString appId();
+  static QString appId(const QString& suffix = QString());
 
   static QString computerName();
 

--- a/src/platforms/macos/macosutils.mm
+++ b/src/platforms/macos/macosutils.mm
@@ -22,7 +22,7 @@ Q_GLOBAL_STATIC(MacOSUtils, macosUtils);
 MacOSUtils* MacOSUtils::instance() { return macosUtils; }
 
 // static
-QString MacOSUtils::appId() {
+QString MacOSUtils::appId(const QString& suffix) {
   NSString* appId = [[NSBundle mainBundle] bundleIdentifier];
   if (!appId) {
     // Fallback. When an unsigned/un-notarized app is executed in
@@ -30,7 +30,7 @@ QString MacOSUtils::appId() {
     appId = @"org.mozilla.macos.FirefoxVPN";
   }
 
-  return QString::fromNSString(appId);
+  return QString::fromNSString(appId) + suffix;
 }
 
 void MacOSUtils::openSystemSettingsLoginItems() {

--- a/src/platforms/macos/macosutils.mm
+++ b/src/platforms/macos/macosutils.mm
@@ -22,7 +22,7 @@ Q_GLOBAL_STATIC(MacOSUtils, macosUtils);
 MacOSUtils* MacOSUtils::instance() { return macosUtils; }
 
 // static
-NSString* MacOSUtils::appId() {
+QString MacOSUtils::appId() {
   NSString* appId = [[NSBundle mainBundle] bundleIdentifier];
   if (!appId) {
     // Fallback. When an unsigned/un-notarized app is executed in
@@ -30,7 +30,7 @@ NSString* MacOSUtils::appId() {
     appId = @"org.mozilla.macos.FirefoxVPN";
   }
 
-  return appId;
+  return QString::fromNSString(appId);
 }
 
 void MacOSUtils::openSystemSettingsLoginItems() {
@@ -49,12 +49,7 @@ QString MacOSUtils::computerName() {
 void MacOSUtils::enableLoginItem(bool startAtBoot) {
   logger.debug() << "Enabling login-item";
 
-  NSString* appId = MacOSUtils::appId();
-  Q_ASSERT(appId);
-
-  NSString* loginItemAppId =
-    QString("%1.login-item").arg(QString::fromNSString(appId)).toNSString();
-
+  NSString* loginItemAppId = QString("%1.login-item").arg(appId()).toNSString();
 
   // For macOS 13 and beyond, register() and unregister() methods
   // are used for managing login items since SMLoginItemSetEnabled() is deprecated.

--- a/src/platforms/macos/xpcdaemonprotocol.h
+++ b/src/platforms/macos/xpcdaemonprotocol.h
@@ -10,6 +10,7 @@
 @protocol XpcDaemonProtocol
 - (void) activate: (NSString*)config;
 - (void) deactivate;
+- (void) getVersion:(void (^)(NSString*))reply;
 - (void) getStatus:(void (^)(NSString*))reply;
 - (void) getBackendLogs:(void (^)(NSString*))reply;
 - (void) cleanupBackendLogs;

--- a/src/platforms/macos/xpcdaemonprotocol.h
+++ b/src/platforms/macos/xpcdaemonprotocol.h
@@ -10,6 +10,7 @@
 @protocol XpcDaemonProtocol
 - (void) activate: (NSString*)config;
 - (void) deactivate;
+- (void) getStatus:(void (^)(NSString*))reply;
 @end
 
 @protocol XpcClientProtocol

--- a/src/platforms/macos/xpcdaemonprotocol.h
+++ b/src/platforms/macos/xpcdaemonprotocol.h
@@ -17,8 +17,9 @@
 @end
 
 @protocol XpcClientProtocol
-- (void) connected: (NSString*)pubkey;
+- (void) connected:(NSString*)pubkey;
 - (void) disconnected;
+- (void)backendFailure:(NSUInteger)reason;
 @end
 
 #endif  // XPCDAEMONPROTOCOL_H

--- a/src/platforms/macos/xpcdaemonprotocol.h
+++ b/src/platforms/macos/xpcdaemonprotocol.h
@@ -11,6 +11,8 @@
 - (void) activate: (NSString*)config;
 - (void) deactivate;
 - (void) getStatus:(void (^)(NSString*))reply;
+- (void) getBackendLogs:(void (^)(NSString*))reply;
+- (void) cleanupBackendLogs;
 @end
 
 @protocol XpcClientProtocol

--- a/src/platforms/macos/xpcdaemonprotocol.h
+++ b/src/platforms/macos/xpcdaemonprotocol.h
@@ -8,17 +8,17 @@
 #import <Foundation/Foundation.h>
 
 @protocol XpcDaemonProtocol
-- (void) activate: (NSString*)config;
-- (void) deactivate;
-- (void) getVersion:(void (^)(NSString*))reply;
-- (void) getStatus:(void (^)(NSString*))reply;
-- (void) getBackendLogs:(void (^)(NSString*))reply;
-- (void) cleanupBackendLogs;
+- (void)activate:(NSString*)config;
+- (void)deactivate;
+- (void)getVersion:(void (^)(NSString*))reply;
+- (void)getStatus:(void (^)(NSString*))reply;
+- (void)getBackendLogs:(void (^)(NSString*))reply;
+- (void)cleanupBackendLogs;
 @end
 
 @protocol XpcClientProtocol
-- (void) connected:(NSString*)pubkey;
-- (void) disconnected;
+- (void)connected:(NSString*)pubkey;
+- (void)disconnected;
 - (void)backendFailure:(NSUInteger)reason;
 @end
 

--- a/src/platforms/macos/xpcdaemonprotocol.h
+++ b/src/platforms/macos/xpcdaemonprotocol.h
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef XPCDAEMONPROTOCOL_H
+#define XPCDAEMONPROTOCOL_H
+
+#import <Foundation/Foundation.h>
+
+@protocol XpcDaemonProtocol
+- (void) activate: (NSString*)config;
+- (void) deactivate;
+@end
+
+@protocol XpcClientProtocol
+- (void) connected: (NSString*)pubkey;
+- (void) disconnected;
+@end
+
+#endif  // XPCDAEMONPROTOCOL_H

--- a/src/platforms/windows/daemon/windowsdaemon.cpp
+++ b/src/platforms/windows/daemon/windowsdaemon.cpp
@@ -38,8 +38,8 @@ WindowsDaemon::WindowsDaemon() : Daemon(nullptr) {
   m_dnsutils = new DnsUtilsWindows(this);
   m_splitTunnelManager = WindowsSplitTunnel::create(m_firewallManager);
 
-  connect(m_wgutils.get(), &WireguardUtilsWindows::backendFailure, this,
-          &WindowsDaemon::monitorBackendFailure);
+  connect(m_wgutils.get(), &WireguardUtils::backendFailure, this,
+          &WindowsDaemon::abortBackendFailure);
   connect(this, &WindowsDaemon::activationFailure,
           [this]() { m_firewallManager->disableKillSwitch(); });
 }
@@ -97,11 +97,4 @@ bool WindowsDaemon::run(Op op, const InterfaceConfig& config) {
   }
   m_splitTunnelManager->stop();
   return true;
-}
-
-void WindowsDaemon::monitorBackendFailure() {
-  logger.warning() << "Tunnel service is down";
-
-  emit backendFailure();
-  deactivate();
 }

--- a/src/platforms/windows/daemon/windowsdaemon.h
+++ b/src/platforms/windows/daemon/windowsdaemon.h
@@ -28,9 +28,6 @@ class WindowsDaemon final : public Daemon {
   DnsUtils* dnsutils() override { return m_dnsutils; }
 
  private:
-  void monitorBackendFailure();
-
- private:
   enum State {
     Active,
     Inactive,

--- a/src/platforms/windows/daemon/wireguardutilswindows.h
+++ b/src/platforms/windows/daemon/wireguardutilswindows.h
@@ -41,9 +41,6 @@ class WireguardUtilsWindows final : public WireguardUtils {
   bool deleteRoutePrefix(const IPAddress& prefix) override;
   bool excludeLocalNetworks(const QList<IPAddress>& addresses) override;
 
- signals:
-  void backendFailure();
-
  private:
   WireguardUtilsWindows(QObject* parent, WindowsFirewall* fw,
                         std::unique_ptr<WireGuardAPI> wireguard_api);

--- a/tests/qml/moccontroller.cpp
+++ b/tests/qml/moccontroller.cpp
@@ -87,3 +87,5 @@ void Controller::logSerialize(QIODevice* device) { device->close(); }
 void Controller::forceDaemonCrash() {}
 
 void Controller::forceDaemonSilentServerSwitch() {}
+
+void Controller::handleBackendFailure(ErrorCode code) {}

--- a/tests/unit/moccontroller.cpp
+++ b/tests/unit/moccontroller.cpp
@@ -91,3 +91,5 @@ void Controller::logSerialize(QIODevice* device) { device->close(); }
 void Controller::forceDaemonCrash() {}
 
 void Controller::forceDaemonSilentServerSwitch() {}
+
+void Controller::handleBackendFailure(ErrorCode code) {}


### PR DESCRIPTION
## Description
This work extends the new MacOSController class to use a new XPC service for communication with the daemon. This gives us the ability to apply codesigning enforcement of the clients that connect to the service and has tighter integration with launchd. This should allow us to grant greater control over access to the daemon without relying on UID and session tracking like the local socket server does.

Much of the pain in figuring this out had to do with the threading model of XPC. It seems like XPC listeners and connections run in their own thread, which of course lacks a Qt event loop. This meant that methods and signals all needed to go through some kind of thread synchronization step to get into and out of the Qt world. For the most part, this is pretty easy using Qt's signals and meta-methods, but it took a bit of banging my head against the wall to figure it out.

As written, this requires the connecting clients to be codesigned with either a Developer ID certificate or an apple developer account, which could make it a bit more difficult for development.

## Reference
Repopened from #10481
JIRA Issue: [VPN-7041](https://mozilla-hub.atlassian.net/browse/VPN-7041)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-7041]: https://mozilla-hub.atlassian.net/browse/VPN-7041?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ