### PR TITLE
VPN-7688: donate app intents on iOS

### DIFF
--- a/src/platforms/ios/ioscontroller.swift
+++ b/src/platforms/ios/ioscontroller.swift
@@ -288,6 +288,7 @@ public class IOSControllerImpl: NSObject {
                             try TunnelManager.session?.sendProviderMessage(message.encode()) {_ in return}
                         } else {
                             try TunnelManager.session?.startTunnel(options: ["source":"app"])
+                            TurnOnIntent().donate()
                         }
                         // If `try` didn't throw, run onboarding callback. This callback only matters when onboarding.
                         onboardingCompletedCallback()
@@ -365,6 +366,7 @@ public class IOSControllerImpl: NSObject {
 
     @objc func disconnect() {
       IOSControllerImpl.staticDisconnect()
+      TurnOffIntent().donate()
     }
 
     static func staticDisconnect() {


### PR DESCRIPTION
## Description

Apple recommends we "donate" app intents - tell the system when the user performs these actions manually. iOS then associates when/where/etc., and is more likely to surface our app intents as Siri suggestions. Of course, none of this is guaranteed.

Example: Someone opens the app and turns on the VPN every day when they arrive at work. Siri - sharing none of this with us - realizes that this happens at their work location, and may start surfacing the “Turn On VPN” suggestion when they are at work.

We should not donate app intents when the action came from the actual intent. I believe both these routes meet this requirement.

I did not create app intent donations for toggle intent (which is used under the hood for the control widgets, so makes little sense here) nor the "get current status" intent (which is mostly there to be used in Shortcuts, if desired).

## Reference

VPN-7688

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] If bug/feature is at all notable, I've added a draft release note as a comment in `addons/strings.yaml`.
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
