### PR TITLE
Fix syntax error in Flatpak RC tag matching

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -2,7 +2,7 @@ name: Release Candidate Automation
 on:
   push:
     tags:
-      - "v[0-9.]+-rc[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+"
 
 jobs:
   flathub-beta:


### PR DESCRIPTION
## Description
It turns out that the workflow [filter syntax](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#filter-pattern-cheat-sheet) isn't regex, but something regex-like and this has caused the Flatpak's Release Candidate workflow from executing on tag events.

To fix this, we need to adjust the filter syntax so that it only uses alphanumeric characters inside the ranges.

## Reference

    i.e Jira or Github issue URL

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
