### PR TITLE
add platform condition for 2.34 addon

### DIFF
--- a/addons/message_whats_new_v2.34/manifest.json
+++ b/addons/message_whats_new_v2.34/manifest.json
@@ -4,6 +4,7 @@
   "name": "What's new message",
   "type": "message",
   "conditions": {
+    "platforms": ["macos", "windows", "linux", "android"],
     "min_client_version": "2.34.0",
     "max_client_version": "2.34.9"
 },


### PR DESCRIPTION
The update addon only goes out on desktop, so we just need to add a platform condition to this "what's new" addon.