### PR TITLE
Workaround for the crash on Pixel devices

### DIFF
--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -2390,6 +2390,12 @@ int MozillaVPN::runGuiApp(std::function<int()>&& a_callback) {
   callback();
 #endif
 
+#if defined(MZ_ANDROID) && (QT_VERSION > QT_VERSION_CHECK(6, 10, 1))
+#  error \
+      "Revisit the code below and replace QCoreApplication::exec() \
+      with app.exec() if the app no longer crashes on Pixel 2 XL, \
+      see https://github.com/mozilla-mobile/mozilla-vpn-client/pull/10895"
+#endif
   return QCoreApplication::exec();
 }
 


### PR DESCRIPTION
## Description

This workaround seems to fix the crash we're experiencing on some Pixel devices, as [described](https://qt-project.atlassian.net/browse/QTBUG-140501?focusedCommentId=2228362) in the Qt bug tracker (we're also getting "W/Qt A11Y : Accessibility: populateNode for Invalid ID" messages, but not many of them). As the impact seems to be wider than just the Pixel device it's happening on, maybe we can use this until the underlying issue is properly fixed?

## Reference

[VPN-7377](https://mozilla-hub.atlassian.net/browse/VPN-7377)

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-7377]: https://mozilla-hub.atlassian.net/browse/VPN-7377?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ