### PR TITLE
remove bullets for things that didn't hit 2.38

### DIFF
--- a/addons/message_update_v2.38/manifest.json
+++ b/addons/message_update_v2.38/manifest.json
@@ -30,20 +30,12 @@
         "type": "ulist",
         "content": [
           {
-            "id": "l_1",
-            "content": "vpn.237updateMessage.bullet1"
-          },
-          {
             "id": "l_2",
             "content": "vpn.237updateMessage.bullet2"
           },
           {
             "id": "l_3",
             "content": "vpn.238updateMessage.bullet1"
-          },
-          {
-            "id": "l_4",
-            "content": "vpn.237updateMessage.bullet6"
           },
           {
             "id": "l_5",

--- a/addons/message_whats_new_v2.38/manifest.json
+++ b/addons/message_whats_new_v2.38/manifest.json
@@ -30,20 +30,12 @@
         "type": "ulist",
         "content": [
           {
-            "id": "l_1",
-            "content": "vpn.237updateMessage.bullet1"
-          },
-          {
             "id": "l_2",
             "content": "vpn.237updateMessage.bullet2"
           },
           {
             "id": "l_3",
             "content": "vpn.238updateMessage.bullet1"
-          },
-          {
-            "id": "l_4",
-            "content": "vpn.237updateMessage.bullet6"
           },
           {
             "id": "l_5",


### PR DESCRIPTION
## Description

Removing these 2:
```
- [macOS] App exclusions are now available for macOS. Want to let some programs bypass the VPN completely? You now can.
- [Windows] IPv6-only networks are now supported.
```

## Reference

N/A

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
