### PR TITLE
VPN-7232: Fix reset behavior on connection timer

### DIFF
--- a/src/ui/screens/home/controller/ConnectionTimer.qml
+++ b/src/ui/screens/home/controller/ConnectionTimer.qml
@@ -43,6 +43,14 @@ RowLayout {
         onTriggered: connectionTime = formatTime(VPNController.connectionTimestamp)
     }
 
+    Connections {
+        target: VPNController
+
+        function onConnectionTimestampChanged() {
+            connectionTime = formatTime(VPNController.connectionTimestamp)
+        }
+    }
+
     Repeater {
         model: connectionTime.split("")
 


### PR DESCRIPTION
## Description
There is a small bug in the code to update the connection timer that was introduced when we moved the logic for it from C++ into QML. The issue occurs because there is no direct signal connection between changes to the `connectionTimestamp` property on the `VPNController` that would cause the timer to be updated, instead it happens indirectly via a QML timer.

This leads to a small race condition where the connection timer resets, but the old text string lingers around for a second until the QML timer fires. Adding a QML `Connection` class to trigger the reformatting of the timer should correct the issue.

## Reference
JIRA Issue: [VPN-7232](https://mozilla-hub.atlassian.net/browse/VPN-7232)
Bug introduced by: #10660

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
