### PR TITLE
Fix app-exclusion error on IPv6-only networks on Windows

### DIFF
--- a/src/platforms/windows/daemon/windowsdaemon.cpp
+++ b/src/platforms/windows/daemon/windowsdaemon.cpp
@@ -64,23 +64,32 @@ bool WindowsDaemon::run(Op op, const InterfaceConfig& config) {
     m_splitTunnelManager->stop();
     return true;
   }
+
   if (config.m_vpnDisabledApps.length() > 0) {
     // Before creating the interface we need to check which adapter routes to
     // the entry server endpoint. This will be selected as the outgoing
     // interface for split-tunnelled traffic.
-    QHostAddress entryServerAddr;
-    if (config.m_hopType == InterfaceConfig::HopType::SingleHop) {
-      entryServerAddr.setAddress(config.m_serverIpv4AddrIn);
-    } else if (config.m_hopType == InterfaceConfig::HopType::MultiHopExit) {
-      auto entry = m_connections.value(InterfaceConfig::HopType::MultiHopEntry);
-      entryServerAddr.setAddress(entry.m_config.m_serverIpv4AddrIn);
-    } else {
+    InterfaceConfig entry = config;
+
+    if (config.m_hopType == InterfaceConfig::HopType::MultiHopExit) {
+      entry =
+          m_connections.value(InterfaceConfig::HopType::MultiHopEntry).m_config;
+    } else if (config.m_hopType != InterfaceConfig::HopType::SingleHop) {
       return true;
     }
 
-    int inetAdapterIndex = WindowsCommons::AdapterIndexTo(entryServerAddr);
+    int inetAdapterIndex = -1;
+
+    for (const QString& a :
+         {entry.m_serverIpv4AddrIn, entry.m_serverIpv6AddrIn}) {
+      if (a.isEmpty()) continue;
+      inetAdapterIndex = WindowsCommons::AdapterIndexTo(QHostAddress(a));
+      if (inetAdapterIndex >= 0) break;
+    }
+
     if (inetAdapterIndex < 0) {
       emit backendFailure(DaemonError::ERROR_SPLIT_TUNNEL_START_FAILURE);
+      return true;
     }
 
     if (!m_splitTunnelManager->start(inetAdapterIndex)) {

--- a/src/platforms/windows/daemon/windowssplittunnel.cpp
+++ b/src/platforms/windows/daemon/windowssplittunnel.cpp
@@ -530,11 +530,16 @@ bool WindowsSplitTunnel::getAddress(int adapterIndex, IN_ADDR* out_ipv4,
     }
   }
 
-  // An IPv4 address is required for split tunnelling.
+  // At least one address family is required for split tunnelling.
+  if (!bestIpv4 && !bestIpv6) {
+    return false;
+  }
+
+  // Output the IPv4 address, if any.
   if (bestIpv4) {
     out_ipv4->s_addr = bestIpv4->Address.Ipv4.sin_addr.s_addr;
   } else {
-    return false;
+    out_ipv4->s_addr = 0;
   }
 
   // Output the IPv6 address, if any.

--- a/src/platforms/windows/windowscommons.cpp
+++ b/src/platforms/windows/windowscommons.cpp
@@ -9,6 +9,8 @@
 #include <dxgi.h>
 #include <iphlpapi.h>
 #include <shlobj_core.h>
+#include <winsock2.h>
+#include <ws2ipdef.h>
 
 #include <QDir>
 #include <QHostAddress>
@@ -115,9 +117,22 @@ QString WindowsCommons::getTunnelLogFilePath() {
 int WindowsCommons::AdapterIndexTo(const QHostAddress& dst) {
   logger.debug() << "Getting Current Internet Adapter that routes to"
                  << logger.sensitive(dst.toString());
-  quint32 ipv4be = qToBigEndian<quint32>(dst.toIPv4Address());
   DWORD index = 0;
-  DWORD result = GetBestInterface(ipv4be, &index);
+  DWORD result;
+
+  if (dst.protocol() == QAbstractSocket::IPv6Protocol) {
+    sockaddr_in6 addr = {};
+    addr.sin6_family = AF_INET6;
+    Q_IPV6ADDR buf = dst.toIPv6Address();
+    memcpy(&addr.sin6_addr, &buf, sizeof(buf));
+    result = GetBestInterfaceEx(reinterpret_cast<sockaddr*>(&addr), &index);
+  } else {
+    sockaddr_in addr = {};
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = qToBigEndian<quint32>(dst.toIPv4Address());
+    result = GetBestInterfaceEx(reinterpret_cast<sockaddr*>(&addr), &index);
+  }
+
   if (result != NO_ERROR) {
     logger.warning() << "Interface lookup failed:"
                      << WindowsUtils::getErrorMessage(result);


### PR DESCRIPTION
## Description

When at least one app was excluded from the VPN, turning the VPN on displayed the "Error activating App exclusions" banner on IPv6-only networks. With no IPv4 route to the server the lookup failed, returning -1.

## Reference

[VPN-4368](https://mozilla-hub.atlassian.net/browse/VPN-4368)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] If bug/feature is at all notable, I've added a draft release note as a comment in `addons/strings.yaml`.
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-4368]: https://mozilla-hub.atlassian.net/browse/VPN-4368?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ