### PR TITLE
Nit: Make NSError loggable

### DIFF
--- a/src/utils/logger.cpp
+++ b/src/utils/logger.cpp
@@ -56,16 +56,22 @@ Logger::Log& Logger::Log::operator<<(QTextStreamFunction t) {
 
 #ifdef Q_OS_APPLE
 Logger::Log& Logger::Log::operator<<(const NSString* t) {
-  m_data->m_ts << QString::fromNSString(t);
+  m_data->m_ts << QString::fromNSString(t) << ' ';
+  return *this;
+}
+Logger::Log& Logger::Log::operator<<(const NSError* t) {
+  CFStringRef ref = CFErrorCopyDescription((CFErrorRef)t);
+  m_data->m_ts << QString::fromCFString(ref) << ' ';
+  CFRelease(ref);
   return *this;
 }
 Logger::Log& Logger::Log::operator<<(CFStringRef t) {
-  m_data->m_ts << QString::fromCFString(t);
+  m_data->m_ts << QString::fromCFString(t) << ' ';
   return *this;
 }
 Logger::Log& Logger::Log::operator<<(CFErrorRef t) {
   CFStringRef ref = CFErrorCopyDescription(t);
-  m_data->m_ts << QString::fromCFString(ref);
+  m_data->m_ts << QString::fromCFString(ref) << ' ';
   CFRelease(ref);
   return *this;
 }

--- a/src/utils/logger.h
+++ b/src/utils/logger.h
@@ -14,6 +14,8 @@
 
 #ifdef Q_OS_APPLE
 #  include <CoreFoundation/CoreFoundation.h>
+#  include <QtDarwinHelpers>
+Q_FORWARD_DECLARE_OBJC_CLASS(NSError);
 #endif
 
 class QJsonObject;
@@ -39,6 +41,7 @@ class Logger {
     Log& operator<<(const void* t);
 #ifdef Q_OS_APPLE
     Log& operator<<(const NSString* t);
+    Log& operator<<(const NSError* t);
     Log& operator<<(CFStringRef t);
     Log& operator<<(CFErrorRef t);
 #endif


### PR DESCRIPTION
## Description
The `NSError` type is one of the macOS Foundation error reporting types, and it can be toll-free-bridged into the already-supported CFErrorRef type. So let's add the appropriate logging wrapper to support it in the `Logger` class.

While we're at it, we are also adding the trailing space for the other macOS logging types to keep them consistent with the rest of the logger class.

This should fix a couple of error logs where we print out a raw pointer rather than the error message.

## Reference
Split from: #11236 

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] If bug/feature is at all notable, I've added a draft release note as a comment in `addons/strings.yaml`.
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
