### PR TITLE
VPN-6941: Update OSX permission screen to match SUMO

### DIFF
--- a/src/translations/strings.yaml
+++ b/src/translations/strings.yaml
@@ -1053,15 +1053,15 @@ permissionMacos:
   title:
     value: Allow VPN to run in background
     comment: Title of the screen directing macOS users to allow the VPN to run in background
-  body:
-    value: To use Mozilla VPN, please allow it to run in the background.
+  request:
+    value: To use Mozilla VPN, please update your System Preferences to allow it to run in the background.
     comment: Paragraph requesting the user to allow the VPN to run in the background.
-  instructions:
-    value: In order to do this, please click the button below to open the <i>Login Items</i> of your <i>System Preferences</i>, and enable <i>Allow in the background</i> for Mozilla VPN.
+  steps:
+    value: Select the button below to go to the “Login Items“ section of System Preferences. Then enable “Allow in the background“ toggle for Mozilla VPN.
     comment: Paragraph explaining how to enable the VPN to run in the background.
-  openSettingsButtonLabel:
-    value: Open Login Items
-    comment: Label for the button that opens the login items settings page
+  openSystemPreferences:
+    value: Open System Preferences
+    comment: Label for the button that opens the system preferences page
 
 global:
   expand:
@@ -1128,6 +1128,9 @@ getHelp:
   developerOptions:
     value: Developer options
     comment: Button label
+  externalHelpLink:
+    value: Get help
+    comment: Label for link to a support article
 
 product:
   name: Mozilla VPN

--- a/src/ui/sharedViews/ViewPermissionRequiredOSX.qml
+++ b/src/ui/sharedViews/ViewPermissionRequiredOSX.qml
@@ -56,7 +56,7 @@ MZFlickable {
                 Layout.topMargin: 8
                 Layout.fillWidth: true
 
-                text: MZI18n.PermissionMacosBody
+                text: MZI18n.PermissionMacosRequest
                 horizontalAlignment: Text.AlignLeft
             }
 
@@ -64,7 +64,7 @@ MZFlickable {
                 Layout.topMargin: 8
                 Layout.fillWidth: true
 
-                text: MZI18n.PermissionMacosInstructions
+                text: MZI18n.PermissionMacosSteps
                 horizontalAlignment: Text.AlignLeft
             }
         }
@@ -76,30 +76,30 @@ MZFlickable {
         MZButton {
             id: openSettingsButton
 
-            text: MZI18n.PermissionMacosOpenSettingsButtonLabel
+            text: MZI18n.PermissionMacosOpenSystemPreferences
             Layout.preferredHeight: MZTheme.theme.rowHeight
             loaderVisible: false
             onClicked: VPNMacOSUtils.openSystemSettingsLoginItems()
         }
 
         MZLinkButton {
-            id: learnMoreLink
+            id: getHelpLink
 
-            labelText:  MZI18n.GlobalLearnMore
+            labelText:  MZI18n.GetHelpExternalHelpLink
             Layout.preferredHeight: MZTheme.theme.rowHeight
             Layout.alignment: Qt.AlignHCenter
             onClicked: MZUrlOpener.openUrlLabel("sumoAllowBackgroundMacos")
         }
 
-        MZSignOut {
+        MZLinkButton {
             id: signOff
 
+            labelText: MZI18n.GlobalSignOut
+            linkColor: MZTheme.colors.fontColor
             Layout.preferredHeight: MZTheme.theme.rowHeight
             Layout.alignment: Qt.AlignHCenter
-            anchors.horizontalCenter: undefined
-            anchors.bottom: undefined
-            anchors.bottomMargin: undefined
-            height: undefined
+
+            onClicked: () => VPN.logout()
         }
     }
 }


### PR DESCRIPTION
## Description
I overstepped during the UX design of the OSX permissions screen and we should have taken the SUMO article and Figma as the absolute source of truth and now it's a problem that the UX in the client doesn't match our support articles. The client should be updated to match these designs **exactly**

## Reference
JIRA Issue: [VPN-6941](https://mozilla-hub.atlassian.net/browse/VPN-6941)
Figma design: [link](https://www.figma.com/design/aqZq6eYrgAthI6BU3Soasr/macOS-Permissions-Update?node-id=97-157)
SUMO article: [link](https://support.mozilla.org/kb/allow-vpn-run-background-macos)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
