### PR TITLE
VPN-7662 - Submit button not working for unauthenticated users

### DIFF
--- a/src/qmlengineholder.cpp
+++ b/src/qmlengineholder.cpp
@@ -25,6 +25,7 @@
 #include "theme.h"
 #include "urlopener.h"
 #include "utils.h"
+#include "validator.h"
 
 #ifdef SENTRY_ENABLED
 #  include "sentry/sentryadapter.h"
@@ -84,7 +85,8 @@ QmlEngineHolder::QmlEngineHolder(QQmlEngine* engine) : m_engine(engine) {
                                UrlOpener::instance());
   qmlRegisterSingletonInstance("Mozilla.Shared", 1, 0, "MZUtils",
                                Utils::instance());
-
+  qmlRegisterSingletonInstance("Mozilla.Shared", 1, 0, "MZValidator",
+                               Validator::instance());
   Theme::instance()->initialize(engine);
   qmlRegisterSingletonInstance("Mozilla.Shared", 1, 0, "MZTheme",
                                Theme::instance());

--- a/src/ui/screens/getHelp/contactUs/ViewContactUsForm.qml
+++ b/src/ui/screens/getHelp/contactUs/ViewContactUsForm.qml
@@ -90,7 +90,7 @@ MZViewBase {
 
                         verticalAlignment: Text.AlignVCenter
                         Layout.fillWidth: true
-                        hasError: !MZAuthInApp.validateEmailAddress(emailInput.text)
+                        hasError: !MZValidator.validateEmailAddress(emailInput.text)
                         _placeholderText: MZI18n.InAppSupportWorkflowSupportEmailFieldPlaceholder
                     }
                 }
@@ -100,7 +100,7 @@ MZViewBase {
 
                     verticalAlignment: Text.AlignVCenter
                     Layout.fillWidth: true
-                    hasError: !MZAuthInApp.validateEmailAddress(confirmEmailInput.text) || emailInput.text != confirmEmailInput.text
+                    hasError: !MZValidator.validateEmailAddress(confirmEmailInput.text) || emailInput.text != confirmEmailInput.text
                     _placeholderText: MZI18n.InAppSupportWorkflowSupportConfirmEmailPlaceholder
                 }
             }
@@ -202,7 +202,7 @@ MZViewBase {
                     }
                     enabled: dropDown.currentValue != null && textArea.userEntry != "" &&
                              (VPN.userAuthenticated  ? true :
-                                (MZAuthInApp.validateEmailAddress(emailInput.text) && emailInput.text == confirmEmailInput.text)
+                                (MZValidator.validateEmailAddress(emailInput.text) && emailInput.text == confirmEmailInput.text)
                              )
                     opacity: enabled ? 1 : .5
                     Layout.preferredHeight: MZTheme.theme.rowHeight

--- a/src/ui/screens/getHelp/contactUs/ViewContactUsForm.qml
+++ b/src/ui/screens/getHelp/contactUs/ViewContactUsForm.qml
@@ -87,6 +87,7 @@ MZViewBase {
 
                     MZTextField {
                         id: emailInput
+                        objectName: "contactUs-emailInput"
 
                         verticalAlignment: Text.AlignVCenter
                         Layout.fillWidth: true
@@ -97,6 +98,7 @@ MZViewBase {
 
                 MZTextField {
                     id: confirmEmailInput
+                    objectName: "contactUs-confirmEmailInput"
 
                     verticalAlignment: Text.AlignVCenter
                     Layout.fillWidth: true

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -77,6 +77,8 @@ add_library(mzutils STATIC
     taskgroup.h
     taskscheduler.cpp
     taskscheduler.h
+    validator.cpp
+    validator.h
 )
 
 # Signal handling for unix platforms

--- a/src/utils/validator.cpp
+++ b/src/utils/validator.cpp
@@ -1,0 +1,71 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "validator.h"
+
+#include <QCoreApplication>
+#include <QFile>
+#include <QMetaEnum>
+#include <QRegularExpression>
+
+#include "leakdetector.h"
+#include "logger.h"
+
+namespace {
+Logger logger("Validator");
+Validator* s_instance = nullptr;
+}  // namespace
+
+// static
+Validator* Validator::instance() {
+  if (!s_instance) {
+    s_instance = new Validator(qApp);
+    qAddPostRoutine([]() { delete s_instance; });
+  }
+  return s_instance;
+}
+
+Validator::Validator(QObject* parent) : QObject(parent) {
+  MZ_COUNT_CTOR(Validator);
+  Q_ASSERT(!s_instance);
+}
+
+Validator::~Validator() {
+  MZ_COUNT_DTOR(Validator);
+  Q_ASSERT(s_instance == this);
+  s_instance = nullptr;
+}
+
+// static
+bool Validator::validateEmailAddress(const QString& emailAddress) {
+  // https://github.com/mozilla/fxa/blob/main/packages/fxa-auth-server/lib/routes/validators.js#L144-L177
+
+  if (emailAddress.isEmpty()) {
+    return false;
+  }
+
+  QStringList parts = emailAddress.split("@");
+  if (parts.length() != 2 || parts[1].length() > 255) {
+    return false;
+  }
+
+  static QRegularExpression emailRE("^[A-Z0-9.!#$%&'*+/=?^_`{|}~-]{1,64}$",
+                                    QRegularExpression::CaseInsensitiveOption);
+  // We don't have to convert the first part of the email address to ASCII
+  // Compatible Encoding (ace).
+  if (!emailRE.match(parts[0]).hasMatch()) {
+    return false;
+  }
+
+  QByteArray domainAce = QUrl::toAce(parts[1]);
+  static QRegularExpression domainRE(
+      "^[A-Z0-9](?:[A-Z0-9-]{0,253}[A-Z0-9])?(?:\\.[A-Z0-9](?:[A-Z0-9-]{0,253}["
+      "A-Z0-9])?)+$",
+      QRegularExpression::CaseInsensitiveOption);
+  if (!domainRE.match(domainAce).hasMatch()) {
+    return false;
+  }
+
+  return true;
+}

--- a/src/utils/validator.h
+++ b/src/utils/validator.h
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef VALIDATOR_H
+#define VALIDATOR_H
+
+#include <QObject>
+#include <QUrl>
+
+class Validator final : public QObject {
+  Q_OBJECT
+  Q_DISABLE_COPY_MOVE(Validator)
+
+ public:
+  static Validator* instance();
+  Q_INVOKABLE static bool validateEmailAddress(const QString& emailAddress);
+
+ private:
+  explicit Validator(QObject* parent);
+  ~Validator();
+};
+
+#endif  // VALIDATOR_H

--- a/tests/functional/queries.js
+++ b/tests/functional/queries.js
@@ -259,6 +259,8 @@ const screenGetHelp = {
   contactSupportView: {
     VIEW: new QmlQueryComposer('//contactUs-flickable'),
     UNAUTH_USER_INPUTS: new QmlQueryComposer('//contactUs-unauthedUserInputs'),
+    EMAIL_INPUT: new QmlQueryComposer('//contactUs-emailInput'),
+    CONFIRM_EMAIL_INPUT: new QmlQueryComposer('//contactUs-confirmEmailInput'),
     USER_INFO: new QmlQueryComposer('//contactUs-userInfo'),
     SHARE_LOGS_CHECKBOX: new QmlQueryComposer('//contactUs-shareLogsCheckBox'),
     DROPDOWN: new QmlQueryComposer('//contactUs-dropDown'),

--- a/tests/functional/testContactUs.js
+++ b/tests/functional/testContactUs.js
@@ -9,28 +9,89 @@ const {validators} = require('./servers/guardian_endpoints.js');
 
 
 describe('Contact us view', function() {
-  it('VPNUserInfo is not visible to unathenticated users', async () => {
-    await vpn.waitForQueryAndClick(queries.screenInitialize.GET_HELP_LINK);
-    await vpn.waitForQuery(queries.screenGetHelp.LINKS.visible());
+  describe('Contact us view - unauthenticated user', function() {
+    this.ctx.authenticationNeeded = false;
 
-    await vpn.waitForQueryAndClick(queries.screenGetHelp.SUPPORT);
+    const ticket = {
+      email: null,
+      logs: null,
+      versionString: null,
+      platformVersion: null,
+      subject: null,
+      issueText: null,
+      category: null
+    };
 
-    await vpn.waitForQuery(
-        queries.screenGetHelp.contactSupportView.USER_INFO.hidden());
-    assert.equal(
-        await vpn.getQueryProperty(
-            queries.screenGetHelp.contactSupportView.USER_INFO, 'visible'),
-        'false');
-  });
+    this.ctx.guardianOverrideEndpoints = {
+      POSTs: {
+        '/api/v1/vpn/createGuestSupportTicket': {
+          status: 201,
+          callback: (req) => {
+            ticket.email = req.body.email;
+            ticket.logs = req.body.logs;
+            ticket.subject = req.body.subject;
+            ticket.issueText = req.body.issueText;
+            ticket.category = req.body.category;
+          },
+          body: {},
+        },
+      }
+    };
 
-  it('Email inputs are visible to unauthenticated user', async () => {
-    await vpn.waitForQueryAndClick(queries.screenInitialize.GET_HELP_LINK);
-    await vpn.waitForQuery(queries.screenGetHelp.LINKS.visible());
+    it('Unauthenticated user can create support ticket', async () => {
+      await vpn.waitForQueryAndClick(queries.screenInitialize.GET_HELP_LINK);
+      await vpn.waitForQuery(queries.screenGetHelp.LINKS.visible());
+      await vpn.waitForQueryAndClick(queries.screenGetHelp.SUPPORT);
+      await vpn.waitForQuery(queries.screenGetHelp.contactSupportView
+                                 .UNAUTH_USER_INPUTS.visible());
+      await vpn.setQueryProperty(
+          queries.screenGetHelp.contactSupportView.EMAIL_INPUT, 'text',
+          'test@test.com');
+      await vpn.setQueryProperty(
+          queries.screenGetHelp.contactSupportView.CONFIRM_EMAIL_INPUT, 'text',
+          'test@test.com');
+      await vpn.waitForQuery(
+          queries.screenGetHelp.contactSupportView.DROPDOWN.visible());
+      await vpn.setQueryProperty(
+          queries.screenGetHelp.contactSupportView.DROPDOWN, 'currentIndex', 1);
+      await vpn.setQueryProperty(
+          queries.screenGetHelp.contactSupportView.TEXTAREA, 'text',
+          'user issue description');
+      await vpn.setQueryProperty(
+          queries.screenGetHelp.contactSupportView.SUBJECT_INPUT, 'text',
+          'user issue subject');
+      await vpn.wait(200);
+      await vpn.scrollToQuery(
+          queries.screenGetHelp.contactSupportView.VIEW,
+          queries.screenGetHelp.contactSupportView.SUBMIT_BUTTON);
+      await vpn.waitForQueryAndClick(
+          queries.screenGetHelp.contactSupportView.SUBMIT_BUTTON.enabled());
+      await vpn.waitForQuery(
+          queries.screenGetHelp.contactSupportView.THANK_YOU_PANEL.visible());
+      await vpn.waitForQueryAndClick(
+          queries.screenGetHelp.contactSupportView.DONE_BUTTON);
+      await vpn.waitForQuery(queries.screenGetHelp.STACKVIEW.ready());
 
-    await vpn.waitForQueryAndClick(queries.screenGetHelp.SUPPORT);
+      assert.equal(ticket.category, 'account');
+      assert.equal(ticket.issueText, 'user issue description');
+      assert.equal(ticket.subject, 'user issue subject');
+      assert.equal(ticket.email, 'test@test.com');
+      assert.notEqual(ticket.logs, 'Logs not shared.');
+    });
 
-    await vpn.waitForQuery(
-        queries.screenGetHelp.contactSupportView.UNAUTH_USER_INPUTS.visible());
+    it('VPNUserInfo is not visible to unathenticated users', async () => {
+      await vpn.waitForQueryAndClick(queries.screenInitialize.GET_HELP_LINK);
+      await vpn.waitForQuery(queries.screenGetHelp.LINKS.visible());
+
+      await vpn.waitForQueryAndClick(queries.screenGetHelp.SUPPORT);
+
+      await vpn.waitForQuery(
+          queries.screenGetHelp.contactSupportView.USER_INFO.hidden());
+      assert.equal(
+          await vpn.getQueryProperty(
+              queries.screenGetHelp.contactSupportView.USER_INFO, 'visible'),
+          'false');
+    });
   });
 
   describe('Contact us view - authenticated user', function() {
@@ -44,9 +105,9 @@ describe('Contact us view', function() {
       subject: null,
       issueText: null,
       category: null
-    }
+    };
 
-                   this.ctx.guardianOverrideEndpoints = {
+    this.ctx.guardianOverrideEndpoints = {
       POSTs: {
         '/api/v1/vpn/createSupportTicket': {
           status: 201,

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -271,6 +271,8 @@ target_sources(unit_tests PRIVATE
     testserverlatency.h
     teststatusicon.cpp
     teststatusicon.h
+    testvalidator.cpp
+    testvalidator.h
 )
 
 # Generate the version header

--- a/tests/unit/testvalidator.cpp
+++ b/tests/unit/testvalidator.cpp
@@ -1,0 +1,37 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "testvalidator.h"
+
+#include <QDebug>
+#include <QTest>
+
+#include "validator.h"
+
+void TestValidator::basic_data() {
+  QTest::addColumn<QString>("input");
+  QTest::addColumn<bool>("result");
+
+  QTest::addRow("empty") << "" << false;
+  QTest::addRow("no @") << "hello world" << false;
+  QTest::addRow("too many @") << "hello@world@!" << false;
+
+  QString emailAddress("a@");
+  for (int i = 0; i < 256; ++i) emailAddress.append("a");
+  QTest::addRow("domain too big") << emailAddress << false;
+
+  QTest::addRow("invalid part 0") << ",@a" << false;
+  QTest::addRow("invalid part 1") << "a@^" << false;
+  QTest::addRow("missing dot and domain") << "a@b" << false;
+  QTest::addRow("missing domain") << "a@b." << false;
+
+  QTest::addRow("all good") << "a@b.c" << true;
+}
+
+void TestValidator::basic() {
+  QFETCH(QString, input);
+  QFETCH(bool, result);
+
+  QCOMPARE(Validator::validateEmailAddress(input), result);
+}

--- a/tests/unit/testvalidator.h
+++ b/tests/unit/testvalidator.h
@@ -1,0 +1,13 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include <QObject>
+
+class TestValidator final : public QObject {
+  Q_OBJECT
+
+ private slots:
+  void basic_data();
+  void basic();
+};


### PR DESCRIPTION
## Description

`MZAuthInApp.validateEmailAddress` was removed in #11325 but it was still being used by the support form to validate email addresses when the user was not authenticated.

Bring back `validateEmailAddress` in a `Validator` util class in `mzutils`.

## Reference

[Jira Issue](https://mozilla-hub.atlassian.net/browse/VPN-7662)

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
