### PR TITLE
VPN-7664 (test 2 of 3): Server switch sometimes happens really quickly, test gets stuck

### DIFF
--- a/tests/functional/testServers.js
+++ b/tests/functional/testServers.js
@@ -211,7 +211,10 @@ describe('Server', function() {
       await vpn.waitForCondition(async () => {
         let connectingMsg = await vpn.getQueryProperty(
             queries.screenHome.CONTROLLER_TITLE.visible(), 'text');
-        return connectingMsg === 'Switching…';
+        // Sometimes it switches so quickly it is past "Switching" by the time
+        // code gets here. In those cases, test was timing out, as it was
+        // already on "VPN is on". Thus, allow for both.
+        return connectingMsg === 'Switching…' || connectingMsg === 'VPN is on';
       });
 
       await vpn.waitForCondition(async () => {

--- a/tests/functional/testServers.js
+++ b/tests/functional/testServers.js
@@ -208,14 +208,10 @@ describe('Server', function() {
       await vpn.waitForQuery(queries.screenHome.STACKVIEW.ready());
       await vpn.waitForQuery(queries.screenHome.CONTROLLER_TITLE.visible());
 
-      await vpn.waitForCondition(async () => {
-        let connectingMsg = await vpn.getQueryProperty(
-            queries.screenHome.CONTROLLER_TITLE.visible(), 'text');
-        // Sometimes it switches so quickly it is past "Switching" by the time
-        // code gets here. In those cases, test was timing out, as it was
-        // already on "VPN is on". Thus, allow for both.
-        return connectingMsg === 'Switching…' || connectingMsg === 'VPN is on';
-      });
+      // Before it switches, will have "No Signal" visible.
+      // Sometimes it switches faster than we get here, so cannot gate
+      // on "Switching" being visible or it will sometimes hang.
+      await vpn.waitForQuery(queries.screenHome.STABILITY_LABEL.hidden());
 
       await vpn.waitForCondition(async () => {
         return await vpn.getQueryProperty(


### PR DESCRIPTION
## Description

This test has recently started failing sometimes - like [here](https://github.com/mozilla-mobile/mozilla-vpn-client/actions/runs/28223013350/job/83609045413?pr=11396).

This line got [changed recently](https://github.com/mozilla-mobile/mozilla-vpn-client/pull/10995/), and I think we should revert it. From logs, I can see that it's switching servers. But possibly so quickly that we don't get a chance to successfully evaluate it saying "Switching"?

## Reference

VPN-7664

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] If bug/feature is at all notable, I've added a draft release note as a comment in `addons/strings.yaml`.
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
