### PR TITLE
VPN-6945: Add SMAppService registration retries

### DIFF
--- a/src/platforms/macos/macoscontroller.h
+++ b/src/platforms/macos/macoscontroller.h
@@ -19,11 +19,12 @@ class MacOSController final : public LocalSocketController {
   void getBackendLogs(QIODevice* device) override;
 
  private slots:
-  void checkServiceEnabled();
+  void registerService();
 
  private:
   NSString* plist() const;
 
+  bool m_permissionRequired = false;
   QTimer m_regTimer;
 };
 

--- a/src/platforms/macos/macoscontroller.mm
+++ b/src/platforms/macos/macoscontroller.mm
@@ -22,10 +22,9 @@ constexpr const int SERVICE_REG_POLL_INTERVAL_MSEC = 1000;
 MacOSController::MacOSController() :
    LocalSocketController(Constants::MACOS_DAEMON_PATH) {
 
-  m_regTimer.setInterval(SERVICE_REG_POLL_INTERVAL_MSEC);
-  m_regTimer.setSingleShot(false);
+  m_regTimer.setSingleShot(true);
   connect(&m_regTimer, &QTimer::timeout, this,
-          &MacOSController::checkServiceEnabled);
+          &MacOSController::registerService);
 }
 
 NSString* MacOSController::plist() const {
@@ -40,6 +39,36 @@ void MacOSController::initialize(const Device* device, const Keys* keys) {
   if (@available(macOS 13, *)) {
     SMAppService* service = [SMAppService daemonServiceWithPlistName:plist()];
 
+    // If the service purports to be installed, but the local socket doesn't
+    // exist. We might need to forcibly remove the old daemon and upgrade it.
+    // This can occur when upgrading from a legacy launchd-style service to
+    // one that is managed by SMAppService.
+    if ((service.status == SMAppServiceStatusEnabled) &&
+         !QFile::exists(Constants::MACOS_DAEMON_PATH)) {
+      [service unregisterWithCompletionHandler:^(NSError* error){
+        if (error != nil) {
+          logger.warning() << "Legacy service removal failed:" << error;
+        } else {
+          logger.info() << "Legacy service removal succeeded";
+        }
+        QMetaObject::invokeMethod(this, &MacOSController::registerService);
+      }];
+      return;
+    }
+
+    // Perform the service installation.
+    return registerService();
+  } else {
+    // Otherwise, for legacy Mac users, they will need to install the daemon
+    // some other way. This is normally handled by the installer package.
+    return LocalSocketController::initialize(device, keys);
+  }
+}
+
+void MacOSController::registerService(void) {
+  if (@available(macOS 13, *)) {
+    SMAppService* service = [SMAppService daemonServiceWithPlistName:plist()];
+
     // Attempt to register the service upon initialization. This should be a
     // no-op if the service is already registered.
     NSError* error = nil;
@@ -51,7 +80,7 @@ void MacOSController::initialize(const Device* device, const Keys* keys) {
       // of a pre-existing daemon from a signed installation.
       logger.error() << "Unable to register Mozilla VPN daemon:"
                      << "code signature invalid";
-      return LocalSocketController::initialize(device, keys);
+      return LocalSocketController::initialize(nullptr, nullptr);
     } else {
       // Otherwise, we encountered some other error. Most likely the user
       // needs to approve the daemon to run. Which will be handled below.
@@ -71,33 +100,17 @@ void MacOSController::initialize(const Device* device, const Keys* keys) {
 
       case SMAppServiceStatusEnabled:
         logger.debug() << "Mozilla VPN daemon enabled.";
-        return LocalSocketController::initialize(device, keys);
+        m_permissionRequired = false;
+        return LocalSocketController::initialize(nullptr, nullptr);
 
       case SMAppServiceStatusRequiresApproval:
         logger.debug() << "Mozilla VPN daemon requires approval.";
-        emit permissionRequired();
-        m_regTimer.start();
+        if (!m_permissionRequired) {
+          m_permissionRequired = true;
+          emit permissionRequired();
+        } 
+        m_regTimer.start(SERVICE_REG_POLL_INTERVAL_MSEC);
         break;
-    }
-  } else {
-    // Otherwise, for legacy Mac users, they will need to install the daemon
-    // some other way. This is normally handled by the installer package.
-    return LocalSocketController::initialize(device, keys);
-  }
-}
-
-void MacOSController::checkServiceEnabled(void) {
-  if (@available(macOS 13, *)) {
-    // Create the daemon delegate object.
-    SMAppService* service = [SMAppService daemonServiceWithPlistName:plist()];
-    if ([service status] == SMAppServiceStatusEnabled) {
-      logger.debug() << "Mozilla VPN daemon enabled.";
-
-      // We can continue with initialization.
-      // NOTE: It just so happens that the LocalSocketController doesn't use
-      // the device or keys, so it's safe to pass null here.
-      m_regTimer.stop();
-      LocalSocketController::initialize(nullptr, nullptr);
     }
   } else {
     // This method should only ever be called for macOS 13 and newer.


### PR DESCRIPTION
## Description
Another entry in the endless saga of the MacOS daemon upgrade. This time we put some debugging energy into macOS13 to see what happens.

It seems like there is a bit of an API behaviour difference on macOS 13 vs. later operating systems. In particular `registerAndReturnError` can fail when permission has been denied, so we actually need to retry `regsiterAndReturnError` until we get a successful return code and the status of the service is `SMAppServiceStatusEnabled`

## Reference
JIRA Issue: [VPN-6945](https://mozilla-hub.atlassian.net/browse/VPN-6945)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-6945]: https://mozilla-hub.atlassian.net/browse/VPN-6945?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ