### PR TITLE
VPN-7124: Switch macOS signing behavior to mac_sign_hardened

### DIFF
--- a/taskcluster/mozillavpn_taskgraph/transforms/signing.py
+++ b/taskcluster/mozillavpn_taskgraph/transforms/signing.py
@@ -121,5 +121,5 @@ def add_hardened_sign_config(config, tasks):
         ]
 
         task["worker"]["hardened-sign-config"] = hardened_sign_config
-        task["worker"]["mac-behavior"] = "mac_sign_and_pkg_hardened"
+        task["worker"]["mac-behavior"] = "mac_sign_hardened"
         yield task

--- a/taskcluster/mozillavpn_taskgraph/worker_types.py
+++ b/taskcluster/mozillavpn_taskgraph/worker_types.py
@@ -32,6 +32,7 @@ from voluptuous import Any, Optional, Required
         Required("mac-behavior"): Any(
             "mac_sign_and_pkg_vpn",
             "mac_sign_and_pkg_hardened",
+            "mac_sign_hardened",
             "mac_sign_pkg",
         ),
         Optional("entitlementsUrl"): str,


### PR DESCRIPTION
## Description
In the recent round of macOS signing work, we abandoned the VPN-specific signing behavior and switched to Firefox's `mac_sign_and_pkg_hardened` to produce a signed application. Unfortunately, this created a byproduct `MozillaVPN.pkg` artifact in the signing tasks that isn't suitable for installation.

The subsequent taskcluster jobs ignore this artifact and go on to create a correct installation package in the `repackage-macpkg`and `repackage-signing-macpkg` tasks, so the infrastructure is sound. However, the existence of this byproduct in the `signing-macos/opt` task can lead to confusion. Switching from `mac_sign_and_pkg_hardened` to `mac_sign_hardened` should disable the generation of this unwanted installer package.

## Reference
JIRA Issue [VPN-7124](https://mozilla-hub.atlassian.net/browse/VPN-7124)
Introduced by: #10594

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
