### PR TITLE
VPN-7625: fix test alignment in update button

### DIFF
--- a/nebula/ui/components/MZButton.qml
+++ b/nebula/ui/components/MZButton.qml
@@ -18,6 +18,7 @@ MZButtonBase {
 
     property int fontSize: MZTheme.theme.fontSize
     property alias label: label
+    property int wrapMode: Text.NoWrap
 
     id: button
 
@@ -26,11 +27,12 @@ MZButtonBase {
         id: style
         property var colorScheme: (buttonType === MZButton.ButtonType.Normal) ? MZTheme.colors.normalButton : MZTheme.colors.destructiveButton
     }
-    height: MZTheme.theme.rowHeight
+    height: Math.max(MZTheme.theme.rowHeight, label.implicitHeight + MZTheme.theme.rowHeight / 2)
     width: Math.min(parent.width * 0.83, MZTheme.theme.maxHorizontalContentWidth)
 
     Layout.alignment: Layout ? Qt.AlignHCenter : undefined
-    Layout.preferredHeight: Layout ? MZTheme.theme.rowHeight : undefined
+    Layout.preferredHeight: Layout ? Math.max(MZTheme.theme.rowHeight, label.implicitHeight + MZTheme.theme.rowHeight / 2) : undefined
+
     Layout.preferredWidth: Layout
         ? Math.min(parent.width * 0.83, MZTheme.theme.maxHorizontalContentWidth)
         : undefined
@@ -65,7 +67,8 @@ MZButtonBase {
         text: button.text
         horizontalAlignment: Text.AlignHCenter
         verticalAlignment: Text.AlignVCenter
-        elide: Text.ElideRight
+        wrapMode: button.wrapMode
+        elide: button.wrapMode === Text.NoWrap ? Text.ElideRight : Text.ElideNone
         width: button.width
         font.family: MZTheme.theme.fontBoldFamily
         font.pixelSize: fontSize

--- a/src/ui/screens/settings/ViewAboutUs.qml
+++ b/src/ui/screens/settings/ViewAboutUs.qml
@@ -163,6 +163,7 @@ MZViewBase {
             Layout.rightMargin: MZTheme.theme.windowMargin
             leftPadding: MZTheme.theme.iconSize * 1.5 + MZTheme.theme.windowMargin * 1.25
             rightPadding: MZTheme.theme.iconSize * 1.5 + MZTheme.theme.windowMargin * 1.25
+            wrapMode: Text.WordWrap
 
             onClicked: {
                 listenForUpdateEvents=true;

--- a/src/ui/screens/settings/ViewAboutUs.qml
+++ b/src/ui/screens/settings/ViewAboutUs.qml
@@ -161,8 +161,8 @@ MZViewBase {
             Layout.fillWidth: true
             Layout.leftMargin: MZTheme.theme.windowMargin
             Layout.rightMargin: MZTheme.theme.windowMargin
-            leftPadding: MZTheme.theme.iconSize * 1.5 + MZTheme.theme.windowMargin * 2
-            rightPadding: MZTheme.theme.windowMargin
+            leftPadding: MZTheme.theme.iconSize * 1.5 + MZTheme.theme.windowMargin * 1.25
+            rightPadding: MZTheme.theme.iconSize * 1.5 + MZTheme.theme.windowMargin * 1.25
 
             onClicked: {
                 listenForUpdateEvents=true;
@@ -174,7 +174,7 @@ MZViewBase {
                 id:updateButtonImage
                 anchors {
                     left: updateButton.left
-                    leftMargin: MZTheme.theme.windowMargin
+                    leftMargin: MZTheme.theme.windowMargin * 1.25
                     verticalCenter: parent.verticalCenter
                 }
                 fillMode: Image.PreserveAspectFit


### PR DESCRIPTION
## Description
Adjust right padding to make update button text centered again.

<img width="366" height="673" alt="Screenshot from 2026-05-18 19-45-43" src="https://github.com/user-attachments/assets/4b87ea79-6142-43fd-929f-1520be5459c3" />

Add `wrapMode` property to MZButton, defaults to Text.NoWrap when set to disable elide and make the button wrap longer strings.
Set wrapMode to Text.WordWrap on check update button, Russian translation is now wrapped.

<img width="366" height="673" alt="Screenshot from 2026-05-19 01-05-45" src="https://github.com/user-attachments/assets/75650544-5815-47f1-9329-9935197d6bd6" />


## Reference

[VPN-7625](https://mozilla-hub.atlassian.net/browse/VPN-7625)

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed


[VPN-7625]: https://mozilla-hub.atlassian.net/browse/VPN-7625?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ