### PR TITLE
VPN-7262: change os tunnel removal to a task

### DIFF
--- a/src/cmake/sources.cmake
+++ b/src/cmake/sources.cmake
@@ -164,6 +164,8 @@ target_sources(mozillavpn-sources INTERFACE
     ${CMAKE_CURRENT_SOURCE_DIR}/tasks/controlleraction/taskcontrolleraction.h
     ${CMAKE_CURRENT_SOURCE_DIR}/tasks/createsupportticket/taskcreatesupportticket.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/tasks/createsupportticket/taskcreatesupportticket.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/tasks/deleteostunnelconfig/taskdeleteostunnelconfig.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/tasks/deleteostunnelconfig/taskdeleteostunnelconfig.h
     ${CMAKE_CURRENT_SOURCE_DIR}/tasks/getlocation/taskgetlocation.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/tasks/getlocation/taskgetlocation.h
     ${CMAKE_CURRENT_SOURCE_DIR}/tasks/getsubscriptiondetails/taskgetsubscriptiondetails.cpp

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -236,6 +236,7 @@ void Controller::forceDaemonCrash() {
 }
 
 void Controller::deleteOSTunnelConfig() {
+  // This should only be called from TaskDeleteOSTunnelConfig
   if (m_impl) {
     m_impl->deleteOSTunnelConfig();
   }
@@ -825,8 +826,8 @@ void Controller::captivePortalPresent() {
 }
 
 void Controller::serverDataChanged() {
-  if (!isActive()) {
-    logger.debug() << "Server data changed but we are off";
+  if (!isActive() || m_state == StateDisconnecting) {
+    logger.debug() << "Server data changed but we are off or disconnecting";
     return;
   }
 

--- a/src/models/serverdata.cpp
+++ b/src/models/serverdata.cpp
@@ -88,6 +88,7 @@ void ServerData::update(const QString& exitCountryCode,
                         const QString& exitCityName,
                         const QString& entryCountryCode,
                         const QString& entryCityName) {
+  logger.debug() << "Updating server data";
   Q_ASSERT(m_initialized);
 
   m_previousExitCountryCode = m_exitCountryCode;

--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -53,6 +53,7 @@
 #include "tasks/captiveportallookup/taskcaptiveportallookup.h"
 #include "tasks/controlleraction/taskcontrolleraction.h"
 #include "tasks/createsupportticket/taskcreatesupportticket.h"
+#include "tasks/deleteostunnelconfig/taskdeleteostunnelconfig.h"
 #include "tasks/getlocation/taskgetlocation.h"
 #include "tasks/getsubscriptiondetails/taskgetsubscriptiondetails.h"
 #include "tasks/heartbeat/taskheartbeat.h"
@@ -845,7 +846,7 @@ void MozillaVPN::reset(bool forceInitialState) {
   m_private->m_keys.forgetKeys();
   m_private->m_serverData.forget();
 
-  controller()->deleteOSTunnelConfig();
+  TaskScheduler::scheduleTask(new TaskDeleteOSTunnelConfig());
 
   PurchaseHandler::instance()->stopSubscription();
   if (!Feature::get(Feature::Feature_webPurchase)->isSupported()) {
@@ -1257,7 +1258,7 @@ void MozillaVPN::maybeRegenerateDeviceKey() {
 
 void MozillaVPN::hardReset() {
   SettingsManager::instance()->hardReset();
-  controller()->deleteOSTunnelConfig();
+  TaskScheduler::scheduleTask(new TaskDeleteOSTunnelConfig());
 }
 
 void MozillaVPN::hardResetAndQuit() {

--- a/src/tasks/deleteostunnelconfig/taskdeleteostunnelconfig.cpp
+++ b/src/tasks/deleteostunnelconfig/taskdeleteostunnelconfig.cpp
@@ -1,0 +1,35 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "taskdeleteostunnelconfig.h"
+
+#include "controller.h"
+#include "leakdetector.h"
+#include "logger.h"
+#include "mozillavpn.h"
+
+namespace {
+Logger logger("TaskDeleteOSTunnelConfig");
+}
+
+TaskDeleteOSTunnelConfig::TaskDeleteOSTunnelConfig()
+    : Task("TaskDeleteOSTunnelConfig") {
+  MZ_COUNT_CTOR(TaskDeleteOSTunnelConfig);
+
+  logger.debug() << "TaskDeleteOSTunnelConfig created";
+}
+
+TaskDeleteOSTunnelConfig::~TaskDeleteOSTunnelConfig() {
+  MZ_COUNT_DTOR(TaskDeleteOSTunnelConfig);
+}
+
+void TaskDeleteOSTunnelConfig::run() {
+  logger.debug() << "TaskDeleteOSTunnelConfig run";
+
+  Controller* controller = MozillaVPN::instance()->controller();
+  Q_ASSERT(controller);
+
+  controller->deleteOSTunnelConfig();
+  emit completed();
+}

--- a/src/tasks/deleteostunnelconfig/taskdeleteostunnelconfig.h
+++ b/src/tasks/deleteostunnelconfig/taskdeleteostunnelconfig.h
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef TASKDELETEOSTUNNELCONFIG_H
+#define TASKDELETEOSTUNNELCONFIG_H
+
+#include <QObject>
+
+#include "task.h"
+
+// The purpose of this task is to remove the OSs tunnel config.
+class TaskDeleteOSTunnelConfig final : public Task {
+  Q_DISABLE_COPY_MOVE(TaskDeleteOSTunnelConfig)
+
+ public:
+  explicit TaskDeleteOSTunnelConfig();
+
+  ~TaskDeleteOSTunnelConfig();
+
+  void run() override;
+
+  virtual DeletePolicy deletePolicy() const override { return NonDeletable; }
+
+ private:
+};
+
+#endif  // TASKDELETEOSTUNNELCONFIG_H


### PR DESCRIPTION
## Description

Note: This behavior reproduces consistently when signing out on iOS _when the VPN is turned on_.

This behavior was caused because the controller was not getting to StateOff. On iOS, we listen for the OS's VPN state changes. If they say it's off, then we emit something back to the controller. 

However, we were removing the network extension before the VPN was completely turned off, and so that emit was never happening. Modifying this so the tunnel removal is a task allows the deactivation to complete before removing the tunnel config, thus allowing the controller to understand it's in an `off` state.

Additionally - `serverDataChanged` causes a server switch, which was unexpected behavior also seen in the logs here. However, we signing out (or resetting), we clear all settings. This causes the serverData setting to change, triggering `serverDataChanged`. And since the controller state was in `disconnecting`, it was trying a server switch. I've stopped that behavior by doing an early exit if it's disconnected _or disconnecting_.

## Reference

VPN-7262

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
