### PR TITLE
VPN-7713: improve Siri translations

### DIFF
--- a/scripts/utils/generate_xcstrings.py
+++ b/scripts/utils/generate_xcstrings.py
@@ -48,7 +48,7 @@ def load_xliff_translations(xliff_path, isEnglish):
 
 
 def using_app_placeholder(value):
-    return value.replace("%@", "\\(.applicationName)")
+    return value.replace("%@", "${applicationName}")
 
 
 SPECIAL_LOCALE_MAP = {
@@ -180,7 +180,7 @@ def build_phrase_section(phrase_strings, locale_translations):
         else:
             print(f"No translations found for {string_id} in {locale}")
 
-    return {"localizations": localizations}, error_locales
+    return {"extractionState": "extracted_with_value", "localizations": localizations}, error_locales
 
 
 def build_appshortcuts_xcstrings(intent_phrase_array, intent_title_array, locale_translations):


### PR DESCRIPTION
## Description

Apple really want us hand-building these xcstring files, but we're brute forcing our way through it. While it seemed to accept the other format for `applicationName`, when you give it a chance to build the file itself, it goes for this format. Adding a probably-unneeded `extractionState` key - but one that Apple adds when creating the file itself.

From testing, I got this working sometimes on Spanish and German.

## Reference

VPN-7713

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] If bug/feature is at all notable, I've added a draft release note as a comment in `addons/strings.yaml`.
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
