### PR TITLE
VPN-7730 Add port selection code for fallback server on ios

### DIFF
--- a/src/platforms/ios/ioscontroller.mm
+++ b/src/platforms/ios/ioscontroller.mm
@@ -160,6 +160,22 @@ void IOSController::activate(const InterfaceConfig& config, Controller::Reason r
   NSString* mainServerGateway = config.m_serverIpv4Gateway.toNSString();
   BOOL isUsingNormalDns = [mainServerDns isEqualToString:mainServerGateway];
 
+  // Fallback/backup servers must pick their port the same way the main server
+  // did in Controller::setupConfigs(), otherwise a switch to a fallback server
+  // will silently drops the forced port.
+  SettingsHolder::ObfuscationPolicy obfuscationPolicy =
+      static_cast<SettingsHolder::ObfuscationPolicy>(settingsHolder->obfuscationPolicy());
+  auto fallbackPort = [&](const Server& server) -> uint32_t {
+    if (obfuscationPolicy == SettingsHolder::ObfuscationPolicy::Port53 ||
+        obfuscationPolicy == SettingsHolder::ObfuscationPolicy::LwoOverPort53) {
+      return 53;
+    }
+    if (config.m_obfuscationMethod == Server::ObfuscationMethod::UdpOverTcp) {
+      return server.chooseTcpPort();
+    }
+    return server.choosePort();
+  };
+
   const QList<Server> fallbackServers = mainServerData.backupServers(config.m_serverPublicKey);
   for (const Server& fallbackServer : fallbackServers) {
     NSString* dnsServer;
@@ -173,7 +189,7 @@ void IOSController::activate(const InterfaceConfig& config, Controller::Reason r
                                ipv6Gateway:fallbackServer.ipv6Gateway().toNSString()
                                  publicKey:fallbackServer.publicKey().toNSString()
                                 ipv4AddrIn:fallbackServer.ipv4AddrIn().toNSString()
-                                      port:fallbackServer.choosePort()
+                                      port:fallbackPort(fallbackServer)
                                  // Reusing config here - city names will be identical, and no good
                                  // way to get entry city otherwise.
                                  entryCity:config.m_entryCity.toNSString()


### PR DESCRIPTION
## Description

This is an attempt to fix iOS not using port 53 to connect when "Always connect using port 53" is selected in obfuscation features .
I think the issue was caused by the use of a fallback server,  with port selection code being completely missing from the iOS fallback server selection branch.

## Reference

[VPN-7730](https://mozilla-hub.atlassian.net/browse/VPN-7730)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] If bug/feature is at all notable, I've added a draft release note as a comment in `addons/strings.yaml`.
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-7730]: https://mozilla-hub.atlassian.net/browse/VPN-7730?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ