### PR TITLE
update tag to maybe fix Windows builds

### DIFF
--- a/windows/split-tunnel/CMakeLists.txt
+++ b/windows/split-tunnel/CMakeLists.txt
@@ -8,7 +8,11 @@ FetchContent_Declare(
     win_split_tunnel
     DOWNLOAD_EXTRACT_TIMESTAMP true
     GIT_REPOSITORY https://github.com/mullvad/mullvadvpn-app-binaries.git
-    GIT_TAG 84b943f9dfce49a571092846effa44e8200ec33f # Latest commit as of December 8, 2025
+    GIT_TAG cc0affb2f06e870fb594e2dd6d61049611991586 # Latest commit as of August 24, 2026
+    # We only need the prebuilt driver files, which live in the top-level tree.
+    # Skip the submodules: libmnl and libnftnl are Linux-only netfilter libraries
+    # served over git:// from git.netfilter.org, which CI cannot reach.
+    GIT_SUBMODULES ""
 )
 FetchContent_MakeAvailable(win_split_tunnel)
 


### PR DESCRIPTION
logs

```
[task 2026-08-24T18:58:42.282+00:00]   Failed to update submodules in:
[task 2026-08-24T18:58:42.282+00:00]   '/builds/worker/build-win/_deps/win_split_tunnel-src'
[task 2026-08-24T18:58:42.282+00:00] 
[task 2026-08-24T18:58:42.282+00:00] 
[task 2026-08-24T18:58:42.282+00:00] FAILED: win_split_tunnel-populate-prefix/src/win_split_tunnel-populate-stamp/win_split_tunnel-populate-download /builds/worker/build-win/_deps/win_split_tunnel-subbuild/win_split_tunnel-populate-prefix/src/win_split_tunnel-populate-stamp/win_split_tunnel-populate-download 
[task 2026-08-24T18:58:42.282+00:00] cd /builds/worker/build-win/_deps && /builds/worker/fetches/conda/bin/cmake -DCMAKE_MESSAGE_LOG_LEVEL=VERBOSE -P /builds/worker/build-win/_deps/win_split_tunnel-subbuild/win_split_tunnel-populate-prefix/tmp/win_split_tunnel-populate-gitclone.cmake && /builds/worker/fetches/conda/bin/cmake -E touch /builds/worker/build-win/_deps/win_split_tunnel-subbuild/win_split_tunnel-populate-prefix/src/win_split_tunnel-populate-stamp/win_split_tunnel-populate-download
[task 2026-08-24T18:58:42.282+00:00] ninja: build stopped: subcommand failed.
[task 2026-08-24T18:58:42.282+00:00] 
[task 2026-08-24T18:58:42.283+00:00] CMake Error at /builds/worker/fetches/conda/share/cmake-4.2/Modules/FetchContent.cmake:1928 (message):
[task 2026-08-24T18:58:42.283+00:00]   Build step for win_split_tunnel failed: 1
[task 2026-08-24T18:58:42.283+00:00] Call Stack (most recent call first):
[task 2026-08-24T18:58:42.283+00:00]   /builds/worker/fetches/conda/share/cmake-4.2/Modules/FetchContent.cmake:1619 (__FetchContent_populateSubbuild)
[task 2026-08-24T18:58:42.283+00:00]   /builds/worker/fetches/conda/share/cmake-4.2/Modules/FetchContent.cmake:2155:EVAL:2 (__FetchContent_doPopulation)
[task 2026-08-24T18:58:42.283+00:00]   /builds/worker/fetches/conda/share/cmake-4.2/Modules/FetchContent.cmake:2155 (cmake_language)
[task 2026-08-24T18:58:42.283+00:00]   /builds/worker/fetches/conda/share/cmake-4.2/Modules/FetchContent.cmake:2394 (__FetchContent_Populate)
[task 2026-08-24T18:58:42.283+00:00]   windows/split-tunnel/CMakeLists.txt:13 (FetchContent_MakeAvailable)
```