### PR TITLE
VPN-7122: Fix view logs when macOS daemon not running

### DIFF
--- a/src/daemon/daemon.h
+++ b/src/daemon/daemon.h
@@ -37,10 +37,10 @@ class Daemon : public QObject {
 
   QJsonObject getStatus();
   QString logs();
-  void cleanLogs();
 
   Q_INVOKABLE bool activate(const QString& json);
   Q_INVOKABLE bool deactivate() { return deactivate(true); };
+  Q_INVOKABLE void cleanLogs();
 
  signals:
   void connected(const QString& pubkey);

--- a/src/platforms/macos/daemon/xpcdaemonserver.mm
+++ b/src/platforms/macos/daemon/xpcdaemonserver.mm
@@ -226,7 +226,7 @@ shouldAcceptNewConnection:(NSXPCConnection *) newConnection {
 }
 
 - (void)cleanupBackendLogs {
-  QMetaObject::invokeMethod(self.daemon, [&]{ self.daemon->cleanLogs(); });
+  QMetaObject::invokeMethod(self.daemon, "cleanLogs");
 }
 
 @end

--- a/src/platforms/macos/macoscontroller.mm
+++ b/src/platforms/macos/macoscontroller.mm
@@ -238,7 +238,13 @@ void MacOSController::checkStatus() {
 }
 
 void MacOSController::getBackendLogs(QIODevice* device) {
-  auto conn = static_cast<NSXPCConnection*>(m_connection);
+  NSXPCConnection* conn = [NSXPCConnection alloc];
+  [conn initWithMachServiceName:machServiceName()
+                        options:NSXPCConnectionPrivileged];
+  conn.remoteObjectInterface =
+      [NSXPCInterface interfaceWithProtocol:@protocol(XpcDaemonProtocol)];
+  [conn activate];
+
   NSObject<XpcDaemonProtocol>* remote =
       [conn remoteObjectProxyWithErrorHandler:^(NSError*error){
     // Otherwise, try our best to scrape the logs directly off disk.


### PR DESCRIPTION
## Description
When we added the XPC service API, we rewrote the implementation of `MacOSController::getBackendLogs()` and we introduced a bug where we can fail to read the logs in a way that never invokes the error handler either. This results in a call to `getBackendLogs()` that never closes the logfile, and results in an incomplete log file.

This occurs when the daemon is not running, and has never successfully been initialized. In such a situation `m_connection` is a null pointer, which results in no XPC call ever being made. To fix this, we can create an ad-hoc XPC connection to the daemon for reading the logs. This should ensure that an attempt is always made to read the logs, regardless of the state of the daemon.

## Reference
JIRA issue: [VPN-7122](https://mozilla-hub.atlassian.net/browse/VPN-7122)
JIRA issue: [VPN-7106](https://mozilla-hub.atlassian.net/browse/VPN-7106)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-7122]: https://mozilla-hub.atlassian.net/browse/VPN-7122?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[VPN-7106]: https://mozilla-hub.atlassian.net/browse/VPN-7106?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ