### PR TITLE
VPN-7012: Fix Socksproxy service paths

### DIFF
--- a/extension/CMakeLists.txt
+++ b/extension/CMakeLists.txt
@@ -46,6 +46,7 @@ set_property(TARGET mozillavpnnp PROPERTY
 
 ## Handle installation by platform.
 if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+    include(GNUInstallDirs)
     if(NOT DEFINED WEBEXT_INSTALL_LIBDIR)
         set(WEBEXT_INSTALL_LIBDIR ${CMAKE_INSTALL_FULL_LIBDIR})
     endif()


### PR DESCRIPTION
## Description
The systemd service file for the `socksproxy` service used for the Firefox extension uses the `CMAKE_INSTALL_FULL_BINDIR` variable to determine the path to the binary. This variable is defined by the `GNUInstallDirs` CMake package which we include in the main project, but can be missing for the extension. To fix this, we simply need to include the module.

Thanks to @awisse for reporting this one.

## Reference
JIRA Issue: [VPN-7012](https://mozilla-hub.atlassian.net/browse/VPN-7012)
Github issue: #10446

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-7012]: https://mozilla-hub.atlassian.net/browse/VPN-7012?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ