### PR TITLE
Ensure silent server switching for servers with different gateway

### DIFF
--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -487,11 +487,11 @@ bool Daemon::supportServerSwitching(const InterfaceConfig& config) const {
   const InterfaceConfig& current =
       m_connections.value(config.m_hopType).m_config;
 
+  // Gateways are intentionally not compared: a different-gateway switch is
+  // still handled in-place by switchServer(), avoiding a teardown/leak gap.
   return current.m_privateKey == config.m_privateKey &&
          current.m_deviceIpv4Address == config.m_deviceIpv4Address &&
-         current.m_deviceIpv6Address == config.m_deviceIpv6Address &&
-         current.m_serverIpv4Gateway == config.m_serverIpv4Gateway &&
-         current.m_serverIpv6Gateway == config.m_serverIpv6Gateway;
+         current.m_deviceIpv6Address == config.m_deviceIpv6Address;
 }
 
 bool Daemon::switchServer(const InterfaceConfig& config) {


### PR DESCRIPTION
## Description

Ensure interface teardown doesn't happen when silently switching servers.

## Reference

[VPN-7733](https://mozilla-hub.atlassian.net/browse/VPN-7733)

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] If bug/feature is at all notable, I've added a draft release note as a comment in `addons/strings.yaml`.
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed


[VPN-7733]: https://mozilla-hub.atlassian.net/browse/VPN-7733?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ