### PR TITLE
VPN-7090: Add repackage-signing-macpkg task to sign the macOS installer

### DIFF
--- a/taskcluster/kinds/mac-notarization/kind.yml
+++ b/taskcluster/kinds/mac-notarization/kind.yml
@@ -18,7 +18,7 @@ tasks:
         worker-type: signing
         requires-level: 3
         dependencies:
-            repackage-signing: repackage-signing-macsign
+            repackage-signing: repackage-signing-macpkg
         if-dependencies:
             - repackage-signing
         treeherder:

--- a/taskcluster/kinds/mac-notarization/kind.yml
+++ b/taskcluster/kinds/mac-notarization/kind.yml
@@ -10,7 +10,7 @@ transforms:
     - taskgraph.transforms.task:transforms
 
 kind-dependencies:
-    - repackage
+    - repackage-signing
 
 tasks:
     macos/opt:
@@ -18,9 +18,9 @@ tasks:
         worker-type: signing
         requires-level: 3
         dependencies:
-            repackage: repackage-macpkg
+            repackage-signing: repackage-signing-macsign
         if-dependencies:
-            - repackage
+            - repackage-signing
         treeherder:
             symbol: Bn
             kind: build
@@ -31,8 +31,8 @@ tasks:
             signing-type: "release-apple-notarization"
             upstream-artifacts:
                 - taskId:
-                      task-reference: <repackage>
-                  taskType: repackage
+                      task-reference: <repackage-signing>
+                  taskType: repackage-signing
                   paths:
                       - public/build/MozillaVPN.pkg
                   formats:

--- a/taskcluster/kinds/repackage-signing/kind.yml
+++ b/taskcluster/kinds/repackage-signing/kind.yml
@@ -47,6 +47,8 @@ tasks:
                 attribute: build-type
             copy-attributes: true
         signing-format: macapp
+        worker:
+            mac-behavior: mac_sign_pkg
         treeherder:
             job-symbol: Bs
             kind: build

--- a/taskcluster/kinds/repackage-signing/kind.yml
+++ b/taskcluster/kinds/repackage-signing/kind.yml
@@ -17,7 +17,7 @@ kind-dependencies:
 
 tasks:
     repackage-msi:
-        description: repackage mozillavpn msi
+        description: Sign MSI installer package
         run-on-tasks-for: []
         from-deps:
             with-attributes:
@@ -35,3 +35,20 @@ tasks:
             kind: build
             tier: 1
             platform: windows/x86_64
+
+    repackage-macpkg:
+        description: Sign macOS installer package
+        run-on-tasks-for: []
+        from-deps:
+            with-attributes:
+                build-type:
+                    - macos/opt
+            group-by:
+                attribute: build-type
+            copy-attributes: true
+        signing-format: macapp
+        treeherder:
+            job-symbol: Bs
+            kind: build
+            tier: 1
+            platform: macos/opt

--- a/taskcluster/kinds/repackage/kind.yml
+++ b/taskcluster/kinds/repackage/kind.yml
@@ -17,7 +17,7 @@ kind-dependencies:
 
 tasks:
     msi:
-        description: repackage mozillavpn msi
+        description: Build MSI installer package
         run-on-tasks-for: [github-push]
         fetches:
             signing:
@@ -48,7 +48,7 @@ tasks:
             platform: windows/x86_64
 
     macpkg:
-        description: repackage mozillavpn macpkg
+        description: Build macOS installer package
         run-on-tasks-for: [github-pull-request, github-push]
         fetches:
             fetch:

--- a/taskcluster/mozillavpn_taskgraph/transforms/signing.py
+++ b/taskcluster/mozillavpn_taskgraph/transforms/signing.py
@@ -123,17 +123,3 @@ def add_hardened_sign_config(config, tasks):
         task["worker"]["hardened-sign-config"] = hardened_sign_config
         task["worker"]["mac-behavior"] = "mac_sign_and_pkg_hardened"
         yield task
-
-
-@transforms.add
-def add_repackage_macpkg_behavior(config, tasks):
-    for task in tasks:
-        if config.kind != "repackage-signing":
-            yield task
-            continue
-        if not task["attributes"]["build-type"].startswith("macos"):
-            yield task
-            continue
-
-        task["worker"]["mac-behavior"] = "mac_sign_pkg"
-        yield task

--- a/taskcluster/mozillavpn_taskgraph/transforms/signing.py
+++ b/taskcluster/mozillavpn_taskgraph/transforms/signing.py
@@ -99,7 +99,7 @@ def script_url(params, path):
 @transforms.add
 def add_hardened_sign_config(config, tasks):
     for task in tasks:
-        if "signing" not in config.kind:
+        if config.kind != "signing":
             yield task
             continue
         if not task["attributes"]["build-type"].startswith("macos"):
@@ -122,4 +122,18 @@ def add_hardened_sign_config(config, tasks):
 
         task["worker"]["hardened-sign-config"] = hardened_sign_config
         task["worker"]["mac-behavior"] = "mac_sign_and_pkg_hardened"
+        yield task
+
+
+@transforms.add
+def add_repackage_macpkg_behavior(config, tasks):
+    for task in tasks:
+        if config.kind != "repackage-signing":
+            yield task
+            continue
+        if not task["attributes"]["build-type"].startswith("macos"):
+            yield task
+            continue
+
+        task["worker"]["mac-behavior"] = "mac_sign_pkg"
         yield task

--- a/taskcluster/mozillavpn_taskgraph/worker_types.py
+++ b/taskcluster/mozillavpn_taskgraph/worker_types.py
@@ -32,6 +32,7 @@ from voluptuous import Any, Optional, Required
         Required("mac-behavior"): Any(
             "mac_sign_and_pkg_vpn",
             "mac_sign_and_pkg_hardened",
+            "mac_sign_pkg",
         ),
         Optional("entitlementsUrl"): str,
         Optional("loginItemsEntitlementsUrl"): str,


### PR DESCRIPTION
## Description
We recently updated the macOS taskcluster jobs to use a new hardened signer that gives us more fine-grained control over the provisioning profiles and entitlements used to sign the application, but this left us with an unsigned macOS installer package, which then failed notarization.

To fix this, we need to add an extra `repackage-signing-macpkg` job to taskcluster to sign the installer package before notarization.

This depends on a new `mac_sign_pkg` signing behavior in `iscript` which needs to land first.

## Reference
Waiting on: mozilla-releng/scriptworker-scripts#1236
Signing change: https://github.com/mozilla-mobile/mozilla-vpn-client/pull/10594
JIRA Issue: [VPN-7090](https://mozilla-hub.atlassian.net/browse/VPN-7090)
JIRA Issue: [VPN-7091](https://mozilla-hub.atlassian.net/browse/VPN-7091)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-7090]: https://mozilla-hub.atlassian.net/browse/VPN-7090?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[VPN-7091]: https://mozilla-hub.atlassian.net/browse/VPN-7091?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ