### PR TITLE
VPN-7599: fix unauthenticated reset crash

### DIFF
--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -786,7 +786,14 @@ bool Controller::silentServerSwitchingSupported() const {
 }
 
 bool Controller::splitTunnelSupported() const {
-  return m_impl->splitTunnelSupported();
+  if (m_impl) {
+    return m_impl->splitTunnelSupported();
+  } else {
+    // Fix for VPN-7599 - when signed out, we need this to
+    // resolve when resetting client, as one line is shown
+    // depending on whether split tunnel is supported.
+    return false;
+  }
 }
 
 void Controller::logSerialize(QIODevice* device) {


### PR DESCRIPTION
## Description

Crashing when tapping "reset" when signed out - as it tries to figure out whether it should show the line about resetting excluded apps, but there is no implementation. Now, let's default to `false` in this scenario.

## Reference

VPN-7599

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
