### PR TITLE
turn off feature for iOS and Windows

### DIFF
--- a/src/feature/featurelistcallback.h
+++ b/src/feature/featurelistcallback.h
@@ -83,10 +83,11 @@ bool FeatureCallback_captivePortal() {
 }
 
 bool FeatureCallback_inAppAuthentication() {
-#if defined(MZ_ANDROID) || defined(MZ_WASM)
+#if defined(MZ_ANDROID) || defined(MZ_IOS) || defined(MZ_WASM) || \
+    defined(MZ_WINDOWS)
   return true;
 #else
-  // iOS, Windows, macOS and Linux
+  // macOS and Linux
   return false;
 #endif
 }


### PR DESCRIPTION
Keep in app auth for Windows and iOS for the 2.33 release branch.

This was changed https://github.com/mozilla-mobile/mozilla-vpn-client/pull/10988/ and https://github.com/mozilla-mobile/mozilla-vpn-client/pull/10984/