### PR TITLE
Prompt system restart when upgrading from 2.32 on Windows

### DIFF
--- a/windows/installer/MozillaVPN.wxs
+++ b/windows/installer/MozillaVPN.wxs
@@ -28,6 +28,10 @@
       <UpgradeVersion OnlyDetect='no' Property='PREVIOUSFOUND'
         Minimum='0.0.0.0' IncludeMinimum='yes'
         Maximum='1.0.0.0' IncludeMaximum='no' />
+      <!-- Prompt system restart when upgrading from 2.32 to properly reload split tunnel driver -->
+      <UpgradeVersion OnlyDetect='yes' Property='NEEDSREBOOT'
+        Minimum='0.0.0.0' IncludeMinimum='yes'
+        Maximum='2.32.99.99' IncludeMaximum='yes' />
     </Upgrade>
 
     <MediaTemplate EmbedCab="yes" CompressionLevel="high" />
@@ -182,8 +186,9 @@
     <CustomAction Id="LaunchVPNFirstExecution" Impersonate="yes" FileRef="MozillaVPNExecutable" ExeCommand="" Return="asyncNoWait" />
     <CustomAction Id="LaunchVPNAfterUpdate" Impersonate="yes" FileRef="MozillaVPNExecutable" ExeCommand="ui --updated" Return="asyncNoWait" />
     <InstallExecuteSequence>
-       <Custom Action="LaunchVPNFirstExecution" After="InstallFinalize" Condition="NOT WIX_UPGRADE_DETECTED" />
-       <Custom Action="LaunchVPNAfterUpdate" After="InstallFinalize" Condition="WIX_UPGRADE_DETECTED" />
+       <Custom Action="LaunchVPNFirstExecution" After="InstallFinalize" Condition="NOT WIX_UPGRADE_DETECTED AND NOT NEEDSREBOOT" />
+       <Custom Action="LaunchVPNAfterUpdate" After="InstallFinalize" Condition="WIX_UPGRADE_DETECTED AND NOT NEEDSREBOOT" />
+       <ScheduleReboot After="InstallFinalize" Condition="NEEDSREBOOT" />
     </InstallExecuteSequence>
 
     <!--


### PR DESCRIPTION
## Description

Prompt system restart when upgrading from 2.32 on Windows to reload split tunnel driver.

## Reference

[VPN-7449](https://mozilla-hub.atlassian.net/browse/VPN-7449)

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed


[VPN-7449]: https://mozilla-hub.atlassian.net/browse/VPN-7449?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ