### PR TITLE
Nit: Support explicit provision profiles when building for MacOS.

### DIFF
--- a/docs/Building/macos.md
+++ b/docs/Building/macos.md
@@ -97,6 +97,14 @@ user@example ~ % security find-identity -v -p codesigning
 
 Thus, to configure the project to use the above codesigning identity, we can provide the argument `-DCODE_SIGN_IDENTITY=AAAABBBBCCCCDDDDEEEEFFFFAAAABBBBCCCCDDDD`
 
+To distribute a signed application for installation on other machines, an
+embedded provisioning profile is also required. The path to the provisioning
+profile can be specified with the argument
+`-DCODE_SIGN_PROFILE=<path/to/embedded.provisionprofile>`.
+When this arugment is unset, an attempt will be made to automatically lookup the
+provisining profile from the `~/Library/Developer/Xcode/UserData/Provisioning\ Profiles`
+directory.
+
 # Building the installer
 
 Use the `--target pkg` to build the MacOS installer.

--- a/scripts/cmake/osxtools.cmake
+++ b/scripts/cmake/osxtools.cmake
@@ -166,6 +166,14 @@ function(osx_embed_provision_profile TARGET)
     if(NOT CODE_SIGN_IDENTITY)
         return()
     endif()
+    ## A provisioning profile can be manually specified
+    if(CODE_SIGN_PROFILE)
+        add_custom_command(TARGET ${TARGET} POST_BUILD
+            COMMAND ${COMMENT_ECHO_COMMAND} "Bundling embedded.provisionprofile"
+            COMMAND ${CMAKE_COMMAND} -E copy ${CODE_SIGN_PROFILE} $<TARGET_BUNDLE_CONTENT_DIR:${TARGET}>/embedded.provisionprofile
+        )
+        return()
+    endif()
 
     # Enumerate the provioning profiles managed by Xcode
     set(XCODE_PROVISION_PROFILES_DIR "$ENV{HOME}/Library/Developer/Xcode/UserData/Provisioning\ Profiles")


### PR DESCRIPTION
## Description
This adds a CMake argument, `CODE_SIGN_PROFILE`, for macOS which can be used to specify an embedded provisioning profile to be added to the signed application bundle. This allows the bundle to be installed on other development machines. When the argument is unset, an attempt is made to automatically lookup a suitable provisioning profile from `~/Library/Developer/Xcode/UserData/Provisioning Profiles`

## Reference

    i.e Jira or Github issue URL

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
