### PR TITLE
VPN-7754: Install socksproxy tool as a macOS launch agent

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,18 +170,18 @@ message("Using Qt version ${Qt6_VERSION}")
 add_definitions(-DQT_DEPRECATED_WARNINGS)
 add_definitions(-DQT_DISABLE_DEPRECATED_BEFORE=0x050F00)
 
-# VPN Client build targets
-add_subdirectory(src)
-add_subdirectory(lottie)
-add_subdirectory(nebula)
-add_subdirectory(addons)
-
 # Build the extension for desktop targets
 if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux" OR
    ${CMAKE_SYSTEM_NAME} STREQUAL "Windows" OR
    ${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
     add_subdirectory(extension)
 endif()
+
+# VPN Client build targets
+add_subdirectory(src)
+add_subdirectory(lottie)
+add_subdirectory(nebula)
+add_subdirectory(addons)
 
 if(NOT CMAKE_CROSSCOMPILING AND BUILD_TESTS)
     # Unit Tests

--- a/extension/socks5proxy/bin/CMakeLists.txt
+++ b/extension/socks5proxy/bin/CMakeLists.txt
@@ -56,6 +56,10 @@ elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
     install(TARGETS socksproxy)
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
     target_compile_definitions(socksproxy PRIVATE PROXY_OS_MACOS)
+    target_sources(socksproxy PRIVATE
+        macfwpolicy.cpp
+        macfwpolicy.h
+    )
 
     set_target_properties(socksproxy PROPERTIES
         OUTPUT_NAME "${BUILD_OSX_APP_IDENTIFIER}.socksproxy"

--- a/extension/socks5proxy/bin/CMakeLists.txt
+++ b/extension/socks5proxy/bin/CMakeLists.txt
@@ -54,10 +54,31 @@ elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
     endif()
 
     install(TARGETS socksproxy)
-else()
-    # TODO: This is currently pointless on macos, 
-    # so no point in shipping it.
+elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+    target_compile_definitions(socksproxy PRIVATE PROXY_OS_MACOS)
+
+    set_target_properties(socksproxy PROPERTIES
+        OUTPUT_NAME "${BUILD_OSX_APP_IDENTIFIER}.socksproxy"
+        XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER "${BUILD_OSX_APP_IDENTIFIER}.socksproxy"
+        XCODE_ATTRIBUTE_MARKETING_VERSION "${CMAKE_PROJECT_VERSION}"
+        XCODE_GENERATE_SCHEME TRUE
+    )
+
+    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/agent.plist.in ${BUILD_OSX_APP_IDENTIFIER}.socksproxy.plist)
+
+    # Embed the property list into the binary.
+    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/info.plist.in info.plist)
+    if(XCODE)
+        set_target_properties(socksproxy PROPERTIES
+            XCODE_ATTRIBUTE_INFOPLIST_FILE ${CMAKE_CURRENT_BINARY_DIR}/info.plist
+            XCODE_ATTRIBUTE_CREATE_INFOPLIST_SECTION_IN_BINARY YES
+        )
+    else()
+        target_link_options(socksproxy PRIVATE
+            LINKER:-sectcreate,__TEXT,__info_plist,${CMAKE_CURRENT_BINARY_DIR}/info.plist
+        )
+    endif()
+
+    include(${CMAKE_SOURCE_DIR}/scripts/cmake/osxtools.cmake)
+    osx_codesign_target(socksproxy FORCE)
 endif()
-
-
-add_dependencies(mozillavpn socksproxy)

--- a/extension/socks5proxy/bin/agent.plist.in
+++ b/extension/socks5proxy/bin/agent.plist.in
@@ -12,12 +12,17 @@
     <array>
         <string>${BUILD_OSX_APP_IDENTIFIER}.socksproxy</string>
         <string>-l</string>
-        <string>-p</string>
-        <string>8123</string>
+        <string>-n</string>
+        <string>/var/tmp/mozillavpn.proxy</string>
     </array>
     <key>RunAtLoad</key>
     <true/>
     <key>KeepAlive</key>
     <true/>
+    <key>SoftResourceLimits</key>
+    <dict>
+        <key>NumberOfFiles</key>
+        <integer>8192</integer>
+    </dict>
 </dict>
 </plist>

--- a/extension/socks5proxy/bin/agent.plist.in
+++ b/extension/socks5proxy/bin/agent.plist.in
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>AssociatedBundleIdentifiers</key>
+    <string>${BUILD_OSX_APP_IDENTIFIER}</string>
+    <key>Label</key>
+    <string>${BUILD_OSX_APP_IDENTIFIER}.socksproxy</string>
+    <key>BundleProgram</key>
+    <string>Contents/Library/LaunchServices/${BUILD_OSX_APP_IDENTIFIER}.socksproxy</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>${BUILD_OSX_APP_IDENTIFIER}.socksproxy</string>
+        <string>-l</string>
+        <string>-p</string>
+        <string>8123</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+</dict>
+</plist>

--- a/extension/socks5proxy/bin/info.plist.in
+++ b/extension/socks5proxy/bin/info.plist.in
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleIdentifier</key>
+    <string>${BUILD_OSX_APP_IDENTIFIER}.socksproxy</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>Mozilla VPN Proxy</string>
+    <key>CFBundleVersion</key>
+    <string>${CMAKE_PROJECT_VERSION}-${BUILD_ID}</string>
+    <key>CFBundleShortVersionString</key>
+    <string>${CMAKE_PROJECT_VERSION}</string>
+</dict>
+</plist>

--- a/extension/socks5proxy/bin/macfwpolicy.cpp
+++ b/extension/socks5proxy/bin/macfwpolicy.cpp
@@ -4,13 +4,17 @@
 
 #include "macfwpolicy.h"
 
+extern "C" {
+#include <CoreFoundation/CoreFoundation.h>
+};
+
 #include <QLocalServer>
+#include <QProcessEnvironment>
 
 #include "proxyconnection.h"
 #include "socks5.h"
 
 MacFwPolicy::MacFwPolicy(Socks5* proxy) : QObject(proxy) {
-
   // For QLocalServers, we should check that the local client
   // name corresponds to a known web browser.
   if (qobject_cast<QLocalServer*>(proxy->parent()) != nullptr) {
@@ -18,12 +22,51 @@ MacFwPolicy::MacFwPolicy(Socks5* proxy) : QObject(proxy) {
             &MacFwPolicy::checkLocalSocket);
   }
 
-  // TODO: Somehow enumerate the list of installed web browsers.
-  m_browsers = QStringList({
-    "com.apple.Safari",
-    "org.mozilla.firefox",
-    "org.mozilla.nightly",
-  });
+  // Search for applications with the NSUserActivityTypes containing
+  // NSUserActivityTypeBrowsingWeb, indicating that they are web browsers.
+  QProcessEnvironment pe = QProcessEnvironment::systemEnvironment();
+  if (pe.contains("HOME")) {
+    enumerateBrowsers(pe.value("HOME") + "/Applications");
+    enumerateBrowsers(pe.value("HOME") + "/Applications/Utilities");
+  }
+
+  enumerateBrowsers("/Applications");
+  enumerateBrowsers("/Applications/Utilities");
+  enumerateBrowsers("/System/Applications");
+  enumerateBrowsers("/System/Applications/Utilities");
+  enumerateBrowsers("/System/Cryptexes/App/System/Applications");
+}
+
+void MacFwPolicy::enumerateBrowsers(const QString& appDir) {
+  static const CFStringRef kBundleTypeApp = CFSTR(".app");
+  static const CFStringRef kActivityTypes = CFSTR("NSUserActivityTypes");
+  static const CFStringRef kActivityBrowser = CFSTR("NSUserActivityTypeBrowsingWeb");
+
+  CFStringRef s = appDir.toCFString();
+  CFURLRef url = CFURLCreateWithFileSystemPath(kCFAllocatorDefault, s,
+                                               kCFURLPOSIXPathStyle, TRUE);
+  CFArrayRef list = CFBundleCreateBundlesFromDirectory(kCFAllocatorDefault, url,
+                                                       kBundleTypeApp);
+  for (CFIndex i = 0; list && i < CFArrayGetCount(list); i++) {
+    CFBundleRef bundle = (CFBundleRef)CFArrayGetValueAtIndex(list, i);
+    CFArrayRef values =
+        (CFArrayRef)CFBundleGetValueForInfoDictionaryKey(bundle, kActivityTypes);
+    if ((!values) || (CFGetTypeID(values) != CFArrayGetTypeID())) {
+      continue;
+    }
+    CFRange range = {
+        .location = 0,
+        .length = CFArrayGetCount(values),
+    };
+    if (CFArrayContainsValue(values, range, kActivityBrowser)) {
+        QString id = QString::fromCFString(CFBundleGetIdentifier(bundle));
+        qDebug() << "Authorizing browser:" << id;
+        m_browsers.append(id);
+    }
+  }
+  CFRelease(url);
+  CFRelease(list);
+  CFRelease(s);
 }
 
 void MacFwPolicy::checkLocalSocket(ProxyConnection* connection) {

--- a/extension/socks5proxy/bin/macfwpolicy.cpp
+++ b/extension/socks5proxy/bin/macfwpolicy.cpp
@@ -8,6 +8,7 @@ extern "C" {
 #include <CoreFoundation/CoreFoundation.h>
 };
 
+#include <QtDebug>
 #include <QLocalServer>
 #include <QProcessEnvironment>
 

--- a/extension/socks5proxy/bin/macfwpolicy.cpp
+++ b/extension/socks5proxy/bin/macfwpolicy.cpp
@@ -1,0 +1,33 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "macfwpolicy.h"
+
+#include <QLocalServer>
+
+#include "proxyconnection.h"
+#include "socks5.h"
+
+MacFwPolicy::MacFwPolicy(Socks5* proxy) : QObject(proxy) {
+
+  // For QLocalServers, we should check that the local client
+  // name corresponds to a known web browser.
+  if (qobject_cast<QLocalServer*>(proxy->parent()) != nullptr) {
+    connect(proxy, &Socks5::incomingConnection, this,
+            &MacFwPolicy::checkLocalSocket);
+  }
+
+  // TODO: Somehow enumerate the list of installed web browsers.
+  m_browsers = QStringList({
+    "com.apple.Safari",
+    "org.mozilla.firefox",
+    "org.mozilla.nightly",
+  });
+}
+
+void MacFwPolicy::checkLocalSocket(ProxyConnection* connection) {
+  if (!m_browsers.contains(connection->clientName())) {
+    connection->abort();
+  }
+}

--- a/extension/socks5proxy/bin/macfwpolicy.cpp
+++ b/extension/socks5proxy/bin/macfwpolicy.cpp
@@ -8,9 +8,9 @@ extern "C" {
 #include <CoreFoundation/CoreFoundation.h>
 };
 
-#include <QtDebug>
 #include <QLocalServer>
 #include <QProcessEnvironment>
+#include <QtDebug>
 
 #include "proxyconnection.h"
 #include "socks5.h"
@@ -41,7 +41,8 @@ MacFwPolicy::MacFwPolicy(Socks5* proxy) : QObject(proxy) {
 void MacFwPolicy::enumerateBrowsers(const QString& appDir) {
   static const CFStringRef kBundleTypeApp = CFSTR(".app");
   static const CFStringRef kActivityTypes = CFSTR("NSUserActivityTypes");
-  static const CFStringRef kActivityBrowser = CFSTR("NSUserActivityTypeBrowsingWeb");
+  static const CFStringRef kActivityBrowser =
+      CFSTR("NSUserActivityTypeBrowsingWeb");
 
   CFStringRef s = appDir.toCFString();
   CFURLRef url = CFURLCreateWithFileSystemPath(kCFAllocatorDefault, s,
@@ -50,8 +51,8 @@ void MacFwPolicy::enumerateBrowsers(const QString& appDir) {
                                                        kBundleTypeApp);
   for (CFIndex i = 0; list && i < CFArrayGetCount(list); i++) {
     CFBundleRef bundle = (CFBundleRef)CFArrayGetValueAtIndex(list, i);
-    CFArrayRef values =
-        (CFArrayRef)CFBundleGetValueForInfoDictionaryKey(bundle, kActivityTypes);
+    CFArrayRef values = (CFArrayRef)CFBundleGetValueForInfoDictionaryKey(
+        bundle, kActivityTypes);
     if ((!values) || (CFGetTypeID(values) != CFArrayGetTypeID())) {
       continue;
     }
@@ -60,9 +61,9 @@ void MacFwPolicy::enumerateBrowsers(const QString& appDir) {
         .length = CFArrayGetCount(values),
     };
     if (CFArrayContainsValue(values, range, kActivityBrowser)) {
-        QString id = QString::fromCFString(CFBundleGetIdentifier(bundle));
-        qDebug() << "Authorizing browser:" << id;
-        m_browsers.append(id);
+      QString id = QString::fromCFString(CFBundleGetIdentifier(bundle));
+      qDebug() << "Authorizing browser:" << id;
+      m_browsers.append(id);
     }
   }
   CFRelease(url);

--- a/extension/socks5proxy/bin/macfwpolicy.h
+++ b/extension/socks5proxy/bin/macfwpolicy.h
@@ -18,6 +18,7 @@ class MacFwPolicy final : public QObject {
   ~MacFwPolicy() = default;
 
  private:
+  void enumerateBrowsers(const QString& appDir);
   void checkLocalSocket(ProxyConnection* connection);
 
   // The signing identifiers of known web browsers.

--- a/extension/socks5proxy/bin/macfwpolicy.h
+++ b/extension/socks5proxy/bin/macfwpolicy.h
@@ -1,0 +1,27 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef MACFWPOLICY_H
+#define MACFWPOLICY_H
+
+#include <QObject>
+
+class Socks5;
+class ProxyConnection;
+
+class MacFwPolicy final : public QObject {
+  Q_OBJECT
+
+ public:
+  explicit MacFwPolicy(Socks5* proxy);
+  ~MacFwPolicy() = default;
+
+ private:
+  void checkLocalSocket(ProxyConnection* connection);
+
+  // The signing identifiers of known web browsers.
+  QStringList m_browsers;
+};
+
+#endif  // MACFWPOLICY_H

--- a/extension/socks5proxy/bin/main.cpp
+++ b/extension/socks5proxy/bin/main.cpp
@@ -21,6 +21,8 @@
 #  include "windowsbypass.h"
 #  include "winfwpolicy.h"
 #  include "winsvcthread.h"
+#elif defined(PROXY_OS_MACOS)
+#  include "macfwpolicy.h"
 #endif
 
 struct CliOptions {
@@ -191,6 +193,8 @@ int main(int argc, char** argv) {
 #elif defined(PROXY_OS_WIN)
   new WindowsBypass(socks5);
   WinFwPolicy::create(socks5);
+#elif defined(PROXY_OS_MACOS)
+  new MacFwPolicy(socks5);
 #endif
 
   QObject::connect(qApp, &QCoreApplication::aboutToQuit,

--- a/extension/socks5proxy/src/CMakeLists.txt
+++ b/extension/socks5proxy/src/CMakeLists.txt
@@ -41,8 +41,10 @@ if(WIN32)
         winutils.cpp
         winutils.h
     )
-elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     target_sources(libSocks5proxy PRIVATE proxylocal_linux.cpp)
+elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+    target_sources(libSocks5proxy PRIVATE proxylocal_macos.cpp)
 else()
     target_sources(libSocks5proxy PRIVATE proxylocal_default.cpp)
 endif()

--- a/extension/socks5proxy/src/proxyconnection.cpp
+++ b/extension/socks5proxy/src/proxyconnection.cpp
@@ -130,6 +130,11 @@ void ProxyConnection::setState(int newstate) {
   }
 }
 
+void ProxyConnection::abort(const QString& reason) {
+  m_errorString = reason;
+  setState(Closed);
+}
+
 template <typename T>
 void ProxyConnection::clientErrorOccurred(int error) {
   auto socket = qobject_cast<T*>(QObject::sender());

--- a/extension/socks5proxy/src/proxyconnection.h
+++ b/extension/socks5proxy/src/proxyconnection.h
@@ -43,6 +43,8 @@ class ProxyConnection : public QObject {
 
   int state() const { return m_state; }
 
+  void abort(const QString& reason = "connection aborted");
+
   // Proxy protocols must implement these methods to read data off the client
   // socket in the Handshake and Proxy states, respectively.
   virtual void handshakeRead() = 0;

--- a/extension/socks5proxy/src/proxylocal_macos.cpp
+++ b/extension/socks5proxy/src/proxylocal_macos.cpp
@@ -2,10 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#include "proxyconnection.h"
-
 #include <sys/socket.h>
 #include <sys/un.h>
+
+#include "proxyconnection.h"
 
 extern "C" {
 #include <CoreFoundation/CoreFoundation.h>
@@ -20,7 +20,7 @@ QString ProxyConnection::localClientName(QLocalSocket* s) {
   // Fetch the audit token of the peer process.
   audit_token_t token;
   socklen_t len = sizeof(audit_token_t);
-  int sd = s->socketDescriptor();  
+  int sd = s->socketDescriptor();
   if (getsockopt(sd, SOL_LOCAL, LOCAL_PEERTOKEN, &token, &len) != 0) {
     return QString();
   }

--- a/extension/socks5proxy/src/proxylocal_macos.cpp
+++ b/extension/socks5proxy/src/proxylocal_macos.cpp
@@ -1,0 +1,42 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "proxyconnection.h"
+
+#include <sys/socket.h>
+#include <sys/un.h>
+
+extern "C" {
+#include <CoreFoundation/CoreFoundation.h>
+#include <Security/SecTask.h>
+};
+
+#include <QLocalSocket>
+#include <QScopeGuard>
+
+// static
+QString ProxyConnection::localClientName(QLocalSocket* s) {
+  // Fetch the audit token of the peer process.
+  audit_token_t token;
+  socklen_t len = sizeof(audit_token_t);
+  int sd = s->socketDescriptor();  
+  if (getsockopt(sd, SOL_LOCAL, LOCAL_PEERTOKEN, &token, &len) != 0) {
+    return QString();
+  }
+
+  // Get the sending task.
+  SecTaskRef task = SecTaskCreateWithAuditToken(NULL, token);
+  if (task == NULL) {
+    return QString();
+  }
+  auto taskGuard = qScopeGuard([task]() { CFRelease(task); });
+
+  // Get the signing identifier.
+  CFStringRef id = SecTaskCopySigningIdentifier(task, NULL);
+  if (id == NULL) {
+    return QString();
+  }
+  auto stringGuard = qScopeGuard([id]() { CFRelease(id); });
+  return QString::fromCFString(id);
+}

--- a/macos/networkextension/VPNSplitTunnelProvider.mm
+++ b/macos/networkextension/VPNSplitTunnelProvider.mm
@@ -34,6 +34,7 @@
 @property (strong) InterfaceConfig* config;
 
 @property (strong) NSSet* vpnDisabledApps;
+@property (strong) NSSet* vpnBypassApps;
 
 @property (strong) NSTask* dnsManager;
 
@@ -49,7 +50,14 @@
   self = [super init];
   NSLog(@"init proxy class");
 
+  NSString* extensionId = [[NSBundle mainBundle] bundleIdentifier];
+  NSMutableArray* parts = [NSMutableArray new];
+  [parts setArray:[extensionId componentsSeparatedByString:@"."]];
+  [parts replaceObjectAtIndex:parts.count-1
+                   withObject:@"socksproxy"];
+
   self.vpnDisabledApps = [NSSet set];
+  self.vpnBypassApps = [NSSet setWithObject:[parts componentsJoinedByString:@"."]];
 
   m_handledTcpFlows = 0;
   m_handledUdpFlows = 0;
@@ -427,6 +435,11 @@
 #ifdef MZ_DEBUG
   NSLog(@"new flow: %@ -> %@", sourceId, flow.remoteHostname);
 #endif
+
+  // Check if the app has been hard-coded to bypass the VPN.
+  if ([self.vpnBypassApps containsObject:sourceId]) {
+    return NO;
+  }
 
   for (NSString* appId in self.vpnDisabledApps) {
     if (sourceId.length < appId.length) {

--- a/macos/networkextension/VPNSplitTunnelProvider.mm
+++ b/macos/networkextension/VPNSplitTunnelProvider.mm
@@ -34,7 +34,7 @@
 @property (strong) InterfaceConfig* config;
 
 @property (strong) NSSet* vpnDisabledApps;
-@property (strong) NSSet* vpnBypassApps;
+@property (strong) NSSet* vpnHardcodeApps;
 
 @property (strong) NSTask* dnsManager;
 
@@ -57,7 +57,7 @@
                    withObject:@"socksproxy"];
 
   self.vpnDisabledApps = [NSSet set];
-  self.vpnBypassApps = [NSSet setWithObject:[parts componentsJoinedByString:@"."]];
+  self.vpnHardcodeApps = [NSSet setWithObject:[parts componentsJoinedByString:@"."]];
 
   m_handledTcpFlows = 0;
   m_handledUdpFlows = 0;
@@ -437,7 +437,7 @@
 #endif
 
   // Check if the app has been hard-coded to bypass the VPN.
-  if ([self.vpnBypassApps containsObject:sourceId]) {
+  if ([self.vpnHardcodeApps containsObject:sourceId]) {
     return NO;
   }
 

--- a/src/cmake/macos.cmake
+++ b/src/cmake/macos.cmake
@@ -215,6 +215,29 @@ set_source_files_properties(${CMAKE_SOURCE_DIR}/extension/manifests/macos/mozill
     HEADER_FILE_ONLY TRUE
 )
 
+# Install the extension proxy into the bundle.
+add_dependencies(mozillavpn socksproxy)
+get_target_property(PROXY_BINARY_DIR socksproxy BINARY_DIR)
+get_target_property(PROXY_OUTPUT_NAME socksproxy OUTPUT_NAME)
+if(XCODE)
+    set_property(TARGET mozillavpn APPEND PROPERTY XCODE_EMBED_XPC_SERVICES socksproxy)
+else()
+    get_target_property(PROXY_BINARY_DIR socksproxy BINARY_DIR)
+    get_target_property(PROXY_OUTPUT_NAME socksproxy OUTPUT_NAME)
+    target_sources(mozillavpn PRIVATE ${PROXY_BINARY_DIR}/${PROXY_OUTPUT_NAME})
+    set_source_files_properties(${PROXY_BINARY_DIR}/${PROXY_OUTPUT_NAME} PROPERTIES
+        MACOSX_PACKAGE_LOCATION "Library/LaunchServices"
+        HEADER_FILE_ONLY TRUE
+        GENERATED TRUE
+    )
+endif()
+
+target_sources(mozillavpn PRIVATE ${PROXY_BINARY_DIR}/${PROXY_OUTPUT_NAME}.plist)
+set_source_files_properties(${PROXY_BINARY_DIR}/${PROXY_OUTPUT_NAME}.plist PROPERTIES
+    MACOSX_PACKAGE_LOCATION Library/LaunchAgents
+    HEADER_FILE_ONLY TRUE
+)
+
 # Install the lproj translation files into the bundle.
 get_filename_component(I18N_DIR ${CMAKE_SOURCE_DIR}/3rdparty/i18n ABSOLUTE)
 file(GLOB I18N_LOCALES LIST_DIRECTORIES true RELATIVE ${I18N_DIR} ${I18N_DIR}/*)

--- a/src/constants.h
+++ b/src/constants.h
@@ -299,6 +299,7 @@ constexpr const char* WINDOWS_DAEMON_PATH = "\\\\.\\pipe\\mozillavpn";
 constexpr const char* MACOS_DAEMON_PATH = "/var/run/mozillavpn/daemon.socket";
 
 constexpr const char* SOCKSPROXY_UNIX_PATH = "/var/run/mozillavpn.proxy";
+constexpr const char* SOCKSPROXY_MACOS_PATH = "/var/tmp/mozillavpn.proxy";
 constexpr const char* SOCKSPROXY_SERVICE_NAME = "MozillaVPNProxy";
 
 constexpr const char* SUBPLAT_PRODUCT_ID_VPN_PRODUCTION = "prod_FvnsFHIfezy3ZI";

--- a/src/platforms/macos/macoscontroller.mm
+++ b/src/platforms/macos/macoscontroller.mm
@@ -22,7 +22,6 @@
 #import <Security/Authorization.h>
 #import <Security/AuthorizationTags.h>
 #import <ServiceManagement/ServiceManagement.h>
-#import <SystemExtensions/SystemExtensions.h>
 
 namespace {
 Logger logger("MacOSController");

--- a/src/platforms/macos/macosextensioncontroller.mm
+++ b/src/platforms/macos/macosextensioncontroller.mm
@@ -6,6 +6,7 @@
 
 #import <Foundation/Foundation.h>
 #import <NetworkExtension/NetworkExtension.h>
+#import <ServiceManagement/ServiceManagement.h>
 #import <SystemExtensions/SystemExtensions.h>
 
 #include <QMetaMethod>
@@ -47,6 +48,16 @@ void MacOSExtensionController::initialize(const Device* device, const Keys* keys
   // Start the request
   logger.debug() << "activation request started:" << req.identifier;
   [[OSSystemExtensionManager sharedManager] submitRequest: req];
+
+  // Attempt to register the socks proxy tool.
+  NSError* err = nil;
+  NSString* proxyPlistName = MacOSUtils::appId(".socksproxy.plist").toNSString();
+  SMAppService* proxy = [SMAppService agentServiceWithPlistName:proxyPlistName];
+  if (![proxy registerAndReturnError:&err]) {
+    logger.debug() << "socks proxy agent registration failed:" << err;
+  } else {
+    logger.debug() << "socks proxy agent registration successful";
+  }
 }
 
 NSString* MacOSExtensionController::extIdentifier() {

--- a/src/webextension/server_macos.cpp
+++ b/src/webextension/server_macos.cpp
@@ -3,13 +3,65 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include <QDir>
+#include <QScopeGuard>
 #include <QStandardPaths>
+
+extern "C" {
+#include <CoreFoundation/CoreFoundation.h>
+#include <Security/SecTask.h>
+};
+
+#include <sys/socket.h>
+#include <sys/un.h>
 
 #include "server.h"
 
+static QString getSelfSigningIdentifier() {
+  SecTaskRef task = SecTaskCreateFromSelf(NULL);
+  if (!task) {
+    return QString();
+  }
+  CFStringRef id = SecTaskCopySigningIdentifier(task, NULL);
+  CFRelease(task);
+  if (!id) {
+    return QString();
+  }
+  QString result = QString::fromCFString(id);
+  CFRelease(id);
+  return result;
+}
+
 bool WebExtension::Server::isAllowedToConnect(qintptr sd) {
-  // TODO: Implement Me!
+  static QString selfIdentifier = getSelfSigningIdentifier();
+  if (selfIdentifier.isEmpty()) {
+    // If our task is unsigned, then permit all access.
+    return true;
+  }
+
+  // Fetch the audit token and signing identifier of the peer process.
+  audit_token_t token;
+  socklen_t len = sizeof(audit_token_t);
+  if (getsockopt(sd, SOL_LOCAL, LOCAL_PEERTOKEN, &token, &len) != 0) {
+    return false;
+  }
+  SecTaskRef task = SecTaskCreateWithAuditToken(NULL, token);
+  if (!task) {
+    return false;
+  }
+  CFStringRef id = SecTaskCopySigningIdentifier(task, NULL);
+  CFRelease(task);
+  if (!id) {
+    return false;
+  }
+  auto guard = qScopeGuard([id]() { CFRelease(id); });
+
+#ifdef MZ_DEBUG
+  qDebug() << "[Debug] Allowing Webextension Connection from:"
+           << QString::fromCFString(id);
   return true;
+#else
+  return selfIdentifier == QString::fromCFString(id);
+#endif
 }
 
 QString WebExtension::Server::localSocketName() {

--- a/src/webextension/webexthandler.cpp
+++ b/src/webextension/webexthandler.cpp
@@ -10,8 +10,8 @@
 #include <QFileDevice>
 #include <QJsonDocument>
 #include <QJsonObject>
-#include <QMetaObject>
 #include <QMetaMethod>
+#include <QMetaObject>
 
 #include "webextreader.h"
 

--- a/src/webextension/webexthandler.cpp
+++ b/src/webextension/webexthandler.cpp
@@ -11,6 +11,7 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QMetaObject>
+#include <QMetaMethod>
 
 #include "webextreader.h"
 
@@ -61,14 +62,19 @@ void WebExtHandler::handleMessage(const QByteArray& msg) {
   QString name = msgType.toString();
   QByteArray signature = QString("%1(QByteArray)").arg(name).toLocal8Bit();
   int index = this->metaObject()->indexOfMethod(signature.constData());
-  if (index >= 0) {
-    // This command can be handled locally.
-    QMetaObject::invokeMethod(this, name.toLocal8Bit().constData(),
-                              Q_ARG(QByteArray, msg));
-  } else {
-    // Otherwise - we cannot handle this message.
-    emit unhandledMessage(msg);
+  while (index >= 0) {
+    QMetaMethod m = this->metaObject()->method(index);
+    if (m.methodType() != QMetaMethod::Method) {
+      break;
+    }
+    if (!m.invoke(this, Q_ARG(QByteArray, msg))) {
+      break;
+    }
+    return;
   }
+
+  // Otherwise - we cannot handle this message.
+  emit unhandledMessage(msg);
 }
 
 void WebExtHandler::bridge_ping(const QByteArray& msg) {

--- a/src/webextension/webexthandler.h
+++ b/src/webextension/webexthandler.h
@@ -24,7 +24,6 @@ class WebExtHandler final : public QObject {
   // The methods we can handle locally are exposed as meta-methods.
   Q_INVOKABLE void bridge_ping(const QByteArray& msg);
   Q_INVOKABLE void proc_info(const QByteArray& msg);
-  Q_INVOKABLE void proxy_info(const QByteArray& msg);
   Q_INVOKABLE void start(const QByteArray& msg);
 
   void writeMsgStdout(const QByteArray& msg);

--- a/src/webextension/webexthandler.h
+++ b/src/webextension/webexthandler.h
@@ -24,6 +24,7 @@ class WebExtHandler final : public QObject {
   // The methods we can handle locally are exposed as meta-methods.
   Q_INVOKABLE void bridge_ping(const QByteArray& msg);
   Q_INVOKABLE void proc_info(const QByteArray& msg);
+  Q_INVOKABLE void proxy_info(const QByteArray& msg);
   Q_INVOKABLE void start(const QByteArray& msg);
 
   void writeMsgStdout(const QByteArray& msg);

--- a/src/webextension/webexthandler_linux.cpp
+++ b/src/webextension/webexthandler_linux.cpp
@@ -28,6 +28,17 @@ void WebExtHandler::proc_info(const QByteArray& msg) {
   writeJsonStdout(obj);
 }
 
+void WebExtHandler::proxy_info(const QByteArray& msg) {
+  Q_UNUSED(msg);
+
+  QJsonObject obj;
+  obj["type"] = "socks";
+  obj["host"] = "file:/var/run/mozillavpn.proxy";
+  obj["port"] = QJsonValue(1234);
+  obj["proxyDNS"] = QJsonValue(true);
+  writeJsonStdout(obj);
+}
+
 void WebExtHandler::start(const QByteArray& msg) {
   Q_UNUSED(msg);
 

--- a/src/webextension/webexthandler_linux.cpp
+++ b/src/webextension/webexthandler_linux.cpp
@@ -28,17 +28,6 @@ void WebExtHandler::proc_info(const QByteArray& msg) {
   writeJsonStdout(obj);
 }
 
-void WebExtHandler::proxy_info(const QByteArray& msg) {
-  Q_UNUSED(msg);
-
-  QJsonObject obj;
-  obj["type"] = "socks";
-  obj["host"] = "file:/var/run/mozillavpn.proxy";
-  obj["port"] = QJsonValue(1234);
-  obj["proxyDNS"] = QJsonValue(true);
-  writeJsonStdout(obj);
-}
-
 void WebExtHandler::start(const QByteArray& msg) {
   Q_UNUSED(msg);
 

--- a/src/webextension/webexthandler_macos.mm
+++ b/src/webextension/webexthandler_macos.mm
@@ -5,6 +5,7 @@
 #include "webexthandler.h"
 
 #include <QJsonObject>
+#include <QStandardPaths>
 #include <QString>
 
 #include <libproc.h>
@@ -30,6 +31,16 @@ void WebExtHandler::proc_info(const QByteArray& msg) {
   if (ret > 0) {
     obj["exe"] = QString(path);
   }
+  writeJsonStdout(obj);
+}
+
+void WebExtHandler::proxy_info(const QByteArray& msg) {
+  Q_UNUSED(msg);
+  QJsonObject obj;
+  obj["type"] = "socks";
+  obj["host"] = QString("file:/var/tmp/mozillavpn.proxy");
+  obj["port"] = QJsonValue(1234);
+  obj["proxyDNS"] = QJsonValue(true);
   writeJsonStdout(obj);
 }
 

--- a/src/webextension/webexthandler_macos.mm
+++ b/src/webextension/webexthandler_macos.mm
@@ -34,16 +34,6 @@ void WebExtHandler::proc_info(const QByteArray& msg) {
   writeJsonStdout(obj);
 }
 
-void WebExtHandler::proxy_info(const QByteArray& msg) {
-  Q_UNUSED(msg);
-  QJsonObject obj;
-  obj["type"] = "socks";
-  obj["host"] = QString("file:/var/tmp/mozillavpn.proxy");
-  obj["port"] = QJsonValue(1234);
-  obj["proxyDNS"] = QJsonValue(true);
-  writeJsonStdout(obj);
-}
-
 void WebExtHandler::start(const QByteArray& msg) {
   Q_UNUSED(msg);
 

--- a/src/webextension/webexthandler_windows.cpp
+++ b/src/webextension/webexthandler_windows.cpp
@@ -36,6 +36,17 @@ static DWORD getParentProcessId(DWORD pid) {
   return 0;
 }
 
+void WebExtHandler::proxy_info(const QByteArray& msg) {
+  Q_UNUSED(msg);
+
+  QJsonObject obj;
+  obj["type"] = "socks";
+  obj["host"] = "socks5://127.0.0.1";
+  obj["port"] = QJsonValue(8123);
+  obj["proxyDNS"] = QJsonValue(true);
+  writeJsonStdout(obj);
+}
+
 void WebExtHandler::proc_info(const QByteArray& msg) {
   Q_UNUSED(msg);
 

--- a/src/webextension/webexthandler_windows.cpp
+++ b/src/webextension/webexthandler_windows.cpp
@@ -36,17 +36,6 @@ static DWORD getParentProcessId(DWORD pid) {
   return 0;
 }
 
-void WebExtHandler::proxy_info(const QByteArray& msg) {
-  Q_UNUSED(msg);
-
-  QJsonObject obj;
-  obj["type"] = "socks";
-  obj["host"] = "socks5://127.0.0.1";
-  obj["port"] = QJsonValue(8123);
-  obj["proxyDNS"] = QJsonValue(true);
-  writeJsonStdout(obj);
-}
-
 void WebExtHandler::proc_info(const QByteArray& msg) {
   Q_UNUSED(msg);
 

--- a/src/webextensionadapter.cpp
+++ b/src/webextensionadapter.cpp
@@ -216,6 +216,9 @@ QJsonObject WebExtensionAdapter::serializeFeaturelist() {
   // TODO: Need to check if the service is running.
   out["localProxy"] =
       WindowsUtils::getServiceStatus(Constants::SOCKSPROXY_SERVICE_NAME);
+#elif defined(MZ_MACOS)
+  out["localProxy"] = Feature::isEnabled(Feature::networkExtension) &&
+      QFileInfo::exists(Constants::SOCKSPROXY_MACOS_PATH);
 #else
   out["localProxy"] = false;
 #endif

--- a/src/webextensionadapter.cpp
+++ b/src/webextensionadapter.cpp
@@ -218,7 +218,7 @@ QJsonObject WebExtensionAdapter::serializeFeaturelist() {
       WindowsUtils::getServiceStatus(Constants::SOCKSPROXY_SERVICE_NAME);
 #elif defined(MZ_MACOS)
   out["localProxy"] = Feature::isEnabled(Feature::networkExtension) &&
-      QFileInfo::exists(Constants::SOCKSPROXY_MACOS_PATH);
+                      QFileInfo::exists(Constants::SOCKSPROXY_MACOS_PATH);
 #else
   out["localProxy"] = false;
 #endif


### PR DESCRIPTION
## Description
To start making progress towards enabling the Mozilla VPN Firefox extension for macOS, we will need to install and launch the `socksproxy` tool. To get there, we build the tool as a LaunchAgent and install it using the `SMAppService` framework.

To try and constrain the clients that can connect to the proxy, we use a UNIX domain socket for the proxy at `/var/tmp/mozillavpn.proxy` then use the `LOCAL_PEERTOKEN` socket option to verify that only installed web browsers are able to establish connections.

## Reference
JIRA Issues:
 - [VPN-7754](https://mozilla-hub.atlassian.net/browse/VPN-7754)
 - [VPN-7775](https://mozilla-hub.atlassian.net/browse/VPN-7775)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] If bug/feature is at all notable, I've added a draft release note as a comment in `addons/strings.yaml`.
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-7754]: https://mozilla-hub.atlassian.net/browse/VPN-7754?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[VPN-7775]: https://mozilla-hub.atlassian.net/browse/VPN-7775?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ