### PR TITLE
VPN-7002 fix - always load location

### DIFF
--- a/addons/message_upgrade_to_bundle_1/conditions.js
+++ b/addons/message_upgrade_to_bundle_1/conditions.js
@@ -20,6 +20,9 @@ api.connectSignal(api.subscriptionData, 'changed', () => computeCondition());
 api.connectSignal(
     api.subscriptionData, 'initialized', () => computeCondition());
 
+// Run on app launch after getting current location
+api.connectSignal(api.location, 'changed', () => computeCondition());
+
 // This is for already-running clients that receive this addon while the client
 // is launched and signed in. (These users may not see a change in
 // subscriptionData for a long time.)

--- a/addons/message_upgrade_to_bundle_2/conditions.js
+++ b/addons/message_upgrade_to_bundle_2/conditions.js
@@ -20,6 +20,9 @@ api.connectSignal(api.subscriptionData, 'changed', () => computeCondition());
 api.connectSignal(
     api.subscriptionData, 'initialized', () => computeCondition());
 
+// Run on app launch after getting current location
+api.connectSignal(api.location, 'changed', () => computeCondition());
+
 // This is for already-running clients that receive this addon while the client
 // is launched and signed in. (These users may not see a change in
 // subscriptionData for a long time.)

--- a/addons/message_upgrade_to_bundle_3/conditions.js
+++ b/addons/message_upgrade_to_bundle_3/conditions.js
@@ -20,6 +20,9 @@ api.connectSignal(api.subscriptionData, 'changed', () => computeCondition());
 api.connectSignal(
     api.subscriptionData, 'initialized', () => computeCondition());
 
+// Run on app launch after getting current location
+api.connectSignal(api.location, 'changed', () => computeCondition());
+
 // This is for already-running clients that receive this addon while the client
 // is launched and signed in. (These users may not see a change in
 // subscriptionData for a long time.)

--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -1125,18 +1125,25 @@ void MozillaVPN::controllerStateChanged() {
   }
 
   if (!m_controllerInitialized && m_private->m_controller.isInitialized()) {
+    logger.debug() << "Controller initialized";
     m_controllerInitialized = true;
-
-    if (SettingsHolder::instance()->startAtBoot()) {
-      logger.debug() << "Start on boot";
-      activate();
-    }
+    maybeConnectOnStartup();
   }
 
   if (m_updating && controllerState == Controller::StateOff) {
     update();
   }
   NetworkManager::instance()->clearCache();
+}
+
+void MozillaVPN::maybeConnectOnStartup() {
+  if (m_controllerInitialized && m_locationInitialized) {
+    if (SettingsHolder::instance()->startAtBoot()) {
+      logger.debug()
+          << "Both controller and location initialized. Starting on boot.";
+      activate();
+    }
+  }
 }
 
 void MozillaVPN::heartbeatCompleted(bool success) {
@@ -1271,8 +1278,16 @@ void MozillaVPN::scheduleRefreshDataTasks() {
   // https://mozilla-hub.atlassian.net/browse/VPN-3726 for more information.
   if (!m_private->m_location.initialized() &&
       !m_private->m_controller.isActive()) {
-    TaskScheduler::scheduleTask(
-        new TaskGetLocation(ErrorHandler::PropagateError));
+    TaskGetLocation* locationTask =
+        new TaskGetLocation(ErrorHandler::PropagateError);
+    connect(locationTask, &TaskGetLocation::completed, [this]() {
+      if (!m_locationInitialized) {
+        logger.debug() << "Location initialized";
+        m_locationInitialized = true;
+        maybeConnectOnStartup();
+      }
+    });
+    TaskScheduler::scheduleTask(locationTask);
   }
 
   TaskScheduler::scheduleTask(new TaskGroup(refreshTasks));

--- a/src/mozillavpn.h
+++ b/src/mozillavpn.h
@@ -227,6 +227,8 @@ class MozillaVPN final : public App {
 
   void controllerStateChanged();
 
+  void maybeConnectOnStartup();
+
   void maybeRegenerateDeviceKey();
 
   bool checkCurrentDevice();
@@ -280,6 +282,7 @@ class MozillaVPN final : public App {
   bool m_startMinimized = false;
   bool m_updating = false;
   bool m_controllerInitialized = false;
+  bool m_locationInitialized = false;
 };
 
 #endif  // MOZILLAVPN_H


### PR DESCRIPTION
## Description

This does 2 things:
- The bundle-related addons recheck their conditions on location updates.
- Activating on boot waits for location check. (Note: The server prioritization still does not run in this case

This works in my testing, both when "on boot" is active and when it is not.

## Reference

VPN-7002

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
