### PR TITLE
VPN-7711 Fix layout issues on ContactUs form with some locales

### DIFF
--- a/nebula/ui/components/MZCheckBox.qml
+++ b/nebula/ui/components/MZCheckBox.qml
@@ -17,8 +17,6 @@ CheckBox {
 
     id: checkBox
 
-    signal clicked()
-
     Layout.preferredHeight: MZTheme.theme.checkBoxHeightWidth
     Layout.preferredWidth: MZTheme.theme.checkBoxHeightWidth
     Layout.margins: MZTheme.theme.checkBoxRowSubLabelTopMargin

--- a/src/ui/screens/getHelp/contactUs/ViewContactUsForm.qml
+++ b/src/ui/screens/getHelp/contactUs/ViewContactUsForm.qml
@@ -127,7 +127,7 @@ MZViewBase {
                     placeholderText: MZI18n.InAppSupportWorkflowDropdownLabel
                     model: VPNSupportCategoryModel
                     Layout.fillWidth: true
-                    Layout.preferredWidth: undefined
+                    Layout.preferredWidth: -1
                     onCurrentValueChanged: {
                         shareLogsCheckBox.isChecked = currentValue === 'account' || currentValue === 'technical';
                     }

--- a/src/ui/screens/getHelp/contactUs/ViewContactUsForm.qml
+++ b/src/ui/screens/getHelp/contactUs/ViewContactUsForm.qml
@@ -16,7 +16,7 @@ MZViewBase {
 
     objectName: "contactUs"
     _menuTitle: MZI18n.InAppSupportWorkflowSupportNavLinkText
-   _viewContentData: ColumnLayout {
+    _viewContentData: ColumnLayout {
        property string _emailAddress: ""
        Layout.preferredWidth: parent.width
 
@@ -61,7 +61,6 @@ MZViewBase {
 
         ColumnLayout {
             Layout.alignment: Qt.AlignTop
-
             spacing: 24
 
             ColumnLayout {
@@ -173,8 +172,7 @@ MZViewBase {
             spacing: 24
 
             MZLinkButton {
-                anchors.left: parent.left
-                anchors.right: parent.right
+                Layout.fillWidth: true
                 labelText: MZI18n.InAppSupportWorkflowPrivacyNoticeLinkText
                 onClicked: MZUrlOpener.openUrlLabel("privacyNotice")
             }


### PR DESCRIPTION
## Description

The contact form overflowed to the right for some locales.

The issue was introduced by me in the share-logs PR, which removed the `Column { Layout.fillWidth: true }` wrapper that used to bound `MZLinkButton` and left it as a direct child of the `ColumnLayout` still using:
```
anchors.left: parent.left
anchors.right: parent.right
```

Fix a couple of warnings too.

## Reference

[VPN-7711](https://mozilla-hub.atlassian.net/browse/VPN-7711)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] If bug/feature is at all notable, I've added a draft release note as a comment in `addons/strings.yaml`.
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-7711]: https://mozilla-hub.atlassian.net/browse/VPN-7711?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ