### PR TITLE
Use the in-memory buffer for loading add-ons

### DIFF
--- a/src/addons/manager/addonindex.cpp
+++ b/src/addons/manager/addonindex.cpp
@@ -264,7 +264,7 @@ QList<AddonData> AddonIndex::extractAddonsFromIndex(
     QJsonObject addon = item.toObject();
     addons.append(
         {QByteArray::fromHex(addon["sha256"].toString().toLocal8Bit()),
-         addon["id"].toString(), nullptr});
+         QByteArray(), addon["id"].toString(), nullptr});
   }
 
   return addons;

--- a/src/addons/manager/addonindex.h
+++ b/src/addons/manager/addonindex.h
@@ -23,6 +23,7 @@ constexpr const char* ADDON_INDEX_SIGNATURE_FILENAME = "manifest.json.sig";
 // addon does not need to be loaded for unmatched conditions.
 struct AddonData {
   QByteArray m_sha256;
+  QByteArray m_buffer;
   QString m_addonId;
   Addon* m_addon;
 };


### PR DESCRIPTION
## Description

It can happen that an add-on is modified between the computation of its hash and the loading of the resources. This patch fixes the issue loading the add-on from the memory buffer.

## Reference

https://bugzilla.mozilla.org/show_bug.cgi?id=2009454

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
