### PR TITLE
Revert "VPN-7092: Move from Taskcluster to Xcode Cloud for iOS test builds (#10640)"

### DIFF
--- a/taskcluster/kinds/build/ios.yml
+++ b/taskcluster/kinds/build/ios.yml
@@ -1,0 +1,34 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+---
+task-defaults:
+    description: "IOS Debug Build"
+    treeherder:
+        symbol: BD
+        kind: build
+        tier: 1
+        platform: ios/arm64
+    worker-type: b-macos
+    fetches:
+        fetch:
+            - miniconda-osx
+    worker:
+        taskcluster-proxy: true
+        chain-of-trust: true
+        max-run-time: 3600
+    release-artifacts:
+        - MozillaVPN.tar.gz
+    run:
+        using: run-task
+        use-caches: []
+        cwd: '{checkout}'
+        command: ./taskcluster/scripts/build/ios_build_debug.sh
+
+ios-arm64/debug:
+    description: "IOS Debug Build"
+    treeherder:
+        symbol: BD
+    fetches:
+        toolchain:
+            - conda-ios-6.6.0

--- a/taskcluster/kinds/build/kind.yml
+++ b/taskcluster/kinds/build/kind.yml
@@ -24,4 +24,5 @@ tasks-from:
     - android.yml
     - macos.yml
     - wasm.yml
+    - ios.yml
     - addons.yml

--- a/taskcluster/kinds/toolchain/conda_osx.yml
+++ b/taskcluster/kinds/toolchain/conda_osx.yml
@@ -13,11 +13,23 @@ task-defaults:
             QT_VERSION: "6.6.3"
     worker-type: b-macos
     run:
+        script: conda_pack_ios.sh
         use-caches: []
         resources:
             - requirements.txt
             - env-apple.yml
             - scripts/macos/conda_setup_qt.sh
+
+
+conda-ios-x86_64-6.6.0:
+        treeherder:
+            symbol: "conda-ios-6.6"
+        worker:
+            env:
+                QT_VERSION: "6.6.0"
+        run:
+            toolchain-alias: conda-ios-6.6.0
+            toolchain-artifact: public/build/conda-ios.tar.gz
 
 conda-macos:
     treeherder:

--- a/taskcluster/kinds/toolchain/qt.yml
+++ b/taskcluster/kinds/toolchain/qt.yml
@@ -42,6 +42,23 @@ qt-windows-x86_64-6.6:
         platform: windows/x86_64
     worker-type: b-win2022
 
+qt-ios:
+    description: "QT ios bundle Task"
+    run:
+        script: bundle_qt_ios.sh
+        resources:
+            - taskcluster/scripts/toolchain/bundle_qt_ios.sh
+        toolchain-alias: qt-ios
+        toolchain-artifact: public/build/qt6_ios.zip
+    treeherder:
+        symbol: TL(qt-ios)
+    worker-type: b-linux
+    worker:
+        docker-image: {in-tree: base}
+        env:
+            QT_VERSION: "6.2.4"
+            QT_MAJOR: "6.2"
+
 qt-linux:
     description: "Linux QT compile Task"
     fetches:

--- a/taskcluster/scripts/build/ios_build_debug.sh
+++ b/taskcluster/scripts/build/ios_build_debug.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+set -xe
+
+
+. $(dirname $0)/../../../scripts/utils/commons.sh
+
+# Find the Output Directory and clear that
+TASK_HOME=$(dirname "${MOZ_FETCHES_DIR}" )
+rm -rf "${TASK_HOME}/artifacts"
+mkdir -p "${TASK_HOME}/artifacts"
+
+
+print N "Taskcluster iOS compilation script"
+print N ""
+
+
+# TC NIT: we need to assert
+# that everything is UTF-8
+export LC_ALL=en_US.utf-8
+export LANG=en_US.utf-8
+export PYTHONIOENCODING="UTF-8"
+
+print Y "Installing conda"
+# We need to call bash with a login shell, so that conda is intitialized
+source $TASK_WORKDIR/fetches/bin/activate
+conda-unpack
+
+# Should already have been done by taskcluser, but double checking c:
+print Y "Get the submodules..."
+git submodule update --init --recursive || die "Failed to init submodules"
+print G "done."
+
+print Y "Configuring the build..."
+
+if [ -d ${TASK_HOME}/build ]; then
+    echo "Found old build-folder, weird!"
+    echo "Removing it..."
+    rm -r ${TASK_HOME}/build
+fi
+mkdir ${TASK_HOME}/build
+
+# Clear the SDKROOT and rely on CMake to figure it out. Otherwise, if this
+# is set to the host SDK it will break the iOS toolchain detection.
+unset SDKROOT
+
+$TASK_WORKDIR/fetches/bin/qt-cmake -S . -B ${TASK_HOME}/build \
+  -DCMAKE_OSX_ARCHITECTURES="arm64" \
+  -DCMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY="" \
+  -DCMAKE_XCODE_ATTRIBUTE_CODE_SIGNING_REQUIRED="NO" \
+  -DCMAKE_XCODE_ATTRIBUTE_CODE_SIGNING_ALLOWED="NO" \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DBUILD_TESTS=OFF
+
+print Y "Building the client..."
+cmake --build ${TASK_HOME}/build --config Release || die
+
+print Y "Exporting the build artifacts..."
+mkdir -p tmp || die
+cp -r ${TASK_HOME}/build/src/Release-iphoneos/* tmp || die
+
+print Y "Compressing the build artifacts..."
+tar -C tmp -czvf "${TASK_HOME}/artifacts/MozillaVPN.tar.gz" . || die
+rm -rf tmp || die
+rm -rf ${TASK_HOME}/build || die
+
+# Check for unintended writes to the source directory.
+print G "Ensuring the source dir is clean:"
+./scripts/utils/dirtycheck.sh
+
+print G "Done!"

--- a/taskcluster/scripts/toolchain/bundle_qt_ios.sh
+++ b/taskcluster/scripts/toolchain/bundle_qt_ios.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# This script creates a qt-bundle that we can use in xcode-cloud and 
+# in the taskcluser/ios builds ( to be coming ... )
+
+python3 -m pip install --upgrade pip
+python3 -m pip install --upgrade aqtinstall
+
+aqt install-qt -O qt_ios mac desktop $QT_VERSION -m qtwebsockets qt5compat qtnetworkauth
+aqt install-qt -O qt_ios mac ios $QT_VERSION -m qtwebsockets qt5compat qtnetworkauth
+
+zip -qr $UPLOAD_DIR/qt6_ios.zip qt_ios/*
+

--- a/taskcluster/scripts/toolchain/conda_pack_ios.sh
+++ b/taskcluster/scripts/toolchain/conda_pack_ios.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+set -e
+
+echo pwd 
+ls 
+cd vcs
+ls 
+
+
+
+# save the passed QT_Version
+# as that will be overwritten once 
+# we enable the env-apple.yml
+BACKUP_QT_VERSION=${QT_VERSION}
+chmod +x ${MOZ_FETCHES_DIR}/miniconda.sh
+bash ${MOZ_FETCHES_DIR}/miniconda.sh -b -u -p .
+source bin/activate
+
+# Normally pip is locked down to only 
+# allow download from moz-pip mirror. 
+# The packages are firefox only and everything
+# we're going to fetch is pinned down, so 
+# let's remove that restriction for the current task. 
+rm -f ~/.config/pip/pip.conf
+pip config --user set install.no-index 0 
+pip config debug
+
+conda env create -f env-apple.yml -n vpn
+conda activate vpn
+echo "SETTING QT_VERSION=${BACKUP_QT_VERSION}"
+conda env config vars set QT_VERSION=${BACKUP_QT_VERSION}
+# Re-enable to apply
+env
+conda deactivate
+
+conda run -n vpn ./scripts/macos/conda_setup_qt.sh
+conda run -n vpn conda info
+conda install conda-pack -y
+
+mkdir -p ../../public/build
+find ../../public/build/ -mindepth 1 -delete
+
+conda-pack -p envs/vpn -o conda-ios.tar.gz
+mv conda-ios.tar.gz  ../../public/build
+
+# remove our Pip conf, so the restrictions are back. 
+rm -f ~/.config/pip/pip.conf

--- a/taskcluster/test/params/release-promotion-promote-addons.yml
+++ b/taskcluster/test/params/release-promotion-promote-addons.yml
@@ -22,6 +22,7 @@ existing_tasks:
   build-docker-image-build: OiiIOA8BQPmzMeqF-_FuBw
   build-docker-image-lint: Kzoqg9mgQQ2DAzfjaQBz-A
   build-docker-image-wasm: fFfeWVUQTY-m1bbJGwhtqw
+  build-ios/debug: cX6WjYQ4RnaNrNhItxYBeA
   build-linux/opt: BEe2AnFPRhSdi1EEaEZvcg
   build-macos/opt: LtezQlIiSluUubmPzb4Q1g
   build-wasm/opt: V3DmBEM3SMKQ7QqU23dFVw
@@ -43,6 +44,7 @@ existing_tasks:
   signing-windows/opt: CoxpMyQgT2OkcQA_3MAHfg
   test-taskgraph-definition: AzkgKc07TFGLeEY2pMgJog
   toolchain-openssl-win: YBVSnsOlS4SCezclXnphag
+  toolchain-qt-ios: Cs-gByGmRXGSKgCjinEMmw
   toolchain-qt-mac: ZXY0C1bQQ82jE3fa2f51xg
   toolchain-qt-win: G1GO1AWXRkiuGFWagSR1xQ
 filters:

--- a/taskcluster/test/params/release-promotion-promote-client.yml
+++ b/taskcluster/test/params/release-promotion-promote-client.yml
@@ -22,6 +22,7 @@ existing_tasks:
   build-docker-image-build: OiiIOA8BQPmzMeqF-_FuBw
   build-docker-image-lint: Kzoqg9mgQQ2DAzfjaQBz-A
   build-docker-image-wasm: fFfeWVUQTY-m1bbJGwhtqw
+  build-ios/debug: cX6WjYQ4RnaNrNhItxYBeA
   build-linux/opt: BEe2AnFPRhSdi1EEaEZvcg
   build-macos/opt: LtezQlIiSluUubmPzb4Q1g
   build-wasm/opt: V3DmBEM3SMKQ7QqU23dFVw
@@ -43,6 +44,7 @@ existing_tasks:
   signing-windows/opt: CoxpMyQgT2OkcQA_3MAHfg
   test-taskgraph-definition: AzkgKc07TFGLeEY2pMgJog
   toolchain-openssl-win: YBVSnsOlS4SCezclXnphag
+  toolchain-qt-ios: Cs-gByGmRXGSKgCjinEMmw
   toolchain-qt-mac: ZXY0C1bQQ82jE3fa2f51xg
   toolchain-qt-win: G1GO1AWXRkiuGFWagSR1xQ
 filters:

--- a/taskcluster/test/params/release-promotion-ship-addons.yml
+++ b/taskcluster/test/params/release-promotion-ship-addons.yml
@@ -22,6 +22,7 @@ existing_tasks:
   build-docker-image-build: OiiIOA8BQPmzMeqF-_FuBw
   build-docker-image-lint: Kzoqg9mgQQ2DAzfjaQBz-A
   build-docker-image-wasm: fFfeWVUQTY-m1bbJGwhtqw
+  build-ios/debug: cX6WjYQ4RnaNrNhItxYBeA
   build-linux/opt: BEe2AnFPRhSdi1EEaEZvcg
   build-macos/opt: LtezQlIiSluUubmPzb4Q1g
   build-wasm/opt: V3DmBEM3SMKQ7QqU23dFVw
@@ -43,6 +44,7 @@ existing_tasks:
   signing-windows/opt: CoxpMyQgT2OkcQA_3MAHfg
   test-taskgraph-definition: AzkgKc07TFGLeEY2pMgJog
   toolchain-openssl-win: YBVSnsOlS4SCezclXnphag
+  toolchain-qt-ios: Cs-gByGmRXGSKgCjinEMmw
   toolchain-qt-mac: ZXY0C1bQQ82jE3fa2f51xg
   toolchain-qt-win: G1GO1AWXRkiuGFWagSR1xQ
 filters:

--- a/taskcluster/test/params/release-promotion-ship-client.yml
+++ b/taskcluster/test/params/release-promotion-ship-client.yml
@@ -22,6 +22,7 @@ existing_tasks:
   build-docker-image-build: OiiIOA8BQPmzMeqF-_FuBw
   build-docker-image-lint: ANCUUUyNR2W7mKRsgL5Q9w
   build-docker-image-wasm: fFfeWVUQTY-m1bbJGwhtqw
+  build-ios/debug: Tvqat7mqT4-JsthTCaSVpA
   build-linux/opt: EHhfiDzVSMaVh8tnVMGezA
   build-macos/opt: YsDBZowUSvKTh2G9pkaYig
   build-wasm/opt: JqlM_tFGTcm_plxOMTd3bQ
@@ -43,6 +44,7 @@ existing_tasks:
   signing-windows/opt: dMuIg-2dSjmICd8cti80WA
   test-taskgraph-definition: EMtIyKY7TxCqFbyB7jiFdA
   toolchain-openssl-win: P_D5Ht0qT-mQLUmBh_Alxg
+  toolchain-qt-ios: Pyw_bgMXRSidDQUOHypXug
   toolchain-qt-mac: ZXY0C1bQQ82jE3fa2f51xg
   toolchain-qt-win: f_3Sw3GiQVOeuaom6G_8Dg
 filters:

--- a/taskcluster/test/params/stage-release-promotion-promote-client.yml
+++ b/taskcluster/test/params/stage-release-promotion-promote-client.yml
@@ -10,6 +10,7 @@ existing_tasks:
   build-android-arm64/debug: FatrFwiXSgqHNKLQbmo2EQ
   build-android-arm64/release: LrM8vfBwToWoyUyEZY75iQ
   build-android-x64/debug: BEdBMoxpRH-leSCwQyokUg
+  build-ios/debug/cmake: SXk_sq61TGmeQAt-aMEOOA
   build-linux/fedora-fc36: a0XHF5AUTqGH6tJ3I-ewqg
   build-linux/fedora-fc37: A5v7lco5SPy7h-8Bu3NS3w
   build-linux/focal: bKHeWPQRR7e0SSnZoctS3g

--- a/taskcluster/test/params/stage-release-promotion-ship-client.yml
+++ b/taskcluster/test/params/stage-release-promotion-ship-client.yml
@@ -10,6 +10,7 @@ existing_tasks:
   build-android-arm64/debug: FatrFwiXSgqHNKLQbmo2EQ
   build-android-arm64/release: LrM8vfBwToWoyUyEZY75iQ
   build-android-x64/debug: BEdBMoxpRH-leSCwQyokUg
+  build-ios/debug/cmake: SXk_sq61TGmeQAt-aMEOOA
   build-linux/fedora-fc36: a0XHF5AUTqGH6tJ3I-ewqg
   build-linux/fedora-fc37: A5v7lco5SPy7h-8Bu3NS3w
   build-linux/focal: bKHeWPQRR7e0SSnZoctS3g


### PR DESCRIPTION
## Description

This reverts commit 27874285aa2bd090c084922de757405778d1af3d.

Back to TaskCluster for iOS - looks like we moved it out prematurely

## Reference

N/A

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
