### PR TITLE
VPN-7646: Accessory widgets

### DIFF
--- a/ios/widgetextension/CMakeLists.txt
+++ b/ios/widgetextension/CMakeLists.txt
@@ -42,6 +42,8 @@ target_compile_options(widgetextension PRIVATE -DGROUP_ID=\"${BUILD_IOS_GROUP_ID
 target_compile_options(widgetextension PRIVATE -DNETWORK_EXTENSION=1)
 
 target_sources(widgetextension PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/CityAccessoryWidget.swift
+    ${CMAKE_CURRENT_SOURCE_DIR}/LogoAccessoryWidget.swift
     ${CMAKE_CURRENT_SOURCE_DIR}/ToggleIntent.swift
     ${CMAKE_CURRENT_SOURCE_DIR}/ToggleWidgetBundle.swift
     ${CMAKE_CURRENT_SOURCE_DIR}/ToggleWidgetControl.swift

--- a/ios/widgetextension/CityAccessoryWidget.swift
+++ b/ios/widgetextension/CityAccessoryWidget.swift
@@ -7,6 +7,58 @@ import NetworkExtension
 import SwiftUI
 import WidgetKit
 
+struct CityInlineAccessoryWidget: View {
+  @Environment(\.colorScheme) var colorScheme
+  let entry: VPNStatusEntry
+
+  var body: some View {
+    ViewThatFits(in: .horizontal) {
+      HStack(spacing: 4) {
+        Image(systemName: entry.isConnected ? "shield.lefthalf.filled" : "shield.lefthalf.filled.slash")
+          .font(.system(size: 26))
+        if let exitCity = entry.exitCity, !exitCity.isEmpty {
+          if let entryCity = entry.entryCity, !entryCity.isEmpty {
+            Text(LocalizedStringResource("vpn.multiHopFeature.multiHopToggleCTA", defaultValue: "Multi-hop"))
+          } else {
+            Text(exitCity)
+          }
+        }
+      }
+    }
+  }
+}
+
+struct CityRectangularAccessoryWidget: View {
+  @Environment(\.colorScheme) var colorScheme
+  let entry: VPNStatusEntry
+
+  var body: some View {
+    ZStack {
+      if entry.isConnected {
+        AccessoryWidgetBackground()
+      }
+      HStack {
+        VStack {
+          Image("logo")
+            .resizable()
+            .frame(width: 25, height: 25)
+          Spacer()
+          Image(systemName: entry.isConnected ? "shield.lefthalf.filled" : "shield.lefthalf.filled.slash")
+            .font(.system(size: 25))
+        }
+        Spacer()
+        CityTextComponentView(entry: entry)
+          .allowsTightening(true)
+          .minimumScaleFactor(0.5)
+        }
+        .padding(8)
+    }
+    .containerBackground(for: .widget) { // need this for AccessoryWidgetBackground to work, it seems
+      WidgetColors.backgroundColor(colorScheme, isConnected: entry.isConnected)
+    }
+  }
+}
+
 struct CityCircularAccessoryWidget: View {
   @Environment(\.colorScheme) var colorScheme
   let entry: VPNStatusEntry
@@ -54,6 +106,10 @@ struct CityAccessoryWidgetView: View {
     switch family {
     case .accessoryCircular:
       CityCircularAccessoryWidget(entry: entry)
+    case .accessoryInline:
+      CityInlineAccessoryWidget(entry: entry)
+    case .accessoryRectangular:
+      CityRectangularAccessoryWidget(entry: entry)
     default:
       // This should never be seen
       Text("Error: Unsupported widget size")
@@ -70,6 +126,6 @@ struct CityAccessoryWidget: Widget {
           }
           .configurationDisplayName(LocalizedStringResource("vpn.mobileOnboarding.panelOneTitle", defaultValue: "Mozilla VPN"))
           // .description(LocalizedStringResfource("vpn.accessoryCityWidget.description", defaultValue: "See current Mozilla VPN status")) // PUT THIS IN ALL THINGS
-          .supportedFamilies([.accessoryCircular])
+          .supportedFamilies([.accessoryCircular, .accessoryInline, .accessoryRectangular])
   }
 }

--- a/ios/widgetextension/CityAccessoryWidget.swift
+++ b/ios/widgetextension/CityAccessoryWidget.swift
@@ -128,7 +128,7 @@ struct CityAccessoryWidget: Widget {
             CityAccessoryWidgetView(entry: entry)
           }
           .configurationDisplayName(LocalizedStringResource("vpn.mobileOnboarding.panelOneTitle", defaultValue: "Mozilla VPN"))
-          // .description(LocalizedStringResfource("vpn.accessoryCityWidget.description", defaultValue: "See current Mozilla VPN status")) // PUT THIS IN ALL THINGS
+           .description(LocalizedStringResource("vpn.cityAccessoryWidget.description", defaultValue: "See current Mozilla VPN status, along with the current server."))
           .supportedFamilies([.accessoryCircular, .accessoryInline, .accessoryRectangular])
   }
 }

--- a/ios/widgetextension/CityAccessoryWidget.swift
+++ b/ios/widgetextension/CityAccessoryWidget.swift
@@ -129,7 +129,7 @@ struct CityAccessoryWidget: Widget {
             CityAccessoryWidgetView(entry: entry)
           }
           .configurationDisplayName(LocalizedStringResource("vpn.mobileOnboarding.panelOneTitle", defaultValue: "Mozilla VPN"))
-           .description(LocalizedStringResource("vpn.cityAccessoryWidget.description", defaultValue: "See current Mozilla VPN status, along with the current server."))
+          .description(LocalizedStringResource("vpn.cityAccessoryWidget.description", defaultValue: "See current Mozilla VPN status, along with the current server."))
           .supportedFamilies([.accessoryCircular, .accessoryInline, .accessoryRectangular])
   }
 }

--- a/ios/widgetextension/CityAccessoryWidget.swift
+++ b/ios/widgetextension/CityAccessoryWidget.swift
@@ -84,8 +84,7 @@ struct CityCircularAccessoryWidget: View {
         }
       }
       .padding(8)
-      .containerRelativeFrame(.vertical, alignment: .center)
-      .containerRelativeFrame(.horizontal, alignment: .center)
+      .containerRelativeFrame([.vertical, .horizontal])
     }
     .containerBackground(for: .widget) { // need this for AccessoryWidgetBackground to work, it seems
       WidgetColors.backgroundColor(colorScheme, isConnected: entry.isConnected)

--- a/ios/widgetextension/CityAccessoryWidget.swift
+++ b/ios/widgetextension/CityAccessoryWidget.swift
@@ -14,7 +14,7 @@ struct CityInlineAccessoryWidget: View {
   var body: some View {
     ViewThatFits(in: .horizontal) {
       HStack(spacing: 4) {
-        Image(systemName: entry.isConnected ? "shield.lefthalf.filled" : "shield.lefthalf.filled.slash")
+        Image(systemName: entry.sysImageName)
           .font(.system(size: 26))
         if let exitCity = entry.exitCity, !exitCity.isEmpty {
           if let entryCity = entry.entryCity, !entryCity.isEmpty {
@@ -43,7 +43,7 @@ struct CityRectangularAccessoryWidget: View {
             .resizable()
             .frame(width: 22, height: 22)
           Spacer()
-          Image(systemName: entry.isConnected ? "shield.lefthalf.filled" : "shield.lefthalf.filled.slash")
+          Image(systemName: entry.sysImageName)
             .font(.system(size: 22))
         }
         Spacer()
@@ -74,7 +74,7 @@ struct CityCircularAccessoryWidget: View {
           .padding(5)
       }
       VStack(spacing: 7) {
-        Image(systemName: entry.isConnected ? "shield.lefthalf.filled" : "shield.lefthalf.filled.slash")
+        Image(systemName: entry.sysImageName)
           .font(.system(size: 20))
         if let exitCity = entry.exitCity, !exitCity.isEmpty {
           if let entryCity = entry.entryCity, !entryCity.isEmpty {

--- a/ios/widgetextension/CityAccessoryWidget.swift
+++ b/ios/widgetextension/CityAccessoryWidget.swift
@@ -41,17 +41,17 @@ struct CityRectangularAccessoryWidget: View {
         VStack {
           Image("logo")
             .resizable()
-            .frame(width: 25, height: 25)
+            .frame(width: 22, height: 22)
           Spacer()
           Image(systemName: entry.isConnected ? "shield.lefthalf.filled" : "shield.lefthalf.filled.slash")
-            .font(.system(size: 25))
+            .font(.system(size: 22))
         }
         Spacer()
         CityTextComponentView(entry: entry)
           .allowsTightening(true)
           .minimumScaleFactor(0.5)
         }
-        .padding(8)
+        .padding(10)
     }
     .containerBackground(for: .widget) { // need this for AccessoryWidgetBackground to work, it seems
       WidgetColors.backgroundColor(colorScheme, isConnected: entry.isConnected)
@@ -71,10 +71,11 @@ struct CityCircularAccessoryWidget: View {
     ZStack {
       if entry.isConnected {
         AccessoryWidgetBackground()
+          .padding(5)
       }
       VStack(spacing: 7) {
         Image(systemName: entry.isConnected ? "shield.lefthalf.filled" : "shield.lefthalf.filled.slash")
-          .font(.system(size: 25))
+          .font(.system(size: 20))
         if let exitCity = entry.exitCity, !exitCity.isEmpty {
           if let entryCity = entry.entryCity, !entryCity.isEmpty {
             formattedText(String(localized: LocalizedStringResource("vpn.multiHopFeature.multiHopToggleCTA", defaultValue: "Multi-hop")))
@@ -83,7 +84,7 @@ struct CityCircularAccessoryWidget: View {
           }
         }
       }
-      .padding(8)
+      .padding(12)
       .containerRelativeFrame([.vertical, .horizontal])
     }
     .containerBackground(for: .widget) { // need this for AccessoryWidgetBackground to work, it seems

--- a/ios/widgetextension/CityAccessoryWidget.swift
+++ b/ios/widgetextension/CityAccessoryWidget.swift
@@ -56,6 +56,10 @@ struct CityRectangularAccessoryWidget: View {
     .containerBackground(for: .widget) { // need this for AccessoryWidgetBackground to work, it seems
       WidgetColors.backgroundColor(colorScheme, isConnected: entry.isConnected)
     }
+    .containerRelativeFrame([.horizontal, .vertical])
+    .mask {
+      RoundedRectangle(cornerRadius: 10, style: .continuous)
+    }
   }
 }
 

--- a/ios/widgetextension/CityAccessoryWidget.swift
+++ b/ios/widgetextension/CityAccessoryWidget.swift
@@ -1,0 +1,75 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import AppIntents
+import NetworkExtension
+import SwiftUI
+import WidgetKit
+
+struct CityCircularAccessoryWidget: View {
+  @Environment(\.colorScheme) var colorScheme
+  let entry: VPNStatusEntry
+
+  var body: some View {
+    ZStack {
+      if entry.isConnected {
+        AccessoryWidgetBackground()
+      }
+      VStack(spacing: 7) {
+        Image(systemName: entry.isConnected ? "shield.lefthalf.filled" : "shield.lefthalf.filled.slash")
+          .font(.system(size: 25))
+        if let exitCity = entry.exitCity, !exitCity.isEmpty {
+          if let entryCity = entry.entryCity, !entryCity.isEmpty {
+            formattedText(String(localized: LocalizedStringResource("vpn.multiHopFeature.multiHopToggleCTA", defaultValue: "Multi-hop")))
+          } else {
+            formattedText(exitCity)
+          }
+        }
+      }
+      .padding(8)
+      .containerRelativeFrame(.vertical, alignment: .center)
+      .containerRelativeFrame(.horizontal, alignment: .center)
+    }
+    .containerBackground(for: .widget) { // need this for AccessoryWidgetBackground to work, it seems
+      WidgetColors.backgroundColor(colorScheme, isConnected: entry.isConnected)
+    }
+  }
+
+  func formattedText(_ text: String) -> some View {
+    return Text(text)
+      .font(Font.custom("Metropolis", size: 13))
+      .allowsTightening(true)
+      .minimumScaleFactor(0.5)
+      .multilineTextAlignment(.center)
+      .foregroundStyle(WidgetColors.cityTextColor(colorScheme, isConnected: entry.isConnected))
+  }
+}
+
+struct CityAccessoryWidgetView: View {
+  @Environment(\.widgetFamily) var family
+  let entry: VPNStatusEntry
+
+  var body: some View {
+    switch family {
+    case .accessoryCircular:
+      CityCircularAccessoryWidget(entry: entry)
+    default:
+      // This should never be seen
+      Text("Error: Unsupported widget size")
+    }
+  }
+}
+
+struct CityAccessoryWidget: Widget {
+  static let kind = "org.mozilla.ios.FirefoxVPN.CityAccessoryWidget"
+
+  var body: some WidgetConfiguration {
+      return StaticConfiguration(kind: Self.kind, provider: VPNStatusProvider()) { entry in
+            CityAccessoryWidgetView(entry: entry)
+          }
+          .configurationDisplayName(LocalizedStringResource("vpn.mobileOnboarding.panelOneTitle", defaultValue: "Mozilla VPN"))
+          // .description(LocalizedStringResfource("vpn.accessoryCityWidget.description", defaultValue: "See current Mozilla VPN status")) // PUT THIS IN ALL THINGS
+          .supportedFamilies([.accessoryCircular])
+  }
+}

--- a/ios/widgetextension/LogoAccessoryWidget.swift
+++ b/ios/widgetextension/LogoAccessoryWidget.swift
@@ -33,6 +33,21 @@ struct LogoCircularAccessoryWidget: View {
   }
 }
 
+struct LogoInlineAccessoryWidget: View {
+  @Environment(\.colorScheme) var colorScheme
+  let entry: VPNStatusEntry
+
+  var body: some View {
+    ViewThatFits(in: .horizontal) {
+      HStack(spacing: 4) {
+        Image(systemName: entry.isConnected ? "shield.lefthalf.filled" : "shield.lefthalf.filled.slash")
+          .font(.system(size: 26))
+        Text(entry.isConnected ? "Mozilla VPN On" : "Mozilla VPN Off") // GET TRANSLATIONS FOR THIS
+      }
+    }
+  }
+}
+
 struct LogoAccessoryWidgetView: View {
   @Environment(\.widgetFamily) var family
   let entry: VPNStatusEntry
@@ -41,6 +56,8 @@ struct LogoAccessoryWidgetView: View {
     switch family {
     case .accessoryCircular:
       LogoCircularAccessoryWidget(entry: entry)
+    case .accessoryInline:
+      LogoInlineAccessoryWidget(entry: entry)
     default:
       // This should never be seen
       Text("Error: Unsupported widget size")
@@ -57,6 +74,6 @@ struct LogoAccessoryWidget: Widget {
           }
           .configurationDisplayName(LocalizedStringResource("vpn.mobileOnboarding.panelOneTitle", defaultValue: "Mozilla VPN"))
           // .description(LocalizedStringResfource("vpn.accessoryLogoWidget.description", defaultValue: "See current Mozilla VPN status")) // PUT THIS IN ALL THINGS
-          .supportedFamilies([.accessoryCircular])
+          .supportedFamilies([.accessoryCircular, .accessoryInline])
   }
 }

--- a/ios/widgetextension/LogoAccessoryWidget.swift
+++ b/ios/widgetextension/LogoAccessoryWidget.swift
@@ -22,7 +22,7 @@ struct LogoCircularAccessoryWidget: View {
           .resizable()
           .frame(width: 16, height: 16)
           .containerRelativeFrame(.horizontal, alignment: .center)
-        Image(systemName: entry.isConnected ? "shield.lefthalf.filled" : "shield.lefthalf.filled.slash")
+        Image(systemName: entry.sysImageName)
           .font(.system(size: 22))
           .containerRelativeFrame(.horizontal, alignment: .center)
       }
@@ -41,7 +41,7 @@ struct LogoInlineAccessoryWidget: View {
   var body: some View {
     ViewThatFits(in: .horizontal) {
       HStack(spacing: 4) {
-        Image(systemName: entry.isConnected ? "shield.lefthalf.filled" : "shield.lefthalf.filled.slash")
+        Image(systemName: entry.sysImageName)
           .font(.system(size: 26))
         Text(entry.isConnected ? LocalizedStringResource("vpn.logoAccessoryWidget.vpnOn", defaultValue: "Mozilla VPN on") : LocalizedStringResource("vpn.logoAccessoryWidget.vpnOff", defaultValue: "Mozilla VPN off"))
       }

--- a/ios/widgetextension/LogoAccessoryWidget.swift
+++ b/ios/widgetextension/LogoAccessoryWidget.swift
@@ -1,0 +1,62 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import AppIntents
+import NetworkExtension
+import SwiftUI
+import WidgetKit
+
+struct LogoCircularAccessoryWidget: View {
+  @Environment(\.colorScheme) var colorScheme
+  let entry: VPNStatusEntry
+
+  var body: some View {
+    ZStack {
+      if entry.isConnected {
+        AccessoryWidgetBackground()
+      }
+      VStack(spacing: 7) {
+        Image("logo")
+          .resizable()
+          .frame(width: 18, height: 18)
+          .containerRelativeFrame(.horizontal, alignment: .center)
+        Image(systemName: entry.isConnected ? "shield.lefthalf.filled" : "shield.lefthalf.filled.slash")
+          .font(.system(size: 25))
+          .containerRelativeFrame(.horizontal, alignment: .center)
+      }
+      .containerRelativeFrame(.vertical, alignment: .center)
+    }
+    .containerBackground(for: .widget) { // need this for AccessoryWidgetBackground to work, it seems
+      WidgetColors.backgroundColor(colorScheme, isConnected: entry.isConnected)
+    }
+  }
+}
+
+struct LogoAccessoryWidgetView: View {
+  @Environment(\.widgetFamily) var family
+  let entry: VPNStatusEntry
+
+  var body: some View {
+    switch family {
+    case .accessoryCircular:
+      LogoCircularAccessoryWidget(entry: entry)
+    default:
+      // This should never be seen
+      Text("Error: Unsupported widget size")
+    }
+  }
+}
+
+struct LogoAccessoryWidget: Widget {
+  static let kind = "org.mozilla.ios.FirefoxVPN.LogoAccessoryWidget"
+
+  var body: some WidgetConfiguration {
+      return StaticConfiguration(kind: Self.kind, provider: VPNStatusProvider()) { entry in
+            LogoAccessoryWidgetView(entry: entry)
+          }
+          .configurationDisplayName(LocalizedStringResource("vpn.mobileOnboarding.panelOneTitle", defaultValue: "Mozilla VPN"))
+          // .description(LocalizedStringResfource("vpn.accessoryLogoWidget.description", defaultValue: "See current Mozilla VPN status")) // PUT THIS IN ALL THINGS
+          .supportedFamilies([.accessoryCircular])
+  }
+}

--- a/ios/widgetextension/LogoAccessoryWidget.swift
+++ b/ios/widgetextension/LogoAccessoryWidget.swift
@@ -73,7 +73,7 @@ struct LogoAccessoryWidget: Widget {
             LogoAccessoryWidgetView(entry: entry)
           }
           .configurationDisplayName(LocalizedStringResource("vpn.mobileOnboarding.panelOneTitle", defaultValue: "Mozilla VPN"))
-          // .description(LocalizedStringResfource("vpn.accessoryLogoWidget.description", defaultValue: "See current Mozilla VPN status")) // PUT THIS IN ALL THINGS
+          .description(LocalizedStringResource("vpn.logoAccessoryWidget.description", defaultValue: "See current Mozilla VPN status."))
           .supportedFamilies([.accessoryCircular, .accessoryInline])
   }
 }

--- a/ios/widgetextension/LogoAccessoryWidget.swift
+++ b/ios/widgetextension/LogoAccessoryWidget.swift
@@ -15,14 +15,15 @@ struct LogoCircularAccessoryWidget: View {
     ZStack {
       if entry.isConnected {
         AccessoryWidgetBackground()
+          .padding(5)
       }
       VStack(spacing: 7) {
         Image("logo")
           .resizable()
-          .frame(width: 18, height: 18)
+          .frame(width: 16, height: 16)
           .containerRelativeFrame(.horizontal, alignment: .center)
         Image(systemName: entry.isConnected ? "shield.lefthalf.filled" : "shield.lefthalf.filled.slash")
-          .font(.system(size: 25))
+          .font(.system(size: 22))
           .containerRelativeFrame(.horizontal, alignment: .center)
       }
       .containerRelativeFrame(.vertical, alignment: .center)
@@ -42,7 +43,7 @@ struct LogoInlineAccessoryWidget: View {
       HStack(spacing: 4) {
         Image(systemName: entry.isConnected ? "shield.lefthalf.filled" : "shield.lefthalf.filled.slash")
           .font(.system(size: 26))
-        Text(entry.isConnected ? "Mozilla VPN On" : "Mozilla VPN Off") // GET TRANSLATIONS FOR THIS
+        Text(entry.isConnected ? LocalizedStringResource("vpn.logoAccessoryWidget.vpnOn", defaultValue: "Mozilla VPN on") : LocalizedStringResource("vpn.logoAccessoryWidget.vpnOff", defaultValue: "Mozilla VPN off"))
       }
     }
   }

--- a/ios/widgetextension/ToggleWidget.swift
+++ b/ios/widgetextension/ToggleWidget.swift
@@ -12,6 +12,10 @@ struct VPNStatusEntry: TimelineEntry {
   let isConnected: Bool
   let entryCity: String?
   let exitCity: String?
+
+  var sysImageName: String {
+    return isConnected ? "shield.lefthalf.filled" : "shield.lefthalf.filled.slash"
+  }
 }
 
 struct VPNStatusProvider: TimelineProvider {

--- a/ios/widgetextension/ToggleWidget.swift
+++ b/ios/widgetextension/ToggleWidget.swift
@@ -113,6 +113,29 @@ struct CityTextToggleComponentView: View {
   @ViewBuilder
   var body: some View {
 
+    CityTextComponentView(entry: entry, largeText: largeText)
+
+    Spacer(minLength: 10)
+
+    Toggle("VPN", isOn: entry.isConnected, intent: ToggleIntent(value: !entry.isConnected))
+      .toggleStyle(WidgetSwitchToggleStyle(capsuleColor: WidgetColors.toggleBackground(colorScheme, isConnected: entry.isConnected), circleColor: WidgetColors.toggleCircle(colorScheme, isConnected: entry.isConnected)))
+      .labelsHidden()
+      .frame(maxWidth: .infinity, alignment: .center)
+  }
+}
+
+struct CityTextComponentView: View {
+  @Environment(\.colorScheme) var colorScheme
+  let entry: VPNStatusEntry
+  let largeText: Bool
+
+  init(entry: VPNStatusEntry, largeText: Bool = false) {
+    self.entry = entry
+    self.largeText = largeText
+  }
+
+  @ViewBuilder
+  var body: some View {
     if let exitCity = entry.exitCity, !exitCity.isEmpty {
 
       if let entryCity = entry.entryCity, !entryCity.isEmpty {
@@ -134,14 +157,9 @@ struct CityTextToggleComponentView: View {
           .foregroundStyle(WidgetColors.cityTextColor(colorScheme, isConnected: entry.isConnected))
           .multilineTextAlignment(.center)
       }
-
-      Spacer(minLength: 10)
+    } else {
+      EmptyView()
     }
-
-    Toggle("VPN", isOn: entry.isConnected, intent: ToggleIntent(value: !entry.isConnected))
-      .toggleStyle(WidgetSwitchToggleStyle(capsuleColor: WidgetColors.toggleBackground(colorScheme, isConnected: entry.isConnected), circleColor: WidgetColors.toggleCircle(colorScheme, isConnected: entry.isConnected)))
-      .labelsHidden()
-      .frame(maxWidth: .infinity, alignment: .center)
   }
 }
 
@@ -172,20 +190,6 @@ struct WidgetSwitchToggleStyle: ToggleStyle {
   }
 }
 
-struct ToggleWidget: Widget {
-  static let kind = "org.mozilla.ios.FirefoxVPN.ToggleWidget"
-
-  var body: some WidgetConfiguration {
-    StaticConfiguration(kind: Self.kind, provider: VPNStatusProvider()) { entry in
-      ToggleWidgetView(entry: entry)
-    }
-    .configurationDisplayName(LocalizedStringResource("vpn.mobileOnboarding.panelOneTitle", defaultValue: "Mozilla VPN"))
-    .description(LocalizedStringResource("vpn.toggleWidget.description", defaultValue: "Turn Mozilla VPN on and off, and see the current location."))
-    .supportedFamilies([.systemSmall, .systemMedium])
-  }
-}
-
-
 struct ToggleWidgetView: View {
   @Environment(\.widgetFamily) var family
   let entry: VPNStatusEntry
@@ -199,6 +203,24 @@ struct ToggleWidgetView: View {
     default:
       // This should never be seen
       Text("Error: Unsupported widget size")
+    }
+  }
+}
+
+struct ToggleWidget: Widget {
+  static let kind = "org.mozilla.ios.FirefoxVPN.ToggleWidget"
+
+  var body: some WidgetConfiguration {
+      let config = StaticConfiguration(kind: Self.kind, provider: VPNStatusProvider()) { entry in
+            ToggleWidgetView(entry: entry)
+          }
+          .configurationDisplayName(LocalizedStringResource("vpn.mobileOnboarding.panelOneTitle", defaultValue: "Mozilla VPN"))
+          .description(LocalizedStringResource("vpn.toggleWidget.description", defaultValue: "Turn Mozilla VPN on and off, and see the current location."))
+          .supportedFamilies([.systemSmall, .systemMedium])
+    if #available(iOS 26.0, *) {
+      return config.disfavoredLocations([.carPlay, .iPhoneWidgetsOnMac, .standBy], for: [.systemSmall, .systemMedium])
+    } else {
+      return config.disfavoredLocations([.iPhoneWidgetsOnMac, .standBy], for: [.systemSmall, .systemMedium])
     }
   }
 }

--- a/ios/widgetextension/ToggleWidget.swift
+++ b/ios/widgetextension/ToggleWidget.swift
@@ -16,7 +16,7 @@ struct VPNStatusEntry: TimelineEntry {
 
 struct VPNStatusProvider: TimelineProvider {
   func placeholder(in context: Context) -> VPNStatusEntry {
-    VPNStatusEntry(date: Date(), isConnected: true, entryCity: "-------", exitCity: nil)
+    VPNStatusEntry(date: Date(), isConnected: true, entryCity: "Portland", exitCity: nil)
   }
 
   func getSnapshot(in context: Context, completion: @escaping (VPNStatusEntry) -> Void) {
@@ -156,6 +156,7 @@ struct CityTextComponentView: View {
           .font(Font.custom("Metropolis", size: largeText ? 25 : 16))
           .foregroundStyle(WidgetColors.cityTextColor(colorScheme, isConnected: entry.isConnected))
           .multilineTextAlignment(.center)
+          .lineSpacing(5.0)
       }
     } else {
       EmptyView()

--- a/ios/widgetextension/ToggleWidgetBundle.swift
+++ b/ios/widgetextension/ToggleWidgetBundle.swift
@@ -9,6 +9,8 @@ import SwiftUI
 struct ToggleWidgetBundle: WidgetBundle {
     var body: some Widget {
         ToggleWidget()
+        LogoAccessoryWidget()
+        CityAccessoryWidget()
         if #available(iOS 18.0, *) {
             ToggleWidgetControl()
         }

--- a/scripts/utils/generate_xcstrings.py
+++ b/scripts/utils/generate_xcstrings.py
@@ -258,10 +258,19 @@ def main():
             exit(1)
         shortcut_strings.append(current_string_set)
 
+    WIDGET_STRING_PREFIXES = (
+      "vpn.iosAppIntentsMain",
+      "vpn.mobileOnboarding.panelOneTitle",
+      "vpn.toggleWidget",
+      "vpn.cityAccessoryWidget",
+      "vpn.logoAccessoryWidget",
+      "vpn.multiHopFeature.multiHopToggleCTA"
+    )
+
     main_strings = {
         k: v
         for k, v in all_strings.items()
-        if v["string_id"].startswith("vpn.iosAppIntentsMain") or v["string_id"].startswith("vpn.mobileOnboarding.panelOneTitle") or v["string_id"].startswith("vpn.toggleWidget") or v["string_id"].startswith("vpn.multiHopFeature.multiHopToggleCTA")
+        if v["string_id"].startswith(WIDGET_STRING_PREFIXES)
     }
 
     intent_titles = ["vpn.iosAppIntentsMain.statusQueryTitle", "vpn.iosAppIntentsMain.turnOffAction", "vpn.iosAppIntentsMain.turnOnAction"]

--- a/scripts/utils/generate_xcstrings.py
+++ b/scripts/utils/generate_xcstrings.py
@@ -261,7 +261,7 @@ def main():
     main_strings = {
         k: v
         for k, v in all_strings.items()
-        if v["string_id"].startswith("vpn.iosAppIntentsMain") or v["string_id"].startswith("vpn.mobileOnboarding.panelOneTitle") or v["string_id"].startswith("vpn.toggleWidget")
+        if v["string_id"].startswith("vpn.iosAppIntentsMain") or v["string_id"].startswith("vpn.mobileOnboarding.panelOneTitle") or v["string_id"].startswith("vpn.toggleWidget") or v["string_id"].startswith("vpn.multiHopFeature.multiHopToggleCTA")
     }
 
     intent_titles = ["vpn.iosAppIntentsMain.statusQueryTitle", "vpn.iosAppIntentsMain.turnOffAction", "vpn.iosAppIntentsMain.turnOnAction"]

--- a/src/translations/strings.yaml
+++ b/src/translations/strings.yaml
@@ -1150,6 +1150,12 @@ logoAccessoryWidget:
   description:
     value: See current Mozilla VPN status.
     comment: More information about what the logo widget contains - which is simply current VPN status.
+  vpnOn:
+    value: Mozilla VPN on
+    comment: Very short string shown when VPN is active
+  vpnOff:
+    value: Mozilla VPN off
+    comment: Very short string shown when VPN is inactive
 
 cityAccessoryWidget:
   description:

--- a/src/translations/strings.yaml
+++ b/src/translations/strings.yaml
@@ -1152,10 +1152,10 @@ logoAccessoryWidget:
     comment: More information about what the logo widget contains - which is simply current VPN status.
   vpnOn:
     value: Mozilla VPN on
-    comment: Very short string shown when VPN is active
+    comment: Shown as part of inline widget when VPN is active. If translation will be more than 16 characters, instead translate `VPN on` to keep this within available space.
   vpnOff:
     value: Mozilla VPN off
-    comment: Very short string shown when VPN is inactive
+    comment: Shown as part of inline widget when VPN is inactive.  If translation will be more than 16 characters, instead translate `VPN on` to keep this within available space.
 
 cityAccessoryWidget:
   description:

--- a/src/translations/strings.yaml
+++ b/src/translations/strings.yaml
@@ -1146,6 +1146,16 @@ toggleWidget:
     value: Turn Mozilla VPN on and off, and see the current location.
     comment: More information about what the Mozilla VPN widget contains.
 
+logoAccessoryWidget:
+  description:
+    value: See current Mozilla VPN status.
+    comment: More information about what the logo widget contains - which is simply current VPN status.
+
+cityAccessoryWidget:
+  description:
+    value: See current Mozilla VPN status, along with the current server.
+    comment: More information about what the city widget contains - which is current VPN status and the current city server.
+
 iosAppIntentsActivate:
   phrases:
     value: |


### PR DESCRIPTION
## Description

Adding several iOS accessory widgets - 2 round, 2 inline (where we get just text and an SF symbol), and one rectangular.

Also snuck in some improvements to existing widgets:
- It doesn't seem like a good candidate for Standby (nightstand mode on iOS) nor Carplay, so removed them from these spots. (Dark mode didn't work for Standby, and I realized it wasn't worth fixing it.) Inexplicably deprioritizing CarPlay is only available on iOS 26+, hence the split logic there.
- Restructured code to allow for more reuse

## Images
Single hop (both round, sole rectangular, and the city name inline one - inline one is next to date on top)
<img width="263" alt="IMG_0069" src="https://github.com/user-attachments/assets/c7f1214b-c82a-4514-ad5d-bf393e014709" /> <img width="263" alt="IMG_0070" src="https://github.com/user-attachments/assets/7a10cc28-e96e-468c-9403-d9ccba45ed2d" />

Multi-hop (both round, sole rectangular, and the simple inline one - inline one is next to date on top)
<img width="263" alt="IMG_0073" src="https://github.com/user-attachments/assets/7d09e534-6347-4aef-9bb7-dc940a42d1f2" /><img width="263" alt="IMG_0074" src="https://github.com/user-attachments/assets/ad941136-1ecb-404d-8786-fcf59c84dd65" />



## Reference

VPN-7646

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
