### PR TITLE
VPN-7304: Reset controller state after deleteOSTunnelConfig()

### DIFF
--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -240,6 +240,7 @@ void Controller::deleteOSTunnelConfig() {
   if (m_impl) {
     m_impl->deleteOSTunnelConfig();
   }
+  setState(Controller::StateInitializing);
 }
 
 void Controller::startHandshakeTimer() {


### PR DESCRIPTION
## Description
There is a bug that can occur when signing out of the VPN that fails to update the controller's device and key configuration upon signing back in. The cause seems to be that some controller implementations only set the key/device information in the `initialize()` method but the controller state machine never returns to `Controller::StateInitializing` which causes the `MozillaVPN` class to think that the controller is already initialized.

This can easily be fixed by returning the `Controller` class back to` Controller::StateInitializing` when deleting the OS tunnel configuration.

This issue seems like it would affect both the Flatpak (`NetMgrController`) and iOS (`IOSController`) platforms. Everything else appears to be unaffected.

## Reference
JIRA Issue: [VPN-7304](https://mozilla-hub.atlassian.net/browse/VPN-7304)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-7304]: https://mozilla-hub.atlassian.net/browse/VPN-7304?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ