### PR TITLE
VPN-7376: fix overlap on android devices with old style navigation

### DIFF
--- a/nebula/ui/components/MZStepNavigation.qml
+++ b/nebula/ui/components/MZStepNavigation.qml
@@ -112,7 +112,7 @@ ColumnLayout {
         Layout.fillWidth: true
 
         //Always goes to bottom of the screen - can expose this property if we ever need a custom height
-        implicitHeight: window.height - window.safeAreaHeightByDevice() - stepProgressBar.implicitHeight - stepNavigation.anchors.topMargin
+        implicitHeight: root.height - window.safeAreaHeightByDevice() - stepProgressBar.implicitHeight - stepNavigation.anchors.topMargin
         flickContentHeight: stackView.currentItem.implicitHeight + stackView.currentItem.anchors.topMargin + stackView.currentItem.anchors.bottomMargin
 
         StackView {


### PR DESCRIPTION
## Description
On older Android devices w/ older navigation, the bottom system navigation overlapped with onboarding buttons. It's possible there is a better way to do this - I'm not as familiar with our deep QML global layout. Please let me know if I could improve this.

Fixed:
<img width="174" alt="Screenshot 44" src="https://github.com/user-attachments/assets/b5d60e6b-857c-4e24-a13f-91bf64390b42" />

Will fix top/bottom color issue in a separate PR.

Adding @lesleyjanenorton as a reviewer as it's deeper QML stuff.

## Reference

VPN-7376

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
