### PR TITLE
VPN-7409: fix iOS colors

### DIFF
--- a/src/ui/main.qml
+++ b/src/ui/main.qml
@@ -70,7 +70,8 @@ ApplicationWindow {
     }
 
     screen: Qt.platform.os === "wasm" && Qt.application.screens.length > 1 ? Qt.application.screens[1] : Qt.application.screens[0]
-    flags: Qt.Window | Qt.ExpandedClientAreaHint | Qt.NoTitlebarBackgroundHint
+    // TODO: Once every platform is on Qt 6.9, swap MaximizeUsingFullscreenGeometryHint for ExpandedClientAreaHint: https://doc.qt.io/qt-6.9/qt.html
+    flags: Qt.Window | Qt.ExpandedClientAreaHint | Qt.NoTitlebarBackgroundHint | Qt.MaximizeUsingFullscreenGeometryHint
     visible: true
 
     width: fullscreenRequired() ? Screen.width : MZTheme.theme.desktopAppWidth;


### PR DESCRIPTION
## Description

This flag fixes the issue on iOS. I cannot find any regressions with this.

The preferred flag changed in Qt 6.9, so I left a note to update this when all platforms are on 6.9.

## Reference

VPN-7409 (and VPN-7413, a dup of that one)

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
