### PR TITLE
Fix android check

### DIFF
--- a/src/commands/commandui.cpp
+++ b/src/commands/commandui.cpp
@@ -218,7 +218,7 @@ int CommandUI::run(QStringList& tokens) {
     // https://bugreports.qt.io/browse/QTBUG-82617
     // Currently there is a crash happening on exit with Huawei devices.
     // Until this is fixed, setting this variable is the "official" workaround.
-    // We certainly should look at this once 6.6 is out.
+    // We certainly should look at this once 6.11 is out.
 #  if QT_VERSION >= QT_VERSION_CHECK(6, 11, 0)
 #    error We have forgotten to remove this Huawei hack!
 #  endif


### PR DESCRIPTION
## Description

I was surprised I was able to build on 6.10, given this check. From some debugging, seems like it was giving a weird `QT_VERSION` used, and that passed this check. Updating this snippet to the better way of checking Qt version.

There are 3 other spots we use the older way of checking Qt version (all 3 check if it's less than Qt 6.4) - Once in linuxutils.cpp, twice in networkrequest.cpp. I'm leaving those for now - do they need to be in the old version to support Linux installs with older Qt versions? Or can we update these as well? (Realistically, we could probably just remove the code - unless some Linux installs still use Qt 6.4 or earlier.)

## Reference

None

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
