### PR TITLE
Add aarch64 balrog target for Windows

### DIFF
--- a/src/update/balrog.cpp
+++ b/src/update/balrog.cpp
@@ -38,7 +38,11 @@ bool verify_content_signature(const char* x5u_ptr, size_t x5u_length,
 }
 
 #if defined(MZ_WINDOWS)
+#  if defined(_M_ARM64) || defined(__aarch64__)
+constexpr const char* BALROG_WINDOWS_BUILD_TARGET = "WINNT_aarch64";
+#  else
 constexpr const char* BALROG_WINDOWS_BUILD_TARGET = "WINNT_x86_64";
+#  endif
 #elif defined(MZ_MACOS)
 constexpr const char* BALROG_MACOS_BUILD_TARGET = "Darwin_x86";
 #else


### PR DESCRIPTION
## Description

Basti has updated Balrog rule for the arm64 build, this fixes the URL on Windows arm systems accordingly.

## Reference

[VPN-7494](https://mozilla-hub.atlassian.net/browse/VPN-7494)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-7494]: https://mozilla-hub.atlassian.net/browse/VPN-7494?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ