### PR TITLE
VPN-433: Add beetmover task for static RPM artifact

### DIFF
--- a/taskcluster/kinds/beetmover-promote/kind.yml
+++ b/taskcluster/kinds/beetmover-promote/kind.yml
@@ -97,6 +97,13 @@ tasks:
             build: build-linux64/release-deb
         attributes:
             build-type: linux64/release-deb
+    linux64-rpm:
+        run-on-tasks-for: [action]
+        release-artifacts: [mozillavpn.rpm]
+        dependencies:
+            build: build-linux64/release-rpm
+        attributes:
+            build-type: linux64/release-rpm
     source-zip:
         run-on-tasks-for: [action]
         release-artifacts: [mozillavpn-sources.tar.gz]

--- a/taskcluster/mozillavpn_taskgraph/transforms/beetmover.py
+++ b/taskcluster/mozillavpn_taskgraph/transforms/beetmover.py
@@ -80,6 +80,7 @@ def add_beetmover_worker_config(config, tasks):
         "android/armv7": "android",
         "android/arm64-v8a": "android",
         "linux64/release-deb": "linux",
+        "linux64/release-rpm": "linux",
         "source/vpn" : "source",
     }
 


### PR DESCRIPTION
## Description
Now that we build a static RPM, we should also upload it to the archive as a part of the release process. Let's add a beetmover task to do just that.

## Reference
JIRA Issue: [VPN-433](https://mozilla-hub.atlassian.net/browse/VPN-433)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-433]: https://mozilla-hub.atlassian.net/browse/VPN-433?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ