### PR TITLE
VPN-7468: Add workflow to upload release artifacts to github

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   gh-upload-artifacts:
     name: Upload artifacts
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       contents: write
     strategy:


### PR DESCRIPTION
## Description
There's an easier way to do this, we can just write a github workflow to fetch the release artifacts from taskcluster and upload them to the github release. This is a little bit crude in that we need to filter out a bunch of stuff from the taskcluster artifacts and it kind of winds up with too many artifacts being uploaded.

For example, I gave this a test run on my personal fork and it produced a release something like [this](https://github.com/oskirby/mozilla-vpn-client/releases/tag/v2.1.1)

## Reference
JIRA Issue: [VPN-7468](https://mozilla-hub.atlassian.net/browse/VPN-7468)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-7468]: https://mozilla-hub.atlassian.net/browse/VPN-7468?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ