### PR TITLE
VPN-7205: Fix hardened-sign config when multiple macos signing tasks exist

### DIFF
--- a/taskcluster/mozillavpn_taskgraph/transforms/signing.py
+++ b/taskcluster/mozillavpn_taskgraph/transforms/signing.py
@@ -107,9 +107,9 @@ def add_hardened_sign_config(config, tasks):
             yield task
             continue
 
-        # Convert paths to file URLs.
-        hardened_sign_config = config.config["mac-signing"]["hardened-sign-config"]
-        for cfg in hardened_sign_config:
+        # Convert entitlement paths to file URLs.
+        hs_config = [x.copy() for x in config.config["mac-signing"]["hardened-sign-config"]]
+        for cfg in hs_config:
             if "entitlements" in cfg:
                 cfg["entitlements"] = config.params.file_url(cfg["entitlements"])
 
@@ -121,6 +121,6 @@ def add_hardened_sign_config(config, tasks):
             },
         ]
 
-        task["worker"]["hardened-sign-config"] = hardened_sign_config
+        task["worker"]["hardened-sign-config"] = hs_config
         task["worker"]["mac-behavior"] = "mac_sign_hardened"
         yield task


### PR DESCRIPTION
## Description
Turns out there is a bug in the `signing.py` transform that occurs when multiple macos signing tasks are created. Because scriptworker runs on a dedicated worker that doesn't have access to the checkout, it needs the entitlements files to be URLs, so the `config.params.file_url()` method is used to convert them.

However, because python dicts are shared, this means that converting the entitlement multiple times can result in a mangled URL and `config.params.file_url()` is too dumb to catch when the input is already a URL.

To fix this, we can take a deep copy of the hardened sign configuration before applying the transform to it.

## Reference
Bug triggered by:
- #10708
- #10712 
- #10714

JIRA Issue: [VPN-7205](https://mozilla-hub.atlassian.net/browse/VPN-7205)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-7205]: https://mozilla-hub.atlassian.net/browse/VPN-7205?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ