### PR TITLE
VPN-7195: Add a watchdog timer for the status icon

### DIFF
--- a/src/statusicon.cpp
+++ b/src/statusicon.cpp
@@ -24,6 +24,9 @@ constexpr const QColor ORANGE_COLOR = QColor(255, 164, 54, 255);
 constexpr const QColor RED_COLOR = QColor(226, 40, 80, 255);
 constexpr const QColor INVALID_COLOR = QColor();
 
+using namespace std::chrono_literals;
+constexpr const std::chrono::milliseconds ANIMATION_WATCHDOG_TIMEOUT = 1000ms;
+
 #if defined(MZ_LINUX) || defined(MZ_WINDOWS)
 constexpr const std::array<const char*, 4> ANIMATED_LOGO_STEPS = {
     ":/ui/resources/logo-animated1.png", ":/ui/resources/logo-animated2.png",
@@ -53,6 +56,10 @@ StatusIcon::StatusIcon() {
 
   connect(&m_animatedIconTimer, &QTimer::timeout, this,
           &StatusIcon::animateIcon);
+
+  m_animationWatchdog.setSingleShot(true);
+  connect(&m_animationWatchdog, &QTimer::timeout, this,
+          &StatusIcon::refreshNeeded);
 }
 
 StatusIcon::~StatusIcon() { MZ_COUNT_DTOR(StatusIcon); }
@@ -78,6 +85,7 @@ void StatusIcon::animateIcon() {
   if (m_animatedIconIndex == ANIMATED_LOGO_STEPS.size()) {
     m_animatedIconIndex = 0;
   }
+  m_animationWatchdog.start(ANIMATION_WATCHDOG_TIMEOUT);
   refreshNeeded();
 }
 

--- a/src/statusicon.h
+++ b/src/statusicon.h
@@ -44,6 +44,8 @@ class StatusIcon final : public QObject {
   // Animated icon.
   QTimer m_animatedIconTimer;
   uint8_t m_animatedIconIndex = 0;
+
+  QTimer m_animationWatchdog;
 };
 
 #endif  // STATUSICON_H


### PR DESCRIPTION
## Description
It seems that some Linux desktops are prone to race conditions when handling frequent changes to the system tray icon. I suspect that this is because the D-Bus backend that implements can lose the update signals if they occur too frequently. To work around it, lets add a watchdog timer to the `StatusIcon` class that fires another update after the animated logo ends.

This way, if the last transition to a stable icon got lost, the watchdog will fix it by forcing the desktop environment to redraw it after it becomes stable.

## Reference
JIRA Issue: [VPN-7195](https://mozilla-hub.atlassian.net/browse/VPN-7195)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-7195]: https://mozilla-hub.atlassian.net/browse/VPN-7195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ