### PR TITLE
VPN-7142: Fix helper tool installation on macOS < 13

### DIFF
--- a/macos/pkg/scripts/postinstall.in
+++ b/macos/pkg/scripts/postinstall.in
@@ -79,6 +79,10 @@ fi
 # of the SMAppService interface.
 if [ ${OSX_MAJOR_VER} -lt 13 ]; then
   echo "Installing privileged helper tool"
+  if [ ! -d /Library/PrivilegedHelperTools ]; then
+    mkdir -m 755 /Library/PrivilegedHelperTools
+    chown root:wheel /Library/PrivilegedHelperTools
+  fi
   touch $DAEMON_HELPER_TOOL
   chown root:wheel $DAEMON_HELPER_TOOL
   chmod 744 $DAEMON_HELPER_TOOL


### PR DESCRIPTION
## Description
When installing on macOS versions < 13, we can't use `SMAppService` and have to fall back to a privileged helper tool. This works by installing a script into `/Library/PrivilegedHelperTools` that validates the codesign and launches the daemon. However, if the `PrivilegedHelperTools` directory doesn't exist (eg: no other software has ever created it), then the `postinstall` script can fail.

## Reference
JIRA Issue: [VPN-7142](https://mozilla-hub.atlassian.net/browse/VPN-7142)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
