### PR TITLE
fix(l10n): correct typo 'commnent' to 'comment' in strings.yaml

### DIFF
--- a/src/translations/strings.yaml
+++ b/src/translations/strings.yaml
@@ -463,7 +463,7 @@ connectionInfo:
     comment: Label for the upload benchmark shown in the speed test view.
   unitPing:
     value: ms
-    commnent: milliseconds
+    comment: milliseconds
   loadingIndicatorLabel:
     value: Testing speed…
     comment: Shown to the user while waiting for the connection speed test results


### PR DESCRIPTION
## Description

The l10n string extraction was failing because of an unknown field 'commnent' in the strings.yaml file. This corrects the typo so that localization extraction can proceed successfully.

## Changes

- Fixed typo: 'commnent' → 'comment' in  line 466

## Verification

- The field now reads 'comment' which is an allowed field in the l10n extraction
- This aligns with the main branch where this typo was already fixed

Fixes #11282

## Related

- The same typo exists in the releases/2.35.0 branch and will be fixed in a separate PR.