### PR TITLE
Minor UI fixes

### DIFF
--- a/nebula/ui/components/MZExternalLinkListItem.qml
+++ b/nebula/ui/components/MZExternalLinkListItem.qml
@@ -23,9 +23,7 @@ MZClickableRow {
 
         MZBoldLabel {
             id: title
-        }
-
-        Item {
+            wrapMode: Text.Wrap
             Layout.fillWidth: true
         }
 

--- a/src/ui/screens/settings/ViewAboutUs.qml
+++ b/src/ui/screens/settings/ViewAboutUs.qml
@@ -161,6 +161,8 @@ MZViewBase {
             Layout.fillWidth: true
             Layout.leftMargin: MZTheme.theme.windowMargin
             Layout.rightMargin: MZTheme.theme.windowMargin
+            leftPadding: MZTheme.theme.iconSize * 1.5 + MZTheme.theme.windowMargin * 2
+            rightPadding: MZTheme.theme.windowMargin
 
             onClicked: {
                 listenForUpdateEvents=true;
@@ -171,10 +173,7 @@ MZViewBase {
             Image {
                 id:updateButtonImage
                 anchors {
-                    // TODO: The content item spans the whole Button
-                    // If we wish to align to the text, maybe we can get
-                    // the texts bounding box with "TextMetrics"?
-                    left: updateButton.contentItem.left
+                    left: updateButton.left
                     leftMargin: MZTheme.theme.windowMargin
                     verticalCenter: parent.verticalCenter
                 }


### PR DESCRIPTION
## Description

Fixes for:
VPN-6277 "Check for updates" button label has UI issues when the language is set to Russian or Ukrainian.

<img width="732" height="673" alt="out" src="https://github.com/user-attachments/assets/9a805e89-0016-4b10-a0cc-81c70ec657b6" />

VPN-4943 "Last option from Licenses has the title not wrapped" aka `MZExternalLinkListItem` does not wrap or elide text. 
Now it wraps.

<img width="732" height="673" alt="out" src="https://github.com/user-attachments/assets/3fbef15c-3e09-4536-bdc0-a6260b620174" />

## Reference

[VPN-6277](https://mozilla-hub.atlassian.net/browse/VPN-6277)
[VPN-4943](https://mozilla-hub.atlassian.net/browse/VPN-4943)

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed

[VPN-6277]: https://mozilla-hub.atlassian.net/browse/VPN-6277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[VPN-4943]: https://mozilla-hub.atlassian.net/browse/VPN-4943?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ