### PR TITLE
VPN-7482: Add .pkla Local Authority policy files for Ubuntu 22.04 

### DIFF
--- a/linux/debian/mozillavpn.install
+++ b/linux/debian/mozillavpn.install
@@ -18,3 +18,4 @@ usr/share/metainfo/org.mozilla.vpn.metainfo.xml
 usr/share/metainfo/org.mozilla.vpn.releases.xml
 usr/share/polkit-1/actions/org.mozilla.vpn.policy
 usr/share/polkit-1/rules.d/org.mozilla.vpn.rules
+var/lib/polkit-1/localauthority/55-org.mozilla.d/org.mozilla.vpn.pkla

--- a/linux/org.mozilla.vpn.pkla
+++ b/linux/org.mozilla.vpn.pkla
@@ -1,0 +1,6 @@
+[Activate or deactivate MozillaVPN]
+Identity=unix-group:admin;unix-group:sudo
+Action=org.mozilla.vpn.activate;org.mozilla.vpn.deactivate
+ResultAny=no
+ResultInactive=no
+ResultActive=yes

--- a/src/cmake/linux.cmake
+++ b/src/cmake/linux.cmake
@@ -195,6 +195,8 @@ if(NOT BUILD_FLATPAK)
         install(FILES ${CMAKE_SOURCE_DIR}/linux/org.mozilla.vpn.rules-debian
             RENAME org.mozilla.vpn.rules
             DESTINATION ${POLKIT_DATA_DIR}/polkit-1/rules.d)
+        install(FILES ${CMAKE_SOURCE_DIR}/linux/org.mozilla.vpn.pkla
+            DESTINATION /var/lib/polkit-1/localauthority/55-org.mozilla.d/)
     elseif(EXISTS /etc/redhat-release)
         install(FILES ${CMAKE_SOURCE_DIR}/linux/org.mozilla.vpn.rules-others
             RENAME org.mozilla.vpn.rules


### PR DESCRIPTION
## Description

Ubuntu 22.04 (Jammy) uses polkit 0.105, which does not support JavaScript rules.
Install both policy types:

 - `.pkla` files in `/var/lib/polkit-1/localauthority/55-org.mozilla.d/`
 - `.rules` (JS) files in `/usr/share/polkit-1/rules.d/`

## Reference

  [Jira Issue](https://mozilla-hub.atlassian.net/browse/VPN-7482) 

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
