### PR TITLE
VPN-6945: Add retries on service not registered error

### DIFF
--- a/src/platforms/macos/macoscontroller.mm
+++ b/src/platforms/macos/macoscontroller.mm
@@ -92,6 +92,7 @@ void MacOSController::registerService(void) {
     switch ([service status]) {
       case SMAppServiceStatusNotRegistered:
         logger.debug() << "Mozilla VPN daemon not registered.";
+        m_regTimer.start(SERVICE_REG_POLL_INTERVAL_MSEC);
         break;
 
       case SMAppServiceStatusNotFound:


### PR DESCRIPTION
## Description
I found another edge case that can result in a stuck client during service registration. In particular, it seems that sometimes when removing a service registration it can take a bit of time for the old service to terminate. During this time the call to `registerAndReturnError` can return an error and leave the status in `not regsitered`. Simply retrying the registration at a later time seems to fix the issue.

I have observed this occurring on macOS 13 when re-installing 2.29 over an existing 2.29 build.

## Reference
JIRA Issue: [VPN-6945](https://mozilla-hub.atlassian.net/browse/VPN-6945)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-6945]: https://mozilla-hub.atlassian.net/browse/VPN-6945?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ