### PR TITLE
VPN-7212: Support KDE cgroup parsing

### DIFF
--- a/src/feature/featurelistcallback.h
+++ b/src/feature/featurelistcallback.h
@@ -107,14 +107,13 @@ bool FeatureCallback_splitTunnel() {
   }
   initDone = true;
 
-  /* Control groups v2 must be mounted for app/traffic classification
-   */
+  // Control groups v2 must be mounted for traffic classification
   if (LinuxUtils::findCgroup2Path().isNull()) {
     return false;
   }
 
-  /* Application tracking is only supported on GTK-based desktops
-   */
+  // The desktop environment must support scoping applications by cgroup upon
+  // launch for application detection to work as expected.
   QProcessEnvironment pe = QProcessEnvironment::systemEnvironment();
   if (!pe.contains("XDG_CURRENT_DESKTOP")) {
     return false;
@@ -129,12 +128,12 @@ bool FeatureCallback_splitTunnel() {
       return false;
     }
   } else if (desktop.contains("KDE")) {
-    QVersionNumber kdeVersion = LinuxUtils::kdeFrameworkVersion();
+    // This has been tested as far back as KDE Plasma v5.24.
+    QVersionNumber kdeVersion = LinuxUtils::kdePlasmaVersion();
     if (kdeVersion.isNull()) {
       return false;
     }
-    /* The metadata we need (SourcePath) is only added since kio v5.75 */
-    if (kdeVersion < QVersionNumber(5, 75)) {
+    if (kdeVersion < QVersionNumber(5, 24)) {
       return false;
     }
   }

--- a/src/platforms/linux/linuxutils.cpp
+++ b/src/platforms/linux/linuxutils.cpp
@@ -73,11 +73,13 @@ QVersionNumber LinuxUtils::gnomeShellVersion() {
   QDBusInterface iface("org.gnome.Shell", "/org/gnome/Shell",
                        "org.gnome.Shell");
   if (!iface.isValid()) {
+    logger.debug() << "Unable to read Gnome version";
     return QVersionNumber();
   }
 
   QVariant shellVersion = iface.property("ShellVersion");
   if (!shellVersion.isValid()) {
+    logger.debug() << "Invalid Gnome version string";
     return QVersionNumber();
   }
   return QVersionNumber::fromString(shellVersion.toString());
@@ -88,11 +90,13 @@ QVersionNumber LinuxUtils::kdePlasmaVersion() {
   QDBusInterface iface("org.kde.plasmashell", "/MainApplication",
                        "org.qtproject.Qt.QCoreApplication");
   if (!iface.isValid()) {
+    logger.debug() << "Unable to read KDE version";
     return QVersionNumber();
   }
 
   QVariant appVersion = iface.property("applicationVersion");
   if (!appVersion.isValid()) {
+    logger.debug() << "Invalid KDE version string";
     return QVersionNumber();
   }
   return QVersionNumber::fromString(appVersion.toString());

--- a/src/platforms/linux/linuxutils.cpp
+++ b/src/platforms/linux/linuxutils.cpp
@@ -84,22 +84,18 @@ QVersionNumber LinuxUtils::gnomeShellVersion() {
 }
 
 // static
-QVersionNumber LinuxUtils::kdeFrameworkVersion() {
-  QProcess proc;
-  proc.start("kf5-config", QStringList{"--version"}, QIODeviceBase::ReadOnly);
-  if (!proc.waitForFinished()) {
+QVersionNumber LinuxUtils::kdePlasmaVersion() {
+  QDBusInterface iface("org.kde.plasmashell", "/MainApplication",
+                       "org.qtproject.Qt.QCoreApplication");
+  if (!iface.isValid()) {
     return QVersionNumber();
   }
 
-  QByteArray result = proc.readAllStandardOutput();
-  for (const QByteArray& line : result.split('\n')) {
-    if (line.startsWith("KDE Frameworks: ")) {
-      auto vstr = QString::fromUtf8(line.last(line.size() - 16));
-      return QVersionNumber::fromString(vstr);
-    }
+  QVariant appVersion = iface.property("applicationVersion");
+  if (!appVersion.isValid()) {
+    return QVersionNumber();
   }
-
-  return QVersionNumber();
+  return QVersionNumber::fromString(appVersion.toString());
 }
 
 // static

--- a/src/platforms/linux/linuxutils.h
+++ b/src/platforms/linux/linuxutils.h
@@ -12,7 +12,7 @@ namespace LinuxUtils {
 QString findCgroupPath(const QString& type);
 QString findCgroup2Path();
 QVersionNumber gnomeShellVersion();
-QVersionNumber kdeFrameworkVersion();
+QVersionNumber kdePlasmaVersion();
 QString desktopFileId(const QString& path);
 }  // namespace LinuxUtils
 

--- a/src/platforms/linux/xdgportal.cpp
+++ b/src/platforms/linux/xdgportal.cpp
@@ -202,7 +202,7 @@ QString XdgPortal::parseCgroupAppId(const QString& cgroup) {
   if (dot < 0) {
     QString();
   }
-  QString suffix = cgName.sliced(dot+1);
+  QString suffix = cgName.sliced(dot + 1);
 
   QString appId;
   QStringList cgSplit = cgName.first(dot).split("-");

--- a/src/platforms/linux/xdgportal.cpp
+++ b/src/platforms/linux/xdgportal.cpp
@@ -139,9 +139,9 @@ QString XdgPortal::parentWindow() {
   return QString("");
 }
 
-// Decode systemd escape characters in the unit names.
+// Decode systemd escape characters in the cgroup names.
 static QString decodeSystemdEscape(const QString& str) {
-  static const QRegularExpression re("(_[0-9A-Fa-f][0-9A-Fa-f])");
+  static const QRegularExpression re("(\\\\x[0-9A-Fa-f][0-9A-Fa-f])");
 
   QString result = str;
   qsizetype offset = 0;
@@ -154,7 +154,7 @@ static QString decodeSystemdEscape(const QString& str) {
 
     bool okay;
     qsizetype start = match.capturedStart(0);
-    QChar code = match.captured(0).mid(1).toUShort(&okay, 16);
+    QChar code = match.captured(0).sliced(2).toUShort(&okay, 16);
     if (okay && (code != 0)) {
       // Replace the matched escape sequence with the decoded character.
       result.replace(start, match.capturedLength(0), QString(code));

--- a/src/platforms/linux/xdgportal.cpp
+++ b/src/platforms/linux/xdgportal.cpp
@@ -219,6 +219,7 @@ QString XdgPortal::parseCgroupAppId(const QString& cgroup) {
     //   app[-<launcher>]-<ApplicationID>-<RANDOM>.scope
     //   app[-<launcher>]-<ApplicationID>-<RANDOM>.slice
     if (cgSplit.length() < 3) {
+      logger.debug() << "Malformed" << suffix << "for:" << cgName;
       return QString();
     }
     appId = cgSplit.at(cgSplit.length() - 2);

--- a/src/platforms/linux/xdgportal.h
+++ b/src/platforms/linux/xdgportal.h
@@ -38,6 +38,8 @@ class XdgPortal : public QDBusAbstractInterface {
   void setReplyPath(const QString& path);
   static void setupAppScope(const QString& appid);
 
+  static QString parseCgroupAppId(const QString& cgroup);
+
   // Convenience wrapper for QDBusConnection::connect()
   template <typename... T>
   bool xdgConnect(const QString& name, T... args) {


### PR DESCRIPTION
## Description
It's been a while since we took a look at how application scoping is handled on KDE, and there seem to be a few bugs in there. It seems that modern versions of KDE are now launching applications as systemd `service` units rather than `scope` or `slice` as we typically see on Gnome. Failing to handle this causes the VPN client to unnecessarily create a new systemd unit at startup.

This cgroup parsing change also affects how split tunneling is handled in KDE, and rather than implementing this twice, we expose a new `XdgPortal::parseCgroupAppId()` method that the split-tunneling `AppTracker` class can make use of when tracking application launches.

It also seems that our KDE version detection broke during the transition to KDE 6. So let's update that one too.

## Reference
Systemd: [desktop environments](https://systemd.io/DESKTOP_ENVIRONMENTS/)

Found while investigating:
- [VPN-7212](https://mozilla-hub.atlassian.net/browse/VPN-7212) / #10728
- [VPN-7208](https://mozilla-hub.atlassian.net/browse/VPN-7208) / #10720

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-7212]: https://mozilla-hub.atlassian.net/browse/VPN-7212?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[VPN-7208]: https://mozilla-hub.atlassian.net/browse/VPN-7208?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ