### PR TITLE
Debug: Try to trace through wasm test hang

### DIFF
--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -493,7 +493,7 @@ void Daemon::checkHandshake() {
     if (connection.m_date.isValid()) {
       continue;
     }
-    logger.debug() << "awaiting" << logger.keys(config.m_serverPublicKey);
+    logger.debug() << "awaiting" << logger.sensitive(config.m_serverPublicKey);
 
     // Check if the handshake has completed.
     for (const WireguardUtils::PeerStatus& status : peers) {

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -66,7 +66,7 @@ Logger::Log& Logger::Log::operator<<(CFStringRef t) {
 #endif
 
 QString Logger::sensitive(const QString& input) {
-#ifdef MZ_DEBUG
+#if defined(MZ_DEBUG) || defined(MZ_WASM)
   return input;
 #else
   Q_UNUSED(input);

--- a/src/platforms/wasm/wasmcontroller.cpp
+++ b/src/platforms/wasm/wasmcontroller.cpp
@@ -5,6 +5,7 @@
 #include "wasmcontroller.h"
 
 #include <QHostAddress>
+#include <QJsonDocument>
 #include <QJsonObject>
 #include <QRandomGenerator>
 
@@ -31,12 +32,15 @@ WasmController::~WasmController() { MZ_COUNT_DTOR(WasmController); }
 void WasmController::activate(const InterfaceConfig& config,
                               Controller::Reason reason) {
   Q_UNUSED(reason);
-  m_mock->activate(config);
+  QJsonDocument jsDocument = QJsonDocument(config.toJson());
+  QByteArray jsBlob = jsDocument.toJson(QJsonDocument::Compact);
+  QMetaObject::invokeMethod(m_mock, "activate", Qt::QueuedConnection,
+                            Q_ARG(QString, QString::fromUtf8(jsBlob)));
 }
 
 void WasmController::deactivate(Controller::Reason reason) {
   Q_UNUSED(reason);
-  m_mock->deactivate();
+  QMetaObject::invokeMethod(m_mock, "deactivate", Qt::QueuedConnection);
 }
 
 void WasmController::checkStatus() { emitStatusFromJson(m_mock->getStatus()); }

--- a/tests/functional/setupWasm.js
+++ b/tests/functional/setupWasm.js
@@ -106,32 +106,20 @@ exports.mochaHooks = {
   },
 
   async afterAll() {
-    console.log("afterAll step A");
     guardian.stop();
-    console.log("afterAll step B");
     fxaServer.stop();
-    console.log("afterAll step C");
     addonServer.stop();
-    console.log("afterAll step D");
     captivePortalServer.stop();
-    console.log("afterAll step E");
     wasm.stop();
-    console.log("afterAll step F");
 
     guardian.throwExceptionsIfAny();
-    console.log("afterAll step G");
     fxaServer.throwExceptionsIfAny();
-    console.log("afterAll step H");
     addonServer.throwExceptionsIfAny();
-    console.log("afterAll step I");
     captivePortalServer.throwExceptionsIfAny();
-    console.log("afterAll step J");
 
     await driver.quit();
 
-    console.log("afterAll step K");
     logSocket.destroy();
-    console.log("afterAll step L");
     logServer.close();
     console.log("afterAll step Done");
   },

--- a/tests/functional/setupWasm.js
+++ b/tests/functional/setupWasm.js
@@ -170,28 +170,21 @@ exports.mochaHooks = {
       console.log(fs.readFileSync(stdout).toString());
       console.log('::endgroup');
     }
-    console.log("afterEach step A");
 
     // Close VPN app
     // If something's gone really wrong with the test,
     // then this can fail and cause the tests to hang.
     // Logging the error lets us clean-up and move on.
     try {
-      console.log("afterEach step B");
       await vpn.hardReset();
-      console.log("afterEach step C");
       await vpn.quit();
-      console.log("afterEach step D");
     } catch (error) {
       console.error(error);
     }
-    console.log("afterEach step E");
     vpn.disconnect();
     // Give each test 2 seconds to chill!
     // Seems to help with tests that are slow to close vpn app at end.
-    console.log("afterEach step F");
     await vpn.wait();
-    console.log("afterEach step G");
     await vpn.wait();
     console.log("afterEach step Done");
   },

--- a/tests/functional/setupWasm.js
+++ b/tests/functional/setupWasm.js
@@ -106,21 +106,34 @@ exports.mochaHooks = {
   },
 
   async afterAll() {
+    console.log("afterAll step A");
     guardian.stop();
+    console.log("afterAll step B");
     fxaServer.stop();
+    console.log("afterAll step C");
     addonServer.stop();
+    console.log("afterAll step D");
     captivePortalServer.stop();
+    console.log("afterAll step E");
     wasm.stop();
+    console.log("afterAll step F");
 
     guardian.throwExceptionsIfAny();
+    console.log("afterAll step G");
     fxaServer.throwExceptionsIfAny();
+    console.log("afterAll step H");
     addonServer.throwExceptionsIfAny();
+    console.log("afterAll step I");
     captivePortalServer.throwExceptionsIfAny();
+    console.log("afterAll step J");
 
     await driver.quit();
 
+    console.log("afterAll step K");
     logSocket.destroy();
+    console.log("afterAll step L");
     logServer.close();
+    console.log("afterAll step M");
   },
 
   async beforeEach() {
@@ -157,21 +170,29 @@ exports.mochaHooks = {
       console.log(fs.readFileSync(stdout).toString());
       console.log('::endgroup');
     }
+    console.log("afterEach step A");
 
     // Close VPN app
     // If something's gone really wrong with the test,
     // then this can fail and cause the tests to hang.
     // Logging the error lets us clean-up and move on.
     try {
+      console.log("afterEach step B");
       await vpn.hardReset();
+      console.log("afterEach step C");
       await vpn.quit();
+      console.log("afterEach step D");
     } catch (error) {
       console.error(error);
     }
+    console.log("afterEach step E");
     vpn.disconnect();
     // Give each test 2 seconds to chill!
     // Seems to help with tests that are slow to close vpn app at end.
+    console.log("afterEach step F");
     await vpn.wait();
+    console.log("afterEach step G");
     await vpn.wait();
+    console.log("afterEach step Done");
   },
 }

--- a/tests/functional/setupWasm.js
+++ b/tests/functional/setupWasm.js
@@ -133,7 +133,7 @@ exports.mochaHooks = {
     logSocket.destroy();
     console.log("afterAll step L");
     logServer.close();
-    console.log("afterAll step M");
+    console.log("afterAll step Done");
   },
 
   async beforeEach() {


### PR DESCRIPTION
## Description
The WASM tests appear to be rather flaky and hang somewhere in the `afterEach()` or `afterAll()` hook, which leads to frequently failing tests that need to be retried even though the body of the test was able to pass. We should try to figure out where it's hanging and fix the problem.

Oh yeah, it also seems like I broke the WASM connection test with #10520 according to when that particular test started failing en mass.

## Reference

    i.e Jira or Github issue URL

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
