### PR TITLE
VPN-5276: Split apple and android conda environments

### DIFF
--- a/.github/workflows/auth_tests.yml
+++ b/.github/workflows/auth_tests.yml
@@ -54,12 +54,11 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v3
         with:
           miniconda-version: "latest"
-          environment-file: env.yml
+          environment-file: env-apple.yml
           activate-environment: vpn
 
       - name: Install build dependencies
         run: |
-          ./scripts/macos/conda_install_extras.sh
           export SDKROOT=$(xcrun --sdk macosx --show-sdk-path)
           brew install ninja
 

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -97,7 +97,7 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v3
         with:
           activate-environment: vpn
-          environment-file: env.yml
+          environment-file: env-android.yml
       - name: Setup Android SDK
         run: |
           conda info

--- a/.github/workflows/macos_tests.yaml
+++ b/.github/workflows/macos_tests.yaml
@@ -38,7 +38,7 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v3
         with:
           miniconda-version: "latest"
-          environment-file: "env.yml"
+          environment-file: "env-apple.yml"
           activate-environment: vpn
 
       - name: Setup compiler cache
@@ -51,7 +51,6 @@ jobs:
 
       - name: Install build dependencies
         run: |
-          ./scripts/macos/conda_install_extras.sh
           export SDKROOT=$(xcrun --sdk macosx --show-sdk-path)
           brew install ninja
 

--- a/.github/workflows/test_unit.yaml
+++ b/.github/workflows/test_unit.yaml
@@ -69,12 +69,11 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v3
         with:
           miniconda-version: "latest"
-          environment-file: env.yml
+          environment-file: env-apple.yml
           activate-environment: vpn
 
       - name: Install dependencies
         run: |
-          ./scripts/macos/conda_install_extras.sh
           export SDKROOT=$(xcrun --sdk macosx --show-sdk-path)
           brew install ninja
 

--- a/docs/Building/android.md
+++ b/docs/Building/android.md
@@ -8,7 +8,7 @@ this can break building for other platforms, it's advised to do those steps
 in a separate environment. 
 
 ```bash 
-$ conda env create -f env.yml -n vpn-android
+$ conda env create -f env-android.yml -n vpn-android
 $ conda activate vpn-android
 ```
 
@@ -23,7 +23,7 @@ $ conda deactivate
 $ conda activate vpn-android
 ```
 ### Optional: Choosing your QT Version: 
-By default this environment will be setup to use the QT-Version noted in env.yml
+By default this environment will be setup to use the QT-Version noted in env-android.yml
 If you need any other architecture you need to set `QT_VERSION` before continuing.
 ```
 $ conda env config vars set QT_VERSION=1.2.3

--- a/docs/Building/index.md
+++ b/docs/Building/index.md
@@ -28,7 +28,7 @@ Wherever possible, dependencies are managed using [conda](https://docs.conda.io/
 Please install [miniconda](https://docs.conda.io/en/latest/miniconda.html).
 
 Then run:
-* `conda env create -f env.yml`
+* `conda env create -f env-windows.yml`
 * `conda activate vpn`
 
 For windows, see [windows docs](./windows.md#conda)

--- a/docs/Building/ios.md
+++ b/docs/Building/ios.md
@@ -12,19 +12,11 @@ Apple ID. If you are a Mozilla developer, this is an Apple ID associated with yo
 ## Activate conda
 
 ```bash 
-$ conda env create -f env.yml -n vpn
+$ conda env create -f env-apple.yml -n vpn
 $ conda activate vpn
 ```
 
 See [here](./index.md#conda) for conda environment instructions.
-
-Install extra conda packages
-
-```bash 
-$ conda activate vpn
-$ ./scripts/macos/conda_install_extras.sh
-```
-
 
 ## Get Qt
 

--- a/docs/Building/macos.md
+++ b/docs/Building/macos.md
@@ -10,17 +10,11 @@ Apple ID. If you are a Mozilla developer, this is an Apple ID associated with yo
 ## Activate conda
 
 ```
-conda env create -f env.yml
+conda env create -f env-apple.yml
 conda activate vpn
 ```
 
 See [here](./index.md#conda) for conda environment instructions.
-
-Install extra conda packages
-
-```
-./scripts/macos/conda_install_extras.sh
-```
 
 Your Xcode install comes with a copy of the MacOS-SDK.
 We need to tell the conda environment where to find it.

--- a/env-android.yml
+++ b/env-android.yml
@@ -11,7 +11,6 @@ dependencies:
   - rust-std-x86_64-linux-android=1.75
   - rust-std-i686-linux-android=1.75
   - rust-std-aarch64-linux-android=1.75
-  - go=1.22
   - cmake=3.26.3
   - ninja=1.11.0
   - conda-forge::openjdk=17

--- a/env-android.yml
+++ b/env-android.yml
@@ -2,24 +2,16 @@ name: vpn
 channels:
   - conda-forge
 dependencies:
-  - clang=16.0.6
-  - clang-tools=16.0.6
-  - clangxx=16.0.6
   - ccache=4.10.1
   - python=3.9
   - nodejs=18.16.*
   - pip=22.3.1
   - rust=1.75
-  - rust-std-aarch64-apple-darwin=1.75
-  - rust-std-x86_64-apple-darwin=1.75
-  - rust-std-aarch64-apple-ios=1.75
-  - rust-std-x86_64-apple-ios=1.75
   - rust-std-armv7-linux-androideabi=1.75
   - rust-std-x86_64-linux-android=1.75
   - rust-std-i686-linux-android=1.75
   - rust-std-aarch64-linux-android=1.75
   - go=1.22
-  - compiler-rt
   - cmake=3.26.3
   - ninja=1.11.0
   - conda-forge::openjdk=17

--- a/env-apple.yml
+++ b/env-apple.yml
@@ -1,0 +1,26 @@
+name: vpn
+channels:
+  - conda-forge
+dependencies:
+  - clang=16.0.6
+  - clang-tools=16.0.6
+  - clangxx=16.0.6
+  - ccache=4.10.1
+  - cctools=973.0.1
+  - python=3.9
+  - nodejs=18.16.*
+  - pip=22.3.1
+  - rust=1.75
+  - rust-std-aarch64-apple-darwin=1.75
+  - rust-std-x86_64-apple-darwin=1.75
+  - rust-std-aarch64-apple-ios=1.75
+  - rust-std-x86_64-apple-ios=1.75
+  - go=1.22
+  - compiler-rt
+  - cmake=3.26.3
+  - ninja=1.11.0
+  - pip:
+      - -r requirements.txt
+      - -r taskcluster/scripts/requirements.txt
+variables:
+  QT_VERSION: 6.6.3

--- a/scripts/android/conda_trim.sh
+++ b/scripts/android/conda_trim.sh
@@ -12,12 +12,8 @@ fi
 
 ## Saves 1gb - Go is handled by gradle. 
 conda remove go --offline -y
-## Also saves 1gb
-conda remove rust-std-aarch64-apple-darwin rust-std-x86_64-apple-darwin rust-std-aarch64-apple-ios rust-std-x86_64-apple-ios --offline -y
 ## Saves another 1gb
 sdkmanager --uninstall --sdk_root=$ANDROID_HOME emulator
-## No Need for other Compilers, as we use NDK. - easy 500mb save. 
-conda remove --offline -y clang clang-tools clangxx compiler-rt
 ## Clean the PKG cache, cleans 7gb ~~
 
 conda clean -a -y 

--- a/scripts/android/conda_trim.sh
+++ b/scripts/android/conda_trim.sh
@@ -10,8 +10,6 @@ fi
 ## In our .env we ship a lot of stuff that we do not need
 ## Let's remove that. 
 
-## Saves 1gb - Go is handled by gradle. 
-conda remove go --offline -y
 ## Saves another 1gb
 sdkmanager --uninstall --sdk_root=$ANDROID_HOME emulator
 ## Clean the PKG cache, cleans 7gb ~~

--- a/scripts/macos/conda_install_extras.sh
+++ b/scripts/macos/conda_install_extras.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-conda install -y -c conda-forge cctools=973.0.1

--- a/taskcluster/kinds/toolchain/conda_android.yml
+++ b/taskcluster/kinds/toolchain/conda_android.yml
@@ -22,7 +22,7 @@ task-defaults:
             - scripts/android/conda_trim.sh
             - android_sdk.txt
             - requirements.txt
-            - env.yml
+            - env-android.yml
         toolchain-alias: "filled-by-transform: conda.py"
         toolchain-artifact: public/build/conda-android.tar.gz
 

--- a/taskcluster/kinds/toolchain/conda_osx.yml
+++ b/taskcluster/kinds/toolchain/conda_osx.yml
@@ -17,8 +17,7 @@ task-defaults:
         use-caches: []
         resources:
             - requirements.txt
-            - env.yml
-            - scripts/macos/conda_install_extras.sh
+            - env-apple.yml
             - scripts/macos/conda_setup_qt.sh
 
 

--- a/taskcluster/scripts/toolchain/conda_pack_android.sh
+++ b/taskcluster/scripts/toolchain/conda_pack_android.sh
@@ -12,7 +12,7 @@ ls
 
 /opt/conda/bin/conda install conda-pack -y
 
-/opt/conda/bin/conda env create -f env.yml -n vpn
+/opt/conda/bin/conda env create -f env-android.yml -n vpn
 bash -l -c "conda activate vpn && conda env config vars set QT_VERSION=${QT_VERSION}"
 bash -l -c "conda activate vpn && ./scripts/android/conda_setup_sdk.sh"
 bash -l -c "conda activate vpn && ./scripts/android/conda_setup_qt.sh"
@@ -20,4 +20,3 @@ bash -l -c "conda activate vpn && ./scripts/android/conda_trim.sh"
     
 mkdir -p ../../public/build
 /opt/conda/bin/conda pack -n vpn -o $UPLOAD_DIR/conda-android.tar.gz
-

--- a/taskcluster/scripts/toolchain/conda_pack_ios.sh
+++ b/taskcluster/scripts/toolchain/conda_pack_ios.sh
@@ -14,7 +14,7 @@ ls
 
 # save the passed QT_Version
 # as that will be overwritten once 
-# we enable the env.yml
+# we enable the env-apple.yml
 BACKUP_QT_VERSION=${QT_VERSION}
 chmod +x ${MOZ_FETCHES_DIR}/miniconda.sh
 bash ${MOZ_FETCHES_DIR}/miniconda.sh -b -u -p .
@@ -29,23 +29,16 @@ rm -f ~/.config/pip/pip.conf
 pip config --user set install.no-index 0 
 pip config debug
 
-conda env create -f env.yml -n vpn
+conda env create -f env-apple.yml -n vpn
 conda activate vpn
 echo "SETTING QT_VERSION=${BACKUP_QT_VERSION}"
 conda env config vars set QT_VERSION=${BACKUP_QT_VERSION}
 # Re-enable to apply
 env
 conda deactivate
-conda activate vpn
-./scripts/macos/conda_install_extras.sh
-./scripts/macos/conda_setup_qt.sh
 
-conda deactivate
-conda activate vpn
-echo "INFO"
-conda info 
-env
-echo "INFO"
+conda run -n vpn ./scripts/macos/conda_setup_qt.sh
+conda run -n vpn conda info
 conda install conda-pack -y
 
 mkdir -p ../../public/build

--- a/taskcluster/scripts/toolchain/conda_pack_macos.sh
+++ b/taskcluster/scripts/toolchain/conda_pack_macos.sh
@@ -27,11 +27,8 @@ pip config --user set install.no-index 0
 pip config debug
 
 echo "Installing provided conda env..."
-conda env create -f ${VCS_PATH}/env.yml
-conda activate VPN
-${VCS_PATH}/scripts/macos/conda_install_extras.sh
-conda info
-conda deactivate
+conda env create -f ${VCS_PATH}/env-apple.yml
+conda run -n vpn conda info
 
 echo "Installing conda-pack..."
 conda install conda-pack -y


### PR DESCRIPTION
## Description
As a prerequisite to supporting OSX cross compilation, we are going to need to add a bunch of tooling to the conda environment and rather than injecting a lot of cruft into the Android build environment, it would be best if we just split the Conda environments for Apple and Android targets.

For what it's worth, we have never really had a common environment anyways, since the `conda_trim.sh` script removes a lot of stuff from the Android environment.

## Reference
Prerequisite for [VPN-5276](https://mozilla-hub.atlassian.net/browse/VPN-5276)
Split from: #10584

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-5276]: https://mozilla-hub.atlassian.net/browse/VPN-5276?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ