### PR TITLE
VPN-7217: Fix Auth unit test hang on TOTP error

### DIFF
--- a/.github/actions/qt-setup-taskcluster/action.yml
+++ b/.github/actions/qt-setup-taskcluster/action.yml
@@ -66,11 +66,16 @@ runs:
         tar -xf ${FILENAME}
 
     - name: Setup cmake paths
-      if: ${{ inputs.cmake-env == 'true' }}
-      working-directory: ${{ inputs.dest }}
+      if: ${{ inputs.cmake-env == 'true' && runner.os != 'Windows' }}
+      working-directory: ${{ inputs.dest }}/${{ steps.resolve.outputs.toolchain-path }}
       shell: bash
-      run: |
-        echo CMAKE_PREFIX_PATH=$(cd ${{ steps.resolve.outputs.toolchain-path }}/lib/cmake && pwd) >> $GITHUB_ENV
+      run: echo CMAKE_PREFIX_PATH=$(pwd)/lib/cmake >> $GITHUB_ENV
+
+    - name: Setup cmake paths
+      if: ${{ inputs.cmake-env == 'true' && runner.os == 'Windows' }}
+      working-directory: ${{ inputs.dest }}/${{ steps.resolve.outputs.toolchain-path }}
+      shell: pwsh
+      run: echo "CMAKE_PREFIX_PATH=$(Resolve-Path lib/cmake)" >> $Env:GITHUB_ENV
 
     - name: Save Qt toolchain
       uses: actions/cache/save@v4

--- a/.github/workflows/auth_tests.yml
+++ b/.github/workflows/auth_tests.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
       - "releases/**"
+  # For testing... delete before merge
+  pull_request:
+    branches:
+      - main
 
 # Restrict tests to the most recent commit.
 concurrency:
@@ -86,23 +90,45 @@ jobs:
         with:
           dest: ${{ github.workspace }}/3rdparty
 
-      - name: Add msvc dev commands to PATH
-        uses: ilammy/msvc-dev-cmd@v1
+      - name: Install LLVM and Clang
+        uses: KyleMayes/install-llvm-action@v2
+        with:
+          version: 20.1.4
 
-      - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v2
-
-      - name: Install dependencies
-        shell: bash
+      - name: Setup clang env variables
         run: |
-          pip3 install -r requirements.txt
+          echo "CC=${{ env.LLVM_PATH }}/bin/clang-cl.exe" >> $GITHUB_ENV
+          echo "CXX=${{ env.LLVM_PATH }}/bin/clang-cl.exe" >> $GITHUB_ENV
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.9"
+          cache: "pip"
+      - run: pip install -r requirements.txt
+
+      - name: Cache Wireguard NT
+        id: cache-wireguard-nt
+        uses: actions/cache@v4
+        with:
+          path: 3rdparty/wireguard-nt
+          key: wireguard-nt-${{ hashFiles('windows/wireguard_nt/CMakeLists.txt') }}
+
+      - name: Download Wireguard NT
+        if: steps.cache-wireguard-nt.outputs.cache-hit != 'true'
+        run: |
+          WIREGUARD_NT_URL=$(grep -Eo 'DOWNLOAD[[:space:]].*' windows/wireguard_nt/CMakeLists.txt | awk '{print $2}')
+          curl -sSL -o wireguard-nt.zip $WIREGUARD_NT_URL
+          unzip -d 3rdparty/ wireguard-nt.zip
 
       - name: Building tests
         run: |
-          mkdir ./build
-          cmake -S . -B ./build -GNinja -DCMAKE_BUILD_TYPE=Debug
-          cmake --build ./build --target app_auth_tests
+          mkdir ./build-win
+
+          cmake -S . -B ./build-win -GNinja \
+              -DCMAKE_BUILD_TYPE=Debug \
+              -DWIREGUARD_FOLDER="$(pwd)/3rdparty/wireguard-nt"
+          cmake --build ./build-win --target app_auth_tests
 
       - name: Running tests
         shell: bash
-        run: ctest -L auth --output-on-failure
+        run: ctest -L auth --test-dir ./build-win --output-on-failure

--- a/.github/workflows/auth_tests.yml
+++ b/.github/workflows/auth_tests.yml
@@ -124,9 +124,7 @@ jobs:
         run: |
           mkdir ./build-win
 
-          cmake -S . -B ./build-win -GNinja \
-              -DCMAKE_BUILD_TYPE=Debug \
-              -DWIREGUARD_FOLDER="$(pwd)/3rdparty/wireguard-nt"
+          cmake -S . -B ./build-win -GNinja -DCMAKE_BUILD_TYPE=Debug -DWIREGUARD_FOLDER="$(pwd)/3rdparty/wireguard-nt"
           cmake --build ./build-win --target app_auth_tests
 
       - name: Running tests

--- a/.github/workflows/auth_tests.yml
+++ b/.github/workflows/auth_tests.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Running tests
         shell: bash
-        run: ctest -L auth --output-on-failure
+        run: ctest -L auth --test-dir $(pwd)/build --output-on-failure
 
   macos-unit-tests:
     runs-on: macos-latest
@@ -73,7 +73,7 @@ jobs:
           cmake --build build/cmake --target app_auth_tests
 
       - name: Running tests
-        run: ctest -L auth --output-on-failure
+        run: ctest -L auth --test-dir build/cmake --output-on-failure
 
   windows-unit-tests:
     name: Run auth tests on Windows

--- a/.github/workflows/auth_tests.yml
+++ b/.github/workflows/auth_tests.yml
@@ -5,10 +5,6 @@ on:
     branches:
       - main
       - "releases/**"
-  # For testing... delete before merge
-  pull_request:
-    branches:
-      - main
 
 # Restrict tests to the most recent commit.
 concurrency:

--- a/src/authenticationinapp/authenticationinappsession.cpp
+++ b/src/authenticationinapp/authenticationinappsession.cpp
@@ -768,7 +768,7 @@ void AuthenticationInAppSession::processErrorObject(const QJsonObject& obj) {
 
   int errorCode = obj["errno"].toInt();
 
-  // For case 107: Invalid parameter in request body, convert it into a better code.
+  // For case 107: Invalid parameter in request body, map it to a better error.
   if (errorCode == 107) {
     QJsonObject objValidation = obj["validation"].toObject();
     const QJsonArray keyArray = objValidation["keys"].toArray();
@@ -780,7 +780,7 @@ void AuthenticationInAppSession::processErrorObject(const QJsonObject& obj) {
     }
 
     if (keys.contains("unblockCode")) {
-      errorCode = 127; // Invalid unblock code
+      errorCode = 127;  // Invalid unblock code
     } else if (keys.contains("email")) {
       // We don't really know why email validation failed, so
       // let's just handle this one here.
@@ -790,7 +790,7 @@ void AuthenticationInAppSession::processErrorObject(const QJsonObject& obj) {
           this, AuthenticationInApp::ErrorInvalidEmailAddress);
       return;
     } else if (keys.contains("code")) {
-      errorCode = 152; // Invalid token confirmation code
+      errorCode = 152;  // Invalid token confirmation code
     }
   }
 
@@ -872,8 +872,8 @@ void AuthenticationInAppSession::processErrorObject(const QJsonObject& obj) {
       if (aia->state() == AuthenticationInApp::StateVerifyingSessionTotpCode) {
         aia->requestState(
             AuthenticationInApp::StateVerificationSessionByTotpNeeded, this);
-        aia->requestErrorPropagation(
-            this, AuthenticationInApp::ErrorInvalidTotpCode);
+        aia->requestErrorPropagation(this,
+                                     AuthenticationInApp::ErrorInvalidTotpCode);
       } else {
         aia->requestState(
             AuthenticationInApp::StateVerificationSessionByEmailNeeded, this);
@@ -903,7 +903,7 @@ void AuthenticationInAppSession::processErrorObject(const QJsonObject& obj) {
       [[fallthrough]];
     case 106:  // Invalid JSON in request body
       [[fallthrough]];
-    case 107:   // Invalid parameter in request body
+    case 107:  // Invalid parameter in request body
       [[fallthrough]];
     case 108:  // Missing parameter in request body
       [[fallthrough]];

--- a/src/authenticationinapp/authenticationinappsession.cpp
+++ b/src/authenticationinapp/authenticationinappsession.cpp
@@ -768,6 +768,32 @@ void AuthenticationInAppSession::processErrorObject(const QJsonObject& obj) {
 
   int errorCode = obj["errno"].toInt();
 
+  // For case 107: Invalid parameter in request body, convert it into a better code.
+  if (errorCode == 107) {
+    QJsonObject objValidation = obj["validation"].toObject();
+    const QJsonArray keyArray = objValidation["keys"].toArray();
+    QStringList keys;
+    for (const QJsonValue& key : keyArray) {
+      if (key.isString()) {
+        keys.append(key.toString());
+      }
+    }
+
+    if (keys.contains("unblockCode")) {
+      errorCode = 127; // Invalid unblock code
+    } else if (keys.contains("email")) {
+      // We don't really know why email validation failed, so
+      // let's just handle this one here.
+      AuthenticationInApp* aia = AuthenticationInApp::instance();
+      aia->requestState(AuthenticationInApp::StateStart, this);
+      aia->requestErrorPropagation(
+          this, AuthenticationInApp::ErrorInvalidEmailAddress);
+      return;
+    } else if (keys.contains("code")) {
+      errorCode = 152; // Invalid token confirmation code
+    }
+  }
+
   // See
   // https://github.com/mozilla/fxa/blob/main/packages/fxa-auth-server/docs/api.md#defined-errors
   switch (errorCode) {
@@ -788,57 +814,6 @@ void AuthenticationInAppSession::processErrorObject(const QJsonObject& obj) {
       aia->requestErrorPropagation(this,
                                    AuthenticationInApp::ErrorIncorrectPassword);
       break;
-
-    case 107: {  // Invalid parameter in request body
-      QJsonObject objValidation = obj["validation"].toObject();
-      const QJsonArray keyArray = objValidation["keys"].toArray();
-      QStringList keys;
-      for (const QJsonValue& key : keyArray) {
-        if (key.isString()) {
-          keys.append(key.toString());
-        }
-      }
-
-      if (keys.contains("unblockCode")) {
-        AuthenticationInApp* aia = AuthenticationInApp::instance();
-        aia->requestState(AuthenticationInApp::StateUnblockCodeNeeded, this);
-        aia->requestErrorPropagation(
-            this, AuthenticationInApp::ErrorInvalidUnblockCode);
-        break;
-      }
-
-      if (keys.contains("email")) {
-        AuthenticationInApp* aia = AuthenticationInApp::instance();
-        aia->requestState(AuthenticationInApp::StateStart, this);
-        aia->requestErrorPropagation(
-            this, AuthenticationInApp::ErrorInvalidEmailAddress);
-        break;
-      }
-
-      if (keys.contains("code")) {
-        AuthenticationInApp* aia = AuthenticationInApp::instance();
-        // Code invalid can be received both in totp and in email verification
-        // steps. We need to check the current step in order to send the correct
-        // message.
-        if (aia->state() ==
-            AuthenticationInApp::StateVerifyingSessionTotpCode) {
-          aia->requestState(
-              AuthenticationInApp::StateVerificationSessionByTotpNeeded, this);
-          aia->requestErrorPropagation(
-              this, AuthenticationInApp::ErrorInvalidTotpCode);
-          return;
-        }
-
-        aia->requestState(
-            AuthenticationInApp::StateVerificationSessionByEmailNeeded, this);
-        aia->requestErrorPropagation(
-            this, AuthenticationInApp::ErrorInvalidOrExpiredVerificationCode);
-        break;
-      }
-
-      logger.error() << "Unsupported validation parameter";
-      break;
-    }
 
     case 114:  // Client has sent too many requests
       if (m_typeAuthentication == TypeDefault) {
@@ -890,6 +865,23 @@ void AuthenticationInAppSession::processErrorObject(const QJsonObject& obj) {
                                    AuthenticationInApp::ErrorFailedToSendEmail);
       break;
 
+    case 152:  // Invalid token confirmation code
+      // Code invalid can be received both in totp and in email verification
+      // steps. We need to check the current step in order to send the correct
+      // message.
+      if (aia->state() == AuthenticationInApp::StateVerifyingSessionTotpCode) {
+        aia->requestState(
+            AuthenticationInApp::StateVerificationSessionByTotpNeeded, this);
+        aia->requestErrorPropagation(
+            this, AuthenticationInApp::ErrorInvalidTotpCode);
+      } else {
+        aia->requestState(
+            AuthenticationInApp::StateVerificationSessionByEmailNeeded, this);
+        aia->requestErrorPropagation(
+            this, AuthenticationInApp::ErrorInvalidOrExpiredVerificationCode);
+      }
+      break;
+
     case 183:  // Invalid or expired verification code
       aia->requestState(
           AuthenticationInApp::StateVerificationSessionByEmailNeeded, this);
@@ -910,6 +902,8 @@ void AuthenticationInAppSession::processErrorObject(const QJsonObject& obj) {
     case 105:  // Invalid verification code
       [[fallthrough]];
     case 106:  // Invalid JSON in request body
+      [[fallthrough]];
+    case 107:   // Invalid parameter in request body
       [[fallthrough]];
     case 108:  // Missing parameter in request body
       [[fallthrough]];
@@ -972,8 +966,6 @@ void AuthenticationInAppSession::processErrorObject(const QJsonObject& obj) {
       [[fallthrough]];
     case 150:  // Can not resend email code to an email that does not belong to
                // this account
-      [[fallthrough]];
-    case 152:  // Invalid token verification code
       [[fallthrough]];
     case 153:  // Expired token verification code
       [[fallthrough]];

--- a/tests/auth_tests/main.cpp
+++ b/tests/auth_tests/main.cpp
@@ -64,7 +64,7 @@ int main(int argc, char* argv[]) {
   TestSignUpAndIn tsu(nonce, "vpn.auth.test.");
   failures += QTest::qExec(&tsu);
 
-  TestSignUpAndIn tsuTotp(nonce, "vpn.auth.test.totp.", true /* totp creation */);
+  TestSignUpAndIn tsuTotp(nonce, "vpn.auth.test.totp.", true);
   failures += QTest::qExec(&tsuTotp);
 
   TestSignUpAndIn tsuBlocked(nonce, "block.vpn.auth.test.");

--- a/tests/auth_tests/main.cpp
+++ b/tests/auth_tests/main.cpp
@@ -61,11 +61,11 @@ int main(int argc, char* argv[]) {
   TestPasswordValidation tpv(nonce);
   failures += QTest::qExec(&tpv);
 
-  TestSignUpAndIn tsuTotp(nonce, "vpn.auth.test.", true /* totp creation */);
-  failures += QTest::qExec(&tsuTotp);
-
   TestSignUpAndIn tsu(nonce, "vpn.auth.test.");
   failures += QTest::qExec(&tsu);
+
+  TestSignUpAndIn tsuTotp(nonce, "vpn.auth.test.totp.", true /* totp creation */);
+  failures += QTest::qExec(&tsuTotp);
 
   TestSignUpAndIn tsuBlocked(nonce, "block.vpn.auth.test.");
   failures += QTest::qExec(&tsuBlocked);


### PR DESCRIPTION
## Description
The Auth tests for Windows have been failing for a while, but we don't really notice it because it only runs on push (not on PR). Let's fix them.

This more or less just applies all the recent unit test fixes into the `auth_tests.yaml` workflow.

## Reference
JIRA issue: [VPN-7217](https://mozilla-hub.atlassian.net/browse/VPN-7217)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-7217]: https://mozilla-hub.atlassian.net/browse/VPN-7217?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ