### PR TITLE
Controller bug fix on config setup

### DIFF
--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -1034,7 +1034,6 @@ void Controller::maybeSendUpdatedConfig(const ServerData& serverData) {
     InterfaceConfig entryConfig;
     if (!serverConfigs.isEmpty()) {
       entryConfig = serverConfigs.takeFirst();
-      m_activationQueue.append(entryConfig);
     }
     m_impl->sendUpdatedConfig(entryConfig, exitConfig);
   } else {


### PR DESCRIPTION
## Description

While looking through https://github.com/mozilla-mobile/mozilla-vpn-client/pull/11489/, I noticed that we append the entry server - but not the exit server - to `m_activationQueue` in `maybeSendUpdatedConfig`. 

I believe this is a bug, as we do not activate when sending updated configs - it's explicitly for when the VPN is disconnected.

This has existed since I refactored the config setup and created `maybeSendUpdatedConfig` a little over 3 months ago: https://github.com/mozilla-mobile/mozilla-vpn-client/pull/11206/ It seems like this may have been a copy error, as this block that includes the errant line is the exact code block from `activateInternal`, the other spot where we consume the output of `setupConfigs`.

I do not think this has had any bad impact, as in `activateInternal` we run `m_activationQueue.clear();` before we try to start setting up the new configs. That said, I'm not 100% confident it hasn't impacted anything.

## Reference

None

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] If bug/feature is at all notable, I've added a draft release note as a comment in `addons/strings.yaml`.
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
