### PR TITLE
Obfuscation features part 2 - Add LWO obfuscator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -948,6 +948,7 @@ dependencies = [
  "base64",
  "clap",
  "log",
+ "nix",
  "once_cell",
  "rand",
  "tokio",

--- a/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/VPNService.kt
+++ b/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/VPNService.kt
@@ -75,6 +75,15 @@ class VPNService : android.net.VpnService() {
             return
         }
         Log.init(this)
+        // Route logs from the Rust obfuscator
+        // Levels mirror obfuscators/src/logger.rs: 4=Error, 3=Warn, 2=Info, 1=Debug, 0=Trace
+        Obfuscator.setLogHandler { level, message ->
+            when (level) {
+                4, 3 -> Log.e("Obfuscator", message)
+                2 -> Log.i("Obfuscator", message)
+                else -> Log.v("Obfuscator", message)
+            }
+        }
         // No need to load the library here; WireGuardGo does it statically.
         Log.i(tag, "Initialised Service with Wireguard Version ${WireGuardGo.wgVersion()}")
 
@@ -241,6 +250,7 @@ class VPNService : android.net.VpnService() {
                 serverPort = jServer.getInt("port"),
                 serverPublicKey = jServer.optString("publicKey").ifEmpty { null },
                 publicKey = json.optJSONObject("device")?.optString("publicKey")?.ifEmpty { null },
+                lwoVersion = json.optInt("lwoVersion", 1)
             ) ?: throw Error("Failed to start obfuscator method: $obfuscationMethod")
             Log.i(tag, "Obfuscator '$obfuscationMethod' listening on 127.0.0.1:${r.localPort}")
             r

--- a/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/VPNService.kt
+++ b/android/daemon/src/main/java/org/mozilla/firefox/vpn/daemon/VPNService.kt
@@ -250,7 +250,7 @@ class VPNService : android.net.VpnService() {
                 serverPort = jServer.getInt("port"),
                 serverPublicKey = jServer.optString("publicKey").ifEmpty { null },
                 publicKey = json.optJSONObject("device")?.optString("publicKey")?.ifEmpty { null },
-                lwoVersion = json.optInt("lwoVersion", 1)
+                lwoVersion = json.optInt("lwoVersion", 1),
             ) ?: throw Error("Failed to start obfuscator method: $obfuscationMethod")
             Log.i(tag, "Obfuscator '$obfuscationMethod' listening on 127.0.0.1:${r.localPort}")
             r

--- a/android/obfuscator/src/main/java/org/mozilla/firefox/vpn/obfuscator/Obfuscator.kt
+++ b/android/obfuscator/src/main/java/org/mozilla/firefox/vpn/obfuscator/Obfuscator.kt
@@ -66,6 +66,7 @@ class Obfuscator private constructor(
             "listen_port",
             "server_public_key",
             "public_key",
+            "lwo_version",
         )
         open class Config : Structure() {
             @JvmField var obfuscation_method: Int = 0
@@ -75,6 +76,7 @@ class Obfuscator private constructor(
             @JvmField var listen_port: Short = 0
             @JvmField var server_public_key: String? = null
             @JvmField var public_key: String? = null
+            @JvmField var lwo_version: Int = 1
 
             class ByReference : Config(), Structure.ByReference
         }
@@ -123,6 +125,7 @@ class Obfuscator private constructor(
             serverPort: Int,
             serverPublicKey: String? = null,
             publicKey: String? = null,
+            lwoVersion: Int = 1,
         ): Obfuscator? {
             val cfg = Config.ByReference().apply {
                 this.obfuscation_method = method.value
@@ -131,6 +134,7 @@ class Obfuscator private constructor(
                 this.server_port = serverPort.toShort()
                 this.server_public_key = serverPublicKey
                 this.public_key = publicKey
+                this.lwo_version = lwoVersion
             }
             val handle = LIB.obfuscator_start(cfg) ?: return null
             val localPort = LIB.obfuscator_local_port(handle).toInt() and 0xFFFF

--- a/obfuscators/Cargo.toml
+++ b/obfuscators/Cargo.toml
@@ -20,3 +20,6 @@ once_cell = "1.21.4"
 tokio = { version = "1", features = ["rt", "macros", "time", "net"] }
 udp-over-tcp = { git = "https://github.com/mullvad/udp-over-tcp", rev = "5c6d8f44a5aa12ed9bb4ae51dd17e5e22e5ec303" }
 clap = { version = "=4.5.20", features = ["derive"] }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+nix = { version = "0.31.2", features = ["socket"] }

--- a/obfuscators/src/factory.rs
+++ b/obfuscators/src/factory.rs
@@ -4,7 +4,7 @@
 
 use std::io;
 
-use crate::obfuscator::{Config, Obfuscator, ObfuscationMethod};
+use crate::obfuscator::{Config, ObfuscationMethod, Obfuscator};
 
 use crate::lwo::LwoObfuscator;
 use crate::udp_over_tcp::UdpOverTcpObfuscator;

--- a/obfuscators/src/factory.rs
+++ b/obfuscators/src/factory.rs
@@ -6,12 +6,14 @@ use std::io;
 
 use crate::obfuscator::{Config, Obfuscator, ObfuscationMethod};
 
+use crate::lwo::LwoObfuscator;
 use crate::udp_over_tcp::UdpOverTcpObfuscator;
 
 pub fn create_obfuscator(cfg: &Config) -> io::Result<Box<dyn Obfuscator>> {
     log::info!("Creating obfuscator for config: {cfg:#?}");
     match cfg.method {
         ObfuscationMethod::UdpOverTcp => Ok(Box::new(UdpOverTcpObfuscator::new(cfg)?)),
+        ObfuscationMethod::Lwo => Ok(Box::new(LwoObfuscator::new(cfg)?)),
 
         // No obfuscation should raise an error as the daemon should skip start the obfuscator in this case
         m => Err(io::Error::new(

--- a/obfuscators/src/lib.rs
+++ b/obfuscators/src/lib.rs
@@ -13,9 +13,10 @@ pub mod factory;
 mod logger;
 #[allow(dead_code)]
 mod obfuscator;
+mod lwo;
 mod udp_over_tcp;
 
-pub use obfuscator::{Config, ObfuscationMethod, Obfuscator, ObfuscatorConfig};
+pub use obfuscator::{Config, LwoVersion, ObfuscationMethod, Obfuscator, ObfuscatorConfig};
 
 /// Opaque handle held by the JNA caller.
 /// Owns the runner thread and the shutdown flag dropping it stops the obfuscator.
@@ -51,6 +52,7 @@ pub unsafe extern "C" fn obfuscator_start(
     let local_port = obf.local_port();
     let socket_v4 = obf.socket_v4();
     let socket_v6 = obf.socket_v6();
+
 
     let shutdown = Arc::new(AtomicBool::new(false));
     let shutdown_run = Arc::clone(&shutdown);

--- a/obfuscators/src/lib.rs
+++ b/obfuscators/src/lib.rs
@@ -2,18 +2,18 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use logger::Logger;
 use std::os::raw::c_char;
 use std::ptr;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::thread::{self, JoinHandle};
-use logger::Logger;
 
 pub mod factory;
 mod logger;
+mod lwo;
 #[allow(dead_code)]
 mod obfuscator;
-mod lwo;
 mod udp_over_tcp;
 
 pub use obfuscator::{Config, LwoVersion, ObfuscationMethod, Obfuscator, ObfuscatorConfig};
@@ -38,9 +38,7 @@ impl Drop for ObfuscatorHandle {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn obfuscator_start(
-    cfg: *const ObfuscatorConfig,
-) -> *mut ObfuscatorHandle {
+pub unsafe extern "C" fn obfuscator_start(cfg: *const ObfuscatorConfig) -> *mut ObfuscatorHandle {
     let Some(cfg) = Config::from_c(cfg) else {
         return ptr::null_mut();
     };
@@ -52,7 +50,6 @@ pub unsafe extern "C" fn obfuscator_start(
     let local_port = obf.local_port();
     let socket_v4 = obf.socket_v4();
     let socket_v6 = obf.socket_v6();
-
 
     let shutdown = Arc::new(AtomicBool::new(false));
     let shutdown_run = Arc::clone(&shutdown);
@@ -73,9 +70,7 @@ pub unsafe extern "C" fn obfuscator_start(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn obfuscator_local_port(
-    handle: *const ObfuscatorHandle,
-) -> u16 {
+pub unsafe extern "C" fn obfuscator_local_port(handle: *const ObfuscatorHandle) -> u16 {
     if handle.is_null() {
         return 0;
     }
@@ -83,20 +78,15 @@ pub unsafe extern "C" fn obfuscator_local_port(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn obfuscator_socket_v4(
-    handle: *const ObfuscatorHandle,
-) -> i32 {
+pub unsafe extern "C" fn obfuscator_socket_v4(handle: *const ObfuscatorHandle) -> i32 {
     if handle.is_null() {
         return -1;
     }
     (*handle).socket_v4
 }
 
-
 #[no_mangle]
-pub unsafe extern "C" fn obfuscator_socket_v6(
-    handle: *const ObfuscatorHandle,
-) -> i32 {
+pub unsafe extern "C" fn obfuscator_socket_v6(handle: *const ObfuscatorHandle) -> i32 {
     if handle.is_null() {
         return -1;
     }
@@ -112,6 +102,6 @@ pub unsafe extern "C" fn obfuscator_stop(handle: *mut ObfuscatorHandle) {
 }
 
 #[no_mangle]
-pub extern "C" fn obfuscators_set_log_handler(message_handler: extern "C" fn(i32, *mut c_char)){
+pub extern "C" fn obfuscators_set_log_handler(message_handler: extern "C" fn(i32, *mut c_char)) {
     Logger::init(message_handler);
 }

--- a/obfuscators/src/logger.rs
+++ b/obfuscators/src/logger.rs
@@ -2,8 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use std::os::raw::c_char;
 use std::ffi::CString;
+use std::os::raw::c_char;
 
 use log::{Level, LevelFilter, Log, Metadata, Record};
 use once_cell::sync::OnceCell;
@@ -12,16 +12,14 @@ use once_cell::sync::OnceCell;
 //
 // This message handler should be initialized alogside the Qt message handler.
 pub struct Logger {
-    message_handler: extern "C" fn(i32, *mut c_char)
+    message_handler: extern "C" fn(i32, *mut c_char),
 }
 
 static LOGGER: OnceCell<Logger> = OnceCell::new();
 
 impl Logger {
     fn new(f: extern "C" fn(i32, *mut c_char)) -> Logger {
-        Logger {
-            message_handler: f
-        }
+        Logger { message_handler: f }
     }
 
     pub fn init(f: extern "C" fn(i32, *mut c_char)) {

--- a/obfuscators/src/lwo.rs
+++ b/obfuscators/src/lwo.rs
@@ -1,0 +1,210 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use std::io;
+use std::net::SocketAddr;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use tokio::net::UdpSocket;
+use tokio::runtime::Runtime;
+
+use crate::obfuscator::{Config, LwoVersion, Obfuscator};
+
+mod v1;
+mod v2;
+
+const SHUTDOWN_POLL: Duration = Duration::from_millis(200);
+const MAX_PACKET: usize = 65535;
+
+type WgAddr = Arc<Mutex<Option<SocketAddr>>>;
+
+pub struct LwoObfuscator {
+    runtime: Option<Runtime>,
+    local: Option<Arc<UdpSocket>>,
+    remote: Option<Arc<UdpSocket>>,
+    local_port: u16,
+    socket_v4: i32,
+    socket_v6: i32,
+    version: LwoVersion,
+    server_public_key: [u8; 32],
+    public_key: [u8; 32],
+}
+
+impl LwoObfuscator {
+    pub fn new(cfg: &Config) -> io::Result<Self> {
+        let server = cfg.server_addr();
+        let server_public_key = cfg.server_public_key.ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "LWO requires the WireGuard server public key",
+            )
+        })?;
+        match cfg.lwo_version {
+            LwoVersion::V1 => log::info!("Using LWO v1 obfuscation"),
+            LwoVersion::V2 => log::info!("Using LWO v2 obfuscation"),
+        }
+        // v2 obfuscates in both directions with the server's public key, so the
+        // client's own key is only needed for v1 inbound deobfuscation.
+        let public_key = match cfg.lwo_version {
+            LwoVersion::V1 => cfg.public_key.ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "LWO v1 requires the WireGuard public key",
+                )
+            })?,
+            LwoVersion::V2 => cfg.public_key.unwrap_or([0u8; 32]),
+        };
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()?;
+
+        let listen_port = cfg.listen_port;
+        #[cfg(target_os = "linux")]
+        let fwmark = cfg.fwmark;
+        let (local, remote) = runtime.block_on(async {
+            let local = UdpSocket::bind(("127.0.0.1", listen_port)).await?;
+            let remote = match server {
+                SocketAddr::V4(_) => UdpSocket::bind(("0.0.0.0", 0)).await?,
+                SocketAddr::V6(_) => UdpSocket::bind(("::", 0)).await?,
+            };
+            // Protect the outbound socket so its packets are routed around the
+            // VPN tunnel instead of back into it. Must be set before connect()
+            // so route selection observes the mark.
+            #[cfg(target_os = "linux")]
+            if let Some(fwmark) = fwmark {
+                set_fwmark(&remote, fwmark)?;
+            }
+            remote.connect(server).await?;
+            io::Result::Ok((local, remote))
+        })?;
+
+        let local_port = local.local_addr()?.port();
+        let fd = socket_fd(&remote);
+        let (socket_v4, socket_v6) = match server {
+            SocketAddr::V4(_) => (fd, -1),
+            SocketAddr::V6(_) => (-1, fd),
+        };
+
+        Ok(Self {
+            runtime: Some(runtime),
+            local: Some(Arc::new(local)),
+            remote: Some(Arc::new(remote)),
+            local_port,
+            socket_v4,
+            socket_v6,
+            version: cfg.lwo_version,
+            server_public_key,
+            public_key,
+        })
+    }
+}
+
+impl Obfuscator for LwoObfuscator {
+    fn local_port(&self) -> u16 {
+        self.local_port
+    }
+    fn socket_v4(&self) -> i32 {
+        self.socket_v4
+    }
+    fn socket_v6(&self) -> i32 {
+        self.socket_v6
+    }
+
+    fn run(&mut self, shutdown: Arc<AtomicBool>) {
+        let Some(runtime) = self.runtime.take() else {
+            return;
+        };
+        let Some(local) = self.local.take() else {
+            return;
+        };
+        let Some(remote) = self.remote.take() else {
+            return;
+        };
+
+        let server_public_key = self.server_public_key;
+        let public_key = self.public_key;
+        let version = self.version;
+
+        runtime.block_on(async move {
+            let wg_addr: WgAddr = Arc::new(Mutex::new(None));
+
+            let (outbound, inbound) = match version {
+                LwoVersion::V1 => (
+                    tokio::spawn(v1::outbound(
+                        Arc::clone(&local),
+                        Arc::clone(&remote),
+                        Arc::clone(&wg_addr),
+                        server_public_key,
+                    )),
+                    tokio::spawn(v1::inbound(
+                        Arc::clone(&local),
+                        Arc::clone(&remote),
+                        Arc::clone(&wg_addr),
+                        public_key,
+                    )),
+                ),
+                LwoVersion::V2 => (
+                    tokio::spawn(v2::outbound(
+                        Arc::clone(&local),
+                        Arc::clone(&remote),
+                        Arc::clone(&wg_addr),
+                        server_public_key,
+                    )),
+                    tokio::spawn(v2::inbound(
+                        Arc::clone(&local),
+                        Arc::clone(&remote),
+                        Arc::clone(&wg_addr),
+                        server_public_key,
+                    )),
+                ),
+            };
+
+            let mut ticker = tokio::time::interval(SHUTDOWN_POLL);
+            loop {
+                ticker.tick().await;
+                if shutdown.load(Ordering::Acquire) {
+                    break;
+                }
+            }
+            outbound.abort();
+            inbound.abort();
+            let _ = outbound.await;
+            let _ = inbound.await;
+        });
+    }
+}
+
+#[cfg(unix)]
+fn socket_fd(s: &UdpSocket) -> i32 {
+    use std::os::unix::io::AsRawFd;
+    s.as_raw_fd()
+}
+
+#[cfg(not(unix))]
+fn socket_fd(_s: &UdpSocket) -> i32 {
+    -1
+}
+
+/// Set SO_MARK on the outbound socket so the platform's routing policy keeps
+/// its traffic out of the VPN tunnel (avoiding a routing loop)
+#[cfg(target_os = "linux")]
+fn set_fwmark(socket: &UdpSocket, fwmark: u32) -> io::Result<()> {
+    use nix::sys::socket::{setsockopt, sockopt};
+    setsockopt(socket, sockopt::Mark, &fwmark)
+        .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("failed to set SO_MARK: {e}")))
+}
+
+// WG message types, copied from gotatun
+type MessageType = u8;
+const HANDSHAKE_INIT: MessageType = 1;
+const HANDSHAKE_RESP: MessageType = 2;
+const COOKIE_REPLY: MessageType = 3;
+const DATA: MessageType = 4;
+
+const HANDSHAKE_INIT_SZ: usize = 148;
+const HANDSHAKE_RESP_SZ: usize = 92;
+const COOKIE_REPLY_SZ: usize = 64;
+const DATA_OVERHEAD_SZ: usize = 32;

--- a/obfuscators/src/lwo/v1.rs
+++ b/obfuscators/src/lwo/v1.rs
@@ -1,0 +1,199 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+//! LWO v1 packet transformation.
+
+use std::sync::Arc;
+
+use rand::rngs::OsRng;
+use rand::RngCore;
+use tokio::net::UdpSocket;
+
+use super::{
+    WgAddr, COOKIE_REPLY, COOKIE_REPLY_SZ, DATA, DATA_OVERHEAD_SZ, HANDSHAKE_INIT,
+    HANDSHAKE_INIT_SZ, HANDSHAKE_RESP, HANDSHAKE_RESP_SZ, MAX_PACKET,
+};
+
+/// Bit to set in the second byte of the WG header to enable LWO
+const OBFUSCATION_BIT: u8 = 0b10000000;
+
+pub async fn outbound(local: Arc<UdpSocket>, remote: Arc<UdpSocket>, wg_addr: WgAddr, key: [u8; 32]) {
+    let mut buf = vec![0u8; MAX_PACKET];
+    let mut rng = OsRng;
+    loop {
+        let Ok((n, src)) = local.recv_from(&mut buf).await else {
+            break;
+        };
+        *wg_addr.lock().unwrap() = Some(src);
+        obfuscate(&mut rng, &mut buf[..n], &key);
+        let _ = remote.send(&buf[..n]).await;
+    }
+}
+
+pub async fn inbound(local: Arc<UdpSocket>, remote: Arc<UdpSocket>, wg_addr: WgAddr, key: [u8; 32]) {
+    let mut buf = vec![0u8; MAX_PACKET];
+    loop {
+        let Ok(n) = remote.recv(&mut buf).await else {
+            break;
+        };
+        let Some(addr) = *wg_addr.lock().unwrap() else {
+            continue;
+        };
+        deobfuscate(&mut buf[..n], &key);
+        let _ = local.send_to(&buf[..n], addr).await;
+    }
+}
+
+pub fn obfuscate(rng: &mut impl RngCore, packet: &mut [u8], key: &[u8; 32]) {
+    log::error!("Obfuscating packet of size {}", packet.len());
+
+    let Some(header) = resolve_packet_header(packet, 0) else {
+        return;
+    };
+
+    // Encrypt the header region with a repeating 32-byte key
+    apply_cyclic_xor(header, key);
+
+    // Generate 7 random bits and set the MSB to mark the packet
+    header[1] = (rng.next_u32() as u8 & 0x7F) | OBFUSCATION_BIT;
+}
+
+
+pub fn deobfuscate(packet: &mut [u8], key: &[u8; 32]) {
+    log::info!("Deobfuscating packet of size {}", packet.len());
+
+    let Some(header) = resolve_packet_header(packet, key[0]) else {
+        return;
+    };
+
+    #[cfg(debug_assertions)]
+    if !has_obfuscation_flag(header[1]) {
+        log::error!("Received non-obfuscated packet from relay");
+        return;
+    }
+
+    // XOR is symmetric, so the same operation reverses the encryption
+    apply_cyclic_xor(header, key);
+    header[1] = 0;
+}
+
+#[cfg(debug_assertions)]
+const fn has_obfuscation_flag(byte: u8) -> bool {
+    byte & OBFUSCATION_BIT != 0
+}
+
+/// Resolves the correct header slice by decoding the message type via XOR
+fn resolve_packet_header<'a>(pkt: &'a mut [u8], seed: u8) -> Option<&'a mut [u8]> {
+    let raw_type = *pkt.first()?;
+    let decoded_type = raw_type ^ seed;
+
+    let expected_len = match decoded_type {
+        HANDSHAKE_INIT => HANDSHAKE_INIT_SZ,
+        HANDSHAKE_RESP => HANDSHAKE_RESP_SZ,
+        COOKIE_REPLY => COOKIE_REPLY_SZ,
+        DATA => DATA_OVERHEAD_SZ,
+        _ => return None,
+    };
+
+    pkt.get_mut(..expected_len)
+}
+
+
+fn apply_cyclic_xor(buf: &mut [u8], key: &[u8; 32]) {
+    for (b, k) in buf.iter_mut().zip(key.iter().cycle()) {
+        *b ^= *k;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::rngs::OsRng;
+
+    fn key() -> [u8; 32] {
+        let mut k = [0u8; 32];
+        for (i, b) in k.iter_mut().enumerate() {
+            *b = (i as u8).wrapping_mul(7).wrapping_add(3);
+        }
+        k
+    }
+
+    /// Build a WireGuard-looking packet: `type` in byte 0, reserved byte 1 = 0
+    /// (as WireGuard sends it), and deterministic filler afterwards.
+    fn packet(msg_type: u8, len: usize) -> Vec<u8> {
+        let mut p = vec![0u8; len];
+        p[0] = msg_type;
+        for (i, b) in p.iter_mut().enumerate().skip(2) {
+            *b = (i as u8) ^ 0x5a;
+        }
+        p
+    }
+
+    /// A v1 handshake initiation round-trips: obfuscate scrambles the header and
+    /// sets the marker bit; deobfuscate restores the original bytes.
+    #[test]
+    fn v1_handshake_roundtrip() {
+        let key = key();
+        let original = packet(HANDSHAKE_INIT, HANDSHAKE_INIT_SZ);
+        let mut buf = original.clone();
+
+        obfuscate(&mut OsRng, &mut buf, &key);
+        assert_ne!(&buf[..HANDSHAKE_INIT_SZ], &original[..], "header obfuscated");
+        assert_ne!(buf[1] & OBFUSCATION_BIT, 0, "marker bit set");
+
+        deobfuscate(&mut buf, &key);
+        assert_eq!(buf, original, "header restored");
+    }
+
+    /// A v1 data packet round-trips, and the payload past the obfuscated header
+    /// is left untouched in both directions.
+    #[test]
+    fn v1_data_roundtrip() {
+        let key = key();
+        let original = packet(DATA, 128);
+        let mut buf = original.clone();
+
+        obfuscate(&mut OsRng, &mut buf, &key);
+        assert_ne!(&buf[..DATA_OVERHEAD_SZ], &original[..DATA_OVERHEAD_SZ]);
+        assert_eq!(
+            &buf[DATA_OVERHEAD_SZ..],
+            &original[DATA_OVERHEAD_SZ..],
+            "payload past the header is untouched"
+        );
+
+        deobfuscate(&mut buf, &key);
+        assert_eq!(buf, original);
+    }
+
+    /// Packets whose type is not a known WireGuard message are left untouched.
+    #[test]
+    fn v1_unknown_type_untouched() {
+        let key = key();
+        let original = packet(0x77, 148);
+        let mut buf = original.clone();
+
+        obfuscate(&mut OsRng, &mut buf, &key);
+        assert_eq!(buf, original, "unknown type not obfuscated");
+    }
+
+    /// `header_mut` selects the header length from the (unmasked) message type.
+    #[test]
+    fn resolve_packet_header_sizes() {
+        let sizes = [
+            (HANDSHAKE_INIT, HANDSHAKE_INIT_SZ),
+            (HANDSHAKE_RESP, HANDSHAKE_RESP_SZ),
+            (COOKIE_REPLY, COOKIE_REPLY_SZ),
+            (DATA, DATA_OVERHEAD_SZ),
+        ];
+        for (ty, sz) in sizes {
+            let mut buf = vec![0u8; 256];
+            buf[0] = ty;
+            assert_eq!(resolve_packet_header(&mut buf, 0).map(|h| h.len()), Some(sz));
+        }
+
+        let mut buf = vec![0u8; 256];
+        buf[0] = 0x77;
+        assert!(resolve_packet_header(&mut buf, 0).is_none(), "unknown type");
+    }
+}

--- a/obfuscators/src/lwo/v1.rs
+++ b/obfuscators/src/lwo/v1.rs
@@ -18,7 +18,12 @@ use super::{
 /// Bit to set in the second byte of the WG header to enable LWO
 const OBFUSCATION_BIT: u8 = 0b10000000;
 
-pub async fn outbound(local: Arc<UdpSocket>, remote: Arc<UdpSocket>, wg_addr: WgAddr, key: [u8; 32]) {
+pub async fn outbound(
+    local: Arc<UdpSocket>,
+    remote: Arc<UdpSocket>,
+    wg_addr: WgAddr,
+    key: [u8; 32],
+) {
     let mut buf = vec![0u8; MAX_PACKET];
     let mut rng = OsRng;
     loop {
@@ -31,7 +36,12 @@ pub async fn outbound(local: Arc<UdpSocket>, remote: Arc<UdpSocket>, wg_addr: Wg
     }
 }
 
-pub async fn inbound(local: Arc<UdpSocket>, remote: Arc<UdpSocket>, wg_addr: WgAddr, key: [u8; 32]) {
+pub async fn inbound(
+    local: Arc<UdpSocket>,
+    remote: Arc<UdpSocket>,
+    wg_addr: WgAddr,
+    key: [u8; 32],
+) {
     let mut buf = vec![0u8; MAX_PACKET];
     loop {
         let Ok(n) = remote.recv(&mut buf).await else {
@@ -58,7 +68,6 @@ pub fn obfuscate(rng: &mut impl RngCore, packet: &mut [u8], key: &[u8; 32]) {
     // Generate 7 random bits and set the MSB to mark the packet
     header[1] = (rng.next_u32() as u8 & 0x7F) | OBFUSCATION_BIT;
 }
-
 
 pub fn deobfuscate(packet: &mut [u8], key: &[u8; 32]) {
     log::info!("Deobfuscating packet of size {}", packet.len());
@@ -99,7 +108,6 @@ fn resolve_packet_header<'a>(pkt: &'a mut [u8], seed: u8) -> Option<&'a mut [u8]
     pkt.get_mut(..expected_len)
 }
 
-
 fn apply_cyclic_xor(buf: &mut [u8], key: &[u8; 32]) {
     for (b, k) in buf.iter_mut().zip(key.iter().cycle()) {
         *b ^= *k;
@@ -139,7 +147,11 @@ mod tests {
         let mut buf = original.clone();
 
         obfuscate(&mut OsRng, &mut buf, &key);
-        assert_ne!(&buf[..HANDSHAKE_INIT_SZ], &original[..], "header obfuscated");
+        assert_ne!(
+            &buf[..HANDSHAKE_INIT_SZ],
+            &original[..],
+            "header obfuscated"
+        );
         assert_ne!(buf[1] & OBFUSCATION_BIT, 0, "marker bit set");
 
         deobfuscate(&mut buf, &key);
@@ -189,7 +201,10 @@ mod tests {
         for (ty, sz) in sizes {
             let mut buf = vec![0u8; 256];
             buf[0] = ty;
-            assert_eq!(resolve_packet_header(&mut buf, 0).map(|h| h.len()), Some(sz));
+            assert_eq!(
+                resolve_packet_header(&mut buf, 0).map(|h| h.len()),
+                Some(sz)
+            );
         }
 
         let mut buf = vec![0u8; 256];

--- a/obfuscators/src/lwo/v1.rs
+++ b/obfuscators/src/lwo/v1.rs
@@ -56,8 +56,6 @@ pub async fn inbound(
 }
 
 pub fn obfuscate(rng: &mut impl RngCore, packet: &mut [u8], key: &[u8; 32]) {
-    log::error!("Obfuscating packet of size {}", packet.len());
-
     let Some(header) = resolve_packet_header(packet, 0) else {
         return;
     };
@@ -70,8 +68,6 @@ pub fn obfuscate(rng: &mut impl RngCore, packet: &mut [u8], key: &[u8; 32]) {
 }
 
 pub fn deobfuscate(packet: &mut [u8], key: &[u8; 32]) {
-    log::info!("Deobfuscating packet of size {}", packet.len());
-
     let Some(header) = resolve_packet_header(packet, key[0]) else {
         return;
     };

--- a/obfuscators/src/lwo/v2.rs
+++ b/obfuscators/src/lwo/v2.rs
@@ -1,0 +1,264 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+
+/// The LWO v2 spec also jitters selected WireGuard timers
+/// (keepalive, rekey, retransmit). That is intentionally not done
+/// here: this obfuscator is a userspace UDP proxy and does not drive
+/// the WireGuard state machine, so it cannot adjust those timers.
+/// Only the packet obfuscation is applied.
+
+use std::sync::Arc;
+
+use rand::rngs::OsRng;
+use rand::RngCore;
+use tokio::net::UdpSocket;
+
+use super::{
+    MessageType, WgAddr, DATA, HANDSHAKE_INIT, HANDSHAKE_INIT_SZ, HANDSHAKE_RESP, HANDSHAKE_RESP_SZ,
+    MAX_PACKET,
+};
+
+pub async fn outbound(local: Arc<UdpSocket>, remote: Arc<UdpSocket>, wg_addr: WgAddr, key: [u8; 32]) {
+    let mut buf = vec![0u8; MAX_PACKET];
+    let mut rng = OsRng;
+    loop {
+        let Ok((n, src)) = local.recv_from(&mut buf).await else {
+            break;
+        };
+        *wg_addr.lock().unwrap() = Some(src);
+        let send_len = obfuscate(&mut rng, &mut buf, n, &key);
+        let _ = remote.send(&buf[..send_len]).await;
+    }
+}
+
+pub async fn inbound(local: Arc<UdpSocket>, remote: Arc<UdpSocket>, wg_addr: WgAddr, key: [u8; 32]) {
+    let mut buf = vec![0u8; MAX_PACKET];
+    loop {
+        let Ok(n) = remote.recv(&mut buf).await else {
+            break;
+        };
+        let Some(addr) = *wg_addr.lock().unwrap() else {
+            continue;
+        };
+        if let Some(len) = deobfuscate(&mut buf, n, &key) {
+            let _ = local.send_to(&buf[..len], addr).await;
+        }
+    }
+}
+
+/// Leading bytes obfuscated for a data packet in v2 (v1 obfuscates 32)
+const DATA_PROTECTED_SZ_V2: usize = 16;
+/// A v2 data packet is valid only when its UDP payload is at least this long
+const DATA_MIN_SZ_V2: usize = 32;
+/// Maximum random padding appended to a v2 handshake (range is 1..256)
+const MAX_HANDSHAKE_PADDING: u32 = 256;
+/// Marker bits (byte 1): bit 7 = 0, bit 6 = 1
+const V2_MARKER_MASK: u8 = 0xc0;
+const V2_MARKER: u8 = 0x40;
+
+/// Length of the leading area LWO v2 obfuscates for each WireGuard message
+/// type. Returns `None` for types not covered by v2 (cookie reply, unknown)
+fn protected_area(msg_type: MessageType) -> Option<usize> {
+    match msg_type {
+        HANDSHAKE_INIT => Some(HANDSHAKE_INIT_SZ),
+        HANDSHAKE_RESP => Some(HANDSHAKE_RESP_SZ),
+        DATA => Some(DATA_PROTECTED_SZ_V2),
+        _ => None,
+    }
+}
+
+/// Whether the on-wire length is valid for a recovered v2 message type
+fn valid_len(msg_type: MessageType, n: usize) -> bool {
+    let pad = MAX_HANDSHAKE_PADDING as usize;
+    match msg_type {
+        HANDSHAKE_INIT => (HANDSHAKE_INIT_SZ..=HANDSHAKE_INIT_SZ + pad).contains(&n),
+        HANDSHAKE_RESP => (HANDSHAKE_RESP_SZ..=HANDSHAKE_RESP_SZ + pad).contains(&n),
+        DATA => n >= DATA_MIN_SZ_V2,
+        _ => false,
+    }
+}
+
+/// Obfuscate a plaintext WireGuard packet in place for LWO v2.
+///
+/// `buf` holds the packet in `buf[..n]` and must have spare capacity for
+/// appended handshake padding. Returns the number of bytes to send, which may
+/// exceed `n` for padded handshakes. Cookie replies and packets that are not
+/// recognized WireGuard messages are left untouched (returned length `n`)
+pub fn obfuscate(rng: &mut impl RngCore, buf: &mut [u8], n: usize, key: &[u8; 32]) -> usize {
+    if n == 0 {
+        return 0;
+    }
+    let msg_type = buf[0];
+    let Some(protected) = protected_area(msg_type) else {
+        // Cookie replies and anything unrecognized  must be sent unchanged
+        return n;
+    };
+    if n < protected {
+        return n;
+    }
+
+    // Handshake initiations and responses get 1..256 random padding bytes
+    // appended before obfuscation. The padding itself is not obfuscated, but
+    // the padded length is used by length mix
+    let padded_len = match msg_type {
+        HANDSHAKE_INIT | HANDSHAKE_RESP => {
+            let pad = 1 + (rng.next_u32() % MAX_HANDSHAKE_PADDING) as usize;
+            let new_len = n + pad;
+            if new_len <= buf.len() {
+                rng.fill_bytes(&mut buf[n..new_len]);
+                new_len
+            } else {
+                n
+            }
+        }
+        _ => n,
+    };
+
+    let len_mix = padded_len as u8;
+    apply_len_mixed_xor(&mut buf[..protected], len_mix, key);
+    buf[1] = (key[0].wrapping_add(len_mix) & 0x3f) | V2_MARKER;
+
+    padded_len
+}
+
+pub fn deobfuscate(buf: &mut [u8], n: usize, key: &[u8; 32]) -> Option<usize> {
+    // A packet is LWO v2 only when the marker bits in byte 1 are set
+    if n < 2 || buf[1] & V2_MARKER_MASK != V2_MARKER {
+        return Some(n);
+    }
+    // is LWO v2 but is too short, drop it
+    if n < 4 {
+        return None;
+    }
+
+    let len_mix = n as u8;
+
+    // Validate bytes 1, 2 and 3 against their expected obfuscated values
+    let expect1 = (key[0].wrapping_add(len_mix) & 0x3f) | V2_MARKER;
+    let expect2 = key[2].wrapping_add(len_mix).wrapping_add(2);
+    let expect3 = key[3].wrapping_add(len_mix).wrapping_add(3);
+    if buf[1] != expect1 || buf[2] != expect2 || buf[3] != expect3 {
+        return None;
+    }
+
+    // Recover the WireGuard message type. Unknown types and cookie replies
+    // (type 3, excluded from LWO v2) are dropped
+    let msg_type = buf[0] ^ key[0].wrapping_add(len_mix);
+    let protected = protected_area(msg_type)?;
+    if !valid_len(msg_type, n) {
+        return None;
+    }
+
+    // Same XOR pass as obfuscation restores the header, then byte 1 is cleared
+    apply_len_mixed_xor(&mut buf[..protected], len_mix, key);
+    buf[1] = 0x00;
+
+    // Non-data packets carry padding past the protected area; trim it before
+    // handing the packet to WireGuard. Data packets keep their full length
+    if msg_type != DATA && n > protected {
+        Some(protected)
+    } else {
+        Some(n)
+    }
+}
+
+fn apply_len_mixed_xor(buf: &mut [u8], len_mix: u8, key: &[u8; 32]) {
+    for (i, b) in buf.iter_mut().enumerate() {
+        *b ^= key[i % 32].wrapping_add(len_mix).wrapping_add(i as u8);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lwo::{COOKIE_REPLY, COOKIE_REPLY_SZ, MAX_PACKET};
+    use rand::rngs::OsRng;
+
+    fn key() -> [u8; 32] {
+        let mut k = [0u8; 32];
+        for (i, b) in k.iter_mut().enumerate() {
+            *b = (i as u8).wrapping_mul(7).wrapping_add(3);
+        }
+        k
+    }
+
+    /// A v2 handshake initiation round-trips: obfuscate pads + marks it, and
+    /// deobfuscate validates, restores the header and trims the padding
+    #[test]
+    fn handshake_roundtrip() {
+        let key = key();
+        let mut original = vec![0u8; HANDSHAKE_INIT_SZ];
+        original[0] = HANDSHAKE_INIT;
+        for (i, b) in original.iter_mut().enumerate().skip(4) {
+            *b = (i as u8) ^ 0xa5;
+        }
+
+        let mut buf = vec![0u8; MAX_PACKET];
+        buf[..HANDSHAKE_INIT_SZ].copy_from_slice(&original);
+
+        let sent = obfuscate(&mut OsRng, &mut buf, HANDSHAKE_INIT_SZ, &key);
+        // Padding was appended and the marker set.
+        assert!(sent > HANDSHAKE_INIT_SZ && sent <= HANDSHAKE_INIT_SZ + 256);
+        assert_eq!(buf[1] & V2_MARKER_MASK, V2_MARKER);
+
+        let out = deobfuscate(&mut buf, sent, &key).expect("must forward");
+        assert_eq!(out, HANDSHAKE_INIT_SZ, "padding trimmed");
+        assert_eq!(&buf[..HANDSHAKE_INIT_SZ], &original[..]);
+    }
+
+    /// A v2 data packet round-trips without padding or trimming
+    #[test]
+    fn data_roundtrip() {
+        let key = key();
+        let len = 128;
+        let mut original = vec![0u8; len];
+        original[0] = DATA;
+        for (i, b) in original.iter_mut().enumerate().skip(4) {
+            *b = (i as u8).wrapping_mul(3);
+        }
+
+        let mut buf = vec![0u8; MAX_PACKET];
+        buf[..len].copy_from_slice(&original);
+
+        let sent = obfuscate(&mut OsRng, &mut buf, len, &key);
+        assert_eq!(sent, len, "data packets are not padded");
+        assert_eq!(buf[1] & V2_MARKER_MASK, V2_MARKER);
+        assert_ne!(&buf[..DATA_PROTECTED_SZ_V2], &original[..DATA_PROTECTED_SZ_V2]);
+
+        let out = deobfuscate(&mut buf, sent, &key).expect("must forward");
+        assert_eq!(out, len);
+        assert_eq!(&buf[..len], &original[..]);
+    }
+
+    /// Cookie replies are not LWO v2 packets: never obfuscated on send, and
+    /// passed through unchanged on receive
+    #[test]
+    fn cookie_reply_passthrough() {
+        let key = key();
+        let mut buf = vec![0u8; MAX_PACKET];
+        buf[0] = COOKIE_REPLY;
+        let before = buf[..COOKIE_REPLY_SZ].to_vec();
+
+        let sent = obfuscate(&mut OsRng, &mut buf, COOKIE_REPLY_SZ, &key);
+        assert_eq!(sent, COOKIE_REPLY_SZ);
+        assert_eq!(&buf[..COOKIE_REPLY_SZ], &before[..], "cookie reply untouched");
+
+        // A plain packet whose byte 1 lacks the marker passes through on receive.
+        let out = deobfuscate(&mut buf, COOKIE_REPLY_SZ, &key).expect("pass through");
+        assert_eq!(out, COOKIE_REPLY_SZ);
+    }
+
+    /// A packet that claims LWO v2 but fails byte 1/2/3 validation is dropped
+    #[test]
+    fn invalid_marker_dropped() {
+        let key = key();
+        let mut buf = vec![0u8; 200];
+        buf[0] = 0x11;
+        buf[1] = V2_MARKER; // claims v2 but bytes 2/3 won't validate
+        buf[2] = 0x00;
+        buf[3] = 0x00;
+        assert_eq!(deobfuscate(&mut buf, 200, &key), None);
+    }
+}

--- a/obfuscators/src/lwo/v2.rs
+++ b/obfuscators/src/lwo/v2.rs
@@ -2,13 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-
 /// The LWO v2 spec also jitters selected WireGuard timers
 /// (keepalive, rekey, retransmit). That is intentionally not done
 /// here: this obfuscator is a userspace UDP proxy and does not drive
 /// the WireGuard state machine, so it cannot adjust those timers.
 /// Only the packet obfuscation is applied.
-
 use std::sync::Arc;
 
 use rand::rngs::OsRng;
@@ -16,11 +14,16 @@ use rand::RngCore;
 use tokio::net::UdpSocket;
 
 use super::{
-    MessageType, WgAddr, DATA, HANDSHAKE_INIT, HANDSHAKE_INIT_SZ, HANDSHAKE_RESP, HANDSHAKE_RESP_SZ,
-    MAX_PACKET,
+    MessageType, WgAddr, DATA, HANDSHAKE_INIT, HANDSHAKE_INIT_SZ, HANDSHAKE_RESP,
+    HANDSHAKE_RESP_SZ, MAX_PACKET,
 };
 
-pub async fn outbound(local: Arc<UdpSocket>, remote: Arc<UdpSocket>, wg_addr: WgAddr, key: [u8; 32]) {
+pub async fn outbound(
+    local: Arc<UdpSocket>,
+    remote: Arc<UdpSocket>,
+    wg_addr: WgAddr,
+    key: [u8; 32],
+) {
     let mut buf = vec![0u8; MAX_PACKET];
     let mut rng = OsRng;
     loop {
@@ -33,7 +36,12 @@ pub async fn outbound(local: Arc<UdpSocket>, remote: Arc<UdpSocket>, wg_addr: Wg
     }
 }
 
-pub async fn inbound(local: Arc<UdpSocket>, remote: Arc<UdpSocket>, wg_addr: WgAddr, key: [u8; 32]) {
+pub async fn inbound(
+    local: Arc<UdpSocket>,
+    remote: Arc<UdpSocket>,
+    wg_addr: WgAddr,
+    key: [u8; 32],
+) {
     let mut buf = vec![0u8; MAX_PACKET];
     loop {
         let Ok(n) = remote.recv(&mut buf).await else {
@@ -225,7 +233,10 @@ mod tests {
         let sent = obfuscate(&mut OsRng, &mut buf, len, &key);
         assert_eq!(sent, len, "data packets are not padded");
         assert_eq!(buf[1] & V2_MARKER_MASK, V2_MARKER);
-        assert_ne!(&buf[..DATA_PROTECTED_SZ_V2], &original[..DATA_PROTECTED_SZ_V2]);
+        assert_ne!(
+            &buf[..DATA_PROTECTED_SZ_V2],
+            &original[..DATA_PROTECTED_SZ_V2]
+        );
 
         let out = deobfuscate(&mut buf, sent, &key).expect("must forward");
         assert_eq!(out, len);
@@ -243,7 +254,11 @@ mod tests {
 
         let sent = obfuscate(&mut OsRng, &mut buf, COOKIE_REPLY_SZ, &key);
         assert_eq!(sent, COOKIE_REPLY_SZ);
-        assert_eq!(&buf[..COOKIE_REPLY_SZ], &before[..], "cookie reply untouched");
+        assert_eq!(
+            &buf[..COOKIE_REPLY_SZ],
+            &before[..],
+            "cookie reply untouched"
+        );
 
         // A plain packet whose byte 1 lacks the marker passes through on receive.
         let out = deobfuscate(&mut buf, COOKIE_REPLY_SZ, &key).expect("pass through");

--- a/obfuscators/src/main.rs
+++ b/obfuscators/src/main.rs
@@ -9,7 +9,7 @@ use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
 use base64::Engine;
-use clap::{Parser, Subcommand, ValueEnum};
+use clap::{Args, Parser, Subcommand, ValueEnum};
 
 use obfuscators::factory::create_obfuscator;
 use obfuscators::{Config, LwoVersion, ObfuscationMethod};
@@ -21,38 +21,36 @@ use obfuscators::{Config, LwoVersion, ObfuscationMethod};
     version
 )]
 struct Cli {
+    #[command(flatten)]
+    common: CommonArgs,
     #[command(subcommand)]
     obfuscator: Obfuscator,
+}
+
+/// Common arguments specified before the obfuscator name,
+#[derive(Args)]
+struct CommonArgs {
+    /// Server IPv4 or IPv6 address.
+    #[arg(short, long)]
+    server: IpAddr,
+    /// Server port.
+    #[arg(short, long, value_parser = parse_nonzero_port)]
+    port: u16,
+    /// Local UDP port to listen on (127.0.0.1). Defaults to OS-assigned.
+    #[arg(short, long, value_parser = parse_nonzero_port)]
+    listen_port: Option<u16>,
+    /// Fwmark applied to the obfuscator's outbound socket (Linux only).
+    #[cfg(target_os = "linux")]
+    #[arg(long)]
+    fwmark: Option<u32>,
 }
 
 #[derive(Subcommand)]
 enum Obfuscator {
     /// Tunnel WireGuard UDP through a TCP stream.
-    UdpOverTcp {
-        /// Server IPv4 or IPv6 address.
-        #[arg(short, long)]
-        server: IpAddr,
-        /// Server TCP port.
-        #[arg(short, long, value_parser = parse_nonzero_port)]
-        port: u16,
-        /// Local UDP port to listen on (127.0.0.1). Defaults to OS-assigned.
-        #[arg(short, long, value_parser = parse_nonzero_port)]
-        listen_port: Option<u16>,
-        /// Fwmark
-        #[arg(long)]
-        fwmark: Option<u32>,
-    },
+    UdpOverTcp,
     /// Obfuscate WireGuard UDP with Lightweight Obfuscation (LWO).
     Lwo {
-        /// Server IPv4 or IPv6 address.
-        #[arg(short, long)]
-        server: IpAddr,
-        /// Server UDP port.
-        #[arg(short, long, value_parser = parse_nonzero_port)]
-        port: u16,
-        /// Local UDP port to listen on (127.0.0.1). Defaults to OS-assigned.
-        #[arg(short, long, value_parser = parse_nonzero_port)]
-        listen_port: Option<u16>,
         /// Server WireGuard public key (base64). Required by LWO.
         #[arg(long, value_parser = parse_wg_key)]
         server_public_key: [u8; 32],
@@ -62,9 +60,6 @@ enum Obfuscator {
         /// LWO protocol version.
         #[arg(long, value_enum, default_value_t = LwoVersionArg::V1)]
         lwo_version: LwoVersionArg,
-        /// Fwmark
-        #[arg(long)]
-        fwmark: Option<u32>,
     },
 }
 
@@ -105,54 +100,47 @@ fn main() -> ExitCode {
     let cli = Cli::parse();
     obfuscators::obfuscators_set_log_handler(log_to_stderr);
 
+    let CommonArgs {
+        server,
+        port,
+        listen_port,
+        #[cfg(target_os = "linux")]
+        fwmark,
+    } = cli.common;
+    let (server_ipv4, server_ipv6) = match server {
+        IpAddr::V4(v4) => (Some(v4), None),
+        IpAddr::V6(v6) => (None, Some(v6)),
+    };
+
     let cfg = match cli.obfuscator {
-        Obfuscator::UdpOverTcp {
-            server,
-            port,
-            listen_port,
+        Obfuscator::UdpOverTcp => Config {
+            method: ObfuscationMethod::UdpOverTcp,
+            public_key: None,
+            server_ipv4,
+            server_ipv6,
+            server_port: port,
+            listen_port: listen_port.unwrap_or(0),
+            server_public_key: None,
+            lwo_version: LwoVersion::V1,
+            #[cfg(target_os = "linux")]
             fwmark,
-        } => {
-            let (server_ipv4, server_ipv6) = match server {
-                IpAddr::V4(v4) => (Some(v4), None),
-                IpAddr::V6(v6) => (None, Some(v6)),
-            };
-            Config {
-                method: ObfuscationMethod::UdpOverTcp,
-                public_key: None,
-                server_ipv4,
-                server_ipv6,
-                server_port: port,
-                listen_port: listen_port.unwrap_or(0),
-                server_public_key: None,
-                lwo_version: LwoVersion::V1,
-                fwmark,
-            }
-        }
+        },
         Obfuscator::Lwo {
-            server,
-            port,
-            listen_port,
             server_public_key,
             public_key,
             lwo_version,
+        } => Config {
+            method: ObfuscationMethod::Lwo,
+            public_key,
+            server_ipv4,
+            server_ipv6,
+            server_port: port,
+            listen_port: listen_port.unwrap_or(0),
+            server_public_key: Some(server_public_key),
+            lwo_version: lwo_version.into(),
+            #[cfg(target_os = "linux")]
             fwmark,
-        } => {
-            let (server_ipv4, server_ipv6) = match server {
-                IpAddr::V4(v4) => (Some(v4), None),
-                IpAddr::V6(v6) => (None, Some(v6)),
-            };
-            Config {
-                method: ObfuscationMethod::Lwo,
-                public_key,
-                server_ipv4,
-                server_ipv6,
-                server_port: port,
-                listen_port: listen_port.unwrap_or(0),
-                server_public_key: Some(server_public_key),
-                lwo_version: lwo_version.into(),
-                fwmark,
-            }
-        }
+        },
     };
 
     let mut obf = match create_obfuscator(&cfg) {

--- a/obfuscators/src/main.rs
+++ b/obfuscators/src/main.rs
@@ -106,7 +106,12 @@ fn main() -> ExitCode {
     obfuscators::obfuscators_set_log_handler(log_to_stderr);
 
     let cfg = match cli.obfuscator {
-        Obfuscator::UdpOverTcp { server, port, listen_port, fwmark } => {
+        Obfuscator::UdpOverTcp {
+            server,
+            port,
+            listen_port,
+            fwmark,
+        } => {
             let (server_ipv4, server_ipv6) = match server {
                 IpAddr::V4(v4) => (Some(v4), None),
                 IpAddr::V6(v6) => (None, Some(v6)),

--- a/obfuscators/src/main.rs
+++ b/obfuscators/src/main.rs
@@ -8,10 +8,11 @@ use std::process::ExitCode;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
-use clap::{Parser, Subcommand};
+use base64::Engine;
+use clap::{Parser, Subcommand, ValueEnum};
 
 use obfuscators::factory::create_obfuscator;
-use obfuscators::{Config, ObfuscationMethod};
+use obfuscators::{Config, LwoVersion, ObfuscationMethod};
 
 #[derive(Parser)]
 #[command(
@@ -41,6 +42,46 @@ enum Obfuscator {
         #[arg(long)]
         fwmark: Option<u32>,
     },
+    /// Obfuscate WireGuard UDP with Lightweight Obfuscation (LWO).
+    Lwo {
+        /// Server IPv4 or IPv6 address.
+        #[arg(short, long)]
+        server: IpAddr,
+        /// Server UDP port.
+        #[arg(short, long, value_parser = parse_nonzero_port)]
+        port: u16,
+        /// Local UDP port to listen on (127.0.0.1). Defaults to OS-assigned.
+        #[arg(short, long, value_parser = parse_nonzero_port)]
+        listen_port: Option<u16>,
+        /// Server WireGuard public key (base64). Required by LWO.
+        #[arg(long, value_parser = parse_wg_key)]
+        server_public_key: [u8; 32],
+        /// Client WireGuard public key (base64). Required by LWO v1.
+        #[arg(long, value_parser = parse_wg_key)]
+        public_key: Option<[u8; 32]>,
+        /// LWO protocol version.
+        #[arg(long, value_enum, default_value_t = LwoVersionArg::V1)]
+        lwo_version: LwoVersionArg,
+        /// Fwmark
+        #[arg(long)]
+        fwmark: Option<u32>,
+    },
+}
+
+/// CLI mirror of `obfuscators::LwoVersion`
+#[derive(Copy, Clone, ValueEnum)]
+enum LwoVersionArg {
+    V1,
+    V2,
+}
+
+impl From<LwoVersionArg> for LwoVersion {
+    fn from(v: LwoVersionArg) -> Self {
+        match v {
+            LwoVersionArg::V1 => LwoVersion::V1,
+            LwoVersionArg::V2 => LwoVersion::V2,
+        }
+    }
 }
 
 fn parse_nonzero_port(s: &str) -> Result<u16, String> {
@@ -49,6 +90,15 @@ fn parse_nonzero_port(s: &str) -> Result<u16, String> {
         return Err("port cannot be 0".into());
     }
     Ok(port)
+}
+
+fn parse_wg_key(s: &str) -> Result<[u8; 32], String> {
+    let decoded = base64::engine::general_purpose::STANDARD
+        .decode(s)
+        .map_err(|e| format!("invalid base64 key: {e}"))?;
+    decoded
+        .try_into()
+        .map_err(|v: Vec<u8>| format!("WireGuard key must be 32 bytes, got {}", v.len()))
 }
 
 fn main() -> ExitCode {
@@ -69,6 +119,32 @@ fn main() -> ExitCode {
                 server_port: port,
                 listen_port: listen_port.unwrap_or(0),
                 server_public_key: None,
+                lwo_version: LwoVersion::V1,
+                fwmark,
+            }
+        }
+        Obfuscator::Lwo {
+            server,
+            port,
+            listen_port,
+            server_public_key,
+            public_key,
+            lwo_version,
+            fwmark,
+        } => {
+            let (server_ipv4, server_ipv6) = match server {
+                IpAddr::V4(v4) => (Some(v4), None),
+                IpAddr::V6(v6) => (None, Some(v6)),
+            };
+            Config {
+                method: ObfuscationMethod::Lwo,
+                public_key,
+                server_ipv4,
+                server_ipv6,
+                server_port: port,
+                listen_port: listen_port.unwrap_or(0),
+                server_public_key: Some(server_public_key),
+                lwo_version: lwo_version.into(),
                 fwmark,
             }
         }

--- a/obfuscators/src/obfuscator.rs
+++ b/obfuscators/src/obfuscator.rs
@@ -14,7 +14,6 @@ use base64::Engine;
 
 pub const WG_KEY_LEN: usize = 32;
 
-
 /// An obfuscator is a self-contained proxy. Implementations bind their own
 /// sockets in their constructor, expose the bound port + outbound socket FDs.
 pub trait Obfuscator: Send {
@@ -61,6 +60,24 @@ impl ObfuscationMethod {
     }
 }
 
+/// LWO protocol version. Ignored by non-LWO obfuscation methods
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LwoVersion {
+    V1 = 1,
+    V2 = 2,
+}
+
+impl LwoVersion {
+    /// Map the JNA-supplied flag to a version, defaulting to v1 for unknown values.
+    pub fn from_u32(v: u32) -> Self {
+        match v {
+            2 => Self::V2,
+            _ => Self::V1,
+        }
+    }
+}
+
 /// C-ABI view: what the JNA caller actually fills in and passes across the FFI.
 #[repr(C)]
 pub struct ObfuscatorConfig {
@@ -74,8 +91,9 @@ pub struct ObfuscatorConfig {
     // Wireguard keys required by LWO
     pub server_public_key: *const c_char,
     pub public_key: *const c_char,
-    #[cfg(target_os = "linux")]
-    pub fwmark: u32,
+    /// LWO protocol version (1 or 2). Ignored by non-LWO methods
+    /// unknown values fall back to v1.
+    pub lwo_version: u32,
 }
 
 /// Safe Rust mirror used inside the crate.
@@ -88,12 +106,13 @@ pub struct Config {
     pub server_port: u16,
     pub listen_port: u16,
     pub server_public_key: Option<[u8; WG_KEY_LEN]>,
+    pub lwo_version: LwoVersion,
     #[cfg(target_os = "linux")]
     pub fwmark: Option<u32>,
 }
 
 impl Config {
-    /// Convert a C struct from C++ into a safe Rust value.
+    /// Convert the C-ABI struct passed by the JNA caller into a safe Rust value.
     /// Returns None in case of error: obfuscation method is unknown, the port is zero, or both addresses are missing / unparseable.
     pub unsafe fn from_c(cfg: *const ObfuscatorConfig) -> Option<Self> {
         if cfg.is_null() {
@@ -120,8 +139,9 @@ impl Config {
             server_port: cfg.server_port,
             listen_port: cfg.listen_port,
             server_public_key,
+            lwo_version: LwoVersion::from_u32(cfg.lwo_version),
             #[cfg(target_os = "linux")]
-            fwmark: if cfg.fwmark == 0 { None } else { Some(cfg.fwmark) },
+            fwmark: None,
         })
     }
 

--- a/obfuscators/src/udp_over_tcp.rs
+++ b/obfuscators/src/udp_over_tcp.rs
@@ -11,7 +11,7 @@ use std::time::Duration;
 use tokio::runtime::Runtime;
 use udp_over_tcp::{TcpOptions, Udp2Tcp};
 
-use crate::obfuscator::{Obfuscator, Config};
+use crate::obfuscator::{Config, Obfuscator};
 
 const SHUTDOWN_POLL: Duration = Duration::from_millis(200);
 

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -474,9 +474,19 @@ auto Controller::setupConfigs(
       exitConfig.m_serverPort = 53;
     }
 
-    // If UDP over TCP is enabled choose a dedicated port
-    if (obfuscationMethod == Server::ObfuscationMethod::UdpOverTcp) {
-      exitConfig.m_serverPort = exitServer.chooseTcpPort();
+    switch (obfuscationMethod) {
+      case Server::ObfuscationMethod::UdpOverTcp:
+        // If UDP over TCP is enabled choose a dedicated port
+        exitConfig.m_serverPort = exitServer.chooseTcpPort();
+        break;
+      case Server::ObfuscationMethod::LWO:
+        // If LWO is enabled, silently set the version based on the exit
+        // server's capabilities
+        exitConfig.m_lwoVersion = exitServer.supportsLwoV2() ? 2 : 1;
+        logger.info() << "LWO version set to" << exitConfig.m_lwoVersion;
+        break;
+      default:
+        break;
     }
   }
   // For controllers that support multiple hops, create a queue of connections.
@@ -525,9 +535,20 @@ auto Controller::setupConfigs(
       logger.info() << "Forcing port 53";
       entryConfig.m_serverPort = 53;
     }
-    // If UDP over TCP is enabled choose a dedicated port
-    if (obfuscationMethod == Server::ObfuscationMethod::UdpOverTcp) {
-      entryConfig.m_serverPort = entryServer.chooseTcpPort();
+
+    switch (obfuscationMethod) {
+      case Server::ObfuscationMethod::UdpOverTcp:
+        // If UDP over TCP is enabled choose a dedicated port
+        exitConfig.m_serverPort = exitServer.chooseTcpPort();
+        break;
+      case Server::ObfuscationMethod::LWO:
+        // If LWO is enabled, silently set the version based on the exit
+        // server's capabilities
+        exitConfig.m_lwoVersion = exitServer.supportsLwoV2() ? 2 : 1;
+        logger.info() << "LWO version set to" << exitConfig.m_lwoVersion;
+        break;
+      default:
+        break;
     }
 
     returnList.append(entryConfig);

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -539,13 +539,13 @@ auto Controller::setupConfigs(
     switch (obfuscationMethod) {
       case Server::ObfuscationMethod::UdpOverTcp:
         // If UDP over TCP is enabled choose a dedicated port
-        exitConfig.m_serverPort = exitServer.chooseTcpPort();
+        entryConfig.m_serverPort = entryServer.chooseTcpPort();
         break;
       case Server::ObfuscationMethod::LWO:
-        // If LWO is enabled, silently set the version based on the exit
+        // If LWO is enabled, silently set the version based on the entry
         // server's capabilities
-        exitConfig.m_lwoVersion = exitServer.supportsLwoV2() ? 2 : 1;
-        logger.info() << "LWO version set to" << exitConfig.m_lwoVersion;
+        entryConfig.m_lwoVersion = entryServer.supportsLwoV2() ? 2 : 1;
+        logger.info() << "LWO version set to" << entryConfig.m_lwoVersion;
         break;
       default:
         break;

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -385,6 +385,17 @@ bool Daemon::parseConfig(const QJsonObject& obj, InterfaceConfig& config) {
     }
   }
 
+  if (!obj.contains("lwoVersion")) {
+    config.m_lwoVersion = 1;
+  } else {
+    QJsonValue value = obj.value("lwoVersion");
+    if (!value.isDouble()) {
+      logger.error() << "lwoVersion is not a number";
+      return false;
+    }
+    config.m_lwoVersion = value.toInt();
+  }
+
   return true;
 }
 

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -393,7 +393,12 @@ bool Daemon::parseConfig(const QJsonObject& obj, InterfaceConfig& config) {
       logger.error() << "lwoVersion is not a number";
       return false;
     }
-    config.m_lwoVersion = value.toInt();
+    int lwoVersion = value.toInt();
+    if (lwoVersion < 1 || lwoVersion > 2) {
+      logger.error() << "lwoVersion" << lwoVersion << "is not valid";
+      return false;
+    }
+    config.m_lwoVersion = lwoVersion;
   }
 
   return true;

--- a/src/daemon/obfuscator/qprocessobfuscator.cpp
+++ b/src/daemon/obfuscator/qprocessobfuscator.cpp
@@ -96,6 +96,16 @@ quint16 QProcessObfuscator::parseListeningPort(const QByteArray& line) const {
 
 QStringList QProcessObfuscator::buildArgs(const InterfaceConfig& config) {
   QStringList args;
+
+  const QString server = !config.m_serverIpv4AddrIn.isEmpty()
+                             ? config.m_serverIpv4AddrIn
+                             : config.m_serverIpv6AddrIn;
+  args << QStringLiteral("--server") << server;
+  args << QStringLiteral("--port") << QString::number(config.m_serverPort);
+#ifdef MZ_LINUX
+  args << QStringLiteral("--fwmark") << QString::number(WG_FIREWALL_MARK);
+#endif
+
   switch (config.m_obfuscationMethod) {
     case Server::ObfuscationMethod::UdpOverTcp:
       args << QStringLiteral("udp-over-tcp");
@@ -111,15 +121,6 @@ QStringList QProcessObfuscator::buildArgs(const InterfaceConfig& config) {
       return {};
   }
 
-  const QString server = !config.m_serverIpv4AddrIn.isEmpty()
-                             ? config.m_serverIpv4AddrIn
-                             : config.m_serverIpv6AddrIn;
-  args << QStringLiteral("--server") << server;
-  args << QStringLiteral("--port") << QString::number(config.m_serverPort);
-#ifdef MZ_LINUX
-  args << QStringLiteral("--fwmark") << QString::number(WG_FIREWALL_MARK);
-#endif
-  // The obfuscator needs to bind to the same interface as the WireGuard peer
   return args;
 }
 

--- a/src/daemon/obfuscator/qprocessobfuscator.cpp
+++ b/src/daemon/obfuscator/qprocessobfuscator.cpp
@@ -100,6 +100,13 @@ QStringList QProcessObfuscator::buildArgs(const InterfaceConfig& config) {
     case Server::ObfuscationMethod::UdpOverTcp:
       args << QStringLiteral("udp-over-tcp");
       break;
+    case Server::ObfuscationMethod::LWO:
+      args << QStringLiteral("lwo");
+      args << QStringLiteral("--lwo-version")
+           << QStringLiteral("v%1").arg(config.m_lwoVersion);
+      args << QStringLiteral("--public-key") << config.m_publicKey;
+      args << QStringLiteral("--server-public-key") << config.m_serverPublicKey;
+      break;
     default:
       return {};
   }

--- a/src/feature/features.h
+++ b/src/feature/features.h
@@ -242,7 +242,7 @@ inline constexpr ConstantFeature freeTrial = {
 inline constexpr ConstantFeature obfuscationLwo = {
     .id = "obfuscationLwo",
     .name = "LWO obfuscation",
-    .supported = false,
+    .supported = Platform::linux_ || Platform::android,
 };
 
 inline constexpr ConstantFeature obfuscationMasque = {

--- a/src/platforms/android/androidcontroller.cpp
+++ b/src/platforms/android/androidcontroller.cpp
@@ -208,6 +208,7 @@ void AndroidController::activate(const InterfaceConfig& config,
   args["excludedApps"] = excludedApps;
   args["dns"] = config.m_dnsServer;
   args["obfuscationMethod"] = (int)config.m_obfuscationMethod;
+  args["lwoVersion"] = (int)config.m_lwoVersion;
 
   // Build the "canned" Notification messages
   // They will be used in case this config will be re-enabled

--- a/src/utils/interfaceconfig.cpp
+++ b/src/utils/interfaceconfig.cpp
@@ -52,6 +52,8 @@ QJsonObject InterfaceConfig::toJson() const {
   json.insert("obfuscationMethod",
               QJsonValue(obfuscationMetaEnum.valueToKey(m_obfuscationMethod)));
 
+  json.insert("lwoVersion", QJsonValue((double)m_lwoVersion));
+
   return json;
 }
 

--- a/src/utils/interfaceconfig.h
+++ b/src/utils/interfaceconfig.h
@@ -44,6 +44,7 @@ class InterfaceConfig {
   QList<IPAddress> m_allowedIPAddressRanges;
   QStringList m_vpnDisabledApps;
   Server::ObfuscationMethod m_obfuscationMethod;
+  int m_lwoVersion = 1;
 
   QJsonObject toJson() const;
   QString toWgConf(

--- a/src/utils/models/server.cpp
+++ b/src/utils/models/server.cpp
@@ -40,6 +40,8 @@ Server& Server::operator=(const Server& other) {
   m_multihopPort = other.m_multihopPort;
   m_countryCode = other.m_countryCode;
   m_cityName = other.m_cityName;
+  m_supportsLwoV1 = other.m_supportsLwoV1;
+  m_supportsLwoV2 = other.m_supportsLwoV2;
 
   return *this;
 }
@@ -115,6 +117,20 @@ bool Server::fromJson(const QJsonObject& obj) {
     prList.append(QPair<uint32_t, uint32_t>(a.toInt(), b.toInt()));
   }
 
+  // Server features / obfuscation methods
+  QJsonValue features = obj.value("features");
+  if (features.isObject()) {
+    QJsonObject featuresObj = features.toObject();
+    QJsonValue supportsLWOv1 = featuresObj.value("lwo");
+    if (supportsLWOv1.isObject()) {
+      m_supportsLwoV1 = true;
+    }
+    QJsonValue supportsLWOv2 = featuresObj.value("lwo_v2");
+    if (supportsLWOv2.isObject()) {
+      m_supportsLwoV2 = true;
+    }
+  }
+
   m_hostname = hostname.toString();
   m_ipv4AddrIn = ipv4AddrIn.toString();
   m_ipv4Gateway = ipv4Gateway.toString();
@@ -155,7 +171,7 @@ bool Server::supportObfuscationMethod(const ObfuscationMethod method) const {
     case UdpOverTcp:
       return true;
     case LWO:
-      [[fallthrough]];
+      return m_supportsLwoV1 || m_supportsLwoV2;
     case Masque:
       [[fallthrough]];
     case Shadowsocks:

--- a/src/utils/models/server.h
+++ b/src/utils/models/server.h
@@ -68,6 +68,8 @@ class Server final {
 
   const QString& cityName() const { return m_cityName; }
 
+  bool supportsLwoV2() const { return m_supportsLwoV2; }
+
   bool forcePort(uint32_t port);
 
   bool operator==(const Server& other) const {
@@ -97,6 +99,8 @@ class Server final {
   uint32_t m_multihopPort = 0;
   QString m_countryCode;
   QString m_cityName;
+  bool m_supportsLwoV1 = false;
+  bool m_supportsLwoV2 = false;
 };
 
 #endif  // SERVER_H


### PR DESCRIPTION
## Description

Add LWO v1 and v2 obfuscators.

Protocol version selection is opaque and it's done in the `Controller`:
- select a server that supports LWO (v1 or v2).
- check whether the `Controller` supports v2
- if v2 is available, set lwoVersion to v2 in `InterfaceConfig`
- use v1 otherwise

LWO v2 is currently supported only on a single staging server.

## Reference

[Jira Issue](https://mozilla-hub.atlassian.net/browse/VPN-7567)

## Checklist
    
- [x] My code follows the style guidelines for this project
- [ ] If bug/feature is at all notable, I've added a draft release note as a comment in `addons/strings.yaml`.
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
