### PR TITLE
VPN-7293: update language for permissions screen on macOS 15 and 26

### DIFF
--- a/nebula/ui/utils/MZAssetLookup.js
+++ b/nebula/ui/utils/MZAssetLookup.js
@@ -447,7 +447,7 @@ var localizedImageLookup =
           nl: 'qrc:/ui/resources/permissions/macos-background-dark-nl.svg'
         }
       },
-      'MacosPermissionBackgroundTahoe': {
+      'MacosPermissionBackgroundMacOS26': {
         filenameLight: {
           de: 'qrc:/ui/resources/permissions/macos-tahoe-background-light-de.svg',
           en: 'qrc:/ui/resources/permissions/macos-tahoe-background-light-en.svg',

--- a/src/translations/strings.yaml
+++ b/src/translations/strings.yaml
@@ -1048,16 +1048,19 @@ permissionMacos:
     comment: Paragraph requesting the user to allow the VPN to run in the background.
   instructions:
     value: In order to do this, please click the button below to open the <i>Login Items</i> of your <i>System Preferences</i>, and enable <i>Allow in the background</i> for Mozilla VPN.
-    comment: Paragraph explaining how to enable the VPN to run in the background.
-  instructionsTahoe:
+    comment: Paragraph explaining how to enable the VPN to run in the background on macOS 14, see https://support.apple.com/guide/mac-help/mtusr003/mac for reference translations of these features on different versions of macOS.
+  instructionsMacOS15:
+    value: In order to do this, please click the button below to open the <i>Login Items & Extensions</i> of your <i>System Preferences</i>, and enable <i>Allow in the background</i> for Mozilla VPN.
+    comment: Paragraph explaining how to enable the VPN to run in the background on macOS 15 and above, see https://support.apple.com/guide/mac-help/mtusr003/mac for reference translations of these features on different versions of macOS.
+  instructionsMacOS26:
     value: In order to do this, please click the button below to open the <i>Login Items & Extensions</i> of your <i>System Preferences</i>, and enable <i>App Background Activity</i> for Mozilla VPN.
-    comment: Paragraph explaining how to enable the VPN to run in the background.
+    comment: Paragraph explaining how to enable the VPN to run in the background on macOS 26 and above, see https://support.apple.com/guide/mac-help/mtusr003/mac for reference translations of these features on different versions of macOS.
   openSettingsButtonLabel:
     value: Open Login Items
-    comment: Label for the button that opens the login items settings page
-  openSettingsButtonLabelTahoe:
+    comment: Label for the button that opens the login items settings page on macOS 14
+  openSettingsButtonLabelMacOS15:
     value: Open Login Items & Extensions
-    comment: Label for the button that opens the login items settings page
+    comment: Label for the button that opens the login items settings page on macOS 15 and above
 
 global:
   expand:

--- a/src/ui/sharedViews/ViewPermissionRequiredOSX.qml
+++ b/src/ui/sharedViews/ViewPermissionRequiredOSX.qml
@@ -28,7 +28,7 @@ MZFlickable {
             Layout.alignment: Qt.AlignHCenter
             Layout.topMargin: MZTheme.theme.contentTopMarginDesktop
 
-            source: VPNMacOSUtils.getMacOSMajorVersion() > 25 ? MZAssetLookup.getLocalizedImageSource("MacosPermissionBackgroundTahoe") : MZAssetLookup.getLocalizedImageSource("MacosPermissionBackground")
+            source: VPNMacOSUtils.getMacOSMajorVersion() > 25 ? MZAssetLookup.getLocalizedImageSource("MacosPermissionBackgroundMacOS26") : MZAssetLookup.getLocalizedImageSource("MacosPermissionBackground")
             fillMode: Image.PreserveAspectFit
         }
 
@@ -64,7 +64,8 @@ MZFlickable {
                 Layout.topMargin: 8
                 Layout.fillWidth: true
 
-                text: VPNMacOSUtils.getMacOSMajorVersion() > 25 ? MZI18n.PermissionMacosInstructionsTahoe : MZI18n.PermissionMacosInstructions
+                text: VPNMacOSUtils.getMacOSMajorVersion() > 25 ? MZI18n.PermissionMacosInstructionsMacOS26 :
+                      VPNMacOSUtils.getMacOSMajorVersion() > 14 ? MZI18n.PermissionMacosInstructionsMacOS15 : MZI18n.PermissionMacosInstructions
                 horizontalAlignment: Text.AlignLeft
             }
         }
@@ -76,7 +77,7 @@ MZFlickable {
         MZButton {
             id: openSettingsButton
 
-            text: VPNMacOSUtils.getMacOSMajorVersion() > 25 ? MZI18n.PermissionMacosOpenSettingsButtonLabelTahoe : MZI18n.PermissionMacosOpenSettingsButtonLabel
+            text: VPNMacOSUtils.getMacOSMajorVersion() > 14 ? MZI18n.PermissionMacosOpenSettingsButtonLabelMacOS15 : MZI18n.PermissionMacosOpenSettingsButtonLabel
             Layout.preferredHeight: MZTheme.theme.rowHeight
             loaderVisible: false
             onClicked: VPNMacOSUtils.openSystemSettingsLoginItems()


### PR DESCRIPTION
## Description

Follow-up to https://github.com/mozilla-mobile/mozilla-vpn-client/pull/10800 . Valentina has discovered that "Login Items" has been called "Login Items & Extensions" since MacOS 15, so it has to be updated accordingly.

Full list of different names for different macOS versions on those screens can be found at https://support.apple.com/en-gb/guide/mac-help/mtusr003

I've updated comments for translators too.

## Reference

https://mozilla-hub.atlassian.net/browse/VPN-7293

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
