### PR TITLE
VPN-7709: add SBOM

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -1,0 +1,16 @@
+name: ssdlc-sbom
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: write
+
+jobs:
+  sbom:
+    uses: mozilla/ssdlc-actions/.github/workflows/ssdlc-sbom.yml@5cc2b20e42d53d1643853f12244fbec9ed2f2e0c
+    with:
+      sbom_name: ${{ github.event.release.tag_name || github.sha }}


### PR DESCRIPTION
## Description

Per our discussion, there are some questions about whether this will include all our dependencies (especially Qt). However, we need to use this tool, so let's add it in and see what the output looks like.

From [instructions](https://mozilla-hub.atlassian.net/wiki/spaces/MozPolicies/pages/2770665546/Software+Bill+of+Materials+SBOM+Standard):

> Engineers must only use the Mozilla-approved reusable workflow for all SBOM generation. Use of third-party or custom SBOM tooling outside of the officially sanctioned workflow is not permitted, in order to ensure consistency, accuracy, and compliance across all products.

Additionally, it will produce one SBOM per release, even though not all dependencies are used by all platforms. I'll check in with the tool's creators to make sure this is okay.

## Reference

Email to engineers, VPN-7709

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] If bug/feature is at all notable, I've added a draft release note as a comment in `addons/strings.yaml`.
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
