### PR TITLE
VPN-7087: Fix Android nav bar

### DIFF
--- a/src/commands/commandui.cpp
+++ b/src/commands/commandui.cpp
@@ -206,8 +206,6 @@ int CommandUI::run(QStringList& tokens) {
     }
 
     // Configure graphics rendering for Android
-    QGuiApplication::setHighDpiScaleFactorRoundingPolicy(
-        Qt::HighDpiScaleFactorRoundingPolicy::Round);
     if (AndroidUtils::isChromeOSContext()) {
       QQuickWindow::setGraphicsApi(QSGRendererInterface::Software);
     }

--- a/src/commands/commandui.cpp
+++ b/src/commands/commandui.cpp
@@ -140,6 +140,26 @@ int CommandUI::run(QStringList& tokens) {
     LogHandler::instance()->setStderr(true);
   }
 
+#ifdef MZ_ANDROID
+  // Configure graphics rendering for Android
+  QGuiApplication::setHighDpiScaleFactorRoundingPolicy(
+      Qt::HighDpiScaleFactorRoundingPolicy::Round);
+  if (AndroidUtils::isChromeOSContext()) {
+    QQuickWindow::setGraphicsApi(QSGRendererInterface::Software);
+  }
+#endif
+
+#ifdef MZ_WINDOWS
+  // Configure graphics rendering for Windows
+  SetProcessDPIAware();
+  if (WindowsCommons::requireSoftwareRendering()) {
+    QQuickWindow::setGraphicsApi(QSGRendererInterface::Software);
+  }
+#endif
+
+  // Ensure that external styling hints are disabled.
+  qunsetenv("QT_STYLE_OVERRIDE");
+
   return MozillaVPN::runGuiApp([&]() {
     Telemetry::startTimeToFirstScreenTimer();
 
@@ -204,23 +224,7 @@ int CommandUI::run(QStringList& tokens) {
     if (AndroidCommons::GetManufacturer() == "Huawei") {
       qputenv("QT_ANDROID_NO_EXIT_CALL", "1");
     }
-
-    // Configure graphics rendering for Android
-    if (AndroidUtils::isChromeOSContext()) {
-      QQuickWindow::setGraphicsApi(QSGRendererInterface::Software);
-    }
 #endif
-
-#ifdef MZ_WINDOWS
-    // Configure graphics rendering for Windows
-    SetProcessDPIAware();
-    if (WindowsCommons::requireSoftwareRendering()) {
-      QQuickWindow::setGraphicsApi(QSGRendererInterface::Software);
-    }
-#endif
-
-    // Ensure that external styling hints are disabled.
-    qunsetenv("QT_STYLE_OVERRIDE");
 
     // This object _must_ live longer than MozillaVPN to avoid shutdown crashes.
     QQmlApplicationEngine* engine = new QQmlApplicationEngine();


### PR DESCRIPTION
## Description

According to [Qt documentation](https://doc.qt.io/qt-6/qguiapplication.html#setHighDpiScaleFactorRoundingPolicy), `setHighDpiScaleFactorRoundingPolicy` "must be called before creating the application object."

In [a recent PR](https://github.com/mozilla-mobile/mozilla-vpn-client/pull/10571/files#diff-705b181dfea5ef23cadef0ed0e133fdf1192f2d41d0ba9435e4b7f5ecd8f8cfcR207-R225), this was moved and was no longer called before the app object was created - which apparently causes this bad behavior. I isolated the issue to this single line (removing the line with `setHighDpiScaleFactorRoundingPolicy` makes it work as expected), but moved this whole chunk of graphics stuff up to be on the safe side of things.

Looks okay again:
<img src="https://github.com/user-attachments/assets/da391fc0-bf1c-4420-b9f3-c23be488cecd" width=150>

## Reference

VPN-7087

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
