### PR TITLE
VPN-7551: Add elide on server list

### DIFF
--- a/nebula/ui/components/MZRadioDelegate.qml
+++ b/nebula/ui/components/MZRadioDelegate.qml
@@ -15,6 +15,7 @@ RadioDelegate {
     property string accessibleName: ""
     property bool isRadioButtonLabelAccessible: true
     property var uiState: MZTheme.theme.uiState
+    property real labelRightPadding: 0
     readonly property int labelX: radioButton.anchors.margins + radioButton.implicitWidth + radioButtonLabel.anchors.leftMargin
 
     ButtonGroup.group: radioButtonGroup
@@ -143,11 +144,13 @@ RadioDelegate {
         anchors.left: radioButton.right
         anchors.right: parent.right
         anchors.leftMargin: 16 + radioButton.anchors.rightMargin
+        anchors.rightMargin: radioControl.labelRightPadding
 
         text: radioButtonLabelText
         lineHeightMode: Text.FixedHeight
         lineHeight: MZTheme.theme.labelLineHeight
-        wrapMode: Text.Wrap
+        wrapMode: Text.NoWrap
+        elide: Text.ElideRight
     }
 
     background: Rectangle {

--- a/src/ui/screens/home/servers/ServerCountry.qml
+++ b/src/ui/screens/home/servers/ServerCountry.qml
@@ -192,6 +192,8 @@ MZClickableRow {
                     // provides all the necessary information
                     isRadioButtonLabelAccessible: false
                     implicitWidth: parent.width
+                    // Reserve space for the latency indicator
+                    labelRightPadding: latencyIndicator.implicitWidth + MZTheme.theme.hSpacing
 
                     onClicked: {
                         if (!isAvailable) {


### PR DESCRIPTION
## Description

Server name overlaps on latency indicator icon with Japanese language, add right elide.

<img width="416" height="929" alt="Screenshot from 2026-04-20 14-39-49" src="https://github.com/user-attachments/assets/6490772c-7825-4100-bb63-60d8e02d9ba8" />


## Reference

[Jira Issue](https://mozilla-hub.atlassian.net/browse/VPN-7551)


## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
