### PR TITLE
Disable caches in qt-toolchain tasks

### DIFF
--- a/taskcluster/kinds/build/addons.yml
+++ b/taskcluster/kinds/build/addons.yml
@@ -11,7 +11,7 @@ addons-bundle:
         platform: addons/all
     fetches:
         toolchain: 
-            - qt-tools-6.6.3
+            - qt-tools-6.6
     attributes:
         build-type: addons/opt  # needed by the signing kind
     worker-type: b-linux

--- a/taskcluster/kinds/build/macos.yml
+++ b/taskcluster/kinds/build/macos.yml
@@ -49,7 +49,7 @@ macos/opt:
             - cargo-vendor
             - conda-osxcross
             - qt-macos-6.6
-            - qt-tools-6.6.3
+            - qt-tools-6.6
     worker-type: b-linux-large
     worker:
         docker-image: {in-tree: conda-base}

--- a/taskcluster/kinds/build/wasm.yml
+++ b/taskcluster/kinds/build/wasm.yml
@@ -21,7 +21,7 @@ wasm/opt:
     fetches:
         toolchain:
             - conda-wasm
-            - qt-tools-6.6.3
+            - qt-tools-6.6
             - qt-wasm
     run:
         using: run-task

--- a/taskcluster/kinds/toolchain/qt.yml
+++ b/taskcluster/kinds/toolchain/qt.yml
@@ -133,16 +133,16 @@ qt-linux-next:
     worker:
         docker-image: {in-tree: linux-qt6-build}
 
-qt-tools-6.6.3:
+qt-tools-6.6:
     description: "Linux Qt host tools"
     run:
         script: bundle_qt_tools.sh
         resources:
             - requirements.txt
-        toolchain-alias: qt-tools-6.6.3
+        toolchain-alias: qt-tools-6.6
         toolchain-artifact: public/build/qt-host-tools.tar.xz
     treeherder:
-        symbol: TL(qt-tools-6.6.3)
+        symbol: TL(qt-tools-6.6)
     worker-type: b-linux
     worker:
         docker-image: {in-tree: conda-base}


### PR DESCRIPTION
## Description

https://firefox-ci-tc.services.mozilla.com/tasks/RwYGQPLmT-OOsv40dTF9uQ

This is the cursed task - according to the logs we seem to pull qt.6.6.3. 
But looking at the artifact, we have both qt 6.9.2 (qt-host-tools\) and 6.6.3 (qt-host-tools\gcc_64\)! 

## What i think that happened: 

- The taskcluster update has seemed to force rebuilt of our toolchain tasks. 
- The tools-6.9 task was scheudled before the 6.6 task.
- The cache of the 6.9 task was reused on the 6.6. which seems to be the pwd.
- We have hence all the 6.9 files already there, causing the wierd artifact. 
--- 

What this patch does: 
1. Disable caches on toolchain tasks, by putting as task-default:
```yaml
    run: 
        use-caches: []
```

2. Change the artifact name to be explicit, so it's clear what version of qt-tools and qt are used in a task i.e 
```yaml

macos/opt:
    description: "macOS Build (release)"
   (..)
    fetches:
        toolchain:
            - qt-macos-6.6
            - qt-tools-6.6.3
```