### PR TITLE
VPN-7328 - Report Android Manifacturer for Support

### DIFF
--- a/src/models/devicemodel.cpp
+++ b/src/models/devicemodel.cpp
@@ -18,6 +18,7 @@
 
 #if MZ_ANDROID
 #  include "platforms/android/androidcommons.h"
+#  include "platforms/android/androidutils.h"
 #endif
 
 #ifdef MZ_WINDOWS
@@ -299,6 +300,8 @@ void DeviceModel::logSerialize(QIODevice* device) {
 #endif
 #ifdef MZ_ANDROID
   out << "SDK Version -> " << AndroidCommons::getSDKVersion() << Qt::endl;
+  out << "Manufacturer -> " << AndroidCommons::GetManufacturer() << Qt::endl;
+  out << "Device Name -> " << AndroidUtils::getDeviceName() << Qt::endl;
 #endif
 
   out << "APP Version -> " << QCoreApplication::applicationVersion()


### PR DESCRIPTION
We get reports that on some android devices disconnecting even with  always-on. Logs don't show any specific bug or any disconnection caused by us  or the network. 

So we might be fighting with background closing issues. 

In order to better understand that, support should know the device that is failing so we can point to the manufacturer.

