### PR TITLE
VPN-7659: Initialize localizer before using translations

### DIFF
--- a/src/ipaddresslookup.cpp
+++ b/src/ipaddresslookup.cpp
@@ -10,6 +10,7 @@
 
 #include "controller.h"
 #include "leakdetector.h"
+#include "localizer.h"
 #include "logger.h"
 #include "mozillavpn.h"
 #include "tasks/ipfinder/taskipfinder.h"
@@ -43,6 +44,13 @@ void IpAddressLookup::reset() {
   logger.debug() << "Resetting the data";
 
   if (m_state != StateWaiting) {
+    // On iOS (and possibly Android), we need to ensure the Localizer
+    // is initialized before setting it to the loading string ID in
+    // a few lines. This is a hacky way to do it, but it works.
+    // See VPN-7659 for more info.
+    bool unusedBooleanUsedForInitialization =
+        Localizer::instance()->isRightToLeft();
+
     //% "Loading"
     //: This refers to the current IP address, i.e. "IP: Loading".
     m_ipv4Address = qtTrId("vpn.connectionInfo.loading");

--- a/src/ipaddresslookup.cpp
+++ b/src/ipaddresslookup.cpp
@@ -44,12 +44,9 @@ void IpAddressLookup::reset() {
   logger.debug() << "Resetting the data";
 
   if (m_state != StateWaiting) {
-    // On iOS (and possibly Android), we need to ensure the Localizer
-    // is initialized before setting it to the loading string ID in
-    // a few lines. This is a hacky way to do it, but it works.
-    // See VPN-7659 for more info.
-    bool unusedBooleanUsedForInitialization =
-        Localizer::instance()->isRightToLeft();
+    // VPN-7659: On iOS and Android, we need to ensure the Localizer
+    // is initialized before setting it to the loading string ID.
+    Localizer::instance();
 
     //% "Loading"
     //: This refers to the current IP address, i.e. "IP: Loading".

--- a/tests/unit/testipaddresslookup.cpp
+++ b/tests/unit/testipaddresslookup.cpp
@@ -31,16 +31,14 @@ void TestIpAddressLookup::checkIpAddressSucceess_data() {
   QTest::addColumn<QString>("ipAddress");
   QTest::addColumn<bool>("signal");
 
-  QTest::addRow("invalid") << QByteArray("") << "vpn.connectionInfo.loading"
-                           << false;
+  QTest::addRow("invalid") << QByteArray("") << "Loading" << false;
 
   QJsonObject json;
-  QTest::addRow("empty") << QJsonDocument(json).toJson()
-                         << "vpn.connectionInfo.loading" << false;
+  QTest::addRow("empty") << QJsonDocument(json).toJson() << "Loading" << false;
 
   json.insert("ip", 42);
   QTest::addRow("invalid ip")
-      << QJsonDocument(json).toJson() << "vpn.connectionInfo.loading" << false;
+      << QJsonDocument(json).toJson() << "Loading" << false;
 
   json.insert("ip", "42");
   QTest::addRow("valid ip") << QJsonDocument(json).toJson() << "42" << true;


### PR DESCRIPTION
## Description

While this was recently fixed in https://github.com/mozilla-mobile/mozilla-vpn-client/pull/10939, it was reintroduced in https://github.com/mozilla-mobile/mozilla-vpn-client/pull/11041/ when we improved localizer behavior.

I think this is a hacky fix, and I'm open to better solutions. 

Before / after
<img width="163" alt="IMG_0078" src="https://github.com/user-attachments/assets/3910100d-7cd2-4948-9e2b-5dc562e3f281" /> <img width="163" alt="IMG_0079" src="https://github.com/user-attachments/assets/436539da-8725-4a00-8061-00e68b859ea3" /> 



## Reference

VPN-7659

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] If bug/feature is at all notable, I've added a draft release note as a comment in `addons/strings.yaml`.
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
