### PR TITLE
VPN-7427: Fix error in repackage-signing index routes

### DIFF
--- a/taskcluster/kinds/repackage-signing/kind.yml
+++ b/taskcluster/kinds/repackage-signing/kind.yml
@@ -27,8 +27,7 @@ tasks:
             group-by:
                 attribute: build-type
             copy-attributes: true
-        add-index-routes:
-            type: build
+        add-index-routes: build
         signing-format: gcp_prod_autograph_authenticode_202412
         treeherder:
             job-symbol: Bs


### PR DESCRIPTION
## Description
In PR #10969 we tried adding signing tasks for the aarch64 windows installer, but this introduced a schema error in handling the `add-index-routes` YAML entry. When set to a dict, it must explicitly set both the `type` and `name`. We should just set it to a string with the `type` for the name to be generated automatically.

## Reference
Introduced by: #10969
JIRA Issue: [VPN-7427](https://mozilla-hub.atlassian.net/browse/VPN-7427)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-7427]: https://mozilla-hub.atlassian.net/browse/VPN-7427?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ