### PR TITLE
Re-enable web-based auth on iOS

### DIFF
--- a/src/authenticationlistener.cpp
+++ b/src/authenticationlistener.cpp
@@ -10,7 +10,9 @@
 #include "logger.h"
 #include "networkmanager.h"
 
-#if defined(MZ_WASM)
+#if defined(MZ_IOS)
+#  include "platforms/ios/iosauthenticationlistener.h"
+#elif defined(MZ_WASM)
 #  include "platforms/wasm/wasmauthenticationlistener.h"
 #else
 #  include "tasks/authenticate/desktopauthenticationlistener.h"
@@ -29,9 +31,11 @@ AuthenticationListener* AuthenticationListener::create(
     QObject* parent, AuthenticationType authenticationType) {
   switch (authenticationType) {
     case AuthenticationInBrowser:
-#if defined(MZ_ANDROID) or defined(MZ_IOS)
+#if defined(MZ_ANDROID)
       logger.error() << "Something went totally wrong";
       Q_ASSERT(false);
+#elif defined(MZ_IOS)
+      return new IOSAuthenticationListener(parent);
 #elif defined(MZ_WASM)
       return new WasmAuthenticationListener(parent);
 #else

--- a/src/cmake/ios.cmake
+++ b/src/cmake/ios.cmake
@@ -85,12 +85,14 @@ find_library(FW_FOUNDATION Foundation)
 find_library(FW_STORE_KIT StoreKit)
 find_library(FW_USER_NOTIFICATIONS UserNotifications)
 find_library(FW_NETWORK Network)
+find_library(FW_AUTHENTICATION_SERVICES AuthenticationServices)
 
 target_link_libraries(mozillavpn PRIVATE ${FW_UI_KIT})
 target_link_libraries(mozillavpn PRIVATE ${FW_FOUNDATION})
 target_link_libraries(mozillavpn PRIVATE ${FW_STORE_KIT})
 target_link_libraries(mozillavpn PRIVATE ${FW_USER_NOTIFICATIONS})
 target_link_libraries(mozillavpn PRIVATE ${FW_NETWORK})
+target_link_libraries(mozillavpn PRIVATE ${FW_AUTHENTICATION_SERVICES})
 
 ## Hack: IOSUtils needs QtGui internals...
 target_include_directories(mozillavpn PRIVATE ${Qt6Gui_PRIVATE_INCLUDE_DIRS})
@@ -101,6 +103,8 @@ target_sources(mozillavpn PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/platforms/macos/macospingsender.h
     ${CMAKE_CURRENT_SOURCE_DIR}/tasks/purchase/taskpurchase.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/tasks/purchase/taskpurchase.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/platforms/ios/iosauthenticationlistener.mm
+    ${CMAKE_CURRENT_SOURCE_DIR}/platforms/ios/iosauthenticationlistener.h
     ${CMAKE_CURRENT_SOURCE_DIR}/platforms/ios/iosiaphandler.swift
     ${CMAKE_CURRENT_SOURCE_DIR}/platforms/ios/iosiaphandler.mm
     ${CMAKE_CURRENT_SOURCE_DIR}/platforms/ios/iosiaphandler.h

--- a/src/feature/featurelistcallback.h
+++ b/src/feature/featurelistcallback.h
@@ -86,10 +86,10 @@ bool FeatureCallback_inAppAuthentication() {
 #if defined(MZ_WINDOWS)
   // Windows: InAppAuth for prod, web auth for staging
   return Constants::inProduction();
-#elif defined(MZ_ANDROID) || defined(MZ_IOS) || defined(MZ_WASM)
+#elif defined(MZ_ANDROID) || defined(MZ_WASM)
   return true;
 #else
-  // macOS and Linux
+  // iOS, macOS and Linux
   return false;
 #endif
 }

--- a/src/platforms/ios/iosauthenticationlistener.h
+++ b/src/platforms/ios/iosauthenticationlistener.h
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef IOSAUTHENTICATIONLISTENER_H
+#define IOSAUTHENTICATIONLISTENER_H
+
+#include "authenticationlistener.h"
+
+class IOSAuthenticationListener final : public AuthenticationListener {
+  Q_OBJECT
+  Q_DISABLE_COPY_MOVE(IOSAuthenticationListener)
+
+ public:
+  explicit IOSAuthenticationListener(QObject* parent);
+  ~IOSAuthenticationListener();
+
+  void start(Task* task, const QString& codeChallenge,
+             const QString& codeChallengeMethod,
+             const QString& emailAddress) override;
+};
+
+#endif  // IOSAUTHENTICATIONLISTENER_H

--- a/src/platforms/ios/iosauthenticationlistener.mm
+++ b/src/platforms/ios/iosauthenticationlistener.mm
@@ -1,0 +1,160 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "iosauthenticationlistener.h"
+
+#include <QtGui/qpa/qplatformnativeinterface.h>
+#include <QGuiApplication>
+#include <QQmlApplicationEngine>
+#include <QUrl>
+#include <QUrlQuery>
+#include <QWindow>
+#include <QtGlobal>
+
+#include "constants.h"
+#include "leakdetector.h"
+#include "logger.h"
+#include "qmlengineholder.h"
+
+#import <AuthenticationServices/ASWebAuthenticationSession.h>
+#import <UIKit/UIKit.h>
+
+namespace {
+
+Logger logger("IOSAuthenticationListener");
+ASWebAuthenticationSession* session = nullptr;
+
+UIView* resolvePresentationView() {
+  QQmlApplicationEngine* engine =
+      qobject_cast<QQmlApplicationEngine*>(QmlEngineHolder::instance()->engine());
+
+  QObject* rootObject = nullptr;
+  if (engine && !engine->rootObjects().isEmpty()) {
+    rootObject = engine->rootObjects().first();
+  }
+
+  QWindow* window = rootObject ? qobject_cast<QWindow*>(rootObject) : nullptr;
+  if (window) {
+    UIView* view = static_cast<UIView*>(
+        QGuiApplication::platformNativeInterface()->nativeResourceForWindow("uiview", window));
+    if (view) {
+      return view;
+    }
+  }
+
+  return nil;
+}
+
+}  // namespace
+
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
+@interface ContextProvider : NSObject <ASWebAuthenticationPresentationContextProviding> {
+  UIView* m_view;
+}
+@end
+
+@implementation ContextProvider
+
+- (id)initWithUIView:(UIView*)uiView {
+  self = [super init];
+  if (self) {
+    m_view = uiView;
+  }
+  return self;
+}
+
+- (nonnull ASPresentationAnchor)presentationAnchorForWebAuthenticationSession:
+    (nonnull ASWebAuthenticationSession*)unusedSession {
+  Q_UNUSED(unusedSession);
+  return m_view.window;
+}
+
+@end
+#endif
+
+IOSAuthenticationListener::IOSAuthenticationListener(QObject* parent)
+    : AuthenticationListener(parent) {
+  MZ_COUNT_CTOR(IOSAuthenticationListener);
+}
+
+IOSAuthenticationListener::~IOSAuthenticationListener() {
+  MZ_COUNT_DTOR(IOSAuthenticationListener);
+
+  if (session) {
+    [session cancel];
+    [session dealloc];
+    session = nullptr;
+  }
+}
+
+void IOSAuthenticationListener::start(Task* task, const QString& codeChallenge,
+                                      const QString& codeChallengeMethod,
+                                      const QString& emailAddress) {
+  logger.debug() << "IOSAuthenticationListener initialize";
+
+  Q_UNUSED(task);
+
+  QUrl url(createAuthenticationUrl(codeChallenge, codeChallengeMethod, emailAddress));
+  Q_ASSERT(!session);
+
+  NSString* callbackScheme = [NSString stringWithUTF8String:Constants::DEEP_LINK_SCHEME];
+  session = [[ASWebAuthenticationSession alloc]
+            initWithURL:url.toNSURL()
+      callbackURLScheme:callbackScheme
+      completionHandler:^(NSURL* _Nullable callbackURL, NSError* _Nullable error) {
+        if (session) {
+          [session dealloc];
+          session = nullptr;
+        }
+
+        if (error) {
+          logger.error() << "Authentication failed:"
+                         << QString::fromNSString([error localizedDescription]);
+
+          if ([error code] == ASWebAuthenticationSessionErrorCodeCanceledLogin) {
+            emit abortedByUser();
+          } else {
+            emit failed(ErrorHandler::AuthenticationError);
+          }
+
+          return;
+        }
+
+        if (!callbackURL) {
+          logger.error() << "Authentication failed: missing callback URL";
+          emit failed(ErrorHandler::AuthenticationError);
+          return;
+        }
+
+        QUrl callbackUrl = QUrl::fromNSURL(callbackURL);
+        logger.debug() << "Authentication completed:" << callbackUrl.toString();
+
+        QUrlQuery callbackQuery(callbackUrl.query());
+        if (!callbackQuery.hasQueryItem("code")) {
+          logger.error() << "Authentication failed: missing code";
+          emit failed(ErrorHandler::AuthenticationError);
+          return;
+        }
+
+        emit completed(callbackQuery.queryItemValue("code"));
+      }];
+
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
+  UIView* view = resolvePresentationView();
+  if (view) {
+    session.presentationContextProvider = [[ContextProvider alloc] initWithUIView:view];
+  } else {
+    logger.error() << "No presentation anchor found for authentication session.";
+    return;
+  }
+#endif
+
+  if (![session start]) {
+    [session dealloc];
+    session = nullptr;
+
+    logger.error() << "Authentication failed: session doesn't start.";
+    emit failed(ErrorHandler::AuthenticationError);
+  }
+}


### PR DESCRIPTION
## Description

This patch uses ASWebAuthenticationSession to authenticate users on FxA using the web-based flow.

## Reference

VPN-6321

## Checklist
    
- [x] My code follows the style guidelines for this project
- [ x I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
