### PR TITLE
VPN-7597: fix login bug, and save the on demand rule

### DIFF
--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -890,7 +890,15 @@ void Controller::serverDataChanged() {
 #ifdef MZ_IOS
     // If the VPN is disconnected, we still need to update the config in the
     // network extension so if the next connection comes from control center or
-    // app intent the latest config will be used.
+    // app intent the latest config will be used. But skip if not in main state.
+    if (!SettingsHolder::instance()->hasServerData()) {
+      logger.debug() << "Logging out, so skipping iOS config forwarding";
+      return false;
+    }
+    if (MozillaVPN::instance()->state() != MozillaVPN::StateMain) {
+      logger.debug() << "Not in StateMain, so skipping iOS config forwarding";
+      return false;
+    }
     logger.debug() << "However, we are on iOS so we are forwarding the config";
 #else
     return;

--- a/src/platforms/ios/ioscontroller.swift
+++ b/src/platforms/ios/ioscontroller.swift
@@ -311,11 +311,21 @@ public class IOSControllerImpl: NSObject {
         alwaysConnect.interfaceTypeMatch = .any
         tunnel.isOnDemandEnabled = true
         tunnel.onDemandRules = [alwaysConnect]
+        tunnel.saveToPreferences { saveError in
+          if let error = saveError {
+            IOSControllerImpl.logger.error(message: "Tunnel save error when saving on demand rules: \(error)")
+          }
+        }
         return true
       }
 
       do {
         IOSControllerImpl.shouldSkipNextNotification = true
+        // after saving this above, it seems like we need to use an updated session
+        guard let session = TunnelManager.session else {
+          IOSControllerImpl.logger.info(message: "No updated session")
+          return .errorNoSession
+        }
         try session.startTunnel(options: ["source":"intent"])
       } catch let error {
         IOSControllerImpl.logger.info(message: "Error starting from intent: \(error.localizedDescription)")


### PR DESCRIPTION
## Description

We need to skip passing the config to iOS if we're logging out or logging in. This has been added to `controller.cpp`, and again allows logging in and logging out.

I snuck another couple fixes in here as well, in `ioscontroller.swift`:
1) The auto reconnect was being saved. 🤦🏻 
2) I found that if the config was changed while the VPN was disconnected, there was an error when starting the VPN from intent. (This error cleared itself for future runs after starting the VPN from client.) Turns out the session had changed.

## Reference

VPN-7597

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
