### PR TITLE
add cmake version check to iOS

### DIFF
--- a/src/cmake/ios.cmake
+++ b/src/cmake/ios.cmake
@@ -90,6 +90,8 @@ find_library(FW_AUTHENTICATION_SERVICES AuthenticationServices)
 # This next section fixes a compile bug on iOS: https://qt-project.atlassian.net/browse/QTBUG-135978, found
 # via https://forum.qt.io/topic/162177/ios-objc-link-option-leads-to-duplicate-symbol-for-qtcore.framework/2
 # When the fix hits a version of Qt 6.10 we're using, we should be able to remove this section.
+# This flag requires cmake 3.29+.
+cmake_minimum_required(VERSION 3.29)
 if (POLICY CMP0156)
     message(STATUS "Setting CMP0156 policy to NEW...")
     set(QT_FORCE_CMP0156_TO_NEW ON CACHE BOOL "Force CMake policy CMP0156 to NEW behavior for Qt6")


### PR DESCRIPTION
## Description

This flag is only available on cmake 3.29+. The env file specifies a higher version, but if you're on a lower version you only realize you have a problem in the linking stage of the Xcode build. Let's fail the build earlier, and make it clearer why.

## Reference

N/A

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
