### PR TITLE
VPN-7670 Add aarch64 deb packages to archive.mozilla.org and packages.mozilla.org

### DIFF
--- a/taskcluster/kinds/beetmover-apt/kind.yml
+++ b/taskcluster/kinds/beetmover-apt/kind.yml
@@ -16,9 +16,6 @@ task-defaults:
     description: Import .deb package into Google Artifact Registry
     run-on-tasks-for: [action]
     from-deps:
-        with-attributes:
-            build-type:
-                - linux64/release-deb
         set-name: null
     worker:
         product: vpn
@@ -27,10 +24,36 @@ task-defaults:
 tasks:
     promote-linux64-deb:
         worker-type: beetmover-apt-stage
+        from-deps:
+            with-attributes:
+                build-type:
+                    - linux64/release-deb
+        attributes:
+            shipping-phase: promote-client
+
+    promote-linux-aarch64-deb:
+        worker-type: beetmover-apt-stage
+        from-deps:
+            with-attributes:
+                build-type:
+                    - linux-aarch64/release-deb
         attributes:
             shipping-phase: promote-client
 
     ship-linux64-deb:
         worker-type: beetmover-apt
+        from-deps:
+            with-attributes:
+                build-type:
+                    - linux64/release-deb
+        attributes:
+            shipping-phase: ship-client
+
+    ship-linux-aarch64-deb:
+        worker-type: beetmover-apt
+        from-deps:
+            with-attributes:
+                build-type:
+                    - linux-aarch64/release-deb
         attributes:
             shipping-phase: ship-client

--- a/taskcluster/kinds/beetmover-apt/kind.yml
+++ b/taskcluster/kinds/beetmover-apt/kind.yml
@@ -5,7 +5,6 @@
 loader: taskgraph.loader.transform:loader
 
 transforms:
-    - taskgraph.transforms.from_deps
     - mozillavpn_taskgraph.transforms.beetmover_apt
     - taskgraph.transforms.task:transforms
 
@@ -15,8 +14,6 @@ kind-dependencies:
 task-defaults:
     description: Import .deb package into Google Artifact Registry
     run-on-tasks-for: [action]
-    from-deps:
-        set-name: null
     worker:
         product: vpn
         max-run-time: 1800
@@ -24,36 +21,16 @@ task-defaults:
 tasks:
     promote-linux64-deb:
         worker-type: beetmover-apt-stage
-        from-deps:
-            with-attributes:
-                build-type:
-                    - linux64/release-deb
-        attributes:
-            shipping-phase: promote-client
-
-    promote-linux-aarch64-deb:
-        worker-type: beetmover-apt-stage
-        from-deps:
-            with-attributes:
-                build-type:
-                    - linux-aarch64/release-deb
+        dependencies:
+            linux64: beetmover-promote-linux64-deb
+            linux-aarch64: beetmover-promote-linux-aarch64-deb
         attributes:
             shipping-phase: promote-client
 
     ship-linux64-deb:
         worker-type: beetmover-apt
-        from-deps:
-            with-attributes:
-                build-type:
-                    - linux64/release-deb
-        attributes:
-            shipping-phase: ship-client
-
-    ship-linux-aarch64-deb:
-        worker-type: beetmover-apt
-        from-deps:
-            with-attributes:
-                build-type:
-                    - linux-aarch64/release-deb
+        dependencies:
+            linux64: beetmover-promote-linux64-deb
+            linux-aarch64: beetmover-promote-linux-aarch64-deb
         attributes:
             shipping-phase: ship-client

--- a/taskcluster/kinds/beetmover-promote/kind.yml
+++ b/taskcluster/kinds/beetmover-promote/kind.yml
@@ -97,6 +97,13 @@ tasks:
             build: build-linux64/release-deb
         attributes:
             build-type: linux64/release-deb
+    linux-aarch64-deb:
+        run-on-tasks-for: [action]
+        release-artifacts: [mozillavpn_arm64.deb]
+        dependencies:
+            build: build-linux-aarch64/release-deb
+        attributes:
+            build-type: linux-aarch64/release-deb
     linux64-rpm:
         run-on-tasks-for: [action]
         release-artifacts: [mozillavpn.rpm]

--- a/taskcluster/mozillavpn_taskgraph/transforms/beetmover.py
+++ b/taskcluster/mozillavpn_taskgraph/transforms/beetmover.py
@@ -78,6 +78,7 @@ def add_beetmover_worker_config(config, tasks):
         "android/armv7": "android",
         "android/arm64-v8a": "android",
         "linux64/release-deb": "linux",
+        "linux-aarch64/release-deb": "linux",
         "linux64/release-rpm": "linux",
         "source/vpn" : "source",
     }

--- a/taskcluster/mozillavpn_taskgraph/transforms/beetmover_apt.py
+++ b/taskcluster/mozillavpn_taskgraph/transforms/beetmover_apt.py
@@ -4,7 +4,7 @@
 from itertools import islice
 
 from taskgraph.transforms.base import TransformSequence
-from taskgraph.util.dependencies import get_primary_dependency
+from taskgraph.util.dependencies import get_dependencies
 
 from urllib.parse import urlparse
 
@@ -44,9 +44,9 @@ def get_gcs_sources(dependent_task):
 @transforms.add
 def beetmover_apt(config, tasks):
     for task in tasks:
-        dep = get_primary_dependency(config, task)
-        assert dep
-        gcs_sources = get_gcs_sources(dep)
+        gcs_sources = []
+        for dep in get_dependencies(config, task):
+            gcs_sources.extend(get_gcs_sources(dep))
         if len(gcs_sources) == 0:
             # We do have nothing to ship, skip this task
             continue

--- a/taskcluster/scripts/build/linux_build_dpkg.sh
+++ b/taskcluster/scripts/build/linux_build_dpkg.sh
@@ -148,5 +148,11 @@ for FILENAME in ${BUILD_ARTIFACTS}; do
   if echo "${PACKAGE_NAME}" | grep -q -e "-dbgsym$"; then
     PACKAGE_EXT="ddeb"
   fi
-  cp -v "${FILENAME}" "/builds/worker/artifacts/${PACKAGE_NAME}.${PACKAGE_EXT}"
+  # Preserve the architecture in the artifact filename when cross-compiling so
+  # the cross-compiled packages does not collide with the adm64 one on archive.mozilla.org
+  PACKAGE_SUFFIX=""
+  if [[ -n "$DEB_HOST_ARCH" ]]; then
+    PACKAGE_SUFFIX="_${DEB_HOST_ARCH}"
+  fi
+  cp -v "${FILENAME}" "/builds/worker/artifacts/${PACKAGE_NAME}${PACKAGE_SUFFIX}.${PACKAGE_EXT}"
 done


### PR DESCRIPTION
## Description

Publish aarch64 packages to archive.mozilla.org and packages.mozilla.org

## Reference

[VPN-7670](https://mozilla-hub.atlassian.net/browse/VPN-7670)

## Checklist
    
- [x] My code follows the style guidelines for this project
- [ ] If bug/feature is at all notable, I've added a draft release note as a comment in `addons/strings.yaml`.
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed


[VPN-7670]: https://mozilla-hub.atlassian.net/browse/VPN-7670?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ