### PR TITLE
VPN-7024: Rename SMAppService daemon to org.mozilla.macos.FirefoxVPN.service

### DIFF
--- a/macos/app/service.plist.in
+++ b/macos/app/service.plist.in
@@ -3,7 +3,7 @@
 <plist version="1.0">
         <dict>
                 <key>Label</key>
-                <string>${BUILD_OSX_APP_IDENTIFIER}.daemon</string>
+                <string>${BUILD_OSX_APP_IDENTIFIER}.service</string>
                 <key>BundleProgram</key>
                 <string>Contents/MacOS/Mozilla VPN</string>
                 <key>ProgramArguments</key>

--- a/macos/app/service.plist.in
+++ b/macos/app/service.plist.in
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
         <dict>
+                <key>AssociatedBundleIdentifiers</key>
+                <string>${BUILD_OSX_APP_IDENTIFIER}</string>
                 <key>Label</key>
                 <string>${BUILD_OSX_APP_IDENTIFIER}.service</string>
                 <key>BundleProgram</key>

--- a/macos/pkg/scripts/postinstall.in
+++ b/macos/pkg/scripts/postinstall.in
@@ -97,7 +97,8 @@ EOF
   # Modify the SMAppService plist for use as a legacy daemon.
   echo "Loading the Daemon at $DAEMON_PLIST_PATH"
   plutil -replace ProgramArguments -json "[\"$DAEMON_HELPER_TOOL\"]" -o $DAEMON_PLIST_PATH \
-    "${APP_DIR}/Contents/Library/LaunchDaemons/${CODESIGN_APP_IDENTIFIER}.daemon.plist"
+    "${APP_DIR}/Contents/Library/LaunchDaemons/${CODESIGN_APP_IDENTIFIER}.service.plist"
+  plutil -replace Label -string ${CODESIGN_APP_IDENTIFIER}.daemon $DAEMON_PLIST_PATH
   launchctl load -w $DAEMON_PLIST_PATH
 fi
 

--- a/src/cmake/macos.cmake
+++ b/src/cmake/macos.cmake
@@ -154,13 +154,13 @@ osx_bundle_files(mozillavpn FILES
     DESTINATION Resources/utils
 )
 
-# Install the daemon plist into the bundle.
+# Install the background service plist into the bundle.
 configure_file(
-    ${CMAKE_SOURCE_DIR}/macos/app/daemon.plist.in
-    ${CMAKE_CURRENT_BINARY_DIR}/${BUILD_OSX_APP_IDENTIFIER}.daemon.plist
+    ${CMAKE_SOURCE_DIR}/macos/app/service.plist.in
+    ${CMAKE_CURRENT_BINARY_DIR}/${BUILD_OSX_APP_IDENTIFIER}.service.plist
 )
 osx_bundle_files(mozillavpn FILES
-    ${CMAKE_CURRENT_BINARY_DIR}/${BUILD_OSX_APP_IDENTIFIER}.daemon.plist
+    ${CMAKE_CURRENT_BINARY_DIR}/${BUILD_OSX_APP_IDENTIFIER}.service.plist
     DESTINATION Library/LaunchDaemons
 )
 

--- a/src/platforms/macos/macoscontroller.h
+++ b/src/platforms/macos/macoscontroller.h
@@ -24,7 +24,6 @@ class MacOSController final : public LocalSocketController {
  private:
   NSString* plist() const;
 
-  int m_smAppStatus;
   QTimer m_regTimer;
 };
 

--- a/src/platforms/macos/macoscontroller.h
+++ b/src/platforms/macos/macoscontroller.h
@@ -22,7 +22,7 @@ class MacOSController final : public LocalSocketController {
   void checkServiceEnabled();
 
  private:
-  QString plistName() const;
+  NSString* plist() const;
 
   int m_smAppStatus;
   QTimer m_regTimer;

--- a/src/platforms/macos/macoscontroller.mm
+++ b/src/platforms/macos/macoscontroller.mm
@@ -21,7 +21,6 @@ constexpr const int SERVICE_REG_POLL_INTERVAL_MSEC = 1000;
 
 MacOSController::MacOSController() :
    LocalSocketController(Constants::MACOS_DAEMON_PATH) {
-  m_smAppStatus = -1;
 
   m_regTimer.setInterval(SERVICE_REG_POLL_INTERVAL_MSEC);
   m_regTimer.setSingleShot(false);
@@ -61,8 +60,7 @@ void MacOSController::initialize(const Device* device, const Keys* keys) {
     }
 
     // Check the service status for how to proceed.
-    m_smAppStatus = [service status];
-    switch (m_smAppStatus) {
+    switch ([service status]) {
       case SMAppServiceStatusNotRegistered:
         logger.debug() << "Mozilla VPN daemon not registered.";
         break;
@@ -101,6 +99,9 @@ void MacOSController::checkServiceEnabled(void) {
       m_regTimer.stop();
       LocalSocketController::initialize(nullptr, nullptr);
     }
+  } else {
+    // This method should only ever be called for macOS 13 and newer.
+    Q_UNREACHABLE();
   }
 }
 
@@ -110,7 +111,7 @@ void MacOSController::getBackendLogs(QIODevice* device) {
     LocalSocketController::getBackendLogs(device);
     return;
   }
-  
+
   // Otherwise, try our best to scrape the logs directly off disk.
   QByteArray logData("Failed to open backend logs");
   QFile logfile("/var/log/mozillavpn/mozillavpn.log");

--- a/src/platforms/macos/macoscontroller.mm
+++ b/src/platforms/macos/macoscontroller.mm
@@ -29,18 +29,17 @@ MacOSController::MacOSController() :
           &MacOSController::checkServiceEnabled);
 }
 
-QString MacOSController::plistName() const {
+NSString* MacOSController::plist() const {
   NSString* appId = MacOSUtils::appId();
   Q_ASSERT(appId);
-  return QString("%1.daemon.plist").arg(QString::fromNSString(appId));
+  return [NSString stringWithFormat:@"%@.service.plist", appId];
 }
 
 void MacOSController::initialize(const Device* device, const Keys* keys) {
   // For MacOS 13 and beyond, attempt to register the daemon using the
   // SMAppService interface.
   if (@available(macOS 13, *)) {
-    SMAppService* service =
-        [SMAppService daemonServiceWithPlistName:plistName().toNSString()];
+    SMAppService* service = [SMAppService daemonServiceWithPlistName:plist()];
 
     // Attempt to register the service upon initialization. This should be a
     // no-op if the service is already registered.
@@ -92,8 +91,7 @@ void MacOSController::initialize(const Device* device, const Keys* keys) {
 void MacOSController::checkServiceEnabled(void) {
   if (@available(macOS 13, *)) {
     // Create the daemon delegate object.
-    SMAppService* service =
-        [SMAppService daemonServiceWithPlistName:plistName().toNSString()];
+    SMAppService* service = [SMAppService daemonServiceWithPlistName:plist()];
     if ([service status] == SMAppServiceStatusEnabled) {
       logger.debug() << "Mozilla VPN daemon enabled.";
 


### PR DESCRIPTION
## Description
So, digging a little deeper into the bowels of macOS, and I think there's some jankiness in the process of upgrading a service from the legacy launchd-style daemon into an embedded daemon managed with SMAppService. The problem seems to stem from a lack of coordination between launchd and the background task manager.

The problem goes something like this:
1. We remove the old launchd daemon during package installation and purge its plist off disk.
2. We install the new VPN application bundle and it tries to register the service.
3. The daemon identifier is still known as a legacy daemon by the background task manager. So it rejects the service installation.
4. Eventually, the background task manager rescans its database and drops the legacy daemon. But this doesn't seem to occur in any kind of timely manner (the Apple developer forums suggests this runs nightly and/or on reboot).

We can address this by renaming the daemon to use a different identifier when it's installed by `SMAppService` so that it doesn't collide with the zombie status from a legacy daemon. 

## Reference
JIRA Issue: [VPN-7024](https://mozilla-hub.atlassian.net/browse/VPN-7024)
JIRA Issue: [VPN-7042](https://mozilla-hub.atlassian.net/browse/VPN-7042)
JIRA Issue: [VPN-6945](https://mozilla-hub.atlassian.net/browse/VPN-6945)

Alternative solution: #10502

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-7024]: https://mozilla-hub.atlassian.net/browse/VPN-7024?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ