### PR TITLE
VPN-7068: Deprecate Ubuntu/20.04 Focal Fossa

### DIFF
--- a/scripts/linux/script.sh
+++ b/scripts/linux/script.sh
@@ -31,7 +31,6 @@ helpFunction() {
   print N "  -k, --sign-key KEYID   Enable package using using GPG key of KEYID"
   print N "      --no-sign          Disable package signing"
   print N ""
-  print N "By default, the release is 'focal'"
   print N "The default version is 1, but you can recreate packages using the same code version changing the version id."
   print N ""
   exit 0

--- a/src/feature/featurelistcallback.h
+++ b/src/feature/featurelistcallback.h
@@ -38,16 +38,7 @@ struct FeatureSupportedPlatforms {
   bool wasm = false;
 };
 
-// TODO : Remove once focal support is removed
-// as that is that is the only distro we support
-// that does not have consteval q_q
-#if defined(__cpp_consteval)  // If consteval is supported
-#  define constIshExpr consteval
-#else  // Fallback to constexpr
-#  define constIshExpr constexpr
-#endif
-
-constIshExpr auto byPlatform(FeatureSupportedPlatforms support) {
+consteval auto byPlatform(FeatureSupportedPlatforms support) {
   return [support]() constexpr {
 #if defined(MZ_WINDOWS)
     return support.windows;
@@ -66,7 +57,6 @@ constIshExpr auto byPlatform(FeatureSupportedPlatforms support) {
 #endif
   };
 }
-#undef constIshExpr
 
 // Custom callback functions
 // -------------------------

--- a/taskcluster/kinds/build/linux.yml
+++ b/taskcluster/kinds/build/linux.yml
@@ -25,16 +25,6 @@ task-defaults:
         use-caches: [checkout, pip]
         command: /builds/worker/builder.sh
 
-linux/focal:
-    description: "Linux Build (Ubuntu/Focal)"
-    treeherder:
-        platform: linux/focal
-    worker:
-        docker-image: {in-tree: linux-build-focal}
-    add-index-routes:
-        name: linux-focal
-        type: build
-
 linux/jammy:
     description: "Linux Build (Ubuntu/Jammy)"
     treeherder:

--- a/taskcluster/kinds/docker-image/kind.yml
+++ b/taskcluster/kinds/docker-image/kind.yml
@@ -41,12 +41,6 @@ tasks:
         parent: base
         symbol: I(linux-qt6-build)
         definition: linux-qt6-build
-    linux-build-focal:
-        symbol: I(linux-focal)
-        definition: linux-dpkg-build
-        args:
-            DOCKER_BASE_IMAGE: ubuntu:focal
-            QTPPA: ppa:okirby/qt6-backports
     linux-build-jammy:
         symbol: I(linux-jammy)
         definition: linux-dpkg-build


### PR DESCRIPTION
## Description
Ubuntu 20.04/Focal Fossa is coming to its EOL status on May 29th, 2025, and as such the Launchpad PPA will longer accepts builds for this platform. This means that we can start to remove out build tasks and support for this target.

## Reference
JIRA Issue: [VPN-7068](https://mozilla-hub.atlassian.net/browse/VPN-7068)
ESM Announcement: https://lists.ubuntu.com/archives/ubuntu-announce/2025-April/000310.html

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-7068]: https://mozilla-hub.atlassian.net/browse/VPN-7068?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ