### PR TITLE
VPN-7153: Fix setting of rpath for ios/frameworks

### DIFF
--- a/scripts/cmake/rustlang.cmake
+++ b/scripts/cmake/rustlang.cmake
@@ -90,7 +90,7 @@ if(ANDROID)
 elseif(IOS)
     __rust_build_toolchain_config(
         FILENAME ${CMAKE_BINARY_DIR}/cargo_home/config.toml
-        RUSTFLAGS -Clinker=${CMAKE_LINKER} -Clinker-flavor=ld
+        RUSTFLAGS -Clinker=${CMAKE_C_COMPILER}
         ARCH aarch64-apple-ios x86_64-apple-ios aarch64-apple-ios-sim)
 
     # Ensure that the host architecture uses /usr/bin/cc for linking.

--- a/scripts/cmake/rustlang.cmake
+++ b/scripts/cmake/rustlang.cmake
@@ -340,7 +340,7 @@ function(add_rust_library TARGET_NAME)
     endif()
 
     ## For build Apple shared binaries, the install path needs to be relative to the runpath.
-    if (RUST_BUILD_SHARED AND APPLE)
+    if (RUST_TARGET_SHARED AND APPLE)
         list(APPEND RUST_TARGET_CARGO_ENV "RUSTC_LINK_ARG=-Wl,-install_name,@rpath/${RUST_TARGET_FW_NAME}.framework/${RUST_TARGET_FW_NAME}")
     endif()
 
@@ -448,6 +448,7 @@ function(add_rust_library TARGET_NAME)
             IMPORTED_LOCATION_DEBUG ${RUST_TARGET_BINARY_DIR}/${RUST_FIRST_ARCH}/debug/${RUST_LIBRARY_FILENAME}
         )
     endif()
+
     set_target_properties(${TARGET_NAME}_builder PROPERTIES FOLDER "Libs")
     if (ANDROID AND RUST_TARGET_SHARED)
         set_target_properties(${TARGET_NAME} PROPERTIES


### PR DESCRIPTION
## Description
In PR https://github.com/mozilla-mobile/mozilla-vpn-client/pull/10609 we tried to merge all the rustlang environment hacking into a common config.toml file, which mostly worked, but in that change it seems like we broke the setting of the library rpath for iOS Frameworks.

This should fix the issue by reverting some of the changes to the iOS rustlang environment and addressing a copy/paste error (`RUST_BUILD_SHARED` is not defined in `add_rust_library()`).

This is not my preferred fix, but should provide an alternative approach if #10648 doesn't work.

## Reference
JIRA Issue [VPN-7153](https://mozilla-hub.atlassian.net/browse/VPN-7153)
Bug introduced by PR #10609

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-7153]: https://mozilla-hub.atlassian.net/browse/VPN-7153?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ