### PR TITLE
VPN-7604: only use ToggleIntent for our controls

### DIFF
--- a/ios/widgetextension/ToggleIntent.swift
+++ b/ios/widgetextension/ToggleIntent.swift
@@ -10,8 +10,9 @@ import WidgetKit
 @available(iOS 16.0, *)
 struct ToggleIntent: SetValueIntent {
   static let title = LocalizedStringResource("vpn.iosAppIntentsMain.toggleTitle", defaultValue: "Toggle Mozilla VPN")
-
   static let description = IntentDescription(LocalizedStringResource("vpn.iosAppIntentsMain.toggleDescription", defaultValue: "Changes Mozilla VPN status"))
+
+  static var isDiscoverable = false
 
   static var authenticationPolicy: IntentAuthenticationPolicy = .requiresAuthentication
   static let errorSystemImageName = "exclamationmark.triangle"


### PR DESCRIPTION
## Description

This intent was needed for the controls (in control center, home screen, action button), and doesn't seem that helpful to a user in Spotlight, Siri, or for Shortcuts. The existing turn on and turn off should handle most cases. For Shortcuts the query intent can get the current status, allowing the user to fork logic to use Turn On intent or Turn Off intent as appropriate.

Thus, we can use this boolean to turn off access in Shortcuts, Spotlight, Siri (which we already weren't using for this one), etc.

## Reference

VPN-7604

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
