### PR TITLE
Revert "VPN-7365 improve first iOS notification"

### DIFF
--- a/src/platforms/ios/iosnotificationhandler.h
+++ b/src/platforms/ios/iosnotificationhandler.h
@@ -21,7 +21,7 @@ class IOSNotificationHandler final : public NotificationHandler {
               int timerMsec) override;
 
  private:
-  void requestPermission(std::function<void(void)> completionHandler);
+  void requestPermission();
 
  private:
   void* m_delegate = nullptr;

--- a/src/platforms/ios/iosnotificationhandler.mm
+++ b/src/platforms/ios/iosnotificationhandler.mm
@@ -48,7 +48,7 @@ IOSNotificationHandler::IOSNotificationHandler(QObject* parent) : NotificationHa
 
 IOSNotificationHandler::~IOSNotificationHandler() { MZ_COUNT_DTOR(IOSNotificationHandler); }
 
-void IOSNotificationHandler::requestPermission(std::function<void(void)> completionHandler) {
+void IOSNotificationHandler::requestPermission() {
   UNUserNotificationCenter* center = [UNUserNotificationCenter currentNotificationCenter];
   [center requestAuthorizationWithOptions:(UNAuthorizationOptionSound | UNAuthorizationOptionAlert |
                                            UNAuthorizationOptionBadge)
@@ -56,7 +56,6 @@ void IOSNotificationHandler::requestPermission(std::function<void(void)> complet
                           Q_UNUSED(granted);
                           if (!error) {
                             m_delegate = [[IOSNotificationDelegate alloc] initWithObject:this];
-                            completionHandler();
                           }
                         }];
 }
@@ -65,35 +64,32 @@ void IOSNotificationHandler::notify(NotificationHandler::Message type, const QSt
                                     const QString& message, int timerMsec) {
   Q_UNUSED(type);
 
-  void (^sendNotification)(void);
-  sendNotification = ^{
-    UNMutableNotificationContent* content = [[UNMutableNotificationContent alloc] init];
-    content.title = title.toNSString();
-    content.body = message.toNSString();
-    content.sound = [UNNotificationSound defaultSound];
-
-    int timerSec = timerMsec / 1000;
-    UNTimeIntervalNotificationTrigger* trigger =
-        [UNTimeIntervalNotificationTrigger triggerWithTimeInterval:timerSec repeats:NO];
-
-    UNNotificationRequest* request = [UNNotificationRequest requestWithIdentifier:@"mozillavpn"
-                                                                          content:content
-                                                                          trigger:trigger];
-
-    UNUserNotificationCenter* center = [UNUserNotificationCenter currentNotificationCenter];
-    center.delegate = id(m_delegate);
-
-    [center addNotificationRequest:request
-             withCompletionHandler:^(NSError* _Nullable error) {
-               if (error) {
-                 NSLog(@"Local Notification failed");
-               }
-             }];
-  };
+  requestPermission();
 
   if (!m_delegate) {
-    requestPermission(sendNotification);
-  } else {
-    sendNotification();
+    return;
   }
+
+  UNMutableNotificationContent* content = [[UNMutableNotificationContent alloc] init];
+  content.title = title.toNSString();
+  content.body = message.toNSString();
+  content.sound = [UNNotificationSound defaultSound];
+
+  int timerSec = timerMsec / 1000;
+  UNTimeIntervalNotificationTrigger* trigger =
+      [UNTimeIntervalNotificationTrigger triggerWithTimeInterval:timerSec repeats:NO];
+
+  UNNotificationRequest* request = [UNNotificationRequest requestWithIdentifier:@"mozillavpn"
+                                                                        content:content
+                                                                        trigger:trigger];
+
+  UNUserNotificationCenter* center = [UNUserNotificationCenter currentNotificationCenter];
+  center.delegate = id(m_delegate);
+
+  [center addNotificationRequest:request
+           withCompletionHandler:^(NSError* _Nullable error) {
+             if (error) {
+               NSLog(@"Local Notification failed");
+             }
+           }];
 }


### PR DESCRIPTION
This reverts commit 8afef1bd65d299e747599c3e5386e2f95d32fbfc which was VPN-7365.

This code being reverted (VPN-7365) caused a crash: VPN-7369

I believe I have a fix for VPN-7369, but due to FxA issues on stage this week, I'm unable to test it. (And I likely will have minimal workdays between now and the RC.) Thus, I'm backing out this change (VPN-7365). This will leave the improved placement for the notification permission (VPN-7316), at the cost of losing not firing the first notification (VPN-7365). This seems okay to me for now - and I'll get my fix up for this as soon as I can test it - but feel free to request that this whole set of work get backed out.

