### PR TITLE
VPN-7388: Fix windows crash when updating theme

### DIFF
--- a/src/commands/commandui.cpp
+++ b/src/commands/commandui.cpp
@@ -323,7 +323,7 @@ int CommandUI::run(QStringList& tokens) {
     }
 
 #ifdef MZ_WINDOWS
-    auto const updateWindowDecoration = [&engineHolder]() {
+    auto const updateWindowDecoration = [engineHolder]() {
       auto const window = engineHolder->window();
       WindowsUtils::updateTitleBarColor(window,
                                         Theme::instance()->isThemeDark());


### PR DESCRIPTION
## Description
We have observed a crash on Windows when changing the theme. This seems to occur in the `const updateWindowDecoration = [&engineHolder]() { ... }` lambda expression. I think the cause of the crash is that capturing a pointer by reference falls apart which leads to an invalid pointer use once inside the lambda.

This seems to occur when compiled for release, so the issue probably occurs because the outer `engineHolder` pointer gets overwritten with stack junk later in `CommandUI::run()`. Capturing `engineHolder` by value seems to fix the issue.

## Reference
JIRA Issue: [VPN-7388](https://mozilla-hub.atlassian.net/browse/VPN-7388)
Sentry: [crash report](https://mozilla.sentry.io/issues/7066591052)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-7388]: https://mozilla-hub.atlassian.net/browse/VPN-7388?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ