### PR TITLE
VPN-7191: Rename daemon service to xpc-daemon

### DIFF
--- a/macos/app/xpc-daemon.plist.in
+++ b/macos/app/xpc-daemon.plist.in
@@ -5,12 +5,12 @@
                 <key>AssociatedBundleIdentifiers</key>
                 <string>${BUILD_OSX_APP_IDENTIFIER}</string>
                 <key>Label</key>
-                <string>${BUILD_OSX_APP_IDENTIFIER}.service</string>
+                <string>${BUILD_OSX_APP_IDENTIFIER}.xpc-daemon</string>
                 <key>BundleProgram</key>
                 <string>Contents/Library/LaunchServices/${BUILD_OSX_APP_IDENTIFIER}.daemon</string>
                 <key>MachServices</key>
                 <dict>
-                        <key>${BUILD_OSX_APP_IDENTIFIER}.service</key>
+                        <key>${BUILD_OSX_APP_IDENTIFIER}.xpc-daemon</key>
                         <true/>
                 </dict>
                 <key>UserName</key>

--- a/macos/pkg/scripts/postinstall.in
+++ b/macos/pkg/scripts/postinstall.in
@@ -84,7 +84,7 @@ if [ ${OSX_MAJOR_VER} -lt 13 ]; then
   # Modify the SMAppService plist for use as a legacy daemon.
   echo "Loading the Daemon at $DAEMON_PLIST_PATH"
   plutil -insert Program -string "$DAEMON_HELPER_TOOL" -o $DAEMON_PLIST_PATH \
-    "${APP_DIR}/Contents/Library/LaunchDaemons/${CODESIGN_APP_IDENTIFIER}.service.plist"
+    "${APP_DIR}/Contents/Library/LaunchDaemons/${CODESIGN_APP_IDENTIFIER}.xpc-daemon.plist"
   plutil -replace Label -string ${CODESIGN_APP_IDENTIFIER}.daemon $DAEMON_PLIST_PATH
   launchctl load -w $DAEMON_PLIST_PATH
 fi

--- a/macos/pkg/scripts/postinstall.in
+++ b/macos/pkg/scripts/postinstall.in
@@ -60,15 +60,14 @@ if ! codesign -v --verbose=4 -R="${CODESIGN_REQS}" "$APP_DIR"; then
 fi
 echo "Codesign successful!"
 
-# Unload the daemon
+# Unload any daemons matching our app identifier.
 UPDATING=
-if launchctl bootout system/${CODESIGN_APP_IDENTIFIER}.service 2>/dev/null; then
-  echo "Update detected (SMAppService)"
-  UPDATING=1
-elif launchctl bootout system/${CODESIGN_APP_IDENTIFIER}.daemon 2>/dev/null; then
-  echo "Update detected (legacy daemon)"
-  UPDATING=1
-fi
+for SERVICE in $(launchctl list | awk '{print $3}' | grep "^${CODESIGN_APP_IDENTIFIER}."); do
+  echo "Unloading launchd service: ${SERVICE}"
+  if launchctl bootout system/${SERVICE} 2>/dev/null; then
+    UPDATING=1
+  fi
+done
 if [ -f "$DAEMON_PLIST_PATH" ]; then
   echo "Removing legacy daemon plist"
   rm -f ${DAEMON_PLIST_PATH}

--- a/src/cmake/macos.cmake
+++ b/src/cmake/macos.cmake
@@ -164,11 +164,11 @@ osx_bundle_files(mozillavpn FILES
 
 # Install the background service plist into the bundle.
 configure_file(
-    ${CMAKE_SOURCE_DIR}/macos/app/service.plist.in
-    ${CMAKE_CURRENT_BINARY_DIR}/${BUILD_OSX_APP_IDENTIFIER}.service.plist
+    ${CMAKE_SOURCE_DIR}/macos/app/xpc-daemon.plist.in
+    ${CMAKE_CURRENT_BINARY_DIR}/${BUILD_OSX_APP_IDENTIFIER}.xpc-daemon.plist
 )
 osx_bundle_files(mozillavpn FILES
-    ${CMAKE_CURRENT_BINARY_DIR}/${BUILD_OSX_APP_IDENTIFIER}.service.plist
+    ${CMAKE_CURRENT_BINARY_DIR}/${BUILD_OSX_APP_IDENTIFIER}.xpc-daemon.plist
     DESTINATION Library/LaunchDaemons
 )
 

--- a/src/platforms/macos/daemon/xpcdaemonserver.mm
+++ b/src/platforms/macos/daemon/xpcdaemonserver.mm
@@ -42,10 +42,11 @@ XpcDaemonServer::XpcDaemonServer(Daemon* daemon) : QObject(daemon) {
   MZ_COUNT_CTOR(XpcDaemonServer);
 
   // To get the mach service name, take the bundle identifier and replace
-  // the last segment with 'service'
+  // the last segment with 'xpc-daemon'
   NSString* bundleIdentifer = [[NSBundle mainBundle] bundleIdentifier];
   QStringList bundleSplit = QString::fromNSString(bundleIdentifer).split('.');
-  bundleSplit.last() = "service";
+  bundleSplit.last() = "xpc-daemon";
+
   NSString* machServiceName = bundleSplit.join('.').toNSString();
   logger.debug() << "XpcDaemonServer created:" << machServiceName;
 

--- a/src/platforms/macos/macoscontroller.mm
+++ b/src/platforms/macos/macoscontroller.mm
@@ -50,11 +50,11 @@ MacOSController::~MacOSController() {
 }
 
 NSString* MacOSController::plist() const {
-  return MacOSUtils::appId(".service.plist").toNSString();
+  return MacOSUtils::appId(".xpc-daemon.plist").toNSString();
 }
 
 NSString* MacOSController::machServiceName() const {
-  return MacOSUtils::appId(".service").toNSString();
+  return MacOSUtils::appId(".xpc-daemon").toNSString();
 }
 
 void MacOSController::initialize(const Device* device, const Keys* keys) {


### PR DESCRIPTION
## Description
In the 2.30 release, it seems like I screwed up when splitting the GUI and daemon executable and introduced an issue where the daemon would fail to launch after an upgrade.

The problem occurs because `launchd` on macOS makes use of designated requirements when installing daemons to identify the same software component across upgrades, and it uses the signing identifier of the daemon binary as one of the components in that designated identifier. When we split the GUI and daemon, this resulted in changing the signing identifier of the daemon such that it no longer satisfies the designated requirements and `launchd` will refuse to start the daemon after the upgrade.

There appear to be to ways to address the problem:
- We change the daemon service name yet again, so that it appears to `launchd` as a new and separate service.
- We revert the signing identifier on the daemon so that it matches the GUI identifier before the split.

Unfortunately, reverting the signing identifier isn't a great solution since we have already released 2.30.0 into the wild. Even if we fixed it for users who encountered the issue, users who installed it successfully would get stuck by the same problem when they upgrade to 2.31.0. So I think the only viable path forward is to rename the daemon yet again.

## Reference
Caused by: #10571
JIRA Issue: [VPN-7191](https://mozilla-hub.atlassian.net/browse/VPN-7191)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-7191]: https://mozilla-hub.atlassian.net/browse/VPN-7191?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ