### PR TITLE
Fix icnsutil when building with Xcode

### DIFF
--- a/src/cmake/macos.cmake
+++ b/src/cmake/macos.cmake
@@ -206,7 +206,7 @@ endwhile()
 add_custom_command(
     OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/AppIcon.icns
     DEPENDS ${APPICON_IMAGE_FILES}
-    COMMAND icnsutil c ${CMAKE_CURRENT_BINARY_DIR}/AppIcon.icns ${APPICON_IMAGE_FILES}
+    COMMAND ${PYTHON_EXECUTABLE} -m icnsutil c ${CMAKE_CURRENT_BINARY_DIR}/AppIcon.icns ${APPICON_IMAGE_FILES}
 )
 
 target_sources(mozillavpn PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/AppIcon.icns)


### PR DESCRIPTION
## Description
We recently added a new `icnsutil` tool to generate the macOS AppIcon, but unfortunately it doesn't quite work on Xcode because the tool doesn't exist in Xcode's paths. To make it work, we need to use a tool that was found in CMake using `find_program` which will ensure it is invoked by the full path.

## Reference
Introduced in PR #10607

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
