### PR TITLE
VPN-7693: Turn on microsoft signature enforcement

### DIFF
--- a/src/platforms/windows/windowsutils.cpp
+++ b/src/platforms/windows/windowsutils.cpp
@@ -171,6 +171,10 @@ void WindowsUtils::lockDownDLLSearchPath() {
   // Change the load order of DLLs to prefer system32 images
   PROCESS_MITIGATION_IMAGE_LOAD_POLICY pol = {};
   pol.PreferSystem32Images = 1;
-
   SetProcessMitigationPolicy(ProcessImageLoadPolicy, &pol, sizeof(pol));
+
+  // Deny loading of DLLs unless they are signed by microsoft.
+  PROCESS_MITIGATION_BINARY_SIGNATURE_POLICY sig = {};
+  sig.MicrosoftSignedOnly = 1;
+  SetProcessMitigationPolicy(ProcessSignaturePolicy, &sig, sizeof(sig));
 }


### PR DESCRIPTION
## Description
It has come to our attention that we are missing a check to prevent the loading of unsigned DLLs, so let's turn the appropriate process mitigation flags on to close that loophole.

## Reference
JIRA Issue: [VPN-7693](https://mozilla-hub.atlassian.net/browse/VPN-7693)
Bugzilla: [2048684](https://bugzilla.mozilla.org/show_bug.cgi?id=2048684)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] If bug/feature is at all notable, I've added a draft release note as a comment in `addons/strings.yaml`.
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-7693]: https://mozilla-hub.atlassian.net/browse/VPN-7693?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ