### PR TITLE
Fix wrong timeouts passed to QTimer::start in AddonConditionWatcherTriggerTimeSecs::maybeStartTimer()

### DIFF
--- a/src/addons/conditionwatchers/addonconditionwatchertriggertimesecs.cpp
+++ b/src/addons/conditionwatchers/addonconditionwatchertriggertimesecs.cpp
@@ -53,7 +53,7 @@ bool AddonConditionWatcherTriggerTimeSecs::maybeStartTimer() {
   }
 
   m_timer.setSingleShot(true);
-  m_timer.start(now.msecsTo(expire));
+  m_timer.start(std::chrono::milliseconds(now.msecsTo(expire)));
 
   return false;
 }


### PR DESCRIPTION
## Description

I think we might be triggering a [wrong overload](https://codebrowser.dev/qt6/qtbase/src/corelib/kernel/qtimer.cpp.html#_ZN6QTimer5startEi) of `QTimer::start()` in `maybeStartTimer()` method of AddonConditionWatcherTriggerTimeSecs.

This causes negative numbers (from casting a 64-bit integer) to be passed to the actual method and results in a flood of the warnings below and freezes in the UI during startup.

```
[12.12.2025 17:26:27.058] Warning: QTimer::start: negative intervals aren't allowed; the interval will be set to 1ms.
[12.12.2025 17:26:27.059] Warning: QTimer::start: negative intervals aren't allowed; the interval will be set to 1ms.
[12.12.2025 17:26:27.061] Warning: QTimer::start: negative intervals aren't allowed; the interval will be set to 1ms.
[12.12.2025 17:26:27.062] Warning: QTimer::start: negative intervals aren't allowed; the interval will be set to 1ms.
```

Explicitly creating `std::chrono::milliseconds` in `maybeStartTimer()` seems to fix the problem.

## Reference

[VPN-7400](https://mozilla-hub.atlassian.net/browse/VPN-7400) #10826 

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-7400]: https://mozilla-hub.atlassian.net/browse/VPN-7400?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ