### PR TITLE
adjust margins

### DIFF
--- a/src/ui/screens/settings/privacy/ViewPrivacy.qml
+++ b/src/ui/screens/settings/privacy/ViewPrivacy.qml
@@ -94,8 +94,8 @@ MZViewBase {
             anchors.left: undefined
             anchors.right: undefined
 
-            Layout.leftMargin: 16
-            Layout.rightMargin: 16
+            Layout.leftMargin: MZTheme.theme.windowMargin / 2
+            Layout.rightMargin: MZTheme.theme.windowMargin / 2
             Layout.topMargin: -MZTheme.theme.windowMargin / 2
             Layout.fillWidth: true
             Layout.minimumHeight: MZTheme.theme.rowHeight
@@ -111,6 +111,8 @@ MZViewBase {
                 anchors.left: parent.left
                 anchors.right: parent.right
                 anchors.verticalCenter: parent.verticalCenter
+                anchors.leftMargin: MZTheme.theme.windowMargin / 2
+                anchors.rightMargin: MZTheme.theme.windowMargin / 2
 
                 ColumnLayout {
                     id: obfuscationContent


### PR DESCRIPTION
## Description

This matches other rows a bit better. I'd love to also give some vertical padding, but I played around with it for a bit and couldn't find a good way to add some.

And while we're in there, let's change to using the variables.

Before
<img width="166" alt="Screenshot 161" src="https://github.com/user-attachments/assets/6622bf12-8701-45e6-8778-297dde720a0f" />

After
<img width="160" alt="Screenshot 162" src="https://github.com/user-attachments/assets/be092130-667c-423f-8c74-0c3ecb5b5523" />



## Reference

N/A

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] If bug/feature is at all notable, I've added a draft release note as a comment in `addons/strings.yaml`.
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
