### PR TITLE
VPN-7498: fix server functional test: need longer to allow server to connect

### DIFF
--- a/tests/functional/testServers.js
+++ b/tests/functional/testServers.js
@@ -221,7 +221,7 @@ describe('Server', function() {
       });
 
       // Wait at least one second for the timer to tick passed zero.
-      await vpn.wait(1500);
+      await vpn.wait(2500);
       assert.notEqual(
           await vpn.getQueryProperty(
               queries.screenHome.CONNECTION_TIMER, 'connectionTime'),


### PR DESCRIPTION
## Description

The connection is taking a beat longer, and that causes the timer to read 0:00:00 when we expect it to be at at least 0:00:01. To fix this failure, adding a s lightly longer pause here.

## Reference

VPN-7498

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
