### PR TITLE
VPN-7187: Generate BUILD_ID from git if not set

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,7 +99,15 @@ if(ANDROID)
 endif()
 
 if(NOT DEFINED BUILD_ID)
-    string(TIMESTAMP BUILD_ID "${PROJECT_VERSION_MAJOR}.%Y%m%d%H%M")
+    if(IS_DIRECTORY ${CMAKE_SOURCE_DIR}/.git)
+        execute_process(
+            OUTPUT_VARIABLE BUILD_ID
+            OUTPUT_STRIP_TRAILING_WHITESPACE 
+            COMMAND git -C ${CMAKE_SOURCE_DIR} log -1 --format=%cd --date=format:${PROJECT_VERSION_MAJOR}.%Y%m%d%H%M HEAD   
+        )
+    else()
+        string(TIMESTAMP BUILD_ID ${PROJECT_VERSION_MAJOR}.%Y%m%d%H%M)
+    endif()
     message("Generated BUILD_ID: ${BUILD_ID}")
 endif()
 


### PR DESCRIPTION
## Description
We have a bit of a quirk in the official Flatpak builds. In order to make builds reproducable they fiddle with the clock to force build timestamps and the like to produce a constant value. This means that the buildNumber for flatpaks always comes out as 2.201111111111 which really isn't that helpful for identifying what was built.

To fix this, when the build ID is not otherwise set, we first check to see if a `.git` directory exists and generate the `BUILD_ID` using the timestamp of the `HEAD` commit. This should result in a stable `BUILD_ID` that is reproduceable from the source, and will generate something sensible even if the clock has been manipulated.

However, there is a downside here that repeated builds using the same git commit may no longer be distinguishable.

## Reference
Split from PR #10673
JIRA Issue: [VPN-7187](https://mozilla-hub.atlassian.net/browse/VPN-7187)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-7187]: https://mozilla-hub.atlassian.net/browse/VPN-7187?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ