### PR TITLE
VPN-7231: Support XDG Notification portal v1

### DIFF
--- a/src/platforms/linux/xdgnotificationhandler.cpp
+++ b/src/platforms/linux/xdgnotificationhandler.cpp
@@ -113,7 +113,9 @@ void XdgNotificationHandler::notify(Message type, const QString& title,
   }
   notify.insert("title", title);
   notify.insert("body", message);
-  notify.insert("display-hint", hint);
+  if (m_portal->xdgVersion() >= 2) {
+    notify.insert("display-hint", hint);
+  }
 
   m_lastTitle = title;
   m_lastBody = message;

--- a/src/platforms/linux/xdgportal.cpp
+++ b/src/platforms/linux/xdgportal.cpp
@@ -72,12 +72,12 @@ QVariant XdgPortal::xdgProperty(const QString& name) const {
   return reply.value().variant();
 }
 
-uint XdgPortal::xdgVersion() const {
-  QVariant qv = xdgProperty("version");
-  if (qv.typeId() == QMetaType::UInt) {
-    return qv.toUInt();
+uint XdgPortal::xdgVersion() {
+  if (m_version < 0) {
+    QVariant qv = xdgProperty("version");
+    m_version = qv.toUInt();
   }
-  return 0;
+  return m_version;
 }
 
 void XdgPortal::setReplyPath(const QString& path) {

--- a/src/platforms/linux/xdgportal.h
+++ b/src/platforms/linux/xdgportal.h
@@ -32,7 +32,7 @@ class XdgPortal : public QDBusAbstractInterface {
   explicit XdgPortal(const char* interface, QObject* parent = nullptr);
   ~XdgPortal();
 
-  uint xdgVersion() const;
+  uint xdgVersion();
   const QString& xdgToken() const { return m_token; }
   const QString& replyPath() const { return m_replyPath; }
   void setReplyPath(const QString& path);
@@ -57,6 +57,9 @@ class XdgPortal : public QDBusAbstractInterface {
 
   QString m_replyPath;
   QString m_token;
+
+ private:
+  int m_version = -1;
 };
 
 #endif  // XDGPORTAL_H


### PR DESCRIPTION
## Description
Previously in PR #10730 we switched to the XDG Notifications portal to send system tray notifications to the desktop environment, but it turns out there was a change in the notification portal API starting in [xdg-desktop-portal](https://github.com/flatpak/xdg-desktop-portal) version [1.19.1](https://github.com/flatpak/xdg-desktop-portal/releases/tag/1.19.1) which added the display `hints` property.

Unfortunately, it seems like settings these hints on the older API results in a failure to display notifications, so we need to check the portal version before passing any display hints.

## Reference
JIRA Issues:
- [VPN-7231](https://mozilla-hub.atlassian.net/browse/VPN-7231)
- [VPN-7170](https://mozilla-hub.atlassian.net/browse/VPN-7170)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
