### PR TITLE
VPN-7408 - Remove ProgressBarDelegate from the render geometry when 0 sized

### DIFF
--- a/nebula/ui/components/MZStepProgressBarDelegate.qml
+++ b/nebula/ui/components/MZStepProgressBarDelegate.qml
@@ -56,12 +56,15 @@ Column {
 
             anchors.centerIn: parent
 
+            readonly property bool shouldExpand: button.activeFocus || button.state === MZTheme.theme.uiState.stateHovered || button.state === MZTheme.theme.uiState.statePressed || delegate.currentState === MZStepProgressBarDelegate.State.Active
+
             z: parent.z - 1
             radius: implicitWidth / 2
             color: MZTheme.colors.stepProgressBarHighlight
+            visible: implicitWidth > 0 && implicitHeight > 0
 
-            implicitHeight: button.activeFocus || button.state === MZTheme.theme.uiState.stateHovered || button.state === MZTheme.theme.uiState.statePressed || delegate.currentState === MZStepProgressBarDelegate.State.Active ? parent.implicitHeight + 8 : 0
-            implicitWidth: button.activeFocus || button.state === MZTheme.theme.uiState.stateHovered || button.state === MZTheme.theme.uiState.statePressed || delegate.currentState === MZStepProgressBarDelegate.State.Active ? parent.implicitWidth + 8 : 0
+            implicitHeight: shouldExpand ? parent.implicitHeight + 8 : 0
+            implicitWidth: shouldExpand ? parent.implicitWidth + 8 : 0
 
             Behavior on implicitHeight {
                 enabled: button.state !== MZTheme.theme.uiState.stateHovered && button.state !== MZTheme.theme.uiState.statePressed


### PR DESCRIPTION
<img width="814" height="808" alt="image" src="https://github.com/user-attachments/assets/1808156e-0c61-4d60-8a75-d8fca9783962" />

I totally cannot reproduce this gui glitch :c, 
but looking at the screenshot, especially the pill button, this seems to be run before the animation behaviors are kicking in. 
Also given that we are drawing that from 0/0, i have a big suspicion this is some geometry issue. 

So i want to try, to simply hide the element until we have width&height > 0, which implies we have been able ot get width&height from the parent element. 


