### PR TITLE
WIP: Fix taskcluster pip package update.

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,6 @@
 aqtinstall==3.3.0
 oathtool==2.4.0
-jinja2==3.1.2
-jsonschema==4.20.0
+jinja2==3.1.6
+jsonschema==4.26.0
 pyrsistent==0.20.0
 yamllint==1.38.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -465,13 +465,13 @@ inflate64==1.0.4 \
     --hash=sha256:fb2b5a62579d074f38352a3494c3c6ac1a90516b75c5793c39303547f1fea925 \
     --hash=sha256:fb2fdd63ef3933b67af98b3f2ee2f57e7787278041d7ba4821382fedd729b68a
     # via py7zr
-jinja2==3.1.2 \
-    --hash=sha256:31351a702a408a9e7595a8fc6150fc3f43bb6bf7e319770cbc0db9df9437e852 \
-    --hash=sha256:6088930bfe239f0e6710546ab9c19c9ef35e29792895fed6e6e31a023a182a61
+jinja2==3.1.6 \
+    --hash=sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d \
+    --hash=sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67
     # via -r requirements.in
-jsonschema==4.20.0 \
-    --hash=sha256:4f614fd46d8d61258610998997743ec5492a648b33cf478c1ddc23ed4598a5fa \
-    --hash=sha256:ed6231f0429ecf966f5bc8dfef245998220549cbbcf140f913b7464c52c3b6b3
+jsonschema==4.26.0 \
+    --hash=sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326 \
+    --hash=sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce
     # via -r requirements.in
 jsonschema-specifications==2025.9.1 \
     --hash=sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe \

--- a/taskcluster/kinds/test/taskgraph.yml
+++ b/taskcluster/kinds/test/taskgraph.yml
@@ -19,7 +19,7 @@ taskgraph-definition:
         use-caches: [checkout, pip]
         cwd: '{checkout}'
         command: >-
-          pip3 install -r taskcluster/requirements.txt &&
+          pip3 install --upgrade -r taskcluster/requirements.txt &&
           for param in `ls taskcluster/test/params`; do
               taskgraph full -p taskcluster/test/params/$param
           done &&

--- a/taskcluster/mozillavpn_taskgraph/parameters.py
+++ b/taskcluster/mozillavpn_taskgraph/parameters.py
@@ -3,10 +3,12 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import os
+from typing import Annotated, Optional
+
+import msgspec
 
 from taskgraph.parameters import extend_parameters_schema
-from voluptuous import All, Any, Range, Required
-
+from taskgraph.util.schema import Schema
 
 def get_defaults(repo_root):
     return {
@@ -14,15 +16,11 @@ def get_defaults(repo_root):
         "version": "",
     }
 
+class MozillaVpnParametersSchema(Schema, kw_only=True, rename=None):
+    pull_request_number: Optional[Annotated[int, msgspec.Meta(ge=1)]]
+    version: str
 
-extend_parameters_schema(
-    {
-        Required("pull_request_number"): Any(All(int, Range(min=1)), None),
-        Required("version"): str,
-    },
-    defaults_fn=get_defaults,
-)
-
+extend_parameters_schema(MozillaVpnParametersSchema, defaults_fn=get_defaults)
 
 def get_decision_parameters(graph_config, parameters):
     head_tag = parameters["head_tag"]

--- a/taskcluster/requirements.in
+++ b/taskcluster/requirements.in
@@ -1,6 +1,6 @@
 # For instructions on managing dependencies, see:
 # https://taskcluster-taskgraph.readthedocs.io/en/latest/howto/bootstrap-taskgraph.html
 
-mozilla-repo-urls==0.1.1
-mozilla-taskgraph>=3.1
-taskcluster-taskgraph>=19
+mozilla-repo-urls==0.2.2
+mozilla-taskgraph>=4.1.2
+taskcluster-taskgraph>=23.0.0

--- a/taskcluster/requirements.txt
+++ b/taskcluster/requirements.txt
@@ -552,15 +552,15 @@ mohawk==1.1.0 \
     --hash=sha256:3ed296a30453d0b724679e0fd41e4e940497f8e461a9a9c3b7f36e43bab0fa09 \
     --hash=sha256:d2a0e3ab10a209cc79e95e28f2dd54bd4a73fd1998ffe27b7ba0f962b6be9723
     # via taskcluster
-mozilla-repo-urls==0.1.1 \
-    --hash=sha256:30510d3519479aa70211145d0ac9cf6e2fadcb8d30fa3b196bb957bd773502ba \
-    --hash=sha256:7364da790751db2a060eb45adbf1d7db89a145ed279ba235f3425db9dd255915
+mozilla-repo-urls==0.2.2 \
+    --hash=sha256:161ab84cac58c0bef2c9ce0c414aaec5483fc9593fc5616c5b186e0cccff4984 \
+    --hash=sha256:f6e6e037ed28b38956624dfc6b40ed78247e747f13157863ab39ac89ecd7ffd6
     # via
     #   -r taskcluster/requirements.in
     #   taskcluster-taskgraph
-mozilla-taskgraph==4.1.1 \
-    --hash=sha256:43ef061caf80ad0dcb3c8a3e29fa6e547fe6f8a11b77a63f8cce2bede58e428f \
-    --hash=sha256:553935ba90b34476b2d190ba9857b067e8165b35bffbad8cb54e22504ab40f56
+mozilla-taskgraph==4.1.2 \
+    --hash=sha256:22d7d439cc35768d17f43197c71fe7aa5ffa974d486543450f4ab785e74c2008 \
+    --hash=sha256:5e79169bd83dfb0b10ae8d0d87523f534d70f79e2d64cf9534e4f061f25e7f3b
     # via -r taskcluster/requirements.in
 msgspec==0.21.1 \
     --hash=sha256:0d03867786e5d7ba25d666df4b11320c27170f4aeafcb8e3a8b0a50a4fb742ca \
@@ -1011,9 +1011,9 @@ taskcluster==99.2.1 \
     --hash=sha256:31fe0db2d5f5e5144719885632965ed04c1321cc42b42c8e6ea72bafadcba2dd \
     --hash=sha256:5d1cda6142470e98ff3587e3762cf19dbcbad716c5455f9f9738825b07d42104
     # via taskcluster-taskgraph
-taskcluster-taskgraph==20.0.0 \
-    --hash=sha256:cbf0064f39d42303458bbd22ccf0b28597f07fd752254333584149eb0a255a10 \
-    --hash=sha256:ee4536a8f0c9f1668c6a11546361cf4539ff94a3a2e0bdd1fca7871c2a5b55c8
+taskcluster-taskgraph==23.0.0 \
+    --hash=sha256:21f1c482f12608e585e1b74341786b0a20b081edd87e14a59399058fbe49c344 \
+    --hash=sha256:cac5460db5a9d30ab6c8aeb3799f2fc9bae12be62c899e10147b12e947bd93dc
     # via
     #   -r taskcluster/requirements.in
     #   mozilla-taskgraph


### PR DESCRIPTION
## Description
It seems like the latest and greatest `taskcluster` python package has changed API and now requires a [msgspec](https://github.com/jcrist/msgspec) schema. So, I guess let's try and keep up with the state of Taskcluster.

## Reference
Forked from: #11328

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
