### PR TITLE
VPN-7690: add 2 Norwegian languages to app

### DIFF
--- a/src/translations/extras/extras.xliff
+++ b/src/translations/extras/extras.xliff
@@ -89,8 +89,14 @@
       <trans-unit id="languages.ko" xml:space="preserve">
         <source>Korean</source>
       </trans-unit>
+      <trans-unit id="languages.nb_NO" xml:space="preserve">
+        <source>Norwegian Bokmål</source>
+      </trans-unit>
       <trans-unit id="languages.nl" xml:space="preserve">
         <source>Dutch</source>
+      </trans-unit>
+      <trans-unit id="languages.nn_NO" xml:space="preserve">
+        <source>Norwegian Nynorsk</source>
       </trans-unit>
       <trans-unit id="languages.oc" xml:space="preserve">
         <source>Occitan</source>


### PR DESCRIPTION
## Description

Thanks to wonderful volunteers, translations are coming in for [Norwegian Nynorsk](https://pontoon.mozilla.org/nn-NO/) and [Norwegian Bokmål](https://pontoon.mozilla.org/nb-NO/). This is the little bit of manual work requires to get them in.

## Reference

VPN-7690

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] If bug/feature is at all notable, I've added a draft release note as a comment in `addons/strings.yaml`.
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
