### PR TITLE
VPN-7385: fix mac quitting issue

### DIFF
--- a/src/commands/commandui.cpp
+++ b/src/commands/commandui.cpp
@@ -176,9 +176,6 @@ int CommandUI::run(QStringList& tokens) {
   }
 #endif
 
-#ifdef MVPN_WEBEXTENSION
-  std::unique_ptr<WebExtension::Server> extensionServer{nullptr};
-#endif
   std::unique_ptr<KeyRegenerator> keyRegenerator{nullptr};
 
   // Ensure that external styling hints are disabled.
@@ -382,11 +379,11 @@ int CommandUI::run(QStringList& tokens) {
 #endif
 
 #ifdef MVPN_WEBEXTENSION
-    QPointer newServer =
+    QPointer webExtensionServer =
         new WebExtension::Server{new WebExtensionAdapter(qApp)};
-    extensionServer.reset();
     QObject::connect(vpn->controller(), &Controller::readyToQuit,
-                     extensionServer.get(), &WebExtension::Server::close);
+                     webExtensionServer.get(), &WebExtension::Server::close);
+    webExtensionServer.clear();
 #endif
 
 #ifdef MZ_ANDROID


### PR DESCRIPTION
## Description

macOS was having issues when quitting - when VPN was active it would hang, and when VPN was inactive it would close normally but macOS would pop a "do you want to report crash to developer?" prompt. (Or potentially the reverse - I forget.)

I believe this fixes the issue, and from my (macOS) testing doesn't mess anything up for the extension. The reason this is new: We [changed from QTcpServer to QLocalServer in a PR since](https://github.com/mozilla-mobile/mozilla-vpn-client/pull/10865) the 2.32 release which [according to the documentation](https://doc.qt.io/qt-6/qlocalserver.html) should only get a adapter passed to it if it is the parent. A slight change, but enough to affect this apparently.

## Reference

VPN-7385

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
