### PR TITLE
taskcluster: linux builds using docker latest

### DIFF
--- a/taskcluster/kinds/build/linux.yml
+++ b/taskcluster/kinds/build/linux.yml
@@ -58,7 +58,7 @@ linux/plucky:
 linux/ubuntu:
     description: "Linux Build (Ubuntu/Latest)"
     treeherder:
-        platform: linux/plucky
+        platform: linux/ubuntu
     worker:
         docker-image: {in-tree: linux-build-ubuntu}
     add-index-routes:

--- a/taskcluster/kinds/docker-image/kind.yml
+++ b/taskcluster/kinds/docker-image/kind.yml
@@ -60,12 +60,12 @@ tasks:
         symbol: I(linux-ubuntu)
         definition: linux-dpkg-build
         args:
-            DOCKER_BASE_IMAGE: {dockerhub:ubuntu:latest}
+            DOCKER_BASE_IMAGE: '{dockerhub:ubuntu:latest}'
     linux-build-fedora:
         symbol: I(linux-fedora)
         definition: linux-rpm-build
         args:
-            DOCKER_BASE_IMAGE: {dockerhub:fedora:latest}
+            DOCKER_BASE_IMAGE: '{dockerhub:fedora:latest}'
     sentry:
         parent: base
         symbol: I(sentry)

--- a/taskcluster/mozillavpn_taskgraph/transforms/docker_image.py
+++ b/taskcluster/mozillavpn_taskgraph/transforms/docker_image.py
@@ -20,18 +20,19 @@ def dockerhub_fetch_digest(repo, tag):
 def resolve_tag_digest(config, tasks):
     for task in tasks:
         if not "args" in task:
+            yield task
             continue
 
         # If we find text of the form: {dockerhub:repository:tag} then use the
-        # Docker Hub API to replace it with the hash of the tag.
+        # Docker Hub API to generate the image tag including the current digest
         dockerhub_regex = re.compile('{dockerhub:[a-z0-9:]+}')
         for key, value in task.get("args", {}).items():
             match = dockerhub_regex.search(value)
             if match:
                 dh_args = match.group(0)[1:-1].split(':')
                 digest = dockerhub_fetch_digest(dh_args[1], dh_args[2])
-                tag = f'{dh_args[1]}:{dh_args[2]}@{dh_digest}'
-                if dh_digest:
+                if digest:
+                    tag = f'{dh_args[1]}:{dh_args[2]}@{digest}'
                     task["args"][key] = value[0:match.start()] + tag + value[match.end():]
 
         yield task


### PR DESCRIPTION
## Description
The taskcluster linux build targets have required manually updating whenever a new OS release is shipped. Let's try to make this a little better by using a taskcluster transform to follow a moving tag such as `ubuntu:latest` or `fedora:latest`.

Using a transform to manipulate the task `args` should enable us to play nicely with image caching...  this would trigger a rebuild of the docker image whenever the digest changes on Dockerhub.

## Reference

    i.e Jira or Github issue URL

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
