### PR TITLE
(Bugfix) - Should we include the arm merge modules?

### DIFF
--- a/windows/installer/MozillaVPN.wxs
+++ b/windows/installer/MozillaVPN.wxs
@@ -131,14 +131,12 @@
     <!--
       Merge modules
     -->
-    <?if $(var.Platform) = "x64" ?>
-      <DirectoryRef Id="MozillaVPNFolder">
-        <Merge Id="VCRedistModule" SourceFile="Microsoft_CRT_x64.msm" DiskId="1" Language="0"/>
-      </DirectoryRef>
-      <Feature Id="VCRedistFeature" Title="Visual C++ Runtime" AllowAdvertise="no" Display="hidden" Level="1">
-        <MergeRef Id="VCRedistModule" />
-      </Feature>
-    <?endif ?>
+    <DirectoryRef Id="MozillaVPNFolder">
+      <Merge Id="VCRedistModule" SourceFile="Microsoft_CRT_x64.msm" DiskId="1" Language="0"/>
+    </DirectoryRef>
+    <Feature Id="VCRedistFeature" Title="Visual C++ Runtime" AllowAdvertise="no" Display="hidden" Level="1">
+      <MergeRef Id="VCRedistModule" />
+    </Feature>
 
     <DirectoryRef Id="MozillaVPNFolder">
       <Component Id="RegistryEntries" Guid="71d1c1ef-2133-4cbf-954d-7f1e0e24dace">


### PR DESCRIPTION
## Description

We're adding them for x64, and we do see the deamon beeing unable to start in a fresh vm but on a real machine that is used it's fine. So my initial guess is that the vc-resist is missing. 
Maybe we need to add those too for arm?

Fun thing! It seems the x64 msm we have already contains all arm64 files we'd want to have, so no need to special case this i guess!
``` 
PS C:\Users\basti\Desktop\wix> dark.exe Microsoft_VC143_CRT_x64.msm -x out

PS C:\Users\basti\Desktop\wix> ls .\out\File\

    Directory: C:\Users\basti\Desktop\wix\out\File

Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
-a---          11/06/2025    06:21         324208 concrt140.dll_amd64.DFEFC2FE_EEE6_424C_841B_D4E66F0C84A3
-a---          11/06/2025    06:23         722488 concrt140.dll_arm64.DFEFC2FE_EEE6_424C_841B_D4E66F0C84A3
-a---          11/06/2025    06:21          35952 msvcp140_1.dll_amd64.DFEFC2FE_EEE6_424C_841B_D4E66F0C84A3
-a---          11/06/2025    06:23          50744 msvcp140_1.dll_arm64.DFEFC2FE_EEE6_424C_841B_D4E66F0C84A3
-a---          11/06/2025    06:21         280200 msvcp140_2.dll_amd64.DFEFC2FE_EEE6_424C_841B_D4E66F0C84A3
-a---          11/06/2025    06:23         520248 msvcp140_2.dll_arm64.DFEFC2FE_EEE6_424C_841B_D4E66F0C84A3
-a---          11/06/2025    06:21          50304 msvcp140_atomic_wait.dll_amd64.DFEFC2FE_EEE6_424C_841B_D4E66F0C84A3
-a---          11/06/2025    06:23          86048 msvcp140_atomic_wait.dll_arm64.DFEFC2FE_EEE6_424C_841B_D4E66F0C84A3
-a---          11/06/2025    06:21          31872 msvcp140_codecvt_ids.dll_amd64.DFEFC2FE_EEE6_424C_841B_D4E66F0C84A3
-a---          11/06/2025    06:23          41520 msvcp140_codecvt_ids.dll_arm64.DFEFC2FE_EEE6_424C_841B_D4E66F0C84A3
-a---          11/06/2025    06:21         557728 msvcp140.dll_amd64.DFEFC2FE_EEE6_424C_841B_D4E66F0C84A3
-a---          11/06/2025    06:23        1372216 msvcp140.dll_arm64.DFEFC2FE_EEE6_424C_841B_D4E66F0C84A3
-a---          11/06/2025    06:21         352384 vccorlib140.dll_amd64.DFEFC2FE_EEE6_424C_841B_D4E66F0C84A3
-a---          11/06/2025    06:24         888352 vccorlib140.dll_arm64.DFEFC2FE_EEE6_424C_841B_D4E66F0C84A3
-a---          11/06/2025    06:21          49792 vcruntime140_1.dll_amd64.DFEFC2FE_EEE6_424C_841B_D4E66F0C84A3
-a---          11/06/2025    06:24          53320 vcruntime140_1.dll_arm64.DFEFC2FE_EEE6_424C_841B_D4E66F0C84A3
-a---          11/06/2025    06:21          38528 vcruntime140_threads.dll_amd64.DFEFC2FE_EEE6_424C_841B_D4E66F0C84A3
-a---          11/06/2025    06:24          63016 vcruntime140_threads.dll_arm64.DFEFC2FE_EEE6_424C_841B_D4E66F0C84A3
-a---          11/06/2025    06:21         124544 vcruntime140.dll_amd64.DFEFC2FE_EEE6_424C_841B_D4E66F0C84A3
-a---          11/06/2025    06:24         199200 vcruntime140.dll_arm64.DFEFC2FE_EEE6_424C_841B_D4E66F0C84A3

```