### PR TITLE
Fix escape sequence warning in make_template.py

### DIFF
--- a/scripts/utils/make_template.py
+++ b/scripts/utils/make_template.py
@@ -46,9 +46,9 @@ for keyfile in args.keyfile:
 # to any already-transformed text.
 def transform(text):
     start = 0
-    ac_regex = re.compile('@[\w.]+@') ## Autoconf style match: @VARNAME@
-    cm_regex = re.compile('\${[\w.]+}') ## CMake style match: ${VARNAME}
-    xc_regex = re.compile('\$\([\w.]+\)') ## Xcode style match: $(VARNAME)
+    ac_regex = re.compile(r'@[\w.]+@') ## Autoconf style match: @VARNAME@
+    cm_regex = re.compile(r'\${[\w.]+}') ## CMake style match: ${VARNAME}
+    xc_regex = re.compile(r'\$\([\w.]+\)') ## Xcode style match: $(VARNAME)
     while start < len(text):
         ## Search for the next variable to substitute.
         ac_match = ac_regex.search(text, start)


### PR DESCRIPTION
## Description
The `make_template.py` script embeds some regex into a python string. Depending on your python version this can throw a bunch of warnings about invalid escape sequences. Despite the warnings, the regex still seems to work as expected. To fix the warnings we should convert these into python raw strings to disable the escape sequence handling.

## Reference

    i.e Jira or Github issue URL

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] If bug/feature is at all notable, I've added a draft release note as a comment in `addons/strings.yaml`.
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
