### PR TITLE
Free credential buffer returned from CredReadW on Windows

### DIFF
--- a/src/platforms/windows/windowscryptosettings.cpp
+++ b/src/platforms/windows/windowscryptosettings.cpp
@@ -40,6 +40,7 @@ QByteArray WindowsCryptoSettings::getKey(CryptoSettings::Version version,
         m_key =
             QByteArray((char*)cred->CredentialBlob, cred->CredentialBlobSize);
         logger.debug() << "Key found with length:" << m_key.length();
+        CredFree(cred);
         return m_key;
       } else if (GetLastError() != ERROR_NOT_FOUND) {
         logger.error() << "Failed to retrieve the key";


### PR DESCRIPTION
## Description

This fixes a tiny memory leak on Windows, CredReadW requires the returned buffer to be freed with CredFree.

## Reference

 [vpn-7327](https://mozilla-hub.atlassian.net/browse/VPN-7327) (found when working on ticket)

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
