### PR TITLE
Show account deletion link when authenticated

### DIFF
--- a/src/ui/screens/getHelp/ViewGetHelp.qml
+++ b/src/ui/screens/getHelp/ViewGetHelp.qml
@@ -76,7 +76,7 @@ MZViewBase {
         MZExternalLinkListItem {
             objectName: "deleteAccount"
             title: MZI18n.DeleteAccountButtonLabel
-            visible: MZFeatureList.get("accountDeletion").isSupported
+            visible: MZFeatureList.get("accountDeletion").isSupported && VPN.userAuthenticated
 
             onClicked: {
                 MZUrlOpener.openUrlLabel("deleteAccount");


### PR DESCRIPTION
## Description

Help screen is available when not signed in, so we need to hide the account deletion button when the user isn't signed in.

## Reference

[VPN-7329](https://mozilla-hub.atlassian.net/browse/VPN-7329)

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-7329]: https://mozilla-hub.atlassian.net/browse/VPN-7329?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ