### PR TITLE
VPN-7330: add subscription text back

### DIFF
--- a/src/translations/strings.yaml
+++ b/src/translations/strings.yaml
@@ -782,6 +782,15 @@ subscriptionManagement:
     comment: Menu title for a view with details on the user's account.
   manageAccount:
     value: Manage account
+  planMonthly:
+    value: "Monthly plan: %1"
+    comment: Price for a monthly subscription. %1 represents the localized currency string
+  planMonthlyWithoutTax:
+    value: "%1/month"
+    comment: Price for a monthly subscription without tax. %1 represents the localized currency string
+  planMonthlyPlusTax:
+    value: "%1/month + tax"
+    comment: Price for a monthly subscription plus tax. %1 represents the localized currency string
 
 inAppMessaging:
   menuTitle: Messages


### PR DESCRIPTION
## Description

Unfortunately, these were [erroneously removed in a recent PR](https://github.com/mozilla-mobile/mozilla-vpn-client/pull/10829/files#diff-51d1d7d3681b31f83aa184349c06be4a6c4c5500b0219d98b4192a24778daf1f). I take some responsibility for this - I spot-checked a few random strings that were removed in that PR to ensure we didn't use them elsewhere, but didn't check every one - and so these 3 slipped through. (Additionally, today I took the time to confirm there were no other strings erroneously removed - I believe these should be the only ones.)

@flodolo - Giant apologies that there were recently translations for these strings. Would you like us to put a patch up on the translation repo that restores those strings, rather than create additional work for our translation volunteers?

Screenshot of this branch, showing the fix:
<img width="163" height="1218" alt="Screenshot 2025-10-31 at 11 59 18 AM" src="https://github.com/user-attachments/assets/802a1b0a-dddc-4d02-b0eb-fd04759a99ea" />

## Reference

VPN-7330

## Checklist

- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
