### PR TITLE
VPN-7694: add language code to language picker screen

### DIFF
--- a/scripts/cmake/addons.cmake
+++ b/scripts/cmake/addons.cmake
@@ -96,8 +96,12 @@ function(add_addon_target NAME)
     # test addons) don't, and the adjustment also needs ADDON_SOURCE_DIR, which
     # isn't set when building from an explicit SOURCES list.
     if(LATEST_UPDATE_MANIFEST AND ADDON_SOURCE_DIR)
+        # Must live outside ADDON_SOURCE_DIR, and CMAKE_CURRENT_BINARY_DIR is
+        # ADDON_SOURCE_DIR here. Since this is CONFIGURE_DEPENDS glob and
+        # CMAKE_CURRENT_BINARY_DIR is inside the globbed directory, a generated
+        # manifest would trip VerifyGlobs and force an endless reconfigure.
+        set(DEFAULT_UPDATE_GEN_PARENT ${CMAKE_BINARY_DIR}/addons_generated/${NAME})
         set(DEFAULT_UPDATE_SRC_DIR ${ADDON_SOURCE_DIR}/message_update_default)
-        set(DEFAULT_UPDATE_GEN_PARENT ${CMAKE_CURRENT_BINARY_DIR}/${NAME}_generated)
         set(DEFAULT_UPDATE_GEN_DIR ${DEFAULT_UPDATE_GEN_PARENT}/message_update_default)
 
         # Future todo: Ensure that all non-manifest files are identical-ish between latest update message and default update message,

--- a/src/ui/screens/settings/ViewLanguage.qml
+++ b/src/ui/screens/settings/ViewLanguage.qml
@@ -60,7 +60,8 @@ MZViewBase {
             _filterProxyCallback: obj => {
                                       const filterValue = getSearchBarText();
                                       return obj.nativeLanguageName.toLowerCase().includes(filterValue) ||
-                                      obj.localizedLanguageName.toLowerCase().includes(filterValue);
+                                      obj.localizedLanguageName.toLowerCase().includes(filterValue) ||
+                                      obj.code.toLowerCase().includes(filterValue);
                                   }
             _searchBarHasError: repeater.count === 0
             _searchBarPlaceholderText: MZI18n.LanguageViewSearchPlaceholder
@@ -171,7 +172,7 @@ MZViewBase {
                     Layout.rightMargin: MZTheme.theme.windowMargin
                     Layout.fillWidth: true
 
-                    text: localizedLanguageName
+                    text: localizedLanguageName + " (" + code + ")"
                 }
             }
         }


### PR DESCRIPTION
## Description

See ticket for why we need this. If we're putting it on screen, we should also allow searching by language code.

<img width="156" alt="Screenshot 144" src="https://github.com/user-attachments/assets/46499b66-b2d9-4a98-b88d-e5a3d79a6f75" /><img width="161" alt="Screenshot 143" src="https://github.com/user-attachments/assets/57b571ff-76dd-46e5-be94-09c41637584d" />

## Reference

VPN-7694


## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] If bug/feature is at all notable, I've added a draft release note as a comment in `addons/strings.yaml`.
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
