### PR TITLE
VPN-7415: remove themeSelection dev feature

### DIFF
--- a/src/feature/featurelist.h
+++ b/src/feature/featurelist.h
@@ -217,13 +217,6 @@ FEATURE(superDooperMetrics,      // Feature ID
         QStringList(),           // feature dependencies
         FeatureCallback_true)
 
-FEATURE(themeSelection,        // Feature ID
-        "Theme selection",     // Feature name
-        FeatureCallback_true,  // Can be flipped on
-        FeatureCallback_true,  // Can be flipped off
-        QStringList(),         // feature dependencies
-        FeatureCallback_true)
-
 FEATURE(themeSelectionIncludesAutomatic,  // Feature ID
         "Theme option of 'automatic'",    // Feature name
         FeatureCallback_false,            // Can be flipped on

--- a/src/theme.cpp
+++ b/src/theme.cpp
@@ -182,8 +182,7 @@ void Theme::setUsingSystemTheme(const bool usingSystemTheme) {
 }
 
 void Theme::setToSystemTheme() {
-  if (!Feature::get(Feature::Feature_themeSelection)->isSupported() ||
-      !Feature::get(Feature::Feature_themeSelectionIncludesAutomatic)) {
+  if (!Feature::get(Feature::Feature_themeSelectionIncludesAutomatic)) {
     logger.debug()
         << "Not setting to system theme because feature is not supported.";
     return;

--- a/src/ui/screens/settings/ViewPreferences.qml
+++ b/src/ui/screens/settings/ViewPreferences.qml
@@ -153,7 +153,6 @@ MZViewBase {
                 onClicked: {
                     stackview.push("qrc:/qt/qml/Mozilla/VPN/screens/settings/ViewAppearance.qml")
                 }
-                visible: MZFeatureList.get("themeSelection").isSupported
             }
         }
     }


### PR DESCRIPTION
## Description

Removing `themeSelection`. Can't remove `themeSelectionIncludesAutomatic`, as it is automatically calculated and is turned off for certain Linux situations.

## Reference

VPN-7415

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
