### PR TITLE
VPN-7419 and VPN-7420 - android status bar color

### DIFF
--- a/src/platforms/android/androidcommons.cpp
+++ b/src/platforms/android/androidcommons.cpp
@@ -149,6 +149,18 @@ void AndroidCommons::launchPlayStore() {
                                      appActivity.object());
 }
 
+void AndroidCommons::setStatusBarTextColor(QString statusBarTextColor) {
+  QNativeInterface::QAndroidApplication::runOnAndroidMainThread([statusBarTextColor]() {
+    QJniObject window = AndroidCommons::getActivity().callObjectMethod(
+          "getWindow", "()Landroid/view/Window;");
+    if (statusBarTextColor == "light") {
+      window.callMethod<void>("setStatusBarColor", "(I)V", 0xFFFFFFFF);
+    } else {
+      window.callMethod<void>("setStatusBarColor", "(I)V", 0xFF000000);
+    }
+  });
+}
+
 bool AndroidCommons::clearPendingJavaException(const char* where) {
   QJniEnvironment env;
   if (!env->ExceptionCheck()) {

--- a/src/platforms/android/androidcommons.h
+++ b/src/platforms/android/androidcommons.h
@@ -33,6 +33,8 @@ class AndroidCommons final : public QObject {
 
   static void launchPlayStore();
 
+  static void setStatusBarTextColor(QString statusBarTextColor);
+
   static void initializeGlean(bool isTelemetryEnabled, const QString& channel);
 
   static void dispatchToMainThread(std::function<void()> callback);

--- a/src/theme.cpp
+++ b/src/theme.cpp
@@ -21,6 +21,10 @@
 #  include "platforms/ios/ioscommons.h"
 #endif
 
+#ifdef MZ_ANDROID
+#  include "platforms/android/androidcommons.h"
+#endif
+
 #if defined(MZ_LINUX) && !defined(UNIT_TEST)
 #  include "platforms/linux/xdgappearance.h"
 #endif
@@ -276,9 +280,16 @@ QString Theme::currentSystemTheme() {
 #endif
 
 void Theme::setStatusBarTextColor([[maybe_unused]] StatusBarTextColor color) {
-#ifdef MZ_IOS
+#if defined MZ_IOS
   IOSCommons::setStatusBarTextColor(color);
+#elif defined MZ_ANDROID
+  if (color == Theme::StatusBarTextColorLight) {
+    AndroidCommons::setStatusBarTextColor("light");
+  } else {
+    AndroidCommons::setStatusBarTextColor("dark");
+  }
 #endif
+
 }
 
 bool Theme::usesDarkModeAssets() const {

--- a/src/ui/main.qml
+++ b/src/ui/main.qml
@@ -92,20 +92,7 @@ ApplicationWindow {
     maximumHeight: fullscreenRequired() ? Screen.height : MZTheme.theme.desktopAppHeight;
 
     title: MZI18n.ProductName
-    color: {
-        // This is only relevant on android
-        if(Qt.platform.os !== "android"){
-            return MZTheme.colors.bgColor;
-        }
-        if (MZTheme.currentSystemTheme === MZTheme.currentTheme) {
-            return MZTheme.colors.bgColor;
-        } 
-        if (MZTheme.currentSystemTheme === "main") {
-            return "white";
-        } else {
-            return "black";
-        }
-    }
+    color: MZTheme.colors.bgColor
     onClosing: close => {
         console.log("Closing request handling");
 


### PR DESCRIPTION
## Description

This builds on top of #10934.

Decided to look into VPN-7420. Realized we have custom work for iOS status bar, but not Android. Let's give them parity! This should fix VPN-7419 as well!

I didn't include `Theme` in `AndroidCommons` because it ended up with a circular dependency terribleness because of the `VPNAndroidCommons` class. For expediency, I just turned it into a string.

## Reference

VPN-7419 and VPN-7420

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
