### PR TITLE
Re-enable hardware rendering on ChromeOS on Qt 6.10+

### DIFF
--- a/src/commands/commandui.cpp
+++ b/src/commands/commandui.cpp
@@ -162,9 +162,14 @@ int CommandUI::run(QStringList& tokens) {
   // Configure graphics rendering for Android
   QGuiApplication::setHighDpiScaleFactorRoundingPolicy(
       Qt::HighDpiScaleFactorRoundingPolicy::Round);
+  // Skip the workaround on Qt 6.10+
+  // if the underlying ChromeOS rendering bug
+  // resurfaces, re-evaluate after upgrading further.
+#  if QT_VERSION < QT_VERSION_CHECK(6, 10, 0)
   if (AndroidUtils::isChromeOSContext()) {
     QQuickWindow::setGraphicsApi(QSGRendererInterface::Software);
   }
+#  endif
 #endif
 
 #ifdef MZ_WINDOWS


### PR DESCRIPTION
## Description

This seems to fix the splash screen freeze on Chromebooks, probably because surfaceCreated callback arrives before the render loop is listening, or not at all under Qt 6.10.

## Reference

[VPN-7491](https://mozilla-hub.atlassian.net/browse/VPN-7491)

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed


[VPN-7491]: https://mozilla-hub.atlassian.net/browse/VPN-7491?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ