### PR TITLE
VPN-7459 part 2: iOS VoiceOver improvements

### DIFF
--- a/nebula/ui/components/MZLinkButton.qml
+++ b/nebula/ui/components/MZLinkButton.qml
@@ -138,7 +138,8 @@ MZButtonBase {
             font.family: fontName
             wrapMode: Text.WordWrap
             opacity: loaderVisible ? 0 : 1
-            Accessible.ignored: !visible
+            // on iOS, without this the item is read twice - once as a button, once as a label
+            Accessible.ignored: !visible || Qt.platform.os === "ios"
             Behavior on color {
                 ColorAnimation {
                     duration: 200

--- a/nebula/ui/components/MZSettingsItem.qml
+++ b/nebula/ui/components/MZSettingsItem.qml
@@ -51,6 +51,7 @@ MZClickableRow {
         MZBoldLabel {
             id: title
             text: settingTitle
+            Accessible.ignored: true
             Layout.alignment: Qt.AlignLeft | Qt.AlignVCenter
             verticalAlignment: Text.AlignVCenter
             horizontalAlignment: Text.AlignLeft

--- a/nebula/ui/components/MZViewBase.qml
+++ b/nebula/ui/components/MZViewBase.qml
@@ -20,7 +20,8 @@ Item {
    property alias _interactive: vpnFlickable.interactive
    property alias _contentHeight: vpnFlickable.contentHeight
 
-   Accessible.name: (_menuTitle.length > 0) ? _menuTitle : _accessibleName
+   // This adds an element on iOS that we don't want read by VoiceOver.
+   Accessible.name: Qt.platform.os === "ios" ? "" : ((_menuTitle.length > 0) ? _menuTitle : _accessibleName)
    Accessible.role: Accessible.Pane
 
    anchors {

--- a/nebula/ui/components/navigationBar/MZBottomNavigationBar.qml
+++ b/nebula/ui/components/navigationBar/MZBottomNavigationBar.qml
@@ -83,6 +83,7 @@ Rectangle {
                 enabled: root.visible
 
                 checked: buttonItem.checked
+                Accessible.selected: buttonItem.checked
             }
         }
     }


### PR DESCRIPTION
## Description

After https://github.com/mozilla-mobile/mozilla-vpn-client/pull/11091/, QA kicked this back as it still had issues for Messages and Settings. I've made a more general solution, but also have made it iOS-only. Most of the things I'm changing were done by a former engineer who had done a deep dive into Accessibility, and were needed for Android. I'm hesitant to mess with things that could affect other platforms' accessibility - hence the conservative iOS-only for most of this.

In addition to fixing the "tap to select bottom bar buttons" fixes, I've included a few other things that jumped out at me:
- "Sign Out" button was read twice - once for the label, once for the button
- Settings rows were read twice
- VoiceOver didn't share which bottom bar button was currently selected

## Reference

VPN-7459

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
