### PR TITLE
VPN-7472: allow in-app auth on new servers

### DIFF
--- a/src/authenticationinapp/authenticationinappsession.cpp
+++ b/src/authenticationinapp/authenticationinappsession.cpp
@@ -669,10 +669,12 @@ void AuthenticationInAppSession::finalizeSignInOrUp() {
 
   NetworkRequest* request = fxaHawkPostRequest(
       m_task, "/v1/oauth/authorization", m_sessionToken,
-      QJsonObject{{"client_id", m_fxaParams.m_clientId},
-                  {"state", m_fxaParams.m_state},
-                  {"scope", m_fxaParams.m_scope},
-                  {"access_type", m_fxaParams.m_accessType}});
+      QJsonObject{
+          {"client_id", m_fxaParams.m_clientId},
+          {"state", m_fxaParams.m_state},
+          {"scope", m_fxaParams.m_scope},
+          {"access_type", m_fxaParams.m_accessType},
+          {"redirect_uri", Constants::apiUrl(Constants::OAuthSuccess)}});
 
   connect(request, &NetworkRequest::requestFailed, this,
           [this](QNetworkReply::NetworkError error, const QByteArray& data) {

--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -77,6 +77,7 @@ QString Constants::apiUrl(ApiEndpoint endpoint) {
       {ApiEndpoint::Heartbeat, "/__heartbeat__"},
       {ApiEndpoint::IPInfo, "/api/v1/vpn/ipinfo"},
       {ApiEndpoint::LoginVerify, "/api/v2/vpn/login/verify"},
+      {ApiEndpoint::OAuthSuccess, "/oauth/success"},
 #ifdef MZ_ANDROID
       {ApiEndpoint::PurchasesAndroid, "/api/v1/vpn/purchases/android"},
 #endif

--- a/src/constants.h
+++ b/src/constants.h
@@ -28,6 +28,7 @@ enum ApiEndpoint {
   Heartbeat,
   IPInfo,
   LoginVerify,
+  OAuthSuccess,
   Products,
 #ifdef MZ_ANDROID
   PurchasesAndroid,


### PR DESCRIPTION
## Description

Joe Z. did much of the diagnosis on this one.

I've tested on current stage, new stage (that Joe is working on), and prod. It does not seem to cause any regressions.

Without this param, it pulls the first URL it has for an application's success URL... which causes an error when using the new stage server. Thus, we'll now explicitly tell them which we want.

## Reference

VPN-7472

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
