### PR TITLE
Support IPv6-only networks on Windows

### DIFF
--- a/src/platforms/windows/daemon/windowsroutemonitor.cpp
+++ b/src/platforms/windows/daemon/windowsroutemonitor.cpp
@@ -435,6 +435,12 @@ bool WindowsRouteMonitor::addExclusionRoute(const IPAddress& prefix) {
   return true;
 }
 
+quint64 WindowsRouteMonitor::getExclusionRouteLuid(
+    const IPAddress& prefix) const {
+  MIB_IPFORWARD_ROW2* data = m_exclusionRoutes.value(prefix, nullptr);
+  return data ? data->InterfaceLuid.Value : 0;
+}
+
 bool WindowsRouteMonitor::deleteExclusionRoute(const IPAddress& prefix) {
   logger.debug() << "Deleting exclusion route for"
                  << logger.sensitive(prefix.address().toString());

--- a/src/platforms/windows/daemon/windowsroutemonitor.h
+++ b/src/platforms/windows/daemon/windowsroutemonitor.h
@@ -30,6 +30,8 @@ class WindowsRouteMonitor final : public QObject {
   bool deleteExclusionRoute(const IPAddress& prefix);
   void flushExclusionRoutes() { return flushRouteTable(m_exclusionRoutes); };
 
+  quint64 getExclusionRouteLuid(const IPAddress& prefix) const;
+
   quint64 getLuid() const { return m_luid; }
 
  public slots:

--- a/src/platforms/windows/daemon/wireguardutilswindows.cpp
+++ b/src/platforms/windows/daemon/wireguardutilswindows.cpp
@@ -368,6 +368,21 @@ bool WireguardUtilsWindows::deleteInterface() {
   return true;
 }
 
+static bool hasRouteToIPv4(const QString& ipv4addr) {
+  SOCKADDR_INET dest = {};
+  dest.Ipv4.sin_family = AF_INET;
+
+  if (InetPtonA(AF_INET, qPrintable(ipv4addr), &dest.Ipv4.sin_addr) != 1) {
+    return true;
+  }
+
+  MIB_IPFORWARD_ROW2 bestRoute = {};
+  SOCKADDR_INET bestSource = {};
+  DWORD result =
+      GetBestRoute2(nullptr, 0, nullptr, &dest, 0, &bestRoute, &bestSource);
+  return result == NO_ERROR;
+}
+
 bool WireguardUtilsWindows::updatePeer(const InterfaceConfig& config) {
   // Enable the windows firewall for this peer.
   if (!m_firewall->enablePeerTraffic(config)) {
@@ -384,16 +399,29 @@ bool WireguardUtilsWindows::updatePeer(const InterfaceConfig& config) {
   auto wgnt_conf = WireGuardNTConfig{.interface{.PeersCount = 1}};
   wgnt_conf.peer.PersistentKeepalive = WG_KEEPALIVE_PERIOD;
 
-  // TODO: We currently assume an ipv4 reachable endpoint
-  // we need to make sure this is the right decision.
-  wgnt_conf.peer.Endpoint.si_family = AF_INET;
-  wgnt_conf.peer.Endpoint.Ipv4.sin_family = AF_INET;
-  wgnt_conf.peer.Endpoint.Ipv4.sin_port = htons(config.m_serverPort);
+  // Prefer IPv4, but fall back to IPv6 on IPv6-only networks.
+  const bool useIPv4 = !config.m_serverIpv4AddrIn.isEmpty() &&
+                       (config.m_serverIpv6AddrIn.isEmpty() ||
+                        hasRouteToIPv4(config.m_serverIpv4AddrIn));
 
-  if (!inet_pton(AF_INET, qPrintable(config.m_serverIpv4AddrIn),
-                 &wgnt_conf.peer.Endpoint.Ipv4.sin_addr)) {
-    logger.error() << "Failed to parse m_serverIpv4AddrIn";
-    return false;
+  if (useIPv4) {
+    wgnt_conf.peer.Endpoint.si_family = AF_INET;
+    wgnt_conf.peer.Endpoint.Ipv4.sin_family = AF_INET;
+    wgnt_conf.peer.Endpoint.Ipv4.sin_port = htons(config.m_serverPort);
+    if (!InetPtonA(AF_INET, qPrintable(config.m_serverIpv4AddrIn),
+                   &wgnt_conf.peer.Endpoint.Ipv4.sin_addr)) {
+      logger.error() << "Failed to parse m_serverIpv4AddrIn";
+      return false;
+    }
+  } else {
+    wgnt_conf.peer.Endpoint.si_family = AF_INET6;
+    wgnt_conf.peer.Endpoint.Ipv6.sin6_family = AF_INET6;
+    wgnt_conf.peer.Endpoint.Ipv6.sin6_port = htons(config.m_serverPort);
+    if (!InetPtonA(AF_INET6, qPrintable(config.m_serverIpv6AddrIn),
+                   &wgnt_conf.peer.Endpoint.Ipv6.sin6_addr)) {
+      logger.error() << "Failed to parse m_serverIpv6AddrIn";
+      return false;
+    }
   }
 
   const auto peerPubKey = QByteArray::fromBase64Encoding(
@@ -410,7 +438,9 @@ bool WireguardUtilsWindows::updatePeer(const InterfaceConfig& config) {
       WIREGUARD_PEER_HAS_ENDPOINT | WIREGUARD_PEER_REPLACE_ALLOWED_IPS;
 
   logger.debug() << "Configuring peer" << logger.keys(config.m_serverPublicKey)
-                 << "via" << config.m_serverIpv4AddrIn;
+                 << "via"
+                 << (useIPv4 ? config.m_serverIpv4AddrIn
+                             : config.m_serverIpv6AddrIn);
 
   // Everything that has reached the wireguard adapter should be accepted
   wgnt_conf.peer.AllowedIPsCount = 2;
@@ -424,7 +454,9 @@ bool WireguardUtilsWindows::updatePeer(const InterfaceConfig& config) {
   }
   // Exclude the server address, except for multihop exit servers.
   if (m_routeMonitor && (config.m_hopType != InterfaceConfig::MultiHopExit)) {
-    m_routeMonitor->addExclusionRoute(IPAddress(config.m_serverIpv4AddrIn));
+    if (!config.m_serverIpv4AddrIn.isEmpty()) {
+      m_routeMonitor->addExclusionRoute(IPAddress(config.m_serverIpv4AddrIn));
+    }
     if (!config.m_serverIpv6AddrIn.isEmpty()) {
       m_routeMonitor->addExclusionRoute(IPAddress(config.m_serverIpv6AddrIn));
     }

--- a/src/platforms/windows/daemon/wireguardutilswindows.cpp
+++ b/src/platforms/windows/daemon/wireguardutilswindows.cpp
@@ -368,21 +368,6 @@ bool WireguardUtilsWindows::deleteInterface() {
   return true;
 }
 
-static bool hasRouteToIPv4(const QString& ipv4addr) {
-  SOCKADDR_INET dest = {};
-  dest.Ipv4.sin_family = AF_INET;
-
-  if (InetPtonA(AF_INET, qPrintable(ipv4addr), &dest.Ipv4.sin_addr) != 1) {
-    return true;
-  }
-
-  MIB_IPFORWARD_ROW2 bestRoute = {};
-  SOCKADDR_INET bestSource = {};
-  DWORD result =
-      GetBestRoute2(nullptr, 0, nullptr, &dest, 0, &bestRoute, &bestSource);
-  return result == NO_ERROR;
-}
-
 bool WireguardUtilsWindows::updatePeer(const InterfaceConfig& config) {
   // Enable the windows firewall for this peer.
   if (!m_firewall->enablePeerTraffic(config)) {
@@ -399,10 +384,23 @@ bool WireguardUtilsWindows::updatePeer(const InterfaceConfig& config) {
   auto wgnt_conf = WireGuardNTConfig{.interface{.PeersCount = 1}};
   wgnt_conf.peer.PersistentKeepalive = WG_KEEPALIVE_PERIOD;
 
+  bool hasIpv4 = true;
+
+  // Exclude the server address, except for multihop exit servers.
+  if (m_routeMonitor && (config.m_hopType != InterfaceConfig::MultiHopExit)) {
+    if (!config.m_serverIpv4AddrIn.isEmpty()) {
+      IPAddress serverIpv4(config.m_serverIpv4AddrIn);
+      m_routeMonitor->addExclusionRoute(serverIpv4);
+      hasIpv4 = m_routeMonitor->getExclusionRouteLuid(serverIpv4) != 0;
+    }
+    if (!config.m_serverIpv6AddrIn.isEmpty()) {
+      m_routeMonitor->addExclusionRoute(IPAddress(config.m_serverIpv6AddrIn));
+    }
+  }
+
   // Prefer IPv4, but fall back to IPv6 on IPv6-only networks.
   const bool useIPv4 = !config.m_serverIpv4AddrIn.isEmpty() &&
-                       (config.m_serverIpv6AddrIn.isEmpty() ||
-                        hasRouteToIPv4(config.m_serverIpv4AddrIn));
+                       (config.m_serverIpv6AddrIn.isEmpty() || hasIpv4);
 
   if (useIPv4) {
     wgnt_conf.peer.Endpoint.si_family = AF_INET;
@@ -451,15 +449,6 @@ bool WireguardUtilsWindows::updatePeer(const InterfaceConfig& config) {
                                          sizeof(wgnt_conf))) {
     logger.error() << "Failed setting Wireguard Adapter Config";
     return false;
-  }
-  // Exclude the server address, except for multihop exit servers.
-  if (m_routeMonitor && (config.m_hopType != InterfaceConfig::MultiHopExit)) {
-    if (!config.m_serverIpv4AddrIn.isEmpty()) {
-      m_routeMonitor->addExclusionRoute(IPAddress(config.m_serverIpv4AddrIn));
-    }
-    if (!config.m_serverIpv6AddrIn.isEmpty()) {
-      m_routeMonitor->addExclusionRoute(IPAddress(config.m_serverIpv6AddrIn));
-    }
   }
   return true;
 }

--- a/src/platforms/windows/windowspingsender.cpp
+++ b/src/platforms/windows/windowspingsender.cpp
@@ -66,10 +66,39 @@ struct ICMP_ECHO_REPLY_BUFFER {
 static_assert(sizeof(ICMP_ECHO_REPLY_BUFFER) == MinimumReplyBufferSize,
               "Fulfills the size requirements");
 
+/*
+ * IcmpSendEcho2 expects us to provide a Buffer that is
+ * at least this size
+ */
+constexpr size_t MinimumReplyBufferSize6 =
+    sizeof(ICMPV6_ECHO_REPLY) + WindowsPingPayloadSize + ICMP_ERR_SIZE +
+    sizeof(IO_STATUS_BLOCK);
+
+// Disable Packing, so the compiler does not add padding in this struct between
+// different sized types.
+#pragma pack(push, 1)
+struct ICMPV6_ECHO_REPLY_BUFFER {
+  ICMPV6_ECHO_REPLY reply;
+  quint16 payload;
+  std::array<char8_t, ICMP_ERR_SIZE> icmp_error;
+  IO_STATUS_BLOCK status;
+};
+#pragma pack(pop)
+
+// If the Size is not the MinimumReplyBufferSize, the compiler added
+// padding, so the fields will not be properly aligned with
+// what IcmpSendEcho2 will write.
+static_assert(sizeof(ICMPV6_ECHO_REPLY_BUFFER) == MinimumReplyBufferSize6,
+              "Fulfills the IPv6 size requirements");
+
 struct WindowsPingSenderPrivate {
   HANDLE m_handle;
   HANDLE m_event;
   ICMP_ECHO_REPLY_BUFFER m_replyBuffer;
+
+  HANDLE m_handle6;
+  HANDLE m_event6;
+  ICMPV6_ECHO_REPLY_BUFFER m_replyBuffer6;
 };
 
 namespace {
@@ -84,6 +113,12 @@ static DWORD icmpCleanupHelper(LPVOID data) {
   if (p->m_handle != INVALID_HANDLE_VALUE) {
     IcmpCloseHandle(p->m_handle);
   }
+  if (p->m_event6 != INVALID_HANDLE_VALUE) {
+    CloseHandle(p->m_event6);
+  }
+  if (p->m_handle6 != INVALID_HANDLE_VALUE) {
+    IcmpCloseHandle(p->m_handle6);
+  }
   delete p;
   return 0;
 }
@@ -94,20 +129,31 @@ WindowsPingSender::WindowsPingSender(const QHostAddress& source,
   MZ_COUNT_CTOR(WindowsPingSender);
   m_source = source;
   m_private = new struct WindowsPingSenderPrivate;
+
   m_private->m_handle = IcmpCreateFile();
   m_private->m_event = CreateEventA(NULL, FALSE, FALSE, NULL);
-
   m_notifier = new QWinEventNotifier(m_private->m_event, this);
   QObject::connect(m_notifier, &QWinEventNotifier::activated, this,
                    &WindowsPingSender::pingEventReady);
 
   m_private->m_replyBuffer = {};
+
+  m_private->m_handle6 = Icmp6CreateFile();
+  m_private->m_event6 = CreateEventA(NULL, FALSE, FALSE, NULL);
+  m_notifier6 = new QWinEventNotifier(m_private->m_event6, this);
+  QObject::connect(m_notifier6, &QWinEventNotifier::activated, this,
+                   &WindowsPingSender::pingEvent6Ready);
+
+  m_private->m_replyBuffer6 = {};
 }
 
 WindowsPingSender::~WindowsPingSender() {
   MZ_COUNT_DTOR(WindowsPingSender);
   if (m_notifier) {
     delete m_notifier;
+  }
+  if (m_notifier6) {
+    delete m_notifier6;
   }
   // Closing the ICMP handle can hang if there are lost ping replies. Moving
   // the cleanup into a separate thread avoids deadlocking the application.
@@ -120,34 +166,54 @@ WindowsPingSender::~WindowsPingSender() {
 }
 
 void WindowsPingSender::sendPing(const QHostAddress& dest, quint16 sequence) {
-  if (m_private->m_handle == INVALID_HANDLE_VALUE) {
-    return;
-  }
-  if (m_private->m_event == INVALID_HANDLE_VALUE) {
-    return;
-  }
+  if (dest.protocol() == QAbstractSocket::IPv6Protocol) {
+    if (m_private->m_handle6 == INVALID_HANDLE_VALUE) {
+      return;
+    }
+    if (m_private->m_event6 == INVALID_HANDLE_VALUE) {
+      return;
+    }
 
-  quint32 v4dst = dest.toIPv4Address();
-  if (m_source.isNull()) {
-    IcmpSendEcho2(m_private->m_handle,               // IcmpHandle,
-                  m_private->m_event,                // Event
-                  nullptr,                           // ApcRoutine
-                  nullptr,                           // ApcContext
-                  qToBigEndian<quint32>(v4dst),      // DestinationAddress
-                  &sequence,                         // RequestData
-                  sizeof(sequence),                  // RequestSize
-                  nullptr,                           // RequestOptions
-                  &m_private->m_replyBuffer,         // [OUT] ReplyBuffer
-                  sizeof(m_private->m_replyBuffer),  // ReplySize
-                  10000                              // Timeout
+    sockaddr_in6 dst6 = {};
+    dst6.sin6_family = AF_INET6;
+    Q_IPV6ADDR v6dst = dest.toIPv6Address();
+    memcpy(&dst6.sin6_addr, &v6dst, sizeof(dst6.sin6_addr));
+
+    sockaddr_in6 src6 = {};
+    src6.sin6_family = AF_INET6;
+    // Use the unspecified address (::) as source unless set.
+    if (!m_source.isNull()) {
+      Q_IPV6ADDR v6src = m_source.toIPv6Address();
+      memcpy(&src6.sin6_addr, &v6src, sizeof(src6.sin6_addr));
+    }
+
+    Icmp6SendEcho2(m_private->m_handle6,              // IcmpHandle
+                   m_private->m_event6,               // Event
+                   nullptr,                           // ApcRoutine
+                   nullptr,                           // ApcContext
+                   &src6,                             // SourceAddress
+                   &dst6,                             // DestinationAddress
+                   &sequence,                         // RequestData
+                   sizeof(sequence),                  // RequestSize
+                   nullptr,                           // RequestOptions
+                   &m_private->m_replyBuffer6,        // [OUT] ReplyBuffer
+                   sizeof(m_private->m_replyBuffer6), // ReplySize
+                   10000                              // Timeout
     );
   } else {
-    quint32 v4src = m_source.toIPv4Address();
-    IcmpSendEcho2Ex(m_private->m_handle,               // IcmpHandle
+    if (m_private->m_handle == INVALID_HANDLE_VALUE) {
+      return;
+    }
+    if (m_private->m_event == INVALID_HANDLE_VALUE) {
+      return;
+    }
+
+    quint32 v4dst = dest.toIPv4Address();
+    if (m_source.isNull()) {
+      IcmpSendEcho2(m_private->m_handle,               // IcmpHandle,
                     m_private->m_event,                // Event
                     nullptr,                           // ApcRoutine
                     nullptr,                           // ApcContext
-                    qToBigEndian<quint32>(v4src),      // SourceAddress
                     qToBigEndian<quint32>(v4dst),      // DestinationAddress
                     &sequence,                         // RequestData
                     sizeof(sequence),                  // RequestSize
@@ -155,7 +221,23 @@ void WindowsPingSender::sendPing(const QHostAddress& dest, quint16 sequence) {
                     &m_private->m_replyBuffer,         // [OUT] ReplyBuffer
                     sizeof(m_private->m_replyBuffer),  // ReplySize
                     10000                              // Timeout
-    );
+      );
+    } else {
+      quint32 v4src = m_source.toIPv4Address();
+      IcmpSendEcho2Ex(m_private->m_handle,               // IcmpHandle
+                      m_private->m_event,                // Event
+                      nullptr,                           // ApcRoutine
+                      nullptr,                           // ApcContext
+                      qToBigEndian<quint32>(v4src),      // SourceAddress
+                      qToBigEndian<quint32>(v4dst),      // DestinationAddress
+                      &sequence,                         // RequestData
+                      sizeof(sequence),                  // RequestSize
+                      nullptr,                           // RequestOptions
+                      &m_private->m_replyBuffer,         // [OUT] ReplyBuffer
+                      sizeof(m_private->m_replyBuffer),  // ReplySize
+                      10000                              // Timeout
+      );
+    }
   }
 
   DWORD status = GetLastError();
@@ -204,4 +286,28 @@ void WindowsPingSender::pingEventReady() {
          static_cast<PVOID>(&m_private->m_replyBuffer.payload));
 
   emit recvPing(m_private->m_replyBuffer.payload);
+}
+
+void WindowsPingSender::pingEvent6Ready() {
+  // Cleanup all data once we're done with m_replyBuffer6.
+  const auto guard = qScopeGuard([this]() { m_private->m_replyBuffer6 = {}; });
+
+  DWORD replyCount = Icmp6ParseReplies(&m_private->m_replyBuffer6,
+                                       sizeof(m_private->m_replyBuffer6));
+  if (replyCount == 0) {
+    DWORD error = GetLastError();
+    if (error == IP_REQ_TIMED_OUT) {
+      return;
+    }
+    QString errmsg = WindowsUtils::getErrorMessage();
+    logger.error() << "No IPv6 ping reply. Code: " << error
+                   << " Message: " << errmsg;
+    return;
+  }
+  if (replyCount != 1) {
+    logger.error() << "Invalid amount of IPv6 responses received";
+    return;
+  }
+
+  emit recvPing(m_private->m_replyBuffer6.payload);
 }

--- a/src/platforms/windows/windowspingsender.cpp
+++ b/src/platforms/windows/windowspingsender.cpp
@@ -187,18 +187,18 @@ void WindowsPingSender::sendPing(const QHostAddress& dest, quint16 sequence) {
       memcpy(&src6.sin6_addr, &v6src, sizeof(src6.sin6_addr));
     }
 
-    Icmp6SendEcho2(m_private->m_handle6,              // IcmpHandle
-                   m_private->m_event6,               // Event
-                   nullptr,                           // ApcRoutine
-                   nullptr,                           // ApcContext
-                   &src6,                             // SourceAddress
-                   &dst6,                             // DestinationAddress
-                   &sequence,                         // RequestData
-                   sizeof(sequence),                  // RequestSize
-                   nullptr,                           // RequestOptions
-                   &m_private->m_replyBuffer6,        // [OUT] ReplyBuffer
-                   sizeof(m_private->m_replyBuffer6), // ReplySize
-                   10000                              // Timeout
+    Icmp6SendEcho2(m_private->m_handle6,               // IcmpHandle
+                   m_private->m_event6,                // Event
+                   nullptr,                            // ApcRoutine
+                   nullptr,                            // ApcContext
+                   &src6,                              // SourceAddress
+                   &dst6,                              // DestinationAddress
+                   &sequence,                          // RequestData
+                   sizeof(sequence),                   // RequestSize
+                   nullptr,                            // RequestOptions
+                   &m_private->m_replyBuffer6,         // [OUT] ReplyBuffer
+                   sizeof(m_private->m_replyBuffer6),  // ReplySize
+                   10000                               // Timeout
     );
   } else {
     if (m_private->m_handle == INVALID_HANDLE_VALUE) {

--- a/src/platforms/windows/windowspingsender.h
+++ b/src/platforms/windows/windowspingsender.h
@@ -24,10 +24,12 @@ class WindowsPingSender final : public PingSender {
 
  private slots:
   void pingEventReady();
+  void pingEvent6Ready();
 
  private:
   QHostAddress m_source;
   QWinEventNotifier* m_notifier = nullptr;
+  QWinEventNotifier* m_notifier6 = nullptr;
   struct WindowsPingSenderPrivate* m_private = nullptr;
 };
 

--- a/src/serverlatency.cpp
+++ b/src/serverlatency.cpp
@@ -44,7 +44,8 @@ bool hasIPv4Connectivity() {
       continue;
     }
     for (const QNetworkAddressEntry& entry : iface.addressEntries()) {
-      if (entry.ip().protocol() == QAbstractSocket::IPv4Protocol) {
+      if (entry.ip().protocol() == QAbstractSocket::IPv4Protocol &&
+          !entry.ip().isLinkLocal()) {
         return true;
       }
     }


### PR DESCRIPTION
## Description

Support IPv6-only networks on Windows, basically mirroring the Linux implementation from #11171 .

One notable addition is a fix for latency measurement on IPv6-only network: hasIPv4Connectivity() would return true for APIPA addresses (169.254.x.x) on adapters with no IPv5 routing, causing ServerLatency to attempt IPv4 pings anyway.

## Reference

[VPN-4368](https://mozilla-hub.atlassian.net/browse/VPN-4368)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-4368]: https://mozilla-hub.atlassian.net/browse/VPN-4368?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ