### PR TITLE
VPN-7525: Update patched ring crate to fix aarch64-pc-windows-msvc builds

### DIFF
--- a/src/cmake/shared-sources.cmake
+++ b/src/cmake/shared-sources.cmake
@@ -171,8 +171,8 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux" OR
     target_link_libraries(shared-sources INTERFACE signature)
 
     # HACK: Patch in a fix for the ring compilation fail on windows/aarch64.
-    # This can be removed once https://github.com/briansmith/ring/pull/2216
-    # gets merged into mainline
+    # This can be removed once version 0.17.1600 is published to crates.io
+    # See: https://github.com/briansmith/ring/issues/2215
     if(CMAKE_C_COMPILER_TARGET STREQUAL "aarch64-pc-windows-msvc")
         file(APPEND ${CMAKE_BINARY_DIR}/cargo_home/config.toml
             "\n"


### PR DESCRIPTION
## Description
To make Windows/aarch64 builds work, we had to patch in a PR to the `ring` crate to fix compiler detection under cross-compilation. Well, that PR got merged into the `ring` main branch so we need to update what our patch/hack points to.

But wait, there's more! The version of the `ring` crate has also moved to an unreleased 0.17.1600 version, which means that we also have to run an extra `cargo update` step to make it work, or cargo will simply ignore the patched crate due to a version mismatch.

This should get things working again until 0.17.1600 is officially released to crates.io

## Reference
JIRA Issue: [VPN-7525](https://mozilla-hub.atlassian.net/browse/VPN-7525)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-7525]: https://mozilla-hub.atlassian.net/browse/VPN-7525?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ