### PR TITLE
VPN-7122 fix logs

### DIFF
--- a/src/utils/loghandler.cpp
+++ b/src/utils/loghandler.cpp
@@ -482,6 +482,7 @@ void LogSerializeHelper::addSerializer(LogSerializer* serializer) {
 
   // Serialize the logs to the buffer
   serializer->logSerialize(buffer);
+  buffer->close();
 }
 
 void LogSerializeHelper::run(QIODevice* device) {


### PR DESCRIPTION
## Description

Somewhere in the recent mzutils work, this crept in. We listen to `connect(buffer, &QIODevice::aboutToClose...` in a couple spots, but we weren't closing the buffer.

This also fixes VPN-7106, which also looks for that signal before scheduling the task to submit the support ticket.

## Reference

VPN-7122 and VPN-7106

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
