### PR TITLE
VPN-7379: fix order of localization loading

### DIFF
--- a/src/mozillavpn_p.h
+++ b/src/mozillavpn_p.h
@@ -29,6 +29,7 @@
 
 struct MozillaVPNPrivate {
   SettingsHolder m_settingsHolder;
+  Localizer m_localizer;
   CaptivePortal m_captivePortal;
   CaptivePortalDetection m_captivePortalDetection;
   ConnectionHealth m_connectionHealth;
@@ -48,7 +49,6 @@ struct MozillaVPNPrivate {
   Telemetry m_telemetry;
   User m_user;
   TaskGetFeatureListWorker m_taskGetFeatureListWorker;
-  Localizer m_localizer;
 };
 
 #endif  // MOZILLAVPN_PRIVATE_H


### PR DESCRIPTION
## Description

The loading text is set when IpAddressLookup is initialized. And since the localizer wasn't being initialized before that, we were getting the string ID. This seems to fix it.

To stomp out the class of bugs, I've moved Localizer to the 2nd spot in the list. (Localizer relies on SettingsHolder, so SettingsHolder needs to be initialized before it.)

## Reference

VPN-7379

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
