### PR TITLE
Nit: only pull cmake once

### DIFF
--- a/android_sdk.txt
+++ b/android_sdk.txt
@@ -4,7 +4,7 @@ build-tools;29.0.2
 build-tools;30.0.3
 build-tools;31.0.0
 build-tools;33.0.0
-cmake;3.10.2.4988404
+cmake;3.31.6
 emulator
 platform-tools
 ndk;23.1.7779620

--- a/env-android.yml
+++ b/env-android.yml
@@ -11,7 +11,6 @@ dependencies:
   - rust-std-x86_64-linux-android=1.75
   - rust-std-i686-linux-android=1.75
   - rust-std-aarch64-linux-android=1.75
-  - cmake=3.31.6
   - ninja=1.11.0
   - conda-forge::openjdk=17
   - wget


### PR DESCRIPTION
## Description

 I noticed we pull it twice, one for the android_sdk one from conda. Given we require cmake to be in the SDK, let's just use that and save some bytes. 
