### PR TITLE
VPN-7614: Add phrase check for iOS

### DIFF
--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -47,6 +47,12 @@ jobs:
         run: |
           python scripts/ci/check_jsonschema.py addon.json addons/*/manifest.json
 
+      - name: Check for iOS translations on localization PRs
+        run: |
+          if [[${{ github.ref_name }} == "i18n_automation"]]; then
+            python scripts/utils/generate_xcstrings.py src/translations/strings.yaml 3rdparty/i18n .tmp/
+          fi
+
       - name: Check for issues with clang-format
         uses: DoozyX/clang-format-lint-action@bcb4eb2cb0d707ee4f3e5cc3b456eb075f12cf73 # v0.20
         with:

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Check for iOS translations (l10n PRs only)
         run: |
-          if [[ "${{ github.ref_name }}" == "i18n_automation" ]]; then
+          if [[ "${{ github.head_ref }}" == "i18n_automation" ]]; then
             python scripts/utils/generate_xcstrings.py src/translations/strings.yaml 3rdparty/i18n .tmp/
           fi
 

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -47,7 +47,7 @@ jobs:
         run: |
           python scripts/ci/check_jsonschema.py addon.json addons/*/manifest.json
 
-      - name: Check for iOS translations on localization PRs
+      - name: Check for iOS translations (l10n PRs only)
         run: |
           if [[${{ github.ref_name }} == "i18n_automation"]]; then
             python scripts/utils/generate_xcstrings.py src/translations/strings.yaml 3rdparty/i18n .tmp/

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Check for iOS translations (l10n PRs only)
         run: |
-          if [[${{ github.ref_name }} == "i18n_automation"]]; then
+          if [[ "${{ github.ref_name }}" == "i18n_automation" ]]; then
             python scripts/utils/generate_xcstrings.py src/translations/strings.yaml 3rdparty/i18n .tmp/
           fi
 

--- a/scripts/utils/generate_xcstrings.py
+++ b/scripts/utils/generate_xcstrings.py
@@ -129,6 +129,7 @@ def build_phrase_section(phrase_strings, locale_translations):
     string_id = next(iter(phrase_blocks))["string_id"]
 
     localizations = {}
+    error_locales = []
     for locale, translations in locale_translations.items():
         locale_values = []
         translation_block = translations.get(string_id)
@@ -138,7 +139,7 @@ def build_phrase_section(phrase_strings, locale_translations):
             if translation:
                 if translation.count("%@") != 1:
                     print(f"Placeholder found {translation.count('%@')} times in {translation} for {locale}, expected 1")
-                    exit(1)
+                    error_locales.append(locale)
                 locale_values.append(using_app_placeholder(translation))
 
         if locale_values:
@@ -151,15 +152,19 @@ def build_phrase_section(phrase_strings, locale_translations):
         else:
             print(f"No translations found for {string_id} in {locale}")
 
-    return {"localizations": localizations}
+    return {"localizations": localizations}, error_locales
 
 
 def build_appshortcuts_xcstrings(intent_phrase_array, intent_title_array, locale_translations):
     """Build AppShortcuts.xcstrings dict from phrase strings."""
     strings = {}
 
+    overall_error_locales = {}
     for phrase_set in intent_phrase_array:
-        phrase_section = build_phrase_section(phrase_set, locale_translations)
+        phrase_section, error_locales = build_phrase_section(phrase_set, locale_translations)
+        if error_locales:
+            string_id = next(iter(phrase_set.values()))["string_id"]
+            overall_error_locales[string_id] = error_locales
         if (len(phrase_section["localizations"]) > 0):
             # The xcstrings key for a phrase group is the first English phrase value. But this is so ugly, sorry.
             section_key = next(
@@ -168,6 +173,12 @@ def build_appshortcuts_xcstrings(intent_phrase_array, intent_title_array, locale
             strings[section_key] = phrase_section
         else:
             print(f"Skipping {next(iter(phrase_set))} because no translations were found in xliff files. This should only occur for new strings that are yet to be ingested into the l10n repo.")
+
+    if overall_error_locales:
+        print("Incorrect translation phrases found in:")
+        for string_id, locales in overall_error_locales.items():
+            print(f"  {string_id}: {', '.join(locales)}")
+        exit(1)
 
     title_strings = build_main_strings(intent_title_array, locale_translations, False)
     strings.update(title_strings)


### PR DESCRIPTION
## Description

Check for whether iOS App Intent phrases are in the right format when a localization PR is put up. We do *not* want to do this on every PR (as of right now) because there are some malformed ones presently in the system that we're trying to work out - and we don't want to start failing every PR once this is merged.

The actual localization is done while building iOS, and the iOS builds will also fail if the localization fails. However, while we await [TaskCluster iOS updates](https://mozilla.slack.com/archives/C08S7E59CR1/p1778086192160969), we’re not failing PRs if the iOS build fails. Which means even if they fail because of this translation format issue, we're not catching it. 

Given this background, there are two reasons I think we should merge this:
1) We don't know how long TaskCluster will take to be updated, and in the meantime we don't want to merge in bad translations.
2) Even once the TaskCluster builds are working and we're failing PRs on bad iOS builds - it takes less 400-500 ms on my machine to run this script right now. That's not much, and when the phrases are malformed it's far clearer to future engineers to fail/report it at the linter test than have to dig into why the iOS build failed. 

That said, if you think we should back this out once TaskCluster is building iOS again, I'd be okay with that - just let me know.

Also in here: Give better output when it fails - include all locales in the error message, rather than stopping at the first one.

## Reference

VPN-7614

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
