### PR TITLE
NIT: Fix CMAKE_CROSSCOMPILING detection for conda toolchains

### DIFF
--- a/scripts/windows/conda-toolchain.cmake
+++ b/scripts/windows/conda-toolchain.cmake
@@ -17,9 +17,7 @@ endif()
 # Specify default system configuration, if cross compiling
 set(CMAKE_SYSTEM_NAME "Windows" CACHE STRING "Target operating system name")
 set(CMAKE_SYSTEM_VERSION "10.0" CACHE STRING "Target operating system version")
-if(NOT CMAKE_HOST_SYSTEM_NAME STREQUAL "Windows")
-    set(CMAKE_CROSSCOMPILING TRUE CACHE BOOL "Target is cross compiled")
-elseif(NOT CMAKE_HOST_SYSTEM_PROCESSOR)
+if((CMAKE_HOST_SYSTEM_NAME STREQUAL "Windows") AND (NOT CMAKE_HOST_SYSTEM_PROCESSOR))
     string(TOLOWER "$ENV{PROCESSOR_ARCHITECTURE}" CMAKE_HOST_SYSTEM_PROCESSOR)
 endif()
 
@@ -43,6 +41,13 @@ elseif(LOWERCASE_SYSTEM_PROCESSOR STREQUAL "arm64")
     set(CMAKE_RC_COMPILER_TARGET aarch64-pc-windows-msvc)
 else()
     message(FATAL_ERROR "Unsupported system processor: ${CMAKE_SYSTEM_PROCESSOR}")
+endif()
+
+# We are not considered cross compiling iff building on Windows and the processor matches.
+if((CMAKE_HOST_SYSTEM_NAME STREQUAL "Windows") AND (LOWERCASE_SYSTEM_PROCESSOR STREQUAL CMAKE_HOST_SYSTEM_PROCESSOR))
+    set(CMAKE_CROSSCOMPILING FALSE CACHE BOOL "Target is natively compiled")
+else()
+    set(CMAKE_CROSSCOMPILING TRUE CACHE BOOL "Target is cross compiled")
 endif()
 
 # Set the C++ compiler and tools.


### PR DESCRIPTION
## Description
There was a small detail I missed in the CMake [documentation](https://cmake.org/cmake/help/latest/variable/CMAKE_CROSSCOMPILING.html) when writing the `conda-toolchain.cmake` file for Windows, notably:
> This variable will be set to true by CMake if the [CMAKE_SYSTEM_NAME](https://cmake.org/cmake/help/latest/variable/CMAKE_SYSTEM_NAME.html#variable:CMAKE_SYSTEM_NAME) variable has been set manually (i.e. in a toolchain file or as a cache entry from the [cmake](https://cmake.org/cmake/help/latest/manual/cmake.1.html#manual:cmake(1)) command line).

Therefore, since `CMAKE_SYSTEM_NAME` is set explicitly, the value of `CMAKE_CROSSCOMPILING` is also always true. This doesn't really break anything in the build - it all just kinda works out anways. But we disable the unit and functional test targets when cross-compiling and that makes testing in a Windows dev environment kind of a pain.

To fix it, we need to explicitly set `CMAKE_CROSSCOMPILING` by checking if the OS and target processor are a match to the host environment.

## Reference

    i.e Jira or Github issue URL

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
