### PR TITLE
VPN-7205: Add macos/next to valid signing build types

### DIFF
--- a/taskcluster/mozillavpn_taskgraph/transforms/signing.py
+++ b/taskcluster/mozillavpn_taskgraph/transforms/signing.py
@@ -19,6 +19,7 @@ PRODUCTION_SIGNING_BUILD_TYPES = [
     "android-armv7/release",
     "linux/opt",
     "macos/opt",
+    "macos/next", # TODO: This would be a candidate for debug signing, if we supported it.
     "windows/opt",
     "addons/opt",
 ]


### PR DESCRIPTION
## Description
In trying to add a signed `macos/next` build, we have an error in the signing transform that fails to recognize `build-macos/next` as a valid build type for production signing, which results in the Decision task failing due to inadequate scopes. To fix this, we need to update the taskcluster signing transform.

Note, the `macos/next` build is an excellent candidate for debug signing, but unfortunately we do not support debug signing for the mozillavpn project right now.

## Reference
Bug introduced by: #10708 and #10712
JIRA Issue: [VPN-7205](https://mozilla-hub.atlassian.net/browse/VPN-7205)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-7205]: https://mozilla-hub.atlassian.net/browse/VPN-7205?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ