### PR TITLE
Set FORCE option when codesigning wireguard-go

### DIFF
--- a/src/cmake/macos.cmake
+++ b/src/cmake/macos.cmake
@@ -141,7 +141,7 @@ else()
     )
 endif()
 add_dependencies(mozillavpn build_wireguard_go)
-osx_codesign_target(build_wireguard_go FILES ${CMAKE_CURRENT_BINARY_DIR}/wireguard-go)
+osx_codesign_target(build_wireguard_go FILES ${CMAKE_CURRENT_BINARY_DIR}/wireguard-go FORCE)
 osx_bundle_files(mozillavpn
     FILES ${CMAKE_CURRENT_BINARY_DIR}/wireguard-go
     DESTINATION Resources/utils


### PR DESCRIPTION
## Description
Re-running a macOS build can sometimes result in a failed `codesign` attempt on the `wireguard-go` binary. This occurs because the target is built using a CMake `add_custom_target()` and codesigning happens as a `POST_BUILD` hook. Because custom targets are executed on every run, this means that we re-run the `codesign` tool even if the binary wasn't touched and this throws an error if the binary was already signed.

To fix this, we can replace the signature by adding the `FORCE` option to the `osx_codesign_target()` helper, which will cause the signature to be replaced instead of throwing an error.

## Reference
Bug introduced by: #10662

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
