### PR TITLE
VPN-6666: Add null check for NotificationHandler instance in MozillaVPN::errorHandled()

### DIFF
--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -1416,7 +1416,9 @@ void MozillaVPN::errorHandled() {
 
   // Controller errors should trigger a system tray notification.
   if (alert == ErrorHandler::ControllerErrorAlert) {
-    NotificationHandler::instance()->connectionFailureNotification();
+    if (NotificationHandler::instance() != nullptr) {
+      NotificationHandler::instance()->connectionFailureNotification();
+    }
   }
 
   // Any error in authenticating state sends to the Initial state.


### PR DESCRIPTION
## Description

Naive solution to prevent a segfault on Linux when there's an error while executing a command in cli/headless mode. Not sure if supporting the whole notification flow in command-line mode would work here (how do we notify then?), but happy to discuss any alternative approaches.

## Reference

[VPN-6666](https://mozilla-hub.atlassian.net/browse/VPN-6666)

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-6666]: https://mozilla-hub.atlassian.net/browse/VPN-6666?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ