### PR TITLE
Linux: Remove recommends dependency on mozillavpn-keyring

### DIFF
--- a/linux/debian/control
+++ b/linux/debian/control
@@ -41,7 +41,6 @@ Vcs-Git: https://github.com/mozilla-mobile/mozilla-vpn-client
 
 Package: mozillavpn
 Architecture: any
-Recommends: mozillavpn-keyring
 Depends: wireguard (>=1.0.20200319),
          wireguard-tools (>=1.0.20200319),
          libsecret-1-0,


### PR DESCRIPTION
## Description
In the `2.31.0` release we added a `mozillavpn-keyring` package that attempts to automate the installation of the APT keyring to switch users to the static Debian packages. We will need to issue a dot release to get a fix out quickly before this impacts too many users.

Unfortunately, it seems like this package is in conflict with the Firefox users who setup the APT repository according to [Install Firefox on Linux](https://support.mozilla.org/en-US/kb/install-firefox-linux). In order to prevent incuring additional breakage for our users, we should remove this dependency until a better solution can be found.

The root of the problem seems to be that we wound up adding the package repository URL twice, and despite being signed by the same keyfile, the fact that they are at different paths seems to throw errors in the apt package cache.

## Reference
Bugzilla: [1989626](https://bugzilla.mozilla.org/show_bug.cgi?id=1989626)
JIRA Issue: [VPN-7276](https://mozilla-hub.atlassian.net/browse/VPN-7276)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-7276]: https://mozilla-hub.atlassian.net/browse/VPN-7276?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ