### PR TITLE
VPN-7495: improve bottom of messages

### DIFF
--- a/nebula/ui/components/MZFlickable.qml
+++ b/nebula/ui/components/MZFlickable.qml
@@ -120,8 +120,21 @@ Flickable {
     function recalculateContentHeight() {
         //Absolute y coordinate position of the scroll view
         const absoluteYPosition = mapToItem(window.contentItem, 0, 0).y
+
+        var platformBottomBar;
+        switch (Qt.platform.os) {
+        case "ios":
+            platformBottomBar = 34 // This is not needed for touch ID phones, but those are a very small portion of users and will not hurt to have this.
+            break
+        case "android":
+            platformBottomBar = 48 // This should cover both gesture-based and 3 button navigation.
+            break
+        default:
+            platformBottomBar = 0
+        }
+
         //Portion of the screen that a view's contents can reside without interfering with the navbar
-        const contentSpace = window.height - MZTheme.theme.navBarHeightWithMargins
+        const contentSpace = window.height - MZTheme.theme.navBarHeightWithMargins - platformBottomBar
 
         //Checks if the flickable AND it's content interferes with the navbar area (bottom 146px for iOS, bottom 128px for other platforms)
         //If it does, we pad the flickable's contentHeight with whatever bottom padding is needed so that there is always 48px (aka theme.navBarTopMargin)


### PR DESCRIPTION
## Description

Somewhere along the way, we stopped considering the bottom navigation bar. This caused the bug - if content ended in that zone, we didn't get scrolling. (I confirming this by doubling the content size on `main` for a message that had the non-scrolling bug - and it worked again.) 

## Reference

VPN-7495

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
