### PR TITLE
VPN-7389: update toggle color on theme switch

### DIFF
--- a/nebula/ui/components/MZUIStates.qml
+++ b/nebula/ui/components/MZUIStates.qml
@@ -113,10 +113,10 @@ Rectangle {
 
         // Because we intentionally do not bind the color (see above), it must be manually updated when theme changes.
         Connections {
-          target: MZTheme
-          function onChanged() {
-            buttonBackground.color = root.startingState
-          }
+            target: MZTheme
+            function onChanged() {
+                buttonBackground.color = root.startingState
+            }
         }
     }
 


### PR DESCRIPTION
## Description

This code has been stable for a while, but the bug seemingly revealed itself as part of the Qt 6.10 update. This seems to fix the issue. This connection is required due to the logic in the block immediately above it.

## Reference

VPN-7389

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
