### PR TITLE
Maybe fix TestAddonApi timed callback test

### DIFF
--- a/tests/unit_tests/addons/api_settimedcallback.js
+++ b/tests/unit_tests/addons/api_settimedcallback.js
@@ -1,3 +1,7 @@
 (function(api, condition) {
-    api.setTimedCallback(1000, () => condition.enable());
+    api.log("settimedcallback started");
+    api.setTimedCallback(1000, () => {
+        api.log("settimedcallback fired");
+        condition.enable();
+    });
 });

--- a/tests/unit_tests/testaddonapi.cpp
+++ b/tests/unit_tests/testaddonapi.cpp
@@ -207,23 +207,13 @@ void TestAddonApi::settimedcallback() {
   AddonConditionWatcher* a = AddonConditionWatcherJavascript::maybeCreate(
       message, ":/addons_test/api_settimedcallback.js");
   QVERIFY(!!a);
-
-  QTimer timer;
-
-  int timeoutPeriodMsec = 1000;
-
-  timer.setSingleShot(true);
-  timer.start(timeoutPeriodMsec);
-
-  QSignalSpy spy(&timer, &QTimer::timeout);
+  QVERIFY(!a->conditionApplied());
 
   // Give the slot time to execute
+  int timeoutPeriodMsec = 1000;
   QTest::qWait(timeoutPeriodMsec + 1000);
 
-  QObject::connect(&timer, &QTimer::timeout,
-                   [&]() { QVERIFY(a->conditionApplied()); });
-
-  QCOMPARE(spy.count(), 1);
+  QVERIFY(a->conditionApplied());
 }
 
 static TestAddonApi s_testAddonApi;

--- a/tests/unit_tests/testaddonapi.cpp
+++ b/tests/unit_tests/testaddonapi.cpp
@@ -208,12 +208,7 @@ void TestAddonApi::settimedcallback() {
       message, ":/addons_test/api_settimedcallback.js");
   QVERIFY(!!a);
   QVERIFY(!a->conditionApplied());
-
-  // Give the slot time to execute
-  int timeoutPeriodMsec = 1000;
-  QTest::qWait(timeoutPeriodMsec + 1000);
-
-  QVERIFY(a->conditionApplied());
+  QTRY_VERIFY_WITH_TIMEOUT(a->conditionApplied(), 3000);
 }
 
 static TestAddonApi s_testAddonApi;


### PR DESCRIPTION
## Description
We have a flaky unit test on macOS in `TestAddonApi` and reading through the test, I don't think it's really testing anything... so let's rewrite it to actually excercise the timed callback.

The test works by creating an addon with a timed callback, waiting for the callback to verify and then checking the condition. But the verification check is connected to a timer *after* it expires so it likely never runs.

There is also a bit of an anomaly in the failed test runs, with the timestamps showing that `qWait()` ran for more than twice as long as expected, indicating something janky is happening. So lets swap that out with `QTRY_VERIFY()` instead.

## Reference

    i.e Jira or Github issue URL

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
