### PR TITLE
VPN-7451: fix color on iOS

### DIFF
--- a/nebula/ui/components/MZUIStates.qml
+++ b/nebula/ui/components/MZUIStates.qml
@@ -115,7 +115,9 @@ Rectangle {
         Connections {
             target: MZTheme
             function onChanged() {
-                buttonBackground.color = root.startingState
+                if (Qt.platform.os !== "ios") {
+                    buttonBackground.color = root.startingState
+                }
             }
         }
     }


### PR DESCRIPTION
## Description

iOS changes the theme when switching away from an app (to the opposite scheme and then back to the one you are actually on), so that it captures current screenshots of both dark and light mode (so it can show the appropriate one in app switcher if you happen to change the theme). 

For some reason, this iOS changing theme twice is firing in Qt *after* we come back to the app (rather than when it goes in the background). Even more confusingly, this resulting in this problem because the second change of this line somehow doesn't happen. If you remove this line, it works fine. And since this line was added [in VPN-7389](https://github.com/mozilla-mobile/mozilla-vpn-client/pull/10987) AND the VPN-7389 problem is cleared by moving away from a screen and back into it AND by definition, after changing the iOS dark/light mode in settings you have to move back into the app (thus changing screens), this seems like an okay fix for iOS.

There are two times I can think of when we may be re-introducing VPN-7389 into iOS:
- Users who have dark/light mode change at sunrise/sunset. If they are on the VPN app, they may see the wrong toggle color for a moment. This seems like a slim, but real chance of being in the app at the perfect time.
- iPads with VPN and Settings side-by-side. Again, real chance, but slim.

And given that the current state of the iOS app (in prod) shows this issue on the regular, this seems like a fair fix for now.

I'm not going to file a follow up ticket - the remaining issues are minute (and likely caused by Qt code), and will be near-impossible to fix. If we open a ticket, I'd recommend closing it as "won't fix".

## Reference

VPN-7451

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
