### PR TITLE
VPN-7593: renumber Android events and actions

### DIFF
--- a/android/common/src/main/java/org/mozilla/firefox/qt/common/CoreBinder.kt
+++ b/android/common/src/main/java/org/mozilla/firefox/qt/common/CoreBinder.kt
@@ -9,16 +9,15 @@ open class CoreBinder : Binder() {
         const val deactivate = 2
         const val registerEventListener = 3
         const val requestStatistic = 4
-        const val requestCleanupLog = 6
-        const val resumeActivate = 7
-        const val setNotificationText = 8
-        const val recordEvent = 10
-        const val getStatus = 13
-        const val setStartOnBoot = 15
-        const val reactivate = 16
-        const val clearStorage = 17
-        const val notificationPermissionFired = 19
-        const val silentServerSwitch = 20
+        const val requestCleanupLog = 5
+        const val resumeActivate = 6
+        const val setNotificationText = 7
+        const val getStatus = 8
+        const val setStartOnBoot = 9
+        const val reactivate = 10
+        const val clearStorage = 11
+        const val notificationPermissionFired = 12
+        const val silentServerSwitch = 13
     }
 
     /** The codes we Are Using in case of [dispatchEvent] */
@@ -27,9 +26,9 @@ open class CoreBinder : Binder() {
         const val connected = 1
         const val disconnected = 2
         const val statisticUpdate = 3
-        const val activationError = 5
-        const val permissionRequired = 6
-        const val requestNotificationPermission = 8
-        const val onboardingCompleted = 9
+        const val activationError = 4
+        const val permissionRequired = 5
+        const val requestNotificationPermission = 6
+        const val onboardingCompleted = 7
     }
 }

--- a/android/vpnClient/src/main/java/org/mozilla/firefox/vpn/qt/VPNActivity.java
+++ b/android/vpnClient/src/main/java/org/mozilla/firefox/vpn/qt/VPNActivity.java
@@ -311,12 +311,12 @@ public class VPNActivity extends org.qtproject.qt.android.QtActivityBase {
   // so we can use that Shared Code
   private final int PERMISSION_TRANSACTION = 1337;
   private final int ACTION_REGISTER_LISTENER = 3;
-  private final int ACTION_RESUME_ACTIVATE = 7;
-  private final int ACTION_NOTIFICATION_PROMPT_SENT = 19;
-  private final int EVENT_PERMISSION_REQURED = 6;
+  private final int ACTION_RESUME_ACTIVATE = 6;
+  private final int ACTION_NOTIFICATION_PROMPT_SENT = 12;
+  private final int EVENT_PERMISSION_REQURED = 5;
   private final int EVENT_DISCONNECTED = 2;
-  private final int EVENT_ONBOARDING_COMPLETED = 9;
-  private final int EVENT_VPN_CONFIG_PERMISSION_RESPONSE = 10;
+  private final int EVENT_ONBOARDING_COMPLETED = 7;
+  private final int EVENT_VPN_CONFIG_PERMISSION_RESPONSE = 8;
 
   public void onPermissionRequest(int code, Parcel data) {
     if(code != EVENT_PERMISSION_REQURED){

--- a/src/platforms/android/androidvpnactivity.h
+++ b/src/platforms/android/androidvpnactivity.h
@@ -26,26 +26,23 @@ enum ServiceAction {
   // Requests an EVENT_STATISTIC_UPDATE to be send
   ACTION_REQUEST_STATISTIC = 4,
   // Requests to clean up the internal log
-  ACTION_REQUEST_CLEANUP_LOG = 6,
+  ACTION_REQUEST_CLEANUP_LOG = 5,
   // Retry activation using the last config
   // Used when the activation is aborted for VPN-Permission prompt
-  ACTION_RESUME_ACTIVATE = 7,
+  ACTION_RESUME_ACTIVATE = 6,
   // Sets the current notification text.
   // Does nothing if there is no notification
-  ACTION_SET_NOTIFICATION_TEXT = 8,
-  // Sets the fallback text if the OS triggered the VPN-Service
-  // to show a notification
-  ACTION_SET_NOTIFICATION_FALLBACK = 9,
+  ACTION_SET_NOTIFICATION_TEXT = 7,
   // Get's current status
-  ACTION_GET_STATUS = 13,
+  ACTION_GET_STATUS = 8,
   // Set startOnBoot pref
-  ACTION_SET_START_ON_BOOT = 15,
+  ACTION_SET_START_ON_BOOT = 9,
   // Reactivate the last connection (unusued from the client)
-  ACTION_REACTIVATE = 16,
+  ACTION_REACTIVATE = 10,
   // Clear the VPN storage
-  ACTION_CLEAR_STORAGE = 17,
+  ACTION_CLEAR_STORAGE = 11,
   // Daemon-based silent server switch
-  ACTION_SILENT_SERVER_SWITCH = 20,
+  ACTION_SILENT_SERVER_SWITCH = 13,
 
 };
 typedef enum ServiceAction ServiceAction;
@@ -62,16 +59,16 @@ enum ServiceEvents {
   EVENT_STATISTIC_UPDATE = 3,
   // An Error happened during activation
   // Contains the error message
-  EVENT_ACTIVATION_ERROR = 5,
+  EVENT_ACTIVATION_ERROR = 4,
   // The Daemon need's the app to ask for notification
   // permissions, to show the "you're connected" messages.
-  EVENT_REQUEST_NOTIFICATION_PERMISSION = 8,
+  EVENT_REQUEST_NOTIFICATION_PERMISSION = 6,
   // Signals MozillaVPN that we have completed onboarding
-  EVENT_ONBOARDING_COMPLETED = 9,
+  EVENT_ONBOARDING_COMPLETED = 7,
   // Signals the Controller that it may now allow
   // activation retries now that the system vpn config modal
   // has been responded to
-  EVENT_VPN_CONFIG_PERMISSION_RESPONSE = 10,
+  EVENT_VPN_CONFIG_PERMISSION_RESPONSE = 8,
 };
 typedef enum ServiceEvents ServiceEvents;
 


### PR DESCRIPTION
## Description

Per my promise when ripping out Glean, renumbering these.

This removes two that I couldn't find use for: `recordEvent` and `ACTION_SET_NOTIFICATION_FALLBACK`. Do you know what these were used for? Can you confirm it's safe to remove them?

## Reference

VPN-7593

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
