### PR TITLE
WASM: queue the activate/deactivate daemon commands

### DIFF
--- a/src/platforms/wasm/wasmcontroller.cpp
+++ b/src/platforms/wasm/wasmcontroller.cpp
@@ -5,6 +5,7 @@
 #include "wasmcontroller.h"
 
 #include <QHostAddress>
+#include <QJsonDocument>
 #include <QJsonObject>
 #include <QRandomGenerator>
 
@@ -31,12 +32,15 @@ WasmController::~WasmController() { MZ_COUNT_DTOR(WasmController); }
 void WasmController::activate(const InterfaceConfig& config,
                               Controller::Reason reason) {
   Q_UNUSED(reason);
-  m_mock->activate(config);
+  QJsonDocument jsDocument = QJsonDocument(config.toJson());
+  QByteArray jsBlob = jsDocument.toJson(QJsonDocument::Compact);
+  QMetaObject::invokeMethod(m_mock, "activate", Qt::QueuedConnection,
+                            Q_ARG(QString, QString::fromUtf8(jsBlob)));
 }
 
 void WasmController::deactivate(Controller::Reason reason) {
   Q_UNUSED(reason);
-  m_mock->deactivate();
+  QMetaObject::invokeMethod(m_mock, "deactivate", Qt::QueuedConnection);
 }
 
 void WasmController::checkStatus() { emitStatusFromJson(m_mock->getStatus()); }


### PR DESCRIPTION
## Description
In PR #10520 I introduced a bug that was leading to an infinite loop in the WASM Connection test, the underlying cause is a little bit sneaky but has to do with the lack of threading on WASM. The issue occurs in the race condition test, and it goes something like this:

1. When the race condition occurs, we wind up with two `TaskControllerAction` in the `TaskScheduler`.
    - `m_running_task` is activating the VPN
    - a queued task is waiting to silent-switch the VPN.
2. In the final step of the activation, the daemon polls for the server handshake time and does an `emit` in the middle of the for-loop in `Daemon::checkHandshake()` to signal that the connection is up.
3. Note that because WASM is single-threaded, all the signal handling occurs in the same callstack, so in the middle of this for-loop we do the following:
    - Finish the controller state transition to `StateOn`
    - Complete the `TaskControllerAction` for the activation.
    - Start the next `TaskControllerAction` for the silent server switch.
    - Calls `Controller::activate` to start the server switch.
    - Calls through to `MockDaemon::deactivate` and replaces the connection with the new server deets.
    - But wait! We are still in the middle of the for-loop that's checking the status. This corrupts the list iterator resulting in an infinite loop when we descend back down the call stack.

To fix this, we can instead use a queued invocation of the daemon activate/deactivate methods in the WasmController, in which case the activation only happens when the Qt event loop gets back to an idle state. This also makes it a bit more faithful to how a real daemon operates in a threaded/multiprocess world.

## Reference
Bug introduced by: #10520

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
