### PR TITLE
Fix signing and beetmover after windows-x86_64/opt rename

### DIFF
--- a/taskcluster/kinds/beetmover-promote/kind.yml
+++ b/taskcluster/kinds/beetmover-promote/kind.yml
@@ -65,7 +65,7 @@ tasks:
         dependencies:
             repackage-signing: repackage-signing-msi
         attributes:
-            build-type: windows/opt
+            build-type: windows-x86_64/opt
     addons-bundle:
         run-on-tasks-for: [action]
         # The addons-bundle release-artifacts are dynamically generated in the beetmover transform

--- a/taskcluster/mozillavpn_taskgraph/transforms/beetmover.py
+++ b/taskcluster/mozillavpn_taskgraph/transforms/beetmover.py
@@ -73,7 +73,7 @@ def add_beetmover_worker_config(config, tasks):
     build_id = config.params["moz_build_date"]
     build_type_os = {
         "macos/opt": "mac",
-        "windows/opt": "windows",
+        "windows-x86_64/opt": "windows",
         "android/x86": "android",
         "android/x64": "android",
         "android/armv7": "android",

--- a/taskcluster/mozillavpn_taskgraph/transforms/signing.py
+++ b/taskcluster/mozillavpn_taskgraph/transforms/signing.py
@@ -20,7 +20,8 @@ PRODUCTION_SIGNING_BUILD_TYPES = [
     "linux/opt",
     "macos/opt",
     "macos/next", # TODO: This would be a candidate for debug signing, if we supported it.
-    "windows/opt",
+    "windows-x86_64/opt",
+    "windows-aarch64/opt",
     "addons/opt",
 ]
 

--- a/taskcluster/test/params/release-promotion-promote-addons.yml
+++ b/taskcluster/test/params/release-promotion-promote-addons.yml
@@ -26,7 +26,7 @@ existing_tasks:
   build-linux/opt: BEe2AnFPRhSdi1EEaEZvcg
   build-macos/opt: LtezQlIiSluUubmPzb4Q1g
   build-wasm/opt: V3DmBEM3SMKQ7QqU23dFVw
-  build-windows/opt: TbKkztPRSSiTQCvh_u-g9Q
+  build-windows-x86_64/opt: TbKkztPRSSiTQCvh_u-g9Q
   fetch-win-go: MhS7JLgyQe6cxFzzz6vMIw
   fetch-win-perl: An_KRjwzRFa9jGP4YNE_dQ
   fetch-win-rustup: L8UOpjFcT7KEbGRGpFtyNg
@@ -40,7 +40,7 @@ existing_tasks:
   signing-android-x86/release: BTNnWws-SXalEG0I-i4Tmg
   signing-linux/opt: dEY1iR1FSq6aABa2C_38Pg
   signing-macos/opt: MJCFMnxWRsSclwcfr-jFiA
-  signing-windows/opt: CoxpMyQgT2OkcQA_3MAHfg
+  signing-windows-x86_64/opt: CoxpMyQgT2OkcQA_3MAHfg
   test-taskgraph-definition: AzkgKc07TFGLeEY2pMgJog
   toolchain-openssl-win: YBVSnsOlS4SCezclXnphag
   toolchain-qt-ios: Cs-gByGmRXGSKgCjinEMmw

--- a/taskcluster/test/params/release-promotion-promote-client.yml
+++ b/taskcluster/test/params/release-promotion-promote-client.yml
@@ -26,7 +26,7 @@ existing_tasks:
   build-linux/opt: BEe2AnFPRhSdi1EEaEZvcg
   build-macos/opt: LtezQlIiSluUubmPzb4Q1g
   build-wasm/opt: V3DmBEM3SMKQ7QqU23dFVw
-  build-windows/opt: TbKkztPRSSiTQCvh_u-g9Q
+  build-windows-x86_64/opt: TbKkztPRSSiTQCvh_u-g9Q
   fetch-win-go: MhS7JLgyQe6cxFzzz6vMIw
   fetch-win-perl: An_KRjwzRFa9jGP4YNE_dQ
   fetch-win-rustup: L8UOpjFcT7KEbGRGpFtyNg
@@ -40,7 +40,7 @@ existing_tasks:
   signing-android-x86/release: BTNnWws-SXalEG0I-i4Tmg
   signing-linux/opt: dEY1iR1FSq6aABa2C_38Pg
   signing-macos/opt: MJCFMnxWRsSclwcfr-jFiA
-  signing-windows/opt: CoxpMyQgT2OkcQA_3MAHfg
+  signing-windows-x86_64/opt: CoxpMyQgT2OkcQA_3MAHfg
   test-taskgraph-definition: AzkgKc07TFGLeEY2pMgJog
   toolchain-openssl-win: YBVSnsOlS4SCezclXnphag
   toolchain-qt-ios: Cs-gByGmRXGSKgCjinEMmw

--- a/taskcluster/test/params/release-promotion-ship-addons.yml
+++ b/taskcluster/test/params/release-promotion-ship-addons.yml
@@ -26,7 +26,7 @@ existing_tasks:
   build-linux/opt: BEe2AnFPRhSdi1EEaEZvcg
   build-macos/opt: LtezQlIiSluUubmPzb4Q1g
   build-wasm/opt: V3DmBEM3SMKQ7QqU23dFVw
-  build-windows/opt: TbKkztPRSSiTQCvh_u-g9Q
+  build-windows-x86_64/opt: TbKkztPRSSiTQCvh_u-g9Q
   fetch-win-go: MhS7JLgyQe6cxFzzz6vMIw
   fetch-win-perl: An_KRjwzRFa9jGP4YNE_dQ
   fetch-win-rustup: L8UOpjFcT7KEbGRGpFtyNg
@@ -40,7 +40,7 @@ existing_tasks:
   signing-android-x86/release: BTNnWws-SXalEG0I-i4Tmg
   signing-linux/opt: dEY1iR1FSq6aABa2C_38Pg
   signing-macos/opt: MJCFMnxWRsSclwcfr-jFiA
-  signing-windows/opt: CoxpMyQgT2OkcQA_3MAHfg
+  signing-windows-x86_64/opt: CoxpMyQgT2OkcQA_3MAHfg
   test-taskgraph-definition: AzkgKc07TFGLeEY2pMgJog
   toolchain-openssl-win: YBVSnsOlS4SCezclXnphag
   toolchain-qt-ios: Cs-gByGmRXGSKgCjinEMmw

--- a/taskcluster/test/params/release-promotion-ship-client.yml
+++ b/taskcluster/test/params/release-promotion-ship-client.yml
@@ -26,7 +26,7 @@ existing_tasks:
   build-linux/opt: EHhfiDzVSMaVh8tnVMGezA
   build-macos/opt: YsDBZowUSvKTh2G9pkaYig
   build-wasm/opt: JqlM_tFGTcm_plxOMTd3bQ
-  build-windows/opt: NdU9bEA_TCSYBz5jNgpEcQ
+  build-windows-x86_64/opt: NdU9bEA_TCSYBz5jNgpEcQ
   fetch-win-go: aVfhCuu4SVqLmpvz4bAgnQ
   fetch-win-perl: KlpgRvHESp-9hiReWnJnvw
   fetch-win-rustup: RwOTt66NRfyxKIXDF6VBEQ
@@ -40,7 +40,7 @@ existing_tasks:
   signing-android-x86/release: CKVdRCcITRiOZFG5k2Lynw
   signing-linux/opt: UBdcGduyToibUCay3wc9zg
   signing-macos/opt: RUqoZ6rCQ_68QQzRhcWm0Q
-  signing-windows/opt: dMuIg-2dSjmICd8cti80WA
+  signing-windows-x86_64/opt: dMuIg-2dSjmICd8cti80WA
   test-taskgraph-definition: EMtIyKY7TxCqFbyB7jiFdA
   toolchain-openssl-win: P_D5Ht0qT-mQLUmBh_Alxg
   toolchain-qt-ios: Pyw_bgMXRSidDQUOHypXug

--- a/taskcluster/test/params/stage-release-promotion-promote-client.yml
+++ b/taskcluster/test/params/stage-release-promotion-promote-client.yml
@@ -21,12 +21,12 @@ existing_tasks:
   build-macos/pr: ZMxnxgT_SImzRMn27DDyXg
   build-source/vpn: HjtImOLUQV6dFIoIqUfpcQ
   build-wasm/opt: bSjKBM0qSISH7kQ1UIVJdQ
-  build-windows/opt: ajetqRIORX2GnwiKy8bifQ
+  build-windows-x86_64/opt: ajetqRIORX2GnwiKy8bifQ
   repackage-msi: G9UcKDAGTRKiiqic9kIrxQ
   repackage-signing-msi: f7OS87xwQwGerLFCHn7C7w
   signing-addons-bundle: YhdzN2BnQBy5ZHXMEystPA
   signing-android-arm64/release: cbQmLU2FT-GQ7tTvQD6FQA
-  signing-windows/opt: UGL3O7yPRZe4vlO20fbpQg
+  signing-windows-x86_64/opt: UGL3O7yPRZe4vlO20fbpQg
   test-taskgraph-definition: O4LTEpGISkGGMMqKKCBtrg
 filters:
 - target_tasks_method

--- a/taskcluster/test/params/stage-release-promotion-ship-client.yml
+++ b/taskcluster/test/params/stage-release-promotion-ship-client.yml
@@ -21,12 +21,12 @@ existing_tasks:
   build-macos/pr: ZMxnxgT_SImzRMn27DDyXg
   build-source/vpn: HjtImOLUQV6dFIoIqUfpcQ
   build-wasm/opt: bSjKBM0qSISH7kQ1UIVJdQ
-  build-windows/opt: ajetqRIORX2GnwiKy8bifQ
+  build-windows-x86_64/opt: ajetqRIORX2GnwiKy8bifQ
   repackage-msi: G9UcKDAGTRKiiqic9kIrxQ
   repackage-signing-msi: f7OS87xwQwGerLFCHn7C7w
   signing-addons-bundle: YhdzN2BnQBy5ZHXMEystPA
   signing-android-arm64/release: cbQmLU2FT-GQ7tTvQD6FQA
-  signing-windows/opt: UGL3O7yPRZe4vlO20fbpQg
+  signing-windows-x86_64/opt: UGL3O7yPRZe4vlO20fbpQg
   test-taskgraph-definition: O4LTEpGISkGGMMqKKCBtrg
 filters:
 - target_tasks_method


### PR DESCRIPTION
## Description
In the last PR to update desktop targets to Qt 6.10, we did a bit of renaming on the Windows build tasks in order to differentiate `x86_64` and `aarch64` builds. Unfortunately, we missed a few spots and this resulted in the signing tasks missing a lookup from `PRODUCTION_SIGNING_BUILD_TYPES` and signing the windows builds with the `dep-signing` keys instead of the release keys.

## Reference
Previous PR: #10919
JIRA Issue: [VPN-7429](https://mozilla-hub.atlassian.net/browse/VPN-7429)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-7429]: https://mozilla-hub.atlassian.net/browse/VPN-7429?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ