### PR TITLE
Add missing asterick for important fields in contact form

### DIFF
--- a/src/ui/screens/getHelp/contactUs/ViewContactUsForm.qml
+++ b/src/ui/screens/getHelp/contactUs/ViewContactUsForm.qml
@@ -112,7 +112,7 @@ MZViewBase {
                 MZBoldLabel {
                     property string enterEmailAddress: MZI18n.InAppSupportWorkflowSupportFieldHeader
 
-                    text: enterEmailAddress
+                    text: enterEmailAddress + " *"
                     lineHeight: MZTheme.theme.labelLineHeight
                     lineHeightMode: Text.FixedHeight
                     wrapMode: Text.WordWrap

--- a/src/ui/screens/getHelp/contactUs/ViewContactUsForm.qml
+++ b/src/ui/screens/getHelp/contactUs/ViewContactUsForm.qml
@@ -72,7 +72,7 @@ MZViewBase {
                 MZBoldLabel {
                     property string enterEmailAddress: MZI18n.InAppSupportWorkflowSupportEmailFieldLabel
 
-                    text: enterEmailAddress
+                    text: enterEmailAddress + " *"
                     lineHeight: MZTheme.theme.labelLineHeight
                     lineHeightMode: Text.FixedHeight
                     wrapMode: Text.WordWrap
@@ -85,7 +85,7 @@ MZViewBase {
                 MZTextField {
                     id: emailInput
                     objectName: "contactUs-emailInput"
-
+                    Accessible.name: enterEmailAddress
                     verticalAlignment: Text.AlignVCenter
                     Layout.fillWidth: true
                     hasError: !MZValidator.validateEmailAddress(emailInput.text)

--- a/src/ui/screens/getHelp/contactUs/ViewContactUsForm.qml
+++ b/src/ui/screens/getHelp/contactUs/ViewContactUsForm.qml
@@ -112,7 +112,7 @@ MZViewBase {
                 MZBoldLabel {
                     property string enterEmailAddress: MZI18n.InAppSupportWorkflowSupportFieldHeader
 
-                    text: enterEmailAddress + " *"
+                    text: enterEmailAddress
                     lineHeight: MZTheme.theme.labelLineHeight
                     lineHeightMode: Text.FixedHeight
                     wrapMode: Text.WordWrap


### PR DESCRIPTION
## Description
 Added red asterisk indicators (*) to all mandatory fields in the Contact Support form to clearly communicate to users which fields are required before submission.

Fields updated:

Email address & Confirm email


## Reference

https://github.com/mozilla-mobile/mozilla-vpn-client/issues/5636

## Checklist
- [x] My code follows the style guidelines for this project.
- [x] I have not added any packages that contain high-risk or unknown licenses (GPL, LGPL, MPL, etc.; consult DevOps if in question).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added thorough tests where needed.

