### PR TITLE
Fix machine ID for Flatpak builds 

### DIFF
--- a/src/models/device.cpp
+++ b/src/models/device.cpp
@@ -22,6 +22,10 @@
 #  include <QRandomGenerator>
 #endif
 
+#ifdef MZ_FLATPAK
+#  include <QDBusConnection>
+#endif
+
 #ifdef MZ_IOS
 #  include "platforms/ios/iosutils.h"
 #elif MZ_MACOS
@@ -85,8 +89,11 @@ QString Device::currentDeviceName() {
 QString Device::uniqueDeviceId() {
 #if MZ_ANDROID
   return AndroidUtils::DeviceId();
-#endif
+#elif MZ_FLATPAK
+  return QDBusConnection::localMachineId();
+#else
   return QSysInfo::machineUniqueId();
+#endif
 }
 
 Device::Device() { MZ_COUNT_CTOR(Device); }


### PR DESCRIPTION
## Description

Use QDBusConnection::localMachineId() instead of QSysInfo::machineUniqueId() in uniqueDeviceId(). This should fix machine ID which is currently empty in Flatpak builds.

## Reference

[VPN-7496](https://mozilla-hub.atlassian.net/browse/VPN-7496)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-7496]: https://mozilla-hub.atlassian.net/browse/VPN-7496?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ