### PR TITLE
VPN-7120: update addon date

### DIFF
--- a/addons/message_upgrade_to_bundle_1/conditions.js
+++ b/addons/message_upgrade_to_bundle_1/conditions.js
@@ -83,7 +83,8 @@ function computeCondition() {
   else if (now >= startTime && now < endTime) {
     // Between start and end time, show message
     api.setTimedCallback(endTime - now, () => computeCondition())
-    api.addon.date = startTime / 1000
+    const ADDON_RELEASE_DATE = 1750696005
+    api.addon.date = Math.max(startTime / 1000, ADDON_RELEASE_DATE);
     condition.enable()
   }
   else {

--- a/addons/message_upgrade_to_bundle_2/conditions.js
+++ b/addons/message_upgrade_to_bundle_2/conditions.js
@@ -83,7 +83,8 @@ function computeCondition() {
   else if (now >= startTime && now < endTime) {
     // Between start and end time, show message
     api.setTimedCallback(endTime - now, () => computeCondition())
-    api.addon.date = startTime / 1000
+    const ADDON_RELEASE_DATE = 1750696005
+    api.addon.date = Math.max(startTime / 1000, ADDON_RELEASE_DATE);
     condition.enable()
   }
   else {

--- a/addons/message_upgrade_to_bundle_3/conditions.js
+++ b/addons/message_upgrade_to_bundle_3/conditions.js
@@ -81,7 +81,8 @@ function computeCondition() {
   }
   else {
     // Between start and end time, show message
-    api.addon.date = startTime / 1000
+    const ADDON_RELEASE_DATE = 1750696005
+    api.addon.date = Math.max(startTime / 1000, ADDON_RELEASE_DATE);
     condition.enable()
   }
 }


### PR DESCRIPTION
## Description

Santiago pointed out that for those of us with long-running subscriptions, the date shown in the addon can be years ago. (See Jira issue for image.) The original logic was to show the "date this addon would be enabled on", which is in line with many of our other addons.

This updates the logic to use "date the addon was released" (which is hardcoded) or the date the addon would be enabled for your situation - whichever is more recent.

## Reference

VPN-7120

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
