### PR TITLE
fix typos to allow Android RC builds

### DIFF
--- a/taskcluster/kinds/beetmover-promote/kind.yml
+++ b/taskcluster/kinds/beetmover-promote/kind.yml
@@ -39,14 +39,14 @@ tasks:
             build-type: android/armv7
     android-x86:
         requires-level: 3
-        release-artifacts: [mozillavpn-x86-release.apk, mozillavpn-foss-armeabi-v7a-release.apk]
+        release-artifacts: [mozillavpn-x86-release.apk, mozillavpn-foss-x86-release.apk]
         dependencies:
             signing: signing-android-x86/release
         attributes:
             build-type: android/x86
     android-x64:
         requires-level: 3
-        release-artifacts: [mozillavpn-x86_64-release.apk, mozillavpn-foss-armeabi-v7a-release.apk]
+        release-artifacts: [mozillavpn-x86_64-release.apk, mozillavpn-foss-x86_64-release.apk]
         dependencies:
             signing: signing-android-x64/release
         attributes:


### PR DESCRIPTION
In today's edition of "release automation fails in unexpected ways we have never seen before on VPN team", it seems like we had a typo in a recent update. It causes these two jobs to fail in the release process:
https://firefox-ci-tc.services.mozilla.com/tasks/JTUth8DySYuEBGT_xhmVpg
https://firefox-ci-tc.services.mozilla.com/tasks/Cf4PMDX6T8SQgJQjIgX1CQ

After this is merged, it will be updated to the 2.36.0 release branch.