### PR TITLE
VPN-7206: Fix timer reset on server switch with NetmgrController

### DIFF
--- a/src/platforms/linux/netmgrcontroller.cpp
+++ b/src/platforms/linux/netmgrcontroller.cpp
@@ -363,8 +363,6 @@ void NetmgrController::deviceStateChanged(uint state, uint prev, uint reason) {
 
   if (newstate == NetmgrDevice::ACTIVATED) {
     emit connected(m_serverPublicKey);
-  } else if (prevstate == NetmgrDevice::ACTIVATED) {
-    emit disconnected();
   }
 }
 


### PR DESCRIPTION
## Description
With the `NetmgrController` we perform a server switch over D-Bus by issuing an `Update2` call to change the interface configuration, followed by an `ActivateConnection` to apply the new config. This results in the network manager bringing down the network device, and restarting it with the new config.

The result of this, is that we receive a D-Bus notification that the device state has changed away from `ACTIVATED` and we report that as an external disconnection (eg: when the user deactivates it through their network settings menu). To fix this, let's use the device removal as the disconnection event instead (which seems to occur whenever we issue a `DeactivateConnection` via D-Bus) and ignore device state changes for disconnection.

## Reference
JIRA Issues:
 - [VPN-7206](https://mozilla-hub.atlassian.net/browse/VPN-7206)
 - [VPN-7252](https://mozilla-hub.atlassian.net/browse/VPN-7252)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-7206]: https://mozilla-hub.atlassian.net/browse/VPN-7206?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[VPN-7252]: https://mozilla-hub.atlassian.net/browse/VPN-7252?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ