### PR TITLE
VPN-7684: fix onboarding icon color

### DIFF
--- a/nebula/ui/components/MZStepProgressBarDelegate.qml
+++ b/nebula/ui/components/MZStepProgressBarDelegate.qml
@@ -99,7 +99,7 @@ Column {
 
             MultiEffect {
                 anchors.fill: parent
-
+                brightness: 1.0
                 colorization: 1.0
                 colorizationColor: delegate.currentState === MZStepProgressBarDelegate.State.Complete ? MZTheme.colors.stepProgressIconComplete : MZTheme.colors.stepProgressIconIncomplete
                 source: icon

--- a/src/ui/screens/home/servers/ServerList.qml
+++ b/src/ui/screens/home/servers/ServerList.qml
@@ -255,7 +255,7 @@ FocusScope {
 
                                 MultiEffect {
                                     anchors.fill: parent
-
+                                    brightness: 1.0
                                     colorization: 1.0
                                     colorizationColor: MZTheme.colors.normalButton.defaultColor
                                     source: refreshIcon


### PR DESCRIPTION
## Description

This is from [the removal of Qt compat effects](https://github.com/mozilla-mobile/mozilla-vpn-client/pull/11153). Turns out colorization just bases it off the icon's color, unless we give it a brightness. This was only happening on 2 of the 4 onboarding icons as the other 2 were white, and thus applied the color as expected. 

The icon in Server is a light enough color that it didn't make a difference, but I added it there for good measure as well.  These are the only two spots in our code that have `colorization`.

Fixed:
<img width="361" height="97" alt="Screenshot 131" src="https://github.com/user-attachments/assets/957dab00-bb07-40fe-a3be-c503e3d0088d" />
<img width="360" height="101" alt="Screenshot 130" src="https://github.com/user-attachments/assets/ee11a31e-ad6d-4a6b-8c57-a63b43868955" />
<img width="352" height="98" alt="Screenshot 129" src="https://github.com/user-attachments/assets/40738a13-a629-489c-8b09-d6f5b850df95" />



## Reference

VPN-7684

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] If bug/feature is at all notable, I've added a draft release note as a comment in `addons/strings.yaml`.
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
