### PR TITLE
Obfuscation features part 3 - Enable obfuscation features on Windows

### DIFF
--- a/src/cmake/windows.cmake
+++ b/src/cmake/windows.cmake
@@ -72,7 +72,20 @@ target_sources(mozillavpn PRIVATE
      ${CMAKE_CURRENT_SOURCE_DIR}/update/balrog.h
 )
 
+# Build the obfuscator binary.
+add_rust_binary(mozillavpn-obfuscator
+    PACKAGE_DIR ${CMAKE_SOURCE_DIR}/obfuscators
+    BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/obfuscators_target
+    CRATE_NAME obfuscators
+    BIN_NAME mozillavpn-obfuscator
+    CARGO_ENV CARGO_TARGET_DIR=${CMAKE_CURRENT_BINARY_DIR}/obfuscators_target
+)
+add_dependencies(mozillavpn mozillavpn-obfuscator)
+
 install(TARGETS mozillavpn DESTINATION .)
+
+# Install the obfuscator binary next to the main application.
+install(PROGRAMS ${mozillavpn-obfuscator_EXECUTABLE} DESTINATION .)
 install(FILES $<TARGET_PDB_FILE:mozillavpn> DESTINATION . OPTIONAL)
 
 # Deploy Qt runtime dependencies during installation.

--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -157,6 +157,19 @@ bool Daemon::activate(const InterfaceConfig& config) {
                      << config.m_obfuscationMethod;
       return false;
     }
+#if defined(MZ_WINDOWS)
+    // Add exclusion route for exit server to prevent loopbacks
+    {
+      QList<IPAddress> obfuscatorServer;
+      if (!config.m_serverIpv4AddrIn.isEmpty()) {
+        obfuscatorServer.append(IPAddress(config.m_serverIpv4AddrIn));
+      }
+      if (!config.m_serverIpv6AddrIn.isEmpty()) {
+        obfuscatorServer.append(IPAddress(config.m_serverIpv6AddrIn));
+      }
+      wgutils()->excludeLocalNetworks(obfuscatorServer);
+    }
+#endif
     peerConfig.m_serverIpv4AddrIn = "127.0.0.1";
     // The obfuscator only binds 127.0.0.1, so clear the IPv6 endpoint to keep
     // WireGuard from selecting an [::1]
@@ -501,6 +514,19 @@ bool Daemon::switchServer(const InterfaceConfig& config) {
                      << config.m_obfuscationMethod;
       return false;
     }
+#if defined(MZ_WINDOWS)
+    // Add exclusion route for exit server to prevent loopbacks
+    {
+      QList<IPAddress> obfuscatorServer;
+      if (!config.m_serverIpv4AddrIn.isEmpty()) {
+        obfuscatorServer.append(IPAddress(config.m_serverIpv4AddrIn));
+      }
+      if (!config.m_serverIpv6AddrIn.isEmpty()) {
+        obfuscatorServer.append(IPAddress(config.m_serverIpv6AddrIn));
+      }
+      wgutils()->excludeLocalNetworks(obfuscatorServer);
+    }
+#endif
     peerConfig.m_serverIpv4AddrIn = "127.0.0.1";
     // The obfuscator only binds 127.0.0.1, so clear the IPv6 endpoint to keep
     // WireGuard from selecting an [::1]

--- a/src/feature/features.h
+++ b/src/feature/features.h
@@ -242,7 +242,7 @@ inline constexpr ConstantFeature freeTrial = {
 inline constexpr ConstantFeature obfuscationLwo = {
     .id = "obfuscationLwo",
     .name = "LWO obfuscation",
-    .supported = Platform::linux_ || Platform::android,
+    .supported = Platform::linux_ || Platform::android || Platform::windows,
 };
 
 inline constexpr ConstantFeature obfuscationMasque = {

--- a/src/feature/features.h
+++ b/src/feature/features.h
@@ -260,7 +260,7 @@ inline constexpr ConstantFeature obfuscationShadowsocks = {
 inline constexpr ConstantFeature obfuscationUdpOverTcp = {
     .id = "obfuscationUdpOverTcp",
     .name = "UDP over TCP",
-    .supported = Platform::linux_ || Platform::android,
+    .supported = Platform::linux_ || Platform::android || Platform::windows,
 };
 
 inline const OverridableFeature replacerAddon = {

--- a/windows/installer/MozillaVPN.wxs
+++ b/windows/installer/MozillaVPN.wxs
@@ -78,6 +78,7 @@
         <File Source="mullvad-split-tunnel.inf" />
         <File Source="mullvad-split-tunnel.sys" />
         <File Source="mozillavpn.json" />
+        <File Source="mozillavpn-obfuscator.exe" />
 
         <!-- Broker Service -->
         <ServiceInstall


### PR DESCRIPTION
## Description

Enable obfuscation features on Windows:
- add the obfuscator daemon to the windows build and installer
- use `excludeLocalNetworks` to protect the exit server and avoid loopbacks

## Reference

[Jira Issue](https://mozilla-hub.atlassian.net/browse/VPN-7584)

## Checklist
    
- [x] My code follows the style guidelines for this project
- [ ] If bug/feature is at all notable, I've added a draft release note as a comment in `addons/strings.yaml`.
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
