### PR TITLE
VPN-7485: fix iOS swipe color

### DIFF
--- a/nebula/ui/components/MZSwipeDelegate.qml
+++ b/nebula/ui/components/MZSwipeDelegate.qml
@@ -24,6 +24,10 @@ SwipeDelegate {
     }
 
     padding: 0
+    // These next 2 lines should not be needed, given prior line. But it fixes VPN-7485, and infuriatingly Qt themselves
+    // say it is sometimes needed in `note`: https://doc.qt.io/qt-6/qml-qtquick-controls-control.html#padding-prop
+    leftPadding: 0
+    rightPadding: 0
     clip: true
     hoverEnabled: true
     activeFocusOnTab: !blockClose


### PR DESCRIPTION
## Description

See comment in code - I really, really hate that this works. But it does:
<img width="263" alt="IMG_0032" src="https://github.com/user-attachments/assets/81c7c54e-8c2a-4348-b904-7aee8a79f4b9" />

## Reference

VPN-7485

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
