### PR TITLE
VPN-7487: fix top/bottom color on iOS initial purple screens

### DIFF
--- a/src/ui/screens/initialize/ViewInitialize.qml
+++ b/src/ui/screens/initialize/ViewInitialize.qml
@@ -17,15 +17,19 @@ Item {
     property string logoSubtitle: MZI18n.ProductDescription
 
     Rectangle {
+        // The +100 and -50 in this rectangle is an awful hack to allow the purple color to cover
+        // the iOS status bar and bottom bar area (the items outside the safe area). It doesn't make a
+        // difference for other platforms. (In main.qml, we set the background color to the general bgColor,
+        // so this only is needed on this screen - it is the only one that has a custom background color.)
         id: fallBackBackground
         // This is a fallback for MZRadialGradient
         color: MZTheme.colors.onBoardingGradient.end
-        height: Screen.height
+        height: Screen.height + 100
         width: Screen.width
 
         anchors {
             top: parent.top
-            topMargin:  -window.safeAreaHeightByDevice()
+            topMargin:  -50
         }
     }
 


### PR DESCRIPTION
## Description

This is an awful hack, but I spent a while with "neater" ways and wasn't getting anywhere, unfortunately. This has no side effects on other platforms, it seems. (We removed `safeAreaHeightByDevice` a while ago, so that wasn't doing anything here.)


<img width="163" alt="Screenshot 2026-02-17 at 3 31 59 PM" src="https://github.com/user-attachments/assets/d8f7264b-a862-4386-982f-ceb652751ff6" />


## Reference

VPN-7487

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
