### PR TITLE
Nit: Fix changed log path

### DIFF
--- a/src/utils/loghandler.cpp
+++ b/src/utils/loghandler.cpp
@@ -167,7 +167,7 @@ LogHandler::LogHandler() : QObject(nullptr) {
   // If no logfile has been set, derive it automatically from the shortname.
   if (s_filename.isEmpty()) {
     QString where =
-        QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
+        QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation);
     s_filename = QDir(where).filePath(m_shortname + LOG_FILE_SUFFIX);
   }
   openLogFile(lock);


### PR DESCRIPTION
## Description
Here's a neat bug.

In PR #10571 we fiddled a bit with the `LogHandler` to preserve the logfile path of the daemon, and in order to do this we moved the lookup of `QStandardPaths::writeableLocation(QStandardPaths::AppDataLocation)` from a static variable (initialized at the C++ runtime setup) into the `LogHandler` constructor (initialized on first use).

Normally, `QStandardPaths::AppDataLocation` resolves into some path that contains the org and app names (eg: `~/Library/Application Support/<organization>/<app name>`), but when this is invoked before setting the `QCoreApplication::applicationName()` this actually omits the org and app names causing the path to resolve to the same thing as `QStandardPaths::GenericDataLocation`.

Therefore, by moving the initialization code around, we actually wound up changing the default log file location. In order to try and keep the log paths consistent, we should change this to use `QStandardPaths::GenericDataLocation`.

## Reference

    i.e Jira or Github issue URL

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
