### PR TITLE
Migrate to windows 25h2 arm64 builders

### DIFF
--- a/taskcluster/config.yml
+++ b/taskcluster/config.yml
@@ -52,11 +52,11 @@ workers:
             implementation: generic-worker
             os: windows
             worker-type: b-win2022
-        b-win11-2024h2-arm64:
+        b-win11-arm64:
             provisioner: 'mozillavpn-{level}'
             implementation: generic-worker
             os: windows
-            worker-type: win11-a64-24h2-builder
+            worker-type: win11-a64-25h2-builder
         b-macos:
             provisioner: 'releng-hardware'
             implementation: generic-worker

--- a/taskcluster/kinds/toolchain/qt.yml
+++ b/taskcluster/kinds/toolchain/qt.yml
@@ -67,7 +67,7 @@ qt-windows-aarch64-6.10:
     treeherder:
         symbol: TL(qt-win-6.10)
         platform: windows/aarch64
-    worker-type: b-win11-2024h2-arm64
+    worker-type: b-win11-arm64
 
 qt-ios:
     description: "QT ios bundle Task"

--- a/taskcluster/kinds/toolchain/vs.yml
+++ b/taskcluster/kinds/toolchain/vs.yml
@@ -25,7 +25,7 @@ vs-2022-x86_64:
 
 vs-2022-aarch64:
     description: "MS Visual Studio 2022 (aarch64)"
-    worker-type: b-win11-2024h2-arm64
+    worker-type: b-win11-arm64
     treeherder:
         symbol: TL(vs-2022-aarch64)
         platform: windows/aarch64


### PR DESCRIPTION
The 24h2 pools were removed in
https://bugzilla.mozilla.org/show_bug.cgi?id=2042529