### PR TITLE
Fix window contents having wrong offset at various UI scaling factors on Windows

### DIFF
--- a/src/ui/main.qml
+++ b/src/ui/main.qml
@@ -79,8 +79,13 @@ ApplicationWindow {
             return baseFlags;
         }
 
-        // TODO: Once every platform is on Qt 6.9, swap MaximizeUsingFullscreenGeometryHint for ExpandedClientAreaHint: https://doc.qt.io/qt-6.9/qt.html!
-        return baseFlags | Qt.ExpandedClientAreaHint | Qt.MaximizeUsingFullscreenGeometryHint;
+        // workaround for Qt.ExpandedClientAreaHint misbehaving on windows
+        // TODO: revise after Qt 6.10.2 is released
+        if (Qt.platform.os === "windows") {
+            return baseFlags;
+        }
+
+        return baseFlags | Qt.ExpandedClientAreaHint;
     }
     visible: true
 
@@ -141,9 +146,7 @@ ApplicationWindow {
         id: iosSafeAreaTopMargin
 
         color: MZTheme.colors.transparent
-        // offset screen contents by window.safeAreaMargins on desktop
-        // and fall back to device-specific values on iOS
-        height: Math.max(safeAreaHeightByDevice(), window.safeAreaMargins.top)
+        height: safeAreaHeightByDevice()
         width: window.width
         anchors.top: parent.top
     }


### PR DESCRIPTION
## Description

This is for Windows only.

The combination of window flags `Qt.ExpandedClientAreaHint` and `Qt.NoTitlebarBackgroundHint` results in a strange behavior, when the titlebar is present (with the background) and overlaps window contents, with the problem only appearing on dpi scaling factors other than 100%.

Adding an extra margin on top of the window defined by `window.SafeArea.margins` doesn't work very well here either, with the margin value often not matching the titlebar height.

Interestingly, removing `Qt.ExpandedClientAreaHint` on windows seems to both make titlebar transparent and correct the gap on the top of the screen. I am not 100% sure it's a Qt bug, and I was unable to find any known Qt issues similar to this yet.

UPD: looks like the issue is with `QWindowsWindow::safeAreaMargins()` method that always tries to calculate top margin height with dpi of 96:

https://github.com/qt/qtbase/blob/dev/src/plugins/platforms/windows/qwindowswindow.cpp#L2209-L2210

Going to report this as a Qt bug, but we could still use this workaround for the time being.

Before:

<img width="907" height="1602" alt="image" src="https://github.com/user-attachments/assets/06439e75-8b0b-40be-99c5-c0d157faeecc" />

After:

<img width="905" height="1675" alt="image" src="https://github.com/user-attachments/assets/9481e349-2ada-4660-9148-1d6e9891a841" />

## Reference

[VPN-7440](https://mozilla-hub.atlassian.net/browse/VPN-7440)

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed


[VPN-7440]: https://mozilla-hub.atlassian.net/browse/VPN-7440?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ