### PR TITLE
VPN-7173: Use host os-release info for device name

### DIFF
--- a/src/models/device.cpp
+++ b/src/models/device.cpp
@@ -62,9 +62,8 @@ QString Device::currentDeviceName() {
       }
       QString name = line.first(sep);
       QString value = line.sliced(sep+1);
-      if (value.front() == '"' && value.back() == '"') {
-        value.removeFirst();
-        value.removeLast();
+      if (value.startsWith('"') && value.endsWith('"')) {
+        value = value.mid(1, value.length() - 2);
       }
 
       if (name == "ID") {

--- a/src/models/device.cpp
+++ b/src/models/device.cpp
@@ -61,7 +61,7 @@ QString Device::currentDeviceName() {
         continue;
       }
       QString name = line.first(sep);
-      QString value = line.sliced(sep+1);
+      QString value = line.sliced(sep + 1);
       if (value.startsWith('"') && value.endsWith('"')) {
         value = value.mid(1, value.length() - 2);
       }


### PR DESCRIPTION
## Description
When installed via a flatpak, or any containerized environment, the values we get from `QSysInfo` can be misleading and tend to describe the container rather than the host operating system. Fortunately for us, flatpak mounts the host's `/etc/os-release` file at `/run/host/os-release` that we can parse to get information about the host OS instead.

## Reference
JIRA Issue: [VPN-7173](https://mozilla-hub.atlassian.net/browse/VPN-7173)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-7173]: https://mozilla-hub.atlassian.net/browse/VPN-7173?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ