### PR TITLE
VPN-7230: Fix navigation test failure on macOS

### DIFF
--- a/src/commands/commandui.cpp
+++ b/src/commands/commandui.cpp
@@ -340,6 +340,7 @@ int CommandUI::run(QStringList& tokens) {
                      &App::quit, Qt::QueuedConnection);
 
     // Here is the main QML file.
+    logger.debug() << "loading main.qml";
     const QUrl url(QStringLiteral("qrc:/qt/qml/Mozilla/VPN/main.qml"));
     engine->load(url);
     if (!engineHolder.hasWindow()) {

--- a/src/commands/commandui.cpp
+++ b/src/commands/commandui.cpp
@@ -340,7 +340,6 @@ int CommandUI::run(QStringList& tokens) {
                      &App::quit, Qt::QueuedConnection);
 
     // Here is the main QML file.
-    logger.debug() << "loading main.qml";
     const QUrl url(QStringLiteral("qrc:/qt/qml/Mozilla/VPN/main.qml"));
     engine->load(url);
     if (!engineHolder.hasWindow()) {

--- a/src/networkrequest.cpp
+++ b/src/networkrequest.cpp
@@ -521,6 +521,7 @@ void NetworkRequest::sslErrors(const QList<QSslError>& errors) {
 
 void NetworkRequest::enableSSLIntervention() {
   if (s_intervention_certs.isEmpty()) {
+    logger.debug() << "Loading intervention certs";
     s_intervention_certs = QSslConfiguration::systemCaCertificates();
     QDirIterator certFolder(":/certs");
     while (certFolder.hasNext()) {
@@ -528,6 +529,7 @@ void NetworkRequest::enableSSLIntervention() {
       if (!f.open(QIODevice::ReadOnly)) {
         continue;
       }
+      logger.debug() << "Loading file:" << f.fileName();
       QSslCertificate cert(&f, QSsl::Pem);
       if (!cert.isNull()) {
         logger.info() << "Imported cert from:" << cert.issuerDisplayName();

--- a/src/networkrequest.cpp
+++ b/src/networkrequest.cpp
@@ -521,8 +521,9 @@ void NetworkRequest::sslErrors(const QList<QSslError>& errors) {
 
 void NetworkRequest::enableSSLIntervention() {
   if (s_intervention_certs.isEmpty()) {
-    logger.debug() << "Loading intervention certs";
+    logger.debug() << "Loading system certs";
     s_intervention_certs = QSslConfiguration::systemCaCertificates();
+    logger.debug() << "Loading intervention certs";
     QDirIterator certFolder(":/certs");
     while (certFolder.hasNext()) {
       QFile f(certFolder.next());

--- a/src/networkrequest.h
+++ b/src/networkrequest.h
@@ -112,10 +112,10 @@ class NetworkRequest final : public QObject {
 
   QUrl m_redirectedUrl;
 
-#ifndef QT_NO_SSL
+#ifdef MZ_WINDOWS
   /**
-   * @brief this is a workaround against a buggy old version of Firefox with an
-   * expired SRG Root X1 cert
+   * @brief this is a workaround for Windows 10 devices which may be missing the
+   * ISRG X1 root certificate (see: https://bugreports.qt.io/browse/QTBUG-97168)
    */
   void enableSSLIntervention();
 #endif

--- a/src/platforms/macos/macosutils.mm
+++ b/src/platforms/macos/macosutils.mm
@@ -60,16 +60,18 @@ void MacOSUtils::enableLoginItem(bool startAtBoot) {
 
     if (startAtBoot) {
       if (![[SMAppService mainAppService] registerAndReturnError: & error]) {
-        logger.error() << "Failed to register Mozilla VPN LoginItem: " << error.localizedDescription;
+        logger.error() << "Failed to register Mozilla VPN LoginItem: " << error;
       } else {
         logger.debug() << "Mozilla VPN LoginItem registered successfully.";
       }
     } else {
-      if (![[SMAppService mainAppService] unregisterAndReturnError: & error]) {
-        logger.error() << "Failed to unregister Mozilla VPN LoginItem: " << error.localizedDescription;
-      } else {
-        logger.debug() << "LoginItem unregistered successfully.";
-      }
+      [[SMAppService mainAppService] unregisterWithCompletionHandler:^(NSError* error){
+        if (error != nil) {
+          logger.warning() << "Failed to unregister Mozilla VPN LoginItem:" << error;
+        } else {
+          logger.debug() << "LoginItem unregistered successfully.";
+        }
+      }];
     }
   } else {
     CFStringRef cfs = (__bridge CFStringRef) loginItemAppId;


### PR DESCRIPTION
## Description
The navigation tests on macOS are failing because the `performance.time_to_main_screen` timer is taking too long and results in a failed test. This test is set up to fail if it takes more than a second to show the main UI, and we are repeatedly taking 1.5-3 seconds to get there on the test runners.

I have three hypotheses as to why the tests are failing:
- Loading of the SSL intervention certificate takes too long because it has to re-import all of the system certificates.
- Lack of a valid codesign causes the `MacOSStartAtBootWatcher` to hang for a second or two.
- The first run of the client spends way too long compiling the QML cache.

## Reference
JIRA Issue: [VPN-7230](https://mozilla-hub.atlassian.net/browse/VPN-7230)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-7230]: https://mozilla-hub.atlassian.net/browse/VPN-7230?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ