### PR TITLE
Fix assertion crash on silent server switch with no alternative server

### DIFF
--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -751,10 +751,12 @@ bool Controller::silentSwitchServers(
   }
 
   if (selectionPolicy == RandomizeServerSelection) {
+    // The current server is usually filtered out of this list already by the
+    // cooldown set above, or by obfuscation, so an empty list is expected.
     QList<Server> servers = m_serverData.exitServers();
-    Q_ASSERT(!servers.isEmpty());
-
-    if (servers.length() <= 1) {
+    if (servers.isEmpty() ||
+        (servers.length() == 1 &&
+         servers.first().publicKey() == m_serverData.exitServerPublicKey())) {
       logger.warning()
           << "Cannot silent switch servers because must pick new server, and "
              "the only available one is current server";


### PR DESCRIPTION
## Description

Fixes a debug-build abort during silent switching when no alternative server is available. I think the assert was correct before #11474 where setCooldown() was moved before exitServers() query.

This drops the assert and adds a condition to switch only when there's no other server to pick.

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] If bug/feature is at all notable, I've added a draft release note as a comment in `addons/strings.yaml`.
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
