### PR TITLE
VPN-7141 follow up fix

### DIFF
--- a/nebula/ui/components/MZToggleRow.qml
+++ b/nebula/ui/components/MZToggleRow.qml
@@ -85,17 +85,13 @@ RowLayout {
             objectName: "toggle"
             anchors.fill: parent
             accessibleName: labelText
+            onClicked: toggleRow.clicked()
         }
 
         MouseArea {
             anchors.fill: parent
-            onClicked: {
-              if (toggle.enabled == false) {
-                toggleRow.clickedWhileDisabled()
-              } else {
-                toggleRow.clicked()
-              }
-            }
+            enabled: toggle.enabled == false
+            onClicked: toggleRow.clickedWhileDisabled()
         }
     }
 }


### PR DESCRIPTION
## Description

QA found a situation where the toggle background color sometimes doesn't change. I'm able to repro, but it's somewhat inconsistent.

It seems like the mousearea doesn't always cause the background color to change, as it registers differently. Thus, let's make sure to use the toggle's onclicked when the toggle is active.

## Reference

VPN-7141 / follow up to https://github.com/mozilla-mobile/mozilla-vpn-client/pull/10646

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
