### PR TITLE
Fix python deps for the flatpak dependabot workflow

### DIFF
--- a/.github/workflows/rustlang.yaml
+++ b/.github/workflows/rustlang.yaml
@@ -83,7 +83,7 @@ jobs:
 
       - name: Install pip tools
         shell: bash
-        run: pip install requirements-parser PyYAML toml aiohttp
+        run: pip install requirements-parser PyYAML tomlkit aiohttp
 
       # Do not continue if there are changes to the flatpak directory.
       - name: Inspect pull request


### PR DESCRIPTION
## Description
The python dependencies for the Flatpak cargo updater script have changed, replacing the unmaintained `toml` package with `tomlkit`. This caused breakage in the flatpak/dependabot workflow.

## Reference
Caused by: https://github.com/flatpak/flatpak-builder-tools/commit/fb722fe761d63b683a7bea6a1a1f446c03a7afbb

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
