### PR TITLE
Show multihop info in CLI `status' command

### DIFF
--- a/src/commands/commandstatus.cpp
+++ b/src/commands/commandstatus.cpp
@@ -113,14 +113,18 @@ int CommandStatus::run(QStringList& tokens) {
       stream << "Entry Server country: "
              << model->countryName(sd->entryCountryCode()) << Qt::endl;
       stream << "Entry Server city: " << sd->entryCityName() << Qt::endl;
+      stream << "Exit Server country code: " << sd->exitCountryCode()
+             << Qt::endl;
+      stream << "Exit Server country: "
+             << model->countryName(sd->exitCountryCode()) << Qt::endl;
+      stream << "Exit Server city: " << sd->exitCityName() << Qt::endl;
+    } else {
+      stream << "Server country code: " << sd->exitCountryCode() << Qt::endl;
+      stream << "Server country: " << model->countryName(sd->exitCountryCode())
+             << Qt::endl;
+      stream << "Server city: " << sd->exitCityName() << Qt::endl;
     }
-    const QString multihopExit = sd->multihop() ? "Exit " : "";
-    stream << multihopExit << "Server country code: " << sd->exitCountryCode()
-           << Qt::endl;
-    stream << multihopExit
-           << "Server country: " << model->countryName(sd->exitCountryCode())
-           << Qt::endl;
-    stream << multihopExit << "Server city: " << sd->exitCityName() << Qt::endl;
+
     Controller controller;
 
     QEventLoop loop;


### PR DESCRIPTION
## Description

Display information for entry and exit servers in the CLI `status` command when using multihop, in the following format.

```
Entry Server country code: it
Entry Server country: Italy
Entry Server city: Palermo
Exit Server country code: ar
Exit Server country: Argentina
Exit Server city: Buenos Aires
```

## Reference

    i.e Jira or Github issue URL

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
