### PR TITLE
VPN-6477: fix popup padding on iOS

### DIFF
--- a/nebula/ui/components/MZPopup.qml
+++ b/nebula/ui/components/MZPopup.qml
@@ -25,6 +25,7 @@ Popup {
     contentHeight: startContentBeneathCloseButton ? closeButton.height + closeButton.anchors.topMargin + popupContent.implicitHeight + popupContent.anchors.topMargin: popupContent.implicitHeight
     horizontalPadding: 0
     verticalPadding: 0
+    topPadding: 0 // shouldn't be necessary, as it should be equal to verticalPadding. However, it's needed to fix an iOS bug - see VPN-6477 for more info
 
     //Close popup if screen changes
     Connections {


### PR DESCRIPTION
## Description

I hate that this is what fixes it, as that property shouldn't be needed [per documentation](https://doc.qt.io/qt-6/qml-qtquick-controls-popup.html#topPadding-prop).

I looked at macOS as well, and it doesn't seem to change anything or add any regressions on that platform. (Which is what we want - this bug only exists on iOS, it seems.)

Fixed:
<img width="163" alt="Screenshot 2025-12-30 at 1 43 22 PM" src="https://github.com/user-attachments/assets/86ad88a2-e428-4cf0-b925-965a00b9bef6" />

## Reference

VPN-6477

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
