### PR TITLE
VPN-7172: Workaround for QTBUG-135928

### DIFF
--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -2273,6 +2273,8 @@ int MozillaVPN::runCommandLineApp(std::function<int()>&& a_callback) {
   XdgPortal::setupAppScope(Constants::LINUX_APP_ID);
 #endif
 
+  QCoreApplication app(CommandLineParser::argc(), CommandLineParser::argv());
+
   SettingsHolder settingsHolder;
 
   if (settingsHolder.stagingServer()) {
@@ -2285,8 +2287,6 @@ int MozillaVPN::runCommandLineApp(std::function<int()>&& a_callback) {
 
   logger.info() << "MozillaVPN" << Constants::versionString();
   logger.info() << "User-Agent:" << NetworkManager::userAgent();
-
-  QCoreApplication app(CommandLineParser::argc(), CommandLineParser::argv());
 
   Localizer localizer;
 
@@ -2301,6 +2301,8 @@ int MozillaVPN::runGuiApp(std::function<int()>&& a_callback) {
   XdgPortal::setupAppScope(Constants::LINUX_APP_ID);
 #endif
 
+  QApplication app(CommandLineParser::argc(), CommandLineParser::argv());
+
   SettingsHolder settingsHolder;
 
   if (settingsHolder.stagingServer()) {
@@ -2313,8 +2315,6 @@ int MozillaVPN::runGuiApp(std::function<int()>&& a_callback) {
 
   logger.info() << "MozillaVPN" << Constants::versionString();
   logger.info() << "User-Agent:" << NetworkManager::userAgent();
-
-  QApplication app(CommandLineParser::argc(), CommandLineParser::argv());
 
   Localizer localizer;
 

--- a/src/platforms/linux/xdgportal.cpp
+++ b/src/platforms/linux/xdgportal.cpp
@@ -121,35 +121,6 @@ QString XdgPortal::parentWindow() {
   return QString("");
 }
 
-// Decode systemd escape characters in the unit names.
-static QString decodeSystemdEscape(const QString& str) {
-  static const QRegularExpression re("(_[0-9A-Fa-f][0-9A-Fa-f])");
-
-  QString result = str;
-  qsizetype offset = 0;
-  while (offset < result.length()) {
-    // Search for the next unicode escape sequence.
-    QRegularExpressionMatch match = re.match(result, offset);
-    if (!match.hasMatch()) {
-      break;
-    }
-
-    bool okay;
-    qsizetype start = match.capturedStart(0);
-    QChar code = match.captured(0).mid(1).toUShort(&okay, 16);
-    if (okay && (code != 0)) {
-      // Replace the matched escape sequence with the decoded character.
-      result.replace(start, match.capturedLength(0), QString(code));
-      offset = start + 1;
-    } else {
-      // If we failed to decode the character, skip passed the matched string.
-      offset = match.capturedEnd(0);
-    }
-  }
-
-  return result;
-}
-
 // Get our control group scope by reading /proc/self/cgroup
 static QString readCgroupAppId() {
   QFile cgFile("/proc/self/cgroup");

--- a/src/platforms/linux/xdgportal.cpp
+++ b/src/platforms/linux/xdgportal.cpp
@@ -183,12 +183,13 @@ void XdgPortal::setupAppScope(const QString& appId) {
   // Qt 6.8 introduced a bug where using QDBusConnection::sessionBus() before
   // QCoreApplication is created will silently break D-Bus signal connections.
   // To workaround this, spin up a separate, standalone bus for these steps.
-#if (QT_VERSION < QT_VERSION_CHECK(6, 9, 2)) && (QT_VERSION >= QT_VERSION_CHECK(6, 8, 0))
+#if (QT_VERSION >= QT_VERSION_CHECK(6, 8, 0)) && \
+    (QT_VERSION < QT_VERSION_CHECK(6, 9, 2))
   QString busName = QString("%1-appid-scope-helper").arg(appId);
   QDBusConnection bus =
       QDBusConnection::connectToBus(QDBusConnection::SessionBus, busName);
   auto guard =
-      qScopeGuard([busName](){ QDBusConnection::disconnectFromBus(busName); });
+      qScopeGuard([busName]() { QDBusConnection::disconnectFromBus(busName); });
 #else
   // If the XDG Registry portal exists, use it to advertise our application ID.
   // This is the right tool to use, but it's also very new.


### PR DESCRIPTION
## Description
Qt 6.8 introduced a bug where using `QDBusConnection::sessionBus()` before `QCoreApplication` is created will silently break D-Bus signal connections.

We currently use such bus connections for two purposes:
- Reading the settings encryption key from the XDG [Secret](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.Secret.html) portal.
- Configuring the application ID and scope if otherwise unset.

For the XDG secrets portal, this is an easy fix - we simply move the creation of `QCoreApplication` earlier in the program flow so that it exists before we try to reading any settings.

Configuring the application ID is a bit trickier as this needs to be done before we create `QCoreApplication`, otherwise a bunch of D-Bus activity during the application setup will go sideways and break things. So we refactor `XdgPortal::setupAppScope()` to do so without triggering the Qt bug. This is achieved by:
-  We parse the application scope from `/proc/self/cgroup` rather than asking for it over D-Bus. This is actually closer to what `libsystemd` and [xdg-desktop-portal](https://github.com/flatpak/xdg-desktop-portal/blob/main/src/xdp-app-info-host.c) do to determine the application ID for un-sandboxed application.
- If we are using one of the affected Qt versions, create a separate standalone D-Bus connection to invoke `StartTransientUnit()` over D-Bus instead of relying on `QDBusConnection::sessionBus()`.
- Determine if the scope change was successful by polling `/proc/self/cgroups` rather than waiting for the systemd job to finish (which was janky and full of race conditions anyways).

Also of note, the XDG portal specifications has added a new [Registry](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.host.portal.Registry.html) portal precisely to try and solve the problem that `XdgPortal::setupAppScope()` was trying to address. This new portal is pretty new so we can't fully switch to it, but it should be used if available.

## Reference
Qt issue: [QTBUG-135928](https://bugreports.qt.io/browse/QTBUG-135928)
JIRA Issue: [VPN-7172](https://mozilla-hub.atlassian.net/browse/VPN-7172)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
