### PR TITLE
Change icon color for external account link in settings screen to blue

### DIFF
--- a/src/ui/screens/settings/ViewSettingsMenu.qml
+++ b/src/ui/screens/settings/ViewSettingsMenu.qml
@@ -34,7 +34,7 @@ MZViewBase {
                 objectName: "settingsUserProfile"
                 settingTitle: MZI18n.SubscriptionManagementSectionTitle
                 imageLeftSrc: MZAssetLookup.getImageSource("IconAvatar")
-                imageRightSrc: MZAssetLookup.getImageSource("ExternalLinkGrayscale")
+                imageRightSrc: MZAssetLookup.getImageSource("ExternalLink")
                 imageRightMirror: MZLocalizer.isRightToLeft
                 onClicked: {
                    MZUrlOpener.openUrlLabel("account");


### PR DESCRIPTION
## Description

Raluca has noticed that the icon color for account link is grayscale while it's colored everywhere else (e.g. the Help Center icon from the Help menu). Do we want this icon have the same color (see images below)?

## Reference

[VPN-7311](https://mozilla-hub.atlassian.net/browse/VPN-7311)

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed

Before:

<img width="472" height="784" alt="Screenshot 2025-10-29 at 13 03 24" src="https://github.com/user-attachments/assets/f07d2752-e164-453c-a7fd-66762a122767" />

After:

<img width="472" height="784" alt="Screenshot 2025-10-29 at 13 04 50" src="https://github.com/user-attachments/assets/b04ee696-8d3d-490e-b631-98a4b06d20e2" />


[VPN-7311]: https://mozilla-hub.atlassian.net/browse/VPN-7311?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ