### PR TITLE
Add XDG_CURRENT_DESKTOP to log artifacts

### DIFF
--- a/src/models/devicemodel.cpp
+++ b/src/models/devicemodel.cpp
@@ -9,6 +9,7 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QJsonValue>
+#include <QtEnvironmentVariables>
 
 #include "constants.h"
 #include "leakdetector.h"
@@ -296,6 +297,9 @@ void DeviceModel::logSerialize(QIODevice* device) {
   out << "OS -> " << QSysInfo::productType() << Qt::endl;
 #ifdef MZ_WINDOWS
   out << "OS Version (Reg) -> " << WindowsUtils::windowsVersion() << Qt::endl;
+#endif
+#ifdef MZ_LINUX
+  out << "OS Shell -> " << qEnvironmentVariable("XDG_CURRENT_DESKTOP") << Qt::endl;
 #endif
   out << "OS Version -> " << QSysInfo::productVersion() << Qt::endl;
 

--- a/src/models/devicemodel.cpp
+++ b/src/models/devicemodel.cpp
@@ -299,7 +299,8 @@ void DeviceModel::logSerialize(QIODevice* device) {
   out << "OS Version (Reg) -> " << WindowsUtils::windowsVersion() << Qt::endl;
 #endif
 #ifdef MZ_LINUX
-  out << "OS Shell -> " << qEnvironmentVariable("XDG_CURRENT_DESKTOP") << Qt::endl;
+  out << "OS Shell -> " << qEnvironmentVariable("XDG_CURRENT_DESKTOP")
+      << Qt::endl;
 #endif
   out << "OS Version -> " << QSysInfo::productVersion() << Qt::endl;
 


### PR DESCRIPTION
## Description
A common debugging question that we need to ask of Linux users is "what desktop shell are you using?" and this is something that we could just embed into the logs. So, let's do it to save ourself a roundtrip with the user during debug.

## Reference

    i.e Jira or Github issue URL

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] If bug/feature is at all notable, I've added a draft release note as a comment in `addons/strings.yaml`.
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
