### PR TITLE
VPN-6293 - Maybe fix ip assignment c: 

### DIFF
--- a/src/platforms/windows/daemon/wireguardutilswindows.cpp
+++ b/src/platforms/windows/daemon/wireguardutilswindows.cpp
@@ -59,7 +59,7 @@ static void CALLBACK WireGuardLogger(_In_ WIREGUARD_LOGGER_LEVEL Level,
 /**
  * @brief Assigns an ipv4 address to a network device with a given LUID
  *
- * @param luid - LUID of the Adapter
+ * @param ifindex - Interface Index of the Adapter
  * @param address - Address and NetMask of the Adapter
  * @return ulong - nteContext - Call DeleteIPAddress(nteContext) to remove the
  * assignment.


### PR DESCRIPTION
## Description

We see in the ticket the following logs during activation: 

```
[18.09.2025 07:09:52.238] (WireguardUtilsWindows) Error: Failed to assign ivp6: CreateUnicastIpAddressEntry failed with error :  1168
[18.09.2025 07:09:52.238] (WireguardUtilsWindows) Error: Failed setIPv6AddressAndMask
[18.09.2025 07:09:52.238] (WireguardUtilsWindows) Error: Failure during Adapter Creation, Closing Device
```
1168 Means that the row matches an adapter that does not exist. 

-> We set the ipv4 explicitly using it's interface index, so let's do that lookup once and use it for both addresses. This way we should assert before that it exists.
-> I also noticed the row was incorrectly setting it's address type, so maybe that trips it over? 
