### PR TITLE
VPN-7628: do not turn on VPN after trying to connect in airplane mode

### DIFF
--- a/src/platforms/ios/ioscontroller.swift
+++ b/src/platforms/ios/ioscontroller.swift
@@ -329,6 +329,7 @@ public class IOSControllerImpl: NSObject {
         try session.startTunnel(options: ["source":"intent"])
       } catch let error {
         IOSControllerImpl.logger.info(message: "Error starting from intent: \(error.localizedDescription)")
+        IOSControllerImpl.removeOnDemandRules()
         return .errorNoSession
       }
       let deadline = Date().addingTimeInterval(3)
@@ -339,6 +340,7 @@ public class IOSControllerImpl: NSObject {
         }
         try? await Task.sleep(nanoseconds: 250_000_000)
       }
+      IOSControllerImpl.removeOnDemandRules()
       return .errorNoSession
 
     }
@@ -357,24 +359,26 @@ public class IOSControllerImpl: NSObject {
       IOSControllerImpl.staticDisconnect()
     }
 
-  static func staticDisconnect() {
-    IOSControllerImpl.logger.info(message: "Disconnecting")
-    TunnelManager.withTunnel { tunnel in
-
-        // Turn off auto-connect, otherwise it will immediately reconnect.
-        tunnel.isOnDemandEnabled = false;
-        tunnel.onDemandRules = []
-
-        tunnel.saveToPreferences { saveError in
-            if let error = saveError {
-                IOSControllerImpl.logger.error(message: "Disonnect tunnel save error: \(error)")
-            }
-            TunnelManager.session?.stopTunnel()
-        }
-
-        // Needs to return something, but this will be discarded.
-        return true
+    static func staticDisconnect() {
+      IOSControllerImpl.logger.info(message: "Disconnecting")
+      IOSControllerImpl.removeOnDemandRules()
+      TunnelManager.session?.stopTunnel()
     }
+
+    private static func removeOnDemandRules() {
+      TunnelManager.withTunnel { tunnel in
+
+          // Turn off auto-connect, otherwise it will immediately reconnect.
+          tunnel.isOnDemandEnabled = false;
+          tunnel.onDemandRules = []
+
+          tunnel.saveToPreferences { saveError in
+              if let error = saveError {
+                  IOSControllerImpl.logger.error(message: "Disonnect tunnel save error: \(error)")
+              }
+          }
+          return
+      }
   }
 
     @objc func deleteOSTunnelConfig() {


### PR DESCRIPTION
## Description

In https://github.com/mozilla-mobile/mozilla-vpn-client/pull/11272, we stopped giving successful feedback when turning on the VPN via App Intent while in Airplane Mode - instead, we gave an error. However, after reconnecting to the network, the next network activity connects the VPN. This is unexpected, based on the error state feedback we’ve given to the user. This is because we’re setting up the onDemandRules, but not removing them after we error out.

I do not believe this is important enough to uplift to the release branch - it can go out with 2.38.0. I'm open to other opinions on that, though.

## Reference

VPN-7628 / VPN-7627 (these are dups - changed to using VPN-7628 as it has a better write up)

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
