### PR TITLE
Improve release note script: Early exit if typo in string ID

### DIFF
--- a/scripts/utils/generate_release_notes.sh
+++ b/scripts/utils/generate_release_notes.sh
@@ -125,6 +125,12 @@ do
                   -t -m "/x:xliff/x:file/x:body/x:trans-unit[$BLOCK_ID]" \
                   -v "concat(x:target, '\n')" -n \
                   "$XLIFF_FILE")
+          if [[ "$POTENTIAL_TRANSLATION" == "" ]]; then
+            PARTIAL_ID=${BLOCK_ID#*\'}
+            STRING_ID=${PARTIAL_ID%\'*}
+            echo "Error: $STRING_ID not found."
+            exit 1
+          fi
           if [[ "$POTENTIAL_TRANSLATION" == "\n" ]]; then
               MISSING_TRANSLATION=true
           else


### PR DESCRIPTION
## Description

This script silently fails and inserts empty lines when the string ID isn't found (like when there is a typo). Let's fix this.

## Reference

N/A

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
