### PR TITLE
VPN-7153: Use install_name_tool to set rpath for iOS frameworks

### DIFF
--- a/scripts/cmake/rustlang.cmake
+++ b/scripts/cmake/rustlang.cmake
@@ -339,11 +339,6 @@ function(add_rust_library TARGET_NAME)
         endif()
     endif()
 
-    ## For build Apple shared binaries, the install path needs to be relative to the runpath.
-    if (RUST_BUILD_SHARED AND APPLE)
-        list(APPEND RUST_TARGET_CARGO_ENV "RUSTC_LINK_ARG=-Wl,-install_name,@rpath/${RUST_TARGET_FW_NAME}.framework/${RUST_TARGET_FW_NAME}")
-    endif()
-
     get_rust_library_filename(${RUST_TARGET_SHARED} ${RUST_TARGET_CRATE_NAME})
 
     ## Build the rust library file(s)
@@ -378,31 +373,21 @@ function(add_rust_library TARGET_NAME)
             add_custom_command(
                 OUTPUT ${RUST_TARGET_BINARY_DIR}/unified/release/${RUST_TARGET_FW_NAME}.framework
                 DEPENDS ${RUST_TARGET_RELEASE_LIBS}
-                COMMAND ${CMAKE_COMMAND} -E make_directory
-                    \"${RUST_TARGET_BINARY_DIR}/unified/release/${RUST_TARGET_FW_NAME}.framework\"
-                COMMAND lipo 
-                    -create
-                    ${RUST_TARGET_RELEASE_LIBS}
-                    -output
-                    \"${RUST_TARGET_BINARY_DIR}/unified/release/${RUST_TARGET_FW_NAME}.framework/${RUST_TARGET_FW_NAME}\"
-                COMMAND cp -v
-                    \"${FW_INFO_PLIST_FILE_PATH}\"
-                    \"${RUST_TARGET_BINARY_DIR}/unified/release/${RUST_TARGET_FW_NAME}.framework/Info.plist\"
+                WORKING_DIRECTORY ${RUST_TARGET_BINARY_DIR}
+                COMMAND ${CMAKE_COMMAND} -E make_directory unified/release/${RUST_TARGET_FW_NAME}.framework
+                COMMAND ${CMAKE_COMMAND} -E copy ${FW_INFO_PLIST_FILE_PATH} unified/release/${RUST_TARGET_FW_NAME}.framework/Info.plist
+                COMMAND lipo -create ${RUST_TARGET_RELEASE_LIBS} -output unified/release/${RUST_TARGET_FW_NAME}.framework/${RUST_TARGET_FW_NAME}
+                COMMAND install_name_tool -add_rpath @rpath/${RUST_TARGET_FW_NAME}.framework/${RUST_TARGET_FW_NAME} unified/release/${RUST_TARGET_FW_NAME}.framework/${RUST_TARGET_FW_NAME}
             )
 
             add_custom_command(
                 OUTPUT ${RUST_TARGET_BINARY_DIR}/unified/debug/${RUST_TARGET_FW_NAME}.framework
                 DEPENDS ${RUST_TARGET_DEBUG_LIBS}
-                COMMAND ${CMAKE_COMMAND} -E make_directory
-                    \"${RUST_TARGET_BINARY_DIR}/unified/debug/${RUST_TARGET_FW_NAME}.framework\"
-                COMMAND lipo 
-                    -create
-                    ${RUST_TARGET_DEBUG_LIBS}
-                    -output
-                    \"${RUST_TARGET_BINARY_DIR}/unified/debug/${RUST_TARGET_FW_NAME}.framework/${RUST_TARGET_FW_NAME}\"
-                COMMAND cp -v
-                    \"${FW_INFO_PLIST_FILE_PATH}\"
-                    \"${RUST_TARGET_BINARY_DIR}/unified/debug/${RUST_TARGET_FW_NAME}.framework/Info.plist\"
+                WORKING_DIRECTORY ${RUST_TARGET_BINARY_DIR}
+                COMMAND ${CMAKE_COMMAND} -E make_directory ${RUST_TARGET_BINARY_DIR}/unified/debug/${RUST_TARGET_FW_NAME}.framework
+                COMMAND ${CMAKE_COMMAND} -E copy ${FW_INFO_PLIST_FILE_PATH} unified/debug/${RUST_TARGET_FW_NAME}.framework/Info.plist
+                COMMAND lipo -create ${RUST_TARGET_DEBUG_LIBS} -output unified/debug/${RUST_TARGET_FW_NAME}.framework/${RUST_TARGET_FW_NAME}
+                COMMAND install_name_tool -add_rpath @rpath/${RUST_TARGET_FW_NAME}.framework/${RUST_TARGET_FW_NAME} unified/debug/${RUST_TARGET_FW_NAME}.framework/${RUST_TARGET_FW_NAME}
             )
 
             add_custom_target(${TARGET_NAME}_builder


### PR DESCRIPTION
## Description
In PR #10609 we tried to merge all the rustlang environment hacking into a common `config.toml` file, which mostly worked, but in that change it seems like we broke the setting of the library rpath for iOS Frameworks.

This attempts to fix the issue by setting the rpath after the build using the `install_name_tool` program, after which we can remove the linker arguments.

## Reference

JIRA Issue [VPN-7153](https://mozilla-hub.atlassian.net/browse/VPN-7153)
Bug introduced by PR https://github.com/mozilla-mobile/mozilla-vpn-client/pull/10609

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-7153]: https://mozilla-hub.atlassian.net/browse/VPN-7153?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ