### PR TITLE
Disable  obfuscators on Flatpak and LWO over port 53 on Windows and Android

### DIFF
--- a/src/feature/features.h
+++ b/src/feature/features.h
@@ -30,6 +30,12 @@ inline constexpr bool linux_ = true;
 inline constexpr bool linux_ = false;
 #endif
 
+#ifdef MZ_FLATPAK
+inline constexpr bool flatpak = true;
+#else
+inline constexpr bool flatpak = false;
+#endif
+
 #ifdef MZ_ANDROID
 inline constexpr bool android = true;
 #else
@@ -242,7 +248,8 @@ inline constexpr ConstantFeature freeTrial = {
 inline constexpr ConstantFeature obfuscationLwo = {
     .id = "obfuscationLwo",
     .name = "LWO obfuscation",
-    .supported = Platform::linux_ || Platform::android || Platform::windows,
+    .supported = (Platform::linux_ && !Platform::flatpak) ||
+                 Platform::android || Platform::windows,
 };
 
 inline constexpr ConstantFeature obfuscationMasque = {
@@ -260,7 +267,8 @@ inline constexpr ConstantFeature obfuscationShadowsocks = {
 inline constexpr ConstantFeature obfuscationUdpOverTcp = {
     .id = "obfuscationUdpOverTcp",
     .name = "UDP over TCP",
-    .supported = Platform::linux_ || Platform::android || Platform::windows,
+    .supported = (Platform::linux_ && !Platform::flatpak) ||
+                 Platform::android || Platform::windows,
 };
 
 inline const OverridableFeature replacerAddon = {

--- a/src/ui/screens/settings/privacy/obfuscation/ObfuscationFeaturesList.qml
+++ b/src/ui/screens/settings/privacy/obfuscation/ObfuscationFeaturesList.qml
@@ -55,7 +55,9 @@ ColumnLayout {
                 settingDescription: MZI18n.SettingsObfuscationLwoBody,
             }, {
                 objectName: "lwoOverPort53",
-                visible: MZFeatureList.get("obfuscationLwo").isSupported,
+                // LWO over port 53 is broken on Windows and Android, so only
+                // show it on Linux. See VPN-7739.
+                visible: MZFeatureList.get("obfuscationLwo").isSupported && MZEnv.platform === "linux",
                 settingValue: MZSettings.LwoOverPort53,
                 settingTitle: MZI18n.SettingsObfuscationLwoOverPort53Title,
                 settingDescription: MZI18n.SettingsObfuscationLwoOverPort53Body,


### PR DESCRIPTION
## Description

Disable  obfuscators on Flatpak because the flatpak PR is still WIP.
Disable LWO over port 53 on Windows and Android due to VPN-7739

## Reference

    i.e Jira or Github issue URL

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] If bug/feature is at all notable, I've added a draft release note as a comment in `addons/strings.yaml`.
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed
