### PR TITLE
Optimize addons load

### DIFF
--- a/src/addons/manager/addonindex.cpp
+++ b/src/addons/manager/addonindex.cpp
@@ -264,7 +264,7 @@ QList<AddonData> AddonIndex::extractAddonsFromIndex(
     QJsonObject addon = item.toObject();
     addons.append(
         {QByteArray::fromHex(addon["sha256"].toString().toLocal8Bit()),
-         addon["id"].toString(), nullptr});
+         QByteArray(), addon["id"].toString(), nullptr});
   }
 
   return addons;

--- a/src/addons/manager/addonindex.h
+++ b/src/addons/manager/addonindex.h
@@ -23,6 +23,7 @@ constexpr const char* ADDON_INDEX_SIGNATURE_FILENAME = "manifest.json.sig";
 // addon does not need to be loaded for unmatched conditions.
 struct AddonData {
   QByteArray m_sha256;
+  QByteArray m_content;
   QString m_addonId;
   Addon* m_addon;
 };


### PR DESCRIPTION
## Description

We already have the addon in memory, instead of dropping the data and reloading, we should just keep and consume it c: 
