### PR TITLE
Do not abort login when the location lookup fails

### DIFF
--- a/src/mozillavpn.cpp
+++ b/src/mozillavpn.cpp
@@ -1335,8 +1335,9 @@ void MozillaVPN::scheduleRefreshDataTasks() {
   // https://mozilla-hub.atlassian.net/browse/VPN-3726 for more information.
   if (!m_private->m_location.initialized() &&
       !m_private->m_controller.isActive()) {
+    // Location is best-effort: failure should not abort a successful login.
     TaskGetLocation* locationTask =
-        new TaskGetLocation(ErrorHandler::PropagateError);
+        new TaskGetLocation(ErrorHandler::DoNotPropagateError);
     connect(locationTask, &TaskGetLocation::completed, [this]() {
       if (!m_locationInitialized) {
         logger.debug() << "Location initialized";


### PR DESCRIPTION
## Description

This is up for discussion, see linked issue. Possible fix for a bug where a transient network hiccup during login logs the user back out with a misleading "No internet connection, try again", even though authentication actually succeeded.

A Windows 11 user could not sign in over wired Ethernet (Wi-Fi worked fine) with a "No internet connection, try again." error message. Login isn't failing according to the logs: the OAuth flow completed, and the device was registered. The follow-up request to `/api/v1/vpn/ipinfo` (from `TaskGetLocation`) failed though, which reset with `RemoteHostClosedError`.

I'd say we could schedule the location task with `DoNotPropagateError`. The task still emits `completed()`, so the login flow proceeds to the main state; if the lookup fails, auto server selection will be skipped and the client can use the default server.

TaskAuthenticate, TaskAddDevice, TaskRemoveDevice, TaskAccount, TaskServers are unchanged, they still have PropagateError (or report errors unconditionally), so a genuine failure there will still propagate.

## Reference

[VPN-7712](https://mozilla-hub.atlassian.net/browse/VPN-7712)

## Checklist
    
- [x] My code follows the style guidelines for this project
- [ ] If bug/feature is at all notable, I've added a draft release note as a comment in `addons/strings.yaml`.
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed


[VPN-7712]: https://mozilla-hub.atlassian.net/browse/VPN-7712?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ