### PR TITLE
VPN-7687: Attempt a fix for WASM functional testing issue

### DIFF
--- a/src/platforms/wasm/wasmauthenticationlistener.cpp
+++ b/src/platforms/wasm/wasmauthenticationlistener.cpp
@@ -45,6 +45,7 @@ void WasmAuthenticationListener::start(Task* task, const QString& codeChallenge,
 
   // Unless we're in an automated test environment, mock out a successful auth.
   if (!isTesting()) {
+    logger.debug() << "Not in testing";
     QTimer* timer = new QTimer(this);
     connect(timer, &QTimer::timeout, this,
             [this]() { emit completed("WASM"); });

--- a/tests/functional/helper.js
+++ b/tests/functional/helper.js
@@ -413,7 +413,7 @@ module.exports = {
         });
         req.end();
       });
-    } else if (process.platform == 'linux') {
+    } else if (process.platform == 'linux' && !this.runningOnWasm()) {
       // On Windows and Linux, launching the client with the deep-link as an
       // argument will pass it to the test process using the EventListener.
       setup.startAndDetach(['ui', 'mozilla-vpn://login/success?code=the_code']);


### PR DESCRIPTION
## Description

WASM tests are sometimes failing. It seems like this is on login. I'm not quite sure why, but it seems like it could be getting caught here. This shouldn't have any bad effects, and we can see if it makes a difference.

## Reference

VPN-7687

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] If bug/feature is at all notable, I've added a draft release note as a comment in `addons/strings.yaml`.
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
