### PR TITLE
VPN-7603: fix translations

### DIFF
--- a/scripts/utils/generate_xcstrings.py
+++ b/scripts/utils/generate_xcstrings.py
@@ -76,9 +76,13 @@ def get_locales(i18n_dir):
 
 def build_localizable_xcstrings(main_strings, locale_translations):
     """Build Localizable.xcstrings dict for iosAppIntents.main.* strings."""
-    strings = {}
+    strings = build_main_strings(main_strings, locale_translations)
+    return {"sourceLanguage": "en", "strings": strings, "version": "1.1"}
 
-    for data in main_strings.values():
+
+def build_main_strings(strings_to_translate, locale_translations, use_id_as_key = True):
+    strings = {}
+    for data in strings_to_translate.values():
         english_value = data["value"][0]
         string_id = data["string_id"]
         comment = data["comments"][0] if data["comments"] else None
@@ -106,9 +110,11 @@ def build_localizable_xcstrings(main_strings, locale_translations):
         if localizations:
             entry["localizations"] = localizations
 
-        strings[string_id] = entry
-
-    return {"sourceLanguage": "en", "strings": strings, "version": "1.1"}
+        if use_id_as_key:
+            strings[string_id] = entry
+        else:
+            strings[english_value] = entry
+    return strings
 
 
 def build_phrase_section(phrase_strings, locale_translations):
@@ -146,7 +152,7 @@ def build_phrase_section(phrase_strings, locale_translations):
     return {"localizations": localizations}
 
 
-def build_appshortcuts_xcstrings(intent_phrase_array, locale_translations):
+def build_appshortcuts_xcstrings(intent_phrase_array, intent_title_array, locale_translations):
     """Build AppShortcuts.xcstrings dict from phrase strings."""
     strings = {}
 
@@ -160,6 +166,9 @@ def build_appshortcuts_xcstrings(intent_phrase_array, locale_translations):
             strings[section_key] = phrase_section
         else:
             print(f"Skipping {next(iter(phrase_set))} because no translations were found in xliff files. This should only occur for new strings that are yet to be ingested into the l10n repo.")
+
+    title_strings = build_main_strings(intent_title_array, locale_translations, False)
+    strings.update(title_strings)
 
     return {"sourceLanguage": "en", "strings": strings, "version": "1.1"}
 
@@ -214,6 +223,13 @@ def main():
         if v["string_id"].startswith("vpn.iosAppIntentsMain")
     }
 
+    intent_titles = ["vpn.iosAppIntentsMain.statusQueryTitle", "vpn.iosAppIntentsMain.turnOffAction", "vpn.iosAppIntentsMain.turnOnAction"]
+    intent_title_array = {
+        k: v
+        for k, v in all_strings.items()
+        if v["string_id"] in intent_titles
+    }
+
     # Load translations for all locales
     locales = get_locales(args.i18n_dir)
     locale_translations = {}
@@ -248,7 +264,7 @@ def main():
     print(f"Wrote {localizable_path}")
 
     # Write AppShortcuts.xcstrings
-    appshortcuts = build_appshortcuts_xcstrings(shortcut_strings, locale_translations)
+    appshortcuts = build_appshortcuts_xcstrings(shortcut_strings, intent_title_array, locale_translations)
     appshortcuts_path = os.path.join(args.output_dir, "AppShortcuts.xcstrings")
     with open(appshortcuts_path, "w", encoding="utf-8") as f:
         json.dump(appshortcuts, f, indent=2, ensure_ascii=False)

--- a/src/translations/CMakeLists.txt
+++ b/src/translations/CMakeLists.txt
@@ -56,6 +56,12 @@ if(IOS)
         ${TRANSLATIONS_OUT_DIR}/AppShortcuts.xcstrings
         PROPERTIES GENERATED TRUE
     )
+
+    set_property(TARGET mozillavpn APPEND PROPERTY RESOURCE
+        ${TRANSLATIONS_OUT_DIR}/Localizable.xcstrings
+        ${TRANSLATIONS_OUT_DIR}/AppShortcuts.xcstrings
+    )
+
     add_dependencies(mozillavpn generate_xcstrings)
 
 endif()


### PR DESCRIPTION
## Description

Siri suggestions were showing keys. Shortcuts app was sometimes showing the wrong language.

I *believe* this fixes it, or at least gets us close. We're into some real dark arts of iOS at this point - how the app offers intents to the system. The details are not offered by Apple, and when building the iOS app it may parse those pieces out as part of the build process - hopefully before we run our translations script. The internet disagrees on some of these details, and AI doesn't know anything definitive either (though it will lead you down bad paths for as long as you'll let it). Further making things difficult, it caches this stuff hard - seems like rebooting the device is the only way to ensure you've cleared cache when switching languages. The behavior I've seen in testing has been inconsistent.

There may be more work to do on this in the future, but this at least gets us closer for now.

## Reference

VPN-7603

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
