### PR TITLE
VPN-6405: fix red dot on notifications bar button

### DIFF
--- a/src/addons/addonmessage.cpp
+++ b/src/addons/addonmessage.cpp
@@ -105,6 +105,11 @@ AddonMessage::MessageStatus AddonMessage::loadMessageStatus(const QString& id) {
     return static_cast<MessageStatus>(persistedStatus);
   }
 
+  // We need to persist this to disk to allow the SettingGroup that updates
+  // the red dot to properly work (in MozillaVPN::resetNotification).
+  QString newStatusSetting = statusMetaEnum.valueToKey(MessageStatus::Received);
+  m_messageSettingGroup->set(ADDON_MESSAGE_SETTINGS_STATUS_KEY,
+                             newStatusSetting);
   return MessageStatus::Received;
 }
 


### PR DESCRIPTION
## Description

After an incredibly deep dive in learning about SettingGroups, this ended up as a 2 line fix. While we setup the setting groups properly, they apparently look for related settings that are *persisted to disk*. Since a default setting isn't persisted to disk, it missed when it changed (as from one perspective, the setting was actually being set for the first time), and thus didn't update the bar button.

## Reference

VPN-6405

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
