### PR TITLE
Mark IPv6 test socket with WG_FIREWALL_MARK on Linux

### DIFF
--- a/src/platforms/linux/daemon/wireguardutilslinux.cpp
+++ b/src/platforms/linux/daemon/wireguardutilslinux.cpp
@@ -203,6 +203,15 @@ static bool hasRouteToIPv4(const QString& ipv4addr) {
 
   auto guard = qScopeGuard([sock] { ::close(sock); });
 
+  // Mark the socket with WG_FIREWALL_MARK to bypass the VPN routing table to
+  // ensure the VPN's 0.0.0.0/0 route doesn't produce a false positive on
+  // IPv6-only network
+  uint32_t mark = WG_FIREWALL_MARK;
+  if (::setsockopt(sock, SOL_SOCKET, SO_MARK, &mark, sizeof(mark)) < 0) {
+    logger.warning() << "Failed to set SO_MARK on test socket:"
+                     << strerror(errno);
+  }
+
   struct sockaddr_in dest {};
   dest.sin_family = AF_INET;
   dest.sin_port = htons(1);


### PR DESCRIPTION
## Description

Fix server switching on an IPv6-only network.

When the VPN is already up, rule `not fwmark 0xca6c` causes unmasked sockets to find the VPN table's route 0.0.0.0/0 via moz0. On an ipv6-only network, WireGuard's own packets are marked to bypass VPN table, hit the main routing table and find no ipv4 route, causing handshake failure (as described in the linked JIRA ticket).

## Reference

[VPN-4367](https://mozilla-hub.atlassian.net/browse/VPN-4367)

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed


[VPN-4367]: https://mozilla-hub.atlassian.net/browse/VPN-4367?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ