### PR TITLE
VPN-7070: Daemon should link to the Security framework

### DIFF
--- a/src/cmake/macos-daemon.cmake
+++ b/src/cmake/macos-daemon.cmake
@@ -15,9 +15,10 @@ mz_target_handle_warnings(daemon)
 
 find_library(FW_FOUNDATION Foundation)
 find_library(FW_NETWORK Network)
+find_library(FW_SECURITY Security)
 find_library(FW_SYSTEMCONFIG SystemConfiguration)
 
-target_link_libraries(daemon PRIVATE ${FW_FOUNDATION} ${FW_NETWORK} ${FW_SYSTEMCONFIG})
+target_link_libraries(daemon PRIVATE ${FW_FOUNDATION} ${FW_NETWORK} ${FW_SECURITY} ${FW_SYSTEMCONFIG})
 target_link_libraries(daemon PRIVATE Qt6::Core Qt6::Network)
 target_link_libraries(daemon PRIVATE mzutils)
 


### PR DESCRIPTION
## Description
The daemon uses a few functions out of the `Security` framework to determine its signing identities and enforce codesigning of the connecting clients. Unfortunately, it seems that we forgot to link to the `Security` framework causing build failures for some developers.

## Reference
JIRA Issue: [VPN-7070](https://mozilla-hub.atlassian.net/browse/VPN-7070)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-7070]: https://mozilla-hub.atlassian.net/browse/VPN-7070?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ