### PR TITLE
remove staging-only condition from "update to 2.33" addon

### DIFF
--- a/addons/message_update_v2.33/manifest.json
+++ b/addons/message_update_v2.33/manifest.json
@@ -5,8 +5,7 @@
   "type": "message",
   "conditions": {
     "max_client_version": "2.32.9",
-    "javascript": "osCheck.js",
-    "env": "staging"
+    "javascript": "osCheck.js"
   },
   "javascript": {
     "enable": "enable.js"


### PR DESCRIPTION
Removing staging-only condition for 2.33 update addon.

`releases/2.33.1.addons` branch is cut on the commit right before [2.34 addons were merged](https://github.com/mozilla-mobile/mozilla-vpn-client/pull/11059), as we only keep one "update" message at a time.