### PR TITLE
Change Titlebar Color to match new theme

### DIFF
--- a/src/platforms/windows/windowsutils.cpp
+++ b/src/platforms/windows/windowsutils.cpp
@@ -132,7 +132,7 @@ constexpr uint32_t toCOLORREF(const char* color) {
 
 void WindowsUtils::updateTitleBarColor(QWindow* window, bool darkMode) {
   // TODO: Fetch that from the theme data.
-  const COLORREF defaultColor = darkMode ? ColorUtils::toCOLORREF("#0C0C0D")
+  const COLORREF defaultColor = darkMode ? ColorUtils::toCOLORREF("#42414d")
                                          : ColorUtils::toCOLORREF("#F9F9FA");
 
   auto const windowHandle = (HWND)window->winId();


### PR DESCRIPTION
## Description

When i landed that code i did use the colors from the designer not approved theme. This should now use the proper color so that the darkmode bar does not stand out like it does in light mode. 

Before: 
![image](https://github.com/user-attachments/assets/9f5857cd-a191-4f19-9eda-d0ff65d45e4b)



After: 
![image](https://github.com/user-attachments/assets/9e42ddd3-ceef-4779-8be0-2254e79d02dc)

