### PR TITLE
VPN-7412: add debug link for glean viewer

### DIFF
--- a/src/ui/screens/getHelp/developerMenu/ViewTelemetryDebugging.qml
+++ b/src/ui/screens/getHelp/developerMenu/ViewTelemetryDebugging.qml
@@ -112,12 +112,12 @@ MZViewBase {
         }
 
         MZExternalLinkListItem {
-          id: goToPingViewer
-          Layout.preferredHeight: MZTheme.theme.rowHeight
-          title: "Open Glean Debug Ping Viewer"
-          onClicked: {
-              MZUrlOpener.openUrl("https://debug-ping-preview.firebaseapp.com/pings/" + MZSettings.gleanDebugTag);
-          }
+            id: goToPingViewer
+            Layout.preferredHeight: MZTheme.theme.rowHeight
+            title: "Open Glean Debug Ping Viewer"
+            onClicked: {
+                MZUrlOpener.openUrl("https://debug-ping-preview.firebaseapp.com/pings/" + MZSettings.gleanDebugTag);
+            }
         }
 
         MZCheckBoxRow {


### PR DESCRIPTION
## Description

While talking w/ you earlier, I realized that the link for the Glean Debug viewer should be in the debug menu (so nobody needs to ask for the link if they forget it).

New button in this menu:
<img width="154" height="609" alt="Screenshot 37" src="https://github.com/user-attachments/assets/70f068a3-8255-4f9d-9a68-c24c685716d7" />

## Reference

VPN-7412

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
