### PR TITLE
VPN-7157: Disable IFF_PROMISC on VPN network interface

### DIFF
--- a/src/platforms/linux/daemon/iputilslinux.cpp
+++ b/src/platforms/linux/daemon/iputilslinux.cpp
@@ -65,6 +65,7 @@ bool IPUtilsLinux::setMTUAndUp(const InterfaceConfig& config) {
 
   // Up
   ifr.ifr_flags |= (IFF_UP | IFF_RUNNING);
+  ifr.ifr_flags &= ~IFF_PROMISC;
   ret = ioctl(sockfd, SIOCSIFFLAGS, &ifr);
   if (ret) {
     logger.error() << "Failed to set device up -- Return code: " << ret;


### PR DESCRIPTION
## Description
It seems like the default interface flags for Wireguard include `IFF_PROMISC` which some users seem to find undesirable. We don't need this flag to be set for any particular reason, so it shouldn't do any harm to disable it.

## Reference
JIRA issue: [VPN-7157](https://mozilla-hub.atlassian.net/browse/VPN-7157)
Github issue: #10541

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-7157]: https://mozilla-hub.atlassian.net/browse/VPN-7157?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ