### PR TITLE
debug option to show message id

### DIFF
--- a/src/feature/featuremodel.h
+++ b/src/feature/featuremodel.h
@@ -35,6 +35,7 @@ inline const AnyFeature s_exposedFeatures[] = {
     ref(obfuscationUdpOverTcp),
     ref(replacerAddon),
     ref(shareLogs),
+    ref(showAddonId),
     ref(showDetailedConnectionInfo),
     ref(showRotateIPAddressButton),
     ref(startOnBoot),

--- a/src/feature/features.h
+++ b/src/feature/features.h
@@ -269,6 +269,12 @@ inline const OverridableFeature replacerAddon = {
     .evaluator = +[] { return false; },
 };
 
+inline const OverridableFeature showAddonId = {
+    .id = "showAddonId",
+    .name = "Show addon ID in message view",
+    .evaluator = +[] { return false; },
+};
+
 inline const OverridableFeature showDetailedConnectionInfo = {
     .id = "showDetailedConnectionInfo",
     .name = "Show detailed connection info",

--- a/src/ui/screens/messaging/ViewMessage.qml
+++ b/src/ui/screens/messaging/ViewMessage.qml
@@ -77,6 +77,18 @@ MZViewBase {
 
         spacing: 0
 
+        MZTextBlock {
+            objectName: "messageAddonId"
+
+            Layout.fillWidth: true
+            Layout.bottomMargin: MZTheme.theme.listSpacing
+
+            text: message.id
+            font.pixelSize: MZTheme.theme.fontSizeSmall
+            wrapMode: Text.WrapAnywhere
+            visible: MZFeatureList.get("showAddonId").isSupported
+        }
+
         RowLayout {
             id: badgeAndTimestampRow
 


### PR DESCRIPTION
## Description

New debug option. For things with multiple identical addons - like `message_mandatory_update_to_web_auth_[1,2]` - it would be nice for QA to confirm which addon they're seeing without needing to look at logs.

With feature activated:
<img width="167" alt="Screenshot 163" src="https://github.com/user-attachments/assets/3939a868-03a3-46d5-bee0-05fdeace6ba2" />

With feature deactivated (looks like normal):
<img width="163" alt="Screenshot 164" src="https://github.com/user-attachments/assets/ecb54ca5-3bae-4130-975c-bfe5051bcfae" />

## Reference

N/A

## Checklist
    
- [x] My code follows the style guidelines for this project
- [x] If bug/feature is at all notable, I've added a draft release note as a comment in `addons/strings.yaml`.
- [x] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [x] I have performed a self review of my own code
- [x] I have commented my code PARTICULARLY in hard to understand areas
- [x] I have added thorough tests where needed
