### PR TITLE
VPN-7523: fix crash when moving between staging and prod

### DIFF
--- a/src/ui/screens/getHelp/developerMenu/ViewDeveloperMenu.qml
+++ b/src/ui/screens/getHelp/developerMenu/ViewDeveloperMenu.qml
@@ -77,6 +77,60 @@ MZViewBase {
             }
         }
 
+        function maybeTurnOffStartOnBoot() {
+            if (MZSettings.startAtBoot) {
+              startOnBootDeactivated.visible = true;
+              // This settings change fixes a crash (VPN-7523)
+              MZSettings.startAtBoot = false;
+            }
+        }
+
+        MZContextualAlerts {
+            id: restartRequired
+            visible: false
+            Layout.leftMargin: MZTheme.theme.windowMargin/2
+
+            messages: [
+                {
+                    type: MZContextualAlert.AlertType.Warning,
+                    message: MZI18n.SettingsDevRestartRequired,
+                }
+            ]
+
+            Connections {
+                target: MZSettings
+                function onStagingServerAddressChanged() {
+                    restartRequired.visible = true;
+                }
+                function onStagingServerChanged() {
+                    restartRequired.visible = true;
+                }
+            }
+        }
+
+        MZContextualAlerts {
+            id: startOnBootDeactivated
+            visible: false
+            Layout.leftMargin: MZTheme.theme.windowMargin/2
+
+            messages: [
+                {
+                    type: MZContextualAlert.AlertType.Warning,
+                    message: "'Connect VPN on startup' setting has been disabled",
+                }
+            ]
+
+            Connections {
+                target: MZSettings
+                function onStagingServerAddressChanged() {
+                    root.maybeTurnOffStartOnBoot();
+                }
+                function onStagingServerChanged() {
+                    root.maybeTurnOffStartOnBoot();
+                }
+            }
+        }
+
         MZCheckBoxRow {
             Layout.fillWidth: true
             Layout.topMargin: MZTheme.theme.windowMargin
@@ -180,7 +234,7 @@ MZViewBase {
             Layout.fillWidth: true
             Layout.preferredHeight: MZTheme.theme.rowHeight
 
-            visible: checkBoxRowStagingServer.isChecked && !restartRequired.isVisible
+            visible: checkBoxRowStagingServer.isChecked && !restartRequired.visible
 
             MZExternalLinkListItem {
                 id: inspectorLink
@@ -200,9 +254,8 @@ MZViewBase {
         }
 
         MZContextualAlerts {
-            id: restartRequired
-
-            property bool isVisible: false
+            id: restartRequiredForButtons
+            visible: false
 
             Layout.topMargin: MZTheme.theme.listSpacing
             Layout.leftMargin: MZTheme.theme.windowMargin/2
@@ -211,19 +264,8 @@ MZViewBase {
                 {
                     type: MZContextualAlert.AlertType.Warning,
                     message: MZI18n.SettingsDevRestartRequired,
-                    visible: isVisible
                 }
             ]
-
-            Connections {
-                target: MZSettings
-                function onStagingServerAddressChanged() {
-                    restartRequired.isVisible = true;
-                }
-                function onStagingServerChanged() {
-                    restartRequired.isVisible = true;
-                }
-            }
         }
 
         MZButton {
@@ -234,7 +276,7 @@ MZViewBase {
             text: "Reinstate messages"
             onClicked: {
                 MZAddonManager.reinstateMessages()
-                restartRequired.isVisible = true
+                restartRequiredForButtons.visible = true
             }
         }
 
@@ -244,7 +286,7 @@ MZViewBase {
             text: "View onboarding at next launch"
             onClicked: {
                 MZSettings.onboardingCompleted = false
-                restartRequired.isVisible = true
+                restartRequiredForButtons.visible = true
             }
         }
 


### PR DESCRIPTION
## Description

This PR does a few things:
- When needed, changes the "start on boot" setting when swapping environments - this fixes the crash. (There was some sort of race condition between activating the VPN and a guardian check that results in invalidating the current key. There is certainly a better fix than this, but as we discussed in this morning's meeting, this seems like the best path given it was a crash that only affects QA/dev.) 
- Alerts the user that this setting has been changed.
- Duplicates the "need to restart the client" warning, so that it is never hidden "below the fold" - it is always near the setting you just changed that activates it.
- Change the visibility architecture for these `MZContextualAlerts`s a bit, to better handle the vertical spacing.

<img width="160" alt="Screenshot" src="https://github.com/user-attachments/assets/f8ae5d7c-700b-4ec8-a30e-921c63c03ba5" />


## Reference

VPN-7523

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
