### PR TITLE
VPN-7447: Fix Microsoft CRT merge module for aarch64 installer

### DIFF
--- a/windows/installer/CMakeLists.txt
+++ b/windows/installer/CMakeLists.txt
@@ -167,6 +167,20 @@ else()
     set(MSI_OUTPUT_FILENAME "MozillaVPN-${WIX_PLATFORM}.msi")
 endif()
 
+# Repack the CRT merge module to workaround arch mismatches.
+add_custom_command(
+    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/Microsoft_CRT_repack.msm
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/Microsoft_CRT_repack.wxs
+    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/install-stamp.txt
+    COMMAND ${CMAKE_COMMAND} -E echo "Repack CRT merge module"
+    COMMAND ${WIX_BUILD_TOOL} msi decompile
+                -out ${CMAKE_CURRENT_BINARY_DIR}/Microsoft_CRT_repack.wxs
+                -x ${CMAKE_CURRENT_BINARY_DIR}/SourceDir
+                ${WIX_STAGING_DIR}/Microsoft_CRT_x64.msm
+    COMMAND ${WIX_BUILD_TOOL} build -arch ${WIX_PLATFORM} ${CMAKE_CURRENT_BINARY_DIR}/Microsoft_CRT_repack.wxs
+)
+
 # Build the MSI installer package
 add_custom_command(
     OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${MSI_OUTPUT_FILENAME}
@@ -175,6 +189,7 @@ add_custom_command(
     DEPENDS
         ${CMAKE_CURRENT_BINARY_DIR}/install-stamp.txt
         ${CMAKE_CURRENT_BINARY_DIR}/wixext-stamp.txt
+        ${CMAKE_CURRENT_BINARY_DIR}/Microsoft_CRT_repack.msm
         ${WIX_I18N_DEPS}
     COMMAND ${CMAKE_COMMAND} -E echo "Building MSI installer"
     COMMAND ${WIX_BUILD_TOOL} build ${WIX_I18N_ARGS}

--- a/windows/installer/MozillaVPN.wxs
+++ b/windows/installer/MozillaVPN.wxs
@@ -135,14 +135,12 @@
     <!--
       Merge modules
     -->
-    <?if $(var.Platform) = "x64" ?>
-      <DirectoryRef Id="MozillaVPNFolder">
-        <Merge Id="VCRedistModule" SourceFile="Microsoft_CRT_x64.msm" DiskId="1" Language="0"/>
-      </DirectoryRef>
-      <Feature Id="VCRedistFeature" Title="Visual C++ Runtime" AllowAdvertise="no" Display="hidden" Level="1">
-        <MergeRef Id="VCRedistModule" />
-      </Feature>
-    <?endif ?>
+    <DirectoryRef Id="MozillaVPNFolder">
+      <Merge Id="VCRedistModule" SourceFile="Microsoft_CRT_repack.msm" DiskId="1" Language="0"/>
+    </DirectoryRef>
+    <Feature Id="VCRedistFeature" Title="Visual C++ Runtime" AllowAdvertise="no" Display="hidden" Level="1">
+      <MergeRef Id="VCRedistModule" />
+    </Feature>
 
     <DirectoryRef Id="MozillaVPNFolder">
       <Component Id="RegistryEntries" Guid="71d1c1ef-2133-4cbf-954d-7f1e0e24dace">


### PR DESCRIPTION
## Description
Attempting to build the MSI installer for aarch64 with the CRT merge module fails with the following error:

```
FAILED: [code=345] MozillaVPN.msi D:/task_176943831745789/unsigned/MozillaVPN.msi 
[task 2026-01-26T14:41:04.085+00:00] C:\Windows\system32\cmd.exe /C "cd /D D:\task_176943831745789\unsigned && D:\task_176943831745789\fetches\cmake-4.2.1-windows-x86_64\bin\cmake.exe -E echo "Building MSI installer" && D:\task_176943831745789\wix\tools\net6.0\any\wix.exe build -loc D:/task_176943831745789/unsigned/i18n/MozillaVPN-bg.wxl -loc D:/task_176943831745789/unsigned/i18n/MozillaVPN-co.wxl -loc D:/task_176943831745789/unsigned/i18n/MozillaVPN-cs.wxl -loc D:/task_176943831745789/unsigned/i18n/MozillaVPN-cy.wxl -loc D:/task_176943831745789/unsigned/i18n/MozillaVPN-da.wxl -loc D:/task_176943831745789/unsigned/i18n/MozillaVPN-de.wxl -loc D:/task_176943831745789/unsigned/i18n/MozillaVPN-dsb.wxl -loc D:/task_176943831745789/unsigned/i18n/MozillaVPN-el.wxl -loc D:/task_176943831745789/unsigned/i18n/MozillaVPN-en.wxl -loc D:/task_176943831745789/unsigned/i18n/MozillaVPN-en_CA.wxl -loc D:/task_176943831745789/unsigned/i18n/MozillaVPN-en_GB.wxl -loc D:/task_176943831745789/unsigned/i18n/MozillaVPN-es_AR.wxl -loc D:/task_176943831745789/unsigned/i18n/MozillaVPN-es_CL.wxl -loc D:/task_176943831745789/unsigned/i18n/MozillaVPN-es_ES.wxl -loc D:/task_176943831745789/unsigned/i18n/MozillaVPN-es_MX.wxl -loc D:/task_176943831745789/unsigned/i18n/MozillaVPN-fi.wxl -loc D:/task_176943831745789/unsigned/i18n/MozillaVPN-fr.wxl -loc D:/task_176943831745789/unsigned/i18n/MozillaVPN-fur.wxl -loc D:/task_176943831745789/unsigned/i18n/MozillaVPN-fy_NL.wxl -loc D:/task_176943831745789/unsigned/i18n/MozillaVPN-hsb.wxl -loc D:/task_176943831745789/unsigned/i18n/MozillaVPN-hu.wxl -loc D:/task_176943831745789/unsigned/i18n/MozillaVPN-ia.wxl -loc D:/task_176943831745789/unsigned/i18n/MozillaVPN-id.wxl -loc D:/task_176943831745789/unsigned/i18n/MozillaVPN-is.wxl -loc D:/task_176943831745789/unsigned/i18n/MozillaVPN-it.wxl -loc D:/task_176943831745789/unsigned/i18n/MozillaVPN-ja.wxl -loc D:/task_176943831745789/unsigned/i18n/MozillaVPN-ko.wxl -loc D:/task_176943831745789/unsigned/i18n/MozillaVPN-lo.wxl -loc D:/task_176943831745789/unsigned/i18n/MozillaVPN-nl.wxl -loc D:/task_176943831745789/unsigned/i18n/MozillaVPN-pa_IN.wxl -loc D:/task_176943831745789/unsigned/i18n/MozillaVPN-pl.wxl -loc D:/task_176943831745789/unsigned/i18n/MozillaVPN-pt_BR.wxl -loc D:/task_176943831745789/unsigned/i18n/MozillaVPN-pt_PT.wxl -loc D:/task_176943831745789/unsigned/i18n/MozillaVPN-ru.wxl -loc D:/task_176943831745789/unsigned/i18n/MozillaVPN-scn.wxl -loc D:/task_176943831745789/unsigned/i18n/MozillaVPN-sk.wxl -loc D:/task_176943831745789/unsigned/i18n/MozillaVPN-sl.wxl -loc D:/task_176943831745789/unsigned/i18n/MozillaVPN-sq.wxl -loc D:/task_176943831745789/unsigned/i18n/MozillaVPN-th.wxl -loc D:/task_176943831745789/unsigned/i18n/MozillaVPN-tr.wxl -loc D:/task_176943831745789/unsigned/i18n/MozillaVPN-uk.wxl -loc D:/task_176943831745789/unsigned/i18n/MozillaVPN-vi.wxl -loc D:/task_176943831745789/unsigned/i18n/MozillaVPN-zh_CN.wxl -loc D:/task_176943831745789/unsigned/i18n/MozillaVPN-zh_TW.wxl -d Platform=arm64 -arch arm64 -bindpath D:/task_176943831745789/unsigned -ext WixToolset.Util.wixext -out D:/task_176943831745789/unsigned/MozillaVPN.msi D:/task_176943831745789/build/src/windows/installer/MozillaVPN.wxs"
[task 2026-01-26T14:41:04.085+00:00] Building MSI installer
[task 2026-01-26T14:41:04.085+00:00] D:\task_176943831745789\build\src\windows\installer\MozillaVPN.wxs(135) : error WIX0345: 'Microsoft_CRT_x64.msm' is a 64-bit merge module but the product consuming it is 32-bit. 32-bit products can consume only 32-bit merge modules.
[task 2026-01-26T14:41:04.085+00:00] ninja: build stopped: subcommand failed.
```

The root cause of this failure seems to be that the official Microsoft MSM is built for `amd64` (which will technically install on a windows-on-arm machine anyways) but our MSI is targeting `arm64` specifically. To fix this, we add some CMake rules to re-compile the MSM with an updated `-arch` flag, after which we can install the MergeModule on all target architectures.

## Reference
JIRA Issue: [VPN-7447](https://mozilla-hub.atlassian.net/browse/VPN-7447)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-7447]: https://mozilla-hub.atlassian.net/browse/VPN-7447?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ