### PR TITLE
Fix typo in mac-signing configuration for network extension

### DIFF
--- a/taskcluster/kinds/signing/kind.yml
+++ b/taskcluster/kinds/signing/kind.yml
@@ -30,7 +30,7 @@ mac-signing:
           force: true
           entitlements: taskcluster/scripts/signing/networkextension-entitlements.xml
           globs:
-            - "/Contents/Library/SystemExtensionorg.mozilla.macos.FirefoxVPN.network-extension.systemextension"
+            - "/Contents/Library/SystemExtensions/org.mozilla.macos.FirefoxVPN.network-extension.systemextension"
 
         - deep: false
           runtime: true


### PR DESCRIPTION
## Description
I made a typo when setting up the taskcluster signing configuration for the network extension. Both the path was wrong - and I forgot the trailing slash.

This results in a signing failure, with a message something like this:

```
iscript.hardened_sign - WARNING - file pattern "/usr/local/builds/scriptworker/work/0/Mozilla VPN.app/Contents/Library/SystemExtensionorg.mozilla.macos.FirefoxVPN.network-extension.systemextension" matches no files
```

## Reference
JIRA Issue: [VPN-7096](https://mozilla-hub.atlassian.net/browse/VPN-7096)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-7096]: https://mozilla-hub.atlassian.net/browse/VPN-7096?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ