### PR TITLE
VPN-7745 - adjust addons for force update warnings

### DIFF
--- a/addons/message_mandatory_update_to_web_auth_1/manifest.json
+++ b/addons/message_mandatory_update_to_web_auth_1/manifest.json
@@ -5,18 +5,20 @@
   "type": "message",
   "conditions": {
     "max_client_version": "2.34.9",
-    "javascript": "osCheck.js"
+    "javascript": "osCheck.js",
+    "start_time": 1790874000,
+    "end_time": 1791478800
   },
   "javascript": {
     "enable": "enable.js"
   },
   "message": {
-    "date": 1789578000,
+    "date": 1790874000,
     "usesSharedStrings": true,
     "shortVersion": "2.40",
     "id": "message_mandatory_update_to_web_auth_1",
     "title": "vpn.mandatoryUpdate.title",
-    "subtitle": "vpn.mandatoryUpdate.title",
+    "subtitle": "vpn.mandatoryUpdate.body1",
     "badge": "critical",
     "blocks": [
       {

--- a/addons/message_mandatory_update_to_web_auth_1/osCheck.js
+++ b/addons/message_mandatory_update_to_web_auth_1/osCheck.js
@@ -49,20 +49,7 @@ function computeCondition() {
     return;
   }
 
-  // We've confirme we're in a version that may require this addon. Now check
-  // the date.
-  let now = Date.now();
-  let endTime = 1791478800000  // 10am Pacific on Oct 8 2026
-
-  if (now >= endTime) {
-    condition.disable()
-  }
-  else {
-    condition.enable()
-    // Set callback - if app isn't closed, we need to turn off this addon at the
-    // appropriate time
-    api.setTimedCallback(endTime, () => computeCondition());
-  }
+  condition.enable();
 }
 
 computeCondition();

--- a/addons/message_mandatory_update_to_web_auth_2/manifest.json
+++ b/addons/message_mandatory_update_to_web_auth_2/manifest.json
@@ -5,7 +5,8 @@
   "type": "message",
   "conditions": {
     "max_client_version": "2.34.9",
-    "javascript": "osCheck.js"
+    "javascript": "osCheck.js",
+    "start_time": 1791478800
   },
   "javascript": {
     "enable": "enable.js"
@@ -16,7 +17,7 @@
     "shortVersion": "2.40", 
     "id": "message_mandatory_update_to_web_auth_2",
     "title": "vpn.mandatoryUpdate.title",
-    "subtitle": "vpn.mandatoryUpdate.title",
+    "subtitle": "vpn.mandatoryUpdate.body1",
     "badge": "critical",
     "blocks": [
       {

--- a/addons/message_mandatory_update_to_web_auth_2/osCheck.js
+++ b/addons/message_mandatory_update_to_web_auth_2/osCheck.js
@@ -49,20 +49,7 @@ function computeCondition() {
     return;
   }
 
-  // We've confirme we're in a version that may require this addon. Now check
-  // the date.
-  let now = Date.now();
-  let startTime = 1791478800000  // 10am Pacific on Oct 8 2026
-
-  if (now < startTime) {
-    condition.disable()
-    // Set callback - if app isn't closed, we need to turn on this addon at the
-    // appropriate time
-    api.setTimedCallback(startTime, () => computeCondition());
-  }
-  else {
-    condition.enable()
-  }
+  condition.enable();
 }
 
 computeCondition();

--- a/addons/strings.yaml
+++ b/addons/strings.yaml
@@ -240,9 +240,9 @@ mandatoryUpdate:
   title:
     value: "Action required: Update to the latest version"
     comment: Title of a message. Should make it clear the user must take action.
-  # body1:
-  #   value: This version of Mozilla VPN will no longer be supported as of October 19, 2026.
-  #   comment: Line explaining end-of-life for some Mozilla VPN versions. Include the deadline date.
+  body1:
+    value: This version of Mozilla VPN will no longer be supported as of October 19, 2026.
+    comment: Line explaining end-of-life for some Mozilla VPN versions. Include the deadline date.
   body2:
     value: Please update to the latest version to continue using Mozilla VPN.
     comment: Line asking users to update. This should be kind, yet firm. It should not include any language that implies this is optional.


### PR DESCRIPTION
## Description

This reverses changes from https://github.com/mozilla-mobile/mozilla-vpn-client/pull/11507, and updates the timing for the addons.

- Turns out the final deadline is going to remain the same, so no changes needed to the string. Adding it back in.
- We are going to show the first message a little bit later. In adjusting this, I realized we have an addon condition that handles timing, so and that seems more straightforward than manually re-implementing that in the javascript file. So I adjusted how we're handling timing.

I tested this by manually adjusting the system clock, and it seems to work.

## Reference

VPN-7745

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] If bug/feature is at all notable, I've added a draft release note as a comment in `addons/strings.yaml`.
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
