### PR TITLE
remove unneeded string for translation

### DIFF
--- a/addons/message_mandatory_update_to_web_auth_1/manifest.json
+++ b/addons/message_mandatory_update_to_web_auth_1/manifest.json
@@ -16,7 +16,7 @@
     "shortVersion": "2.40",
     "id": "message_mandatory_update_to_web_auth_1",
     "title": "vpn.mandatoryUpdate.title",
-    "subtitle": "vpn.mandatoryUpdate.body1",
+    "subtitle": "vpn.mandatoryUpdate.title",
     "badge": "critical",
     "blocks": [
       {

--- a/addons/message_mandatory_update_to_web_auth_2/manifest.json
+++ b/addons/message_mandatory_update_to_web_auth_2/manifest.json
@@ -16,7 +16,7 @@
     "shortVersion": "2.40", 
     "id": "message_mandatory_update_to_web_auth_2",
     "title": "vpn.mandatoryUpdate.title",
-    "subtitle": "vpn.mandatoryUpdate.body1",
+    "subtitle": "vpn.mandatoryUpdate.title",
     "badge": "critical",
     "blocks": [
       {

--- a/addons/strings.yaml
+++ b/addons/strings.yaml
@@ -240,9 +240,9 @@ mandatoryUpdate:
   title:
     value: "Action required: Update to the latest version"
     comment: Title of a message. Should make it clear the user must take action.
-  body1:
-    value: This version of Mozilla VPN will no longer be supported as of October 19, 2026.
-    comment: Line explaining end-of-life for some Mozilla VPN versions. Include the deadline date.
+  # body1:
+  #   value: This version of Mozilla VPN will no longer be supported as of October 19, 2026.
+  #   comment: Line explaining end-of-life for some Mozilla VPN versions. Include the deadline date.
   body2:
     value: Please update to the latest version to continue using Mozilla VPN.
     comment: Line asking users to update. This should be kind, yet firm. It should not include any language that implies this is optional.


### PR DESCRIPTION
Timeline is changing, and so this string is no longer valid. (Sorry.) We don't have a new confirmed timeline yet, but I want to remove this string to stop translators from having to see it.

(Subtitle needs something, and so I'm giving it a placeholder for now.)