### PR TITLE
Support IPv6-only networks on macOS

### DIFF
--- a/src/platforms/macos/daemon/macosroutemonitor.h
+++ b/src/platforms/macos/daemon/macosroutemonitor.h
@@ -27,6 +27,7 @@ class MacosRouteMonitor final : public QObject {
   bool insertRoute(const IPAddress& prefix, int flags = 0);
   bool deleteRoute(const IPAddress& prefix, int flags = 0);
   int interfaceFlags() { return m_ifflags; }
+  bool hasIpv4DefaultRoute() const { return m_defaultIfindexIpv4 != 0; }
 
   bool addExclusionRoute(const IPAddress& prefix);
   bool deleteExclusionRoute(const IPAddress& prefix);

--- a/src/platforms/macos/daemon/wireguardutilsmacos.cpp
+++ b/src/platforms/macos/daemon/wireguardutilsmacos.cpp
@@ -8,8 +8,6 @@
 #include <Security/SecRequirement.h>
 #include <Security/SecStaticCode.h>
 #include <Security/SecTask.h>
-#include <arpa/inet.h>
-#include <errno.h>
 #include <net/route.h>
 
 #include <QByteArray>
@@ -30,29 +28,6 @@ constexpr const char* WG_RUNTIME_DIR = "/var/run/wireguard";
 namespace {
 Logger logger("WireguardUtilsMacos");
 Logger logwireguard("WireguardGo");
-
-static bool hasRouteToIPv4(const QString& ipv4addr) {
-  int sock = ::socket(AF_INET, SOCK_DGRAM, 0);
-
-  if (sock < 0) {
-    return true;
-  }
-
-  auto guard = qScopeGuard([sock] { ::close(sock); });
-
-  struct sockaddr_in dest {};
-  dest.sin_len = sizeof(dest);
-  dest.sin_family = AF_INET;
-  dest.sin_port = htons(1);
-
-  if (::inet_pton(AF_INET, qPrintable(ipv4addr), &dest.sin_addr) != 1) {
-    return true;
-  }
-
-  int rc =
-      ::connect(sock, reinterpret_cast<struct sockaddr*>(&dest), sizeof(dest));
-  return rc == 0 || (errno != ENETUNREACH && errno != EHOSTUNREACH);
-}
 };  // namespace
 
 WireguardUtilsMacos::WireguardUtilsMacos(QObject* parent)
@@ -321,7 +296,7 @@ bool WireguardUtilsMacos::updatePeer(const InterfaceConfig& config) {
 
   const bool useIPv4 = !config.m_serverIpv4AddrIn.isNull() &&
                        (config.m_serverIpv6AddrIn.isNull() ||
-                        hasRouteToIPv4(config.m_serverIpv4AddrIn));
+                        m_rtmonitor->hasIpv4DefaultRoute());
   const QString endpointAddr =
       useIPv4 ? config.m_serverIpv4AddrIn : config.m_serverIpv6AddrIn;
 

--- a/src/platforms/macos/daemon/wireguardutilsmacos.cpp
+++ b/src/platforms/macos/daemon/wireguardutilsmacos.cpp
@@ -41,6 +41,7 @@ static bool hasRouteToIPv4(const QString& ipv4addr) {
   auto guard = qScopeGuard([sock] { ::close(sock); });
 
   struct sockaddr_in dest {};
+  dest.sin_len = sizeof(dest);
   dest.sin_family = AF_INET;
   dest.sin_port = htons(1);
 

--- a/src/platforms/macos/daemon/wireguardutilsmacos.cpp
+++ b/src/platforms/macos/daemon/wireguardutilsmacos.cpp
@@ -8,11 +8,13 @@
 #include <Security/SecRequirement.h>
 #include <Security/SecStaticCode.h>
 #include <Security/SecTask.h>
+#include <arpa/inet.h>
 #include <errno.h>
 #include <net/route.h>
 
 #include <QByteArray>
 #include <QDir>
+#include <QScopeGuard>
 #include <QFile>
 #include <QLocalSocket>
 #include <QSysInfo>
@@ -28,6 +30,28 @@ constexpr const char* WG_RUNTIME_DIR = "/var/run/wireguard";
 namespace {
 Logger logger("WireguardUtilsMacos");
 Logger logwireguard("WireguardGo");
+
+static bool hasRouteToIPv4(const QString& ipv4addr) {
+  int sock = ::socket(AF_INET, SOCK_DGRAM, 0);
+
+  if (sock < 0) {
+    return true;
+  }
+
+  auto guard = qScopeGuard([sock] { ::close(sock); });
+
+  struct sockaddr_in dest{};
+  dest.sin_family = AF_INET;
+  dest.sin_port = htons(1);
+
+  if (::inet_pton(AF_INET, qPrintable(ipv4addr), &dest.sin_addr) != 1) {
+    return true;
+  }
+
+  int rc =
+      ::connect(sock, reinterpret_cast<struct sockaddr*>(&dest), sizeof(dest));
+  return rc == 0 || (errno != ENETUNREACH && errno != EHOSTUNREACH);
+}
 };  // namespace
 
 WireguardUtilsMacos::WireguardUtilsMacos(QObject* parent)
@@ -294,18 +318,24 @@ bool WireguardUtilsMacos::updatePeer(const InterfaceConfig& config) {
   QByteArray publicKey =
       QByteArray::fromBase64(qPrintable(config.m_serverPublicKey));
 
+  const bool useIPv4 = !config.m_serverIpv4AddrIn.isNull() &&
+                       (config.m_serverIpv6AddrIn.isNull() ||
+                        hasRouteToIPv4(config.m_serverIpv4AddrIn));
+  const QString endpointAddr =
+      useIPv4 ? config.m_serverIpv4AddrIn : config.m_serverIpv6AddrIn;
+
   logger.debug() << "Configuring peer" << logger.keys(config.m_serverPublicKey)
-                 << "via" << config.m_serverIpv4AddrIn;
+                 << "via" << endpointAddr;
 
   // Update/create the peer config
   QString message;
   QTextStream out(&message);
   out << "set=1\n";
   out << "public_key=" << QString(publicKey.toHex()) << "\n";
-  if (!config.m_serverIpv4AddrIn.isNull()) {
-    out << "endpoint=" << config.m_serverIpv4AddrIn << ":";
-  } else if (!config.m_serverIpv6AddrIn.isNull()) {
-    out << "endpoint=[" << config.m_serverIpv6AddrIn << "]:";
+  if (useIPv4) {
+    out << "endpoint=" << endpointAddr << ":";
+  } else if (!endpointAddr.isNull()) {
+    out << "endpoint=[" << endpointAddr << "]:";
   } else {
     logger.warning() << "Failed to create peer with no endpoints";
     return false;

--- a/src/platforms/macos/daemon/wireguardutilsmacos.cpp
+++ b/src/platforms/macos/daemon/wireguardutilsmacos.cpp
@@ -14,9 +14,9 @@
 
 #include <QByteArray>
 #include <QDir>
-#include <QScopeGuard>
 #include <QFile>
 #include <QLocalSocket>
+#include <QScopeGuard>
 #include <QSysInfo>
 #include <QTimer>
 #include <QVersionNumber>
@@ -40,7 +40,7 @@ static bool hasRouteToIPv4(const QString& ipv4addr) {
 
   auto guard = qScopeGuard([sock] { ::close(sock); });
 
-  struct sockaddr_in dest{};
+  struct sockaddr_in dest {};
   dest.sin_family = AF_INET;
   dest.sin_port = htons(1);
 

--- a/src/platforms/macos/macospingsender.cpp
+++ b/src/platforms/macos/macospingsender.cpp
@@ -190,15 +190,15 @@ void MacOSPingSender::socketReady() {
 
 void MacOSPingSender::icmp6SocketReady() {
   u_char packet[IP_MAXPACKET];
- 
+
   ssize_t rc =
       recv(m_socket6, packet, sizeof(packet), MSG_DONTWAIT | MSG_NOSIGNAL);
- 
+
   if (rc < (ssize_t)sizeof(struct icmp6_hdr)) {
     if (rc < 0) {
       logger.error() << "ICMPv6 recv failed:" << strerror(errno);
     }
- 
+
     return;
   }
 

--- a/src/platforms/macos/macospingsender.cpp
+++ b/src/platforms/macos/macospingsender.cpp
@@ -6,6 +6,7 @@
 
 #include <arpa/inet.h>
 #include <net/if.h>
+#include <netinet/icmp6.h>
 #include <netinet/in.h>
 #include <netinet/in_systm.h>
 #include <netinet/ip.h>
@@ -30,6 +31,40 @@ int identifier() { return (getpid() & 0xFFFF); }
 MacOSPingSender::MacOSPingSender(const QHostAddress& source, QObject* parent)
     : PingSender(parent) {
   MZ_COUNT_CTOR(MacOSPingSender);
+
+  if (source.protocol() == QAbstractSocket::IPv6Protocol) {
+    m_socket6 = socket(AF_INET6, SOCK_DGRAM, IPPROTO_ICMPV6);
+
+    if (m_socket6 < 0) {
+      logger.error() << "IPv6 socket creation failed";
+      return;
+    }
+
+    struct sockaddr_in6 addr6;
+    bzero(&addr6, sizeof(addr6));
+    addr6.sin6_family = AF_INET6;
+    addr6.sin6_len = sizeof(addr6);
+    Q_IPV6ADDR qaddr = source.toIPv6Address();
+    memcpy(&addr6.sin6_addr, &qaddr, sizeof(addr6.sin6_addr));
+
+    if (bind(m_socket6, (struct sockaddr*)&addr6, sizeof(addr6)) != 0) {
+      close(m_socket6);
+      m_socket6 = -1;
+      logger.error() << "IPv6 bind error:" << strerror(errno);
+      return;
+    }
+
+    struct icmp6_filter filter;
+    ICMP6_FILTER_SETBLOCKALL(&filter);
+    ICMP6_FILTER_SETPASS(ICMP6_ECHO_REPLY, &filter);
+    setsockopt(m_socket6, IPPROTO_ICMPV6, ICMP6_FILTER, &filter,
+               sizeof(filter));
+
+    m_notifier6 = new QSocketNotifier(m_socket6, QSocketNotifier::Read, this);
+    connect(m_notifier6, &QSocketNotifier::activated, this,
+            &MacOSPingSender::icmp6SocketReady);
+    return;
+  }
 
   if (getuid()) {
     m_socket = socket(AF_INET, SOCK_DGRAM, IPPROTO_ICMP);
@@ -65,12 +100,41 @@ MacOSPingSender::MacOSPingSender(const QHostAddress& source, QObject* parent)
 
 MacOSPingSender::~MacOSPingSender() {
   MZ_COUNT_DTOR(MacOSPingSender);
+
   if (m_socket >= 0) {
     close(m_socket);
+  }
+
+  if (m_socket6 >= 0) {
+    close(m_socket6);
   }
 }
 
 void MacOSPingSender::sendPing(const QHostAddress& dest, quint16 sequence) {
+  if (dest.protocol() == QAbstractSocket::IPv6Protocol) {
+    struct sockaddr_in6 addr6;
+    bzero(&addr6, sizeof(addr6));
+    addr6.sin6_family = AF_INET6;
+    addr6.sin6_len = sizeof(addr6);
+    Q_IPV6ADDR qaddr = dest.toIPv6Address();
+    memcpy(&addr6.sin6_addr, &qaddr, sizeof(addr6.sin6_addr));
+
+    struct icmp6_hdr packet;
+    bzero(&packet, sizeof(packet));
+    packet.icmp6_type = ICMP6_ECHO_REQUEST;
+    packet.icmp6_id = identifier();
+    packet.icmp6_seq = htons(sequence);
+
+    if (sendto(m_socket6, &packet, sizeof(packet), MSG_NOSIGNAL,
+               (struct sockaddr*)&addr6,
+               sizeof(addr6)) != (ssize_t)sizeof(packet)) {
+      logger.error() << "IPv6 ping sending failed:" << strerror(errno);
+      emit criticalPingError();
+    }
+
+    return;
+  }
+
   quint32 ipv4dest = dest.toIPv4Address();
   struct sockaddr_in addr;
   bzero(&addr, sizeof(addr));
@@ -121,5 +185,27 @@ void MacOSPingSender::socketReady() {
 
   if (icmp->icmp_type == ICMP_ECHOREPLY && icmp->icmp_id == identifier()) {
     emit recvPing(htons(icmp->icmp_seq));
+  }
+}
+
+void MacOSPingSender::icmp6SocketReady() {
+  u_char packet[IP_MAXPACKET];
+ 
+  ssize_t rc =
+      recv(m_socket6, packet, sizeof(packet), MSG_DONTWAIT | MSG_NOSIGNAL);
+ 
+  if (rc < (ssize_t)sizeof(struct icmp6_hdr)) {
+    if (rc < 0) {
+      logger.error() << "ICMPv6 recv failed:" << strerror(errno);
+    }
+ 
+    return;
+  }
+
+  struct icmp6_hdr icmp6;
+  memcpy(&icmp6, packet, sizeof(icmp6));
+
+  if (icmp6.icmp6_type == ICMP6_ECHO_REPLY && icmp6.icmp6_id == identifier()) {
+    emit recvPing(htons(icmp6.icmp6_seq));
   }
 }

--- a/src/platforms/macos/macospingsender.h
+++ b/src/platforms/macos/macospingsender.h
@@ -17,16 +17,19 @@ class MacOSPingSender final : public PingSender {
   MacOSPingSender(const QHostAddress& source, QObject* parent = nullptr);
   ~MacOSPingSender();
 
-  bool isValid() override { return (m_socket >= 0); };
+  bool isValid() override { return (m_socket >= 0) || (m_socket6 >= 0); };
 
   void sendPing(const QHostAddress& dest, quint16 sequence) override;
 
  private slots:
   void socketReady();
+  void icmp6SocketReady();
 
  private:
   QSocketNotifier* m_notifier = nullptr;
+  QSocketNotifier* m_notifier6 = nullptr;
   int m_socket = -1;
+  int m_socket6 = -1;
 };
 
 #endif  // MACOSPINGSENDER_H

--- a/src/serverlatency.cpp
+++ b/src/serverlatency.cpp
@@ -44,7 +44,8 @@ bool hasIPv4Connectivity() {
       continue;
     }
     for (const QNetworkAddressEntry& entry : iface.addressEntries()) {
-      if (entry.ip().protocol() == QAbstractSocket::IPv4Protocol) {
+      if (entry.ip().protocol() == QAbstractSocket::IPv4Protocol &&
+          !entry.ip().isLinkLocal()) {
         return true;
       }
     }


### PR DESCRIPTION
## Description

Add IPv6-only network support for macOS, following the Linux support added in #11171

ICMPv6 ping support in MacOSPingSender, in particular `icmp6SocketReady()` is a bit simplified compared to IPv4 implementation, as  IPv6 never includes the IP header in received data so no header-skipping required.

## Reference

[VPN-4369](https://mozilla-hub.atlassian.net/browse/VPN-4369)

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed


[VPN-4369]: https://mozilla-hub.atlassian.net/browse/VPN-4369?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ