### PR TITLE
VPN-7700: Show macOS notifications

### DIFF
--- a/src/platforms/macos/macosstatusicon.mm
+++ b/src/platforms/macos/macosstatusicon.mm
@@ -108,10 +108,26 @@
 }
 @end
 
+@interface MacOSNotificationDelegate : NSObject <UNUserNotificationCenterDelegate>
+@end
+
+@implementation MacOSNotificationDelegate
+- (void)userNotificationCenter:(UNUserNotificationCenter*)center
+       willPresentNotification:(UNNotification*)notification
+         withCompletionHandler:
+             (void (^)(UNNotificationPresentationOptions options))completionHandler {
+  Q_UNUSED(center);
+  Q_UNUSED(notification);
+  completionHandler(UNNotificationPresentationOptionBanner | UNNotificationPresentationOptionList |
+                    UNNotificationPresentationOptionSound);
+}
+@end
+
 namespace {
 Logger logger("MacOSStatusIcon");
 
 MacOSStatusIconDelegate* m_statusBarIcon = nullptr;
+MacOSNotificationDelegate* m_notificationDelegate = nullptr;
 }
 
 MacOSStatusIcon::MacOSStatusIcon(QObject* parent) : QObject(parent) {
@@ -171,6 +187,13 @@ void MacOSStatusIcon::showMessage(const QString& title, const QString& message) 
   logger.debug() << "Show message";
 
   UNUserNotificationCenter* center = [UNUserNotificationCenter currentNotificationCenter];
+
+  // Delegate is needed so notifications are shown as banners even when VPN client is
+  // foregrounded (otherwise macOS puts to Notification Center, but doesn't show banner).
+  if (!m_notificationDelegate) {
+    m_notificationDelegate = [[MacOSNotificationDelegate alloc] init];
+  }
+  center.delegate = m_notificationDelegate;
 
   // This is a no-op is authorization has been granted.
   [center requestAuthorizationWithOptions:(UNAuthorizationOptionSound | UNAuthorizationOptionAlert |


### PR DESCRIPTION
## Description

We were not setting the delegate. From research and testing (and how we handle this on iOS), this is what decides how to handle notifications when app is foregrounded.

## Reference

VPN-7700

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] If bug/feature is at all notable, I've added a draft release note as a comment in `addons/strings.yaml`.
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
