### PR TITLE
Maybe fix the ios widget build on taskcluster

### DIFF
--- a/ios/widgetextension/ToggleWidgetControl.swift
+++ b/ios/widgetextension/ToggleWidgetControl.swift
@@ -20,10 +20,11 @@ struct ToggleWidgetControl: ControlWidget {
       ControlWidgetToggle(
         LocalizedStringResource("vpn.iosAppIntentsMain.toggleTitle", defaultValue: "Toggle Mozilla VPN"),
         isOn: value,
-        action: ToggleIntent()
-      ) { isOn in
-        Label(isOn ? "On" : "Off", systemImage: isOn ? "shield.lefthalf.filled" : "shield.lefthalf.filled.slash")
-      }
+        action: ToggleIntent(),
+        valueLabel: some View { isOn in
+          Label(isOn ? "On" : "Off", systemImage: isOn ? "shield.lefthalf.filled" : "shield.lefthalf.filled.slash")
+        }
+      )
     }
     .displayName("Mozilla VPN") // Not localizing - this is localized in another part of the app (that we can't easily get to Apple-land), and seems like all locales translate it as "Mozilla VPN"
     .description(LocalizedStringResource("vpn.iosAppIntentsMain.toggleDescription", defaultValue: "Changes Mozilla VPN status"))

--- a/scripts/utils/generate_xcstrings.py
+++ b/scripts/utils/generate_xcstrings.py
@@ -48,7 +48,7 @@ def load_xliff_translations(xliff_path, isEnglish):
 
 
 def using_app_placeholder(value):
-    return value.replace("%@", "\(.applicationName)")
+    return value.replace("%@", "\\(.applicationName)")
 
 
 SPECIAL_LOCALE_MAP = {


### PR DESCRIPTION
## Description
The iOS builds on taskcluster are failing. I spotted the following two causes:

```
[task 2026-05-12T01:08:34.094+00:00]     cd /opt/worker/tasks/task_174654944322692/checkouts/vcs
[task 2026-05-12T01:08:34.094+00:00]     /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swift-frontend -c /opt/worker/tasks/task_174654944322692/checkouts/vcs/ios/NETunnelProviderManager+Extension.swift /opt/worker/tasks/task_174654944322692/checkouts/vcs/ios/widgetextension/ToggleIntent.swift /opt/worker/tasks/task_174654944322692/checkouts/vcs/ios/widgetextension/ToggleWidgetBundle.swift /opt/worker/tasks/task_174654944322692/checkouts/vcs/ios/widgetextension/ToggleWidgetControl.swift /opt/worker/tasks/task_174654944322692/checkouts/vcs/src/platforms/ios/iosconstants.swift /opt/worker/tasks/task_174654944322692/checkouts/vcs/src/platforms/ios/ioslogger.swift -supplementary-output-file-map /opt/worker/tasks/task_174654944322692/build/build/widgetextension.build/Release-iphoneos/Objects-normal/arm64/supplementaryOutputs-1 -target arm64-apple-ios17.0 -Xllvm -aarch64-use-tbi -enable-objc-interop -stack-check -sdk /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.1.sdk -I /opt/worker/tasks/task_174654944322692/build/ios/widgetextension/Release-iphoneos -I /opt/worker/tasks/task_174654944322692/build/ios/widgetextension/widgetextension_autogen/include_Release -F /opt/worker/tasks/task_174654944322692/build/ios/widgetextension/Release-iphoneos -F /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.1.sdk/System/Library/Frameworks -no-color-diagnostics -application-extension -swift-version 5 -enforce-exclusivity\=checked -O -D QT_DEPRECATED_WARNINGS -D QT_DISABLE_DEPRECATED_BEFORE -D GROUP_ID\=\"group.org.mozilla.ios.Guardian\" -D NETWORK_EXTENSION\=1 -serialize-debugging-options -const-gather-protocols-file /opt/worker/tasks/task_174654944322692/build/build/widgetextension.build/Release-iphoneos/Objects-normal/arm64/widgetextension_const_extract_protocols.json -enable-experimental-feature DebugDescriptionMacro -enable-bare-slash-regex -empty-abi-descriptor -validate-clang-modules-once -clang-build-session-file /var/folders/x8/827khbhj5pgdg_twn7w11x3w0000jd/C/org.llvm.clang/ModuleCache.noindex/Session.modulevalidation -Xcc -working-directory -Xcc /opt/worker/tasks/task_174654944322692/checkouts/vcs -resource-dir /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift -Xcc -ivfsstatcache -Xcc /var/folders/x8/827khbhj5pgdg_twn7w11x3w0000jd/C/com.apple.DeveloperTools/16.1-16B40/Xcode/SDKStatCaches.noindex/iphoneos18.1-22B74-456b5073a84ca8a40bffd5133c40ea2b.sdkstatcache -Xcc -I/opt/worker/tasks/task_174654944322692/build/build/widgetextension.build/Release-iphoneos/swift-overrides.hmap -Xcc -I/opt/worker/tasks/task_174654944322692/build/ios/widgetextension/Release-iphoneos/include -Xcc -I/opt/worker/tasks/task_174654944322692/build/ios/widgetextension/widgetextension_autogen/include_Release -Xcc -I/opt/worker/tasks/task_174654944322692/build/build/widgetextension.build/Release-iphoneos/DerivedSources-normal/arm64 -Xcc -I/opt/worker/tasks/task_174654944322692/build/build/widgetextension.build/Release-iphoneos/DerivedSources/arm64 -Xcc -I/opt/worker/tasks/task_174654944322692/build/build/widgetextension.build/Release-iphoneos/DerivedSources -Xcc -DCMAKE_INTDIR\=\"Release-iphoneos\" -Xcc -DQT_DEPRECATED_WARNINGS -Xcc -DQT_DISABLE_DEPRECATED_BEFORE\=0x050F00 -module-name MozillaVPNWidgetExtension -frontend-parseable-output -disable-clang-spi -target-sdk-version 18.1 -target-sdk-name iphoneos18.1 -external-plugin-path /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/usr/lib/swift/host/plugins\#/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/usr/bin/swift-plugin-server -external-plugin-path /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/usr/local/lib/swift/host/plugins\#/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/usr/bin/swift-plugin-server -plugin-path /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/host/plugins -plugin-path /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/local/lib/swift/host/plugins -enable-default-cmo -num-threads 12 -o /opt/worker/tasks/task_174654944322692/build/build/widgetextension.build/Release-iphoneos/Objects-normal/arm64/NETunnelProviderManager+Extension.o -o /opt/worker/tasks/task_174654944322692/build/build/widgetextension.build/Release-iphoneos/Objects-normal/arm64/ToggleIntent.o -o /opt/worker/tasks/task_174654944322692/build/build/widgetextension.build/Release-iphoneos/Objects-normal/arm64/ToggleWidgetBundle.o -o /opt/worker/tasks/task_174654944322692/build/build/widgetextension.build/Release-iphoneos/Objects-normal/arm64/ToggleWidgetControl.o -o /opt/worker/tasks/task_174654944322692/build/build/widgetextension.build/Release-iphoneos/Objects-normal/arm64/iosconstants.o -o /opt/worker/tasks/task_174654944322692/build/build/widgetextension.build/Release-iphoneos/Objects-normal/arm64/ioslogger.o -index-unit-output-path /widgetextension.build/Release-iphoneos/Objects-normal/arm64/NETunnelProviderManager+Extension.o -index-unit-output-path /widgetextension.build/Release-iphoneos/Objects-normal/arm64/ToggleIntent.o -index-unit-output-path /widgetextension.build/Release-iphoneos/Objects-normal/arm64/ToggleWidgetBundle.o -index-unit-output-path /widgetextension.build/Release-iphoneos/Objects-normal/arm64/ToggleWidgetControl.o -index-unit-output-path /widgetextension.build/Release-iphoneos/Objects-normal/arm64/iosconstants.o -index-unit-output-path /widgetextension.build/Release-iphoneos/Objects-normal/arm64/ioslogger.o
[task 2026-05-12T01:08:34.094+00:00] /opt/worker/tasks/task_174654944322692/checkouts/vcs/ios/widgetextension/ToggleWidgetControl.swift:20:7: error: initializer 'init(_:isOn:action:valueLabel:)' requires that 'LocalizedStringResource' conform to 'StringProtocol'
[task 2026-05-12T01:08:34.094+00:00]       ControlWidgetToggle(
[task 2026-05-12T01:08:34.094+00:00]       ^
[task 2026-05-12T01:08:34.094+00:00] WidgetKit.ControlWidgetToggle:8:39: note: where 'some StringProtocol' = 'LocalizedStringResource'
[task 2026-05-12T01:08:34.094+00:00]     @MainActor @preconcurrency public init(_ title: some StringProtocol, isOn: Bool, action: Action, @ViewBuilder valueLabel: @escaping (Bool) -> ValueLabel) where Action : SetValueIntent, Action.ValueType == Bool
[task 2026-05-12T01:08:34.094+00:00]                 
```

And a malformed string replacement:
```
[task 2026-05-12T01:08:34.085+00:00]     /bin/sh -c /opt/worker/tasks/task_174654944322692/build/build/Mozilla\\\ VPN.build/Release-iphoneos/generate_xcstrings.build/Script-A8590104765C3E06036CAF9E.sh
[task 2026-05-12T01:08:34.085+00:00] /opt/worker/tasks/task_174654944322692/checkouts/vcs/scripts/utils/generate_xcstrings.py:51: SyntaxWarning: invalid escape sequence '\('
[task 2026-05-12T01:08:34.085+00:00]   return value.replace("%@", "\(.applicationName)")
[task 2026-05-12T01:08:34.085+00:00] Wrote /opt/worker/tasks/task_174654944322692/build/src/translations/generated/Localizable.xcstrings
[task 2026-05-12T01:08:34.085+00:00] Wrote /opt/worker/tasks/task_174654944322692/build/src/translations/generated/AppShortcuts.xcstrings
```

## Reference

    i.e Jira or Github issue URL

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
