### PR TITLE
VPN-7664 (test 3 of 3): always close out of functional tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "scripts": {
     "build": "npm run build --workspaces",
-    "functionalTest": "mocha --require ./tests/functional/setupVpn.js --timeout 30000",
+    "functionalTest": "mocha --exit --require ./tests/functional/setupVpn.js --timeout 30000",
     "functionalTestCli": "mocha ./tests/functional/testCli.js --timeout 30000",
-    "functionalTestWasm": "WASM=true mocha --require ./tests/functional/setupWasm.js --timeout 30000",
+    "functionalTestWasm": "WASM=true mocha --exit --require ./tests/functional/setupWasm.js --timeout 30000",
     "wasm:dev": "node tests/functional/wasm.js"
   },
   "devDependencies": {


### PR DESCRIPTION
## Description

testWebExtensionAPI is sometimes failing, [such as here](https://github.com/mozilla-mobile/mozilla-vpn-client/actions/runs/28254351102/job/83714464923?pr=11397). The tests all successfully complete, but one has a hang. We're creating multiple processes, and one isn't closing - causing the test to time out. Luckily, we have a flag we can pass to mocha to always close out once tests are copmlete.

## Reference

VPN-7664

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] If bug/feature is at all notable, I've added a draft release note as a comment in `addons/strings.yaml`.
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
