### PR TITLE
QOL Fix: Add Type Registrations for VPN.*

### DIFF
--- a/scripts/cmake/whole-archive.cmake
+++ b/scripts/cmake/whole-archive.cmake
@@ -1,0 +1,36 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# link_whole_archive(<consumer> <dep>): force every .o in STATIC `dep`
+# into `consumer` so translation-unit static initializers (e.g.
+# Command::RegistrationProxy<…> in commands/command*.cpp,
+# DBusMetatypeRegistrationProxy in platforms/linux/linuxutils.cpp) are
+# not discarded by the linker.
+#
+# Can't use CMake's $<LINK_LIBRARY:WHOLE_ARCHIVE,…> (3.24+): it forbids
+# the same target appearing with and without the feature, and
+# libMozillavpn is transitively linked from mozillavpn-uiplugin without
+# it.
+
+function(link_whole_archive consumer dep)
+    if(MSVC)
+        # /WHOLEARCHIVE:<name> base-name matching fails under lld-link;
+        # pass the resolved archive path instead.
+        target_link_libraries(${consumer} PRIVATE ${dep})
+        target_link_options(${consumer} PRIVATE
+            "/WHOLEARCHIVE:$<TARGET_FILE:${dep}>"
+        )
+    elseif(APPLE)
+        target_link_libraries(${consumer} PRIVATE ${dep})
+        target_link_libraries(${consumer} PRIVATE
+            "-Wl,-force_load,$<TARGET_FILE:${dep}>"
+        )
+    else()
+        target_link_libraries(${consumer} PRIVATE
+            -Wl,--whole-archive
+            ${dep}
+            -Wl,--no-whole-archive
+        )
+    endif()
+endfunction()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,22 +14,6 @@ if(Qt6_VERSION VERSION_GREATER_EQUAL 6.10.0)
     find_package(Qt6 REQUIRED COMPONENTS GuiPrivate QmlPrivate)
 endif()
 
-target_link_libraries(mozillavpn PRIVATE
-    Qt6::Quick
-    Qt6::QuickControls2
-    Qt6::Test
-    Qt6::WebSockets
-    Qt6::Widgets
-    Qt6::Svg
-)
-
-if(NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Emscripten"
-   AND NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Android" )
-    target_link_libraries(mozillavpn PRIVATE
-        Qt6::NetworkAuth
-    )
-endif()
-
 if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
     set(MZ_PLATFORM_NAME "linux")
 elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
@@ -51,30 +35,67 @@ include(cmake/sources.cmake)
 add_subdirectory(inspector)
 add_subdirectory(utils)
 
-target_link_libraries(mozillavpn PRIVATE
+qt_add_qml_module(libMozillavpn
+    URI Mozilla.VPN.Cpp
+    VERSION 1.0
+    STATIC
+    NO_PLUGIN
+    NO_GENERATE_QMLDIR
+    OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/Mozilla/VPN/Cpp
+)
+mz_target_handle_warnings(libMozillavpn)
+target_link_libraries(libMozillavpn PRIVATE
     shared-sources
     mozillavpn-sources
+)
+
+target_link_libraries(libMozillavpn PUBLIC
     lottie
     mzutils
     nebula
     translations
+    Qt6::Quick
+    Qt6::QuickControls2
+    Qt6::Test
+    Qt6::WebSockets
+    Qt6::Widgets
+    Qt6::Svg
 )
+if(NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Emscripten"
+   AND NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Android" )
+    target_link_libraries(libMozillavpn PUBLIC Qt6::NetworkAuth)
+endif()
+
+target_compile_definitions(libMozillavpn PUBLIC
+    "MZ_$<UPPER_CASE:${MZ_PLATFORM_NAME}>"
+)
+if ((${CMAKE_SYSTEM_NAME} STREQUAL "Android") OR (${CMAKE_SYSTEM_NAME} STREQUAL "iOS"))
+    target_compile_definitions(libMozillavpn PUBLIC "MZ_MOBILE")
+endif()
+
+target_include_directories(libMozillavpn PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/ui/composer
+)
+
+target_include_directories(libMozillavpn PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}/addons
+    ${CMAKE_CURRENT_BINARY_DIR}
+)
+
+include(${CMAKE_SOURCE_DIR}/scripts/cmake/whole-archive.cmake)
+link_whole_archive(mozillavpn libMozillavpn)
 
 if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux" OR
    ${CMAKE_SYSTEM_NAME} STREQUAL "Windows" OR
    ${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
     add_subdirectory(webextension)
     add_subdirectory(interventions)
-    target_link_libraries(mozillavpn PRIVATE mz_webextension)
+    target_link_libraries(libMozillavpn PRIVATE mz_webextension)
 endif()
 
 target_link_libraries(mozillavpn PUBLIC ${CMAKE_DL_LIBS})
 
-if ((${CMAKE_SYSTEM_NAME} STREQUAL "Android") OR (${CMAKE_SYSTEM_NAME} STREQUAL "iOS"))
-    target_compile_definitions(mozillavpn PRIVATE "MZ_MOBILE")
-endif()
-
-target_compile_definitions(mozillavpn PRIVATE "MZ_$<UPPER_CASE:${MZ_PLATFORM_NAME}>")
 include(cmake/${MZ_PLATFORM_NAME}.cmake)
 
 

--- a/src/cmake/android.cmake
+++ b/src/cmake/android.cmake
@@ -10,11 +10,9 @@ if(QT_KNOWN_POLICY_QTP0002)
     qt_policy(SET QTP0002 OLD)
 endif()
 
-target_link_libraries(mozillavpn PRIVATE
-    Qt6::Test
-    Qt6::Xml)
+target_link_libraries(libMozillavpn PRIVATE Qt6::Xml)
 
-target_sources(mozillavpn PRIVATE
+target_sources(libMozillavpn PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/platforms/android/androidauthenticationlistener.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/platforms/android/androidauthenticationlistener.h
     ${CMAKE_CURRENT_SOURCE_DIR}/platforms/android/androidcontroller.cpp
@@ -78,5 +76,5 @@ option(MZ_ANDROID_FOSS_BUILD "Build apk without google play services" OFF)
 
 if(MZ_ANDROID_FOSS_BUILD)
     message(STATUS "Website build enabled")
-    target_compile_definitions(mozillavpn PRIVATE "MZ_ANDROID_FOSS_BUILD=1")
+    target_compile_definitions(libMozillavpn PUBLIC "MZ_ANDROID_FOSS_BUILD=1")
 endif()

--- a/src/cmake/linux.cmake
+++ b/src/cmake/linux.cmake
@@ -13,10 +13,10 @@ endif()
 option(BUILD_APPARMOR "Build AppArmor profile" ${DEFAULT_APPARMOR})
 
 find_package(Qt6 REQUIRED COMPONENTS DBus)
-target_link_libraries(mozillavpn PRIVATE Qt6::DBus)
+target_link_libraries(libMozillavpn PRIVATE Qt6::DBus)
 
 # Linux platform source files
-target_sources(mozillavpn PRIVATE
+target_sources(libMozillavpn PRIVATE
     ${CMAKE_SOURCE_DIR}/src/platforms/linux/dbustypes.h
     ${CMAKE_SOURCE_DIR}/src/platforms/linux/linuxappimageprovider.cpp
     ${CMAKE_SOURCE_DIR}/src/platforms/linux/linuxappimageprovider.h
@@ -46,7 +46,7 @@ target_sources(mozillavpn PRIVATE
 # needs the Gui internal header files on Qt 6.5.0 and later. Otherwise it
 # only works for X11.
 if(Qt6_VERSION VERSION_GREATER_EQUAL 6.5.0)
-    target_link_libraries(mozillavpn PRIVATE Qt6::GuiPrivate)
+    target_link_libraries(libMozillavpn PRIVATE Qt6::GuiPrivate)
 endif()
 
 if(NOT BUILD_FLATPAK)
@@ -56,21 +56,22 @@ if(NOT BUILD_FLATPAK)
     pkg_check_modules(polkit REQUIRED IMPORTED_TARGET polkit-gobject-1)
 
     if (QT_FEATURE_static)
-        target_link_libraries(mozillavpn PRIVATE ${LIBCAP_STATIC_LIBRARIES})
-        target_include_directories(mozillavpn PRIVATE ${LIBCAP_STATIC_INCLUDE_DIRS})
-        target_compile_options(mozillavpn PRIVATE ${LIBCAP_STATIC_CFLAGS})
+        target_link_libraries(libMozillavpn PRIVATE ${LIBCAP_STATIC_LIBRARIES})
+        target_include_directories(libMozillavpn PRIVATE ${LIBCAP_STATIC_INCLUDE_DIRS})
+        target_compile_options(libMozillavpn PRIVATE ${LIBCAP_STATIC_CFLAGS})
 
         find_package(Qt6 REQUIRED COMPONENTS WaylandClientPrivate)
+        # Plugins import into the executable, not the static lib.
         qt_import_plugins(mozillavpn INCLUDE Qt6::QWaylandIntegrationPlugin)
         qt_import_plugins(mozillavpn INCLUDE Qt6::QWaylandAdwaitaDecorationPlugin)
-        target_link_libraries(mozillavpn PRIVATE Qt6::WaylandClientPrivate)
+        target_link_libraries(libMozillavpn PRIVATE Qt6::WaylandClientPrivate)
     else()
-        target_link_libraries(mozillavpn PRIVATE PkgConfig::LIBCAP)
+        target_link_libraries(libMozillavpn PRIVATE PkgConfig::LIBCAP)
     endif()
 
-    target_link_libraries(mozillavpn PRIVATE PkgConfig::polkit)
+    target_link_libraries(libMozillavpn PRIVATE PkgConfig::polkit)
 
-    target_sources(mozillavpn PRIVATE
+    target_sources(libMozillavpn PRIVATE
         ${CMAKE_SOURCE_DIR}/src/platforms/linux/linuxcontroller.cpp
         ${CMAKE_SOURCE_DIR}/src/platforms/linux/linuxcontroller.h
         ${CMAKE_SOURCE_DIR}/src/platforms/linux/dbusclient.cpp
@@ -78,7 +79,7 @@ if(NOT BUILD_FLATPAK)
     )
 
     # Linux daemon source files
-    target_sources(mozillavpn PRIVATE
+    target_sources(libMozillavpn PRIVATE
         ${CMAKE_SOURCE_DIR}/3rdparty/wireguard-tools/contrib/embeddable-wg-library/wireguard.c
         ${CMAKE_SOURCE_DIR}/3rdparty/wireguard-tools/contrib/embeddable-wg-library/wireguard.h
         ${CMAKE_SOURCE_DIR}/src/platforms/linux/daemon/apptracker.cpp
@@ -98,7 +99,7 @@ if(NOT BUILD_FLATPAK)
         ${CMAKE_SOURCE_DIR}/src/platforms/linux/daemon/polkithelper.h
     )
 
-    target_compile_options(mozillavpn PRIVATE -DPROTOCOL_VERSION=\"1\")
+    target_compile_options(libMozillavpn PRIVATE -DPROTOCOL_VERSION=\"1\")
 
     set(DBUS_GENERATED_SOURCES)
     qt_add_dbus_interface(DBUS_GENERATED_SOURCES
@@ -108,17 +109,17 @@ if(NOT BUILD_FLATPAK)
         ${CMAKE_SOURCE_DIR}/src/platforms/linux/daemon/dbusservice.h
         ""
         dbus_adaptor)
-    target_sources(mozillavpn PRIVATE ${DBUS_GENERATED_SOURCES})
+    target_sources(libMozillavpn PRIVATE ${DBUS_GENERATED_SOURCES})
 
     include(${CMAKE_SOURCE_DIR}/scripts/cmake/golang.cmake)
     add_go_library(netfilter ${CMAKE_SOURCE_DIR}/linux/netfilter/netfilter.go)
-    target_link_libraries(mozillavpn PRIVATE netfilter)
+    target_link_libraries(libMozillavpn PRIVATE netfilter)
 else()
     # Linux source files for sandboxed builds
-    target_compile_definitions(mozillavpn PRIVATE MZ_FLATPAK)
+    target_compile_definitions(libMozillavpn PUBLIC MZ_FLATPAK)
 
     # Network Manager controller
-    target_sources(mozillavpn PRIVATE
+    target_sources(libMozillavpn PRIVATE
         ${CMAKE_SOURCE_DIR}/src/platforms/linux/netmgrtypes.h
         ${CMAKE_SOURCE_DIR}/src/platforms/linux/netmgrdevice.h
         ${CMAKE_SOURCE_DIR}/src/platforms/linux/netmgrdevice.cpp

--- a/src/cmake/macos.cmake
+++ b/src/cmake/macos.cmake
@@ -31,17 +31,17 @@ find_library(FW_USER_NOTIFICATIONS UserNotifications)
 find_library(FW_NW_EXTENSION NetworkExtension)
 find_library(FW_SYS_EXTENSION SystemExtensions)
 
-target_link_libraries(mozillavpn PRIVATE ${FW_SYSTEMCONFIG})
-target_link_libraries(mozillavpn PRIVATE ${FW_SERVICEMGMT})
-target_link_libraries(mozillavpn PRIVATE ${FW_SECURITY})
-target_link_libraries(mozillavpn PRIVATE ${FW_COREWLAN})
-target_link_libraries(mozillavpn PRIVATE ${FW_NETWORK})
-target_link_libraries(mozillavpn PRIVATE ${FW_USER_NOTIFICATIONS})
-target_link_libraries(mozillavpn PRIVATE ${FW_NW_EXTENSION})
-target_link_libraries(mozillavpn PRIVATE ${FW_SYS_EXTENSION})
+target_link_libraries(libMozillavpn PRIVATE ${FW_SYSTEMCONFIG})
+target_link_libraries(libMozillavpn PRIVATE ${FW_SERVICEMGMT})
+target_link_libraries(libMozillavpn PRIVATE ${FW_SECURITY})
+target_link_libraries(libMozillavpn PRIVATE ${FW_COREWLAN})
+target_link_libraries(libMozillavpn PRIVATE ${FW_NETWORK})
+target_link_libraries(libMozillavpn PRIVATE ${FW_USER_NOTIFICATIONS})
+target_link_libraries(libMozillavpn PRIVATE ${FW_NW_EXTENSION})
+target_link_libraries(libMozillavpn PRIVATE ${FW_SYS_EXTENSION})
 
 # MacOS platform source files
-target_sources(mozillavpn PRIVATE
+target_sources(libMozillavpn PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/platforms/macos/macosappimageprovider.h
     ${CMAKE_CURRENT_SOURCE_DIR}/platforms/macos/macosappimageprovider.mm
     ${CMAKE_CURRENT_SOURCE_DIR}/platforms/macos/macosapplistprovider.h
@@ -88,8 +88,8 @@ else()
 endif()
 
 # Enable Balrog for update support.
-target_compile_definitions(mozillavpn PRIVATE MVPN_BALROG)
-target_sources(mozillavpn PRIVATE
+target_compile_definitions(libMozillavpn PUBLIC MVPN_BALROG)
+target_sources(libMozillavpn PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/update/balrog.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/update/balrog.h
 )

--- a/src/cmake/wasm.cmake
+++ b/src/cmake/wasm.cmake
@@ -4,7 +4,7 @@
 
 list(APPEND QT_WASM_EXTRA_EXPORTED_METHODS ENV)
 
-target_sources(mozillavpn PRIVATE
+target_sources(libMozillavpn PRIVATE
      ${CMAKE_CURRENT_SOURCE_DIR}/platforms/macos/macosmenubar.cpp
      ${CMAKE_CURRENT_SOURCE_DIR}/platforms/macos/macosmenubar.h
      ${CMAKE_CURRENT_SOURCE_DIR}/platforms/wasm/wasmcontroller.cpp

--- a/src/cmake/windows.cmake
+++ b/src/cmake/windows.cmake
@@ -32,7 +32,7 @@ configure_file(../windows/version.rc.in ${CMAKE_CURRENT_BINARY_DIR}/version.rc)
 target_sources(mozillavpn PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/version.rc)
 
 # Windows platform source files
-target_sources(mozillavpn PRIVATE
+target_sources(libMozillavpn PRIVATE
      ${CMAKE_CURRENT_SOURCE_DIR}/platforms/windows/windowsapplistprovider.cpp
      ${CMAKE_CURRENT_SOURCE_DIR}/platforms/windows/windowsapplistprovider.h
      ${CMAKE_CURRENT_SOURCE_DIR}/platforms/windows/windowsappimageprovider.cpp
@@ -69,12 +69,12 @@ target_sources(mozillavpn PRIVATE
 if(Qt6_VERSION VERSION_GREATER_EQUAL 6.3.0)
     message(WARNING "Remove the Qt6 windows hack!")
 else()
-    target_sources(mozillavpn PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/ui/qt6winhack.qrc)
+    target_sources(libMozillavpn PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/ui/qt6winhack.qrc)
 endif()
 
 # Use Balrog for update support.
-target_compile_definitions(mozillavpn PRIVATE MVPN_BALROG)
-target_sources(mozillavpn PRIVATE
+target_compile_definitions(libMozillavpn PUBLIC MVPN_BALROG)
+target_sources(libMozillavpn PRIVATE
      ${CMAKE_CURRENT_SOURCE_DIR}/update/balrog.cpp
      ${CMAKE_CURRENT_SOURCE_DIR}/update/balrog.h
 )

--- a/src/commands/commandui.cpp
+++ b/src/commands/commandui.cpp
@@ -12,7 +12,6 @@
 #include <QWindow>
 #include <memory>
 
-#include "accessiblenotification.h"
 #include "addons/manager/addonmanager.h"
 #include "apppermission.h"
 #include "commandlineparser.h"
@@ -258,14 +257,6 @@ int CommandUI::run(QStringList& tokens) {
     }
     logger.debug() << "Added QML image provider";
 
-    qmlRegisterSingletonInstance("Mozilla.Shared", 1, 0,
-                                 "MZAccessibleNotification",
-                                 AccessibleNotification::instance());
-
-    // TODO: MZI18n should be moved to QmlEngineHolder but it requires extra
-    // work for the generation of i18nstrings.h/cpp for the unit-test app.
-    qmlRegisterSingletonInstance("Mozilla.Shared", 1, 0, "MZI18n",
-                                 I18nStrings::instance());
     logger.debug() << "Registered I18nStrings";
 
 #if MZ_IOS && QT_VERSION < 0x060300

--- a/src/platforms/ios/iosiaphandler.h
+++ b/src/platforms/ios/iosiaphandler.h
@@ -5,7 +5,6 @@
 #ifndef IOSIAPHANDLER_H
 #define IOSIAPHANDLER_H
 
-#include "Mozilla-Swift.h"
 #include "purchaseiaphandler.h"
 
 class IOSIAPHandler final : public PurchaseIAPHandler {

--- a/src/qmlengineholder.cpp
+++ b/src/qmlengineholder.cpp
@@ -10,26 +10,8 @@
 #include <QQmlNetworkAccessManagerFactory>
 #include <QWindow>
 
-#include "addons/manager/addonmanager.h"
-#include "authenticationinapp/authenticationinapp.h"
-#include "env.h"
-#include "errorhandler.h"
-#include "feature/featuremodel.h"
-#include "frontend/navigationbarmodel.h"
-#include "frontend/navigator.h"
 #include "leakdetector.h"
-#include "localizer.h"
-#include "loghandler.h"
-#include "models/licensemodel.h"
 #include "networkmanager.h"
-#include "settingsholder.h"
-#include "theme.h"
-#include "urlopener.h"
-#include "utils.h"
-
-#ifdef SENTRY_ENABLED
-#  include "sentry/sentryadapter.h"
-#endif
 
 #ifdef MZ_WINDOWS
 #  include <windows.h>
@@ -56,41 +38,6 @@ QmlEngineHolder::QmlEngineHolder(QQmlEngine* engine) : m_engine(engine) {
   Q_ASSERT(!s_instance);
   s_instance = this;
   engine->setNetworkAccessManagerFactory(new NMFactory(qApp));
-
-  qmlRegisterSingletonInstance("Mozilla.Shared", 1, 0, "MZAddonManager",
-                               AddonManager::instance());
-  qmlRegisterSingletonInstance("Mozilla.Shared", 1, 0, "MZAuthInApp",
-                               AuthenticationInApp::instance());
-#ifdef SENTRY_ENABLED
-  qmlRegisterSingletonInstance("Mozilla.Shared", 1, 0, "MZCrashReporter",
-                               SentryAdapter::instance());
-#endif
-  qmlRegisterSingletonInstance("Mozilla.Shared", 1, 0, "MZErrorHandler",
-                               ErrorHandler::instance());
-  qmlRegisterSingletonInstance("Mozilla.Shared", 1, 0, "MZEnv",
-                               Env::instance());
-  qmlRegisterSingletonInstance("Mozilla.Shared", 1, 0, "MZFeatureList",
-                               FeatureModel::instance());
-  qmlRegisterSingletonInstance("Mozilla.Shared", 1, 0, "MZLicenseModel",
-                               LicenseModel::instance());
-  qmlRegisterSingletonInstance("Mozilla.Shared", 1, 0, "MZLocalizer",
-                               Localizer::instance());
-  qmlRegisterSingletonInstance("Mozilla.Shared", 1, 0, "MZLog",
-                               LogHandler::instance());
-  qmlRegisterSingletonInstance("Mozilla.Shared", 1, 0, "MZNavigator",
-                               Navigator::instance());
-  qmlRegisterSingletonInstance("Mozilla.Shared", 1, 0, "MZNavigationBarModel",
-                               NavigationBarModel::instance());
-  qmlRegisterSingletonInstance("Mozilla.Shared", 1, 0, "MZSettings",
-                               SettingsHolder::instance());
-  qmlRegisterSingletonInstance("Mozilla.Shared", 1, 0, "MZUrlOpener",
-                               UrlOpener::instance());
-  qmlRegisterSingletonInstance("Mozilla.Shared", 1, 0, "MZUtils",
-                               Utils::instance());
-
-  Theme::instance()->initialize(engine);
-  qmlRegisterSingletonInstance("Mozilla.Shared", 1, 0, "MZTheme",
-                               Theme::instance());
 }
 
 QmlEngineHolder::~QmlEngineHolder() {

--- a/src/ui/CMakeLists.txt
+++ b/src/ui/CMakeLists.txt
@@ -124,6 +124,7 @@ qt_add_qml_module(mozillavpn-ui
         composer/composerblocktitle.h
         composer/composerblockunorderedlist.cpp
         composer/composerblockunorderedlist.h
+        singletons/BatteryOptimizer.h
         singletons/VPN.h
         singletons/VPNAppPermissions.h
         singletons/VPNCaptivePortal.h
@@ -146,6 +147,8 @@ qt_add_qml_module(mozillavpn-ui
 )
 
 target_link_libraries(mozillavpn-ui PRIVATE
+    libMozillavpn
+    mozillavpn-shared
     mzutils
     Qt6::Quick
     Qt6::Widgets
@@ -166,7 +169,49 @@ target_include_directories(mozillavpn-uiplugin PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/types
 )
 
-target_sources(mozillavpn-ui PRIVATE singletons/BatteryOptimizer.h)
+qt_add_qml_module(mozillavpn-shared
+    VERSION 1.0
+    URI Mozilla.Shared
+    RESOURCE_PREFIX /qt/qml
+    STATIC
+    OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/Mozilla/Shared
+    SOURCES
+        shared/MZAddonManager.h
+        shared/MZAuthInApp.h
+        shared/MZErrorHandler.h
+        shared/MZEnv.h
+        shared/MZFeatureList.h
+        shared/MZLicenseModel.h
+        shared/MZLocalizer.h
+        shared/MZLog.h
+        shared/MZNavigator.h
+        shared/MZNavigationBarModel.h
+        shared/MZSettings.h
+        shared/MZUrlOpener.h
+        shared/MZUtils.h
+        shared/MZAccessibleNotification.h
+        shared/MZI18n.h
+        shared/MZTheme.h
+)
+
+target_link_libraries(mozillavpn-shared PRIVATE
+    libMozillavpn
+    mzutils
+    Qt6::Quick
+)
+
+target_include_directories(mozillavpn-shared PRIVATE
+    ${CMAKE_SOURCE_DIR}/src
+    ${CMAKE_BINARY_DIR}/src/translations/generated
+)
+
+target_include_directories(mozillavpn-shared PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/shared
+)
+
+if(SENTRY_ENABLED)
+    target_sources(mozillavpn-shared PRIVATE shared/MZCrashReporter.h)
+endif()
 
 if(${CMAKE_SYSTEM_NAME} STREQUAL "Android")
     target_compile_definitions(mozillavpn-ui PRIVATE MZ_ANDROID)

--- a/src/ui/shared/MZAccessibleNotification.h
+++ b/src/ui/shared/MZAccessibleNotification.h
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#pragma once
+
+#include <QQmlEngine>
+
+#include "accessiblenotification.h"
+
+struct MZAccessibleNotification {
+  Q_GADGET
+  QML_FOREIGN(AccessibleNotification)
+  QML_NAMED_ELEMENT(MZAccessibleNotification)
+  QML_SINGLETON
+
+ public:
+  static AccessibleNotification* create(QQmlEngine*, QJSEngine*) {
+    return AccessibleNotification::instance();
+  }
+};

--- a/src/ui/shared/MZAddonManager.h
+++ b/src/ui/shared/MZAddonManager.h
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#pragma once
+
+#include <QQmlEngine>
+
+#include "addons/manager/addonmanager.h"
+
+struct MZAddonManager {
+  Q_GADGET
+  QML_FOREIGN(AddonManager)
+  QML_NAMED_ELEMENT(MZAddonManager)
+  QML_SINGLETON
+
+ public:
+  static AddonManager* create(QQmlEngine*, QJSEngine*) {
+    return AddonManager::instance();
+  }
+};

--- a/src/ui/shared/MZAuthInApp.h
+++ b/src/ui/shared/MZAuthInApp.h
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#pragma once
+
+#include <QQmlEngine>
+
+#include "authenticationinapp/authenticationinapp.h"
+
+struct MZAuthInApp {
+  Q_GADGET
+  QML_FOREIGN(AuthenticationInApp)
+  QML_NAMED_ELEMENT(MZAuthInApp)
+  QML_SINGLETON
+
+ public:
+  static AuthenticationInApp* create(QQmlEngine*, QJSEngine*) {
+    return AuthenticationInApp::instance();
+  }
+};

--- a/src/ui/shared/MZCrashReporter.h
+++ b/src/ui/shared/MZCrashReporter.h
@@ -1,0 +1,25 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#pragma once
+
+#ifdef SENTRY_ENABLED
+
+#  include <QQmlEngine>
+
+#  include "sentry/sentryadapter.h"
+
+struct MZCrashReporter {
+  Q_GADGET
+  QML_FOREIGN(SentryAdapter)
+  QML_NAMED_ELEMENT(MZCrashReporter)
+  QML_SINGLETON
+
+ public:
+  static SentryAdapter* create(QQmlEngine*, QJSEngine*) {
+    return SentryAdapter::instance();
+  }
+};
+
+#endif  // SENTRY_ENABLED

--- a/src/ui/shared/MZEnv.h
+++ b/src/ui/shared/MZEnv.h
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#pragma once
+
+#include <QQmlEngine>
+
+#include "env.h"
+
+struct MZEnv {
+  Q_GADGET
+  QML_FOREIGN(Env)
+  QML_NAMED_ELEMENT(MZEnv)
+  QML_SINGLETON
+
+ public:
+  static Env* create(QQmlEngine*, QJSEngine*) { return Env::instance(); }
+};

--- a/src/ui/shared/MZErrorHandler.h
+++ b/src/ui/shared/MZErrorHandler.h
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#pragma once
+
+#include <QQmlEngine>
+
+#include "errorhandler.h"
+
+struct MZErrorHandler {
+  Q_GADGET
+  QML_FOREIGN(ErrorHandler)
+  QML_NAMED_ELEMENT(MZErrorHandler)
+  QML_SINGLETON
+
+ public:
+  static ErrorHandler* create(QQmlEngine*, QJSEngine*) {
+    return ErrorHandler::instance();
+  }
+};

--- a/src/ui/shared/MZFeatureList.h
+++ b/src/ui/shared/MZFeatureList.h
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#pragma once
+
+#include <QQmlEngine>
+
+#include "feature/featuremodel.h"
+
+struct MZFeatureList {
+  Q_GADGET
+  QML_FOREIGN(FeatureModel)
+  QML_NAMED_ELEMENT(MZFeatureList)
+  QML_SINGLETON
+
+ public:
+  static FeatureModel* create(QQmlEngine*, QJSEngine*) {
+    return FeatureModel::instance();
+  }
+};

--- a/src/ui/shared/MZI18n.h
+++ b/src/ui/shared/MZI18n.h
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#pragma once
+
+#include <QQmlEngine>
+
+#include "i18nstrings.h"
+
+struct MZI18n {
+  Q_GADGET
+  QML_FOREIGN(I18nStrings)
+  QML_NAMED_ELEMENT(MZI18n)
+  QML_SINGLETON
+
+ public:
+  static I18nStrings* create(QQmlEngine*, QJSEngine*) {
+    return I18nStrings::instance();
+  }
+};

--- a/src/ui/shared/MZLicenseModel.h
+++ b/src/ui/shared/MZLicenseModel.h
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#pragma once
+
+#include <QQmlEngine>
+
+#include "models/licensemodel.h"
+
+struct MZLicenseModel {
+  Q_GADGET
+  QML_FOREIGN(LicenseModel)
+  QML_NAMED_ELEMENT(MZLicenseModel)
+  QML_SINGLETON
+
+ public:
+  static LicenseModel* create(QQmlEngine*, QJSEngine*) {
+    return LicenseModel::instance();
+  }
+};

--- a/src/ui/shared/MZLocalizer.h
+++ b/src/ui/shared/MZLocalizer.h
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#pragma once
+
+#include <QQmlEngine>
+
+#include "localizer.h"
+
+struct MZLocalizer {
+  Q_GADGET
+  QML_FOREIGN(Localizer)
+  QML_NAMED_ELEMENT(MZLocalizer)
+  QML_SINGLETON
+
+ public:
+  static Localizer* create(QQmlEngine*, QJSEngine*) {
+    return Localizer::instance();
+  }
+};

--- a/src/ui/shared/MZLog.h
+++ b/src/ui/shared/MZLog.h
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not needed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#pragma once
+
+#include <QQmlEngine>
+
+#include "utils/loghandler.h"
+
+struct MZLog {
+  Q_GADGET
+  QML_FOREIGN(LogHandler)
+  QML_NAMED_ELEMENT(MZLog)
+  QML_SINGLETON
+
+ public:
+  static LogHandler* create(QQmlEngine*, QJSEngine*) {
+    return LogHandler::instance();
+  }
+};

--- a/src/ui/shared/MZNavigationBarModel.h
+++ b/src/ui/shared/MZNavigationBarModel.h
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#pragma once
+
+#include <QQmlEngine>
+
+#include "frontend/navigationbarmodel.h"
+
+struct MZNavigationBarModel {
+  Q_GADGET
+  QML_FOREIGN(NavigationBarModel)
+  QML_NAMED_ELEMENT(MZNavigationBarModel)
+  QML_SINGLETON
+
+ public:
+  static NavigationBarModel* create(QQmlEngine*, QJSEngine*) {
+    return NavigationBarModel::instance();
+  }
+};

--- a/src/ui/shared/MZNavigator.h
+++ b/src/ui/shared/MZNavigator.h
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#pragma once
+
+#include <QQmlEngine>
+
+#include "frontend/navigator.h"
+
+struct MZNavigator {
+  Q_GADGET
+  QML_FOREIGN(Navigator)
+  QML_NAMED_ELEMENT(MZNavigator)
+  QML_SINGLETON
+
+ public:
+  static Navigator* create(QQmlEngine*, QJSEngine*) {
+    return Navigator::instance();
+  }
+};

--- a/src/ui/shared/MZSettings.h
+++ b/src/ui/shared/MZSettings.h
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#pragma once
+
+#include <QQmlEngine>
+
+#include "settingsholder.h"
+
+struct MZSettings {
+  Q_GADGET
+  QML_FOREIGN(SettingsHolder)
+  QML_NAMED_ELEMENT(MZSettings)
+  QML_SINGLETON
+
+ public:
+  static SettingsHolder* create(QQmlEngine*, QJSEngine*) {
+    return SettingsHolder::instance();
+  }
+};

--- a/src/ui/shared/MZTheme.h
+++ b/src/ui/shared/MZTheme.h
@@ -1,0 +1,22 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#pragma once
+
+#include <QQmlEngine>
+
+#include "theme.h"
+
+struct MZTheme {
+  Q_GADGET
+  QML_FOREIGN(Theme)
+  QML_NAMED_ELEMENT(MZTheme)
+  QML_SINGLETON
+
+ public:
+  static Theme* create(QQmlEngine* engine, QJSEngine*) {
+    Theme::instance()->initialize(engine);
+    return Theme::instance();
+  }
+};

--- a/src/ui/shared/MZUrlOpener.h
+++ b/src/ui/shared/MZUrlOpener.h
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#pragma once
+
+#include <QQmlEngine>
+
+#include "urlopener.h"
+
+struct MZUrlOpener {
+  Q_GADGET
+  QML_FOREIGN(UrlOpener)
+  QML_NAMED_ELEMENT(MZUrlOpener)
+  QML_SINGLETON
+
+ public:
+  static UrlOpener* create(QQmlEngine*, QJSEngine*) {
+    return UrlOpener::instance();
+  }
+};

--- a/src/ui/shared/MZUtils.h
+++ b/src/ui/shared/MZUtils.h
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#pragma once
+
+#include <QQmlEngine>
+
+#include "utils.h"
+
+struct MZUtils {
+  Q_GADGET
+  QML_FOREIGN(Utils)
+  QML_NAMED_ELEMENT(MZUtils)
+  QML_SINGLETON
+
+ public:
+  static Utils* create(QQmlEngine*, QJSEngine*) { return Utils::instance(); }
+};


### PR DESCRIPTION
## Description

Sooo, i was dropping in a little rabbit hole, trying to get the QML-Language Server to work on my Editor. 
So i did run ` cmake build --target all_aotstats` - which tells us how good qmlcachegen can translate a given qml unit to c++. In order for that to work, the minium dependency is ofc that it understands types. (same as qmlls) 

- We only export the VPN.Shared Types at runtime, so no qml tooling can actually know what we mean by VPN.Shared so as a first step, let's expose those with the same pattern we already use. 

However that does not help us to get qmlls working, as our qml modules define Q_FOREIGN on an object that is compiled in mozillavpn but they don't have a dependency on that. 

RN the dependency tree is this: 
```
                                             
   MOC Happens HERE!                         
                                             
         │                                   
         │                                   
         │                                   
         ▼               ┌─────────────────┐ 
  ┌───────────────┐◄─────┤shared-sources   │ 
  │mozillavpn     │      │                 │ 
  │               │◄───┐ └─────────────────┘ 
  │               │◄─┐ │ ┌─────────────────┐ 
  └───────────────┘  │ └─┤mozillavpn-ui    │ 
                     │   │                 │ 
                     │   └─────────────────┘ 
                     │   ┌─────────────────┐ 
                     └───┼mozillavpn-shared│ 
                         │                 │ 
                         └─────────────────┘ 
 ```

So what i instead did was to create a new intermediary qml-lib `libMozillaVPN` that combines all c++ shared sources as a static lib, that qml and mozillavpn can depend on. So now the moc info flows in one direction. 

Now the tree is this
```
                                         MOC Happens HERE!                        
                                                │                                 
 ┌───────────────┐                              ▼                                 
 │mozillavpn     ◄─┬────────────────────────┬───────────────┐  ┌─────────────────┐
 │               │ │                        │libMozillaVPN  │◄─┼shared-sources   │
 │               │ │  ┌─────────────────┐  ┌┼               │  │                 │
 └───────────────┘ ├──┼mozillavpn-ui    │  │└───────────────┘  └─────────────────┘
                   │  │                 ◄──┼                                      
                   │  └─────────────────┘  │                                      
                   │  ┌─────────────────┐  │                                      
                   └──┼mozillavpn-shared│  │                                      
                      │                 ◄──┘                                      
                      └─────────────────┘                                         
```


Which in the end in combination of `cmake -DQT_QML_GENERATE_QMLLS_INI=ON` allows us to get Type info right inside the IDE :partying_face: and qmlcachegen to generate c++ bindings for accesses to that singletons. 