### PR TITLE
Refactor Controller::getStatus() API to use signals

### DIFF
--- a/src/connectionhealth.cpp
+++ b/src/connectionhealth.cpp
@@ -92,8 +92,7 @@ void ConnectionHealth::stop() {
   m_dnsPingTimer.stop();
 }
 
-void ConnectionHealth::startActive(const QString& serverIpv4Gateway,
-                                   const QString& deviceIpv4Address) {
+void ConnectionHealth::startActive(const ControllerStatus& status) {
   logger.debug() << "ConnectionHealth active started";
 
   bool isNotOnOrOnPartial =
@@ -101,14 +100,14 @@ void ConnectionHealth::startActive(const QString& serverIpv4Gateway,
       MozillaVPN::instance()->controller()->state() !=
           Controller::StateOnPartial;
 
-  if (serverIpv4Gateway.isEmpty() || isNotOnOrOnPartial) {
+  if (status.m_ipv4Gateway.isNull() || isNotOnOrOnPartial) {
     logger.info() << "ConnectionHealth not starting because no connection";
     return;
   }
 
-  m_currentGateway = serverIpv4Gateway;
-  m_deviceAddress = deviceIpv4Address;
-  m_pingHelper.start(serverIpv4Gateway, deviceIpv4Address);
+  m_currentGateway = status.m_ipv4Gateway;
+  m_deviceAddress = status.m_ipv4Address;
+  m_pingHelper.start(m_currentGateway.toString(), m_deviceAddress.toString());
   m_noSignalTimer.start(PING_TIME_NOSIGNAL);
   m_healthCheckTimer.start(PING_TIME_UNSTABLE);
 
@@ -163,7 +162,8 @@ void ConnectionHealth::setStability(ConnectionStability stability) {
 }
 
 void ConnectionHealth::connectionStateChanged() {
-  Controller::State state = MozillaVPN::instance()->controller()->state();
+  Controller* controller = MozillaVPN::instance()->controller();
+  Controller::State state = controller->state();
   logger.debug() << "Connection state changed to" << state;
 
   if ((state != Controller::StateInitializing) &&
@@ -174,16 +174,10 @@ void ConnectionHealth::connectionStateChanged() {
   switch (state) {
     case Controller::StateOnPartial:
     case Controller::StateOn:
-      MozillaVPN::instance()->controller()->getStatus(
-          [this](const QString& serverIpv4Gateway,
-                 const QString& deviceIpv4Address, uint64_t txBytes,
-                 uint64_t rxBytes) {
-            Q_UNUSED(txBytes);
-            Q_UNUSED(rxBytes);
-
-            stop();
-            startActive(serverIpv4Gateway, deviceIpv4Address);
-          });
+      QObject::connect(controller, &Controller::statusUpdated, this,
+                       &ConnectionHealth::startActive,
+                       Qt::SingleShotConnection);
+      controller->refreshStatus();
       break;
 
     case Controller::StateOff:

--- a/src/connectionhealth.cpp
+++ b/src/connectionhealth.cpp
@@ -259,11 +259,14 @@ void ConnectionHealth::applicationStateChanged(Qt::ApplicationState state) {
 #else
   switch (state) {
     case Qt::ApplicationState::ApplicationActive:
-      if (!m_suspended) return;
-
-      m_suspended = false;
-      logger.debug() << "Resuming connection check from suspension";
-      startActive(m_currentGateway, m_deviceAddress);
+      if (m_suspended) {
+        m_suspended = false;
+        logger.debug() << "Resuming connection check from suspension";
+        ControllerStatus st;
+        st.m_ipv4Address = m_deviceAddress;
+        st.m_ipv4Gateway = m_currentGateway;
+        startActive(st);
+      }
       break;
 
     case Qt::ApplicationState::ApplicationSuspended:

--- a/src/connectionhealth.h
+++ b/src/connectionhealth.h
@@ -8,6 +8,8 @@
 #include "dnspingsender.h"
 #include "pinghelper.h"
 
+class ControllerStatus;
+
 // The baseline latency measurement averaged using an Exponentially Weighted
 // Moving Average (EWMA), this defines the decay rate.
 constexpr uint32_t PING_BASELINE_EWMA_DIVISOR = 8;
@@ -55,8 +57,7 @@ class ConnectionHealth final : public QObject {
 
  private:
   void stop();
-  void startActive(const QString& serverIpv4Gateway,
-                   const QString& deviceIpv4Address);
+  void startActive(const ControllerStatus& status);
   void startIdle();
 
   void pingSentAndReceived(qint64 msec);
@@ -89,8 +90,8 @@ class ConnectionHealth final : public QObject {
   bool m_dnsPingInitialized = false;
 
   bool m_suspended = false;
-  QString m_currentGateway;
-  QString m_deviceAddress;
+  QHostAddress m_currentGateway;
+  QHostAddress m_deviceAddress;
 
 #ifdef UNIT_TEST
   friend class TestConnectionHealth;

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -5,6 +5,8 @@
 #include "controller.h"
 
 #include <QFileInfo>
+#include <QJsonObject>
+#include <QJsonValue>
 #include <QNetworkInformation>
 
 #include "constants.h"
@@ -161,7 +163,11 @@ void Controller::initialize() {
   connect(m_impl.get(), &ControllerImpl::permissionRequired, this,
           &Controller::implPermRequired);
   connect(m_impl.get(), &ControllerImpl::statusUpdated, this,
-          &Controller::statusUpdated);
+          [this](const ControllerStatus& status) {
+            logger.debug() << "Status updated";
+            m_status = status;
+            emit statusUpdated(status);
+          });
   connect(m_impl.get(), &ControllerImpl::backendFailure, this,
           &Controller::handleBackendFailure);
   connect(this, &Controller::stateChanged, this,
@@ -849,40 +855,14 @@ void Controller::cleanupBackendLogs() {
   }
 }
 
-void Controller::getStatus(
-    std::function<void(const QString& serverIpv4Gateway,
-                       const QString& deviceIpv4Address, uint64_t txByte,
-                       uint64_t rxBytes)>&& a_callback) {
+void Controller::refreshStatus() {
   logger.debug() << "check status";
 
-  std::function<void(const QString& serverIpv4Gateway,
-                     const QString& deviceIpv4Address, uint64_t txBytes,
-                     uint64_t rxBytes)>
-      callback = std::move(a_callback);
-
-  bool requestStatus = m_getStatusCallbacks.isEmpty();
-
-  m_getStatusCallbacks.append(std::move(callback));
-
-  if (m_impl && requestStatus) {
+  if (m_impl) {
     m_impl->checkStatus();
-  }
-}
-
-void Controller::statusUpdated(const QString& serverIpv4Gateway,
-                               const QString& deviceIpv4Address,
-                               uint64_t txBytes, uint64_t rxBytes) {
-  logger.debug() << "Status updated";
-  QList<std::function<void(const QString& serverIpv4Gateway,
-                           const QString& deviceIpv4Address, uint64_t txBytes,
-                           uint64_t rxBytes)> >
-      list;
-
-  list.swap(m_getStatusCallbacks);
-  for (const std::function<void(
-           const QString& serverIpv4Gateway, const QString& deviceIpv4Address,
-           uint64_t txBytes, uint64_t rxBytes)>&func : list) {
-    func(serverIpv4Gateway, deviceIpv4Address, txBytes, rxBytes);
+  } else {
+    // Nothing changed - but emit it anyways.
+    emit statusUpdated(m_status);
   }
 }
 
@@ -1181,4 +1161,18 @@ bool Controller::shouldSuppressNextNotification() {
     logger.error() << "No implementation found for notification check.";
     return false;
   }
+}
+
+ControllerStatus::ControllerStatus(const QJsonObject& obj) {
+  m_connected = obj.value("connected").toBool();
+  if (m_connected) {
+    QString dateString = obj.value("date").toString();
+    m_timestamp = QDateTime::fromString(dateString, Qt::ISODate);
+  }
+  m_ipv4Address = QHostAddress(obj.value("deviceIpv4Address").toString());
+  m_ipv6Address = QHostAddress(obj.value("deviceIpv6Address").toString());
+  m_ipv4Gateway = QHostAddress(obj.value("serverIpv4Gateway").toString());
+  m_ipv6Gateway = QHostAddress(obj.value("serverIpv6Gateway").toString());
+  m_rxBytes = obj.value("rxBytes").toInteger();
+  m_txBytes = obj.value("txBytes").toInteger();
 }

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -221,6 +221,12 @@ void Controller::implInitialized(bool status, bool a_connected,
 
   setState(a_connected ? StateOn : StateOff);
 
+  // Update the connection status.
+  m_status.clear();
+  m_status.m_connected = a_connected;
+  m_status.m_timestamp = connectionDate;
+  emit statusUpdated(m_status);
+
   // If we are connected already at startup time, we can trigger the connection
   // sequence of tasks.
   if (a_connected) {
@@ -784,8 +790,10 @@ void Controller::disconnected() {
   }
 
   // clear the connection time.
+  m_status.clear();
   m_connectedTimeInUTC = QDateTime();
   emit timestampChanged();
+  emit statusUpdated(m_status);
 
   m_initiator = Null;
   setState(StateOff);
@@ -1175,4 +1183,15 @@ ControllerStatus::ControllerStatus(const QJsonObject& obj) {
   m_ipv6Gateway = QHostAddress(obj.value("serverIpv6Gateway").toString());
   m_rxBytes = obj.value("rxBytes").toInteger();
   m_txBytes = obj.value("txBytes").toInteger();
+}
+
+void ControllerStatus::clear() {
+  m_connected = false;
+  m_timestamp = QDateTime();
+  m_ipv4Address.clear();
+  m_ipv6Address.clear();
+  m_ipv4Gateway.clear();
+  m_ipv6Gateway.clear();
+  m_rxBytes = 0;
+  m_txBytes = 0;
 }

--- a/src/controller.h
+++ b/src/controller.h
@@ -36,6 +36,8 @@ class ControllerStatus {
   ControllerStatus() {}
   ControllerStatus(const QJsonObject& obj);
 
+  void clear();
+
   bool m_connected;
   QDateTime m_timestamp;
   QHostAddress m_ipv4Address;

--- a/src/controller.h
+++ b/src/controller.h
@@ -38,14 +38,14 @@ class ControllerStatus {
 
   void clear();
 
-  bool m_connected;
+  bool m_connected = false;
   QDateTime m_timestamp;
   QHostAddress m_ipv4Address;
   QHostAddress m_ipv6Address;
   QHostAddress m_ipv4Gateway;
   QHostAddress m_ipv6Gateway;
-  quint64 m_rxBytes;
-  quint64 m_txBytes;
+  quint64 m_rxBytes = 0;
+  quint64 m_txBytes = 0;
 };
 
 class Controller : public QObject, public LogSerializer {

--- a/src/controller.h
+++ b/src/controller.h
@@ -20,6 +20,32 @@
 class Controller;
 class ControllerImpl;
 
+class ControllerStatus {
+  Q_GADGET
+
+  Q_PROPERTY(bool connected MEMBER m_connected);
+  Q_PROPERTY(QDateTime timestamp MEMBER m_timestamp);
+  Q_PROPERTY(QHostAddress ipv4Address MEMBER m_ipv4Address);
+  Q_PROPERTY(QHostAddress ipv6Address MEMBER m_ipv6Address);
+  Q_PROPERTY(QHostAddress ipv4Gateway MEMBER m_ipv4Gateway);
+  Q_PROPERTY(QHostAddress ipv6Gateway MEMBER m_ipv6Gateway);
+  Q_PROPERTY(quint64 rxBytes MEMBER m_rxBytes);
+  Q_PROPERTY(quint64 txBytes MEMBER m_txBytes);
+
+ public:
+  ControllerStatus() {}
+  ControllerStatus(const QJsonObject& obj);
+
+  bool m_connected;
+  QDateTime m_timestamp;
+  QHostAddress m_ipv4Address;
+  QHostAddress m_ipv6Address;
+  QHostAddress m_ipv4Gateway;
+  QHostAddress m_ipv6Gateway;
+  quint64 m_rxBytes;
+  quint64 m_txBytes;
+};
+
 class Controller : public QObject, public LogSerializer {
   Q_OBJECT
   Q_DISABLE_COPY_MOVE(Controller)
@@ -134,6 +160,7 @@ class Controller : public QObject, public LogSerializer {
   Q_INVOKABLE bool isActive() const { return m_state > StateOff; }
 
   const ServerData& currentServer() const { return m_serverData; }
+  const ControllerStatus& getStatus() const { return m_status; }
 
   bool enableDisconnectInConfirming() const {
     return m_enableDisconnectInConfirming;
@@ -155,10 +182,7 @@ class Controller : public QObject, public LogSerializer {
   QString logName() const override { return "Mozilla VPN backend logs"; }
   void logSerialize(QIODevice* device) override;
 
-  void getStatus(
-      std::function<void(const QString& serverIpv4Gateway,
-                         const QString& deviceIpv4Address, uint64_t txBytes,
-                         uint64_t rxBytes)>&& callback);
+  void refreshStatus();
 
   QString currentServerString() const;
 
@@ -193,13 +217,12 @@ class Controller : public QObject, public LogSerializer {
   Q_PROPERTY(QString currentServerString READ currentServerString NOTIFY
                  currentServerChanged);
 
+  Q_PROPERTY(ControllerStatus status READ getStatus NOTIFY statusUpdated);
+
  private slots:
   void handshakeTimeout();
   void connected(const QString& pubkey);
   void disconnected();
-  void statusUpdated(const QString& serverIpv4Gateway,
-                     const QString& deviceIpv4Address, uint64_t txBytes,
-                     uint64_t rxBytes);
   void implInitialized(bool status, bool connected,
                        const QDateTime& connectionDate);
   void implPermRequired();
@@ -208,6 +231,7 @@ class Controller : public QObject, public LogSerializer {
  signals:
   void stateChanged();
   void errorChanged();
+  void statusUpdated(const ControllerStatus& status);
   void timestampChanged();
   void enableDisconnectInConfirmingChanged();
   void connectionRetryChanged();
@@ -284,6 +308,7 @@ class Controller : public QObject, public LogSerializer {
   QTimer m_handshakeTimer;
 
   QDateTime m_connectedTimeInUTC;
+  ControllerStatus m_status;
 
   State m_state = StateInitializing;
   ActivationPrincipal m_initiator = Null;
@@ -316,12 +341,6 @@ class Controller : public QObject, public LogSerializer {
 
   PingHelper m_pingCanary;
   bool m_pingReceived = false;
-
-  QList<std::function<void(const QString& serverIpv4Gateway,
-                           const QString& deviceIpv4Address, uint64_t txBytes,
-                           uint64_t rxBytes)>>
-      m_getStatusCallbacks;
-
 };  // namespace Controller
 
 #endif  // CONTROLLER_H

--- a/src/controllerimpl.cpp
+++ b/src/controllerimpl.cpp
@@ -4,43 +4,11 @@
 
 #include "controllerimpl.h"
 
-#include <QJsonObject>
-#include <QJsonValue>
-
 #include "logger.h"
 
 namespace {
 Logger logger("ControllerImpl");
 }  // namespace
-
-void ControllerImpl::emitStatusFromJson(const QJsonObject& obj) {
-  QJsonValue serverIpv4Gateway = obj.value("serverIpv4Gateway");
-  if (!serverIpv4Gateway.isString()) {
-    logger.error() << "Unexpected serverIpv4Gateway value";
-    return;
-  }
-
-  QJsonValue deviceIpv4Address = obj.value("deviceIpv4Address");
-  if (!deviceIpv4Address.isString()) {
-    logger.error() << "Unexpected deviceIpv4Address value";
-    return;
-  }
-
-  QJsonValue txBytes = obj.value("txBytes");
-  if (!txBytes.isDouble()) {
-    logger.error() << "Unexpected txBytes value";
-    return;
-  }
-
-  QJsonValue rxBytes = obj.value("rxBytes");
-  if (!rxBytes.isDouble()) {
-    logger.error() << "Unexpected rxBytes value";
-    return;
-  }
-
-  emit statusUpdated(serverIpv4Gateway.toString(), deviceIpv4Address.toString(),
-                     txBytes.toDouble(), rxBytes.toDouble());
-}
 
 void ControllerImpl::getBackendLogs(QIODevice* device) {
   QString name = metaObject()->className();

--- a/src/controllerimpl.h
+++ b/src/controllerimpl.h
@@ -86,10 +86,6 @@ class ControllerImpl : public QObject {
   virtual void sendUpdatedConfig(InterfaceConfig& entryConfig,
                                  InterfaceConfig& exitConfig) {};
 
- protected:
-  // Helper method - process a JSON status and emit the statusUpdated signal.
-  void emitStatusFromJson(const QJsonObject& obj);
-
  signals:
   // This signal is emitted when the controller is initialized. Note that the
   // VPN tunnel can be already active. In this case, "connected" should be set
@@ -110,13 +106,7 @@ class ControllerImpl : public QObject {
   void disconnected();
 
   // This method should be emitted after a checkStatus() call.
-  // "serverIpv4Gateway" is the current VPN tunnel gateway.
-  // "deviceIpv4Address" is the address of the VPN client.
-  // "txBytes" and "rxBytes" contain the number of transmitted and received
-  // bytes since the last statusUpdated signal.
-  void statusUpdated(const QString& serverIpv4Gateway,
-                     const QString& deviceIpv4Address, uint64_t txBytes,
-                     uint64_t rxBytes);
+  void statusUpdated(const ControllerStatus& status);
 
   // This signal is emitted when the implementation encounters an error.
   void backendFailure(Controller::ErrorCode errorCode);

--- a/src/localsocketcontroller.cpp
+++ b/src/localsocketcontroller.cpp
@@ -269,7 +269,7 @@ void LocalSocketController::parseCommand(const QByteArray& command) {
   }
 
   if (type == "status") {
-    emitStatusFromJson(obj);
+    emit statusUpdated(ControllerStatus(obj));
     return;
   }
 

--- a/src/platforms/android/androidcontroller.cpp
+++ b/src/platforms/android/androidcontroller.cpp
@@ -80,8 +80,8 @@ AndroidController::AndroidController() {
         st.m_connected = true;
         st.m_ipv4Gateway = QHostAddress(doc.object()["endpoint"].toString());
         st.m_ipv4Address = QHostAddress(doc.object()["deviceIpv4"].toString());
-        st.m_rxBytes = doc.object()["tx_bytes"].toInteger();
-        st.m_txBytes = doc.object()["rx_bytes"].toInteger();
+        st.m_rxBytes = doc.object()["rx_bytes"].toInteger();
+        st.m_txBytes = doc.object()["tx_bytes"].toInteger();
         emit statusUpdated(st);
       },
       Qt::QueuedConnection);

--- a/src/platforms/android/androidcontroller.cpp
+++ b/src/platforms/android/androidcontroller.cpp
@@ -76,10 +76,13 @@ AndroidController::AndroidController() {
       activity, &AndroidVPNActivity::eventStatisticUpdate, this,
       [this](const QString& parcelBody) {
         auto doc = QJsonDocument::fromJson(parcelBody.toUtf8());
-        emit statusUpdated(doc.object()["endpoint"].toString(),
-                           doc.object()["deviceIpv4"].toString(),
-                           doc.object()["tx_bytes"].toInt(),
-                           doc.object()["rx_bytes"].toInt());
+        ControllerStatus st;
+        st.m_connected = true;
+        st.m_ipv4Gateway = QHostAddress(doc.object()["endpoint"].toString());
+        st.m_ipv4Address = QHostAddress(doc.object()["deviceIpv4"].toString());
+        st.m_rxBytes = doc.object()["tx_bytes"].toInteger();
+        st.m_txBytes = doc.object()["rx_bytes"].toInteger();
+        emit statusUpdated(st);
       },
       Qt::QueuedConnection);
   connect(

--- a/src/platforms/ios/ioscontroller.mm
+++ b/src/platforms/ios/ioscontroller.mm
@@ -267,8 +267,14 @@ void IOSController::checkStatus() {
     logger.debug() << "ServerIpv4Gateway:" << serverIpv4Gateway
                    << "DeviceIpv4Address:" << deviceIpv4Address << "RxBytes:" << rxBytes
                    << "TxBytes:" << txBytes;
-    emit statusUpdated(QString::fromNSString(serverIpv4Gateway),
-                       QString::fromNSString(deviceIpv4Address), txBytes, rxBytes);
+    ControllerStatus st;
+    st.m_connected = true;
+    st.m_ipv4Gateway = QHostAddress(QString::fromNSString(serverIpv4Gateway));
+    st.m_ipv4Address = QHostAddress(QString::fromNSString(deviceIpv4Address));
+    st.m_rxBytes = rxBytes;
+    st.m_txBytes = txBytes;
+
+    emit statusUpdated(st);
   }];
 }
 

--- a/src/platforms/linux/linuxcontroller.cpp
+++ b/src/platforms/linux/linuxcontroller.cpp
@@ -211,7 +211,7 @@ void LinuxController::checkStatusCompleted(QDBusPendingCallWatcher* call) {
     return;
   }
 
-  emitStatusFromJson(obj);
+  emit statusUpdated(ControllerStatus(obj));
 }
 
 void LinuxController::getBackendLogs(QIODevice* device) {

--- a/src/platforms/linux/netmgrcontroller.cpp
+++ b/src/platforms/linux/netmgrcontroller.cpp
@@ -66,7 +66,8 @@ void NetmgrController::initialize(const Device* device, const Keys* keys) {
   }
   m_uuid = uuid.toString(QUuid::WithoutBraces);
 
-  m_deviceIpv4Address = device->ipv4Address();
+  m_deviceIpv4Address = QHostAddress(device->ipv4Address().split('/').first());
+  m_deviceIpv6Address = QHostAddress(device->ipv6Address().split('/').first());
 
   // Generic connection settings.
   m_config.insert("id", QCoreApplication::applicationName());
@@ -248,11 +249,16 @@ void NetmgrController::activate(const InterfaceConfig& config,
   m_ipv6config.insert("route-data", ipv6routes);
   m_wireguard.insert("peers", peers);
 
+  // Keep the server details for later.
+  m_serverPublicKey = config.m_serverPublicKey;
+  m_serverIpv4Gateway = QHostAddress(config.m_serverIpv4Gateway);
+  m_serverIpv6Gateway = QHostAddress(config.m_serverIpv6Gateway);
+
   // Update the DNS server.
   if ((config.m_dnsServer == config.m_serverIpv4Gateway) ||
       (config.m_dnsServer == config.m_serverIpv6Gateway)) {
-    setDnsConfig(m_ipv4config, QHostAddress(config.m_serverIpv4Gateway));
-    setDnsConfig(m_ipv6config, QHostAddress(config.m_serverIpv6Gateway));
+    setDnsConfig(m_ipv4config, m_serverIpv4Gateway);
+    setDnsConfig(m_ipv6config, m_serverIpv6Gateway);
   } else if (config.m_dnsServer.contains(':')) {
     setDnsConfig(m_ipv4config, QHostAddress());
     setDnsConfig(m_ipv6config, QHostAddress(config.m_dnsServer));
@@ -260,10 +266,6 @@ void NetmgrController::activate(const InterfaceConfig& config,
     setDnsConfig(m_ipv4config, QHostAddress(config.m_dnsServer));
     setDnsConfig(m_ipv6config, QHostAddress());
   }
-
-  // Keep the server details for later.
-  m_serverPublicKey = config.m_serverPublicKey;
-  m_serverIpv4Gateway = config.m_serverIpv4Gateway;
 
   // Update the connection settings.
   QList<QVariant> args;
@@ -390,10 +392,18 @@ void NetmgrController::checkStatus() {
       QString("/sys/class/net/%1/statistics/tx_bytes").arg(WG_INTERFACE_NAME);
   QString rxPath =
       QString("/sys/class/net/%1/statistics/rx_bytes").arg(WG_INTERFACE_NAME);
-  uint64_t tx = readSysfsFile(txPath);
-  uint64_t rx = readSysfsFile(rxPath);
-  logger.info() << "Status:" << m_deviceIpv4Address << tx << rx;
-  emit statusUpdated(m_serverIpv4Gateway, m_deviceIpv4Address, tx, rx);
+
+  ControllerStatus st;
+  st.m_connected = true;
+  st.m_timestamp = guessUptime();
+  st.m_ipv4Gateway = m_serverIpv4Gateway;
+  st.m_ipv6Gateway = m_serverIpv6Gateway;
+  st.m_ipv4Address = m_deviceIpv4Address;
+  st.m_ipv6Address = m_deviceIpv6Address;
+  st.m_rxBytes = readSysfsFile(rxPath);
+  st.m_txBytes = readSysfsFile(txPath);
+
+  emit statusUpdated(st);
 }
 
 QDateTime NetmgrController::guessUptime() {

--- a/src/platforms/linux/netmgrcontroller.h
+++ b/src/platforms/linux/netmgrcontroller.h
@@ -6,6 +6,7 @@
 #define NETWORKMANAGERCONTROLLER_H
 
 #include <QDBusObjectPath>
+#include <QHostAddress>
 #include <QObject>
 #include <QVariant>
 #include <QVersionNumber>
@@ -75,8 +76,10 @@ class NetmgrController final : public ControllerImpl {
   QVariantMap m_wireguard;
 
   QString m_serverPublicKey;
-  QString m_serverIpv4Gateway;
-  QString m_deviceIpv4Address;
+  QHostAddress m_serverIpv4Gateway;
+  QHostAddress m_serverIpv6Gateway;
+  QHostAddress m_deviceIpv4Address;
+  QHostAddress m_deviceIpv6Address;
   QString m_uuid;
 
   QVersionNumber m_version;

--- a/src/platforms/macos/macoscontroller.mm
+++ b/src/platforms/macos/macoscontroller.mm
@@ -307,7 +307,7 @@ void MacOSController::checkStatus() {
   [remoteObject() getStatus:^(NSString* status){
     QByteArray jsBlob = QString::fromNSString(status).toUtf8();
     QJsonObject obj = QJsonDocument::fromJson(jsBlob).object();
-    emitStatusFromJson(obj);
+    emit statusUpdated(ControllerStatus(obj));
   }];
 }
 

--- a/src/platforms/wasm/wasmcontroller.cpp
+++ b/src/platforms/wasm/wasmcontroller.cpp
@@ -42,4 +42,6 @@ void WasmController::deactivate() {
   QMetaObject::invokeMethod(m_mock, "deactivate", Qt::QueuedConnection);
 }
 
-void WasmController::checkStatus() { emitStatusFromJson(m_mock->getStatus()); }
+void WasmController::checkStatus() {
+  emit statusUpdated(ControllerStatus(m_mock->getStatus()));
+}

--- a/tests/qml/moccontroller.cpp
+++ b/tests/qml/moccontroller.cpp
@@ -45,9 +45,6 @@ void Controller::setError(ErrorCode) {}
 
 qint64 Controller::connectionTimestamp() const { return 42; }
 
-void Controller::statusUpdated(const QString&, const QString&, uint64_t,
-                               uint64_t) {}
-
 QList<IPAddress> Controller::getAllowedIPAddressRanges(const Server& server) {
   Q_UNUSED(server);
   return QList<IPAddress>();
@@ -61,16 +58,7 @@ Controller::ErrorCode Controller::error() const {
 
 void Controller::updateRequired() {}
 
-void Controller::getStatus(
-    std::function<void(const QString& serverIpv4Gateway,
-                       const QString& deviceIpv4Address, uint64_t txBytes,
-                       uint64_t rxBytes)>&& a_callback) {
-  std::function<void(const QString& serverIpv4Gateway,
-                     const QString& deviceIpv4Address, uint64_t txBytes,
-                     uint64_t rxBytes)>
-      callback = std::move(a_callback);
-  callback("127.0.0.1", "127.0.0.1", 0, 0);
-}
+void Controller::refreshStatus() { emit statusUpdated(m_status); }
 
 void Controller::quit() {}
 

--- a/tests/unit/moccontroller.cpp
+++ b/tests/unit/moccontroller.cpp
@@ -49,9 +49,6 @@ void Controller::setError(ErrorCode) {}
 
 qint64 Controller::connectionTimestamp() const { return 42; }
 
-void Controller::statusUpdated(const QString&, const QString&, uint64_t,
-                               uint64_t) {}
-
 QList<IPAddress> Controller::getAllowedIPAddressRanges(const Server& server) {
   Q_UNUSED(server);
   return QList<IPAddress>();
@@ -67,16 +64,7 @@ Controller::ErrorCode Controller::error() const {
 
 void Controller::updateRequired() {}
 
-void Controller::getStatus(
-    std::function<void(const QString& serverIpv4Gateway,
-                       const QString& deviceIpv4Address, uint64_t txBytes,
-                       uint64_t rxBytes)>&& a_callback) {
-  std::function<void(const QString& serverIpv4Gateway,
-                     const QString& deviceIpv4Address, uint64_t txBytes,
-                     uint64_t rxBytes)>
-      callback = std::move(a_callback);
-  callback("127.0.0.1", "127.0.0.1", 0, 0);
-}
+void Controller::refreshStatus() { emit statusUpdated(m_status); }
 
 void Controller::quit() {}
 


### PR DESCRIPTION
## Description
Breaking the `Controller::getStatus()` API refactoring work out of PR #11236 and into a standalone PR.

The gist of this is that `Controller::getStatus()` is kind of a mess. It is both brittle and difficult to change by passing a huge number of arguments, and the need to keep a list of callback methods is awkward and prone dangling pointer issues. We can simplify this by:

1. Gathering all of the status bits together into a class.
2. Report their changes using a Qt signal emission.
3. Replace the callback hook thing with a `Qt::SingleShotConnection`.

## Reference
Split from: #11236

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] If bug/feature is at all notable, I've added a draft release note as a comment in `addons/strings.yaml`.
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
