### PR TITLE
Experiment: Support HTTP connect and MASQUE/UDP proxies

### DIFF
--- a/extension/socks5proxy/CMakeLists.txt
+++ b/extension/socks5proxy/CMakeLists.txt
@@ -10,8 +10,3 @@ endif()
 add_subdirectory(src)
 add_subdirectory(bin)
 add_subdirectory(tests)
-
-target_compile_definitions(shared-sources INTERFACE MZ_PROXY_ENABLED)
-
-
-

--- a/extension/socks5proxy/bin/CMakeLists.txt
+++ b/extension/socks5proxy/bin/CMakeLists.txt
@@ -27,7 +27,7 @@ if(WIN32)
         winfwpolicy.h
         winsvcthread.cpp
         winsvcthread.h
-        )
+    )
     target_link_libraries(socksproxy PRIVATE Iphlpapi.lib)
 
     install(FILES

--- a/extension/socks5proxy/bin/linuxbypass.cpp
+++ b/extension/socks5proxy/bin/linuxbypass.cpp
@@ -10,6 +10,7 @@
 #include <unistd.h>
 
 #include <QAbstractSocket>
+#include <QDebug>
 #include <QHostAddress>
 #include <QScopeGuard>
 

--- a/extension/socks5proxy/bin/sockslogger.cpp
+++ b/extension/socks5proxy/bin/sockslogger.cpp
@@ -17,8 +17,8 @@
 #include <QHostAddress>
 #include <QLoggingCategory>
 
-#include "socks5.h"
 #include "proxyconnection.h"
+#include "socks5.h"
 
 // 4MB of log data ought to be enough for anyone.
 constexpr const qsizetype LOGFILE_MAX_SIZE = 4 * 1024 * 1024;
@@ -144,7 +144,7 @@ void SocksLogger::dataSentReceived(qint64 sent, qint64 received) {
 
 QDebug& SocksLogger::printEventStack(QDebug& msg, ProxyConnection* conn) {
   QStringList stack;
-  
+
   if (!conn->destHostname().isEmpty()) {
     stack.append(conn->destHostname());
   }

--- a/extension/socks5proxy/bin/sockslogger.h
+++ b/extension/socks5proxy/bin/sockslogger.h
@@ -11,10 +11,11 @@
 #include <QTimer>
 #include <QVector>
 
+class ProxyConnection;
 class QDir;
 class QFile;
+class QHostAddress;
 class Socks5;
-class Socks5Connection;
 
 // Calculates a boxcar average
 class BoxcarAverage final {
@@ -54,7 +55,7 @@ class SocksLogger final : public QObject {
   ~SocksLogger();
 
   static QString bytesToString(qint64 value);
-  static QDebug& printEventStack(QDebug& msg, Socks5Connection* conn);
+  static QDebug& printEventStack(QDebug& msg, ProxyConnection* conn);
   void printStatus();
 
   const QString& logfile() const { return m_logFileName; }
@@ -62,7 +63,7 @@ class SocksLogger final : public QObject {
   void setVerbose(bool enabled);
 
  public slots:
-  void incomingConnection(Socks5Connection* conn);
+  void incomingConnection(ProxyConnection* conn);
 
  private:
   static bool makeLogDir(const QDir& dir);
@@ -71,7 +72,8 @@ class SocksLogger final : public QObject {
   static void logHandler(QtMsgType type, const QMessageLogContext& ctx,
                          const QString& msg);
   void dataSentReceived(qint64 sent, qint64 received);
-  void connectionStateChanged();
+  void proxyDisconnect();
+  void proxyConnect(qintptr sd, const QHostAddress& dest);
   void tick();
 
  private:

--- a/extension/socks5proxy/bin/sockslogger.h
+++ b/extension/socks5proxy/bin/sockslogger.h
@@ -11,7 +11,8 @@
 #include <QTimer>
 #include <QVector>
 
-class ProxyConnection;
+#include "proxyconnection.h"
+
 class QDir;
 class QFile;
 class QHostAddress;

--- a/extension/socks5proxy/src/CMakeLists.txt
+++ b/extension/socks5proxy/src/CMakeLists.txt
@@ -18,6 +18,8 @@ target_sources(libSocks5proxy PRIVATE
     dnsresolver.cpp
     httpconnection.cpp
     httpconnection.h
+    masqueconnection.cpp
+    masqueconnection.h
     proxyconnection.cpp
     proxyconnection.h
     socks5.h

--- a/extension/socks5proxy/src/CMakeLists.txt
+++ b/extension/socks5proxy/src/CMakeLists.txt
@@ -18,6 +18,8 @@ target_sources(libSocks5proxy PRIVATE
     dnsresolver.cpp
     httpconnection.cpp
     httpconnection.h
+    httpconnectionbase.cpp
+    httpconnectionbase.h
     masqueconnection.cpp
     masqueconnection.h
     proxyconnection.cpp

--- a/extension/socks5proxy/src/CMakeLists.txt
+++ b/extension/socks5proxy/src/CMakeLists.txt
@@ -22,14 +22,19 @@ target_sources(libSocks5proxy PRIVATE
     httpconnectionbase.h
     httprequest.cpp
     httprequest.h
-    masqueconnection.cpp
-    masqueconnection.h
     proxyconnection.cpp
     proxyconnection.h
     socks5.h
     socks5.cpp
     socks5connection.cpp
     socks5connection.h
+)
+
+# MASQUE support is experimental for now, disable it in release builds.
+target_compile_definitions(libSocks5proxy PRIVATE $<$<CONFIG:Debug>:PROXY_MASQUE_ENABLED=1>)
+target_sources(libSocks5proxy PRIVATE
+    $<$<CONFIG:Debug>:masqueconnection.cpp>
+    $<$<CONFIG:Debug>:masqueconnection.h>
 )
 
 if(WIN32)

--- a/extension/socks5proxy/src/CMakeLists.txt
+++ b/extension/socks5proxy/src/CMakeLists.txt
@@ -26,14 +26,14 @@ target_sources(libSocks5proxy PRIVATE
 
 if(WIN32)
     target_sources(libSocks5proxy PRIVATE 
-        socks5local_windows.cpp
+        proxylocal_windows.cpp
         winutils.cpp
         winutils.h
     )
 elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
-    target_sources(libSocks5proxy PRIVATE socks5local_linux.cpp)
+    target_sources(libSocks5proxy PRIVATE proxylocal_linux.cpp)
 else()
-    target_sources(libSocks5proxy PRIVATE socks5local_default.cpp)
+    target_sources(libSocks5proxy PRIVATE proxylocal_default.cpp)
 endif()
 
 target_include_directories(libSocks5proxy PUBLIC

--- a/extension/socks5proxy/src/CMakeLists.txt
+++ b/extension/socks5proxy/src/CMakeLists.txt
@@ -16,6 +16,8 @@ target_compile_definitions(libSocks5proxy PRIVATE CARES_STATICLIB)
 target_sources(libSocks5proxy PRIVATE
     dnsresolver.h
     dnsresolver.cpp
+    httpconnection.cpp
+    httpconnection.h
     proxyconnection.cpp
     proxyconnection.h
     socks5.h

--- a/extension/socks5proxy/src/CMakeLists.txt
+++ b/extension/socks5proxy/src/CMakeLists.txt
@@ -20,6 +20,8 @@ target_sources(libSocks5proxy PRIVATE
     httpconnection.h
     httpconnectionbase.cpp
     httpconnectionbase.h
+    httprequest.cpp
+    httprequest.h
     masqueconnection.cpp
     masqueconnection.h
     proxyconnection.cpp

--- a/extension/socks5proxy/src/CMakeLists.txt
+++ b/extension/socks5proxy/src/CMakeLists.txt
@@ -14,12 +14,14 @@ target_link_libraries(libSocks5proxy PRIVATE c-ares)
 target_compile_definitions(libSocks5proxy PRIVATE CARES_STATICLIB)
 
 target_sources(libSocks5proxy PRIVATE
+    dnsresolver.h
+    dnsresolver.cpp
+    proxyconnection.cpp
+    proxyconnection.h
     socks5.h
     socks5.cpp
     socks5connection.cpp
     socks5connection.h
-    dnsresolver.h
-    dnsresolver.cpp
 )
 
 if(WIN32)

--- a/extension/socks5proxy/src/dnsresolver.cpp
+++ b/extension/socks5proxy/src/dnsresolver.cpp
@@ -105,6 +105,8 @@ void DNSResolver::addressInfoCallback(QObject* ctx, int status, int timeouts,
 
   // This should be our Socks5Connection
   switch (status) {
+    case ARES_SUCCESS:
+      break;
     case ARES_ENOTIMP:
       qDebug() << "The ares library does not know how to find addresses of "
                   "type family. ";
@@ -126,6 +128,9 @@ void DNSResolver::addressInfoCallback(QObject* ctx, int status, int timeouts,
     case ARES_EDESTRUCTION:
       qDebug() << "The name service channel channel is being destroyed; the "
                   "query will not be completed. ";
+      return;
+    default:
+      qDebug() << "Name resolution error:" << ares_strerror(status);
       return;
   }
 

--- a/extension/socks5proxy/src/dnsresolver.cpp
+++ b/extension/socks5proxy/src/dnsresolver.cpp
@@ -13,6 +13,7 @@
 #endif
 
 #include <QCoreApplication>
+#include <QDebug>
 #include <QMutexLocker>
 #include <QObject>
 

--- a/extension/socks5proxy/src/httpconnection.cpp
+++ b/extension/socks5proxy/src/httpconnection.cpp
@@ -5,8 +5,8 @@
 #include "httpconnection.h"
 
 #include <QBuffer>
-#include <QRegularExpression>
 #include <QLocalSocket>
+#include <QRegularExpression>
 #include <QTcpSocket>
 #include <QUrl>
 
@@ -35,7 +35,7 @@ bool HttpConnection::isProxyType(QIODevice* socket) {
 
   // Read one line and then roll it back.
   socket->startTransaction();
-  auto guard = qScopeGuard([socket](){ socket->rollbackTransaction(); });
+  auto guard = qScopeGuard([socket]() { socket->rollbackTransaction(); });
   QString line = QString(socket->readLine());
 
   auto match = m_requestRegex.match(line);
@@ -47,7 +47,7 @@ bool HttpConnection::isProxyType(QIODevice* socket) {
 }
 
 void HttpConnection::sendResponse(int code, const QString& message,
-                                  const QMap<QString,QString>& headers) {
+                                  const QMap<QString, QString>& headers) {
   QString status = QString("HTTP/1.1 %1 %2\r\n").arg(code).arg(message);
   QByteArray response = status.toUtf8();
 
@@ -90,8 +90,8 @@ void HttpConnection::handshakeRead() {
     // Read request headers.
     if (!line.isEmpty()) {
       qsizetype sep = line.indexOf(':');
-      if ((sep > 0) && (sep+1 < line.length())) {
-        QString value = line.sliced(sep+1).trimmed();
+      if ((sep > 0) && (sep + 1 < line.length())) {
+        QString value = line.sliced(sep + 1).trimmed();
         m_headers.insert(line.first(sep).toLower(), value);
         continue;
       } else {
@@ -188,6 +188,4 @@ void HttpConnection::onHostnameResolved(const QHostAddress& resolved) {
   m_destSocket->connectToHost(m_destAddress, m_destPort);
 }
 
-void HttpConnection::onHostnameNotFound() {
-  setError(404, "Not Found");
-}
+void HttpConnection::onHostnameNotFound() { setError(404, "Not Found"); }

--- a/extension/socks5proxy/src/httpconnection.cpp
+++ b/extension/socks5proxy/src/httpconnection.cpp
@@ -1,0 +1,38 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "httpconnection.h"
+
+#include <QRegularExpression>
+#include <QLocalSocket>
+#include <QTcpSocket>
+
+HttpConnection::HttpConnection(QTcpSocket* sock) : ProxyConnection(sock) {}
+HttpConnection::HttpConnection(QLocalSocket* sock) : ProxyConnection(sock) {}
+
+// Peek at the socket and determine if this is a socks connection.
+bool HttpConnection::isProxyType(QIODevice* socket) {
+  if (!socket->canReadLine()) {
+    return false;
+  }
+
+  // Read one line and then roll it back.
+  socket->startTransaction();
+  auto guard = qScopeGuard([socket](){ socket->rollbackTransaction(); });
+  QStringList line = QString(socket->readLine()).split(' ');
+
+  // There should be three tokens:
+  //  Method
+  //  Request-URI
+  //  HTTP-Version
+  static const QRegularExpression nonUpperAlpha("[^A-Z]");
+  static const QRegularExpression httpVersion("HTTP/[0-9].[0-9]");
+  if (line.length() != 3) {
+    return false;
+  }
+  if (!line.at(0).contains(nonUpperAlpha)) {
+    return false;
+  }
+  return line.at(3).indexOf(httpVersion) == 0;
+}

--- a/extension/socks5proxy/src/httpconnection.cpp
+++ b/extension/socks5proxy/src/httpconnection.cpp
@@ -8,7 +8,7 @@
 
 #include "dnsresolver.h"
 
-// Peek at the socket and determine if this is a HTTP connection.
+// Peek at the request and determine if this is a HTTP CONNECT proxy.
 bool HttpConnection::isProxyType(const HttpRequest& request) {
   return request.m_method == "CONNECT";
 }

--- a/extension/socks5proxy/src/httpconnection.cpp
+++ b/extension/socks5proxy/src/httpconnection.cpp
@@ -12,9 +12,6 @@
 
 #include "dnsresolver.h"
 
-HttpConnection::HttpConnection(QTcpSocket* sock) : ProxyConnection(sock) {}
-HttpConnection::HttpConnection(QLocalSocket* sock) : ProxyConnection(sock) {}
-
 const QRegularExpression HttpConnection::m_requestRegex =
     QRegularExpression("^([A-Z-]+)\\s([^\\s]+)*\\sHTTP/([0-9].[0-9])");
 

--- a/extension/socks5proxy/src/httpconnection.cpp
+++ b/extension/socks5proxy/src/httpconnection.cpp
@@ -137,7 +137,6 @@ void HttpConnection::onHostnameResolved(const QHostAddress& resolved) {
     sendResponse(200, "OK");
 
     setState(Proxy);
-    clientReadyRead();
   });
 
   connect(m_destSocket, &QTcpSocket::disconnected, this,

--- a/extension/socks5proxy/src/httpconnection.cpp
+++ b/extension/socks5proxy/src/httpconnection.cpp
@@ -65,16 +65,16 @@ void HttpConnection::handshakeRead() {
     QString header = m_clientSocket->readLine().trimmed();
 
     // Read the header line.
-    if (m_requestMethod.isEmpty()) {
+    if (m_method.isEmpty()) {
       auto match = m_requestRegex.match(header);
       if (!match.hasMatch() || match.lastCapturedIndex() != 3) {
         setError(400, "Bad Request");
         return;
       }
 
-      m_requestMethod = match.captured(1);
-      m_requestUri = match.captured(2);
-      m_requestVersion = match.captured(3);
+      m_method = match.captured(1);
+      m_uri = match.captured(2);
+      m_version = match.captured(3);
       continue;
     }
 
@@ -91,7 +91,7 @@ void HttpConnection::handshakeRead() {
     }
 
     // Handle the request method.
-    if (m_requestMethod == "CONNECT") {
+    if (m_method == "CONNECT") {
       doConnect();
     } else {
       setError(405, "Method Not Allowed");
@@ -102,7 +102,7 @@ void HttpConnection::handshakeRead() {
 
 void HttpConnection::doConnect() {
   // Split the request URI to separate the port and address.
-  QStringList list = m_requestUri.split(':');
+  QStringList list = m_uri.split(':');
   if (list.length() != 2) {
     setError(400, "Bad Request");
     return;
@@ -129,7 +129,6 @@ void HttpConnection::onHostnameResolved(const QHostAddress& resolved) {
   }
   Q_ASSERT(!resolved.isNull());
 
-  // Otherwise, connect to the destination.
   m_destAddress = resolved;
   m_destSocket = createDestSocket(m_destAddress, m_destPort);
 

--- a/extension/socks5proxy/src/httpconnection.cpp
+++ b/extension/socks5proxy/src/httpconnection.cpp
@@ -7,9 +7,15 @@
 #include <QRegularExpression>
 #include <QLocalSocket>
 #include <QTcpSocket>
+#include <QUrl>
+
+#include "dnsresolver.h"
 
 HttpConnection::HttpConnection(QTcpSocket* sock) : ProxyConnection(sock) {}
 HttpConnection::HttpConnection(QLocalSocket* sock) : ProxyConnection(sock) {}
+
+const QRegularExpression HttpConnection::m_requestRegex =
+    QRegularExpression("^([A-Z-]+)\\s([^\\s]+)*\\sHTTP/([0-9].[0-9])");
 
 // Peek at the socket and determine if this is a socks connection.
 bool HttpConnection::isProxyType(QIODevice* socket) {
@@ -20,54 +26,116 @@ bool HttpConnection::isProxyType(QIODevice* socket) {
   // Read one line and then roll it back.
   socket->startTransaction();
   auto guard = qScopeGuard([socket](){ socket->rollbackTransaction(); });
-  QStringList line = QString(socket->readLine()).split(' ');
+  QString line = QString(socket->readLine());
 
-  qDebug() << "Got HTTP request:" << line.join(' ');
-
-  // There should be three tokens:
-  //  Method
-  //  Request-URI
-  //  HTTP-Version
-  static const QRegularExpression nonUpperAlpha("[^A-Z]");
-  static const QRegularExpression httpVersion("HTTP/[0-9].[0-9]");
-  if (line.length() != 3) {
+  auto match = m_requestRegex.match(line);
+  if (!match.hasMatch() || match.lastCapturedIndex() != 3) {
     return false;
   }
-  if (!line.at(0).contains(nonUpperAlpha)) {
-    return false;
+
+  qDebug() << "Got HTTP request:" << match.captured(0);
+  qDebug() << "   method:" << match.captured(1);
+  qDebug() << "   uri:   " << match.captured(2);
+  qDebug() << "   version" << match.captured(3);
+  return true;
+}
+
+void HttpConnection::setError(int code, const QString& message) {
+  if (m_state != Proxy) {
+    QString response = QString("HTTP/1.1 %1 %2\r\n\r\n").arg(code).arg(message);
+    m_clientSocket->write(response.toUtf8());
   }
-  return line.at(3).indexOf(httpVersion) == 0;
+
+  m_errorString = message;
+  setState(Closed);
 }
 
 void HttpConnection::handshakeRead() {
   while (m_clientSocket->canReadLine()) {
+    QString header = m_clientSocket->readLine().trimmed();
+
     // Read the header line.
-    if (m_requestLine.isEmpty()) {
-      m_requestLine = m_clientSocket->readLine();
+    if (m_requestMethod.isEmpty()) {
+      auto match = m_requestRegex.match(header);
+      if (!match.hasMatch() || match.lastCapturedIndex() != 3) {
+        setError(400, "Bad Request");
+        return;
+      }
+
+      m_requestMethod = match.captured(1);
+      m_requestUri = match.captured(2);
+      m_requestVersion = match.captured(3);
       continue;
     }
-    
+
     // Read request headers.
-    QString header = m_clientSocket->readLine().trimmed();
     if (!header.isEmpty()) {
       qsizetype sep = header.indexOf(':');
       if ((sep > 0) && (sep+1 < header.length())) {
         m_headers.insert(header.first(sep), header.sliced(sep+1));
         continue;
       } else {
-        // TODO: Bad request
-        setState(Closed);
+        setError(400, "Bad Request");
         return;
       }
     }
 
-    // Otherwise, an empty line indicates the end of the request headers.
-    // TODO: Parse the headers.
-    setState(Proxy);
+    // Handle the request method.
+    if (m_requestMethod == "CONNECT") {
+      doConnect();
+    } else {
+      setError(405, "Method Not Allowed");
+    }
     return;
   }
 }
 
-void HttpConnection::clientProxyRead() {
-  // TODO:
+void HttpConnection::doConnect() {
+  // Split the request URI to separate the port and address.
+  QStringList list = m_requestUri.split(':');
+  if (list.length() != 2) {
+    setError(400, "Bad Request");
+    return;
+  }
+
+  QString dest = QUrl::fromPercentEncoding(list[1].toUtf8());
+  QHostAddress addr = QHostAddress(dest);
+  m_destPort = list[1].toUInt();
+  if (addr.isNull()) {
+    // Perform DNS resolution.
+    m_destHostname = dest;
+    setState(Resolve);
+    DNSResolver::instance()->resolveAsync(m_destHostname, this);
+    return;
+  }
+
+  onHostnameResolved(addr);
+
+}
+
+void HttpConnection::onHostnameResolved(const QHostAddress& resolved) {
+  if (m_destSocket != nullptr) {
+    // We might get multiple ip results.
+    return;
+  }
+  Q_ASSERT(!resolved.isNull());
+
+  // Otherwise, connect to the destination.
+  m_destAddress = resolved;
+  m_destSocket = createDestSocket(m_destAddress, m_destPort);
+
+  connect(m_destSocket, &QTcpSocket::connected, this, [this]() {
+    setError(200, "OK");
+
+    // Keep track of how many bytes are yet to be written to finish the
+    // negotiation. We should suppress the statistics signals for such traffic.
+    m_recvIgnoreBytes = m_clientSocket->bytesToWrite();
+  
+    setState(Proxy);
+    clientReadyRead();
+  });
+}
+
+void HttpConnection::onHostnameNotFound() {
+  setError(404, "Not Found");
 }

--- a/extension/socks5proxy/src/httpconnection.cpp
+++ b/extension/socks5proxy/src/httpconnection.cpp
@@ -4,28 +4,9 @@
 
 #include "httpconnection.h"
 
-#include <QBuffer>
-#include <QLocalSocket>
-#include <QRegularExpression>
 #include <QTcpSocket>
-#include <QUrl>
 
 #include "dnsresolver.h"
-
-const QRegularExpression HttpConnection::m_requestRegex =
-    QRegularExpression("^([A-Z-]+)\\s([^\\s]+)*\\sHTTP/([0-9].[0-9])");
-
-HttpConnection::HttpConnection(QIODevice* socket) : ProxyConnection(socket) {
-  m_baseUrl.setScheme("http");
-
-  QAbstractSocket* netsock = qobject_cast<QAbstractSocket*>(socket);
-  if (netsock) {
-    m_baseUrl.setHost(netsock->localAddress().toString());
-    m_baseUrl.setPort(netsock->localPort());
-  } else {
-    m_baseUrl.setHost("localhost");
-  }
-}
 
 // Peek at the socket and determine if this is a socks connection.
 bool HttpConnection::isProxyType(QIODevice* socket) {
@@ -44,95 +25,6 @@ bool HttpConnection::isProxyType(QIODevice* socket) {
   }
 
   return match.captured(1) == "CONNECT";
-}
-
-void HttpConnection::sendResponse(int code, const QString& message,
-                                  const QMap<QString, QString>& headers) {
-  QString status = QString("HTTP/1.1 %1 %2\r\n").arg(code).arg(message);
-  QByteArray response = status.toUtf8();
-
-  for (auto i = headers.cbegin(); i != headers.cend(); i++) {
-    QString header = QString("%1: %2\r\n").arg(i.key()).arg(i.value());
-    response.append(header.toUtf8());
-  }
-  response.append("\r\n");
-
-  m_clientSocket->write(response);
-}
-
-void HttpConnection::setError(int code, const QString& message) {
-  if (m_state != Proxy) {
-    sendResponse(code, message);
-  }
-
-  m_errorString = message;
-  setState(Closed);
-}
-
-void HttpConnection::handshakeRead() {
-  while (m_clientSocket->canReadLine()) {
-    QString line = m_clientSocket->readLine().trimmed();
-
-    // Read the header line.
-    if (m_method.isEmpty()) {
-      auto match = m_requestRegex.match(line);
-      if (!match.hasMatch() || match.lastCapturedIndex() != 3) {
-        setError(400, "Bad Request");
-        return;
-      }
-
-      m_method = match.captured(1);
-      m_uri = match.captured(2);
-      m_version = match.captured(3);
-      continue;
-    }
-
-    // Read request headers.
-    if (!line.isEmpty()) {
-      qsizetype sep = line.indexOf(':');
-      if ((sep > 0) && (sep + 1 < line.length())) {
-        QString value = line.sliced(sep + 1).trimmed();
-        m_headers.insert(line.first(sep).toLower(), value);
-        continue;
-      } else {
-        setError(400, "Bad Request");
-        return;
-      }
-    }
-    QString host = header("Host");
-    if (!host.isEmpty()) {
-      m_baseUrl.setAuthority(host);
-    }
-
-    // Attempt to invoke a meta-method to handle the request.
-    // We convert the method into camel-case, prepend 'onHttp'
-    // and invoke it as a method taking no arguments.
-    bool upper = true;
-    QString name = "onHttp";
-    for (const QChar c : m_method) {
-      if (!c.isLetter()) {
-        upper = true;
-      } else if (upper) {
-        name.append(c.toUpper());
-        upper = false;
-      } else {
-        name.append(c.toLower());
-      }
-    }
-    if (!QMetaObject::invokeMethod(this, qPrintable(name))) {
-      setError(405, "Method Not Allowed");
-    }
-    return;
-  }
-}
-
-const QString& HttpConnection::header(const QString& name) const {
-  auto entry = m_headers.find(name.toLower());
-  if (entry != m_headers.end()) {
-    return entry.value();
-  }
-  static const QString empty;
-  return empty;
 }
 
 void HttpConnection::onHttpConnect() {
@@ -187,5 +79,3 @@ void HttpConnection::onHostnameResolved(const QHostAddress& resolved) {
 
   m_destSocket->connectToHost(m_destAddress, m_destPort);
 }
-
-void HttpConnection::onHostnameNotFound() { setError(404, "Not Found"); }

--- a/extension/socks5proxy/src/httpconnection.h
+++ b/extension/socks5proxy/src/httpconnection.h
@@ -29,6 +29,8 @@ class HttpConnection final : public ProxyConnection {
   void onHostnameNotFound();
 
  private:
+  void sendResponse(int code, const QString& message,
+                    const QMap<QString,QString>& hdr = QMap<QString,QString>());
   void setError(int code, const QString& message);
   void doConnect();
 

--- a/extension/socks5proxy/src/httpconnection.h
+++ b/extension/socks5proxy/src/httpconnection.h
@@ -16,7 +16,7 @@ class HttpConnection final : public HttpConnectionBase {
   explicit HttpConnection(QIODevice* socket) : HttpConnectionBase(socket){};
   ~HttpConnection() = default;
 
-  // Peek at the socket and determine if this is a HTTP CONNECT connection.
+  // Peek at the request and determine if this is a HTTP CONNECT proxy.
   static bool isProxyType(const HttpRequest& request);
 
  private slots:

--- a/extension/socks5proxy/src/httpconnection.h
+++ b/extension/socks5proxy/src/httpconnection.h
@@ -16,8 +16,8 @@ class HttpConnection final : public HttpConnectionBase {
   explicit HttpConnection(QIODevice* socket) : HttpConnectionBase(socket){};
   ~HttpConnection() = default;
 
-  // Peek at the socket and determine if this is a MASQUE connection.
-  static bool isProxyType(QIODevice* socket);
+  // Peek at the socket and determine if this is a HTTP CONNECT connection.
+  static bool isProxyType(const HttpRequest& request);
 
  private slots:
   void onHostnameResolved(const QHostAddress& addr);

--- a/extension/socks5proxy/src/httpconnection.h
+++ b/extension/socks5proxy/src/httpconnection.h
@@ -1,0 +1,26 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef HTTPCONNECTION_H
+#define HTTPCONNECTION_H
+
+#include "proxyconnection.h"
+
+class QIODevice;
+class QLocalSocket;
+class QTcpSocket;
+
+class HttpConnection final : public ProxyConnection {
+  Q_OBJECT
+
+ public:
+  explicit HttpConnection(QTcpSocket* socket);
+  explicit HttpConnection(QLocalSocket* socket);
+  ~HttpConnection() = default;
+
+  // Peek at the socket and determine if this is a HTTP connection.
+  static bool isProxyType(QIODevice* socket);
+};
+
+#endif  // HTTPCONNECTION_H

--- a/extension/socks5proxy/src/httpconnection.h
+++ b/extension/socks5proxy/src/httpconnection.h
@@ -8,15 +8,12 @@
 #include "proxyconnection.h"
 
 class QIODevice;
-class QLocalSocket;
-class QTcpSocket;
 
 class HttpConnection final : public ProxyConnection {
   Q_OBJECT
 
  public:
-  explicit HttpConnection(QTcpSocket* socket);
-  explicit HttpConnection(QLocalSocket* socket);
+  explicit HttpConnection(QIODevice* socket) : ProxyConnection(socket) {};
   ~HttpConnection() = default;
 
   // Peek at the socket and determine if this is a HTTP connection.

--- a/extension/socks5proxy/src/httpconnection.h
+++ b/extension/socks5proxy/src/httpconnection.h
@@ -7,13 +7,16 @@
 
 #include "proxyconnection.h"
 
+#include <QMap>
+#include <QUrl>
+
 class QIODevice;
 
-class HttpConnection final : public ProxyConnection {
+class HttpConnection : public ProxyConnection {
   Q_OBJECT
 
  public:
-  explicit HttpConnection(QIODevice* socket) : ProxyConnection(socket) {};
+  explicit HttpConnection(QIODevice* socket);
   ~HttpConnection() = default;
 
   // Peek at the socket and determine if this is a HTTP connection.
@@ -24,14 +27,16 @@ class HttpConnection final : public ProxyConnection {
  private slots:
   void onHostnameResolved(const QHostAddress& addr);
   void onHostnameNotFound();
+  void onHttpConnect();
 
- private:
+ protected:
   void sendResponse(int code, const QString& message,
                     const QMap<QString,QString>& hdr = QMap<QString,QString>());
   void setError(int code, const QString& message);
-  void doConnect();
+  const QString& header(const QString& name) const;
 
   // HTTP Request fields.
+  QUrl m_baseUrl;
   QString m_method;
   QString m_uri;
   QString m_version;

--- a/extension/socks5proxy/src/httpconnection.h
+++ b/extension/socks5proxy/src/httpconnection.h
@@ -5,10 +5,10 @@
 #ifndef HTTPCONNECTION_H
 #define HTTPCONNECTION_H
 
-#include "proxyconnection.h"
-
 #include <QMap>
 #include <QUrl>
+
+#include "proxyconnection.h"
 
 class QIODevice;
 
@@ -30,8 +30,9 @@ class HttpConnection : public ProxyConnection {
   void onHttpConnect();
 
  protected:
-  void sendResponse(int code, const QString& message,
-                    const QMap<QString,QString>& hdr = QMap<QString,QString>());
+  void sendResponse(
+      int code, const QString& message,
+      const QMap<QString, QString>& hdr = QMap<QString, QString>());
   void setError(int code, const QString& message);
   const QString& header(const QString& name) const;
 
@@ -40,7 +41,7 @@ class HttpConnection : public ProxyConnection {
   QString m_method;
   QString m_uri;
   QString m_version;
-  QMap<QString,QString> m_headers;
+  QMap<QString, QString> m_headers;
 
   static const QRegularExpression m_requestRegex;
 };

--- a/extension/socks5proxy/src/httpconnection.h
+++ b/extension/socks5proxy/src/httpconnection.h
@@ -21,6 +21,17 @@ class HttpConnection final : public ProxyConnection {
 
   // Peek at the socket and determine if this is a HTTP connection.
   static bool isProxyType(QIODevice* socket);
+
+  void handshakeRead() override;
+  void clientProxyRead() override;
+
+ private:
+  // HTTP Request fields.
+  QString m_requestLine;
+  QString m_requestMethod;
+  QString m_requestUri;
+  QString m_requestVersion;
+  QMap<QString,QString> m_headers;
 };
 
 #endif  // HTTPCONNECTION_H

--- a/extension/socks5proxy/src/httpconnection.h
+++ b/extension/socks5proxy/src/httpconnection.h
@@ -23,15 +23,23 @@ class HttpConnection final : public ProxyConnection {
   static bool isProxyType(QIODevice* socket);
 
   void handshakeRead() override;
-  void clientProxyRead() override;
+
+ private slots:
+  void onHostnameResolved(const QHostAddress& addr);
+  void onHostnameNotFound();
 
  private:
+  void setError(int code, const QString& message);
+  void doConnect();
+
   // HTTP Request fields.
   QString m_requestLine;
   QString m_requestMethod;
   QString m_requestUri;
   QString m_requestVersion;
   QMap<QString,QString> m_headers;
+
+  static const QRegularExpression m_requestRegex;
 };
 
 #endif  // HTTPCONNECTION_H

--- a/extension/socks5proxy/src/httpconnection.h
+++ b/extension/socks5proxy/src/httpconnection.h
@@ -5,45 +5,23 @@
 #ifndef HTTPCONNECTION_H
 #define HTTPCONNECTION_H
 
-#include <QMap>
-#include <QUrl>
-
-#include "proxyconnection.h"
+#include "httpconnectionbase.h"
 
 class QIODevice;
 
-class HttpConnection : public ProxyConnection {
+class HttpConnection final : public HttpConnectionBase {
   Q_OBJECT
 
  public:
-  explicit HttpConnection(QIODevice* socket);
+  explicit HttpConnection(QIODevice* socket) : HttpConnectionBase(socket){};
   ~HttpConnection() = default;
 
-  // Peek at the socket and determine if this is a HTTP connection.
+  // Peek at the socket and determine if this is a MASQUE connection.
   static bool isProxyType(QIODevice* socket);
-
-  void handshakeRead() override;
 
  private slots:
   void onHostnameResolved(const QHostAddress& addr);
-  void onHostnameNotFound();
   void onHttpConnect();
-
- protected:
-  void sendResponse(
-      int code, const QString& message,
-      const QMap<QString, QString>& hdr = QMap<QString, QString>());
-  void setError(int code, const QString& message);
-  const QString& header(const QString& name) const;
-
-  // HTTP Request fields.
-  QUrl m_baseUrl;
-  QString m_method;
-  QString m_uri;
-  QString m_version;
-  QMap<QString, QString> m_headers;
-
-  static const QRegularExpression m_requestRegex;
 };
 
 #endif  // HTTPCONNECTION_H

--- a/extension/socks5proxy/src/httpconnection.h
+++ b/extension/socks5proxy/src/httpconnection.h
@@ -35,10 +35,9 @@ class HttpConnection final : public ProxyConnection {
   void doConnect();
 
   // HTTP Request fields.
-  QString m_requestLine;
-  QString m_requestMethod;
-  QString m_requestUri;
-  QString m_requestVersion;
+  QString m_method;
+  QString m_uri;
+  QString m_version;
   QMap<QString,QString> m_headers;
 
   static const QRegularExpression m_requestRegex;

--- a/extension/socks5proxy/src/httpconnectionbase.cpp
+++ b/extension/socks5proxy/src/httpconnectionbase.cpp
@@ -1,0 +1,114 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "httpconnectionbase.h"
+
+#include <QBuffer>
+#include <QUrl>
+
+const QRegularExpression HttpConnectionBase::m_requestRegex =
+    QRegularExpression("^([A-Z-]+)\\s([^\\s]+)*\\sHTTP/([0-9].[0-9])");
+
+HttpConnectionBase::HttpConnectionBase(QIODevice* s) : ProxyConnection(s) {
+  m_baseUrl.setScheme("http");
+
+  QAbstractSocket* netsock = qobject_cast<QAbstractSocket*>(s);
+  if (netsock) {
+    m_baseUrl.setHost(netsock->localAddress().toString());
+    m_baseUrl.setPort(netsock->localPort());
+  } else {
+    m_baseUrl.setHost("localhost");
+  }
+}
+
+void HttpConnectionBase::sendResponse(int code, const QString& message,
+                                      const QMap<QString, QString>& headers) {
+  QString status = QString("HTTP/1.1 %1 %2\r\n").arg(code).arg(message);
+  QByteArray response = status.toUtf8();
+
+  for (auto i = headers.cbegin(); i != headers.cend(); i++) {
+    QString header = QString("%1: %2\r\n").arg(i.key()).arg(i.value());
+    response.append(header.toUtf8());
+  }
+  response.append("\r\n");
+
+  m_clientSocket->write(response);
+}
+
+void HttpConnectionBase::setError(int code, const QString& message) {
+  if (m_state != Proxy) {
+    sendResponse(code, message);
+  }
+
+  m_errorString = message;
+  setState(Closed);
+}
+
+void HttpConnectionBase::handshakeRead() {
+  while (m_clientSocket->canReadLine()) {
+    QString line = m_clientSocket->readLine().trimmed();
+
+    // Read the header line.
+    if (m_method.isEmpty()) {
+      auto match = m_requestRegex.match(line);
+      if (!match.hasMatch() || match.lastCapturedIndex() != 3) {
+        setError(400, "Bad Request");
+        return;
+      }
+
+      m_method = match.captured(1);
+      m_uri = match.captured(2);
+      m_version = match.captured(3);
+      continue;
+    }
+
+    // Read request headers.
+    if (!line.isEmpty()) {
+      qsizetype sep = line.indexOf(':');
+      if ((sep > 0) && (sep + 1 < line.length())) {
+        QString value = line.sliced(sep + 1).trimmed();
+        m_headers.insert(line.first(sep).toLower(), value);
+        continue;
+      } else {
+        setError(400, "Bad Request");
+        return;
+      }
+    }
+    QString host = header("Host");
+    if (!host.isEmpty()) {
+      m_baseUrl.setAuthority(host);
+    }
+
+    // Attempt to invoke a meta-method to handle the request.
+    // We convert the method into camel-case, prepend 'onHttp'
+    // and invoke it as a method taking no arguments.
+    bool upper = true;
+    QString name = "onHttp";
+    for (const QChar c : m_method) {
+      if (!c.isLetter()) {
+        upper = true;
+      } else if (upper) {
+        name.append(c.toUpper());
+        upper = false;
+      } else {
+        name.append(c.toLower());
+      }
+    }
+    if (!QMetaObject::invokeMethod(this, qPrintable(name))) {
+      setError(405, "Method Not Allowed");
+    }
+    return;
+  }
+}
+
+const QString& HttpConnectionBase::header(const QString& name) const {
+  auto entry = m_headers.find(name.toLower());
+  if (entry != m_headers.end()) {
+    return entry.value();
+  }
+  static const QString empty;
+  return empty;
+}
+
+void HttpConnectionBase::onHostnameNotFound() { setError(404, "Not Found"); }

--- a/extension/socks5proxy/src/httpconnectionbase.h
+++ b/extension/socks5proxy/src/httpconnectionbase.h
@@ -1,0 +1,45 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef HTTPCONNECTIONBASE_H
+#define HTTPCONNECTIONBASE_H
+
+#include <QMap>
+#include <QRegularExpression>
+#include <QUrl>
+
+#include "proxyconnection.h"
+
+class QIODevice;
+
+class HttpConnectionBase : public ProxyConnection {
+  Q_OBJECT
+
+ public:
+  explicit HttpConnectionBase(QIODevice* socket);
+  ~HttpConnectionBase() = default;
+
+  void handshakeRead() override;
+
+ private slots:
+  void onHostnameNotFound();
+
+ protected:
+  void sendResponse(
+      int code, const QString& message,
+      const QMap<QString, QString>& hdr = QMap<QString, QString>());
+  void setError(int code, const QString& message);
+  const QString& header(const QString& name) const;
+
+  // HTTP Request fields.
+  QUrl m_baseUrl;
+  QString m_method;
+  QString m_uri;
+  QString m_version;
+  QMap<QString, QString> m_headers;
+
+  static const QRegularExpression m_requestRegex;
+};
+
+#endif  // HTTPCONNECTIONBASE_H

--- a/extension/socks5proxy/src/httpconnectionbase.h
+++ b/extension/socks5proxy/src/httpconnectionbase.h
@@ -6,9 +6,9 @@
 #define HTTPCONNECTIONBASE_H
 
 #include <QMap>
-#include <QRegularExpression>
 #include <QUrl>
 
+#include "httprequest.h"
 #include "proxyconnection.h"
 
 class QIODevice;
@@ -30,16 +30,10 @@ class HttpConnectionBase : public ProxyConnection {
       int code, const QString& message,
       const QMap<QString, QString>& hdr = QMap<QString, QString>());
   void setError(int code, const QString& message);
-  const QString& header(const QString& name) const;
 
   // HTTP Request fields.
   QUrl m_baseUrl;
-  QString m_method;
-  QString m_uri;
-  QString m_version;
-  QMap<QString, QString> m_headers;
-
-  static const QRegularExpression m_requestRegex;
+  HttpRequest m_request;
 };
 
 #endif  // HTTPCONNECTIONBASE_H

--- a/extension/socks5proxy/src/httprequest.cpp
+++ b/extension/socks5proxy/src/httprequest.cpp
@@ -1,0 +1,59 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "httprequest.h"
+
+#include <QIODevice>
+#include <QRegularExpression>
+
+const QRegularExpression HttpRequest::m_regex =
+    QRegularExpression("^([A-Z-]+)\\s([^\\s]+)*\\sHTTP/([0-9].[0-9])");
+
+HttpRequest::HttpRequest(const QString& line) {
+  auto match = m_regex.match(line);
+  if (!match.hasMatch() || match.lastCapturedIndex() != 3) {
+    return;
+  }
+
+  m_method = match.captured(1);
+  m_uri = match.captured(2);
+  m_verMajor = match.captured(3)[0].digitValue();
+  m_verMinor = match.captured(3)[2].digitValue();
+}
+
+bool HttpRequest::isValid() const {
+  return !m_method.isEmpty() && !m_uri.isEmpty() && (m_verMajor > 0) &&
+         (m_verMinor >= 0);
+}
+
+// Peek at the socket and determine if this is a socks connection.
+HttpRequest HttpRequest::peek(QIODevice* socket) {
+  if (!socket->canReadLine()) {
+    return HttpRequest();
+  }
+
+  // Read one line and then roll it back.
+  socket->startTransaction();
+  auto guard = qScopeGuard([socket]() { socket->rollbackTransaction(); });
+  return HttpRequest(QString(socket->readLine()));
+}
+
+bool HttpRequest::addHeader(const QString& line) {
+  qsizetype sep = line.indexOf(':');
+  if ((sep <= 0) || ((sep + 1) >= line.length())) {
+    return false;
+  }
+  QString value = line.sliced(sep + 1).trimmed();
+  m_headers.insert(line.first(sep).toLower(), value);
+  return true;
+}
+
+const QString& HttpRequest::header(const QString& name) const {
+  auto entry = m_headers.find(name.toLower());
+  if (entry != m_headers.end()) {
+    return entry.value();
+  }
+  static const QString empty;
+  return empty;
+}

--- a/extension/socks5proxy/src/httprequest.h
+++ b/extension/socks5proxy/src/httprequest.h
@@ -1,0 +1,34 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef HTTPREQUEST_H
+#define HTTPREQUEST_H
+
+#include <QString>
+#include <QMap>
+
+class QIODevice;
+
+class HttpRequest {
+ public:
+  HttpRequest() = default;
+  HttpRequest(const QString& line);
+
+  bool isValid() const;
+  static HttpRequest peek(QIODevice* socket);
+
+  bool addHeader(const QString& line);
+  const QString& header(const QString& name) const;
+
+  QString m_method;
+  QString m_uri;
+  int m_verMajor = -1;
+  int m_verMinor = -1;
+
+ private:
+  QMap<QString, QString> m_headers;
+  static const QRegularExpression m_regex;
+};
+
+#endif  // HTTPREQUEST_H

--- a/extension/socks5proxy/src/httprequest.h
+++ b/extension/socks5proxy/src/httprequest.h
@@ -5,8 +5,8 @@
 #ifndef HTTPREQUEST_H
 #define HTTPREQUEST_H
 
-#include <QString>
 #include <QMap>
+#include <QString>
 
 class QIODevice;
 

--- a/extension/socks5proxy/src/masqueconnection.cpp
+++ b/extension/socks5proxy/src/masqueconnection.cpp
@@ -22,7 +22,7 @@ bool MasqueConnection::isProxyType(QIODevice* socket) {
 
   // Read one line and then roll it back.
   socket->startTransaction();
-  auto guard = qScopeGuard([socket](){ socket->rollbackTransaction(); });
+  auto guard = qScopeGuard([socket]() { socket->rollbackTransaction(); });
   QString line = QString(socket->readLine());
 
   auto match = m_requestRegex.match(line);
@@ -83,7 +83,7 @@ void MasqueConnection::onHostnameResolved(const QHostAddress& resolved) {
   m_destSocket = createDestSocket<QUdpSocket>(m_destAddress, m_destPort);
 
   connect(m_destSocket, &QUdpSocket::connected, this, [this]() {
-    QMap<QString,QString> values;
+    QMap<QString, QString> values;
     values["Connection"] = "Upgrade";
     values["Upgrade"] = "connect-udp";
     sendResponse(101, "Switching Protocols", values);
@@ -100,7 +100,7 @@ void MasqueConnection::onHostnameResolved(const QHostAddress& resolved) {
 
 bool MasqueConnection::readVarInt(quint64& value) {
   quint8 first;
-  if (!m_clientSocket->peek((char *)&first, 1)) {
+  if (!m_clientSocket->peek((char*)&first, 1)) {
     return false;
   }
   quint8 len = 1 << (first >> 6);
@@ -195,8 +195,9 @@ void MasqueConnection::destProxyRead() {
     putVarInt(MASQUE_CAPSULE_DATAGRAM, capsule);
     putVarInt(data.length(), capsule);
 
-    qsizetype available = MAX_CONNECTION_BUFFER - m_clientSocket->bytesToWrite();
-    if ((data.length()+capsule.length()) > available) {
+    qsizetype available =
+        MAX_CONNECTION_BUFFER - m_clientSocket->bytesToWrite();
+    if ((data.length() + capsule.length()) > available) {
       // Drop the datagram if it would overflow the connection buffer.
       continue;
     }

--- a/extension/socks5proxy/src/masqueconnection.cpp
+++ b/extension/socks5proxy/src/masqueconnection.cpp
@@ -4,6 +4,10 @@
 
 #include "masqueconnection.h"
 
+#ifndef PROXY_MASQUE_ENABLED
+#  error "MASQUE proxy protocol is disabled"
+#endif
+
 #include <QDebug>
 #include <QNetworkDatagram>
 #include <QUdpSocket>

--- a/extension/socks5proxy/src/masqueconnection.cpp
+++ b/extension/socks5proxy/src/masqueconnection.cpp
@@ -35,11 +35,11 @@ void MasqueConnection::onHttpGet() {
   // RFC9298 Section 3.2:
   // The request shall include a Connection header with value "upgrade"
   // The request shall include an Upgrade header with value "connect-udp"
-  if (m_request.header("Connection").compare("Upgrade", Qt::CaseInsensitive) != 0) {
+  if (m_request.header("Connection").compare("Upgrade", Qt::CaseInsensitive)) {
     setError(400, "Bad Request");
     return;
   }
-  if (m_request.header("Upgrade").compare("connect-udp", Qt::CaseInsensitive) != 0) {
+  if (m_request.header("Upgrade").compare("connect-udp", Qt::CaseInsensitive)) {
     setError(400, "Bad Request");
     return;
   }

--- a/extension/socks5proxy/src/masqueconnection.cpp
+++ b/extension/socks5proxy/src/masqueconnection.cpp
@@ -1,0 +1,221 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "masqueconnection.h"
+
+#include <QNetworkDatagram>
+#include <QRegularExpression>
+#include <QUdpSocket>
+#include <QUrl>
+#include <QtEndian>
+
+#include "dnsresolver.h"
+
+constexpr const uint MASQUE_CAPSULE_DATAGRAM = 0;
+
+// Peek at the socket and determine if this is a MASQUE connection.
+bool MasqueConnection::isProxyType(QIODevice* socket) {
+  if (!socket->canReadLine()) {
+    return false;
+  }
+
+  // Read one line and then roll it back.
+  socket->startTransaction();
+  auto guard = qScopeGuard([socket](){ socket->rollbackTransaction(); });
+  QString line = QString(socket->readLine());
+
+  auto match = m_requestRegex.match(line);
+  if (!match.hasMatch() || match.lastCapturedIndex() != 3) {
+    return false;
+  }
+
+  return (match.captured(1) == "GET") &&
+         match.captured(2).contains(".well-known/masque/udp/");
+}
+
+void MasqueConnection::onHttpGet() {
+  // Resolve the URL and parse the destination from the path.
+  QUrl fullUrl = m_baseUrl.resolved(QUrl(m_uri, QUrl::StrictMode));
+  QStringList path = fullUrl.path().split('/', Qt::SkipEmptyParts);
+
+  // Validate that it matches our template.
+  if ((path.length() != 5) || (path.at(0) != ".well-known") ||
+      (path.at(1) != "masque") || (path.at(2) != "udp")) {
+    setError(404, "Not Found");
+    return;
+  }
+
+  // RFC9298 Section 3.2:
+  // The request shall include a Connection header with value "upgrade"
+  // The request shall include an Upgrade header with value "connect-udp"
+  if (header("Connection").compare("Upgrade", Qt::CaseInsensitive) != 0) {
+    setError(400, "Bad Request");
+    return;
+  }
+  if (header("Upgrade").compare("connect-udp", Qt::CaseInsensitive) != 0) {
+    setError(400, "Bad Request");
+    return;
+  }
+
+  // Parse the destination and port.
+  m_destPort = path.at(4).toUInt();
+  QHostAddress address;
+  if (address.setAddress(path.at(3))) {
+    onHostnameResolved(address);
+    return;
+  }
+
+  // Perform DNS resolution.
+  m_destHostname = path.at(3);
+  setState(Resolve);
+  DNSResolver::instance()->resolveAsync(m_destHostname, this);
+}
+
+void MasqueConnection::onHostnameResolved(const QHostAddress& resolved) {
+  if (m_destSocket != nullptr) {
+    // We might get multiple ip results.
+    return;
+  }
+  Q_ASSERT(!resolved.isNull());
+
+  m_destAddress = resolved;
+  m_destSocket = createDestSocket<QUdpSocket>(m_destAddress, m_destPort);
+
+  connect(m_destSocket, &QUdpSocket::connected, this, [this]() {
+    QMap<QString,QString> values;
+    values["Connection"] = "Upgrade";
+    values["Upgrade"] = "connect-udp";
+    sendResponse(101, "Switching Protocols", values);
+    setState(Proxy);
+  });
+
+  connect(m_destSocket, &QUdpSocket::errorOccurred, this,
+          [this](QAbstractSocket::SocketError error) {
+            qDebug() << "dest socket error:" << m_destSocket->errorString();
+          });
+
+  m_destSocket->connectToHost(m_destAddress, m_destPort);
+}
+
+bool MasqueConnection::readVarInt(quint64& value) {
+  quint8 first;
+  if (!m_clientSocket->peek((char *)&first, 1)) {
+    return false;
+  }
+  quint8 len = 1 << (first >> 6);
+  QByteArray buf = m_clientSocket->read(len);
+  if (buf.length() != len) {
+    return false;
+  }
+  value = 0;
+  buf[0] &= 0x3F;
+  for (quint8 x : buf) {
+    value = (value << 8) + x;
+  }
+  return true;
+}
+
+void MasqueConnection::putVarInt(quint64 value, QByteArray& buffer) {
+  if ((value >> 6) == 0) {
+    quint8 v = value;
+    buffer.append(v);
+  } else if ((value >> 14) == 0) {
+    quint16 v = qToBigEndian<quint16>(value | (0x1u << 14));
+    buffer.append((char*)&v, sizeof(v));
+  } else if ((value >> 30) == 0) {
+    quint32 v = qToBigEndian<quint32>(value | (0x2u << 30));
+    buffer.append((char*)&v, sizeof(v));
+  } else {
+    quint64 v = qToBigEndian(value | 0x3ull << 62);
+    buffer.append((char*)&v, sizeof(v));
+  }
+}
+
+void MasqueConnection::clientProxyRead() {
+  while (true) {
+    if (m_capsuleLength == 0) {
+      // Read the next capsule header.
+      m_clientSocket->startTransaction();
+      quint64 type;
+      quint64 len;
+      if (!readVarInt(type) || !readVarInt(len)) {
+        m_clientSocket->rollbackTransaction();
+        return;
+      }
+      m_clientSocket->commitTransaction();
+
+      // Reset the buffer.
+      m_capsuleType = type;
+      m_capsuleLength = len;
+      m_capsuleBuffer.clear();
+
+      // If the length exceeds the max buffer size, drop it.
+      m_capsuleDrop = (len > MAX_CONNECTION_BUFFER);
+      if (!m_capsuleDrop) {
+        m_capsuleBuffer.reserve(len);
+      }
+    } else if (m_capsuleDrop) {
+      // Discard unsupportable capsules.
+      qint64 sz = m_clientSocket->skip(m_capsuleLength);
+      if (sz <= 0) {
+        return;
+      }
+      m_capsuleLength -= sz;
+    } else if (m_capsuleBuffer.length() < m_capsuleLength) {
+      // Read more data into the capsule buffer.
+      quint64 needed = m_capsuleLength - m_capsuleBuffer.length();
+      QByteArray chunk = m_clientSocket->read(needed);
+      if (chunk.isEmpty()) {
+        return;
+      }
+      m_capsuleBuffer.append(chunk);
+    } else {
+      // Handle the capsule.
+      handleCapsule(m_capsuleType, m_capsuleBuffer);
+      m_capsuleType = 0;
+      m_capsuleLength = 0;
+      m_capsuleBuffer.clear();
+    }
+  }
+}
+
+void MasqueConnection::destProxyRead() {
+  QUdpSocket* socket = qobject_cast<QUdpSocket*>(m_destSocket);
+  Q_ASSERT(socket);
+
+  while (socket->hasPendingDatagrams()) {
+    auto dgram = socket->receiveDatagram();
+    if (dgram.isNull()) {
+      return;
+    }
+
+    QByteArray data = dgram.data();
+    QByteArray capsule;
+    putVarInt(MASQUE_CAPSULE_DATAGRAM, capsule);
+    putVarInt(data.length(), capsule);
+
+    qsizetype available = MAX_CONNECTION_BUFFER - m_clientSocket->bytesToWrite();
+    if ((data.length()+capsule.length()) > available) {
+      // Drop the datagram if it would overflow the connection buffer.
+      continue;
+    }
+
+    // Send the datagram capsule.
+    m_clientSocket->write(capsule);
+    m_clientSocket->write(data);
+  }
+}
+
+void MasqueConnection::handleCapsule(quint64 type, const QByteArray& data) {
+  switch (type) {
+    case MASQUE_CAPSULE_DATAGRAM:
+      // DATAGRAM capsule
+      m_destSocket->write(data);
+      break;
+
+    default:
+      // Unsupported capsule.
+      break;
+  }
+}

--- a/extension/socks5proxy/src/masqueconnection.cpp
+++ b/extension/socks5proxy/src/masqueconnection.cpp
@@ -5,7 +5,6 @@
 #include "masqueconnection.h"
 
 #include <QNetworkDatagram>
-#include <QRegularExpression>
 #include <QUdpSocket>
 #include <QUrl>
 #include <QtEndian>

--- a/extension/socks5proxy/src/masqueconnection.cpp
+++ b/extension/socks5proxy/src/masqueconnection.cpp
@@ -18,7 +18,7 @@
 
 constexpr const uint MASQUE_CAPSULE_DATAGRAM = 0;
 
-// Peek at the socket and determine if this is a MASQUE connection.
+// Peek at the request and determine if this is a MASQUE connection.
 bool MasqueConnection::isProxyType(const HttpRequest& request) {
   return request.m_method == "GET" &&
          request.m_uri.contains(".well-known/masque/udp/");

--- a/extension/socks5proxy/src/masqueconnection.h
+++ b/extension/socks5proxy/src/masqueconnection.h
@@ -4,6 +4,7 @@
 
 #ifndef MASQUECONNECTION_H
 #define MASQUECONNECTION_H
+#ifdef PROXY_MASQUE_ENABLED
 
 #include "httpconnectionbase.h"
 
@@ -40,4 +41,5 @@ class MasqueConnection final : public HttpConnectionBase {
   bool m_capsuleDrop = false;
 };
 
+#endif  // PROXY_MASQUE_ENABLED
 #endif  // MASQUECONNECTION_H

--- a/extension/socks5proxy/src/masqueconnection.h
+++ b/extension/socks5proxy/src/masqueconnection.h
@@ -5,15 +5,15 @@
 #ifndef MASQUECONNECTION_H
 #define MASQUECONNECTION_H
 
-#include "httpconnection.h"
+#include "httpconnectionbase.h"
 
 class QIODevice;
 
-class MasqueConnection final : public HttpConnection {
+class MasqueConnection final : public HttpConnectionBase {
   Q_OBJECT
 
  public:
-  explicit MasqueConnection(QIODevice* socket) : HttpConnection(socket){};
+  explicit MasqueConnection(QIODevice* socket) : HttpConnectionBase(socket){};
   ~MasqueConnection() = default;
 
   // Peek at the socket and determine if this is a MASQUE connection.

--- a/extension/socks5proxy/src/masqueconnection.h
+++ b/extension/socks5proxy/src/masqueconnection.h
@@ -10,6 +10,7 @@
 
 class QIODevice;
 
+// Implements HTTP connect-udp proxying from MASQUE/RFC9298.
 class MasqueConnection final : public HttpConnectionBase {
   Q_OBJECT
 
@@ -17,7 +18,7 @@ class MasqueConnection final : public HttpConnectionBase {
   explicit MasqueConnection(QIODevice* socket) : HttpConnectionBase(socket){};
   ~MasqueConnection() = default;
 
-  // Peek at the socket and determine if this is a MASQUE connection.
+  // Peek at the request and determine if this is a MASQUE connection.
   static bool isProxyType(const HttpRequest& request);
 
   void clientProxyRead() override;

--- a/extension/socks5proxy/src/masqueconnection.h
+++ b/extension/socks5proxy/src/masqueconnection.h
@@ -1,0 +1,43 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef MASQUECONNECTION_H
+#define MASQUECONNECTION_H
+
+#include "httpconnection.h"
+
+class QIODevice;
+
+class MasqueConnection final : public HttpConnection {
+  Q_OBJECT
+
+ public:
+  explicit MasqueConnection(QIODevice* socket) : HttpConnection(socket) {};
+  ~MasqueConnection() = default;
+
+  // Peek at the socket and determine if this is a MASQUE connection.
+  static bool isProxyType(QIODevice* socket);
+
+  void clientProxyRead() override;
+  void destProxyRead() override;
+
+ private slots:
+  void onHostnameResolved(const QHostAddress& addr);
+  void onHttpGet();
+
+ private:
+  // QUIC variable integer handling.
+  bool readVarInt(quint64& value);
+  static void putVarInt(quint64 value, QByteArray& buffer);
+
+  // RFC 9297 HTTP datagram and capsule protocol handling.
+  void handleCapsule(quint64 type, const QByteArray& data);
+
+  quint64 m_capsuleType = 0;
+  quint64 m_capsuleLength = 0;
+  QByteArray m_capsuleBuffer;
+  bool m_capsuleDrop = false;
+};
+
+#endif  // MASQUECONNECTION_H

--- a/extension/socks5proxy/src/masqueconnection.h
+++ b/extension/socks5proxy/src/masqueconnection.h
@@ -4,9 +4,9 @@
 
 #ifndef MASQUECONNECTION_H
 #define MASQUECONNECTION_H
-#ifdef PROXY_MASQUE_ENABLED
 
-#include "httpconnectionbase.h"
+#ifdef PROXY_MASQUE_ENABLED
+#  include "httpconnectionbase.h"
 
 class QIODevice;
 

--- a/extension/socks5proxy/src/masqueconnection.h
+++ b/extension/socks5proxy/src/masqueconnection.h
@@ -17,7 +17,7 @@ class MasqueConnection final : public HttpConnectionBase {
   ~MasqueConnection() = default;
 
   // Peek at the socket and determine if this is a MASQUE connection.
-  static bool isProxyType(QIODevice* socket);
+  static bool isProxyType(const HttpRequest& request);
 
   void clientProxyRead() override;
   void destProxyRead() override;

--- a/extension/socks5proxy/src/masqueconnection.h
+++ b/extension/socks5proxy/src/masqueconnection.h
@@ -13,7 +13,7 @@ class MasqueConnection final : public HttpConnection {
   Q_OBJECT
 
  public:
-  explicit MasqueConnection(QIODevice* socket) : HttpConnection(socket) {};
+  explicit MasqueConnection(QIODevice* socket) : HttpConnection(socket){};
   ~MasqueConnection() = default;
 
   // Peek at the socket and determine if this is a MASQUE connection.

--- a/extension/socks5proxy/src/proxyconnection.cpp
+++ b/extension/socks5proxy/src/proxyconnection.cpp
@@ -6,11 +6,23 @@
 
 #include <QLocalSocket>
 #include <QTcpSocket>
+#include <QTimer>
+
+#ifdef Q_OS_WIN
+#  include <winsock2.h>
+#  include <ws2ipdef.h>
+
+#  include "winutils.h"
+#else
+#  include <arpa/inet.h>
+#endif
 
 ProxyConnection::ProxyConnection(QIODevice* socket)
     : QObject(socket), m_clientSocket(socket) {
   connect(m_clientSocket, &QIODevice::readyRead, this,
-          &ProxyConnection::readyRead);
+          &ProxyConnection::clientReadyRead);
+  connect(m_clientSocket, &QIODevice::bytesWritten, this,
+          &ProxyConnection::clientBytesWritten);
 
   // Handle TCP/UDP socket setup.
   QAbstractSocket* netsock = qobject_cast<QAbstractSocket*>(socket);
@@ -18,6 +30,8 @@ ProxyConnection::ProxyConnection(QIODevice* socket)
     m_clientPort = netsock->localPort();
     m_clientName = netsock->peerAddress().toString();
 
+    connect(netsock, &QAbstractSocket::disconnected, this,
+            [this]() { setState(Closed); });
     connect(netsock, &QAbstractSocket::errorOccurred, this,
             &ProxyConnection::clientErrorOccurred<QAbstractSocket>);
 
@@ -30,15 +44,20 @@ ProxyConnection::ProxyConnection(QIODevice* socket)
     m_clientPort = 0;
     m_clientName = localClientName(local);
 
+    connect(local, &QLocalSocket::disconnected, this,
+            [this]() { setState(Closed); });
     connect(local, &QLocalSocket::errorOccurred, this,
             &ProxyConnection::clientErrorOccurred<QLocalSocket>);
 
     local->setReadBufferSize(MAX_CONNECTION_BUFFER);
   }
+
+  // Immediately trigger the readyRead signal.
+  QTimer::singleShot(0, this, &ProxyConnection::clientReadyRead);
 }
 
 void ProxyConnection::proxy(QIODevice* from, QIODevice* to,
-                             quint64& watermark) {
+                            quint64& watermark) {
   Q_ASSERT(from && to);
 
   for (;;) {
@@ -70,7 +89,7 @@ void ProxyConnection::proxy(QIODevice* from, QIODevice* to,
   }
 }
 
-void ProxyConnection::readyRead() {
+void ProxyConnection::clientReadyRead() {
   if (m_state >= Handshake) {
     handshakeRead();
   }
@@ -88,14 +107,20 @@ void ProxyConnection::setState(int newstate) {
   m_state = newstate;
   emit stateChanged();
 
+  if (m_state == Proxy) {
+    // Keep track of how many bytes are yet to be written to finish the
+    // negotiation. We should suppress the statistics signals for such traffic.
+    m_recvIgnoreBytes = m_clientSocket->bytesToWrite();
+  }
+
   // If the state is closing. Shutdown the sockets.
   if (m_state == Closed) {
     emit disconnected();
   
     m_clientSocket->close();
-    //if (m_outSocket != nullptr) {
-    //  m_outSocket->close();
-    //}
+    if (m_destSocket != nullptr) {
+      m_destSocket->close();
+    }
 
     // Request self-destruction
     deleteLater();
@@ -110,4 +135,76 @@ void ProxyConnection::clientErrorOccurred(int error) {
   }
 
   setState(Closed);
+}
+
+void ProxyConnection::clientBytesWritten(qint64 bytes) {
+  // Ignore this signal outside of the proxy state.
+  if (m_state != Proxy) {
+    return;
+  }
+
+  // Ignore this signal if it's just reporting a negotiation packet.
+  if (m_recvIgnoreBytes >= bytes) {
+    m_recvIgnoreBytes -= bytes;
+    return;
+  } else if (m_recvIgnoreBytes > 0) {
+    bytes -= m_recvIgnoreBytes;
+    m_recvIgnoreBytes = 0;
+  }
+
+  // Drive statistics and proxy data more data, if available.
+  emit dataSentReceived(0, bytes);
+  destProxyRead();
+}
+
+// The default implementation - just calls proxy().
+void ProxyConnection::clientProxyRead() {
+  proxy(m_clientSocket, m_destSocket, m_sendHighWaterMark);
+}
+
+// The default implementation - just calls proxy().
+void ProxyConnection::destProxyRead() {
+  proxy(m_destSocket, m_clientSocket, m_recvHighWaterMark);
+}
+
+QTcpSocket* ProxyConnection::createDestSocket(const QHostAddress& dest, quint16 port) {
+  Q_ASSERT(!dest.isNull());
+
+  int family;
+  if (dest.protocol() == QAbstractSocket::IPv6Protocol) {
+    family = AF_INET6;
+  } else {
+    family = AF_INET;
+  }
+
+  // The platform layer might want to fiddle with the socket before we connect,
+  // but the socket descriptor is typically created inside the connectToHost()
+  // method. So let's create the socket manually and emit a signal for the
+  // platform logic to hook on.
+  qintptr newsock = socket(family, SOCK_STREAM, IPPROTO_TCP);
+#ifdef Q_OS_WIN
+  if (newsock == INVALID_SOCKET) {
+    m_errorString = WinUtils::win32strerror(WSAGetLastError());
+    return nullptr;
+  }
+#else
+  if (newsock < 0) {
+    m_errorString = strerror(errno);
+    return nullptr;
+  }
+#endif
+  emit setupOutSocket(newsock, m_destAddress);
+
+  auto socket = new QTcpSocket(this);
+  socket->setSocketDescriptor(newsock, QAbstractSocket::UnconnectedState);
+  socket->setSocketOption(QAbstractSocket::KeepAliveOption, 1);
+  socket->connectToHost(m_destAddress, port);
+
+  connect(socket, &QIODevice::readyRead, this, [this]() { destProxyRead(); });
+  connect(socket, &QIODevice::bytesWritten, this, [this](qint64 bytes) {
+    emit dataSentReceived(bytes, 0);
+    clientReadyRead();
+  });
+
+  return socket;
 }

--- a/extension/socks5proxy/src/proxyconnection.cpp
+++ b/extension/socks5proxy/src/proxyconnection.cpp
@@ -4,6 +4,9 @@
 
 #include "proxyconnection.h"
 
+#include <QLocalSocket>
+#include <QTcpSocket>
+
 ProxyConnection::ProxyConnection(QIODevice* socket) : QObject(socket) {
   // Handle TCP/UDP socket setup.
   QAbstractSocket* netsock = qobject_cast<QAbstractSocket*>(socket);

--- a/extension/socks5proxy/src/proxyconnection.cpp
+++ b/extension/socks5proxy/src/proxyconnection.cpp
@@ -111,6 +111,9 @@ void ProxyConnection::setState(int newstate) {
     // Keep track of how many bytes are yet to be written to finish the
     // negotiation. We should suppress the statistics signals for such traffic.
     m_recvIgnoreBytes = m_clientSocket->bytesToWrite();
+
+    // Kick the flow control once we are ready to start passing traffic.
+    clientReadyRead();
   }
 
   // If the state is closing. Shutdown the sockets.

--- a/extension/socks5proxy/src/proxyconnection.cpp
+++ b/extension/socks5proxy/src/proxyconnection.cpp
@@ -1,0 +1,40 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "proxyconnection.h"
+
+ProxyConnection::ProxyConnection(QIODevice* socket) : QObject(socket) {}
+
+void ProxyConnection::proxy(QIODevice* from, QIODevice* to,
+                             quint64& watermark) {
+  Q_ASSERT(from && to);
+
+  for (;;) {
+    qint64 available = from->bytesAvailable();
+    if (available <= 0) {
+      break;
+    }
+
+    qint64 capacity = MAX_CONNECTION_BUFFER - to->bytesToWrite();
+    if (capacity <= 0) {
+      break;
+    }
+
+    QByteArray data = from->read(qMin(available, capacity));
+    if (data.length() == 0) {
+      break;
+    }
+    qint64 sent = to->write(data);
+    if (sent != data.length()) {
+      qDebug() << "Truncated write. Sent" << sent << "of" << data.length();
+      break;
+    }
+  }
+
+  // Update buffer high watermark.
+  qint64 queued = to->bytesToWrite();
+  if (queued > watermark) {
+    watermark = queued;
+  }
+}

--- a/extension/socks5proxy/src/proxyconnection.cpp
+++ b/extension/socks5proxy/src/proxyconnection.cpp
@@ -119,7 +119,7 @@ void ProxyConnection::setState(int newstate) {
   // If the state is closing. Shutdown the sockets.
   if (m_state == Closed) {
     emit disconnected();
-  
+
     m_clientSocket->close();
     if (m_destSocket != nullptr) {
       m_destSocket->close();
@@ -175,7 +175,7 @@ QAbstractSocket* ProxyConnection::createDestSocketImpl(QAbstractSocket* sock,
                                                        quint16 port) {
   Q_ASSERT(!dest.isNull());
   Q_ASSERT(sock != nullptr);
-  auto guard = qScopeGuard([sock](){ sock->deleteLater(); });
+  auto guard = qScopeGuard([sock]() { sock->deleteLater(); });
 
   int family;
   if (dest.protocol() == QAbstractSocket::IPv6Protocol) {
@@ -211,11 +211,10 @@ QAbstractSocket* ProxyConnection::createDestSocketImpl(QAbstractSocket* sock,
   sock->setSocketOption(QAbstractSocket::KeepAliveOption, 1);
 
   connect(sock, &QIODevice::readyRead, this, [this]() { destProxyRead(); });
-  connect(sock, &QIODevice::bytesWritten, this, &ProxyConnection::clientReadyRead,
-          Qt::QueuedConnection);
-  connect(sock, &QIODevice::bytesWritten, this, [this](qint64 bytes) {
-    emit dataSentReceived(bytes, 0);
-  });
+  connect(sock, &QIODevice::bytesWritten, this,
+          &ProxyConnection::clientReadyRead, Qt::QueuedConnection);
+  connect(sock, &QIODevice::bytesWritten, this,
+          [this](qint64 bytes) { emit dataSentReceived(bytes, 0); });
 
   guard.dismiss();
   return sock;

--- a/extension/socks5proxy/src/proxyconnection.cpp
+++ b/extension/socks5proxy/src/proxyconnection.cpp
@@ -170,9 +170,9 @@ void ProxyConnection::destProxyRead() {
   proxy(m_destSocket, m_clientSocket, m_recvHighWaterMark);
 }
 
-QAbstractSocket* ProxyConnection::createDestSocketImpl(QAbstractSocket* sock,
-                                                       const QHostAddress& dest,
-                                                       quint16 port) {
+QAbstractSocket* ProxyConnection::createDestSocket(QAbstractSocket* sock,
+                                                   const QHostAddress& dest,
+                                                   quint16 port) {
   Q_ASSERT(!dest.isNull());
   Q_ASSERT(sock != nullptr);
   auto guard = qScopeGuard([sock]() { sock->deleteLater(); });

--- a/extension/socks5proxy/src/proxyconnection.h
+++ b/extension/socks5proxy/src/proxyconnection.h
@@ -64,8 +64,8 @@ class ProxyConnection : public QObject {
   void clientBytesWritten(qint64 bytes);
 
   // The implementation for templated createDestSocket
-  QAbstractSocket* createDestSocketImpl(QAbstractSocket* sock,
-                                        const QHostAddress& dest, quint16 port);
+  QAbstractSocket* createDestSocket(QAbstractSocket* sock,
+                                    const QHostAddress& dest, quint16 port);
 
  protected:
   /**
@@ -84,7 +84,7 @@ class ProxyConnection : public QObject {
 
   template <typename T>
   T* createDestSocket(const QHostAddress& dest, quint16 port) {
-    return static_cast<T*>(createDestSocketImpl(new T(this), dest, port));
+    return static_cast<T*>(createDestSocket(new T(this), dest, port));
   }
 
   QIODevice* m_clientSocket = nullptr;

--- a/extension/socks5proxy/src/proxyconnection.h
+++ b/extension/socks5proxy/src/proxyconnection.h
@@ -24,6 +24,8 @@ class ProxyConnection : public QObject {
   quint64 recvHighWaterMark() const { return m_recvHighWaterMark; }
   const QString& errorString() const { return m_errorString; }
 
+  const QString& clientName() const { return m_clientName; }
+
   static constexpr const int MAX_CONNECTION_BUFFER = 16 * 1024;
 
  signals:
@@ -39,6 +41,12 @@ class ProxyConnection : public QObject {
    * @param watermark- reference to the buffer high watermark
    */
   static void proxy(QIODevice* rx, QIODevice* tx, quint64& watermark);
+
+  // Implemented by platform-specific code in proxylocal_<platform>.cpp
+  static QString localClientName(QLocalSocket* s);
+
+  QString m_clientName;
+  uint16_t m_clientPort = 0;
 
   quint64 m_sendHighWaterMark = 0;
   quint64 m_recvHighWaterMark = 0;

--- a/extension/socks5proxy/src/proxyconnection.h
+++ b/extension/socks5proxy/src/proxyconnection.h
@@ -64,7 +64,8 @@ class ProxyConnection : public QObject {
   void clientBytesWritten(qint64 bytes);
 
   // The implementation for templated createDestSocket
-  QAbstractSocket* createDestSocketImpl(QAbstractSocket* sock, const QHostAddress& dest, quint16 port);
+  QAbstractSocket* createDestSocketImpl(QAbstractSocket* sock,
+                                        const QHostAddress& dest, quint16 port);
 
  protected:
   /**

--- a/extension/socks5proxy/src/proxyconnection.h
+++ b/extension/socks5proxy/src/proxyconnection.h
@@ -59,6 +59,7 @@ class ProxyConnection : public QObject {
   template <typename T>
   void clientErrorOccurred(int error);
 
+  void clientReadyRead();
   void clientBytesWritten(qint64 bytes);
 
  protected:
@@ -75,8 +76,6 @@ class ProxyConnection : public QObject {
   static QString localClientName(QLocalSocket* s);
 
   void setState(int state);
-
-  void clientReadyRead();
 
   QTcpSocket* createDestSocket(const QHostAddress& dest, quint16 port);
 

--- a/extension/socks5proxy/src/proxyconnection.h
+++ b/extension/socks5proxy/src/proxyconnection.h
@@ -1,0 +1,48 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef PROXYCONNECTION_H
+#define PROXYCONNECTION_H
+
+#include <QByteArray>
+#include <QIODevice>
+#include <QLocalSocket>
+#include <QObject>
+#include <QTcpSocket>
+
+class ProxyConnection : public QObject {
+  Q_OBJECT
+
+ protected:
+  explicit ProxyConnection(QIODevice* socket);
+
+ public:
+  ~ProxyConnection() = default;
+
+  quint64 sendHighWaterMark() const { return m_sendHighWaterMark; }
+  quint64 recvHighWaterMark() const { return m_recvHighWaterMark; }
+  const QString& errorString() const { return m_errorString; }
+
+  static constexpr const int MAX_CONNECTION_BUFFER = 16 * 1024;
+
+ signals:
+  void setupOutSocket(qintptr sd, const QHostAddress& dest);
+  void dataSentReceived(qint64 sent, qint64 received);
+
+ protected:
+  /**
+   * @brief Copies incoming bytes to another QIODevice
+   *
+   * @param from- the source device
+   * @param to- the output device
+   * @param watermark- reference to the buffer high watermark
+   */
+  static void proxy(QIODevice* rx, QIODevice* tx, quint64& watermark);
+
+  quint64 m_sendHighWaterMark = 0;
+  quint64 m_recvHighWaterMark = 0;
+  QString m_errorString;
+};
+
+#endif  // PROXYCONNECTION_H

--- a/extension/socks5proxy/src/proxyconnection.h
+++ b/extension/socks5proxy/src/proxyconnection.h
@@ -6,10 +6,11 @@
 #define PROXYCONNECTION_H
 
 #include <QByteArray>
-#include <QIODevice>
-#include <QLocalSocket>
+#include <QHostAddress>
 #include <QObject>
-#include <QTcpSocket>
+
+class QIODevice;
+class QLocalSocket;
 
 class ProxyConnection : public QObject {
   Q_OBJECT
@@ -25,6 +26,9 @@ class ProxyConnection : public QObject {
   const QString& errorString() const { return m_errorString; }
 
   const QString& clientName() const { return m_clientName; }
+
+  const QHostAddress& destAddress() const { return m_destAddress; }
+  const QString& destHostname() const { return m_destHostname; }
 
   static constexpr const int MAX_CONNECTION_BUFFER = 16 * 1024;
 
@@ -47,6 +51,10 @@ class ProxyConnection : public QObject {
 
   QString m_clientName;
   uint16_t m_clientPort = 0;
+
+  uint16_t m_destPort = 0;
+  QHostAddress m_destAddress;
+  QString m_destHostname;
 
   quint64 m_sendHighWaterMark = 0;
   quint64 m_recvHighWaterMark = 0;

--- a/extension/socks5proxy/src/proxyconnection.h
+++ b/extension/socks5proxy/src/proxyconnection.h
@@ -59,8 +59,12 @@ class ProxyConnection : public QObject {
   template <typename T>
   void clientErrorOccurred(int error);
 
+ private slots:
   void clientReadyRead();
   void clientBytesWritten(qint64 bytes);
+
+  // The implementation for templated createDestSocket
+  QAbstractSocket* createDestSocketImpl(QAbstractSocket* sock, const QHostAddress& dest, quint16 port);
 
  protected:
   /**
@@ -77,7 +81,10 @@ class ProxyConnection : public QObject {
 
   void setState(int state);
 
-  QTcpSocket* createDestSocket(const QHostAddress& dest, quint16 port);
+  template <typename T>
+  T* createDestSocket(const QHostAddress& dest, quint16 port) {
+    return static_cast<T*>(createDestSocketImpl(new T(this), dest, port));
+  }
 
   QIODevice* m_clientSocket = nullptr;
   QString m_clientName;

--- a/extension/socks5proxy/src/proxyconnection.h
+++ b/extension/socks5proxy/src/proxyconnection.h
@@ -43,8 +43,8 @@ class ProxyConnection : public QObject {
 
   int state() const { return m_state; }
 
-  // Protocols must implement these methods to read data off the client socket
-  // in the Handshake and Proxy states, respectively.
+  // Proxy protocols must implement these methods to read data off the client
+  // socket in the Handshake and Proxy states, respectively.
   virtual void handshakeRead() = 0;
   virtual void clientProxyRead();
   virtual void destProxyRead();

--- a/extension/socks5proxy/src/proxyconnection.h
+++ b/extension/socks5proxy/src/proxyconnection.h
@@ -35,6 +35,7 @@ class ProxyConnection : public QObject {
  signals:
   void setupOutSocket(qintptr sd, const QHostAddress& dest);
   void dataSentReceived(qint64 sent, qint64 received);
+  void disconnected();
 
  protected:
   /**

--- a/extension/socks5proxy/src/proxylocal_default.cpp
+++ b/extension/socks5proxy/src/proxylocal_default.cpp
@@ -2,10 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#include "socks5connection.h"
+#include "proxyconnection.h"
 
 // static
-QString Socks5Connection::localClientName(QLocalSocket* s) {
+QString ProxyConnection::localClientName(QLocalSocket* s) {
   Q_UNUSED(s);
   return QString();
 }

--- a/extension/socks5proxy/src/proxylocal_linux.cpp
+++ b/extension/socks5proxy/src/proxylocal_linux.cpp
@@ -7,7 +7,7 @@
 #include <QFile>
 #include <QLocalSocket>
 
-#include "socks5connection.h"
+#include "proxyconnection.h"
 
 // Read /proc/<pid>/cgroup and parse out the cgroupv2 control group path.
 static QString lookupCgroupForPid(pid_t pid) {
@@ -30,7 +30,7 @@ static QString lookupCgroupForPid(pid_t pid) {
 
 // static
 // Return the systemd scope of the process at the other end of the local socket.
-QString Socks5Connection::localClientName(QLocalSocket* s) {
+QString ProxyConnection::localClientName(QLocalSocket* s) {
   struct ucred peer;
   socklen_t len = sizeof(peer);
   int sd = s->socketDescriptor();

--- a/extension/socks5proxy/src/proxylocal_windows.cpp
+++ b/extension/socks5proxy/src/proxylocal_windows.cpp
@@ -11,10 +11,10 @@
 #include <QLocalSocket>
 #include <QScopeGuard>
 
-#include "socks5connection.h"
+#include "proxyconnection.h"
 
 // static
-QString Socks5Connection::localClientName(QLocalSocket* s) {
+QString ProxyConnection::localClientName(QLocalSocket* s) {
   // Get the process at the other end of the socket.
   HANDLE pipe = reinterpret_cast<HANDLE>(s->socketDescriptor());
   ULONG pid;

--- a/extension/socks5proxy/src/socks5.cpp
+++ b/extension/socks5proxy/src/socks5.cpp
@@ -59,8 +59,10 @@ void Socks5::tryCreateProxy(QIODevice* socket) {
   ProxyConnection* con = nullptr;
   if (HttpConnection::isProxyType(req)) {
     con = new HttpConnection(socket);
+#ifdef PROXY_MASQUE_ENABLED
   } else if (MasqueConnection::isProxyType(req)) {
     con = new MasqueConnection(socket);
+#endif
   } else if (Socks5Connection::isProxyType(socket)) {
     con = new Socks5Connection(socket);
   } else if (socket->bytesAvailable() > 4096) {

--- a/extension/socks5proxy/src/socks5.cpp
+++ b/extension/socks5proxy/src/socks5.cpp
@@ -10,6 +10,7 @@
 #include <QTcpSocket>
 
 #include "httpconnection.h"
+#include "httprequest.h"
 #include "masqueconnection.h"
 #include "socks5connection.h"
 
@@ -54,10 +55,11 @@ void Socks5::newConnection(T* server) {
 
 void Socks5::tryCreateProxy(QIODevice* socket) {
   // Inspect the socket to see what kind of protocol its using.
+  HttpRequest req = HttpRequest::peek(socket);
   ProxyConnection* con = nullptr;
-  if (HttpConnection::isProxyType(socket)) {
+  if (HttpConnection::isProxyType(req)) {
     con = new HttpConnection(socket);
-  } else if (MasqueConnection::isProxyType(socket)) {
+  } else if (MasqueConnection::isProxyType(req)) {
     con = new MasqueConnection(socket);
   } else if (Socks5Connection::isProxyType(socket)) {
     con = new Socks5Connection(socket);

--- a/extension/socks5proxy/src/socks5.cpp
+++ b/extension/socks5proxy/src/socks5.cpp
@@ -67,9 +67,9 @@ void Socks5::tryCreateProxy(QIODevice* socket) {
     return;
   } else {
     // Otherwise, wait for more bytes.
-    Qt::ConnectionType ctype = Qt::SingleShotConnection;
-    connect(socket, &QIODevice::readyRead, this,
-            [this, socket](){ tryCreateProxy(socket); }, ctype);
+    connect(
+        socket, &QIODevice::readyRead, this,
+        [this, socket]() { tryCreateProxy(socket); }, Qt::SingleShotConnection);
     return;
   }
 

--- a/extension/socks5proxy/src/socks5.cpp
+++ b/extension/socks5proxy/src/socks5.cpp
@@ -10,6 +10,7 @@
 #include <QTcpSocket>
 
 #include "httpconnection.h"
+#include "masqueconnection.h"
 #include "socks5connection.h"
 
 #define MAX_CLIENTS 1024
@@ -56,6 +57,8 @@ void Socks5::tryCreateProxy(QIODevice* socket) {
   ProxyConnection* con = nullptr;
   if (HttpConnection::isProxyType(socket)) {
     con = new HttpConnection(socket);
+  } else if (MasqueConnection::isProxyType(socket)) {
+    con = new MasqueConnection(socket);
   } else if (Socks5Connection::isProxyType(socket)) {
     con = new Socks5Connection(socket);
   } else if (socket->bytesAvailable() > 4096) {

--- a/extension/socks5proxy/src/socks5.h
+++ b/extension/socks5proxy/src/socks5.h
@@ -36,6 +36,9 @@ class Socks5 final : public QObject {
   template <typename T>
   void newConnection(T* server);
 
+  template <typename T>
+  void tryCreateProxy(T* socket);
+
   uint16_t m_clientCount = 0;
   bool m_shuttingDown = false;
 };

--- a/extension/socks5proxy/src/socks5.h
+++ b/extension/socks5proxy/src/socks5.h
@@ -8,8 +8,8 @@
 #include <QObject>
 
 #include "dnsresolver.h"
-#include "socks5connection.h"
 
+class ProxyConnection;
 class QHostAddress;
 class QLocalServer;
 class QTcpServer;
@@ -27,11 +27,12 @@ class Socks5 final : public QObject {
 
  signals:
   void connectionsChanged();
-  void incomingConnection(Socks5Connection* connection);
+  void incomingConnection(ProxyConnection* connection);
   void outgoingConnection(qintptr sd, const QHostAddress& dest);
 
  private:
   void clientDismissed();
+
   template <typename T>
   void newConnection(T* server);
 

--- a/extension/socks5proxy/src/socks5.h
+++ b/extension/socks5proxy/src/socks5.h
@@ -30,14 +30,16 @@ class Socks5 final : public QObject {
   void incomingConnection(ProxyConnection* connection);
   void outgoingConnection(qintptr sd, const QHostAddress& dest);
 
+ private slots:
+  void discardSocket();
+
  private:
   void clientDismissed();
 
   template <typename T>
   void newConnection(T* server);
 
-  template <typename T>
-  void tryCreateProxy(T* socket);
+  void tryCreateProxy(QIODevice* socket);
 
   uint16_t m_clientCount = 0;
   bool m_shuttingDown = false;

--- a/extension/socks5proxy/src/socks5connection.cpp
+++ b/extension/socks5proxy/src/socks5connection.cpp
@@ -18,7 +18,9 @@
 
 #include <QDnsLookup>
 #include <QHostAddress>
-
+#include <QIODevice>
+#include <QLocalSocket>
+#include <QTcpSocket>
 
 namespace {
 
@@ -262,10 +264,9 @@ void Socks5Connection::readyRead() {
           return;
         }
 
-        QString hostname = QString::fromUtf8(buffer, length);
-        m_hostLookupStack.append(hostname);
+        m_destHostname = QString::fromUtf8(buffer, length);
         m_destPort = htons(port);
-        DNSResolver::instance()->resolveAsync(hostname, this);
+        DNSResolver::instance()->resolveAsync(m_destHostname, this);
       }
 
       else if (m_addressType == 0x04 /* Ipv6 */) {
@@ -333,7 +334,6 @@ void Socks5Connection::onHostnameResolved(QHostAddress resolved) {
 
 void Socks5Connection::configureOutSocket(quint16 port) {
   Q_ASSERT(!m_destAddress.isNull());
-  m_hostLookupStack.append(m_destAddress.toString());
 
   int family;
   if (m_destAddress.protocol() == QAbstractSocket::IPv6Protocol) {

--- a/extension/socks5proxy/src/socks5connection.cpp
+++ b/extension/socks5proxy/src/socks5connection.cpp
@@ -79,9 +79,6 @@ ServerResponsePacket createServerResponsePacket(uint8_t rep,
 
 }  // namespace
 
-Socks5Connection::Socks5Connection(QTcpSocket* s) : ProxyConnection(s) {}
-Socks5Connection::Socks5Connection(QLocalSocket* s) : ProxyConnection(s) {}
-
 void Socks5Connection::setError(Socks5Replies reason,
                                 const QString& errorString) {
   // A Server response message is only sent in certain states.

--- a/extension/socks5proxy/src/socks5connection.cpp
+++ b/extension/socks5proxy/src/socks5connection.cpp
@@ -205,6 +205,8 @@ void Socks5Connection::handshakeRead() {
 
         m_destHostname = QString::fromUtf8(buffer, length);
         m_destPort = htons(port);
+        setState(Resolve);
+
         DNSResolver::instance()->resolveAsync(m_destHostname, this);
       }
 

--- a/extension/socks5proxy/src/socks5connection.cpp
+++ b/extension/socks5proxy/src/socks5connection.cpp
@@ -136,8 +136,8 @@ void Socks5Connection::handshakeRead() {
       packet.version = 0x5;
       packet.cauth = 0x00;  // TODO: authentication check!
 
-      if (m_clientSocket->write((const char*)&packet, sizeof(ServerChoicePacket)) !=
-          sizeof(ServerChoicePacket)) {
+      if (m_clientSocket->write((const char*)&packet, sizeof(packet)) !=
+          sizeof(packet)) {
         setError(ErrorGeneral, m_clientSocket->errorString());
         return;
       }
@@ -325,6 +325,7 @@ bool Socks5Connection::isProxyType(QIODevice* socket) {
   if (data.length() < sizeof(ClientGreetingPacket)) {
     return false;
   }
-  // This is probably a SOCKS proxy connection if the first byte indicates version 4 or 5.
+  // This is probably a SOCKS proxy connection if the first byte indicates
+  // version 4 or 5.
   return (data.at(0) == 0x05) || (data.at(0) == 0x04);
 }

--- a/extension/socks5proxy/src/socks5connection.cpp
+++ b/extension/socks5proxy/src/socks5connection.cpp
@@ -264,7 +264,6 @@ void Socks5Connection::configureOutSocket(quint16 port) {
     }
 
     setState(Proxy);
-    clientReadyRead();
   });
 
   connect(m_destSocket, &QTcpSocket::disconnected, this,

--- a/extension/socks5proxy/src/socks5connection.cpp
+++ b/extension/socks5proxy/src/socks5connection.cpp
@@ -442,3 +442,13 @@ std::optional<T> Socks5Connection::readPacket(QIODevice* connection) {
   connection->commitTransaction();
   return packet;
 }
+
+// Peek at the socket and determine if this is a socks connection.
+bool Socks5Connection::isProxyType(QIODevice* socket) {
+  QByteArray data = socket->peek(sizeof(ClientGreetingPacket));
+  if (data.length() < sizeof(ClientGreetingPacket)) {
+    return false;
+  }
+  // This is probably a SOCKS proxy connection if the first byte indicates version 4 or 5.
+  return (data.at(0) == 0x05) || (data.at(0) == 0x04);
+}

--- a/extension/socks5proxy/src/socks5connection.cpp
+++ b/extension/socks5proxy/src/socks5connection.cpp
@@ -142,6 +142,10 @@ void Socks5Connection::setError(Socks5Replies reason,
 }
 
 void Socks5Connection::setState(Socks5State newstate) {
+  if (m_state == newstate) {
+    return;
+  }
+
   m_state = newstate;
   emit stateChanged();
 
@@ -154,6 +158,8 @@ void Socks5Connection::setState(Socks5State newstate) {
 
   // If the state is closing. Shutdown the sockets.
   if (m_state == Closed) {
+    emit disconnected();
+  
     m_inSocket->close();
     if (m_outSocket != nullptr) {
       m_outSocket->close();

--- a/extension/socks5proxy/src/socks5connection.cpp
+++ b/extension/socks5proxy/src/socks5connection.cpp
@@ -248,7 +248,7 @@ void Socks5Connection::onHostnameResolved(QHostAddress resolved) {
 void Socks5Connection::configureOutSocket(quint16 port) {
   Q_ASSERT(!m_destAddress.isNull());
 
-  m_destSocket = createDestSocket(m_destAddress, port);
+  m_destSocket = createDestSocket<QTcpSocket>(m_destAddress, port);
   if (!m_destSocket) {
     setError(ErrorGeneral, m_errorString);
     return;
@@ -276,6 +276,8 @@ void Socks5Connection::configureOutSocket(quint16 port) {
               setError(ErrorGeneral, m_destSocket->errorString());
             }
           });
+
+  m_destSocket->connectToHost(m_destAddress, port);
 }
 
 void Socks5Connection::onHostnameNotFound() {

--- a/extension/socks5proxy/src/socks5connection.h
+++ b/extension/socks5proxy/src/socks5connection.h
@@ -5,13 +5,9 @@
 #ifndef Socks5Connection_H
 #define Socks5Connection_H
 
-#include <QByteArray>
-#include <QIODevice>
-#include <QLocalSocket>
-#include <QObject>
-#include <QTcpSocket>
+#include "proxyconnection.h"
 
-class Socks5Connection final : public QObject {
+class Socks5Connection final : public ProxyConnection {
   Q_OBJECT
 
  private:
@@ -21,15 +17,6 @@ class Socks5Connection final : public QObject {
   explicit Socks5Connection(QTcpSocket* socket);
   explicit Socks5Connection(QLocalSocket* socket);
   ~Socks5Connection() = default;
-
-  /**
-   * @brief Copies incoming bytes to another QIODevice
-   *
-   * @param from- the source device
-   * @param to- the output device
-   * @param watermark- reference to the buffer high watermark
-   */
-  static void proxy(QIODevice* rx, QIODevice* tx, quint64& watermark);
 
   enum Socks5State {
     ClientGreeting,
@@ -81,13 +68,7 @@ class Socks5Connection final : public QObject {
 
   const Socks5State& state() const { return m_state; }
 
-  quint64 sendHighWaterMark() const { return m_sendHighWaterMark; }
-  quint64 recvHighWaterMark() const { return m_recvHighWaterMark; }
-  const QString& errorString() const { return m_errorString; }
-
  signals:
-  void setupOutSocket(qintptr sd, const QHostAddress& dest);
-  void dataSentReceived(qint64 sent, qint64 received);
   void stateChanged();
 
  private slots:
@@ -105,7 +86,6 @@ class Socks5Connection final : public QObject {
   static QString localClientName(QLocalSocket* s);
 
   Socks5State m_state = ClientGreeting;
-  QString m_errorString;
 
   uint8_t m_authNumber = 0;
   QIODevice* m_inSocket = nullptr;
@@ -119,8 +99,6 @@ class Socks5Connection final : public QObject {
   QHostAddress m_destAddress;
   QStringList m_hostLookupStack;
 
-  quint64 m_sendHighWaterMark = 0;
-  quint64 m_recvHighWaterMark = 0;
   quint64 m_recvIgnoreBytes = 0;
 };
 

--- a/extension/socks5proxy/src/socks5connection.h
+++ b/extension/socks5proxy/src/socks5connection.h
@@ -60,8 +60,6 @@ class Socks5Connection final : public ProxyConnection {
   template <typename T>
   static std::optional<T> readPacket(QIODevice* connection);
 
-  const QString& clientName() const { return m_clientName; }
-
   const QHostAddress& destAddress() const { return m_destAddress; }
 
   const QStringList& hostLookupStack() const { return m_hostLookupStack; }
@@ -82,20 +80,14 @@ class Socks5Connection final : public ProxyConnection {
   void readyRead();
   void bytesWritten(qint64 bytes);
 
-  // Implemented by platform-specific code in socks5local_<platform>.cpp
-  static QString localClientName(QLocalSocket* s);
-
   Socks5State m_state = ClientGreeting;
 
   uint8_t m_authNumber = 0;
   QIODevice* m_inSocket = nullptr;
   QTcpSocket* m_outSocket = nullptr;
 
-  QString m_clientName;
-  uint16_t m_socksPort = 0;
-  uint16_t m_destPort = 0;
-
   uint8_t m_addressType = 0;
+  uint16_t m_destPort = 0;
   QHostAddress m_destAddress;
   QStringList m_hostLookupStack;
 

--- a/extension/socks5proxy/src/socks5connection.h
+++ b/extension/socks5proxy/src/socks5connection.h
@@ -13,9 +13,6 @@ class QLocalSocket;
 class Socks5Connection final : public ProxyConnection {
   Q_OBJECT
 
- private:
-  explicit Socks5Connection(QIODevice* socket);
-
  public:
   explicit Socks5Connection(QTcpSocket* socket);
   explicit Socks5Connection(QLocalSocket* socket);
@@ -65,7 +62,6 @@ class Socks5Connection final : public ProxyConnection {
   static bool isProxyType(QIODevice* socket);
 
   void handshakeRead() override;
-  void clientProxyRead() override;
 
  private slots:
   void onHostnameResolved(QHostAddress addr);
@@ -74,14 +70,9 @@ class Socks5Connection final : public ProxyConnection {
  private:
   void setError(Socks5Replies reply, const QString& errorString);
   void configureOutSocket(quint16 port);
-  void bytesWritten(qint64 bytes);
 
   uint8_t m_authNumber = 0;
-  QTcpSocket* m_outSocket = nullptr;
-
   uint8_t m_addressType = 0;
-
-  quint64 m_recvIgnoreBytes = 0;
 };
 
 #endif  // Socks5Connection_H

--- a/extension/socks5proxy/src/socks5connection.h
+++ b/extension/socks5proxy/src/socks5connection.h
@@ -7,6 +7,9 @@
 
 #include "proxyconnection.h"
 
+class QTcpSocket;
+class QLocalSocket;
+
 class Socks5Connection final : public ProxyConnection {
   Q_OBJECT
 
@@ -60,10 +63,6 @@ class Socks5Connection final : public ProxyConnection {
   template <typename T>
   static std::optional<T> readPacket(QIODevice* connection);
 
-  const QHostAddress& destAddress() const { return m_destAddress; }
-
-  const QStringList& hostLookupStack() const { return m_hostLookupStack; }
-
   const Socks5State& state() const { return m_state; }
 
  signals:
@@ -87,9 +86,6 @@ class Socks5Connection final : public ProxyConnection {
   QTcpSocket* m_outSocket = nullptr;
 
   uint8_t m_addressType = 0;
-  uint16_t m_destPort = 0;
-  QHostAddress m_destAddress;
-  QStringList m_hostLookupStack;
 
   quint64 m_recvIgnoreBytes = 0;
 };

--- a/extension/socks5proxy/src/socks5connection.h
+++ b/extension/socks5proxy/src/socks5connection.h
@@ -7,15 +7,11 @@
 
 #include "proxyconnection.h"
 
-class QTcpSocket;
-class QLocalSocket;
-
 class Socks5Connection final : public ProxyConnection {
   Q_OBJECT
 
  public:
-  explicit Socks5Connection(QTcpSocket* socket);
-  explicit Socks5Connection(QLocalSocket* socket);
+  explicit Socks5Connection(QIODevice* socket) : ProxyConnection(socket) {};
   ~Socks5Connection() = default;
 
   enum Socks5State : int {

--- a/extension/socks5proxy/src/socks5connection.h
+++ b/extension/socks5proxy/src/socks5connection.h
@@ -65,6 +65,9 @@ class Socks5Connection final : public ProxyConnection {
 
   const Socks5State& state() const { return m_state; }
 
+  // Peek at the socket and determine if this is a socks connection.
+  static bool isProxyType(QIODevice* socket);
+
  signals:
   void stateChanged();
 

--- a/extension/socks5proxy/src/socks5connection.h
+++ b/extension/socks5proxy/src/socks5connection.h
@@ -70,7 +70,7 @@ class Socks5Connection final : public ProxyConnection {
   uint8_t m_authNumber = 0;
   uint8_t m_addressType = 0;
 
-  friend class TestSocks5Connection; 
+  friend class TestSocks5Connection;
 };
 
 #endif  // Socks5Connection_H

--- a/extension/socks5proxy/src/socks5connection.h
+++ b/extension/socks5proxy/src/socks5connection.h
@@ -11,7 +11,7 @@ class Socks5Connection final : public ProxyConnection {
   Q_OBJECT
 
  public:
-  explicit Socks5Connection(QIODevice* socket) : ProxyConnection(socket) {};
+  explicit Socks5Connection(QIODevice* socket) : ProxyConnection(socket){};
   ~Socks5Connection() = default;
 
   enum Socks5State : int {

--- a/extension/socks5proxy/src/socks5connection.h
+++ b/extension/socks5proxy/src/socks5connection.h
@@ -69,6 +69,8 @@ class Socks5Connection final : public ProxyConnection {
 
   uint8_t m_authNumber = 0;
   uint8_t m_addressType = 0;
+
+  friend class TestSocks5Connection; 
 };
 
 #endif  // Socks5Connection_H

--- a/extension/socks5proxy/tests/testsocks5.cpp
+++ b/extension/socks5proxy/tests/testsocks5.cpp
@@ -106,10 +106,10 @@ void TestSocks5::proxyTCP() {
 
   QString proxyClientName;
   QObject::connect(
-      &proxy, &Socks5::incomingConnection, [&](Socks5Connection* conn) {
+      &proxy, &Socks5::incomingConnection, [&](ProxyConnection* conn) {
         proxyClientName = conn->clientName();
         proxyHadData =
-            QtFuture::connect(conn, &Socks5Connection::dataSentReceived);
+            QtFuture::connect(conn, &ProxyConnection::dataSentReceived);
       });
 
   while (!connectionToServer.isFinished()) {

--- a/extension/socks5proxy/tests/testsocks5.cpp
+++ b/extension/socks5proxy/tests/testsocks5.cpp
@@ -62,12 +62,12 @@ uint16_t rollPort() {
       QRandomGenerator::global()->bounded(49152, 65535));
 };
 
-QFuture<QByteArray> connectTo(uint serverPort, quint16 proxyPort) {
+QFuture<QByteArray> connectTo(uint serverPort, quint16 proxyPort,
+                              QNetworkProxy::ProxyType proxtType) {
   auto prom = std::make_unique<QPromise<QByteArray>>();
   auto out = prom->future();
   auto socket = new QTcpSocket();
-  socket->setProxy(QNetworkProxy{QNetworkProxy::ProxyType::Socks5Proxy,
-                                 "localhost", proxyPort});
+  socket->setProxy(QNetworkProxy{proxtType, "localhost", proxyPort});
   prom->start();
   QObject::connect(socket, &QTcpSocket::readyRead,
                    [prom = std::move(prom), socket]() {
@@ -82,6 +82,13 @@ QFuture<QByteArray> connectTo(uint serverPort, quint16 proxyPort) {
 };
 #pragma endregion
 
+void TestSocks5::proxyTCP_data() {
+  QTest::addColumn<QNetworkProxy::ProxyType>("proxyType");
+
+  QTest::addRow("SOCKS5") << QNetworkProxy::ProxyType::Socks5Proxy;
+  QTest::addRow("HTTP CONNECT") << QNetworkProxy::ProxyType::HttpProxy;
+}
+
 /**
  * Create a TCP Server -  Sending "Hello Moto"
  * to the first incoming connection.
@@ -92,6 +99,8 @@ QFuture<QByteArray> connectTo(uint serverPort, quint16 proxyPort) {
  *
  */
 void TestSocks5::proxyTCP() {
+  QFETCH(QNetworkProxy::ProxyType, proxyType);
+
   auto const proxyPort = rollPort();
   auto const serverPort = rollPort();
   auto const serverHadConnection = makeServer(serverPort);
@@ -102,7 +111,7 @@ void TestSocks5::proxyTCP() {
   proxyServer.listen(QHostAddress::LocalHost, proxyPort);
 
   QFuture<std::tuple<qint64, qint64>> proxyHadData;
-  auto const connectionToServer = connectTo(serverPort, proxyPort);
+  auto const connectionToServer = connectTo(serverPort, proxyPort, proxyType);
 
   QString proxyClientName;
   QObject::connect(

--- a/extension/socks5proxy/tests/testsocks5.h
+++ b/extension/socks5proxy/tests/testsocks5.h
@@ -12,4 +12,5 @@ class TestSocks5 final : public QObject {
 
  private slots:
   void proxyTCP();
+  void proxyTCP_data();
 };


### PR DESCRIPTION
## Description
This does a bit of refactoring to add support for multiple proxy protocols in the `socksproxy` tool. To get there we refactor a bunch of generic proxy handling code into a parent `ProxyConnection` class which now has three concrete subclasses:
- `Socks5Connection`: Implements version 5 of the SOCKS protocol from [RFC1928](https://datatracker.ietf.org/doc/html/rfc1928)
- `HttpConnection`: Implements the HTTP `CONNECT` method from [RFC2616](https://datatracker.ietf.org/doc/html/rfc2616#section-9.9)
- `MasqueConnection`: Implements HTTP datagram and `connect-udp` support from MASQUE/[RFC9298](https://datatracker.ietf.org/doc/html/rfc9298)

The proxy protocol being used is snooped by peeking at the start of the header data using the `isProxyType()` static method. This allows the `Socks5` class to create the correct subclass to handle the connection.

## Reference

    i.e Jira or Github issue URL

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
