### PR TITLE
Error checking dev menu inputs

### DIFF
--- a/src/ui/screens/getHelp/developerMenu/ViewDeveloperMenu.qml
+++ b/src/ui/screens/getHelp/developerMenu/ViewDeveloperMenu.qml
@@ -65,7 +65,7 @@ MZViewBase {
             onTextChanged: text => {
                 var serverAddressText = serverAddressInput.text.trim();
                 if (serverAddressText.endsWith('/')) {
-                  serverAddressText = serverAddressText.trim(0, -1);
+                  serverAddressText = serverAddressText.slice(0, -1);
                 }
                 if (MZSettings.stagingServerAddress !== serverAddressText) {
                     MZSettings.stagingServerAddress = serverAddressText;


### PR DESCRIPTION
## Description

This comes from VPN-7472, where the issue was a missing trailing slash. This has provided enough confusion over the years, let's error check. It's especially confusing because the addons server requires a trailing slash, and the staging server prohibits it.

I tested on macOS.

## Reference

VPN-7481

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
