### PR TITLE
Fix GitHub tests after taskcluster artifact trim

### DIFF
--- a/.github/actions/qt-setup-taskcluster/action.yml
+++ b/.github/actions/qt-setup-taskcluster/action.yml
@@ -58,7 +58,8 @@ runs:
 
     - name: Save Qt for Windows
       uses: actions/cache/save@v4
-      if: ${{ runner.os == 'Windows' && github.event_name == 'pull_request' }}
+      if: ${{ runner.os == 'Windows' }}
       with:
         path: ${{ inputs.dest }}/qt-windows
         key: qt-windows-${{ env.QT6_TOOLCHAIN_TASKID }}
+        enableCrossOsArchive: true

--- a/.github/actions/qt-setup-taskcluster/action.yml
+++ b/.github/actions/qt-setup-taskcluster/action.yml
@@ -42,7 +42,7 @@ runs:
         # contents. Lucky for us, tar is streamable so this just kinda works
         # even though the archive is truncated.
         curl -sSL -r0-4096 "https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/${TASKID}/artifacts/${NAME}" -o qt-toolchain-head.tar.xz
-        echo "toolchain-path=$(tar -tf qt-toolchain-head.tar.xz 2>&1 | head -1 | grep -o '^[^/]*')" >> $GITHUB_OUTPUT
+        echo "toolchain-path=$(xzcat qt-toolchain-head.tar.xz 2>/dev/null | tar t | head -1 | grep -o '^[^/]*')" >> $GITHUB_OUTPUT
 
     - name: Cache Qt toolchain
       uses: actions/cache/restore@v4

--- a/.github/actions/qt-setup-taskcluster/action.yml
+++ b/.github/actions/qt-setup-taskcluster/action.yml
@@ -42,7 +42,7 @@ runs:
         # contents. Lucky for us, tar is streamable so this just kinda works
         # even though the archive is truncated.
         curl -sSL -r0-4096 "https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/${TASKID}/artifacts/${NAME}" -o qt-toolchain-head.tar.xz
-        echo "toolchain-path=$(tar -tf qt-toolchain-head.tar.xz 2>/dev/null | head -1 | grep -o '^[^/]*')" >> $GITHUB_OUTPUT
+        echo "toolchain-path=$(tar -tf qt-toolchain-head.tar.xz 2>&1 | head -1 | grep -o '^[^/]*')" >> $GITHUB_OUTPUT
 
     - name: Cache Qt toolchain
       uses: actions/cache/restore@v4
@@ -74,7 +74,7 @@ runs:
       run: |
         FILENAME=$(basename "${QT6_TOOLCHAIN_URL}")
         curl -sSL "${QT6_TOOLCHAIN_URL}" -o ${FILENAME}
-        tar -xvf ${FILENAME} > "${{ runner.temp }}/manifest-${FILENAME}"
+        tar -xf ${FILENAME}
 
     - name: Setup cmake paths
       if: ${{ inputs.cmake-env }}

--- a/.github/actions/qt-setup-taskcluster/action.yml
+++ b/.github/actions/qt-setup-taskcluster/action.yml
@@ -1,0 +1,37 @@
+name: Setup Qt
+description: Setup Qt from Taskcluster artifacts
+inputs:
+  dest:
+    description: 'Destination path'
+    required: true
+    default: ${{ github.workspace }}/3rdparty
+  toolchain-alias:
+    description: 'Taskcluster toolchain alias'
+    required: false
+    default: ${{ runner.os == 'Windows' && 'qt-windows-x86_64-6.6' || 'qt-macos-6.6' }}
+  toolchain-artifact:
+    description: 'Taskcluster toolchain artifact'
+    required: false
+    default: ${{ runner.os == 'Windows' && 'qt6_win.tar.xz' || 'qt6_macos.tar.xz' }}
+runs:
+  using: "composite"
+  steps:
+    - name: Install xzutils for Windows
+      if: ${{ runner.os == 'Windows' }}
+      shell: bash
+      working-directory: ${{ runner.temp }}
+      env:
+        XZ_UTILS_URL: https://github.com/tukaani-project/xz/releases/download/v5.8.1/xz-5.8.1-windows.zip
+      run: |
+        curl -sSL ${XZ_UTILS_URL} -o xz-5.8.1-windows.zip
+        unzip xz-5.8.1-windows.zip
+        echo "${{ runner.temp }}/xz-5.8.1-windows/bin_x86-64" >> $GITHUB_PATH
+
+    - name: Install Qt toolchain
+      working-directory: ${{ inputs.dest }}
+      shell: bash
+      env:
+        QT6_TOOLCHAIN_URL: https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/mozillavpn.v2.mozillavpn.cache.level-3.toolchains.v3.${{ inputs.toolchain-alias }}.latest/artifacts/public/build/${{ inputs.toolchain-artifact }}
+      run: |
+        curl -sSL "$QT6_TOOLCHAIN_URL" -o ${{ inputs.toolchain-artifact }}
+        tar xvf ${{ inputs.toolchain-artifact }}

--- a/.github/actions/qt-setup-taskcluster/action.yml
+++ b/.github/actions/qt-setup-taskcluster/action.yml
@@ -16,8 +16,25 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Install xzutils for Windows
+    - name: Resolve artifact URL
+      shell: bash
+      env:
+        QT6_INDEX_URL: https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/mozillavpn.v2.mozillavpn.cache.level-3.toolchains.v3.${{ inputs.toolchain-alias }}.latest/artifacts/public/build/${{ inputs.toolchain-artifact }}
+      run: |
+        echo QT6_TOOLCHAIN_URL=$(curl -sS --etag-save "${{ runner.temp }}/qt-artifact-etag.txt" -w "%header{location}" "${QT6_INDEX_URL}" -o /dev/null) >> $GITHUB_ENV
+        echo QT6_TOOLCHAIN_ETAG=$(cat "${{ runner.temp }}/qt-artifact-etag.txt") >> $GITHUB_ENV
+
+    # Tar extraction is painfully slow on Windows, so use a cache instead.
+    - name: Cache Qt for Windows
+      uses: actions/cache@v4
+      id: qt-windows-cache
       if: ${{ runner.os == 'Windows' }}
+      with:
+        path: ${{ inputs.dest }}/qt-windows
+        key: qt-windows-${{ env.QT6_TOOLCHAIN_ETAG }}
+
+    - name: Install xzutils for Windows
+      if: ${{ runner.os == 'Windows' && steps.qt-windows-cache.outputs.cache-hit != 'true' }}
       shell: bash
       working-directory: ${{ runner.temp }}
       env:
@@ -28,10 +45,9 @@ runs:
         echo "${{ runner.temp }}/xz-5.8.1-windows/bin_x86-64" >> $GITHUB_PATH
 
     - name: Install Qt toolchain
+      if: ${{ runner.os != 'Windows' || steps.qt-windows-cache.outputs.cache-hit != 'true' }}
       working-directory: ${{ inputs.dest }}
       shell: bash
-      env:
-        QT6_TOOLCHAIN_URL: https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/mozillavpn.v2.mozillavpn.cache.level-3.toolchains.v3.${{ inputs.toolchain-alias }}.latest/artifacts/public/build/${{ inputs.toolchain-artifact }}
       run: |
         curl -sSL "$QT6_TOOLCHAIN_URL" -o ${{ inputs.toolchain-artifact }}
         tar xvf ${{ inputs.toolchain-artifact }}

--- a/.github/actions/qt-setup-taskcluster/action.yml
+++ b/.github/actions/qt-setup-taskcluster/action.yml
@@ -27,13 +27,13 @@ runs:
 
     # Tar extraction is painfully slow on Windows, so use a cache instead.
     - name: Cache Qt for Windows
-      uses: actions/cache@v4
+      uses: actions/cache/restore@v4
       id: qt-windows-cache
       if: ${{ runner.os == 'Windows' }}
       with:
         path: ${{ inputs.dest }}/qt-windows
         key: qt-windows-${{ env.QT6_TOOLCHAIN_TASKID }}
-        lookup-only: ${{ github.event_name == 'pull_request' }}
+        enableCrossOsArchive: true
 
     - name: Install xzutils for Windows
       if: ${{ runner.os == 'Windows' && steps.qt-windows-cache.outputs.cache-hit != 'true' }}
@@ -55,3 +55,10 @@ runs:
       run: |
         curl -sSL "$QT6_TOOLCHAIN_URL" -o ${{ inputs.toolchain-artifact }}
         tar -xf ${{ inputs.toolchain-artifact }}
+
+    - name: Save Qt for Windows
+      uses: actions/cache/save@v4
+      if: ${{ runner.os == 'Windows' && github.event_name == 'pull_request' }}
+      with:
+        path: ${{ inputs.dest }}/qt-windows
+        key: qt-windows-${{ env.QT6_TOOLCHAIN_TASKID }}

--- a/.github/actions/qt-setup-taskcluster/action.yml
+++ b/.github/actions/qt-setup-taskcluster/action.yml
@@ -32,13 +32,19 @@ runs:
         echo "taskid=${TASKID}" >> $GITHUB_OUTPUT
         echo "filename=${NAME}" >> $GITHUB_OUTPUT
 
-    # Tar extraction is painfully slow on Windows, so use a cache instead.
+        # The cache path depends on the directory path inside the archive.
+        # To find it, lets download the first 4kB of the archive and list its
+        # contents. Lucky for us, tar is streamable so this just kinda works
+        # even though the archive is truncated.
+        curl -sSL -r0-4096 "https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/${TASKID}/artifacts/${NAME}" -o qt-toolchain-head.tar.xz
+        echo "cache-path=$(tar -tf qt-toolchain-head.tar.xz 2>/dev/null | head -1 | grep -o '^[^/]*')" >> $GITHUB_OUTPUT
+
     - name: Cache Qt toolchain
       uses: actions/cache/restore@v4
       id: qt-toolchain-cache
       if: ${{ inputs.cache == 'true' }}
       with:
-        path: ${{ inputs.dest }}
+        path: ${{ inputs.dest }}/${{ steps.resolve.outputs.cache-path }}
         key: qt-toolchain-${{ steps.resolve.outputs.taskid }}
         enableCrossOsArchive: true
 
@@ -64,12 +70,11 @@ runs:
         FILENAME=$(basename "${QT6_TOOLCHAIN_URL}")
         curl -sSL "${QT6_TOOLCHAIN_URL}" -o ${FILENAME}
         tar -xvf ${FILENAME} > "${{ runner.temp }}/manifest-${FILENAME}"
-        echo "cache-path=$(head -1 "${{ runner.temp }}/manifest-${FILENAME}" | grep -o '^[^/]*')" >> $GITHUB_OUTPUT
 
     - name: Save Qt toolchain
       uses: actions/cache/save@v4
       if: ${{ inputs.cache == 'true' && steps.qt-toolchain-cache.outputs.cache-hit != 'true'}}
       with:
-        path: ${{ inputs.dest }}/${{ steps.qt-toolchain-install.outputs.cache-path }}
+        path: ${{ inputs.dest }}/${{ steps.resolve.outputs.cache-path }}
         key: qt-toolchain-${{ steps.resolve.outputs.taskid }}
         enableCrossOsArchive: true

--- a/.github/actions/qt-setup-taskcluster/action.yml
+++ b/.github/actions/qt-setup-taskcluster/action.yml
@@ -9,10 +9,6 @@ inputs:
     description: 'Taskcluster toolchain alias'
     required: false
     default: ${{ runner.os == 'Windows' && 'qt-windows-x86_64-6.6' || 'qt-macos-6.6' }}
-  toolchain-artifact:
-    description: 'Taskcluster toolchain artifact'
-    required: false
-    default: ${{ runner.os == 'Windows' && 'qt6_win.tar.xz' || 'qt6_macos.tar.xz' }}
 runs:
   using: "composite"
   steps:
@@ -23,7 +19,14 @@ runs:
         QT6_TOOLCHAIN_INDEX: mozillavpn.v2.mozillavpn.cache.level-3.toolchains.v3.${{ inputs.toolchain-alias }}.latest
       run: |
         curl -sSL "https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/${QT6_TOOLCHAIN_INDEX}" -o qt-toolchain-task.json
-        echo "QT6_TOOLCHAIN_TASKID=$(jq -r '.taskId' qt-toolchain-task.json)" >> $GITHUB_ENV
+        TASKID=$(jq -r '.taskId' qt-toolchain-task.json)
+
+        curl -sSL "https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/${TASKID}/artifacts" -o qt-toolchain-artifacts.json
+        NAME=$(jq -r '.artifacts[].name | select(endswith(".tar.xz"))' qt-toolchain-artifacts.json)
+
+        echo "QT6_TOOLCHAIN_TASKID=${TASKID}" >> $GITHUB_ENV
+        echo "QT6_TOOLCHAIN_FILE=$(basename ${NAME})" >> $GITHUB_ENV
+        echo "QT6_TOOLCHAIN_URL=https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/${TASKID}/artifacts/${NAME}" >> $GITHUB_ENV
 
     # Tar extraction is painfully slow on Windows, so use a cache instead.
     - name: Cache Qt for Windows
@@ -50,11 +53,9 @@ runs:
       if: ${{ runner.os != 'Windows' || steps.qt-windows-cache.outputs.cache-hit != 'true' }}
       working-directory: ${{ inputs.dest }}
       shell: bash
-      env:
-        QT6_TOOLCHAIN_URL: https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/${{ env.QT6_TOOLCHAIN_TASKID }}/artifacts/public/build/${{ inputs.toolchain-artifact }}
       run: |
-        curl -sSL "$QT6_TOOLCHAIN_URL" -o ${{ inputs.toolchain-artifact }}
-        tar -xf ${{ inputs.toolchain-artifact }}
+        curl -sSL "$QT6_TOOLCHAIN_URL" -o ${QT6_TOOLCHAIN_FILE}
+        tar -xf ${QT6_TOOLCHAIN_FILE}
 
     - name: Save Qt for Windows
       uses: actions/cache/save@v4

--- a/.github/actions/qt-setup-taskcluster/action.yml
+++ b/.github/actions/qt-setup-taskcluster/action.yml
@@ -21,8 +21,15 @@ runs:
       env:
         QT6_INDEX_URL: https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/mozillavpn.v2.mozillavpn.cache.level-3.toolchains.v3.${{ inputs.toolchain-alias }}.latest/artifacts/public/build/${{ inputs.toolchain-artifact }}
       run: |
-        echo QT6_TOOLCHAIN_URL=$(curl -sS --etag-save "${{ runner.temp }}/qt-artifact-etag.txt" -w "%header{location}" "${QT6_INDEX_URL}" -o /dev/null) >> $GITHUB_ENV
-        echo QT6_TOOLCHAIN_ETAG=$(cat "${{ runner.temp }}/qt-artifact-etag.txt") >> $GITHUB_ENV
+        LOCATION=$(curl -sS -w "%header{location}" "${QT6_INDEX_URL}" -o /dev/null)
+        echo "QT6_TOOLCHAIN_URL=${LOCATION}" >> $GITHUB_ENV
+
+        for SEG in $(echo "${LOCATION}" | tr '/' ' '); do
+          if [ "${PSEG}" = "task" ]; then
+            echo "QT6_TOOLCHAIN_TASKID=${SEG}" >> $GITHUB_ENV
+          fi
+          PSEG=${SEG}
+        done
 
     # Tar extraction is painfully slow on Windows, so use a cache instead.
     - name: Cache Qt for Windows
@@ -31,7 +38,7 @@ runs:
       if: ${{ runner.os == 'Windows' }}
       with:
         path: ${{ inputs.dest }}/qt-windows
-        key: qt-windows-${{ env.QT6_TOOLCHAIN_ETAG }}
+        key: qt-windows-${{ env.QT6_TOOLCHAIN_TASKID }}
 
     - name: Install xzutils for Windows
       if: ${{ runner.os == 'Windows' && steps.qt-windows-cache.outputs.cache-hit != 'true' }}

--- a/.github/actions/qt-setup-taskcluster/action.yml
+++ b/.github/actions/qt-setup-taskcluster/action.yml
@@ -9,6 +9,10 @@ inputs:
     description: 'Taskcluster toolchain alias'
     required: false
     default: ${{ runner.os == 'Windows' && 'qt-windows-x86_64-6.6' || 'qt-macos-6.6' }}
+  cache:
+    description: 'Cache Qt toolchain artifacts'
+    required: false
+    default: ${{ runner.os == 'Windows' }}
 runs:
   using: "composite"
   steps:
@@ -27,20 +31,19 @@ runs:
 
         echo "taskid=${TASKID}" >> $GITHUB_OUTPUT
         echo "filename=${NAME}" >> $GITHUB_OUTPUT
-        echo "url=" >> $GITHUB_OUTPUT
 
     # Tar extraction is painfully slow on Windows, so use a cache instead.
-    - name: Cache Qt for Windows
+    - name: Cache Qt toolchain
       uses: actions/cache/restore@v4
-      id: qt-windows-cache
-      if: ${{ runner.os == 'Windows' }}
+      id: qt-toolchain-cache
+      if: ${{ inputs.cache == 'true' }}
       with:
-        path: ${{ inputs.dest }}/qt-windows
-        key: qt-windows-${{ steps.resolve.outputs.taskid }}
+        path: ${{ inputs.dest }}
+        key: qt-toolchain-${{ steps.resolve.outputs.taskid }}
         enableCrossOsArchive: true
 
     - name: Install xzutils for Windows
-      if: ${{ runner.os == 'Windows' && steps.qt-windows-cache.outputs.cache-hit != 'true' }}
+      if: ${{ runner.os == 'Windows' && steps.qt-toolchain-cache.outputs.cache-hit != 'true' }}
       shell: bash
       working-directory: ${{ runner.temp }}
       env:
@@ -51,19 +54,22 @@ runs:
         echo "${{ runner.temp }}/xz-5.8.1-windows/bin_x86-64" >> $GITHUB_PATH
 
     - name: Install Qt toolchain
-      if: ${{ runner.os != 'Windows' || steps.qt-windows-cache.outputs.cache-hit != 'true' }}
+      if: ${{ inputs.cache != 'true' || steps.qt-toolchain-cache.outputs.cache-hit != 'true' }}
+      id: qt-toolchain-install
       working-directory: ${{ inputs.dest }}
       shell: bash
       env:
         QT6_TOOLCHAIN_URL: https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/${{ steps.resolve.outputs.taskid }}/artifacts/${{ steps.resolve.outputs.filename }}
       run: |
-        curl -sSL "$QT6_TOOLCHAIN_URL" -o $(basename ${{ steps.resolve.outputs.filename }})
-        tar -xf $(basename ${{ steps.resolve.outputs.filename }})
+        FILENAME=$(basename "${QT6_TOOLCHAIN_URL}")
+        curl -sSL "${QT6_TOOLCHAIN_URL}" -o ${FILENAME}
+        tar -xf ${FILENAME}
+        echo "cache-path=$(tar -tf ${FILENAME} | head -1 | grep -o '^[^/]*')" >> $GITHUB_OUTPUT
 
-    - name: Save Qt for Windows
+    - name: Save Qt toolchain
       uses: actions/cache/save@v4
-      if: ${{ runner.os == 'Windows' }}
+      if: ${{ inputs.cache == 'true' && steps.qt-toolchain-cache.outputs.cache-hit != 'true'}}
       with:
-        path: ${{ inputs.dest }}/qt-windows
-        key: qt-windows-${{ steps.resolve.outputs.taskid }}
+        path: ${{ inputs.dest }}/${{ steps.qt-toolchain-install.outputs.cache-path }}
+        key: qt-toolchain-${{ steps.resolve.outputs.taskid }}
         enableCrossOsArchive: true

--- a/.github/actions/qt-setup-taskcluster/action.yml
+++ b/.github/actions/qt-setup-taskcluster/action.yml
@@ -13,6 +13,7 @@ runs:
   using: "composite"
   steps:
     - name: Resolve artifact task
+      id: resolve
       shell: bash
       working-directory: ${{ runner.temp }}
       env:
@@ -24,9 +25,9 @@ runs:
         curl -sSL "https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/${TASKID}/artifacts" -o qt-toolchain-artifacts.json
         NAME=$(jq -r '.artifacts[].name | select(endswith(".tar.xz"))' qt-toolchain-artifacts.json)
 
-        echo "QT6_TOOLCHAIN_TASKID=${TASKID}" >> $GITHUB_ENV
-        echo "QT6_TOOLCHAIN_FILE=$(basename ${NAME})" >> $GITHUB_ENV
-        echo "QT6_TOOLCHAIN_URL=https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/${TASKID}/artifacts/${NAME}" >> $GITHUB_ENV
+        echo "taskid=${TASKID}" >> $GITHUB_OUTPUT
+        echo "filename=${NAME}" >> $GITHUB_OUTPUT
+        echo "url=" >> $GITHUB_OUTPUT
 
     # Tar extraction is painfully slow on Windows, so use a cache instead.
     - name: Cache Qt for Windows
@@ -35,7 +36,7 @@ runs:
       if: ${{ runner.os == 'Windows' }}
       with:
         path: ${{ inputs.dest }}/qt-windows
-        key: qt-windows-${{ env.QT6_TOOLCHAIN_TASKID }}
+        key: qt-windows-${{ steps.resolve.outputs.taskid }}
         enableCrossOsArchive: true
 
     - name: Install xzutils for Windows
@@ -53,14 +54,16 @@ runs:
       if: ${{ runner.os != 'Windows' || steps.qt-windows-cache.outputs.cache-hit != 'true' }}
       working-directory: ${{ inputs.dest }}
       shell: bash
+      env:
+        QT6_TOOLCHAIN_URL: https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/${{ steps.resolve.outputs.taskid }}/artifacts/${{ steps.resolve.outputs.filename }}
       run: |
-        curl -sSL "$QT6_TOOLCHAIN_URL" -o ${QT6_TOOLCHAIN_FILE}
-        tar -xf ${QT6_TOOLCHAIN_FILE}
+        curl -sSL "$QT6_TOOLCHAIN_URL" -o $(basename ${{ steps.resolve.outputs.filename }})
+        tar -xf $(basename ${{ steps.resolve.outputs.filename }})
 
     - name: Save Qt for Windows
       uses: actions/cache/save@v4
       if: ${{ runner.os == 'Windows' }}
       with:
         path: ${{ inputs.dest }}/qt-windows
-        key: qt-windows-${{ env.QT6_TOOLCHAIN_TASKID }}
+        key: qt-windows-${{ steps.resolve.outputs.taskid }}
         enableCrossOsArchive: true

--- a/.github/actions/qt-setup-taskcluster/action.yml
+++ b/.github/actions/qt-setup-taskcluster/action.yml
@@ -39,10 +39,10 @@ runs:
 
         # The toolchain path depends on the directory path inside the archive.
         # To find it, lets download the first 4kB of the archive and list its
-        # contents. Lucky for us, tar is streamable so this just kinda works
+        # contents. Lucky for us, tar is a streamable format this kinda works
         # even though the archive is truncated.
         curl -sSL -r0-4096 "https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/${TASKID}/artifacts/${NAME}" -o qt-toolchain-head.tar.xz
-        echo "toolchain-path=$(xzcat qt-toolchain-head.tar.xz 2>/dev/null | tar t | head -1 | grep -o '^[^/]*')" >> $GITHUB_OUTPUT
+        echo "toolchain-path=$(xzcat qt-toolchain-head.tar.xz 2>/dev/null | tar t 2>/dev/null | head -1 | grep -o '^[^/]*')" >> $GITHUB_OUTPUT
 
     - name: Cache Qt toolchain
       uses: actions/cache/restore@v4

--- a/.github/actions/qt-setup-taskcluster/action.yml
+++ b/.github/actions/qt-setup-taskcluster/action.yml
@@ -66,7 +66,7 @@ runs:
         tar -xf ${FILENAME}
 
     - name: Setup cmake paths
-      if: ${{ inputs.cmake-env }}
+      if: ${{ inputs.cmake-env == 'true' }}
       working-directory: ${{ inputs.dest }}
       shell: bash
       run: |

--- a/.github/actions/qt-setup-taskcluster/action.yml
+++ b/.github/actions/qt-setup-taskcluster/action.yml
@@ -63,8 +63,8 @@ runs:
       run: |
         FILENAME=$(basename "${QT6_TOOLCHAIN_URL}")
         curl -sSL "${QT6_TOOLCHAIN_URL}" -o ${FILENAME}
-        tar -xf ${FILENAME}
-        echo "cache-path=$(tar -tf ${FILENAME} | head -1 | grep -o '^[^/]*')" >> $GITHUB_OUTPUT
+        tar -xvf ${FILENAME} > "${{ runner.temp }}/manifest-${FILENAME}"
+        echo "cache-path=$(head -1 "${{ runner.temp }}/manifest-${FILENAME}" | grep -o '^[^/]*')" >> $GITHUB_OUTPUT
 
     - name: Save Qt toolchain
       uses: actions/cache/save@v4

--- a/.github/actions/qt-setup-taskcluster/action.yml
+++ b/.github/actions/qt-setup-taskcluster/action.yml
@@ -16,20 +16,14 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Resolve artifact URL
+    - name: Resolve artifact task
       shell: bash
+      working-directory: ${{ runner.temp }}
       env:
-        QT6_INDEX_URL: https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/mozillavpn.v2.mozillavpn.cache.level-3.toolchains.v3.${{ inputs.toolchain-alias }}.latest/artifacts/public/build/${{ inputs.toolchain-artifact }}
+        QT6_TOOLCHAIN_INDEX: mozillavpn.v2.mozillavpn.cache.level-3.toolchains.v3.${{ inputs.toolchain-alias }}.latest
       run: |
-        LOCATION=$(curl -sS -w "%header{location}" "${QT6_INDEX_URL}" -o /dev/null)
-        echo "QT6_TOOLCHAIN_URL=${LOCATION}" >> $GITHUB_ENV
-
-        for SEG in $(echo "${LOCATION}" | tr '/' ' '); do
-          if [ "${PSEG}" = "task" ]; then
-            echo "QT6_TOOLCHAIN_TASKID=${SEG}" >> $GITHUB_ENV
-          fi
-          PSEG=${SEG}
-        done
+        curl -sSL "https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/${QT6_TOOLCHAIN_INDEX}" -o qt-toolchain-task.json
+        echo "QT6_TOOLCHAIN_TASKID=$(jq -r '.taskId' qt-toolchain-task.json)" >> $GITHUB_ENV
 
     # Tar extraction is painfully slow on Windows, so use a cache instead.
     - name: Cache Qt for Windows
@@ -55,6 +49,8 @@ runs:
       if: ${{ runner.os != 'Windows' || steps.qt-windows-cache.outputs.cache-hit != 'true' }}
       working-directory: ${{ inputs.dest }}
       shell: bash
+      env:
+        QT6_TOOLCHAIN_URL: https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/${{ env.QT6_TOOLCHAIN_TASKID }}/artifacts/public/build/${{ inputs.toolchain-artifact }}
       run: |
         curl -sSL "$QT6_TOOLCHAIN_URL" -o ${{ inputs.toolchain-artifact }}
         tar xvf ${{ inputs.toolchain-artifact }}

--- a/.github/actions/qt-setup-taskcluster/action.yml
+++ b/.github/actions/qt-setup-taskcluster/action.yml
@@ -14,7 +14,7 @@ inputs:
     required: false
     default: ${{ runner.os == 'Windows' }}
   cmake-env:
-    description: 'Add to environment'
+    description: 'Add cmake environment variables'
     required: false
     default: true
 
@@ -39,7 +39,7 @@ runs:
 
         # The toolchain path depends on the directory path inside the archive.
         # To find it, lets download the first 4kB of the archive and list its
-        # contents. Lucky for us, tar is a streamable format this kinda works
+        # contents. Lucky for us, tar is a streamable format so this kinda works
         # even though the archive is truncated.
         curl -sSL -r0-4096 "https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/${TASKID}/artifacts/${NAME}" -o qt-toolchain-head.tar.xz
         echo "toolchain-path=$(xzcat qt-toolchain-head.tar.xz 2>/dev/null | tar t 2>/dev/null | head -1 | grep -o '^[^/]*')" >> $GITHUB_OUTPUT

--- a/.github/actions/qt-setup-taskcluster/action.yml
+++ b/.github/actions/qt-setup-taskcluster/action.yml
@@ -53,17 +53,6 @@ runs:
         key: qt-toolchain-${{ steps.resolve.outputs.taskid }}
         enableCrossOsArchive: true
 
-    - name: Install xzutils for Windows
-      if: ${{ runner.os == 'Windows' && steps.qt-toolchain-cache.outputs.cache-hit != 'true' }}
-      shell: bash
-      working-directory: ${{ runner.temp }}
-      env:
-        XZ_UTILS_URL: https://github.com/tukaani-project/xz/releases/download/v5.8.1/xz-5.8.1-windows.zip
-      run: |
-        curl -sSL ${XZ_UTILS_URL} -o xz-5.8.1-windows.zip
-        unzip -q xz-5.8.1-windows.zip
-        echo "${{ runner.temp }}/xz-5.8.1-windows/bin_x86-64" >> $GITHUB_PATH
-
     - name: Install Qt toolchain
       if: ${{ inputs.cache != 'true' || steps.qt-toolchain-cache.outputs.cache-hit != 'true' }}
       id: qt-toolchain-install

--- a/.github/actions/qt-setup-taskcluster/action.yml
+++ b/.github/actions/qt-setup-taskcluster/action.yml
@@ -33,6 +33,7 @@ runs:
       with:
         path: ${{ inputs.dest }}/qt-windows
         key: qt-windows-${{ env.QT6_TOOLCHAIN_TASKID }}
+        lookup-only: ${{ github.event_name == 'pull_request' }}
 
     - name: Install xzutils for Windows
       if: ${{ runner.os == 'Windows' && steps.qt-windows-cache.outputs.cache-hit != 'true' }}
@@ -42,7 +43,7 @@ runs:
         XZ_UTILS_URL: https://github.com/tukaani-project/xz/releases/download/v5.8.1/xz-5.8.1-windows.zip
       run: |
         curl -sSL ${XZ_UTILS_URL} -o xz-5.8.1-windows.zip
-        unzip xz-5.8.1-windows.zip
+        unzip -q xz-5.8.1-windows.zip
         echo "${{ runner.temp }}/xz-5.8.1-windows/bin_x86-64" >> $GITHUB_PATH
 
     - name: Install Qt toolchain
@@ -53,4 +54,4 @@ runs:
         QT6_TOOLCHAIN_URL: https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/${{ env.QT6_TOOLCHAIN_TASKID }}/artifacts/public/build/${{ inputs.toolchain-artifact }}
       run: |
         curl -sSL "$QT6_TOOLCHAIN_URL" -o ${{ inputs.toolchain-artifact }}
-        tar xvf ${{ inputs.toolchain-artifact }}
+        tar -xf ${{ inputs.toolchain-artifact }}

--- a/.github/actions/qt-setup-taskcluster/action.yml
+++ b/.github/actions/qt-setup-taskcluster/action.yml
@@ -13,6 +13,11 @@ inputs:
     description: 'Cache Qt toolchain artifacts'
     required: false
     default: ${{ runner.os == 'Windows' }}
+  cmake-env:
+    description: 'Add to environment'
+    required: false
+    default: true
+
 runs:
   using: "composite"
   steps:
@@ -32,19 +37,19 @@ runs:
         echo "taskid=${TASKID}" >> $GITHUB_OUTPUT
         echo "filename=${NAME}" >> $GITHUB_OUTPUT
 
-        # The cache path depends on the directory path inside the archive.
+        # The toolchain path depends on the directory path inside the archive.
         # To find it, lets download the first 4kB of the archive and list its
         # contents. Lucky for us, tar is streamable so this just kinda works
         # even though the archive is truncated.
         curl -sSL -r0-4096 "https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/${TASKID}/artifacts/${NAME}" -o qt-toolchain-head.tar.xz
-        echo "cache-path=$(tar -tf qt-toolchain-head.tar.xz 2>/dev/null | head -1 | grep -o '^[^/]*')" >> $GITHUB_OUTPUT
+        echo "toolchain-path=$(tar -tf qt-toolchain-head.tar.xz 2>/dev/null | head -1 | grep -o '^[^/]*')" >> $GITHUB_OUTPUT
 
     - name: Cache Qt toolchain
       uses: actions/cache/restore@v4
       id: qt-toolchain-cache
       if: ${{ inputs.cache == 'true' }}
       with:
-        path: ${{ inputs.dest }}/${{ steps.resolve.outputs.cache-path }}
+        path: ${{ inputs.dest }}/${{ steps.resolve.outputs.toolchain-path }}
         key: qt-toolchain-${{ steps.resolve.outputs.taskid }}
         enableCrossOsArchive: true
 
@@ -71,10 +76,17 @@ runs:
         curl -sSL "${QT6_TOOLCHAIN_URL}" -o ${FILENAME}
         tar -xvf ${FILENAME} > "${{ runner.temp }}/manifest-${FILENAME}"
 
+    - name: Setup cmake paths
+      if: ${{ inputs.cmake-env }}
+      working-directory: ${{ inputs.dest }}
+      shell: bash
+      run: |
+        echo CMAKE_PREFIX_PATH=$(cd ${{ steps.resolve.outputs.toolchain-path }}/lib/cmake && pwd) >> $GITHUB_ENV
+
     - name: Save Qt toolchain
       uses: actions/cache/save@v4
       if: ${{ inputs.cache == 'true' && github.event_name == 'push' && steps.qt-toolchain-cache.outputs.cache-hit != 'true'}}
       with:
-        path: ${{ inputs.dest }}/${{ steps.resolve.outputs.cache-path }}
+        path: ${{ inputs.dest }}/${{ steps.resolve.outputs.toolchain-path }}
         key: qt-toolchain-${{ steps.resolve.outputs.taskid }}
         enableCrossOsArchive: true

--- a/.github/actions/qt-setup-taskcluster/action.yml
+++ b/.github/actions/qt-setup-taskcluster/action.yml
@@ -73,7 +73,7 @@ runs:
 
     - name: Save Qt toolchain
       uses: actions/cache/save@v4
-      if: ${{ inputs.cache == 'true' && steps.qt-toolchain-cache.outputs.cache-hit != 'true'}}
+      if: ${{ inputs.cache == 'true' && github.event_name == 'push' && steps.qt-toolchain-cache.outputs.cache-hit != 'true'}}
       with:
         path: ${{ inputs.dest }}/${{ steps.resolve.outputs.cache-path }}
         key: qt-toolchain-${{ steps.resolve.outputs.taskid }}

--- a/.github/workflows/auth_tests.yml
+++ b/.github/workflows/auth_tests.yml
@@ -95,8 +95,13 @@ jobs:
         working-directory: 3rdparty
         env:
           QT6_WINDOWS_URL: https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/mozillavpn.v2.mozillavpn.cache.level-3.toolchains.v3.qt-windows-x86_64-6.6.latest/artifacts/public/build/qt6_win.tar.xz
+          XZ_UTILS_URL: https://github.com/tukaani-project/xz/releases/download/v5.8.1/xz-5.8.1-windows.zip
         run: |
-          Invoke-WebRequest -Uri "$Env:QT6_WINDOWS_URL" -OutFile qt6_win.tar.xz -Verbose
+          Invoke-WebRequest -Uri $Env:XZ_UTILS_URL -OutFile xz-5.8.1-windows.zip
+          Expand-Archive xz-5.8.1-windows-zip
+          $Env:Path += ";$(pwd)/xz-5.8.1-windows/bin_x86-64"
+
+          Invoke-WebRequest -Uri $Env:QT6_WINDOWS_URL -OutFile qt6_win.tar.xz -Verbose
           tar xvf qt6_win.tar.xz
 
       - name: Add msvc dev commands to PATH

--- a/.github/workflows/auth_tests.yml
+++ b/.github/workflows/auth_tests.yml
@@ -96,8 +96,8 @@ jobs:
         env:
           QT6_WINDOWS_URL: https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/mozillavpn.v2.mozillavpn.cache.level-3.toolchains.v3.qt-windows-x86_64-6.6.latest/artifacts/public/build/qt6_win.tar.xz
         run: |
-          Invoke-WebRequest -Uri $Env:QT6_WINDOWS_URL -OutFile qt6_win.tar.xz
-          tar xf qt6_win.tar.xz
+          Invoke-WebRequest -Uri "$Env:QT6_WINDOWS_URL" -OutFile qt6_win.tar.xz -Verbose
+          tar xvf qt6_win.tar.xz
 
       - name: Add msvc dev commands to PATH
         uses: ilammy/msvc-dev-cmd@v1

--- a/.github/workflows/auth_tests.yml
+++ b/.github/workflows/auth_tests.yml
@@ -92,10 +92,12 @@ jobs:
 
       - name: Install Qt
         shell: pwsh
+        working-directory: 3rdparty
+        env:
+          QT6_WINDOWS_URL: https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/mozillavpn.v2.mozillavpn.cache.level-3.toolchains.v3.qt-windows-x86_64-6.6.latest/artifacts/public%2Fbuild%2Fqt6_win.tar.xz
         run: |
-          Invoke-WebRequest -Uri https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/mozillavpn.v2.mozillavpn.cache.level-3.toolchains.v3.qt-windows-x86_64-6.6.latest/artifacts/public%2Fbuild%2Fqt6_win.zip -OutFile win.zip
-          Expand-Archive win.zip
-          mv win\QT_OUT "C:\\MozillaVPNBuild"
+          Invoke-WebRequest -Uri $QT6_WINDOWS_URL -OutFile qt6_win.tar.xz
+          tar xf qt6_win.tar.xz
 
       - name: Add msvc dev commands to PATH
         uses: ilammy/msvc-dev-cmd@v1
@@ -111,7 +113,7 @@ jobs:
       - name: Building tests
         run: |
           mkdir ./build
-          cmake -S . -B ./build -GNinja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH="C:\MozillaVPNBuild\lib\cmake"
+          cmake -S . -B ./build -GNinja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=3rdparty/qt-win
           cmake --build ./build --target app_auth_tests
 
       - name: Running tests

--- a/.github/workflows/auth_tests.yml
+++ b/.github/workflows/auth_tests.yml
@@ -65,8 +65,7 @@ jobs:
       - name: Compile test client
         run: |
           mkdir -p build/cmake
-          cmake -S $(pwd) -B build/cmake -GNinja \
-            -DCMAKE_PREFIX_PATH=${{ github.workspace }}/3rdparty/qt-macos/lib/cmake
+          cmake -S $(pwd) -B build/cmake -GNinja
           cmake --build build/cmake --target app_auth_tests
 
       - name: Running tests
@@ -101,7 +100,7 @@ jobs:
       - name: Building tests
         run: |
           mkdir ./build
-          cmake -S . -B ./build -GNinja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=3rdparty/qt-win
+          cmake -S . -B ./build -GNinja -DCMAKE_BUILD_TYPE=Debug
           cmake --build ./build --target app_auth_tests
 
       - name: Running tests

--- a/.github/workflows/auth_tests.yml
+++ b/.github/workflows/auth_tests.yml
@@ -65,10 +65,10 @@ jobs:
       - name: Install Qt6
         working-directory: 3rdparty
         env:
-          QT6_MACOS_URL: https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/mozillavpn.v2.mozillavpn.cache.level-3.toolchains.v3.qt-macos-6.6.latest/artifacts/public%2Fbuild%2Fqt6_mac.tar.xz
+          QT6_MACOS_URL: https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/mozillavpn.v2.mozillavpn.cache.level-3.toolchains.v3.qt-macos-6.6.latest/artifacts/public/build/qt6_macos.tar.xz
         run: |
-          curl -sSL ${QT6_MACOS_URL} -o qt6_mac.tar.xz
-          tar -xf qt6_mac.tar.xz
+          curl -sSL ${QT6_MACOS_URL} -o qt6_macos.tar.xz
+          tar -xf qt6_macos.tar.xz
 
       - name: Compile test client
         run: |
@@ -94,9 +94,9 @@ jobs:
         shell: pwsh
         working-directory: 3rdparty
         env:
-          QT6_WINDOWS_URL: https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/mozillavpn.v2.mozillavpn.cache.level-3.toolchains.v3.qt-windows-x86_64-6.6.latest/artifacts/public%2Fbuild%2Fqt6_win.tar.xz
+          QT6_WINDOWS_URL: https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/mozillavpn.v2.mozillavpn.cache.level-3.toolchains.v3.qt-windows-x86_64-6.6.latest/artifacts/public/build/qt6_win.tar.xz
         run: |
-          Invoke-WebRequest -Uri $QT6_WINDOWS_URL -OutFile qt6_win.tar.xz
+          Invoke-WebRequest -Uri $Env:QT6_WINDOWS_URL -OutFile qt6_win.tar.xz
           tar xf qt6_win.tar.xz
 
       - name: Add msvc dev commands to PATH

--- a/.github/workflows/auth_tests.yml
+++ b/.github/workflows/auth_tests.yml
@@ -57,18 +57,10 @@ jobs:
           environment-file: env-apple.yml
           activate-environment: vpn
 
-      - name: Install build dependencies
-        run: |
-          export SDKROOT=$(xcrun --sdk macosx --show-sdk-path)
-          brew install ninja
-
-      - name: Install Qt6
-        working-directory: 3rdparty
-        env:
-          QT6_MACOS_URL: https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/mozillavpn.v2.mozillavpn.cache.level-3.toolchains.v3.qt-macos-6.6.latest/artifacts/public/build/qt6_macos.tar.xz
-        run: |
-          curl -sSL ${QT6_MACOS_URL} -o qt6_macos.tar.xz
-          tar -xf qt6_macos.tar.xz
+      - name: Setup Qt for macOS
+        uses: ./.github/actions/qt-setup-taskcluster
+        with:
+          dest: ${{ github.workspace }}/3rdparty
 
       - name: Compile test client
         run: |
@@ -90,19 +82,10 @@ jobs:
         with:
           submodules: "recursive"
 
-      - name: Install Qt
-        shell: pwsh
-        working-directory: 3rdparty
-        env:
-          QT6_WINDOWS_URL: https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/mozillavpn.v2.mozillavpn.cache.level-3.toolchains.v3.qt-windows-x86_64-6.6.latest/artifacts/public/build/qt6_win.tar.xz
-          XZ_UTILS_URL: https://github.com/tukaani-project/xz/releases/download/v5.8.1/xz-5.8.1-windows.zip
-        run: |
-          Invoke-WebRequest -Uri $Env:XZ_UTILS_URL -OutFile xz-5.8.1-windows.zip
-          Expand-Archive xz-5.8.1-windows.zip
-          $Env:Path += ";$(pwd)/xz-5.8.1-windows/bin_x86-64"
-
-          Invoke-WebRequest -Uri $Env:QT6_WINDOWS_URL -OutFile qt6_win.tar.xz -Verbose
-          tar xvf qt6_win.tar.xz
+      - name: Setup Qt for Windows
+        uses: ./.github/actions/qt-setup-taskcluster
+        with:
+          dest: ${{ github.workspace }}/3rdparty
 
       - name: Add msvc dev commands to PATH
         uses: ilammy/msvc-dev-cmd@v1

--- a/.github/workflows/auth_tests.yml
+++ b/.github/workflows/auth_tests.yml
@@ -98,7 +98,7 @@ jobs:
           XZ_UTILS_URL: https://github.com/tukaani-project/xz/releases/download/v5.8.1/xz-5.8.1-windows.zip
         run: |
           Invoke-WebRequest -Uri $Env:XZ_UTILS_URL -OutFile xz-5.8.1-windows.zip
-          Expand-Archive xz-5.8.1-windows-zip
+          Expand-Archive xz-5.8.1-windows.zip
           $Env:Path += ";$(pwd)/xz-5.8.1-windows/bin_x86-64"
 
           Invoke-WebRequest -Uri $Env:QT6_WINDOWS_URL -OutFile qt6_win.tar.xz -Verbose

--- a/.github/workflows/auth_tests.yml
+++ b/.github/workflows/auth_tests.yml
@@ -63,15 +63,18 @@ jobs:
           brew install ninja
 
       - name: Install Qt6
+        working-directory: 3rdparty
+        env:
+          QT6_MACOS_URL: https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/mozillavpn.v2.mozillavpn.cache.level-3.toolchains.v3.qt-macos-6.6.latest/artifacts/public%2Fbuild%2Fqt6_mac.tar.xz
         run: |
-          wget https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/mozillavpn.v2.mozillavpn.cache.level-3.toolchains.v3.qt-macos-6.6.latest/artifacts/public%2Fbuild%2Fqt6_mac.zip -O qt6_mac.zip
-          unzip -a -d ${{ github.workspace }} qt6_mac.zip
+          curl -sSL ${QT6_MACOS_URL} -o qt6_mac.tar.xz
+          tar -xf qt6_mac.tar.xz
 
       - name: Compile test client
         run: |
           mkdir -p build/cmake
           cmake -S $(pwd) -B build/cmake -GNinja \
-            -DCMAKE_PREFIX_PATH=${{ github.workspace }}/qt_dist/lib/cmake
+            -DCMAKE_PREFIX_PATH=${{ github.workspace }}/3rdparty/qt-macos/lib/cmake
           cmake --build build/cmake --target app_auth_tests
 
       - name: Running tests

--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -37,6 +37,7 @@ jobs:
         with:
           bundle: mozillavpn.flatpak
           manifest-path: linux/flatpak/org.mozilla.vpn.yml
+          cache: ${{ github.event_name == 'push' }}
           cache-key: flatpak-builder-${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.sha }}
 
       - name: Run post-build linters

--- a/.github/workflows/linux_tests.yaml
+++ b/.github/workflows/linux_tests.yaml
@@ -42,12 +42,11 @@ jobs:
       - run: pip install -r requirements.txt
 
       - name: Setup compiler cache
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: ~/.cache/ccache
           key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}
-          lookup-only: github.event_name == 'pull_request'
-          restore-keys: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.sha }}
+          restore-keys: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.event.pull_request.base.sha }}
 
       - name: Compile test client
         shell: bash
@@ -65,6 +64,13 @@ jobs:
             build-${{ runner.os }}/*.cmake
             build-${{ runner.os }}/src/mozillavpn
             build-${{ runner.os }}/tests/functional
+
+      - name: Save compiler cache
+        uses: actions/cache/save@v4
+        if: ${{ github.event_name != 'pull_request' }}
+        with:
+          path: ~/.cache/ccache
+          key: ccache-linux-${{ runner.arch }}-${{ github.sha }}
 
       - name: Generate tasklist
         id: enumerate

--- a/.github/workflows/macos_tests.yaml
+++ b/.github/workflows/macos_tests.yaml
@@ -60,13 +60,10 @@ jobs:
           lookup-only: github.event_name == 'pull_request'
           restore-keys: ccache-macos-${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.sha }}
 
-      - name: Install Qt6
-        working-directory: 3rdparty
-        env:
-          QT6_MACOS_URL: https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/mozillavpn.v2.mozillavpn.cache.level-3.toolchains.v3.qt-macos-6.6.latest/artifacts/public/build/qt6_macos.tar.xz
-        run: |
-          curl -sSL ${QT6_MACOS_URL} -o qt6_macos.tar.xz
-          tar -xf qt6_macos.tar.xz
+      - name: Setup Qt for macOS
+        uses: ./.github/actions/qt-setup-taskcluster
+        with:
+          dest: ${{ github.workspace }}/3rdparty
 
       - name: Cache Qt6 host tools
         id: qt-tools-cache

--- a/.github/workflows/macos_tests.yaml
+++ b/.github/workflows/macos_tests.yaml
@@ -64,20 +64,11 @@ jobs:
         with:
           dest: ${{ github.workspace }}/3rdparty
 
-      - name: Cache Qt6 host tools
-        id: qt-tools-cache
-        uses: actions/cache@v4
+      - name: Setup Qt host tools
+        uses: ./.github/actions/qt-setup-taskcluster
         with:
-          path: 3rdparty/qt-host-tools
-          key: qt-tools-${{ env.QT_VERSION }}
-
-      - name: Install Qt6 host tools
-        if: steps.qt-tools-cache.outputs.cache-hit != 'true'
-        run: |
-          python3 -m aqt install-qt -O 3rdparty/qt-aqt-install linux desktop ${QT_VERSION} --archives icu qtbase qtdeclarative qttools
-          mv 3rdparty/qt-aqt-install/${QT_VERSION}/gcc_64/ 3rdparty/qt-host-tools
-          rm -rf 3rdparty/qt-aqt-install
-          find 3rdparty/qt-host-tools/lib -name '*.a' -delete
+          dest: ${{ github.workspace }}/3rdparty
+          toolchain-alias: qt-tools
 
       - name: Compile test client
         run: |

--- a/.github/workflows/macos_tests.yaml
+++ b/.github/workflows/macos_tests.yaml
@@ -63,10 +63,10 @@ jobs:
       - name: Install Qt6
         working-directory: 3rdparty
         env:
-          QT6_MACOS_URL: https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/mozillavpn.v2.mozillavpn.cache.level-3.toolchains.v3.qt-macos-6.6.latest/artifacts/public%2Fbuild%2Fqt6_mac.tar.xz
+          QT6_MACOS_URL: https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/mozillavpn.v2.mozillavpn.cache.level-3.toolchains.v3.qt-macos-6.6.latest/artifacts/public/build/qt6_macos.tar.xz
         run: |
-          curl -sSL ${QT6_MACOS_URL} -o qt6_mac.tar.xz
-          tar -xf qt6_mac.tar.xz
+          curl -sSL ${QT6_MACOS_URL} -o qt6_macos.tar.xz
+          tar -xf qt6_macos.tar.xz
 
       - name: Cache Qt6 host tools
         id: qt-tools-cache

--- a/.github/workflows/macos_tests.yaml
+++ b/.github/workflows/macos_tests.yaml
@@ -56,8 +56,8 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: ~/.cache/ccache
-          key: ccache-macos-${{ runner.arch }}-${{ github.sha }}
-          restore-keys: ccache-macos-${{ runner.arch }}-${{ github.event.pull_request.base.sha }}
+          key: ccache-macos-${{ github.sha }}
+          restore-keys: ccache-macos-${{ github.event.pull_request.base.sha }}
 
       - name: Setup Qt for macOS
         uses: ./.github/actions/qt-setup-taskcluster
@@ -104,7 +104,7 @@ jobs:
         if: ${{ github.event_name != 'pull_request' }}
         with:
           path: ~/.cache/ccache
-          key: ccache-macos-${{ runner.arch }}-${{ github.sha }}
+          key: ccache-macos-${{ github.sha }}
 
       - name: Generate tasklist
         id: testGen

--- a/.github/workflows/macos_tests.yaml
+++ b/.github/workflows/macos_tests.yaml
@@ -53,12 +53,11 @@ jobs:
           activate-environment: vpn
 
       - name: Setup compiler cache
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: ~/.cache/ccache
-          key: ccache-macos-${{ github.sha }}
-          lookup-only: github.event_name == 'pull_request'
-          restore-keys: ccache-macos-${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.sha }}
+          key: ccache-macos-${{ runner.arch }}-${{ github.sha }}
+          restore-keys: ccache-macos-${{ runner.arch }}-${{ github.event.pull_request.base.sha }}
 
       - name: Setup Qt for macOS
         uses: ./.github/actions/qt-setup-taskcluster
@@ -99,6 +98,13 @@ jobs:
           path: |
             build/
             !build/cmake/
+
+      - name: Save compiler cache
+        uses: actions/cache/save@v4
+        if: ${{ github.event_name != 'pull_request' }}
+        with:
+          path: ~/.cache/ccache
+          key: ccache-macos-${{ runner.arch }}-${{ github.sha }}
 
       - name: Generate tasklist
         id: testGen

--- a/.github/workflows/macos_tests.yaml
+++ b/.github/workflows/macos_tests.yaml
@@ -69,13 +69,13 @@ jobs:
         with:
           dest: ${{ github.workspace }}/3rdparty
           toolchain-alias: qt-tools
+          cmake-env: false
 
       - name: Compile test client
         run: |
           mkdir -p build/cmake
           cmake -S $(pwd) -B build/cmake -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache \
-            -DCMAKE_PREFIX_PATH=3rdparty/qt-macos/lib/cmake \
             -DCMAKE_TOOLCHAIN_FILE=$(pwd)/scripts/macos/osxcross-toolchain.cmake \
             -DCMAKE_OSX_ARCHITECTURES="arm64" \
             -DQT_HOST_PATH=3rdparty/qt-host-tools \

--- a/.github/workflows/macos_tests.yaml
+++ b/.github/workflows/macos_tests.yaml
@@ -61,9 +61,12 @@ jobs:
           restore-keys: ccache-macos-${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.sha }}
 
       - name: Install Qt6
+        working-directory: 3rdparty
+        env:
+          QT6_MACOS_URL: https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/mozillavpn.v2.mozillavpn.cache.level-3.toolchains.v3.qt-macos-6.6.latest/artifacts/public%2Fbuild%2Fqt6_mac.tar.xz
         run: |
-          wget https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/mozillavpn.v2.mozillavpn.cache.level-3.toolchains.v3.qt-macos-6.6.latest/artifacts/public%2Fbuild%2Fqt6_mac.zip -O qt6_mac.zip
-          unzip -a -d ${{ github.workspace }}/3rdparty qt6_mac.zip
+          curl -sSL ${QT6_MACOS_URL} -o qt6_mac.tar.xz
+          tar -xf qt6_mac.tar.xz
 
       - name: Cache Qt6 host tools
         id: qt-tools-cache
@@ -85,7 +88,7 @@ jobs:
           mkdir -p build/cmake
           cmake -S $(pwd) -B build/cmake -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache \
-            -DCMAKE_PREFIX_PATH=3rdparty/qt_dist/lib/cmake \
+            -DCMAKE_PREFIX_PATH=3rdparty/qt-macos/lib/cmake \
             -DCMAKE_TOOLCHAIN_FILE=$(pwd)/scripts/macos/osxcross-toolchain.cmake \
             -DCMAKE_OSX_ARCHITECTURES="arm64" \
             -DQT_HOST_PATH=3rdparty/qt-host-tools \

--- a/.github/workflows/test_unit.yaml
+++ b/.github/workflows/test_unit.yaml
@@ -115,11 +115,13 @@ jobs:
           submodules: "recursive"
 
       - name: Install Qt
+        shell: pwsh
+        working-directory: 3rdparty
         env:
-          QT_WINDOWS_URL: https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/mozillavpn.v2.mozillavpn.cache.level-3.toolchains.v3.qt-windows-x86_64-6.6.latest/artifacts/public%2Fbuild%2Fqt6_win.zip
+          QT6_WINDOWS_URL: https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/mozillavpn.v2.mozillavpn.cache.level-3.toolchains.v3.qt-windows-x86_64-6.6.latest/artifacts/public%2Fbuild%2Fqt6_win.tar.xz
         run: |
-          curl -sSL -o 3rdparty/qt6_win.zip ${QT_WINDOWS_URL}
-          unzip -d 3rdparty/ 3rdparty/qt6_win.zip
+          Invoke-WebRequest -Uri $QT6_WINDOWS_URL -OutFile qt6_win.tar.xz
+          tar xf qt6_win.tar.xz
 
       - name: Install LLVM and Clang
         uses: KyleMayes/install-llvm-action@v2
@@ -157,7 +159,7 @@ jobs:
 
           cmake -S . -B ./build-win -GNinja \
               -DCMAKE_BUILD_TYPE=Debug \
-              -DCMAKE_PREFIX_PATH="$(pwd)/3rdparty/QT_OUT" \
+              -DCMAKE_PREFIX_PATH="$(pwd)/3rdparty/qt-win" \
               -DWIREGUARD_FOLDER="$(pwd)/3rdparty/wireguard-nt"
           cmake --build ./build-win --target build_tests
 

--- a/.github/workflows/test_unit.yaml
+++ b/.github/workflows/test_unit.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Install dependences
         run: |
           sudo apt-get update
-          sudo apt-get install -y $(./scripts/linux/getdeps.py -a linux/debian/control) ccache
+          sudo apt-get install -y $(./scripts/linux/getdeps.py -a linux/debian/control)
 
       - uses: actions/setup-python@v5
         with:
@@ -34,32 +34,24 @@ jobs:
           cache: "pip"
       - run: pip install -r requirements.txt
 
-      - name: Setup compiler cache
-        uses: actions/cache/restore@v4
-        if: ${{ github.event_name == 'pull_request' }}
-        with:
-          path: ~/.cache/ccache
-          key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.event.pull_request.base.sha }}
-
       - name: Building tests
         shell: bash
         run: |
-          mkdir -p build-${{ runner.os }}
-          cmake -S $(pwd) -B build-${{ runner.os }} -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache
-          cmake --build build-${{ runner.os }} --target build_tests
+          mkdir -p build
+          cmake -S $(pwd) -B build -GNinja
+          cmake --build build --target build_tests
 
       - name: Running native messaging tests
         shell: bash
-        run: ctest -L nativemessaging --test-dir build-${{ runner.os }} --output-on-failure
+        run: ctest -L nativemessaging --test-dir build --output-on-failure
 
       - name: Running QML tests
         shell: bash
-        run: ctest -L qml --test-dir build-${{ runner.os }} --output-on-failure
+        run: ctest -L qml --test-dir build --output-on-failure
 
       - name: Running unit tests
         shell: bash
-        run: ctest -L unit --test-dir build-${{ runner.os }} --output-on-failure
+        run: ctest -L unit --test-dir build --output-on-failure
 
   macos-unit-tests:
     runs-on: macos-latest

--- a/.github/workflows/test_unit.yaml
+++ b/.github/workflows/test_unit.yaml
@@ -85,7 +85,7 @@ jobs:
       - name: Building tests
         run: |
           mkdir -p build
-          cmake -S . -B $(pwd)/build -GNinja -DCMAKE_PREFIX_PATH=${{ github.workspace }}/3rdparty/qt-macos
+          cmake -S . -B $(pwd)/build -GNinja
           cmake --build $(pwd)/build --target build_tests
 
       - name: Running native messaging tests
@@ -151,7 +151,6 @@ jobs:
 
           cmake -S . -B ./build-win -GNinja \
               -DCMAKE_BUILD_TYPE=Debug \
-              -DCMAKE_PREFIX_PATH="$(pwd)/3rdparty/qt-windows" \
               -DWIREGUARD_FOLDER="$(pwd)/3rdparty/wireguard-nt"
           cmake --build ./build-win --target build_tests
 

--- a/.github/workflows/test_unit.yaml
+++ b/.github/workflows/test_unit.yaml
@@ -87,7 +87,6 @@ jobs:
 
       - name: Building tests
         run: |
-          export PATH=/opt/qt_dist/bin:$PATH
           mkdir -p build
           cmake -S . -B $(pwd)/build -GNinja -DCMAKE_PREFIX_PATH=${{ github.workspace }}/3rdparty/qt-macos
           cmake --build $(pwd)/build --target build_tests
@@ -120,8 +119,8 @@ jobs:
         env:
           QT6_WINDOWS_URL: https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/mozillavpn.v2.mozillavpn.cache.level-3.toolchains.v3.qt-windows-x86_64-6.6.latest/artifacts/public/build/qt6_win.tar.xz
         run: |
-          Invoke-WebRequest -Uri $Env:QT6_WINDOWS_URL -OutFile qt6_win.tar.xz
-          tar xf qt6_win.tar.xz
+          Invoke-WebRequest -Uri "$Env:QT6_WINDOWS_URL" -OutFile qt6_win.tar.xz -Verbose
+          tar xvf qt6_win.tar.xz
 
       - name: Install LLVM and Clang
         uses: KyleMayes/install-llvm-action@v2

--- a/.github/workflows/test_unit.yaml
+++ b/.github/workflows/test_unit.yaml
@@ -121,7 +121,7 @@ jobs:
           XZ_UTILS_URL: https://github.com/tukaani-project/xz/releases/download/v5.8.1/xz-5.8.1-windows.zip
         run: |
           Invoke-WebRequest -Uri $Env:XZ_UTILS_URL -OutFile xz-5.8.1-windows.zip
-          Expand-Archive xz-5.8.1-windows-zip
+          Expand-Archive xz-5.8.1-windows.zip
           $Env:Path += ";$(pwd)/xz-5.8.1-windows/bin_x86-64"
 
           Invoke-WebRequest -Uri $Env:QT6_WINDOWS_URL -OutFile qt6_win.tar.xz -Verbose

--- a/.github/workflows/test_unit.yaml
+++ b/.github/workflows/test_unit.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Install dependences
         run: |
           sudo apt-get update
-          sudo apt-get install -y $(./scripts/linux/getdeps.py -a linux/debian/control)
+          sudo apt-get install -y $(./scripts/linux/getdeps.py -a linux/debian/control) ccache
 
       - uses: actions/setup-python@v5
         with:
@@ -34,24 +34,32 @@ jobs:
           cache: "pip"
       - run: pip install -r requirements.txt
 
+      - name: Setup compiler cache
+        uses: actions/cache/restore@v4
+        if: ${{ github.event_name == 'pull_request' }}
+        with:
+          path: ~/.cache/ccache
+          key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.event.pull_request.base.sha }}
+
       - name: Building tests
         shell: bash
         run: |
-          mkdir -p build
-          cmake -S . -B $(pwd)/build -GNinja
-          cmake --build $(pwd)/build --target build_tests
+          mkdir -p build-${{ runner.os }}
+          cmake -S $(pwd) -B build-${{ runner.os }} -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache
+          cmake --build build-${{ runner.os }} --target build_tests
 
       - name: Running native messaging tests
         shell: bash
-        run: ctest -L nativemessaging --test-dir $(pwd)/build --output-on-failure
+        run: ctest -L nativemessaging --test-dir build-${{ runner.os }} --output-on-failure
 
       - name: Running QML tests
         shell: bash
-        run: ctest -L qml --test-dir $(pwd)/build --output-on-failure
+        run: ctest -L qml --test-dir build-${{ runner.os }} --output-on-failure
 
       - name: Running unit tests
         shell: bash
-        run: ctest -L unit --test-dir $(pwd)/build --output-on-failure
+        run: ctest -L unit --test-dir build-${{ runner.os }} --output-on-failure
 
   macos-unit-tests:
     runs-on: macos-latest

--- a/.github/workflows/test_unit.yaml
+++ b/.github/workflows/test_unit.yaml
@@ -77,13 +77,10 @@ jobs:
           export SDKROOT=$(xcrun --sdk macosx --show-sdk-path)
           brew install ninja
 
-      - name: Install Qt6
-        working-directory: 3rdparty
-        env:
-          QT6_MACOS_URL: https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/mozillavpn.v2.mozillavpn.cache.level-3.toolchains.v3.qt-macos-6.6.latest/artifacts/public/build/qt6_macos.tar.xz
-        run: |
-          curl -sSL ${QT6_MACOS_URL} -o qt6_macos.tar.xz
-          tar -xf qt6_macos.tar.xz
+      - name: Setup Qt for macOS
+        uses: ./.github/actions/qt-setup-taskcluster
+        with:
+          dest: ${{ github.workspace }}/3rdparty
 
       - name: Building tests
         run: |
@@ -113,19 +110,10 @@ jobs:
         with:
           submodules: "recursive"
 
-      - name: Install Qt
-        shell: pwsh
-        working-directory: 3rdparty
-        env:
-          QT6_WINDOWS_URL: https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/mozillavpn.v2.mozillavpn.cache.level-3.toolchains.v3.qt-windows-x86_64-6.6.latest/artifacts/public/build/qt6_win.tar.xz
-          XZ_UTILS_URL: https://github.com/tukaani-project/xz/releases/download/v5.8.1/xz-5.8.1-windows.zip
-        run: |
-          Invoke-WebRequest -Uri $Env:XZ_UTILS_URL -OutFile xz-5.8.1-windows.zip
-          Expand-Archive xz-5.8.1-windows.zip
-          $Env:Path += ";$(pwd)/xz-5.8.1-windows/bin_x86-64"
-
-          Invoke-WebRequest -Uri $Env:QT6_WINDOWS_URL -OutFile qt6_win.tar.xz -Verbose
-          tar xvf qt6_win.tar.xz
+      - name: Setup Qt for Windows
+        uses: ./.github/actions/qt-setup-taskcluster
+        with:
+          dest: ${{ github.workspace }}/3rdparty
 
       - name: Install LLVM and Clang
         uses: KyleMayes/install-llvm-action@v2

--- a/.github/workflows/test_unit.yaml
+++ b/.github/workflows/test_unit.yaml
@@ -118,8 +118,13 @@ jobs:
         working-directory: 3rdparty
         env:
           QT6_WINDOWS_URL: https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/mozillavpn.v2.mozillavpn.cache.level-3.toolchains.v3.qt-windows-x86_64-6.6.latest/artifacts/public/build/qt6_win.tar.xz
+          XZ_UTILS_URL: https://github.com/tukaani-project/xz/releases/download/v5.8.1/xz-5.8.1-windows.zip
         run: |
-          Invoke-WebRequest -Uri "$Env:QT6_WINDOWS_URL" -OutFile qt6_win.tar.xz -Verbose
+          Invoke-WebRequest -Uri $Env:XZ_UTILS_URL -OutFile xz-5.8.1-windows.zip
+          Expand-Archive xz-5.8.1-windows-zip
+          $Env:Path += ";$(pwd)/xz-5.8.1-windows/bin_x86-64"
+
+          Invoke-WebRequest -Uri $Env:QT6_WINDOWS_URL -OutFile qt6_win.tar.xz -Verbose
           tar xvf qt6_win.tar.xz
 
       - name: Install LLVM and Clang

--- a/.github/workflows/test_unit.yaml
+++ b/.github/workflows/test_unit.yaml
@@ -80,10 +80,10 @@ jobs:
       - name: Install Qt6
         working-directory: 3rdparty
         env:
-          QT6_MACOS_URL: https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/mozillavpn.v2.mozillavpn.cache.level-3.toolchains.v3.qt-macos-6.6.latest/artifacts/public%2Fbuild%2Fqt6_mac.tar.xz
+          QT6_MACOS_URL: https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/mozillavpn.v2.mozillavpn.cache.level-3.toolchains.v3.qt-macos-6.6.latest/artifacts/public/build/qt6_macos.tar.xz
         run: |
-          curl -sSL ${QT6_MACOS_URL} -o qt6_mac.tar.xz
-          tar -xf qt6_mac.tar.xz
+          curl -sSL ${QT6_MACOS_URL} -o qt6_macos.tar.xz
+          tar -xf qt6_macos.tar.xz
 
       - name: Building tests
         run: |
@@ -118,9 +118,9 @@ jobs:
         shell: pwsh
         working-directory: 3rdparty
         env:
-          QT6_WINDOWS_URL: https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/mozillavpn.v2.mozillavpn.cache.level-3.toolchains.v3.qt-windows-x86_64-6.6.latest/artifacts/public%2Fbuild%2Fqt6_win.tar.xz
+          QT6_WINDOWS_URL: https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/mozillavpn.v2.mozillavpn.cache.level-3.toolchains.v3.qt-windows-x86_64-6.6.latest/artifacts/public/build/qt6_win.tar.xz
         run: |
-          Invoke-WebRequest -Uri $QT6_WINDOWS_URL -OutFile qt6_win.tar.xz
+          Invoke-WebRequest -Uri $Env:QT6_WINDOWS_URL -OutFile qt6_win.tar.xz
           tar xf qt6_win.tar.xz
 
       - name: Install LLVM and Clang

--- a/.github/workflows/test_unit.yaml
+++ b/.github/workflows/test_unit.yaml
@@ -151,7 +151,7 @@ jobs:
 
           cmake -S . -B ./build-win -GNinja \
               -DCMAKE_BUILD_TYPE=Debug \
-              -DCMAKE_PREFIX_PATH="$(pwd)/3rdparty/qt-win" \
+              -DCMAKE_PREFIX_PATH="$(pwd)/3rdparty/qt-windows" \
               -DWIREGUARD_FOLDER="$(pwd)/3rdparty/wireguard-nt"
           cmake --build ./build-win --target build_tests
 

--- a/.github/workflows/test_unit.yaml
+++ b/.github/workflows/test_unit.yaml
@@ -78,17 +78,18 @@ jobs:
           brew install ninja
 
       - name: Install Qt6
+        working-directory: 3rdparty
+        env:
+          QT6_MACOS_URL: https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/mozillavpn.v2.mozillavpn.cache.level-3.toolchains.v3.qt-macos-6.6.latest/artifacts/public%2Fbuild%2Fqt6_mac.tar.xz
         run: |
-          wget https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/mozillavpn.v2.mozillavpn.cache.level-3.toolchains.v3.qt-macos-6.6.latest/artifacts/public%2Fbuild%2Fqt6_mac.zip -O mac.zip
-          unzip -a mac.zip
-          sudo mv qt_dist /opt
-          cd ..
+          curl -sSL ${QT6_MACOS_URL} -o qt6_mac.tar.xz
+          tar -xf qt6_mac.tar.xz
 
       - name: Building tests
         run: |
           export PATH=/opt/qt_dist/bin:$PATH
           mkdir -p build
-          cmake -S . -B $(pwd)/build -GNinja
+          cmake -S . -B $(pwd)/build -GNinja -DCMAKE_PREFIX_PATH=${{ github.workspace }}/3rdparty/qt-macos
           cmake --build $(pwd)/build --target build_tests
 
       - name: Running native messaging tests

--- a/docs/Building/macos.md
+++ b/docs/Building/macos.md
@@ -56,7 +56,7 @@ Get a static build of Qt made built in our CI.
 
 https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/mozillavpn.v2.mozillavpn.cache.level-3.toolchains.v3.qt-macos-6.6.latest/artifacts/public/build/qt6_macos.tar.xz
 
-Unzip the folder and remember the location for the configure step.
+Extract the archive and remember the location for the configure step.
 
 # Build
 

--- a/docs/Building/macos.md
+++ b/docs/Building/macos.md
@@ -54,7 +54,7 @@ When you next want to start building the VPN, all you need to do is activate you
 
 Get a static build of Qt made built in our CI.
 
-https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/mozillavpn.v2.mozillavpn.cache.level-3.toolchains.v3.qt-macos-6.6.latest/artifacts/public%2Fbuild%2Fqt6_mac.zip
+https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/mozillavpn.v2.mozillavpn.cache.level-3.toolchains.v3.qt-macos-6.6.latest/artifacts/public%2Fbuild%2Fqt6_mac.tar.xz
 
 Unzip the folder and remember the location for the configure step.
 

--- a/docs/Building/macos.md
+++ b/docs/Building/macos.md
@@ -54,7 +54,7 @@ When you next want to start building the VPN, all you need to do is activate you
 
 Get a static build of Qt made built in our CI.
 
-https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/mozillavpn.v2.mozillavpn.cache.level-3.toolchains.v3.qt-macos-6.6.latest/artifacts/public%2Fbuild%2Fqt6_mac.tar.xz
+https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/mozillavpn.v2.mozillavpn.cache.level-3.toolchains.v3.qt-macos-6.6.latest/artifacts/public/build/qt6_macos.tar.xz
 
 Unzip the folder and remember the location for the configure step.
 

--- a/docs/Building/windows.md
+++ b/docs/Building/windows.md
@@ -4,7 +4,7 @@
 
 Get a static build of Qt made built in our CI.
 
-https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/mozillavpn.v2.mozillavpn.cache.level-3.toolchains.v3.qt-windows-x86_64-6.6.latest/artifacts/public%2Fbuild%2Fqt6_win.zip
+https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/mozillavpn.v2.mozillavpn.cache.level-3.toolchains.v3.qt-windows-x86_64-6.6.latest/artifacts/public%2Fbuild%2Fqt6_win.tar.xz
 
 Unzip the folder and remember the location for the configure step.
 

--- a/docs/Building/windows.md
+++ b/docs/Building/windows.md
@@ -6,7 +6,7 @@ Get a static build of Qt made built in our CI.
 
 https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/mozillavpn.v2.mozillavpn.cache.level-3.toolchains.v3.qt-windows-x86_64-6.6.latest/artifacts/public%2Fbuild%2Fqt6_win.tar.xz
 
-Unzip the folder and remember the location for the configure step.
+Extract the archive and remember the location for the configure step.
 
 ## Conda
 

--- a/scripts/windows/conda_setup_win_qt.ps1
+++ b/scripts/windows/conda_setup_win_qt.ps1
@@ -16,7 +16,7 @@ Write-Output("Installing in $conda_folder")
 $OLD_PWD = $PWD # Backup that to go back once we done. 
 Set-Location $conda_folder 
 
-$TASKCLUSTER_LINK = "https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/mozillavpn.v2.mozillavpn.cache.level-3.toolchains.v3.qt-windows-x86_64-6.6.latest/artifacts/public%2Fbuild%2Fqt6_win.zip"
+$TASKCLUSTER_LINK = "https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/mozillavpn.v2.mozillavpn.cache.level-3.toolchains.v3.qt-windows-x86_64-6.6.latest/artifacts/public%2Fbuild%2Fqt6_win.tar.xz"
 
 $ProgressPreference = 'SilentlyContinue'
 Set-Location $conda_folder 


### PR DESCRIPTION
## Description
In PR #10650 we changed a bunch of toolchain artifacts from `zip` compression to `xz` instead and this saved a tremendous amount of disk space and network traffic, but as a downside it also forced us to change the URLs to some taskcluster artifacts, most notably the Qt6 builds for macOS and Windows.

Now that that change has landed and the taskcluster index has updated, we need to update the consumers of those toolchains as well.

Windows turned out to be a bit of a dumpster fire. The Github `windows-latest` runner image doesn't support `tar.xz` compression and tar extraction is painfully slow. To mitigate the pain on Windows, we moved the Qt setup into a resuable action and add support for caching the Qt directory.

This also revealed that we were misusing the cache action in our functional test workflow, so we fixed that too.

## Reference
Introduced by: #10650

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
