### PR TITLE
Fix android rust linker for armv7-a

### DIFF
--- a/scripts/cmake/rustlang.cmake
+++ b/scripts/cmake/rustlang.cmake
@@ -73,17 +73,19 @@ function(__rust_build_toolchain_config)
 endfunction()
 
 if(ANDROID)
+    get_filename_component(ANDROID_TOOLCHAIN_ROOT_BIN ${CMAKE_C_COMPILER} DIRECTORY)
     if(CMAKE_SYSTEM_PROCESSOR STREQUAL "armv7-a")
         set(RUSTC_ANDROID_ARCH armv7-linux-androideabi)
+        set(RUSTC_ANDROID_LINKER ${ANDROID_TOOLCHAIN_ROOT_BIN}/armv7a-linux-androideabi${ANDROID_NATIVE_API_LEVEL}-clang)
     else()
         set(RUSTC_ANDROID_ARCH ${CMAKE_SYSTEM_PROCESSOR}-linux-android)
+        set(RUSTC_ANDROID_LINKER ${ANDROID_TOOLCHAIN_ROOT_BIN}/${RUSTC_ANDROID_ARCH}${ANDROID_NATIVE_API_LEVEL}-clang)
     endif()
     set(RUSTC_ANDROID_ARCH ${RUSTC_ANDROID_ARCH} CACHE STRING "Rust target android architecture")
 
-    get_filename_component(ANDROID_TOOLCHAIN_ROOT_BIN ${CMAKE_C_COMPILER} DIRECTORY)
     __rust_build_toolchain_config(
         FILENAME ${CMAKE_BINARY_DIR}/cargo_home/config.toml
-        RUSTFLAGS "-Clinker=${ANDROID_TOOLCHAIN_ROOT_BIN}/${RUSTC_ANDROID_ARCH}${ANDROID_NATIVE_API_LEVEL}-clang"
+        RUSTFLAGS "-Clinker=${RUSTC_ANDROID_LINKER}"
         ARCH ${RUSTC_ANDROID_ARCH})
 elseif(IOS)
     __rust_build_toolchain_config(


### PR DESCRIPTION
## Description
We have a build failure as a result of PR #10609 which moved some things around in the rustlang configuration. This work caused the incorrect linker path to be provided to the `armv7a` android builds. This is due to the fact that the rustc target architecture is `armv7-linux-androideabi` but the toolchain's linker binary prefix is `armv7a-linux-androideabi` (note the extra `a`).

The `armv7a` architecture is a special case, and it also only happens to be built only on main, which is why we missed the error.

## Reference
Introduced by #10609

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
