### PR TITLE
VPN-7450: Consider Android nav style when creating drawer height

### DIFF
--- a/android/vpnClient/src/main/java/org/mozilla/firefox/vpn/qt/VPNActivity.java
+++ b/android/vpnClient/src/main/java/org/mozilla/firefox/vpn/qt/VPNActivity.java
@@ -118,6 +118,16 @@ public class VPNActivity extends org.qtproject.qt.android.QtActivityBase {
     }
   }
 
+  public static int getNavigationBarHeight() {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R && instance != null) {
+      WindowMetrics windowMetrics = instance.getWindowManager().getCurrentWindowMetrics();
+      Insets insets = windowMetrics.getWindowInsets().getInsets(WindowInsets.Type.navigationBars());
+      float density = instance.getResources().getDisplayMetrics().density;
+      return Math.round(insets.bottom / density);
+    }
+    return 0;
+  }
+
   public static VPNActivity getInstance() {
     Log.d("VPNActivity", "getInstance");
     if(instance != null){

--- a/nebula/ui/components/MZBottomSheet.qml
+++ b/nebula/ui/components/MZBottomSheet.qml
@@ -8,6 +8,7 @@ import QtQuick.Layouts 1.14
 
 import components 0.1
 import Mozilla.Shared 1.0
+import Mozilla.VPN 1.0
 
 //SUMMARY: MZBottomSheet opens a drawer from the bottom of the screen showing it's contentItem
 
@@ -50,7 +51,8 @@ Loader {
 
     sourceComponent: Drawer {
         implicitWidth: window.width
-        implicitHeight: root.sizeToContent ? Math.min(contentItem.implicitHeight, maxSheetHeight) : maxSheetHeight
+        bottomPadding: Qt.platform.os === "android" ? VPNAndroidCommons.getNavigationBarHeight() : 0
+        implicitHeight: (root.sizeToContent ? Math.min(contentItem.implicitHeight, maxSheetHeight) : maxSheetHeight) + bottomPadding
 
         topPadding: 0
 

--- a/src/platforms/android/androidcommons.cpp
+++ b/src/platforms/android/androidcommons.cpp
@@ -231,3 +231,10 @@ void AndroidCommons::dismissSplashScreen() {
   QJniObject::callStaticMethod<void>("org/mozilla/firefox/vpn/qt/VPNActivity",
                                      "dismissSplashScreen", "()V");
 }
+
+// static
+int AndroidCommons::getNavigationBarHeight() {
+  return QJniObject::callStaticMethod<jint>(
+      "org/mozilla/firefox/vpn/qt/VPNActivity", "getNavigationBarHeight",
+      "()I");
+}

--- a/src/platforms/android/androidcommons.h
+++ b/src/platforms/android/androidcommons.h
@@ -40,6 +40,8 @@ class AndroidCommons final : public QObject {
   static void dispatchToMainThread(std::function<void()> callback);
 
   static void dismissSplashScreen();
+
+  static int getNavigationBarHeight();
 };
 
 #endif  // ANDROIDCOMMONS_H

--- a/src/ui/singletons/VPNAndroidCommons.h
+++ b/src/ui/singletons/VPNAndroidCommons.h
@@ -18,6 +18,10 @@ class VPNAndroidCommons : public QObject {
   Q_INVOKABLE int getAndroidApiLevel() {
     return AndroidCommons::getSDKVersion();
   }
+
+  Q_INVOKABLE int getNavigationBarHeight() {
+    return AndroidCommons::getNavigationBarHeight();
+  }
 };
 
 #endif  // VPNANDROIDCOMMONS_H


### PR DESCRIPTION
## Description

We didn't consider bottom padding appropriately. I don't know for sure if this is a Qt 6.10 thing or not. I spent a while (possibly too long) trying to make this work with SafeArea insets, and ultimately couldn't make it work. This seems like a sledgehammer, but it works.

Claude helped a bunch with this code. Along the journey, Claude also gave many wrong answers, and let me astray quite a bit.

## Reference

VPN-7450

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
