### PR TITLE
VPN-7826: add Serbian to Mozilla VPN app

### DIFF
--- a/docs/Components/l10n.md
+++ b/docs/Components/l10n.md
@@ -179,7 +179,7 @@ This map can be imported in C++ code through the header `i18nlanguagenames.h`.
 
 ##### Adding
 
-The `extras.xliff` file must always contain strings for all languages supported by the application. In order to know which languages are supported by the application, one can simply look at the folder list in the i18n submodule. To guarantee the `extras.xliff` file and the supported language list is always up to date, a linter workflow is executed on each commit that checks if the i18n submodule and the `extras.xliff` language names are up to date.
+The `./src/translations/extras/extras.xliff` file must always contain strings for all languages supported by the application. In order to know which languages are supported by the application, one can simply look at the folder list in the i18n submodule. To guarantee the `extras.xliff` file and the supported language list is always up to date, a linter workflow is executed on each commit that checks if the i18n submodule and the `extras.xliff` language names are up to date.
 
 ##### Removing
 

--- a/src/translations/extras/extras.xliff
+++ b/src/translations/extras/extras.xliff
@@ -122,6 +122,9 @@
       <trans-unit id="languages.sq" xml:space="preserve">
         <source>Albanian</source>
       </trans-unit>
+      <trans-unit id="languages.sr" xml:space="preserve">
+        <source>Serbian</source>
+      </trans-unit>
       <trans-unit id="languages.sv_SE" xml:space="preserve">
         <source>Swedish</source>
       </trans-unit>


### PR DESCRIPTION
## Description

Linter is failing on [i18n PR](https://github.com/mozilla-mobile/mozilla-vpn-client/pull/11292) to alert us to a new locale - Serbian! This PR will start the process of the word "Serbian" being translated in all the languages. Huge thanks to the volunteer(s) who are making this possible.

Looks like Serbian files are 3-33% [translated right now](https://pontoon.mozilla.org/sr/mozilla-vpn-client/), which means this language won't show up in the app yet. Thus, this can be uplifted to release branch if needed to allow newer translations to be merged in - even though we won't have the "Serbian-in-other-languages" translated yet.

## Reference

VPN-7626 (despite misnamed branch)

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
