### PR TITLE
VPN-7690 part 2: Move to modern translation type

### DIFF
--- a/src/ipaddresslookup.cpp
+++ b/src/ipaddresslookup.cpp
@@ -44,14 +44,8 @@ void IpAddressLookup::reset() {
   logger.debug() << "Resetting the data";
 
   if (m_state != StateWaiting) {
-    // VPN-7659: On iOS and Android, we need to ensure the Localizer
-    // is initialized before setting it to the loading string ID.
-    Localizer::instance();
-
-    //% "Loading"
-    //: This refers to the current IP address, i.e. "IP: Loading".
-    m_ipv4Address = qtTrId("vpn.connectionInfo.loading");
-    m_ipv6Address = qtTrId("vpn.connectionInfo.loading");
+    m_ipv4Address = "";
+    m_ipv6Address = "";
 
     setLookupState(StateWaiting);
     emit ipv4AddressChanged();

--- a/src/mozillavpn_p.h
+++ b/src/mozillavpn_p.h
@@ -22,7 +22,6 @@
 #include "networkwatcher.h"
 #include "releasemonitor.h"
 #include "serverlatency.h"
-#include "settingsholder.h"
 #include "statusicon.h"
 
 struct MozillaVPNPrivate {

--- a/src/translations/strings.yaml
+++ b/src/translations/strings.yaml
@@ -542,6 +542,9 @@ connectionInfo:
   rotateIPAddress:
     value: Attempt to change IP address
     comment: Accessible label for the button to try to get a new server in the same location
+  loading:
+    value: Loading
+    comment: Label when currently loading new information
 
 crashreporter:
   mainTitle:

--- a/src/ui/screens/home/controller/ip/IPInfoPanel.qml
+++ b/src/ui/screens/home/controller/ip/IPInfoPanel.qml
@@ -43,8 +43,9 @@ Rectangle {
 
             // Exit IP:
             ipVersionText: MZI18n.ConnectionInfoExitServerLabelIp
-            ipAddressText: VPNIPAddressLookup.ipv4Address
-            visible: VPNIPAddressLookup.ipv4Address !== ""
+            ipAddressText: VPNIPAddressLookup.ipv4Address !== "" ? VPNIPAddressLookup.ipv4Address : MZI18n.ConnectionInfoLoading
+            // Show when it has an IP address OR when neither have an IP address (and we default to showing "Loading")
+            visible: VPNIPAddressLookup.ipv4Address !== "" || VPNIPAddressLookup.ipv6Address === ""
         }
 
         Rectangle {
@@ -60,8 +61,9 @@ Rectangle {
 
             // Exit IPv6:
             ipVersionText: MZI18n.ConnectionInfoExitServerLabelIpv6
-            ipAddressText: VPNIPAddressLookup.ipv6Address
-            visible: VPNIPAddressLookup.ipv6Address !== ""
+            ipAddressText: VPNIPAddressLookup.ipv6Address !== "" ? VPNIPAddressLookup.ipv6Address : MZI18n.ConnectionInfoLoading
+            // Show when it has an IP address OR when neither have an IP address (and we default to showing "Loading")
+            visible: VPNIPAddressLookup.ipv6Address !== "" || VPNIPAddressLookup.ipv4Address === ""
         }
 
         Rectangle {

--- a/tests/unit/testipaddresslookup.cpp
+++ b/tests/unit/testipaddresslookup.cpp
@@ -31,14 +31,13 @@ void TestIpAddressLookup::checkIpAddressSucceess_data() {
   QTest::addColumn<QString>("ipAddress");
   QTest::addColumn<bool>("signal");
 
-  QTest::addRow("invalid") << QByteArray("") << "Loading" << false;
+  QTest::addRow("invalid") << QByteArray("") << "" << false;
 
   QJsonObject json;
-  QTest::addRow("empty") << QJsonDocument(json).toJson() << "Loading" << false;
+  QTest::addRow("empty") << QJsonDocument(json).toJson() << "" << false;
 
   json.insert("ip", 42);
-  QTest::addRow("invalid ip")
-      << QJsonDocument(json).toJson() << "Loading" << false;
+  QTest::addRow("invalid ip") << QJsonDocument(json).toJson() << "" << false;
 
   json.insert("ip", "42");
   QTest::addRow("valid ip") << QJsonDocument(json).toJson() << "42" << true;


### PR DESCRIPTION
## Description

QA mentioned they still don't see it. And I realized we're not seeing any stage-only languages. 

This is identical to https://github.com/mozilla-mobile/mozilla-vpn-client/pull/11363 - which fixed this less than 3 weeks ago. And the regression was caused by me in https://github.com/mozilla-mobile/mozilla-vpn-client/pull/11389, as I initialized the localizer (which causes settings to come online) earlier.

Since this is a near-immediate regression (within 3 weeks of my fix), let's do a stronger fix. Let's move this to the modern translation type. From my testing, this does both the things:
- "Loading" is shown, instead of the string ID.
- We set staging in an appropriate spot when opening the app - before the localizer turns on. Which means  we're appropriately-showing stage-only languages.

## Reference

VPN-7690

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] If bug/feature is at all notable, I've added a draft release note as a comment in `addons/strings.yaml`.
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
