### PR TITLE
VPN-7065: update string to remove reference to pocket

### DIFF
--- a/src/translations/strings.yaml
+++ b/src/translations/strings.yaml
@@ -747,8 +747,8 @@ deleteAccount:
   subheadline2:
     value: "Your Mozilla account (%1) is connected to Mozilla products that keep you secure and productive on the web. Please acknowledge that by deleting your account:"
     comment: "%1 is the email address that is associated with the current account"
-  optionDescriptionOne:
-    value: Any paid subscriptions you have will be cancelled (Except Pocket)
+  optionDescriptionOneUpdated:
+    value: Any paid subscriptions you have will be cancelled
     comment: Text that belongs to a checkbox that the user has to check in order before they can delete their account.
   optionDescriptionTwo:
     value: You may lose saved information and features within Mozilla products

--- a/src/ui/deleteAccount/ViewDeleteAccountRequest.qml
+++ b/src/ui/deleteAccount/ViewDeleteAccountRequest.qml
@@ -17,7 +17,7 @@ MZInAppAuthenticationBase {
 
     property var checkboxData: [
         {
-            subLabelText: MZI18n.DeleteAccountOptionDescriptionOne,
+            subLabelText: MZI18n.DeleteAccountOptionDescriptionOneUpdated,
             objectName: "check1",
             isSelected: false
         },


### PR DESCRIPTION
## Description

Pocket subscriptions no longer exist; need new string here.

<img width="167" alt="Screenshot 18" src="https://github.com/user-attachments/assets/ad77c83a-26eb-4145-a7b9-3fe79dbb1740" />

## Reference

VPN-7065

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
