### PR TITLE
VPN-5397: Add common Mac keyboard shortcuts

### DIFF
--- a/src/ui/main.qml
+++ b/src/ui/main.qml
@@ -203,6 +203,24 @@ Window {
                  VPN.state === VPN.StateMain
     }
 
+    Shortcut {
+        sequence: "Ctrl+M"
+        enabled: Qt.platform.os === "osx"
+
+        onActivated: {
+            window.showMinimized();
+        }
+    }
+
+    Shortcut {
+        sequence: "Ctrl+,"
+        enabled: Qt.platform.os === "osx"
+
+        onActivated: {
+            MZNavigator.requestScreen(VPN.ScreenSettings);
+        }
+    }
+
     Connections {
         target: VPNAppPermissions
         function onNotification(type,message,action) {


### PR DESCRIPTION
## Description

Add common Mac shortcuts:
- Cmd+M to minimize window
- Cmd+, to show preferences screen

Full list: https://support.apple.com/en-us/102650 - some of them are handled by macOS, but others (in particularly Cmd+M) need handlers under Qt.

## Reference

[VPN-5397](https://mozilla-hub.atlassian.net/browse/VPN-5397)

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
