### PR TITLE
VPN-7528 Fix connection health check not working on Android

### DIFF
--- a/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/VPNService.kt
+++ b/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/VPNService.kt
@@ -274,7 +274,7 @@ class VPNService : android.net.VpnService() {
             return JSONObject().apply {
                 putOpt("rx_bytes", getConfigValue("rx_bytes")?.toInt())
                 putOpt("tx_bytes", getConfigValue("tx_bytes")?.toInt())
-                putOpt("endpoint", mConfig?.getJSONObject("server")?.getString("ipv4Gateway"))
+                putOpt("endpoint", mConfig?.getJSONArray("servers")?.getJSONObject(currentServerConfig)?.getString("ipv4Gateway"))
                 putOpt("deviceIpv4", mConfig?.getJSONObject("device")?.getString("ipv4Address"))
             }
         }


### PR DESCRIPTION
## Description

Connection health check not working properly on Android due to a bug in `VPNService.kt` trying to access to non existent mConfig key “server”.

## Reference

[Jira issue](https://mozilla-hub.atlassian.net/browse/VPN-7528)

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
