### PR TITLE
VPN-5469: Fix unsecured WiFi detection on macOS 14 and later

### DIFF
--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -1979,8 +1979,7 @@ void MozillaVPN::registerInspectorCommands() {
   InspectorHandler::registerCommand(
       "force_unsecured_network", "Force an unsecured network detection", 0,
       [](InspectorHandler*, const QList<QByteArray>&) {
-        MozillaVPN::instance()->networkWatcher()->unsecuredNetwork("Dummy",
-                                                                   "Dummy");
+        MozillaVPN::instance()->networkWatcher()->unsecuredNetwork("Dummy");
         return QJsonObject();
       });
 

--- a/src/networkwatcher.h
+++ b/src/networkwatcher.h
@@ -25,7 +25,7 @@ class NetworkWatcher final : public QObject {
   void initialize();
 
   // Public for the Inspector.
-  void unsecuredNetwork(const QString& networkName, const QString& networkId);
+  void unsecuredNetwork(const QString& networkName);
   // Used for the Inspector. simulateOffline = true to mock being disconnected,
   // false to restore.
   void simulateDisconnection(bool simulatedDisconnection);
@@ -46,8 +46,7 @@ class NetworkWatcher final : public QObject {
 
   // Platform-specific implementation.
   NetworkWatcherImpl* m_impl = nullptr;
-
-  QMap<QString, QElapsedTimer> m_networks;
+  QElapsedTimer m_cooldown;
 
   // This is used to connect NotificationHandler lazily.
   bool m_firstNotification = true;

--- a/src/networkwatcherimpl.h
+++ b/src/networkwatcherimpl.h
@@ -36,7 +36,7 @@ class NetworkWatcherImpl : public QObject {
 
  signals:
   // Fires when the Device Connects to an unsecured Network
-  void unsecuredNetwork(const QString& networkName, const QString& networkId);
+  void unsecuredNetwork(const QString& networkName);
   // Fires on when the connected WIFI Changes
   // TODO: Only windows-networkwatcher has this, the other plattforms should
   // too.

--- a/src/notificationhandler.cpp
+++ b/src/notificationhandler.cpp
@@ -279,7 +279,7 @@ void NotificationHandler::unsecuredNetworkNotification(
 
   QString title =
       i18nStrings->t(I18nStrings::NotificationsUnsecuredNetworkTitle);
-  
+
   QString message;
   if (networkName.isEmpty()) {
     message = i18nStrings->t(I18nStrings::NotificationsUnsecuredNetworkGeneric);

--- a/src/notificationhandler.cpp
+++ b/src/notificationhandler.cpp
@@ -279,9 +279,14 @@ void NotificationHandler::unsecuredNetworkNotification(
 
   QString title =
       i18nStrings->t(I18nStrings::NotificationsUnsecuredNetworkTitle);
-  QString message =
-      i18nStrings->t(I18nStrings::NotificationsUnsecuredNetworkMessage)
-          .arg(networkName);
+  
+  QString message;
+  if (networkName.isEmpty()) {
+    message = i18nStrings->t(I18nStrings::NotificationsUnsecuredNetworkGeneric);
+  } else {
+    message = i18nStrings->t(I18nStrings::NotificationsUnsecuredNetworkMessage)
+                  .arg(networkName);
+  }
 
   notifyInternal(UnsecuredNetwork, title, message,
                  Constants::UNSECURED_NETWORK_ALERT_MSEC);

--- a/src/platforms/linux/linuxnetworkwatcherworker.cpp
+++ b/src/platforms/linux/linuxnetworkwatcherworker.cpp
@@ -162,7 +162,6 @@ void LinuxNetworkWatcherWorker::checkDevices() {
 
     if (!checkUnsecureFlags(rsnFlags.toInt(), wpaFlags.toInt())) {
       QString ssid = ap.property("Ssid").toString();
-      QString bssid = ap.property("HwAddress").toString();
 
       // We have found 1 unsecured network. We don't need to check other wifi
       // network devices.
@@ -170,7 +169,7 @@ void LinuxNetworkWatcherWorker::checkDevices() {
                        << "rsnFlags:" << rsnFlags.toInt()
                        << "wpaFlags:" << wpaFlags.toInt()
                        << "ssid:" << logger.sensitive(ssid);
-      emit unsecuredNetwork(ssid, bssid);
+      emit unsecuredNetwork(ssid);
       break;
     }
   }

--- a/src/platforms/linux/linuxnetworkwatcherworker.h
+++ b/src/platforms/linux/linuxnetworkwatcherworker.h
@@ -22,7 +22,7 @@ class LinuxNetworkWatcherWorker final : public QObject {
   void checkDevices();
 
  signals:
-  void unsecuredNetwork(const QString& networkName, const QString& networkId);
+  void unsecuredNetwork(const QString& networkName);
 
  public slots:
   void initialize();

--- a/src/platforms/macos/macosnetworkwatcher.mm
+++ b/src/platforms/macos/macosnetworkwatcher.mm
@@ -126,5 +126,5 @@ void MacOSNetworkWatcher::checkInterface() {
     logger.debug() << "Unable to fetch WiFi SSID";
   }
 
-  emit unsecuredNetwork(ssid, ssid);
+  emit unsecuredNetwork(ssid);
 }

--- a/src/platforms/macos/macosnetworkwatcher.mm
+++ b/src/platforms/macos/macosnetworkwatcher.mm
@@ -123,11 +123,7 @@ void MacOSNetworkWatcher::checkInterface() {
   if (ssid.isEmpty()) {
     // Note: Starting with macOS 14, retrieving the SSID requires location
     // permissions for the application, which we are unlikely to be granted.
-    // TODO: For most every language, Wi-Fi is a technical term so this kinda
-    // works, but we need a better localization strategy for the case where the
-    // SSID is unknown.
     logger.debug() << "Unable to fetch WiFi SSID";
-    ssid = "Wi-Fi";
   }
 
   emit unsecuredNetwork(ssid, ssid);

--- a/src/platforms/wasm/wasmnetworkwatcher.cpp
+++ b/src/platforms/wasm/wasmnetworkwatcher.cpp
@@ -22,5 +22,5 @@ void WasmNetworkWatcher::initialize() { logger.debug() << "initialize"; }
 
 void WasmNetworkWatcher::start() {
   logger.debug() << "actived";
-  emit unsecuredNetwork("WifiName", "NetworkID");
+  emit unsecuredNetwork("WifiName");
 }

--- a/src/platforms/windows/windowsnetworkwatcher.cpp
+++ b/src/platforms/windows/windowsnetworkwatcher.cpp
@@ -134,7 +134,6 @@ void WindowsNetworkWatcher::processWlan(PWLAN_NOTIFICATION_DATA data) {
         (char)connectionInfo->wlanAssociationAttributes.dot11Ssid.ucSSID[i]));
   }
 
-  logger.debug() << "Unsecure network:" << logger.sensitive(ssid)
-                 << "id:" << logger.sensitive(bssid);
-  emit unsecuredNetwork(ssid, bssid);
+  logger.debug() << "Unsecure network:" << logger.sensitive(ssid);
+  emit unsecuredNetwork(ssid);
 }

--- a/src/translations/strings.yaml
+++ b/src/translations/strings.yaml
@@ -281,6 +281,7 @@ notifications:
   connectionFailedMessage: Sorry, something went wrong with your VPN connection.
   subscriptionNotFound: Your Mozilla VPN subscription cannot be found. Please open the app to resolve this subscription issue.
   unsecuredNetworkTitle: Unsecured Wi-Fi network detected
+  unsecuredNetworkGeneric: "Wi-Fi is not secure. Click here to turn on VPN and secure your device."
   unsecuredNetworkMessage:
     value: "%1 is not secure. Click here to turn on VPN and secure your device."
     comment: "%1 is the Wi-Fi network name"

--- a/src/translations/strings.yaml
+++ b/src/translations/strings.yaml
@@ -281,7 +281,7 @@ notifications:
   connectionFailedMessage: Sorry, something went wrong with your VPN connection.
   subscriptionNotFound: Your Mozilla VPN subscription cannot be found. Please open the app to resolve this subscription issue.
   unsecuredNetworkTitle: Unsecured Wi-Fi network detected
-  unsecuredNetworkGeneric: "Wi-Fi is not secure. Click here to turn on VPN and secure your device."
+  unsecuredNetworkGeneric: "Wi-Fi network is not secure. Click here to turn on VPN and secure your device."
   unsecuredNetworkMessage:
     value: "%1 is not secure. Click here to turn on VPN and secure your device."
     comment: "%1 is the Wi-Fi network name"


### PR DESCRIPTION
## Description
Starting with macOS 14, reading the Wi-Fi SSID requires location services to be enabled for the application, but unfortunately this would lead to a bunch of popups and security notices for our application that doesn't make sense for the minor functionality added by knowing the SSID (IIUC, it is only used to fill in the notification text).

However, the current `MacOSNetworkWatcher` implementation uses the existence of an SSID as a proxy for whether the current network interface is a Wi-Fi device, which causes us to ignore the network changes because we treat them as wired networks.

This PR works around the issue by checking for the 802.11 PHY mode instead to determine if the interface is Wi-Fi or Wired and then uses a generic text string in place of the SSID-specific notification text.

Also, because the BSSID/SSID may not be known, we should refactor the network watcher to use a global notification cooldown rather than one specific to the network.

## Reference
JIRA Issue: [VPN-5469](https://mozilla-hub.atlassian.net/browse/VPN-5469)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-5469]: https://mozilla-hub.atlassian.net/browse/VPN-5469?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ