### PR TITLE
Generate and upload sentry symbols for windows cross builds 

### DIFF
--- a/taskcluster/kinds/build/windows.yml
+++ b/taskcluster/kinds/build/windows.yml
@@ -7,24 +7,24 @@ task-defaults:
         symbol: B
         kind: build
         tier: 1
-        platform: windows/x86_64
-    worker-type: b-win2022
+    worker-type: b-linux
     fetches:
         fetch:
             - wireguard-nt
         toolchain:
+            - conda-windows-cross
             - cargo-vendor
     worker:
+        docker-image: {in-tree: conda-base}
         taskcluster-proxy: true
         chain-of-trust: true
         max-run-time: 3600
+        artifacts:
+            - type: directory
+              name: public/build
+              path: /builds/worker/artifacts
     release-artifacts:
         - unsigned.zip
-    scopes:
-        by-tasks-for:
-            github-pull-request-untrusted: []
-            default:
-                - secrets:get:project/mozillavpn/level-1/sentry
     run:
         using: run-task
         cwd: '{checkout}'
@@ -33,18 +33,10 @@ windows-x86_64/opt:
     description: "Windows Build (Release/x86_64)"
     fetches:
         toolchain:
-            - conda-windows-cross
             - qt-windows-x86_64-6.10
             - qt-tools-6.10
-    worker-type: b-linux
     treeherder:
         platform: windows/x86_64
-    worker:
-        docker-image: {in-tree: conda-base}
-        artifacts:
-            - type: directory
-              name: public/build
-              path: artifacts
     run:
         command: ./taskcluster/scripts/build/windows_cross.sh x86_64
 
@@ -52,17 +44,9 @@ windows-aarch64/opt:
     description: "Windows Build (Release/aarch64)"
     fetches:
         toolchain:
-            - conda-windows-cross
             - qt-windows-aarch64-6.10
             - qt-tools-6.10
     treeherder:
         platform: windows/aarch64
-    worker-type: b-linux
-    worker:
-        docker-image: {in-tree: conda-base}
-        artifacts:
-            - type: directory
-              name: public/build
-              path: artifacts
     run:
         command: ./taskcluster/scripts/build/windows_cross.sh aarch64

--- a/taskcluster/kinds/sentry/kind.yml
+++ b/taskcluster/kinds/sentry/kind.yml
@@ -32,10 +32,9 @@ task-defaults:
         checkout: false
         use-caches: []
         command: /builds/worker/sentry_upload.sh
-    # comment out for debug purposes
-    #requires-level: 3
-    #scopes:
-    #    - secrets:get:project/mozillavpn/level-1/sentry
+    requires-level: 3
+    scopes:
+        - secrets:get:project/mozillavpn/level-1/sentry
 
 tasks:
     macos/opt:

--- a/taskcluster/kinds/sentry/kind.yml
+++ b/taskcluster/kinds/sentry/kind.yml
@@ -13,30 +13,48 @@ transforms:
 kind-dependencies:
     - build
 
+task-defaults:
+    worker-type: b-linux
+    worker:
+        docker-image: {in-tree: sentry}
+        taskcluster-proxy: true
+        chain-of-trust: true
+        max-run-time: 3600
+    treeherder:
+        symbol: SYM
+        kind: other
+        tier: 1
+    fetches:
+        build:
+            - MozillaVPN-dsym.tar.xz
+    run:
+        using: run-task
+        checkout: false
+        use-caches: []
+        command: /builds/worker/sentry_upload.sh
+    # comment out for debug purposes
+    #requires-level: 3
+    #scopes:
+    #    - secrets:get:project/mozillavpn/level-1/sentry
+
 tasks:
     macos/opt:
         description: Upload macOS symbols to Sentry
-        worker-type: b-linux
-        worker:
-            docker-image: {in-tree: sentry}
-            taskcluster-proxy: true
-            chain-of-trust: true
-            max-run-time: 3600
         treeherder:
-            symbol: SYM
-            kind: other
             platform: macos/universal
-            tier: 1
         dependencies:
             build: build-macos/opt
-        fetches:
-            build:
-                - MozillaVPN-dsym.tar.xz
-        run:
-            using: run-task
-            checkout: false
-            use-caches: []
-            command: /builds/worker/sentry_upload.sh
-        requires-level: 3
-        scopes:
-            - secrets:get:project/mozillavpn/level-1/sentry
+
+    windows-x86_64/opt:
+        description: Upload Windows/x86_64 symbols to Sentry
+        treeherder:
+            platform: windows/x86_64
+        dependencies:
+            build: build-windows-x86_64/opt
+
+    windows-aarch64/opt:
+        description: Upload Windows/aarch64 symbols to Sentry
+        treeherder:
+            platform: windows/aarch64
+        dependencies:
+            build: build-windows-aarch64/opt

--- a/taskcluster/scripts/build/sentry_upload.sh
+++ b/taskcluster/scripts/build/sentry_upload.sh
@@ -7,7 +7,7 @@ set -e
 # Auth using the sentry upload key
 SENTRY_UPLOAD_ARGS="--org mozilla -p vpn-client"
 
-# Only on a release build we have access to those secrects.
+# Only on a release build will we have access to those secrects.
 if [ "${MOZ_SCM_LEVEL}" -ge "3" ]; then
     get-secret -s project/mozillavpn/level-1/sentry -k sentry_debug_file_upload_key -f sentry_debug_file_upload_key
     sentry-cli login --auth-token $(cat sentry_debug_file_upload_key)   
@@ -36,11 +36,11 @@ find ${MOZ_FETCHES_DIR} -mindepth 1 -maxdepth 1 | while read FILENAME; do
             ;;
 
         *.pdb)
-            sentry-cli debug-files upload ${SENTRY_UPLOAD_ARGS} ${FILENAME}
+            sentry-cli debug-files upload ${SENTRY_UPLOAD_ARGS} "${FILENAME}"
             ;;
 
         *.src.zip)
-            sentry-cli debug-files upload ${SENTRY_UPLOAD_ARGS} --type sourcebundle ${FILENAME}
+            sentry-cli debug-files upload ${SENTRY_UPLOAD_ARGS} --type sourcebundle "${FILENAME}"
             ;;
 
         *)

--- a/taskcluster/scripts/build/windows_cross.sh
+++ b/taskcluster/scripts/build/windows_cross.sh
@@ -63,6 +63,6 @@ find ${TASK_WORKDIR}/unsigned -type f -name '*.pdb' | while read DBGFILE; do
   sentry-cli difutil check "${DBGFILE}"
   sentry-cli difutil bundle-sources -o ${TASK_WORKDIR}/symbols/ "${DBGFILE}"
 done
-tar -C ${TASK_WORKDIR} -cJvf ${TASK_WORKDIR}/artifacts/MozillaVPN-dsym.tar.xz symbols/ || die 
+tar -C ${TASK_WORKDIR}/symbols/ -cJvf ${TASK_WORKDIR}/artifacts/MozillaVPN-dsym.tar.xz . || die 
 
 print G "Done!"

--- a/taskcluster/scripts/build/windows_cross.sh
+++ b/taskcluster/scripts/build/windows_cross.sh
@@ -56,4 +56,10 @@ cmake --install ${TASK_WORKDIR}/build-win --prefix ${TASK_WORKDIR}/unsigned
 mkdir -p ${TASK_WORKDIR}/artifacts/
 (cd ${TASK_WORKDIR}/unsigned && zip -r ${TASK_WORKDIR}/artifacts/unsigned.zip .)
 
+print Y "Generating debug symbol artifacts..."
+find ${TASK_WORKDIR}/unsigned -type f -name '*.pdb' | while read DBGFILE; do
+  sentry-cli difutil check "${DBGFILE}"
+  sentry-cli difutil bundle-sources -o ${TASK_WORKDIR}/unsigned "${DBGFILE}"
+done
+
 print G "Done!"

--- a/taskcluster/scripts/build/windows_cross.sh
+++ b/taskcluster/scripts/build/windows_cross.sh
@@ -57,9 +57,12 @@ mkdir -p ${TASK_WORKDIR}/artifacts/
 (cd ${TASK_WORKDIR}/unsigned && zip -r ${TASK_WORKDIR}/artifacts/unsigned.zip .)
 
 print Y "Generating debug symbol artifacts..."
+mkdir -p ${TASK_WORKDIR}/symbols/
 find ${TASK_WORKDIR}/unsigned -type f -name '*.pdb' | while read DBGFILE; do
+  cp -v "${DBGFILE}" ${TASK_WORKDIR}/symbols/
   sentry-cli difutil check "${DBGFILE}"
-  sentry-cli difutil bundle-sources -o ${TASK_WORKDIR}/unsigned "${DBGFILE}"
+  sentry-cli difutil bundle-sources -o ${TASK_WORKDIR}/symbols/ "${DBGFILE}"
 done
+tar -C ${TASK_WORKDIR} -cJvf ${TASK_WORKDIR}/artifacts/MozillaVPN-dsym.tar.xz symbols/ || die 
 
 print G "Done!"


### PR DESCRIPTION
## Description
It seems that we have been missing sentry symbols for our windows builds for a few releases, ever since we switched to the cross-compiled builds.

## Reference
This also includes some additional cleanup following:
- #11311
- #11316

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
