### PR TITLE
Bugfix: ICWYU - Include windows.h

### DIFF
--- a/src/qmlengineholder.cpp
+++ b/src/qmlengineholder.cpp
@@ -30,6 +30,10 @@
 #  include "sentry/sentryadapter.h"
 #endif
 
+#ifdef MZ_WINDOWS
+#  include <windows.h>
+#endif
+
 namespace {
 QmlEngineHolder* s_instance = nullptr;
 }  // namespace


### PR DESCRIPTION
## Description

I just upgraded my build machine to Qt 6.9.x 
we use stuff from windows.h but we got that from a QT import