### PR TITLE
VPN-6371 Fix text wrapping on excluded apps list

### DIFF
--- a/nebula/ui/components/MZRadioDelegate.qml
+++ b/nebula/ui/components/MZRadioDelegate.qml
@@ -149,8 +149,7 @@ RadioDelegate {
         text: radioButtonLabelText
         lineHeightMode: Text.FixedHeight
         lineHeight: MZTheme.theme.labelLineHeight
-        wrapMode: Text.NoWrap
-        elide: Text.ElideRight
+        wrapMode: Text.Wrap
     }
 
     background: Rectangle {

--- a/src/ui/screens/settings/appPermissions/AppPermissionsList.qml
+++ b/src/ui/screens/settings/appPermissions/AppPermissionsList.qml
@@ -188,6 +188,7 @@ ColumnLayout {
                 spacing: MZTheme.theme.windowMargin
                 opacity: enabled ? 1.0 : 0.5
                 Layout.preferredHeight: MZTheme.theme.navBarTopMargin
+                width: listView.width
 
                 function handleClick() {
                     VPNAppPermissions.flip(appID)


### PR DESCRIPTION
## Description

Fix text wrapping on excluded app list

<img width="732" height="266" alt="Screenshot from 2026-04-23 13-06-39" src="https://github.com/user-attachments/assets/4cc77c7c-9ec8-4cd5-b2a5-37fc8bfc51f5" />


Also: restore text wrapping for city names. When fixing the right padding issue in #11219 i replaced wrapping with right truncation. This is incorrect, restore text wrapping as intended.

<img width="393" height="150" alt="Screenshot from 2026-04-23 13-24-09" src="https://github.com/user-attachments/assets/65cb7e78-2550-470b-8fb6-82a3fc049763" />


## Reference

[Jira Issue](https://mozilla-hub.atlassian.net/browse/VPN-6371)

#9511 

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
