### PR TITLE
VPN-7563: bump content height for messages

### DIFF
--- a/nebula/ui/components/MZFlickable.qml
+++ b/nebula/ui/components/MZFlickable.qml
@@ -141,7 +141,7 @@ Flickable {
         //between the bottom of the flickable's content and the navbar
         if (vpnFlickable.addNavbarHeightOffset && absoluteYPosition + height >= contentSpace
                 && flickContentHeight + absoluteYPosition >= contentSpace) {
-            vpnFlickable.contentHeight = flickContentHeight + (flickContentHeight >= height ? MZTheme.theme.navBarHeightWithMargins : (absoluteYPosition + flickContentHeight) - contentSpace + (height - flickContentHeight))
+            vpnFlickable.contentHeight = flickContentHeight + (flickContentHeight >= height ? MZTheme.theme.navBarHeightWithMargins : (absoluteYPosition + flickContentHeight) - contentSpace + (height - flickContentHeight)) + 15
         }
         //If the navbar isn't visible, or the flickable's content does not interfere with the navbar area, don't worry about adding any padding
         else {


### PR DESCRIPTION
## Description

We had similar work in https://github.com/mozilla-mobile/mozilla-vpn-client/pull/11097/

See ticket for screenshot of bug.

This doesn't repro on my dev iPhone 13, but I do see it on my personal device (iPhone 15). They're similar-but-not-identically sized. We can't test this on simulator, and I don't have a dev device of iPhone 15 size. Thus, I'm suggesting an awful, awful hack: Just bump it up a *little* bit.

(As always, tapping the sign - This is the sort of thing we'd get for free with a native app.)

## Reference

VPN-7563

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
