### PR TITLE
VPN-7596: early return when needed

### DIFF
--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -900,7 +900,16 @@ void Controller::maybeSendUpdatedConfig(const ServerData& serverData) {
     m_serverData = serverData;
     QList<InterfaceConfig> serverConfigs =
         setupConfigs(DoNotForceDNSPort, RandomizeServerSelection);
+    if (serverConfigs.isEmpty()) {
+      // Error in setupConfigs, so do not continue
+      // This most commonly happens when signing out -
+      // Controller::serverDataChanged is called because all settings emit a
+      // changed signal while updating the settings during sign out. However
+      // when signing out, there is no new server data to send.
+      return;
+    }
     Q_ASSERT(serverConfigs.size() == 1 || serverConfigs.size() == 2);
+
     InterfaceConfig exitConfig = serverConfigs.takeLast();
     InterfaceConfig entryConfig;
     if (!serverConfigs.isEmpty()) {

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -504,6 +504,7 @@ void Controller::activateInternal(
   QList<InterfaceConfig> serverConfigs =
       setupConfigs(dnsPort, serverSelectionPolicy);
   if (serverConfigs.isEmpty()) {
+    logger.info() << "Config setup error";
     // Error in setupConfigs, so do not continue
     return;
   }
@@ -906,6 +907,7 @@ void Controller::maybeSendUpdatedConfig(const ServerData& serverData) {
       // Controller::serverDataChanged is called because all settings emit a
       // changed signal while updating the settings during sign out. However
       // when signing out, there is no new server data to send.
+      logger.info() << "Error setting up configs";
       return;
     }
     Q_ASSERT(serverConfigs.size() == 1 || serverConfigs.size() == 2);


### PR DESCRIPTION
## Description

This was introduced a few days ago in https://github.com/mozilla-mobile/mozilla-vpn-client/pull/11206

When signing out, all settings emit `changed` signals. (TIL!) The `serverDataChanged` signal causes us to try to switch servers, but usually we stop due to the early return if `!isActive()` at the top of `Controller::switchServers`. Since we now try to send the config anyway on iOS (via `maybeSendUpdatedConfig(serverData)` before that early return): `setupConfigs` was  returning early (it was erroring out, essentially), so we were hitting this Q_ASSERT on the line after this. We should always return early here if we didn't get new server configs.

## Reference

VPN-7596

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
