### PR TITLE
VPN-7604: wait for confirmation when activating from intent

### DIFF
--- a/src/platforms/ios/TurnOnIntent.swift
+++ b/src/platforms/ios/TurnOnIntent.swift
@@ -21,7 +21,7 @@ struct TurnOnIntent: AppIntent {
   @MainActor
   func perform() async throws -> some IntentResult & ProvidesDialog {
     let dialog: IntentDialog
-    let activationResult = IOSControllerImpl.startTunnelFromIntent()
+    let activationResult = await IOSControllerImpl.startTunnelFromIntent()
     let responseText: LocalizedStringResource
     let responseImage: String
 

--- a/src/platforms/ios/ioscontroller.swift
+++ b/src/platforms/ios/ioscontroller.swift
@@ -296,7 +296,7 @@ public class IOSControllerImpl: NSObject {
         }
     }
 
-    static func startTunnelFromIntent() -> TurnOnIntent.Result {
+    static func startTunnelFromIntent() async -> TurnOnIntent.Result {
       guard let session = TunnelManager.session else {
         IOSControllerImpl.logger.info(message: "No current session")
         return .errorNoSession
@@ -316,13 +316,21 @@ public class IOSControllerImpl: NSObject {
 
       do {
         IOSControllerImpl.shouldSkipNextNotification = true
-        try TunnelManager.session?.startTunnel(options: ["source":"intent"])
-        let config = TunnelManager.protocolConfiguration?.providerConfiguration
-        return .success(entryCity: config?["entryCity"] as? String, exitCity: config?["exitCity"] as? String)
+        try session.startTunnel(options: ["source":"intent"])
       } catch let error {
         IOSControllerImpl.logger.info(message: "Error starting from intent: \(error.localizedDescription)")
         return .errorNoSession
       }
+      let deadline = Date().addingTimeInterval(3)
+      while Date() < deadline {
+        if session.status == .connected {
+          let config = TunnelManager.protocolConfiguration?.providerConfiguration
+          return .success(entryCity: config?["entryCity"] as? String, exitCity: config?["exitCity"] as? String)
+        }
+        try? await Task.sleep(nanoseconds: 250_000_000)
+      }
+      return .errorNoSession
+
     }
 
     static func stopTunnelFromIntent() -> Bool {


### PR DESCRIPTION
## Description

Just because I couldn't find a path that caused an issue when optimistically returning success, doesn't mean QA couldn't. This optimistic return fails in the case lack of network. (However, it did set the VPN to auto-connect the next time there was a network.) Now we give a 3 second timeout - return success when connected, and return error if the timeout ends. Three seconds seems like enough time to set up the connection without false postives on the timeout, but I'm open to discussion.

## Reference

VPN-7604

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
