### PR TITLE
Fix possible race condition in XDG scope creation

### DIFF
--- a/src/platforms/linux/xdgportal.cpp
+++ b/src/platforms/linux/xdgportal.cpp
@@ -167,14 +167,14 @@ void XdgPortal::setupAppScope(const QString& appId) {
     logger.warning() << "Failed to get scope:" << getunit.errorMessage();
     return;
   }
-  QList<QVariant> result = getunit.arguments();
-  if ((getunit.type() != QDBusMessage::ReplyMessage) || result.isEmpty()) {
+  QList<QVariant> unitResult = getunit.arguments();
+  if ((getunit.type() != QDBusMessage::ReplyMessage) || unitResult.isEmpty()) {
     logger.warning() << "Bad reply for current scope:";
     return;
   }
 
   // Fetch the names of the unit to figure out the appid.
-  QDBusObjectPath unitPath = result.first().value<QDBusObjectPath>();
+  QDBusObjectPath unitPath = unitResult.first().value<QDBusObjectPath>();
   QDBusInterface ownUnit("org.freedesktop.systemd1", unitPath.path(),
                          "org.freedesktop.systemd1.Unit");
   QStringList unitNames = ownUnit.property("Names").toStringList();
@@ -222,7 +222,8 @@ void XdgPortal::setupAppScope(const QString& appId) {
     logger.warning() << "Failed to create scope:" << msg.errorMessage();
     return;
   }
-  QDBusObjectPath jobPath = result.first().value<QDBusObjectPath>();
+  QList<QVariant> jobResult = msg.arguments();
+  QDBusObjectPath jobPath = jobResult.first().value<QDBusObjectPath>();
   if ((msg.type() != QDBusMessage::ReplyMessage) || jobPath.path().isEmpty()) {
     logger.warning() << "Bad reply for create scope";
     return;


### PR DESCRIPTION
## Description
While running some functional tests on my Linux machine, I encountered a possible race condition during the creation of the XDG application scope. The bug occurs when we call `StartTransientUnit()` to create an application scope, but instead of grabbing the job's D-Bus object path, we re-use the result from `GetUnitByPid()` in which case we don't really check the job status for completion... meaning that we can return from this method before the job is complete.

## Reference
Possibly the cause of:
- [VPN-6542](https://mozilla-hub.atlassian.net/browse/VPN-6542)
- [VPN-6422](https://mozilla-hub.atlassian.net/browse/VPN-6422)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
