### PR TITLE
VPN-7774: Fix invalid ASN.1 encoding of zero

### DIFF
--- a/signature/src/balrog.rs
+++ b/signature/src/balrog.rs
@@ -215,6 +215,12 @@ impl<'a> Balrog<'_> {
      * ensure the sign is positive.
      */
     fn ecdsa_uint_to_asn1(value: &[u8]) -> Vec<u8> {
+        // 8.3.1: The encoding of an integer value shall be primitive. The
+        // contents octets shall consist of one or more octets. 
+        if value.is_empty() {
+            return Vec::from(&[0u8]);
+        }
+
         // Add padding to ensure the sign is positive.
         if value[0] & 0x80 != 0 {
             let mut result = Vec::from(&[0u8]);
@@ -222,13 +228,17 @@ impl<'a> Balrog<'_> {
             return result;
         }
 
-        // Strip unnecessary padding.
-        let mut strip = 0;
-        while (value[strip] == 0x00) && (value[strip+1] & 0x80 == 0) {
-            strip = strip+1;
+        // 8.3.2: If the contents octets of an integer value encoding consist
+        // of more than one octet, then the bits of the first octet and bit 8
+        // of the second octet:
+        //   1. Shall not be all ones; and
+        //   2. Shall not be all zero.
+        let mut strip = value;
+        while (strip.len() > 1) && (strip[0] == 0x00) && (strip[1] & 0x80 == 0) {
+            strip = &strip[1..];
         }
 
-        Vec::from(&value[strip..])
+        Vec::from(strip)
     }
 
     /* Take a fixed-length ECDSA signature and convert into ASN.1 DER encoding */
@@ -643,5 +653,38 @@ culpa qui officia deserunt mollit anim id est laborum.";
 
         let r = b.verify_content_signature(VALID_INPUT, VALID_SIGNATURE);
         assert_eq!(r, Err(BalrogError::CertificateNotFound));
+    }
+
+    #[test]
+    fn test_ecdsa_asn1_conversion() {
+        // All zero values should encode to a single byte in ASN.1 DER.
+        let r = Balrog::ecdsa_uint_to_asn1(&[0u8; 0]);
+        assert_eq!(r, vec![0u8]);
+        let r = Balrog::ecdsa_uint_to_asn1(&[0u8; 1]);
+        assert_eq!(r, vec![0u8]);
+        let r = Balrog::ecdsa_uint_to_asn1(&[0u8; 2]);
+        assert_eq!(r, vec![0u8]);
+        let r = Balrog::ecdsa_uint_to_asn1(&[0u8; 3]);
+        assert_eq!(r, vec![0u8]);
+
+        // A leading bit should result in an extra padding byte being added.
+        let r = Balrog::ecdsa_uint_to_asn1(&[0xff]);
+        assert_eq!(r, vec![0x00, 0xff]);
+        let r = Balrog::ecdsa_uint_to_asn1(&[0xff, 0xff]);
+        assert_eq!(r, vec![0x00, 0xff, 0xff]);
+        let r = Balrog::ecdsa_uint_to_asn1(&[0x80, 0x00]);
+        assert_eq!(r, vec![0x00, 0x80, 0x00]);
+        let r = Balrog::ecdsa_uint_to_asn1(&[0xDE, 0xAD, 0xBE, 0xEF]);
+        assert_eq!(r, vec![0x00, 0xDE, 0xAD, 0xBE, 0xEF]);
+
+        // Otherwise, this should just convert a slice to a vec.
+        let input = vec![0x7f];
+        assert_eq!(Balrog::ecdsa_uint_to_asn1(input.as_slice()), input);
+        let input = vec![0x7f, 0xff];
+        assert_eq!(Balrog::ecdsa_uint_to_asn1(input.as_slice()), input);
+        let input = vec![0x00, 0x80, 0x00];
+        assert_eq!(Balrog::ecdsa_uint_to_asn1(input.as_slice()), input);
+        let input = vec![0x5E, 0xAD, 0xBE, 0xEF];
+        assert_eq!(Balrog::ecdsa_uint_to_asn1(input.as_slice()), input);
     }
 }


### PR DESCRIPTION
## Description
Turns out there was another bug in the ECDSA/ASN.1 integer conversion routine. This time we find ourselves generating an invalid ASN.1 DER encoding of the integer zero. As per the X.690 specification, section 8.3.1:

```
8.3.1 The encoding of an integer value shall be primitive. The contents octets shall consist of one or more octets
```

The current implementation of `ecdsa_uint_to_asn1()` screws this up by producing an empty string, when in fact we should produce a 1-byte string with the value `0x00`

## Reference
JIRA Issue: [VPN-7774](https://mozilla-hub.atlassian.net/browse/VPN-7774)

## Checklist
    
- [ ] My code follows the style guidelines for this project
- [ ] If bug/feature is at all notable, I've added a draft release note as a comment in `addons/strings.yaml`.
- [ ] I have not added any packages that contain high risk or unknown licenses (GPL,  LGPL, MPL, etc. consult with DevOps if in question)
- [ ] I have performed a self review of my own code
- [ ] I have commented my code PARTICULARLY in hard to understand areas
- [ ] I have added thorough tests where needed


[VPN-7774]: https://mozilla-hub.atlassian.net/browse/VPN-7774?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ