### PR TITLE
VPN-7090: Change taskType to signing for mac-notarization

### DIFF
--- a/taskcluster/kinds/mac-notarization/kind.yml
+++ b/taskcluster/kinds/mac-notarization/kind.yml
@@ -32,7 +32,7 @@ tasks:
             upstream-artifacts:
                 - taskId:
                       task-reference: <repackage-signing>
-                  taskType: repackage-signing
+                  taskType: signing
                   paths:
                       - public/build/MozillaVPN.pkg
                   formats:


### PR DESCRIPTION
## Description
After merging PR #10604 we are correctly producing signed macOS installer packages, but the notarization task fails with an error like the following:

```
2025-06-26T22:07:39     INFO - Running scriptworker version 60.10.2
2025-06-26T22:07:39     INFO - build_task_dependencies scriptworker aTNCHHK7S8KmgPiPiQsHbw
2025-06-26T22:07:39     INFO - find_sorted_task_dependencies scriptworker aTNCHHK7S8KmgPiPiQsHbw
2025-06-26T22:07:39     INFO - found dependencies: [('scriptworker:parent', 'G3KSWn_ZS0KWmT5AkSRYNQ'), ('scriptworker:repackage-signing', 'IbZr3rUOT9K7f0gT9cIyqw')]
2025-06-26T22:07:39    DEBUG -  scriptworker:parent G3KSWn_ZS0KWmT5AkSRYNQ is docker-worker
2025-06-26T22:07:39    DEBUG -  makedirs(/app/workdir/cot/G3KSWn_ZS0KWmT5AkSRYNQ)
2025-06-26T22:07:39     INFO - build_task_dependencies scriptworker:parent G3KSWn_ZS0KWmT5AkSRYNQ
2025-06-26T22:07:39     INFO - find_sorted_task_dependencies scriptworker:parent G3KSWn_ZS0KWmT5AkSRYNQ
2025-06-26T22:07:39     INFO - found dependencies: [('scriptworker:parent:parent', 'G3KSWn_ZS0KWmT5AkSRYNQ')]
2025-06-26T22:07:39 CRITICAL - Chain of Trust verification error!
Traceback (most recent call last):
  File "/app/lib/python3.11/site-packages/scriptworker/cot/verify.py", line 2047, in verify_chain_of_trust
    await build_task_dependencies(chain, chain.task, chain.name, chain.task_id)
  File "/app/lib/python3.11/site-packages/scriptworker/cot/verify.py", line 665, in build_task_dependencies
    await build_link(chain, task_name, task_id)
  File "/app/lib/python3.11/site-packages/scriptworker/cot/verify.py", line 636, in build_link
    link.task = task_defn
    ^^^^^^^^^
  File "/app/lib/python3.11/site-packages/scriptworker/cot/verify.py", line 283, in task
    self.task_type = guess_task_type(self.name, self.task)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/lib/python3.11/site-packages/scriptworker/cot/verify.py", line 430, in guess_task_type
    raise CoTError("Invalid task type for {}!".format(name))
scriptworker.exceptions.CoTError: 'Invalid task type for scriptworker:repackage-signing!'
2025-06-26T22:07:39    ERROR - Hit ScriptWorkerException: 'Invalid task type for scriptworker:repackage-signing!'
2025-06-26T22:07:39    DEBUG -  "/app/artifacts/public/logs/chain_of_trust.log" is encoded with "None" and has mime/type "text/plain"
2025-06-26T22:07:39     INFO - "/app/artifacts/public/logs/chain_of_trust.log" can be gzip'd. Compressing...
```

The problem seems to be caused by a bad `taskType` value in the `mac-notarization` task, which should be `signing` instead of `repackage-signing`

## Reference
Introduced by #10604
JIRA Issue: [VPN-7090](https://mozilla-hub.atlassian.net/browse/VPN-7090)
JIRA Issue: [VPN-7091](https://mozilla-hub.atlassian.net/browse/VPN-7091)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-7090]: https://mozilla-hub.atlassian.net/browse/VPN-7090?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ