### PR TITLE
Add staging addon with custom length

### DIFF
--- a/addons/message_staging_test_length/addLine.js
+++ b/addons/message_staging_test_length/addLine.js
@@ -1,0 +1,8 @@
+((api) => {
+  if (api.lineCount === undefined) api.lineCount = 0;
+  api.lineCount = api.lineCount + 1;
+  const id = 'dynamic_' + api.lineCount;
+  const block = api.addon.composer.create(
+      id, 'text', {content: 'This is a sample additional line of text.'});
+  api.addon.composer.insert(api.lineCount - 1, block);
+});

--- a/addons/message_staging_test_length/manifest.json
+++ b/addons/message_staging_test_length/manifest.json
@@ -1,0 +1,34 @@
+{
+  "api_version": "0.1",
+  "id": "message_staging_test_length",
+  "name": "Staging Test for Addon Length",
+  "translatable": false,
+  "type": "message",
+  "conditions": {
+    "env": "staging",
+    "translation_threshold": 0
+  },
+  "javascript": {
+    "enable": "setDate.js"
+  },
+  "message": {
+    "id": "message_staging_test_length",
+    "title": "Testing message length",
+    "subtitle": "This is for testing UI with various message lengths.",
+    "badge": "new_update",
+    "blocks": [
+      { "id": "c_add",
+        "type": "button",
+        "style": "primary",
+        "content": "Add line",
+        "javascript": "addLine.js"
+      },
+      { "id": "c_remove",
+        "type": "button",
+        "style": "destructive",
+        "content": "Remove line",
+        "javascript": "removeLine.js"
+      }
+    ]  
+  }
+}

--- a/addons/message_staging_test_length/removeLine.js
+++ b/addons/message_staging_test_length/removeLine.js
@@ -1,0 +1,5 @@
+((api) => {
+  if (!api.lineCount || api.lineCount === 0) return;
+  api.addon.composer.remove('dynamic_' + api.lineCount);
+  api.lineCount = api.lineCount - 1;
+});

--- a/addons/message_staging_test_length/setDate.js
+++ b/addons/message_staging_test_length/setDate.js
@@ -1,0 +1,3 @@
+(function(api) {
+api.addon.date = (api.settings.installationTime.getTime() / 1000) + 1800
+})


### PR DESCRIPTION
## Description

QA mentioned that they couldn't test VPN-7495, as it needs an addon that fills one screen almost exactly. So let's create a new addon staging tool. This lets you create an addon of any length you want, thanks to those buttons.

Claude helped with this.

<img width="162" alt="Screenshot" src="https://github.com/user-attachments/assets/22260cf7-1b2b-4931-902b-7e1d7a02c2fc" />

## Reference

VPN-7495, sort of

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
