### PR TITLE
VPN-7103: Increase the APT pin priority to 1000

### DIFF
--- a/linux/keyring/mozilla-vpn.pref
+++ b/linux/keyring/mozilla-vpn.pref
@@ -1,4 +1,4 @@
 Package: mozillavpn
 Pin: origin packages.mozilla.org
-Pin-Priority: 100
+Pin-Priority: 1000
 


### PR DESCRIPTION
## Description
When we originally wrote the APT preferences file for the Mozilla VPN package, we misunderstood the values of the preference. A value of 100 causes APT to prefer already-installed packages over updates. We should change this to 1000 to prefer the pinned repository.

## Reference
JIRA Issue: [VPN-7103](https://mozilla-hub.atlassian.net/browse/VPN-7103)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-7103]: https://mozilla-hub.atlassian.net/browse/VPN-7103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ