### PR TITLE
Allow prompting restart when updating on Windows

### DIFF
--- a/src/update/balrog.cpp
+++ b/src/update/balrog.cpp
@@ -393,7 +393,6 @@ bool Balrog::install(const QString& filePath) {
   QString logFile = m_tmpDir.filePath("msiexec.log");
   QStringList arguments;
   arguments << "/qb!+"
-            << "REBOOT=Suppress"
             << "/i" << QDir::toNativeSeparators(filePath) << "/lv!"
             << QDir::toNativeSeparators(logFile);
 

--- a/windows/installer/MozillaVPN.wxs
+++ b/windows/installer/MozillaVPN.wxs
@@ -188,7 +188,7 @@
     <InstallExecuteSequence>
        <Custom Action="LaunchVPNFirstExecution" After="InstallFinalize" Condition="NOT WIX_UPGRADE_DETECTED AND NOT NEEDSREBOOT" />
        <Custom Action="LaunchVPNAfterUpdate" After="InstallFinalize" Condition="WIX_UPGRADE_DETECTED AND NOT NEEDSREBOOT" />
-       <ScheduleReboot After="InstallFinalize" Condition="NEEDSREBOOT" />
+       <ScheduleReboot Before="InstallFinalize" Condition="NEEDSREBOOT" />
     </InstallExecuteSequence>
 
     <!--


### PR DESCRIPTION
## Description

Follow-up to https://github.com/mozilla-mobile/mozilla-vpn-client/pull/10999

msiexec is suppressing restarting when we're updating from balrog, this is supposed to fix it.

`REBOOT=ReallySuppress` completely prevents the restart dialog from appearing (and causes the installer to exit with error code 3010 - ERROR_SUCCESS_REBOOT_REQUIRED instead). In normal circumstances it doesn't seem to be necessary, as running the MSI without any arguments doesn't prompt restarting in my current tests.

`/qb!-` argument to `msiexec` is replaced with `/qb!+` to allow dialogs in [the end of install sequence](https://learn.microsoft.com/de-de/windows/win32/msi/command-line-options).

N.B.: the option is also causing a dialog prompting closing of MozillaVPN if it's running, but I think it's not a bad idea.

`REBOOT=ReallySuppress` is removed as it's causing the reboot prompt to disappear.

ScheduleReboot has to be scheduled **before** "InstallFinalize", otherwise we get error 2762 (previously silenced by qb!-).

## Reference

[vpn-7449](https://mozilla-hub.atlassian.net/browse/VPN-7449)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
