### PR TITLE
VPN-7193: xcode cloud fix

### DIFF
--- a/ci_scripts/ci_post_clone.sh
+++ b/ci_scripts/ci_post_clone.sh
@@ -31,9 +31,9 @@ EOF
 
 
 export INDEX_KEY=mozillavpn.v2.mozillavpn.cache.level-3.toolchains.v3.conda-ios-x86_64-6.6.0.latest
-curl -L https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/$INDEX_KEY/artifacts/public%2Fbuild%2Fconda-ios.tar.gz --output conda-ios.tar.gz 
+curl -L https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/$INDEX_KEY/artifacts/public%2Fbuild%2Fconda-ios.tar.xz --output conda-ios.tar.xz
 
-tar -xf conda-ios.tar.gz 
+tar -xf conda-ios.tar.xz
 # Activate the Conda-ENV
 source bin/activate
 conda-unpack

--- a/src/platforms/macos/macosmenubar.cpp
+++ b/src/platforms/macos/macosmenubar.cpp
@@ -20,7 +20,7 @@
 #include <QMenuBar>
 
 namespace {
-Logger logger("MacOSManuBar");
+Logger logger("MacOSMenuBar");
 MacOSMenuBar* s_instance = nullptr;
 }  // namespace
 


### PR DESCRIPTION
## Description

Xcode Cloud builds broke due to one of the 4 commits on July 23.

The failure is happening when working w/ the just-downloaded conda tarball, and I can repro that locally - was getting a 404 JSON file.

Given that, it seems highly likely that this commit on July 23rd introduced the issue: https://github.com/mozilla-mobile/mozilla-vpn-client/pull/10650/files#diff-f847843176919d23e84c529a4d6f14bde9f743c1e2679a5616eac636db866b3e

This updates the file we're trying to download. It works for me locally.

(Also fixing a small typo in this PR that has been bugging me.)

## Reference

VPN-7193

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
