### PR TITLE
VPN-7138: Update macos index route to use mac-notarization

### DIFF
--- a/taskcluster/kinds/mac-notarization/kind.yml
+++ b/taskcluster/kinds/mac-notarization/kind.yml
@@ -21,6 +21,9 @@ tasks:
             repackage-signing: repackage-signing-macpkg
         if-dependencies:
             - repackage-signing
+        add-index-routes:
+            name: macos
+            type: build
         treeherder:
             symbol: Bn
             kind: build

--- a/taskcluster/kinds/signing/kind.yml
+++ b/taskcluster/kinds/signing/kind.yml
@@ -58,6 +58,7 @@ tasks:
         add-index-routes:
             by-build-type:
                 windows/opt: null  # for Windows we want the 'repackage-signing' task
+                macos/opt: null    # for macOS we want the 'mac-notarization' task
                 default: build
         signing-format:
             by-build-type:


### PR DESCRIPTION
## Description
It seems that the taskcluster index route for the latest macOS build points to the `signing-macos/opt` task. This was a bit dubious before the recent signing changes as this would have linked to a signed-but-not-notarized installer package but after the signing change this now points to an intermediate build artifact.

What this should really point to is either `repackage-signing-macpkg` or `mac-notarization`.

## Reference
JIRA Issue: [VPN-7138](https://mozilla-hub.atlassian.net/browse/VPN-7138)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-7138]: https://mozilla-hub.atlassian.net/browse/VPN-7138?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ