### PR TITLE
VPN-7457: add app exclusions help center link to toast

### DIFF
--- a/nebula/ui/components/MZSystemAlert.qml
+++ b/nebula/ui/components/MZSystemAlert.qml
@@ -84,6 +84,19 @@ MZAlert {
                 }
             },
             State {
+                name: MZErrorHandler.SplitTunnelErrorAlertWithLink
+                PropertyChanges {
+                    target: alertBox
+                    alertText: MZI18n.SplittunnelErrorActivating
+                    alertActionText: MZI18n.GetHelpHelpCenter
+                    visible: true
+
+                    onActionPressed: ()=>{
+                        MZUrlOpener.openUrlLabel("sumoExcludedApps")
+                    }
+                }
+            },
+            State {
                 name: MZErrorHandler.UnrecoverableErrorAlert
                 PropertyChanges {
                     target: alertBox

--- a/src/errorhandler.cpp
+++ b/src/errorhandler.cpp
@@ -49,8 +49,13 @@ QList<ErrorTypeData> s_errorData{
 
     ErrorTypeData(ErrorHandler::ControllerError, true,
                   []() { return ErrorHandler::ControllerErrorAlert; }),
+#ifdef MZ_WINDOWS
+    ErrorTypeData(ErrorHandler::SplitTunnelError, true,
+                  []() { return ErrorHandler::SplitTunnelErrorAlertWithLink; }),
+#else
     ErrorTypeData(ErrorHandler::SplitTunnelError, true,
                   []() { return ErrorHandler::SplitTunnelErrorAlert; }),
+#endif
 
     ErrorTypeData(ErrorHandler::RemoteServiceError, true,
                   []() { return ErrorHandler::RemoteServiceErrorAlert; }),
@@ -227,6 +232,7 @@ void ErrorHandler::requestAlert(AlertType alert) {
 }
 
 void ErrorHandler::setAlert(AlertType alert) {
+  logger.debug() << "Setting alert" << alert;
   m_alertTimer.stop();
 
   if (alert != NoAlert) {

--- a/src/errorhandler.h
+++ b/src/errorhandler.h
@@ -44,6 +44,7 @@ class ErrorHandler final : public QObject {
     NoConnectionAlert,
     ControllerErrorAlert,
     SplitTunnelErrorAlert,
+    SplitTunnelErrorAlertWithLink,
     RemoteServiceErrorAlert,
     SubscriptionFailureAlert,
     GeoIpRestrictionAlert,


### PR DESCRIPTION
## Description

Adding link to sumo. This is on Windows only, but perhaps we should use it for all app exclusions errors?

I tried a version where the link just said "Help", but that didn't seem as good as this version.

There is currently a conversation in slack - we may change the link. If so, I'll make a follow-on PR.

<img width="200"  alt="Screenshot 67" src="https://github.com/user-attachments/assets/7056e8d6-7861-4fe8-b332-449846283079" />

## Reference

VPN-7457

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
