### PR TITLE
Obfuscation features part 4 - Flatpak

### DIFF
--- a/src/cmake/linux.cmake
+++ b/src/cmake/linux.cmake
@@ -46,6 +46,17 @@ target_sources(mozillavpn PRIVATE
 # needs the Gui internal header files on Qt 6.5.0 and later.
 target_link_libraries(mozillavpn PRIVATE Qt6::GuiPrivate)
 
+# Add the obfuscator binary
+add_rust_binary(mozillavpn-obfuscator
+    PACKAGE_DIR ${CMAKE_SOURCE_DIR}/obfuscators
+    BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/obfuscators_target
+    CRATE_NAME obfuscators
+    BIN_NAME mozillavpn-obfuscator
+    CARGO_ENV CARGO_TARGET_DIR=${CMAKE_CURRENT_BINARY_DIR}/obfuscators_target
+)
+add_dependencies(mozillavpn mozillavpn-obfuscator)
+install(PROGRAMS ${mozillavpn-obfuscator_EXECUTABLE} DESTINATION bin)
+
 if(NOT BUILD_FLATPAK)
     # Link to polkit
     find_package(PkgConfig REQUIRED)
@@ -104,19 +115,6 @@ if(NOT BUILD_FLATPAK)
     include(${CMAKE_SOURCE_DIR}/scripts/cmake/golang.cmake)
     add_go_library(netfilter ${CMAKE_SOURCE_DIR}/linux/netfilter/netfilter.go)
     target_link_libraries(mozillavpn PRIVATE netfilter)
-
-    # Add the obfuscator binary
-    add_rust_binary(mozillavpn-obfuscator
-        PACKAGE_DIR ${CMAKE_SOURCE_DIR}/obfuscators
-        BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/obfuscators_target
-        CRATE_NAME obfuscators
-        BIN_NAME mozillavpn-obfuscator
-        CARGO_ENV CARGO_TARGET_DIR=${CMAKE_CURRENT_BINARY_DIR}/obfuscators_target
-    )
-    add_dependencies(mozillavpn mozillavpn-obfuscator)
-
-    # Install the obfuscator binary
-    install(PROGRAMS ${mozillavpn-obfuscator_EXECUTABLE} DESTINATION bin)
 else()
     # Linux source files for sandboxed builds
     target_compile_definitions(mozillavpn PRIVATE MZ_FLATPAK)

--- a/src/daemon/obfuscator/dummyobfuscator.cpp
+++ b/src/daemon/obfuscator/dummyobfuscator.cpp
@@ -21,4 +21,8 @@ bool DummyObfuscator::start() {
   return false;
 }
 
+bool DummyObfuscator::restart() { return start(); }
+
+bool DummyObfuscator::isRunning() const { return false; }
+
 DummyObfuscator::~DummyObfuscator() { MZ_COUNT_DTOR(DummyObfuscator); }

--- a/src/daemon/obfuscator/dummyobfuscator.h
+++ b/src/daemon/obfuscator/dummyobfuscator.h
@@ -17,6 +17,7 @@ class DummyObfuscator final : public Obfuscator {
   ~DummyObfuscator() override;
 
   bool start() override;
+  void stop() override {};
   bool restart() override;
   bool isRunning() const override;
   quint16 localPort() const override { return m_localPort; }

--- a/src/daemon/obfuscator/dummyobfuscator.h
+++ b/src/daemon/obfuscator/dummyobfuscator.h
@@ -17,6 +17,8 @@ class DummyObfuscator final : public Obfuscator {
   ~DummyObfuscator() override;
 
   bool start() override;
+  bool restart() override;
+  bool isRunning() const override;
   quint16 localPort() const override { return m_localPort; }
 
  private:

--- a/src/daemon/obfuscator/obfuscator.h
+++ b/src/daemon/obfuscator/obfuscator.h
@@ -17,6 +17,14 @@ class Obfuscator {
 
   virtual bool start() = 0;
 
+  // Relaunch the relay reusing the local port assigned by the previous start().
+  // Used when the tunnel is toggled outside the app and the relay must come
+  // back on the same 127.0.0.1:<port> the WireGuard peer still points at.
+  virtual bool restart() = 0;
+
+  // Whether the relay process is currently alive.
+  virtual bool isRunning() const = 0;
+
   virtual quint16 localPort() const = 0;
 
  protected:

--- a/src/daemon/obfuscator/obfuscator.h
+++ b/src/daemon/obfuscator/obfuscator.h
@@ -17,6 +17,9 @@ class Obfuscator {
 
   virtual bool start() = 0;
 
+  
+  virtual void stop() = 0;
+
   // Relaunch the relay reusing the local port assigned by the previous start().
   // Used when the tunnel is toggled outside the app and the relay must come
   // back on the same 127.0.0.1:<port> the WireGuard peer still points at.

--- a/src/daemon/obfuscator/qprocessobfuscator.cpp
+++ b/src/daemon/obfuscator/qprocessobfuscator.cpp
@@ -24,15 +24,9 @@ namespace {
 Logger logger("QProcessObfuscator");
 }
 
-QProcessObfuscator::QProcessObfuscator(const InterfaceConfig& config) {
+QProcessObfuscator::QProcessObfuscator(const InterfaceConfig& config)
+    : m_config(config) {
   MZ_COUNT_CTOR(QProcessObfuscator);
-
-  const QStringList args = buildArgs(config);
-  if (args.isEmpty()) {
-    logger.error() << "Unsupported obfuscation method"
-                   << config.m_obfuscationMethod;
-    return;
-  }
 
   QString binaryFile = binaryName();
   if (binaryFile.isEmpty()) {
@@ -45,14 +39,39 @@ QProcessObfuscator::QProcessObfuscator(const InterfaceConfig& config) {
     logger.error() << "Obfuscator binary not found at" << binaryFile;
     return;
   }
+  m_binaryFile = binaryFile;
 
-  m_process.setProgram(binaryFile);
-  m_process.setArguments(args);
   // Merge stderr into stdout so we can read the "listening on" announce line
   m_process.setProcessChannelMode(QProcess::MergedChannels);
 }
 
-bool QProcessObfuscator::start() {
+bool QProcessObfuscator::start() { return launch(0); }
+
+bool QProcessObfuscator::restart() {
+  stop();
+  // Reuse the port assigned by the previous launch so the WireGuard peer config
+  // that still points at 127.0.0.1:<port> keeps working.
+  return launch(m_localPort);
+}
+
+bool QProcessObfuscator::isRunning() const {
+  return m_process.state() == QProcess::Running;
+}
+
+bool QProcessObfuscator::launch(quint16 listenPort) {
+  if (m_binaryFile.isEmpty()) {
+    return false;
+  }
+
+  const QStringList args = buildArgs(m_config, listenPort);
+  if (args.isEmpty()) {
+    logger.error() << "Unsupported obfuscation method"
+                   << m_config.m_obfuscationMethod;
+    return false;
+  }
+  m_process.setProgram(m_binaryFile);
+  m_process.setArguments(args);
+
   logger.debug() << "Starting obfuscator";
   m_process.start();
   if (!m_process.waitForStarted(OBFUSCATOR_PROC_TIMEOUT_MS)) {
@@ -96,7 +115,8 @@ quint16 QProcessObfuscator::parseListeningPort(const QByteArray& line) const {
   return ok ? port : 0;
 }
 
-QStringList QProcessObfuscator::buildArgs(const InterfaceConfig& config) {
+QStringList QProcessObfuscator::buildArgs(const InterfaceConfig& config,
+                                          quint16 listenPort) const {
   QStringList args;
 
   const QString server = !config.m_serverIpv4AddrIn.isEmpty()
@@ -104,6 +124,9 @@ QStringList QProcessObfuscator::buildArgs(const InterfaceConfig& config) {
                              : config.m_serverIpv6AddrIn;
   args << QStringLiteral("--server") << server;
   args << QStringLiteral("--port") << QString::number(config.m_serverPort);
+  if (listenPort != 0) {
+    args << QStringLiteral("--listen-port") << QString::number(listenPort);
+  }
 #if defined(MZ_LINUX) && !defined(MZ_FLATPAK)
   args << QStringLiteral("--fwmark") << QString::number(WG_FIREWALL_MARK);
 #endif
@@ -137,8 +160,7 @@ QString QProcessObfuscator::binaryName() const {
 #endif
 }
 
-QProcessObfuscator::~QProcessObfuscator() {
-  MZ_COUNT_DTOR(QProcessObfuscator);
+void QProcessObfuscator::stop() {
   if (m_process.state() == QProcess::NotRunning) {
     return;
   }
@@ -148,4 +170,9 @@ QProcessObfuscator::~QProcessObfuscator() {
     m_process.kill();
     m_process.waitForFinished(OBFUSCATOR_PROC_TIMEOUT_MS);
   }
+}
+
+QProcessObfuscator::~QProcessObfuscator() {
+  MZ_COUNT_DTOR(QProcessObfuscator);
+  stop();
 }

--- a/src/daemon/obfuscator/qprocessobfuscator.cpp
+++ b/src/daemon/obfuscator/qprocessobfuscator.cpp
@@ -14,7 +14,8 @@
 #include "logger.h"
 
 constexpr int OBFUSCATOR_PROC_TIMEOUT_MS = 5000;
-// SO_MARK set is not available in the Flatpak sandbox, so we only use it on non-Flatpak Linux builds.
+// SO_MARK set is not available in the Flatpak sandbox, so we only use it on
+// non-Flatpak Linux builds.
 #if defined(MZ_LINUX) && !defined(MZ_FLATPAK)
 constexpr uint32_t WG_FIREWALL_MARK = 0xca6c;
 #endif

--- a/src/daemon/obfuscator/qprocessobfuscator.cpp
+++ b/src/daemon/obfuscator/qprocessobfuscator.cpp
@@ -14,7 +14,8 @@
 #include "logger.h"
 
 constexpr int OBFUSCATOR_PROC_TIMEOUT_MS = 5000;
-#ifdef MZ_LINUX
+// SO_MARK set is not available in the Flatpak sandbox, so we only use it on non-Flatpak Linux builds.
+#if defined(MZ_LINUX) && !defined(MZ_FLATPAK)
 constexpr uint32_t WG_FIREWALL_MARK = 0xca6c;
 #endif
 
@@ -102,7 +103,7 @@ QStringList QProcessObfuscator::buildArgs(const InterfaceConfig& config) {
                              : config.m_serverIpv6AddrIn;
   args << QStringLiteral("--server") << server;
   args << QStringLiteral("--port") << QString::number(config.m_serverPort);
-#ifdef MZ_LINUX
+#if defined(MZ_LINUX) && !defined(MZ_FLATPAK)
   args << QStringLiteral("--fwmark") << QString::number(WG_FIREWALL_MARK);
 #endif
 

--- a/src/daemon/obfuscator/qprocessobfuscator.h
+++ b/src/daemon/obfuscator/qprocessobfuscator.h
@@ -23,7 +23,8 @@ class QProcessObfuscator final : public Obfuscator {
 
  private:
   quint16 parseListeningPort(const QByteArray& line) const;
-  QStringList buildArgs(const InterfaceConfig& config, quint16 listenPort) const;
+  QStringList buildArgs(const InterfaceConfig& config,
+                        quint16 listenPort) const;
   QString binaryName() const;
   // Launch the relay, blocking until it announces its listening port.
   // A non-zero listenPort forces the relay onto that local port.

--- a/src/daemon/obfuscator/qprocessobfuscator.h
+++ b/src/daemon/obfuscator/qprocessobfuscator.h
@@ -17,13 +17,21 @@ class QProcessObfuscator final : public Obfuscator {
   ~QProcessObfuscator() override;
 
   bool start() override;
+  bool restart() override;
+  bool isRunning() const override;
   quint16 localPort() const override { return m_localPort; }
 
  private:
   quint16 parseListeningPort(const QByteArray& line) const;
-  QStringList buildArgs(const InterfaceConfig& config);
+  QStringList buildArgs(const InterfaceConfig& config, quint16 listenPort) const;
   QString binaryName() const;
+  // Launch the relay, blocking until it announces its listening port.
+  // A non-zero listenPort forces the relay onto that local port.
+  bool launch(quint16 listenPort);
+  void stop();
 
+  const InterfaceConfig m_config;
+  QString m_binaryFile;
   QProcess m_process;
   quint16 m_localPort = 0;
 };

--- a/src/daemon/obfuscator/qprocessobfuscator.h
+++ b/src/daemon/obfuscator/qprocessobfuscator.h
@@ -17,6 +17,7 @@ class QProcessObfuscator final : public Obfuscator {
   ~QProcessObfuscator() override;
 
   bool start() override;
+  void stop() override;
   bool restart() override;
   bool isRunning() const override;
   quint16 localPort() const override { return m_localPort; }
@@ -29,7 +30,6 @@ class QProcessObfuscator final : public Obfuscator {
   // Launch the relay, blocking until it announces its listening port.
   // A non-zero listenPort forces the relay onto that local port.
   bool launch(quint16 listenPort);
-  void stop();
 
   const InterfaceConfig m_config;
   QString m_binaryFile;

--- a/src/platforms/linux/netmgrcontroller.cpp
+++ b/src/platforms/linux/netmgrcontroller.cpp
@@ -393,7 +393,11 @@ void NetmgrController::activateCompleted(const QDBusObjectPath& path) {
 }
 
 void NetmgrController::deactivate() {
-  m_obfuscator.reset();
+  // Stop the obfuscator relay but keep the instance, so it can be restarted on
+  // the same local port if the tunnel is reactivated from NetworkManager.
+  if (m_obfuscator) {
+    m_obfuscator->stop();
+  }
 
   if (!m_device || m_device->uuid() != m_uuid) {
     logger.warning() << "Client already disconnected";

--- a/src/platforms/linux/netmgrcontroller.cpp
+++ b/src/platforms/linux/netmgrcontroller.cpp
@@ -53,6 +53,18 @@ NetmgrController::NetmgrController() {
 NetmgrController::~NetmgrController() {
   MZ_COUNT_DTOR(NetmgrController);
   logger.debug() << "Destroying NetmgrController";
+
+  // Stop the obfuscator relay first so its process doesn't outlive us.
+  m_obfuscator.reset();
+
+  // Remove the connection from NetworkManager 
+  if (m_remote) {
+    QDBusReply<void> reply = m_remote->call("Delete");
+    if (!reply.isValid()) {
+      logger.warning() << "Failed to delete connection on shutdown:"
+                       << reply.error().message();
+    }
+  }
 }
 
 // static

--- a/src/platforms/linux/netmgrcontroller.cpp
+++ b/src/platforms/linux/netmgrcontroller.cpp
@@ -57,7 +57,7 @@ NetmgrController::~NetmgrController() {
   // Stop the obfuscator relay first so its process doesn't outlive us.
   m_obfuscator.reset();
 
-  // Remove the connection from NetworkManager 
+  // Remove the connection from NetworkManager
   if (m_remote) {
     QDBusReply<void> reply = m_remote->call("Delete");
     if (!reply.isValid()) {
@@ -474,6 +474,25 @@ void NetmgrController::deviceStateChanged(uint state, uint prev, uint reason) {
 
   if (m_device->uuid() != m_uuid) {
     return;
+  }
+
+  // The connection can be toggled directly from NetworkManager, bypassing
+  // activate()/deactivate(). When obfuscation is in use, the relay
+  // process may have exited while the tunnel was down, but the connection
+  // still points at 127.0.0.1:<port>.
+  // Detect a fresh (re)activation coming from NetworkManager and bring the
+  // relay back on the same local port.
+  bool reactivating = prevstate < NetmgrDevice::PREPARE &&
+                      newstate >= NetmgrDevice::PREPARE &&
+                      newstate <= NetmgrDevice::ACTIVATED;
+  if (m_obfuscator && reactivating && !m_obfuscator->isRunning()) {
+    logger.warning() << "Obfuscator not running on reactivation; restarting on"
+                     << "port" << m_obfuscator->localPort();
+    if (!m_obfuscator->restart()) {
+      logger.error() << "Failed to restart obfuscator";
+      emit backendFailure(Controller::ErrorFatal);
+      return;
+    }
   }
 
   if (newstate == NetmgrDevice::ACTIVATED) {

--- a/src/platforms/linux/netmgrcontroller.cpp
+++ b/src/platforms/linux/netmgrcontroller.cpp
@@ -286,6 +286,8 @@ void NetmgrController::activate(const InterfaceConfig& config,
                        << "is too old for obfuscation bypass routes (need"
                        << kThrowRouteMinVersion.toString() << "or newer);"
                        << "server traffic may loop back into wg0";
+      emit backendFailure(Controller::ErrorFatal);
+      return;
     } else {
       for (const QString& addr :
            {config.m_serverIpv4AddrIn, config.m_serverIpv6AddrIn}) {

--- a/src/platforms/linux/netmgrcontroller.cpp
+++ b/src/platforms/linux/netmgrcontroller.cpp
@@ -138,67 +138,28 @@ void NetmgrController::initialize(const Device* device, const Keys* keys) {
     return;
   }
 
-  // Check if the connection already exists.
-  QDBusReply<QDBusObjectPath> reply = iface.call("GetConnectionByUuid", m_uuid);
-  if (reply.isValid()) {
-    logger.info() << "Connection" << m_uuid << "already exists";
-    initCompleted(reply.value(), QVariantMap());
-    return;
-  }
-
-  // Create the connection
-  logger.info() << "Adding connection:" << m_uuid;
-  QVariantList args;
-  args << serializeConfig();
-  args << (uint)IN_MEMORY;
-  args << QVariantMap();
-  bool okay = iface.callWithCallback(
-      "AddConnection2", args, this,
-      SLOT(initCompleted(const QDBusObjectPath&, const QVariantMap&)),
-      SLOT(dbusInitError(const QDBusError&)));
-  if (!okay) {
-    logger.debug() << "AddConnection2 failed";
-    emit initialized(false, false, QDateTime());
-  }
-}
-
-void NetmgrController::initCompleted(const QDBusObjectPath& path,
-                                     const QVariantMap& results) {
-  logger.debug() << "connection created:" << path.path();
-  m_remote = new QDBusInterface(DBUS_NM_SERVICE, path.path(),
-                                nmInterface("Settings.Connection"),
-                                m_client->connection(), this);
-  if (!m_remote->isValid()) {
-    logger.warning() << "NetworkManager connection is not available";
-    emit initialized(false, false, QDateTime());
-    return;
-  }
-
   // Monitor for changes in the connected devices.
   connect(m_client, SIGNAL(DeviceAdded(QDBusObjectPath)), this,
           SLOT(deviceAdded(QDBusObjectPath)));
   connect(m_client, SIGNAL(DeviceRemoved(QDBusObjectPath)), this,
           SLOT(deviceRemoved(QDBusObjectPath)));
 
-  // Fetch the device in case it already exists.
-  bool isConnected = false;
-  QDBusReply<QDBusObjectPath> reply =
-      m_client->call("GetDeviceByIpIface", WG_INTERFACE_NAME);
+  // Delete any profile left over from a previous session, it should not exist and can't be trusted.
+  // If obfuscation was in use the process died with that session.
+  // WireGuard peer points to a dead 127.0.0.1:<port> and we have no InterfaceConfig
+  // to rebuild the obfuscator.
+  QDBusReply<QDBusObjectPath> reply = iface.call("GetConnectionByUuid", m_uuid);
   if (reply.isValid()) {
-    m_device = new NetmgrDevice(reply.value().path(), this);
-    connect(m_device, &NetmgrDevice::stateChanged, this,
-            &NetmgrController::deviceStateChanged);
-
-    isConnected = m_device->state() == NetmgrDevice::ACTIVATED &&
-                  m_device->uuid() == m_uuid;
+    logger.info() << "Deleting stale connection:" << m_uuid;
+    QDBusInterface stale(DBUS_NM_SERVICE, reply.value().path(),
+                         nmInterface("Settings.Connection"),
+                         m_client->connection());
+    stale.call("Delete");
   }
 
-  emit initialized(true, isConnected, guessUptime());
-}
+  // Interface creation is deferred until the first activation.
 
-void NetmgrController::dbusInitError(const QDBusError& error) {
-  logger.warning() << "initialization failed:" << error.message();
-  emit initialized(false, false, QDateTime());
+  emit initialized(true, false, QDateTime());
 }
 
 void NetmgrController::dbusBackendError(const QDBusError& error) {
@@ -262,7 +223,7 @@ QVariant NetmgrController::serializeConfig() const {
 
 void NetmgrController::activate(const InterfaceConfig& config,
                                 Controller::Reason reason) {
-  if (!m_client || !m_client->isValid() || !m_remote || !m_remote->isValid()) {
+  if (!m_client || !m_client->isValid()) {
     logger.warning() << "Cannot activate without a valid NetworkManager "
                         "connection";
     emit backendFailure(Controller::ErrorFatal);
@@ -361,6 +322,28 @@ void NetmgrController::activate(const InterfaceConfig& config,
   } else {
     setDnsConfig(m_ipv4config, QHostAddress(config.m_dnsServer));
     setDnsConfig(m_ipv6config, QHostAddress());
+  }
+
+  if (!m_remote) {
+    logger.info() << "Adding connection:" << m_uuid;
+    QString path = QStringLiteral(DBUS_NM_PATH) + "/Settings";
+    QDBusInterface iface(DBUS_NM_SERVICE, path, nmInterface("Settings"),
+                         m_client->connection());
+    QVariantList addArgs;
+    addArgs << serializeConfig();
+    addArgs << (uint)IN_MEMORY;
+    addArgs << QVariantMap();
+    // Use a blocking AddConnection2 to keep the flow simple
+    QDBusReply<QDBusObjectPath> added =
+        iface.callWithArgumentList(QDBus::Block, "AddConnection2", addArgs);
+    if (!added.isValid()) {
+      logger.warning() << "AddConnection2 failed:" << added.error().message();
+      emit backendFailure(Controller::ErrorFatal);
+      return;
+    }
+    m_remote = new QDBusInterface(DBUS_NM_SERVICE, added.value().path(),
+                                  nmInterface("Settings.Connection"),
+                                  m_client->connection(), this);
   }
 
   // Update the connection settings.

--- a/src/platforms/linux/netmgrcontroller.cpp
+++ b/src/platforms/linux/netmgrcontroller.cpp
@@ -15,6 +15,7 @@
 #include <QScopeGuard>
 #include <QUuid>
 
+#include "daemon/obfuscator/qprocessobfuscator.h"
 #include "dbustypes.h"
 #include "leakdetector.h"
 #include "logger.h"
@@ -255,6 +256,9 @@ void NetmgrController::activate(const InterfaceConfig& config,
     emit backendFailure(Controller::ErrorFatal);
     return;
   }
+  const bool obfuscate =
+      config.m_obfuscationMethod != Server::ObfuscationMethod::NoObfuscation &&
+      config.m_hopType != InterfaceConfig::MultiHopExit;
 
   // Update routes and allowedIpAddreses
   NetmgrDataList ipv4routes;
@@ -271,7 +275,58 @@ void NetmgrController::activate(const InterfaceConfig& config,
     }
   }
 
-  NetmgrDataList peers(wgPeer(config));
+  // The traffic to the real server must bypass the tunnel.
+  // In the Flatpak sandbox, we cannot use SO_MARK so instead we set
+  // "throw" route for each server endpoint into the WireGuard policy table
+  // "throw" needs NetworkManager >= 1.38.
+  if (obfuscate) {
+    static const QVersionNumber kThrowRouteMinVersion(1, 38);
+    if (m_version < kThrowRouteMinVersion) {
+      logger.warning() << "NetworkManager" << m_version.toString()
+                       << "is too old for obfuscation bypass routes (need"
+                       << kThrowRouteMinVersion.toString() << "or newer);"
+                       << "server traffic may loop back into wg0";
+    } else {
+      for (const QString& addr :
+           {config.m_serverIpv4AddrIn, config.m_serverIpv6AddrIn}) {
+        if (addr.isEmpty()) {
+          continue;
+        }
+        QVariantMap route;
+        route.insert("dest", addr);
+        route.insert("type", QStringLiteral("throw"));
+        route.insert("table", WG_FIREWALL_MARK);
+        if (QHostAddress(addr).protocol() == QAbstractSocket::IPv6Protocol) {
+          route.insert("prefix", (uint)128);
+          ipv6routes.append(route);
+        } else {
+          route.insert("prefix", (uint)32);
+          ipv4routes.append(route);
+        }
+      }
+    }
+  }
+
+  // Start the obfuscator proxy and point the WireGuard peer at it.
+  InterfaceConfig peerConfig = config;
+  m_obfuscator.reset();
+  if (obfuscate) {
+    auto obfuscator = std::make_unique<QProcessObfuscator>(config);
+    if (!obfuscator->start()) {
+      logger.error() << "Failed to start obfuscator"
+                     << config.m_obfuscationMethod;
+      emit backendFailure(Controller::ErrorFatal);
+      return;
+    }
+    peerConfig.m_serverIpv4AddrIn = "127.0.0.1";
+    // The relay only binds 127.0.0.1, so clear the IPv6 endpoint to stop
+    // WireGuard from selecting [::1].
+    peerConfig.m_serverIpv6AddrIn = QString();
+    peerConfig.m_serverPort = obfuscator->localPort();
+    m_obfuscator = std::move(obfuscator);
+  }
+
+  NetmgrDataList peers(wgPeer(peerConfig));
   m_ipv4config.insert("route-data", ipv4routes);
   m_ipv6config.insert("route-data", ipv6routes);
   m_wireguard.insert("peers", peers);
@@ -341,6 +396,8 @@ void NetmgrController::activateCompleted(const QDBusObjectPath& path) {
 }
 
 void NetmgrController::deactivate() {
+  m_obfuscator.reset();
+
   if (!m_device || m_device->uuid() != m_uuid) {
     logger.warning() << "Client already disconnected";
     emit disconnected();

--- a/src/platforms/linux/netmgrcontroller.h
+++ b/src/platforms/linux/netmgrcontroller.h
@@ -10,7 +10,6 @@
 #include <QObject>
 #include <QVariant>
 #include <QVersionNumber>
-
 #include <memory>
 
 #include "controllerimpl.h"

--- a/src/platforms/linux/netmgrcontroller.h
+++ b/src/platforms/linux/netmgrcontroller.h
@@ -11,9 +11,12 @@
 #include <QVariant>
 #include <QVersionNumber>
 
+#include <memory>
+
 #include "controllerimpl.h"
 
 class NetmgrDevice;
+class Obfuscator;
 class QDateTime;
 class QDBusInterface;
 class QDBusError;
@@ -88,6 +91,8 @@ class NetmgrController final : public ControllerImpl {
 
   QString m_connectionPath;
   NetmgrDevice* m_device = nullptr;
+
+  std::unique_ptr<Obfuscator> m_obfuscator;
 };
 
 #endif  // NETWORKMANAGERCONTROLLER_H

--- a/src/platforms/linux/netmgrcontroller.h
+++ b/src/platforms/linux/netmgrcontroller.h
@@ -49,11 +49,9 @@ class NetmgrController final : public ControllerImpl {
   Q_ENUM(Flags);
 
  private slots:
-  void initCompleted(const QDBusObjectPath& path, const QVariantMap& results);
   void peerCompleted(const QVariantMap& results);
   void activateCompleted(const QDBusObjectPath& path);
 
-  void dbusInitError(const QDBusError& error);
   void dbusBackendError(const QDBusError& error);
 
   void deviceAdded(const QDBusObjectPath& path);


### PR DESCRIPTION
## Description

 Enable obfuscation features in Flatpak builds:
- add stop / restart capability to `Obfuscator`
- defer connection inizialization to activate
- build and install  `mozillavpn-obfuscator`  for Flatpak
- spin the `mozillavpn-obfuscator` inside `NetmgrController`  and rewrite the peer to `127.0.0.1`
- add a **throw** route for the VPN server into the WireGuard policy table so the relay's traffic to the server escapes the tunnel 
- the throw route requires NetWork Manager [1.38](https://networkmanager.dev/docs/api/1.38/nm-settings-nmcli.html), emit a `backendFailure` and log a warning if network manager is too old (jammy is still on [1.36](https://networkmanager.dev/docs/api/1.36/nm-settings-nmcli.html))

## Reference

[VPN-7737](https://mozilla-hub.atlassian.net/browse/VPN-7737)

## Checklist
    
- [x] My code follows the style guidelines for this project
- [ ] If bug/feature is at all notable, I've added a draft release note as a comment in `addons/strings.yaml`.
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-7737]: https://mozilla-hub.atlassian.net/browse/VPN-7737?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ