### PR TITLE
VPN-7096: Fix macOS codesigning for network extension support

### DIFF
--- a/taskcluster/mozillavpn_taskgraph/transforms/signing.py
+++ b/taskcluster/mozillavpn_taskgraph/transforms/signing.py
@@ -120,6 +120,10 @@ def add_hardened_sign_config(config, tasks):
                 "profile_name": "orgmozillamacosFirefoxVPN.provisionprofile",
                 "target_path": "/Contents/embedded.provisionprofile",
             },
+            {
+                "profile_name": "orgmozillamacosFirefoxVPNnetworkextension.provisionprofile",
+                "target_path": "/Contents/Library/SystemExtensions/org.mozilla.macos.FirefoxVPN.network-extension.systemextension/Contents/embedded.provisionprofile",
+            },
         ]
 
         task["worker"]["hardened-sign-config"] = hs_config

--- a/taskcluster/scripts/signing/entitlements.xml
+++ b/taskcluster/scripts/signing/entitlements.xml
@@ -31,7 +31,7 @@
 
 	<key>com.apple.developer.networking.networkextension</key>
 	<array>
-		<string>app-proxy-provider</string>
+		<string>app-proxy-provider-systemextension</string>
 	</array>
 
 	<key>com.apple.developer.system-extension.install</key>

--- a/taskcluster/scripts/signing/networkextension-entitlements.xml
+++ b/taskcluster/scripts/signing/networkextension-entitlements.xml
@@ -9,7 +9,7 @@
 	<string>43AQ936H96.org.mozilla.macos.FirefoxVPN.network-extension</string>
 	<key>com.apple.developer.networking.networkextension</key>
 	<array>
-		<string>app-proxy-provider</string>
+		<string>app-proxy-provider-systemextension</string>
 	</array>
 	<key>com.apple.developer.team-identifier</key>
 	<string>43AQ936H96</string>


### PR DESCRIPTION
## Description
It seems like the production macOS builds have some problems after the merge of #11199 and installation is failing due to unsatisfied entitlements:
  - `com.apple.developer.networking.networkextension`: This seems to fail because the production provisioning profile grants us `app-proxy-provider-systemextension`, but the app was signed with `app-proxy-provider`
  - `com.apple.developer.system-extension.install` is missing from the main bundle's provisioning profile.

And while we were in there, we also added a new provisioning profile for the network extension, which should now be accessible.

## Reference
JIRA Issue: [VPN-7096](https://mozilla-hub.atlassian.net/browse/VPN-7096)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-7096]: https://mozilla-hub.atlassian.net/browse/VPN-7096?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ