### PR TITLE
Cherry-pick VPN-7276: Remove recommends dependency on mozillavpn-keyring

### DIFF
--- a/linux/debian/control
+++ b/linux/debian/control
@@ -41,7 +41,6 @@ Vcs-Git: https://github.com/mozilla-mobile/mozilla-vpn-client
 
 Package: mozillavpn
 Architecture: any
-Recommends: mozillavpn-keyring
 Depends: wireguard (>=1.0.20200319),
          wireguard-tools (>=1.0.20200319),
          libsecret-1-0,


### PR DESCRIPTION
## Description
During the 2.31.x release cycle, we had to make an emergency dot release for Linux to remove the `Recommends` dependency on `mozillavpn-keyring` but that patch was never merged onto `main` which means that we can still encounter the bug when installing the latest release.

This cherry-picks the fix to `main`

## Reference
Cherry-pick: #10786
JIRA Issue: [VPN-7276](https://mozilla-hub.atlassian.net/browse/VPN-7276)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-7276]: https://mozilla-hub.atlassian.net/browse/VPN-7276?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ