### PR TITLE
VPN-7630: Refactor IPAddress type to inherit QHostAddress

### DIFF
--- a/src/platforms/ios/ioscontroller.mm
+++ b/src/platforms/ios/ioscontroller.mm
@@ -132,9 +132,9 @@ void IOSController::activate(const InterfaceConfig& config, Controller::Reason r
       arrayWithCapacity:config.m_allowedIPAddressRanges.length()];
   for (const IPAddress& i : config.m_allowedIPAddressRanges) {
     VPNIPAddressRange* range =
-        [[VPNIPAddressRange alloc] initWithAddress:i.address().toString().toNSString()
+        [[VPNIPAddressRange alloc] initWithAddress:i.toHostString().toNSString()
                                networkPrefixLength:i.prefixLength()
-                                            isIpv6:i.type() == QAbstractSocket::IPv6Protocol];
+                                            isIpv6:i.protocol() == QAbstractSocket::IPv6Protocol];
     [allowedIPAddressRangesNS addObject:[range autorelease]];
   }
 

--- a/src/platforms/linux/daemon/wireguardutilslinux.cpp
+++ b/src/platforms/linux/daemon/wireguardutilslinux.cpp
@@ -639,12 +639,12 @@ bool WireguardUtilsLinux::rtmIncludePeer(int action, const IPAddress& prefix,
   nlmsg_append_attr32(nlmsg, sizeof(buf), FRA_FWMARK, WG_FIREWALL_MARK);
   nlmsg_append_attr32(nlmsg, sizeof(buf), FRA_TABLE, WG_ROUTE_TABLE);
 
-  if (prefix.address().protocol() == QAbstractSocket::IPv6Protocol) {
-    Q_IPV6ADDR dst = prefix.address().toIPv6Address();
+  if (prefix.protocol() == QAbstractSocket::IPv6Protocol) {
+    Q_IPV6ADDR dst = prefix.toIPv6Address();
     nlmsg_append_attr(nlmsg, sizeof(buf), FRA_DST, &dst, sizeof(dst));
     rule->family = AF_INET6;
-  } else if (prefix.address().protocol() == QAbstractSocket::IPv4Protocol) {
-    quint32 dst = prefix.address().toIPv4Address();
+  } else if (prefix.protocol() == QAbstractSocket::IPv4Protocol) {
+    quint32 dst = prefix.toIPv4Address();
     nlmsg_append_attr32(nlmsg, sizeof(buf), FRA_DST, htonl(dst));
     rule->family = AF_INET;
   } else {
@@ -828,13 +828,13 @@ void WireguardUtilsLinux::resetAllCgroups() {
 // static
 bool WireguardUtilsLinux::buildAllowedIp(wg_allowedip* ip,
                                          const IPAddress& prefix) {
-  const char* addrString = qPrintable(prefix.address().toString());
-  if (prefix.type() == QAbstractSocket::IPv4Protocol) {
+  const char* addrString = qPrintable(prefix.toHostString());
+  if (prefix.protocol() == QAbstractSocket::IPv4Protocol) {
     ip->family = AF_INET;
     ip->cidr = prefix.prefixLength();
     return inet_pton(AF_INET, addrString, &ip->ip4) == 1;
   }
-  if (prefix.type() == QAbstractSocket::IPv6Protocol) {
+  if (prefix.protocol() == QAbstractSocket::IPv6Protocol) {
     ip->family = AF_INET6;
     ip->cidr = prefix.prefixLength();
     return inet_pton(AF_INET6, addrString, &ip->ip6) == 1;

--- a/src/platforms/linux/netmgrcontroller.cpp
+++ b/src/platforms/linux/netmgrcontroller.cpp
@@ -234,10 +234,10 @@ void NetmgrController::activate(const InterfaceConfig& config,
   NetmgrDataList ipv6routes;
   for (const IPAddress& i : config.m_allowedIPAddressRanges) {
     QVariantMap route;
-    route.insert("dest", i.address().toString());
+    route.insert("dest", i.toHostString());
     route.insert("prefix", (uint)i.prefixLength());
     route.insert("table", WG_FIREWALL_MARK);
-    if (i.address().protocol() == QAbstractSocket::IPv6Protocol) {
+    if (i.protocol() == QAbstractSocket::IPv6Protocol) {
       ipv6routes.append(route);
     } else {
       ipv4routes.append(route);

--- a/src/platforms/macos/daemon/macosroutemonitor.cpp
+++ b/src/platforms/macos/daemon/macosroutemonitor.cpp
@@ -149,7 +149,7 @@ void MacosRouteMonitor::handleRtmDelete(const struct rt_msghdr* rtm,
   logger.debug() << "Lost default route via" << ifname
                  << logger.sensitive(addrToString(addrlist[1]));
   for (const IPAddress& prefix : m_exclusionRoutes) {
-    if (prefix.address().protocol() == protocol) {
+    if (prefix.protocol() == protocol) {
       logger.debug() << "Removing exclusion route to"
                      << logger.sensitive(prefix.toString());
       rtmSendRoute(RTM_DELETE, prefix, rtm->rtm_index, nullptr);
@@ -264,7 +264,7 @@ void MacosRouteMonitor::handleRtmUpdate(const struct rt_msghdr* rtm,
   logger.debug() << "Updating default route via" << ifname
                  << addrToString(addrlist[1]);
   for (const IPAddress& prefix : m_exclusionRoutes) {
-    if (prefix.address().protocol() == protocol) {
+    if (prefix.protocol() == protocol) {
       logger.debug() << "Updating exclusion route to"
                      << logger.sensitive(prefix.toString());
       rtmSendRoute(rtm_type, prefix, ifindex, addrlist[1].constData());
@@ -372,9 +372,9 @@ bool MacosRouteMonitor::rtmSendRoute(int action, const IPAddress& prefix,
   // by RTF_IFSCOPE|RTF_REJECT routes. isHostRoute identifies a /32 or
   // /128 route so we can set RTF_HOST and omit RTA_NETMASK later.
   const bool isHostRoute =
-      (prefix.address().protocol() == QAbstractSocket::IPv6Protocol &&
+      (prefix.protocol() == QAbstractSocket::IPv6Protocol &&
        prefix.prefixLength() == 128) ||
-      (prefix.address().protocol() == QAbstractSocket::IPv4Protocol &&
+      (prefix.protocol() == QAbstractSocket::IPv4Protocol &&
        prefix.prefixLength() == 32);
 
   if (isHostRoute) {
@@ -394,9 +394,9 @@ bool MacosRouteMonitor::rtmSendRoute(int action, const IPAddress& prefix,
   memset(&rtm->rtm_rmx, 0, sizeof(rtm->rtm_rmx));
 
   // Append RTA_DST
-  if (prefix.address().protocol() == QAbstractSocket::IPv6Protocol) {
+  if (prefix.protocol() == QAbstractSocket::IPv6Protocol) {
     struct sockaddr_in6 sin6;
-    Q_IPV6ADDR dst = prefix.address().toIPv6Address();
+    Q_IPV6ADDR dst = prefix.toIPv6Address();
     memset(&sin6, 0, sizeof(sin6));
     sin6.sin6_family = AF_INET6;
     sin6.sin6_len = sizeof(sin6);
@@ -404,7 +404,7 @@ bool MacosRouteMonitor::rtmSendRoute(int action, const IPAddress& prefix,
     rtmAppendAddr(rtm, rtm_max_size, RTA_DST, &sin6);
   } else {
     struct sockaddr_in sin;
-    quint32 dst = prefix.address().toIPv4Address();
+    quint32 dst = prefix.toIPv4Address();
     memset(&sin, 0, sizeof(sin));
     sin.sin_family = AF_INET;
     sin.sin_len = sizeof(sin);
@@ -425,7 +425,7 @@ bool MacosRouteMonitor::rtmSendRoute(int action, const IPAddress& prefix,
 
   // RTF_HOST implies an all-ones netmask; do not append RTA_NETMASK with it.
   if (!isHostRoute) {
-    if (prefix.address().protocol() == QAbstractSocket::IPv6Protocol) {
+    if (prefix.protocol() == QAbstractSocket::IPv6Protocol) {
       struct sockaddr_in6 sin6;
       memset(&sin6, 0, sizeof(sin6));
 
@@ -438,7 +438,7 @@ bool MacosRouteMonitor::rtmSendRoute(int action, const IPAddress& prefix,
       }
 
       rtmAppendAddr(rtm, rtm_max_size, RTA_NETMASK, &sin6);
-    } else if (prefix.address().protocol() == QAbstractSocket::IPv4Protocol) {
+    } else if (prefix.protocol() == QAbstractSocket::IPv4Protocol) {
       struct sockaddr_in sin;
       memset(&sin, 0, sizeof(sin));
 
@@ -545,12 +545,12 @@ bool MacosRouteMonitor::addExclusionRoute(const IPAddress& prefix) {
   m_exclusionRoutes.append(prefix);
 
   // If the default route is known, then updte the routing table immediately.
-  if ((prefix.address().protocol() == QAbstractSocket::IPv4Protocol) &&
+  if ((prefix.protocol() == QAbstractSocket::IPv4Protocol) &&
       (m_defaultIfindexIpv4 != 0) && !m_defaultGatewayIpv4.isEmpty()) {
     return rtmSendRoute(RTM_ADD, prefix, m_defaultIfindexIpv4,
                         m_defaultGatewayIpv4.constData());
   }
-  if ((prefix.address().protocol() == QAbstractSocket::IPv6Protocol) &&
+  if ((prefix.protocol() == QAbstractSocket::IPv6Protocol) &&
       (m_defaultIfindexIpv6 != 0) && !m_defaultGatewayIpv6.isEmpty()) {
     return rtmSendRoute(RTM_ADD, prefix, m_defaultIfindexIpv6,
                         m_defaultGatewayIpv6.constData());
@@ -565,9 +565,9 @@ bool MacosRouteMonitor::deleteExclusionRoute(const IPAddress& prefix) {
                  << logger.sensitive(prefix.toString());
 
   m_exclusionRoutes.removeAll(prefix);
-  if (prefix.address().protocol() == QAbstractSocket::IPv4Protocol) {
+  if (prefix.protocol() == QAbstractSocket::IPv4Protocol) {
     return rtmSendRoute(RTM_DELETE, prefix, m_defaultIfindexIpv4, nullptr);
-  } else if (prefix.address().protocol() == QAbstractSocket::IPv6Protocol) {
+  } else if (prefix.protocol() == QAbstractSocket::IPv6Protocol) {
     return rtmSendRoute(RTM_DELETE, prefix, m_defaultIfindexIpv6, nullptr);
   } else {
     return false;
@@ -577,9 +577,9 @@ bool MacosRouteMonitor::deleteExclusionRoute(const IPAddress& prefix) {
 void MacosRouteMonitor::flushExclusionRoutes() {
   while (!m_exclusionRoutes.isEmpty()) {
     IPAddress prefix = m_exclusionRoutes.takeFirst();
-    if (prefix.address().protocol() == QAbstractSocket::IPv4Protocol) {
+    if (prefix.protocol() == QAbstractSocket::IPv4Protocol) {
       rtmSendRoute(RTM_DELETE, prefix, m_defaultIfindexIpv4, nullptr);
-    } else if (prefix.address().protocol() == QAbstractSocket::IPv6Protocol) {
+    } else if (prefix.protocol() == QAbstractSocket::IPv6Protocol) {
       rtmSendRoute(RTM_DELETE, prefix, m_defaultIfindexIpv6, nullptr);
     }
   }

--- a/src/platforms/macos/daemon/wireguardutilsmacos.cpp
+++ b/src/platforms/macos/daemon/wireguardutilsmacos.cpp
@@ -411,11 +411,11 @@ bool WireguardUtilsMacos::updateRoutePrefix(const IPAddress& prefix) {
   }
 
   // Ensure that we do not replace the default route.
-  if (prefix.type() == QAbstractSocket::IPv4Protocol) {
+  if (prefix.protocol() == QAbstractSocket::IPv4Protocol) {
     return m_rtmonitor->insertRoute(IPAddress("0.0.0.0/1")) &&
            m_rtmonitor->insertRoute(IPAddress("128.0.0.0/1"));
   }
-  if (prefix.type() == QAbstractSocket::IPv6Protocol) {
+  if (prefix.protocol() == QAbstractSocket::IPv6Protocol) {
     return m_rtmonitor->insertRoute(IPAddress("::/1")) &&
            m_rtmonitor->insertRoute(IPAddress("8000::/1"));
   }
@@ -433,10 +433,10 @@ bool WireguardUtilsMacos::deleteRoutePrefix(const IPAddress& prefix) {
   }
 
   // Ensure that we do not replace the default route.
-  if (prefix.type() == QAbstractSocket::IPv4Protocol) {
+  if (prefix.protocol() == QAbstractSocket::IPv4Protocol) {
     return m_rtmonitor->deleteRoute(IPAddress("0.0.0.0/1")) &&
            m_rtmonitor->deleteRoute(IPAddress("128.0.0.0/1"));
-  } else if (prefix.type() == QAbstractSocket::IPv6Protocol) {
+  } else if (prefix.protocol() == QAbstractSocket::IPv6Protocol) {
     return m_rtmonitor->deleteRoute(IPAddress("::/1")) &&
            m_rtmonitor->deleteRoute(IPAddress("8000::/1"));
   } else {

--- a/src/platforms/windows/daemon/windowsfirewall.cpp
+++ b/src/platforms/windows/daemon/windowsfirewall.cpp
@@ -479,7 +479,7 @@ bool WindowsFirewall::allowTrafficTo(const IPAddress& addr, int weight,
                                      const QString& peer) {
   GUID layerKeyOut;
   GUID layerKeyIn;
-  if (addr.type() == QAbstractSocket::IPv4Protocol) {
+  if (addr.protocol() == QAbstractSocket::IPv4Protocol) {
     layerKeyOut = FWPM_LAYER_ALE_AUTH_CONNECT_V4;
     layerKeyIn = FWPM_LAYER_ALE_AUTH_RECV_ACCEPT_V4;
   } else {
@@ -493,7 +493,7 @@ bool WindowsFirewall::allowTrafficTo(const IPAddress& addr, int weight,
   QByteArray lowIpV6Buffer;
   QByteArray highIpV6Buffer;
 
-  importAddress(addr.address(), ipRange.valueLow, &lowIpV6Buffer);
+  importAddress(addr, ipRange.valueLow, &lowIpV6Buffer);
   importAddress(addr.broadcastAddress(), ipRange.valueHigh, &highIpV6Buffer);
 
   cond[0].fieldKey = FWPM_CONDITION_IP_REMOTE_ADDRESS;
@@ -769,10 +769,7 @@ bool WindowsFirewall::blockTrafficTo(const IPAddress& addr, uint8_t weight,
                                      const QString& peer) {
   QString description("Block traffic %1 %2 ");
 
-  auto lower = addr.address();
-  auto upper = addr.broadcastAddress();
-
-  const bool isV4 = addr.type() == QAbstractSocket::IPv4Protocol;
+  const bool isV4 = addr.protocol() == QAbstractSocket::IPv4Protocol;
   const GUID layerKeyOut =
       isV4 ? FWPM_LAYER_ALE_AUTH_CONNECT_V4 : FWPM_LAYER_ALE_AUTH_CONNECT_V6;
   const GUID layerKeyIn = isV4 ? FWPM_LAYER_ALE_AUTH_RECV_ACCEPT_V4
@@ -791,8 +788,8 @@ bool WindowsFirewall::blockTrafficTo(const IPAddress& addr, uint8_t weight,
   QByteArray lowIpV6Buffer;
   QByteArray highIpV6Buffer;
 
-  importAddress(lower, ipRange.valueLow, &lowIpV6Buffer);
-  importAddress(upper, ipRange.valueHigh, &highIpV6Buffer);
+  importAddress(addr, ipRange.valueLow, &lowIpV6Buffer);
+  importAddress(addr.broadcastAddress(), ipRange.valueHigh, &highIpV6Buffer);
 
   cond[0].fieldKey = FWPM_CONDITION_IP_REMOTE_ADDRESS;
   cond[0].matchType = FWP_MATCH_RANGE;

--- a/src/platforms/windows/daemon/windowsroutemonitor.cpp
+++ b/src/platforms/windows/daemon/windowsroutemonitor.cpp
@@ -372,9 +372,8 @@ bool WindowsRouteMonitor::addExclusionRoute(const IPAddress& prefix) {
                  << logger.sensitive(prefix.toString());
 
   // Silently ignore non-routeable addresses.
-  QHostAddress addr = prefix.address();
-  if (addr.isLoopback() || addr.isBroadcast() || addr.isLinkLocal() ||
-      addr.isMulticast()) {
+  if (prefix.isLoopback() || prefix.isBroadcast() || prefix.isLinkLocal() ||
+      prefix.isMulticast()) {
     return true;
   }
 
@@ -386,14 +385,14 @@ bool WindowsRouteMonitor::addExclusionRoute(const IPAddress& prefix) {
   // Allocate and initialize the MIB routing table row.
   MIB_IPFORWARD_ROW2* data = new MIB_IPFORWARD_ROW2;
   InitializeIpForwardEntry(data);
-  if (prefix.address().protocol() == QAbstractSocket::IPv6Protocol) {
-    Q_IPV6ADDR buf = prefix.address().toIPv6Address();
+  if (prefix.protocol() == QAbstractSocket::IPv6Protocol) {
+    Q_IPV6ADDR buf = prefix.toIPv6Address();
 
     memcpy(&data->DestinationPrefix.Prefix.Ipv6.sin6_addr, &buf, sizeof(buf));
     data->DestinationPrefix.Prefix.Ipv6.sin6_family = AF_INET6;
     data->DestinationPrefix.PrefixLength = prefix.prefixLength();
   } else {
-    quint32 buf = prefix.address().toIPv4Address();
+    quint32 buf = prefix.toIPv4Address();
 
     data->DestinationPrefix.Prefix.Ipv4.sin_addr.s_addr = htonl(buf);
     data->DestinationPrefix.Prefix.Ipv4.sin_family = AF_INET;
@@ -414,7 +413,7 @@ bool WindowsRouteMonitor::addExclusionRoute(const IPAddress& prefix) {
 
   PMIB_IPFORWARD_TABLE2 table;
   int family;
-  if (prefix.address().protocol() == QAbstractSocket::IPv6Protocol) {
+  if (prefix.protocol() == QAbstractSocket::IPv6Protocol) {
     family = AF_INET6;
   } else {
     family = AF_INET;
@@ -443,7 +442,7 @@ quint64 WindowsRouteMonitor::getExclusionRouteLuid(
 
 bool WindowsRouteMonitor::deleteExclusionRoute(const IPAddress& prefix) {
   logger.debug() << "Deleting exclusion route for"
-                 << logger.sensitive(prefix.address().toString());
+                 << logger.sensitive(prefix.toHostString());
 
   MIB_IPFORWARD_ROW2* data = m_exclusionRoutes.take(prefix);
   if (data == nullptr) {

--- a/src/platforms/windows/daemon/wireguardutilswindows.cpp
+++ b/src/platforms/windows/daemon/wireguardutilswindows.cpp
@@ -608,7 +608,7 @@ bool WireguardUtilsWindows::updateRoutePrefix(const IPAddress& prefix) {
   // Install the route
   DWORD result = CreateIpForwardEntry2(&entry);
   if ((result == ERROR_NOT_FOUND) &&
-      (prefix.type() == QAbstractSocket::IPv6Protocol)) {
+      (prefix.protocol() == QAbstractSocket::IPv6Protocol)) {
     return true;
   }
   if (result == ERROR_OBJECT_ALREADY_EXISTS) {

--- a/src/platforms/windows/daemon/wireguardutilswindows.cpp
+++ b/src/platforms/windows/daemon/wireguardutilswindows.cpp
@@ -68,7 +68,7 @@ ulong setIPv4AddressAndMask(NET_IFINDEX ifindex, const IPAddress address) {
   ULONG nteContext = 0;
   ULONG nteInstance = 0;
   IN_ADDR ipAddrBinary, subnetMaskBinary;
-  if (InetPtonA(AF_INET, qPrintable(address.address().toString()),
+  if (InetPtonA(AF_INET, qPrintable(address.toHostString()),
                 &ipAddrBinary) != 1) {
     return 0;
   }
@@ -97,10 +97,10 @@ bool setIPv6AddressAndMask(NET_LUID luid, const IPAddress ipAddress) {
   MIB_UNICASTIPADDRESS_ROW row;
   SOCKADDR_IN6 sockaddr = {};
   sockaddr.sin6_family = AF_INET6;
-  if (InetPtonA(AF_INET6, qPrintable(ipAddress.address().toString()),
+  if (InetPtonA(AF_INET6, qPrintable(ipAddress.toHostString()),
                 &sockaddr.sin6_addr) != 1) {
     logger.error() << "Failed to assign ivp6: Cannot Parse IPv6 Address "
-                   << ipAddress.address().toString();
+                   << ipAddress.toHostString();
     return false;
   }
 
@@ -568,13 +568,13 @@ void WireguardUtilsWindows::buildMibForwardRow(const IPAddress& prefix,
   InitializeIpForwardEntry(entry);
 
   // Populate the next hop
-  if (prefix.type() == QAbstractSocket::IPv6Protocol) {
-    InetPtonA(AF_INET6, qPrintable(prefix.address().toString()),
+  if (prefix.protocol() == QAbstractSocket::IPv6Protocol) {
+    InetPtonA(AF_INET6, qPrintable(prefix.toHostString()),
               &entry->DestinationPrefix.Prefix.Ipv6.sin6_addr);
     entry->DestinationPrefix.Prefix.Ipv6.sin6_family = AF_INET6;
     entry->DestinationPrefix.PrefixLength = prefix.prefixLength();
   } else {
-    InetPtonA(AF_INET, qPrintable(prefix.address().toString()),
+    InetPtonA(AF_INET, qPrintable(prefix.toHostString()),
               &entry->DestinationPrefix.Prefix.Ipv4.sin_addr);
     entry->DestinationPrefix.Prefix.Ipv4.sin_family = AF_INET;
     entry->DestinationPrefix.PrefixLength = prefix.prefixLength();

--- a/src/platforms/windows/daemon/wireguardutilswindows.cpp
+++ b/src/platforms/windows/daemon/wireguardutilswindows.cpp
@@ -60,32 +60,30 @@ static void CALLBACK WireGuardLogger(_In_ WIREGUARD_LOGGER_LEVEL Level,
  * @brief Assigns an ipv4 address to a network device with a given LUID
  *
  * @param ifindex - Interface Index of the Adapter
- * @param address - Address and NetMask of the Adapter
+ * @param addr - Address and NetMask of the Adapter
  * @return ulong - nteContext - Call DeleteIPAddress(nteContext) to remove the
  * assignment.
  */
-ulong setIPv4AddressAndMask(NET_IFINDEX ifindex, const IPAddress address) {
+ulong setIPv4AddressAndMask(NET_IFINDEX ifindex, const IPAddress& addr) {
   ULONG nteContext = 0;
   ULONG nteInstance = 0;
-  IN_ADDR ipAddrBinary, subnetMaskBinary;
-  if (InetPtonA(AF_INET, qPrintable(address.toHostString()),
-                &ipAddrBinary) != 1) {
+  IN_ADDR inAddr, inMask;
+  if (InetPtonA(AF_INET, qPrintable(addr.toHostString()), &inAddr) != 1) {
     return 0;
   }
-  if (InetPtonA(AF_INET, qPrintable(address.netmask().toString()),
-                &subnetMaskBinary) != 1) {
+  if (InetPtonA(AF_INET, qPrintable(addr.netmask().toString()), &inMask) != 1) {
     return 0;
   }
   // Add IP address and subnet mask
-  DWORD dwResult =
-      AddIPAddress(ipAddrBinary.S_un.S_addr, subnetMaskBinary.S_un.S_addr,
-                   ifindex, &nteContext, &nteInstance);
+  DWORD dwResult = AddIPAddress(inAddr.S_un.S_addr, inMask.S_un.S_addr, ifindex,
+                                &nteContext, &nteInstance);
   if (dwResult != NO_ERROR) {
     WindowsUtils::windowsLog("WELP, failed to add ip address to adapter");
     return 0;
   }
   return nteContext;
 }
+
 /**
  * @brief
  *
@@ -93,7 +91,7 @@ ulong setIPv4AddressAndMask(NET_IFINDEX ifindex, const IPAddress address) {
  * @param ipAddress - Address and NetMask of the Adapter
  * @return bool - If the assignment was successful
  */
-bool setIPv6AddressAndMask(NET_LUID luid, const IPAddress ipAddress) {
+bool setIPv6AddressAndMask(NET_LUID luid, const IPAddress& ipAddress) {
   MIB_UNICASTIPADDRESS_ROW row;
   SOCKADDR_IN6 sockaddr = {};
   sockaddr.sin6_family = AF_INET6;

--- a/src/utils/interfaceconfig.cpp
+++ b/src/utils/interfaceconfig.cpp
@@ -33,7 +33,7 @@ QJsonObject InterfaceConfig::toJson() const {
   QJsonArray allowedIPAddesses;
   for (const IPAddress& i : m_allowedIPAddressRanges) {
     QJsonObject range;
-    range.insert("address", QJsonValue(static_cast<const QHostAddress&>(i).toString()));
+    range.insert("address", QJsonValue(i.toHostString()));
     range.insert("range", QJsonValue((double)i.prefixLength()));
     range.insert("isIpv6",
                  QJsonValue(i.protocol() == QAbstractSocket::IPv6Protocol));

--- a/src/utils/interfaceconfig.cpp
+++ b/src/utils/interfaceconfig.cpp
@@ -33,10 +33,10 @@ QJsonObject InterfaceConfig::toJson() const {
   QJsonArray allowedIPAddesses;
   for (const IPAddress& i : m_allowedIPAddressRanges) {
     QJsonObject range;
-    range.insert("address", QJsonValue(i.address().toString()));
+    range.insert("address", QJsonValue(static_cast<const QHostAddress&>(i).toString()));
     range.insert("range", QJsonValue((double)i.prefixLength()));
     range.insert("isIpv6",
-                 QJsonValue(i.type() == QAbstractSocket::IPv6Protocol));
+                 QJsonValue(i.protocol() == QAbstractSocket::IPv6Protocol));
     allowedIPAddesses.append(range);
   };
   json.insert("allowedIPAddressRanges", allowedIPAddesses);

--- a/src/utils/ipaddress.cpp
+++ b/src/utils/ipaddress.cpp
@@ -55,7 +55,7 @@ IPAddress::IPAddress(const QHostAddress& address) : QHostAddress(address) {
 
   if (address.protocol() == QAbstractSocket::IPv4Protocol) {
     m_prefixLength = 32;
-  } else if(address.protocol() == QAbstractSocket::IPv6Protocol) {
+  } else if (address.protocol() == QAbstractSocket::IPv6Protocol) {
     m_prefixLength = 128;
   } else if (address.isNull()) {
     m_prefixLength = -1;
@@ -87,10 +87,6 @@ IPAddress::~IPAddress() { MZ_COUNT_DTOR(IPAddress); }
 
 QString IPAddress::toString() const {
   return QString("%1/%2").arg(toHostString()).arg(m_prefixLength);
-}
-
-QString IPAddress::toHostString() const  {
-  return reinterpret_cast<const QHostAddress*>(this)->toString();
 }
 
 QHostAddress IPAddress::netmask() const {
@@ -126,7 +122,7 @@ QHostAddress IPAddress::hostmask() const {
     }
     return QHostAddress(rawHostmask);
   }
-  
+
   if (protocol() == QAbstractSocket::IPv4Protocol) {
     if (m_prefixLength < 32) {
       return QHostAddress(0xffffffff >> m_prefixLength);
@@ -151,9 +147,9 @@ QHostAddress IPAddress::broadcastAddress() const {
     if (m_prefixLength % 8) {
       rawAddress[m_prefixLength / 8] |= 0xFF >> (m_prefixLength % 8);
     }
-    return QHostAddress(rawAddress);    
+    return QHostAddress(rawAddress);
   }
-  
+
   if (protocol() == QAbstractSocket::IPv4Protocol) {
     quint32 rawAddress = toIPv4Address();
     if (m_prefixLength < 32) {
@@ -161,7 +157,7 @@ QHostAddress IPAddress::broadcastAddress() const {
     }
     return QHostAddress(rawAddress);
   }
-  
+
   return QHostAddress();
 }
 

--- a/src/utils/ipaddress.cpp
+++ b/src/utils/ipaddress.cpp
@@ -14,27 +14,25 @@
 
 IPAddress::IPAddress() { MZ_COUNT_CTOR(IPAddress); }
 
-IPAddress::IPAddress(const QString& ip) {
+IPAddress::IPAddress(const QString& ip) : QHostAddress() {
   MZ_COUNT_CTOR(IPAddress);
   if (ip.contains("/")) {
     QPair<QHostAddress, int> p = QHostAddress::parseSubnet(ip);
-    m_address = p.first;
+    *reinterpret_cast<QHostAddress*>(this) = p.first;
     m_prefixLength = p.second;
   } else {
-    m_address = QHostAddress(ip);
+    setAddress(ip);
     m_prefixLength = 999999;
   }
 
-  if (m_address.protocol() == QAbstractSocket::IPv4Protocol) {
+  if (protocol() == QAbstractSocket::IPv4Protocol) {
     if (m_prefixLength >= 32) {
       m_prefixLength = 32;
     }
-  } else if (m_address.protocol() == QAbstractSocket::IPv6Protocol) {
+  } else if (protocol() == QAbstractSocket::IPv6Protocol) {
     if (m_prefixLength >= 128) {
       m_prefixLength = 128;
     }
-  } else {
-    Q_ASSERT(false);
   }
 }
 
@@ -46,122 +44,145 @@ IPAddress::IPAddress(const IPAddress& other) {
 IPAddress& IPAddress::operator=(const IPAddress& other) {
   if (this == &other) return *this;
 
-  m_address = other.m_address;
+  *reinterpret_cast<QHostAddress*>(this) = other;
   m_prefixLength = other.m_prefixLength;
 
   return *this;
 }
 
-IPAddress::IPAddress(const QHostAddress& address) : m_address(address) {
+IPAddress::IPAddress(const QHostAddress& address) : QHostAddress(address) {
   MZ_COUNT_CTOR(IPAddress);
 
   if (address.protocol() == QAbstractSocket::IPv4Protocol) {
     m_prefixLength = 32;
-  } else {
-    Q_ASSERT(address.protocol() == QAbstractSocket::IPv6Protocol);
+  } else if(address.protocol() == QAbstractSocket::IPv6Protocol) {
     m_prefixLength = 128;
+  } else if (address.isNull()) {
+    m_prefixLength = -1;
   }
 }
 
 IPAddress::IPAddress(const QHostAddress& address, int prefixLength)
-    : m_address(address), m_prefixLength(prefixLength) {
+    : QHostAddress(address), m_prefixLength(prefixLength) {
   MZ_COUNT_CTOR(IPAddress);
 
-  if (address.protocol() == QAbstractSocket::IPv4Protocol) {
-    Q_ASSERT(prefixLength >= 0 && prefixLength <= 32);
-  } else {
-    Q_ASSERT(address.protocol() == QAbstractSocket::IPv6Protocol);
-    Q_ASSERT(prefixLength >= 0 && prefixLength <= 128);
+  if (m_prefixLength < 0) {
+    clear();
+  } else if (address.protocol() == QAbstractSocket::IPv4Protocol) {
+    if (m_prefixLength > 32) {
+      m_prefixLength = -1;
+      clear();
+    }
+  } else if (address.protocol() == QAbstractSocket::IPv6Protocol) {
+    if (m_prefixLength > 128) {
+      m_prefixLength = -1;
+      clear();
+    }
+  } else if (address.isNull()) {
+    m_prefixLength = -1;
   }
 }
 
 IPAddress::~IPAddress() { MZ_COUNT_DTOR(IPAddress); }
 
-QAbstractSocket::NetworkLayerProtocol IPAddress::type() const {
-  return m_address.protocol();
+QString IPAddress::toString() const {
+  return QString("%1/%2").arg(toHostString()).arg(m_prefixLength);
+}
+
+QString IPAddress::toHostString() const  {
+  return reinterpret_cast<const QHostAddress*>(this)->toString();
 }
 
 QHostAddress IPAddress::netmask() const {
-  if (m_address.protocol() == QAbstractSocket::IPv6Protocol) {
+  if ((protocol() == QAbstractSocket::IPv6Protocol) &&
+      (m_prefixLength <= 128)) {
     Q_IPV6ADDR rawNetmask = {0};
-    Q_ASSERT(m_prefixLength <= 128);
     memset(&rawNetmask, 0xff, m_prefixLength / 8);
     if (m_prefixLength % 8) {
       rawNetmask[m_prefixLength / 8] = 0xFF ^ (0xFF >> (m_prefixLength % 8));
     }
     return QHostAddress(rawNetmask);
-  } else if (m_address.protocol() == QAbstractSocket::IPv4Protocol) {
+  }
+
+  if ((protocol() == QAbstractSocket::IPv4Protocol) && (m_prefixLength <= 32)) {
     quint32 rawNetmask = 0xffffffff;
-    Q_ASSERT(m_prefixLength <= 32);
     if (m_prefixLength < 32) {
       rawNetmask ^= (0xffffffff >> m_prefixLength);
     }
     return QHostAddress(rawNetmask);
-  } else {
-    return QHostAddress();
   }
+
+  return QHostAddress();
 }
 
 QHostAddress IPAddress::hostmask() const {
-  if (m_address.protocol() == QAbstractSocket::IPv6Protocol) {
+  if ((protocol() == QAbstractSocket::IPv6Protocol) &&
+      (m_prefixLength <= 128)) {
     Q_IPV6ADDR rawHostmask = {0};
     int offset = (m_prefixLength + 7) / 8;
-    Q_ASSERT(m_prefixLength <= 128);
     memset(&rawHostmask[offset], 0xff, sizeof(rawHostmask) - offset);
     if (m_prefixLength % 8) {
       rawHostmask[m_prefixLength / 8] = 0xFF >> (m_prefixLength % 8);
     }
     return QHostAddress(rawHostmask);
-  } else if (m_address.protocol() == QAbstractSocket::IPv4Protocol) {
+  }
+  
+  if (protocol() == QAbstractSocket::IPv4Protocol) {
     if (m_prefixLength < 32) {
       return QHostAddress(0xffffffff >> m_prefixLength);
     } else {
       quint32 zero = 0;
       return QHostAddress(zero);
     }
-  } else {
-    return QHostAddress();
   }
+  
+  return QHostAddress();
 }
 
 QHostAddress IPAddress::broadcastAddress() const {
-  if (m_address.protocol() == QAbstractSocket::IPv6Protocol) {
-    Q_IPV6ADDR rawAddress = m_address.toIPv6Address();
+  if (protocol() == QAbstractSocket::IPv6Protocol) {
+    Q_IPV6ADDR rawAddress = toIPv6Address();
+    if (m_prefixLength >= 128) {
+      return QHostAddress(rawAddress);
+    }
+
     int offset = (m_prefixLength + 7) / 8;
     memset(&rawAddress[offset], 0xff, sizeof(rawAddress) - offset);
     if (m_prefixLength % 8) {
       rawAddress[m_prefixLength / 8] |= 0xFF >> (m_prefixLength % 8);
     }
-    return QHostAddress(rawAddress);
-  } else if (m_address.protocol() == QAbstractSocket::IPv4Protocol) {
-    quint32 rawAddress = m_address.toIPv4Address();
+    return QHostAddress(rawAddress);    
+  }
+  
+  if (protocol() == QAbstractSocket::IPv4Protocol) {
+    quint32 rawAddress = toIPv4Address();
     if (m_prefixLength < 32) {
       rawAddress |= (0xffffffff >> m_prefixLength);
     }
     return QHostAddress(rawAddress);
-  } else {
-    return QHostAddress();
   }
+  
+  return QHostAddress();
 }
 
 bool IPAddress::overlaps(const IPAddress& other) const {
   if (m_prefixLength < other.m_prefixLength) {
-    return contains(other.m_address);
+    return contains(other);
   } else {
-    return other.contains(m_address);
+    return other.contains(*this);
   }
 }
 
 bool IPAddress::contains(const QHostAddress& address) const {
-  if (address.protocol() != m_address.protocol()) {
+  if (address.protocol() != protocol()) {
     return false;
   }
   if (m_prefixLength == 0) {
     return true;
   }
 
-  if (m_address.protocol() == QAbstractSocket::IPv6Protocol) {
-    Q_IPV6ADDR a = m_address.toIPv6Address();
+  if (protocol() == QAbstractSocket::IPv6Protocol) {
+    Q_IPV6ADDR a = toIPv6Address();
     Q_IPV6ADDR b = address.toIPv6Address();
     int bytes = m_prefixLength / 8;
     if (bytes > 0) {
@@ -178,8 +199,8 @@ bool IPAddress::contains(const QHostAddress& address) const {
     return true;
   }
 
-  if (m_address.protocol() == QAbstractSocket::IPv4Protocol) {
-    quint32 diff = m_address.toIPv4Address() ^ address.toIPv4Address();
+  if (protocol() == QAbstractSocket::IPv4Protocol) {
+    quint32 diff = toIPv4Address() ^ address.toIPv4Address();
     if (m_prefixLength < 32) {
       diff >>= (32 - m_prefixLength);
     }
@@ -190,50 +211,47 @@ bool IPAddress::contains(const QHostAddress& address) const {
 }
 
 bool IPAddress::operator==(const IPAddress& other) const {
-  return m_address == other.m_address && m_prefixLength == other.m_prefixLength;
+  const QHostAddress* hostpart = reinterpret_cast<const QHostAddress*>(this);
+  return hostpart->isEqual(other) && m_prefixLength == other.m_prefixLength;
 }
 
 bool IPAddress::subnetOf(const IPAddress& other) const {
-  if (other.m_address.protocol() != m_address.protocol()) {
+  if (other.protocol() != this->protocol()) {
     return false;
   }
   if (m_prefixLength < other.m_prefixLength) {
     return false;
   }
 
-  return other.contains(m_address);
+  return other.contains(*this);
 }
 
 QList<IPAddress> IPAddress::subnets() const {
   QList<IPAddress> list;
 
-  if (m_address.protocol() == QAbstractSocket::IPv4Protocol) {
+  if (protocol() == QAbstractSocket::IPv4Protocol) {
     if (m_prefixLength >= 32) {
       list.append(*this);
       return list;
     }
 
-    quint32 rawAddress = m_address.toIPv4Address();
+    quint32 rawAddress = toIPv4Address();
     list.append(IPAddress(QHostAddress(rawAddress), m_prefixLength + 1));
 
     rawAddress |= (0x80000000 >> m_prefixLength);
     list.append(IPAddress(QHostAddress(rawAddress), m_prefixLength + 1));
+  } else if (protocol() == QAbstractSocket::IPv6Protocol) {
+    if (m_prefixLength >= 128) {
+      list.append(*this);
+      return list;
+    }
 
-    return list;
+    Q_IPV6ADDR rawAddress = toIPv6Address();
+    list.append(IPAddress(QHostAddress(rawAddress), m_prefixLength + 1));
+
+    rawAddress[m_prefixLength / 8] |= (0x80 >> (m_prefixLength % 8));
+    list.append(IPAddress(QHostAddress(rawAddress), m_prefixLength + 1));
   }
-
-  Q_ASSERT(m_address.protocol() == QAbstractSocket::IPv6Protocol);
-
-  if (m_prefixLength >= 128) {
-    list.append(*this);
-    return list;
-  }
-
-  Q_IPV6ADDR rawAddress = m_address.toIPv6Address();
-  list.append(IPAddress(QHostAddress(rawAddress), m_prefixLength + 1));
-
-  rawAddress[m_prefixLength / 8] |= (0x80 >> (m_prefixLength % 8));
-  list.append(IPAddress(QHostAddress(rawAddress), m_prefixLength + 1));
 
   return list;
 }

--- a/src/utils/ipaddress.cpp
+++ b/src/utils/ipaddress.cpp
@@ -131,7 +131,7 @@ QHostAddress IPAddress::hostmask() const {
       return QHostAddress(zero);
     }
   }
-  
+
   return QHostAddress();
 }
 

--- a/src/utils/ipaddress.h
+++ b/src/utils/ipaddress.h
@@ -21,7 +21,7 @@ class IPAddress final : public QHostAddress {
   ~IPAddress();
 
   QString toString() const;
-  QString toHostString() const;
+  QString toHostString() const { return QHostAddress::toString(); }
   int prefixLength() const { return m_prefixLength; }
   QHostAddress netmask() const;
   QHostAddress hostmask() const;

--- a/src/utils/ipaddress.h
+++ b/src/utils/ipaddress.h
@@ -7,7 +7,7 @@
 
 #include <QHostAddress>
 
-class IPAddress final {
+class IPAddress final : public QHostAddress {
  public:
   static QList<IPAddress> excludeAddresses(const QList<IPAddress>& sourceList,
                                            const QList<IPAddress>& excludeList);
@@ -20,11 +20,8 @@ class IPAddress final {
   IPAddress& operator=(const IPAddress& other);
   ~IPAddress();
 
-  QString toString() const {
-    return QString("%1/%2").arg(m_address.toString()).arg(m_prefixLength);
-  }
-
-  const QHostAddress& address() const { return m_address; }
+  QString toString() const;
+  QString toHostString() const;
   int prefixLength() const { return m_prefixLength; }
   QHostAddress netmask() const;
   QHostAddress hostmask() const;
@@ -43,18 +40,15 @@ class IPAddress final {
 
   QList<IPAddress> excludeAddresses(const IPAddress& ip) const;
 
-  QAbstractSocket::NetworkLayerProtocol type() const;
-
   static QList<IPAddress> lanAddressRanges();
 
  private:
-  QHostAddress m_address;
   int m_prefixLength;
 };
 
 inline size_t qHash(const IPAddress& key, size_t seed) {
-  const QHostAddress& address = key.address();
-  return qHash(address, seed) ^ key.prefixLength();
+  const QHostAddress& hostpart = static_cast<const QHostAddress&>(key);
+  return qHash(hostpart, seed) ^ key.prefixLength();
 }
 
 #endif  // IPADDRESS_H

--- a/src/utils/tests/testipaddress.cpp
+++ b/src/utils/tests/testipaddress.cpp
@@ -90,7 +90,7 @@ void TestIpAddress::basic() {
   IPAddress ipAddress = IPAddress(input);
 
   QFETCH(QString, address);
-  QCOMPARE(ipAddress.address().toString(), address);
+  QCOMPARE(static_cast<QHostAddress>(ipAddress).toString(), address);
   QFETCH(int, prefixLength);
   QCOMPARE(ipAddress.prefixLength(), prefixLength);
   QFETCH(QString, netmask);
@@ -99,6 +99,50 @@ void TestIpAddress::basic() {
   QCOMPARE(ipAddress.hostmask().toString(), hostmask);
   QFETCH(QString, broadcastAddress);
   QCOMPARE(ipAddress.broadcastAddress().toString(), broadcastAddress);
+}
+
+void TestIpAddress::invalid_data() {
+  QTest::addColumn<QString>("input");
+
+  QTest::addRow("junk ipv4 address") << "192.168.1.abc/24";
+  QTest::addRow("junk ipv4 prefix") << "192.168.1.123/4foo";
+  QTest::addRow("negative ipv4 prefix") << "192.168.1.123/-42";
+  QTest::addRow("overflow ipv4 prefix") << "192.168.1.132/33";
+
+  QTest::addRow("junk ipv6 address") << "fe80::123z/64";
+  QTest::addRow("junk ipv6 prefix") << "fe80::1234/4foo";
+  QTest::addRow("negative ipv6 prefix") << "fe80::1234/-42";
+  QTest::addRow("overflow ipv6 prefix") << "fe80::1234/129";
+}
+
+void TestIpAddress::invalid() {
+  QFETCH(QString, input);
+
+  // Initialize as a string. 
+  IPAddress ipAddress = IPAddress(input);
+  QVERIFY(ipAddress.prefixLength() < 0);
+  QVERIFY(ipAddress.isNull());
+  QVERIFY(ipAddress.netmask().isNull());
+  QVERIFY(ipAddress.hostmask().isNull());
+  QVERIFY(ipAddress.broadcastAddress().isNull());
+
+  // Manually split it and try as parts and check again.
+  qsizetype i = input.indexOf('/');
+  if (i < 0) {
+    return;
+  }
+  bool okay = false;
+  int plen = input.mid(i+1).toInt(&okay);
+  if (!okay) {
+    plen = -1;
+  }
+
+  IPAddress ipAddress2 = IPAddress(QHostAddress(input.first(i)), plen);
+  QVERIFY(ipAddress2.prefixLength() < 0);
+  QVERIFY(ipAddress2.isNull());
+  QVERIFY(ipAddress2.netmask().isNull());
+  QVERIFY(ipAddress2.hostmask().isNull());
+  QVERIFY(ipAddress2.broadcastAddress().isNull());
 }
 
 void TestIpAddress::overlaps_data() {

--- a/src/utils/tests/testipaddress.cpp
+++ b/src/utils/tests/testipaddress.cpp
@@ -118,7 +118,7 @@ void TestIpAddress::invalid_data() {
 void TestIpAddress::invalid() {
   QFETCH(QString, input);
 
-  // Initialize as a string. 
+  // Initialize as a string.
   IPAddress ipAddress = IPAddress(input);
   QVERIFY(ipAddress.prefixLength() < 0);
   QVERIFY(ipAddress.isNull());
@@ -132,7 +132,7 @@ void TestIpAddress::invalid() {
     return;
   }
   bool okay = false;
-  int plen = input.mid(i+1).toInt(&okay);
+  int plen = input.mid(i + 1).toInt(&okay);
   if (!okay) {
     plen = -1;
   }

--- a/src/utils/tests/testipaddress.h
+++ b/src/utils/tests/testipaddress.h
@@ -15,6 +15,9 @@ class TestIpAddress final : public QObject, TestHelper<TestIpAddress> {
   void basic_data();
   void basic();
 
+  void invalid_data();
+  void invalid();
+
   void overlaps_data();
   void overlaps();
 


### PR DESCRIPTION
## Description
The `IPAddress` class has long been a bit awkward. It's name is somewhat misleading as it actually holds an IP range or prefix, and nearly all of what the class is actually just a wrapper around a `QHostAddress`. So let's put a bit of energy into cleaning things up a bit.

This PR attempts to eliminate a couple of wrapper functions by refactoring `IPAddress` to become an inherited subclass of `QHostAddress`, and adds a bunch of input validation to the constructor.

## Reference
JIRA Issue: [VPN-7630](https://mozilla-hub.atlassian.net/browse/VPN-7630)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] If bug/feature is at all notable, I've added a draft release note as a comment in `addons/strings.yaml`.
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-7630]: https://mozilla-hub.atlassian.net/browse/VPN-7630?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ