### PR TITLE
Fix windows qt action

### DIFF
--- a/.github/actions/qt-setup-taskcluster/action.yml
+++ b/.github/actions/qt-setup-taskcluster/action.yml
@@ -42,10 +42,7 @@ runs:
         # even though the archive is truncated.
         curl -sSL -r0-4096 "https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/${TASKID}/artifacts/${NAME}" -o qt-toolchain-head.tar.xz
         TARBALL_PATH=$((xzcat qt-toolchain-head.tar.xz | tar t | head -1 | grep -o '^[^/]*') 2>/dev/null || true)
-        # On Windows, $GITHUB_WORKSPACE uses backslashes; normalize to forward
-        # slashes so the path isn't a mix of both separators, causing failure.
-        ADJUSTED_WORKSPACE="${GITHUB_WORKSPACE//\\//}"
-        echo "toolchain-path=${ADJUSTED_WORKSPACE}/3rdparty/${TARBALL_PATH}" >> $GITHUB_OUTPUT
+        echo "toolchain-path=${GITHUB_WORKSPACE}/3rdparty/${TARBALL_PATH}" >> $GITHUB_OUTPUT
 
     - name: Cache Qt toolchain
       uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4

--- a/.github/actions/qt-setup-taskcluster/action.yml
+++ b/.github/actions/qt-setup-taskcluster/action.yml
@@ -56,14 +56,14 @@ runs:
     - name: Install Qt toolchain
       if: ${{ inputs.cache != 'true' || steps.qt-toolchain-cache.outputs.cache-hit != 'true' }}
       id: qt-toolchain-install
-      working-directory: ${{ runner.temp }}
+      working-directory: ${{ github.workspace }}/3rdparty
       shell: bash
       env:
         QT6_TOOLCHAIN_URL: https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/${{ steps.resolve.outputs.taskid }}/artifacts/${{ steps.resolve.outputs.filename }}
       run: |
         FILENAME=$(basename "${QT6_TOOLCHAIN_URL}")
         curl -sSL "${QT6_TOOLCHAIN_URL}" -o ${FILENAME}
-        tar -C ${GITHUB_WORKSPACE}/3rdparty/ -xf ${FILENAME}
+        tar -xf ${FILENAME}
 
     - name: Save Qt toolchain
       uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4


### PR DESCRIPTION
## Description
So, the actual cause of the breakage is a little more complex. IIUC, because we are running `bash` on Windows we wind up with a mix of GNU `tar` on a Windows environment and it really has no idea what to do with absolute paths that begin with a drive identifier. The `-C` option doesn't work because it thinks the drive identifier ought to be a path and giving it an absolute filename doesn't work because the colon gets interpreted as some kind of remote port.

To make this work, we *must* use relative path names when interacting with GNU tar on Windows.

The reason this wasn't found earlier was due to Github caching, which we enable for Windows targets. The broken tar extraction step was therefore skipped due to a cache hit and only failed later once the Qt toolchain bundle got updated.

## Reference
Reverts: #11359
Bug introduced by: #11331
Qt toolchain updated by: #11349

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
