### PR TITLE
VPN-7642 Force default state on share logs checkbox when changing category

### DIFF
--- a/src/ui/screens/getHelp/contactUs/ViewContactUsForm.qml
+++ b/src/ui/screens/getHelp/contactUs/ViewContactUsForm.qml
@@ -140,6 +140,9 @@ MZViewBase {
                     model: VPNSupportCategoryModel
                     Layout.fillWidth: true
                     Layout.preferredWidth: undefined
+                    onCurrentValueChanged: {
+                        shareLogsCheckBox.isChecked = currentValue === 'account' || currentValue === 'technical';
+                    }
                 }
             }
 
@@ -170,7 +173,6 @@ MZViewBase {
                 Layout.rightMargin: MZTheme.theme.windowMargin
                 leftMargin: 0
                 showDivider: false
-                isChecked: dropDown.currentValue === 'account' || dropDown.currentValue === 'technical'
                 onClicked: () => isChecked = !isChecked
             }
         }


### PR DESCRIPTION
## Description

Force the default state of the 'Share Logs' checkbox when changing the category by using the dropdown's `onCurrentValueChanged` callback instead of the checkbox's `isChecked` property

## Reference

[Jira Issue](https://mozilla-hub.atlassian.net/browse/VPN-7642)

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
