### PR TITLE
VPN-7387: fix scrolling to Washington DC when selected

### DIFF
--- a/src/ui/screens/home/servers/ServerList.qml
+++ b/src/ui/screens/home/servers/ServerList.qml
@@ -54,19 +54,30 @@ FocusScope {
                 continue;
             }
 
-            // Get distance to the current server city and scroll
-            const currentCityYPosition = (countryItem.y
-                                          + MZTheme.theme.cityListTopMargin * 3 * countryItem.currentCityIndex
-                                          - serverListYCenter);
-            const destinationY = (currentCityYPosition + serverListFlickable.height > serverListFlickable.contentHeight)
-                               ? serverListFlickable.contentHeight - serverListFlickable.height
-                               : currentCityYPosition;
-            serverListFlickable.contentY = destinationY;
-
             if (!countryItem.cityListVisible) {
                 countryItem.openCityList();
             }
 
+            const doScroll = () => {
+                // Get distance to the current server city and scroll
+                const currentCityYPosition = (countryItem.y
+                                              + MZTheme.theme.cityListTopMargin * 3 * countryItem.currentCityIndex
+                                              - serverListYCenter);
+                const destinationY = (currentCityYPosition + serverListFlickable.height > serverListFlickable.contentHeight)
+                                   ? serverListFlickable.contentHeight - serverListFlickable.height
+                                   : currentCityYPosition;
+                serverListFlickable.contentY = destinationY;
+
+                // Call it again if we're not ready yet. However, we want to set the contentY
+                // on each pass, as it gets close to the accurate contentY and thus prevents
+                // one final large visual jump for the user.
+                if (!countryItem.ready) {
+                    Qt.callLater(doScroll);
+                    return;
+                }
+            };
+
+            doScroll();
             return;
         }
     }


### PR DESCRIPTION
## Description

Layout passes seemingly are handled differently in 6.9, causing this bug. I tried calling `scrollToActiveServer` in an `onFinished` for `scrollAnimation`, but that didn't do it. I don't see any other place we could call this `scrollToActiveServer` after the final layout pass is completed, but I may be missing some QML magic - open to suggestions here. In the meantime, this PR proposes we keep scrolling to it until the `ServerCountry` is `ready`.

Fixed (Jira ticket has "before" video):
https://github.com/user-attachments/assets/ed9564f6-cef1-4c24-a6a4-cda4aab16f13

## Reference

VPN-7387

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
