### PR TITLE
VPN-7671 - fix to again show all languages on stage

### DIFF
--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -88,17 +88,6 @@ Controller::Controller() {
   connect(&m_handshakeTimer, &QTimer::timeout, this,
           &Controller::handshakeTimeout);
 
-  // if the locale changed, send the new translation for the city name to iOS
-  // widget
-  connect(Localizer::instance(), &Localizer::localeChanged, this, [this]() {
-    if (SettingsHolder::instance()->languageCode().isEmpty()) {
-      // If setting is empty, this was called while tearing down the client
-      return;
-    }
-    const ServerData& serverData = *MozillaVPN::instance()->serverData();
-    maybeSendUpdatedConfig(serverData);
-  });
-
   LogHandler::instance()->registerLogSerializer(this);
 }
 
@@ -194,6 +183,17 @@ void Controller::initialize() {
 
   connect(LogHandler::instance(), &LogHandler::cleanupLogsNeeded, this,
           &Controller::cleanupBackendLogs);
+
+  // if the locale changed, send the new translation for the city name to iOS
+  // widget
+  connect(Localizer::instance(), &Localizer::localeChanged, this, [this]() {
+    if (SettingsHolder::instance()->languageCode().isEmpty()) {
+      // If setting is empty, this was called while tearing down the client
+      return;
+    }
+    const ServerData& serverData = *MozillaVPN::instance()->serverData();
+    maybeSendUpdatedConfig(serverData);
+  });
 }
 
 void Controller::implPermRequired() {

--- a/src/localizer.cpp
+++ b/src/localizer.cpp
@@ -261,11 +261,17 @@ void Localizer::loadLanguagesFromI18n() {
         parts[0].remove(0, strlen(Constants::LOCALIZER_FILENAME_PREFIX) +
                                /* the final '_': */ 1);
 
-    if (Constants::inProduction() &&
-        m_translationCompleteness.value(code, 0) < 0.7) {
-      logger.debug() << "Language excluded:" << code << "completeness:"
-                     << m_translationCompleteness.value(code, 0);
-      continue;
+    QString appendText = "";
+    double translationPercent = m_translationCompleteness.value(code, 0);
+    if (translationPercent < 0.7) {
+      logger.debug() << "Language below threshold:" << code
+                     << "completeness:" << translationPercent;
+      if (Constants::inProduction()) {
+        continue;
+      } else {
+        appendText = QString(" (stage only: %1%)")
+                         .arg(translationPercent * 100, 0, 'f', 0);
+      }
     }
 
     QStringList codeParts = code.split("_");
@@ -277,7 +283,7 @@ void Localizer::loadLanguagesFromI18n() {
 
     Language language{code, codeParts[0],
                       codeParts.length() > 1 ? codeParts[1] : QString(),
-                      nativeLanguageName(locale, code),
+                      nativeLanguageName(locale, code) + appendText,
                       locale.textDirection() == Qt::RightToLeft};
     m_languages.append(language);
   }

--- a/src/mozillavpn_p.h
+++ b/src/mozillavpn_p.h
@@ -11,7 +11,6 @@
 #include "controller.h"
 #include "feature/taskgetfeaturelistworker.h"
 #include "ipaddresslookup.h"
-#include "localizer.h"
 #include "models/devicemodel.h"
 #include "models/keys.h"
 #include "models/location.h"


### PR DESCRIPTION
## Description

It's me, hi, I'm the problem, it's me - I'm the one who introduced the bug. In https://github.com/mozilla-mobile/mozilla-vpn-client/pull/11323/ I added this check, but this causes the Localizer to be initialized earlier than before, and that means we haven't set staging yet - and thus we were only loading the languages that passed the translation threshold. Let's move it to where it always should have been.

Two other things while we're in here:
- Remove an unneeded `#include "localizer.h"`. This was maybe missed [when related parts were removed](https://github.com/mozilla-mobile/mozilla-vpn-client/pull/11041/).
- I didn't know that some locales were only shown on stage. Let's make this explicit when we show locales that would otherwise fail the threshold test.

*Stage / prod*
<img width="163" alt="Screenshot 118" src="https://github.com/user-attachments/assets/9c36a051-bd4f-4468-9362-a3b25d72877a" /><img width="156" alt="Screenshot 119" src="https://github.com/user-attachments/assets/c4ee0f3f-0f25-4fa0-ad77-66c4c741d59c" />

Separately, Swedish is mistakenly not included. I'll fix that in another PR.

## Reference

VPN-7671

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
