### PR TITLE
Preload and pin wireguard.dll before calling lockDownDLLSearchPath

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -47,6 +47,12 @@ Q_DECL_EXPORT int main(int argc, char* argv[]) {
       std::cout.clear();
     }
   }
+  // wireguard.dll is signed by WireGuard LLC so it cannot be loaded
+  // once the Microsoft signed-only policy is enabled.
+  // Preload it when running as windowsdaemon.
+  if (argc > 1 && QString(argv[1]) == "windowsdaemon") {
+    WindowsUtils::preloadLibrary("wireguard.dll");
+  }
   WindowsUtils::lockDownDLLSearchPath();
 #endif
 

--- a/src/platforms/windows/windowsutils.cpp
+++ b/src/platforms/windows/windowsutils.cpp
@@ -178,3 +178,24 @@ void WindowsUtils::lockDownDLLSearchPath() {
   sig.MicrosoftSignedOnly = 1;
   SetProcessMitigationPolicy(ProcessSignaturePolicy, &sig, sizeof(sig));
 }
+
+bool WindowsUtils::preloadLibrary(const QString& name) {
+  HMODULE handle = LoadLibraryExW(
+      (const wchar_t*)name.utf16(), nullptr,
+      LOAD_LIBRARY_SEARCH_APPLICATION_DIR | LOAD_LIBRARY_SEARCH_SYSTEM32);
+  if (handle == nullptr) {
+    windowsLog(QString("Failed to preload %1").arg(name));
+    return false;
+  }
+
+  // Pin the module so it stays mapped until the process exits.
+  HMODULE pinned = nullptr;
+  if (!GetModuleHandleExW(GET_MODULE_HANDLE_EX_FLAG_PIN,
+                          (const wchar_t*)name.utf16(), &pinned)) {
+    windowsLog(QString("Failed to pin %1").arg(name));
+    return false;
+  }
+
+  windowsLog(QString("Preloaded %1").arg(name));
+  return true;
+}

--- a/src/platforms/windows/windowsutils.h
+++ b/src/platforms/windows/windowsutils.h
@@ -20,6 +20,14 @@ class WindowsUtils final {
 
   static void lockDownDLLSearchPath();
 
+  /**
+   * @brief Maps a DLL keeps it loaded for the lifetime of the process.
+   *
+   * This must be called before lockDownDLLSearchPath() for libraries that are
+   * not signed by Microsoft.
+   */
+  static bool preloadLibrary(const QString& name);
+
   // Returns the major version of Windows
   static QString windowsVersion();
 


### PR DESCRIPTION
## Description

wireguard.dll is not signed by Microsoft, preload and [pin](https://learn.microsoft.com/en-us/windows/win32/api/libloaderapi/nf-libloaderapi-getmodulehandleexw#get_module_handle_ex_flag_pin-0x00000001) it before turning on signature enforcement.


## Reference

    i.e Jira or Github issue URL

## Checklist
    
- [x] My code follows the style guidelines for this project
- [ ] If bug/feature is at all notable, I've added a draft release note as a comment in `addons/strings.yaml`.
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
