### PR TITLE
VPN-7123: Fix misssing background image in macOS installer

### DIFF
--- a/macos/pkg/CMakeLists.txt
+++ b/macos/pkg/CMakeLists.txt
@@ -112,7 +112,7 @@ foreach(FILENAME ${RESOURCE_FILES})
     add_custom_command(
         OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/Resources/${FILENAME}
         DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/Resources/${FILENAME}
-        COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/Resources/${FILENAME} ${CMAKE_CURRENT_SOURCE_DIR}/Resources
+        COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/Resources/${FILENAME} ${CMAKE_CURRENT_BINARY_DIR}/Resources/
     )
     add_custom_command(
         OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/MozillaVPN.pkg APPEND


### PR DESCRIPTION
## Description
In some recent macOS refactoring, we tweaked how the installer Resources got embedded into the package, and introduced a bug where the non-localized files were coped into the wrong directory and therefore got omitted from the final bundle. 

## Reference
JIRA Issue: [VPN-7123](https://mozilla-hub.atlassian.net/browse/VPN-7123)
Issue caused by: #10594

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-7123]: https://mozilla-hub.atlassian.net/browse/VPN-7123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ