### PR TITLE
VPN-7208: Disable split tunnel for MATE, Cinnamon and Unity

### DIFF
--- a/src/feature/featurelistcallback.h
+++ b/src/feature/featurelistcallback.h
@@ -138,9 +138,8 @@ bool FeatureCallback_splitTunnel() {
       return false;
     }
   }
-  // TODO: These shells need more testing.
-  else if (!desktop.contains("MATE") && !desktop.contains("Unity") &&
-           !desktop.contains("X-Cinnamon")) {
+  // For all other desktop environments, assume split tunneling unsupported.
+  else {
     return false;
   }
   splitTunnelSupported = true;


### PR DESCRIPTION
## Description
When we migrated our split tunneling implementation from cgroups v1 to v2, we neglected to update the `FeatureCallback_splitTunnel()` method to remove support for desktop environments that only used cgroupsv1. Until these desktop environments can support application grouping via cgroups, it will not be possible to support split tunneling.

## Reference
JIRA Issue:  [VPN-7208](https://mozilla-hub.atlassian.net/browse/VPN-7208) - #10720

Support is blocked by:
- Cinnamon: linuxmint/cinnamon#12015
- MATE: mate-desktop/mate-desktop#519
- Unity: project appears to be dead.

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-7208]: https://mozilla-hub.atlassian.net/browse/VPN-7208?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ