### PR TITLE
VPN-7608: app intent translation fixes

### DIFF
--- a/scripts/utils/generate_xcstrings.py
+++ b/scripts/utils/generate_xcstrings.py
@@ -142,6 +142,8 @@ def build_phrase_section(phrase_strings, locale_translations):
                     "values": locale_values,
                 }
             }
+        else:
+            print(f"No translations found for {string_id} in {locale}")
 
     return {"localizations": localizations}
 

--- a/scripts/utils/generate_xcstrings.py
+++ b/scripts/utils/generate_xcstrings.py
@@ -48,7 +48,7 @@ def load_xliff_translations(xliff_path, isEnglish):
 
 
 def using_app_placeholder(value):
-    return value.replace("%@", "\(.applicationName)")
+    return value.replace("%@", "\\(.applicationName)")
 
 
 SPECIAL_LOCALE_MAP = {
@@ -130,8 +130,8 @@ def build_phrase_section(phrase_strings, locale_translations):
             continue
         for translation in translation_block.split("\n"):
             if translation:
-                if "%@" not in translation:
-                    print(f"Missing required placeholder in {translation} for {locale}")
+                if translation.count("%@") != 1:
+                    print(f"Placeholder found {translation.count('%@')} times in {translation} for {locale}, expected 1")
                     exit(1)
                 locale_values.append(using_app_placeholder(translation))
 


### PR DESCRIPTION
## Description

Addresses 3 things: 
1) Poorly escaped string (thanks for finding that in the logs)
2) Some translations messed up and put multiple phrases on one line. I'm working w/ l10n team on this, but also let's check for this when building.
3) I was surprised that we were missing several languages in the iOS app. From looking into it, it seems like they're just locales that haven't translated these strings yet. Let's add some logging around that.

Important: The second thing will cause iOS builds to fail once this is merged, as there are messed up translations currently. (I've already fixed the ones I could in pontoon, and asked l10n team about a couple others - so hopefully this will be fixed shortly.) Failing builds seems okay: We do not want to go to prod w/ the current state. TaskCluster is already failing (so no change), and it will cause Xcode Cloud to fail for a bit. For local builds, we'll just need to comment out a line for the time being. But it's important to catch these malformed translations, and this hammer seems like the best way to make sure we do in the future (IMO).

## Reference

VPN-7608

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
