### PR TITLE
VPN-7459 iOS voice over

### DIFF
--- a/src/ui/main.qml
+++ b/src/ui/main.qml
@@ -103,6 +103,7 @@ ApplicationWindow {
     MouseArea {
         anchors.fill: parent
         z: MZTheme.theme.maxZLevel
+        Accessible.ignored: true
         onPressed: (mouse) => {
             window.screenClicked(mouse.x, mouse.y)
             mouse.accepted = false

--- a/src/ui/screens/ScreenHome.qml
+++ b/src/ui/screens/ScreenHome.qml
@@ -12,8 +12,6 @@ import components 0.1
 MZScreenBase {
     objectName: "screenHome"
     id: screenHome
-    Accessible.name: MZI18n.ProductName
-    Accessible.role: Accessible.Client
 
     Component.onCompleted: () => {
         MZNavigator.addStackView(VPN.ScreenHome, getStack())


### PR DESCRIPTION
## Description

VoiceOver on iOS: There was a full screen frame saying "Mozilla VPN". When swiping through it, this came between the location bar and the bottom nav bar. But when trying to tap directly on the bottom nav bar, this frame usurped the tap. 

This fixes it. Most of the work is done in ScreenHome. And then the main.qml change is needed to allow direct VoiceOver taps onto the VPN activation switch.

(Claude helped hone in on some areas to focus on.)

## Reference

VPN-7459

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
