### PR TITLE
Revert "Rustlang/CMake helper cleanup (#10528)"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.20)
 
 # The source file GENERATED property is visible from all directory scopes when set.
 cmake_policy(SET CMP0118 NEW)
@@ -44,6 +44,12 @@ include(scripts/cmake/clang_tidy.cmake)
 
 ## Some workarounds for platform build quirks
 if(WIN32)
+    ## CMake v3.20 has problems with race conditions in dependency generation.
+    ## See: https://gitlab.kitware.com/cmake/cmake/-/issues/22014
+    if(${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION} VERSION_EQUAL 3.20)
+        cmake_policy(SET CMP0116 OLD)
+    endif()
+
     ## CMake also has trouble finding OpenSSL libraries on Windows, and may
     ## need some help.
     if(EXISTS "C:/MozillaVPNBuild/SSL" AND NOT DEFINED OPENSSL_ROOT_DIR)
@@ -147,9 +153,6 @@ endif()
 
 if(QT_KNOWN_POLICY_QTP0001)
     qt_policy(SET QTP0001 NEW)
-endif()
-if(QT_KNOWN_POLICY_QTP0002)
-    qt_policy(SET QTP0002 NEW)
 endif()
 
 message("Using Qt version ${Qt6_VERSION}")

--- a/android/common/build.gradle
+++ b/android/common/build.gradle
@@ -42,6 +42,8 @@ dependencies {
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
 
+    implementation 'org.bouncycastle:bcprov-jdk15on:1.70'
+
     implementation project(path: ':qtglean')
     implementation project(path: ':qtBindings')
     implementation project(path: ':adjust')

--- a/android/common/src/main/java/org/mozilla/firefox/qt/common/Utils.kt
+++ b/android/common/src/main/java/org/mozilla/firefox/qt/common/Utils.kt
@@ -11,10 +11,37 @@ import android.util.Log
 import mozilla.telemetry.glean.BuildInfo
 import mozilla.telemetry.glean.Glean
 import mozilla.telemetry.glean.config.Configuration
+import org.bouncycastle.asn1.ASN1Sequence
+import org.bouncycastle.asn1.pkcs.RSAPublicKey
+import java.security.KeyFactory
+import java.security.Signature
+import java.security.spec.RSAPublicKeySpec
 import java.util.*
 
 // Companion for Utils.cpp
 object Utils {
+
+    @SuppressLint("Unused")
+    @JvmStatic
+    fun verifyContentSignature(publicKey: ByteArray, content: ByteArray, signature: ByteArray): Boolean {
+        return try {
+            val sig = Signature.getInstance("SHA256withRSA")
+            // Use bountycastle to parse the openssl-rsa file
+            val pk: RSAPublicKey =
+                RSAPublicKey.getInstance(ASN1Sequence.fromByteArray(publicKey))
+            // Pass this to android signing stuff :)
+            val spec = RSAPublicKeySpec(pk.modulus, pk.publicExponent)
+            val kf: KeyFactory = KeyFactory.getInstance("RSA")
+            sig.initVerify(kf.generatePublic(spec))
+
+            sig.update(content)
+            sig.verify(signature)
+        } catch (e: Exception) {
+            Log.e("VPNUtils", "Signature Exception $e")
+            false
+        }
+    }
+
     @SuppressLint("NewApi")
     @JvmStatic
     fun initializeGlean(

--- a/linux/debian/control
+++ b/linux/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: mozilla <vpn@mozilla.com>
 Build-Depends: debhelper (>= 11.2),
                cdbs,
-               cmake (>= 3.22~),
+               cmake (>= 3.20~),
                flex,
                gcc (>=4:8.0.0~),
                g++ (>=4:8.0.0~),

--- a/qtglean/CMakeLists.txt
+++ b/qtglean/CMakeLists.txt
@@ -73,11 +73,38 @@ if(NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Emscripten")
     set(SHARED 0)
 
     if(IOS)
+        set(RUST_ARCH "")
+        if("arm64" IN_LIST CMAKE_OSX_ARCHITECTURES)
+            list(APPEND RUST_ARCH aarch64-apple-ios)
+        endif()
+
+        if("x86_64" IN_LIST CMAKE_OSX_ARCHITECTURES)
+            list(APPEND RUST_ARCH x86_64-apple-ios)
+        endif()
+
+        # If no architecure is defined, just do all of them.
+        if (RUST_ARCH STREQUAL "")
+            set(RUST_ARCH aarch64-apple-ios x86_64-apple-ios)
+        endif()
+
         # On iOS we will build a dynamic lib,
         # so that it can be linked to both the main app and the network extension.
         set(RUSTFLAGS "-Ctarget-feature=-crt-static")
         set(SHARED 1)
+        set(FW_NAME "QtGleanBindings")
     elseif(ANDROID)
+        if(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "aarch64")
+            set(RUST_ARCH "aarch64-linux-android")
+        elseif(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "armv7-a")
+            set(RUST_ARCH "armv7-linux-androideabi")
+        elseif(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "i686")
+            set(RUST_ARCH "i686-linux-android")
+        elseif(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "x86_64")
+            set(RUST_ARCH "x86_64-linux-android")
+        else()
+            message(FATAL_ERROR "Attempting to for unsupported architecture '${CMAKE_SYSTEM_PROCESSOR}'")
+        endif()
+
         get_property(ssl_module GLOBAL PROPERTY OPENSSL_SSL_MODULE)
         get_property(openssl_libs GLOBAL PROPERTY OPENSSL_LIBS)
         list(APPEND CARGO_ENV
@@ -103,25 +130,18 @@ if(NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Emscripten")
     ## Build the qtglean Rust library
     list(APPEND CARGO_ENV RUSTFLAGS=${RUSTFLAGS})
     add_rust_library(qtglean_bindings
+        ARCH ${RUST_ARCH}
         PACKAGE_DIR ${CMAKE_CURRENT_SOURCE_DIR}
+        CRATE_NAME qtglean
         CARGO_ENV ${CARGO_ENV}
         DEPENDS
             ${CMAKE_CURRENT_BINARY_DIR}/glean/generated/metrics.rs
             ${CMAKE_CURRENT_BINARY_DIR}/glean/generated/pings.rs
         SHARED ${SHARED}
+        FW_NAME ${FW_NAME}
     )
 
-    ## For IOS targets - turn the rust library into a framework.
-    if(IOS)
-        set_target_properties(qtglean_bindings PROPERTIES
-            FRAMEWORK TRUE
-            OUTPUT_NAME QtGleanBindings
-            MACOSX_FRAMEWORK_IDENTIFIER ${BUILD_IOS_APP_IDENTIFIER}.QtGleanBindings
-            XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER ${BUILD_IOS_APP_IDENTIFIER}.QtGleanBindings
-        )
-    endif()
-
-    target_link_libraries(qtglean PUBLIC qtglean_bindings)
+    target_link_libraries(qtglean PRIVATE qtglean_bindings)
 endif()
 
 set(GLEAN_PARSER_VERSION_MIN 5.0)

--- a/qtglean/include/glean/errortype.h
+++ b/qtglean/include/glean/errortype.h
@@ -6,7 +6,7 @@
 #define ERROR_TYPE_H
 
 #ifndef __wasm__
-#  include "bindings/qtglean.h"
+#  include "qtglean.h"
 #else
 enum ErrorType {};
 #endif

--- a/qtglean/src/cpp/boolean.cpp
+++ b/qtglean/src/cpp/boolean.cpp
@@ -8,7 +8,7 @@
 #include <QJsonValue>
 
 #ifndef __wasm__
-#  include "bindings/qtglean.h"
+#  include "qtglean.h"
 #endif
 
 BooleanMetric::BooleanMetric(int id) : BaseMetric(id) {}

--- a/qtglean/src/cpp/counter.cpp
+++ b/qtglean/src/cpp/counter.cpp
@@ -8,7 +8,7 @@
 #include <QJsonValue>
 
 #ifndef __wasm__
-#  include "bindings/qtglean.h"
+#  include "qtglean.h"
 #endif
 
 CounterMetric::CounterMetric(int id) : BaseMetric(id) {}

--- a/qtglean/src/cpp/customdistribution.cpp
+++ b/qtglean/src/cpp/customdistribution.cpp
@@ -5,7 +5,7 @@
 #include "glean/customdistribution.h"
 
 #ifndef __wasm__
-#  include "bindings/qtglean.h"
+#  include "qtglean.h"
 #endif
 
 #include <QJsonDocument>

--- a/qtglean/src/cpp/datetime.cpp
+++ b/qtglean/src/cpp/datetime.cpp
@@ -8,7 +8,7 @@
 #include <QJsonValue>
 
 #ifndef __wasm__
-#  include "bindings/qtglean.h"
+#  include "qtglean.h"
 #endif
 
 DatetimeMetric::DatetimeMetric(int id) : BaseMetric(id) {}

--- a/qtglean/src/cpp/event.cpp
+++ b/qtglean/src/cpp/event.cpp
@@ -5,7 +5,7 @@
 #include "glean/event.h"
 
 #ifndef __wasm__
-#  include "bindings/qtglean.h"
+#  include "qtglean.h"
 #endif
 
 #include <QJsonDocument>

--- a/qtglean/src/cpp/memorydistribution.cpp
+++ b/qtglean/src/cpp/memorydistribution.cpp
@@ -5,7 +5,7 @@
 #include "glean/memorydistribution.h"
 
 #ifndef __wasm__
-#  include "bindings/qtglean.h"
+#  include "qtglean.h"
 #endif
 
 #include <QJsonDocument>

--- a/qtglean/src/cpp/ping.cpp
+++ b/qtglean/src/cpp/ping.cpp
@@ -4,7 +4,7 @@
 
 #include "glean/ping.h"
 #ifndef __wasm__
-#  include "bindings/qtglean.h"
+#  include "qtglean.h"
 #endif
 
 Ping::Ping(int aId) : m_id(aId) {}

--- a/qtglean/src/cpp/quantity.cpp
+++ b/qtglean/src/cpp/quantity.cpp
@@ -8,7 +8,7 @@
 #include <QJsonValue>
 
 #ifndef __wasm__
-#  include "bindings/qtglean.h"
+#  include "qtglean.h"
 #endif
 
 QuantityMetric::QuantityMetric(int id) : BaseMetric(id) {}

--- a/qtglean/src/cpp/string.cpp
+++ b/qtglean/src/cpp/string.cpp
@@ -8,7 +8,7 @@
 #include <QJsonValue>
 
 #ifndef __wasm__
-#  include "bindings/qtglean.h"
+#  include "qtglean.h"
 #endif
 
 StringMetric::StringMetric(int id) : BaseMetric(id) {}

--- a/qtglean/src/cpp/timingdistribution.cpp
+++ b/qtglean/src/cpp/timingdistribution.cpp
@@ -5,7 +5,7 @@
 #include "glean/timingdistribution.h"
 
 #ifndef __wasm__
-#  include "bindings/qtglean.h"
+#  include "qtglean.h"
 #endif
 
 #include <QJsonDocument>

--- a/qtglean/src/cpp/uuid.cpp
+++ b/qtglean/src/cpp/uuid.cpp
@@ -8,7 +8,7 @@
 #include <QJsonValue>
 
 #ifndef __wasm__
-#  include "bindings/qtglean.h"
+#  include "qtglean.h"
 #endif
 
 UuidMetric::UuidMetric(int id) : BaseMetric(id) {}

--- a/scripts/cmake/Info.plist.QtGleanBindings
+++ b/scripts/cmake/Info.plist.QtGleanBindings
@@ -1,0 +1,22 @@
+<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">
+<plist version=\"1.0\">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>en</string>
+    <key>CFBundleExecutable</key>
+    <string>QtGleanBindings</string>
+    <key>CFBundleIdentifier</key>
+    <string>org.mozilla.ios.FirefoxVPN.QtGleanBindings</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundlePackageType</key>
+    <string>FMWK</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>MinimumOSVersion</key>
+    <string>15.0</string>
+</dict>
+</plist>

--- a/scripts/cmake/rustlang-dummylib.cpp.in
+++ b/scripts/cmake/rustlang-dummylib.cpp.in
@@ -1,8 +1,0 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
-/* This file is a placeholder to generate an empty library which will be
- * replaced by the rust library in a POST_BUILD step.
- */
-#include <bindings/@RUST_TARGET_LIB_NAME@.h>

--- a/scripts/cmake/rustlang.cmake
+++ b/scripts/cmake/rustlang.cmake
@@ -2,36 +2,16 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-## The contents of this file should only be processed once.
-include_guard(GLOBAL)
-file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/cargo_home)
-
 ## Find the absolute path to the rust build tools.
 find_program(CARGO_BUILD_TOOL NAMES cargo REQUIRED)
-
-## Don't trust Xcode to provide us with a usable linker.
-if(APPLE AND XCODE)
-    find_program(RUSTC_BUILD_TOOL_PATH NAMES rustc REQUIRED)
-    file(WRITE ${CMAKE_BINARY_DIR}/cargo_home/rustwrapper.sh "#!/bin/sh\n")
-    file(APPEND ${CMAKE_BINARY_DIR}/cargo_home/rustwrapper.sh "${RUSTC_BUILD_TOOL_PATH} -C linker=/usr/bin/cc \$@\n")
-    file(CHMOD ${CMAKE_BINARY_DIR}/cargo_home/rustwrapper.sh FILE_PERMISSIONS
-        OWNER_READ OWNER_WRITE OWNER_EXECUTE
-        GROUP_READ GROUP_WRITE GROUP_EXECUTE
-        WORLD_READ WORLD_EXECUTE
-    )
-    set(RUSTC_BUILD_TOOL ${CMAKE_BINARY_DIR}/cargo_home/rustwrapper.sh
-        CACHE FILEPATH "Path to the rustc build tool"
-    )
-else()
-    find_program(RUSTC_BUILD_TOOL NAMES rustc REQUIRED)
-endif()
+find_program(RUSTC_BUILD_TOOL NAMES rustc REQUIRED)
 
 # Figure out Rust's host architecture
 execute_process(OUTPUT_VARIABLE RUSTC_VERSION_RAW COMMAND ${RUSTC_BUILD_TOOL} --version --verbose)
 if(RUSTC_VERSION_RAW MATCHES "host: ([^\n]+)")
-    set(RUSTC_HOST_ARCH ${CMAKE_MATCH_1} CACHE STRING "Rustlang host architecture")
+    set(RUSTC_HOST_ARCH ${CMAKE_MATCH_1})
 else()
-    message(FATAL_ERROR "Failed to find rustc host arch")
+    error("Failed to find rustc host arch")
 endif()
 
 ## For the Ninja generator, setup a job pool for Cargo targets, which share a
@@ -43,104 +23,31 @@ if(NOT HAS_CARGO_POOL)
     set_property(GLOBAL APPEND PROPERTY JOB_POOLS cargo=1)
 endif()
 
-## We want to make use of DEPFILE support when building rust crates as it speeds
-## up the build jobs fairly significantly. This is supported by most generators
-## so let's just make extra sure that we are using one.
-if((CMAKE_GENERATOR MATCHES "Ninja") OR (CMAKE_GENERATOR MATCHES "Makefiles"))
-    # Ninja generators support DEPFILEs since CMake 3.7 (3.17 for multi-config).
-    # Makefile generators support DEPFILEs as of CMake 3.20.
-    set(HAS_DEPFILE_SUPPORT TRUE)
-elseif(XCODE OR CMAKE_VS_VERSION_BUILD_NUMBER)
-    # Xcode and Visual Studio 2012 and later support DEPFILEs as of CMake 3.21.
-    set(HAS_DEPFILE_SUPPORT TRUE)
-else()
-    message(FATAL_ERROR "CMake generator is missing DEPFILE support")
-endif()
-
-## Create a target to build the cbindgen tool.
-## TODO: This should be versioned by the Cargo.lock, if present.
-add_custom_command(
-    OUTPUT ${CMAKE_BINARY_DIR}/cargo_home/bin/cbindgen
-    COMMENT "Building rust cbindgen tool"
-    JOB_POOL cargo
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-    COMMAND ${CMAKE_COMMAND} -E env CARGO_HOME=${CMAKE_BINARY_DIR}/cargo_home RUSTC=${RUSTC_BUILD_TOOL}
-            ${CARGO_BUILD_TOOL} install --root ${CMAKE_BINARY_DIR}/cargo_home cbindgen
-)
-add_custom_target(cbindgen_builder
-    DEPENDS ${CMAKE_BINARY_DIR}/cargo_home/bin/cbindgen
-)
-set(CBINDGEN_BUILD_TOOL ${CMAKE_BINARY_DIR}/cargo_home/bin/cbindgen
-    CACHE FILEPATH "Path to the cbindgen build tool"
-)
-
-### Helper function to parse a Rust manifest
+### Helper function to get the rust library filename with extension.
 #
-# Accepts the following arguments:
-#   PACKAGE_DIR: Source directory where Cargo.toml can be found.
-#   CRATE_TARGET: Which target to parse from the manifest, defaults to the package name.
-#
-# Outputs the following values:
-#   OUTPUT_LIB_NAME: Output variable name to receive the library name. 
-#   OUTPUT_LIB_KINDS: Output variable name to receive a list of target kinds.
-#
-function(parse_rust_manifest)
-    cmake_parse_arguments(RUST_PARSE
-        ""
-        "PACKAGE_DIR;OUTPUT_LIB_NAME;OUTPUT_LIB_KINDS"
-        ""
-        ${ARGN})
-
-    if(NOT RUST_PARSE_PACKAGE_DIR)
-        set(RUST_PARSE_PACKAGE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+# Sets the variable "RUST_LIBRARY_FILENAME" with the value.
+function(get_rust_library_filename SHARED CRATE_NAME)
+    if(${SHARED})
+        set(RUST_LIBRARY_FILENAME
+            ${CMAKE_SHARED_LIBRARY_PREFIX}${CRATE_NAME}${CMAKE_SHARED_LIBRARY_SUFFIX}
+            PARENT_SCOPE)
+    else()
+        set(RUST_LIBRARY_FILENAME
+            ${CMAKE_STATIC_LIBRARY_PREFIX}${CRATE_NAME}${CMAKE_STATIC_LIBRARY_SUFFIX}
+            PARENT_SCOPE)
     endif()
-
-    # Parse the crate manifest to figure out what we're building.
-    execute_process(
-        WORKING_DIRECTORY ${RUST_PARSE_PACKAGE_DIR}
-        OUTPUT_VARIABLE RUST_PARSE_CRATE_JSON
-        COMMAND ${CARGO_BUILD_TOOL} read-manifest 
-    )
-    string(JSON RUST_PARSE_TARGET_JSON GET ${RUST_PARSE_CRATE_JSON} "targets")
-    string(JSON RUST_PARSE_TARGET_COUNT LENGTH ${RUST_PARSE_TARGET_JSON})
-
-    # Look for the targets entry in the parsed manifest.
-    set(RUST_PARSE_TARGET_INDEX 0)
-    while(${RUST_PARSE_TARGET_INDEX} LESS ${RUST_PARSE_TARGET_COUNT})
-        string(JSON JSON_TARGET GET ${RUST_PARSE_TARGET_JSON} ${RUST_PARSE_TARGET_INDEX})
-        string(JSON TARGET_NAME GET ${JSON_TARGET} "name")
-        math(EXPR RUST_PARSE_TARGET_INDEX "${RUST_PARSE_TARGET_INDEX} + 1")
-
-        # Parse the target kinds
-        set(KIND_INDEX 0)
-        set(KIND_LIST)
-        string(JSON KIND_COUNT LENGTH ${JSON_TARGET} "kind")
-        while(${KIND_INDEX} LESS ${KIND_COUNT})
-            string(JSON KIND_TYPE GET ${JSON_TARGET} "kind" ${KIND_INDEX})
-            math(EXPR KIND_INDEX "${KIND_INDEX} + 1")
-            list(APPEND KIND_LIST ${KIND_TYPE})
-        endwhile()
-
-        # Check if this is the library target - crates can have at most one.
-        if(("staticlib" IN_LIST KIND_LIST) OR ("cdylib" IN_LIST KIND_LIST))
-            if(RUST_PARSE_OUTPUT_LIB_NAME)
-                set(${RUST_PARSE_OUTPUT_LIB_NAME} ${TARGET_NAME} PARENT_SCOPE)
-            endif()
-            if(RUST_PARSE_OUTPUT_LIB_KINDS)
-                set(${RUST_PARSE_OUTPUT_LIB_KINDS} ${KIND_LIST} PARENT_SCOPE)
-            endif()
-        endif()
-    endwhile()
 endfunction()
 
-### Helper function to build a Rust library target
+### Helper function to build Rust static libraries.
 #
 # Accepts the following arguments:
 #   ARCH: Rust target architecture to build with --target ${ARCH}
 #   BINARY_DIR: Binary directory to output build artifacts to.
-#   PACKAGE_DIR: Source directory where Cargo.toml can be found.
+#   PACKAGE_DIR: Soruce directory where Cargo.toml can be found.
+#   LIBRARY_FILE: Filename of the expected library to be built.
 #   CARGO_ENV: Environment variables to pass to cargo
-#   DEPENDS: Additional dependencies required to build the library.
+#   SHARED: Whether or not we are building a shared library. Defaults to "false".
+#   FW_NAME: Standalone dylibs need to be wrapped in a framework for distribtuion. Required when building shared lib for iOS.
 #
 # This function generates commands necessary to build static archives
 # in ${BINARY_DIR}/${ARCH}/debug/ and ${BINARY_DIR}/${ARCH}/release/
@@ -153,13 +60,19 @@ endfunction()
 function(build_rust_archives)
     cmake_parse_arguments(RUST_BUILD
         ""
-        "ARCH;BINARY_DIR;PACKAGE_DIR"
-        "CARGO_ENV;DEPENDS"
+        "ARCH;BINARY_DIR;PACKAGE_DIR;CRATE_NAME"
+        "CARGO_ENV;SHARED;FW_NAME"
         ${ARGN})
 
+    file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/cargo_home)
     list(APPEND RUST_BUILD_CARGO_ENV CARGO_HOME=\"${CMAKE_BINARY_DIR}/cargo_home\")
-    list(APPEND RUST_BUILD_CARGO_ENV RUSTC=${RUSTC_BUILD_TOOL})
 
+    if(NOT DEFINED RUST_BUILD_SHARED)
+        message(FATAL_ERROR "Mandatory argument SHARED was not found")
+    endif()
+    if(NOT RUST_BUILD_CRATE_NAME)
+        message(FATAL_ERROR "Mandatory argument CRATE_NAME was not found")
+    endif()
     if(NOT RUST_BUILD_ARCH)
         message(FATAL_ERROR "Mandatory argument ARCH was not found")
     endif()
@@ -170,29 +83,9 @@ function(build_rust_archives)
         set(RUST_BUILD_PACKAGE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
     endif()
 
-    # Parse the crate manifest for the kinds of targets we are building.
-    set(RUST_BUILD_DEBUG_OUTPUT_FILES)
-    set(RUST_BUILD_RELEASE_OUTPUT_FILES)
-    parse_rust_manifest(
-        PACKAGE_DIR ${RUST_BUILD_PACKAGE_DIR}
-        OUTPUT_LIB_NAME RUST_BUILD_LIB_NAME
-        OUTPUT_LIB_KINDS RUST_BUILD_LIB_KINDS
-    )
-    foreach(KIND ${RUST_BUILD_LIB_KINDS})
-        set(TARGET_FILENAME)
-        if(KIND STREQUAL "staticlib")
-            set(TARGET_FILENAME ${CMAKE_STATIC_LIBRARY_PREFIX}${RUST_BUILD_LIB_NAME}${CMAKE_STATIC_LIBRARY_SUFFIX})
-        elseif(KIND STREQUAL "cdylib")
-            set(TARGET_FILENAME ${CMAKE_SHARED_LIBRARY_PREFIX}${RUST_BUILD_LIB_NAME}${CMAKE_SHARED_LIBRARY_SUFFIX})
-        else()
-            continue()
-        endif()
-        list(APPEND RUST_BUILD_DEBUG_OUTPUT_FILES ${RUST_BUILD_BINARY_DIR}/${ARCH}/debug/${TARGET_FILENAME})
-        list(APPEND RUST_BUILD_RELEASE_OUTPUT_FILES ${RUST_BUILD_BINARY_DIR}/${ARCH}/release/${TARGET_FILENAME})
-    endforeach()
-
     ## Some files that we will be building.
     file(MAKE_DIRECTORY ${RUST_BUILD_BINARY_DIR})
+    get_rust_library_filename(${RUST_BUILD_SHARED} ${RUST_BUILD_CRATE_NAME})
 
     ## For iOS simulator targets, ensure that we unset the `SDKROOT` variable as
     ## this will result in broken simulation builds in Xcode. For all other apple
@@ -208,6 +101,11 @@ function(build_rust_archives)
     ## For MacOS platforms, set the OS deployment version.
     if(RUST_BUILD_ARCH MATCHES "-apple-darwin$")
         list(APPEND RUST_BUILD_CARGO_ENV MACOSX_DEPLOYMENT_TARGET=${CMAKE_OSX_DEPLOYMENT_TARGET})
+    endif()
+
+    ## For build Apple shared binaries, the install path needs to be relative to the runpath.
+    if (RUST_BUILD_SHARED AND APPLE)
+        list(APPEND RUST_BUILD_CARGO_ENV "RUSTC_LINK_ARG=-Wl,-install_name,@rpath/${RUST_BUILD_FW_NAME}.framework/${RUST_BUILD_FW_NAME}")
     endif()
 
     if(ANDROID)
@@ -226,49 +124,62 @@ function(build_rust_archives)
         list(APPEND RUST_BUILD_CARGO_ENV LD=${ANDROID_TOOLCHAIN_ROOT_BIN}/lld)
     endif()
 
-    cmake_policy(PUSH)
-    cmake_policy(SET CMP0116 NEW)
-    set(RUST_BUILD_DEPENDENCY_FILE ${CMAKE_STATIC_LIBRARY_PREFIX}${RUST_BUILD_LIB_NAME}.d)
+    if((CMAKE_GENERATOR MATCHES "Ninja") OR (CMAKE_GENERATOR MATCHES "Makefiles"))
+        ## If we are building with Ninja, then we can improve build times by
+        # specifying a DEPFILE to let CMake know when the library needs
+        # building and when we can skip it.
+        set(RUST_BUILD_DEPENDENCY_FILE
+            ${CMAKE_STATIC_LIBRARY_PREFIX}${RUST_BUILD_CRATE_NAME}.d
+        )
+        cmake_policy(PUSH)
+        cmake_policy(SET CMP0116 NEW)
 
-    ## Outputs for the release build
-    add_custom_command(
-        OUTPUT ${RUST_BUILD_RELEASE_OUTPUT_FILES}
-        DEPENDS ${RUST_BUILD_DEPENDS}
-        DEPFILE ${RUST_BUILD_BINARY_DIR}/${ARCH}/release/${RUST_BUILD_DEPENDENCY_FILE}
-        JOB_POOL cargo
-        WORKING_DIRECTORY ${RUST_BUILD_PACKAGE_DIR}
-        COMMAND ${CMAKE_COMMAND} -E env ${RUST_BUILD_CARGO_ENV}
-                ${CARGO_BUILD_TOOL} build --lib --release --target ${ARCH} --target-dir ${RUST_BUILD_BINARY_DIR}
-    )
+        ## Outputs for the release build
+        add_custom_command(
+            OUTPUT ${RUST_BUILD_BINARY_DIR}/${ARCH}/release/${RUST_LIBRARY_FILENAME}
+            DEPFILE ${RUST_BUILD_BINARY_DIR}/${ARCH}/release/${RUST_BUILD_DEPENDENCY_FILE}
+            JOB_POOL cargo
+            WORKING_DIRECTORY ${RUST_BUILD_PACKAGE_DIR}
+            COMMAND ${CMAKE_COMMAND} -E env ${RUST_BUILD_CARGO_ENV}
+                    ${CARGO_BUILD_TOOL} build --lib --release --target ${ARCH} --target-dir ${RUST_BUILD_BINARY_DIR}
+        )
 
-    ## Outputs for the debug build
-    add_custom_command(
-        OUTPUT ${RUST_BUILD_DEBUG_OUTPUT_FILES}
-        DEPENDS ${RUST_BUILD_DEPENDS}
-        DEPFILE ${RUST_BUILD_BINARY_DIR}/${ARCH}/debug/${RUST_BUILD_DEPENDENCY_FILE}
-        JOB_POOL cargo
-        WORKING_DIRECTORY ${RUST_BUILD_PACKAGE_DIR}
-        COMMAND ${CMAKE_COMMAND} -E env ${RUST_BUILD_CARGO_ENV}
-                ${CARGO_BUILD_TOOL} build --lib --target ${ARCH} --target-dir ${RUST_BUILD_BINARY_DIR}
-    )
+        ## Outputs for the debug build
+        add_custom_command(
+            OUTPUT ${RUST_BUILD_BINARY_DIR}/${ARCH}/debug/${RUST_LIBRARY_FILENAME}
+            DEPFILE ${RUST_BUILD_BINARY_DIR}/${ARCH}/debug/${RUST_BUILD_DEPENDENCY_FILE}
+            JOB_POOL cargo
+            WORKING_DIRECTORY ${RUST_BUILD_PACKAGE_DIR}
+            COMMAND ${CMAKE_COMMAND} -E env ${RUST_BUILD_CARGO_ENV}
+                    ${CARGO_BUILD_TOOL} build --lib --target ${ARCH} --target-dir ${RUST_BUILD_BINARY_DIR}
+        )
 
-    ## Reset our policy changes
-    cmake_policy(POP)
-endfunction()
+        ## Reset our policy changes
+        cmake_policy(POP)
+    else()
+        ## For all other generators, set a non-existent output file to force
+        # the command to be invoked on every build. This ensures that the
+        # library stays up todate with the sources, and relies on cargo to
+        # rebuild if necessary.
 
-### Helper function to adjust build rules on the library target
-#
-# This function is run at the end of the directory scope, allowing the caller
-# to specify additional properties on the library target.
-#
-function(__rust_library_finalize TARGET_NAME)
-    get_property(TARGET_FRAMEWORK TARGET ${TARGET_NAME} PROPERTY FRAMEWORK)
-    get_property(TARGET_TYPE TARGET ${TARGET_NAME} PROPERTY TYPE)
+        ## Outputs for the release build
+        add_custom_command(
+            OUTPUT
+                ${RUST_BUILD_BINARY_DIR}/${ARCH}/release/${RUST_LIBRARY_FILENAME}
+                ${RUST_BUILD_BINARY_DIR}/${ARCH}/release/.noexist
+            WORKING_DIRECTORY ${RUST_BUILD_PACKAGE_DIR}
+            COMMAND ${CMAKE_COMMAND} -E env ${RUST_BUILD_CARGO_ENV}
+                    ${CARGO_BUILD_TOOL} build --lib --release --target ${ARCH} --target-dir ${RUST_BUILD_BINARY_DIR}
+        )
 
-    # For Apple frameworks update the rpath
-    if(IOS AND TARGET_FRAMEWORK AND TARGET_TYPE STREQUAL "SHARED_LIBRARY")
-        add_custom_command(TARGET ${TARGET_NAME} POST_BUILD
-            COMMAND install_name_tool -add_rpath @rpath/$<TARGET_BUNDLE_DIR_NAME:${TARGET_NAME}>/$<TARGET_FILE_NAME:${TARGET_NAME}> $<TARGET_FILE:${TARGET_NAME}>
+        ## Outputs for the debug build
+        add_custom_command(
+            OUTPUT
+                ${RUST_BUILD_BINARY_DIR}/${ARCH}/debug/${RUST_LIBRARY_FILENAME}
+                ${RUST_BUILD_BINARY_DIR}/${ARCH}/debug/.noexist
+            WORKING_DIRECTORY ${RUST_BUILD_PACKAGE_DIR}
+            COMMAND ${CMAKE_COMMAND} -E env ${RUST_BUILD_CARGO_ENV}
+                    ${CARGO_BUILD_TOOL} build --lib --target ${ARCH} --target-dir ${RUST_BUILD_BINARY_DIR}
         )
     endif()
 endfunction()
@@ -282,33 +193,45 @@ endfunction()
 #   ARCH: Rust target architecture(s) to build with --target ${ARCH}
 #   BINARY_DIR: Binary directory to output build artifacts to.
 #   PACKAGE_DIR: Soruce directory where Cargo.toml can be found.
+#   CRATE_NAME: Name of the staticlib crate we want to build.
 #   CARGO_ENV: Environment variables to pass to cargo.
 #   DEPENDS: Additional files on which the target depends.
 #   SHARED: Whether or not we are building a shared library. Defaults to "false".
+#   FW_NAME: Standalone dylibs need to be wrapped in a framework for distribtuion. Required when building shared lib for iOS.
 #
 function(add_rust_library TARGET_NAME)
     cmake_parse_arguments(RUST_TARGET
         ""
-        "BINARY_DIR;PACKAGE_DIR"
-        "ARCH;CARGO_ENV;DEPENDS;SHARED"
+        "BINARY_DIR;PACKAGE_DIR;CRATE_NAME"
+        "ARCH;CARGO_ENV;DEPENDS;SHARED;FW_NAME"
         ${ARGN})
 
     if(NOT RUST_TARGET_SHARED)
         set(RUST_TARGET_SHARED 0)
     endif()
 
-    if(${RUST_TARGET_SHARED})
-        add_library(${TARGET_NAME} SHARED)
-    else()
-        add_library(${TARGET_NAME} STATIC)
+    if(${RUST_TARGET_SHARED} AND IOS AND NOT RUST_TARGET_FW_NAME)
+        message(FATAL_ERROR "A framework name must be provided when building a shared Rust library for iOS.")
     endif()
-    set_target_properties(${TARGET_NAME} PROPERTIES
-        FOLDER "Libs"
-        AUTOMOC OFF
-        AUTOUIC OFF
-    )
-    cmake_language(EVAL CODE "cmake_language(DEFER CALL __rust_library_finalize ${TARGET_NAME})")
 
+    if(IOS AND RUST_TARGET_FW_NAME)
+        set(FW_INFO_PLIST_FILE_PATH ${CMAKE_SOURCE_DIR}/scripts/cmake/Info.plist.${RUST_TARGET_FW_NAME})
+
+        if(NOT EXISTS ${FW_INFO_PLIST_FILE_PATH})
+            message(FATAL_ERROR "An Info.plist.${RUST_TARGET_FW_NAME} file must exist to support creation of ${FW_NAME} framework.")
+        endif()
+    endif()
+
+    if(${RUST_TARGET_SHARED})
+        add_library(${TARGET_NAME} SHARED IMPORTED GLOBAL)
+    else()
+        add_library(${TARGET_NAME} STATIC IMPORTED GLOBAL)
+    endif()
+
+    if(NOT RUST_TARGET_CRATE_NAME)
+        ## TODO: I would like to pull this from the package manifest.
+        error("Mandatory argument CRATE_NAME was not found")
+    endif()
     if(NOT RUST_TARGET_BINARY_DIR)
         set(RUST_TARGET_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR})
     endif()
@@ -316,155 +239,144 @@ function(add_rust_library TARGET_NAME)
         set(RUST_TARGET_PACKAGE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
     endif()
 
-    ## Parse the crate manifest to determine the library being built.
-    parse_rust_manifest(
-        PACKAGE_DIR ${RUST_TARGET_PACKAGE_DIR}
-        OUTPUT_LIB_NAME RUST_TARGET_LIB_NAME
-    )
-    if(NOT RUST_TARGET_LIB_NAME)
-        message(FATAL_ERROR "No library targets found in ${RUST_TARGET_PACKAGE_DIR}")
-    endif()
-    if(RUST_TARGET_SHARED)
-        set(RUST_TARGET_FILENAME
-            ${CMAKE_SHARED_LIBRARY_PREFIX}${RUST_TARGET_LIB_NAME}${CMAKE_SHARED_LIBRARY_SUFFIX}
-        )
-    else()
-        set(RUST_TARGET_FILENAME
-            ${CMAKE_STATIC_LIBRARY_PREFIX}${RUST_TARGET_LIB_NAME}${CMAKE_STATIC_LIBRARY_SUFFIX}
-        )
-    endif()
-
-    ## Generate a library header with cbindgen
-    file(MAKE_DIRECTORY ${RUST_TARGET_BINARY_DIR}/include/bindings)
-    target_include_directories(${TARGET_NAME} PUBLIC ${RUST_TARGET_BINARY_DIR}/include)
-    add_custom_command(
-        OUTPUT ${RUST_TARGET_BINARY_DIR}/include/bindings/${RUST_TARGET_LIB_NAME}.h
-        BYPRODUCTS ${RUST_TARGET_BINARY_DIR}/${RUST_TARGET_LIB_NAME}-bindings.d
-        DEPENDS cbindgen_builder
-        DEPFILE ${RUST_TARGET_BINARY_DIR}/${RUST_TARGET_LIB_NAME}-bindings.d
-        WORKING_DIRECTORY ${RUST_TARGET_PACKAGE_DIR}
-        COMMAND ${CBINDGEN_BUILD_TOOL}
-                    -o ${RUST_TARGET_BINARY_DIR}/include/bindings/${RUST_TARGET_LIB_NAME}.h
-                    --depfile ${RUST_TARGET_BINARY_DIR}/${RUST_TARGET_LIB_NAME}-bindings.d
-    )
-    set_source_files_properties(
-        ${RUST_TARGET_BINARY_DIR}/include/bindings/${RUST_TARGET_LIB_NAME}.h
-        PROPERTIES
-            GENERATED TRUE
-            SKIP_AUTOGEN TRUE
-    )
-    configure_file(
-        ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/rustlang-dummylib.cpp.in
-        ${RUST_TARGET_BINARY_DIR}/${RUST_TARGET_LIB_NAME}-dummylib.cpp
-    )
-    target_sources(${TARGET_NAME}
-        PUBLIC ${RUST_TARGET_BINARY_DIR}/include/bindings/${RUST_TARGET_LIB_NAME}.h
-        PRIVATE ${RUST_TARGET_BINARY_DIR}/${RUST_TARGET_LIB_NAME}-dummylib.cpp
-    )
-
     # Guess the target architecture if not set.
     if(NOT RUST_TARGET_ARCH)
-        if(ANDROID)
-            if(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "armv7-a")
-                set(RUST_TARGET_ARCH "armv7-linux-androideabi")
-            else()
-                set(RUST_TARGET_ARCH "${CMAKE_SYSTEM_PROCESSOR}-linux-android")
-            endif()
-        elseif(IOS)
-            ## TODO: This doesn't work for aarch64 simulators.
-            # See also: https://bugreports.qt.io/browse/QTBUG-101276
-            foreach(OSXARCH ${CMAKE_OSX_ARCHITECTURES})
-                string(REPLACE "arm64" "aarch64" OSXARCH ${OSXARCH})
-                list(APPEND RUST_TARGET_ARCH "${OSXARCH}-apple-ios")
-            endforeach()
-            # Build all architectures if nothing is set.
-            if(NOT RUST_TARGET_ARCH)
-                set(RUST_TARGET_ARCH aarch64-apple-ios x86_64-apple-ios)
-            endif()
+        if(CMAKE_CROSSCOMPILING)
+            # TODO: We could write something here for Android and IOS maybe
+            message(FATAL_ERROR "Unable to determine rust target architecture when cross compiling.")
         elseif((CMAKE_SYSTEM_NAME STREQUAL "Darwin") AND CMAKE_OSX_ARCHITECTURES)
             # Special case for MacOS universal binaries.
             foreach(OSXARCH ${CMAKE_OSX_ARCHITECTURES})
                 string(REPLACE "arm64" "aarch64" OSXARCH ${OSXARCH})
                 list(APPEND RUST_TARGET_ARCH "${OSXARCH}-apple-darwin")
             endforeach()
-        elseif(NOT CMAKE_CROSSCOMPILING)
-            set(RUST_TARGET_ARCH ${RUSTC_HOST_ARCH})
         else()
-            message(FATAL_ERROR "Unable to determine rust target architecture.")
+            set(RUST_TARGET_ARCH ${RUSTC_HOST_ARCH})
         endif()
     endif()
 
-    ## Build the rust library target(s)
+    get_rust_library_filename(${RUST_TARGET_SHARED} ${RUST_TARGET_CRATE_NAME})
+
+    ## Don't trust Xcode to provide us with a usable linker.
+    if(APPLE AND XCODE)
+        file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/rustwrapper.sh "#!/bin/sh\n")
+        file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/rustwrapper.sh "${RUSTC_BUILD_TOOL} -C linker=/usr/bin/cc \$@\n")
+        file(CHMOD ${CMAKE_CURRENT_BINARY_DIR}/rustwrapper.sh FILE_PERMISSIONS
+            OWNER_READ OWNER_WRITE OWNER_EXECUTE
+            GROUP_READ GROUP_WRITE GROUP_EXECUTE
+            WORLD_READ WORLD_EXECUTE
+        )
+        list(APPEND CARGO_ENV RUSTC=${CMAKE_CURRENT_BINARY_DIR}/rustwrapper.sh)
+    endif()
+
+    ## Build the rust library file(s)
     foreach(ARCH ${RUST_TARGET_ARCH})
         build_rust_archives(
             ARCH ${ARCH}
             BINARY_DIR ${RUST_TARGET_BINARY_DIR}
             PACKAGE_DIR ${RUST_TARGET_PACKAGE_DIR}
-            CARGO_ENV ${RUST_TARGET_CARGO_ENV}
-            DEPENDS ${RUST_TARGET_DEPENDS}
+            CRATE_NAME ${RUST_TARGET_CRATE_NAME}
+            CARGO_ENV ${CARGO_ENV}
+            SHARED ${RUST_TARGET_SHARED}
+            FW_NAME ${RUST_TARGET_FW_NAME}
         )
+
+        if(RUST_TARGET_DEPENDS)
+            add_custom_command(APPEND
+                OUTPUT ${RUST_TARGET_BINARY_DIR}/${ARCH}/release/${RUST_LIBRARY_FILENAME}
+                DEPENDS ${RUST_TARGET_DEPENDS}
+            )
+            add_custom_command(APPEND
+                OUTPUT ${RUST_TARGET_BINARY_DIR}/${ARCH}/debug/${RUST_LIBRARY_FILENAME}
+                DEPENDS ${RUST_TARGET_DEPENDS}
+            )
+        endif()
 
         # Keep track of the expected library artifacts.
-        list(APPEND RUST_TARGET_RELEASE_LIBS ${RUST_TARGET_BINARY_DIR}/${ARCH}/release/${RUST_TARGET_FILENAME})
-        list(APPEND RUST_TARGET_DEBUG_LIBS ${RUST_TARGET_BINARY_DIR}/${ARCH}/debug/${RUST_TARGET_FILENAME})
+        list(APPEND RUST_TARGET_RELEASE_LIBS ${RUST_TARGET_BINARY_DIR}/${ARCH}/release/${RUST_LIBRARY_FILENAME})
+        list(APPEND RUST_TARGET_DEBUG_LIBS ${RUST_TARGET_BINARY_DIR}/${ARCH}/debug/${RUST_LIBRARY_FILENAME})
     endforeach()
 
-    # Use a POST_BUILD hook to replace the dummy library with the rust library
-    # built by cargo.
-    if(IOS AND XCODE)
-        # Xcode struggles to determine which dependencies need building and will
-        # result in building every config and target of the rust library. To cut
-        # down on build time, only link the release libraries when building for
-        # Xcode.
-        add_custom_command(TARGET ${TARGET_NAME} POST_BUILD
-            COMMAND lipo -create -output $<TARGET_FILE:${TARGET_NAME}> ${RUST_TARGET_RELEASE_LIBS}
-        )
-        add_custom_target(${TARGET_NAME}_builder DEPENDS ${RUST_TARGET_RELEASE_LIBS})
-    elseif(APPLE)
-        # For all other Apple targets, merge the compiled librares together with
-        # lipo into a universal library.
-        add_custom_command(
-            OUTPUT ${RUST_TARGET_BINARY_DIR}/unified/release/${RUST_TARGET_FILENAME}
-            DEPENDS ${RUST_TARGET_RELEASE_LIBS}
-            COMMAND ${CMAKE_COMMAND} -E make_directory ${RUST_TARGET_BINARY_DIR}/unified/release
-            COMMAND lipo -create -output ${RUST_TARGET_BINARY_DIR}/unified/release/${RUST_TARGET_FILENAME}
-                        ${RUST_TARGET_RELEASE_LIBS}
-        )
-        add_custom_command(
-            OUTPUT ${RUST_TARGET_BINARY_DIR}/unified/debug/${RUST_TARGET_FILENAME}
-            DEPENDS ${RUST_TARGET_DEBUG_LIBS}
-            COMMAND ${CMAKE_COMMAND} -E make_directory ${RUST_TARGET_BINARY_DIR}/unified/debug
-            COMMAND lipo -create -output ${RUST_TARGET_BINARY_DIR}/unified/debug/${RUST_TARGET_FILENAME}
-                        ${RUST_TARGET_DEBUG_LIBS}
-        )
+    if(APPLE)
+        if (${RUST_TARGET_SHARED} AND IOS)
+            add_custom_command(
+                OUTPUT ${RUST_TARGET_BINARY_DIR}/unified/release/${RUST_TARGET_FW_NAME}.framework
+                DEPENDS ${RUST_TARGET_RELEASE_LIBS}
+                COMMAND ${CMAKE_COMMAND} -E make_directory 
+                    \"${RUST_TARGET_BINARY_DIR}/unified/release/${RUST_TARGET_FW_NAME}.framework\"
+                COMMAND lipo 
+                    -create
+                    ${RUST_TARGET_RELEASE_LIBS}
+                    -output
+                    \"${RUST_TARGET_BINARY_DIR}/unified/release/${RUST_TARGET_FW_NAME}.framework/${RUST_TARGET_FW_NAME}\"
+                COMMAND cp -v
+                    \"${FW_INFO_PLIST_FILE_PATH}\"
+                    \"${RUST_TARGET_BINARY_DIR}/unified/release/${RUST_TARGET_FW_NAME}.framework/Info.plist\"
+            )
 
-        ## Replace the dummy library with the rust library.
-        add_custom_command(TARGET ${TARGET_NAME} POST_BUILD
-            COMMAND ${CMAKE_COMMAND} -E copy
-                ${RUST_TARGET_BINARY_DIR}/unified/$<IF:$<CONFIG:Debug>,debug,release>/${RUST_TARGET_FILENAME}
-                $<TARGET_FILE:${TARGET_NAME}>
-        )
-        add_custom_target(${TARGET_NAME}_builder DEPENDS
-            ${RUST_TARGET_BINARY_DIR}/unified/$<IF:$<CONFIG:Debug>,debug,release>/${RUST_TARGET_FILENAME}
-        )
+            add_custom_command(
+                OUTPUT ${RUST_TARGET_BINARY_DIR}/unified/debug/${RUST_TARGET_FW_NAME}.framework
+                DEPENDS ${RUST_TARGET_DEBUG_LIBS}
+                COMMAND ${CMAKE_COMMAND} -E make_directory 
+                    \"${RUST_TARGET_BINARY_DIR}/unified/debug/${RUST_TARGET_FW_NAME}.framework\"
+                COMMAND lipo 
+                    -create
+                    ${RUST_TARGET_DEBUG_LIBS}
+                    -output
+                    \"${RUST_TARGET_BINARY_DIR}/unified/debug/${RUST_TARGET_FW_NAME}.framework/${RUST_TARGET_FW_NAME}\"
+                COMMAND cp -v
+                    \"${FW_INFO_PLIST_FILE_PATH}\"
+                    \"${RUST_TARGET_BINARY_DIR}/unified/debug/${RUST_TARGET_FW_NAME}.framework/Info.plist\"
+            )
+
+            add_custom_target(${TARGET_NAME}_builder
+                DEPENDS ${RUST_TARGET_BINARY_DIR}/unified/$<IF:$<CONFIG:Debug>,debug,release>/${RUST_TARGET_FW_NAME}.framework
+            )
+            set_target_properties(${TARGET_NAME} PROPERTIES
+                IMPORTED_LOCATION ${RUST_TARGET_BINARY_DIR}/unified/release/${FW_NAME}.framework/${FW_NAME}
+                IMPORTED_LOCATION_DEBUG ${RUST_TARGET_BINARY_DIR}/unified/debug/${FW_NAME}.framework/${FW_NAME}
+            )
+        else()
+            add_custom_command(
+                OUTPUT ${RUST_TARGET_BINARY_DIR}/unified/release/${RUST_LIBRARY_FILENAME}
+                DEPENDS ${RUST_TARGET_RELEASE_LIBS}
+                COMMAND ${CMAKE_COMMAND} -E make_directory ${RUST_TARGET_BINARY_DIR}/unified/release
+                COMMAND lipo -create -output ${RUST_TARGET_BINARY_DIR}/unified/release/${RUST_LIBRARY_FILENAME}
+                            ${RUST_TARGET_RELEASE_LIBS}
+            )
+            add_custom_command(
+                OUTPUT ${RUST_TARGET_BINARY_DIR}/unified/debug/${RUST_LIBRARY_FILENAME}
+                DEPENDS ${RUST_TARGET_DEBUG_LIBS}
+                COMMAND ${CMAKE_COMMAND} -E make_directory ${RUST_TARGET_BINARY_DIR}/unified/debug
+                COMMAND lipo -create -output ${RUST_TARGET_BINARY_DIR}/unified/debug/${RUST_LIBRARY_FILENAME}
+                            ${RUST_TARGET_DEBUG_LIBS}
+            )
+
+            add_custom_target(${TARGET_NAME}_builder
+                DEPENDS ${RUST_TARGET_BINARY_DIR}/unified/$<IF:$<CONFIG:Debug>,debug,release>/${RUST_LIBRARY_FILENAME}
+            )
+            set_target_properties(${TARGET_NAME} PROPERTIES
+                IMPORTED_LOCATION ${RUST_TARGET_BINARY_DIR}/unified/release/${RUST_LIBRARY_FILENAME}
+                IMPORTED_LOCATION_DEBUG ${RUST_TARGET_BINARY_DIR}/unified/debug/${RUST_LIBRARY_FILENAME}
+            )
+        endif()
     else()
         ## For all other platforms, only build the first architecture
         list(GET RUST_TARGET_ARCH 0 RUST_FIRST_ARCH)
-
-        ## Replace the dummy library with the rust library.
-        add_custom_command(TARGET ${TARGET_NAME} POST_BUILD
-            COMMAND ${CMAKE_COMMAND} -E copy
-                ${RUST_TARGET_BINARY_DIR}/${RUST_FIRST_ARCH}/$<IF:$<CONFIG:Debug>,debug,release>/${RUST_TARGET_FILENAME}
-                $<TARGET_FILE:${TARGET_NAME}>
+        add_custom_target(${TARGET_NAME}_builder
+            DEPENDS ${RUST_TARGET_BINARY_DIR}/${RUST_FIRST_ARCH}/$<IF:$<CONFIG:Debug>,debug,release>/${RUST_LIBRARY_FILENAME}
         )
 
-        add_custom_target(${TARGET_NAME}_builder DEPENDS
-            ${RUST_TARGET_BINARY_DIR}/${RUST_FIRST_ARCH}/$<IF:$<CONFIG:Debug>,debug,release>/${RUST_TARGET_FILENAME}
+        set_target_properties(${TARGET_NAME} PROPERTIES
+            IMPORTED_LOCATION ${RUST_TARGET_BINARY_DIR}/${RUST_FIRST_ARCH}/release/${RUST_LIBRARY_FILENAME}
+            IMPORTED_LOCATION_DEBUG ${RUST_TARGET_BINARY_DIR}/${RUST_FIRST_ARCH}/debug/${RUST_LIBRARY_FILENAME}
         )
     endif()
     set_target_properties(${TARGET_NAME}_builder PROPERTIES FOLDER "Libs")
     if (ANDROID AND RUST_TARGET_SHARED)
-        set_target_properties(${TARGET_NAME} PROPERTIES NO_SONAME TRUE)
+        set_target_properties(${TARGET_NAME} PROPERTIES
+            IMPORTED_NO_SONAME TRUE
+        )
     endif()
 
     add_dependencies(${TARGET_NAME} ${TARGET_NAME}_builder)

--- a/scripts/cmake/utilities.cmake
+++ b/scripts/cmake/utilities.cmake
@@ -298,6 +298,7 @@ function(mz_generate_link_libraries)
         add_rust_library(${CRATE_NAME}
             PACKAGE_DIR ${RUST_CRATE_PATH}
             BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}
+            CRATE_NAME ${CRATE_NAME}
         )
 
         list(APPEND LOCAL_LINK_LIBRARIES ${CRATE_NAME})

--- a/src/cmake/android.cmake
+++ b/src/cmake/android.cmake
@@ -37,6 +37,7 @@ target_sources(mozillavpn PRIVATE
 )
 
 get_property(OPENSSL_LIBS_DIR GLOBAL PROPERTY OPENSSL_LIBS)
+get_property(QTGLEAN_LIB_LOCATION TARGET qtglean_bindings PROPERTY LOCATION_${CMAKE_BUILD_TYPE})
 
 # This property flags the build system to copy these
 # shared libraries into the expected Android shared library folder.
@@ -60,6 +61,7 @@ set_property(TARGET mozillavpn PROPERTY QT_ANDROID_EXTRA_LIBS
     ${OPENSSL_LIBS_DIR}/libssl.so
     ${OPENSSL_LIBS_DIR}/libcrypto_1_1.so
     ${OPENSSL_LIBS_DIR}/libssl_1_1.so
+    ${QTGLEAN_LIB_LOCATION}
     APPEND)
 
 
@@ -68,15 +70,4 @@ if( ${Qt6_VERSION} VERSION_GREATER_EQUAL 6.4.0)
         ${OPENSSL_LIBS_DIR}/libcrypto_3.so
         ${OPENSSL_LIBS_DIR}/libssl_3.so
     APPEND)
-endif()
-
-if(Qt6_VERSION VERSION_GREATER_EQUAL 6.6.0)
-    set_property(TARGET mozillavpn APPEND PROPERTY
-        QT_ANDROID_EXTRA_LIBS $<TARGET_FILE:qtglean_bindings>
-    )
-else()
-    get_property(QTGLEAN_LIB_DIR TARGET qtglean_bindings PROPERTY BINARY_DIR)
-    set_property(TARGET mozillavpn APPEND PROPERTY
-        QT_ANDROID_EXTRA_LIBS ${QTGLEAN_LIB_DIR}/libqtglean_bindings.so
-    )
 endif()

--- a/src/cmake/ios.cmake
+++ b/src/cmake/ios.cmake
@@ -21,7 +21,7 @@ target_link_options(mozillavpn PRIVATE "-ObjC")
 ## Install the Glean iOS SDK into the bundle.
 include(${CMAKE_SOURCE_DIR}/qtglean/ios.cmake)
 
-target_link_libraries(mozillavpn PRIVATE iosglean signature)
+target_link_libraries(mozillavpn PRIVATE iosglean)
 target_sources(mozillavpn PRIVATE
     ${CMAKE_CURRENT_BINARY_DIR}/generated/VPNMetrics.swift
     ${CMAKE_SOURCE_DIR}/src/platforms/ios/iosgleanbridge.swift
@@ -31,6 +31,11 @@ target_sources(mozillavpn PRIVATE
 
 ## Install the Network Extension into the bundle.
 add_dependencies(mozillavpn networkextension)
+
+# We have to manually build the QtGlean bindings framework,
+# so we also have to manually add it.
+get_property(QTGLEAN_LIB_LOCATION TARGET qtglean_bindings PROPERTY LOCATION)
+get_filename_component(QTGLEAN_FW_LOCATION ${QTGLEAN_LIB_LOCATION} DIRECTORY)
 
 # Configure the application bundle Info.plist
 set_target_properties(mozillavpn PROPERTIES
@@ -61,7 +66,7 @@ set_target_properties(mozillavpn PROPERTIES
     XCODE_EMBED_APP_EXTENSIONS_REMOVE_HEADERS_ON_COPY "YES"
     XCODE_EMBED_APP_EXTENSIONS_CODE_SIGN_ON_COPY "YES"
     # Make sure Glean is added as a framework to the final bundle
-    XCODE_EMBED_FRAMEWORKS "qtglean_bindings;iosglean"
+    XCODE_EMBED_FRAMEWORKS "${QTGLEAN_FW_LOCATION};iosglean"
     XCODE_EMBED_FRAMEWORKS_REMOVE_HEADERS_ON_COPY "YES"
     XCODE_EMBED_FRAMEWORKS_CODE_SIGN_ON_COPY "YES"
     XCODE_ATTRIBUTE_LD_RUNPATH_SEARCH_PATHS "@executable_path/Frameworks"

--- a/src/cmake/shared-sources.cmake
+++ b/src/cmake/shared-sources.cmake
@@ -215,12 +215,15 @@ if(NOT CMAKE_CROSSCOMPILING)
        )
 endif()
 
-if(NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Emscripten")
+if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux" OR
+   ${CMAKE_SYSTEM_NAME} STREQUAL "Windows" OR
+   ${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
     # Compile and link the signature library.
     include(${CMAKE_SOURCE_DIR}/scripts/cmake/rustlang.cmake)
     add_rust_library(signature
         PACKAGE_DIR ${CMAKE_SOURCE_DIR}/signature
         BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}
+        CRATE_NAME signature
     )
     target_compile_definitions(shared-sources INTERFACE MZ_SIGNATURE)
     target_link_libraries(shared-sources INTERFACE signature)
@@ -234,7 +237,6 @@ add_dependencies(shared-sources translations)
 mz_add_clang_tidy(shared-sources)
 if(TARGET shared-sources_clang_tidy_report)
     add_dependencies(shared-sources_clang_tidy_report
-	signature
         translations
         qtglean
     )

--- a/src/glean/mzglean.cpp
+++ b/src/glean/mzglean.cpp
@@ -12,7 +12,7 @@
 #include "logger.h"
 #include "settingsholder.h"
 #if not(defined(MZ_WASM))
-#  include "bindings/qtglean.h"
+#  include "qtglean.h"
 #endif
 #if defined(MZ_ANDROID)
 #  include "../platforms/android/androidvpnactivity.h"

--- a/src/platforms/android/androidcommons.h
+++ b/src/platforms/android/androidcommons.h
@@ -19,6 +19,10 @@ class AndroidCommons final : public QObject {
 
   static QString GetManufacturer();
 
+  static bool verifySignature(const QByteArray& publicKey,
+                              const QByteArray& content,
+                              const QByteArray& signature);
+
   // Creates a "share" intent to Open/Send Plaintext
   static bool shareText(const QString& plainText);
 

--- a/src/platforms/ios/ioscommons.h
+++ b/src/platforms/ios/ioscommons.h
@@ -18,6 +18,10 @@ class IOSCommons final {
 
   static QStringList systemLanguageCodes();
 
+  static bool verifySignature(const QByteArray& publicKey,
+                              const QByteArray& content,
+                              const QByteArray& signature);
+
   static void shareLogs(const QString& logs);
 };
 

--- a/src/platforms/ios/ioscommons.mm
+++ b/src/platforms/ios/ioscommons.mm
@@ -74,6 +74,26 @@ void IOSCommons::statusBarUpdateHack() {
   }
 }
 
+// static
+bool IOSCommons::verifySignature(const QByteArray& publicKey, const QByteArray& content,
+                                 const QByteArray& signature) {
+  NSDictionary* attributes = @{
+    (__bridge NSString*)kSecAttrKeyType : (__bridge NSString*)kSecAttrKeyTypeRSA,
+    (__bridge NSString*)kSecAttrKeyClass : (__bridge NSString*)kSecAttrKeyClassPublic
+  };
+  SecKeyRef publicKeyRef = SecKeyCreateWithData((CFDataRef)publicKey.toNSData(),
+                                                (__bridge CFDictionaryRef)attributes, nullptr);
+
+  if (SecKeyVerifySignature(publicKeyRef, kSecKeyAlgorithmRSASignatureMessagePKCS1v15SHA256,
+                            (CFDataRef)content.toNSData(), (CFDataRef)signature.toNSData(),
+                            nullptr)) {
+    return true;
+  }
+
+  logger.warning() << "Signature verification failed";
+  return false;
+}
+
 void IOSCommons::shareLogs(const QString& logs) {
   UIView* view =
       static_cast<UIView*>(QGuiApplication::platformNativeInterface()->nativeResourceForWindow(

--- a/tests/functional/addons/CMakeLists.txt
+++ b/tests/functional/addons/CMakeLists.txt
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.20)
 
 project(testing_addons VERSION 1.0.0 LANGUAGES CXX
         DESCRIPTION "Mozilla VPN Addons for Functional Testing"

--- a/tests/unit/testaddon.cpp
+++ b/tests/unit/testaddon.cpp
@@ -19,7 +19,6 @@
 #include "addons/conditionwatchers/addonconditionwatchertimestart.h"
 #include "addons/conditionwatchers/addonconditionwatchertriggertimesecs.h"
 #include "addons/manager/addonmanager.h"
-#include "bindings/qtglean.h"
 #include "feature/feature.h"
 #include "feature/featuremodel.h"
 #include "glean/generated/metrics.h"
@@ -27,6 +26,7 @@
 #include "helper.h"
 #include "localizer.h"
 #include "qmlengineholder.h"
+#include "qtglean.h"
 #include "settingsholder.h"
 #include "systemtraynotificationhandler.h"
 

--- a/tests/unit_tests/testaddon.cpp
+++ b/tests/unit_tests/testaddon.cpp
@@ -18,7 +18,6 @@
 #include "addons/conditionwatchers/addonconditionwatchertimeend.h"
 #include "addons/conditionwatchers/addonconditionwatchertimestart.h"
 #include "addons/conditionwatchers/addonconditionwatchertriggertimesecs.h"
-#include "bindings/qtglean.h"
 #include "feature/feature.h"
 #include "feature/featuremodel.h"
 #include "glean/generated/metrics.h"
@@ -26,6 +25,7 @@
 #include "helper.h"
 #include "localizer.h"
 #include "qmlengineholder.h"
+#include "qtglean.h"
 #include "settings/settingsmanager.h"
 #include "settingsholder.h"
 

--- a/tests/unit_tests/testlocalizer.cpp
+++ b/tests/unit_tests/testlocalizer.cpp
@@ -4,11 +4,11 @@
 
 #include "testlocalizer.h"
 
-#include "bindings/qtglean.h"
 #include "glean/generated/metrics.h"
 #include "glean/mzglean.h"
 #include "helper.h"
 #include "localizer.h"
+#include "qtglean.h"
 #include "settings/settingsmanager.h"
 #include "settingsholder.h"
 


### PR DESCRIPTION
This reverts commit ffa46af27ef1a1f0a58191ac88912453c712cac8 aka PR #10528

## Description

Something in this commit broke iOS builds on Xcode Cloud and locally (at least for me). I'm not quite sure which part, and there is a lot in there, so I'm proposing backing out this entire commit, and letting Naomi take another go at it when she's back.

## Reference

VPN-7072

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
