### PR TITLE
Set both rpath and id using install_name_tool

### DIFF
--- a/scripts/cmake/rustlang.cmake
+++ b/scripts/cmake/rustlang.cmake
@@ -377,7 +377,9 @@ function(add_rust_library TARGET_NAME)
                 COMMAND ${CMAKE_COMMAND} -E make_directory unified/release/${RUST_TARGET_FW_NAME}.framework
                 COMMAND ${CMAKE_COMMAND} -E copy ${FW_INFO_PLIST_FILE_PATH} unified/release/${RUST_TARGET_FW_NAME}.framework/Info.plist
                 COMMAND lipo -create ${RUST_TARGET_RELEASE_LIBS} -output unified/release/${RUST_TARGET_FW_NAME}.framework/${RUST_TARGET_FW_NAME}
-                COMMAND install_name_tool -add_rpath @rpath/${RUST_TARGET_FW_NAME}.framework/${RUST_TARGET_FW_NAME} unified/release/${RUST_TARGET_FW_NAME}.framework/${RUST_TARGET_FW_NAME}
+                COMMAND install_name_tool unified/release/${RUST_TARGET_FW_NAME}.framework/${RUST_TARGET_FW_NAME}
+                            -add_rpath @rpath/${RUST_TARGET_FW_NAME}.framework/${RUST_TARGET_FW_NAME}
+                            -id @rpath/${RUST_TARGET_FW_NAME}.framework/${RUST_TARGET_FW_NAME}
             )
 
             add_custom_command(
@@ -387,7 +389,9 @@ function(add_rust_library TARGET_NAME)
                 COMMAND ${CMAKE_COMMAND} -E make_directory ${RUST_TARGET_BINARY_DIR}/unified/debug/${RUST_TARGET_FW_NAME}.framework
                 COMMAND ${CMAKE_COMMAND} -E copy ${FW_INFO_PLIST_FILE_PATH} unified/debug/${RUST_TARGET_FW_NAME}.framework/Info.plist
                 COMMAND lipo -create ${RUST_TARGET_DEBUG_LIBS} -output unified/debug/${RUST_TARGET_FW_NAME}.framework/${RUST_TARGET_FW_NAME}
-                COMMAND install_name_tool -add_rpath @rpath/${RUST_TARGET_FW_NAME}.framework/${RUST_TARGET_FW_NAME} unified/debug/${RUST_TARGET_FW_NAME}.framework/${RUST_TARGET_FW_NAME}
+                COMMAND install_name_tool unified/debug/${RUST_TARGET_FW_NAME}.framework/${RUST_TARGET_FW_NAME}
+                            -add_rpath @rpath/${RUST_TARGET_FW_NAME}.framework/${RUST_TARGET_FW_NAME}
+                            -id @rpath/${RUST_TARGET_FW_NAME}.framework/${RUST_TARGET_FW_NAME}
             )
 
             add_custom_target(${TARGET_NAME}_builder


### PR DESCRIPTION
## Description
Seems like our attempt to fix the rpath loading issues for the `QtGleanBindings` framework failed and still results in an iOS build that fails to launch. Digging a little deeper into the `otool` output between version 2.29.0 and 2.30.0 it seems that we missed the setting of `LC_ID_DYLIB` which was `@rpath/QtGleanBindings.framework` in 2.29.0 and some ugly path into the repository on 2.30.0.

In fact, the 2.29.0 release, didn't set an `LC_RPATH` at all, so think the proper fix is to just set `LC_ID_DYLIB`. This chan be achieved using  the `-id <name>` argument to `install_name_tool`

## Reference
Last attempt: #10648
JIRA Issue: [VPN-7153](https://mozilla-hub.atlassian.net/browse/VPN-7153)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
