### PR TITLE
VPN-7050: give explict colors for StateSilentSwitching

### DIFF
--- a/src/ui/screens/home/controller/ControllerImage.qml
+++ b/src/ui/screens/home/controller/ControllerImage.qml
@@ -95,6 +95,23 @@ Rectangle {
             }
         },
         State {
+            name: VPNController.StateSilentSwitching
+
+            PropertyChanges {
+                target: logo
+                showVPNOnIcon: true
+            }
+            PropertyChanges {
+                target: insetCircle
+                color: MZTheme.colors.successAlert.defaultColor
+            }
+            PropertyChanges {
+                target: insetIcon
+                source: MZAssetLookup.getImageSource("ShieldOn")
+                opacity: 1
+            }
+        },
+        State {
             name: VPNController.StateOff
             PropertyChanges {
                 target: insetCircle


### PR DESCRIPTION
## Description

This was caused by going to default colors. I gave it some explicit state.

FWIW, it's not noticable on desktop because it moves from StateSilentSwitching to StateConnecting in a few milliseconds. Whereas on iOS, it moves from StateSilentSwitching to StateOn, which takes a few hundred milliseconds typically.

To repro/test on desktop, just comment out the `deactivate()` line in `Controller::silentSwitchServers`.

## Reference

VPN-7050

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
