### PR TITLE
VPN-7464 Add flag to disable authentication in app in CLI login command

### DIFF
--- a/src/commands/commandlogin.h
+++ b/src/commands/commandlogin.h
@@ -5,8 +5,6 @@
 #ifndef COMMANDLOGIN_H
 #define COMMANDLOGIN_H
 
-#define MZ_CLI_AUTHENTICATION_IN_APP
-
 #include "command.h"
 
 class CommandLogin final : public Command {


### PR DESCRIPTION
## Description

The CLI now implements its own authentication flow, independent of Feature_inAppAuthentication. We cannot rely on this feature flag to enable or disable authentication in the CLI because, on desktop, we may want AIA enabled for the CLI while disabled for the GUI.

Additionally, feature flags are loaded asynchronously. In the CLI context, we cannot depend on them since we would need to wait (somehow) for `TaskGetFeatureList` to complete before proceeding.

To avoid this, the CLI AIA flow is now enabled or disabled at compile time by a dedicated flag.  

## Reference

 [Jira Issue](https://mozilla-hub.atlassian.net/browse/VPN-7464)

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
