### PR TITLE
VPN-7156: Fix view logs in containerized environments

### DIFF
--- a/src/utils.h
+++ b/src/utils.h
@@ -31,7 +31,10 @@ class Utils final : public QObject {
  private:
   Utils() = default;
 
-  bool writeAndShowLogs(QStandardPaths::StandardLocation location);
+  bool writeAndShowLogs(const QString& location);
+  bool writeAndShowLogs(QStandardPaths::StandardLocation location) {
+    return writeAndShowLogs(QStandardPaths::writableLocation(location));
+  }
 };
 
 #endif  // UTILS_H

--- a/src/utils/loghandler.cpp
+++ b/src/utils/loghandler.cpp
@@ -392,7 +392,7 @@ void LogHandler::logSerialize(QIODevice* device) {
 }
 
 bool LogHandler::writeLogsToLocation(
-    QStandardPaths::StandardLocation location,
+    const QString& location,
     std::function<void(const QString& filename)>&& a_callback) {
 #ifdef MZ_DEBUG
   logger.debug() << "Trying to save logs in:" << location;
@@ -402,7 +402,7 @@ bool LogHandler::writeLogsToLocation(
 
   std::function<void(const QString& filename)> callback = std::move(a_callback);
 
-  if (!QFileInfo::exists(QStandardPaths::writableLocation(location))) {
+  if (!QFileInfo::exists(location)) {
     return false;
   }
 
@@ -412,7 +412,7 @@ bool LogHandler::writeLogsToLocation(
   QTextStream(&filename) << m_shortname << "-" << now.year() << "-"
                          << now.month() << "-" << now.day() << LOG_FILE_SUFFIX;
 
-  QDir logDir(QStandardPaths::writableLocation(location));
+  QDir logDir(location);
   QString logFile = logDir.filePath(filename);
 
   if (QFileInfo::exists(logFile)) {

--- a/src/utils/loghandler.h
+++ b/src/utils/loghandler.h
@@ -99,7 +99,7 @@ class LogHandler final : public QObject, public LogSerializer {
   void logSerialize(QIODevice* device) override;
 
   bool writeLogsToLocation(
-      QStandardPaths::StandardLocation location,
+      const QString& location,
       std::function<void(const QString& filename)>&& a_callback);
 
   void registerLogSerializer(LogSerializer* logSerializer);


### PR DESCRIPTION
## Description
Now that things are moving again with Flatpak distribution, I have done some testing discovered that the view logs link doesn't work as expected when running in a Flatpak, or any sandboxed environment for that matter.

The problem is that we look for the following paths to write logs:
- desktop
- home
- tmp

But, none these paths are not reachable outside the sandbox, so when the client tries to open a URL to the log file, it doesn't get translated into anything the host environment can access. To fix this, we should try to write the logs first to the path indicated by the [XDG_DATA_HOME](https://specifications.freedesktop.org/basedir-spec/latest/#variables) environment variable.

## Reference
JIRA issue: [VPN-7156](https://mozilla-hub.atlassian.net/browse/VPN-7156)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-7156]: https://mozilla-hub.atlassian.net/browse/VPN-7156?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ