### PR TITLE
VPN-7024: Add retries and workarounds for launchd->SMAppService upgrade

### DIFF
--- a/macos/app/daemon.plist.in
+++ b/macos/app/daemon.plist.in
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
         <dict>
+                <key>AssociatedBundleIdentifiers</key>
+                <string>${BUILD_OSX_APP_IDENTIFIER}</string>
                 <key>Label</key>
                 <string>${BUILD_OSX_APP_IDENTIFIER}.daemon</string>
                 <key>BundleProgram</key>

--- a/macos/pkg/scripts/postinstall.in
+++ b/macos/pkg/scripts/postinstall.in
@@ -68,6 +68,7 @@ if launchctl bootout system/${CODESIGN_APP_IDENTIFIER}.daemon 2>/dev/null; then
 fi
 if [ -f "$DAEMON_PLIST_PATH" ]; then
   echo "Removing legacy daemon plist"
+  launchctl remove ${CODESIGN_APP_IDENTIFIER}.daemon
   rm -f ${DAEMON_PLIST_PATH}
 fi
 

--- a/src/platforms/macos/macoscontroller.h
+++ b/src/platforms/macos/macoscontroller.h
@@ -19,10 +19,11 @@ class MacOSController final : public LocalSocketController {
   void getBackendLogs(QIODevice* device) override;
 
  private slots:
+  void registerService();
   void checkServiceEnabled();
 
  private:
-  QString plistName() const;
+  NSString* plist() const;
 
   int m_smAppStatus;
   QTimer m_regTimer;

--- a/src/platforms/macos/macoscontroller.h
+++ b/src/platforms/macos/macoscontroller.h
@@ -25,7 +25,7 @@ class MacOSController final : public LocalSocketController {
  private:
   NSString* plist() const;
 
-  int m_smAppStatus;
+  bool m_launchdUpgradeWorkaround = false;
   QTimer m_regTimer;
 };
 


### PR DESCRIPTION
## Description
So, digging a little deeper into the bowels of macOS, and I think there's some jankiness in the process of upgrading a service from the legacy `launchd`-style daemon into an embedded daemon managed with `SMAppService`. The problem seems to stem from a lack of coordination between `launchd` and the background task manager.

The problem goes something like this:
1. We remove the old `launchd` daemon during package installation and purge its plist off disk.
2. We install the new VPN application bundle and it tries to register the service.
3. But, the daemon identifier is still known as a legacy daemon by the background task manager. So it rejects the service installation.
4. If we open the login item settings, this kicks the background task manager to rescan and update its database, finally purging the old legacy daemon.

This fix works around the issue by catching a failure to register the service and throwing the permission required screen anyways. This should prompt the user to open the login items settings, which will trigger the database update and allow a retry of the registration to get things moving again.

For what its worth, I feel kinda gross about this fix and I feel like it's really a bug in macOS that we can't cleanly remove a legacy daemon. The other option might be to give the new service a different bundle identifier so that it can be installed along side the zombie state of the legacy daemon.

## Reference
JIRA Issue: [VPN-7024](https://mozilla-hub.atlassian.net/browse/VPN-7024)
JIRA Issue: [VPN-7042](https://mozilla-hub.atlassian.net/browse/VPN-7042)
JIRA Issue: [VPN-6945](https://mozilla-hub.atlassian.net/browse/VPN-6945)

Alternative solution: #10504 

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-7024]: https://mozilla-hub.atlassian.net/browse/VPN-7024?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ