### PR TITLE
VPN-7197: Enable sentry upload for macos/opt build

### DIFF
--- a/taskcluster/kinds/build/macos.yml
+++ b/taskcluster/kinds/build/macos.yml
@@ -48,7 +48,7 @@ macos/opt:
     treeherder:
         symbol: B
     run:
-        command: ./taskcluster/scripts/build/macos_build.sh -d
+        command: ./taskcluster/scripts/build/macos_build.sh
     requires-level: 3 
     scopes:
         - secrets:get:project/mozillavpn/level-1/sentry


### PR DESCRIPTION
## Description
Looks like we have a bug in the taskcluster `build-macos/opt` job, which incorrectly sets the `-d` option. This disables the upload of symbols to Sentry, thereby preventing us from getting proper backtrace analysis in crash reports.

## Reference
JIRA Issue: [VPN-7197](https://mozilla-hub.atlassian.net/browse/VPN-7197)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-7197]: https://mozilla-hub.atlassian.net/browse/VPN-7197?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ