### PR TITLE
Update DNS resolvers in place during a server switch

### DIFF
--- a/src/daemon/daemon.cpp
+++ b/src/daemon/daemon.cpp
@@ -85,10 +85,17 @@ bool Daemon::activate(const InterfaceConfig& config) {
         return false;
       }
 
+#if defined(MZ_MACOS)
+      // macOS restores the resolvers by terminating the DNS manager process,
+      // so they must be reverted before a new configuration can be applied
+      // (see https://mozilla-hub.atlassian.net/browse/VPN-7752)
       if (!dnsutils()->restoreResolvers()) {
         return false;
       }
+#endif
 
+      // Elsewhere updateResolvers() replaces the configuration in place.
+      // Reverting first would expose the physical link's DNS until it lands
       if (!maybeUpdateResolvers(config)) {
         return false;
       }


### PR DESCRIPTION
## Description

Remove redundant reverting and restarting resolvers on a live interface under Windows and Linux, as `updateResolvers()` replaces resolver configuration on these platforms.

## Reference

[VPN-7733](https://mozilla-hub.atlassian.net/browse/VPN-7733)

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] If bug/feature is at all notable, I've added a draft release note as a comment in `addons/strings.yaml`.
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed


[VPN-7733]: https://mozilla-hub.atlassian.net/browse/VPN-7733?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ