### PR TITLE
VPN-7039: Fix socksproxy logspam

### DIFF
--- a/extension/socks5proxy/bin/main.cpp
+++ b/extension/socks5proxy/bin/main.cpp
@@ -126,6 +126,10 @@ int main(int argc, char** argv) {
     return 1;
   }
 
+  // QHostAddress isn't registered as a built-in metatype, and sometimes the
+  // moc tool doesn't figure out that we need it.
+  qRegisterMetaType<QHostAddress>();
+
   auto* logger = new SocksLogger(&app);
   logger->setVerbose(config.verbose);
   if (config.logfile) {

--- a/extension/socks5proxy/bin/sockslogger.cpp
+++ b/extension/socks5proxy/bin/sockslogger.cpp
@@ -90,6 +90,11 @@ void SocksLogger::tick() {
 }
 
 void SocksLogger::printStatus() {
+  // Don't print status unless we are writing to an interactive terminal.
+  if (!isatty(fileno(stdout))) {
+    return;
+  }
+
   QString output;
   {
     QTextStream out(&output);

--- a/extension/socks5proxy/bin/sockslogger.cpp
+++ b/extension/socks5proxy/bin/sockslogger.cpp
@@ -4,6 +4,9 @@
 
 #include "sockslogger.h"
 
+#include <stdio.h>
+#include <unistd.h>
+
 #include <QDateTime>
 #include <QDir>
 #include <QFile>

--- a/extension/socks5proxy/bin/sockslogger.cpp
+++ b/extension/socks5proxy/bin/sockslogger.cpp
@@ -5,7 +5,9 @@
 #include "sockslogger.h"
 
 #include <stdio.h>
-#include <unistd.h>
+#ifndef PROXY_OS_WIN
+#  include <unistd.h>
+#endif
 
 #include <QDateTime>
 #include <QDir>

--- a/extension/socks5proxy/bin/sockslogger.cpp
+++ b/extension/socks5proxy/bin/sockslogger.cpp
@@ -7,6 +7,8 @@
 #include <stdio.h>
 #ifndef PROXY_OS_WIN
 #  include <unistd.h>
+#else
+#  include <io.h>
 #endif
 
 #include <QDateTime>
@@ -96,9 +98,15 @@ void SocksLogger::tick() {
 
 void SocksLogger::printStatus() {
   // Don't print status unless we are writing to an interactive terminal.
+#ifndef PROXY_OS_WIN
   if (!isatty(fileno(stdout))) {
     return;
   }
+#else
+  if (!_isatty(_fileno(stdout))) {
+    return;
+  }
+#endif
 
   QString output;
   {


### PR DESCRIPTION
## Description
The status logger in the `socksproxy` tool periodically writes to `stdout` to show some live statistics when the proxy is running, but this is inappropriate to be printing into logfiles. We should disable this feature when the output device is not a TTY.

During testing, it was also found that we have a bug on Qt 6.2.4 where the `QHostAddress` class doesn't automatically get registered as a metatype for signal/slot delivery, which can result in another source of spammy log messages and breakage of of the socket bypass hooks.

Thanks to @awisse for reporting this one!

## Reference
JIRA Issue: [VPN-7039](https://mozilla-hub.atlassian.net/browse/VPN-7039)
Github issue: #10490

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-7039]: https://mozilla-hub.atlassian.net/browse/VPN-7039?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ