### PR TITLE
fix xcode cloud

### DIFF
--- a/scripts/cmake/addons.cmake
+++ b/scripts/cmake/addons.cmake
@@ -96,8 +96,12 @@ function(add_addon_target NAME)
     # test addons) don't, and the adjustment also needs ADDON_SOURCE_DIR, which
     # isn't set when building from an explicit SOURCES list.
     if(LATEST_UPDATE_MANIFEST AND ADDON_SOURCE_DIR)
+        # Must live outside ADDON_SOURCE_DIR, and CMAKE_CURRENT_BINARY_DIR is
+        # ADDON_SOURCE_DIR here. Since this is CONFIGURE_DEPENDS glob and
+        # CMAKE_CURRENT_BINARY_DIR is inside the globbed directory, a generated
+        # manifest would trip VerifyGlobs and force an endless reconfigure.
+        set(DEFAULT_UPDATE_GEN_PARENT ${CMAKE_BINARY_DIR}/addons_generated/${NAME})
         set(DEFAULT_UPDATE_SRC_DIR ${ADDON_SOURCE_DIR}/message_update_default)
-        set(DEFAULT_UPDATE_GEN_PARENT ${CMAKE_CURRENT_BINARY_DIR}/${NAME}_generated)
         set(DEFAULT_UPDATE_GEN_DIR ${DEFAULT_UPDATE_GEN_PARENT}/message_update_default)
 
         # Future todo: Ensure that all non-manifest files are identical-ish between latest update message and default update message,


### PR DESCRIPTION
## Description

Xcode cloud builds are broken by a configure step that is re-globbing, and failing on this second round of configuring the default addon.

## Reference

N/A

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] If bug/feature is at all notable, I've added a draft release note as a comment in `addons/strings.yaml`.
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
