### PR TITLE
VPN-7090: Fix macOS repackage chain of trust

### DIFF
--- a/taskcluster/kinds/mac-notarization/kind.yml
+++ b/taskcluster/kinds/mac-notarization/kind.yml
@@ -32,7 +32,7 @@ tasks:
             upstream-artifacts:
                 - taskId:
                       task-reference: <repackage>
-                  taskType: scriptworker
+                  taskType: repackage
                   paths:
                       - public/build/MozillaVPN.pkg
                   formats:


### PR DESCRIPTION
## Description
In PR #10594 we reorganized the macOS taskcluster jobs to split the package step into its own `repackage-macpkg` task separate from the application codesigning. Unfortunately, this seems to have broken the `mac-notarization` task due to a chain-of-trust validation error, which is trying to validate the `repackage-macpkg` task under the expectation it was run as a scriptworker task.

I think the culprit is the `buildType` settings in the `upstream-artifacts`, which should have been updated to `repackage` from `signing`

## Reference
Introduced by: #10594
JIRA Issue: [VPN-7090](https://mozilla-hub.atlassian.net/browse/VPN-7090)
JIRA Issue: [VPN-7091](https://mozilla-hub.atlassian.net/browse/VPN-7091)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-7090]: https://mozilla-hub.atlassian.net/browse/VPN-7090?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[VPN-7091]: https://mozilla-hub.atlassian.net/browse/VPN-7091?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ