### PR TITLE
VPN-7680: IP address rotation button (behind feature flag)

### DIFF
--- a/nebula/ui/utils/MZAssetLookup.js
+++ b/nebula/ui/utils/MZAssetLookup.js
@@ -27,6 +27,10 @@ var imageLookup = {
     filenameLight: 'qrc:/nebula/resources/refresh.svg',
     filenameDark: 'qrc:/nebula/resources/refresh-dark.svg'
   },
+  'RefreshArrowsIPInfo': {
+    filenameLight: 'qrc:/nebula/resources/refresh.svg',
+    filenameDark: 'qrc:/nebula/resources/refresh.svg'
+  },
   'RefreshArrowsForShield': {
     filenameLight: 'qrc:/ui/resources/switching.svg',
     filenameDark: 'qrc:/ui/resources/switching-dark.svg'

--- a/src/feature/featuremodel.h
+++ b/src/feature/featuremodel.h
@@ -36,6 +36,7 @@ inline const AnyFeature s_exposedFeatures[] = {
     ref(replacerAddon),
     ref(serverUnavailableNotification),
     ref(shareLogs),
+    ref(showRotateIPAddressButton),
     ref(startOnBoot),
     ref(subscriptionManagement),
     ref(themeSelectionIncludesAutomatic),

--- a/src/feature/features.h
+++ b/src/feature/features.h
@@ -275,6 +275,12 @@ inline const OverridableFeature recommendedServers = {
     .evaluator = +[] { return true; },
 };
 
+inline const OverridableFeature showRotateIPAddressButton = {
+    .id = "showRotateIPAddressButton",
+    .name = "Show Rotate IP address button",
+    .evaluator = +[] { return false; },
+};
+
 inline const OverridableFeature subscriptionManagement = {
     .id = "subscriptionManagement",
     .name = "Subscription management",

--- a/src/ipaddresslookup.cpp
+++ b/src/ipaddresslookup.cpp
@@ -48,7 +48,7 @@ void IpAddressLookup::reset() {
     m_ipv4Address = qtTrId("vpn.connectionInfo.loading");
     m_ipv6Address = qtTrId("vpn.connectionInfo.loading");
 
-    m_state = StateWaiting;
+    setLookupState(StateWaiting);
     emit ipv4AddressChanged();
     emit ipv6AddressChanged();
   }
@@ -60,7 +60,7 @@ void IpAddressLookup::updateIpAddress() {
   if (m_state == StateUpdating) {
     return;
   }
-  m_state = StateUpdating;
+  setLookupState(StateUpdating);
 
   TaskIPFinder* ipfinder = new TaskIPFinder();
   connect(
@@ -68,7 +68,7 @@ void IpAddressLookup::updateIpAddress() {
       [this](const QString& ipv4, const QString& ipv6, const QString& country) {
         if (ipv4.isEmpty() && ipv6.isEmpty()) {
           logger.error() << "IP address request failed";
-          m_state = StateUpdated;
+          setLookupState(StateUpdated);
           emit ipAddressChecked();
           return;
         }
@@ -114,7 +114,7 @@ void IpAddressLookup::updateIpAddress() {
                        << "ipv6:" << logger.sensitive(m_ipv6Address) << "in"
                        << logger.sensitive(country);
 
-        m_state = StateUpdated;
+        setLookupState(StateUpdated);
         emit ipAddressChecked();
       });
 
@@ -133,4 +133,9 @@ void IpAddressLookup::stateChanged() {
   }
 
   updateIpAddress();
+}
+
+void IpAddressLookup::setLookupState(IpAddressLookupState state) {
+  m_state = state;
+  emit lookupStateChanged();
 }

--- a/src/ipaddresslookup.cpp
+++ b/src/ipaddresslookup.cpp
@@ -49,6 +49,8 @@ void IpAddressLookup::reset() {
     m_ipv6Address = qtTrId("vpn.connectionInfo.loading");
 
     m_state = StateWaiting;
+    emit ipv4AddressChanged();
+    emit ipv6AddressChanged();
   }
 }
 

--- a/src/ipaddresslookup.h
+++ b/src/ipaddresslookup.h
@@ -18,6 +18,7 @@ class IpAddressLookup final : public QObject {
 
   Q_PROPERTY(QString ipv4Address READ ipv4Address NOTIFY ipv4AddressChanged)
   Q_PROPERTY(QString ipv6Address READ ipv6Address NOTIFY ipv6AddressChanged)
+  Q_PROPERTY(bool isFinished READ isFinished NOTIFY lookupStateChanged)
 
  public:
   IpAddressLookup();
@@ -27,23 +28,10 @@ class IpAddressLookup final : public QObject {
 
   const QString& ipv4Address() const { return m_ipv4Address; }
   const QString& ipv6Address() const { return m_ipv6Address; }
+  bool isFinished() const { return m_state == StateUpdated; }
 
  private:
-  void updateIpAddress();
-
-  void reset();
-
-  void stateChanged();
-
- signals:
-  // for testing.
-  void ipAddressChecked();
-
-  void ipv4AddressChanged();
-  void ipv6AddressChanged();
-
- private:
-  enum {
+  enum IpAddressLookupState {
     // Waiting for the VPN to turn on.
     StateWaiting,
 
@@ -52,8 +40,28 @@ class IpAddressLookup final : public QObject {
 
     // IP address is a known.
     StateUpdated,
-  }  // Let's use `StateUpdated` to force a refresh in the CTOR.
-  m_state = StateUpdated;
+  };
+
+  void updateIpAddress();
+
+  void reset();
+
+  void stateChanged();
+
+  void setLookupState(IpAddressLookupState state);
+
+ signals:
+  // for testing.
+  void ipAddressChecked();
+
+  void ipv4AddressChanged();
+  void ipv6AddressChanged();
+
+  void lookupStateChanged();
+
+ private:
+  // Let's use `StateUpdated` to force a refresh in the CTOR.
+  IpAddressLookupState m_state = StateUpdated;
 
   QString m_ipv4Address;
   QString m_ipv6Address;

--- a/src/translations/strings.yaml
+++ b/src/translations/strings.yaml
@@ -541,7 +541,7 @@ connectionInfo:
     comment: Accessible label for the button to restart the speed test upon its completion.
   rotateIPAddress:
     value: Attempt to change IP address
-    comment: Accessible label for the button to try to get a new server in the same locale
+    comment: Accessible label for the button to try to get a new server in the same location
 
 crashreporter:
   mainTitle:

--- a/src/translations/strings.yaml
+++ b/src/translations/strings.yaml
@@ -539,6 +539,9 @@ connectionInfo:
   restartSpeedTest:
     value: Restart speed test
     comment: Accessible label for the button to restart the speed test upon its completion.
+  rotateIPAddress:
+    value: Attempt to change IP address
+    comment: Accessible label for the button to try to get a new server in the same locale
 
 crashreporter:
   mainTitle:

--- a/src/ui/screens/home/controller/ControllerView.qml
+++ b/src/ui/screens/home/controller/ControllerView.qml
@@ -675,7 +675,9 @@ Item {
         Connections {
             target: VPNController
             function onStateChanged() {
-                ipInfoPanel.isOpen = false
+                if (VPNController.state === VPNController.StateDisconnecting || VPNController.state === VPNController.StateOff) {
+                    ipInfoPanel.isOpen = false
+                }
             }
         }
     }

--- a/src/ui/screens/home/controller/ip/IPAddress.qml
+++ b/src/ui/screens/home/controller/ip/IPAddress.qml
@@ -8,6 +8,7 @@ import QtQuick.Layouts 1.14
 import Mozilla.Shared 1.0
 import Mozilla.VPN 1.0
 import components 0.1
+import "qrc:/nebula/utils/MZAssetLookup.js" as MZAssetLookup
 
 RowLayout {
     property real maxPaintedTextWidth: box.width - ipVersion.paintedWidth - MZTheme.theme.windowMargin
@@ -36,5 +37,31 @@ RowLayout {
         opacity: 0.8
 
         Layout.maximumWidth: maxPaintedTextWidth
+    }
+
+    // spacer
+    Item {
+        Layout.fillWidth: true
+    }
+
+    MZIconButton {
+        id: ipRefreshToggleButton
+        visible: MZFeatureList.get("showRotateIPAddressButton").isSupported && VPNIPAddressLookup.isFinished
+        accessibleName: MZI18n.ConnectionInfoRotateIPAddress
+        buttonColorScheme: MZTheme.colors.iconButtonDarkBackground
+        onClicked: {
+            VPN.silentSwitch();
+        }
+
+        Image {
+            property int iconSize: MZTheme.theme.iconSize * 1.5
+
+            anchors.centerIn: ipRefreshToggleButton
+            source: MZAssetLookup.getImageSource("RefreshArrowsIPInfo")
+            sourceSize {
+                height: iconSize
+                width: iconSize
+            }
+        }
     }
 }

--- a/src/ui/screens/home/controller/ip/IPInfoPanel.qml
+++ b/src/ui/screens/home/controller/ip/IPInfoPanel.qml
@@ -8,6 +8,7 @@ import QtQuick.Layouts 1.14
 import Mozilla.Shared 1.0
 import Mozilla.VPN 1.0
 import components 0.1
+import "qrc:/nebula/utils/MZAssetLookup.js" as MZAssetLookup
 
 Rectangle {
     property bool isOpen: false
@@ -16,6 +17,36 @@ Rectangle {
     anchors.fill: parent
     color: MZTheme.colors.primary
     radius: boxBackground.radius
+
+    MZIconButton {
+        id: ipRefreshToggleButton
+        visible: MZFeatureList.get("showRotateIPAddressButton").isSupported
+
+        anchors {
+            left: parent.left
+            leftMargin: MZTheme.theme.windowMargin / 2
+            top: parent.top
+            topMargin: MZTheme.theme.windowMargin / 2
+            bottomMargin: MZTheme.theme.windowMargin
+        }
+        accessibleName: MZI18n.ConnectionInfoRotateIPAddress
+        buttonColorScheme: MZTheme.colors.iconButtonDarkBackground
+        z: 1
+        onClicked: {
+            VPN.silentSwitch();
+        }
+
+        Image {
+            property int iconSize: MZTheme.theme.iconSize * 1.5
+
+            anchors.centerIn: ipRefreshToggleButton
+            source: MZAssetLookup.getImageSource("RefreshArrowsIPInfo")
+            sourceSize {
+                height: iconSize
+                width: iconSize
+            }
+        }
+    }
 
     // IP Adresses
     ColumnLayout {

--- a/src/ui/screens/home/controller/ip/IPInfoPanel.qml
+++ b/src/ui/screens/home/controller/ip/IPInfoPanel.qml
@@ -8,7 +8,6 @@ import QtQuick.Layouts 1.14
 import Mozilla.Shared 1.0
 import Mozilla.VPN 1.0
 import components 0.1
-import "qrc:/nebula/utils/MZAssetLookup.js" as MZAssetLookup
 
 Rectangle {
     property bool isOpen: false
@@ -17,36 +16,6 @@ Rectangle {
     anchors.fill: parent
     color: MZTheme.colors.primary
     radius: boxBackground.radius
-
-    MZIconButton {
-        id: ipRefreshToggleButton
-        visible: MZFeatureList.get("showRotateIPAddressButton").isSupported
-
-        anchors {
-            left: parent.left
-            leftMargin: MZTheme.theme.windowMargin / 2
-            top: parent.top
-            topMargin: MZTheme.theme.windowMargin / 2
-            bottomMargin: MZTheme.theme.windowMargin
-        }
-        accessibleName: MZI18n.ConnectionInfoRotateIPAddress
-        buttonColorScheme: MZTheme.colors.iconButtonDarkBackground
-        z: 1
-        onClicked: {
-            VPN.silentSwitch();
-        }
-
-        Image {
-            property int iconSize: MZTheme.theme.iconSize * 1.5
-
-            anchors.centerIn: ipRefreshToggleButton
-            source: MZAssetLookup.getImageSource("RefreshArrowsIPInfo")
-            sourceSize {
-                height: iconSize
-                width: iconSize
-            }
-        }
-    }
 
     // IP Adresses
     ColumnLayout {


### PR DESCRIPTION
## Description

If this wasn't going to live behind a feature flag, I'd want a slightly thinner icon - but given it's not revealed to normal users, I think this is okay.

<img width="161" alt="Screenshot 121" src="https://github.com/user-attachments/assets/f05d26fb-26bb-40cb-8c59-d04edb3fffdb" /> <img width="168" alt="Screenshot 122" src="https://github.com/user-attachments/assets/d21120b8-612b-47e1-bae8-efd894156aa8" />


- `ControllerView.qml` work - keeps the window open when it is refreshing. This was added for VPN-3613, and I believe my change keeps the original intent.
- `src/ipaddresslookup.cpp` work - changes the label back to "Loading" after tapping the button
- `nebula/ui/utils/MZAssetLookup.js` - we need it to be white in both dark and light mode. This adds a dictionary entry, but we're reusing existing assets

## Reference

VPN-7680

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
