### PR TITLE
Revert "add platform condition (#11117)"

### DIFF
--- a/addons/message_whats_new_v2.34/manifest.json
+++ b/addons/message_whats_new_v2.34/manifest.json
@@ -4,7 +4,6 @@
   "name": "What's new message",
   "type": "message",
   "conditions": {
-    "platforms": ["macos", "windows", "linux", "android"],
     "min_client_version": "2.34.0",
     "max_client_version": "2.34.9"
 },


### PR DESCRIPTION
This reverts commit 51dd9eabfec4b2e21557b47e68e7b4e3bfeb76aa.

That commit was not needed:
- That last PR was to only show “what’s new” on non-iOS platforms.
- You only see “what’s new” when you’ve installed 2.34
- iOS doesn’t have 2.34 released yet
- Thus there is no way for iOS clients to see “what’s new”

("Update to 2.34" addon is only for desktop, so iOS will not see that one either.)