### PR TITLE
VPN-7632 Fix title drifting right with wider shadows in Adwaita decoration

### DIFF
--- a/taskcluster/scripts/toolchain/patches/VPN-7529-qwaylandadwaitadecoration-add-shadows.patch
+++ b/taskcluster/scripts/toolchain/patches/VPN-7529-qwaylandadwaitadecoration-add-shadows.patch
@@ -1,5 +1,5 @@
 diff --git a/src/plugins/decorations/adwaita/qwaylandadwaitadecoration.cpp b/src/plugins/decorations/adwaita/qwaylandadwaitadecoration.cpp
-index ca1f0af0..5b6414f8 100644
+index ca1f0af0..2ee77937 100644
 --- a/src/plugins/decorations/adwaita/qwaylandadwaitadecoration.cpp
 +++ b/src/plugins/decorations/adwaita/qwaylandadwaitadecoration.cpp
 @@ -42,7 +42,7 @@ namespace QtWaylandClient {
@@ -108,6 +108,16 @@ index ca1f0af0..5b6414f8 100644
      /*
       * Titlebar and window border
       */
+@@ -162,7 +252,8 @@ void QWaylandAdwaitaDecoration::paint(QPaintDevice *device)
+     /*
+      * Window title
+      */
+-    const QRect top = QRect(margins().left(), margins().bottom(), surfaceRect.width(),
++    const QRect top = QRect(margins().left(), margins().bottom(),
++                            surfaceRect.width() - margins().left() - margins().right(),
+                             margins().top() - margins().bottom());
+     const QString windowTitleText = waylandWindow()->windowTitle();
+     if (!windowTitleText.isEmpty()) {
 diff --git a/src/plugins/decorations/adwaita/qwaylandadwaitadecoration_p.h b/src/plugins/decorations/adwaita/qwaylandadwaitadecoration_p.h
 index 34874e08..abd5c6d6 100644
 --- a/src/plugins/decorations/adwaita/qwaylandadwaitadecoration_p.h


### PR DESCRIPTION
## Description

Fix title drifting right with wider shadows in Adwaita decoration by  subtracting both side margins from the rect width.

The window title rect was built using the full `surfaceRect.width()` while its origin was already offset by `margins().left()`. Since the title was centered within this `rect (dx = (top.width() - size.width()) / 2)`, the left margin was counted twice, pushing the title right by `margins().left()` pixels.

This was always slightly off-center in the Adwaita decoration plugin, but became clearly visible after
`ceShadowsWidth` grew from 10 to 30 (except for me because i was looking at the shadows)

From the top:

- Title with unpatched qtwayland plugin
- Title after shadows patch 
- Fixed title

<img width="382" height="150" alt="Screenshot from 2026-06-09 19-20-53" src="https://github.com/user-attachments/assets/f3637ba2-659a-43f4-b750-100101949ff3" />


## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
