### PR TITLE
VPN-7746 Part 2 - add libdbus-1-3

### DIFF
--- a/linux/debian/control
+++ b/linux/debian/control
@@ -63,6 +63,7 @@ Vcs-Git: https://github.com/mozilla-mobile/mozilla-vpn-client
 Package: mozillavpn
 Architecture: any
 Depends: wireguard (>=1.0.20200319),
+         libdbus-1-3,
          libfreetype6,
          libfontconfig1,
          libegl1,


### PR DESCRIPTION
## Description

This is a follow up to #11514.
Added `libdbus-1-3`. This should be installed even on a minimal Ubuntu setup, i'm doing this mostly for convenience because is  not included in the Ubuntu Docker image, which is the setup i use to test the CLI.

## Reference

    i.e Jira or Github issue URL

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] If bug/feature is at all notable, I've added a draft release note as a comment in `addons/strings.yaml`.
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
