### PR TITLE
Nit: add padding between obfuscation label and timer

### DIFF
--- a/src/ui/screens/home/controller/ControllerView.qml
+++ b/src/ui/screens/home/controller/ControllerView.qml
@@ -535,11 +535,15 @@ Item {
     Column {
         id: col
 
+        property int baseTopMargin: 24
+
         spacing: 0
         anchors.left: box.left
         anchors.right: box.right
         anchors.top: logo.bottom
-        anchors.topMargin: 24
+        // When the obfuscation label is shown it adds a line at the bottom of the
+        // column, to shift the column a little up and avoid overlap with the toggle.
+        anchors.topMargin: baseTopMargin - (obfuscationEnabled.visible ? 8 : 0)
         width: parent.width
 
         function handleMultilineText() {
@@ -548,23 +552,23 @@ Item {
             const subTitleIsWrapped = (logoSubtitle.visible && logoSubtitle.lineCount > 1 || (connectionStability.visible && connectionStability.gridFlow === Grid.TopToBottom));
 
             if (titleIsWrapped && subTitleIsWrapped) {
-                col.anchors.topMargin = 12
+                col.baseTopMargin = 12
                 spacer.height = 6;
                 return;
             }
 
             if (subTitleIsWrapped) {
-                col.anchors.topMargin = 24
+                col.baseTopMargin = 24
                 spacer.height = 4;
                 return;
             }
 
             if (titleIsWrapped) {
-                col.anchors.topMargin = 16
+                col.baseTopMargin = 16
                 spacer.height = 12;
                 return;
             }
-            col.anchors.topMargin = 24
+            col.baseTopMargin = 24
             spacer.height = 16;
         }
 
@@ -636,6 +640,7 @@ Item {
         MZInterLabel {
             id: obfuscationEnabled
             anchors.horizontalCenter: parent.horizontalCenter
+            topPadding: 8
             opacity: 0.8
             color: MZTheme.colors.fontColorInverted
             lineHeight: MZTheme.theme.controllerInterLineHeight


### PR DESCRIPTION
## Description

Add some padding between obfuscation label and timer. Shift everything a little up when obfuscation is enabled to avoid overlapping the toggle button.

<img width="382" height="700" alt="Screenshot from 2026-08-13 17-26-21" src="https://github.com/user-attachments/assets/30a9cc92-b723-4600-8a11-6c1bcf35b9f2" />
<img width="382" height="700" alt="Screenshot from 2026-08-13 17-27-15" src="https://github.com/user-attachments/assets/e0ecfb45-ed0f-4a9e-84e6-88724064d6a8" />

## Reference

    i.e Jira or Github issue URL

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] If bug/feature is at all notable, I've added a draft release note as a comment in `addons/strings.yaml`.
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
