### PR TITLE
Submit Telemetry Extras 

### DIFF
--- a/src/webextensiontelemetry.cpp
+++ b/src/webextensiontelemetry.cpp
@@ -44,7 +44,14 @@ namespace handlers {
 // For Events we want to just record it to glean.
 // It will be send out with the next ping
 auto constexpr event(EventMetric* metric) {
-  return [metric](QVariant) { metric->record(); };
+  return [metric](QVariant args) { 
+    if(args.isValid()){
+      auto const obj = args.toJsonObject();
+      metric->record(obj);
+      return;
+    }
+    metric->record();
+  };
 };
 auto constexpr count(QuantityMetric* metric) {
   return [metric](QVariant args) {

--- a/src/webextensiontelemetry.cpp
+++ b/src/webextensiontelemetry.cpp
@@ -44,8 +44,8 @@ namespace handlers {
 // For Events we want to just record it to glean.
 // It will be send out with the next ping
 auto constexpr event(EventMetric* metric) {
-  return [metric](QVariant args) { 
-    if(args.isValid()){
+  return [metric](QVariant args) {
+    if (args.isValid()) {
       auto const obj = args.toJsonObject();
       metric->record(obj);
       return;


### PR DESCRIPTION
In case of an event we did not submit the extras object we might have been sending from the extension