### PR TITLE
Nit: Remove dead code from macos loginitem

### DIFF
--- a/macos/loginitem/main.m
+++ b/macos/loginitem/main.m
@@ -25,13 +25,6 @@ int main()
            }];
 
     [NSThread sleepForTimeInterval:10];
-  } else {
-    NSString* appId = [NSString stringWithUTF8String:APP_ID];
-
-    [[NSWorkspace sharedWorkspace] launchAppWithBundleIdentifier:appId
-                                                         options:NSWorkspaceLaunchDefault
-                                  additionalEventParamDescriptor:NULL
-                                                launchIdentifier:NULL];
   }
 
   return 0;

--- a/macos/loginitem/main.m
+++ b/macos/loginitem/main.m
@@ -6,26 +6,24 @@
 
 int main()
 {
-  if (@available(macOS 10.15, *)) {
-    // When an app is sandboxed, the configuration.arguments array is ignored. Let's use env
-    // variables to pass startup flags.
-    NSDictionary* env = @{@"MVPN_MINIMIZED" : @"1", @"MVPN_STARTATBOOT" : @"1"};
+  // When an app is sandboxed, the configuration.arguments array is ignored. Let's use env
+  // variables to pass startup flags.
+  NSDictionary* env = @{@"MVPN_MINIMIZED" : @"1", @"MVPN_STARTATBOOT" : @"1"};
 
-    NSWorkspaceOpenConfiguration* configuration = [NSWorkspaceOpenConfiguration new];
-    [configuration setEnvironment:env];
+  NSWorkspaceOpenConfiguration* configuration = [NSWorkspaceOpenConfiguration new];
+  [configuration setEnvironment:env];
 
-    [[NSWorkspace sharedWorkspace]
-        openApplicationAtURL:[NSURL fileURLWithPath:@"/Applications/Mozilla VPN.app"]
-               configuration:configuration
-           completionHandler:^(NSRunningApplication* _Nullable app, NSError* _Nullable error) {
-             if (error) {
-               NSLog(@"Failed to run the Mozilla VPN app: %@", error.localizedDescription);
-             }
-             exit(0);
-           }];
+  [[NSWorkspace sharedWorkspace]
+      openApplicationAtURL:[NSURL fileURLWithPath:@"/Applications/Mozilla VPN.app"]
+              configuration:configuration
+          completionHandler:^(NSRunningApplication* _Nullable app, NSError* _Nullable error) {
+            if (error) {
+              NSLog(@"Failed to run the Mozilla VPN app: %@", error.localizedDescription);
+            }
+            exit(0);
+          }];
 
-    [NSThread sleepForTimeInterval:10];
-  }
+  [NSThread sleepForTimeInterval:10];
 
   return 0;
 }


### PR DESCRIPTION
## Description
After we increased the minimum macOS deployment target to 11.0, the legacy branch in the loginitem handler is no longer reachable, and it has left a bunch of deprecated code warnings in the `loginitem` target due to the deprecation of [launchAppWithBundleIdentifier](https://developer.apple.com/documentation/appkit/nsworkspace/launchapplication(withbundleidentifier:options:additionaleventparamdescriptor:launchidentifier:)) in macOS 11.0. We can simply delete the offending code.

The errors go something like this:
```
(vpn) naomi@Naomi-MBP build-macos % cmake --build . --target loginitem
[0/2] Re-checking globbed directories...
[2/3] Building OBJC object macos/loginitem/CMakeFiles/loginitem.dir/main.m.o
/Users/naomi/Work/mozilla-vpn-client/macos/loginitem/main.m:32:66: warning: 'NSWorkspaceLaunchDefault' is deprecated: first deprecated in macOS 11.0 - Use NSWorkspaceOpenConfiguration instead. [-Wdeprecated-declarations]
   32 |                                                          options:NSWorkspaceLaunchDefault
      |                                                                  ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.2.sdk/System/Library/Frameworks/AppKit.framework/Headers/NSWorkspace.h:355:5: note: 'NSWorkspaceLaunchDefault' has been explicitly marked deprecated here
  355 |     NSWorkspaceLaunchDefault                  API_DEPRECATED("Use NSWorkspaceOpenConfiguration instead.", macos(10.3, 11.0)) = NSWorkspaceLaunchAsync,
      |     ^
/Users/naomi/Work/mozilla-vpn-client/macos/loginitem/main.m:31:36: warning: 'launchAppWithBundleIdentifier:options:additionalEventParamDescriptor:launchIdentifier:' is deprecated: first deprecated in macOS 11.0 - Use -[NSWorkspace openApplicationAtURL:configuration:completionHandler:] instead. [-Wdeprecated-declarations]
   31 |     [[NSWorkspace sharedWorkspace] launchAppWithBundleIdentifier:appId
      |                                    ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.2.sdk/System/Library/Frameworks/AppKit.framework/Headers/NSWorkspace.h:405:1: note: 'launchAppWithBundleIdentifier:options:additionalEventParamDescriptor:launchIdentifier:' has been explicitly marked deprecated here
  405 | - (BOOL)launchAppWithBundleIdentifier:(NSString *)bundleIdentifier options:(NSWorkspaceLaunchOptions)options additionalEventParamDescriptor:(nullable NSAppleEventDescriptor *)descriptor launchIdentifier:(NSNumber * _Nullable * _Nullable)identifier API_DEPRECATED("Use -[NSWorkspace openApplicationAtURL:configuration:completionHandler:] instead.", macos(10.0, 11.0));
      | ^
2 warnings generated.
/Users/naomi/Work/mozilla-vpn-client/macos/loginitem/main.m:32:66: warning: 'NSWorkspaceLaunchDefault' is deprecated: first deprecated in macOS 11.0 - Use NSWorkspaceOpenConfiguration instead. [-Wdeprecated-declarations]
   32 |                                                          options:NSWorkspaceLaunchDefault
      |                                                                  ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.2.sdk/System/Library/Frameworks/AppKit.framework/Headers/NSWorkspace.h:355:5: note: 'NSWorkspaceLaunchDefault' has been explicitly marked deprecated here
  355 |     NSWorkspaceLaunchDefault                  API_DEPRECATED("Use NSWorkspaceOpenConfiguration instead.", macos(10.3, 11.0)) = NSWorkspaceLaunchAsync,
      |     ^
/Users/naomi/Work/mozilla-vpn-client/macos/loginitem/main.m:31:36: warning: 'launchAppWithBundleIdentifier:options:additionalEventParamDescriptor:launchIdentifier:' is deprecated: first deprecated in macOS 11.0 - Use -[NSWorkspace openApplicationAtURL:configuration:completionHandler:] instead. [-Wdeprecated-declarations]
   31 |     [[NSWorkspace sharedWorkspace] launchAppWithBundleIdentifier:appId
      |                                    ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.2.sdk/System/Library/Frameworks/AppKit.framework/Headers/NSWorkspace.h:405:1: note: 'launchAppWithBundleIdentifier:options:additionalEventParamDescriptor:launchIdentifier:' has been explicitly marked deprecated here
  405 | - (BOOL)launchAppWithBundleIdentifier:(NSString *)bundleIdentifier options:(NSWorkspaceLaunchOptions)options additionalEventParamDescriptor:(nullable NSAppleEventDescriptor *)descriptor launchIdentifier:(NSNumber * _Nullable * _Nullable)identifier API_DEPRECATED("Use -[NSWorkspace openApplicationAtURL:configuration:completionHandler:] instead.", macos(10.0, 11.0));
      | ^
2 warnings generated.
```

## Reference

    i.e Jira or Github issue URL

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
