### PR TITLE
VPN-7601: see if finishing transaction helps

### DIFF
--- a/src/platforms/ios/iosiaphandler.swift
+++ b/src/platforms/ios/iosiaphandler.swift
@@ -188,20 +188,24 @@ import StoreKit
     if let _ = transaction.revocationDate {
       InAppPurchaseHandler.logger.info(message: "Transaction was revoked")
       errorCallback(false)
+      await transaction.finish()
     } else if let expirationDate = transaction.expirationDate,
         expirationDate < Date() {
       // Expirations handled by server
       InAppPurchaseHandler.logger.info(message: "Transaction has expired")
       errorCallback(false)
+      await transaction.finish()
     } else if transaction.isUpgraded {
         // Do nothing, there is an active transaction
         // for a higher level of service.
       InAppPurchaseHandler.logger.info(message: "Transaction was upgraded")
       errorCallback(false)
+      await transaction.finish()
     } else {
       InAppPurchaseHandler.logger.info(message: "New successful transaction returned")
       let originalTransactionIdentifier: String = "\(transaction.originalID)"
       successCallback(NSString(string: transaction.productID), NSString(string: originalTransactionIdentifier))
+      await transaction.finish()
       await transaction.finish()
     }
   }


### PR DESCRIPTION
## Description

I'd call [Apple's documentation](https://developer.apple.com/documentation/storekit/transaction/finish()) unclear on whether this is required for failed transactions. However, we're seeing the same log lines about an expired transaction show up several times in a row before getting a TestFlight crash screen (without actually having an app crash), which makes me think there is something else happening here - I wonder if this fixes itself if we `finish` these.

Note: For a while I thought the issue was a mismatch between the Apple account (that has an expired IAP subscription) and Mozilla account (that may be a different one, say with a web subscription). However, the IAP error callback does an early return if we're not actively in the subscription flow, so I no longer think that's it.

~I want to get this on the nightly build - if it doesn't fix the issues, I'll back it out.~ Running a TestFlight build off this branch, to see if this fixes it. Putting on Draft until we hear if it does.

## Reference

Potentially solves VPN-7601, VPN-7629, and/or VPN-6243

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
