### PR TITLE
Fix firewall inbound mark/clear mismatch on server switch

### DIFF
--- a/src/platforms/linux/daemon/wireguardutilslinux.cpp
+++ b/src/platforms/linux/daemon/wireguardutilslinux.cpp
@@ -284,6 +284,8 @@ bool WireguardUtilsLinux::updatePeer(const InterfaceConfig& config) {
     return false;
   }
 
+  m_peerEndpoints[config.m_serverPublicKey] = endpointAddr;
+
   // Set/update peer
   strncpy(device->name, WG_INTERFACE, IFNAMSIZ);
   device->flags = (wg_device_flags)0;
@@ -328,12 +330,9 @@ bool WireguardUtilsLinux::deletePeer(const InterfaceConfig& config) {
   }
 
   // Clear firewall settings for this server.
-  const bool useIPv4 = !config.m_serverIpv4AddrIn.isNull() &&
-                       (config.m_serverIpv6AddrIn.isNull() ||
-                        hasRouteToIPv4(config.m_serverIpv4AddrIn));
-  const QString endpointAddr =
-      useIPv4 ? config.m_serverIpv4AddrIn : config.m_serverIpv6AddrIn;
-  if (!m_firewall.clearInbound(endpointAddr)) {
+  const QString endpointAddr = m_peerEndpoints.take(config.m_serverPublicKey);
+
+  if (!endpointAddr.isEmpty() && !m_firewall.clearInbound(endpointAddr)) {
     return false;
   }
 

--- a/src/platforms/linux/daemon/wireguardutilslinux.h
+++ b/src/platforms/linux/daemon/wireguardutilslinux.h
@@ -5,6 +5,7 @@
 #ifndef WIREGUARDUTILSLINUX_H
 #define WIREGUARDUTILSLINUX_H
 
+#include <QHash>
 #include <QHostAddress>
 #include <QObject>
 #include <QSocketNotifier>
@@ -70,6 +71,10 @@ class WireguardUtilsLinux final : public WireguardUtils {
   // Excluded routes are not automatically removed when the interface goes down
   // therefore, we have to remove them manually in deleteInterface()
   QList<IPAddress> m_routesExcluded;
+
+  // Maps server public key to the endpoint address marked in updatePeer(),
+  // so we can clear that address in deletePeer()
+  QHash<QString, QString> m_peerEndpoints;
 
  private slots:
   void nlsockReady();


### PR DESCRIPTION
## Description

Multihop server switching on ipv6-only networks may break in some configurations, when `hasRouteToIPv4` in `deletePeer` returns a different result than it did in `updatePeer`, so `clearInbound` is called with an address that wasn't marked.

This is an attempt to fix it by tracking endpoint address actually passed to `markInbound`, so the addresses in `updatePeer` and `deletePeer` are the same.

A potentially cleaner fix would be to pass the endpoint address explicitly to `deletePeer`, rather than having `deletePeer` re-derive it, but that would require a larger refactor of WireguardUtils interface and all implementations.

## Reference

[VPN-4367](https://mozilla-hub.atlassian.net/browse/VPN-4367)

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed


[VPN-4367]: https://mozilla-hub.atlassian.net/browse/VPN-4367?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ