### PR TITLE
VPN-7090: Fix codesign identifier detection when building macpkg

### DIFF
--- a/macos/pkg/CMakeLists.txt
+++ b/macos/pkg/CMakeLists.txt
@@ -24,6 +24,25 @@ if(NOT DEFINED MACPKG_SOURCE_BUNDLE)
     endif()
 endif()
 
+if(NOT BUILD_OSX_APP_IDENTIFIER)
+    if(IS_DIRECTORY ${MACPKG_SOURCE_BUNDLE})
+        execute_process(
+            OUTPUT_VARIABLE BUILD_OSX_APP_IDENTIFIER
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+            COMMAND plutil -extract CFBundleIdentifier raw ${MACPKG_SOURCE_BUNDLE}/Contents/Info.plist
+        )
+    else()
+        message(FATAL_ERROR "Unable to determine macOS app bundle identifier")
+    endif()
+endif()
+if(NOT BUILD_VPN_DEVELOPMENT_TEAM)
+    if(CMAKE_XCODE_ATTRIBUTE_DEVELOPMENT_TEAM)
+        set(BUILD_VPN_DEVELOPMENT_TEAM ${CMAKE_XCODE_ATTRIBUTE_DEVELOPMENT_TEAM})
+    else()
+        set(BUILD_VPN_DEVELOPMENT_TEAM 43AQ936H96 CACHE STRING "Mozilla VPN Development Team")
+    endif()
+endif()
+
 ## Stage 1: Preprocess the installation scripts.
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/scripts)
 configure_file(


### PR DESCRIPTION
## Description
During some recent macOS signing changes, we split the generation of the macOS installer package into a separate taskcluster job. Unfortunately, by doing so we introduced a bug where the postinstall codesigning checks were left without app and team identifiers defined. This causes the postinstall script to fail its codesigning checks, resulting in a failed package installation.

To fix this, we can pull the app identifiers out of the application bundle's plist and we provide a sensible default for the development team. 

## Reference
Introduced by: #10594
JIRA Issue: [VPN-7090](https://mozilla-hub.atlassian.net/browse/VPN-7090)
JIRA Issue: [VPN-7091](https://mozilla-hub.atlassian.net/browse/VPN-7091)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-7090]: https://mozilla-hub.atlassian.net/browse/VPN-7090?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[VPN-7091]: https://mozilla-hub.atlassian.net/browse/VPN-7091?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ