### PR TITLE
VPN-7317: Fix XPC connection use-after-free after sign-out

### DIFF
--- a/src/platforms/macos/macoscontroller.mm
+++ b/src/platforms/macos/macoscontroller.mm
@@ -47,7 +47,9 @@ MacOSController::MacOSController() : ControllerImpl()  {
 
 MacOSController::~MacOSController() {
   if (m_connection != nil) {
-    [static_cast<NSXPCConnection*>(m_connection) release];
+    NSXPCConnection* conn = static_cast<NSXPCConnection*>(m_connection);
+    [conn invalidate];
+    [conn release];
   }
 }
 
@@ -222,6 +224,9 @@ void MacOSController::connectService(void) {
     QJsonObject jsObj = QJsonDocument::fromJson(jsBlob).object();
     emit initialized(true, jsObj.value("connected").toBool(),
                      QDateTime::fromString(jsObj.value("date").toString()));
+    
+    // The delegate is now owned by the NSXPCConnection
+    [delegate release];
   }];
 }
 


### PR DESCRIPTION
## Description
There are a pair of use-after-free bugs in the `MacOSController` that can occur when the controller is destructed.

The first issue is that we have the reference counting wrong when managing the `XpcClientDelegate`. The `NSXPCConnection.exportedObject` property has the `retain` characteristic, which I think cause an extra refcount to be held, preventing it from being freed by the destructor.

The second issue is that we are missing a call to [NSXPCConnection.invalidate](https://developer.apple.com/documentation/foundation/nsxpcconnection/invalidate()?language=objc) before destructing the connection. Leaving the object referenced by the XPC message handlers.

## Reference
JIRA Issue: [VPN-7317](https://mozilla-hub.atlassian.net/browse/VPN-7317)
Caused-by: #10813

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-7317]: https://mozilla-hub.atlassian.net/browse/VPN-7317?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ