### PR TITLE
VPN-7702 and VPN-7703: Messages for users being forced to migrate to a web-auth-era client

### DIFF
--- a/addons/message_mandatory_update_to_web_auth_1/enable.js
+++ b/addons/message_mandatory_update_to_web_auth_1/enable.js
@@ -1,0 +1,56 @@
+(function(api) {
+// "Extra" fields are used only to get a localized string.
+api.addon.composer.remove('extra_1');
+
+if (('updateTime' in api.settings)) {
+  api.addon.date = (api.settings.updateTime.getTime() / 1000);
+}
+
+
+// Macos v2.16.0 requires a web-based update.
+if (api.env.platform === 'macos' && api.env.versionString === '2.16.0') {
+  api.addon.setTitle(
+      'message.message_mandatory_update_to_web_auth_1.block.extra_1',
+      'Download the new Mozilla VPN');
+  api.addon.composer.remove('c_3');
+  return;
+}
+
+// Windows v2.10 to v2.12 do require a web-based update,
+// with the exception on v2.11.1.
+if (api.env.platform !== 'windows' || api.env.versionString === '2.11.1') {
+  api.addon.composer.remove('c_4');
+  return;
+}
+
+const parts = api.env.versionString.split('.');
+
+// No idea which version we are in...
+if (parts.length < 3) {
+  api.addon.composer.remove('c_4');
+  return;
+}
+
+const version = parts.map(a => parseInt(a, 10));
+
+function versionCompare(a, b) {
+  for (let i = 0; i < 3; ++i) {
+    if (a[i] != b[i]) {
+      return a[i] > b[i] ? -1 : 1;
+    }
+  }
+  return 0;
+}
+
+if (versionCompare([2, 13, 0], version) >= 0 ||
+    versionCompare([2, 10, 0], version) < -1) {
+  api.addon.composer.remove('c_4');
+  return;
+}
+
+api.addon.composer.remove('c_3');
+
+api.addon.setTitle(
+    'message.message_mandatory_update_to_web_auth_1.block.extra_1',
+    'Download the new Mozilla VPN');
+})

--- a/addons/message_mandatory_update_to_web_auth_1/getHelp.js
+++ b/addons/message_mandatory_update_to_web_auth_1/getHelp.js
@@ -1,0 +1,25 @@
+(function(api) {
+function versionCompare(a, b) {
+  for (let i = 0; i < 3; ++i) {
+    if (a[i] != b[i]) {
+      return a[i] > b[i] ? -1 : 1;
+    }
+  }
+  return 0;
+}
+
+const parts = api.env.versionString.split('.');
+
+const version = parts.map(a => parseInt(a, 10));
+
+// Post 2.16 API
+if (versionCompare([2, 16, 0], version) >= 0) {
+  api.navigator.requestScreen(api.vpn.ScreenGetHelp);
+  return;
+}
+// Pre 2.16 API
+else {
+  api.navigator.requestScreen(api.navigator.ScreenGetHelp);
+  return;
+}
+})

--- a/addons/message_mandatory_update_to_web_auth_1/manifest.json
+++ b/addons/message_mandatory_update_to_web_auth_1/manifest.json
@@ -1,0 +1,55 @@
+{
+  "api_version": "0.1",
+  "id": "message_mandatory_update_to_web_auth_1",
+  "name": "Action Required: Update to the latest version",
+  "type": "message",
+  "conditions": {
+    "max_client_version": "2.34.9",
+    "javascript": "osCheck.js"
+  },
+  "javascript": {
+    "enable": "enable.js"
+  },
+  "message": {
+    "date": 1789578000,
+    "usesSharedStrings": true,
+    "shortVersion": "2.40",
+    "id": "message_mandatory_update_to_web_auth_1",
+    "title": "vpn.mandatoryUpdate.title",
+    "subtitle": "vpn.mandatoryUpdate.body1",
+    "badge": "critical",
+    "blocks": [
+      {
+        "id": "c_2",
+        "type": "text",
+        "content": "vpn.mandatoryUpdate.body2"
+      },
+      {
+        "id": "c_3",
+        "type": "button",
+        "style": "primary",
+        "content": "vpn.commonStrings.updateButton",
+        "javascript": "update.js"
+      },
+      {
+        "id": "c_4",
+        "type": "button",
+        "style": "primary",
+        "content": "vpn.commonStrings.downloadButton",
+        "javascript": "updateWeb.js"
+      },
+      {
+        "id": "c_5",
+        "type": "button",
+        "style": "link",
+        "content": "vpn.commonStrings.getHelpButton",
+        "javascript": "getHelp.js"
+      },
+      {
+        "id": "extra_1",
+        "type": "text",
+        "content": "vpn.commonStrings.downloadTitle"
+      }
+    ]
+  }
+}

--- a/addons/message_mandatory_update_to_web_auth_1/osCheck.js
+++ b/addons/message_mandatory_update_to_web_auth_1/osCheck.js
@@ -1,0 +1,69 @@
+// show for:
+// 2.31.9 and earlier: macOS and Linux
+// 2.33.9 and earlier: Windows and iOS
+// 2.34.9 and earlier: Android
+
+// Disable all Android and iOS versions, and all macOS versions before 11
+(function(api, condition) {
+
+function versionCompare(a, b) {
+  for (let i = 0; i < 3; ++i) {
+    if (a[i] != b[i]) {
+      return a[i] > b[i] ? -1 : 1;
+    }
+  }
+  return 0;
+}
+
+function computeCondition() {
+  const parts = api.env.versionString.split('.');
+  const version = parts.map(a => parseInt(a, 10));
+
+  const isMacOS = (api.env.platform === 'macos');
+  const isLinux = (api.env.platform === 'linux');
+  if (isMacOS || isLinux) {
+    // Post 2.32
+    if (versionCompare([2, 32, 0], version) >= 0) {
+      condition.disable();
+      return;
+    }
+  }
+
+  const isIOS = (api.env.platform === 'ios');
+  const isWindows = (api.env.platform === 'windows');
+  if (isWindows || isIOS) {
+    // Post 2.34
+    if (versionCompare([2, 34, 0], version) >= 0) {
+      condition.disable();
+      return;
+    }
+  }
+
+  // Covers Android
+  // Additionally, we fail restrictive - any unknown or poorly-formed platform
+  //   must be on 2.35 or later (guaranteed okay on all platforms) to not see
+  //   message
+  // Post 2.35
+  if (versionCompare([2, 35, 0], version) >= 0) {
+    condition.disable();
+    return;
+  }
+
+  // We've confirme we're in a version that may require this addon. Now check
+  // the date.
+  let now = Date.now();
+  let endTime = 1791478800000  // 10am Pacific on Oct 8 2026
+
+  if (now >= endTime) {
+    condition.disable()
+  }
+  else {
+    condition.enable()
+    // Set callback - if app isn't closed, we need to turn off this addon at the
+    // appropriate time
+    api.setTimedCallback(endTime, () => computeCondition());
+  }
+}
+
+computeCondition();
+});

--- a/addons/message_mandatory_update_to_web_auth_1/update.js
+++ b/addons/message_mandatory_update_to_web_auth_1/update.js
@@ -1,0 +1,5 @@
+((api) => {
+  api.navigator.requestScreen(
+      'vpn' in api ? api.vpn.ScreenUpdateRecommended :
+                     api.navigator.ScreenUpdateRecommended);
+});

--- a/addons/message_mandatory_update_to_web_auth_1/updateWeb.js
+++ b/addons/message_mandatory_update_to_web_auth_1/updateWeb.js
@@ -1,0 +1,7 @@
+((api) => {
+  if ('openLink' in api.urlOpener) {
+    api.urlOpener.openLink(api.urlOpener.LinkUpdate);
+  } else {
+    api.urlOpener.openUrlLabel('update');
+  }
+});

--- a/addons/message_mandatory_update_to_web_auth_2/enable.js
+++ b/addons/message_mandatory_update_to_web_auth_2/enable.js
@@ -1,0 +1,56 @@
+(function(api) {
+// "Extra" fields are used only to get a localized string.
+api.addon.composer.remove('extra_1');
+
+if (('updateTime' in api.settings)) {
+  api.addon.date = (api.settings.updateTime.getTime() / 1000);
+}
+
+
+// Macos v2.16.0 requires a web-based update.
+if (api.env.platform === 'macos' && api.env.versionString === '2.16.0') {
+  api.addon.setTitle(
+      'message.message_mandatory_update_to_web_auth_2.block.extra_1',
+      'Download the new Mozilla VPN');
+  api.addon.composer.remove('c_3');
+  return;
+}
+
+// Windows v2.10 to v2.12 do require a web-based update,
+// with the exception on v2.11.1.
+if (api.env.platform !== 'windows' || api.env.versionString === '2.11.1') {
+  api.addon.composer.remove('c_4');
+  return;
+}
+
+const parts = api.env.versionString.split('.');
+
+// No idea which version we are in...
+if (parts.length < 3) {
+  api.addon.composer.remove('c_4');
+  return;
+}
+
+const version = parts.map(a => parseInt(a, 10));
+
+function versionCompare(a, b) {
+  for (let i = 0; i < 3; ++i) {
+    if (a[i] != b[i]) {
+      return a[i] > b[i] ? -1 : 1;
+    }
+  }
+  return 0;
+}
+
+if (versionCompare([2, 13, 0], version) >= 0 ||
+    versionCompare([2, 10, 0], version) < -1) {
+  api.addon.composer.remove('c_4');
+  return;
+}
+
+api.addon.composer.remove('c_3');
+
+api.addon.setTitle(
+    'message.message_mandatory_update_to_web_auth_2.block.extra_1',
+    'Download the new Mozilla VPN');
+})

--- a/addons/message_mandatory_update_to_web_auth_2/getHelp.js
+++ b/addons/message_mandatory_update_to_web_auth_2/getHelp.js
@@ -1,0 +1,25 @@
+(function(api) {
+function versionCompare(a, b) {
+  for (let i = 0; i < 3; ++i) {
+    if (a[i] != b[i]) {
+      return a[i] > b[i] ? -1 : 1;
+    }
+  }
+  return 0;
+}
+
+const parts = api.env.versionString.split('.');
+
+const version = parts.map(a => parseInt(a, 10));
+
+// Post 2.16 API
+if (versionCompare([2, 16, 0], version) >= 0) {
+  api.navigator.requestScreen(api.vpn.ScreenGetHelp);
+  return;
+}
+// Pre 2.16 API
+else {
+  api.navigator.requestScreen(api.navigator.ScreenGetHelp);
+  return;
+}
+})

--- a/addons/message_mandatory_update_to_web_auth_2/manifest.json
+++ b/addons/message_mandatory_update_to_web_auth_2/manifest.json
@@ -1,0 +1,55 @@
+{
+  "api_version": "0.1",
+  "id": "message_mandatory_update_to_web_auth_2",
+  "name": "Action required: Update to the latest version",
+  "type": "message",
+  "conditions": {
+    "max_client_version": "2.34.9",
+    "javascript": "osCheck.js"
+  },
+  "javascript": {
+    "enable": "enable.js"
+  },
+  "message": {
+    "date": 1791478800,
+    "usesSharedStrings": true,
+    "shortVersion": "2.40", 
+    "id": "message_mandatory_update_to_web_auth_2",
+    "title": "vpn.mandatoryUpdate.title",
+    "subtitle": "vpn.mandatoryUpdate.body1",
+    "badge": "critical",
+    "blocks": [
+      {
+        "id": "c_2",
+        "type": "text",
+        "content": "vpn.mandatoryUpdate.body2"
+      },
+      {
+        "id": "c_3",
+        "type": "button",
+        "style": "primary",
+        "content": "vpn.commonStrings.updateButton",
+        "javascript": "update.js"
+      },
+      {
+        "id": "c_4",
+        "type": "button",
+        "style": "primary",
+        "content": "vpn.commonStrings.downloadButton",
+        "javascript": "updateWeb.js"
+      },
+      {
+        "id": "c_5",
+        "type": "button",
+        "style": "link",
+        "content": "vpn.commonStrings.getHelpButton",
+        "javascript": "getHelp.js"
+      },
+      {
+        "id": "extra_1",
+        "type": "text",
+        "content": "vpn.commonStrings.downloadTitle"
+      }
+    ]
+  }
+}

--- a/addons/message_mandatory_update_to_web_auth_2/osCheck.js
+++ b/addons/message_mandatory_update_to_web_auth_2/osCheck.js
@@ -1,0 +1,69 @@
+// show for:
+// 2.31.9 and earlier: macOS and Linux
+// 2.33.9 and earlier: Windows and iOS
+// 2.34.9 and earlier: Android
+
+// Disable all Android and iOS versions, and all macOS versions before 11
+(function(api, condition) {
+
+function versionCompare(a, b) {
+  for (let i = 0; i < 3; ++i) {
+    if (a[i] != b[i]) {
+      return a[i] > b[i] ? -1 : 1;
+    }
+  }
+  return 0;
+}
+
+function computeCondition() {
+  const parts = api.env.versionString.split('.');
+  const version = parts.map(a => parseInt(a, 10));
+
+  const isMacOS = (api.env.platform === 'macos');
+  const isLinux = (api.env.platform === 'linux');
+  if (isMacOS || isLinux) {
+    // Post 2.32
+    if (versionCompare([2, 32, 0], version) >= 0) {
+      condition.disable();
+      return;
+    }
+  }
+
+  const isIOS = (api.env.platform === 'ios');
+  const isWindows = (api.env.platform === 'windows');
+  if (isWindows || isIOS) {
+    // Post 2.34
+    if (versionCompare([2, 34, 0], version) >= 0) {
+      condition.disable();
+      return;
+    }
+  }
+
+  // Covers Android
+  // Additionally, we fail restrictive - any unknown or poorly-formed platform
+  //   must be on 2.35 or later (guaranteed okay on all platforms) to not see
+  //   message
+  // Post 2.35
+  if (versionCompare([2, 35, 0], version) >= 0) {
+    condition.disable();
+    return;
+  }
+
+  // We've confirme we're in a version that may require this addon. Now check
+  // the date.
+  let now = Date.now();
+  let startTime = 1791478800000  // 10am Pacific on Oct 8 2026
+
+  if (now < startTime) {
+    condition.disable()
+    // Set callback - if app isn't closed, we need to turn on this addon at the
+    // appropriate time
+    api.setTimedCallback(startTime, () => computeCondition());
+  }
+  else {
+    condition.enable()
+  }
+}
+
+computeCondition();
+});

--- a/addons/message_mandatory_update_to_web_auth_2/update.js
+++ b/addons/message_mandatory_update_to_web_auth_2/update.js
@@ -1,0 +1,5 @@
+((api) => {
+  api.navigator.requestScreen(
+      'vpn' in api ? api.vpn.ScreenUpdateRecommended :
+                     api.navigator.ScreenUpdateRecommended);
+});

--- a/addons/message_mandatory_update_to_web_auth_2/updateWeb.js
+++ b/addons/message_mandatory_update_to_web_auth_2/updateWeb.js
@@ -1,0 +1,7 @@
+((api) => {
+  if ('openLink' in api.urlOpener) {
+    api.urlOpener.openLink(api.urlOpener.LinkUpdate);
+  } else {
+    api.urlOpener.openUrlLabel('update');
+  }
+});

--- a/addons/strings.yaml
+++ b/addons/strings.yaml
@@ -236,6 +236,18 @@ commonStrings:
     value: "[iOS] When on Airplane Mode, trying to start the VPN gives an error. However if starting via Siri or Shortcuts, the VPN would be turned on after Airplane Mode was deactivated. This no longer happens."
     comment: Bullet point with a specific update. Should have tag that indicates it applies to iOS platform.
 
+mandatoryUpdate:
+  title:
+    value: "Action required: Update to the latest version"
+    comment: Title of a message. Should make it clear the user must take action.
+  body1:
+    value: This version of Mozilla VPN will no longer be supported as of October 19, 2026.
+    comment: Line explaining end-of-life for some Mozilla VPN versions. Include the deadline date.
+  body2:
+    value: Please update to the latest version to continue using Mozilla VPN.
+    comment: Line asking users to update. This should be kind, yet firm. It should not include any language that implies this is optional.
+
+
 # Has not been used yet (from above)
 # 237updateMessage.bullet1
 


### PR DESCRIPTION
## Description

This shows an addon to users twice informing them of end-of-life.

Technical notes:
- Most of the addon pieces are copied verbatim from the typical "update" addons, such as those done in https://github.com/mozilla-mobile/mozilla-vpn-client/pull/11420:
  - `getHelp.js` - fully copied, no changes
  - `update.js` - fully copied, no changes
  - `updateWeb.js` - fully copied, no changes
  - `enable.js` - essentially copied, just had to update the two string IDs
  - `manifest.json` - all new, this is where some of the special stuff is (determines what we show for the addon)
  - `osCheck.js` - all new, this is where the rest of the special stuff is (determines whether we show addon). From testing, I learnd we need the long form date to check against here.
- As I discovered when working on https://github.com/mozilla-mobile/mozilla-vpn-client/pull/10524, we need to use two different (yet identical) addons to ensure we pop the message a second time. From that PR, in describing what happens if you try to use the same addon but re-enable it: `I found out that it has a bug - if you dismiss the message and re-launch the VPN, it will never resurface. (It works as expected if the client keeps running, and is never quit.) This is because in AddonMessage::create, we do an early return if the addon was already dismissed (if (messageStatus == MessageStatus::Dismissed) {   return nullptr; }). And I believe this is called before evaluating conditions, so the message never gets set up on the next launch.`
- It turns out `subtitle` is required is an addon. Luckily, we display subtitle as the first line of text, and that's why "body1" is assigned to subtitle here.
- `shortVersion` is also required when `usesSharedStrings` is `true`. This was a design decision I made to ensure we never accidentally put up a "what's new" or typical "update" addon without the needed `shortVersion`. (I could probably do this another way, now that I think of it. May do that in a separate PR.) For now, we include `shortVersion`, though it will not be used.
- I left a condition of `max_client_version` for a small performance boost for modern clients - it's quicker and cheaper to check `max_client_version` than run the javascript condition. And thus for sufficiently modern clients that we know are definitely okay, we don't have to run the JS.
- No `promo_text` because (as someone else pointed out when we were writing the copy) the versions that must be updated (and will see these addons) are old enough that none of them support this newer promo text feature. Thus, `promo_text` would have no result here.

I made a few executive decisions on the copy; I'm confirming these w/ product before we merge:
- Using the `Action required: Update to the latest version` for both addons. When I looked at the plain `Update to the latest version` title we discussed for the first one, in the messages list it basically looked identical to the typical update addon (which by definition, these users have ignored for months or years)
- Cutoff date is Oct 19th (must be settled now, as it's part of the string)
- First addon shown upon 2.40 release cycle, probably around September 16th (this can be changed later, it's just some code)
- Second addon shown on Oct 8, and first one turned off that day (this can be changed later, it's just some code)

<img width="161"  alt="Screenshot 157" src="https://github.com/user-attachments/assets/c39ea0e9-1cd5-4f3c-b409-2366e440c5a5" />

## Testing note
- Very helpful: Using the `set_version_override` inspector command followed by `reset_addons`.
- Additionally, you'll likely need to change the clock on the device.

## Reference

VPN-7702 and VPN-7703

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] If bug/feature is at all notable, I've added a draft release note as a comment in `addons/strings.yaml`.
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
