### PR TITLE
VPN-7525: Update ARM build hack branch

### DIFF
--- a/src/cmake/shared-sources.cmake
+++ b/src/cmake/shared-sources.cmake
@@ -177,7 +177,7 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux" OR
         file(APPEND ${CMAKE_BINARY_DIR}/cargo_home/config.toml
             "\n"
             "[patch.crates-io]\n"
-            "ring = { git = \"https://github.com/briansmith/ring\", branch = \"main\" }\n"
+            "ring = { git = \"https://github.com/briansmith/ring\", rev = \"e26dd862c9c2d08c6ed5ac9208be0e70c37de0c1\" }\n"
         )
     endif()
 endif()


### PR DESCRIPTION
## Description

https://github.com/briansmith/ring/pull/2216 was closed in favor of https://github.com/briansmith/ring/pull/2699, and the source branch was deleted. This updates it.

## Reference

VPN-7525

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
