### PR TITLE
VPN-7205: Remove accidental index route to macos/next build

### DIFF
--- a/taskcluster/kinds/signing/kind.yml
+++ b/taskcluster/kinds/signing/kind.yml
@@ -59,7 +59,7 @@ tasks:
         add-index-routes:
             by-build-type:
                 windows/opt: null  # for Windows we want the 'repackage-signing' task
-                macos/opt: null    # for macOS we want the 'mac-notarization' task
+                macos.*: null      # for macOS we want the 'mac-notarization' task
                 default: build
         signing-format:
             by-build-type:


### PR DESCRIPTION
## Description
In PR #10708 we added a signing task for the `macos/next` build type, but we neglected to update the index route logic accordingly. This resulted in a duplicate index route (one for `signing-macos/next`  and one for `mac-notarization`) and caused the Decision Task to fail.

## Reference
Bug introduced by: #10708
JIRA Issue: [VPN-7205](https://mozilla-hub.atlassian.net/browse/VPN-7205)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-7205]: https://mozilla-hub.atlassian.net/browse/VPN-7205?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ