### PR TITLE
fix: don't allow untrusted pull requests to fetch secrets

### DIFF
--- a/taskcluster/kinds/build/windows.yml
+++ b/taskcluster/kinds/build/windows.yml
@@ -21,7 +21,10 @@ task-defaults:
     release-artifacts:
         - unsigned.zip
     scopes:
-        - secrets:get:project/mozillavpn/level-1/sentry
+        by-tasks-for:
+            github-pull-request-untrusted: []
+            default:
+                - secrets:get:project/mozillavpn/level-1/sentry
     run:
         using: run-task
         cwd: '{checkout}'

--- a/taskcluster/mozillavpn_taskgraph/transforms/build.py
+++ b/taskcluster/mozillavpn_taskgraph/transforms/build.py
@@ -64,6 +64,7 @@ def resolve_keys_scope(config, tasks):
             item_name=task["name"],
             **{
                 "level": config.params["level"],
+                "tasks-for": config.params["tasks_for"],
             },
         )
         yield task


### PR DESCRIPTION
We're currently allowing pull requests opened by anybody to access the Sentry secret (see https://github.com/mozilla-mobile/mozilla-vpn-client/pull/11315). This change remove the necessary scope from untrusted pull requests.