### PR TITLE
VPN-7409: fix iOS status bar

### DIFF
--- a/src/ui/main.qml
+++ b/src/ui/main.qml
@@ -85,6 +85,7 @@ ApplicationWindow {
             return baseFlags;
         }
 
+        // TODO: Once every platform is on Qt 6.9, swap MaximizeUsingFullscreenGeometryHint for ExpandedClientAreaHint: https://doc.qt.io/qt-6.9/qt.html
         return baseFlags | Qt.ExpandedClientAreaHint | Qt.MaximizeUsingFullscreenGeometryHint;
     }
     visible: true


### PR DESCRIPTION
## Description

[This commit](https://github.com/mozilla-mobile/mozilla-vpn-client/commit/2ab719f768118cf3f8832bcdc36bdeab02c1469c) removed this flag. Since we're still using an older Qt version for iOS, we need it still. This fixes the issue.  (There were a few days where we expected to upgrade iOS as well; this may have gone in during that time.)

<img width="163"  alt="Screenshot 2026-01-27 at 1 12 40 PM" src="https://github.com/user-attachments/assets/b76430f6-d268-4c7b-bf48-6d45d6344e7f" /><img width="163" alt="Screenshot 2026-01-27 at 1 12 43 PM-1" src="https://github.com/user-attachments/assets/7496ea40-998d-45dc-be32-e5987a4c64f3" />


## Reference

VPN-7409

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
