### PR TITLE
VPN-7133: server location telemetry

### DIFF
--- a/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/VPNService.kt
+++ b/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/VPNService.kt
@@ -78,9 +78,9 @@ class VPNService : android.net.VpnService() {
     private val isServerLocatedInUserCountry: Boolean?
         get() {
             if (this.mConfig?.isNull("serverLocatedInUserCountry") ?: false) {
-              return null
+                return null
             } else {
-              return this.mConfig?.optBoolean("serverLocatedInUserCountry")
+                return this.mConfig?.optBoolean("serverLocatedInUserCountry")
             }
         }
 
@@ -675,7 +675,7 @@ class VPNService : android.net.VpnService() {
         Log.v(tag, "Recording data metrics")
         val isServerInCountry = isServerLocatedInUserCountry // with an open getter, can't directly use isServerLocatedInUserCountry in smart cast
         if (isServerInCountry != null) {
-          Session.serverInSameCountry.set(isServerInCountry)
+            Session.serverInSameCountry.set(isServerInCountry)
         }
         val rxBytes = getConfigValue("rx_bytes")?.toLong()
         val txBytes = getConfigValue("tx_bytes")?.toLong()

--- a/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/VPNService.kt
+++ b/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/VPNService.kt
@@ -77,7 +77,11 @@ class VPNService : android.net.VpnService() {
 
     private val isServerLocatedInUserCountry: Boolean?
         get() {
-            return this.mConfig?.optBoolean("serverLocatedInUserCountry", null)
+            if (this.mConfig?.isNull("serverLocatedInUserCountry") ?: false) {
+              return null
+            } else {
+              return this.mConfig?.optBoolean("serverLocatedInUserCountry")
+            }
         }
 
     // Is a VPN connection coming from the app (not daemon) AND
@@ -669,8 +673,9 @@ class VPNService : android.net.VpnService() {
 
     private fun recordDataTransferMetrics() {
         Log.v(tag, "Recording data metrics")
-        if (isServerLocatedInUserCountry != null) {
-          Session.isServerLocatedInUserCountry.set(isServerLocatedInUserCountry)
+        val isServerInCountry = isServerLocatedInUserCountry // with an open getter, can't directly use isServerLocatedInUserCountry in smart cast
+        if (isServerInCountry != null) {
+          Session.serverInSameCountry.set(isServerInCountry)
         }
         val rxBytes = getConfigValue("rx_bytes")?.toLong()
         val txBytes = getConfigValue("tx_bytes")?.toLong()

--- a/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/VPNService.kt
+++ b/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/VPNService.kt
@@ -75,6 +75,11 @@ class VPNService : android.net.VpnService() {
             return this.mConfig?.optBoolean("isSuperDooperFeatureActive", false) ?: false
         }
 
+    private val isServerLocatedInUserCountry: Boolean?
+        get() {
+            return this.mConfig?.optBoolean("serverLocatedInUserCountry", null)
+        }
+
     // Is a VPN connection coming from the app (not daemon) AND
     // is happening because of a server switch?
     private val isAppChangingServers: Boolean
@@ -664,6 +669,9 @@ class VPNService : android.net.VpnService() {
 
     private fun recordDataTransferMetrics() {
         Log.v(tag, "Recording data metrics")
+        if (isServerLocatedInUserCountry != null) {
+          Session.isServerLocatedInUserCountry.set(isServerLocatedInUserCountry)
+        }
         val rxBytes = getConfigValue("rx_bytes")?.toLong()
         val txBytes = getConfigValue("tx_bytes")?.toLong()
         if (rxBytes != null && txBytes != null) {

--- a/src/models/serverdata.cpp
+++ b/src/models/serverdata.cpp
@@ -10,6 +10,7 @@
 #include "leakdetector.h"
 #include "localizer.h"
 #include "logger.h"
+#include "models/location.h"
 #include "models/servercountrymodel.h"
 #include "mozillavpn.h"
 #include "serverlatency.h"
@@ -190,6 +191,11 @@ QString ServerData::localizedEntryCountryName() const {
 QString ServerData::localizedExitCountryName() const {
   Q_ASSERT(m_initialized);
   return ServerCountry::localizedName(m_exitCountryCode, m_exitCountryName);
+}
+
+bool ServerData::serverLocatedInUserCountry() {
+  QString trueCountryCode = MozillaVPN::instance()->location()->countryCode();
+  return trueCountryCode.toUpper() == exitCountryCode().toUpper();
 }
 
 void ServerData::changeServer(const QString& countryCode,

--- a/src/models/serverdata.h
+++ b/src/models/serverdata.h
@@ -75,6 +75,8 @@ class ServerData final : public QObject {
   QString localizedEntryCityName() const;
   QString localizedEntryCountryName() const;
 
+  bool serverLocatedInUserCountry();
+
   const QString& previousExitCountryCode() const {
     return m_previousExitCountryCode;
   }

--- a/src/platforms/android/androidcontroller.cpp
+++ b/src/platforms/android/androidcontroller.cpp
@@ -23,6 +23,7 @@
 #include "logger.h"
 #include "models/device.h"
 #include "models/keys.h"
+#include "models/location.h"
 #include "models/server.h"
 #include "mozillavpn.h"
 #include "notificationhandler.h"

--- a/src/platforms/android/androidcontroller.cpp
+++ b/src/platforms/android/androidcontroller.cpp
@@ -231,6 +231,14 @@ void AndroidController::activate(const InterfaceConfig& config,
 
   args["isSuperDooperFeatureActive"] =
       Feature::get(Feature::Feature_superDooperMetrics)->isSupported();
+  QString trueCountryCode = MozillaVPN::instance()->location()->countryCode();
+  if (!trueCountryCode.isEmpty()) {
+    args["serverLocatedInUserCountry"] =
+        MozillaVPN::instance()->serverData()->serverLocatedInUserCountry();
+  } else {
+    logger.warning() << "Not setting `server_in_same_country` in Android "
+                        "payload because country code is blank.";
+  }
   args["installationId"] = config.m_installationId;
 
   SettingsHolder* settingsHolder = SettingsHolder::instance();

--- a/src/platforms/ios/ioscontroller.mm
+++ b/src/platforms/ios/ioscontroller.mm
@@ -12,6 +12,7 @@
 #include "logger.h"
 #include "models/device.h"
 #include "models/keys.h"
+#include "models/location.h"
 #include "models/server.h"
 #include "mozillavpn.h"
 #include "settingsholder.h"
@@ -184,11 +185,10 @@ void IOSController::activate(const InterfaceConfig& config, Controller::Reason r
                         : @""
       isSuperDooperFeatureActive:Feature::get(Feature::Feature_superDooperMetrics)->isSupported()
       installationId:config.m_installationId.toNSString()
-      isServerLocatedInUserCountry:MozillaVPN::instance()->location()->countryCode().isEmpty()
-                                       ? nullptr
-                                       : MozillaVPN::instance()
-                                             ->serverData()
-                                             ->serverLocatedInUserCountry()
+      isMissingLocalLocation:MozillaVPN::instance()->location()->countryCode().isEmpty()
+      isServerLocatedInUserCountry:MozillaVPN::instance()
+                                       ->serverData()
+                                       ->serverLocatedInUserCountry()
       disconnectOnErrorCallback:^() {
         logger.error() << "IOSSWiftController - disconnecting";
         emit disconnected();

--- a/src/platforms/ios/ioscontroller.mm
+++ b/src/platforms/ios/ioscontroller.mm
@@ -184,6 +184,11 @@ void IOSController::activate(const InterfaceConfig& config, Controller::Reason r
                         : @""
       isSuperDooperFeatureActive:Feature::get(Feature::Feature_superDooperMetrics)->isSupported()
       installationId:config.m_installationId.toNSString()
+      isServerLocatedInUserCountry:MozillaVPN::instance()->location()->countryCode().isEmpty()
+                                       ? nullptr
+                                       : MozillaVPN::instance()
+                                             ->serverData()
+                                             ->serverLocatedInUserCountry()
       disconnectOnErrorCallback:^() {
         logger.error() << "IOSSWiftController - disconnecting";
         emit disconnected();

--- a/src/platforms/ios/ioscontroller.swift
+++ b/src/platforms/ios/ioscontroller.swift
@@ -162,7 +162,7 @@ public class IOSControllerImpl: NSObject {
     }
 
     @objc func connect(serverData: [VPNServerData], excludeLocalNetworks: Bool, allowedIPAddressRanges: [VPNIPAddressRange], reason: Int,
-            gleanDebugTag: String, isSuperDooperFeatureActive: Bool, installationId: String, isServerLocatedInUserCountry: Bool?,
+            gleanDebugTag: String, isSuperDooperFeatureActive: Bool, installationId: String, isMissingLocalLocation: Bool, isServerLocatedInUserCountry: Bool,
             disconnectOnErrorCallback: @escaping () -> Void, onboardingCompletedCallback: @escaping () -> Void,
             vpnConfigPermissionResponseCallback: @escaping (Bool) -> Void) {
         IOSControllerImpl.logger.debug(message: "Connecting")
@@ -177,7 +177,7 @@ public class IOSControllerImpl: NSObject {
               disconnectOnErrorCallback()
               return
             }
-            return self.configureTunnel(configs: configs, reason: reason, serverName: serverName, excludeLocalNetworks: excludeLocalNetworks, gleanDebugTag: gleanDebugTag, isSuperDooperFeatureActive: isSuperDooperFeatureActive, installationId: installationId, isServerLocatedInUserCountry: isServerLocatedInUserCountry, disconnectOnErrorCallback: disconnectOnErrorCallback, onboardingCompletedCallback: onboardingCompletedCallback, vpnConfigPermissionResponseCallback: vpnConfigPermissionResponseCallback)
+          return self.configureTunnel(configs: configs, reason: reason, serverName: serverName, excludeLocalNetworks: excludeLocalNetworks, gleanDebugTag: gleanDebugTag, isSuperDooperFeatureActive: isSuperDooperFeatureActive, installationId: installationId, isServerLocatedInUserCountry: !isMissingLocalLocation ? isServerLocatedInUserCountry : nil, disconnectOnErrorCallback: disconnectOnErrorCallback, onboardingCompletedCallback: onboardingCompletedCallback, vpnConfigPermissionResponseCallback: vpnConfigPermissionResponseCallback)
         }
     }
 

--- a/src/platforms/ios/ioscontroller.swift
+++ b/src/platforms/ios/ioscontroller.swift
@@ -162,7 +162,7 @@ public class IOSControllerImpl: NSObject {
     }
 
     @objc func connect(serverData: [VPNServerData], excludeLocalNetworks: Bool, allowedIPAddressRanges: [VPNIPAddressRange], reason: Int,
-            gleanDebugTag: String, isSuperDooperFeatureActive: Bool, installationId: String,
+            gleanDebugTag: String, isSuperDooperFeatureActive: Bool, installationId: String, isServerLocatedInUserCountry: Bool?,
             disconnectOnErrorCallback: @escaping () -> Void, onboardingCompletedCallback: @escaping () -> Void,
             vpnConfigPermissionResponseCallback: @escaping (Bool) -> Void) {
         IOSControllerImpl.logger.debug(message: "Connecting")
@@ -177,12 +177,12 @@ public class IOSControllerImpl: NSObject {
               disconnectOnErrorCallback()
               return
             }
-            return self.configureTunnel(configs: configs, reason: reason, serverName: serverName, excludeLocalNetworks: excludeLocalNetworks, gleanDebugTag: gleanDebugTag, isSuperDooperFeatureActive: isSuperDooperFeatureActive, installationId: installationId, disconnectOnErrorCallback: disconnectOnErrorCallback, onboardingCompletedCallback: onboardingCompletedCallback, vpnConfigPermissionResponseCallback: vpnConfigPermissionResponseCallback)
+            return self.configureTunnel(configs: configs, reason: reason, serverName: serverName, excludeLocalNetworks: excludeLocalNetworks, gleanDebugTag: gleanDebugTag, isSuperDooperFeatureActive: isSuperDooperFeatureActive, installationId: installationId, isServerLocatedInUserCountry: isServerLocatedInUserCountry, disconnectOnErrorCallback: disconnectOnErrorCallback, onboardingCompletedCallback: onboardingCompletedCallback, vpnConfigPermissionResponseCallback: vpnConfigPermissionResponseCallback)
         }
     }
 
     func configureTunnel(configs: [TunnelConfiguration], reason: Int, serverName: String, excludeLocalNetworks: Bool,
-            gleanDebugTag: String, isSuperDooperFeatureActive: Bool, installationId: String,
+            gleanDebugTag: String, isSuperDooperFeatureActive: Bool, installationId: String, isServerLocatedInUserCountry: Bool?,
             disconnectOnErrorCallback: @escaping () -> Void, onboardingCompletedCallback: @escaping () -> Void,
             vpnConfigPermissionResponseCallback: @escaping (Bool) -> Void) {
         TunnelManager.withTunnel { tunnel in
@@ -209,6 +209,7 @@ public class IOSControllerImpl: NSObject {
 
             var customConfig = proto?.providerConfiguration ?? [:]
             customConfig["isSuperDooperFeatureActive"] = isSuperDooperFeatureActive
+            customConfig["isServerLocatedInUserCountry"] = isServerLocatedInUserCountry
             customConfig["gleanDebugTag"] = gleanDebugTag
             customConfig["installationId"] = installationId
             customConfig["configs"] = configs.map({ $0.asWgQuickConfig() })

--- a/src/platforms/ios/iostunnel.swift
+++ b/src/platforms/ios/iostunnel.swift
@@ -169,7 +169,9 @@ class PacketTunnelProvider: NEPacketTunnelProvider, SilentServerSwitching {
             ErrorNotifier.removeLastErrorFile()
             self.connectionHealthMonitor.stop()
             if self.shouldSendTelemetry {
-                GleanMetrics.Session.isServerLocatedInUserCountry.set(isServerLocatedInUserCountry)
+                if let isServerLocatedInUserCountry = self.isServerLocatedInUserCountry {
+                  GleanMetrics.Session.serverInSameCountry.set(isServerLocatedInUserCountry)
+                }
                 GleanMetrics.Session.daemonSessionEnd.set()
                 GleanMetrics.Pings.shared.daemonsession.submit(reason: .daemonEnd)
 

--- a/src/platforms/ios/iostunnel.swift
+++ b/src/platforms/ios/iostunnel.swift
@@ -38,6 +38,10 @@ class PacketTunnelProvider: NEPacketTunnelProvider, SilentServerSwitching {
         return ((protocolConfiguration as? NETunnelProviderProtocol)?.providerConfiguration?["isSuperDooperFeatureActive"] as? Bool) ?? false
     }
 
+    private var isServerLocatedInUserCountry: Bool? {
+        return ((protocolConfiguration as? NETunnelProviderProtocol)?.providerConfiguration?["isServerLocatedInUserCountry"] as? Bool)
+    }
+
     override init() {
         super.init()
 
@@ -165,6 +169,7 @@ class PacketTunnelProvider: NEPacketTunnelProvider, SilentServerSwitching {
             ErrorNotifier.removeLastErrorFile()
             self.connectionHealthMonitor.stop()
             if self.shouldSendTelemetry {
+                GleanMetrics.Session.isServerLocatedInUserCountry.set(isServerLocatedInUserCountry)
                 GleanMetrics.Session.daemonSessionEnd.set()
                 GleanMetrics.Pings.shared.daemonsession.submit(reason: .daemonEnd)
 

--- a/src/platforms/ios/iostunnel.swift
+++ b/src/platforms/ios/iostunnel.swift
@@ -171,6 +171,8 @@ class PacketTunnelProvider: NEPacketTunnelProvider, SilentServerSwitching {
             if self.shouldSendTelemetry {
                 if let isServerLocatedInUserCountry = self.isServerLocatedInUserCountry {
                   GleanMetrics.Session.serverInSameCountry.set(isServerLocatedInUserCountry)
+                } else {
+                  self.logger.error(message: "Not setting serverInSameCountry because no local location was found.")
                 }
                 GleanMetrics.Session.daemonSessionEnd.set()
                 GleanMetrics.Pings.shared.daemonsession.submit(reason: .daemonEnd)

--- a/src/telemetry.cpp
+++ b/src/telemetry.cpp
@@ -12,6 +12,7 @@
 #include "glean/generated/pings.h"
 #include "leakdetector.h"
 #include "logger.h"
+#include "models/location.h"
 #include "mozillavpn.h"
 #include "settingsholder.h"
 
@@ -125,6 +126,18 @@ void Telemetry::initialize() {
               mozilla::glean::connection_health::data_transferred_rx
                   .accumulate_single_sample(rxBytes);
             });
+
+            QString trueCountryCode =
+                MozillaVPN::instance()->location()->countryCode();
+            if (!trueCountryCode.isEmpty()) {
+              mozilla::glean::session::server_in_same_country.set(
+                  MozillaVPN::instance()
+                      ->serverData()
+                      ->serverLocatedInUserCountry());
+            } else {
+              logger.warning() << "Not recording `server_in_same_country` "
+                                  "because country code is blank.";
+            }
           });
 #endif
 }

--- a/src/telemetry/metrics.yaml
+++ b/src/telemetry/metrics.yaml
@@ -276,6 +276,27 @@ session:
         description: True when the daemon has a saved server to switch to, false otherwise.
         type: boolean
 
+  server_in_same_country:
+    type: boolean
+    lifetime: ping
+    description:
+      True if the VPN server's country is the same as the user's actual country.
+
+      When using multihop, the exit server is used.
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/VPN-7133
+    data_reviews:
+      - ADD IN ONCE REVIEW IS COMPLETE
+    send_in_pings:
+      - vpnsession
+      - daemonsession
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - mcleinman@mozilla.com
+      - vpn-telemetry@mozilla.com
+    expires: 2026-06-30
+
 connection_health:
   data_transferred_tx:
     type: custom_distribution


### PR DESCRIPTION
## Description

Adding new telemetry to see if the user connected to a server in the same location that they are located in.

I'm open to feedback on a better name for this metric. Other ones I considered:
- using_in_country_server
- server_in_user_location
- server_in_true_country
- user_country_is_server_country
- server_country_is_user_country
- is_server_location_in_user_country

## Reference

VPN-7133

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
