### PR TITLE
Fix timer rollover in AddonApi::setTimedCallback

### DIFF
--- a/src/addons/addonapi.cpp
+++ b/src/addons/addonapi.cpp
@@ -94,7 +94,7 @@ void AddonApi::initialize() {
   m_timer.setSingleShot(true);
 }
 
-void AddonApi::setTimedCallback(int interval, const QJSValue& callback) {
+void AddonApi::setTimedCallback(qint64 interval, const QJSValue& callback) {
   if (!callback.isCallable()) {
     logger.debug() << "No callback received";
     return;
@@ -109,7 +109,7 @@ void AddonApi::setTimedCallback(int interval, const QJSValue& callback) {
 
   connect(&m_timer, &QTimer::timeout, this, [callback]() { callback.call(); });
 
-  m_timer.start(interval);
+  m_timer.start(std::chrono::milliseconds(interval));
 }
 
 void AddonApi::log(const QString& message) { logger.debug() << message; }

--- a/src/addons/addonapi.h
+++ b/src/addons/addonapi.h
@@ -28,7 +28,7 @@ class AddonApi final : public QQmlPropertyMap {
                                  const QJSValue& callback);
   Q_INVOKABLE void log(const QString& message);
 
-  Q_INVOKABLE void setTimedCallback(int interval, const QJSValue& callback);
+  Q_INVOKABLE void setTimedCallback(qint64 interval, const QJSValue& callback);
 
   /**
    * @brief callback executed when a new AddonApi is created. Use it to add


### PR DESCRIPTION
## Description
After ignoring my macbook for a couple of weeks, I returned to it in order to discover that it was displaying the infinite timer loop bug reported in #10826 so I went and chased down the root cause.

The problem occurs because of an integer truncation bug when scheduling a timer via `AddonApi::setTimedCallback()` with a duration greater than 24 days. This can occur when the `message_upgrade_to_annual_plan` addon detects that the subscription is between 14 and 63 days old.

Changing the `AddonApi::setTimedCallback()` API to take a 64-bit integer for the timeout value prevents the truncation from occurring.

## Reference
Github issue: #10826

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
