### PR TITLE
fix(l10n): correct typo 'commnent' to 'comment' in strings.yaml (#11283)

### DIFF
--- a/src/translations/strings.yaml
+++ b/src/translations/strings.yaml
@@ -463,7 +463,7 @@ connectionInfo:
     comment: Label for the upload benchmark shown in the speed test view.
   unitPing:
     value: ms
-    commnent: milliseconds
+    comment: milliseconds
   loadingIndicatorLabel:
     value: Testing speed…
     comment: Shown to the user while waiting for the connection speed test results


### PR DESCRIPTION
## Description

This is porting the same fix we already have on main and releases/2.36.0 to unblock #11282 

## Reference

Issue #11282 
