### PR TITLE
VPN-7101: Update system settings links for network extension

### DIFF
--- a/src/platforms/macos/macosutils.h
+++ b/src/platforms/macos/macosutils.h
@@ -17,7 +17,7 @@ class MacOSUtils final : public QObject {
 
   static MacOSUtils* instance();
 
-  Q_INVOKABLE void openSystemSettingsLoginItems();
+  Q_INVOKABLE void openSystemSettingsLink();
 
   Q_INVOKABLE int getMacOSMajorVersion();
 

--- a/src/platforms/macos/macosutils.mm
+++ b/src/platforms/macos/macosutils.mm
@@ -3,6 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "macosutils.h"
+
+#include "feature/features.h"
 #include "logger.h"
 #include "qmlengineholder.h"
 
@@ -12,6 +14,7 @@
 #include <objc/objc.h>
 
 #import <Cocoa/Cocoa.h>
+#import <Foundation/Foundation.h>
 #import <ServiceManagement/ServiceManagement.h>
 
 namespace {
@@ -34,7 +37,25 @@ QString MacOSUtils::appId(const QString& suffix) {
 }
 
 void MacOSUtils::openSystemSettingsLoginItems() {
-  [SMAppService openSystemSettingsLoginItems];
+  if (!Feature::isEnabled(Feature::networkExtension)) {
+    // When using a daemon installed via the SMAppService API, there is a
+    // helper method to go directly to the appropriate settings screen.
+    [SMAppService openSystemSettingsLoginItems];
+  } else if (@available(iOS 15.0, *)) {
+    // Users on macOS 15 and later: System extensions are managed via a special
+    // section in the Login Items panel. We can navigate directly to the
+    // extensions section, from there, the user must find the Mozilla VPN
+    // network extension and enable it.
+    NSString* url = @"x-apple.systempreferences:com.apple.LoginItems-Settings.extension?ExtensionItems";
+    [[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:url]];
+  } else {
+    // Users on macOS 13/14: When the system extension is blocked, and a message
+    // along the lines of "System software from application 'Mozilla VPN' was
+    // blocked from loading" will be displated in the Security panel. The users
+    // must click "Allow" on this screen to install the system extension.
+    NSString* url = @"x-apple.systempreferences:com.apple.preference.security?Security";
+    [[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:url]];
+  }
 }
 
 // static

--- a/src/platforms/macos/macosutils.mm
+++ b/src/platforms/macos/macosutils.mm
@@ -41,7 +41,7 @@ void MacOSUtils::openSystemSettingsLink() {
     // When using a daemon installed via the SMAppService API, there is a
     // helper method to go directly to the appropriate settings screen.
     [SMAppService openSystemSettingsLoginItems];
-  } else if (@available(iOS 15.0, *)) {
+  } else if (@available(macOS 15.0, *)) {
     // Users on macOS 15 and later: System extensions are managed via a special
     // section in the Login Items panel. We can navigate directly to the
     // extensions section and, from there, the user must find the Mozilla VPN

--- a/src/platforms/macos/macosutils.mm
+++ b/src/platforms/macos/macosutils.mm
@@ -47,14 +47,18 @@ void MacOSUtils::openSystemSettingsLink() {
     // extensions section and, from there, the user must find the Mozilla VPN
     // network extension and enable it.
     NSString* url = @"x-apple.systempreferences:com.apple.LoginItems-Settings.extension?ExtensionItems";
-    [[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:url]];
+    if (![[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:url]]) {
+      logger.warning() << "Unable to open settings to the Extensions panel";
+    }
   } else {
     // Users on macOS 13/14: When the system extension is blocked, a message
     // along the lines of "System software from application 'Mozilla VPN' was
     // blocked from loading" will be displayed in the Security panel. The users
     // must click "Allow" on this screen to install the system extension.
     NSString* url = @"x-apple.systempreferences:com.apple.preference.security?Security";
-    [[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:url]];
+    if (![[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:url]]) {
+      logger.warning() << "Unable to open settings to the Security panel";
+    }
   }
 }
 

--- a/src/platforms/macos/macosutils.mm
+++ b/src/platforms/macos/macosutils.mm
@@ -49,9 +49,9 @@ void MacOSUtils::openSystemSettingsLink() {
     NSString* url = @"x-apple.systempreferences:com.apple.LoginItems-Settings.extension?ExtensionItems";
     [[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:url]];
   } else {
-    // Users on macOS 13/14: When the system extension is blocked, and a message
+    // Users on macOS 13/14: When the system extension is blocked, a message
     // along the lines of "System software from application 'Mozilla VPN' was
-    // blocked from loading" will be displated in the Security panel. The users
+    // blocked from loading" will be displayed in the Security panel. The users
     // must click "Allow" on this screen to install the system extension.
     NSString* url = @"x-apple.systempreferences:com.apple.preference.security?Security";
     [[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:url]];

--- a/src/platforms/macos/macosutils.mm
+++ b/src/platforms/macos/macosutils.mm
@@ -36,7 +36,7 @@ QString MacOSUtils::appId(const QString& suffix) {
   return QString::fromNSString(appId) + suffix;
 }
 
-void MacOSUtils::openSystemSettingsLoginItems() {
+void MacOSUtils::openSystemSettingsLink() {
   if (!Feature::isEnabled(Feature::networkExtension)) {
     // When using a daemon installed via the SMAppService API, there is a
     // helper method to go directly to the appropriate settings screen.
@@ -44,7 +44,7 @@ void MacOSUtils::openSystemSettingsLoginItems() {
   } else if (@available(iOS 15.0, *)) {
     // Users on macOS 15 and later: System extensions are managed via a special
     // section in the Login Items panel. We can navigate directly to the
-    // extensions section, from there, the user must find the Mozilla VPN
+    // extensions section and, from there, the user must find the Mozilla VPN
     // network extension and enable it.
     NSString* url = @"x-apple.systempreferences:com.apple.LoginItems-Settings.extension?ExtensionItems";
     [[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:url]];

--- a/src/ui/sharedViews/ViewPermissionRequiredOSX.qml
+++ b/src/ui/sharedViews/ViewPermissionRequiredOSX.qml
@@ -80,7 +80,7 @@ MZFlickable {
             text: VPNMacOSUtils.getMacOSMajorVersion() > 14 ? MZI18n.PermissionMacosOpenSettingsButtonLabelMacOS15 : MZI18n.PermissionMacosOpenSettingsButtonLabel
             Layout.preferredHeight: MZTheme.theme.rowHeight
             loaderVisible: false
-            onClicked: VPNMacOSUtils.openSystemSettingsLoginItems()
+            onClicked: VPNMacOSUtils.openSystemSettingsLink()
         }
 
         MZLinkButton {


### PR DESCRIPTION
## Description
When installing the macOS network extension, there are some steps that the user must navigate in order to grant permissions for the network extension to be installed. Until those steps are complete, the application is blocked in the `Permission Required` state and a screen is displayed to the user. This screen includes a clickable link to open the system settings screen.

This PR attempts to update the clickable links to get the user closer to the appropriate settings screen. There are three cases we need to address here:
- Network Extension feature disabled: In this case the daemon is installed via the `SMAppService` API, which includes a helper method to direct the user to the correct screen.
- macOS 15 and later: The user needs to be directed to the `Extensions` section of the `Login Items` settings panel. On this panel they will need to find the `Mozilla VPN Network Extension` and enable it. The exact look and feel of this panel varies by OS version.
- macOS 13-14: The system extension is blocked and a message is displayed in the `Security` settings panel. The user needs to explicitly click `Allow` to unblock the installation process.

## Reference
JIRA Issue: [VPN-7101](https://mozilla-hub.atlassian.net/browse/VPN-7101)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] If bug/feature is at all notable, I've added a draft release note as a comment in `addons/strings.yaml`.
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-7101]: https://mozilla-hub.atlassian.net/browse/VPN-7101?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ