### PR TITLE
VPN-7042: Fix shutdown/upgrade deadlock

### DIFF
--- a/macos/pkg/scripts/postinstall.in
+++ b/macos/pkg/scripts/postinstall.in
@@ -35,7 +35,7 @@ exec 2>&1 > $LOG_DIR/postinstall.log
 echo "Running postinstall at $(date)"
 echo "Installing Mozilla VPN to ${APP_DIR}"
 
-pkill -x "Mozilla VPN" || echo "Unable to kill GUI, not running?"
+pkill -U "${USER}" -x "Mozilla VPN" || echo "Unable to kill GUI, not running?"
 sleep 1
 
 ## Before MacOS 13, take extra care to prevent tampering with the app.
@@ -62,8 +62,11 @@ echo "Codesign successful!"
 
 # Unload the daemon
 UPDATING=
-if launchctl bootout system/${CODESIGN_APP_IDENTIFIER}.daemon 2>/dev/null; then
-  echo "Update detected"
+if launchctl bootout system/${CODESIGN_APP_IDENTIFIER}.service 2>/dev/null; then
+  echo "Update detected (SMAppService)"
+  UPDATING=1
+elif launchctl bootout system/${CODESIGN_APP_IDENTIFIER}.daemon 2>/dev/null; then
+  echo "Update detected (legacy daemon)"
   UPDATING=1
 fi
 if [ -f "$DAEMON_PLIST_PATH" ]; then

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -249,16 +249,12 @@ void Controller::quit() {
   logger.debug() << "Quitting";
 
   if (!isActive()) {
-    m_nextStep = Quit;
     emit readyToQuit();
     return;
   }
 
   m_nextStep = Quit;
-
-  if (m_state == StateOn || m_state == StateOnPartial ||
-      m_state == StateSwitching || m_state == StateSilentSwitching ||
-      m_state == StateConnecting || m_state == StateConfirming) {
+  if (m_state > StateDisconnecting) {
     deactivate();
     return;
   }

--- a/src/tasks/controlleraction/taskcontrolleraction.cpp
+++ b/src/tasks/controlleraction/taskcontrolleraction.cpp
@@ -42,12 +42,13 @@ void TaskControllerAction::run() {
   Q_ASSERT(controller);
 
   connect(controller, &Controller::stateChanged, this,
-          &TaskControllerAction::stateChanged, Qt::QueuedConnection);
+          &TaskControllerAction::stateChanged);
+
+  // Give the action some time to complete.
+  m_timer.start(TASKCONTROLLER_TIMER_MSEC);
 
   bool expectSignal = false;
-
   m_lastState = controller->state();
-
   switch (m_action) {
     case eActivate:
       expectSignal = controller->activate(m_serverData);
@@ -70,15 +71,10 @@ void TaskControllerAction::run() {
       break;
   }
 
-  // No signal expected. Probably, the VPN is already in the right state. Let's
-  // use the timer to wait 1 cycle only.
+  // If no signal is expected, the VPN is probably already in the right state.
   if (!expectSignal) {
-    m_timer.start(0);
-    return;
+    checkStatus();
   }
-
-  // Fallback 3 seconds.
-  m_timer.start(TASKCONTROLLER_TIMER_MSEC);
 }
 
 void TaskControllerAction::stateChanged() {


### PR DESCRIPTION
## Description
There is something of a deadlock that can occur during shutdown of the VPN client if the backend service is also unavailable. This can manifest on a macOS machine during package upgrade (or when triggered manually with `sudo pkill -x "Mozilla VPN"`).

The sequence of events that lead to the deadlock goes something like this:
1. The VPN client receives a `SIGTERM` signal and requests the Controller class to quit. The controller, is already disconnected so this is a no-op and the controller class emits `readyToQuit()`
2. The `MozillaVPN` class receives `readyToQuit` and starts the shutdown process. During this time, it flushes the task queue and calls `MozillaVPN::disconnect(true)` which requests the controller to disconnect and blocks until complete. This is done using a `TaskControllerAction` and manually running the `QEventLoop` until disconnected.
3. Meanwhile, the daemon terminates and the client catches this event in the `LocalSocketController` - this causes a background service error and emits a `disconnected()` signal. 
4. The controller handles the `disconnected` signal, finds that the next steps is `Quit` and emits another `readyToQuit()` signal.
5. The `MozillaVPN` class receives `readyToQuit` and starts the shutdown process again. It flushes the task queue, destroying the `TaskControllerAction` from step 2, leading the `QEventLoop` in `MozillaVPN::disconnect()` to run indefinitely because it never detects the task completion. This deadlocks the client and prevents it from terminating.

Steps 3-5 can repeat multiple times as the `LocalSocketController` continuously retries the connection to the daemon.

To fix this issue, we add some additional guard rails to prevent the deadlock from occurring by:

- The `Controller` class only sets the `m_nextStep = Quit` when it actually needs to wait for a signal.
- We update `TaskControllerAction::run()`so that it can run synchronously to completion when no signals are needed, this minimizes the window for race conditions to sneak in.

Then, to try and minimize the chances of triggering the race condition in existing clients, we limit the use of `pkill` during installation to target just the GUI applications (the daemon's will be shutdown later anyways by `launchctl bootout` anyways).

## Reference
JIRA Issue: [VPN-7042](https://mozilla-hub.atlassian.net/browse/VPN-7042)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-7042]: https://mozilla-hub.atlassian.net/browse/VPN-7042?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ