### PR TITLE
Update balrog target URL for windows/arm64 to correct arch

### DIFF
--- a/src/update/balrog.cpp
+++ b/src/update/balrog.cpp
@@ -12,6 +12,7 @@
 #include <QScopeGuard>
 #include <QSslCertificate>
 #include <QSslKey>
+#include <QSysInfo>
 
 #include "constants.h"
 #include "env.h"
@@ -36,14 +37,6 @@ bool verify_content_signature(const char* x5u_ptr, size_t x5u_length,
                               const char* signature, const char* certSubject,
                               void (*logfn)(const char*));
 }
-
-#if defined(MZ_WINDOWS)
-constexpr const char* BALROG_WINDOWS_BUILD_TARGET = "WINNT_x86_64";
-#elif defined(MZ_MACOS)
-constexpr const char* BALROG_MACOS_BUILD_TARGET = "Darwin_x86";
-#else
-#  error Platform not supported yet
-#endif
 
 constexpr const char* BALROG_CERT_SUBJECT_CN =
     "aus.content-signature.mozilla.org";
@@ -72,9 +65,9 @@ Balrog::~Balrog() {
 // static
 QString Balrog::buildTarget() {
 #if defined(MZ_WINDOWS)
-  return BALROG_WINDOWS_BUILD_TARGET;
+  return QString("WINNT_%1").arg(QSysInfo::currentCpuArchitecture());
 #elif defined(MZ_MACOS)
-  return BALROG_MACOS_BUILD_TARGET;
+  return "Darwin_x86";
 #else
 #  error Balrog: Unsupported platform
 #endif


### PR DESCRIPTION
## Description
It occurs to me that before we try shipping an `arm64` MSI installer, we should update the Balrog URL to distinguish the `x86_64` and `arm64` builds otherwise Balrog would be unable to tell them apart and could ship the wrong MSI upon update.

## Reference

    i.e Jira or Github issue URL

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
