### PR TITLE
Lock down where we can load dll's at runtime

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,12 +4,15 @@
 
 #include "commandlineparser.h"
 #include "leakdetector.h"
+#include "platforms/windows/windowsutils.h"
 #include "stdio.h"
 #ifdef MZ_WINDOWS
 
 #  include <windows.h>
 
 #  include <iostream>
+
+#  include "platforms/windows/windowsutils.h"
 
 #endif
 
@@ -29,6 +32,7 @@ Q_DECL_EXPORT int main(int argc, char* argv[]) {
     std::clog.clear();
     std::cerr.clear();
   }
+  WindowsUtils::lockDownDLLSearchPath();
 #endif
 
   CommandLineParser clp;

--- a/src/platforms/windows/windowsutils.cpp
+++ b/src/platforms/windows/windowsutils.cpp
@@ -141,3 +141,25 @@ void WindowsUtils::updateTitleBarColor(QWindow* window, bool darkMode) {
       sizeof(defaultColor)));
   Q_ASSERT(ok);
 }
+
+/**
+ * @brief Locks down the DLL search path to mitigate DLL hijacking risks.
+ *
+ * Configures process mitigation policies to prefer system DLLs and disallow
+ * loading DLLs from remote locations. Adjusts the default DLL directories to
+ * further restrict where DLLs can be loaded from.
+ */
+void WindowsUtils::lockDownDLLSearchPath() {
+  // Clear the current dir from the DLL search path
+  SetDllDirectoryA("");
+  // Lock down the DLL search path to the system32 and application directories
+  // as they need admin rights to write to.
+  SetDefaultDllDirectories(LOAD_LIBRARY_SEARCH_SYSTEM32 |
+                           LOAD_LIBRARY_SEARCH_APPLICATION_DIR);
+
+  // Change the load order of DLLs to prefer system32 images
+  PROCESS_MITIGATION_IMAGE_LOAD_POLICY pol = {};
+  pol.PreferSystem32Images = 1;
+
+  SetProcessMitigationPolicy(ProcessImageLoadPolicy, &pol, sizeof(pol));
+}

--- a/src/platforms/windows/windowsutils.h
+++ b/src/platforms/windows/windowsutils.h
@@ -18,6 +18,8 @@ class WindowsUtils final {
 
   static bool getServiceStatus(const QString& name);
 
+  static void lockDownDLLSearchPath();
+
   // Returns the major version of Windows
   static QString windowsVersion();
 


### PR DESCRIPTION
## Description

We should only need to call loadlibrary with things in our app path and system32, really. 
