### PR TITLE
Fix shutdown semaphore signaling in network extension

### DIFF
--- a/macos/networkextension/wireguardtunnel.mm
+++ b/macos/networkextension/wireguardtunnel.mm
@@ -283,13 +283,13 @@ static void wgLog(const char* msg) {
     if (rx == 0) {
       // Socket has closed.
       NSLog(@"utun closed");
-      return;
+      break;
     }
     if (rx < 0) {
       // Socket error occurred.
       NSLog(@"utun error: %s", strerror(errno));
       if (errno == EINTR) continue;
-      return;
+      break;
     }
     if ((rx < sizeof(header)) || (rx > (mtu - sizeof(header)))) {
       continue;
@@ -313,6 +313,8 @@ static void wgLog(const char* msg) {
     [self.peer writePacket:htonl(header)
                   withData:buffer];
   }
+
+  dispatch_semaphore_signal(m_semaphore);
 }
 
 - (void)shutdownTunnel {


### PR DESCRIPTION
## Description
Just noticing a little quirk in the network extension. When restarting the extension for any reason, the extension hangs for about 5 seconds during the shutdown process. This seems to be caused by a missing semaphore signal when the worker thread exits.

This PR should address that and ensure the shutdown happens promptly.

## Reference

    i.e Jira or Github issue URL

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] If bug/feature is at all notable, I've added a draft release note as a comment in `addons/strings.yaml`.
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
