### PR TITLE
VPN-7399: Fix crash when toggling addons signature feature

### DIFF
--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -216,6 +216,14 @@ MozillaVPN::MozillaVPN() : App(nullptr), m_private(new MozillaVPNPrivate()) {
           &m_private->m_connectionHealth,
           &ConnectionHealth::connectionStateChanged);
 
+  // Staging must be set before the featuremodel is initialized, otherwise
+  // FeatureCallback_inStaging is read incorrectly.
+  // A feature is checked while setting up the ProductHandler, hence
+  // the staging initialization is here.
+  if (SettingsHolder::instance()->stagingServer()) {
+    Constants::setStaging();
+    LogHandler::instance()->setStderr(true);
+  }
   ProductsHandler::createInstance();
   PurchaseHandler* purchaseHandler = PurchaseHandler::createInstance();
   connect(purchaseHandler, &PurchaseHandler::subscriptionStarted, this,
@@ -2345,11 +2353,6 @@ int MozillaVPN::runGuiApp(std::function<int()>&& a_callback) {
   // TODO pending #3398
   QQmlContext* ctx = engine->rootContext();
   ctx->setContextProperty("QT_QUICK_BACKEND", qgetenv("QT_QUICK_BACKEND"));
-
-  if (SettingsHolder::instance()->stagingServer()) {
-    Constants::setStaging();
-    LogHandler::instance()->setStderr(true);
-  }
 
   MZGlean::registerLogHandler(LogHandler::rustMessageHandler);
   qInstallMessageHandler(LogHandler::messageQTHandler);


### PR DESCRIPTION
## Description

This was introduced in [this PR](https://github.com/mozilla-mobile/mozilla-vpn-client/pull/10863), when we reordered our initialization to support modern Android.

This change resulted in not setting `stage` until after the feature model was initialized, which then caused features using `FeatureCallback_inStaging` to not be setup correctly.

## Reference

VPN-7399

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
