### PR TITLE
Fix an assert in socksproxy DNS resolution

### DIFF
--- a/extension/socks5proxy/src/dnsresolver.cpp
+++ b/extension/socks5proxy/src/dnsresolver.cpp
@@ -105,6 +105,8 @@ void DNSResolver::addressInfoCallback(QObject* ctx, int status, int timeouts,
 
   // This should be our Socks5Connection
   switch (status) {
+    case ARES_SUCCESS:
+      break;
     case ARES_ENOTIMP:
       qDebug() << "The ares library does not know how to find addresses of "
                   "type family. ";
@@ -126,6 +128,9 @@ void DNSResolver::addressInfoCallback(QObject* ctx, int status, int timeouts,
     case ARES_EDESTRUCTION:
       qDebug() << "The name service channel channel is being destroyed; the "
                   "query will not be completed. ";
+      return;
+    default:
+      qDebug() << "Name resolution error:" << ares_strerror(status);
       return;
   }
 


### PR DESCRIPTION
## Description
During some load testing, I was able to hit an assert in the socksproxy `DNSResolver` class if we get a malformed DNS response. This occurs because our `switch` statement doesn't necessarily handle all cases and one slipped through. To fix this, let's add a `default` case.

## Reference

    i.e Jira or Github issue URL

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
