### PR TITLE
VPN-7136: improve iOS notification request

### DIFF
--- a/src/notificationhandler.cpp
+++ b/src/notificationhandler.cpp
@@ -324,6 +324,12 @@ void NotificationHandler::newInAppMessageNotification(const QString& title,
     return;
   }
 
+  if (App::instance()->state() == App::StateOnboarding ||
+      App::instance()->state() == MozillaVPN::StateDeviceLimit) {
+    logger.debug() << "User is onboarding, will not be notified.";
+    return;
+  }
+
   notifyInternal(NewInAppMessage, title, message,
                  Constants::NEW_IN_APP_MESSAGE_ALERT_MSEC);
 }

--- a/src/platforms/ios/iosnotificationhandler.h
+++ b/src/platforms/ios/iosnotificationhandler.h
@@ -21,7 +21,7 @@ class IOSNotificationHandler final : public NotificationHandler {
               int timerMsec) override;
 
  private:
-  void initialize() override;
+  void requestPermission();
 
  private:
   void* m_delegate = nullptr;

--- a/src/platforms/ios/iosnotificationhandler.mm
+++ b/src/platforms/ios/iosnotificationhandler.mm
@@ -5,9 +5,9 @@
 #include "platforms/ios/iosnotificationhandler.h"
 #include "leakdetector.h"
 
-#import <UserNotifications/UserNotifications.h>
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
+#import <UserNotifications/UserNotifications.h>
 
 @interface IOSNotificationDelegate
     : UIResponder <UIApplicationDelegate, UNUserNotificationCenterDelegate> {
@@ -48,7 +48,7 @@ IOSNotificationHandler::IOSNotificationHandler(QObject* parent) : NotificationHa
 
 IOSNotificationHandler::~IOSNotificationHandler() { MZ_COUNT_DTOR(IOSNotificationHandler); }
 
-void IOSNotificationHandler::initialize() {
+void IOSNotificationHandler::requestPermission() {
   UNUserNotificationCenter* center = [UNUserNotificationCenter currentNotificationCenter];
   [center requestAuthorizationWithOptions:(UNAuthorizationOptionSound | UNAuthorizationOptionAlert |
                                            UNAuthorizationOptionBadge)
@@ -63,6 +63,8 @@ void IOSNotificationHandler::initialize() {
 void IOSNotificationHandler::notify(NotificationHandler::Message type, const QString& title,
                                     const QString& message, int timerMsec) {
   Q_UNUSED(type);
+
+  requestPermission();
 
   if (!m_delegate) {
     return;


### PR DESCRIPTION
## Description

This is a small improvement. We currently request iOS permissions immediately upon first launch of the app. This changes it to request the first time the VPN is activated. (It would be better if this was part of the onboarding flow, and we showed a screen with our own language/pitch, but this is an improvement over the current behavior.)

- After the first time the permission is requested, iOS system ignores the request. So it's safe to run this code on each notification request.
- Had to block notifications (from addons) when onboarding, otherwise it would pop the request during the onboarding flow.

## Reference

VPN-7136

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
