### PR TITLE
VPN-7455 Paint status indicator while changing the Privacy/DNS preferences

### DIFF
--- a/src/statusicon.cpp
+++ b/src/statusicon.cpp
@@ -145,12 +145,16 @@ const QColor StatusIcon::indicatorColor() const {
     return INVALID_COLOR;
   }
 
-  if (vpn->controller()->state() == Controller::StateConnectionError) {
-    return RED_COLOR;
-  }
-
-  if (vpn->controller()->state() != Controller::StateOn) {
-    return INVALID_COLOR;
+  switch (vpn->controller()->state()) {
+    case Controller::StateConnectionError:
+      return RED_COLOR;
+      break;
+    case Controller::StateOn:
+      [[fallthrough]];
+    case Controller::StateSilentSwitching:
+      break;
+    default:
+      return INVALID_COLOR;
   }
 
   switch (vpn->connectionHealth()->stability()) {
@@ -182,7 +186,8 @@ QIcon StatusIcon::drawStatusIndicator() {
   // Only draw a status indicator if the VPN is connected or in connection error
   // state.
   if (vpn->controller()->state() == Controller::StateOn ||
-      vpn->controller()->state() == Controller::StateConnectionError) {
+      vpn->controller()->state() == Controller::StateConnectionError ||
+      vpn->controller()->state() == Controller::StateSilentSwitching) {
     QPainter painter(&iconPixmap);
     painter.setRenderHint(QPainter::Antialiasing);
     painter.setPen(Qt::NoPen);


### PR DESCRIPTION
## Description

    Enable status indicator painting when in `Controller::StatusSilentSwitching`

## Reference
 
[Jira Issue](https://mozilla-hub.atlassian.net/browse/VPN-7455)

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
