### PR TITLE
Exclude 3rdparty from dh_clean

### DIFF
--- a/linux/debian/rules
+++ b/linux/debian/rules
@@ -19,6 +19,9 @@ export SYSTEMD_UNIT_PATH := $(shell (pkg-config --variable=systemdsystemunitdir 
 %:
 	dh $@ --buildsystem=cmake+ninja --builddirectory=build-$(DEB_HOST_MULTIARCH) --warn-missing
 
+override_dh_clean:
+	dh_clean --exclude=3rdparty
+
 override_dh_auto_configure:
 	dh_auto_configure -- -DWEBEXT_INSTALL_LIBDIR=/lib -DBUILD_ID=$(DEB_VERSION) -DCMAKE_CXX_STANDARD=17 -DBUILD_TESTS=OFF ${OPENSSL_BUILD_ARGS}
 


### PR DESCRIPTION
## Description
It seems that the PPA builds have been failing in something to do with the vendored cargo crates. The issue occurs because vendoring the crates causes modifications to the `Cargo.toml` file, while preserving the original as `Cargo.toml.orig`. Unfortunately, `dh_clean` mistakes these for cruft left after a merge failure, and deletes them.

To fix this, we can explicitly exclude the `3rdparty` directory where the crates are vendored when running `dh_clean`

## Reference

    i.e Jira or Github issue URL

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
