### PR TITLE
VPN-7607: remove bullet points that won't hit 2.37

### DIFF
--- a/addons/message_update_v2.37/manifest.json
+++ b/addons/message_update_v2.37/manifest.json
@@ -38,8 +38,8 @@
             "content": "vpn.237updateMessage.bullet4"
           },
           {
-            "id": "l_6",
-            "content": "vpn.237updateMessage.bullet6"
+            "id": "l_5",
+            "content": "vpn.237updateMessage.bullet5"
           },
           {
             "id": "l_7",

--- a/addons/message_update_v2.37/manifest.json
+++ b/addons/message_update_v2.37/manifest.json
@@ -30,24 +30,12 @@
         "type": "ulist",
         "content": [
           {
-            "id": "l_1",
-            "content": "vpn.237updateMessage.bullet1"
-          },
-          {
-            "id": "l_2",
-            "content": "vpn.237updateMessage.bullet2"
-          },
-          {
             "id": "l_3",
             "content": "vpn.237updateMessage.bullet3"
           },
           {
             "id": "l_4",
             "content": "vpn.237updateMessage.bullet4"
-          },
-          {
-            "id": "l_5",
-            "content": "vpn.237updateMessage.bullet5"
           },
           {
             "id": "l_6",

--- a/addons/message_whats_new_v2.37/manifest.json
+++ b/addons/message_whats_new_v2.37/manifest.json
@@ -38,8 +38,8 @@
             "content": "vpn.237updateMessage.bullet4"
           },
           {
-            "id": "l_6",
-            "content": "vpn.237updateMessage.bullet6"
+            "id": "l_5",
+            "content": "vpn.237updateMessage.bullet5"
           },
           {
             "id": "l_7",

--- a/addons/message_whats_new_v2.37/manifest.json
+++ b/addons/message_whats_new_v2.37/manifest.json
@@ -30,24 +30,12 @@
         "type": "ulist",
         "content": [
           {
-            "id": "l_1",
-            "content": "vpn.237updateMessage.bullet1"
-          },
-          {
-            "id": "l_2",
-            "content": "vpn.237updateMessage.bullet2"
-          },
-          {
             "id": "l_3",
             "content": "vpn.237updateMessage.bullet3"
           },
           {
             "id": "l_4",
             "content": "vpn.237updateMessage.bullet4"
-          },
-          {
-            "id": "l_5",
-            "content": "vpn.237updateMessage.bullet5"
           },
           {
             "id": "l_6",


### PR DESCRIPTION
Updating messages for 2.37 based on what is going to hit the release.

The translations will stay, and will be used when these features are released.

For reference:
```
  bullet1:
    value: "[macOS] App exclusions are now available for macOS. Want to let some programs bypass the VPN completely? You now can."
  bullet2:
    value: "[iOS] Exciting news: Mozilla VPN widgets are now available."
  bullet6:
    value: "[Windows] IPv6-only networks are now supported."
```