### PR TITLE
Revert "Workaround for the crash on Pixel devices (#10895)"

### DIFF
--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -2392,13 +2392,7 @@ int MozillaVPN::runGuiApp(std::function<int()>&& a_callback) {
   callback();
 #endif
 
-#if defined(MZ_ANDROID) && (QT_VERSION > QT_VERSION_CHECK(6, 10, 1))
-#  error \
-      "Revisit the code below and replace QCoreApplication::exec() \
-      with app.exec() if the app no longer crashes on Pixel 2 XL, \
-      see https://github.com/mozilla-mobile/mozilla-vpn-client/pull/10895"
-#endif
-  return QCoreApplication::exec();
+  return app.exec();
 }
 
 #ifdef MZ_MACOS


### PR DESCRIPTION
This reverts commit 1236d3494fc9efcd166a705c1d1cbcf2ae286f9b.

## Description

The pixel crash workaround prevents talkback from function correctly. This PR reverts it, but we're gonna need to apply [this patch](https://codereview.qt-project.org/c/qt/qtbase/+/704879) for Qt 6.10.1 on Android (for which we don't have taskcluster builds? going to look into it next).

## Reference

[vpn-7454](https://mozilla-hub.atlassian.net/browse/VPN-7454)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
