### PR TITLE
Remove major language flag in AddonConditionWatcherLocales

### DIFF
--- a/src/addons/conditionwatchers/addonconditionwatcherlocales.cpp
+++ b/src/addons/conditionwatchers/addonconditionwatcherlocales.cpp
@@ -10,22 +10,17 @@
 
 // static
 AddonConditionWatcher* AddonConditionWatcherLocales::maybeCreate(
-    QObject* parent, const QStringList& locales,
-    MajorLanguageCodePolicy majorLanguageCodePolicy) {
+    QObject* parent, const QStringList& locales) {
   if (locales.isEmpty()) {
     return nullptr;
   }
 
-  return new AddonConditionWatcherLocales(parent, locales,
-                                          majorLanguageCodePolicy);
+  return new AddonConditionWatcherLocales(parent, locales);
 }
 
 AddonConditionWatcherLocales::AddonConditionWatcherLocales(
-    QObject* parent, const QStringList& locales,
-    MajorLanguageCodePolicy majorLanguageCodePolicy)
-    : AddonConditionWatcher(parent),
-      m_locales(locales),
-      m_majorLanguageCodePolicy(majorLanguageCodePolicy) {
+    QObject* parent, const QStringList& locales)
+    : AddonConditionWatcher(parent), m_locales(locales) {
   MZ_COUNT_CTOR(AddonConditionWatcherLocales);
 
   m_currentStatus = conditionApplied();
@@ -48,14 +43,5 @@ bool AddonConditionWatcherLocales::conditionApplied() const {
   QString code = Localizer::instance()->languageCodeOrSystem();
   Q_ASSERT(!code.isEmpty());
 
-  if (m_locales.contains(code)) {
-    return true;
-  }
-
-  if (m_majorLanguageCodePolicy == CheckMajorLanguageCode) {
-    code = Localizer::majorLanguageCode(code);
-    return m_locales.contains(code.toLower());
-  }
-
-  return false;
+  return m_locales.contains(code);
 }

--- a/src/addons/conditionwatchers/addonconditionwatcherlocales.h
+++ b/src/addons/conditionwatchers/addonconditionwatcherlocales.h
@@ -12,32 +12,18 @@ class AddonConditionWatcherLocales final : public AddonConditionWatcher {
   Q_DISABLE_COPY_MOVE(AddonConditionWatcherLocales)
 
  public:
-  enum MajorLanguageCodePolicy {
-    // if the current locale is 'xx_YY' and the condition is 'xx', the addon is
-    // enabled.
-    CheckMajorLanguageCode,
-
-    // if the current locale is 'xx_YY' and the condition is 'xx', the addon is
-    // not enabled.
-    DoNotCheckMajorLanguageCode,
-  };
-
   ~AddonConditionWatcherLocales();
 
-  static AddonConditionWatcher* maybeCreate(
-      QObject* parent, const QStringList& locales,
-      MajorLanguageCodePolicy majorLanguageCodePolicy = CheckMajorLanguageCode);
+  static AddonConditionWatcher* maybeCreate(QObject* parent,
+                                            const QStringList& locales);
 
   bool conditionApplied() const override;
 
  private:
-  AddonConditionWatcherLocales(QObject* parent, const QStringList& locales,
-                               MajorLanguageCodePolicy majorLanguageCodePolicy);
+  AddonConditionWatcherLocales(QObject* parent, const QStringList& locales);
 
  private:
   const QStringList m_locales;
-  const MajorLanguageCodePolicy m_majorLanguageCodePolicy =
-      CheckMajorLanguageCode;
 
   bool m_currentStatus = false;
 };

--- a/src/addons/conditionwatchers/addonconditionwatchertranslationthreshold.cpp
+++ b/src/addons/conditionwatchers/addonconditionwatchertranslationthreshold.cpp
@@ -41,6 +41,5 @@ AddonConditionWatcher* AddonConditionWatcherTranslationThreshold::maybeCreate(
     }
   }
 
-  return AddonConditionWatcherLocales::maybeCreate(
-      addon, locales, AddonConditionWatcherLocales::CheckMajorLanguageCode);
+  return AddonConditionWatcherLocales::maybeCreate(addon, locales);
 }

--- a/tests/unit_tests/testaddon.cpp
+++ b/tests/unit_tests/testaddon.cpp
@@ -311,56 +311,43 @@ void TestAddon::conditionWatcher_locale() {
   // No locales -> no watcher.
   QVERIFY(!AddonConditionWatcherLocales::maybeCreate(&parent, QStringList()));
 
-  AddonConditionWatcher* acw = AddonConditionWatcherLocales::maybeCreate(
-      &parent, QStringList{"it", "fo_BAR"});
-  QVERIFY(!!acw);
-
   AddonConditionWatcher* acw2 = AddonConditionWatcherLocales::maybeCreate(
-      &parent, QStringList{"it", "fo_BAR"},
-      AddonConditionWatcherLocales::DoNotCheckMajorLanguageCode);
+      &parent, QStringList{"it", "fo_BAR"});
   QVERIFY(!!acw2);
 
-  QSignalSpy signalSpy(acw, &AddonConditionWatcher::conditionChanged);
+  QSignalSpy signalSpy(acw2, &AddonConditionWatcher::conditionChanged);
   QCOMPARE(signalSpy.count(), 0);
   SettingsHolder::instance()->setLanguageCode("en");
   QCOMPARE(signalSpy.count(), 0);
   SettingsHolder::instance()->setLanguageCode("it_RU");
-  QCOMPARE(signalSpy.count(), 1);
+  QCOMPARE(signalSpy.count(), 0);
   SettingsHolder::instance()->setLanguageCode("it");
   QCOMPARE(signalSpy.count(), 1);
   SettingsHolder::instance()->setLanguageCode("es");
   QCOMPARE(signalSpy.count(), 2);
 
   SettingsHolder::instance()->setLanguageCode("en");
-  QVERIFY(!acw->conditionApplied());
   QVERIFY(!acw2->conditionApplied());
 
   SettingsHolder::instance()->setLanguageCode("it");
-  QVERIFY(acw->conditionApplied());
   QVERIFY(acw2->conditionApplied());
 
   SettingsHolder::instance()->setLanguageCode("ru");
-  QVERIFY(!acw->conditionApplied());
   QVERIFY(!acw2->conditionApplied());
 
   SettingsHolder::instance()->setLanguageCode("it-IT");
-  QVERIFY(acw->conditionApplied());
   QVERIFY(!acw2->conditionApplied());
 
   SettingsHolder::instance()->setLanguageCode("en");
-  QVERIFY(!acw->conditionApplied());
   QVERIFY(!acw2->conditionApplied());
 
   SettingsHolder::instance()->setLanguageCode("it_RU");
-  QVERIFY(acw->conditionApplied());
   QVERIFY(!acw2->conditionApplied());
 
   SettingsHolder::instance()->setLanguageCode("fo");
-  QVERIFY(!acw->conditionApplied());
   QVERIFY(!acw2->conditionApplied());
 
   SettingsHolder::instance()->setLanguageCode("fo_BAR");
-  QVERIFY(acw->conditionApplied());
   QVERIFY(acw2->conditionApplied());
 }
 


### PR DESCRIPTION
## Description

`CheckMajorLanguageCode` isn’t really used. Because up until VPN-7665, we’ve hardly ever used the “locales” condition for addons. So we’ve never really used `AddonConditionWatcherLocales` or cared about which of the two major language code variants were used in deciding whether there was a match. Let's remove them.

In https://github.com/mozilla-mobile/mozilla-vpn-client/pull/11367, I was confused about the intended behavior for this. I changed it, and then changed it back. (The crux: If the major part of the current app locale matches a locale that the addon should be activated for based on addon conditions, then activate it. That is, the addon must list plain “es” as an addon locale to match when a user’s locale is “es_MX”. If the addon lists “es_AR” as a locale it should be activated it, it will be turned off if the user selects “es_MX”. Though some might expect that matching major locale would mean "es_AR" as an app language would activate an addon with a locale condition including "es_MX".)

Going back further, this flag has caused [other bugs](https://mozilla-hub.atlassian.net/browse/VPN-5569). And frustratingly, we've essentially never used this feature.

I think we should rip out this variant:
- We have essentially never used this functionality.
- We don’t have too many locales with country variants. If we remove this, for an example in Spanish, we’d change from listing “es” in the locales list to “es_MX”, “es_AR”, “es_ES”, and “es_CL”. IMO: This is clearer, and more straightforward. Especially since we don’t have a plain “es” language that we translate to, which is what we'd include if we were using the "major language" variant flag to match Spanish variants.
- How it is designed to work is confusing, at least for me - see above, and I missed the goal on my first read.
- We have fallback locales for addons (and main app), which seems like it covers this situation pretty well.

Currently, there is just one addon in prod that uses the locales condition. It’s `message_fpn_trial_subscription_expiring`, which is only shown to folks on an Firefox Private Network trial. There should be zero people who see this addon, as FPN has been dead for years. I spotchecked what addons were around in 2.20, which went out 2.5 years ago - no other ones in that time used “locales” as a condition. I think this is one of those things where code was written, but we almost never utilized it outside of testing. And so the “check major locale code” / “don’t check major locale code” difference has never really mattered.

## Reference

N/A

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] If bug/feature is at all notable, I've added a draft release note as a comment in `addons/strings.yaml`.
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
