### PR TITLE
VPN-6365: Build mozilla-vpn-keyring package on Taskcluster

### DIFF
--- a/taskcluster/kinds/build/linux.yml
+++ b/taskcluster/kinds/build/linux.yml
@@ -102,3 +102,18 @@ linux64/next-deb:
         docker-image: {in-tree: linux-qt6-build}
     run:
         command: /builds/worker/builder.sh -s
+
+linux64/keyring-deb:
+    description: "Linux Build (APT Keyring)"
+    treeherder:
+        platform: linux/keyring
+    worker:
+        docker-image: {in-tree: build}
+    add-index-routes:
+        name: linux-keyring
+        type: build
+    run:
+        cwd: '{checkout}'
+        command: >-
+            make -C linux/keyring deb &&
+            cp $(find linux -maxdepth 1 -name 'mozilla-vpn-keyring_*') /builds/worker/artifacts/


### PR DESCRIPTION
## Description
In order to deprecate the PPA for Linux package distribution, we need to provide an automated mechanism to migrate users to the Mozilla APT repository for the static builds. The first step is to actually release the `mozilla-vpn-keyring` package which contains the repository configuration details.

## Reference
JIRA Issue: [VPN-6365](https://mozilla-hub.atlassian.net/browse/VPN-6365)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
